### PR TITLE
docs(kubernetes): note SGLang status on the vanilla vLLM on-ramp

### DIFF
--- a/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
@@ -511,6 +511,15 @@ The standalone path currently targets aggregated vLLM serving with data-parallel
 does not provide the DGD/operator lifecycle, Dynamo runtime discovery, disaggregated prefill/decode
 orchestration, request migration, topology-aware routing, or full operator-managed observability.
 
+<Warning>
+This on-ramp does not work with vanilla SGLang workers yet. `DYN_EPP_TOKENIZER_PROTOCOL` accepts only
+`vllm-render`, so the EPP has no SGLang tokenizer to call and exits at startup. Track
+[ai-dynamo/dynamo#13390](https://github.com/ai-dynamo/dynamo/issues/13390) and
+[sgl-project/sglang#28669](https://github.com/sgl-project/sglang/issues/28669). Once those land, the
+`InferencePool`, `HTTPRoute`, and EPP resources carry over under your own SGLang names. The worker
+flags do not: SGLang spells them differently, starting with `--page-size` for `--block-size`.
+</Warning>
+
 Use [GAIE with Dynamo](gateway-api.mdx) when you want the supported
 operator-managed lifecycle, Dynamo workers, or disaggregated serving. Use
 [Gateway API Routing Reference](../../reference/components/gateway-api-routing.mdx) for the DGD and


### PR DESCRIPTION
## Overview:

The vanilla SGLang GAIE on-ramp cannot be deployed yet. The standalone EPP accepts only `vllm-render` for `DYN_EPP_TOKENIZER_PROTOCOL` and aborts startup on anything else (`deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs:76`), so it has no SGLang tokenizer to call. This documents that on the existing vLLM on-ramp page instead of shipping a page and manifest for a path that does not work.

## Details:

Adds one `<Warning>` to the "Scope and Limitations" section of `vanilla-vllm-onramp.mdx`. It names what blocks SGLang today and links #13390 and sgl-project/sglang#28669, then says which resources carry over once those land and which worker flags do not.

An earlier revision of this branch added a dedicated `vanilla-sglang-onramp.mdx`, an `onramp/sglang-agg.yaml`, a nav entry, and a manifest-shape unit test. Review feedback was that a dedicated page duplicates the vLLM one, which differs only in resource naming and the tokenizer URL, and that the test was overkill. All four are dropped here.

Validation: docs-only, one file, no code paths touched. `docs/fern/scripts/check_asset_paths.py` passes on the changed file, every page path in `docs/fern/index.yml` still resolves, and nothing in the tree references the dropped page or manifest.

## Where should the reviewer start?

`docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx` is the only file changed.

## Related Issues

- Relates to #13392
- Relates to #13390

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a warning that vanilla SGLang workers are not supported with standalone EPP.
  * Clarified tokenizer protocol requirements and noted that resource definitions can be reused with SGLang naming.
  * Documented the need for SGLang-specific worker flags, such as `--page-size`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->