### PR TITLE
fix(http): bound remote media downloads

### DIFF
--- a/components/src/dynamo/common/http/__init__.py
+++ b/components/src/dynamo/common/http/__init__.py
@@ -37,6 +37,7 @@ from dynamo.common.configuration.groups.http_args import (
 
 from .aiohttp_client import AiohttpClient
 from .base import (
+    HttpBodyTooLargeError,
     HttpClient,
     HttpConnectionError,
     HttpError,
@@ -79,9 +80,11 @@ def get_default_client() -> HttpClient:
     return _default
 
 
-async def fetch_bytes(url, timeout, *, policy=None) -> bytes:
+async def fetch_bytes(url, timeout, *, policy=None, max_bytes=None) -> bytes:
     """Singleton-backed convenience wrapper over :meth:`HttpClient.fetch_bytes`."""
-    return await get_default_client().fetch_bytes(url, timeout, policy=policy)
+    return await get_default_client().fetch_bytes(
+        url, timeout, policy=policy, max_bytes=max_bytes
+    )
 
 
 async def close_http_client() -> None:
@@ -105,6 +108,7 @@ __all__ = [
     "HttpError",
     "HttpTimeoutError",
     "HttpConnectionError",
+    "HttpBodyTooLargeError",
     "HttpStatusError",
     "HttpConfigBase",
     "HttpArgGroup",

--- a/components/src/dynamo/common/http/aiohttp_client.py
+++ b/components/src/dynamo/common/http/aiohttp_client.py
@@ -17,7 +17,13 @@ from typing import Optional
 import aiohttp
 from yarl import URL
 
-from .base import HttpClient, HttpConnectionError, HttpStatusError, HttpTimeoutError
+from .base import (
+    HttpBodyTooLargeError,
+    HttpClient,
+    HttpConnectionError,
+    HttpStatusError,
+    HttpTimeoutError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +79,31 @@ class AiohttpClient(HttpClient):
                 )
         return self._session
 
-    async def _fetch_simple(self, url: str, timeout: float) -> bytes:
+    @staticmethod
+    async def _read_response(
+        response: aiohttp.ClientResponse, url: str, max_bytes: Optional[int]
+    ) -> bytes:
+        if max_bytes is None:
+            return await response.read()
+
+        content_length = response.headers.get("Content-Length")
+        if content_length is not None:
+            try:
+                if int(content_length) > max_bytes:
+                    raise HttpBodyTooLargeError(max_bytes, url)
+            except ValueError:
+                pass
+
+        body = bytearray()
+        async for chunk in response.content.iter_chunked(min(64 * 1024, max_bytes + 1)):
+            body.extend(chunk)
+            if len(body) > max_bytes:
+                raise HttpBodyTooLargeError(max_bytes, url)
+        return bytes(body)
+
+    async def _fetch_simple(
+        self, url: str, timeout: float, *, max_bytes: Optional[int] = None
+    ) -> bytes:
         session = await self._get_session()
         client_timeout = self._effective_timeout(timeout)
         try:
@@ -81,7 +111,7 @@ class AiohttpClient(HttpClient):
                 url, timeout=client_timeout, allow_redirects=True
             ) as response:
                 response.raise_for_status()
-                return await response.read()
+                return await self._read_response(response, url, max_bytes)
         except aiohttp.ClientResponseError as e:
             raise HttpStatusError(e.status, e.message or "", url) from e
         except (asyncio.TimeoutError, aiohttp.ServerTimeoutError) as e:
@@ -96,7 +126,7 @@ class AiohttpClient(HttpClient):
             raise HttpConnectionError(f"HTTP error loading {url}: {e}") from e
 
     async def _fetch_body_or_redirect(
-        self, url: str, timeout: float
+        self, url: str, timeout: float, *, max_bytes: Optional[int] = None
     ) -> tuple[bytes | None, str | None]:
         session = await self._get_session()
         client_timeout = self._effective_timeout(timeout)
@@ -109,13 +139,13 @@ class AiohttpClient(HttpClient):
                     if location:
                         next_url = str(response.url.join(URL(location)))
                         return None, next_url
-                    return await response.read(), None
+                    return await self._read_response(response, url, max_bytes), None
 
                 try:
                     response.raise_for_status()
                 except aiohttp.ClientResponseError as e:
                     raise HttpStatusError(e.status, e.message or "", url) from e
-                return await response.read(), None
+                return await self._read_response(response, url, max_bytes), None
         except (asyncio.TimeoutError, aiohttp.ServerTimeoutError) as e:
             raise HttpTimeoutError(f"Timeout loading {url}") from e
         except (

--- a/components/src/dynamo/common/http/base.py
+++ b/components/src/dynamo/common/http/base.py
@@ -47,6 +47,15 @@ class HttpStatusError(HttpError):
         self.url = url
 
 
+class HttpBodyTooLargeError(HttpError):
+    """Response body exceeded a caller-provided byte limit."""
+
+    def __init__(self, limit: int, url: str) -> None:
+        super().__init__(f"Response body for {url} exceeds {limit} bytes")
+        self.limit = limit
+        self.url = url
+
+
 class HttpClient(abc.ABC):
     """Backend-neutral HTTP client.
 
@@ -66,6 +75,7 @@ class HttpClient(abc.ABC):
         timeout: float,
         *,
         policy: Optional[UrlValidationPolicy] = None,
+        max_bytes: Optional[int] = None,
     ) -> bytes:
         """Fetch ``url`` and return the response body.
 
@@ -79,15 +89,23 @@ class HttpClient(abc.ABC):
         This is the SSRF-safe path; raises :class:`UrlValidationError`
         if any hop fails or the chain exceeds ``_MAX_REDIRECTS``.
         """
+        if max_bytes is not None and max_bytes <= 0:
+            raise ValueError("max_bytes must be positive")
         if policy is None:
-            return await self._fetch_simple(url, timeout)
-        return await self._fetch_with_revalidation(url, timeout, policy)
+            if max_bytes is None:
+                return await self._fetch_simple(url, timeout)
+            return await self._fetch_simple(url, timeout, max_bytes=max_bytes)
+        return await self._fetch_with_revalidation(
+            url, timeout, policy, max_bytes=max_bytes
+        )
 
     async def _fetch_with_revalidation(
         self,
         url: str,
         timeout: float,
         policy: UrlValidationPolicy,
+        *,
+        max_bytes: Optional[int] = None,
     ) -> bytes:
         """Manual redirect loop with per-hop SSRF validation (backend-neutral)."""
         current = url
@@ -97,7 +115,12 @@ class HttpClient(abc.ABC):
             await validate_url(current, policy)
             visited.append(current)
 
-            body, redirect_to = await self._fetch_body_or_redirect(current, timeout)
+            if max_bytes is None:
+                body, redirect_to = await self._fetch_body_or_redirect(current, timeout)
+            else:
+                body, redirect_to = await self._fetch_body_or_redirect(
+                    current, timeout, max_bytes=max_bytes
+                )
 
             if redirect_to is None:
                 if body is None:
@@ -115,12 +138,14 @@ class HttpClient(abc.ABC):
             current = redirect_to
 
     @abc.abstractmethod
-    async def _fetch_simple(self, url: str, timeout: float) -> bytes:
+    async def _fetch_simple(
+        self, url: str, timeout: float, *, max_bytes: Optional[int] = None
+    ) -> bytes:
         """Backend's native redirect-following GET (no SSRF policy applied)."""
 
     @abc.abstractmethod
     async def _fetch_body_or_redirect(
-        self, url: str, timeout: float
+        self, url: str, timeout: float, *, max_bytes: Optional[int] = None
     ) -> tuple[bytes | None, str | None]:
         """Single hop with redirects disabled.
 

--- a/components/src/dynamo/common/http/httpx_client.py
+++ b/components/src/dynamo/common/http/httpx_client.py
@@ -28,7 +28,13 @@ from typing import Optional
 
 import httpx
 
-from .base import HttpClient, HttpConnectionError, HttpStatusError, HttpTimeoutError
+from .base import (
+    HttpBodyTooLargeError,
+    HttpClient,
+    HttpConnectionError,
+    HttpStatusError,
+    HttpTimeoutError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -95,10 +101,45 @@ class HttpxClient(HttpClient):
                 )
         return self._client
 
-    async def _fetch_simple(self, url: str, timeout: float) -> bytes:
+    @staticmethod
+    async def _read_response(
+        response: httpx.Response, url: str, max_bytes: Optional[int]
+    ) -> bytes:
+        if max_bytes is None:
+            return response.content
+
+        content_length = response.headers.get("Content-Length")
+        if content_length is not None:
+            try:
+                if int(content_length) > max_bytes:
+                    raise HttpBodyTooLargeError(max_bytes, url)
+            except ValueError:
+                pass
+
+        body = bytearray()
+        async for chunk in response.aiter_bytes(
+            chunk_size=min(64 * 1024, max_bytes + 1)
+        ):
+            body.extend(chunk)
+            if len(body) > max_bytes:
+                raise HttpBodyTooLargeError(max_bytes, url)
+        return bytes(body)
+
+    async def _fetch_simple(
+        self, url: str, timeout: float, *, max_bytes: Optional[int] = None
+    ) -> bytes:
         client = await self._get_client()
         async with self._get_semaphore():
             try:
+                if max_bytes is not None:
+                    async with client.stream(
+                        "GET",
+                        url,
+                        timeout=self._per_call_timeout(timeout),
+                        follow_redirects=True,
+                    ) as response:
+                        response.raise_for_status()
+                        return await self._read_response(response, url, max_bytes)
                 response = await client.get(
                     url, timeout=self._per_call_timeout(timeout)
                 )
@@ -114,7 +155,7 @@ class HttpxClient(HttpClient):
                 raise HttpConnectionError(f"HTTP error loading {url}: {e}") from e
 
     async def _fetch_body_or_redirect(
-        self, url: str, timeout: float
+        self, url: str, timeout: float, *, max_bytes: Optional[int] = None
     ) -> tuple[bytes | None, str | None]:
         client = await self._get_client()
         async with self._get_semaphore():
@@ -125,6 +166,7 @@ class HttpxClient(HttpClient):
                 response = await client.send(
                     request,
                     follow_redirects=False,
+                    stream=max_bytes is not None,
                 )
             except httpx.TimeoutException as e:
                 raise HttpTimeoutError(f"Timeout loading {url}") from e
@@ -140,13 +182,13 @@ class HttpxClient(HttpClient):
                         next_url = str(response.url.join(location))
                         return None, next_url
                     # 3xx without Location: treat as terminal, surface the body.
-                    return response.content, None
+                    return await self._read_response(response, url, max_bytes), None
 
                 try:
                     response.raise_for_status()
                 except httpx.HTTPStatusError as e:
                     raise HttpStatusError(e.response.status_code, str(e), url) from e
-                return response.content, None
+                return await self._read_response(response, url, max_bytes), None
             finally:
                 await response.aclose()
 

--- a/components/src/dynamo/common/tests/http/test_aiohttp_client.py
+++ b/components/src/dynamo/common/tests/http/test_aiohttp_client.py
@@ -42,12 +42,22 @@ class _FakeResponse:
         self.headers = headers or {}
         self.url = url
         self._body = body
+        self.content = _FakeContent(body)
 
     def raise_for_status(self) -> None:
         return None
 
     async def read(self) -> bytes:
         return self._body
+
+
+class _FakeContent:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    async def iter_chunked(self, size: int):
+        for offset in range(0, len(self._body), size):
+            yield self._body[offset : offset + size]
 
 
 def _cm_returning(response):
@@ -123,6 +133,32 @@ async def test_fetch_bytes_returns_body_on_200() -> None:
     assert result == b"hello"
 
 
+async def test_fetch_bytes_aborts_when_stream_exceeds_limit() -> None:
+    response = _FakeResponse(status=200, body=b"too large")
+    session = MagicMock(spec=aiohttp.ClientSession)
+    session.closed = False
+    session.get = _cm_returning(response)
+    client = _make_client_with_session(session)
+
+    with pytest.raises(mm_http.HttpBodyTooLargeError):
+        await client.fetch_bytes("https://h/x", 30.0, max_bytes=4)
+
+
+async def test_fetch_bytes_rejects_declared_body_over_limit() -> None:
+    response = _FakeResponse(
+        status=200,
+        headers={"Content-Length": "1024"},
+        body=b"not-read",
+    )
+    session = MagicMock(spec=aiohttp.ClientSession)
+    session.closed = False
+    session.get = _cm_returning(response)
+    client = _make_client_with_session(session)
+
+    with pytest.raises(mm_http.HttpBodyTooLargeError):
+        await client.fetch_bytes("https://h/x", 30.0, max_bytes=4)
+
+
 async def test_fetch_bytes_maps_timeout() -> None:
     session = MagicMock(spec=aiohttp.ClientSession)
     session.closed = False
@@ -175,3 +211,23 @@ async def test_redirect_resolved_through_policy_path() -> None:
 
     body = await client.fetch_bytes("https://h/x.png", 30.0, policy=_PERMISSIVE)
     assert body == b"final"
+
+
+async def test_redirect_target_is_subject_to_body_limit() -> None:
+    responses = {
+        "https://h/x.png": _FakeResponse(
+            status=302,
+            headers={"Location": "/next.png"},
+            url=URL("https://h/x.png"),
+        ),
+        "https://h/next.png": _FakeResponse(status=200, body=b"too large"),
+    }
+    session = MagicMock(spec=aiohttp.ClientSession)
+    session.closed = False
+    session.get = _cm_per_url(responses)
+    client = _make_client_with_session(session)
+
+    with pytest.raises(mm_http.HttpBodyTooLargeError):
+        await client.fetch_bytes(
+            "https://h/x.png", 30.0, policy=_PERMISSIVE, max_bytes=4
+        )

--- a/components/src/dynamo/common/tests/http/test_httpx_client.py
+++ b/components/src/dynamo/common/tests/http/test_httpx_client.py
@@ -69,6 +69,51 @@ async def test_fetch_bytes_returns_body_on_200() -> None:
     assert result == b"hello"
 
 
+async def test_fetch_bytes_aborts_when_stream_exceeds_limit() -> None:
+    response = MagicMock(spec=httpx.Response)
+    response.is_redirect = False
+    response.headers = {}
+    response.raise_for_status = MagicMock(return_value=None)
+    response.aclose = AsyncMock(return_value=None)
+
+    async def _chunks(*args, **kwargs):
+        yield b"too"
+        yield b" large"
+
+    response.aiter_bytes = _chunks
+    inner = MagicMock(spec=httpx.AsyncClient)
+    inner.is_closed = False
+    inner.build_request = MagicMock(
+        side_effect=lambda method, url, **kw: MagicMock(url=httpx.URL(url))
+    )
+    inner.send = MagicMock(side_effect=_async_returning(response))
+    client = _make_client_with_inner(inner)
+
+    with pytest.raises(mm_http.HttpBodyTooLargeError):
+        await client.fetch_bytes("https://h/x", 30.0, policy=_PERMISSIVE, max_bytes=4)
+
+
+async def test_fetch_bytes_rejects_declared_body_over_limit() -> None:
+    response = MagicMock(spec=httpx.Response)
+    response.headers = {"Content-Length": "1024"}
+    response.raise_for_status = MagicMock(return_value=None)
+
+    async def _chunks(*args, **kwargs):
+        yield b"not-read"
+
+    response.aiter_bytes = _chunks
+    stream_context = AsyncMock()
+    stream_context.__aenter__.return_value = response
+    stream_context.__aexit__.return_value = False
+    inner = MagicMock(spec=httpx.AsyncClient)
+    inner.is_closed = False
+    inner.stream = MagicMock(return_value=stream_context)
+    client = _make_client_with_inner(inner)
+
+    with pytest.raises(mm_http.HttpBodyTooLargeError):
+        await client.fetch_bytes("https://h/x", 30.0, max_bytes=4)
+
+
 async def test_fetch_bytes_maps_timeout() -> None:
     inner = MagicMock(spec=httpx.AsyncClient)
     inner.is_closed = False
@@ -139,3 +184,42 @@ async def test_redirect_resolved_through_policy_path() -> None:
     client = _make_client_with_inner(inner)
     body = await client.fetch_bytes("https://h/x.png", 30.0, policy=_PERMISSIVE)
     assert body == b"final"
+
+
+async def test_redirect_target_is_subject_to_body_limit() -> None:
+    redirect_response = MagicMock(spec=httpx.Response)
+    redirect_response.is_redirect = True
+    redirect_response.headers = {"location": "/next.png"}
+    redirect_response.url = httpx.URL("https://h/x.png")
+    redirect_response.aclose = AsyncMock(return_value=None)
+
+    final_response = MagicMock(spec=httpx.Response)
+    final_response.is_redirect = False
+    final_response.headers = {}
+    final_response.raise_for_status = MagicMock(return_value=None)
+    final_response.aclose = AsyncMock(return_value=None)
+
+    async def _chunks(*args, **kwargs):
+        yield b"too large"
+
+    final_response.aiter_bytes = _chunks
+    responses_by_url = {
+        "https://h/x.png": redirect_response,
+        "https://h/next.png": final_response,
+    }
+
+    async def _send(request, *args, **kwargs):
+        return responses_by_url[str(request.url)]
+
+    inner = MagicMock(spec=httpx.AsyncClient)
+    inner.is_closed = False
+    inner.build_request = MagicMock(
+        side_effect=lambda method, url, **kw: MagicMock(url=httpx.URL(url))
+    )
+    inner.send = MagicMock(side_effect=_send)
+    client = _make_client_with_inner(inner)
+
+    with pytest.raises(mm_http.HttpBodyTooLargeError):
+        await client.fetch_bytes(
+            "https://h/x.png", 30.0, policy=_PERMISSIVE, max_bytes=4
+        )


### PR DESCRIPTION
## Why

Dynamo fetches user-supplied remote media through shared HTTP clients, but response size was only known after buffering the complete body. Large or unbounded responses could therefore consume arbitrary memory before callers rejected them. Enforcing an optional limit inside both streaming clients keeps existing uncapped callers unchanged while giving media paths a reliable resource boundary, including across redirects.

## What Change

- Add opt-in response byte limits to both HTTP client implementations.
- Reject oversized headers and streaming bodies with a shared typed error.
- Revalidate limits after redirects.

```mermaid
classDiagram
    HttpClient <|-- AiohttpClient
    HttpClient <|-- HttpxClient
    AiohttpClient ..> HttpBodyTooLargeError : rejects oversized streams
    HttpxClient ..> HttpBodyTooLargeError : rejects oversized streams

    note for HttpClient "Defines the optional max-bytes contract"
    note for HttpBodyTooLargeError "Reports one backend-neutral limit failure"
```

## Test Plan

- Run focused aiohttp and httpx client tests.
- Run pre-commit on all changed files.
