### PR TITLE
feat(vllm): add Qwen3.5 custom encoder example

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -815,7 +815,8 @@ jobs:
       enable_coverage: true
       run_cpu_only_tests: true
       cpu_only_test_markers: vllm and gpu_0
-      gpu_test_markers: vllm and gpu_1
+      # Exclude h100 tests: they need >24 GiB and run on the vllm-h100-test lane below.
+      gpu_test_markers: vllm and gpu_1 and not h100
       gpu_test_timeout_minutes: 240
       # Profiled tests run in the parallel stage; unprofiled fall through to sequential.
       # 24 GiB admits all currently profiled vLLM tests (max is ~20.4 GiB) on a 48 GiB GPU.

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -815,8 +815,7 @@ jobs:
       enable_coverage: true
       run_cpu_only_tests: true
       cpu_only_test_markers: vllm and gpu_0
-      # Exclude h100 tests: they need >24 GiB and run on the vllm-h100-test lane below.
-      gpu_test_markers: vllm and gpu_1 and not h100
+      gpu_test_markers: vllm and gpu_1
       gpu_test_timeout_minutes: 240
       # Profiled tests run in the parallel stage; unprofiled fall through to sequential.
       # 24 GiB admits all currently profiled vLLM tests (max is ~20.4 GiB) on a 48 GiB GPU.

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/factory.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/factory.py
@@ -13,7 +13,7 @@ from dynamo.vllm.multimodal_utils.custom_encoder.adapter.linear import (
 )
 from dynamo.vllm.multimodal_utils.custom_encoder.adapter.qwen3_vl import (
     Qwen3VLNativeAdapter,
-    _is_qwen3_vl_model,
+    _is_native_qwen_vlm,
 )
 from dynamo.vllm.multimodal_utils.custom_encoder.backend.base import (
     VisionEncoderBackend,
@@ -33,7 +33,7 @@ def create_custom_encoder_adapter(
 
     if model_config is None:
         raise ValueError("CustomEncoder requires the resolved vLLM ModelConfig")
-    if _is_qwen3_vl_model(model_config):
+    if _is_native_qwen_vlm(model_config):
         return Qwen3VLNativeAdapter(model_config)
 
     if _is_multimodal_model(model_config):

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/qwen3_vl.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/qwen3_vl.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Native external-multimodal adapter for Qwen3-VL decoders."""
+"""Native external-multimodal adapter for supported Qwen decoders."""
 
 from dataclasses import dataclass
 from typing import Any, Sequence
@@ -14,18 +14,21 @@ from dynamo.vllm.multimodal_utils.custom_encoder.adapter.base import (
 )
 from dynamo.vllm.multimodal_utils.model_config import _model_architectures
 
-_QWEN3_VL_ARCHITECTURES = frozenset(
+# Only these registered Qwen VLM wrappers can consume external image features
+# through TokensPrompt. Text-only Qwen decoders must use LinearEmbedsAdapter.
+_NATIVE_QWEN_VLM_ARCHITECTURES = frozenset(
     {
         "Qwen3VLForConditionalGeneration",
         "Qwen3VLMoeForConditionalGeneration",
+        "Qwen3_5ForConditionalGeneration",
     }
 )
 
 
-def _is_qwen3_vl_model(model_config: Any) -> bool:
-    """Whether vLLM resolved a supported dense or MoE Qwen3-VL model."""
+def _is_native_qwen_vlm(model_config: Any) -> bool:
+    """Whether vLLM resolved a supported native Qwen VLM wrapper."""
     return any(
-        architecture in _QWEN3_VL_ARCHITECTURES
+        architecture in _NATIVE_QWEN_VLM_ARCHITECTURES
         for architecture in _model_architectures(model_config)
     )
 
@@ -35,20 +38,20 @@ def _spatial_merge_size(model_config: Any) -> int:
     vision_config = getattr(hf_config, "vision_config", None)
     value = getattr(vision_config, "spatial_merge_size", None)
     if not isinstance(value, int) or isinstance(value, bool) or value < 1:
-        raise ValueError("Qwen3-VL could not resolve spatial_merge_size")
+        raise ValueError("Qwen decoder could not resolve spatial_merge_size")
     return value
 
 
 @dataclass(frozen=True)
 class Qwen3VLImageEncoding:
-    """Packed Qwen3-VL image features and their pre-merge grid."""
+    """Packed Qwen image features and their pre-merge grid."""
 
     embeddings: torch.Tensor
     grid_thw: tuple[int, int, int]
 
 
 class Qwen3VLNativeAdapter(CustomEncoderAdapter[Qwen3VLImageEncoding]):
-    """Build a native external-MM ``TokensPrompt`` for Qwen3-VL."""
+    """Build a native external-MM ``TokensPrompt`` for Qwen3-VL or Qwen3.5."""
 
     def __init__(self, model_config: Any) -> None:
         self._spatial_merge_size = _spatial_merge_size(model_config)
@@ -59,13 +62,13 @@ class Qwen3VLNativeAdapter(CustomEncoderAdapter[Qwen3VLImageEncoding]):
         artifacts: Sequence[Qwen3VLImageEncoding],
     ) -> TokensPrompt:
         if not artifacts:
-            raise ValueError("Qwen3-VL CustomEncoder artifacts must not be empty")
+            raise ValueError("Qwen CustomEncoder artifacts must not be empty")
 
         encodings: list[Qwen3VLImageEncoding] = []
         for index, artifact in enumerate(artifacts):
             if not isinstance(artifact, Qwen3VLImageEncoding):
                 raise TypeError(
-                    "Qwen3-VL CustomEncoder must return Qwen3VLImageEncoding; "
+                    "Qwen CustomEncoder must return Qwen3VLImageEncoding; "
                     f"result {index} is {type(artifact).__name__}"
                 )
             self._validate_encoding(index, artifact)
@@ -90,16 +93,16 @@ class Qwen3VLNativeAdapter(CustomEncoderAdapter[Qwen3VLImageEncoding]):
     def _validate_encoding(self, index: int, encoding: Qwen3VLImageEncoding) -> None:
         embeddings = encoding.embeddings
         if not isinstance(embeddings, torch.Tensor):
-            raise TypeError(f"Qwen3-VL image {index} embeddings must be a tensor")
+            raise TypeError(f"Qwen image {index} embeddings must be a tensor")
         if embeddings.dim() != 2:
             raise ValueError(
-                f"Qwen3-VL image {index} embeddings must be 2D; "
+                f"Qwen image {index} embeddings must be 2D; "
                 f"got shape {tuple(embeddings.shape)}"
             )
         if embeddings.shape[0] < 1:
-            raise ValueError(f"Qwen3-VL image {index} has no embedding rows")
+            raise ValueError(f"Qwen image {index} has no embedding rows")
         if embeddings.device.type != "cpu":
-            raise ValueError(f"Qwen3-VL image {index} embeddings must be on CPU")
+            raise ValueError(f"Qwen image {index} embeddings must be on CPU")
 
         grid = encoding.grid_thw
         if (
@@ -111,19 +114,19 @@ class Qwen3VLNativeAdapter(CustomEncoderAdapter[Qwen3VLImageEncoding]):
             or any(value < 1 for value in grid)
         ):
             raise ValueError(
-                f"Qwen3-VL image {index} grid_thw must contain three positive integers"
+                f"Qwen image {index} grid_thw must contain three positive integers"
             )
 
         temporal, height, width = grid
         merge_size = self._spatial_merge_size
         if height % merge_size or width % merge_size:
             raise ValueError(
-                f"Qwen3-VL image {index} grid H/W must be divisible by "
+                f"Qwen image {index} grid H/W must be divisible by "
                 f"spatial_merge_size={merge_size}"
             )
         expected_rows = temporal * height * width // merge_size**2
         if embeddings.shape[0] != expected_rows:
             raise ValueError(
-                f"Qwen3-VL image {index} has {embeddings.shape[0]} embedding rows; "
+                f"Qwen image {index} has {embeddings.shape[0]} embedding rows; "
                 f"grid {grid} requires {expected_rows}"
             )

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/qwen3_vl.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/qwen3_vl.py
@@ -21,6 +21,7 @@ _NATIVE_QWEN_VLM_ARCHITECTURES = frozenset(
         "Qwen3VLForConditionalGeneration",
         "Qwen3VLMoeForConditionalGeneration",
         "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
     }
 )
 

--- a/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/adapter/test_vllm_linear.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/adapter/test_vllm_linear.py
@@ -127,8 +127,14 @@ class _Backend(VisionEncoderBackend):
         raise NotImplementedError
 
 
-def _model_config(*, multimodal: bool = False, callable_flag: bool = False):
+def _model_config(
+    *,
+    multimodal: bool = False,
+    callable_flag: bool = False,
+    architecture: str | None = None,
+) -> SimpleNamespace:
     return SimpleNamespace(
+        architectures=[architecture] if architecture is not None else [],
         dtype=torch.bfloat16,
         get_hidden_size=lambda: 4,
         is_multimodal_model=(lambda: multimodal) if callable_flag else multimodal,
@@ -155,6 +161,16 @@ def test_text_decoder_selects_linear_adapter_and_builds_final_prompt():
         2,
     ]
     assert prompt["prompt_is_token_ids"] == [True, False, False, True]
+
+
+def test_text_only_qwen_decoder_selects_linear_adapter():
+    adapter = create_custom_encoder_adapter(
+        _Backend(),
+        _model_config(architecture="Qwen2ForCausalLM"),
+        _engine_args(),
+    )
+
+    assert type(adapter).__name__ == "LinearEmbedsAdapter"
 
 
 def test_linear_adapter_requires_prompt_embeds_flag():

--- a/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/adapter/test_vllm_qwen3_vl.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/adapter/test_vllm_qwen3_vl.py
@@ -48,9 +48,10 @@ def _adapter(architecture: str = "Qwen3VLForConditionalGeneration"):
     [
         "Qwen3VLForConditionalGeneration",
         "Qwen3VLMoeForConditionalGeneration",
+        "Qwen3_5ForConditionalGeneration",
     ],
 )
-def test_qwen3_vl_decoder_selects_native_adapter(architecture):
+def test_supported_qwen_decoder_selects_native_adapter(architecture):
     assert type(_adapter(architecture)).__name__ == "Qwen3VLNativeAdapter"
 
 

--- a/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/adapter/test_vllm_qwen3_vl.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/adapter/test_vllm_qwen3_vl.py
@@ -49,6 +49,7 @@ def _adapter(architecture: str = "Qwen3VLForConditionalGeneration"):
         "Qwen3VLForConditionalGeneration",
         "Qwen3VLMoeForConditionalGeneration",
         "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
     ],
 )
 def test_supported_qwen_decoder_selects_native_adapter(architecture):

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_qwen3_5_vision_encoder.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_qwen3_5_vision_encoder.py
@@ -3,6 +3,8 @@
 
 """CPU unit tests for the Qwen3.5 custom vision-encoder example."""
 
+import base64
+import io
 from types import SimpleNamespace
 
 import pytest
@@ -66,35 +68,59 @@ def _item(grid: tuple[int, int, int]) -> Qwen35ImageInputs:
     )
 
 
-class _FakeResponse:
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        return False
-
-    def read(self) -> bytes:
-        return b"image-bytes"
+def _png_data_url() -> str:
+    stream = io.BytesIO()
+    Image.new("RGB", (2, 2), color="green").save(stream, format="PNG")
+    encoded = base64.b64encode(stream.getvalue()).decode()
+    return f"data:image/png;base64,{encoded}"
 
 
-def test_preprocess_returns_processor_output(monkeypatch):
+def test_preprocess_returns_processor_output():
     encoder = Qwen35VisionEncoder()
     encoder._processor = SimpleNamespace(image_processor=_FakeImageProcessor())
-    monkeypatch.setattr(
-        "examples.custom_encoder.qwen3_5_vision_encoder.urllib.request.urlopen",
-        lambda raw, timeout: _FakeResponse(),
-    )
-    monkeypatch.setattr(
-        "examples.custom_encoder.qwen3_5_vision_encoder.Image.open",
-        lambda _stream: Image.new("RGB", (2, 2)),
-    )
 
-    result = encoder.preprocess("data:image/png;base64,example")
+    result = encoder.preprocess(_png_data_url())
 
     assert isinstance(result, Preprocessed)
     assert result.cost == 1
     assert result.item.pixel_values.shape == (4, 6)
     assert result.item.image_grid_thw.tolist() == [[1, 2, 2]]
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "https://example.com/image.png",
+        "file:///etc/passwd",
+        "data:text/plain;base64,aGVsbG8=",
+        "data:image/png,not-base64",
+    ],
+)
+def test_preprocess_rejects_non_base64_image_data_urls(raw):
+    encoder = Qwen35VisionEncoder()
+    encoder._processor = SimpleNamespace(image_processor=_FakeImageProcessor())
+
+    with pytest.raises(ValueError, match="inline base64 image data URL"):
+        encoder.preprocess(raw)
+
+
+def test_preprocess_rejects_invalid_base64():
+    encoder = Qwen35VisionEncoder()
+    encoder._processor = SimpleNamespace(image_processor=_FakeImageProcessor())
+
+    with pytest.raises(ValueError, match="invalid base64"):
+        encoder.preprocess("data:image/png;base64,not_valid!")
+
+
+def test_preprocess_rejects_oversized_inline_image(monkeypatch):
+    encoder = Qwen35VisionEncoder()
+    encoder._processor = SimpleNamespace(image_processor=_FakeImageProcessor())
+    monkeypatch.setattr(
+        "examples.custom_encoder.qwen3_5_vision_encoder._MAX_BASE64_CHARS", 4
+    )
+
+    with pytest.raises(ValueError, match="exceeds"):
+        encoder.preprocess("data:image/png;base64,AAAAA")
 
 
 def test_forward_batch_splits_qwen_artifacts_in_input_order():

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_qwen3_5_vision_encoder.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_qwen3_5_vision_encoder.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU unit tests for the Qwen3.5 custom vision-encoder example."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from PIL import Image
+
+from dynamo.vllm.multimodal_utils.custom_encoder import (
+    Preprocessed,
+    Qwen3VLImageEncoding,
+)
+from examples.custom_encoder.qwen3_5_vision_encoder import (
+    Qwen35ImageInputs,
+    Qwen35VisionEncoder,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.multimodal,
+]
+
+
+class _FakeImageProcessor:
+    def __call__(self, *, images, return_tensors):
+        assert len(images) == 1
+        assert return_tensors == "pt"
+        return {
+            "pixel_values": torch.ones((4, 6)),
+            "image_grid_thw": torch.tensor([[1, 2, 2]]),
+        }
+
+
+class _FakeVisual(torch.nn.Module):
+    dtype = torch.bfloat16
+    spatial_merge_size = 2
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor,
+        *,
+        return_dict: bool,
+    ) -> SimpleNamespace:
+        assert pixel_values.dtype == torch.bfloat16
+        assert return_dict is True
+        token_count = int((grid_thw.prod(dim=-1) // 4).sum().item())
+        return SimpleNamespace(
+            pooler_output=torch.arange(
+                token_count * 4,
+                dtype=torch.bfloat16,
+            ).reshape(token_count, 4)
+        )
+
+
+def _item(grid: tuple[int, int, int]) -> Qwen35ImageInputs:
+    return Qwen35ImageInputs(
+        pixel_values=torch.ones((grid[0] * grid[1] * grid[2], 6)),
+        image_grid_thw=torch.tensor([grid]),
+    )
+
+
+class _FakeResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def read(self) -> bytes:
+        return b"image-bytes"
+
+
+def test_preprocess_returns_processor_output(monkeypatch):
+    encoder = Qwen35VisionEncoder()
+    encoder._processor = SimpleNamespace(image_processor=_FakeImageProcessor())
+    monkeypatch.setattr(
+        "examples.custom_encoder.qwen3_5_vision_encoder.urllib.request.urlopen",
+        lambda raw, timeout: _FakeResponse(),
+    )
+    monkeypatch.setattr(
+        "examples.custom_encoder.qwen3_5_vision_encoder.Image.open",
+        lambda _stream: Image.new("RGB", (2, 2)),
+    )
+
+    result = encoder.preprocess("data:image/png;base64,example")
+
+    assert isinstance(result, Preprocessed)
+    assert result.cost == 1
+    assert result.item.pixel_values.shape == (4, 6)
+    assert result.item.image_grid_thw.tolist() == [[1, 2, 2]]
+
+
+def test_forward_batch_splits_qwen_artifacts_in_input_order():
+    encoder = Qwen35VisionEncoder()
+    encoder._device = torch.device("cpu")
+    encoder._visual = _FakeVisual()
+
+    outputs = encoder.forward_batch([_item((1, 2, 2)), _item((1, 2, 4))])
+
+    assert all(isinstance(output, Qwen3VLImageEncoding) for output in outputs)
+    assert [output.grid_thw for output in outputs] == [(1, 2, 2), (1, 2, 4)]
+    assert [tuple(output.embeddings.shape) for output in outputs] == [(1, 4), (2, 4)]
+    assert outputs[0].embeddings[:, 0].tolist() == [0]
+    assert outputs[1].embeddings[:, 0].tolist() == [4, 8]
+    assert all(output.embeddings.device.type == "cpu" for output in outputs)
+
+
+def test_close_releases_example_resources():
+    encoder = Qwen35VisionEncoder()
+    encoder._processor = object()
+    encoder._visual = _FakeVisual()
+
+    encoder.close()
+
+    assert encoder._processor is None
+    assert encoder._visual is None

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_qwen3_5_vision_encoder.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_qwen3_5_vision_encoder.py
@@ -71,7 +71,11 @@ def _item(grid: tuple[int, int, int]) -> Qwen35ImageInputs:
 def _png_data_url() -> str:
     stream = io.BytesIO()
     Image.new("RGB", (2, 2), color="green").save(stream, format="PNG")
-    encoded = base64.b64encode(stream.getvalue()).decode()
+    return _image_data_url(stream.getvalue())
+
+
+def _image_data_url(image_bytes: bytes) -> str:
+    encoded = base64.b64encode(image_bytes).decode()
     return f"data:image/png;base64,{encoded}"
 
 
@@ -110,6 +114,31 @@ def test_preprocess_rejects_invalid_base64():
 
     with pytest.raises(ValueError, match="invalid base64"):
         encoder.preprocess("data:image/png;base64,not_valid!")
+
+
+def test_preprocess_normalizes_invalid_image_errors():
+    encoder = Qwen35VisionEncoder()
+    encoder._processor = SimpleNamespace(image_processor=_FakeImageProcessor())
+
+    with pytest.raises(ValueError, match="could not be decoded"):
+        encoder.preprocess(_image_data_url(b"not-an-image"))
+
+
+def test_preprocess_rejects_decoded_images_over_pixel_limit(monkeypatch):
+    encoder = Qwen35VisionEncoder()
+    encoder._processor = SimpleNamespace(image_processor=_FakeImageProcessor())
+    raw = _png_data_url()
+    monkeypatch.setattr(
+        "examples.custom_encoder.qwen3_5_vision_encoder._MAX_IMAGE_PIXELS", 3
+    )
+    monkeypatch.setattr(
+        Image.Image,
+        "convert",
+        lambda *_args, **_kwargs: pytest.fail("oversized image was converted"),
+    )
+
+    with pytest.raises(ValueError, match="decoded pixels"):
+        encoder.preprocess(raw)
 
 
 def test_preprocess_rejects_oversized_inline_image(monkeypatch):

--- a/examples/custom_encoder/launch/agg_qwen3_5_native.sh
+++ b/examples/custom_encoder/launch/agg_qwen3_5_native.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../common/gpu_utils.sh"
 source "$SCRIPT_DIR/../../common/launch_utils.sh"
 
-MODEL="${DYN_MODEL:-Qwen/Qwen3.5-2B}"
+MODEL="${DYN_MODEL:-Qwen/Qwen3.5-0.8B}"
 ENCODER_CLASS="${DYN_ENCODER_CLASS:-examples.custom_encoder.qwen3_5_vision_encoder.Qwen35VisionEncoder}"
 WORKER_GPU="${DYN_WORKER_GPU:-${CUDA_VISIBLE_DEVICES:-0}}"
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
@@ -34,7 +34,7 @@ Usage: agg_qwen3_5_native.sh [OPTIONS]
 Run Qwen3.5 with the in-process teaching custom vision encoder.
 
 Options:
-  --model <id>           Qwen3.5 checkpoint (default: Qwen/Qwen3.5-2B)
+  --model <id>           Qwen3.5 checkpoint (default: Qwen/Qwen3.5-0.8B)
   --encoder-class <path> Dotted CustomEncoder class
   --gpu <index>          GPU index for the aggregated worker
   -h, --help             Show this help
@@ -45,8 +45,10 @@ EOF
     esac
 done
 
+# Match the bounded Qwen3.5-0.8B aggregate profile by default. The profiler and
+# test harness can replace this per run through the same override.
+: "${_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES:=920126000}"
 GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
-[[ -z "$GPU_MEM_ARGS" ]] && GPU_MEM_ARGS="--gpu-memory-utilization ${DYN_VLLM_GPU_MEMORY_UTILIZATION:-0.55}"
 
 print_launch_banner --multimodal "Qwen3.5 CustomEncoder — Aggregated" \
     "$MODEL" "$HTTP_PORT" \

--- a/examples/custom_encoder/launch/agg_qwen3_5_native.sh
+++ b/examples/custom_encoder/launch/agg_qwen3_5_native.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Aggregated Qwen3.5 with the teaching custom vision encoder.
+
+set -e
+trap 'echo "Cleaning up..."; kill 0' EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../common/gpu_utils.sh"
+source "$SCRIPT_DIR/../../common/launch_utils.sh"
+
+MODEL="${DYN_MODEL:-Qwen/Qwen3.5-2B}"
+ENCODER_CLASS="${DYN_ENCODER_CLASS:-examples.custom_encoder.qwen3_5_vision_encoder.Qwen35VisionEncoder}"
+WORKER_GPU="${DYN_WORKER_GPU:-${CUDA_VISIBLE_DEVICES:-0}}"
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+MAX_MODEL_LEN="${DYN_MAX_MODEL_LEN:-4096}"
+MAX_NUM_SEQS="${DYN_MAX_NUM_SEQS:-2}"
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model)
+            MODEL=$2; shift 2 ;;
+        --encoder-class)
+            ENCODER_CLASS=$2; shift 2 ;;
+        --gpu)
+            WORKER_GPU=$2; shift 2 ;;
+        -h|--help)
+            cat <<'EOF'
+Usage: agg_qwen3_5_native.sh [OPTIONS]
+
+Run Qwen3.5 with the in-process teaching custom vision encoder.
+
+Options:
+  --model <id>           Qwen3.5 checkpoint (default: Qwen/Qwen3.5-2B)
+  --encoder-class <path> Dotted CustomEncoder class
+  --gpu <index>          GPU index for the aggregated worker
+  -h, --help             Show this help
+EOF
+            exit 0 ;;
+        *)
+            EXTRA_ARGS+=("$1"); shift ;;
+    esac
+done
+
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+[[ -z "$GPU_MEM_ARGS" ]] && GPU_MEM_ARGS="--gpu-memory-utilization ${DYN_VLLM_GPU_MEMORY_UTILIZATION:-0.55}"
+
+print_launch_banner --multimodal "Qwen3.5 CustomEncoder — Aggregated" \
+    "$MODEL" "$HTTP_PORT" \
+    "Worker GPU:  $WORKER_GPU" \
+    "Encoder:     $ENCODER_CLASS" \
+    "NOTE: This encoder is a readable teaching example, not a tuned backend."
+
+export DYN_REQUEST_PLANE=tcp
+export DYN_TCP_MAX_MESSAGE_SIZE=209715200
+export DYN_HTTP_BODY_LIMIT_MB=200
+
+echo "[1/2] Starting frontend (port $HTTP_PORT)..."
+python -m dynamo.frontend &
+
+echo "[2/2] Starting Qwen3.5 worker (model=$MODEL, GPU=$WORKER_GPU)..."
+CUDA_VISIBLE_DEVICES=$WORKER_GPU \
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+python -m dynamo.vllm \
+    --model "$MODEL" \
+    --custom-encoder-class "$ENCODER_CLASS" \
+    --enable-multimodal \
+    --enable-mm-embeds \
+    --no-enable-prefix-caching \
+    --no-enable-chunked-prefill \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --max-num-seqs "$MAX_NUM_SEQS" \
+    $GPU_MEM_ARGS \
+    "${EXTRA_ARGS[@]}" &
+
+wait_any_exit

--- a/examples/custom_encoder/qwen3_5_vision_encoder.py
+++ b/examples/custom_encoder/qwen3_5_vision_encoder.py
@@ -33,6 +33,7 @@ from dynamo.vllm.multimodal_utils.custom_encoder import (
 
 _MAX_IMAGE_BYTES = 20 * 1024 * 1024
 _MAX_BASE64_CHARS = 4 * ((_MAX_IMAGE_BYTES + 2) // 3)
+_MAX_IMAGE_PIXELS = 16_777_216
 
 
 def _decode_image_data_url(raw: str) -> bytes:
@@ -56,6 +57,20 @@ def _decode_image_data_url(raw: str) -> bytes:
     if len(image_bytes) > _MAX_IMAGE_BYTES:
         raise ValueError(f"Inline image exceeds {_MAX_IMAGE_BYTES} bytes")
     return image_bytes
+
+
+def _open_bounded_image(image_bytes: bytes) -> Image.Image:
+    """Decode one RGB image without exceeding the processor's pixel ceiling."""
+    try:
+        with Image.open(io.BytesIO(image_bytes)) as source:
+            width, height = source.size
+            if width < 1 or height < 1 or width * height > _MAX_IMAGE_PIXELS:
+                raise ValueError(
+                    f"Inline image exceeds {_MAX_IMAGE_PIXELS} decoded pixels"
+                )
+            return source.convert("RGB")
+    except (Image.DecompressionBombError, OSError) as exc:
+        raise ValueError("Inline image could not be decoded") from exc
 
 
 @dataclass(frozen=True)
@@ -107,8 +122,13 @@ class Qwen35VisionEncoder(
         if self._processor is None:
             raise RuntimeError("Qwen35VisionEncoder is not loaded")
 
-        image = Image.open(io.BytesIO(_decode_image_data_url(raw))).convert("RGB")
-        inputs = self._processor.image_processor(images=[image], return_tensors="pt")
+        image = _open_bounded_image(_decode_image_data_url(raw))
+        try:
+            inputs = self._processor.image_processor(
+                images=[image], return_tensors="pt"
+            )
+        finally:
+            image.close()
         return Preprocessed(
             Qwen35ImageInputs(
                 pixel_values=inputs["pixel_values"].contiguous(),

--- a/examples/custom_encoder/qwen3_5_vision_encoder.py
+++ b/examples/custom_encoder/qwen3_5_vision_encoder.py
@@ -6,29 +6,56 @@
 This is a teaching example, not a performance reference. It favors a short,
 readable implementation over fast checkpoint loading, caching, CUDA graphs, or
 production media handling. In particular, ``build`` temporarily loads the full
-checkpoint before retaining only the vision tower, and ``preprocess`` uses
-``urllib`` without an application-specific URL allowlist.
+checkpoint before retaining only the vision tower. ``preprocess`` accepts only
+bounded inline image data so the example never performs server-side URL fetches.
 Production backends should add the policies and optimizations their workload
 requires.
 """
 
 from __future__ import annotations
 
+import base64
+import binascii
 import gc
 import io
-import urllib.request
 from dataclasses import dataclass
 from typing import Any
 
 import torch
 from PIL import Image
-from transformers import AutoProcessor, Qwen3_5ForConditionalGeneration
+from transformers import AutoModelForImageTextToText, AutoProcessor
 
 from dynamo.vllm.multimodal_utils.custom_encoder import (
     Preprocessed,
     Qwen3VLImageEncoding,
     VisionEncoderBackend,
 )
+
+_MAX_IMAGE_BYTES = 20 * 1024 * 1024
+_MAX_BASE64_CHARS = 4 * ((_MAX_IMAGE_BYTES + 2) // 3)
+
+
+def _decode_image_data_url(raw: str) -> bytes:
+    """Decode one bounded base64 image data URL without network access."""
+    header, separator, encoded = raw.partition(",")
+    media_type, *parameters = header[5:].split(";")
+    if (
+        not separator
+        or header[:5].lower() != "data:"
+        or not media_type.lower().startswith("image/")
+        or "base64" not in {parameter.lower() for parameter in parameters}
+    ):
+        raise ValueError("Expected an inline base64 image data URL")
+    if len(encoded) > _MAX_BASE64_CHARS:
+        raise ValueError(f"Inline image exceeds {_MAX_IMAGE_BYTES} bytes")
+
+    try:
+        image_bytes = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("Inline image contains invalid base64 data") from exc
+    if len(image_bytes) > _MAX_IMAGE_BYTES:
+        raise ValueError(f"Inline image exceeds {_MAX_IMAGE_BYTES} bytes")
+    return image_bytes
 
 
 @dataclass(frozen=True)
@@ -64,7 +91,7 @@ class Qwen35VisionEncoder(
         self._processor = AutoProcessor.from_pretrained(model_id)
         # This teaching backend retains Qwen3.5's tower. A custom backend can
         # load its own encoder and projector here instead.
-        model = Qwen3_5ForConditionalGeneration.from_pretrained(
+        model = AutoModelForImageTextToText.from_pretrained(
             model_id,
             dtype=torch.bfloat16,
             low_cpu_mem_usage=True,
@@ -76,12 +103,11 @@ class Qwen35VisionEncoder(
         gc.collect()
 
     def preprocess(self, raw: str) -> Preprocessed[Qwen35ImageInputs]:
-        """Fetch, decode, and patchify one image on a preprocessing thread."""
+        """Decode and patchify one bounded inline image on a preprocessing thread."""
         if self._processor is None:
             raise RuntimeError("Qwen35VisionEncoder is not loaded")
 
-        with urllib.request.urlopen(raw, timeout=30) as response:
-            image = Image.open(io.BytesIO(response.read())).convert("RGB")
+        image = Image.open(io.BytesIO(_decode_image_data_url(raw))).convert("RGB")
         inputs = self._processor.image_processor(images=[image], return_tensors="pt")
         return Preprocessed(
             Qwen35ImageInputs(

--- a/examples/custom_encoder/qwen3_5_vision_encoder.py
+++ b/examples/custom_encoder/qwen3_5_vision_encoder.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small Qwen3.5 implementation of Dynamo's custom vision-encoder contract.
+
+This is a teaching example, not a performance reference. It favors a short,
+readable implementation over fast checkpoint loading, caching, CUDA graphs, or
+production media handling. In particular, ``build`` temporarily loads the full
+checkpoint before retaining only the vision tower, and ``preprocess`` uses
+``urllib`` without an application-specific URL allowlist.
+Production backends should add the policies and optimizations their workload
+requires.
+"""
+
+from __future__ import annotations
+
+import gc
+import io
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from PIL import Image
+from transformers import AutoProcessor, Qwen3_5ForConditionalGeneration
+
+from dynamo.vllm.multimodal_utils.custom_encoder import (
+    Preprocessed,
+    Qwen3VLImageEncoding,
+    VisionEncoderBackend,
+)
+
+
+@dataclass(frozen=True)
+class Qwen35ImageInputs:
+    """CPU processor output for one image."""
+
+    pixel_values: torch.Tensor
+    image_grid_thw: torch.Tensor
+
+
+class Qwen35VisionEncoder(
+    VisionEncoderBackend[str, Qwen35ImageInputs, Qwen3VLImageEncoding]
+):
+    """Run the Qwen3.5 vision tower as a minimal custom-encoder example.
+
+    The class demonstrates the four lifecycle hooks and native ``TokensPrompt``
+    artifact shape. This implementation reuses the checkpoint's vision tower,
+    but users can bring their own vision encoder and projector by replacing the
+    loading and forward paths. The replacement must return projected rows and
+    grid metadata compatible with the running Qwen3.5 decoder.
+    """
+
+    preprocess_concurrency = 4
+
+    def __init__(self) -> None:
+        self._device = torch.device("cpu")
+        self._processor: Any | None = None
+        self._visual: Any | None = None
+
+    def build(self, model_id: str) -> None:
+        """Load the processor and retain only the checkpoint's vision tower."""
+        self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self._processor = AutoProcessor.from_pretrained(model_id)
+        # This teaching backend retains Qwen3.5's tower. A custom backend can
+        # load its own encoder and projector here instead.
+        model = Qwen3_5ForConditionalGeneration.from_pretrained(
+            model_id,
+            dtype=torch.bfloat16,
+            low_cpu_mem_usage=True,
+            attn_implementation="sdpa",
+        )
+        self._visual = model.model.visual.eval().to(self._device)
+        model.model.visual = None
+        del model
+        gc.collect()
+
+    def preprocess(self, raw: str) -> Preprocessed[Qwen35ImageInputs]:
+        """Fetch, decode, and patchify one image on a preprocessing thread."""
+        if self._processor is None:
+            raise RuntimeError("Qwen35VisionEncoder is not loaded")
+
+        with urllib.request.urlopen(raw, timeout=30) as response:
+            image = Image.open(io.BytesIO(response.read())).convert("RGB")
+        inputs = self._processor.image_processor(images=[image], return_tensors="pt")
+        return Preprocessed(
+            Qwen35ImageInputs(
+                pixel_values=inputs["pixel_values"].contiguous(),
+                image_grid_thw=inputs["image_grid_thw"].to(dtype=torch.long),
+            )
+        )
+
+    def forward_batch(
+        self,
+        items: list[Qwen35ImageInputs],
+        target_bucket: int | None = None,
+    ) -> list[Qwen3VLImageEncoding]:
+        """Encode a Dynamo-formed batch and restore one artifact per image."""
+        del target_bucket
+        if self._visual is None:
+            raise RuntimeError("Qwen35VisionEncoder is not loaded")
+
+        pixel_values = torch.cat([item.pixel_values for item in items], dim=0).to(
+            device=self._device,
+            dtype=self._visual.dtype,
+        )
+        image_grid_thw_cpu = torch.cat([item.image_grid_thw for item in items], dim=0)
+        image_grid_thw = image_grid_thw_cpu.to(self._device)
+
+        with torch.inference_mode():
+            vision_output = self._visual(
+                pixel_values,
+                grid_thw=image_grid_thw,
+                return_dict=True,
+            )
+
+        embeddings = vision_output.pooler_output.to(
+            device="cpu", dtype=torch.bfloat16
+        ).contiguous()
+        split_sizes = (
+            image_grid_thw_cpu.prod(dim=-1) // self._visual.spatial_merge_size**2
+        ).tolist()
+
+        return [
+            Qwen3VLImageEncoding(
+                embeddings=rows,
+                grid_thw=(int(grid[0]), int(grid[1]), int(grid[2])),
+            )
+            for rows, grid in zip(
+                torch.split(embeddings, split_sizes),
+                image_grid_thw_cpu.tolist(),
+                strict=True,
+            )
+        ]
+
+    def close(self) -> None:
+        """Release resources created by ``build``."""
+        self._processor = None
+        self._visual = None

--- a/examples/custom_encoder/qwen_vision_encoder.py
+++ b/examples/custom_encoder/qwen_vision_encoder.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Reusable example base for Qwen-family ``VisionEncoderBackend`` authors.
+"""Reusable example base for Qwen-family ``EmbedsPrompt`` encoder authors.
 
 Hardcodes the Qwen ``<|image_pad|>`` placeholder id and loads the model tokenizer
 (handy for subclasses that tokenize text). A concrete Qwen-family encoder
@@ -27,14 +27,13 @@ from dynamo.vllm.multimodal_utils.custom_encoder import VisionEncoderBackend
 
 
 class QwenVisionEncoderBackend(VisionEncoderBackend):
-    """``VisionEncoderBackend`` base for Qwen-family models (Qwen2-VL / Qwen3-VL /
-    Qwen3.5).
+    """``VisionEncoderBackend`` base for Qwen-family ``EmbedsPrompt`` examples.
 
     Hardcodes ``image_token_id`` to Qwen3-VL's ``<|image_pad|>`` (151655) — override
-    it for other versions (e.g. 248056 for Qwen3.5). ``build`` loads the model
-    tokenizer; ``forward_batch`` stays abstract, so this class cannot be
-    instantiated directly — subclass it and implement ``forward_batch`` (and
-    ``preprocess`` only if it needs off-loop prep).
+    it for other versions. The linear adapter uses this token to locate embedding
+    replacement spans; native ``TokensPrompt`` encoders, such as the Qwen3.5
+    example, do not need it. ``build`` loads the model tokenizer;
+    ``forward_batch`` stays abstract, so this class cannot be instantiated directly.
     """
 
     # Qwen3-VL <|image_pad|>; override for other Qwen versions.

--- a/tests/serve/conftest.py
+++ b/tests/serve/conftest.py
@@ -93,11 +93,20 @@ MULTIMODAL_MEDIA_DIR = _MEDIA_DIR
 MULTIMODAL_VIDEO_EXPECTED = ["triangle"]
 
 
-def get_multimodal_test_image_bytes() -> bytes:
-    """Return a deterministic PNG with an obvious green square."""
+def get_multimodal_test_image_bytes(color: str = "green") -> bytes:
+    """Return a deterministic PNG with an obvious green or red square."""
 
     # Lazy import so conftest loads in environments that don't have Pillow (e.g. pre-commit).
     from PIL import Image, ImageDraw
+
+    palette = {
+        "green": ((0, 180, 0), (0, 90, 0)),
+        "red": ((220, 30, 30), (130, 0, 0)),
+    }
+    try:
+        fill, outline = palette[color]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported multimodal test image color: {color}") from exc
 
     buf = BytesIO()
     # Keep this synthetic so CI never depends on Git LFS media. The white
@@ -105,8 +114,8 @@ def get_multimodal_test_image_bytes() -> bytes:
     # an edge-to-edge flat color.
     img = Image.new("RGB", (512, 512), color="white")
     draw = ImageDraw.Draw(img)
-    draw.rectangle((96, 96, 416, 416), fill=(0, 180, 0), outline=(0, 90, 0), width=8)
-    draw.text((214, 444), "GREEN", fill=(0, 90, 0))
+    draw.rectangle((96, 96, 416, 416), fill=fill, outline=outline, width=8)
+    draw.text((214, 444), color.upper(), fill=outline)
     img.save(buf, format="PNG")
     return buf.getvalue()
 

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -405,7 +405,6 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 requested_vllm_kv_cache_bytes=920_126_000,
                 directory=os.path.join(WORKSPACE_DIR, "examples/custom_encoder"),
                 env={
-                    "DYN_WORKER_GPU": "0",
                     "PYTHONPATH": str(WORKSPACE_DIR),
                 },
                 tests=[

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -404,7 +404,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
         short_name="qwen3.5-2b-custom-encoder",
         topologies={
             "agg_custom_qwen3_5": TopologyConfig(
-                marks=[pytest.mark.post_merge],
+                marks=[pytest.mark.nightly, pytest.mark.h100],
                 timeout_s=900,
                 # Single-pass H100 peak: 44.5 GiB. Keep this sequential until a
                 # bounded --kv-cache-memory-bytes profile is available.

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -397,17 +397,12 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                     )
                 ],
             ),
-        },
-    ),
-    MultimodalModelProfile(
-        name="Qwen/Qwen3.5-2B",
-        short_name="qwen3.5-2b-custom-encoder",
-        topologies={
             "agg_custom_qwen3_5": TopologyConfig(
-                marks=[pytest.mark.nightly, pytest.mark.h100],
+                marks=[pytest.mark.nightly],
                 timeout_s=900,
-                # Single-pass H100 peak: 44.5 GiB. Keep this sequential until a
-                # bounded --kv-cache-memory-bytes profile is available.
+                profiled_vram_gib=4.7,
+                # Reuse the aggregate profile's 2x-safe KV cache cap.
+                requested_vllm_kv_cache_bytes=920_126_000,
                 directory=os.path.join(WORKSPACE_DIR, "examples/custom_encoder"),
                 env={
                     "DYN_WORKER_GPU": "0",

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -21,6 +21,8 @@ from tests.utils.multimodal import (
     make_image_payload_b64,
     make_image_payload_cached_tokens,
     make_image_payload_uuid_passthrough,
+    make_qwen35_custom_encoder_multi_image_payload,
+    make_qwen35_custom_encoder_payload,
     make_video_payload,
 )
 from tests.utils.payload_builder import (
@@ -78,10 +80,11 @@ VLLM_TOPOLOGY_SCRIPTS: dict[str, str] = {
     "epd": "disagg_multimodal_epd.sh",
     "epd_video": "disagg_multimodal_epd.sh",
     "p_d": "disagg_multimodal_p_d.sh",
-    # CustomEncoder: a custom in-process vision encoder on a text-only LM
+    # CustomEncoder: a custom in-process vision encoder beside the decoder
     # (no separate encode worker, no NIXL). Lives in examples/custom_encoder,
     # not examples/backends/vllm — the TopologyConfig sets `directory` to match.
     "agg_custom": "agg_custom.sh",
+    "agg_custom_qwen3_5": "agg_qwen3_5_native.sh",
 }
 
 VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
@@ -392,6 +395,33 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                             prompt_filler_repeats=120,
                         )
                     )
+                ],
+            ),
+        },
+    ),
+    MultimodalModelProfile(
+        name="Qwen/Qwen3.5-2B",
+        short_name="qwen3.5-2b-custom-encoder",
+        topologies={
+            "agg_custom_qwen3_5": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=900,
+                # Single-pass H100 peak: 44.5 GiB. Keep this sequential until a
+                # bounded --kv-cache-memory-bytes profile is available.
+                directory=os.path.join(WORKSPACE_DIR, "examples/custom_encoder"),
+                env={
+                    "DYN_WORKER_GPU": "0",
+                    "PYTHONPATH": str(WORKSPACE_DIR),
+                },
+                tests=[
+                    MmCase(
+                        suffix="single_image",
+                        payload=make_qwen35_custom_encoder_payload(),
+                    ),
+                    MmCase(
+                        suffix="multi_image",
+                        payload=make_qwen35_custom_encoder_multi_image_payload(),
+                    ),
                 ],
             ),
         },

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -289,6 +289,8 @@ class Base64LazyChatPayload(ChatPayload):
         temperature: float = 0.0,
         repeat_count: int = 1,
         timeout: int = 60,
+        expected_log: Optional[list[str]] = None,
+        image_count: int = 1,
     ):
         """Stash payload params for lazy body construction, then run parent init."""
         # Initialize lazy state and the init flag BEFORE super().__init__ —
@@ -298,12 +300,13 @@ class Base64LazyChatPayload(ChatPayload):
         object.__setattr__(self, "_b64_prompt", prompt)
         object.__setattr__(self, "_b64_max_tokens", max_tokens)
         object.__setattr__(self, "_b64_temperature", temperature)
+        object.__setattr__(self, "_b64_image_count", image_count)
         object.__setattr__(self, "_b64_storage", None)
         object.__setattr__(self, "_b64_materialized", False)
         super().__init__(
             body=None,  # placeholder; replaced when .body is first read
             expected_response=expected_response,
-            expected_log=[],
+            expected_log=list(expected_log or []),
             repeat_count=repeat_count,
             timeout=timeout,
         )
@@ -312,14 +315,18 @@ class Base64LazyChatPayload(ChatPayload):
     def _materialize_body(self) -> dict:
         """Read the LFS image, base64-encode it, and build the chat body dict."""
         b64 = base64.b64encode(get_multimodal_test_image_bytes()).decode()
-        ref = chat_payload(
-            [
-                {"type": "text", "text": self._b64_prompt},
+        content = [
+            {"type": "text", "text": self._b64_prompt},
+            *[
                 {
                     "type": "image_url",
                     "image_url": {"url": f"data:image/png;base64,{b64}"},
-                },
+                }
+                for _ in range(self._b64_image_count)
             ],
+        ]
+        ref = chat_payload(
+            content,
             repeat_count=1,
             expected_response=list(self.expected_response),
             max_tokens=self._b64_max_tokens,
@@ -449,15 +456,8 @@ def make_custom_encoder_payload() -> ChatPayload:
 
 def make_qwen35_custom_encoder_payload() -> ChatPayload:
     """Single-image semantic check for the native Qwen3.5 custom encoder."""
-    return chat_payload(
-        [
-            {
-                "type": "text",
-                "text": "What color is the large square? Answer with one color.",
-            },
-            {"type": "image_url", "image_url": {"url": MULTIMODAL_IMG_URL}},
-        ],
-        repeat_count=1,
+    return Base64LazyChatPayload(
+        prompt="What color is the large square? Answer with one color.",
         expected_response=["green"],
         expected_log=["Qwen35VisionEncoder", "Qwen3VLNativeAdapter"],
         max_tokens=16,
@@ -467,20 +467,13 @@ def make_qwen35_custom_encoder_payload() -> ChatPayload:
 
 def make_qwen35_custom_encoder_multi_image_payload() -> ChatPayload:
     """Two-image check for artifact ordering and placeholder expansion."""
-    return chat_payload(
-        [
-            {
-                "type": "text",
-                "text": "How many images are provided? Answer with only the number.",
-            },
-            {"type": "image_url", "image_url": {"url": MULTIMODAL_IMG_URL}},
-            {"type": "image_url", "image_url": {"url": MULTIMODAL_IMG_URL}},
-        ],
-        repeat_count=1,
+    return Base64LazyChatPayload(
+        prompt="How many images are provided? Answer with only the number.",
         expected_response=["2", "two"],
         expected_log=["Qwen35VisionEncoder", "Qwen3VLNativeAdapter"],
         max_tokens=16,
         temperature=0.0,
+        image_count=2,
     )
 
 

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -447,6 +447,43 @@ def make_custom_encoder_payload() -> ChatPayload:
     )
 
 
+def make_qwen35_custom_encoder_payload() -> ChatPayload:
+    """Single-image semantic check for the native Qwen3.5 custom encoder."""
+    return chat_payload(
+        [
+            {
+                "type": "text",
+                "text": "What color is the large square? Answer with one color.",
+            },
+            {"type": "image_url", "image_url": {"url": MULTIMODAL_IMG_URL}},
+        ],
+        repeat_count=1,
+        expected_response=["green"],
+        expected_log=["Qwen35VisionEncoder", "Qwen3VLNativeAdapter"],
+        max_tokens=16,
+        temperature=0.0,
+    )
+
+
+def make_qwen35_custom_encoder_multi_image_payload() -> ChatPayload:
+    """Two-image check for artifact ordering and placeholder expansion."""
+    return chat_payload(
+        [
+            {
+                "type": "text",
+                "text": "How many images are provided? Answer with only the number.",
+            },
+            {"type": "image_url", "image_url": {"url": MULTIMODAL_IMG_URL}},
+            {"type": "image_url", "image_url": {"url": MULTIMODAL_IMG_URL}},
+        ],
+        repeat_count=1,
+        expected_response=["2", "two"],
+        expected_log=["Qwen35VisionEncoder", "Qwen3VLNativeAdapter"],
+        max_tokens=16,
+        temperature=0.0,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Config dataclasses
 # ---------------------------------------------------------------------------

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -290,8 +290,8 @@ class Base64LazyChatPayload(ChatPayload):
         repeat_count: int = 1,
         timeout: int = 60,
         expected_log: Optional[list[str]] = None,
-        image_count: int = 1,
-    ):
+        image_colors: tuple[str, ...] = ("green",),
+    ) -> None:
         """Stash payload params for lazy body construction, then run parent init."""
         # Initialize lazy state and the init flag BEFORE super().__init__ —
         # the parent dataclass __init__ assigns self.body = ..., which routes
@@ -300,7 +300,7 @@ class Base64LazyChatPayload(ChatPayload):
         object.__setattr__(self, "_b64_prompt", prompt)
         object.__setattr__(self, "_b64_max_tokens", max_tokens)
         object.__setattr__(self, "_b64_temperature", temperature)
-        object.__setattr__(self, "_b64_image_count", image_count)
+        object.__setattr__(self, "_b64_image_colors", image_colors)
         object.__setattr__(self, "_b64_storage", None)
         object.__setattr__(self, "_b64_materialized", False)
         super().__init__(
@@ -314,15 +314,18 @@ class Base64LazyChatPayload(ChatPayload):
 
     def _materialize_body(self) -> dict:
         """Read the LFS image, base64-encode it, and build the chat body dict."""
-        b64 = base64.b64encode(get_multimodal_test_image_bytes()).decode()
+        encoded_images = [
+            base64.b64encode(get_multimodal_test_image_bytes(color)).decode()
+            for color in self._b64_image_colors
+        ]
         content = [
             {"type": "text", "text": self._b64_prompt},
             *[
                 {
                     "type": "image_url",
-                    "image_url": {"url": f"data:image/png;base64,{b64}"},
+                    "image_url": {"url": f"data:image/png;base64,{encoded}"},
                 }
-                for _ in range(self._b64_image_count)
+                for encoded in encoded_images
             ],
         ]
         ref = chat_payload(
@@ -466,14 +469,17 @@ def make_qwen35_custom_encoder_payload() -> ChatPayload:
 
 
 def make_qwen35_custom_encoder_multi_image_payload() -> ChatPayload:
-    """Two-image semantic check for multiple placeholder expansion."""
+    """Order-sensitive two-image check for multiple placeholder expansion."""
     return Base64LazyChatPayload(
-        prompt="What color is the large square in both images? Answer with one color.",
-        expected_response=["green"],
+        prompt=(
+            "Name the square color in the first image and then the second image. "
+            "Answer exactly as: COLOR then COLOR."
+        ),
+        expected_response=["green then red"],
         expected_log=["Qwen35VisionEncoder", "Qwen3VLNativeAdapter"],
         max_tokens=16,
         temperature=0.0,
-        image_count=2,
+        image_colors=("green", "red"),
     )
 
 

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -466,10 +466,10 @@ def make_qwen35_custom_encoder_payload() -> ChatPayload:
 
 
 def make_qwen35_custom_encoder_multi_image_payload() -> ChatPayload:
-    """Two-image check for artifact ordering and placeholder expansion."""
+    """Two-image semantic check for multiple placeholder expansion."""
     return Base64LazyChatPayload(
-        prompt="How many images are provided? Answer with only the number.",
-        expected_response=["2", "two"],
+        prompt="What color is the large square in both images? Answer with one color.",
+        expected_response=["green"],
         expected_log=["Qwen35VisionEncoder", "Qwen3VLNativeAdapter"],
         max_tokens=16,
         temperature=0.0,

--- a/tests/utils/test_multimodal.py
+++ b/tests/utils/test_multimodal.py
@@ -1,10 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
+
 import pytest
 
-from tests.serve.conftest import MULTIMODAL_IMG_URL
-from tests.utils.multimodal import UuidPassthroughChatPayload
+from tests.serve.conftest import MULTIMODAL_IMG_URL, get_multimodal_test_image_bytes
+from tests.utils.multimodal import (
+    UuidPassthroughChatPayload,
+    make_qwen35_custom_encoder_multi_image_payload,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -63,3 +68,17 @@ def test_uuid_embedding_cache_payload_checks_hit_after_gpu_eviction() -> None:
         r"identifier='dynamo\-mm\-cache\-image\-1'"
     ]
     payload.final_validation()
+
+
+def test_qwen35_multi_image_payload_is_order_sensitive() -> None:
+    payload = make_qwen35_custom_encoder_multi_image_payload()
+    content = payload.body["messages"][0]["content"]
+
+    assert payload.expected_response == ["green then red"]
+    assert "green" not in content[0]["text"].lower()
+    assert "red" not in content[0]["text"].lower()
+    assert [part["image_url"]["url"] for part in content[1:]] == [
+        "data:image/png;base64,"
+        + base64.b64encode(get_multimodal_test_image_bytes(color)).decode()
+        for color in ("green", "red")
+    ]


### PR DESCRIPTION
## Why

Dynamo's custom encoder path can splice projected tensors into text-only decoders, but main lacks a runnable native VLM reference that preserves Qwen's multimodal grid and position handling. Qwen3.5 accepts external image features through its registered vLLM wrapper, so this teaching backend shows how an author-provided encoder can run beside the decoder without modifying vLLM. The implementation stays eager and compact so the lifecycle and artifact contract remain visible.

## What Change

- Support Qwen3.5 through the native external-multimodal adapter.
- Add an author-replaceable Qwen3.5 vision backend and launcher.
- Cover adapter selection, lifecycle, and ordered multi-image behavior.

```mermaid
classDiagram
    VisionEncoderBackend <|-- Qwen35VisionEncoder : implements lifecycle
    Qwen35VisionEncoder --> Qwen3VLImageEncoding : emits
    Qwen3VLNativeAdapter --> Qwen3VLImageEncoding : validates
    Qwen3VLNativeAdapter --> TokensPrompt : builds

    note for Qwen35VisionEncoder "Shows a replaceable in-process vision backend"
    note for Qwen3VLNativeAdapter "Preserves the native Qwen multimodal contract"
```

## Test Plan

- Local adapter, lifecycle, compilation, and launcher checks pass.
- Published SHA passed 28 focused tests on one H100.
- Single- and two-image H100 requests returned the expected outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Qwen3.5 multimodal models with custom vision encoders.
  * Added an example vision encoder for loading, preprocessing, batching, and releasing image-processing resources.
  * Added a launch script for aggregated Qwen3.5 multimodal serving.
  * Added single- and multi-image serving profiles, including color recognition, image counting, and artifact ordering scenarios.

* **Bug Fixes**
  * Improved adapter selection for native Qwen vision-language configurations and text-only Qwen decoders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->