### PR TITLE
fix(vllm): account for DCP in KV event block size

### DIFF
--- a/components/src/dynamo/vllm/cache_info.py
+++ b/components/src/dynamo/vllm/cache_info.py
@@ -17,12 +17,23 @@ MAIN_ATTENTION_KV_CACHE_KINDS = {
 }
 
 
+def kv_event_block_size(vllm_config: VllmConfig, block_size: int) -> int:
+    """Widen a physical block size to the granularity vLLM emits KV events at.
+
+    Under DCP the cache manager multiplies ``KVCacheSpec.block_size`` by the DCP
+    world size; cache-group metadata still reports the unwidened value.
+    """
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    dcp_size = int(getattr(parallel_config, "decode_context_parallel_size", 1) or 1)
+    return block_size * dcp_size
+
+
 def get_configured_kv_event_block_size(vllm_config: VllmConfig) -> int:
     """Return the configured KV event block size, falling back to vLLM's cache block size."""
     additional_config = vllm_config.additional_config or {}
     return additional_config.get(
         DYNAMO_KV_EVENT_BLOCK_SIZE_KEY,
-        vllm_config.cache_config.block_size,
+        kv_event_block_size(vllm_config, vllm_config.cache_config.block_size),
     )
 
 
@@ -57,14 +68,24 @@ async def configure_kv_event_block_size(
             "vLLM cache_config.block_size: %s",
             e,
         )
-        kv_event_block_size = fallback_block_size
+        physical_block_size = fallback_block_size
     else:
-        kv_event_block_size = select_main_attention_block_size(
+        physical_block_size = select_main_attention_block_size(
             group_metadata,
             fallback_block_size,
         )
 
+    configured_block_size = kv_event_block_size(vllm_config, physical_block_size)
+    if configured_block_size != physical_block_size:
+        logger.info(
+            "Using DCP-aware vLLM KV event block size %d (physical_block_size=%d)",
+            configured_block_size,
+            physical_block_size,
+        )
+
     if vllm_config.additional_config is None:
         vllm_config.additional_config = {}
-    vllm_config.additional_config[DYNAMO_KV_EVENT_BLOCK_SIZE_KEY] = kv_event_block_size
-    return kv_event_block_size
+    vllm_config.additional_config[
+        DYNAMO_KV_EVENT_BLOCK_SIZE_KEY
+    ] = configured_block_size
+    return configured_block_size

--- a/components/src/dynamo/vllm/tests/test_vllm_cache_info.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_cache_info.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dynamo.vllm.cache_info import (
+    DYNAMO_KV_EVENT_BLOCK_SIZE_KEY,
+    configure_kv_event_block_size,
+    get_configured_kv_event_block_size,
+    kv_event_block_size,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.core,
+    pytest.mark.gpu_0,
+    pytest.mark.xpu_1,
+    pytest.mark.profiled_vram_gib(0),
+    pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s
+    pytest.mark.pre_merge,
+]
+
+
+def _vllm_config(
+    *,
+    block_size: int = 16,
+    dcp_size: int | None = 1,
+    additional_config: dict | None = None,
+):
+    return SimpleNamespace(
+        additional_config=additional_config,
+        cache_config=SimpleNamespace(block_size=block_size),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp_size,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "vllm_config, physical_block_size, expected",
+    [
+        (SimpleNamespace(), 64, 64),
+        (_vllm_config(dcp_size=None), 64, 64),
+        (_vllm_config(dcp_size=1), 64, 64),
+        (_vllm_config(dcp_size=8), 64, 512),
+    ],
+)
+def test_kv_event_block_size_accounts_for_dcp(
+    vllm_config, physical_block_size, expected
+):
+    assert kv_event_block_size(vllm_config, physical_block_size) == expected
+
+
+def test_get_configured_kv_event_block_size_does_not_multiply_cached_value_twice():
+    vllm_config = _vllm_config(
+        dcp_size=8,
+        additional_config={DYNAMO_KV_EVENT_BLOCK_SIZE_KEY: 128},
+    )
+
+    assert get_configured_kv_event_block_size(vllm_config) == 128
+
+
+def test_get_configured_kv_event_block_size_uses_dcp_aware_fallback():
+    vllm_config = _vllm_config(dcp_size=8)
+
+    assert get_configured_kv_event_block_size(vllm_config) == 128
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kind, physical_block_size",
+    [
+        ("full_attention", 16),
+        ("mla_attention", 64),
+        ("sink_full_attention", 128),
+    ],
+)
+async def test_configure_kv_event_block_size_applies_dcp_to_main_attention_group(
+    kind, physical_block_size
+):
+    group_metadata = [
+        {"kind": "mamba", "block_size": 4096},
+        {"kind": kind, "block_size": physical_block_size},
+    ]
+    engine = SimpleNamespace(
+        engine_core=SimpleNamespace(
+            call_utility_async=AsyncMock(return_value=group_metadata)
+        )
+    )
+    vllm_config = _vllm_config(dcp_size=2)
+
+    configured = await configure_kv_event_block_size(engine, vllm_config)
+
+    assert configured == physical_block_size * 2
+    assert (
+        vllm_config.additional_config[DYNAMO_KV_EVENT_BLOCK_SIZE_KEY]
+        == physical_block_size * 2
+    )
+    engine.engine_core.call_utility_async.assert_awaited_once_with(
+        "get_kv_cache_group_metadata"
+    )
+
+
+@pytest.mark.asyncio
+async def test_configure_kv_event_block_size_applies_dcp_to_fallback():
+    engine = SimpleNamespace(
+        engine_core=SimpleNamespace(
+            call_utility_async=AsyncMock(side_effect=RuntimeError("unsupported"))
+        )
+    )
+    vllm_config = _vllm_config(block_size=16, dcp_size=8)
+
+    configured = await configure_kv_event_block_size(engine, vllm_config)
+
+    assert configured == 128
+    assert vllm_config.additional_config[DYNAMO_KV_EVENT_BLOCK_SIZE_KEY] == 128

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -15,6 +15,8 @@ from typing import Any, Dict, Optional
 import aiohttp
 import pytest
 
+from dynamo.llm import KvRouter, KvRouterConfig
+from tests.router.common import _create_kv_router_with_timeout
 from tests.router.e2e_harness import (
     ManagedEngineProcessMixin,
     run_basic_router_test,
@@ -26,7 +28,10 @@ from tests.router.helper import (
     generate_random_suffix,
     get_kv_indexer_command,
     get_kv_indexer_test_env,
+    managed_runtime,
+    send_request_via_python_kv_router,
     wait_for_indexer_workers_active,
+    wait_for_workers_ready,
 )
 from tests.utils.constants import DynamoPortRange
 from tests.utils.gpu_args import build_gpu_mem_args
@@ -40,6 +45,7 @@ from tests.utils.port_utils import (
 logger = logging.getLogger(__name__)
 
 MODEL_NAME = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+DCP_MODEL_NAME = "Qwen/Qwen2.5-3B-Instruct"
 
 pytestmark = [
     pytest.mark.e2e,
@@ -65,6 +71,13 @@ VLLM_ARGS_NO_BLOCK_SIZE: Dict[str, Any] = {
     "gpu_memory_utilization": 0.4,  # Limit VRAM allocation per worker
     "max_model_len": 1024,  # Limit context length to reduce KV cache size
     "enforce_eager": True,  # Disable CUDA graphs for faster startup & lower memory
+}
+
+VLLM_DCP2_ARGS: Dict[str, Any] = {
+    **VLLM_ARGS,
+    "model": DCP_MODEL_NAME,
+    "tensor_parallel_size": 4,
+    "decode_context_parallel_size": 2,
 }
 
 # Twice vLLM's 165,900,288-byte minimum for TinyLlama at max_model_len=1024.
@@ -136,6 +149,8 @@ class VLLMProcess(ManagedEngineProcessMixin):
                 - num_gpu_blocks_override: Cap on number of KV cache blocks (optional)
                 - max_model_len: Maximum sequence length (optional)
                 - enforce_eager: Disable CUDA graphs (default: False)
+                - tensor_parallel_size: GPUs assigned to each TP worker (default: 1)
+                - decode_context_parallel_size: DCP ranks per worker (default: 1)
             num_workers: Number of vLLM worker processes
             single_gpu: If True, all workers share GPU 0
             data_parallel_size: If set, enables data parallelism with this many ranks (num_workers must equal data_parallel_size)
@@ -221,6 +236,8 @@ class VLLMProcess(ManagedEngineProcessMixin):
         num_gpu_blocks_override = vllm_args.get("num_gpu_blocks_override")
         max_model_len = vllm_args.get("max_model_len")
         enforce_eager = vllm_args.get("enforce_eager", False)
+        tensor_parallel_size = vllm_args.get("tensor_parallel_size", 1)
+        decode_context_parallel_size = vllm_args.get("decode_context_parallel_size", 1)
 
         self.model_name = model
         self.block_size = vllm_args.get("block_size", BLOCK_SIZE)
@@ -237,18 +254,20 @@ class VLLMProcess(ManagedEngineProcessMixin):
             if single_gpu:
                 # Force all processes to GPU 0 (for single-GPU testing)
                 gpu_device = str(gpu_start_index)
-            elif data_parallel_size is not None:
-                # Worker sees dp_rank GPUs (each DP rank gets its own GPU)
-                worker_start_gpu = gpu_start_index + worker_idx * data_parallel_size
+            else:
+                # Each process owns a contiguous GPU group sized by whichever of
+                # DP/TP is in play; combining them needs a real layout, not this.
+                assert not (
+                    data_parallel_size and tensor_parallel_size > 1
+                ), "VLLMProcess cannot place workers for combined DP and TP"
+                worker_gpu_count = data_parallel_size or tensor_parallel_size
+                worker_start_gpu = gpu_start_index + worker_idx * worker_gpu_count
                 gpu_device = ",".join(
                     str(i)
                     for i in range(
-                        worker_start_gpu, worker_start_gpu + data_parallel_size
+                        worker_start_gpu, worker_start_gpu + worker_gpu_count
                     )
                 )
-            else:
-                # No DP; worker sees one GPU
-                gpu_device = str(gpu_start_index + worker_idx)
 
             command = ["python3", "-m", "dynamo.vllm", "--model", model]
 
@@ -281,6 +300,17 @@ class VLLMProcess(ManagedEngineProcessMixin):
             if num_gpu_blocks_override is not None:
                 command.extend(
                     ["--num-gpu-blocks-override", str(num_gpu_blocks_override)]
+                )
+
+            if tensor_parallel_size > 1:
+                command.extend(["--tensor-parallel-size", str(tensor_parallel_size)])
+
+            if decode_context_parallel_size > 1:
+                command.extend(
+                    [
+                        "--decode-context-parallel-size",
+                        str(decode_context_parallel_size),
+                    ]
                 )
 
             if data_parallel_size is not None:
@@ -360,7 +390,8 @@ class VLLMProcess(ManagedEngineProcessMixin):
                 )
             else:
                 logger.info(
-                    f"Created vLLM worker {worker_idx} on GPU {gpu_device} "
+                    f"Created vLLM worker {worker_idx} on GPU(s) {gpu_device} "
+                    f"(tp={tensor_parallel_size}, dcp={decode_context_parallel_size}) "
                     f"(gpu_mem={gpu_memory_utilization}, system_port={system_port}) "
                     f"with endpoint: {self.endpoint}"
                 )
@@ -544,6 +575,93 @@ class VLLMProcess(ManagedEngineProcessMixin):
     init_delay_reason = "initialize NIXL before starting next worker"
 
 
+def run_dcp_event_delivery_test(
+    request,
+    model_name: str,
+    vllm_args: Dict[str, Any],
+    event_block_size: int,
+    num_requests: int,
+    request_plane: str,
+) -> None:
+    """Require full DCP-sized blocks to reach a real Dynamo KV router."""
+    blocks_per_request = 3
+    expected_blocks = num_requests * blocks_per_request
+    process = VLLMProcess(
+        request,
+        vllm_args,
+        num_workers=1,
+        single_gpu=False,
+        request_plane=request_plane,
+    )
+
+    with process as engine_workers, managed_runtime(
+        request_plane=request_plane
+    ) as runtime:
+        endpoint = runtime.endpoint(
+            f"{engine_workers.namespace}.{engine_workers.component_name}.generate"
+        )
+
+        async def run_test() -> int:
+            kv_router = _create_kv_router_with_timeout(
+                router_factory=lambda: KvRouter(
+                    endpoint=endpoint,
+                    block_size=event_block_size,
+                    kv_router_config=KvRouterConfig(
+                        use_kv_events=True,
+                        router_event_threads=4,
+                    ),
+                ),
+                num_workers=1,
+                engine_workers=engine_workers,
+                timeout=300,
+            )
+            worker_ids = await wait_for_workers_ready(
+                endpoint,
+                kv_router,
+                expected_num_workers=1,
+                model_name=model_name,
+            )
+
+            for request_idx in range(num_requests):
+                token_ids = [
+                    (request_idx * blocks_per_request * event_block_size + offset)
+                    % 10000
+                    + 1
+                    for offset in range(blocks_per_request * event_block_size)
+                ]
+                await send_request_via_python_kv_router(
+                    kv_python_router=kv_router,
+                    model_name=model_name,
+                    token_ids=token_ids,
+                    stop_conditions={"ignore_eos": True, "max_tokens": 2},
+                    worker_id=worker_ids[0],
+                )
+
+            stored_blocks = 0
+            for _ in range(100):
+                events = json.loads(await kv_router.dump_events())
+                stored_blocks = sum(
+                    len(
+                        event.get("event", {})
+                        .get("data", {})
+                        .get("stored", {})
+                        .get("blocks", [])
+                    )
+                    for event in events
+                )
+                if stored_blocks >= expected_blocks:
+                    return stored_blocks
+                await asyncio.sleep(0.1)
+
+            return stored_blocks
+
+        stored_blocks = asyncio.run(run_test())
+        assert stored_blocks >= expected_blocks, (
+            f"Expected at least {expected_blocks} DCP-sized stored blocks, "
+            f"but the router received {stored_blocks}"
+        )
+
+
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
 @pytest.mark.profiled_vram_gib(6.9)  # actual profiled peak with kv-bytes
@@ -662,6 +780,31 @@ def test_router_decisions_vllm_dp(
         single_gpu=False,
         test_dp_rank=True,
         extra_process_kwargs={"data_parallel_size": 2},
+    )
+
+
+@pytest.mark.h100
+@pytest.mark.gpu_4
+@pytest.mark.nightly
+# Module pytestmark only pre-downloads MODEL_NAME; DCP needs its own model.
+@pytest.mark.model(DCP_MODEL_NAME)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+@pytest.mark.timeout(900)
+def test_vllm_dcp2_basic(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+    set_ucx_tls_no_mm,
+    request_plane,
+):
+    """Deliver KV events from one TP4/DCP2 worker."""
+    run_dcp_event_delivery_test(
+        request=request,
+        model_name=DCP_MODEL_NAME,
+        vllm_args=VLLM_DCP2_ARGS,
+        event_block_size=BLOCK_SIZE * 2,
+        num_requests=4,
+        request_plane=request_plane,
     )
 
 


### PR DESCRIPTION
## Overview:

vLLM decode-context parallelism widens the logical KV block represented by each KV event, but Dynamo currently registers the physical cache block size. For a physical block size of 16 with DCP=2, vLLM emits 32-token blocks and Dynamo rejects them because it expects 16.

This change mirrors the SGLang fix by multiplying the physical main-attention block size by the DCP world size before configuring Dynamo's KV-event publisher and model metadata.

## Details:

- Derive the router-facing vLLM KV-event block size as `physical_block_size * decode_context_parallel_size`.
- Apply the same logic to cache-group metadata and compatibility fallback paths without multiplying an already cached value twice.
- Add unit coverage for DCP-aware selection, fallback behavior, and multiple attention cache kinds.
- Extend the vLLM router harness with TP/DCP GPU allocation and nightly functional, two-worker routing, and DCP4 scale coverage.

### Validation

The exact staged patch (`75a78fdef350bf64a76f8a2ba2d261e1852e0d115d0b5de63c8dd1fc7a3c1f31`) was tested before push by Slurm job `16285517` on eight H100 80GB GPUs with vLLM 0.27.1 and Qwen2.5-3B-Instruct:

- Unpatched TP4/DCP2 functional control: expected failure with the 16-vs-32 block mismatch.
- Unpatched TP4/DCP2 two-worker routing control: expected failure with the same mismatch.
- Patched TP4/DCP2 functional test: passed with 32-token logical blocks.
- Patched TP4/DCP2 two-worker routing test: passed.
- Patched TP8/DCP4 scale test: passed with 64-token logical blocks.
- Slurm accounting: `COMPLETED`, exit `0:0`, runtime 11m11s.
- `pre-commit run --all-files`: passed.

## Where should the reviewer start?

1. `components/src/dynamo/vllm/cache_info.py` for the DCP-aware block-size calculation and fallback behavior.
2. `components/src/dynamo/vllm/tests/test_vllm_cache_info.py` for focused unit coverage.
3. `tests/router/test_router_e2e_with_vllm.py` for the real multi-GPU regression tests.

## Related Issues

- Relates to [DYN-3997](https://linear.app/nvidia/issue/DYN-3997/bug-vllm-dcp-publishes-logical-kv-blocks-but-dynamo-registers-the)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved vLLM KV-cache event handling for decode-context parallel deployments.
  - KV-cache block sizes now automatically account for parallel decoding configuration.
  - Added support for more reliable KV-cache event delivery across distributed workers.

- **Bug Fixes**
  - Improved fallback behavior when cache metadata is unavailable.
  - Ensured calculated cache settings remain consistent throughout request processing.

- **Tests**
  - Added coverage for distributed KV-cache handling and end-to-end event delivery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->