### PR TITLE
fix(deps): [cherry-pick 1.4.2] pin plotext below 6 in planner requirements

### DIFF
--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -15,6 +15,8 @@ filterpy==1.4.5
 grpcio>=1.63.0
 kubernetes==32.0.1
 kubernetes_asyncio==32.0.0
+# aiconfigurator calls the top-level plotext.plot_size, removed in plotext 6.
+plotext<6
 plotly>=6.0.1
 pmdarima==2.1.1
 prometheus-api-client==0.6.0


### PR DESCRIPTION
Backport of #13716 ([`759cb4e3`](https://github.com/ai-dynamo/dynamo/commit/759cb4e3e)) onto `release/1.4.2`. Clean pick — the file is identical between branches apart from this line.

## Why this branch needs it

`plotext 6.0.0` published on 2026-08-23 and removed the top-level `plot_size`, which `aiconfigurator` calls.

`release/1.4.2` was cut from `v1.4.1` on 2026-08-22, so it predates the fix on main. Every PR against this branch fails the same six profiler integration tests:

```
AttributeError: module 'plotext' has no attribute 'plot_size'

components/src/dynamo/profiler/tests/integration/test_profile_sla_dgdr.py
components/src/dynamo/profiler/tests/integration/test_aic_task_v2_contract.py
```

Observed on this branch as **6 failed, 2391 passed**.

## Why it is not reproducible from a version bump

`plotext` was unpinned, so the resolve takes whatever is current at build time. Nothing in the tree changed — the break arrived from PyPI. That is what the upper bound fixes.

## Impact on 1.4.2

This blocks #13745 and #13746 from going green. It is also the suite that exercises the profiler, which is what DYN-4038 needs in order to verify the Nsight plugin removal.

Related: DYN-4021
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->