### PR TITLE
fix(mocker): preserve LLM responses under output pressure

### DIFF
--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -27,7 +27,7 @@ use dynamo_mocker::common::handoff::HandoffId;
 use dynamo_mocker::common::protocols::{
     DirectRequest, KvCacheEventSink, KvEventPublishers, MockEngineArgs, RawKvEventSink,
 };
-use dynamo_mocker::live::{LiveEngine, LiveEngineConfig};
+use dynamo_mocker::live::{LiveEngine, LiveEngineConfig, RequestOutputBuffering};
 use dynamo_mocker::loadgen::{OUTPUT_REPLAY_ID_ANNOTATION_KEY, effective_replay_key};
 use dynamo_mocker::services::bootstrap::{
     BootstrapIdentity, BootstrapParticipantRole, BootstrapServer, BootstrapServerConfig,
@@ -719,7 +719,11 @@ impl MockerExecutionContext {
         // One logical worker owns one attention-DP generalized engine. The
         // returned rank-scoped LiveEngine handles share its single actor and
         // grouped pass barrier.
-        let engines = LiveEngine::start_grouped_with_configs(args.clone(), engine_configs)?;
+        let engines = LiveEngine::start_grouped_with_configs_and_request_output_buffering(
+            args.clone(),
+            engine_configs,
+            RequestOutputBuffering::FullResponse,
+        )?;
         Ok((engines, relay_publishers, handoff_session_permits))
     }
 
@@ -1488,33 +1492,46 @@ mod tests {
             .speedup_ratio(1000.0)
             .build()
             .unwrap();
-        let live = LiveEngine::start(args.clone(), 0).unwrap();
+        let engines = LiveEngine::start_grouped_with_configs_and_request_output_buffering(
+            args.clone(),
+            vec![LiveEngineConfig::default()],
+            RequestOutputBuffering::FullResponse,
+        )
+        .unwrap();
+        let live = engines[0].clone();
         let engine = MockerExecutionContext::new(args);
-        assert!(engine.engines.set(vec![live.clone()]).is_ok());
+        assert!(engine.engines.set(engines).is_ok());
 
-        let mut stream = engine
-            .generate(SingleIn::new(decode_request(1, 32)))
-            .await
-            .unwrap();
+        let mut streams = Vec::new();
+        for _ in 0..4 {
+            streams.push(
+                engine
+                    .generate(SingleIn::new(decode_request(1, 32)))
+                    .await
+                    .unwrap(),
+            );
+        }
         tokio::time::timeout(Duration::from_secs(2), async {
             while live.active_request_count() != 0 {
                 tokio::task::yield_now().await;
             }
         })
         .await
-        .expect("generation should finish while the response remains unread");
+        .expect("generations should finish while every response remains unread");
 
-        let mut output_tokens = 0;
-        let mut finish = None;
-        while let Some(output) = stream.next().await {
-            let output = output.data.unwrap();
-            output_tokens += output.token_ids.len();
-            if output.finish_reason.is_some() {
-                finish = output.finish_reason;
+        for mut stream in streams {
+            let mut output_tokens = 0;
+            let mut finish = None;
+            while let Some(output) = stream.next().await {
+                let output = output.data.unwrap();
+                output_tokens += output.token_ids.len();
+                if output.finish_reason.is_some() {
+                    finish = output.finish_reason;
+                }
             }
+            assert_eq!(output_tokens, 32);
+            assert_eq!(finish, LLMEngineOutput::length().finish_reason);
         }
-        assert_eq!(output_tokens, 32);
-        assert_eq!(finish, LLMEngineOutput::length().finish_reason);
     }
 
     #[test]

--- a/lib/mocker/src/live.rs
+++ b/lib/mocker/src/live.rs
@@ -52,6 +52,33 @@ use request::{
 const SCHEDULER_EVENT_CAPACITY: usize = 8;
 const DEFAULT_REQUEST_OUTPUT_CAPACITY: usize = 8;
 
+/// Controls how much output one live request may retain before it is consumed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RequestOutputBuffering {
+    /// Cancel the request when its output queue reaches `capacity`.
+    CancelOnOverflow { capacity: NonZeroUsize },
+    /// Buffer the request's full declared response.
+    FullResponse,
+}
+
+impl Default for RequestOutputBuffering {
+    fn default() -> Self {
+        Self::CancelOnOverflow {
+            capacity: NonZeroUsize::new(DEFAULT_REQUEST_OUTPUT_CAPACITY).unwrap(),
+        }
+    }
+}
+
+impl RequestOutputBuffering {
+    fn capacity_for(self, output_length: usize) -> usize {
+        let output_length = output_length.max(1);
+        match self {
+            Self::CancelOnOverflow { capacity } => output_length.min(capacity.get()),
+            Self::FullResponse => output_length,
+        }
+    }
+}
+
 /// Runtime publishers used by one live Mocker scheduler.
 #[derive(Clone, Default)]
 pub struct LiveEngineConfig {
@@ -64,24 +91,13 @@ pub(crate) struct ObservedAdmission {
     pub(crate) observed_at: tokio::time::Instant,
 }
 
+#[derive(Default)]
 pub(crate) struct LiveEngineOptions {
     pub(crate) kv_event_publishers: KvEventPublishers,
     pub(crate) admission_tx: Option<mpsc::UnboundedSender<ObservedAdmission>>,
     pub(crate) fpm_publisher: FpmPublisher,
-    pub(crate) request_output_capacity: Option<NonZeroUsize>,
+    pub(crate) request_output_buffering: RequestOutputBuffering,
     pub(crate) allow_zero_output: bool,
-}
-
-impl Default for LiveEngineOptions {
-    fn default() -> Self {
-        Self {
-            kv_event_publishers: KvEventPublishers::default(),
-            admission_tx: None,
-            fpm_publisher: FpmPublisher::default(),
-            request_output_capacity: NonZeroUsize::new(DEFAULT_REQUEST_OUTPUT_CAPACITY),
-            allow_zero_output: false,
-        }
-    }
 }
 
 /// Map a wire-protocol request ID to a deterministic scheduler UUID.
@@ -124,7 +140,7 @@ struct LiveEngineInner {
     routes: Routes,
     handoff_routes: SharedHandoffRoutes,
     metrics_rx: tokio::sync::watch::Receiver<MockerMetrics>,
-    request_output_capacity: Option<NonZeroUsize>,
+    request_output_buffering: RequestOutputBuffering,
     allow_zero_output: bool,
     group: Arc<LiveEngineGroup>,
     cancel: CancellationToken,
@@ -210,12 +226,29 @@ impl LiveEngine {
         dp_rank: u32,
         config: LiveEngineConfig,
     ) -> anyhow::Result<Self> {
+        Self::start_with_config_and_request_output_buffering(
+            args,
+            dp_rank,
+            config,
+            RequestOutputBuffering::default(),
+        )
+    }
+
+    /// Start one live scheduler with runtime-owned publishers and an explicit
+    /// per-request output buffering policy.
+    pub fn start_with_config_and_request_output_buffering(
+        args: MockEngineArgs,
+        dp_rank: u32,
+        config: LiveEngineConfig,
+        request_output_buffering: RequestOutputBuffering,
+    ) -> anyhow::Result<Self> {
         Self::start_internal(
             args,
             dp_rank,
             LiveEngineOptions {
                 kv_event_publishers: config.kv_event_publishers,
                 fpm_publisher: config.fpm_publisher,
+                request_output_buffering,
                 ..LiveEngineOptions::default()
             },
             None,
@@ -231,11 +264,26 @@ impl LiveEngine {
         args: MockEngineArgs,
         configs: Vec<LiveEngineConfig>,
     ) -> anyhow::Result<Vec<Self>> {
+        Self::start_grouped_with_configs_and_request_output_buffering(
+            args,
+            configs,
+            RequestOutputBuffering::default(),
+        )
+    }
+
+    /// Start all attention-DP ranks with an explicit per-request output
+    /// buffering policy.
+    pub fn start_grouped_with_configs_and_request_output_buffering(
+        args: MockEngineArgs,
+        configs: Vec<LiveEngineConfig>,
+        request_output_buffering: RequestOutputBuffering,
+    ) -> anyhow::Result<Vec<Self>> {
         let options = configs
             .into_iter()
             .map(|config| LiveEngineOptions {
                 kv_event_publishers: config.kv_event_publishers,
                 fpm_publisher: config.fpm_publisher,
+                request_output_buffering,
                 ..LiveEngineOptions::default()
             })
             .collect();
@@ -321,7 +369,9 @@ impl LiveEngine {
             args,
             dp_rank,
             LiveEngineOptions {
-                request_output_capacity: Some(request_output_capacity),
+                request_output_buffering: RequestOutputBuffering::CancelOnOverflow {
+                    capacity: request_output_capacity,
+                },
                 ..LiveEngineOptions::default()
             },
             output_gate,
@@ -415,7 +465,7 @@ impl LiveEngine {
                 routes,
                 handoff_routes,
                 metrics_rx,
-                request_output_capacity: options.request_output_capacity,
+                request_output_buffering: options.request_output_buffering,
                 allow_zero_output: options.allow_zero_output,
                 group,
                 cancel,
@@ -452,10 +502,10 @@ impl LiveEngine {
         let client_id = request.uuid.unwrap_or_else(Uuid::new_v4);
         let scheduler_id = Uuid::new_v4();
         request.uuid = Some(scheduler_id);
-        let output_capacity = self.inner.request_output_capacity.map_or_else(
-            || output_length.max(1),
-            |capacity| output_length.max(1).min(capacity.get()),
-        );
+        let output_capacity = self
+            .inner
+            .request_output_buffering
+            .capacity_for(output_length);
         let (tx, rx) = mpsc::channel(output_capacity);
         let route = Arc::new(RequestRoute::new(client_id, scheduler_id, tx));
         match self.inner.routes.by_client.entry(client_id) {

--- a/lib/mocker/src/live/tests.rs
+++ b/lib/mocker/src/live/tests.rs
@@ -689,7 +689,9 @@ async fn full_output_stream_is_cancelled_without_stalling_an_unrelated_request()
         args(EngineType::Vllm),
         0,
         LiveEngineOptions {
-            request_output_capacity: Some(NonZeroUsize::MIN),
+            request_output_buffering: RequestOutputBuffering::CancelOnOverflow {
+                capacity: NonZeroUsize::MIN,
+            },
             fpm_publisher: FpmPublisher::new(Some(Arc::clone(&fpm) as Arc<dyn FpmSink>)),
             ..LiveEngineOptions::default()
         },
@@ -1000,12 +1002,12 @@ async fn ordered_lane_forwards_admission_before_releasing_output() {
 }
 
 #[tokio::test]
-async fn replay_options_allow_zero_output_and_full_response_buffering() {
+async fn replay_options_allow_zero_output() {
     let zero_engine = LiveEngine::start_with_options(
         args(EngineType::Sglang),
         0,
         LiveEngineOptions {
-            request_output_capacity: None,
+            request_output_buffering: RequestOutputBuffering::FullResponse,
             allow_zero_output: true,
             ..LiveEngineOptions::default()
         },
@@ -1024,45 +1026,56 @@ async fn replay_options_allow_zero_output_and_full_response_buffering() {
     assert!(terminal.completed);
     assert_eq!(terminal.token_id, None);
     zero_engine.shutdown().await.unwrap();
+}
 
-    let buffered_engine = LiveEngine::start_with_options(
+#[tokio::test]
+async fn full_response_buffering_preserves_concurrent_unread_requests() {
+    let buffered_engine = LiveEngine::start_with_config_and_request_output_buffering(
         args(EngineType::Vllm),
         0,
-        LiveEngineOptions {
-            request_output_capacity: None,
-            allow_zero_output: true,
-            ..LiveEngineOptions::default()
-        },
+        LiveEngineConfig::default(),
+        RequestOutputBuffering::FullResponse,
     )
     .unwrap();
-    let mut buffered = buffered_engine
-        .submit(DirectRequest {
-            tokens: vec![4, 5, 6],
-            max_output_tokens: 32,
-            output_token_ids: Some(vec![7; 32]),
-            uuid: Some(Uuid::from_u128(22)),
-            ..Default::default()
-        })
-        .await
-        .unwrap();
+    let mut requests = Vec::new();
+    for ordinal in 0..4_u128 {
+        let token_id = 7 + ordinal as u32;
+        requests.push(
+            buffered_engine
+                .submit(DirectRequest {
+                    tokens: vec![4, 5, 6],
+                    max_output_tokens: 32,
+                    output_token_ids: Some(vec![token_id; 32]),
+                    uuid: Some(Uuid::from_u128(22 + ordinal)),
+                    ..Default::default()
+                })
+                .await
+                .unwrap(),
+        );
+    }
     tokio::time::timeout(Duration::from_secs(1), async {
         while buffered_engine.active_request_count() != 0 {
             tokio::task::yield_now().await;
         }
     })
     .await
-    .expect("the full response should buffer without a receiver draining it");
-    let mut output_count = 0;
-    let mut saw_terminal = false;
-    while let Some(output) = buffered.recv().await {
-        output_count += usize::from(output.token_id.is_some());
-        if output.completed {
-            saw_terminal = true;
-            break;
+    .expect("full responses should buffer without any receiver draining them");
+    for (ordinal, mut request) in requests.into_iter().enumerate() {
+        let expected_token_id = 7 + ordinal as u32;
+        let mut output_count = 0;
+        let mut saw_terminal = false;
+        while let Some(output) = request.recv().await {
+            assert_eq!(output.token_id, Some(expected_token_id));
+            output_count += 1;
+            if output.completed {
+                saw_terminal = true;
+                break;
+            }
         }
+        assert_eq!(output_count, 32);
+        assert!(saw_terminal);
+        assert!(request.recv().await.is_none());
     }
-    assert_eq!(output_count, 32);
-    assert!(saw_terminal);
     assert_eq!(buffered_engine.active_request_count(), 0);
     buffered_engine.shutdown().await.unwrap();
 }

--- a/lib/mocker/src/replay/online/live_runtime.rs
+++ b/lib/mocker/src/replay/online/live_runtime.rs
@@ -10,7 +10,7 @@ use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 use crate::common::protocols::{DirectRequest, FpmPublisher};
-use crate::live::{LiveEngine, LiveEngineOptions, ObservedAdmission};
+use crate::live::{LiveEngine, LiveEngineOptions, ObservedAdmission, RequestOutputBuffering};
 use crate::loadgen::WorkloadDriver;
 use crate::replay::TraceSimulationReport;
 
@@ -241,7 +241,7 @@ impl LiveRuntime {
                     kv_event_publishers: router.sink(worker_idx as _),
                     admission_tx: Some(admission_tx.clone()),
                     fpm_publisher: FpmPublisher::default(),
-                    request_output_capacity: None,
+                    request_output_buffering: RequestOutputBuffering::FullResponse,
                     allow_zero_output: true,
                 })
                 .collect();


### PR DESCRIPTION
## Summary

- Add an explicit `RequestOutputBuffering` policy to LiveEngine while keeping the current eight-item cancel-on-overflow behavior as the default.
- Configure the standard LLM mocker and online replay to buffer each finite declared response in full.
- Preserve receiver-drop cancellation and slow-reader isolation for default LiveEngine consumers.

[PR #11917](https://github.com/ai-dynamo/dynamo/pull/11917) first added bounded live response buffering. Its original global response reservation was removed because a large request could block unrelated requests before they reached the scheduler. [PR #12253](https://github.com/ai-dynamo/dynamo/pull/12253) then selected full-response buffering for online replay. [PR #12381](https://github.com/ai-dynamo/dynamo/pull/12381) migrated the LLM mocker but retained an eight-item inner queue.

Under high concurrency, the LLM response-pump task can fall more than eight signals behind even when the client is healthy. LiveEngine then treats normal task-scheduling delay as a slow reader and cancels the request. This change gives the LLM mocker request-bounded buffering without restoring a global admission layer. Retained output remains bounded by each request declared output length.

## Validation

- `cargo test -p dynamo-mocker full_response_buffering_preserves_concurrent_unread_requests`
- `cargo test -p dynamo-mocker full_output_stream_is_cancelled_without_stalling_an_unrelated_request`
- `cargo test -p dynamo-llm unread_response_completes_without_overflow_cancellation`
- `cargo test -p dynamo-mocker` (196 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-mocker -p dynamo-llm --lib -- -D warnings`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple live responses are generated concurrently.
  * Complete responses are now preserved when output consumption is delayed, preventing incomplete results or unexpected interruptions.
  * Improved handling of responses that produce no immediate output.

* **Tests**
  * Expanded coverage for concurrent generation, response completion, token counts, and terminal results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->