### PR TITLE
feat(recipes): add A.X K2 NVFP4 B200 recipes

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -87,6 +87,7 @@ These recipes are under active development and may require additional setup step
 
 | Model | Framework | Mode | GPUs | Deployment | Notes |
 |-------|-----------|------|------|------------|-------|
+| **[A.X K2 NVFP4](a.x-k2/)** | vLLM | Aggregated + Disaggregated | 4x / 8x B200 | ✅ | NVFP4 W4A4 routed experts with FP8/BF16 remainder, TP4 + expert parallel, 256K context, reasoning + tool calling. Requires the [SKT-AI vLLM fork and custom Dynamo runtime](a.x-k2/container/). |
 | **[GLM-5-NVFP4 (EFA)](glm-5-nvfp4/sglang/disagg/efa/)** | SGLang | Disagg Prefill/Decode over AWS EFA | 20x GB200 | ✅ | KV transfer over AWS EFA via NIXL LIBFABRIC instead of UCX. Patched libfabric baked into image. Requires [custom container build](glm-5-nvfp4/sglang/disagg/efa/Dockerfile.efa). |
 | **[Nemotron-3-Nano-Omni-NVFP4](nemotron-3-nano-omni/vllm/agg/)** | vLLM | Aggregated | 1x GPU | ✅ | Multimodal text/image/video/audio serving. Requires [custom container build](nemotron-3-nano-omni/). |
 | **[nvidia/Kimi-K2.5-NVFP4](kimi-k2.5/tokenspeed/agg/nvidia/)** | TokenSpeed | Aggregated | 4x B200 | ✅ | Text only — MoE model, TP4×EP4, reasoning + tool calling. Requires [custom container build](kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile) (no public Dynamo+TokenSpeed image yet) and raw `Deployment`s/`Service`s instead of `DynamoGraphDeployment` (operator backend support pending). |

--- a/recipes/a.x-k2/README.md
+++ b/recipes/a.x-k2/README.md
@@ -21,7 +21,7 @@ and keeps embeddings and the LM head in BF16.
 Both variants expose the model as `A.X-K2-NVFP4`, select the
 `FLASHINFER_MLA_SPARSE` attention backend, enable FlashInfer NVFP4 MoE kernels,
 use the `hermes` tool-call parser and `deepseek_v3` reasoning parser, and mount
-the `shared-model-cache` ReadWriteMany (RWX) PersistentVolumeClaim (PVC) at
+the `model-cache` ReadWriteMany (RWX) PersistentVolumeClaim (PVC) at
 `/models`.
 
 ## Prerequisites
@@ -29,7 +29,7 @@ the `shared-model-cache` ReadWriteMany (RWX) PersistentVolumeClaim (PVC) at
 - Dynamo Platform with the `nvidia.com/v1beta1` `DynamoGraphDeployment` API
 - One 4-GPU B200 node for aggregated serving
 - Two 4-GPU B200 nodes and the `rdma/ib` device plugin for disaggregated serving
-- An existing `shared-model-cache` RWX PVC
+- An existing `model-cache` RWX PVC
 - The A.X K2 NVFP4 checkpoint downloaded into that PVC
 - A registry-accessible custom runtime built from [`container/README.md`](container/README.md)
 - A `hf-token-secret` secret in the deployment namespace
@@ -37,7 +37,7 @@ the `shared-model-cache` ReadWriteMany (RWX) PersistentVolumeClaim (PVC) at
 ## Download the Model
 
 The download Job uses the existing PVC. Do not apply
-`model-cache/model-cache.yaml` when `shared-model-cache` already exists.
+`model-cache/model-cache.yaml` when `model-cache` already exists.
 
 ```bash
 export NAMESPACE=<your-namespace>
@@ -92,7 +92,7 @@ kubectl get pods \
 
 The first worker startup compiles model kernels and can take up to 90 minutes.
 `VLLM_CACHE_ROOT`, `TRITON_CACHE_DIR`, and `FLASHINFER_WORKSPACE_BASE` point
-into `shared-model-cache` so subsequent workers can reuse the generated
+into `model-cache` so subsequent workers can reuse the generated
 artifacts.
 
 ## Smoke Test

--- a/recipes/a.x-k2/README.md
+++ b/recipes/a.x-k2/README.md
@@ -80,10 +80,12 @@ Start with aggregated serving to validate the custom vLLM image and model
 implementation:
 
 ```bash
+export DEPLOYMENT=axk2-vllm-agg-b200   # axk2-vllm-disagg-b200 for disaggregated serving
+
 kubectl apply -f "${RECIPE}/deploy.yaml" -n "${NAMESPACE}"
 
 kubectl get pods \
-  -l nvidia.com/dynamo-graph-deployment-name=axk2-vllm-agg-b200 \
+  -l nvidia.com/dynamo-graph-deployment-name="${DEPLOYMENT}" \
   -n "${NAMESPACE}" \
   --watch
 ```
@@ -97,7 +99,7 @@ artifacts.
 
 ```bash
 kubectl port-forward \
-  svc/axk2-vllm-agg-b200-frontend \
+  "svc/${DEPLOYMENT}-frontend" \
   8000:8000 \
   -n "${NAMESPACE}"
 ```

--- a/recipes/a.x-k2/README.md
+++ b/recipes/a.x-k2/README.md
@@ -1,0 +1,125 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# A.X K2 NVFP4 vLLM Recipes
+
+These experimental recipes serve
+[`skt/A.X-K2-NVFP4`](https://huggingface.co/skt/A.X-K2-NVFP4) with Dynamo and
+the `axk2-v0.23.0` branch of the SKT-AI vLLM fork. The checkpoint quantizes
+routed experts to NVFP4 W4A4, keeps attention and other compute layers in FP8,
+and keeps embeddings and the LM head in BF16.
+
+## Deployment Targets
+
+| Variant | Topology | GPUs | Parallelism |
+|---|---|---:|---|
+| [`agg-b200`](vllm/agg-b200/deploy.yaml) | Aggregated | 4 B200 | TP4 + expert parallel |
+| [`disagg-b200`](vllm/disagg-b200/deploy.yaml) | 1 prefill + 1 decode | 8 B200 | TP4 + expert parallel per worker |
+
+Both variants expose the model as `A.X-K2-NVFP4`, select the
+`FLASHINFER_MLA_SPARSE` attention backend, enable FlashInfer NVFP4 MoE kernels,
+use the `hermes` tool-call parser and `deepseek_v3` reasoning parser, and mount
+the `shared-model-cache` ReadWriteMany (RWX) PersistentVolumeClaim (PVC) at
+`/models`.
+
+## Prerequisites
+
+- Dynamo Platform with the `nvidia.com/v1beta1` `DynamoGraphDeployment` API
+- One 4-GPU B200 node for aggregated serving
+- Two 4-GPU B200 nodes and the `rdma/ib` device plugin for disaggregated serving
+- An existing `shared-model-cache` RWX PVC
+- The A.X K2 NVFP4 checkpoint downloaded into that PVC
+- A registry-accessible custom runtime built from [`container/README.md`](container/README.md)
+- A `hf-token-secret` secret in the deployment namespace
+
+## Download the Model
+
+The download Job uses the existing PVC. Do not apply
+`model-cache/model-cache.yaml` when `shared-model-cache` already exists.
+
+```bash
+export NAMESPACE=<your-namespace>
+
+kubectl apply \
+  -f model-cache/model-download.yaml \
+  -n "${NAMESPACE}"
+
+kubectl wait \
+  --for=condition=Complete \
+  job/model-download \
+  -n "${NAMESPACE}" \
+  --timeout=14400s
+```
+
+The checkpoint occupies about 398 GB on disk. The Job stores it under the
+standard Hugging Face cache path in `/models/hub`.
+
+## Configure the Runtime Image
+
+Replace every placeholder image in the selected manifest with the image built
+from [`container/README.md`](container/README.md):
+
+```bash
+export AXK2_IMAGE=<your-registry>/dynamo/vllm-runtime:axk2-v0.23.0
+export RECIPE=vllm/agg-b200
+
+yq -i \
+  '(.spec.components[].podTemplate.spec.containers[] | select(.name == "main").image) = strenv(AXK2_IMAGE)' \
+  "${RECIPE}/deploy.yaml"
+```
+
+For disaggregated serving, set `RECIPE=vllm/disagg-b200`. If the cluster uses a
+different RDMA extended resource, replace `rdma/ib` in that manifest before
+deployment.
+
+## Deploy
+
+Start with aggregated serving to validate the custom vLLM image and model
+implementation:
+
+```bash
+kubectl apply -f "${RECIPE}/deploy.yaml" -n "${NAMESPACE}"
+
+kubectl get pods \
+  -l nvidia.com/dynamo-graph-deployment-name=axk2-vllm-agg-b200 \
+  -n "${NAMESPACE}" \
+  --watch
+```
+
+The first worker startup compiles model kernels and can take up to 90 minutes.
+`VLLM_CACHE_ROOT`, `TRITON_CACHE_DIR`, and `FLASHINFER_WORKSPACE_BASE` point
+into `shared-model-cache` so subsequent workers can reuse the generated
+artifacts.
+
+## Smoke Test
+
+```bash
+kubectl port-forward \
+  svc/axk2-vllm-agg-b200-frontend \
+  8000:8000 \
+  -n "${NAMESPACE}"
+```
+
+In another terminal:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "A.X-K2-NVFP4",
+    "messages": [{"role": "user", "content": "A.X K2를 한 문장으로 소개해줘."}],
+    "max_tokens": 256,
+    "chat_template_kwargs": {"enable_thinking": false}
+  }'
+```
+
+For thinking mode, set `chat_template_kwargs.enable_thinking` to `true`.
+
+## Validation Status
+
+The model publisher documents native vLLM serving on 4 B200 GPUs. The custom
+Dynamo image performs import, compiled-extension, NIXL, and parser checks during
+the build. The aggregated and disaggregated Dynamo deployments still require a
+B200 smoke test; treat both as experimental until that validation is recorded.

--- a/recipes/a.x-k2/container/Dockerfile.axk2.vllm.b200
+++ b/recipes/a.x-k2/container/Dockerfile.axk2.vllm.b200
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Dynamo 1.3.0 and the A.X K2 fork both use vLLM 0.23.0. The fork changes only
+# Python files, so overlay its package on the precompiled Dynamo runtime.
+ARG DYNAMO_VLLM_IMAGE=nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0
+ARG AXK2_VLLM_REPOSITORY=https://github.com/SKT-AI/vllm.git
+ARG AXK2_VLLM_REF=9cca6f06f4b9d0b4247f9446252ed81cf197aaf4
+
+FROM ${DYNAMO_VLLM_IMAGE} AS axk2_source
+
+ARG AXK2_VLLM_REPOSITORY
+ARG AXK2_VLLM_REF
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --filter=blob:none "${AXK2_VLLM_REPOSITORY}" /opt/axk2-vllm \
+    && git -C /opt/axk2-vllm fetch --depth=1 origin "${AXK2_VLLM_REF}" \
+    && git -C /opt/axk2-vllm checkout --detach "${AXK2_VLLM_REF}"
+
+FROM ${DYNAMO_VLLM_IMAGE} AS runtime
+
+USER root
+COPY --from=axk2_source /opt/axk2-vllm/vllm /opt/axk2-vllm/vllm
+
+# Preserve the base image's version-matched compiled extensions and dependency
+# solve while replacing the vLLM Python package with the fork implementation.
+RUN VLLM_PACKAGE="$(python3 -c 'import pathlib, vllm; print(pathlib.Path(vllm.__file__).parent)')" \
+    && cp -a /opt/axk2-vllm/vllm/. "${VLLM_PACKAGE}/" \
+    && rm -rf /opt/axk2-vllm \
+    && python3 -c "import importlib.metadata as md; import vllm._C; from vllm.transformers_utils.configs.axk2 import AXK2Config; assert md.version('vllm').startswith('0.23.0'); assert AXK2Config.model_type == 'axk2'" \
+    && python3 -c "import ctypes, dynamo.vllm, nixl; from dynamo._core import get_reasoning_parser_names, get_tool_parser_names; ctypes.CDLL('libnixl.so'); assert 'deepseek_v3' in get_reasoning_parser_names(); assert 'hermes' in get_tool_parser_names()"
+
+USER dynamo
+WORKDIR /workspace
+
+ENTRYPOINT []
+CMD ["bash"]

--- a/recipes/a.x-k2/container/Dockerfile.axk2.vllm.b200
+++ b/recipes/a.x-k2/container/Dockerfile.axk2.vllm.b200
@@ -30,11 +30,15 @@ COPY --from=axk2_source /opt/axk2-vllm/vllm /opt/axk2-vllm/vllm
 
 # Preserve the base image's version-matched compiled extensions and dependency
 # solve while replacing the vLLM Python package with the fork implementation.
-RUN VLLM_PACKAGE="$(python3 -c 'import pathlib, vllm; print(pathlib.Path(vllm.__file__).parent)')" \
+# Keep build-time checks static so cross-platform builds do not load AMD64 CUDA
+# libraries under emulation; runtime imports are verified on the B200 target.
+RUN VLLM_PACKAGE="$(python3 -c "import importlib.util, pathlib; print(pathlib.Path(importlib.util.find_spec('vllm').origin).parent)")" \
     && cp -a /opt/axk2-vllm/vllm/. "${VLLM_PACKAGE}/" \
     && rm -rf /opt/axk2-vllm \
-    && python3 -c "import importlib.metadata as md; import vllm._C; from vllm.transformers_utils.configs.axk2 import AXK2Config; assert md.version('vllm').startswith('0.23.0'); assert AXK2Config.model_type == 'axk2'" \
-    && python3 -c "import ctypes, dynamo.vllm, nixl; from dynamo._core import get_reasoning_parser_names, get_tool_parser_names; ctypes.CDLL('libnixl.so'); assert 'deepseek_v3' in get_reasoning_parser_names(); assert 'hermes' in get_tool_parser_names()"
+    && python3 -c "import importlib.metadata as md; assert md.version('vllm').startswith('0.23.0')" \
+    && test -f "${VLLM_PACKAGE}/transformers_utils/configs/axk2.py" \
+    && set -- "${VLLM_PACKAGE}"/_C*.so \
+    && test -e "$1"
 
 USER dynamo
 WORKDIR /workspace

--- a/recipes/a.x-k2/container/README.md
+++ b/recipes/a.x-k2/container/README.md
@@ -51,5 +51,7 @@ docker run --rm --gpus all --entrypoint python3 "${AXK2_IMAGE}" -c \
   "import dynamo.vllm; from vllm.transformers_utils.configs.axk2 import AXK2Config; print(AXK2Config.model_type)"
 ```
 
-The command must print `axk2`. A complete verification still requires starting
+The command must print `axk2`, confirming the Dynamo import and the A.X K2
+config registration. It does not check NIXL or parser registration. A complete
+verification, including NIXL and parser registration, still requires starting
 the aggregated recipe on a 4-GPU B200 node.

--- a/recipes/a.x-k2/container/README.md
+++ b/recipes/a.x-k2/container/README.md
@@ -14,10 +14,10 @@ overlays its Python package on
 image retains the base image's compiled CUDA extensions, Dynamo integration,
 and NIXL libraries without rebuilding vLLM.
 
-This integration is experimental. The build checks the vLLM version, compiled
-extension, A.X K2 registration, Dynamo imports, NIXL library, and parser
-registration. A 4-GPU B200 smoke test is still required before treating the
-image as deployable.
+This integration is experimental. The build checks the vLLM version and the
+presence of the compiled extension and A.X K2 implementation without loading
+architecture-specific CUDA libraries. Verify Dynamo imports, NIXL, parser
+registration, and model execution with a 4-GPU B200 smoke test.
 
 ## Build
 
@@ -44,10 +44,10 @@ the Dockerfile rejects another version during the build.
 
 ## Verify
 
-Run import checks without a GPU:
+Run import checks on an AMD64 host with an NVIDIA driver:
 
 ```bash
-docker run --rm --entrypoint python3 "${AXK2_IMAGE}" -c \
+docker run --rm --gpus all --entrypoint python3 "${AXK2_IMAGE}" -c \
   "import dynamo.vllm; from vllm.transformers_utils.configs.axk2 import AXK2Config; print(AXK2Config.model_type)"
 ```
 

--- a/recipes/a.x-k2/container/README.md
+++ b/recipes/a.x-k2/container/README.md
@@ -1,0 +1,55 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# A.X K2 NVFP4 vLLM Runtime Image
+
+A.X K2 requires the
+[`SKT-AI/vllm`](https://github.com/SKT-AI/vllm/tree/axk2-v0.23.0) fork until its
+model implementation is available in upstream vLLM. The Dockerfile pins commit
+`9cca6f06f4b9d0b4247f9446252ed81cf197aaf4` from the `axk2-v0.23.0` branch and
+overlays its Python package on
+`nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0`. Both use vLLM 0.23.0, so the
+image retains the base image's compiled CUDA extensions, Dynamo integration,
+and NIXL libraries without rebuilding vLLM.
+
+This integration is experimental. The build checks the vLLM version, compiled
+extension, A.X K2 registration, Dynamo imports, NIXL library, and parser
+registration. A 4-GPU B200 smoke test is still required before treating the
+image as deployable.
+
+## Build
+
+Build the A.X K2 runtime from the repository root:
+
+```bash
+export AXK2_IMAGE=<your-registry>/dynamo/vllm-runtime:axk2-v0.23.0
+
+docker build \
+  -f recipes/a.x-k2/container/Dockerfile.axk2.vllm.b200 \
+  -t "${AXK2_IMAGE}" \
+  .
+
+docker push "${AXK2_IMAGE}"
+```
+
+To test another fork revision, pass
+`--build-arg AXK2_VLLM_REF=<full-commit-sha>`. Pin a full commit rather than the
+branch name.
+
+To use another compatible Dynamo image, pass
+`--build-arg DYNAMO_VLLM_IMAGE=<image>`. The image must contain vLLM 0.23.0;
+the Dockerfile rejects another version during the build.
+
+## Verify
+
+Run import checks without a GPU:
+
+```bash
+docker run --rm --entrypoint python3 "${AXK2_IMAGE}" -c \
+  "import dynamo.vllm; from vllm.transformers_utils.configs.axk2 import AXK2Config; print(AXK2Config.model_type)"
+```
+
+The command must print `axk2`. A complete verification still requires starting
+the aggregated recipe on a 4-GPU B200 node.

--- a/recipes/a.x-k2/model-cache/model-cache.yaml
+++ b/recipes/a.x-k2/model-cache/model-cache.yaml
@@ -11,5 +11,3 @@ spec:
   resources:
     requests:
       storage: 750Gi
-  # Edit this
-  storageClassName: "your-storage-class-name"

--- a/recipes/a.x-k2/model-cache/model-cache.yaml
+++ b/recipes/a.x-k2/model-cache/model-cache.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
+  storageClassName: "your-storage-class-name"
   resources:
     requests:
       storage: 750Gi

--- a/recipes/a.x-k2/model-cache/model-cache.yaml
+++ b/recipes/a.x-k2/model-cache/model-cache.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: shared-model-cache
+  name: model-cache
 spec:
   accessModes:
     - ReadWriteMany

--- a/recipes/a.x-k2/model-cache/model-cache.yaml
+++ b/recipes/a.x-k2/model-cache/model-cache.yaml
@@ -10,3 +10,5 @@ spec:
   resources:
     requests:
       storage: 750Gi
+  # Edit this
+  storageClassName: "your-storage-class-name"

--- a/recipes/a.x-k2/model-cache/model-cache.yaml
+++ b/recipes/a.x-k2/model-cache/model-cache.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-model-cache
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 750Gi

--- a/recipes/a.x-k2/model-cache/model-download.yaml
+++ b/recipes/a.x-k2/model-cache/model-download.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          image: python:3.10-slim
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["sh", "-c"]
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: MODEL_NAME
+              value: skt/A.X-K2-NVFP4
+            - name: HF_HOME
+              value: /models
+            # Disable the 64 GiB high-performance XET buffer on small CPU nodes.
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "0"
+          args:
+            - |
+              set -eu
+              # huggingface_hub 1.11.0 hf CLI imports click; recent typer no longer pulls it in
+              pip install --no-cache-dir huggingface_hub==1.11.0 click
+              hf download "${MODEL_NAME}"
+          resources:
+            requests:
+              cpu: "2"
+              # memory: "64Gi"
+              memory: "8Gi"
+            limits:
+              cpu: "8"
+              memory: "16Gi"
+          volumeMounts:
+            - name: shared-model-cache
+              mountPath: /models
+      volumes:
+        - name: shared-model-cache
+          persistentVolumeClaim:
+            claimName: shared-model-cache

--- a/recipes/a.x-k2/model-cache/model-download.yaml
+++ b/recipes/a.x-k2/model-cache/model-download.yaml
@@ -50,9 +50,9 @@ spec:
               cpu: "8"
               memory: "16Gi"
           volumeMounts:
-            - name: shared-model-cache
+            - name: model-cache
               mountPath: /models
       volumes:
-        - name: shared-model-cache
+        - name: model-cache
           persistentVolumeClaim:
-            claimName: shared-model-cache
+            claimName: model-cache

--- a/recipes/a.x-k2/vllm/agg-b200/deploy.yaml
+++ b/recipes/a.x-k2/vllm/agg-b200/deploy.yaml
@@ -19,6 +19,7 @@ spec:
               imagePullPolicy: IfNotPresent
               command:
                 - python3
+              args:
                 - -m
                 - dynamo.frontend
               env:

--- a/recipes/a.x-k2/vllm/agg-b200/deploy.yaml
+++ b/recipes/a.x-k2/vllm/agg-b200/deploy.yaml
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: axk2-vllm-agg-b200
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              image: your-registry.example.com/dynamo/vllm-runtime:axk2-v0.23.0
+              imagePullPolicy: IfNotPresent
+              command:
+                - python3
+                - -m
+                - dynamo.frontend
+              env:
+                - name: HF_HOME
+                  value: /models
+                - name: HF_HUB_OFFLINE
+                  value: "1"
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /models
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+
+    - name: agg
+      type: worker
+      replicas: 1
+      sharedMemorySize: 200Gi
+      podTemplate:
+        spec:
+          runtimeClassName: nvidia
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-B200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
+          containers:
+            - name: main
+              image: your-registry.example.com/dynamo/vllm-runtime:axk2-v0.23.0
+              imagePullPolicy: IfNotPresent
+              workingDir: /workspace
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  mkdir -p "${VLLM_CACHE_ROOT}" "${TRITON_CACHE_DIR}" "${FLASHINFER_WORKSPACE_BASE}"
+                  exec python3 -m dynamo.vllm \
+                    --model skt/A.X-K2-NVFP4 \
+                    --served-model-name A.X-K2-NVFP4 \
+                    --tensor-parallel-size 4 \
+                    --enable-expert-parallel \
+                    --attention-backend FLASHINFER_MLA_SPARSE \
+                    --max-model-len 262144 \
+                    --max-num-seqs 32 \
+                    --max-num-batched-tokens 16384 \
+                    --gpu-memory-utilization 0.92 \
+                    --kv-cache-dtype fp8 \
+                    --block-size 64 \
+                    --enable-prefix-caching \
+                    --dyn-tool-call-parser hermes \
+                    --dyn-reasoning-parser deepseek_v3
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              env:
+                - name: HF_HOME
+                  value: /models
+                - name: HF_HUB_CACHE
+                  value: /models/hub
+                - name: HF_HUB_OFFLINE
+                  value: "1"
+                - name: TRANSFORMERS_OFFLINE
+                  value: "1"
+                - name: VLLM_CACHE_ROOT
+                  value: /models/runtime-cache/axk2-nvfp4/vllm
+                - name: TRITON_CACHE_DIR
+                  value: /models/runtime-cache/axk2-nvfp4/triton
+                - name: FLASHINFER_WORKSPACE_BASE
+                  value: /models/runtime-cache/axk2-nvfp4/flashinfer
+                - name: VLLM_USE_FLASHINFER_MOE_FP4
+                  value: "1"
+                - name: FLASHINFER_DISABLE_VERSION_CHECK
+                  value: "1"
+                - name: VLLM_SKIP_P2P_CHECK
+                  value: "1"
+                - name: NCCL_CUMEM_ENABLE
+                  value: "1"
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+                failureThreshold: 90
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_RESOURCE
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  memory: 400Gi
+                limits:
+                  nvidia.com/gpu: "4"
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /models
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache

--- a/recipes/a.x-k2/vllm/agg-b200/deploy.yaml
+++ b/recipes/a.x-k2/vllm/agg-b200/deploy.yaml
@@ -95,6 +95,8 @@ spec:
                   value: /models/runtime-cache/axk2-nvfp4/flashinfer
                 - name: VLLM_USE_FLASHINFER_MOE_FP4
                   value: "1"
+                - name: VLLM_OMNI_USE_QUACK_FP8
+                  value: "0"
                 - name: FLASHINFER_DISABLE_VERSION_CHECK
                   value: "1"
                 - name: VLLM_SKIP_P2P_CHECK

--- a/recipes/a.x-k2/vllm/agg-b200/deploy.yaml
+++ b/recipes/a.x-k2/vllm/agg-b200/deploy.yaml
@@ -28,12 +28,12 @@ spec:
                 - name: HF_HUB_OFFLINE
                   value: "1"
               volumeMounts:
-                - name: shared-model-cache
+                - name: model-cache
                   mountPath: /models
           volumes:
-            - name: shared-model-cache
+            - name: model-cache
               persistentVolumeClaim:
-                claimName: shared-model-cache
+                claimName: model-cache
 
     - name: agg
       type: worker
@@ -124,9 +124,9 @@ spec:
                 limits:
                   nvidia.com/gpu: "4"
               volumeMounts:
-                - name: shared-model-cache
+                - name: model-cache
                   mountPath: /models
           volumes:
-            - name: shared-model-cache
+            - name: model-cache
               persistentVolumeClaim:
-                claimName: shared-model-cache
+                claimName: model-cache

--- a/recipes/a.x-k2/vllm/disagg-b200/deploy.yaml
+++ b/recipes/a.x-k2/vllm/disagg-b200/deploy.yaml
@@ -33,12 +33,12 @@ spec:
                 - name: HF_HUB_OFFLINE
                   value: "1"
               volumeMounts:
-                - name: shared-model-cache
+                - name: model-cache
                   mountPath: /models
           volumes:
-            - name: shared-model-cache
+            - name: model-cache
               persistentVolumeClaim:
-                claimName: shared-model-cache
+                claimName: model-cache
 
     - name: VllmPrefillWorker
       type: prefill
@@ -146,12 +146,12 @@ spec:
                   nvidia.com/gpu: "4"
                   rdma/ib: "4"
               volumeMounts:
-                - name: shared-model-cache
+                - name: model-cache
                   mountPath: /models
           volumes:
-            - name: shared-model-cache
+            - name: model-cache
               persistentVolumeClaim:
-                claimName: shared-model-cache
+                claimName: model-cache
 
     - name: VllmDecodeWorker
       type: decode
@@ -258,9 +258,9 @@ spec:
                   nvidia.com/gpu: "4"
                   rdma/ib: "4"
               volumeMounts:
-                - name: shared-model-cache
+                - name: model-cache
                   mountPath: /models
           volumes:
-            - name: shared-model-cache
+            - name: model-cache
               persistentVolumeClaim:
-                claimName: shared-model-cache
+                claimName: model-cache

--- a/recipes/a.x-k2/vllm/disagg-b200/deploy.yaml
+++ b/recipes/a.x-k2/vllm/disagg-b200/deploy.yaml
@@ -105,6 +105,8 @@ spec:
                   value: /models/runtime-cache/axk2-nvfp4/flashinfer
                 - name: VLLM_USE_FLASHINFER_MOE_FP4
                   value: "1"
+                - name: VLLM_OMNI_USE_QUACK_FP8
+                  value: "0"
                 - name: FLASHINFER_DISABLE_VERSION_CHECK
                   value: "1"
                 - name: VLLM_SKIP_P2P_CHECK
@@ -215,6 +217,8 @@ spec:
                   value: /models/runtime-cache/axk2-nvfp4/flashinfer
                 - name: VLLM_USE_FLASHINFER_MOE_FP4
                   value: "1"
+                - name: VLLM_OMNI_USE_QUACK_FP8
+                  value: "0"
                 - name: FLASHINFER_DISABLE_VERSION_CHECK
                   value: "1"
                 - name: VLLM_SKIP_P2P_CHECK

--- a/recipes/a.x-k2/vllm/disagg-b200/deploy.yaml
+++ b/recipes/a.x-k2/vllm/disagg-b200/deploy.yaml
@@ -19,6 +19,7 @@ spec:
               imagePullPolicy: IfNotPresent
               command:
                 - python3
+              args:
                 - -m
                 - dynamo.frontend
                 - --router-mode

--- a/recipes/a.x-k2/vllm/disagg-b200/deploy.yaml
+++ b/recipes/a.x-k2/vllm/disagg-b200/deploy.yaml
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: axk2-vllm-disagg-b200
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              image: your-registry.example.com/dynamo/vllm-runtime:axk2-v0.23.0
+              imagePullPolicy: IfNotPresent
+              command:
+                - python3
+                - -m
+                - dynamo.frontend
+                - --router-mode
+                - kv
+                - --router-kv-events
+                - --kv-cache-block-size
+                - "64"
+              env:
+                - name: HF_HOME
+                  value: /models
+                - name: HF_HUB_OFFLINE
+                  value: "1"
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /models
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+
+    - name: VllmPrefillWorker
+      type: prefill
+      replicas: 1
+      sharedMemorySize: 200Gi
+      podTemplate:
+        spec:
+          runtimeClassName: nvidia
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-B200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
+          containers:
+            - name: main
+              image: your-registry.example.com/dynamo/vllm-runtime:axk2-v0.23.0
+              imagePullPolicy: IfNotPresent
+              workingDir: /workspace
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  mkdir -p "${VLLM_CACHE_ROOT}" "${TRITON_CACHE_DIR}" "${FLASHINFER_WORKSPACE_BASE}"
+                  ulimit -l unlimited
+                  ulimit -n 1048576
+                  exec python3 -m dynamo.vllm \
+                    --model skt/A.X-K2-NVFP4 \
+                    --served-model-name A.X-K2-NVFP4 \
+                    --tensor-parallel-size 4 \
+                    --enable-expert-parallel \
+                    --attention-backend FLASHINFER_MLA_SPARSE \
+                    --max-model-len 262144 \
+                    --max-num-seqs 16 \
+                    --max-num-batched-tokens 32768 \
+                    --gpu-memory-utilization 0.92 \
+                    --kv-cache-dtype fp8 \
+                    --block-size 64 \
+                    --enable-prefix-caching \
+                    --dyn-tool-call-parser hermes \
+                    --dyn-reasoning-parser deepseek_v3 \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cuda"}' \
+                    --disaggregation-mode prefill \
+                    --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5571","enable_kv_cache_events":true}'
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              env:
+                - name: HF_HOME
+                  value: /models
+                - name: HF_HUB_CACHE
+                  value: /models/hub
+                - name: HF_HUB_OFFLINE
+                  value: "1"
+                - name: TRANSFORMERS_OFFLINE
+                  value: "1"
+                - name: VLLM_CACHE_ROOT
+                  value: /models/runtime-cache/axk2-nvfp4/vllm
+                - name: TRITON_CACHE_DIR
+                  value: /models/runtime-cache/axk2-nvfp4/triton
+                - name: FLASHINFER_WORKSPACE_BASE
+                  value: /models/runtime-cache/axk2-nvfp4/flashinfer
+                - name: VLLM_USE_FLASHINFER_MOE_FP4
+                  value: "1"
+                - name: FLASHINFER_DISABLE_VERSION_CHECK
+                  value: "1"
+                - name: VLLM_SKIP_P2P_CHECK
+                  value: "1"
+                - name: NCCL_CUMEM_ENABLE
+                  value: "1"
+                - name: NCCL_IB_DISABLE
+                  value: "0"
+                - name: UCX_TLS
+                  value: rc_x,rc,cuda_copy,cuda_ipc
+                - name: UCX_IB_ADDR_TYPE
+                  value: eth
+                - name: UCX_RNDV_SCHEME
+                  value: get_zcopy
+                - name: UCX_RNDV_THRESH
+                  value: "0"
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+                failureThreshold: 90
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_RESOURCE
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  rdma/ib: "4"
+                  memory: 400Gi
+                limits:
+                  nvidia.com/gpu: "4"
+                  rdma/ib: "4"
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /models
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+
+    - name: VllmDecodeWorker
+      type: decode
+      replicas: 1
+      sharedMemorySize: 200Gi
+      podTemplate:
+        spec:
+          runtimeClassName: nvidia
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-B200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
+          containers:
+            - name: main
+              image: your-registry.example.com/dynamo/vllm-runtime:axk2-v0.23.0
+              imagePullPolicy: IfNotPresent
+              workingDir: /workspace
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  mkdir -p "${VLLM_CACHE_ROOT}" "${TRITON_CACHE_DIR}" "${FLASHINFER_WORKSPACE_BASE}"
+                  ulimit -l unlimited
+                  ulimit -n 1048576
+                  exec python3 -m dynamo.vllm \
+                    --model skt/A.X-K2-NVFP4 \
+                    --served-model-name A.X-K2-NVFP4 \
+                    --tensor-parallel-size 4 \
+                    --enable-expert-parallel \
+                    --attention-backend FLASHINFER_MLA_SPARSE \
+                    --max-model-len 262144 \
+                    --max-num-seqs 64 \
+                    --max-num-batched-tokens 16384 \
+                    --gpu-memory-utilization 0.92 \
+                    --kv-cache-dtype fp8 \
+                    --block-size 64 \
+                    --enable-prefix-caching \
+                    --dyn-tool-call-parser hermes \
+                    --dyn-reasoning-parser deepseek_v3 \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cuda","kv_connector_extra_config":{"num_threads":8}}' \
+                    --disaggregation-mode decode
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              env:
+                - name: HF_HOME
+                  value: /models
+                - name: HF_HUB_CACHE
+                  value: /models/hub
+                - name: HF_HUB_OFFLINE
+                  value: "1"
+                - name: TRANSFORMERS_OFFLINE
+                  value: "1"
+                - name: VLLM_CACHE_ROOT
+                  value: /models/runtime-cache/axk2-nvfp4/vllm
+                - name: TRITON_CACHE_DIR
+                  value: /models/runtime-cache/axk2-nvfp4/triton
+                - name: FLASHINFER_WORKSPACE_BASE
+                  value: /models/runtime-cache/axk2-nvfp4/flashinfer
+                - name: VLLM_USE_FLASHINFER_MOE_FP4
+                  value: "1"
+                - name: FLASHINFER_DISABLE_VERSION_CHECK
+                  value: "1"
+                - name: VLLM_SKIP_P2P_CHECK
+                  value: "1"
+                - name: NCCL_CUMEM_ENABLE
+                  value: "1"
+                - name: NCCL_IB_DISABLE
+                  value: "0"
+                - name: UCX_TLS
+                  value: rc_x,rc,cuda_copy,cuda_ipc
+                - name: UCX_IB_ADDR_TYPE
+                  value: eth
+                - name: UCX_RNDV_SCHEME
+                  value: get_zcopy
+                - name: UCX_RNDV_THRESH
+                  value: "0"
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+                failureThreshold: 90
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_RESOURCE
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  rdma/ib: "4"
+                  memory: 400Gi
+                limits:
+                  nvidia.com/gpu: "4"
+                  rdma/ib: "4"
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /models
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache


### PR DESCRIPTION

  ## Overview:

  ### Summary

  Add experimental NVIDIA Dynamo recipes for serving
  [skt/A.X-K2-NVFP4](https://huggingface.co/skt/A.X-K2-NVFP4) with vLLM on NVIDIA B200 GPUs.

  The recipes provide aggregated and disaggregated deployments using a custom
  runtime image that overlays the A.X K2 vLLM fork onto the Dynamo vLLM runtime.

  ## Details:

  - Add a 750 GiB shared model-cache PVC and model download job.
  - Add an aggregated B200 deployment with:
    - 4 GPUs
    - Tensor Parallelism (TP) 4
    - Expert Parallelism (EP)
    - FlashInfer sparse MLA attention
    - FP8 KV cache
  - Add a disaggregated B200 deployment with:
    - One 4-GPU prefill worker
    - One 4-GPU decode worker
    - NIXL KV-cache transfer over UCX/RDMA
    - KV-aware routing
  - Add a custom vLLM runtime Dockerfile based on the Dynamo vLLM runtime.
  - Overlay the A.X K2 vLLM fork while preserving the base image's compiled CUDA extensions and Dynamo
  integration.
  - Disable Quack FP8 for A.X K2 to avoid a TorchDynamo graph-tracing failure and use the FlashInfer FP8
  fallback.
  - Separate frontend `command` and `args` to match Dynamo operator injection behavior.
  - Avoid importing AMD64 CUDA libraries during cross-platform container builds.
  - Add build, deployment, and verification documentation.
  - Register the recipe in `recipes/README.md`.

  ### Validation

  - Parsed the aggregated and disaggregated manifests as YAML.
  - Passed Kubernetes server-side dry-run validation.
  - Deployed the aggregated recipe on 4 NVIDIA B200 GPUs.
  - Verified the aggregated frontend and worker became Ready with zero restarts.
  - Received HTTP 200 from `/v1/chat/completions` using `A.X-K2-NVFP4`.
  - Deployed the disaggregated recipe on 8 NVIDIA B200 GPUs.
  - Verified the frontend, prefill worker, and decode worker became Ready with zero restarts.
  - Received HTTP 200 from the disaggregated `/v1/chat/completions` endpoint.
  - Confirmed NIXL compatibility across all four tensor-parallel ranks.
  - Confirmed four successful KV transfers from prefill to decode.
  - Ran `git diff --check`.

  ## Where should the reviewer start?

  1. `recipes/a.x-k2/README.md` for the supported topology, prerequisites, and deployment flow.
  2. `recipes/a.x-k2/container/Dockerfile.axk2.vllm.b200` for the custom vLLM fork integration.
  3. `recipes/a.x-k2/vllm/agg-b200/deploy.yaml` for the aggregated configuration.
  4. `recipes/a.x-k2/vllm/disagg-b200/deploy.yaml` for the NIXL-based prefill/decode configuration.

  ## Related Issues

  **🚫 This PR is NOT linked to an issue**:

  - [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an experimental A.X K2 NVFP4 recipe for vLLM deployments on NVIDIA B200 GPUs.
  - Added aggregated and disaggregated deployment configurations, including model caching, GPU scheduling, health checks, and networking.
  - Added instructions for building the required runtime image, downloading the model, deploying, smoke testing, and validating the setup.

- **Documentation**
  - Documented supported capabilities, prerequisites, configuration options, and deployment workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->