### PR TITLE
feat(agent): normalize DeepSeek Harness metadata

### DIFF
--- a/lib/llm/src/protocols/agents.rs
+++ b/lib/llm/src/protocols/agents.rs
@@ -14,6 +14,8 @@ pub(crate) const HEADER_CLAUDE_CODE_PARENT_AGENT_ID: &str = "x-claude-code-paren
 pub(crate) const HEADER_CODEX_THREAD_ID: &str = "thread-id";
 pub(crate) const HEADER_CODEX_PARENT_THREAD_ID: &str = "x-codex-parent-thread-id";
 pub(crate) const HEADER_CODEX_TURN_METADATA: &str = "x-codex-turn-metadata";
+pub(crate) const HEADER_DEEPSEEK_HARNESS_SESSION_ID: &str = "x-deepseek-harness-session-id";
+pub(crate) const HEADER_DEEPSEEK_HARNESS_COMPACT: &str = "x-deepseek-harness-compact";
 pub(crate) const HEADER_OPENCODE_SESSION_ID: &str = "x-session-id";
 pub(crate) const HEADER_OPENCODE_PARENT_SESSION_ID: &str = "x-parent-session-id";
 pub(crate) const HEADER_DYNAMO_SESSION_ID: &str = "x-dynamo-session-id";
@@ -39,6 +41,12 @@ const AGENT_HEADER_MAPPINGS: &[AgentHeaderMapping] = &[
         root_session_header: HEADER_CODEX_THREAD_ID,
         child_session_header: None,
         parent_session_header: Some(HEADER_CODEX_PARENT_THREAD_ID),
+        infer_parent_from_session_for_child: false,
+    },
+    AgentHeaderMapping {
+        root_session_header: HEADER_DEEPSEEK_HARNESS_SESSION_ID,
+        child_session_header: None,
+        parent_session_header: None,
         infer_parent_from_session_for_child: false,
     },
     AgentHeaderMapping {
@@ -70,8 +78,6 @@ fn borrowed_header_value<'a>(headers: &'a HeaderMap, header_name: &str) -> Optio
 
 pub(crate) fn agent_context_header_values(headers: &HeaderMap) -> Option<AgentContextHeaderValues> {
     let session_final = header_bool(headers, HEADER_DYNAMO_SESSION_FINAL);
-    let compaction = borrowed_header_value(headers, HEADER_CODEX_THREAD_ID)
-        .and_then(|_| codex_compaction_header_value(headers));
 
     if let Some(session_id) = borrowed_header_value(headers, HEADER_DYNAMO_SESSION_ID) {
         return Some(AgentContextHeaderValues {
@@ -80,7 +86,8 @@ pub(crate) fn agent_context_header_values(headers: &HeaderMap) -> Option<AgentCo
                 .map(str::to_owned),
             session_id: session_id.to_owned(),
             session_final,
-            compaction,
+            compaction: borrowed_header_value(headers, HEADER_CODEX_THREAD_ID)
+                .and_then(|_| codex_compaction_header_value(headers)),
         });
     }
 
@@ -109,7 +116,11 @@ pub(crate) fn agent_context_header_values(headers: &HeaderMap) -> Option<AgentCo
             session_id: session_id.to_owned(),
             parent_session_id,
             session_final,
-            compaction,
+            compaction: match mapping.root_session_header {
+                HEADER_CODEX_THREAD_ID => codex_compaction_header_value(headers),
+                HEADER_DEEPSEEK_HARNESS_SESSION_ID => deepseek_compaction_header_value(headers),
+                _ => None,
+            },
         });
     }
     None
@@ -120,6 +131,12 @@ fn codex_compaction_header_value(headers: &HeaderMap) -> Option<AgentCompaction>
     let metadata: CodexTurnMetadata = serde_json::from_str(raw).ok()?;
     (metadata.request_kind.as_deref() == Some("compaction"))
         .then(|| metadata.compaction.unwrap_or_default())
+}
+
+fn deepseek_compaction_header_value(headers: &HeaderMap) -> Option<AgentCompaction> {
+    borrowed_header_value(headers, HEADER_DEEPSEEK_HARNESS_SESSION_ID)?;
+    (borrowed_header_value(headers, HEADER_DEEPSEEK_HARNESS_COMPACT) == Some("1"))
+        .then(AgentCompaction::default)
 }
 
 pub(crate) fn session_affinity_header_value(headers: &HeaderMap) -> Option<String> {

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -860,8 +860,10 @@ mod tests {
     use crate::protocols::agents::{
         HEADER_CLAUDE_CODE_AGENT_ID, HEADER_CLAUDE_CODE_PARENT_AGENT_ID,
         HEADER_CLAUDE_CODE_SESSION_ID, HEADER_CODEX_PARENT_THREAD_ID, HEADER_CODEX_THREAD_ID,
-        HEADER_CODEX_TURN_METADATA, HEADER_DYNAMO_PARENT_SESSION_ID, HEADER_DYNAMO_SESSION_FINAL,
-        HEADER_DYNAMO_SESSION_ID, HEADER_OPENCODE_PARENT_SESSION_ID, HEADER_OPENCODE_SESSION_ID,
+        HEADER_CODEX_TURN_METADATA, HEADER_DEEPSEEK_HARNESS_COMPACT,
+        HEADER_DEEPSEEK_HARNESS_SESSION_ID, HEADER_DYNAMO_PARENT_SESSION_ID,
+        HEADER_DYNAMO_SESSION_FINAL, HEADER_DYNAMO_SESSION_ID, HEADER_OPENCODE_PARENT_SESSION_ID,
+        HEADER_OPENCODE_SESSION_ID,
     };
 
     #[derive(Default)]
@@ -1259,6 +1261,7 @@ mod tests {
         let cases = [
             (HEADER_CLAUDE_CODE_SESSION_ID, "claude-run-1", None, None),
             (HEADER_CODEX_THREAD_ID, "codex-root", None, None),
+            (HEADER_DEEPSEEK_HARNESS_SESSION_ID, "dsh-run-1", None, None),
             (
                 HEADER_OPENCODE_SESSION_ID,
                 "opencode-run-1",
@@ -1355,6 +1358,74 @@ mod tests {
     }
 
     #[test]
+    fn agent_context_from_deepseek_harness_headers_preserves_compaction() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HEADER_DEEPSEEK_HARNESS_SESSION_ID,
+            "dsh-session".parse().unwrap(),
+        );
+        headers.insert(HEADER_DEEPSEEK_HARNESS_COMPACT, "1".parse().unwrap());
+
+        let agent_context = agent_context_from_headers(&headers).unwrap();
+        assert_eq!(agent_context.session_id, "dsh-session");
+        assert_eq!(agent_context.parent_session_id, None);
+        assert_eq!(agent_context.compaction, Some(AgentCompaction::default()));
+        assert_eq!(
+            session_affinity_from_headers(&headers).unwrap().as_str(),
+            "dsh-session"
+        );
+
+        headers.insert(HEADER_DEEPSEEK_HARNESS_COMPACT, "0".parse().unwrap());
+        assert_eq!(
+            agent_context_from_headers(&headers).unwrap().compaction,
+            None
+        );
+    }
+
+    #[test]
+    fn deepseek_compaction_requires_selected_deepseek_identity() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HEADER_DEEPSEEK_HARNESS_SESSION_ID,
+            "dsh-session".parse().unwrap(),
+        );
+        headers.insert(HEADER_DEEPSEEK_HARNESS_COMPACT, "1".parse().unwrap());
+
+        headers.insert(HEADER_DYNAMO_SESSION_ID, "canonical".parse().unwrap());
+        let canonical_context = agent_context_from_headers(&headers).unwrap();
+        assert_eq!(canonical_context.session_id, "canonical");
+        assert_eq!(canonical_context.compaction, None);
+
+        headers.remove(HEADER_DYNAMO_SESSION_ID);
+        headers.insert(HEADER_CODEX_THREAD_ID, "codex-thread".parse().unwrap());
+        headers.insert(
+            HEADER_CODEX_TURN_METADATA,
+            r#"{"request_kind":"compaction","compaction":{"strategy":"memento"}}"#
+                .parse()
+                .unwrap(),
+        );
+        let codex_context = agent_context_from_headers(&headers).unwrap();
+        assert_eq!(codex_context.session_id, "codex-thread");
+        assert_eq!(
+            codex_context
+                .compaction
+                .and_then(|compaction| compaction.strategy)
+                .as_deref(),
+            Some("memento")
+        );
+
+        headers.remove(HEADER_CODEX_THREAD_ID);
+        headers.remove(HEADER_CODEX_TURN_METADATA);
+        headers.insert(
+            HEADER_CLAUDE_CODE_SESSION_ID,
+            "claude-session".parse().unwrap(),
+        );
+        let claude_context = agent_context_from_headers(&headers).unwrap();
+        assert_eq!(claude_context.session_id, "claude-session");
+        assert_eq!(claude_context.compaction, None);
+    }
+
+    #[test]
     fn agent_context_from_codex_thread_headers_preserves_subagent_lineage() {
         let mut headers = HeaderMap::new();
         headers.insert(HEADER_CODEX_THREAD_ID, "codex-child".parse().unwrap());
@@ -1411,6 +1482,10 @@ mod tests {
             "claude-session".parse().unwrap(),
         );
         headers.insert(HEADER_CODEX_THREAD_ID, "codex-thread".parse().unwrap());
+        headers.insert(
+            HEADER_DEEPSEEK_HARNESS_SESSION_ID,
+            "dsh-session".parse().unwrap(),
+        );
         headers.insert(
             HEADER_OPENCODE_SESSION_ID,
             "opencode-session".parse().unwrap(),


### PR DESCRIPTION
## Summary

- Normalizes native DeepSeek Harness session and compaction headers into Dynamo agent context.
- Keeps this server-side enhancement independent from the DeepSeek onboarding guide.
- Does not require or contain a DeepSeek Harness source patch.

## Scope boundary

This PR improves routing and observability metadata. It is not required for DeepSeek Harness to connect to Dynamo, call tools, persist its own session artifacts, or run the Web UI. The native guide in #13632 therefore does not depend on this PR.

## Validation

`cargo test -p dynamo-llm --no-default-features agent_context_from_deepseek_harness_headers_preserves_compaction`: 1 passed, 0 failed.