### PR TITLE
fix(deps): pin cupy to cuda13x and enforce the CUDA major (OPS-8336)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ sglang = [
     "accelerate>=0.17.0",
     "blake3>=1.0.0,<2.0.0",
     "nixl[cu13]==1.3.2",
-    "cupy-cuda12x>=13.0.0",
+    "cupy-cuda13x>=13.6.0",
 ]
 
 mocker = [
@@ -344,6 +344,7 @@ markers = [
     "trtllm: marks tests as requiring trtllm",
     "sglang: marks tests as requiring sglang",
     "lmcache: marks tests as requiring lmcache",
+    "framework_agnostic: marks tests that inspect the container image itself; they carry framework markers for CI selection but need no framework module installed",
     "multimodal: marks tests as multimodal (image/video) tests",
     "slow: marks tests as known to be slow",
     "h100: marks tests to run on H100",

--- a/tests/basic/test_cuda_version_consistency.py
+++ b/tests/basic/test_cuda_version_consistency.py
@@ -209,8 +209,11 @@ def test_cuda_version_consistency() -> None:
         if len(lines) > MAX_REPORTED_LINES:
             report.append(f"        ... ({len(lines) - MAX_REPORTED_LINES} more lines)")
 
-    if not detected and not excused:
-        pytest.skip("No CUDA version detected from any signal.")
+    # Excused packages are tolerated noise, not evidence that the scan worked:
+    # an image whose only CUDA signal is an exception entry has told us nothing
+    # about the major it ships, so treat it as unevaluable rather than green.
+    if not detected:
+        pytest.skip("No non-excused CUDA version detected from any signal.")
 
     violations: list[str] = []
     for label, line, (major, minor) in detected:

--- a/tests/basic/test_cuda_version_consistency.py
+++ b/tests/basic/test_cuda_version_consistency.py
@@ -1,14 +1,23 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Integration test to check CUDA major version consistency across various packages."""
+"""Integration test to check CUDA version consistency across various packages.
+
+Every CUDA signal readable from a running container -- environment variables,
+nvcc, dpkg packages, pip distributions -- must report the CUDA major this
+repository ships. Asserting against a fixed expected major (rather than merely
+asserting the signals agree with each other) catches both a mix of majors
+within one image and a stray wheel built for a major we no longer support.
+"""
 
 import re
 import subprocess
 
 import pytest
 
-# Mark this with every framework to test every container
+# Mark this with every framework to test every container. framework_agnostic
+# stops tests/conftest.py from skipping it in containers that ship only one of
+# them: this test reads the image itself and imports no framework module.
 pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.integration,
@@ -19,10 +28,64 @@ pytestmark = [
     pytest.mark.trtllm,
     pytest.mark.vllm,
     pytest.mark.core,
+    pytest.mark.framework_agnostic,
 ]
 
-# Easy to edit later:
-IGNORE_PIP_PREFIXES = ("cupy", "nixl")
+# The CUDA major every signal must report. Bump this when the images migrate to
+# the next major; the scan patterns and the assertion both derive from it.
+EXPECTED_MAJOR = 13
+
+# Majors the scanner recognizes. Keep majors we have already left behind, so a
+# stray package is reported rather than silently unmatched, and add the next one
+# ahead of a migration.
+RECOGNIZED_MAJORS = (12, 13, 14)
+
+# Optional floor as (major, minor), applied to every signal that carries a minor
+# version. Set to (13, 1) to require CUDA >= 13.1 image-wide. None checks the
+# major only.
+MIN_VERSION: tuple[int, int] | None = None
+
+# pip distributions permitted to report a major other than EXPECTED_MAJOR, keyed
+# by exact distribution name and carrying the reason it cannot be removed.
+#
+# Exact names, never prefixes: the prefix list this replaced ignored "cupy" and
+# "nixl" wholesale, which hid a cupy-cuda12x pin in pyproject.toml and every
+# nixl-cu12 wheel. An entry here means "upstream forces this on us", so it needs
+# a reason; it does not mean "this package is uninteresting".
+PIP_MAJOR_EXCEPTIONS = {
+    # nvidia-cutlass-dsl requires nvidia-cutlass-dsl-libs-cu12 unconditionally
+    # and puts only the cu13 libs behind an extra, so the cu12 wheel always
+    # lands alongside it.
+    "nvidia-cutlass-dsl-libs-cu12": "unconditional dependency of nvidia-cutlass-dsl",
+    # The nixl meta package requires both nixl-cu12 and nixl-cu13
+    # unconditionally; nixl[cu13] narrows nothing.
+    "nixl-cu12": "unconditional dependency of the nixl meta package",
+}
+
+_MAJORS = "|".join(str(m) for m in RECOGNIZED_MAJORS)
+
+# Group 1 is the CUDA major; group 2, where the signal carries one, is the minor.
+# fmt: off
+PATTERNS = [
+    rf"\bCUDA_VERSION=({_MAJORS})\.(\d+)",             # CUDA_VERSION=13.0.2
+    rf"\bNV_CUDA_.*?_VERSION=({_MAJORS})\.(\d+)",      # NV_CUDA_CUDART_VERSION=13.0.96-1
+    rf"\+cuda({_MAJORS})\.(\d+)",                      # ...+cuda13.0
+    rf"\bcuda\s*>=\s*({_MAJORS})\.(\d+)",              # cuda>=13.0 ...
+    rf"\brelease\s+({_MAJORS})\.(\d+)",                # nvcc: release 13.0
+    rf"-({_MAJORS})-(\d)\b",                           # dpkg: ...-13-0
+    rf"\bcuda({_MAJORS})x\b",                          # cupy-cuda13x (from name)
+    rf"[-+]cu({_MAJORS})(\d)?",                        # -cu13, +cu130
+    rf"\bcuda({_MAJORS})(\d)?\b",                      # ...-cuda13, nvidia-dali-cuda130
+    rf"^(?:nvidia-)?cuda[\w-]*==({_MAJORS})\.(\d+)",   # cuda-toolkit==13.0.2
+]
+# fmt: on
+
+# Targeted pip listing: anything whose name or version could carry a CUDA major.
+PIP_LIST_CMD = (
+    "python -m pip list --format=freeze | grep -Ei "
+    rf"'(cuda|cudnn|nccl|nvshmem|\+cu({_MAJORS})[0-9]{{1,2}}|-cu({_MAJORS})|"
+    r"^(torch|torchaudio|torchvision)==)'"
+)
 
 
 def sh(cmd: str) -> str:
@@ -39,52 +102,44 @@ def sh(cmd: str) -> str:
     return (p.stdout or "").strip()
 
 
-def major_from_text(text: str) -> int | None:
-    """Extract CUDA major (12 or 13) from arbitrary text; otherwise None."""
+def cuda_version_from_text(text: str) -> tuple[int, int | None] | None:
+    """
+    Extract a CUDA (major, minor) from arbitrary text. minor is None when the
+    signal carries only a major (e.g. a '-cu13' wheel tag). Returns None when no
+    recognized CUDA version is present.
+    """
     if not text:
         return None
 
-    # fmt: off
-    pats = [
-        r"\bCUDA_VERSION=(1[23])\.",          # CUDA_VERSION=13.0.2
-        r"\bNV_CUDA_.*?_VERSION=(1[23])\.",   # NV_CUDA_CUDART_VERSION=13.0...
-        r"\+cuda(1[23])\.",                   # ...+cuda13.0
-        r"\bcuda\s*>=\s*(1[23])\.",           # cuda>=13.0 ...
-        r"\brelease\s+(1[23])\.",             # nvcc: release 13.0
-        r"-(1[23])-\d\b",                     # dpkg: ...-13-0
-        r"\bcuda(1[23])x\b",                  # cupy-cuda12x (from name)
-        r"[-+]cu(1[23])",                     # -cu13 or +cu13 in name
-    ]
-    # fmt: on
-    for pat in pats:
+    for pat in PATTERNS:
         m = re.search(pat, text, flags=re.IGNORECASE)
-        if m:
-            maj = int(m.group(1))
-            if maj in (12, 13):
-                return maj
+        if m is None:
+            continue
+        minor = None
+        if m.re.groups >= 2 and m.group(2) is not None:
+            minor = int(m.group(2))
+        return int(m.group(1)), minor
     return None
 
 
-def pip_cuda_major_from_line(line: str) -> int | None:
-    """
-    Given a pip freeze line like 'torch==2.9.0+cu130', infer CUDA major.
-    Returns 12/13 or None.
-    """
-    return major_from_text(line)
+def pip_distribution_name(line: str) -> str:
+    """Distribution name from a pip freeze line, e.g. 'nixl-cu12==1.3.1'."""
+    return line.split("==", 1)[0].strip().lower()
 
 
-def keep_pip_line(line: str) -> bool:
-    """
-    Ignore some packages from pip signal (editable allow/ignore policy).
-    """
-    name = line.split("==", 1)[0].strip().lower()
-    return not name.startswith(IGNORE_PIP_PREFIXES)
+def format_version(version: tuple[int, int | None] | None) -> str:
+    """Render a parsed version for the report: '13.0', '13', or '-'."""
+    if version is None:
+        return "-"
+    major, minor = version
+    return f"{major}.{minor}" if minor is not None else str(major)
 
 
-def test_cuda_major_consistency() -> None:
+def test_cuda_version_consistency() -> None:
     """
-    Collect CUDA major versions (12/13) from predefined signals and assert consistency.
-    Prints a readable report with full relevant output when failing.
+    Collect CUDA versions from predefined signals and assert every one of them
+    reports EXPECTED_MAJOR. Prints a readable report with full relevant output
+    when failing.
     """
 
     signals = [
@@ -94,66 +149,70 @@ def test_cuda_major_consistency() -> None:
         ("env:NV_LIBNCCL_PACKAGE", "env | grep -i '^NV_LIBNCCL_PACKAGE='"),
         ("env:NVIDIA_REQUIRE_CUDA", "env | grep -i '^NVIDIA_REQUIRE_CUDA='"),
         ("nvcc", "nvcc --version | grep -i 'release' || nvcc --version"),
-        ("dpkg:cuda-*", "dpkg -l | grep -E '^(ii|hi)\\s+cuda-.*-(12|13)-'"),
+        ("dpkg:cuda-*", rf"dpkg -l | grep -E '^(ii|hi)\s+cuda-.*-({_MAJORS})-'"),
         (
             "dpkg:libcublas/libnccl",
-            "dpkg -l | grep -E '^(ii|hi)\\s+lib(cublas|nccl).*-(12|13)-'",
+            rf"dpkg -l | grep -E '^(ii|hi)\s+lib(cublas|nccl).*-({_MAJORS})-'",
         ),
-        # pip signal: gather a targeted list, then infer majors per line (excluding ignored prefixes)
-        (
-            "pip:selected",
-            "python -m pip list --format=freeze | grep -Ei '(cuda|cudnn|nccl|nvshmem|\\+cu(12|13)[0-9]{2}|-cu(12|13)|^(torch|torchaudio|torchvision)==)'",
-        ),
+        # pip signal: majors are inferred per line, so one stray wheel is named
+        # rather than averaged away.
+        ("pip:selected", PIP_LIST_CMD),
     ]
 
-    rows: list[tuple[str, int | None, list[str]]] = []
+    # (signal label, what to name in the failure, parsed version)
+    detected: list[tuple[str, str, tuple[int, int | None]]] = []
+    excused: list[tuple[str, tuple[int, int | None], str]] = []
+    report: list[str] = [f"CUDA version signals (expected major {EXPECTED_MAJOR}):"]
 
     for label, cmd in signals:
         out = sh(cmd)
         lines = [ln.strip() for ln in out.splitlines() if ln.strip()]
 
         if label.startswith("pip:"):
-            lines = [ln for ln in lines if keep_pip_line(ln)]
-            majors = {pip_cuda_major_from_line(ln) for ln in lines}
-            majors.discard(None)
-            maj = majors.pop() if len(majors) == 1 else None  # None if ambiguous/mixed
-            # If mixed, we’ll surface it via the global consistency check below.
-        else:
-            maj = major_from_text(out)
+            report.append(f"      {label}")
+            for line in lines:
+                version = cuda_version_from_text(line)
+                reason = PIP_MAJOR_EXCEPTIONS.get(pip_distribution_name(line))
+                note = ""
+                if version is not None and reason is not None:
+                    excused.append((line, version, reason))
+                    note = f"   (allowed: {reason})"
+                elif version is not None:
+                    detected.append((label, line, version))
+                report.append(f"        {format_version(version):>5}  {line}{note}")
+            if not lines:
+                report.append("        <no output>")
+            continue
 
-        rows.append((label, maj, lines if lines else ["<no output>"]))
-
-    # Compute all detected majors across *all* signals, including per-line pip majors.
-    detected: list[int] = []
-    for label, maj, lines in rows:
-        if label.startswith("pip:"):
-            for ln in lines:
-                m = pip_cuda_major_from_line(ln)
-                if m is not None:
-                    detected.append(m)
-        else:
-            if maj is not None:
-                detected.append(maj)
-
-    if not detected:
-        pytest.skip("No CUDA major (12/13) detected from any signal.")
-
-    unique = sorted(set(detected))
-
-    # Build a readable multi-line report (no truncation to first line).
-    report = [
-        "CUDA major signals (pip ignores prefixes: "
-        + ", ".join(IGNORE_PIP_PREFIXES)
-        + "):"
-    ]
-    for label, maj, lines in rows:
-        maj_s = str(maj) if maj is not None else "-"
-        report.append(f"  {maj_s:>2}  {label}")
-        for ln in lines[:50]:  # keep it readable; adjust if you want more
-            report.append(f"      {ln}")
+        version = cuda_version_from_text(out)
+        if version is not None:
+            detected.append((label, label, version))
+        report.append(f"  {format_version(version):>5}  {label}")
+        for line in lines[:50] or ["<no output>"]:
+            report.append(f"        {line}")
         if len(lines) > 50:
-            report.append(f"      ... ({len(lines) - 50} more lines)")
+            report.append(f"        ... ({len(lines) - 50} more lines)")
 
-    assert len(unique) == 1, (
-        "\n".join(report) + f"\n\nInconsistent CUDA majors detected: {unique}"
+    if not detected and not excused:
+        pytest.skip("No CUDA version detected from any signal.")
+
+    violations: list[str] = []
+    for label, detail, (major, minor) in detected:
+        if major != EXPECTED_MAJOR:
+            violations.append(
+                f"  {label}: {detail} reports CUDA {format_version((major, minor))}, "
+                f"expected major {EXPECTED_MAJOR}"
+            )
+        elif (
+            MIN_VERSION is not None
+            and minor is not None
+            and (major, minor) < MIN_VERSION
+        ):
+            violations.append(
+                f"  {label}: {detail} reports CUDA {format_version((major, minor))}, "
+                f"below the required minimum {MIN_VERSION[0]}.{MIN_VERSION[1]}"
+            )
+
+    assert not violations, "\n".join(
+        report + ["", "Unexpected CUDA versions:"] + violations
     )

--- a/tests/basic/test_cuda_version_consistency.py
+++ b/tests/basic/test_cuda_version_consistency.py
@@ -29,7 +29,14 @@ pytestmark = [
     pytest.mark.vllm,
     pytest.mark.core,
     pytest.mark.framework_agnostic,
+    # Runs in well under a second, but every signal is a subprocess: bound the
+    # whole test so a wedged nvcc, dpkg or pip cannot hang CI.
+    pytest.mark.timeout(60),
 ]
+
+# Per-command bound, so one stuck tool fails fast instead of consuming the
+# test-wide budget.
+COMMAND_TIMEOUT_S = 20
 
 # The CUDA major every signal must report. Bump this when the images migrate to
 # the next major; the scan patterns and the assertion both derive from it.
@@ -37,8 +44,8 @@ EXPECTED_MAJOR = 13
 
 # Majors the scanner recognizes. Keep majors we have already left behind, so a
 # stray package is reported rather than silently unmatched, and add the next one
-# ahead of a migration.
-RECOGNIZED_MAJORS = (12, 13, 14)
+# here when a migration starts (nothing else needs editing).
+RECOGNIZED_MAJORS = (12, 13)
 
 # Optional floor as (major, minor), applied to every signal that carries a minor
 # version. Set to (13, 1) to require CUDA >= 13.1 image-wide. None checks the
@@ -61,6 +68,10 @@ PIP_MAJOR_EXCEPTIONS = {
     # unconditionally; nixl[cu13] narrows nothing.
     "nixl-cu12": "unconditional dependency of the nixl meta package",
 }
+
+# Cap how much of a long signal (dpkg listings) the failure report prints. Only
+# the report is truncated; every line is still scanned.
+MAX_REPORTED_LINES = 50
 
 _MAJORS = "|".join(str(m) for m in RECOGNIZED_MAJORS)
 
@@ -92,21 +103,28 @@ def sh(cmd: str) -> str:
     """
     Run command and return stdout only.
     We intentionally drop stderr to avoid noisy tools (pip warnings, etc.).
+    A timeout is deliberately left to propagate: a signal we cannot read is a
+    failure, not a signal that reports nothing.
     """
     p = subprocess.run(
         ["bash", "-lc", f"{cmd} 2>/dev/null"],
         stdout=subprocess.PIPE,
         text=True,
         check=False,
+        timeout=COMMAND_TIMEOUT_S,
     )
     return (p.stdout or "").strip()
 
 
 def cuda_version_from_text(text: str) -> tuple[int, int | None] | None:
     """
-    Extract a CUDA (major, minor) from arbitrary text. minor is None when the
-    signal carries only a major (e.g. a '-cu13' wheel tag). Returns None when no
-    recognized CUDA version is present.
+    Extract a CUDA (major, minor) from a single line of text. minor is None when
+    the signal carries only a major (e.g. a '-cu13' wheel tag). Returns None when
+    no recognized CUDA version is present.
+
+    Call this per line, never on a multi-line blob: it returns the first match,
+    so scanning combined output would let a stray major hide behind an expected
+    one earlier in the same output.
     """
     if not text:
         return None
@@ -154,53 +172,51 @@ def test_cuda_version_consistency() -> None:
             "dpkg:libcublas/libnccl",
             rf"dpkg -l | grep -E '^(ii|hi)\s+lib(cublas|nccl).*-({_MAJORS})-'",
         ),
-        # pip signal: majors are inferred per line, so one stray wheel is named
-        # rather than averaged away.
         ("pip:selected", PIP_LIST_CMD),
     ]
 
-    # (signal label, what to name in the failure, parsed version)
+    # (signal label, the line to name in a failure, parsed version)
     detected: list[tuple[str, str, tuple[int, int | None]]] = []
     excused: list[tuple[str, tuple[int, int | None], str]] = []
     report: list[str] = [f"CUDA version signals (expected major {EXPECTED_MAJOR}):"]
 
     for label, cmd in signals:
-        out = sh(cmd)
-        lines = [ln.strip() for ln in out.splitlines() if ln.strip()]
+        lines = [ln.strip() for ln in sh(cmd).splitlines() if ln.strip()]
+        report.append(f"  {label}")
 
-        if label.startswith("pip:"):
-            report.append(f"      {label}")
-            for line in lines:
-                version = cuda_version_from_text(line)
-                reason = PIP_MAJOR_EXCEPTIONS.get(pip_distribution_name(line))
-                note = ""
-                if version is not None and reason is not None:
-                    excused.append((line, version, reason))
-                    note = f"   (allowed: {reason})"
-                elif version is not None:
-                    detected.append((label, line, version))
-                report.append(f"        {format_version(version):>5}  {line}{note}")
-            if not lines:
-                report.append("        <no output>")
+        if not lines:
+            report.append("        <no output>")
             continue
 
-        version = cuda_version_from_text(out)
-        if version is not None:
-            detected.append((label, label, version))
-        report.append(f"  {format_version(version):>5}  {label}")
-        for line in lines[:50] or ["<no output>"]:
-            report.append(f"        {line}")
-        if len(lines) > 50:
-            report.append(f"        ... ({len(lines) - 50} more lines)")
+        for index, line in enumerate(lines):
+            version = cuda_version_from_text(line)
+            reason = (
+                PIP_MAJOR_EXCEPTIONS.get(pip_distribution_name(line))
+                if label.startswith("pip:")
+                else None
+            )
+
+            note = ""
+            if version is not None and reason is not None:
+                excused.append((line, version, reason))
+                note = f"   (allowed: {reason})"
+            elif version is not None:
+                detected.append((label, line, version))
+
+            if index < MAX_REPORTED_LINES:
+                report.append(f"        {format_version(version):>5}  {line}{note}")
+
+        if len(lines) > MAX_REPORTED_LINES:
+            report.append(f"        ... ({len(lines) - MAX_REPORTED_LINES} more lines)")
 
     if not detected and not excused:
         pytest.skip("No CUDA version detected from any signal.")
 
     violations: list[str] = []
-    for label, detail, (major, minor) in detected:
+    for label, line, (major, minor) in detected:
         if major != EXPECTED_MAJOR:
             violations.append(
-                f"  {label}: {detail} reports CUDA {format_version((major, minor))}, "
+                f"  {label}: {line} reports CUDA {format_version((major, minor))}, "
                 f"expected major {EXPECTED_MAJOR}"
             )
         elif (
@@ -209,10 +225,10 @@ def test_cuda_version_consistency() -> None:
             and (major, minor) < MIN_VERSION
         ):
             violations.append(
-                f"  {label}: {detail} reports CUDA {format_version((major, minor))}, "
+                f"  {label}: {line} reports CUDA {format_version((major, minor))}, "
                 f"below the required minimum {MIN_VERSION[0]}.{MIN_VERSION[1]}"
             )
 
     assert not violations, "\n".join(
-        report + ["", "Unexpected CUDA versions:"] + violations
+        [*report, "", "Unexpected CUDA versions:", *violations]
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -658,7 +658,12 @@ def pytest_collection_modifyitems(config, items):
     This function is called to modify the list of tests to run.
     """
     _check_sglang_mm_hashes_present(items)
-    # Auto-skip tests marked with a framework marker when the framework is not installed
+    # Auto-skip tests marked with a framework marker when the framework is not
+    # installed. Framework markers are also how CI selects which container runs a
+    # test, so a test that inspects the container itself must carry every
+    # framework marker to be selected everywhere -- and would then be skipped
+    # everywhere, since no image ships all of them. framework_agnostic opts such
+    # a test out of the skip while leaving its selection markers intact.
     framework_markers = {
         "trtllm": "tensorrt_llm",
         "vllm": "vllm",
@@ -670,7 +675,9 @@ def pytest_collection_modifyitems(config, items):
         if importlib.util.find_spec(module_name) is None:
             skip = pytest.mark.skip(reason=f"{module_name} is not installed")
             for item in items:
-                if _item_has_marker(item, marker_name):
+                if _item_has_marker(item, marker_name) and not _item_has_marker(
+                    item, "framework_agnostic"
+                ):
                     item.add_marker(skip)
 
     # Deselect tests based on --max-vram-gib:


### PR DESCRIPTION
Linear: OPS-8336

## Summary

`pyproject.toml` declared `cupy-cuda12x>=13.0.0` in the `sglang` extra, left over from CUDA 12. Every image flavor in `container/context.yaml` is CUDA 13 (`cuda13.0` / `cuda13.1`) or XPU, and this was the only CUDA-12 reference left in `pyproject.toml`.

`cupy-cuda12x` and `cupy-cuda13x` are mutually exclusive distributions of the same import path — `top_level.txt` for the installed `cupy-cuda13x` lists `cupy`, `cupy_backends`, `cupyx`, all under `/usr/local/lib/python3.12/dist-packages/cupy/`. Resolving `ai-dynamo[sglang]` on a CUDA 13 host installs the CUDA 12 wheel; doing it inside the sglang image would clobber a working CUDA 13 build.

No build caught it because the container builds install the Dynamo wheels with `--no-deps` (`container/sglang-runtime-cuda13.0-amd64-rendered.Dockerfile:861`), so that extra is never resolved during a build. Nothing under `container/` installs cupy at all — the images inherit `cupy-cuda13x 14.1.1` from upstream `lmsysorg/sglang`, via `mscclpp[cuda13]`.

`tests/basic/test_cuda_version_consistency.py` exists for exactly this class of drift and could not catch it, for four independent reasons.

### 1. It ignored cupy by name

`IGNORE_PIP_PREFIXES = ("cupy", "nixl")` blanket-skipped every distribution starting with either prefix, hiding both the cupy pin and every `nixl-cu12` wheel. Replaced with an exact-name exception map that records *why* each entry cannot be removed. Both current entries are unconditional upstream dependencies, not judgement calls:

| distribution | why it stays |
|---|---|
| `nvidia-cutlass-dsl-libs-cu12` | `nvidia-cutlass-dsl` requires it outside any extra; only the cu13 libs sit behind `extra == "cu13"` |
| `nixl-cu12` | the `nixl` meta package requires both cu12 and cu13 outside any extra, so `nixl[cu13]` narrows nothing |

### 2. It could never run

CI selects containers *by* framework marker (`'(pre_merge or post_merge) and vllm and gpu_0'`), so a test that inspects the image must carry every framework marker to be selected everywhere. But `tests/conftest.py` skips a test when *any* of its framework modules is missing, so those markers AND together into a universal skip. Post-merge run `32503495891`:

```
SKIPPED [1] tests/basic/test_cuda_version_consistency.py: tensorrt_llm is not installed
```

No image ships all three:

| image | framework modules present |
|---|---|
| tensorrtllm-runtime:1.4.0 | `tensorrt_llm`, `kvbm` |
| sglang-runtime:1.4.0 | `sglang` |
| vllm-runtime:1.4.0 | `vllm`, `kvbm`, `lmcache` |

The new `framework_agnostic` marker opts a test out of that skip while leaving its selection markers intact. It is additive: no existing test changes behaviour.

### 3. It only asserted self-consistency

`assert len(unique) == 1` passes on an image that is uniformly wrong. The assertion now requires every signal to report `EXPECTED_MAJOR`, which subsumes the old consistency check and rejects CUDA 12 outright.

`RECOGNIZED_MAJORS` and `EXPECTED_MAJOR` are constants that the patterns, the pip listing and the dpkg greps all derive from, and minor versions are now parsed and shown in the report — so adding CUDA 14 or introducing a `>= 13.1` floor through `MIN_VERSION` is a constant edit rather than a rewrite. Scanning also picks up two forms the old patterns missed (`...-cuda13`, `cuda-toolkit==13.0.2`).

### 4. Multi-line signals were parsed as one blob

Found in review. `cuda_version_from_text` returns on the first pattern match, so scanning combined `dpkg` / `env` output stopped at the first CUDA 13 line and never reached anything after it — a CUDA 12 package sitting behind a CUDA 13 one was invisible:

```
whole-blob parse (old): (13, 0)              <- cu12 line never seen
per-line parse  (new): [(13, 0), (12, 4)]
```

Both branches are now one per-line loop, so there is no blob path left to regress into. Report truncation affects display only; every line is scanned.

Also from review: the test carries `pytest.mark.timeout(60)` and passes a per-command `timeout=` to `subprocess.run`, per `.ai/pytest-guidelines.md:305-308`. `TimeoutExpired` deliberately propagates instead of degrading into empty output — a signal that cannot be read is a failure, not a signal reporting nothing.

## Validation

All runs against `nvcr.io/nvidia/ai-dynamo/{sglang,vllm,tensorrtllm}-runtime:1.4.0` on an RTX 6000 Ada box.

**Before:** the test fails on sglang and vllm today (masked only by never being selected) — `nvidia-cutlass-dsl-libs-cu12` yields major 12 against the image's 13.

**After:** passes in all three images.

```
sglang-runtime:1.4.0        1 passed
vllm-runtime:1.4.0          1 passed
tensorrtllm-runtime:1.4.0   1 passed
```

**Not vacuous.** Forcing `EXPECTED_MAJOR = 12` in the sglang image reports 62 detected signals, every one of them 13.x — including entries the old ignore list hid or the old patterns missed:

```
  13  cupy-cuda13x==14.1.1
  13  mooncake-transfer-engine-cuda13==0.3.11.post1
  13  nixl-cu13==1.3.2
  12  nvidia-cutlass-dsl-libs-cu12==4.6.0   (allowed: unconditional dependency of nvidia-cutlass-dsl)
  13  nvidia-cutlass-dsl-libs-cu13==4.6.0
```

That count was 34 before the per-line fix: 28 dpkg lines were previously collapsed into a single detection.

**Exceptions are load-bearing.** Dropping both entries makes vllm-runtime fail, as it should:

```
pip:selected: nixl-cu12==1.3.1 reports CUDA 12, expected major 13
pip:selected: nvidia-cutlass-dsl-libs-cu12==4.6.0 reports CUDA 12, expected major 13
```

**The marker fix is what makes it run.** Same container (sglang, so `tensorrt_llm` absent), same marker expression, real `tests/conftest.py`, opt-out reverted vs applied:

```
without framework_agnostic:  SKIPPED [1] ... tensorrt_llm is not installed
with framework_agnostic:     1 passed
```

**Lint:** `pre-commit run --files pyproject.toml tests/conftest.py tests/basic/test_cuda_version_consistency.py` — all hooks pass except `pytest-marker-report`, which fails identically on a clean tree in this environment (`RuntimeError: Could not find 1 available ports after 100 retries`).

### CI evidence

Run `32519184375`. The arm64 lane executed the test in all three containers:

```
vllm-runtime / Test cuda13.0, arm64      PASSED  tests/basic/test_cuda_version_consistency.py
sglang-runtime / Test cuda13.0, arm64    PASSED
trtllm-runtime / Test cuda13.1, arm64    PASSED   (1.76s, well inside the 60s bound)
```

That is the marker fix working end to end: the test was *selected and executed* in every container, where before it was skipped in all of them.

The amd64 jobs in that run failed, but before pytest started, on all three backends:

```
##[error]Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'/home/runner/_work/dynamo/dynamo/.github/actions/pytest-local'.
Did you forget to run actions/checkout before running your local action?
```

`.github/actions/pytest-local/action.yml` is present on both `main` and this branch, the same jobs pass on other PRs, and the split is purely by architecture (arm64 green, amd64 red, every backend) — so this is the amd64 `k8s-novolume` runner not exposing the checked-out workspace, not a change in this PR. A test-content failure would have failed arm64 too. Needs a re-run.

### Review round 3

`dynamo-review-agent` caught a false-green that this PR introduced: the skip guard was `if not detected and not excused`, so an image whose only CUDA signal is an exception entry took the assert path with an empty violation list and reported green. Confirmed by stubbing `sh` to return only the two exception packages (`RESULT: PASSED`), then fixed in 933696606f. The guard now keys on `detected` alone:

```
only excused cu12    -> SKIPPED (was PASSED)
no CUDA at all       -> SKIPPED
excused cu12 + cu13  -> PASSED
excused cu12 + cu12  -> FAILED
```

Reachable rather than hypothetical: `container/templates/vllm_runtime.Dockerfile:191-206` installs `nixl-cu12` for `device != "cuda"` and deliberately skips `nixl-cu13`, which is exactly that shape. Not measured — the XPU job was skipped on this run.

## Follow-up

The same marker interaction leaves two other tests unrunnable in every shipped image. Each needs a per-test call on whether it is genuinely framework-agnostic, so they are deliberately not touched here:

- `tests/test_predownload_models.py::test_predownload_models` (`sglang`+`trtllm`+`vllm`)
- `tests/kvbm_integration/test_determinism_disagg.py` (`kvbm`+`trtllm`+`vllm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
