### PR TITLE
feat(RL): publish worker transfer metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,6 +2440,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/lib/backend-common/Cargo.toml
+++ b/lib/backend-common/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/lib/backend-common/src/lib.rs
+++ b/lib/backend-common/src/lib.rs
@@ -42,6 +42,7 @@ pub use engine::{
 };
 pub use error::{BackendError, DynamoError, ErrorType};
 pub use metrics::{ComponentGauges, EngineMetrics, LifecycleGauges};
+pub use rl::RlWorkerMetadata;
 pub use run::{run, run_raw};
 pub use snapshot_publisher::SnapshotPublisher;
 pub use worker::{RuntimeConfig, Worker, WorkerConfig};

--- a/lib/backend-common/src/rl.rs
+++ b/lib/backend-common/src/rl.rs
@@ -37,25 +37,20 @@ impl RlWorkerMetadata {
     pub fn new(world_size: u32, admin_base_url: Option<String>) -> anyhow::Result<Self> {
         let world_size = NonZeroU32::new(world_size)
             .ok_or_else(|| anyhow::anyhow!("RL worker world size must be positive"))?;
-        let admin_base_url =
-            normalized_optional(admin_base_url, "RL admin base URL must not be blank")?;
+        let admin_base_url = admin_base_url
+            .map(|value| {
+                let value = value.trim();
+                if value.is_empty() {
+                    anyhow::bail!("RL admin base URL must not be blank");
+                }
+                Ok(value.to_string())
+            })
+            .transpose()?;
         Ok(Self {
             world_size,
             admin_base_url,
         })
     }
-}
-
-fn normalized_optional(value: Option<String>, error: &str) -> anyhow::Result<Option<String>> {
-    value
-        .map(|value| {
-            let value = value.trim();
-            if value.is_empty() {
-                anyhow::bail!(error.to_string());
-            }
-            Ok(value.to_string())
-        })
-        .transpose()
 }
 
 impl RlServeEndpoint {

--- a/lib/backend-common/src/rl.rs
+++ b/lib/backend-common/src/rl.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{num::NonZeroU32, sync::Arc};
 
 use async_trait::async_trait;
 use dynamo_runtime::component::{Endpoint, StartedEndpoint};
@@ -24,6 +24,48 @@ pub(crate) struct RlServeEndpoint {
 pub(crate) struct RlEndpointConfig {
     endpoint_name: String,
     system_url: String,
+    metadata: Option<RlWorkerMetadata>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RlWorkerMetadata {
+    world_size: NonZeroU32,
+    weight_transfer_backend: Option<String>,
+    admin_base_url: Option<String>,
+}
+
+impl RlWorkerMetadata {
+    pub fn new(
+        world_size: u32,
+        weight_transfer_backend: Option<String>,
+        admin_base_url: Option<String>,
+    ) -> anyhow::Result<Self> {
+        let world_size = NonZeroU32::new(world_size)
+            .ok_or_else(|| anyhow::anyhow!("RL worker world size must be positive"))?;
+        let weight_transfer_backend = normalized_optional(
+            weight_transfer_backend,
+            "RL weight-transfer backend must not be blank",
+        )?;
+        let admin_base_url =
+            normalized_optional(admin_base_url, "RL admin base URL must not be blank")?;
+        Ok(Self {
+            world_size,
+            weight_transfer_backend,
+            admin_base_url,
+        })
+    }
+}
+
+fn normalized_optional(value: Option<String>, error: &str) -> anyhow::Result<Option<String>> {
+    value
+        .map(|value| {
+            let value = value.trim();
+            if value.is_empty() {
+                anyhow::bail!(error.to_string());
+            }
+            Ok(value.to_string())
+        })
+        .transpose()
 }
 
 impl RlServeEndpoint {
@@ -32,7 +74,10 @@ impl RlServeEndpoint {
     }
 }
 
-pub(crate) fn prepare_endpoint(primary: &Endpoint) -> anyhow::Result<RlEndpointConfig> {
+pub(crate) fn prepare_endpoint(
+    primary: &Endpoint,
+    metadata: Option<RlWorkerMetadata>,
+) -> anyhow::Result<RlEndpointConfig> {
     let endpoint_name = resolve_endpoint_name(&primary.id().name)?;
     let system_url = self_host_base_url(primary.drt()).ok_or_else(|| {
         anyhow::anyhow!(
@@ -42,6 +87,7 @@ pub(crate) fn prepare_endpoint(primary: &Endpoint) -> anyhow::Result<RlEndpointC
     Ok(RlEndpointConfig {
         endpoint_name,
         system_url,
+        metadata,
     })
 }
 
@@ -53,6 +99,7 @@ pub(crate) async fn serve_endpoint(
     let handler = Arc::new(RlRouteHandler {
         routes: primary.drt().engine_routes().clone(),
         system_url: config.system_url,
+        metadata: config.metadata,
     });
     let ingress = Ingress::for_engine(handler)?;
     let started = endpoint
@@ -100,6 +147,7 @@ fn validate_endpoint_name(endpoint_name: &str, primary_name: &str) -> anyhow::Re
 struct RlRouteHandler {
     routes: EngineRouteRegistry,
     system_url: String,
+    metadata: Option<RlWorkerMetadata>,
 }
 
 impl RlRouteHandler {
@@ -122,11 +170,21 @@ impl RlRouteHandler {
         let mut routes = self.routes.routes().into_iter().collect::<Vec<_>>();
         routes.sort();
         routes.dedup();
-        json!({
+        let mut response = json!({
             "status": "ok",
             "routes": routes,
             "system_url": self.system_url,
-        })
+        });
+        if let Some(metadata) = &self.metadata {
+            response["world_size"] = json!(metadata.world_size.get());
+            if let Some(backend) = &metadata.weight_transfer_backend {
+                response["weight_transfer_backend"] = json!(backend);
+            }
+            if let Some(url) = &metadata.admin_base_url {
+                response["admin_base_url"] = json!(url);
+            }
+        }
+        response
     }
 }
 
@@ -156,6 +214,14 @@ mod tests {
         let handler = RlRouteHandler {
             routes,
             system_url: "http://worker:8080".to_string(),
+            metadata: Some(
+                RlWorkerMetadata::new(
+                    4,
+                    Some(" nccl ".to_string()),
+                    Some(" http://worker:8120 ".to_string()),
+                )
+                .expect("valid metadata"),
+            ),
         };
 
         assert_eq!(
@@ -164,11 +230,21 @@ mod tests {
                 "status": "ok",
                 "routes": ["control/pause_generation"],
                 "system_url": "http://worker:8080",
+                "admin_base_url": "http://worker:8120",
+                "world_size": 4,
+                "weight_transfer_backend": "nccl",
             })
         );
         assert_eq!(
             handler.dispatch(&json!({"method": "control/pause_generation"}))["status"],
             "error"
         );
+    }
+
+    #[test]
+    fn rl_worker_metadata_rejects_invalid_values() {
+        assert!(RlWorkerMetadata::new(0, None, None).is_err());
+        assert!(RlWorkerMetadata::new(1, Some("   ".to_string()), None).is_err());
+        assert!(RlWorkerMetadata::new(1, None, Some("   ".to_string())).is_err());
     }
 }

--- a/lib/backend-common/src/rl.rs
+++ b/lib/backend-common/src/rl.rs
@@ -43,6 +43,11 @@ impl RlWorkerMetadata {
                 if value.is_empty() {
                     anyhow::bail!("RL admin base URL must not be blank");
                 }
+                let parsed = url::Url::parse(value)
+                    .map_err(|error| anyhow::anyhow!("invalid RL admin base URL: {error}"))?;
+                if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+                    anyhow::bail!("RL admin base URL must use HTTP or HTTPS");
+                }
                 Ok(value.to_string())
             })
             .transpose()?;
@@ -222,5 +227,7 @@ mod tests {
     fn rl_worker_metadata_rejects_invalid_values() {
         assert!(RlWorkerMetadata::new(0, None).is_err());
         assert!(RlWorkerMetadata::new(1, Some("   ".to_string())).is_err());
+        assert!(RlWorkerMetadata::new(1, Some("worker:8120".to_string())).is_err());
+        assert!(RlWorkerMetadata::new(1, Some("ftp://worker:8120".to_string())).is_err());
     }
 }

--- a/lib/backend-common/src/rl.rs
+++ b/lib/backend-common/src/rl.rs
@@ -30,27 +30,17 @@ pub(crate) struct RlEndpointConfig {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RlWorkerMetadata {
     world_size: NonZeroU32,
-    weight_transfer_backend: Option<String>,
     admin_base_url: Option<String>,
 }
 
 impl RlWorkerMetadata {
-    pub fn new(
-        world_size: u32,
-        weight_transfer_backend: Option<String>,
-        admin_base_url: Option<String>,
-    ) -> anyhow::Result<Self> {
+    pub fn new(world_size: u32, admin_base_url: Option<String>) -> anyhow::Result<Self> {
         let world_size = NonZeroU32::new(world_size)
             .ok_or_else(|| anyhow::anyhow!("RL worker world size must be positive"))?;
-        let weight_transfer_backend = normalized_optional(
-            weight_transfer_backend,
-            "RL weight-transfer backend must not be blank",
-        )?;
         let admin_base_url =
             normalized_optional(admin_base_url, "RL admin base URL must not be blank")?;
         Ok(Self {
             world_size,
-            weight_transfer_backend,
             admin_base_url,
         })
     }
@@ -177,9 +167,6 @@ impl RlRouteHandler {
         });
         if let Some(metadata) = &self.metadata {
             response["world_size"] = json!(metadata.world_size.get());
-            if let Some(backend) = &metadata.weight_transfer_backend {
-                response["weight_transfer_backend"] = json!(backend);
-            }
             if let Some(url) = &metadata.admin_base_url {
                 response["admin_base_url"] = json!(url);
             }
@@ -215,12 +202,8 @@ mod tests {
             routes,
             system_url: "http://worker:8080".to_string(),
             metadata: Some(
-                RlWorkerMetadata::new(
-                    4,
-                    Some(" nccl ".to_string()),
-                    Some(" http://worker:8120 ".to_string()),
-                )
-                .expect("valid metadata"),
+                RlWorkerMetadata::new(4, Some(" http://worker:8120 ".to_string()))
+                    .expect("valid metadata"),
             ),
         };
 
@@ -242,8 +225,7 @@ mod tests {
 
     #[test]
     fn rl_worker_metadata_rejects_invalid_values() {
-        assert!(RlWorkerMetadata::new(0, None, None).is_err());
-        assert!(RlWorkerMetadata::new(1, Some("   ".to_string()), None).is_err());
-        assert!(RlWorkerMetadata::new(1, None, Some("   ".to_string())).is_err());
+        assert!(RlWorkerMetadata::new(0, None).is_err());
+        assert!(RlWorkerMetadata::new(1, Some("   ".to_string())).is_err());
     }
 }

--- a/lib/backend-common/src/rl.rs
+++ b/lib/backend-common/src/rl.rs
@@ -232,7 +232,6 @@ mod tests {
                 "system_url": "http://worker:8080",
                 "admin_base_url": "http://worker:8120",
                 "world_size": 4,
-                "weight_transfer_backend": "nccl",
             })
         );
         assert_eq!(

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -193,6 +193,8 @@ pub struct WorkerConfig {
     pub route_to_encoder: bool,
     /// Publish the worker's engine routes through an auxiliary RL discovery endpoint.
     pub enable_rl: bool,
+    /// Optional RL topology and weight-transfer metadata published by the worker.
+    pub rl_metadata: Option<crate::RlWorkerMetadata>,
     /// Optional frontend media decoding and fetch policy advertised on the
     /// model deployment card.
     pub media_decoder: Option<MediaDecoder>,
@@ -238,6 +240,7 @@ impl Default for WorkerConfig {
             runtime: RuntimeConfig::default(),
             route_to_encoder: false,
             enable_rl: false,
+            rl_metadata: None,
             media_decoder: None,
             media_fetcher: None,
             default_thinking_mode: None,
@@ -926,12 +929,16 @@ impl Worker {
         let model_type = resolve_model_type(&self.config)?;
         let (worker_type, needs) = resolve_worker_type_and_needs(&self.config);
         let rl_config = if self.config.enable_rl {
-            Some(crate::rl::prepare_endpoint(&endpoint).map_err(|error| {
-                err(
-                    ErrorType::Backend(BackendError::InvalidArgument),
-                    format!("RL endpoint configuration: {error}"),
-                )
-            })?)
+            Some(
+                crate::rl::prepare_endpoint(&endpoint, self.config.rl_metadata.clone()).map_err(
+                    |error| {
+                        err(
+                            ErrorType::Backend(BackendError::InvalidArgument),
+                            format!("RL endpoint configuration: {error}"),
+                        )
+                    },
+                )?,
+            )
         } else {
             None
         };

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1697,6 +1697,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-opentelemetry",
+ "url",
 ]
 
 [[package]]

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -469,6 +469,7 @@ impl WorkerConfig {
                 // Python vLLM owns and serves its existing `.rl` endpoint.
                 // The shared Rust endpoint is opt-in for Rust sidecars only.
                 enable_rl: false,
+                rl_metadata: None,
                 media_decoder: media_decoder.map(|decoder| decoder.inner),
                 media_fetcher: media_fetcher.map(|fetcher| fetcher.inner),
             },

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -112,8 +112,6 @@ pub struct RlWorkerInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub world_size: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub weight_transfer_backend: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 
@@ -355,7 +353,6 @@ struct WorkerRoutes {
     system_url: Option<String>,
     admin_base_url: Option<String>,
     world_size: Option<u32>,
-    weight_transfer_backend: Option<String>,
 }
 
 async fn call_worker_routes(
@@ -481,26 +478,11 @@ fn parse_worker_routes(value: serde_json::Value) -> anyhow::Result<WorkerRoutes>
                 .ok_or_else(|| anyhow::anyhow!("worker routes response has invalid 'world_size'"))
         })
         .transpose()?;
-    let weight_transfer_backend = value
-        .get("weight_transfer_backend")
-        .map(|value| {
-            let value = value.as_str().ok_or_else(|| {
-                anyhow::anyhow!("worker routes response has invalid 'weight_transfer_backend'")
-            })?;
-            let value = value.trim();
-            if value.is_empty() {
-                anyhow::bail!("worker routes response has invalid 'weight_transfer_backend'");
-            }
-            Ok(value.to_string())
-        })
-        .transpose()?;
-
     Ok(WorkerRoutes {
         routes,
         system_url,
         admin_base_url,
         world_size,
-        weight_transfer_backend,
     })
 }
 
@@ -525,7 +507,6 @@ fn worker_info(
         model,
         routes: discovered.routes,
         world_size: discovered.world_size,
-        weight_transfer_backend: discovered.weight_transfer_backend,
         error,
     }
 }
@@ -611,7 +592,6 @@ mod tests {
         assert_eq!(parsed.system_url.as_deref(), Some("http://worker:8080"));
         assert_eq!(parsed.admin_base_url.as_deref(), Some("http://worker:8120"));
         assert_eq!(parsed.world_size, Some(4));
-        assert_eq!(parsed.weight_transfer_backend.as_deref(), Some("nccl"));
     }
 
     #[test]
@@ -645,12 +625,6 @@ mod tests {
     fn parse_worker_routes_rejects_invalid_rl_metadata() {
         let zero = parse_worker_routes(json!({ "routes": [], "world_size": 0 })).unwrap_err();
         assert!(zero.to_string().contains("world_size"));
-        let blank = parse_worker_routes(json!({
-            "routes": [],
-            "weight_transfer_backend": "  ",
-        }))
-        .unwrap_err();
-        assert!(blank.to_string().contains("weight_transfer_backend"));
     }
 
     #[test]

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -240,11 +240,21 @@ async fn list_workers(state: &RlDiscoveryState) -> anyhow::Result<Vec<RlWorkerIn
         .unwrap_or_default();
 
     let models = model_map(model_instances);
-    let rl_endpoints = rl_endpoint_instances(
-        endpoint_instances,
-        &config.rl_endpoint,
-        config.component_filter.as_deref(),
-    );
+    let rl_endpoints = endpoint_instances
+        .into_iter()
+        .filter_map(|instance| match instance {
+            DiscoveryInstance::Endpoint(endpoint) => Some(endpoint),
+            _ => None,
+        })
+        .filter(|endpoint| endpoint.endpoint == config.rl_endpoint)
+        .filter(|endpoint| {
+            config
+                .component_filter
+                .as_ref()
+                .map(|components| components.iter().any(|c| c == &endpoint.component))
+                .unwrap_or(true)
+        })
+        .collect::<Vec<_>>();
 
     // Bound the client cache (N2): drop clients for endpoints that are no longer
     // present. Live endpoints are retained, so the fan-out below still reuses their
@@ -292,26 +302,6 @@ async fn list_workers(state: &RlDiscoveryState) -> anyhow::Result<Vec<RlWorkerIn
     });
 
     Ok(workers)
-}
-
-fn rl_endpoint_instances(
-    instances: Vec<DiscoveryInstance>,
-    rl_endpoint: &str,
-    component_filter: Option<&[String]>,
-) -> Vec<Instance> {
-    instances
-        .into_iter()
-        .filter_map(|instance| match instance {
-            DiscoveryInstance::Endpoint(endpoint) => Some(endpoint),
-            _ => None,
-        })
-        .filter(|endpoint| endpoint.endpoint == rl_endpoint)
-        .filter(|endpoint| {
-            component_filter
-                .map(|components| components.iter().any(|c| c == &endpoint.component))
-                .unwrap_or(true)
-        })
-        .collect()
 }
 
 async fn describe_worker(
@@ -489,6 +479,9 @@ fn parse_worker_routes(value: serde_json::Value) -> anyhow::Result<WorkerRoutes>
                 .ok_or_else(|| anyhow::anyhow!("worker routes response has invalid 'world_size'"))
         })
         .transpose()?;
+    if admin_base_url.is_some() && world_size.is_none() {
+        anyhow::bail!("worker routes response has 'admin_base_url' without valid 'world_size'");
+    }
     Ok(WorkerRoutes {
         routes,
         system_url,
@@ -567,23 +560,38 @@ fn model_map(instances: Vec<DiscoveryInstance>) -> HashMap<ModelKey, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dynamo_runtime::{
+        discovery::DiscoverySpec,
+        pipeline::{
+            AsyncEngine, AsyncEngineContextProvider, ManyOut, ResponseStream, async_trait,
+            network::Ingress,
+        },
+    };
+    use futures::stream;
     use serde_json::json;
 
-    fn endpoint_instance(
-        namespace: &str,
-        component: &str,
-        endpoint: &str,
-        instance_id: u64,
-    ) -> DiscoveryInstance {
-        DiscoveryInstance::Endpoint(Instance {
-            namespace: namespace.to_string(),
-            component: component.to_string(),
-            endpoint: endpoint.to_string(),
-            instance_id,
-            transport: TransportType::Nats("nats://127.0.0.1:4222".to_string()),
-            device_type: None,
-            request_plane_codec: None,
-        })
+    struct TestRoutesHandler;
+
+    #[async_trait]
+    impl
+        AsyncEngine<
+            SingleIn<serde_json::Value>,
+            ManyOut<Annotated<serde_json::Value>>,
+            anyhow::Error,
+        > for TestRoutesHandler
+    {
+        async fn generate(
+            &self,
+            input: SingleIn<serde_json::Value>,
+        ) -> anyhow::Result<ManyOut<Annotated<serde_json::Value>>> {
+            let (_, context) = input.into_parts();
+            Ok(ResponseStream::new(
+                Box::pin(stream::once(async {
+                    Annotated::from_data(json!({"status": "ok", "routes": []}))
+                })),
+                context.context(),
+            ))
+        }
     }
 
     fn model_instance(
@@ -668,6 +676,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_worker_routes_requires_world_size_with_admin_base_url() {
+        let err = parse_worker_routes(json!({
+            "routes": [],
+            "admin_base_url": "http://worker:8120",
+        }))
+        .unwrap_err();
+        assert!(err.to_string().contains("world_size"));
+
+        let parsed = parse_worker_routes(json!({ "routes": [], "world_size": 1 }))
+            .expect("world size does not require an admin URL");
+        assert_eq!(parsed.world_size, Some(1));
+        assert!(parsed.admin_base_url.is_none());
+    }
+
+    #[test]
     fn parse_worker_routes_propagates_worker_error_status() {
         let err = parse_worker_routes(json!({ "status": "error", "message": "engine is dead" }))
             .unwrap_err();
@@ -735,15 +758,62 @@ mod tests {
         assert!(map.is_empty());
     }
 
-    #[test]
-    fn rl_endpoint_instances_do_not_require_model_metadata() {
-        let endpoints = rl_endpoint_instances(
-            vec![endpoint_instance("dynamo", "backend", "rl", 1)],
-            "rl",
-            None,
+    #[tokio::test]
+    async fn list_workers_keeps_endpoints_without_unambiguous_model_metadata() {
+        let runtime = dynamo_runtime::Runtime::from_current().expect("test runtime");
+        let distributed = Arc::new(
+            DistributedRuntime::new(
+                runtime,
+                dynamo_runtime::distributed::DistributedConfig::process_local(),
+            )
+            .await
+            .expect("distributed runtime"),
         );
+        let ingress = Ingress::for_engine(Arc::new(TestRoutesHandler)).expect("test ingress");
+        let started = distributed
+            .namespace("dynamo")
+            .expect("namespace")
+            .component("backend")
+            .expect("component")
+            .endpoint("rl")
+            .endpoint_builder()
+            .handler(ingress)
+            .start_with_registration()
+            .await
+            .expect("RL endpoint");
+        let state = RlDiscoveryState::new(RlDiscoveryConfig {
+            runtime: distributed.clone(),
+            namespace: "dynamo".to_string(),
+            rl_endpoint: "rl".to_string(),
+            component_filter: None,
+            request_timeout: Duration::from_secs(1),
+            max_concurrent_probes: 1,
+        });
 
-        assert_eq!(endpoints.len(), 1);
-        assert_eq!(endpoints[0].instance_id, 1);
+        let workers = list_workers(&state).await.expect("workers without models");
+        assert_eq!(workers.len(), 1);
+        assert!(workers[0].model.is_none());
+
+        for (endpoint, display_name) in [("generate", "model-a"), ("embed", "model-b")] {
+            distributed
+                .discovery()
+                .register(DiscoverySpec::Model {
+                    namespace: "dynamo".to_string(),
+                    component: "backend".to_string(),
+                    endpoint: endpoint.to_string(),
+                    card_json: json!({"display_name": display_name}),
+                    model_suffix: None,
+                })
+                .await
+                .expect("model registration");
+        }
+
+        let workers = list_workers(&state)
+            .await
+            .expect("workers with ambiguous models");
+        assert_eq!(workers.len(), 1);
+        assert!(workers[0].model.is_none());
+
+        started.shutdown().await.expect("endpoint shutdown");
     }
 }

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -40,6 +40,7 @@ const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
 /// Global cap on concurrent per-worker probes (across all in-flight discovery
 /// requests), so a large fleet or many concurrent callers can't fan out without bound.
 const DEFAULT_MAX_CONCURRENT_PROBES: usize = 32;
+const RL_WORKERS_PROTOCOL_VERSION: u32 = 1;
 
 type ModelKey = (String, String, u64);
 
@@ -104,14 +105,21 @@ pub struct RlWorkerInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub admin_base_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     pub routes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub world_size: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weight_transfer_backend: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct RlWorkersResponse {
+    pub protocol_version: u32,
     pub namespace: String,
     pub workers: Vec<RlWorkerInfo>,
 }
@@ -195,6 +203,7 @@ pub fn rl_router(state: RlDiscoveryState) -> Router {
 async fn workers_handler(State(state): State<RlDiscoveryState>) -> impl IntoResponse {
     match list_workers(&state).await {
         Ok(workers) => Json(RlWorkersResponse {
+            protocol_version: RL_WORKERS_PROTOCOL_VERSION,
             namespace: state.config.namespace.clone(),
             workers,
         })
@@ -229,8 +238,7 @@ async fn list_workers(state: &RlDiscoveryState) -> anyhow::Result<Vec<RlWorkerIn
         .list(DiscoveryQuery::NamespacedModels {
             namespace: config.namespace.clone(),
         })
-        .await
-        .unwrap_or_default();
+        .await?;
 
     let models = model_map(model_instances);
     let rl_endpoints = endpoint_instances
@@ -246,6 +254,13 @@ async fn list_workers(state: &RlDiscoveryState) -> anyhow::Result<Vec<RlWorkerIn
                 .as_ref()
                 .map(|components| components.iter().any(|c| c == &endpoint.component))
                 .unwrap_or(true)
+        })
+        .filter(|endpoint| {
+            models.contains_key(&(
+                endpoint.namespace.clone(),
+                endpoint.component.clone(),
+                endpoint.instance_id,
+            ))
         })
         .collect::<Vec<_>>();
 
@@ -315,13 +330,17 @@ async fn describe_worker(
         call_worker_routes(state, &endpoint, timeout).await
     };
     match tokio::time::timeout(timeout, probe).await {
-        Ok(Ok(routes)) => worker_info(endpoint, model, routes.routes, routes.system_url, None),
-        Ok(Err(err)) => worker_info(endpoint, model, Vec::new(), None, Some(err.to_string())),
+        Ok(Ok(routes)) => worker_info(endpoint, model, routes, None),
+        Ok(Err(err)) => worker_info(
+            endpoint,
+            model,
+            WorkerRoutes::default(),
+            Some(err.to_string()),
+        ),
         Err(_) => worker_info(
             endpoint,
             model,
-            Vec::new(),
-            None,
+            WorkerRoutes::default(),
             Some(format!(
                 "worker discovery timed out after {}s",
                 timeout.as_secs()
@@ -334,6 +353,9 @@ async fn describe_worker(
 struct WorkerRoutes {
     routes: Vec<String>,
     system_url: Option<String>,
+    admin_base_url: Option<String>,
+    world_size: Option<u32>,
+    weight_transfer_backend: Option<String>,
 }
 
 async fn call_worker_routes(
@@ -440,18 +462,56 @@ fn parse_worker_routes(value: serde_json::Value) -> anyhow::Result<WorkerRoutes>
         .filter(|url| !url.is_empty())
         .map(ToString::to_string);
 
-    Ok(WorkerRoutes { routes, system_url })
+    let admin_base_url = value
+        .get("admin_base_url")
+        .and_then(|url| url.as_str())
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .map(ToString::to_string);
+
+    let world_size = value
+        .get("world_size")
+        .map(|value| {
+            let value = value.as_u64().ok_or_else(|| {
+                anyhow::anyhow!("worker routes response has invalid 'world_size'")
+            })?;
+            u32::try_from(value)
+                .ok()
+                .filter(|value| *value > 0)
+                .ok_or_else(|| anyhow::anyhow!("worker routes response has invalid 'world_size'"))
+        })
+        .transpose()?;
+    let weight_transfer_backend = value
+        .get("weight_transfer_backend")
+        .map(|value| {
+            let value = value.as_str().ok_or_else(|| {
+                anyhow::anyhow!("worker routes response has invalid 'weight_transfer_backend'")
+            })?;
+            let value = value.trim();
+            if value.is_empty() {
+                anyhow::bail!("worker routes response has invalid 'weight_transfer_backend'");
+            }
+            Ok(value.to_string())
+        })
+        .transpose()?;
+
+    Ok(WorkerRoutes {
+        routes,
+        system_url,
+        admin_base_url,
+        world_size,
+        weight_transfer_backend,
+    })
 }
 
 fn worker_info(
     endpoint: Instance,
     model: Option<String>,
-    mut routes: Vec<String>,
-    system_url: Option<String>,
+    mut discovered: WorkerRoutes,
     error: Option<String>,
 ) -> RlWorkerInfo {
-    routes.sort();
-    routes.dedup();
+    discovered.routes.sort();
+    discovered.routes.dedup();
 
     RlWorkerInfo {
         request_plane_url: request_plane_url(&endpoint),
@@ -460,9 +520,12 @@ fn worker_info(
         endpoint: endpoint.endpoint,
         instance_id: endpoint.instance_id,
         transport: endpoint.transport,
-        system_url,
+        system_url: discovered.system_url,
+        admin_base_url: discovered.admin_base_url,
         model,
-        routes,
+        routes: discovered.routes,
+        world_size: discovered.world_size,
+        weight_transfer_backend: discovered.weight_transfer_backend,
         error,
     }
 }
@@ -537,12 +600,18 @@ mod tests {
         let parsed = parse_worker_routes(json!({
             "routes": ["pause_generation", "resume_generation"],
             "system_url": "  http://worker:8080  ",
+            "admin_base_url": "  http://worker:8120  ",
+            "world_size": 4,
+            "weight_transfer_backend": "nccl",
         }))
         .expect("valid payload");
         let routes: Vec<&str> = parsed.routes.iter().map(String::as_str).collect();
         assert_eq!(routes, ["pause_generation", "resume_generation"]);
         // system_url is trimmed.
         assert_eq!(parsed.system_url.as_deref(), Some("http://worker:8080"));
+        assert_eq!(parsed.admin_base_url.as_deref(), Some("http://worker:8120"));
+        assert_eq!(parsed.world_size, Some(4));
+        assert_eq!(parsed.weight_transfer_backend.as_deref(), Some("nccl"));
     }
 
     #[test]
@@ -570,6 +639,18 @@ mod tests {
     fn parse_worker_routes_rejects_empty_entry() {
         let err = parse_worker_routes(json!({ "routes": ["pause", ""] })).unwrap_err();
         assert!(err.to_string().contains("empty route entry"));
+    }
+
+    #[test]
+    fn parse_worker_routes_rejects_invalid_rl_metadata() {
+        let zero = parse_worker_routes(json!({ "routes": [], "world_size": 0 })).unwrap_err();
+        assert!(zero.to_string().contains("world_size"));
+        let blank = parse_worker_routes(json!({
+            "routes": [],
+            "weight_transfer_backend": "  ",
+        }))
+        .unwrap_err();
+        assert!(blank.to_string().contains("weight_transfer_backend"));
     }
 
     #[test]

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -236,31 +236,15 @@ async fn list_workers(state: &RlDiscoveryState) -> anyhow::Result<Vec<RlWorkerIn
         .list(DiscoveryQuery::NamespacedModels {
             namespace: config.namespace.clone(),
         })
-        .await?;
+        .await
+        .unwrap_or_default();
 
     let models = model_map(model_instances);
-    let rl_endpoints = endpoint_instances
-        .into_iter()
-        .filter_map(|instance| match instance {
-            DiscoveryInstance::Endpoint(endpoint) => Some(endpoint),
-            _ => None,
-        })
-        .filter(|endpoint| endpoint.endpoint == config.rl_endpoint)
-        .filter(|endpoint| {
-            config
-                .component_filter
-                .as_ref()
-                .map(|components| components.iter().any(|c| c == &endpoint.component))
-                .unwrap_or(true)
-        })
-        .filter(|endpoint| {
-            models.contains_key(&(
-                endpoint.namespace.clone(),
-                endpoint.component.clone(),
-                endpoint.instance_id,
-            ))
-        })
-        .collect::<Vec<_>>();
+    let rl_endpoints = rl_endpoint_instances(
+        endpoint_instances,
+        &config.rl_endpoint,
+        config.component_filter.as_deref(),
+    );
 
     // Bound the client cache (N2): drop clients for endpoints that are no longer
     // present. Live endpoints are retained, so the fan-out below still reuses their
@@ -308,6 +292,26 @@ async fn list_workers(state: &RlDiscoveryState) -> anyhow::Result<Vec<RlWorkerIn
     });
 
     Ok(workers)
+}
+
+fn rl_endpoint_instances(
+    instances: Vec<DiscoveryInstance>,
+    rl_endpoint: &str,
+    component_filter: Option<&[String]>,
+) -> Vec<Instance> {
+    instances
+        .into_iter()
+        .filter_map(|instance| match instance {
+            DiscoveryInstance::Endpoint(endpoint) => Some(endpoint),
+            _ => None,
+        })
+        .filter(|endpoint| endpoint.endpoint == rl_endpoint)
+        .filter(|endpoint| {
+            component_filter
+                .map(|components| components.iter().any(|c| c == &endpoint.component))
+                .unwrap_or(true)
+        })
+        .collect()
 }
 
 async fn describe_worker(
@@ -461,10 +465,17 @@ fn parse_worker_routes(value: serde_json::Value) -> anyhow::Result<WorkerRoutes>
 
     let admin_base_url = value
         .get("admin_base_url")
-        .and_then(|url| url.as_str())
-        .map(str::trim)
-        .filter(|url| !url.is_empty())
-        .map(ToString::to_string);
+        .map(|value| {
+            let url = value.as_str().ok_or_else(|| {
+                anyhow::anyhow!("worker routes response has invalid 'admin_base_url'")
+            })?;
+            let url = url.trim();
+            if url.is_empty() {
+                anyhow::bail!("worker routes response has invalid 'admin_base_url'");
+            }
+            Ok(url.to_string())
+        })
+        .transpose()?;
 
     let world_size = value
         .get("world_size")

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -558,6 +558,23 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn endpoint_instance(
+        namespace: &str,
+        component: &str,
+        endpoint: &str,
+        instance_id: u64,
+    ) -> DiscoveryInstance {
+        DiscoveryInstance::Endpoint(Instance {
+            namespace: namespace.to_string(),
+            component: component.to_string(),
+            endpoint: endpoint.to_string(),
+            instance_id,
+            transport: TransportType::Nats("nats://127.0.0.1:4222".to_string()),
+            device_type: None,
+            request_plane_codec: None,
+        })
+    }
+
     fn model_instance(
         namespace: &str,
         component: &str,
@@ -628,6 +645,18 @@ mod tests {
     }
 
     #[test]
+    fn parse_worker_routes_rejects_invalid_admin_base_url() {
+        for value in [json!("   "), json!(42)] {
+            let err = parse_worker_routes(json!({
+                "routes": [],
+                "admin_base_url": value,
+            }))
+            .unwrap_err();
+            assert!(err.to_string().contains("admin_base_url"));
+        }
+    }
+
+    #[test]
     fn parse_worker_routes_propagates_worker_error_status() {
         let err = parse_worker_routes(json!({ "status": "error", "message": "engine is dead" }))
             .unwrap_err();
@@ -693,5 +722,17 @@ mod tests {
             Some("lora-1"),
         )]);
         assert!(map.is_empty());
+    }
+
+    #[test]
+    fn rl_endpoint_instances_do_not_require_model_metadata() {
+        let endpoints = rl_endpoint_instances(
+            vec![endpoint_instance("dynamo", "backend", "rl", 1)],
+            "rl",
+            None,
+        );
+
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0].instance_id, 1);
     }
 }


### PR DESCRIPTION
## Summary

- publish RL worker world size and optional admin URL through the existing worker discovery endpoint
- version the discovery response and reject stale or malformed worker entries
- keep live RL workers visible when model metadata is unavailable or ambiguous
- keep Python-backed workers unchanged unless they explicitly opt into the shared Rust RL endpoint

This is the contract layer of a two-PR stack. The vLLM sidecar producer is follow-up PR #13607.

Supersedes #13524 without changing its reviewed commit history.

## Validation

- `cargo fmt --all`
- `cargo clippy -p dynamo-backend-common -p dynamo-rl --all-targets -- -D warnings`
- `cargo test -p dynamo-backend-common -p dynamo-rl`
- review follow-up: `cargo test -p dynamo-rl --lib` (13 passed)

## Review follow-up evidence

- RED: the worker-selection regression test failed before a model-independent selector existed
- GREEN: workers without resolvable model metadata remain listed with `model` omitted
- present blank or non-string `admin_base_url` values now produce worker probe errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional RL worker metadata, including worker count and administrator URL.
  * RL worker discovery responses now include protocol version and available metadata.
  * Worker routes expose world size and optional administrator base URL.
* **Bug Fixes**
  * Added validation to reject invalid worker counts and blank administrator URLs.
  * Improved endpoint filtering and metadata handling during worker discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->