### PR TITLE
fix(sglang): cancel prefill before first output

### DIFF
--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -349,7 +349,7 @@ async def init_prefill(
         except asyncio.CancelledError:
             logging.info("Metrics task successfully cancelled")
             pass
-        handler.cleanup()
+        await handler.cleanup_async()
         if run_deferred_handlers is not None:
             logging.info("Running deferred handlers")
             await run_deferred_handlers()

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import logging
+import sys
 from collections.abc import AsyncIterator
 from typing import Any, AsyncGenerator, Dict, Optional
 
@@ -33,6 +34,8 @@ _DP_RANK_UNSET = 2**32 - 1
 
 class PrefillWorkerHandler(BaseWorkerHandler):
     """Handler for prefill workers in disaggregated serving mode."""
+
+    _REQUEST_REGISTRATION_TIMEOUT_SECONDS = 5.0
 
     def __init__(
         self,
@@ -71,6 +74,28 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         self.engine.shutdown()
         logging.info("Prefill engine shutdown")
 
+    async def cleanup_async(self) -> None:
+        """Await pending prefill consumers before shutting down the engine."""
+        tasks = list(self._consume_tasks)
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, Exception) and not isinstance(
+                    result, asyncio.CancelledError
+                ):
+                    logging.error(
+                        "Prefill consumer failed during handler cleanup",
+                        exc_info=(type(result), result, result.__traceback__),
+                    )
+        self._consume_tasks.clear()
+
+        super().cleanup()
+        self.engine.shutdown()
+        logging.info("Prefill engine shutdown")
+
     async def generate(
         self, request: Dict[str, Any], context: Context
     ) -> AsyncGenerator[Dict[str, Any], None]:
@@ -85,6 +110,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         """
         logging.debug(f"New Request ID: {context.id()}")
         trace_id = context.trace_id
+        sglang_request_id = trace_id or context.id()
 
         if "request" in request:
             # DisaggPreprocessedRequest format
@@ -173,7 +199,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             native_request = build_native_generate_request(
                 native_payload,
                 input_ids=input_ids,
-                fallback_rid=trace_id or context.id(),
+                fallback_rid=sglang_request_id,
                 priority=priority_kwargs.get("priority"),
                 sampling_overrides={"n": 1, "max_new_tokens": 1},
                 bootstrap_host=bootstrap_host,
@@ -183,6 +209,9 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 routed_dp_rank=dp_rank,
                 lora_path=lora_path,
             )
+            if not isinstance(native_request.rid, str):
+                raise ValueError("SGLang prefill requires a single request ID")
+            sglang_request_id = native_request.rid
             results = native_generate_stream(self.engine, native_request)
         else:
             results = await self.engine.async_generate(
@@ -195,7 +224,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 bootstrap_port=bootstrap_port,
                 bootstrap_room=bootstrap_room,
                 external_trace_header=trace_header,
-                rid=trace_id,
+                rid=sglang_request_id,
                 data_parallel_rank=dp_rank,
                 lora_path=lora_path,
                 **priority_kwargs,
@@ -216,33 +245,136 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             "disaggregated_params": bootstrap_info,
         }
 
-        task = asyncio.create_task(self._consume_results(results, context))
+        task = asyncio.create_task(
+            self._consume_results(results, sglang_request_id, context)
+        )
         self._consume_tasks.add(task)
         task.add_done_callback(self._consume_tasks.discard)
 
         await task
 
+    async def _wait_for_request_registration(self, rid: str) -> None:
+        """Wait until SGLang owns the request ID, without waiting for output."""
+        tokenizer_manager = getattr(self.engine, "tokenizer_manager", None)
+        rid_to_state = getattr(tokenizer_manager, "rid_to_state", None)
+        if rid_to_state is None:
+            raise RuntimeError("SGLang tokenizer manager has no request registry")
+
+        async def poll_registry() -> None:
+            while rid not in rid_to_state:
+                await asyncio.sleep(0.001)
+
+        try:
+            await asyncio.wait_for(
+                poll_registry(),
+                timeout=self._REQUEST_REGISTRATION_TIMEOUT_SECONDS,
+            )
+        except TimeoutError as error:
+            raise RuntimeError(
+                f"SGLang did not register prefill request {rid} within "
+                f"{self._REQUEST_REGISTRATION_TIMEOUT_SECONDS:g}s"
+            ) from error
+
     async def _consume_results(
-        self, results: AsyncIterator[Any], context: Context
+        self,
+        results: AsyncIterator[Any],
+        sglang_request_id: str,
+        context: Context,
     ) -> None:
         """Consume async generator results without processing.
 
         Args:
             results: Async generator from engine.async_generate.
+            sglang_request_id: Request ID submitted to SGLang.
             context: Context object for cancellation handling.
         """
-        # Use Future pattern for request ID - will be set when first response arrives
         request_id_future: asyncio.Future[str] = asyncio.Future()
-        async with self._cancellation_monitor(request_id_future, context):
-            async for res in results:
-                # Extract SGLang request ID from the first response and set the future
-                if not request_id_future.done():
-                    meta_info = res.get("meta_info", {})
-                    sglang_request_id = meta_info.get("id")
-                    if sglang_request_id:
-                        request_id_future.set_result(sglang_request_id)
-                        logging.debug(f"New Prefill Request ID: {sglang_request_id}")
+        registration_task = asyncio.create_task(
+            self._wait_for_request_registration(sglang_request_id)
+        )
+        first_result_task: asyncio.Task[Any] | None = asyncio.create_task(
+            anext(results)
+        )
+        pre_registration_cancellation = context.async_killed_or_stopped()
+        first_result_ready = False
 
-                # Note: No explicit cancellation checks needed here.
-                # When abort_request is called by the cancellation monitor,
-                # SGLang will terminate this async generator automatically.
+        try:
+            # Advancing the lazy iterator registers the request. A disconnect
+            # observed before registration remains sticky; keep the iterator
+            # alive until the exact RID can be aborted safely.
+            while not registration_task.done():
+                wait_for: set[asyncio.Future[Any]] = {registration_task}
+                if first_result_task is not None and not first_result_task.done():
+                    wait_for.add(first_result_task)
+                if not pre_registration_cancellation.done():
+                    wait_for.add(pre_registration_cancellation)
+
+                done, _ = await asyncio.wait(
+                    wait_for,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if first_result_task is not None and first_result_task in done:
+                    try:
+                        await first_result_task
+                    except StopAsyncIteration as error:
+                        raise RuntimeError(
+                            "SGLang prefill stream ended before request registration"
+                        ) from error
+                    first_result_ready = True
+
+            await registration_task
+            request_id_future.set_result(sglang_request_id)
+            logging.debug(f"Registered Prefill Request ID: {sglang_request_id}")
+
+            if not pre_registration_cancellation.done():
+                pre_registration_cancellation.cancel()
+                try:
+                    await pre_registration_cancellation
+                except asyncio.CancelledError:
+                    pass
+
+            async with self._cancellation_monitor(request_id_future, context):
+                if not first_result_ready:
+                    assert first_result_task is not None
+                    try:
+                        await first_result_task
+                    except StopAsyncIteration:
+                        return
+                first_result_task = None
+
+                # Keep draining after abort so accepted KV-transfer work can
+                # release its resources before the consumer exits.
+                async for _ in results:
+                    pass
+        finally:
+            pending_exception = sys.exc_info()[1]
+            cleanup_tasks: list[tuple[asyncio.Future[Any], bool]] = [
+                (registration_task, False),
+                (pre_registration_cancellation, False),
+            ]
+            if first_result_task is not None:
+                cleanup_tasks.append((first_result_task, True))
+
+            for task, _ in cleanup_tasks:
+                if not task.done():
+                    task.cancel()
+            results = await asyncio.gather(
+                *(task for task, _ in cleanup_tasks),
+                return_exceptions=True,
+            )
+            for (_, allow_stop_iteration), result in zip(
+                cleanup_tasks, results, strict=True
+            ):
+                if isinstance(result, asyncio.CancelledError) or (
+                    allow_stop_iteration and isinstance(result, StopAsyncIteration)
+                ):
+                    continue
+                if not isinstance(result, BaseException):
+                    continue
+                if pending_exception is None:
+                    raise result
+                if result is not pending_exception:
+                    logging.error(
+                        "SGLang prefill task failed during cleanup",
+                        exc_info=(type(result), result, result.__traceback__),
+                    )

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
@@ -34,6 +35,25 @@ pytestmark = [
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.pre_merge,
 ]
+
+
+class _CancelableContext:
+    def __init__(self, request_id: str, *, trace_id: str | None = None):
+        self._request_id = request_id
+        self.trace_id = trace_id
+        self._cancelled = asyncio.Event()
+
+    def id(self) -> str:
+        return self._request_id
+
+    def trace_headers(self) -> dict[str, str]:
+        return {}
+
+    def async_killed_or_stopped(self) -> asyncio.Task[bool]:
+        return asyncio.create_task(self._cancelled.wait())
+
+    def cancel(self) -> None:
+        self._cancelled.set()
 
 
 def _read_zstd_payload(path):
@@ -112,6 +132,125 @@ async def test_prefill_rejects_cache_uuid_before_building_media_kwargs(
             pass
 
     assert not build_media_kwargs_called
+
+
+@pytest.mark.asyncio
+async def test_prefill_uses_context_id_as_sglang_rid_before_first_result(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured_kwargs = {}
+
+    async def empty_results():
+        if False:
+            yield {}
+
+    class _Engine:
+        async def async_generate(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            return empty_results()
+
+    handler = PrefillWorkerHandler.__new__(PrefillWorkerHandler)
+    handler.engine = _Engine()
+    handler.bootstrap_host = "127.0.0.1"
+    handler.bootstrap_port = 1234
+    handler.enable_trace = False
+    handler._consume_tasks = set()
+    handler._generate_bootstrap_room = lambda: 17
+    handler._get_input_param = lambda request: {"input_ids": request["token_ids"]}
+    handler._resolve_lora = lambda request: None
+    handler._priority_kwargs = lambda priority: {}
+    monkeypatch.setattr(
+        "dynamo.sglang.request_handlers.llm.prefill_handler.require_reasoning_kwargs",
+        lambda engine, request: {},
+    )
+
+    stream = handler.generate(
+        {
+            "request": {"token_ids": [1, 2, 3], "routing": {}},
+            "sampling_params": {},
+        },
+        _CancelableContext("request-id"),
+    )
+    await anext(stream)
+
+    assert captured_kwargs["rid"] == "request-id"
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_prefill_cancellation_waits_for_registration_before_abort():
+    rid = "request-id"
+    abort_calls = []
+    iteration_started = asyncio.Event()
+    allow_registration = asyncio.Event()
+    aborted = asyncio.Event()
+    result_stopped = asyncio.Event()
+
+    class _TokenizerManager:
+        def __init__(self):
+            self.rid_to_state = {}
+
+        def abort_request(self, *, rid, abort_all):
+            abort_calls.append((rid, abort_all))
+            aborted.set()
+
+    tokenizer_manager = _TokenizerManager()
+    handler = PrefillWorkerHandler.__new__(PrefillWorkerHandler)
+    handler.engine = SimpleNamespace(tokenizer_manager=tokenizer_manager)
+    handler.shutdown_event = None
+    handler._REQUEST_REGISTRATION_TIMEOUT_SECONDS = 1.0
+    context = _CancelableContext(rid)
+
+    async def results():
+        try:
+            iteration_started.set()
+            await allow_registration.wait()
+            tokenizer_manager.rid_to_state[rid] = object()
+            await aborted.wait()
+            return
+            yield {}
+        finally:
+            result_stopped.set()
+
+    consumer = asyncio.create_task(handler._consume_results(results(), rid, context))
+    await asyncio.wait_for(iteration_started.wait(), timeout=1)
+
+    context.cancel()
+    await asyncio.sleep(0)
+    assert abort_calls == []
+
+    allow_registration.set()
+    await asyncio.wait_for(consumer, timeout=1)
+
+    assert abort_calls == [(rid, False)]
+    assert result_stopped.is_set()
+
+
+@pytest.mark.asyncio
+async def test_prefill_cleanup_awaits_consumers_before_engine_shutdown():
+    events = []
+
+    async def consume_forever():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            await asyncio.sleep(0)
+            events.append("consumer-stopped")
+
+    consume_task = asyncio.create_task(consume_forever())
+    await asyncio.sleep(0)
+
+    handler = PrefillWorkerHandler.__new__(PrefillWorkerHandler)
+    handler._consume_tasks = {consume_task}
+    handler.publisher = SimpleNamespace(
+        cleanup=lambda: events.append("publisher-cleaned")
+    )
+    handler.engine = SimpleNamespace(shutdown=lambda: events.append("engine-shutdown"))
+
+    await handler.cleanup_async()
+
+    assert events == ["consumer-stopped", "publisher-cleaned", "engine-shutdown"]
+    assert not handler._consume_tasks
 
 
 def test_extract_media_urls_returns_none_for_missing_modality():

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -408,6 +408,7 @@ where
                  Expected prefill_worker_id to be set via x-dynamo-prefill-instance-id header by external router (e.g., EPP)."
             ));
         }
+        link_prefill_cancellation(&engine_ctx, prefill_context.context());
 
         let router = &binding.router;
         let endpoint_id = &binding.endpoint_id;
@@ -637,6 +638,22 @@ where
 
         self.model_manager
             .get_kv_transfer_routing_constraints(endpoint_id, worker_id)
+    }
+}
+
+fn link_prefill_cancellation(
+    parent: &Arc<dyn dynamo_runtime::engine::AsyncEngineContext>,
+    child: Arc<dyn dynamo_runtime::engine::AsyncEngineContext>,
+) {
+    parent.link_child(child.clone());
+
+    // Cancellation is sticky, but linking a child is not atomic with a parent
+    // cancellation. Mirror an already-observed parent state so a disconnect in
+    // the small construction window cannot leave remote prefill running.
+    if parent.is_killed() {
+        child.kill();
+    } else if parent.is_stopped() {
+        child.stop();
     }
 }
 
@@ -891,6 +908,26 @@ mod tests {
         })
         .await
         .expect("pending activation tasks retained their PrefillRouter");
+    }
+
+    #[tokio::test]
+    async fn prefill_cancellation_tracks_parent_before_and_after_linking() {
+        let parent = Context::new(()).context();
+        let child = Context::new(()).context();
+        link_prefill_cancellation(&parent, child.clone());
+
+        parent.kill();
+        tokio::time::timeout(std::time::Duration::from_secs(1), child.killed())
+            .await
+            .expect("linked prefill context did not receive parent cancellation");
+        assert!(child.is_killed());
+
+        let already_killed_parent = Context::new(()).context();
+        already_killed_parent.kill();
+        let late_child = Context::new(()).context();
+        link_prefill_cancellation(&already_killed_parent, late_child.clone());
+
+        assert!(late_child.is_killed());
     }
 
     #[test]


### PR DESCRIPTION
## Overview:

### Summary

Stop selected remote SGLang prefill work when a client disconnects before the
first engine output, while preserving the KV-transfer drain path.

## Details:

- Link the remote prefill request context to the original request context,
  including cancellation that arrives during context construction.
- Submit a stable SGLang request ID before the first output, advance the lazy
  stream to registration, and retain early cancellation until that exact ID can
  be aborted.
- Continue draining accepted prefill work after abort and await tracked
  consumers before shutting down the engine.
- Add focused regressions for request-ID assignment, cancellation across the
  registration race, context propagation, and shutdown ordering.

## Validation:

- Focused baseline-versus-patched lifecycle probe: passed. The baseline cannot
  abort before the first output; the patched path aborts the registered request
  and completes cleanup.
- Python source, test-discovery mapping, and changed-file style checks: passed.
- The repository SGLang pytest environment is not installed locally; the added
  CPU tests are delegated to the pre-merge SGLang job.
- `cargo fmt --all -- --check`: passed.
- The targeted Rust unit test could not compile locally because the offline
  Cargo cache lacks `aisimulate-core v0.1.0-dev.1`; the Rust build and test are
  delegated to pull-request CI.
- The H20/Kubernetes/NIXL end-to-end deployment is not available locally, so
  cluster-level latency validation remains outside this local check.

## Where should the reviewer start?

- `lib/llm/src/kv_router/prefill_router/mod.rs` for parent/child cancellation
  propagation.
- `components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py` for
  registration-aware abort and cleanup.
- `components/src/dynamo/sglang/tests/test_sglang_decode_handler.py` for the
  focused Python regressions.

## Related Issues

**🔗 This PR is linked to an issue:**

- Closes #13691

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling for prefill requests, including requests canceled before registration.
  * Ensured request identifiers are propagated consistently for more reliable request tracking.
  * Improved cleanup during shutdown to prevent lingering request-processing tasks.
  * Fixed cancellation propagation when requests are linked to an engine that has already stopped.

* **Tests**
  * Added coverage for request identification, cancellation timing, cleanup, and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->