### PR TITLE
feat(epp): recover KV index from peer snapshots

### DIFF
--- a/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
@@ -26,10 +26,12 @@
 #
 # Replication: each EPP replica runs its own in-process selector. To keep the
 # load-aware routing view consistent, replicas discover each other from this
-# Deployment's own Service (EndpointSlices) and sync admission/prefill-complete/
-# free over ZMQ. This is enabled by DYN_EPP_PEER_SERVICE below; set replicas: 1
-# and drop that env for a single, fully-local replica. (A freshly started replica
-# has an empty KV index and re-warms from live traffic + replay.)
+# Deployment's own Service (EndpointSlices), sync admission/prefill-complete/free over
+# ZMQ, and recover the KV index at startup. A replica registers its initial workers,
+# recovers a Ready sibling's HTTP dump, then drains its queued KV traffic. This is
+# enabled by DYN_EPP_PEER_SERVICE below; set replicas: 1 and drop that env for a
+# fully-local replica. Without a Ready sibling, it starts with an empty KV index and
+# warms from live traffic + replay.
 #
 # Prerequisites:
 #   - Gateway API and GAIE CRDs.
@@ -258,10 +260,10 @@ spec:
             # the vLLM engine's --max-num-batched-tokens.
             - name: DYN_EPP_MAX_NUM_BATCHED_TOKENS
               value: "8192"
-            # Replication: watch THIS Deployment's own Service
-            # (EndpointSlices) to find sibling EPP replicas and sync active load
-            # over its required named replica-agg port. Omit this env to run a
-            # single fully-local replica (and set replicas: 1).
+            # Replication: watch THIS Deployment's own Service (EndpointSlices) to find
+            # sibling EPP replicas, sync active load over its named replica-agg port,
+            # and recover KV-index snapshots over selection-http. Omit this env to run
+            # a single fully-local replica (and set replicas: 1).
             - name: DYN_EPP_PEER_SERVICE
               value: dynamo-epp
             # The reflector watches pods in the EPP's own namespace.
@@ -282,6 +284,8 @@ spec:
             # ZMQ replica-sync between EPP replicas (embedded replication).
             - name: replica-agg
               containerPort: 9092
+            - name: selection-http
+              containerPort: 9090
           readinessProbe:
             grpc:
               port: 9003
@@ -295,7 +299,7 @@ spec:
               drop:
                 - ALL
 ---
-# GAIE calls the gRPC port. EPP replicas use `replica-agg` for load-state sync.
+# GAIE calls gRPC; EPP replicas use `replica-agg` for load sync and `selection-http` for KV-index recovery.
 apiVersion: v1
 kind: Service
 metadata:
@@ -311,6 +315,9 @@ spec:
     - name: replica-agg
       port: 9092
       targetPort: replica-agg
+    - name: selection-http
+      port: 9090
+      targetPort: selection-http
 ---
 # InferencePool selects the raw vLLM pods and delegates endpoint selection to
 # the EPP. The EPP reads this object (read-only) to learn the pod selector and

--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use tokio::sync::Semaphore;
 
 use dynamo_kv_router::services::selection::SelectionService;
@@ -36,7 +36,7 @@ use crate::epp_standalone_config::EppStandaloneConfig;
 use crate::picker::{Endpoint, EndpointPicker, PickError, PickResult, RequestInfo};
 use crate::pod_discovery::PodDiscovery;
 use crate::selector::{SelectRequest, Selector};
-use crate::topology_adapter::{RegistrationDefaults, TopologyAdapter};
+use crate::topology_adapter::{RegistrationDefaults, TopologyAdapter, registrations};
 use crate::vllm_render_client::{VllmRenderClient, VllmRenderError};
 
 /// Standalone endpoint picker backed by the standalone selection service.
@@ -69,8 +69,37 @@ pub struct EppRouter {
 impl EppRouter {
     /// Assemble the standalone runtime from the validated selector config.
     pub async fn from_selector(cfg: EppStandaloneConfig) -> Result<Self> {
-        let selector = Arc::new(Selector::new(&cfg).await?);
         let (renderer, reflector, reflector_ready) = Self::dependencies(&cfg).await?;
+        while !reflector_ready.load(Ordering::Acquire) {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        let defaults = RegistrationDefaults::from_config(&cfg);
+        let initial_workers = registrations(reflector.as_ref(), &defaults);
+        let (indexer_peers, dump_server_ip) = match &cfg.peer_service {
+            Some(service_name) => {
+                let (self_ip, pod_ip) = Self::pod_ip_from_env()?;
+                let peers = crate::peer_discovery::resolve_indexer_peers(
+                    &cfg.namespace,
+                    service_name,
+                    &self_ip,
+                )
+                .await?;
+                (peers, Some(pod_ip))
+            }
+            None => (Vec::new(), None),
+        };
+        let selector = Arc::new(
+            Selector::new_with_initial_workers(&cfg, initial_workers, indexer_peers).await?,
+        );
+        if let Some(pod_ip) = dump_server_ip {
+            crate::peer_discovery::spawn_indexer_dump_server(
+                selector.selection_service(),
+                pod_ip,
+                selector.cancellation_token(),
+            )
+            .await?;
+        }
         Ok(Self::from_selector_parts(
             cfg,
             renderer,
@@ -86,6 +115,15 @@ impl EppRouter {
         service: SelectionService,
     ) -> Result<Self> {
         let selector = Arc::new(Selector::from_service(&cfg, service).await?);
+        if cfg.peer_service.is_some() {
+            let (_, pod_ip) = Self::pod_ip_from_env()?;
+            crate::peer_discovery::spawn_indexer_dump_server(
+                selector.selection_service(),
+                pod_ip,
+                selector.cancellation_token(),
+            )
+            .await?;
+        }
         let (renderer, reflector, reflector_ready) = Self::dependencies(&cfg).await?;
         Ok(Self::from_selector_parts(
             cfg,
@@ -192,6 +230,19 @@ impl EppRouter {
         self.reflector.ready_worker_ids_matching(|endpoint| {
             endpoint_in_subset(endpoint, &candidates, &candidate_ips)
         })
+    }
+    fn pod_ip_from_env() -> Result<(String, IpAddr)> {
+        let pod_ip = std::env::var("POD_IP")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!("DYN_EPP_PEER_SERVICE is set but POD_IP is unavailable")
+            })?;
+        let address = pod_ip
+            .parse()
+            .with_context(|| format!("parsing POD_IP {pod_ip:?}"))?;
+        Ok((pod_ip, address))
     }
 }
 

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -87,8 +87,8 @@ pub struct EppStandaloneConfig {
     /// KV indexer thread-pool size for the in-process selector.
     #[validate(range(min = 1))]
     pub selector_threads: usize,
-    /// EPP Service for peer discovery and state synchronization. The eventual
-    /// selector resolves its named `replica-agg` port from EndpointSlices.
+    /// EPP Service for static KV-index recovery, peer discovery, and state synchronization.
+    /// The selector resolves its named `replica-agg` port from EndpointSlices.
     pub peer_service: Option<String>,
     /// `InferencePool` this EPP backs; its selector + target port drive discovery.
     #[validate(length(min = 1, message = "DYN_EPP_INFERENCE_POOL_NAME is required"))]

--- a/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
@@ -7,8 +7,12 @@
 //! in-process [`SelectionService`] as sibling EPP replicas join or leave.
 
 use std::collections::BTreeSet;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+
+use axum::{Json, Router, extract::State, routing::get};
+use tokio::net::TcpListener;
 
 use anyhow::{Context, Result};
 use k8s_openapi::api::discovery::v1::EndpointSlice;
@@ -22,6 +26,9 @@ const SERVICE_NAME_LABEL: &str = "kubernetes.io/service-name";
 
 /// Named Service/EndpointSlice port used for aggregated replica synchronization.
 pub const REPLICA_AGG_PORT_NAME: &str = "replica-agg";
+
+/// TCP port used by sibling EPPs for startup KV-index dump recovery.
+pub const SELECTION_HTTP_PORT: u16 = 9090;
 
 type Store = kube::runtime::reflector::Store<EndpointSlice>;
 
@@ -108,7 +115,95 @@ fn replica_sync_port<'a>(slices: impl Iterator<Item = &'a EndpointSlice>) -> Res
     Ok(*resolved.first().expect("validated one resolved port"))
 }
 
-/// Starts peer discovery for the EPP's own Kubernetes Service, keeping
+/// Resolve a static set of sibling HTTP dump URLs from the initial EndpointSlice
+/// LIST. The long-lived replica-sync watch is started separately after recovery.
+pub async fn resolve_indexer_peers(
+    namespace: &str,
+    service_name: &str,
+    self_ip: &str,
+) -> Result<Vec<String>> {
+    use kube::{Api, Client, api::ListParams};
+
+    let client = Client::try_default()
+        .await
+        .context("building Kubernetes client for EPP peer recovery")?;
+    let slices: Api<EndpointSlice> = Api::namespaced(client, namespace);
+    let list = slices
+        .list(&ListParams::default().labels(&format!("{SERVICE_NAME_LABEL}={service_name}")))
+        .await
+        .with_context(|| {
+            format!("listing EndpointSlices for EPP peer Service {namespace}/{service_name}")
+        })?;
+    Ok(static_recovery_peer_urls(list.items.iter(), self_ip))
+}
+
+/// Construct the one-shot peer dump set from Ready, non-terminating siblings only.
+/// The replica-sync watch intentionally has broader membership so it can retain
+/// draining peers until their final load events arrive.
+fn static_recovery_peer_urls<'a>(
+    slices: impl Iterator<Item = &'a EndpointSlice>,
+    self_ip: &str,
+) -> Vec<String> {
+    let want_ipv6 = is_ipv6(self_ip);
+    let mut ips = BTreeSet::new();
+    for slice in slices {
+        if slice.address_type.eq_ignore_ascii_case("IPv6") != want_ipv6 {
+            continue;
+        }
+        for endpoint in &slice.endpoints {
+            let ready = endpoint.conditions.as_ref().is_some_and(|conditions| {
+                conditions.ready == Some(true) && conditions.terminating != Some(true)
+            });
+            if !ready {
+                continue;
+            }
+            for address in &endpoint.addresses {
+                if !address.is_empty() {
+                    ips.insert(address.clone());
+                }
+            }
+        }
+    }
+    ips.remove(self_ip);
+    ips.into_iter()
+        .map(|ip| format!("http://{}", authority(&ip, SELECTION_HTTP_PORT)))
+        .collect()
+}
+
+/// Bind the sibling HTTP endpoint used to export this EPP's KV-index dump.
+pub(crate) async fn spawn_indexer_dump_server(
+    service: Arc<SelectionService>,
+    pod_ip: IpAddr,
+    cancel: CancellationToken,
+) -> Result<()> {
+    let address = dump_listener_addr(pod_ip);
+    let listener = TcpListener::bind(address)
+        .await
+        .with_context(|| format!("binding EPP peer dump server on {address}"))?;
+    let app = Router::new().route("/dump", get(dump)).with_state(service);
+    tokio::spawn(async move {
+        if let Err(error) = axum::serve(listener, app)
+            .with_graceful_shutdown(cancel.cancelled_owned())
+            .await
+        {
+            tracing::error!(%error, "EPP peer dump server exited");
+        }
+    });
+    Ok(())
+}
+
+fn dump_listener_addr(pod_ip: IpAddr) -> SocketAddr {
+    match pod_ip {
+        IpAddr::V4(_) => SocketAddr::from((Ipv4Addr::UNSPECIFIED, SELECTION_HTTP_PORT)),
+        IpAddr::V6(_) => SocketAddr::from((Ipv6Addr::UNSPECIFIED, SELECTION_HTTP_PORT)),
+    }
+}
+
+async fn dump(State(service): State<Arc<SelectionService>>) -> Json<serde_json::Value> {
+    Json(service.indexer_snapshot().await)
+}
+
+/// Starts peer discovery for the EPP's own Kubernetes `Service`, keeping
 /// replica-sync peers registered on `service` and excluding `self_ip`.
 ///
 /// Returns a readiness flag that becomes `true` after the initial reconciliation.
@@ -410,6 +505,32 @@ mod tests {
         let v6 = peer_ips(slices.iter(), true);
         assert_eq!(v6.len(), 1);
         assert!(v6.contains("fd00::1"));
+    }
+
+    #[test]
+    fn static_recovery_peers_require_ready_nonterminating_siblings() {
+        let mut ready = slice_with(&["10.0.0.2"], false, "IPv4");
+        ready.endpoints[0].conditions = Some(EndpointConditions {
+            ready: Some(true),
+            terminating: Some(false),
+            ..Default::default()
+        });
+        let mut not_ready = slice_with(&["10.0.0.3"], false, "IPv4");
+        not_ready.endpoints[0].conditions = Some(EndpointConditions {
+            ready: Some(false),
+            ..Default::default()
+        });
+        let mut terminating = slice_with(&["10.0.0.4"], true, "IPv4");
+        terminating.endpoints[0].conditions = Some(EndpointConditions {
+            ready: Some(true),
+            terminating: Some(true),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            static_recovery_peer_urls([ready, not_ready, terminating].iter(), "10.0.0.1"),
+            vec!["http://10.0.0.2:9090"]
+        );
     }
 
     #[test]

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -119,6 +119,37 @@ impl Selector {
         Self::new_with_kv_router_config(cfg, kv_router_config_from_dynamo_env()).await
     }
 
+    /// Build a selector after registering the initial worker snapshot behind
+    /// SelectionService's indexer readiness gate.
+    pub(crate) async fn new_with_initial_workers(
+        cfg: &EppStandaloneConfig,
+        initial_workers: Vec<WorkerRegistration>,
+        indexer_peers: Vec<String>,
+    ) -> Result<Self> {
+        let mut seen = HashSet::with_capacity(initial_workers.len());
+        for registration in &initial_workers {
+            if !seen.insert(registration.worker_id) {
+                anyhow::bail!("duplicate initial worker_id {}", registration.worker_id);
+            }
+        }
+
+        let service = Self::build_selection_service_with_initial_workers(
+            cfg,
+            initial_workers.iter().map(Self::worker_request).collect(),
+            indexer_peers,
+        )
+        .await?;
+        let selector = Self::from_service(cfg, service).await?;
+        {
+            let mut state = selector.reconcile_state.lock().await;
+            for registration in initial_workers {
+                state.tracked_worker_ids.insert(registration.worker_id);
+                state.converged.insert(registration.worker_id, registration);
+            }
+        }
+        Ok(selector)
+    }
+
     /// Build a selection service using the custom policy compiled into this EPP image.
     pub(crate) async fn build_selection_service_with_worker_selection_policy_factory(
         cfg: &EppStandaloneConfig,
@@ -163,7 +194,33 @@ impl Selector {
             .map_err(|e| anyhow!("building embedded selection service: {e}"))
     }
 
-    /// Wrap a prebuilt selection service for use by a custom EPP image.
+    /// Build a selection service after registering a static worker snapshot.
+    async fn build_selection_service_with_initial_workers(
+        cfg: &EppStandaloneConfig,
+        initial_workers: Vec<CoreWorkerRequest>,
+        indexer_peers: Vec<String>,
+    ) -> Result<SelectionService> {
+        let kv_router_config = kv_router_config_from_dynamo_env();
+        let queueing_enabled = kv_router_config
+            .queueing_enabled(Some(&cfg.model_name))
+            .map_err(|e| anyhow!("resolving router policy for model {}: {e}", cfg.model_name))?;
+        Self::validate_queueing_requirements(cfg, queueing_enabled)?;
+
+        let mut builder = SelectionServiceBuilder::new(kv_router_config)
+            .indexer_threads(cfg.selector_threads)
+            .initial_workers(initial_workers)
+            .indexer_peers(indexer_peers);
+        let replication = Self::replication(cfg).await?;
+        if let Some((_, peer_sync_port)) = &replication {
+            builder = builder.replica_sync(*peer_sync_port, Vec::new());
+        }
+
+        builder
+            .build()
+            .await
+            .map_err(|e| anyhow!("building embedded selection service: {e}"))
+    }
+
     pub(crate) async fn from_service(
         cfg: &EppStandaloneConfig,
         service: SelectionService,
@@ -243,6 +300,14 @@ impl Selector {
             reconcile_state: Mutex::new(ReconcileState::default()),
             peer_ready,
         })
+    }
+
+    pub(crate) fn selection_service(&self) -> Arc<SelectionService> {
+        self.service.clone()
+    }
+
+    pub(crate) fn cancellation_token(&self) -> CancellationToken {
+        self.cancel.clone()
     }
 
     pub fn peer_ready(&self) -> Option<Arc<AtomicBool>> {
@@ -760,6 +825,27 @@ models:
             .prefill_complete("never-booked")
             .await
             .expect("prefill-complete of an unknown id is a no-op");
+    }
+
+    #[tokio::test]
+    async fn initial_workers_seed_reconcile_state() {
+        let initial = schedulable_registration(7);
+        let selector =
+            Selector::new_with_initial_workers(&test_config(), vec![initial.clone()], Vec::new())
+                .await
+                .expect("initial selector build should succeed");
+
+        assert!(selector.any_ready().await);
+        assert_eq!(
+            selector.reconcile_state.lock().await.converged.get(&7),
+            Some(&initial),
+            "the first live topology reconcile must not re-upsert the bootstrap worker"
+        );
+
+        selector
+            .reconcile(&[initial])
+            .await
+            .expect("the matching live snapshot should reconcile");
     }
 
     #[tokio::test]

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -92,15 +92,23 @@ async fn reconcile_once(
     selector: &Selector,
     defaults: &RegistrationDefaults,
 ) {
-    let desired: Vec<WorkerRegistration> = reflector
-        .ready_workers()
-        .into_iter()
-        .map(|w| build_registration(w, defaults))
-        .collect();
+    let desired = registrations(reflector, defaults);
 
     if let Err(e) = selector.reconcile(&desired).await {
         tracing::warn!(error = %e, "Selector reconcile failed; will retry on next change");
     }
+}
+
+/// Convert the reflector's current Ready-worker snapshot into selector input.
+pub(crate) fn registrations(
+    reflector: &PodDiscovery,
+    defaults: &RegistrationDefaults,
+) -> Vec<WorkerRegistration> {
+    reflector
+        .ready_workers()
+        .into_iter()
+        .map(|worker| build_registration(worker, defaults))
+        .collect()
 }
 
 fn build_registration(w: RawWorker, defaults: &RegistrationDefaults) -> WorkerRegistration {

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -60,11 +60,6 @@ impl SelectionServiceBuilder {
         self
     }
 
-    /// Register workers before peer index recovery begins.
-    ///
-    /// The listener readiness gate remains closed until [`Self::build`] finishes
-    /// recovery, so their SUB sockets can accumulate the peer dump's live tail
-    /// before normal batch application starts.
     pub fn initial_workers(mut self, initial_workers: Vec<WorkerRequest>) -> Self {
         self.initial_workers = initial_workers;
         self
@@ -134,8 +129,6 @@ impl SelectionServiceBuilder {
             tracking_hash,
         ));
 
-        let requires_peer_recovery =
-            !self.initial_workers.is_empty() && !self.indexer_peers.is_empty();
         for worker in self.initial_workers {
             let worker_id = worker.worker_id;
             let record = core.upsert_worker(worker).await.map_err(|error| {
@@ -152,22 +145,10 @@ impl SelectionServiceBuilder {
         if !self.indexer_peers.is_empty() {
             match core.recover_indexer_from_peers(&self.indexer_peers).await {
                 Ok(true) => tracing::info!("Selection indexer recovery completed"),
-                Ok(false) if requires_peer_recovery => {
-                    anyhow::bail!(
-                        "no selection indexer peers were reachable during required startup recovery"
-                    );
-                }
-                Ok(false) => {
-                    tracing::warn!(
-                        "No reachable selection indexer peers; starting with empty state"
-                    )
-                }
-                Err(error) if requires_peer_recovery => {
-                    anyhow::bail!("selection indexer recovery failed: {error}");
-                }
-                Err(error) => {
-                    tracing::warn!(%error, "Selection indexer recovery failed; starting with empty state")
-                }
+                Ok(false) => anyhow::bail!(
+                    "no selection indexer peers were reachable during startup recovery"
+                ),
+                Err(error) => anyhow::bail!("selection indexer recovery failed: {error}"),
             }
         }
         core.signal_indexer_ready();

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -29,6 +29,7 @@ pub struct SelectionServiceBuilder {
     kv_router_config: KvRouterConfig,
     indexer_threads: usize,
     indexer_peers: Vec<String>,
+    initial_workers: Vec<WorkerRequest>,
     replica_sync_port: Option<u16>,
     replica_sync_peers: Vec<String>,
     selection_cache: SelectionCacheConfig,
@@ -41,6 +42,7 @@ impl SelectionServiceBuilder {
             kv_router_config,
             indexer_threads: 4,
             indexer_peers: Vec::new(),
+            initial_workers: Vec::new(),
             replica_sync_port: None,
             replica_sync_peers: Vec::new(),
             selection_cache: SelectionCacheConfig::default(),
@@ -55,6 +57,16 @@ impl SelectionServiceBuilder {
 
     pub fn indexer_peers(mut self, indexer_peers: Vec<String>) -> Self {
         self.indexer_peers = indexer_peers;
+        self
+    }
+
+    /// Register workers before peer index recovery begins.
+    ///
+    /// The listener readiness gate remains closed until [`Self::build`] finishes
+    /// recovery, so their SUB sockets can accumulate the peer dump's live tail
+    /// before normal batch application starts.
+    pub fn initial_workers(mut self, initial_workers: Vec<WorkerRequest>) -> Self {
+        self.initial_workers = initial_workers;
         self
     }
 
@@ -122,13 +134,36 @@ impl SelectionServiceBuilder {
             tracking_hash,
         ));
 
+        let requires_peer_recovery =
+            !self.initial_workers.is_empty() && !self.indexer_peers.is_empty();
+        for worker in self.initial_workers {
+            let worker_id = worker.worker_id;
+            let record = core.upsert_worker(worker).await.map_err(|error| {
+                anyhow::anyhow!("registering initial worker {worker_id}: {error}")
+            })?;
+            if record.lifecycle != super::types::WorkerLifecycle::Schedulable {
+                anyhow::bail!(
+                    "initial worker {worker_id} is not schedulable: {:?}",
+                    record.not_schedulable_reasons
+                );
+            }
+        }
+
         if !self.indexer_peers.is_empty() {
             match core.recover_indexer_from_peers(&self.indexer_peers).await {
                 Ok(true) => tracing::info!("Selection indexer recovery completed"),
+                Ok(false) if requires_peer_recovery => {
+                    anyhow::bail!(
+                        "no selection indexer peers were reachable during required startup recovery"
+                    );
+                }
                 Ok(false) => {
                     tracing::warn!(
                         "No reachable selection indexer peers; starting with empty state"
                     )
+                }
+                Err(error) if requires_peer_recovery => {
+                    anyhow::bail!("selection indexer recovery failed: {error}");
                 }
                 Err(error) => {
                     tracing::warn!(%error, "Selection indexer recovery failed; starting with empty state")
@@ -433,6 +468,17 @@ mod tests {
         }
     }
 
+    fn initial_worker(worker_id: WorkerId) -> WorkerRequest {
+        WorkerRequest {
+            worker_id,
+            model_name: "model".to_string(),
+            endpoint: Some(format!("http://worker-{worker_id}:8000")),
+            block_size: Some(4),
+            max_num_batched_tokens: Some(1024),
+            ..Default::default()
+        }
+    }
+
     fn reserve_tcp_port() -> u16 {
         StdTcpListener::bind("127.0.0.1:0")
             .unwrap()
@@ -500,7 +546,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn startup_waits_for_indexer_recovery() {
+    async fn initial_workers_wait_for_indexer_recovery() {
         let gate = RecoveryGate {
             requested: Arc::new(Notify::new()),
             release: Arc::new(Notify::new()),
@@ -515,6 +561,7 @@ mod tests {
         let build = tokio::spawn(
             SelectionServiceBuilder::new(test_config())
                 .indexer_threads(1)
+                .initial_workers(vec![initial_worker(7)])
                 .indexer_peers(vec![peer_url])
                 .build(),
         );
@@ -525,6 +572,7 @@ mod tests {
 
         gate.release.notify_one();
         let service = build.await.unwrap().unwrap();
+        assert_eq!(service.ready().schedulable_workers, 1);
         service.shutdown().await;
         server.abort();
     }


### PR DESCRIPTION
Summary
- Seed `SelectionServiceBuilder` with the initial ready-worker snapshot before peer recovery.
- Resolve Ready, non-terminating sibling EPPs from EndpointSlices; recover their KV-index dump before opening live listener processing.
- Expose peer `/dump` on `selection-http` (9090), then start normal topology and replica-peer watches.
- Fail startup when a nonempty static peer set cannot provide a dump.

Validation
- `cargo test -p dynamo-ext-proc`
- `cargo test -p dynamo-kv-router --features standalone-selection services::selection::service::tests::`
- `cargo check -p dynamo-kv-router`
- `cargo check -p dynamo-ext-proc`

Non-goals
- This intentionally uses the existing Indexer listener gate and libzmq receive queue for the initial tail. It does not add a publisher-confirmed subscription barrier, explicit capture queue/limits, or configurable subscribe grace; those remain follow-up work.