### PR TITLE
fix(frontend): return JSON errors on the remaining OpenAI routes

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1369,8 +1369,10 @@ async fn completions_batch(
 async fn embeddings(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(mut request): Json<NvCreateEmbeddingRequest>,
+    body: Body,
 ) -> Result<Response, ErrorResponse> {
+    let body = read_json_request_body(&headers, body).await?;
+    let mut request: NvCreateEmbeddingRequest = parse_json_request("embeddings", &body)?;
     // return a 503 if the service or model is not ready
     check_ready(&state)?;
     check_model_serving_ready(&state, &request.inner.model)?;
@@ -1547,8 +1549,10 @@ fn decode_base64_embedding_to_floats(s: &str) -> Result<Vec<f32>, anyhow::Error>
 async fn classify(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(mut request): Json<NvCreateClassifyRequest>,
+    body: Body,
 ) -> Result<Response, ErrorResponse> {
+    let body = read_json_request_body(&headers, body).await?;
+    let mut request: NvCreateClassifyRequest = parse_json_request("classify", &body)?;
     // return a 503 if the service or model is not ready
     check_ready(&state)?;
     check_model_serving_ready(&state, &request.model)?;
@@ -1824,8 +1828,10 @@ fn build_pooling_binary_response(
 async fn pooling(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(mut request): Json<NvCreatePoolingRequest>,
+    body: Body,
 ) -> Result<Response, ErrorResponse> {
+    let body = read_json_request_body(&headers, body).await?;
+    let mut request: NvCreatePoolingRequest = parse_json_request("pooling", &body)?;
     // return a 503 if the service or model is not ready
     check_ready(&state)?;
     check_model_serving_ready(&state, &request.model)?;
@@ -4264,7 +4270,19 @@ pub fn responses_router(
 async fn images(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(request): Json<NvCreateImageRequest>,
+    body: Body,
+) -> Result<Response, ErrorResponse> {
+    let body = read_json_request_body(&headers, body).await?;
+    let request: NvCreateImageRequest = parse_json_request("images", &body)?;
+    images_with_request(state, headers, request).await
+}
+
+/// Shared by `/v1/images/generations` and `/v1/images/edits`, which differ only
+/// in the validation `images_edits` applies before handing the request over.
+async fn images_with_request(
+    state: Arc<service_v2::State>,
+    headers: HeaderMap,
+    request: NvCreateImageRequest,
 ) -> Result<Response, ErrorResponse> {
     // return a 503 if the service is not ready
     // (per-model readiness check is deferred until after we resolve the
@@ -4364,8 +4382,10 @@ async fn images(
 async fn images_edits(
     state: State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(request): Json<NvCreateImageRequest>,
+    body: Body,
 ) -> Result<Response, ErrorResponse> {
+    let body = read_json_request_body(&headers, body).await?;
+    let request: NvCreateImageRequest = parse_json_request("image edits", &body)?;
     if request.input_reference.is_none() {
         let code = StatusCode::BAD_REQUEST;
         return Err((
@@ -4379,7 +4399,7 @@ async fn images_edits(
             }),
         ));
     }
-    images(state, headers, Json(request)).await
+    images_with_request(state.0, headers, request).await
 }
 
 /// Create an Axum [`Router`] for the OpenAI API Images endpoints.
@@ -4405,8 +4425,10 @@ pub fn images_router(
 async fn videos(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(request): Json<NvCreateVideoRequest>,
+    body: Body,
 ) -> Result<Response, ErrorResponse> {
+    let body = read_json_request_body(&headers, body).await?;
+    let request: NvCreateVideoRequest = parse_json_request("videos", &body)?;
     // return a 503 if the service or model is not ready
     check_ready(&state)?;
     check_model_serving_ready(&state, &request.model)?;
@@ -4527,8 +4549,10 @@ async fn videos(
 async fn video_stream(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(request): Json<NvCreateVideoRequest>,
+    body: Body,
 ) -> Result<Response, ErrorResponse> {
+    let body = read_json_request_body(&headers, body).await?;
+    let request: NvCreateVideoRequest = parse_json_request("video stream", &body)?;
     check_ready(&state)?;
     check_model_serving_ready(&state, &request.model)?;
 
@@ -4722,8 +4746,10 @@ fn decode_audio_chunks(response: &NvAudioSpeechResponse) -> Result<Vec<Bytes>, S
 async fn handler_audio_speech(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(mut request): Json<NvCreateAudioSpeechRequest>,
+    body: Body,
 ) -> Result<Response, ErrorResponse> {
+    let body = read_json_request_body(&headers, body).await?;
+    let mut request: NvCreateAudioSpeechRequest = parse_json_request("audio speech", &body)?;
     // return a 503 if the service is not ready
     // (per-model readiness check is deferred until after we resolve the
     // Option<String> model field; see below)

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -1808,6 +1808,41 @@ mod tests {
         handle.abort();
     }
 
+    /// The JSON error envelope has to be the same on every OpenAI-compatible
+    /// route, not just the ones converted first. `/v1/embeddings` returned
+    /// Axum's plain-text rejection while `/v1/responses` returned JSON, so a
+    /// client parsing the error worked on one endpoint and failed on the other.
+    #[tokio::test]
+    async fn test_embeddings_non_json_content_type_returns_json_error() {
+        let (port, handle) = spawn_default_service().await;
+
+        let resp = reqwest::Client::new()
+            .post(format!("http://localhost:{port}/v1/embeddings"))
+            .header("content-type", "text/plain")
+            .body(r#"{"model":"model","input":"hi"}"#)
+            .send()
+            .await
+            .expect("request failed");
+
+        assert_eq!(resp.status(), reqwest::StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        assert_eq!(
+            resp.headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .map(|v| v.starts_with("application/json")),
+            Some(true),
+            "the 415 must be JSON, not Axum's text/plain rejection"
+        );
+        let body: serde_json::Value = resp.json().await.expect("body must be JSON");
+        assert_eq!(body["code"], 415);
+        assert_eq!(
+            body["message"],
+            "Expected request with Content-Type application/json"
+        );
+
+        handle.abort();
+    }
+
     /// Verifies that malformed JSON returns the standard JSON error envelope
     /// instead of Axum's default plain-text rejection.
     #[tokio::test]


### PR DESCRIPTION
## Summary

#13102 gave `/v1/responses`, `/v1/chat/completions` and `/v1/completions` a JSON error envelope for a bad `Content-Type`, an oversized body and malformed JSON, by reading the body through `read_json_request_body` and `parse_json_request`.

Eight handlers were left on the plain `Json<T>` extractor and still return Axum's `text/plain` rejection. The envelope therefore depends on which endpoint the client happened to call. Measured on `main`, same mistake, same status code:

```
POST /v1/responses  + Content-Type: text/plain
  415  content-type: application/json
       {"message":"Expected request with Content-Type application/json","type":...,"code":415}

POST /v1/embeddings + Content-Type: text/plain
  415  content-type: text/plain; charset=utf-8
       Expected request with `Content-Type: application/json`
```

A client that parses the error body succeeds against one endpoint and throws against the other. That is the defect: not the status, which is already right, but the shape.

This routes the remaining handlers through the same two helpers: **embeddings, classify, pooling, images, image edits, videos, video stream, audio speech**. They already took `HeaderMap` and already returned `Result<Response, ErrorResponse>`, so each one is a signature swap plus the two lines #13102 established. No new abstraction and no new error text.

One handler needed more than the swap. `images_edits` validates `input_reference` and then delegates to `images`, which now consumes a `Body` it has already read. The part of `images` after parsing moves into `images_with_request`, which both call. Two real callers, so it is not a wrapper for its own sake.

### Overlap worth flagging

@chanh has #13268 open against `ensure_json_content_type`, changing an absent `Content-Type` to be treated as JSON. This PR adds callers of that helper rather than touching it, so the changes are complementary and should not conflict textually. If #13268 lands first, these eight endpoints inherit the new semantics automatically, which is the point of routing them through the shared helper. Happy to rebase behind it.

## Validation

Behaviour checked by driving a real server through the existing `spawn_default_service` harness, before and after:

| endpoint | before | after |
|---|---|---|
| `/v1/responses` | `415 application/json` | unchanged |
| `/v1/embeddings` | `415 text/plain` | **`415 application/json`**, identical envelope |

Added `test_embeddings_non_json_content_type_returns_json_error`, mirroring the `/v1/responses` test from #13102 and additionally asserting the response `content-type`, since the status was already correct before this change and only the envelope was wrong. **Confirmed red first** by restoring `openai.rs` from `upstream/main` and re-running:

```
assertion `left == right` failed: the 415 must be JSON, not Axum's text/plain rejection
  left: Some(false)
 right: Some(true)
```

- `cargo test -p dynamo-llm --lib --no-default-features`: **2042 passed, 0 failed** on a clean run.
- `cargo clippy` clean, `cargo fmt --all -- --check` clean.

Disclosing one flake rather than reporting only the clean run: `test_oversized_body_returns_json_413` fails intermittently, 3 of 6 runs in isolation on this branch. That is the same rate I measured on clean `main` and reported on #13624; it is a pre-existing race between the 413 response and the client still sending the body, not something this change introduces. The two full-suite runs that failed failed only on that test.

Not verified here: I have no GPU, so the success paths of these eight endpoints were not exercised end to end. The change does not touch them, only how the request body is read and how the read is reported when it fails.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for API request bodies, including JSON content types and configured size limits.
  * Standardized request parsing across embeddings, classification, pooling, video, image, and audio endpoints.
  * Non-JSON embedding requests now return a clear `415 Unsupported Media Type` response with structured error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->