### PR TITLE
fix(runtime): mark endpoint NotReady when a health-check stream stalls mid-response

### DIFF
--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -226,67 +226,86 @@ impl HealthCheckManager {
 
         // Spawn task to send health check and wait for response
         tokio::spawn(async move {
-            let result = tokio::time::timeout(timeout, async {
+            // Phase 1, bounded by `request_timeout`: send the canary and get
+            // its first item, which carries the provisional verdict.
+            let first = tokio::time::timeout(timeout, async {
                 let request = SingleIn::new(payload);
                 match engine.generate(request).await {
                     Ok(mut response_stream) => {
-                        // Get the first response to verify endpoint is alive.
-                        // Check for errors
-                        let is_healthy = if let Some(response) = response_stream.next().await {
-                            if let Some(error) = response.err() {
-                                warn!(
-                                    "Health check error response from {}: {:?}",
-                                    endpoint_subject_owned, error
-                                );
-                                false
-                            } else {
-                                debug!("Health check successful for {}", endpoint_subject_owned);
-                                true
-                            }
-                        } else {
-                            warn!(
-                                "Health check got no response from {}",
-                                endpoint_subject_owned
-                            );
-                            false
-                        };
-
-                        tokio::spawn(async move {
-                            // We need to consume the rest of the stream to avoid warnings on the frontend.
-                            response_stream.for_each(|_| async {}).await;
-                        });
-
-                        // Update health status based on response
-                        system_health.lock().set_endpoint_health_status(
-                            &endpoint_subject_owned,
-                            if is_healthy {
-                                HealthStatus::Ready
-                            } else {
-                                HealthStatus::NotReady
-                            },
-                        );
+                        let first_item = response_stream.next().await;
+                        Ok((first_item, response_stream))
                     }
-                    Err(e) => {
-                        error!(
-                            "Health check request failed for {}: {}",
-                            endpoint_subject_owned, e
-                        );
-                        system_health.lock().set_endpoint_health_status(
-                            &endpoint_subject_owned,
-                            HealthStatus::NotReady,
-                        );
-                    }
+                    Err(e) => Err(e),
                 }
             })
             .await;
 
-            // Handle timeout
-            if result.is_err() {
-                warn!("Health check timeout for {}", endpoint_subject_owned);
-                system_health
-                    .lock()
-                    .set_endpoint_health_status(&endpoint_subject_owned, HealthStatus::NotReady);
-            }
+            let (provisionally_healthy, response_stream) = match first {
+                Err(_) => {
+                    warn!("Health check timeout for {}", endpoint_subject_owned);
+                    (false, None)
+                }
+                Ok(Err(e)) => {
+                    error!(
+                        "Health check request failed for {}: {}",
+                        endpoint_subject_owned, e
+                    );
+                    (false, None)
+                }
+                Ok(Ok((first_item, response_stream))) => match first_item {
+                    Some(response) => {
+                        if let Some(error) = response.err() {
+                            warn!(
+                                "Health check error response from {}: {:?}",
+                                endpoint_subject_owned, error
+                            );
+                            (false, Some(response_stream))
+                        } else {
+                            debug!("Health check successful for {}", endpoint_subject_owned);
+                            (true, Some(response_stream))
+                        }
+                    }
+                    None => {
+                        warn!(
+                            "Health check got no response from {}",
+                            endpoint_subject_owned
+                        );
+                        (false, Some(response_stream))
+                    }
+                },
+            };
+
+            // Phase 2, bounded by a second `request_timeout` window: the
+            // canary must also finish streaming. A stream that stalls after
+            // its first chunk means the engine is wedged mid-response — a
+            // state a first-chunk-only verdict can never see. Draining
+            // inline (instead of in a detached task) also ensures this task
+            // cannot outlive the canary it belongs to.
+            let is_healthy = match response_stream {
+                Some(response_stream) => {
+                    let drained =
+                        tokio::time::timeout(timeout, response_stream.for_each(|_| async {}))
+                            .await
+                            .is_ok();
+                    if !drained {
+                        warn!(
+                            "Health check stream from {} stalled after its first chunk",
+                            endpoint_subject_owned
+                        );
+                    }
+                    provisionally_healthy && drained
+                }
+                None => provisionally_healthy,
+            };
+
+            system_health.lock().set_endpoint_health_status(
+                &endpoint_subject_owned,
+                if is_healthy {
+                    HealthStatus::Ready
+                } else {
+                    HealthStatus::NotReady
+                },
+            );
 
             debug!("Health check completed for {}", endpoint_subject_owned);
         });
@@ -694,6 +713,141 @@ mod push_handler_notify_tests {
             endpoint,
             HealthStatus::Ready,
             "successful chunks should set Ready despite trailing error",
+        );
+    }
+
+    // =================================================================
+    // Canary streams that stall mid-response (#13429)
+    // =================================================================
+
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    /// Increments its counter when dropped; carried inside canary streams so
+    /// tests can assert the health checker releases them instead of parking
+    /// them in a task forever.
+    struct StreamDropGuard(Arc<AtomicUsize>);
+    impl Drop for StreamDropGuard {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    /// Canary engine that streams one healthy chunk and then stalls forever
+    /// while `healed` is false; once `healed` is set, canary streams complete
+    /// normally.
+    struct StallingCanaryEngine {
+        healed: Arc<AtomicBool>,
+        canaries_issued: Arc<AtomicUsize>,
+        streams_dropped: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl AsyncEngine<SingleIn<TestRequest>, ManyOut<TestResponse>, anyhow::Error>
+        for StallingCanaryEngine
+    {
+        async fn generate(
+            &self,
+            input: SingleIn<TestRequest>,
+        ) -> anyhow::Result<ManyOut<TestResponse>> {
+            let (_data, ctx) = input.into_parts();
+            self.canaries_issued.fetch_add(1, Ordering::SeqCst);
+            let guard = StreamDropGuard(self.streams_dropped.clone());
+            let head = stream::iter(vec![Annotated::from_data(serde_json::json!({"token": 0}))]);
+            let tail: futures::stream::BoxStream<'static, TestResponse> =
+                if self.healed.load(Ordering::SeqCst) {
+                    Box::pin(stream::once(async move {
+                        let _guard = guard;
+                        Annotated::from_data(serde_json::json!({"token": 1}))
+                    }))
+                } else {
+                    Box::pin(stream::once(async move {
+                        let _guard = guard;
+                        std::future::pending::<()>().await;
+                        unreachable!()
+                    }))
+                };
+            Ok(ResponseStream::new(
+                Box::pin(head.chain(tail)),
+                ctx.context(),
+            ))
+        }
+    }
+
+    /// A canary whose stream stalls after a healthy first chunk must mark the
+    /// endpoint NotReady, and the stalled stream must be released rather than
+    /// parked in a detached drain task forever.
+    #[tokio::test]
+    async fn test_canary_stalled_after_first_chunk_sets_not_ready() {
+        let drt = create_test_drt_async().await;
+        let endpoint = "stalled_mid_stream";
+        let healed = Arc::new(AtomicBool::new(false));
+        let canaries_issued = Arc::new(AtomicUsize::new(0));
+        let streams_dropped = Arc::new(AtomicUsize::new(0));
+        let engine: LocalAsyncEngine = Arc::new(StallingCanaryEngine {
+            healed,
+            canaries_issued: canaries_issued.clone(),
+            streams_dropped: streams_dropped.clone(),
+        });
+        let _notifier = register_endpoint(&drt, endpoint, engine);
+        start_manager(&drt, 400).await;
+
+        // First canary fires after 400ms; its drain window (request_timeout,
+        // 1s) expires ~1.4s in. Allow slack for CI schedulers.
+        tokio::time::sleep(Duration::from_millis(3000)).await;
+
+        assert!(
+            canaries_issued.load(Ordering::SeqCst) >= 2,
+            "canaries should keep firing"
+        );
+        assert!(
+            streams_dropped.load(Ordering::SeqCst) >= 1,
+            "stalled canary streams must be released when the drain window \
+             expires, not parked forever"
+        );
+        assert_status(
+            &drt,
+            endpoint,
+            HealthStatus::NotReady,
+            "a canary stream that stalls after its first chunk means the \
+             engine is wedged mid-response",
+        );
+    }
+
+    /// An engine that recovers after a mid-stream stall must be promoted back
+    /// to Ready by a later completing canary — demotion is not sticky.
+    #[tokio::test]
+    async fn test_canary_recovery_after_stall_sets_ready_again() {
+        let drt = create_test_drt_async().await;
+        let endpoint = "stalled_then_healed";
+        let healed = Arc::new(AtomicBool::new(false));
+        let canaries_issued = Arc::new(AtomicUsize::new(0));
+        let streams_dropped = Arc::new(AtomicUsize::new(0));
+        let engine: LocalAsyncEngine = Arc::new(StallingCanaryEngine {
+            healed: healed.clone(),
+            canaries_issued: canaries_issued.clone(),
+            streams_dropped: streams_dropped.clone(),
+        });
+        let _notifier = register_endpoint(&drt, endpoint, engine);
+        start_manager(&drt, 400).await;
+
+        tokio::time::sleep(Duration::from_millis(3000)).await;
+        assert_status(
+            &drt,
+            endpoint,
+            HealthStatus::NotReady,
+            "wedged engine should be NotReady before recovery",
+        );
+
+        healed.store(true, Ordering::SeqCst);
+        // Verdicts from pre-recovery canaries land within one more drain
+        // window (~1.4s); completing canaries then land every 400ms.
+        tokio::time::sleep(Duration::from_millis(2600)).await;
+
+        assert_status(
+            &drt,
+            endpoint,
+            HealthStatus::Ready,
+            "a recovered engine must be promoted by the next completing canary",
         );
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **Rework in progress (2026-09-03).** The public head has a confirmed first-error timing bug and can overlap health-check canaries. A locally verified rewrite builds on #13436, but I am holding the branch while the overlapping foundation work in #13434 and #13436 remains open. This head is not ready to merge; see the latest status comment below.


Fixes #13429

## Summary

`HealthCheckManager::send_health_check_request` applied `request_timeout` only
to canary generation and the first stream item; the remaining stream was moved
into a detached drain task with no timeout and no handle. Two defects followed:

- **A worker frozen mid-response passes every health check forever.** The
  verdict came from the first chunk alone, so an engine that streams one chunk
  and then stalls was marked `Ready` on every canary tick. Its health surface
  stayed green, so nothing — not Kubernetes, not the router — ever got a
  signal to act. This is the same silent mid-stream-stall mode measured on
  #13095 (the "established stream freeze" arms of the churn matrix) surviving
  at the detection layer.
- **Each canary against a stalled stream leaked one drain task**, parked on
  `for_each` until process exit (14 leaked tasks in 3 s at a 200 ms canary
  interval when pinning the defect).

The fix keeps phase 1 exactly as today (generation + first item within
`request_timeout`, first-item error semantics unchanged) and adds a bounded
phase 2: the canary stream must also finish draining within one further
`request_timeout` window. The verdict is set once, after both phases, so a
mid-stream stall demotes the endpoint to `NotReady` and cannot be overwritten
by a later canary's first chunk. Draining inline also means the drain cannot
outlive its canary — the task leak is gone by construction.

Recovery needs no new machinery: canaries keep firing regardless of current
status, so a recovered engine is promoted by its next completing canary, and
real traffic still promotes via the existing activity notifier. A truly wedged
worker now fails its health probe, which is what lets the orchestrator replace
it.

Behavior note for reviewers: an engine whose canary legitimately needs more
than `request_timeout` (default 3 s) *after* its first chunk would previously
be marked Ready at the first chunk and is now marked NotReady. Health-check
payloads are worker-registered and designed to be minimal, so we believe the
bounded window is the intended semantics; deployments needing a longer window
can raise `request_timeout`, which is already configurable.

## Relationship to existing PRs (corrected 2026-08-22)

An earlier version of this section claimed no open PR addressed #13429; that
was wrong — #13436 (opened 2026-08-18) bounds the same detached drain and
cancels it on shutdown, while explicitly leaving the endpoint's health status
unchanged by the drain result. This PR additionally folds the drain outcome
into the health verdict, so a mid-stream stall demotes the endpoint to
NotReady (recovery regression-tested). See the correction comment below for
the full comparison and options for combining the two. #13095 and #13224
remain disjoint (routing layer).

## Validation

- `cargo test -p dynamo-runtime --lib --features integration health_check`
  — 13 passed (11 pre-existing + 2 new), 0 failed.
- Full crate, with local etcd v3.5.17 and NATS 2.10.24 (JetStream) up:
  `cargo test -p dynamo-runtime --lib --features integration`
  — **635 passed, 0 failed, 2 ignored**.
- **Fail-on-main:** with only the `send_health_check_request` body reverted to
  `main` (new tests kept), both new tests fail —
  `test_canary_stalled_after_first_chunk_sets_not_ready` (endpoint stays
  Ready; stalled streams never released) and
  `test_canary_recovery_after_stall_sets_ready_again` — while every
  pre-existing health-check test still passes, so the new tests pin this fix
  rather than passing incidentally.
- The new regression tests carry a drop-guard inside canary streams to assert
  stalled streams are released when the drain window expires (on `main` they
  are never released), plus a heal-switch engine to assert the
  NotReady → Ready recovery path.
- `cargo fmt --check` clean; `cargo clippy -p dynamo-runtime --lib
  --features integration --all-targets` — no warnings.

## AI assistance disclosure

This change was developed with AI assistance (Claude Code). I reviewed every
changed line, the failure analysis, and all test results myself. The
mid-stream-stall failure mode was verified against `main` with live pinning
tests before the fix was written.
