### PR TITLE
fix(container): patch vLLM 0.27.1 DSpark rejection sampler NaN/OOB crash

### DIFF
--- a/container/deps/vllm/patches/01-dspark-rejection-sampler-nan-oob.patch
+++ b/container/deps/vllm/patches/01-dspark-rejection-sampler-nan-oob.patch
@@ -1,0 +1,106 @@
+From: Shubham Gandhi <shugandhi@nvidia.com>
+Subject: [Bugfix] Guard DSpark rejection sampler against NaN-driven OOB token ids
+
+Backports the NaN->-inf guard + block-index clamp from upstream vllm-project/vllm#50183
+(merged 2026-08-06, first release v0.28.0) and adds a clamp-at-store bounds check for the
+still-open vllm-project/vllm#53029, where an all-NaN verification row launders a token id
+== vocab_size through the resample chain and detonates 1-3 steps later as
+'Indexing.cu:1524 indexSelectSmallIndex: srcIndex < srcSelectDimSize' in the embedding
+gather. Reproduced on DeepSeek-V4-Pro-0813 DSpark k=7 TP16 GB200 under sustained c=8
+load (~25 min to crash, engine-fatal). All guards are no-ops on healthy logits.
+
+--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
++++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+@@ -108,7 +108,12 @@
+         mask=blocks_mask,
+         other=float("-inf"),
+     )
++    # PR #50183: NaN local maxes make tl.argmax return an out-of-range block
++    # index (into the padded region), causing an OOB read. Map NaN to -inf
++    # and clamp the block index so it stays in range.
++    local_max = tl.where(local_max != local_max, float("-inf"), local_max)
+     max_block_idx = tl.argmax(local_max, axis=0)
++    max_block_idx = tl.minimum(max_block_idx, vocab_num_blocks - 1)
+     return tl.load(
+         target_local_argmax_ptr + logit_idx * target_local_argmax_stride + max_block_idx
+     ).to(tl.int64)
+@@ -508,6 +513,7 @@
+     # [num_logits, num_blocks]
+     local_residual_mass_ptr,
+     local_residual_mass_stride,
++    vocab_size,
+     vocab_num_blocks,
+     PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+     HAS_DRAFT_LOGITS: tl.constexpr,
+@@ -573,6 +579,13 @@
+                     logit_idx,
+                     vocab_num_blocks,
+                     PADDED_VOCAB_NUM_BLOCKS,
++                )
++                # Issue #53029: bounds-validate before the store so an OOB
++                # token id can never escape into the sampled buffer.
++                target_argmax = tl.where(
++                    (target_argmax < 0) | (target_argmax >= vocab_size),
++                    0,
++                    target_argmax,
+                 )
+                 if SYNTHETIC_MODE:
+                     rate = tl.load(synthetic_conditional_rates_ptr + i)
+@@ -822,6 +835,7 @@
+     expanded_idx_mapping_ptr,
+     # [max_num_reqs]
+     temp_ptr,
++    vocab_size,
+     PADDED_RESAMPLE_NUM_BLOCKS: tl.constexpr,
+ ):
+     req_idx = tl.program_id(0)
+@@ -848,13 +862,33 @@
+         resampled_local_max_ptr + req_idx * resampled_local_max_stride + block,
+         mask=mask,
+         other=float("-inf"),
++    )
++    # PR #50183: NaN max values (from NaN target logits) make tl.argmax
++    # return an out-of-range block index (into the padded region), causing
++    # an OOB read of resampled_local_argmax. Map NaN to -inf and clamp the
++    # block index so argmax stays in range.
++    resampled_local_max = tl.where(
++        resampled_local_max != resampled_local_max,
++        float("-inf"),
++        resampled_local_max,
+     )
+     resampled_max_block_idx = tl.argmax(resampled_local_max, axis=0)
++    resampled_max_block_idx = tl.minimum(
++        resampled_max_block_idx, resample_num_blocks - 1
++    )
+     resampled = tl.load(
+         resampled_local_argmax_ptr
+         + req_idx * resampled_local_argmax_stride
+         + resampled_max_block_idx,
+     )
++    # Issue #53029: the resample path can produce token id == vocab_size
++    # (or other OOB ids). Bounds-validate at the store and substitute a
++    # valid fallback token (0) so downstream index_select cannot assert.
++    resampled = tl.where(
++        (resampled < 0) | (resampled >= vocab_size),
++        0,
++        resampled,
++    )
+     tl.store(
+         sampled_ptr + req_idx * sampled_stride + num_sampled,
+         resampled,
+@@ -1064,6 +1098,7 @@
+         cumulative_log_p,
+         local_residual_mass,
+         local_residual_mass.stride(0) if local_residual_mass is not None else 0,
++        vocab_size,
+         vocab_num_blocks,
+         PADDED_VOCAB_NUM_BLOCKS=padded_vocab_num_blocks,
+         HAS_DRAFT_LOGITS=has_draft_logits,
+@@ -1124,6 +1159,7 @@
+         cu_num_logits,
+         expanded_idx_mapping,
+         temperature,
++        vocab_size,
+         PADDED_RESAMPLE_NUM_BLOCKS=padded_resample_num_blocks,
+     )
+     return sampled, num_sampled

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -259,6 +259,16 @@ RUN --mount=type=bind,source=./container/deps/vllm/protected_packages.txt,target
     export VLLM_OMNI_TARGET_DEVICE={{ device }}; \
     bash /tmp/install_vllm_omni.sh
 
+{% if device == "cuda" %}
+# Apply vLLM hotfixes to the installed package tree. Patches are applied with
+# --fuzz=5 to tolerate minor line-number drift across nightly builds.
+RUN --mount=type=bind,source=./container/deps/vllm/patches,target=/tmp/vllm_patches,readonly \
+    SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])')" && \
+    for p in $(ls /tmp/vllm_patches/*.patch 2>/dev/null | sort); do \
+        patch --fuzz=5 -p1 -d "${SITE_PACKAGES}" < "$p"; \
+    done
+{% endif %}
+
 {% if device == "xpu" %}
 # Remove conflicting standard triton package for XPU and reinstall triton-xpu
 # This must be done after vLLM-Omni installation to ensure no dependencies re-install triton


### PR DESCRIPTION
## What

Adds a vLLM hotfix-patch mechanism to the cuda `vllm_runtime` image (same block as #12513, applied onto the installed site-packages tree) and one patch fixing an engine-fatal DSpark spec-decode crash on vLLM v0.27.1:

- Backport of vllm-project/vllm#50183 (merged upstream 2026-08-06, absent from v0.27.1): NaN→-inf guard before `tl.argmax` + block-index clamp in `_compute_global_target_argmax` / `_insert_resampled_kernel`.
- Clamp-at-store bounds check for the still-open vllm-project/vllm#53029: an all-NaN verification row stores a token id == vocab_size which detonates 1–3 steps later as `Indexing.cu:1524 indexSelectSmallIndex: srcIndex < srcSelectDimSize` (device-side assert, kills all TP workers).

## Why

Reproduced engine-fatal on DeepSeek-V4-Pro-0813 (DSpark k=7, TP16 across 4×GB200, 1M max-model-len) under sustained c=8 load on a 64K-ISL agentic trace — ~25 min to crash, 2/2 reproductions. Both real and synthetic rejection sampling execute the affected kernels.

All guards are no-ops on healthy logits. Patch applies cleanly (`patch -p1`, zero fuzz) against the v0.27.1 site-packages tree and is py_compile-verified.

## Testing

- Local dry-run apply + py_compile against stock v0.27.1 tree: clean.
- Planned: crash-repro validation on the CI-built image on GB200 (the unpatched image reliably crashes in ~25 min under this load).

cc @chw001 — follow-up to our thread; draft to trigger the image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


(Reopened from #13615 after the head branch was renamed to `deepseek-v4-pro-0813-dspark`.)
