### PR TITLE
fix(mocker): replay planned live prefill token

### DIFF
--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -152,8 +152,8 @@ impl ResponseReplayTable {
         Ok(Self { rows })
     }
 
-    fn get(&self, key: &str) -> Option<Vec<TokenIdType>> {
-        self.rows.get(key).cloned()
+    fn get(&self, key: &str) -> Option<&[TokenIdType]> {
+        self.rows.get(key).map(Vec::as_slice)
     }
 
     #[cfg(test)]
@@ -822,9 +822,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                 .ok_or_else(|| Error::msg("max_output_tokens must be specified for mocker"))?
                 as usize
         };
-        let replay_key = (!is_prefill)
-            .then(|| request.get_annotation_value(OUTPUT_REPLAY_ID_ANNOTATION_KEY))
-            .flatten();
+        let replay_key = request.get_annotation_value(OUTPUT_REPLAY_ID_ANNOTATION_KEY);
         let planned_output_token_ids = replay_key.as_deref().and_then(|key| {
             let Some(table) = self.response_replay_table.as_ref() else {
                 tracing::warn!(
@@ -834,7 +832,8 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                 return None;
             };
             match table.get(key) {
-                Some(tokens) => Some(tokens),
+                Some(tokens) if is_prefill => Some(tokens[..tokens.len().min(1)].to_vec()),
+                Some(tokens) => Some(tokens.to_vec()),
                 None => {
                     tracing::warn!(
                         replay_key = key,
@@ -864,7 +863,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         let direct_request = DirectRequest {
             tokens: request.token_ids.clone(),
             max_output_tokens,
-            output_token_ids: planned_output_token_ids.clone(),
+            output_token_ids: planned_output_token_ids,
             uuid: Some(request_uuid),
             dp_rank,
             arrival_timestamp_ms: request.request_timestamp_ms,
@@ -1313,7 +1312,7 @@ mod tests {
     use super::*;
     use crate::protocols::common::llm_backend::PreprocessedRequest;
     use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
-    use dynamo_mocker::common::protocols::{MockEngineArgs, WorkerType};
+    use dynamo_mocker::common::protocols::{EngineType, MockEngineArgs, WorkerType};
     use dynamo_runtime::pipeline::{AsyncEngine, SingleIn};
     use futures::StreamExt;
     use std::collections::BTreeMap;
@@ -1612,6 +1611,45 @@ mod tests {
         file
     }
 
+    #[tokio::test]
+    async fn response_replay_prefill_uses_only_first_planned_token() {
+        let file = write_replay_trace(&[serde_json::json!({
+            "request_id": "planned",
+            "output_length": 2,
+            "output_token_ids": [7, 8],
+        })]);
+
+        for engine_type in [EngineType::Vllm, EngineType::Sglang] {
+            for (worker_type, expected) in [
+                (WorkerType::Prefill, &[7][..]),
+                (WorkerType::Decode, &[7, 8][..]),
+            ] {
+                let args = MockEngineArgs::builder()
+                    .engine_type(engine_type)
+                    .worker_type(worker_type)
+                    .block_size(4)
+                    .num_gpu_blocks(64)
+                    .max_num_batched_tokens(Some(64))
+                    .speedup_ratio(1000.0)
+                    .response_replay_trace_path(Some(file.path().to_path_buf()))
+                    .build()
+                    .unwrap();
+                let live = LiveEngine::start(args.clone(), 0).unwrap();
+                let engine = MockerExecutionContext::new(args);
+                assert!(engine.engines.set(vec![live]).is_ok());
+
+                let mut request = decode_request(3, 2);
+                request.annotations = vec!["output_replay_id:planned".to_string()];
+                let mut stream = engine.generate(SingleIn::new(request)).await.unwrap();
+                let mut output_token_ids = Vec::new();
+                while let Some(output) = stream.next().await {
+                    output_token_ids.extend(output.data.unwrap().token_ids);
+                }
+                assert_eq!(output_token_ids, expected);
+            }
+        }
+    }
+
     #[test]
     fn response_replay_table_derives_keys_and_validates_lengths() {
         let file = write_replay_trace(&[
@@ -1634,9 +1672,9 @@ mod tests {
 
         let table = ResponseReplayTable::from_path(file.path()).unwrap();
         assert_eq!(table.len(), 3);
-        assert_eq!(table.get("explicit").as_deref(), Some(&[7, 8][..]));
-        assert_eq!(table.get("s:1").as_deref(), Some(&[9][..]));
-        assert_eq!(table.get("line:2").as_deref(), Some(&[10][..]));
+        assert_eq!(table.get("explicit"), Some(&[7, 8][..]));
+        assert_eq!(table.get("s:1"), Some(&[9][..]));
+        assert_eq!(table.get("line:2"), Some(&[10][..]));
 
         let invalid = write_replay_trace(&[serde_json::json!({
             "output_length": 2,


### PR DESCRIPTION
## Overview

Use the first replay-plan token for live disaggregated prefill instead of a random bootstrap token.

## Details

Prefill keeps only the first planned token, while decode retains the full plan. Adds focused vLLM and SGLang regression coverage.

## Where should the reviewer start?

`lib/llm/src/mocker.rs`.

## Summary

Align live prefill replay with offline replay while preserving one-token prefill behavior.

## Validation

- `cargo test -p dynamo-llm response_replay_prefill_uses_only_first_planned_token --lib`
- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-llm --lib -- -D warnings`

## Related Issues

- Closes #13058
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved response replay consistency for prefilling and decoding requests.
  * Prefill requests now use the planned first output token, while subsequent decoding returns the complete replayed sequence.
  * Enhanced support for disaggregated worker deployments across vLLM and SGLang.
  * Improved replay reliability when requests are retried through the frontend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->