### PR TITLE
docs(sglang): pin the MMEncoder link to the SGLang version Dynamo uses

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/multimodal.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/multimodal.md
@@ -551,7 +551,7 @@ Controls how many threads the encoder uses to fetch and load images concurrently
 export SGLANG_ENCODER_MM_LOAD_WORKERS=16
 ```
 
-Only applies to the EPD encode worker (which uses [SGLang's MMEncoder](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/disaggregation/encode_server.py) internally).
+Only applies to the EPD encode worker (which uses [SGLang's MMEncoder](https://github.com/sgl-project/sglang/blob/v0.5.17/python/sglang/srt/disaggregation/encode_server.py) internally).
 
 ## Profiling
 


### PR DESCRIPTION
## Summary

The MMEncoder reference link on the SGLang multimodal page points at `main` in the SGLang repository. SGLang has since moved the encode server from `disaggregation/encode_server.py` to `disaggregation/encoder/server.py`, so that URL now returns **404** and fails `lychee` on pull requests that do not touch this page at all. I found it on my own unrelated PR #13626, whose diff is Python with no links in it.

Point the link at `v0.5.17`, the version `pyproject.toml` pins. That URL returns 200, it matches the code sample directly above it, and unlike a `main` URL it cannot rot again the next time SGLang moves the file.

**The code sample is deliberately unchanged.** My first version of this PR also "fixed" the sample's import to `sglang.srt.disaggregation.encoder.server`, matching SGLang `main`. That was wrong and I have reverted it. Dynamo pins `sglang[diffusion]==0.5.17`, and at that tag `encode_server.py` exists while `encoder/server.py` does not, so the edit would have broken a working sample for every reader on the pinned version. The same reasoning applies to the production import at `components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py:18`, which is correct as it stands and which I have left alone.

So the defect here is only that the link was not version pinned, and pinning it is the whole fix.

## Validation

Checked against both the pinned tag and `main`, since which one is authoritative is the entire question:

| path | at `v0.5.17` | at `main` |
|---|---|---|
| `.../disaggregation/encode_server.py` | 200 | 404 |
| `.../disaggregation/encoder/server.py` | 404 | 200 |

- New link `https://github.com/sgl-project/sglang/blob/v0.5.17/.../encode_server.py` returns **200**.
- `class MMEncoder` confirmed present in that file at `v0.5.17`.
- `pyproject.toml:81` pins `sglang[diffusion]==0.5.17`, which is what makes v0.5.17 the right target rather than `main`.
- `pre-commit run --files <the page>` passes with zero failing hooks.

One line, text only, no navigation or frontmatter touched. I have no SGLang runtime here, so the import path was verified by reading the module at the pinned tag rather than by executing it.