### PR TITLE
feat(examples): add Google TPU DRA sidecar deployment for vLLM

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -532,6 +532,12 @@ areas:
   - tests/router/test_router_e2e_with_vllm_xpu.py
   - tests/serve/multimodal_profiles/vllm_xpu.py
   - tests/serve/test_vllm_xpu.py
+- label: tpu
+  github_team: '@ai-dynamo/dynamo-tpu-codeowners'
+  path_globs:
+  - examples/backends/vllm/deploy/tpu/
+  - examples/backends/vllm/launch/tpu/
+  - tests/serve/test_vllm_tpu.py
 required_owners:
 - glob: components/src/dynamo/planner/connectors/clients/kubernetes_api.py
   owners:
@@ -572,6 +578,7 @@ shared:
   - router
   - runtime
   - tokenspeed
+  - tpu
   - xpu
 # areas.yaml is the routing decision itself, not a generated artifact, so it
 # does not get the wide list above: nothing stops a rule here from re-routing

--- a/.github/codeowners/external_contributors.yaml
+++ b/.github/codeowners/external_contributors.yaml
@@ -42,3 +42,9 @@
 #       - router
 
 contributors:
+  - name: Antonio Ojea
+    github: aojea
+    level: contributor
+    affiliation: Google
+    areas:
+      - tpu

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,6 +28,7 @@
 #   router           @ai-dynamo/dynamo-router-codeowners
 #   runtime          @ai-dynamo/dynamo-runtime-codeowners
 #   tokenspeed       @ai-dynamo/dynamo-tokenspeed-codeowners
+#   tpu              @ai-dynamo/dynamo-tpu-codeowners
 #   xpu              @ai-dynamo/dynamo-xpu-codeowners
 #   *                @ai-dynamo/dynamo-runtime-codeowners  (catch-all)
 #
@@ -54,6 +55,7 @@
 #   @ai-dynamo/dynamo-router-codeowners
 #   @ai-dynamo/dynamo-runtime-codeowners
 #   @ai-dynamo/dynamo-tokenspeed-codeowners
+#   @ai-dynamo/dynamo-tpu-codeowners
 #   @ai-dynamo/dynamo-xpu-codeowners
 
 *                                                                                                       @ai-dynamo/dynamo-runtime-codeowners
@@ -495,6 +497,7 @@
 /lib/llm/src/block_manager.md                                                                           @ai-dynamo/dynamo-kv-memory-codeowners
 /lib/llm/src/block_manager.rs                                                                           @ai-dynamo/dynamo-kv-memory-codeowners
 /tests/benchmarks/multimodal/                                                                           @ai-dynamo/dynamo-multimodal-codeowners
+/tests/serve/test_vllm_tpu.py                                                                           @ai-dynamo/dynamo-tpu-codeowners @aojea
 /tests/serve/test_vllm_xpu.py                                                                           @ai-dynamo/dynamo-xpu-codeowners
 /.github/codeowners/areas.yaml                                                                          @ai-dynamo/dynamo-process-codeowners
 /.github/workflows/pr-xpu.yaml                                                                          @ai-dynamo/dynamo-xpu-codeowners
@@ -527,6 +530,8 @@
 /lib/llm/src/block_manager/pool.rs                                                                      @ai-dynamo/dynamo-kv-memory-codeowners
 /lib/llm/src/preprocessor/media.rs                                                                      @ai-dynamo/dynamo-multimodal-codeowners
 /components/src/dynamo/common/http/                                                                     @ai-dynamo/dynamo-frontend-codeowners
+/examples/backends/vllm/deploy/tpu/                                                                     @ai-dynamo/dynamo-tpu-codeowners @aojea
+/examples/backends/vllm/launch/tpu/                                                                     @ai-dynamo/dynamo-tpu-codeowners @aojea
 /lib/llm/src/block_manager/block.rs                                                                     @ai-dynamo/dynamo-kv-memory-codeowners
 /lib/llm/src/block_manager/offload/                                                                     @ai-dynamo/dynamo-kv-memory-codeowners
 /lib/llm/src/block_manager/state.rs                                                                     @ai-dynamo/dynamo-kv-memory-codeowners
@@ -573,7 +578,7 @@
 /.codex/                                                                                                @ai-dynamo/dynamo-process-codeowners @ai-dynamo/dynamo-agents-codeowners
 /agents/                                                                                                @ai-dynamo/dynamo-process-codeowners @ai-dynamo/dynamo-agents-codeowners
 /.agents/                                                                                               @ai-dynamo/dynamo-process-codeowners @ai-dynamo/dynamo-agents-codeowners
-/CODEOWNERS                                                                                             @ai-dynamo/dynamo-process-codeowners @ai-dynamo/dynamo-agents-codeowners @ai-dynamo/dynamo-backend-sglang-codeowners @ai-dynamo/dynamo-backend-trtllm-codeowners @ai-dynamo/dynamo-backend-vllm-codeowners @ai-dynamo/dynamo-diffusion-codeowners @ai-dynamo/dynamo-docs-codeowners @ai-dynamo/dynamo-epp-codeowners @ai-dynamo/dynamo-fault-tolerance-codeowners @ai-dynamo/dynamo-frontend-codeowners @ai-dynamo/dynamo-gms-codeowners @ai-dynamo/dynamo-kv-memory-codeowners @ai-dynamo/dynamo-multimodal-codeowners @ai-dynamo/dynamo-observability-codeowners @ai-dynamo/dynamo-operator-codeowners @ai-dynamo/dynamo-ops-codeowners @ai-dynamo/dynamo-performance-codeowners @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-rl-codeowners @ai-dynamo/dynamo-router-codeowners @ai-dynamo/dynamo-runtime-codeowners @ai-dynamo/dynamo-tokenspeed-codeowners @ai-dynamo/dynamo-xpu-codeowners
+/CODEOWNERS                                                                                             @ai-dynamo/dynamo-process-codeowners @ai-dynamo/dynamo-agents-codeowners @ai-dynamo/dynamo-backend-sglang-codeowners @ai-dynamo/dynamo-backend-trtllm-codeowners @ai-dynamo/dynamo-backend-vllm-codeowners @ai-dynamo/dynamo-diffusion-codeowners @ai-dynamo/dynamo-docs-codeowners @ai-dynamo/dynamo-epp-codeowners @ai-dynamo/dynamo-fault-tolerance-codeowners @ai-dynamo/dynamo-frontend-codeowners @ai-dynamo/dynamo-gms-codeowners @ai-dynamo/dynamo-kv-memory-codeowners @ai-dynamo/dynamo-multimodal-codeowners @ai-dynamo/dynamo-observability-codeowners @ai-dynamo/dynamo-operator-codeowners @ai-dynamo/dynamo-ops-codeowners @ai-dynamo/dynamo-performance-codeowners @ai-dynamo/dynamo-planner-codeowners @ai-dynamo/dynamo-rl-codeowners @ai-dynamo/dynamo-router-codeowners @ai-dynamo/dynamo-runtime-codeowners @ai-dynamo/dynamo-tokenspeed-codeowners @ai-dynamo/dynamo-tpu-codeowners @ai-dynamo/dynamo-xpu-codeowners @aojea
 /agent-docs/                                                                                            @ai-dynamo/dynamo-process-codeowners @ai-dynamo/dynamo-agents-codeowners
 /.lycheeignore                                                                                          @ai-dynamo/dynamo-ops-codeowners @ai-dynamo/dynamo-docs-codeowners
 /tests/deploy/                                                                                          @ai-dynamo/dynamo-ops-codeowners @ai-dynamo/dynamo-operator-codeowners

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,4 +9,6 @@ Generated from `.github/codeowners/external_contributors.yaml`. Do not
 hand-edit — update that file and regenerate (see
 `.github/codeowners/README.md`).
 
-_No external contributors yet._
+| Contributor | Level | GitHub | Affiliation | Areas |
+| --- | --- | --- | --- | --- |
+| Antonio Ojea | Contributor | [@aojea](https://github.com/aojea) | Google | `tpu` |

--- a/examples/backends/vllm/deploy/README.md
+++ b/examples/backends/vllm/deploy/README.md
@@ -59,6 +59,13 @@ Aggregated deployment that offloads KV cache to a per-node LMCache MP DaemonSet,
 - `VllmDecodeWorker`: Single worker, `hostIPC: true` + `runAsUser: 0` (required for cross-Pod CUDA IPC with the LMCache server)
 - `LMCacheEngine` (separate CR): per-node DaemonSet that imports the worker's KV-cache IPC handles and serves cache hits over ZMQ
 
+### 8. **Deployments with Google TPU** (see [`tpu/`](./tpu/))
+
+Hardware-specific template for Google TPU using Kubernetes DRA. Aggregated serving only —
+no disaggregated prefill/decode, KVBM, or GPU Memory Service support yet.
+
+See [`tpu/README.md`](./tpu/README.md) for available templates, prerequisites, and usage.
+
 ## CRD Structure
 
 All templates use the **DynamoGraphDeployment** CRD:

--- a/examples/backends/vllm/deploy/tpu/README.md
+++ b/examples/backends/vllm/deploy/tpu/README.md
@@ -1,0 +1,288 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Google TPU Deployment Examples
+
+Hardware-specific deployment template for Google TPU using Kubernetes Dynamic Resource
+Allocation (DRA), via the [kubernetes-sigs/dra-driver-google-tpu](https://github.com/kubernetes-sigs/dra-driver-google-tpu)
+driver and the [vLLM TPU (tpu-inference)](https://docs.vllm.ai/projects/tpu/en/latest/) plugin paired with the Dynamo vLLM sidecar.
+
+Supported scope: vLLM, aggregated serving, single-host TPU slices. Disaggregated
+prefill/decode, KVBM, and the GPU Memory Service are not available on TPU.
+
+## Available Templates
+
+| File | Pattern | Description |
+|------|---------|-------------|
+| `agg_tpu_dra.yaml` | Aggregated (Sidecar) | Single worker pod pairing Dynamo sidecar with stock `vllm/vllm-tpu` on a single-host slice |
+
+## Prerequisites
+
+1. **Any conformant Kubernetes cluster with TPU nodes**, version 1.34 or later so the
+   `resource.k8s.io/v1` Dynamic Resource Allocation (DRA) API is GA and enabled by default.
+   A plain kubeadm cluster on a TPU VM is sufficient — see
+   [Running on a vanilla Kubernetes cluster](#running-on-a-vanilla-kubernetes-cluster).
+2. **CDI enabled in containerd** — how the DRA driver injects `/dev/vfio` into the
+   container. containerd 2.x enables it by default; 1.x needs `enable_cdi = true`.
+   Managed clusters usually preconfigure this; a hand-rolled one may not.
+3. **An unlimited memlock limit on every TPU node.** libtpu locks large regions of memory
+   when it initialises the chip, and with the systemd default of 8 MB the engine aborts
+   with `TPU initialization failed: Couldn't mmap: Resource temporarily unavailable`.
+   The limit has to be raised on the container runtime: rlimits are per-process and
+   inherited from the runtime, and Kubernetes has no pod-spec field for them. Adding
+   `IPC_LOCK` is not an alternative either, because the runtime image runs as a non-root
+   user and added capabilities never reach a non-root process's effective set.
+   ```bash
+   sudo mkdir -p /etc/systemd/system/containerd.service.d
+   printf '[Service]\nLimitMEMLOCK=infinity\n' \
+     | sudo tee /etc/systemd/system/containerd.service.d/memlock.conf
+   sudo systemctl daemon-reload && sudo systemctl restart containerd
+   ```
+   Verify from inside a pod on that node: `ulimit -l` must print `unlimited`. Some
+   distributions already set this. To set the limit per pod instead of node-wide, see
+   containerd's [ulimit-adjuster NRI plugin](https://github.com/containerd/nri/tree/main/plugins/ulimit-adjuster),
+   which applies `RLIMIT_MEMLOCK` from a pod annotation.
+4. **[kubernetes-sigs/dra-driver-google-tpu](https://github.com/kubernetes-sigs/dra-driver-google-tpu)
+   v0.2.0 or later**, registering the `tpu.google.com` `DeviceClass`. Released artifacts are
+   `registry.k8s.io/dra-driver-google/dra-driver-google-tpu:v0.2.0` and the Helm chart
+   `oci://registry.k8s.io/dra-driver-google/charts/dra-driver-google-tpu:0.2.0`; that repo's
+   `demo/scripts/install-dra-driver.sh` wraps both.
+
+   v0.2.0 and later discover the chips from the host, so no node labelling is required.
+   Earlier releases need the accelerator labels applied to the node by hand.
+5. **Dynamo Sidecar image and Stock vLLM TPU image**:
+   - The worker pod uses a generic, CPU-only Dynamo sidecar image ([`lib/sidecar/Dockerfile`](../../../../../lib/sidecar/Dockerfile)) alongside the stock `vllm/vllm-tpu` image from Docker Hub.
+   - Build and push `dynamo-sidecar` if no published image is available:
+     ```bash
+     docker build -f lib/sidecar/Dockerfile -t <your-registry>/dynamo-sidecar:1.4.0 .
+     docker push <your-registry>/dynamo-sidecar:1.4.0
+     ```
+6. **HuggingFace token secret**:
+   ```bash
+   export NAMESPACE=default
+   export HF_TOKEN=your_hf_token
+   kubectl create secret generic hf-token-secret \
+     --from-literal=HF_TOKEN=${HF_TOKEN} \
+     -n ${NAMESPACE}
+   ```
+
+## Deploy
+
+```bash
+# Substitute template sidecar image tag with your built sidecar image
+export DYNAMO_SIDECAR_IMAGE=nvcr.io/nvidia/ai-dynamo/dynamo-sidecar:1.4.0
+
+sed "s#image: nvcr.io/nvidia/ai-dynamo/dynamo-sidecar:.*#image: ${DYNAMO_SIDECAR_IMAGE}#" \
+  examples/backends/vllm/deploy/tpu/agg_tpu_dra.yaml | kubectl apply -n $NAMESPACE -f -
+
+# Verify TPU allocation
+kubectl get resourceclaim -n $NAMESPACE
+kubectl get resourceslices
+
+# Check deployment status
+kubectl get dynamographdeployment -n $NAMESPACE
+kubectl get pods -n $NAMESPACE
+```
+
+## Testing
+
+```bash
+# Port forward to frontend in the background
+kubectl port-forward deployment/vllm-agg-tpu-dra-frontend 8000:8000 -n $NAMESPACE &
+
+# Test inference
+curl localhost:8000/v1/models
+curl localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"Qwen/Qwen3-0.6B","prompt":"Hello","max_tokens":20}'
+```
+
+For a non-Kubernetes launch or test on a single Cloud TPU VM, see
+[agg_tpu.sh](../../launch/tpu/agg_tpu.sh) and [Automated test coverage](#automated-test-coverage).
+
+## Running on a vanilla Kubernetes cluster
+
+The steps above assume a cluster where the `tpu.google.com` `DeviceClass` and
+`ResourceSlice`s already exist. This section builds one from scratch with upstream
+Kubernetes and the OSS DRA driver.
+
+### 1. Bring up a cluster with TPU nodes and the DRA driver
+On GCE, the DRA driver repo ships a script that does all of it — control-plane VM, a
+TPU VM joined as a worker, and the driver itself:
+```bash
+git clone --branch v0.2.0 https://github.com/kubernetes-sigs/dra-driver-google-tpu.git
+cd dra-driver-google-tpu
+PROJECT=my-project ZONE=us-central1-a ./demo/clusters/gce/create-kubeadm-tpu-cluster.sh
+```
+See [demo/clusters/gce](https://github.com/kubernetes-sigs/dra-driver-google-tpu/tree/main/demo/clusters/gce)
+for quota checks, machine-type overrides and teardown.
+
+That script leaves containerd at the systemd default 8 MB memlock limit, so raise it on
+the TPU node before deploying (see prerequisite 3).
+
+Any conformant installer works instead; the driver's
+[README](https://github.com/kubernetes-sigs/dra-driver-google-tpu#readme) covers the
+other supported paths, and `demo/scripts/install-dra-driver.sh` installs the driver into
+a cluster you already have. The cluster needs:
+
+- **Kubernetes 1.34 or later**, for the GA `resource.k8s.io/v1` API (see
+  [install-dynamo.md](../../../../../docs/fern/pages/kubernetes/installation/install-dynamo.md)).
+- **containerd with CDI enabled**, which is how the driver injects the TPU device nodes.
+  containerd 2.x enables it by default; 1.x needs `enable_cdi = true`.
+- **An unlimited memlock limit**, set on the container runtime.
+- **Nodes with TPU chips attached** (`ls /dev | grep -E 'accel|vfio'`).
+- **A container registry the nodes can pull from**, for the image built in step 3.
+
+### 2. Verify the driver sees the TPU chips
+```bash
+kubectl get pod -n dra-driver-google-tpu
+kubectl get deviceclass tpu.google.com
+kubectl get resourceslice -o jsonpath='{range .items[*]}{.spec.nodeName} {.spec.driver}{"\n"}{range .spec.devices[*]}  {.name} {.attributes}{"\n"}{end}{end}'
+```
+
+**Expected output**
+
+```text
+NAME                                        READY   STATUS    RESTARTS   AGE
+dra-driver-google-tpu-kubeletplugin-mqlxz   3/3     Running   0          29m
+dra-driver-google-tpu-kubeletplugin-vcgmp   3/3     Running   0          29m
+
+NAME             AGE
+tpu.google.com   29m
+
+tpu-dra-tpu tpu.google.com
+  0 {"accelerator":{"string":"tpu-v5-lite-podslice"},"brand":{"string":"Google"},"chipCount":{"int":1},"index":{"int":0},"topology":{"string":"1x1"},"tpuGen":{"string":"v5litepod"},"uuid":{"string":"tpu-585695ce-c265-152a-e04a-88b343209584"}}
+```
+
+The plugin runs on every node but publishes a `ResourceSlice` only where TPUs exist, so
+one slice for a single TPU node is expected. The `uuid` and `tpuGen` values are read from
+the hardware.
+
+### 3. Build and publish the Dynamo sidecar image
+Push to any registry the cluster can pull from:
+```bash
+cd /path/to/dynamo
+docker build -f lib/sidecar/Dockerfile -t gcr.io/$PROJECT/dynamo-sidecar:1.4.0 .
+gcloud auth configure-docker gcr.io --quiet
+docker push gcr.io/$PROJECT/dynamo-sidecar:1.4.0
+```
+Verify the sidecar executable before deploying:
+```bash
+docker run --rm --entrypoint dynamo-vllm-sidecar gcr.io/$PROJECT/dynamo-sidecar:1.4.0 --help
+```
+
+### 4. Install the Dynamo Platform
+An aggregated deployment needs only the operator and etcd. Persistence is disabled here
+because a kubeadm cluster has no default `StorageClass` for the PVC to bind to:
+```bash
+export NAMESPACE=dynamo-system
+helm fetch https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-<RELEASE_VERSION>.tgz
+helm install dynamo-platform dynamo-platform-<RELEASE_VERSION>.tgz \
+  --namespace $NAMESPACE --create-namespace \
+  --set global.etcd.install=true \
+  --set etcd.persistence.enabled=false
+kubectl get pods -n $NAMESPACE
+```
+
+**Expected output**
+
+```text
+NAME                                                              READY   STATUS    RESTARTS   AGE
+dynamo-platform-dynamo-operator-controller-manager-76f6d7dwbbsd   1/1     Running   0          2m
+dynamo-platform-etcd-0                                            1/1     Running   0          2m
+```
+
+### 5. Secrets, then deploy
+```bash
+export NS=dynamo-tpu
+kubectl create namespace $NS
+kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=$HF_TOKEN -n $NS
+
+# Attaching the pull secret to the namespace's default ServiceAccount covers every
+# pod the operator creates, so the manifest needs no imagePullSecrets.
+kubectl create secret docker-registry gcr-pull \
+  --docker-server=gcr.io --docker-username=oauth2accesstoken \
+  --docker-password="$(gcloud auth print-access-token)" -n $NS
+kubectl patch serviceaccount default -n $NS \
+  -p '{"imagePullSecrets":[{"name":"gcr-pull"}]}'
+
+sed "s#image: nvcr.io/nvidia/ai-dynamo/dynamo-sidecar:.*#image: gcr.io/$PROJECT/dynamo-sidecar:1.4.0#" \
+  agg_tpu_dra.yaml | kubectl apply -n $NS -f -
+```
+The access token expires after about an hour; recreate the secret if a later pull fails.
+
+### 6. Verify allocation and scheduling
+```bash
+kubectl get resourceclaim -n $NS     # status.allocation should name your real accel device
+kubectl get pods -n $NS -o wide
+kubectl logs -n $NS -l nvidia.com/dynamo-component-type=worker -c vllm-engine -f
+```
+
+**Expected output**
+
+```text
+NAME                                                          READY   STATUS    NODE
+vllm-agg-tpu-dra-frontend-5b7797df9d-nbrdt                    1/1     Running   tpu-dra-cpu
+vllm-agg-tpu-dra-vllmdecodeworker-2aed0841-78fc5b7774-bbcrn   1/1     Running   tpu-dra-tpu
+
+NAME                                                           STATE                AGE
+vllm-agg-tpu-dra-vllmdecodeworker-2aed0841-78fc5b77-tpuqzh7x   allocated,reserved   8m
+```
+
+The worker lands on the TPU node and the frontend on the CPU node. In the worker log,
+`Registered base model 'Qwen/Qwen3-0.6B' MDC` means vLLM finished loading on the TPU
+(first start includes XLA compilation, so allow several minutes).
+
+A worker stuck in `Pending` with `cannot allocate all claims` means the chip is still
+held by another pod — `allocationMode: All` is exclusive, so only one claimant at a time.
+
+### 7. Smoke test
+```bash
+kubectl port-forward -n dynamo-tpu svc/vllm-agg-tpu-dra-frontend 8000:8000 &
+curl localhost:8000/v1/models
+curl localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"Qwen/Qwen3-0.6B","prompt":"The capital of France is","max_tokens":20,"temperature":0}'
+```
+
+**Expected output**
+
+```text
+{"object":"list","data":[{"id":"Qwen/Qwen3-0.6B","object":"model","owned_by":"nvidia","context_window":2048}]}
+
+{"id":"cmpl-6e337253-...","choices":[{"text":" Paris. The capital of France is also the
+ capital of the Republic of France. The capital of France","index":0,"finish_reason":"length"}],
+ "model":"Qwen/Qwen3-0.6B","object":"text_completion",
+ "usage":{"prompt_tokens":5,"completion_tokens":20,"total_tokens":25}}
+```
+
+### Troubleshooting
+- Pod stuck `Pending` → `kubectl describe pod` for DRA scheduling errors; re-check
+  `resourceslice`/`deviceclass` from step 2.
+- Pod `CrashLoopBackOff` on the vLLM container → check logs first for the
+  tpu-inference/JAX device-init error; confirm `/dev/accel*` or `/dev/vfio/*` actually
+  got injected (`kubectl exec ... -- ls /dev`).
+- `TPU initialization failed: Couldn't mmap: Resource temporarily unavailable` → the host
+  memlock limit is too low. Confirm with `ulimit -l` inside a pod on that node and fix the
+  container runtime limit, not the pod spec (see prerequisite 3).
+
+## Automated test coverage
+
+[tests/serve/test_vllm_tpu.py](../../../../../tests/serve/test_vllm_tpu.py) runs the same
+aggregated scenario (chat completion, text completion, and a Prometheus metrics sanity
+check) through Dynamo's `EngineConfig`/`run_serve_deployment` test framework, using
+[examples/backends/vllm/launch/tpu/agg_tpu.sh](../../launch/tpu/agg_tpu.sh) as the
+bare-metal (non-Kubernetes) launch script. It's marked `tpu_1` (see `pyproject.toml`) and
+only runs where a TPU-attached test runner is available — there is no CI runner for it
+yet, so it must currently be run manually on real TPU hardware:
+```bash
+python3 -m pytest tests/serve/test_vllm_tpu.py -v
+```
+
+## Further Reading
+
+- [Main Deployment README](../README.md) - Overview of all deployment patterns
+- [kubernetes-sigs/dra-driver-google-tpu](https://github.com/kubernetes-sigs/dra-driver-google-tpu)
+- [vLLM TPU documentation](https://docs.vllm.ai/projects/tpu/en/latest/)

--- a/examples/backends/vllm/deploy/tpu/agg_tpu_dra.yaml
+++ b/examples/backends/vllm/deploy/tpu/agg_tpu_dra.yaml
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated vLLM deployment on Google TPU using Kubernetes Dynamic Resource Allocation (DRA)
+# and the Dynamo vLLM sidecar.
+#
+# The worker pod has two containers:
+#   - main: the Dynamo worker (dynamo-vllm-sidecar). No TPU access needed.
+#     Handles registration, discovery, and communicates with the engine over gRPC on 127.0.0.1.
+#   - vllm-engine: stock upstream vLLM TPU image (vllm/vllm-tpu). Holds the TPU DRA claim.
+#     Runs as a native sidecar container (initContainers with restartPolicy: Always).
+
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: tpu-template
+spec:
+  spec:
+    devices:
+      requests:
+        - name: tpus
+          exactly:
+            deviceClassName: tpu.google.com
+            # Grabs every TPU chip exposed on whatever node this claim is
+            # scheduled onto (matches a single-host TPU slice, e.g. a v5e-8 node).
+            # Replace with `count: N` to request a specific number of chips instead.
+            allocationMode: All
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-agg-tpu-dra
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        # Dynamo frontend. The operator injects discovery env and command.
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.4.0
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+  - name: VllmWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        tolerations:
+        - key: "google.com/tpu"
+          operator: "Exists"
+          effect: "NoSchedule"
+        initContainers:
+        # vllm-engine as a native sidecar (initContainer with restartPolicy: Always):
+        # Starts before `main` and stops after it. Uses stock vllm/vllm-tpu image.
+        - name: vllm-engine
+          image: vllm/vllm-tpu:v0.27.0
+          restartPolicy: Always
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60   # ~5 min for model load / XLA compilation; raise for larger models
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            claims:
+            - name: tpus
+            requests:
+              ephemeral-storage: 2Gi
+          volumeMounts:
+          - name: dshm
+            mountPath: /dev/shm
+          # vllm-rs is located in the installed vllm package directory.
+          # --host 127.0.0.1 keeps unauthenticated gRPC on pod loopback.
+          command:
+          - /bin/sh
+          - -c
+          - >-
+            exec "$(python3 -c 'import os,vllm; print(os.path.join(os.path.dirname(vllm.__file__), "vllm-rs"))')"
+            serve Qwen/Qwen3-0.6B --host 127.0.0.1 --grpc-port 50051 -- --max-model-len 2048
+        containers:
+        # The Dynamo sidecar worker.
+        # Must be named "main": the operator injects discovery env + probes by name.
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-sidecar:1.4.0
+          command:
+          - dynamo-vllm-sidecar
+          args:
+          - --grpc-endpoint
+          - 127.0.0.1:50051
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+        resourceClaims:
+        - name: tpus
+          resourceClaimTemplateName: tpu-template

--- a/examples/backends/vllm/launch/tpu/agg_tpu.sh
+++ b/examples/backends/vllm/launch/tpu/agg_tpu.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated serving on a single-host Google TPU slice.
+# No NIXL/KVBM support on this path -- aggregated only, no disaggregation.
+
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
+
+# Default model
+MODEL="Qwen/Qwen3-0.6B"
+
+# Parse command line arguments
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model)
+            MODEL="$2"
+            shift 2
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# ---- Tunable (override via env vars) ----
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-2048}"
+TENSOR_PARALLEL_SIZE="${TENSOR_PARALLEL_SIZE:-1}"
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+print_launch_banner "Launching Aggregated Serving (single-host TPU)" "$MODEL" "$HTTP_PORT"
+
+# run ingress
+# Explicit python3 call avoids depending on python symlink resolution.
+python3 -m dynamo.frontend &
+
+# run worker
+# Device/platform detection is automatic (vLLM's TPU platform plugin via JAX/libtpu);
+# no --gpu-memory-utilization equivalent flag is passed here.
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+    python3 -m dynamo.vllm --model "$MODEL" \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --tensor-parallel-size "$TENSOR_PARALLEL_SIZE" \
+    "${EXTRA_ARGS[@]}" &
+
+# Exit on first worker failure; kill 0 in the EXIT trap tears down the rest
+wait_any_exit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,6 +314,7 @@ markers = [
     "gpu_8: marks tests to run on 8GPUs",
     "xpu_1: marks tests to run on XPU",
     "xpu_2: marks tests to run on 2XPUs",
+    "tpu_1: marks tests to run on a single-host TPU slice",
     # These 6 (profiled_vram_gib and requested_*) are used for parallel pytest executions:
     "profiled_vram_gib(N): actual peak VRAM observed by nvidia-smi during profiling. Used for --max-vram-gib filtering and scheduler budget tracking",
     "requested_vllm_kv_cache_bytes(N): exact KV cache bytes for vLLM (skips memory profiling). Sets _PROFILE_PYTEST_KV_CACHE_BYTES. Most deterministic method for parallel execution",

--- a/tests/marker_categories.py
+++ b/tests/marker_categories.py
@@ -32,6 +32,7 @@ REQUIRED_CATEGORIES: dict[str, frozenset[str]] = {
             "k8s",
             "xpu_1",
             "xpu_2",
+            "tpu_1",
         }
     ),
 }

--- a/tests/serve/test_vllm_tpu.py
+++ b/tests/serve/test_vllm_tpu.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end tests for aggregated vLLM serving on a single-host Google TPU slice.
+
+No NIXL/KVBM support on this path yet, so only the aggregated (non-disaggregated)
+scenario is covered here -- see examples/backends/vllm/deploy/tpu/README.md for the
+scope of the current TPU integration.
+
+Requires a real single-host TPU slice; there is no simulated/CPU fallback for these
+tests (unlike gpu_0-marked tests), so they only run where a `tpu_1`-labeled runner
+is available.
+"""
+
+import os
+
+import pytest
+
+from tests.serve.common import (
+    WORKSPACE_DIR,
+    params_with_model_mark,
+    run_serve_deployment,
+)
+from tests.utils.engine_process import EngineConfig
+from tests.utils.payload_builder import (
+    chat_payload_default,
+    completion_payload_default,
+    metric_payload_default,
+)
+
+
+def get_vllm_tpu_configs() -> dict[str, EngineConfig]:
+    vllm_dir = os.environ.get("VLLM_DIR") or os.path.join(
+        WORKSPACE_DIR, "examples/backends/vllm"
+    )
+    return {
+        "aggregated": EngineConfig(
+            name="aggregated_tpu",
+            directory=vllm_dir,
+            script_name="tpu/agg_tpu.sh",
+            marks=[
+                pytest.mark.core,
+                pytest.mark.tpu_1,
+                # No profiled_vram_gib / requested_vllm_kv_cache_bytes markers yet --
+                # those are measured on real hardware; add once a TPU CI runner exists.
+                pytest.mark.timeout(300),
+                pytest.mark.pre_merge,
+            ],
+            model="Qwen/Qwen3-0.6B",
+            request_payloads=[
+                chat_payload_default(),
+                completion_payload_default(),
+                metric_payload_default(min_num_requests=6, backend="vllm"),
+            ],
+        ),
+    }
+
+
+@pytest.fixture(params=params_with_model_mark(get_vllm_tpu_configs()))
+def vllm_tpu_config_test(request):
+    """Fixture that provides different vLLM-on-TPU test configurations"""
+    return get_vllm_tpu_configs()[request.param]
+
+
+@pytest.mark.vllm
+@pytest.mark.e2e
+@pytest.mark.parametrize("num_system_ports", [1], indirect=True)
+def test_serve_deployment(
+    vllm_tpu_config_test,
+    request,
+    runtime_services_dynamic_ports,
+    dynamo_dynamic_ports,
+    num_system_ports,
+    predownload_models,
+):
+    """Aggregated vLLM+TPU deployment: chat + completion + metrics sanity."""
+    assert num_system_ports >= 1, "serve tests require at least SYSTEM_PORT1"
+    run_serve_deployment(vllm_tpu_config_test, request, ports=dynamo_dynamic_ports)


### PR DESCRIPTION
## Overview

Adds Google Cloud TPU support for vLLM using Dynamo's sidecar architecture and Kubernetes Dynamic Resource Allocation (DRA).

Scope is deliberately narrow: vLLM only, aggregated serving only, single-host TPU slices. Disaggregated prefill/decode, KVBM, and the GPU Memory Service are out of scope.

## Details

**Sidecar Architecture & Deployment (`examples/backends/vllm/deploy/tpu/`)**
- Uses Dynamo's vLLM sidecar model (`dynamo-vllm-sidecar`) which requires **no container build modifications** to Dynamo.
- The worker pod pairs two containers:
  - `vllm-engine`: Stock upstream `vllm/vllm-tpu:v0.27.0` image as a native sidecar container (`restartPolicy: Always`), holding the TPU DRA claim.
  - `main`: Generic CPU-only Dynamo sidecar (`nvcr.io/nvidia/ai-dynamo/dynamo-sidecar:1.4.0`) that handles discovery/registration and communicates with the engine over localhost gRPC on `127.0.0.1:50051`.
- A `DynamoGraphDeployment` using a DRA `ResourceClaimTemplate` against the `tpu.google.com` `DeviceClass`, requiring [kubernetes-sigs/dra-driver-google-tpu](https://github.com/kubernetes-sigs/dra-driver-google-tpu) v0.2.0+.
- Includes a complete deployment guide and from-scratch runbook for vanilla Kubernetes clusters with the OSS DRA driver.

**Testing & Bare-Metal Launch (`examples/backends/vllm/launch/tpu/`, `tests/serve/`)**
- Bare-metal launch script (`launch/tpu/agg_tpu.sh`).
- Aggregated e2e test (`tests/serve/test_vllm_tpu.py`) marked `tpu_1`.
- `tpu_1` is registered in `pyproject.toml` and `tests/marker_categories.py` under the Hardware category so the test is not auto-marked `gpu_0` by `conftest.py` and is safely ignored by standard CI runner expressions.

**Codeowners (`.github/codeowners/`)**
- TPU-specific paths mapped to area `tpu` (`@ai-dynamo/dynamo-tpu-codeowners`) with `@aojea` as co-owner.

## Validation

- Tested deployment on GCE kubeadm cluster (K8s 1.34) with `dra-driver-google-tpu` v0.2.0 on TPU v5e (`v5litepod-1`).
- `ResourceClaim` allocated; worker scheduled onto TPU node, frontend on CPU node.
- `/v1/models`, `/v1/completions`, and `/v1/chat/completions` validated.
- Codeowners strict validation (`build_codeowners.py --strict` and `test_codeowners.py`) passes with 100% explicit coverage.
- Pytest marker coverage tests pass (`tests/test_default_markers.py`).

## Related Issues

🚫 This PR is NOT linked to an issue:
- [x] Confirmed — no related issue