### PR TITLE
test(router): allow slower vLLM worker registration

### DIFF
--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 from typing import Any, Dict, Optional
 
 import aiohttp
@@ -49,6 +50,26 @@ pytestmark = [
 ]
 SPEEDUP_RATIO = 10.0
 BLOCK_SIZE = 16
+
+# How long a single vLLM worker gets to appear in the endpoint's instance list after its
+# subprocess is spawned, in `VLLMProcess.launch_workers_with_indexer()`.
+#
+# 180s is the budget every *other* vLLM router e2e test in this suite already grants worker
+# registration: they reach it via `wait_for_frontend_ready` -> `poll_for_worker_instances`
+# with `frontend_timeout: int = 180` (tests/router/e2e_harness.py). The standalone-indexer
+# path was the outlier at 60s, which is what made `test_vllm_indexers_sync` flaky -- a
+# healthy but slow-starting worker (cold weight load, contended GPU) was declared dead
+# before it registered. Note that this file states three times below that vLLM startup
+# "can exceed 150s on contended CI runners", so a smaller ceiling would leave that
+# documented worst case still failing.
+#
+# Raising the ceiling does not slow a healthy run: the wait returns as soon as the worker
+# registers, so only the pathological tail moves. Two sequential registrations at the full
+# budget plus the ~130s of non-registration work still fit inside the test's existing
+# `@pytest.mark.timeout(690)`, which keeps a stall reported as the precise "worker N never
+# registered" error below rather than as an opaque pytest timeout.
+WORKER_REGISTRATION_TIMEOUT_S = 180.0
+WORKER_REGISTRATION_POLL_S = 0.5
 
 # Shared vLLM configuration for all tests
 # gpu_memory_utilization limits actual VRAM allocation (required for multi-worker on same GPU)
@@ -434,20 +455,57 @@ class VLLMProcess(ManagedEngineProcessMixin):
                 process.__enter__()
 
                 new_worker_id = None
-                for _ in range(120):
+                # Deadline wait rather than a fixed iteration count, and the budget is read
+                # from the module-level constant on every call so it can be overridden in
+                # process (e.g. monkeypatched down) without editing this call site.
+                started_at = time.monotonic()
+                deadline = started_at + WORKER_REGISTRATION_TIMEOUT_S
+                while True:
                     ids = set(client.instance_ids())
                     new = ids - known_ids
                     if new:
                         new_worker_id = new.pop()
                         known_ids.add(new_worker_id)
                         break
-                    await asyncio.sleep(0.5)
+                    if time.monotonic() >= deadline:
+                        break
+                    await asyncio.sleep(WORKER_REGISTRATION_POLL_S)
+
+                registration_s = time.monotonic() - started_at
 
                 if new_worker_id is None:
+                    # Report enough to triage the next CI occurrence from the failure text
+                    # alone. A worker still running at the deadline means the budget was
+                    # too small; a worker that already exited died during startup (CUDA
+                    # OOM, port collision, ...) and no budget would have saved it. The
+                    # diagnostic is guarded so it can never mask the timeout it describes.
+                    try:
+                        returncode = process.proc.poll() if process.proc else None
+                        if process.proc is None:
+                            liveness = "subprocess was never started"
+                        elif returncode is None:
+                            liveness = "subprocess still running"
+                        else:
+                            liveness = (
+                                f"subprocess already exited with code {returncode}"
+                            )
+                    except Exception as diag_exc:
+                        liveness = f"subprocess liveness unavailable ({diag_exc})"
                     raise RuntimeError(
                         f"Timed out waiting for vLLM worker {worker_idx} to register "
-                        f"(known_ids={known_ids})"
+                        f"(known_ids={known_ids}) after {registration_s:.1f}s of a "
+                        f"{WORKER_REGISTRATION_TIMEOUT_S:.0f}s budget; {liveness}; "
+                        f"worker log: {process.log_path}"
                     )
+
+                logger.info(
+                    "vLLM worker %s registered as instance %s after %.1fs "
+                    "(budget %.0fs)",
+                    worker_idx,
+                    new_worker_id,
+                    registration_s,
+                    WORKER_REGISTRATION_TIMEOUT_S,
+                )
 
                 zmq_endpoint = f"tcp://127.0.0.1:{self._kv_event_ports[worker_idx]}"
                 replay_endpoint = (

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -51,23 +51,6 @@ pytestmark = [
 SPEEDUP_RATIO = 10.0
 BLOCK_SIZE = 16
 
-# How long a single vLLM worker gets to appear in the endpoint's instance list after its
-# subprocess is spawned, in `VLLMProcess.launch_workers_with_indexer()`.
-#
-# 180s is the budget every *other* vLLM router e2e test in this suite already grants worker
-# registration: they reach it via `wait_for_frontend_ready` -> `poll_for_worker_instances`
-# with `frontend_timeout: int = 180` (tests/router/e2e_harness.py). The standalone-indexer
-# path was the outlier at 60s, which is what made `test_vllm_indexers_sync` flaky -- a
-# healthy but slow-starting worker (cold weight load, contended GPU) was declared dead
-# before it registered. Note that this file states three times below that vLLM startup
-# "can exceed 150s on contended CI runners", so a smaller ceiling would leave that
-# documented worst case still failing.
-#
-# Raising the ceiling does not slow a healthy run: the wait returns as soon as the worker
-# registers, so only the pathological tail moves. Two sequential registrations at the full
-# budget plus the ~130s of non-registration work still fit inside the test's existing
-# `@pytest.mark.timeout(690)`, which keeps a stall reported as the precise "worker N never
-# registered" error below rather than as an opaque pytest timeout.
 WORKER_REGISTRATION_TIMEOUT_S = 180.0
 WORKER_REGISTRATION_POLL_S = 0.5
 
@@ -455,9 +438,6 @@ class VLLMProcess(ManagedEngineProcessMixin):
                 process.__enter__()
 
                 new_worker_id = None
-                # Deadline wait rather than a fixed iteration count, and the budget is read
-                # from the module-level constant on every call so it can be overridden in
-                # process (e.g. monkeypatched down) without editing this call site.
                 started_at = time.monotonic()
                 deadline = started_at + WORKER_REGISTRATION_TIMEOUT_S
                 while True:
@@ -470,19 +450,11 @@ class VLLMProcess(ManagedEngineProcessMixin):
                     remaining = deadline - time.monotonic()
                     if remaining <= 0:
                         break
-                    # Short the final sleep so the last poll lands on the deadline instead
-                    # of one interval past it, keeping the wait inside the stated budget.
                     await asyncio.sleep(min(WORKER_REGISTRATION_POLL_S, remaining))
 
                 registration_s = time.monotonic() - started_at
 
                 if new_worker_id is None:
-                    # Report enough to triage the next CI occurrence from the failure text
-                    # alone. A worker still running at the deadline means the budget was
-                    # too small; a worker that already exited died during startup (CUDA
-                    # OOM, port collision, ...) and no budget would have saved it. The
-                    # diagnostic is guarded against the errors Popen.poll() can raise, so
-                    # it can never mask the timeout it describes.
                     try:
                         returncode = process.proc.poll() if process.proc else None
                         if process.proc is None:

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -467,9 +467,12 @@ class VLLMProcess(ManagedEngineProcessMixin):
                         new_worker_id = new.pop()
                         known_ids.add(new_worker_id)
                         break
-                    if time.monotonic() >= deadline:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
                         break
-                    await asyncio.sleep(WORKER_REGISTRATION_POLL_S)
+                    # Short the final sleep so the last poll lands on the deadline instead
+                    # of one interval past it, keeping the wait inside the stated budget.
+                    await asyncio.sleep(min(WORKER_REGISTRATION_POLL_S, remaining))
 
                 registration_s = time.monotonic() - started_at
 
@@ -478,7 +481,8 @@ class VLLMProcess(ManagedEngineProcessMixin):
                     # alone. A worker still running at the deadline means the budget was
                     # too small; a worker that already exited died during startup (CUDA
                     # OOM, port collision, ...) and no budget would have saved it. The
-                    # diagnostic is guarded so it can never mask the timeout it describes.
+                    # diagnostic is guarded against the errors Popen.poll() can raise, so
+                    # it can never mask the timeout it describes.
                     try:
                         returncode = process.proc.poll() if process.proc else None
                         if process.proc is None:
@@ -489,7 +493,7 @@ class VLLMProcess(ManagedEngineProcessMixin):
                             liveness = (
                                 f"subprocess already exited with code {returncode}"
                             )
-                    except Exception as diag_exc:
+                    except (OSError, ValueError) as diag_exc:
                         liveness = f"subprocess liveness unavailable ({diag_exc})"
                     raise RuntimeError(
                         f"Timed out waiting for vLLM worker {worker_idx} to register "

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -447,6 +447,12 @@ class VLLMProcess(ManagedEngineProcessMixin):
                         new_worker_id = new.pop()
                         known_ids.add(new_worker_id)
                         break
+                    # A dead worker never registers. Check liveness each poll so the
+                    # loop fails in one interval instead of waiting out the full
+                    # budget. Matches _check_port/_check_url/_check_func.
+                    process._check_process_alive(
+                        f"while waiting for vLLM worker {worker_idx} to register"
+                    )
                     remaining = deadline - time.monotonic()
                     if remaining <= 0:
                         break


### PR DESCRIPTION
## Summary

The vLLM indexer synchronization test allowed only 60 seconds for each worker to register. A healthy cold-cache worker was observed taking 79.6 seconds, so the test could fail before reaching the NATS interruption, ZMQ replay, peer recovery, and state-convergence checks it was meant to exercise.

Worker registration now has a 180-second deadline, matching the other vLLM router end-to-end tests. Polling still occurs every half second and returns as soon as the worker appears, so the larger limit affects only slow or failed startups.

A timeout now reports the elapsed time, configured budget, known worker IDs, subprocess state, exit code when available, and worker log path. Successful registration logs the worker ID and elapsed time. This changes the test harness only; runtime behavior is unchanged.

Related: [DYN-4092](https://linear.app/nvidia/issue/DYN-4092/fix-flaky-test-vllm-indexers-syncnats-tcp-60s-worker-registration)

## Validation

On an RTX 6000 Ada with the 2026-08-20 vLLM nightly runtime, the complete `test_vllm_indexers_sync[nats-tcp]` path passed 11 times. The cold-cache run registered its first worker in 79.6 seconds; ten repeated runs registered that worker in 54.1–55.6 seconds. All runs completed the synchronization and four-way state comparison.
