### PR TITLE
chore: bump the image tags the 1.4.1 release commit missed

### DIFF
--- a/benchmarks/incluster/benchmark_job.yaml
+++ b/benchmarks/incluster/benchmark_job.yaml
@@ -21,7 +21,7 @@ spec:
         # aiperf, with the prebuilt arm64 crick wheel). Backend runtime images
         # deliberately do not carry benchmark tooling.
         # TODO: update to latest public image in next release
-        image: nvcr.io/nvidia/ai-dynamo/frontend:1.4.0
+        image: nvcr.io/nvidia/ai-dynamo/frontend:1.4.1
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/examples/backends/vllm/deploy/xpu/README.md
+++ b/examples/backends/vllm/deploy/xpu/README.md
@@ -27,7 +27,7 @@ Hardware-specific deployment templates for Intel XPU GPUs using Kubernetes Dynam
 3. **Custom XPU runtime image** built with Intel XPU support:
    ```bash
    python container/render.py --framework=vllm --device=xpu --target=runtime
-   docker build -t nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:1.4.0 \
+   docker build -t nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:1.4.1 \
      -f container/vllm-runtime-xpu-amd64-rendered.Dockerfile .
    ```
    See [container/README.md](../../../../../container/README.md) for complete build instructions.

--- a/examples/custom_backend/hello_world/deploy/hello_world.yaml
+++ b/examples/custom_backend/hello_world/deploy/hello_world.yaml
@@ -40,7 +40,7 @@ spec:
           memory: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.4.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.4.1
           workingDir: /workspace/examples/custom_backend/hello_world/
           command:
             - /bin/sh
@@ -78,7 +78,7 @@ spec:
           memory: "4Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.4.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.4.1
           workingDir: /workspace/examples/custom_backend/hello_world/
           command:
             - /bin/sh

--- a/examples/custom_backend/hello_world/deploy/v1beta1/hello_world.yaml
+++ b/examples/custom_backend/hello_world/deploy/v1beta1/hello_world.yaml
@@ -17,7 +17,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.4.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.4.1
           livenessProbe:
             exec:
               command:
@@ -58,7 +58,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.4.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.4.1
           livenessProbe:
             exec:
               command:

--- a/examples/diffusers/deploy/agg.yaml
+++ b/examples/diffusers/deploy/agg.yaml
@@ -18,7 +18,7 @@ spec:
           value: kubernetes
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.1
           imagePullPolicy: IfNotPresent
           workingDir: /opt/app
           command:
@@ -55,7 +55,7 @@ spec:
           mountPoint: /root/.cache/huggingface
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.1
           imagePullPolicy: IfNotPresent
           workingDir: /opt/app
           command:

--- a/examples/diffusers/deploy/agg_user_workload.yaml
+++ b/examples/diffusers/deploy/agg_user_workload.yaml
@@ -29,7 +29,7 @@ spec:
             value: user-workload
             effect: NoExecute
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.1
           imagePullPolicy: IfNotPresent
           workingDir: /opt/app
           command:
@@ -77,7 +77,7 @@ spec:
             value: user-workload
             effect: NoExecute
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.1
           imagePullPolicy: IfNotPresent
           workingDir: /opt/app
           command:

--- a/examples/diffusers/deploy/v1beta1/agg.yaml
+++ b/examples/diffusers/deploy/v1beta1/agg.yaml
@@ -25,7 +25,7 @@ spec:
             value: /cache/triton
           - name: HF_HOME
             value: /root/.cache/huggingface
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.1
           imagePullPolicy: IfNotPresent
           name: main
           resources:
@@ -58,7 +58,7 @@ spec:
           env:
           - name: DYN_DISCOVERY_BACKEND
             value: kubernetes
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.1
           imagePullPolicy: IfNotPresent
           name: main
           workingDir: /opt/app

--- a/examples/diffusers/deploy/v1beta1/agg_user_workload.yaml
+++ b/examples/diffusers/deploy/v1beta1/agg_user_workload.yaml
@@ -25,7 +25,7 @@ spec:
             value: /cache/triton
           - name: HF_HOME
             value: /root/.cache/huggingface
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.1
           imagePullPolicy: IfNotPresent
           name: main
           resources:
@@ -69,7 +69,7 @@ spec:
           env:
           - name: DYN_DISCOVERY_BACKEND
             value: kubernetes
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.4.1
           imagePullPolicy: IfNotPresent
           name: main
           workingDir: /opt/app

--- a/recipes/qwen3-vl-32b-fp8/vllm/hetero_hardware_disagg/deploy.yaml
+++ b/recipes/qwen3-vl-32b-fp8/vllm/hetero_hardware_disagg/deploy.yaml
@@ -48,7 +48,7 @@ spec:
           - name: intel-gpu-rdma-resource
             resourceClaimTemplateName: intel-xpu-rdma-template
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:1.4.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:1.4.1
           workingDir: /workspace/examples/multimodal
           securityContext:
             runAsUser: 0


### PR DESCRIPTION
## Overview

`release: set version 1.4.1` (9f6c6be7, `containers=all wheels=all crates=all helm=all`) left four image names at 1.4.0:

- `frontend`
- `dynamo`
- `vllm-runtime-xpu`
- `fastvideo-runtime`

Fifteen tags across nine files.

## Why these are in scope

Every one of these files was bumped by the 1.4.0 release commit (46642c4d) and skipped by the 1.4.1 one, so they track the release rather than pinning a validated artifact. `examples/backends/vllm/deploy/xpu/agg_xpu_dra.yaml` is the control: it uses `vllm-runtime`, which the bot does know about, and it already reads 1.4.1.

Recipes that pin a dev tag (`1.4.0-inkling-dev.1`, `1.4.0-kimi-k3-dev.1`) are deliberately left alone; those record what the recipe was validated against. The one recipe included here, qwen3-vl, pins a plain release tag and was bumped at 1.4.0.

## Follow-up for the release bot

The four image names above look like a gap in the bot's rules rather than anything specific to this release, so the same files will drift again at 1.4.2 unless the rules learn them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->