### PR TITLE
test(vllm): restore KV-transfer migration coverage

### DIFF
--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -26,6 +26,7 @@ from .utils import (
     DynamoFrontendProcess,
     managed_processes_concurrently,
     run_migration_test,
+    wait_for_endpoint_instances,
 )
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,9 @@ AGGREGATED_MAX_MODEL_LEN = 1024
 AGGREGATED_MAX_TOKENS = 512
 DECODE_MAX_MODEL_LEN = 1024
 DECODE_MAX_TOKENS = 512
+KV_TRANSFER_MAX_MODEL_LEN = 1024
+KV_TRANSFER_MAX_TOKENS = 192
+KV_TRANSFER_PROMPT_REPETITIONS = 800
 
 # Cover each distinct migration policy with complementary lifecycle, API,
 # response, and transport values. Together these eight rows cover every pair
@@ -152,6 +156,32 @@ DECODE_MIGRATION_CASES = [
     ),
 ]
 
+# This target enters KV transfer only when migration is enabled and under the
+# sequence cap. The aggregate test owns the shared disabled/max-seq policies.
+# Chat retains the historical prefix-cache regression shape; these two cases
+# cover both shutdown lifecycles and both request-plane implementations while
+# pairing the response mode, which is independent before KV transfer completes.
+KV_TRANSFER_CASES = [
+    pytest.param(
+        3,
+        None,
+        True,
+        "chat",
+        True,
+        "nats",
+        id="worker-failure-chat-stream-nats",
+    ),
+    pytest.param(
+        3,
+        None,
+        False,
+        "chat",
+        False,
+        "tcp",
+        id="graceful-shutdown-chat-unary-tcp",
+    ),
+]
+
 MIGRATION_PARAMETERS = pytest.mark.parametrize(
     (
         "migration_limit",
@@ -174,6 +204,19 @@ DECODE_MIGRATION_PARAMETERS = pytest.mark.parametrize(
         "request_plane",
     ),
     DECODE_MIGRATION_CASES,
+    indirect=["request_plane"],
+)
+
+KV_TRANSFER_MIGRATION_PARAMETERS = pytest.mark.parametrize(
+    (
+        "migration_limit",
+        "migration_max_seq_len",
+        "immediate_kill",
+        "request_api",
+        "stream",
+        "request_plane",
+    ),
+    KV_TRANSFER_CASES,
     indirect=["request_plane"],
 )
 
@@ -420,18 +463,11 @@ def test_request_migration_vllm_aggregated(
             )
 
 
-@pytest.mark.skip(
-    reason=(
-        "Migration reuses the same request_id for vLLM, but the prefill worker's "
-        "KV cache still holds the request due to delay_free_blocks in disaggregated mode. "
-        "With chat completions API, prefix cache hits on chat template tokens cause "
-        "an assertion error in vLLM's KV cache manager (save_new_computed_blocks expects "
-        "no new computed blocks for existing requests)."
-    ),
-)
 @pytest.mark.timeout(350)  # 3x average
 @pytest.mark.nightly
-@MIGRATION_PARAMETERS
+@pytest.mark.profiled_vram_gib(6.9)
+@pytest.mark.requested_vllm_kv_cache_bytes(331_711_000)
+@KV_TRANSFER_MIGRATION_PARAMETERS
 def test_request_migration_vllm_kv_transfer(
     request,
     runtime_services_dynamic_ports,
@@ -464,49 +500,56 @@ def test_request_migration_vllm_kv_transfer(
     ) as frontend:
         logger.info("Frontend started successfully")
 
-        # Step 2: Start prefill worker first
-        with DynamoWorkerProcess(
+        # Step 2: Start the independent prefill and decode workers concurrently.
+        prefill_worker = DynamoWorkerProcess(
             request,
             "worker0",
             frontend.frontend_port,
             tmp_path,
             is_prefill=True,
-        ) as prefill_worker:
+            max_model_len=KV_TRANSFER_MAX_MODEL_LEN,
+        )
+        decode1 = DynamoWorkerProcess(
+            request,
+            "worker1",
+            frontend.frontend_port,
+            tmp_path,
+            is_prefill=False,
+            max_model_len=KV_TRANSFER_MAX_MODEL_LEN,
+        )
+        decode2 = DynamoWorkerProcess(
+            request,
+            "worker2",
+            frontend.frontend_port,
+            tmp_path,
+            is_prefill=False,
+            max_model_len=KV_TRANSFER_MAX_MODEL_LEN,
+        )
+        with managed_processes_concurrently(prefill_worker, decode1, decode2):
             logger.info("Prefill Worker PID: %s", prefill_worker.get_pid())
-
-            # Step 3: Start 2 decode workers
-            with DynamoWorkerProcess(
-                request,
-                "worker1",
+            logger.info("Decode Worker 1 PID: %s", decode1.get_pid())
+            logger.info("Decode Worker 2 PID: %s", decode2.get_pid())
+            wait_for_endpoint_instances(
                 frontend.frontend_port,
-                tmp_path,
-                is_prefill=False,
-            ) as decode1:
-                logger.info("Decode Worker 1 PID: %s", decode1.get_pid())
+                {("prefill", "generate"): 1, ("backend", "generate"): 2},
+            )
 
-                with DynamoWorkerProcess(
-                    request,
-                    "worker2",
-                    frontend.frontend_port,
-                    tmp_path,
-                    is_prefill=False,
-                ) as decode2:
-                    logger.info("Decode Worker 2 PID: %s", decode2.get_pid())
-
-                    # Step 4: Run migration test
-                    run_migration_test(
-                        frontend,
-                        decode1,
-                        decode2,
-                        receiving_pattern="Decode Request ID: ",
-                        migration_limit=migration_limit,
-                        migration_max_seq_len=migration_max_seq_len,
-                        immediate_kill=immediate_kill,
-                        use_chat_completion=(request_api == "chat"),
-                        stream=stream,
-                        use_long_prompt=True,
-                        expected_ongoing_request_count=1,
-                    )
+            # Step 3: Run migration test
+            run_migration_test(
+                frontend,
+                decode1,
+                decode2,
+                receiving_pattern="Decode Request ID: ",
+                migration_limit=migration_limit,
+                migration_max_seq_len=migration_max_seq_len,
+                immediate_kill=immediate_kill,
+                use_chat_completion=(request_api == "chat"),
+                stream=stream,
+                max_tokens=KV_TRANSFER_MAX_TOKENS,
+                use_long_prompt=True,
+                long_prompt_repetitions=KV_TRANSFER_PROMPT_REPETITIONS,
+                expected_ongoing_request_count=1,
+            )
 
 
 @pytest.mark.timeout(350)  # 3x average

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -99,6 +99,7 @@ def start_completion_request(
     stream: bool,
     use_long_prompt: bool = False,
     max_tokens: int | None = None,
+    long_prompt_repetitions: int = 8_000,
 ) -> tuple:
     """
     Start a long-running completion request in a separate thread.
@@ -111,6 +112,7 @@ def start_completion_request(
         stream: Whether to use streaming responses
         use_long_prompt: Whether to use a long prompt (~8000 tokens)
         max_tokens: Explicit output-token cap, or the backend default when unset
+        long_prompt_repetitions: Number of repeated words in the long prompt
 
     Returns:
         tuple: (request_thread, response_list) where response_list contains
@@ -123,7 +125,7 @@ def start_completion_request(
     def send_request():
         prompt = "Tell me a long long long story about yourself?"
         if use_long_prompt:
-            prompt += " Make sure it is" + " long" * 8000 + "!"
+            prompt += " Make sure it is" + " long" * long_prompt_repetitions + "!"
 
         logger.info(
             "Sending completion request (stream=%s) with prompt: '%s...'",
@@ -173,6 +175,7 @@ def start_chat_completion_request(
     stream: bool,
     use_long_prompt: bool = False,
     max_tokens: int | None = None,
+    long_prompt_repetitions: int = 8_000,
 ) -> tuple:
     """
     Start a long-running chat completion request in a separate thread.
@@ -185,6 +188,7 @@ def start_chat_completion_request(
         stream: Whether to use streaming responses
         use_long_prompt: Whether to use a long prompt (~8000 tokens)
         max_tokens: Explicit output-token cap, or the backend default when unset
+        long_prompt_repetitions: Number of repeated words in the long prompt
 
     Returns:
         tuple: (request_thread, response_list) where response_list contains
@@ -197,7 +201,7 @@ def start_chat_completion_request(
     def send_request():
         prompt = "Tell me a long long long story about yourself?"
         if use_long_prompt:
-            prompt += " Make sure it is" + " long" * 8000 + "!"
+            prompt += " Make sure it is" + " long" * long_prompt_repetitions + "!"
 
         logger.info(
             "Sending chat completion request (stream=%s) with prompt: '%s...'",
@@ -322,6 +326,48 @@ def determine_request_receiving_worker(
         pytest.fail("Both workers received the request")
     else:
         pytest.fail("Neither worker received the request")
+
+
+def wait_for_endpoint_instances(
+    frontend_port: int,
+    expected_counts: dict[tuple[str, str], int],
+    max_wait_time: float = 10.0,
+) -> None:
+    """Wait until the frontend's discovery view contains every required endpoint."""
+    deadline = time.monotonic() + max_wait_time
+    last_counts: dict[tuple[str, str], int] = {}
+    last_error: Exception | None = None
+    poll_event = threading.Event()
+
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(
+                f"http://localhost:{frontend_port}/health",
+                timeout=1,
+            )
+            response.raise_for_status()
+            instances = response.json().get("instances", [])
+            last_counts = {}
+            for instance in instances:
+                key = (instance.get("component"), instance.get("endpoint"))
+                last_counts[key] = last_counts.get(key, 0) + 1
+
+            if all(
+                last_counts.get(endpoint, 0) >= expected
+                for endpoint, expected in expected_counts.items()
+            ):
+                logger.info("Frontend discovery is ready: %s", last_counts)
+                return
+        except (requests.RequestException, ValueError) as error:
+            last_error = error
+
+        poll_event.wait(timeout=0.1)
+
+    pytest.fail(
+        "Frontend discovery did not reach the required endpoint counts "
+        f"{expected_counts} within {max_wait_time}s; last counts={last_counts}, "
+        f"last error={last_error}"
+    )
 
 
 def wait_for_response(
@@ -531,6 +577,7 @@ def run_migration_test(
     stream: bool,
     max_tokens: int | None = None,
     use_long_prompt: bool = False,
+    long_prompt_repetitions: int = 8_000,
     wait_for_new_response_before_stop: bool = False,
     expected_ongoing_request_count: int | None = None,
 ) -> None:
@@ -549,6 +596,7 @@ def run_migration_test(
         stream: Whether to use streaming responses
         max_tokens: Explicit output-token cap, or the backend default when unset
         use_long_prompt: Whether to use long prompt (for prefill tests)
+        long_prompt_repetitions: Number of repeated words in the long prompt
         wait_for_new_response_before_stop: Whether to wait for response before stopping (for decode tests)
         expected_ongoing_request_count: Exact expected count for callers that
             opt into strict metric validation. When omitted, preserve the
@@ -561,6 +609,7 @@ def run_migration_test(
             stream=stream,
             use_long_prompt=use_long_prompt,
             max_tokens=max_tokens,
+            long_prompt_repetitions=long_prompt_repetitions,
         )
     else:
         request_thread, response_list = start_completion_request(
@@ -568,12 +617,16 @@ def run_migration_test(
             stream=stream,
             use_long_prompt=use_long_prompt,
             max_tokens=max_tokens,
+            long_prompt_repetitions=long_prompt_repetitions,
         )
 
     # Step 2: Determine which worker received the request
     worker, worker_name = determine_request_receiving_worker(
         worker1, worker2, receiving_pattern=receiving_pattern
     )
+    assert (
+        request_thread.is_alive()
+    ), "Request completed before the migration fault could be injected"
 
     # Step 3: Optionally wait for new response before stop (for decode tests)
     if wait_for_new_response_before_stop:


### PR DESCRIPTION
## Summary

- restore the vLLM disaggregated KV-transfer migration test on top of #13693
- pass the explicit NIXL `--kv-transfer-config` now required by vLLM 0.27.1
- replace the inherited eight migration combinations with two KV-specific cases while the aggregate test continues to own shared migration-policy coverage
- reduce the functional workload from an approximately 8K-token prompt and 8,192-token context to an 823-token transferred prefix, 1,024-token context, and 192-token output cap
- start the independent prefill and two decode workers concurrently and wait on the frontend's structured discovery view before injecting the fault
- add the measured 6.9 GiB VRAM marker so the GPU scheduler selects the test safely
- retain the measured 350-second pytest timeout and return the restored matrix to `nightly` after 2/2 KV-transfer cases passed the no-retry pre-merge GPU qualification

## Scope and traceability

The target now retains two cases:

| Case | Fault lifecycle | API | Response | Request plane |
| --- | --- | --- | --- | --- |
| `worker-failure-chat-stream-nats` | SIGKILL | chat | streaming | NATS |
| `graceful-shutdown-chat-unary-tcp` | SIGTERM | chat | unary | TCP |

- Chat is retained because the historical defect involved chat-template prefix-cache hits and reuse of the request ID.
- Migration-disabled and sequence-cap combinations cannot enter successful KV transfer; they remain covered by the aggregate migration test.
- Completion differs only at the renderer boundary for this defect. Streaming/unary are paired across the retained cases rather than multiplied with every other axis.
- Both fault lifecycles and both request planes remain represented.

On the stacked base, this changes the target from eight skipped outcomes to two executing outcomes. The module changes from 20 outcomes (12 pass / 8 skip) to 14 executing outcomes with zero function-level migration skips. The original pre-#13684 Cartesian target had 96 combinations.

## Root cause and restored contract

The first forced execution failed before migration because current vLLM rejects disaggregated startup without an explicit KV connector. After configuring NIXL, the old 8K workload did transfer approximately 878.5 MB, but nearly filled the functional test's cache and failed to complete within the 350-second test timeout (377.97 seconds including teardown).

The smaller workload still transfers an 823-token prefix through NIXL and exercises the historical same-request-ID/chat-prefix path. The test now proves that the request is still in flight when the worker fault is injected, the user response completes after migration, and the frontend reports exactly one ongoing-request migration.

Profiling also exposed an independent startup race: three concurrently healthy engines did not guarantee that the frontend had observed both decode instances. The test now condition-polls `/health` until one prefill and two decode `generate` instances are present; it does not add sleeps or retries.

## Validation

Exact image:

`210086341041.dkr.ecr.us-west-2.amazonaws.com/ai-dynamo/dynamo:10d71514e9c9c1c6a1b902be4b692378e78bff8a-vllm-runtime-nightly-test`

All qualification runs used the local GPU, the exact nightly image, the mounted model cache, and zero pytest/OpenAI retries.

- readiness-hardened NATS fault case: 1/1 passed in 100.31s (96.63s call)
- repository NVML profiler: 2/2 passed; calls 96.53s and 77.19s; 177.74s pytest / 184.7s profiler wall
- profile: 6.9 GiB peak, 668 MiB baseline and final, 0 MiB measured leak
- CI-equivalent `--max-vram-gib=41 -n 1`: scheduler selected both cases at 6.9 GiB / 0.31 GiB requested KV and passed 2/2 in 216.05s (128s and 88s including scheduler-managed setup/teardown)
- exact collection: two KV-transfer cases, neither skipped nor deselected
- `py_compile`, `git diff --check`, isort, Black 23.1.0, flake8, codespell, Ruff, and file-integrity hooks passed

The repo-wide marker-report hook also reported this module at 14 collected tests with no missing marker sets, then failed elsewhere during full-repository collection because the local port pool was exhausted in `tests/serve`; that unrelated collection failure is not hidden by a retry.

## Merge dependency

**Resolved.** [#13716](https://github.com/ai-dynamo/dynamo/pull/13716) merged as `759cb4e3ea31cf6e20902a74da41cbaf8f86f2a1`. On August 24, 2026, the complete four-layer stack was rebased onto that `main` commit. This layer's rebased head is `ff2516f13d26880231d1fb49b9ad28db92b8f111`.

## Stack navigation

1. [#13684 — Aggregate migration](https://github.com/ai-dynamo/dynamo/pull/13684)
2. [#13692 — Prefill removal](https://github.com/ai-dynamo/dynamo/pull/13692) · [DYN-4118](https://linear.app/nvidia/issue/DYN-4118)
3. [#13693 — Decode migration](https://github.com/ai-dynamo/dynamo/pull/13693) · [DYN-4119](https://linear.app/nvidia/issue/DYN-4119)
4. [#13694 — KV-transfer migration](https://github.com/ai-dynamo/dynamo/pull/13694) · [DYN-4120](https://linear.app/nvidia/issue/DYN-4120)

This PR is layer **4** and targets `codex/vllm-decode-migration`. Review and merge the stack in order.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->