### PR TITLE
fix(epp): format IPv6 worker endpoints as [addr]:port

### DIFF
--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -307,7 +307,7 @@ impl Router {
             let Some(addr_port) = pod_endpoint_address(&pod) else {
                 continue;
             };
-            let ip = addr_port.split(':').next().unwrap_or("");
+            let ip = crate::picker::host_of(&addr_port);
             if candidates.contains(addr_port.as_str()) || candidates.contains(ip) {
                 ids.insert(hash_pod_name(pod_name));
             }
@@ -681,7 +681,7 @@ fn pod_endpoint_address(pod: &k8s_openapi::api::core::v1::Pod) -> Option<String>
         .flatten()
         .find(|p| p.name.as_deref() == Some(DYNAMO_CONTAINER_PORT_NAME))
         .map(|p| p.container_port)?;
-    Some(format!("{ip}:{port}"))
+    Some(crate::picker::join_host_port(ip, &port.to_string()))
 }
 
 /// Start a background pod reflector that watches worker pods matching the

--- a/deploy/inference-gateway/ext-proc/src/picker.rs
+++ b/deploy/inference-gateway/ext-proc/src/picker.rs
@@ -26,10 +26,41 @@ pub struct Endpoint {
 }
 
 impl Endpoint {
-    /// Returns the endpoint in "ip:port" format.
+    /// Returns the endpoint in "ip:port" format, bracketing IPv6 literals.
     pub fn address_port(&self) -> String {
-        format!("{}:{}", self.address, self.port)
+        join_host_port(&self.address, &self.port)
     }
+}
+
+/// Join a host and a port into socket-address syntax.
+///
+/// An IPv6 literal has to be bracketed or the result is ambiguous: address
+/// `fd00::10` with port `8000` concatenates to `fd00::10:8000`, which reads as
+/// another IPv6 address rather than as a host and a port. Hosts that are
+/// already bracketed are left alone, and IPv4 addresses and DNS names are
+/// unaffected.
+pub fn join_host_port(host: &str, port: &str) -> String {
+    if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    }
+}
+
+/// Extract the host from `host:port`, `[v6]:port`, or a bare host.
+///
+/// `split(':').next()` cannot do this: it truncates a bare IPv6 literal at its
+/// first group, so `fd00::10` becomes `fd00`.
+pub fn host_of(addr: &str) -> &str {
+    if let Some(rest) = addr.strip_prefix('[') {
+        return rest.split(']').next().unwrap_or(rest);
+    }
+    // More than one colon and no brackets means a bare IPv6 literal, which
+    // carries no port to strip.
+    if addr.matches(':').count() > 1 {
+        return addr;
+    }
+    addr.split(':').next().unwrap_or(addr)
 }
 
 /// RequestInfo contains metadata about the incoming HTTP request.
@@ -151,4 +182,45 @@ pub enum PickError {
     /// multiplexing means the connection cap does not bound concurrent requests.
     #[error("endpoint picker overloaded")]
     Overloaded,
+}
+
+#[cfg(test)]
+mod addr_tests {
+    use super::{host_of, join_host_port};
+
+    #[test]
+    fn ipv6_endpoints_are_bracketed() {
+        // Without brackets this is "fd00::10:8000", which reads as another
+        // IPv6 address rather than a host and a port.
+        assert_eq!(join_host_port("fd00::10", "8000"), "[fd00::10]:8000");
+    }
+
+    #[test]
+    fn ipv4_and_hostnames_are_unchanged() {
+        assert_eq!(join_host_port("10.0.0.1", "8000"), "10.0.0.1:8000");
+        assert_eq!(join_host_port("worker.svc", "8000"), "worker.svc:8000");
+    }
+
+    #[test]
+    fn an_already_bracketed_host_is_not_double_bracketed() {
+        assert_eq!(join_host_port("[fd00::10]", "8000"), "[fd00::10]:8000");
+    }
+
+    #[test]
+    fn host_of_handles_every_subset_form() {
+        // The two forms a subset hint can carry for one IPv6 worker.
+        assert_eq!(host_of("[fd00::10]:8000"), "fd00::10");
+        assert_eq!(host_of("fd00::10"), "fd00::10");
+        // And the forms that already worked.
+        assert_eq!(host_of("10.0.0.1:8000"), "10.0.0.1");
+        assert_eq!(host_of("10.0.0.1"), "10.0.0.1");
+        assert_eq!(host_of("worker.svc:8000"), "worker.svc");
+    }
+
+    #[test]
+    fn round_trip_recovers_the_host() {
+        for host in ["fd00::10", "10.0.0.1", "worker.svc"] {
+            assert_eq!(host_of(&join_host_port(host, "8000")), host);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #12063.

The Rust EPP built worker endpoints by concatenating address and port with a colon, so an IPv6 pod produced `fd00::10:8000`. That is not a host and a port, it reads as another IPv6 address, and nothing downstream can split it back apart.

The subset matcher had the mirror of the same fault. It recovered the host with `split(':').next()`, which truncates a bare IPv6 literal at its first group, so `fd00::10` became `fd00` and no reflected pod matched the hint. IPv6 workers were therefore both mis-addressed and unroutable by subset.

Three sites shared it, one more than the issue lists:

- `Endpoint::address_port` in `picker.rs`
- `subset_to_worker_ids` in `epp.rs`, the `split(':')` above
- **`pod_endpoint_address` in `epp.rs`**, which builds the very string the subset matcher then tries to parse. Fixing only the first two would have left the reflector still producing ambiguous endpoints.

All three now go through two helpers next to `Endpoint`, which already owned endpoint formatting:

```rust
pub fn join_host_port(host: &str, port: &str) -> String
pub fn host_of(addr: &str) -> &str
```

`join_host_port` brackets a host containing a colon, matching Go's `net.JoinHostPort` rule, and leaves an already bracketed host alone. `host_of` accepts `[v6]:port`, a bare IPv6 literal, `v4:port`, and a hostname. Bare-literal handling is the case `split` cannot express: a bare IPv6 carries no port to strip, so it is returned whole.

I did not reach for `SocketAddr` parsing, because these values are not always IP literals. `pod_endpoint_address` reads `pod.status.pod_ip`, but subset hints and the `Endpoint.address` field also carry DNS names, which would fail to parse and silently drop hosts that work today.

## Validation

`cargo test -p dynamo-ext-proc` — 125 passed, 0 failed. `cargo clippy -p dynamo-ext-proc --all-targets` is clean and `cargo fmt` applied.

Five unit tests cover the endpoint forms: IPv6 is bracketed, IPv4 and DNS names are untouched, an already bracketed host is not double-bracketed, `host_of` recovers the host from every subset form, and a round trip through both helpers returns the original host.

Three of the five fail against the previous behaviour, verified by reverting both helpers to the old expressions and keeping the tests:

```
FAILED picker::addr_tests::ipv6_endpoints_are_bracketed
FAILED picker::addr_tests::host_of_handles_every_subset_form
   left: "[fd00"   right: "fd00::10"
FAILED picker::addr_tests::round_trip_recovers_the_host
   left: "fd00"
```

The two that still pass are the IPv4 and hostname cases, which is the point of them: they pin that this change is inert for the addressing everyone uses today.

Not verified here: no dual-stack cluster, so I have not observed an IPv6 worker being routed end to end. The change is at the string layer and the tests cover the forms the issue names.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint address handling for IPv6 connections.
  * Preserved correct formatting for IPv4 addresses, DNS names, and already-bracketed hosts.
  * Improved host extraction and host/port formatting across supported endpoint address formats.
  * Added coverage for address formatting and round-trip scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->