### PR TITLE
feat(vllm): add audio and video sidecar inputs

### DIFF
--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -27,13 +27,11 @@ It is a standalone Rust executable.
 - Opaque `kv_transfer_params` handoff
 - Data-parallel rank routing and KV-event source discovery
 - Capability-gated RL pause/resume, sleep/wake, weight-transfer, and weight-version controls through native gRPC
-- Image URL and data-URI inputs, including media UUIDs
+- Image, video, and audio URL and data-URI inputs; cache UUIDs remain image-only
 
-The protocol does not support LoRA, encode workers, beam search, `n > 1`,
-preprocessed multimodal features, audio/video media, or Dynamo tool-call and
-reasoning parsers. Parser defaults returned by Control are intentionally not
-advertised to the Dynamo frontend because the current inference protocol does
-not preserve all parser-related request semantics.
+Audio and video inputs require `connorcarpenter15/vllm:main` at commit [`9e97605e4eb0add37c7a7002ffd3d52baf381385`](https://github.com/connorcarpenter15/vllm/commit/9e97605e4eb0add37c7a7002ffd3d52baf381385). Stock vLLM releases continue to return gRPC `UNIMPLEMENTED` for these modalities.
+
+The protocol does not support LoRA, encode workers, beam search, `n > 1`, or Dynamo tool-call and reasoning parsers. The sidecar does not support `input_audio`, `file://` media, `use_audio_in_video` or other `mm_processor_kwargs`, preprocessed multimodal features, decoded RDMA media, UUID-only media, audio/video cache UUIDs, or EPD. Direct vLLM gRPC callers can send raw media bytes, but Dynamo's current `MultimodalData` representation cannot. Parser defaults returned by Control are intentionally not advertised to the Dynamo frontend because the current inference protocol does not preserve all parser-related request semantics.
 
 ## Run
 

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -29,7 +29,7 @@ It is a standalone Rust executable.
 - Capability-gated RL pause/resume, sleep/wake, weight-transfer, and weight-version controls through native gRPC
 - Image, video, and audio URL and data-URI inputs; cache UUIDs remain image-only
 
-Audio and video inputs require `connorcarpenter15/vllm:main` at commit [`300be949c23cd4e32c110cad8943bb7394efe132`](https://github.com/connorcarpenter15/vllm/commit/300be949c23cd4e32c110cad8943bb7394efe132). Stock vLLM releases continue to return gRPC `UNIMPLEMENTED` for these modalities.
+Audio and video inputs currently require the `connorcarpenter15/vllm:feat/grpc-audio-video-combined` review branch at commit [`236caaec7221842c307e87e05ea3356539be6b20`](https://github.com/connorcarpenter15/vllm/commit/236caaec7221842c307e87e05ea3356539be6b20), tracked by [connorcarpenter15/vllm#32](https://github.com/connorcarpenter15/vllm/pull/32). The fork's current `main` and stock vLLM releases do not contain this support while that PR remains open.
 
 The protocol does not support LoRA, encode workers, beam search, `n > 1`, or Dynamo tool-call and reasoning parsers. The sidecar does not support `input_audio`, `file://` media, `use_audio_in_video` or other `mm_processor_kwargs`, preprocessed multimodal features, decoded RDMA media, UUID-only media, audio/video cache UUIDs, or EPD. Direct vLLM gRPC callers can send raw media bytes, but Dynamo's current `MultimodalData` representation cannot. Parser defaults returned by Control are intentionally not advertised to the Dynamo frontend because the current inference protocol does not preserve all parser-related request semantics.
 

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -29,9 +29,13 @@ It is a standalone Rust executable.
 - Capability-gated RL pause/resume, sleep/wake, weight-transfer, and weight-version controls through native gRPC
 - Image, video, and audio URL and data-URI inputs; cache UUIDs remain image-only
 
-Audio and video inputs require `connorcarpenter15/vllm:main` at commit [`9e97605e4eb0add37c7a7002ffd3d52baf381385`](https://github.com/connorcarpenter15/vllm/commit/9e97605e4eb0add37c7a7002ffd3d52baf381385). Stock vLLM releases continue to return gRPC `UNIMPLEMENTED` for these modalities.
+Audio and video inputs require `connorcarpenter15/vllm:main` at commit [`300be949c23cd4e32c110cad8943bb7394efe132`](https://github.com/connorcarpenter15/vllm/commit/300be949c23cd4e32c110cad8943bb7394efe132). Stock vLLM releases continue to return gRPC `UNIMPLEMENTED` for these modalities.
 
 The protocol does not support LoRA, encode workers, beam search, `n > 1`, or Dynamo tool-call and reasoning parsers. The sidecar does not support `input_audio`, `file://` media, `use_audio_in_video` or other `mm_processor_kwargs`, preprocessed multimodal features, decoded RDMA media, UUID-only media, audio/video cache UUIDs, or EPD. Direct vLLM gRPC callers can send raw media bytes, but Dynamo's current `MultimodalData` representation cannot. Parser defaults returned by Control are intentionally not advertised to the Dynamo frontend because the current inference protocol does not preserve all parser-related request semantics.
+
+In prefill/decode deployments, both engines independently prepare the original media. Reusing only the prefill-expanded prompt IDs is insufficient because KV transfer does not carry model-specific multimodal position metadata.
+
+The official `Qwen/Qwen3-ASR-1.7B` repository currently needs Rust-frontend-compatible tokenizer and config metadata (`tokenizer.json` and a top-level `vocab_size`). Dynamo's Rust chat renderer also does not yet insert the model-native audio placeholder for `audio_url` content parts; callers can supply those prompt token IDs through `nvext.token_data`. These are model-loading and request-rendering gaps rather than sidecar media-transport limitations.
 
 ## Run
 

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -11,7 +11,6 @@ use crate::json::{json_to_struct, struct_to_json};
 use crate::proto as pb;
 
 const VLLM_LOGPROB_FLOOR: f64 = -9999.0;
-const MULTIMODAL_PROMPT_TOKEN_IDS_KEY: &str = "_dynamo_sidecar_multimodal_prompt_token_ids";
 const MM_HASHES_KEY: &str = "mm_hashes";
 const IMAGE_URL_KEY: &str = "image_url";
 const VIDEO_URL_KEY: &str = "video_url";
@@ -36,22 +35,16 @@ pub(crate) fn build_generate_request(
         .as_ref()
         .and_then(|media| media.get(IMAGE_URL_KEY))
         .is_some_and(|items| !items.is_empty());
-    // Decode reuses the prefill-expanded tokens without reprocessing media.
-    let forwarded_image_uuids = if has_images && !mode.is_decode() {
+    // Each engine must prepare multimodal inputs independently so model-specific
+    // position metadata matches the transferred KV state.
+    let forwarded_image_uuids = if has_images {
         forwarded_image_uuids(&request)?
     } else {
         None
     };
-    let media = if mode.is_decode() {
-        Vec::new()
-    } else {
-        build_media(&request, forwarded_image_uuids.as_deref())?
-    };
-    let mut prefill_result = request.prefill_result;
-    let mut token_ids = request.token_ids;
-    if mode.is_decode() && has_media {
-        token_ids = take_multimodal_prompt_token_ids(&mut prefill_result)?;
-    }
+    let media = build_media(&request, forwarded_image_uuids.as_deref())?;
+    let prefill_result = request.prefill_result;
+    let token_ids = request.token_ids;
     let prompt_logprobs = request.output_options.prompt_logprobs;
     let output_logprobs = request.output_options.logprobs;
     let max_new_tokens = if mode.is_prefill() {
@@ -119,7 +112,7 @@ pub(crate) fn build_generate_request(
             ignore_eos: stop_conditions.ignore_eos.unwrap_or(false),
         }),
         response: Some(pb::ResponseOptions {
-            prompt_token_ids: prompt_logprobs.is_some() || (has_media && mode.is_prefill()),
+            prompt_token_ids: prompt_logprobs.is_some(),
             prompt_logprobs: prompt_logprobs.is_some(),
             prompt_candidates: prompt_logprobs.map(top_n_candidates).transpose()?,
             output_text: Some(true),
@@ -195,34 +188,6 @@ fn consume_redundant_nvext(
         extra.remove("nvext");
     }
     Ok(())
-}
-
-fn take_multimodal_prompt_token_ids(
-    prefill_result: &mut Option<PrefillResult>,
-) -> Result<Vec<u32>, DynamoError> {
-    let params = &mut prefill_result
-        .as_mut()
-        .ok_or_else(|| {
-            client::invalid_argument("multimodal decode request is missing the prefill result")
-        })?
-        .disaggregated_params;
-    let value = params
-        .as_object_mut()
-        .and_then(|params| params.remove(MULTIMODAL_PROMPT_TOKEN_IDS_KEY))
-        .ok_or_else(|| {
-            client::invalid_argument(
-                "multimodal decode request is missing expanded prefill token IDs",
-            )
-        })?;
-    let token_ids: Vec<u32> = serde_json::from_value(value).map_err(|error| {
-        client::invalid_argument(format!("multimodal prefill token IDs are invalid: {error}"))
-    })?;
-    if token_ids.is_empty() {
-        return Err(client::invalid_argument(
-            "multimodal prefill token IDs must not be empty",
-        ));
-    }
-    Ok(token_ids)
 }
 
 fn media_source(modality: &str, source: &str) -> Result<pb::media_item::Source, DynamoError> {
@@ -672,7 +637,6 @@ fn validate_request(
 pub(crate) struct ResponseState {
     prompt_tokens: u32,
     has_media: bool,
-    multimodal_prompt_token_ids: Option<Vec<u32>>,
     completion_tokens: u32,
     is_prefill: bool,
     output_logprobs: Option<u32>,
@@ -688,7 +652,6 @@ impl ResponseState {
                 .multi_modal_data
                 .as_ref()
                 .is_some_and(|media| media.values().any(|items| !items.is_empty())),
-            multimodal_prompt_token_ids: None,
             completion_tokens: 0,
             is_prefill: mode.is_prefill(),
             output_logprobs: request.output_options.logprobs,
@@ -811,28 +774,6 @@ impl ResponseState {
                 "prefill terminal is missing kv_transfer_params",
             ));
         }
-        if self.is_prefill && self.has_media {
-            let token_ids = self.multimodal_prompt_token_ids.take().ok_or_else(|| {
-                client::protocol_error(
-                    "multimodal prefill did not return expanded prompt token IDs",
-                )
-            })?;
-            let params = mapped
-                .disaggregated_params
-                .as_mut()
-                .and_then(serde_json::Value::as_object_mut)
-                .ok_or_else(|| {
-                    client::protocol_error("prefill kv_transfer_params is not a JSON object")
-                })?;
-            params.insert(
-                MULTIMODAL_PROMPT_TOKEN_IDS_KEY.to_string(),
-                serde_json::to_value(token_ids).map_err(|error| {
-                    client::protocol_error(format!(
-                        "failed to encode multimodal prefill token IDs: {error}"
-                    ))
-                })?,
-            );
-        }
         self.attach_prompt_data(&mut mapped);
         Ok(Some(mapped))
     }
@@ -853,16 +794,6 @@ impl ResponseState {
             }
             // vLLM's count includes expanded media tokens.
             self.prompt_tokens = prompt.num_prompt_tokens;
-        }
-        if self.is_prefill && self.has_media {
-            if prompt.token_ids.len() != prompt.num_prompt_tokens as usize {
-                return Err(client::protocol_error(format!(
-                    "multimodal prefill returned {} prompt token IDs for {} prompt tokens",
-                    prompt.token_ids.len(),
-                    prompt.num_prompt_tokens
-                )));
-            }
-            self.multimodal_prompt_token_ids = Some(prompt.token_ids.clone());
         }
         if !self.expect_prompt_logprobs {
             return Ok(());

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -13,6 +13,9 @@ use crate::proto as pb;
 const VLLM_LOGPROB_FLOOR: f64 = -9999.0;
 const MULTIMODAL_PROMPT_TOKEN_IDS_KEY: &str = "_dynamo_sidecar_multimodal_prompt_token_ids";
 const MM_HASHES_KEY: &str = "mm_hashes";
+const IMAGE_URL_KEY: &str = "image_url";
+const VIDEO_URL_KEY: &str = "video_url";
+const AUDIO_URL_KEY: &str = "audio_url";
 // Must match DYNAMO_CACHE_SALT_PREFIX in lib/kv-router/src/zmq_wire/extra_keys.rs.
 const DYNAMO_CACHE_SALT_PREFIX: &str = "dynamo-cache-salt:";
 
@@ -22,21 +25,27 @@ pub(crate) fn build_generate_request(
     mode: DisaggregationMode,
 ) -> Result<pb::GenerateRequest, DynamoError> {
     validate_request(&request, mode)?;
+    validate_multimodal_cache_uuids(&request)?;
 
     let has_media = request
         .multi_modal_data
         .as_ref()
         .is_some_and(|media| media.values().any(|items| !items.is_empty()));
+    let has_images = request
+        .multi_modal_data
+        .as_ref()
+        .and_then(|media| media.get(IMAGE_URL_KEY))
+        .is_some_and(|items| !items.is_empty());
     // Decode reuses the prefill-expanded tokens without reprocessing media.
-    let forwarded_mm_uuids = if has_media && !mode.is_decode() {
-        forwarded_mm_uuids(&request)?
+    let forwarded_image_uuids = if has_images && !mode.is_decode() {
+        forwarded_image_uuids(&request)?
     } else {
         None
     };
     let media = if mode.is_decode() {
         Vec::new()
     } else {
-        build_media(&request, forwarded_mm_uuids.as_deref())?
+        build_media(&request, forwarded_image_uuids.as_deref())?
     };
     let mut prefill_result = request.prefill_result;
     let mut token_ids = request.token_ids;
@@ -216,26 +225,46 @@ fn take_multimodal_prompt_token_ids(
     Ok(token_ids)
 }
 
-fn media_source(source: &str) -> Result<pb::media_item::Source, DynamoError> {
+fn media_source(modality: &str, source: &str) -> Result<pb::media_item::Source, DynamoError> {
     if source.starts_with("data:") {
         Ok(pb::media_item::Source::DataUri(source.to_string()))
     } else if source.starts_with("http://") || source.starts_with("https://") {
         Ok(pb::media_item::Source::Url(source.to_string()))
     } else {
-        Err(client::invalid_argument(
-            "vLLM gRPC image input must use an http://, https://, or data: URI",
-        ))
+        Err(client::invalid_argument(format!(
+            "vLLM gRPC {modality} input must use an http://, https://, or data: URI"
+        )))
     }
 }
 
-fn forwarded_mm_uuids(request: &PreprocessedRequest) -> Result<Option<Vec<String>>, DynamoError> {
+fn validate_multimodal_cache_uuids(request: &PreprocessedRequest) -> Result<(), DynamoError> {
+    let Some(uuids_by_modality) = request.multi_modal_uuids.as_ref() else {
+        return Ok(());
+    };
+    for (modality, uuids) in uuids_by_modality {
+        if modality != IMAGE_URL_KEY
+            && uuids
+                .iter()
+                .any(|uuid| uuid.as_ref().is_some_and(|uuid| !uuid.is_empty()))
+        {
+            return Err(client::invalid_argument(format!(
+                "multimodal cache UUIDs are supported only for {IMAGE_URL_KEY}; got non-empty multi_modal_uuids.{modality}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn forwarded_image_uuids(
+    request: &PreprocessedRequest,
+) -> Result<Option<Vec<String>>, DynamoError> {
     let has_user_uuid = request
         .multi_modal_uuids
         .as_ref()
-        .is_some_and(|by_modality| {
-            by_modality
-                .values()
-                .flatten()
+        .and_then(|by_modality| by_modality.get(IMAGE_URL_KEY))
+        .is_some_and(|uuids| {
+            uuids
+                .iter()
                 .any(|uuid| uuid.as_ref().is_some_and(|uuid| !uuid.is_empty()))
         });
     if has_user_uuid {
@@ -299,11 +328,16 @@ fn build_media(
         if items.is_empty() {
             continue;
         }
-        if key != "image_url" {
-            return Err(client::invalid_argument(format!(
-                "vLLM gRPC currently supports image_url media only; got `{key}`"
-            )));
-        }
+        let modality = match key.as_str() {
+            IMAGE_URL_KEY => pb::Modality::Image,
+            VIDEO_URL_KEY => pb::Modality::Video,
+            AUDIO_URL_KEY => pb::Modality::Audio,
+            _ => {
+                return Err(client::invalid_argument(format!(
+                    "vLLM gRPC does not support media modality `{key}`"
+                )));
+            }
+        };
         let uuids = request
             .multi_modal_uuids
             .as_ref()
@@ -317,7 +351,8 @@ fn build_media(
                 items.len()
             )));
         }
-        if let Some(uuids) = forwarded_uuids
+        if modality == pb::Modality::Image
+            && let Some(uuids) = forwarded_uuids
             && uuids.len() != items.len()
         {
             return Err(client::invalid_argument(format!(
@@ -329,8 +364,8 @@ fn build_media(
 
         for (index, item) in items.iter().enumerate() {
             let source = match item {
-                MultimodalData::Url(url) => media_source(url.as_str())?,
-                MultimodalData::RawUrl(source) => media_source(source)?,
+                MultimodalData::Url(url) => media_source(key, url.as_str())?,
+                MultimodalData::RawUrl(source) => media_source(key, source)?,
                 MultimodalData::Decoded(_) => {
                     return Err(client::invalid_argument(
                         "vLLM sidecar cannot dereference pre-decoded RDMA media; configure URL passthrough",
@@ -342,13 +377,17 @@ fn build_media(
                     ));
                 }
             };
-            let uuid = uuids
-                .and_then(|uuids| uuids.get(index))
-                .and_then(Clone::clone)
-                .or_else(|| forwarded_uuids.and_then(|uuids| uuids.get(index)).cloned())
-                .unwrap_or_default();
+            let uuid = if modality == pb::Modality::Image {
+                uuids
+                    .and_then(|uuids| uuids.get(index))
+                    .and_then(Clone::clone)
+                    .or_else(|| forwarded_uuids.and_then(|uuids| uuids.get(index)).cloned())
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            };
             media.push(pb::MediaItem {
-                modality: pb::Modality::Image as i32,
+                modality: modality as i32,
                 source: Some(source),
                 mime_type: String::new(),
                 uuid,

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -1267,13 +1267,6 @@ async fn mixed_multimodal_media_is_forwarded_with_image_uuid_only() {
         .disaggregated_params
         .clone()
         .expect("multimodal handoff");
-    assert_eq!(
-        handoff["_dynamo_sidecar_multimodal_prompt_token_ids"]
-            .as_array()
-            .expect("expanded prompt token IDs")
-            .len(),
-        601
-    );
 
     let mut decode_request = multimodal_request;
     decode_request.prefill_result = Some(PrefillResult {
@@ -1294,31 +1287,21 @@ async fn mixed_multimodal_media_is_forwarded_with_image_uuid_only() {
     let prefill_wire = &requests[requests.len() - 2];
     let decode_wire = &requests[requests.len() - 1];
     assert_eq!(prefill_wire.media.len(), 3);
-    assert!(
-        prefill_wire
-            .response
-            .as_ref()
-            .expect("prefill response options")
-            .prompt_token_ids
-    );
-    assert!(decode_wire.media.is_empty());
+    assert_eq!(decode_wire.media.len(), 3);
     assert_eq!(
         decode_wire.prompt.as_ref(),
         Some(&pb::generate_request::Prompt::TokenIds(pb::TokenIds {
-            ids: (0..601).collect(),
+            ids: vec![11, 22, 33],
         }))
     );
-    let decode_kv = struct_to_json(
-        decode_wire
-            .kv
-            .as_ref()
-            .and_then(|kv| kv.kv_transfer_params.clone())
-            .expect("decode KV handoff"),
-    )
-    .expect("decode KV JSON");
-    assert!(
-        decode_kv["_dynamo_sidecar_multimodal_prompt_token_ids"].is_null(),
-        "sidecar metadata must not reach vLLM"
+    let decode_image = decode_wire
+        .media
+        .iter()
+        .find(|item| item.modality() == pb::Modality::Image)
+        .expect("decode image media");
+    assert_eq!(
+        decode_image.uuid,
+        "0123456789abcdef000000000000000000000000000000000000000000000000"
     );
 }
 

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -1161,7 +1161,7 @@ async fn sleep_status_remains_advertised_without_sleep_mode() {
 }
 
 #[tokio::test]
-async fn multimodal_image_is_forwarded_with_uuid() {
+async fn mixed_multimodal_media_is_forwarded_with_image_uuid_only() {
     let service = FakeVllm::default();
     let mut discovered = model_info();
     discovered.supports_multimodal = true;
@@ -1170,15 +1170,29 @@ async fn multimodal_image_is_forwarded_with_uuid() {
     let (aggregate, _) = engine_from_args(&server.endpoint).await;
     aggregate.start(0).await.expect("start");
 
-    let mut image_request = request();
-    image_request.multi_modal_data = Some(std::collections::HashMap::from([(
-        "image_url".to_string(),
-        vec![MultimodalData::RawUrl(
-            "data:image/png;base64,iVBORw0KGgo=".to_string(),
-        )],
-    )]));
-    image_request.output_options.prompt_logprobs = None;
-    image_request
+    let mut multimodal_request = request();
+    multimodal_request.multi_modal_data = Some(std::collections::HashMap::from([
+        (
+            "image_url".to_string(),
+            vec![MultimodalData::RawUrl(
+                "data:image/png;base64,iVBORw0KGgo=".to_string(),
+            )],
+        ),
+        (
+            "video_url".to_string(),
+            vec![MultimodalData::RawUrl(
+                "https://example.com/sample.mp4".to_string(),
+            )],
+        ),
+        (
+            "audio_url".to_string(),
+            vec![MultimodalData::RawUrl(
+                "data:audio/wav;base64,UklGRg==".to_string(),
+            )],
+        ),
+    ]));
+    multimodal_request.output_options.prompt_logprobs = None;
+    multimodal_request
         .extra_args
         .as_mut()
         .and_then(serde_json::Value::as_object_mut)
@@ -1192,7 +1206,7 @@ async fn multimodal_image_is_forwarded_with_uuid() {
             ("mm_hashes".to_string(), json!(["0123456789abcdef"])),
         ]);
 
-    let outputs = collect(&aggregate, image_request.clone()).await;
+    let outputs = collect(&aggregate, multimodal_request.clone()).await;
     assert_eq!(outputs[0].finish_reason, Some(FinishReason::Stop));
     assert_eq!(
         outputs[0]
@@ -1205,14 +1219,35 @@ async fn multimodal_image_is_forwarded_with_uuid() {
 
     let requests = server.service.requests.lock().await;
     let media = &requests.last().expect("recorded request").media;
-    assert_eq!(media.len(), 1);
-    assert_eq!(media[0].modality(), pb::Modality::Image);
+    assert_eq!(media.len(), 3);
+    let image = media
+        .iter()
+        .find(|item| item.modality() == pb::Modality::Image)
+        .expect("image media");
+    let video = media
+        .iter()
+        .find(|item| item.modality() == pb::Modality::Video)
+        .expect("video media");
+    let audio = media
+        .iter()
+        .find(|item| item.modality() == pb::Modality::Audio)
+        .expect("audio media");
     assert_eq!(
-        media[0].uuid,
+        image.uuid,
         "0123456789abcdef000000000000000000000000000000000000000000000000"
     );
+    assert!(video.uuid.is_empty());
+    assert!(audio.uuid.is_empty());
     assert!(matches!(
-        media[0].source.as_ref(),
+        image.source.as_ref(),
+        Some(pb::media_item::Source::DataUri(_))
+    ));
+    assert!(matches!(
+        video.source.as_ref(),
+        Some(pb::media_item::Source::Url(_))
+    ));
+    assert!(matches!(
+        audio.source.as_ref(),
         Some(pb::media_item::Source::DataUri(_))
     ));
     drop(requests);
@@ -1227,7 +1262,7 @@ async fn multimodal_image_is_forwarded_with_uuid() {
     prefill.start(1).await.expect("start prefill");
     decode.start(2).await.expect("start decode");
 
-    let prefill_outputs = collect(&prefill, image_request.clone()).await;
+    let prefill_outputs = collect(&prefill, multimodal_request.clone()).await;
     let handoff = prefill_outputs[0]
         .disaggregated_params
         .clone()
@@ -1240,7 +1275,7 @@ async fn multimodal_image_is_forwarded_with_uuid() {
         601
     );
 
-    let mut decode_request = image_request;
+    let mut decode_request = multimodal_request;
     decode_request.prefill_result = Some(PrefillResult {
         disaggregated_params: handoff,
         prompt_tokens_details: None,
@@ -1258,7 +1293,7 @@ async fn multimodal_image_is_forwarded_with_uuid() {
     let requests = server.service.requests.lock().await;
     let prefill_wire = &requests[requests.len() - 2];
     let decode_wire = &requests[requests.len() - 1];
-    assert_eq!(prefill_wire.media.len(), 1);
+    assert_eq!(prefill_wire.media.len(), 3);
     assert!(
         prefill_wire
             .response
@@ -1616,11 +1651,13 @@ async fn decode_cancellation_maps_premature_eof_to_cancelled() {
 #[tokio::test]
 async fn unsupported_features_fail_before_rpc_submission() {
     let server = FakeServer::start(FakeVllm::default()).await;
+    let mut discovered = model_info();
+    discovered.supports_multimodal = true;
     let engine = engine(
         &server.endpoint,
         DisaggregationMode::Aggregated,
         1,
-        model_info(),
+        discovered,
     );
     engine.start(0).await.expect("start");
 
@@ -1637,6 +1674,19 @@ async fn unsupported_features_fail_before_rpc_submission() {
     let mut multimodal = request();
     multimodal.mm_processor_kwargs = Some(json!({"use_audio_in_video": true}));
     requests.push(multimodal);
+
+    let mut audio_uuid = request();
+    audio_uuid.multi_modal_data = Some(std::collections::HashMap::from([(
+        "audio_url".to_string(),
+        vec![MultimodalData::RawUrl(
+            "https://example.com/sample.wav".to_string(),
+        )],
+    )]));
+    audio_uuid.multi_modal_uuids = Some(std::collections::HashMap::from([(
+        "audio_url".to_string(),
+        vec![Some("audio-cache-id".to_string())],
+    )]));
+    requests.push(audio_uuid);
 
     let mut lora_request = serde_json::to_value(request()).expect("serialize request");
     lora_request["routing"] = json!({"lora_name": "adapter"});


### PR DESCRIPTION
## Summary

- Forward `image_url`, `video_url`, and `audio_url` as the matching vLLM gRPC media modalities.
- Reuse HTTP(S)/data-URI validation across modalities while keeping raw bytes unavailable through Dynamo's current media representation.
- Keep user cache UUIDs and padded `extra_args.mm_hashes` image-only.
- In prefill/decode deployments, send the original media and prompt IDs to both engines so each can reconstruct model-specific multimodal positions around the transferred KV.
- Document the exact vLLM fork commit and current Qwen3-ASR frontend limitations.

Addresses DIS-2749.

## Scope

- No protobuf or manifest pin changes.
- Image cache UUID precedence is unchanged.
- Audio/video cache UUIDs are rejected before gRPC submission.
- `mm_processor_kwargs`, preprocessed features, decoded RDMA media, UUID-only media, `input_audio`, file URLs, `use_audio_in_video`, and EPD remain unsupported.
- #13360 changes multimodal KV routing; this PR keeps the existing image-only hash contract.
- #13533 adds a separate preprocessed-feature path; this PR changes only URL/data-URI media conversion.

## CPU validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p dynamo-vllm-sidecar` — 21 library tests and 1 executable integration test passed
- The fake gRPC regression covers mixed image/video/audio aggregate, prefill, and decode requests; it asserts that both P/D engines receive all media and only the image receives the padded `mm_hashes` UUID.
- The unsupported-feature regression covers non-image UUID rejection before gRPC submission.

## GPU validation

Environment: two A100 80 GB GPUs in the `vllm-dev` container, with Dynamo at this PR and the vLLM combined branch tree now published as `af50828043114793cd5344a43e62fbb0daa79c76`.

### Video aggregate

```bash
bash /scratch/run.sh agg video Qwen/Qwen3-VL-8B-Instruct video-agg-final
python /validate.py --model Qwen/Qwen3-VL-8B-Instruct --media-type video_url --media-url https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/sample_demo_1.mp4 --prompt "Describe this video." --output /scratch/video-agg-final-result.json
```

- HTTP 200; `finish_reason=length`
- Prompt usage: 10 text-only tokens, 2290 video tokens
- Non-empty completion: `A toddler wearing glasses sits on a bed, engrossed in a book...`

### Video prefill/decode

```bash
bash /scratch/run.sh disagg video Qwen/Qwen3-VL-8B-Instruct video-disagg-resend
python /validate.py --model Qwen/Qwen3-VL-8B-Instruct --media-type video_url --media-url https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/sample_demo_1.mp4 --prompt "Describe this video." --output /scratch/video-disagg-resend-result.json
```

- HTTP 200; `finish_reason=length`
- Prompt usage: 10 text-only tokens, 2290 video tokens
- Same non-empty toddler/book description
- Prefill and decode each logged `media_count=1`

### Audio aggregate

```bash
bash /scratch/run.sh agg audio /scratch/qwen3-asr-model audio-agg-token-data
python /tmp/validate-audio.py
```

- HTTP 200; `finish_reason=length`
- Prompt usage: 13 text-only tokens, 346 audio tokens
- Non-empty transcription: `And the 0-1 pitch on the way to Edgar Martinez. Swung on the line down the left field line for a base hit.`

### Audio prefill/decode

```bash
bash /scratch/run.sh disagg audio /scratch/qwen3-asr-model audio-disagg-placeholder-length
python /tmp/validate-audio.py
```

- HTTP 200; `finish_reason=length`
- Prompt usage: 13 text-only tokens, 346 audio tokens
- Same non-empty transcription
- Prefill and decode each logged `media_count=1`
- No gRPC `UNIMPLEMENTED` or media-preparation error in any successful run

The audio run used the official `winning_call.ogg` asset. Its validation-only model overlay was derived from the exact `Qwen/Qwen3-ASR-1.7B` snapshot and added `tokenizer.json` plus top-level `vocab_size` for the Rust frontend. The request supplied model-native audio placeholder IDs through `nvext.token_data` because Dynamo's Rust chat renderer currently omits `audio_url` content parts. The weights and audio were unchanged.

## AI assistance

AI assistance was used to investigate current main, implement the converter and tests, run CPU and GPU validation, and draft this PR.

