### PR TITLE
fix(sglang): skip tag reasoning when the backend gates grammar

### DIFF
--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -70,9 +70,7 @@ def publish_sglang_structural_tag_reasoning_policy(
     detect the boundary, and an engine whose ``async_generate`` predates the
     argument silently drops the gate (see ``_compat.require_reasoning_kwargs``).
     """
-    supported = engine is not None and bool(
-        getattr(server_args, "reasoning_parser", None)
-    )
+    supported = engine is not None and bool(server_args.reasoning_parser)
     if supported:
         supported = "require_reasoning" in filter_supported_async_generate_kwargs(
             engine, {"require_reasoning": True}

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -30,7 +30,10 @@ from dynamo.llm import (
     WorkerType,
     register_model,
 )
-from dynamo.sglang._compat import sglang_uses_mla_backend
+from dynamo.sglang._compat import (
+    filter_supported_async_generate_kwargs,
+    sglang_uses_mla_backend,
+)
 from dynamo.sglang._disagg import SGLANG_WORKER_GROUP_ID_KEY, get_sglang_worker_group_id
 from dynamo.sglang.args import DynamoConfig, use_modelexpress_remote_instance
 from dynamo.sglang.capacity import (
@@ -44,6 +47,40 @@ from dynamo.sglang.engine_generate import SGLANG_GENERATE_CAPABILITY
 
 SGLANG_HICACHE_MOONCAKE_RUNTIME_KEY = "sglang_hicache_mooncake"
 SPEC_DECODE_RUNTIME_KEY = "spec_decode"
+TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_WHEN_REQUIRED_RUNTIME_KEY = (
+    "tool_call_structural_tag_excludes_reasoning_when_required"
+)
+
+
+def publish_sglang_structural_tag_reasoning_policy(
+    runtime_config: ModelRuntimeConfig,
+    engine: Optional[sgl.Engine],
+    server_args: ServerArgs,
+) -> None:
+    """Tell the frontend that SGLang gates the tool grammar on require_reasoning.
+
+    SGLang holds the tool grammar back until its engine-side reasoning parser
+    sees the end of reasoning, but only for requests Dynamo marks with
+    ``require_reasoning``. On those requests the frontend's structural tag must
+    not model the reasoning block again; otherwise the model has to close
+    reasoning twice before it may emit a call and the turn runs out of tokens
+    as plain text.
+
+    Both conditions are required: without ``--reasoning-parser`` SGLang cannot
+    detect the boundary, and an engine whose ``async_generate`` predates the
+    argument silently drops the gate (see ``_compat.require_reasoning_kwargs``).
+    """
+    supported = engine is not None and bool(
+        getattr(server_args, "reasoning_parser", None)
+    )
+    if supported:
+        supported = "require_reasoning" in filter_supported_async_generate_kwargs(
+            engine, {"require_reasoning": True}
+        )
+    runtime_config.set_engine_specific(
+        TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_WHEN_REQUIRED_RUNTIME_KEY,
+        json.dumps(supported),
+    )
 
 
 def _supports_engine_generate(
@@ -421,6 +458,7 @@ async def get_runtime_config(
     )
     runtime_config.set_structural_tag_scope(dynamo_args.dyn_structural_tag_scope)
     runtime_config.set_structural_tag_schema(dynamo_args.dyn_structural_tag_schema)
+    publish_sglang_structural_tag_reasoning_policy(runtime_config, engine, server_args)
     # Decode workers don't create the WorkerKvQuery endpoint, so don't advertise local indexer
     is_decode_worker = server_args.disaggregation_mode == "decode"
     runtime_config.enable_local_indexer = (

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -3,12 +3,14 @@
 
 """Unit tests for SGLang backend components."""
 
+import json
 import logging
 import os
 import re
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -598,6 +600,47 @@ def test_require_reasoning_kwarg_silently_drops_false(caplog):
         assert require_reasoning_kwargs(OldEngine(), {"require_reasoning": False}) == {}
 
     assert "Dropping require_reasoning=true" not in caplog.text
+
+
+class _ReasoningGateEngine:
+    async def async_generate(self, require_reasoning=False):
+        return None
+
+
+class _LegacyEngine:
+    async def async_generate(self, input_ids=None, sampling_params=None):
+        return None
+
+
+@pytest.mark.parametrize(
+    ("engine", "reasoning_parser", "expected"),
+    [
+        (_ReasoningGateEngine(), "kimi_k2", True),
+        # No engine-side parser: SGLang cannot find the reasoning boundary.
+        (_ReasoningGateEngine(), None, False),
+        # Engine predates the gate, so require_reasoning is dropped silently.
+        (_LegacyEngine(), "kimi_k2", False),
+        # Multimodal encode workers register without an engine.
+        (None, "kimi_k2", False),
+    ],
+)
+def test_sglang_publishes_structural_tag_reasoning_policy(
+    engine, reasoning_parser, expected
+):
+    if sglang_register is None:
+        pytest.skip("dynamo.sglang.register is unavailable")
+
+    runtime_config = SimpleNamespace(set_engine_specific=Mock())
+    server_args = SimpleNamespace(reasoning_parser=reasoning_parser)
+
+    sglang_register.publish_sglang_structural_tag_reasoning_policy(
+        runtime_config, engine, server_args
+    )
+
+    runtime_config.set_engine_specific.assert_called_once_with(
+        sglang_register.TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_WHEN_REQUIRED_RUNTIME_KEY,
+        json.dumps(expected),
+    )
 
 
 def test_routed_experts_kwarg_omitted_when_flag_off():

--- a/lib/llm/src/discovery.rs
+++ b/lib/llm/src/discovery.rs
@@ -30,7 +30,7 @@ mod worker_set;
 pub use worker_set::WorkerSet;
 
 pub(crate) mod runtime_configs;
-pub use runtime_configs::{RuntimeConfigWatch, runtime_config_watch};
+pub use runtime_configs::{RuntimeConfigWatch, all_workers_advertise, runtime_config_watch};
 
 mod endpoint_card;
 pub use endpoint_card::wait_for_endpoint_model_card;

--- a/lib/llm/src/discovery/runtime_configs.rs
+++ b/lib/llm/src/discovery/runtime_configs.rs
@@ -191,6 +191,37 @@ pub async fn runtime_config_watch(
     Ok(rx)
 }
 
+/// True when every worker currently serving the model advertises boolean
+/// capability `key` in its `runtime_data`.
+///
+/// Capabilities arrive per worker, but a decision that shapes a request before
+/// it is routed applies to whichever worker the router later picks. Such a
+/// capability is therefore only usable once the whole fleet reports it: during
+/// an N/N-1 rollout an upgraded worker's `true` must not shape a request that a
+/// not-yet-upgraded worker will serve, and a retired worker's absent key must
+/// not keep the capability off once every live worker has it.
+///
+/// An empty fleet answers `false`, which is the compatibility behavior for
+/// every caller: absent metadata means "assume the old shape".
+pub fn all_workers_advertise(configs: &HashMap<WorkerId, ModelRuntimeConfig>, key: &str) -> bool {
+    !configs.is_empty()
+        && configs.iter().all(
+            |(worker_id, config)| match config.get_engine_specific::<bool>(key) {
+                Ok(Some(advertised)) => advertised,
+                Ok(None) => false,
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        key,
+                        worker_id,
+                        "Ignoring invalid worker capability metadata; treating it as unsupported"
+                    );
+                    false
+                }
+            },
+        )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -28,7 +28,7 @@ use dynamo_renderer::PromptFormatter;
 
 use crate::{
     backend::Backend,
-    discovery::{LoadThresholdHandle, WORKER_TYPE_DECODE, WorkerSet},
+    discovery::{LoadThresholdHandle, WORKER_TYPE_DECODE, WorkerSet, runtime_config_watch},
     entrypoint::{self, ChatEngineFactoryCallback, RouterConfig},
     http::service::metrics::Metrics,
     kv_router::{
@@ -682,6 +682,28 @@ where
                 None
             };
 
+            // Capabilities that shape a request before it is routed cannot be
+            // read off the representative card: `runtime_config` is excluded
+            // from `mdcsum`, so workers advertising different `runtime_data`
+            // still share one cohort and one representative. Hand the
+            // preprocessor the live per-worker view instead, so those reads can
+            // require the whole fleet. Scoped to this WorkerSet's lifecycle;
+            // see `base_runtime_config_watch`'s note on quiescent endpoints.
+            let worker_runtime_configs = if needs_preprocessed_routing {
+                match runtime_config_watch(&endpoint, cancellation.child_token()).await {
+                    Ok(watch) => Some(watch),
+                    Err(error) => {
+                        tracing::warn!(
+                            %error,
+                            "Falling back to the representative card for pre-routing capabilities"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
             // Add chat engine only if the model supports chat
             if card.model_type.supports_chat() {
                 let routing = preprocessed_routing.as_ref().ok_or_else(|| {
@@ -704,9 +726,13 @@ where
                 } else if let Some(tk) = tokenizer.clone() {
                     let PromptFormatter::OAI(formatter) =
                         prompt_formatter_from_mdc(card).context("prompt_formatter_from_mdc")?;
-                    let preprocessor =
-                        OpenAIPreprocessor::new_with_parts(card.clone(), formatter, tk.clone())
-                            .context("OpenAIPreprocessor.new_with_parts")?;
+                    let preprocessor = OpenAIPreprocessor::new_with_parts_and_worker_configs(
+                        card.clone(),
+                        formatter,
+                        tk.clone(),
+                        worker_runtime_configs.clone(),
+                    )
+                    .context("OpenAIPreprocessor.new_with_parts_and_worker_configs")?;
                     Some(
                         routing
                             .build_pipeline::<
@@ -746,9 +772,13 @@ where
                 if let Some(tk) = tokenizer {
                     let formatter = PromptFormatter::no_op();
                     let PromptFormatter::OAI(formatter) = formatter;
-                    let preprocessor =
-                        OpenAIPreprocessor::new_with_parts(card.clone(), formatter, tk.clone())
-                            .context("OpenAIPreprocessor::new_with_parts")?;
+                    let preprocessor = OpenAIPreprocessor::new_with_parts_and_worker_configs(
+                        card.clone(),
+                        formatter,
+                        tk.clone(),
+                        worker_runtime_configs.clone(),
+                    )
+                    .context("OpenAIPreprocessor::new_with_parts_and_worker_configs")?;
                     let routing = preprocessed_routing.as_ref().ok_or_else(|| {
                         anyhow::anyhow!("completions pipeline requires preprocessed routing")
                     })?;

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -44,6 +44,16 @@ pub(crate) const MAX_DATA_PARALLEL_RANKS_PER_WORKER: u32 = 4096;
 pub const TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY: &str =
     "tool_call_structural_tag_excludes_reasoning";
 
+/// Runtime-data key indicating that a backend defers tool-grammar activation
+/// until reasoning completes, but only for requests that carry
+/// `require_reasoning`. SGLang publishes this: its grammar backend takes the
+/// reasoning gate per request, so the frontend must drop the reasoning section
+/// from the structural tag on exactly those requests and keep it otherwise.
+///
+/// Absence means `false`, which leaves the compatibility behavior in place.
+pub const TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_WHEN_REQUIRED_RUNTIME_KEY: &str =
+    "tool_call_structural_tag_excludes_reasoning_when_required";
+
 /// Describes which request-token overflows the frontend may reject early.
 ///
 /// The combined limit already accounts for engine-reserved tokens. A false

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1556,6 +1556,16 @@ pub struct OpenAIPreprocessor {
     lora_name: Option<String>,
     /// Per-model runtime configuration propagated to response generator (e.g., reasoning/tool parser)
     runtime_config: crate::local_model::runtime_config::ModelRuntimeConfig,
+    /// Live per-worker view of `runtime_data` for this model, when it is served
+    /// by discovered workers.
+    ///
+    /// `runtime_config` above is one representative worker's card, and
+    /// `runtime_config` does not participate in `mdcsum`, so a fleet running two
+    /// versions shares a single WorkerSet and a single representative. A
+    /// capability read that shapes a request *before* it is routed must
+    /// therefore consult the whole fleet, not the representative. `None` for
+    /// local and static engines, which are single-worker by construction.
+    worker_runtime_configs: Option<crate::discovery::RuntimeConfigWatch>,
     /// KV cache block size published in the model deployment card.
     kv_cache_block_size: usize,
     tool_call_parser: Option<String>,
@@ -2238,7 +2248,7 @@ impl OpenAIPreprocessor {
         let tokenizer = mdc.tokenizer()?;
         let PromptFormatter::OAI(formatter) = embedding_prompt_formatter(&mdc)?;
         let embedding_tokenizers = EmbeddingTokenizerState::new(&mdc)?;
-        Self::new_with_parts_inner(mdc, formatter, tokenizer, Some(embedding_tokenizers))
+        Self::new_with_parts_inner(mdc, formatter, tokenizer, Some(embedding_tokenizers), None)
     }
 
     pub fn new_with_parts(
@@ -2246,7 +2256,18 @@ impl OpenAIPreprocessor {
         formatter: Arc<dyn OAIPromptFormatter>,
         tokenizer: crate::tokenizers::Tokenizer,
     ) -> Result<Arc<Self>> {
-        Self::new_with_parts_inner(mdc, formatter, tokenizer, None)
+        Self::new_with_parts_inner(mdc, formatter, tokenizer, None, None)
+    }
+
+    /// As `new_with_parts`, with the live per-worker `runtime_data` view that
+    /// pre-routing capability reads consult. See `worker_runtime_configs`.
+    pub fn new_with_parts_and_worker_configs(
+        mdc: ModelDeploymentCard,
+        formatter: Arc<dyn OAIPromptFormatter>,
+        tokenizer: crate::tokenizers::Tokenizer,
+        worker_runtime_configs: Option<crate::discovery::RuntimeConfigWatch>,
+    ) -> Result<Arc<Self>> {
+        Self::new_with_parts_inner(mdc, formatter, tokenizer, None, worker_runtime_configs)
     }
 
     fn new_with_parts_inner(
@@ -2254,6 +2275,7 @@ impl OpenAIPreprocessor {
         formatter: Arc<dyn OAIPromptFormatter>,
         tokenizer: crate::tokenizers::Tokenizer,
         embedding_tokenizers: Option<EmbeddingTokenizerState>,
+        worker_runtime_configs: Option<crate::discovery::RuntimeConfigWatch>,
     ) -> Result<Arc<Self>> {
         let mdcsum = mdc.mdcsum().to_string();
         let tokenizer: Arc<dyn Tokenizer> = (*tokenizer).clone();
@@ -2556,6 +2578,7 @@ impl OpenAIPreprocessor {
             mdcsum,
             lora_name,
             runtime_config,
+            worker_runtime_configs,
             kv_cache_block_size,
             tool_call_parser,
             normalize_tool_call_args,

--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -5,6 +5,7 @@
 
 use crate::local_model::runtime_config::{
     StructuralTagMode, StructuralTagScope, TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY,
+    TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_WHEN_REQUIRED_RUNTIME_KEY,
 };
 use crate::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
 use crate::protocols::openai::tools::{ToolChoiceValidation, validate_tool_choice_against_names};
@@ -194,23 +195,36 @@ impl OpenAIPreprocessor {
             parallel_tool_calls,
             schema_mode: self.runtime_config.structural_tag_schema,
             starts_in_reasoning: prompt_injected_reasoning
-                && !self.tool_call_structural_tag_excludes_reasoning(),
+                && !self.tool_call_structural_tag_excludes_reasoning(
+                    preprocessed_request.require_reasoning,
+                ),
         };
 
         Self::apply_tool_call_format(parser_name, builder, &ctx, preprocessed_request)
     }
 
-    fn tool_call_structural_tag_excludes_reasoning(&self) -> bool {
-        match self
-            .runtime_config
-            .get_engine_specific::<bool>(TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY)
-        {
+    /// Whether the tool structural tag must leave the reasoning block to the
+    /// backend. A backend either defers grammar activation for every request,
+    /// or only for the requests the frontend gates with `require_reasoning`.
+    /// Sending both the gate and a tag that opens with a reasoning section makes
+    /// the model close reasoning twice before it can emit a call, which burns
+    /// the token budget instead of producing tool calls.
+    fn tool_call_structural_tag_excludes_reasoning(&self, require_reasoning: bool) -> bool {
+        self.structural_tag_reasoning_flag(TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY)
+            || (require_reasoning
+                && self.structural_tag_reasoning_flag(
+                    TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_WHEN_REQUIRED_RUNTIME_KEY,
+                ))
+    }
+
+    fn structural_tag_reasoning_flag(&self, key: &str) -> bool {
+        match self.runtime_config.get_engine_specific::<bool>(key) {
             Ok(Some(excludes_reasoning)) => excludes_reasoning,
             Ok(None) => false,
             Err(error) => {
                 tracing::warn!(
                     %error,
-                    key = TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY,
+                    key,
                     "Ignoring invalid structural-tag reasoning metadata; using the compatibility behavior"
                 );
                 false
@@ -349,7 +363,10 @@ mod tests {
             .unwrap()
     }
 
-    fn kimi_k2_preprocessor(excludes_reasoning: Option<bool>) -> Arc<OpenAIPreprocessor> {
+    fn kimi_k2_preprocessor_with(
+        key: &str,
+        excludes_reasoning: Option<bool>,
+    ) -> Arc<OpenAIPreprocessor> {
         let model_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/data/sample-models/mock-llama-3.1-8b-instruct");
         let mut mdc = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
@@ -357,10 +374,7 @@ mod tests {
         mdc.runtime_config.tool_call_parser = Some("kimi_k2".to_string());
         if let Some(excludes_reasoning) = excludes_reasoning {
             mdc.runtime_config
-                .set_engine_specific(
-                    TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY,
-                    excludes_reasoning,
-                )
+                .set_engine_specific(key, excludes_reasoning)
                 .unwrap();
         }
 
@@ -377,13 +391,26 @@ mod tests {
     }
 
     fn kimi_k2_required_format(excludes_reasoning: Option<bool>) -> serde_json::Value {
-        let preprocessor = kimi_k2_preprocessor(excludes_reasoning);
+        kimi_k2_required_format_with(
+            TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY,
+            excludes_reasoning,
+            false,
+        )
+    }
+
+    fn kimi_k2_required_format_with(
+        key: &str,
+        excludes_reasoning: Option<bool>,
+        require_reasoning: bool,
+    ) -> serde_json::Value {
+        let preprocessor = kimi_k2_preprocessor_with(key, excludes_reasoning);
         let tools = [ToolDefinition {
             name: "get_weather".to_string(),
             parameters: None,
             strict: None,
         }];
         let mut request = preprocessed_request();
+        request.require_reasoning = require_reasoning;
 
         assert!(
             preprocessor
@@ -422,6 +449,50 @@ mod tests {
             format["elements"][0]["value"],
             "<|tool_calls_section_begin|>"
         );
+    }
+
+    #[test]
+    fn request_gated_reasoning_metadata_follows_require_reasoning() {
+        // SGLang takes the reasoning gate per request, so the tag drops its
+        // reasoning section only on the requests that carry the gate.
+        let format = kimi_k2_required_format_with(
+            TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_WHEN_REQUIRED_RUNTIME_KEY,
+            Some(true),
+            true,
+        );
+        assert_eq!(format["elements"][0]["type"], "const_string");
+        assert_eq!(
+            format["elements"][0]["value"],
+            "<|tool_calls_section_begin|>"
+        );
+
+        // Without the gate the backend enforces the grammar from the first
+        // token, so the tag must still model the open reasoning block.
+        let format = kimi_k2_required_format_with(
+            TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_WHEN_REQUIRED_RUNTIME_KEY,
+            Some(true),
+            false,
+        );
+        assert_eq!(format["elements"][0]["type"], "tag");
+        assert_eq!(format["elements"][0]["end"], "</think>");
+
+        // A backend that never advertises the capability keeps the
+        // compatibility behavior even when the gate is requested.
+        let format = kimi_k2_required_format_with(
+            TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_WHEN_REQUIRED_RUNTIME_KEY,
+            None,
+            true,
+        );
+        assert_eq!(format["elements"][0]["type"], "tag");
+        assert_eq!(format["elements"][0]["end"], "</think>");
+
+        // The unconditional capability stays independent of the gate.
+        let format = kimi_k2_required_format_with(
+            TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY,
+            Some(true),
+            false,
+        );
+        assert_eq!(format["elements"][0]["type"], "const_string");
     }
 
     #[test]

--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -217,7 +217,21 @@ impl OpenAIPreprocessor {
                 ))
     }
 
+    /// Read a structural-tag capability.
+    ///
+    /// The tag is chosen before the request is routed, so the answer has to
+    /// hold for whichever worker ends up serving it. When a live per-worker
+    /// view exists, the capability counts only if every worker advertises it:
+    /// an upgraded worker alone must not strip the reasoning section from a
+    /// request a not-yet-upgraded worker will serve, which is the mixed-version
+    /// direction, and a stale worker must not keep the old shape once the
+    /// rollout finishes, which is the other one. Absent that view (local and
+    /// static engines) the model has exactly one worker and its card is the
+    /// fleet.
     fn structural_tag_reasoning_flag(&self, key: &str) -> bool {
+        if let Some(worker_configs) = self.worker_runtime_configs.as_ref() {
+            return crate::discovery::all_workers_advertise(&worker_configs.borrow(), key);
+        }
         match self.runtime_config.get_engine_specific::<bool>(key) {
             Ok(Some(excludes_reasoning)) => excludes_reasoning,
             Ok(None) => false,
@@ -363,6 +377,13 @@ mod tests {
             .unwrap()
     }
 
+    fn kimi_k2_preprocessor(excludes_reasoning: Option<bool>) -> Arc<OpenAIPreprocessor> {
+        kimi_k2_preprocessor_with(
+            TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY,
+            excludes_reasoning,
+        )
+    }
+
     fn kimi_k2_preprocessor_with(
         key: &str,
         excludes_reasoning: Option<bool>,
@@ -448,6 +469,190 @@ mod tests {
         assert_eq!(
             format["elements"][0]["value"],
             "<|tool_calls_section_begin|>"
+        );
+    }
+
+    /// Build a kimi_k2 preprocessor whose capability answer comes from a live
+    /// per-worker view rather than from its own card.
+    ///
+    /// `card_says` is written onto the representative card so a test can prove
+    /// which of the two the request path actually reads.
+    fn kimi_k2_preprocessor_with_fleet(
+        key: &str,
+        card_says: Option<bool>,
+        fleet: &[Option<bool>],
+    ) -> (
+        Arc<OpenAIPreprocessor>,
+        tokio::sync::watch::Sender<
+            std::collections::HashMap<
+                dynamo_kv_router::protocols::WorkerId,
+                crate::local_model::runtime_config::ModelRuntimeConfig,
+            >,
+        >,
+    ) {
+        let model_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/sample-models/mock-llama-3.1-8b-instruct");
+        let mut mdc = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
+        mdc.runtime_config.structural_tag_mode = StructuralTagMode::On;
+        mdc.runtime_config.tool_call_parser = Some("kimi_k2".to_string());
+        if let Some(card_says) = card_says {
+            mdc.runtime_config
+                .set_engine_specific(key, card_says)
+                .unwrap();
+        }
+
+        let (tx, rx) = tokio::sync::watch::channel(worker_configs(key, fleet));
+        let crate::preprocessor::PromptFormatter::OAI(formatter) =
+            crate::preprocessor::prompt::prompt_formatter_from_mdc(&mdc).unwrap();
+        let tokenizer = mdc.tokenizer().unwrap();
+        let preprocessor = OpenAIPreprocessor::new_with_parts_and_worker_configs(
+            mdc,
+            formatter,
+            tokenizer,
+            Some(rx),
+        )
+        .unwrap();
+        (preprocessor, tx)
+    }
+
+    /// One entry per worker: `Some(v)` publishes `key = v`, `None` is a worker
+    /// that predates the capability and publishes nothing.
+    fn worker_configs(
+        key: &str,
+        fleet: &[Option<bool>],
+    ) -> std::collections::HashMap<
+        dynamo_kv_router::protocols::WorkerId,
+        crate::local_model::runtime_config::ModelRuntimeConfig,
+    > {
+        fleet
+            .iter()
+            .enumerate()
+            .map(|(index, advertises)| {
+                let mut config = crate::local_model::runtime_config::ModelRuntimeConfig::default();
+                if let Some(advertises) = advertises {
+                    config.set_engine_specific(key, *advertises).unwrap();
+                }
+                (index as dynamo_kv_router::protocols::WorkerId, config)
+            })
+            .collect()
+    }
+
+    fn required_format(preprocessor: &Arc<OpenAIPreprocessor>) -> serde_json::Value {
+        let tools = [ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: None,
+            strict: None,
+        }];
+        let mut request = preprocessed_request();
+        request.require_reasoning = true;
+
+        assert!(
+            preprocessor
+                .apply_tool_choice_structural_tag(
+                    &ToolChoice::Required,
+                    &tools,
+                    None,
+                    true,
+                    &mut request,
+                )
+                .unwrap()
+        );
+
+        request
+            .sampling_options
+            .guided_decoding
+            .unwrap()
+            .structural_tag
+            .unwrap()["format"]
+            .clone()
+    }
+
+    fn assert_models_reasoning(format: &serde_json::Value, why: &str) {
+        assert_eq!(format["elements"][0]["type"], "tag", "{why}");
+        assert_eq!(format["elements"][0]["end"], "</think>", "{why}");
+    }
+
+    fn assert_omits_reasoning(format: &serde_json::Value, why: &str) {
+        assert_eq!(format["elements"][0]["type"], "const_string", "{why}");
+        assert_eq!(
+            format["elements"][0]["value"], "<|tool_calls_section_begin|>",
+            "{why}"
+        );
+    }
+
+    /// Regression for the N/N-1 rollout hazard: the structural tag is chosen
+    /// before the request is routed, and `runtime_config` is excluded from
+    /// `mdcsum`, so workers publishing different `runtime_data` still share one
+    /// WorkerSet and one representative card. Shaping requests off that card
+    /// sends a reasoning-stripped tag to a worker that never got the
+    /// `require_reasoning` gate, which is unfollowable for it.
+    #[test]
+    fn mixed_version_fleet_keeps_the_compatibility_tag() {
+        let key = TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_WHEN_REQUIRED_RUNTIME_KEY;
+
+        // One upgraded worker, one that predates the capability.
+        let (preprocessor, tx) = kimi_k2_preprocessor_with_fleet(key, None, &[Some(true), None]);
+        assert_models_reasoning(
+            &required_format(&preprocessor),
+            "a worker without the capability must still be able to follow the tag",
+        );
+
+        // Rollout finishes: the last old worker is replaced.
+        tx.send(worker_configs(key, &[Some(true), Some(true)]))
+            .unwrap();
+        assert_omits_reasoning(
+            &required_format(&preprocessor),
+            "a fully upgraded fleet should get the fix",
+        );
+
+        // An old worker rejoins (rollback, or a straggler restarting).
+        tx.send(worker_configs(key, &[Some(true), None])).unwrap();
+        assert_models_reasoning(
+            &required_format(&preprocessor),
+            "the capability must switch back off when a worker without it returns",
+        );
+
+        // A worker that publishes the key as false is not support either.
+        tx.send(worker_configs(key, &[Some(true), Some(false)]))
+            .unwrap();
+        assert_models_reasoning(
+            &required_format(&preprocessor),
+            "an explicit false must count against the fleet",
+        );
+    }
+
+    /// No workers means nothing is known, which is the compatibility answer,
+    /// not an all-of-empty-set `true`.
+    #[test]
+    fn empty_fleet_keeps_the_compatibility_tag() {
+        let key = TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_WHEN_REQUIRED_RUNTIME_KEY;
+        let (preprocessor, _tx) = kimi_k2_preprocessor_with_fleet(key, None, &[]);
+        assert_models_reasoning(
+            &required_format(&preprocessor),
+            "an empty fleet advertises nothing",
+        );
+    }
+
+    /// The representative card is one worker's view. When a fleet view exists
+    /// it is the authority, in both directions.
+    #[test]
+    fn fleet_view_overrides_the_representative_card() {
+        let key = TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_WHEN_REQUIRED_RUNTIME_KEY;
+
+        // Representative advertises, fleet does not agree.
+        let (preprocessor, _tx) =
+            kimi_k2_preprocessor_with_fleet(key, Some(true), &[Some(true), None]);
+        assert_models_reasoning(
+            &required_format(&preprocessor),
+            "the representative card must not speak for a worker that lacks the capability",
+        );
+
+        // Representative is the stale one; every live worker has the capability.
+        let (preprocessor, _tx) =
+            kimi_k2_preprocessor_with_fleet(key, None, &[Some(true), Some(true)]);
+        assert_omits_reasoning(
+            &required_format(&preprocessor),
+            "a fully upgraded fleet should get the fix even if the card is stale",
         );
     }
 


### PR DESCRIPTION
# Issue #13240 — SGLang reasoning-enabled forced tool calls intermittently fail

## 1. Root cause

Two reasoning constraints are applied to the same request, and they contradict each other.

For a forced tool call (`tool_choice="required"` or a named tool) the Rust frontend does
two independent things:

1. `OpenAIPreprocessor::guided_output_requires_reasoning` (`lib/llm/src/preprocessor.rs`)
   sets `PreprocessedRequest::require_reasoning = true` whenever a reasoning parser is
   configured and reasoning is effectively enabled for the request. The SGLang worker
   forwards that to `Engine.async_generate(require_reasoning=True)`
   (`components/src/dynamo/sglang/_compat.py`), which tells SGLang's grammar backend to
   hold the tool grammar back until its engine-side reasoning parser sees the end of
   reasoning.

2. `OpenAIPreprocessor::apply_tool_choice_structural_tag`
   (`lib/llm/src/preprocessor/structural_tag.rs`) builds the Kimi-K2 structural tag with
   `starts_in_reasoning = prompt_injected_reasoning && !tool_call_structural_tag_excludes_reasoning()`.
   With the prompt ending in `<think>`, the tag's first element is a `tag` element that
   ends at `</think>` — i.e. the tag itself models a reasoning block.

`tool_call_structural_tag_excludes_reasoning()` reads the
`tool_call_structural_tag_excludes_reasoning` runtime-data key, which **only the vLLM
worker ever publishes** (`components/src/dynamo/vllm/main.py`). The SGLang worker never
published anything, so the key was absent, so it defaulted to `false`, so
`starts_in_reasoning` stayed `true`.

The result on the wire: SGLang activates the grammar *after* reasoning ends, and the
grammar it then activates begins by demanding another reasoning block terminated by
`</think>`. The model has to finish reasoning twice before it is allowed to emit
`<|tool_calls_section_begin|>`. Sometimes it converges and the call comes out; often it
does not, and the turn degrades into plain assistant text until the token budget is
exhausted — matching the reported 16/20 pass rate with reasoning on and 20/20 with
reasoning off.

The vLLM capability could not simply be reused, because the two backends gate
differently: vLLM's deferral is a *deployment* property (engine reasoning parser present
and `enable_in_reasoning=False`, so it always defers), while SGLang's is a *per-request*
property (it defers only for requests carrying `require_reasoning`). Publishing the
existing key from SGLang would break the reverse case — a request where the prompt opens
a reasoning block but `require_reasoning` is not set, where SGLang enforces the grammar
from the first token and the tag *must* model reasoning.

## 2. The fix

A second runtime-data key,
`tool_call_structural_tag_excludes_reasoning_when_required`, for the request-gated shape:

- **`lib/llm/src/local_model/runtime_config.rs`** — declare
  `TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_WHEN_REQUIRED_RUNTIME_KEY`. Absence means
  `false`, i.e. today's compatibility behavior.
- **`lib/llm/src/preprocessor/structural_tag.rs`** — the tag now omits the reasoning
  section when the unconditional capability is advertised (unchanged, vLLM) **or** when
  the request-gated capability is advertised *and* this request carries
  `require_reasoning`. The key lookup and its warn-on-garbage handling were factored into
  `structural_tag_reasoning_flag` so both keys read the same way.
- **`components/src/dynamo/sglang/register.py`** — publish the new key at registration.
  It is `true` only when both halves of SGLang's gate are actually present: an
  engine-side `--reasoning-parser` (without it SGLang cannot locate the boundary) and an
  `Engine.async_generate` that accepts `require_reasoning` (older engines drop the kwarg
  silently — see `_compat.require_reasoning_kwargs`). Encode-only workers register with
  `engine=None` and publish `false`.

This is the capability-announcement design the issue asks for, expressed with the
mechanism the repo already has, and it preserves the vLLM contract exactly.

## 3. Files changed

| File | Change |
|------|--------|
| `lib/llm/src/local_model/runtime_config.rs` | New runtime-data key constant + docs |
| `lib/llm/src/preprocessor/structural_tag.rs` | Request-gated exclusion + shared flag reader; new unit test |
| `components/src/dynamo/sglang/register.py` | `publish_sglang_structural_tag_reasoning_policy` and its call site |
| `components/src/dynamo/sglang/tests/test_sglang_unit.py` | Unit test for the publisher's four cases |

## 4. Risk and uncertainty

- **Rolling upgrades (N-2).** Additive and fail-safe in both directions: an older
  frontend ignores an unknown `runtime_data` key; a newer frontend paired with an older
  SGLang worker sees the key absent, reads `false`, and keeps exactly today's behavior
  (bug unfixed, nothing regressed).
- **vLLM is untouched.** The unconditional key is still checked first and is not ANDed
  with `require_reasoning`. This matters: vLLM's engine-side `--reasoning-parser` and
  Dynamo's `--dyn-reasoning-parser` are independent flags, so a vLLM deployment can
  legitimately advertise the capability while `require_reasoning` is `false`. A test
  asserts that independence.
- **Blast radius.** Only requests that reach `apply_tool_choice_structural_tag` with
  `prompt_injected_reasoning=true` change behavior, i.e. forced tool choice on a
  structural-tag-capable parser (in practice Kimi K2 required/named) with reasoning
  active. Everything else takes an identical path.
- **Unverified on hardware.** I could not run Kimi-K2.6-NVFP4 on SGLang here, so the
  end-to-end claim rests on the wire-level reasoning above plus the unit tests. The
  reported symptom (`finish_reason="length"`, plain text instead of calls, only with
  reasoning enabled) is what a doubly-required reasoning block produces, and the issue's
  own analysis names the same mechanism.
- **SGLang gate assumption.** I assume SGLang's `require_reasoning` needs
  `--reasoning-parser` to find the boundary — the repro config sets both, and the
  publisher requires both, so the conservative direction of that assumption is to publish
  `false` and leave behavior unchanged.

## 5. Verification

Rust (protoc from `~/bin` on PATH):

```
cargo test -p dynamo-llm --lib preprocessor::structural_tag
    8 passed; 0 failed   (incl. the new request_gated_reasoning_metadata_follows_require_reasoning)

cargo test -p dynamo-llm --lib preprocessor
    132 passed; 0 failed

cargo clippy -p dynamo-llm --lib --all-targets     # no errors, no new warnings
cargo fmt --all -- --check                         # clean
```

The new Rust test pins all four combinations: gated capability + `require_reasoning`
→ tag starts at `<|tool_calls_section_begin|>`; gated capability without the flag → tag
still opens with the `</think>` tag element; capability absent + flag set → unchanged;
unconditional capability → independent of the flag.

Python:

```
python3 -m py_compile components/src/dynamo/sglang/register.py \
                      components/src/dynamo/sglang/tests/test_sglang_unit.py
python3 -m ruff check <both files>        # All checks passed
python3 -m ruff format --check register.py  # clean
```

`pytest` for `test_sglang_unit.py` could not run here — the module imports `sglang`,
which is not installed in this environment (the file is GPU-image-gated). The new test
follows the existing `sglang_register is None → skip` convention and mirrors the shape of
`test_vllm_publishes_structural_tag_reasoning_policy`. `ruff format --check` also reports
a pre-existing reformat on `test_sglang_unit.py` (present at `HEAD`, from a ruff version
skew); I left it alone rather than mixing unrelated churn into this diff.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved structural-tag handling for tool calls when reasoning is required.
  * Added runtime capability detection for engines that conditionally exclude reasoning content.
  * Added compatibility filtering for unsupported generation arguments.

* **Bug Fixes**
  * Structural tags now correctly honor both unconditional and request-specific reasoning exclusion settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->