### PR TITLE
fix(deps): hold pillow at the requirements floor in frontend and planner

### DIFF
--- a/container/deps/overrides.frontend.txt
+++ b/container/deps/overrides.frontend.txt
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# uv dependency overrides for the frontend image.
+#
+# requirements.common.txt already floors pillow at 12.3.0, but the frontend
+# does not stop there: the last build step installs benchmarks/, which depends
+# on aiperf==0.10.0, and aiperf declares pillow~=12.2.0. That constraint pins
+# the patch series, so it forbids 12.3.0 and the re-resolve walks the image
+# back under the floor. The shipped 1.4.1 frontend carries pillow 12.2.0 for
+# exactly this reason.
+#
+# An override applies to the whole resolve, so it holds across the later
+# install steps in a way a requirements floor does not.
+#
+# The upper bound is required, not decorative: a uv override REPLACES every
+# other constraint on the package, so nothing else caps this at the 12.x
+# series once the override is in force. Drop this entry once aiperf widens its
+# own constraint.
+pillow>=12.3.0,<13

--- a/container/deps/overrides.planner.txt
+++ b/container/deps/overrides.planner.txt
@@ -18,3 +18,15 @@
 # requirements files does not apply here. Without it this image would be the only
 # one that accepts a 4.x release.
 aiohttp>=3.14.3,<4.0
+
+# Same story for pillow. aiperf declares pillow~=12.2.0, which pins the patch
+# series and so forbids 12.3.0, the floor requirements.common.txt already
+# targets. The planner installs aiperf for the thorough profiler path, so
+# without this override the image resolves back to 12.2.0 no matter what the
+# requirements files ask for.
+#
+# The upper bound is required for the same reason as above: a uv override
+# REPLACES every other constraint on the package, so nothing else caps this at
+# the 12.x series once the override is in force. Drop this entry once aiperf
+# widens its own constraint.
+pillow>=12.3.0,<13

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -142,9 +142,11 @@ RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home
 # Test and dev dependencies are NOT installed here — they go in the test and dev images.
 RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tmp/requirements.common.txt \
     --mount=type=bind,source=./container/deps/requirements.frontend.txt,target=/tmp/requirements.frontend.txt \
+    --mount=type=bind,source=./container/deps/overrides.frontend.txt,target=/tmp/overrides.frontend.txt \
     --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv pip install \
+        --overrides /tmp/overrides.frontend.txt \
         --requirement /tmp/requirements.common.txt \
         --requirement /tmp/requirements.frontend.txt
 
@@ -153,10 +155,12 @@ ARG NIXL_REF
 # In an ideal world, we'd use a mirror of PyPI for much more reliable downloads.
 # UV_FIND_LINKS points at the crick wheel pre-built in the crick_builder stage;
 # uv prefers it over the sdist on arm64 where no manylinux aarch64 wheel exists.
-RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+RUN --mount=type=bind,source=./container/deps/overrides.frontend.txt,target=/tmp/overrides.frontend.txt \
+    --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     echo "${NIXL_REF}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' || { echo "NIXL_REF must be a vX.Y.Z release tag; got '${NIXL_REF}'" >&2; exit 1; } && \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_FIND_LINKS=/opt/dynamo/wheelhouse/extra && \
     uv pip install \
+    --overrides /tmp/overrides.frontend.txt \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl && \
     # The meta package requires both backends unconditionally (its cu12/cu13
@@ -175,7 +179,7 @@ RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home
     fi && \
     cd /workspace/benchmarks && \
     export UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
-    uv pip install .
+    uv pip install --overrides /tmp/overrides.frontend.txt .
 
 # Setup environment for all users
 USER root


### PR DESCRIPTION
## Summary

`container/deps/requirements.common.txt` already floors pillow at `12.3.0`, but neither the frontend nor the planner image ships that version. Both land on `12.2.0`.

## Why the floor does not hold

`aiperf` declares `pillow~=12.2.0`. That pins the patch series, so it excludes `12.3.0` outright.

uv resolves each `uv pip install` independently, so the floor is applied by one step and then replaced by a later one:

- **frontend** installs `requirements.common.txt`, then finishes with `cd /workspace/benchmarks && uv pip install .` — and `benchmarks/pyproject.toml` depends on `aiperf==0.10.0`
- **planner** installs aiperf directly for the thorough profiler path

Resolved together, the two constraints are not just contradictory in practice, they are unsatisfiable:

```
Because aiperf==0.10.0 depends on pillow>=12.2.0,<12.3.dev0 and you require
pillow>=12.3.0, we can conclude that your requirements are unsatisfiable.
```

A requirements floor cannot survive that. An override can, because it applies to the whole resolve rather than to a single install step.

## Change

- `overrides.planner.txt` gains `pillow>=12.3.0,<13`
- new `overrides.frontend.txt` with the same entry
- `--overrides` threaded through the frontend's install steps, including the trailing benchmarks install

This is the same mechanism, and the same upstream dependency, as the `aiohttp` override the planner already carries. Both entries carry an upper bound deliberately: a uv override **replaces** every other constraint on the package, so nothing else would cap the major version once it is in force. The existing aiohttp entry documents the same trap.

Drop both entries once aiperf widens its own constraint.

## Verification

With uv 0.11.7, the same input set (`aiperf==0.10.0` + `pillow>=12.3.0`):

| | Result |
|---|---|
| without override | resolve fails as unsatisfiable |
| with override | `pillow==12.3.0` |

Related: DYN-4024
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontend and planner dependency compatibility by standardizing Pillow on version 12.x.
  * Updated frontend and benchmark setup to consistently apply the dependency constraints during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->