### PR TITLE
refactor(router): resolve the encoder CUDA-to-CPU ratio once

### DIFF
--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -281,6 +281,38 @@ fn p2c_select_from(occupancy_state: &RoutingOccupancyState, instance_ids: &[u64]
         .worker_id
 }
 
+/// Ratio of accelerator to CPU capacity used when weighting device-aware
+/// routing candidates.
+const DEFAULT_ENCODER_CUDA_TO_CPU_RATIO: usize = 8;
+
+static ENCODER_CUDA_TO_CPU_RATIO: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+/// Read the encoder accelerator-to-CPU ratio once and share it across the
+/// device-aware routing paths.
+///
+/// Both callers sit on the per-request routing path, so reading the variable
+/// there charged every routed request a `std::env::var` lookup and the `String`
+/// it allocates. Resolving once also removes the second copy of this parsing,
+/// which had to be kept in step with the first by hand.
+fn encoder_cuda_to_cpu_ratio() -> usize {
+    *ENCODER_CUDA_TO_CPU_RATIO.get_or_init(|| {
+        parse_encoder_cuda_to_cpu_ratio(
+            std::env::var("DYN_ENCODER_CUDA_TO_CPU_RATIO")
+                .ok()
+                .as_deref(),
+        )
+    })
+}
+
+/// Split out from the environment read so the parsing contract can be tested
+/// without mutating process state, which would race the `OnceLock` above.
+fn parse_encoder_cuda_to_cpu_ratio(value: Option<&str>) -> usize {
+    value
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value >= 1)
+        .unwrap_or(DEFAULT_ENCODER_CUDA_TO_CPU_RATIO)
+}
+
 /// At most one `list_and_watch` per endpoint, across all `PushRouter`
 /// instances. Entry removed on watcher exit so a later router can re-arm.
 static ENDPOINT_WATCHER_ACTIVE: std::sync::OnceLock<dashmap::DashMap<EndpointId, ()>> =
@@ -1080,11 +1112,7 @@ where
                 (instance.instance_id, device)
             })
             .collect::<HashMap<_, _>>();
-        let cuda_to_cpu_ratio = std::env::var("DYN_ENCODER_CUDA_TO_CPU_RATIO")
-            .ok()
-            .and_then(|value| value.parse::<usize>().ok())
-            .filter(|value| *value >= 1)
-            .unwrap_or(8);
+        let cuda_to_cpu_ratio = encoder_cuda_to_cpu_ratio();
 
         let (request_cache_keys, cache_matched_candidates) =
             if let (Some(indexer), Some(extractor)) = (
@@ -1244,11 +1272,7 @@ where
                     .iter()
                     .map(|instance| (instance.instance_id, instance.device_type.clone()))
                     .collect();
-                let cuda_to_cpu_ratio = std::env::var("DYN_ENCODER_CUDA_TO_CPU_RATIO")
-                    .ok()
-                    .and_then(|value| value.parse::<usize>().ok())
-                    .filter(|value| *value >= 1)
-                    .unwrap_or(8);
+                let cuda_to_cpu_ratio = encoder_cuda_to_cpu_ratio();
                 let candidates = instance_ids
                     .iter()
                     .map(|worker_id| RouteCandidate {
@@ -1837,6 +1861,26 @@ impl<U: Data + MaybeError> crate::engine::AsyncEngineStream<U> for OccupancyTrac
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn encoder_cuda_to_cpu_ratio_parsing_matches_the_previous_inline_copies() {
+        // Pins the contract the two former inline copies shared, so the default
+        // and the >= 1 floor cannot drift now that there is a single owner.
+        assert_eq!(parse_encoder_cuda_to_cpu_ratio(Some("4")), 4);
+        assert_eq!(parse_encoder_cuda_to_cpu_ratio(Some("1")), 1);
+        assert_eq!(
+            parse_encoder_cuda_to_cpu_ratio(None),
+            DEFAULT_ENCODER_CUDA_TO_CPU_RATIO
+        );
+        // Zero, negatives and junk all fall back rather than disabling the ratio.
+        for rejected in ["0", "-1", "", "eight", "2.5"] {
+            assert_eq!(
+                parse_encoder_cuda_to_cpu_ratio(Some(rejected)),
+                DEFAULT_ENCODER_CUDA_TO_CPU_RATIO,
+                "{rejected:?} should fall back to the default"
+            );
+        }
+    }
     use super::*;
     use crate::{
         DistributedRuntime, Runtime,


### PR DESCRIPTION
## Summary

Addresses #12116.

`push_router.rs` read `DYN_ENCODER_CUDA_TO_CPU_RATIO` in two places with byte-identical parsing: once in `device_aware_candidates`, once in the `DeviceAwareWeighted` arm of the worker selector.

The issue frames this as duplication, and it is, but the part that made it worth fixing is where the duplication sits. Both call sites are on the per-request routing path, so every routed request paid for a `std::env::var` lookup and the `String` it allocates in order to re-derive a value that cannot change during the process lifetime. The drift hazard is real too: the default, the `>= 1` floor and the variable name each existed twice, with nothing in either copy pointing at the other.

Resolved once behind a `OnceLock`.

### One deliberate deviation from the proposed solution

The issue suggests adding `non_cpu_to_cpu_ratio` to `RouterConfig` and its PyO3 binding, keeping the environment variable as a fallback. I did not do that, and I want to be explicit about why rather than quietly shipping something different.

This crate already has an idiom for exactly this: a named default, a `OnceLock`, and one accessor. `get_tcp_max_message_size` in `pipeline/network.rs` and `RequestPlanePayloadCodec::configured` are the closest matches, and there are five of these statics in the runtime crate. Following it keeps the diff at one file and adds no public API surface, where the `RouterConfig` route means a new struct field, a new binding, and a precedence rule between field and environment variable to document and test.

What that trades away is the second half of the issue's motivation: with a `OnceLock` the value still is not part of `RouterConfig`, so it still cannot be set programmatically per router. If you want that, it is a different and larger change, and I am happy to do it instead. I did not want to add public configuration surface on my own judgement when the smaller fix removes the concrete problems the issue opens with.

The parsing is split into `parse_encoder_cuda_to_cpu_ratio` so the contract can be tested without mutating process state, which would race the `OnceLock`. That split mirrors `RequestPlanePayloadCodec::from_config_value` in the same crate.

## Validation

No behaviour change is intended. The environment variable, the default of 8 and the `>= 1` floor all keep their current meaning, and the new parse function is the old expression with the `std::env::var` call lifted out.

- `cargo test -p dynamo-runtime --lib push_router` is 38 passed, 0 failed.
- Full crate with a live NATS (JetStream) and etcd: `cargo test -p dynamo-runtime --lib --features integration` is 634 passed, 0 failed, 2 ignored.
- `cargo clippy -p dynamo-runtime --lib --all-targets --features integration` clean, `cargo fmt` clean.

On the added test, stated plainly: it pins the parsing contract, it is not a regression test, and it cannot be red against the current tree because it is asserting behaviour this change preserves rather than behaviour it introduces. Its value is that the default and the floor now have exactly one owner and a test that fails if either drifts. The issue asked for coverage of the floor and the fallback, so the cases are there, including `0`, a negative, empty and non-numeric input.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the CUDA-to-CPU encoder ratio.
  * Uses a default ratio of 8 when no configuration is provided.
  * Rejects invalid values and values below 1.

* **Bug Fixes**
  * Improved device-aware candidate selection and worker allocation using the configured ratio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->