### PR TITLE
fix(frontend): return the Anthropic error envelope on bad request bodies

### DIFF
--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -63,7 +63,9 @@ use crate::types::Annotated;
 // Re-use helpers from the openai module (sibling under service/)
 use super::error::{SanitizedError, invalid_argument};
 use super::metadata::{attach_x_request_id, extract_metadata_from_http};
-use super::openai::{get_body_limit, get_or_create_request_id, warn_nvext_disabled};
+use super::openai::{
+    get_body_limit, get_or_create_request_id, is_json_content_type, warn_nvext_disabled,
+};
 
 // ---------------------------------------------------------------------------
 // Router
@@ -134,6 +136,63 @@ async fn anthropic_error_middleware(request: Request<Body>, next: Next) -> Respo
     }
 
     response
+}
+
+/// Read a request body, reporting a bad `Content-Type`, an oversized body or
+/// malformed JSON in the nested Anthropic error envelope.
+///
+/// Axum's `Json` extractor rejects all three as `text/plain`, and
+/// `anthropic_error_middleware` only rewrites 422, so an Anthropic client
+/// parsing `{"type": "error", "error": {...}}` got an unparseable body for the
+/// most common request mistakes.
+async fn read_anthropic_request<T: serde::de::DeserializeOwned>(
+    headers: &HeaderMap,
+    body: Body,
+) -> Result<T, Response> {
+    let is_json = headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(is_json_content_type);
+    if !is_json {
+        return Err(anthropic_error(
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "invalid_request_error",
+            "Expected request with Content-Type application/json",
+        ));
+    }
+
+    let bytes = axum::body::to_bytes(body, get_body_limit())
+        .await
+        .map_err(|error| {
+            // `to_bytes` wraps an oversized-body failure in its error source
+            // rather than returning `LengthLimitError` directly.
+            if std::error::Error::source(&error)
+                .is_some_and(|source| source.is::<http_body_util::LengthLimitError>())
+            {
+                anthropic_error(
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    "invalid_request_error",
+                    &format!(
+                        "Request body exceeds the limit of {} bytes",
+                        get_body_limit()
+                    ),
+                )
+            } else {
+                anthropic_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request_error",
+                    "Failed to read the request body",
+                )
+            }
+        })?;
+
+    serde_json::from_slice(&bytes).map_err(|error| {
+        anthropic_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            &format!("Failed to parse the request body as JSON: {error}"),
+        )
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -249,8 +308,9 @@ fn validate_anthropic_tools(
 async fn handler_anthropic_messages(
     State((state, template)): State<(Arc<service_v2::State>, Option<RequestTemplate>)>,
     headers: HeaderMap,
-    Json(mut request): Json<AnthropicCreateMessageRequest>,
+    body: Body,
 ) -> Result<Response, Response> {
+    let mut request: AnthropicCreateMessageRequest = read_anthropic_request(&headers, body).await?;
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.stream;
     let resolved_model = resolve_request_model(&request.model, template.as_ref());
@@ -778,8 +838,10 @@ async fn anthropic_messages(
 /// Returns an estimated input token count using a len/3 heuristic.
 async fn handler_count_tokens(
     State((state, _template)): State<(Arc<service_v2::State>, Option<RequestTemplate>)>,
-    Json(mut request): Json<AnthropicCountTokensRequest>,
+    headers: HeaderMap,
+    body: Body,
 ) -> Result<Response, Response> {
+    let mut request: AnthropicCountTokensRequest = read_anthropic_request(&headers, body).await?;
     if let Err(error) = validate_anthropic_messages(&request.messages) {
         return Err(anthropic_error(
             error.status(),

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2179,7 +2179,7 @@ async fn read_json_request_body(headers: &HeaderMap, body: Body) -> Result<Bytes
         })
 }
 
-fn is_json_content_type(content_type: &str) -> bool {
+pub(super) fn is_json_content_type(content_type: &str) -> bool {
     let media_type = content_type.split(';').next().unwrap_or_default().trim();
     let Some((media_type, subtype)) = media_type.split_once('/') else {
         return false;

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -2452,4 +2452,68 @@ mod tests {
             assert!(validate_generate_route_path(path).is_err());
         }
     }
+
+    /// Anthropic clients parse the nested `{"type": "error", "error": {...}}`
+    /// envelope, which #13102 established for unmatched routes. The Messages
+    /// handler still used Axum's `Json` extractor, whose rejections are
+    /// `text/plain`, so the two most common request mistakes came back
+    /// unparseable. `anthropic_error_middleware` does not cover them; it only
+    /// rewrites 422.
+    #[tokio::test]
+    async fn test_anthropic_bad_content_type_returns_anthropic_envelope() {
+        let (port, _state, handle) =
+            spawn_service(|builder| builder.enable_anthropic_endpoints(true)).await;
+
+        let resp = reqwest::Client::new()
+            .post(format!("http://localhost:{port}/v1/messages"))
+            .header("content-type", "text/plain")
+            .header("anthropic-version", "2023-06-01")
+            .body("not json")
+            .send()
+            .await
+            .expect("request failed");
+
+        assert_eq!(resp.status(), reqwest::StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        assert_eq!(
+            resp.headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.starts_with("application/json")),
+            Some(true),
+            "the 415 must use the Anthropic envelope, not Axum's text/plain rejection"
+        );
+        let body: serde_json::Value = resp.json().await.expect("body must be JSON");
+        assert_eq!(body["type"], "error");
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_anthropic_malformed_json_returns_anthropic_envelope() {
+        let (port, _state, handle) =
+            spawn_service(|builder| builder.enable_anthropic_endpoints(true)).await;
+
+        let resp = reqwest::Client::new()
+            .post(format!("http://localhost:{port}/v1/messages"))
+            .header("content-type", "application/json")
+            .header("anthropic-version", "2023-06-01")
+            .body("{not json")
+            .send()
+            .await
+            .expect("request failed");
+
+        assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+        assert_eq!(
+            resp.headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.starts_with("application/json")),
+            Some(true),
+            "the 400 must use the Anthropic envelope, not Axum's text/plain rejection"
+        );
+        let body: serde_json::Value = resp.json().await.expect("body must be JSON");
+        assert_eq!(body["type"], "error");
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        handle.abort();
+    }
 }


### PR DESCRIPTION
## Summary

`/v1/messages` and `/v1/messages/count_tokens` answer every failure they produce themselves with the nested Anthropic envelope, and #13102 added the same envelope for unmatched Anthropic routes, with the note that Anthropic clients expect that shape:

```json
{"type":"error","error":{"type":"not_found_error","message":"Route not found: GET /v1/messages/missing"}}
```

Requests that fail *before* reaching the handler did not get it. Both handlers used Axum's `Json` extractor, whose rejections are `text/plain`. Measured on `main` with the Anthropic endpoints enabled:

```
Content-Type: text/plain  ->  415  text/plain  Expected request with `Content-Type: application/json`
body "{not json"          ->  400  text/plain  Failed to parse the request body as JSON: ...
```

So a client written against the documented envelope parses an unmatched route fine and throws on the two most common request mistakes.

I checked the obvious counter-hypothesis before concluding anything: this router layers `anthropic_error_middleware`, so it looked like this might already be handled. It is not. That middleware only rewrites 422 to 400, and neither rejection is a 422.

The fix reads the body explicitly and reports unsupported media type, oversized body and malformed JSON through `anthropic_error`. `handler_count_tokens` gains the `HeaderMap` it needs to see the content type.

Content-type parsing reuses `is_json_content_type` from the openai module rather than reimplementing it, so this route keeps the same notion of what counts as JSON, including parameters and `+json` suffixes. **The policy is unchanged, only the envelope**: an absent `Content-Type` is still rejected, matching `ensure_json_content_type` today.

### Overlap worth flagging

Two things this touches are also touched elsewhere, so whoever merges second should expect a trivial rebase rather than a surprise:

- #13696 makes the identical one-line change exposing `is_json_content_type` as `pub(super)`, for the same reason on `/inference/v1/generate`. Whichever lands first, the other drops that hunk.
- @chanh has #13268 open to treat an absent `Content-Type` as JSON. If that lands, this route should follow it, and reusing the shared helper is what keeps that a one-place change.

This is the same class as #13685 and #13696 but a third module with a third envelope, so it is deliberately not a copy of either: Anthropic nests under `{"type":"error","error":{...}}`, `generate` uses `{"error":{...}}`, and the openai routes use a flat `{message,type,code}`.

## Validation

Measured before and after by driving the route through `spawn_service(|b| b.enable_anthropic_endpoints(true))`:

| input | before | after |
|---|---|---|
| `Content-Type: text/plain` | `415 text/plain` | **`415 application/json`**, `{"type":"error","error":{"type":"invalid_request_error",...}}` |
| `{not json` | `400 text/plain` | **`400 application/json`**, same envelope |

Added `test_anthropic_bad_content_type_returns_anthropic_envelope` and `test_anthropic_malformed_json_returns_anthropic_envelope`, asserting the response `content-type` as well as the body, because the status codes were already correct on `main` and only the shape was wrong. **Both confirmed red first** by restoring `anthropic.rs` from `upstream/main` and re-running:

```
the 415 must use the Anthropic envelope, not Axum's text/plain rejection
the 400 must use the Anthropic envelope, not Axum's text/plain rejection
```

- Full crate: **2043 tests**, which is `main`'s 2041 plus the two added, with `cargo clippy` and `cargo fmt --all -- --check` clean.
- The one failure in those runs is `test_oversized_body_returns_json_413`, the pre-existing intermittent I reported on #13624. It is unrelated to this change and fails at the same rate on `main`.

Not verified here: no GPU, so the success path of `/v1/messages` was not exercised end to end. This change only affects how the request body is read and how that read is reported when it fails.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Anthropic Messages and token-count requests now provide consistent JSON-formatted error responses for unsupported content types, oversized request bodies, read failures, and malformed JSON.
  - Invalid requests now return the appropriate HTTP status codes, including 400 for malformed JSON and 415 for unsupported media types.
  - Request body size limits are enforced consistently across supported Anthropic endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->