### PR TITLE
fix(frontend): return the generate route's own error envelope on bad input

### DIFF
--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -3085,6 +3085,14 @@ mod tests {
             .expect("generate request failed");
 
         assert_eq!(resp.status().as_u16(), StatusCode::BAD_REQUEST.as_u16());
+        assert_eq!(
+            resp.headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.starts_with("application/json")),
+            Some(true),
+            "the 400 must use this route's JSON envelope, not Axum's text/plain rejection"
+        );
         let body: serde_json::Value = resp.json().await.expect("json body");
         assert_eq!(body["error"]["code"], 400);
         assert_eq!(body["error"]["type"], "invalid_request_error");

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use axum::{
     Json, Router,
+    body::Body,
     extract::State,
     http::{HeaderMap, StatusCode},
     middleware,
@@ -31,7 +32,7 @@ use super::metrics::{
 };
 use super::openai::{
     check_model_serving_ready, check_ready, context_from_headers, get_body_limit,
-    get_or_create_request_id, smart_json_error_middleware,
+    get_or_create_request_id, is_json_content_type, smart_json_error_middleware,
 };
 use super::{RouteDoc, service_v2};
 use crate::local_model::runtime_config::VLLM_INFERENCE_V1_GENERATE_CAPABILITY;
@@ -106,6 +107,62 @@ pub fn generate_router(
         .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
         .with_state(state);
     (vec![doc], router)
+}
+
+/// Read the request body, reporting a bad `Content-Type`, an oversized body or
+/// malformed JSON in this route's own nested-`error` envelope.
+///
+/// Axum's `Json` extractor rejects all three as `text/plain`, so a client that
+/// parsed the `{"error": {...}}` shape this route returns everywhere else got
+/// an unparseable body for the most common client mistakes.
+async fn read_generate_request(
+    headers: &HeaderMap,
+    body: Body,
+) -> Result<GenerateRequest, Response> {
+    let is_json = headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(is_json_content_type);
+    if !is_json {
+        return Err(generate_error_response(
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "invalid_request_error",
+            "Expected request with Content-Type application/json".to_string(),
+        ));
+    }
+
+    let bytes = axum::body::to_bytes(body, get_body_limit())
+        .await
+        .map_err(|error| {
+            // `to_bytes` wraps an oversized-body failure in its error source
+            // rather than returning `LengthLimitError` directly.
+            if std::error::Error::source(&error)
+                .is_some_and(|source| source.is::<http_body_util::LengthLimitError>())
+            {
+                generate_error_response(
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    "invalid_request_error",
+                    format!(
+                        "Request body exceeds the limit of {} bytes",
+                        get_body_limit()
+                    ),
+                )
+            } else {
+                generate_error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request_error",
+                    "Failed to read the request body".to_string(),
+                )
+            }
+        })?;
+
+    serde_json::from_slice(&bytes).map_err(|error| {
+        generate_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            format!("Failed to parse the request body as JSON: {error}"),
+        )
+    })
 }
 
 /// Build a vLLM-style nested-`error` response.
@@ -788,8 +845,12 @@ impl Drop for GenerateMetricCollector {
 async fn handler_generate(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(mut request): Json<GenerateRequest>,
+    body: Body,
 ) -> Response {
+    let mut request = match read_generate_request(&headers, body).await {
+        Ok(request) => request,
+        Err(response) => return response,
+    };
     let request_context = resolve_generate_request_context(&headers, request.request_id.as_deref());
     let implicit_models = if request.model.is_none() {
         canonical_generate_models(
@@ -2976,5 +3037,57 @@ mod tests {
     #[test]
     fn priority_inversion_saturates_at_i32_min() {
         assert_eq!(dynamo_routing_priority(i32::MIN), i32::MAX);
+    }
+
+    /// Every other failure on this route answers with the nested-`error`
+    /// envelope, and the route's own tests assert that shape. Axum's `Json`
+    /// extractor rejected a bad `Content-Type` as `text/plain`, so a client
+    /// parsing that envelope got an unparseable body for one of the most
+    /// common mistakes.
+    #[tokio::test]
+    async fn generate_route_bad_content_type_returns_structured_415() {
+        let (port, handle) = serve(Some(true)).await;
+        let resp = reqwest::Client::new()
+            .post(format!("http://localhost:{}/inference/v1/generate", port))
+            .header("content-type", "text/plain")
+            .body("not json")
+            .send()
+            .await
+            .expect("generate request failed");
+
+        assert_eq!(
+            resp.status().as_u16(),
+            StatusCode::UNSUPPORTED_MEDIA_TYPE.as_u16()
+        );
+        assert_eq!(
+            resp.headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.starts_with("application/json")),
+            Some(true),
+            "the 415 must use this route's JSON envelope, not Axum's text/plain rejection"
+        );
+        let body: serde_json::Value = resp.json().await.expect("json body");
+        assert_eq!(body["error"]["code"], 415);
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn generate_route_malformed_json_returns_structured_400() {
+        let (port, handle) = serve(Some(true)).await;
+        let resp = reqwest::Client::new()
+            .post(format!("http://localhost:{}/inference/v1/generate", port))
+            .header("content-type", "application/json")
+            .body("{not json")
+            .send()
+            .await
+            .expect("generate request failed");
+
+        assert_eq!(resp.status().as_u16(), StatusCode::BAD_REQUEST.as_u16());
+        let body: serde_json::Value = resp.json().await.expect("json body");
+        assert_eq!(body["error"]["code"], 400);
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        handle.abort();
     }
 }

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -1149,6 +1149,18 @@ mod tests {
 
     use super::service_v2::{HttpService, VLLM_ENABLE_INFERENCE_V1_GENERATE_ENV};
     use super::*;
+
+    /// `handler_generate` now reads the raw body, so direct calls need both the
+    /// JSON content type and a serialized body.
+    fn generate_body(value: serde_json::Value) -> (HeaderMap, Body) {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::CONTENT_TYPE,
+            axum::http::HeaderValue::from_static("application/json"),
+        );
+        (headers, Body::from(serde_json::to_vec(&value).unwrap()))
+    }
+
     use crate::http::service::metrics::{Endpoint, RequestType, Status};
     use crate::protocols::{Annotated, common::llm_backend::LLMEngineOutput};
     use dynamo_runtime::{
@@ -1601,15 +1613,13 @@ mod tests {
             vec![PRIMARY.to_string()]
         );
 
-        let request = serde_json::from_value(serde_json::json!({
+        let (headers, body) = generate_body(serde_json::json!({
             "request_id": "generate-alias-request",
             "token_ids": [1, 2, 3],
             "sampling_params": {},
             "model": ALIAS
-        }))
-        .unwrap();
-        let response =
-            handler_generate(State(state.clone()), HeaderMap::new(), Json(request)).await;
+        }));
+        let response = handler_generate(State(state.clone()), headers, body).await;
 
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
@@ -1630,34 +1640,24 @@ mod tests {
         let state = service.state_clone();
         let metric_model = crate::discovery::UNKNOWN_METRIC_MODEL;
 
-        let invalid_request = serde_json::from_value(serde_json::json!({
+        let (invalid_headers, invalid_body) = generate_body(serde_json::json!({
             "request_id": "generate-invalid-request",
             "token_ids": [],
             "sampling_params": {},
             "model": "missing-generate-model"
-        }))
-        .unwrap();
-        let invalid_response = handler_generate(
-            State(state.clone()),
-            HeaderMap::new(),
-            Json(invalid_request),
-        )
-        .await;
+        }));
+        let invalid_response =
+            handler_generate(State(state.clone()), invalid_headers, invalid_body).await;
         assert_eq!(invalid_response.status(), StatusCode::BAD_REQUEST);
 
-        let missing_model_request = serde_json::from_value(serde_json::json!({
+        let (missing_headers, missing_body) = generate_body(serde_json::json!({
             "request_id": "generate-missing-model-request",
             "token_ids": [1],
             "sampling_params": {},
             "model": "missing-generate-model"
-        }))
-        .unwrap();
-        let missing_model_response = handler_generate(
-            State(state.clone()),
-            HeaderMap::new(),
-            Json(missing_model_request),
-        )
-        .await;
+        }));
+        let missing_model_response =
+            handler_generate(State(state.clone()), missing_headers, missing_body).await;
         assert_eq!(missing_model_response.status(), StatusCode::NOT_FOUND);
 
         let metrics = state.metrics_clone();

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2170,7 +2170,7 @@ async fn read_json_request_body(headers: &HeaderMap, body: Body) -> Result<Bytes
         })
 }
 
-fn is_json_content_type(content_type: &str) -> bool {
+pub(super) fn is_json_content_type(content_type: &str) -> bool {
     let media_type = content_type.split(';').next().unwrap_or_default().trim();
     let Some((media_type, subtype)) = media_type.split_once('/') else {
         return false;


### PR DESCRIPTION
## Summary

`/inference/v1/generate` answers every failure it produces itself with a vLLM-style nested envelope, and its own tests assert that shape:

```json
{"error":{"message":"no generate-capable model is registered","type":"not_found","code":404}}
```

Requests that fail *before* reaching the handler did not get it. The route used Axum's `Json` extractor, whose rejections are `text/plain`, so the two most common client mistakes came back unparseable. Measured on `main`:

```
Content-Type: text/plain   ->  415  text/plain   Expected request with `Content-Type: application/json`
body "{not json"           ->  400  text/plain   Failed to parse the request body as JSON: ...
handler-produced error     ->  404  application/json  {"error":{...}}
```

A client written against the documented envelope parses the third and throws on the first two.

`smart_json_error_middleware`, which this router already layers on, does not cover them: it only rewrites 422 to 400, and neither rejection is a 422. I checked that rather than assuming the middleware was doing the job.

The fix reads the body explicitly and reports unsupported media type, oversized body and malformed JSON through `generate_error_response`, the helper the rest of the route already uses.

Content-type parsing reuses `is_json_content_type` from the openai module instead of reimplementing it, so this route keeps the same notion of what counts as JSON, including parameters and `+json` suffixes. That function becomes `pub(super)`; `generate.rs` already imports `get_body_limit` from the same place.

**The policy is unchanged, only the envelope.** An absent `Content-Type` is still rejected, matching `ensure_json_content_type` today. Worth noting @chanh has #13268 open to treat an absent header as JSON; if that lands, this route should follow it, and reusing the shared helper is what makes that a one-place change.

This is the same class as #13685 but a different module and a different envelope, so it is deliberately not a copy: `generate.rs` uses `{"error": {...}}` where the openai routes use a flat `{message, type, code}`.

## Validation

Behaviour measured before and after by driving the route through its existing `serve()` test harness:

| input | before | after |
|---|---|---|
| `Content-Type: text/plain` | `415 text/plain` | **`415 application/json`** `{"error":{...,"code":415}}` |
| `{not json` | `400 text/plain` | **`400 application/json`** `{"error":{...,"code":400}}` |
| handler error | `404` nested envelope | unchanged |

Added `generate_route_bad_content_type_returns_structured_415` and `generate_route_malformed_json_returns_structured_400`, alongside the route's existing structured-error tests, asserting the response `content-type` as well as the body since the status codes were already correct and only the shape was wrong.

- Full crate: **2043 passed, 0 failed** on a clean run, against 2041 on `main`, which is exactly the two tests added.
- `cargo clippy` and `cargo fmt --all -- --check` clean.

Two pre-existing issues I ran into and am **not** fixing here, disclosed so the numbers make sense:

`test_oversized_body_returns_json_413` fails intermittently, roughly half the time in isolation. Same rate on clean `main`; I reported it on #13624. It is the only failure in the non-clean full-suite runs above.

The `generate_route_*` tests fail under parallel execution. I confirmed this is pre-existing rather than caused by the two tests I added: with my changes reverted, `cargo test generate_route_` fails 4 of 8 on clean `main`, while serialized with my tests included it is 10 of 10. It does not surface in a full-suite run, and fixing that harness is a separate change from this one.

Not verified here: no GPU, so the success path of `/inference/v1/generate` was not exercised end to end. This change only affects how the request body is read and how that read is reported when it fails.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request validation for generation requests, including unsupported content types, oversized payloads, body-read failures, and malformed JSON.
  * Added consistent structured JSON error responses for invalid requests.
  * Enforced configured request body-size limits.
* **Tests**
  * Added coverage for invalid content types and malformed request payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->