### PR TITLE
test(vllm): restore decode migration coverage

### DIFF
--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -32,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 AGGREGATED_MAX_MODEL_LEN = 1024
 AGGREGATED_MAX_TOKENS = 512
+DECODE_MAX_MODEL_LEN = 1024
+DECODE_MAX_TOKENS = 512
 
 # Cover each distinct migration policy with complementary lifecycle, API,
 # response, and transport values. Together these eight rows cover every pair
@@ -257,6 +259,14 @@ class DynamoWorkerProcess(ManagedProcess):
             command.extend(["--disaggregation-mode", "prefill"])
         elif is_prefill is False:
             command.extend(["--disaggregation-mode", "decode"])
+
+        if is_prefill is not None:
+            command.extend(
+                [
+                    "--kv-transfer-config",
+                    '{"kv_connector":"NixlConnector","kv_role":"kv_both"}',
+                ]
+            )
 
         # Aggregated mode and prefill workers publish KV events
         if is_prefill is not False:
@@ -499,17 +509,10 @@ def test_request_migration_vllm_kv_transfer(
                     )
 
 
-@pytest.mark.skip(
-    reason=(
-        "Migration reuses the same request_id for vLLM, but the prefill worker's "
-        "KV cache still holds the request due to delay_free_blocks in disaggregated mode. "
-        "With chat completions API, prefix cache hits on chat template tokens cause "
-        "an assertion error in vLLM's KV cache manager (save_new_computed_blocks expects "
-        "no new computed blocks for existing requests)."
-    ),
-)
 @pytest.mark.timeout(350)  # 3x average
 @pytest.mark.nightly
+@pytest.mark.profiled_vram_gib(6.8)
+@pytest.mark.requested_vllm_kv_cache_bytes(331_711_000)
 @DECODE_MIGRATION_PARAMETERS
 def test_request_migration_vllm_decode(
     request,
@@ -526,13 +529,15 @@ def test_request_migration_vllm_decode(
     End-to-end test for decode worker request migration in disaggregated mode.
 
     Setup: 1 prefill worker + 2 decode workers
+    The request is streamed so the test can inject a fault after decode starts.
 
     Parameters:
         immediate_kill: True for abrupt kill (SIGKILL), False for graceful shutdown (SIGTERM)
         migration_limit: > 0 to verify migration succeeds, 0 to verify request fails
         request_api: "chat" for chat completion API, "completion" for completion API
-        This target is always streaming so the fault can be injected while the
-        decode request is in flight.
+
+    This target is always streaming so the fault can be injected while the
+    decode request is in flight.
     """
     # Step 1: Start the frontend
     with DynamoFrontendProcess(
@@ -542,46 +547,48 @@ def test_request_migration_vllm_decode(
     ) as frontend:
         logger.info("Frontend started successfully")
 
-        # Step 2: Start prefill worker first
-        with DynamoWorkerProcess(
+        # Step 2: Start the independent prefill and decode workers concurrently
+        prefill_worker = DynamoWorkerProcess(
             request,
             "worker0",
             frontend.frontend_port,
             tmp_path,
             is_prefill=True,
-        ) as prefill_worker:
+            max_model_len=DECODE_MAX_MODEL_LEN,
+        )
+        decode1 = DynamoWorkerProcess(
+            request,
+            "worker1",
+            frontend.frontend_port,
+            tmp_path,
+            is_prefill=False,
+            max_model_len=DECODE_MAX_MODEL_LEN,
+        )
+        decode2 = DynamoWorkerProcess(
+            request,
+            "worker2",
+            frontend.frontend_port,
+            tmp_path,
+            is_prefill=False,
+            max_model_len=DECODE_MAX_MODEL_LEN,
+        )
+        with managed_processes_concurrently(prefill_worker, decode1, decode2):
             logger.info("Prefill Worker PID: %s", prefill_worker.get_pid())
+            logger.info("Decode Worker 1 PID: %s", decode1.get_pid())
+            logger.info("Decode Worker 2 PID: %s", decode2.get_pid())
 
-            # Step 3: Start 2 decode workers
-            with DynamoWorkerProcess(
-                request,
-                "worker1",
-                frontend.frontend_port,
-                tmp_path,
-                is_prefill=False,
-            ) as decode1:
-                logger.info("Decode Worker 1 PID: %s", decode1.get_pid())
-
-                with DynamoWorkerProcess(
-                    request,
-                    "worker2",
-                    frontend.frontend_port,
-                    tmp_path,
-                    is_prefill=False,
-                ) as decode2:
-                    logger.info("Decode Worker 2 PID: %s", decode2.get_pid())
-
-                    # Step 4: Run migration test
-                    run_migration_test(
-                        frontend,
-                        decode1,
-                        decode2,
-                        receiving_pattern="Decode Request ID: ",
-                        migration_limit=migration_limit,
-                        migration_max_seq_len=migration_max_seq_len,
-                        immediate_kill=immediate_kill,
-                        use_chat_completion=(request_api == "chat"),
-                        stream=True,
-                        wait_for_new_response_before_stop=True,
-                        expected_ongoing_request_count=1,
-                    )
+            # Step 3: Run migration test
+            run_migration_test(
+                frontend,
+                decode1,
+                decode2,
+                receiving_pattern="Decode Request ID: ",
+                migration_limit=migration_limit,
+                migration_max_seq_len=migration_max_seq_len,
+                immediate_kill=immediate_kill,
+                use_chat_completion=(request_api == "chat"),
+                stream=True,
+                max_tokens=DECODE_MAX_TOKENS,
+                wait_for_new_response_before_stop=True,
+                expected_ongoing_request_count=1,
+            )

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -340,19 +340,16 @@ def wait_for_response(
     initial_len = len(response_list)
     target_len = initial_len + num_responses
     poll_interval = 0.001  # 1ms
-    elapsed = 0.0
+    deadline = time.monotonic() + max_wait_time
 
-    while elapsed < max_wait_time:
+    while time.monotonic() < deadline:
         if len(response_list) >= target_len:
             return
         time.sleep(poll_interval)
-        elapsed += poll_interval
 
-    logger.warning(
-        "Only received %s/%s new responses within %ss",
-        len(response_list) - initial_len,
-        num_responses,
-        max_wait_time,
+    pytest.fail(
+        f"Only received {len(response_list) - initial_len}/{num_responses} new "
+        f"responses within {max_wait_time}s"
     )
 
 
@@ -581,6 +578,9 @@ def run_migration_test(
     # Step 3: Optionally wait for new response before stop (for decode tests)
     if wait_for_new_response_before_stop:
         wait_for_response(response_list)
+        assert (
+            request_thread.is_alive()
+        ), "Request completed before the worker fault was injected"
 
     # Step 4: Stop the worker (kill or graceful shutdown)
     if immediate_kill:


### PR DESCRIPTION
## Summary

- Stack this change on #13684 and restore the vLLM disaggregated decode-worker migration test.
- Replace the inherited eight-row parameter surface with four explicit streaming cases: one for each migration policy outcome, while retaining both shutdown paths, both OpenAI APIs, and both request-plane transports.
- Supply the explicit NIXL `kv_both` transfer configuration now required by disaggregated vLLM workers.
- Bound the workload to a 1,024-token context and 512 output tokens, then start the independent prefill and decode workers concurrently.
- Require five streamed responses and prove the request is still in flight before injecting the worker fault; a missed causal window now fails instead of logging a warning.
- Add deterministic KV-cache and measured VRAM markers so the cases participate safely in the GPU scheduler.
- Retain the measured 350-second pytest timeout and return the restored matrix to `nightly` after 4/4 decode cases passed the no-retry pre-merge GPU qualification.

## Scope reduction and traceability

The inherited covering array supplied eight rows to every migration test. Decode migration can only inject its fault after a response stream has started, so the four unary rows were not applicable and immediately self-skipped.

| Original equivalence class | Permanent decode case |
| --- | --- |
| Migration enabled, no sequence cap | `migration_enabled-worker_failure-chat-stream-nats` |
| Migration disabled | `migration_disabled-graceful_shutdown-completion-stream-nats` |
| Migration sequence cap exceeded | `max_seq_len_exceeded-worker_failure-completion-stream-tcp` |
| Finite sequence cap not exceeded | `max_seq_len_not_exceeded-graceful_shutdown-chat-stream-tcp` |
| Four unary rows | Omitted: the complete response leaves no in-flight decode request to fault |

This changes decode collection from eight outer-skipped rows (and four additional inner skips if the outer skip was bypassed) to four named executable cases with no skip.

## Live root cause

Forced execution in the exact nightly image failed before model readiness:

```text
ValueError: --connector is deprecated and the default is no longer nixl.
When using --disaggregation-mode prefill, you must explicitly provide
--kv-transfer-config.
```

The test harness had not followed the current disaggregated vLLM CLI contract. Adding the canonical `NixlConnector`/`kv_both` configuration lets the test reach and validate the complete decode migration chain. The enabled chat case also exercises the historical request-ID/prefix-cache regression described by the removed skip.

## Validation

Exact image:

```text
210086341041.dkr.ecr.us-west-2.amazonaws.com/ai-dynamo/dynamo:10d71514e9c9c1c6a1b902be4b692378e78bff8a-vllm-runtime-nightly-test
```

- Exact-image collection: four decode node IDs collected, zero target skips.
- Focused repaired case with sequential worker startup: 1/1 passed first attempt in 183.29s.
- Focused case with concurrent startup: 1/1 passed first attempt in 104.47s, a 43% reduction.
- VRAM profile with the deterministic 331,711,000-byte cache cap: 1/1 passed; 6.8 GiB peak; 0 MiB leaked (668 MiB baseline and final).
- All retained cases together using `-n 4 --max-vram-gib=41`: 4/4 passed first attempt, zero retries/skips, in 150.05s (2m30s); scheduler reported 3.5x versus 520s sequential and observed an 18.1/48 GiB suite peak.
- Post-suite GPU process query returned no compute processes.
- `isort`, direct single-worker `black --check`, `flake8`, `codespell`, `ruff`, whitespace checks, `py_compile`, and `git diff --check` passed.
- The repository-wide marker report found zero missing marker sets across 4,806 tests, but its local hook exited nonzero because unrelated collection exhausted the shared workstation port allocator after GPU runs. Exact-image target collection above passed.

No retry-assisted result is included, and no new test was added: this restores the existing behaviorally justified end-to-end test at its smallest meaningful surface.

## Merge dependency

**Resolved.** [#13716](https://github.com/ai-dynamo/dynamo/pull/13716) merged as `759cb4e3ea31cf6e20902a74da41cbaf8f86f2a1`. On August 24, 2026, the complete four-layer stack was rebased onto that `main` commit. This layer's rebased head is `f4d622223ef7f452f833bc179d6e2da62febb5f9`.

## Stack navigation

1. [#13684 — Aggregate migration](https://github.com/ai-dynamo/dynamo/pull/13684)
2. [#13692 — Prefill removal](https://github.com/ai-dynamo/dynamo/pull/13692) · [DYN-4118](https://linear.app/nvidia/issue/DYN-4118)
3. [#13693 — Decode migration](https://github.com/ai-dynamo/dynamo/pull/13693) · [DYN-4119](https://linear.app/nvidia/issue/DYN-4119)
4. [#13694 — KV-transfer migration](https://github.com/ai-dynamo/dynamo/pull/13694) · [DYN-4120](https://linear.app/nvidia/issue/DYN-4120)

This PR is layer **3** and targets `codex/vllm-prefill-migration`. Review and merge the stack in order.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->