### PR TITLE
fix(common): stop the lazy __getattr__ hiding typos from mypy

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -15,6 +15,13 @@ Main submodules:
 
 from importlib import import_module
 from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Declared, not imported at runtime. Without these the `__getattr__` below
+    # is the only thing that resolves them, and hiding it from the type checker
+    # would make every one of these look missing.
+    from . import config_dump, constants, snapshot, utils
 
 try:
     from ._version import __version__
@@ -29,9 +36,15 @@ except Exception:
 __all__ = ["__version__", "config_dump", "constants", "snapshot", "utils"]
 
 
-def __getattr__(name: str) -> ModuleType:
-    if name in {"config_dump", "constants", "snapshot", "utils"}:
-        module = import_module(f"{__name__}.{name}")
-        globals()[name] = module
-        return module
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+# Hidden from the type checker on purpose. A module-level `__getattr__` tells
+# mypy this package may have any attribute, so `from dynamo.common import Typo`
+# would check clean in every module that imports from here. The block above
+# already declares the real submodules, so the checker loses nothing.
+if not TYPE_CHECKING:
+
+    def __getattr__(name: str) -> ModuleType:
+        if name in {"config_dump", "constants", "snapshot", "utils"}:
+            module = import_module(f"{__name__}.{name}")
+            globals()[name] = module
+            return module
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/components/src/dynamo/common/configuration/__init__.py
+++ b/components/src/dynamo/common/configuration/__init__.py
@@ -10,6 +10,15 @@ This module provides a modular, domain-driven configuration architecture where:
 - Unrecognized arguments are captured for backend engines (passthrough)
 """
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Declared, not imported at runtime, so the type checker still resolves the
+    # names `__getattr__` provides lazily below.
+    from .arg_group import ArgGroup
+    from .config_base import ConfigBase
+    from .utils import add_argument, add_negatable_bool_argument, env_or_default
+
 __all__ = [
     # Base classes
     "ArgGroup",
@@ -21,17 +30,20 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str):
-    if name == "ArgGroup":
-        from .arg_group import ArgGroup
+# Hidden from the type checker on purpose; see the note in dynamo/common/__init__.py.
+if not TYPE_CHECKING:
 
-        return ArgGroup
-    if name == "ConfigBase":
-        from .config_base import ConfigBase
+    def __getattr__(name: str):
+        if name == "ArgGroup":
+            from .arg_group import ArgGroup
 
-        return ConfigBase
-    if name in {"add_argument", "add_negatable_bool_argument", "env_or_default"}:
-        from . import utils
+            return ArgGroup
+        if name == "ConfigBase":
+            from .config_base import ConfigBase
 
-        return getattr(utils, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+            return ConfigBase
+        if name in {"add_argument", "add_negatable_bool_argument", "env_or_default"}:
+            from . import utils
+
+            return getattr(utils, name)
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

`dynamo/common/__init__.py` and `dynamo/common/configuration/__init__.py` both resolve their exports through a module-level `__getattr__`. mypy treats a module that defines `__getattr__` as possibly having *any* attribute, so a typo type-checks clean:

```python
from dynamo.common import config_dumps          # note the s
from dynamo.common.configuration import ArgGroups
```

The part that makes this worth fixing is that the widening is not local to these files. It applies in every module that imports from these packages, and `dynamo.common` is imported across the tree.

The fix is to declare the real exports under `TYPE_CHECKING` and put `__getattr__` behind `if not TYPE_CHECKING`. The checker then sees exactly the names each package provides; the runtime keeps resolving them lazily, unchanged.

This is the same correction @GuanLuo asked for on #13626, applied to the two other packages in `dynamo/common` that have the pattern. It is deliberately scoped to those two so it stays in one owner area.

**Three more packages have the same shape and are not touched here**, because they belong to other areas and I did not want to make this a four-area review. Measured the same way, all three currently accept an unknown name:

- `dynamo/sglang/request_handlers/__init__.py`
- `dynamo/planner/plugins/transport/__init__.py`
- `dynamo/vllm/envs.py`

`envs.py` is the interesting one: it already declares `DYN_FORWARDPASS_METRIC_PORT` under `TYPE_CHECKING`, so half the pattern is there and only the guard is missing. Happy to follow up on all three, together or separately, whichever suits the owners.

## Validation

Checked with a control, since "mypy reports no error" can mean the module was never really analysed. Modules with no `__getattr__` were confirmed to reject an unknown name first, so the probe is known to be capable of failing:

| module | before | after |
|---|---|---|
| `dynamo.common` | no error | `has no attribute "ZZZDoesNotExist"  [attr-defined]` |
| `dynamo.common.configuration` | no error | `has no attribute "ZZZDoesNotExist"  [attr-defined]` |
| `dynamo.common.multimodal` (control, no `__getattr__`) | error | error |
| `dynamo.planner.core.budget` (control, no `__getattr__`) | error | error |

Real names still resolve, and with precise types rather than `Any`:

```
reveal_type(ArgGroup)       -> def () -> dynamo.common.configuration.arg_group.ArgGroup
reveal_type(env_or_default) -> def [T] (env_var: str, default: T, value_type: ... | None =) -> T
reveal_type(utils)          -> types.ModuleType
```

Runtime behaviour is unchanged, verified rather than argued:

- After `import dynamo.common`, none of `config_dump`, `constants`, `snapshot`, `utils` is in `sys.modules`. Laziness is preserved.
- Touching `dynamo.common.utils` then loads it and caches it into module globals.
- `ArgGroup`, `ConfigBase` and `env_or_default` all resolve from `dynamo.common.configuration`.
- An unknown attribute still raises `AttributeError` at runtime on both packages.
- `__all__` is unchanged on both.

Test runs, with the same numbers on clean `main` with the change stashed, so the failures below are pre-existing and unrelated:

- `pytest components/src/dynamo/common/tests/` — 488 passed, 14 failed, 6 skipped, identical before and after. The 14 are `test_video_utils.py` codec tests.
- `pytest components/src/dynamo/planner/tests/unit` — 608 passed, 1 failed, 3 skipped, identical before and after, excluding three modules that fail to collect on any tree here for missing optional deps (`pmdarima` and friends).
- `mypy` clean on both changed files, `pre-commit run --files` passes with zero failing hooks.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved development-time type checking for lazily loaded configuration and utility components.
  * Preserved existing runtime behavior, including on-demand loading and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->