### PR TITLE
fix(sglang): use incremental gRPC streams

### DIFF
--- a/lib/mocker/servers/sglang/src/server.rs
+++ b/lib/mocker/servers/sglang/src/server.rs
@@ -263,19 +263,15 @@ impl pb::sglang_service_server::SglangService for SglangMockerService {
         });
         let stream = async_stream::try_stream! {
             let _permit = permit;
-            let mut output_tokens = Vec::with_capacity(prepared.max_output_tokens);
+            // The sidecar contract enables SGLang's incremental streaming output,
+            // so each response contains only this chunk's token and metadata.
             while let Some(signal) = signal_rx.recv().await {
                 let token_id = checked_token(&signal).map_err(|status| *status)?;
-                output_tokens.push(token_id);
-                let output_ids = output_tokens
-                    .iter()
-                    .copied()
-                    .map(i32::try_from)
-                    .collect::<Result<Vec<_>, _>>()
+                let output_id = i32::try_from(token_id)
                     .map_err(|_| Status::internal("synthetic token ID does not fit i32"))?;
                 yield pb::GenerateResponse {
-                    output_ids,
-                    meta_info: prepared.meta_info(&output_tokens, signal.completed),
+                    output_ids: vec![output_id],
+                    meta_info: prepared.meta_info(&[token_id], signal.completed),
                     finished: signal.completed,
                 };
                 if signal.completed {

--- a/lib/mocker/servers/sglang/tests/sidecar.rs
+++ b/lib/mocker/servers/sglang/tests/sidecar.rs
@@ -146,7 +146,7 @@ async fn collect_with_context(
 }
 
 #[tokio::test]
-async fn sidecar_discovers_and_streams_mocker_tokens_logprobs_and_usage() {
+async fn sidecar_streams_incremental_mocker_tokens_logprobs_and_usage() {
     let server = RunningServer::start(ServerMode::Aggregated, fast_engine_args()).await;
     let engine = sidecar(&server.endpoint, DisaggregationMode::Aggregated).await;
     let config = engine.start(0).await.unwrap();

--- a/lib/sidecar/sglang/README.md
+++ b/lib/sidecar/sglang/README.md
@@ -42,6 +42,7 @@ SGLang can load the Python entry point and supply the gRPC endpoint arguments:
 python3 -m sglang.launch_server \
     <args> \
     --grpc-port 30001 \
+    --incremental-streaming-output \
     --sidecar dynamo.sglang.sidecar
 ```
 

--- a/lib/sidecar/sglang/deploy/agg.yaml
+++ b/lib/sidecar/sglang/deploy/agg.yaml
@@ -85,6 +85,7 @@ spec:
           - "30000"
           - --grpc-port
           - "30001"
+          - --incremental-streaming-output
         containers:
         # Sidecar worker. No published image yet — build from
         # lib/sidecar/sglang/Dockerfile, set <your-registry> (see README), add

--- a/lib/sidecar/sglang/deploy/disagg.yaml
+++ b/lib/sidecar/sglang/deploy/disagg.yaml
@@ -104,6 +104,7 @@ spec:
           - "30000"
           - --grpc-port
           - "30001"
+          - --incremental-streaming-output
           - --disaggregation-mode
           - prefill
           - --disaggregation-bootstrap-port
@@ -192,6 +193,7 @@ spec:
           - "30000"
           - --grpc-port
           - "30001"
+          - --incremental-streaming-output
           - --disaggregation-mode
           - decode
           - --disaggregation-bootstrap-port

--- a/lib/sidecar/sglang/launch/agg.sh
+++ b/lib/sidecar/sglang/launch/agg.sh
@@ -79,6 +79,7 @@ CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_HTTP_PORT" \
     --grpc-port "$SGLANG_GRPC_PORT" \
+    --incremental-streaming-output \
     --context-length "$MAX_MODEL_LEN" \
     --max-running-requests "$MAX_CONCURRENT_SEQS" \
     $GPU_MEM_ARGS \

--- a/lib/sidecar/sglang/launch/agg_kv_router.sh
+++ b/lib/sidecar/sglang/launch/agg_kv_router.sh
@@ -94,6 +94,7 @@ CUDA_VISIBLE_DEVICES="$SGLANG_WORKER1_GPU" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_WORKER1_HTTP_PORT" \
     --grpc-port "$SGLANG_WORKER1_GRPC_PORT" \
+    --incremental-streaming-output \
     --kv-events-config "$KV_EVENTS_CONFIG_1" \
     --page-size "$SGLANG_PAGE_SIZE" \
     --context-length "$MAX_MODEL_LEN" \
@@ -108,6 +109,7 @@ CUDA_VISIBLE_DEVICES="$SGLANG_WORKER2_GPU" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_WORKER2_HTTP_PORT" \
     --grpc-port "$SGLANG_WORKER2_GRPC_PORT" \
+    --incremental-streaming-output \
     --kv-events-config "$KV_EVENTS_CONFIG_2" \
     --page-size "$SGLANG_PAGE_SIZE" \
     --context-length "$MAX_MODEL_LEN" \

--- a/lib/sidecar/sglang/launch/disagg.sh
+++ b/lib/sidecar/sglang/launch/disagg.sh
@@ -90,6 +90,7 @@ CUDA_VISIBLE_DEVICES="$SGLANG_PREFILL_GPU" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_PREFILL_HTTP_PORT" \
     --grpc-port "$SGLANG_PREFILL_GRPC_PORT" \
+    --incremental-streaming-output \
     --disaggregation-mode prefill \
     --disaggregation-bootstrap-port "$SGLANG_DISAGGREGATION_BOOTSTRAP_PORT" \
     --disaggregation-transfer-backend nixl \
@@ -105,6 +106,7 @@ CUDA_VISIBLE_DEVICES="$SGLANG_DECODE_GPU" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_DECODE_HTTP_PORT" \
     --grpc-port "$SGLANG_DECODE_GRPC_PORT" \
+    --incremental-streaming-output \
     --disaggregation-mode decode \
     --disaggregation-bootstrap-port "$SGLANG_DISAGGREGATION_BOOTSTRAP_PORT" \
     --disaggregation-transfer-backend nixl \

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -25,7 +25,7 @@ use crate::client::{self, Client, Discovery, Pool};
 use crate::proto as pb;
 use crate::protocol::{
     build_generate_request, disaggregated_params_to_json, engine_data_from_meta, extract_logprobs,
-    meta_u32, new_output_ids, output_ids_to_u32, terminal_from_meta,
+    meta_u32, output_ids_to_u32, terminal_from_meta,
 };
 
 pub struct SglangSidecarEngine {
@@ -278,8 +278,6 @@ impl LLMEngine for SglangSidecarEngine {
 
             let mut generated = 0_u32;
             let mut observed_prompt_tokens = prompt_tokens;
-            let mut logprob_offset = 0_usize;
-            let mut token_offset = 0_usize;
             loop {
                 tokio::select! {
                     biased;
@@ -311,35 +309,21 @@ impl LLMEngine for SglangSidecarEngine {
                         if let Some(value) = meta_u32(&response.meta_info, "prompt_tokens") {
                             observed_prompt_tokens = value;
                         }
-                        // SGLang streams output_ids cumulatively (the whole sequence
-                        // so far, like its logprob metadata), so emit only the tokens
-                        // appended since the previous chunk.
-                        let token_ids = match output_ids_to_u32(new_output_ids(
-                            &response.output_ids,
-                            token_offset,
-                        )) {
+                        let token_ids = match output_ids_to_u32(&response.output_ids) {
                             Ok(ids) => ids,
                             Err(err) => {
                                 yield Err(err);
                                 break;
                             }
                         };
-                        // Never rewind: a regressive chunk (shorter than what we
-                        // already emitted) must not let later growth re-emit tokens.
-                        token_offset = token_offset.max(response.output_ids.len());
-                        let (log_probs, top_logprobs, next_offset) =
-                            match extract_logprobs(
-                                &response.meta_info,
-                                logprob_offset,
-                                return_tokens_as_ids,
-                            ) {
+                        let (log_probs, top_logprobs) =
+                            match extract_logprobs(&response.meta_info, return_tokens_as_ids) {
                                 Ok(values) => values,
                                 Err(err) => {
                                     yield Err(err);
                                     break;
                                 }
                             };
-                        logprob_offset = next_offset;
 
                         if is_prefill {
                             if response.finished {

--- a/lib/sidecar/sglang/src/protocol.rs
+++ b/lib/sidecar/sglang/src/protocol.rs
@@ -327,13 +327,6 @@ fn json_value_to_string(value: &Value) -> String {
     }
 }
 
-/// Tokens appended since the previous chunk. SGLang streams `output_ids`
-/// cumulatively, so each chunk carries the full sequence so far; `offset` is the
-/// previous chunk's total length. Guards against a non-growing chunk.
-pub(crate) fn new_output_ids(output_ids: &[i32], offset: usize) -> &[i32] {
-    output_ids.get(offset..).unwrap_or(&[])
-}
-
 pub(crate) fn output_ids_to_u32(ids: &[i32]) -> Result<Vec<u32>, DynamoError> {
     ids.iter()
         .map(|id| {
@@ -502,22 +495,18 @@ fn prompt_logprob_entry(value: &Value, label: &str) -> Result<(String, Value), D
     Ok((token_id.to_string(), Value::Object(entry)))
 }
 
-pub(crate) type ExtractedLogprobs = (Option<Vec<f64>>, Option<Vec<Vec<TopLogprob>>>, usize);
+pub(crate) type ExtractedLogprobs = (Option<Vec<f64>>, Option<Vec<Vec<TopLogprob>>>);
 
 pub(crate) fn extract_logprobs(
     meta: &HashMap<String, String>,
-    offset: usize,
     return_tokens_as_ids: bool,
 ) -> Result<ExtractedLogprobs, DynamoError> {
     let Some(Value::Array(all_logprobs)) = meta_value(meta, "output_token_logprobs") else {
-        return Ok((None, None, offset));
+        return Ok((None, None));
     };
-    if offset >= all_logprobs.len() {
-        return Ok((None, None, all_logprobs.len()));
-    }
 
-    let mut log_probs = Vec::with_capacity(all_logprobs.len() - offset);
-    for entry in &all_logprobs[offset..] {
+    let mut log_probs = Vec::with_capacity(all_logprobs.len());
+    for entry in &all_logprobs {
         let value = entry
             .as_array()
             .and_then(|parts| parts.first())
@@ -531,7 +520,7 @@ pub(crate) fn extract_logprobs(
     let top_logprobs = match meta_value(meta, "output_top_logprobs") {
         Some(Value::Array(all_top)) => {
             let mut positions = Vec::new();
-            for position in all_top.iter().skip(offset) {
+            for position in &all_top {
                 let Some(entries) = position.as_array() else {
                     positions.push(Vec::new());
                     continue;
@@ -570,7 +559,7 @@ pub(crate) fn extract_logprobs(
         _ => None,
     };
 
-    Ok((Some(log_probs), top_logprobs, all_logprobs.len()))
+    Ok((Some(log_probs), top_logprobs))
 }
 
 #[cfg(test)]
@@ -585,7 +574,7 @@ mod tests {
 
     use super::{
         build_generate_request, disaggregated_params_to_json, engine_data_from_meta,
-        extract_logprobs, new_output_ids, terminal_from_meta,
+        extract_logprobs, terminal_from_meta,
     };
 
     fn request() -> PreprocessedRequest {
@@ -679,35 +668,7 @@ mod tests {
     }
 
     #[test]
-    fn new_output_ids_slices_the_cumulative_stream() {
-        // SGLang re-sends the whole sequence each chunk; only the tail is new.
-        assert_eq!(new_output_ids(&[1, 2, 3], 0), &[1, 2, 3]);
-        assert_eq!(new_output_ids(&[1, 2, 3], 2), &[3]);
-        assert_eq!(new_output_ids(&[1, 2, 3], 3), &[] as &[i32]);
-        // A chunk that did not grow (or an over-large offset) yields nothing.
-        assert_eq!(new_output_ids(&[1, 2, 3], 5), &[] as &[i32]);
-    }
-
-    #[test]
-    fn cumulative_offset_never_rewinds_on_regression() {
-        // Mirror the engine loop: emit the new tail, then advance the offset
-        // monotonically (token_offset.max(len)) so a regressive chunk can't cause
-        // re-emission when the sequence later grows again.
-        let mut offset = 0usize;
-        let mut step = |ids: &[i32]| -> Vec<i32> {
-            let new = new_output_ids(ids, offset).to_vec();
-            offset = offset.max(ids.len());
-            new
-        };
-        assert_eq!(step(&[1, 2, 3]), vec![1, 2, 3]);
-        // Regressive chunk: emits nothing and leaves the offset at 3.
-        assert_eq!(step(&[1, 2]), Vec::<i32>::new());
-        // Growth resumes: only the genuinely-new tail is emitted, not 1..3 again.
-        assert_eq!(step(&[1, 2, 3, 4]), vec![4]);
-    }
-
-    #[test]
-    fn logprobs_are_sliced_from_cumulative_metadata() {
+    fn logprobs_are_read_from_incremental_chunk() {
         let meta = HashMap::from([
             (
                 "output_token_logprobs".to_string(),
@@ -718,10 +679,11 @@ mod tests {
                 json!([[[-0.1, 10, "a"]], [[-0.2, 11, "b"]]]).to_string(),
             ),
         ]);
-        let (logprobs, top, next) = extract_logprobs(&meta, 1, false).unwrap();
-        assert_eq!(logprobs.unwrap(), vec![-0.2]);
-        assert_eq!(top.unwrap()[0][0].token_id, 11);
-        assert_eq!(next, 2);
+        let (logprobs, top) = extract_logprobs(&meta, false).unwrap();
+        assert_eq!(logprobs.unwrap(), vec![-0.1, -0.2]);
+        let top = top.unwrap();
+        assert_eq!(top[0][0].token_id, 10);
+        assert_eq!(top[1][0].token_id, 11);
     }
 
     #[test]


### PR DESCRIPTION
## Overview:

Use SGLang's incremental streaming contract consistently across the native gRPC sidecar path and its launch and deployment examples. This is a prerequisite for #13659, which can rebase on this shared contract before adding native HTTP forwarding.

## Details:

- Enables `--incremental-streaming-output` in all SGLang sidecar launch scripts, deployment manifests, and the README example.
- Consumes native gRPC token IDs and logprob metadata as per-chunk deltas, removing cumulative-stream handling.
- Updates the SGLang mock server and integration test to enforce the incremental response contract.

### Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-sglang-sidecar -p dynamo-sglang-mocker`
- `cargo test -p dynamo-sglang-mocker --test sidecar sidecar_streams_incremental_mocker_tokens_logprobs_and_usage`
- `bash -n lib/sidecar/sglang/launch/agg.sh lib/sidecar/sglang/launch/agg_kv_router.sh lib/sidecar/sglang/launch/disagg.sh`

## Where should the reviewer start?

- `lib/sidecar/sglang/src/engine.rs` and `lib/sidecar/sglang/src/protocol.rs` for the gRPC response handling.
- `lib/mocker/servers/sglang/src/server.rs` and `lib/mocker/servers/sglang/tests/sidecar.rs` for the regression coverage.
- `lib/sidecar/sglang/launch/` and `lib/sidecar/sglang/deploy/` for flag propagation.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Related PR: #13659