### PR TITLE
docs(fern): keep the hero community rail beside the mark on laptop widths

### DIFF
--- a/docs/fern/components/LandingStyles.tsx
+++ b/docs/fern/components/LandingStyles.tsx
@@ -2032,7 +2032,13 @@ article:has(.dynamo-community-page) { margin-bottom: 0; }
 .dynamo-welcome__community {
   position: absolute;
   top: -20rem;
-  right: calc((100vw - 1200px) / -2 + 1rem);
+  /* Sit 1rem in from the viewport's right edge whatever the content column is
+     doing. The previous form hardcoded the 1200px column width, so it only
+     landed correctly while the column was exactly that wide, and it drifted
+     back inward once the viewport fell below 1200px. 50% is half the
+     containing block (the centred column), so 50% - 50vw is the offset from
+     the column's right edge out to the viewport's. */
+  right: calc(50% - 50vw + 1rem);
   z-index: 30;
   display: flex;
   width: 242px;
@@ -2168,7 +2174,19 @@ article:has(.dynamo-community-page) { margin-bottom: 0; }
   text-transform: uppercase;
 }
 
-@media (max-width: 1360px) {
+/* Below this the rail stops floating and becomes a row under the hero.
+   The cutoff was 1360px, which dropped the cards into flow on every ordinary
+   laptop (1280 and 1366 included) and put them below the Get started button
+   rather than up beside the mark, which is not the intended hero.
+
+   1024px is what the geometry actually calls for. The rail is 242px wide and
+   sits 1rem from the viewport edge, so its left edge is at 100vw - 258px,
+   while the only thing level with it is the 92px centred mark spanning
+   50vw ± 46px. Those do not meet until roughly 610px. The wide centred
+   heading and subtitle sit lower than the rail, so they are not in contention
+   either. 1024px therefore keeps a wide margin and still hands tablets the
+   stacked layout. */
+@media (max-width: 1024px) {
 
   .dynamo-welcome__community {
     position: static;

--- a/docs/fern/components/LandingStyles.tsx
+++ b/docs/fern/components/LandingStyles.tsx
@@ -2036,8 +2036,16 @@ article:has(.dynamo-community-page) { margin-bottom: 0; }
      doing. The previous form hardcoded the 1200px column width, so it only
      landed correctly while the column was exactly that wide, and it drifted
      back inward once the viewport fell below 1200px. 50% is half the
-     containing block (the centred column), so 50% - 50vw is the offset from
-     the column's right edge out to the viewport's. */
+     containing block, so 50% - 50vw is the offset from the containing block's
+     right edge out to the viewport's, and the column's own width and padding
+     cancel out of the result.
+
+     This holds only while the containing block is centred in the viewport.
+     It is: the containing block is .dynamo-welcome above, and it fills
+     article:has(.dynamo-welcome), which sets max-width with margin-inline:
+     auto and symmetric padding-inline. If that article ever becomes offset
+     rather than centred -- a sidebar returning to this layout, say -- this
+     offset drifts by exactly that asymmetry and wants revisiting. */
   right: calc(50% - 50vw + 1rem);
   z-index: 30;
   display: flex;


### PR DESCRIPTION
The Slack and Calendar cards render **below the Get started button** instead of floating at the top right of the hero, as designed.

## Cause

Two problems in `.dynamo-welcome__community`, both in `LandingStyles.tsx`.

**1. The static fallback cut in far too early.**

```css
@media (max-width: 1360px) {
  .dynamo-welcome__community { position: static; margin: 2rem auto 0; flex-direction: row; }
}
```

1360px is above every ordinary laptop viewport — 1280 and 1366 included — so on a normal window the rail drops into normal flow. Because `<CommunityRail />` is last in the hero's DOM order, it lands under the terminal and the Get started button. The floating layout only ever appeared on unusually wide displays.

**2. The right offset hardcoded the column width.**

```css
right: calc((100vw - 1200px) / -2 + 1rem);
```

This lands correctly only while the content column is exactly 1200px, and inverts sign once the viewport falls below 1200px, drifting the rail back inward.

## Fix

- Cutoff moved to **1024px**, which is what the geometry supports. The rail is 242px wide and sits 1rem from the viewport edge, so its left edge is at `100vw - 258px`; the only thing level with it is the 92px centred mark spanning `50vw ± 46px`. Those do not meet until roughly **610px**. The wide centred heading and subtitle sit lower than the rail, so they are not in contention either. Tablets and below keep the stacked row.
- Right offset replaced with **`calc(50% - 50vw + 1rem)`**, measuring from the containing block out to the viewport edge, so it holds at any column width and drops the 1200px magic number.

## Verification

Computed the rail's position against the mark across laptop widths:

| viewport | layout | rail spans | mark spans | clear | edge gap |
|---|---|---|---|---|---|
| 1512 | floating | 1254–1496 | 710–802 | yes | 16px |
| 1440 | floating | 1182–1424 | 674–766 | yes | 16px |
| 1366 | floating | 1108–1350 | 637–729 | yes | 16px |
| 1280 | floating | 1022–1264 | 594–686 | yes | 16px |
| 1100 | floating | 842–1084 | 504–596 | yes | 16px |
| 1024 and below | stacked | row under hero | — | — | — |

The constant 16px gap at every width is the new formula doing its job; the old one produced 16px only at exactly 1200px.

Also confirmed the cascade is intact — base `absolute`, `≤1024px` `static`, and the existing `≤640px` block inherits `static` from it rather than re-floating.

## Note

**Not visually verified.** The Fern dev server does not run in this environment (its CLI is incompatible with the Node available here), so this rests on the CSS geometry rather than a rendered page. Worth an eye on the hero before merge, at a normal laptop width and at ~1024px where the layout switches.

If the rail still needs to float below 1024px, that breakpoint is the single knob.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the community rail’s positioning for centered layouts and varying viewport widths.
  * Preserved the floating rail layout on screens as narrow as 1024px for a more consistent responsive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->