### PR TITLE
fix(vllm): stop the envs __getattr__ hiding typos from mypy

### DIFF
--- a/components/src/dynamo/vllm/envs.py
+++ b/components/src/dynamo/vllm/envs.py
@@ -65,13 +65,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
 }
 
 
-def __getattr__(name: str):
-    """
-    Gets environment variables lazily.
-    """
-    if name in environment_variables:
-        return environment_variables[name]()
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+# Hidden from the type checker on purpose. A module-level `__getattr__` tells
+# mypy this module may have any attribute, so `envs.DYN_TYPO` would check clean
+# in every module that imports it. The `TYPE_CHECKING` block above already
+# declares the real names, so the checker loses nothing by not seeing this.
+if not TYPE_CHECKING:
+
+    def __getattr__(name: str):
+        """
+        Gets environment variables lazily.
+        """
+        if name in environment_variables:
+            return environment_variables[name]()
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def __dir__():


### PR DESCRIPTION
## Summary

`dynamo/vllm/envs.py` resolves its environment-backed values through a module-level `__getattr__`. mypy treats a module that defines `__getattr__` as possibly having *any* attribute, so a typo checks clean:

```python
envs.DYN_FORWADPASS_METRIC_PORT     # note the missing R
```

and it checks clean in every module that imports `envs`, not just inside this file.

What makes this the clearest of these cases is that the module **already** declares `DYN_FORWARDPASS_METRIC_PORT: int` under `TYPE_CHECKING`. The intent to keep the name statically visible is already expressed in the file; only the guard was missing. Putting `__getattr__` behind `if not TYPE_CHECKING` makes the checker see exactly the declared name and nothing else.

This is the same correction @GuanLuo asked for on #13626, and the same one applied to the two `dynamo/common` packages in #13666. Kept to one file and one owner area on purpose rather than bundling the remaining packages together.

## Validation

Checked with a control, because "mypy reports no error" can also mean the module was never really analysed. The declared name is used as that control: it resolves to `int` both before and after, so the probe is known to be reading real type information.

| probe | before | after |
|---|---|---|
| `reveal_type(envs.DYN_FORWARDPASS_METRIC_PORT)` | `int` | `int` |
| `envs.DYN_TYPO_DOES_NOT_EXIST` | no error | `Module has no attribute "DYN_TYPO_DOES_NOT_EXIST"  [attr-defined]` |

Runtime behaviour is unchanged, exercised directly rather than argued:

- `envs.DYN_FORWARDPASS_METRIC_PORT` resolves to the default `20380`.
- Setting the variable to `20999` is honoured on the next access, so the lookup is still lazy rather than captured at import.
- Setting it to `99` still raises the range error (`port 99 is outside of the registered port range`), so `_resolve_port` validation is intact.
- An unknown attribute still raises `AttributeError: module 'dynamo.vllm.envs' has no attribute 'DYN_NOPE'`.
- `__dir__()` still returns `['DYN_FORWARDPASS_METRIC_PORT']` and `is_set` still works.

Test runs:

- `pytest components/src/dynamo/vllm/tests` is 113 passed, 7 errors, identical on clean `main` with the change stashed. The 7 are `test_state_agent.py` collection errors unrelated to this file.
- `test_vllm_unit.py` is the one test module that touches `envs`, and it cannot be collected here at all (`ModuleNotFoundError: No module named 'vllm'`), on this branch and on clean `main` alike. I did not want to claim coverage I do not have, so the runtime checks above were run directly against the module instead.
- `mypy` clean on the file, `pre-commit run --files` passes with zero failing hooks.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime handling of environment-based settings.
  * Preserved clear errors when an unavailable setting is requested.
  * Enhanced compatibility with static type checking without changing the public interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->