### PR TITLE
test(frontend): stop the oversized-body test racing the server

### DIFF
--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -1867,9 +1867,23 @@ mod tests {
         temp_env::async_with_vars([(env_llm::DYN_HTTP_BODY_LIMIT_MB, Some("1"))], async move {
             let (port, handle) = spawn_default_service().await;
 
+            // Only just over the limit, deliberately. The server answers 413 and
+            // closes as soon as it has read one byte past the cap, so a large
+            // overshoot leaves the client still writing into a socket whose peer
+            // has gone away, and the reset can take the buffered response with
+            // it. The status arrives, then reading the body fails with
+            // `hyper::Error(Body, "connection error")`.
+            //
+            // That is ordinary HTTP rather than a server bug, so the fix is to
+            // stop racing: a small overshoot is fully written before the server
+            // replies. Keep it small if you touch this. Measured on macOS at a
+            // 1 MiB cap: a 2 MiB body failed 13 of 16 runs, this passes 24 of 24.
+            // Linux CI does not surface it, so a green `rust-tests` is not
+            // evidence the race is gone.
+            const BODY_LIMIT_BYTES: usize = 1024 * 1024;
             let oversized = serde_json::json!({
                 "model": "model",
-                "input": "x".repeat(2 * 1024 * 1024),
+                "input": "x".repeat(BODY_LIMIT_BYTES + 4096),
             });
             let resp = reqwest::Client::new()
                 .post(format!("http://localhost:{port}/v1/responses"))


### PR DESCRIPTION
## Summary

`test_oversized_body_returns_json_413` posts a 2 MiB body against a 1 MiB cap. The server answers 413 and closes as soon as it has read one byte past the cap, so the client is still writing into a socket whose peer has gone away. The status arrives, and then reading the body fails:

```
body must be JSON: reqwest::Error { kind: Decode, source: hyper::Error(Body, "connection error") }
```

**This is ordinary HTTP rather than a server bug.** A server may answer and close before a request body is fully sent. The test was asserting a guarantee HTTP does not give it once the overshoot is large enough to outlive the socket buffers.

The fix is to stop racing: overshoot the cap by 4 KiB instead of 1 MiB. The body is still oversized, every assertion is unchanged (413, `application/json`, the exact message naming `DYN_HTTP_BODY_LIMIT_MB`), and the client finishes writing before the server replies, so the response body is readable every time.

I first reported this as a flake on #13624 and have been disclosing it in the validation notes of #13685, #13696, #13698 and #13699. It is worth fixing rather than continuing to annotate, because it makes `cargo test -p dynamo-llm` red by default for a whole class of contributors, and a suite that is normally red stops being read.

**This is not a CI fix, and I do not want it read as one.** `rust-tests` is green on Linux and was green throughout; the race depends on socket buffering and does not surface there. The benefit is local development on macOS. The comment in the test says this explicitly, so a green CI run is not mistaken for evidence the race is gone, and so nobody enlarges the overshoot again.

## Validation

Measured rather than asserted, serialized so nothing else could interfere, at a 1 MiB cap on macOS arm64:

| body | result |
|---|---|
| 2 MiB (before) | **3 pass / 13 fail** of 16 |
| cap + 4 KiB (after) | **24 pass / 0 fail** (16 + an earlier 8) |
| cap + 4 KiB, re-run on the final commit | **12 pass / 0 fail** |

Whole-crate effect, which is the reason this matters:

```
before: test result: FAILED. 2042 passed; 1 failed;  (on most runs)
after:  test result: ok.     2041 passed; 0 failed;  (three consecutive runs)
```

`cargo clippy` and `cargo fmt --all -- --check` clean.

Not addressed here, deliberately: making the server deliver its 413 body reliably under a large overshoot would mean draining a request body that was just rejected for being too large. That is a cost decision for whoever owns that path, not something to smuggle into a test fix.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated oversized-request coverage to exceed the configured payload limit by a smaller margin.
  * Documented connection-reset behavior that can occur when requests significantly exceed the limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->