### PR TITLE
test(vllm): remove unsupported prefill migration test

### DIFF
--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -4,7 +4,6 @@
 """
 Test Execution Times (Last Run: 2026-01-09):
 - test_request_migration_vllm_aggregated: ~95s
-- test_request_migration_vllm_prefill: N/A
 - test_request_migration_vllm_kv_transfer: N/A
 - test_request_migration_vllm_decode: ~115s
 """
@@ -409,87 +408,6 @@ def test_request_migration_vllm_aggregated(
                 max_tokens=AGGREGATED_MAX_TOKENS,
                 expected_ongoing_request_count=1,
             )
-
-
-@pytest.mark.skip(reason="Prefill migration not yet supported")
-@pytest.mark.timeout(350)  # 3x average
-@pytest.mark.nightly
-@MIGRATION_PARAMETERS
-def test_request_migration_vllm_prefill(
-    request,
-    runtime_services_dynamic_ports,
-    set_ucx_tls_no_mm,
-    predownload_models,
-    migration_limit,
-    migration_max_seq_len,
-    immediate_kill,
-    request_api,
-    stream,
-    tmp_path,
-):
-    """
-    End-to-end test for prefill worker request migration in disaggregated mode.
-
-    Setup: 1 decode worker + 2 prefill workers
-
-    Parameters:
-        immediate_kill: True for abrupt kill (SIGKILL), False for graceful shutdown (SIGTERM)
-        migration_limit: > 0 to verify migration succeeds, 0 to verify request fails
-        request_api: "chat" for chat completion API, "completion" for completion API
-        stream: True for streaming, False for non-streaming
-    """
-
-    # Step 1: Start the frontend
-    with DynamoFrontendProcess(
-        request,
-        migration_limit=migration_limit,
-        migration_max_seq_len=migration_max_seq_len,
-    ) as frontend:
-        logger.info("Frontend started successfully")
-
-        # Step 2: Start decode worker first (required for prefill workers to connect)
-        with DynamoWorkerProcess(
-            request,
-            "worker0",
-            frontend.frontend_port,
-            tmp_path,
-            is_prefill=False,
-        ) as decode_worker:
-            logger.info("Decode Worker PID: %s", decode_worker.get_pid())
-
-            # Step 3: Start 2 prefill workers
-            with DynamoWorkerProcess(
-                request,
-                "worker1",
-                frontend.frontend_port,
-                tmp_path,
-                is_prefill=True,
-            ) as prefill1:
-                logger.info("Prefill Worker 1 PID: %s", prefill1.get_pid())
-
-                with DynamoWorkerProcess(
-                    request,
-                    "worker2",
-                    frontend.frontend_port,
-                    tmp_path,
-                    is_prefill=True,
-                ) as prefill2:
-                    logger.info("Prefill Worker 2 PID: %s", prefill2.get_pid())
-
-                    # Step 4: Run migration test
-                    run_migration_test(
-                        frontend,
-                        prefill1,
-                        prefill2,
-                        receiving_pattern="Prefill Request ID: ",
-                        migration_limit=migration_limit,
-                        migration_max_seq_len=migration_max_seq_len,
-                        immediate_kill=immediate_kill,
-                        use_chat_completion=(request_api == "chat"),
-                        stream=stream,
-                        use_long_prompt=True,
-                        expected_ongoing_request_count=1,
-                    )
 
 
 @pytest.mark.skip(


### PR DESCRIPTION
## Summary

- remove the permanently skipped vLLM prefill-migration test and its stale timing entry
- remove 8 matrix nodes that described a capability Dynamo does not implement
- keep the supported aggregated, KV-transfer, and decode migration tests unchanged

## Support evidence and decision

This is intentionally a removal rather than an unskip:

- Dynamo's `Migration` operator wraps the complete prefill-to-decode pipeline. On a migratable error, `RetryManager` clones and reissues the `PreprocessedRequest` through that pipeline.
- The migrator accumulates generated response token IDs. During prefill there are no generated response tokens to preserve, and the vLLM prefill path exposes no checkpoint/export/restore mechanism for partially computed prefill KV state.
- Consequently, a failure during prefill can at most restart and recompute the prompt on another prefill worker. That is request replay/new-request recovery, not migration of in-flight prefill state.
- The test was introduced in #5448 already marked `xfail` with `Prefill migration not yet supported`; it was later converted to an unconditional skip. It never represented a supported regression boundary.
- The test's assertion only checked eventual request success, so even an `xpass` could not distinguish full recomputation from state migration.

A permanently skipped hypothetical test has no regression sensitivity and should not remain in the nightly denominator. If partial prefill-state transfer is implemented later, it needs a new test with an observable state-reuse contract.

## Validation

- exact nightly image collection before: `28 tests collected`
- exact nightly image collection after: `20 tests collected` (8 unsupported prefill nodes removed)
- `python3 -m py_compile tests/fault_tolerance/migration/test_vllm.py`
- `git diff --check`
- scoped pre-commit formatting, lint, spelling, and hygiene hooks passed
- repository-wide `pytest-marker-report` reached the changed file and reported `tests/fault_tolerance/migration/test_vllm.py: 20`, then failed while collecting unrelated suites because the shared test port allocator was exhausted

No GPU run was needed: this change only deletes an unconditionally skipped test, and production-code inspection conclusively shows that its claimed state-transfer capability is absent.

## Merge dependency

**Resolved.** [#13716](https://github.com/ai-dynamo/dynamo/pull/13716) merged as `759cb4e3ea31cf6e20902a74da41cbaf8f86f2a1`. On August 24, 2026, the complete four-layer stack was rebased onto that `main` commit. This layer's rebased head is `8477ac88b2061f73be9075b43f218b8b3c1d2ab7`.

## Stack navigation

1. [#13684 — Aggregate migration](https://github.com/ai-dynamo/dynamo/pull/13684)
2. [#13692 — Prefill removal](https://github.com/ai-dynamo/dynamo/pull/13692) · [DYN-4118](https://linear.app/nvidia/issue/DYN-4118)
3. [#13693 — Decode migration](https://github.com/ai-dynamo/dynamo/pull/13693) · [DYN-4119](https://linear.app/nvidia/issue/DYN-4119)
4. [#13694 — KV-transfer migration](https://github.com/ai-dynamo/dynamo/pull/13694) · [DYN-4120](https://linear.app/nvidia/issue/DYN-4120)

This PR is layer **2** and targets `codex/vllm-agg-migration`. Review and merge the stack in order.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an outdated prefill migration test and its associated execution-time entry.
  * Aggregated, key-value transfer, and decode migration coverage remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->