### PR TITLE
test(ci): run vLLM multi-GPU suite on G6e canary

### DIFF
--- a/.github/workflows/build-on-demand.yml
+++ b/.github/workflows/build-on-demand.yml
@@ -22,6 +22,10 @@ on:
         description: 'Build and push operator image, tagged with branch name'
         type: boolean
         default: false
+      run_g6e_multi_gpu_canary:
+        description: 'Run the vLLM multi-GPU suite on the isolated OPS-8335 G6e runner'
+        type: boolean
+        default: false
 
 env:
   BUILDER_NAME: b-${{ github.run_id }}-${{ github.run_attempt }}
@@ -89,6 +93,22 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       builder_name: ${{ needs.init.outputs.builder_name }}
       build_timeout_minutes: 60
+    secrets: inherit
+
+  g6e-multi-gpu-canary:
+    name: G6e L40S vLLM multi-GPU canary
+    needs: [vllm-build]
+    if: inputs.run_g6e_multi_gpu_canary && inputs.build_vllm
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: G6e Multi-GPU Canary
+      amd_runner: ops-8335-g6e-l40s-canary
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64"]'
+      gpu_test_markers: pre_merge and vllm and (gpu_2 or gpu_4)
+      gpu_test_timeout_minutes: 60
     secrets: inherit
 
   vllm-copy-to-acr:


### PR DESCRIPTION
## Summary

- add a temporary Build On Demand option for OPS-8335 validation
- build a fresh vLLM runtime image from this PR commit
- run the standard reusable multi-GPU test workflow on the isolated `ops-8335-g6e-l40s-canary` runner
- exercise the production markers `pre_merge and vllm and (gpu_2 or gpu_4)`

This PR is test-only and will not be merged.

Related infrastructure change: [ai-dynamo/velonix#609](https://github.com/ai-dynamo/velonix/pull/609)

## Isolation

The canary runner used a unique GitHub runner scale-set name, Kubernetes label, and `NoSchedule` taint. It was backed by a one-node Karpenter NodePool pinned to Spot `g6e.12xlarge`; existing production runners could not schedule on the canary node.

## Validation

- [Build On Demand run 32517695275](https://github.com/ai-dynamo/dynamo/actions/runs/32517695275): passed
- fresh vLLM CUDA 13.0 multi-architecture image build: passed
- runner assigned to Spot `g6e.12xlarge` in `us-west-2a`, Ready with 4 allocatable GPUs
- PyTorch GPU visibility: CUDA available, 4 GPUs, `NVIDIA L40S`
- runtime sanity check: passed
- `pre_merge and vllm and (gpu_2 or gpu_4)`: 9 passed, 4 skipped, 0 failed in 16m11s
- test artifacts and Allure results uploaded successfully
- temporary ARC scale set and Karpenter NodePool deleted after the run