### PR TITLE
feat(trtllm): publish worker prefill completion

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -255,6 +255,7 @@ class RequestHandlerConfig:
     conversation_affinity: bool = False
     # Select whether the engine or Dynamo owns initial DP-rank placement in affinity mode.
     conversation_affinity_dp_rank_source: str = "engine"
+    first_token_source: Optional[Any] = None
 
 
 class HandlerBase(BaseGenerativeHandler):
@@ -297,6 +298,7 @@ class HandlerBase(BaseGenerativeHandler):
         self.additional_metrics = config.additional_metrics
         self.max_seq_len = config.max_seq_len
         self.disagg_machine_id = config.disagg_machine_id
+        self.first_token_source = config.first_token_source
         # Sleep/wake state
         self._pause_lock = asyncio.Lock()
         self._inflight_lock = asyncio.Lock()
@@ -950,6 +952,9 @@ class HandlerBase(BaseGenerativeHandler):
         ep_disaggregated_params: Optional[DisaggregatedParams] = None,
     ) -> AsyncGenerator[dict, None]:
         """Track in-flight count, reject during sleep, then delegate to implementation."""
+        routing = request.get("routing") or {}
+        if self.first_token_source is not None:
+            self.first_token_source.bind(context, routing.get("dp_rank"))
         started = await self._mark_request_started()
         if not started:
             yield {
@@ -1078,6 +1083,7 @@ class HandlerBase(BaseGenerativeHandler):
         # choice and emit only the new slice for each Dynamo chunk.
         output_tokens_per_choice: dict[int, int] = {}
         prompt_logprobs_payload = None
+        first_output_seen = False
 
         sampling_params = self._override_sampling_params(
             self.default_sampling_params, request
@@ -1288,6 +1294,13 @@ class HandlerBase(BaseGenerativeHandler):
                             "token_ids": output.token_ids[tokens_so_far:],
                             "index": output_idx,
                         }
+                        if (
+                            self.first_token_source is not None
+                            and out["token_ids"]
+                            and not first_output_seen
+                        ):
+                            first_output_seen = True
+                            context.notify_first_token()
 
                         # Extract logprobs from the output. Logprobs are
                         # aligned with the cumulative token list, so use the

--- a/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
@@ -65,6 +65,7 @@ def _make_handler() -> _ConcreteHandler:
     handler._no_inflight_requests = asyncio.Event()
     handler._no_inflight_requests.set()
     handler._reject_new_requests = False
+    handler.first_token_source = None
     # Mock the pause controller that release/resume delegate to.
     # pause side_effect mirrors the real implementation;
     # tests don't need to manually update state after a release call.

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -863,6 +863,10 @@ async def init_llm_worker(
         else:
             needs = [needs_set] if needs_set else []
 
+        handler_config.first_token_source = await endpoint.first_token_source(
+            worker_type
+        )
+
         await register_model(
             model_input,
             model_type,


### PR DESCRIPTION
## Summary

- Add TRT-LLM worker-side first-token completion publication using the shared endpoint-scoped source introduced by #13655.
- Bind the source per request and notify once on the first substantive token output.
- Depend on #13655; when the source is unavailable, preserve the existing router response fallback.

## Validation

- `git diff --check`
- Relevant pre-commit formatting and static checks passed during the DCO-signed commit.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added first-token event tracking for locally generated requests.
  * Request handling now connects first-token notifications with the appropriate routing context.
  * Workers automatically configure first-token tracking for the selected endpoint type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->