### PR TITLE
test(vllm): cover LLaVA encode worker initialization

### DIFF
--- a/components/src/dynamo/vllm/tests/multimodal_handlers/test_vllm_encode_worker_init.py
+++ b/components/src/dynamo/vllm/tests/multimodal_handlers/test_vllm_encode_worker_init.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for multimodal encode-worker initialization."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import dynamo.vllm.multimodal_handlers.encode_worker_handler as handler_module
+from dynamo.vllm.constants import EmbeddingTransferMode
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.multimodal,
+]
+
+
+@pytest.mark.asyncio
+async def test_init_accepts_vision_model_without_out_hidden_size(monkeypatch):
+    """A LLaVA-like vision model must not crash encode-worker initialization."""
+    vision_model = SimpleNamespace(config=SimpleNamespace(hidden_size=4096))
+    engine_args = SimpleNamespace(
+        model="llava-hf/llava-1.5-7b-hf",
+        enforce_eager=True,
+        trust_remote_code=False,
+    )
+    monkeypatch.setattr(
+        handler_module.AutoImageProcessor,
+        "from_pretrained",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(
+        handler_module, "load_vision_model", MagicMock(return_value=vision_model)
+    )
+    monkeypatch.setattr(
+        handler_module,
+        "get_encoder_components",
+        MagicMock(return_value=(MagicMock(), MagicMock())),
+    )
+    monkeypatch.setattr(handler_module, "ENABLE_ENCODER_CACHE", False)
+
+    assert not hasattr(vision_model, "out_hidden_size")
+
+    handler = handler_module.EncodeWorkerHandler(
+        engine_args, EmbeddingTransferMode.LOCAL
+    )
+    try:
+        assert handler.vision_model is vision_model
+    finally:
+        handler.cleanup()
+        await handler.send_complete_checker_task


### PR DESCRIPTION
## Overview

Adds the missing GPU-free regression test for [OPS-7091](https://linear.app/nvidia/issue/OPS-7091/unit-test-vllmllava-encoder-regression-coverage-for-nvbug-5935944) / NVBug 5935944.

The production fix already allows `EncodeWorkerHandler` to initialize when a LLaVA vision model lacks `out_hidden_size`. This PR pins that behavior at the constructor boundary so the original startup `AttributeError` cannot return unnoticed.

## Details

- Constructs the real `EncodeWorkerHandler` with a LLaVA-like vision model exposing only `config.hidden_size`.
- Mocks model loading, image-processor loading, and encoder-component extraction; no checkpoint download or GPU is required.
- Uses the real background-task lifecycle and awaits cleanup to avoid leaked-task or unawaited-coroutine warnings.
- Adds only the distinct historical regression case; it does not duplicate Qwen, unknown-dimension, or debug-log assertions.

## Where should the reviewer start?

`components/src/dynamo/vllm/tests/multimodal_handlers/test_vllm_encode_worker_init.py`

## Test Plan

- [x] `python -m py_compile components/src/dynamo/vllm/tests/multimodal_handlers/test_vllm_encode_worker_init.py`
- [x] `uvx pre-commit run --files components/src/dynamo/vllm/tests/multimodal_handlers/test_vllm_encode_worker_init.py`
- [ ] Linux vLLM CPU pytest in PR CI (the local macOS workspace has no supported vLLM/Dynamo runtime environment)

## Related Issues

- Linear: [OPS-7091](https://linear.app/nvidia/issue/OPS-7091/unit-test-vllmllava-encoder-regression-coverage-for-nvbug-5935944)
- Relates to NVBug 5935944

**This PR is NOT linked to a GitHub issue:**

- [x] Confirmed — no related GitHub issue
