### PR TITLE
fix(deps): [cherry-pick 1.4.2] hold pillow at the requirements floor in frontend and planner

### DIFF
--- a/container/deps/overrides.frontend.txt
+++ b/container/deps/overrides.frontend.txt
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# uv dependency overrides for the frontend image.
+#
+# requirements.common.txt already floors pillow at 12.3.0, but the frontend
+# does not stop there: the last build step installs benchmarks/, which depends
+# on aiperf==0.10.0, and aiperf declares pillow~=12.2.0. That constraint pins
+# the patch series, so it forbids 12.3.0 and the re-resolve walks the image
+# back under the floor. The shipped 1.4.1 frontend carries pillow 12.2.0 for
+# exactly this reason.
+#
+# An override applies to the whole resolve, so it holds across the later
+# install steps in a way a requirements floor does not.
+#
+# The upper bound is required, not decorative: a uv override REPLACES every
+# other constraint on the package, so nothing else caps this at the 12.x
+# series once the override is in force. Drop this entry once aiperf widens its
+# own constraint.
+pillow>=12.3.0,<13

--- a/container/deps/overrides.planner.txt
+++ b/container/deps/overrides.planner.txt
@@ -18,3 +18,15 @@
 # requirements files does not apply here. Without it this image would be the only
 # one that accepts a 4.x release.
 aiohttp>=3.14.3,<4.0
+
+# Same story for pillow. aiperf declares pillow~=12.2.0, which pins the patch
+# series and so forbids 12.3.0, the floor requirements.common.txt already
+# targets. The planner installs aiperf for the thorough profiler path, so
+# without this override the image resolves back to 12.2.0 no matter what the
+# requirements files ask for.
+#
+# The upper bound is required for the same reason as above: a uv override
+# REPLACES every other constraint on the package, so nothing else caps this at
+# the 12.x series once the override is in force. Drop this entry once aiperf
+# widens its own constraint.
+pillow>=12.3.0,<13

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -78,20 +78,23 @@ COPY --from=crick_builder /wheels/ /opt/dynamo/wheelhouse/extra/
 
 RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tmp/requirements.common.txt \
     --mount=type=bind,source=./container/deps/requirements.frontend.txt,target=/tmp/requirements.frontend.txt \
+    --mount=type=bind,source=./container/deps/overrides.frontend.txt,target=/tmp/overrides.frontend.txt \
     --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=shared \
     export UV_CACHE_DIR=/root/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv venv /opt/dynamo/venv --python ${PYTHON_VERSION} && \
     uv pip install \
+        --overrides /tmp/overrides.frontend.txt \
         --requirement /tmp/requirements.common.txt \
         --requirement /tmp/requirements.frontend.txt
 
 # benchmarks also declares aiconfigurator-core, so install it while the same
 # source-build toolchain is available.
 RUN --mount=type=bind,source=./benchmarks,target=/tmp/benchmarks,rw \
+    --mount=type=bind,source=./container/deps/overrides.frontend.txt,target=/tmp/overrides.frontend.txt \
     --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=shared \
     export UV_CACHE_DIR=/root/.cache/uv UV_FIND_LINKS=/opt/dynamo/wheelhouse/extra \
         UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
-    uv pip install /tmp/benchmarks
+    uv pip install --overrides /tmp/overrides.frontend.txt /tmp/benchmarks
 
 FROM ${FRONTEND_IMAGE} AS pre_frontend
 
@@ -185,9 +188,11 @@ ARG ENABLE_GPU_MEMORY_SERVICE
 # In an ideal world, we'd use a mirror of PyPI for much more reliable downloads.
 # UV_FIND_LINKS points at the crick wheel pre-built in the crick_builder stage;
 # uv prefers it over the sdist on arm64 where no manylinux aarch64 wheel exists.
-RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+RUN --mount=type=bind,source=./container/deps/overrides.frontend.txt,target=/tmp/overrides.frontend.txt \
+    --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_FIND_LINKS=/opt/dynamo/wheelhouse/extra && \
     uv pip install \
+    --overrides /tmp/overrides.frontend.txt \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
     /opt/dynamo/wheelhouse/nixl/nixl*.whl && \


### PR DESCRIPTION
Cherry-pick of #13741 onto `release/1.4.2`.

**Not a clean pick.** `container/templates/frontend.Dockerfile` has diverged from main (+44/-64), so the change was reapplied against this branch's own structure rather than transplanted. The substance is identical; the install sites differ.

## Problem

`requirements.common.txt` already floors pillow at `12.3.0`, but neither the frontend nor the planner image ships it. Both land on `12.2.0`.

`aiperf` declares `pillow~=12.2.0`, which pins the patch series and so excludes `12.3.0`. uv resolves each `uv pip install` independently, so the floor is applied by one step and replaced by a later one. Resolved together the constraints are unsatisfiable:

```
Because aiperf==0.10.0 depends on pillow>=12.2.0,<12.3.dev0 and you require
pillow>=12.3.0, we can conclude that your requirements are unsatisfiable.
```

An override survives that; a requirements floor does not, because the override applies to the whole resolve.

## What differs from the main PR

On main the benchmarks install is `cd /workspace/benchmarks && uv pip install .` inside a larger RUN. On this branch it is its own RUN, `uv pip install /tmp/benchmarks`, in an earlier builder stage. `--overrides` is threaded through all three install sites that can resolve pillow on this branch:

1. the `requirements.common.txt` + `requirements.frontend.txt` install
2. the benchmarks install, which is the one that pulls aiperf in
3. the wheelhouse install in `pre_frontend`

`overrides.planner.txt` is identical on both branches, so that hunk is the same.

## Verification

`uv 0.12.0`, the version `container/context.yaml` pins for these images:

| | Result |
|---|---|
| without override | resolve fails as unsatisfiable |
| with override | `pillow==12.3.0` |

Both entries carry an upper bound deliberately: a uv override **replaces** every other constraint on the package. Drop them once aiperf widens its own.

Related: DYN-4024
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->