### PR TITLE
docs(agent): add native Omnigent well-lit path

### DIFF
--- a/docs/fern/pages/use-cases/agents/agent-harnesses.mdx
+++ b/docs/fern/pages/use-cases/agents/agent-harnesses.mdx
@@ -92,6 +92,62 @@ If the endpoint requires bearer authentication, export `DYNAMO_API_KEY` and add 
     Headless mode creates and persists one session artifact, prints the final answer, and exits by design. Use `dsh web` when a person needs a long-running UI with persistent sessions. A successful tool call proves the transport works; separately qualify the deployed model's coding and tool-use quality.
 
   </Tab>
+  <Tab title="Omnigent">
+
+    Omnigent can wrap its stock Codex harness around Dynamo's Responses endpoint. It uses Omnigent's native Gateway/provider store and agent YAML; no Dynamo-specific bridge or Databricks workspace is required for the local path.
+
+    ```bash
+    uv tool install --python 3.12 'omnigent==0.11.0'
+    omnigent setup
+    ```
+
+    Add a provider like the following to the Omnigent configuration created by setup. Keep the API key in the referenced environment variable, not in the file:
+
+    ```yaml
+    providers:
+      dynamo:
+        kind: gateway
+        default: true
+        openai:
+          base_url: https://your-dynamo-endpoint.example.com/v1
+          api_key_ref: env:DYNAMO_API_KEY
+          wire_api: responses
+          models:
+            default: your-recipe-served-model
+    ```
+
+    Create `dynamo-codex.yaml` outside the target repository:
+
+    ```yaml
+    spec_version: 1
+    name: dynamo-codex
+    prompt: Use tools to verify claims before answering.
+    skills: none
+    executor:
+      type: omnigent
+      model: your-recipe-served-model
+      config:
+        harness: codex
+    os_env:
+      type: caller_process
+      cwd: /absolute/worktree
+      sandbox:
+        type: auto
+    ```
+
+    Run one bounded task and keep the target worktree scoped to the files it may inspect or edit:
+
+    ```bash
+    omnigent run ./dynamo-codex.yaml \
+      --server local \
+      --harness codex \
+      --model "$DYNAMO_MODEL" \
+      -p 'Inspect one named file and report one verified fact. Do not modify files.'
+    ```
+
+    Omnigent owns orchestration, sandboxing, credentials, and process cleanup; Codex owns the Responses session and tool loop; Dynamo serves inference. One `omnigent run` proves a bounded task, not reuse of the same Codex thread across separate top-level runs.
+
+  </Tab>
   <Tab title="Pi">
 
     Pi uses the Dynamo provider plugin. Build and install it from the [agent-plugins](https://github.com/ai-dynamo/agent-plugins/tree/main/pi-plugin) checkout:


### PR DESCRIPTION
## Summary

- Adds the Omnigent native Gateway/provider configuration for a Dynamo Responses endpoint.
- Adds a stock Omnigent agent YAML that selects the Codex harness and a scoped platform sandbox.
- Requires no Dynamo-specific Omnigent bridge and no Databricks workspace for the local path.
- Removes experiment helpers and retains only the public MDX guide.

## Validation

Stock Omnigent 0.11.0 through its Gateway/provider store and Codex harness returned exact text and completed a read-only file-tool run through Dynamo. `fern check --warnings` passes with 0 errors at the composed stack tip.

## Stack

Depends on #13632. This is the lowest-priority harness addition.