### PR TITLE
feat(video): support typed input references

### DIFF
--- a/components/src/dynamo/common/protocols/video_protocol.py
+++ b/components/src/dynamo/common/protocols/video_protocol.py
@@ -10,7 +10,17 @@ to ensure compatibility with the Dynamo HTTP frontend.
 
 from typing import Literal, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
+
+
+class VideoInputReference(BaseModel):
+    """Typed conditioning input for video generation."""
+
+    type: Literal["image", "video", "audio"]
+    """Reference media type."""
+
+    source: str
+    """HTTP(S), data, file URL, or an allowed local path."""
 
 
 class VideoNvExt(BaseModel):
@@ -64,6 +74,9 @@ class NvCreateVideoRequest(BaseModel):
     input_reference: Optional[str] = None
     """Optional image reference that guides generation (for I2V)."""
 
+    input_references: Optional[list[VideoInputReference]] = None
+    """Typed references; order is preserved within each media type."""
+
     seconds: Optional[int] = None
     """Clip duration in seconds."""
 
@@ -86,6 +99,16 @@ class NvCreateVideoRequest(BaseModel):
 
     nvext: Optional[VideoNvExt] = None
     """NVIDIA extensions."""
+
+    @model_validator(mode="after")
+    def validate_input_references(self) -> "NvCreateVideoRequest":
+        if self.input_reference is not None and self.input_references is not None:
+            raise ValueError(
+                "input_reference and input_references are mutually exclusive"
+            )
+        if self.input_references is not None and not self.input_references:
+            raise ValueError("input_references must not be empty")
+        return self
 
 
 class VideoData(BaseModel):

--- a/components/src/dynamo/common/tests/test_video_protocol.py
+++ b/components/src/dynamo/common/tests/test_video_protocol.py
@@ -39,6 +39,35 @@ def test_video_request_wire_shape():
     }
 
 
+def test_video_request_typed_references_preserve_wire_order():
+    request = NvCreateVideoRequest(
+        prompt="cat",
+        model="video-model",
+        input_references=[
+            {"type": "image", "source": "https://example.com/cat.png"},
+            {"type": "audio", "source": "data:audio/wav;base64,AA=="},
+        ],
+    )
+
+    assert [reference.type for reference in request.input_references] == [
+        "image",
+        "audio",
+    ]
+
+
+@pytest.mark.parametrize(
+    "input_references",
+    [[], [{"type": "image", "source": "https://example.com/cat.png"}]],
+)
+def test_video_request_rejects_invalid_reference_combinations(input_references):
+    kwargs: dict[str, object] = {"input_references": input_references}
+    if input_references:
+        kwargs["input_reference"] = "https://example.com/legacy.png"
+
+    with pytest.raises(ValueError):
+        NvCreateVideoRequest(prompt="cat", model="video-model", **kwargs)
+
+
 def test_video_response_wire_shape():
     response = NvVideosResponse(
         id="r1",

--- a/components/src/dynamo/sglang/protocol.py
+++ b/components/src/dynamo/sglang/protocol.py
@@ -3,7 +3,7 @@
 
 from typing import Any, List, Literal, Optional, Tuple, Union
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 
 from dynamo.common.multimodal import TransferRequest
@@ -217,6 +217,15 @@ class CreateVideoRequest(BaseModel):
     response_format: Optional[str] = "url"  # url or b64_json
     output_format: Optional[str] = None  # only mp4 is supported
     nvext: Optional[VideoNvExt] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_typed_input_references(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data.get("input_references") is not None:
+            raise ValueError(
+                "input_references is not supported by the SGLang video backend"
+            )
+        return data
 
 
 class VideoData(BaseModel):

--- a/components/src/dynamo/sglang/tests/test_video_protocol.py
+++ b/components/src/dynamo/sglang/tests/test_video_protocol.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from pydantic import ValidationError
+
+from dynamo.sglang.protocol import CreateVideoRequest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_rejects_typed_input_references() -> None:
+    with pytest.raises(ValidationError, match="not supported by the SGLang"):
+        CreateVideoRequest.model_validate(
+            {
+                "prompt": "a cat",
+                "model": "video-model",
+                "input_references": [
+                    {"type": "image", "source": "https://example.com/cat.png"}
+                ],
+            }
+        )

--- a/components/src/dynamo/trtllm/request_handlers/diffusion/video_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/diffusion/video_handler.py
@@ -190,6 +190,10 @@ class VideoGenerationHandler(BaseGenerativeHandler):
         try:
             # Parse request
             req = NvCreateVideoRequest(**request)
+            if req.input_references is not None:
+                raise ValueError(
+                    "input_references is not supported by the TensorRT-LLM video backend"
+                )
             nvext = req.nvext or VideoNvExt()
 
             # Parse parameters

--- a/components/src/dynamo/trtllm/tests/test_trtllm_video_diffusion.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_video_diffusion.py
@@ -365,6 +365,17 @@ class TestNvCreateVideoRequest:
         assert req.output_format is None
         assert req.nvext is None
 
+    def test_protocol_accepts_typed_references_for_capability_routing(self):
+        req = NvCreateVideoRequest(
+            prompt="A cat",
+            model="wan_t2v",
+            input_references=[
+                {"type": "image", "source": "https://example.com/cat.png"}
+            ],
+        )
+
+        assert req.input_references is not None
+
     def test_full_request_valid(self):
         """Test a fully populated request with nvext."""
         req = NvCreateVideoRequest(
@@ -394,6 +405,34 @@ class TestNvCreateVideoRequest:
         assert req.nvext.guidance_scale == 7.5
         assert req.nvext.negative_prompt == "blurry, low quality"
         assert req.nvext.seed == 42
+
+
+@pytest.mark.asyncio
+async def test_handler_rejects_typed_input_references() -> None:
+    from dynamo.trtllm.request_handlers.diffusion.video_handler import (
+        VideoGenerationHandler,
+    )
+
+    handler = object.__new__(VideoGenerationHandler)
+    context = MagicMock()
+    context.id.return_value = "request-id"
+
+    results = [
+        result
+        async for result in handler.generate(
+            {
+                "prompt": "A cat",
+                "model": "wan_t2v",
+                "input_references": [
+                    {"type": "image", "source": "https://example.com/cat.png"}
+                ],
+            },
+            context,
+        )
+    ]
+
+    assert results[0]["status"] == "failed"
+    assert "not supported by the TensorRT-LLM" in results[0]["error"]
 
 
 class TestVideoData:

--- a/components/src/dynamo/vllm/omni/base_handler.py
+++ b/components/src/dynamo/vllm/omni/base_handler.py
@@ -19,6 +19,7 @@ except ImportError:
 
 from dynamo._core import Context
 from dynamo.common.protocols.audio_protocol import NvAudioSpeechResponse
+from dynamo.common.protocols.video_protocol import NvVideosResponse
 from dynamo.common.utils.output_modalities import RequestType
 from dynamo.vllm.handlers import BaseWorkerHandler, build_sampling_params
 from dynamo.vllm.lora_state import LoRAState
@@ -213,14 +214,24 @@ class BaseOmniHandler(BaseWorkerHandler[Dict[str, Any], Dict[str, Any]]):
     ) -> Dict[str, Any]:
         """Create an error response matching the expected protocol for the request type.
 
-        For AUDIO_GENERATION returns NvAudioSpeechResponse format.
-        For all other types returns OpenAI chat.completion.chunk format.
+        Audio and video generation failures use their endpoint response shapes.
+        All other types return an OpenAI chat.completion.chunk.
         """
         if request_type == RequestType.AUDIO_GENERATION:
             return NvAudioSpeechResponse(
                 id=request_id,
                 model=self.config.served_model_name or self.config.model,
                 status="failed",
+                created=int(time.time()),
+                error=error_message,
+            ).model_dump()
+
+        if request_type == RequestType.VIDEO_GENERATION:
+            return NvVideosResponse(
+                id=request_id,
+                model=self.config.served_model_name or self.config.model,
+                status="failed",
+                progress=0,
                 created=int(time.time()),
                 error=error_message,
             ).model_dump()

--- a/components/src/dynamo/vllm/omni/omni_handler.py
+++ b/components/src/dynamo/vllm/omni/omni_handler.py
@@ -54,6 +54,7 @@ from dynamo.vllm.omni.utils import (
     image_generation_sampling_overrides,
     image_generation_size_from_request,
 )
+from dynamo.vllm.omni.video_references import VideoReferenceMaterializer
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +204,7 @@ class OmniHandler(BaseOmniHandler):
         self.media_output_fs = media_output_fs
         self.media_output_http_url = media_output_http_url
         self._image_loader = ImageLoader()
+        self._video_reference_materializer = VideoReferenceMaterializer()
         self.generate_endpoint = generate_endpoint
 
         # Keep parity with BaseWorkerHandler LoRA resolver contract.
@@ -308,9 +310,24 @@ class OmniHandler(BaseOmniHandler):
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Single generation path for all request protocols and output modalities."""
 
-        parsed_request_raw, request_type = parse_request_type(
-            request, self.config.output_modalities
-        )
+        try:
+            parsed_request_raw, request_type = parse_request_type(
+                request, self.config.output_modalities
+            )
+        except (TypeError, ValueError) as e:
+            logger.error("Invalid request %s: %s", request_id, e)
+            output_modality = (
+                self.config.output_modalities[0].lower()
+                if self.config.output_modalities
+                else "text"
+            )
+            error_request_type = {
+                "audio": RequestType.AUDIO_GENERATION,
+                "image": RequestType.IMAGE_GENERATION,
+                "video": RequestType.VIDEO_GENERATION,
+            }.get(output_modality, RequestType.CHAT_COMPLETION)
+            yield self._error_chunk(request_id, str(e), error_request_type)
+            return
         parsed_request = cast(
             Union[NvCreateImageRequest, NvCreateVideoRequest, Dict[str, Any]],
             parsed_request_raw,
@@ -318,6 +335,7 @@ class OmniHandler(BaseOmniHandler):
 
         # Pre-load input image for I2V requests (async I/O before sync build)
         image = None
+        materialized_references = None
         if (
             request_type == RequestType.VIDEO_GENERATION
             and isinstance(parsed_request, NvCreateVideoRequest)
@@ -338,14 +356,45 @@ class OmniHandler(BaseOmniHandler):
                 }
                 return
 
+        if (
+            request_type == RequestType.VIDEO_GENERATION
+            and isinstance(parsed_request, NvCreateVideoRequest)
+            and parsed_request.input_references is not None
+        ):
+            try:
+                materialized_references = (
+                    await self._video_reference_materializer.materialize(parsed_request)
+                )
+            except Exception as e:
+                logger.warning("Failed to materialize input_references: %s", e)
+                yield self._error_chunk(
+                    request_id,
+                    f"Failed to materialize input_references: {e}",
+                    request_type,
+                )
+                return
+
         try:
             inputs = await self.build_engine_inputs(
-                parsed_request, request_type, image=image
+                parsed_request,
+                request_type,
+                image=image,
+                multi_modal_data=(
+                    materialized_references.as_omni_data()
+                    if materialized_references is not None
+                    else None
+                ),
             )
         except (ValueError, NotImplementedError, RuntimeError) as e:
+            if materialized_references is not None:
+                materialized_references.cleanup()
             logger.error(f"Invalid request {request_id}: {e}")
             yield self._error_chunk(request_id, str(e), request_type)
             return
+        except Exception:
+            if materialized_references is not None:
+                materialized_references.cleanup()
+            raise
 
         generate_kwargs: Dict[str, Any] = {
             "prompt": inputs.prompt,
@@ -424,6 +473,9 @@ class OmniHandler(BaseOmniHandler):
             except Exception as e:
                 logger.error(f"Error during generation for request {request_id}: {e}")
                 yield self._error_chunk(request_id, str(e), inputs.request_type)
+            finally:
+                if materialized_references is not None:
+                    materialized_references.cleanup()
 
     async def _generate_with_lora_admission_lock(
         self,
@@ -534,6 +586,7 @@ class OmniHandler(BaseOmniHandler):
         ],
         request_type: RequestType,
         image: PIL.Image.Image | None = None,
+        multi_modal_data: dict[str, Any] | None = None,
     ) -> EngineInputs:
         """Convert a parsed request into AsyncOmni engine inputs.
 
@@ -542,6 +595,7 @@ class OmniHandler(BaseOmniHandler):
                 for image/video/audio requests, or a raw dict for chat completions.
             request_type: The RequestType determined by parse_request_type.
             image: Pre-loaded PIL Image for I2V requests (from input_reference).
+            multi_modal_data: Materialized typed references adapted for the pipeline.
 
         Returns:
             EngineInputs ready for engine_client.generate().
@@ -554,7 +608,11 @@ class OmniHandler(BaseOmniHandler):
             return self._engine_inputs_from_image(parsed_request)
         elif request_type == RequestType.VIDEO_GENERATION:
             assert isinstance(parsed_request, NvCreateVideoRequest)
-            return self._engine_inputs_from_video(parsed_request, image=image)
+            return self._engine_inputs_from_video(
+                parsed_request,
+                image=image,
+                multi_modal_data=multi_modal_data,
+            )
         elif request_type == RequestType.AUDIO_GENERATION:
             assert isinstance(parsed_request, NvCreateAudioSpeechRequest)
             return await self.audio.build_engine_inputs(parsed_request)
@@ -669,6 +727,7 @@ class OmniHandler(BaseOmniHandler):
         self,
         req: NvCreateVideoRequest,
         image: PIL.Image.Image | None = None,
+        multi_modal_data: dict[str, Any] | None = None,
     ) -> EngineInputs:
         """Build engine inputs from an NvCreateVideoRequest.
 
@@ -677,10 +736,10 @@ class OmniHandler(BaseOmniHandler):
             image: Pre-loaded PIL Image for I2V. When provided, the image is
                 attached to the prompt via ``multi_modal_data`` so vllm-omni's
                 I2V pipeline pre-process can use it.
+            multi_modal_data: Typed reference paths adapted for the pipeline.
         """
         width, height = parse_size(req.size)
         nvext = req.nvext or VideoNvExt()
-
         num_frames = compute_num_frames(
             num_frames=nvext.num_frames,
             seconds=req.seconds,
@@ -700,6 +759,15 @@ class OmniHandler(BaseOmniHandler):
                 image.size[0],
                 image.size[1],
             )
+        elif multi_modal_data is not None:
+            prompt["multi_modal_data"] = multi_modal_data
+            logger.info(
+                "Video references attached: %s",
+                {
+                    key: len(value) if isinstance(value, (list, tuple)) else 1
+                    for key, value in multi_modal_data.items()
+                },
+            )
 
         sp = OmniDiffusionSamplingParams(
             height=height,
@@ -714,7 +782,6 @@ class OmniHandler(BaseOmniHandler):
         self._update_if_not_none(sp, "boundary_ratio", nvext.boundary_ratio)
         self._update_if_not_none(sp, "guidance_scale_2", nvext.guidance_scale_2)
         self._update_if_not_none(sp, "fps", fps)
-
         sampling_params_list = self._build_sampling_params_list(sp)
         lora_request = self._resolve_and_apply_lora(req.model, sampling_params_list)
 

--- a/components/src/dynamo/vllm/omni/video_references.py
+++ b/components/src/dynamo/vllm/omni/video_references.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Request-scoped typed reference materialization for video diffusion."""
+
+import asyncio
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+from urllib.request import url2pathname
+
+from dynamo.common.http import HttpBodyTooLargeError, fetch_bytes
+from dynamo.common.http.url_validator import UrlValidationPolicy, validate_media_url
+from dynamo.common.multimodal.media_source import read_local_media_bytes
+from dynamo.common.protocols.video_protocol import (
+    NvCreateVideoRequest,
+    VideoInputReference,
+)
+
+_REFERENCE_LIMITS = {
+    "image": 30 * 1024 * 1024,
+    "video": 50 * 1024 * 1024,
+    "audio": 15 * 1024 * 1024,
+}
+_MAX_REFERENCE_COUNT = 12
+_MAX_TOTAL_REFERENCE_BYTES = 512 * 1024 * 1024
+_DEFAULT_SUFFIXES = {"image": ".png", "video": ".mp4", "audio": ".wav"}
+_ALLOWED_SUFFIXES = {
+    "image": {".jpg", ".jpeg", ".png", ".webp", ".heic", ".heif"},
+    "video": {".mp4", ".mov"},
+    "audio": {".wav", ".mp3"},
+}
+_MIME_SUFFIXES = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/heic": ".heic",
+    "image/heif": ".heif",
+    "video/mp4": ".mp4",
+    "video/quicktime": ".mov",
+    "audio/wav": ".wav",
+    "audio/x-wav": ".wav",
+    "audio/mpeg": ".mp3",
+    "audio/mp3": ".mp3",
+}
+
+
+@dataclass
+class MaterializedVideoReferences:
+    """References grouped for ``OmniTextPrompt.multi_modal_data``."""
+
+    multi_modal_data: dict[str, list[str]]
+    temporary_directory: tempfile.TemporaryDirectory[str]
+
+    def as_omni_data(self, *, allow_multiple: bool = False) -> dict[str, object]:
+        """Adapt grouped paths to the selected vLLM-Omni pipeline ABI."""
+        if allow_multiple:
+            return dict(self.multi_modal_data)
+
+        result: dict[str, object] = {}
+        for media_type, paths in self.multi_modal_data.items():
+            if len(paths) != 1:
+                raise ValueError(
+                    "generic vLLM-Omni video pipelines accept at most one "
+                    f"{media_type} reference"
+                )
+            result[media_type] = paths[0]
+        return result
+
+    def cleanup(self) -> None:
+        self.temporary_directory.cleanup()
+
+
+class VideoReferenceMaterializer:
+    """Securely fetch and stage typed video references."""
+
+    def __init__(
+        self,
+        *,
+        http_timeout: float = 60.0,
+        url_policy: UrlValidationPolicy | None = None,
+    ) -> None:
+        self._http_timeout = http_timeout
+        self._url_policy = url_policy or UrlValidationPolicy.from_env()
+
+    async def materialize(
+        self, request: NvCreateVideoRequest
+    ) -> MaterializedVideoReferences | None:
+        references = request.input_references
+        if references is None:
+            return None
+        if len(references) > _MAX_REFERENCE_COUNT:
+            raise ValueError(
+                f"input_references accepts at most {_MAX_REFERENCE_COUNT} references"
+            )
+
+        temporary_directory = tempfile.TemporaryDirectory(
+            prefix="dynamo_video_references_"
+        )
+        grouped: dict[str, list[str]] = {}
+        total_bytes = 0
+        try:
+            for index, reference in enumerate(references):
+                path, size = await self._materialize_one(
+                    reference,
+                    index=index,
+                    directory=Path(temporary_directory.name),
+                    remaining_bytes=_MAX_TOTAL_REFERENCE_BYTES - total_bytes,
+                )
+                total_bytes += size
+                if total_bytes > _MAX_TOTAL_REFERENCE_BYTES:
+                    raise ValueError("input_references exceed the 512 MiB total limit")
+                grouped.setdefault(reference.type, []).append(path)
+        except BaseException:
+            temporary_directory.cleanup()
+            raise
+
+        return MaterializedVideoReferences(grouped, temporary_directory)
+
+    async def _materialize_one(
+        self,
+        reference: VideoInputReference,
+        *,
+        index: int,
+        directory: Path,
+        remaining_bytes: int,
+    ) -> tuple[str, int]:
+        if remaining_bytes <= 0:
+            raise ValueError("input_references exceed the 512 MiB total limit")
+        normalized = await validate_media_url(reference.source, self._url_policy)
+        parsed = urlparse(normalized)
+        if parsed.scheme == "file":
+            path = Path(url2pathname(unquote(parsed.path)))
+            size = path.stat().st_size
+            self._validate_size(size, reference.type)
+            return str(path), size
+
+        if parsed.scheme == "data":
+            content = await read_local_media_bytes(normalized, self._url_policy)
+        else:
+            limit = _REFERENCE_LIMITS[reference.type]
+            effective_limit = min(limit, remaining_bytes)
+            try:
+                content = await fetch_bytes(
+                    normalized,
+                    self._http_timeout,
+                    policy=self._url_policy,
+                    max_bytes=effective_limit,
+                )
+            except HttpBodyTooLargeError as e:
+                if effective_limit < limit:
+                    raise ValueError(
+                        "input_references exceed the 512 MiB total limit"
+                    ) from e
+                raise ValueError(
+                    f"{reference.type} reference exceeds the "
+                    f"{limit // (1024 * 1024)} MiB limit"
+                ) from e
+        if not content:
+            raise ValueError(f"{reference.type} reference is empty")
+        self._validate_size(len(content), reference.type)
+
+        path = directory / f"{index:02d}{self._suffix(reference)}"
+        await asyncio.to_thread(path.write_bytes, content)
+        return str(path), len(content)
+
+    @staticmethod
+    def _validate_size(size: int, reference_type: str) -> None:
+        limit = _REFERENCE_LIMITS[reference_type]
+        if size > limit:
+            raise ValueError(
+                f"{reference_type} reference exceeds the {limit // (1024 * 1024)} MiB limit"
+            )
+
+    @staticmethod
+    def _suffix(reference: VideoInputReference) -> str:
+        parsed = urlparse(reference.source)
+        if parsed.scheme == "data":
+            media_type = parsed.path.partition(",")[0].partition(";")[0].lower()
+            return _MIME_SUFFIXES.get(media_type, _DEFAULT_SUFFIXES[reference.type])
+        suffix = Path(unquote(parsed.path)).suffix.lower()
+        if suffix in _ALLOWED_SUFFIXES[reference.type]:
+            return suffix
+        return _DEFAULT_SUFFIXES[reference.type]

--- a/components/src/dynamo/vllm/tests/omni/test_omni_handler.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_handler.py
@@ -244,6 +244,30 @@ class TestI2VEngineInputs:
         assert empty.guidance_scale_2 is None
 
 
+class TestTypedVideoReferencesEngineInputs:
+    @pytest.mark.asyncio
+    async def test_request_maps_typed_references(self):
+        handler = _make_handler()
+        req = NvCreateVideoRequest(
+            prompt="a talking cat",
+            model="video-model",
+        )
+        references = {
+            "image": ["/tmp/cat.png"],
+            "video": ["/tmp/motion.mp4"],
+            "audio": ["/tmp/voice.wav"],
+        }
+
+        result = await handler.build_engine_inputs(
+            req,
+            RequestType.VIDEO_GENERATION,
+            multi_modal_data=references,
+        )
+
+        assert result.prompt["multi_modal_data"] == references
+        assert result.fps == 16
+
+
 class TestBuildSamplingParamsList:
     def test_single_diffusion_stage(self):
         handler = _make_handler(stage_types=("diffusion",))

--- a/components/src/dynamo/vllm/tests/omni/test_video_references.py
+++ b/components/src/dynamo/vllm/tests/omni/test_video_references.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+try:
+    from dynamo.common.http.url_validator import UrlValidationPolicy
+    from dynamo.common.protocols.video_protocol import NvCreateVideoRequest
+    from dynamo.vllm.omni.video_references import VideoReferenceMaterializer
+except ImportError:
+    pytest.skip("vLLM omni dependencies not available", allow_module_level=True)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+@pytest.mark.asyncio
+async def test_materializes_typed_data_references_in_per_type_order():
+    request = NvCreateVideoRequest(
+        prompt="cat",
+        model="video-model",
+        input_references=[
+            {"type": "image", "source": "data:image/png;base64,aW1hZ2U="},
+            {"type": "audio", "source": "data:audio/mpeg;base64,YXVkaW8="},
+            {"type": "image", "source": "data:image/jpeg;base64,aW1hZ2Uy"},
+        ],
+    )
+
+    materialized = await VideoReferenceMaterializer().materialize(request)
+    assert materialized is not None
+    root = Path(materialized.temporary_directory.name)
+    try:
+        assert [
+            Path(path).suffix for path in materialized.multi_modal_data["image"]
+        ] == [
+            ".png",
+            ".jpg",
+        ]
+        assert Path(materialized.multi_modal_data["audio"][0]).suffix == ".mp3"
+        assert [
+            Path(path).read_bytes() for path in materialized.multi_modal_data["image"]
+        ] == [
+            b"image",
+            b"image2",
+        ]
+    finally:
+        materialized.cleanup()
+    assert not root.exists()
+
+
+@pytest.mark.asyncio
+async def test_generic_omni_data_scalarizes_singletons():
+    request = NvCreateVideoRequest(
+        prompt="cat",
+        model="video-model",
+        input_references=[
+            {"type": "image", "source": "data:image/png;base64,aW1hZ2U="},
+            {"type": "audio", "source": "data:audio/wav;base64,YXVkaW8="},
+        ],
+    )
+
+    materialized = await VideoReferenceMaterializer().materialize(request)
+    assert materialized is not None
+    try:
+        omni_data = materialized.as_omni_data()
+        assert isinstance(omni_data["image"], str)
+        assert isinstance(omni_data["audio"], str)
+    finally:
+        materialized.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_generic_omni_data_rejects_unsupported_multiplicity():
+    request = NvCreateVideoRequest(
+        prompt="cat",
+        model="video-model",
+        input_references=[
+            {"type": "image", "source": "data:image/png;base64,aW1hZ2U="},
+            {"type": "image", "source": "data:image/png;base64,aW1hZ2Uy"},
+        ],
+    )
+
+    materialized = await VideoReferenceMaterializer().materialize(request)
+    assert materialized is not None
+    try:
+        with pytest.raises(ValueError, match="at most one image"):
+            materialized.as_omni_data()
+        assert len(materialized.as_omni_data(allow_multiple=True)["image"]) == 2
+    finally:
+        materialized.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_rejects_cumulative_reference_size(monkeypatch):
+    monkeypatch.setattr(
+        "dynamo.vllm.omni.video_references._MAX_TOTAL_REFERENCE_BYTES", 5
+    )
+    request = NvCreateVideoRequest(
+        prompt="cat",
+        model="video-model",
+        input_references=[
+            {"type": "image", "source": "data:image/png;base64,YWFh"},
+            {"type": "audio", "source": "data:audio/wav;base64,YmJi"},
+        ],
+    )
+
+    with pytest.raises(ValueError, match="total limit"):
+        await VideoReferenceMaterializer().materialize(request)
+
+
+@pytest.mark.asyncio
+async def test_rejects_more_than_twelve_references_before_materialization():
+    request = SimpleNamespace(input_references=[None] * 13)
+
+    with pytest.raises(ValueError, match="at most 12"):
+        await VideoReferenceMaterializer().materialize(request)
+
+
+@pytest.mark.asyncio
+async def test_uses_validated_local_path_without_copy(tmp_path):
+    source = tmp_path / "clip.mp4"
+    source.write_bytes(b"video")
+    request = NvCreateVideoRequest(
+        prompt="cat",
+        model="video-model",
+        input_references=[{"type": "video", "source": str(source)}],
+    )
+    materializer = VideoReferenceMaterializer(
+        url_policy=UrlValidationPolicy(allowed_local_path=str(tmp_path))
+    )
+
+    materialized = await materializer.materialize(request)
+    assert materialized is not None
+    try:
+        assert materialized.multi_modal_data == {"video": [str(source.resolve())]}
+    finally:
+        materialized.cleanup()
+    assert source.exists()
+
+
+def test_unknown_remote_suffix_uses_media_type_default():
+    reference = NvCreateVideoRequest(
+        prompt="cat",
+        model="video-model",
+        input_references=[
+            {"type": "video", "source": "https://example.com/download.bin?format=mp4"}
+        ],
+    ).input_references[0]
+
+    assert VideoReferenceMaterializer._suffix(reference) == ".mp4"

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -4325,6 +4325,7 @@ async fn videos(
     // return a 503 if the service or model is not ready
     check_ready(&state)?;
     check_model_serving_ready(&state, &request.model)?;
+    validate_video_fields_generic(&request)?;
 
     let request_id = get_or_create_request_id(&headers);
     let request = context_from_headers(request, request_id, &headers)?;
@@ -4446,6 +4447,7 @@ async fn video_stream(
 ) -> Result<Response, ErrorResponse> {
     check_ready(&state)?;
     check_model_serving_ready(&state, &request.model)?;
+    validate_video_fields_generic(&request)?;
 
     let request_id = get_or_create_request_id(&headers);
     let request = context_from_headers(request, request_id, &headers)?;
@@ -4581,6 +4583,16 @@ async fn video_stream(
                 format!("{e}"),
             )
         })
+}
+
+/// Validates a video-generation request and returns an OpenAI-compatible error.
+fn validate_video_fields_generic(request: &NvCreateVideoRequest) -> Result<(), ErrorResponse> {
+    validator::Validate::validate(request).map_err(|e| {
+        ErrorMessage::from_http_error(HttpError {
+            code: 400,
+            message: VALIDATION_PREFIX.to_string() + &e.to_string(),
+        })
+    })
 }
 
 /// Create an Axum [`Router`] for the OpenAI API Videos endpoint

--- a/lib/llm/src/protocols/openai/videos.rs
+++ b/lib/llm/src/protocols/openai/videos.rs
@@ -3,15 +3,33 @@
 
 use dynamo_runtime::protocols::annotated::AnnotationsProvider;
 use serde::{Deserialize, Serialize};
-use validator::Validate;
+use validator::{Validate, ValidationError};
 
 mod aggregator;
 mod nvext;
 
 pub use nvext::{NvExt, NvExtProvider};
 
+/// Media type for a video-generation conditioning reference.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum VideoInputReferenceType {
+    Image,
+    Video,
+    Audio,
+}
+
+/// Typed conditioning input for video generation.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct VideoInputReference {
+    #[serde(rename = "type")]
+    pub reference_type: VideoInputReferenceType,
+    pub source: String,
+}
+
 /// Request for video generation (/v1/videos endpoint)
 #[derive(Serialize, Deserialize, Validate, Debug, Clone)]
+#[validate(schema(function = "validate_video_request"))]
 pub struct NvCreateVideoRequest {
     /// The text prompt for video generation
     pub prompt: String,
@@ -22,6 +40,10 @@ pub struct NvCreateVideoRequest {
     /// Optional image reference that guides generation (for I2V)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_reference: Option<String>,
+
+    /// Typed references; order is preserved within each media type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_references: Option<Vec<VideoInputReference>>,
 
     /// Clip duration in seconds
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -68,6 +90,20 @@ pub struct VideoData {
     /// Base64-encoded video (if response_format is "b64_json")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub b64_json: Option<String>,
+}
+
+fn validate_video_request(request: &NvCreateVideoRequest) -> Result<(), ValidationError> {
+    if request.input_reference.is_some() && request.input_references.is_some() {
+        return Err(ValidationError::new("input_references_conflict"));
+    }
+    if request
+        .input_references
+        .as_ref()
+        .is_some_and(|references| references.is_empty())
+    {
+        return Err(ValidationError::new("input_references_empty"));
+    }
+    Ok(())
 }
 
 /// Response structure for video generation
@@ -206,6 +242,7 @@ mod tests {
             prompt: "cat".into(),
             model: "wan".into(),
             input_reference: None,
+            input_references: None,
             seconds: None,
             size: None,
             user: None,
@@ -230,6 +267,41 @@ mod tests {
         let json = r#"{"prompt":"cat","model":"wan","output_format":"mp4"}"#;
         let req: NvCreateVideoRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.output_format.as_deref(), Some("mp4"));
+    }
+
+    #[test]
+    fn video_request_typed_references_round_trip() {
+        let json = r#"{
+            "prompt":"cat",
+            "model":"video-model",
+            "input_references":[
+                {"type":"image","source":"https://example.com/cat.png"},
+                {"type":"audio","source":"data:audio/wav;base64,AA=="}
+            ]
+        }"#;
+        let req: NvCreateVideoRequest = serde_json::from_str(json).unwrap();
+        let references = req.input_references.as_ref().unwrap();
+        assert_eq!(references.len(), 2);
+        assert_eq!(references[0].reference_type, VideoInputReferenceType::Image);
+        assert_eq!(references[1].reference_type, VideoInputReferenceType::Audio);
+        assert!(req.validate().is_ok());
+
+        let out = serde_json::to_string(&req).unwrap();
+        assert!(out.contains("\"input_references\""));
+    }
+
+    #[test]
+    fn video_request_rejects_legacy_and_typed_references() {
+        let json = r#"{
+            "prompt":"cat",
+            "model":"video-model",
+            "input_reference":"https://example.com/legacy.png",
+            "input_references":[
+                {"type":"image","source":"https://example.com/new.png"}
+            ]
+        }"#;
+        let req: NvCreateVideoRequest = serde_json::from_str(json).unwrap();
+        assert!(req.validate().is_err());
     }
 
     // --- VideoData ---


### PR DESCRIPTION
_Based on #13705._

## Why

The video API exposes only one untyped image reference, while vLLM-Omni pipelines can condition generation on image, video, and audio inputs. Dynamo needs a typed contract that preserves per-modality order, materializes remote media within request-level limits, and adapts singleton values to existing pipeline ABIs. Backends without this capability must reject the field instead of silently producing unconditioned video.

## What Change

- Add typed image, video, and audio references to Rust and Python protocols.
- Materialize validated references with count, byte, and cleanup boundaries.
- Scalarize generic singleton inputs and reject unsupported backend usage.

```mermaid
classDiagram
    NvCreateVideoRequest --> VideoReferenceMaterializer : supplies typed references
    VideoReferenceMaterializer --> OmniHandler : returns pipeline-ready paths
    OmniHandler --> OmniTextPrompt : attaches multimodal data

    note for VideoReferenceMaterializer "Bounds, stages, groups, and cleans request media"
    note for OmniHandler "Adapts references to the selected pipeline ABI"
```

## Test Plan

- Run Rust/Python video protocol and materializer tests.
- Run SGLang and TensorRT-LLM rejection tests.
