### PR TITLE
fix(agent-skills): correct mechanical defects in the optimization skill pack (OPS-8324)

### DIFF
--- a/.agents/skills/analyze-aiperf-results/SKILL.md
+++ b/.agents/skills/analyze-aiperf-results/SKILL.md
@@ -12,6 +12,11 @@ metadata:
     - benchmarking
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Analyze AIPerf Results
 
 Audit benchmark evidence before interpreting performance. Preserve raw files unchanged and do not claim an unmeasured

--- a/.agents/skills/analyze-aiperf-results/SKILL.md
+++ b/.agents/skills/analyze-aiperf-results/SKILL.md
@@ -12,12 +12,12 @@ metadata:
     - benchmarking
 ---
 
+# Analyze AIPerf Results
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
-# Analyze AIPerf Results
 
 Audit benchmark evidence before interpreting performance. Preserve raw files unchanged and do not claim an unmeasured
 server-side cause.

--- a/.agents/skills/configure-aiperf-benchmark/SKILL.md
+++ b/.agents/skills/configure-aiperf-benchmark/SKILL.md
@@ -13,12 +13,12 @@ metadata:
     - benchmarking
 ---
 
+# Configure AIPerf Benchmark
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
-# Configure AIPerf Benchmark
 
 Create a reproducible benchmark that answers the current performance question without changing the deployed candidate.
 Freeze semantics only for runs used in the same direct comparison.

--- a/.agents/skills/configure-aiperf-benchmark/SKILL.md
+++ b/.agents/skills/configure-aiperf-benchmark/SKILL.md
@@ -13,6 +13,11 @@ metadata:
     - benchmarking
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Configure AIPerf Benchmark
 
 Create a reproducible benchmark that answers the current performance question without changing the deployed candidate.

--- a/.agents/skills/consult-perf-knowledge/SKILL.md
+++ b/.agents/skills/consult-perf-knowledge/SKILL.md
@@ -15,6 +15,11 @@ metadata:
     - performance
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Consult Performance Knowledge
 
 Turn the current audited performance finding into one documented configuration proposal. Write the reasoning record;

--- a/.agents/skills/consult-perf-knowledge/SKILL.md
+++ b/.agents/skills/consult-perf-knowledge/SKILL.md
@@ -15,12 +15,12 @@ metadata:
     - performance
 ---
 
+# Consult Performance Knowledge
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
-# Consult Performance Knowledge
 
 Turn the current audited performance finding into one documented configuration proposal. Write the reasoning record;
 do not edit a deployment manifest, deploy anything, or run AIPerf.

--- a/.agents/skills/create-optimization-hypothesis/SKILL.md
+++ b/.agents/skills/create-optimization-hypothesis/SKILL.md
@@ -15,12 +15,12 @@ metadata:
     - yaml
 ---
 
+# Create Optimization Hypothesis
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
-# Create Optimization Hypothesis
 
 Materialize an already-reasoned proposal. Treat `knowledge-consult.md` as a flexible reasoning record, not a rigid
 schema. Do not select a different lever, broaden the proposal, deploy, benchmark, or approve it.

--- a/.agents/skills/create-optimization-hypothesis/SKILL.md
+++ b/.agents/skills/create-optimization-hypothesis/SKILL.md
@@ -15,6 +15,11 @@ metadata:
     - yaml
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Create Optimization Hypothesis
 
 Materialize an already-reasoned proposal. Treat `knowledge-consult.md` as a flexible reasoning record, not a rigid

--- a/.agents/skills/deploy-dynamo-recipe/SKILL.md
+++ b/.agents/skills/deploy-dynamo-recipe/SKILL.md
@@ -11,12 +11,12 @@ metadata:
     - deployment
 ---
 
+# Deploy Dynamo Recipe
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
-# Deploy Dynamo Recipe
 
 ## Purpose
 

--- a/.agents/skills/deploy-dynamo-recipe/SKILL.md
+++ b/.agents/skills/deploy-dynamo-recipe/SKILL.md
@@ -11,6 +11,11 @@ metadata:
     - deployment
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Deploy Dynamo Recipe
 
 ## Purpose
@@ -66,7 +71,10 @@ Create exactly one directory for the assigned candidate:
 
 Create `applied_manifests/` beneath it. Copy the assigned DGD and every explicitly handed-off support manifest used by
 the deployment into that directory with stable names such as `deploy.yaml`, `model-cache.yaml`,
-`model-download.yaml`, and `model-validate.yaml`. Never modify the handed-off source files.
+`model-download.yaml`, and `model-validate.yaml`. Which support manifests exist is recipe-dependent: some recipes ship
+precision-suffixed download manifests (`recipes/deepseek-v4/*` ship `model-download-fp8.yaml` and
+`model-download-nvfp4.yaml`), some fold the download into the model-cache manifest, and few ship a validation job at
+all. Copy what the handoff actually contains. Never modify the handed-off source files.
 
 Update these run-scoped copies in place when a compatibility fix is required, then reapply them. Record every change
 and reason in `deployment_ledger.json`; do not retain numbered intermediate copies. After a successful smoke test,
@@ -157,12 +165,14 @@ If the effective cluster context differs from what `<EXP_ROOT>/manifest.yaml` re
 cluster-context entry before mutating anything.
 
 Read each support manifest's `kind` and `metadata.name`; never infer a Kubernetes resource name from its filename. Set
-`DOWNLOAD_JOB` and `VALIDATE_JOB` from the corresponding Job manifests.
+`DOWNLOAD_MANIFEST` and `DOWNLOAD_JOB` from the handed-off download manifest, and `VALIDATE_MANIFEST` and
+`VALIDATE_JOB` from the validation manifest. Both are optional: skip the corresponding block when the recipe ships no
+such manifest, and never assume the literal filename `model-download.yaml`.
 
 ```bash
 set -euo pipefail
 kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/model-cache.yaml" -n "${NAMESPACE}"
-kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/model-download.yaml" -n "${NAMESPACE}"
+kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/${DOWNLOAD_MANIFEST}" -n "${NAMESPACE}"
 job_state=""
 for _ in $(seq 1 200); do  # 200 x 30s = 100 min bound
   # NOTE: match by substring - a successful Job on Kubernetes 1.31+ carries BOTH
@@ -179,7 +189,7 @@ If a validation job exists, run it after download and before the DGD:
 
 ```bash
 set -euo pipefail
-kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/model-validate.yaml" -n "${NAMESPACE}"
+kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/${VALIDATE_MANIFEST}" -n "${NAMESPACE}"
 job_state=""
 for _ in $(seq 1 120); do  # 120 x 30s = 60 min bound
   job_state="$(kubectl --context "${KUBE_CONTEXT}" get "job/${VALIDATE_JOB}" -n "${NAMESPACE}" \

--- a/.agents/skills/deploy-dynamo-recipe/SKILL.md
+++ b/.agents/skills/deploy-dynamo-recipe/SKILL.md
@@ -71,10 +71,10 @@ Create exactly one directory for the assigned candidate:
 
 Create `applied_manifests/` beneath it. Copy the assigned DGD and every explicitly handed-off support manifest used by
 the deployment into that directory with stable names such as `deploy.yaml`, `model-cache.yaml`,
-`model-download.yaml`, and `model-validate.yaml`. Which support manifests exist is recipe-dependent: some recipes ship
-precision-suffixed download manifests (`recipes/deepseek-v4/*` ship `model-download-fp8.yaml` and
-`model-download-nvfp4.yaml`), some fold the download into the model-cache manifest, and few ship a validation job at
-all. Copy what the handoff actually contains. Never modify the handed-off source files.
+`model-download.yaml`, and `model-validate.yaml` — normalizing the filename at copy time. A recipe may ship
+variant-specific manifests (`recipes/deepseek-v4/*` ship `model-download-fp8.yaml` and `model-download-nvfp4.yaml`):
+select the one matching the assigned DGD's precision and copy it as `model-download.yaml`. Few recipes ship a
+validation job at all. Copy what the handoff actually contains. Never modify the handed-off source files.
 
 Update these run-scoped copies in place when a compatibility fix is required, then reapply them. Record every change
 and reason in `deployment_ledger.json`; do not retain numbered intermediate copies. After a successful smoke test,
@@ -165,14 +165,14 @@ If the effective cluster context differs from what `<EXP_ROOT>/manifest.yaml` re
 cluster-context entry before mutating anything.
 
 Read each support manifest's `kind` and `metadata.name`; never infer a Kubernetes resource name from its filename. Set
-`DOWNLOAD_MANIFEST` and `DOWNLOAD_JOB` from the handed-off download manifest, and `VALIDATE_MANIFEST` and
-`VALIDATE_JOB` from the validation manifest. Both are optional: skip the corresponding block when the recipe ships no
-such manifest, and never assume the literal filename `model-download.yaml`.
+`DOWNLOAD_JOB` and `VALIDATE_JOB` from the corresponding Job manifests. The run-scoped copies are already normalized to
+the stable filenames above, so the applies below reference those names directly; skip a block when the recipe ships no
+such manifest.
 
 ```bash
 set -euo pipefail
 kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/model-cache.yaml" -n "${NAMESPACE}"
-kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/${DOWNLOAD_MANIFEST}" -n "${NAMESPACE}"
+kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/model-download.yaml" -n "${NAMESPACE}"
 job_state=""
 for _ in $(seq 1 200); do  # 200 x 30s = 100 min bound
   # NOTE: match by substring - a successful Job on Kubernetes 1.31+ carries BOTH
@@ -189,7 +189,7 @@ If a validation job exists, run it after download and before the DGD:
 
 ```bash
 set -euo pipefail
-kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/${VALIDATE_MANIFEST}" -n "${NAMESPACE}"
+kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/model-validate.yaml" -n "${NAMESPACE}"
 job_state=""
 for _ in $(seq 1 120); do  # 120 x 30s = 60 min bound
   job_state="$(kubectl --context "${KUBE_CONTEXT}" get "job/${VALIDATE_JOB}" -n "${NAMESPACE}" \

--- a/.agents/skills/perform-adversarial-review/SKILL.md
+++ b/.agents/skills/perform-adversarial-review/SKILL.md
@@ -15,12 +15,12 @@ metadata:
     - kubernetes
 ---
 
+# Perform Adversarial Review
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
-# Perform Adversarial Review
 
 Try to falsify a proposed optimization experiment before it consumes GPU time. Review the proposal; do not generate a
 second one, edit its draft, deploy it, or run AIPerf.

--- a/.agents/skills/perform-adversarial-review/SKILL.md
+++ b/.agents/skills/perform-adversarial-review/SKILL.md
@@ -15,6 +15,11 @@ metadata:
     - kubernetes
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Perform Adversarial Review
 
 Try to falsify a proposed optimization experiment before it consumes GPU time. Review the proposal; do not generate a

--- a/.agents/skills/run-aiperf-benchmark/SKILL.md
+++ b/.agents/skills/run-aiperf-benchmark/SKILL.md
@@ -12,12 +12,12 @@ metadata:
     - benchmarking
 ---
 
+# Run AIPerf Benchmark
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
-# Run AIPerf Benchmark
 
 Execute the configured Job and preserve operational evidence. Do not interpret performance.
 

--- a/.agents/skills/run-aiperf-benchmark/SKILL.md
+++ b/.agents/skills/run-aiperf-benchmark/SKILL.md
@@ -12,6 +12,11 @@ metadata:
     - benchmarking
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Run AIPerf Benchmark
 
 Execute the configured Job and preserve operational evidence. Do not interpret performance.

--- a/.agents/skills/synthesize-user-workload/SKILL.md
+++ b/.agents/skills/synthesize-user-workload/SKILL.md
@@ -14,6 +14,11 @@ metadata:
     - optimization
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Synthesize User Workload
 
 Create the durable workload contract and user-provided baseline DGD that every later optimization role receives. Do

--- a/.agents/skills/synthesize-user-workload/SKILL.md
+++ b/.agents/skills/synthesize-user-workload/SKILL.md
@@ -14,12 +14,12 @@ metadata:
     - optimization
 ---
 
+# Synthesize User Workload
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
-# Synthesize User Workload
 
 Create the durable workload contract and user-provided baseline DGD that every later optimization role receives. Do
 not search for or select a recipe, deploy, benchmark, or propose tuning changes.

--- a/.github/ISSUE_TEMPLATE/agent-reported.yml
+++ b/.github/ISSUE_TEMPLATE/agent-reported.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 name: Agent-reported instruction gap
 description: For AI agents using the optimization skills — report instructions that misled, blocked, or contradicted live verification.
 title: "[AGENT]: "

--- a/agent-docs/guides/deployment/kubernetes-recipe-workflow.md
+++ b/agent-docs/guides/deployment/kubernetes-recipe-workflow.md
@@ -51,16 +51,17 @@ kubectl --context "${KUBE_CONTEXT}" get pvc -n "${NAMESPACE}"
 ```
 
 Run model download and validation jobs when present. Read each Job name from its manifest's `metadata.name`; never infer
-the resource name from the filename. Both the existence and the filename of these manifests are recipe-dependent — some
-recipes ship precision-suffixed download manifests, and some fold the download into the model-cache manifest — so take
-the filename from the handoff and skip the block entirely when the recipe ships no such job.
+the resource name from the filename. A recipe may ship variant-specific download manifests (for example
+`model-download-fp8.yaml` and `model-download-nvfp4.yaml`); select the one matching the assigned DGD and copy it into
+`applied_manifests/` as `model-download.yaml`, per `deploy-dynamo-recipe`. Skip a block when the recipe ships no such
+job.
 
 ```bash
-kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/${DOWNLOAD_MANIFEST}" -n "${NAMESPACE}"
+kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/model-download.yaml" -n "${NAMESPACE}"
 # Poll the job true condition with a bounded loop (Complete -> proceed, Failed -> exit 1); a Failed job must
 # fail fast, not burn the timeout. Use the scripted poll block from deploy-dynamo-recipe SKILL.md.
 
-kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/${VALIDATE_MANIFEST}" -n "${NAMESPACE}"
+kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/model-validate.yaml" -n "${NAMESPACE}"
 # Same bounded Complete/Failed poll as the download job (60 min bound).
 ```
 

--- a/agent-docs/guides/deployment/kubernetes-recipe-workflow.md
+++ b/agent-docs/guides/deployment/kubernetes-recipe-workflow.md
@@ -21,9 +21,18 @@ retained beyond the deployment ledger.
 
 ```bash
 kubectl --context "${KUBE_CONTEXT}" get namespace "${NAMESPACE}"
-kubectl --context "${KUBE_CONTEXT}" get crd | grep -i dynamo || { echo "Dynamo CRDs missing"; exit 1; }
-kubectl --context "${KUBE_CONTEXT}" get storageclass
-kubectl --context "${KUBE_CONTEXT}" get nodes -o wide
+# CRD presence gate: a Forbidden here is tolerated because deploy-dynamo-recipe's server
+# dry-run re-checks it authoritatively; a confirmed absence stops before any mutation.
+crds="$(kubectl --context "${KUBE_CONTEXT}" get crd 2>&1 || true)"
+case "${crds}" in
+  *Forbidden*) echo "WARN: cluster-scope CRD list forbidden for this identity; deferring to server dry-run" ;;
+  *dynamographdeployment*) : ;;
+  *) echo "Dynamo CRDs missing"; exit 1 ;;
+esac
+# Advisory reads: storage classes and node inventory inform sizing but a namespace-scoped
+# identity may lack cluster-scope list rights. Record a Forbidden as a run limitation; do not fail.
+kubectl --context "${KUBE_CONTEXT}" get storageclass || echo "WARN: storageclass list forbidden; record as limitation"
+kubectl --context "${KUBE_CONTEXT}" get nodes -o wide || echo "WARN: node list forbidden; record as limitation"
 ```
 
 Check secrets only by name. Never print, decode, or persist secret values.
@@ -42,14 +51,16 @@ kubectl --context "${KUBE_CONTEXT}" get pvc -n "${NAMESPACE}"
 ```
 
 Run model download and validation jobs when present. Read each Job name from its manifest's `metadata.name`; never infer
-the resource name from the filename.
+the resource name from the filename. Both the existence and the filename of these manifests are recipe-dependent — some
+recipes ship precision-suffixed download manifests, and some fold the download into the model-cache manifest — so take
+the filename from the handoff and skip the block entirely when the recipe ships no such job.
 
 ```bash
-kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/model-download.yaml" -n "${NAMESPACE}"
+kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/${DOWNLOAD_MANIFEST}" -n "${NAMESPACE}"
 # Poll the job true condition with a bounded loop (Complete -> proceed, Failed -> exit 1); a Failed job must
 # fail fast, not burn the timeout. Use the scripted poll block from deploy-dynamo-recipe SKILL.md.
 
-kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/model-validate.yaml" -n "${NAMESPACE}"
+kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/${VALIDATE_MANIFEST}" -n "${NAMESPACE}"
 # Same bounded Complete/Failed poll as the download job (60 min bound).
 ```
 
@@ -59,7 +70,7 @@ Apply the selected DGD from its run-scoped copy:
 kubectl --context "${KUBE_CONTEXT}" apply -f "${DEPLOY_ROOT}/applied_manifests/deploy.yaml" -n "${NAMESPACE}"
 kubectl --context "${KUBE_CONTEXT}" get dynamographdeployment -n "${NAMESPACE}"
 kubectl --context "${KUBE_CONTEXT}" get pods -n "${NAMESPACE}" -o wide
-kubectl get svc -n "${NAMESPACE}"
+kubectl --context "${KUBE_CONTEXT}" get svc -n "${NAMESPACE}"
 ```
 
 ## Readiness Signals

--- a/agent-docs/guides/knob-tuning/vllm.md
+++ b/agent-docs/guides/knob-tuning/vllm.md
@@ -87,13 +87,15 @@ guidance is in [`memory.md`](../model-sizing/memory.md) and [`parallelism.md`](.
 Exact API surfaces may differ by version.
 
 - **Chunked prefill** (`enable_chunked_prefill`) — splits long prefill into chunks so prefill and decode interleave.
-  Strongly recommended `true` for throughput workloads. recent vLLM versions enable it by default for standard generation; verify against the running version
-  models.
+  Strongly recommended `true` for throughput workloads. Recent vLLM versions enable it by default for standard
+  generation models; verify against the running version.
 - **`max_num_seqs`** — maximum sequences per iteration; primary throughput/latency knob, analogous to
   `max_batch_size` in TensorRT-LLM.
 - **`max_num_batched_tokens`** — maximum total tokens admitted per scheduling step, analogous to `max_num_tokens` in
-  TensorRT-LLM. Without chunked prefill, the largest prompt must fit within this budget. An approximate sizing relation
-  is `max_num_batched_tokens ≈ max_num_seqs × avg_seq_len`.
+  TensorRT-LLM. Without chunked prefill, the largest prompt must fit within this budget. This is a *per-step* budget,
+  not total KV capacity: in steady-state decode each running sequence contributes about one token per step, so the
+  budget only has to cover the decode batch plus one prefill chunk. Start in the low thousands — raise it for
+  throughput, lower it for TTFT — and size total in-flight tokens with `max_num_seqs` and `max_model_len` instead.
 - **`max_model_len`** — per-request sequence cap. Fix it to the workload maximum rather than tuning it unless GPU memory
   is tight after weights; see [`memory.md`](../model-sizing/memory.md).
 - **`gpu_memory_utilization`** — fraction of total GPU memory for weights, KV cache, and buffers, with a default of 0.9;

--- a/agent-docs/guides/knob-tuning/vllm.md
+++ b/agent-docs/guides/knob-tuning/vllm.md
@@ -94,8 +94,9 @@ Exact API surfaces may differ by version.
 - **`max_num_batched_tokens`** — maximum total tokens admitted per scheduling step, analogous to `max_num_tokens` in
   TensorRT-LLM. Without chunked prefill, the largest prompt must fit within this budget. This is a *per-step* budget,
   not total KV capacity: in steady-state decode each running sequence contributes about one token per step, so the
-  budget only has to cover the decode batch plus one prefill chunk. Start in the low thousands — raise it for
-  throughput, lower it for TTFT — and size total in-flight tokens with `max_num_seqs` and `max_model_len` instead.
+  budget only has to cover the decode batch plus one prefill chunk. Start in the low thousands — raise it to finish
+  prefill in fewer steps for throughput and TTFT, lower it to keep prefill from crowding decode for smoother
+  inter-token latency — and size total in-flight tokens with `max_num_seqs` and `max_model_len` instead.
 - **`max_model_len`** — per-request sequence cap. Fix it to the workload maximum rather than tuning it unless GPU memory
   is tight after weights; see [`memory.md`](../model-sizing/memory.md).
 - **`gpu_memory_utilization`** — fraction of total GPU memory for weights, KV cache, and buffers, with a default of 0.9;

--- a/agent-docs/guides/optimization/optimize-loop.md
+++ b/agent-docs/guides/optimization/optimize-loop.md
@@ -31,12 +31,12 @@ rules:
   - agent-docs/rules/verification/stack-verdict.md
 ---
 
+# Optimize Loop
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
-# Optimize Loop
 
 Use this workflow for an end-to-end Dynamo configuration optimization job. The baseline DGD comes from the
 interview's baseline-source ladder (`agents/user-interviewer/AGENTS.md`): supplied by the user, or a recipe or

--- a/agent-docs/guides/optimization/optimize-loop.md
+++ b/agent-docs/guides/optimization/optimize-loop.md
@@ -31,6 +31,11 @@ rules:
   - agent-docs/rules/verification/stack-verdict.md
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Optimize Loop
 
 Use this workflow for an end-to-end Dynamo configuration optimization job. The baseline DGD comes from the

--- a/agents/hypothesis-challenger/AGENTS.md
+++ b/agents/hypothesis-challenger/AGENTS.md
@@ -25,12 +25,12 @@ skills:
   - agent-docs/rules/verification/stack-verdict.md
 ---
 
+# Hypothesis Challenger
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
-# Hypothesis Challenger
 
 You are the independent adversarial reviewer between hypothesis generation and GPU spend. Assume the proposal may be
 wrong, redundant, or misleading until its evidence, diff, and risks survive review.

--- a/agents/hypothesis-challenger/AGENTS.md
+++ b/agents/hypothesis-challenger/AGENTS.md
@@ -25,6 +25,11 @@ skills:
   - agent-docs/rules/verification/stack-verdict.md
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Hypothesis Challenger
 
 You are the independent adversarial reviewer between hypothesis generation and GPU spend. Assume the proposal may be

--- a/agents/hypothesis-generator/AGENTS.md
+++ b/agents/hypothesis-generator/AGENTS.md
@@ -32,6 +32,11 @@ skills:
   - agent-docs/rules/verification/stack-verdict.md
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Hypothesis Generator
 
 You are the evidence-driven configuration hypothesis generator for the Dynamo optimization loop. You own the first

--- a/agents/hypothesis-generator/AGENTS.md
+++ b/agents/hypothesis-generator/AGENTS.md
@@ -32,12 +32,12 @@ skills:
   - agent-docs/rules/verification/stack-verdict.md
 ---
 
+# Hypothesis Generator
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
-# Hypothesis Generator
 
 You are the evidence-driven configuration hypothesis generator for the Dynamo optimization loop. You own the first
 proposal after `perf-analyzer` finishes, not its approval or execution.

--- a/agents/perf-analyzer/AGENTS.md
+++ b/agents/perf-analyzer/AGENTS.md
@@ -30,12 +30,12 @@ skills:
   - agent-docs/rules/verification/stack-verdict.md
 ---
 
+# Perf Analyzer
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
-# Perf Analyzer
 
 You own the complete AIPerf lifecycle for one already-deployed candidate. The candidate must have a successful
 `<DEPLOY_ROOT>/smoke_test_artifact.json`, a complete deployment ledger, and durable config-engagement evidence before

--- a/agents/perf-analyzer/AGENTS.md
+++ b/agents/perf-analyzer/AGENTS.md
@@ -30,6 +30,11 @@ skills:
   - agent-docs/rules/verification/stack-verdict.md
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Perf Analyzer
 
 You own the complete AIPerf lifecycle for one already-deployed candidate. The candidate must have a successful

--- a/agents/recipe-deployer/AGENTS.md
+++ b/agents/recipe-deployer/AGENTS.md
@@ -20,12 +20,12 @@ skills:
   - agent-docs/rules/verification/config-engagement.md
 ---
 
+# Recipe Deployer
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
-# Recipe Deployer
 
 You are the mechanical deployer for one assigned Dynamo Kubernetes DGD.
 

--- a/agents/recipe-deployer/AGENTS.md
+++ b/agents/recipe-deployer/AGENTS.md
@@ -20,6 +20,11 @@ skills:
   - agent-docs/rules/verification/config-engagement.md
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Recipe Deployer
 
 You are the mechanical deployer for one assigned Dynamo Kubernetes DGD.

--- a/agents/user-interviewer/AGENTS.md
+++ b/agents/user-interviewer/AGENTS.md
@@ -16,6 +16,11 @@ skills:
   - agent-docs/rules/execution/user-workload.md
 ---
 
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # User Interviewer
 
 You are the first specialized role for every new Dynamo recipe optimization run. Receive the user's initial message

--- a/agents/user-interviewer/AGENTS.md
+++ b/agents/user-interviewer/AGENTS.md
@@ -16,12 +16,12 @@ skills:
   - agent-docs/rules/execution/user-workload.md
 ---
 
+# User Interviewer
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
-# User Interviewer
 
 You are the first specialized role for every new Dynamo recipe optimization run. Receive the user's initial message
 before deployment, benchmarking, or hypothesis work begins.

--- a/docs/fern/pages/agent-skills/overview.mdx
+++ b/docs/fern/pages/agent-skills/overview.mdx
@@ -34,9 +34,9 @@ deploys; the agent asks if you don't state them). The final handoff includes the
 configuration, reproduction commands, limitations, and preserved raw evidence.
 
 The workflow spine is documented in
-[`agent-docs/guides/optimization/optimize-loop.md`](https://github.com/ai-dynamo/dynamo/blob/3e522d8ef0b4b96ae75126c1f5e7c71ae6923dcf/agent-docs/guides/optimization/optimize-loop.md),
+[`agent-docs/guides/optimization/optimize-loop.md`](https://github.com/ai-dynamo/dynamo/blob/main/agent-docs/guides/optimization/optimize-loop.md),
 with benchmark-validity and evidence rules under
-[`agent-docs/rules/`](https://github.com/ai-dynamo/dynamo/tree/3e522d8ef0b4b96ae75126c1f5e7c71ae6923dcf/agent-docs/rules).
+[`agent-docs/rules/`](https://github.com/ai-dynamo/dynamo/tree/main/agent-docs/rules).
 Harnesses that support isolated sub-agents (Codex) run the loop's roles as separate agents;
 other harnesses run the same roles in one agent.
 

--- a/docs/fern/pages/agent-skills/overview.mdx
+++ b/docs/fern/pages/agent-skills/overview.mdx
@@ -34,9 +34,9 @@ deploys; the agent asks if you don't state them). The final handoff includes the
 configuration, reproduction commands, limitations, and preserved raw evidence.
 
 The workflow spine is documented in
-[`agent-docs/guides/optimization/optimize-loop.md`](https://github.com/ai-dynamo/dynamo/blob/main/agent-docs/guides/optimization/optimize-loop.md),
+[`agent-docs/guides/optimization/optimize-loop.md`](https://github.com/ai-dynamo/dynamo/blob/3e522d8ef0b4b96ae75126c1f5e7c71ae6923dcf/agent-docs/guides/optimization/optimize-loop.md),
 with benchmark-validity and evidence rules under
-[`agent-docs/rules/`](https://github.com/ai-dynamo/dynamo/tree/main/agent-docs/rules).
+[`agent-docs/rules/`](https://github.com/ai-dynamo/dynamo/tree/3e522d8ef0b4b96ae75126c1f5e7c71ae6923dcf/agent-docs/rules).
 Harnesses that support isolated sub-agents (Codex) run the loop's roles as separate agents;
 other harnesses run the same roles in one agent.
 

--- a/docs/fern/pages/recipes/feature-benchmarks/agentic-coding-throughput-stack-kimi-k2-5.mdx
+++ b/docs/fern/pages/recipes/feature-benchmarks/agentic-coding-throughput-stack-kimi-k2-5.mdx
@@ -19,13 +19,18 @@ Four configurations run Dynamo + TensorRT-LLM on 6x GB200 nodes (24 GPUs, MNNVL)
 <span><b>Model</b> nvidia/Kimi-K2.5-NVFP4</span>
 <span><b>GPUs</b> 24x GB200 (6 nodes, MNNVL)</span>
 <span><b>Runtime</b> TensorRT-LLM</span>
-<span><b>Workload</b> Mooncake-style agentic coding trace (~200K-token context, multi-turn), one-hour replay</span>
+<span><b>Workload</b> Mooncake-style agentic coding trace (~200K-token context, multi-turn), 30-minute replay</span>
 <span><b>Metrics</b> tok/s/user, tok/s/GPU, goodput at TTFT 5s / ITL 10ms</span>
 <span><b>Held constant</b> Model, runtime, GPU count, trace, duration, and goodput thresholds across all configurations</span>
 </div>
 </div>
 
 ## Results
+
+<Warning>
+The values below come from the earlier one-hour qualification. The current manifests cap each measured run at 30
+minutes, so these numbers require requalification before they can be treated as expected 30-minute results.
+</Warning>
 
 The disaggregated configuration with KV-aware routing, Eagle3 decoding, and KV offloading achieves the best system throughput and interactivity. Each row is that configuration's chosen operating point on the source Pareto plot — concurrency differs by row and the values are approximate plot readings, so read them as per-configuration operating points rather than an equal-load sweep:
 
@@ -81,7 +86,7 @@ aiperf profile -m nvidia/Kimi-K2.5-NVFP4 \
   --url http://<frontend>:8000 \
   --streaming --extra-inputs ignore_eos:true \
   --concurrency <8|24|32> --random-seed 42 \
-  --benchmark-duration 3600 --concurrency-ramp-duration 60 \
+  --benchmark-duration 1800 --concurrency-ramp-duration 60 \
   --goodput "time_to_first_token:5000 inter_token_latency:10"
 ```
 


### PR DESCRIPTION
## Summary

Post-merge follow-up to #13557. That PR added the performance optimization skill pack; a review after merge ([review](https://github.com/ai-dynamo/dynamo/pull/13557#pullrequestreview-4993850577)) surfaced 13 findings. This PR fixes only the ones with an unambiguous mechanical correction. The four that need an author decision on intent, and the two stale Sigstore bundles, are deliberately left out and tracked below.

Linear: OPS-8324

### Fixed

| Finding | Fix |
|---|---|
| `kubernetes-recipe-workflow.md` reverts the RBAC hardening from #13557's own final commit `7e14ea4` | Adopt the tolerant CRD gate from `deploy-dynamo-recipe/SKILL.md:84-95`. The guide kept `get crd \| grep -i dynamo \|\| exit 1`, so a namespace-scoped identity aborted with a false `Dynamo CRDs missing`; `get storageclass` / `get nodes` are advisory here now too |
| One `kubectl get svc` in the same guide omits `--context` | Pin it, per the invariant `deploy-dynamo-recipe/SKILL.md:98` states |
| `deploy-dynamo-recipe/SKILL.md` unconditionally applies `model-download.yaml` under `set -euo pipefail` | `recipes/deepseek-v4/{flash,pro}` ship `model-download-fp8.yaml` / `model-download-nvfp4.yaml`, so the literal path never resolved and aborted the whole deployment. Download and validate manifests are now both optional and named from the handoff |
| `agent-skills/overview.mdx` links pinned to `3e522d8e` | #13557 was squash-merged, so that SHA is not an ancestor of `main` — a dangling object that also predates the branch's own hardening commits. The paths resolve on `main` now, which is the reason the pin existed |
| kimi-k2.5 feature-benchmark page still documents the old duration | #13557 moved `BENCHMARK_DURATION` 3600 → 1800 in all four `perf.yaml` files and added a requalification caveat to the recipe README, but not to the published page. Sync the workload line and the `aiperf` command, and carry the caveat over |
| `vllm.md` sizing relation `max_num_batched_tokens ≈ max_num_seqs × avg_seq_len` | Conflates the per-step token budget with total KV capacity — ~1M batched tokens at 256×4096, exactly the oversized budget the neighbouring bullet warns will OOM or hurt TTFT. Replaced with per-step guidance. Also repairs a garbled sentence in the chunked-prefill bullet |
| SPDX header missing on 15 files #13557 added | Added, placed after the frontmatter as the other skills do |

### Deliberately not fixed here

Left open on the #13557 thread because they need the author's call, not a mechanical edit:

- ~~`concurrency-grid.md:17`~~ — **already fixed in #13625** by `feab9402c9`, ~10 hours before my review. The author kept the AT MOST 4x cap, corrected the example to 16, and added a `>= concurrency` floor — the opposite resolution from the one I inferred, and a better one. Nothing needed here.
- `run-aiperf-benchmark` / `run-artifacts.md` — fixed artifact paths plus a never-overwrite rule plus mandatory n=3 repeats in one `DEPLOY_ROOT` is unsatisfiable. Needs a per-run layout decision that spans both files.
- `optimize-loop.md:193` — GPU-hours derived from benchmark duration alone, excluding the download/validate/readiness window the GPUs are held for, so `BUDGET_STOP` under-counts. The fix needs new timestamps in `deployment_ledger.json`.
- `parallelism.md:45` — "no need to benchmark multiple replicas" authorizes the unmeasured fleet projection `comparison-uncertainty.md` forbids.
- `dynamo-router-starter` and `dynamo-interconnect-check` `skill.oms.sig` — both bundles now fail verification (3 and 2 digest mismatches). These are the only two signed skills in the repo; re-signing needs a maintainer `/nvskills-ci` run.
- `${DEPLOY_ROOT}/smoke/` is an artifact directory `run-artifacts.md` neither declares nor permits.

## Validation

Docs and agent-instruction files only — no runtime code paths change.

- `pre-commit run --files <the 19 changed files>` — all applicable hooks pass (`codespell`, `check-yaml`, `trim trailing whitespace`, `mixed line ending`, `Check docs asset paths are ones Fern rewrites`, `Validate .agents/skills SKILL.md frontmatter and AGENTS.md index`)
- `python scripts/validate_skills.py` — `validated 25 skills: OK`
- Every claim above re-verified against `origin/main` at `d91b99c` rather than the PR diff: `recipes/deepseek-v4/*/model-cache/` file listings, the squash-merge parentage of `341f9ac`, and the decoded per-file digests in both `skill.oms.sig` DSSE payloads
- Admonition syntax follows the style guide (Fern `<Warning>` in `.mdx`)
- SPDX placement follows the `SKILL.md` convention: the block sits below the H1, as in all 15 skills that already carry one. (For a `.md` with frontmatter the repo has two forms and neither can be at line 1, since the frontmatter opens there: 217 files — essentially all of `docs/fern/` — put it inside the frontmatter as `#` YAML comments, and 15 put it below the H1. These are agent-instruction files, not Fern pages. Neither form is CI-enforced: `.md` is in `ignored_types` in `.github/workflows/copyright-check.ps1`, which makes that script's own `.md` matcher unreachable.)

Note: `.agents/skills/` changes need a maintainer `/nvskills-ci` comment, and full CI needs `/ok to test <sha>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added licensing and copyright notices across guides, skills, agent documentation, and issue templates.
  - Updated Kubernetes deployment guidance to support recipe-specific manifests, restricted cluster permissions, and consistent context selection.
  - Refined vLLM tuning guidance for chunked prefill and batching budgets.
  - Updated optimization links to follow the main documentation branch.
  - Revised the Kimi benchmark example to use a 30-minute replay and clarify result requalification requirements.

- **Bug Fixes**
  - Improved deployment handling when optional manifests or cluster metadata are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

