### PR TITLE
fix(frontend): preserve chat_template_args through Responses conversion

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -3446,20 +3446,24 @@ async fn responses(
     let parsing_options =
         parsing_options.with_parallel_tool_calls(request.inner.parallel_tool_calls);
 
-    // NOTE: `move_reasoning_to_content_when_empty` is the aggregator flag and is
-    // not set here. A non-streaming Responses request DOES reach the aggregator
-    // (forcing stream=true on the converted request only drives internal
-    // streaming; the client-facing `streaming` flag still selects the aggregating
-    // branch below), so it reaches it with the flag false.
+    // A non-streaming Responses request DOES reach the aggregator (forcing
+    // stream=true on the converted request only drives internal streaming; the
+    // client-facing `streaming` flag still selects the aggregating branch
+    // below), so it needs the same backstop the chat path installs.
     //
-    // That is currently unreachable rather than wrong: the Responses-to-chat
-    // conversion hard-codes `chat_template_args: None`, so
-    // `force_nonempty_content` can never be set on this path in the first place.
-    // If that conversion ever forwards chat_template_args, the streaming stage
-    // would still cover the reasoning-only case — `postprocessor_parsing_stream`
-    // gates on the request's own args via `wants_reasoning_as_content_when_empty`
-    // rather than on this flag — but the aggregator backstop should be wired here
-    // too at that point. Tracked as follow-up.
+    // This used to be left unset, which was safe only because the
+    // Responses-to-chat conversion hard-coded `chat_template_args: None` and
+    // `force_nonempty_content` could never be set on this path. Now that the
+    // conversion forwards those args, the flag has to be wired here: the
+    // streaming stage gates on the request's own args via
+    // `wants_reasoning_as_content_when_empty`, but the aggregating branch reads
+    // this flag instead.
+    let move_reasoning_to_content_when_empty =
+        crate::preprocessor::OpenAIPreprocessor::wants_reasoning_as_content_when_empty(
+            request.chat_template_args.as_ref(),
+        );
+    let parsing_options = parsing_options
+        .with_move_reasoning_to_content_when_empty(move_reasoning_to_content_when_empty);
 
     let mut response_collector = state
         .metrics_clone()
@@ -5083,6 +5087,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         }
     }
 

--- a/lib/llm/src/protocols/common/input_trigger.rs
+++ b/lib/llm/src/protocols/common/input_trigger.rs
@@ -185,6 +185,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         }
     }
 

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -51,6 +51,19 @@ pub struct NvCreateResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Object)]
     pub nvext: Option<NvExt>,
+
+    /// Chat-template arguments, forwarded to the converted chat request.
+    ///
+    /// Mirrors the Chat Completions field, including the `chat_template_kwargs`
+    /// alias, so a Responses client controls template-driven behaviour such as
+    /// reasoning and tool formatting the same way a chat client does.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "chat_template_kwargs"
+    )]
+    #[schema(value_type = Object)]
+    pub chat_template_args: Option<std::collections::HashMap<String, serde_json::Value>>,
 }
 
 #[derive(ToSchema, Deserialize, Validate, Debug, Clone)]
@@ -891,7 +904,7 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
             },
             common: Default::default(),
             nvext: resp.nvext,
-            chat_template_args: None,
+            chat_template_args: resp.chat_template_args,
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
@@ -1348,6 +1361,7 @@ mod tests {
                 annotations: Some(vec!["debug".into(), "trace".into()]),
                 ..Default::default()
             }),
+            chat_template_args: None,
         }
     }
 
@@ -1374,6 +1388,58 @@ mod tests {
             },
             _ => panic!("expected user message"),
         }
+    }
+
+    #[test]
+    fn chat_template_args_survive_the_conversion() {
+        // The repro from the issue: a Responses request carrying template args
+        // must not lose them on the way to the chat request, or template-driven
+        // behaviour like reasoning and tool formatting cannot be controlled
+        // from /v1/responses at all.
+        let request: NvCreateResponse = serde_json::from_value(serde_json::json!({
+            "model": "dummy-model",
+            "input": "hello",
+            "chat_template_args": {"enable_thinking": true},
+        }))
+        .expect("responses request with chat_template_args should deserialize");
+
+        let nv_req: NvCreateChatCompletionRequest = request.try_into().unwrap();
+
+        let args = nv_req
+            .chat_template_args
+            .expect("chat_template_args should reach the chat request");
+        assert_eq!(
+            args.get("enable_thinking"),
+            Some(&serde_json::Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn chat_template_kwargs_alias_is_accepted() {
+        // Chat Completions accepts either spelling, so Responses has to as
+        // well or the same client payload behaves differently per endpoint.
+        let request: NvCreateResponse = serde_json::from_value(serde_json::json!({
+            "model": "dummy-model",
+            "input": "hello",
+            "chat_template_kwargs": {"enable_thinking": true},
+        }))
+        .expect("chat_template_kwargs alias should deserialize");
+
+        let nv_req: NvCreateChatCompletionRequest = request.try_into().unwrap();
+
+        assert!(nv_req.chat_template_args.is_some_and(
+            |args| args.get("enable_thinking") == Some(&serde_json::Value::Bool(true))
+        ));
+    }
+
+    #[test]
+    fn absent_chat_template_args_stay_absent() {
+        // The overwhelmingly common request has none; it must not gain an
+        // empty map, which would change downstream template rendering.
+        let nv_req: NvCreateChatCompletionRequest =
+            make_response_with_input("hi there").try_into().unwrap();
+
+        assert!(nv_req.chat_template_args.is_none());
     }
 
     #[test]
@@ -1405,6 +1471,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1449,6 +1516,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1528,6 +1596,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1569,6 +1638,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1612,6 +1682,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1660,6 +1731,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1699,6 +1771,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1733,6 +1806,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1775,6 +1849,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1836,6 +1911,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1908,6 +1984,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1965,6 +2042,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -2020,6 +2098,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -2067,6 +2146,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -2132,6 +2212,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -2211,6 +2292,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -2284,6 +2366,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
         let messages = &chat_req.inner.messages;
@@ -2353,6 +2436,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
         let messages = &chat_req.inner.messages;
@@ -2419,6 +2503,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
         let messages = &chat_req.inner.messages;
@@ -2476,6 +2561,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
         let messages = &chat_req.inner.messages;


### PR DESCRIPTION
## Summary

Fixes #12284, which @michaelfeil confirmed on the issue.

`/v1/responses` dropped chat-template arguments on the way to the chat request. `NvCreateResponse` had no field for them at all, and the conversion hard-coded `chat_template_args: None`, so template-driven behaviour such as reasoning and tool formatting could be controlled from `/v1/chat/completions` but not from `/v1/responses`, even for the model families that depend on it.

The field is added to the Responses request mirroring the chat spelling, including the `chat_template_kwargs` alias, so one client payload behaves the same on both endpoints, and the conversion forwards it.

## The coupled change, and why it is in the same PR

The Responses handler left `move_reasoning_to_content_when_empty` unset, and a NOTE there explained why:

> That is currently unreachable rather than wrong: the Responses-to-chat conversion hard-codes `chat_template_args: None`, so `force_nonempty_content` can never be set on this path in the first place. If that conversion ever forwards chat_template_args, [...] the aggregator backstop should be wired here too at that point.

Forwarding the args is exactly the condition that comment names, so the flag is wired here as well, mirroring the six lines the chat path already uses. The streaming stage gates on the request's own args through `wants_reasoning_as_content_when_empty`, but a non-streaming Responses request reaches the aggregating branch, which reads the flag instead. Shipping the forwarding alone would have made `force_nonempty_content` work when streaming and silently not when not, which is the failure mode the NOTE anticipated. The comment is rewritten to describe the wiring rather than the old exemption.

Adding a field to `NvCreateResponse` also required `chat_template_args: None` at 22 existing struct literals, all in test code and one test helper in `input_trigger.rs`. That is mechanical and separate from the behaviour change.

## Validation

`cargo test -p dynamo-llm --no-default-features --lib` — 1935 passed. `cargo clippy --no-default-features --all-targets` clean, `cargo fmt` applied.

Three tests, following the repro shape in the issue:

- a Responses request carrying `chat_template_args` reaches the chat request with `enable_thinking == true`
- the `chat_template_kwargs` alias deserializes the same way, so the endpoints do not diverge on spelling
- a request without the field still produces `None` rather than an empty map, which would change downstream template rendering

The first two fail against the previous behaviour, verified by restoring `chat_template_args: None` in the conversion and keeping the tests:

```
FAILED protocols::openai::responses::tests::chat_template_args_survive_the_conversion
FAILED protocols::openai::responses::tests::chat_template_kwargs_alias_is_accepted
```

One caveat worth stating: `http::service::service_v2::tests::test_oversized_body_returns_json_413` is flaky in my environment under the full parallel suite. It passed and failed on two consecutive runs of identical code, passes in isolation, and passes in isolation with this change stashed, so it is unrelated to this diff. It touches `service_v2.rs`, which this PR does not.

Not verified here: no live model, so I have not observed a template actually consuming a forwarded argument end to end. The change is at the conversion and wiring layer and the tests cover those.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional chat template arguments in the Responses API.
  * Supports both `chat_template_args` and the `chat_template_kwargs` alias.
  * Preserves these settings when converting Responses API requests to chat completions.

* **Bug Fixes**
  * Configured reasoning-only output can now be included in message content during non-streaming response aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->