### PR TITLE
test(vllm): re-enable aggregate migration matrix

### DIFF
--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -23,7 +23,11 @@ from tests.utils.payloads import check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_ports
 
 # Customized utils for migration tests
-from .utils import DynamoFrontendProcess, run_migration_test
+from .utils import (
+    DynamoFrontendProcess,
+    managed_processes_concurrently,
+    run_migration_test,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -251,38 +255,38 @@ def test_request_migration_vllm_aggregated(
     ) as frontend:
         logger.info("Frontend started successfully")
 
-        # Step 2: Start 2 workers
-        with DynamoWorkerProcess(
+        # Step 2: Start 2 independent workers concurrently
+        worker1 = DynamoWorkerProcess(
             request,
             "worker1",
             frontend.frontend_port,
             tmp_path,
             max_model_len=AGGREGATED_MAX_MODEL_LEN,
-        ) as worker1:
+        )
+        worker2 = DynamoWorkerProcess(
+            request,
+            "worker2",
+            frontend.frontend_port,
+            tmp_path,
+            max_model_len=AGGREGATED_MAX_MODEL_LEN,
+        )
+        with managed_processes_concurrently(worker1, worker2):
             logger.info(f"Worker 1 PID: {worker1.get_pid()}")
+            logger.info(f"Worker 2 PID: {worker2.get_pid()}")
 
-            with DynamoWorkerProcess(
-                request,
-                "worker2",
-                frontend.frontend_port,
-                tmp_path,
-                max_model_len=AGGREGATED_MAX_MODEL_LEN,
-            ) as worker2:
-                logger.info(f"Worker 2 PID: {worker2.get_pid()}")
-
-                # Step 3: Run migration test
-                run_migration_test(
-                    frontend,
-                    worker1,
-                    worker2,
-                    receiving_pattern="Decode Request ID: ",
-                    migration_limit=migration_limit,
-                    migration_max_seq_len=migration_max_seq_len,
-                    immediate_kill=immediate_kill,
-                    use_chat_completion=(request_api == "chat"),
-                    stream=stream,
-                    max_tokens=AGGREGATED_MAX_TOKENS,
-                )
+            # Step 3: Run migration test
+            run_migration_test(
+                frontend,
+                worker1,
+                worker2,
+                receiving_pattern="Decode Request ID: ",
+                migration_limit=migration_limit,
+                migration_max_seq_len=migration_max_seq_len,
+                immediate_kill=immediate_kill,
+                use_chat_completion=(request_api == "chat"),
+                stream=stream,
+                max_tokens=AGGREGATED_MAX_TOKENS,
+            )
 
 
 @pytest.mark.skip(reason="Prefill migration not yet supported")

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -112,24 +112,76 @@ MIGRATION_CASES = [
     ),
 ]
 
+# Decode migration injects the fault only after a response stream is
+# established, so unary responses are not an executable policy value here.
+# Retain one streaming case for each migration-policy outcome while balancing
+# both shutdown paths, APIs, and request-plane transports.
+DECODE_MIGRATION_CASES = [
+    pytest.param(
+        3,
+        None,
+        True,
+        "chat",
+        "nats",
+        id="migration_enabled-worker_failure-chat-stream-nats",
+    ),
+    pytest.param(
+        0,
+        None,
+        False,
+        "completion",
+        "nats",
+        id="migration_disabled-graceful_shutdown-completion-stream-nats",
+    ),
+    pytest.param(
+        3,
+        1,
+        True,
+        "completion",
+        "tcp",
+        id="max_seq_len_exceeded-worker-failure-completion-stream-tcp",
+    ),
+    pytest.param(
+        3,
+        1_000_000,
+        False,
+        "chat",
+        "tcp",
+        id="max_seq_len_not_exceeded-graceful-shutdown-chat-stream-tcp",
+    ),
+]
+
+MIGRATION_PARAMETERS = pytest.mark.parametrize(
+    (
+        "migration_limit",
+        "migration_max_seq_len",
+        "immediate_kill",
+        "request_api",
+        "stream",
+        "request_plane",
+    ),
+    MIGRATION_CASES,
+    indirect=["request_plane"],
+)
+
+DECODE_MIGRATION_PARAMETERS = pytest.mark.parametrize(
+    (
+        "migration_limit",
+        "migration_max_seq_len",
+        "immediate_kill",
+        "request_api",
+        "request_plane",
+    ),
+    DECODE_MIGRATION_CASES,
+    indirect=["request_plane"],
+)
+
 pytestmark = [
     pytest.mark.fault_tolerance,
     pytest.mark.vllm,
     pytest.mark.gpu_1,
     pytest.mark.e2e,
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
-    pytest.mark.parametrize(
-        (
-            "migration_limit",
-            "migration_max_seq_len",
-            "immediate_kill",
-            "request_api",
-            "stream",
-            "request_plane",
-        ),
-        MIGRATION_CASES,
-        indirect=["request_plane"],
-    ),
 ]
 
 
@@ -276,20 +328,23 @@ class DynamoWorkerProcess(ManagedProcess):
         try:
             data = response.json()
             if data.get("status") == "ready":
-                logger.info(f"{self.worker_id} status is ready")
+                logger.info("%s status is ready", self.worker_id)
                 return True
             logger.warning(
-                f"{self.worker_id} status is not ready: {data.get('status')}"
+                "%s status is not ready: %s",
+                self.worker_id,
+                data.get("status"),
             )
         except ValueError:
-            logger.warning(f"{self.worker_id} health response is not valid JSON")
+            logger.warning("%s health response is not valid JSON", self.worker_id)
         return False
 
 
 @pytest.mark.timeout(290)  # 3x average
-@pytest.mark.post_merge
+@pytest.mark.nightly
 @pytest.mark.profiled_vram_gib(4.8)
 @pytest.mark.requested_vllm_kv_cache_bytes(331_711_000)
+@MIGRATION_PARAMETERS
 def test_request_migration_vllm_aggregated(
     request,
     runtime_services_dynamic_ports,
@@ -337,8 +392,8 @@ def test_request_migration_vllm_aggregated(
             max_model_len=AGGREGATED_MAX_MODEL_LEN,
         )
         with managed_processes_concurrently(worker1, worker2):
-            logger.info(f"Worker 1 PID: {worker1.get_pid()}")
-            logger.info(f"Worker 2 PID: {worker2.get_pid()}")
+            logger.info("Worker 1 PID: %s", worker1.get_pid())
+            logger.info("Worker 2 PID: %s", worker2.get_pid())
 
             # Step 3: Run migration test
             run_migration_test(
@@ -352,12 +407,14 @@ def test_request_migration_vllm_aggregated(
                 use_chat_completion=(request_api == "chat"),
                 stream=stream,
                 max_tokens=AGGREGATED_MAX_TOKENS,
+                expected_ongoing_request_count=1,
             )
 
 
 @pytest.mark.skip(reason="Prefill migration not yet supported")
 @pytest.mark.timeout(350)  # 3x average
 @pytest.mark.nightly
+@MIGRATION_PARAMETERS
 def test_request_migration_vllm_prefill(
     request,
     runtime_services_dynamic_ports,
@@ -398,7 +455,7 @@ def test_request_migration_vllm_prefill(
             tmp_path,
             is_prefill=False,
         ) as decode_worker:
-            logger.info(f"Decode Worker PID: {decode_worker.get_pid()}")
+            logger.info("Decode Worker PID: %s", decode_worker.get_pid())
 
             # Step 3: Start 2 prefill workers
             with DynamoWorkerProcess(
@@ -408,7 +465,7 @@ def test_request_migration_vllm_prefill(
                 tmp_path,
                 is_prefill=True,
             ) as prefill1:
-                logger.info(f"Prefill Worker 1 PID: {prefill1.get_pid()}")
+                logger.info("Prefill Worker 1 PID: %s", prefill1.get_pid())
 
                 with DynamoWorkerProcess(
                     request,
@@ -417,7 +474,7 @@ def test_request_migration_vllm_prefill(
                     tmp_path,
                     is_prefill=True,
                 ) as prefill2:
-                    logger.info(f"Prefill Worker 2 PID: {prefill2.get_pid()}")
+                    logger.info("Prefill Worker 2 PID: %s", prefill2.get_pid())
 
                     # Step 4: Run migration test
                     run_migration_test(
@@ -431,6 +488,7 @@ def test_request_migration_vllm_prefill(
                         use_chat_completion=(request_api == "chat"),
                         stream=stream,
                         use_long_prompt=True,
+                        expected_ongoing_request_count=1,
                     )
 
 
@@ -445,6 +503,7 @@ def test_request_migration_vllm_prefill(
 )
 @pytest.mark.timeout(350)  # 3x average
 @pytest.mark.nightly
+@MIGRATION_PARAMETERS
 def test_request_migration_vllm_kv_transfer(
     request,
     runtime_services_dynamic_ports,
@@ -485,7 +544,7 @@ def test_request_migration_vllm_kv_transfer(
             tmp_path,
             is_prefill=True,
         ) as prefill_worker:
-            logger.info(f"Prefill Worker PID: {prefill_worker.get_pid()}")
+            logger.info("Prefill Worker PID: %s", prefill_worker.get_pid())
 
             # Step 3: Start 2 decode workers
             with DynamoWorkerProcess(
@@ -495,7 +554,7 @@ def test_request_migration_vllm_kv_transfer(
                 tmp_path,
                 is_prefill=False,
             ) as decode1:
-                logger.info(f"Decode Worker 1 PID: {decode1.get_pid()}")
+                logger.info("Decode Worker 1 PID: %s", decode1.get_pid())
 
                 with DynamoWorkerProcess(
                     request,
@@ -504,7 +563,7 @@ def test_request_migration_vllm_kv_transfer(
                     tmp_path,
                     is_prefill=False,
                 ) as decode2:
-                    logger.info(f"Decode Worker 2 PID: {decode2.get_pid()}")
+                    logger.info("Decode Worker 2 PID: %s", decode2.get_pid())
 
                     # Step 4: Run migration test
                     run_migration_test(
@@ -518,6 +577,7 @@ def test_request_migration_vllm_kv_transfer(
                         use_chat_completion=(request_api == "chat"),
                         stream=stream,
                         use_long_prompt=True,
+                        expected_ongoing_request_count=1,
                     )
 
 
@@ -532,6 +592,7 @@ def test_request_migration_vllm_kv_transfer(
 )
 @pytest.mark.timeout(350)  # 3x average
 @pytest.mark.nightly
+@DECODE_MIGRATION_PARAMETERS
 def test_request_migration_vllm_decode(
     request,
     runtime_services_dynamic_ports,
@@ -541,7 +602,6 @@ def test_request_migration_vllm_decode(
     migration_max_seq_len,
     immediate_kill,
     request_api,
-    stream,
     tmp_path,
 ):
     """
@@ -553,13 +613,9 @@ def test_request_migration_vllm_decode(
         immediate_kill: True for abrupt kill (SIGKILL), False for graceful shutdown (SIGTERM)
         migration_limit: > 0 to verify migration succeeds, 0 to verify request fails
         request_api: "chat" for chat completion API, "completion" for completion API
-        stream: True for streaming, False for non-streaming
+        This target is always streaming so the fault can be injected while the
+        decode request is in flight.
     """
-    if not stream:
-        pytest.skip(
-            "Decode test requires streaming to wait for response before stopping worker"
-        )
-
     # Step 1: Start the frontend
     with DynamoFrontendProcess(
         request,
@@ -576,7 +632,7 @@ def test_request_migration_vllm_decode(
             tmp_path,
             is_prefill=True,
         ) as prefill_worker:
-            logger.info(f"Prefill Worker PID: {prefill_worker.get_pid()}")
+            logger.info("Prefill Worker PID: %s", prefill_worker.get_pid())
 
             # Step 3: Start 2 decode workers
             with DynamoWorkerProcess(
@@ -586,7 +642,7 @@ def test_request_migration_vllm_decode(
                 tmp_path,
                 is_prefill=False,
             ) as decode1:
-                logger.info(f"Decode Worker 1 PID: {decode1.get_pid()}")
+                logger.info("Decode Worker 1 PID: %s", decode1.get_pid())
 
                 with DynamoWorkerProcess(
                     request,
@@ -595,7 +651,7 @@ def test_request_migration_vllm_decode(
                     tmp_path,
                     is_prefill=False,
                 ) as decode2:
-                    logger.info(f"Decode Worker 2 PID: {decode2.get_pid()}")
+                    logger.info("Decode Worker 2 PID: %s", decode2.get_pid())
 
                     # Step 4: Run migration test
                     run_migration_test(
@@ -607,6 +663,7 @@ def test_request_migration_vllm_decode(
                         migration_max_seq_len=migration_max_seq_len,
                         immediate_kill=immediate_kill,
                         use_chat_completion=(request_api == "chat"),
-                        stream=stream,
+                        stream=True,
                         wait_for_new_response_before_stop=True,
+                        expected_ongoing_request_count=1,
                     )

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -12,19 +12,23 @@ Test Execution Times (Last Run: 2026-01-09):
 import json
 import logging
 import os
-import shutil
+from pathlib import Path
 
 import pytest
 
 from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME, DynamoPortRange
+from tests.utils.gpu_args import build_gpu_mem_args
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_models_api
-from tests.utils.port_utils import allocate_port, deallocate_port
+from tests.utils.port_utils import allocate_port, deallocate_ports
 
 # Customized utils for migration tests
 from .utils import DynamoFrontendProcess, run_migration_test
 
 logger = logging.getLogger(__name__)
+
+AGGREGATED_MAX_MODEL_LEN = 1024
+AGGREGATED_MAX_TOKENS = 512
 
 pytestmark = [
     pytest.mark.fault_tolerance,
@@ -48,24 +52,12 @@ pytestmark = [
     ),
     pytest.mark.parametrize(
         "request_api",
-        [
-            pytest.param("chat"),
-            pytest.param(
-                "completion",
-                marks=pytest.mark.skip(reason="Behavior unverified yet"),
-            ),
-        ],
+        ["chat", "completion"],
     ),
     pytest.mark.parametrize(
         "stream",
-        [
-            pytest.param(True, id="stream"),
-            pytest.param(
-                False,
-                id="unary",
-                marks=pytest.mark.skip(reason="Behavior unverified yet"),
-            ),
-        ],
+        [True, False],
+        ids=["stream", "unary"],
     ),
     pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True),
 ]
@@ -82,6 +74,7 @@ class DynamoWorkerProcess(ManagedProcess):
         worker_id: Unique identifier for the worker (e.g., "worker1", "prefill1")
         frontend_port: Port where the frontend is running
         is_prefill: None for aggregated mode, True for prefill worker, False for decode worker
+        max_model_len: Maximum input-plus-output context exposed by the worker
     """
 
     def __init__(
@@ -89,11 +82,40 @@ class DynamoWorkerProcess(ManagedProcess):
         request,
         worker_id: str,
         frontend_port: int,
+        log_root: Path,
         is_prefill: bool | None = None,
+        max_model_len: int = 8192,
     ):
         self.worker_id = worker_id
+        allocated_ports: list[int] = []
+        request.addfinalizer(lambda ports=allocated_ports: deallocate_ports(ports))
+
         self.system_port = allocate_port(DynamoPortRange.SERVE.value)
-        request.addfinalizer(lambda port=self.system_port: deallocate_port(port))
+        allocated_ports.append(self.system_port)
+
+        self.nixl_side_channel_port = allocate_port(DynamoPortRange.NIXL.value)
+        allocated_ports.append(self.nixl_side_channel_port)
+
+        # vLLM defaults every engine to the same torch.distributed rendezvous
+        # port (29501). TP=1 does not always bind it, but assigning it explicitly
+        # avoids startup races when several engine processes initialize together.
+        self.master_port = allocate_port(DynamoPortRange.BOOTSTRAP.value)
+        allocated_ports.append(self.master_port)
+
+        env = os.environ.copy()
+        if "_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES" not in env:
+            kv_mark = request.node.get_closest_marker("requested_vllm_kv_cache_bytes")
+            if kv_mark:
+                env["_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES"] = str(int(kv_mark.args[0]))
+
+        gpu_mem_args = build_gpu_mem_args("build_vllm_gpu_mem_args", env=env)
+        if not gpu_mem_args:
+            gpu_mem_args = [
+                "--num-gpu-blocks-override",
+                "512",  # 8192 tokens / 16 tokens per block
+                "--gpu-memory-utilization",
+                "0.15",
+            ]
 
         command = [
             "python3",
@@ -103,13 +125,12 @@ class DynamoWorkerProcess(ManagedProcess):
             FAULT_TOLERANCE_MODEL_NAME,
             "--enforce-eager",
             "--max-model-len",
-            "8192",  # input + output tokens
+            str(max_model_len),
             "--max-num-seqs",
             "1",  # number of requests at a time
-            "--num-gpu-blocks-override",  # limit total KV cache allocation
-            "512",  # 8192 tokens x 1 context / 16 tokens per block = 512 blocks
-            "--gpu-memory-utilization",
-            "0.15",  # avoid assertion error on vLLM available memory checks
+            "--master-port",
+            str(self.master_port),
+            *gpu_mem_args,
         ]
         if is_prefill is True:
             command.extend(["--disaggregation-mode", "prefill"])
@@ -118,7 +139,8 @@ class DynamoWorkerProcess(ManagedProcess):
 
         # Aggregated mode and prefill workers publish KV events
         if is_prefill is not False:
-            kv_event_port = f"2008{worker_id[-1]}"  # TODO: use dynamic port allocation
+            kv_event_port = allocate_port(DynamoPortRange.SERVE.value)
+            allocated_ports.append(kv_event_port)
             command.extend(
                 [
                     "--kv-events-config",
@@ -134,13 +156,10 @@ class DynamoWorkerProcess(ManagedProcess):
             )
 
         # Set environment variables
-        env = os.environ.copy()
         env["DYN_REQUEST_PLANE"] = request.getfixturevalue("request_plane")
 
         # All workers need unique NIXL side channel ports for KV transfer
-        env[
-            "VLLM_NIXL_SIDE_CHANNEL_PORT"
-        ] = f"560{worker_id[-1]}"  # TODO: use dynamic port allocation
+        env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(self.nixl_side_channel_port)
 
         env["DYN_LOG"] = "debug"
         # Disable canary health check - these tests expect full control over requests
@@ -165,28 +184,20 @@ class DynamoWorkerProcess(ManagedProcess):
                 (f"http://localhost:{frontend_port}/v1/models", check_models_api)
             )
 
-        # TODO: Have the managed process take a command name explicitly to distinguish
-        #       between processes started with the same command.
-        log_dir = f"{request.node.name}_{worker_id}"
-
-        # Clean up any existing log directory from previous runs
-        try:
-            shutil.rmtree(log_dir)
-            logger.info(f"Cleaned up existing log directory: {log_dir}")
-        except FileNotFoundError:
-            # Directory doesn't exist, which is fine
-            pass
+        log_dir = log_root / worker_id
 
         super().__init__(
             command=command,
             env=env,
             health_check_urls=health_check_urls,
             timeout=300,
-            display_output=True,
+            # Every worker retains a complete per-test log. Avoid interleaving
+            # verbose engine output when several GPU tests run concurrently.
+            display_output=False,
             terminate_all_matching_process_names=False,
             stragglers=["VLLM::EngineCore"],
             straggler_commands=["-m dynamo.vllm"],
-            log_dir=log_dir,
+            log_dir=str(log_dir),
             display_name=worker_id,
         )
 
@@ -207,10 +218,8 @@ class DynamoWorkerProcess(ManagedProcess):
 
 @pytest.mark.timeout(290)  # 3x average
 @pytest.mark.post_merge
-@pytest.mark.skip(
-    reason="Flaky: 0% post-merge pass rate across multiple parametrizations; "
-    "skipped wholesale until the underlying migration fault is owned and fixed."
-)
+@pytest.mark.profiled_vram_gib(4.8)
+@pytest.mark.requested_vllm_kv_cache_bytes(331_711_000)
 def test_request_migration_vllm_aggregated(
     request,
     runtime_services_dynamic_ports,
@@ -221,6 +230,7 @@ def test_request_migration_vllm_aggregated(
     immediate_kill,
     request_api,
     stream,
+    tmp_path,
 ):
     """
     End-to-end test for aggregated worker request migration.
@@ -242,13 +252,21 @@ def test_request_migration_vllm_aggregated(
         logger.info("Frontend started successfully")
 
         # Step 2: Start 2 workers
-        with DynamoWorkerProcess(request, "worker1", frontend.frontend_port) as worker1:
+        with DynamoWorkerProcess(
+            request,
+            "worker1",
+            frontend.frontend_port,
+            tmp_path,
+            max_model_len=AGGREGATED_MAX_MODEL_LEN,
+        ) as worker1:
             logger.info(f"Worker 1 PID: {worker1.get_pid()}")
 
             with DynamoWorkerProcess(
                 request,
                 "worker2",
                 frontend.frontend_port,
+                tmp_path,
+                max_model_len=AGGREGATED_MAX_MODEL_LEN,
             ) as worker2:
                 logger.info(f"Worker 2 PID: {worker2.get_pid()}")
 
@@ -263,6 +281,7 @@ def test_request_migration_vllm_aggregated(
                     immediate_kill=immediate_kill,
                     use_chat_completion=(request_api == "chat"),
                     stream=stream,
+                    max_tokens=AGGREGATED_MAX_TOKENS,
                 )
 
 
@@ -279,6 +298,7 @@ def test_request_migration_vllm_prefill(
     immediate_kill,
     request_api,
     stream,
+    tmp_path,
 ):
     """
     End-to-end test for prefill worker request migration in disaggregated mode.
@@ -305,6 +325,7 @@ def test_request_migration_vllm_prefill(
             request,
             "worker0",
             frontend.frontend_port,
+            tmp_path,
             is_prefill=False,
         ) as decode_worker:
             logger.info(f"Decode Worker PID: {decode_worker.get_pid()}")
@@ -314,6 +335,7 @@ def test_request_migration_vllm_prefill(
                 request,
                 "worker1",
                 frontend.frontend_port,
+                tmp_path,
                 is_prefill=True,
             ) as prefill1:
                 logger.info(f"Prefill Worker 1 PID: {prefill1.get_pid()}")
@@ -322,6 +344,7 @@ def test_request_migration_vllm_prefill(
                     request,
                     "worker2",
                     frontend.frontend_port,
+                    tmp_path,
                     is_prefill=True,
                 ) as prefill2:
                     logger.info(f"Prefill Worker 2 PID: {prefill2.get_pid()}")
@@ -362,6 +385,7 @@ def test_request_migration_vllm_kv_transfer(
     immediate_kill,
     request_api,
     stream,
+    tmp_path,
 ):
     """
     End-to-end test for request migration during KV transfer in disaggregated mode.
@@ -388,6 +412,7 @@ def test_request_migration_vllm_kv_transfer(
             request,
             "worker0",
             frontend.frontend_port,
+            tmp_path,
             is_prefill=True,
         ) as prefill_worker:
             logger.info(f"Prefill Worker PID: {prefill_worker.get_pid()}")
@@ -397,6 +422,7 @@ def test_request_migration_vllm_kv_transfer(
                 request,
                 "worker1",
                 frontend.frontend_port,
+                tmp_path,
                 is_prefill=False,
             ) as decode1:
                 logger.info(f"Decode Worker 1 PID: {decode1.get_pid()}")
@@ -405,6 +431,7 @@ def test_request_migration_vllm_kv_transfer(
                     request,
                     "worker2",
                     frontend.frontend_port,
+                    tmp_path,
                     is_prefill=False,
                 ) as decode2:
                     logger.info(f"Decode Worker 2 PID: {decode2.get_pid()}")
@@ -445,6 +472,7 @@ def test_request_migration_vllm_decode(
     immediate_kill,
     request_api,
     stream,
+    tmp_path,
 ):
     """
     End-to-end test for decode worker request migration in disaggregated mode.
@@ -475,6 +503,7 @@ def test_request_migration_vllm_decode(
             request,
             "worker0",
             frontend.frontend_port,
+            tmp_path,
             is_prefill=True,
         ) as prefill_worker:
             logger.info(f"Prefill Worker PID: {prefill_worker.get_pid()}")
@@ -484,6 +513,7 @@ def test_request_migration_vllm_decode(
                 request,
                 "worker1",
                 frontend.frontend_port,
+                tmp_path,
                 is_prefill=False,
             ) as decode1:
                 logger.info(f"Decode Worker 1 PID: {decode1.get_pid()}")
@@ -492,6 +522,7 @@ def test_request_migration_vllm_decode(
                     request,
                     "worker2",
                     frontend.frontend_port,
+                    tmp_path,
                     is_prefill=False,
                 ) as decode2:
                     logger.info(f"Decode Worker 2 PID: {decode2.get_pid()}")

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -34,6 +34,84 @@ logger = logging.getLogger(__name__)
 AGGREGATED_MAX_MODEL_LEN = 1024
 AGGREGATED_MAX_TOKENS = 512
 
+# Cover each distinct migration policy with complementary lifecycle, API,
+# response, and transport values. Together these eight rows cover every pair
+# of those four binary dimensions without paying for their Cartesian product.
+MIGRATION_CASES = [
+    pytest.param(
+        3,
+        None,
+        True,
+        "chat",
+        True,
+        "nats",
+        id="migration_enabled-no_seq_cap-worker_failure-chat-stream-nats",
+    ),
+    pytest.param(
+        3,
+        None,
+        False,
+        "completion",
+        False,
+        "tcp",
+        id="migration_enabled-no_seq_cap-graceful_shutdown-completion-unary-tcp",
+    ),
+    pytest.param(
+        0,
+        None,
+        True,
+        "chat",
+        False,
+        "tcp",
+        id="migration_disabled-worker_failure-chat-unary-tcp",
+    ),
+    pytest.param(
+        0,
+        None,
+        False,
+        "completion",
+        True,
+        "nats",
+        id="migration_disabled-graceful_shutdown-completion-stream-nats",
+    ),
+    pytest.param(
+        3,
+        1,
+        True,
+        "completion",
+        True,
+        "tcp",
+        id="max_seq_len_exceeded-worker_failure-completion-stream-tcp",
+    ),
+    pytest.param(
+        3,
+        1,
+        False,
+        "chat",
+        False,
+        "nats",
+        id="max_seq_len_exceeded-graceful_shutdown-chat-unary-nats",
+    ),
+    pytest.param(
+        3,
+        1_000_000,
+        True,
+        "completion",
+        False,
+        "nats",
+        id="max_seq_len_not_exceeded-worker_failure-completion-unary-nats",
+    ),
+    pytest.param(
+        3,
+        1_000_000,
+        False,
+        "chat",
+        True,
+        "tcp",
+        id="max_seq_len_not_exceeded-graceful_shutdown-chat-stream-tcp",
+    ),
+]
+
 pytestmark = [
     pytest.mark.fault_tolerance,
     pytest.mark.vllm,
@@ -41,29 +119,17 @@ pytestmark = [
     pytest.mark.e2e,
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
     pytest.mark.parametrize(
-        "migration_limit", [3, 0], ids=["migration_enabled", "migration_disabled"]
+        (
+            "migration_limit",
+            "migration_max_seq_len",
+            "immediate_kill",
+            "request_api",
+            "stream",
+            "request_plane",
+        ),
+        MIGRATION_CASES,
+        indirect=["request_plane"],
     ),
-    pytest.mark.parametrize(
-        "migration_max_seq_len",
-        [
-            pytest.param(None, id="max_seq_len_disabled"),
-            pytest.param(1_000_000, id="max_seq_len_not_exceeded"),
-            pytest.param(1, id="max_seq_len_exceeded"),
-        ],
-    ),
-    pytest.mark.parametrize(
-        "immediate_kill", [True, False], ids=["worker_failure", "graceful_shutdown"]
-    ),
-    pytest.mark.parametrize(
-        "request_api",
-        ["chat", "completion"],
-    ),
-    pytest.mark.parametrize(
-        "stream",
-        [True, False],
-        ids=["stream", "unary"],
-    ),
-    pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True),
 ]
 
 

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -61,7 +61,10 @@ def _make_client(frontend_port: int) -> OpenAI:
 
 
 def start_completion_request(
-    frontend_port: int, stream: bool, use_long_prompt: bool = False
+    frontend_port: int,
+    stream: bool,
+    use_long_prompt: bool = False,
+    max_tokens: int | None = None,
 ) -> tuple:
     """
     Start a long-running completion request in a separate thread.
@@ -73,6 +76,7 @@ def start_completion_request(
         frontend_port: Port where the frontend is running
         stream: Whether to use streaming responses
         use_long_prompt: Whether to use a long prompt (~8000 tokens)
+        max_tokens: Explicit output-token cap, or the backend default when unset
 
     Returns:
         tuple: (request_thread, response_list) where response_list contains
@@ -91,35 +95,36 @@ def start_completion_request(
             f"Sending completion request (stream={stream}) with prompt: '{prompt[:50]}...'"
         )
 
-        response_list.append((None, time.time()))  # start timestamp
+        response_list.append((None, time.monotonic()))  # start observation
 
         try:
             client = _make_client(frontend_port)
+            request_args = {
+                "model": FAULT_TOLERANCE_MODEL_NAME,
+                "prompt": prompt,
+                "stream": stream,
+                "temperature": 0,
+                "seed": 0,
+            }
+            if max_tokens is not None:
+                request_args["max_tokens"] = max_tokens
             if stream:
-                for chunk in client.completions.create(
-                    model=FAULT_TOLERANCE_MODEL_NAME,
-                    prompt=prompt,
-                    stream=True,
-                ):
+                for chunk in client.completions.create(**request_args):
                     text = chunk.choices[0].text if chunk.choices else None
                     # Match the original hand-rolled parser: keep empty strings,
                     # drop only None. Empty chunks (e.g. the first stream frame)
                     # still count as a response arrival for delay measurement.
                     if text is not None:
-                        response_list.append((text, time.time()))
+                        response_list.append((text, time.monotonic()))
             else:
-                resp = client.completions.create(
-                    model=FAULT_TOLERANCE_MODEL_NAME,
-                    prompt=prompt,
-                    stream=False,
-                )
-                response_list.append((resp.choices[0].text, time.time()))
+                resp = client.completions.create(**request_args)
+                response_list.append((resp.choices[0].text, time.monotonic()))
         except Exception as e:
             # openai.APIError subclasses cover HTTP non-200, mid-stream
             # structured `data: {"error": {...}}` frames, connection failures,
             # and timeouts. Non-openai exceptions (network, etc.) also bubble.
             logger.error(f"Request failed with error: {e}")
-            response_list.append((e, time.time()))
+            response_list.append((e, time.monotonic()))
 
     request_thread = threading.Thread(target=send_request, daemon=True)
     request_thread.start()
@@ -128,7 +133,10 @@ def start_completion_request(
 
 
 def start_chat_completion_request(
-    frontend_port: int, stream: bool, use_long_prompt: bool = False
+    frontend_port: int,
+    stream: bool,
+    use_long_prompt: bool = False,
+    max_tokens: int | None = None,
 ) -> tuple:
     """
     Start a long-running chat completion request in a separate thread.
@@ -140,6 +148,7 @@ def start_chat_completion_request(
         frontend_port: Port where the frontend is running
         stream: Whether to use streaming responses
         use_long_prompt: Whether to use a long prompt (~8000 tokens)
+        max_tokens: Explicit output-token cap, or the backend default when unset
 
     Returns:
         tuple: (request_thread, response_list) where response_list contains
@@ -158,36 +167,39 @@ def start_chat_completion_request(
             f"Sending chat completion request (stream={stream}) with prompt: '{prompt[:50]}...'"
         )
 
-        response_list.append((None, time.time()))  # start timestamp
+        response_list.append((None, time.monotonic()))  # start observation
 
         try:
             client = _make_client(frontend_port)
+            request_args = {
+                "model": FAULT_TOLERANCE_MODEL_NAME,
+                "messages": [{"role": "user", "content": prompt}],
+                "stream": stream,
+                "temperature": 0,
+                "seed": 0,
+            }
+            if max_tokens is not None:
+                request_args["max_tokens"] = max_tokens
             if stream:
-                for chunk in client.chat.completions.create(
-                    model=FAULT_TOLERANCE_MODEL_NAME,
-                    messages=[{"role": "user", "content": prompt}],
-                    stream=True,
-                ):
+                for chunk in client.chat.completions.create(**request_args):
                     content = chunk.choices[0].delta.content if chunk.choices else None
                     # Match the original hand-rolled parser: keep empty strings,
                     # drop only None. Empty chunks (e.g. the first `role`-only
                     # stream frame) still count as a response arrival for delay
                     # measurement.
                     if content is not None:
-                        response_list.append((content, time.time()))
+                        response_list.append((content, time.monotonic()))
             else:
-                resp = client.chat.completions.create(
-                    model=FAULT_TOLERANCE_MODEL_NAME,
-                    messages=[{"role": "user", "content": prompt}],
-                    stream=False,
+                resp = client.chat.completions.create(**request_args)
+                response_list.append(
+                    (resp.choices[0].message.content, time.monotonic())
                 )
-                response_list.append((resp.choices[0].message.content, time.time()))
         except Exception as e:
             # openai.APIError subclasses cover HTTP non-200, mid-stream
             # structured `data: {"error": {...}}` frames, connection failures,
             # and timeouts. Non-openai exceptions also bubble for visibility.
             logger.error(f"Request failed with error: {e}")
-            response_list.append((e, time.time()))
+            response_list.append((e, time.monotonic()))
 
     request_thread = threading.Thread(target=send_request, daemon=True)
     request_thread.start()
@@ -214,14 +226,17 @@ def determine_request_receiving_worker(
     # Event to signal all threads to exit when one finds the pattern
     found_event = threading.Event()
 
+    # Engine logs are written asynchronously and can arrive noticeably later
+    # under loaded CI nodes. Keep this timeout comfortably below the request
+    # timeout while avoiding a sub-second race when identifying the worker to
+    # terminate. See the aggregate vLLM migration regression in #9465.
+    max_wait_s = 10.0
+    poll_interval_s = 0.1
+
     # Poll both workers in parallel
     def poll_worker(worker: ManagedProcess, result_list: list[bool]):
-        max_wait_ms = 500
-        poll_interval_ms = 5
-        max_iterations = max_wait_ms // poll_interval_ms
-        iteration = 0
-
-        while iteration < max_iterations and not found_event.is_set():
+        deadline = time.monotonic() + max_wait_s
+        while time.monotonic() < deadline and not found_event.is_set():
             # Check if the worker logs contain the pattern
             try:
                 with open(worker.log_path, "r") as f:
@@ -234,8 +249,9 @@ def determine_request_receiving_worker(
                 logger.error(f"Could not read log file {worker.log_path}: {e}")
                 return
 
-            time.sleep(poll_interval_ms / 1000.0)
-            iteration += 1
+            # This is condition-driven polling: wake immediately when the other
+            # worker finds the request instead of sleeping for a fixed duration.
+            found_event.wait(timeout=poll_interval_s)
 
     # Look for which worker received the request
     thread1 = threading.Thread(
@@ -246,8 +262,9 @@ def determine_request_receiving_worker(
     )
     thread1.start()
     thread2.start()
-    thread1.join(timeout=1)
-    thread2.join(timeout=1)
+    join_timeout_s = max_wait_s + 1
+    thread1.join(timeout=join_timeout_s)
+    thread2.join(timeout=join_timeout_s)
 
     # Get results from lists
     worker1_received = worker1_results[0] if worker1_results else False
@@ -297,17 +314,17 @@ def wait_for_response(
 def validate_response(
     request_thread: threading.Thread,
     response_list: list[tuple[str | None | Exception, float]],
-    validate_delay: bool = True,
 ) -> None:
     """
     Wait for and validate the response after migration.
-    Checks that delay before each response is reasonable (covers both TTFT and TPOT).
+    Timing observations are logged for diagnosis, but they are not correctness
+    assertions. Loaded CI nodes and concurrent GPU tests can legitimately change
+    TTFT/TPOT without changing migration behavior.
 
     Args:
         request_thread: The thread running the request
         response_list: List of (content_string | None | Exception, timestamp) tuples.
                        Content is already parsed - no SSE format parsing needed.
-        validate_delay: Whether to validate delay before each response.
     """
     request_thread.join(timeout=240)
     assert not request_thread.is_alive(), "Request did not complete within 240 seconds"
@@ -319,11 +336,8 @@ def validate_response(
     response_words: list[str] = []
     for res, timestamp in response_list[1:]:
         delay = timestamp - prev_timestamp
-        if delay > 2.0 and validate_delay:
-            # Cold workers can take longer on first token - only warn but don't fail
-            logger.warning(f"Delay before response: {delay:.3f} secs")
-            # Capture cases like migration is blocked by engine graceful shutdown
-            assert delay <= 6.0, f"Delay before response > 6 secs, got {delay:.3f} secs"
+        if delay > 2.0:
+            logger.info("Observed %.3fs before the next response chunk", delay)
         prev_timestamp = timestamp
 
         assert res is not None, "Response entry should not be None"
@@ -333,6 +347,7 @@ def validate_response(
         # Content is already parsed - just collect it
         response_words.append(res)
 
+    assert response_words, "Request completed without any response content"
     logger.info(
         f"Received {len(response_words)} response(s): {''.join(response_words)[:100]}..."
     )
@@ -428,17 +443,15 @@ def verify_migration_metrics(
         f"max_seq_len_exceeded: {max_seq_len_exceeded_count}"
     )
 
-    if expected_ongoing_request_count > 0:
-        assert ongoing_count >= expected_ongoing_request_count, (
-            f"Expected at least {expected_ongoing_request_count} ongoing_request migrations, "
-            f"but got {ongoing_count}"
-        )
+    assert ongoing_count == expected_ongoing_request_count, (
+        f"Expected {expected_ongoing_request_count} ongoing_request migrations, "
+        f"but got {ongoing_count}"
+    )
 
-    if expected_new_request_count > 0:
-        assert new_request_count >= expected_new_request_count, (
-            f"Expected at least {expected_new_request_count} new_request migrations, "
-            f"but got {new_request_count}"
-        )
+    assert new_request_count == expected_new_request_count, (
+        f"Expected {expected_new_request_count} new_request migrations, "
+        f"but got {new_request_count}"
+    )
 
     assert max_seq_len_exceeded_count == expected_max_seq_len_exceeded_count, (
         f"Expected {expected_max_seq_len_exceeded_count} "
@@ -456,6 +469,7 @@ def run_migration_test(
     immediate_kill: bool,
     use_chat_completion: bool,
     stream: bool,
+    max_tokens: int | None = None,
     use_long_prompt: bool = False,
     wait_for_new_response_before_stop: bool = False,
 ) -> None:
@@ -472,17 +486,24 @@ def run_migration_test(
         immediate_kill: True for immediate kill, False for graceful shutdown
         use_chat_completion: Whether to use chat completion API (True) or completion API (False)
         stream: Whether to use streaming responses
+        max_tokens: Explicit output-token cap, or the backend default when unset
         use_long_prompt: Whether to use long prompt (for prefill tests)
         wait_for_new_response_before_stop: Whether to wait for response before stopping (for decode tests)
     """
     # Step 1: Send the request
     if use_chat_completion:
         request_thread, response_list = start_chat_completion_request(
-            frontend.frontend_port, stream=stream, use_long_prompt=use_long_prompt
+            frontend.frontend_port,
+            stream=stream,
+            use_long_prompt=use_long_prompt,
+            max_tokens=max_tokens,
         )
     else:
         request_thread, response_list = start_completion_request(
-            frontend.frontend_port, stream=stream, use_long_prompt=use_long_prompt
+            frontend.frontend_port,
+            stream=stream,
+            use_long_prompt=use_long_prompt,
+            max_tokens=max_tokens,
         )
 
     # Step 2: Determine which worker received the request
@@ -509,22 +530,22 @@ def run_migration_test(
     # request does not exceed the migration seq-len cap; otherwise the in-flight
     # request must fail.
     if migration_limit > 0 and migration_max_seq_len != 1:
-        validate_response(request_thread, response_list, validate_delay=stream)
+        validate_response(request_thread, response_list)
     else:
         # openai.APIError covers both mid-stream structured error frames and
         # HTTP non-200 responses.
         with pytest.raises(APIError):
-            validate_response(request_thread, response_list, validate_delay=stream)
+            validate_response(request_thread, response_list)
 
     # Step 6: Verify that migration behaved as expected via the frontend's
     # Prometheus metrics (a stable structured surface) instead of asserting on
-    # log strings. `ongoing_request` is incremented at the same point the
-    # migration layer detects a disconnect and recreates the stream, so it is
-    # the structured equivalent of the old "Stream disconnected, recreating
-    # stream" log assertion; `max_seq_len_exceeded` records hitting the
-    # migration seq-len cap.
+    # log strings. `ongoing_request` counts an error from an established
+    # stream, including an attempt that cannot retry because migration_limit is
+    # zero. It is the structured equivalent of the old "Stream disconnected,
+    # recreating stream" log assertion. `max_seq_len_exceeded` records hitting
+    # the migration seq-len cap.
     verify_migration_metrics(
         frontend.frontend_port,
-        expected_ongoing_request_count=1 if migration_limit > 0 else 0,
+        expected_ongoing_request_count=1,
         expected_max_seq_len_exceeded_count=1 if migration_max_seq_len == 1 else 0,
     )

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -557,7 +557,11 @@ def run_migration_test(
         logger.info(
             f"Gracefully shutting down {worker_name} with PID {worker.get_pid()}"
         )
-        terminate_process_tree(worker.get_pid(), immediate_kill=False, timeout=10)
+        # Give the runtime time to withdraw the endpoint from discovery, then
+        # stop its engine child before this short request can finish. A long
+        # parent-first grace period lets vLLM exhaust the output budget and
+        # turns the intended disconnect into a zero-token migration retry.
+        terminate_process_tree(worker.get_pid(), immediate_kill=False, timeout=2)
 
     # Step 5: Validate the request outcome via its response (the user-facing
     # contract). Migration is expected to succeed only when it is enabled and the

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -5,6 +5,9 @@ import logging
 import re
 import threading
 import time
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack, contextmanager
 
 import pytest
 import requests
@@ -17,6 +20,37 @@ from tests.utils.managed_process import (
 from tests.utils.managed_process import ManagedProcess, terminate_process_tree
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def managed_processes_concurrently(
+    *processes: ManagedProcess,
+) -> Iterator[tuple[ManagedProcess, ...]]:
+    """Enter independent managed processes concurrently and clean them up safely."""
+    if not processes:
+        yield ()
+        return
+
+    entered: list[ManagedProcess | None] = [None] * len(processes)
+    startup_error: BaseException | None = None
+    with ThreadPoolExecutor(max_workers=len(processes)) as executor:
+        futures = [executor.submit(process.__enter__) for process in processes]
+        for index, future in enumerate(futures):
+            try:
+                entered[index] = future.result()
+            except BaseException as error:
+                if startup_error is None:
+                    startup_error = error
+
+    with ExitStack() as stack:
+        for process in entered:
+            if process is not None:
+                stack.callback(process.__exit__, None, None, None)
+
+        if startup_error is not None:
+            raise startup_error
+
+        yield tuple(process for process in entered if process is not None)
 
 
 class DynamoFrontendProcess(BaseDynamoFrontendProcess):

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -126,7 +126,9 @@ def start_completion_request(
             prompt += " Make sure it is" + " long" * 8000 + "!"
 
         logger.info(
-            f"Sending completion request (stream={stream}) with prompt: '{prompt[:50]}...'"
+            "Sending completion request (stream=%s) with prompt: '%s...'",
+            stream,
+            prompt[:50],
         )
 
         response_list.append((None, time.monotonic()))  # start observation
@@ -153,12 +155,12 @@ def start_completion_request(
             else:
                 resp = client.completions.create(**request_args)
                 response_list.append((resp.choices[0].text, time.monotonic()))
-        except Exception as e:
+        except Exception as error:
             # openai.APIError subclasses cover HTTP non-200, mid-stream
             # structured `data: {"error": {...}}` frames, connection failures,
             # and timeouts. Non-openai exceptions (network, etc.) also bubble.
-            logger.error(f"Request failed with error: {e}")
-            response_list.append((e, time.monotonic()))
+            logger.error("Request failed with error: %s", error)
+            response_list.append((error, time.monotonic()))
 
     request_thread = threading.Thread(target=send_request, daemon=True)
     request_thread.start()
@@ -198,7 +200,9 @@ def start_chat_completion_request(
             prompt += " Make sure it is" + " long" * 8000 + "!"
 
         logger.info(
-            f"Sending chat completion request (stream={stream}) with prompt: '{prompt[:50]}...'"
+            "Sending chat completion request (stream=%s) with prompt: '%s...'",
+            stream,
+            prompt[:50],
         )
 
         response_list.append((None, time.monotonic()))  # start observation
@@ -228,12 +232,12 @@ def start_chat_completion_request(
                 response_list.append(
                     (resp.choices[0].message.content, time.monotonic())
                 )
-        except Exception as e:
+        except Exception as error:
             # openai.APIError subclasses cover HTTP non-200, mid-stream
             # structured `data: {"error": {...}}` frames, connection failures,
             # and timeouts. Non-openai exceptions also bubble for visibility.
-            logger.error(f"Request failed with error: {e}")
-            response_list.append((e, time.monotonic()))
+            logger.error("Request failed with error: %s", error)
+            response_list.append((error, time.monotonic()))
 
     request_thread = threading.Thread(target=send_request, daemon=True)
     request_thread.start()
@@ -279,8 +283,12 @@ def determine_request_receiving_worker(
                         result_list.append(True)
                         found_event.set()  # Signal other thread to exit
                         return
-            except Exception as e:
-                logger.error(f"Could not read log file {worker.log_path}: {e}")
+            except Exception as error:
+                logger.error(
+                    "Could not read log file %s: %s",
+                    worker.log_path,
+                    error,
+                )
                 return
 
             # This is condition-driven polling: wake immediately when the other
@@ -341,7 +349,10 @@ def wait_for_response(
         elapsed += poll_interval
 
     logger.warning(
-        f"Only received {len(response_list) - initial_len}/{num_responses} new responses within {max_wait_time}s"
+        "Only received %s/%s new responses within %ss",
+        len(response_list) - initial_len,
+        num_responses,
+        max_wait_time,
     )
 
 
@@ -383,7 +394,9 @@ def validate_response(
 
     assert response_words, "Request completed without any response content"
     logger.info(
-        f"Received {len(response_words)} response(s): {''.join(response_words)[:100]}..."
+        "Received %s response(s): %s...",
+        len(response_words),
+        "".join(response_words)[:100],
     )
 
 
@@ -439,6 +452,7 @@ def verify_migration_metrics(
     expected_ongoing_request_count: int = 0,
     expected_new_request_count: int = 0,
     expected_max_seq_len_exceeded_count: int = 0,
+    exact_counts: bool = False,
 ) -> None:
     """
     Verify migration metrics by querying the frontend's /metrics endpoint.
@@ -448,6 +462,8 @@ def verify_migration_metrics(
         expected_ongoing_request_count: Expected count of ongoing_request migrations
         expected_new_request_count: Expected count of new_request migrations
         expected_max_seq_len_exceeded_count: Expected count of max_seq_len exceeded events
+        exact_counts: Require exact ongoing/new-request counts instead of the
+            shared helper's historical lower-bound assertions
     """
     metrics_url = f"http://localhost:{frontend_port}/metrics"
 
@@ -458,7 +474,7 @@ def verify_migration_metrics(
         pytest.fail(f"Failed to fetch metrics from {metrics_url}: {e}")
 
     metrics_text = response.text
-    logger.info(f"Fetched metrics from {metrics_url}")
+    logger.info("Fetched metrics from %s", metrics_url)
 
     # Parse metrics to find migration counts
     ongoing_count = _parse_migration_metric(
@@ -472,20 +488,33 @@ def verify_migration_metrics(
     )
 
     logger.info(
-        f"Migration metrics - ongoing_request: {ongoing_count}, "
-        f"new_request: {new_request_count}, "
-        f"max_seq_len_exceeded: {max_seq_len_exceeded_count}"
+        "Migration metrics - ongoing_request: %s, new_request: %s, "
+        "max_seq_len_exceeded: %s",
+        ongoing_count,
+        new_request_count,
+        max_seq_len_exceeded_count,
     )
 
-    assert ongoing_count == expected_ongoing_request_count, (
-        f"Expected {expected_ongoing_request_count} ongoing_request migrations, "
-        f"but got {ongoing_count}"
-    )
-
-    assert new_request_count == expected_new_request_count, (
-        f"Expected {expected_new_request_count} new_request migrations, "
-        f"but got {new_request_count}"
-    )
+    if exact_counts:
+        assert ongoing_count == expected_ongoing_request_count, (
+            f"Expected {expected_ongoing_request_count} ongoing_request migrations, "
+            f"but got {ongoing_count}"
+        )
+        assert new_request_count == expected_new_request_count, (
+            f"Expected {expected_new_request_count} new_request migrations, "
+            f"but got {new_request_count}"
+        )
+    else:
+        if expected_ongoing_request_count > 0:
+            assert ongoing_count >= expected_ongoing_request_count, (
+                f"Expected at least {expected_ongoing_request_count} "
+                f"ongoing_request migrations, but got {ongoing_count}"
+            )
+        if expected_new_request_count > 0:
+            assert new_request_count >= expected_new_request_count, (
+                f"Expected at least {expected_new_request_count} "
+                f"new_request migrations, but got {new_request_count}"
+            )
 
     assert max_seq_len_exceeded_count == expected_max_seq_len_exceeded_count, (
         f"Expected {expected_max_seq_len_exceeded_count} "
@@ -506,6 +535,7 @@ def run_migration_test(
     max_tokens: int | None = None,
     use_long_prompt: bool = False,
     wait_for_new_response_before_stop: bool = False,
+    expected_ongoing_request_count: int | None = None,
 ) -> None:
     """
     Run the common migration test flow after frontend and workers are started.
@@ -523,6 +553,9 @@ def run_migration_test(
         max_tokens: Explicit output-token cap, or the backend default when unset
         use_long_prompt: Whether to use long prompt (for prefill tests)
         wait_for_new_response_before_stop: Whether to wait for response before stopping (for decode tests)
+        expected_ongoing_request_count: Exact expected count for callers that
+            opt into strict metric validation. When omitted, preserve the
+            shared helper's historical backend-agnostic lower-bound behavior.
     """
     # Step 1: Send the request
     if use_chat_completion:
@@ -551,11 +584,13 @@ def run_migration_test(
 
     # Step 4: Stop the worker (kill or graceful shutdown)
     if immediate_kill:
-        logger.info(f"Killing {worker_name} with PID {worker.get_pid()}")
+        logger.info("Killing %s with PID %s", worker_name, worker.get_pid())
         terminate_process_tree(worker.get_pid(), immediate_kill=True, timeout=0)
     else:
         logger.info(
-            f"Gracefully shutting down {worker_name} with PID {worker.get_pid()}"
+            "Gracefully shutting down %s with PID %s",
+            worker_name,
+            worker.get_pid(),
         )
         # Give the runtime time to withdraw the endpoint from discovery, then
         # stop its engine child before this short request can finish. A long
@@ -582,8 +617,13 @@ def run_migration_test(
     # zero. It is the structured equivalent of the old "Stream disconnected,
     # recreating stream" log assertion. `max_seq_len_exceeded` records hitting
     # the migration seq-len cap.
+    exact_metric_counts = expected_ongoing_request_count is not None
+    if expected_ongoing_request_count is None:
+        expected_ongoing_request_count = 1 if migration_limit > 0 else 0
+
     verify_migration_metrics(
         frontend.frontend_port,
-        expected_ongoing_request_count=1,
+        expected_ongoing_request_count=expected_ongoing_request_count,
         expected_max_seq_len_exceeded_count=1 if migration_max_seq_len == 1 else 0,
+        exact_counts=exact_metric_counts,
     )


### PR DESCRIPTION
## Summary

- re-enable aggregate vLLM request migration with eight explicit high-value cases instead of the 96-case Cartesian product
- cover migration enabled, migration disabled, sequence cap exceeded, and finite sequence cap not exceeded
- cover both abrupt and graceful worker loss, chat and completion APIs, streaming and unary responses, and NATS and TCP request planes for every policy state
- start the two vLLM workers concurrently after assigning dynamically allocated system, NIXL, KV-event, and rendezvous ports
- replace wall-clock and fixed-delay correctness checks with condition-driven polling, response completion, and exact vLLM migration metrics while preserving the shared helper's backend-agnostic defaults
- shrink the aggregate-only context/output bounds while preserving the migration behavior under test
- bound graceful parent-first shutdown so short completions disconnect and migrate before the engine child can exhaust the output budget

## Why eight cases

The old matrix multiplied six mostly independent dimensions: `2 migration modes × 3 sequence-limit states × 2 shutdown modes × 2 APIs × 2 response modes × 2 transports = 96`.

The replacement is an explicit covering array. Each of the four meaningful migration-policy states appears in two complementary rows, so every policy is exercised with both values of every binary dimension. Across the eight rows, every pair of shutdown/API/response/transport values is covered. The set also retains the graceful-shutdown + completion + unary + TCP shape that exposed the short-completion shutdown race.

We intentionally do not combine migration-disabled with sequence-cap rejection: each independently suppresses the same retry, and multiplying two rejection policies does not protect a unique observable contract. The Rust migration unit tests retain detailed retry accounting and sequence-boundary coverage.

## Root cause

The aggregate matrix was skipped wholesale after repeated failures. The test infrastructure was not safe under concurrent GPU execution: workers shared several fixed ports and log paths, log-based worker discovery allowed only 500 ms, and response correctness included a hard six-second timing assertion. The metric assertions also accepted counts above the expected value, which could hide duplicate migrations.

Starting worker 2 only after worker 1 was ready added about 24 seconds of serialized cold-start time to every case. Starting both together makes their request planes ready within roughly 40 ms of each other.

The shorter request exposed a separate graceful-shutdown race: the previous 10-second parent-first wait allowed vLLM to finish all 512 output tokens before its engine child was stopped, leaving a zero-token retry that the frontend rejected. The two-second child-cleanup bound preserves endpoint withdrawal and forces the intended disconnect/retry without making request timing a correctness assertion.

## Impact

Pre-merge CI exercised meaningful aggregate vLLM migration coverage instead of skipped or duplicated permutations. With the no-retry GPU qualification complete, the test is back on nightly. The active aggregate set falls from 96 cases to 8, and the shared parameter set reduces the three unsupported disaggregated functions from 288 reported skips to 24.

Concurrent worker startup plus the reduced covering set lowers the aggregate GPU job from 27m49s originally to 2m22s while retaining the important behavioral boundaries.

## Validation

- exact nightly image: `210086341041.dkr.ecr.us-west-2.amazonaws.com/ai-dynamo/dynamo:10d71514e9c9c1c6a1b902be4b692378e78bff8a-vllm-runtime-nightly-test`
- exhaustive qualification before reduction: **96 passed, 0 skipped, 0 final failures** in 20m25s
- reduced covering matrix: **8 passed, 0 skipped, 0 retries** in 2m22s using eight scheduler slots; 20.2 GiB peak GPU memory
- collection check on this layer: 28 total cases, consisting of 8 active aggregate, 8 skipped prefill, 8 skipped KV-transfer, and 4 skipped stream-only decode cases
- pre-commit formatting, lint, spelling, and repository checks for the changed files (repository-wide marker report skipped after the GPU run exhausted its shared port allocator)
- `python3 -m py_compile tests/fault_tolerance/migration/test_vllm.py tests/fault_tolerance/migration/utils.py tests/utils/managed_process.py`
- `git diff --check origin/main...HEAD`


## CI qualification

- [vllm-runtime / Test cuda13.0, amd64](https://github.com/ai-dynamo/dynamo/actions/runs/32686029622/job/97318954122): 14/14 stacked migration cases passed (8 aggregate, 4 decode, 2 KV-transfer)
- zero target skips, xfails, or observed retries/reruns; target durations were 78–102 seconds
- aggregate retains its measured 290-second timeout and is back on `nightly` in `04d3b322ff`; decode/KV-transfer retain 350-second timeouts in their layers

## Review guidance

Start with the explicit aggregate/decode parameter sets and per-test markers in `tests/fault_tolerance/migration/test_vllm.py`. Then review `run_migration_test` in `tests/fault_tolerance/migration/utils.py`: strict exact-count validation is opt-in for vLLM, while SGLang/TRT-LLM callers retain the prior lower-bound behavior.

## Related issues

No public GitHub issue. This is the base layer of the internal Dynamo + vLLM Nightly Health project; follow-on work is tracked by [DYN-4118](https://linear.app/nvidia/issue/DYN-4118), [DYN-4119](https://linear.app/nvidia/issue/DYN-4119), and [DYN-4120](https://linear.app/nvidia/issue/DYN-4120).

## Merge dependency

**Resolved.** [#13716](https://github.com/ai-dynamo/dynamo/pull/13716) merged as `759cb4e3ea31cf6e20902a74da41cbaf8f86f2a1`. On August 24, 2026, the complete four-layer stack was rebased onto that `main` commit. This layer's rebased head is `ac3b2dd7703c05a95d91beba1c9775e12e6eef13`.

## Stack navigation

1. [#13684 — Aggregate migration](https://github.com/ai-dynamo/dynamo/pull/13684)
2. [#13692 — Prefill removal](https://github.com/ai-dynamo/dynamo/pull/13692) · [DYN-4118](https://linear.app/nvidia/issue/DYN-4118)
3. [#13693 — Decode migration](https://github.com/ai-dynamo/dynamo/pull/13693) · [DYN-4119](https://linear.app/nvidia/issue/DYN-4119)
4. [#13694 — KV-transfer migration](https://github.com/ai-dynamo/dynamo/pull/13694) · [DYN-4120](https://linear.app/nvidia/issue/DYN-4120)

This PR is layer **1** and targets `main`. Review and merge the stack in order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded migration test coverage across policy, sequence limits, termination modes, APIs, streaming, and request handling.
  * Improved validation of response content and migration metrics for more reliable results.
  * Added isolated logging, dynamic runtime configuration, and concurrent service startup coverage.

* **Bug Fixes**
  * Improved process cleanup and startup-error reporting.
  * Reduced flaky timing-related failures by using more resilient readiness and response checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->