### PR TITLE
fix(container): drop the Nsight efa_metrics plugin from the shipped images

### DIFF
--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -228,6 +228,18 @@ RUN set -eux; \
     ldconfig
 {% endif %}
 
+# Drop the Nsight efa_metrics plugin the CUDA floor carries: a Go NIC sampler
+# nothing in the serving path loads. On this image it arrives under Nsight
+# Compute rather than Nsight Systems, and both roots move with every base bump,
+# so the paths are globbed and the removal is asserted rather than pinned. This
+# stage has no overlay rebase -- `runtime` is FROM pre_runtime -- so one
+# deletion here ships.
+RUN rm -rf \
+        /usr/local/cuda-*/NsightSystems-cli-*/target-linux-*/plugins/efa_metrics \
+        /opt/nvidia/nsight-systems-cli/*/target-linux-*/plugins/efa_metrics \
+        /opt/nvidia/nsight-compute/*/host/target-linux-*/plugins/efa_metrics && \
+    [ -z "$(find /usr/local /opt -xdev -type d -name efa_metrics 2>/dev/null)" ]
+
 {% if device == "cuda" %}
 # Copy the in-tree VP9 ffmpeg from wheel_builder: versioned shared libs
 # (libav*.so*, libsw*.so*) + libvpx + the in-tree CLI binary that imageio targets

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -59,7 +59,10 @@ WORKDIR /workspace
 # for shells, not K8s python3 launches), swap upstream's standalone etcd
 # tooling (etcd, etcdctl, etcdutl) for dynamo_base's directory so the image
 # carries a single copy of each tool, drop the unused wandb developer tooling
-# the DLFW base carries (upstream removes it on main, Dockerfile.multi), and
+# the DLFW base carries (upstream removes it on main, Dockerfile.multi), drop
+# the Nsight efa_metrics plugin (a Go NIC sampler nothing in the serving path
+# loads; the CUDA and Nsight versions in its path move with every base bump, so
+# the paths are globbed and the removal is asserted rather than pinned), and
 # symlink system libstdc++ to a stable
 # path for LD_PRELOAD — keeps PyInstaller-bundled tools (specifically `jet`,
 # NVIDIA's internal PyInstaller-packaged CI runner) from shadowing it with an
@@ -86,6 +89,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         /usr/local/bin/etcd \
         /usr/local/bin/etcdctl \
         /usr/local/bin/etcdutl && \
+    rm -rf \
+        /usr/local/cuda-*/NsightSystems-cli-*/target-linux-*/plugins/efa_metrics \
+        /opt/nvidia/nsight-systems-cli/*/target-linux-*/plugins/efa_metrics \
+        /opt/nvidia/nsight-compute/*/host/target-linux-*/plugins/efa_metrics && \
+    [ -z "$(find /usr/local /opt -xdev -type d -name efa_metrics 2>/dev/null)" ] && \
     /usr/bin/python3 -m pip uninstall -y --break-system-packages wandb && \
     ! /usr/bin/python3 -c "import wandb" 2>/dev/null && \
     [ ! -e /usr/local/lib/python3.12/dist-packages/wandb ] && \
@@ -431,6 +439,9 @@ RUN rm -rf /workspace /home/ubuntu \
     /usr/local/bin/etcd \
     /usr/local/bin/etcdctl \
     /usr/local/bin/etcdutl \
+    /usr/local/cuda-*/NsightSystems-cli-*/target-linux-*/plugins/efa_metrics \
+    /opt/nvidia/nsight-systems-cli/*/target-linux-*/plugins/efa_metrics \
+    /opt/nvidia/nsight-compute/*/host/target-linux-*/plugins/efa_metrics \
     /usr/local/bin/wandb \
     /usr/local/lib/python3.12/dist-packages/wandb \
     /usr/local/lib/python3.12/dist-packages/wandb-* \
@@ -491,6 +502,13 @@ RUN --mount=type=bind,source=./container/compliance/enumerate_bundled_decoders.p
     for lib in $(find /usr/local/lib/python3.12/dist-packages/nvidia/dali/.libs -name 'libavcodec*.so*' 2>/dev/null); do \
         /usr/bin/python3 /tmp/enumerate_bundled_decoders.py "$lib"; \
     done
+
+# Post-overlay guard for the efa_metrics whiteout above, for the same reason the
+# DALI one exists: the in-stage assertion runs inside runtime_full, before
+# `COPY --from=runtime_full / /`, so by construction it cannot observe a whiteout
+# mistake. Both stages start FROM the same upstream image, so a deletion in only
+# one of them ships the plugin anyway.
+RUN [ -z "$(find /usr/local /opt -xdev -type d -name efa_metrics 2>/dev/null)" ]
 
 # Post-overlay guard for the system-site floor whiteouts above, for the same
 # reason DALI has one: the in-stage assertion runs inside runtime_full, before

--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -198,6 +198,17 @@ RUN if [ "${TARGETARCH}" != "amd64" ]; then \
       echo "ERROR: Dynamo Snapshot requires x86_64 (cuda-checkpoint has no ${TARGETARCH} binary)" >&2; exit 1; \
     fi
 
+# Drop the Nsight efa_metrics plugin AGENT_BASE_IMAGE carries: a Go NIC sampler
+# nothing in the agent path loads. The CUDA and Nsight versions in its path move
+# with every base bump, so the paths are globbed and the removal is asserted
+# rather than pinned. `agent` is FROM agent_pre with no overlay rebase, so one
+# deletion here ships.
+RUN rm -rf \
+        /usr/local/cuda-*/NsightSystems-cli-*/target-linux-*/plugins/efa_metrics \
+        /opt/nvidia/nsight-systems-cli/*/target-linux-*/plugins/efa_metrics \
+        /opt/nvidia/nsight-compute/*/host/target-linux-*/plugins/efa_metrics && \
+    [ -z "$(find /usr/local /opt -xdev -type d -name efa_metrics 2>/dev/null)" ]
+
 # Install CRIU runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libbsd0 \


### PR DESCRIPTION
## Overview:

The Nsight `efa_metrics` plugin ships a Go binary, `nic_sampler`, that samples AWS EFA NIC
counters for `nsys profile --enable=efa_metrics`. Nothing in the serving path loads it, and on
our EFA fleet it cannot collect anything — the driver exposes no `hw_counters` in sysfs, and
the plugin fails on exactly that path. It arrives prebuilt from upstream images, so we cannot
patch it, and no published Nsight build clears its advisory set. This deletes it.

## Details:

It reaches five image/arch combinations along **two** Nsight roots — Nsight Systems for the
TRT-LLM and snapshot bases, Nsight **Compute** for the CUDA floor under SGLang (amd64 only):

| image | arch | path |
| -- | -- | -- |
| `tensorrtllm-runtime`, `-efa` | amd64 + arm64 | `…/NsightSystems-cli-*/target-linux-*/plugins/efa_metrics` |
| `snapshot-agent` | amd64 | same shape, different CUDA/Nsight version |
| `sglang-runtime`, `-efa` | amd64 | `/opt/nvidia/nsight-compute/*/host/target-linux-*/plugins/efa_metrics` |

`vllm-runtime` carries no Nsight and is untouched.

Deleted by glob, not pinned path: the CUDA and Nsight versions in those paths move with every
base bump, and a pinned path stops matching silently. The directory goes, not just the binary —
that is what makes `nsys plugins list` drop the entry.

Each deletion is asserted in the same `RUN`, so a build cannot go green with the plugin still
present.

## Where should the reviewer start?

`container/templates/trtllm_runtime.Dockerfile` — the only non-obvious part. The deletion has
to land in **both** `runtime_full` and the `pre_runtime` whiteout, because
`COPY --from=runtime_full / /` re-adds anything `runtime_full` still holds; one line in
`pre_runtime` alone would silently do nothing. This mirrors the existing etcd/wandb pair, and
there is a second assertion after the overlay `COPY` to catch a whiteout mistake.

The other two files are one deletion each — those stages have no overlay rebase.

## Validation

All 8 image builds green. Every built image was pulled and run on an AWS dev cluster:
`efa_metrics`/`nic_sampler` absent, `--enable=efa_metrics` → `Plugin not found: efa_metrics`,
`nsys` still runs and still produces a report, and the other three plugins
(`network_interface`, `nvml_metrics`, `storage_metrics`) are intact. Framework imports,
`dynamo.<backend> --help` and `dynamo._core` all OK, including `import tensorrt_llm` on an
H100. End-to-end serve (frontend + worker, Qwen3-8B, one H100) passes on `vllm-runtime` and on
`sglang-runtime`.

The sglang images emit `.qdstrm` rather than `.nsys-rep` from a plain profile — the pre-change
`sglang-runtime:1.4.1` does the same on the same node, so that belongs to the bundled nsys
2025.3.1, not to this change.


## Related Issues

- Closes: DYN-4021

