### PR TITLE
feat(vllm): publish RL worker metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,7 +2441,6 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,6 +3167,7 @@ dependencies = [
  "tonic-build 0.13.1",
  "tonic-health",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,6 +2428,7 @@ dependencies = [
  "clap",
  "dynamo-llm",
  "dynamo-protocols",
+ "dynamo-rl",
  "dynamo-runtime",
  "futures",
  "opentelemetry",
@@ -2915,6 +2916,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -3167,7 +3169,6 @@ dependencies = [
  "tonic-build 0.13.1",
  "tonic-health",
  "tracing",
- "url",
 ]
 
 [[package]]

--- a/lib/backend-common/Cargo.toml
+++ b/lib/backend-common/Cargo.toml
@@ -25,6 +25,7 @@ integration = ["dynamo-runtime/integration"]
 dynamo-runtime = { workspace = true }
 dynamo-llm = { path = "../llm", default-features = false }
 dynamo-protocols = { workspace = true }
+dynamo-rl = { workspace = true }
 
 anyhow = { workspace = true }
 async-stream = { workspace = true }

--- a/lib/backend-common/Cargo.toml
+++ b/lib/backend-common/Cargo.toml
@@ -41,7 +41,6 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
-url = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/lib/backend-common/src/lib.rs
+++ b/lib/backend-common/src/lib.rs
@@ -42,7 +42,7 @@ pub use engine::{
 };
 pub use error::{BackendError, DynamoError, ErrorType};
 pub use metrics::{ComponentGauges, EngineMetrics, LifecycleGauges};
-pub use rl::RlWorkerMetadata;
+pub use rl::{RlAdminBaseUrl, RlWorkerMetadata};
 pub use run::{run, run_raw};
 pub use snapshot_publisher::SnapshotPublisher;
 pub use worker::{RuntimeConfig, Worker, WorkerConfig};

--- a/lib/backend-common/src/rl.rs
+++ b/lib/backend-common/src/rl.rs
@@ -4,6 +4,7 @@
 use std::{num::NonZeroU32, sync::Arc};
 
 use async_trait::async_trait;
+pub use dynamo_rl::RlAdminBaseUrl;
 use dynamo_runtime::component::{Endpoint, StartedEndpoint};
 use dynamo_runtime::engine_routes::EngineRouteRegistry;
 use dynamo_runtime::pipeline::network::Ingress;
@@ -30,27 +31,13 @@ pub(crate) struct RlEndpointConfig {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RlWorkerMetadata {
     world_size: NonZeroU32,
-    admin_base_url: Option<String>,
+    admin_base_url: Option<RlAdminBaseUrl>,
 }
 
 impl RlWorkerMetadata {
-    pub fn new(world_size: u32, admin_base_url: Option<String>) -> anyhow::Result<Self> {
+    pub fn new(world_size: u32, admin_base_url: Option<RlAdminBaseUrl>) -> anyhow::Result<Self> {
         let world_size = NonZeroU32::new(world_size)
             .ok_or_else(|| anyhow::anyhow!("RL worker world size must be positive"))?;
-        let admin_base_url = admin_base_url
-            .map(|value| {
-                let value = value.trim();
-                if value.is_empty() {
-                    anyhow::bail!("RL admin base URL must not be blank");
-                }
-                let parsed = url::Url::parse(value)
-                    .map_err(|error| anyhow::anyhow!("invalid RL admin base URL: {error}"))?;
-                if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
-                    anyhow::bail!("RL admin base URL must use HTTP or HTTPS");
-                }
-                Ok(value.to_string())
-            })
-            .transpose()?;
         Ok(Self {
             world_size,
             admin_base_url,
@@ -168,7 +155,7 @@ impl RlRouteHandler {
         if let Some(metadata) = &self.metadata {
             response["world_size"] = json!(metadata.world_size.get());
             if let Some(url) = &metadata.admin_base_url {
-                response["admin_base_url"] = json!(url);
+                response["admin_base_url"] = json!(url.as_str());
             }
         }
         response
@@ -202,8 +189,14 @@ mod tests {
             routes,
             system_url: "http://worker:8080".to_string(),
             metadata: Some(
-                RlWorkerMetadata::new(4, Some(" http://worker:8120 ".to_string()))
-                    .expect("valid metadata"),
+                RlWorkerMetadata::new(
+                    4,
+                    Some(
+                        RlAdminBaseUrl::parse(" http://worker:8120 ")
+                            .expect("valid admin base URL"),
+                    ),
+                )
+                .expect("valid metadata"),
             ),
         };
 
@@ -235,7 +228,7 @@ mod tests {
             "https://worker.example.com/admin#fragment",
         ] {
             assert!(
-                RlWorkerMetadata::new(1, Some(admin_base_url.to_string())).is_err(),
+                RlAdminBaseUrl::parse(admin_base_url).is_err(),
                 "accepted invalid admin base URL: {admin_base_url}"
             );
         }

--- a/lib/backend-common/src/rl.rs
+++ b/lib/backend-common/src/rl.rs
@@ -226,8 +226,18 @@ mod tests {
     #[test]
     fn rl_worker_metadata_rejects_invalid_values() {
         assert!(RlWorkerMetadata::new(0, None).is_err());
-        assert!(RlWorkerMetadata::new(1, Some("   ".to_string())).is_err());
-        assert!(RlWorkerMetadata::new(1, Some("worker:8120".to_string())).is_err());
-        assert!(RlWorkerMetadata::new(1, Some("ftp://worker:8120".to_string())).is_err());
+        for admin_base_url in [
+            "   ",
+            "worker:8120",
+            "ftp://worker:8120",
+            "https://user:token@worker.example.com/admin",
+            "https://worker.example.com/admin?token=secret",
+            "https://worker.example.com/admin#fragment",
+        ] {
+            assert!(
+                RlWorkerMetadata::new(1, Some(admin_base_url.to_string())).is_err(),
+                "accepted invalid admin base URL: {admin_base_url}"
+            );
+        }
     }
 }

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1933,6 +1933,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1698,7 +1698,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-opentelemetry",
- "url",
 ]
 
 [[package]]

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1686,6 +1686,7 @@ dependencies = [
  "clap",
  "dynamo-llm",
  "dynamo-protocols",
+ "dynamo-rl",
  "dynamo-runtime",
  "futures",
  "opentelemetry",
@@ -2046,6 +2047,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/lib/mocker/servers/vllm/src/server.rs
+++ b/lib/mocker/servers/vllm/src/server.rs
@@ -106,6 +106,7 @@ impl VllmMockerService {
                 data_parallel_size: engine_args.dp_size,
                 data_parallel_rank: DP_RANK,
                 decode_context_parallel_size: 1,
+                world_size: 1,
             }),
             max_model_len: engine_args
                 .max_model_len

--- a/lib/rl/Cargo.toml
+++ b/lib/rl/Cargo.toml
@@ -20,3 +20,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -665,7 +665,13 @@ mod tests {
 
     #[test]
     fn parse_worker_routes_rejects_invalid_admin_base_url() {
-        for value in [json!("   "), json!(42)] {
+        for value in [
+            json!("   "),
+            json!(42),
+            json!("https://user:token@worker.example.com/admin"),
+            json!("https://worker.example.com/admin?token=secret"),
+            json!("https://worker.example.com/admin#fragment"),
+        ] {
             let err = parse_worker_routes(json!({
                 "routes": [],
                 "admin_base_url": value,

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -42,6 +42,48 @@ const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_MAX_CONCURRENT_PROBES: usize = 32;
 const RL_WORKERS_PROTOCOL_VERSION: u32 = 1;
 
+/// Validated base URL for worker-specific RL HTTP administration routes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RlAdminBaseUrl(String);
+
+impl RlAdminBaseUrl {
+    pub fn parse(raw: &str) -> anyhow::Result<Self> {
+        let value = raw.trim();
+        if value.is_empty() {
+            anyhow::bail!("RL admin base URL must not be blank");
+        }
+        let parsed = url::Url::parse(value)
+            .map_err(|error| anyhow::anyhow!("invalid RL admin base URL: {error}"))?;
+        let has_valid_authority = value
+            .split_once("://")
+            .is_some_and(|(_, authority)| !authority.is_empty() && !authority.starts_with('/'));
+        if !matches!(parsed.scheme(), "http" | "https")
+            || parsed.host_str().is_none()
+            || !has_valid_authority
+        {
+            anyhow::bail!("RL admin base URL must use HTTP or HTTPS and include a host");
+        }
+        if !parsed.username().is_empty() || parsed.password().is_some() {
+            anyhow::bail!("RL admin base URL must not include user information");
+        }
+        if parsed.query().is_some() {
+            anyhow::bail!("RL admin base URL must not include a query string");
+        }
+        if parsed.fragment().is_some() {
+            anyhow::bail!("RL admin base URL must not include a fragment");
+        }
+        Ok(Self(value.to_string()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
 type ModelKey = (String, String, u64);
 
 #[derive(Clone)]
@@ -456,14 +498,14 @@ fn parse_worker_routes(value: serde_json::Value) -> anyhow::Result<WorkerRoutes>
     let admin_base_url = value
         .get("admin_base_url")
         .map(|value| {
-            let url = value.as_str().ok_or_else(|| {
+            let raw = value.as_str().ok_or_else(|| {
                 anyhow::anyhow!("worker routes response has invalid 'admin_base_url'")
             })?;
-            let url = url.trim();
-            if url.is_empty() {
-                anyhow::bail!("worker routes response has invalid 'admin_base_url'");
-            }
-            Ok(url.to_string())
+            RlAdminBaseUrl::parse(raw)
+                .map(RlAdminBaseUrl::into_string)
+                .map_err(|error| {
+                    anyhow::anyhow!("worker routes response has invalid 'admin_base_url': {error}")
+                })
         })
         .transpose()?;
 

--- a/lib/sidecar/common/src/endpoint.rs
+++ b/lib/sidecar/common/src/endpoint.rs
@@ -14,6 +14,43 @@ pub struct HttpEndpoint {
 }
 
 impl HttpEndpoint {
+    /// Parse an HTTP endpoint, allowing a path prefix but no credentials, query, or fragment.
+    pub fn parse(raw: &str, argument: &str) -> Result<Self, DynamoError> {
+        let endpoint = raw.trim();
+        if endpoint.is_empty() {
+            return Err(invalid_argument(format!(
+                "`{argument}` is required and must specify an HTTP server address"
+            )));
+        }
+        if endpoint
+            .split_once("://")
+            .is_some_and(|(_, authority)| authority.starts_with('/'))
+        {
+            return Err(invalid_argument(format!(
+                "`{argument}` must include a host"
+            )));
+        }
+        let endpoint = url::Url::parse(endpoint).map_err(|error| {
+            invalid_argument(format!("invalid HTTP endpoint for `{argument}`: {error}"))
+        })?;
+        if !matches!(endpoint.scheme(), "http" | "https") || endpoint.host().is_none() {
+            return Err(invalid_argument(format!(
+                "`{argument}` must use HTTP or HTTPS and include a host"
+            )));
+        }
+        if !endpoint.username().is_empty() || endpoint.password().is_some() {
+            return Err(invalid_argument(format!(
+                "`{argument}` must not include user information"
+            )));
+        }
+        if endpoint.query().is_some() || endpoint.fragment().is_some() {
+            return Err(invalid_argument(format!(
+                "`{argument}` must not include a query or fragment"
+            )));
+        }
+        Ok(Self { endpoint })
+    }
+
     /// Reuse the host from a validated gRPC endpoint with a discovered HTTP port.
     pub fn from_grpc(grpc_endpoint: &GrpcEndpoint, port: u16) -> Result<Self, DynamoError> {
         if port == 0 {
@@ -192,5 +229,32 @@ mod tests {
         let http = HttpEndpoint::from_grpc(&grpc, 30000).unwrap();
         assert_eq!(http.as_str(), "http://[2001:db8::1]:30000/");
         assert!(HttpEndpoint::from_grpc(&grpc, 0).is_err());
+    }
+
+    #[test]
+    fn parses_http_endpoints_with_path_prefixes() {
+        for endpoint in [
+            "http://worker:8120",
+            "https://worker.example.com",
+            "https://worker.example.com/admin/v1",
+        ] {
+            assert!(HttpEndpoint::parse(endpoint, "--http-endpoint").is_ok());
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_http_endpoints() {
+        for endpoint in [
+            "",
+            "worker:8120",
+            "grpc://worker:8120",
+            "https:///admin",
+            "HTTP:///admin",
+            "https://user:token@worker.example.com/admin",
+            "https://worker.example.com/admin?token=secret",
+            "https://worker.example.com/admin#fragment",
+        ] {
+            assert!(HttpEndpoint::parse(endpoint, "--http-endpoint").is_err());
+        }
     }
 }

--- a/lib/sidecar/vllm/Cargo.toml
+++ b/lib/sidecar/vllm/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 
 prost = { workspace = true }
 prost-types = { workspace = true }

--- a/lib/sidecar/vllm/Cargo.toml
+++ b/lib/sidecar/vllm/Cargo.toml
@@ -32,7 +32,6 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
-url = { workspace = true }
 
 prost = { workspace = true }
 prost-types = { workspace = true }

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -76,21 +76,29 @@ Start vLLM with the capabilities required by the workflow, then opt the sidecar 
 
 ```bash
 vllm-rs serve Qwen/Qwen3-0.6B \
-  --host 127.0.0.1 \
+  --host 0.0.0.0 \
+  --port 8000 \
   --grpc-port 50051 \
   --enable-sleep-mode \
   --weight-transfer-config '{"backend":"nccl"}'
 
 DYN_SYSTEM_PORT=8081 dynamo-vllm-sidecar \
   --grpc-endpoint 127.0.0.1:50051 \
+  --vllm-http-endpoint http://rollout-0.rl.svc.cluster.local:8000 \
   --enable-rl
 ```
 
-`--enable-rl` (or `DYN_ENABLE_RL=true`) requires the Dynamo system server (`DYN_SYSTEM_PORT=0` or a positive port) and registers `dyn://<namespace>.<component>.rl`, which lets the Dynamo frontend discover this worker and its `/engine/control/*` and `/engine/update/*` routes through `/v1/rl/workers`. The sidecar advertises pause/resume, sleep-status, and weight-version controls when the vLLM server reports the RL gRPC API; mutating sleep/wake routes require `--enable-sleep-mode`, weight-transfer routes require `--weight-transfer-config`, and draft updates require speculative decoding support.
+Replace `rollout-0.rl.svc.cluster.local` with a private address that the RL controller can route to. Binding vLLM to `0.0.0.0` exposes both its HTTP and gRPC listeners, so restrict both ports with host firewall rules, Kubernetes NetworkPolicy, or an equivalent trusted-network control. A colocated sidecar can continue to use loopback for `--grpc-endpoint`; the advertised HTTP URL must be routable from the controller, not merely from the worker.
+
+`--enable-rl` (or `DYN_ENABLE_RL=true`) requires the Dynamo system server (`DYN_SYSTEM_PORT=0` or a positive port) and registers `dyn://<namespace>.<component>.rl`, which lets the Dynamo frontend discover this worker and its `/engine/control/*` and `/engine/update/*` routes through `/v1/rl/workers`. The sidecar advertises pause/resume, sleep-status, and weight-version controls when the vLLM server reports the RL gRPC API; mutating sleep/wake routes require `--enable-sleep-mode`, weight-transfer routes require `--weight-transfer-config`, and draft updates require speculative decoding support. The sidecar publishes `--vllm-http-endpoint` (or `VLLM_HTTP_ENDPOINT`) only as part of this RL worker metadata.
+
+Native vLLM lifecycle and weight-update operations use the typed gRPC Control service and do not require `--vllm-http-endpoint`. Configure the HTTP base URL only when an RL framework needs a compatibility operation that is not represented by the typed service, such as a custom `worker_extension_cls` method invoked through `/collective_rpc`.
+
+The HTTP value must be a controller-routable `http://` or `https://` base URL. Path prefixes are preserved, so a reverse proxy can advertise a value such as `https://rollout.example.internal/vllm-admin`; downstream clients append the compatibility route beneath that prefix. User information, query strings, and fragments are rejected. Do not place credentials or tokens in the URL.
 
 The update request bodies match vLLM's RL HTTP schemas: `init_weight_transfer_engine` requires `{"init_info": {...}}`, `update_weights` requires `{"update_info": {...}}`, `finish_weight_update` accepts `{"weight_version": "..."}`, and `update_weight_version` requires `{"new_version": "..."}`. Weight tensors remain on the configured NCCL, IPC, or sparse-NCCL transport; only backend metadata crosses gRPC.
 
-The RL endpoint and engine routes are unauthenticated administrative surfaces that can pause serving, release GPU memory, and replace model weights. Enable them only on trusted request and system networks.
+The RL endpoint, engine routes, and raw HTTP compatibility surface are administrative interfaces that can pause serving, release GPU memory, and replace model weights. The sidecar does not add HTTP authentication to the advertised URL. Enable these interfaces only on trusted request and system networks, or place the HTTP endpoint behind an authenticated private proxy without embedding credentials in the published URL.
 
 The sidecar discovers `model_id`, the served name, context length, KV capacity, scheduler limits, data-parallel topology, and KV-event sources through `vllm.Control`. `model_id` must be readable locally or fetchable by Dynamo for tokenization and chat templates. Parser defaults are not advertised because the current inference protocol cannot preserve all parser-related request semantics.
 

--- a/lib/sidecar/vllm/proto/README.md
+++ b/lib/sidecar/vllm/proto/README.md
@@ -6,8 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 # Vendored vLLM protocol
 
 - Inference source: [`rust/proto/inference.proto`](https://github.com/vllm-project/vllm/blob/3d1f5cee1552b8208f3009c75f8bc856f27e0eff/rust/proto/inference.proto) at `3d1f5cee1552b8208f3009c75f8bc856f27e0eff`
-- RL Control source: [`rust/proto/control.proto`](https://github.com/vllm-project/vllm/blob/76ebe5a217d7536a5661272c680f0b1e3a62f5be/rust/proto/control.proto) from [vllm-project/vllm#51316](https://github.com/vllm-project/vllm/pull/51316) at `76ebe5a217d7536a5661272c680f0b1e3a62f5be`
+- RL Control source: [`rust/proto/control.proto`](https://github.com/vllm-project/vllm/blob/2991f864083fdd5c60aa140d4fe1a561585a85dc/rust/proto/control.proto) from [vllm-project/vllm#51316](https://github.com/vllm-project/vllm/pull/51316) and [vllm-project/vllm#53204](https://github.com/vllm-project/vllm/pull/53204) at `2991f864083fdd5c60aa140d4fe1a561585a85dc`
 - `inference.proto` SHA-256: `6152c306583166ecd691c9c715cab950523e8d1ed2db3dc2bcb538f6ca90e56f`
-- `control.proto` SHA-256: `db72b0782142054293b07fd48247cc821c048213b9c95dbc37fb0d81dde8f46f`
+- `control.proto` SHA-256: `c8363fd4397187a44e667d3d04ada30401e078ab6763ed5144f674184dd8d787`
 
 The files are copied without modification. Update the revision and checksums together. `dynamo-vllm-sidecar` generates and temporarily exports these types for `dynamo-vllm-mocker-server`.

--- a/lib/sidecar/vllm/proto/control.proto
+++ b/lib/sidecar/vllm/proto/control.proto
@@ -54,6 +54,8 @@ message ParallelismInfo {
   uint32 data_parallel_size = 3;
   uint32 data_parallel_rank = 4;
   uint32 decode_context_parallel_size = 5;
+  // Process world size for one data-parallel engine (TP * PP * PCP).
+  uint64 world_size = 6;
 }
 
 message GetModelInfoRequest {}

--- a/lib/sidecar/vllm/src/args.rs
+++ b/lib/sidecar/vllm/src/args.rs
@@ -1,7 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_sidecar_common::SidecarArgs;
+use dynamo_sidecar_common::{HttpEndpoint, SidecarArgs};
+
+fn parse_http_endpoint(raw: &str) -> Result<HttpEndpoint, String> {
+    HttpEndpoint::parse(raw, "--vllm-http-endpoint").map_err(|error| error.to_string())
+}
 
 #[derive(clap::Parser, Clone, Debug)]
 #[command(
@@ -13,6 +17,10 @@ pub(crate) struct Args {
     pub sidecar: SidecarArgs,
 
     /// Optional controller-routable vLLM HTTP base URL for RL compatibility operations.
-    #[arg(long, env = "VLLM_HTTP_ENDPOINT")]
-    pub vllm_http_endpoint: Option<String>,
+    #[arg(
+        long,
+        env = "VLLM_HTTP_ENDPOINT",
+        value_parser = parse_http_endpoint
+    )]
+    pub vllm_http_endpoint: Option<HttpEndpoint>,
 }

--- a/lib/sidecar/vllm/src/args.rs
+++ b/lib/sidecar/vllm/src/args.rs
@@ -11,4 +11,8 @@ use dynamo_sidecar_common::SidecarArgs;
 pub(crate) struct Args {
     #[command(flatten)]
     pub sidecar: SidecarArgs,
+
+    /// Optional vLLM HTTP admin endpoint advertised for RL weight-transfer control.
+    #[arg(long, env = "VLLM_HTTP_ENDPOINT")]
+    pub vllm_http_endpoint: Option<String>,
 }

--- a/lib/sidecar/vllm/src/args.rs
+++ b/lib/sidecar/vllm/src/args.rs
@@ -12,7 +12,7 @@ pub(crate) struct Args {
     #[command(flatten)]
     pub sidecar: SidecarArgs,
 
-    /// Optional vLLM HTTP admin endpoint advertised for RL weight-transfer control.
+    /// Optional controller-routable vLLM HTTP base URL for RL compatibility operations.
     #[arg(long, env = "VLLM_HTTP_ENDPOINT")]
     pub vllm_http_endpoint: Option<String>,
 }

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -36,6 +36,25 @@ fn cancelled(state: &ResponseState) -> LLMEngineOutput {
     ))
 }
 
+pub(crate) fn validate_http_endpoint(value: &str) -> Result<String, DynamoError> {
+    let value = value.trim();
+    let parsed = url::Url::parse(value).map_err(|error| {
+        client::invalid_argument(format!("invalid --vllm-http-endpoint: {error}"))
+    })?;
+    let has_valid_authority = value
+        .split_once("://")
+        .is_some_and(|(_, authority)| !authority.is_empty() && !authority.starts_with('/'));
+    if !matches!(parsed.scheme(), "http" | "https")
+        || parsed.host_str().is_none()
+        || !has_valid_authority
+    {
+        return Err(client::invalid_argument(
+            "invalid --vllm-http-endpoint: expected an http:// or https:// URL with a host",
+        ));
+    }
+    Ok(value.to_string())
+}
+
 impl VllmSidecarEngine {
     pub(crate) fn new(
         endpoint: GrpcEndpoint,
@@ -95,15 +114,11 @@ impl VllmSidecarEngine {
 
         let endpoint = args.sidecar.grpc_endpoint;
         let enable_rl = args.sidecar.common.enable_rl;
-        let vllm_http_url = if enable_rl {
-            args.vllm_http_endpoint
-                .as_deref()
-                .map(|value| GrpcEndpoint::parse(value, "--vllm-http-endpoint"))
-                .transpose()?
-                .map(|endpoint| endpoint.to_string())
-        } else {
-            None
-        };
+        let vllm_http_url = args
+            .vllm_http_endpoint
+            .as_deref()
+            .map(validate_http_endpoint)
+            .transpose()?;
         let transport = args.sidecar.grpc.config();
         let bootstrap_deadline = client::startup_deadline(transport.startup_deadline)?;
         eprintln!(

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -36,11 +36,6 @@ fn cancelled(state: &ResponseState) -> LLMEngineOutput {
     ))
 }
 
-pub(crate) fn parse_http_endpoint_arg(value: &str) -> Result<RlAdminBaseUrl, DynamoError> {
-    RlAdminBaseUrl::parse(value)
-        .map_err(|error| client::invalid_argument(format!("invalid --vllm-http-endpoint: {error}")))
-}
-
 impl VllmSidecarEngine {
     pub(crate) fn new(
         endpoint: GrpcEndpoint,
@@ -102,8 +97,13 @@ impl VllmSidecarEngine {
         let enable_rl = args.sidecar.common.enable_rl;
         let vllm_http_url = args
             .vllm_http_endpoint
-            .as_deref()
-            .map(parse_http_endpoint_arg)
+            .map(|endpoint| {
+                RlAdminBaseUrl::parse(endpoint.as_str()).map_err(|error| {
+                    client::invalid_argument(format!(
+                        "invalid RL admin endpoint derived from --vllm-http-endpoint: {error}"
+                    ))
+                })
+            })
             .transpose()?;
         let transport = args.sidecar.grpc.config();
         let bootstrap_deadline = client::startup_deadline(transport.startup_deadline)?;

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -94,6 +94,16 @@ impl VllmSidecarEngine {
         }
 
         let endpoint = args.sidecar.grpc_endpoint;
+        let enable_rl = args.sidecar.common.enable_rl;
+        let vllm_http_url = if enable_rl {
+            args.vllm_http_endpoint
+                .as_deref()
+                .map(|value| GrpcEndpoint::parse(value, "--vllm-http-endpoint"))
+                .transpose()?
+                .map(|endpoint| endpoint.to_string())
+        } else {
+            None
+        };
         let transport = args.sidecar.grpc.config();
         let bootstrap_deadline = client::startup_deadline(transport.startup_deadline)?;
         eprintln!(
@@ -102,6 +112,9 @@ impl VllmSidecarEngine {
         );
         let model = bootstrap_discover(&endpoint, transport, bootstrap_deadline)?;
         let mode = args.sidecar.common.disaggregation_mode;
+        let rl_metadata = enable_rl
+            .then(|| model.rl_worker_metadata(vllm_http_url))
+            .transpose()?;
         let engine = Self::new(endpoint, model.clone(), mode, transport);
         let config = WorkerConfig {
             namespace: args.sidecar.common.namespace,
@@ -127,7 +140,8 @@ impl VllmSidecarEngine {
             enable_kv_routing: true,
             disaggregation_mode: mode,
             route_to_encoder: false,
-            enable_rl: args.sidecar.common.enable_rl,
+            enable_rl,
+            rl_metadata,
             ..Default::default()
         };
         Ok((engine, config))

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use dynamo_backend_common::{
     DisaggregationMode, DynamoError, GenerateContext, KvEventSource, LLMEngine, LLMEngineOutput,
-    LLMEngineOutputExt, WorkerConfig, usage,
+    LLMEngineOutputExt, RlAdminBaseUrl, WorkerConfig, usage,
 };
 use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig, SidecarStartupError};
 use futures::stream::BoxStream;
@@ -36,23 +36,9 @@ fn cancelled(state: &ResponseState) -> LLMEngineOutput {
     ))
 }
 
-pub(crate) fn validate_http_endpoint(value: &str) -> Result<String, DynamoError> {
-    let value = value.trim();
-    let parsed = url::Url::parse(value).map_err(|error| {
-        client::invalid_argument(format!("invalid --vllm-http-endpoint: {error}"))
-    })?;
-    let has_valid_authority = value
-        .split_once("://")
-        .is_some_and(|(_, authority)| !authority.is_empty() && !authority.starts_with('/'));
-    if !matches!(parsed.scheme(), "http" | "https")
-        || parsed.host_str().is_none()
-        || !has_valid_authority
-    {
-        return Err(client::invalid_argument(
-            "invalid --vllm-http-endpoint: expected an http:// or https:// URL with a host",
-        ));
-    }
-    Ok(value.to_string())
+pub(crate) fn parse_http_endpoint_arg(value: &str) -> Result<RlAdminBaseUrl, DynamoError> {
+    RlAdminBaseUrl::parse(value)
+        .map_err(|error| client::invalid_argument(format!("invalid --vllm-http-endpoint: {error}")))
 }
 
 impl VllmSidecarEngine {
@@ -117,7 +103,7 @@ impl VllmSidecarEngine {
         let vllm_http_url = args
             .vllm_http_endpoint
             .as_deref()
-            .map(validate_http_endpoint)
+            .map(parse_http_endpoint_arg)
             .transpose()?;
         let transport = args.sidecar.grpc.config();
         let bootstrap_deadline = client::startup_deadline(transport.startup_deadline)?;

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_backend_common::{DynamoError, EngineConfig, LlmRegistration};
+use dynamo_backend_common::{DynamoError, EngineConfig, LlmRegistration, RlWorkerMetadata};
 
 use crate::client;
 use crate::proto as pb;
@@ -82,11 +82,10 @@ impl DiscoveredModel {
                 self.identity, observed.identity
             )));
         }
-        let expected_dp_size = self.data_parallel_size();
-        let observed_dp_size = observed.data_parallel_size();
-        if expected_dp_size != observed_dp_size {
+        if self.server.parallelism != observed.server.parallelism {
             return Err(client::protocol_error(format!(
-                "data-parallel size changed between bootstrap and startup: expected {expected_dp_size}, observed {observed_dp_size}"
+                "parallelism changed between bootstrap and startup: expected {:?}, observed {:?}",
+                self.server.parallelism, observed.server.parallelism
             )));
         }
         if self.server.rl_capabilities != observed.server.rl_capabilities {
@@ -100,6 +99,32 @@ impl DiscoveredModel {
 
     pub(crate) fn rl_capabilities(&self) -> Option<&pb::RlCapabilities> {
         self.server.rl_capabilities.as_ref()
+    }
+
+    pub(crate) fn rl_worker_metadata(
+        &self,
+        admin_base_url: Option<String>,
+    ) -> Result<RlWorkerMetadata, DynamoError> {
+        let parallelism = self.server.parallelism.as_ref().ok_or_else(|| {
+            client::protocol_error("RL discovery requires vLLM parallelism metadata")
+        })?;
+        let world_size = parallelism
+            .tensor_parallel_size
+            .checked_mul(parallelism.pipeline_parallel_size)
+            .and_then(|size| size.checked_mul(parallelism.data_parallel_size))
+            .filter(|size| *size > 0)
+            .ok_or_else(|| client::protocol_error("vLLM reports an invalid RL world size"))?;
+        let backend = self
+            .server
+            .rl_capabilities
+            .as_ref()
+            .and_then(|capabilities| {
+                capabilities
+                    .weight_transfer_enabled
+                    .then(|| capabilities.weight_transfer_backend.clone())
+            });
+        RlWorkerMetadata::new(world_size, backend, admin_base_url)
+            .map_err(|error| client::protocol_error(error.to_string()))
     }
 
     pub(crate) fn engine_config(&self) -> EngineConfig {

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_backend_common::{DynamoError, EngineConfig, LlmRegistration, RlWorkerMetadata};
+use dynamo_backend_common::{
+    DynamoError, EngineConfig, LlmRegistration, RlAdminBaseUrl, RlWorkerMetadata,
+};
 
 use crate::client;
 use crate::proto as pb;
@@ -103,7 +105,7 @@ impl DiscoveredModel {
 
     pub(crate) fn rl_worker_metadata(
         &self,
-        admin_base_url: Option<String>,
+        admin_base_url: Option<RlAdminBaseUrl>,
     ) -> Result<RlWorkerMetadata, DynamoError> {
         let parallelism = self.server.parallelism.as_ref().ok_or_else(|| {
             client::protocol_error("RL discovery requires vLLM parallelism metadata")

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -114,16 +114,7 @@ impl DiscoveredModel {
             .and_then(|size| size.checked_mul(parallelism.data_parallel_size))
             .filter(|size| *size > 0)
             .ok_or_else(|| client::protocol_error("vLLM reports an invalid RL world size"))?;
-        let backend = self
-            .server
-            .rl_capabilities
-            .as_ref()
-            .and_then(|capabilities| {
-                capabilities
-                    .weight_transfer_enabled
-                    .then(|| capabilities.weight_transfer_backend.clone())
-            });
-        RlWorkerMetadata::new(world_size, backend, admin_base_url)
+        RlWorkerMetadata::new(world_size, admin_base_url)
             .map_err(|error| client::protocol_error(error.to_string()))
     }
 

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -108,11 +108,15 @@ impl DiscoveredModel {
         let parallelism = self.server.parallelism.as_ref().ok_or_else(|| {
             client::protocol_error("RL discovery requires vLLM parallelism metadata")
         })?;
-        let world_size = parallelism
-            .tensor_parallel_size
-            .checked_mul(parallelism.pipeline_parallel_size)
+        let tensor_parallel_size = nonzero(parallelism.tensor_parallel_size)
+            .ok_or_else(|| client::protocol_error("vLLM reports a tensor-parallel size of zero"))?;
+        let pipeline_parallel_size =
+            nonzero(parallelism.pipeline_parallel_size).ok_or_else(|| {
+                client::protocol_error("vLLM reports a pipeline-parallel size of zero")
+            })?;
+        let world_size = tensor_parallel_size
+            .checked_mul(pipeline_parallel_size)
             .and_then(|size| size.checked_mul(parallelism.data_parallel_size))
-            .filter(|size| *size > 0)
             .ok_or_else(|| client::protocol_error("vLLM reports an invalid RL world size"))?;
         RlWorkerMetadata::new(world_size, admin_base_url)
             .map_err(|error| client::protocol_error(error.to_string()))

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -116,9 +116,20 @@ impl DiscoveredModel {
             nonzero(parallelism.pipeline_parallel_size).ok_or_else(|| {
                 client::protocol_error("vLLM reports a pipeline-parallel size of zero")
             })?;
-        let world_size = tensor_parallel_size
+        let engine_world_size = u32::try_from(parallelism.world_size)
+            .ok()
+            .and_then(nonzero)
+            .ok_or_else(|| client::protocol_error("vLLM reports an invalid engine world size"))?;
+        let expected_minimum_world_size = tensor_parallel_size
             .checked_mul(pipeline_parallel_size)
-            .and_then(|size| size.checked_mul(parallelism.data_parallel_size))
+            .ok_or_else(|| client::protocol_error("vLLM reports an invalid RL world size"))?;
+        if engine_world_size % expected_minimum_world_size != 0 {
+            return Err(client::protocol_error(
+                "vLLM reports an engine world size that is not divisible by TP * PP",
+            ));
+        }
+        let world_size = engine_world_size
+            .checked_mul(parallelism.data_parallel_size)
             .ok_or_else(|| client::protocol_error("vLLM reports an invalid RL world size"))?;
         RlWorkerMetadata::new(world_size, admin_base_url)
             .map_err(|error| client::protocol_error(error.to_string()))

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -24,7 +24,7 @@ use tonic_health::ServingStatus as HealthServingStatus;
 
 use crate::client::{CONTROL_SERVICE, INFERENCE_SERVICE, VllmClient};
 use crate::convert::{ResponseState, build_generate_request};
-use crate::engine::VllmSidecarEngine;
+use crate::engine::{VllmSidecarEngine, validate_http_endpoint};
 use crate::json::{json_to_struct, struct_to_json};
 use crate::model::DiscoveredModel;
 use crate::proto as pb;
@@ -469,6 +469,28 @@ fn discovered_model_reports_rl_worker_metadata() {
         RlWorkerMetadata::new(4, Some("http://worker:8120".to_string()))
             .expect("valid expected metadata")
     );
+}
+
+#[test]
+fn http_admin_endpoint_accepts_http_https_and_path_prefixes() {
+    for endpoint in [
+        "http://worker:8120",
+        "https://worker.example.com",
+        "https://worker.example.com/admin/v1",
+    ] {
+        assert_eq!(
+            validate_http_endpoint(endpoint).expect("valid HTTP admin endpoint"),
+            endpoint
+        );
+    }
+}
+
+#[test]
+fn http_admin_endpoint_rejects_invalid_values() {
+    for endpoint in ["", "worker:8120", "grpc://worker:8120", "https:///admin"] {
+        let error = validate_http_endpoint(endpoint).unwrap_err();
+        assert!(error.to_string().contains("--vllm-http-endpoint"));
+    }
 }
 
 #[test]

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -11,7 +11,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use dynamo_backend_common::engine::RoutingHints;
 use dynamo_backend_common::{
     DisaggregationMode, FinishReason, GenerateContext, LLMEngine, MultimodalData, OutputOptions,
-    PrefillResult, PreprocessedRequest, RlWorkerMetadata, SamplingOptions, StopConditions,
+    PrefillResult, PreprocessedRequest, RlAdminBaseUrl, RlWorkerMetadata, SamplingOptions,
+    StopConditions,
 };
 use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
 use futures::{Stream, StreamExt};
@@ -24,7 +25,7 @@ use tonic_health::ServingStatus as HealthServingStatus;
 
 use crate::client::{CONTROL_SERVICE, INFERENCE_SERVICE, VllmClient};
 use crate::convert::{ResponseState, build_generate_request};
-use crate::engine::{VllmSidecarEngine, validate_http_endpoint};
+use crate::engine::{VllmSidecarEngine, parse_http_endpoint_arg};
 use crate::json::{json_to_struct, struct_to_json};
 use crate::model::DiscoveredModel;
 use crate::proto as pb;
@@ -486,7 +487,9 @@ fn http_admin_endpoint_accepts_http_https_and_path_prefixes() {
         "https://worker.example.com/admin/v1",
     ] {
         assert_eq!(
-            validate_http_endpoint(endpoint).expect("valid HTTP admin endpoint"),
+            parse_http_endpoint_arg(endpoint)
+                .expect("valid HTTP admin endpoint")
+                .as_str(),
             endpoint
         );
     }
@@ -495,7 +498,7 @@ fn http_admin_endpoint_accepts_http_https_and_path_prefixes() {
 #[test]
 fn http_admin_endpoint_rejects_invalid_values() {
     for endpoint in ["", "worker:8120", "grpc://worker:8120", "https:///admin"] {
-        let error = validate_http_endpoint(endpoint).unwrap_err();
+        let error = parse_http_endpoint_arg(endpoint).unwrap_err();
         assert!(error.to_string().contains("--vllm-http-endpoint"));
     }
 }
@@ -908,8 +911,11 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
     assert_eq!(
         worker.rl_metadata,
         Some(
-            RlWorkerMetadata::new(4, Some("http://worker:8120".to_string()))
-                .expect("valid RL metadata")
+            RlWorkerMetadata::new(
+                4,
+                Some(RlAdminBaseUrl::parse("http://worker:8120").expect("valid admin base URL"),),
+            )
+            .expect("valid RL metadata")
         )
     );
     let config = engine.start(0).await.expect("start");

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -480,6 +480,22 @@ fn rl_worker_metadata_identifies_zero_parallelism_dimensions() {
 }
 
 #[test]
+fn rl_worker_metadata_includes_prefill_context_parallelism() {
+    let mut server = server_info();
+    let parallelism = server.parallelism.as_mut().expect("parallelism metadata");
+    parallelism.tensor_parallel_size = 2;
+    parallelism.pipeline_parallel_size = 3;
+    parallelism.data_parallel_size = 5;
+    parallelism.world_size = 12;
+
+    let model = DiscoveredModel::from_proto(model_info(), server).expect("valid discovery");
+    assert_eq!(
+        model.rl_worker_metadata(None).expect("valid RL metadata"),
+        RlWorkerMetadata::new(60, None).expect("valid expected metadata")
+    );
+}
+
+#[test]
 fn http_admin_endpoint_accepts_http_https_and_path_prefixes() {
     for endpoint in [
         "http://worker:8120",

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -445,6 +445,7 @@ fn server_info() -> pb::ServerInfo {
             data_parallel_size: 2,
             data_parallel_rank: 0,
             decode_context_parallel_size: 1,
+            world_size: 2,
         }),
         max_model_len: 8192,
         kv_block_size: 16,
@@ -493,6 +494,20 @@ fn rl_worker_metadata_includes_prefill_context_parallelism() {
         model.rl_worker_metadata(None).expect("valid RL metadata"),
         RlWorkerMetadata::new(60, None).expect("valid expected metadata")
     );
+}
+
+#[test]
+fn rl_worker_metadata_rejects_missing_engine_world_size() {
+    let mut server = server_info();
+    server
+        .parallelism
+        .as_mut()
+        .expect("parallelism metadata")
+        .world_size = 0;
+
+    let model = DiscoveredModel::from_proto(model_info(), server).expect("valid discovery");
+    let error = model.rl_worker_metadata(None).unwrap_err();
+    assert!(error.to_string().contains("engine world size"));
 }
 
 #[test]

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -472,6 +472,25 @@ fn discovered_model_reports_rl_worker_metadata() {
 }
 
 #[test]
+fn rl_worker_metadata_identifies_zero_parallelism_dimensions() {
+    for (dimension, expected) in [
+        ("tensor", "tensor-parallel size of zero"),
+        ("pipeline", "pipeline-parallel size of zero"),
+    ] {
+        let mut server = server_info();
+        let parallelism = server.parallelism.as_mut().expect("parallelism metadata");
+        match dimension {
+            "tensor" => parallelism.tensor_parallel_size = 0,
+            "pipeline" => parallelism.pipeline_parallel_size = 0,
+            _ => unreachable!(),
+        }
+        let model = DiscoveredModel::from_proto(model_info(), server).expect("valid discovery");
+        let error = model.rl_worker_metadata(None).unwrap_err();
+        assert!(error.to_string().contains(expected));
+    }
+}
+
+#[test]
 fn http_admin_endpoint_accepts_http_https_and_path_prefixes() {
     for endpoint in [
         "http://worker:8120",

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -460,18 +460,6 @@ fn server_info() -> pb::ServerInfo {
 }
 
 #[test]
-fn discovered_model_reports_rl_worker_metadata() {
-    let model = DiscoveredModel::from_proto(model_info(), server_info()).expect("valid discovery");
-    assert_eq!(
-        model
-            .rl_worker_metadata(Some("http://worker:8120".to_string()))
-            .expect("valid RL metadata"),
-        RlWorkerMetadata::new(4, Some("http://worker:8120".to_string()))
-            .expect("valid expected metadata")
-    );
-}
-
-#[test]
 fn rl_worker_metadata_identifies_zero_parallelism_dimensions() {
     for (dimension, expected) in [
         ("tensor", "tensor-parallel size of zero"),

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -466,12 +466,8 @@ fn discovered_model_reports_rl_worker_metadata() {
         model
             .rl_worker_metadata(Some("http://worker:8120".to_string()))
             .expect("valid RL metadata"),
-        RlWorkerMetadata::new(
-            4,
-            Some("nccl".to_string()),
-            Some("http://worker:8120".to_string()),
-        )
-        .expect("valid expected metadata")
+        RlWorkerMetadata::new(4, Some("http://worker:8120".to_string()))
+            .expect("valid expected metadata")
     );
 }
 
@@ -883,12 +879,8 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
     assert_eq!(
         worker.rl_metadata,
         Some(
-            RlWorkerMetadata::new(
-                4,
-                Some("nccl".to_string()),
-                Some("http://worker:8120".to_string()),
-            )
-            .expect("valid RL metadata")
+            RlWorkerMetadata::new(4, Some("http://worker:8120".to_string()))
+                .expect("valid RL metadata")
         )
     );
     let config = engine.start(0).await.expect("start");

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -25,7 +25,7 @@ use tonic_health::ServingStatus as HealthServingStatus;
 
 use crate::client::{CONTROL_SERVICE, INFERENCE_SERVICE, VllmClient};
 use crate::convert::{ResponseState, build_generate_request};
-use crate::engine::{VllmSidecarEngine, parse_http_endpoint_arg};
+use crate::engine::VllmSidecarEngine;
 use crate::json::{json_to_struct, struct_to_json};
 use crate::model::DiscoveredModel;
 use crate::proto as pb;
@@ -481,30 +481,6 @@ fn rl_worker_metadata_identifies_zero_parallelism_dimensions() {
 }
 
 #[test]
-fn http_admin_endpoint_accepts_http_https_and_path_prefixes() {
-    for endpoint in [
-        "http://worker:8120",
-        "https://worker.example.com",
-        "https://worker.example.com/admin/v1",
-    ] {
-        assert_eq!(
-            parse_http_endpoint_arg(endpoint)
-                .expect("valid HTTP admin endpoint")
-                .as_str(),
-            endpoint
-        );
-    }
-}
-
-#[test]
-fn http_admin_endpoint_rejects_invalid_values() {
-    for endpoint in ["", "worker:8120", "grpc://worker:8120", "https:///admin"] {
-        let error = parse_http_endpoint_arg(endpoint).unwrap_err();
-        assert!(error.to_string().contains("--vllm-http-endpoint"));
-    }
-}
-
-#[test]
 fn startup_compatibility_rejects_tensor_or_pipeline_parallelism_change() {
     let bootstrap = DiscoveredModel::from_proto(model_info(), server_info())
         .expect("valid bootstrap discovery");
@@ -914,7 +890,7 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
         Some(
             RlWorkerMetadata::new(
                 4,
-                Some(RlAdminBaseUrl::parse("http://worker:8120").expect("valid admin base URL"),),
+                Some(RlAdminBaseUrl::parse("http://worker:8120/").expect("valid admin base URL"),),
             )
             .expect("valid RL metadata")
         )

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -481,36 +481,6 @@ fn rl_worker_metadata_identifies_zero_parallelism_dimensions() {
 }
 
 #[test]
-fn rl_worker_metadata_includes_prefill_context_parallelism() {
-    let mut server = server_info();
-    let parallelism = server.parallelism.as_mut().expect("parallelism metadata");
-    parallelism.tensor_parallel_size = 2;
-    parallelism.pipeline_parallel_size = 3;
-    parallelism.data_parallel_size = 5;
-    parallelism.world_size = 12;
-
-    let model = DiscoveredModel::from_proto(model_info(), server).expect("valid discovery");
-    assert_eq!(
-        model.rl_worker_metadata(None).expect("valid RL metadata"),
-        RlWorkerMetadata::new(60, None).expect("valid expected metadata")
-    );
-}
-
-#[test]
-fn rl_worker_metadata_rejects_missing_engine_world_size() {
-    let mut server = server_info();
-    server
-        .parallelism
-        .as_mut()
-        .expect("parallelism metadata")
-        .world_size = 0;
-
-    let model = DiscoveredModel::from_proto(model_info(), server).expect("valid discovery");
-    let error = model.rl_worker_metadata(None).unwrap_err();
-    assert!(error.to_string().contains("engine world size"));
-}
-
-#[test]
 fn http_admin_endpoint_accepts_http_https_and_path_prefixes() {
     for endpoint in [
         "http://worker:8120",

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use dynamo_backend_common::engine::RoutingHints;
 use dynamo_backend_common::{
     DisaggregationMode, FinishReason, GenerateContext, LLMEngine, MultimodalData, OutputOptions,
-    PrefillResult, PreprocessedRequest, SamplingOptions, StopConditions,
+    PrefillResult, PreprocessedRequest, RlWorkerMetadata, SamplingOptions, StopConditions,
 };
 use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
 use futures::{Stream, StreamExt};
@@ -459,6 +459,48 @@ fn server_info() -> pb::ServerInfo {
     }
 }
 
+#[test]
+fn discovered_model_reports_rl_worker_metadata() {
+    let model = DiscoveredModel::from_proto(model_info(), server_info()).expect("valid discovery");
+    assert_eq!(
+        model
+            .rl_worker_metadata(Some("http://worker:8120".to_string()))
+            .expect("valid RL metadata"),
+        RlWorkerMetadata::new(
+            4,
+            Some("nccl".to_string()),
+            Some("http://worker:8120".to_string()),
+        )
+        .expect("valid expected metadata")
+    );
+}
+
+#[test]
+fn startup_compatibility_rejects_tensor_or_pipeline_parallelism_change() {
+    let bootstrap = DiscoveredModel::from_proto(model_info(), server_info())
+        .expect("valid bootstrap discovery");
+
+    for dimension in ["tensor", "pipeline"] {
+        let mut changed_server = server_info();
+        let parallelism = changed_server
+            .parallelism
+            .as_mut()
+            .expect("parallelism metadata");
+        match dimension {
+            "tensor" => parallelism.tensor_parallel_size += 1,
+            "pipeline" => parallelism.pipeline_parallel_size += 1,
+            _ => unreachable!(),
+        }
+        let observed = DiscoveredModel::from_proto(model_info(), changed_server)
+            .expect("valid startup discovery");
+
+        assert!(
+            bootstrap.ensure_startup_compatible(&observed).is_err(),
+            "{dimension} parallelism change should be rejected"
+        );
+    }
+}
+
 fn sequence_response(
     terminal: bool,
     logprobs: bool,
@@ -761,6 +803,9 @@ async fn engine_from_args(
         "dynamo-vllm-sidecar".to_string(),
         "--grpc-endpoint".to_string(),
         endpoint.to_string(),
+        "--vllm-http-endpoint".to_string(),
+        "http://worker:8120".to_string(),
+        "--enable-rl".to_string(),
         "--grpc-connections".to_string(),
         "2".to_string(),
         "--grpc-startup-deadline-secs".to_string(),
@@ -835,6 +880,17 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
     assert_eq!(worker.served_model_name.as_deref(), Some("served-model"));
     assert!(worker.reasoning_parser.is_none());
     assert!(worker.tool_call_parser.is_none());
+    assert_eq!(
+        worker.rl_metadata,
+        Some(
+            RlWorkerMetadata::new(
+                4,
+                Some("nccl".to_string()),
+                Some("http://worker:8120".to_string()),
+            )
+            .expect("valid RL metadata")
+        )
+    );
     let config = engine.start(0).await.expect("start");
     assert_eq!(config.model, "model-source");
     assert_eq!(config.served_model_name.as_deref(), Some("served-model"));


### PR DESCRIPTION
## Summary

- publish vLLM sidecar RL worker metadata through Dynamo discovery
- compute inference world size from tensor, pipeline, and data parallelism
- advertise and validate the optional HTTP or HTTPS admin endpoint for weight-transfer control
- reject topology or RL-capability drift between bootstrap and startup
- attribute malformed TP/PP topology to the exact dimension

## Stack

- Depends on #13606, which defines the shared worker metadata contract
- This PR contains only the vLLM sidecar producer delta when viewed against its GitHub base

Supersedes #13529 without changing its reviewed commit history.

## Validation

- `cargo fmt --all`
- `cargo test -p dynamo-vllm-sidecar --lib` (25 passed)
- `cargo clippy -p dynamo-vllm-sidecar --all-targets -- -D warnings`
- `git diff --check`

## Review follow-up evidence

- RED: HTTP endpoint tests failed before the dedicated validator existed
- RED: topology tests failed against the generic world-size error
- GREEN: HTTP, HTTPS, and path-prefixed admin URLs are accepted; malformed schemes and zero topology dimensions are rejected precisely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RL worker metadata reporting, including world size and optional administration endpoints.
  * Added configurable vLLM HTTP endpoints through startup arguments or environment variables.
  * Added protocol version information and expanded parallelism details for worker discovery.
* **Bug Fixes**
  * Improved validation for RL endpoints and parallelism settings, with clearer startup errors.
  * Prevented incompatible workers from starting when parallelism configuration changes.
* **Documentation**
  * Expanded vLLM RL workflow guidance, routing examples, compatibility details, and security recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->