### PR TITLE
build(trtllm): drop the unused Nsight efa_metrics sampler from the runtime image

### DIFF
--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -640,6 +640,29 @@ RUN --mount=type=bind,source=./container/compliance/enumerate_bundled_decoders.p
         exit 1; \
     fi
 
+# The Nsight Systems CLI in the CUDA base ships an optional efa_metrics sampler
+# for EFA network counters. Nothing in the Dynamo tree references it, and AWS
+# EFA confirmed on 2026-08-18 that they do not use it. It is a static Go binary,
+# so it carries its own copy of the Go standard library and is the sole carrier
+# for 17 of this image's Critical and High findings.
+#
+# Removed after the overlay rather than in the rm -rf above, for the same reason
+# that block documents in the other direction: COPY --from=runtime_full / /
+# reinstates whatever the base holds, so a pre-overlay whiteout here would just
+# be undone. The glob spans the CUDA version, the Nsight version and both target
+# architectures, all of which move with the base image.
+#
+# The guard is the point of the change, not decoration: a glob that silently
+# matches nothing after a base bump would leave the finding in place while the
+# build stayed green.
+RUN rm -rf /usr/local/cuda-*/NsightSystems-cli-*/target-linux-*/plugins/efa_metrics; \
+    if find /usr/local -type d -name efa_metrics 2>/dev/null | grep -q .; then \
+        echo "ERROR: an efa_metrics plugin directory survived removal; the glob no" >&2; \
+        echo "       longer matches the base image's Nsight layout." >&2; \
+        find /usr/local -type d -name efa_metrics >&2; \
+        exit 1; \
+    fi
+
 # Mirrors runtime_full's ENV — must stay in sync. Re-declaration is required
 # because `FROM ${RUNTIME_IMAGE}` here does not inherit runtime_full's config.
 # dev/local-dev create their own venv in a later stage, so the venv ENV is left


### PR DESCRIPTION
## Summary

The Nsight Systems CLI that ships in the CUDA base carries an optional `efa_metrics` plugin, a sampler for EFA network counters:

```
/usr/local/cuda-*/NsightSystems-cli-*/target-linux-*/plugins/efa_metrics/nic_sampler
```

Nothing in the Dynamo tree references it. AWS EFA confirmed on 2026-08-18 that they do not use it.

It is a static Go binary, so it carries its own copy of the Go standard library. On the scanned 1.4.1 images it is the **sole carrier** for 17 Critical and High findings per tensorrtllm-runtime image. Present on the base and `-efa` variants alike, on both `x64` and `sbsa-armv8`.

## Why the removal goes after the overlay

This stage does `rm -rf`, then `COPY --from=runtime_full / /`. That overlay reinstates whatever the base image holds, and COPY cannot represent a deletion, so a whiteout written in the pre-overlay block would simply be undone. The DALI and FFmpeg comments in that block document the same rule from the other side.

So the removal is placed after the overlay and after its post-overlay guard.

## The glob and the guard

The path spans the CUDA version, the Nsight version and the target architecture, all of which move with the base image, so the removal is globbed.

A glob that silently stops matching is the real risk here: the finding would come back while the build stayed green. The change therefore asserts its own post-condition and fails the build if any `efa_metrics` directory survives.

## Scope

This covers **tensorrtllm-runtime only.**

The same plugin is present in `snapshot-agent`, and that image is not built from this repository. Per-image impact measured against the 1.4.1 scan:

| image | findings touching the plugin | sole-carrier, clear on removal | blocked by another carrier |
|---|---|---|---|
| `tensorrtllm-runtime` | 24 | 17 | 7 |
| `tensorrtllm-runtime-efa` | 24 | 17 | 7 |
| `snapshot-agent` | 36 | 36 | 0 |

The 7 blocked on the trtllm images share a carrier with the mooncake wheel's `libetcd_wrapper.so`, so they need that wheel to move as well.

## Verification

Not build-verified locally. CI builds both architectures, and the guard turns a non-matching glob into a build failure rather than a silent no-op.

Related: DYN-4021
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the Nsight Systems `efa_metrics` plugin from runtime images across supported CUDA versions, Nsight versions, and architectures.
  * Added a build-time validation check to ensure the plugin is fully removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->