### PR TITLE
fix(vllm): [cherry-pick 1.4.1] use writable buffer for NIXL objects (#13228)

### DIFF
--- a/components/src/dynamo/vllm/omni/connectors/nixl_connector.py
+++ b/components/src/dynamo/vllm/omni/connectors/nixl_connector.py
@@ -501,9 +501,10 @@ def _tensor_uint8_to_bytes(tensor: torch.Tensor) -> bytes:
 
 
 def _bytes_to_uint8_tensor(value: bytes, device: torch.device) -> torch.Tensor:
+    # Use writable storage because torch.frombuffer warns on immutable bytes.
+    writable_value = bytearray(value)
     return (
-        torch.frombuffer(value, dtype=torch.uint8)
-        .clone()
+        torch.frombuffer(writable_value, dtype=torch.uint8)
         .to(device=device)
         .contiguous()
     )


### PR DESCRIPTION
## Overview

Cherry-pick of #13228 onto `release/1.4.1`. Fixes the one GPU test failing on this branch, which is currently red on every 1.4.1 cherry-pick PR regardless of content.

## Details

`components/src/dynamo/vllm/tests/omni/test_omni_nixl_connector.py::test_nixl_connector_object_roundtrip` fails on the branch with:

```
The given buffer is not writable, and PyTorch does not support non-writable tensors.
```

#13228 wraps the value in a `bytearray` before `torch.frombuffer`, which is exactly this failure. The fix landed on main after the 1.4.0 branch cut, so `release/1.4.1` never had it.

Confirmed branch-level rather than PR-caused: the same test fails on #13563, which changes only a CI YAML file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->