### PR TITLE
ci: centralize model selection and speed vLLM startup

### DIFF
--- a/examples/backends/vllm/launch/agg_request_planes.sh
+++ b/examples/backends/vllm/launch/agg_request_planes.sh
@@ -8,8 +8,9 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
 source "$SCRIPT_DIR/../../../common/launch_utils.sh"
 
-# Parse command-line arguments for request plane mode
+# Parse command-line arguments for request plane mode and model
 REQUEST_PLANE="tcp"  # Default to TCP
+MODEL="Qwen/Qwen3-0.6B"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -21,10 +22,15 @@ while [[ $# -gt 0 ]]; do
             REQUEST_PLANE="nats"
             shift
             ;;
+        --model)
+            MODEL="$2"
+            shift 2
+            ;;
         -h|--help)
-            echo "Usage: $0 [--tcp|--nats]"
+            echo "Usage: $0 [--tcp|--nats] [--model MODEL]"
             echo "  --tcp   Use TCP request plane (default)"
             echo "  --nats  Use NATS request plane"
+            echo "  --model Model name or path (default: $MODEL)"
             exit 0
             ;;
         *)
@@ -34,8 +40,6 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
-
-MODEL="Qwen/Qwen3-0.6B"
 
 # ---- Tunable (override via env vars) ----
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,17 +12,25 @@ All tests run inside containers. See the [Container Development Guide](../contai
 
 ## CI model registry and selection
 
-All Hugging Face repositories referenced by files under `tests/` must have a
-`ModelSpec` in [`tests/utils/model_registry.py`](utils/model_registry.py). The
+All model dependencies declared with `@pytest.mark.model` anywhere in the root
+pytest collection must have a `ModelSpec` in
+[`tests/utils/model_registry.py`](utils/model_registry.py). Quoted Hugging Face
+repository IDs under `tests/` are also scanned, covering launch scripts and
+other assets that pytest does not collect. Strings used only as protocol or
+metadata fixtures do not need registry entries unless a test loads them. The
 registry records snapshot size, model kind, architecture characteristics,
 runtime support, parameter count, context length, license, and whether access
-is gated. A unit test rejects new unregistered model literals and models over
-the 20 GiB default snapshot cap unless they carry a documented exception.
+is gated. A unit test rejects unregistered dependencies and models over the
+20 GiB default snapshot cap unless they carry a documented exception.
 
 Prefer a role from `tests.utils.constants` when the test needs any compatible
 model. Keep an exact registry constant when the behavior is architecture- or
 checkpoint-specific (for example a Qwen reasoning parser, a LoRA adapter/base
 pair, MLA, or EAGLE speculative decoding).
+
+Set `DYN_CI_MODEL` to replace every generic smoke role in one CI invocation.
+A role-specific variable from the table below takes precedence. KV-transfer
+and architecture-specific coverage deliberately ignore the global override.
 
 | Role | Override | Compatibility constraint |
 |---|---|---|
@@ -51,6 +59,13 @@ To compare a compatible model in a role without editing tests:
 ```bash
 DYN_CI_VLLM_SMOKE_MODEL=ibm-granite/granite-4.0-h-350m \
   python3 -m pytest -m 'vllm and pre_merge' tests/
+```
+
+To compare one cross-backend candidate across all generic smoke coverage:
+
+```bash
+DYN_CI_MODEL=google/gemma-3-270m-it \
+  python3 -m pytest -m 'pre_merge and (vllm or sglang or trtllm)' tests/
 ```
 
 See [Fast vLLM startup in CI](VLLM_STARTUP.md) for measured H100 startup and

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,6 +10,52 @@ Dynamo has three areas of tests and checks:
 
 All tests run inside containers. See the [Container Development Guide](../container/README.md) for how to build and launch one.
 
+## CI model registry and selection
+
+All Hugging Face repositories referenced by files under `tests/` must have a
+`ModelSpec` in [`tests/utils/model_registry.py`](utils/model_registry.py). The
+registry records snapshot size, model kind, architecture characteristics,
+runtime support, parameter count, context length, license, and whether access
+is gated. A unit test rejects new unregistered model literals and models over
+the 20 GiB default snapshot cap unless they carry a documented exception.
+
+Prefer a role from `tests.utils.constants` when the test needs any compatible
+model. Keep an exact registry constant when the behavior is architecture- or
+checkpoint-specific (for example a Qwen reasoning parser, a LoRA adapter/base
+pair, MLA, or EAGLE speculative decoding).
+
+| Role | Override | Compatibility constraint |
+|---|---|---|
+| `CROSS_BACKEND_SMOKE_MODEL` (`QWEN` compatibility alias) | `DYN_CI_CROSS_BACKEND_SMOKE_MODEL` | Chat/instruct LLM supported by vLLM, SGLang, and TensorRT-LLM |
+| `VLLM_SMOKE_MODEL` | `DYN_CI_VLLM_SMOKE_MODEL` | Chat/instruct vLLM LLM, at most 700M parameters |
+| `SGLANG_SMOKE_MODEL` | `DYN_CI_SGLANG_SMOKE_MODEL` | Chat/instruct SGLang LLM, at most 700M parameters |
+| `TRTLLM_SMOKE_MODEL` | `DYN_CI_TRTLLM_SMOKE_MODEL` | Chat/instruct TensorRT-LLM LLM, at most 700M parameters |
+| `KV_TRANSFER_MODEL` | `DYN_CI_KV_TRANSFER_MODEL` | vLLM model with full attention (hybrid state-space models excluded) |
+
+Overrides are validated during collection, so an incompatible choice fails
+before acquiring a GPU. Gated models may satisfy a role, but the CI job remains
+responsible for accepting the model's license and providing download access.
+To find the smallest registered model with a set of characteristics:
+
+```bash
+python3 -m tests.utils.model_registry \
+  --kind llm \
+  --require instruction_tuned \
+  --require small_ci_candidate \
+  --backend vllm \
+  --max-parameters-millions 400
+```
+
+To compare a compatible model in a role without editing tests:
+
+```bash
+DYN_CI_VLLM_SMOKE_MODEL=ibm-granite/granite-4.0-h-350m \
+  python3 -m pytest -m 'vllm and pre_merge' tests/
+```
+
+See [Fast vLLM startup in CI](VLLM_STARTUP.md) for measured H100 startup and
+GPU-memory results, the recommended launch policy, and candidate tradeoffs.
+
 Each area can have one or more of the following types of tests:
 
 1. **Unit** -- Exercises a single function, class, or module in isolation. No external services, no GPU. Each test typically runs in milliseconds; all unit tests combined may take <5 minutes.

--- a/tests/VLLM_STARTUP.md
+++ b/tests/VLLM_STARTUP.md
@@ -43,7 +43,9 @@ container, model length 2,048, maximum 8 sequences, maximum 2,048 batched
 tokens, and a 512 MiB explicit KV cache. Time-to-ready is from process launch
 to the `HTTP server started` log. A four-to-eight-token chat request verified
 each candidate returned HTTP 200; this benchmark did not attempt to rank model
-quality.
+quality. These measurements use upstream `vllm serve` to isolate the engine
+and API server. Dynamo's removed scheduler/stagger delays are separate
+orchestration savings and are not included in the table.
 
 | Model/configuration | Cache state | Ready (s) | Engine init (s) | GPU memory (MiB) | First request (s) |
 |---|---:|---:|---:|---:|---:|

--- a/tests/VLLM_STARTUP.md
+++ b/tests/VLLM_STARTUP.md
@@ -1,0 +1,114 @@
+# Fast vLLM startup in CI
+
+This note separates model size, GPU memory, and startup latency. They are
+related, but they are not interchangeable: for small models, Python imports,
+model/tokenizer configuration, process creation, compilation, and kernel
+warmup dominate checkpoint loading.
+
+## CI policy
+
+1. Give every parallel vLLM test an explicit
+   `requested_vllm_kv_cache_bytes` marker. The launch helpers translate it to
+   `--kv-cache-memory-bytes`, which skips vLLM memory profiling and makes GPU
+   allocation deterministic.
+2. For correctness and plumbing tests, keep compilation disabled. Existing
+   launch scripts use `--enforce-eager`; vLLM 0.27.1 and newer can use
+   `--optimization-level 0`. Use the default optimization level only when the
+   test exercises compilation, CUDA graphs, or production-like performance.
+3. Do not stagger explicitly capped vLLM launches. They do not run the memory
+   profiler whose free-memory snapshot races with another process. The test
+   scheduler and `tests/serve/common.py` therefore allow capped launches to
+   start concurrently.
+4. If a test needs compilation, persist `VLLM_CACHE_ROOT` across identical
+   boots or bake a validated cache into the image. Consider
+   `VLLM_FORCE_AOT_LOAD=1` in the cache-validation job so a cache miss cannot
+   silently become a long compile.
+5. If an explicit KV size is impossible, enable `VLLM_ENABLE_STARTUP_PLAN=1`.
+   A later identical boot can reuse the recorded memory profile when its
+   hardware/config fingerprint and free-memory baseline match.
+6. Predownload models, then run with `HF_HUB_OFFLINE=1`. Dynamo's parallel GPU
+   runner already does this. On network filesystems, retain vLLM's automatic
+   safetensors prefetch or benchmark `--safetensors-load-strategy eager` when
+   enough host RAM is available.
+
+Do not globally use `--skip-tokenizer-init`: current Dynamo vLLM integration
+forces tokenizer initialization because vLLM sampling parameters require it.
+`--load-format dummy` is appropriate only for tests that intentionally do not
+validate model output.
+
+## H100 measurements
+
+Measured on one H100 80 GB with `vllm/vllm-openai:v0.27.1-ubuntu2404`, a warm
+container, model length 2,048, maximum 8 sequences, maximum 2,048 batched
+tokens, and a 512 MiB explicit KV cache. Time-to-ready is from process launch
+to the `HTTP server started` log. A four-to-eight-token chat request verified
+each candidate returned HTTP 200; this benchmark did not attempt to rank model
+quality.
+
+| Model/configuration | Cache state | Ready (s) | Engine init (s) | GPU memory (MiB) | First request (s) |
+|---|---:|---:|---:|---:|---:|
+| Qwen3-0.6B, `-O0`, offline | warm files | 35.7 | 2.07 | 2,586 | 0.151 |
+| Qwen3-0.6B, `--enforce-eager` | warm files | 40.1 | 2.26 | 2,586 | 0.085 |
+| Qwen3-0.6B, default `-O2` | cold compile | 79.3 | 41.25 | — | — |
+| Qwen3-0.6B, default `-O2` | warm AOT cache | 30.3 | 3.09 | — | — |
+| Gemma 3 270M IT, `-O0`, offline | first load | 46.8 | 3.25 | 1,924 | 0.115 |
+| Granite 4.0 H 350M, `-O0` | cold Mamba JIT | 103.1 | 61.91 | 2,036 | 0.922 |
+| Granite 4.0 H 350M, `-O0` | warm kernel cache | 28.0 | 2.06 | 2,036 | 0.164 |
+| LFM2.5 350M, `-O0` | first load | 48.0 | 7.82 | 2,102 | 0.452 |
+
+The default Qwen cold compile spent 34.13 seconds in `torch.compile`; the same
+AOT cache loaded in 0.28 seconds. Granite's first boot spent about 61 seconds
+warming Mamba2 Triton kernels, even at `-O0`, then reused that kernel cache on
+the next boot.
+
+## Model choice
+
+- **Best memory reduction with broad runtime coverage:** Gemma 3 270M IT used
+  about 662 MiB less GPU memory than Qwen in this setup. It is a well-known,
+  recent architecture and is registered for vLLM, SGLang, and TensorRT-LLM,
+  but every CI environment must accept the Gemma license and provide access.
+- **Best ungated, permissively licensed newer architecture:** Granite 4.0 H
+  350M is Apache-2.0 and used about 550 MiB less GPU memory. It is attractive
+  when the Mamba kernel cache persists, but a poor default for isolated cold
+  containers.
+- **Newest capability-oriented candidate:** LFM2.5 350M is newer, advertises
+  tool use, and used about 484 MiB less GPU memory. It is limited to the vLLM
+  and SGLang roles in the registry and uses the LFM 1.0 license.
+- **Keep Qwen3-0.6B for architecture-sensitive coverage:** KV transfer,
+  Qwen-specific parsing, Qwen LoRA, and cross-backend tests should remain
+  pinned until a candidate is validated for those exact behaviors.
+
+The measurements show that replacing Qwen can improve same-GPU packing by
+roughly 19–26%, but does not automatically reduce cold time-to-ready. The
+largest broadly applicable startup wins are explicit KV sizing, disabling or
+reusing compilation, and removing artificial launch staggering.
+
+## Reproducing a comparison
+
+Resolve a compatible candidate from the registry, override only the desired
+role, and run the same CI slice:
+
+```bash
+candidate=$(python3 -m tests.utils.model_registry \
+  --kind llm \
+  --require instruction_tuned \
+  --require small_ci_candidate \
+  --backend vllm \
+  --max-parameters-millions 400)
+
+DYN_CI_VLLM_SMOKE_MODEL="$candidate" python3 -m pytest tests/serve/test_vllm.py
+```
+
+Use the role override rather than a repository-wide replacement: the registry
+will reject a model that lacks the role's declared backend or architectural
+requirements.
+
+## Upstream references
+
+- [vLLM optimization levels and faster startup](https://docs.vllm.ai/en/latest/configuration/optimization/)
+- [vLLM environment variables and startup plans](https://docs.vllm.ai/en/latest/configuration/env_vars/)
+- [vLLM safetensors loading strategies](https://docs.vllm.ai/en/v0.27.1/api/vllm/config/load/)
+- [Gemma 3 270M IT model card](https://huggingface.co/google/gemma-3-270m-it)
+- [Granite 4.0 H 350M model card](https://huggingface.co/ibm-granite/granite-4.0-h-350m)
+- [LFM2.5 350M model card](https://huggingface.co/LiquidAI/LFM2.5-350M)
+- [TensorRT-LLM supported models](https://nvidia.github.io/TensorRT-LLM/latest/models/supported-models.html)

--- a/tests/basic/test_autodeploy_backend.py
+++ b/tests/basic/test_autodeploy_backend.py
@@ -11,6 +11,7 @@ import shutil
 import pytest
 import requests
 
+from tests.utils.constants import TRTLLM_SMOKE_MODEL
 from tests.utils.engine_process import FRONTEND_PORT
 from tests.utils.managed_process import DynamoFrontendProcess, ManagedProcess
 from tests.utils.payloads import check_models_api
@@ -18,7 +19,7 @@ from tests.utils.payloads import check_models_api
 logger = logging.getLogger(__name__)
 
 # Just need a model to show the config works rather than any stress of the system.
-MODEL_PATH = "Qwen/Qwen3-0.6B"
+MODEL_PATH = TRTLLM_SMOKE_MODEL
 SERVED_MODEL_NAME = MODEL_PATH
 
 PROMPT = "Takes skill to be real"
@@ -172,6 +173,7 @@ def send_completion_request(
 @pytest.mark.slow
 @pytest.mark.gpu_1
 @pytest.mark.nightly
+@pytest.mark.model(TRTLLM_SMOKE_MODEL)
 def test_smoke(request, runtime_services):
     """End-to-end test for TRTLLM worker with autodeploy backend in its most basic form."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,12 @@ from tests.utils.collection_env_guard import (
 )
 from tests.utils.constants import TEST_MODELS, DynamoPortRange
 from tests.utils.managed_process import ManagedProcess
+from tests.utils.model_registry import (
+    DEFAULT_CI_MODEL_SNAPSHOT_CAP_GIB,
+    downloadable_model_ids,
+    get_model_spec,
+    validate_ci_model_ids,
+)
 from tests.utils.port_utils import (
     ServicePorts,
     allocate_port,
@@ -446,6 +452,7 @@ def download_models(model_list=None, ignore_weights=False):
     """
     if model_list is None:
         model_list = TEST_MODELS
+    model_list = downloadable_model_ids(model_list)
 
     # Check for HF_TOKEN in environment. snapshot_download() picks it up
     # automatically via huggingface_hub's token resolution (HF_TOKEN env var →
@@ -468,6 +475,16 @@ def download_models(model_list=None, ignore_weights=False):
 
     failures = []
     for model_id in model_list:
+        spec = get_model_spec(model_id)
+        if spec.over_cap_exception:
+            logging.warning(
+                "CI model %s is a registered over-cap exception: "
+                "%.1f GiB > %.1f GiB. Reason: %s",
+                model_id,
+                spec.snapshot_size_gib,
+                DEFAULT_CI_MODEL_SNAPSHOT_CAP_GIB,
+                spec.exception_reason,
+            )
         logging.info(
             f"Pre-downloading {'model (no weights)' if ignore_weights else 'model'}: {model_id}"
         )
@@ -750,6 +767,16 @@ def pytest_collection_modifyitems(config, items):
         return
 
     # Collect models via explicit pytest mark from final filtered items only
+    models_to_download = _collect_models_to_download(items)
+
+    # Store models to download in pytest config for fixtures to access
+    if models_to_download:
+        config.models_to_download = models_to_download
+
+
+def _collect_models_to_download(items) -> set[str]:
+    """Collect and validate Hugging Face model ids from pytest model marks."""
+
     models_to_download = set()
     for item in items:
         # Only collect from items that are not skipped
@@ -760,10 +787,8 @@ def pytest_collection_modifyitems(config, items):
         for model_mark in item.iter_markers("model"):
             for repo_id in model_mark.args:
                 models_to_download.add(repo_id)
-
-    # Store models to download in pytest config for fixtures to access
-    if models_to_download:
-        config.models_to_download = models_to_download
+    validate_ci_model_ids(models_to_download)
+    return models_to_download
 
 
 class EtcdServer(ManagedProcess):

--- a/tests/deploy/conftest.py
+++ b/tests/deploy/conftest.py
@@ -16,6 +16,7 @@ import pytest
 
 from tests.deploy.dgd_utils import DeploymentSpec, _get_workspace_dir
 from tests.deploy.dgdr_utils import DGDRTestConfig, ManagedDGDR
+from tests.utils.constants import CROSS_BACKEND_SMOKE_MODEL
 
 
 # Shared CLI options (--image, --namespace, --skip-service-restart) are defined in tests/conftest.py.
@@ -69,7 +70,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
     parser.addoption(
         "--dgdr-model",
-        default="Qwen/Qwen3-0.6B",
+        default=CROSS_BACKEND_SMOKE_MODEL,
         help="Default model for DynamoGraphDeploymentRequest tests.",
     )
     parser.addoption(

--- a/tests/deploy/dgdr_utils.py
+++ b/tests/deploy/dgdr_utils.py
@@ -20,6 +20,8 @@ import yaml
 from kubernetes_asyncio import client, config
 from kubernetes_asyncio.client import exceptions
 
+from tests.utils.constants import CROSS_BACKEND_SMOKE_MODEL
+
 logger = logging.getLogger(__name__)
 
 DGDR_GROUP = "nvidia.com"
@@ -62,7 +64,7 @@ class DGDRTestConfig:
 
     namespace: str
     image: str
-    model: str = "Qwen/Qwen3-0.6B"
+    model: str = CROSS_BACKEND_SMOKE_MODEL
     backend: str = "vllm"
     mocker: bool = True
     profiling_timeout: int = 3600

--- a/tests/deploy/test_dgd.py
+++ b/tests/deploy/test_dgd.py
@@ -23,6 +23,7 @@ import yaml
 from tests.deploy.conftest import DeploymentTarget
 from tests.deploy.dgd_utils import DeploymentSpec, ManagedDeployment, _get_workspace_dir
 from tests.utils.client import send_request, wait_for_model_availability
+from tests.utils.constants import CROSS_BACKEND_SMOKE_MODEL
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ DEFAULT_REQUEST_TIMEOUT = 120
 # Minimum response content length to validate that the model is generating meaningful output.
 # This matches the validation threshold from the original shell-based deployment tests.
 MIN_RESPONSE_CONTENT_LENGTH = 100
-GAIE_MODEL_NAME = "Qwen/Qwen3-0.6B"
+GAIE_MODEL_NAME = CROSS_BACKEND_SMOKE_MODEL
 # The install script deploys the Gateway into agentgateway-system; the
 # controller provisions the proxy Service in that same namespace.
 GAIE_AGW_NAMESPACE = "agentgateway-system"

--- a/tests/deploy/test_dynamocheckpoint.py
+++ b/tests/deploy/test_dynamocheckpoint.py
@@ -18,6 +18,7 @@ from kubernetes_asyncio.client import exceptions as k8s_exceptions
 
 from tests.deploy.dgd_utils import DeploymentSpec, ManagedDeployment, _get_workspace_dir
 from tests.utils.client import send_request, wait_for_model_availability
+from tests.utils.constants import CROSS_BACKEND_SMOKE_MODEL
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +42,7 @@ CHECKPOINT_PLURAL = "dynamocheckpoints"
 
 FRONTEND_COMPONENT = "Frontend"
 TARGET_CONTAINER = "main"
-CHECKPOINT_MODEL = "Qwen/Qwen3-0.6B"
+CHECKPOINT_MODEL = CROSS_BACKEND_SMOKE_MODEL
 CHECKPOINT_STORAGE_MOUNT_PATH = "/checkpoints"
 TRTLLM_HF_HOME = f"{CHECKPOINT_STORAGE_MOUNT_PATH}/trtllm-hf-cache"
 

--- a/tests/fault_tolerance/deploy/scenarios.py
+++ b/tests/fault_tolerance/deploy/scenarios.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Pattern
 from typing_extensions import Required, TypedDict
 
 from tests.deploy.dgd_utils import DeploymentSpec, ManagedDeployment
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
 
 if TYPE_CHECKING:
     from tests.fault_tolerance.deploy.base_checker import BaseChecker
@@ -641,7 +642,7 @@ class TerminateProcessFailure(Failure):
             logger.info(f"Could not get model from {service_name}: {e}")
 
         # Fallback to default
-        model = "Qwen/Qwen3-0.6B"
+        model = FAULT_TOLERANCE_MODEL_NAME
         logger.info(f"Using default model: {model}")
         return model
 
@@ -1343,7 +1344,7 @@ def add_rolling_upgrade_scenarios():
             )
 
             scenario_name = f"{backend}-{worker_mode}-rolling-upgrade"
-            model = "Qwen/Qwen3-0.6B"
+            model = FAULT_TOLERANCE_MODEL_NAME
 
             failure = RollingUpgradeFailure(
                 time=30,

--- a/tests/fault_tolerance/deploy/test_deployment.py
+++ b/tests/fault_tolerance/deploy/test_deployment.py
@@ -26,6 +26,7 @@ from tests.fault_tolerance.deploy.scenarios import (
     Scenario,
     scenarios,
 )
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
 from tests.utils.test_output import resolve_test_output_path
 
 
@@ -83,8 +84,8 @@ def get_model_from_deployment(
             )
 
     # Fallback to default
-    logging.info("Using default model: Qwen/Qwen3-0.6B")
-    return "Qwen/Qwen3-0.6B"
+    logging.info("Using default model: %s", FAULT_TOLERANCE_MODEL_NAME)
+    return FAULT_TOLERANCE_MODEL_NAME
 
 
 @pytest.fixture

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -353,7 +353,7 @@ def _parse_migration_metric(
         The metric count, or 0 if not found
     """
     # Match pattern like:
-    # dynamo_frontend_model_migration_total{migration_type="ongoing_request",model="Qwen/Qwen3-0.6B"} 1
+    # dynamo_frontend_model_migration_total{migration_type="ongoing_request",model="<model-id>"} 1
     # Labels can be in any order
     pattern = rf'dynamo_frontend_model_migration_total\{{[^}}]*migration_type="{migration_type}"[^}}]*model="{re.escape(model_name)}"[^}}]*\}}\s+(\d+)'
     match = re.search(pattern, metrics_text)

--- a/tests/fault_tolerance/test_canary_rank_pause.py
+++ b/tests/fault_tolerance/test_canary_rank_pause.py
@@ -25,6 +25,7 @@ import requests
 from tests.serve.test_sglang import sglang_configs
 from tests.serve.test_trtllm import trtllm_configs
 from tests.serve.test_vllm import vllm_configs
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
 from tests.utils.engine_process import EngineProcess
 
 logger = logging.getLogger(__name__)
@@ -147,7 +148,7 @@ def _wait_for_status(url: str, target: int, deadline_s: float) -> int:
 @pytest.mark.nightly
 @pytest.mark.gpu_1
 @pytest.mark.timeout(300)
-@pytest.mark.model("Qwen/Qwen3-0.6B")
+@pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
 @pytest.mark.parametrize("scenario", SCENARIOS)
 @pytest.mark.parametrize("num_system_ports", [2], indirect=True)
 def test_canary_detects_rank_pause(

--- a/tests/fault_tolerance/test_unified_canary.py
+++ b/tests/fault_tolerance/test_unified_canary.py
@@ -14,11 +14,12 @@ import pytest
 import requests
 
 from dynamo.common.utils.paths import WORKSPACE_DIR
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
 from tests.utils.engine_process import EngineConfig, EngineProcess
 
 CANARY_READY_BUDGET_S = 60
 SAMPLE_DIR = os.path.join(WORKSPACE_DIR, "examples/backends/sample")
-MODEL = "Qwen/Qwen3-0.6B"
+MODEL = FAULT_TOLERANCE_MODEL_NAME
 
 pytestmark = [
     pytest.mark.fault_tolerance,

--- a/tests/frontend/test_prepost.py
+++ b/tests/frontend/test_prepost.py
@@ -10,6 +10,8 @@ import json
 
 import pytest
 
+from tests.utils.model_registry import QWEN_QWEN3_0_6B
+
 from .common import check_module_available
 
 HAS_VLLM = check_module_available("vllm.entrypoints.openai.chat_completion.protocol")
@@ -1304,7 +1306,7 @@ def request_for_sampling():
                 "role": "user",
             }
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         tools=[
             ChatCompletionToolsParam(
                 type="function",

--- a/tests/frontend/test_prompt_embeds.py
+++ b/tests/frontend/test_prompt_embeds.py
@@ -33,13 +33,14 @@ from openai import BadRequestError, OpenAI
 
 from tests.utils.device import detect_target_device
 from tests.utils.managed_process import DynamoFrontendProcess, ManagedProcess
+from tests.utils.model_registry import QWEN_QWEN3_0_6B
 from tests.utils.payloads import check_models_api
 from tests.utils.port_utils import ServicePorts
 
 logger = logging.getLogger(__name__)
 
 # Test model - small and fast for CI
-TEST_MODEL = "Qwen/Qwen3-0.6B"
+TEST_MODEL = QWEN_QWEN3_0_6B
 
 pytestmark = [
     pytest.mark.integration,

--- a/tests/frontend/test_tool_calling_sglang.py
+++ b/tests/frontend/test_tool_calling_sglang.py
@@ -30,6 +30,7 @@ import pytest
 from tests.conftest import EtcdServer, NatsServer
 from tests.utils.gpu_args import build_gpu_mem_args
 from tests.utils.managed_process import ManagedProcess
+from tests.utils.model_registry import QWEN_QWEN3_0_6B
 from tests.utils.payloads import check_models_api
 from tests.utils.port_utils import allocate_ports
 
@@ -40,7 +41,7 @@ Draft7Validator = jsonschema.Draft7Validator
 
 logger = logging.getLogger(__name__)
 
-MODEL_NAME = "Qwen/Qwen3-0.6B"
+MODEL_NAME = QWEN_QWEN3_0_6B
 
 pytestmark = [
     pytest.mark.sglang,

--- a/tests/kvbm_integration/common.py
+++ b/tests/kvbm_integration/common.py
@@ -521,7 +521,7 @@ def llm_server_kvbm(request, runtime_services_dynamic_ports):
 
     Usage in test files:
         @pytest.mark.parametrize("llm_server_kvbm",
-            [{"cpu_blocks": 100, "gpu_blocks": 10, "model": "Qwen/Qwen3-0.6B"}], indirect=True)
+            [{"cpu_blocks": 100, "gpu_blocks": 10, "model": KV_TRANSFER_MODEL}], indirect=True)
         def test_example(llm_server_kvbm):
             ...
     """

--- a/tests/kvbm_integration/test_chunked_prefill.py
+++ b/tests/kvbm_integration/test_chunked_prefill.py
@@ -14,11 +14,13 @@ import math
 
 import pytest
 
+from tests.utils.constants import KV_TRANSFER_MODEL
+
 from .common import llm_server_kvbm  # noqa: F401
 from .common import DeterminismTester, fetch_kvbm_metrics
 
 # Test configuration
-KVBM_TEST_MODEL = "Qwen/Qwen3-0.6B"
+KVBM_TEST_MODEL = KV_TRANSFER_MODEL
 BLOCK_SIZE = 16  # Standard vLLM block size in tokens
 MAX_NUM_BATCHED_TOKENS = 256  # Small value to force chunking
 MAX_TOKENS = 1  # Max tokens to generate in test responses

--- a/tests/kvbm_integration/test_consolidator_router_e2e.py
+++ b/tests/kvbm_integration/test_consolidator_router_e2e.py
@@ -24,6 +24,7 @@ import requests
 import yaml
 
 from tests.kvbm_integration.common import ApiTester, check_logs_for_patterns
+from tests.utils.constants import KV_TRANSFER_MODEL
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.test_output import resolve_test_output_path
 
@@ -340,7 +341,7 @@ def engine_type(request):
 @pytest.fixture
 def llm_worker(frontend_server, test_directory, runtime_services, engine_type):
     """Start LLM worker (vLLM or TensorRT-LLM) with KVBM connector and KV Event Consolidator."""
-    model_id = os.environ.get("CONSOLIDATOR_MODEL_ID", "Qwen/Qwen3-0.6B")
+    model_id = os.environ.get("CONSOLIDATOR_MODEL_ID", KV_TRANSFER_MODEL)
     engine = engine_type
 
     logger.info(
@@ -770,7 +771,7 @@ class TestConsolidatorRouterE2E:
             logger.info(f"Frontend started on port {FRONTEND_PORT}")
 
             # Start worker with constrained GPU blocks but larger KVBM blocks
-            model_id = os.environ.get("CONSOLIDATOR_MODEL_ID", "Qwen/Qwen3-0.6B")
+            model_id = os.environ.get("CONSOLIDATOR_MODEL_ID", KV_TRANSFER_MODEL)
 
             # Fixed cache tier sizes
             block_size = 16

--- a/tests/kvbm_integration/test_kvbm.py
+++ b/tests/kvbm_integration/test_kvbm.py
@@ -14,6 +14,8 @@ These tests validate core KVBM functionality:
 import pytest
 import requests
 
+from tests.utils.constants import KV_TRANSFER_MODEL
+
 from .common import llm_server_kvbm  # noqa: F401
 from .common import DeterminismTester, assert_deterministic, fetch_kvbm_metrics
 
@@ -98,7 +100,7 @@ def reset_cache(base_url: str) -> None:
 
 
 # Model used for test_kvbm tests (smaller model for faster CI)
-KVBM_TEST_MODEL = "Qwen/Qwen3-0.6B"
+KVBM_TEST_MODEL = KV_TRANSFER_MODEL
 
 
 # Fixtures

--- a/tests/router/counter_worker.py
+++ b/tests/router/counter_worker.py
@@ -29,11 +29,12 @@ from dynamo.common.configuration.groups.router_args import (
     RouterConfigBase,
 )
 from dynamo.common.configuration.utils import add_argument
+from tests.utils.constants import CROSS_BACKEND_SMOKE_MODEL
 
 request_count = 0
 
 # Register needs a model path, so we use a HF model name here.
-HF_MODEL_NAME = "Qwen/Qwen3-0.6B"
+HF_MODEL_NAME = CROSS_BACKEND_SMOKE_MODEL
 
 _ROUTER_MODE_MAP = {
     "round-robin": "RoundRobin",

--- a/tests/serve/common.py
+++ b/tests/serve/common.py
@@ -177,10 +177,17 @@ def _prepare_deployment(
                 str(gib_to_bytes),
             )
 
-    # Stagger engine startup under xdist to avoid vLLM profiling race
-    # (vLLM bug #10643: concurrent profilers miscount each other's memory).
+    # Stagger only uncapped vLLM launches under plain xdist. An explicit
+    # --kv-cache-memory-bytes value skips vLLM's memory profiler, so delaying
+    # those launches only serializes otherwise parallel-safe CI work. The
+    # dedicated GPU scheduler already supplies a cap to every GPU test.
     worker_id = os.environ.get("PYTEST_XDIST_WORKER", "")
-    if worker_id.startswith("gw"):
+    is_vllm = request.node.get_closest_marker("vllm") is not None
+    has_vllm_kv_cap = (
+        "_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES" in merged_env
+        or "_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES" in os.environ
+    )
+    if is_vllm and not has_vllm_kv_cap and worker_id.startswith("gw"):
         worker_num = int(worker_id.removeprefix("gw"))
         if worker_num > 0:
             stagger_s = worker_num * 15

--- a/tests/serve/launch/template_verifier.py
+++ b/tests/serve/launch/template_verifier.py
@@ -11,6 +11,7 @@ from transformers import AutoTokenizer
 from dynamo.common.utils.paths import WORKSPACE_DIR
 from dynamo.llm import ModelInput, ModelType, WorkerType, register_model
 from dynamo.runtime import DistributedRuntime, dynamo_worker
+from tests.utils.constants import CROSS_BACKEND_SMOKE_MODEL
 
 SERVE_TEST_DIR = os.path.join(WORKSPACE_DIR, "tests/serve")
 
@@ -18,7 +19,7 @@ SERVE_TEST_DIR = os.path.join(WORKSPACE_DIR, "tests/serve")
 class TemplateVerificationHandler:
     """Handler to verify custom template application during preprocessing."""
 
-    def __init__(self, model_name="Qwen/Qwen3-0.6B"):
+    def __init__(self, model_name=CROSS_BACKEND_SMOKE_MODEL):
         self.tokenizer = AutoTokenizer.from_pretrained(model_name)
         self.template_marker = "CUSTOM_TEMPLATE_ACTIVE|"
 
@@ -52,7 +53,7 @@ async def main(runtime: DistributedRuntime):
         sys.exit(1)
 
     # Register model with custom template
-    model_name = "Qwen/Qwen3-0.6B"
+    model_name = CROSS_BACKEND_SMOKE_MODEL
     await register_model(
         ModelInput.Tokens,
         ModelType.Chat,

--- a/tests/serve/test_sample.py
+++ b/tests/serve/test_sample.py
@@ -12,7 +12,7 @@ from tests.serve.common import (
     params_with_model_mark,
     run_serve_deployment,
 )
-from tests.utils.constants import DefaultPort
+from tests.utils.constants import VLLM_SMOKE_MODEL, DefaultPort
 from tests.utils.engine_process import EngineConfig
 from tests.utils.payload_builder import (
     chat_payload_default,
@@ -29,7 +29,7 @@ sample_configs = {
         name="aggregated",
         directory=sample_dir,
         script_name="agg.sh",
-        script_args=["--model-name", "Qwen/Qwen3-0.6B"],
+        script_args=["--model-name", VLLM_SMOKE_MODEL],
         marks=[
             pytest.mark.gpu_0,
             # CPU-mode vLLM startup for this deployment runs ~237s; the old
@@ -43,7 +43,7 @@ sample_configs = {
             pytest.mark.unified,
             pytest.mark.vllm,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=VLLM_SMOKE_MODEL,
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
             chat_payload_default(),

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -30,8 +30,14 @@ from tests.serve.multimodal_profiles.sglang import (
     SGLANG_MULTIMODAL_PROFILES,
     SGLANG_TOPOLOGY_SCRIPTS,
 )
-from tests.utils.constants import DefaultPort, DynamoPortRange
+from tests.utils.constants import (
+    CROSS_BACKEND_SMOKE_MODEL,
+    SGLANG_SMOKE_MODEL,
+    DefaultPort,
+    DynamoPortRange,
+)
 from tests.utils.engine_process import EngineConfig
+from tests.utils.model_registry import QWEN_QWEN3_0_6B
 from tests.utils.multimodal import make_image_payload_b64, make_multimodal_configs
 from tests.utils.payload_builder import (
     anthropic_messages_payload_default,
@@ -133,7 +139,8 @@ sglang_configs = {
             pytest.mark.timeout(360),  # 3x ~119s (sglang gpu_1 log)
             pytest.mark.pre_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=SGLANG_SMOKE_MODEL,
+        script_args=["--model-path", SGLANG_SMOKE_MODEL],
         env={},
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
@@ -162,7 +169,7 @@ sglang_configs = {
             pytest.mark.gpu_2,
             pytest.mark.pre_merge,
         ],  # TODO(gpu_2): profile max_vram, timeout, add markers (separate PR)
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         env={},
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
@@ -221,7 +228,7 @@ sglang_configs = {
             pytest.mark.timeout(470),  # parity with sglang disaggregated configs
             pytest.mark.nightly,  # heavy e2e launch scenario; runs on nightly multi-gpu lane
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         env={},
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
@@ -257,7 +264,7 @@ sglang_configs = {
             pytest.mark.timeout(470),  # 3x ~155s (sglang gpu_1 log)
             pytest.mark.pre_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         delayed_start=10,
         health_check_workers=True,
         env={},
@@ -294,7 +301,7 @@ sglang_configs = {
             pytest.mark.timeout(470),  # 3x ~156s (sglang gpu_1 log)
             pytest.mark.post_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         delayed_start=10,
         health_check_workers=True,
         env={"DYN_CHAT_PROCESSOR": "sglang"},
@@ -317,7 +324,7 @@ sglang_configs = {
             pytest.mark.timeout(470),  # 3x ~151s (sglang gpu_1 log)
             pytest.mark.post_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         delayed_start=10,
         health_check_workers=True,
         env={
@@ -341,7 +348,7 @@ sglang_configs = {
             pytest.mark.gpu_2,
             pytest.mark.pre_merge,
         ],  # TODO(gpu_2): profile max_vram, timeout, add markers (separate PR)
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         env={},
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
@@ -367,7 +374,7 @@ sglang_configs = {
             pytest.mark.pre_merge,
             pytest.mark.nightly,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=CROSS_BACKEND_SMOKE_MODEL,
         env={},
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
@@ -1028,7 +1035,8 @@ sglang_configs = {
             pytest.mark.skip(reason="DYN-2261"),
             # TODO: profile once DYN-2261 is fixed (uses agg.sh, profiler works)
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=SGLANG_SMOKE_MODEL,
+        script_args=["--model-path", SGLANG_SMOKE_MODEL],
         env={"DYN_ENABLE_ANTHROPIC_API": "1"},
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
@@ -1140,7 +1148,7 @@ def lora_chat_payload(
 @pytest.mark.core
 @pytest.mark.e2e
 @pytest.mark.gpu_1
-@pytest.mark.model("Qwen/Qwen3-0.6B")
+@pytest.mark.model(QWEN_QWEN3_0_6B)
 @pytest.mark.model(DEFAULT_LORA_REPO)
 @pytest.mark.profiled_vram_gib(4.7)
 @pytest.mark.requested_sglang_kv_tokens(2848)
@@ -1176,7 +1184,7 @@ def test_sglang_lora_aggregated(
         directory=sglang_dir,
         script_name="lora/agg_lora.sh",
         marks=[],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         timeout=158,
         env=minio_config.get_env_vars(),
         request_payloads=[lora_payload],

--- a/tests/serve/test_token_budget_parity.py
+++ b/tests/serve/test_token_budget_parity.py
@@ -15,13 +15,13 @@ import requests
 import yaml
 
 from tests.serve.common import WORKSPACE_DIR, managed_serve_deployment
-from tests.utils.constants import DynamoPortRange
+from tests.utils.constants import CROSS_BACKEND_SMOKE_MODEL, DynamoPortRange
 from tests.utils.engine_process import EngineConfig
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port
 
-MODEL = "Qwen/Qwen3-0.6B"
+MODEL = CROSS_BACKEND_SMOKE_MODEL
 CONTEXT_LIMIT = 128
 
 

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -21,8 +21,9 @@ from tests.serve.conftest import (
     MULTIMODAL_VIDEO_H264_URL,
     MULTIMODAL_VIDEO_H265_URL,
 )
-from tests.utils.constants import DefaultPort
+from tests.utils.constants import TRTLLM_SMOKE_MODEL, DefaultPort
 from tests.utils.engine_process import EngineConfig
+from tests.utils.model_registry import QWEN_QWEN3_0_6B
 from tests.utils.multimodal import make_image_payload_cached_tokens
 from tests.utils.payload_builder import (
     TEXT_PROMPT,
@@ -88,12 +89,16 @@ trtllm_configs = {
                 650
             ),  # 3x measured time (44.66s) + download time (150s)
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=TRTLLM_SMOKE_MODEL,
         frontend_port=DefaultPort.FRONTEND.value,
         delayed_start=5,
         # TRT-LLM blocks greedy n>1 by default. Keep the request OpenAI-shaped
         # with only "n", and enable TRT-LLM's backend guard for this E2E.
-        env={"TLLM_ALLOW_N_GREEDY_DECODING": "1"},
+        env={
+            "MODEL_PATH": TRTLLM_SMOKE_MODEL,
+            "SERVED_MODEL_NAME": TRTLLM_SMOKE_MODEL,
+            "TLLM_ALLOW_N_GREEDY_DECODING": "1",
+        },
         request_payloads=[
             chat_payload_default(),
             chat_payload(
@@ -118,7 +123,7 @@ trtllm_configs = {
             pytest.mark.trtllm,
             pytest.mark.pre_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
             chat_payload_default(),
@@ -143,7 +148,7 @@ trtllm_configs = {
             ),  # KV cache cap (2x safety over min=256)
             pytest.mark.timeout(432),  # ~6x profiled wall time 72s
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         frontend_port=DefaultPort.FRONTEND.value,
         delayed_start=10,
         health_check_workers=True,
@@ -173,7 +178,11 @@ trtllm_configs = {
             ),  # KV cache cap (2x safety over min=1296)
             pytest.mark.timeout(440),  # 3x ~145s (trtllm gpu_1 log)
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=TRTLLM_SMOKE_MODEL,
+        env={
+            "MODEL_PATH": TRTLLM_SMOKE_MODEL,
+            "SERVED_MODEL_NAME": TRTLLM_SMOKE_MODEL,
+        },
         frontend_port=DefaultPort.FRONTEND.value,
         delayed_start=5,
         request_payloads=[
@@ -193,7 +202,7 @@ trtllm_configs = {
             pytest.mark.pre_merge,
             pytest.mark.trtllm,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
             chat_payload(content=TEXT_PROMPT, logprobs=True, top_logprobs=5),
@@ -217,7 +226,7 @@ trtllm_configs = {
                 360
             ),  # 3x measured time (37.91s) + download time (180s)
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
             router_selection_chat_payload_default(
@@ -250,7 +259,7 @@ trtllm_configs = {
             ),  # KV cache cap (2x safety over min=1296)
             pytest.mark.timeout(300),
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[chat_payload_default()],
     ),
@@ -264,7 +273,7 @@ trtllm_configs = {
             pytest.mark.trtllm,
             pytest.mark.nightly,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
             chat_payload_default(),
@@ -778,6 +787,7 @@ def test_qwen3_vl_multimodal_engine_configs_set_torch_dtype(config_file):
 @pytest.mark.profiled_vram_gib(3.9)
 @pytest.mark.requested_trtllm_kv_tokens(2592)
 @pytest.mark.timeout(660)  # 3x measured time (159.68s) + download time (180s)
+@pytest.mark.model(TRTLLM_SMOKE_MODEL)
 def test_chat_only_aggregated_with_test_logits_processor(
     request,
     runtime_services_dynamic_ports,
@@ -786,8 +796,8 @@ def test_chat_only_aggregated_with_test_logits_processor(
     monkeypatch,
 ):
     """
-    Run a single aggregated chat-completions test using Qwen 0.6B with the
-    test logits processor enabled, and expect "Hello world" in the response.
+    Run a single aggregated chat-completions test with the test logits
+    processor enabled, and expect "Hello world" in the response.
     """
 
     # Enable HelloWorld logits processor only for this test
@@ -795,14 +805,14 @@ def test_chat_only_aggregated_with_test_logits_processor(
 
     base = trtllm_configs["aggregated"]
     config = TRTLLMConfig(
-        name="aggregated_qwen_chatonly",
+        name="aggregated_smoke_chatonly",
         directory=base.directory,
-        script_name=base.script_name,  # agg.sh
+        script_name=base.script_name,
         marks=[],  # not used by this direct test
         request_payloads=[
             chat_payload_default(expected_response=["Hello world!"]),
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=TRTLLM_SMOKE_MODEL,
         delayed_start=base.delayed_start,
         timeout=base.timeout,
     )
@@ -828,6 +838,7 @@ def test_chat_only_aggregated_with_test_logits_processor(
 @pytest.mark.requested_trtllm_kv_tokens(2592)
 @pytest.mark.timeout(300)
 @pytest.mark.parametrize("num_system_ports", [1], indirect=True)
+@pytest.mark.model(TRTLLM_SMOKE_MODEL)
 def test_aggregated_health_check_priority(
     request,
     runtime_services_dynamic_ports,
@@ -851,7 +862,7 @@ def test_aggregated_health_check_priority(
         directory=base.directory,
         script_name=base.script_name,
         marks=[],
-        model="Qwen/Qwen3-0.6B",
+        model=TRTLLM_SMOKE_MODEL,
         frontend_port=dynamo_dynamic_ports.frontend_port,
         delayed_start=base.delayed_start,
         timeout=base.timeout,
@@ -861,8 +872,8 @@ def test_aggregated_health_check_priority(
         env={
             "DYN_HEALTH_CHECK_ENABLED": "true",
             "DYN_CANARY_WAIT_TIME": "2",
-            "MODEL_PATH": "Qwen/Qwen3-0.6B",
-            "SERVED_MODEL_NAME": "Qwen/Qwen3-0.6B",
+            "MODEL_PATH": TRTLLM_SMOKE_MODEL,
+            "SERVED_MODEL_NAME": TRTLLM_SMOKE_MODEL,
         },
         request_payloads=[
             chat_payload_default(),

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -22,8 +22,9 @@ from tests.serve.multimodal_profiles.vllm import (
     VLLM_MULTIMODAL_PROFILES,
     VLLM_TOPOLOGY_SCRIPTS,
 )
-from tests.utils.constants import DefaultPort
+from tests.utils.constants import VLLM_SMOKE_MODEL, DefaultPort
 from tests.utils.engine_process import EngineConfig
+from tests.utils.model_registry import QWEN_QWEN3_0_6B
 from tests.utils.multimodal import make_multimodal_configs
 from tests.utils.payload_builder import (
     chat_payload,
@@ -121,7 +122,7 @@ vllm_configs = {
             pytest.mark.timeout(610),  # 3x ~203s under new scheduler (3d1554f)
             pytest.mark.pre_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         request_payloads=[
             chat_payload_default(),
             chat_payload(
@@ -208,7 +209,8 @@ vllm_configs = {
             pytest.mark.timeout(120),  # ~5x observed 24.3s; CI machines are slower
             pytest.mark.post_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=VLLM_SMOKE_MODEL,
+        script_args=["--model", VLLM_SMOKE_MODEL],
         request_payloads=[
             chat_payload_with_logprobs(
                 repeat_count=2,
@@ -242,7 +244,7 @@ vllm_configs = {
             pytest.mark.timeout(600),  # 3x ~200s under new scheduler (3d1554f)
             pytest.mark.pre_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
@@ -266,7 +268,7 @@ vllm_configs = {
             pytest.mark.timeout(600),  # 3x ~199s multiproc, new scheduler (3d1554f)
             pytest.mark.pre_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         env={
             "PROMETHEUS_MULTIPROC_DIR": f"/tmp/prometheus_multiproc_test_{os.getpid()}_{random.randint(0, 10000)}"
         },
@@ -292,7 +294,7 @@ vllm_configs = {
             pytest.mark.timeout(640),  # 3x ~213s under new scheduler (3d1554f)
             pytest.mark.pre_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         env={"LMCACHE_L1_SIZE_GB": "8"},
         request_payloads=[
             chat_payload_default(),
@@ -314,8 +316,8 @@ vllm_configs = {
             pytest.mark.timeout(600),  # 3x ~199s under new scheduler (3d1554f)
             pytest.mark.pre_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
-        script_args=["--tcp"],
+        model=VLLM_SMOKE_MODEL,
+        script_args=["--tcp", "--model", VLLM_SMOKE_MODEL],
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
@@ -331,7 +333,7 @@ vllm_configs = {
             pytest.mark.pre_merge,
             pytest.mark.timeout(600),
         ],  # TODO: profile to get max_vram
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         request_payloads=[
             router_selection_chat_payload_default(),
             kv_events_metrics_payload(system_ports=[DefaultPort.SYSTEM2.value]),
@@ -348,7 +350,7 @@ vllm_configs = {
             pytest.mark.pre_merge,
             pytest.mark.timeout(600),
         ],  # TODO: profile to get max_vram
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         request_payloads=[
             # Test approximate KV routing (--no-kv-events mode)
             # Repeated requests should show cache-aware routing in nvext.
@@ -367,7 +369,7 @@ vllm_configs = {
             pytest.mark.gpu_2,
             pytest.mark.pre_merge,
         ],  # TODO: profile to get max_vram and timeout
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
@@ -389,7 +391,7 @@ vllm_configs = {
             # Move back to pre_merge once GPU tests run in parallel.
             pytest.mark.post_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         delayed_start=10,
         health_check_workers=True,
         request_payloads=[
@@ -408,7 +410,7 @@ vllm_configs = {
             pytest.mark.timeout(300),
             pytest.mark.post_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         delayed_start=10,
         health_check_workers=True,
         env={"DYN_CHAT_PROCESSOR": "vllm"},
@@ -428,7 +430,7 @@ vllm_configs = {
             pytest.mark.timeout(300),
             pytest.mark.post_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         delayed_start=10,
         health_check_workers=True,
         env={
@@ -610,7 +612,7 @@ vllm_configs = {
             # TODO: profile to get max_vram
             pytest.mark.timeout(300),
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
@@ -630,7 +632,8 @@ vllm_configs = {
             pytest.mark.timeout(220),  # 3x ~72s under new scheduler (3d1554f)
             pytest.mark.pre_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=VLLM_SMOKE_MODEL,
+        script_args=["--model", VLLM_SMOKE_MODEL],
         request_payloads=[
             chat_payload(
                 "Generate a person with name and age",
@@ -900,7 +903,7 @@ def lora_chat_payload(
 @pytest.mark.core
 @pytest.mark.e2e
 @pytest.mark.gpu_1
-@pytest.mark.model("Qwen/Qwen3-0.6B")
+@pytest.mark.model(QWEN_QWEN3_0_6B)
 @pytest.mark.model("codelion/Qwen3-0.6B-accuracy-recovery-lora")
 @pytest.mark.profiled_vram_gib(4.0)  # actual nvidia-smi peak with kv-bytes cap
 @pytest.mark.requested_vllm_kv_cache_bytes(
@@ -940,7 +943,7 @@ def test_lora_aggregated(
         directory=vllm_dir,
         script_name="lora/agg_lora.sh",
         marks=[],  # markers at function-level
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         timeout=600,
         env=minio_config.get_env_vars(),
         request_payloads=[lora_payload],
@@ -961,7 +964,7 @@ def test_lora_aggregated(
 @pytest.mark.router
 @pytest.mark.e2e
 @pytest.mark.gpu_2
-@pytest.mark.model("Qwen/Qwen3-0.6B")
+@pytest.mark.model(QWEN_QWEN3_0_6B)
 @pytest.mark.model("codelion/Qwen3-0.6B-accuracy-recovery-lora")
 @pytest.mark.timeout(600)
 @pytest.mark.pre_merge
@@ -1024,7 +1027,7 @@ def test_lora_aggregated_router(
         directory=vllm_dir,
         script_name="lora/agg_lora_router.sh",
         marks=[],  # markers at function-level
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         timeout=600,
         env=env_vars,
         request_payloads=[

--- a/tests/serve/test_vllm_xpu.py
+++ b/tests/serve/test_vllm_xpu.py
@@ -28,6 +28,7 @@ from tests.serve.multimodal_profiles.vllm_xpu import (
 )
 from tests.utils.constants import DefaultPort
 from tests.utils.engine_process import EngineConfig
+from tests.utils.model_registry import QWEN_QWEN3_0_6B
 from tests.utils.multimodal import (
     IMAGE_COLOR_PROMPT,
     LOCAL_VIDEO_TEST_URI,
@@ -86,7 +87,7 @@ vllm_configs = {
             ),  # ~8.5x observed 42.2s; bumped for GPU-parallel headroom
             pytest.mark.pre_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
@@ -118,7 +119,7 @@ vllm_configs = {
             pytest.mark.timeout(420),
             pytest.mark.post_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         request_payloads=[
             chat_payload_with_logprobs(
                 repeat_count=2,
@@ -151,7 +152,7 @@ vllm_configs = {
             pytest.mark.timeout(360),  # ~7x observed 49.0s; old value before profiling
             pytest.mark.pre_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
@@ -174,7 +175,7 @@ vllm_configs = {
             pytest.mark.timeout(360),  # ~7x observed 49.3s; old value before profiling
             pytest.mark.pre_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         env={
             "PROMETHEUS_MULTIPROC_DIR": f"/tmp/prometheus_multiproc_test_{os.getpid()}_{random.randint(0, 10000)}",
         },
@@ -201,7 +202,7 @@ vllm_configs = {
             ),  # ~8x observed 43.0s; bumped for GPU-parallel headroom
             pytest.mark.pre_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         script_args=["--tcp"],
         request_payloads=[
             chat_payload_default(),
@@ -224,7 +225,7 @@ vllm_configs = {
             ),  # 2 workers + router startup; bumped for GPU-parallel headroom
             pytest.mark.post_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         request_payloads=[
             router_selection_chat_payload_default(),
             kv_events_metrics_payload(system_ports=[DefaultPort.SYSTEM2.value]),
@@ -247,7 +248,7 @@ vllm_configs = {
             ),  # 2 workers + router startup; bumped for GPU-parallel headroom
             pytest.mark.post_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         request_payloads=[
             # Test approximate KV routing (--no-kv-events mode)
             # Repeated requests should show cache-aware routing in nvext.
@@ -543,7 +544,7 @@ vllm_configs = {
             pytest.mark.timeout(360),
             pytest.mark.pre_merge,
         ],
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         request_payloads=[
             chat_payload(
                 "Generate a person with name and age",
@@ -801,7 +802,7 @@ def lora_chat_payload(
 @pytest.mark.core
 @pytest.mark.e2e
 @pytest.mark.xpu_1
-@pytest.mark.model("Qwen/Qwen3-0.6B", "codelion/Qwen3-0.6B-accuracy-recovery-lora")
+@pytest.mark.model(QWEN_QWEN3_0_6B, "codelion/Qwen3-0.6B-accuracy-recovery-lora")
 @pytest.mark.timeout(600)
 @pytest.mark.post_merge
 @pytest.mark.xfail(
@@ -842,7 +843,7 @@ def test_lora_aggregated(
         directory=vllm_dir,
         script_name="lora/xpu/agg_lora_xpu.sh",
         marks=[],  # markers at function-level
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         timeout=600,
         env=env_vars,
         request_payloads=[lora_payload],
@@ -863,7 +864,7 @@ def test_lora_aggregated(
 @pytest.mark.router
 @pytest.mark.e2e
 @pytest.mark.xpu_2
-@pytest.mark.model("Qwen/Qwen3-0.6B")
+@pytest.mark.model(QWEN_QWEN3_0_6B)
 @pytest.mark.timeout(600)
 @pytest.mark.post_merge
 @pytest.mark.xfail(
@@ -928,7 +929,7 @@ def test_lora_aggregated_router(
         directory=vllm_dir,
         script_name="lora/xpu/agg_lora_router_xpu.sh",
         marks=[],  # markers at function-level
-        model="Qwen/Qwen3-0.6B",
+        model=QWEN_QWEN3_0_6B,
         timeout=600,
         env=env_vars,
         request_payloads=[

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -10,17 +10,20 @@ avoid importing from conftest and to keep values consistent.
 import os
 from enum import IntEnum
 
-QWEN = "Qwen/Qwen3-0.6B"
-LLAMA = "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"  # on an l4 gpu, must limit --max-seq-len, otherwise it will not fit
-GPT_OSS = "openai/gpt-oss-20b"
-QWEN_EMBEDDING = "Qwen/Qwen3-Embedding-4B"
+from tests.utils.model_registry import (
+    DEEPSEEK_AI_DEEPSEEK_R1_DISTILL_LLAMA_8B,
+    DEFAULT_TEST_MODELS,
+    OPENAI_GPT_OSS_20B,
+    QWEN_QWEN3_0_6B,
+    QWEN_QWEN3_EMBEDDING_4B,
+)
 
-TEST_MODELS = [
-    QWEN,
-    LLAMA,
-    GPT_OSS,
-    QWEN_EMBEDDING,
-]
+QWEN = QWEN_QWEN3_0_6B
+LLAMA = DEEPSEEK_AI_DEEPSEEK_R1_DISTILL_LLAMA_8B  # on an l4 gpu, must limit --max-seq-len, otherwise it will not fit
+GPT_OSS = OPENAI_GPT_OSS_20B
+QWEN_EMBEDDING = QWEN_QWEN3_EMBEDDING_4B
+
+TEST_MODELS = list(DEFAULT_TEST_MODELS)
 
 
 # Default ports used by test payloads/scripts when not overridden.

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -14,11 +14,22 @@ from tests.utils.model_registry import (
     DEEPSEEK_AI_DEEPSEEK_R1_DISTILL_LLAMA_8B,
     DEFAULT_TEST_MODELS,
     OPENAI_GPT_OSS_20B,
-    QWEN_QWEN3_0_6B,
     QWEN_QWEN3_EMBEDDING_4B,
+    resolve_model_profile,
 )
 
-QWEN = QWEN_QWEN3_0_6B
+# Role-based defaults are intentionally resolved at import/collection time. A CI
+# job can compare a candidate without editing every test, while the profile
+# rejects models that lack the required runtime or architectural properties.
+CROSS_BACKEND_SMOKE_MODEL = resolve_model_profile("cross_backend_smoke")
+VLLM_SMOKE_MODEL = resolve_model_profile("vllm_smoke")
+SGLANG_SMOKE_MODEL = resolve_model_profile("sglang_smoke")
+TRTLLM_SMOKE_MODEL = resolve_model_profile("trtllm_smoke")
+KV_TRANSFER_MODEL = resolve_model_profile("kv_transfer")
+
+# Compatibility alias for existing tests. New tests should name the role they
+# need rather than the current model family.
+QWEN = CROSS_BACKEND_SMOKE_MODEL
 LLAMA = DEEPSEEK_AI_DEEPSEEK_R1_DISTILL_LLAMA_8B  # on an l4 gpu, must limit --max-seq-len, otherwise it will not fit
 GPT_OSS = OPENAI_GPT_OSS_20B
 QWEN_EMBEDDING = QWEN_QWEN3_EMBEDDING_4B
@@ -56,5 +67,9 @@ class DynamoPortRange(IntEnum):
 
 # Env-driven defaults for specific test groups
 # Allows overriding via environment variables
-ROUTER_MODEL_NAME = os.environ.get("ROUTER_MODEL_NAME", QWEN)
-FAULT_TOLERANCE_MODEL_NAME = os.environ.get("FAULT_TOLERANCE_MODEL_NAME", QWEN)
+ROUTER_MODEL_NAME = resolve_model_profile(
+    "cross_backend_smoke", override=os.environ.get("ROUTER_MODEL_NAME")
+)
+FAULT_TOLERANCE_MODEL_NAME = resolve_model_profile(
+    "cross_backend_smoke", override=os.environ.get("FAULT_TOLERANCE_MODEL_NAME")
+)

--- a/tests/utils/model_registry.py
+++ b/tests/utils/model_registry.py
@@ -10,6 +10,8 @@ the closest static proxy for CI download and cache cost.
 
 from __future__ import annotations
 
+import argparse
+import os
 from dataclasses import dataclass
 from typing import Iterable
 
@@ -23,7 +25,13 @@ class ModelSpec:
     repo_id: str
     snapshot_size_gib: float
     kind: str
-    architecture_tags: tuple[str, ...]
+    characteristics: tuple[str, ...]
+    architecture: str = ""
+    backends: tuple[str, ...] = ()
+    parameter_count_millions: int | None = None
+    context_length: int | None = None
+    release_year: int | None = None
+    license: str = ""
     gated: bool = False
     download_required: bool = True
     over_cap_exception: bool = False
@@ -36,6 +44,29 @@ class ModelSpec:
     @property
     def exceeds_default_cap(self) -> bool:
         return self.snapshot_size_gib > DEFAULT_CI_MODEL_SNAPSHOT_CAP_GIB
+
+
+@dataclass(frozen=True)
+class ModelQuery:
+    """Compatibility constraints used to select a CI model."""
+
+    kind: str | None = None
+    required_characteristics: frozenset[str] = frozenset()
+    excluded_characteristics: frozenset[str] = frozenset()
+    required_backends: frozenset[str] = frozenset()
+    max_parameter_count_millions: int | None = None
+    max_snapshot_size_gib: float | None = None
+    allow_gated: bool = False
+    include_metadata_only: bool = False
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    """A stable CI role whose concrete model can be safely overridden."""
+
+    default_repo_id: str
+    query: ModelQuery
+    override_env_var: str
 
 
 QWEN_QWEN_IMAGE = "Qwen/Qwen-Image"
@@ -79,9 +110,12 @@ DEEPSEEK_AI_DEEPSEEK_LLM_7B_BASE = "deepseek-ai/deepseek-llm-7b-base"
 
 BAAI_BGE_SMALL_EN_V1_5 = "BAAI/bge-small-en-v1.5"
 CROSS_ENCODER_NLI_MINILM2_L6_H768 = "cross-encoder/nli-MiniLM2-L6-H768"
+GOOGLE_GEMMA_3_270M_IT = "google/gemma-3-270m-it"
 GOOGLE_GEMMA_4_E2B_IT = "google/gemma-4-E2B-it"
 GOOGLE_GEMMA_3_4B_IT = "google/gemma-3-4b-it"
+IBM_GRANITE_GRANITE_4_0_H_350M = "ibm-granite/granite-4.0-h-350m"
 INCLUSIONAI_LLADA2_0_MINI_PREVIEW = "inclusionAI/LLaDA2.0-mini-preview"
+LIQUIDAI_LFM2_5_350M = "LiquidAI/LFM2.5-350M"
 LLAVA_HF_LLAVA_1_5_7B_HF = "llava-hf/llava-1.5-7b-hf"
 LLAVA_HF_LLAVA_V1_6_MISTRAL_7B_HF = "llava-hf/llava-v1.6-mistral-7b-hf"
 MICROSOFT_PHI_3_VISION_128K_INSTRUCT = "microsoft/Phi-3-vision-128k-instruct"
@@ -111,19 +145,79 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         repo_id=BAAI_BGE_SMALL_EN_V1_5,
         snapshot_size_gib=0.4,
         kind="embedding",
-        architecture_tags=("bert", "dense", "encoder"),
+        characteristics=("bert", "dense", "encoder"),
     ),
     ModelSpec(
         repo_id=CROSS_ENCODER_NLI_MINILM2_L6_H768,
         snapshot_size_gib=2.7,
         kind="reranker",
-        architecture_tags=("dense", "encoder", "roberta"),
+        characteristics=("dense", "encoder", "roberta"),
+    ),
+    ModelSpec(
+        repo_id=GOOGLE_GEMMA_3_270M_IT,
+        snapshot_size_gib=0.54,
+        kind="llm",
+        characteristics=(
+            "chat",
+            "dense",
+            "instruction_tuned",
+            "sliding_window",
+            "small_ci_candidate",
+            "text_generation",
+        ),
+        architecture="Gemma3ForCausalLM",
+        backends=("sglang", "trtllm", "vllm"),
+        parameter_count_millions=270,
+        context_length=32768,
+        release_year=2025,
+        license="gemma",
+        gated=True,
+    ),
+    ModelSpec(
+        repo_id=IBM_GRANITE_GRANITE_4_0_H_350M,
+        snapshot_size_gib=0.64,
+        kind="llm",
+        characteristics=(
+            "chat",
+            "hybrid_state_space",
+            "instruction_tuned",
+            "mamba2",
+            "small_ci_candidate",
+            "text_generation",
+            "tool_calling",
+        ),
+        architecture="GraniteMoeHybridForCausalLM",
+        backends=("sglang", "vllm"),
+        parameter_count_millions=340,
+        context_length=32768,
+        release_year=2025,
+        license="apache-2.0",
+    ),
+    ModelSpec(
+        repo_id=LIQUIDAI_LFM2_5_350M,
+        snapshot_size_gib=0.66,
+        kind="llm",
+        characteristics=(
+            "chat",
+            "hybrid_state_space",
+            "instruction_tuned",
+            "short_convolution",
+            "small_ci_candidate",
+            "text_generation",
+            "tool_calling",
+        ),
+        architecture="Lfm2ForCausalLM",
+        backends=("sglang", "vllm"),
+        parameter_count_millions=350,
+        context_length=32768,
+        release_year=2026,
+        license="lfm1.0",
     ),
     ModelSpec(
         repo_id=QWEN_QWEN_IMAGE,
         snapshot_size_gib=53.7,
         kind="image_generation",
-        architecture_tags=("diffusion", "image"),
+        characteristics=("diffusion", "image"),
         over_cap_exception=True,
         exception_reason=(
             "Legacy skipped vLLM-Omni image-generation coverage; exceeds "
@@ -134,25 +228,25 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         repo_id=QWEN_QWEN2_AUDIO_7B_INSTRUCT,
         snapshot_size_gib=15.7,
         kind="audio_text_to_text",
-        architecture_tags=("audio", "dense", "multimodal"),
+        characteristics=("audio", "dense", "multimodal"),
     ),
     ModelSpec(
         repo_id=QWEN_QWEN2_VL_2B_INSTRUCT,
         snapshot_size_gib=4.1,
         kind="vlm",
-        architecture_tags=("dense", "gqa", "vision"),
+        characteristics=("dense", "gqa", "vision"),
     ),
     ModelSpec(
         repo_id=QWEN_QWEN2_VL_7B_INSTRUCT,
         snapshot_size_gib=15.5,
         kind="vlm",
-        architecture_tags=("dense", "gqa", "vision"),
+        characteristics=("dense", "gqa", "vision"),
     ),
     ModelSpec(
         repo_id=QWEN_QWEN2_5_OMNI_7B,
         snapshot_size_gib=20.8,
         kind="omni",
-        architecture_tags=("audio", "dense", "multimodal", "vision"),
+        characteristics=("audio", "dense", "multimodal", "vision"),
         over_cap_exception=True,
         exception_reason=(
             "Legacy skipped vLLM-Omni text coverage; exceeds the default "
@@ -163,31 +257,45 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         repo_id=QWEN_QWEN2_5_VL_3B_INSTRUCT,
         snapshot_size_gib=7.0,
         kind="vlm",
-        architecture_tags=("dense", "gqa", "vision"),
+        characteristics=("dense", "gqa", "vision"),
     ),
     ModelSpec(
         repo_id=QWEN_QWEN2_5_1_5B_INSTRUCT,
         snapshot_size_gib=2.9,
         kind="llm",
-        architecture_tags=("dense", "gqa"),
+        characteristics=("dense", "gqa"),
     ),
     ModelSpec(
         repo_id=QWEN_QWEN2_5_VL_7B_INSTRUCT,
         snapshot_size_gib=15.5,
         kind="vlm",
-        architecture_tags=("dense", "gqa", "vision"),
+        characteristics=("dense", "gqa", "vision"),
     ),
     ModelSpec(
         repo_id=QWEN_QWEN3_0_6B,
         snapshot_size_gib=1.4,
         kind="llm",
-        architecture_tags=("dense", "gqa"),
+        characteristics=(
+            "chat",
+            "dense",
+            "full_attention",
+            "gqa",
+            "instruction_tuned",
+            "text_generation",
+            "tool_calling",
+        ),
+        architecture="Qwen3ForCausalLM",
+        backends=("sglang", "trtllm", "vllm"),
+        parameter_count_millions=600,
+        context_length=40960,
+        release_year=2025,
+        license="apache-2.0",
     ),
     ModelSpec(
         repo_id=QWEN_QWEN3_32B,
         snapshot_size_gib=61.0,
         kind="llm",
-        architecture_tags=("aic_metadata", "dense", "gqa"),
+        characteristics=("aic_metadata", "dense", "gqa"),
         download_required=False,
         over_cap_exception=True,
         exception_reason=(
@@ -198,7 +306,7 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         repo_id=QWEN_QWEN3_235B_A22B_FP8,
         snapshot_size_gib=222.6,
         kind="llm",
-        architecture_tags=("fp8", "gqa", "moe"),
+        characteristics=("fp8", "gqa", "moe"),
         over_cap_exception=True,
         exception_reason="H100 DGDR deployment coverage for a large FP8 MoE model.",
     ),
@@ -206,49 +314,49 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         repo_id=QWEN_QWEN3_5_0_8B,
         snapshot_size_gib=1.6,
         kind="vlm",
-        architecture_tags=("dense", "hybrid_attention", "mamba", "vision"),
+        characteristics=("dense", "hybrid_attention", "mamba", "vision"),
     ),
     ModelSpec(
         repo_id=QWEN_QWEN3_EMBEDDING_0_6B,
         snapshot_size_gib=1.2,
         kind="embedding",
-        architecture_tags=("dense", "gqa"),
+        characteristics=("dense", "gqa"),
     ),
     ModelSpec(
         repo_id=QWEN_QWEN3_EMBEDDING_4B,
         snapshot_size_gib=7.5,
         kind="embedding",
-        architecture_tags=("dense", "gqa"),
+        characteristics=("dense", "gqa"),
     ),
     ModelSpec(
         repo_id=QWEN_QWEN3_TTS_12HZ_1_7B_CUSTOMVOICE,
         snapshot_size_gib=4.2,
         kind="tts",
-        architecture_tags=("audio", "dense"),
+        characteristics=("audio", "dense"),
     ),
     ModelSpec(
         repo_id=QWEN_QWEN3_VL_2B_INSTRUCT,
         snapshot_size_gib=4.0,
         kind="vlm",
-        architecture_tags=("dense", "gqa", "vision"),
+        characteristics=("dense", "gqa", "vision"),
     ),
     ModelSpec(
         repo_id=QWEN_QWEN3_VL_2B_INSTRUCT_FP8,
         snapshot_size_gib=3.3,
         kind="vlm",
-        architecture_tags=("fp8", "gqa", "vision"),
+        characteristics=("fp8", "gqa", "vision"),
     ),
     ModelSpec(
         repo_id=QWEN_QWEN3_VL_8B_INSTRUCT,
         snapshot_size_gib=16.3,
         kind="vlm",
-        architecture_tags=("dense", "gqa", "vision"),
+        characteristics=("dense", "gqa", "vision"),
     ),
     ModelSpec(
         repo_id=BLACK_FOREST_LABS_FLUX_2_KLEIN_4B,
         snapshot_size_gib=22.1,
         kind="image_generation",
-        architecture_tags=("diffusion", "image"),
+        characteristics=("diffusion", "image"),
         over_cap_exception=True,
         exception_reason=(
             "Current TRT-LLM diffusion pre-merge smoke coverage; exceeds "
@@ -259,19 +367,19 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         repo_id=TINYLLAMA_TINYLLAMA_1_1B_CHAT_V1_0,
         snapshot_size_gib=2.1,
         kind="llm",
-        architecture_tags=("dense", "gqa"),
+        characteristics=("dense", "gqa"),
     ),
     ModelSpec(
         repo_id=TINYLLAMA_TINYLLAMA_1_1B_INTERMEDIATE_STEP_1431K_3T,
         snapshot_size_gib=8.2,
         kind="llm",
-        architecture_tags=("dense", "gqa"),
+        characteristics=("dense", "gqa"),
     ),
     ModelSpec(
         repo_id=TONGYI_MAI_Z_IMAGE_TURBO,
         snapshot_size_gib=30.6,
         kind="image_generation",
-        architecture_tags=("diffusion", "image"),
+        characteristics=("diffusion", "image"),
         over_cap_exception=True,
         exception_reason=(
             "Current SGLang diffusion nightly coverage; exceeds the "
@@ -282,7 +390,7 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         repo_id=WAN_AI_WAN2_1_T2V_1_3B_DIFFUSERS,
         snapshot_size_gib=26.9,
         kind="video_generation",
-        architecture_tags=("diffusion", "video"),
+        characteristics=("diffusion", "video"),
         over_cap_exception=True,
         exception_reason=(
             "Current TRT-LLM/vLLM-Omni video-generation CI coverage; "
@@ -293,7 +401,7 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         repo_id=WAN_AI_WAN2_2_TI2V_5B_DIFFUSERS,
         snapshot_size_gib=31.9,
         kind="video_generation",
-        architecture_tags=("diffusion", "image_to_video", "video"),
+        characteristics=("diffusion", "image_to_video", "video"),
         over_cap_exception=True,
         exception_reason=(
             "Current vLLM-Omni image-to-video CI coverage; replace with a "
@@ -304,19 +412,19 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         repo_id=CODELION_QWEN3_0_6B_ACCURACY_RECOVERY_LORA,
         snapshot_size_gib=0.2,
         kind="lora_adapter",
-        architecture_tags=("adapter", "lora"),
+        characteristics=("adapter", "lora"),
     ),
     ModelSpec(
         repo_id=DEEPSEEK_AI_DEEPSEEK_R1_DISTILL_LLAMA_8B,
         snapshot_size_gib=15.0,
         kind="llm",
-        architecture_tags=("dense", "gqa"),
+        characteristics=("dense", "gqa"),
     ),
     ModelSpec(
         repo_id=DEEPSEEK_AI_DEEPSEEK_V2_LITE,
         snapshot_size_gib=29.3,
         kind="llm",
-        architecture_tags=("mla", "moe"),
+        characteristics=("mla", "moe"),
         over_cap_exception=True,
         exception_reason=(
             "Legacy MoE/MLA coverage for vLLM, KVBM, and fault-tolerance "
@@ -327,26 +435,26 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         repo_id=DEEPSEEK_AI_DEEPSEEK_LLM_7B_BASE,
         snapshot_size_gib=12.9,
         kind="llm",
-        architecture_tags=("dense", "mha"),
+        characteristics=("dense", "mha"),
     ),
     ModelSpec(
         repo_id=GOOGLE_GEMMA_4_E2B_IT,
         snapshot_size_gib=9.6,
         kind="vlm",
-        architecture_tags=("dense", "vision"),
+        characteristics=("dense", "vision"),
     ),
     ModelSpec(
         repo_id=GOOGLE_GEMMA_3_4B_IT,
         snapshot_size_gib=8.0,
         kind="vlm",
-        architecture_tags=("dense", "gated", "vision"),
+        characteristics=("dense", "gated", "vision"),
         gated=True,
     ),
     ModelSpec(
         repo_id=INCLUSIONAI_LLADA2_0_MINI_PREVIEW,
         snapshot_size_gib=30.3,
         kind="llm",
-        architecture_tags=("diffusion", "moe"),
+        characteristics=("diffusion", "moe"),
         over_cap_exception=True,
         exception_reason="SGLang diffusion-language-model coverage.",
     ),
@@ -354,31 +462,31 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         repo_id=LLAVA_HF_LLAVA_1_5_7B_HF,
         snapshot_size_gib=13.2,
         kind="vlm",
-        architecture_tags=("dense", "vision"),
+        characteristics=("dense", "vision"),
     ),
     ModelSpec(
         repo_id=LLAVA_HF_LLAVA_V1_6_MISTRAL_7B_HF,
         snapshot_size_gib=14.1,
         kind="vlm",
-        architecture_tags=("dense", "vision"),
+        characteristics=("dense", "vision"),
     ),
     ModelSpec(
         repo_id=MICROSOFT_PHI_3_VISION_128K_INSTRUCT,
         snapshot_size_gib=7.7,
         kind="vlm",
-        architecture_tags=("dense", "vision"),
+        characteristics=("dense", "vision"),
     ),
     ModelSpec(
         repo_id=MISTRALAI_MINISTRAL_3_3B_REASONING_2512,
         snapshot_size_gib=14.4,
         kind="llm",
-        architecture_tags=("dense", "gqa"),
+        characteristics=("dense", "gqa"),
     ),
     ModelSpec(
         repo_id=OPENAI_GPT_OSS_20B,
         snapshot_size_gib=38.5,
         kind="llm",
-        architecture_tags=("gqa", "moe"),
+        characteristics=("gqa", "moe"),
         over_cap_exception=True,
         exception_reason=(
             "Required by current GPT-OSS reasoning/tool-calling frontend "
@@ -389,7 +497,7 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         repo_id=META_LLAMA_META_LLAMA_3_1_70B,
         snapshot_size_gib=131.0,
         kind="llm",
-        architecture_tags=("dense", "gated", "gqa"),
+        characteristics=("dense", "gated", "gqa"),
         gated=True,
         over_cap_exception=True,
         exception_reason="H100 DGDR deployment coverage for Llama 3.1 70B.",
@@ -398,26 +506,26 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         repo_id=META_LLAMA_META_LLAMA_3_1_8B_INSTRUCT,
         snapshot_size_gib=15.0,
         kind="llm",
-        architecture_tags=("dense", "gated", "gqa"),
+        characteristics=("dense", "gated", "gqa"),
         gated=True,
     ),
     ModelSpec(
         repo_id=SILENCE09_DEEPSEEK_R1_SMALL_2LAYERS,
         snapshot_size_gib=4.5,
         kind="llm",
-        architecture_tags=("mla", "moe"),
+        characteristics=("mla", "moe"),
     ),
     ModelSpec(
         repo_id=YUHUILI_EAGLE3_LLAMA3_1_INSTRUCT_8B,
         snapshot_size_gib=0.9,
         kind="speculative_draft",
-        architecture_tags=("dense", "eagle3", "gqa"),
+        characteristics=("dense", "eagle3", "gqa"),
     ),
     ModelSpec(
         repo_id=ZAI_ORG_GLM_IMAGE,
         snapshot_size_gib=33.3,
         kind="image_generation",
-        architecture_tags=("diffusion", "image"),
+        characteristics=("diffusion", "image"),
         over_cap_exception=True,
         exception_reason=(
             "Legacy skipped vLLM-Omni image-generation coverage; exceeds "
@@ -427,6 +535,66 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
 )
 
 MODEL_REGISTRY: dict[str, ModelSpec] = {spec.repo_id: spec for spec in MODEL_SPECS}
+
+
+_SMOKE_CHARACTERISTICS = frozenset({"chat", "instruction_tuned", "text_generation"})
+
+MODEL_PROFILES: dict[str, ModelProfile] = {
+    "cross_backend_smoke": ModelProfile(
+        default_repo_id=QWEN_QWEN3_0_6B,
+        query=ModelQuery(
+            kind="llm",
+            required_characteristics=_SMOKE_CHARACTERISTICS,
+            required_backends=frozenset({"sglang", "trtllm", "vllm"}),
+            max_parameter_count_millions=700,
+            allow_gated=True,
+        ),
+        override_env_var="DYN_CI_CROSS_BACKEND_SMOKE_MODEL",
+    ),
+    "kv_transfer": ModelProfile(
+        default_repo_id=QWEN_QWEN3_0_6B,
+        query=ModelQuery(
+            kind="llm",
+            required_characteristics=_SMOKE_CHARACTERISTICS | {"full_attention"},
+            required_backends=frozenset({"vllm"}),
+            max_parameter_count_millions=700,
+        ),
+        override_env_var="DYN_CI_KV_TRANSFER_MODEL",
+    ),
+    "sglang_smoke": ModelProfile(
+        default_repo_id=QWEN_QWEN3_0_6B,
+        query=ModelQuery(
+            kind="llm",
+            required_characteristics=_SMOKE_CHARACTERISTICS,
+            required_backends=frozenset({"sglang"}),
+            max_parameter_count_millions=700,
+            allow_gated=True,
+        ),
+        override_env_var="DYN_CI_SGLANG_SMOKE_MODEL",
+    ),
+    "trtllm_smoke": ModelProfile(
+        default_repo_id=QWEN_QWEN3_0_6B,
+        query=ModelQuery(
+            kind="llm",
+            required_characteristics=_SMOKE_CHARACTERISTICS,
+            required_backends=frozenset({"trtllm"}),
+            max_parameter_count_millions=700,
+            allow_gated=True,
+        ),
+        override_env_var="DYN_CI_TRTLLM_SMOKE_MODEL",
+    ),
+    "vllm_smoke": ModelProfile(
+        default_repo_id=QWEN_QWEN3_0_6B,
+        query=ModelQuery(
+            kind="llm",
+            required_characteristics=_SMOKE_CHARACTERISTICS,
+            required_backends=frozenset({"vllm"}),
+            max_parameter_count_millions=700,
+            allow_gated=True,
+        ),
+        override_env_var="DYN_CI_VLLM_SMOKE_MODEL",
+    ),
+}
 
 
 DEFAULT_TEST_MODELS = (
@@ -445,6 +613,82 @@ def get_model_spec(repo_id: str) -> ModelSpec:
             f"{repo_id!r} is not registered in tests.utils.model_registry. "
             "Add a ModelSpec with HF snapshot size and architecture metadata."
         ) from exc
+
+
+def model_matches_query(spec: ModelSpec, query: ModelQuery) -> bool:
+    """Return whether a model satisfies every compatibility constraint."""
+
+    characteristics = frozenset(spec.characteristics)
+    backends = frozenset(spec.backends)
+    return all(
+        (
+            query.kind is None or spec.kind == query.kind,
+            query.required_characteristics <= characteristics,
+            not (query.excluded_characteristics & characteristics),
+            query.required_backends <= backends,
+            query.max_parameter_count_millions is None
+            or (
+                spec.parameter_count_millions is not None
+                and spec.parameter_count_millions <= query.max_parameter_count_millions
+            ),
+            query.max_snapshot_size_gib is None
+            or spec.snapshot_size_gib <= query.max_snapshot_size_gib,
+            query.allow_gated or not spec.gated,
+            query.include_metadata_only or spec.download_required,
+        )
+    )
+
+
+def select_models(query: ModelQuery) -> tuple[ModelSpec, ...]:
+    """Return compatible models, smallest parameter count first."""
+
+    matches = [
+        spec for spec in MODEL_REGISTRY.values() if model_matches_query(spec, query)
+    ]
+    return tuple(
+        sorted(
+            matches,
+            key=lambda spec: (
+                spec.parameter_count_millions
+                if spec.parameter_count_millions is not None
+                else float("inf"),
+                spec.snapshot_size_gib,
+                spec.repo_id,
+            ),
+        )
+    )
+
+
+def select_model(query: ModelQuery) -> str:
+    """Return the smallest compatible model id, or fail with the query."""
+
+    matches = select_models(query)
+    if not matches:
+        raise ValueError(f"No registered CI model satisfies {query!r}")
+    return matches[0].repo_id
+
+
+def resolve_model_profile(profile_name: str, *, override: str | None = None) -> str:
+    """Resolve a stable CI role and validate any environment override."""
+
+    try:
+        profile = MODEL_PROFILES[profile_name]
+    except KeyError as exc:
+        choices = ", ".join(sorted(MODEL_PROFILES))
+        raise KeyError(
+            f"Unknown CI model profile {profile_name!r}; choose {choices}"
+        ) from exc
+
+    repo_id = override or os.environ.get(
+        profile.override_env_var, profile.default_repo_id
+    )
+    spec = get_model_spec(repo_id)
+    if not model_matches_query(spec, profile.query):
+        raise ValueError(
+            f"{repo_id!r} does not satisfy CI model profile {profile_name!r}: "
+            f"{profile.query!r}"
+        )
+    return repo_id
 
 
 def validate_ci_model_ids(repo_ids: Iterable[str]) -> tuple[str, ...]:
@@ -469,3 +713,35 @@ def downloadable_model_ids(repo_ids: Iterable[str]) -> tuple[str, ...]:
         for repo_id in validate_ci_model_ids(repo_ids)
         if MODEL_REGISTRY[repo_id].download_required
     )
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(description="Select a compatible Dynamo CI model")
+    parser.add_argument("--profile", choices=sorted(MODEL_PROFILES))
+    parser.add_argument("--kind", default="llm")
+    parser.add_argument("--require", action="append", default=[])
+    parser.add_argument("--backend", action="append", default=[])
+    parser.add_argument("--max-parameters-millions", type=int)
+    parser.add_argument("--max-snapshot-gib", type=float)
+    parser.add_argument("--allow-gated", action="store_true")
+    args = parser.parse_args()
+
+    if args.profile:
+        print(resolve_model_profile(args.profile))
+        return
+    print(
+        select_model(
+            ModelQuery(
+                kind=args.kind,
+                required_characteristics=frozenset(args.require),
+                required_backends=frozenset(args.backend),
+                max_parameter_count_millions=args.max_parameters_millions,
+                max_snapshot_size_gib=args.max_snapshot_gib,
+                allow_gated=args.allow_gated,
+            )
+        )
+    )
+
+
+if __name__ == "__main__":
+    _main()

--- a/tests/utils/model_registry.py
+++ b/tests/utils/model_registry.py
@@ -1,0 +1,471 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Central Hugging Face model registry for Dynamo CI tests.
+
+The size policy uses Hugging Face snapshot download size: the sum of file sizes
+returned for the current repo snapshot by the Hugging Face model API. This is
+the closest static proxy for CI download and cache cost.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+DEFAULT_CI_MODEL_SNAPSHOT_CAP_GIB = 20.0
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """Metadata for a model or adapter used by CI tests."""
+
+    repo_id: str
+    snapshot_size_gib: float
+    kind: str
+    architecture_tags: tuple[str, ...]
+    gated: bool = False
+    download_required: bool = True
+    over_cap_exception: bool = False
+    exception_reason: str = ""
+
+    @property
+    def hf_url(self) -> str:
+        return f"https://huggingface.co/{self.repo_id}"
+
+    @property
+    def exceeds_default_cap(self) -> bool:
+        return self.snapshot_size_gib > DEFAULT_CI_MODEL_SNAPSHOT_CAP_GIB
+
+
+QWEN_QWEN_IMAGE = "Qwen/Qwen-Image"
+QWEN_QWEN2_AUDIO_7B_INSTRUCT = "Qwen/Qwen2-Audio-7B-Instruct"
+QWEN_QWEN2_VL_2B_INSTRUCT = "Qwen/Qwen2-VL-2B-Instruct"
+QWEN_QWEN2_VL_7B_INSTRUCT = "Qwen/Qwen2-VL-7B-Instruct"
+QWEN_QWEN2_5_OMNI_7B = "Qwen/Qwen2.5-Omni-7B"
+QWEN_QWEN2_5_VL_3B_INSTRUCT = "Qwen/Qwen2.5-VL-3B-Instruct"
+QWEN_QWEN2_5_VL_7B_INSTRUCT = "Qwen/Qwen2.5-VL-7B-Instruct"
+QWEN_QWEN2_5_1_5B_INSTRUCT = "Qwen/Qwen2.5-1.5B-Instruct"
+QWEN_QWEN3_0_6B = "Qwen/Qwen3-0.6B"
+QWEN_QWEN3_32B = "Qwen/Qwen3-32B"
+QWEN_QWEN3_235B_A22B_FP8 = "Qwen/Qwen3-235B-A22B-FP8"
+QWEN_QWEN3_5_0_8B = "Qwen/Qwen3.5-0.8B"
+QWEN_QWEN3_EMBEDDING_0_6B = "Qwen/Qwen3-Embedding-0.6B"
+QWEN_QWEN3_EMBEDDING_4B = "Qwen/Qwen3-Embedding-4B"
+QWEN_QWEN3_TTS_12HZ_1_7B_CUSTOMVOICE = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+QWEN_QWEN3_VL_2B_INSTRUCT = "Qwen/Qwen3-VL-2B-Instruct"
+QWEN_QWEN3_VL_2B_INSTRUCT_FP8 = "Qwen/Qwen3-VL-2B-Instruct-FP8"
+QWEN_QWEN3_VL_8B_INSTRUCT = "Qwen/Qwen3-VL-8B-Instruct"
+
+BLACK_FOREST_LABS_FLUX_2_KLEIN_4B = "black-forest-labs/FLUX.2-klein-4B"
+
+TINYLLAMA_TINYLLAMA_1_1B_CHAT_V1_0 = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+TINYLLAMA_TINYLLAMA_1_1B_INTERMEDIATE_STEP_1431K_3T = (
+    "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
+)
+
+TONGYI_MAI_Z_IMAGE_TURBO = "Tongyi-MAI/Z-Image-Turbo"
+
+WAN_AI_WAN2_1_T2V_1_3B_DIFFUSERS = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+WAN_AI_WAN2_2_TI2V_5B_DIFFUSERS = "Wan-AI/Wan2.2-TI2V-5B-Diffusers"
+
+CODELION_QWEN3_0_6B_ACCURACY_RECOVERY_LORA = (
+    "codelion/Qwen3-0.6B-accuracy-recovery-lora"
+)
+
+DEEPSEEK_AI_DEEPSEEK_R1_DISTILL_LLAMA_8B = "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+DEEPSEEK_AI_DEEPSEEK_V2_LITE = "deepseek-ai/DeepSeek-V2-Lite"
+DEEPSEEK_AI_DEEPSEEK_LLM_7B_BASE = "deepseek-ai/deepseek-llm-7b-base"
+
+BAAI_BGE_SMALL_EN_V1_5 = "BAAI/bge-small-en-v1.5"
+CROSS_ENCODER_NLI_MINILM2_L6_H768 = "cross-encoder/nli-MiniLM2-L6-H768"
+GOOGLE_GEMMA_4_E2B_IT = "google/gemma-4-E2B-it"
+GOOGLE_GEMMA_3_4B_IT = "google/gemma-3-4b-it"
+INCLUSIONAI_LLADA2_0_MINI_PREVIEW = "inclusionAI/LLaDA2.0-mini-preview"
+LLAVA_HF_LLAVA_1_5_7B_HF = "llava-hf/llava-1.5-7b-hf"
+LLAVA_HF_LLAVA_V1_6_MISTRAL_7B_HF = "llava-hf/llava-v1.6-mistral-7b-hf"
+MICROSOFT_PHI_3_VISION_128K_INSTRUCT = "microsoft/Phi-3-vision-128k-instruct"
+MISTRALAI_MINISTRAL_3_3B_REASONING_2512 = "mistralai/Ministral-3-3B-Reasoning-2512"
+OPENAI_GPT_OSS_20B = "openai/gpt-oss-20b"
+META_LLAMA_META_LLAMA_3_1_70B = "meta-llama/Meta-Llama-3.1-70B"
+META_LLAMA_META_LLAMA_3_1_8B_INSTRUCT = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+SILENCE09_DEEPSEEK_R1_SMALL_2LAYERS = "silence09/DeepSeek-R1-Small-2layers"
+YUHUILI_EAGLE3_LLAMA3_1_INSTRUCT_8B = "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B"
+ZAI_ORG_GLM_IMAGE = "zai-org/GLM-Image"
+
+
+def constant_name_for_repo_id(repo_id: str) -> str:
+    """Return the exported constant name for a Hugging Face repo id."""
+
+    return (
+        repo_id.upper()
+        .replace("/", "_")
+        .replace("-", "_")
+        .replace(".", "_")
+        .replace("__", "_")
+    )
+
+
+MODEL_SPECS: tuple[ModelSpec, ...] = (
+    ModelSpec(
+        repo_id=BAAI_BGE_SMALL_EN_V1_5,
+        snapshot_size_gib=0.4,
+        kind="embedding",
+        architecture_tags=("bert", "dense", "encoder"),
+    ),
+    ModelSpec(
+        repo_id=CROSS_ENCODER_NLI_MINILM2_L6_H768,
+        snapshot_size_gib=2.7,
+        kind="reranker",
+        architecture_tags=("dense", "encoder", "roberta"),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN_IMAGE,
+        snapshot_size_gib=53.7,
+        kind="image_generation",
+        architecture_tags=("diffusion", "image"),
+        over_cap_exception=True,
+        exception_reason=(
+            "Legacy skipped vLLM-Omni image-generation coverage; exceeds "
+            "CI capacity and should be replaced."
+        ),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN2_AUDIO_7B_INSTRUCT,
+        snapshot_size_gib=15.7,
+        kind="audio_text_to_text",
+        architecture_tags=("audio", "dense", "multimodal"),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN2_VL_2B_INSTRUCT,
+        snapshot_size_gib=4.1,
+        kind="vlm",
+        architecture_tags=("dense", "gqa", "vision"),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN2_VL_7B_INSTRUCT,
+        snapshot_size_gib=15.5,
+        kind="vlm",
+        architecture_tags=("dense", "gqa", "vision"),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN2_5_OMNI_7B,
+        snapshot_size_gib=20.8,
+        kind="omni",
+        architecture_tags=("audio", "dense", "multimodal", "vision"),
+        over_cap_exception=True,
+        exception_reason=(
+            "Legacy skipped vLLM-Omni text coverage; exceeds the default "
+            "CI snapshot cap."
+        ),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN2_5_VL_3B_INSTRUCT,
+        snapshot_size_gib=7.0,
+        kind="vlm",
+        architecture_tags=("dense", "gqa", "vision"),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN2_5_1_5B_INSTRUCT,
+        snapshot_size_gib=2.9,
+        kind="llm",
+        architecture_tags=("dense", "gqa"),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN2_5_VL_7B_INSTRUCT,
+        snapshot_size_gib=15.5,
+        kind="vlm",
+        architecture_tags=("dense", "gqa", "vision"),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN3_0_6B,
+        snapshot_size_gib=1.4,
+        kind="llm",
+        architecture_tags=("dense", "gqa"),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN3_32B,
+        snapshot_size_gib=61.0,
+        kind="llm",
+        architecture_tags=("aic_metadata", "dense", "gqa"),
+        download_required=False,
+        over_cap_exception=True,
+        exception_reason=(
+            "Used as AIC metadata in router tests; not predownloaded by CI."
+        ),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN3_235B_A22B_FP8,
+        snapshot_size_gib=222.6,
+        kind="llm",
+        architecture_tags=("fp8", "gqa", "moe"),
+        over_cap_exception=True,
+        exception_reason="H100 DGDR deployment coverage for a large FP8 MoE model.",
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN3_5_0_8B,
+        snapshot_size_gib=1.6,
+        kind="vlm",
+        architecture_tags=("dense", "hybrid_attention", "mamba", "vision"),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN3_EMBEDDING_0_6B,
+        snapshot_size_gib=1.2,
+        kind="embedding",
+        architecture_tags=("dense", "gqa"),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN3_EMBEDDING_4B,
+        snapshot_size_gib=7.5,
+        kind="embedding",
+        architecture_tags=("dense", "gqa"),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN3_TTS_12HZ_1_7B_CUSTOMVOICE,
+        snapshot_size_gib=4.2,
+        kind="tts",
+        architecture_tags=("audio", "dense"),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN3_VL_2B_INSTRUCT,
+        snapshot_size_gib=4.0,
+        kind="vlm",
+        architecture_tags=("dense", "gqa", "vision"),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN3_VL_2B_INSTRUCT_FP8,
+        snapshot_size_gib=3.3,
+        kind="vlm",
+        architecture_tags=("fp8", "gqa", "vision"),
+    ),
+    ModelSpec(
+        repo_id=QWEN_QWEN3_VL_8B_INSTRUCT,
+        snapshot_size_gib=16.3,
+        kind="vlm",
+        architecture_tags=("dense", "gqa", "vision"),
+    ),
+    ModelSpec(
+        repo_id=BLACK_FOREST_LABS_FLUX_2_KLEIN_4B,
+        snapshot_size_gib=22.1,
+        kind="image_generation",
+        architecture_tags=("diffusion", "image"),
+        over_cap_exception=True,
+        exception_reason=(
+            "Current TRT-LLM diffusion pre-merge smoke coverage; exceeds "
+            "the default CI snapshot cap."
+        ),
+    ),
+    ModelSpec(
+        repo_id=TINYLLAMA_TINYLLAMA_1_1B_CHAT_V1_0,
+        snapshot_size_gib=2.1,
+        kind="llm",
+        architecture_tags=("dense", "gqa"),
+    ),
+    ModelSpec(
+        repo_id=TINYLLAMA_TINYLLAMA_1_1B_INTERMEDIATE_STEP_1431K_3T,
+        snapshot_size_gib=8.2,
+        kind="llm",
+        architecture_tags=("dense", "gqa"),
+    ),
+    ModelSpec(
+        repo_id=TONGYI_MAI_Z_IMAGE_TURBO,
+        snapshot_size_gib=30.6,
+        kind="image_generation",
+        architecture_tags=("diffusion", "image"),
+        over_cap_exception=True,
+        exception_reason=(
+            "Current SGLang diffusion nightly coverage; exceeds the "
+            "default CI snapshot cap."
+        ),
+    ),
+    ModelSpec(
+        repo_id=WAN_AI_WAN2_1_T2V_1_3B_DIFFUSERS,
+        snapshot_size_gib=26.9,
+        kind="video_generation",
+        architecture_tags=("diffusion", "video"),
+        over_cap_exception=True,
+        exception_reason=(
+            "Current TRT-LLM/vLLM-Omni video-generation CI coverage; "
+            "replace with a smaller fixture when available."
+        ),
+    ),
+    ModelSpec(
+        repo_id=WAN_AI_WAN2_2_TI2V_5B_DIFFUSERS,
+        snapshot_size_gib=31.9,
+        kind="video_generation",
+        architecture_tags=("diffusion", "image_to_video", "video"),
+        over_cap_exception=True,
+        exception_reason=(
+            "Current vLLM-Omni image-to-video CI coverage; replace with a "
+            "smaller fixture when available."
+        ),
+    ),
+    ModelSpec(
+        repo_id=CODELION_QWEN3_0_6B_ACCURACY_RECOVERY_LORA,
+        snapshot_size_gib=0.2,
+        kind="lora_adapter",
+        architecture_tags=("adapter", "lora"),
+    ),
+    ModelSpec(
+        repo_id=DEEPSEEK_AI_DEEPSEEK_R1_DISTILL_LLAMA_8B,
+        snapshot_size_gib=15.0,
+        kind="llm",
+        architecture_tags=("dense", "gqa"),
+    ),
+    ModelSpec(
+        repo_id=DEEPSEEK_AI_DEEPSEEK_V2_LITE,
+        snapshot_size_gib=29.3,
+        kind="llm",
+        architecture_tags=("mla", "moe"),
+        over_cap_exception=True,
+        exception_reason=(
+            "Legacy MoE/MLA coverage for vLLM, KVBM, and fault-tolerance "
+            "tests; intentionally noisy until reduced."
+        ),
+    ),
+    ModelSpec(
+        repo_id=DEEPSEEK_AI_DEEPSEEK_LLM_7B_BASE,
+        snapshot_size_gib=12.9,
+        kind="llm",
+        architecture_tags=("dense", "mha"),
+    ),
+    ModelSpec(
+        repo_id=GOOGLE_GEMMA_4_E2B_IT,
+        snapshot_size_gib=9.6,
+        kind="vlm",
+        architecture_tags=("dense", "vision"),
+    ),
+    ModelSpec(
+        repo_id=GOOGLE_GEMMA_3_4B_IT,
+        snapshot_size_gib=8.0,
+        kind="vlm",
+        architecture_tags=("dense", "gated", "vision"),
+        gated=True,
+    ),
+    ModelSpec(
+        repo_id=INCLUSIONAI_LLADA2_0_MINI_PREVIEW,
+        snapshot_size_gib=30.3,
+        kind="llm",
+        architecture_tags=("diffusion", "moe"),
+        over_cap_exception=True,
+        exception_reason="SGLang diffusion-language-model coverage.",
+    ),
+    ModelSpec(
+        repo_id=LLAVA_HF_LLAVA_1_5_7B_HF,
+        snapshot_size_gib=13.2,
+        kind="vlm",
+        architecture_tags=("dense", "vision"),
+    ),
+    ModelSpec(
+        repo_id=LLAVA_HF_LLAVA_V1_6_MISTRAL_7B_HF,
+        snapshot_size_gib=14.1,
+        kind="vlm",
+        architecture_tags=("dense", "vision"),
+    ),
+    ModelSpec(
+        repo_id=MICROSOFT_PHI_3_VISION_128K_INSTRUCT,
+        snapshot_size_gib=7.7,
+        kind="vlm",
+        architecture_tags=("dense", "vision"),
+    ),
+    ModelSpec(
+        repo_id=MISTRALAI_MINISTRAL_3_3B_REASONING_2512,
+        snapshot_size_gib=14.4,
+        kind="llm",
+        architecture_tags=("dense", "gqa"),
+    ),
+    ModelSpec(
+        repo_id=OPENAI_GPT_OSS_20B,
+        snapshot_size_gib=38.5,
+        kind="llm",
+        architecture_tags=("gqa", "moe"),
+        over_cap_exception=True,
+        exception_reason=(
+            "Required by current GPT-OSS reasoning/tool-calling frontend "
+            "coverage; exceeds CI size cap."
+        ),
+    ),
+    ModelSpec(
+        repo_id=META_LLAMA_META_LLAMA_3_1_70B,
+        snapshot_size_gib=131.0,
+        kind="llm",
+        architecture_tags=("dense", "gated", "gqa"),
+        gated=True,
+        over_cap_exception=True,
+        exception_reason="H100 DGDR deployment coverage for Llama 3.1 70B.",
+    ),
+    ModelSpec(
+        repo_id=META_LLAMA_META_LLAMA_3_1_8B_INSTRUCT,
+        snapshot_size_gib=15.0,
+        kind="llm",
+        architecture_tags=("dense", "gated", "gqa"),
+        gated=True,
+    ),
+    ModelSpec(
+        repo_id=SILENCE09_DEEPSEEK_R1_SMALL_2LAYERS,
+        snapshot_size_gib=4.5,
+        kind="llm",
+        architecture_tags=("mla", "moe"),
+    ),
+    ModelSpec(
+        repo_id=YUHUILI_EAGLE3_LLAMA3_1_INSTRUCT_8B,
+        snapshot_size_gib=0.9,
+        kind="speculative_draft",
+        architecture_tags=("dense", "eagle3", "gqa"),
+    ),
+    ModelSpec(
+        repo_id=ZAI_ORG_GLM_IMAGE,
+        snapshot_size_gib=33.3,
+        kind="image_generation",
+        architecture_tags=("diffusion", "image"),
+        over_cap_exception=True,
+        exception_reason=(
+            "Legacy skipped vLLM-Omni image-generation coverage; exceeds "
+            "CI capacity and should be replaced."
+        ),
+    ),
+)
+
+MODEL_REGISTRY: dict[str, ModelSpec] = {spec.repo_id: spec for spec in MODEL_SPECS}
+
+
+DEFAULT_TEST_MODELS = (
+    QWEN_QWEN3_0_6B,
+    DEEPSEEK_AI_DEEPSEEK_R1_DISTILL_LLAMA_8B,
+    OPENAI_GPT_OSS_20B,
+    QWEN_QWEN3_EMBEDDING_4B,
+)
+
+
+def get_model_spec(repo_id: str) -> ModelSpec:
+    try:
+        return MODEL_REGISTRY[repo_id]
+    except KeyError as exc:
+        raise KeyError(
+            f"{repo_id!r} is not registered in tests.utils.model_registry. "
+            "Add a ModelSpec with HF snapshot size and architecture metadata."
+        ) from exc
+
+
+def validate_ci_model_ids(repo_ids: Iterable[str]) -> tuple[str, ...]:
+    """Validate and normalize CI model ids collected from pytest marks."""
+
+    unique_repo_ids = tuple(dict.fromkeys(repo_ids))
+    missing = [repo_id for repo_id in unique_repo_ids if repo_id not in MODEL_REGISTRY]
+    if missing:
+        raise ValueError(
+            "Unregistered CI model id(s): "
+            + ", ".join(sorted(missing))
+            + ". Add them to tests.utils.model_registry before using them in CI."
+        )
+    return unique_repo_ids
+
+
+def downloadable_model_ids(repo_ids: Iterable[str]) -> tuple[str, ...]:
+    """Return registered ids that should be downloaded by CI predownload fixtures."""
+
+    return tuple(
+        repo_id
+        for repo_id in validate_ci_model_ids(repo_ids)
+        if MODEL_REGISTRY[repo_id].download_required
+    )

--- a/tests/utils/model_registry.py
+++ b/tests/utils/model_registry.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 DEFAULT_CI_MODEL_SNAPSHOT_CAP_GIB = 20.0
+GLOBAL_CI_MODEL_OVERRIDE_ENV_VAR = "DYN_CI_MODEL"
 
 
 @dataclass(frozen=True)
@@ -67,6 +68,7 @@ class ModelProfile:
     default_repo_id: str
     query: ModelQuery
     override_env_var: str
+    allow_global_override: bool = True
 
 
 QWEN_QWEN_IMAGE = "Qwen/Qwen-Image"
@@ -560,6 +562,7 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
             max_parameter_count_millions=700,
         ),
         override_env_var="DYN_CI_KV_TRANSFER_MODEL",
+        allow_global_override=False,
     ),
     "sglang_smoke": ModelProfile(
         default_repo_id=QWEN_QWEN3_0_6B,
@@ -679,8 +682,16 @@ def resolve_model_profile(profile_name: str, *, override: str | None = None) -> 
             f"Unknown CI model profile {profile_name!r}; choose {choices}"
         ) from exc
 
-    repo_id = override or os.environ.get(
-        profile.override_env_var, profile.default_repo_id
+    global_override = (
+        os.environ.get(GLOBAL_CI_MODEL_OVERRIDE_ENV_VAR)
+        if profile.allow_global_override
+        else None
+    )
+    repo_id = (
+        override
+        or os.environ.get(profile.override_env_var)
+        or global_override
+        or profile.default_repo_id
     )
     spec = get_model_spec(repo_id)
     if not model_matches_query(spec, profile.query):

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -652,12 +652,9 @@ def run_parallel(
     pending = list(tests)
     running: dict[int, _RunningTest] = {}
     next_status = t0 + 10
-    # vLLM needs a stagger because --gpu-memory-utilization triggers a memory
-    # profiling step that snapshots free memory — concurrent launches corrupt
-    # each other's snapshots (bug #10643). SGLang uses --max-total-tokens
-    # which is deterministic, so no stagger is needed.
-    _VLLM_LAUNCH_STAGGER_S = 5.0
-    last_vllm_launch: dict[int, float] = {}  # gpu_index -> monotonic timestamp
+    # Every scheduled GPU test has an explicit runtime-specific KV cap. In
+    # particular, --kv-cache-memory-bytes makes vLLM skip memory profiling, so
+    # capped vLLM launches are safe to start concurrently on the same GPU.
 
     def _build_status_lines(now: float) -> list[str]:
         """Build per-GPU status lines for periodic output."""
@@ -869,8 +866,7 @@ def run_parallel(
         # _select_launches packs VRAM tests up to budget (pairing a big test
         # with smaller ones), backfills spare slots with zero-VRAM fillers, and
         # reserves space for a blocked high-priority test so it can't be starved
-        # onto the tail. The vLLM stagger below is per-GPU only — tests on
-        # different GPUs launch simultaneously.
+        # onto the tail.
         if pending and len(running) < num_slots:
             actual_free = {
                 gi: gs.total_gib - _get_gpu_used_gib(gi)
@@ -897,26 +893,10 @@ def run_parallel(
                 w_id = entry.w_id
                 gi = entry.assigned_gpu
                 assert gi is not None
-                is_vllm = (
-                    entry.requested_vllm_kv_cache_bytes is not None
-                    and entry.profiled_gib > 0
-                )
-
-                # Per-GPU vLLM stagger — only between vLLM tests on the
-                # same GPU.  Tests on different GPUs launch simultaneously.
-                if is_vllm:
-                    last_t = last_vllm_launch.get(gi, 0)
-                    wait = _VLLM_LAUNCH_STAGGER_S - (time.monotonic() - last_t)
-                    if wait > 0:
-                        time.sleep(wait)
-
                 gpu_states[gi].budget_used += entry.profiled_gib
                 gpu_states[gi].running_count += 1
                 run_info = _launch_test(entry, env_base)
                 running[w_id] = run_info
-
-                if is_vllm:
-                    last_vllm_launch[gi] = time.monotonic()
 
                 retry_str = f" (retry {entry.retries})" if entry.retries else ""
                 _print(

--- a/tests/utils/test_model_registry.py
+++ b/tests/utils/test_model_registry.py
@@ -12,6 +12,7 @@ from tests.conftest import _collect_models_to_download
 from tests.utils import model_registry
 from tests.utils.model_registry import (
     DEFAULT_CI_MODEL_SNAPSHOT_CAP_GIB,
+    GLOBAL_CI_MODEL_OVERRIDE_ENV_VAR,
     MODEL_PROFILES,
     MODEL_REGISTRY,
     MODEL_SPECS,
@@ -156,7 +157,9 @@ def test_model_registry_invariants_and_size_policy():
     assert model_registry.downloadable_model_ids([model_registry.QWEN_QWEN3_32B]) == ()
 
 
-def test_characteristic_selection_is_smallest_first_and_profiles_are_safe():
+def test_characteristic_selection_is_smallest_first_and_profiles_are_safe(
+    monkeypatch,
+):
     candidates = select_models(
         ModelQuery(
             kind="llm",
@@ -182,6 +185,29 @@ def test_characteristic_selection_is_smallest_first_and_profiles_are_safe():
             "trtllm_smoke", override=model_registry.GOOGLE_GEMMA_3_270M_IT
         )
         == model_registry.GOOGLE_GEMMA_3_270M_IT
+    )
+
+    monkeypatch.setenv(
+        GLOBAL_CI_MODEL_OVERRIDE_ENV_VAR, model_registry.GOOGLE_GEMMA_3_270M_IT
+    )
+    for profile_name in (
+        "cross_backend_smoke",
+        "sglang_smoke",
+        "trtllm_smoke",
+        "vllm_smoke",
+    ):
+        assert (
+            resolve_model_profile(profile_name) == model_registry.GOOGLE_GEMMA_3_270M_IT
+        )
+    assert resolve_model_profile("kv_transfer") == model_registry.QWEN_QWEN3_0_6B
+
+    monkeypatch.setenv(
+        "DYN_CI_VLLM_SMOKE_MODEL",
+        model_registry.IBM_GRANITE_GRANITE_4_0_H_350M,
+    )
+    assert (
+        resolve_model_profile("vllm_smoke")
+        == model_registry.IBM_GRANITE_GRANITE_4_0_H_350M
     )
     with pytest.raises(ValueError, match="does not satisfy"):
         resolve_model_profile(

--- a/tests/utils/test_model_registry.py
+++ b/tests/utils/test_model_registry.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import _collect_models_to_download
+from tests.utils import model_registry
+from tests.utils.model_registry import (
+    DEFAULT_CI_MODEL_SNAPSHOT_CAP_GIB,
+    MODEL_REGISTRY,
+    MODEL_SPECS,
+    constant_name_for_repo_id,
+    downloadable_model_ids,
+    validate_ci_model_ids,
+)
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.parallel,
+    pytest.mark.gpu_0,
+]
+
+
+_QUOTED_REPO_ID_RE = re.compile(
+    r"""["']([A-Za-z0-9][A-Za-z0-9_.-]+/[A-Za-z0-9][A-Za-z0-9_.-]+)["']"""
+)
+
+_NON_MODEL_REPO_LIKE_STRINGS = {
+    "A100/H100",
+    "A6000/A40",
+    "America/Los_Angeles",
+    "Frontend/Router",
+    "Offload/Onboard",
+    "app.kubernetes.io/name",
+    "application/json",
+    "bin/compliance-test.ts",
+    "cais/mmlu",
+    "chaos-mesh.org/v1alpha1",
+    "components/src",
+    "container/build.sh",
+    "data/dev",
+    "data/test",
+    "edge/embedded",
+    "image/png",
+    "kubernetes.io/hostname",
+    "kubernetes.io/metadata.name",
+    "launch/lora",
+    "lora/agg_lora.sh",
+    "lora/agg_lora_router.sh",
+    "networking.k8s.io/v1",
+    "node_name/gpu0",
+    "nvidia.com/enable-grove",
+    "nvidia.com/v1alpha1",
+    "nvidia.com/v1beta1",
+    "pods/exec",
+    "test.dynamo/managed",
+    "test.fault-injection/cordoned",
+    "test.fault-injection/reason",
+    "tests/serve",
+    "tests/test_models_dir_flag.py",
+    # A deliberately fake served-model id used by a frontend protocol unit test.
+    "Qwen/Qwen3-Coder",
+    "xpu/agg_lmcache_multiproc_xpu.sh",
+    "xpu/agg_lmcache_xpu.sh",
+    "xpu/agg_multimodal_xpu.sh",
+    "xpu/agg_request_planes_xpu.sh",
+    "xpu/agg_router_approx_xpu.sh",
+    "xpu/agg_router_xpu.sh",
+    "xpu/agg_xpu.sh",
+}
+
+
+class _DummyMark:
+    def __init__(self, name: str, *args):
+        self.name = name
+        self.args = args
+
+
+class _DummyItem:
+    own_markers: list[_DummyMark]
+
+    def __init__(self, model_id: str, *, skipped: bool = False):
+        self.own_markers = [_DummyMark("skip")] if skipped else []
+        self._model_mark = _DummyMark("model", model_id)
+
+    def iter_markers(self, marker_name: str):
+        if marker_name == "model":
+            return iter([self._model_mark])
+        return iter(())
+
+
+def test_model_registry_metadata_is_complete():
+    assert MODEL_REGISTRY
+    assert len(MODEL_REGISTRY) == len(MODEL_SPECS)
+    for repo_id, spec in MODEL_REGISTRY.items():
+        assert repo_id == spec.repo_id
+        assert re.fullmatch(
+            r"[A-Za-z0-9][A-Za-z0-9_.-]+/[A-Za-z0-9][A-Za-z0-9_.-]+",
+            spec.repo_id,
+        )
+        assert spec.hf_url == f"https://huggingface.co/{spec.repo_id}"
+        assert spec.snapshot_size_gib > 0
+        assert spec.kind
+        assert spec.architecture_tags
+        assert tuple(sorted(set(spec.architecture_tags))) == spec.architecture_tags
+
+
+def test_model_registry_constant_exports_match_repo_ids():
+    for repo_id in MODEL_REGISTRY:
+        constant_name = constant_name_for_repo_id(repo_id)
+        assert hasattr(model_registry, constant_name), repo_id
+        assert getattr(model_registry, constant_name) == repo_id
+
+
+def test_model_registry_size_policy():
+    unapproved = [
+        spec.repo_id
+        for spec in MODEL_REGISTRY.values()
+        if spec.download_required
+        and spec.snapshot_size_gib > DEFAULT_CI_MODEL_SNAPSHOT_CAP_GIB
+        and not spec.over_cap_exception
+    ]
+    assert unapproved == []
+
+    for spec in MODEL_REGISTRY.values():
+        if spec.over_cap_exception:
+            assert spec.snapshot_size_gib > DEFAULT_CI_MODEL_SNAPSHOT_CAP_GIB
+            assert spec.exception_reason
+        elif spec.download_required:
+            assert spec.snapshot_size_gib <= DEFAULT_CI_MODEL_SNAPSHOT_CAP_GIB
+
+
+def test_downloadable_model_ids_skip_metadata_only_models():
+    assert downloadable_model_ids([model_registry.QWEN_QWEN3_32B]) == ()
+
+
+def test_validate_ci_model_ids_rejects_unknown_models():
+    with pytest.raises(ValueError, match="Unregistered CI model"):
+        validate_ci_model_ids(["unknown-org/unknown-model"])
+
+
+def test_collection_model_smoke_validates_and_skips_skipped_items():
+    items = [
+        _DummyItem(model_registry.QWEN_QWEN3_0_6B),
+        _DummyItem("unknown-org/unknown-model", skipped=True),
+    ]
+
+    assert _collect_models_to_download(items) == {model_registry.QWEN_QWEN3_0_6B}
+
+
+def test_ci_test_model_literals_are_registered():
+    tests_dir = Path(__file__).resolve().parents[1]
+    found: set[str] = set()
+
+    for path in tests_dir.rglob("*"):
+        if not path.is_file() or "__pycache__" in path.parts:
+            continue
+        if path == Path(__file__).resolve():
+            continue
+        if path.suffix not in {".py", ".sh", ".yaml", ".yml"}:
+            continue
+        text = path.read_text(errors="ignore")
+        found.update(match.group(1) for match in _QUOTED_REPO_ID_RE.finditer(text))
+
+    unknown = sorted(found - set(MODEL_REGISTRY) - _NON_MODEL_REPO_LIKE_STRINGS)
+    assert unknown == []

--- a/tests/utils/test_model_registry.py
+++ b/tests/utils/test_model_registry.py
@@ -12,11 +12,12 @@ from tests.conftest import _collect_models_to_download
 from tests.utils import model_registry
 from tests.utils.model_registry import (
     DEFAULT_CI_MODEL_SNAPSHOT_CAP_GIB,
+    MODEL_PROFILES,
     MODEL_REGISTRY,
     MODEL_SPECS,
-    constant_name_for_repo_id,
-    downloadable_model_ids,
-    validate_ci_model_ids,
+    ModelQuery,
+    resolve_model_profile,
+    select_models,
 )
 
 pytestmark = [
@@ -39,40 +40,66 @@ _NON_MODEL_REPO_LIKE_STRINGS = {
     "Offload/Onboard",
     "app.kubernetes.io/name",
     "application/json",
+    "application/octet-stream",
+    "benchmarks/pyproject.toml",
     "bin/compliance-test.ts",
     "cais/mmlu",
     "chaos-mesh.org/v1alpha1",
     "components/src",
+    "components/leaf",
+    "components/parent",
+    "capacity/fast",
+    "capacity/other",
+    "capacity/slow",
+    "control/sleep",
     "container/build.sh",
     "data/dev",
     "data/test",
     "edge/embedded",
+    "examples/custom_encoder",
     "image/png",
     "kubernetes.io/hostname",
     "kubernetes.io/metadata.name",
+    "kustomize/base",
+    "kvbm_integration/t8.shakespeare.txt",
     "launch/lora",
     "lora/agg_lora.sh",
     "lora/agg_lora_router.sh",
     "networking.k8s.io/v1",
     "node_name/gpu0",
     "nvidia.com/enable-grove",
+    "nvidia.com/dynamo-graph-deployment-name",
+    "nvidia.com/gpu",
+    "nvidia.com/gpu.present",
+    "nvidia.com/mig.config",
+    "nvidia.com/snapshot-checkpoint-id",
+    "nvidia.com/snapshot-is-checkpoint-source",
+    "nvidia.com/snapshot-is-restore-target",
+    "nvidia.com/snapshot-target-containers",
     "nvidia.com/v1alpha1",
     "nvidia.com/v1beta1",
     "pods/exec",
+    "scripts/generate_kustomize_openapi.py",
+    "scripts/kustomize-matrix.py",
+    "systems/h200_sxm.yaml",
     "test.dynamo/managed",
     "test.fault-injection/cordoned",
     "test.fault-injection/reason",
     "tests/serve",
     "tests/test_models_dir_flag.py",
+    "video/mp4",
     # A deliberately fake served-model id used by a frontend protocol unit test.
     "Qwen/Qwen3-Coder",
     "xpu/agg_lmcache_multiproc_xpu.sh",
     "xpu/agg_lmcache_xpu.sh",
     "xpu/agg_multimodal_xpu.sh",
+    "xpu/agg_multimodal_router_chat_processor_xpu.sh",
+    "xpu/agg_multimodal_router_xpu.sh",
     "xpu/agg_request_planes_xpu.sh",
     "xpu/agg_router_approx_xpu.sh",
     "xpu/agg_router_xpu.sh",
     "xpu/agg_xpu.sh",
+    "model_configs/Qwen--Qwen3-32B_config.json",
 }
 
 
@@ -95,7 +122,7 @@ class _DummyItem:
         return iter(())
 
 
-def test_model_registry_metadata_is_complete():
+def test_model_registry_invariants_and_size_policy():
     assert MODEL_REGISTRY
     assert len(MODEL_REGISTRY) == len(MODEL_SPECS)
     for repo_id, spec in MODEL_REGISTRY.items():
@@ -107,26 +134,11 @@ def test_model_registry_metadata_is_complete():
         assert spec.hf_url == f"https://huggingface.co/{spec.repo_id}"
         assert spec.snapshot_size_gib > 0
         assert spec.kind
-        assert spec.architecture_tags
-        assert tuple(sorted(set(spec.architecture_tags))) == spec.architecture_tags
-
-
-def test_model_registry_constant_exports_match_repo_ids():
-    for repo_id in MODEL_REGISTRY:
-        constant_name = constant_name_for_repo_id(repo_id)
-        assert hasattr(model_registry, constant_name), repo_id
+        assert spec.characteristics
+        assert tuple(sorted(set(spec.characteristics))) == spec.characteristics
+        assert tuple(sorted(set(spec.backends))) == spec.backends
+        constant_name = model_registry.constant_name_for_repo_id(repo_id)
         assert getattr(model_registry, constant_name) == repo_id
-
-
-def test_model_registry_size_policy():
-    unapproved = [
-        spec.repo_id
-        for spec in MODEL_REGISTRY.values()
-        if spec.download_required
-        and spec.snapshot_size_gib > DEFAULT_CI_MODEL_SNAPSHOT_CAP_GIB
-        and not spec.over_cap_exception
-    ]
-    assert unapproved == []
 
     for spec in MODEL_REGISTRY.values():
         if spec.over_cap_exception:
@@ -135,14 +147,51 @@ def test_model_registry_size_policy():
         elif spec.download_required:
             assert spec.snapshot_size_gib <= DEFAULT_CI_MODEL_SNAPSHOT_CAP_GIB
 
+    for profile_name, profile in MODEL_PROFILES.items():
+        assert (
+            resolve_model_profile(profile_name, override=profile.default_repo_id)
+            == profile.default_repo_id
+        )
 
-def test_downloadable_model_ids_skip_metadata_only_models():
-    assert downloadable_model_ids([model_registry.QWEN_QWEN3_32B]) == ()
+    assert model_registry.downloadable_model_ids([model_registry.QWEN_QWEN3_32B]) == ()
 
 
-def test_validate_ci_model_ids_rejects_unknown_models():
-    with pytest.raises(ValueError, match="Unregistered CI model"):
-        validate_ci_model_ids(["unknown-org/unknown-model"])
+def test_characteristic_selection_is_smallest_first_and_profiles_are_safe():
+    candidates = select_models(
+        ModelQuery(
+            kind="llm",
+            required_characteristics=frozenset(
+                {"instruction_tuned", "small_ci_candidate", "text_generation"}
+            ),
+            required_backends=frozenset({"vllm"}),
+            max_parameter_count_millions=400,
+        )
+    )
+    assert [spec.repo_id for spec in candidates] == [
+        model_registry.IBM_GRANITE_GRANITE_4_0_H_350M,
+        model_registry.LIQUIDAI_LFM2_5_350M,
+    ]
+    assert (
+        resolve_model_profile(
+            "vllm_smoke", override=model_registry.IBM_GRANITE_GRANITE_4_0_H_350M
+        )
+        == model_registry.IBM_GRANITE_GRANITE_4_0_H_350M
+    )
+    assert (
+        resolve_model_profile(
+            "trtllm_smoke", override=model_registry.GOOGLE_GEMMA_3_270M_IT
+        )
+        == model_registry.GOOGLE_GEMMA_3_270M_IT
+    )
+    with pytest.raises(ValueError, match="does not satisfy"):
+        resolve_model_profile(
+            "trtllm_smoke",
+            override=model_registry.IBM_GRANITE_GRANITE_4_0_H_350M,
+        )
+    with pytest.raises(ValueError, match="does not satisfy"):
+        resolve_model_profile(
+            "kv_transfer", override=model_registry.LIQUIDAI_LFM2_5_350M
+        )
 
 
 def test_collection_model_smoke_validates_and_skips_skipped_items():
@@ -152,6 +201,8 @@ def test_collection_model_smoke_validates_and_skips_skipped_items():
     ]
 
     assert _collect_models_to_download(items) == {model_registry.QWEN_QWEN3_0_6B}
+    with pytest.raises(ValueError, match="Unregistered CI model"):
+        _collect_models_to_download([_DummyItem("unknown-org/unknown-model")])
 
 
 def test_ci_test_model_literals_are_registered():
@@ -163,7 +214,7 @@ def test_ci_test_model_literals_are_registered():
             continue
         if path == Path(__file__).resolve():
             continue
-        if path.suffix not in {".py", ".sh", ".yaml", ".yml"}:
+        if path.suffix not in {".json", ".py", ".sh", ".toml", ".yaml", ".yml"}:
             continue
         text = path.read_text(errors="ignore")
         found.update(match.group(1) for match in _QUOTED_REPO_ID_RE.finditer(text))

--- a/tests/utils/test_pytest_parallel_gpu.py
+++ b/tests/utils/test_pytest_parallel_gpu.py
@@ -276,7 +276,7 @@ def _legacy_select(pending, gpu_states, actual_free, num_slots, running_count):
 def _simulate_makespan(tests, *, num_slots, gpus_total, order_key, select) -> float:
     """Discrete-event makespan model of run_parallel's loop.
 
-    Polls/staggers are omitted (they affect both schedulers equally); GPU actual
+    Polls are omitted (they affect both schedulers equally); GPU actual
     usage is modeled as the sum of running tests' profiled VRAM. Returns the wall
     time in seconds.
     """


### PR DESCRIPTION
## Overview:

Centralize the models used by Dynamo CI, make generic test models selectable by declared capabilities, and reduce avoidable vLLM startup overhead.

This ports and extends the model-registry work from #9582 onto current `main`. It also adds a single `DYN_CI_MODEL` experiment switch for compatible smoke tests and documents measured vLLM startup behavior on H100.

## Details:

### Central CI model registry

- Adds 46 characterized `ModelSpec` entries in `tests/utils/model_registry.py`.
- Records snapshot size, model kind, architecture characteristics, supported backends, parameter count, context length, license, gating, download metadata, and documented size-cap exceptions.
- Validates every `@pytest.mark.model` dependency collected from the repository root.
- Statically scans model references under `tests/` so shell scripts, YAML, and other non-pytest assets cannot introduce an unregistered model.
- Retains exact model constants where behavior depends on a checkpoint or architecture, such as Qwen parsing, LoRA pairs, MLA, EAGLE, and KV transfer.

### Capability-based selection

- Adds validated profiles for cross-backend, vLLM, SGLang, TensorRT-LLM, and KV-transfer coverage.
- Allows selection by model kind, characteristics, backend, snapshot size, and parameter count.
- Adds role-specific overrides such as `DYN_CI_VLLM_SMOKE_MODEL`.
- Adds `DYN_CI_MODEL` to replace all compatible generic smoke roles for one CI invocation.
- Keeps KV-transfer and architecture-specific tests pinned so a broad experiment cannot silently invalidate their coverage.

The initial smaller candidates are:

| Model | Parameters | Snapshot | Backends | Notes |
|---|---:|---:|---|---|
| Gemma 3 270M IT | 270M | 0.54 GiB | vLLM, SGLang, TRT-LLM | Broadest smaller candidate; gated Gemma license |
| Granite 4.0 H 350M | 340M | 0.64 GiB | vLLM, SGLang | Apache-2.0 hybrid Mamba2 architecture |
| LFM2.5 350M | 350M | 0.66 GiB | vLLM, SGLang | Newer short-convolution hybrid; LFM license |

### Faster vLLM startup

- Removes the fixed five-second same-GPU vLLM launch stagger when tests provide deterministic memory caps.
- Skips the xdist-worker startup delay for explicitly capped vLLM launches.
- Uses explicit `--kv-cache-memory-bytes` values to avoid vLLM memory profiling.
- Documents when CI should use optimization level 0, persist compilation caches, force validated AOT cache loading, use startup plans, and predownload models.

Measured with upstream `vllm serve` 0.27.1 on an H100 80 GB:

| Configuration | Ready | Engine init |
|---|---:|---:|
| Qwen3-0.6B, `-O0`, warm/offline | 35.7 s | 2.07 s |
| Qwen3-0.6B, default `-O2`, cold compile | 79.3 s | 41.25 s |
| Qwen3-0.6B, default `-O2`, warm AOT cache | 30.3 s | 3.09 s |
| Gemma 3 270M IT, `-O0`, first load | 46.8 s | 3.25 s |

The cold `-O2` run spent 34.13 seconds in `torch.compile`. Gemma used 1,924 MiB versus Qwen's 2,586 MiB in the same capped setup, improving potential same-GPU packing even though a smaller checkpoint did not automatically improve cold readiness.

## User and developer impact:

- CI model changes now happen in one registry instead of scattered literals.
- Maintainers can compare a candidate across generic smoke coverage without editing test files:

  ```bash
  DYN_CI_MODEL=google/gemma-3-270m-it \
    python3 -m pytest -m 'pre_merge and (vllm or sglang or trtllm)' tests/
  ```

- Incompatible overrides fail during collection before acquiring a GPU.
- Explicitly capped vLLM tests can initialize concurrently without artificial sleeps.

## Where should the reviewer start?

1. `tests/utils/model_registry.py` — model metadata, capability queries, profiles, and overrides.
2. `tests/utils/test_model_registry.py` — registry completeness, size policy, and selection safety.
3. `tests/utils/constants.py` — generic CI roles and compatibility aliases.
4. `tests/utils/pytest_parallel_gpu.py` and `tests/serve/common.py` — startup-delay removal and safeguards.
5. `tests/VLLM_STARTUP.md` — benchmark methodology, results, and recommended policy.

## Validation:

- 17 focused registry and GPU-scheduler tests passed.
- Full pre-commit formatting, lint, model-policy, and pytest marker-report hooks passed.
- Repository collection covered 4,788 tests with no missing marker sets.
- Full marker collection also passed with `DYN_CI_MODEL=google/gemma-3-270m-it`.
- H100 generation checks returned HTTP 200 for Qwen, Gemma, Granite, and LFM candidates.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Supersedes #9582.
