### PR TITLE
docs(fern): lead nightly chips with the engine version

### DIFF
--- a/docs/fern/components/InstallSelector.tsx
+++ b/docs/fern/components/InstallSelector.tsx
@@ -170,7 +170,7 @@ export function InstallSelector({ hardware = "all" }: { hardware?: "all" | "nvid
         : "Pinned nightly wheel build"
       : "Intel XPU local runtime";
   const hardwareLabel = activeHardware === "nvidia" ? "NVIDIA GPU" : "Intel XPU";
-  const versionRowLabel = channel === "nightly" ? "Dynamo nightly" : `${INSTALL_DATA[backend].label} version`;
+  const versionRowLabel = `${INSTALL_DATA[backend].label} version`;
 
   return (
     <>
@@ -215,14 +215,16 @@ export function InstallSelector({ hardware = "all" }: { hardware?: "all" | "nvid
               {entries.map((version, index) => {
                 const hasContainer = Boolean(version.commands.container);
                 const hasWheel = Boolean(version.commands.wheel);
-                const displayVersion = channel === "nightly" && version.dynamo ? version.dynamo : version.backend_version;
+                // Engine version leads on every channel, Dynamo version beneath
+                // it, so a nightly chip reads the same way as a stable one.
+                const displayVersion = version.backend_version;
                 const displayMeta = version.source
                   ? "from main"
-                  : channel === "nightly"
-                    ? version.latest
+                  : version.dynamo
+                    ? `Dynamo ${version.dynamo}`
+                    : version.latest
                       ? "latest nightly"
-                      : version.date ?? "nightly wheel"
-                    : `Dynamo ${version.dynamo}`;
+                      : version.date ?? "nightly wheel";
                 return (
                   <button
                     key={`${version.backend_version}-${version.dynamo ?? index}`}

--- a/docs/fern/components/KubernetesContainerSelector.tsx
+++ b/docs/fern/components/KubernetesContainerSelector.tsx
@@ -205,7 +205,7 @@ export function KubernetesContainerSelector() {
         ? "Latest nightly container"
         : "Pinned nightly build"
       : "Intel XPU Kubernetes runtime";
-  const versionRowLabel = channel === "nightly" ? "Dynamo nightly" : `${INSTALL_DATA[backend].label} version`;
+  const versionRowLabel = `${INSTALL_DATA[backend].label} version`;
 
   function chooseHardware(next: Hardware) {
     setHardware(next);
@@ -282,14 +282,16 @@ export function KubernetesContainerSelector() {
             <span className="lqs-label">{versionRowLabel}</span>
             <div className="lqs-options" role="group" aria-label={versionRowLabel}>
               {entries.map((version, index) => {
-                const displayVersion = channel === "nightly" && version.dynamo ? version.dynamo : version.backend_version;
+                // Engine version leads on every channel, Dynamo version beneath
+                // it, so a nightly chip reads the same way as a stable one.
+                const displayVersion = version.backend_version;
                 const displayMeta = version.source
                   ? "from main"
-                  : channel === "nightly"
-                    ? version.latest
+                  : version.dynamo
+                    ? `Dynamo ${version.dynamo}`
+                    : version.latest
                       ? "latest nightly"
-                      : version.date ?? "nightly"
-                    : `Dynamo ${version.dynamo}`;
+                      : version.date ?? "nightly";
                 return (
                   <button
                     key={`${version.backend_version}-${version.dynamo ?? index}`}


### PR DESCRIPTION
## Overview:

The nightly chip in both install selectors read the opposite way round from the stable chip. Stable shows the engine version on top with the Dynamo version beneath; nightly led with the Dynamo dev version and put `latest nightly` underneath, so the same row changed meaning depending on which channel you were on.

Both selectors now lead with the engine version on every channel.

## Details:

**Before → after** (SGLang, nightly):

| | Row label | Chip |
|---|---|---|
| Before | `DYNAMO NIGHTLY` | **1.4.0.dev20260803** · latest nightly |
| After | `SGLANG VERSION` | **0.5.18** · Dynamo 1.4.0.dev20260803 |

Stable is unchanged and was already **0.5.16** · `Dynamo 1.4.1`.

The row label loses its nightly special case for the same reason: it read "Dynamo nightly" while the chip below it now leads with an SGLang or vLLM version.

Applied to `InstallSelector` (CLI quickstart) and `KubernetesContainerSelector` (Kubernetes quickstart), which carried the display logic verbatim — the point of the change is that the two agree.

Entries with no Dynamo version keep their existing subtitle. The TensorRT-LLM nightly publishes no pinned wheel, so it still reads **1.3.0rc24** · `latest nightly`, and source builds still read `from main`.

## Where should the reviewer start?

`docs/fern/components/InstallSelector.tsx` — the `displayVersion` / `displayMeta` pair. `KubernetesContainerSelector.tsx` gets the identical edit.

### Presentation only — two data problems are NOT fixed here

Both are with the ops team; flagging so the diff isn't mistaken for a fix.

**The engine version is the same across all three nightlies.** It comes from the single `MAIN_TOT` tip-of-main pin per backend (`sglang: 0.5.18`, `vllm: 0.27.1`), which is not recorded per nightly build — so the Aug 3 / Aug 2 / Jul 30 chips all show `0.5.18` even if those builds shipped different engine versions. Recording it per entry in `NIGHTLY_BUILDS` is the real fix. That list is also hand-maintained and its newest entry is Aug 3.

**Kubernetes still offers only one nightly, and that is correct today.** Its command uses the floating `dynamo-planner:nightly` tag, and the operator CRD validates `runtimeVersionOverride` against `^\d+\.\d+\.\d+$`, so `1.4.0.dev20260802` would be rejected — all three nightlies would render an identical command. The CLI can offer three because *wheels* are published per date.

### Validation

Rendered against a local `fern docs dev` server, exercised by clicking through the widget:

- CLI nightly: `SGLang version` → `0.5.18 / Dynamo 1.4.0.dev20260803`, `…802`, `…730`; vLLM → `0.27.1 / …`.
- Kubernetes nightly: `vLLM version` → `0.27.1 / Dynamo 1.4.0.dev20260803`.
- TensorRT-LLM nightly (no Dynamo version in data) falls back to `1.3.0rc24 / latest nightly`.
- Stable and source channels unchanged on both pages.
- `fern check` 0 errors; `check_style_components.py` and `check_asset_paths.py` pass.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Version labels in installation and Kubernetes container selectors now consistently reflect the selected backend version, regardless of release channel.
  - Version metadata now prioritizes available Dynamo version information and clearly indicates source status, latest nightly builds, nightly dates, or fallback details.
  - Resolved inconsistent labeling that could incorrectly display “Dynamo nightly” for nightly channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->