### PR TITLE
docs: clarify macOS dynamo-llm validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,10 @@ cargo test                  # Rust
 pytest -m unit tests/       # Python unit tests
 ```
 
+On macOS, run `dynamo-llm` checks and targeted tests with `--no-default-features` unless the
+target explicitly requires `block-manager`. The default feature enables Linux/CUDA-oriented NIXL,
+NUMA, and `O_DIRECT` code that is not a valid general-purpose macOS validation path.
+
 Markers are strict (`--strict-markers`); the full marker list lives in
 [`pyproject.toml`](pyproject.toml) `[tool.pytest.ini_options]`, including GPU gating
 (`gpu_0` … `gpu_8`). Read [`.ai/pytest-guidelines.md`](.ai/pytest-guidelines.md) and


### PR DESCRIPTION
## Summary

Document that macOS `dynamo-llm` checks and targeted tests should use `--no-default-features` unless they explicitly exercise the block manager. This avoids selecting Linux/CUDA-oriented NIXL, NUMA, and `O_DIRECT` code for general-purpose macOS validation.

## Validation

- `git diff --check`
- Repository pre-commit hooks, including codespell and agent-instruction validation

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added macOS testing guidance for running checks and targeted tests without default features.
  * Clarified when the `block-manager` feature should be explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->