### PR TITLE
fix(router): propagate trace context through worker dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,6 +2756,7 @@ dependencies = [
  "tonic-build 0.13.1",
  "tower-http",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
  "utoipa",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -2189,6 +2189,7 @@ dependencies = [
  "tonic-build 0.13.1",
  "tower-http",
  "tracing",
+ "tracing-opentelemetry",
  "url",
  "utoipa",
  "utoipa-swagger-ui",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2241,6 +2241,7 @@ dependencies = [
  "tonic-build 0.13.1",
  "tower-http",
  "tracing",
+ "tracing-opentelemetry",
  "url",
  "utoipa",
  "utoipa-swagger-ui",

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -118,6 +118,7 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { workspace = true }

--- a/lib/llm/src/kv_router/routing_host.rs
+++ b/lib/llm/src/kv_router/routing_host.rs
@@ -14,6 +14,10 @@ use dynamo_kv_router::{
 };
 use dynamo_runtime::{
     error::{DynamoError, ErrorType, match_error_chain},
+    logging::{
+        DistributedTraceContext, get_distributed_tracing_context,
+        otel_parent_context_from_distributed,
+    },
     metrics::frontend_perf::{STAGE_ROUTE, StageGuard},
     pipeline::{
         AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider, Error, ManyOut, PushRouter,
@@ -25,7 +29,8 @@ use dynamo_runtime::{
     protocols::annotated::Annotated,
 };
 use futures::stream::{self, StreamExt};
-use tracing::Instrument;
+use tracing::{Instrument, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::{
     kv_router::{
@@ -72,6 +77,47 @@ pub(crate) fn is_cancelled(error: &Error) -> bool {
 
 fn route_target(worker: WorkerWithDpRank) -> AffinityTarget {
     AffinityTarget::new(worker.worker_id, Some(worker.dp_rank))
+}
+
+fn route_request_span(
+    context_id: &str,
+    worker: &WorkerWithDpRank,
+    overlap_blocks: u32,
+    phase: &RequestPhase,
+    trace_context: Option<&DistributedTraceContext>,
+) -> Span {
+    let request_id = trace_context
+        .and_then(|context| context.request_id.as_deref())
+        .unwrap_or(context_id);
+    let span = tracing::info_span!(
+        target: "request_span",
+        "kv_router.route_request",
+        otel.kind = "client",
+        request_id = %request_id,
+        worker_id = tracing::field::Empty,
+        dp_rank = worker.dp_rank,
+        overlap_blocks,
+        phase = ?phase,
+        "request.attempt" = tracing::field::Empty,
+        "request.outcome" = tracing::field::Empty,
+        "migration.is_retry" = tracing::field::Empty,
+        "migration.reason" = tracing::field::Empty,
+        "migration.from_worker_id" = tracing::field::Empty,
+        "migration.tokens_completed" = tracing::field::Empty,
+        "cancellation.signal" = tracing::field::Empty,
+        "error.type" = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+        otel.status_description = tracing::field::Empty,
+        trace_id = trace_context.map(|context| context.trace_id.as_str()),
+        parent_id = trace_context.map(|context| context.span_id.as_str()),
+        trace_flags = trace_context.map(|context| context.trace_flags.as_str()),
+        tracestate = trace_context.and_then(|context| context.tracestate.as_deref()),
+        x_request_id = trace_context.and_then(|context| context.x_request_id.as_deref()),
+    );
+    if let Some(parent) = trace_context.and_then(otel_parent_context_from_distributed) {
+        let _ = span.set_parent(parent);
+    }
+    span
 }
 
 fn monitor_response_stream<Sel>(

--- a/lib/llm/src/kv_router/routing_host/kv.rs
+++ b/lib/llm/src/kv_router/routing_host/kv.rs
@@ -396,6 +396,7 @@ where
     ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
         let context_id = request.context().id().to_string();
         let request_context = request.context().clone();
+        let trace_context = get_distributed_tracing_context();
         let route_trace_context = get_route_trace_context(&request);
         let phase = request
             .tracker
@@ -431,25 +432,12 @@ where
         let dispatch = self
             .inner
             .dispatch_kv_admitted(updated_request, selection.worker.worker_id);
-        let route_span = tracing::info_span!(
-            target: "request_span",
-            "kv_router.route_request",
-            otel.kind = "client",
-            request_id = %context_id,
-            worker_id = tracing::field::Empty,
-            dp_rank = selection.worker.dp_rank,
-            overlap_blocks = selection.overlap_amount,
-            phase = ?phase,
-            "request.attempt" = tracing::field::Empty,
-            "request.outcome" = tracing::field::Empty,
-            "migration.is_retry" = tracing::field::Empty,
-            "migration.reason" = tracing::field::Empty,
-            "migration.from_worker_id" = tracing::field::Empty,
-            "migration.tokens_completed" = tracing::field::Empty,
-            "cancellation.signal" = tracing::field::Empty,
-            "error.type" = tracing::field::Empty,
-            otel.status_code = tracing::field::Empty,
-            otel.status_description = tracing::field::Empty,
+        let route_span = route_request_span(
+            &context_id,
+            &selection.worker,
+            selection.overlap_amount,
+            &phase,
+            trace_context.as_ref(),
         );
         record_route_span_start(
             &route_span,

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -20,6 +20,10 @@ use dynamo_runtime::{
     discovery::EventTransportKind,
     distributed::{DiscoveryBackend, DistributedConfig, RequestPlaneMode},
     error::{BackendError, ErrorType, match_error_chain},
+    logging::{
+        DistributedTraceIdLayer, inject_trace_headers_into_map,
+        make_handle_payload_span_from_tcp_headers,
+    },
     pipeline::{
         AddressedRequest, AsyncEngineContext, Context, ManyIn, Operator, PushRouter, RouterMode,
         ServerStreamingEngine, StreamingDispatch, context::Controller,
@@ -28,6 +32,7 @@ use dynamo_runtime::{
     traits::DistributedRuntimeProvider,
 };
 use tokio::sync::watch;
+use tracing_subscriber::layer::SubscriberExt;
 
 use super::*;
 use crate::{
@@ -92,6 +97,72 @@ fn selector_state_remains_owned_by_the_scheduler_actor() {
     fn assert_send_sync<T: Send + Sync>() {}
 
     assert_send_sync::<RoutingHost<WorkerSelectionPolicy>>();
+}
+
+#[test]
+fn route_request_span_propagates_distributed_trace_context() {
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
+
+    const TRACE_ID: &str = "11111111111111111111111111111111";
+    const PARENT_SPAN_ID: &str = "2222222222222222";
+    const REQUEST_ID: &str = "33333333-3333-4333-8333-333333333333";
+
+    let provider = SdkTracerProvider::builder()
+        .with_sampler(Sampler::ParentBased(Box::new(Sampler::AlwaysOn)))
+        .build();
+    let tracer = provider.tracer("kv-router-test");
+    let subscriber = tracing_subscriber::registry()
+        .with(tracing_opentelemetry::layer().with_tracer(tracer))
+        .with(DistributedTraceIdLayer);
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let mut inbound_headers = HashMap::from([
+        (
+            "traceparent".to_string(),
+            format!("00-{TRACE_ID}-{PARENT_SPAN_ID}-00"),
+        ),
+        ("tracestate".to_string(), "vendor=dynamo".to_string()),
+        ("x-request-id".to_string(), "external-1".to_string()),
+        ("request-id".to_string(), REQUEST_ID.to_string()),
+    ]);
+    let ingress_span = make_handle_payload_span_from_tcp_headers(
+        &inbound_headers,
+        "frontend",
+        "generate",
+        "test",
+        1,
+    );
+    let trace_context = ingress_span
+        .in_scope(get_distributed_tracing_context)
+        .expect("ingress span must expose its distributed trace context");
+    let worker = WorkerWithDpRank::new(7, 3);
+
+    let span = route_request_span(
+        "trace-propagation",
+        &worker,
+        2,
+        &RequestPhase::Aggregated,
+        Some(&trace_context),
+    );
+    assert_eq!(
+        span.metadata().map(|metadata| metadata.target()),
+        Some("request_span")
+    );
+
+    inbound_headers.clear();
+    span.in_scope(|| inject_trace_headers_into_map(&mut inbound_headers));
+    let traceparent = inbound_headers
+        .get("traceparent")
+        .expect("route span must provide an outbound trace context");
+    let fields = traceparent.split('-').collect::<Vec<_>>();
+
+    assert_eq!(fields.len(), 4);
+    assert_eq!(fields[1], TRACE_ID);
+    assert_ne!(fields[2], trace_context.span_id);
+    assert_eq!(fields[3], "00");
+    assert_eq!(inbound_headers["tracestate"], "vendor=dynamo");
+    assert_eq!(inbound_headers["x-request-id"], "external-1");
+    assert_eq!(inbound_headers["request-id"], REQUEST_ID);
 }
 
 #[test]


### PR DESCRIPTION
## Overview

Preserve the frontend OpenTelemetry trace when the KV push router dispatches a request to the selected worker.

## Summary

- make `kv_router.route_request` an always-on request-plane span
- explicitly parent the route span to the captured distributed OTel context
- preserve trace flags, tracestate, and Dynamo request identifiers across the dispatch boundary
- add a regression test that captures a real ingress context, leaves the ambient span, and verifies outbound propagation

## Details

The route span previously relied on the ambient tracing parent. That parent is not reliable across the KV-router dispatch boundary, so downstream request-plane header injection could start a separate trace.

The new helper records the complete distributed context on the route span and calls `set_parent` before instrumenting the `dispatch_kv_admitted` future. The test exercises the detached-parent case with an unsampled W3C context and checks `traceparent`, `tracestate`, `x-request-id`, and `request-id`.

## Where should the reviewer start?

Start with `lib/llm/src/kv_router/routing_host.rs` (`route_request_span`), then `lib/llm/src/kv_router/routing_host/kv.rs` (dispatch integration), and `lib/llm/src/kv_router/routing_host/tests.rs` (regression coverage).

## Contribution roles

I led the contribution direction and acceptance criteria, reviewed and approved
the final design, and reviewed every changed line. I understand the change and
own the final design decision and the submission. AI assistance was used for
repository research, root-cause analysis, implementation preparation, and
automated validation execution.

## Validation

Current revision: `afd927056504d359b00c3eaab115794c6dc23738`. Status checked on 2026-09-09:

- GitHub reports this PR as mergeable without conflicts. The branch is 1 commit ahead and 69 commits behind `main` at this check.
- The [current-head lightweight pre-merge matrix](https://github.com/ai-dynamo/dynamo/actions/runs/33713441263) completed successfully, including pre-commit, generated API references, all four Rust test jobs, all four Rust Clippy jobs, and the aggregate pre-merge status check.
- DCO, copyright, docs-link, codeowners, PR-title, and CodeRabbit checks are successful. No current check is failed or pending; unrelated jobs are skipped.
- The existing `route_request_span_propagates_distributed_trace_context` regression remains in this revision. It verifies injected outbound headers retain the inbound trace ID, generate a different child span ID, and preserve unsampled trace flags, tracestate, and request identifiers after leaving the ambient ingress span.
- Full NVIDIA runner validation still requires maintainer authorization for this revision: `/ok to test afd927056504d359b00c3eaab115794c6dc23738`. Lightweight CI success does not establish that the full NVIDIA suite has run.

### Real exporter acceptance — PASS (2026-09-10)

Validated unchanged head afd927056504d359b00c3eaab115794c6dc23738 on WSL2 Ubuntu 24.04. A real frontend with KV routing dispatched over TCP to an independent CPU Python sample worker. Actual SDK OTLP/gRPC exports were received by OpenTelemetry Collector 0.145.0 and persisted as raw OTLP JSONL.

- Two real HTTP requests returned 200. Both traces preserved their injected IDs through http-request → kv_router.route_request → handle_payload → engine.generate → sample.tokens, with correct parent/child relationships and no request-ID cross-trace mixing in these two requests.
- All 26 aggregate checks passed: 23 request/OTLP assertions plus regression/build-provenance checks. The existing unsampled injected-header library regression passed unchanged (1 passed, exit 0).
- The loaded Python extension hash matches the artifact built from this head; the source checkout is clean.
- Scope: CPU Python sample handoff. GPU/vendor backends, generic Python OTel contextvars, disaggregated serving, concurrency stress, and full NVIDIA CI were not validated.
- [Public acceptance summary and span-ID evidence](https://github.com/ai-dynamo/dynamo/pull/13713#issuecomment-5615473232). The complete evidence archive and reproduction scripts are retained locally, not uploaded.

### Before merge

Following the [2026-09-08 review](https://github.com/ai-dynamo/dynamo/pull/13713#issuecomment-5581509059):

- [x] Retain the injected-header regression in the current Rust change.
- [ ] Preserve that assertion when the Python-side handoff is integrated.
- [x] Validate the real frontend-to-router-to-worker trace with an actual exporter in the CPU Python sample topology. Two HTTP requests passed on the unchanged head; shared trace IDs, parent/child relationships, and the Python-created child span were verified. [Acceptance result and Collector span evidence](https://github.com/ai-dynamo/dynamo/pull/13713#issuecomment-5615473232). Full evidence archive remains local.
- [ ] Obtain required maintainer review and full NVIDIA runner validation.

## Related Issues

- Closes #13345
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced distributed request tracing for KV routing operations.
  - Trace context now carries across services, making request flows easier to follow.
  - Added richer routing metadata, including request, worker, and processing phase details.
  - Improved visibility into request propagation and outbound trace information for troubleshooting and performance analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

