### PR TITLE
fix(sglang): give the lazily exported handlers real types

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/__init__.py
+++ b/components/src/dynamo/sglang/request_handlers/__init__.py
@@ -2,7 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from importlib import import_module
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    # Declared, not imported at runtime. These mirror `_EXPORTS` below; without
+    # them the module-level `__getattr__` is the only thing that resolves the
+    # handlers, and hiding it from the type checker would make them all look
+    # missing.
+    from .embedding import EmbeddingWorkerHandler
+    from .handler_base import BaseGenerativeHandler, BaseWorkerHandler
+    from .image_diffusion import ImageDiffusionWorkerHandler
+    from .llm import DecodeWorkerHandler, DiffusionWorkerHandler, PrefillWorkerHandler
+    from .multimodal import (
+        MultimodalEncodeWorkerHandler,
+        MultimodalPrefillWorkerHandler,
+        MultimodalWorkerHandler,
+    )
+    from .video_generation import VideoGenerationWorkerHandler
 
 _EXPORTS = {
     # Base handlers
@@ -25,14 +41,22 @@ _EXPORTS = {
 }
 
 
-def __getattr__(name: str) -> Any:
-    if name not in _EXPORTS:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+# Hidden from the type checker on purpose. A module-level `__getattr__` tells
+# mypy this package may have any attribute, so a typo such as
+# `from ... request_handlers import DecodeWorkerHandlr` would check clean in
+# every module that imports from here, and the real handlers resolve as `Any`.
+# The `TYPE_CHECKING` block above declares them, so the checker gains their
+# actual types and loses nothing.
+if not TYPE_CHECKING:
 
-    module = import_module(_EXPORTS[name], __name__)
-    value = getattr(module, name)
-    globals()[name] = value
-    return value
+    def __getattr__(name: str) -> Any:
+        if name not in _EXPORTS:
+            raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+        module = import_module(_EXPORTS[name], __name__)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

`dynamo/sglang/request_handlers/__init__.py` resolves its eleven handler classes through a module-level `__getattr__` so that importing the package does not pull in every backend submodule.

mypy treats a module defining `__getattr__` as possibly having *any* attribute, and here that costs two things rather than one:

- **Every handler resolves as `Any`** for all consumers, so nothing about their constructors or methods is checked at a call site.
- A typo checks clean, in every module importing from this package.

The first is the bigger loss and is what makes this worth more than typo detection. `DecodeWorkerHandler` is constructed in the sglang worker paths, and until now mypy had nothing to check those calls against.

Declaring the eleven names under `TYPE_CHECKING`, mirroring `_EXPORTS`, and putting `__getattr__` behind `if not TYPE_CHECKING` gives the checker the real classes back.

This completes the set. Same correction @GuanLuo asked for on #13626, already applied to the two `dynamo/common` packages (#13666), `dynamo/vllm/envs.py` (#13680) and `planner/plugins/transport` (#13681). One file and one owner area per PR on purpose; this is the last package in the repo with the pattern.

## Validation

| probe | before | after |
|---|---|---|
| `reveal_type(DecodeWorkerHandler)` | `Any` | `def (engine: Any, config: dynamo.sglang.args.Config, publisher: ... , shutdown_event: ..., enable_frontend_decoding: bool =, first_token_source: ...) -> ...DecodeWorkerHandler` |
| all eleven exported names | 11 resolve as `Any` | **0 resolve as `Any`** |
| `import DecodeWorkerHandlr` | no error | `has no attribute "DecodeWorkerHandlr"; maybe "DecodeWorkerHandler"?  [attr-defined]` |

The "0 remaining `Any`" line is the check that matters, and it doubles as the completeness proof that the `TYPE_CHECKING` block covers `_EXPORTS` exactly: any name I had missed would still have revealed as `Any`.

Runtime behaviour unchanged, verified directly:

- After `import dynamo.sglang.request_handlers`, `sys.modules` contains none of the handler submodules. Laziness is the reason this `__getattr__` exists, so this was the thing worth proving.
- `_EXPORTS` and `__all__` are untouched at eleven names each, and every `__all__` entry is still covered by `_EXPORTS`.
- An unknown attribute still raises `AttributeError: module 'dynamo.sglang.request_handlers' has no attribute 'DecodeWorkerHandlr'`.

`mypy` clean on the file. `pre-commit run --files` initially failed on `isort`, which reordered the new imports; re-run after applying that, it passes with zero failing hooks.

Not verified here: I have no SGLang installed, so actually constructing a handler raises `ModuleNotFoundError` on this machine, on this branch and on `main` alike. The type-level checks above were run against the declarations rather than by instantiating anything.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved static type checking for exported request handlers.
  * Preserved existing runtime lazy-loading behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->