### PR TITLE
feat(skills): add fern-recipe-page for publishing a released recipe's docs

### DIFF
--- a/.agents/skills/fern-recipe-page/SKILL.md
+++ b/.agents/skills/fern-recipe-page/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: fern-recipe-page
+description: Publish the Fern docs page for a newly released Dynamo recipe, wire it into the Recipes landing page, catalog and navigation, and validate it before review. Use when a recipe lands under recipes/ and needs customer-facing docs, or when an existing recipe page has drifted from its README. Builds the page from the recipe's own READMEs (including perf/, efa/ and per-precision sub-READMEs) as the source of truth, mirrors their heading structure, and assembles the GPU/Workload/Backend/Topology target picker so it offers exactly the targets that ship. Ships check_recipe_page.py, which gates the PR on MDX structure, CSS-coupled picker vocabulary, dead-end selections, path resolution, catalog coverage and landing-page counts, and emits a checklist for the PR description.
+license: Apache-2.0
+metadata:
+  author: Shwetha Krishnamurthy <skrishnamurt@nvidia.com>
+  tags:
+    - dynamo
+    - docs
+    - fern
+    - recipes
+  permissions:
+    - file_read
+    - file_write
+---
+
+# Fern Recipe Page
+
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+Publish the customer-facing Fern page for a recipe, from the recipe's own
+READMEs, and prove it is correct before asking for review.
+
+**The recipe README on GitHub is the source of truth.** The Fern page presents
+the same information with a target picker on top. It does not add facts the
+READMEs do not carry, and it does not contradict them.
+
+## When to use
+
+- A new recipe landed under `recipes/<model>/` and needs a docs page.
+- An existing page has drifted from its README.
+- A recipe gained or lost a target and the picker needs to match.
+
+## Inputs
+
+The recipe directory, and **every** README inside it — not just the top-level
+one. Find them first; sub-READMEs carry the benchmark procedure and the
+per-precision detail, and missing them is the most common cause of a thin page:
+
+```bash
+find recipes/<model> -name README.md
+```
+
+For `deepseek-v4` that is five files; for `qwen3.5-122b`, five; for `qwen3-32b`,
+three. A page built from the top-level README alone will be missing the trace
+staging step, and its benchmark section will not work.
+
+## Steps
+
+### 1. Read the recipe
+
+Read every README end to end, then the shipped `deploy.yaml` and `perf.yaml`.
+Build the target list: for each target, its GPU, workload, backend, topology,
+deploy asset, and the values a reader must set.
+
+Where a README contradicts its own manifest — a service name no manifest
+defines, an image tag nothing pins — **the manifest wins on the page**, and the
+README bug goes in the PR description for its owner. Copying a command that
+fails helps nobody.
+
+### 2. Write the catalog entry
+
+Create `docs/fern/pages/recipes/_catalog/recipes/<id>.yaml` with one entry per
+shipped target, and add `<id>` to `index.yaml` in nav order. See
+`docs/fern/pages/recipes/_catalog/README.md` for the schema. The catalog is the
+machine-readable contract the validator checks the page against, so get the
+target list right here first.
+
+```bash
+python3 docs/fern/pages/recipes/_catalog/validate.py
+```
+
+### 3. Write the page
+
+`docs/fern/pages/recipes/model-recipes/<slug>.mdx`.
+
+**Mirror the README's own heading structure and order.** If its sections are
+`Configurations / Supported features / Prerequisites / Quick Start /
+Configuration notes / Known issues`, use those, with that wording and
+capitalisation. Do not impose a house structure the README does not use — a
+reader moving between GitHub and the docs should recognise the same page.
+
+Add only `## Source` at the end, linking back to the README and the manifests.
+
+See [references/page-anatomy.md](references/page-anatomy.md) for what belongs to
+the README and what is Fern scaffolding.
+
+### 4. Build the target picker
+
+Four rows, always in this order, one row per dimension the recipe has values
+for:
+
+```
+GPU  ->  Workload  ->  Backend  ->  Topology
+```
+
+Gate options that only exist for some selections with `data-needs-*`, so the
+picker never offers a combination that ships no recipe. Full contract, the
+CSS-coupled vocabulary, and the traps in
+[references/picker.md](references/picker.md). Read it before writing the
+picker — every value is hardcoded in `RecipeStyles.tsx`, and an unlisted value
+renders a control that silently filters nothing.
+
+### 5. Wire it up
+
+- **Landing page** — add a card to `docs/fern/pages/recipes/model-recipes/overview.mdx`
+  in catalog order, and update both header counts: model families, and
+  deployable configurations (the sum of catalog targets across carded recipes).
+- **Navigation** — add a `- page:` entry under the Recipes tab in
+  `docs/fern/index.yml`.
+
+### 6. Validate
+
+```bash
+python3 .agents/skills/fern-recipe-page/scripts/check_recipe_page.py <slug>
+```
+
+It exits non-zero on failure. Checks MDX structure, picker vocabulary,
+dead-end selections, path resolution, catalog target coverage, landing-page
+card and counts, and navigation.
+
+Then the repo's own gates:
+
+```bash
+python3 docs/fern/pages/recipes/_catalog/validate.py
+python3 docs/fern/scripts/check_asset_paths.py
+pre-commit run --files docs/fern/pages/recipes/model-recipes/<slug>.mdx
+```
+
+If the Fern CLI is available, also `fern check` and `fern docs broken-links`.
+
+### 7. Attach to the PR
+
+```bash
+python3 .agents/skills/fern-recipe-page/scripts/check_recipe_page.py <slug> --pr
+```
+
+Paste the block into the PR description under `Validation`. PR descriptions
+need `Summary` and `Validation` sections, and commits need `git commit -s`
+(see the PR conventions in `AGENTS.md`). State plainly anything you could not
+run rather than implying it passed.
+
+## Traps
+
+Each of these has shipped broken at least once.
+
+- **A `##` heading inside a `data-*` wrapper** is invisible for every other
+  selection. Walk the file tracking `<div>` depth and confirm every heading sits
+  at depth 0. Headings are page scaffolding, never per-target content.
+- **The global CSS hides any element with a non-matching `data-*`, including
+  `<tr>`.** Tagging a results-table row filters it out rather than dimming it.
+  Comparison tables that should show every target must carry no `data-*` on
+  their rows.
+- **A picker chip can group several catalog targets.** One `hopper` chip may
+  cover `h100/h200/a100`, so selectable combinations and catalog target counts
+  legitimately differ. The reliable check is that every catalog deploy asset is
+  referenced somewhere on the page.
+- **A section can look covered while its deploy step is blank.** Check coverage
+  per `##` *and* `###` section, not per page: a page-wide `<div data-sku="...">`
+  in Prerequisites makes every combination look served.
+- **Curl and AIPerf commands often live in the manifests, not the README
+  prose.** Do not delete a Smoke Test or Benchmark section just because the
+  README has no equivalent heading.
+- **`recipes/README.md` is owned elsewhere.** Do not edit it from a docs PR.

--- a/.agents/skills/fern-recipe-page/references/page-anatomy.md
+++ b/.agents/skills/fern-recipe-page/references/page-anatomy.md
@@ -1,0 +1,88 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Page anatomy
+
+What the page takes from the README, and what belongs to Fern.
+
+## From the README
+
+Everything substantive. The page mirrors its recipe's READMEs in both
+directions: every fact they carry appears, and the page asserts nothing they do
+not support.
+
+**Mirror their heading structure and order**, with their wording and
+capitalisation. Recipes differ, and that is fine — a reader moving between
+GitHub and the docs should recognise the same page. Three shapes are common:
+
+```
+Configurations · Supported features · Prerequisites · Quick Start
+  · Optimization targets · Performance results · Known issues
+
+Available Configurations · Prerequisites · Quick Start
+  · Test the Deployment · Model Details · Notes
+
+Results · Experiment Overview · Dataset · Prerequisites · Quick Start
+  · Expected Results · Cleanup · References
+```
+
+Sub-READMEs matter as much as the top-level one. `perf/README.md` usually owns
+the benchmark procedure — trace staging, the environment variables to edit, the
+concurrency sweep. Skip it and the benchmark section will not work.
+
+## Fern scaffolding
+
+Not in any README, and legitimately so:
+
+- **Frontmatter** — SPDX header, `title`, one-sentence `subtitle`. Fern renders
+  the title, so the body has no `#` H1.
+- **Intro paragraph** — what it deploys and the strongest proof point.
+- **The target picker** and its summary panels. This re-presents the README's
+  configuration table one target at a time; it is the UX, not extra
+  information, as long as every value in it comes from a README or a manifest.
+- **`data-*` wrappers** and the duplication they force — the same command shown
+  once per target.
+- **`## Source`** — links back to the README and the manifests. Always last.
+- **Cross-links** to other Fern pages.
+
+## Tables
+
+Two kinds, treated oppositely. Getting this backwards is easy and the symptom
+is silent.
+
+**Comparison tables** — Performance results, Optimization targets, Benchmark
+Results, Expected Results. The point is seeing every target side by side, and
+the README prints them in full. **No `data-*` on any row**, or the global CSS
+hides the rows that do not match and the table quietly loses most of itself.
+
+**Per-target configuration** — the shipped settings for one target. These live
+in the picker summary panels rather than a table, so a reader sees their
+target's full configuration in one place.
+
+## Where a README is wrong
+
+READMEs drift from their own manifests: a `port-forward` naming a service no
+`deploy.yaml` defines, an image tag nothing pins, a context length the engine
+config contradicts.
+
+**The page follows the manifest**, because a command that fails helps nobody,
+and the README bug goes in the PR description for its owner. This is the only
+case where the page diverges from its README, and it should be called out
+rather than left silent.
+
+## Reader impact ordering
+
+When deciding whether something belongs, ask what happens if it is missing:
+
+1. **Breaks the reader** — a command fails, or they deploy the wrong thing.
+   Service names, image tags, GPU counts, trace staging, required env vars.
+2. **Misleads** — they form a false belief. Limitations, known issues,
+   unsupported combinations.
+3. **Informational** — useful, not load-bearing.
+
+The first two are why the page exists. Resist adding beyond what the READMEs
+carry, especially maturity framing — "Day-0", "experimental", "not yet
+promoted" — unless a README says it. That status lives in the catalog for
+internal use and should not leak into reader-facing prose on its own authority.

--- a/.agents/skills/fern-recipe-page/references/picker.md
+++ b/.agents/skills/fern-recipe-page/references/picker.md
@@ -1,0 +1,123 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# The target picker
+
+Pure CSS, no JavaScript. Radios drive `body:has(...)` rules in
+`docs/fern/components/RecipeStyles.tsx` that show and hide content by
+`data-*` attribute. It survives Fern's static render, "View as Markdown" and
+`llms.txt`, and degrades to everything-visible on older browsers.
+
+## Row order
+
+Four rows, always in this order. Include a row for each dimension the recipe
+has at least one value for; a single-value row is fine and tells the reader
+something ("this recipe is vLLM only").
+
+| Row | `name=` | Purpose |
+|---|---|---|
+| GPU | `recipe-sku` | hardware |
+| Workload | `recipe-usecase` | traffic shape |
+| Backend | `recipe-engine` | inference engine |
+| Topology | `recipe-variant` | aggregated / disaggregated / build variant |
+
+Backend is its own row. Folding it into Topology — variant values like
+`trtllm-agg` — was the original source of unreachable states, because it let
+a page express combinations no recipe ships.
+
+## Vocabulary
+
+Every value is hardcoded in `RecipeStyles.tsx`. **A value not listed there
+renders a control that filters nothing** — the picker looks fine and does
+nothing. Check before inventing one:
+
+```bash
+grep -o 'name="recipe-[a-z]*"\]\[value="[a-z0-9-]*"' docs/fern/components/RecipeStyles.tsx | sort -u
+```
+
+| Dimension | Values |
+|---|---|
+| `recipe-sku` | `b200` `h200` `h100` `gb200` `gb300` `hopper` `blackwell` |
+| `recipe-usecase` | `chat` `agentic` `static` `multimodal` |
+| `recipe-engine` | `vllm` `sglang` `trtllm` |
+| `recipe-variant` | `agg` `disagg` `disagg-single-node` `disagg-multi-node` `standard` `efa` `kvbm` |
+
+Adding a value means adding its hide rule, its `data-needs-*` rule and its
+tab-order companion in `RecipeStyles.tsx`. Do that deliberately; prefer an
+existing value where one fits. `hopper` and `blackwell` exist precisely so a
+recipe validated across `h100/h200/a100` can offer one chip.
+
+## Conditional options
+
+When a target only exists for some selections, gate its option rather than
+letting a reader pick a combination with nothing behind it. Put
+`data-needs-*` on the **label**:
+
+```jsx
+<input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" />
+<label htmlFor="recipe-variant-disagg"
+       data-needs-sku="b200" data-needs-usecase="agentic">Disaggregated</label>
+```
+
+Space-separate to allow several: `data-needs-sku="b200 h200"`. A label with no
+`data-needs-*` is always offered, so this is additive — existing pickers are
+unaffected.
+
+Work out the minimal set that makes reachable combinations exactly equal the
+shipped target set. Over-constraining strands readers; under-constraining puts
+back the blank deploy step.
+
+**CSS cannot un-check a radio.** A well-formed set of `data-needs-*` makes bad
+states unclickable, because any option that would strand you is itself hidden
+by the time you could click it. Hidden options are also removed from the tab
+order, so they cannot be keyboard-focused. State restored by the browser is the
+only remaining path, which is why the validator reports stranded states
+separately.
+
+## Tagging content
+
+Per-target content goes in a wrapper carrying the dimensions that discriminate
+it. Omit a dimension that does not:
+
+```jsx
+<div data-sku="b200" data-variant="disagg">
+
+```bash
+kubectl apply -f recipes/<model>/vllm/disagg-b200/deploy.yaml -n ${NAMESPACE}
+```
+
+</div>
+```
+
+**MDX rule:** blank line after the opening `<div ...>` and before `</div>`, and
+code fences at column 0. Without the blank lines the markdown inside is not
+parsed as markdown.
+
+Space-separate to apply to several: `data-sku="b200 h200"`.
+
+## Summary panels
+
+`.dynamo-target-picker-summary` panels carry the selected target's full
+configuration, one `<span><b>Label</b> value</span>` per fact. Each panel is
+tagged like any other block. Values may contain inline `` `code` `` — the cell
+is a block container, so an inline run wraps as prose.
+
+## What not to tag
+
+- **Headings.** A `##` inside a wrapper is invisible for every other selection.
+- **Comparison-table rows.** The global rule hides any element with a
+  non-matching `data-*`, `<tr>` included, so tagging a results row filters it
+  out rather than dimming it. Tables meant to show every target — Performance
+  results, Optimization targets — carry no `data-*` on rows.
+
+## Checking
+
+```bash
+python3 .agents/skills/fern-recipe-page/scripts/check_recipe_page.py <slug>
+```
+
+Enumerates reachable combinations, confirms each renders content in every
+`##`/`###` section that has `data-*` blocks, and confirms every catalog deploy
+asset is referenced.

--- a/.agents/skills/fern-recipe-page/scripts/check_recipe_page.py
+++ b/.agents/skills/fern-recipe-page/scripts/check_recipe_page.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate a Fern model-recipe page against its recipe and the catalog.
+
+Run from the repo root:
+
+    python3 .agents/skills/fern-recipe-page/scripts/check_recipe_page.py <slug>
+    python3 .agents/skills/fern-recipe-page/scripts/check_recipe_page.py --all
+    python3 .agents/skills/fern-recipe-page/scripts/check_recipe_page.py --all --pr
+
+<slug> is the page basename without .mdx, e.g. `kimi-k3`.
+
+Checks, in the order they tend to bite:
+
+  structure   MDX that renders wrong or breaks the build - <div> balance, code
+              fences, frontmatter/SPDX, and any `##` heading trapped inside a
+              data-* wrapper (invisible for every other selection).
+  vocabulary  data-* and picker values are CSS-coupled. A value absent from
+              RecipeStyles.tsx renders a control that silently filters nothing.
+  picker      Reachable combinations must equal the catalog's target list, and
+              every reachable combination must render content in every section
+              that has data-* blocks. A dead end looks fine until a reader
+              picks that combination and the deploy step is blank.
+  paths       Every kubectl path, GitHub blob URL and relative .mdx link must
+              resolve.
+  landing     The page needs a card on overview.mdx, in catalog order, and the
+              two header counts must match the catalog.
+
+Exit code is non-zero if any check fails, so it can gate a PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import os
+import re
+import sys
+from pathlib import Path
+
+PDIR = Path("docs/fern/pages/recipes/model-recipes")
+CATALOG = Path("docs/fern/pages/recipes/_catalog")
+STYLES = Path("docs/fern/components/RecipeStyles.tsx")
+OVERVIEW = PDIR / "overview.mdx"
+
+# Rows in the order every recipe page must present them.
+ROW_ORDER = ["sku", "usecase", "engine", "variant"]
+ROW_LABEL = {"sku": "GPU", "usecase": "Workload", "engine": "Backend", "variant": "Topology"}
+
+
+# --------------------------------------------------------------------------- util
+class Report:
+    def __init__(self) -> None:
+        self.rows: list[tuple[str, str, str]] = []
+
+    def add(self, check: str, ok: bool, detail: str = "") -> None:
+        self.rows.append((check, "PASS" if ok else "FAIL", detail))
+
+    @property
+    def failed(self) -> bool:
+        return any(s == "FAIL" for _, s, _ in self.rows)
+
+    def render(self, title: str) -> str:
+        out = [f"### {title}", ""]
+        for check, status, detail in self.rows:
+            mark = "x" if status == "PASS" else " "
+            out.append(f"- [{mark}] **{check}** {detail}".rstrip())
+        return "\n".join(out)
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def strip_fences(text: str):
+    """Yield (line, in_fence) so checks can ignore code blocks."""
+    fence = False
+    for line in text.split("\n"):
+        if line.lstrip().startswith("```"):
+            fence = not fence
+            yield line, True
+            continue
+        yield line, fence
+
+
+def css_vocabulary() -> dict[str, set[str]]:
+    """The values RecipeStyles.tsx actually implements, per picker dimension."""
+    if not STYLES.is_file():
+        return {}
+    css = read(STYLES)
+    vocab: dict[str, set[str]] = {}
+    for dim, value in re.findall(r'name="recipe-(\w+)"\]\[value="([\w-]+)"', css):
+        vocab.setdefault(dim, set()).add(value)
+    return vocab
+
+
+# ----------------------------------------------------------------------- parsing
+def parse_picker(text: str):
+    """Return (dims, needs, row_labels) for the page's target picker."""
+    dims: dict[str, list[str]] = {}
+    for dim, value in re.findall(
+        r'<input type="radio"[^>]*name="recipe-(\w+)"[^>]*value="([^"]+)"', text
+    ):
+        dims.setdefault(dim, []).append(value)
+
+    needs: dict[tuple[str, str], dict[str, str]] = {}
+    for m in re.finditer(r'<label htmlFor="recipe-(\w+)-([\w.-]+)"([^>]*)>', text):
+        req = dict(re.findall(r'data-needs-(\w+)="([^"]*)"', m.group(3)))
+        if req:
+            needs[(m.group(1), m.group(2))] = req
+
+    labels = re.findall(r'<span className="dynamo-target-picker-dim">([^<]+)</span>', text)
+    return dims, needs, labels
+
+
+def sections(text: str) -> dict[str, str]:
+    """Split at `##` and `###`, ignoring headings inside code fences."""
+    out: dict[str, list[str]] = {}
+    current = "(intro)"
+    for line, in_fence in strip_fences(text):
+        if not in_fence and re.match(r"^#{2,3} ", line):
+            current = line.strip()
+        out.setdefault(current, []).append(line)
+    return {k: "\n".join(v) for k, v in out.items()}
+
+
+def wrapper_blocks(body: str) -> list[dict[str, str]]:
+    """data-* wrapper divs in a section, excluding picker summary panels."""
+    return [
+        dict(re.findall(r'data-(\w+)="([^"]*)"', raw))
+        for raw in re.findall(r'<div ((?:data-\w+="[^"]*"\s*)+)>', body)
+        if "picker-summary" not in raw
+    ]
+
+
+def visible(block: dict[str, str], selection: dict[str, str]) -> bool:
+    """A block shows when, for every dimension, it omits the attribute or lists
+    the selected value. Mirrors the `[data-x]:not([data-x~="v"])` CSS."""
+    return all(
+        selection[dim] in block.get(dim, selection[dim]).split() for dim in selection
+    )
+
+
+def reachable(dims, needs) -> list[dict[str, str]]:
+    """Combinations a reader can actually click to, honouring data-needs-*."""
+    keys = sorted(dims)
+    out = []
+    for combo in itertools.product(*[dims[k] for k in keys]):
+        sel = dict(zip(keys, combo))
+        if all(
+            all(sel.get(rk) in rv.split() for rk, rv in needs.get((k, sel[k]), {}).items())
+            for k in keys
+        ):
+            out.append(sel)
+    return out
+
+
+# Catalog values are free-text; these map them onto the picker vocabulary.
+ENGINE_ALIAS = {"vllm": "vllm", "sglang": "sglang", "trtllm": "trtllm",
+                "tensorrt-llm": "trtllm", "tensorrtllm": "trtllm"}
+TOPOLOGY_ALIAS = {"aggregated": "agg", "disaggregated": "disagg"}
+WORKLOAD_ALIAS = {"chat": "chat", "agentic": "agentic",
+                  "agentic-trace-replay": "agentic", "trace-replay": "agentic",
+                  "static-synthetic": "static", "static-generation": "static",
+                  "multimodal": "multimodal"}
+
+
+def catalog_groups(targets):
+    """Distinct (gpu, workload, engine, topology) groups behind the target list.
+
+    Several catalog targets routinely collapse onto one picker combination -
+    Nemotron-3.5-Lightning ships 30 targets across 12 groups because it
+    enumerates spec-decode variants the picker does not expose as a dimension.
+    Compare groups, not raw target counts. Returns None if any value falls
+    outside the known vocabulary, so the caller can skip rather than false-fail.
+    """
+    groups = set()
+    for t in targets:
+        gpu, eng, top, wl = t["gpu"], t["engine"], t["topology"], t["workload"]
+        if not all((gpu, eng, top, wl)):
+            return None
+        eng = ENGINE_ALIAS.get(eng.lower())
+        top = TOPOLOGY_ALIAS.get(top.lower())
+        wl = WORKLOAD_ALIAS.get(wl.lower())
+        if not all((eng, top, wl)):
+            return None
+        for one in gpu.replace("/", " ").split():
+            groups.add((one.strip(",").lower(), wl, eng, top))
+    return groups
+
+
+def catalog_targets(slug: str):
+    """(gpu, framework, topology, workload) per shipped target, from the catalog."""
+    for path in sorted((CATALOG / "recipes").glob("*.yaml")):
+        text = read(path)
+        page = re.search(r"^page:\s*(\S+)", text, re.M)
+        if not page or Path(page.group(1)).stem != slug:
+            continue
+        rows = []
+        for block in re.split(r"\n- id: ", text)[1:]:
+            grab = lambda pat: (re.search(pat, block).group(1) if re.search(pat, block) else None)
+            rows.append(
+                {
+                    "gpu": grab(r"gpu:\s*(\S+)"),
+                    "engine": grab(r"framework:\s*(\S+)"),
+                    "topology": grab(r"topology:\s*(\S+)"),
+                    "workload": grab(r"type:\s*(\S+)"),
+                    "asset": grab(r"asset:\s*(\S+)"),
+                }
+            )
+        return path, rows
+    return None, None
+
+
+# ------------------------------------------------------------------------ checks
+def check_structure(text: str, rep: Report) -> None:
+    opens = len(re.findall(r"<div\b", text))
+    closes = len(re.findall(r"</div>", text))
+    rep.add("div balance", opens == closes, "" if opens == closes else f"{opens} open / {closes} close")
+    rep.add("code fences", text.count("\n```") % 2 == 0)
+
+    body = text.split("---", 2)[2] if text.startswith("---") and text.count("---") >= 2 else text
+    # `# ...` inside a bash fence is a comment, not a heading.
+    h1 = [l for l, in_fence in strip_fences(body) if not in_fence and re.match(r"^# ", l)]
+    rep.add("no body H1", not h1, "Fern renders the title from frontmatter; found " + h1[0][:40] if h1 else "")
+    rep.add("SPDX header", "SPDX-License-Identifier" in text[:400])
+
+    depth, nested, indented = 0, [], []
+    for line, in_fence in strip_fences(text):
+        if in_fence:
+            if re.match(r"^\s+```", line):
+                indented.append(line.strip()[:30])
+            continue
+        if re.match(r"^<div\b", line):
+            depth += 1
+        elif re.match(r"^</div>", line):
+            depth = max(0, depth - 1)
+        elif line.startswith("## ") and depth > 0:
+            nested.append(line.strip())
+    rep.add("headings at top level", not nested, "; ".join(nested[:3]))
+    rep.add("fences at column 0", not indented, "; ".join(indented[:3]))
+
+    # A wrapper div must be surrounded by blank lines or the markdown inside it
+    # is not parsed as markdown.
+    lines = text.split("\n")
+    tight = [
+        f"L{i+1}"
+        for i, line in enumerate(lines)
+        if re.match(r"^<div data-[^>]*>$", line) and i + 1 < len(lines) and lines[i + 1].strip()
+    ]
+    rep.add("blank line after wrapper divs", not tight, " ".join(tight[:5]))
+
+
+def check_vocabulary(text: str, dims, rep: Report) -> None:
+    vocab = css_vocabulary()
+    if not vocab:
+        rep.add("CSS vocabulary", True, "(RecipeStyles.tsx not found - skipped)")
+        return
+    bad = []
+    for dim, values in dims.items():
+        for value in values:
+            if value not in vocab.get(dim, set()):
+                bad.append(f"recipe-{dim}={value}")
+    for dim, value in re.findall(r'data-(sku|usecase|engine|variant)="([^"]*)"', text):
+        for token in value.split():
+            if token not in vocab.get(dim, set()):
+                bad.append(f"data-{dim}={token}")
+    rep.add(
+        "CSS-coupled values implemented",
+        not bad,
+        "unimplemented: " + ", ".join(sorted(set(bad))[:6]) if bad else "",
+    )
+
+
+def check_picker(slug: str, text: str, rep: Report) -> None:  # noqa: C901
+    dims, needs, labels = parse_picker(text)
+    if not dims:
+        rep.add("picker present", False, "no recipe-* radios found")
+        return
+
+    expected = [ROW_LABEL[d] for d in ROW_ORDER if d in dims]
+    rep.add(
+        "row order GPU/Workload/Backend/Topology",
+        labels[: len(expected)] == expected,
+        f"got {labels}" if labels[: len(expected)] != expected else "",
+    )
+
+    for dim, values in dims.items():
+        checked = len(re.findall(rf'name="recipe-{dim}"[^>]*defaultChecked', text))
+        rep.add(f"one default in {ROW_LABEL.get(dim, dim)}", checked == 1, f"{checked} defaultChecked")
+
+    combos = reachable(dims, needs)
+    rep.add("reachable combinations", bool(combos), f"{len(combos)} selectable")
+
+    # Dead ends: a section with data-* blocks that renders nothing, and has no
+    # static prose to carry it.
+    dead = []
+    for name, body in sections(text).items():
+        blocks = wrapper_blocks(body)
+        if not blocks:
+            continue
+        stripped = re.sub(r"<[^>]+>", "", re.sub(r"^#{1,6} .*$", "", body, flags=re.M))
+        has_static = len(stripped.strip()) > 40
+        for sel in combos:
+            if not any(visible(b, sel) for b in blocks) and not has_static:
+                dead.append(f"{'+'.join(sel[k] for k in sorted(sel))} -> {name}")
+    rep.add("no dead-end selections", not dead, "; ".join(dead[:3]) + (f" (+{len(dead)-3})" if len(dead) > 3 else ""))
+
+    path, targets = catalog_targets(slug)
+    if targets is None:
+        rep.add("catalog entry", False, f"no _catalog/recipes/*.yaml with page {slug}.mdx")
+    else:
+        rep.add("catalog entry", True, f"{path.name}, {len(targets)} target(s)")
+        groups = catalog_groups(targets)
+        # Advisory only. A picker chip often groups several catalog rows (one
+        # `hopper` chip covers h100/h200/a100), and one catalog target can be
+        # split across chips, so the counts legitimately differ. The reliable
+        # signal is asset coverage, below.
+        detail = f"{len(combos)} selectable"
+        if groups is not None:
+            detail += f" vs {len(groups)} catalog group(s) from {len(targets)} target(s)"
+            if len(combos) != len(groups):
+                detail += " - confirm by hand that each maps to a real target"
+        rep.add("combinations vs catalog (advisory)", True, detail)
+
+        # Hard check: every shipped target must be reachable from the page.
+        # Pages reference a target three ways: the full asset path, a
+        # recipe-relative path (`vllm/agg-b200-agentic/deploy.yaml`), or a
+        # RECIPE= variable holding the directory. Matching the last two path
+        # components of the asset's directory covers all three.
+        missing = []
+        for t in targets:
+            asset = t.get("asset")
+            if not asset:
+                continue
+            tail = "/".join(Path(asset).parent.parts[-2:])
+            if tail and tail not in text:
+                missing.append(asset)
+        rep.add(
+            "every catalog target referenced",
+            not missing,
+            "page never mentions: " + ", ".join(missing[:3]) if missing else f"{len(targets)} target(s)",
+        )
+
+
+def check_paths(page: Path, text: str, rep: Report) -> None:
+    missing = []
+    for rel in set(re.findall(r"github\.com/ai-dynamo/dynamo/(?:blob|tree)/main/([A-Za-z0-9_./\-]+)", text)):
+        if not Path(rel.rstrip(".,);")).exists():
+            missing.append(rel)
+    for rel in set(re.findall(r"-f\s+(recipes/[A-Za-z0-9_./\-]+)", text)):
+        if not Path(rel.rstrip(".,);")).exists():
+            missing.append(rel)
+    for rel in re.findall(r"\]\((\.\.?/[^)#]*\.mdx)", text):
+        if not (page.parent / rel).resolve().exists():
+            missing.append(rel)
+    rep.add("paths and links resolve", not missing, "missing: " + ", ".join(missing[:4]) if missing else "")
+
+
+def check_landing(slug: str, rep: Report) -> None:
+    if not OVERVIEW.is_file():
+        rep.add("landing page", False, "overview.mdx not found")
+        return
+    text = read(OVERVIEW)
+    hrefs = [h[:-4] for h in re.findall(r'href="([a-z0-9.\-]+\.mdx)"', text)]
+    rep.add("card on landing page", slug in hrefs, "" if slug in hrefs else f"no card links to {slug}.mdx")
+
+    index = CATALOG / "index.yaml"
+    if index.is_file():
+        body = read(index)
+        active = re.split(r"^deferred_recipes:", body, flags=re.M)[0]
+        ids = re.findall(r"^-\s+([a-z0-9-]+)\s*$", active, re.M)
+        # The catalog id is not always the page filename (inkling -> inkling-nvfp4),
+        # so resolve each id through its entry's `page:` field.
+        order = []
+        for rid in ids:
+            entry = CATALOG / "recipes" / f"{rid}.yaml"
+            page_ref = re.search(r"^page:\s*(\S+)", read(entry), re.M) if entry.is_file() else None
+            order.append(Path(page_ref.group(1)).stem if page_ref else rid)
+        mismatch = [f"{a}!={b}" for a, b in zip(hrefs, order) if a != b]
+        rep.add(
+            "card order matches catalog",
+            hrefs == order,
+            "; ".join(mismatch[:3]) if mismatch else "",
+        )
+
+        families = re.search(r"<h3>(\d+) model families</h3>", text)
+        configs = re.search(r"<strong>(\d+)</strong>\s*\n?\s*<span>Deployable configurations", text)
+        want_families = len(ids)
+        want_configs = 0
+        for rid in ids:
+            entry = CATALOG / "recipes" / f"{rid}.yaml"
+            if entry.is_file():
+                want_configs += len(re.findall(r"^- id: ", read(entry), re.M))
+        rep.add(
+            "landing counts",
+            bool(families and configs)
+            and int(families.group(1)) == want_families
+            and int(configs.group(1)) == want_configs,
+            f"page says {families.group(1) if families else '?'} families / "
+            f"{configs.group(1) if configs else '?'} configs; "
+            f"catalog says {want_families} / {want_configs}",
+        )
+
+
+def check_nav(slug: str, rep: Report) -> None:
+    nav = Path("docs/fern/index.yml")
+    if not nav.is_file():
+        rep.add("navigation", True, "(index.yml not found - skipped)")
+        return
+    rep.add(
+        "wired into index.yml",
+        f"model-recipes/{slug}.mdx" in read(nav),
+        "" if f"model-recipes/{slug}.mdx" in read(nav) else "add a `- page:` entry under the Recipes tab",
+    )
+
+
+# -------------------------------------------------------------------------- main
+def check_page(slug: str) -> Report:
+    rep = Report()
+    page = PDIR / f"{slug}.mdx"
+    if not page.is_file():
+        rep.add("page exists", False, str(page))
+        return rep
+    text = read(page)
+    check_structure(text, rep)
+    dims, _, _ = parse_picker(text)
+    check_vocabulary(text, dims, rep)
+    check_picker(slug, text, rep)
+    check_paths(page, text, rep)
+    check_landing(slug, rep)
+    check_nav(slug, rep)
+    return rep
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("slug", nargs="?", help="page basename without .mdx, e.g. kimi-k3")
+    ap.add_argument("--all", action="store_true", help="check every recipe page")
+    ap.add_argument("--pr", action="store_true", help="emit a markdown block for the PR description")
+    args = ap.parse_args()
+
+    if not PDIR.is_dir():
+        print("run this from the repo root (docs/fern/pages/recipes/model-recipes not found)", file=sys.stderr)
+        return 2
+
+    slugs = (
+        sorted(p.stem for p in PDIR.glob("*.mdx") if p.stem != "overview")
+        if args.all
+        else ([args.slug] if args.slug else [])
+    )
+    if not slugs:
+        ap.print_usage(sys.stderr)
+        return 2
+
+    blocks, failed = [], False
+    for slug in slugs:
+        rep = check_page(slug)
+        failed |= rep.failed
+        blocks.append(rep.render(slug))
+
+    if args.pr:
+        print("<!-- generated by .agents/skills/fern-recipe-page/scripts/check_recipe_page.py -->")
+        print("## Recipe page validation\n")
+    print("\n\n".join(blocks))
+    if failed:
+        print("\nFAILED - fix the items above before requesting review.", file=sys.stderr)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ to it — edit only the canonical copy. Reach for the right group first:
 - `dynamo-docs` — Fern docs-site content per the style guide
 - `dynamo-frontend-benchmark` — benchmark/profile the frontend against mock workers
 - `fern-components` — Fern MDX component library and usage guidance
+- `fern-recipe-page` — publish a released recipe's Fern page, landing card and picker
 - `fern-navigation` — Fern navigation and site-structure configuration guidance
 - `dynamo-kv-replay-parity` — validate offline KV replay parity and performance
 - `dynamo-agent-harness` — drive persistent Claude Code, Codex, or OpenCode sessions through Dynamo over ACP

--- a/docs/fern/components/RecipeStyles.tsx
+++ b/docs/fern/components/RecipeStyles.tsx
@@ -2140,22 +2140,111 @@ main.fern-main:not(:has(> .fern-layout-content-wrapper ~ aside)) .fern-layout-gu
 }
 
 .dynamo-target-picker-summary span {
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
+    /* Block, not flex-column: a flex container promotes EVERY child to its own
+       row, so a value containing inline <code> ("FLASHINFER_MLA, TRTLLM_RAGGED
+       MLA prefill") breaks across four lines with the comma stranded on one of
+       them. Block keeps the value's inline run flowing; the label below is what
+       stacks it above the value. */
+    display: block;
     /* the value (text node after the label) — prominent, dark */
     font-size: 13.5px;
-    line-height: 1.35;
+    line-height: 1.45;
     color: var(--pst-color-text-base);
 }
 
 .dynamo-target-picker-summary b {
-    /* the label — small, uppercase, muted, sits above the value */
+    /* the label — small, uppercase, muted, sits above the value.
+       Block + margin replaces the old flex gap property, which no longer applies now
+       that the cell is a block container. */
+    display: block;
+    margin-bottom: 3px;
     font-size: 10px;
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--grayscale-a9, #777);
+}
+
+/* Inline code inside a summary value must not introduce line breaks: the value
+   is a single inline run and wraps as prose. */
+.dynamo-target-picker-summary span code {
+    white-space: nowrap;
+}
+
+/* A hidden conditional option must also leave the tab order: the radio itself is
+   only visually hidden (position:absolute;opacity:0), so without this a keyboard
+   user could Tab onto an option whose label is not shown and land the page on a
+   combination that ships no recipe. :has(+ label) keys the input off the very
+   label the rules below hide.                                                   */
+.dynamo-target-picker input[type="radio"]:has(+ label[data-needs-sku]),
+.dynamo-target-picker input[type="radio"]:has(+ label[data-needs-usecase]),
+.dynamo-target-picker input[type="radio"]:has(+ label[data-needs-engine]),
+.dynamo-target-picker input[type="radio"]:has(+ label[data-needs-variant]) {
+    /* re-enabled below whenever its label is actually visible */
+}
+.dynamo-target-picker label[data-needs-sku],
+.dynamo-target-picker label[data-needs-usecase],
+.dynamo-target-picker label[data-needs-engine],
+.dynamo-target-picker label[data-needs-variant] {
+    /* marker class only; visibility is decided by the body:has() rules below */
+}
+
+/* ---- Conditional picker options -------------------------------------------
+   A recipe may offer a target only for some selections (e.g. Nemotron-3-Ultra
+   ships a disaggregated lane on B200 agentic only). Tag that option's label
+   with the selections it requires:
+
+     <label htmlFor="recipe-variant-disagg"
+            data-needs-sku="b200" data-needs-usecase="agentic">Disaggregated</label>
+
+   The label then hides whenever the current selection does not satisfy it, so
+   the picker never offers a combination that has no content behind it. A label
+   with no data-needs-* attribute is always shown, which is every existing
+   option, so this is additive. Same :has() mechanism as the content rules
+   below -- no JavaScript.                                                     */
+body:has(input[name="recipe-sku"][value="b200"]:checked) .dynamo-target-picker label[data-needs-sku]:not([data-needs-sku~="b200"]),
+body:has(input[name="recipe-sku"][value="h200"]:checked) .dynamo-target-picker label[data-needs-sku]:not([data-needs-sku~="h200"]),
+body:has(input[name="recipe-sku"][value="h100"]:checked) .dynamo-target-picker label[data-needs-sku]:not([data-needs-sku~="h100"]),
+body:has(input[name="recipe-sku"][value="gb200"]:checked) .dynamo-target-picker label[data-needs-sku]:not([data-needs-sku~="gb200"]),
+body:has(input[name="recipe-sku"][value="gb300"]:checked) .dynamo-target-picker label[data-needs-sku]:not([data-needs-sku~="gb300"]),
+body:has(input[name="recipe-sku"][value="hopper"]:checked) .dynamo-target-picker label[data-needs-sku]:not([data-needs-sku~="hopper"]),
+body:has(input[name="recipe-sku"][value="blackwell"]:checked) .dynamo-target-picker label[data-needs-sku]:not([data-needs-sku~="blackwell"]),
+body:has(input[name="recipe-usecase"][value="chat"]:checked) .dynamo-target-picker label[data-needs-usecase]:not([data-needs-usecase~="chat"]),
+body:has(input[name="recipe-usecase"][value="agentic"]:checked) .dynamo-target-picker label[data-needs-usecase]:not([data-needs-usecase~="agentic"]),
+body:has(input[name="recipe-usecase"][value="static"]:checked) .dynamo-target-picker label[data-needs-usecase]:not([data-needs-usecase~="static"]),
+body:has(input[name="recipe-usecase"][value="multimodal"]:checked) .dynamo-target-picker label[data-needs-usecase]:not([data-needs-usecase~="multimodal"]),
+body:has(input[name="recipe-engine"][value="vllm"]:checked) .dynamo-target-picker label[data-needs-engine]:not([data-needs-engine~="vllm"]),
+body:has(input[name="recipe-engine"][value="sglang"]:checked) .dynamo-target-picker label[data-needs-engine]:not([data-needs-engine~="sglang"]),
+body:has(input[name="recipe-engine"][value="trtllm"]:checked) .dynamo-target-picker label[data-needs-engine]:not([data-needs-engine~="trtllm"]),
+body:has(input[name="recipe-variant"][value="agg"]:checked) .dynamo-target-picker label[data-needs-variant]:not([data-needs-variant~="agg"]),
+body:has(input[name="recipe-variant"][value="disagg"]:checked) .dynamo-target-picker label[data-needs-variant]:not([data-needs-variant~="disagg"]),
+body:has(input[name="recipe-variant"][value="disagg-single-node"]:checked) .dynamo-target-picker label[data-needs-variant]:not([data-needs-variant~="disagg-single-node"]),
+body:has(input[name="recipe-variant"][value="disagg-multi-node"]:checked) .dynamo-target-picker label[data-needs-variant]:not([data-needs-variant~="disagg-multi-node"]),
+body:has(input[name="recipe-variant"][value="efa"]:checked) .dynamo-target-picker label[data-needs-variant]:not([data-needs-variant~="efa"]),
+body:has(input[name="recipe-variant"][value="standard"]:checked) .dynamo-target-picker label[data-needs-variant]:not([data-needs-variant~="standard"]),
+body:has(input[name="recipe-variant"][value="kvbm"]:checked) .dynamo-target-picker label[data-needs-variant]:not([data-needs-variant~="kvbm"]) {
+    display: none;
+}
+
+
+/* Companion: when the label is hidden, drop its radio from the tab order too. */
+body:has(input[name="recipe-sku"][value="b200"]:checked) .dynamo-target-picker input:has(+ label[data-needs-sku]:not([data-needs-sku~="b200"])),
+body:has(input[name="recipe-sku"][value="h200"]:checked) .dynamo-target-picker input:has(+ label[data-needs-sku]:not([data-needs-sku~="h200"])),
+body:has(input[name="recipe-sku"][value="h100"]:checked) .dynamo-target-picker input:has(+ label[data-needs-sku]:not([data-needs-sku~="h100"])),
+body:has(input[name="recipe-sku"][value="gb200"]:checked) .dynamo-target-picker input:has(+ label[data-needs-sku]:not([data-needs-sku~="gb200"])),
+body:has(input[name="recipe-sku"][value="gb300"]:checked) .dynamo-target-picker input:has(+ label[data-needs-sku]:not([data-needs-sku~="gb300"])),
+body:has(input[name="recipe-sku"][value="hopper"]:checked) .dynamo-target-picker input:has(+ label[data-needs-sku]:not([data-needs-sku~="hopper"])),
+body:has(input[name="recipe-sku"][value="blackwell"]:checked) .dynamo-target-picker input:has(+ label[data-needs-sku]:not([data-needs-sku~="blackwell"])),
+body:has(input[name="recipe-usecase"][value="chat"]:checked) .dynamo-target-picker input:has(+ label[data-needs-usecase]:not([data-needs-usecase~="chat"])),
+body:has(input[name="recipe-usecase"][value="agentic"]:checked) .dynamo-target-picker input:has(+ label[data-needs-usecase]:not([data-needs-usecase~="agentic"])),
+body:has(input[name="recipe-usecase"][value="static"]:checked) .dynamo-target-picker input:has(+ label[data-needs-usecase]:not([data-needs-usecase~="static"])),
+body:has(input[name="recipe-usecase"][value="multimodal"]:checked) .dynamo-target-picker input:has(+ label[data-needs-usecase]:not([data-needs-usecase~="multimodal"])),
+body:has(input[name="recipe-engine"][value="vllm"]:checked) .dynamo-target-picker input:has(+ label[data-needs-engine]:not([data-needs-engine~="vllm"])),
+body:has(input[name="recipe-engine"][value="sglang"]:checked) .dynamo-target-picker input:has(+ label[data-needs-engine]:not([data-needs-engine~="sglang"])),
+body:has(input[name="recipe-engine"][value="trtllm"]:checked) .dynamo-target-picker input:has(+ label[data-needs-engine]:not([data-needs-engine~="trtllm"])),
+body:has(input[name="recipe-variant"][value="agg"]:checked) .dynamo-target-picker input:has(+ label[data-needs-variant]:not([data-needs-variant~="agg"])),
+body:has(input[name="recipe-variant"][value="disagg"]:checked) .dynamo-target-picker input:has(+ label[data-needs-variant]:not([data-needs-variant~="disagg"])) {
+    display: none;
 }
 
 /* Variant visibility: hide blocks that do not match the checked sku/usecase */
@@ -2165,7 +2254,9 @@ body:has(input[name="recipe-sku"][value="h100"]:checked) [data-sku]:not([data-sk
 body:has(input[name="recipe-sku"][value="gb200"]:checked) [data-sku]:not([data-sku~="gb200"]),
 body:has(input[name="recipe-sku"][value="gb300"]:checked) [data-sku]:not([data-sku~="gb300"]),
 body:has(input[name="recipe-usecase"][value="chat"]:checked) [data-usecase]:not([data-usecase~="chat"]),
-body:has(input[name="recipe-usecase"][value="agentic"]:checked) [data-usecase]:not([data-usecase~="agentic"]) {
+body:has(input[name="recipe-usecase"][value="agentic"]:checked) [data-usecase]:not([data-usecase~="agentic"]),
+body:has(input[name="recipe-usecase"][value="static"]:checked) [data-usecase]:not([data-usecase~="static"]),
+body:has(input[name="recipe-usecase"][value="multimodal"]:checked) [data-usecase]:not([data-usecase~="multimodal"]) {
     display: none;
 }
 

--- a/docs/fern/pages/recipes/model-recipes/deepseek-v3-2-nvfp4.mdx
+++ b/docs/fern/pages/recipes/model-recipes/deepseek-v3-2-nvfp4.mdx
@@ -9,11 +9,32 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-This recipe deploys DeepSeek V3.2 NVFP4 disaggregated across 32 GB200 GPUs — 2x prefill + 2x decode workers (DEP8) with KV-aware routing and WideEP — for long-context coding traces with heavy prefix reuse (~39.2K avg ISL, 44% KV block hit rate). The aggregated round-robin configuration is the benchmark control and lives on the related Feature Benchmark page.
+This recipe deploys DeepSeek V3.2 NVFP4 disaggregated across 32 GB200 GPUs — 2x prefill + 2x decode workers (DEP8) with KV-aware routing and WideEP — for long-context coding traces with heavy prefix reuse (~39.2K avg ISL, 44% KV block hit rate). The aggregated round-robin configuration is the benchmark control and lives on the related Feature Benchmark page. This page ships one validated target — GB200, agentic trace replay, TensorRT-LLM, disaggregated — so every picker row below carries a single option.
 
-<div className="dynamo-target-picker static">
+<div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Deployment target</p>
-<div className="dynamo-target-picker-summary">
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">GPU</span>
+<input type="radio" id="recipe-sku-gb200" name="recipe-sku" value="gb200" defaultChecked />
+<label htmlFor="recipe-sku-gb200">GB200</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-agentic" name="recipe-usecase" value="agentic" defaultChecked />
+<label htmlFor="recipe-usecase-agentic">Agentic trace replay</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-trtllm" name="recipe-engine" value="trtllm" defaultChecked />
+<label htmlFor="recipe-engine-trtllm">TensorRT-LLM</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Topology</span>
+<input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" defaultChecked />
+<label htmlFor="recipe-variant-disagg">Disaggregated</label>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="gb200" data-engine="trtllm" data-usecase="agentic" data-variant="disagg">
+<span><b>Target</b> disagg-kv-router (GB200 / agentic trace replay / TensorRT-LLM / disaggregated)</span>
 <span><b>Checkpoint</b> nvidia/DeepSeek-V3.2-NVFP4</span>
 <span><b>GPUs</b> 32x GB200 across 8 nodes (NVL72, MNNVL)</span>
 <span><b>Techniques</b> Disagg, KV-aware routing, WideEP</span>
@@ -22,56 +43,31 @@ This recipe deploys DeepSeek V3.2 NVFP4 disaggregated across 32 GB200 GPUs — 2
 </div>
 </div>
 
-## Prerequisites
+## Results
 
-- A Kubernetes cluster with the Dynamo platform (operator) installed and **32x GB200 across 8 nodes (NVL72, MNNVL-connected)** available.
-- A Hugging Face token with access to `nvidia/DeepSeek-V3.2-NVFP4`.
-- The `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1` image (already pinned in `deploy.yaml`).
+The reference run is published as a video rather than a numeric table:
 
-Create the namespace and token secret:
+<video controls width="100%">
+  <source src="https://github.com/user-attachments/assets/fcdb703c-7c1a-4109-a7ca-54196fcef885" type="video/mp4" />
+</video>
 
-```bash
-export NAMESPACE=your-namespace
-kubectl create namespace ${NAMESPACE}
-kubectl create secret generic hf-token-secret \
-  --from-literal=HF_TOKEN="your-token" \
-  -n ${NAMESPACE}
-```
+## Experiment Overview
 
-Multinode deployments on MNNVL-connected GB200 clusters typically require a ComputeDomain in your namespace so the DRA scheduler co-locates worker pods on MNNVL-connected nodes — otherwise internode GPU peer memory access fails:
+Two deployment modes are compared on **32x GB200 GPUs across 8 nodes**:
 
-```bash
-kubectl apply -f recipes/deepseek-v32-fp4/model-cache/compute-domain.yaml -n ${NAMESPACE}
-```
+| Mode | Routing | Configuration |
+| --- | --- | --- |
+| **Aggregated** | Round-robin | 4x DEP8 workers |
+| **Disaggregated** | KV-aware | 2x prefill + 2x decode w/ WideEP (DEP8) |
 
-If you rename the ComputeDomain or its `resourceClaimTemplate` (defaults: `your-compute-domain` / `your-compute-domain-channel`), apply the same names in the deploy YAMLs under `extraPodSpec.resourceClaims` and `mainContainer.resources.claims`.
+- The aggregated round-robin configuration (`trtllm/agg-round-robin/`) is the benchmark control arm — 4x DEP8 workers with round-robin routing on the same 32x GB200 across 8 nodes. It appears on the Feature Benchmark page, not as a recipe target here.
+- Decode workers run the WIDEEP MoE backend with `moe_expert_parallel_size: 8` and FP8 KV cache; prefill enables chunked prefill and KV block reuse (`tokens_per_block: 64`, matching `--kv-block-size 64`).
+- The trace tops out at 109,459 input tokens; both engine configs set `max_seq_len: 121000` to accommodate it.
+- Related feature benchmark: [DeepSeek V3.2 WideEP routing A/B](../feature-benchmarks/deepseek-v3-2-wideep-routing.mdx)
 
-<Warning>
-Edit cluster-specific values before applying: `storageClassName` in `model-cache/model-cache.yaml` (run kubectl get storageclass), your namespace (perf.yaml hardcodes `namespace: your-namespace`), and the ComputeDomain claim names.
-</Warning>
+## Dataset: Mooncake-based Synthetic Coding Trace
 
-## Deploy
-
-Create storage, download NVIDIA's official NVFP4 checkpoint, copy the trace into the PVC, then deploy:
-
-```bash
-# 1. Create the model-cache PVC (RWX, 400Gi).
-kubectl apply -f recipes/deepseek-v32-fp4/model-cache/model-cache.yaml -n ${NAMESPACE}
-
-# 2. Download nvidia/DeepSeek-V3.2-NVFP4 into the PVC.
-kubectl apply -f recipes/deepseek-v32-fp4/model-cache/model-download.yaml -n ${NAMESPACE}
-kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=600s
-
-# 3. Copy the synthesized trace file into the PVC.
-kubectl cp <local_trace.jsonl> ${NAMESPACE}/<helper-pod>:/model-cache/traces/
-
-# 4. Deploy: KV-routed frontend + 2x prefill + 2x decode (WideEP) workers.
-kubectl apply -f recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/deploy.yaml -n ${NAMESPACE}
-kubectl wait --for=condition=ready pod -l nvidia.com/dynamo-graph-deployment-name=disagg-kv-dsv32-nvfp4 \
-  -n ${NAMESPACE} --timeout=1200s
-```
-
-To synthesize the trace, run Dynamo's [prefix data generator](https://github.com/ai-dynamo/dynamo/tree/main/benchmarks/prefix_data_generator) on the Mooncake `conversation_trace.jsonl`:
+The trace simulates a coding workload. To synthesize it, run Dynamo's [prefix data generator](https://github.com/ai-dynamo/dynamo/tree/main/benchmarks/prefix_data_generator) on the [Mooncake](https://github.com/kvcache-ai/Mooncake) FAST25 [`conversation_trace.jsonl`](https://github.com/kvcache-ai/Mooncake/blob/main/FAST25-release/traces/conversation_trace.jsonl), which increases the input sequence length and prefix reuse rate of the original conversation trace:
 
 ```bash
 datagen synthesize \
@@ -83,9 +79,83 @@ datagen synthesize \
 # emits conversation_trace_synth_16.00x1+10.00_speedup1_maxisl110000.jsonl
 ```
 
-## Smoke Test
+The resulting trace is long-context and heavily reuse-biased:
 
-The Dynamo operator creates the `disagg-kv-dsv32-nvfp4-frontend` service for this deployment.
+| Statistic | Value |
+| --- | ---: |
+| Total requests | 10,000 |
+| Unique / total hash blocks | 430,838 / 770,934 |
+| ISL — average / maximum / minimum | 39,186 / 109,459 / 12,801 tokens |
+| OSL — average / maximum / minimum | 344 / 2,000 / 1 tokens |
+| KV hit rate — block-level / token-level | 44.1% / 44.0% |
+| Avg context (shared) | 22,400 tokens/req |
+| Avg unique prompt | 16,786 tokens/req |
+| Shared prefix ratio | 57.2% |
+
+The ~44% KV cache hit rate is computed from `hash_id` overlap across requests, and roughly 57% of input tokens come from shared context prefixes.
+
+## Prerequisites
+
+- A Kubernetes cluster with the Dynamo platform (operator) installed and **32x GB200 across 8 nodes (NVL72, MNNVL-connected)** available. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
+- A Hugging Face token with access to [`nvidia/DeepSeek-V3.2-NVFP4`](https://huggingface.co/nvidia/DeepSeek-V3.2-NVFP4), NVIDIA's official NVFP4-quantized checkpoint.
+- The `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0` image (already pinned in `deploy.yaml`).
+
+Create the namespace and token secret:
+
+```bash
+export NAMESPACE=your-namespace
+kubectl create namespace ${NAMESPACE}
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="your-token" \
+  -n ${NAMESPACE}
+```
+
+## Quick Start
+
+Create storage, download NVIDIA's official NVFP4 checkpoint, copy the trace into the PVC, then deploy:
+
+### 1. Create Storage
+
+<Warning>
+Edit cluster-specific values before applying: `storageClassName` in `model-cache/model-cache.yaml` (run kubectl get storageclass), your namespace (perf.yaml hardcodes `namespace: your-namespace`), and the ComputeDomain claim names.
+</Warning>
+
+```bash
+# 1. Create the model-cache PVC (RWX, 400Gi).
+kubectl apply -f recipes/deepseek-v32-fp4/model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+### 2. Configure K8 Benchmarking Environment
+
+Multinode deployments on MNNVL-connected GB200 clusters typically require a ComputeDomain in your namespace so the DRA scheduler co-locates worker pods on MNNVL-connected nodes — otherwise internode GPU peer memory access fails:
+
+```bash
+kubectl apply -f recipes/deepseek-v32-fp4/model-cache/compute-domain.yaml -n ${NAMESPACE}
+```
+
+If you rename the ComputeDomain or its `resourceClaimTemplate` (defaults: `your-compute-domain` / `your-compute-domain-channel`), apply the same names in the deploy YAMLs under `extraPodSpec.resourceClaims` and `resources.claims`.
+
+### 3. Setup Model and Data
+
+```bash
+# 2. Download nvidia/DeepSeek-V3.2-NVFP4 into the PVC.
+kubectl apply -f recipes/deepseek-v32-fp4/model-cache/model-download.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=600s
+
+# 3. Copy the synthesized trace file into the PVC.
+kubectl cp <local_trace.jsonl> ${NAMESPACE}/<helper-pod>:/model-cache/traces/
+```
+
+### 4. Deploy & Benchmark
+
+```bash
+# 4. Deploy: KV-routed frontend + 2x prefill + 2x decode (WideEP) workers.
+kubectl apply -f recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/deploy.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=ready pod -l nvidia.com/dynamo-graph-deployment-name=disagg-kv-dsv32-nvfp4 \
+  -n ${NAMESPACE} --timeout=1200s
+```
+
+Smoke test the deployment before benchmarking. The Dynamo operator creates the `disagg-kv-dsv32-nvfp4-frontend` service for this deployment.
 
 ```bash
 kubectl port-forward svc/disagg-kv-dsv32-nvfp4-frontend 8000:8000 -n ${NAMESPACE}
@@ -94,8 +164,6 @@ curl http://localhost:8000/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{"model":"nvidia/DeepSeek-V3.2-NVFP4","messages":[{"role":"user","content":"Write a one-sentence readiness check."}],"max_tokens":64}'
 ```
-
-## Benchmark
 
 The checked-in [`perf.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/perf.yaml) runs a short synthetic warmup, then replays the trace at its original timestamps. It wraps this AIPerf run:
 
@@ -107,27 +175,57 @@ aiperf profile -m nvidia/DeepSeek-V3.2-NVFP4 --tokenizer nvidia/DeepSeek-V3.2-NV
   --goodput "time_to_first_token:20000 inter_token_latency:50"
 ```
 
+Launch it as a Job:
+
 ```bash
 kubectl apply -f recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/perf.yaml -n ${NAMESPACE}
+```
+
+### 5. Monitor Benchmark Progress
+
+```bash
+# Find the benchmark pod:
+kubectl get pods -n ${NAMESPACE} -l job-name=disagg-kv-dsv32-nvfp4-bench
 
 # Follow the benchmark Job's logs:
 kubectl logs -f -l job-name=disagg-kv-dsv32-nvfp4-bench -n ${NAMESPACE}
 ```
 
-Results land under `/model-cache/perf/<epoch>_<job-name>/` on the `model-cache` PVC; copy them out with `kubectl cp`.
+### 6. View Results
+
+Results land under `/model-cache/perf/<epoch>_<job-name>/` on the `model-cache` PVC. Inspect the artifact directory in place, or copy it to your machine:
+
+```bash
+# Check artifact directory
+kubectl exec -it -n ${NAMESPACE} <benchmark-pod-name> -- ls -la /model-cache/perf/
+
+# Copy results to local machine
+kubectl cp ${NAMESPACE}/<benchmark-pod-name>:/model-cache/perf ./benchmark-results
+```
+
+## Expected Results
 
 Because the replay is `--fixed-schedule`, throughput is fixed by the trace — the metrics to compare are TTFT (KV-aware routing cuts prefill compute via prefix hits), ITL (disaggregation isolates decode from prefill interference), total request latency, and goodput against the TTFT 20s / ITL 50ms SLA.
 
-## Related Feature Benchmarks
+| Metric | Why it matters |
+| --- | --- |
+| **TTFT** (time to first token) | KV-aware routing reduces prefill compute via prefix cache hits |
+| **ITL** (inter-token latency) | Disaggregated serving isolates decode from prefill interference |
+| **Total request latency** | Combined benefit of both optimizations |
 
-- [DeepSeek V3.2 WideEP routing A/B](../feature-benchmarks/deepseek-v3-2-wideep-routing.mdx)
+For production contexts, evaluate the deployments with **goodput** — the rate of requests that satisfy a predetermined service level agreement (SLA). These experiments set the SLA at TTFT 20s and ITL 50ms.
 
-## Notes
+## Cleanup
 
-- The aggregated round-robin configuration (`trtllm/agg-round-robin/`) is the benchmark control arm; it appears on the Feature Benchmark page, not as a recipe target here.
-- The benchmark job pins `transformers==4.57.6`: the trtllm-runtime base ships 4.55.0, and aiperf's `transformers>=4.56.0` floor would otherwise pull 5.x, which cannot load the `deepseek_v32` tokenizer (surfaces as "Failed to load tokenizer").
-- Decode workers run the WIDEEP MoE backend with `moe_expert_parallel_size: 8` and FP8 KV cache; prefill enables chunked prefill and KV block reuse (`tokens_per_block: 64`, matching `--kv-block-size 64`).
-- The trace tops out at 109,459 input tokens; both engine configs set `max_seq_len: 121000` to accommodate it.
+```bash
+kubectl delete job disagg-kv-dsv32-nvfp4-bench -n ${NAMESPACE}
+kubectl delete dynamographdeployment disagg-kv-dsv32-nvfp4 -n ${NAMESPACE}
+```
+
+## References
+
+- [Mooncake: A KVCache-centric Disaggregated Architecture for LLM Serving](https://github.com/kvcache-ai/Mooncake) — the FAST25 paper and trace data this dataset is derived from.
+- Background on the underlying optimizations: [Optimizing DeepSeek-V3.2 on NVIDIA Blackwell GPUs](https://nvidia.github.io/TensorRT-LLM/blogs/tech_blog/blog15_Optimizing_DeepSeek_V32_on_NVIDIA_Blackwell_GPUs.html), the TensorRT-LLM tech blog covering DeepSeek V3.2 on GB200.
 
 ## Source
 

--- a/docs/fern/pages/recipes/model-recipes/deepseek-v4-flash.mdx
+++ b/docs/fern/pages/recipes/model-recipes/deepseek-v4-flash.mdx
@@ -9,7 +9,7 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-Each target below is an agentic-workload vLLM deployment of DeepSeek-V4-Flash — a MoE model (284B total / 13B active) with hybrid CSA + HCA attention, FP8 KV cache, and KV-aware routing. B200 serves the `nvidia/DeepSeek-V4-Flash-NVFP4` checkpoint; H200 serves the public `deepseek-ai/DeepSeek-V4-Flash`. Pick your GPU and topology; every command on this page updates to match. Text only; reasoning + tool calling supported.
+Each target below is an agentic-workload vLLM deployment of DeepSeek-V4-Flash — a MoE model (284B total / 13B active) with hybrid CSA + HCA attention, a Blackwell FP4 indexer cache, FP8 KV cache (block 256), and KV-aware routing with prefix caching. The two agentic B200 targets serve the `nvidia/DeepSeek-V4-Flash-NVFP4` checkpoint; H200 serves the public `deepseek-ai/DeepSeek-V4-Flash`. Pick your GPU and topology — the backend and workload rows carry a single option each, because every benchmarked target here is vLLM on the agentic workload; every command on this page updates to match. Text only; reasoning + tool calling supported.
 
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
@@ -21,41 +21,232 @@ Each target below is an agentic-workload vLLM deployment of DeepSeek-V4-Flash �
 <label htmlFor="recipe-sku-h200">H200</label>
 </div>
 <div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-agentic" name="recipe-usecase" value="agentic" defaultChecked />
+<label htmlFor="recipe-usecase-agentic">Agentic</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-vllm" name="recipe-engine" value="vllm" defaultChecked />
+<label htmlFor="recipe-engine-vllm">vLLM</label>
+</div>
+<div className="dynamo-target-picker-row">
 <span className="dynamo-target-picker-dim">Topology</span>
 <input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" defaultChecked />
 <label htmlFor="recipe-variant-disagg">Disaggregated <span className="dynamo-target-picker-hint">Higher throughput</span></label>
 <input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" />
 <label htmlFor="recipe-variant-agg">Aggregated</label>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="agg" data-usecase="agentic">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> nvidia/DeepSeek-V4-Flash-NVFP4</span>
-<span><b>GPUs</b> 4x B200, TP4 + EP</span>
-<span><b>MoE / KV</b> FLASHINFER_TRTLLM, FP8 KV (block 256)</span>
+<span><b>GPUs</b> 4x B200</span>
+<span><b>Parallelism</b> TP4</span>
+<span><b>MoE backend</b> FLASHINFER_TRTLLM</span>
+<span><b>Spec. decode</b> none</span>
+<span><b>KV cache</b> FP8 KV (block 256)</span>
 <span><b>Routing</b> KV-aware, prefix caching</span>
 <span><b>Context</b> 1,048,576</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="disagg" data-usecase="agentic">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 <span><b>Checkpoint</b> nvidia/DeepSeek-V4-Flash-NVFP4</span>
-<span><b>GPUs</b> 12x B200 — 2P1D (2 prefill + 1 decode, TP4 each)</span>
-<span><b>MoE / KV</b> FLASHINFER_TRTLLM, FP8 KV (block 256)</span>
-<span><b>Transfer</b> NIXL over RDMA/GDR</span>
+<span><b>GPUs</b> 12x B200</span>
+<span><b>Topology</b> 2P1D (2 prefill + 1 decode, TP4 each)</span>
+<span><b>Parallelism</b> TP4 / TP4</span>
+<span><b>MoE backend</b> FLASHINFER_TRTLLM</span>
+<span><b>Spec. decode</b> none</span>
+<span><b>KV cache</b> FP8 KV (block 256)</span>
+<span><b>Transfer</b> NIXL GDR</span>
 <span><b>Context</b> 1,048,576</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-variant="agg" data-usecase="agentic">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> deepseek-ai/DeepSeek-V4-Flash</span>
-<span><b>GPUs</b> 4x H200, DP4 + TP1 + EP</span>
-<span><b>MoE / spec</b> MARLIN (FLASHINFER_MLA attn), MTP-1</span>
+<span><b>GPUs</b> 4x H200</span>
+<span><b>Parallelism</b> DP4 + TP1 + EP</span>
+<span><b>MoE backend</b> MARLIN (FLASHINFER_MLA attn)</span>
+<span><b>Spec. decode</b> MTP-1</span>
 <span><b>Routing</b> KV-aware, prefix caching</span>
-<span><b>Context</b> 1,048,576</span>
+<span><b>Context</b> 1,048,576 (model default, not pinned)</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-variant="disagg" data-usecase="agentic">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 <span><b>Checkpoint</b> deepseek-ai/DeepSeek-V4-Flash</span>
-<span><b>GPUs</b> 28x H200 — 4P3D (DP4+TP1+EP per worker)</span>
-<span><b>MoE / spec</b> MARLIN, decode MTP-1</span>
-<span><b>Transfer</b> NIXL over RDMA/GDR</span>
+<span><b>GPUs</b> 28x H200</span>
+<span><b>Topology</b> 4P3D (DP4+TP1+EP per worker)</span>
+<span><b>Parallelism</b> DP4+TP1+EP / DP4+TP1+EP</span>
+<span><b>MoE backend</b> MARLIN (decode FLASHINFER_MLA attn)</span>
+<span><b>Spec. decode</b> decode MTP-1</span>
+<span><b>Transfer</b> NIXL GDR</span>
 <span><b>Context</b> 1,048,576</span>
 </div>
 </div>
+
+<Note>
+Recommended picks per SKU: **B200 → `disagg-b200-agentic` (2P1D)**; **H200 → `disagg-h200-agentic` (4P3D)**.
+</Note>
+
+## Recipes
+
+### Agentic (vLLM)
+
+The four agentic targets are the four combinations of the target picker above (`agg-b200`, `disagg-b200` 2P1D, `agg-h200`, `disagg-h200` 4P3D); each target's summary panel lists its full configuration.
+
+### Day-0
+
+The recipe tree also ships the four original single-node, single-replica aggregated recipes. They are **experimental (Day-0)**, text only, and functional but unbenchmarked:
+
+| Variant | Engine | GPUs | Parallelism | MoE backend | Spec. decode |
+|---|---|---|---|---|---|
+| `vllm/agg_b200` | vLLM | 4x B200 | DP4 + TP1 + EP | vLLM V4 expert (FP4) | none |
+| `vllm/agg_gb200` | vLLM | 4x GB200 | TP4 + EP | `deep_gemm_mega_moe` | none |
+| `sglang/agg` | SGLang | 4x B200 | TP4 | `flashinfer_mxfp4` | EAGLE MTP 3/4 |
+| `sglang/agg-gb200` | SGLang | 4x GB200 | TP4 | `flashinfer_mxfp4` | EAGLE MTP 3/4 |
+
+The B200 variants fill 4 of the 8 GPUs on a B200 node; the GB200 variants fill all 4 GPUs of a single GB200 NVL4 tray (arm64), whose nodes must be labeled `nvidia.com/gpu.product=NVIDIA-GB200` and tainted `kubernetes.io/arch=arm64:NoSchedule` — the manifests carry the matching `nodeSelector` and `toleration`. All four serve the public checkpoint and use prebuilt NGC images: `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.3` (multi-arch) for both vLLM variants, `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.3` for SGLang B200, and `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.3` (arm64) for SGLang GB200. To rebuild from source — a custom Dynamo branch, a different engine base — see the [container README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/container/README.md).
+
+## Performance
+
+Floor-picks (max system tok/s/GPU at user P50 >= 50 tok/s), default temperature. Flash is characterized on two workloads (Pro is agentic-only):
+
+| Workload | Median ISL | Median OSL | KV reuse | User output tok/s |
+|---|---:|---:|---:|---:|
+| Agentic (coding / tool use) | 64k | 400 | 90% | >= 50 |
+| Custom (decode-heavy synthetic) | 10k | 1k | 10% | >= 50 |
+
+### Agentic workload
+
+| Target | Concurrency | User tok/s | System tok/s/GPU |
+|---|---:|---:|---:|
+| agg-b200 | 38 | 50.6 | 362.1 |
+| disagg-b200 (2P1D) | 128 | 50.35 | 409.9 |
+| agg-h200 | 16 | 50.7 | 145.4 |
+| disagg-h200 (4P3D) | 128 | 51.8 | 201.9 |
+
+### Custom workload
+
+| Target | Concurrency | User tok/s | System tok/s/GPU |
+|---|---:|---:|---:|
+| agg-b200 | 64 | 50.1 | 741.6 |
+| disagg-b200 (2P1D) | 128 | 51.9 | 738.2 |
+| agg-h200 | 16 | 58.9 | 222.0 |
+| disagg-h200 (4P3D) | 416 | 51.8 | 513.6 |
+
+<div data-sku="b200" data-variant="disagg">
+
+The disagg-b200 custom-workload figure (738.2) was measured at a **1P1D** prefill:decode ratio — optimal for that decode-heavy workload — while the shipped `disagg-b200-agentic` `deploy.yaml` is **2P1D** (agentic-tuned). The config is otherwise the same, so set the `VllmPrefillWorker` / `VllmDecodeWorker` replicas to 1P1D to reproduce it.
+
+</div>
+
+<div data-sku="b200" data-variant="agg">
+
+The agg-b200 custom-workload figure (741.6) was measured on the shipped `agg-b200-agentic` `deploy.yaml` as-is — no replica or parallelism change. Only the client load differs: set `CONCURRENCY` to `64` instead of the agentic floor-pick of `38`.
+
+</div>
+
+<div data-sku="h200">
+
+The H200 custom-workload figures were measured on the shipped `agg-h200-agentic` and `disagg-h200-agentic` `deploy.yaml`s as-is — no replica or parallelism change, and `disagg-h200` keeps its 4P3D layout. Only the client load differs: set `CONCURRENCY` to `16` for `agg-h200` and `416` for `disagg-h200`.
+
+</div>
+
+The AGG rows are single-replica floor-picks; scale AGG by deploying independent single-replica DGDs.
+
+The disaggregated figures were measured with the per-rank NIC map in place (GDR). Without it, KV transfer falls back to host-staging and these numbers are not reproducible.
+
+### Benchmark
+
+The shared [`perf.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/perf/perf.yaml) replays the agentic [Mooncake-format](https://github.com/kvcache-ai/Mooncake) trace (64k median ISL / 400 median OSL, 90% KV reuse) with AIPerf against the deployed frontend, and writes its artifacts to `/model-cache/perf` on the model-cache PVC.
+
+The Job reads its trace from the `model-cache` PVC, so stage the traces first — they are vendored via Git LFS, and `kubectl run` returns before the helper pod is Ready:
+
+```bash
+git lfs pull --include="recipes/deepseek-v4/perf/traces/*.jsonl"
+
+kubectl run pvc-helper -n ${NAMESPACE} \
+  --image=busybox:1.36 --restart=Never \
+  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"model-cache","mountPath":"/model-cache"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"model-cache"}}]}}' \
+  --command -- sleep 3600
+
+kubectl wait --for=condition=Ready pod/pvc-helper -n ${NAMESPACE} --timeout=120s
+kubectl cp recipes/deepseek-v4/perf/traces ${NAMESPACE}/pvc-helper:/model-cache/
+```
+
+The Job expects three Mooncake JSONL traces on the PVC — `/model-cache/traces/64k_400_90kv_agent_new_noschedule.jsonl` plus the `..._short_30perc.jsonl` and `..._short_15perc.jsonl` subsets. The shipped `TRACE_FILE` default is the 15% subset.
+
+`perf.yaml` ships pointed at the Pro AGG B200 deployment, so edit its `env` block before applying. `ENDPOINT` is the target's frontend service (`${DGD}-frontend:8000`) and `TARGET_MODEL` is the served model name for your SKU, which must match what `GET /v1/models` reports:
+
+<div data-sku="b200" data-variant="agg">
+
+```yaml
+- name: ENDPOINT
+  value: dsv4-flash-agg-b200-agentic-frontend:8000
+- name: TARGET_MODEL
+  value: nvidia/DeepSeek-V4-Flash-NVFP4
+```
+
+</div>
+
+<div data-sku="b200" data-variant="disagg">
+
+```yaml
+- name: ENDPOINT
+  value: dsv4-flash-disagg-b200-agentic-frontend:8000
+- name: TARGET_MODEL
+  value: nvidia/DeepSeek-V4-Flash-NVFP4
+```
+
+</div>
+
+<div data-sku="h200" data-variant="agg">
+
+```yaml
+- name: ENDPOINT
+  value: dsv4-flash-agg-h200-agentic-frontend:8000
+- name: TARGET_MODEL
+  value: deepseek-ai/DeepSeek-V4-Flash
+```
+
+</div>
+
+<div data-sku="h200" data-variant="disagg">
+
+```yaml
+- name: ENDPOINT
+  value: dsv4-flash-disagg-h200-agentic-frontend:8000
+- name: TARGET_MODEL
+  value: deepseek-ai/DeepSeek-V4-Flash
+```
+
+</div>
+
+```bash
+kubectl apply -f recipes/deepseek-v4/perf/perf.yaml -n ${NAMESPACE}
+kubectl logs -n ${NAMESPACE} -l job-name=dsv4-bench -f
+kubectl wait --for=condition=Complete job/dsv4-bench -n ${NAMESPACE} --timeout=7200s
+```
+
+Fetch the artifacts from the PVC with the same helper pod:
+
+```bash
+kubectl cp ${NAMESPACE}/pvc-helper:/model-cache/perf/<epoch>_dsv4-bench ./results
+```
+
+The rest of the `env` block is tunable:
+
+- `CONCURRENCY` is one value per Job and defaults to `16`, the agentic floor-pick concurrency for `agg-h200` only — the other three targets need `38` (`agg-b200`) or `128` (both disaggregated) to reproduce the [Performance](#performance) numbers.
+- `TRACE_FILE` defaults to the 15% agentic subset on the PVC.
+- `REQUEST_TIMEOUT_SECONDS` defaults to `1200`, long enough for long-context requests.
+- `AIPERF_VERSION` defaults to `0.10.0`; match local benchmark runs unless you update it intentionally.
+
+For a concurrency sweep, run one concurrency per Job and reset server state between rows:
+
+1. Delete the previous benchmark Job.
+2. Stop clients and wait for in-flight requests to drain.
+3. Delete/restart the worker pods to clear backend KV/prefix-cache state.
+4. Restart the frontend/router if testing KV-aware routing, so router state is also cleared.
+5. Wait for `/v1/models`, run a chat smoke test, then launch the next Job.
+
+Do not rely on `cache_salt` for Dynamo unless that support has been explicitly validated for the deployed frontend/backend path.
+
+Record this evidence for every result row you report: deploy manifest path, image ref/digest, endpoint, target model, trace path and sha256, concurrency, reset sequence, `profile_export_aiperf.json`, metrics summary, frontend/router metrics when KV-aware routing is enabled, and worker prefix-cache metrics.
 
 ## Prerequisites
 
@@ -63,21 +254,78 @@ Each target below is an agentic-workload vLLM deployment of DeepSeek-V4-Flash �
 
 <div data-sku="b200">
 
-- **4x B200** (aggregated) or **12x B200** (disaggregated, 2P1D) available.
+- **4x B200** (aggregated: 4 GPUs on one x86_64 node) or **12x B200** (disaggregated, 2P1D) available; the disaggregated pods — (2 prefill + 1 decode) x 4 GPUs — span **multiple nodes**.
+- For **disaggregated**, an RDMA device plugin that provides `rdma/shared_ib`: each worker requests `rdma/shared_ib: "1"` — see [Per-Rank NIC Map](#per-rank-nic-map).
 - A Hugging Face token with access to `nvidia/DeepSeek-V4-Flash-NVFP4`.
 
 </div>
 
 <div data-sku="h200">
 
-- **4x H200** (aggregated) or **28x H200** (disaggregated, 4P3D) available.
+- **4x H200** (aggregated: 4 GPUs on one x86_64 node) or **28x H200** (disaggregated, 4P3D) available; the disaggregated pods — (4 prefill + 3 decode) x 4 GPUs — span **multiple nodes**.
+- For **disaggregated**, an RDMA device plugin that provides `rdma/ib`: each worker requests `rdma/ib` — see [Per-Rank NIC Map](#per-rank-nic-map).
 - A Hugging Face token with access to `deepseek-ai/DeepSeek-V4-Flash`.
 
 </div>
 
-- The `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0` image (pinned in each `deploy.yaml`).
+- The `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0` image (pinned in each agentic `deploy.yaml`).
 
-Create the namespace and token secret:
+### Per-Rank NIC Map
+
+<div data-variant="agg">
+
+Aggregated targets need no NIC map: there is no cross-worker KV transfer, so the aggregated recipes set neither NIC env var and need no GDR. Continue to [Deploy](#deploy).
+
+</div>
+
+<div data-variant="disagg">
+
+In disaggregated serving the prefill workers stream the KV cache to the decode workers' GPUs over InfiniBand using **GPU-Direct RDMA (GDR)**. Each tensor-parallel rank should transfer over the RDMA NIC on **its own PCIe switch** (its affine NIC); if several ranks are forced onto the **same** NIC they oversubscribe it and GPU-direct registration collapses to slow host-staging — **~0.76 GB/s with 4 ranks on one NIC vs ~15-25 GB/s with one NIC per rank (~25x slower)**. The disaggregated recipe originally pinned every rank to one device (`UCX_NET_DEVICES=mlx5_0:1`), triggering exactly this. `VLLM_GPU_NIC_PCIE_MAPPING` together with `VLLM_NIC_SELECTION_VARS=UCX_NET_DEVICES:1` ([vLLM #42083](https://github.com/vllm-project/vllm/pull/42083)) assigns each rank its PCIe-affine NIC and restores GDR. This is a general tensor-parallel NIC-assignment requirement, not a DeepSeek-V4 property — any TP>1 NIXL disaggregated worker pinned to a single NIC collapses the same way, and DeepSeek-V4's packed KV layout was ruled out as the cause.
+
+Regenerate the map on a target node:
+
+```bash
+# 1) GPU PCIe BDFs, in device order:
+nvidia-smi --query-gpu=index,pci.bus_id --format=csv,noheader
+#    -> e.g. 0, 00000000:18:00.0
+
+# 2) RDMA NIC PCIe BDF for each mlx5 device:
+for d in /sys/class/infiniband/*/device; do
+  echo "$(basename "$(dirname "$d")") -> $(basename "$(readlink -f "$d")")"
+done
+#    -> e.g. mlx5_0 -> 0000:19:00.0
+```
+
+Pair each GPU with the NIC sharing its PCIe switch (its closest NIC), join the pairs in GPU order, and set both env vars on **both** the prefill and decode workers:
+
+```text
+VLLM_GPU_NIC_PCIE_MAPPING="<gpu0_bdf>=<nic0_bdf>,<gpu1_bdf>=<nic1_bdf>,..."
+VLLM_NIC_SELECTION_VARS="UCX_NET_DEVICES:1"
+```
+
+There is no "just auto-select" shortcut: pinning all ranks to one NIC degrades to single-NIC host-staging (~20x slower, but still functional), while *unsetting* `UCX_NET_DEVICES` to expose all NICs can fail NIXL backend creation — the working fast path is exactly one affine NIC per rank. The map references the NIC BDFs the cluster injects into the pod, so it breaks if the cluster injects a different NIC set; derive it from the pod's actual `/sys/class/infiniband` rather than hard-coding it. With no RDMA fabric at all, fall back to TCP: set `NCCL_IB_DISABLE=1` and `NCCL_NET=Socket`, and drop the RDMA resource requests.
+
+Which RDMA resource to request is cluster-plugin-dependent, not GPU-dependent. `rdma/ib: "N"` (N exclusive devices) is clean and NIC-isolated but relies on the plugin injecting the pod's *affine* NICs; `rdma/shared_ib: "1"` exposes **all** of the node's NICs to the pod, so the per-rank map can always find each rank's affine NIC even when the plugin would inject a non-affine set. Both pair with the same `VLLM_GPU_NIC_PCIE_MAPPING` — pick whichever your cluster's plugin exposes.
+
+<div data-sku="b200">
+
+The B200 disaggregated recipe ships `rdma/shared_ib`, and because that exposes **all** NICs a wrong or stale map **fails silently**: the NIC is present, so the rank quietly opens a **non-affine** NIC and GDR degrades to a cross-socket path with no error. (Under exclusive `rdma/ib` the same map hard-fails with `createBackend` errors.) Derive the map from the pod's actual `/sys/class/infiniband` at deploy time and verify the per-rank NIC selection in the worker log rather than trusting a hard-coded map. Shared NICs are also not bandwidth-isolated from co-tenant pods — a throughput, not a correctness, concern.
+
+</div>
+
+<div data-sku="h200">
+
+The H200 disaggregated recipe ships exclusive `rdma/ib`, so a map that points a rank at a NIC not injected into the pod hard-fails with `createBackend` errors instead of degrading silently (which is what happens under `rdma/shared_ib`, where every NIC is present). Still derive the map from the pod's actual `/sys/class/infiniband` at deploy time and verify the per-rank NIC selection in the worker log rather than trusting a hard-coded map.
+
+</div>
+
+After deploying, confirm the worker log shows NIXL registering the CUDA/GDR path (~15-17 GB/s KV transfer). A wrong or missing map degrades to slow TCP transfer or fails NIXL setup.
+
+</div>
+
+## Quick Start
+
+Create the namespace and token secret. The secret is consumed by the download Job and, as a convenience, by the worker (workers mount it via `envFrom`):
 
 ```bash
 export NAMESPACE=your-namespace
@@ -86,18 +334,16 @@ kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN="your-toke
 ```
 
 <Warning>
-Edit cluster-specific values before applying: `storageClassName` in `model-cache/model-cache.yaml` (a RWX class). For **disaggregated** targets, also set `VLLM_GPU_NIC_PCIE_MAPPING` in the manifest to your node's per-rank affine NICs — see [Per-rank NIC mapping](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/README.md#per-rank-nic-mapping-b200--h200-disaggregated).
+Edit cluster-specific values before applying: `storageClassName` in `model-cache/model-cache.yaml` (a RWX class). For **disaggregated** targets, also set **both** `VLLM_GPU_NIC_PCIE_MAPPING` (your node's `GPU_BDF=NIC_BDF` map) and `VLLM_NIC_SELECTION_VARS=UCX_NET_DEVICES:1` on the prefill and decode workers — they are a pair, setting only one fails EngineCore init, and the manifests ship neither. See [Per-Rank NIC Map](#per-rank-nic-map).
 </Warning>
 
-## Deploy
-
-Create storage, download the checkpoint into the PVC, then apply the target's `deploy.yaml`:
+Create storage, download the checkpoint into the PVC, then apply the target's `deploy.yaml`. The PVC requests 400Gi; DeepSeek-V4-Flash is ~160 GB on disk (46 safetensors shards, FP4 + FP8 mixed) and typically takes 30-60 min to download on first apply:
 
 ```bash
 kubectl apply -f recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-cache.yaml -n ${NAMESPACE}
 ```
 
-There is one download Job per checkpoint, because the PVC holds one, not both. B200 serves the NVFP4 checkpoint; every other variant serves the public one.
+There is one download Job per checkpoint, because the PVC holds one, not both. The two agentic B200 targets (`vllm/agg-b200-agentic` and `vllm/disagg-b200-agentic`) serve the NVFP4 checkpoint; the other six variants — H200 agentic, GB200, Day-0 B200, and all SGLang — serve the public one.
 
 <div data-sku="b200">
 
@@ -124,6 +370,8 @@ The workers mount the PVC read-only with `HF_HUB_OFFLINE=1`, so they cannot fetc
 <Note>
 To switch a populated PVC to the other checkpoint: stop the workers, delete the PVC, re-apply `model-cache.yaml`, then apply the other Job. The two Jobs have distinct names, so applying the second one does not collide with the first.
 </Note>
+
+### Deploy
 
 <div data-sku="b200" data-variant="agg">
 
@@ -157,6 +405,12 @@ RECIPE=recipes/deepseek-v4/deepseek-v4-flash/vllm/disagg-h200-agentic
 
 </div>
 
+<div data-variant="disagg">
+
+Set `VLLM_GPU_NIC_PCIE_MAPPING` and `VLLM_NIC_SELECTION_VARS` on the prefill and decode workers in `${RECIPE}/deploy.yaml` before applying — see [Per-Rank NIC Map](#per-rank-nic-map).
+
+</div>
+
 ```bash
 kubectl apply -f ${RECIPE}/deploy.yaml -n ${NAMESPACE}
 
@@ -166,11 +420,11 @@ kubectl wait --for=condition=Ready pod \
   -l nvidia.com/dynamo-graph-deployment-name=${DGD} -n ${NAMESPACE} --timeout=3600s
 ```
 
-First launch loads weights and warms CUDA graphs; the startup probes allow for it.
+First worker launch loads weights and warms CUDA graphs / kernels — up to ~60 min; the manifests' startup probes are sized for it.
 
-## Smoke Test
+### Test the Deployment
 
-The `model` field must be the **served model name for your SKU** (the `--served-model-name` in the deploy): B200 serves `nvidia/DeepSeek-V4-Flash-NVFP4`, H200 serves `deepseek-ai/DeepSeek-V4-Flash`.
+The `model` field must be the **served model name for your SKU** (the `--served-model-name` in the deploy): B200 serves `nvidia/DeepSeek-V4-Flash-NVFP4`, H200 serves `deepseek-ai/DeepSeek-V4-Flash`. The same OpenAI-compatible endpoints apply to the vLLM and SGLang variants.
 
 <div data-sku="b200">
 
@@ -196,32 +450,124 @@ curl http://localhost:8000/v1/chat/completions -H 'Content-Type: application/jso
 
 Flash reasons by default: the chain-of-thought fills `message.reasoning_content` and the answer fills `message.content`. With too small a `max_tokens` the budget is spent on reasoning before any `content` (`content: null`, `finish_reason: "length"`) — expected; raise `max_tokens`.
 
-## Benchmark
+### Verifying Reasoning
 
-The shared [`perf.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/perf/perf.yaml) replays the agentic MoonTrace (64K avg ISL / 400 OSL, 90% KV reuse) with AIPerf against the deployed frontend. Point `ENDPOINT` at `${DGD}-frontend:8000` and apply it:
+Same flow on every variant — same model, same `--dyn-reasoning-parser deepseek_v4`:
+
+<div data-sku="b200">
 
 ```bash
-kubectl apply -f recipes/deepseek-v4/perf/perf.yaml -n ${NAMESPACE}
+curl -s http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "nvidia/DeepSeek-V4-Flash-NVFP4",
+    "messages": [{"role": "user", "content": "What is 2+2? Answer briefly."}],
+    "max_tokens": 200
+  }' | python3 -m json.tool
 ```
 
-## Compare All Targets
+</div>
 
-| Target | GPUs | Parallelism | MoE backend | Spec. decode | Transfer |
-|---|---|---|---|---|---|
-| agg-b200 | 4x B200 | TP4 + EP | FLASHINFER_TRTLLM | none | — |
-| disagg-b200 (2P1D) | 12x B200 | TP4 / TP4 | FLASHINFER_TRTLLM | none | NIXL GDR |
-| agg-h200 | 4x H200 | DP4 + TP1 + EP | MARLIN (FLASHINFER_MLA attn) | MTP-1 | — |
-| disagg-h200 (4P3D) | 28x H200 | DP4+TP1+EP / DP4+TP1+EP | MARLIN | decode MTP-1 | NIXL GDR |
+<div data-sku="h200">
 
-## Notes
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek-ai/DeepSeek-V4-Flash",
+    "messages": [{"role": "user", "content": "What is 2+2? Answer briefly."}],
+    "max_tokens": 200
+  }' | python3 -m json.tool
+```
+
+</div>
+
+Expected:
+
+- `choices[0].message.reasoning_content` contains the model's chain-of-thought.
+- `choices[0].message.content` contains only the final answer.
+- No raw `</think>` tags in either field.
+
+If `reasoning_content` is `null` and `</think>` appears in `content`, the reasoning parser is not wired up — confirm `--dyn-reasoning-parser deepseek_v4` is on the worker command.
+
+### Verifying Tool Calling
+
+Same flow on every variant:
+
+<div data-sku="b200">
+
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "nvidia/DeepSeek-V4-Flash-NVFP4",
+    "messages": [{"role": "user", "content": "What is the weather in San Francisco?"}],
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a location",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": {"type": "string", "description": "City name"}
+          },
+          "required": ["location"]
+        }
+      }
+    }],
+    "max_tokens": 300
+  }' | python3 -m json.tool
+```
+
+</div>
+
+<div data-sku="h200">
+
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek-ai/DeepSeek-V4-Flash",
+    "messages": [{"role": "user", "content": "What is the weather in San Francisco?"}],
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a location",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": {"type": "string", "description": "City name"}
+          },
+          "required": ["location"]
+        }
+      }
+    }],
+    "max_tokens": 300
+  }' | python3 -m json.tool
+```
+
+</div>
+
+Expected:
+
+- `choices[0].message.tool_calls` is a structured array with `function.name`, `function.arguments`, and `id`.
+- `choices[0].finish_reason` is `"tool_calls"`.
+- `choices[0].message.reasoning_content` may contain the model's reasoning about tool selection.
+
+If `tool_calls` is missing and raw tool-call markers appear in `content`, confirm `--dyn-tool-call-parser deepseek_v4` is on the worker command.
+
+### Notes
 
 - **Reasoning / tool parsers** are wired via the Dynamo variants (`--dyn-reasoning-parser deepseek_v4`, `--dyn-tool-call-parser deepseek_v4`); the engine-native parsers do not feed the Dynamo OpenAI renderer.
-- **Disaggregated** targets require the per-rank NIC map (`VLLM_GPU_NIC_PCIE_MAPPING`) for GPU-Direct RDMA KV transfer; B200 ships `rdma/shared_ib`, H200 ships `rdma/ib`. See the [top-level recipe README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/README.md#per-rank-nic-mapping-b200--h200-disaggregated).
-- **AGG scales by independent single-replica DGDs** — KV-routed multi-replica AGG does not improve per-GPU throughput.
-- Day-0 / GB200 SGLang variants exist in the recipe tree but are experimental (dev images) and not shown here.
+- **Disaggregated** targets require the per-rank NIC map (the `VLLM_GPU_NIC_PCIE_MAPPING` + `VLLM_NIC_SELECTION_VARS` pair) for GPU-Direct RDMA KV transfer; B200 ships `rdma/shared_ib`, H200 ships `rdma/ib`. See [Per-Rank NIC Map](#per-rank-nic-map).
+- **AGG scales by independent single-replica DGDs.** With `DYN_ROUTER_MODE=kv` the KV-affinity router concentrates the 90%-reuse agentic prefixes onto a few replicas, so KV-routed multi-replica AGG lands *below* single-replica per-GPU throughput (measured N=7 at `router_temperature=1.0`: B200 293 vs 362, H200 121 vs 145 tok/s/GPU). The disaggregated variants are the multi-worker path.
+- **Workers run as `runAsUser: 0`** — FlashInfer's TRT-LLM FP4 MoE JIT writes cubins into a root-owned `site-packages` directory during `determine_available_memory`, which a non-root user cannot write. The fix (making that directory group-writable in the image) is tracked separately; drop `runAsUser: 0` once it lands.
 
 ## Source
 
 - Recipe README: [recipes/deepseek-v4/deepseek-v4-flash/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/deepseek-v4-flash/README.md)
 - Top-level DeepSeek-V4 README (shared workloads, NIC mapping, limitations): [recipes/deepseek-v4/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/README.md)
-- Manifests: [vllm/](https://github.com/ai-dynamo/dynamo/tree/main/recipes/deepseek-v4/deepseek-v4-flash/vllm) and shared [perf/perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/perf/perf.yaml)
+- Manifests: [vllm/](https://github.com/ai-dynamo/dynamo/tree/main/recipes/deepseek-v4/deepseek-v4-flash/vllm), [sglang/](https://github.com/ai-dynamo/dynamo/tree/main/recipes/deepseek-v4/deepseek-v4-flash/sglang), and shared [perf/perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/perf/perf.yaml)
+- Benchmark README (trace staging, variant targeting, sweep and reset procedure): [recipes/deepseek-v4/perf/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/perf/README.md)

--- a/docs/fern/pages/recipes/model-recipes/deepseek-v4-pro.mdx
+++ b/docs/fern/pages/recipes/model-recipes/deepseek-v4-pro.mdx
@@ -9,7 +9,7 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-Each target below is an agentic-workload vLLM deployment of DeepSeek-V4-Pro — a MoE model (1.6T total / 49B active) with hybrid CSA + HCA attention, a Blackwell FP4 indexer cache, and mHC residual connections. B200 serves the `nvidia/DeepSeek-V4-Pro-NVFP4` checkpoint at the full 1M context; H200 serves the public `deepseek-ai/DeepSeek-V4-Pro` (FP8), capped at `max_model_len=86016` by HBM. Pick your GPU and topology; every command updates to match. Text only; reasoning + tool calling supported.
+Each target below is an agentic-workload vLLM deployment of DeepSeek-V4-Pro — a MoE model (1.6T total / 49B active) with hybrid CSA + HCA attention, a Blackwell FP4 indexer cache, and mHC residual connections. The agentic B200 targets serve the `nvidia/DeepSeek-V4-Pro-NVFP4` checkpoint at the full 1M context; H200 serves the public `deepseek-ai/DeepSeek-V4-Pro` (FP8), capped at `max_model_len=86016` by HBM. Pick your GPU, backend, workload, and topology; every command updates to match. Text only; reasoning + tool calling supported. A second family — the original **Day-0** recipes (B200/GB200, vLLM + SGLang) — is covered in [Day-0 variants](#day-0).
 
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
@@ -21,39 +21,63 @@ Each target below is an agentic-workload vLLM deployment of DeepSeek-V4-Pro — 
 <label htmlFor="recipe-sku-h200">H200</label>
 </div>
 <div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-agentic" name="recipe-usecase" value="agentic" defaultChecked />
+<label htmlFor="recipe-usecase-agentic">Agentic</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-vllm" name="recipe-engine" value="vllm" defaultChecked />
+<label htmlFor="recipe-engine-vllm">vLLM</label>
+</div>
+<div className="dynamo-target-picker-row">
 <span className="dynamo-target-picker-dim">Topology</span>
 <input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" defaultChecked />
 <label htmlFor="recipe-variant-disagg">Disaggregated</label>
 <input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" />
 <label htmlFor="recipe-variant-agg">Aggregated</label>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="agg" data-usecase="agentic">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
+<span><b>Target</b> agg-b200</span>
 <span><b>Checkpoint</b> nvidia/DeepSeek-V4-Pro-NVFP4</span>
-<span><b>GPUs</b> 8x B200, TP8 + EP</span>
-<span><b>MoE / spec</b> FLASHINFER_TRTLLM, MTP-2</span>
-<span><b>KV / routing</b> FP8 KV (block 256), KV-aware</span>
-<span><b>Context</b> 1,048,576</span>
+<span><b>GPUs</b> 8x B200</span>
+<span><b>Parallelism</b> TP8 + EP</span>
+<span><b>MoE backend</b> FLASHINFER_TRTLLM</span>
+<span><b>Spec. decode</b> MTP-2</span>
+<span><b>KV / routing</b> FP8 KV (block 256), KV-aware, prefix caching</span>
+<span><b>max_model_len</b> 1,048,576</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="disagg" data-usecase="agentic">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
+<span><b>Target</b> disagg-b200 (1P1D)</span>
 <span><b>Checkpoint</b> nvidia/DeepSeek-V4-Pro-NVFP4 <span className="dynamo-target-picker-hint">Recommended</span></span>
-<span><b>GPUs</b> 16x B200 — 1P1D (TP8 + EP per worker)</span>
-<span><b>MoE / spec</b> FLASHINFER_TRTLLM, decode MTP-2</span>
-<span><b>Transfer</b> NIXL over RDMA/GDR</span>
-<span><b>Context</b> 1,048,576</span>
+<span><b>GPUs</b> 16x B200</span>
+<span><b>Parallelism</b> TP8 + EP</span>
+<span><b>MoE backend</b> FLASHINFER_TRTLLM</span>
+<span><b>Spec. decode</b> decode MTP-2</span>
+<span><b>KV / routing</b> FP8 KV (block 256), KV-aware, prefix caching</span>
+<span><b>Transfer</b> NIXL GDR</span>
+<span><b>max_model_len</b> 1,048,576</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-variant="agg" data-usecase="agentic">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
+<span><b>Target</b> agg-h200</span>
 <span><b>Checkpoint</b> deepseek-ai/DeepSeek-V4-Pro (FP8) <span className="dynamo-target-picker-hint">Recommended on H200</span></span>
-<span><b>GPUs</b> 8x H200, TP8 + EP</span>
-<span><b>MoE</b> MARLIN</span>
-<span><b>KV / routing</b> FP8 KV (block 256), KV-aware</span>
-<span><b>Context</b> 86,016 (HBM cap)</span>
+<span><b>GPUs</b> 8x H200</span>
+<span><b>Parallelism</b> TP8 + EP</span>
+<span><b>MoE backend</b> MARLIN</span>
+<span><b>Spec. decode</b> none</span>
+<span><b>KV / routing</b> FP8 KV (block 256), KV-aware, prefix caching</span>
+<span><b>max_model_len</b> 86,016 (HBM cap)</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-variant="disagg" data-usecase="agentic">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
+<span><b>Target</b> disagg-h200 (1P3D)</span>
 <span><b>Checkpoint</b> deepseek-ai/DeepSeek-V4-Pro (FP8)</span>
-<span><b>GPUs</b> 32x H200 — 1P3D (TP8 + EP per worker)</span>
-<span><b>MoE</b> MARLIN</span>
-<span><b>Transfer</b> NIXL over RDMA/GDR</span>
-<span><b>Context</b> 86,016 (HBM cap)</span>
+<span><b>GPUs</b> 32x H200</span>
+<span><b>Parallelism</b> TP8 + EP</span>
+<span><b>MoE backend</b> MARLIN</span>
+<span><b>Spec. decode</b> none</span>
+<span><b>KV / routing</b> FP8 KV (block 256), KV-aware, prefix caching</span>
+<span><b>Transfer</b> NIXL GDR</span>
+<span><b>max_model_len</b> 86,016 (HBM cap)</span>
 </div>
 </div>
 
@@ -61,27 +85,318 @@ Each target below is an agentic-workload vLLM deployment of DeepSeek-V4-Pro — 
 Recommended picks differ by SKU: **B200 → Disaggregated (1P1D)** (highest tok/s/GPU); **H200 → Aggregated** (AGG beats the 1P3D disagg lane). H200 targets are a secondary/best-effort lane on the public FP8 checkpoint.
 </Note>
 
+## Recipes
+
+- **Recommended per SKU:** B200 ships **disaggregated 1P1D** (+6% tok/s/GPU over AGG at matched user_p50); H200 ships **aggregated** (AGG > the 1P3D disagg lane). H200 is a secondary/best-effort lane on the public FP8 checkpoint at `max_model_len=86016`, so it cannot serve the longest agentic contexts the B200 1M recipes handle.
+- **Reasoning / tool parsers** are wired via `--dyn-reasoning-parser deepseek_v4` / `--dyn-tool-call-parser deepseek_v4`.
+- **Disaggregated** targets require the per-rank NIC map (`VLLM_GPU_NIC_PCIE_MAPPING` + `VLLM_NIC_SELECTION_VARS`, set as a pair on prefill and decode); B200 ships `rdma/shared_ib`, H200 ships `rdma/ib`. See [Per-rank NIC mapping](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/README.md#per-rank-nic-mapping-b200--h200-disaggregated).
+- **AGG scales by independent single-replica DGDs** — with `DYN_ROUTER_MODE=kv`, the KV-affinity router concentrates the 90%-reuse agentic prefixes onto a few replicas, so KV-routed *multi*-replica AGG lands *below* single-replica per-GPU throughput (measured N=7 at `router_temperature=1.0`: Flash B200 293 vs 362, H200 121 vs 145 tok/s/GPU). Use the disaggregated variants for the multi-worker path.
+- **Workers run as root** (`runAsUser: 0` in every worker `securityContext`) because the FlashInfer TRT-LLM FP4 MoE JIT writes cubins into a root-owned `site-packages` directory, which a non-root user cannot write during `determine_available_memory`. The fix — making that directory group-writable in the image — is tracked separately; drop `runAsUser: 0` once it lands.
+- **Day-0 / GB200 variants** (vLLM + SGLang, ComputeDomain/MNNVL) are experimental and ship dev images — see [Day-0 variants](#day-0).
+
+### Agentic (vLLM)
+
+Common to all four: FP8 KV cache, block size 256, KV-aware routing, and prefix caching.
+
+### Day-0
+
+Alongside the four benchmarked agentic targets above, the recipe tree ships seven **Day-0** variants — the original single-node and cross-tray aggregated + disaggregated recipes on B200 and GB200, with vLLM and SGLang. They are **experimental (Day-0)**, text only, and are not covered by the picker or the published floor-picks.
+
+| Variant | Backend | GPUs | Parallelism | MoE backend | Spec. decode |
+|---|---|---|---|---|---|
+| [`vllm-agg-b200`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/b200/deploy.yaml) | vLLM | 8x B200 | TP8 + EP | vLLM V4 expert (FP4) | none |
+| [`vllm-agg-gb200`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/gb200/deploy.yaml) | vLLM | 8x GB200 (2 trays) | TP8 + EP cross-tray | `deep_gemm_mega_moe` | none |
+| [`vllm-disagg-gb200`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/gb200/deploy.yaml) | vLLM | 16x GB200 (1P1D, 2 trays/worker) | DP8 + EP / DP8 + EP | vLLM V4 expert (FP4) | none |
+| [`sglang-agg`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/deepseek-v4-pro/sglang/agg/deploy.yaml) | SGLang | 8x B200 | TP8 | `flashinfer_mxfp4` | EAGLE MTP 3/4 |
+| [`sglang-agg-gb200`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/deepseek-v4-pro/sglang/agg-gb200/deploy.yaml) | SGLang | 8x GB200 (2 trays) | TP8 cross-tray | `flashinfer_mxfp4` | EAGLE MTP 3/4 |
+| [`sglang-disagg-b200`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/deepseek-v4-pro/sglang/disagg-b200/deploy.yaml) | SGLang | 16x B200 (1P1D) | TP8 / TP8 | `flashinfer_mxfp4` | EAGLE MTP 3/4 |
+| [`sglang-disagg-gb200`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/deepseek-v4-pro/sglang/disagg-gb200/deploy.yaml) | SGLang | 16x GB200 (1P1D, 2 trays/worker) | TP8 / TP8 cross-tray | `flashinfer_mxfp4` | EAGLE MTP 3/4 |
+
+All seven serve the public FP8 `deepseek-ai/DeepSeek-V4-Pro`, so stage the checkpoint with `model-download-fp8.yaml`, then deploy exactly as above: apply the variant's `deploy.yaml` and wait on its DGD.
+
+All Day-0 variants use prebuilt NGC images — vLLM (all): `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.3` (multi-arch); SGLang B200: `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.3` (the shipped `sglang/disagg-b200` manifest pins `…-cuda12-dev.2`); SGLang GB200: `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.3` (arm64). To rebuild from source — a custom Dynamo branch, a different engine base — see [`container/README.md`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/container/README.md).
+
+The GB200 disaggregated variant also ships a perf Job, [`vllm/disagg/gb200/perf.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/gb200/perf.yaml) — an 8K-input / 1K-output sweep at c=256/512/1024.
+
+#### GB200 cross-tray (MNNVL / ComputeDomain)
+
+DeepSeek-V4-Pro (~865 GB) exceeds a single GB200 NVL4 tray (~768 GB HBM across 4 GPUs), so every GB200 variant spans **two trays** over NVLink72 (MNNVL), not RoCE. The DRA **ComputeDomain** controller co-locates the worker pod set on the same NVLink72 clique — 2 pods for aggregated, 4 for disaggregated — and allocates the MNNVL channel on demand; the cross-node TP/DP all-reduce flows over that fabric.
+
+The cluster needs **2 GB200 nodes per worker**, each with 4 GPUs (one NVL4 tray), on the **same NVLink72 clique**. Label them `nvidia.com/gpu.product=NVIDIA-GB200`, taint them `kubernetes.io/arch=arm64:NoSchedule`, and install the DRA / ComputeDomain controller:
+
+```bash
+kubectl get crd | grep computedomain
+```
+
+Each manifest's `ComputeDomain` CR and `resourceClaims` co-locate the pod set on one NVLink72 fabric, and the manifests already set `NCCL_MNNVL_ENABLE=1`, `UCX_CUDA_IPC_ENABLE_MNNVL=y`, and `NCCL_NVLS_ENABLE=1`.
+
+#### SGLang disaggregated on B200
+
+Serves [`deepseek-ai/DeepSeek-V4-Pro`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro) with SGLang and disaggregated prefill/decode on B200 nodes with InfiniBand RDMA. Topology: 1 decode node (8 GPUs, TP8) plus 1 prefill node (8 GPUs, TP8), 16 GPUs total.
+
+Prerequisites: 2x B200 nodes with InfiniBand and the `rdma/ib` device plugin; the Dynamo operator and dynamo-platform HelmRelease installed; a shared RWX PVC for model weights (`shared-model-cache`); and a Hugging Face token secret:
+
+```bash
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN=<your-token> -n <namespace>
+```
+
+```bash
+# 0. Replace <your-namespace> in deploy.yaml with your namespace
+
+# 1. Deploy
+kubectl apply -f recipes/deepseek-v4/deepseek-v4-pro/sglang/disagg-b200/deploy.yaml
+
+# 2. Test
+kubectl port-forward svc/dsv4-pro-disagg-frontend 8000:8000 &
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"deepseek-ai/DeepSeek-V4-Pro","messages":[{"role":"user","content":"Hello!"}],"max_tokens":128}'
+```
+
+The `deploy.yaml` includes InfiniBand-specific UCX configuration validated on nscale B200 (ConnectX-8):
+
+| Variable | Value | Purpose |
+|---|---|---|
+| `UCX_TLS` | `rc_x,rc,cuda_copy,cuda_ipc` | Accelerated RC transport for IB RDMA |
+| `UCX_NET_DEVICES` | `mlx5_0:1` | Single IB device (avoids bonded device issues) |
+| `UCX_IB_ADDR_TYPE` | `eth` | Ethernet addressing — required for cross-pod IB on Kubernetes |
+| `UCX_RNDV_SCHEME` | `get_zcopy` | Zero-copy RDMA GET for KV transfers |
+| `UCX_RNDV_THRESH` | `0` | Use rendezvous for all message sizes |
+| `rdma/ib` | `8` (1 per GPU) | RDMA device plugin injects IB devices |
+
+Without `UCX_IB_ADDR_TYPE=eth`, UCX uses LID-based InfiniBand addressing, which does not route correctly between Kubernetes pods on different nodes; `eth` switches to GID/Ethernet-style addressing that works across the pod network. This is the most common issue when bringing up NIXL disaggregation on InfiniBand clusters.
+
+Some clusters expose `mlx5_bond_0` with LID=0. Setting `UCX_NET_DEVICES=mlx5_0:1` avoids that device; if your cluster uses a different IB device naming scheme, check with `ibv_devinfo`.
+
+Key configuration notes:
+
+- **EAGLE disabled** — it causes OOM on TP8 (4.23 GB free with EAGLE vs 7.75 GB without).
+- **`mem-fraction-static=0.82`** — higher than the GB200 recipe's 0.75, because B200 single-node TP avoids the multi-node weight-shuffle overhead.
+- **Security** — the `IPC_LOCK` and `SYS_RESOURCE` capabilities are required for RDMA memory pinning.
+- **Cold start ~20 min** — FP4 weight shuffle plus CUDA graph capture.
+
+The [disaggregated communication guide](../../developer-guide/knowledge-base/kubernetes/kubernetes-operator/disagg-communication.md) is the full RDMA transport reference.
+
+#### SGLang disaggregated on GB200
+
+Serves [`deepseek-ai/DeepSeek-V4-Pro`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro) with SGLang and disaggregated prefill/decode on GB200 nodes. Topology: 2 decode nodes at 4 GPUs each (TP8, 8 GPUs) plus 2 prefill nodes at 4 GPUs each (TP8, 8 GPUs).
+
+Prerequisites: 4x GB200 nodes with RDMA networking; the Dynamo operator and dynamo-platform HelmRelease installed; the ComputeDomain DRA driver (`compute-domain-default-channel.nvidia.com` device class); and a shared RWX PVC for model weights.
+
+```bash
+# 0. Replace <your-namespace> in deploy.yaml with your namespace
+
+# 1. Deploy
+kubectl apply -f recipes/deepseek-v4/deepseek-v4-pro/sglang/disagg-gb200/deploy.yaml
+
+# 2. Test
+kubectl port-forward svc/dsv4-pro-disagg-frontend 8000:8000 &
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"deepseek-ai/DeepSeek-V4-Pro","messages":[{"role":"user","content":"Hello!"}],"max_tokens":128}'
+```
+
+##### Cluster-specific configuration
+
+The base `deploy.yaml` is generic. Each cluster type requires additional configuration for RDMA networking, which NIXL needs for KV cache transfer between prefill and decode.
+
+**GKE (GCP GB200).** Add RDMA annotations to both the decode and prefill services:
+
+```yaml
+# In spec.services.decode and spec.services.prefill:
+annotations:
+  networking.gke.io/default-interface: eth0
+  networking.gke.io/interfaces: |
+    [
+      {"interfaceName":"eth0","network":"default"},
+      {"interfaceName":"rdma0","network":"rdma-0"},
+      {"interfaceName":"rdma1","network":"rdma-1"},
+      {"interfaceName":"rdma2","network":"rdma-2"},
+      {"interfaceName":"rdma3","network":"rdma-3"}
+    ]
+resources:
+  limits:
+    custom:
+      networking.gke.io.networks/rdma-0: "1"
+      networking.gke.io.networks/rdma-1: "1"
+      networking.gke.io.networks/rdma-2: "1"
+      networking.gke.io.networks/rdma-3: "1"
+```
+
+GCP clusters may isolate the `system-cpu` and `customer-gpu` pod networks. If the dynamo-system NATS is unreachable, deploy a namespace-local NATS on a `customer-cpu` node and override `NATS_SERVER` in `spec.envs`.
+
+GCP GPU nodes carry taints, so add these tolerations to all services:
+
+```yaml
+tolerations:
+  - key: dedicated
+    operator: Equal
+    value: user-workload
+    effect: NoExecute
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: kubernetes.io/arch
+    operator: Equal
+    value: arm64
+    effect: NoSchedule
+```
+
+**AWS EFA.** See the [disaggregated communication guide](../../developer-guide/knowledge-base/kubernetes/kubernetes-operator/disagg-communication.md#aws-efa-configuration) for EFA-specific NIXL configuration with libfabric.
+
+**InfiniBand.** For clusters with native IB (for example, DGX), add `rdma/ib` resource limits and make sure UCX UD transport is supported on your ConnectX firmware.
+
+Key configuration notes:
+
+- **EAGLE disabled** — it causes OOM on TP8 (4.23 GB free with EAGLE vs 7.75 GB without).
+- **`mem-fraction-static=0.75`** — lower than the default to prevent OOM during the FP4 MxFP4 weight shuffle.
+- **`cuda-graph-max-bs=128`** — limits CUDA graph capture memory.
+- **Cold start ~45 min** — the FP4 weight shuffle dominates startup time.
+
+## Performance
+
+These recipes are tuned against two optimization targets:
+
+| Workload | Median ISL | Median OSL | KV reuse | User output tok/s |
+|---|---:|---:|---:|---:|
+| Agentic (coding / tool use) | 64k | 400 | 90% | >= 50 |
+| Custom (decode-heavy synthetic) | 10k | 1k | 10% | >= 50 |
+
+Benchmarks replay [Mooncake-format](https://github.com/kvcache-ai/Mooncake) traces. Pro is characterized on the **Agentic** workload only — the Custom cell is Flash-only.
+
+Floor-picks (max system tok/s/GPU at user_p50 >= 50) at default temperature, on the agentic (MoonTrace) workload. Bold = recommended pick per SKU:
+
+| Target | Concurrency | User tok/s | System tok/s/GPU |
+|---|---:|---:|---:|
+| agg-b200 | 13 | 51.3 | 72.79 |
+| disagg-b200 (1P1D) | 28 | 51.3 | **77.31** |
+| agg-h200 | 8 | 53.2 | **45.90** |
+| disagg-h200 (1P3D) | 32 | 50.5 | 43.86 |
+
+The disaggregated rows were measured with the per-rank NIC mapping (GDR) in place; without it, KV transfer falls back to host-staging and will not reach these figures.
+
+### Benchmark
+
+The shared [`perf.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/perf/perf.yaml) replays the agentic MoonTrace (64K median ISL / 400 median OSL, 90% KV reuse) with AIPerf and writes its artifacts to the `model-cache` PVC under `/model-cache/perf`.
+
+The Job expects Mooncake-format JSONL traces on that PVC — the full trace plus 30% and 15% subsets:
+
+```text
+/model-cache/traces/64k_400_90kv_agent_new_noschedule.jsonl
+/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_30perc.jsonl
+/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
+```
+
+They are vendored via Git LFS, so fetch their content and stage them on the PVC first. `kubectl run` returns before the pod is Ready, so wait for it before `kubectl cp`:
+
+```bash
+git lfs pull --include="recipes/deepseek-v4/perf/traces/*.jsonl"
+
+kubectl run pvc-helper -n ${NAMESPACE} \
+  --image=busybox:1.36 --restart=Never \
+  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"model-cache","mountPath":"/model-cache"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"model-cache"}}]}}' \
+  --command -- sleep 3600
+
+kubectl wait --for=condition=Ready pod/pvc-helper -n ${NAMESPACE} --timeout=120s
+kubectl cp recipes/deepseek-v4/perf/traces ${NAMESPACE}/pvc-helper:/model-cache/
+```
+
+Next, edit the `env` block in `perf.yaml` to target your variant:
+
+| Target | `ENDPOINT` | `TARGET_MODEL` | Default trace |
+|---|---|---|---|
+| Pro AGG B200 | `dsv4-pro-agg-b200-agentic-frontend:8000` | `nvidia/DeepSeek-V4-Pro-NVFP4` | agentic |
+| Pro AGG H200 | `dsv4-pro-agg-h200-agentic-frontend:8000` | `deepseek-ai/DeepSeek-V4-Pro` | agentic |
+| Pro DisAgg B200 | `dsv4-pro-disagg-b200-agentic-frontend:8000` | `nvidia/DeepSeek-V4-Pro-NVFP4` | agentic |
+| Pro DisAgg H200 | `dsv4-pro-disagg-h200-agentic-frontend:8000` | `deepseek-ai/DeepSeek-V4-Pro` | agentic |
+
+`TARGET_MODEL` must match each manifest's `--served-model-name` (B200 → the NVFP4 name, H200 → the public checkpoint) as reported by `GET /v1/models`. Then apply the Job:
+
+```bash
+kubectl apply -f recipes/deepseek-v4/perf/perf.yaml -n ${NAMESPACE}
+kubectl logs -n ${NAMESPACE} -l job-name=dsv4-bench -f
+kubectl wait --for=condition=Complete job/dsv4-bench -n ${NAMESPACE} --timeout=7200s
+```
+
+Fetch the artifacts from the PVC through the same helper pod:
+
+```bash
+kubectl cp ${NAMESPACE}/pvc-helper:/model-cache/perf/<epoch>_dsv4-bench ./results
+```
+
+#### Tunable environment variables
+
+| Variable | Default | Notes |
+|---|---|---|
+| `ENDPOINT` | `dsv4-pro-agg-b200-agentic-frontend:8000` | DGD frontend service and port |
+| `TARGET_MODEL` | `nvidia/DeepSeek-V4-Pro-NVFP4` | Must match `/v1/models` |
+| `TRACE_FILE` | `/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` | Mooncake JSONL on PVC |
+| `CONCURRENCY` | `16` | Single value per Job |
+| `REQUEST_TIMEOUT_SECONDS` | `1200` | Long enough for long-context requests |
+| `AIPERF_VERSION` | `0.10.0` | Match local benchmark runs unless updated intentionally |
+
+The published floor-picks are c13 (agg-b200), c28 (disagg-b200), c8 (agg-h200), and c32 (disagg-h200).
+
+#### Reset between independent runs
+
+For a concurrency sweep, run one concurrency per Job and reset server state between rows:
+
+1. Delete the previous benchmark Job.
+2. Stop clients and wait for in-flight requests to drain.
+3. Delete/restart worker pods to clear backend KV/prefix-cache state.
+4. Restart the frontend/router if testing KV-aware routing so router state is also cleared.
+5. Wait for `/v1/models`, run a chat smoke, then launch the next Job.
+
+Do not rely on `cache_salt` for Dynamo unless that support has been explicitly validated for the deployed frontend/backend path.
+
+#### Required evidence for a result row
+
+```text
+deploy manifest path
+image ref/digest
+endpoint
+target model
+trace path and sha256
+concurrency
+reset sequence
+profile_export_aiperf.json
+metrics summary
+frontend/router metrics when KV-aware routing is enabled
+worker prefix-cache metrics
+```
+
 ## Prerequisites
 
-- A Kubernetes cluster with the Dynamo Platform (operator) installed.
+- A Kubernetes cluster with the Dynamo Platform (operator) installed — see the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 
 <div data-sku="b200">
 
-- **8x B200** (aggregated) or **16x B200** (disaggregated, 1P1D) available.
+- **8 B200 GPUs per worker** (TP=8 fills the box, x86_64): **8 total** for aggregated (1 node), **16 total** for disaggregated 1P1D (1 prefill + 1 decode pod, across 2 nodes).
 - A Hugging Face token with access to `nvidia/DeepSeek-V4-Pro-NVFP4`.
 
 </div>
 
 <div data-sku="h200">
 
-- **8x H200** (aggregated) or **32x H200** (disaggregated, 1P3D) available.
+- **8 H200 GPUs per worker** (public FP8 checkpoint, `max_model_len=86016`): **8 total** for aggregated (1 node — the recommended H200 pick), **32 total** for disaggregated 1P3D (1 prefill + 3 decode pods, across 4 nodes).
 - A Hugging Face token with access to `deepseek-ai/DeepSeek-V4-Pro`.
 
 </div>
 
-- The `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0` image (pinned in each `deploy.yaml`).
+- The `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0` image, pinned in each agentic `deploy.yaml`.
 
-Create the namespace and token secret:
+<div data-variant="disagg">
+
+<Warning>
+Disaggregated targets also need **both** `VLLM_GPU_NIC_PCIE_MAPPING` and `VLLM_NIC_SELECTION_VARS=UCX_NET_DEVICES:1` set in the manifest, on prefill and decode. They are a pair — setting only one fails EngineCore init. The recipe ships neither, because the map is node-specific and cannot be pre-baked; see [Per-rank NIC mapping](#per-rank-nic-mapping).
+</Warning>
+
+</div>
+
+## Quick Start
+
+Create the namespace and token secret. The secret is consumed by the download Job and, as a convenience, by the worker:
 
 ```bash
 export NAMESPACE=your-namespace
@@ -89,19 +404,17 @@ kubectl create namespace ${NAMESPACE}
 kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN="your-token" -n ${NAMESPACE}
 ```
 
+Create storage, download the checkpoint, then apply the target's `deploy.yaml`. The PVC requests 1500Gi; DeepSeek-V4-Pro is ~865 GB on disk (64 safetensors shards, FP4+FP8 mixed) and typically takes 1.5–3 hours to download on first apply.
+
 <Warning>
-Edit cluster-specific values before applying: `storageClassName` in `model-cache/model-cache.yaml` (a RWX class). For **disaggregated** targets, also set `VLLM_GPU_NIC_PCIE_MAPPING` in the manifest — see [Per-rank NIC mapping](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/README.md#per-rank-nic-mapping-b200--h200-disaggregated).
+Edit cluster-specific values before applying: `storageClassName` in `model-cache/model-cache.yaml` must name a RWX class in your cluster.
 </Warning>
-
-## Deploy
-
-Create storage, download the checkpoint (~865 GB, 1.5–3 h first apply), then apply the target's `deploy.yaml`:
 
 ```bash
 kubectl apply -f recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-cache.yaml -n ${NAMESPACE}
 ```
 
-There is one download Job per checkpoint, because each checkpoint is ~865 GB and the PVC holds one, not both. B200 serves the NVFP4 checkpoint; every other variant serves the public FP8 one.
+There is one download Job per checkpoint, because each checkpoint is ~865 GB and the PVC holds one, not both. Only the two agentic B200 variants (`vllm/agg-b200-agentic` and `vllm/disagg-b200-agentic`) serve NVFP4; the H200 agentic, GB200, Day-0 B200, and all SGLang variants — 9 of the 11 variants — serve the public FP8 checkpoint.
 
 <div data-sku="b200">
 
@@ -129,7 +442,49 @@ The workers mount the PVC read-only with `HF_HUB_OFFLINE=1`, so they cannot fetc
 To switch a populated PVC to the other checkpoint: stop the workers, delete the PVC, re-apply `model-cache.yaml`, then apply the other Job. The two Jobs have distinct names, so applying the second one does not collide with the first.
 </Note>
 
-<div data-sku="b200" data-variant="agg">
+<div data-variant="disagg">
+
+### Per-rank NIC mapping
+
+Set the map before applying the manifest. In disaggregated serving the prefill workers stream the KV cache to the decode workers' GPUs over InfiniBand using GPU-Direct RDMA (GDR). Each tensor-parallel rank should transfer over the RDMA NIC on **its own PCIe switch** (its affine NIC); if several ranks are forced onto the **same** NIC they oversubscribe it and GPU-direct registration collapses to slow host-staging — **~0.76 GB/s with 4 ranks on one NIC vs ~15–25 GB/s with one NIC per rank (~25x slower)**. The disagg recipe originally pinned every rank to one device (`UCX_NET_DEVICES=mlx5_0:1`), triggering exactly this. `VLLM_GPU_NIC_PCIE_MAPPING` together with `VLLM_NIC_SELECTION_VARS=UCX_NET_DEVICES:1` ([vLLM #42083](https://github.com/vllm-project/vllm/pull/42083)) assigns each rank its PCIe-affine NIC and restores GDR. This is a general tensor-parallel NIC-assignment requirement, not a DeepSeek-V4 property — any TP>1 NIXL disaggregated worker pinned to a single NIC collapses the same way, and DeepSeek-V4's packed KV layout was investigated at length and ruled out as the cause. Aggregated recipes have no cross-worker KV transfer and set neither NIC env var.
+
+Regenerate the map on a target node:
+
+```bash
+# 1) GPU PCIe BDFs, in device order:
+nvidia-smi --query-gpu=index,pci.bus_id --format=csv,noheader
+#    -> e.g. 0, 00000000:18:00.0
+
+# 2) RDMA NIC PCIe BDF for each mlx5 device:
+for d in /sys/class/infiniband/*/device; do
+  echo "$(basename "$(dirname "$d")") -> $(basename "$(readlink -f "$d")")"
+done
+#    -> e.g. mlx5_0 -> 0000:19:00.0
+```
+
+Pair each GPU with the NIC sharing its PCIe switch (the closest NIC), join the pairs in GPU order, and set both variables on **both** the prefill and decode workers:
+
+```text
+VLLM_GPU_NIC_PCIE_MAPPING="<gpu0_bdf>=<nic0_bdf>,<gpu1_bdf>=<nic1_bdf>,…"
+VLLM_NIC_SELECTION_VARS="UCX_NET_DEVICES:1"
+```
+
+The map references the pod's NIC BDFs, so it **breaks if the cluster injects a different NIC set** — derive it from the pod's actual `/sys/class/infiniband` rather than hard-coding it, and regenerate it per node type. There is no "just auto-select" shortcut: pinning all ranks to one NIC degrades to single-NIC host-staging (~20x slower, but still functional), while *unsetting* `UCX_NET_DEVICES` to expose all NICs can fail NIXL backend creation. The working fast path is exactly one affine NIC per rank, which this map constructs. With no RDMA fabric at all, fall back to TCP: `NCCL_IB_DISABLE=1`, `NCCL_NET=Socket`, and drop the `rdma/ib` resource requests.
+
+Which RDMA resource to request is cluster-plugin-dependent, not GPU-dependent:
+
+- **`rdma/ib: "N"`** (N exclusive devices) is clean and NIC-isolated but relies on the plugin injecting the pod's *affine* NICs. The **H200 disaggregated** recipes ship this, validated where affine injection works.
+- **`rdma/shared_ib: "1"`** exposes **all** of the node's NICs to the pod, so the per-rank map can always find each rank's affine NIC even when the plugin would inject a non-affine set. The **B200 disaggregated** recipes ship this, validated on a cluster where affine injection had drifted.
+
+Both pair with the same `VLLM_GPU_NIC_PCIE_MAPPING`; pick whichever your cluster's plugin exposes. Under `shared_ib` a wrong or stale map **fails silently**: with exclusive `rdma/ib`, a map that points a rank at a NIC not in the pod hard-fails (`createBackend` errors), but under `shared_ib` that NIC is present, so the rank quietly opens a **non-affine** NIC and GDR degrades to a cross-socket path with no error. Verify the per-rank NIC selection in the worker log rather than trusting a hard-coded map. Shared NICs are also not bandwidth-isolated from co-tenant pods — a throughput, not a correctness, concern.
+
+After deploy, confirm the worker log shows NIXL registering the CUDA/GDR path (~15–17 GB/s KV transfer). A wrong or missing map degrades to slow TCP transfer or fails NIXL setup.
+
+</div>
+
+### Deploy
+
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 RECIPE=recipes/deepseek-v4/deepseek-v4-pro/vllm/agg-b200-agentic
@@ -137,7 +492,7 @@ RECIPE=recipes/deepseek-v4/deepseek-v4-pro/vllm/agg-b200-agentic
 
 </div>
 
-<div data-sku="b200" data-variant="disagg">
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 
 ```bash
 RECIPE=recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg-b200-agentic
@@ -145,7 +500,7 @@ RECIPE=recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg-b200-agentic
 
 </div>
 
-<div data-sku="h200" data-variant="agg">
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 RECIPE=recipes/deepseek-v4/deepseek-v4-pro/vllm/agg-h200-agentic
@@ -153,7 +508,7 @@ RECIPE=recipes/deepseek-v4/deepseek-v4-pro/vllm/agg-h200-agentic
 
 </div>
 
-<div data-sku="h200" data-variant="disagg">
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 
 ```bash
 RECIPE=recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg-h200-agentic
@@ -170,11 +525,11 @@ kubectl wait --for=condition=Ready pod \
   -l nvidia.com/dynamo-graph-deployment-name=${DGD} -n ${NAMESPACE} --timeout=5400s
 ```
 
-First launch loads weights across 8 TP ranks and warms CUDA graphs — up to ~90 min; the startup probes allow for it.
+First launch loads weights across 8 TP ranks and warms CUDA graphs / kernels — up to ~90 min; the startup probes allow for it.
 
-## Smoke Test
+### Test the Deployment
 
-The `model` field must be the **served model name for your SKU** (the `--served-model-name` in the deploy): B200 serves `nvidia/DeepSeek-V4-Pro-NVFP4`, H200 serves `deepseek-ai/DeepSeek-V4-Pro`.
+The `model` field must be the **served model name for your target** (the `--served-model-name` in the deploy): the agentic B200 targets serve `nvidia/DeepSeek-V4-Pro-NVFP4`, H200 serves `deepseek-ai/DeepSeek-V4-Pro`. The endpoints are the same for vLLM and SGLang.
 
 <div data-sku="b200">
 
@@ -198,34 +553,122 @@ curl http://localhost:8000/v1/chat/completions -H 'Content-Type: application/jso
 
 </div>
 
-Pro emits chain-of-thought into `message.reasoning_content` and the answer into `message.content`. Reasoning effort is selected via `chat_template_kwargs` (`{"thinking":true,"reasoning_effort":"high"|"max"}`; Think Max needs `--max-model-len >= 393216`).
+Pro emits chain-of-thought into `message.reasoning_content` and the final answer into `message.content`. With too small a `max_tokens` the budget can be spent on reasoning before any `content` is emitted (`content: null`, `finish_reason: "length"`) — that is expected, not a failure; raise `max_tokens`. Reasoning effort is selected via `chat_template_kwargs` (`{"thinking":true,"reasoning_effort":"high"}` or `{"thinking":true,"reasoning_effort":"max"}`; Think Max needs `--max-model-len >= 393216`).
 
-## Benchmark
+### Verifying Reasoning
 
-The shared [`perf.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/perf/perf.yaml) replays the agentic MoonTrace (64K avg ISL / 400 OSL, 90% KV reuse) with AIPerf. Point `ENDPOINT` at `${DGD}-frontend:8000` and apply it:
+Pro emits `reasoning_content` by default; this example passes `chat_template_kwargs` to request high effort explicitly (same model, same `--dyn-reasoning-parser deepseek_v4`):
+
+<div data-sku="b200">
 
 ```bash
-kubectl apply -f recipes/deepseek-v4/perf/perf.yaml -n ${NAMESPACE}
+curl -s http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "nvidia/DeepSeek-V4-Pro-NVFP4",
+    "messages": [{"role": "user", "content": "What is 2+2? Answer briefly."}],
+    "max_tokens": 200,
+    "chat_template_kwargs": {"thinking": true, "reasoning_effort": "high"}
+  }' | python3 -m json.tool
 ```
 
-## Compare All Targets
+</div>
 
-| Target | GPUs | Parallelism | MoE backend | Spec. decode | max_model_len | Transfer |
-|---|---|---|---|---|---|---|
-| agg-b200 | 8x B200 | TP8 + EP | FLASHINFER_TRTLLM | MTP-2 | 1,048,576 | — |
-| disagg-b200 (1P1D) | 16x B200 | TP8 + EP | FLASHINFER_TRTLLM | decode MTP-2 | 1,048,576 | NIXL GDR |
-| agg-h200 | 8x H200 | TP8 + EP | MARLIN | none | 86,016 | — |
-| disagg-h200 (1P3D) | 32x H200 | TP8 + EP | MARLIN | none | 86,016 | NIXL GDR |
+<div data-sku="h200">
 
-## Notes
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek-ai/DeepSeek-V4-Pro",
+    "messages": [{"role": "user", "content": "What is 2+2? Answer briefly."}],
+    "max_tokens": 200,
+    "chat_template_kwargs": {"thinking": true, "reasoning_effort": "high"}
+  }' | python3 -m json.tool
+```
 
-- **Recommended per SKU:** B200 ships **disaggregated 1P1D** (+6% tok/s/GPU over AGG); H200 ships **aggregated** (AGG > the 1P3D disagg lane). H200 is a secondary/best-effort lane on the public FP8 checkpoint at `max_model_len=86016`.
-- **Reasoning / tool parsers** are wired via `--dyn-reasoning-parser deepseek_v4` / `--dyn-tool-call-parser deepseek_v4`.
-- **Disaggregated** targets require the per-rank NIC map (`VLLM_GPU_NIC_PCIE_MAPPING`); B200 ships `rdma/shared_ib`, H200 ships `rdma/ib`. See the [top-level README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/README.md#per-rank-nic-mapping-b200--h200-disaggregated).
-- Day-0 / GB200 (vLLM + SGLang, ComputeDomain/MNNVL) variants exist in the recipe tree but are experimental (dev images) and not shown here.
+</div>
+
+Expected:
+
+- `choices[0].message.reasoning_content` contains the model's chain-of-thought.
+- `choices[0].message.content` contains only the final answer.
+- No raw `</think>` tags in either field.
+
+If `reasoning_content` is `null` and `</think>` appears in `content`, the reasoning parser is not wired up — confirm `--dyn-reasoning-parser deepseek_v4` is on the worker command.
+
+### Verifying Tool Calling
+
+Same flow on both variants:
+
+<div data-sku="b200">
+
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "nvidia/DeepSeek-V4-Pro-NVFP4",
+    "messages": [{"role": "user", "content": "What is the weather in San Francisco?"}],
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a location",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": {"type": "string", "description": "City name"}
+          },
+          "required": ["location"]
+        }
+      }
+    }],
+    "max_tokens": 300
+  }' | python3 -m json.tool
+```
+
+</div>
+
+<div data-sku="h200">
+
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek-ai/DeepSeek-V4-Pro",
+    "messages": [{"role": "user", "content": "What is the weather in San Francisco?"}],
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a location",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": {"type": "string", "description": "City name"}
+          },
+          "required": ["location"]
+        }
+      }
+    }],
+    "max_tokens": 300
+  }' | python3 -m json.tool
+```
+
+</div>
+
+Expected:
+
+- `choices[0].message.tool_calls` is a structured array with `function.name`, `function.arguments`, and `id`.
+- `choices[0].finish_reason` is `"tool_calls"`.
+- `choices[0].message.reasoning_content` may contain the model's reasoning about tool selection.
+
+If `tool_calls` is missing and raw tool-call markers appear in `content`, confirm `--dyn-tool-call-parser deepseek_v4` is on the worker command.
 
 ## Source
 
 - Recipe README: [recipes/deepseek-v4/deepseek-v4-pro/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/deepseek-v4-pro/README.md)
 - Top-level DeepSeek-V4 README (shared workloads, NIC mapping, limitations): [recipes/deepseek-v4/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/README.md)
-- Manifests: [vllm/](https://github.com/ai-dynamo/dynamo/tree/main/recipes/deepseek-v4/deepseek-v4-pro/vllm) and shared [perf/perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/perf/perf.yaml)
+- Benchmark README: [recipes/deepseek-v4/perf/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/perf/README.md)
+- SGLang disaggregated READMEs: [sglang/disagg-b200](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/deepseek-v4-pro/sglang/disagg-b200/README.md) and [sglang/disagg-gb200](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/deepseek-v4-pro/sglang/disagg-gb200/README.md)
+- Manifests: [vllm/](https://github.com/ai-dynamo/dynamo/tree/main/recipes/deepseek-v4/deepseek-v4-pro/vllm), [sglang/](https://github.com/ai-dynamo/dynamo/tree/main/recipes/deepseek-v4/deepseek-v4-pro/sglang), and shared [perf/perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-v4/perf/perf.yaml)

--- a/docs/fern/pages/recipes/model-recipes/glm-5-2.mdx
+++ b/docs/fern/pages/recipes/model-recipes/glm-5-2.mdx
@@ -9,7 +9,7 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-Each target below is a Dynamo + SGLang deployment of Z.AI's GLM-5.2 tuned for an agentic workload (64K median ISL / 400 median OSL, 90% KV cache hit rate) with KV-aware routing and EAGLE-style MTP speculative decoding. B200 serves the NVFP4 checkpoint at up to 500K context with HiCache CPU offload; H200 serves the FP8 checkpoint at up to 250K context. Both run aggregated or with prefill/decode disaggregation. Pick your GPU architecture and serving topology; every command on this page updates to match.
+Each target below is a Dynamo + SGLang deployment of Z.AI's [GLM-5.2](https://huggingface.co/zai-org/GLM-5.2) tuned for an agentic workload (64K median ISL / 400 median OSL, 90% KV cache hit rate, 50 output tok/s per user) with KV-aware routing and EAGLE-style MTP speculative decoding. B200 serves the NVFP4 checkpoint at up to 500K context with HiCache CPU offload; H200 serves the FP8 checkpoint at up to 250K context. Both run aggregated or with prefill/decode disaggregation. Pick your GPU, workload, backend, and serving topology; every command on this page updates to match.
 
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
@@ -21,61 +21,93 @@ Each target below is a Dynamo + SGLang deployment of Z.AI's GLM-5.2 tuned for an
 <label htmlFor="recipe-sku-h200">H200 (FP8)</label>
 </div>
 <div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-agentic" name="recipe-usecase" value="agentic" defaultChecked />
+<label htmlFor="recipe-usecase-agentic">Agentic</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-sglang" name="recipe-engine" value="sglang" defaultChecked />
+<label htmlFor="recipe-engine-sglang">SGLang</label>
+</div>
+<div className="dynamo-target-picker-row">
 <span className="dynamo-target-picker-dim">Topology</span>
 <input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" defaultChecked />
 <label htmlFor="recipe-variant-agg">Aggregated</label>
 <input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" />
 <label htmlFor="recipe-variant-disagg">Disaggregated</label>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="agg">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> nvidia/GLM-5.2-NVFP4</span>
 <span><b>Precision</b> NVFP4 + FP8 KV cache</span>
-<span><b>GPUs</b> 4x B200, one worker</span>
+<span><b>GPUs</b> 4x B200 per worker, 4 workers</span>
 <span><b>Parallelism</b> DTP4</span>
 <span><b>Routing</b> KV-aware</span>
-<span><b>Context</b> Up to 500K, HiCache CPU offload</span>
+<span><b>KV offload</b> HiCache CPU</span>
+<span><b>Max context</b> 500K</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="disagg">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">
 <span><b>Checkpoint</b> nvidia/GLM-5.2-NVFP4</span>
 <span><b>Precision</b> NVFP4 + FP8 KV cache</span>
 <span><b>GPUs</b> 4x B200 prefill + 8x B200 decode</span>
 <span><b>Parallelism</b> DEP4 prefill / DTP8 decode</span>
 <span><b>Routing</b> KV-aware, NIXL/UCX over IB</span>
-<span><b>Context</b> Up to 500K, HiCache CPU offload</span>
+<span><b>KV offload</b> HiCache CPU</span>
+<span><b>Max context</b> 500K</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-variant="agg">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> zai-org/GLM-5.2-FP8</span>
 <span><b>Precision</b> FP8 + FP8 KV cache</span>
-<span><b>GPUs</b> 8x H200, one worker</span>
+<span><b>GPUs</b> 8x H200 per worker, 3 workers</span>
 <span><b>Parallelism</b> TP8/EP8</span>
 <span><b>Routing</b> KV-aware</span>
-<span><b>Context</b> Up to 250K</span>
+<span><b>KV offload</b> None</span>
+<span><b>Max context</b> 250K</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-variant="disagg">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">
 <span><b>Checkpoint</b> zai-org/GLM-5.2-FP8</span>
 <span><b>Precision</b> FP8 + FP8 KV cache</span>
 <span><b>GPUs</b> 8x H200 prefill + 8x H200 decode</span>
 <span><b>Parallelism</b> TP8/EP8 prefill / TP8/DP8/EP1 decode</span>
 <span><b>Routing</b> KV-aware, NIXL/UCX over IB</span>
-<span><b>Context</b> Up to 250K</span>
+<span><b>KV offload</b> None</span>
+<span><b>Max context</b> 250K</span>
 </div>
 </div>
+
+## Configurations
+
+All four targets serve GLM-5.2 on SGLang with KV-aware routing at the frontend and EAGLE-style MTP speculative decoding (draft length 3, SpeedBench acceptance length 2.69), benchmarked on the same agentic trace. They differ in checkpoint, GPU count, and topology:
+
+- B200 targets run `nvidia/GLM-5.2-NVFP4` with FP8 KV cache and add HiCache CPU offload; H200 targets run `zai-org/GLM-5.2-FP8`. Both serve under the name `zai-org/GLM-5.2`.
+- The agentic trace is shaped to show the value of KV-aware routing and offloading.
+- The disaggregated targets transfer KV over NIXL/UCX on InfiniBand.
+
+## Supported features
+
+- Modalities: Text
+- Reasoning
+- Tool calling
 
 ## Prerequisites
 
-<div data-sku="b200">
+<div data-sku="b200" data-engine="sglang" data-usecase="agentic">
 
-- A Kubernetes cluster with the Dynamo platform installed and B200 GPUs available — 4x for aggregated, 12x for disaggregated. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
+- A Kubernetes cluster with the Dynamo platform installed and B200 GPUs available — aggregated needs 4x B200 per worker and the manifest ships 4 workers; disaggregated needs 4x B200 per prefill worker and 8x B200 per decode worker, and the manifest ships 3P1D. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - A Hugging Face token with access to `nvidia/GLM-5.2-NVFP4`.
 
 </div>
 
-<div data-sku="h200">
+<div data-sku="h200" data-engine="sglang" data-usecase="agentic">
 
-- A Kubernetes cluster with the Dynamo platform installed and H200 GPUs available — 8x for aggregated, 16x for disaggregated. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
+- A Kubernetes cluster with the Dynamo platform installed and H200 GPUs available — aggregated needs 8x H200 per worker and the manifest ships 3 workers; disaggregated needs 8x H200 per prefill worker and 8x H200 per decode worker, and the manifest ships 1P1D. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - A Hugging Face token with access to `zai-org/GLM-5.2-FP8`.
 
 </div>
+
+## Quick Start
+
+### 1. Create namespace and secret
 
 Create the namespace and token secret:
 
@@ -87,24 +119,33 @@ kubectl create secret generic hf-token-secret \
   -n ${NAMESPACE}
 ```
 
+### 2. Create storage
+
 <Warning>
 Edit `storageClassName` in `model-cache/model-cache.yaml` to a ReadWriteMany storage class on your cluster (`kubectl get storageclass`) before applying it. Review namespace, image tags, node selectors, and resource claims in the manifests as well.
 </Warning>
 
-## Deploy
-
-Create the shared model cache, then download the checkpoint for your target SKU. Edit `model-cache/model-download.yaml` and remove the `hf download` line for the checkpoint you are not serving:
+Create the shared model cache:
 
 ```bash
 # Edit storageClassName in model-cache/model-cache.yaml first.
 kubectl apply -f recipes/glm-5.2/model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+### 3. Download the model
+
+Download the checkpoint for your target SKU. Edit `model-cache/model-download.yaml` and remove the `hf download` line for the checkpoint you are not serving:
+
+```bash
 kubectl apply -f recipes/glm-5.2/model-cache/model-download.yaml -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=7200s
 ```
 
+### 4. Deploy the DGD
+
 Then deploy the target DGD:
 
-<div data-sku="b200" data-variant="agg">
+<div data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/glm-5.2/sglang/agg-b200-agentic/deploy.yaml -n ${NAMESPACE}
@@ -112,7 +153,7 @@ kubectl apply -f recipes/glm-5.2/sglang/agg-b200-agentic/deploy.yaml -n ${NAMESP
 
 </div>
 
-<div data-sku="b200" data-variant="disagg">
+<div data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/glm-5.2/sglang/disagg-b200-agentic/deploy.yaml -n ${NAMESPACE}
@@ -120,7 +161,7 @@ kubectl apply -f recipes/glm-5.2/sglang/disagg-b200-agentic/deploy.yaml -n ${NAM
 
 </div>
 
-<div data-sku="h200" data-variant="agg">
+<div data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/glm-5.2/sglang/agg-h200-agentic/deploy.yaml -n ${NAMESPACE}
@@ -128,7 +169,7 @@ kubectl apply -f recipes/glm-5.2/sglang/agg-h200-agentic/deploy.yaml -n ${NAMESP
 
 </div>
 
-<div data-sku="h200" data-variant="disagg">
+<div data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/glm-5.2/sglang/disagg-h200-agentic/deploy.yaml -n ${NAMESPACE}
@@ -136,11 +177,37 @@ kubectl apply -f recipes/glm-5.2/sglang/disagg-h200-agentic/deploy.yaml -n ${NAM
 
 </div>
 
-## Smoke Test
+All four targets serve under the same model name, `zai-org/GLM-5.2`. Readiness is that model appearing on the target DGD frontend: the benchmark Job blocks on exactly that check before it runs its warmup, so a target whose frontend service lists the model is ready to benchmark. The frontend service for your target is:
+
+<div data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="agg">
+
+`glm52-agg-b200-agentic-frontend:8000`
+
+</div>
+
+<div data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">
+
+`glm52-disagg-b200-agentic-frontend:8000`
+
+</div>
+
+<div data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="agg">
+
+`glm52-agg-h200-agentic-frontend:8000`
+
+</div>
+
+<div data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">
+
+`glm52-disagg-h200-agentic-frontend:8000`
+
+</div>
+
+### 5. Smoke test
 
 Send a test request to verify the deployment serves traffic. First forward the frontend port for your target:
 
-<div data-sku="b200" data-variant="agg">
+<div data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/glm52-agg-b200-agentic-frontend 8000:8000 -n ${NAMESPACE}
@@ -148,7 +215,7 @@ kubectl port-forward svc/glm52-agg-b200-agentic-frontend 8000:8000 -n ${NAMESPAC
 
 </div>
 
-<div data-sku="b200" data-variant="disagg">
+<div data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">
 
 ```bash
 kubectl port-forward svc/glm52-disagg-b200-agentic-frontend 8000:8000 -n ${NAMESPACE}
@@ -156,7 +223,7 @@ kubectl port-forward svc/glm52-disagg-b200-agentic-frontend 8000:8000 -n ${NAMES
 
 </div>
 
-<div data-sku="h200" data-variant="agg">
+<div data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/glm52-agg-h200-agentic-frontend 8000:8000 -n ${NAMESPACE}
@@ -164,7 +231,7 @@ kubectl port-forward svc/glm52-agg-h200-agentic-frontend 8000:8000 -n ${NAMESPAC
 
 </div>
 
-<div data-sku="h200" data-variant="disagg">
+<div data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">
 
 ```bash
 kubectl port-forward svc/glm52-disagg-h200-agentic-frontend 8000:8000 -n ${NAMESPACE}
@@ -172,7 +239,7 @@ kubectl port-forward svc/glm52-disagg-h200-agentic-frontend 8000:8000 -n ${NAMES
 
 </div>
 
-All four targets serve under the same model name, `zai-org/GLM-5.2`:
+Then send a request against the shared model name, `zai-org/GLM-5.2`:
 
 ```bash
 curl http://localhost:8000/v1/chat/completions \
@@ -188,11 +255,11 @@ curl http://localhost:8000/v1/chat/completions \
   -d '{"model":"zai-org/GLM-5.2","messages":[{"role":"user","content":"What is 17 times 24?"}],"chat_template_kwargs":{"enable_thinking":false},"max_tokens":64}'
 ```
 
-## Benchmark
+### 6. Benchmark
 
-A single AIPerf trace-replay Job — `perf/perf.yaml` — covers all four DGDs. It replays a Mooncake-format agentic trace (64K ISL / 400 OSL, 90% KV cache hit rate) at one concurrency value and writes artifacts to the shared `model-cache` PVC. The benchmark pod is co-located with a DGD frontend through `podAffinity`.
+A single [AIPerf](https://github.com/ai-dynamo/aiperf) trace-replay Job — `perf/perf.yaml` — covers all four DGDs. It waits for the target model on the DGD frontend, runs a short warmup, replays a Mooncake-format agentic trace (64K ISL / 400 OSL, 90% KV cache hit rate) at one concurrency value, and writes raw artifacts to the shared `model-cache` PVC. The benchmark pod is co-located with a DGD frontend through `podAffinity`. The Job uses `nvcr.io/nvidia/ai-dynamo/aiperf:0.11.0` directly and does not install or patch AIPerf at runtime.
 
-Edit the `env` block in `perf/perf.yaml` to target your deployed DGD — set `ENDPOINT` to the matching frontend service, `SYNTHESIS_MAX_ISL` to its context limit, and `CONCURRENCY` to the value for that target. The `CONCURRENCY` values below reproduce the [Expected Performance](#expected-performance) numbers:
+Edit the `env` block in `perf/perf.yaml` to target your deployed DGD — set `ENDPOINT` to the matching frontend service, `SYNTHESIS_MAX_ISL` to its context limit, and `CONCURRENCY` to the value for that target. Also update the `podAffinity` `values` list to contain only the target DGD name, so the benchmark pod is co-located with the correct frontend. If you run more than one benchmark in the same namespace, also update `metadata.name` and `labels.app` so Jobs and artifact directories stay distinct. The `CONCURRENCY` values below reproduce the [Performance results](#performance-results) numbers:
 
 | Target | `ENDPOINT` | `SYNTHESIS_MAX_ISL` | `CONCURRENCY` |
 | --- | --- | --- | --- |
@@ -201,46 +268,106 @@ Edit the `env` block in `perf/perf.yaml` to target your deployed DGD — set `EN
 | H200 aggregated | `glm52-agg-h200-agentic-frontend:8000` | `250000` | `32` |
 | H200 disaggregated | `glm52-disagg-h200-agentic-frontend:8000` | `250000` | `24` |
 
-Then run the Job:
+All four targets read the same trace: `TRACE_FILE` defaults to `/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl`, and the Job aborts with `trace file not found` if that path is missing from the PVC. `TARGET_MODEL` defaults to `zai-org/GLM-5.2` and must match `--served-model-name`.
+
+The trace is replayed through `--custom-dataset-type mooncake_trace`, and each [Mooncake-format](https://github.com/kvcache-ai/Mooncake) JSONL line describes one request with `input_length`, `output_length`, and `hash_ids`. This recipe does not store the trace: it is the same 64K-ISL / 400-OSL / 90%-KV-reuse agentic trace shared across the agentic recipes, so rather than duplicate the Git LFS blob it is referenced from the Kimi-K2.6 recipe through a symlink:
+
+```text
+traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
+  -> ../../../kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
+```
+
+The default 15% trace contains 3,541 requests. Its SHA-256 is `f20d3f2bc83dd1306cda659fbe34e7c4d85ca5497626c98bc0b1c4d2211379d0`.
+
+Stage the trace on the PVC first. Materialize the Git LFS trace file, then copy it through a helper pod that mounts `model-cache`:
+
+```bash
+git lfs pull --include='recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl'
+
+kubectl run pvc-helper -n ${NAMESPACE} \
+  --image=busybox:1.36 --restart=Never \
+  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"model-cache","mountPath":"/model-cache"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"model-cache"}}]}}' \
+  --command -- sleep 3600
+
+TRACE_SOURCE="$(git rev-parse --show-toplevel)/recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl"
+kubectl exec -n "${NAMESPACE}" pvc-helper -- mkdir -p /model-cache/traces
+kubectl cp "${TRACE_SOURCE}" \
+  "${NAMESPACE}/pvc-helper:/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl"
+```
+
+Keep `pvc-helper` for fetching artifacts, or delete it after staging. Then run the Job:
 
 ```bash
 kubectl apply -f recipes/glm-5.2/perf/perf.yaml -n ${NAMESPACE}
-kubectl wait --for=condition=Complete job/glm52-bench -n ${NAMESPACE} --timeout=7200s
+kubectl logs -n ${NAMESPACE} -l job-name=glm52-bench -f
+kubectl wait --for=condition=Complete job/glm52-bench -n ${NAMESPACE} --timeout=10800s
 ```
 
-For trace staging, concurrency sweeps, and fetching artifacts, see the [benchmark README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/glm-5.2/perf/README.md).
+Fetch the artifacts:
 
-## Expected Performance
+```bash
+kubectl cp \
+  ${NAMESPACE}/pvc-helper:/model-cache/perf/<epoch>_glm52-bench \
+  ./results
+```
 
-Measured on the 15% agentic trace subset. System throughput is per-GPU output tokens per second; user throughput is the P50 per-request output rate.
+Results are written to:
+
+```text
+/model-cache/perf/<epoch>_<job-name>/
+  warmup/
+  GLM-5.2_trace_c<concurrency>_<timestamp>/
+    profile_export_aiperf.json
+    inputs.json
+    ...
+```
+
+Clean up when you are done:
+
+```bash
+kubectl delete job glm52-bench -n ${NAMESPACE}
+kubectl delete pod pvc-helper -n ${NAMESPACE}
+```
+
+`perf.yaml` runs a single `CONCURRENCY` value, so sweeping the concurrencies in the table above means one run per value. Clear SGLang KV state and Dynamo frontend/router state between independent runs:
+
+```bash
+kubectl delete job glm52-bench -n ${NAMESPACE} --ignore-not-found
+
+DGD=glm52-agg-b200-agentic # Choose one of the four variant names above.
+kubectl delete pods -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD}
+kubectl wait --for=condition=Ready pod -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD} \
+  --timeout=7200s
+
+# Update CONCURRENCY in perf.yaml before each run.
+kubectl apply -f recipes/glm-5.2/perf/perf.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/glm52-bench -n ${NAMESPACE} --timeout=10800s
+```
+
+Do not compare partial runs. A completed run must account for successful, errored, and unfinished requests before reporting aggregate throughput.
+
+## Optimization targets
+
+Each target is tuned for the agentic workload shape at a 50 tok/s/user interactivity target:
+
+| Workload | Median ISL | Median OSL | KV cache hit rate | User output tok/s |
+| --- | ---: | ---: | ---: | ---: |
+| Agentic | 64K | 400 | 90% | 50 |
+
+## Performance results
+
+Measured on the 15% agentic trace subset, against an optimization target of 50 output tok/s per user. System throughput is per-GPU output tokens per second; user throughput is the P50 per-request output rate.
 
 | | Concurrency | System output tok/s/GPU | User output tok/s (P50) | TTFT P50 (ms) |
 |---|---|---|---|---|
-| <span data-sku="b200" data-variant="agg">**B200 aggregated** (4 workers)</span><span data-sku="b200" data-variant="disagg">**B200 disaggregated** (3P1D)</span><span data-sku="h200" data-variant="agg">**H200 aggregated** (3 workers)</span><span data-sku="h200" data-variant="disagg">**H200 disaggregated** (1P1D)</span> | <span data-sku="b200" data-variant="agg">64</span><span data-sku="b200" data-variant="disagg">128</span><span data-sku="h200" data-variant="agg">32</span><span data-sku="h200" data-variant="disagg">24</span> | <span data-sku="b200" data-variant="agg">176.420</span><span data-sku="b200" data-variant="disagg">320.907</span><span data-sku="h200" data-variant="agg">54.550</span><span data-sku="h200" data-variant="disagg">68.860</span> | <span data-sku="b200" data-variant="agg">57.493</span><span data-sku="b200" data-variant="disagg">65.105</span><span data-sku="h200" data-variant="agg">52.370</span><span data-sku="h200" data-variant="disagg">53.880</span> | <span data-sku="b200" data-variant="agg">355.555</span><span data-sku="b200" data-variant="disagg">1938.059</span><span data-sku="h200" data-variant="agg">1790.000</span><span data-sku="h200" data-variant="disagg">1874.000</span> |
-
-## Compare All Targets
-
-All four targets serve GLM-5.2 on SGLang with KV-aware routing and EAGLE-style MTP speculative decoding (draft length 3, SpeedBench acceptance length 2.69), benchmarked on the same agentic trace:
-
-| | B200 aggregated | B200 disaggregated | H200 aggregated | H200 disaggregated |
-|---|---|---|---|---|
-| **Checkpoint** | nvidia/GLM-5.2-NVFP4 | nvidia/GLM-5.2-NVFP4 | zai-org/GLM-5.2-FP8 | zai-org/GLM-5.2-FP8 |
-| **Precision** | NVFP4 + FP8 KV | NVFP4 + FP8 KV | FP8 + FP8 KV | FP8 + FP8 KV |
-| **GPUs** | 4x B200 | 4x B200 prefill + 8x B200 decode | 8x H200 | 8x H200 prefill + 8x H200 decode |
-| **Parallelism** | DTP4 | DEP4 / DTP8 | TP8/EP8 | TP8/EP8 prefill / TP8/DP8/EP1 decode |
-| **KV offload** | HiCache CPU | HiCache CPU | None | None |
-| **Max context** | 500K | 500K | 250K | 250K |
-
-## Notes
-
-- Speculative decoding uses EAGLE-style MTP with draft length 3, measured at a SpeedBench acceptance length of 2.69.
-- All four targets use KV-aware routing at the frontend. The B200 targets add HiCache CPU offload; the agentic traces are shaped to show the value of KV-aware routing and offloading.
-- The disaggregated targets transfer KV over NIXL/UCX on InfiniBand.
+| <span data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="agg">**B200 aggregated** (4 workers)</span><span data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">**B200 disaggregated** (3P1D)</span><span data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="agg">**H200 aggregated** (3 workers)</span><span data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">**H200 disaggregated** (1P1D)</span> | <span data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="agg">64</span><span data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">128</span><span data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="agg">32</span><span data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">24</span> | <span data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="agg">176.420</span><span data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">320.907</span><span data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="agg">54.550</span><span data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">68.860</span> | <span data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="agg">57.493</span><span data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">65.105</span><span data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="agg">52.370</span><span data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">53.880</span> | <span data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="agg">355.555</span><span data-sku="b200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">1938.059</span><span data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="agg">1790.000</span><span data-sku="h200" data-engine="sglang" data-usecase="agentic" data-variant="disagg">1874.000</span> |
 
 ## Limitations
 
 - B200 targets support up to 500K context; the full 1M context length is not supported out of the box. H200 targets support up to 250K context.
-- Structured decoding requires reasoning to be disabled (`"chat_template_kwargs": {"enable_thinking": false}`) so the output lands in the `content` field instead of `reasoning_content`.
+- Structured decoding works with reasoning enabled — the generated JSON is populated in the `content` field and the chain-of-thought in `reasoning_content`. This requires both `--dyn-reasoning-parser glm45` (frontend) and `--reasoning-parser glm45` (engine), which the recipes set.
 - `n>1` requests are not supported with the disaggregated targets.
 
 ## Source

--- a/docs/fern/pages/recipes/model-recipes/glm-5-nvfp4.mdx
+++ b/docs/fern/pages/recipes/model-recipes/glm-5-nvfp4.mdx
@@ -9,34 +9,60 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-This recipe serves `nvidia/GLM-5-NVFP4` with disaggregated prefill/decode and EAGLE MTP speculative decoding across 5 nodes of 4x GB200 (TP4 prefill, TP16/DP16/EP16 decode), sustaining roughly 16.8K output tokens/sec on the standard UCX path (19K with the AWS EFA variant) at 512-way concurrency on a 1K ISL / 8K OSL long-output workload. Pick your KV-transfer path; every command on this page updates to match.
+This recipe serves `nvidia/GLM-5-NVFP4` with disaggregated prefill/decode and EAGLE MTP speculative decoding across 5 nodes of 4x GB200 (TP4 prefill, TP16/DP16/EP16 decode), sustaining roughly 16.8K output tokens/sec on the standard UCX path (19.1K with the AWS EFA variant, measured on 5x p6e-gb200.36xlarge) at 512-way concurrency on a 1K ISL / 8K OSL long-output workload. Both targets are SGLang, disaggregated, on 20x GB200 under the same static synthetic workload; they differ only in the KV-transfer path. Pick your target below and every command on this page updates to match.
 
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
 <div className="dynamo-target-picker-row">
-<span className="dynamo-target-picker-dim">KV transfer</span>
-<input type="radio" id="recipe-variant-standard" name="recipe-variant" value="standard" defaultChecked />
-<label htmlFor="recipe-variant-standard">Standard (UCX) <span className="dynamo-target-picker-hint">Recommended</span></label>
-<input type="radio" id="recipe-variant-efa" name="recipe-variant" value="efa" />
-<label htmlFor="recipe-variant-efa">AWS EFA (custom build)</label>
+<span className="dynamo-target-picker-dim">GPU</span>
+<input type="radio" id="recipe-sku-gb200" name="recipe-sku" value="gb200" defaultChecked />
+<label htmlFor="recipe-sku-gb200">GB200</label>
 </div>
-<div className="dynamo-target-picker-summary" data-variant="standard">
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-static" name="recipe-usecase" value="static" defaultChecked />
+<label htmlFor="recipe-usecase-static">Static synthetic</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-sglang" name="recipe-engine" value="sglang" defaultChecked />
+<label htmlFor="recipe-engine-sglang">SGLang</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Topology</span>
+<input type="radio" id="recipe-variant-standard" name="recipe-variant" value="standard" defaultChecked />
+<label htmlFor="recipe-variant-standard">Disaggregated, UCX <span className="dynamo-target-picker-hint">Recommended</span></label>
+<input type="radio" id="recipe-variant-efa" name="recipe-variant" value="efa" />
+<label htmlFor="recipe-variant-efa">Disaggregated, AWS EFA</label>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="standard">
 <span><b>Checkpoint</b> nvidia/GLM-5-NVFP4</span>
 <span><b>Precision</b> NVFP4 + FP8 KV cache</span>
-<span><b>GPUs</b> 20x GB200, 5 nodes of 4</span>
+<span><b>GPUs</b> 20x GB200 (5x 4-GPU nodes, NVL36/NVL72)</span>
 <span><b>Parallelism</b> TP4 prefill, TP16/DP16/EP16 decode</span>
 <span><b>KV transfer</b> NIXL over UCX</span>
 <span><b>Workload</b> 1K ISL / 8K OSL, 512 concurrency</span>
+<span><b>Container image</b> Published runtime image</span>
+<span><b>Output throughput</b> 16,824 tok/s</span>
 </div>
-<div className="dynamo-target-picker-summary" data-variant="efa">
+<div className="dynamo-target-picker-summary" data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="efa">
 <span><b>Checkpoint</b> nvidia/GLM-5-NVFP4</span>
 <span><b>Precision</b> NVFP4 + FP8 KV cache</span>
-<span><b>GPUs</b> 20x GB200, 5x p6e-gb200.36xlarge</span>
+<span><b>GPUs</b> 20x GB200 (5x p6e-gb200.36xlarge)</span>
 <span><b>Parallelism</b> TP4 prefill, TP16/DP16/EP16 decode</span>
 <span><b>KV transfer</b> NIXL LIBFABRIC over EFA RDMA</span>
 <span><b>Workload</b> 1K ISL / 8K OSL, 512 concurrency</span>
+<span><b>Container image</b> Custom build from `Dockerfile.efa`</span>
+<span><b>Extra requirements</b> EFA driver 3.0.0g+, privileged containers</span>
+<span><b>Output throughput</b> 19,131 tok/s</span>
 </div>
 </div>
+
+## Topology
+
+Both targets run the same disaggregated topology — 1 prefill node (TP4) plus 4 decode nodes (TP16/DP16/EP16) with EAGLE MTP speculative decoding and FP8 KV cache — and differ only in infrastructure and the KV-transfer backend.
+
+The EFA README compares against an approximate ~19,000 tok/s non-EFA baseline rather than the exact 16,824 tok/s measured on the standard target below.
 
 ## Prerequisites
 
@@ -44,19 +70,65 @@ This recipe serves `nvidia/GLM-5-NVFP4` with disaggregated prefill/decode and EA
 - A shared RWX PVC for model weights and FlashInfer JIT artifacts.
 - A Hugging Face token with access to `nvidia/GLM-5-NVFP4`.
 
-<div data-variant="standard">
+<div data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="standard">
 
-- **5x 4xGB200 nodes** in an NVL36 or NVL72 domain. The published runtime image (`nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.1-cuda13`) is used as-is.
+- **5x 4xGB200 nodes** in an NVL36 or NVL72 domain.
 
 </div>
 
-<div data-variant="efa">
+<div data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="efa">
 
 - **5x p6e-gb200.36xlarge** nodes (4x GB200 + 4x EFA NICs each) or equivalent GB200 in an MNNVL domain.
 - AWS EFA driver 3.0.0g or newer on the nodes (default on modern AWS EKS AMIs).
+- Kernel 5.12 or newer — modern AWS EKS AMIs ship kernel 6.14, which is fine. On older kernels the host also needs the `efa_nv_peermem` module loaded; on 5.12 and newer the dmabuf path is the default and peermem is not required.
 - A container registry you can push to — this variant requires building a custom image from `Dockerfile.efa` before deploying (there is no prebuilt EFA image).
 
+The libfabric is built into the image, so no cluster-side DaemonSet is required. See [EFA on AWS](../../kubernetes/installation/rdma-setup/efa-on-aws.mdx) for more on EFA.
+
 </div>
+
+<Warning>
+The manifests use standard NVIDIA GPU Feature Discovery labels to select GB200 nodes and include common GPU/ARM tolerations. If your cluster uses different labels, taints, or storage classes, update `nodeSelector`, `tolerations`, and `storageClassName` before deploying.
+</Warning>
+
+## Step 1: Container Image
+
+Worker containers run as root because FlashInfer's bundled cubin package creates TRTLLM MoE symlinks inside its installed package directory during startup.
+
+<div data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="standard">
+
+The published runtime image (`nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.1-cuda13`) is used as-is.
+
+</div>
+
+<div data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="efa">
+
+Build the custom container image first — it bakes a patched libfabric ([ofiwg/libfabric#12019](https://github.com/ofiwg/libfabric/pull/12019)) into the runtime so `fi_mr_reg` on CUDA VRAM succeeds on GB200's 64K-page arm64 kernel:
+
+```bash
+docker buildx build \
+  --platform linux/arm64 \
+  --build-arg ARCH=arm64 \
+  -t <your-registry>/sglang-dynamo-glm5-efa:latest \
+  -f recipes/glm-5-nvfp4/sglang/disagg/efa/Dockerfile.efa \
+  --push .
+```
+
+Sanity-check the resulting image to confirm the patched, CUDA-linked libfabric actually landed in it:
+
+```bash
+docker run --rm <your-registry>/sglang-dynamo-glm5-efa:latest \
+  bash -c '
+    /opt/amazon/efa/bin/fi_info --version &&
+    ldd /opt/amazon/efa/lib/libfabric.so.1 | grep -i cuda &&
+    grep -F "efa_mr_is_cuda(efa_mr)" \
+      /opt/amazon/efa/share/doc/libfabric/efa_mr.c.diff 2>/dev/null ||
+      echo "(patch verified at build time via Dockerfile RUN grep)"'
+```
+
+</div>
+
+## Step 2: Download the Model
 
 Create the namespace and token secret:
 
@@ -68,12 +140,6 @@ kubectl create secret generic hf-token-secret \
   -n ${NAMESPACE}
 ```
 
-<Warning>
-The manifests use standard NVIDIA GPU Feature Discovery labels to select GB200 nodes and include common GPU/ARM tolerations. If your cluster uses different labels, taints, or storage classes, update `nodeSelector`, `tolerations`, and `storageClassName` before deploying.
-</Warning>
-
-## Deploy
-
 Create the model-cache PVC and download the weights (shared by both targets):
 
 ```bash
@@ -84,9 +150,11 @@ kubectl apply -f recipes/glm-5-nvfp4/model-cache/model-download.yaml -n ${NAMESP
 kubectl wait --for=condition=complete job/model-download -n ${NAMESPACE} --timeout=3600s
 ```
 
-If your cluster already provides a shared RWX cache PVC, skip `model-cache.yaml` and update `claimName: model-cache` in the download, deploy, and perf manifests, keeping the mount path as `/model-store`.
+If your cluster already provides a shared RWX cache PVC, skip `model-cache.yaml` and update `claimName: model-cache` in the download, deploy, and perf manifests. Keep the mount path as `/model-store` so the workers, model download job, and benchmark job share the same Hugging Face cache and JIT artifacts.
 
-<div data-variant="standard">
+## Step 3: Deploy
+
+<div data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="standard">
 
 Edit `sglang/disagg/deploy.yaml` and replace the `<your-namespace>` placeholder, then:
 
@@ -105,35 +173,22 @@ kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/part-of=glm5-sglang -w
 
 </div>
 
-<div data-variant="efa">
+<div data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="efa">
 
-Build the custom container image first — it bakes a patched libfabric ([ofiwg/libfabric#12019](https://github.com/ofiwg/libfabric/pull/12019)) into the runtime so `fi_mr_reg` on CUDA VRAM succeeds on GB200's 64K-page arm64 kernel:
-
-```bash
-docker buildx build \
-  --platform linux/arm64 \
-  --build-arg ARCH=arm64 \
-  -t <your-registry>/sglang-dynamo-glm5-efa:latest \
-  -f recipes/glm-5-nvfp4/sglang/disagg/efa/Dockerfile.efa \
-  --push .
-```
-
-Then edit `sglang/disagg/efa/deploy.yaml` to replace `<your-namespace>` and the image placeholder, and:
+Edit `sglang/disagg/efa/deploy.yaml` to replace `<your-namespace>` and the image placeholder, then:
 
 ```bash
 kubectl apply -f recipes/glm-5-nvfp4/sglang/disagg/efa/deploy.yaml
 kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/part-of=glm5-sglang-efa -w
 ```
 
-After startup, verify the LIBFABRIC backend is actually carrying KV traffic (not silent TCP fallback) — the [EFA README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/glm-5-nvfp4/sglang/disagg/efa/README.md) includes three checks (NIXL backend log line, executable `libplugin_LIBFABRIC.so` mapping, and `nixl_num_failed_transfers_total` staying at 0).
-
 </div>
 
-## Smoke Test
+## Step 4: Test
 
 Send a test request to verify the deployment serves traffic:
 
-<div data-variant="standard">
+<div data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="standard">
 
 ```bash
 kubectl port-forward svc/glm5-sglang-frontend 8000:8000 -n ${NAMESPACE} &
@@ -141,7 +196,7 @@ kubectl port-forward svc/glm5-sglang-frontend 8000:8000 -n ${NAMESPACE} &
 
 </div>
 
-<div data-variant="efa">
+<div data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="efa">
 
 ```bash
 kubectl port-forward svc/glm5-sglang-efa-frontend 8000:8000 -n ${NAMESPACE} &
@@ -152,14 +207,44 @@ kubectl port-forward svc/glm5-sglang-efa-frontend 8000:8000 -n ${NAMESPACE} &
 ```bash
 curl http://localhost:8000/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -d '{"model":"nvidia/GLM-5-NVFP4","messages":[{"role":"user","content":"Write a one-sentence readiness check."}],"max_tokens":128}'
+  -d '{"model":"nvidia/GLM-5-NVFP4","messages":[{"role":"user","content":"Hello!"}],"max_tokens":128}'
 ```
 
-## Benchmark
+<div data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="efa">
+
+After startup, three quick checks confirm the LIBFABRIC backend is actually carrying KV traffic (not silent TCP fallback):
+
+```bash
+NS=<your-namespace>
+POD=$(kubectl -n $NS get pods -l nvidia.com/dynamo-component=decode \
+        -o jsonpath='{.items[0].metadata.name}')
+
+# 1. NIXL selected LIBFABRIC at startup.
+kubectl -n $NS logs $POD | grep -i 'NIXL.*backend.*LIBFABRIC' | head -1
+# Expected: "NIXL INFO Backend LIBFABRIC was instantiated" or similar.
+# WRONG:    "NIXL agent uses UCX backend".
+
+# 2. libplugin_LIBFABRIC.so is actually executing (not just dlopen'd).
+kubectl -n $NS exec $POD -- bash -c '
+  grep libplugin_LIBFABRIC /proc/$(pgrep -f sglang | head -1)/maps |
+    grep "r-xp"' | head -3
+# Expected: at least one line ending in "r-xp" (executable mapping).
+
+# 3. NIXL transfer metrics show no failures.
+kubectl -n $NS exec $POD -- curl -s localhost:19090/metrics |
+  grep -E 'nixl_(bytes_transferred|num_failed)'
+# Expected: nixl_num_failed_transfers_total stays 0; bytes_transferred grows.
+```
+
+If check 1 shows UCX, the most likely cause is `SGLANG_DISAGGREGATION_NIXL_BACKEND=LIBFABRIC` not being applied — verify the env block in the running pod. If check 2 is empty, `LD_LIBRARY_PATH` ordering is wrong: `/opt/amazon/efa/lib` must come before any other libfabric on the path.
+
+</div>
+
+## Step 5: Benchmark (optional)
 
 Both targets ship a `perf.yaml` Kubernetes Job with the same workload shape: ISL=1000, OSL=8192, concurrency=512 (32 per decode GPU), 1,536 requests.
 
-<div data-variant="standard">
+<div data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="standard">
 
 The Job wraps this AIPerf run:
 
@@ -182,7 +267,7 @@ kubectl logs -f -l job-name=glm5-disagg-bench -n ${NAMESPACE}
 
 </div>
 
-<div data-variant="efa">
+<div data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="efa">
 
 The Job wraps this AIPerf run:
 
@@ -205,9 +290,37 @@ kubectl logs -f -l job-name=glm5-disagg-efa-bench -n ${NAMESPACE}
 
 </div>
 
-## Expected Performance
+The benchmark pod runs as a non-root user, installs AIPerf into `/tmp/.local`, and pins Transformers v5 because `nvidia/GLM-5-NVFP4` declares `tokenizer_class=TokenizersBackend`, which older Transformers v4 releases do not load.
 
-<div data-variant="standard">
+## Key Configuration Notes
+
+### Speculative Decoding (EAGLE MTP)
+
+**EAGLE MTP speculative decoding** (~85-95% accept rate) is enabled by two env vars: `SGLANG_ENABLE_SPEC_V2=1` (EAGLEWorkerV2 with overlap scheduler) and `SGLANG_NVFP4_CKPT_FP8_NEXTN_MOE=1` (quantizes the BF16 MTP layer to FP8 at load time, matching the base model's compute path). The MTP layer weights in `nvidia/GLM-5-NVFP4` are BF16, split across shards 271-274, and fully indexed in the checkpoint's `model.safetensors.index.json`.
+
+### KV Cache
+
+**FP8 KV cache**: uses `--kv-cache-dtype fp8_e4m3` (the NSA backend auto-selects this on SM100/GB200), saving roughly 50% KV memory vs BF16.
+
+### FlashInfer JIT Cache
+
+**FlashInfer JIT cache**: the runtime image has no prebuilt `flashinfer-jit-cache` wheel, so the recipe sets `FLASHINFER_WORKSPACE_BASE=/model-store` to persist first-run JIT artifacts on the shared PVC for later pod starts.
+
+### NIXL / UCX
+
+The standard target sets `UCX_TLS=cuda_copy,cuda_ipc,tcp` for NIXL/UCX KV transfer, so CUDA IPC/copy handles GPU memory movement while TCP provides UCX active-message control traffic. The EFA variant instead sets `SGLANG_DISAGGREGATION_NIXL_BACKEND=LIBFABRIC` and runs containers privileged so `fi_mr_reg` can pin VRAM for RDMA. Without the env var, SGLang silently falls back to TCP on kernel 6.8+.
+
+### Discovery
+
+**Discovery**: the recipe uses Kubernetes service discovery. Worker registration is tied to pod lifetime via Kubernetes EndpointSlices, which prevents TTL expiry issues under high load.
+
+### Recovery and Rollouts
+
+**Recovery caveat**: the decode side is one TP16 rank group spread across four nodes. Treat single decode-pod replacement as disruptive and validate full-group recovery before relying on individual decode pod restarts. In validation, cold deploy plus frontend and prefill replacement recovered successfully, while deleting one decode worker restarted the decode leader and left the graph NotReady through repeated rank-group reinitialization attempts.
+
+## Performance (ISL=1k, OSL=8k, concurrency=512)
+
+<div data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="standard">
 
 Reference AIPerf run for the standard target (ISL=1k, OSL=8k, concurrency=512): 1,536 requests, 0 errors, 747.87s benchmark duration. This is a concurrency-burst benchmark, so TTFT includes queueing under 512 concurrent users.
 
@@ -222,41 +335,39 @@ Reference AIPerf run for the standard target (ISL=1k, OSL=8k, concurrency=512): 
 
 </div>
 
-<div data-variant="efa">
+<div data-sku="gb200" data-engine="sglang" data-usecase="static" data-variant="efa">
 
-Reference AIPerf run for the EFA variant at the same workload shape (ISL=1k, OSL=8k, concurrency=512; measured on 5x p6e-gb200.36xlarge, EFA driver 3.0.0g):
+Reference AIPerf run for the EFA variant at the same workload shape (ISL=1k, OSL=8k, concurrency=512), measured on 5x p6e-gb200.36xlarge, EFA driver 3.0.0g, kernel 6.14.0-1018-aws-64k:
 
-| Metric | Value |
-| --- | ---: |
-| Output throughput | 19,131 tokens/sec |
-| TTFT p50 | 621 ms |
-| ITL avg | 24.5 ms/token |
-| Output tokens/user/sec | 41.0 |
+| Metric | EFA (this recipe) | Non-EFA (UCX/RoCE) baseline |
+| --- | ---: | ---: |
+| Output token throughput | **19,131 tok/s** | ~19,000 tok/s |
+| Total token throughput | 21,468 tok/s | — |
+| TTFT p50 | **621 ms** | ~850 ms |
+| TTFT avg | 2,786 ms | — |
+| ITL avg | **24.5 ms/token** | ~24 ms/token |
+| Output tokens/user/sec | **41.0** | ~41 |
+| Request count | 1,536 | — |
+| Benchmark duration | 657 s | — |
 
-At long context (ISL=20k, OSL=2k, concurrency=64), the LIBFABRIC backend delivers 39% higher throughput and 56% lower TTFT p50 than the UCX default — full tables in the [EFA README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/glm-5-nvfp4/sglang/disagg/efa/README.md).
+EFA achieves parity on all four published metrics. TTFT p50 is lower (better) on EFA, though TTFT avg is higher with a long tail (p99 approximately 12.5 s).
+
+### Long-context performance (ISL=20k, OSL=2k, concurrency=64)
+
+The benefit of the LIBFABRIC backend grows with per-request KV cache size. Running the same recipe with `SGLANG_DISAGGREGATION_NIXL_BACKEND=LIBFABRIC` set vs. unset (NIXL defaults to UCX) on the same 5x p6e-gb200.36xlarge hardware:
+
+| Metric | LIBFABRIC (this recipe) | UCX (default) |
+| --- | ---: | ---: |
+| Output token throughput | **2,023 tok/s** | 1,454 tok/s |
+| TTFT p50 | **20,273 ms** | 46,369 ms |
+| TTFT avg | **20,452 ms** | 41,746 ms |
+| ITL avg | 17.56 ms | 17.20 ms |
+| Benchmark duration | **194 s** | 270 s |
+| Request count | 192 | 192 |
+
+With a 20x larger per-request KV cache, LIBFABRIC delivers **39% higher throughput** and **56% lower TTFT p50** than UCX. ITL is essentially unchanged because steady-state decoding never touches the KV transfer path — only the prefill-to-decode KV hand-off does.
 
 </div>
-
-## Compare All Targets
-
-Both targets run the same disaggregated topology — 1 prefill node (TP4) plus 4 decode nodes (TP16/DP16/EP16) with EAGLE MTP speculative decoding and FP8 KV cache — and differ only in infrastructure and the KV-transfer backend:
-
-| | Standard (UCX) | AWS EFA (custom build) |
-|---|---|---|
-| **Hardware** | 20x GB200 (5x 4-GPU nodes, NVL36/NVL72) | 20x GB200 (5x p6e-gb200.36xlarge) |
-| **KV transfer** | NIXL over UCX | NIXL LIBFABRIC over EFA RDMA |
-| **Container image** | Published runtime image | Custom build from `Dockerfile.efa` |
-| **Extra requirements** | — | EFA driver 3.0.0g+, privileged containers |
-| **Output throughput** | 16,824 tok/s | 19,131 tok/s |
-
-## Notes
-
-- **EAGLE MTP speculative decoding** (~85-95% accept rate) is enabled by two env vars: `SGLANG_ENABLE_SPEC_V2=1` (EAGLEWorkerV2 with overlap scheduler) and `SGLANG_NVFP4_CKPT_FP8_NEXTN_MOE=1` (quantizes the BF16 MTP layer to FP8 at load time, matching the base model's compute path).
-- **FP8 KV cache**: uses `--kv-cache-dtype fp8_e4m3` (the NSA backend auto-selects this on SM100/GB200), saving roughly 50% KV memory vs BF16.
-- **FlashInfer JIT cache**: the runtime image has no prebuilt `flashinfer-jit-cache` wheel, so the recipe sets `FLASHINFER_WORKSPACE_BASE=/model-store` to persist first-run JIT artifacts on the shared PVC for later pod starts.
-- Worker containers run as root because FlashInfer's bundled cubin package creates TRTLLM MoE symlinks inside its installed package directory during startup. The benchmark pod runs as a non-root user and pins Transformers v5 because `nvidia/GLM-5-NVFP4` declares `tokenizer_class=TokenizersBackend`.
-- The standard target sets `UCX_TLS=cuda_copy,cuda_ipc,tcp` for NIXL/UCX KV transfer; the EFA variant instead sets `SGLANG_DISAGGREGATION_NIXL_BACKEND=LIBFABRIC` and runs containers privileged so `fi_mr_reg` can pin VRAM for RDMA. Without the env var, SGLang silently falls back to TCP on kernel 6.8+.
-- **Recovery caveat**: the decode side is one TP16 rank group spread across four nodes. Treat single decode-pod replacement as disruptive and validate full-group recovery before relying on individual decode pod restarts; in validation, deleting one decode worker left the graph NotReady through repeated rank-group reinitialization attempts.
 
 ## Source
 

--- a/docs/fern/pages/recipes/model-recipes/gpt-oss-120b.mdx
+++ b/docs/fern/pages/recipes/model-recipes/gpt-oss-120b.mdx
@@ -9,18 +9,32 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-Validated deployment targets for `openai/gpt-oss-120b` (MXFP4 MoE, 128 experts, top-4) across two runtimes. The vLLM targets serve the Mooncake agentic trace (64K ISL / 400 OSL, 90% KV cache hit) on B200 or H200, aggregated or disaggregated, with KV-aware routing and EAGLE3 speculative decoding. The TensorRT-LLM targets cover short-prompt high-concurrency and long-context generation on GB200. The GPU choice selects the runtime — B200/H200 run vLLM, GB200 runs TensorRT-LLM — and the targets use different traffic shapes, so this page is not a backend benchmark. Pick your GPU and topology; every command on this page updates to match.
+Validated deployment targets for `openai/gpt-oss-120b` (MXFP4 MoE, 128 experts / top-4, GQA + sliding-window + attention sinks) across two runtimes. The vLLM targets serve the Mooncake agentic trace (64K ISL / 400 OSL, 90% KV cache hit) on B200 or H200, aggregated or disaggregated, with KV-aware routing and EAGLE3-v3 speculative decoding. The TensorRT-LLM targets serve the same checkpoint on GB200: aggregated for short-prompt high-concurrency traffic, disaggregated prefill/decode for long-context generation. The GPU choice pins both the backend and the workload — B200/H200 run vLLM on the agentic trace, GB200 runs TensorRT-LLM on static synthetic traffic — and the targets use different traffic shapes, so this page is not a backend benchmark. Pick your GPU and topology; the Workload and Backend rows follow from the GPU, and every command on this page updates to match.
 
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
 <div className="dynamo-target-picker-row">
 <span className="dynamo-target-picker-dim">GPU</span>
 <input type="radio" id="recipe-sku-b200" name="recipe-sku" value="b200" defaultChecked />
-<label htmlFor="recipe-sku-b200">B200 · vLLM</label>
+<label htmlFor="recipe-sku-b200">B200</label>
 <input type="radio" id="recipe-sku-h200" name="recipe-sku" value="h200" />
-<label htmlFor="recipe-sku-h200">H200 · vLLM</label>
+<label htmlFor="recipe-sku-h200">H200</label>
 <input type="radio" id="recipe-sku-gb200" name="recipe-sku" value="gb200" />
-<label htmlFor="recipe-sku-gb200">GB200 · TRT-LLM</label>
+<label htmlFor="recipe-sku-gb200">GB200</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-agentic" name="recipe-usecase" value="agentic" defaultChecked />
+<label htmlFor="recipe-usecase-agentic" data-needs-sku="b200 h200">Agentic</label>
+<input type="radio" id="recipe-usecase-static" name="recipe-usecase" value="static" />
+<label htmlFor="recipe-usecase-static" data-needs-sku="gb200">Static synthetic</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-vllm" name="recipe-engine" value="vllm" defaultChecked />
+<label htmlFor="recipe-engine-vllm" data-needs-sku="b200 h200">vLLM</label>
+<input type="radio" id="recipe-engine-trtllm" name="recipe-engine" value="trtllm" />
+<label htmlFor="recipe-engine-trtllm" data-needs-sku="gb200">TensorRT-LLM</label>
 </div>
 <div className="dynamo-target-picker-row">
 <span className="dynamo-target-picker-dim">Topology</span>
@@ -31,76 +45,177 @@ Validated deployment targets for `openai/gpt-oss-120b` (MXFP4 MoE, 128 experts, 
 </div>
 <div className="dynamo-target-picker-summary" data-sku="b200" data-variant="agg">
 <span><b>Checkpoint</b> openai/gpt-oss-120b</span>
-<span><b>Runtime</b> vLLM · MXFP4 + FP8 KV cache</span>
-<span><b>GPUs</b> 8x B200, 8x TP1 replicas</span>
-<span><b>Techniques</b> KV-aware routing, EAGLE3-v3, flashinfer_trtllm MoE</span>
+<span><b>Framework</b> Dynamo 1.3.0 / vLLM 0.23</span>
+<span><b>GPUs (per node)</b> 8x B200</span>
+<span><b>Techniques</b> KV-aware routing, EAGLE3-v3, flashinfer_trtllm MoE, FlashInfer attention</span>
 <span><b>Workload</b> Agentic (64K ISL / 400 OSL, 90% KV hit)</span>
+<span><b>Deployment</b> DGD (8 pods, KV router)</span>
+<span><b>Precision</b> MXFP4 + FP8 KV</span>
+<span><b>Parallelism</b> 8x TP1 replicas</span>
+<span><b>MoE backend</b> flashinfer_trtllm (MXFP4xFP8)</span>
+<span><b>Attention backend</b> FlashInfer</span>
+<span><b>Routing</b> KV-aware</span>
+<span><b>Speculative decoding</b> EAGLE3-v3 (DL=3), ON</span>
+<span><b>KV cache offloading</b> none (SimpleCPUOffload opt-in)</span>
 </div>
 <div className="dynamo-target-picker-summary" data-sku="b200" data-variant="disagg">
 <span><b>Checkpoint</b> openai/gpt-oss-120b</span>
-<span><b>Runtime</b> vLLM · MXFP4 + FP8 KV cache</span>
-<span><b>GPUs</b> 8x B200, 2 prefill + 6 decode (in-pod)</span>
-<span><b>Techniques</b> KV-aware routing, EAGLE3-v3, flashinfer_trtllm MoE</span>
+<span><b>Framework</b> Dynamo 1.3.0 / vLLM 0.23</span>
+<span><b>GPUs (per node)</b> 8x B200 (2 prefill + 6 decode)</span>
+<span><b>Techniques</b> KV-aware routing, EAGLE3-v3, flashinfer_trtllm MoE, FlashInfer attention</span>
 <span><b>Workload</b> Agentic (64K ISL / 400 OSL, 90% KV hit)</span>
+<span><b>Deployment</b> DGD (colocated 1 node)</span>
+<span><b>Precision</b> MXFP4 + FP8 KV</span>
+<span><b>Parallelism</b> 2x TP1 prefill + 6x TP1 decode</span>
+<span><b>MoE backend</b> flashinfer_trtllm</span>
+<span><b>Attention backend</b> FlashInfer</span>
+<span><b>Routing</b> KV-aware</span>
+<span><b>Speculative decoding</b> EAGLE3-v3 (DL=3), ON (both)</span>
+<span><b>KV cache offloading</b> none (NIXL-incompatible)</span>
 </div>
 <div className="dynamo-target-picker-summary" data-sku="h200" data-variant="agg">
 <span><b>Checkpoint</b> openai/gpt-oss-120b</span>
-<span><b>Runtime</b> vLLM · MXFP4 + FP8 KV cache</span>
-<span><b>GPUs</b> 8x H200, 8x TP1 replicas</span>
-<span><b>Techniques</b> KV-aware routing, EAGLE3-v3, SimpleCPUOffload, flashinfer_cutlass MoE</span>
+<span><b>Framework</b> Dynamo 1.3.0 / vLLM 0.23</span>
+<span><b>GPUs (per node)</b> 8x H200</span>
+<span><b>Techniques</b> KV-aware routing, EAGLE3-v3, SimpleCPUOffload, flashinfer_cutlass MoE, FlashInfer attention</span>
 <span><b>Workload</b> Agentic (64K ISL / 400 OSL, 90% KV hit)</span>
+<span><b>Deployment</b> DGD (8 pods, KV router)</span>
+<span><b>Precision</b> MXFP4 + FP8 KV</span>
+<span><b>Parallelism</b> 8x TP1 replicas</span>
+<span><b>MoE backend</b> flashinfer_cutlass</span>
+<span><b>Attention backend</b> FlashInfer</span>
+<span><b>Routing</b> KV-aware</span>
+<span><b>Speculative decoding</b> EAGLE3-v3 (DL=3), ON</span>
+<span><b>KV cache offloading</b> SimpleCPUOffload ON</span>
 </div>
 <div className="dynamo-target-picker-summary" data-sku="h200" data-variant="disagg">
 <span><b>Checkpoint</b> openai/gpt-oss-120b</span>
-<span><b>Runtime</b> vLLM · MXFP4 + FP8 KV cache</span>
-<span><b>GPUs</b> 8x H200, 4 prefill + 4 decode (in-pod)</span>
-<span><b>Techniques</b> KV-aware routing, EAGLE3-v3, flashinfer_cutlass MoE</span>
+<span><b>Framework</b> Dynamo 1.3.0 / vLLM 0.23</span>
+<span><b>GPUs (per node)</b> 8x H200 (4 prefill + 4 decode)</span>
+<span><b>Techniques</b> KV-aware routing, EAGLE3-v3, flashinfer_cutlass MoE, FlashInfer attention</span>
 <span><b>Workload</b> Agentic (64K ISL / 400 OSL, 90% KV hit)</span>
+<span><b>Deployment</b> DGD (colocated 1 node)</span>
+<span><b>Precision</b> MXFP4 + FP8 KV</span>
+<span><b>Parallelism</b> 4x TP1 prefill + 4x TP1 decode</span>
+<span><b>MoE backend</b> flashinfer_cutlass</span>
+<span><b>Attention backend</b> FlashInfer</span>
+<span><b>Routing</b> KV-aware</span>
+<span><b>Speculative decoding</b> EAGLE3-v3 (DL=3), ON (both)</span>
+<span><b>KV cache offloading</b> none (NIXL-incompatible)</span>
 </div>
 <div className="dynamo-target-picker-summary" data-sku="gb200" data-variant="agg">
 <span><b>Checkpoint</b> openai/gpt-oss-120b</span>
-<span><b>Runtime</b> TensorRT-LLM (tensorrtllm-runtime:1.2.1)</span>
-<span><b>GPUs</b> 4x GB200 (ARM64), TP4, EP4 + attention-DP</span>
-<span><b>Workload</b> Short prompts, long outputs, high concurrency (128 ISL / 1000 OSL)</span>
+<span><b>Runtime</b> TensorRT-LLM (tensorrtllm-runtime:1.3.0)</span>
+<span><b>Topology</b> TP4, EP4 + attention-DP</span>
+<span><b>GPUs</b> 4x GB200 (ARM64 required)</span>
+<span><b>Quantization</b> Checkpoint default</span>
+<span><b>Workload</b> 128 ISL / 1000 OSL, 3,600 concurrency</span>
 </div>
 <div className="dynamo-target-picker-summary" data-sku="gb200" data-variant="disagg">
 <span><b>Checkpoint</b> openai/gpt-oss-120b</span>
-<span><b>Runtime</b> TensorRT-LLM (tensorrtllm-runtime:1.2.1)</span>
-<span><b>GPUs</b> 5x GB200/B200 (TP1 prefill + TP4 decode)</span>
+<span><b>Runtime</b> TensorRT-LLM (tensorrtllm-runtime:1.3.0)</span>
+<span><b>Topology</b> TP1 prefill + TP4 decode</span>
+<span><b>GPUs</b> 5x GB200/B200</span>
 <span><b>Quantization</b> W4A8_MXFP4_MXFP8</span>
-<span><b>Workload</b> Long-context generation (8K ISL / 1K OSL)</span>
+<span><b>Workload</b> 8K ISL / 1K OSL, 1,536 concurrency</span>
+<span><b>KV transfer</b> UCX cache transceiver</span>
 </div>
+</div>
+
+## Configurations
+
+<div data-sku="b200 h200">
+
+Dynamo + vLLM deployment profiles for the Mooncake agentic trace (64k/400/90%-KV) across two GPU SKUs and two topologies.
+
+- The disaggregated targets run **single-node colocated**: a `podAffinity` packs the prefill and decode Pods onto one node so NIXL P→D KV transfer stays on the NVLink path.
+- KV-offload defaults differ by SKU: **B200 aggregated ships prefix-caching only** (net-neutral there) while **H200 aggregated ships CPU offload ON** (`--kv-transfer-config=$(KV_TRANSFER_CONFIG)`, +9% at the 50-tps floor, quality-neutral).
+- **Do not enable LMCache for gpt-oss.** `LMCacheConnectorV1` crashes the engine on the request-completion path (`lmcache vllm_v1_adapter request_finished: assert self.lmcache_engine is not None` → `EngineDeadError`) and is not `SupportsHMA`, so it force-disables the hybrid KV cache manager — costing KV capacity on gpt-oss sliding-window attention.
+- **The working opt-in backend is `SimpleCPUOffloadConnector`** (native, `SupportsHMA` so the hybrid KV manager stays on; verified coherent and stable across a 384-request concurrent soak with 0 crashes). It is pre-wired as `KV_TRANSFER_CONFIG` in the aggregated deploy YAMLs — enable it by adding `--kv-transfer-config=$(KV_TRANSFER_CONFIG)` to the worker args, with no `--disable-hybrid-kv-cache-manager` needed.
+- Disaggregated variants stay NixlConnector-only — combining offload connectors with NIXL breaks the P→D handshake.
+- Speculative decoding uses the `nvidia/gpt-oss-120b-Eagle3-v3` head (EAGLE3-v3, draft length 3).
+
+</div>
+
+<div data-sku="gb200">
+
+TensorRT-LLM targets (GB200, static synthetic traffic).
+
+- The aggregated target requires ARM64 (GB200) nodes; the disaggregated target accepts GB200 or B200.
+- Do not read the two TensorRT-LLM targets as an aggregated-vs-disaggregated benchmark; their traffic shapes differ by design.
+
+</div>
+
+<div data-sku="gb200" data-variant="agg">
+
+- The `deploy.yaml` ships a ConfigMap with `enable_attention_dp: true`, `moe_config.backend: CUTLASS` and `cuda_graph_config.max_batch_size: 800`; the worker runs TP4 with expert parallelism 4 and `--free-gpu-memory-fraction 0.9`.
+- Quantization is the checkpoint default — no `OVERRIDE_QUANT_ALGO` is applied.
+
+</div>
+
+<div data-sku="gb200" data-variant="disagg">
+
+The disaggregated target splits prefill and decode across two worker roles:
+
+| Role | Nodes | GPUs/node | Total GPUs | Parallelism |
+|---|---|---|---|---|
+| Prefill | 1 | 1 | 1 | TP1 |
+| Decode | 1 | 4 | 4 | TP4 |
+
+- The `deploy.yaml` includes a ConfigMap with separate engine configurations for the prefill and decode workers. Key differences: **prefill** is TP1 with `max_batch_size=64`, `free_gpu_memory_fraction=0.8` and the overlap scheduler disabled; **decode** is TP4 with `max_batch_size=1280`, `free_gpu_memory_fraction=0.85` and the overlap scheduler enabled.
+- KV cache moves between the prefill and decode workers over a UCX-based cache transceiver (`max_tokens_in_buffer=9216`).
+- Quantization is `W4A8_MXFP4_MXFP8`, applied via the `OVERRIDE_QUANT_ALGO` environment variable.
+
+</div>
+
+## Supported features
+
+<div data-sku="b200 h200">
+
+- Modality: text, in the gpt-oss "harmony" format (reasoning traces plus tool calls).
+- Reasoning and tool calling use that harmony format, wired with `--dyn-reasoning-parser gpt_oss --dyn-tool-call-parser harmony`; `tool_calls` populates with `finish_reason: tool_calls`.
+
+</div>
+
+<div data-sku="gb200">
+
+- Modality: text. The TensorRT-LLM targets serve the same checkpoint over `/v1/chat/completions`, but they do not wire the `gpt_oss` reasoning parser or the `harmony` tool-call parser — harmony reasoning and tool-call segments arrive as raw text in `content`.
+
 </div>
 
 ## Prerequisites
 
 <div data-sku="b200">
 
-- A Kubernetes cluster with the Dynamo platform installed and **8x B200 on a single node** — the disaggregated target co-locates prefill and decode workers in one Pod.
+- A Kubernetes cluster with the Dynamo platform installed and **8x B200 on a single node** — the disaggregated target co-locates prefill and decode workers on one node. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx). The recipes pull `nvcr.io/nvidia/ai-dynamo/vllm-runtime` images via the `dynamo-ngc-token` image pull secret.
 - A Hugging Face token with access to `openai/gpt-oss-120b` and `nvidia/gpt-oss-120b-Eagle3-v3` (the EAGLE3 speculative-decoding head).
 
 </div>
 
 <div data-sku="h200">
 
-- A Kubernetes cluster with the Dynamo platform installed and **8x H200 on a single node** — the disaggregated target co-locates prefill and decode workers in one Pod.
+- A Kubernetes cluster with the Dynamo platform installed and **8x H200 on a single node** — the disaggregated target co-locates prefill and decode workers on one node. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx). The recipes pull `nvcr.io/nvidia/ai-dynamo/vllm-runtime` images via the `dynamo-ngc-token` image pull secret.
 - A Hugging Face token with access to `openai/gpt-oss-120b` and `nvidia/gpt-oss-120b-Eagle3-v3` (the EAGLE3 speculative-decoding head).
 
 </div>
 
 <div data-sku="gb200" data-variant="agg">
 
-- A Kubernetes cluster with the Dynamo platform installed and **4x GB200 available on ARM64 nodes** — the aggregated target will not run on x86 Hopper/Ampere hardware.
+- A Kubernetes cluster with the Dynamo platform installed and **4x GB200 available on ARM64 nodes** — the aggregated target will not run on x86 Hopper/Ampere hardware. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - A Hugging Face token with access to `openai/gpt-oss-120b`.
 
 </div>
 
 <div data-sku="gb200" data-variant="disagg">
 
-- A Kubernetes cluster with the Dynamo platform installed and **5x GB200 or B200** available (1 prefill + 4 decode GPUs).
+- A Kubernetes cluster with the Dynamo platform installed and **Blackwell GPU nodes (GB200 or B200)** — 5 GPUs in total: 1 for the TP1 prefill worker and 4 for the TP4 decode worker. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - A Hugging Face token with access to `openai/gpt-oss-120b`.
 
 </div>
+
+## Quick Start
+
+### 1. Create namespace
 
 Create the namespace and token secret:
 
@@ -112,18 +227,22 @@ kubectl create secret generic hf-token-secret \
   -n ${NAMESPACE}
 ```
 
+### 2. Create Storage
+
 <Warning>
-Update `storageClassName` in `model-cache/model-cache.yaml` and the container image tag in `deploy.yaml` to match your Dynamo release before deploying. Also edit namespace, node selectors, and cluster-specific placement.
+Edit `model-cache/model-cache.yaml` first and update `storageClassName` to match your cluster (`kubectl get storageclass`). Also update the container image tag in `deploy.yaml` to match your Dynamo release, and edit the namespace, node selectors, and any other cluster-specific placement before deploying.
 </Warning>
 
-## Deploy
+### 3. Download model + EAGLE3 head
 
-Prepare the model cache (shared by all targets; the vLLM targets also pull the EAGLE3 head):
+Prepare the model cache (shared by all targets; the download Job pulls both `openai/gpt-oss-120b` and the `nvidia/gpt-oss-120b-Eagle3-v3` head):
 
 ```bash
 kubectl apply -f recipes/gpt-oss-120b/model-cache/ -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=3600s
 ```
+
+### 4. Deploy
 
 Then deploy:
 
@@ -178,8 +297,6 @@ kubectl get pods -n ${NAMESPACE} -l nvidia.com/dynamo-graph-deployment-name=gpt-
 
 </div>
 
-## Smoke Test
-
 Send a test request to verify the deployment serves traffic. First forward the frontend port for your target:
 
 <div data-sku="b200" data-variant="agg">
@@ -192,10 +309,8 @@ kubectl port-forward svc/turbo-gptoss-120b-agg-b200-agentic-frontend 8000:8000 -
 
 <div data-sku="b200" data-variant="disagg">
 
-The disaggregated target is a single co-located Pod exposed as one Service (no separate frontend):
-
 ```bash
-kubectl port-forward svc/turbo-gptoss-120b-disagg-b200-agentic 8000:8000 -n ${NAMESPACE}
+kubectl port-forward svc/turbo-gptoss-120b-disagg-b200-agentic-frontend 8000:8000 -n ${NAMESPACE}
 ```
 
 </div>
@@ -210,10 +325,8 @@ kubectl port-forward svc/turbo-gptoss-120b-agg-h200-agentic-frontend 8000:8000 -
 
 <div data-sku="h200" data-variant="disagg">
 
-The disaggregated target is a single co-located Pod exposed as one Service (no separate frontend):
-
 ```bash
-kubectl port-forward svc/turbo-gptoss-120b-disagg-h200-agentic 8000:8000 -n ${NAMESPACE}
+kubectl port-forward svc/turbo-gptoss-120b-disagg-h200-agentic-frontend 8000:8000 -n ${NAMESPACE}
 ```
 
 </div>
@@ -238,35 +351,137 @@ All targets serve `openai/gpt-oss-120b`:
 
 ```bash
 curl http://localhost:8000/v1/chat/completions \
-  -H 'Content-Type: application/json' \
-  -d '{"model":"openai/gpt-oss-120b","messages":[{"role":"user","content":"Write a one-sentence readiness check."}],"max_tokens":64}'
+  -H "Content-Type: application/json" \
+  -d '{"model":"openai/gpt-oss-120b","messages":[{"role":"user","content":"Hello!"}],"max_tokens":50}'
 ```
 
-## Benchmark
+### 5. Benchmark
 
 <div data-sku="b200 h200">
 
-A single AIPerf trace-replay Job — `perf/perf.yaml` — covers every vLLM variant. It replays the Mooncake agentic trace (reused from the Kimi-K2.6 recipe; fetch it with `git lfs pull --include "recipes/kimi-k2.6/perf/traces/*"`) at one concurrency value and writes artifacts to the shared `model-cache` PVC. Edit the `env` block to set `ENDPOINT`, `TRACE_FILE`, and `CONCURRENCY` for your target:
+A single [AIPerf](https://github.com/ai-dynamo/aiperf) trace-replay Job — `perf/perf.yaml` — covers every vLLM variant (agg/disagg x B200/H200). The benchmark is identical across variants; only `ENDPOINT`, `TRACE_FILE`, and `CONCURRENCY` need to change.
 
-| Target | `ENDPOINT` | `CONCURRENCY` |
+The Job waits for `GET /v1/models` on the frontend to return `openai/gpt-oss-120b` (up to ~1h by default), runs a short warmup, then replays the configured trace at a single `CONCURRENCY` value and writes raw artifacts to the shared `model-cache` PVC. The Job carries a 2h hard cap (`activeDeadlineSeconds: 7200`), which is why the wait below uses a 7200s timeout.
+
+The bench pod is **co-located with the DGD frontend** (`podAffinity` on the frontend's host) so client → server traffic stays on a single node.
+
+Edit the `env` block in `perf.yaml` to target a variant:
+
+| Variant target | `ENDPOINT` | Measured `CONCURRENCY` |
 | --- | --- | --- |
-| vLLM aggregated (B200) | `turbo-gptoss-120b-agg-b200-agentic-frontend:8000` | `512` |
-| vLLM aggregated (H200) | `turbo-gptoss-120b-agg-h200-agentic-frontend:8000` | `256` |
-| vLLM disaggregated (B200) | `turbo-gptoss-120b-disagg-b200-agentic:8000` | `256` |
-| vLLM disaggregated (H200) | `turbo-gptoss-120b-disagg-h200-agentic:8000` | `256` |
+| B200 agg, agentic | `turbo-gptoss-120b-agg-b200-agentic-frontend:8000` | `512` |
+| H200 agg, agentic | `turbo-gptoss-120b-agg-h200-agentic-frontend:8000` | `256` |
+| B200 disagg, agentic | `turbo-gptoss-120b-disagg-b200-agentic-frontend:8000` | `256` |
+| H200 disagg, agentic | `turbo-gptoss-120b-disagg-h200-agentic-frontend:8000` | `256` |
+
+All variants serve `openai/gpt-oss-120b`, so any trace can be replayed against any variant by swapping `TRACE_FILE`.
+
+<Note>
+The `podAffinity` in `perf.yaml` matches the `nvidia.com/dynamo-component-type: frontend` + `nvidia.com/dynamo-graph-deployment-name` labels. Every target here is a DGD with its own `Frontend` component, so the operator sets these labels on all four frontends; `perf.yaml` already lists all four deployment names, and the one perf Job co-locates with aggregated and disaggregated targets unchanged.
+</Note>
+
+If you run more than one benchmark in the same namespace, also update `metadata.name` / `labels.app` so Jobs and artifact directories stay distinct.
+
+Stage the trace on the `model-cache` PVC with a short-lived helper pod that mounts it:
 
 ```bash
+kubectl run pvc-helper -n ${NAMESPACE} \
+  --image=busybox:1.36 --restart=Never \
+  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"model-cache","mountPath":"/model-cache"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"model-cache"}}]}}' \
+  --command -- sleep 3600
+
+git lfs install
+git lfs pull --include "recipes/kimi-k2.6/perf/traces/*"
+kubectl exec -n ${NAMESPACE} pvc-helper -- mkdir -p /model-cache/traces
+kubectl cp recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl \
+  ${NAMESPACE}/pvc-helper:/model-cache/traces/
+```
+
+Keep `pvc-helper` around for fetching artifacts later, or delete it once you are done staging.
+
+Then run the Job:
+
+```bash
+kubectl apply -f recipes/gpt-oss-120b/perf/perf.yaml -n ${NAMESPACE}
+
+# Stream logs
+kubectl logs -n ${NAMESPACE} -l job-name=turbo-gptoss-120b-bench -f
+
+# Wait for completion (2h hard cap on the Job)
+kubectl wait --for=condition=Complete \
+  job/turbo-gptoss-120b-bench \
+  -n ${NAMESPACE} --timeout=7200s
+```
+
+Fetch the artifacts, then clean up:
+
+```bash
+kubectl cp ${NAMESPACE}/pvc-helper:/model-cache/perf/<epoch>_turbo-gptoss-120b-bench ./results
+
+kubectl delete job turbo-gptoss-120b-bench -n ${NAMESPACE}
+kubectl delete pod pvc-helper -n ${NAMESPACE}   # if you kept it around
+```
+
+Results are written to:
+
+```text
+/model-cache/perf/<epoch>_<job-name>/
+  warmup/
+  gpt-oss-120b_trace_c<concurrency>_<timestamp>/
+    profile_export.json
+    inputs.json
+    ...
+```
+
+Per-GPU throughput = `output_token_throughput` / 8 (all variants run on 8 GPUs); the interactivity target is ≥50 tok/s/user.
+
+**Tunable environment variables.** Edit the `env` block on the Job to adjust:
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `ENDPOINT` | `turbo-gptoss-120b-agg-b200-agentic-frontend:8000` | Frontend service:port — change per variant (see the table above) |
+| `TRACE_FILE` | agentic 15% subset | Swap to the full trace, the chat flavour, or a smaller subset |
+| `CONCURRENCY` | `384` | B200 agentic ~50-tps floor; H200 ~128. See the concurrency sweep below |
+| `TARGET_MODEL` | `openai/gpt-oss-120b` | Must match `--served-model-name` |
+
+**Running a concurrency sweep.** `perf.yaml` runs a **single** `CONCURRENCY` value. To measure multiple concurrencies you must clear server state between runs — otherwise residual KV cache / prefix-cache hits from the previous run skew results. For each concurrency value you want to measure:
+
+```bash
+# 1. Delete the previous bench job
+kubectl delete job turbo-gptoss-120b-bench -n ${NAMESPACE} --ignore-not-found
+
+# 2. Drop KV / prefix-cache state.
+#    agg (DGD): DGDs are Grove-managed (DGD → PodCliqueSet → PodClique → Pod), not
+#    Deployments, so `kubectl rollout restart deployment` won't match anything —
+#    delete the worker pods directly and let Grove recreate them.
+DGD=turbo-gptoss-120b-agg-b200-agentic
+kubectl delete pods -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD},nvidia.com/dynamo-component-type=worker
+kubectl wait --for=condition=Ready pod -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD},nvidia.com/dynamo-component-type=worker \
+  --timeout=900s
+
+#    disagg (also a DGD): delete its worker pods and let the operator recreate them.
+# kubectl delete pods -n ${NAMESPACE} -l nvidia.com/dynamo-graph-deployment-name=turbo-gptoss-120b-disagg-b200-agentic,nvidia.com/dynamo-component-type=worker
+
+# 3. Bump CONCURRENCY in perf.yaml, then re-apply
 kubectl apply -f recipes/gpt-oss-120b/perf/perf.yaml -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/turbo-gptoss-120b-bench -n ${NAMESPACE} --timeout=7200s
 ```
 
-To measure multiple concurrencies, clear server state between runs — otherwise residual KV/prefix-cache hits skew results. See the [benchmark README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gpt-oss-120b/perf/README.md).
+The bench Job's `wait_for_model_ready` loop handles the worker restart window — it re-polls `/v1/models` until the frontend reports ready again.
+
+</div>
+
+<div data-sku="gb200">
+
+Edit `perf.yaml` to set your namespace and PVC before running the Job.
 
 </div>
 
 <div data-sku="gb200" data-variant="agg">
 
-The TensorRT-LLM target ships a `perf.yaml` Kubernetes Job that runs AIPerf at ISL 128 / OSL 1000 and 900 per GPU x 4 GPUs = 3,600 total concurrency (request count 10x concurrency). The Job wraps this AIPerf run:
+The TensorRT-LLM aggregated target ships a `perf.yaml` Kubernetes Job that runs AIPerf at ISL 128 / OSL 1000 and 900 per GPU x 4 GPUs = 3,600 total concurrency (request count 10x concurrency). The Job wraps this AIPerf run:
 
 ```bash
 aiperf profile \
@@ -287,7 +502,7 @@ kubectl logs -f -l job-name=gpt-oss-120b-bench -n ${NAMESPACE}
 
 <div data-sku="gb200" data-variant="disagg">
 
-The TensorRT-LLM target ships a `perf.yaml` Kubernetes Job that runs AIPerf at ISL 8192 / OSL 1024 and 1,536 total concurrency (request count 10x concurrency). The Job wraps this AIPerf run:
+The TensorRT-LLM disaggregated target ships a `perf.yaml` Kubernetes Job that runs AIPerf at ISL 8192 / OSL 1024 and 1,536 total concurrency (request count 10x concurrency). The Job wraps this AIPerf run:
 
 ```bash
 aiperf profile \
@@ -306,66 +521,75 @@ kubectl logs -f -l job-name=gpt-oss-120b-disagg-bench -n ${NAMESPACE}
 
 </div>
 
-## Expected Performance
+## Optimization targets
+
+The vLLM recipes are optimized for the following configuration, at the target user interactivity:
+
+| Workload | Median ISL | Median OSL | KV cache hit rate | User output tok/s |
+| --- | ---: | ---: | ---: | ---: |
+| Agentic | 64k | 400 | 90% | 50 |
 
 <div data-sku="b200 h200">
 
-Measured on the agentic 15% trace (8 GPUs) with the synthetic-acceptance EAGLE3 throughput proxy (AL=2.72; use for *relative* comparison — the generated text is intentionally garbage). Per-GPU throughput is system throughput / 8.
+The benchmark replays a [Mooncake-format](https://github.com/kvcache-ai/Mooncake) trace via `aiperf --custom-dataset-type mooncake_trace`. Each JSONL line describes one request (`input_length`, `output_length`, `hash_ids`). The traces are token-length-only, so model-agnostic — this recipe reuses the [traces shipped with the Kimi-K2.6 recipe](https://github.com/ai-dynamo/dynamo/tree/main/recipes/kimi-k2.6/perf/traces). **Only the agentic 15% subset is needed** — the recipes target the agentic workload (64k/400/90%-KV), and the 15% subset keeps run time short while preserving the KV-hit rate. It is the default `TRACE_FILE`; the full trace, the 30% subset, and the chat flavour live in the same folder for longer runs or experimentation.
 
-| Target | Concurrency | tok/s/GPU | tok/s/user | TTFT avg |
-| --- | --- | --- | --- | --- |
-| vLLM aggregated (B200) | 512 | 2896 | 58 | 4.4s |
-| vLLM aggregated (H200) | 256 | 1256 | 47.5 | 1.4s |
-| vLLM disaggregated (B200) | 256 | 2069 | 99 | 5.6s |
-| vLLM disaggregated (H200) | 256 | 1046 | 43 | 4.4s |
+<Note>
+The trace files are stored in **Git LFS** — a plain `git clone` leaves ~132-byte pointer files, so fetch the actual data with `git lfs install` followed by `git lfs pull` before staging. A real trace file is several MB (`ls -lh`); if the first line starts with `version https://git-lfs...`, it is still a pointer.
+</Note>
+
+The trace was generated for models with a longer context window than gpt-oss-120b. A small, deterministic fraction of requests (~7%) has `input_length` above 131072 (the recipes' `--max-model-len`) and is rejected by the server. The rejected set is identical on every run, so comparisons across configs and concurrencies remain valid — just expect the error count in the AIPerf export to be non-zero.
 
 </div>
 
 <div data-sku="gb200">
 
-The TensorRT-LLM targets ship benchmark Jobs but no published numbers — reproduce them with the [Benchmark](#benchmark) step above.
+The TensorRT-LLM targets replay static synthetic traffic instead of a trace, so their optimization target is the ISL/OSL pair and concurrency baked into each `perf.yaml`:
+
+| Target | ISL | OSL | Total concurrency |
+| --- | --- | --- | --- |
+| TRT-LLM aggregated | 128 | 1000 | 3,600 (900 per GPU x 4 GPUs) |
+| TRT-LLM disaggregated | 8192 | 1024 | 1,536 (256 per GPU x 6) |
 
 </div>
 
-## Compare All Targets
-
-vLLM targets (agentic Mooncake trace, 8 GPUs, MXFP4 + FP8 KV, EAGLE3-v3, KV-aware routing):
-
-| | vLLM agg B200 | vLLM agg H200 | vLLM disagg B200 | vLLM disagg H200 |
-|---|---|---|---|---|
-| **GPUs** | 8x B200, 8x TP1 | 8x H200, 8x TP1 | 8x B200, 2P6D in-pod | 8x H200, 4P4D in-pod |
-| **MoE backend** | flashinfer_trtllm | flashinfer_cutlass | flashinfer_trtllm | flashinfer_cutlass |
-| **KV offload** | none | SimpleCPUOffload | none (NIXL-incompatible) | none (NIXL-incompatible) |
-| **Concurrency** | 512 | 256 | 256 | 256 |
-
-TensorRT-LLM targets (GB200, static synthetic traffic):
-
-| | TRT-LLM aggregated | TRT-LLM disaggregated |
-|---|---|---|
-| **GPUs** | 4x GB200 (ARM64 required) | 5x GB200/B200 |
-| **Topology** | TP4, EP4 + attention-DP | TP1 prefill + TP4 decode |
-| **Workload** | 128 ISL / 1000 OSL, 3,600 concurrency | 8K ISL / 1K OSL, 1,536 concurrency |
-| **Quantization** | Checkpoint default | W4A8_MXFP4_MXFP8 |
-| **KV transfer** | — | UCX cache transceiver |
-
-## Notes
+## Performance results
 
 <div data-sku="b200 h200">
 
-- Reasoning and tool calling use the gpt-oss "harmony" format, wired with `--dyn-reasoning-parser gpt_oss --dyn-tool-call-parser harmony`; `tool_calls` populates with `finish_reason: tool_calls`.
-- The disaggregated targets run **single-node in-pod** (prefill and decode co-located in one Pod). Multi-pod disaggregation is not supported.
-- Structured output (`response_format: json_object` / `json_schema`) may return invalid JSON while speculative decoding is enabled — use tool calling or validate client-side.
-- The H200 aggregated target enables `SimpleCPUOffload` (about +9% throughput, quality-neutral); the B200 targets leave it off by default.
-- Speculative decoding uses the `nvidia/gpt-oss-120b-Eagle3-v3` head (EAGLE3-v3, draft length 3).
+Measured 2026-07-09 on the agentic 15% trace, 8 GPUs, with the **synthetic-acceptance EAGLE3 throughput proxy** (AL=2.72 on all workers — output is garbage by design; use for *relative* comparisons) and each recipe's KV-offload default. Per-GPU throughput is system throughput / 8, and the recipes are tuned to an interactivity target of 50 user output tok/s.
+
+| Target | Concurrency | tok/s/GPU | tok/s/user | TTFT avg | Note |
+| --- | --- | --- | --- | --- | --- |
+| vLLM aggregated (B200), 8x TP1 | c512 | **2896** | 58 | 4.4s | offload quality-neutral |
+| vLLM disaggregated (B200), 2P6D colocated | c256 | 2069 | 99 | 5.6s | plateau; TTFT-limited above c256 |
+| vLLM aggregated (H200), 8x TP1 + CPU offload | c256 | **1256** | 47.5 | 1.4s | at the 50-tps floor; offload = +9%, quality-neutral |
+| vLLM disaggregated (H200), 4P4D colocated | c256 | 1046 | 43 | 4.4s | best usable H200 split |
 
 </div>
 
 <div data-sku="gb200">
 
-- The aggregated target requires ARM64 (GB200) nodes; the disaggregated target accepts GB200 or B200.
-- Do not read the two TensorRT-LLM targets as an aggregated-vs-disaggregated benchmark; their traffic shapes differ by design.
-- The disaggregated deployment uses 5 GPUs (1x TP1 prefill + 1x TP4 decode), while its `perf.yaml` computes total concurrency from a 6-GPU count (256 x 6 = 1,536); adjust `DEPLOYMENT_GPU_COUNT` if you want strict per-GPU normalization.
-- The disaggregated target uses `W4A8_MXFP4_MXFP8` quantization via the `OVERRIDE_QUANT_ALGO` environment variable, and UCX-based KV transfer (`max_tokens_in_buffer=9216`).
+The TensorRT-LLM targets ship benchmark Jobs but no published numbers — reproduce them with the [Benchmark](#5-benchmark) step above.
+
+</div>
+
+## Known issues
+
+<div data-sku="b200 h200">
+
+- Structured output (`response_format: json_object` / `json_schema`) is not working — it may return invalid JSON while speculative decoding is enabled; use tool calling or validate client-side.
+
+</div>
+
+<div data-sku="gb200" data-variant="disagg">
+
+- The disaggregated deployment uses 5 GPUs (1x TP1 prefill + 1x TP4 decode), while its `perf.yaml` computes total concurrency from a 6-GPU count (`DEPLOYMENT_GPU_COUNT: "6"`, 256 x 6 = 1,536); adjust `DEPLOYMENT_GPU_COUNT` if you want strict per-GPU normalization.
+
+</div>
+
+<div data-sku="gb200" data-variant="agg">
+
+- The benchmark Job compiles the `crick` dependency from source because it has no Linux aarch64 wheel, so the pod installs build tools before AIPerf starts — expect a few extra minutes of startup on GB200.
 
 </div>
 
@@ -377,4 +601,5 @@ TensorRT-LLM targets (GB200, static synthetic traffic):
 - vLLM disaggregated: [B200](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gpt-oss-120b/vllm/disagg-b200-agentic/deploy.yaml) and [H200](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gpt-oss-120b/vllm/disagg-h200-agentic/deploy.yaml) deploy.yaml
 - vLLM benchmark manifest: [perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gpt-oss-120b/perf/perf.yaml)
 - TRT-LLM aggregated: [deploy.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml) and [perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gpt-oss-120b/trtllm/agg/perf.yaml)
+- TRT-LLM disaggregated README: [recipes/gpt-oss-120b/trtllm/disagg/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gpt-oss-120b/trtllm/disagg/README.md)
 - TRT-LLM disaggregated: [deploy.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gpt-oss-120b/trtllm/disagg/deploy.yaml) and [perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gpt-oss-120b/trtllm/disagg/perf.yaml)

--- a/docs/fern/pages/recipes/model-recipes/inkling-nvfp4.mdx
+++ b/docs/fern/pages/recipes/model-recipes/inkling-nvfp4.mdx
@@ -9,23 +9,68 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-Day-0 aggregated SGLang deployment for `thinkingmachines/Inkling-NVFP4` — the NVFP4-quantized checkpoint of Thinking Machines Lab's first open-weights model, a Mixture-of-Experts that reasons natively over text, image, and audio input with controllable reasoning effort. One TP8 worker on 8x B200 with EAGLE speculative decoding, FA4 attention, and the Inkling reasoning and tool-call parsers wired end to end.
+Day-0 aggregated SGLang deployment for `thinkingmachines/Inkling-NVFP4` — the NVFP4-quantized checkpoint of Thinking Machines Lab's first open-weights model, a Mixture-of-Experts that reasons natively over text, image, and audio input with controllable reasoning effort. One TP8 worker on 8x B200 with EAGLE speculative decoding, FA4 attention, and the Inkling reasoning and tool-call parsers wired end to end. Every row of the picker below carries a single option, because this recipe ships exactly one target — SGLang, aggregated, on 8x B200, for the multimodal workload.
 
-<div className="dynamo-target-picker static">
-<p className="dynamo-target-picker-title">Deployment target</p>
-<div className="dynamo-target-picker-summary">
+<div className="dynamo-target-picker">
+<p className="dynamo-target-picker-title">Choose your deployment target</p>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">GPU</span>
+<input type="radio" id="recipe-sku-b200" name="recipe-sku" value="b200" defaultChecked />
+<label htmlFor="recipe-sku-b200">B200 <span className="dynamo-target-picker-hint">8x, one node</span></label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-multimodal" name="recipe-usecase" value="multimodal" defaultChecked />
+<label htmlFor="recipe-usecase-multimodal">Multimodal</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-sglang" name="recipe-engine" value="sglang" defaultChecked />
+<label htmlFor="recipe-engine-sglang">SGLang</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Topology</span>
+<input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" defaultChecked />
+<label htmlFor="recipe-variant-agg">Aggregated</label>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="sglang" data-usecase="multimodal" data-variant="agg">
 <span><b>Checkpoint</b> thinkingmachines/Inkling-NVFP4 (~592 GB)</span>
-<span><b>Precision</b> NVFP4 (modelopt_fp4)</span>
+<span><b>Precision</b> NVFP4 (`modelopt_fp4`)</span>
 <span><b>GPUs</b> 8x B200, one TP8 worker</span>
 <span><b>Techniques</b> Aggregated serving, EAGLE speculative decoding, FA4 attention, Mamba radix cache</span>
 <span><b>Modalities</b> Text + image + audio input, text output</span>
+<span><b>GPU (per worker)</b> 8x B200</span>
+<span><b>Mode</b> aggregated</span>
+<span><b>Framework</b> SGLang (`sglang-inkling` custom build)</span>
+<span><b>Parallelism</b> TP8</span>
+<span><b>Attention backend</b> FA4</span>
+<span><b>FP4 GEMM backend</b> `FLASHINFER_TRTLLM`</span>
+<span><b>MoE runner backend</b> `FLASHINFER_TRTLLM_ROUTED`</span>
+<span><b>AllReduce backend</b> Torch symmetric memory (`--enable-torch-symm-mem`)</span>
+<span><b>Mamba radix cache</b> `extra_buffer` strategy</span>
+<span><b>Speculative decoding</b> EAGLE multi-layer (8 steps, topk 1, 9 draft tokens, rejection sampling)</span>
 </div>
 </div>
+
+## Configurations
+
+Dynamo + SGLang deployment profile, as set in `sglang/agg-b200/deploy.yaml`:
+
+- EAGLE speculative decoding is enabled by default in the deploy manifest; remove the `--speculative-*` flags to run without it.
+- The Mamba radix cache (`extra_buffer` strategy) and the FlashInfer TRT-LLM GEMM/MoE backends are part of the validated configuration — change them only deliberately.
+- This is a Day-0 recipe on a dedicated dev runtime image (`nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0-inkling-dev.1`, a custom SGLang build carrying the Inkling model support); it is functional but not yet promoted to a release runtime image, and no benchmark results are published yet.
+
+## Supported features
+
+- Inkling accepts text, image, and audio input in a single OpenAI-compatible API.
+- Reasoning and tool calling use the model's dedicated parsers, wired in both the frontend and the worker (`--reasoning-parser inkling --tool-call-parser inkling`).
+- Audio input: the model card specifies WAV sampled at 16 kHz, ideally under 20 minutes. The runtime image ships without royalty-bearing media codecs — AAC/`.m4a` decode is not included; other common formats (WAV, FLAC, OGG/Opus, MP3) decode via `libsndfile`. Image input is unaffected.
+- Video input is not supported in this recipe: the model card notes video handling exists for downstream fine-tuning but is unevaluated out of the box.
 
 ## Prerequisites
 
 - A Kubernetes cluster with the Dynamo platform installed and **8x B200** available on one node — see the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
-- An image pull secret with access to the runtime image registry.
+- An image pull secret for `nvcr.io` — the deploy manifest pulls the dev runtime image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0-inkling-dev.1`.
 - A Hugging Face token (the model is public, but a token avoids rate limits).
 
 Create the namespace and secrets:
@@ -45,20 +90,31 @@ kubectl create secret generic hf-token-secret \
   -n ${NAMESPACE}
 ```
 
+## Quick Start
+
+### 1. Create Storage
+
 <Warning>
-Update `storageClassName` in `model-cache/model-cache.yaml` to match your cluster (`kubectl get storageclass`) before applying. The checkpoint is ~592 GB — the download job can take a while. On clusters that already provide a shared RWX PVC, skip the cache step and replace the `model-cache` claim name in the manifests with the shared PVC name.
+Update `storageClassName` in `model-cache/model-cache.yaml` to a ReadWriteMany storage class on your cluster (`kubectl get storageclass`) before applying. The checkpoint is ~592 GB — the download job can take a while. On clusters that already provide a shared RWX PVC (for example `shared-model-cache` on the Dynamo dev clusters), skip the cache step and replace the `model-cache` claim name in three places: `model-cache/model-download.yaml` (`.spec.template.spec.volumes[0].persistentVolumeClaim.claimName`) and `sglang/agg-b200/deploy.yaml` in both the Frontend and the decode component volumes.
 </Warning>
 
-## Deploy
-
-Prepare the model cache and download the checkpoint:
+Prepare the model cache:
 
 ```bash
 # Update storageClassName in model-cache.yaml first!
 kubectl apply -f recipes/inkling/model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+### 2. Download the Model
+
+Download the checkpoint:
+
+```bash
 kubectl apply -f recipes/inkling/model-cache/model-download.yaml -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/inkling-model-download -n ${NAMESPACE} --timeout=7200s
 ```
+
+### 3. Deploy the DynamoGraphDeployment
 
 Then deploy:
 
@@ -66,15 +122,15 @@ Then deploy:
 kubectl apply -f recipes/inkling/sglang/agg-b200/deploy.yaml -n ${NAMESPACE}
 ```
 
-## Smoke Test
+### 4. Smoke Test
 
-Inkling accepts text, image, and audio input in a single OpenAI-compatible API. First, forward the frontend port:
+First, forward the frontend port:
 
 ```bash
 kubectl port-forward svc/tml-inkling-sglang-agg-frontend 8000:8000 -n ${NAMESPACE} &
 ```
 
-### Text
+#### Text
 
 ```bash
 curl -s http://localhost:8000/v1/chat/completions \
@@ -82,11 +138,11 @@ curl -s http://localhost:8000/v1/chat/completions \
   -d '{
     "model": "thinkingmachines/Inkling-NVFP4",
     "messages": [{"role": "user", "content": "Hello, who are you?"}],
-    "max_tokens": 64
+    "max_tokens": 128
   }'
 ```
 
-### Image
+#### Image
 
 Images ride as an `image_url` content part — a public HTTP(S) URL (the worker pod fetches it, so it needs egress) or a base64 `data:` URI:
 
@@ -98,15 +154,36 @@ curl -s http://localhost:8000/v1/chat/completions \
     "messages": [{
       "role": "user",
       "content": [
-        {"type": "text", "text": "Describe this image, including its text and visual elements."},
-        {"type": "image_url", "image_url": {"url": "https://raw.githubusercontent.com/ai-dynamo/dynamo/main/docs/assets/img/frontpage-banner.png"}}
+        {"type": "image_url", "image_url": {"url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint.png"}},
+        {"type": "text", "text": "Describe what is in this image."}
       ]
     }],
-    "max_tokens": 256
+    "max_tokens": 512
   }'
 ```
 
-### Audio
+#### Multiple Images
+
+Send several `image_url` content parts in the same user message to exercise multi-image input:
+
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "thinkingmachines/Inkling-NVFP4",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "image_url", "image_url": {"url": "https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/cats.jpg"}},
+        {"type": "image_url", "image_url": {"url": "https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/corgi.jpg"}},
+        {"type": "text", "text": "Describe each image separately. Label them Image 1 and Image 2."}
+      ]
+    }],
+    "max_tokens": 512
+  }'
+```
+
+#### Audio
 
 Audio rides as an `audio_url` content part, same URL-or-data-URI rule. Inkling expects 16 kHz audio; WAV is ideal, and MP3/FLAC/OGG also decode in this image. This sample is 16 kHz mono WAV, matching the model card spec:
 
@@ -126,9 +203,38 @@ curl -s http://localhost:8000/v1/chat/completions \
   }'
 ```
 
-For air-gapped clusters, send local files as `data:` URIs instead. Encode to a single line first (`base64` wraps output by default, which breaks the JSON payload): `AUDIO_B64=$(base64 < sample.wav | tr -d '\n')`, then `{"type": "audio_url", "audio_url": {"url": "data:audio/wav;base64,'"${AUDIO_B64}"'"}}`. Multiple media parts can ride in one message as the context budget allows.
+#### Multiple Audio Clips
 
-### Reasoning effort
+Send several `audio_url` content parts in the same user message to exercise multi-audio input:
+
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "thinkingmachines/Inkling-NVFP4",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "audio_url", "audio_url": {"url": "https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/mlk.wav"}},
+        {"type": "audio_url", "audio_url": {"url": "https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/librispeech_asr_demo_validation_0.wav"}},
+        {"type": "text", "text": "Transcribe each audio clip separately. Label them Audio 1 and Audio 2."}
+      ]
+    }],
+    "max_tokens": 512
+  }'
+```
+
+For air-gapped clusters, send local media files as `data:` URIs instead:
+
+```json
+{"type": "audio_url", "audio_url": {"url": "data:audio/wav;base64,<BASE64_WAV>"}}
+```
+
+Encode to a single line first (`base64` wraps output by default, which breaks the JSON payload): `AUDIO_B64=$(base64 < sample.wav | tr -d '\n')`, then interpolate that value into the `url` field.
+
+Mix multiple media parts in one message as the context budget allows.
+
+#### Reasoning Effort
 
 Inkling's controllable thinking is exposed per request: pass `reasoning_effort` as a named level (`none` / `minimal` / `low` / `medium` / `high` / `max`) or a float in `[0.0, 0.99]`; omitted requests default to `0.9` (high). These are the values in this checkpoint's chat template — `xhigh` from the launch blog is not in its map and is rejected:
 
@@ -143,15 +249,36 @@ curl -s http://localhost:8000/v1/chat/completions \
   }'
 ```
 
-## Notes
+## Cleanup
 
-- This is a Day-0 recipe on a dedicated dev runtime image (`sglang-runtime:1.4.0-inkling-dev.1`, a custom SGLang build carrying the Inkling model support); it is functional but not yet promoted to a release runtime image, and no benchmark results are published yet.
-- Audio input: the model card specifies WAV sampled at 16 kHz, ideally under 20 minutes. The runtime image ships without royalty-bearing media codecs — AAC/`.m4a` decode is not included; other common formats (WAV, FLAC, OGG/Opus, MP3) decode via `libsndfile`. Image input is unaffected.
-- Video input is not supported in this recipe: the model card notes video handling exists for downstream fine-tuning but is unevaluated out of the box.
-- Reasoning and tool calling use the model's dedicated parsers, wired in both the frontend and the worker (`--reasoning-parser inkling --tool-call-parser inkling`).
-- EAGLE speculative decoding is enabled by default in the deploy manifest (multi-layer, 8 steps, rejection sampling); remove the `--speculative-*` flags to run without it.
-- The manifest sets `DYN_FORWARDPASS_METRIC_PORT` to an empty value — a deliberate workaround that keeps forward-pass metrics off, because this rc image crashes on EAGLE batches when they are enabled. Keep it (and don't set that variable) until a fixed image ships.
-- The worker enables the Mamba radix cache (`extra_buffer` strategy) and FlashInfer TRT-LLM GEMM/MoE backends; these flags are part of the validated configuration — change them only deliberately.
+Tear down the deployment and free cluster resources:
+
+```bash
+# Stop the port-forward if it is still running
+pkill -f "kubectl port-forward svc/tml-inkling-sglang-agg-frontend" 2>/dev/null || true
+
+# Delete the deployment (stops all pods)
+kubectl delete dynamographdeployment tml-inkling-sglang-agg -n ${NAMESPACE} 2>/dev/null || true
+
+# Delete the model-download job (idempotent — already finished or not yet run)
+kubectl delete job inkling-model-download -n ${NAMESPACE} 2>/dev/null || true
+
+# Delete secrets (optional — omit if you reuse them across deployments)
+kubectl delete secret nvcr-imagepullsecret hf-token-secret -n ${NAMESPACE} 2>/dev/null || true
+
+# Delete the PVC — WARNING: this destroys the downloaded 592 GB model.
+# Skip this step if you plan to redeploy or share the PVC with other workloads.
+# kubectl delete pvc model-cache -n ${NAMESPACE}
+
+# Delete the namespace — WARNING: this destroys everything in it.
+# kubectl delete namespace ${NAMESPACE}
+```
+
+For a one-shot cleanup run, the recipe also ships [`cleanup.sh`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/inkling/cleanup.sh).
+
+## Known Issues
+
+- Known issue: the manifest overrides `DYN_FORWARDPASS_METRIC_PORT` to an empty value. This override is required for MTP/EAGLE speculative decoding with SGLang, because the forward-pass metrics reporter — auto-enabled by the operator-injected port — crashes the scheduler on speculative batches (`batch.seq_lens_cpu` is `None`). Only per-forward-pass telemetry is lost. Remove the override once the container image carries a fix.
 
 ## Source
 

--- a/docs/fern/pages/recipes/model-recipes/kimi-k2-6.mdx
+++ b/docs/fern/pages/recipes/model-recipes/kimi-k2-6.mdx
@@ -9,7 +9,7 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-Each target below is a validated aggregated vLLM deployment of Kimi-K2.6 — text + image input, reasoning, and tool calling — with KV-aware routing, Eagle3 MLA speculative decoding, and LMCache CPU KV-cache offload, benchmarked to roughly 50 output tok/s per user on its trace. Pick your GPU and workload; every command on this page updates to match.
+Each target below is a validated aggregated vLLM deployment of Kimi-K2.6 — text + image input, reasoning, and tool calling — with KV-aware routing, Eagle3 MLA speculative decoding, and LMCache CPU KV-cache offload, benchmarked to roughly 50 output tok/s per user on its trace. This recipe ships one backend (vLLM) and one topology (aggregated), so pick your GPU and workload; every command on this page updates to match.
 
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
@@ -27,55 +27,98 @@ Each target below is a validated aggregated vLLM deployment of Kimi-K2.6 — tex
 <input type="radio" id="recipe-usecase-agentic" name="recipe-usecase" value="agentic" />
 <label htmlFor="recipe-usecase-agentic">Agentic</label>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-usecase="chat">
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-vllm" name="recipe-engine" value="vllm" defaultChecked />
+<label htmlFor="recipe-engine-vllm">vLLM</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Topology</span>
+<input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" defaultChecked />
+<label htmlFor="recipe-variant-agg">Aggregated</label>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="chat" data-variant="agg">
 <span><b>Checkpoint</b> nvidia/Kimi-K2.6-NVFP4</span>
-<span><b>Precision</b> NVFP4 + FP8 KV cache</span>
-<span><b>GPUs</b> 4x B200 per worker, TP4</span>
+<span><b>GPUs per worker</b> 4x B200</span>
+<span><b>Precision</b> NVFP4 + FP8 KV</span>
+<span><b>Parallelism</b> TP4</span>
 <span><b>MoE backend</b> FlashInfer-TRTLLM</span>
-<span><b>Attention</b> TokenSpeed MLA</span>
-<span><b>Workload</b> Chat, 70% KV reuse</span>
+<span><b>Attention backend</b> TokenSpeed MLA</span>
+<span><b>AllReduce</b> NCCL symmetric memory</span>
+<span><b>All2All backend</b> N/A</span>
+<span><b>Workload</b> Chat trace</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-usecase="agentic">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> nvidia/Kimi-K2.6-NVFP4</span>
-<span><b>Precision</b> NVFP4 + FP8 KV cache</span>
-<span><b>GPUs</b> 4x B200 per worker, TP4</span>
+<span><b>GPUs per worker</b> 4x B200</span>
+<span><b>Precision</b> NVFP4 + FP8 KV</span>
+<span><b>Parallelism</b> TP4</span>
 <span><b>MoE backend</b> FlashInfer-TRTLLM</span>
-<span><b>Attention</b> TokenSpeed MLA</span>
-<span><b>Workload</b> Agentic, 64K-median ISL, 90% KV reuse</span>
+<span><b>Attention backend</b> TokenSpeed MLA</span>
+<span><b>AllReduce</b> NCCL symmetric memory</span>
+<span><b>All2All backend</b> N/A</span>
+<span><b>Workload</b> Agentic trace</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-usecase="chat">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="agg">
 <span><b>Checkpoint</b> moonshotai/Kimi-K2.6 (native INT4)</span>
-<span><b>Precision</b> INT4</span>
-<span><b>GPUs</b> 8x H200 per worker, TP8</span>
+<span><b>GPUs per worker</b> 8x H200</span>
+<span><b>Precision</b> INT4 (native)</span>
+<span><b>Parallelism</b> TP8</span>
 <span><b>MoE backend</b> Marlin</span>
-<span><b>Attention</b> FlashAttention MLA</span>
-<span><b>Workload</b> Chat, 70% KV reuse</span>
+<span><b>Attention backend</b> FlashAttention MLA</span>
+<span><b>AllReduce</b> NCCL</span>
+<span><b>All2All backend</b> N/A</span>
+<span><b>Workload</b> Chat trace</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-usecase="agentic">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> moonshotai/Kimi-K2.6 (native INT4)</span>
-<span><b>Precision</b> INT4</span>
-<span><b>GPUs</b> 8x H200 per worker, TP8</span>
+<span><b>GPUs per worker</b> 8x H200</span>
+<span><b>Precision</b> INT4 (native)</span>
+<span><b>Parallelism</b> TP8</span>
 <span><b>MoE backend</b> Marlin</span>
-<span><b>Attention</b> FlashAttention MLA</span>
-<span><b>Workload</b> Agentic, 64K-median ISL, 90% KV reuse</span>
+<span><b>Attention backend</b> FlashAttention MLA</span>
+<span><b>AllReduce</b> NCCL</span>
+<span><b>All2All backend</b> N/A</span>
+<span><b>Workload</b> Agentic trace</span>
 </div>
 </div>
+
+## Configurations
+
+All four targets serve `moonshotai/Kimi-K2.6` on aggregated vLLM 0.21.0 with KV-aware routing, Eagle3 MLA speculative decoding (3 draft tokens, SpeedBench acceptance length 2.49), and LMCache CPU KV-cache offload. They differ in checkpoint, parallelism, kernel backends, and the trace they are benchmarked against:
+
+- B200 targets run `nvidia/Kimi-K2.6-NVFP4` with FP8 KV cache; H200 targets run the native INT4 `moonshotai/Kimi-K2.6` checkpoint. Both serve under the name `moonshotai/Kimi-K2.6`.
+- The chat- and agentic-tuned deployments for a given SKU share the same engine configuration; they are separate targets because each is benchmarked and sized against its own trace, and either trace can be replayed against either DGD.
+
+## Supported features
+
+- Modalities: Text + Image
+- Reasoning
+- Tool calling
 
 ## Prerequisites
 
-<div data-sku="b200">
+<div data-sku="b200" data-engine="vllm" data-variant="agg">
 
-- A Kubernetes cluster with the Dynamo platform installed and **4x B200 per worker replica** available (results below were measured at 4 replicas).
-- A Hugging Face token with access to `nvidia/Kimi-K2.6-NVFP4` and `lightseekorg/kimi-k2.6-eagle3-mla`.
+- A Kubernetes cluster with the Dynamo platform installed and **4x B200 per worker replica** available (results below were measured at 4 replicas) — see the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
+- A Hugging Face token with access to `nvidia/Kimi-K2.6-NVFP4`, `moonshotai/Kimi-K2.6`, and `lightseekorg/kimi-k2.6-eagle3-mla`.
+
+</div>
+
+<div data-sku="h200" data-engine="vllm" data-variant="agg">
+
+- A Kubernetes cluster with the Dynamo platform installed and **8x H200 per worker replica** available (results below were measured at 4 replicas) — see the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
+- A Hugging Face token with access to `nvidia/Kimi-K2.6-NVFP4`, `moonshotai/Kimi-K2.6`, and `lightseekorg/kimi-k2.6-eagle3-mla`.
 
 </div>
 
-<div data-sku="h200">
+<Warning>
+Edit namespace, storage class, image tags, node selectors, resource claims, and cluster-specific placement in the manifests before applying them.
+</Warning>
 
-- A Kubernetes cluster with the Dynamo platform installed and **8x H200 per worker replica** available (results below were measured at 4 replicas).
-- A Hugging Face token with access to `moonshotai/Kimi-K2.6` and `lightseekorg/kimi-k2.6-eagle3-mla`.
+## Quick Start
 
-</div>
+### 1. Create namespace
 
 Create the namespace and token secret:
 
@@ -87,20 +130,22 @@ kubectl create secret generic hf-token-secret \
   -n ${NAMESPACE}
 ```
 
-<Warning>
-Edit namespace, storage class, image tags, node selectors, resource claims, and cluster-specific placement in the manifests before applying them.
-</Warning>
+### 2. Create Storage
 
-## Deploy
-
-Prepare the model cache and download the checkpoint and Eagle3 head:
-
-<div data-sku="b200">
+Prepare the shared `model-cache` PVC:
 
 ```bash
 # 1. Storage — edit storageClassName in model-cache.yaml first (kubectl get storageclass).
 kubectl apply -f recipes/kimi-k2.6/model-cache/model-cache.yaml -n ${NAMESPACE}
+```
 
+### 3. Download model + EAGLE3 head
+
+Download the checkpoint and Eagle3 head onto the PVC:
+
+<div data-sku="b200" data-engine="vllm" data-variant="agg">
+
+```bash
 # 2. Download. B200 uses the NVFP4 checkpoint — remove the native INT4
 #    download from model-download.yaml before applying.
 kubectl apply -f recipes/kimi-k2.6/model-cache/model-download.yaml -n ${NAMESPACE}
@@ -109,12 +154,9 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 
 </div>
 
-<div data-sku="h200">
+<div data-sku="h200" data-engine="vllm" data-variant="agg">
 
 ```bash
-# 1. Storage — edit storageClassName in model-cache.yaml first (kubectl get storageclass).
-kubectl apply -f recipes/kimi-k2.6/model-cache/model-cache.yaml -n ${NAMESPACE}
-
 # 2. Download. H200 uses the native INT4 checkpoint — remove the NVFP4
 #    download from model-download.yaml before applying.
 kubectl apply -f recipes/kimi-k2.6/model-cache/model-download.yaml -n ${NAMESPACE}
@@ -123,9 +165,11 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 
 </div>
 
+### 4. Deploy the DGD
+
 Then deploy:
 
-<div data-sku="b200" data-usecase="chat">
+<div data-sku="b200" data-engine="vllm" data-usecase="chat" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/kimi-k2.6/vllm/agg-b200-chat/deploy.yaml -n ${NAMESPACE}
@@ -133,7 +177,7 @@ kubectl apply -f recipes/kimi-k2.6/vllm/agg-b200-chat/deploy.yaml -n ${NAMESPACE
 
 </div>
 
-<div data-sku="b200" data-usecase="agentic">
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/kimi-k2.6/vllm/agg-b200-agentic/deploy.yaml -n ${NAMESPACE}
@@ -141,7 +185,7 @@ kubectl apply -f recipes/kimi-k2.6/vllm/agg-b200-agentic/deploy.yaml -n ${NAMESP
 
 </div>
 
-<div data-sku="h200" data-usecase="chat">
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/kimi-k2.6/vllm/agg-h200-chat/deploy.yaml -n ${NAMESPACE}
@@ -149,7 +193,7 @@ kubectl apply -f recipes/kimi-k2.6/vllm/agg-h200-chat/deploy.yaml -n ${NAMESPACE
 
 </div>
 
-<div data-sku="h200" data-usecase="agentic">
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/kimi-k2.6/vllm/agg-h200-agentic/deploy.yaml -n ${NAMESPACE}
@@ -157,11 +201,9 @@ kubectl apply -f recipes/kimi-k2.6/vllm/agg-h200-agentic/deploy.yaml -n ${NAMESP
 
 </div>
 
-## Smoke Test
-
 Send a test request to verify the deployment serves traffic:
 
-<div data-sku="b200" data-usecase="chat">
+<div data-sku="b200" data-engine="vllm" data-usecase="chat" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/kimi-k26-agg-b200-chat-frontend 8000:8000 -n ${NAMESPACE}
@@ -169,7 +211,7 @@ kubectl port-forward svc/kimi-k26-agg-b200-chat-frontend 8000:8000 -n ${NAMESPAC
 
 </div>
 
-<div data-sku="b200" data-usecase="agentic">
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/kimi-k26-agg-b200-agentic-frontend 8000:8000 -n ${NAMESPACE}
@@ -177,7 +219,7 @@ kubectl port-forward svc/kimi-k26-agg-b200-agentic-frontend 8000:8000 -n ${NAMES
 
 </div>
 
-<div data-sku="h200" data-usecase="chat">
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/kimi-k26-agg-h200-chat-frontend 8000:8000 -n ${NAMESPACE}
@@ -185,7 +227,7 @@ kubectl port-forward svc/kimi-k26-agg-h200-chat-frontend 8000:8000 -n ${NAMESPAC
 
 </div>
 
-<div data-sku="h200" data-usecase="agentic">
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/kimi-k26-agg-h200-agentic-frontend 8000:8000 -n ${NAMESPACE}
@@ -199,9 +241,13 @@ curl http://localhost:8000/v1/chat/completions \
   -d '{"model":"moonshotai/Kimi-K2.6","messages":[{"role":"user","content":"Write a one-sentence readiness check."}],"max_tokens":64}'
 ```
 
-## Benchmark
+### 5. Benchmark
 
-A single AIPerf trace-replay Job ([`perf/perf.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/kimi-k2.6/perf/perf.yaml)) covers every target — only `ENDPOINT` and `TRACE_FILE` change. Before running it: point the worker's `SPECULATIVE_CONFIG` at the `speculative-config-synthetic` ConfigMap key (synthetic Eagle3 acceptance, AL=2.49), set worker `replicas` to your target, and stage the traces from [`recipes/kimi-k2.6/perf/traces/`](https://github.com/ai-dynamo/dynamo/tree/main/recipes/kimi-k2.6/perf/traces) onto the `model-cache` PVC:
+A single [AIPerf](https://github.com/ai-dynamo/aiperf) trace-replay Job ([`perf/perf.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/kimi-k2.6/perf/perf.yaml), documented in the [benchmark README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/kimi-k2.6/perf/README.md)) covers every target — only `ENDPOINT` and `TRACE_FILE` change. The Job waits for `GET /v1/models` on the DGD frontend to return `moonshotai/Kimi-K2.6` (up to about an hour by default), runs a short warmup, then replays the configured trace at a single `CONCURRENCY` value and writes raw artifacts to the shared `model-cache` PVC. The bench pod is co-located with the DGD frontend by a `podAffinity` rule on the frontend's host, so client-to-server traffic stays on a single node.
+
+The benchmark replays a [Mooncake-format](https://github.com/kvcache-ai/Mooncake) trace via `aiperf --custom-dataset-type mooncake_trace`, where each JSONL line describes one request (`input_length`, `output_length`, `hash_ids`). The modified Mooncake traces shipped with the recipe are provided to showcase the value of KV-aware routing and CPU offloading. The Dynamo Kimi-K2.5 recipe is the closest reference for trace handling — see [its README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/kimi-k2.5/README.md#dataset-agentic-coding-workflow) and [perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/kimi-k2.5/trtllm/agg-eagle-kv-router/perf.yaml).
+
+Before deploying the DGD for a benchmark run, point the worker's `SPECULATIVE_CONFIG` at the `speculative-config-synthetic` ConfigMap key and set worker `replicas` to your target. Then stage the traces from [`recipes/kimi-k2.6/perf/traces/`](https://github.com/ai-dynamo/dynamo/tree/main/recipes/kimi-k2.6/perf/traces) onto the `model-cache` PVC:
 
 ```bash
 kubectl run pvc-helper -n ${NAMESPACE} \
@@ -211,9 +257,24 @@ kubectl run pvc-helper -n ${NAMESPACE} \
 kubectl cp recipes/kimi-k2.6/perf/traces ${NAMESPACE}/pvc-helper:/model-cache/
 ```
 
-<div data-sku="b200" data-usecase="chat">
+Keep `pvc-helper` around for fetching artifacts later, or delete it once staging is done (`kubectl delete pod pvc-helper -n ${NAMESPACE}`).
 
-Set `ENDPOINT` to `kimi-k26-agg-b200-chat-frontend:8000` and `TRACE_FILE` to the chat trace, then apply. The Job wraps this AIPerf run:
+Then edit the `env` block on the Job:
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `ENDPOINT` | `kimi-k26-agg-b200-chat-frontend:8000` | DGD frontend service:port — change per target |
+| `TRACE_FILE` | `/model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl` | Swap to the agentic trace, or to a smaller subset (`..._short_15perc.jsonl`) for shorter runs |
+| `CONCURRENCY` | `24` | A single value — see the concurrency sweep below |
+| `TARGET_MODEL` | `moonshotai/Kimi-K2.6` | Must match `--served-model-name` on the DGD frontend |
+
+If you run more than one benchmark in the same namespace, also update `metadata.name` and `labels.app` so jobs and artifact directories stay distinct.
+
+For your target:
+
+<div data-sku="b200" data-engine="vllm" data-usecase="chat" data-variant="agg">
+
+Set `ENDPOINT` to `kimi-k26-agg-b200-chat-frontend:8000` and `TRACE_FILE` to `/model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl`. The Job wraps this AIPerf run:
 
 ```bash
 aiperf profile -m moonshotai/Kimi-K2.6 --tokenizer moonshotai/Kimi-K2.6 --tokenizer-trust-remote-code \
@@ -224,9 +285,9 @@ aiperf profile -m moonshotai/Kimi-K2.6 --tokenizer moonshotai/Kimi-K2.6 --tokeni
 
 </div>
 
-<div data-sku="b200" data-usecase="agentic">
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
-Set `ENDPOINT` to `kimi-k26-agg-b200-agentic-frontend:8000` and `TRACE_FILE` to the agentic trace, then apply. The Job wraps this AIPerf run:
+Set `ENDPOINT` to `kimi-k26-agg-b200-agentic-frontend:8000` and `TRACE_FILE` to `/model-cache/traces/64k_400_90kv_agent_new_noschedule.jsonl`. The Job wraps this AIPerf run:
 
 ```bash
 aiperf profile -m moonshotai/Kimi-K2.6 --tokenizer moonshotai/Kimi-K2.6 --tokenizer-trust-remote-code \
@@ -237,9 +298,9 @@ aiperf profile -m moonshotai/Kimi-K2.6 --tokenizer moonshotai/Kimi-K2.6 --tokeni
 
 </div>
 
-<div data-sku="h200" data-usecase="chat">
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="agg">
 
-Set `ENDPOINT` to `kimi-k26-agg-h200-chat-frontend:8000` and `TRACE_FILE` to the chat trace, then apply. The Job wraps this AIPerf run:
+Set `ENDPOINT` to `kimi-k26-agg-h200-chat-frontend:8000` and `TRACE_FILE` to `/model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl`. The Job wraps this AIPerf run:
 
 ```bash
 aiperf profile -m moonshotai/Kimi-K2.6 --tokenizer moonshotai/Kimi-K2.6 --tokenizer-trust-remote-code \
@@ -250,9 +311,9 @@ aiperf profile -m moonshotai/Kimi-K2.6 --tokenizer moonshotai/Kimi-K2.6 --tokeni
 
 </div>
 
-<div data-sku="h200" data-usecase="agentic">
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
-Set `ENDPOINT` to `kimi-k26-agg-h200-agentic-frontend:8000` and `TRACE_FILE` to the agentic trace, then apply. The Job wraps this AIPerf run:
+Set `ENDPOINT` to `kimi-k26-agg-h200-agentic-frontend:8000` and `TRACE_FILE` to `/model-cache/traces/64k_400_90kv_agent_new_noschedule.jsonl`. The Job wraps this AIPerf run:
 
 ```bash
 aiperf profile -m moonshotai/Kimi-K2.6 --tokenizer moonshotai/Kimi-K2.6 --tokenizer-trust-remote-code \
@@ -263,21 +324,115 @@ aiperf profile -m moonshotai/Kimi-K2.6 --tokenizer moonshotai/Kimi-K2.6 --tokeni
 
 </div>
 
+The performance results below were measured on the 15% subsets, so to reproduce them point `TRACE_FILE` at the matching `*_short_15perc.jsonl` file and set `CONCURRENCY` to the value shown in your target's row. For shorter runs (smoke tests, faster iteration), point `TRACE_FILE` at a smaller variant of the same trace rather than capping run time — 15% and 30% subsets are staged alongside the full dataset:
+
+```text
+/model-cache/traces/<flavour>.jsonl                 # full
+/model-cache/traces/<flavour>_short_30perc.jsonl    # ~30% subset
+/model-cache/traces/<flavour>_short_15perc.jsonl    # ~15% subset
+```
+
+Then run the Job:
+
 ```bash
+kubectl apply -f recipes/kimi-k2.6/perf/perf.yaml -n ${NAMESPACE}
+
+# Stream logs
+kubectl logs -n ${NAMESPACE} -l job-name=kimi-k26-bench -f
+
+# Wait for completion (2h hard cap on the Job)
+kubectl wait --for=condition=Complete job/kimi-k26-bench -n ${NAMESPACE} --timeout=7200s
+```
+
+Results are written to the PVC as:
+
+```text
+/model-cache/perf/<epoch>_<job-name>/
+  warmup/
+  Kimi-K2.6_trace_c<concurrency>_<timestamp>/
+    profile_export.json
+    inputs.json
+    ...
+```
+
+Fetch them, then clean up:
+
+```bash
+kubectl cp ${NAMESPACE}/pvc-helper:/model-cache/perf/<epoch>_kimi-k26-bench ./results
+kubectl delete job kimi-k26-bench -n ${NAMESPACE}
+kubectl delete pod pvc-helper -n ${NAMESPACE}   # if you kept it around
+```
+
+`perf.yaml` runs a **single** `CONCURRENCY` value. To measure multiple concurrencies you must clear server state between runs — otherwise residual KV-cache and prefix-cache hits from the previous run skew results. Set `DGD` to the deployment you are benchmarking:
+
+<div data-sku="b200" data-engine="vllm" data-usecase="chat" data-variant="agg">
+
+```bash
+DGD=kimi-k26-agg-b200-chat
+```
+
+</div>
+
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
+
+```bash
+DGD=kimi-k26-agg-b200-agentic
+```
+
+</div>
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="agg">
+
+```bash
+DGD=kimi-k26-agg-h200-chat
+```
+
+</div>
+
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
+
+```bash
+DGD=kimi-k26-agg-h200-agentic
+```
+
+</div>
+
+Then, for each concurrency value you want to measure:
+
+```bash
+# 1. Delete the previous bench job
+kubectl delete job kimi-k26-bench -n ${NAMESPACE} --ignore-not-found
+
+# 2. Delete the DGD worker pods to drop KV / prefix-cache state.
+#    DGDs are Grove-managed (DGD -> PodCliqueSet -> PodClique -> Pod), not
+#    Deployments, so `kubectl rollout restart deployment` won't match anything —
+#    delete the pods directly and let Grove recreate them.
+kubectl delete pods -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD},nvidia.com/dynamo-component-type=worker
+kubectl wait --for=condition=Ready pod -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD},nvidia.com/dynamo-component-type=worker \
+  --timeout=900s
+
+# 3. Bump CONCURRENCY in perf.yaml (or use kubectl create -f perf.yaml with
+#    --dry-run=client -o yaml | yq '.spec.template.spec.containers[0].env[] |= ...')
 kubectl apply -f recipes/kimi-k2.6/perf/perf.yaml -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/kimi-k26-bench -n ${NAMESPACE} --timeout=7200s
 ```
 
-15% and 30% trace subsets are provided for shorter runs. To sweep concurrencies, delete the DGD worker pods between runs so residual KV-cache and prefix-cache state does not skew results — see the [benchmark README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/kimi-k2.6/perf/README.md) for the full workflow, artifact layout, and tunable environment variables.
+The bench Job's `wait_for_model_ready` loop handles the worker restart window — it re-polls `/v1/models` until the frontend reports ready again.
 
-## Expected Performance
+- For benchmarking, swap `SPECULATIVE_CONFIG` to the `speculative-config-synthetic` ConfigMap key so Eagle3 acceptance is synthetic and deterministic (AL=2.49); production deployments use the standard `speculative-config` key.
+
+## Optimization targets
 
 Each target is tuned for its workload shape at a 50 tok/s/user interactivity target:
 
 | Workload | Median ISL | Median OSL | KV cache hit rate | User output tok/s |
 | --- | ---: | ---: | ---: | ---: |
-| Chat | 1K | 1K | 70% | 50 |
+| Chat | 8K | 1K | 70% | 50 |
 | Agentic | 64K | 400 | 90% | 50 |
+
+## Performance results
 
 Measured results below were collected by replaying the **15% trace subsets** (`*_short_15perc.jsonl`) with 4 worker replicas per deployment; your selected target's row is highlighted:
 
@@ -293,27 +448,10 @@ Measured results below were collected by replaying the **15% trace subsets** (`*
 </table>
 </div>
 
-## Compare All Targets
-
-All four targets serve `moonshotai/Kimi-K2.6` on aggregated vLLM 0.21.0 with KV-aware routing, Eagle3 MLA speculative decoding (3 draft tokens), and LMCache CPU KV-cache offload. They differ in checkpoint, parallelism, kernel backends, and the trace they are benchmarked against:
-
-| | B200 chat | H200 chat | B200 agentic | H200 agentic |
-|---|---|---|---|---|
-| **GPUs per worker** | 4x B200 | 8x H200 | 4x B200 | 8x H200 |
-| **Precision** | NVFP4 + FP8 KV | INT4 (native) | NVFP4 + FP8 KV | INT4 (native) |
-| **Parallelism** | TP4 | TP8 | TP4 | TP8 |
-| **MoE backend** | FlashInfer-TRTLLM | Marlin | FlashInfer-TRTLLM | Marlin |
-| **Attention backend** | TokenSpeed MLA | FlashAttention MLA | TokenSpeed MLA | FlashAttention MLA |
-| **AllReduce** | NCCL symmetric memory | NCCL | NCCL symmetric memory | NCCL |
-| **Workload** | Chat trace | Chat trace | Agentic trace | Agentic trace |
-
-## Notes
+## Known issues
 
 - Dynamo's KV cache router does not support all LMCache KV events, so routing can be sub-optimal.
 - Some 400 HTTP errors raised by workers on invalid inputs can surface as 500 errors through the frontend.
-- B200 targets run `nvidia/Kimi-K2.6-NVFP4` with FP8 KV cache; H200 targets run the native INT4 `moonshotai/Kimi-K2.6` checkpoint. Both serve under the name `moonshotai/Kimi-K2.6`.
-- The chat- and agentic-tuned deployments for a given SKU share the same engine configuration; they are separate targets because each is benchmarked and sized against its own trace, and either trace can be replayed against either DGD.
-- For benchmarking, swap `SPECULATIVE_CONFIG` to the `speculative-config-synthetic` key so Eagle3 acceptance is synthetic and deterministic (AL=2.49); production deployments use the standard `speculative-config` key.
 
 ## Source
 

--- a/docs/fern/pages/recipes/model-recipes/kimi-k3.mdx
+++ b/docs/fern/pages/recipes/model-recipes/kimi-k3.mdx
@@ -9,7 +9,9 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-Each target below is a Dynamo + vLLM deployment of Moonshot AI's Kimi-K3 — a multimodal MoE model serving up to 1M-token context — with KV-aware routing, MXFP4-packed routed experts, and FP8 KV cache, running aggregated or with prefill/decode disaggregation on GB200 and GB300 NVL72 racks. KV transfer and tensor parallelism run over NVLink (MNNVL) using Kubernetes ComputeDomains. Pick your GPU architecture and serving topology; every command on this page updates to match.
+Each target below is a Dynamo + vLLM deployment of Moonshot AI's Kimi-K3 — a multimodal MoE model serving up to 1M-token context — with KV-aware routing, MXFP4-packed routed experts, and FP8 KV cache, running aggregated or with prefill/decode disaggregation on GB200 and GB300 NVL72 racks. Tensor parallelism runs over NVLink (MNNVL) using Kubernetes ComputeDomains, and disaggregated KV transfer moves over NIXL — over MNNVL on GB300, over RDMA InfiniBand on GB200. Pick your GPU architecture and serving topology; every command on this page updates to match.
+
+K3 is a hybrid-attention MoE model: 93 layers of Kimi Delta Attention (KDA, linear attention with a short convolution state) with full MLA attention on 24 of them (every fourth layer), 896 routed experts (16 active per token) plus 2 shared experts, a vision tower for image input, and 1,048,576 max positions. Routed-expert weights are MXFP4-packed (`compressed-tensors`, group size 32); attention, shared experts, `lm_head`, and the vision tower stay BF16.
 
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
@@ -21,48 +23,104 @@ Each target below is a Dynamo + vLLM deployment of Moonshot AI's Kimi-K3 — a m
 <label htmlFor="recipe-sku-gb300">GB300</label>
 </div>
 <div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-agentic" name="recipe-usecase" value="agentic" defaultChecked />
+<label htmlFor="recipe-usecase-agentic">Agentic</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-vllm" name="recipe-engine" value="vllm" defaultChecked />
+<label htmlFor="recipe-engine-vllm">vLLM</label>
+</div>
+<div className="dynamo-target-picker-row">
 <span className="dynamo-target-picker-dim">Topology</span>
 <input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" defaultChecked />
 <label htmlFor="recipe-variant-agg">Aggregated</label>
 <input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" />
 <label htmlFor="recipe-variant-disagg">Disaggregated</label>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="gb200" data-variant="agg">
+<div className="dynamo-target-picker-summary" data-sku="gb200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> moonshotai/Kimi-K3</span>
-<span><b>Precision</b> MXFP4 experts + BF16 dense, FP8 KV</span>
-<span><b>GPUs</b> 16x GB200 (4 nodes), one worker</span>
-<span><b>Parallelism</b> TP16 over MNNVL</span>
+<span><b>Precision</b> MXFP4 + BF16, FP8 KV</span>
+<span><b>GPUs</b> 16x GB200 (4 nodes)</span>
+<span><b>Workers</b> 1</span>
+<span><b>Parallelism</b> TP16</span>
 <span><b>Routing</b> KV-aware</span>
+<span><b>Attention</b> `FLASHINFER_MLA`, `TRTLLM_RAGGED` MLA prefill with prefill query quantization</span>
+<span><b>MoE backend</b> `flashinfer_trtllm`</span>
+<span><b>AllReduce backend</b> FlashInfer MNNVL</span>
+<span><b>CUDA graphs</b> `FULL_AND_PIECEWISE`, capture up to 8192</span>
+<span><b>Batching</b> 16384 batched tokens / 256 seqs</span>
+<span><b>GPU memory util</b> 0.92</span>
+<span><b>Max context</b> 1,048,576 (model default)</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="gb200" data-variant="disagg">
+<div className="dynamo-target-picker-summary" data-sku="gb200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 <span><b>Checkpoint</b> moonshotai/Kimi-K3</span>
-<span><b>Precision</b> MXFP4 experts + BF16 dense, FP8 KV</span>
-<span><b>GPUs</b> 16x GB200 prefill + 16x GB200 decode (1P1D)</span>
-<span><b>Parallelism</b> TP16 / TP16 over MNNVL</span>
+<span><b>Precision</b> MXFP4 + BF16, FP8 KV</span>
+<span><b>GPUs</b> 16x prefill + 16x decode</span>
+<span><b>Workers</b> 1P + 1D</span>
+<span><b>Parallelism</b> TP16 / TP16</span>
 <span><b>Routing</b> KV-aware, NIXL KV transfer over RDMA</span>
+<span><b>KV transfer</b> NIXL (`NixlConnector`, `kv_both`) over RDMA (IB); `UCX_TLS=^cuda_ipc`</span>
+<span><b>Attention</b> `FLASHINFER_MLA`; `TRTLLM_RAGGED` on prefill, `FLASHINFER` on decode</span>
+<span><b>MoE backend</b> `flashinfer_trtllm`</span>
+<span><b>AllReduce backend</b> NCCL (MNNVL + NVLS)</span>
+<span><b>CUDA graphs</b> `FULL_AND_PIECEWISE`, capture up to 2048 on decode</span>
+<span><b>Batching</b> 16384 tokens / 4 seqs prefill; 2048 tokens / 256 seqs decode</span>
+<span><b>GPU memory util</b> 0.90</span>
+<span><b>Max context</b> 1,048,576 (model default)</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="gb300" data-variant="agg">
+<div className="dynamo-target-picker-summary" data-sku="gb300" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> moonshotai/Kimi-K3</span>
-<span><b>Precision</b> MXFP4 experts + BF16 dense, FP8 KV</span>
-<span><b>GPUs</b> 16x GB300 — two 8-GPU replicas</span>
-<span><b>Parallelism</b> TP8 per replica, KV-routed</span>
+<span><b>Precision</b> MXFP4 + BF16, FP8 KV</span>
+<span><b>GPUs</b> 16x GB300 (2 replicas)</span>
+<span><b>Workers</b> 2 (KV-routed)</span>
+<span><b>Parallelism</b> TP8 per replica</span>
 <span><b>Routing</b> KV-aware across replicas</span>
+<span><b>Attention</b> `FLASHINFER_MLA`, `TRTLLM_RAGGED` MLA prefill with prefill query quantization</span>
+<span><b>MoE backend</b> trtllm-gen cubins + K3 latent-MoE tail fusion (CuTeDSL)</span>
+<span><b>AllReduce backend</b> FlashInfer MNNVL</span>
+<span><b>CUDA graphs</b> `FULL_AND_PIECEWISE`, capture up to 8192</span>
+<span><b>Batching</b> 8192 batched tokens / 256 seqs</span>
+<span><b>GPU memory util</b> 0.85</span>
+<span><b>Max context</b> 1,048,576 (explicit `--max-model-len`)</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="gb300" data-variant="disagg">
+<div className="dynamo-target-picker-summary" data-sku="gb300" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 <span><b>Checkpoint</b> moonshotai/Kimi-K3</span>
-<span><b>Precision</b> MXFP4 experts + BF16 dense, FP8 KV</span>
-<span><b>GPUs</b> 8x GB300 prefill + 16x GB300 decode (1P2D)</span>
-<span><b>Parallelism</b> TP8 per replica over MNNVL</span>
+<span><b>Precision</b> MXFP4 + BF16, FP8 KV</span>
+<span><b>GPUs</b> 8x prefill + 16x decode</span>
+<span><b>Workers</b> 1P + 2D</span>
+<span><b>Parallelism</b> TP8 per replica</span>
 <span><b>Routing</b> KV-aware, NIXL/MNNVL KV transfer</span>
+<span><b>KV transfer</b> NIXL (`NixlConnector`, `kv_both`) over MNNVL; UCX left at defaults</span>
+<span><b>Attention</b> `FLASHINFER_MLA`, `TRTLLM_RAGGED` MLA prefill with prefill query quantization, on both roles</span>
+<span><b>MoE backend</b> trtllm-gen cubins; tail fusion on decode only</span>
+<span><b>AllReduce backend</b> FlashInfer MNNVL</span>
+<span><b>CUDA graphs</b> `FULL_DECODE_ONLY`, capture up to 2048 on decode; prefill runs eager</span>
+<span><b>Batching</b> 32768 tokens / 4 seqs prefill; 2048 tokens / 256 seqs decode</span>
+<span><b>GPU memory util</b> 0.90</span>
+<span><b>Max context</b> 1,048,576 (model default)</span>
 </div>
 </div>
+
+## Configurations
+
+All four targets serve Kimi-K3 on vLLM with FP8 KV cache, KV-aware routing, and prefix caching, with tensor parallelism over NVLink (MNNVL). The target picker at the top of this page carries the full per-target configuration.
+
+## Supported features
+
+- Modalities: text and image (`--enable-multimodal`; K3 ships a vision tower)
+- Reasoning, through the `kimi_k3` reasoning parser on both the engine and the frontend side
+- Tool calling, through the `kimi_k3` tool-call parser
+- KV-aware routing and prefix caching on every profile
+- Disaggregated serving
 
 ## Prerequisites
 
 <div data-sku="gb200">
 
 - A Kubernetes cluster with the Dynamo platform installed and GB200 GPUs available — 16x (4 nodes) for aggregated, 32x (8 nodes, 4 prefill + 4 decode) for disaggregated. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
-- The NVIDIA DRA driver with ComputeDomain support installed (required for multi-node NVLink).
+- Every profile spans multiple 4-GPU nodes over MNNVL — TP16 across four nodes on GB200 — so the tensor-parallel group crosses the node boundary on NVLink, which is why every worker pod set claims a DRA `ComputeDomain` channel.
 - A Hugging Face token with access to `moonshotai/Kimi-K3`.
 
 </div>
@@ -70,10 +128,129 @@ Each target below is a Dynamo + vLLM deployment of Moonshot AI's Kimi-K3 — a m
 <div data-sku="gb300">
 
 - A Kubernetes cluster with the Dynamo platform installed and GB300 GPUs available — 16x (4 nodes) for aggregated, 24x (6 nodes) for disaggregated. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
-- The NVIDIA DRA driver with ComputeDomain support installed (required for multi-node NVLink).
-- A Hugging Face token with access to `moonshotai/Kimi-K3`.
+- Every profile spans multiple 4-GPU nodes over MNNVL — TP8 across two nodes on GB300 — so the tensor-parallel group crosses the node boundary on NVLink, which is why every worker pod set claims a DRA `ComputeDomain` channel.
+- A Hugging Face token with access to `moonshotai/Kimi-K3`. The workers read the weights from the `model-cache` PVC — see [Download the model](#3-download-the-model).
 
 </div>
+
+The NVIDIA DRA driver with ComputeDomain support provides that channel. Confirm the CRD is installed:
+
+```bash
+kubectl get crd | grep computedomain
+```
+
+Each manifest creates its own `ComputeDomain` and its workers claim that domain's channel. The names vary by profile — check the `metadata.name` fields in the `deploy.yaml` you are applying.
+
+## Cluster assumptions
+
+These manifests are written against a specific cluster shape per SKU, with a ReadWriteMany storage class for the weights. Every value below is expected to differ elsewhere; nothing outside this section is cluster-specific.
+
+<div data-sku="gb200">
+
+| Assumption | Where | Shipped value |
+| ---------- | ----- | ------------- |
+| GPU nodes carry a product label | `nodeSelector` on every pod | `NVIDIA-GB200` |
+| Pool taint | `tolerations` | `kubernetes.io/arch=arm64:NoSchedule` |
+| GPUs per node x nodes per TP group | `resources` and `multinode.nodeCount` | 4 GPUs x 4 nodes = TP16 |
+| A ReadWriteMany storage class exists for the weights | `model-cache/model-cache.yaml` | `your-storage-class-name` placeholder (PVC flow only) |
+
+</div>
+
+<div data-sku="gb300">
+
+| Assumption | Where | Shipped value |
+| ---------- | ----- | ------------- |
+| GPU nodes carry a product label | `nodeAffinity` on every worker | `NVIDIA-GB300` |
+| Pool taint | `tolerations` | none |
+| GPUs per node x nodes per TP group | `resources` and `multinode.nodeCount` | 4 GPUs x 2 nodes = TP8 |
+| A ReadWriteMany storage class exists for the weights | `model-cache/model-cache.yaml` | `your-storage-class-name` placeholder |
+
+</div>
+
+### Reading the values off your cluster
+
+<div data-sku="gb200">
+
+Read the values off your cluster:
+
+```bash
+# Which product label identifies the GPUs?
+kubectl get nodes -o custom-columns='NODE:.metadata.name,PRODUCT:.metadata.labels.nvidia\.com/gpu\.product'
+
+# Set this to whatever the command above reports, then reuse it below.
+export GPU_PRODUCT=NVIDIA-GB200
+
+# Allocatable GPUs per node, then any taints as key=value:effect.
+kubectl get nodes -l nvidia.com/gpu.product=${GPU_PRODUCT} \
+  -o go-template='{{range .items}}{{.metadata.name}}{{"\t"}}{{index .status.allocatable "nvidia.com/gpu"}}{{"\t"}}{{range .spec.taints}}{{.key}}={{.value}}:{{.effect}} {{end}}{{"\n"}}{{end}}'
+
+# Available storage classes — pick one whose provisioner supports ReadWriteMany
+# (a network filesystem, not block storage).
+kubectl get storageclass
+```
+
+If the product label differs from the shipped value, update the `nodeSelector` value in each `deploy.yaml`. If the first command reports no GPU nodes at all, the recipe has nothing to land on.
+
+</div>
+
+<div data-sku="gb300">
+
+Read the values off your cluster:
+
+```bash
+# Which product label identifies the GPUs?
+kubectl get nodes -o custom-columns='NODE:.metadata.name,PRODUCT:.metadata.labels.nvidia\.com/gpu\.product'
+
+# Set this to whatever the command above reports, then reuse it below.
+export GPU_PRODUCT=NVIDIA-GB300
+
+# Allocatable GPUs per node, then any taints as key=value:effect.
+kubectl get nodes -l nvidia.com/gpu.product=${GPU_PRODUCT} \
+  -o go-template='{{range .items}}{{.metadata.name}}{{"\t"}}{{index .status.allocatable "nvidia.com/gpu"}}{{"\t"}}{{range .spec.taints}}{{.key}}={{.value}}:{{.effect}} {{end}}{{"\n"}}{{end}}'
+
+# Available storage classes — pick one whose provisioner supports ReadWriteMany
+# (a network filesystem, not block storage).
+kubectl get storageclass
+```
+
+If the product label differs from the shipped value, update the `nodeAffinity` `values` list in each `deploy.yaml`. If the first command reports no GPU nodes at all, the recipe has nothing to land on.
+
+</div>
+
+### Tainted GPU pools
+
+<div data-sku="gb200">
+
+The GB200 manifests include a `kubernetes.io/arch=arm64:NoSchedule` toleration for the arm64 node pool.
+
+</div>
+
+<div data-sku="gb300">
+
+The GB300 manifests ship with no tolerations, which assumes an unreserved GPU pool.
+
+</div>
+
+If your GPU pool carries additional taints, add matching tolerations to **every** pod template in the `deploy.yaml` you are using:
+
+```yaml
+# In each podTemplate.spec
+tolerations:
+  - key: dedicated          # from the key=value:effect output above
+    operator: Equal
+    value: your-pool-name
+    effect: NoSchedule
+```
+
+To cover several pools at once, use `operator: Exists` with the key and drop `value`. Keep `effect: NoSchedule`: a bare `operator: Exists` with no key also tolerates `NoExecute` and `node.kubernetes.io/unschedulable`, which would schedule pods onto cordoned nodes and ignore eviction taints.
+
+<Note>
+A toleration only permits placement, it does not attract it — node selection stays with the node affinity or selector above. Adding one widens the candidate set to include reserved pools, so check that the pool is yours to consume.
+</Note>
+
+## Quick Start
+
+### 1. Create namespace and secret
 
 Create the namespace and token secret:
 
@@ -85,17 +262,19 @@ kubectl create secret generic hf-token-secret \
   -n ${NAMESPACE}
 ```
 
+### 2. Create storage
+
 <Warning>
-If you use the `model-cache` PVC (required on GB300, optional on GB200), edit `storageClassName` in `model-cache/model-cache.yaml` to a ReadWriteMany storage class on your cluster (`kubectl get storageclass`) before applying it. Review namespace, image tags, node selectors, and resource claims in the manifests as well.
+If you use the `model-cache` PVC (required on GB300, optional on GB200), edit `storageClassName` in `model-cache/model-cache.yaml` to a ReadWriteMany storage class on your cluster (`kubectl get storageclass`) before applying it. The claim requests 3000Gi; the checkpoint is ~1.5 TB. Review namespace, image tags, node selectors, and resource claims in the manifests as well — see [Cluster assumptions](#cluster-assumptions).
 </Warning>
 
-## Deploy
+### 3. Download the model
 
 The two SKUs source the checkpoint differently, so follow the block for your target.
 
 <div data-sku="gb300">
 
-The GB300 manifests read the checkpoint from a `model-cache` PVC (`HF_HOME=/model-cache`, `--model moonshotai/Kimi-K3`). Create the cache and download the weights:
+The GB300 manifests read the checkpoint from a `model-cache` PVC: each worker pod mounts it at `/model-cache` with `HF_HOME=/model-cache` and passes the repo id (`MODEL_ID=moonshotai/Kimi-K3`) to `--model`, so vLLM loads the checkpoint out of the cache instead of downloading it. `envFrom: hf-token-secret` on the workers covers the hub lookup at startup, and the frontend does not mount the PVC. Create the cache and download the weights:
 
 ```bash
 # Edit storageClassName in model-cache/model-cache.yaml first.
@@ -104,6 +283,8 @@ kubectl apply -f recipes/kimi-k3/model-cache/model-download.yaml -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=14400s
 ```
 
+The Job sets `HF_HOME=/model-cache`, so the checkpoint lands in the PVC's Hugging Face cache — which is why the workers resolve the repo id straight out of it.
+
 </div>
 
 <div data-sku="gb200">
@@ -111,7 +292,7 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 The GB200 manifests read the checkpoint from node-local storage, not the `model-cache` PVC: they mount the host path `/mnt/stateful_partition/kube-ephemeral-ssd/models` (a GKE layout) at `/models` and serve `--model /models/model_weight` with `HF_HUB_OFFLINE=1`. Pick one of:
 
 - **Pre-stage the weights on every GB200 node** in the deployment at `<host-path>/model_weight`, then edit the `models` `hostPath` in the deploy manifest to match your cluster's path.
-- **Switch the manifest to the PVC flow** used by the GB300 recipes: create the cache and run the download job below, then in the deploy manifest replace the `models` `hostPath` volume with a `persistentVolumeClaim` (`claimName: model-cache`) mounted at `/model-cache`, add `HF_HOME=/model-cache`, and set `MODEL_PATH` to `moonshotai/Kimi-K3`.
+- **Switch the manifest to the PVC flow** used by the GB300 recipes: create the cache and run the download job below — the Job sets `HF_HOME=/model-cache`, so the checkpoint lands in the PVC's Hugging Face cache — then in the deploy manifest replace the `models` `hostPath` volume with a `persistentVolumeClaim` (`claimName: model-cache`) mounted at `/model-cache`, add `HF_HOME=/model-cache`, and set `MODEL_PATH` to `moonshotai/Kimi-K3`.
 
 ```bash
 # PVC flow only. Edit storageClassName in model-cache/model-cache.yaml first.
@@ -122,64 +303,87 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 
 </div>
 
-Then deploy the target DGD:
+### 4. Deploy the DGD
 
-<div data-sku="gb200" data-variant="agg">
+Then deploy the target DGD and wait for its pods to report Ready:
+
+<div data-sku="gb200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/kimi-k3/vllm/agg-gb200-agentic/deploy.yaml -n ${NAMESPACE}
+
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=kimi-k3-agg \
+  -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
-<div data-sku="gb200" data-variant="disagg">
+<div data-sku="gb200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/kimi-k3/vllm/disagg-gb200-agentic/deploy.yaml -n ${NAMESPACE}
+
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=kimi-k3-disagg \
+  -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
-<div data-sku="gb300" data-variant="agg">
+<div data-sku="gb300" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/kimi-k3/vllm/agg-gb300-agentic/deploy.yaml -n ${NAMESPACE}
+
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=kimi-k3-agg \
+  -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
-<div data-sku="gb300" data-variant="disagg">
+<div data-sku="gb300" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/kimi-k3/vllm/disagg-gb300-agentic/deploy.yaml -n ${NAMESPACE}
+
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=kimi-k3-disagg \
+  -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
-First worker launch loads weights and captures CUDA graphs and can take tens of minutes.
+First launch loads ~1.5 TB of weights across the TP ranks and warms CuTeDSL kernels and CUDA graphs. The startup probes budget 120 minutes per worker (`failureThreshold: 720`), and the multinode pod set only reports Ready once all nodes have joined the TP group.
 
-## Smoke Test
+<div data-sku="gb200">
+
+The shipped GB200 manifests keep the checkpoint on node-local storage, which avoids the shared-filesystem cost. On the PVC conversion path, every worker pod pulls the full ~1.5 TB checkpoint over the PVC on each cold start, so first-load time is bounded by the storage backend rather than by the GPUs — raise `failureThreshold` if your storage class is slower, and keep the pods on nodes that already hold a warm page cache.
+
+</div>
+
+<div data-sku="gb300" data-engine="vllm" data-usecase="agentic" data-variant="agg">
+
+Serving ~1.5 TB of weights off a shared filesystem is the slow path: every worker pod pulls the full checkpoint over the PVC on each cold start — 4 pods for the aggregated profile — so first-load time is bounded by the storage backend rather than by the GPUs. Raise `failureThreshold` if your storage class is slower. Keeping the pods on nodes that already hold a warm page cache, or staging the checkpoint on node-local NVMe and mounting it as a `hostPath` instead, both cut this substantially.
+
+</div>
+
+<div data-sku="gb300" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
+
+Serving ~1.5 TB of weights off a shared filesystem is the slow path: every worker pod pulls the full checkpoint over the PVC on each cold start — 6 pods for the disaggregated profile — so first-load time is bounded by the storage backend rather than by the GPUs. Raise `failureThreshold` if your storage class is slower. Keeping the pods on nodes that already hold a warm page cache, or staging the checkpoint on node-local NVMe and mounting it as a `hostPath` instead, both cut this substantially.
+
+</div>
+
+<Note>
+The containers run as `runAsUser: 0` because the cached weight files are root-owned while the image defaults to uid 1000.
+</Note>
+
+### 5. Smoke test
 
 Send a test request to verify the deployment serves traffic. First forward the frontend port for your target:
 
-
-<div data-sku="gb200" data-variant="agg">
-
-```bash
-kubectl port-forward svc/kimi-k3-agg-frontend 8000:8000 -n ${NAMESPACE}
-```
-
-</div>
-
-<div data-sku="gb200" data-variant="disagg">
-
-```bash
-kubectl port-forward svc/kimi-k3-disagg-frontend 8000:8000 -n ${NAMESPACE}
-```
-
-</div>
-
-<div data-sku="gb300" data-variant="agg">
+<div data-sku="gb200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/kimi-k3-agg-frontend 8000:8000 -n ${NAMESPACE}
@@ -187,7 +391,7 @@ kubectl port-forward svc/kimi-k3-agg-frontend 8000:8000 -n ${NAMESPACE}
 
 </div>
 
-<div data-sku="gb300" data-variant="disagg">
+<div data-sku="gb200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 
 ```bash
 kubectl port-forward svc/kimi-k3-disagg-frontend 8000:8000 -n ${NAMESPACE}
@@ -195,36 +399,137 @@ kubectl port-forward svc/kimi-k3-disagg-frontend 8000:8000 -n ${NAMESPACE}
 
 </div>
 
-All targets serve under the same model name, `moonshotai/Kimi-K3`:
+<div data-sku="gb300" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
-curl http://localhost:8000/v1/chat/completions \
+kubectl port-forward svc/kimi-k3-agg-frontend 8000:8000 -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="gb300" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
+
+```bash
+kubectl port-forward svc/kimi-k3-disagg-frontend 8000:8000 -n ${NAMESPACE}
+```
+
+</div>
+
+All targets serve under the same model name, `moonshotai/Kimi-K3`.
+
+#### Text
+
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -d '{"model":"moonshotai/Kimi-K3","messages":[{"role":"user","content":"Write a one-sentence readiness check."}],"max_tokens":64}'
+  -d '{
+    "model": "moonshotai/Kimi-K3",
+    "messages": [{"role": "user", "content": "Hello, who are you?"}],
+    "max_tokens": 128
+  }'
 ```
 
-Kimi-K3 reasons before answering, and tool calling is supported — the deployment uses the `kimi_k3` reasoning and tool-call parsers at the frontend.
+Chain-of-thought lands in `choices[0].message.reasoning_content` and the answer in `choices[0].message.content`. If `reasoning_content` is `null` and raw `</think>` markers show up in `content`, the parsers are not wired — check `--reasoning-parser kimi_k3` and `--dyn-reasoning-parser kimi_k3` on the worker command.
 
-## Compare All Targets
+#### Image
 
-All four targets serve Kimi-K3 on vLLM with FP8 KV cache, KV-aware routing, prefix caching, and the FlashInfer TRT-LLM MoE backend, with tensor parallelism over NVLink (MNNVL):
+Images are sent as `image_url` content parts. Use a public HTTP(S) URL the deployment can fetch, or a base64 `data:` URI on air-gapped clusters.
 
-| | GB200 aggregated | GB200 disaggregated | GB300 aggregated | GB300 disaggregated |
-|---|---|---|---|---|
-| **GPUs** | 16x GB200 (4 nodes) | 16x prefill + 16x decode | 16x GB300 (2 replicas) | 8x prefill + 16x decode |
-| **Workers** | 1 | 1P + 1D | 2 (KV-routed) | 1P + 2D |
-| **Parallelism** | TP16 | TP16 / TP16 | TP8 per replica | TP8 per replica |
-| **KV transfer** | — | NIXL over RDMA (IB) | — | NIXL over MNNVL |
-| **Attention** | FlashInfer MLA | FlashInfer MLA | FlashInfer MLA | FlashInfer MLA |
-| **Precision** | MXFP4 + BF16, FP8 KV | MXFP4 + BF16, FP8 KV | MXFP4 + BF16, FP8 KV | MXFP4 + BF16, FP8 KV |
-| **Max context** | 1,048,576 | 1,048,576 | 1,048,576 | 1,048,576 |
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "moonshotai/Kimi-K3",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "image_url", "image_url": {"url": "https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/cats.jpg"}},
+        {"type": "text", "text": "Describe what is in this image."}
+      ]
+    }],
+    "max_tokens": 512
+  }'
+```
 
-## Notes
+#### Tool calling
 
-- All targets use KV-aware routing at the Dynamo frontend with prefix caching and KV events enabled.
-- Kimi-K3 is multimodal — the deployments enable the multimodal encoder (`--enable-multimodal`) with data-parallel encoder sharding.
-- Multi-node tensor parallelism runs over NVLink (MNNVL) via Kubernetes ComputeDomains (DRA). Disaggregated KV transfer uses NIXL — over NVLink on GB300, over RDMA InfiniBand on GB200 (`UCX_TLS=^cuda_ipc`, GKE `rdma-*` network resources).
-- Kimi-K3 support requires the updated Dynamo frontend (tokenizer, `kimi_k3` reasoning and tool-call parsers) that ships with this release.
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "moonshotai/Kimi-K3",
+    "messages": [{"role": "user", "content": "What is the weather in San Francisco?"}],
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a location",
+        "parameters": {
+          "type": "object",
+          "properties": {"location": {"type": "string", "description": "City name"}},
+          "required": ["location"]
+        }
+      }
+    }],
+    "max_tokens": 300
+  }' | python3 -m json.tool
+```
+
+Expected: `choices[0].message.tool_calls[0].function.name` is `get_weather` with JSON arguments naming San Francisco, and `finish_reason` is `tool_calls`.
+
+## Configuration notes
+
+- Kimi-K3 is multimodal — every profile enables the vision tower with `--enable-multimodal`.
+- **KV routing.** Every profile runs the frontend with `--router-mode kv` and enables prefix caching, and every worker publishes KV cache events (`--kv-events-config`, `enable_kv_cache_events: true`).
+- **Frontend build.** Kimi-K3 support requires the updated Dynamo frontend (tokenizer, `kimi_k3` reasoning and tool-call parsers) that ships with this release — every manifest pins the dev image `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0-kimi-k3-dev.1`.
+- Multi-node tensor parallelism runs over NVLink (MNNVL) via Kubernetes ComputeDomains (DRA).
+- **Pod networking.** DGD pods use CNI networking, so `NCCL_SOCKET_IFNAME` and `GLOO_SOCKET_IFNAME` are pinned to `eth0`.
+
+<div data-sku="gb200">
+
+- **Multimodal encoder.** The GB200 profiles shard the vision encoder data-parallel with `--mm-encoder-tp-mode data` and run it on `--mm-encoder-attn-backend TORCH_SDPA`. The GB300 profiles leave both at their defaults.
+- **Event-driven KV routing.** The GB200 frontend adds `--router-kv-events` (with `--router-temperature 0`, `--router-min-initial-workers 1`, and `--kv-cache-block-size 64`) so routing tracks the workers' published KV events. The GB300 frontends run `--router-mode kv` without the event feed.
+
+</div>
+
+<div data-sku="gb200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
+
+- **MNNVL all-reduce.** The GB200 aggregated profile sets `VLLM_ALLREDUCE_USE_FLASHINFER=1` with `VLLM_FLASHINFER_ALLREDUCE_BACKEND=mnnvl`. Do not enable the NCCL symmetric-memory knobs alongside it — `VLLM_USE_NCCL_SYMM_MEM=0` is required because symmetric memory breaks CUDA-graph capture on this build.
+
+</div>
+
+<div data-sku="gb200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
+
+- **All-reduce.** The GB200 disaggregated profile uses NCCL directly (MNNVL + NVLS) instead of FlashInfer. `VLLM_USE_NCCL_SYMM_MEM=0` is still required, because symmetric memory breaks CUDA-graph capture on this build.
+- **UCX.** `UCX_TLS=^cuda_ipc` disables NVLink IPC so NIXL KV transfer routes over RDMA InfiniBand, allocated via `networking.gke.io.networks/rdma-*` resources.
+- **Asymmetric worker config.** Prefill and decode carry separate attention configs — `TRTLLM_RAGGED` MLA prefill on the prefill worker, `FLASHINFER` on decode — and both roles use `FULL_AND_PIECEWISE` graphs, captured up to 2048 on decode.
+
+</div>
+
+<div data-sku="gb300">
+
+- **MNNVL all-reduce.** The GB300 profiles set `VLLM_ALLREDUCE_USE_FLASHINFER=1` with `VLLM_FLASHINFER_ALLREDUCE_BACKEND=mnnvl`. Do not enable the NCCL symmetric-memory knobs alongside it — `VLLM_USE_NCCL_SYMM_MEM=0` is required because symmetric memory breaks CUDA-graph capture on this build.
+- **Cubins.** `FLASHINFER_PRIVATE_CUBIN_DIR` points at the trtllm-gen MoE cubins bundled in the image, with `CUDA_HOME=/usr/local/cuda` for JIT.
+
+</div>
+
+<div data-sku="gb300" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
+
+- **UCX.** The GB300 disaggregated profile leaves UCX at its defaults for the NIXL transport.
+- **Asymmetric worker config.** Prefill runs `--enforce-eager` (no CUDA graphs) while decode captures `FULL_DECODE_ONLY` graphs up to 2048.
+
+</div>
+
+<div data-variant="disagg">
+
+- **KDA state transfer.** The disaggregated profiles set `VLLM_SSM_CONV_STATE_LAYOUT=DS` — the Mamba-style conv state needs the DS layout to move across NIXL.
+
+</div>
+
+## Known issues
+
+- Known issue — `dynamo.vllm`'s `InstrumentedScheduler.schedule(self)` is stale against this vLLM build's `schedule(self, throttle_prefills=False)` and raises a `TypeError` on the first request. Every profile works around it by forcing vLLM's native `AsyncScheduler` with `--scheduler-cls vllm.v1.core.sched.async_scheduler.AsyncScheduler`, which gives up Dynamo scheduler instrumentation. Remove the override once the image carries a fix.
+- Known issue — every worker replica loads its own copy of the ~1.5 TB checkpoint on every cold start, with no shared or streamed loading between them. That makes pod restarts expensive, which matters most for benchmark sweeps that restart workers between concurrency points to reset prefix-cache state.
 
 ## Source
 

--- a/docs/fern/pages/recipes/model-recipes/llama-3-3-70b-fp8.mdx
+++ b/docs/fern/pages/recipes/model-recipes/llama-3-3-70b-fp8.mdx
@@ -9,10 +9,25 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-Three validated vLLM topologies for `RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic` — aggregated TP4, single-node prefill/decode split, and two-node prefill/decode — all benchmarked with the same 8K ISL / 1K OSL traffic at 16 concurrency per GPU so you can compare normalized TPS/GPU across footprints. Pick your topology; every command on this page updates to match.
+Production-ready deployments of `RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic` using vLLM with FP8 dynamic quantization, in three configurations — aggregated TP4 on one node, prefill/decode separation on one node, and disaggregated across two nodes of 8 GPUs each. All three are benchmarked with the same 8K ISL / 1K OSL traffic at 16 concurrency per GPU, so you can compare normalized TPS/GPU across footprints. Pick your GPU, workload, backend, and topology; every command on this page updates to match.
 
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">GPU</span>
+<input type="radio" id="recipe-sku-hopper" name="recipe-sku" value="hopper" defaultChecked />
+<label htmlFor="recipe-sku-hopper">H100 / H200</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-static" name="recipe-usecase" value="static" defaultChecked />
+<label htmlFor="recipe-usecase-static">Static synthetic</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-vllm" name="recipe-engine" value="vllm" defaultChecked />
+<label htmlFor="recipe-engine-vllm">vLLM</label>
+</div>
 <div className="dynamo-target-picker-row">
 <span className="dynamo-target-picker-dim">Topology</span>
 <input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" />
@@ -22,50 +37,80 @@ Three validated vLLM topologies for `RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic
 <input type="radio" id="recipe-variant-disagg-multi-node" name="recipe-variant" value="disagg-multi-node" />
 <label htmlFor="recipe-variant-disagg-multi-node">Disagg multi-node (16 GPU)</label>
 </div>
-<div className="dynamo-target-picker-summary" data-variant="agg">
+<div className="dynamo-target-picker-summary" data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="agg">
 <span><b>Checkpoint</b> RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic</span>
 <span><b>Precision</b> FP8 dynamic</span>
-<span><b>GPUs</b> 4x H100/H200, one TP4 worker</span>
-<span><b>Techniques</b> Aggregated serving</span>
-<span><b>Workload</b> 8K ISL / 1K OSL, 64 concurrency</span>
+<span><b>Backend</b> vLLM</span>
+<span><b>GPUs</b> 4x H100/H200</span>
+<span><b>Techniques</b> Aggregated serving, single-node TP4</span>
+<span><b>Workload</b> Static synthetic, 8K ISL / 1K OSL, 64 concurrency</span>
+<span><b>Nodes</b> 1</span>
+<span><b>Mode</b> Aggregated</span>
+<span><b>Workers</b> 1x TP4</span>
+<span><b>Details</b> Single-node, TP4</span>
+<span><b>Total concurrency</b> 64</span>
 </div>
-<div className="dynamo-target-picker-summary" data-variant="disagg-single-node">
+<div className="dynamo-target-picker-summary" data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="disagg-single-node">
 <span><b>Checkpoint</b> RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic</span>
 <span><b>Precision</b> FP8 dynamic</span>
-<span><b>GPUs</b> 8x H100/H200: 2x TP2 prefill + 1x TP4 decode</span>
-<span><b>Techniques</b> Disaggregated P/D over NIXL</span>
-<span><b>Workload</b> 8K ISL / 1K OSL, 128 concurrency</span>
+<span><b>Backend</b> vLLM</span>
+<span><b>GPUs</b> 8x H100/H200</span>
+<span><b>Techniques</b> Disaggregated P/D over NIXL, prefill/decode separation on one node</span>
+<span><b>Workload</b> Static synthetic, 8K ISL / 1K OSL, 128 concurrency</span>
+<span><b>Nodes</b> 1</span>
+<span><b>Mode</b> Disaggregated</span>
+<span><b>Workers</b> 2x TP2 prefill + 1x TP4 decode</span>
+<span><b>Details</b> Prefill/decode separation on one node</span>
+<span><b>Total concurrency</b> 128</span>
 </div>
-<div className="dynamo-target-picker-summary" data-variant="disagg-multi-node">
+<div className="dynamo-target-picker-summary" data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="disagg-multi-node">
 <span><b>Checkpoint</b> RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic</span>
 <span><b>Precision</b> FP8 dynamic</span>
-<span><b>GPUs</b> 16x H100/H200: 1x TP8 prefill + 1x TP8 decode</span>
-<span><b>Techniques</b> Disaggregated P/D over NIXL</span>
-<span><b>Workload</b> 8K ISL / 1K OSL, 256 concurrency</span>
+<span><b>Backend</b> vLLM</span>
+<span><b>GPUs</b> 16x H100/H200</span>
+<span><b>Techniques</b> Disaggregated P/D over NIXL, 2 nodes with 8 GPUs each</span>
+<span><b>Workload</b> Static synthetic, 8K ISL / 1K OSL, 256 concurrency</span>
+<span><b>Nodes</b> 2</span>
+<span><b>Mode</b> Disaggregated</span>
+<span><b>Workers</b> 1x TP8 prefill + 1x TP8 decode</span>
+<span><b>Details</b> 2 nodes, 8 GPUs each</span>
+<span><b>Total concurrency</b> 256</span>
 </div>
 </div>
+
+## Available Configurations
+
+All three targets serve `RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic` with vLLM and FP8 dynamic quantization on the vLLM runtime image (`nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0`), and are benchmarked at 16 concurrency per GPU with 8K ISL / 1K OSL traffic.
+
+GPU class (H100/H200), workload (static synthetic), and backend (vLLM) are the same for every target, so those rows of the picker each offer a single option — topology is the only choice that changes the commands below.
 
 ## Prerequisites
 
-<div data-variant="agg">
+<div data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="agg">
 
-- A Kubernetes cluster with the Dynamo platform installed and **4x H100 or H200** available on one node.
-
-</div>
-
-<div data-variant="disagg-single-node">
-
-- A Kubernetes cluster with the Dynamo platform installed and **8x H100 or H200** available on one node.
+- A Kubernetes cluster with the Dynamo platform installed and **4x H100 or H200** available on one node — see the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 
 </div>
 
-<div data-variant="disagg-multi-node">
+<div data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="disagg-single-node">
 
-- A Kubernetes cluster with the Dynamo platform installed and **16x H100 or H200** available across two nodes.
+- A Kubernetes cluster with the Dynamo platform installed and **8x H100 or H200** available on one node — see the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 
 </div>
 
-- A Hugging Face token with access to `RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic`.
+<div data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="disagg-multi-node">
+
+- A Kubernetes cluster with the Dynamo platform installed and **16x H100 or H200** available across two nodes — see the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
+
+</div>
+
+- A Hugging Face token with access to Llama models (`RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic`).
+
+<Warning>
+Update `storageClassName` in `model-cache/model-cache.yaml` to match your cluster, and edit namespace, image tags, node selectors, and Hugging Face secrets before applying these manifests. Model download takes approximately 15-30 minutes depending on network speed.
+</Warning>
+
+## Quick Start
 
 Create the namespace and token secret:
 
@@ -77,51 +122,45 @@ kubectl create secret generic hf-token-secret \
   -n ${NAMESPACE}
 ```
 
-<Warning>
-Update `storageClassName` in `model-cache/model-cache.yaml` to match your cluster, and edit namespace, image tags, node selectors, and Hugging Face secrets before applying these manifests. Model download takes approximately 15-30 minutes depending on network speed.
-</Warning>
-
-## Deploy
-
-Prepare the model cache and download the checkpoint (shared by all three targets):
+Prepare the model cache and download the checkpoint (shared by all three targets). Run the `kubectl apply` commands on this page from the recipe directory, `recipes/llama-3-70b/`:
 
 ```bash
 # Update storageClassName in model-cache.yaml first!
-kubectl apply -f recipes/llama-3-70b/model-cache/ -n ${NAMESPACE}
+kubectl apply -f model-cache/ -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=3600s
 ```
 
 Then deploy:
 
-<div data-variant="agg">
+<div data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="agg">
 
 ```bash
-kubectl apply -f recipes/llama-3-70b/vllm/agg/deploy.yaml -n ${NAMESPACE}
+kubectl apply -f vllm/agg/deploy.yaml -n ${NAMESPACE}
 ```
 
 </div>
 
-<div data-variant="disagg-single-node">
+<div data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="disagg-single-node">
 
 ```bash
-kubectl apply -f recipes/llama-3-70b/vllm/disagg-single-node/deploy.yaml -n ${NAMESPACE}
+kubectl apply -f vllm/disagg-single-node/deploy.yaml -n ${NAMESPACE}
 ```
 
 </div>
 
-<div data-variant="disagg-multi-node">
+<div data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="disagg-multi-node">
 
 ```bash
-kubectl apply -f recipes/llama-3-70b/vllm/disagg-multi-node/deploy.yaml -n ${NAMESPACE}
+kubectl apply -f vllm/disagg-multi-node/deploy.yaml -n ${NAMESPACE}
 ```
 
 </div>
 
-## Smoke Test
+## Test the Deployment
 
 Send a test request to verify the deployment serves traffic:
 
-<div data-variant="agg">
+<div data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/llama3-70b-agg-frontend 8000:8000 -n ${NAMESPACE}
@@ -129,7 +168,7 @@ kubectl port-forward svc/llama3-70b-agg-frontend 8000:8000 -n ${NAMESPACE}
 
 </div>
 
-<div data-variant="disagg-single-node">
+<div data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="disagg-single-node">
 
 ```bash
 kubectl port-forward svc/llama3-70b-disagg-sn-frontend 8000:8000 -n ${NAMESPACE}
@@ -137,7 +176,7 @@ kubectl port-forward svc/llama3-70b-disagg-sn-frontend 8000:8000 -n ${NAMESPACE}
 
 </div>
 
-<div data-variant="disagg-multi-node">
+<div data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="disagg-multi-node">
 
 ```bash
 kubectl port-forward svc/llama3-70b-disagg-mn-frontend 8000:8000 -n ${NAMESPACE}
@@ -147,15 +186,19 @@ kubectl port-forward svc/llama3-70b-disagg-mn-frontend 8000:8000 -n ${NAMESPACE}
 
 ```bash
 curl http://localhost:8000/v1/chat/completions \
-  -H 'Content-Type: application/json' \
-  -d '{"model":"RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic","messages":[{"role":"user","content":"Write a one-sentence readiness check."}],"max_tokens":64}'
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 50
+  }'
 ```
 
-## Benchmark
+### Benchmark
 
 Each target ships a `perf.yaml` Kubernetes Job that waits for the model to come up, then runs AIPerf with the same traffic shape: ISL=8192, OSL=1024, 16 concurrency per GPU (so total concurrency scales with the target's GPU count), and a request count of 10x total concurrency.
 
-<div data-variant="agg">
+<div data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="agg">
 
 The Job wraps this AIPerf run (64 concurrency, 640 requests):
 
@@ -171,13 +214,13 @@ aiperf profile \
 ```
 
 ```bash
-kubectl apply -f recipes/llama-3-70b/vllm/agg/perf.yaml -n ${NAMESPACE}
+kubectl apply -f vllm/agg/perf.yaml -n ${NAMESPACE}
 kubectl logs -f job/llama3-70b-agg-perf -n ${NAMESPACE}
 ```
 
 </div>
 
-<div data-variant="disagg-single-node">
+<div data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="disagg-single-node">
 
 The Job wraps this AIPerf run (128 concurrency, 1,280 requests):
 
@@ -193,13 +236,13 @@ aiperf profile \
 ```
 
 ```bash
-kubectl apply -f recipes/llama-3-70b/vllm/disagg-single-node/perf.yaml -n ${NAMESPACE}
+kubectl apply -f vllm/disagg-single-node/perf.yaml -n ${NAMESPACE}
 kubectl logs -f job/llama3-70b-disagg-sn-perf -n ${NAMESPACE}
 ```
 
 </div>
 
-<div data-variant="disagg-multi-node">
+<div data-sku="hopper" data-engine="vllm" data-usecase="static" data-variant="disagg-multi-node">
 
 The Job wraps this AIPerf run (256 concurrency, 2,560 requests):
 
@@ -215,33 +258,25 @@ aiperf profile \
 ```
 
 ```bash
-kubectl apply -f recipes/llama-3-70b/vllm/disagg-multi-node/perf.yaml -n ${NAMESPACE}
+kubectl apply -f vllm/disagg-multi-node/perf.yaml -n ${NAMESPACE}
 kubectl logs -f job/llama3-70b-disagg-mn-perf -n ${NAMESPACE}
 ```
 
 </div>
 
-## Compare All Targets
-
-All three targets serve `RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic` on the vLLM runtime (`nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1`) and are benchmarked at 16 concurrency per GPU with 8K ISL / 1K OSL traffic:
-
-| | Aggregated | Disagg single-node | Disagg multi-node |
-|---|---|---|---|
-| **GPUs** | 4x H100/H200 | 8x H100/H200 | 16x H100/H200 |
-| **Nodes** | 1 | 1 | 2 |
-| **Workers** | 1x TP4 | 2x TP2 prefill + 1x TP4 decode | 1x TP8 prefill + 1x TP8 decode |
-| **Technique** | Aggregated serving | Disaggregated prefill/decode | Disaggregated prefill/decode |
-| **Total concurrency** | 64 | 128 | 256 |
-
-## Related Feature Benchmarks
+### Related Feature Benchmarks
 
 - [Llama-3.3-70B topology benchmark](../feature-benchmarks/llama-3-3-70b-topology.mdx) — how the three topologies compare when normalized by GPU.
 
-## Notes
+## Model Details
 
 - FP8 dynamic quantization is applied at runtime; the served model is `RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic`.
+- Context length is the default model context.
+
+## Notes
+
 - GPU counts differ by target (4 / 8 / 16), so compare total throughput and TPS/GPU — the topology comparison lives on the related Feature Benchmarks page.
-- A GAIE (Gateway API Inference Extension) integration example is included: apply the manifests under [vllm/agg/gaie/](https://github.com/ai-dynamo/dynamo/tree/main/recipes/llama-3-70b/vllm/agg/gaie) (or [vllm/disagg-single-node/gaie/](https://github.com/ai-dynamo/dynamo/tree/main/recipes/llama-3-70b/vllm/disagg-single-node/gaie)) to front the deployment with an inference gateway. These are integration artifacts, not separate recipe targets.
+- For GAIE (Gateway API Inference Extension) integration, `kubectl apply` the files from the corresponding subfolder, for example [vllm/agg/gaie/](https://github.com/ai-dynamo/dynamo/tree/main/recipes/llama-3-70b/vllm/agg/gaie) (or [vllm/disagg-single-node/gaie/](https://github.com/ai-dynamo/dynamo/tree/main/recipes/llama-3-70b/vllm/disagg-single-node/gaie)) to front the deployment with an inference gateway. These are integration artifacts, not separate recipe targets.
 
 ## Source
 

--- a/docs/fern/pages/recipes/model-recipes/nemotron-3-5-lightning.mdx
+++ b/docs/fern/pages/recipes/model-recipes/nemotron-3-5-lightning.mdx
@@ -25,88 +25,98 @@ This recipe deploys `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4`, a 30B 
 <label htmlFor="recipe-sku-gb200">GB200</label>
 </div>
 <div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-agentic" name="recipe-usecase" value="agentic" defaultChecked />
+<label htmlFor="recipe-usecase-agentic">Agentic</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-vllm" name="recipe-engine" value="vllm" defaultChecked />
+<label htmlFor="recipe-engine-vllm">vLLM</label>
+<input type="radio" id="recipe-engine-trtllm" name="recipe-engine" value="trtllm" />
+<label htmlFor="recipe-engine-trtllm">TensorRT-LLM</label>
+</div>
+<div className="dynamo-target-picker-row">
 <span className="dynamo-target-picker-dim">Topology</span>
 <input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" defaultChecked />
-<label htmlFor="recipe-variant-agg">vLLM aggregated</label>
-<input type="radio" id="recipe-variant-vllm-disagg" name="recipe-variant" value="vllm-disagg" />
-<label htmlFor="recipe-variant-vllm-disagg">vLLM disaggregated</label>
-<input type="radio" id="recipe-variant-trtllm-agg" name="recipe-variant" value="trtllm-agg" />
-<label htmlFor="recipe-variant-trtllm-agg">TensorRT-LLM aggregated</label>
+<label htmlFor="recipe-variant-agg">Aggregated</label>
+<input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" />
+<label htmlFor="recipe-variant-disagg" data-needs-engine="vllm">Disaggregated</label>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="agg">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4</span>
 <span><b>GPUs</b> 1x B200, or 4x B200 with KV routing</span>
 <span><b>Runtime</b> vLLM aggregate worker</span>
 <span><b>Spec decode</b> DSpark, DFlash, or MTP</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h100" data-variant="agg">
+<div className="dynamo-target-picker-summary" data-sku="h100" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4</span>
 <span><b>GPUs</b> 1x H100, or 4x H100 with KV routing</span>
 <span><b>Runtime</b> vLLM aggregate worker</span>
 <span><b>Spec decode</b> DSpark, DFlash, or MTP</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-variant="agg">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4</span>
 <span><b>GPUs</b> 1x H200, or 4x H200 with KV routing</span>
 <span><b>Runtime</b> vLLM aggregate worker</span>
 <span><b>Spec decode</b> DSpark, DFlash, or MTP</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="gb200" data-variant="agg">
+<div className="dynamo-target-picker-summary" data-sku="gb200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4</span>
 <span><b>GPUs</b> 1x GB200</span>
 <span><b>Runtime</b> vLLM, aggregate worker</span>
 <span><b>Spec decode</b> DSpark, DFlash, or MTP</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="vllm-disagg">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4</span>
 <span><b>GPUs</b> 2x B200</span>
 <span><b>Runtime</b> vLLM, 1 prefill + 1 decode</span>
 <span><b>Transport</b> IB/RDMA with UCX</span>
 <span><b>Spec decode</b> DSpark</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h100" data-variant="vllm-disagg">
+<div className="dynamo-target-picker-summary" data-sku="h100" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4</span>
 <span><b>GPUs</b> 2x H100</span>
 <span><b>Runtime</b> vLLM, 1 prefill + 1 decode</span>
 <span><b>Transport</b> AWS EFA/LIBFABRIC</span>
 <span><b>Spec decode</b> MTP, DFlash, or DSpark</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-variant="vllm-disagg">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4</span>
 <span><b>GPUs</b> 2x H200</span>
 <span><b>Runtime</b> vLLM, 1 prefill + 1 decode</span>
 <span><b>Transport</b> IB/RDMA with UCX</span>
 <span><b>Spec decode</b> MTP, DFlash, or DSpark</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="gb200" data-variant="vllm-disagg">
+<div className="dynamo-target-picker-summary" data-sku="gb200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4</span>
 <span><b>GPUs</b> 2x GB200</span>
 <span><b>Runtime</b> vLLM, 1 prefill + 1 decode</span>
 <span><b>Transport</b> UCX/NIXL with cluster-specific fabric resources</span>
 <span><b>Spec decode</b> DFlash or DSpark</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="trtllm-agg">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="trtllm" data-usecase="agentic">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4</span>
 <span><b>GPUs</b> 1x B200</span>
 <span><b>Runtime</b> TensorRT-LLM, aggregate worker</span>
 <span><b>Spec decode</b> MTP or no-spec fallback</span>
 <span><b>Status</b> Experimental</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h100" data-variant="trtllm-agg">
+<div className="dynamo-target-picker-summary" data-sku="h100" data-engine="trtllm" data-usecase="agentic">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4</span>
 <span><b>GPUs</b> 1x H100</span>
 <span><b>Runtime</b> TensorRT-LLM, aggregate worker</span>
 <span><b>Spec decode</b> MTP</span>
 <span><b>Status</b> Experimental</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-variant="trtllm-agg">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="trtllm" data-usecase="agentic">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4</span>
 <span><b>GPUs</b> 1x H200</span>
 <span><b>Runtime</b> TensorRT-LLM, aggregate worker</span>
 <span><b>Spec decode</b> MTP</span>
 <span><b>Status</b> Experimental</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="gb200" data-variant="trtllm-agg">
+<div className="dynamo-target-picker-summary" data-sku="gb200" data-engine="trtllm" data-usecase="agentic">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4</span>
 <span><b>GPUs</b> 1x GB200</span>
 <span><b>Runtime</b> TensorRT-LLM, aggregate worker</span>
@@ -115,33 +125,80 @@ This recipe deploys `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4`, a 30B 
 </div>
 </div>
 
+## Configurations
+
+<div className="dynamo-variant-table-wrap">
+<table className="dynamo-variant-table">
+<thead>
+<tr><th>Runtime</th><th>Topology</th><th>GPU</th><th>Spec decode options</th><th>Checked-in manifests</th></tr>
+</thead>
+<tbody>
+<tr data-sku="b200" data-engine="vllm" data-variant="agg"><td>vLLM</td><td>Aggregated</td><td>B200</td><td>MTP, DFlash, DSpark</td><td><code>vllm/agg-b200-dspark-kv-router/deploy.yaml</code> (DSpark + KV router)<br /><code>vllm/agg-b200-dspark/deploy.yaml</code><br /><code>vllm/agg-b200-dflash/deploy.yaml</code><br /><code>vllm/agg-b200-mtp/deploy.yaml</code></td></tr>
+<tr data-sku="h100" data-engine="vllm" data-variant="agg"><td>vLLM</td><td>Aggregated</td><td>H100</td><td>MTP, DFlash, DSpark</td><td><code>vllm/agg-h100-dspark-kv-router/deploy.yaml</code> (DSpark + KV router)<br /><code>vllm/agg-h100-dspark/deploy.yaml</code><br /><code>vllm/agg-h100-dflash/deploy.yaml</code><br /><code>vllm/agg-h100-mtp/deploy.yaml</code></td></tr>
+<tr data-sku="h200" data-engine="vllm" data-variant="agg"><td>vLLM</td><td>Aggregated</td><td>H200</td><td>MTP, DFlash, DSpark</td><td><code>vllm/agg-h200-dspark-kv-router/deploy.yaml</code> (DSpark + KV router)<br /><code>vllm/agg-h200-dspark/deploy.yaml</code><br /><code>vllm/agg-h200-dflash/deploy.yaml</code><br /><code>vllm/agg-h200-mtp/deploy.yaml</code></td></tr>
+<tr data-sku="gb200" data-engine="vllm" data-variant="agg"><td>vLLM</td><td>Aggregated</td><td>GB200</td><td>MTP, DFlash, DSpark</td><td><code>vllm/agg-gb200-dspark/deploy.yaml</code><br /><code>vllm/agg-gb200-dflash/deploy.yaml</code><br /><code>vllm/agg-gb200-mtp/deploy.yaml</code></td></tr>
+<tr data-sku="b200" data-engine="vllm" data-variant="disagg"><td>vLLM</td><td>Disaggregated 1P1D</td><td>B200</td><td>DSpark</td><td><code>vllm/disagg-b200-dspark/deploy.yaml</code></td></tr>
+<tr data-sku="h100" data-engine="vllm" data-variant="disagg"><td>vLLM</td><td>Disaggregated 1P1D</td><td>H100</td><td>MTP, DFlash, DSpark</td><td><code>vllm/disagg-h100-dspark/deploy.yaml</code><br /><code>vllm/disagg-h100-dflash/deploy.yaml</code><br /><code>vllm/disagg-h100-mtp/deploy.yaml</code></td></tr>
+<tr data-sku="h200" data-engine="vllm" data-variant="disagg"><td>vLLM</td><td>Disaggregated 1P1D</td><td>H200</td><td>MTP, DFlash, DSpark</td><td><code>vllm/disagg-h200-dspark/deploy.yaml</code><br /><code>vllm/disagg-h200-dflash/deploy.yaml</code><br /><code>vllm/disagg-h200-mtp/deploy.yaml</code></td></tr>
+<tr data-sku="gb200" data-engine="vllm" data-variant="disagg"><td>vLLM</td><td>Disaggregated 1P1D</td><td>GB200</td><td>DFlash, DSpark</td><td><code>vllm/disagg-gb200-dspark/deploy.yaml</code><br /><code>vllm/disagg-gb200-dflash/deploy.yaml</code></td></tr>
+<tr data-sku="b200" data-engine="trtllm"><td>TensorRT-LLM</td><td>Aggregated</td><td>B200</td><td>MTP, no-spec fallback</td><td><code>trtllm/agg-b200-mtp/deploy.yaml</code><br /><code>trtllm/agg-b200/deploy.yaml</code></td></tr>
+<tr data-sku="h100" data-engine="trtllm"><td>TensorRT-LLM</td><td>Aggregated</td><td>H100</td><td>MTP</td><td><code>trtllm/agg-h100-mtp/deploy.yaml</code></td></tr>
+<tr data-sku="h200" data-engine="trtllm"><td>TensorRT-LLM</td><td>Aggregated</td><td>H200</td><td>MTP</td><td><code>trtllm/agg-h200-mtp/deploy.yaml</code></td></tr>
+<tr data-sku="gb200" data-engine="trtllm"><td>TensorRT-LLM</td><td>Aggregated</td><td>GB200</td><td>MTP, no-spec fallback</td><td><code>trtllm/agg-gb200-mtp/deploy.yaml</code><br /><code>trtllm/agg-gb200/deploy.yaml</code></td></tr>
+</tbody>
+</table>
+</div>
+
+## Repository layout
+
+The recipe directory holds `model-cache/` for the shared cache PVC and the model-download Job, `vllm/` for the aggregate and 1P/1D disaggregated vLLM recipes, `trtllm/` for the aggregate TensorRT-LLM recipes, and `perf/` for the benchmark trace reference and trace results. vLLM recipes are organized as `vllm/{agg,disagg}-{hardware}-{specdec}` and TensorRT-LLM recipes as `trtllm/agg-{hardware}[-{specdec}]`; each identifier corresponds to `identifier/deploy.yaml`.
+
 ## Prerequisites
 
 - A Kubernetes cluster with the Dynamo Platform installed and DGD CRDs served.
 - A namespace with access to the selected GPU target.
-- A Hugging Face token with access to the base model and draft models.
+- A Hugging Face secret named `hf-token-secret` with access to the target and draft-model repositories.
 - An image pull secret if your cluster requires authenticated image pulls.
 
-<div data-sku="h100" data-variant="vllm-disagg">
+<div data-sku="gb200" data-engine="vllm" data-variant="agg disagg">
 
-- AWS EFA/LIBFABRIC resources exposed as `vpc.amazonaws.com/efa` for the H100 disaggregated manifests.
+- GB200 vLLM recipes require ARM-node scheduling. The manifests select `nvidia.com/gpu.product: NVIDIA-GB200` nodes and tolerate the `kubernetes.io/arch=arm64` taint.
+
+</div>
+
+<div data-sku="gb200" data-engine="trtllm">
+
+- GB200 TensorRT-LLM recipes require GB200 nodes. The manifests select `nvidia.com/gpu.product: NVIDIA-GB200` through node affinity rather than by architecture, and they carry no `kubernetes.io/arch=arm64` toleration.
+
+</div>
+
+<div data-sku="h100" data-engine="vllm" data-variant="disagg">
+
+- AWS EFA resources exposed as `vpc.amazonaws.com/efa`. The H100 disaggregated manifests request `vpc.amazonaws.com/efa: 4` and select the NIXL LIBFABRIC backend. Change that resource when your cluster exposes different RDMA devices.
 - AWS EFA userspace available in the runtime image or installed by your cluster bootstrap flow before pod startup. The manifests do not download or install EFA packages. Use the [EFA check helper](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3.5-lightning/vllm/check-efa-userspace.sh) to validate a prepared image or running pod; its install mode requires a pinned `EFA_INSTALLER_VERSION` and `EFA_INSTALLER_SHA256`.
 
+Run the helper against a prepared image or a running pod:
+
+```bash
+kubectl exec -i -n "${NAMESPACE}" <h100-worker-pod> -- \
+  bash -s -- check < recipes/nemotron-3.5-lightning/vllm/check-efa-userspace.sh
+```
+
 </div>
 
-<div data-sku="h200 b200" data-variant="vllm-disagg">
+<div data-sku="h200 b200" data-engine="vllm" data-variant="disagg">
 
-- IB/RDMA resources exposed as `rdma/ib` for the H200 and B200 disaggregated manifests.
+- An IB/RDMA fabric for the H200 and B200 disaggregated manifests, which move KV cache with UCX over IB/RDMA. Those manifests request `rdma/ib: 1`. Change that resource when your cluster exposes different RDMA devices.
 
 </div>
 
-<div data-sku="gb200" data-variant="vllm-disagg">
+<div data-sku="gb200" data-engine="vllm" data-variant="disagg">
 
 - GB200 disaggregated manifests leave fabric resources cluster-specific. Add the UCX/NIXL resource claims or network resources required by your platform.
 
 </div>
 
-Create the namespace and Hugging Face token secret:
+Set the namespace used by the commands on this page, then create it along with the Hugging Face token secret:
 
 ```bash
 export NAMESPACE=your-namespace
@@ -155,7 +212,7 @@ kubectl create secret generic hf-token-secret \
 Edit storage class, image pull secret names, node selectors, fabric resources, and cluster-specific placement before applying these manifests.
 </Warning>
 
-## Deploy
+## Quick start
 
 Create the shared model cache and download the base and draft checkpoints. This step is common to every target:
 
@@ -168,40 +225,46 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 
 Then deploy the selected target.
 
-<div data-sku="b200" data-variant="agg">
+<div data-sku="b200" data-engine="vllm" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/nemotron-3.5-lightning/vllm/agg-b200-dspark/deploy.yaml -n ${NAMESPACE}
 kubectl get dgd vllm-agg-b200-dspark -n ${NAMESPACE} -w
 ```
 
-DSpark is the promoted single-worker B200 aggregate path from the checked-in validation table. Use `agg-b200-dflash`, `agg-b200-mtp`, or `agg-b200-dspark-kv-router` to compare the other aggregate options. For this validation trace, KV-aware routing did not materially change the result because KV-cache pressure was low; it can help workloads with enough reusable KV state to pressure a single worker.
+DSpark is the promoted single-worker B200 aggregate path from the checked-in validation table. Use `agg-b200-dflash`, `agg-b200-mtp`, or `agg-b200-dspark-kv-router` to compare the other aggregate options.
+
+`agg-b200-dspark-kv-router` keeps the vLLM aggregate DSpark worker configuration, runs four aggregate replicas, and publishes KV-cache events to the frontend KV router. It is provided for workloads that benefit from distributing reusable KV state across several workers, for example when a single worker sees enough distinct long-prefix families to create KV-cache pressure. For this validation trace, KV-aware routing was not promoted over the single-worker aggregate DSpark recipe: even H100, the lowest-VRAM SKU tested here, peaked at only 38.1% GPU KV-cache usage in the one-worker full-trace run, so the single worker kept useful prefixes resident without meaningful eviction pressure while adding replicas split work across more GPUs.
 
 </div>
 
-<div data-sku="h100" data-variant="agg">
+<div data-sku="h100" data-engine="vllm" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/nemotron-3.5-lightning/vllm/agg-h100-dspark/deploy.yaml -n ${NAMESPACE}
 kubectl get dgd vllm-agg-h100-dspark -n ${NAMESPACE} -w
 ```
 
-DSpark is the highest-throughput H100 single-worker aggregate row in the checked-in validation table. Use `agg-h100-dflash`, `agg-h100-mtp`, or `agg-h100-dspark-kv-router` to compare the other aggregate options. For this validation trace, KV-aware routing did not materially change the result because KV-cache pressure was low; it can help workloads with enough reusable KV state to pressure a single worker.
+DSpark is the highest-throughput H100 single-worker aggregate row in the checked-in validation table. Use `agg-h100-dflash`, `agg-h100-mtp`, or `agg-h100-dspark-kv-router` to compare the other aggregate options.
+
+`agg-h100-dspark-kv-router` keeps the vLLM aggregate DSpark worker configuration, runs four aggregate replicas, and publishes KV-cache events to the frontend KV router. It is provided for workloads that benefit from distributing reusable KV state across several workers, for example when a single worker sees enough distinct long-prefix families to create KV-cache pressure. For this validation trace, KV-aware routing was not promoted over the single-worker aggregate DSpark recipe: even H100, the lowest-VRAM SKU tested here, peaked at only 38.1% GPU KV-cache usage in the one-worker full-trace run, so the single worker kept useful prefixes resident without meaningful eviction pressure while adding replicas split work across more GPUs.
 
 </div>
 
-<div data-sku="h200" data-variant="agg">
+<div data-sku="h200" data-engine="vllm" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/nemotron-3.5-lightning/vllm/agg-h200-dspark/deploy.yaml -n ${NAMESPACE}
 kubectl get dgd vllm-agg-h200-dspark -n ${NAMESPACE} -w
 ```
 
-DSpark is the highest-throughput H200 single-worker aggregate row in the checked-in validation table. Use `agg-h200-dflash`, `agg-h200-mtp`, or `agg-h200-dspark-kv-router` to compare the other aggregate options. For this validation trace, KV-aware routing did not materially change the result because KV-cache pressure was low; it can help workloads with enough reusable KV state to pressure a single worker.
+DSpark is the highest-throughput H200 single-worker aggregate row in the checked-in validation table. Use `agg-h200-dflash`, `agg-h200-mtp`, or `agg-h200-dspark-kv-router` to compare the other aggregate options.
+
+`agg-h200-dspark-kv-router` keeps the vLLM aggregate DSpark worker configuration, runs four aggregate replicas, and publishes KV-cache events to the frontend KV router. It is provided for workloads that benefit from distributing reusable KV state across several workers, for example when a single worker sees enough distinct long-prefix families to create KV-cache pressure. For this validation trace, KV-aware routing was not promoted over the single-worker aggregate DSpark recipe: even H100, the lowest-VRAM SKU tested here, peaked at only 38.1% GPU KV-cache usage in the one-worker full-trace run, so the single worker kept useful prefixes resident without meaningful eviction pressure while adding replicas split work across more GPUs.
 
 </div>
 
-<div data-sku="gb200" data-variant="agg">
+<div data-sku="gb200" data-engine="vllm" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/nemotron-3.5-lightning/vllm/agg-gb200-dspark/deploy.yaml -n ${NAMESPACE}
@@ -212,7 +275,7 @@ DSpark is the highest-throughput GB200 aggregate row in the checked-in validatio
 
 </div>
 
-<div data-sku="b200" data-variant="vllm-disagg">
+<div data-sku="b200" data-engine="vllm" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/nemotron-3.5-lightning/vllm/disagg-b200-dspark/deploy.yaml -n ${NAMESPACE}
@@ -223,7 +286,7 @@ Use this target for B200 disaggregated vLLM validation with DSpark speculative d
 
 </div>
 
-<div data-sku="h100" data-variant="vllm-disagg">
+<div data-sku="h100" data-engine="vllm" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/nemotron-3.5-lightning/vllm/disagg-h100-dspark/deploy.yaml -n ${NAMESPACE}
@@ -234,7 +297,7 @@ DSpark is the highest-output-throughput H100 disaggregated row in the source inv
 
 </div>
 
-<div data-sku="h200" data-variant="vllm-disagg">
+<div data-sku="h200" data-engine="vllm" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/nemotron-3.5-lightning/vllm/disagg-h200-dspark/deploy.yaml -n ${NAMESPACE}
@@ -245,7 +308,7 @@ DSpark is the highest-throughput H200 disaggregated row in the source inventory.
 
 </div>
 
-<div data-sku="gb200" data-variant="vllm-disagg">
+<div data-sku="gb200" data-engine="vllm" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/nemotron-3.5-lightning/vllm/disagg-gb200-dspark/deploy.yaml -n ${NAMESPACE}
@@ -256,18 +319,18 @@ DSpark is the highest-throughput GB200 disaggregated row in the source inventory
 
 </div>
 
-<div data-sku="b200" data-variant="trtllm-agg">
+<div data-sku="b200" data-engine="trtllm">
 
 ```bash
 kubectl apply -f recipes/nemotron-3.5-lightning/trtllm/agg-b200-mtp/deploy.yaml -n ${NAMESPACE}
 kubectl get dgd trtllm-agg-b200-mtp -n ${NAMESPACE} -w
 ```
 
-Use `trtllm/agg-b200/deploy.yaml` for the no-spec fallback.
+Use `trtllm/agg-b200/deploy.yaml` for the no-spec fallback. Its Kubernetes resources keep the `-nospec` suffix, so watch `dgd/trtllm-agg-b200-nospec` and port-forward `svc/trtllm-agg-b200-nospec-frontend`.
 
 </div>
 
-<div data-sku="h100" data-variant="trtllm-agg">
+<div data-sku="h100" data-engine="trtllm">
 
 ```bash
 kubectl apply -f recipes/nemotron-3.5-lightning/trtllm/agg-h100-mtp/deploy.yaml -n ${NAMESPACE}
@@ -278,7 +341,7 @@ The H100 TensorRT-LLM target uses the MTP manifest.
 
 </div>
 
-<div data-sku="h200" data-variant="trtllm-agg">
+<div data-sku="h200" data-engine="trtllm">
 
 ```bash
 kubectl apply -f recipes/nemotron-3.5-lightning/trtllm/agg-h200-mtp/deploy.yaml -n ${NAMESPACE}
@@ -289,22 +352,20 @@ The H200 TensorRT-LLM target uses the MTP manifest.
 
 </div>
 
-<div data-sku="gb200" data-variant="trtllm-agg">
+<div data-sku="gb200" data-engine="trtllm">
 
 ```bash
 kubectl apply -f recipes/nemotron-3.5-lightning/trtllm/agg-gb200-mtp/deploy.yaml -n ${NAMESPACE}
 kubectl get dgd trtllm-agg-gb200-mtp -n ${NAMESPACE} -w
 ```
 
-Use `trtllm/agg-gb200/deploy.yaml` for the no-spec fallback.
+Use `trtllm/agg-gb200/deploy.yaml` for the no-spec fallback. Its Kubernetes resources keep the `-nospec` suffix, so watch `dgd/trtllm-agg-gb200-nospec` and port-forward `svc/trtllm-agg-gb200-nospec-frontend`.
 
 </div>
 
-## Smoke Test
-
 Port-forward the frontend service for the deployment you applied:
 
-<div data-sku="b200" data-variant="agg">
+<div data-sku="b200" data-engine="vllm" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/vllm-agg-b200-dspark-frontend 8000:8000 -n ${NAMESPACE}
@@ -312,7 +373,7 @@ kubectl port-forward svc/vllm-agg-b200-dspark-frontend 8000:8000 -n ${NAMESPACE}
 
 </div>
 
-<div data-sku="h100" data-variant="agg">
+<div data-sku="h100" data-engine="vllm" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/vllm-agg-h100-dspark-frontend 8000:8000 -n ${NAMESPACE}
@@ -320,7 +381,7 @@ kubectl port-forward svc/vllm-agg-h100-dspark-frontend 8000:8000 -n ${NAMESPACE}
 
 </div>
 
-<div data-sku="h200" data-variant="agg">
+<div data-sku="h200" data-engine="vllm" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/vllm-agg-h200-dspark-frontend 8000:8000 -n ${NAMESPACE}
@@ -328,7 +389,7 @@ kubectl port-forward svc/vllm-agg-h200-dspark-frontend 8000:8000 -n ${NAMESPACE}
 
 </div>
 
-<div data-sku="gb200" data-variant="agg">
+<div data-sku="gb200" data-engine="vllm" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/vllm-agg-gb200-dspark-frontend 8000:8000 -n ${NAMESPACE}
@@ -336,7 +397,7 @@ kubectl port-forward svc/vllm-agg-gb200-dspark-frontend 8000:8000 -n ${NAMESPACE
 
 </div>
 
-<div data-sku="b200" data-variant="vllm-disagg">
+<div data-sku="b200" data-engine="vllm" data-variant="disagg">
 
 ```bash
 kubectl port-forward svc/vllm-disagg-b200-dspark-frontend 8000:8000 -n ${NAMESPACE}
@@ -344,7 +405,7 @@ kubectl port-forward svc/vllm-disagg-b200-dspark-frontend 8000:8000 -n ${NAMESPA
 
 </div>
 
-<div data-sku="h100" data-variant="vllm-disagg">
+<div data-sku="h100" data-engine="vllm" data-variant="disagg">
 
 ```bash
 kubectl port-forward svc/vllm-disagg-h100-dspark-frontend 8000:8000 -n ${NAMESPACE}
@@ -352,7 +413,7 @@ kubectl port-forward svc/vllm-disagg-h100-dspark-frontend 8000:8000 -n ${NAMESPA
 
 </div>
 
-<div data-sku="h200" data-variant="vllm-disagg">
+<div data-sku="h200" data-engine="vllm" data-variant="disagg">
 
 ```bash
 kubectl port-forward svc/vllm-disagg-h200-dspark-frontend 8000:8000 -n ${NAMESPACE}
@@ -360,7 +421,7 @@ kubectl port-forward svc/vllm-disagg-h200-dspark-frontend 8000:8000 -n ${NAMESPA
 
 </div>
 
-<div data-sku="gb200" data-variant="vllm-disagg">
+<div data-sku="gb200" data-engine="vllm" data-variant="disagg">
 
 ```bash
 kubectl port-forward svc/vllm-disagg-gb200-dspark-frontend 8000:8000 -n ${NAMESPACE}
@@ -368,7 +429,7 @@ kubectl port-forward svc/vllm-disagg-gb200-dspark-frontend 8000:8000 -n ${NAMESP
 
 </div>
 
-<div data-sku="b200" data-variant="trtllm-agg">
+<div data-sku="b200" data-engine="trtllm">
 
 ```bash
 kubectl port-forward svc/trtllm-agg-b200-mtp-frontend 8000:8000 -n ${NAMESPACE}
@@ -376,7 +437,7 @@ kubectl port-forward svc/trtllm-agg-b200-mtp-frontend 8000:8000 -n ${NAMESPACE}
 
 </div>
 
-<div data-sku="h100" data-variant="trtllm-agg">
+<div data-sku="h100" data-engine="trtllm">
 
 ```bash
 kubectl port-forward svc/trtllm-agg-h100-mtp-frontend 8000:8000 -n ${NAMESPACE}
@@ -384,7 +445,7 @@ kubectl port-forward svc/trtllm-agg-h100-mtp-frontend 8000:8000 -n ${NAMESPACE}
 
 </div>
 
-<div data-sku="h200" data-variant="trtllm-agg">
+<div data-sku="h200" data-engine="trtllm">
 
 ```bash
 kubectl port-forward svc/trtllm-agg-h200-mtp-frontend 8000:8000 -n ${NAMESPACE}
@@ -392,7 +453,7 @@ kubectl port-forward svc/trtllm-agg-h200-mtp-frontend 8000:8000 -n ${NAMESPACE}
 
 </div>
 
-<div data-sku="gb200" data-variant="trtllm-agg">
+<div data-sku="gb200" data-engine="trtllm">
 
 ```bash
 kubectl port-forward svc/trtllm-agg-gb200-mtp-frontend 8000:8000 -n ${NAMESPACE}
@@ -405,22 +466,54 @@ Then send a chat completion request:
 ```bash
 curl http://localhost:8000/v1/models
 curl http://localhost:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
+  -H 'Content-Type: application/json' \
   -d '{
     "model": "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4",
-    "messages": [{"role": "user", "content": "Hello!"}],
-    "max_tokens": 32,
+    "messages": [{"role": "user", "content": "Say OK."}],
+    "max_tokens": 128,
     "temperature": 0
   }'
 ```
 
-## Benchmark
-
 The checked-in recipe includes benchmark results in [`recipes/nemotron-3.5-lightning/perf/README.md`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3.5-lightning/perf/README.md). The pass criteria are `tok/s/user >= 50` and TTFT p50 under 5 seconds.
 
-To reproduce the shape, run AIPerf against the selected frontend with a Mooncake trace replay and the target concurrency from the table.
+To reproduce a row, run AIPerf against the port-forwarded frontend with the AIPerf shape below, using the request count and concurrency shown for that row in the results table.
 
-<div data-sku="b200" data-variant="agg">
+The trace is `recipes/nemotron-3.5-lightning/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl`, a symlink to the shared trace under `recipes/kimi-k2.6/perf/traces/`. Some trace requests exceed the model's native 262144-token context length. Those requests return errors and are excluded from the valid-request latency and throughput metrics, which is what the non-zero error counts in the results table represent.
+
+<div data-engine="vllm" data-variant="agg disagg">
+
+The published numbers use the synthetic acceptance configuration. Every vLLM manifest defines two draft configurations: `speculative-config` is the standard serving configuration, and `speculative-config-synthetic` enables synthetic rejection sampling for benchmark reproduction. Before benchmarking, select the synthetic configuration by changing the `SPECULATIVE_CONFIG` ConfigMap key.
+
+The synthetic configuration for the selected target:
+
+<div className="dynamo-variant-table-wrap">
+<table className="dynamo-variant-table">
+<thead>
+<tr><th>Spec decode</th><th>Draft tokens</th><th>Expected acceptance length</th></tr>
+</thead>
+<tbody>
+<tr data-sku="b200 h100 h200 gb200" data-engine="vllm" data-variant="agg"><td>DSpark</td><td>7</td><td>3.69</td></tr>
+<tr data-sku="b200 h100 h200 gb200" data-engine="vllm" data-variant="agg"><td>DFlash</td><td>5</td><td>3.18</td></tr>
+<tr data-sku="h100 h200" data-engine="vllm" data-variant="agg"><td>MTP</td><td>7</td><td>3.687</td></tr>
+<tr data-sku="b200 gb200" data-engine="vllm" data-variant="agg"><td>MTP</td><td>3</td><td>2.874</td></tr>
+<tr data-sku="b200 h100 h200 gb200" data-engine="vllm" data-variant="disagg"><td>DSpark</td><td>1</td><td>1.83</td></tr>
+<tr data-sku="h100 h200" data-engine="vllm" data-variant="disagg"><td>DFlash</td><td>3</td><td>2.73</td></tr>
+<tr data-sku="gb200" data-engine="vllm" data-variant="disagg"><td>DFlash</td><td>7</td><td>3.41</td></tr>
+<tr data-sku="h100 h200" data-engine="vllm" data-variant="disagg"><td>MTP</td><td>5</td><td>3.421</td></tr>
+</tbody>
+</table>
+</div>
+
+</div>
+
+<div data-engine="trtllm">
+
+The published MTP numbers use synthetic acceptance.
+
+</div>
+
+<div data-sku="b200" data-engine="vllm" data-variant="agg">
 
 ```bash
 aiperf profile \
@@ -432,31 +525,93 @@ aiperf profile \
   --use-server-token-count \
   --extra-inputs ignore_eos:true \
   --request-timeout-seconds 1200 \
-  --url http://vllm-agg-b200-dspark-frontend:8000 \
+  --url http://localhost:8000 \
+  --concurrency 24
+```
+
+For `agg-b200-dspark-kv-router`, start benchmark concurrency at 4x the matching non-KV aggregate recommendation: 4 worker replicas, base concurrency 24, suggested KV-router concurrency 96.
+
+</div>
+
+<div data-sku="h100" data-engine="vllm" data-variant="agg">
+
+```bash
+aiperf profile \
+  -m nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 \
+  --custom-dataset-type mooncake_trace \
+  --num-requests 3541 \
+  --endpoint-type chat \
+  --streaming \
+  --use-server-token-count \
+  --extra-inputs ignore_eos:true \
+  --request-timeout-seconds 1200 \
+  --url http://localhost:8000 \
+  --concurrency 20
+```
+
+For `agg-h100-dspark-kv-router`, start benchmark concurrency at 4x the matching non-KV aggregate recommendation: 4 worker replicas, base concurrency 20, suggested KV-router concurrency 80.
+
+</div>
+
+<div data-sku="h200" data-engine="vllm" data-variant="agg">
+
+```bash
+aiperf profile \
+  -m nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 \
+  --custom-dataset-type mooncake_trace \
+  --num-requests 3541 \
+  --endpoint-type chat \
+  --streaming \
+  --use-server-token-count \
+  --extra-inputs ignore_eos:true \
+  --request-timeout-seconds 1200 \
+  --url http://localhost:8000 \
+  --concurrency 20
+```
+
+For `agg-h200-dspark-kv-router`, start benchmark concurrency at 4x the matching non-KV aggregate recommendation: 4 worker replicas, base concurrency 20, suggested KV-router concurrency 80.
+
+</div>
+
+<div data-sku="gb200" data-engine="vllm" data-variant="agg">
+
+```bash
+aiperf profile \
+  -m nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 \
+  --custom-dataset-type mooncake_trace \
+  --num-requests 3541 \
+  --endpoint-type chat \
+  --streaming \
+  --use-server-token-count \
+  --extra-inputs ignore_eos:true \
+  --request-timeout-seconds 1200 \
+  --url http://localhost:8000 \
   --concurrency 24
 ```
 
 </div>
 
-<div data-sku="h100" data-variant="agg">
+<div data-sku="b200" data-engine="vllm" data-variant="disagg">
 
 ```bash
 aiperf profile \
   -m nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 \
   --custom-dataset-type mooncake_trace \
-  --num-requests 3541 \
+  --num-requests 500 \
   --endpoint-type chat \
   --streaming \
   --use-server-token-count \
   --extra-inputs ignore_eos:true \
   --request-timeout-seconds 1200 \
-  --url http://vllm-agg-h100-dspark-frontend:8000 \
-  --concurrency 20
+  --url http://localhost:8000 \
+  --concurrency 8
 ```
+
+The published B200 disaggregated row is a 500-request run, not the full 3541-request trace used by the other vLLM rows.
 
 </div>
 
-<div data-sku="h200" data-variant="agg">
+<div data-sku="h100" data-engine="vllm" data-variant="disagg">
 
 ```bash
 aiperf profile \
@@ -468,31 +623,13 @@ aiperf profile \
   --use-server-token-count \
   --extra-inputs ignore_eos:true \
   --request-timeout-seconds 1200 \
-  --url http://vllm-agg-h200-dspark-frontend:8000 \
-  --concurrency 20
-```
-
-</div>
-
-<div data-sku="gb200" data-variant="agg">
-
-```bash
-aiperf profile \
-  -m nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 \
-  --custom-dataset-type mooncake_trace \
-  --num-requests 3541 \
-  --endpoint-type chat \
-  --streaming \
-  --use-server-token-count \
-  --extra-inputs ignore_eos:true \
-  --request-timeout-seconds 1200 \
-  --url http://vllm-agg-gb200-dspark-frontend:8000 \
+  --url http://localhost:8000 \
   --concurrency 24
 ```
 
 </div>
 
-<div data-sku="b200" data-variant="vllm-disagg">
+<div data-sku="h200" data-engine="vllm" data-variant="disagg">
 
 ```bash
 aiperf profile \
@@ -504,153 +641,153 @@ aiperf profile \
   --use-server-token-count \
   --extra-inputs ignore_eos:true \
   --request-timeout-seconds 1200 \
-  --url http://vllm-disagg-b200-dspark-frontend:8000 \
+  --url http://localhost:8000 \
+  --concurrency 24
+```
+
+</div>
+
+<div data-sku="gb200" data-engine="vllm" data-variant="disagg">
+
+```bash
+aiperf profile \
+  -m nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 \
+  --custom-dataset-type mooncake_trace \
+  --num-requests 3541 \
+  --endpoint-type chat \
+  --streaming \
+  --use-server-token-count \
+  --extra-inputs ignore_eos:true \
+  --request-timeout-seconds 1200 \
+  --url http://localhost:8000 \
   --concurrency 8
 ```
 
 </div>
 
-<div data-sku="h100" data-variant="vllm-disagg">
+<div data-engine="trtllm">
+
+The published TensorRT-LLM rows were measured over 500 requests, not the full 3541-request trace. Use the shape below with the concurrency listed for the selected TensorRT-LLM row.
+
+</div>
+
+<div data-sku="b200 gb200" data-engine="trtllm">
 
 ```bash
 aiperf profile \
   -m nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 \
   --custom-dataset-type mooncake_trace \
-  --num-requests 3541 \
+  --num-requests 500 \
   --endpoint-type chat \
   --streaming \
   --use-server-token-count \
   --extra-inputs ignore_eos:true \
   --request-timeout-seconds 1200 \
-  --url http://vllm-disagg-h100-dspark-frontend:8000 \
-  --concurrency 24
+  --url http://localhost:8000 \
+  --concurrency 18
 ```
 
 </div>
 
-<div data-sku="h200" data-variant="vllm-disagg">
+<div data-sku="h100 h200" data-engine="trtllm">
 
 ```bash
 aiperf profile \
   -m nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 \
   --custom-dataset-type mooncake_trace \
-  --num-requests 3541 \
+  --num-requests 500 \
   --endpoint-type chat \
   --streaming \
   --use-server-token-count \
   --extra-inputs ignore_eos:true \
   --request-timeout-seconds 1200 \
-  --url http://vllm-disagg-h200-dspark-frontend:8000 \
-  --concurrency 24
+  --url http://localhost:8000 \
+  --concurrency 12
 ```
 
 </div>
-
-<div data-sku="gb200" data-variant="vllm-disagg">
-
-```bash
-aiperf profile \
-  -m nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 \
-  --custom-dataset-type mooncake_trace \
-  --num-requests 3541 \
-  --endpoint-type chat \
-  --streaming \
-  --use-server-token-count \
-  --extra-inputs ignore_eos:true \
-  --request-timeout-seconds 1200 \
-  --url http://vllm-disagg-gb200-dspark-frontend:8000 \
-  --concurrency 8
-```
-
-</div>
-
-<div data-variant="trtllm-agg">
-
-TensorRT-LLM rows are experimental smoke or inventory results in the source README. Use the same AIPerf shape after replacing the `--url` and concurrency with the selected TensorRT-LLM row below.
-
-</div>
-
-## Expected Performance
 
 <div className="dynamo-variant-table-wrap">
 <table className="dynamo-variant-table">
 <thead>
-<tr><th>Recipe</th><th>Spec decode</th><th>Routing</th><th>Concurrency</th><th>TTFT p50 (ms)</th><th>Output tok/s/GPU</th><th>Tok/s/user</th></tr>
+<tr><th>Recipe</th><th>Spec decode</th><th>Routing</th><th>Spec tok</th><th>Synthetic AL</th><th>Concurrency</th><th>Requests</th><th>Valid requests</th><th>Errors</th><th>TTFT p50 (ms)</th><th>Output tok/s/GPU</th><th>Tok/s/user</th></tr>
 </thead>
 <tbody>
-<tr data-sku="b200" data-variant="agg"><td><code>vllm/agg-b200-dspark-kv-router/deploy.yaml</code></td><td>DSpark</td><td>KV router</td><td>96</td><td>295.03</td><td>2507.70</td><td>104.49</td></tr>
-<tr data-sku="b200" data-variant="agg"><td><code>vllm/agg-b200-dspark/deploy.yaml</code></td><td>DSpark</td><td>Single worker</td><td>24</td><td>207.44</td><td>2471.12</td><td>102.96</td></tr>
-<tr data-sku="b200" data-variant="agg"><td><code>vllm/agg-b200-dflash/deploy.yaml</code></td><td>DFlash</td><td>Single worker</td><td>20</td><td>212.57</td><td>2004.06</td><td>100.20</td></tr>
-<tr data-sku="b200" data-variant="agg"><td><code>vllm/agg-b200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>18</td><td>217.12</td><td>1829.94</td><td>101.66</td></tr>
-<tr data-sku="h100" data-variant="agg"><td><code>vllm/agg-h100-dspark-kv-router/deploy.yaml</code></td><td>DSpark</td><td>KV router</td><td>80</td><td>303.84</td><td>2037.43</td><td>101.87</td></tr>
-<tr data-sku="h100" data-variant="agg"><td><code>vllm/agg-h100-dspark/deploy.yaml</code></td><td>DSpark</td><td>Single worker</td><td>20</td><td>238.64</td><td>1878.11</td><td>93.91</td></tr>
-<tr data-sku="h100" data-variant="agg"><td><code>vllm/agg-h100-dflash/deploy.yaml</code></td><td>DFlash</td><td>Single worker</td><td>16</td><td>216.44</td><td>1757.75</td><td>109.86</td></tr>
-<tr data-sku="h100" data-variant="agg"><td><code>vllm/agg-h100-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>12</td><td>241.21</td><td>1275.37</td><td>106.28</td></tr>
-<tr data-sku="h200" data-variant="agg"><td><code>vllm/agg-h200-dspark-kv-router/deploy.yaml</code></td><td>DSpark</td><td>KV router</td><td>80</td><td>286.67</td><td>2171.00</td><td>108.55</td></tr>
-<tr data-sku="h200" data-variant="agg"><td><code>vllm/agg-h200-dspark/deploy.yaml</code></td><td>DSpark</td><td>Single worker</td><td>20</td><td>243.97</td><td>2193.59</td><td>109.68</td></tr>
-<tr data-sku="h200" data-variant="agg"><td><code>vllm/agg-h200-dflash/deploy.yaml</code></td><td>DFlash</td><td>Single worker</td><td>16</td><td>243.30</td><td>1744.04</td><td>109.00</td></tr>
-<tr data-sku="h200" data-variant="agg"><td><code>vllm/agg-h200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>12</td><td>250.66</td><td>1478.67</td><td>123.22</td></tr>
-<tr data-sku="gb200" data-variant="agg"><td><code>vllm/agg-gb200-dspark/deploy.yaml</code></td><td>DSpark</td><td>Single worker</td><td>24</td><td>296.82</td><td>2860.20</td><td>119.18</td></tr>
-<tr data-sku="gb200" data-variant="agg"><td><code>vllm/agg-gb200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>18</td><td>402.99</td><td>1758.22</td><td>97.68</td></tr>
-<tr data-sku="gb200" data-variant="agg"><td><code>vllm/agg-gb200-dflash/deploy.yaml</code></td><td>DFlash</td><td>Single worker</td><td>20</td><td>429.97</td><td>842.42</td><td>42.12</td></tr>
-<tr data-sku="b200" data-variant="vllm-disagg"><td><code>vllm/disagg-b200-dspark/deploy.yaml</code></td><td>DSpark</td><td>1P1D</td><td>8</td><td>236.43</td><td>904.03</td><td>226.01</td></tr>
-<tr data-sku="h100" data-variant="vllm-disagg"><td><code>vllm/disagg-h100-dflash/deploy.yaml</code></td><td>DFlash</td><td>1P1D</td><td>12</td><td>542.71</td><td>1117.29</td><td>186.21</td></tr>
-<tr data-sku="h100" data-variant="vllm-disagg"><td><code>vllm/disagg-h100-dspark/deploy.yaml</code></td><td>DSpark</td><td>1P1D</td><td>24</td><td>2028.23</td><td>1445.29</td><td>120.44</td></tr>
-<tr data-sku="h100" data-variant="vllm-disagg"><td><code>vllm/disagg-h100-mtp/deploy.yaml</code></td><td>MTP</td><td>1P1D</td><td>12</td><td>493.52</td><td>1055.68</td><td>175.95</td></tr>
-<tr data-sku="h200" data-variant="vllm-disagg"><td><code>vllm/disagg-h200-dflash/deploy.yaml</code></td><td>DFlash</td><td>1P1D</td><td>12</td><td>408.30</td><td>1277.86</td><td>212.98</td></tr>
-<tr data-sku="h200" data-variant="vllm-disagg"><td><code>vllm/disagg-h200-dspark/deploy.yaml</code></td><td>DSpark</td><td>1P1D</td><td>24</td><td>834.80</td><td>1656.90</td><td>138.08</td></tr>
-<tr data-sku="h200" data-variant="vllm-disagg"><td><code>vllm/disagg-h200-mtp/deploy.yaml</code></td><td>MTP</td><td>1P1D</td><td>12</td><td>424.66</td><td>1203.97</td><td>200.66</td></tr>
-<tr data-sku="gb200" data-variant="vllm-disagg"><td><code>vllm/disagg-gb200-dflash/deploy.yaml</code></td><td>DFlash</td><td>1P1D</td><td>4</td><td>491.40</td><td>584.85</td><td>292.43</td></tr>
-<tr data-sku="gb200" data-variant="vllm-disagg"><td><code>vllm/disagg-gb200-dspark/deploy.yaml</code></td><td>DSpark</td><td>1P1D</td><td>8</td><td>599.17</td><td>939.28</td><td>234.82</td></tr>
-<tr data-sku="b200" data-variant="trtllm-agg"><td><code>trtllm/agg-b200/deploy.yaml</code></td><td>None</td><td>Single worker</td><td>18</td><td>377.68</td><td>386.998</td><td>21.50</td></tr>
-<tr data-sku="b200" data-variant="trtllm-agg"><td><code>trtllm/agg-b200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>18</td><td>446.88</td><td>427.82</td><td>23.77</td></tr>
-<tr data-sku="h100" data-variant="trtllm-agg"><td><code>trtllm/agg-h100-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>12</td><td>1757.00</td><td>264.87</td><td>22.07</td></tr>
-<tr data-sku="h200" data-variant="trtllm-agg"><td><code>trtllm/agg-h200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>12</td><td>1630.96</td><td>269.26</td><td>22.44</td></tr>
-<tr data-sku="gb200" data-variant="trtllm-agg"><td><code>trtllm/agg-gb200/deploy.yaml</code></td><td>None</td><td>Single worker</td><td>18</td><td>318.88</td><td>280.10</td><td>15.56</td></tr>
-<tr data-sku="gb200" data-variant="trtllm-agg"><td><code>trtllm/agg-gb200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>18</td><td>400.88</td><td>580.09</td><td>32.23</td></tr>
+<tr data-sku="b200" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-b200-dspark-kv-router/deploy.yaml</code></td><td>DSpark</td><td>KV router</td><td>7</td><td>3.69</td><td>96</td><td>3541</td><td>3411</td><td>130</td><td>295.03</td><td>2507.70</td><td>104.49</td></tr>
+<tr data-sku="b200" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-b200-dspark/deploy.yaml</code></td><td>DSpark</td><td>Single worker</td><td>7</td><td>3.69</td><td>24</td><td>3541</td><td>3411</td><td>130</td><td>207.44</td><td>2471.12</td><td>102.96</td></tr>
+<tr data-sku="b200" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-b200-dflash/deploy.yaml</code></td><td>DFlash</td><td>Single worker</td><td>5</td><td>3.18</td><td>20</td><td>3541</td><td>3411</td><td>130</td><td>212.57</td><td>2004.06</td><td>100.20</td></tr>
+<tr data-sku="b200" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-b200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>3</td><td>2.874</td><td>18</td><td>3541</td><td>3411</td><td>130</td><td>217.12</td><td>1829.94</td><td>101.66</td></tr>
+<tr data-sku="h100" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-h100-dspark-kv-router/deploy.yaml</code></td><td>DSpark</td><td>KV router</td><td>7</td><td>3.69</td><td>80</td><td>3541</td><td>3411</td><td>130</td><td>303.84</td><td>2037.43</td><td>101.87</td></tr>
+<tr data-sku="h100" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-h100-dspark/deploy.yaml</code></td><td>DSpark</td><td>Single worker</td><td>7</td><td>3.69</td><td>20</td><td>3541</td><td>3411</td><td>130</td><td>238.64</td><td>1878.11</td><td>93.91</td></tr>
+<tr data-sku="h100" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-h100-dflash/deploy.yaml</code></td><td>DFlash</td><td>Single worker</td><td>5</td><td>3.18</td><td>16</td><td>3541</td><td>3411</td><td>130</td><td>216.44</td><td>1757.75</td><td>109.86</td></tr>
+<tr data-sku="h100" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-h100-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>7</td><td>3.687</td><td>12</td><td>3541</td><td>3411</td><td>130</td><td>241.21</td><td>1275.37</td><td>106.28</td></tr>
+<tr data-sku="h200" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-h200-dspark-kv-router/deploy.yaml</code></td><td>DSpark</td><td>KV router</td><td>7</td><td>3.69</td><td>80</td><td>3541</td><td>3411</td><td>130</td><td>286.67</td><td>2171.00</td><td>108.55</td></tr>
+<tr data-sku="h200" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-h200-dspark/deploy.yaml</code></td><td>DSpark</td><td>Single worker</td><td>7</td><td>3.69</td><td>20</td><td>3541</td><td>3411</td><td>130</td><td>243.97</td><td>2193.59</td><td>109.68</td></tr>
+<tr data-sku="h200" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-h200-dflash/deploy.yaml</code></td><td>DFlash</td><td>Single worker</td><td>5</td><td>3.18</td><td>16</td><td>3541</td><td>3411</td><td>130</td><td>243.30</td><td>1744.04</td><td>109.00</td></tr>
+<tr data-sku="h200" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-h200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>7</td><td>3.687</td><td>12</td><td>3541</td><td>3411</td><td>130</td><td>250.66</td><td>1478.67</td><td>123.22</td></tr>
+<tr data-sku="gb200" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-gb200-dspark/deploy.yaml</code></td><td>DSpark</td><td>Single worker</td><td>7</td><td>3.69</td><td>24</td><td>3541</td><td>3411</td><td>130</td><td>296.82</td><td>2860.20</td><td>119.18</td></tr>
+<tr data-sku="gb200" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-gb200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>3</td><td>2.874</td><td>18</td><td>3541</td><td>3411</td><td>130</td><td>402.99</td><td>1758.22</td><td>97.68</td></tr>
+<tr data-sku="gb200" data-engine="vllm" data-variant="agg"><td><code>vllm/agg-gb200-dflash/deploy.yaml</code></td><td>DFlash</td><td>Single worker</td><td>5</td><td>3.18</td><td>20</td><td>3541</td><td>3411</td><td>130</td><td>429.97</td><td>842.42</td><td>42.12</td></tr>
+<tr data-sku="b200" data-engine="vllm" data-variant="disagg"><td><code>vllm/disagg-b200-dspark/deploy.yaml</code></td><td>DSpark</td><td>1P1D</td><td>1</td><td>1.83</td><td>8</td><td>500</td><td>489</td><td>11</td><td>236.43</td><td>904.03</td><td>226.01</td></tr>
+<tr data-sku="h100" data-engine="vllm" data-variant="disagg"><td><code>vllm/disagg-h100-dflash/deploy.yaml</code></td><td>DFlash</td><td>1P1D</td><td>3</td><td>2.73</td><td>12</td><td>3541</td><td>3404</td><td>137</td><td>542.71</td><td>1117.29</td><td>186.21</td></tr>
+<tr data-sku="h100" data-engine="vllm" data-variant="disagg"><td><code>vllm/disagg-h100-dspark/deploy.yaml</code></td><td>DSpark</td><td>1P1D</td><td>1</td><td>1.83</td><td>24</td><td>3541</td><td>3411</td><td>130</td><td>2028.23</td><td>1445.29</td><td>120.44</td></tr>
+<tr data-sku="h100" data-engine="vllm" data-variant="disagg"><td><code>vllm/disagg-h100-mtp/deploy.yaml</code></td><td>MTP</td><td>1P1D</td><td>5</td><td>3.421</td><td>12</td><td>3541</td><td>3398</td><td>143</td><td>493.52</td><td>1055.68</td><td>175.95</td></tr>
+<tr data-sku="h200" data-engine="vllm" data-variant="disagg"><td><code>vllm/disagg-h200-dflash/deploy.yaml</code></td><td>DFlash</td><td>1P1D</td><td>3</td><td>2.73</td><td>12</td><td>3541</td><td>3401</td><td>140</td><td>408.30</td><td>1277.86</td><td>212.98</td></tr>
+<tr data-sku="h200" data-engine="vllm" data-variant="disagg"><td><code>vllm/disagg-h200-dspark/deploy.yaml</code></td><td>DSpark</td><td>1P1D</td><td>1</td><td>1.83</td><td>24</td><td>3541</td><td>3411</td><td>130</td><td>834.80</td><td>1656.90</td><td>138.08</td></tr>
+<tr data-sku="h200" data-engine="vllm" data-variant="disagg"><td><code>vllm/disagg-h200-mtp/deploy.yaml</code></td><td>MTP</td><td>1P1D</td><td>5</td><td>3.421</td><td>12</td><td>3541</td><td>3342</td><td>199</td><td>424.66</td><td>1203.97</td><td>200.66</td></tr>
+<tr data-sku="gb200" data-engine="vllm" data-variant="disagg"><td><code>vllm/disagg-gb200-dflash/deploy.yaml</code></td><td>DFlash</td><td>1P1D</td><td>7</td><td>3.41</td><td>4</td><td>3541</td><td>3411</td><td>130</td><td>491.40</td><td>584.85</td><td>292.43</td></tr>
+<tr data-sku="gb200" data-engine="vllm" data-variant="disagg"><td><code>vllm/disagg-gb200-dspark/deploy.yaml</code></td><td>DSpark</td><td>1P1D</td><td>1</td><td>1.83</td><td>8</td><td>3541</td><td>3411</td><td>130</td><td>599.17</td><td>939.28</td><td>234.82</td></tr>
+<tr data-sku="b200" data-engine="trtllm"><td><code>trtllm/agg-b200/deploy.yaml</code></td><td>None</td><td>Single worker</td><td>0</td><td>0.0</td><td>18</td><td>500</td><td>489</td><td>11</td><td>377.68</td><td>386.998</td><td>21.50</td></tr>
+<tr data-sku="b200" data-engine="trtllm"><td><code>trtllm/agg-b200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>3</td><td>2.874</td><td>18</td><td>500</td><td>489</td><td>11</td><td>446.88</td><td>427.82</td><td>23.77</td></tr>
+<tr data-sku="h100" data-engine="trtllm"><td><code>trtllm/agg-h100-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>7</td><td>3.687</td><td>12</td><td>500</td><td>499</td><td>1</td><td>1757.00</td><td>264.87</td><td>22.07</td></tr>
+<tr data-sku="h200" data-engine="trtllm"><td><code>trtllm/agg-h200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>7</td><td>3.687</td><td>12</td><td>500</td><td>499</td><td>1</td><td>1630.96</td><td>269.26</td><td>22.44</td></tr>
+<tr data-sku="gb200" data-engine="trtllm"><td><code>trtllm/agg-gb200/deploy.yaml</code></td><td>None</td><td>Single worker</td><td>0</td><td>0.0</td><td>18</td><td>500</td><td>499</td><td>1</td><td>318.88</td><td>280.10</td><td>15.56</td></tr>
+<tr data-sku="gb200" data-engine="trtllm"><td><code>trtllm/agg-gb200-mtp/deploy.yaml</code></td><td>MTP</td><td>Single worker</td><td>3</td><td>2.874</td><td>18</td><td>500</td><td>499</td><td>1</td><td>400.88</td><td>580.09</td><td>32.23</td></tr>
 </tbody>
 </table>
 </div>
 
-## Compare All Targets
+## Model cache
 
-<div className="dynamo-variant-table-wrap">
-<table className="dynamo-variant-table">
-<thead>
-<tr><th>Runtime</th><th>Topology</th><th>GPU</th><th>Spec decode options</th><th>Checked-in manifests</th></tr>
-</thead>
-<tbody>
-<tr data-sku="b200" data-variant="agg"><td>vLLM</td><td>Aggregated</td><td>B200</td><td>MTP, DFlash, DSpark</td><td><code>vllm/agg-b200-dspark-kv-router/deploy.yaml</code> (DSpark + KV router)<br /><code>vllm/agg-b200-dspark/deploy.yaml</code><br /><code>vllm/agg-b200-dflash/deploy.yaml</code><br /><code>vllm/agg-b200-mtp/deploy.yaml</code></td></tr>
-<tr data-sku="h100" data-variant="agg"><td>vLLM</td><td>Aggregated</td><td>H100</td><td>MTP, DFlash, DSpark</td><td><code>vllm/agg-h100-dspark-kv-router/deploy.yaml</code> (DSpark + KV router)<br /><code>vllm/agg-h100-dspark/deploy.yaml</code><br /><code>vllm/agg-h100-dflash/deploy.yaml</code><br /><code>vllm/agg-h100-mtp/deploy.yaml</code></td></tr>
-<tr data-sku="h200" data-variant="agg"><td>vLLM</td><td>Aggregated</td><td>H200</td><td>MTP, DFlash, DSpark</td><td><code>vllm/agg-h200-dspark-kv-router/deploy.yaml</code> (DSpark + KV router)<br /><code>vllm/agg-h200-dspark/deploy.yaml</code><br /><code>vllm/agg-h200-dflash/deploy.yaml</code><br /><code>vllm/agg-h200-mtp/deploy.yaml</code></td></tr>
-<tr data-sku="gb200" data-variant="agg"><td>vLLM</td><td>Aggregated</td><td>GB200</td><td>MTP, DFlash, DSpark</td><td><code>vllm/agg-gb200-dspark/deploy.yaml</code><br /><code>vllm/agg-gb200-dflash/deploy.yaml</code><br /><code>vllm/agg-gb200-mtp/deploy.yaml</code></td></tr>
-<tr data-sku="b200" data-variant="vllm-disagg"><td>vLLM</td><td>Disaggregated 1P1D</td><td>B200</td><td>DSpark</td><td><code>vllm/disagg-b200-dspark/deploy.yaml</code></td></tr>
-<tr data-sku="h100" data-variant="vllm-disagg"><td>vLLM</td><td>Disaggregated 1P1D</td><td>H100</td><td>MTP, DFlash, DSpark</td><td><code>vllm/disagg-h100-dspark/deploy.yaml</code><br /><code>vllm/disagg-h100-dflash/deploy.yaml</code><br /><code>vllm/disagg-h100-mtp/deploy.yaml</code></td></tr>
-<tr data-sku="h200" data-variant="vllm-disagg"><td>vLLM</td><td>Disaggregated 1P1D</td><td>H200</td><td>MTP, DFlash, DSpark</td><td><code>vllm/disagg-h200-dspark/deploy.yaml</code><br /><code>vllm/disagg-h200-dflash/deploy.yaml</code><br /><code>vllm/disagg-h200-mtp/deploy.yaml</code></td></tr>
-<tr data-sku="gb200" data-variant="vllm-disagg"><td>vLLM</td><td>Disaggregated 1P1D</td><td>GB200</td><td>DFlash, DSpark</td><td><code>vllm/disagg-gb200-dspark/deploy.yaml</code><br /><code>vllm/disagg-gb200-dflash/deploy.yaml</code></td></tr>
-<tr data-sku="b200" data-variant="trtllm-agg"><td>TensorRT-LLM</td><td>Aggregated</td><td>B200</td><td>MTP, no-spec fallback</td><td><code>trtllm/agg-b200-mtp/deploy.yaml</code><br /><code>trtllm/agg-b200/deploy.yaml</code></td></tr>
-<tr data-sku="h100" data-variant="trtllm-agg"><td>TensorRT-LLM</td><td>Aggregated</td><td>H100</td><td>MTP</td><td><code>trtllm/agg-h100-mtp/deploy.yaml</code></td></tr>
-<tr data-sku="h200" data-variant="trtllm-agg"><td>TensorRT-LLM</td><td>Aggregated</td><td>H200</td><td>MTP</td><td><code>trtllm/agg-h200-mtp/deploy.yaml</code></td></tr>
-<tr data-sku="gb200" data-variant="trtllm-agg"><td>TensorRT-LLM</td><td>Aggregated</td><td>GB200</td><td>MTP, no-spec fallback</td><td><code>trtllm/agg-gb200-mtp/deploy.yaml</code><br /><code>trtllm/agg-gb200/deploy.yaml</code></td></tr>
-</tbody>
-</table>
+The download Job pulls three repositories:
+
+- `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4`
+- `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DFlash`
+- `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark`
+
+<div data-engine="vllm" data-variant="agg disagg">
+
+Every vLLM recipe serves `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4` as the target model. The draft model depends on the speculative decoding mode: MTP uses the embedded MTP draft, DFlash uses `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DFlash`, and DSpark uses `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark`.
+
 </div>
-
-<div data-variant="vllm-disagg trtllm-agg">
 
 ## Notes
 
-<div data-variant="vllm-disagg">
+- Replace `your-image-pull-secret` and any cluster-specific networking resource names with values available in the target cluster.
 
-- H100 disaggregated manifests request `vpc.amazonaws.com/efa: 4`; H200 and B200 disaggregated manifests request `rdma/ib: 1`. Change those resources when your cluster exposes different RDMA devices.
+<div data-sku="b200" data-engine="vllm" data-variant="agg disagg">
+
+- The B200 vLLM manifests disable the FlashInfer FP8 ScaledMM linear kernel with `VLLM_DISABLED_KERNELS: FlashInferFP8ScaledMMLinearKernel`.
 
 </div>
 
-<div data-variant="trtllm-agg">
+<div data-sku="gb200" data-engine="vllm" data-variant="disagg">
+
+- The GB200 disaggregated manifests disable the FlashInfer FP8 ScaledMM linear kernel with `VLLM_DISABLED_KERNELS: FlashInferFP8ScaledMMLinearKernel`.
+
+</div>
+
+<div data-engine="vllm" data-variant="disagg">
+
+- Disaggregated recipes require identical speculative-decoding settings on the prefill and decode workers so NIXL cache metadata stays compatible. Do not change `SPECULATIVE_CONFIG` on only one side.
+
+</div>
+
+<div data-engine="trtllm">
 
 - TensorRT-LLM manifests are experimental in this recipe.
-
-</div>
+- MTP and no-spec TensorRT-LLM recipes are separate serving configurations with their own manifest-level engine settings.
+- No TensorRT-LLM row meets the `tok/s/user >= 50` pass criterion in the source results (15.56 to 32.23 tok/s/user).
 
 </div>
 

--- a/docs/fern/pages/recipes/model-recipes/nemotron-3-super.mdx
+++ b/docs/fern/pages/recipes/model-recipes/nemotron-3-super.mdx
@@ -9,7 +9,7 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-Each target below is a validated aggregated vLLM deployment of Nemotron-3-Super — NVIDIA's ~120B hybrid Mamba/Attention/MoE model (~12B active) — with MTP speculative decoding (DL=3) and KV-aware routing; the B200 agentic target measured 1388.4 system output tok/s per GPU on its trace. B200 serves the NVFP4 checkpoint, H200 the FP8 checkpoint. Pick your GPU and workload; every command on this page updates to match.
+Each target below is a validated aggregated vLLM deployment of Nemotron-3-Super — NVIDIA's ~120B hybrid Mamba/Attention/MoE model (~12B active) — with MTP speculative decoding (DL=3) and KV-aware routing; the B200 agentic target measured 1388.4 system output tok/s per GPU on its trace. B200 serves the NVFP4 checkpoint, H200 the FP8 checkpoint. Pick your GPU, workload, backend, and topology; every command on this page updates to match.
 
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
@@ -27,39 +27,71 @@ Each target below is a validated aggregated vLLM deployment of Nemotron-3-Super 
 <input type="radio" id="recipe-usecase-agentic" name="recipe-usecase" value="agentic" />
 <label htmlFor="recipe-usecase-agentic">Agentic</label>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-usecase="chat">
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-vllm" name="recipe-engine" value="vllm" defaultChecked />
+<label htmlFor="recipe-engine-vllm">vLLM</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Topology</span>
+<input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" defaultChecked />
+<label htmlFor="recipe-variant-agg">Aggregated</label>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="chat" data-variant="agg">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4</span>
 <span><b>Precision</b> NVFP4 + FP8 KV cache</span>
-<span><b>GPUs</b> 4x B200 per worker, TP4 + EP (2 replicas)</span>
-<span><b>All2All</b> DeepEP high-throughput</span>
+<span><b>GPUs</b> 8x B200 (2x TP4)</span>
+<span><b>All2All backend</b> DeepEP high-throughput</span>
 <span><b>Spec decode</b> MTP, DL=3</span>
-<span><b>Workload</b> Chat 8K/1K, 70% KV reuse</span>
+<span><b>Workload</b> Chat trace (8k_1k_70kv)</span>
+<span><b>MoE backend</b> FLASHINFER_TRTLLM</span>
+<span><b>Attention backend</b> FLASH_ATTN</span>
+<span><b>AllReduce backend</b> FlashInfer TRTLLM</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-usecase="agentic">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4</span>
 <span><b>Precision</b> NVFP4 + FP8 KV cache</span>
-<span><b>GPUs</b> 4x B200 per worker, TP4 + EP (2 replicas)</span>
-<span><b>All2All</b> DeepEP low-latency</span>
+<span><b>GPUs</b> 8x B200 (2x TP4)</span>
+<span><b>All2All backend</b> DeepEP low-latency</span>
 <span><b>Spec decode</b> MTP, DL=3</span>
-<span><b>Workload</b> Agentic 64K/400, 90% KV reuse</span>
+<span><b>Workload</b> Agentic trace (64k_400_90kv)</span>
+<span><b>MoE backend</b> FLASHINFER_TRTLLM</span>
+<span><b>Attention backend</b> FLASH_ATTN</span>
+<span><b>AllReduce backend</b> FlashInfer TRTLLM</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-usecase="chat">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="agg">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8</span>
 <span><b>Precision</b> FP8 + FP8 KV cache</span>
-<span><b>GPUs</b> 4x H200 per worker, TP4 + EP (2 replicas)</span>
-<span><b>All2All</b> FlashInfer NVLink one-sided</span>
+<span><b>GPUs</b> 8x H200 (2x TP4)</span>
+<span><b>All2All backend</b> FlashInfer NVLink one-sided</span>
 <span><b>Spec decode</b> MTP, DL=3</span>
-<span><b>Workload</b> Chat 8K/1K, 70% KV reuse</span>
+<span><b>Workload</b> Chat trace (8k_1k_70kv)</span>
+<span><b>MoE backend</b> FLASHINFER_CUTLASS (default)</span>
+<span><b>Attention backend</b> FLASH_ATTN (default)</span>
+<span><b>AllReduce backend</b> FlashInfer TRTLLM (default)</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-usecase="agentic">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8</span>
 <span><b>Precision</b> FP8 + FP8 KV cache</span>
-<span><b>GPUs</b> 4x H200 per worker, TP4 + EP (2 replicas)</span>
-<span><b>All2All</b> DeepEP high-throughput</span>
+<span><b>GPUs</b> 8x H200 (2x TP4)</span>
+<span><b>All2All backend</b> DeepEP high-throughput</span>
 <span><b>Spec decode</b> MTP, DL=3</span>
-<span><b>Workload</b> Agentic 64K/400, 90% KV reuse</span>
+<span><b>Workload</b> Agentic trace (64k_400_90kv)</span>
+<span><b>MoE backend</b> FLASHINFER_CUTLASS (default)</span>
+<span><b>Attention backend</b> FLASH_ATTN (default)</span>
+<span><b>AllReduce backend</b> FlashInfer TRTLLM (default)</span>
 </div>
 </div>
+
+## Configurations
+
+All four targets run aggregated vLLM 0.21.0 (runtime image `vllm-runtime:1.3.0-nemotron-super-dev.1`) with two TP4 + EP worker replicas, MTP speculative decoding (DL=3), and KV-aware routing. They differ in checkpoint, kernel backends, and the trace they are benchmarked against.
+
+This is a Day-0 recipe on a dedicated dev runtime image (`vllm-runtime:1.3.0-nemotron-super-dev.1`); it is functional and benchmarked but not yet promoted to a release runtime image.
+
+## Supported features
+
+- The model is text-only. Reasoning is controlled per request via `chat_template_kwargs` (`enable_thinking: true|false`); tool calling and function calling with JSON arguments are supported.
 
 ## Prerequisites
 
@@ -95,17 +127,24 @@ kubectl create secret generic hf-token-secret \
 Edit namespace, storage class, image tags, and other cluster-specific settings in the manifests before applying them.
 </Warning>
 
-## Deploy
+## Quick Start
 
-Prepare the model cache and download the checkpoint for your SKU:
+### 1. Create storage
+
+The PVC requests 200Gi ReadWriteMany and ships with `storageClassName: vast`. Pick an RWX-capable storage class for your cluster and edit `storageClassName` in `model-cache.yaml` first (`kubectl get storageclass`):
+
+```bash
+kubectl apply -f recipes/nemotron-3-super/model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+### 2. Download model
+
+Both download Jobs share the same PVC and pull into the default Hugging Face cache layout (`HF_HOME=/model-cache`), so files land at `/model-cache/hub/models--nvidia--<repo>/snapshots/<sha>/`. Downloading both checkpoints lands ~200 GB on the PVC — the default size in `model-cache.yaml` — so bump `storage:` first if you want both. Download the checkpoint for your SKU:
 
 <div data-sku="b200">
 
 ```bash
-# 1. Storage — edit storageClassName in model-cache.yaml first (kubectl get storageclass).
-kubectl apply -f recipes/nemotron-3-super/model-cache/model-cache.yaml -n ${NAMESPACE}
-
-# 2. Download. B200 uses the NVFP4 checkpoint (~80 GB).
+# B200 uses the NVFP4 checkpoint (~80 GB, ~80 s on Vast storage).
 kubectl apply -f recipes/nemotron-3-super/model-cache/model-download.yaml -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=1800s
 ```
@@ -115,19 +154,16 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 <div data-sku="h200">
 
 ```bash
-# 1. Storage — edit storageClassName in model-cache.yaml first (kubectl get storageclass).
-kubectl apply -f recipes/nemotron-3-super/model-cache/model-cache.yaml -n ${NAMESPACE}
-
-# 2. Download. H200 uses the FP8 checkpoint (~120 GB).
+# H200 uses the FP8 checkpoint (~120 GB).
 kubectl apply -f recipes/nemotron-3-super/model-cache/model-download-fp8.yaml -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/model-download-fp8 -n ${NAMESPACE} --timeout=3600s
 ```
 
 </div>
 
-Downloading both checkpoints lands ~200 GB on the PVC — the default size in `model-cache.yaml` — so bump `storage:` first if you want both.
+### 3. Deploy the DGD
 
-Then deploy. First-time boot per worker takes about 6–9 minutes (image pull + vLLM engine init + Inductor + CUDA graph capture up to size 512):
+Then deploy. Each deployment runs two worker replicas of four GPUs each, so a worker occupies half a node. First-time boot per worker takes about 6–9 minutes (image pull + vLLM engine init + Inductor + CUDA graph capture up to size 512):
 
 <div data-sku="b200" data-usecase="chat">
 
@@ -165,7 +201,7 @@ kubectl get dgd nemotron-3-super-h200-agentic -n ${NAMESPACE} -w
 
 </div>
 
-## Smoke Test
+### 4. Smoke test
 
 Send a test request to verify the deployment serves traffic:
 
@@ -233,9 +269,15 @@ curl http://localhost:8000/v1/chat/completions \
 
 </div>
 
-## Benchmark
+### 5. Benchmark
 
-A single AIPerf trace-replay Job ([`perf/perf.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3-super/perf/perf.yaml)) covers every target — only `ENDPOINT`, `TRACE_FILE`, `TARGET_MODEL`, and `CONCURRENCY` change in its env block (`TARGET_MODEL` is the NVFP4 id for B200, FP8 for H200). First stage the bundled traces from [`recipes/nemotron-3-super/perf/traces/`](https://github.com/ai-dynamo/dynamo/tree/main/recipes/nemotron-3-super/perf/traces) onto the `model-cache` PVC:
+A single [AIPerf](https://github.com/ai-dynamo/aiperf) trace-replay Job ([`perf/perf.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3-super/perf/perf.yaml)) covers every target — only `ENDPOINT`, `TRACE_FILE`, `TARGET_MODEL`, and `CONCURRENCY` change in its env block (`TARGET_MODEL` is the NVFP4 id for B200, FP8 for H200). If you run more than one benchmark in the same namespace, also update `metadata.name` / `labels.app` in `perf.yaml` so jobs and artifact directories stay distinct.
+
+The Job first waits for `GET /v1/models` on the DGD frontend to return the configured `TARGET_MODEL` (up to ~1h by default), then runs a short warmup pass and replays the configured trace at a single `CONCURRENCY` value, writing raw artifacts to the shared `model-cache` PVC. The bench pod is co-located with the DGD frontend (`podAffinity` on the frontend's host) so client → server traffic stays on a single node.
+
+Before benchmarking, set the worker `replicas` in the DGD to match the target you want to measure — the published numbers assume 2.
+
+The benchmark replays a [Mooncake-format](https://github.com/kvcache-ai/Mooncake) trace via `aiperf --custom-dataset-type mooncake_trace`; each JSONL line describes one request (`input_length`, `output_length`, `hash_ids`). These are workload-shape traces, not model-specific, so you can stage your own Mooncake-format JSONLs at whatever path you point `TRACE_FILE` at. The bundled traces in [`recipes/nemotron-3-super/perf/traces/`](https://github.com/ai-dynamo/dynamo/tree/main/recipes/nemotron-3-super/perf/traces) ship as a full file plus `<flavour>_short_30perc.jsonl` (~30%) and `<flavour>_short_15perc.jsonl` (~15%) subsets — for shorter runs, point `TRACE_FILE` at a smaller subset rather than capping run time. Stage them on the `model-cache` PVC:
 
 ```bash
 kubectl run pvc-helper -n ${NAMESPACE} \
@@ -246,9 +288,11 @@ kubectl run pvc-helper -n ${NAMESPACE} \
 kubectl cp recipes/nemotron-3-super/perf/traces ${NAMESPACE}/pvc-helper:/model-cache/
 ```
 
+Keep `pvc-helper` around afterwards — it is how you fetch the results off the PVC.
+
 <div data-sku="b200" data-usecase="chat">
 
-Set `ENDPOINT` to `nemotron-3-super-b200-chat-frontend:8000` (the Job default) with the NVFP4 `TARGET_MODEL` and the chat trace, then apply. The Job wraps this AIPerf Mooncake trace replay:
+Set `ENDPOINT` to `nemotron-3-super-b200-chat-frontend:8000` and `TRACE_FILE` to `/model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl` (both are the Job defaults), `TARGET_MODEL` to `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` (also the default), and `CONCURRENCY` to `128` (the Job ships `"24"`), then apply. The Job wraps this AIPerf Mooncake trace replay:
 
 ```bash
 aiperf profile \
@@ -269,7 +313,7 @@ aiperf profile \
 
 <div data-sku="b200" data-usecase="agentic">
 
-Set `ENDPOINT` to `nemotron-3-super-b200-agentic-frontend:8000` with the NVFP4 `TARGET_MODEL` and the agentic trace, then apply. The Job wraps this AIPerf Mooncake trace replay:
+Set `ENDPOINT` to `nemotron-3-super-b200-agentic-frontend:8000`, `TRACE_FILE` to `/model-cache/traces/64k_400_90kv_agent_new_noschedule.jsonl`, `TARGET_MODEL` to `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` (the Job default), and `CONCURRENCY` to `192` (the Job ships `"24"`), then apply. The Job wraps this AIPerf Mooncake trace replay:
 
 ```bash
 aiperf profile \
@@ -290,7 +334,7 @@ aiperf profile \
 
 <div data-sku="h200" data-usecase="chat">
 
-Set `ENDPOINT` to `nemotron-3-super-h200-chat-frontend:8000` with the FP8 `TARGET_MODEL` and the chat trace, then apply. The Job wraps this AIPerf Mooncake trace replay:
+Set `ENDPOINT` to `nemotron-3-super-h200-chat-frontend:8000`, `TRACE_FILE` to `/model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl` (the Job default), `TARGET_MODEL` to `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8`, and `CONCURRENCY` to `64` (the Job ships `"24"`), then apply. The Job wraps this AIPerf Mooncake trace replay:
 
 ```bash
 aiperf profile \
@@ -311,7 +355,7 @@ aiperf profile \
 
 <div data-sku="h200" data-usecase="agentic">
 
-Set `ENDPOINT` to `nemotron-3-super-h200-agentic-frontend:8000` with the FP8 `TARGET_MODEL` and the agentic trace, then apply. The Job wraps this AIPerf Mooncake trace replay:
+Set `ENDPOINT` to `nemotron-3-super-h200-agentic-frontend:8000`, `TRACE_FILE` to `/model-cache/traces/64k_400_90kv_agent_new_noschedule.jsonl`, `TARGET_MODEL` to `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8`, and `CONCURRENCY` to `128` (the Job ships `"24"`), then apply. The Job wraps this AIPerf Mooncake trace replay:
 
 ```bash
 aiperf profile \
@@ -333,12 +377,71 @@ aiperf profile \
 ```bash
 kubectl apply -f recipes/nemotron-3-super/perf/perf.yaml -n ${NAMESPACE}
 kubectl logs -n ${NAMESPACE} -l job-name=nemotron-3-super-bench -f
+
+# Wait for completion — the Job carries a 2h hard cap, hence the matching timeout
 kubectl wait --for=condition=Complete job/nemotron-3-super-bench -n ${NAMESPACE} --timeout=7200s
 ```
 
-Artifacts land on the PVC under `/model-cache/perf/<epoch>_nemotron-3-super-bench/`. 15% and 30% trace subsets are provided for shorter runs. For concurrency sweeps, delete the worker pods between runs so residual KV/prefix-cache state does not skew results (Dynamo workers are PodClique pods — `kubectl rollout restart deployment` is a silent no-op) — see the [benchmark README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3-super/perf/README.md) for the full workflow, artifact layout, and tunable environment variables.
+Artifacts land on the PVC under `/model-cache/perf/<epoch>_nemotron-3-super-bench/`, which holds a `warmup/` subdirectory and a run directory named after the served model:
 
-## Expected Performance
+<div data-sku="b200">
+
+```text
+/model-cache/perf/<epoch>_nemotron-3-super-bench/
+  warmup/
+  NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4_trace_c<concurrency>_<timestamp>/
+    profile_export.json
+    inputs.json
+    ...
+```
+
+</div>
+
+<div data-sku="h200">
+
+```text
+/model-cache/perf/<epoch>_nemotron-3-super-bench/
+  warmup/
+  NVIDIA-Nemotron-3-Super-120B-A12B-FP8_trace_c<concurrency>_<timestamp>/
+    profile_export.json
+    inputs.json
+    ...
+```
+
+</div>
+
+Pull the results down through the helper pod, then clean up:
+
+```bash
+kubectl cp ${NAMESPACE}/pvc-helper:/model-cache/perf/<epoch>_nemotron-3-super-bench ./results
+
+kubectl delete job nemotron-3-super-bench -n ${NAMESPACE}
+kubectl delete pod pvc-helper -n ${NAMESPACE}
+```
+
+`perf.yaml` runs a **single** `CONCURRENCY` value. To sweep concurrencies you must clear server state between runs, otherwise residual KV/prefix-cache hits from the previous run skew results. For each value you want to measure:
+
+```bash
+# 1. Delete the previous bench job
+kubectl delete job nemotron-3-super-bench -n ${NAMESPACE} --ignore-not-found
+
+# 2. Drop KV / prefix-cache by deleting the worker pods; Grove respawns them
+#    (Dynamo workers are PodClique pods, not k8s Deployments — `kubectl rollout
+#    restart deployment ...` is a silent no-op against the Grove resource chain.)
+DGD=nemotron-3-super-b200-chat   # or any of the four variants
+kubectl delete pods -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD},nvidia.com/dynamo-component-type=worker
+
+# 3. Bump CONCURRENCY in perf.yaml, then re-apply
+kubectl apply -f recipes/nemotron-3-super/perf/perf.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/nemotron-3-super-bench -n ${NAMESPACE} --timeout=7200s
+```
+
+The bench Job's `wait_for_model_ready` loop covers the worker restart window — it re-polls `/v1/models` until the frontend reports ready again. See the [benchmark README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3-super/perf/README.md) for the full tunable environment variable table.
+
+- Both DGDs of a given SKU serve the same `--served-model-name`, so either trace can be replayed against either DGD by swapping `TRACE_FILE`.
+
+## Performance results
 
 Each target is tuned for its workload shape:
 
@@ -361,28 +464,33 @@ Measured results below replay the **15% trace subsets** (`*_short_15perc.jsonl`)
 </table>
 </div>
 
-## Compare All Targets
+## Spec-dec toggle
 
-All four targets run aggregated vLLM 0.21.0 (runtime image `vllm-runtime:1.3.0-nemotron-super-dev.1`) with two TP4 + EP worker replicas, MTP speculative decoding (DL=3), and KV-aware routing. They differ in checkpoint, kernel backends, and the trace they are benchmarked against:
-
-| | B200 chat | H200 chat | B200 agentic | H200 agentic |
-|---|---|---|---|---|
-| **GPUs** | 8x B200 (2x TP4) | 8x H200 (2x TP4) | 8x B200 (2x TP4) | 8x H200 (2x TP4) |
-| **Precision** | NVFP4 + FP8 KV | FP8 + FP8 KV | NVFP4 + FP8 KV | FP8 + FP8 KV |
-| **MoE backend** | FLASHINFER_TRTLLM | FLASHINFER_CUTLASS | FLASHINFER_TRTLLM | FLASHINFER_CUTLASS |
-| **Attention backend** | FLASH_ATTN | FLASH_ATTN | FLASH_ATTN | FLASH_ATTN |
-| **All2All backend** | DeepEP high-throughput | FlashInfer NVLink one-sided | DeepEP low-latency | DeepEP high-throughput |
-| **Workload** | Chat trace | Chat trace | Agentic trace | Agentic trace |
-
-## Notes
-
-- This is a Day-0 recipe on a dedicated dev runtime image (`vllm-runtime:1.3.0-nemotron-super-dev.1`); it is functional and benchmarked but not yet promoted to a release runtime image.
-- The namespace must carry the `kai.scheduler/enabled=true` label before deploying; without it, pods stay `SchedulingGated` indefinitely.
-- B200 chat and agentic ship with MTP spec dec ON by default (DL=3, `moe_backend=triton`, stripped `compilation-config`, `MAX_NUM_BATCHED_TOKENS=65536`). To turn MTP off, remove the `- --speculative-config=$(SPECULATIVE_CONFIG)` line from worker args; with the freed memory headroom you can bump `MAX_NUM_BATCHED_TOKENS` to `"131072"` and switch `COMPILATION_CONFIG` to the `compilation-config-fused` ConfigMap key for better throughput.
+- B200 chat and agentic ship with MTP spec dec ON by default (DL=3, `moe_backend=triton`, stripped `compilation-config`, `MAX_NUM_BATCHED_TOKENS=65536`). To turn MTP off, remove the `- --speculative-config=$(SPECULATIVE_CONFIG)` line from worker args; with the freed memory headroom you can bump `MAX_NUM_BATCHED_TOKENS` to `"131072"` and switch `COMPILATION_CONFIG` to the `compilation-config-fused` ConfigMap key — which enables `use_inductor_graph_partition` + `fuse_allreduce_rms` + `fuse_attn_quant` — for better throughput.
 - For a fixed-AL synthetic MTP run on H200, point the `SPECULATIVE_CONFIG` env at the `speculative-config-synthetic` ConfigMap key before deploying.
-- Known issue: some 400 HTTP errors raised by the workers on invalid inputs surface as 500 through the Dynamo frontend (the proxy does not always preserve the worker's original status code).
-- Reasoning is controlled per request via `chat_template_kwargs` (`enable_thinking: true|false`); tool calling and function calling with JSON arguments are supported.
-- Both DGDs of a given SKU serve the same `--served-model-name`, so either trace can be replayed against either DGD by swapping `TRACE_FILE`.
+
+## Known issues
+
+- Some 400 HTTP errors raised by the workers on invalid inputs surface as 500 through the Dynamo frontend (the proxy does not always preserve the worker's original status code).
+
+## File layout
+
+```text
+recipes/nemotron-3-super/
+  README.md
+  model-cache/
+    model-cache.yaml          # PVC (RWX, 200Gi on storageClass vast)
+    model-download.yaml       # Job: hf download NVFP4 checkpoint (B200)
+    model-download-fp8.yaml   # Job: hf download FP8 checkpoint (H200)
+  vllm/
+    agg-b200-chat/deploy.yaml      # DGD: B200×4, NVFP4, DeepEP high-throughput
+    agg-b200-agentic/deploy.yaml   # DGD: B200×4, NVFP4, DeepEP low-latency
+    agg-h200-chat/deploy.yaml      # DGD: H200×4, FP8, FlashInfer NVLink one-sided, MTP spec-dec
+    agg-h200-agentic/deploy.yaml   # DGD: H200×4, FP8, DeepEP high-throughput, MTP spec-dec
+  perf/
+    README.md                 # benchmark workflow
+    perf.yaml                 # AIPerf trace-replay Job
+```
 
 ## Source
 

--- a/docs/fern/pages/recipes/model-recipes/nemotron-3-ultra.mdx
+++ b/docs/fern/pages/recipes/model-recipes/nemotron-3-ultra.mdx
@@ -9,7 +9,7 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-Each target below is a validated aggregated vLLM deployment of Nemotron-3-Ultra — NVIDIA's ~550B hybrid Mamba/Attention/MoE model (~55B active) — with MTP speculative decoding (1 token) and KV-aware routing; the B200 agentic target measured 310.8 system output tok/s per GPU on its trace. Pick your GPU and workload; every command on this page updates to match.
+Each target below is a validated vLLM deployment of Nemotron-3-Ultra — NVIDIA's ~550B hybrid Mamba/Attention/MoE model (~55B active) — with MTP speculative decoding (1 token) and KV-aware routing; the B200 agentic target measured 310.8 system output tok/s per GPU on its trace. Pick your GPU, workload, backend, and topology — vLLM is the only backend this recipe ships — and every command on this page updates to match.
 
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
@@ -27,65 +27,134 @@ Each target below is a validated aggregated vLLM deployment of Nemotron-3-Ultra 
 <input type="radio" id="recipe-usecase-agentic" name="recipe-usecase" value="agentic" />
 <label htmlFor="recipe-usecase-agentic">Agentic</label>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-usecase="chat">
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-vllm" name="recipe-engine" value="vllm" defaultChecked />
+<label htmlFor="recipe-engine-vllm">vLLM</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Topology</span>
+<input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" defaultChecked />
+<label htmlFor="recipe-variant-agg">Aggregated</label>
+<input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" />
+<label htmlFor="recipe-variant-disagg" data-needs-sku="b200" data-needs-usecase="agentic">Disaggregated</label>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="chat">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4</span>
 <span><b>Precision</b> NVFP4 + FP8</span>
+<span><b>Backend</b> vLLM</span>
 <span><b>GPUs</b> 4x B200 per worker, TP4 + EP</span>
 <span><b>Spec decode</b> MTP, 1 token</span>
 <span><b>Routing</b> KV-aware</span>
 <span><b>Workload</b> Chat 8K/1K Moontrace, 70% KV reuse</span>
+<span><b>Mode</b> aggregated</span>
+<span><b>Parallelism</b> TP4 + EP</span>
+<span><b>Max sequences</b> 64</span>
+<span><b>Max batched tokens</b> 32768</span>
+<span><b>Block size</b> 64</span>
+<span><b>Reference concurrency</b> 18</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-usecase="agentic">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4</span>
 <span><b>Precision</b> NVFP4 + FP8</span>
+<span><b>Backend</b> vLLM</span>
 <span><b>GPUs</b> 4x B200 per worker, TP4 + EP</span>
 <span><b>Spec decode</b> MTP, 1 token</span>
 <span><b>Routing</b> KV-aware</span>
 <span><b>Workload</b> Agentic 64K/400 Moontrace, 90% KV reuse</span>
+<span><b>Mode</b> aggregated</span>
+<span><b>Parallelism</b> TP4 + EP</span>
+<span><b>Max sequences</b> 24</span>
+<span><b>Max batched tokens</b> 32768</span>
+<span><b>Block size</b> 64</span>
+<span><b>Reference concurrency</b> 20</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-usecase="chat">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4</span>
 <span><b>Precision</b> NVFP4 + FP8</span>
+<span><b>Backend</b> vLLM</span>
+<span><b>GPUs</b> 4x B200 prefill + 4x B200 decode</span>
+<span><b>Spec decode</b> no MTP</span>
+<span><b>Routing</b> KV-aware + P/D transfer</span>
+<span><b>Workload</b> Agentic 64K/400 Moontrace, 90% KV reuse</span>
+<span><b>Mode</b> disaggregated 1P1D</span>
+<span><b>Parallelism</b> TP4 prefill + TP4 decode</span>
+<span><b>Max sequences</b> 32</span>
+<span><b>Max batched tokens</b> 32768</span>
+<span><b>Block size</b> 64</span>
+<span><b>Reference concurrency</b> 32</span>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="chat">
+<span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4</span>
+<span><b>Precision</b> NVFP4 + FP8</span>
+<span><b>Backend</b> vLLM</span>
 <span><b>GPUs</b> 8x H200 per worker, TP8 + EP</span>
 <span><b>Spec decode</b> MTP, 1 token</span>
 <span><b>Routing</b> KV-aware</span>
 <span><b>Workload</b> Chat 8K/1K Moontrace, 70% KV reuse</span>
+<span><b>Mode</b> aggregated</span>
+<span><b>Parallelism</b> TP8 + EP</span>
+<span><b>Max sequences</b> 16</span>
+<span><b>Max batched tokens</b> 32768</span>
+<span><b>Block size</b> 64</span>
+<span><b>Reference concurrency</b> 10</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-usecase="agentic">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="agentic">
 <span><b>Checkpoint</b> nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4</span>
 <span><b>Precision</b> NVFP4 + FP8</span>
+<span><b>Backend</b> vLLM</span>
 <span><b>GPUs</b> 8x H200 per worker, TP8 + EP</span>
 <span><b>Spec decode</b> MTP, 1 token</span>
 <span><b>Routing</b> KV-aware</span>
 <span><b>Workload</b> Agentic 64K/400 Moontrace, 90% KV reuse</span>
+<span><b>Mode</b> aggregated</span>
+<span><b>Parallelism</b> TP8 + EP</span>
+<span><b>Max sequences</b> 32</span>
+<span><b>Max batched tokens</b> 32768</span>
+<span><b>Block size</b> 64</span>
+<span><b>Reference concurrency</b> 8</span>
 </div>
 </div>
+
+## Configurations
+
+All targets serve `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` on Dynamo + vLLM with the runtime image `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1`, NVFP4 + FP8 precision, and a 262144 max model length. Choose a GPU, workload, backend, and topology above to see that target's full configuration.
+
+The **Disaggregated** topology is offered on B200 with the agentic workload only; it is the one 1P1D lane the recipe ships, and it runs without MTP. Every target on this page runs the vLLM backend, so the **Backend** row offers vLLM alone.
+
+- This is a Day-0 recipe on a dedicated dev runtime image (`vllm-runtime:1.3.0-nemotron-ultra-dev.1`); it is functional and benchmarked but not yet promoted to a release runtime image.
+- No-MTP fallback manifests are included for every aggregated target at `vllm/agg-<sku>-<usecase>-nomtp/deploy.yaml`; their DGD names carry the `-nomtp` suffix, and their measured rows appear in the performance table below.
+
+## Supported Features
+
+- Supported features: text-only chat, reasoning control through `chat_template_kwargs`, tool calling with `qwen3_coder`, Ultra reasoning parser support through the model-local `ultra_v3_reasoning_parser.py` (validated by the model-validate Job), and raw Moontrace replay through AIPerf.
 
 ## Prerequisites
 
-<div data-sku="b200">
+<div data-sku="b200" data-engine="vllm">
 
-- A Kubernetes cluster with the Dynamo Platform installed (DGD CRDs served) and **4x B200 per aggregated worker** available (8x B200 for the disaggregated fallback).
+- A Kubernetes cluster with the Dynamo Platform installed (DGD CRDs served) and **4x B200 per aggregated worker** available (8x B200 total for the disaggregated fallback: 4x B200 prefill + 4x B200 decode).
 - An NGC image pull secret named `nvcr-secret` for `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1`.
 - A Hugging Face token with access to `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4`.
-- A `shared-model-cache` PVC containing the tokenizer-patched Ultra model view, or permission to create and populate it with the manifests in `model-cache/` (~1200 Gi).
+- A `shared-model-cache` PVC containing the tokenizer-patched Ultra model view at `/opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` — the worker path shared by all B200 and H200 recipes — or permission to create and populate it with the manifests in `model-cache/` (~1200 Gi).
 
 </div>
 
-<div data-sku="h200">
+<div data-sku="h200" data-engine="vllm">
 
 - A Kubernetes cluster with the Dynamo Platform installed (DGD CRDs served) and **8x H200 per worker** available.
 - An NGC image pull secret named `nvcr-secret` for `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1`.
 - A Hugging Face token with access to `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4`.
-- A `shared-model-cache` PVC containing the tokenizer-patched Ultra model view, or permission to create and populate it with the manifests in `model-cache/` (~1200 Gi).
+- A `shared-model-cache` PVC containing the tokenizer-patched Ultra model view at `/opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` — the worker path shared by all B200 and H200 recipes — or permission to create and populate it with the manifests in `model-cache/` (~1200 Gi).
 
 </div>
 
-Create the namespace and token secret:
+Create the namespace, and create the `hf-token-secret` when you use the model download Job:
 
 ```bash
 export NAMESPACE=your-namespace
 kubectl create namespace ${NAMESPACE}
+
 kubectl create secret generic hf-token-secret \
   --from-literal=HF_TOKEN="$HF_TOKEN" \
   -n ${NAMESPACE}
@@ -95,26 +164,49 @@ kubectl create secret generic hf-token-secret \
 Edit namespace, storage class, image tags, node selectors, and cluster-specific placement in the manifests before applying them.
 </Warning>
 
-## Deploy
+## Quick Start
 
-Create and populate the model cache, then validate the patched model view before deploying any server:
+### 1. Create or Validate Model Cache
+
+If the namespace does not already provide a `shared-model-cache` PVC, create and populate it; otherwise skip to step 3 and only validate the patched model view before deploying any server:
 
 ```bash
+# 0. Dry-run the model-cache manifests server-side first.
+kubectl -n ${NAMESPACE} apply --dry-run=server -f recipes/nemotron-3-ultra/model-cache/model-cache.yaml
+kubectl -n ${NAMESPACE} apply --dry-run=server -f recipes/nemotron-3-ultra/model-cache/model-download.yaml
+kubectl -n ${NAMESPACE} apply --dry-run=server -f recipes/nemotron-3-ultra/model-cache/model-validate.yaml
+
 # 1. Storage — edit storageClassName in model-cache.yaml first (kubectl get storageclass).
 kubectl apply -f recipes/nemotron-3-ultra/model-cache/model-cache.yaml -n ${NAMESPACE}
 
-# 2. Download the checkpoint and build the tokenizer-patched model view.
+# 2. Download the checkpoint and build the tokenizer-patched model view (No-GPU Job).
 kubectl apply -f recipes/nemotron-3-ultra/model-cache/model-download.yaml -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/nemotron-ultra-model-download -n ${NAMESPACE} --timeout=12h
 
-# 3. Validate the patched model view (model/tokenizer/parser files).
+# 3. Validate the patched model view (model/tokenizer/parser files, No-GPU Job).
 kubectl apply -f recipes/nemotron-3-ultra/model-cache/model-validate.yaml -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/nemotron-ultra-model-validate -n ${NAMESPACE} --timeout=30m
 ```
 
+The download Job pulls `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` at revision `main` — set `MODEL_REVISION` to the release-pinned commit when one is provided — into the exact patched model path. The validation Job checks the minimum files vLLM needs at startup and fails with an actionable message if the model view is missing:
+
+```text
+config.json
+tokenizer.json
+tokenizer_config.json
+generation_config.json
+ultra_v3_reasoning_parser.py
+```
+
+<Warning>
+Do not apply `model-cache.yaml` over an existing platform-managed `shared-model-cache` PVC — storage class and capacity are immutable. When the platform already provides the PVC, skip `model-cache.yaml` and `model-download.yaml` and run only `model-validate.yaml`; a server-side dry-run against the existing PVC may warn about immutable field changes even though the platform cache itself is valid.
+</Warning>
+
+### 2. Deploy the DGD
+
 Then deploy:
 
-<div data-sku="b200" data-usecase="chat">
+<div data-sku="b200" data-engine="vllm" data-usecase="chat">
 
 ```bash
 kubectl apply -f recipes/nemotron-3-ultra/vllm/agg-b200-chat-mtp/deploy.yaml -n ${NAMESPACE}
@@ -123,16 +215,18 @@ kubectl get dgd ultra-agg-b200-chat-mtp -n ${NAMESPACE} -w
 
 </div>
 
-<div data-sku="b200" data-usecase="agentic">
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/nemotron-3-ultra/vllm/agg-b200-agentic-mtp/deploy.yaml -n ${NAMESPACE}
 kubectl get dgd ultra-agg-b200-agentic-mtp -n ${NAMESPACE} -w
 ```
 
-### Alternate topology: disaggregated fallback (1P1D, no MTP)
+</div>
 
-A disaggregated B200 agentic fallback splits prefill and decode into separate TP4 workers (8x B200 total: 4 prefill + 4 decode) with KV-aware routing plus P/D transfer, and runs without MTP. Its frontend service is `ultra-disagg-b200-1p1d-agentic-nomtp-frontend`; benchmark it by retargeting the same perf Job at that endpoint with the agentic trace at concurrency 32:
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
+
+The disaggregated B200 agentic target splits prefill and decode into separate TP4 workers (4x B200 prefill + 4x B200 decode) with KV-aware routing plus P/D transfer, and runs without MTP. Its frontend service is `ultra-disagg-b200-1p1d-agentic-nomtp-frontend`; benchmark it by retargeting the same perf Job at that endpoint with the agentic trace at concurrency 32:
 
 ```bash
 kubectl apply -f recipes/nemotron-3-ultra/vllm/disagg-b200-agentic/deploy.yaml -n ${NAMESPACE}
@@ -143,7 +237,7 @@ Measured on the 15% agentic trace at concurrency 32: **61.6 user output tok/s** 
 
 </div>
 
-<div data-sku="h200" data-usecase="chat">
+<div data-sku="h200" data-engine="vllm" data-usecase="chat">
 
 ```bash
 kubectl apply -f recipes/nemotron-3-ultra/vllm/agg-h200-chat-mtp/deploy.yaml -n ${NAMESPACE}
@@ -152,7 +246,7 @@ kubectl get dgd ultra-agg-h200-chat-mtp -n ${NAMESPACE} -w
 
 </div>
 
-<div data-sku="h200" data-usecase="agentic">
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic">
 
 ```bash
 kubectl apply -f recipes/nemotron-3-ultra/vllm/agg-h200-agentic-mtp/deploy.yaml -n ${NAMESPACE}
@@ -161,11 +255,11 @@ kubectl get dgd ultra-agg-h200-agentic-mtp -n ${NAMESPACE} -w
 
 </div>
 
-## Smoke Test
+### 3. Smoke Test
 
 Send a test request to verify the deployment serves traffic:
 
-<div data-sku="b200" data-usecase="chat">
+<div data-sku="b200" data-engine="vllm" data-usecase="chat">
 
 ```bash
 kubectl port-forward svc/ultra-agg-b200-chat-mtp-frontend 8000:8000 -n ${NAMESPACE}
@@ -173,7 +267,7 @@ kubectl port-forward svc/ultra-agg-b200-chat-mtp-frontend 8000:8000 -n ${NAMESPA
 
 </div>
 
-<div data-sku="b200" data-usecase="agentic">
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/ultra-agg-b200-agentic-mtp-frontend 8000:8000 -n ${NAMESPACE}
@@ -181,7 +275,15 @@ kubectl port-forward svc/ultra-agg-b200-agentic-mtp-frontend 8000:8000 -n ${NAME
 
 </div>
 
-<div data-sku="h200" data-usecase="chat">
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
+
+```bash
+kubectl port-forward svc/ultra-disagg-b200-1p1d-agentic-nomtp-frontend 8000:8000 -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat">
 
 ```bash
 kubectl port-forward svc/ultra-agg-h200-chat-mtp-frontend 8000:8000 -n ${NAMESPACE}
@@ -189,7 +291,7 @@ kubectl port-forward svc/ultra-agg-h200-chat-mtp-frontend 8000:8000 -n ${NAMESPA
 
 </div>
 
-<div data-sku="h200" data-usecase="agentic">
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic">
 
 ```bash
 kubectl port-forward svc/ultra-agg-h200-agentic-mtp-frontend 8000:8000 -n ${NAMESPACE}
@@ -209,9 +311,11 @@ curl http://localhost:8000/v1/chat/completions \
        \"chat_template_kwargs\":{\"enable_thinking\":false,\"force_nonempty_content\":true}}"
 ```
 
-## Benchmark
+### 4. Benchmark
 
-A single AIPerf trace-replay Job ([`perf/perf.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3-ultra/perf/perf.yaml)) covers every target — only `ENDPOINT`, `TRACE_FILE`, and `CONCURRENCY` change in its env block. First stage the bundled Moontrace files from [`recipes/nemotron-3-ultra/perf/traces/`](https://github.com/ai-dynamo/dynamo/tree/main/recipes/nemotron-3-ultra/perf/traces) onto the `shared-model-cache` PVC:
+A single AIPerf trace-replay Job ([`perf/perf.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3-ultra/perf/perf.yaml)) covers every target — the benchmark is identical across variants, and `ENDPOINT`, `TRACE_FILE`, `CONCURRENCY`, and `TARGET_MODEL` change in its env block to target a specific server. The Job waits for `GET /v1/models` on the DGD frontend to return `TARGET_MODEL`, runs a short warmup, then replays the configured Mooncake-format trace at one `CONCURRENCY` value; artifacts are written to the `shared-model-cache` PVC under `/opt/models/perf`.
+
+First stage the bundled Moontrace files from [`recipes/nemotron-3-ultra/perf/traces/`](https://github.com/ai-dynamo/dynamo/tree/main/recipes/nemotron-3-ultra/perf/traces) onto the `shared-model-cache` PVC:
 
 ```bash
 kubectl run pvc-helper -n ${NAMESPACE} \
@@ -223,9 +327,54 @@ kubectl exec -n ${NAMESPACE} pvc-helper -- mkdir -p /opt/models/traces
 kubectl cp recipes/nemotron-3-ultra/perf/traces/. ${NAMESPACE}/pvc-helper:/opt/models/traces/
 ```
 
-<div data-sku="b200" data-usecase="chat">
+Keep `pvc-helper` around for fetching artifacts later, or delete it once staging is complete.
 
-Set `ENDPOINT` to `ultra-agg-b200-chat-mtp-frontend:8000` (the Job default) with the chat trace at concurrency 18, then apply. The Job wraps this AIPerf raw Moontrace replay:
+#### Traces
+
+The benchmark replays a Mooncake-format trace through `aiperf --custom-dataset-type mooncake_trace`. Each JSONL line describes one request with fields such as `input_length`, `output_length`, and `hash_ids`. The traces bundled with this recipe:
+
+<div data-engine="vllm" data-usecase="chat">
+
+- `traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl` — 1805 rows
+- `traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_30perc.jsonl` — 3609 rows
+- `traces/nim_turbo_8k_1k_70kv_chat_new_noschedule.jsonl` — 12031 rows
+
+</div>
+
+<div data-engine="vllm" data-usecase="agentic">
+
+- `traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` — 3541 rows
+- `traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_30perc.jsonl` — 7082 rows
+- `traces/nim_turbo_64k_400_90kv_agent_new_noschedule.jsonl` — 23608 rows
+
+</div>
+
+The 15% and 30% traces are prefix slices, not random samples, so they preserve trace order and cache warmup behavior.
+
+#### Replay policy
+
+The intended replay policy is raw direct Moontrace replay:
+
+- No context-length filtering.
+- No OSL clipping.
+- No synthetic output-length substitution.
+- No `--export-http-trace`.
+- No `bad_words` guard.
+- `ignore_eos:true` is the only extra input.
+- HTTP400 and no-content rows remain benchmark failure evidence.
+
+#### Run the Job
+
+<div data-sku="b200" data-engine="vllm" data-usecase="chat">
+
+Point the Job env block at the B200 aggregated chat MTP server, then apply — these are the shipped defaults:
+
+- `ENDPOINT`: `ultra-agg-b200-chat-mtp-frontend:8000`
+- `TARGET_MODEL`: `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4`
+- `TRACE_FILE`: `/opt/models/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl`
+- `CONCURRENCY`: `18`
+
+The Job wraps this AIPerf raw Moontrace replay:
 
 ```bash
 aiperf profile \
@@ -241,11 +390,20 @@ aiperf profile \
   --concurrency 18 --random-seed 42
 ```
 
+For the no-MTP fallback row, use `ultra-agg-b200-chat-nomtp-frontend:8000` with the same trace at concurrency 16.
+
 </div>
 
-<div data-sku="b200" data-usecase="agentic">
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
-Set `ENDPOINT` to `ultra-agg-b200-agentic-mtp-frontend:8000` with the agentic trace at concurrency 20, then apply. The Job wraps this AIPerf raw Moontrace replay:
+Point the Job env block at the B200 aggregated agentic MTP server, then apply:
+
+- `ENDPOINT`: `ultra-agg-b200-agentic-mtp-frontend:8000`
+- `TARGET_MODEL`: `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4`
+- `TRACE_FILE`: `/opt/models/traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_15perc.jsonl`
+- `CONCURRENCY`: `20`
+
+The Job wraps this AIPerf raw Moontrace replay:
 
 ```bash
 aiperf profile \
@@ -261,13 +419,49 @@ aiperf profile \
   --concurrency 20 --random-seed 42
 ```
 
-For the disaggregated fallback, point `ENDPOINT` at `ultra-disagg-b200-1p1d-agentic-nomtp-frontend:8000` with the same agentic trace at concurrency 32.
+For the no-MTP fallback row, use `ultra-agg-b200-agentic-nomtp-frontend:8000` with the same trace at concurrency 8. For the disaggregated fallback, point `ENDPOINT` at `ultra-disagg-b200-1p1d-agentic-nomtp-frontend:8000` with the same agentic trace at concurrency 32.
 
 </div>
 
-<div data-sku="h200" data-usecase="chat">
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 
-Set `ENDPOINT` to `ultra-agg-h200-chat-mtp-frontend:8000` with the chat trace at concurrency 10, then apply. The Job wraps this AIPerf raw Moontrace replay:
+Point the Job env block at the B200 disaggregated (1P1D) agentic server, then apply:
+
+- `ENDPOINT`: `ultra-disagg-b200-1p1d-agentic-nomtp-frontend:8000`
+- `TARGET_MODEL`: `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4`
+- `TRACE_FILE`: `/opt/models/traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_15perc.jsonl`
+- `CONCURRENCY`: `32`
+
+The Job wraps this AIPerf raw Moontrace replay:
+
+```bash
+aiperf profile \
+  -m nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 \
+  --tokenizer /opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 \
+  --tokenizer-trust-remote-code \
+  --input-file /opt/models/traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_15perc.jsonl \
+  --custom-dataset-type mooncake_trace \
+  --prompt-input-tokens-block-size 512 \
+  --url http://ultra-disagg-b200-1p1d-agentic-nomtp-frontend:8000 \
+  --streaming --use-server-token-count \
+  --extra-inputs ignore_eos:true \
+  --concurrency 32 --random-seed 42
+```
+
+This lane runs without MTP. It measured **61.6 user output tok/s** and **231.1 system output tok/s/GPU** on the 15% agentic trace at concurrency 32.
+
+</div>
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat">
+
+Point the Job env block at the H200 aggregated chat MTP server, then apply:
+
+- `ENDPOINT`: `ultra-agg-h200-chat-mtp-frontend:8000`
+- `TARGET_MODEL`: `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4`
+- `TRACE_FILE`: `/opt/models/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl`
+- `CONCURRENCY`: `10`
+
+The Job wraps this AIPerf raw Moontrace replay:
 
 ```bash
 aiperf profile \
@@ -283,11 +477,20 @@ aiperf profile \
   --concurrency 10 --random-seed 42
 ```
 
+For the no-MTP fallback row, use `ultra-agg-h200-chat-nomtp-frontend:8000` with the same trace at concurrency 8.
+
 </div>
 
-<div data-sku="h200" data-usecase="agentic">
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic">
 
-Set `ENDPOINT` to `ultra-agg-h200-agentic-mtp-frontend:8000` with the agentic trace at concurrency 8, then apply. The Job wraps this AIPerf raw Moontrace replay:
+Point the Job env block at the H200 aggregated agentic MTP server, then apply:
+
+- `ENDPOINT`: `ultra-agg-h200-agentic-mtp-frontend:8000`
+- `TARGET_MODEL`: `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4`
+- `TRACE_FILE`: `/opt/models/traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_15perc.jsonl`
+- `CONCURRENCY`: `8`
+
+The Job wraps this AIPerf raw Moontrace replay:
 
 ```bash
 aiperf profile \
@@ -303,7 +506,11 @@ aiperf profile \
   --concurrency 8 --random-seed 42
 ```
 
+For the no-MTP fallback row, use `ultra-agg-h200-agentic-nomtp-frontend:8000` with the same trace at concurrency 8.
+
 </div>
+
+The bench pod is co-located with the DGD frontend through pod affinity on the frontend host, so deploy the DGD first. If you run more than one benchmark in the same namespace, also update `metadata.name` and `labels.app` in `perf.yaml` so Jobs and artifact directories stay distinct.
 
 ```bash
 kubectl apply -f recipes/nemotron-3-ultra/perf/perf.yaml -n ${NAMESPACE}
@@ -311,9 +518,61 @@ kubectl logs -n ${NAMESPACE} -l job-name=ultra-bench -f
 kubectl wait --for=condition=Complete job/ultra-bench -n ${NAMESPACE} --timeout=7200s
 ```
 
-Artifacts land on the PVC under `/opt/models/perf/<epoch>_ultra-bench/`. 15% and 30% prefix-slice traces are provided for shorter runs. For concurrency sweeps, delete the worker pods between runs so residual KV/prefix-cache state does not skew results — see the [benchmark README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3-ultra/perf/README.md) for the full workflow, artifact layout, and tunable environment variables.
+Fetch the artifacts through the helper pod, then clean up:
 
-## Expected Performance
+```bash
+kubectl cp ${NAMESPACE}/pvc-helper:/opt/models/perf/<epoch>_ultra-bench ./results
+
+kubectl delete job ultra-bench -n ${NAMESPACE}
+kubectl delete pod pvc-helper -n ${NAMESPACE}
+```
+
+Results land on the PVC in this layout:
+
+```text
+/opt/models/perf/<epoch>_<job-name>/
+  trace_replay_manifest.json
+  warmup/
+  NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4_trace_c<concurrency>_<timestamp>/
+    profile_export.json
+    inputs.json
+    ...
+```
+
+#### Concurrency sweep
+
+`perf.yaml` runs a single `CONCURRENCY` value. To measure multiple concurrencies, clear server state between runs so residual KV cache and prefix-cache hits from the previous run do not skew results. For each concurrency value:
+
+```bash
+kubectl delete job ultra-bench -n ${NAMESPACE} --ignore-not-found
+
+DGD=ultra-agg-b200-chat-mtp
+kubectl delete pods -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD},nvidia.com/dynamo-component-type=worker
+
+kubectl apply -f recipes/nemotron-3-ultra/perf/perf.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/ultra-bench -n ${NAMESPACE} --timeout=7200s
+```
+
+The Job's `wait_for_model_ready` loop handles the worker restart window by polling `/v1/models` until the frontend reports the target model.
+
+#### Tunable environment variables
+
+Edit the `env` block on the Job:
+
+| Variable | Default | Notes |
+|---|---|---|
+| `ENDPOINT` | `ultra-agg-b200-chat-mtp-frontend:8000` | DGD frontend service:port |
+| `TRACE_FILE` | `/opt/models/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl` | Swap to the chat or agentic 15%, 30%, or full trace |
+| `CONCURRENCY` | `18` | Single value; see the concurrency sweep above |
+| `TARGET_MODEL` | `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` | Must match the served model name on the DGD frontend |
+| `TOKENIZER_PATH` | `/opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` | Used by AIPerf tokenization |
+| `AIPERF_VERSION` | `0.10.0` | aiperf version used for benchmarking |
+| `ROOT_ARTIFACT_DIR` | `/opt/models/perf` | Shared PVC artifact root |
+
+For release evidence, preserve the AIPerf output directory, Job logs, DGD manifest, image digest, trace SHA, server-shape evidence, and model-cache validation proof. The [benchmark README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3-ultra/perf/README.md) carries the same workflow alongside the per-variant targeting table.
+
+## Benchmark Results
 
 Each target is tuned for its workload shape:
 
@@ -322,7 +581,7 @@ Each target is tuned for its workload shape:
 | Chat | 8K | 1K | 70% |
 | Agentic | 64K | 400 | 90% |
 
-B200 rows use 15% raw Moontrace replay with `raw_direct_no_filter` trace semantics; H200 rows use 300-sample replay evidence. `User output tok/s` is Gen TPS/user p50 from AIPerf; `System output tok/s/GPU` is TPS/GPU. Your selected target's rows are highlighted:
+B200 rows use 15% raw Moontrace replay with `raw_direct_no_filter` trace semantics; H200 rows use 300-sample replay evidence. Every row assumes the vLLM DGD manifests in this recipe, including the CUDA13 image `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1` and the pinned worker runtime settings. `User output tok/s` is Gen TPS/user p50 from AIPerf; `System output tok/s/GPU` is TPS/GPU. Your selected target's rows are highlighted:
 
 <div className="dynamo-variant-table-wrap">
 <table className="dynamo-variant-table">
@@ -330,9 +589,9 @@ B200 rows use 15% raw Moontrace replay with `raw_direct_no_filter` trace semanti
 <tbody>
 <tr data-sku="b200" data-usecase="chat"><td><code>vllm/agg-b200-chat-mtp/deploy.yaml</code></td><td>B200</td><td>AGG</td><td>chat</td><td>yes</td><td>18</td><td>52.0</td><td>201.4</td></tr>
 <tr data-sku="b200" data-usecase="chat"><td><code>vllm/agg-b200-chat-nomtp/deploy.yaml</code></td><td>B200</td><td>AGG</td><td>chat</td><td>no</td><td>16</td><td>51.0</td><td>181.3</td></tr>
-<tr data-sku="b200" data-usecase="agentic"><td><code>vllm/agg-b200-agentic-mtp/deploy.yaml</code></td><td>B200</td><td>AGG</td><td>agentic</td><td>yes</td><td>20</td><td>80.6</td><td>310.8</td></tr>
-<tr data-sku="b200" data-usecase="agentic"><td><code>vllm/agg-b200-agentic-nomtp/deploy.yaml</code></td><td>B200</td><td>AGG</td><td>agentic</td><td>no</td><td>8</td><td>99.5</td><td>175.9</td></tr>
-<tr data-sku="b200" data-usecase="agentic"><td><code>vllm/disagg-b200-agentic/deploy.yaml</code></td><td>B200</td><td>1P1D</td><td>agentic</td><td>no</td><td>32</td><td>61.6</td><td>231.1</td></tr>
+<tr data-sku="b200" data-usecase="agentic" data-variant="agg"><td><code>vllm/agg-b200-agentic-mtp/deploy.yaml</code></td><td>B200</td><td>AGG</td><td>agentic</td><td>yes</td><td>20</td><td>80.6</td><td>310.8</td></tr>
+<tr data-sku="b200" data-usecase="agentic" data-variant="agg"><td><code>vllm/agg-b200-agentic-nomtp/deploy.yaml</code></td><td>B200</td><td>AGG</td><td>agentic</td><td>no</td><td>8</td><td>99.5</td><td>175.9</td></tr>
+<tr data-sku="b200" data-usecase="agentic" data-variant="disagg"><td><code>vllm/disagg-b200-agentic/deploy.yaml</code></td><td>B200</td><td>1P1D</td><td>agentic</td><td>no</td><td>32</td><td>61.6</td><td>231.1</td></tr>
 <tr data-sku="h200" data-usecase="chat"><td><code>vllm/agg-h200-chat-mtp/deploy.yaml</code></td><td>H200</td><td>AGG</td><td>chat</td><td>yes</td><td>10</td><td>58.7</td><td>46.8</td></tr>
 <tr data-sku="h200" data-usecase="chat"><td><code>vllm/agg-h200-chat-nomtp/deploy.yaml</code></td><td>H200</td><td>AGG</td><td>chat</td><td>no</td><td>8</td><td>54.2</td><td>43.0</td></tr>
 <tr data-sku="h200" data-usecase="agentic"><td><code>vllm/agg-h200-agentic-mtp/deploy.yaml</code></td><td>H200</td><td>AGG</td><td>agentic</td><td>yes</td><td>8</td><td>53.2</td><td>27.4</td></tr>
@@ -343,28 +602,41 @@ B200 rows use 15% raw Moontrace replay with `raw_direct_no_filter` trace semanti
 
 Treat each row together with its matching recipe, image, trace, and server-shape artifacts.
 
-## Compare All Targets
+## Reasoning Controls
 
-All targets serve `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` on the dedicated dev runtime image `vllm-runtime:1.3.0-nemotron-ultra-dev.1` with KV-aware routing and a 262144 max model length:
+- Reasoning is controlled per request. Send `{"chat_template_kwargs": {"enable_thinking": false, "force_nonempty_content": true}}` for a no-thinking response, and `{"nvext": {"max_thinking_tokens": 10}}` to cap the reasoning budget. Do not send `force_nonempty_content` as a top-level request parameter.
 
-| | B200 chat | H200 chat | B200 agentic | H200 agentic | B200 disagg agentic |
-|---|---|---|---|---|---|
-| **GPUs** | 4x B200 | 8x H200 | 4x B200 | 8x H200 | 4x B200 prefill + 4x B200 decode |
-| **Mode** | aggregated | aggregated | aggregated | aggregated | disaggregated 1P1D |
-| **Parallelism** | TP4 + EP | TP8 + EP | TP4 + EP | TP8 + EP | TP4 prefill + TP4 decode |
-| **Spec decode** | MTP, 1 token | MTP, 1 token | MTP, 1 token | MTP, 1 token | no MTP |
-| **Max sequences** | 64 | 16 | 24 | 32 | 32 |
-| **Reference concurrency** | 18 | 10 | 20 | 8 | 32 |
-| **Workload** | Chat trace | Chat trace | Agentic trace | Agentic trace | Agentic trace |
+## Known Issues
 
-## Notes
-
-- This is a Day-0 recipe on a dedicated dev runtime image (`vllm-runtime:1.3.0-nemotron-ultra-dev.1`); it is functional and benchmarked but not yet promoted to a release runtime image.
+- Optional OpenAI/vLLM/NIM API fields are shared Dynamo API compatibility gaps, not Ultra recipe-specific failures. Top-level reasoning controls such as `include_reasoning`, `thinking_token_budget`, `reasoning_effort`, and `usage.reasoning_tokens` are part of that shared work; use the Ultra-specific `chat_template_kwargs` and `nvext` controls above as the current model-specific workaround.
 - The recipes pin `VLLM_DISABLED_KERNELS=FlashInferFP8ScaledMMLinearKernel` and pass `--no-enable-flashinfer-autotune` on vLLM workers. Do not remove these unless rerunning the benchmark qualification — they select the non-FlashInfer FP8 linear kernel path and avoid a measured vLLM 0.22 FlashInfer FP8 regression.
-- No-MTP fallback manifests are included for every aggregated target at `vllm/agg-<sku>-<usecase>-nomtp/deploy.yaml`; their DGD names carry the `-nomtp` suffix, and their measured rows appear in the performance table above.
-- Reasoning is controlled per request via `chat_template_kwargs` (`enable_thinking`, `force_nonempty_content`) and `nvext.max_thinking_tokens`. Do not send `force_nonempty_content` as a top-level request parameter. Top-level reasoning controls such as `include_reasoning` and `reasoning_effort` are part of shared Dynamo API compatibility work, not Ultra-specific failures.
-- Raw Moontrace replay may contain over-context or pathological long-generation rows. Preserve them as HTTP/error evidence rather than dropping them silently.
-- Tool calling uses the `qwen3_coder` parser; reasoning parsing uses the model-local `ultra_v3_reasoning_parser.py` (validated by the model-validate Job).
+- Raw Moontrace replay may contain over-context or pathological long-generation rows. Do not drop those rows silently; preserve them as HTTP/error evidence or classify the run accordingly.
+
+## File Layout
+
+```text
+recipes/nemotron-3-ultra/
+  README.md
+  model-cache/
+    README.md
+    model-cache.yaml          # PVC
+    model-download.yaml       # Job: populate patched Ultra model view
+    model-validate.yaml       # Job: validate model/tokenizer/parser files
+  vllm/
+    agg-b200-chat-mtp/deploy.yaml
+    agg-b200-chat-nomtp/deploy.yaml
+    agg-b200-agentic-mtp/deploy.yaml
+    agg-b200-agentic-nomtp/deploy.yaml
+    agg-h200-chat-mtp/deploy.yaml
+    agg-h200-chat-nomtp/deploy.yaml
+    agg-h200-agentic-mtp/deploy.yaml
+    agg-h200-agentic-nomtp/deploy.yaml
+    disagg-b200-agentic/deploy.yaml
+  perf/
+    README.md                 # benchmark workflow
+    perf.yaml                 # AIPerf trace-replay Job
+    traces/                   # 15%, 30%, and full Moontrace JSONL assets
+```
 
 ## Source
 

--- a/docs/fern/pages/recipes/model-recipes/overview.mdx
+++ b/docs/fern/pages/recipes/model-recipes/overview.mdx
@@ -37,11 +37,11 @@ Start with the model, runtime, and hardware you need to run. Model cards are sor
   <div className="dynamo-recipe-browser-header">
     <div>
       <p className="dynamo-recipe-eyebrow">Recipe catalog</p>
-      <h3>17 model families</h3>
+      <h3>18 model families</h3>
       <p>Filter by provider, runtime, and hardware. Each card notes its serving technique and workload shape.</p>
     </div>
     <div className="dynamo-catalog-facts">
-      <strong>84</strong>
+      <strong>92</strong>
       <span>Deployable configurations</span>
       <button className="dynamo-filter-reset" type="reset">Reset filters</button>
     </div>
@@ -77,6 +77,15 @@ Start with the model, runtime, and hardware you need to run. Model cards are sor
     <p className="dynamo-model-summary">Day-0 vLLM recipes for Moonshot's Kimi-K3 on GB200 and GB300, aggregated or with prefill/decode disaggregation and KV-aware routing.</p>
     <div className="dynamo-model-tags"><span>vLLM</span><span>GB200 · GB300</span><span>Day-0</span></div>
   <a className="dynamo-card-link" href="kimi-k3.mdx" aria-label="Open the Kimi-K3 recipe">Open recipe</a>
+  </div>
+  <div className="dynamo-model-card" data-recipe-card data-provider="qwen" data-runtime="vllm sglang" data-hardware="gb200 gb300" data-technique="aggregated disaggregated kv-routing spec-decoding" data-workload="agentic-coding long-context-reuse">
+    <div className="dynamo-model-card-top">
+      <img className="dynamo-model-logo" src="../../../assets/img/recipes/providers/qwen.webp" alt="" />
+      <div><h3>Qwen3.8-2.4T-A95B</h3><p>Qwen</p></div>
+    </div>
+    <p className="dynamo-model-summary">vLLM and SGLang recipes for a 2.4T hybrid gated-delta-net + 512-expert MoE checkpoint on 16x GB300 or GB200, aggregated or SGLang-disaggregated, with TP16 over MNNVL and KV-aware routing.</p>
+    <div className="dynamo-model-tags"><span>vLLM + SGLang</span><span>16x GB300 · GB200 per worker</span><span>Chat + agentic · 262K context</span></div>
+  <a className="dynamo-card-link" href="qwen-3-8-2-4t-a95b-fp8.mdx" aria-label="Open the Qwen3.8-2.4T-A95B recipe">Open recipe</a>
   </div>
   <div className="dynamo-model-card" data-recipe-card data-provider="zai" data-runtime="sglang" data-hardware="b200 h200" data-technique="aggregated disaggregated kv-routing spec-decoding" data-workload="agentic-coding long-context-reuse">
     <div className="dynamo-model-card-top">

--- a/docs/fern/pages/recipes/model-recipes/qwen-3-8-2-4t-a95b-fp8.mdx
+++ b/docs/fern/pages/recipes/model-recipes/qwen-3-8-2-4t-a95b-fp8.mdx
@@ -10,7 +10,7 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 <RecipeStyles />
 
 
-Each target below is a Dynamo + vLLM or SGLang deployment of [Qwen3.8-2.4T-A95B](https://huggingface.co/Qwen/Qwen3.8-2.4T-A95B-FP8) — a hybrid gated-delta-net + MoE model with 512 experts and a 262k-token context — with KV-aware routing and FP8 weights/KV cache. Tensor parallelism runs over MNNVL through Kubernetes ComputeDomains. Pick your GPU architecture, serving topology, and inference engine; every command on this page updates to match.
+Each target below is a Dynamo + vLLM or SGLang deployment of [Qwen3.8-2.4T-A95B](https://huggingface.co/Qwen/Qwen3.8-2.4T-A95B-FP8) — a hybrid model that interleaves gated delta-net (GDN, linear attention with a short convolution state) with full grouped-query attention (GQA), on top of a 512-expert MoE and a 262k-token context — with KV-aware routing and FP8 weights/KV cache. The supported modality is text only; the model has no vision tower. Tensor parallelism runs over MNNVL through Kubernetes ComputeDomains. Pick your GPU, workload, backend, and serving topology; every command on this page updates to match.
 
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
@@ -22,66 +22,167 @@ Each target below is a Dynamo + vLLM or SGLang deployment of [Qwen3.8-2.4T-A95B]
 <label htmlFor="recipe-sku-gb200">GB200</label>
 </div>
 <div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-chat" name="recipe-usecase" value="chat" defaultChecked />
+<label htmlFor="recipe-usecase-chat">Chat</label>
+<input type="radio" id="recipe-usecase-agentic" name="recipe-usecase" value="agentic" />
+<label htmlFor="recipe-usecase-agentic" data-needs-engine="vllm" data-needs-variant="agg">Agentic</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-vllm" name="recipe-engine" value="vllm" defaultChecked />
+<label htmlFor="recipe-engine-vllm" data-needs-variant="agg">vLLM</label>
+<input type="radio" id="recipe-engine-sglang" name="recipe-engine" value="sglang" />
+<label htmlFor="recipe-engine-sglang" data-needs-usecase="chat">SGLang</label>
+</div>
+<div className="dynamo-target-picker-row">
 <span className="dynamo-target-picker-dim">Topology</span>
 <input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" defaultChecked />
 <label htmlFor="recipe-variant-agg">Aggregated</label>
 <input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" />
-<label htmlFor="recipe-variant-disagg">Disaggregated</label>
+<label htmlFor="recipe-variant-disagg" data-needs-engine="sglang" data-needs-usecase="chat">Disaggregated</label>
 </div>
-<div className="dynamo-target-picker-row">
-<span className="dynamo-target-picker-dim">Engine</span>
-<input type="radio" id="recipe-engine-vllm" name="recipe-engine" value="vllm" defaultChecked />
-<label htmlFor="recipe-engine-vllm">vLLM</label>
-<input type="radio" id="recipe-engine-sglang" name="recipe-engine" value="sglang" />
-<label htmlFor="recipe-engine-sglang">SGLang</label>
-</div>
-<div className="dynamo-target-picker-summary" data-sku="gb300" data-variant="agg">
+<div className="dynamo-target-picker-summary" data-sku="gb300" data-engine="vllm" data-usecase="chat agentic" data-variant="agg">
 <span><b>Checkpoint</b> Qwen/Qwen3.8-2.4T-A95B-FP8</span>
 <span><b>Precision</b> FP8 weights, FP8 KV</span>
-<span><b>GPUs</b> 16x GB300 (4 nodes), 1 replica</span>
+<span><b>GPUs</b> 16× GB300, 4 nodes, 1 replica</span>
 <span><b>Parallelism</b> TP16 over MNNVL</span>
-<span><b>Routing</b> event-driven KV-aware, prefix caching</span>
+<span><b>MoE backend</b> not set in the manifest</span>
+<span><b>AllReduce backend</b> FlashInfer MNNVL</span>
+<span><b>Speculative decoding</b> MTP, 3 speculative tokens</span>
+<span><b>Context length</b> 262 144</span>
+<span><b>CUDA graphs</b> FULL_AND_PIECEWISE, capped at batch size 512</span>
+<span><b>Batching</b> 12288 tokens / 512 sequences</span>
+<span><b>GPU memory utilization</b> 0.90</span>
+<span><b>Routing</b> event-driven KV-aware</span>
+<span><b>Prefix caching</b> Enabled</span>
 </div>
 
-<div className="dynamo-target-picker-summary" data-sku="gb300" data-variant="disagg" data-engine="sglang">
+<div className="dynamo-target-picker-summary" data-sku="gb300" data-engine="sglang" data-usecase="chat" data-variant="agg">
 <span><b>Checkpoint</b> Qwen/Qwen3.8-2.4T-A95B-FP8</span>
 <span><b>Precision</b> FP8 weights, FP8 KV</span>
-<span><b>GPUs</b> 16x GB300 prefill (4 nodes) + 16x GB300 decode (4 nodes)</span>
-<span><b>Parallelism</b> TP16 / TP16 over MNNVL</span>
-<span><b>KV transfer</b> NIXL over cuda_ipc + MNNVL</span>
-<span><b>Routing</b> KV-aware, load-balanced prefill; NIXL KV transfer</span>
-</div>
-<div className="dynamo-target-picker-summary" data-sku="gb200" data-variant="agg" data-engine="vllm">
-<span><b>Checkpoint</b> Qwen/Qwen3.8-2.4T-A95B-FP8</span>
-<span><b>Precision</b> FP8 weights, FP8 KV</span>
-<span><b>GPUs</b> 16x GB200 (4 nodes), 1 replica</span>
+<span><b>GPUs</b> 16× GB300, 4 nodes, 1 replica</span>
 <span><b>Parallelism</b> TP16 over MNNVL</span>
 <span><b>MoE backend</b> flashinfer_trtllm</span>
-<span><b>Routing</b> KV-aware (ZMQ events)</span>
+<span><b>Attention backend</b> trtllm_mha</span>
+<span><b>AllReduce backend</b> FlashInfer MNNVL</span>
+<span><b>Speculative decoding</b> NEXTN, 3 steps / 4 draft tokens, eagle-topk 1</span>
+<span><b>Context length</b> 262 144</span>
+<span><b>CUDA graphs</b> breakable prefill / full decode</span>
+<span><b>mem-fraction-static</b> 0.90</span>
+<span><b>Watchdog timeout</b> 900s</span>
+<span><b>Routing</b> event-driven KV-aware</span>
+<span><b>Prefix caching</b> Enabled (radix cache)</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="gb200" data-variant="agg" data-engine="sglang">
+
+<div className="dynamo-target-picker-summary" data-sku="gb300" data-engine="sglang" data-usecase="chat" data-variant="disagg">
 <span><b>Checkpoint</b> Qwen/Qwen3.8-2.4T-A95B-FP8</span>
 <span><b>Precision</b> FP8 weights, FP8 KV</span>
-<span><b>GPUs</b> 16x GB200 (4 nodes), 1 replica</span>
-<span><b>Parallelism</b> TP16 over MNNVL</span>
-<span><b>MoE backend</b> flashinfer_trtllm; trtllm_mha attention</span>
-<span><b>Routing</b> KV-aware (ZMQ events)</span>
-</div>
-<div className="dynamo-target-picker-summary" data-sku="gb200" data-variant="disagg" data-engine="sglang">
-<span><b>Checkpoint</b> Qwen/Qwen3.8-2.4T-A95B-FP8</span>
-<span><b>Precision</b> FP8 weights, FP8 KV</span>
-<span><b>GPUs</b> 16x GB200 × 2 prefill + 16x GB200 decode (2P1D, 12 nodes)</span>
+<span><b>GPUs</b> 16× GB300 prefill + 16× GB300 decode (1P1D, 8 nodes)</span>
 <span><b>Parallelism</b> TP16 / TP16 over MNNVL</span>
-<span><b>MoE backend</b> flashinfer_trtllm; trtllm_mha attention</span>
-<span><b>Routing</b> KV-aware, load-balanced across prefill replicas; NIXL KV transfer over cuda_ipc + MNNVL</span>
+<span><b>KV transfer</b> NIXL over cuda_ipc + MNNVL</span>
+<span><b>MoE backend</b> flashinfer_trtllm</span>
+<span><b>Attention backend</b> trtllm_mha</span>
+<span><b>AllReduce backend</b> FlashInfer MNNVL</span>
+<span><b>Speculative decoding</b> NEXTN, 3 steps / 4 draft tokens, eagle-topk 1</span>
+<span><b>Context length</b> 262 144</span>
+<span><b>CUDA graphs</b> breakable prefill / full decode</span>
+<span><b>mem-fraction-static</b> 0.90 both roles</span>
+<span><b>Watchdog timeout</b> 900s</span>
+<span><b>Routing</b> KV-aware</span>
+<span><b>Prefix caching</b> Prefill-side only</span>
+</div>
+
+<div className="dynamo-target-picker-summary" data-sku="gb200" data-engine="vllm" data-usecase="chat agentic" data-variant="agg">
+<span><b>Checkpoint</b> Qwen/Qwen3.8-2.4T-A95B-FP8</span>
+<span><b>Precision</b> FP8 weights, FP8 KV</span>
+<span><b>GPUs</b> 16× GB200, 4 nodes, 1 replica</span>
+<span><b>Parallelism</b> TP16 over MNNVL</span>
+<span><b>MoE backend</b> flashinfer_trtllm</span>
+<span><b>AllReduce backend</b> FlashInfer MNNVL</span>
+<span><b>Speculative decoding</b> MTP, 3 speculative tokens</span>
+<span><b>Context length</b> 262 144</span>
+<span><b>CUDA graphs</b> FULL_AND_PIECEWISE, capped at batch size 512</span>
+<span><b>Batching</b> 12288 tokens / 512 sequences</span>
+<span><b>GPU memory utilization</b> 0.90</span>
+<span><b>Routing</b> KV-aware (ZMQ events)</span>
+<span><b>Prefix caching</b> Enabled</span>
+</div>
+
+<div className="dynamo-target-picker-summary" data-sku="gb200" data-engine="sglang" data-usecase="chat" data-variant="agg">
+<span><b>Checkpoint</b> Qwen/Qwen3.8-2.4T-A95B-FP8</span>
+<span><b>Precision</b> FP8 weights, FP8 KV</span>
+<span><b>GPUs</b> 16× GB200, 4 nodes, 1 replica</span>
+<span><b>Parallelism</b> TP16 over MNNVL</span>
+<span><b>MoE backend</b> flashinfer_trtllm</span>
+<span><b>Attention backend</b> trtllm_mha</span>
+<span><b>AllReduce backend</b> FlashInfer MNNVL</span>
+<span><b>Speculative decoding</b> Not enabled</span>
+<span><b>Context length</b> 262 144</span>
+<span><b>CUDA graphs</b> breakable prefill / full decode</span>
+<span><b>mem-fraction-static</b> 0.92</span>
+<span><b>Watchdog timeout</b> 900s</span>
+<span><b>Routing</b> KV-aware (ZMQ events)</span>
+<span><b>Prefix caching</b> Enabled (radix cache)</span>
+</div>
+
+<div className="dynamo-target-picker-summary" data-sku="gb200" data-engine="sglang" data-usecase="chat" data-variant="disagg">
+<span><b>Checkpoint</b> Qwen/Qwen3.8-2.4T-A95B-FP8</span>
+<span><b>Precision</b> FP8 weights, FP8 KV</span>
+<span><b>GPUs</b> 2× 16× GB200 prefill + 16× GB200 decode (2P1D, 12 nodes)</span>
+<span><b>Parallelism</b> TP16 / TP16 over MNNVL</span>
+<span><b>KV transfer</b> NIXL over cuda_ipc + MNNVL (~900 GB/s/GPU)</span>
+<span><b>MoE backend</b> flashinfer_trtllm</span>
+<span><b>Attention backend</b> trtllm_mha</span>
+<span><b>AllReduce backend</b> FlashInfer MNNVL</span>
+<span><b>Speculative decoding</b> Not enabled</span>
+<span><b>Context length</b> 262 144</span>
+<span><b>CUDA graphs</b> breakable prefill / full decode</span>
+<span><b>mem-fraction-static</b> 0.85 prefill / 0.92 decode</span>
+<span><b>Watchdog timeout</b> 7200s (breakable graph capture takes 30–60 min)</span>
+<span><b>Routing</b> KV-aware, load-balanced across prefill replicas</span>
+<span><b>Prefix caching</b> Prefill-side only</span>
 </div>
 </div>
+
+## Configurations
+
+Aggregated targets support both vLLM and SGLang. Disaggregated targets are SGLang only. GB300 disagg is 1P1D; GB200 disagg is 2P1D.
+
+<div data-engine="vllm" data-usecase="chat" data-variant="agg">
+
+The chat profiles are tuned for an 8k total context / 1k output workload with 70% KV cache reuse.
+
+</div>
+
+<div data-engine="vllm" data-usecase="agentic" data-variant="agg">
+
+The agentic profiles are tuned for a 64k total context / 400 output workload with 90% KV cache reuse.
+
+</div>
+
+<div data-engine="sglang" data-usecase="chat">
+
+The SGLang targets ship chat profiles only — switch the engine to vLLM for the agentic profiles.
+
+</div>
+
+<div data-engine="vllm" data-variant="agg">
+
+The disaggregated targets ship SGLang only — switch the engine to SGLang for the 1P1D and 2P1D profiles.
+
+</div>
+
+## Supported features
+
+- **Multi-replica scale-out.** Supported; the shipped manifests run one replica per worker role, apart from the two prefill replicas on the GB200 2P1D target.
+- **Speculative decoding.** The vLLM targets run MTP with 3 speculative tokens. The GB300 SGLang targets run NEXTN with 3 steps and 4 draft tokens (`speculative-eagle-topk: 1`). The GB200 SGLang targets ship without speculative decoding.
 
 ## Prerequisites
 
 <div data-sku="gb300">
 
-- A Kubernetes cluster with the Dynamo platform installed and GB300 GPUs available — 16x (4 nodes). See the [Kubernetes Deployment Guide](../kubernetes/quickstart.mdx).
+- A Kubernetes cluster with the Dynamo platform installed and GB300 GPUs available — 16x (4 nodes) for aggregated; 32x (8 nodes, 4 prefill + 4 decode) for 1P1D disaggregated. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - The NVIDIA DRA driver with ComputeDomain support installed (required for multi-node NVLink).
 - A Hugging Face token with access to `Qwen/Qwen3.8-2.4T-A95B-FP8`.
 
@@ -89,12 +190,36 @@ Each target below is a Dynamo + vLLM or SGLang deployment of [Qwen3.8-2.4T-A95B]
 
 <div data-sku="gb200">
 
-- A Kubernetes cluster with the Dynamo platform installed and GB200 GPUs available — 16x (4 nodes) for aggregated; 48x (12 nodes, 2×4 prefill + 4 decode) for 2P1D disaggregated. See the [Kubernetes Deployment Guide](../kubernetes/quickstart.mdx).
+- A Kubernetes cluster with the Dynamo platform installed and GB200 GPUs available — 16x (4 nodes) for aggregated; 48x (12 nodes, 2×4 prefill + 4 decode) for 2P1D disaggregated. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - The NVIDIA DRA driver with ComputeDomain support installed (required for multi-node NVLink).
 - A Hugging Face token with access to `Qwen/Qwen3.8-2.4T-A95B-FP8`.
-- The `model-cache` PVC, populated by the model-download Job (see step 3 below).
+- The `model-cache` PVC, populated by the model-download Job (applied in the [Download the model](#3-download-the-model) section below).
 
 </div>
+
+Confirm the ComputeDomain CRD is present:
+
+```bash
+kubectl get crd | grep computedomain
+```
+
+Each deploy manifest creates its own `ComputeDomain` and the workers claim its channel, so you do not create one yourself.
+
+<div data-sku="gb300">
+
+The vLLM manifests create `qwen38max-compute-domain`; the SGLang manifests create `sglang-qwen38max-compute-domain`.
+
+</div>
+
+<div data-sku="gb200">
+
+The vLLM manifests create `qwen38max-agg-cd` (chat) and `qwen38max-agg-agentic-cd` (agentic); the SGLang manifests create `qwen38max-sgl-agg-cd` (aggregated) and `qwen38max-sgl-disagg-cd` (disaggregated).
+
+</div>
+
+## Quick Start
+
+### 1. Create namespace and secret
 
 Create the namespace:
 
@@ -109,13 +234,22 @@ Create the Hugging Face token secret:
 kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN="your-token" -n ${NAMESPACE}
 ```
 
+### 2. Create storage
+
 <Warning>
 Edit `storageClassName` in `model-cache/model-cache.yaml` to a ReadWriteMany storage class on your
 cluster (`kubectl get storageclass`) before applying it. Review namespace, image tag, node selectors,
 and resource claims in the manifests as well.
 </Warning>
 
-## Deploy
+### 3. Download the model
+
+<Note>
+If you previously ran `model-download` against `Qwen/Qwen3.8-2.4T-A95B`, re-run the Job — workers resolve
+weights from the Hugging Face cache key `models--Qwen--Qwen3.8-2.4T-A95B-FP8` and fail offline until the new
+download completes. The old `models--Qwen--Qwen3.8-2.4T-A95B` directory (~2.4 TB) can be removed once the new
+download is verified.
+</Note>
 
 <div data-sku="gb300">
 
@@ -141,129 +275,208 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 
 </div>
 
+The Job sets `HF_HOME=/model-cache`, so the checkpoint lands in the PVC's Hugging Face cache; each worker then passes the repo id `Qwen/Qwen3.8-2.4T-A95B-FP8` to `--model` and resolves the weights from there.
+
+<Note>
+The containers run as `runAsUser: 0` because the cached weight files are root-owned while the image
+defaults to a non-root uid.
+</Note>
+
+### 4. Deploy the DGD
+
 Then deploy the target DGD:
 
-<div className="dynamo-target-picker-row">
-<span className="dynamo-target-picker-dim">Workload</span>
-<input type="radio" id="recipe-usecase-chat" name="recipe-usecase" value="chat" defaultChecked />
-<label htmlFor="recipe-usecase-chat">Chat</label>
-<input type="radio" id="recipe-usecase-agentic" name="recipe-usecase" value="agentic" />
-<label htmlFor="recipe-usecase-agentic">Agentic</label>
-</div>
-
-<div data-sku="gb300" data-variant="agg" data-engine="vllm" data-usecase="chat">
+<div data-sku="gb300" data-engine="vllm" data-usecase="chat" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/qwen3.8-2.4t-a95b-fp8/vllm/agg-gb300-chat/deploy.yaml -n ${NAMESPACE}
+
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=qwen38max-agg-chat \
+  -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
-<div data-sku="gb300" data-variant="agg" data-engine="vllm" data-usecase="agentic">
+<div data-sku="gb300" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/qwen3.8-2.4t-a95b-fp8/vllm/agg-gb300-agentic/deploy.yaml -n ${NAMESPACE}
+
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=qwen38max-agg-agentic \
+  -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
-<div data-sku="gb300" data-variant="agg" data-engine="sglang" data-usecase="chat">
+<div data-sku="gb300" data-engine="sglang" data-usecase="chat" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/qwen3.8-2.4t-a95b-fp8/sglang/agg-gb300-chat/deploy.yaml -n ${NAMESPACE}
+
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=sglang-qwen38max-agg \
+  -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
-<div data-sku="gb300" data-variant="disagg" data-engine="sglang" data-usecase="chat">
+<div data-sku="gb300" data-engine="sglang" data-usecase="chat" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/qwen3.8-2.4t-a95b-fp8/sglang/disagg-gb300-chat/deploy.yaml -n ${NAMESPACE}
+
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=sglang-qwen38max-1p1d \
+  -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
 
-<div data-sku="gb200" data-variant="agg" data-engine="vllm" data-usecase="chat">
+<div data-sku="gb200" data-engine="vllm" data-usecase="chat" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/qwen3.8-2.4t-a95b-fp8/vllm/agg-gb200-chat/deploy.yaml -n ${NAMESPACE}
+
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=qwen38max-agg \
+  -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
 
-<div data-sku="gb200" data-variant="agg" data-engine="vllm" data-usecase="agentic">
+<div data-sku="gb200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/qwen3.8-2.4t-a95b-fp8/vllm/agg-gb200-agentic/deploy.yaml -n ${NAMESPACE}
+
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=qwen38max-agg-agentic \
+  -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
 
-<div data-sku="gb200" data-variant="agg" data-engine="sglang" data-usecase="chat">
+<div data-sku="gb200" data-engine="sglang" data-usecase="chat" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/qwen3.8-2.4t-a95b-fp8/sglang/agg-gb200-chat/deploy.yaml -n ${NAMESPACE}
+
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=qwen38max-sgl-agg \
+  -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
-<div data-sku="gb200" data-variant="disagg" data-engine="sglang" data-usecase="chat">
+<div data-sku="gb200" data-engine="sglang" data-usecase="chat" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/qwen3.8-2.4t-a95b-fp8/sglang/disagg-gb200-chat/deploy.yaml -n ${NAMESPACE}
+
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=qwen38max-sgl-disagg \
+  -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
-First worker launch loads ~2.4 TB of FP8 weights across the TP ranks and warms CUDA graphs. Allow up to 4 hours; the multinode pod set reports ready only once all nodes have joined the TP group.
+First worker launch loads the checkpoint across the TP ranks and warms CUDA graphs. Each worker pod pulls the full checkpoint from the shared filesystem, so first-load time is bounded by the storage backend, not the GPUs. Allow up to 2 hours — the worker startup probe budgets 120 minutes (`failureThreshold: 720`); raise it if your storage is slower. The multinode pod set reports ready only once all nodes have joined the TP group.
 
-## Smoke Test
+<div data-sku="gb200" data-engine="sglang" data-usecase="chat" data-variant="disagg">
+
+Breakable CUDA-graph capture takes 30–60 minutes on this target, so both roles run with `--watchdog-timeout 7200`. The other SGLang targets use 900s.
+
+</div>
+
+### 5. Smoke test
 
 Forward the frontend port:
 
-<div data-sku="gb300" data-variant="agg">
+<div data-sku="gb300" data-engine="vllm" data-usecase="chat" data-variant="agg">
 
 ```bash
-kubectl port-forward svc/qwen38max-agg-frontend 8000:8000 -n ${NAMESPACE}
+kubectl port-forward svc/qwen38max-agg-chat-frontend 8000:8000 -n ${NAMESPACE} &
 ```
 
 </div>
 
-<div data-sku="gb300" data-variant="disagg">
+<div data-sku="gb300" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
-kubectl port-forward svc/sglang-qwen38max-1p1d-frontend 8000:8000 -n ${NAMESPACE}
+kubectl port-forward svc/qwen38max-agg-agentic-frontend 8000:8000 -n ${NAMESPACE} &
 ```
 
 </div>
 
-<div data-sku="gb200" data-variant="agg">
+<div data-sku="gb300" data-engine="sglang" data-usecase="chat" data-variant="agg">
 
 ```bash
-kubectl port-forward svc/qwen38max-agg-frontend 8000:8000 -n ${NAMESPACE}
+kubectl port-forward svc/sglang-qwen38max-agg-frontend 8000:8000 -n ${NAMESPACE} &
 ```
 
 </div>
 
-<div data-sku="gb200" data-variant="disagg">
+<div data-sku="gb300" data-engine="sglang" data-usecase="chat" data-variant="disagg">
 
 ```bash
-kubectl port-forward svc/qwen38max-sgl-disagg-frontend 8000:8000 -n ${NAMESPACE}
+kubectl port-forward svc/sglang-qwen38max-1p1d-frontend 8000:8000 -n ${NAMESPACE} &
 ```
 
 </div>
+
+<div data-sku="gb200" data-engine="vllm" data-usecase="chat" data-variant="agg">
+
+```bash
+kubectl port-forward svc/qwen38max-agg-frontend 8000:8000 -n ${NAMESPACE} &
+```
+
+</div>
+
+<div data-sku="gb200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
+
+```bash
+kubectl port-forward svc/qwen38max-agg-agentic-frontend 8000:8000 -n ${NAMESPACE} &
+```
+
+</div>
+
+<div data-sku="gb200" data-engine="sglang" data-usecase="chat" data-variant="agg">
+
+```bash
+kubectl port-forward svc/qwen38max-sgl-agg-frontend 8000:8000 -n ${NAMESPACE} &
+```
+
+</div>
+
+<div data-sku="gb200" data-engine="sglang" data-usecase="chat" data-variant="disagg">
+
+```bash
+kubectl port-forward svc/qwen38max-sgl-disagg-frontend 8000:8000 -n ${NAMESPACE} &
+```
+
+</div>
+
+Backgrounding the port-forward keeps the same shell free for the requests below.
+
+#### Text
 
 Send a test request:
 
 <div data-sku="gb300">
 
 ```bash
-curl http://localhost:8000/v1/chat/completions \
+curl -s http://localhost:8000/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -d '{"model":"Qwen/Qwen3.8-2.4T-A95B-FP8","messages":[{"role":"user","content":"Write a one-sentence readiness check."}],"max_tokens":64}'
+  -d '{
+    "model": "Qwen/Qwen3.8-2.4T-A95B-FP8",
+    "messages": [{"role": "user", "content": "Hello, who are you?"}],
+    "max_tokens": 128
+  }'
 ```
 
 </div>
@@ -271,16 +484,50 @@ curl http://localhost:8000/v1/chat/completions \
 <div data-sku="gb200">
 
 ```bash
-curl http://localhost:8000/v1/chat/completions \
+curl -s http://localhost:8000/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -d '{"model":"Qwen/Qwen3.8-2.4T-A95B-FP8","messages":[{"role":"user","content":"Write a one-sentence readiness check."}],"max_tokens":64}'
+  -d '{
+    "model": "Qwen/Qwen3.8-2.4T-A95B-FP8",
+    "messages": [{"role": "user", "content": "Hello, who are you?"}],
+    "max_tokens": 128
+  }'
 ```
 
 </div>
 
-Qwen3.8-2.4T-A95B reasons before answering; chain-of-thought lands in `choices[0].message.reasoning_content` and the answer in `choices[0].message.content`. The deployment wires the `qwen3` reasoning parser and `qwen3_coder` tool-call parser at the frontend.
+Qwen3.8-2.4T-A95B reasons before answering; chain-of-thought lands in `choices[0].message.reasoning_content` and the answer in `choices[0].message.content`. The deployment wires the `qwen3` reasoning parser and `qwen3_coder` tool-call parser at the frontend. If `reasoning_content` is `null` and raw `</think>` markers show up in `content`, the parsers are not wired — check `--reasoning-parser qwen3` and `--dyn-reasoning-parser qwen3` on the worker command.
 
-## Benchmark
+#### Tool calling
+
+Exercise the tool-call parser:
+
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen3.8-2.4T-A95B-FP8",
+    "messages": [{"role": "user", "content": "What is the weather in San Francisco?"}],
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a location",
+        "parameters": {
+          "type": "object",
+          "properties": {"location": {"type": "string", "description": "City name"}},
+          "required": ["location"]
+        }
+      }
+    }],
+    "max_tokens": 300
+  }' | python3 -m json.tool
+```
+
+Expected: `choices[0].message.tool_calls[0].function.name` is `get_weather` and `finish_reason` is `tool_calls`.
+
+### 6. Benchmark
+
+<div data-usecase="chat">
 
 Standard chat workload: 8k total context / 1k output, 70% KV cache reuse.
 
@@ -304,25 +551,46 @@ for C in 2 4 8 16 32 64 128; do
 done
 ```
 
-## Compare All Targets
+</div>
 
-Aggregated targets support both vLLM and SGLang. Disaggregated targets are SGLang only. GB300 disagg is 1P1D; GB200 disagg is 2P1D.
+<div data-usecase="agentic">
 
-| | GB300 agg | GB300 disagg (SGLang) | GB200 agg | GB200 disagg (SGLang, 2P1D) |
-|---|---|---|---|---|
-| **GPUs** | 16× GB300, 4 nodes | 16× GB300 prefill + 16× GB300 decode (1P1D, 8 nodes) | 16× GB200, 4 nodes | 2× 16× GB200 prefill + 16× GB200 decode (2P1D, 12 nodes) |
-| **Parallelism** | TP16 | TP16 / TP16 | TP16 | TP16 / TP16 |
-| **KV transfer** | — | NIXL over cuda_ipc + MNNVL | — | NIXL over cuda_ipc + MNNVL |
-| **MoE backend** | flashinfer_trtllm | flashinfer_trtllm | flashinfer_trtllm | flashinfer_trtllm |
-| **Precision** | FP8 weights, FP8 KV | FP8 weights, FP8 KV | FP8 weights, FP8 KV | FP8 weights, FP8 KV |
-| **Context length** | 262 144 | 262 144 | 262 144 | 262 144 |
+Agentic workload: 64k total context / 400 output, 90% KV cache reuse — the profile the agentic manifests are tuned for.
 
-## Notes
+```bash
+BASE_URL="http://localhost:8000"
+SALT=$(openssl rand -base64 4 | tr -d '=+/')
+for C in 2 4 8 16 32 64 128; do
+  aiperf profile \
+    --model Qwen/Qwen3.8-2.4T-A95B-FP8 \
+    --url "${BASE_URL}" \
+    --endpoint-type chat --streaming \
+    --shared-system-prompt-length 58982 \
+    --isl 6554 --osl 400 \
+    --concurrency ${C} --workers-max ${C} \
+    --num-requests $((C*3)) --num-prompts $((C*3)) \
+    --extra-inputs ignore_eos:true \
+    --extra-inputs "cache_salt:salt_${SALT}_c${C}" \
+    --request-timeout-seconds 300 \
+    --warmup-request-count 1 \
+    --tokenizer builtin --use-server-token-count
+done
+```
 
-- **Event-driven KV-aware routing.** Both workers publish KV events (`--kv-events-config` over ZMQ), and the frontend enables `--router-kv-events`; otherwise the disaggregated route cannot be verified.
+</div>
+
+## Configuration notes
+
+- **Model resolution.** Each worker pod mounts the `model-cache` PVC at `/model-cache` with `HF_HOME=/model-cache` and passes the repo id `Qwen/Qwen3.8-2.4T-A95B-FP8` to `--model`, so the engine loads the checkpoint out of the PVC's Hugging Face cache. The workers resolve everything offline (`HF_HUB_OFFLINE=1`, `TRANSFORMERS_OFFLINE=1`); only the model-download Job consumes `hf-token-secret` through `envFrom`.
+- **Event-driven KV-aware routing.** Both workers publish KV events (`--kv-events-config` over ZMQ), and the frontend runs with `--router-mode kv --router-kv-events`. Missing either worker flag can silently route traffic as aggregated/random instead of a verifiable prefill-to-decode path.
 - **`--no-async-scheduling`** is required for the shipped fixed shapes.
-- **MNNVL all-reduce.** `VLLM_ALLREDUCE_USE_FLASHINFER=1` with `VLLM_FLASHINFER_ALLREDUCE_BACKEND=mnnvl`. Keep `VLLM_USE_NCCL_SYMM_MEM=0` alongside it.
-- **GB300 P-to-D fabric.** The disaggregated workers select the DRA-injected RoCE HCA and use `UCX_TLS=rc_x,rc,cuda_copy,cuda_ipc` with Ethernet GIDs. This is RC/GDR for NIXL payloads; MNNVL remains the TP all-reduce fabric.
+- **MNNVL all-reduce.** On vLLM, `VLLM_ALLREDUCE_USE_FLASHINFER=1` with `VLLM_FLASHINFER_ALLREDUCE_BACKEND=mnnvl`. Keep `VLLM_USE_NCCL_SYMM_MEM=0` alongside it — symmetric memory breaks CUDA-graph capture on this build. The SGLang targets reach the same fabric through `flashinfer-allreduce-fusion-backend: mnnvl` on every worker role.
+- **Disaggregated KV fabric.** The SGLang prefill and decode workers move KV over NIXL with the UCX backend (`SGLANG_DISAGGREGATION_NIXL_BACKEND=UCX`), pinned to `UCX_TLS=cuda_copy,cuda_ipc,tcp` with `UCX_CUDA_IPC_ENABLE_MNNVL=y` and `UCX_MEMTYPE_CACHE=n` so the transfer rides MNNVL instead of falling back to TCP. MNNVL remains the TP all-reduce fabric on both roles.
+- **Pod networking.** DGD pods use CNI networking, so `NCCL_SOCKET_IFNAME` and `GLOO_SOCKET_IFNAME` are pinned to `eth0`.
+
+## Known issues
+
+- **Cold-start cost.** Every worker replica loads its own copy of the checkpoint from the PVC on every cold start, with no shared or streamed loading — pod restarts are expensive.
 
 ## Source
 

--- a/docs/fern/pages/recipes/model-recipes/qwen3-235b-a22b-fp8.mdx
+++ b/docs/fern/pages/recipes/model-recipes/qwen3-235b-a22b-fp8.mdx
@@ -11,6 +11,8 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 Each target below is a validated TensorRT-LLM deployment of Qwen3-235B-A22B-FP8 — a 235B-parameter Mixture-of-Experts model with ~22B active parameters per token — on 16 GPUs with KV-aware routing, benchmarked at 4K ISL / 200 OSL. Hopper and Blackwell need different MoE backends, and you can serve aggregated or with prefill/decode disaggregation. Pick your GPU architecture and serving topology; every command on this page updates to match.
 
+## Available Configurations
+
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
 <div className="dynamo-target-picker-row">
@@ -21,41 +23,59 @@ Each target below is a validated TensorRT-LLM deployment of Qwen3-235B-A22B-FP8 
 <label htmlFor="recipe-sku-hopper">Hopper (H100/H200)</label>
 </div>
 <div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-static" name="recipe-usecase" value="static" defaultChecked />
+<label htmlFor="recipe-usecase-static">Static generation</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-trtllm" name="recipe-engine" value="trtllm" defaultChecked />
+<label htmlFor="recipe-engine-trtllm">TensorRT-LLM</label>
+</div>
+<div className="dynamo-target-picker-row">
 <span className="dynamo-target-picker-dim">Topology</span>
 <input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" defaultChecked />
 <label htmlFor="recipe-variant-agg">Aggregated</label>
 <input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" />
 <label htmlFor="recipe-variant-disagg">Disaggregated</label>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="blackwell" data-variant="agg">
-<span><b>Checkpoint</b> Qwen/Qwen3-235B-A22B-FP8</span>
-<span><b>GPUs</b> 16x B100/B200, 4 workers</span>
-<span><b>Parallelism</b> TP4 x EP4 per worker</span>
-<span><b>MoE backend</b> DEEPGEMM (required on SM100+)</span>
-<span><b>Routing</b> KV-aware</span>
-<span><b>Workload</b> 4K ISL / 200 OSL, concurrency 32</span>
-</div>
-<div className="dynamo-target-picker-summary" data-sku="blackwell" data-variant="disagg">
+<div className="dynamo-target-picker-summary" data-sku="blackwell" data-engine="trtllm" data-usecase="static" data-variant="agg">
 <span><b>Checkpoint</b> Qwen/Qwen3-235B-A22B-FP8</span>
 <span><b>GPUs</b> 16x B100/B200</span>
-<span><b>Parallelism</b> 6x prefill (TP2) + 1x decode (TP4 x EP4)</span>
+<span><b>Topology</b> 4x workers</span>
+<span><b>Parallelism</b> TP4 x EP4 (Expert Parallel) per worker</span>
 <span><b>MoE backend</b> DEEPGEMM (required on SM100+)</span>
+<span><b>Chunked prefill</b> Enabled</span>
 <span><b>Routing</b> KV-aware</span>
 <span><b>Workload</b> 4K ISL / 200 OSL, concurrency 32</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="hopper" data-variant="agg">
+<div className="dynamo-target-picker-summary" data-sku="blackwell" data-engine="trtllm" data-usecase="static" data-variant="disagg">
 <span><b>Checkpoint</b> Qwen/Qwen3-235B-A22B-FP8</span>
-<span><b>GPUs</b> 16x H100/H200, 4 workers</span>
-<span><b>Parallelism</b> TP4 x EP4 per worker</span>
-<span><b>MoE backend</b> CUTLASS (TRT-LLM default)</span>
+<span><b>GPUs</b> 16x B100/B200</span>
+<span><b>Topology</b> 6x prefill + 1x decode</span>
+<span><b>Parallelism</b> Prefill TP2; decode TP4 x EP4 (Expert Parallel)</span>
+<span><b>MoE backend</b> DEEPGEMM (required on SM100+)</span>
+<span><b>Chunked prefill</b> Disabled</span>
 <span><b>Routing</b> KV-aware</span>
 <span><b>Workload</b> 4K ISL / 200 OSL, concurrency 32</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="hopper" data-variant="disagg">
+<div className="dynamo-target-picker-summary" data-sku="hopper" data-engine="trtllm" data-usecase="static" data-variant="agg">
 <span><b>Checkpoint</b> Qwen/Qwen3-235B-A22B-FP8</span>
 <span><b>GPUs</b> 16x H100/H200</span>
-<span><b>Parallelism</b> 6x prefill (TP2) + 1x decode (TP4 x EP4)</span>
-<span><b>MoE backend</b> CUTLASS (TRT-LLM default)</span>
+<span><b>Topology</b> 4x workers</span>
+<span><b>Parallelism</b> TP4 x EP4 (Expert Parallel) per worker</span>
+<span><b>MoE backend</b> CUTLASS (TRT-LLM default on SM90)</span>
+<span><b>Chunked prefill</b> Enabled</span>
+<span><b>Routing</b> KV-aware</span>
+<span><b>Workload</b> 4K ISL / 200 OSL, concurrency 32</span>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="hopper" data-engine="trtllm" data-usecase="static" data-variant="disagg">
+<span><b>Checkpoint</b> Qwen/Qwen3-235B-A22B-FP8</span>
+<span><b>GPUs</b> 16x H100/H200</span>
+<span><b>Topology</b> 6x prefill + 1x decode</span>
+<span><b>Parallelism</b> Prefill TP2; decode TP4 x EP4 (Expert Parallel)</span>
+<span><b>MoE backend</b> CUTLASS (TRT-LLM default on SM90)</span>
+<span><b>Chunked prefill</b> Disabled</span>
 <span><b>Routing</b> KV-aware</span>
 <span><b>Workload</b> 4K ISL / 200 OSL, concurrency 32</span>
 </div>
@@ -63,24 +83,26 @@ Each target below is a validated TensorRT-LLM deployment of Qwen3-235B-A22B-FP8 
 
 ## Prerequisites
 
-<div data-sku="blackwell">
+<div data-sku="blackwell" data-engine="trtllm" data-usecase="static" data-variant="agg disagg">
 
-- A Kubernetes cluster with the Dynamo platform installed and **16x B100/B200** available (~1.3 TB total GPU VRAM).
+- A Kubernetes cluster with the Dynamo platform installed and **16x B100/B200** available (~1.3 TB total GPU VRAM). See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - A Hugging Face token with access to `Qwen/Qwen3-235B-A22B-FP8`.
 
 </div>
 
-<div data-sku="hopper">
+<div data-sku="hopper" data-engine="trtllm" data-usecase="static" data-variant="agg disagg">
 
-- A Kubernetes cluster with the Dynamo platform installed and **16x H100/H200** available (~1.3 TB total GPU VRAM).
+- A Kubernetes cluster with the Dynamo platform installed and **16x H100/H200** available (~1.3 TB total GPU VRAM). See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - A Hugging Face token with access to `Qwen/Qwen3-235B-A22B-FP8`.
 
 </div>
+
+## Quick Start
 
 Create the namespace and token secret:
 
 ```bash
-export NAMESPACE=your-namespace
+export NAMESPACE=dynamo-demo
 kubectl create namespace ${NAMESPACE}
 kubectl create secret generic hf-token-secret \
   --from-literal=HF_TOKEN="your-token" \
@@ -90,8 +112,6 @@ kubectl create secret generic hf-token-secret \
 <Warning>
 Edit namespace, storage class, image tags, node selectors, resource claims, and cluster-specific placement in the manifests before applying them.
 </Warning>
-
-## Deploy
 
 Prepare the model cache and download the checkpoint (30-60 minutes):
 
@@ -104,7 +124,7 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 
 Then deploy:
 
-<div data-sku="blackwell" data-variant="agg">
+<div data-sku="blackwell" data-engine="trtllm" data-usecase="static" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/agg/blackwell/deploy.yaml -n ${NAMESPACE}
@@ -112,21 +132,24 @@ kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/agg/blackwell/deploy.yaml -n
 
 </div>
 
-<div data-sku="blackwell" data-variant="disagg">
+<div data-sku="blackwell" data-engine="trtllm" data-usecase="static" data-variant="disagg">
 
-Choose the manifest matching your cluster interconnect:
+Choose the manifest matching your cluster interconnect, or the provider-neutral baseline if none apply:
 
 ```bash
+# Provider-neutral baseline
+kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy-generic.yaml -n ${NAMESPACE}
+# OR AWS EFA on p6-b200.48xlarge (8 EFA per worker)
 kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy-aws-p6-b200.48xlarge.yaml -n ${NAMESPACE}
-# OR
+# OR GKE RoCE
 kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy-gcp-roce.yaml -n ${NAMESPACE}
-# OR
+# OR Nscale InfiniBand
 kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy-nscale-ib.yaml -n ${NAMESPACE}
 ```
 
 </div>
 
-<div data-sku="hopper" data-variant="agg">
+<div data-sku="hopper" data-engine="trtllm" data-usecase="static" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/agg/hopper/deploy.yaml -n ${NAMESPACE}
@@ -134,7 +157,7 @@ kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/agg/hopper/deploy.yaml -n ${
 
 </div>
 
-<div data-sku="hopper" data-variant="disagg">
+<div data-sku="hopper" data-engine="trtllm" data-usecase="static" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/deploy.yaml -n ${NAMESPACE}
@@ -142,11 +165,62 @@ kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/deploy.yaml -n
 
 </div>
 
-## Smoke Test
+## Cloud Provider Overlays
+
+Provider-specific interconnect overlays ship for the Blackwell disaggregated target.
+
+<div data-sku="blackwell" data-engine="trtllm" data-usecase="static" data-variant="disagg">
+
+Applying a checked-in `deploy-*.yaml` and applying its public overlay with `kubectl apply -k` are equivalent, and neither path requires regeneration. For example, the GKE RoCE composition from its checked-in Kustomization:
+
+```bash
+kubectl apply -k recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/kustomize/overlays/gcp-roce -n ${NAMESPACE}
+```
+
+Kustomize is both the authoring model and the documentation for these variants: the base and Components explain the provider settings, and each public overlay documents the composition it selects. The shared deployment lives in `trtllm/disagg/blackwell/kustomize/base/deploy.yaml`, provider-specific deltas live in Kustomize Components, and `trtllm/disagg/blackwell/.kustomize-matrix.yaml` selects the composition behind each rendered manifest. Shared building blocks belong under `recipes/kustomize/components/`, and the disaggregated provider Components target the backend-neutral `PrefillWorker` and `DecodeWorker` service keys. Each manifest's patch source:
+
+- `deploy-generic.yaml` (provider-neutral baseline) — `trtllm/disagg/blackwell/kustomize/overlays/generic/`
+- `deploy-aws-p6-b200.48xlarge.yaml` (AWS EFA on `p6-b200.48xlarge`, 8 EFA per worker) — `recipes/kustomize/components/aws-efa-p8d8/`
+- `deploy-gcp-roce.yaml` (GKE RoCE) — `recipes/kustomize/components/disagg-workers/gke-roce/`
+- `deploy-nscale-ib.yaml` (Nscale InfiniBand) — `recipes/kustomize/components/disagg-workers/nscale-ib/`
+
+To make a local, uncommitted composition, create your own `kustomization.yaml` in the repository checkout, or run `compose` from the repository root:
+
+```bash
+scripts/kustomize-matrix.py compose \
+  recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/kustomize/base \
+  recipes/kustomize/components/disagg-workers/gke-roce \
+  | kubectl apply -f - -n ${NAMESPACE}
+```
+
+Only recipe contributors update the checked-in derived artifacts. The source of truth is the matrix, `kustomize/base/`, and the recipe-local plus referenced shared Components; the public overlay `kustomization.yaml` files and the `deploy-*.yaml` manifests are generated — commit them for review, but do not edit them by hand. After editing the matrix, base, or Components, regenerate from the repository root:
+
+```bash
+scripts/kustomize-matrix.py unfold recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/.kustomize-matrix.yaml
+scripts/kustomize-matrix.py render recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/.kustomize-matrix.yaml
+```
+
+Kustomize drops comments while rendering Kubernetes objects, so the renderer re-inserts non-SPDX comments from the source YAML before the matching rendered fields. Comments inside literal block scalars already render in place.
+
+</div>
+
+<div data-sku="blackwell hopper" data-engine="trtllm" data-usecase="static" data-variant="agg">
+
+The aggregated targets ship a single `deploy.yaml` per GPU architecture and need no interconnect overlay: each worker is self-contained, so there is no cross-node KV transfer to tune. Nothing extra to apply here — continue to [Test the Deployment](#test-the-deployment). To see the overlay workflow, select **GPU** Blackwell with **Topology** Disaggregated.
+
+</div>
+
+<div data-sku="hopper" data-engine="trtllm" data-usecase="static" data-variant="disagg">
+
+The Hopper disaggregated target ships one provider-neutral `trtllm/disagg/hopper/deploy.yaml` and no generated interconnect overlays. Apply it as shown in [Quick Start](#quick-start), and set your cluster's RDMA resource claims and node selectors directly in that manifest. To see the overlay workflow, switch **GPU** to Blackwell.
+
+</div>
+
+## Test the Deployment
 
 Send a test request to verify the deployment serves traffic:
 
-<div data-variant="agg">
+<div data-sku="blackwell hopper" data-engine="trtllm" data-usecase="static" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/qwen3-235b-a22b-agg-frontend 8000:8000 -n ${NAMESPACE}
@@ -154,7 +228,7 @@ kubectl port-forward svc/qwen3-235b-a22b-agg-frontend 8000:8000 -n ${NAMESPACE}
 
 </div>
 
-<div data-variant="disagg">
+<div data-sku="blackwell hopper" data-engine="trtllm" data-usecase="static" data-variant="disagg">
 
 ```bash
 kubectl port-forward svc/qwen3-235b-a22b-disagg-frontend 8000:8000 -n ${NAMESPACE}
@@ -164,15 +238,19 @@ kubectl port-forward svc/qwen3-235b-a22b-disagg-frontend 8000:8000 -n ${NAMESPAC
 
 ```bash
 curl http://localhost:8000/v1/chat/completions \
-  -H 'Content-Type: application/json' \
-  -d '{"model":"Qwen/Qwen3-235B-A22B-FP8","messages":[{"role":"user","content":"Write a one-sentence readiness check."}],"max_tokens":64}'
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-235B-A22B-FP8",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 50
+  }'
 ```
 
-## Benchmark
+### Benchmark
 
 Every target ships a `perf.yaml` AIPerf Job sized at 4K ISL / 200 OSL and concurrency 32 (2 per GPU x 16 GPUs) with `--request-count 320`, so aggregated vs disaggregated results are comparable within the same hardware architecture. Artifacts land on the `model-cache` PVC under `/model-cache/perf`.
 
-<div data-variant="agg">
+<div data-sku="blackwell hopper" data-engine="trtllm" data-usecase="static" data-variant="agg">
 
 The aggregated Job wraps this AIPerf run:
 
@@ -190,7 +268,7 @@ aiperf profile \
 
 </div>
 
-<div data-variant="disagg">
+<div data-sku="blackwell hopper" data-engine="trtllm" data-usecase="static" data-variant="disagg">
 
 The disaggregated Job wraps this AIPerf run:
 
@@ -210,7 +288,7 @@ aiperf profile \
 
 Apply the manifest matching your deployed target:
 
-<div data-sku="blackwell" data-variant="agg">
+<div data-sku="blackwell" data-engine="trtllm" data-usecase="static" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/agg/blackwell/perf.yaml -n ${NAMESPACE}
@@ -219,7 +297,7 @@ kubectl wait --for=condition=Complete job/qwen3-235b-a22b-bench -n ${NAMESPACE} 
 
 </div>
 
-<div data-sku="blackwell" data-variant="disagg">
+<div data-sku="blackwell" data-engine="trtllm" data-usecase="static" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/perf.yaml -n ${NAMESPACE}
@@ -228,7 +306,7 @@ kubectl wait --for=condition=Complete job/qwen3-235b-a22b-disagg-bench -n ${NAME
 
 </div>
 
-<div data-sku="hopper" data-variant="agg">
+<div data-sku="hopper" data-engine="trtllm" data-usecase="static" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/agg/hopper/perf.yaml -n ${NAMESPACE}
@@ -237,7 +315,7 @@ kubectl wait --for=condition=Complete job/qwen3-235b-a22b-bench -n ${NAMESPACE} 
 
 </div>
 
-<div data-sku="hopper" data-variant="disagg">
+<div data-sku="hopper" data-engine="trtllm" data-usecase="static" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/perf.yaml -n ${NAMESPACE}
@@ -246,30 +324,25 @@ kubectl wait --for=condition=Complete job/qwen3-235b-a22b-disagg-bench -n ${NAME
 
 </div>
 
-## Compare All Targets
+## Model Details
 
-All four targets serve `Qwen/Qwen3-235B-A22B-FP8` on TensorRT-LLM (PyTorch backend) over 16 GPUs with KV-aware routing and the same 4K ISL / 200 OSL benchmark shape:
+All four targets serve `Qwen/Qwen3-235B-A22B-FP8` on TensorRT-LLM (PyTorch backend) over 16 GPUs with KV-aware routing and the same 4K ISL / 200 OSL benchmark shape.
 
-| | Blackwell aggregated | Blackwell disaggregated | Hopper aggregated | Hopper disaggregated |
-|---|---|---|---|---|
-| **GPUs** | 16x B100/B200 | 16x B100/B200 | 16x H100/H200 | 16x H100/H200 |
-| **Topology** | 4x workers, TP4 x EP4 | 6x prefill (TP2) + 1x decode (TP4 x EP4) | 4x workers, TP4 x EP4 | 6x prefill (TP2) + 1x decode (TP4 x EP4) |
-| **MoE backend** | DEEPGEMM | DEEPGEMM | CUTLASS (default) | CUTLASS (default) |
-| **Chunked prefill** | Enabled | Disabled | Enabled | Disabled |
-| **Workload** | 4K / 200, conc. 32 | 4K / 200, conc. 32 | 4K / 200, conc. 32 | 4K / 200, conc. 32 |
+## Hardware Requirements
+
+- The Hopper/Blackwell split is required with TRT-LLM 1.3.x: Hopper (H100/H200, SM90) uses the default MoE backend, while on Blackwell (B100/B200, SM100+) that default CUTLASS backend falls through to a Hopper-specific JIT path and crashes, so Blackwell needs `moe_config.backend: DEEPGEMM`. DEEPGEMM in turn crashes on Hopper due to a scale-factor dtype mismatch — hence two separate variants per topology.
 
 ## Notes
 
-- The Hopper/Blackwell split is required with TRT-LLM 1.3.x: the default CUTLASS MoE backend falls through to a Hopper-specific JIT path on SM100 and crashes, so Blackwell needs `moe_config.backend: DEEPGEMM`. DEEPGEMM in turn crashes on Hopper due to a scale-factor dtype mismatch — hence two separate variants per topology.
 - Chunked prefill is enabled for the aggregated targets and disabled for the disaggregated targets.
-- All targets use KV-aware routing (`--router-mode kv`) at the frontend.
+- All targets use KV-aware routing (`--router-mode kv`) at the frontend for efficient cache utilization.
 - Model download may take 30-60 minutes; update `storageClassName` in `model-cache/model-cache.yaml` before deploying.
 
 ## Source
 
 - Source README: [recipes/qwen3-235b-a22b-fp8/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/README.md)
 - Aggregated Blackwell: [deploy.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/agg/blackwell/deploy.yaml) and [perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/agg/blackwell/perf.yaml)
-- Disaggregated Blackwell: [AWS EFA](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy-aws-p6-b200.48xlarge.yaml), [GKE RoCE](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy-gcp-roce.yaml), [Nscale InfiniBand](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy-nscale-ib.yaml), and [perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/perf.yaml)
+- Disaggregated Blackwell: [provider-neutral baseline](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy-generic.yaml), [AWS EFA](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy-aws-p6-b200.48xlarge.yaml), [GKE RoCE](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy-gcp-roce.yaml), [Nscale InfiniBand](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy-nscale-ib.yaml), and [perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/perf.yaml)
 - Aggregated Hopper: [deploy.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/agg/hopper/deploy.yaml) and [perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/agg/hopper/perf.yaml)
 - Disaggregated Hopper: [deploy.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/deploy.yaml) and [perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/perf.yaml)
 - Setup assets: [model-cache/model-cache.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/model-cache/model-cache.yaml) and [model-cache/model-download.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/model-cache/model-download.yaml)

--- a/docs/fern/pages/recipes/model-recipes/qwen3-32b-fp8.mdx
+++ b/docs/fern/pages/recipes/model-recipes/qwen3-32b-fp8.mdx
@@ -9,35 +9,54 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-Each target below is a validated FP8 deployment of Qwen3-32B — from a 2-GPU TensorRT-LLM aggregate to 8-GPU disaggregated prefill/decode setups on TensorRT-LLM or vLLM — each with a checked-in AIPerf benchmark Job. The targets use different traffic shapes and GPU counts, so this page is not a backend benchmark. Pick your target; every command on this page updates to match.
+Each target below is a validated FP8 deployment of Qwen3-32B — from a 2-GPU TensorRT-LLM aggregate to 8-GPU disaggregated prefill/decode setups on TensorRT-LLM or vLLM — each with a checked-in AIPerf benchmark Job. The targets use different traffic shapes and GPU counts, so this page is not a backend benchmark. Pick your backend and topology; every command on this page updates to match.
 
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
 <div className="dynamo-target-picker-row">
-<span className="dynamo-target-picker-dim">Target</span>
-<input type="radio" id="recipe-variant-trtllm-agg" name="recipe-variant" value="trtllm-agg" defaultChecked />
-<label htmlFor="recipe-variant-trtllm-agg">TRT-LLM aggregated (2 GPU) <span className="dynamo-target-picker-hint">Recommended</span></label>
-<input type="radio" id="recipe-variant-trtllm-disagg" name="recipe-variant" value="trtllm-disagg" />
-<label htmlFor="recipe-variant-trtllm-disagg">TRT-LLM disaggregated (8 GPU)</label>
-<input type="radio" id="recipe-variant-vllm-disagg" name="recipe-variant" value="vllm-disagg" />
-<label htmlFor="recipe-variant-vllm-disagg">vLLM disaggregated (8 GPU)</label>
+<span className="dynamo-target-picker-dim">GPU</span>
+<input type="radio" id="recipe-sku-hopper" name="recipe-sku" value="hopper" defaultChecked />
+<label htmlFor="recipe-sku-hopper">H100 / H200 / A100</label>
 </div>
-<div className="dynamo-target-picker-summary" data-variant="trtllm-agg">
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-static" name="recipe-usecase" value="static" defaultChecked />
+<label htmlFor="recipe-usecase-static">Static generation</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-trtllm" name="recipe-engine" value="trtllm" defaultChecked />
+<label htmlFor="recipe-engine-trtllm">TensorRT-LLM <span className="dynamo-target-picker-hint">Recommended</span></label>
+<input type="radio" id="recipe-engine-vllm" name="recipe-engine" value="vllm" />
+<label htmlFor="recipe-engine-vllm" data-needs-variant="disagg">vLLM</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Topology</span>
+<input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" />
+<label htmlFor="recipe-variant-agg" data-needs-engine="trtllm">Aggregated</label>
+<input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" defaultChecked />
+<label htmlFor="recipe-variant-disagg">Disaggregated</label>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="hopper" data-usecase="static" data-engine="trtllm" data-variant="agg">
 <span><b>Checkpoint</b> Qwen/Qwen3-32B-FP8</span>
+<span><b>Backend</b> TensorRT-LLM (PyTorch backend)</span>
 <span><b>GPUs</b> 2x H100/H200/A100, single TP2 worker</span>
+<span><b>Topology</b> 1x worker, TP2</span>
 <span><b>Routing</b> Round-robin</span>
 <span><b>Techniques</b> CUDA graphs, FP8 KV cache</span>
 <span><b>Workload</b> 4K ISL / 500 OSL, concurrency 4</span>
 </div>
-<div className="dynamo-target-picker-summary" data-variant="trtllm-disagg">
+<div className="dynamo-target-picker-summary" data-sku="hopper" data-usecase="static" data-engine="trtllm" data-variant="disagg">
 <span><b>Checkpoint</b> Qwen/Qwen3-32B-FP8</span>
+<span><b>Backend</b> TensorRT-LLM (PyTorch backend)</span>
 <span><b>GPUs</b> 8x H100/H200/A100</span>
 <span><b>Topology</b> 4x prefill (TP1) + 2x decode (TP2)</span>
 <span><b>Routing</b> Round-robin</span>
 <span><b>Workload</b> 4K ISL / 500 OSL, concurrency 48</span>
 </div>
-<div className="dynamo-target-picker-summary" data-variant="vllm-disagg">
+<div className="dynamo-target-picker-summary" data-sku="hopper" data-usecase="static" data-engine="vllm" data-variant="disagg">
 <span><b>Checkpoint</b> Qwen/Qwen3-32B-FP8</span>
+<span><b>Backend</b> vLLM</span>
 <span><b>GPUs</b> 8x H100/H200/A100, single node</span>
 <span><b>Topology</b> 2x prefill (TP2) + 1x decode (TP4)</span>
 <span><b>KV transfer</b> NIXL (NixlConnector)</span>
@@ -45,91 +64,101 @@ Each target below is a validated FP8 deployment of Qwen3-32B — from a 2-GPU Te
 </div>
 </div>
 
+## Available Configurations
+
+All three targets serve `Qwen/Qwen3-32B-FP8` on H100/H200/A100-class GPUs with a static-generation benchmark workload; they differ in backend, GPU count, topology, and benchmark traffic. Use the target picker above — GPU, then workload, then backend, then topology: the summary panel for each target lists its backend, GPUs, topology, routing or KV transfer, and benchmark workload.
+
+The GPU and workload levels have a single value each, so the choices that matter here are backend and topology, and the picker only offers the pairs the recipe actually ships.
+
+The **Aggregated** topology is offered on TensorRT-LLM only — it is the one aggregated lane the recipe ships. vLLM ships a disaggregated target only, so the **vLLM** chip appears only while **Disaggregated** is selected.
+
 ## Prerequisites
 
-<div data-variant="trtllm-agg">
+<div data-sku="hopper" data-usecase="static" data-engine="trtllm" data-variant="agg">
 
-- A Kubernetes cluster with the Dynamo platform installed and **2x H100/H200/A100-class GPUs** available.
+- A Kubernetes cluster with the Dynamo platform installed and **2x H100/H200/A100-class GPUs** available — see the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - A Hugging Face token with access to `Qwen/Qwen3-32B-FP8`.
 
 </div>
 
-<div data-variant="trtllm-disagg">
+<div data-sku="hopper" data-usecase="static" data-engine="trtllm" data-variant="disagg">
 
-- A Kubernetes cluster with the Dynamo platform installed and **8x H100/H200/A100-class GPUs** available.
+- A Kubernetes cluster with the Dynamo platform installed and **8x H100/H200/A100-class GPUs** available — see the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - A Hugging Face token with access to `Qwen/Qwen3-32B-FP8`.
 
 </div>
 
-<div data-variant="vllm-disagg">
+<div data-sku="hopper" data-usecase="static" data-engine="vllm" data-variant="disagg">
 
-- A Kubernetes cluster with the Dynamo platform installed and **8x H100/H200/A100-class GPUs on a single node** — all prefill and decode workers must be co-located for NIXL KV transfer.
+- A Kubernetes cluster with the Dynamo platform installed and **8x H100/H200/A100-class GPUs on a single node** — all prefill and decode workers must be co-located for NIXL KV transfer. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - A Hugging Face token with access to `Qwen/Qwen3-32B-FP8`.
 
 </div>
+
+<Warning>
+Edit namespace, storage class, image tags, node selectors, resource claims, and cluster-specific placement in the manifests before applying them.
+</Warning>
+
+## Quick Start
+
+Run the commands on this page from the recipe directory, `recipes/qwen3-32b-fp8/`.
 
 Create the namespace and token secret:
 
 ```bash
-export NAMESPACE=your-namespace
+export NAMESPACE=dynamo-demo
 kubectl create namespace ${NAMESPACE}
 kubectl create secret generic hf-token-secret \
   --from-literal=HF_TOKEN="your-token" \
   -n ${NAMESPACE}
 ```
 
-<Warning>
-Edit namespace, storage class, image tags, node selectors, resource claims, and cluster-specific placement in the manifests before applying them.
-</Warning>
-
-## Deploy
-
 Prepare the model cache and download the checkpoint:
 
 ```bash
 # Edit storageClassName in model-cache/model-cache.yaml to match your cluster first
 # (kubectl get storageclass).
-kubectl apply -f recipes/qwen3-32b-fp8/model-cache/ -n ${NAMESPACE}
+kubectl apply -f model-cache/ -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=1800s
 ```
 
 Then deploy:
 
-<div data-variant="trtllm-agg">
+<div data-sku="hopper" data-usecase="static" data-engine="trtllm" data-variant="agg">
 
 A single TP2 TensorRT-LLM worker with round-robin routing and CUDA graphs enabled:
 
 ```bash
-kubectl apply -f recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml -n ${NAMESPACE}
+kubectl apply -f trtllm/agg/deploy.yaml -n ${NAMESPACE}
 ```
 
 </div>
 
-<div data-variant="trtllm-disagg">
+<div data-sku="hopper" data-usecase="static" data-engine="trtllm" data-variant="disagg">
 
 4x prefill workers (TP1) and 2x decode workers (TP2):
 
 ```bash
-kubectl apply -f recipes/qwen3-32b-fp8/trtllm/disagg/deploy.yaml -n ${NAMESPACE}
+kubectl apply -f trtllm/disagg/deploy.yaml -n ${NAMESPACE}
 ```
 
 </div>
 
-<div data-variant="vllm-disagg">
+<div data-sku="hopper" data-usecase="static" data-engine="vllm" data-variant="disagg">
 
 2x prefill workers (TP2) and 1x decode worker (TP4) using NixlConnector KV transfer; all workers must land on one node:
 
 ```bash
-kubectl apply -f recipes/qwen3-32b-fp8/vllm/disagg/deploy.yaml -n ${NAMESPACE}
+kubectl apply -f vllm/disagg/deploy.yaml -n ${NAMESPACE}
 ```
 
 </div>
 
-## Smoke Test
+## Test the Deployment
 
 Send a test request to verify the deployment serves traffic:
 
-<div data-variant="trtllm-agg">
+<div data-sku="hopper" data-usecase="static" data-engine="trtllm" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/qwen3-32b-fp8-agg-frontend 8000:8000 -n ${NAMESPACE}
@@ -137,7 +166,7 @@ kubectl port-forward svc/qwen3-32b-fp8-agg-frontend 8000:8000 -n ${NAMESPACE}
 
 </div>
 
-<div data-variant="trtllm-disagg">
+<div data-sku="hopper" data-usecase="static" data-engine="trtllm" data-variant="disagg">
 
 ```bash
 kubectl port-forward svc/qwen3-32b-fp8-disagg-frontend 8000:8000 -n ${NAMESPACE}
@@ -145,7 +174,7 @@ kubectl port-forward svc/qwen3-32b-fp8-disagg-frontend 8000:8000 -n ${NAMESPACE}
 
 </div>
 
-<div data-variant="vllm-disagg">
+<div data-sku="hopper" data-usecase="static" data-engine="vllm" data-variant="disagg">
 
 ```bash
 kubectl port-forward svc/qwen3-32b-fp8-vllm-disagg-frontend 8000:8000 -n ${NAMESPACE}
@@ -156,14 +185,14 @@ kubectl port-forward svc/qwen3-32b-fp8-vllm-disagg-frontend 8000:8000 -n ${NAMES
 ```bash
 curl http://localhost:8000/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -d '{"model":"Qwen/Qwen3-32B-FP8","messages":[{"role":"user","content":"Write a one-sentence readiness check."}],"max_tokens":64}'
+  -d '{"model":"Qwen/Qwen3-32B-FP8","messages":[{"role":"user","content":"Hello!"}],"max_tokens":50}'
 ```
 
-## Benchmark
+### Benchmark
 
 Each target ships its own `perf.yaml` AIPerf Job, sized at a fixed concurrency per GPU with `request-count = 10x concurrency`. Artifacts land on the `model-cache` PVC under `/model-cache/perf`.
 
-<div data-variant="trtllm-agg">
+<div data-sku="hopper" data-usecase="static" data-engine="trtllm" data-variant="agg">
 
 The Job wraps this AIPerf run — 4K ISL / 500 OSL at concurrency 4 (2 per GPU x 2 GPUs):
 
@@ -180,13 +209,13 @@ aiperf profile \
 ```
 
 ```bash
-kubectl apply -f recipes/qwen3-32b-fp8/trtllm/agg/perf.yaml -n ${NAMESPACE}
+kubectl apply -f trtllm/agg/perf.yaml -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/qwen3-32b-fp8-bench -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
-<div data-variant="trtllm-disagg">
+<div data-sku="hopper" data-usecase="static" data-engine="trtllm" data-variant="disagg">
 
 The Job wraps this AIPerf run — 4K ISL / 500 OSL at concurrency 48 (6 per GPU x 8 GPUs):
 
@@ -203,13 +232,13 @@ aiperf profile \
 ```
 
 ```bash
-kubectl apply -f recipes/qwen3-32b-fp8/trtllm/disagg/perf.yaml -n ${NAMESPACE}
+kubectl apply -f trtllm/disagg/perf.yaml -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/qwen3-32b-fp8-bench -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
-<div data-variant="vllm-disagg">
+<div data-sku="hopper" data-usecase="static" data-engine="vllm" data-variant="disagg">
 
 The Job wraps this AIPerf run — 2K ISL / 500 OSL at concurrency 8 (1 per GPU x 8 GPUs); note the shorter input length than the TRT-LLM targets:
 
@@ -226,26 +255,18 @@ aiperf profile \
 ```
 
 ```bash
-kubectl apply -f recipes/qwen3-32b-fp8/vllm/disagg/perf.yaml -n ${NAMESPACE}
+kubectl apply -f vllm/disagg/perf.yaml -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/qwen3-32b-fp8-vllm-disagg-perf -n ${NAMESPACE} --timeout=7200s
 ```
 
 </div>
 
-## Compare All Targets
+## Model Details
 
-All three targets serve `Qwen/Qwen3-32B-FP8`; they differ in runtime, GPU count, topology, and benchmark traffic:
-
-| | TRT-LLM aggregated | TRT-LLM disaggregated | vLLM disaggregated |
-|---|---|---|---|
-| **GPUs** | 2x H100/H200/A100 | 8x H100/H200/A100 | 8x H100/H200/A100, single node |
-| **Topology** | 1x worker, TP2 | 4x prefill (TP1) + 2x decode (TP2) | 2x prefill (TP2) + 1x decode (TP4) |
-| **Routing / KV transfer** | Round-robin | Round-robin | NIXL (NixlConnector) |
-| **Workload** | 4K / 500, conc. 4 | 4K / 500, conc. 48 | 2K / 500, conc. 8 |
+- This page is the FP8 alternative to the BF16 [Qwen3-32B](qwen3-32b.mdx) recipe.
 
 ## Notes
 
-- This page is the FP8 alternative to the BF16 [Qwen3-32B](qwen3-32b.mdx) recipe.
 - The TRT-LLM and vLLM targets use different traffic shapes (4K vs 2K ISL) and different GPU counts; normalize traffic before making backend performance claims.
 - The aggregated config uses CUDA graphs for optimized inference, and KV cache uses FP8 dtype for memory efficiency.
 - `--max-model-len 8192` is set in `vllm/disagg/deploy.yaml` for A100 40 GB compatibility; remove or increase it on H100/H200.

--- a/docs/fern/pages/recipes/model-recipes/qwen3-32b.mdx
+++ b/docs/fern/pages/recipes/model-recipes/qwen3-32b.mdx
@@ -9,26 +9,151 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-This recipe deploys `Qwen/Qwen3-32B` on 16x H200 with prefill/decode disaggregation and KV-aware routing — the winning configuration from the [KV routing A/B benchmark](../feature-benchmarks/qwen3-32b-kv-routing-a-b.mdx), validated against a real Mooncake conversation trace (12,031 requests, 12K average input length, 36.64% cache efficiency). It fits multi-turn conversational workloads where requests share long prefixes that KV-aware routing can exploit.
+This recipe deploys `Qwen/Qwen3-32B` on vLLM in three shapes: the headline **disaggregated + KV-aware routing** target on 16x H200 across 2 nodes — the winning configuration from the [KV routing A/B benchmark](../feature-benchmarks/qwen3-32b-kv-routing-a-b.mdx), validated against a real [Mooncake conversation trace](https://github.com/kvcache-ai/Mooncake) (12,031 requests, 12,035 average input length, 36.64% cache efficiency); a single-GPU **aggregated + KVBM** target that extends the cache beyond GPU HBM by offloading cold KV blocks to host memory; and a **1P1D cloud provider** family whose overlays adapt one deployment to each vendor's RDMA fabric. Pick your target; every command on this page updates to match.
 
-<div className="dynamo-target-picker static">
-<p className="dynamo-target-picker-title">Deployment target</p>
-<div className="dynamo-target-picker-summary">
+<div className="dynamo-target-picker">
+<p className="dynamo-target-picker-title">Choose your deployment target</p>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">GPU</span>
+<input type="radio" id="recipe-sku-h200" name="recipe-sku" value="h200" defaultChecked />
+<label htmlFor="recipe-sku-h200">H200</label>
+<input type="radio" id="recipe-sku-b200" name="recipe-sku" value="b200" />
+<label htmlFor="recipe-sku-b200" data-needs-variant="kvbm">B200</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-chat" name="recipe-usecase" value="chat" defaultChecked />
+<label htmlFor="recipe-usecase-chat">Conversational chat</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-vllm" name="recipe-engine" value="vllm" defaultChecked />
+<label htmlFor="recipe-engine-vllm">vLLM</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Topology</span>
+<input type="radio" id="recipe-variant-disagg-multi-node" name="recipe-variant" value="disagg-multi-node" defaultChecked />
+<label htmlFor="recipe-variant-disagg-multi-node" data-needs-sku="h200">Disaggregated + KV routing (16 GPU, 2 nodes) <span className="dynamo-target-picker-hint">Recommended</span></label>
+<input type="radio" id="recipe-variant-kvbm" name="recipe-variant" value="kvbm" />
+<label htmlFor="recipe-variant-kvbm">Aggregated + KVBM (1 GPU)</label>
+<input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" />
+<label htmlFor="recipe-variant-disagg" data-needs-sku="h200">Disaggregated 1P1D, cloud fabrics</label>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg-multi-node">
 <span><b>Checkpoint</b> Qwen/Qwen3-32B</span>
 <span><b>Precision</b> BF16</span>
+<span><b>Backend</b> vLLM</span>
 <span><b>GPUs</b> 16x H200, 2 nodes: 6x TP2 prefill + 2x TP2 decode</span>
 <span><b>Techniques</b> Disaggregated P/D + KV-aware routing</span>
-<span><b>Workload</b> Multi-turn conversation with prefix reuse (Mooncake trace, 12K avg ISL / 343 avg OSL)</span>
+<span><b>Workload</b> Mooncake conversation trace: 12,031 requests over ~59 min (3.4 req/s), 12,035 avg ISL / 343 avg OSL</span>
 <span><b>SLA</b> Goodput at TTFT 2s / ITL 25ms</span>
 </div>
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="kvbm">
+<span><b>Checkpoint</b> Qwen/Qwen3-32B</span>
+<span><b>Precision</b> BF16</span>
+<span><b>Backend</b> vLLM</span>
+<span><b>GPUs</b> 1x H200 (141 GB)</span>
+<span><b>Host memory</b> ≥ ~150 GiB, 100 GiB of it pinned for the KVBM host tier</span>
+<span><b>Techniques</b> Aggregated + KVBM host-memory KV offload</span>
+<span><b>Workload</b> Conversational chat, no bundled dataset</span>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="chat" data-variant="kvbm">
+<span><b>Checkpoint</b> Qwen/Qwen3-32B</span>
+<span><b>Precision</b> BF16</span>
+<span><b>Backend</b> vLLM</span>
+<span><b>GPUs</b> 1x B200 (192 GB)</span>
+<span><b>Host memory</b> ≥ ~150 GiB, 100 GiB of it pinned for the KVBM host tier</span>
+<span><b>Techniques</b> Aggregated + KVBM host-memory KV offload</span>
+<span><b>Workload</b> Conversational chat, no bundled dataset</span>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg">
+<span><b>Checkpoint</b> Qwen/Qwen3-32B</span>
+<span><b>Precision</b> BF16</span>
+<span><b>Backend</b> vLLM</span>
+<span><b>GPUs</b> 1 prefill + 1 decode worker (1P1D), 4 GPUs each</span>
+<span><b>Techniques</b> Disaggregated P/D + provider fabric overlays</span>
+<span><b>Fabrics</b> Azure AKS IB, AWS EFA (p5.48xlarge), GKE RoCE, Nebius IB, Nscale IB</span>
+<span><b>Workload</b> Conversational chat, no bundled dataset</span>
+</div>
+</div>
+
+## Results
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg-multi-node">
+
+The recipe publishes the outcome of the comparison as a [results video](https://github.com/user-attachments/assets/c425002b-4459-47c4-bfca-fd1e2620500c) rather than a numeric table.
+
+</div>
+
+<div data-sku="h200 b200" data-engine="vllm" data-usecase="chat" data-variant="kvbm disagg">
+
+This target ships deployment manifests only — the published comparison covers the disaggregated + KV-routing target, and there are no measured numbers for this one.
+
+</div>
+
+## Experiment Overview
+
+- The aggregated round-robin configuration (`recipes/qwen3-32b/vllm/agg-round-robin/`, deployment `agg-8xtp2`, 8x TP2 workers) ships in this recipe directory as a benchmark control, but is documented on the related Feature Benchmarks page rather than here.
+
+## Dataset: Mooncake Conversation Trace
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg-multi-node">
+
+The benchmark replays a production conversation trace with significant prefix-sharing potential:
+
+| Metric | Value |
+|--------|-------|
+| Requests | 12,031 over ~59 minutes (3.4 req/s) |
+| Input tokens/sec | 40,937 tok/s |
+| Input length | avg 12,035 tokens (range: 891 - 126,195) |
+| Output length | avg 343 tokens |
+
+Cache reuse analysis:
+
+| Metric | Value | What it measures |
+|--------|-------|------------------|
+| Blocks reused | 24.2% | Of 182,790 unique blocks, 44,144 appeared in more than one request |
+| Cache efficiency | 36.64% | Of 288,500 total block references, 105,710 were repeats (reusable with infinite cache) |
+
+The two differ because block reuse counts unique blocks that repeat, ignoring how often they repeat, while cache efficiency weights by frequency — a block reused 12,031 times contributes more than one reused once. With 36.64% cache efficiency, requests can be routed to workers that already hold the relevant KV blocks, which is what makes this workload ideal for KV-aware routing and significantly reduces TTFT.
+
+</div>
+
+<div data-sku="h200 b200" data-engine="vllm" data-usecase="chat" data-variant="kvbm disagg">
+
+The Mooncake trace ships only with the disaggregated + KV-routing target's `perf.yaml`. This target has no bundled dataset — benchmark it against your own workload.
+
 </div>
 
 ## Prerequisites
 
-- A Kubernetes cluster with the Dynamo platform installed and **16x H200 across 2 nodes** available.
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg-multi-node">
+
+- A Kubernetes cluster with the Dynamo platform installed and **16x H200 across 2 nodes** available — see the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
+- A Hugging Face token with access to `Qwen/Qwen3-32B`.
+- RDMA NICs exposed to pods (an `rdma/ib` device plugin) for NIXL KV transfer — each prefill and decode worker reserves 2 `rdma/ib` devices.
+
+</div>
+
+<div data-sku="h200 b200" data-engine="vllm" data-usecase="chat" data-variant="kvbm">
+
+- A Kubernetes cluster with the Dynamo platform installed and **1x NVIDIA H200 (141 GB) or B200 (192 GB)** available — see the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx). Qwen3-32B in BF16 is ~64 GB of weights plus KV cache and activations, so an 80 GB H100 leaves very little room and is likely to OOM under real load; if you only have H100 80 GB, use the [Qwen3-32B FP8 recipe](qwen3-32b-fp8.mdx) instead.
+- **≥ ~150 GiB of host memory on the node.** `DYN_KVBM_CPU_CACHE_GB=100` is pinned as page-locked host memory for KVBM's G2 tier, and the worker declares `resources.requests.memory: 150Gi` and `resources.limits.memory: 200Gi` (100 GiB pinned KV pool plus ~50 GiB headroom for Python, weight-loader working memory, and CUDA/NCCL buffers). If you raise `DYN_KVBM_CPU_CACHE_GB`, scale both memory values up by roughly the same delta.
+- Pre-existing `model-cache` and `compilation-cache` PVCs — created by the storage step in [Quick Start](#quick-start).
 - A Hugging Face token with access to `Qwen/Qwen3-32B`.
 
-Create the namespace and token secret:
+</div>
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg">
+
+- A Kubernetes cluster with the Dynamo platform installed on one of the supported provider fabrics — Azure AKS InfiniBand, AWS EFA on `p5.48xlarge`, GKE RoCE, Nebius InfiniBand, or Nscale InfiniBand. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
+- A Hugging Face token with access to `Qwen/Qwen3-32B`.
+
+</div>
+
+- For 80 GB GPUs (H100), use the [Qwen3-32B FP8 recipe](qwen3-32b-fp8.mdx) — BF16 weights are ~64 GB and leave little KV headroom.
+
+Create the token secret in your namespace:
 
 ```bash
 export NAMESPACE=your-namespace
@@ -42,18 +167,30 @@ kubectl create secret generic hf-token-secret \
 Edit namespace, storage class, image tags, node selectors, resource claims, Hugging Face secrets, and cluster-specific placement before applying these manifests.
 </Warning>
 
-## Deploy
+## Quick Start
+
+### 1. Create Storage
 
 Prepare the model cache and download the checkpoint (`cache.yaml` creates the `model-cache`, `compilation-cache`, and `perf-cache` PVCs):
 
 ```bash
 # Edit storageClassName in cache.yaml to match your cluster first.
+# Run `kubectl get storageclass` to find the available options.
 kubectl apply -f recipes/qwen3-32b/model-cache/cache.yaml -n ${NAMESPACE}
+```
+
+### 2. Download Model
+
+```bash
 kubectl apply -f recipes/qwen3-32b/model-cache/model-download.yaml -n ${NAMESPACE}
 kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=600s
 ```
 
-Then deploy:
+### 3. Deploy & Benchmark
+
+Deploy the target you selected:
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg-multi-node">
 
 ```bash
 kubectl apply -f recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml -n ${NAMESPACE}
@@ -63,22 +200,147 @@ kubectl wait --for=condition=ready pod \
   -n ${NAMESPACE} --timeout=1200s
 ```
 
-## Smoke Test
+</div>
+
+<div data-sku="h200 b200" data-engine="vllm" data-usecase="chat" data-variant="kvbm">
+
+A single aggregated worker with the KV Block Manager (KVBM) enabled, so cold KV cache blocks spill to host memory and the effective cache footprint extends beyond GPU HBM — which improves prefix-reuse hit rate on long or repeated prompts without adding GPUs:
+
+```bash
+kubectl apply -f recipes/qwen3-32b/vllm/agg-kvbm/deploy.yaml -n ${NAMESPACE}
+
+kubectl wait --for=condition=ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=agg-kvbm-qwen3-32b \
+  -n ${NAMESPACE} --timeout=1200s
+```
+
+</div>
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg">
+
+The base keeps the common Qwen3-32B 1P1D vLLM deployment in one `DynamoGraphDeployment`, and provider overlays patch only the pieces that vary by fabric: RDMA resources, annotations, host mounts, image selection, and runtime environment. Apply the rendered manifest for your fabric:
+
+```bash
+# Azure AKS InfiniBand
+kubectl apply -f recipes/qwen3-32b/vllm/cloud-providers/deploy-aks-ib.yaml -n ${NAMESPACE}
+# OR AWS EFA + libfabric on p5.48xlarge (16 EFA per worker)
+kubectl apply -f recipes/qwen3-32b/vllm/cloud-providers/deploy-aws-p5.48xlarge.yaml -n ${NAMESPACE}
+# OR GKE RoCE
+kubectl apply -f recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-roce.yaml -n ${NAMESPACE}
+# OR Nebius InfiniBand
+kubectl apply -f recipes/qwen3-32b/vllm/cloud-providers/deploy-nebius-ib.yaml -n ${NAMESPACE}
+# OR Nscale InfiniBand
+kubectl apply -f recipes/qwen3-32b/vllm/cloud-providers/deploy-nscale-ib.yaml -n ${NAMESPACE}
+```
+
+Kustomize is both the authoring model and the documentation for these variants: the base and Components explain the provider settings, and each public overlay documents the concrete selection. Applying a rendered `deploy-*.yaml` and applying its public overlay are equivalent, and neither path requires regeneration. Each manifest's overlay:
+
+- `deploy-aks-ib.yaml` (Azure AKS InfiniBand) — `kustomize/overlays/aks-ib/`
+- `deploy-aws-p5.48xlarge.yaml` (AWS EFA + libfabric on `p5.48xlarge`, 16 EFA per worker) — `kustomize/overlays/aws-p5.48xlarge/`
+- `deploy-gke-roce.yaml` (GKE RoCE) — `kustomize/overlays/gke-roce/`
+- `deploy-nebius-ib.yaml` (Nebius InfiniBand) — `kustomize/overlays/nebius-ib/`
+- `deploy-nscale-ib.yaml` (Nscale InfiniBand) — `kustomize/overlays/nscale-ib/`
+
+For example, apply the GKE RoCE composition directly from its checked-in Kustomization:
+
+```bash
+kubectl apply -k recipes/qwen3-32b/vllm/cloud-providers/kustomize/overlays/gke-roce -n ${NAMESPACE}
+```
+
+To make a local, uncommitted composition, create your own `kustomization.yaml` in the repository checkout, or run `compose` from the repository root:
+
+```bash
+scripts/kustomize-matrix.py compose \
+  recipes/qwen3-32b/vllm/cloud-providers/kustomize/base \
+  recipes/kustomize/components/aks-ib \
+  | kubectl apply -f - -n ${NAMESPACE}
+```
+
+The vLLM command line reads provider-specific values from environment variables — `KV_TRANSFER_CONFIG`, `GPU_MEMORY_UTILIZATION`, `HF_HOME`, and transport-specific variables such as `UCX_NET_DEVICES` or `DYN_KVBM_NIXL_BACKEND_LIBFABRIC` — so overlays can patch individual values without replacing the shared `args` list. Shared provider Components apply to the backend-neutral `PrefillWorker` and `DecodeWorker` service keys, while model-specific images, mounts, and command configuration remain in local Components; the EFA leaf Component includes its AWS and libfabric parents and names the per-worker EFA request explicitly.
+
+Only recipe contributors update the checked-in derived artifacts. The source of truth is `.kustomize-matrix.yaml`, `kustomize/base/`, the recipe-local Components, plus the referenced shared Components under `recipes/kustomize/components/`; the public overlay `kustomization.yaml` files and the `deploy-*.yaml` manifests are generated — commit them for review, but do not edit them by hand. Regenerate them from the repository root:
+
+```bash
+scripts/kustomize-matrix.py unfold recipes/qwen3-32b/vllm/cloud-providers/.kustomize-matrix.yaml
+scripts/kustomize-matrix.py render recipes/qwen3-32b/vllm/cloud-providers/.kustomize-matrix.yaml
+```
+
+</div>
 
 Send a test request to verify the deployment serves traffic:
 
-```bash
-kubectl port-forward svc/disagg-router-6p-2d-frontend 8000:8000 -n ${NAMESPACE} &
-sleep 3
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg-multi-node">
 
-curl http://localhost:8000/v1/chat/completions \
-  -H 'Content-Type: application/json' \
-  -d '{"model":"Qwen/Qwen3-32B","messages":[{"role":"user","content":"Write a one-sentence readiness check."}],"max_tokens":64}'
+```bash
+kubectl port-forward svc/disagg-router-6p-2d-frontend 8000:8000 -n ${NAMESPACE}
 ```
 
-## Benchmark
+</div>
 
-The checked-in `perf.yaml` downloads the Mooncake conversation trace (FAST25; 12,031 requests over ~59 minutes) and replays it on a fixed schedule, so throughput is set by the trace and latency is what you measure. It wraps this AIPerf run:
+<div data-sku="h200 b200" data-engine="vllm" data-usecase="chat" data-variant="kvbm">
+
+```bash
+kubectl port-forward svc/agg-kvbm-qwen3-32b-frontend 8000:8000 -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg">
+
+```bash
+kubectl port-forward svc/q32b-1p1d-cloud-provider-frontend 8000:8000 -n ${NAMESPACE}
+```
+
+</div>
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-32B",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 64
+  }'
+```
+
+<div data-sku="h200 b200" data-engine="vllm" data-usecase="chat" data-variant="kvbm">
+
+#### KVBM Configuration
+
+The connector is selected through the worker's `--kv-transfer-config`:
+
+```json
+{"kv_connector":"DynamoConnector","kv_role":"kv_both","kv_connector_module_path":"kvbm.vllm_integration.connector"}
+```
+
+This recipe sets one worker environment variable:
+
+| Variable | Default in this recipe | Description |
+|---|---|---|
+| `DYN_KVBM_CPU_CACHE_GB` | `100` | CPU memory reserved for offloaded KV blocks. Raise it for longer contexts or higher reuse; if you change it, also bump `resources.requests.memory` / `limits.memory` on the worker by roughly the same delta. |
+
+##### Prometheus Metrics (Optional)
+
+Metrics are **off** by default. To expose them, add the following to the worker's `env` and `mainContainer.ports` in `deploy.yaml`:
+
+```yaml
+env:
+  - name: DYN_KVBM_METRICS
+    value: "true"
+  - name: DYN_KVBM_METRICS_PORT
+    value: "6880"
+ports:
+  - name: kvbm
+    containerPort: 6880
+```
+
+Once enabled, scrape `:6880/metrics` for counters like `kvbm_offload_blocks_d2h`, `kvbm_onboard_blocks_h2d`, `kvbm_matched_tokens`, and `kvbm_host_cache_hit_rate`, plus per-route transfer counters. If you run the Prometheus Operator, add a `PodMonitor` selecting pods with `nvidia.com/dynamo-component-type: worker` and port `kvbm`.
+
+</div>
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg-multi-node">
+
+The checked-in `perf.yaml` downloads the Mooncake conversation trace (FAST25) and replays it on a fixed schedule, so throughput is set by the trace and latency is what you measure. It wraps this AIPerf run:
 
 ```bash
 aiperf profile -m Qwen/Qwen3-32B \
@@ -92,25 +354,119 @@ aiperf profile -m Qwen/Qwen3-32B \
 
 ```bash
 kubectl apply -f recipes/qwen3-32b/vllm/disagg-kv-router/perf.yaml -n ${NAMESPACE}
+```
 
+</div>
+
+### 4. Monitor Benchmark Progress
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg-multi-node">
+
+```bash
 # The benchmark runs in a tmux session; attach to watch intermediate results.
 kubectl get pods -n ${NAMESPACE} | grep benchmark
 kubectl exec -it -n ${NAMESPACE} <benchmark-pod-name> -- tmux a -t benchmark
+
+# Detach from tmux: Ctrl+B, then D
 ```
 
-Results land on the `perf-cache` PVC under `/perf-cache/artifacts/`.
+</div>
 
-## Related Feature Benchmarks
+<div data-sku="h200 b200" data-engine="vllm" data-usecase="chat" data-variant="kvbm disagg">
+
+This target ships no benchmark job, so there is nothing to monitor — skip to the next step.
+
+</div>
+
+### 5. View Results
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg-multi-node">
+
+Results land on the `perf-cache` PVC under `/perf-cache/artifacts/`:
+
+```bash
+# Check the artifact directory
+kubectl exec -it -n ${NAMESPACE} <benchmark-pod-name> -- ls -la /perf-cache/artifacts/
+
+# Copy results to your local machine
+kubectl cp ${NAMESPACE}/<benchmark-pod-name>:/perf-cache/artifacts ./benchmark-results
+```
+
+</div>
+
+<div data-sku="h200 b200" data-engine="vllm" data-usecase="chat" data-variant="kvbm disagg">
+
+This target produces no benchmark artifacts. Collect results from your own load generator instead.
+
+</div>
+
+## Expected Results
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg-multi-node">
+
+Since the replay is fixed-schedule — requests arrive at their original timestamps — throughput metrics are fixed by the trace, and the latency metrics are what the comparison turns on:
+
+| Metric | Why it matters |
+|--------|----------------|
+| **TTFT** (time to first token) | KV-aware routing reduces prefill compute via prefix cache hits |
+| **ITL** (inter-token latency) | Disaggregated serving isolates decode from prefill interference |
+| **Total request latency** | Combined benefit of both optimizations |
+
+Why disaggregated serving plus KV-aware routing helps this workload:
+
+1. **KV-aware routing** leverages the 36% cache efficiency to route requests to workers that already have relevant KV cache blocks, reducing redundant prefill computation and lowering TTFT.
+2. **Disaggregated serving** separates prefill and decode workers. With long input sequences (avg 12K tokens) and short outputs (avg 343 tokens), dedicated decode workers avoid "prefill injection" — where a new long-context request interrupts ongoing decode operations, causing ITL spikes.
+
+</div>
+
+<div data-sku="h200 b200" data-engine="vllm" data-usecase="chat" data-variant="kvbm disagg">
+
+There is no published baseline for this target. For background on why disaggregated serving and KV-aware routing help prefix-heavy conversational traffic, see the [Qwen3-32B KV routing A/B](../feature-benchmarks/qwen3-32b-kv-routing-a-b.mdx) benchmark.
+
+</div>
+
+## Cleanup
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg-multi-node">
+
+```bash
+# Delete benchmark pods
+kubectl delete pod -l app=benchmark -n ${NAMESPACE}
+
+# Delete deployments
+kubectl delete dynamographdeployment disagg-router-6p-2d -n ${NAMESPACE}
+# ...and the aggregated round-robin control, if you deployed it
+kubectl delete dynamographdeployment agg-8xtp2 -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="h200 b200" data-engine="vllm" data-usecase="chat" data-variant="kvbm">
+
+```bash
+kubectl delete dynamographdeployment agg-kvbm-qwen3-32b -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="h200" data-engine="vllm" data-usecase="chat" data-variant="disagg">
+
+```bash
+kubectl delete dynamographdeployment q32b-1p1d-cloud-provider -n ${NAMESPACE}
+```
+
+</div>
+
+## References
 
 - [Qwen3-32B KV routing A/B](../feature-benchmarks/qwen3-32b-kv-routing-a-b.mdx) — the evidence behind this recipe: this configuration vs. aggregated round-robin on the same trace.
-
-## Notes
-
-- The aggregated round-robin manifest is a benchmark control and lives on the related Feature Benchmarks page, not in this recipe.
-- For 80 GB GPUs (H100), use the [Qwen3-32B FP8 recipe](qwen3-32b-fp8.mdx) — BF16 weights are ~64 GB and leave little KV headroom.
 
 ## Source
 
 - Source README: [recipes/qwen3-32b/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/README.md)
 - Deploy and benchmark: [deploy.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml) and [perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/disagg-kv-router/perf.yaml)
+- Aggregated round-robin control: [deploy.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/agg-round-robin/deploy.yaml) and [perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/agg-round-robin/perf.yaml)
+- Aggregated + KVBM: [README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/agg-kvbm/README.md) and [deploy.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/agg-kvbm/deploy.yaml)
+- Cloud provider overlays: [README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/cloud-providers/README.md), [deploy-aks-ib.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/cloud-providers/deploy-aks-ib.yaml), [deploy-aws-p5.48xlarge.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/cloud-providers/deploy-aws-p5.48xlarge.yaml), [deploy-gke-roce.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/cloud-providers/deploy-gke-roce.yaml), [deploy-nebius-ib.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/cloud-providers/deploy-nebius-ib.yaml), and [deploy-nscale-ib.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/cloud-providers/deploy-nscale-ib.yaml) — adapted from the provider-specific examples in [ai-dynamo/dynamo#10202](https://github.com/ai-dynamo/dynamo/pull/10202)
 - Setup assets: [model-cache/cache.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/model-cache/cache.yaml) and [model-cache/model-download.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/model-cache/model-download.yaml)
+- Trace source: [Mooncake: A KVCache-centric Disaggregated Architecture for LLM Serving](https://github.com/kvcache-ai/Mooncake) — FAST25 paper and trace data

--- a/docs/fern/pages/recipes/model-recipes/qwen3-5-122b.mdx
+++ b/docs/fern/pages/recipes/model-recipes/qwen3-5-122b.mdx
@@ -9,7 +9,7 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-All four targets below are Dynamo + vLLM deployments of Alibaba's Qwen3.5-122B-A10B — a 122B total / 10B active hybrid MoE combining Gated DeltaNet linear attention with full attention every fourth layer — tuned for an agentic workload (64K median ISL / 400 median OSL, 90% KV cache hit) with KV-aware routing. B200 runs the NVFP4 checkpoint at TP1; H200 runs FP8, where the weights leave less room for paged KV, so the aggregated profile shards to TP2 and adds MTP speculative decoding. Aggregated is the recommended path on both SKUs. Pick your target; every command on this page updates to match.
+All four targets below are Dynamo + vLLM deployments of Alibaba's Qwen3.5-122B-A10B — a 122B total / 10B active hybrid MoE combining Gated DeltaNet linear attention with full attention every fourth layer — tuned for an agentic workload (64K median ISL / 400 median OSL, 90% KV cache hit) with KV-aware routing. B200 runs the NVFP4 checkpoint at TP1; H200 runs FP8, which fits one 143 GB H200 at the full 262,144-token context. The H200 aggregated profile shards to TP2 and adds MTP speculative decoding. Every target accepts text, image, and video input and supports reasoning (`--dyn-reasoning-parser qwen3`) and tool calling (`--dyn-tool-call-parser qwen3_coder`). Aggregated is the recommended path on both SKUs. Pick your target; every command on this page updates to match.
 
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
@@ -21,57 +21,129 @@ All four targets below are Dynamo + vLLM deployments of Alibaba's Qwen3.5-122B-A
 <label htmlFor="recipe-sku-b200">B200 · NVFP4</label>
 </div>
 <div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Workload</span>
+<input type="radio" id="recipe-usecase-agentic" name="recipe-usecase" value="agentic" defaultChecked />
+<label htmlFor="recipe-usecase-agentic">Agentic</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Backend</span>
+<input type="radio" id="recipe-engine-vllm" name="recipe-engine" value="vllm" defaultChecked />
+<label htmlFor="recipe-engine-vllm">vLLM</label>
+</div>
+<div className="dynamo-target-picker-row">
 <span className="dynamo-target-picker-dim">Topology</span>
 <input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" defaultChecked />
 <label htmlFor="recipe-variant-agg">Aggregated <span className="dynamo-target-picker-hint">Recommended</span></label>
 <input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" />
 <label htmlFor="recipe-variant-disagg">Disaggregated</label>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-variant="agg">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> Qwen/Qwen3.5-122B-A10B-FP8</span>
 <span><b>Precision</b> FP8 weights, BF16 KV</span>
+<span><b>Context length</b> 262,144</span>
 <span><b>GPUs</b> 2x H200 per replica, `replicas: 2` (4x)</span>
 <span><b>Parallelism</b> TP2</span>
+<span><b>MoE backend</b> `triton`</span>
+<span><b>KV cache manager</b> Hybrid (DeltaNet SSM + attention)</span>
 <span><b>Spec decode</b> MTP, 3 tokens</span>
-<span><b>Routing</b> KV-aware</span>
+<span><b>Routing</b> KV-aware + worker KV events</span>
+<span><b>Async scheduling</b> Enabled</span>
+<span><b>Target</b> `agg-h200-agentic`</span>
+<span><b>GPU</b> H200</span>
+<span><b>Backend</b> vLLM</span>
+<span><b>Workload</b> Agentic trace replay</span>
+<span><b>Topology</b> Aggregated</span>
+<span><b>Reported point</b> c64, highest SLA-passing</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="h200" data-variant="disagg">
+<div className="dynamo-target-picker-summary" data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 <span><b>Checkpoint</b> Qwen/Qwen3.5-122B-A10B-FP8</span>
 <span><b>Precision</b> FP8 + FP8 KV</span>
+<span><b>Context length</b> 262,144</span>
 <span><b>GPUs</b> 1x H200 prefill + 2x H200 decode</span>
 <span><b>Parallelism</b> TP1 per worker</span>
+<span><b>MoE backend</b> `triton`</span>
+<span><b>KV cache manager</b> Hybrid (DeltaNet SSM + attention)</span>
 <span><b>Spec decode</b> None — see Limitations</span>
-<span><b>Routing</b> KV-aware, NIXL/UCX over IB</span>
+<span><b>Routing</b> KV-aware + worker KV events</span>
+<span><b>KV transfer</b> NIXL/UCX over InfiniBand</span>
+<span><b>Async scheduling</b> Disabled on decode — see Limitations</span>
+<span><b>Target</b> `disagg-h200-agentic`</span>
+<span><b>GPU</b> H200</span>
+<span><b>Backend</b> vLLM</span>
+<span><b>Workload</b> Agentic trace replay</span>
+<span><b>Topology</b> Disaggregated 1P2D</span>
+<span><b>Reported point</b> c18, highest SLA-passing</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="agg">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 <span><b>Checkpoint</b> nvidia/Qwen3.5-122B-A10B-NVFP4</span>
 <span><b>Precision</b> NVFP4 + FP8 KV</span>
+<span><b>Context length</b> 262,144</span>
 <span><b>GPUs</b> 1x B200 per replica, `replicas: 2` (2x)</span>
 <span><b>Parallelism</b> TP1</span>
-<span><b>Spec decode</b> None</span>
-<span><b>Routing</b> KV-aware</span>
+<span><b>MoE backend</b> FLASHINFER_TRTLLM</span>
+<span><b>KV cache manager</b> Hybrid (DeltaNet SSM + attention)</span>
+<span><b>Spec decode</b> None — see Limitations</span>
+<span><b>Routing</b> KV-aware (workers publish KV events)</span>
+<span><b>Target</b> `agg-b200-agentic`</span>
+<span><b>GPU</b> B200</span>
+<span><b>Backend</b> vLLM</span>
+<span><b>Workload</b> Agentic trace replay</span>
+<span><b>Topology</b> Aggregated</span>
+<span><b>Reported point</b> c50, just above the 50 tok/s/user floor</span>
 </div>
-<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="disagg">
+<div className="dynamo-target-picker-summary" data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 <span><b>Checkpoint</b> nvidia/Qwen3.5-122B-A10B-NVFP4</span>
 <span><b>Precision</b> NVFP4 + FP8 KV</span>
+<span><b>Context length</b> 262,144</span>
 <span><b>GPUs</b> 1x B200 prefill + 2x B200 decode</span>
 <span><b>Parallelism</b> TP1 per worker</span>
-<span><b>Spec decode</b> None</span>
-<span><b>Routing</b> KV-aware, NIXL/UCX over IB</span>
+<span><b>MoE backend</b> FLASHINFER_TRTLLM</span>
+<span><b>KV cache manager</b> Hybrid (DeltaNet SSM + attention)</span>
+<span><b>Spec decode</b> None — see Limitations</span>
+<span><b>Routing</b> KV-aware (workers publish KV events)</span>
+<span><b>KV transfer</b> NIXL/UCX over InfiniBand</span>
+<span><b>Target</b> `disagg-b200-agentic`</span>
+<span><b>GPU</b> B200</span>
+<span><b>Backend</b> vLLM</span>
+<span><b>Workload</b> Agentic trace replay</span>
+<span><b>Topology</b> Disaggregated 1P2D</span>
+<span><b>Reported point</b> c60, just above the 50 tok/s/user floor</span>
 </div>
 </div>
+
+## Configurations
+
+- All four targets run Dynamo 1.3.0 / vLLM 0.23.
+- The H200 aggregated target runs `--kv-cache-dtype auto`; the disaggregated targets and both B200 targets use `fp8`. FP8 KV costs compute and only pays back when the cache is the binding constraint, which it is not at TP2.
+- Worker `--block-size` must match the frontend `--kv-cache-block-size`. If they diverge, prefix hashing does not line up and KV-aware routing silently degrades toward round-robin.
+
+## Supported features
+
+- Modalities: text, image, video
+- Reasoning (`--dyn-reasoning-parser qwen3`)
+- Tool calling (`--dyn-tool-call-parser qwen3_coder`)
 
 ## Prerequisites
 
-1. Dynamo Platform installed on the target cluster with DGD CRDs served.
-2. A Hugging Face token stored as `hf-token-secret`. The checkpoint is public and Apache-2.0.
+1. Dynamo Platform installed on the target cluster with DGD CRDs served — see the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
+2. A Hugging Face token stored as `hf-token-secret`, with access to the checkpoint your target uses. `Qwen/Qwen3.5-122B-A10B-FP8` is public and Apache-2.0; the B200 target additionally needs access to `nvidia/Qwen3.5-122B-A10B-NVFP4`.
 3. A `model-cache` PVC (ReadWriteMany), populated with the manifests in `model-cache/`.
 
-<div data-variant="disagg">
+<div data-sku="b200 h200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
+
+4. No RDMA fabric requirement — an aggregated replica prefills and decodes on the same worker, so no KV crosses the network.
+
+</div>
+
+<div data-sku="b200 h200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 
 4. GPU-local RDMA NICs exposed to pods (an `rdma/ib` device plugin) for NIXL KV transfer.
 
 </div>
+
+## Quick Start
+
+### 1. Namespace + HF secret
 
 ```bash
 export NAMESPACE=your-namespace
@@ -80,11 +152,13 @@ kubectl create secret generic hf-token-secret \
   --from-literal=HF_TOKEN="your-token" -n ${NAMESPACE}
 ```
 
-## Deploy
+### 2. Storage
 
 Create the cache and download the checkpoint. Set `storageClassName` in `model-cache.yaml` to a ReadWriteMany class first.
 
-<div data-sku="h200">
+### 3. Download the model
+
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg disagg">
 
 ```bash
 kubectl apply -f recipes/qwen3.5-122b/fp8/model-cache/model-cache.yaml -n ${NAMESPACE}
@@ -94,17 +168,19 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 
 </div>
 
-<div data-sku="b200">
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg disagg">
 
 ```bash
 kubectl apply -f recipes/qwen3.5-122b/nvfp4/model-cache/model-cache.yaml -n ${NAMESPACE}
 kubectl apply -f recipes/qwen3.5-122b/nvfp4/model-cache/model-download.yaml -n ${NAMESPACE}
-kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=7200s
+kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=3600s
 ```
 
 </div>
 
-<div data-sku="h200" data-variant="agg">
+### 4. Deploy
+
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/qwen3.5-122b/fp8/vllm/agg-h200-agentic/deploy.yaml -n ${NAMESPACE}
@@ -113,11 +189,11 @@ kubectl wait --for=condition=Ready pod \
   -n ${NAMESPACE} --timeout=7200s
 ```
 
-Deploy `replicas: 2` or more so the KV-aware router has replicas to route shared prefixes across. Each replica is TP2, so a full 8x H200 node runs `replicas: 4`.
+Deploy `replicas: 2` or more so the KV-aware router has replicas to route shared prefixes across. Each replica is TP2, so scale aggregated to a full 8x H200 node with `replicas: 4`.
 
 </div>
 
-<div data-sku="h200" data-variant="disagg">
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/qwen3.5-122b/fp8/vllm/disagg-h200-agentic/deploy.yaml -n ${NAMESPACE}
@@ -128,7 +204,7 @@ kubectl wait --for=condition=Ready pod \
 
 </div>
 
-<div data-sku="b200" data-variant="agg">
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 ```bash
 kubectl apply -f recipes/qwen3.5-122b/nvfp4/vllm/agg-b200-agentic/deploy.yaml -n ${NAMESPACE}
@@ -141,7 +217,7 @@ Deploy `replicas: 2` or more so the KV-aware router has replicas to route shared
 
 </div>
 
-<div data-sku="b200" data-variant="disagg">
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
 
 ```bash
 kubectl apply -f recipes/qwen3.5-122b/nvfp4/vllm/disagg-b200-agentic/deploy.yaml -n ${NAMESPACE}
@@ -154,7 +230,7 @@ kubectl wait --for=condition=Ready pod \
 
 First cold starts take 30-45 minutes while the runtime loads the weights and captures CUDA graphs; a measured cold load spent 28.5 minutes on weights alone before graph capture began.
 
-## Smoke Test
+### 5. Smoke test
 
 ```bash
 kubectl port-forward -n ${NAMESPACE} \
@@ -171,32 +247,40 @@ curl http://localhost:8000/v1/chat/completions -H 'Content-Type: application/jso
 
 Both SKUs serve the model as `Qwen/Qwen3.5-122B-A10B` regardless of the underlying checkpoint.
 
-## Benchmark
+### 6. Benchmark
 
-The benchmark replays a Mooncake-format agentic trace through AIPerf.
+The benchmark replays a [Mooncake-format](https://github.com/kvcache-ai/Mooncake) agentic trace through [AIPerf](https://github.com/ai-dynamo/aiperf). The Job waits for the target model on the DGD frontend, runs a short warmup, replays the configured trace at one `CONCURRENCY` value, and writes raw artifacts to the shared `model-cache` PVC. Its pod is co-located with a DGD frontend through `podAffinity`.
 
-<div data-sku="b200">
+Each JSONL line in the trace describes one request (`input_length`, `output_length`, `hash_ids`, `timestamp`).
 
-```bash
-kubectl apply -f recipes/qwen3.5-122b/nvfp4/perf/perf.yaml -n ${NAMESPACE}
-```
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg disagg">
 
-See [nvfp4/perf/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3.5-122b/nvfp4/perf/README.md) for the full workflow.
-
-</div>
-
-<div data-sku="h200">
-
-```bash
-kubectl apply -f recipes/qwen3.5-122b/fp8/perf/perf.yaml -n ${NAMESPACE}
-```
-
-Edit `ENDPOINT` and `CONCURRENCY` in the Job to select a target — aggregated at c64, disaggregated at c18. See [fp8/perf/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3.5-122b/fp8/perf/README.md) for the full workflow.
+Edit `ENDPOINT` and `CONCURRENCY` in the Job to select a target — `qwen35-122b-agg-b200-agentic-frontend:8000` at c50, or `qwen35-122b-disagg-b200-agentic-frontend:8000` at c60; the shipped default is the aggregated endpoint at c64. See [nvfp4/perf/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3.5-122b/nvfp4/perf/README.md) for the full workflow.
 
 AIPerf builds its replay schedule from a `timestamp` field. The shipped trace rows have none, and without one AIPerf replays a small default instead of the whole file, so add one before staging the trace on the PVC:
 
 ```bash
 git lfs install
+git lfs pull --include "recipes/*/perf/traces/*"
+python3 -c "
+import json
+src='recipes/qwen3.5-122b/nvfp4/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl'
+for line in open(src):
+    print(json.dumps({'timestamp': 0, **json.loads(line)}))
+" > mooncake_agentic.jsonl
+```
+
+</div>
+
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg disagg">
+
+Edit `ENDPOINT` and `CONCURRENCY` in the Job to select a target — `qwen35-122b-agg-h200-agentic-frontend:8000` at c64, or `qwen35-122b-disagg-h200-agentic-frontend:8000` at c18. See [fp8/perf/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3.5-122b/fp8/perf/README.md) for the full workflow. This Job replays at a 512-token prompt block size and aborts if the trace has no `timestamp` field.
+
+AIPerf builds its replay schedule from a `timestamp` field. The shipped trace rows have none, and without one AIPerf replays a small default instead of the whole file, so add one before staging the trace on the PVC:
+
+```bash
+git lfs install
+# the trace here is a symlink into recipes/kimi-k2.6, where the LFS object lives
 git lfs pull --include "recipes/kimi-k2.6/perf/traces/*"
 python3 -c "
 import json
@@ -206,13 +290,124 @@ for line in open(src):
 " > mooncake_agentic.jsonl
 ```
 
-Confirm a run replayed the whole file: `Request Count` in `profile_export_aiperf.csv` should be about 3,411, plus roughly 130 rows that exceed the 262,144-token context and return errors.
+</div>
+
+Stage the generated `mooncake_agentic.jsonl` on the `model-cache` PVC before running the Job:
+
+```bash
+kubectl run pvc-helper -n ${NAMESPACE} \
+  --image=busybox:1.36 --restart=Never \
+  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"model-cache","mountPath":"/model-cache"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"model-cache"}}]}}' \
+  --command -- sleep 3600
+
+kubectl exec -n ${NAMESPACE} pvc-helper -- mkdir -p /model-cache/traces
+kubectl cp mooncake_agentic.jsonl ${NAMESPACE}/pvc-helper:/model-cache/traces/
+```
+
+Keep `pvc-helper` around for fetching artifacts later, or delete it once staging is done. If you run more than one benchmark in the same namespace, also update `metadata.name` and `labels.app` in `perf.yaml` so Jobs and artifact directories stay distinct.
+
+Then run the Job:
+
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg disagg">
+
+```bash
+kubectl apply -f recipes/qwen3.5-122b/nvfp4/perf/perf.yaml -n ${NAMESPACE}
+kubectl logs -n ${NAMESPACE} -l job-name=qwen35-122b-bench -f
+kubectl wait --for=condition=Complete job/qwen35-122b-bench \
+  -n ${NAMESPACE} --timeout=10800s
+```
 
 </div>
 
-## Expected Performance
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg disagg">
 
-Measured on the 3,541-request agentic Mooncake trace, block size 512, closed-loop. SLA: P50 TTFT under 5 s and P50 output at or above 50 tok/s/user. Each target is reported at its highest SLA-passing concurrency.
+```bash
+kubectl apply -f recipes/qwen3.5-122b/fp8/perf/perf.yaml -n ${NAMESPACE}
+kubectl logs -n ${NAMESPACE} -l job-name=qwen35-122b-fp8-bench -f
+kubectl wait --for=condition=Complete job/qwen35-122b-fp8-bench \
+  -n ${NAMESPACE} --timeout=10800s
+```
+
+</div>
+
+Besides `ENDPOINT` and `CONCURRENCY`, the Job reads `TRACE_FILE` (`/model-cache/traces/mooncake_agentic.jsonl` — the 3,541-request agentic trace with timestamps) and `TARGET_MODEL` (`Qwen/Qwen3.5-122B-A10B`, which must match `--served-model-name`).
+
+Run one `CONCURRENCY` value per Job, and restart the DGD pods between values (`kubectl delete pods -n ${NAMESPACE} -l nvidia.com/dynamo-graph-deployment-name=<DGD>`) so vLLM KV and Dynamo router state do not carry over — otherwise runs are not comparable. `perf.yaml` sets `--num-requests` to the trace line count, so in mooncake mode AIPerf replays the whole file provided each row carries a `timestamp`; subset the file to cap the request count.
+
+Confirm a run replayed the whole file: `Request Count` in `profile_export_aiperf.csv` should be about 3,411, plus roughly 130 rows that exceed the 262,144-token context and return errors. Do not compare partial runs — a completed run must account for successful, errored, and unfinished requests before reporting aggregate throughput.
+
+Results land on the PVC under `/model-cache/perf/<epoch>_<job-name>/`:
+
+```text
+/model-cache/perf/<epoch>_<job-name>/
+  warmup/
+  Qwen3.5-122B-A10B_trace_c<concurrency>_<timestamp>/
+    profile_export_aiperf.json
+    inputs.json
+    ...
+```
+
+Read `Output Token Throughput`, `Request Throughput`, `Time to First Token`, `Inter Token Latency`, and `Output Token Throughput Per User` from `profile_export_aiperf.{csv,json}`. KV-cache hit rate is on the frontend `/metrics` (`dynamo_component_router_kv_hit_rate_{sum,count}`).
+
+Fetch the artifacts through `pvc-helper`, then clean up:
+
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg disagg">
+
+```bash
+kubectl cp \
+  ${NAMESPACE}/pvc-helper:/model-cache/perf/<epoch>_qwen35-122b-bench \
+  ./results
+
+kubectl delete job qwen35-122b-bench -n ${NAMESPACE}
+kubectl delete pod pvc-helper -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg disagg">
+
+```bash
+kubectl cp \
+  ${NAMESPACE}/pvc-helper:/model-cache/perf/<epoch>_qwen35-122b-fp8-bench \
+  ./results
+
+kubectl delete job qwen35-122b-fp8-bench -n ${NAMESPACE}
+kubectl delete pod pvc-helper -n ${NAMESPACE}
+```
+
+</div>
+
+To drive AIPerf directly instead of through the Job, run the same image against the frontend service — the Job uses `nvcr.io/nvidia/ai-dynamo/aiperf:0.11.0` with the `model-cache` PVC mounted, and does not install or patch AIPerf at runtime:
+
+```bash
+aiperf profile Qwen/Qwen3.5-122B-A10B --tokenizer Qwen/Qwen3.5-122B-A10B \
+  --url http://${ENDPOINT} --endpoint-type chat \
+  --input-file ${TRACE_FILE} \
+  --custom-dataset-type mooncake_trace --prompt-input-tokens-block-size 512 \
+  --concurrency ${CONCURRENCY} --workers-max ${CONCURRENCY} \
+  --extra-inputs ignore_eos:true --streaming --use-server-token-count \
+  --artifact-dir /model-cache/perf/<run> --ui none
+```
+
+## Optimization targets
+
+The agentic target is median ISL ~64k, OSL ~400, ~90% token-weighted cache hit, replayed closed-loop at a fixed concurrency. Sweep concurrency to find the SLA knee: the highest value holding P50 TTFT under 5 s and P50 output at or above 50 tok/s/user.
+
+## Benchmark Results
+
+Measured 2026-08-06 on the 3,541-request agentic Mooncake trace, closed-loop, with both profiles on a SKU run against the same trace. SLA: P50 TTFT under 5 s and P50 output at or above 50 tok/s/user. `System output tok/s/GPU` is system throughput divided by GPUs.
+
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg disagg">
+
+Each H200 profile is reported at its highest SLA-passing concurrency, at the 512-token prompt block size its `perf.yaml` sets.
+
+</div>
+
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg disagg">
+
+Both B200 profiles are reported at the concurrency where P50 user tok/s sits just above the floor.
+
+</div>
 
 | Target | GPUs | Concurrency | User output tok/s | TTFT (P50) | System output tok/s/GPU |
 |--------|------|-------------|-------------------|------------|-------------------------|
@@ -221,23 +416,9 @@ Measured on the 3,541-request agentic Mooncake trace, block size 512, closed-loo
 | H200 aggregated, 2x TP2 + MTP | 4 | 64 | 52.9 | 313 ms | 720.3 |
 | H200 disaggregated 1P2D | 3 | 18 | 52.5 | 3087 ms | 256.5 |
 
-## Compare All Targets
+Aggregated leads on both SKUs at the same SLA: 1173.2 against 916.6 output tok/s per GPU on B200, where disaggregated is 22% lower per GPU, and 720.3 against 256.5 on H200, where it is 2.8x lower per GPU. **Aggregated is the recommended profile; the disaggregated targets are a functional reference rather than a throughput recommendation.** At 90% KV-cache hit the dedicated prefill worker has little to do yet emits no output tokens, so a third of the fleet is unproductive, and both disaggregated targets pay ~7% for `--no-async-scheduling` on vLLM < 0.26.0. MTP runs on H200 aggregated only — H200 disaggregated gives it up, and neither B200 profile runs it. Choose disaggregation to scale prefill and decode independently, or for a workload with a lower cache-hit rate where the prefill GPU earns its place.
 
-| Target | GPU | Topology | GPUs | Spec decode | Reported point |
-|--------|-----|----------|------|-------------|----------------|
-| `agg-b200-agentic` | B200 | Aggregated | 2 | None | c50, at the 50 tok/s/user floor |
-| `disagg-b200-agentic` | B200 | Disaggregated 1P2D | 3 | None | c60, at the 50 tok/s/user floor |
-| `agg-h200-agentic` | H200 | Aggregated | 4 | MTP, 3 tokens | c64, at the 50 tok/s/user floor |
-| `disagg-h200-agentic` | H200 | Disaggregated 1P2D | 3 | None | c18, at the 50 tok/s/user floor |
-
-Aggregated leads on both SKUs at the same SLA: 1173.2 against 916.6 output tok/s per GPU on B200, 720.3 against 256.5 on H200. **Aggregated is the recommended profile; the disaggregated targets are a functional reference rather than a throughput recommendation.** At 90% KV-cache hit the dedicated prefill worker has little to do yet emits no output tokens, and both disaggregated targets pay ~7% for `--no-async-scheduling` on vLLM < 0.26.0. MTP runs on H200 aggregated only — H200 disaggregated gives it up, and neither B200 profile runs it. Choose disaggregation to scale prefill and decode independently, or for a workload with a lower cache-hit rate.
-
-## Notes
-
-- Worker `--block-size` must match the frontend `--kv-cache-block-size`. If they diverge, prefix hashing does not line up and KV-aware routing silently degrades toward round-robin.
-- The H200 aggregated target runs `--kv-cache-dtype auto`; the disaggregated targets and both B200 targets use `fp8`. FP8 KV costs compute and only pays back when the cache is the binding constraint, which it is not at TP2.
-
-<div data-sku="h200" data-variant="agg">
+<div data-sku="h200" data-engine="vllm" data-usecase="agentic" data-variant="agg">
 
 - Ship the `speculative-config` ConfigMap key; benchmark with `speculative-config-synthetic`, which forces the acceptance length of 2.937 measured against real text. Real MTP reports about 3.2 on this trace because the Mooncake rows synthesise prompts from `hash_ids`, which the draft predicts more easily than real text.
 
@@ -245,12 +426,28 @@ Aggregated leads on both SKUs at the same SLA: 1173.2 against 916.6 output tok/s
 
 ## Limitations
 
+<div data-sku="b200 h200" data-engine="vllm" data-usecase="agentic" data-variant="agg disagg">
+
 - Prefill and decode must use the same tensor-parallel size when disaggregated — asymmetric sharding fails the NIXL transfer with a block-size mismatch.
-- MTP is not supported with disaggregation on this architecture. NIXL's Mamba conv-state transfer needs `VLLM_SSM_CONV_STATE_LAYOUT=DS`, which conflicts with the `mamba_cache_mode='align'` that MTP plus prefix caching forces ([vllm#38898](https://github.com/vllm-project/vllm/issues/38898)).
+- MTP is not supported with disaggregation on this architecture. NIXL's 3-read Mamba conv-state transfer needs `VLLM_SSM_CONV_STATE_LAYOUT=DS`, which conflicts with the `mamba_cache_mode='align'` that MTP plus prefix caching forces ([vllm#38898](https://github.com/vllm-project/vllm/issues/38898)); the align-mode DS conv-state copy path is unimplemented for `num_accepted_tokens > 1` in the shipped vLLM 0.23.0 runtime, so the decode `EngineCore` crashes (`NotImplementedError` → `EngineDeadError`) on the first concurrent batch of real long-context traffic. Patching that crash ([vllm#45473](https://github.com/vllm-project/vllm/pull/45473)) does not make it usable — a spec-decode conv-state metadata mismatch between prefill and decode then makes the NIXL transfer misplace the Mamba conv state, producing garbage output.
 
-<div data-variant="disagg">
+</div>
 
-- Disaggregated decode requires `--no-async-scheduling` on vLLM earlier than 0.26.0. Without it the KV-block zeroing kernel races the NIXL RDMA write and silently erases transferred KV. The flag costs about 7% throughput and can be dropped on a runtime shipping vLLM 0.26.0 or later.
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg disagg">
+
+- MTP on B200 NVFP4 aggregation is also not shipped. Output is *correct* in isolation — aggregated plus MTP stays coherent even on a forced Mamba prefix-cache hit, because the prefill-to-decode transfer garbage above cannot occur without disaggregation — but MTP plus prefix caching forces `mamba_cache_mode='align'`, whose conv-state copy path crashes under real concurrent long-context traffic ([vllm#38898](https://github.com/vllm-project/vllm/issues/38898) / PR [#40454](https://github.com/vllm-project/vllm/pull/40454); NVBug 6442165). Even with DS unset to sidestep that crash, MTP-heavy decode starves prefill on the shared GPU, with TTFT regressions, for no throughput win.
+
+</div>
+
+<div data-sku="b200" data-engine="vllm" data-usecase="agentic" data-variant="agg disagg">
+
+- Neither B200 profile ships MTP. Do **not** reintroduce a `rejection_sample_method: synthetic` block to "benchmark" it — a forced-acceptance sweep skips the conv-state copy path that crashes on real traffic, so it reports throughput for a configuration that cannot actually serve. Validate any spec-decode change against the real trace, not a synthetic sweep.
+
+</div>
+
+<div data-sku="b200 h200" data-engine="vllm" data-usecase="agentic" data-variant="disagg">
+
+- Disaggregated decode requires `--no-async-scheduling` on vLLM earlier than 0.26.0. Without it the KV-block zeroing kernel races the NIXL RDMA write and silently erases transferred KV — measured on the H200 FP8 recipe as IFEval 84.66 → 51.02 and GPQA-Diamond 83.84 → 19.19. Fixed upstream by [vllm#45357](https://github.com/vllm-project/vllm/pull/45357) and [vllm#48481](https://github.com/vllm-project/vllm/pull/48481); the flag costs about 7% throughput and can be dropped on a runtime shipping vLLM 0.26.0 or later.
 
 </div>
 


### PR DESCRIPTION
> **Stacked on #13661.** That PR establishes the four-row picker, the `data-needs-*` mechanism and the extended CSS vocabulary this skill validates against. On `main` today `kimi-k3`'s picker has only `GPU` and `Topology` rows and `data-needs-` does not exist in `RecipeStyles.tsx`, so the validator cannot pass until #13661 lands. **Please merge #13661 first.** Until then this PR shows both commits; afterwards it reduces to the skill alone.

## Summary

Publishing a recipe's Fern page is currently tribal knowledge, and its failure modes are quiet — nothing here breaks the build, it breaks for the reader who picks a particular combination:

- A `##` heading nested inside a `data-*` wrapper is invisible for every other selection.
- The global CSS hides any element with a non-matching `data-*`, `<tr>` included — so tagging a results row filters it out rather than dimming it, and a comparison table silently loses most of itself.
- A picker can offer a combination that ships no recipe, leaving the deploy step blank.
- A page built from the top-level README alone misses the trace-staging step that lives in `perf/README.md`, so its benchmark section does not work.

`fern-recipe-page` walks an engineer from the recipe's READMEs to a published page: read every README in the recipe directory (including `perf/`, `efa/` and the per-precision ones), write the catalog entry, mirror the README's own heading structure, assemble the GPU → Workload → Backend → Topology picker so it offers exactly the targets that ship, then wire up the landing card, counts and navigation.

`scripts/check_recipe_page.py` is the gate. It enumerates the picker's reachable combinations, confirms each renders content in every `##` **and** `###` section carrying `data-*` blocks, and confirms every catalog deploy asset is referenced on the page — matching the three ways pages point at a target (full path, recipe-relative, and a `RECIPE=` variable). It also checks MDX structure, that every picker and `data-*` value is actually implemented in `RecipeStyles.tsx` rather than silently filtering nothing, path resolution, and the landing card's position and counts.

`--pr` emits a checklist for the PR description; a non-zero exit gates review.

Two references carry the detail: `references/picker.md` (the picker contract, the CSS-coupled vocabulary, conditional options) and `references/page-anatomy.md` (what mirrors the README, what is Fern scaffolding, and the two opposite kinds of table).

## Validation

- `python3 scripts/validate_skills.py` — **validated 19 skills: OK** (frontmatter, kebab-case name matching the directory, `license: Apache-2.0`, `metadata.author` / `metadata.tags`, and the AGENTS.md index entry).
- `check_recipe_page.py --all` — **passes on all 18 current recipe pages, exit 0.**
- Failure paths exercised: a nonexistent slug, a page with an unimplemented `data-*` value, and a dead-end picker combination all fail with actionable detail and a non-zero exit.
- Description is 773 characters (limit 1024).

The validator's checks were derived from real defects found while reconciling these pages in #13661 — four `## Smoke Test` sections deleted because their curl commands live in manifests rather than README prose, four `## Benchmark` sections lost the same way, and headings left trapped inside `data-variant="kvbm"` so they only rendered for one selection.

Not run: NVSkills CI, which needs a maintainer to comment `/nvskills-ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added interactive selectors for GPU, workload, backend, and topology across recipe pages.
  - Added target-specific deployment, benchmarking, smoke-test, troubleshooting, and performance guidance.
  - Added a new Qwen3.8 recipe and expanded the catalog to 18 model families and 92 configurations.
  - Improved picker behavior with conditional options and clearer summary layouts.

- **Documentation**
  - Added guidance for creating and maintaining recipe pages.
  - Added validation checks for page structure, links, catalog coverage, navigation, and picker combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->