### PR TITLE
feat(planner): add Redis connector for scaling up / down worker fleet

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -180,6 +180,7 @@ repos:
         - pyyaml
         - prometheus_client>=0.23.1
         - openai
+        - redis>=5.0.0,<6.0
     - id: validate-skills
       name: Validate .agents/skills SKILL.md frontmatter and AGENTS.md index
       entry: python3 scripts/validate_skills.py

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -385,7 +385,7 @@ class PlannerConfig(BaseModel):
     )
 
     environment: Literal[
-        "kubernetes", "virtual", "global-planner"
+        "kubernetes", "virtual", "global-planner", "redis"
     ] = SLAPlannerDefaults.environment
     namespace: str = Field(
         default_factory=lambda: os.environ.get("DYN_NAMESPACE", "dynamo"),
@@ -894,6 +894,17 @@ class PlannerConfig(BaseModel):
             raise ValueError(
                 "global_planner_namespace is required when environment='global-planner'. "
                 "Please specify the namespace where GlobalPlanner is running."
+            )
+
+        if self.optimization_target == "sla" and self.environment == "redis":
+            raise ValueError(
+                "optimization_target='sla' is not supported with "
+                "environment='redis'. SLA sizing needs forward-pass metrics "
+                "from a runtime binding, which -- unlike 'virtual' -- the "
+                "redis connector never wires up (no worker_info_provider), "
+                "so it would silently fall back to static config sizing "
+                "alone. Use 'throughput'/'latency'/'load' with "
+                "environment='redis', or 'virtual'/'kubernetes' for 'sla'."
             )
 
         if self.optimization_target == "load":

--- a/components/src/dynamo/planner/connectors/redis_connector.py
+++ b/components/src/dynamo/planner/connectors/redis_connector.py
@@ -1,0 +1,291 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Redis connector: publishes scaling decisions to Redis and reads back
+observed worker state, instead of talking to Kubernetes directly.
+
+Sibling to VirtualConnector for "hand the decision to a non-native
+environment," but with no etcd/nats/DistributedRuntime dependency -- just a
+Redis connection.
+
+Wire format: one Redis hash per deployment, key
+``{prefix}:{dynamo_namespace}:{model_name}``. Two deployments serving the
+same model_name under different namespaces get distinct keys -- necessary
+since Redis may be shared across more than one deployment. This connector
+owns the "desired" fields (``prefill``, ``decode``, ``updated_at``).
+An external actuator (not part of this repo) is expected to read those and,
+separately, write back "observed" fields (``prefill_active``,
+``decode_active``, ``prefill_stable``, ``decode_stable``, ``observed_at``)
+reflecting what it actually did. Distinct field names on both sides means
+neither side's write can clobber the other's fields, even sharing one key.
+The two ``*_stable`` fields are plain strings, ``"true"``/``"false"``
+(case-insensitive), not JSON booleans -- kept human-readable for anyone
+inspecting the key by hand.
+
+If the external actuator never writes the observed fields -- before its
+first write-back, or because it doesn't track this at all --
+``get_actual_worker_counts`` reads inactive/unstable defaults rather than
+raising or assuming a settled empty deployment.
+"""
+
+import logging
+import os
+import time
+
+import redis.asyncio as redis_asyncio
+
+from dynamo.planner.config.defaults import SubComponentType, TargetReplica
+from dynamo.planner.connectors.base import PlannerConnector
+from dynamo.planner.errors import EmptyTargetReplicasError
+from dynamo.planner.monitoring.worker_info import (
+    WorkerInfo,
+    build_worker_info_from_defaults,
+)
+from dynamo.runtime.logging import configure_dynamo_logging
+
+configure_dynamo_logging()
+logger = logging.getLogger(__name__)
+
+REDIS_KEY_PREFIX = os.environ.get("DYN_REDIS_KEY_PREFIX", "dynamo:planner:target")
+
+
+def _parse_non_negative_int(raw: dict[str, str], field: str) -> int:
+    """Parse one hash field as a non-negative int, defaulting to 0 if absent.
+
+    Raises ValueError naming the offending field on a negative or otherwise
+    invalid value -- corrupted or hand-edited Redis data should fail loudly
+    rather than silently propagate a nonsensical replica count.
+    """
+    value = raw.get(field, "0")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"redis field {field!r} is not a valid integer: {value!r}"
+        ) from None
+    if parsed < 0:
+        raise ValueError(f"redis field {field!r} must not be negative, got {parsed}")
+    return parsed
+
+
+class RedisConnector(PlannerConnector):
+    """Publishes scaling decisions to Redis; reads observed state back from it."""
+
+    def __init__(
+        self,
+        dynamo_namespace: str,
+        model_name: str | None = None,
+        redis_url: str | None = None,
+    ) -> None:
+        if not model_name:
+            raise ValueError("Model name is required for redis connector")
+        # Case-preserving: unlike VirtualConnector/KubernetesConnector, this
+        # connector never matches model_name against MDC entries, so there's
+        # no reason to fold case -- and doing so would risk merging two
+        # distinct, differently-cased model names onto the same Redis key.
+        self.model_name = model_name
+        self.dynamo_namespace = dynamo_namespace
+
+        redis_url = redis_url or os.environ.get("DYN_REDIS_URL")
+        if not redis_url:
+            raise ValueError(
+                "redis_url is required for redis connector "
+                "(pass explicitly or set DYN_REDIS_URL)"
+            )
+        self._redis = redis_asyncio.from_url(redis_url, decode_responses=True)
+        self._closed = False
+        # Curly braces are a Redis Cluster hash tag: only the portion inside
+        # them is hashed to pick a shard, so every key for one deployment
+        # lands on the same node regardless of what prefix precedes it.
+        # Namespace is part of the tag, not just the prefix, so two
+        # deployments sharing a model_name under different namespaces never
+        # collide on the same key.
+        self._key = f"{REDIS_KEY_PREFIX}:{{{self.dynamo_namespace}:{self.model_name}}}"
+
+    async def async_init(self) -> None:
+        """Nothing to do -- the Redis client connects lazily on first command."""
+
+    async def _read_desired_counts(self) -> tuple[int, int]:
+        raw = await self._redis.hgetall(self._key)
+        return (
+            _parse_non_negative_int(raw, "prefill"),
+            _parse_non_negative_int(raw, "decode"),
+        )
+
+    async def add_component(
+        self, sub_component_type: SubComponentType, blocking: bool = True
+    ) -> None:
+        """Add a component by increasing its published replica count by 1.
+
+        Not exercised by the automatic tick loop (that goes through
+        ``set_component_replicas`` below); implemented only for parity with
+        the other connectors' manual/CLI use. Read-then-write, same as
+        ``VirtualConnector``'s equivalent -- fine off the hot path.
+        """
+        current_p, current_d = await self._read_desired_counts()
+        if sub_component_type == SubComponentType.PREFILL:
+            await self._redis.hset(
+                self._key,
+                mapping={"prefill": current_p + 1, "updated_at": time.time()},
+            )
+        elif sub_component_type == SubComponentType.DECODE:
+            await self._redis.hset(
+                self._key,
+                mapping={"decode": current_d + 1, "updated_at": time.time()},
+            )
+
+    async def remove_component(
+        self, sub_component_type: SubComponentType, blocking: bool = True
+    ) -> None:
+        """Remove a component by decreasing its published replica count by 1.
+
+        See ``add_component`` -- not on the automatic scaling path.
+        """
+        current_p, current_d = await self._read_desired_counts()
+        if sub_component_type == SubComponentType.PREFILL:
+            await self._redis.hset(
+                self._key,
+                mapping={"prefill": max(0, current_p - 1), "updated_at": time.time()},
+            )
+        elif sub_component_type == SubComponentType.DECODE:
+            await self._redis.hset(
+                self._key,
+                mapping={"decode": max(0, current_d - 1), "updated_at": time.time()},
+            )
+
+    async def set_component_replicas(
+        self, target_replicas: list[TargetReplica], blocking: bool = True
+    ) -> None:
+        """Publish the tick's final decision to Redis.
+
+        This is the method every planner mode actually calls. A single
+        ``HSET`` covers only the roles present in ``target_replicas`` -- no
+        read-modify-write, so two planners sharing this model_name's key
+        (e.g. a dedicated PrefillPlanner and DecodePlanner) can't race each
+        other clobbering the other's field.
+
+        ``blocking`` is accepted for interface compatibility but ignored:
+        there's no "wait for the external actuator to finish scaling"
+        concept here. Our job ends when the write returns; the external
+        control plane picks it up and actuates on its own schedule.
+        """
+        if not target_replicas:
+            raise EmptyTargetReplicasError()
+
+        mapping: dict[str, int | float] = {}
+        for target_replica in target_replicas:
+            if target_replica.desired_replicas < 0:
+                raise ValueError(
+                    f"desired_replicas must not be negative, got "
+                    f"{target_replica.desired_replicas} for "
+                    f"{target_replica.sub_component_type.value}"
+                )
+            if target_replica.sub_component_type == SubComponentType.PREFILL:
+                mapping["prefill"] = target_replica.desired_replicas
+            elif target_replica.sub_component_type == SubComponentType.DECODE:
+                mapping["decode"] = target_replica.desired_replicas
+
+        if not mapping:
+            return
+        mapping["updated_at"] = time.time()
+        await self._redis.hset(self._key, mapping=mapping)
+
+    async def validate_deployment(
+        self,
+        prefill_component_name: str | None = None,
+        decode_component_name: str | None = None,
+        require_prefill: bool = True,
+        require_decode: bool = True,
+    ) -> None:
+        """No external deployment for this connector to validate against."""
+
+    async def wait_for_deployment_ready(self, include_planner: bool = True) -> None:
+        """No external deployment to wait on."""
+
+    def get_model_name(
+        self, require_prefill: bool = True, require_decode: bool = True
+    ) -> str:
+        """Get the model name (as given at construction)."""
+        del require_prefill, require_decode
+        return self.model_name
+
+    def get_gpu_counts(
+        self,
+        require_prefill: bool = True,
+        require_decode: bool = True,
+    ) -> tuple[int | None, int | None]:
+        """No live view of GPU shape -- same reasoning as ``VirtualConnector``:
+        this connector's Redis hash carries replica counts only, never GPU
+        shape. The planner falls back to its own ``prefill_engine_num_gpu``/
+        ``decode_engine_num_gpu`` config for its sizing math.
+        """
+        del require_prefill, require_decode
+        return None, None
+
+    def get_worker_info(
+        self,
+        sub_component_type: SubComponentType,
+        backend: str = "vllm",
+    ) -> WorkerInfo:
+        """No live discovery source for this connector -- always defaults.
+
+        ``VirtualConnector`` gets an MDC source wired in after construction
+        (a ``VirtualConnector``-specific hook in ``construct_environment``);
+        this connector never receives one and always falls back to defaults.
+        """
+        info = build_worker_info_from_defaults(backend, sub_component_type)
+        info.model_name = self.model_name
+        return info
+
+    async def get_actual_worker_counts(
+        self,
+        prefill_component_name: str | None = None,
+        decode_component_name: str | None = None,
+    ) -> tuple[int, int, bool]:
+        """Read observed state written back by the external actuator.
+
+        Per the ``PlannerConnector`` contract, a component whose name arg is
+        ``None`` (not required by this planner mode) reports 0 and does not
+        count against the returned ``stable`` flag -- only roles actually in
+        play for this planner instance affect it.
+
+        If the external actuator hasn't published observed counts for this
+        model -- before its first write-back, or because it doesn't track
+        this at all -- missing fields default to inactive/unstable: fail
+        closed as "still converging," never a false "settled empty."
+        """
+        raw = await self._redis.hgetall(self._key)
+
+        prefill_active = 0
+        decode_active = 0
+        stable = True
+
+        if prefill_component_name is not None:
+            prefill_active = _parse_non_negative_int(raw, "prefill_active")
+            stable = stable and raw.get("prefill_stable", "").lower() == "true"
+        if decode_component_name is not None:
+            decode_active = _parse_non_negative_int(raw, "decode_active")
+            stable = stable and raw.get("decode_stable", "").lower() == "true"
+
+        return prefill_active, decode_active, stable
+
+    async def shutdown(self) -> None:
+        """Release the Redis client. Idempotent -- safe to call more than
+        once (e.g. if the environment's own shutdown and a caller's
+        explicit cleanup both fire)."""
+        if self._closed:
+            return
+        self._closed = True
+        await self._redis.aclose()

--- a/components/src/dynamo/planner/core/planner_factory.py
+++ b/components/src/dynamo/planner/core/planner_factory.py
@@ -9,6 +9,7 @@ from dynamo.planner.config.planner_config import PlannerConfig
 from dynamo.planner.connectors.base import PlannerConnector, WorkerInfoProvider
 from dynamo.planner.connectors.global_planner import GlobalPlannerConnector
 from dynamo.planner.connectors.kubernetes import KubernetesConnector
+from dynamo.planner.connectors.redis_connector import RedisConnector
 from dynamo.planner.connectors.virtual import VirtualConnector
 from dynamo.planner.environment.base import PlannerEnvironmentImpl
 from dynamo.planner.environment.interface import PlannerEnvironment
@@ -63,6 +64,11 @@ def construct_connector(
             runtime=runtime,
             dynamo_namespace=config.namespace,
             worker_info_provider=worker_info_provider,
+            model_name=config.model_name,
+        )
+    if config.environment == "redis":
+        return RedisConnector(
+            dynamo_namespace=config.namespace,
             model_name=config.model_name,
         )
     raise ValueError(f"Invalid environment: {config.environment}")

--- a/components/src/dynamo/planner/environment/base.py
+++ b/components/src/dynamo/planner/environment/base.py
@@ -171,6 +171,9 @@ class PlannerEnvironmentImpl(PlannerEnvironment):
         await self.controller.set_component_replicas(targets, blocking=blocking)
 
     async def shutdown(self) -> None:
+        controller_shutdown = getattr(self.controller, "shutdown", None)
+        if callable(controller_shutdown):
+            await controller_shutdown()
         await self.fpm_provider.shutdown()
 
     async def _refresh_deployment_state(

--- a/components/src/dynamo/planner/environment/base.py
+++ b/components/src/dynamo/planner/environment/base.py
@@ -172,9 +172,11 @@ class PlannerEnvironmentImpl(PlannerEnvironment):
 
     async def shutdown(self) -> None:
         controller_shutdown = getattr(self.controller, "shutdown", None)
-        if callable(controller_shutdown):
-            await controller_shutdown()
-        await self.fpm_provider.shutdown()
+        try:
+            if callable(controller_shutdown):
+                await controller_shutdown()
+        finally:
+            await self.fpm_provider.shutdown()
 
     async def _refresh_deployment_state(
         self, deployment: Optional[dict] = None

--- a/components/src/dynamo/planner/tests/unit/test_environment.py
+++ b/components/src/dynamo/planner/tests/unit/test_environment.py
@@ -281,3 +281,70 @@ def test_gpu_refresh_validates_required_widths(
 
     with pytest.raises(DeploymentValidationError, match=missing_field):
         environment._refresh_gpu_counts()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_calls_controller_and_fpm_provider():
+    controller = _controller()
+    controller.shutdown = AsyncMock()
+    fpm_provider = _fpm_provider()
+    environment = PlannerEnvironmentImpl(
+        config=_config(),
+        controller=controller,
+        require_prefill=True,
+        require_decode=True,
+        fpm_provider=fpm_provider,
+    )
+
+    await environment.shutdown()
+
+    controller.shutdown.assert_awaited_once()
+    fpm_provider.shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_still_releases_fpm_provider_if_controller_shutdown_raises():
+    """A connector's own shutdown failing must not leak the fpm provider's
+    resources -- it should still get its chance to clean up."""
+    controller = _controller()
+    controller.shutdown = AsyncMock(side_effect=RuntimeError("boom"))
+    fpm_provider = _fpm_provider()
+    environment = PlannerEnvironmentImpl(
+        config=_config(),
+        controller=controller,
+        require_prefill=True,
+        require_decode=True,
+        fpm_provider=fpm_provider,
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await environment.shutdown()
+
+    fpm_provider.shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_skips_controller_call_when_connector_has_no_shutdown():
+    """Existing connectors (Kubernetes/Virtual/GlobalPlanner) have no
+    shutdown method; the environment must not assume one exists.
+
+    ``controller.shutdown = None`` (rather than leaving it unset) is
+    deliberate: a bare MagicMock auto-vivifies any accessed attribute as a
+    callable child mock, which would falsely satisfy this code's
+    ``callable(getattr(...))`` check and mask exactly the bug this test
+    guards against.
+    """
+    controller = _controller()
+    controller.shutdown = None
+    fpm_provider = _fpm_provider()
+    environment = PlannerEnvironmentImpl(
+        config=_config(),
+        controller=controller,
+        require_prefill=True,
+        require_decode=True,
+        fpm_provider=fpm_provider,
+    )
+
+    await environment.shutdown()
+
+    fpm_provider.shutdown.assert_awaited_once()

--- a/components/src/dynamo/planner/tests/unit/test_planner_config.py
+++ b/components/src/dynamo/planner/tests/unit/test_planner_config.py
@@ -46,6 +46,29 @@ def test_invalid_environment():
         )
 
 
+def test_sla_target_rejects_redis_environment():
+    """optimization_target='sla' needs forward-pass metrics from a runtime
+    binding; the redis connector never wires one up (no worker_info_provider,
+    unlike 'virtual'), so it would silently degrade to static config sizing
+    rather than actually doing SLA-aware scaling."""
+    with pytest.raises(ValidationError, match="not supported with environment='redis'"):
+        PlannerConfig(
+            namespace="test-ns",
+            environment="redis",
+            optimization_target="sla",
+        )
+
+
+def test_sla_target_allowed_with_virtual_environment():
+    """Sanity check the rejection is redis-specific, not sla-in-general."""
+    config = PlannerConfig(
+        namespace="test-ns",
+        environment="virtual",
+        optimization_target="sla",
+    )
+    assert config.optimization_target == "sla"
+
+
 # ---------------------------------------------------------------------------
 # Power-awareness validator (DGD-owned caps; read-only)
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/planner/tests/unit/test_redis_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_redis_connector.py
@@ -1,0 +1,317 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dynamo.planner.config.defaults import SubComponentType, TargetReplica
+from dynamo.planner.connectors.redis_connector import RedisConnector
+from dynamo.planner.errors import EmptyTargetReplicasError
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+@pytest.fixture
+def mock_redis_client():
+    client = AsyncMock()
+    client.hgetall = AsyncMock(return_value={})
+    client.hset = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def connector(mock_redis_client):
+    with patch(
+        "dynamo.planner.connectors.redis_connector.redis_asyncio.from_url",
+        return_value=mock_redis_client,
+    ):
+        return RedisConnector(
+            "test-namespace",
+            model_name="test-model",
+            redis_url="redis://localhost:6379",
+        )
+
+
+def test_requires_model_name():
+    with pytest.raises(ValueError, match="Model name is required"):
+        RedisConnector(
+            "test-namespace", model_name=None, redis_url="redis://localhost:6379"
+        )
+
+
+def test_requires_redis_url(monkeypatch):
+    monkeypatch.delenv("DYN_REDIS_URL", raising=False)
+    with pytest.raises(ValueError, match="redis_url is required"):
+        RedisConnector("test-namespace", model_name="test-model", redis_url=None)
+
+
+def test_redis_url_falls_back_to_env(mock_redis_client, monkeypatch):
+    monkeypatch.setenv("DYN_REDIS_URL", "redis://from-env:6379")
+    with patch(
+        "dynamo.planner.connectors.redis_connector.redis_asyncio.from_url",
+        return_value=mock_redis_client,
+    ) as mock_from_url:
+        RedisConnector("test-namespace", model_name="test-model")
+        mock_from_url.assert_called_once_with(
+            "redis://from-env:6379", decode_responses=True
+        )
+
+
+def test_key_uses_hash_tag_on_namespace_and_model_name(connector):
+    assert connector._key == "dynamo:planner:target:{test-namespace:test-model}"
+
+
+def test_key_isolates_same_model_name_across_namespaces(mock_redis_client):
+    with patch(
+        "dynamo.planner.connectors.redis_connector.redis_asyncio.from_url",
+        return_value=mock_redis_client,
+    ):
+        a = RedisConnector(
+            "namespace-a", model_name="shared-model", redis_url="redis://localhost:6379"
+        )
+        b = RedisConnector(
+            "namespace-b", model_name="shared-model", redis_url="redis://localhost:6379"
+        )
+    assert a._key != b._key
+
+
+def test_get_model_name_is_sync(connector):
+    assert connector.get_model_name() == "test-model"
+
+
+def test_model_name_case_is_preserved(mock_redis_client):
+    """Unlike VirtualConnector/KubernetesConnector, this connector never
+    matches model_name against MDC entries, so there's no reason to fold
+    case -- and doing so risks merging two distinct, differently-cased
+    model names onto the same Redis key."""
+    with patch(
+        "dynamo.planner.connectors.redis_connector.redis_asyncio.from_url",
+        return_value=mock_redis_client,
+    ):
+        connector = RedisConnector(
+            "test-namespace",
+            model_name="Some-Mixed-Case-Model",
+            redis_url="redis://localhost:6379",
+        )
+    assert connector.model_name == "Some-Mixed-Case-Model"
+    assert connector.get_model_name() == "Some-Mixed-Case-Model"
+    assert "{test-namespace:Some-Mixed-Case-Model}" in connector._key
+
+
+def test_get_gpu_counts_returns_none_none(connector):
+    assert connector.get_gpu_counts() == (None, None)
+
+
+def test_get_worker_info_uses_defaults(connector):
+    info = connector.get_worker_info(SubComponentType.PREFILL, backend="vllm")
+    assert info.model_name == "test-model"
+
+
+@pytest.mark.asyncio
+async def test_set_component_replicas_disagg_writes_both_roles(
+    connector, mock_redis_client
+):
+    await connector.set_component_replicas(
+        [
+            TargetReplica(
+                sub_component_type=SubComponentType.PREFILL, desired_replicas=3
+            ),
+            TargetReplica(
+                sub_component_type=SubComponentType.DECODE, desired_replicas=5
+            ),
+        ]
+    )
+    mock_redis_client.hset.assert_called_once()
+    args, kwargs = mock_redis_client.hset.call_args
+    assert args[0] == "dynamo:planner:target:{test-namespace:test-model}"
+    mapping = kwargs["mapping"]
+    assert mapping["prefill"] == 3
+    assert mapping["decode"] == 5
+    assert "updated_at" in mapping
+
+
+@pytest.mark.asyncio
+async def test_set_component_replicas_single_role_omits_the_other(
+    connector, mock_redis_client
+):
+    """A dedicated PrefillPlanner only ever sends its own role -- the write
+    must not clobber whatever a sibling DecodePlanner last wrote for
+    "decode" under the same model_name key."""
+    await connector.set_component_replicas(
+        [TargetReplica(sub_component_type=SubComponentType.PREFILL, desired_replicas=4)]
+    )
+    mapping = mock_redis_client.hset.call_args.kwargs["mapping"]
+    assert mapping["prefill"] == 4
+    assert "decode" not in mapping
+
+
+@pytest.mark.asyncio
+async def test_set_component_replicas_empty_raises(connector):
+    with pytest.raises(EmptyTargetReplicasError):
+        await connector.set_component_replicas([])
+
+
+@pytest.mark.asyncio
+async def test_set_component_replicas_negative_raises(connector, mock_redis_client):
+    with pytest.raises(ValueError, match="must not be negative"):
+        await connector.set_component_replicas(
+            [
+                TargetReplica(
+                    sub_component_type=SubComponentType.PREFILL, desired_replicas=-1
+                )
+            ]
+        )
+    mock_redis_client.hset.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_add_component_increments_from_current(connector, mock_redis_client):
+    mock_redis_client.hgetall.return_value = {"prefill": "2", "decode": "1"}
+    await connector.add_component(SubComponentType.PREFILL)
+    mapping = mock_redis_client.hset.call_args.kwargs["mapping"]
+    assert mapping["prefill"] == 3
+
+
+@pytest.mark.asyncio
+async def test_remove_component_floors_at_zero(connector, mock_redis_client):
+    mock_redis_client.hgetall.return_value = {"prefill": "0", "decode": "0"}
+    await connector.remove_component(SubComponentType.DECODE)
+    mapping = mock_redis_client.hset.call_args.kwargs["mapping"]
+    assert mapping["decode"] == 0
+
+
+@pytest.mark.asyncio
+async def test_validate_deployment_and_wait_are_no_ops(connector):
+    await connector.validate_deployment()
+    await connector.wait_for_deployment_ready()
+
+
+@pytest.mark.asyncio
+async def test_read_desired_counts_negative_raises(connector, mock_redis_client):
+    mock_redis_client.hgetall.return_value = {"prefill": "-1", "decode": "0"}
+    with pytest.raises(ValueError, match="'prefill'.*must not be negative"):
+        await connector.add_component(SubComponentType.PREFILL)
+
+
+@pytest.mark.asyncio
+async def test_read_desired_counts_invalid_raises(connector, mock_redis_client):
+    mock_redis_client.hgetall.return_value = {"prefill": "not-a-number", "decode": "0"}
+    with pytest.raises(ValueError, match="'prefill'.*not a valid integer"):
+        await connector.add_component(SubComponentType.PREFILL)
+
+
+class TestShutdown:
+    @pytest.mark.asyncio
+    async def test_shutdown_closes_the_client(self, connector, mock_redis_client):
+        mock_redis_client.aclose = AsyncMock()
+        await connector.shutdown()
+        mock_redis_client.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_is_idempotent(self, connector, mock_redis_client):
+        mock_redis_client.aclose = AsyncMock()
+        await connector.shutdown()
+        await connector.shutdown()
+        mock_redis_client.aclose.assert_awaited_once()
+
+
+class TestGetActualWorkerCounts:
+    """get_actual_worker_counts reads observed state a companion process
+    (not part of this repo) writes back into the same hash. If it hasn't
+    published anything yet -- or never does -- missing fields must default
+    to inactive/unstable, and a component whose name arg is None must
+    report 0 and not count against the returned stable flag.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_observed_fields_defaults_to_unstable(
+        self, connector, mock_redis_client
+    ):
+        mock_redis_client.hgetall.return_value = {"prefill": "3", "decode": "5"}
+        prefill, decode, stable = await connector.get_actual_worker_counts(
+            prefill_component_name="prefill-worker",
+            decode_component_name="decode-worker",
+        )
+        assert (prefill, decode, stable) == (0, 0, False)
+
+    @pytest.mark.asyncio
+    async def test_reads_observed_fields_when_present(
+        self, connector, mock_redis_client
+    ):
+        mock_redis_client.hgetall.return_value = {
+            "prefill_active": "3",
+            "decode_active": "5",
+            "prefill_stable": "true",
+            "decode_stable": "true",
+        }
+        prefill, decode, stable = await connector.get_actual_worker_counts(
+            prefill_component_name="prefill-worker",
+            decode_component_name="decode-worker",
+        )
+        assert (prefill, decode, stable) == (3, 5, True)
+
+    @pytest.mark.asyncio
+    async def test_either_role_unstable_makes_the_whole_result_unstable(
+        self, connector, mock_redis_client
+    ):
+        mock_redis_client.hgetall.return_value = {
+            "prefill_active": "3",
+            "decode_active": "5",
+            "prefill_stable": "true",
+            "decode_stable": "false",
+        }
+        _, _, stable = await connector.get_actual_worker_counts(
+            prefill_component_name="prefill-worker",
+            decode_component_name="decode-worker",
+        )
+        assert stable is False
+
+    @pytest.mark.asyncio
+    async def test_component_name_none_reports_zero_and_excluded_from_stable(
+        self, connector, mock_redis_client
+    ):
+        """Decode isn't required by this planner mode (name arg is None):
+        its observed values must not appear in the count or gate stability,
+        even though the hash happens to carry stale/irrelevant decode data.
+        """
+        mock_redis_client.hgetall.return_value = {
+            "prefill_active": "3",
+            "prefill_stable": "true",
+            "decode_active": "99",
+            "decode_stable": "false",
+        }
+        prefill, decode, stable = await connector.get_actual_worker_counts(
+            prefill_component_name="prefill-worker",
+            decode_component_name=None,
+        )
+        assert (prefill, decode, stable) == (3, 0, True)
+
+    @pytest.mark.asyncio
+    async def test_negative_observed_value_raises(self, connector, mock_redis_client):
+        mock_redis_client.hgetall.return_value = {
+            "prefill_active": "-2",
+            "prefill_stable": "true",
+        }
+        with pytest.raises(ValueError, match="'prefill_active'.*must not be negative"):
+            await connector.get_actual_worker_counts(
+                prefill_component_name="prefill-worker",
+                decode_component_name=None,
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "msgspec>=0.19.0",
     "zstandard>=0.23.0,<1.0",
     "pyzmq>=26.0.0",
+    "redis>=5.0.0,<6.0",
     # typing.Self is 3.11+; declared minimum is 3.10 (see requires-python),
     # so back-port Self via typing_extensions in dynamo.common.configuration.
     "typing_extensions>=4.10.0",


### PR DESCRIPTION
## Overview:

Adds a Redis connector to the planner for handling worker fleet scaling via Redis.

## Details:

Currently there are various connectors for managing worker fleet size (KubernetesConnector, VirtualConnector etc).
The present change adds a connector for managing fleet size via Redis read and writes. 

## Where should the reviewer start?

Most of the implementation is in [redis_connector.py](components/src/dynamo/planner/connectors/redis_connector.py)



**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redis as a supported planner environment.
  * Added Redis-backed coordination for publishing replica targets and reading worker status.
  * Added support for adjusting prefill and decode component replicas through Redis.
* **Bug Fixes**
  * Improved handling of missing or unstable worker status data with safe defaults.
* **Tests**
  * Added coverage for Redis configuration, replica updates, validation, and worker-count reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->