### PR TITLE
fix(planner): stop the transport __getattr__ hiding typos from mypy

### DIFF
--- a/components/src/dynamo/planner/plugins/transport/__init__.py
+++ b/components/src/dynamo/planner/plugins/transport/__init__.py
@@ -48,9 +48,16 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str) -> Any:
-    if name == "GrpcTransport":
-        from dynamo.planner.plugins.transport.grpc_remote import GrpcTransport
+# Hidden from the type checker on purpose. A module-level `__getattr__` tells
+# mypy this package may have any attribute, so a typo such as
+# `from ... transport import GrpcTranport` would check clean in every module
+# that imports from here. The `TYPE_CHECKING` block above already declares
+# `GrpcTransport`, so the checker loses nothing by not seeing this.
+if not TYPE_CHECKING:
 
-        return GrpcTransport
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    def __getattr__(name: str) -> Any:
+        if name == "GrpcTransport":
+            from dynamo.planner.plugins.transport.grpc_remote import GrpcTransport
+
+            return GrpcTransport
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

`dynamo/planner/plugins/transport/__init__.py` resolves `GrpcTransport` through a module-level `__getattr__`, deliberately, so that importing the package does not pull in `_grpc_base` → `_proto_bridge` → `plugin_pb2`, which is generated at install time and absent in a source tree before proto generation. The file says so in a comment.

The side effect is that mypy treats a module defining `__getattr__` as possibly having *any* attribute, so a realistic typo checks clean:

```python
from dynamo.planner.plugins.transport import GrpcTranport   # missing s
```

and it checks clean in every module importing from this package, not only inside this file.

The file already declares `GrpcTransport` under `TYPE_CHECKING`, so the intent to keep the name statically visible is already expressed here; only the guard was missing. Putting `__getattr__` behind `if not TYPE_CHECKING` makes the checker see exactly the declared names.

This is the same correction @GuanLuo asked for on #13626, previously applied to the two `dynamo/common` packages in #13666 and to `dynamo/vllm/envs.py` in #13680. One file and one owner area per PR on purpose.

## Validation

Used the real exports as a control, so a clean result means the probe was actually reading type information rather than an unanalysed module:

| probe | before | after |
|---|---|---|
| `reveal_type(GrpcTransport)` | full signature | unchanged, full signature |
| `reveal_type(InProcessTransport)` | full signature | unchanged, full signature |
| `from ... import GrpcTranport` | no error | `has no attribute "GrpcTranport"; maybe "GrpcTransport"?  [attr-defined]` |

mypy now suggests the correction, which is the practical benefit.

**The laziness this file exists to protect is intact**, checked directly rather than argued, since breaking it would be the real risk of this change:

- After `import dynamo.planner.plugins.transport`, `sys.modules` contains none of `grpc_remote`, `_proto_bridge` or `plugin_pb2`.
- `GrpcTransport` still resolves on first access.
- `InProcessTransport` and the five error types still import eagerly, `__all__` is unchanged at 8 names.
- An unknown attribute still raises `AttributeError: module 'dynamo.planner.plugins.transport' has no attribute 'GrpcTranport'`.

Test runs, identical on clean `main` with the change stashed:

- `pytest components/src/dynamo/planner/tests/unit` is 608 passed, 1 failed, 3 skipped. The failure is `test_load_based_scaling.py::test_updates_engine_capabilities` and is unrelated to this file.
- Three planner test modules cannot be collected on this machine at all, on this branch and on `main` alike, for missing optional deps (`pmdarima` and friends); they are excluded from the run above.
- `mypy` clean on the changed file, `pre-commit run --files` passes with zero failing hooks.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved runtime handling for transport module attributes.
  * Preserved existing lazy loading behavior and error handling for unsupported attributes.
  * No changes to the public API or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->