### PR TITLE
feat(epp): add role-scoped worker catalogs for standalone disaggregated routing

### DIFF
--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -15,7 +15,9 @@ For the user-facing walkthrough, start with
 
 ## How the on-ramp works
 
-This on-ramp is available for aggregated serving only at this time.
+This on-ramp covers aggregated serving. `DYN_EPP_TOPOLOGY_MODE=disaggregated` builds role-scoped
+prefill and decode catalogs, but pair selection and the decode-sidecar handoff are not in place
+yet, so there is no disaggregated manifest here.
 
 The aggregated on-ramp uses the upstream `vllm/vllm-openai:v0.28.0` image. Replace it with the vLLM
 image your platform standardizes on if you need another pinned or internally mirrored image.
@@ -62,7 +64,8 @@ flowchart LR
 
 ## What Dynamo-managed GAIE adds
 
-- Disaggregated prefill/decode (Disaggregated serving is planned follow-up in the standalone mode.)
+- Disaggregated prefill/decode (standalone mode discovers and splits the two roles, but does not yet
+  select a prefill/decode pair.)
 - Operator-managed lifecycle for Workers, Services, `InferencePool`, and EPP resources.
 - Request migration, rejection, cancellation - overall admission control
 - Data parallelism (The standalone mode which targets DP=1.)

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -78,7 +78,11 @@ fn validate_kube_discovery_mode_value(mode: Option<&str>) -> Result<bool> {
     }
 }
 
-fn decode_router_config_override(is_disaggregated: bool) -> Option<RouterConfigOverride> {
+/// The decode leg's per-request selection semantics. Shared with the standalone
+/// path through `crate::role_config::router_config_override_for_role`.
+pub(crate) fn decode_router_config_override(
+    is_disaggregated: bool,
+) -> Option<RouterConfigOverride> {
     is_disaggregated.then_some(RouterConfigOverride {
         overlap_score_credit: Some(0.0),
         assume_kv_reuse: Some(false),

--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -51,9 +51,7 @@ pub struct EppRouter {
     _adapter: TopologyAdapter,
     reflector_ready: Arc<AtomicBool>,
     /// The only role this EPP will ever hand the gateway as a destination:
-    /// `Aggregated` in aggregated topology, `Decode` in disaggregated. Every
-    /// reflector read in `pick()` is scoped by it, which is what makes "never
-    /// route to a prefill endpoint" structural rather than a convention.
+    /// `Aggregated` in aggregated topology, `Decode` in disaggregated.
     serving_role: WorkerRole,
     model_name: String,
     /// Bounds total concurrent in-flight `pick()`s. HTTP/2 stream multiplexing
@@ -274,9 +272,7 @@ impl EndpointPicker for EppRouter {
         }
 
         if !self.reflector.has_ready_workers(self.serving_role) {
-            // Distinguish "this role is empty" from "the pool is empty": under a
-            // role split the pool can be full of prefill pods while decode has
-            // none, and the two need different operator responses.
+            // Distinguish "this role is empty" from "the pool is empty".
             return Err(match self.serving_role {
                 WorkerRole::Aggregated => PickError::NoEndpoints,
                 role => PickError::RoleCatalogEmpty(role),
@@ -650,8 +646,6 @@ mod tests {
         assert!(!fired.load(Ordering::SeqCst));
     }
 
-    // --- the invariant: a prefill worker is never a destination -------------
-
     use crate::pod_discovery::RawWorker;
     use crate::selector::RoleSelectors;
     use dynamo_runtime::discovery::hash_pod_name;
@@ -694,103 +688,63 @@ mod tests {
         EppRouter::from_selector_parts(cfg, renderer, Arc::new(reflector), ready, selectors)
     }
 
+    /// The body-less path resolves an arbitrary worker without consulting the
+    /// selector at all, which is exactly why it must be role-scoped.
     #[tokio::test]
-    async fn serving_role_follows_the_topology() {
-        let agg = router_over(EppStandaloneConfig::for_test(), vec![]).await;
-        assert_eq!(agg.serving_role, WorkerRole::Aggregated);
-
-        // `from_selector_parts` reads the role off the selectors it is handed, so
-        // a disaggregated router is exercised through its real constructor in
-        // `build_selectors`; here we assert the aggregated default explicitly.
-        let disagg_selectors_role = RoleSelectors::Disaggregated {
-            prefill: Arc::new(
-                Selector::new(&disagg_config(), WorkerSelectionPolicyRegistry::default())
-                    .await
-                    .expect("selector should build"),
-            ),
-            decode: Arc::new(
-                Selector::new(&disagg_config(), WorkerSelectionPolicyRegistry::default())
-                    .await
-                    .expect("selector should build"),
-            ),
+    async fn decode_serving_pick_never_returns_a_prefill_endpoint() {
+        enum Expected {
+            Endpoint(&'static str),
+            NoEndpoints,
+            DecodeCatalogEmpty,
         }
-        .serving_role();
-        assert_eq!(disagg_selectors_role, WorkerRole::Decode);
-    }
+        let prefill = || worker("p-0", "10.0.0.1", WorkerRole::Prefill);
+        let decode = || worker("d-0", "10.0.0.2", WorkerRole::Decode);
+        let cases = [
+            (
+                "body-less pick resolves the decode worker",
+                vec![prefill(), decode()],
+                vec![],
+                Expected::Endpoint("10.0.0.2:8000"),
+            ),
+            (
+                "subset hint naming only prefill pods refuses to route",
+                vec![prefill(), decode()],
+                vec!["10.0.0.1:8000".to_string()],
+                Expected::NoEndpoints,
+            ),
+            (
+                "prefill-only catalog reports the empty decode role",
+                vec![prefill()],
+                vec![],
+                Expected::DecodeCatalogEmpty,
+            ),
+        ];
 
-    #[tokio::test]
-    async fn body_less_pick_never_returns_a_prefill_endpoint() {
-        // The body-less path resolves an arbitrary worker without consulting the
-        // selector at all, which is exactly why it must be role-scoped.
-        let mut router = router_over(
-            EppStandaloneConfig::for_test(),
-            vec![
-                worker("p-0", "10.0.0.1", WorkerRole::Prefill),
-                worker("d-0", "10.0.0.2", WorkerRole::Decode),
-            ],
-        )
-        .await;
-        router.serving_role = WorkerRole::Decode;
-
-        let req = RequestInfo {
-            request_id: "r1".to_string(),
-            headers: Vec::new(),
-            body: bytes::Bytes::new(),
-            model: String::new(),
-            candidate_subset: Vec::new(),
-        };
-        let picked = router
-            .pick(&req, &[])
-            .await
-            .expect("decode should be picked");
-        assert_eq!(picked.endpoint, "10.0.0.2:8000");
-    }
-
-    #[tokio::test]
-    async fn a_subset_hint_naming_only_prefill_pods_refuses_to_route() {
-        let mut router = router_over(
-            EppStandaloneConfig::for_test(),
-            vec![
-                worker("p-0", "10.0.0.1", WorkerRole::Prefill),
-                worker("d-0", "10.0.0.2", WorkerRole::Decode),
-            ],
-        )
-        .await;
-        router.serving_role = WorkerRole::Decode;
-
-        let req = RequestInfo {
-            request_id: "r1".to_string(),
-            headers: Vec::new(),
-            body: bytes::Bytes::new(),
-            model: String::new(),
-            candidate_subset: vec!["10.0.0.1:8000".to_string()],
-        };
-        assert!(matches!(
-            router.pick(&req, &[]).await,
-            Err(PickError::NoEndpoints)
-        ));
-    }
-
-    #[tokio::test]
-    async fn a_prefill_only_catalog_reports_the_empty_role() {
-        let mut router = router_over(
-            EppStandaloneConfig::for_test(),
-            vec![worker("p-0", "10.0.0.1", WorkerRole::Prefill)],
-        )
-        .await;
-        router.serving_role = WorkerRole::Decode;
-
-        let req = RequestInfo {
-            request_id: "r1".to_string(),
-            headers: Vec::new(),
-            body: bytes::Bytes::new(),
-            model: String::new(),
-            candidate_subset: Vec::new(),
-        };
-        // Attributable in the client's 503, not conflated with an empty pool.
-        assert!(matches!(
-            router.pick(&req, &[]).await,
-            Err(PickError::RoleCatalogEmpty(WorkerRole::Decode))
-        ));
+        for (label, workers, candidate_subset, expected) in cases {
+            let mut router = router_over(disagg_config(), workers).await;
+            router.serving_role = WorkerRole::Decode;
+            let req = RequestInfo {
+                request_id: "r1".to_string(),
+                headers: Vec::new(),
+                body: bytes::Bytes::new(),
+                model: String::new(),
+                candidate_subset,
+            };
+            let got = router.pick(&req, &[]).await;
+            match expected {
+                Expected::Endpoint(endpoint) => {
+                    assert_eq!(got.expect(label).endpoint, endpoint, "{label}");
+                }
+                Expected::NoEndpoints => {
+                    assert!(matches!(got, Err(PickError::NoEndpoints)), "{label}");
+                }
+                Expected::DecodeCatalogEmpty => {
+                    assert!(
+                        matches!(got, Err(PickError::RoleCatalogEmpty(WorkerRole::Decode))),
+                        "{label}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -70,11 +70,16 @@ impl EppRouter {
         policy_registry: WorkerSelectionPolicyRegistry,
     ) -> Result<Self> {
         let selectors = Self::build_selectors(&cfg, policy_registry).await?;
-        let (renderer, reflector, reflector_ready) = Self::dependencies(&cfg).await?;
+        let renderer = VllmRenderClient::new(
+            &cfg.tokenizer_service_url,
+            Duration::from_millis(cfg.tokenization_timeout_ms),
+            cfg.tokenizer_max_response_bytes,
+        )?;
+        let (reflector, reflector_ready) = PodDiscovery::spawn(&cfg).await?;
         Ok(Self::from_selector_parts(
             cfg,
             renderer,
-            reflector,
+            Arc::new(reflector),
             reflector_ready,
             selectors,
         ))
@@ -120,18 +125,6 @@ impl EppRouter {
             prefill: Arc::new(prefill),
             decode: Arc::new(decode),
         })
-    }
-
-    async fn dependencies(
-        cfg: &EppStandaloneConfig,
-    ) -> Result<(VllmRenderClient, Arc<PodDiscovery>, Arc<AtomicBool>)> {
-        let renderer = VllmRenderClient::new(
-            &cfg.tokenizer_service_url,
-            Duration::from_millis(cfg.tokenization_timeout_ms),
-            cfg.tokenizer_max_response_bytes,
-        )?;
-        let (reflector, reflector_ready) = PodDiscovery::spawn(cfg).await?;
-        Ok((renderer, Arc::new(reflector), reflector_ready))
     }
 
     fn from_selector_parts(
@@ -669,7 +662,7 @@ mod tests {
         }
     }
 
-    /// Assemble a router over a fixed catalog, bypassing `dependencies` — the
+    /// Assemble a router over a fixed catalog, bypassing `PodDiscovery::spawn` — the
     /// only thing in the constructor that needs a cluster.
     async fn router_over(cfg: EppStandaloneConfig, workers: Vec<RawWorker>) -> EppRouter {
         let selectors = RoleSelectors::Aggregated(Arc::new(

--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -118,12 +118,6 @@ impl EppRouter {
         )
         .await?;
 
-        tracing::warn!(
-            "DYN_EPP_TOPOLOGY_MODE=disaggregated is incomplete until ai-dynamo/dynamo#13405 and \
-             #13407 land: the prefill catalog is populated but nothing selects from it yet, so \
-             decode workers still perform the whole prefill"
-        );
-
         Ok(RoleSelectors::Disaggregated {
             prefill: Arc::new(prefill),
             decode: Arc::new(decode),

--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -84,9 +84,9 @@ impl EppRouter {
 
     /// One selector per role in play.
     ///
-    /// Disaggregated needs two `SelectionService` instances rather than one with
-    /// two partitions because the knobs that distinguish the roles live on
-    /// `KvRouterConfig`, which a service takes once at construction.
+    /// Disaggregated builds two `SelectionService`s: `use_kv_events` is fixed at
+    /// construction and differs per role, and the catalogs must be disjoint so a
+    /// decode pick can never see a prefill worker.
     async fn build_selectors(
         cfg: &EppStandaloneConfig,
         policy_registry: WorkerSelectionPolicyRegistry,

--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -26,6 +26,7 @@ use std::time::Duration;
 use anyhow::Result;
 use tokio::sync::Semaphore;
 
+use dynamo_kv_router::config::try_kv_router_config_from_dynamo_env;
 use dynamo_kv_router::services::selection::WorkerSelectionPolicyRegistry;
 use dynamo_llm::protocols::common::extensions::{
     AgentHints, HEADER_REQUEST_PRIORITY, HEADER_REQUEST_STRICT_PRIORITY, resolve_request_priority,
@@ -35,18 +36,25 @@ use serde::Deserialize;
 use crate::epp_standalone_config::EppStandaloneConfig;
 use crate::picker::{Endpoint, EndpointPicker, PickError, PickResult, RequestInfo};
 use crate::pod_discovery::PodDiscovery;
-use crate::selector::{SelectRequest, Selector};
-use crate::topology_adapter::{RegistrationDefaults, TopologyAdapter};
+use crate::role_config::{kv_router_config_for_role, reject_unsupported_router_config};
+use crate::selector::{RoleSelectors, SelectRequest, Selector};
+use crate::topology_adapter::TopologyAdapter;
 use crate::vllm_render_client::{VllmRenderClient, VllmRenderError};
+use crate::worker_role::WorkerRole;
 
 /// Standalone endpoint picker backed by the standalone selection service.
 pub struct EppRouter {
     renderer: VllmRenderClient,
     reflector: Arc<PodDiscovery>,
-    selector: Arc<Selector>,
+    selectors: RoleSelectors,
     // Kept alive for the lifetime of the router; the reconcile loop runs on it.
     _adapter: TopologyAdapter,
     reflector_ready: Arc<AtomicBool>,
+    /// The only role this EPP will ever hand the gateway as a destination:
+    /// `Aggregated` in aggregated topology, `Decode` in disaggregated. Every
+    /// reflector read in `pick()` is scoped by it, which is what makes "never
+    /// route to a prefill endpoint" structural rather than a convention.
+    serving_role: WorkerRole,
     model_name: String,
     /// Bounds total concurrent in-flight `pick()`s. HTTP/2 stream multiplexing
     /// means the TCP-connection cap (`MAX_CONCURRENT_CONNECTIONS`) does NOT bound
@@ -63,30 +71,103 @@ impl EppRouter {
         cfg: EppStandaloneConfig,
         policy_registry: WorkerSelectionPolicyRegistry,
     ) -> Result<Self> {
-        let selector = Arc::new(Selector::new(&cfg, policy_registry).await?);
+        let selectors = Self::build_selectors(&cfg, policy_registry).await?;
+        let (renderer, reflector, reflector_ready) = Self::dependencies(&cfg).await?;
+        Ok(Self::from_selector_parts(
+            cfg,
+            renderer,
+            reflector,
+            reflector_ready,
+            selectors,
+        ))
+    }
+
+    /// One selector per role in play.
+    ///
+    /// Disaggregated needs two `SelectionService` instances rather than one with
+    /// two partitions because the knobs that distinguish the roles live on
+    /// `KvRouterConfig`, which a service takes once at construction.
+    async fn build_selectors(
+        cfg: &EppStandaloneConfig,
+        policy_registry: WorkerSelectionPolicyRegistry,
+    ) -> Result<RoleSelectors> {
+        if !cfg.topology_mode.is_disaggregated() {
+            return Ok(RoleSelectors::Aggregated(Arc::new(
+                Selector::new(cfg, policy_registry).await?,
+            )));
+        }
+
+        // Parsed once and cloned per role: the parse both reads the process env
+        // and logs the resolved config, so doing it twice would double the
+        // startup block for no benefit.
+        let base = try_kv_router_config_from_dynamo_env().map_err(anyhow::Error::msg)?;
+        reject_unsupported_router_config(cfg.topology_mode, &base)?;
+
+        let prefill = Selector::new_with_kv_router_config(
+            cfg,
+            WorkerRole::Prefill,
+            kv_router_config_for_role(&base, WorkerRole::Prefill),
+            policy_registry.clone(),
+        )
+        .await?;
+        let decode = Selector::new_with_kv_router_config(
+            cfg,
+            WorkerRole::Decode,
+            kv_router_config_for_role(&base, WorkerRole::Decode),
+            policy_registry,
+        )
+        .await?;
+
+        tracing::warn!(
+            "DYN_EPP_TOPOLOGY_MODE=disaggregated is incomplete until ai-dynamo/dynamo#13405 and \
+             #13407 land: the prefill catalog is populated but nothing selects from it yet, so \
+             decode workers still perform the whole prefill"
+        );
+
+        Ok(RoleSelectors::Disaggregated {
+            prefill: Arc::new(prefill),
+            decode: Arc::new(decode),
+        })
+    }
+
+    async fn dependencies(
+        cfg: &EppStandaloneConfig,
+    ) -> Result<(VllmRenderClient, Arc<PodDiscovery>, Arc<AtomicBool>)> {
         let renderer = VllmRenderClient::new(
             &cfg.tokenizer_service_url,
             Duration::from_millis(cfg.tokenization_timeout_ms),
             cfg.tokenizer_max_response_bytes,
         )?;
-        let (reflector, reflector_ready) = PodDiscovery::spawn(&cfg).await?;
-        let reflector = Arc::new(reflector);
-        let defaults = RegistrationDefaults::from_config(&cfg);
-        let adapter =
-            TopologyAdapter::spawn(reflector.as_ref().clone(), selector.clone(), defaults);
+        let (reflector, reflector_ready) = PodDiscovery::spawn(cfg).await?;
+        Ok((renderer, Arc::new(reflector), reflector_ready))
+    }
+
+    fn from_selector_parts(
+        cfg: EppStandaloneConfig,
+        renderer: VllmRenderClient,
+        reflector: Arc<PodDiscovery>,
+        reflector_ready: Arc<AtomicBool>,
+        selectors: RoleSelectors,
+    ) -> Self {
+        let serving_role = selectors.serving_role();
+        let adapter = TopologyAdapter::spawn(reflector.as_ref().clone(), selectors.clone(), &cfg);
 
         // Readiness is driven solely by the live pod+pool signal (see `is_ready`);
         // we do not block startup on a schedulable worker. A valid, empty pool is
-        // ready immediately and returns 503 per-request until capacity appears.
-        Ok(Self {
+        // ready immediately and returns 503 per-request until capacity appears —
+        // and in disaggregated topology that includes a pool whose decode role is
+        // empty, which is deliberately a per-request failure rather than a health
+        // flip, since the gateway fails closed and would drop everything.
+        Self {
             renderer,
             reflector,
-            selector,
+            selectors,
             _adapter: adapter,
             reflector_ready,
+            serving_role,
             model_name: cfg.model_name,
             inflight: Arc::new(Semaphore::new(cfg.max_inflight_requests)),
-        })
+        }
     }
 
     /// Overall EPP readiness for the gRPC health signal: the pod reflector has
@@ -135,9 +216,10 @@ impl EppRouter {
             .filter_map(|candidate| candidate.parse().ok())
             .collect();
         // Single index pass; the predicate borrows each endpoint (no clone).
-        self.reflector.ready_worker_ids_matching(|endpoint| {
-            endpoint_in_subset(endpoint, &candidates, &candidate_ips)
-        })
+        self.reflector
+            .ready_worker_ids_matching(self.serving_role, |endpoint| {
+                endpoint_in_subset(endpoint, &candidates, &candidate_ips)
+            })
     }
 }
 
@@ -197,8 +279,14 @@ impl EndpointPicker for EppRouter {
             ));
         }
 
-        if !self.reflector.has_ready_workers() {
-            return Err(PickError::NoEndpoints);
+        if !self.reflector.has_ready_workers(self.serving_role) {
+            // Distinguish "this role is empty" from "the pool is empty": under a
+            // role split the pool can be full of prefill pods while decode has
+            // none, and the two need different operator responses.
+            return Err(match self.serving_role {
+                WorkerRole::Aggregated => PickError::NoEndpoints,
+                role => PickError::RoleCatalogEmpty(role),
+            });
         }
 
         // Bound total in-flight picks. This caps the tokenizer/render fan-out,
@@ -248,12 +336,12 @@ impl EndpointPicker for EppRouter {
                 Some(ids) => {
                     let worker_id = *ids.iter().next().ok_or(PickError::NoEndpoints)?;
                     self.reflector
-                        .resolve_endpoint(worker_id)
+                        .resolve_endpoint(worker_id, self.serving_role)
                         .ok_or(PickError::NoEndpoints)?
                 }
                 None => self
                     .reflector
-                    .resolve_any_endpoint()
+                    .resolve_any_endpoint(self.serving_role)
                     .ok_or(PickError::NoEndpoints)?,
             };
             return Ok(PickResult {
@@ -284,7 +372,7 @@ impl EndpointPicker for EppRouter {
         // reclaimed by the queue's drop-retraction. Disarmed on the handled paths
         // below; until then, dropping this future frees the reservation.
         let mut reservation_guard =
-            ReservationGuard::new(self.selector.clone(), reservation_id.clone());
+            ReservationGuard::new(self.selectors.serving().clone(), reservation_id.clone());
 
         let select_req = SelectRequest {
             model_name: self.model_name.clone(),
@@ -299,7 +387,12 @@ impl EndpointPicker for EppRouter {
         };
 
         // On either error return below the guard (still armed) frees the booking.
-        let resp = match self.selector.select_and_reserve(select_req).await {
+        let resp = match self
+            .selectors
+            .serving()
+            .select_and_reserve(select_req)
+            .await
+        {
             Ok(resp) => resp,
             Err(e) => return Err(PickError::RoutingFailed(e.to_string())),
         };
@@ -307,7 +400,10 @@ impl EndpointPicker for EppRouter {
         // The reflector owns the address + readiness. If it can no longer resolve
         // the selected worker, the pod left Ready in the race, so the selection is
         // stale: refuse rather than route to a stale address.
-        let Some(endpoint) = self.reflector.resolve_endpoint(resp.worker_id) else {
+        let Some(endpoint) = self
+            .reflector
+            .resolve_endpoint(resp.worker_id, self.serving_role)
+        else {
             tracing::warn!(
                 worker_id = resp.worker_id,
                 "Selected worker no longer resolvable in reflector; treating selection as stale"
@@ -335,7 +431,7 @@ impl EndpointPicker for EppRouter {
     /// Response complete: release the booking from `pick`. `booking_id` is that
     /// reservation id; `free_reservation` is idempotent (body-less pick → no-op).
     async fn on_request_complete(&self, booking_id: &str) {
-        if let Err(e) = self.selector.free_reservation(booking_id).await {
+        if let Err(e) = self.selectors.serving().free_reservation(booking_id).await {
             tracing::warn!(reservation_id = booking_id, error = %e, "Failed to free reservation");
         }
     }
@@ -343,7 +439,7 @@ impl EndpointPicker for EppRouter {
     /// First token: release prefill load, keep decode booked until completion.
     /// `booking_id` is `pick`'s reservation id; `prefill_complete` is idempotent.
     async fn on_prefill_complete(&self, booking_id: &str) {
-        if let Err(e) = self.selector.prefill_complete(booking_id).await {
+        if let Err(e) = self.selectors.serving().prefill_complete(booking_id).await {
             tracing::warn!(reservation_id = booking_id, error = %e, "Failed to mark prefill complete");
         }
     }
@@ -558,5 +654,149 @@ mod tests {
             guard.disarm();
         }
         assert!(!fired.load(Ordering::SeqCst));
+    }
+
+    // --- the invariant: a prefill worker is never a destination -------------
+
+    use crate::pod_discovery::RawWorker;
+    use crate::selector::RoleSelectors;
+    use dynamo_runtime::discovery::hash_pod_name;
+
+    fn disagg_config() -> EppStandaloneConfig {
+        EppStandaloneConfig {
+            topology_mode: crate::epp_standalone_config::EppTopologyMode::Disaggregated,
+            ..EppStandaloneConfig::for_test()
+        }
+    }
+
+    fn worker(name: &str, ip: &str, role: WorkerRole) -> RawWorker {
+        RawWorker {
+            worker_id: hash_pod_name(name),
+            pod_name: name.to_string(),
+            pod_ip: ip.to_string(),
+            role,
+            http_endpoint: format!("http://{ip}:8000"),
+            kv_events_endpoint: (role != WorkerRole::Decode).then(|| format!("tcp://{ip}:5557")),
+            replay_endpoint: None,
+        }
+    }
+
+    /// Assemble a router over a fixed catalog, bypassing `dependencies` — the
+    /// only thing in the constructor that needs a cluster.
+    async fn router_over(cfg: EppStandaloneConfig, workers: Vec<RawWorker>) -> EppRouter {
+        let selectors = RoleSelectors::Aggregated(Arc::new(
+            Selector::new(&cfg, WorkerSelectionPolicyRegistry::default())
+                .await
+                .expect("selector should build"),
+        ));
+        let renderer = VllmRenderClient::new(
+            &cfg.tokenizer_service_url,
+            Duration::from_millis(cfg.tokenization_timeout_ms),
+            cfg.tokenizer_max_response_bytes,
+        )
+        .expect("render client construction does no I/O");
+        let (reflector, _changes_tx) = PodDiscovery::for_test(workers);
+        let ready = Arc::new(AtomicBool::new(true));
+        EppRouter::from_selector_parts(cfg, renderer, Arc::new(reflector), ready, selectors)
+    }
+
+    #[tokio::test]
+    async fn serving_role_follows_the_topology() {
+        let agg = router_over(EppStandaloneConfig::for_test(), vec![]).await;
+        assert_eq!(agg.serving_role, WorkerRole::Aggregated);
+
+        // `from_selector_parts` reads the role off the selectors it is handed, so
+        // a disaggregated router is exercised through its real constructor in
+        // `build_selectors`; here we assert the aggregated default explicitly.
+        let disagg_selectors_role = RoleSelectors::Disaggregated {
+            prefill: Arc::new(
+                Selector::new(&disagg_config(), WorkerSelectionPolicyRegistry::default())
+                    .await
+                    .expect("selector should build"),
+            ),
+            decode: Arc::new(
+                Selector::new(&disagg_config(), WorkerSelectionPolicyRegistry::default())
+                    .await
+                    .expect("selector should build"),
+            ),
+        }
+        .serving_role();
+        assert_eq!(disagg_selectors_role, WorkerRole::Decode);
+    }
+
+    #[tokio::test]
+    async fn body_less_pick_never_returns_a_prefill_endpoint() {
+        // The body-less path resolves an arbitrary worker without consulting the
+        // selector at all, which is exactly why it must be role-scoped.
+        let mut router = router_over(
+            EppStandaloneConfig::for_test(),
+            vec![
+                worker("p-0", "10.0.0.1", WorkerRole::Prefill),
+                worker("d-0", "10.0.0.2", WorkerRole::Decode),
+            ],
+        )
+        .await;
+        router.serving_role = WorkerRole::Decode;
+
+        let req = RequestInfo {
+            request_id: "r1".to_string(),
+            headers: Vec::new(),
+            body: bytes::Bytes::new(),
+            model: String::new(),
+            candidate_subset: Vec::new(),
+        };
+        let picked = router
+            .pick(&req, &[])
+            .await
+            .expect("decode should be picked");
+        assert_eq!(picked.endpoint, "10.0.0.2:8000");
+    }
+
+    #[tokio::test]
+    async fn a_subset_hint_naming_only_prefill_pods_refuses_to_route() {
+        let mut router = router_over(
+            EppStandaloneConfig::for_test(),
+            vec![
+                worker("p-0", "10.0.0.1", WorkerRole::Prefill),
+                worker("d-0", "10.0.0.2", WorkerRole::Decode),
+            ],
+        )
+        .await;
+        router.serving_role = WorkerRole::Decode;
+
+        let req = RequestInfo {
+            request_id: "r1".to_string(),
+            headers: Vec::new(),
+            body: bytes::Bytes::new(),
+            model: String::new(),
+            candidate_subset: vec!["10.0.0.1:8000".to_string()],
+        };
+        assert!(matches!(
+            router.pick(&req, &[]).await,
+            Err(PickError::NoEndpoints)
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_prefill_only_catalog_reports_the_empty_role() {
+        let mut router = router_over(
+            EppStandaloneConfig::for_test(),
+            vec![worker("p-0", "10.0.0.1", WorkerRole::Prefill)],
+        )
+        .await;
+        router.serving_role = WorkerRole::Decode;
+
+        let req = RequestInfo {
+            request_id: "r1".to_string(),
+            headers: Vec::new(),
+            body: bytes::Bytes::new(),
+            model: String::new(),
+            candidate_subset: Vec::new(),
+        };
+        // Attributable in the client's 503, not conflated with an empty pool.
+        assert!(matches!(
+            router.pick(&req, &[]).await,
+            Err(PickError::RoleCatalogEmpty(WorkerRole::Decode))
+        ));
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -14,6 +14,7 @@ use validator::Validate;
 use validator::ValidationError;
 
 use crate::vllm_render_client::parse_tokenizer_service_base_url;
+use crate::worker_role::{DEFAULT_WORKER_ROLE_LABEL, WorkerRole};
 
 const DEFAULT_KV_EVENT_PORT: u16 = 5557;
 const DEFAULT_REPLICA_SYNC_PORT: u16 = 9092;
@@ -36,6 +37,19 @@ pub const DYNAMO_RUNTIME_MODE: &str = "dynamo";
 /// Mirrors `DYN_KUBE_DISCOVERY_MODE` in `dynamo_runtime::discovery`; read
 /// directly here because standalone mode has no Dynamo runtime to read it for.
 const DYN_KUBE_DISCOVERY_MODE: &str = "DYN_KUBE_DISCOVERY_MODE";
+/// Environment variable that selects the serving topology within standalone mode.
+pub const DYN_EPP_TOPOLOGY_MODE: &str = "DYN_EPP_TOPOLOGY_MODE";
+/// `DYN_EPP_TOPOLOGY_MODE` value selecting a single routable worker pool.
+pub const AGGREGATED_TOPOLOGY: &str = "aggregated";
+/// `DYN_EPP_TOPOLOGY_MODE` value selecting role-split prefill/decode pools.
+pub const DISAGGREGATED_TOPOLOGY: &str = "disaggregated";
+/// Environment variable naming the pod label that carries a worker's role.
+pub const DYN_EPP_WORKER_ROLE_LABEL: &str = "DYN_EPP_WORKER_ROLE_LABEL";
+
+/// Longest Kubernetes label-key name segment (the part after any `/`).
+const MAX_LABEL_NAME_LEN: usize = 63;
+/// Longest Kubernetes label-key prefix (the DNS subdomain before the `/`).
+const MAX_LABEL_PREFIX_LEN: usize = 253;
 
 /// Reads an environment variable, matching the injectable getter used in tests.
 type EnvGet<'a> = dyn Fn(&str) -> Option<String> + 'a;
@@ -64,6 +78,44 @@ impl EppMode {
                  expected {STANDALONE_MODE:?} or {DYNAMO_RUNTIME_MODE:?}"
             ),
         }
+    }
+}
+
+/// Serving topology inside standalone mode.
+///
+/// Parsed separately from [`EppStandaloneConfig`] because `run_inner` must reject
+/// `Disaggregated` under `DYN_EPP_MODE=dynamo` *before* the standalone config is
+/// ever read — otherwise the setting is silently ignored and every pool-selected
+/// pod, prefill included, becomes a routable gateway destination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EppTopologyMode {
+    /// Every eligible worker is a routable decode target. Today's behavior.
+    Aggregated,
+    /// The pool carries both prefill and decode pods, split by the worker-role
+    /// label into two catalogs with their own `SelectionService` instances.
+    Disaggregated,
+}
+
+impl EppTopologyMode {
+    pub fn from_env() -> anyhow::Result<Self> {
+        Self::parse(&|k| std::env::var(k).ok())
+    }
+
+    fn parse(get: &EnvGet) -> anyhow::Result<Self> {
+        match trimmed(get(DYN_EPP_TOPOLOGY_MODE)).as_deref() {
+            None | Some(AGGREGATED_TOPOLOGY) => Ok(Self::Aggregated),
+            Some(DISAGGREGATED_TOPOLOGY) => Ok(Self::Disaggregated),
+            // Never fall back: a typo that silently selected aggregated would
+            // hand prefill pods to the gateway as destinations.
+            Some(other) => anyhow::bail!(
+                "{DYN_EPP_TOPOLOGY_MODE} has invalid value {other:?}; \
+                 expected {DISAGGREGATED_TOPOLOGY:?} or {AGGREGATED_TOPOLOGY:?}"
+            ),
+        }
+    }
+
+    pub fn is_disaggregated(self) -> bool {
+        matches!(self, Self::Disaggregated)
     }
 }
 
@@ -115,6 +167,12 @@ pub struct EppStandaloneConfig {
     /// `InferencePool` this EPP backs; its selector + target port drive discovery.
     #[validate(length(min = 1, message = "DYN_EPP_INFERENCE_POOL_NAME is required"))]
     pub inference_pool_name: String,
+    /// Whether the pool holds one routable worker set or a prefill/decode split.
+    pub topology_mode: EppTopologyMode,
+    /// Pod label key carrying a worker's role. Read only when
+    /// `topology_mode == Disaggregated`; the key's syntax is checked there by
+    /// [`EppStandaloneConfig::validate_config`].
+    pub worker_role_label: String,
     /// Kubernetes namespace the EPP runs in (from `POD_NAMESPACE`, downward API).
     #[validate(length(min = 1, message = "POD_NAMESPACE is required"))]
     pub namespace: String,
@@ -148,12 +206,37 @@ pub struct EppStandaloneConfig {
     pub replay_port: Option<u16>,
     /// Optional per-worker total KV blocks.
     pub total_kv_blocks: Option<u64>,
+    /// Per-worker total KV blocks for prefill workers, defaulting to
+    /// [`Self::total_kv_blocks`]. Disaggregated fleets size the two roles
+    /// differently (different TP degree and GPU count), so one shared value
+    /// misdescribes at least one of them.
+    pub prefill_total_kv_blocks: Option<u64>,
+    /// Per-worker total KV blocks for decode workers, defaulting to
+    /// [`Self::total_kv_blocks`].
+    pub decode_total_kv_blocks: Option<u64>,
     /// Optional per-worker max batched tokens.
     #[validate(range(
         min = 1,
         message = "DYN_EPP_MAX_NUM_BATCHED_TOKENS must be greater than zero when set"
     ))]
     pub max_num_batched_tokens: Option<u64>,
+    /// Max batched tokens for prefill workers, defaulting to
+    /// [`Self::max_num_batched_tokens`]. This is the denominator of the
+    /// scheduler's busy test, and shipped disaggregated recipes differ between
+    /// the roles by 8-16x, so sharing one value mis-sizes one role by an order
+    /// of magnitude.
+    #[validate(range(
+        min = 1,
+        message = "DYN_EPP_PREFILL_MAX_NUM_BATCHED_TOKENS must be greater than zero when set"
+    ))]
+    pub prefill_max_num_batched_tokens: Option<u64>,
+    /// Max batched tokens for decode workers, defaulting to
+    /// [`Self::max_num_batched_tokens`].
+    #[validate(range(
+        min = 1,
+        message = "DYN_EPP_DECODE_MAX_NUM_BATCHED_TOKENS must be greater than zero when set"
+    ))]
+    pub decode_max_num_batched_tokens: Option<u64>,
     /// Safety ceiling on concurrent in-flight `pick()`s: bounds concurrent
     /// tokenizer/render calls and buffered bodies (a load-shed guardrail, not a
     /// throughput throttle). Excess requests are shed with a 503, not queued.
@@ -194,11 +277,19 @@ impl EppStandaloneConfig {
             })
             .transpose()?;
 
+        // Bound first: the per-role capacity vars fall back to these, so an
+        // operator can set only the shared value and have both roles inherit it.
+        let total_kv_blocks = opt_parse::<u64>(get, "DYN_EPP_TOTAL_KV_BLOCKS")?;
+        let max_num_batched_tokens = opt_parse::<u64>(get, "DYN_EPP_MAX_NUM_BATCHED_TOKENS")?;
+
         Ok(Self {
             selector_threads: opt_parse::<usize>(get, "DYN_EPP_SELECTION_INDEXER_THREADS")?
                 .unwrap_or(DEFAULT_SELECTOR_THREADS),
             peer_replication,
             inference_pool_name: trimmed(get("DYN_EPP_INFERENCE_POOL_NAME")).unwrap_or_default(),
+            topology_mode: EppTopologyMode::parse(get)?,
+            worker_role_label: trimmed(get(DYN_EPP_WORKER_ROLE_LABEL))
+                .unwrap_or_else(|| DEFAULT_WORKER_ROLE_LABEL.to_string()),
             namespace: trimmed(get("POD_NAMESPACE")).unwrap_or_default(),
             model_name: trimmed(get("DYN_MODEL_NAME")).unwrap_or_default(),
             tokenizer_service_url: trimmed(get("DYN_EPP_TOKENIZER_SERVICE_URL"))
@@ -215,18 +306,118 @@ impl EppStandaloneConfig {
             kv_event_port: opt_parse::<u16>(get, "DYN_EPP_KV_EVENT_PORT")?
                 .unwrap_or(DEFAULT_KV_EVENT_PORT),
             replay_port: opt_parse::<u16>(get, "DYN_EPP_KV_EVENT_REPLAY_PORT")?,
-            total_kv_blocks: opt_parse::<u64>(get, "DYN_EPP_TOTAL_KV_BLOCKS")?,
-            max_num_batched_tokens: opt_parse::<u64>(get, "DYN_EPP_MAX_NUM_BATCHED_TOKENS")?,
+            total_kv_blocks,
+            prefill_total_kv_blocks: opt_parse::<u64>(get, "DYN_EPP_PREFILL_TOTAL_KV_BLOCKS")?
+                .or(total_kv_blocks),
+            decode_total_kv_blocks: opt_parse::<u64>(get, "DYN_EPP_DECODE_TOTAL_KV_BLOCKS")?
+                .or(total_kv_blocks),
+            max_num_batched_tokens,
+            prefill_max_num_batched_tokens: opt_parse::<u64>(
+                get,
+                "DYN_EPP_PREFILL_MAX_NUM_BATCHED_TOKENS",
+            )?
+            .or(max_num_batched_tokens),
+            decode_max_num_batched_tokens: opt_parse::<u64>(
+                get,
+                "DYN_EPP_DECODE_MAX_NUM_BATCHED_TOKENS",
+            )?
+            .or(max_num_batched_tokens),
             max_inflight_requests: opt_parse::<usize>(get, "DYN_EPP_MAX_INFLIGHT_REQUESTS")?
                 .unwrap_or(DEFAULT_MAX_INFLIGHT_REQUESTS),
         })
     }
 
-    /// Enforce the `validator` constraints, mapping the failure to `anyhow`.
+    /// Enforce the `validator` constraints, then the cross-field rules the
+    /// derive cannot express, mapping any failure to `anyhow`.
     pub fn validate_config(&self) -> anyhow::Result<()> {
         self.validate()
             .map_err(|e| anyhow::anyhow!("invalid {STANDALONE_MODE} EPP config: {e}"))?;
+
+        if self.topology_mode.is_disaggregated() {
+            // Only meaningful when the label is actually read. Note the
+            // emptiness case is unreachable through `parse` — `trimmed` maps a
+            // whitespace-only value to `None` and the field takes its non-empty
+            // default — but a caller building the struct literally can still
+            // produce it, so `validate_label_key` rejects it on its own merits.
+            validate_label_key(&self.worker_role_label).map_err(|reason| {
+                anyhow::anyhow!("{DYN_EPP_WORKER_ROLE_LABEL} is not a valid label key: {reason}")
+            })?;
+
+            if self.peer_replication.is_some() {
+                // Both role instances would resolve the same `replica-agg`
+                // named port and race to bind one ZMQ publisher. Multi-replica
+                // disaggregated EPP is Milestone 8.
+                anyhow::bail!(
+                    "{DYN_EPP_TOPOLOGY_MODE}={DISAGGREGATED_TOPOLOGY} does not support \
+                     DYN_EPP_PEER_SERVICE; multi-replica disaggregated EPP is tracked by \
+                     ai-dynamo/dynamo#13418"
+                );
+            }
+        }
+
         Ok(())
+    }
+
+    /// Max batched tokens to register for a worker in `role`.
+    pub fn max_num_batched_tokens_for(&self, role: WorkerRole) -> Option<u64> {
+        match role {
+            WorkerRole::Aggregated => self.max_num_batched_tokens,
+            WorkerRole::Prefill => self.prefill_max_num_batched_tokens,
+            WorkerRole::Decode => self.decode_max_num_batched_tokens,
+        }
+    }
+
+    /// Total KV blocks to register for a worker in `role`.
+    pub fn total_kv_blocks_for(&self, role: WorkerRole) -> Option<u64> {
+        match role {
+            WorkerRole::Aggregated => self.total_kv_blocks,
+            WorkerRole::Prefill => self.prefill_total_kv_blocks,
+            WorkerRole::Decode => self.decode_total_kv_blocks,
+        }
+    }
+
+    /// Env var naming the effective max-batched-tokens for `role`, for error
+    /// messages that must tell an operator which knob to set.
+    pub fn max_num_batched_tokens_env_for(role: WorkerRole) -> &'static str {
+        match role {
+            WorkerRole::Aggregated => "DYN_EPP_MAX_NUM_BATCHED_TOKENS",
+            WorkerRole::Prefill => "DYN_EPP_PREFILL_MAX_NUM_BATCHED_TOKENS",
+            WorkerRole::Decode => "DYN_EPP_DECODE_MAX_NUM_BATCHED_TOKENS",
+        }
+    }
+
+    /// Minimal aggregated config for tests in this crate.
+    ///
+    /// Exists so test fixtures use `..EppStandaloneConfig::for_test()` instead
+    /// of exhaustive struct literals — otherwise every new field is a
+    /// compile break in every test module that builds one.
+    /// `max_num_batched_tokens` is set so `Selector::new` never trips its
+    /// queueing fast-fail regardless of the ambient router policy.
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
+        Self {
+            selector_threads: 1,
+            peer_replication: None,
+            inference_pool_name: "test-pool".to_string(),
+            topology_mode: EppTopologyMode::Aggregated,
+            worker_role_label: DEFAULT_WORKER_ROLE_LABEL.to_string(),
+            namespace: "test-ns".to_string(),
+            model_name: "test-model".to_string(),
+            tokenizer_service_url: "http://vllm-render:8000".to_string(),
+            tokenizer_protocol: TokenizerProtocol::VllmRender,
+            tokenization_timeout_ms: DEFAULT_TOKENIZATION_TIMEOUT_MS,
+            tokenizer_max_response_bytes: DEFAULT_TOKENIZER_MAX_RESPONSE_BYTES,
+            block_size: 16,
+            kv_event_port: DEFAULT_KV_EVENT_PORT,
+            replay_port: None,
+            total_kv_blocks: None,
+            prefill_total_kv_blocks: None,
+            decode_total_kv_blocks: None,
+            max_num_batched_tokens: Some(8192),
+            prefill_max_num_batched_tokens: Some(8192),
+            decode_max_num_batched_tokens: Some(8192),
+            max_inflight_requests: DEFAULT_MAX_INFLIGHT_REQUESTS,
+        }
     }
 }
 
@@ -276,6 +467,101 @@ fn validate_tokenizer_service_url(value: &str) -> Result<(), ValidationError> {
                 Some("DYN_EPP_TOKENIZER_SERVICE_URL must be an absolute HTTP(S) URL".into());
             error
         })
+}
+
+/// Validate a Kubernetes label key, per apimachinery's qualified-name rules.
+///
+/// Written here because the repo has no label-key validator and `validator` is
+/// pulled in derive-only, without `regex`.
+///
+/// ```text
+/// key    := [ prefix "/" ] name        at most one '/'
+/// name   := 1..=63 chars, [A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?   (case-sensitive)
+/// prefix := 1..=253 chars, dot-joined DNS-1123 labels, each [a-z0-9]([-a-z0-9]*[a-z0-9])?
+/// ```
+fn validate_label_key(key: &str) -> Result<(), String> {
+    let (prefix, name) = match key.split_once('/') {
+        Some((prefix, name)) => (Some(prefix), name),
+        None => (None, key),
+    };
+
+    if name.contains('/') {
+        return Err(format!("{key:?} contains more than one '/'"));
+    }
+    validate_label_name(name)?;
+
+    match prefix {
+        None => Ok(()),
+        Some(prefix) => validate_label_prefix(prefix),
+    }
+}
+
+fn validate_label_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("the name segment is empty".to_string());
+    }
+    if name.len() > MAX_LABEL_NAME_LEN {
+        return Err(format!(
+            "the name segment is {} characters, over the {MAX_LABEL_NAME_LEN}-character limit",
+            name.len()
+        ));
+    }
+    if !bounded_by_alphanumeric(name, char::is_ascii_alphanumeric) {
+        return Err(format!(
+            "the name segment {name:?} must start and end with an alphanumeric"
+        ));
+    }
+    if let Some(bad) = name
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')))
+    {
+        return Err(format!(
+            "the name segment {name:?} contains {bad:?}; only alphanumerics, '-', '_' and '.' are allowed"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_label_prefix(prefix: &str) -> Result<(), String> {
+    if prefix.is_empty() {
+        return Err("the prefix before '/' is empty".to_string());
+    }
+    if prefix.len() > MAX_LABEL_PREFIX_LEN {
+        return Err(format!(
+            "the prefix is {} characters, over the {MAX_LABEL_PREFIX_LEN}-character limit",
+            prefix.len()
+        ));
+    }
+    for label in prefix.split('.') {
+        if label.is_empty() {
+            return Err(format!(
+                "the prefix {prefix:?} has an empty dot-separated label"
+            ));
+        }
+        if !bounded_by_alphanumeric(label, |c| c.is_ascii_lowercase() || c.is_ascii_digit()) {
+            return Err(format!(
+                "the prefix label {label:?} must start and end with a lowercase alphanumeric"
+            ));
+        }
+        if let Some(bad) = label
+            .chars()
+            .find(|c| !(c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '-'))
+        {
+            return Err(format!(
+                "the prefix label {label:?} contains {bad:?}; only lowercase alphanumerics and '-' are allowed"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Whether the first and last characters both satisfy `allowed`.
+fn bounded_by_alphanumeric(segment: &str, allowed: impl Fn(&char) -> bool) -> bool {
+    let mut chars = segment.chars();
+    let (Some(first), last) = (chars.next(), segment.chars().next_back()) else {
+        return false;
+    };
+    allowed(&first) && last.is_some_and(|c| allowed(&c))
 }
 
 /// Trim a raw value and treat empty as absent.
@@ -724,6 +1010,254 @@ mod tests {
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ])
             .is_err()
+        );
+    }
+
+    // --- disaggregated topology -------------------------------------------
+
+    /// The minimum env every valid standalone config needs, so topology tests
+    /// state only what they are actually about.
+    const BASE_ENV: &[(&str, &str)] = &[
+        ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+        ("POD_NAMESPACE", "inference"),
+        ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+        ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+        ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
+        ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+    ];
+
+    fn cfg_with(extra: &[(&str, &str)]) -> anyhow::Result<EppStandaloneConfig> {
+        let mut pairs = BASE_ENV.to_vec();
+        pairs.extend_from_slice(extra);
+        parse_cfg(&pairs)
+    }
+
+    fn disagg_with(extra: &[(&str, &str)]) -> anyhow::Result<EppStandaloneConfig> {
+        let mut pairs = vec![(DYN_EPP_TOPOLOGY_MODE, DISAGGREGATED_TOPOLOGY)];
+        pairs.extend_from_slice(extra);
+        cfg_with(&pairs)
+    }
+
+    fn parse_topology(pairs: &[(&str, &str)]) -> anyhow::Result<EppTopologyMode> {
+        EppTopologyMode::parse(&getter(pairs))
+    }
+
+    #[test]
+    fn topology_defaults_to_aggregated_when_unset_or_blank() {
+        assert_eq!(parse_topology(&[]).unwrap(), EppTopologyMode::Aggregated);
+        assert_eq!(
+            parse_topology(&[(DYN_EPP_TOPOLOGY_MODE, "   ")]).unwrap(),
+            EppTopologyMode::Aggregated
+        );
+        assert_eq!(
+            parse_topology(&[(DYN_EPP_TOPOLOGY_MODE, AGGREGATED_TOPOLOGY)]).unwrap(),
+            EppTopologyMode::Aggregated
+        );
+    }
+
+    #[test]
+    fn topology_parses_disaggregated() {
+        assert_eq!(
+            parse_topology(&[(DYN_EPP_TOPOLOGY_MODE, DISAGGREGATED_TOPOLOGY)]).unwrap(),
+            EppTopologyMode::Disaggregated
+        );
+    }
+
+    #[test]
+    fn topology_rejects_unknown_values_naming_both_alternatives() {
+        // Falling back to aggregated on a typo would make every prefill pod a
+        // routable gateway destination, so this must fail loudly.
+        for value in ["disagg", "DISAGGREGATED", "true", "nonsense"] {
+            let error = parse_topology(&[(DYN_EPP_TOPOLOGY_MODE, value)])
+                .expect_err("unknown topology must not fall back")
+                .to_string();
+            assert!(error.contains(DISAGGREGATED_TOPOLOGY), "{error}");
+            assert!(error.contains(AGGREGATED_TOPOLOGY), "{error}");
+        }
+    }
+
+    #[test]
+    fn worker_role_label_defaults_to_the_dep_contract() {
+        let cfg = cfg_with(&[]).unwrap();
+        assert_eq!(cfg.worker_role_label, DEFAULT_WORKER_ROLE_LABEL);
+        assert_eq!(cfg.topology_mode, EppTopologyMode::Aggregated);
+    }
+
+    #[test]
+    fn worker_role_label_is_overridable() {
+        let cfg = disagg_with(&[(
+            DYN_EPP_WORKER_ROLE_LABEL,
+            "nvidia.com/dynamo-component-type",
+        )])
+        .unwrap();
+        assert_eq!(cfg.worker_role_label, "nvidia.com/dynamo-component-type");
+    }
+
+    #[test]
+    fn malformed_role_label_keys_fail_only_under_disaggregated() {
+        let malformed = [
+            ("a/b/c", "two slashes"),
+            ("prefix/", "empty name segment"),
+            ("/role", "empty prefix"),
+            ("-lead", "name starts with a dash"),
+            ("trail-", "name ends with a dash"),
+            ("NVIDIA.com/role", "uppercase in the prefix"),
+        ];
+
+        for (key, why) in malformed {
+            assert!(
+                disagg_with(&[(DYN_EPP_WORKER_ROLE_LABEL, key)]).is_err(),
+                "{key:?} should be rejected under disaggregated ({why})"
+            );
+            // Aggregated never reads the label, so it must not gate startup on it.
+            assert!(
+                cfg_with(&[(DYN_EPP_WORKER_ROLE_LABEL, key)]).is_ok(),
+                "{key:?} must be ignored under aggregated ({why})"
+            );
+        }
+    }
+
+    #[test]
+    fn role_label_name_segment_length_is_bounded() {
+        let ok = "a".repeat(MAX_LABEL_NAME_LEN);
+        let too_long = "a".repeat(MAX_LABEL_NAME_LEN + 1);
+        assert!(disagg_with(&[(DYN_EPP_WORKER_ROLE_LABEL, &ok)]).is_ok());
+        assert!(disagg_with(&[(DYN_EPP_WORKER_ROLE_LABEL, &too_long)]).is_err());
+    }
+
+    #[test]
+    fn role_label_prefix_length_is_bounded() {
+        let long_prefix = format!("{}.com", "a".repeat(MAX_LABEL_PREFIX_LEN));
+        assert!(
+            disagg_with(&[(DYN_EPP_WORKER_ROLE_LABEL, &format!("{long_prefix}/role"))]).is_err()
+        );
+    }
+
+    #[test]
+    fn valid_prefixed_and_bare_role_label_keys_pass() {
+        for key in [
+            "nvidia.com/role",
+            "role",
+            "a.b.c/some_name.with-punct",
+            "x/y",
+        ] {
+            assert!(
+                disagg_with(&[(DYN_EPP_WORKER_ROLE_LABEL, key)]).is_ok(),
+                "{key:?} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn disaggregated_rejects_peer_service() {
+        // Both role instances would resolve the same `replica-agg` named port
+        // and race to bind one ZMQ publisher.
+        let error = disagg_with(&[
+            ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
+            ("POD_IP", "10.0.0.5"),
+        ])
+        .expect_err("multi-replica disaggregated EPP is not supported yet")
+        .to_string();
+        assert!(error.contains("DYN_EPP_PEER_SERVICE"), "{error}");
+        assert!(error.contains("13418"), "{error}");
+    }
+
+    #[test]
+    fn aggregated_still_accepts_peer_service() {
+        assert!(
+            cfg_with(&[
+                ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
+                ("POD_IP", "10.0.0.5")
+            ])
+            .is_ok()
+        );
+    }
+
+    // --- per-role capacity -------------------------------------------------
+
+    #[test]
+    fn per_role_capacity_falls_back_to_the_shared_value() {
+        let cfg = cfg_with(&[
+            ("DYN_EPP_MAX_NUM_BATCHED_TOKENS", "8192"),
+            ("DYN_EPP_TOTAL_KV_BLOCKS", "1000"),
+        ])
+        .unwrap();
+
+        for role in [WorkerRole::Prefill, WorkerRole::Decode] {
+            assert_eq!(cfg.max_num_batched_tokens_for(role), Some(8192));
+            assert_eq!(cfg.total_kv_blocks_for(role), Some(1000));
+        }
+    }
+
+    #[test]
+    fn per_role_capacity_overrides_independently() {
+        // Shipped disaggregated recipes differ between the roles by 8-16x, so
+        // one shared value mis-sizes one role by an order of magnitude.
+        let cfg = disagg_with(&[
+            ("DYN_EPP_MAX_NUM_BATCHED_TOKENS", "8192"),
+            ("DYN_EPP_PREFILL_MAX_NUM_BATCHED_TOKENS", "16384"),
+            ("DYN_EPP_DECODE_MAX_NUM_BATCHED_TOKENS", "2048"),
+            ("DYN_EPP_TOTAL_KV_BLOCKS", "1000"),
+            ("DYN_EPP_PREFILL_TOTAL_KV_BLOCKS", "4000"),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            cfg.max_num_batched_tokens_for(WorkerRole::Prefill),
+            Some(16384)
+        );
+        assert_eq!(
+            cfg.max_num_batched_tokens_for(WorkerRole::Decode),
+            Some(2048)
+        );
+        assert_eq!(
+            cfg.max_num_batched_tokens_for(WorkerRole::Aggregated),
+            Some(8192)
+        );
+
+        assert_eq!(cfg.total_kv_blocks_for(WorkerRole::Prefill), Some(4000));
+        // Not overridden: falls back to the shared value.
+        assert_eq!(cfg.total_kv_blocks_for(WorkerRole::Decode), Some(1000));
+    }
+
+    #[test]
+    fn per_role_capacity_is_absent_when_nothing_is_set() {
+        let cfg = cfg_with(&[]).unwrap();
+        for role in [
+            WorkerRole::Aggregated,
+            WorkerRole::Prefill,
+            WorkerRole::Decode,
+        ] {
+            assert!(cfg.max_num_batched_tokens_for(role).is_none());
+            assert!(cfg.total_kv_blocks_for(role).is_none());
+        }
+    }
+
+    #[test]
+    fn zero_per_role_max_num_batched_tokens_fails() {
+        // Mirrors the existing guard on the shared var: a zero denominator
+        // would reach the scheduler's busy test.
+        for var in [
+            "DYN_EPP_PREFILL_MAX_NUM_BATCHED_TOKENS",
+            "DYN_EPP_DECODE_MAX_NUM_BATCHED_TOKENS",
+        ] {
+            assert!(disagg_with(&[(var, "0")]).is_err(), "{var} = 0 must fail");
+        }
+    }
+
+    #[test]
+    fn per_role_capacity_env_names_are_reported_for_operators() {
+        assert_eq!(
+            EppStandaloneConfig::max_num_batched_tokens_env_for(WorkerRole::Prefill),
+            "DYN_EPP_PREFILL_MAX_NUM_BATCHED_TOKENS"
+        );
+        assert_eq!(
+            EppStandaloneConfig::max_num_batched_tokens_env_for(WorkerRole::Decode),
+            "DYN_EPP_DECODE_MAX_NUM_BATCHED_TOKENS"
+        );
+        assert_eq!(
+            EppStandaloneConfig::max_num_batched_tokens_env_for(WorkerRole::Aggregated),
+            "DYN_EPP_MAX_NUM_BATCHED_TOKENS"
         );
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -1045,7 +1045,7 @@ mod tests {
     }
 
     #[test]
-    fn worker_role_label_defaults_to_the_dep_contract() {
+    fn worker_role_label_has_a_default() {
         let cfg = cfg_with(&[]).unwrap();
         assert_eq!(cfg.worker_role_label, DEFAULT_WORKER_ROLE_LABEL);
         assert_eq!(cfg.topology_mode, EppTopologyMode::Aggregated);
@@ -1104,7 +1104,7 @@ mod tests {
     #[test]
     fn valid_prefixed_and_bare_role_label_keys_pass() {
         for key in [
-            "nvidia.com/role",
+            "nvidia.com/dynamo-worker-role",
             "role",
             "a.b.c/some_name.with-punct",
             "x/y",

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -82,11 +82,6 @@ impl EppMode {
 }
 
 /// Serving topology inside standalone mode.
-///
-/// Parsed separately from [`EppStandaloneConfig`] because `run_inner` must reject
-/// `Disaggregated` under `DYN_EPP_MODE=dynamo` *before* the standalone config is
-/// ever read — otherwise the setting is silently ignored and every pool-selected
-/// pod, prefill included, becomes a routable gateway destination.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EppTopologyMode {
     /// Every eligible worker is a routable decode target. Today's behavior.
@@ -97,10 +92,6 @@ pub enum EppTopologyMode {
 }
 
 impl EppTopologyMode {
-    pub fn from_env() -> anyhow::Result<Self> {
-        Self::parse(&|k| std::env::var(k).ok())
-    }
-
     fn parse(get: &EnvGet) -> anyhow::Result<Self> {
         match trimmed(get(DYN_EPP_TOPOLOGY_MODE)).as_deref() {
             None | Some(AGGREGATED_TOPOLOGY) => Ok(Self::Aggregated),
@@ -206,14 +197,6 @@ pub struct EppStandaloneConfig {
     pub replay_port: Option<u16>,
     /// Optional per-worker total KV blocks.
     pub total_kv_blocks: Option<u64>,
-    /// Per-worker total KV blocks for prefill workers, defaulting to
-    /// [`Self::total_kv_blocks`]. Disaggregated fleets size the two roles
-    /// differently (different TP degree and GPU count), so one shared value
-    /// misdescribes at least one of them.
-    pub prefill_total_kv_blocks: Option<u64>,
-    /// Per-worker total KV blocks for decode workers, defaulting to
-    /// [`Self::total_kv_blocks`].
-    pub decode_total_kv_blocks: Option<u64>,
     /// Optional per-worker max batched tokens.
     #[validate(range(
         min = 1,
@@ -307,10 +290,6 @@ impl EppStandaloneConfig {
                 .unwrap_or(DEFAULT_KV_EVENT_PORT),
             replay_port: opt_parse::<u16>(get, "DYN_EPP_KV_EVENT_REPLAY_PORT")?,
             total_kv_blocks,
-            prefill_total_kv_blocks: opt_parse::<u64>(get, "DYN_EPP_PREFILL_TOTAL_KV_BLOCKS")?
-                .or(total_kv_blocks),
-            decode_total_kv_blocks: opt_parse::<u64>(get, "DYN_EPP_DECODE_TOTAL_KV_BLOCKS")?
-                .or(total_kv_blocks),
             max_num_batched_tokens,
             prefill_max_num_batched_tokens: opt_parse::<u64>(
                 get,
@@ -367,15 +346,6 @@ impl EppStandaloneConfig {
         }
     }
 
-    /// Total KV blocks to register for a worker in `role`.
-    pub fn total_kv_blocks_for(&self, role: WorkerRole) -> Option<u64> {
-        match role {
-            WorkerRole::Aggregated => self.total_kv_blocks,
-            WorkerRole::Prefill => self.prefill_total_kv_blocks,
-            WorkerRole::Decode => self.decode_total_kv_blocks,
-        }
-    }
-
     /// Env var naming the effective max-batched-tokens for `role`, for error
     /// messages that must tell an operator which knob to set.
     pub fn max_num_batched_tokens_env_for(role: WorkerRole) -> &'static str {
@@ -411,8 +381,6 @@ impl EppStandaloneConfig {
             kv_event_port: DEFAULT_KV_EVENT_PORT,
             replay_port: None,
             total_kv_blocks: None,
-            prefill_total_kv_blocks: None,
-            decode_total_kv_blocks: None,
             max_num_batched_tokens: Some(8192),
             prefill_max_num_batched_tokens: Some(8192),
             decode_max_num_batched_tokens: Some(8192),
@@ -1177,15 +1145,10 @@ mod tests {
 
     #[test]
     fn per_role_capacity_falls_back_to_the_shared_value() {
-        let cfg = cfg_with(&[
-            ("DYN_EPP_MAX_NUM_BATCHED_TOKENS", "8192"),
-            ("DYN_EPP_TOTAL_KV_BLOCKS", "1000"),
-        ])
-        .unwrap();
+        let cfg = cfg_with(&[("DYN_EPP_MAX_NUM_BATCHED_TOKENS", "8192")]).unwrap();
 
         for role in [WorkerRole::Prefill, WorkerRole::Decode] {
             assert_eq!(cfg.max_num_batched_tokens_for(role), Some(8192));
-            assert_eq!(cfg.total_kv_blocks_for(role), Some(1000));
         }
     }
 
@@ -1197,8 +1160,6 @@ mod tests {
             ("DYN_EPP_MAX_NUM_BATCHED_TOKENS", "8192"),
             ("DYN_EPP_PREFILL_MAX_NUM_BATCHED_TOKENS", "16384"),
             ("DYN_EPP_DECODE_MAX_NUM_BATCHED_TOKENS", "2048"),
-            ("DYN_EPP_TOTAL_KV_BLOCKS", "1000"),
-            ("DYN_EPP_PREFILL_TOTAL_KV_BLOCKS", "4000"),
         ])
         .unwrap();
 
@@ -1214,10 +1175,6 @@ mod tests {
             cfg.max_num_batched_tokens_for(WorkerRole::Aggregated),
             Some(8192)
         );
-
-        assert_eq!(cfg.total_kv_blocks_for(WorkerRole::Prefill), Some(4000));
-        // Not overridden: falls back to the shared value.
-        assert_eq!(cfg.total_kv_blocks_for(WorkerRole::Decode), Some(1000));
     }
 
     #[test]
@@ -1229,7 +1186,6 @@ mod tests {
             WorkerRole::Decode,
         ] {
             assert!(cfg.max_num_batched_tokens_for(role).is_none());
-            assert!(cfg.total_kv_blocks_for(role).is_none());
         }
     }
 

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -84,7 +84,7 @@ impl EppMode {
 /// Serving topology inside standalone mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EppTopologyMode {
-    /// Every eligible worker is a routable decode target. Today's behavior.
+    /// Every eligible worker is a routable decode target.
     Aggregated,
     /// The pool carries both prefill and decode pods, split by the worker-role
     /// label into two catalogs with their own `SelectionService` instances.
@@ -204,10 +204,9 @@ pub struct EppStandaloneConfig {
     ))]
     pub max_num_batched_tokens: Option<u64>,
     /// Max batched tokens for prefill workers, defaulting to
-    /// [`Self::max_num_batched_tokens`]. This is the denominator of the
-    /// scheduler's busy test, and shipped disaggregated recipes differ between
-    /// the roles by 8-16x, so sharing one value mis-sizes one role by an order
-    /// of magnitude.
+    /// [`Self::max_num_batched_tokens`]. Split per role because this is the
+    /// denominator of the scheduler's busy test and shipped disaggregated
+    /// recipes differ between the roles by 8-16x.
     #[validate(range(
         min = 1,
         message = "DYN_EPP_PREFILL_MAX_NUM_BATCHED_TOKENS must be greater than zero when set"
@@ -260,8 +259,6 @@ impl EppStandaloneConfig {
             })
             .transpose()?;
 
-        // Bound first: the per-role capacity vars fall back to these, so an
-        // operator can set only the shared value and have both roles inherit it.
         let total_kv_blocks = opt_parse::<u64>(get, "DYN_EPP_TOTAL_KV_BLOCKS")?;
         let max_num_batched_tokens = opt_parse::<u64>(get, "DYN_EPP_MAX_NUM_BATCHED_TOKENS")?;
 
@@ -306,26 +303,20 @@ impl EppStandaloneConfig {
         })
     }
 
-    /// Enforce the `validator` constraints, then the cross-field rules the
-    /// derive cannot express, mapping any failure to `anyhow`.
+    /// Enforce the field and cross-field constraints, mapping any failure to `anyhow`.
     pub fn validate_config(&self) -> anyhow::Result<()> {
         self.validate()
             .map_err(|e| anyhow::anyhow!("invalid {STANDALONE_MODE} EPP config: {e}"))?;
 
         if self.topology_mode.is_disaggregated() {
-            // Only meaningful when the label is actually read. Note the
-            // emptiness case is unreachable through `parse` — `trimmed` maps a
-            // whitespace-only value to `None` and the field takes its non-empty
-            // default — but a caller building the struct literally can still
-            // produce it, so `validate_label_key` rejects it on its own merits.
+            // Only meaningful when the label is actually read.
             validate_label_key(&self.worker_role_label).map_err(|reason| {
                 anyhow::anyhow!("{DYN_EPP_WORKER_ROLE_LABEL} is not a valid label key: {reason}")
             })?;
 
             if self.peer_replication.is_some() {
                 // Both role instances would resolve the same `replica-agg`
-                // named port and race to bind one ZMQ publisher. Multi-replica
-                // disaggregated EPP is Milestone 8.
+                // named port and race to bind one ZMQ publisher.
                 anyhow::bail!(
                     "{DYN_EPP_TOPOLOGY_MODE}={DISAGGREGATED_TOPOLOGY} does not support \
                      DYN_EPP_PEER_SERVICE; multi-replica disaggregated EPP is tracked by \
@@ -356,13 +347,9 @@ impl EppStandaloneConfig {
         }
     }
 
-    /// Minimal aggregated config for tests in this crate.
-    ///
-    /// Exists so test fixtures use `..EppStandaloneConfig::for_test()` instead
-    /// of exhaustive struct literals — otherwise every new field is a
-    /// compile break in every test module that builds one.
-    /// `max_num_batched_tokens` is set so `Selector::new` never trips its
-    /// queueing fast-fail regardless of the ambient router policy.
+    /// Minimal aggregated config for tests in this crate. `max_num_batched_tokens`
+    /// is set so `Selector::new` never trips its queueing fast-fail regardless of
+    /// the ambient router policy.
     #[cfg(test)]
     pub(crate) fn for_test() -> Self {
         Self {
@@ -437,10 +424,9 @@ fn validate_tokenizer_service_url(value: &str) -> Result<(), ValidationError> {
         })
 }
 
-/// Validate a Kubernetes label key, per apimachinery's qualified-name rules.
-///
-/// Written here because the repo has no label-key validator and `validator` is
-/// pulled in derive-only, without `regex`.
+/// Validate a Kubernetes label key per apimachinery's qualified-name rules; written
+/// here because the repo has no label-key validator and `validator` is derive-only
+/// (no `regex`).
 ///
 /// ```text
 /// key    := [ prefix "/" ] name        at most one '/'
@@ -1011,181 +997,204 @@ mod tests {
     }
 
     #[test]
-    fn topology_defaults_to_aggregated_when_unset_or_blank() {
-        assert_eq!(parse_topology(&[]).unwrap(), EppTopologyMode::Aggregated);
-        assert_eq!(
-            parse_topology(&[(DYN_EPP_TOPOLOGY_MODE, "   ")]).unwrap(),
-            EppTopologyMode::Aggregated
-        );
-        assert_eq!(
-            parse_topology(&[(DYN_EPP_TOPOLOGY_MODE, AGGREGATED_TOPOLOGY)]).unwrap(),
-            EppTopologyMode::Aggregated
-        );
-    }
+    fn topology_mode_parsing() {
+        type Env = &'static [(&'static str, &'static str)];
+        type Case = (&'static str, Env, Option<EppTopologyMode>);
 
-    #[test]
-    fn topology_parses_disaggregated() {
-        assert_eq!(
-            parse_topology(&[(DYN_EPP_TOPOLOGY_MODE, DISAGGREGATED_TOPOLOGY)]).unwrap(),
-            EppTopologyMode::Disaggregated
-        );
-    }
+        let cases: [Case; 8] = [
+            ("unset", &[], Some(EppTopologyMode::Aggregated)),
+            (
+                "blank",
+                &[(DYN_EPP_TOPOLOGY_MODE, "   ")],
+                Some(EppTopologyMode::Aggregated),
+            ),
+            (
+                "aggregated",
+                &[(DYN_EPP_TOPOLOGY_MODE, AGGREGATED_TOPOLOGY)],
+                Some(EppTopologyMode::Aggregated),
+            ),
+            (
+                "disaggregated",
+                &[(DYN_EPP_TOPOLOGY_MODE, DISAGGREGATED_TOPOLOGY)],
+                Some(EppTopologyMode::Disaggregated),
+            ),
+            ("abbreviated", &[(DYN_EPP_TOPOLOGY_MODE, "disagg")], None),
+            (
+                "wrong case",
+                &[(DYN_EPP_TOPOLOGY_MODE, "DISAGGREGATED")],
+                None,
+            ),
+            ("boolean", &[(DYN_EPP_TOPOLOGY_MODE, "true")], None),
+            ("nonsense", &[(DYN_EPP_TOPOLOGY_MODE, "nonsense")], None),
+        ];
 
-    #[test]
-    fn topology_rejects_unknown_values_naming_both_alternatives() {
-        // Falling back to aggregated on a typo would make every prefill pod a
-        // routable gateway destination, so this must fail loudly.
-        for value in ["disagg", "DISAGGREGATED", "true", "nonsense"] {
-            let error = parse_topology(&[(DYN_EPP_TOPOLOGY_MODE, value)])
-                .expect_err("unknown topology must not fall back")
-                .to_string();
-            assert!(error.contains(DISAGGREGATED_TOPOLOGY), "{error}");
-            assert!(error.contains(AGGREGATED_TOPOLOGY), "{error}");
+        for (name, env, expected) in cases {
+            match expected {
+                Some(mode) => {
+                    let got = parse_topology(env).unwrap_or_else(|error| panic!("{name}: {error}"));
+                    assert_eq!(got, mode, "{name}");
+                }
+                None => {
+                    let error = parse_topology(env).expect_err(name).to_string();
+                    assert!(error.contains(DISAGGREGATED_TOPOLOGY), "{name}: {error}");
+                    assert!(error.contains(AGGREGATED_TOPOLOGY), "{name}: {error}");
+                }
+            }
         }
     }
 
     #[test]
-    fn worker_role_label_has_a_default() {
+    fn worker_role_label_defaults_and_overrides() {
         let cfg = cfg_with(&[]).unwrap();
-        assert_eq!(cfg.worker_role_label, DEFAULT_WORKER_ROLE_LABEL);
         assert_eq!(cfg.topology_mode, EppTopologyMode::Aggregated);
-    }
+        assert_eq!(cfg.worker_role_label, DEFAULT_WORKER_ROLE_LABEL);
 
-    #[test]
-    fn worker_role_label_is_overridable() {
         let cfg = disagg_with(&[(
             DYN_EPP_WORKER_ROLE_LABEL,
             "nvidia.com/dynamo-component-type",
         )])
         .unwrap();
+        assert_eq!(cfg.topology_mode, EppTopologyMode::Disaggregated);
         assert_eq!(cfg.worker_role_label, "nvidia.com/dynamo-component-type");
     }
 
     #[test]
-    fn malformed_role_label_keys_fail_only_under_disaggregated() {
-        let malformed = [
-            ("a/b/c", "two slashes"),
-            ("prefix/", "empty name segment"),
-            ("/role", "empty prefix"),
-            ("-lead", "name starts with a dash"),
-            ("trail-", "name ends with a dash"),
-            ("NVIDIA.com/role", "uppercase in the prefix"),
+    fn worker_role_label_key_validation() {
+        // Four dot-joined DNS labels; the last is sized to land on the prefix limit.
+        let prefix_of = |last: usize| {
+            let label = "a".repeat(63);
+            format!("{label}.{label}.{label}.{}", "a".repeat(last))
+        };
+        let max_name = "a".repeat(MAX_LABEL_NAME_LEN);
+        let over_name = "a".repeat(MAX_LABEL_NAME_LEN + 1);
+        let max_prefix = prefix_of(61);
+        let over_prefix = prefix_of(62);
+        assert_eq!(max_prefix.len(), MAX_LABEL_PREFIX_LEN);
+        assert_eq!(over_prefix.len(), MAX_LABEL_PREFIX_LEN + 1);
+        let max_prefix_key = format!("{max_prefix}/role");
+        let over_prefix_key = format!("{over_prefix}/role");
+
+        let cases: [(&str, bool); 14] = [
+            ("nvidia.com/dynamo-worker-role", true),
+            ("role", true),
+            ("a.b.c/some_name.with-punct", true),
+            ("x/y", true),
+            (max_name.as_str(), true),
+            (max_prefix_key.as_str(), true),
+            ("a/b/c", false),
+            ("prefix/", false),
+            ("/role", false),
+            ("-lead", false),
+            ("trail-", false),
+            ("NVIDIA.com/role", false),
+            (over_name.as_str(), false),
+            (over_prefix_key.as_str(), false),
         ];
 
-        for (key, why) in malformed {
-            assert!(
-                disagg_with(&[(DYN_EPP_WORKER_ROLE_LABEL, key)]).is_err(),
-                "{key:?} should be rejected under disaggregated ({why})"
+        for (key, valid) in cases {
+            assert_eq!(
+                disagg_with(&[(DYN_EPP_WORKER_ROLE_LABEL, key)]).is_ok(),
+                valid,
+                "{key:?} under disaggregated"
             );
-            // Aggregated never reads the label, so it must not gate startup on it.
+        }
+
+        // Aggregated never reads the label, so startup must not gate on it.
+        for (key, _) in cases {
             assert!(
                 cfg_with(&[(DYN_EPP_WORKER_ROLE_LABEL, key)]).is_ok(),
-                "{key:?} must be ignored under aggregated ({why})"
+                "{key:?} under aggregated"
             );
         }
     }
 
     #[test]
-    fn role_label_name_segment_length_is_bounded() {
-        let ok = "a".repeat(MAX_LABEL_NAME_LEN);
-        let too_long = "a".repeat(MAX_LABEL_NAME_LEN + 1);
-        assert!(disagg_with(&[(DYN_EPP_WORKER_ROLE_LABEL, &ok)]).is_ok());
-        assert!(disagg_with(&[(DYN_EPP_WORKER_ROLE_LABEL, &too_long)]).is_err());
-    }
+    fn peer_service_is_rejected_only_under_disaggregated() {
+        let cases = [(AGGREGATED_TOPOLOGY, true), (DISAGGREGATED_TOPOLOGY, false)];
 
-    #[test]
-    fn role_label_prefix_length_is_bounded() {
-        let long_prefix = format!("{}.com", "a".repeat(MAX_LABEL_PREFIX_LEN));
-        assert!(
-            disagg_with(&[(DYN_EPP_WORKER_ROLE_LABEL, &format!("{long_prefix}/role"))]).is_err()
-        );
-    }
-
-    #[test]
-    fn valid_prefixed_and_bare_role_label_keys_pass() {
-        for key in [
-            "nvidia.com/dynamo-worker-role",
-            "role",
-            "a.b.c/some_name.with-punct",
-            "x/y",
-        ] {
-            assert!(
-                disagg_with(&[(DYN_EPP_WORKER_ROLE_LABEL, key)]).is_ok(),
-                "{key:?} should be accepted"
-            );
-        }
-    }
-
-    #[test]
-    fn disaggregated_rejects_peer_service() {
-        // Both role instances would resolve the same `replica-agg` named port
-        // and race to bind one ZMQ publisher.
-        let error = disagg_with(&[
-            ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
-            ("POD_IP", "10.0.0.5"),
-        ])
-        .expect_err("multi-replica disaggregated EPP is not supported yet")
-        .to_string();
-        assert!(error.contains("DYN_EPP_PEER_SERVICE"), "{error}");
-        assert!(error.contains("13418"), "{error}");
-    }
-
-    #[test]
-    fn aggregated_still_accepts_peer_service() {
-        assert!(
-            cfg_with(&[
+        for (topology, accepted) in cases {
+            let result = cfg_with(&[
+                (DYN_EPP_TOPOLOGY_MODE, topology),
                 ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
-                ("POD_IP", "10.0.0.5")
-            ])
-            .is_ok()
-        );
+                ("POD_IP", "10.0.0.5"),
+            ]);
+            match result {
+                Ok(_) => assert!(accepted, "{topology}: peer service must be rejected"),
+                Err(error) => {
+                    let error = error.to_string();
+                    assert!(!accepted, "{topology}: {error}");
+                    assert!(
+                        error.contains("DYN_EPP_PEER_SERVICE"),
+                        "{topology}: {error}"
+                    );
+                    assert!(error.contains("13418"), "{topology}: {error}");
+                }
+            }
+        }
     }
 
     // --- per-role capacity -------------------------------------------------
 
     #[test]
-    fn per_role_capacity_falls_back_to_the_shared_value() {
-        let cfg = cfg_with(&[("DYN_EPP_MAX_NUM_BATCHED_TOKENS", "8192")]).unwrap();
+    fn per_role_max_num_batched_tokens() {
+        type Env = &'static [(&'static str, &'static str)];
+        type Case = (&'static str, Env, WorkerRole, Option<u64>);
 
-        for role in [WorkerRole::Prefill, WorkerRole::Decode] {
-            assert_eq!(cfg.max_num_batched_tokens_for(role), Some(8192));
-        }
-    }
-
-    #[test]
-    fn per_role_capacity_overrides_independently() {
-        // Shipped disaggregated recipes differ between the roles by 8-16x, so
-        // one shared value mis-sizes one role by an order of magnitude.
-        let cfg = disagg_with(&[
+        const SHARED: Env = &[("DYN_EPP_MAX_NUM_BATCHED_TOKENS", "8192")];
+        const OVERRIDES: Env = &[
             ("DYN_EPP_MAX_NUM_BATCHED_TOKENS", "8192"),
             ("DYN_EPP_PREFILL_MAX_NUM_BATCHED_TOKENS", "16384"),
             ("DYN_EPP_DECODE_MAX_NUM_BATCHED_TOKENS", "2048"),
-        ])
-        .unwrap();
+        ];
+        let cases: [Case; 9] = [
+            ("unset", &[], WorkerRole::Aggregated, None),
+            ("unset", &[], WorkerRole::Prefill, None),
+            ("unset", &[], WorkerRole::Decode, None),
+            ("shared only", SHARED, WorkerRole::Aggregated, Some(8192)),
+            ("shared only", SHARED, WorkerRole::Prefill, Some(8192)),
+            ("shared only", SHARED, WorkerRole::Decode, Some(8192)),
+            (
+                "per-role overrides",
+                OVERRIDES,
+                WorkerRole::Aggregated,
+                Some(8192),
+            ),
+            (
+                "per-role overrides",
+                OVERRIDES,
+                WorkerRole::Prefill,
+                Some(16384),
+            ),
+            (
+                "per-role overrides",
+                OVERRIDES,
+                WorkerRole::Decode,
+                Some(2048),
+            ),
+        ];
 
-        assert_eq!(
-            cfg.max_num_batched_tokens_for(WorkerRole::Prefill),
-            Some(16384)
-        );
-        assert_eq!(
-            cfg.max_num_batched_tokens_for(WorkerRole::Decode),
-            Some(2048)
-        );
-        assert_eq!(
-            cfg.max_num_batched_tokens_for(WorkerRole::Aggregated),
-            Some(8192)
-        );
-    }
+        for (name, env, role, expected) in cases {
+            let cfg = disagg_with(env).unwrap_or_else(|error| panic!("{name}: {error}"));
+            assert_eq!(
+                cfg.max_num_batched_tokens_for(role),
+                expected,
+                "{name}: {role:?}"
+            );
+        }
 
-    #[test]
-    fn per_role_capacity_is_absent_when_nothing_is_set() {
-        let cfg = cfg_with(&[]).unwrap();
-        for role in [
-            WorkerRole::Aggregated,
-            WorkerRole::Prefill,
-            WorkerRole::Decode,
+        for (role, var) in [
+            (WorkerRole::Aggregated, "DYN_EPP_MAX_NUM_BATCHED_TOKENS"),
+            (
+                WorkerRole::Prefill,
+                "DYN_EPP_PREFILL_MAX_NUM_BATCHED_TOKENS",
+            ),
+            (WorkerRole::Decode, "DYN_EPP_DECODE_MAX_NUM_BATCHED_TOKENS"),
         ] {
-            assert!(cfg.max_num_batched_tokens_for(role).is_none());
+            assert_eq!(
+                EppStandaloneConfig::max_num_batched_tokens_env_for(role),
+                var,
+                "{role:?}"
+            );
         }
     }
 
@@ -1199,21 +1208,5 @@ mod tests {
         ] {
             assert!(disagg_with(&[(var, "0")]).is_err(), "{var} = 0 must fail");
         }
-    }
-
-    #[test]
-    fn per_role_capacity_env_names_are_reported_for_operators() {
-        assert_eq!(
-            EppStandaloneConfig::max_num_batched_tokens_env_for(WorkerRole::Prefill),
-            "DYN_EPP_PREFILL_MAX_NUM_BATCHED_TOKENS"
-        );
-        assert_eq!(
-            EppStandaloneConfig::max_num_batched_tokens_env_for(WorkerRole::Decode),
-            "DYN_EPP_DECODE_MAX_NUM_BATCHED_TOKENS"
-        );
-        assert_eq!(
-            EppStandaloneConfig::max_num_batched_tokens_env_for(WorkerRole::Aggregated),
-            "DYN_EPP_MAX_NUM_BATCHED_TOKENS"
-        );
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -21,11 +21,13 @@ pub mod peer_discovery;
 pub mod picker;
 pub mod pod_discovery;
 pub mod proto;
+mod role_config;
 mod runner;
 pub mod selector;
 pub mod server;
 pub mod topology_adapter;
 pub mod vllm_render_client;
+pub mod worker_role;
 
 pub use epp::Router;
 pub use epp_router::EppRouter;
@@ -40,3 +42,4 @@ pub use selector::{OverlapSummary, SelectRequest, SelectResponse, Selector, Work
 pub use server::ExtProcServer;
 pub use topology_adapter::{RegistrationDefaults, TopologyAdapter};
 pub use vllm_render_client::{VllmRenderClient, VllmRenderError};
+pub use worker_role::{RoleCounts, RoleLabelError, WorkerRole};

--- a/deploy/inference-gateway/ext-proc/src/picker.rs
+++ b/deploy/inference-gateway/ext-proc/src/picker.rs
@@ -10,6 +10,8 @@ use std::collections::HashMap;
 
 use bytes::Bytes;
 
+use crate::worker_role::WorkerRole;
+
 /// A model server pod endpoint available for serving requests.
 #[derive(Debug, Clone)]
 pub struct Endpoint {
@@ -153,6 +155,12 @@ pub struct ResponseUsage {
 pub enum PickError {
     #[error("no endpoints available")]
     NoEndpoints,
+    /// The serving role's catalog is empty while the pool itself is fine — the
+    /// disaggregated shape of `NoEndpoints`, kept distinct so a mislabelled or
+    /// drained role is attributable in the client's 503 rather than looking like
+    /// an empty pool.
+    #[error("no {0} workers available")]
+    RoleCatalogEmpty(WorkerRole),
     #[error("routing failed: {0}")]
     RoutingFailed(String),
     /// Malformed client input (unparseable body, or a 4xx from the tokenizer) → 400.

--- a/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
@@ -20,6 +20,7 @@ use tokio::sync::watch;
 
 use crate::epp_standalone_config::EppStandaloneConfig;
 use crate::inference_pool::{PoolState, spawn_pool_watch};
+use crate::worker_role::{RoleCounts, RoleLabelError, WorkerRole};
 
 /// A discovered, `Ready` raw inference engine worker normalized for selector registration.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,12 +31,35 @@ pub struct RawWorker {
     pub pod_name: String,
     /// Pod IP.
     pub pod_ip: String,
+    /// Stage this worker serves. Always [`WorkerRole::Aggregated`] in aggregated
+    /// topology; `Prefill` or `Decode` when the pool is role-split.
+    pub role: WorkerRole,
     /// OpenAI HTTP inference endpoint, `http://<ip>:<target_port>`.
     pub http_endpoint: String,
     /// Inference engine KV-event ZMQ PUB endpoint, `tcp://<ip>:<kv_event_port>`.
-    pub kv_events_endpoint: String,
-    /// Optional ZMQ REQ endpoint for live-stream gap replay.
+    ///
+    /// `None` for [`WorkerRole::Decode`]: that role's `SelectionService` runs
+    /// with KV events off, so it neither subscribes nor requires an endpoint to
+    /// call the worker schedulable.
+    pub kv_events_endpoint: Option<String>,
+    /// Optional ZMQ REQ endpoint for live-stream gap replay. `None` for
+    /// [`WorkerRole::Decode`] for the same reason as `kv_events_endpoint`.
     pub replay_endpoint: Option<String>,
+}
+
+/// Why a pod produced no worker.
+///
+/// The two arms are deliberately distinct: an ineligible pod is normal and
+/// silent, while an eligible pod the EPP cannot assign a role to is an operator
+/// error worth surfacing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PodRejection {
+    /// Not `Ready`, not pool-selected, unnamed, or without a parseable IP.
+    /// Pre-existing behavior, and the only outcome possible in aggregated
+    /// topology.
+    Ineligible,
+    /// Pool-selected and `Ready`, but the role label is missing or unparseable.
+    Role(RoleLabelError),
 }
 
 /// One indexed worker: the materialized [`RawWorker`] for selector registration
@@ -59,10 +83,71 @@ impl WorkerEntry {
 /// Derived catalog of the `Ready`, pool-selected workers, keyed by `worker_id`.
 type WorkerIndex = HashMap<u64, WorkerEntry>;
 
+/// The worker index plus denormalized per-role counts.
+///
+/// The counts exist so [`PodDiscovery::has_ready_workers`] — which runs on every
+/// request — stays O(1) after the index gains a role dimension.
+///
+/// [`Deref`](std::ops::Deref) exposes the map for reads, so every existing
+/// lookup is unchanged. There is deliberately **no** `DerefMut`: mutating the
+/// map directly would silently desynchronize `counts`, so all writes go through
+/// the inherent methods below.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct IndexState {
+    workers: WorkerIndex,
+    counts: RoleCounts,
+}
+
+impl std::ops::Deref for IndexState {
+    type Target = WorkerIndex;
+
+    fn deref(&self) -> &Self::Target {
+        &self.workers
+    }
+}
+
+impl IndexState {
+    /// Adopt a whole map, recomputing counts from it.
+    fn from_workers(workers: WorkerIndex) -> Self {
+        let mut counts = RoleCounts::default();
+        for entry in workers.values() {
+            counts.add(entry.worker.role);
+        }
+        Self { workers, counts }
+    }
+
+    fn insert(&mut self, worker_id: u64, entry: WorkerEntry) {
+        let role = entry.worker.role;
+        if let Some(previous) = self.workers.insert(worker_id, entry) {
+            // A role flip is an in-place update: drop the old role's count
+            // before adding the new one.
+            self.counts.remove(previous.worker.role);
+        }
+        self.counts.add(role);
+    }
+
+    fn remove(&mut self, worker_id: &u64) -> Option<WorkerEntry> {
+        let removed = self.workers.remove(worker_id);
+        if let Some(entry) = &removed {
+            self.counts.remove(entry.worker.role);
+        }
+        removed
+    }
+
+    fn clear(&mut self) {
+        self.workers.clear();
+        self.counts = RoleCounts::default();
+    }
+
+    fn counts(&self) -> RoleCounts {
+        self.counts
+    }
+}
+
 /// Provides an index of `Ready` workers selected by the EPP's `InferencePool`.
 #[derive(Clone)]
 pub struct PodDiscovery {
-    index: Arc<RwLock<WorkerIndex>>,
+    index: Arc<RwLock<IndexState>>,
     changes: watch::Receiver<u64>,
 }
 
@@ -100,10 +185,9 @@ impl PodDiscovery {
 
         let (changes_tx, changes_rx) = watch::channel(0u64);
 
-        let kv_event_port = cfg.kv_event_port;
-        let replay_port = cfg.replay_port;
+        let role_cfg = RoleDiscoveryConfig::from_config(cfg);
 
-        let index: Arc<RwLock<WorkerIndex>> = Arc::new(RwLock::new(WorkerIndex::new()));
+        let index: Arc<RwLock<IndexState>> = Arc::new(RwLock::new(IndexState::default()));
 
         tracing::info!(
             namespace = %namespace,
@@ -118,6 +202,7 @@ impl PodDiscovery {
             let mut pool_rx = pool_rx;
             tokio::pin!(reflect);
             let mut generation = 0u64;
+            let mut last_counts = RoleCounts::default();
             // The pod cache is "synced" once the reflector's initial LIST lands
             // (InitDone); readiness stays gated on this AND pool presence below.
             let mut pod_synced = false;
@@ -175,22 +260,23 @@ impl PodDiscovery {
                 let index_changed = match delta {
                     Delta::Stop => break,
                     Delta::Skip => continue,
-                    Delta::Rebuild => rebuild_index(
-                        &store,
-                        pool_rx.borrow().as_ref(),
-                        kv_event_port,
-                        replay_port,
-                        &index_task,
-                    ),
-                    Delta::Upsert(pod) => upsert_pod(
-                        &index_task,
-                        &pod,
-                        pool_rx.borrow().as_ref(),
-                        kv_event_port,
-                        replay_port,
-                    ),
+                    Delta::Rebuild => {
+                        rebuild_index(&store, pool_rx.borrow().as_ref(), &role_cfg, &index_task)
+                    }
+                    Delta::Upsert(pod) => {
+                        upsert_pod(&index_task, &pod, pool_rx.borrow().as_ref(), &role_cfg)
+                    }
                     Delta::Remove(pod) => remove_pod(&index_task, &pod),
                 };
+
+                // This loop is the only place with a before/after view of the
+                // index, so the crossed-zero edge is reported here rather than
+                // inside the pure mutators.
+                if index_changed {
+                    let counts = index_task.read().unwrap().counts();
+                    log_role_count_transitions(&role_cfg, last_counts, counts);
+                    last_counts = counts;
+                }
 
                 // Readiness based on initial pods being synced and the pool being resolved.
                 ready_task.store(pod_synced && pool_rx.borrow().is_some(), Ordering::Release);
@@ -213,7 +299,8 @@ impl PodDiscovery {
         ))
     }
 
-    // Return all currently `Ready` workers selected by the pool.
+    // Return all currently `Ready` workers selected by the pool, regardless of
+    // role. Used by the aggregated reconcile path.
     pub fn ready_workers(&self) -> Vec<RawWorker> {
         self.index
             .read()
@@ -223,29 +310,61 @@ impl PodDiscovery {
             .collect()
     }
 
-    /// Whether any `Ready`, pool-selected worker exists. O(1) — lets the hot path
-    /// test emptiness without materializing the id set.
-    pub fn has_ready_workers(&self) -> bool {
-        !self.index.read().unwrap().is_empty()
+    /// Both role sets from a single read lock.
+    ///
+    /// Reading the two roles through separate calls would take two locks and so
+    /// observe two generations; a role flip landing between them would put one
+    /// `worker_id` into both desired sets, which is exactly the cross-catalog
+    /// duplication the reconcile ordering exists to avoid.
+    pub fn ready_workers_by_role(&self) -> RoleWorkerSets {
+        let index = self.index.read().unwrap();
+        let mut sets = RoleWorkerSets::default();
+        for entry in index.values() {
+            match entry.worker.role {
+                WorkerRole::Prefill => sets.prefill.push(entry.worker.clone()),
+                WorkerRole::Decode => sets.decode.push(entry.worker.clone()),
+                WorkerRole::Aggregated => {}
+            }
+        }
+        sets
     }
 
-    /// Resolve any `Ready` worker's `ip:port` endpoint, for body-less requests
-    /// that route to an arbitrary worker without building an id set.
-    pub fn resolve_any_endpoint(&self) -> Option<String> {
+    /// Whether any `Ready`, pool-selected worker in `role` exists. O(1) via the
+    /// denormalized counts — this runs on every request, so it must not become
+    /// a scan when the index gains a role dimension.
+    pub fn has_ready_workers(&self, role: WorkerRole) -> bool {
+        self.index.read().unwrap().counts().get(role) > 0
+    }
+
+    /// Ready-worker count per role.
+    pub fn role_counts(&self) -> RoleCounts {
+        self.index.read().unwrap().counts()
+    }
+
+    /// Resolve any `Ready` worker in `role` to its `ip:port` endpoint, for
+    /// body-less requests that route to an arbitrary worker without building an
+    /// id set. O(n), but only on that path, which has no reservation.
+    pub fn resolve_any_endpoint(&self, role: WorkerRole) -> Option<String> {
         self.index
             .read()
             .unwrap()
             .values()
-            .next()
+            .find(|entry| entry.worker.role == role)
             .map(|entry| entry.endpoint.clone())
     }
 
-    // Resolve a `worker_id` to its current `ip:port` HTTP endpoint.
-    pub fn resolve_endpoint(&self, worker_id: u64) -> Option<String> {
+    /// Resolve a `worker_id` to its current `ip:port` HTTP endpoint, refusing a
+    /// worker whose role is not `role`.
+    ///
+    /// The role check is what makes "never route to a prefill endpoint" a
+    /// compiler-and-runtime property rather than a convention: a caller holding
+    /// a prefill id simply cannot turn it into a destination.
+    pub fn resolve_endpoint(&self, worker_id: u64, role: WorkerRole) -> Option<String> {
         self.index
             .read()
             .unwrap()
             .get(&worker_id)
+            .filter(|entry| entry.worker.role == role)
             .map(|entry| entry.endpoint.clone())
     }
 
@@ -257,11 +376,15 @@ impl PodDiscovery {
     /// `pred` runs while the index read lock is held, so it must not re-enter
     /// `PodDiscovery` (`resolve_endpoint`, another read, …): `std::sync::RwLock`
     /// read locks are not guaranteed re-entrant and a nested acquire can deadlock.
-    pub fn ready_worker_ids_matching(&self, pred: impl Fn(&str) -> bool) -> HashSet<u64> {
+    pub fn ready_worker_ids_matching(
+        &self,
+        role: WorkerRole,
+        pred: impl Fn(&str) -> bool,
+    ) -> HashSet<u64> {
         let index = self.index.read().unwrap();
         index
             .iter()
-            .filter(|(_, entry)| pred(entry.endpoint.as_str()))
+            .filter(|(_, entry)| entry.worker.role == role && pred(entry.endpoint.as_str()))
             .map(|(worker_id, _)| *worker_id)
             .collect()
     }
@@ -272,18 +395,67 @@ impl PodDiscovery {
 
     #[cfg(test)]
     pub(crate) fn for_test(workers: Vec<RawWorker>) -> (Self, watch::Sender<u64>) {
-        let index = workers
-            .into_iter()
-            .map(|worker| (worker.worker_id, WorkerEntry::from_raw(worker)))
-            .collect();
         let (changes_tx, changes) = watch::channel(0u64);
         (
             Self {
-                index: Arc::new(RwLock::new(index)),
+                index: Arc::new(RwLock::new(index_state_from(workers))),
                 changes,
             },
             changes_tx,
         )
+    }
+
+    /// Swap the whole worker set, so a test can drive add / role-flip / remove
+    /// through a real [`crate::TopologyAdapter`] without a cluster.
+    ///
+    /// The caller wakes the adapter by sending on the `watch::Sender` that
+    /// [`Self::for_test`] handed back — the generation channel is owned there,
+    /// not here.
+    #[cfg(test)]
+    pub(crate) fn set_workers(&self, workers: Vec<RawWorker>) {
+        *self.index.write().unwrap() = index_state_from(workers);
+    }
+}
+
+/// The `Ready` workers of each disaggregated role, taken from one snapshot.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RoleWorkerSets {
+    pub prefill: Vec<RawWorker>,
+    pub decode: Vec<RawWorker>,
+}
+
+#[cfg(test)]
+fn index_state_from(workers: Vec<RawWorker>) -> IndexState {
+    IndexState::from_workers(
+        workers
+            .into_iter()
+            .map(|worker| (worker.worker_id, WorkerEntry::from_raw(worker)))
+            .collect(),
+    )
+}
+
+/// Log the roles whose ready count crossed zero in either direction.
+///
+/// A role emptying is the condition an operator most needs to see — it is the
+/// difference between "the EPP is fine" and "every request for that role 503s"
+/// — and health stays SERVING through it by design, so a log line is the signal.
+fn log_role_count_transitions(cfg: &RoleDiscoveryConfig, before: RoleCounts, after: RoleCounts) {
+    let roles: &[WorkerRole] = if cfg.role_label.is_some() {
+        &[WorkerRole::Prefill, WorkerRole::Decode]
+    } else {
+        &[WorkerRole::Aggregated]
+    };
+
+    for &role in roles {
+        match (before.get(role), after.get(role)) {
+            (0, 0) => {}
+            (0, now) => tracing::info!(role = role.as_str(), ready = now, "Role has ready workers"),
+            (_, 0) => tracing::warn!(
+                role = role.as_str(),
+                "Role has no ready workers; requests needing it will fail until one appears"
+            ),
+            _ => {}
+        }
     }
 }
 
@@ -336,18 +508,37 @@ fn defer_pool_rebuild(relisting: bool, pool_present: bool) -> bool {
 /// pool-selected, otherwise drop any existing entry (a pod that went NotReady,
 /// terminating, or unselected). Returns whether the derived index changed.
 fn upsert_pod(
-    index: &RwLock<WorkerIndex>,
+    index: &RwLock<IndexState>,
     pod: &Pod,
     pool: Option<&PoolState>,
-    kv_event_port: u16,
-    replay_port: Option<u16>,
+    cfg: &RoleDiscoveryConfig,
 ) -> bool {
     let Some(worker_id) = pod_worker_id(pod) else {
         return false;
     };
-    let entry = pool
-        .and_then(|pool| raw_worker_from_pod(pod, pool, kv_event_port, replay_port))
-        .map(WorkerEntry::from_raw);
+    let outcome = match pool {
+        Some(pool) => raw_worker_from_pod(pod, pool, cfg),
+        None => Err(PodRejection::Ineligible),
+    };
+
+    let entry = match outcome {
+        Ok(worker) => Some(WorkerEntry::from_raw(worker)),
+        Err(PodRejection::Ineligible) => None,
+        Err(PodRejection::Role(error)) => {
+            // Eligible but unassignable: exclude it from every catalog. Warn
+            // rather than fail, because a rolling update transiently produces
+            // such pods; the operator-visible consequence of a wholly
+            // mislabelled fleet is an empty role catalog and 503s.
+            tracing::warn!(
+                pod = pod.metadata.name.as_deref().unwrap_or("<unnamed>"),
+                reason = error.reason(),
+                %error,
+                "Pod is pool-selected and Ready but has no usable worker role; excluding it"
+            );
+            None
+        }
+    };
+
     let mut index = index.write().unwrap();
     match entry {
         Some(entry) => {
@@ -358,12 +549,14 @@ fn upsert_pod(
                 true
             }
         }
+        // Covers a live pod whose role label was removed or edited to something
+        // unparseable: it is evicted, not left serving from a stale entry.
         None => index.remove(&worker_id).is_some(),
     }
 }
 
 /// Drop a deleted pod's worker from the index. Returns whether an entry existed.
-fn remove_pod(index: &RwLock<WorkerIndex>, pod: &Pod) -> bool {
+fn remove_pod(index: &RwLock<IndexState>, pod: &Pod) -> bool {
     pod_worker_id(pod)
         .and_then(|worker_id| index.write().unwrap().remove(&worker_id))
         .is_some()
@@ -377,18 +570,35 @@ fn remove_pod(index: &RwLock<WorkerIndex>, pod: &Pod) -> bool {
 fn rebuild_index(
     store: &kube::runtime::reflector::Store<Pod>,
     pool: Option<&PoolState>,
-    kv_event_port: u16,
-    replay_port: Option<u16>,
-    index: &RwLock<WorkerIndex>,
+    cfg: &RoleDiscoveryConfig,
+    index: &RwLock<IndexState>,
 ) -> bool {
     let mut fresh = WorkerIndex::new();
+    let mut excluded = 0usize;
     if let Some(pool) = pool {
         for pod in store.state().iter() {
-            if let Some(worker) = raw_worker_from_pod(pod, pool, kv_event_port, replay_port) {
-                fresh.insert(worker.worker_id, WorkerEntry::from_raw(worker));
+            match raw_worker_from_pod(pod, pool, cfg) {
+                Ok(worker) => {
+                    fresh.insert(worker.worker_id, WorkerEntry::from_raw(worker));
+                }
+                // Silent and expected: the pod is simply not one of ours.
+                Err(PodRejection::Ineligible) => {}
+                Err(_) => excluded += 1,
             }
         }
     }
+    if excluded > 0 {
+        // Counted over the snapshot rather than warned per pod, because this
+        // path also runs on every watch relist and would otherwise repeat the
+        // same warning for the same pods indefinitely.
+        tracing::warn!(
+            excluded,
+            eligible = fresh.len(),
+            "Pool-selected Ready pods were excluded because their worker role could not be resolved"
+        );
+    }
+
+    let fresh = IndexState::from_workers(fresh);
     let mut current = index.write().unwrap();
     if *current == fresh {
         false
@@ -398,34 +608,95 @@ fn rebuild_index(
     }
 }
 
-/// Build a [`RawWorker`] from a pod, or `None` if it is not `Ready`, not
-/// pool-selected, or lacks an IP/name. Pure function — unit-testable.
+/// Inputs the pure per-pod mapping needs, replacing the loose port pair that
+/// used to be threaded through every index mutator.
+#[derive(Debug, Clone)]
+pub(crate) struct RoleDiscoveryConfig {
+    /// Label key carrying a worker's role, or `None` in aggregated topology.
+    /// When `None` the label is never read at all, which is what keeps
+    /// aggregated discovery byte-identical to its previous behavior.
+    role_label: Option<String>,
+    kv_event_port: u16,
+    replay_port: Option<u16>,
+}
+
+impl RoleDiscoveryConfig {
+    pub(crate) fn from_config(cfg: &EppStandaloneConfig) -> Self {
+        Self {
+            role_label: cfg
+                .topology_mode
+                .is_disaggregated()
+                .then(|| cfg.worker_role_label.clone()),
+            kv_event_port: cfg.kv_event_port,
+            replay_port: cfg.replay_port,
+        }
+    }
+
+    fn role_of(&self, pod: &Pod) -> Result<WorkerRole, RoleLabelError> {
+        let Some(key) = self.role_label.as_deref() else {
+            return Ok(WorkerRole::Aggregated);
+        };
+        let value = pod
+            .metadata
+            .labels
+            .as_ref()
+            .and_then(|labels| labels.get(key))
+            .ok_or(RoleLabelError::Missing)?;
+        WorkerRole::from_pod_label(value)
+    }
+}
+
+/// Build a [`RawWorker`] from a pod, or say why the pod produced none. Pure
+/// function — unit-testable.
+///
+/// Eligibility is decided first and unchanged, so a `NotReady` prefill pod is
+/// [`PodRejection::Ineligible`] rather than a role error: a rolling update must
+/// not read as a misconfiguration.
 fn raw_worker_from_pod(
     pod: &Pod,
     pool: &PoolState,
-    kv_event_port: u16,
-    replay_port: Option<u16>,
-) -> Option<RawWorker> {
+    cfg: &RoleDiscoveryConfig,
+) -> Result<RawWorker, PodRejection> {
     if !pod_is_ready(pod) || !pod_matches(pod, &pool.match_labels) {
-        return None;
+        return Err(PodRejection::Ineligible);
     }
-    let pod_name = pod.metadata.name.as_deref()?;
-    let pod_ip = pod.status.as_ref()?.pod_ip.as_deref()?;
-    let ip: IpAddr = pod_ip.parse().ok()?;
+    let (Some(pod_name), Some(pod_ip)) = (
+        pod.metadata.name.as_deref(),
+        pod.status.as_ref().and_then(|s| s.pod_ip.as_deref()),
+    ) else {
+        return Err(PodRejection::Ineligible);
+    };
+    let Ok(ip) = pod_ip.parse::<IpAddr>() else {
+        return Err(PodRejection::Ineligible);
+    };
 
-    Some(RawWorker {
+    let role = cfg.role_of(pod).map_err(PodRejection::Role)?;
+    // The decode instance runs with KV events off, so handing decode workers an
+    // endpoint would open a ZMQ subscription nothing ever publishes to — and a
+    // dead subscriber is indistinguishable from a genuine cache miss.
+    let subscribes_to_kv_events = role != WorkerRole::Decode;
+
+    Ok(RawWorker {
         worker_id: hash_pod_name(pod_name),
         pod_name: pod_name.to_string(),
         pod_ip: pod_ip.to_string(),
+        role,
         http_endpoint: format!("http://{}", SocketAddr::new(ip, pool.target_port)),
-        kv_events_endpoint: format!("tcp://{}", SocketAddr::new(ip, kv_event_port)),
-        replay_endpoint: replay_port.map(|p| format!("tcp://{}", SocketAddr::new(ip, p))),
+        kv_events_endpoint: subscribes_to_kv_events
+            .then(|| format!("tcp://{}", SocketAddr::new(ip, cfg.kv_event_port))),
+        replay_endpoint: subscribes_to_kv_events
+            .then(|| {
+                cfg.replay_port
+                    .map(|p| format!("tcp://{}", SocketAddr::new(ip, p)))
+            })
+            .flatten(),
     })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::worker_role::DEFAULT_WORKER_ROLE_LABEL;
     use k8s_openapi::api::core::v1::{PodCondition, PodStatus};
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
     use kube::api::ObjectMeta;
@@ -464,6 +735,40 @@ mod tests {
         }
     }
 
+    /// Aggregated discovery: the role label is never read, so every eligible
+    /// pod is `WorkerRole::Aggregated` no matter what labels it carries.
+    fn agg_cfg() -> RoleDiscoveryConfig {
+        RoleDiscoveryConfig {
+            role_label: None,
+            kv_event_port: 5557,
+            replay_port: None,
+        }
+    }
+
+    /// Disaggregated discovery keyed on the default role label.
+    fn disagg_cfg() -> RoleDiscoveryConfig {
+        RoleDiscoveryConfig {
+            role_label: Some(DEFAULT_WORKER_ROLE_LABEL.to_string()),
+            kv_event_port: 5557,
+            replay_port: None,
+        }
+    }
+
+    fn with_replay(mut cfg: RoleDiscoveryConfig, port: u16) -> RoleDiscoveryConfig {
+        cfg.replay_port = Some(port);
+        cfg
+    }
+
+    /// A pod carrying the default role label.
+    fn role_pod(name: &str, ip: &str, role: &str) -> Pod {
+        pod(
+            name,
+            Some(ip),
+            Some(true),
+            &[("app", "vllm-qwen"), (DEFAULT_WORKER_ROLE_LABEL, role)],
+        )
+    }
+
     #[test]
     fn ready_selected_pod_maps_to_worker() {
         let w = raw_worker_from_pod(
@@ -474,13 +779,12 @@ mod tests {
                 &[("app", "vllm-qwen")],
             ),
             &pool(),
-            5557,
-            Some(5560),
+            &with_replay(agg_cfg(), 5560),
         )
         .expect("ready, selected pod should map");
         assert_eq!(w.worker_id, hash_pod_name("vllm-0"));
         assert_eq!(w.http_endpoint, "http://10.0.0.1:8000");
-        assert_eq!(w.kv_events_endpoint, "tcp://10.0.0.1:5557");
+        assert_eq!(w.kv_events_endpoint.as_deref(), Some("tcp://10.0.0.1:5557"));
         assert_eq!(w.replay_endpoint.as_deref(), Some("tcp://10.0.0.1:5560"));
     }
 
@@ -494,13 +798,15 @@ mod tests {
                 &[("app", "vllm-qwen")],
             ),
             &pool(),
-            5557,
-            Some(5560),
+            &with_replay(agg_cfg(), 5560),
         )
         .expect("ready, selected IPv6 pod should map");
         // SocketAddr brackets the IPv6 host so host and port are unambiguous.
         assert_eq!(w.http_endpoint, "http://[fd00::10]:8000");
-        assert_eq!(w.kv_events_endpoint, "tcp://[fd00::10]:5557");
+        assert_eq!(
+            w.kv_events_endpoint.as_deref(),
+            Some("tcp://[fd00::10]:5557")
+        );
         assert_eq!(w.replay_endpoint.as_deref(), Some("tcp://[fd00::10]:5560"));
     }
 
@@ -515,10 +821,9 @@ mod tests {
                     &[("app", "vllm-qwen")]
                 ),
                 &pool(),
-                5557,
-                None,
+                &agg_cfg(),
             )
-            .is_none()
+            .is_err()
         );
     }
 
@@ -533,10 +838,9 @@ mod tests {
                     &[("app", "something-else")]
                 ),
                 &pool(),
-                5557,
-                None,
+                &agg_cfg(),
             )
-            .is_none()
+            .is_err()
         );
     }
 
@@ -551,10 +855,9 @@ mod tests {
                     &[("app", "vllm-qwen")]
                 ),
                 &pool(),
-                5557,
-                None,
+                &agg_cfg(),
             )
-            .is_none()
+            .is_err()
         );
     }
 
@@ -567,7 +870,7 @@ mod tests {
             &[("app", "vllm-qwen")],
         );
         p.metadata.deletion_timestamp = Some(Time(k8s_openapi::chrono::Utc::now()));
-        assert!(raw_worker_from_pod(&p, &pool(), 5557, None).is_none());
+        assert!(raw_worker_from_pod(&p, &pool(), &agg_cfg()).is_err());
     }
 
     #[test]
@@ -576,10 +879,9 @@ mod tests {
             raw_worker_from_pod(
                 &pod("vllm-0", None, Some(true), &[("app", "vllm-qwen")]),
                 &pool(),
-                5557,
-                None,
+                &agg_cfg(),
             )
-            .is_none()
+            .is_err()
         );
     }
 
@@ -613,19 +915,17 @@ mod tests {
             pod("other-0", Some("10.0.0.3"), Some(true), &[("app", "nope")]),
         ]);
 
-        let index = RwLock::new(WorkerIndex::new());
+        let index = RwLock::new(IndexState::default());
         assert!(rebuild_index(
             &store,
             Some(&pool()),
-            5557,
-            Some(5560),
+            &with_replay(agg_cfg(), 5560),
             &index
         ));
         assert!(!rebuild_index(
             &store,
             Some(&pool()),
-            5557,
-            Some(5560),
+            &with_replay(agg_cfg(), 5560),
             &index
         ));
 
@@ -647,14 +947,14 @@ mod tests {
             Some(true),
             &[("app", "vllm-qwen")],
         )]);
-        let index = RwLock::new(WorkerIndex::new());
-        assert!(!rebuild_index(&store, None, 5557, None, &index));
+        let index = RwLock::new(IndexState::default());
+        assert!(!rebuild_index(&store, None, &agg_cfg(), &index));
         assert!(index.read().unwrap().is_empty());
     }
 
     #[test]
     fn upsert_and_remove_pod_mutate_index_incrementally() {
-        let index = RwLock::new(WorkerIndex::new());
+        let index = RwLock::new(IndexState::default());
         let id = hash_pod_name("vllm-0");
         let ready = pod(
             "vllm-0",
@@ -664,8 +964,8 @@ mod tests {
         );
 
         // Ready + selected -> inserted, with a pre-stripped endpoint.
-        assert!(upsert_pod(&index, &ready, Some(&pool()), 5557, None));
-        assert!(!upsert_pod(&index, &ready, Some(&pool()), 5557, None));
+        assert!(upsert_pod(&index, &ready, Some(&pool()), &agg_cfg()));
+        assert!(!upsert_pod(&index, &ready, Some(&pool()), &agg_cfg()));
         assert_eq!(
             index.read().unwrap().get(&id).map(|e| e.endpoint.as_str()),
             Some("10.0.0.1:8000")
@@ -678,12 +978,12 @@ mod tests {
             Some(false),
             &[("app", "vllm-qwen")],
         );
-        assert!(upsert_pod(&index, &not_ready, Some(&pool()), 5557, None));
-        assert!(!upsert_pod(&index, &not_ready, Some(&pool()), 5557, None));
+        assert!(upsert_pod(&index, &not_ready, Some(&pool()), &agg_cfg()));
+        assert!(!upsert_pod(&index, &not_ready, Some(&pool()), &agg_cfg()));
         assert!(!index.read().unwrap().contains_key(&id));
 
         // Re-add, then a Delete removes it.
-        assert!(upsert_pod(&index, &ready, Some(&pool()), 5557, None));
+        assert!(upsert_pod(&index, &ready, Some(&pool()), &agg_cfg()));
         assert!(index.read().unwrap().contains_key(&id));
         assert!(remove_pod(&index, &ready));
         assert!(!remove_pod(&index, &ready));
@@ -691,14 +991,14 @@ mod tests {
 
         // An unrelated namespace pod does not change the derived worker index.
         let unselected = pod("other-0", Some("10.0.0.2"), Some(true), &[("app", "other")]);
-        assert!(!upsert_pod(&index, &unselected, Some(&pool()), 5557, None));
+        assert!(!upsert_pod(&index, &unselected, Some(&pool()), &agg_cfg()));
     }
 
     #[test]
     fn upsert_pod_without_pool_drops_entry() {
         // A `None` pool (unresolved or deleted) means nothing is routable, so an
         // upsert must evict any existing entry rather than leave stale routing.
-        let index = RwLock::new(WorkerIndex::new());
+        let index = RwLock::new(IndexState::default());
         let id = hash_pod_name("vllm-0");
         let ready = pod(
             "vllm-0",
@@ -707,11 +1007,11 @@ mod tests {
             &[("app", "vllm-qwen")],
         );
 
-        assert!(upsert_pod(&index, &ready, Some(&pool()), 5557, None));
+        assert!(upsert_pod(&index, &ready, Some(&pool()), &agg_cfg()));
         assert!(index.read().unwrap().contains_key(&id));
 
-        assert!(upsert_pod(&index, &ready, None, 5557, None));
-        assert!(!upsert_pod(&index, &ready, None, 5557, None));
+        assert!(upsert_pod(&index, &ready, None, &agg_cfg()));
+        assert!(!upsert_pod(&index, &ready, None, &agg_cfg()));
         assert!(!index.read().unwrap().contains_key(&id));
     }
 
@@ -739,8 +1039,8 @@ mod tests {
         writer.apply_watcher_event(&watcher::Event::InitApply(vllm_0.clone()));
         writer.apply_watcher_event(&watcher::Event::InitApply(vllm_1.clone()));
         writer.apply_watcher_event(&watcher::Event::InitDone);
-        let index = RwLock::new(WorkerIndex::new());
-        assert!(rebuild_index(&store, Some(&pool()), 5557, None, &index));
+        let index = RwLock::new(IndexState::default());
+        assert!(rebuild_index(&store, Some(&pool()), &agg_cfg(), &index));
         assert_eq!(index.read().unwrap().len(), 2);
 
         // During the next LIST, vllm-1 has disappeared. The reflector buffers
@@ -769,8 +1069,7 @@ mod tests {
         assert!(rebuild_index(
             &store,
             Some(&updated_pool),
-            5557,
-            None,
+            &agg_cfg(),
             &index
         ));
         let index = index.read().unwrap();
@@ -794,7 +1093,7 @@ mod tests {
         // rebuild must *replace* the index, not merge into it — otherwise dead
         // workers linger and keep receiving traffic. Seed two workers, then
         // rebuild from a store that holds only one.
-        let index = RwLock::new(WorkerIndex::new());
+        let index = RwLock::new(IndexState::default());
         upsert_pod(
             &index,
             &pod(
@@ -804,8 +1103,7 @@ mod tests {
                 &[("app", "vllm-qwen")],
             ),
             Some(&pool()),
-            5557,
-            None,
+            &agg_cfg(),
         );
         upsert_pod(
             &index,
@@ -816,8 +1114,7 @@ mod tests {
                 &[("app", "vllm-qwen")],
             ),
             Some(&pool()),
-            5557,
-            None,
+            &agg_cfg(),
         );
         assert_eq!(index.read().unwrap().len(), 2);
 
@@ -828,7 +1125,7 @@ mod tests {
             Some(true),
             &[("app", "vllm-qwen")],
         )]);
-        assert!(rebuild_index(&store, Some(&pool()), 5557, None, &index));
+        assert!(rebuild_index(&store, Some(&pool()), &agg_cfg(), &index));
 
         let index = index.read().unwrap();
         assert_eq!(index.len(), 1);
@@ -847,8 +1144,9 @@ mod tests {
                 .rsplit_once(':')
                 .map_or(endpoint, |(ip, _)| ip)
                 .to_string(),
+            role: WorkerRole::Aggregated,
             http_endpoint: format!("http://{endpoint}"),
-            kv_events_endpoint: format!("tcp://{endpoint}"),
+            kv_events_endpoint: Some(format!("tcp://{endpoint}")),
             replay_endpoint: None,
         }
     }
@@ -867,7 +1165,7 @@ mod tests {
             .collect();
         let (_, changes) = watch::channel(0u64);
         PodDiscovery {
-            index: Arc::new(RwLock::new(index)),
+            index: Arc::new(RwLock::new(IndexState::from_workers(index))),
             changes,
         }
     }
@@ -881,14 +1179,350 @@ mod tests {
         ]));
 
         // Predicate borrows the endpoint; only worker 2 matches.
-        let filtered = discovery.ready_worker_ids_matching(|endpoint| endpoint == "10.0.0.2:8000");
+        let filtered = discovery.ready_worker_ids_matching(WorkerRole::Aggregated, |endpoint| {
+            endpoint == "10.0.0.2:8000"
+        });
         assert_eq!(filtered, HashSet::from([2]));
 
         // Match-all returns every ready worker (single pass, no input set).
-        let all = discovery.ready_worker_ids_matching(|_| true);
+        let all = discovery.ready_worker_ids_matching(WorkerRole::Aggregated, |_| true);
         assert_eq!(all, HashSet::from([1, 2, 3]));
 
         // No match -> empty.
-        assert!(discovery.ready_worker_ids_matching(|_| false).is_empty());
+        assert!(
+            discovery
+                .ready_worker_ids_matching(WorkerRole::Aggregated, |_| false)
+                .is_empty()
+        );
+    }
+
+    // --- role resolution ---------------------------------------------------
+
+    /// Recompute counts from the map, so the denormalized copy can be checked
+    /// against the source of truth after every mutation path.
+    fn recount(index: &IndexState) -> RoleCounts {
+        let mut counts = RoleCounts::default();
+        for entry in index.values() {
+            counts.add(entry.worker.role);
+        }
+        counts
+    }
+
+    #[test]
+    fn aggregated_topology_ignores_the_role_label() {
+        // Not merely "defaults to Aggregated": the label is never read, which is
+        // what keeps aggregated discovery byte-identical to its old behavior.
+        let w = raw_worker_from_pod(
+            &role_pod("vllm-0", "10.0.0.1", "prefill"),
+            &pool(),
+            &agg_cfg(),
+        )
+        .expect("labelled pod is still eligible under aggregated");
+        assert_eq!(w.role, WorkerRole::Aggregated);
+        assert!(w.kv_events_endpoint.is_some());
+    }
+
+    #[test]
+    fn disaggregated_topology_maps_the_two_roles() {
+        for (label, expected) in [
+            ("prefill", WorkerRole::Prefill),
+            ("decode", WorkerRole::Decode),
+        ] {
+            let w = raw_worker_from_pod(
+                &role_pod("vllm-0", "10.0.0.1", label),
+                &pool(),
+                &disagg_cfg(),
+            )
+            .expect("labelled pod should map");
+            assert_eq!(w.role, expected);
+        }
+    }
+
+    #[test]
+    fn only_prefill_workers_carry_kv_event_endpoints() {
+        // The decode instance runs with KV events off, so an endpoint there would
+        // open a subscription nothing publishes to.
+        let cfg = with_replay(disagg_cfg(), 5560);
+        let prefill = raw_worker_from_pod(&role_pod("p-0", "10.0.0.1", "prefill"), &pool(), &cfg)
+            .expect("prefill should map");
+        assert_eq!(
+            prefill.kv_events_endpoint.as_deref(),
+            Some("tcp://10.0.0.1:5557")
+        );
+        assert_eq!(
+            prefill.replay_endpoint.as_deref(),
+            Some("tcp://10.0.0.1:5560")
+        );
+
+        let decode = raw_worker_from_pod(&role_pod("d-0", "10.0.0.2", "decode"), &pool(), &cfg)
+            .expect("decode should map");
+        assert!(decode.kv_events_endpoint.is_none());
+        assert!(decode.replay_endpoint.is_none());
+    }
+
+    #[test]
+    fn missing_role_label_is_a_role_rejection() {
+        let p = pod(
+            "vllm-0",
+            Some("10.0.0.1"),
+            Some(true),
+            &[("app", "vllm-qwen")],
+        );
+        assert_eq!(
+            raw_worker_from_pod(&p, &pool(), &disagg_cfg()),
+            Err(PodRejection::Role(RoleLabelError::Missing))
+        );
+    }
+
+    #[test]
+    fn unparseable_role_label_is_a_role_rejection() {
+        let p = role_pod("vllm-0", "10.0.0.1", "gibberish");
+        let Err(PodRejection::Role(error)) = raw_worker_from_pod(&p, &pool(), &disagg_cfg()) else {
+            panic!("an unparseable role must be a role rejection");
+        };
+        assert_eq!(error.reason(), "role_label_invalid");
+    }
+
+    #[test]
+    fn ineligibility_outranks_role_resolution() {
+        // The boundary that keeps a rolling update from reading as a
+        // misconfiguration: a NotReady prefill pod is ineligible, not a role error.
+        let not_ready = pod(
+            "vllm-0",
+            Some("10.0.0.1"),
+            Some(false),
+            &[("app", "vllm-qwen"), (DEFAULT_WORKER_ROLE_LABEL, "prefill")],
+        );
+        assert_eq!(
+            raw_worker_from_pod(&not_ready, &pool(), &disagg_cfg()),
+            Err(PodRejection::Ineligible)
+        );
+
+        // Likewise for a pod the pool does not select, even with a valid role.
+        let unselected = pod(
+            "vllm-0",
+            Some("10.0.0.1"),
+            Some(true),
+            &[("app", "other"), (DEFAULT_WORKER_ROLE_LABEL, "prefill")],
+        );
+        assert_eq!(
+            raw_worker_from_pod(&unselected, &pool(), &disagg_cfg()),
+            Err(PodRejection::Ineligible)
+        );
+    }
+
+    // --- role changes and counts -------------------------------------------
+
+    #[test]
+    fn role_flip_keeps_worker_id_and_moves_counts() {
+        let index = RwLock::new(IndexState::default());
+        let id = hash_pod_name("vllm-0");
+
+        assert!(upsert_pod(
+            &index,
+            &role_pod("vllm-0", "10.0.0.1", "prefill"),
+            Some(&pool()),
+            &disagg_cfg()
+        ));
+        assert_eq!(index.read().unwrap().counts().prefill, 1);
+
+        // One in-place update, not a remove-then-add: the id is derived from the
+        // pod name, so it cannot exist in two catalogs at once.
+        assert!(upsert_pod(
+            &index,
+            &role_pod("vllm-0", "10.0.0.1", "decode"),
+            Some(&pool()),
+            &disagg_cfg()
+        ));
+        let index = index.read().unwrap();
+        assert_eq!(index.len(), 1);
+        assert_eq!(index.get(&id).unwrap().worker.role, WorkerRole::Decode);
+        assert_eq!(index.counts().prefill, 0);
+        assert_eq!(index.counts().decode, 1);
+        assert_eq!(recount(&index), index.counts());
+    }
+
+    #[test]
+    fn live_pod_losing_its_role_label_is_evicted() {
+        let index = RwLock::new(IndexState::default());
+        assert!(upsert_pod(
+            &index,
+            &role_pod("vllm-0", "10.0.0.1", "decode"),
+            Some(&pool()),
+            &disagg_cfg()
+        ));
+
+        // Label edited away: the worker must go, not linger serving traffic.
+        let unlabelled = pod(
+            "vllm-0",
+            Some("10.0.0.1"),
+            Some(true),
+            &[("app", "vllm-qwen")],
+        );
+        assert!(upsert_pod(
+            &index,
+            &unlabelled,
+            Some(&pool()),
+            &disagg_cfg()
+        ));
+        let index = index.read().unwrap();
+        assert!(index.is_empty());
+        assert_eq!(index.counts(), RoleCounts::default());
+    }
+
+    #[test]
+    fn counts_stay_consistent_across_every_mutation_path() {
+        let index = RwLock::new(IndexState::default());
+        let store = store_from_pods(vec![
+            role_pod("p-0", "10.0.0.1", "prefill"),
+            role_pod("d-0", "10.0.0.2", "decode"),
+            role_pod("d-1", "10.0.0.3", "decode"),
+        ]);
+
+        // rebuild_index
+        assert!(rebuild_index(&store, Some(&pool()), &disagg_cfg(), &index));
+        {
+            let index = index.read().unwrap();
+            assert_eq!(index.counts(), recount(&index));
+            assert_eq!(index.counts().prefill, 1);
+            assert_eq!(index.counts().decode, 2);
+        }
+
+        // upsert_pod (add)
+        assert!(upsert_pod(
+            &index,
+            &role_pod("p-1", "10.0.0.4", "prefill"),
+            Some(&pool()),
+            &disagg_cfg()
+        ));
+        assert_eq!(
+            index.read().unwrap().counts(),
+            recount(&index.read().unwrap())
+        );
+
+        // remove_pod
+        assert!(remove_pod(&index, &role_pod("d-0", "10.0.0.2", "decode")));
+        {
+            let index = index.read().unwrap();
+            assert_eq!(index.counts(), recount(&index));
+            assert_eq!(index.counts().decode, 1);
+        }
+
+        // clear
+        index.write().unwrap().clear();
+        let index = index.read().unwrap();
+        assert!(index.is_empty());
+        assert_eq!(index.counts(), RoleCounts::default());
+    }
+
+    #[test]
+    fn deleting_every_prefill_pod_leaves_the_decode_catalog_intact() {
+        let index = RwLock::new(IndexState::default());
+        let store = store_from_pods(vec![
+            role_pod("p-0", "10.0.0.1", "prefill"),
+            role_pod("d-0", "10.0.0.2", "decode"),
+        ]);
+        assert!(rebuild_index(&store, Some(&pool()), &disagg_cfg(), &index));
+
+        assert!(remove_pod(&index, &role_pod("p-0", "10.0.0.1", "prefill")));
+        let index = index.read().unwrap();
+        assert_eq!(index.counts().prefill, 0);
+        assert_eq!(index.counts().decode, 1);
+    }
+
+    // --- the invariant: a prefill worker is never a destination -------------
+
+    fn role_discovery(workers: &[(&str, &str, WorkerRole)]) -> PodDiscovery {
+        let raw = workers
+            .iter()
+            .map(|(name, ip, role)| RawWorker {
+                worker_id: hash_pod_name(name),
+                pod_name: (*name).to_string(),
+                pod_ip: (*ip).to_string(),
+                role: *role,
+                http_endpoint: format!("http://{ip}:8000"),
+                kv_events_endpoint: (*role != WorkerRole::Decode)
+                    .then(|| format!("tcp://{ip}:5557")),
+                replay_endpoint: None,
+            })
+            .collect();
+        PodDiscovery::for_test(raw).0
+    }
+
+    #[test]
+    fn a_prefill_only_catalog_yields_nothing_for_decode() {
+        let discovery = role_discovery(&[("p-0", "10.0.0.1", WorkerRole::Prefill)]);
+        let prefill_id = hash_pod_name("p-0");
+
+        assert!(!discovery.has_ready_workers(WorkerRole::Decode));
+        assert!(discovery.resolve_any_endpoint(WorkerRole::Decode).is_none());
+        assert!(
+            discovery
+                .ready_worker_ids_matching(WorkerRole::Decode, |_| true)
+                .is_empty()
+        );
+        // Even holding the id outright, it cannot be turned into a destination.
+        assert!(
+            discovery
+                .resolve_endpoint(prefill_id, WorkerRole::Decode)
+                .is_none()
+        );
+
+        // ...while the same catalog is fully visible to prefill-scoped reads.
+        assert!(discovery.has_ready_workers(WorkerRole::Prefill));
+        assert_eq!(
+            discovery
+                .resolve_endpoint(prefill_id, WorkerRole::Prefill)
+                .as_deref(),
+            Some("10.0.0.1:8000")
+        );
+    }
+
+    #[test]
+    fn mixed_catalog_reads_never_cross_roles() {
+        let discovery = role_discovery(&[
+            ("p-0", "10.0.0.1", WorkerRole::Prefill),
+            ("d-0", "10.0.0.2", WorkerRole::Decode),
+        ]);
+
+        assert_eq!(
+            discovery
+                .resolve_any_endpoint(WorkerRole::Decode)
+                .as_deref(),
+            Some("10.0.0.2:8000")
+        );
+        assert_eq!(
+            discovery.ready_worker_ids_matching(WorkerRole::Decode, |_| true),
+            HashSet::from([hash_pod_name("d-0")])
+        );
+        assert_eq!(
+            discovery.ready_worker_ids_matching(WorkerRole::Prefill, |_| true),
+            HashSet::from([hash_pod_name("p-0")])
+        );
+    }
+
+    #[test]
+    fn ready_workers_by_role_partitions_one_snapshot() {
+        let discovery = role_discovery(&[
+            ("p-0", "10.0.0.1", WorkerRole::Prefill),
+            ("d-0", "10.0.0.2", WorkerRole::Decode),
+            ("d-1", "10.0.0.3", WorkerRole::Decode),
+        ]);
+
+        let sets = discovery.ready_workers_by_role();
+        assert_eq!(sets.prefill.len(), 1);
+        assert_eq!(sets.decode.len(), 2);
+        assert!(sets.prefill.iter().all(|w| w.role == WorkerRole::Prefill));
+        assert!(sets.decode.iter().all(|w| w.role == WorkerRole::Decode));
+    }
+
+    #[test]
+    fn set_workers_replaces_the_catalog_and_recomputes_counts() {
+        let discovery = role_discovery(&[("p-0", "10.0.0.1", WorkerRole::Prefill)]);
+        assert_eq!(discovery.role_counts().prefill, 1);
+
+        discovery.set_workers(vec![]);
+        assert_eq!(discovery.role_counts(), RoleCounts::default());
+        assert!(!discovery.has_ready_workers(WorkerRole::Prefill));
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
@@ -203,6 +203,9 @@ impl PodDiscovery {
             tokio::pin!(reflect);
             let mut generation = 0u64;
             let mut last_counts = RoleCounts::default();
+            // Set once discovery first has a complete picture; see the census
+            // block below for why the crossed-zero log alone is not enough.
+            let mut census_logged = false;
             // The pod cache is "synced" once the reflector's initial LIST lands
             // (InitDone); readiness stays gated on this AND pool presence below.
             let mut pod_synced = false;
@@ -269,17 +272,42 @@ impl PodDiscovery {
                     Delta::Remove(pod) => remove_pod(&index_task, &pod),
                 };
 
+                // Readiness based on initial pods being synced and the pool being resolved.
+                let is_ready = pod_synced && pool_rx.borrow().is_some();
+
+                // The first iteration holding a complete picture reports every
+                // role's count, not just the ones that moved: `last_counts`
+                // starts at zeros, so a role that is empty from process start
+                // never crosses zero and `log_role_count_transitions` would say
+                // nothing about it — while the healthy role logs normally. That
+                // is the shape of the likeliest disaggregated misconfiguration
+                // (the role label misspelled on every decode pod), and it would
+                // otherwise be reported by nothing but the 503s themselves. An
+                // all-empty index does not even set `index_changed`, so the
+                // census cannot be gated on it.
+                //
+                // Gated on the role label as well as on readiness, so that under
+                // aggregated topology `first_census` is always false and this
+                // block collapses to exactly the transition-only path it had
+                // before: one catalog makes "no workers" unambiguous already,
+                // and its startup output must not change.
+                let first_census = is_ready && !census_logged && role_cfg.role_label.is_some();
+
                 // This loop is the only place with a before/after view of the
                 // index, so the crossed-zero edge is reported here rather than
                 // inside the pure mutators.
-                if index_changed {
+                if index_changed || first_census {
                     let counts = index_task.read().unwrap().counts();
-                    log_role_count_transitions(&role_cfg, last_counts, counts);
+                    if first_census {
+                        census_logged = true;
+                        log_role_census(&role_cfg, counts);
+                    } else if index_changed {
+                        log_role_count_transitions(&role_cfg, last_counts, counts);
+                    }
                     last_counts = counts;
                 }
 
-                // Readiness based on initial pods being synced and the pool being resolved.
-                ready_task.store(pod_synced && pool_rx.borrow().is_some(), Ordering::Release);
+                ready_task.store(is_ready, Ordering::Release);
                 if index_changed {
                     generation = generation.wrapping_add(1);
                     let _ = changes_tx.send(generation);
@@ -432,6 +460,39 @@ fn index_state_from(workers: Vec<RawWorker>) -> IndexState {
             .map(|worker| (worker.worker_id, WorkerEntry::from_raw(worker)))
             .collect(),
     )
+}
+
+/// The roles to report in a startup census, with the count to report for each.
+///
+/// Empty under aggregated topology: there is one catalog, "no workers" is
+/// already unambiguous, and staying silent keeps aggregated startup output
+/// byte-identical to its previous behavior. Under a role split the opposite is
+/// true — one catalog can be empty while the other logs normally, and the
+/// difference is invisible without this.
+fn role_census(cfg: &RoleDiscoveryConfig, counts: RoleCounts) -> Vec<(WorkerRole, usize)> {
+    if cfg.role_label.is_none() {
+        return Vec::new();
+    }
+    [WorkerRole::Prefill, WorkerRole::Decode]
+        .into_iter()
+        .map(|role| (role, counts.get(role)))
+        .collect()
+}
+
+/// Report every role's ready count once, when discovery first has a complete
+/// picture, so a role that is empty from the start is not silent.
+fn log_role_census(cfg: &RoleDiscoveryConfig, counts: RoleCounts) {
+    for (role, ready) in role_census(cfg, counts) {
+        if ready == 0 {
+            tracing::warn!(
+                role = role.as_str(),
+                "Role has no ready workers at startup; requests needing it will fail until one \
+                 appears. Check the worker-role label on this pool's pods."
+            );
+        } else {
+            tracing::info!(role = role.as_str(), ready, "Role has ready workers");
+        }
+    }
 }
 
 /// Log the roles whose ready count crossed zero in either direction.
@@ -752,6 +813,52 @@ mod tests {
             kv_event_port: 5557,
             replay_port: None,
         }
+    }
+
+    #[test]
+    fn the_startup_census_reports_a_role_that_was_never_populated() {
+        // The crossed-zero log cannot: `last_counts` starts at zeros, so a role
+        // that is empty from process start never crosses. Without the census a
+        // fleet whose decode pods are all mislabelled logs a healthy prefill
+        // line and nothing else, and the only remaining signal is the 503s.
+        let counts = RoleCounts {
+            aggregated: 0,
+            prefill: 2,
+            decode: 0,
+        };
+        assert_eq!(
+            role_census(&disagg_cfg(), counts),
+            vec![(WorkerRole::Prefill, 2), (WorkerRole::Decode, 0)]
+        );
+    }
+
+    #[test]
+    fn the_startup_census_is_silent_under_aggregated() {
+        // One catalog makes "no workers" unambiguous already, and aggregated
+        // startup output must stay byte-identical to its previous behavior.
+        assert!(role_census(&agg_cfg(), RoleCounts::default()).is_empty());
+        assert!(
+            role_census(
+                &agg_cfg(),
+                RoleCounts {
+                    aggregated: 3,
+                    prefill: 0,
+                    decode: 0,
+                },
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn the_startup_census_covers_the_all_empty_pool() {
+        // This is the case that cannot be gated on `index_changed`: an index
+        // that starts empty and stays empty never reports a change, so gating
+        // the census on one would make both roles silent.
+        assert_eq!(
+            role_census(&disagg_cfg(), RoleCounts::default()),
+            vec![(WorkerRole::Prefill, 0), (WorkerRole::Decode, 0)]
+        );
     }
 
     fn with_replay(mut cfg: RoleDiscoveryConfig, port: u16) -> RoleDiscoveryConfig {

--- a/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
@@ -54,9 +54,8 @@ pub struct RawWorker {
 /// error worth surfacing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum PodRejection {
-    /// Not `Ready`, not pool-selected, unnamed, or without a parseable IP.
-    /// Pre-existing behavior, and the only outcome possible in aggregated
-    /// topology.
+    /// Not `Ready`, not pool-selected, unnamed, or without a parseable IP; the
+    /// only outcome possible in aggregated topology.
     Ineligible,
     /// Pool-selected and `Ready`, but the role label is missing or unparseable.
     Role(RoleLabelError),
@@ -203,8 +202,7 @@ impl PodDiscovery {
             tokio::pin!(reflect);
             let mut generation = 0u64;
             let mut last_counts = RoleCounts::default();
-            // Set once discovery first has a complete picture; see the census
-            // block below for why the crossed-zero log alone is not enough.
+            // Set once discovery first has a complete picture.
             let mut census_logged = false;
             // The pod cache is "synced" once the reflector's initial LIST lands
             // (InitDone); readiness stays gated on this AND pool presence below.
@@ -275,22 +273,9 @@ impl PodDiscovery {
                 // Readiness based on initial pods being synced and the pool being resolved.
                 let is_ready = pod_synced && pool_rx.borrow().is_some();
 
-                // The first iteration holding a complete picture reports every
-                // role's count, not just the ones that moved: `last_counts`
-                // starts at zeros, so a role that is empty from process start
-                // never crosses zero and `log_role_count_transitions` would say
-                // nothing about it — while the healthy role logs normally. That
-                // is the shape of the likeliest disaggregated misconfiguration
-                // (the role label misspelled on every decode pod), and it would
-                // otherwise be reported by nothing but the 503s themselves. An
-                // all-empty index does not even set `index_changed`, so the
-                // census cannot be gated on it.
-                //
-                // Gated on the role label as well as on readiness, so that under
-                // aggregated topology `first_census` is always false and this
-                // block collapses to exactly the transition-only path it had
-                // before: one catalog makes "no workers" unambiguous already,
-                // and its startup output must not change.
+                // `last_counts` starts at zeros, so a role empty from process
+                // start never crosses zero, and an all-empty index does not set
+                // `index_changed` either; report the census once instead.
                 let first_census = is_ready && !census_logged && role_cfg.role_label.is_some();
 
                 // This loop is the only place with a before/after view of the
@@ -328,7 +313,7 @@ impl PodDiscovery {
     }
 
     // Return all currently `Ready` workers selected by the pool, regardless of
-    // role. Used by the aggregated reconcile path.
+    // role.
     pub fn ready_workers(&self) -> Vec<RawWorker> {
         self.index
             .read()
@@ -357,9 +342,8 @@ impl PodDiscovery {
         sets
     }
 
-    /// Whether any `Ready`, pool-selected worker in `role` exists. O(1) via the
-    /// denormalized counts — this runs on every request, so it must not become
-    /// a scan when the index gains a role dimension.
+    /// Whether any `Ready`, pool-selected worker in `role` exists. This runs on
+    /// every request, so it must not become a scan.
     pub fn has_ready_workers(&self, role: WorkerRole) -> bool {
         self.index.read().unwrap().counts().get(role) > 0
     }
@@ -383,10 +367,6 @@ impl PodDiscovery {
 
     /// Resolve a `worker_id` to its current `ip:port` HTTP endpoint, refusing a
     /// worker whose role is not `role`.
-    ///
-    /// The role check is what makes "never route to a prefill endpoint" a
-    /// compiler-and-runtime property rather than a convention: a caller holding
-    /// a prefill id simply cannot turn it into a destination.
     pub fn resolve_endpoint(&self, worker_id: u64, role: WorkerRole) -> Option<String> {
         self.index
             .read()
@@ -464,11 +444,8 @@ fn index_state_from(workers: Vec<RawWorker>) -> IndexState {
 
 /// The roles to report in a startup census, with the count to report for each.
 ///
-/// Empty under aggregated topology: there is one catalog, "no workers" is
-/// already unambiguous, and staying silent keeps aggregated startup output
-/// byte-identical to its previous behavior. Under a role split the opposite is
-/// true — one catalog can be empty while the other logs normally, and the
-/// difference is invisible without this.
+/// Empty under aggregated topology: one catalog makes "no workers" unambiguous
+/// already.
 fn role_census(cfg: &RoleDiscoveryConfig, counts: RoleCounts) -> Vec<(WorkerRole, usize)> {
     if cfg.role_label.is_none() {
         return Vec::new();
@@ -642,7 +619,6 @@ fn rebuild_index(
                 Ok(worker) => {
                     fresh.insert(worker.worker_id, WorkerEntry::from_raw(worker));
                 }
-                // Silent and expected: the pod is simply not one of ours.
                 Err(PodRejection::Ineligible) => {}
                 Err(_) => excluded += 1,
             }
@@ -669,13 +645,11 @@ fn rebuild_index(
     }
 }
 
-/// Inputs the pure per-pod mapping needs, replacing the loose port pair that
-/// used to be threaded through every index mutator.
+/// Inputs the per-pod mapping needs.
 #[derive(Debug, Clone)]
 pub(crate) struct RoleDiscoveryConfig {
     /// Label key carrying a worker's role, or `None` in aggregated topology.
-    /// When `None` the label is never read at all, which is what keeps
-    /// aggregated discovery byte-identical to its previous behavior.
+    /// When `None` the label is never read at all.
     role_label: Option<String>,
     kv_event_port: u16,
     replay_port: Option<u16>,
@@ -707,10 +681,9 @@ impl RoleDiscoveryConfig {
     }
 }
 
-/// Build a [`RawWorker`] from a pod, or say why the pod produced none. Pure
-/// function — unit-testable.
+/// Build a [`RawWorker`] from a pod, or say why the pod produced none.
 ///
-/// Eligibility is decided first and unchanged, so a `NotReady` prefill pod is
+/// Eligibility is decided first, so a `NotReady` prefill pod is
 /// [`PodRejection::Ineligible`] rather than a role error: a rolling update must
 /// not read as a misconfiguration.
 fn raw_worker_from_pod(
@@ -815,52 +788,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn the_startup_census_reports_a_role_that_was_never_populated() {
-        // The crossed-zero log cannot: `last_counts` starts at zeros, so a role
-        // that is empty from process start never crosses. Without the census a
-        // fleet whose decode pods are all mislabelled logs a healthy prefill
-        // line and nothing else, and the only remaining signal is the 503s.
-        let counts = RoleCounts {
-            aggregated: 0,
-            prefill: 2,
-            decode: 0,
-        };
-        assert_eq!(
-            role_census(&disagg_cfg(), counts),
-            vec![(WorkerRole::Prefill, 2), (WorkerRole::Decode, 0)]
-        );
-    }
-
-    #[test]
-    fn the_startup_census_is_silent_under_aggregated() {
-        // One catalog makes "no workers" unambiguous already, and aggregated
-        // startup output must stay byte-identical to its previous behavior.
-        assert!(role_census(&agg_cfg(), RoleCounts::default()).is_empty());
-        assert!(
-            role_census(
-                &agg_cfg(),
-                RoleCounts {
-                    aggregated: 3,
-                    prefill: 0,
-                    decode: 0,
-                },
-            )
-            .is_empty()
-        );
-    }
-
-    #[test]
-    fn the_startup_census_covers_the_all_empty_pool() {
-        // This is the case that cannot be gated on `index_changed`: an index
-        // that starts empty and stays empty never reports a change, so gating
-        // the census on one would make both roles silent.
-        assert_eq!(
-            role_census(&disagg_cfg(), RoleCounts::default()),
-            vec![(WorkerRole::Prefill, 0), (WorkerRole::Decode, 0)]
-        );
-    }
-
     fn with_replay(mut cfg: RoleDiscoveryConfig, port: u16) -> RoleDiscoveryConfig {
         cfg.replay_port = Some(port);
         cfg
@@ -877,119 +804,241 @@ mod tests {
     }
 
     #[test]
-    fn ready_selected_pod_maps_to_worker() {
-        let w = raw_worker_from_pod(
-            &pod(
-                "vllm-0",
-                Some("10.0.0.1"),
-                Some(true),
-                &[("app", "vllm-qwen")],
-            ),
-            &pool(),
-            &with_replay(agg_cfg(), 5560),
-        )
-        .expect("ready, selected pod should map");
-        assert_eq!(w.worker_id, hash_pod_name("vllm-0"));
-        assert_eq!(w.http_endpoint, "http://10.0.0.1:8000");
-        assert_eq!(w.kv_events_endpoint.as_deref(), Some("tcp://10.0.0.1:5557"));
-        assert_eq!(w.replay_endpoint.as_deref(), Some("tcp://10.0.0.1:5560"));
-    }
-
-    #[test]
-    fn ipv6_pod_ip_is_bracketed_in_all_endpoints() {
-        let w = raw_worker_from_pod(
-            &pod(
-                "vllm-0",
-                Some("fd00::10"),
-                Some(true),
-                &[("app", "vllm-qwen")],
-            ),
-            &pool(),
-            &with_replay(agg_cfg(), 5560),
-        )
-        .expect("ready, selected IPv6 pod should map");
-        // SocketAddr brackets the IPv6 host so host and port are unambiguous.
-        assert_eq!(w.http_endpoint, "http://[fd00::10]:8000");
-        assert_eq!(
-            w.kv_events_endpoint.as_deref(),
-            Some("tcp://[fd00::10]:5557")
+    fn raw_worker_from_pod_maps_eligible_pods_and_rejects_the_rest() {
+        type Endpoints = (
+            WorkerRole,
+            &'static str,
+            Option<&'static str>,
+            Option<&'static str>,
         );
-        assert_eq!(w.replay_endpoint.as_deref(), Some("tcp://[fd00::10]:5560"));
-    }
+        type Expected = Result<Endpoints, PodRejection>;
 
-    #[test]
-    fn malformed_pod_ip_is_skipped() {
-        assert!(
-            raw_worker_from_pod(
-                &pod(
-                    "vllm-0",
-                    Some("not-an-ip"),
-                    Some(true),
-                    &[("app", "vllm-qwen")]
-                ),
-                &pool(),
-                &agg_cfg(),
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn pod_not_matching_selector_is_skipped() {
-        assert!(
-            raw_worker_from_pod(
-                &pod(
-                    "other-0",
-                    Some("10.0.0.1"),
-                    Some(true),
-                    &[("app", "something-else")]
-                ),
-                &pool(),
-                &agg_cfg(),
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn not_ready_pod_is_skipped() {
-        assert!(
-            raw_worker_from_pod(
-                &pod(
-                    "vllm-0",
-                    Some("10.0.0.1"),
-                    Some(false),
-                    &[("app", "vllm-qwen")]
-                ),
-                &pool(),
-                &agg_cfg(),
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn terminating_pod_is_skipped() {
-        let mut p = pod(
+        let mut terminating = pod(
             "vllm-0",
             Some("10.0.0.1"),
             Some(true),
             &[("app", "vllm-qwen")],
         );
-        p.metadata.deletion_timestamp = Some(Time(k8s_openapi::chrono::Utc::now()));
-        assert!(raw_worker_from_pod(&p, &pool(), &agg_cfg()).is_err());
+        terminating.metadata.deletion_timestamp = Some(Time(k8s_openapi::chrono::Utc::now()));
+
+        let cases: Vec<(&str, Pod, RoleDiscoveryConfig, Expected)> = vec![
+            (
+                "ready selected pod maps to a worker",
+                pod(
+                    "vllm-0",
+                    Some("10.0.0.1"),
+                    Some(true),
+                    &[("app", "vllm-qwen")],
+                ),
+                with_replay(agg_cfg(), 5560),
+                Ok((
+                    WorkerRole::Aggregated,
+                    "http://10.0.0.1:8000",
+                    Some("tcp://10.0.0.1:5557"),
+                    Some("tcp://10.0.0.1:5560"),
+                )),
+            ),
+            (
+                "IPv6 pod IP is bracketed in every endpoint",
+                pod(
+                    "vllm-0",
+                    Some("fd00::10"),
+                    Some(true),
+                    &[("app", "vllm-qwen")],
+                ),
+                with_replay(agg_cfg(), 5560),
+                Ok((
+                    WorkerRole::Aggregated,
+                    "http://[fd00::10]:8000",
+                    Some("tcp://[fd00::10]:5557"),
+                    Some("tcp://[fd00::10]:5560"),
+                )),
+            ),
+            (
+                "malformed pod IP is ineligible",
+                pod(
+                    "vllm-0",
+                    Some("not-an-ip"),
+                    Some(true),
+                    &[("app", "vllm-qwen")],
+                ),
+                agg_cfg(),
+                Err(PodRejection::Ineligible),
+            ),
+            (
+                "pod outside the pool selector is ineligible",
+                pod(
+                    "other-0",
+                    Some("10.0.0.1"),
+                    Some(true),
+                    &[("app", "something-else")],
+                ),
+                agg_cfg(),
+                Err(PodRejection::Ineligible),
+            ),
+            (
+                "NotReady pod is ineligible",
+                pod(
+                    "vllm-0",
+                    Some("10.0.0.1"),
+                    Some(false),
+                    &[("app", "vllm-qwen")],
+                ),
+                agg_cfg(),
+                Err(PodRejection::Ineligible),
+            ),
+            (
+                "terminating pod is ineligible",
+                terminating,
+                agg_cfg(),
+                Err(PodRejection::Ineligible),
+            ),
+            (
+                "pod without an IP is ineligible",
+                pod("vllm-0", None, Some(true), &[("app", "vllm-qwen")]),
+                agg_cfg(),
+                Err(PodRejection::Ineligible),
+            ),
+            (
+                "aggregated topology never reads the role label",
+                role_pod("vllm-0", "10.0.0.1", "prefill"),
+                agg_cfg(),
+                Ok((
+                    WorkerRole::Aggregated,
+                    "http://10.0.0.1:8000",
+                    Some("tcp://10.0.0.1:5557"),
+                    None,
+                )),
+            ),
+            (
+                "prefill carries both KV-event endpoints",
+                role_pod("p-0", "10.0.0.1", "prefill"),
+                with_replay(disagg_cfg(), 5560),
+                Ok((
+                    WorkerRole::Prefill,
+                    "http://10.0.0.1:8000",
+                    Some("tcp://10.0.0.1:5557"),
+                    Some("tcp://10.0.0.1:5560"),
+                )),
+            ),
+            (
+                "decode carries no KV-event endpoint even with a replay port",
+                role_pod("d-0", "10.0.0.2", "decode"),
+                with_replay(disagg_cfg(), 5560),
+                Ok((WorkerRole::Decode, "http://10.0.0.2:8000", None, None)),
+            ),
+            (
+                "missing role label is a role rejection",
+                pod(
+                    "vllm-0",
+                    Some("10.0.0.1"),
+                    Some(true),
+                    &[("app", "vllm-qwen")],
+                ),
+                disagg_cfg(),
+                Err(PodRejection::Role(RoleLabelError::Missing)),
+            ),
+            (
+                "unparseable role label is a role rejection carrying the token",
+                role_pod("vllm-0", "10.0.0.1", "gibberish"),
+                disagg_cfg(),
+                Err(PodRejection::Role(RoleLabelError::Invalid {
+                    token: "gibberish".to_string(),
+                })),
+            ),
+            (
+                "NotReady outranks a valid role label",
+                pod(
+                    "vllm-0",
+                    Some("10.0.0.1"),
+                    Some(false),
+                    &[("app", "vllm-qwen"), (DEFAULT_WORKER_ROLE_LABEL, "prefill")],
+                ),
+                disagg_cfg(),
+                Err(PodRejection::Ineligible),
+            ),
+            (
+                "unselected outranks a valid role label",
+                pod(
+                    "vllm-0",
+                    Some("10.0.0.1"),
+                    Some(true),
+                    &[("app", "other"), (DEFAULT_WORKER_ROLE_LABEL, "prefill")],
+                ),
+                disagg_cfg(),
+                Err(PodRejection::Ineligible),
+            ),
+            (
+                "missing IP outranks a broken role label",
+                pod(
+                    "vllm-0",
+                    None,
+                    Some(true),
+                    &[("app", "vllm-qwen"), (DEFAULT_WORKER_ROLE_LABEL, "bogus")],
+                ),
+                disagg_cfg(),
+                Err(PodRejection::Ineligible),
+            ),
+        ];
+
+        for (label, p, cfg, want) in cases {
+            let got = raw_worker_from_pod(&p, &pool(), &cfg);
+            match want {
+                Ok((role, http, kv, replay)) => {
+                    let w = got.unwrap_or_else(|e| panic!("{label}: {e:?}"));
+                    let name = p.metadata.name.as_deref().unwrap();
+                    assert_eq!(w.worker_id, hash_pod_name(name), "{label}");
+                    assert_eq!(w.role, role, "{label}");
+                    assert_eq!(w.http_endpoint, http, "{label}");
+                    assert_eq!(w.kv_events_endpoint.as_deref(), kv, "{label}");
+                    assert_eq!(w.replay_endpoint.as_deref(), replay, "{label}");
+                }
+                Err(rejection) => assert_eq!(got, Err(rejection), "{label}"),
+            }
+        }
     }
 
     #[test]
-    fn pod_without_ip_is_skipped() {
-        assert!(
-            raw_worker_from_pod(
-                &pod("vllm-0", None, Some(true), &[("app", "vllm-qwen")]),
-                &pool(),
-                &agg_cfg(),
-            )
-            .is_err()
-        );
+    fn role_census_covers_both_roles_or_is_empty_under_aggregated() {
+        let prefill_only = RoleCounts {
+            aggregated: 0,
+            prefill: 2,
+            decode: 0,
+        };
+        let aggregated_only = RoleCounts {
+            aggregated: 3,
+            prefill: 0,
+            decode: 0,
+        };
+        let cases = [
+            (
+                "a role empty from process start is reported at 0",
+                disagg_cfg(),
+                prefill_only,
+                vec![(WorkerRole::Prefill, 2), (WorkerRole::Decode, 0)],
+            ),
+            (
+                "an all-empty pool reports both roles at 0",
+                disagg_cfg(),
+                RoleCounts::default(),
+                vec![(WorkerRole::Prefill, 0), (WorkerRole::Decode, 0)],
+            ),
+            (
+                "aggregated with no workers adds nothing",
+                agg_cfg(),
+                RoleCounts::default(),
+                vec![],
+            ),
+            (
+                "aggregated with workers adds nothing",
+                agg_cfg(),
+                aggregated_only,
+                vec![],
+            ),
+        ];
+        for (label, cfg, counts, want) in cases {
+            assert_eq!(role_census(&cfg, counts), want, "{label}");
+        }
     }
 
     fn store_from_pods(pods: Vec<Pod>) -> kube::runtime::reflector::Store<Pod> {
@@ -1303,7 +1352,7 @@ mod tests {
         );
     }
 
-    // --- role resolution ---------------------------------------------------
+    // --- role changes and counts -------------------------------------------
 
     /// Recompute counts from the map, so the denormalized copy can be checked
     /// against the source of truth after every mutation path.
@@ -1314,111 +1363,6 @@ mod tests {
         }
         counts
     }
-
-    #[test]
-    fn aggregated_topology_ignores_the_role_label() {
-        // Not merely "defaults to Aggregated": the label is never read, which is
-        // what keeps aggregated discovery byte-identical to its old behavior.
-        let w = raw_worker_from_pod(
-            &role_pod("vllm-0", "10.0.0.1", "prefill"),
-            &pool(),
-            &agg_cfg(),
-        )
-        .expect("labelled pod is still eligible under aggregated");
-        assert_eq!(w.role, WorkerRole::Aggregated);
-        assert!(w.kv_events_endpoint.is_some());
-    }
-
-    #[test]
-    fn disaggregated_topology_maps_the_two_roles() {
-        for (label, expected) in [
-            ("prefill", WorkerRole::Prefill),
-            ("decode", WorkerRole::Decode),
-        ] {
-            let w = raw_worker_from_pod(
-                &role_pod("vllm-0", "10.0.0.1", label),
-                &pool(),
-                &disagg_cfg(),
-            )
-            .expect("labelled pod should map");
-            assert_eq!(w.role, expected);
-        }
-    }
-
-    #[test]
-    fn only_prefill_workers_carry_kv_event_endpoints() {
-        // The decode instance runs with KV events off, so an endpoint there would
-        // open a subscription nothing publishes to.
-        let cfg = with_replay(disagg_cfg(), 5560);
-        let prefill = raw_worker_from_pod(&role_pod("p-0", "10.0.0.1", "prefill"), &pool(), &cfg)
-            .expect("prefill should map");
-        assert_eq!(
-            prefill.kv_events_endpoint.as_deref(),
-            Some("tcp://10.0.0.1:5557")
-        );
-        assert_eq!(
-            prefill.replay_endpoint.as_deref(),
-            Some("tcp://10.0.0.1:5560")
-        );
-
-        let decode = raw_worker_from_pod(&role_pod("d-0", "10.0.0.2", "decode"), &pool(), &cfg)
-            .expect("decode should map");
-        assert!(decode.kv_events_endpoint.is_none());
-        assert!(decode.replay_endpoint.is_none());
-    }
-
-    #[test]
-    fn missing_role_label_is_a_role_rejection() {
-        let p = pod(
-            "vllm-0",
-            Some("10.0.0.1"),
-            Some(true),
-            &[("app", "vllm-qwen")],
-        );
-        assert_eq!(
-            raw_worker_from_pod(&p, &pool(), &disagg_cfg()),
-            Err(PodRejection::Role(RoleLabelError::Missing))
-        );
-    }
-
-    #[test]
-    fn unparseable_role_label_is_a_role_rejection() {
-        let p = role_pod("vllm-0", "10.0.0.1", "gibberish");
-        let Err(PodRejection::Role(error)) = raw_worker_from_pod(&p, &pool(), &disagg_cfg()) else {
-            panic!("an unparseable role must be a role rejection");
-        };
-        assert_eq!(error.reason(), "role_label_invalid");
-    }
-
-    #[test]
-    fn ineligibility_outranks_role_resolution() {
-        // The boundary that keeps a rolling update from reading as a
-        // misconfiguration: a NotReady prefill pod is ineligible, not a role error.
-        let not_ready = pod(
-            "vllm-0",
-            Some("10.0.0.1"),
-            Some(false),
-            &[("app", "vllm-qwen"), (DEFAULT_WORKER_ROLE_LABEL, "prefill")],
-        );
-        assert_eq!(
-            raw_worker_from_pod(&not_ready, &pool(), &disagg_cfg()),
-            Err(PodRejection::Ineligible)
-        );
-
-        // Likewise for a pod the pool does not select, even with a valid role.
-        let unselected = pod(
-            "vllm-0",
-            Some("10.0.0.1"),
-            Some(true),
-            &[("app", "other"), (DEFAULT_WORKER_ROLE_LABEL, "prefill")],
-        );
-        assert_eq!(
-            raw_worker_from_pod(&unselected, &pool(), &disagg_cfg()),
-            Err(PodRejection::Ineligible)
-        );
-    }
-
-    // --- role changes and counts -------------------------------------------
 
     #[test]
     fn role_flip_keeps_worker_id_and_moves_counts() {
@@ -1515,6 +1459,16 @@ mod tests {
             assert_eq!(index.counts().decode, 1);
         }
 
+        // remove_pod for every prefill pod: the decode catalog is untouched.
+        assert!(remove_pod(&index, &role_pod("p-0", "10.0.0.1", "prefill")));
+        assert!(remove_pod(&index, &role_pod("p-1", "10.0.0.4", "prefill")));
+        {
+            let index = index.read().unwrap();
+            assert_eq!(index.counts(), recount(&index));
+            assert_eq!(index.counts().prefill, 0);
+            assert_eq!(index.counts().decode, 1);
+        }
+
         // clear
         index.write().unwrap().clear();
         let index = index.read().unwrap();
@@ -1522,25 +1476,10 @@ mod tests {
         assert_eq!(index.counts(), RoleCounts::default());
     }
 
-    #[test]
-    fn deleting_every_prefill_pod_leaves_the_decode_catalog_intact() {
-        let index = RwLock::new(IndexState::default());
-        let store = store_from_pods(vec![
-            role_pod("p-0", "10.0.0.1", "prefill"),
-            role_pod("d-0", "10.0.0.2", "decode"),
-        ]);
-        assert!(rebuild_index(&store, Some(&pool()), &disagg_cfg(), &index));
-
-        assert!(remove_pod(&index, &role_pod("p-0", "10.0.0.1", "prefill")));
-        let index = index.read().unwrap();
-        assert_eq!(index.counts().prefill, 0);
-        assert_eq!(index.counts().decode, 1);
-    }
-
     // --- the invariant: a prefill worker is never a destination -------------
 
-    fn role_discovery(workers: &[(&str, &str, WorkerRole)]) -> PodDiscovery {
-        let raw = workers
+    fn role_workers(workers: &[(&str, &str, WorkerRole)]) -> Vec<RawWorker> {
+        workers
             .iter()
             .map(|(name, ip, role)| RawWorker {
                 worker_id: hash_pod_name(name),
@@ -1552,8 +1491,11 @@ mod tests {
                     .then(|| format!("tcp://{ip}:5557")),
                 replay_endpoint: None,
             })
-            .collect();
-        PodDiscovery::for_test(raw).0
+            .collect()
+    }
+
+    fn role_discovery(workers: &[(&str, &str, WorkerRole)]) -> PodDiscovery {
+        PodDiscovery::for_test(role_workers(workers)).0
     }
 
     #[test]
@@ -1606,27 +1548,22 @@ mod tests {
             discovery.ready_worker_ids_matching(WorkerRole::Prefill, |_| true),
             HashSet::from([hash_pod_name("p-0")])
         );
-    }
 
-    #[test]
-    fn ready_workers_by_role_partitions_one_snapshot() {
-        let discovery = role_discovery(&[
+        // set_workers swaps the whole catalog and recomputes the counts.
+        discovery.set_workers(role_workers(&[
             ("p-0", "10.0.0.1", WorkerRole::Prefill),
             ("d-0", "10.0.0.2", WorkerRole::Decode),
             ("d-1", "10.0.0.3", WorkerRole::Decode),
-        ]);
+        ]));
+        assert_eq!(discovery.role_counts().prefill, 1);
+        assert_eq!(discovery.role_counts().decode, 2);
 
+        // Both role sets partition one snapshot.
         let sets = discovery.ready_workers_by_role();
         assert_eq!(sets.prefill.len(), 1);
         assert_eq!(sets.decode.len(), 2);
         assert!(sets.prefill.iter().all(|w| w.role == WorkerRole::Prefill));
         assert!(sets.decode.iter().all(|w| w.role == WorkerRole::Decode));
-    }
-
-    #[test]
-    fn set_workers_replaces_the_catalog_and_recomputes_counts() {
-        let discovery = role_discovery(&[("p-0", "10.0.0.1", WorkerRole::Prefill)]);
-        assert_eq!(discovery.role_counts().prefill, 1);
 
         discovery.set_workers(vec![]);
         assert_eq!(discovery.role_counts(), RoleCounts::default());

--- a/deploy/inference-gateway/ext-proc/src/role_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/role_config.rs
@@ -24,7 +24,7 @@
 //! and crediting it for a prefix it never cached would be a fiction.
 
 use anyhow::Result;
-use dynamo_kv_router::config::KvRouterConfig;
+use dynamo_kv_router::config::{KvRouterConfig, RouterPrefillLoadModel};
 
 use crate::epp_standalone_config::{DISAGGREGATED_TOPOLOGY, EppTopologyMode};
 use crate::worker_role::WorkerRole;
@@ -123,6 +123,36 @@ pub(crate) fn kv_router_config_for_role(base: &KvRouterConfig, role: WorkerRole)
                      a KV-event-fed index, and the decode role consumes no KV events"
                 );
             }
+
+            // Two more settings are cross-field validated against knobs this arm
+            // just turned off: `router_prefill_load_model` requires
+            // `router_track_prefill_tokens`, and `serve_indexer` requires
+            // `overlap_score_credit > 0`. Inheriting either would fail the same
+            // validation and take the EPP down at startup.
+            //
+            // Neither is settable from the EPP's only config source today:
+            // `kv_router_config_from_lookup` starts from `KvRouterConfig::default()`
+            // and applies a fixed list of `DYN_ROUTER_*` overrides that does not
+            // include them, so both hold their disabled defaults. Clear them
+            // anyway — the day one of those env knobs is added, the decode
+            // selector should keep building rather than fail on a setting that
+            // only ever described the prefill leg.
+            if cfg.router_prefill_load_model.is_enabled() {
+                cfg.router_prefill_load_model = RouterPrefillLoadModel::None;
+                tracing::warn!(
+                    role = %WorkerRole::Decode,
+                    "Clearing router_prefill_load_model for the decode selector: it estimates \
+                     prefill load from tracked prefill tokens, which this role does not track"
+                );
+            }
+            if cfg.serve_indexer {
+                cfg.serve_indexer = false;
+                tracing::warn!(
+                    role = %WorkerRole::Decode,
+                    "Clearing serve_indexer for the decode selector: it would publish an index \
+                     that no KV event ever reaches"
+                );
+            }
         }
     }
 
@@ -190,6 +220,35 @@ mod tests {
         // Prefill still consumes events, so its TTL is left alone.
         let prefill = kv_router_config_for_role(&base, WorkerRole::Prefill);
         assert_eq!(prefill.router_predicted_ttl_secs, Some(120.0));
+    }
+
+    #[test]
+    fn decode_clears_the_other_settings_its_own_overrides_would_invalidate() {
+        // `router_prefill_load_model` requires `router_track_prefill_tokens` and
+        // `serve_indexer` requires `overlap_score_credit > 0` -- both of which
+        // the decode arm turns off. A base that sets them is valid on its own,
+        // so the failure would land on the decode selector at startup.
+        let mut base = base();
+        base.router_prefill_load_model = RouterPrefillLoadModel::Aic;
+        base.serve_indexer = true;
+        assert!(
+            base.validate_config().is_ok(),
+            "the base itself must be valid"
+        );
+
+        let cfg = kv_router_config_for_role(&base, WorkerRole::Decode);
+        assert!(!cfg.router_prefill_load_model.is_enabled());
+        assert!(!cfg.serve_indexer);
+        assert!(cfg.validate_config().is_ok(), "decode config must build");
+
+        // Prefill keeps both: it tracks prefill tokens and scores overlap.
+        let prefill = kv_router_config_for_role(&base, WorkerRole::Prefill);
+        assert_eq!(
+            prefill.router_prefill_load_model,
+            RouterPrefillLoadModel::Aic
+        );
+        assert!(prefill.serve_indexer);
+        assert!(prefill.validate_config().is_ok());
     }
 
     #[test]

--- a/deploy/inference-gateway/ext-proc/src/role_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/role_config.rs
@@ -1,73 +1,29 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Per-role router configuration for the disaggregated standalone EPP.
-//!
-//! The two roles need genuinely different selection behavior, and every knob
-//! that expresses the difference lives on [`KvRouterConfig`], which a
-//! `SelectionService` takes once at construction. That is why disaggregated mode
-//! builds two services rather than one service with two partitions: a single
-//! config cannot describe both roles.
-//!
-//! The split mirrors what the full Dynamo runtime does for the same two legs:
-//!
-//! | knob | prefill | decode |
-//! |---|---|---|
-//! | `use_kv_events` | on | off |
-//! | `overlap_score_credit` | base | `0.0` |
-//! | `router_track_prefill_tokens` | base | off |
-//! | `router_assume_kv_reuse` | base | off |
-//!
-//! In words: prefill scores on prefix overlap and does not model long-lived
-//! block occupancy; decode ignores overlap and models occupancy. A decode worker
-//! did not compute the prompt, so charging it prefill work would mis-rank it,
-//! and crediting it for a prefix it never cached would be a fiction.
+//! A decode worker never computed the prompt, so it is never credited for prefix
+//! overlap or charged prefill work; it also has no KV-event source, so its
+//! selector is built with events off.
 
 use anyhow::Result;
-use dynamo_kv_router::config::{KvRouterConfig, RouterPrefillLoadModel};
+use dynamo_kv_router::config::{KvRouterConfig, RouterConfigOverride};
 
+use crate::epp::decode_router_config_override;
 use crate::epp_standalone_config::{DISAGGREGATED_TOPOLOGY, EppTopologyMode};
 use crate::worker_role::WorkerRole;
 
-/// Env var that enables conditional disaggregation, rejected below.
 const DYN_ROUTER_CONDITIONAL_DISAGG: &str = "DYN_ROUTER_CONDITIONAL_DISAGG";
-/// Env var whose value the decode role must clear; named in the warning.
 const DYN_ROUTER_PREDICTED_TTL_SECS: &str = "DYN_ROUTER_PREDICTED_TTL_SECS";
-/// Env var the standalone selector cannot honor; warned about, not rejected.
-const DYN_ROUTER_TRACK_ACTIVE_BLOCKS: &str = "DYN_ROUTER_TRACK_ACTIVE_BLOCKS";
 
-/// Reject router settings the standalone EPP cannot honor under a role split.
-///
-/// Separate from [`kv_router_config_for_role`] so it can fail loudly at startup
-/// instead of silently producing a config that means something else.
+/// Reject router settings the standalone EPP cannot honor under a role split, so
+/// they fail at startup instead of silently meaning something else.
 pub(crate) fn reject_unsupported_router_config(
     topology: EppTopologyMode,
     base: &KvRouterConfig,
 ) -> Result<()> {
-    if !topology.is_disaggregated() {
-        return Ok(());
-    }
-
-    if !base.router_track_active_blocks {
-        // Not an error, because the flag is currently a no-op on this path: the
-        // selection service computes tracking hashes directly rather than
-        // through the `KvRouterConfig` wrapper that honors it. Worth saying out
-        // loud, though — an operator who set this expects load accounting to be
-        // off, and under a role split active-block occupancy is the decode
-        // selector's only remaining load signal.
-        tracing::warn!(
-            "{DYN_ROUTER_TRACK_ACTIVE_BLOCKS}=false has no effect on the standalone selector; \
-             active-block accounting stays on, and it is the decode role's only load signal \
-             once overlap scoring and prefill-token tracking are disabled for it"
-        );
-    }
-
-    if base.conditional_disagg_enabled {
-        // Conditional disaggregation inverts the decode role's whole profile: it
-        // needs decode-side KV events to decide whether to bypass prefill at
-        // all, and the bypass itself is orchestration `SelectionService` does not
-        // perform. Honoring the flag would be a lie; ignoring it silently would
-        // be worse.
+    if topology.is_disaggregated() && base.conditional_disagg_enabled {
+        // Needs decode-side KV events and a bypass the selection service does
+        // not orchestrate.
         anyhow::bail!(
             "{DYN_ROUTER_CONDITIONAL_DISAGG} is not supported with \
              DYN_EPP_TOPOLOGY_MODE={DISAGGREGATED_TOPOLOGY}: conditional disaggregation requires \
@@ -75,242 +31,148 @@ pub(crate) fn reject_unsupported_router_config(
              provide"
         );
     }
-
     Ok(())
 }
 
-/// Derive the config for one role from the process-wide base.
-///
-/// Prefill *inherits* rather than overrides when the base already disables
-/// KV-aware selection: an operator who turned it off meant it, and
-/// `should_subscribe_to_kv_events()` is `use_kv_events && overlap_score_credit > 0`,
-/// so either switch alone is a complete opt-out. Re-enabling one of them here
-/// would resurrect a subscription the operator deliberately removed.
+/// Static `SelectionService` configuration for one role. Only what must be fixed
+/// at construction lives here; the decode leg's selection semantics ride on
+/// [`router_config_override_for_role`] instead.
 pub(crate) fn kv_router_config_for_role(base: &KvRouterConfig, role: WorkerRole) -> KvRouterConfig {
     let mut cfg = base.clone();
-
-    match role {
-        // Aggregated is the untouched base: this is what keeps aggregated mode
-        // byte-identical to its previous behavior.
-        WorkerRole::Aggregated => {}
-
-        WorkerRole::Prefill => {
-            if !kv_aware_selection_enabled(base) {
-                tracing::warn!(
-                    role = %WorkerRole::Prefill,
-                    use_kv_events = base.use_kv_events,
-                    overlap_score_credit = base.overlap_score_credit,
-                    "KV-aware prefill selection is disabled by the base router config; \
-                     the prefill catalog will select on load alone"
-                );
-            }
-        }
-
-        WorkerRole::Decode => {
-            cfg.use_kv_events = false;
-            cfg.overlap_score_credit = 0.0;
-            cfg.router_track_prefill_tokens = false;
-            cfg.router_assume_kv_reuse = false;
-
-            // `SelectionServiceBuilder::build` validates the config before it
-            // constructs anything, and predicted-TTL pruning requires the event
-            // stream this role just turned off. Clearing it is the only reading
-            // that keeps both settings meaningful.
-            if cfg.router_predicted_ttl_secs.take().is_some() {
-                tracing::warn!(
-                    role = %WorkerRole::Decode,
-                    "Clearing {DYN_ROUTER_PREDICTED_TTL_SECS} for the decode selector: it prunes \
-                     a KV-event-fed index, and the decode role consumes no KV events"
-                );
-            }
-
-            // Two more settings are cross-field validated against knobs this arm
-            // just turned off: `router_prefill_load_model` requires
-            // `router_track_prefill_tokens`, and `serve_indexer` requires
-            // `overlap_score_credit > 0`. Inheriting either would fail the same
-            // validation and take the EPP down at startup.
-            //
-            // Neither is settable from the EPP's only config source today:
-            // `kv_router_config_from_lookup` starts from `KvRouterConfig::default()`
-            // and applies a fixed list of `DYN_ROUTER_*` overrides that does not
-            // include them, so both hold their disabled defaults. Clear them
-            // anyway — the day one of those env knobs is added, the decode
-            // selector should keep building rather than fail on a setting that
-            // only ever described the prefill leg.
-            if cfg.router_prefill_load_model.is_enabled() {
-                cfg.router_prefill_load_model = RouterPrefillLoadModel::None;
-                tracing::warn!(
-                    role = %WorkerRole::Decode,
-                    "Clearing router_prefill_load_model for the decode selector: it estimates \
-                     prefill load from tracked prefill tokens, which this role does not track"
-                );
-            }
-            if cfg.serve_indexer {
-                cfg.serve_indexer = false;
-                tracing::warn!(
-                    role = %WorkerRole::Decode,
-                    "Clearing serve_indexer for the decode selector: it would publish an index \
-                     that no KV event ever reaches"
-                );
-            }
+    if role == WorkerRole::Decode {
+        cfg.use_kv_events = false;
+        // Predicted-TTL pruning needs the event stream this role does not have,
+        // and the builder rejects the pair.
+        if cfg.router_predicted_ttl_secs.take().is_some() {
+            tracing::warn!(
+                role = %role,
+                "Clearing {DYN_ROUTER_PREDICTED_TTL_SECS} for the decode selector: it prunes a \
+                 KV-event-fed index, and the decode role consumes no KV events"
+            );
         }
     }
-
     cfg
 }
 
-/// Whether the base config leaves prefix-overlap selection switched on at all.
-fn kv_aware_selection_enabled(base: &KvRouterConfig) -> bool {
-    base.use_kv_events && base.overlap_score_credit > 0.0
+/// Per-request selection semantics for one role's selector, supplied on every
+/// selection and booking it performs. Decode carries the same override the
+/// Dynamo-runtime EPP applies to its decode leg; prefill and aggregated carry none.
+pub(crate) fn router_config_override_for_role(role: WorkerRole) -> Option<RouterConfigOverride> {
+    decode_router_config_override(role == WorkerRole::Decode)
 }
 
 #[cfg(test)]
 mod tests {
+    use dynamo_kv_router::config::RouterPrefillLoadModel;
+
     use super::*;
 
-    fn base() -> KvRouterConfig {
-        KvRouterConfig::default()
+    const ROLES: [WorkerRole; 3] = [
+        WorkerRole::Aggregated,
+        WorkerRole::Prefill,
+        WorkerRole::Decode,
+    ];
+
+    #[test]
+    fn only_decode_changes_the_static_config_and_only_for_kv_events() {
+        let base = KvRouterConfig::default();
+        for role in ROLES {
+            let cfg = kv_router_config_for_role(&base, role);
+            assert_eq!(cfg.use_kv_events, role != WorkerRole::Decode, "{role}");
+            // Selection semantics are per-request, never static.
+            assert_eq!(
+                cfg.overlap_score_credit, base.overlap_score_credit,
+                "{role}"
+            );
+            assert_eq!(
+                cfg.router_track_prefill_tokens, base.router_track_prefill_tokens,
+                "{role}"
+            );
+            assert_eq!(
+                cfg.router_assume_kv_reuse, base.router_assume_kv_reuse,
+                "{role}"
+            );
+            assert!(cfg.validate_config().is_ok(), "{role}");
+        }
     }
 
     #[test]
-    fn aggregated_is_the_untouched_base() {
-        let base = base();
-        let cfg = kv_router_config_for_role(&base, WorkerRole::Aggregated);
-        assert_eq!(cfg.use_kv_events, base.use_kv_events);
-        assert_eq!(cfg.overlap_score_credit, base.overlap_score_credit);
-        assert_eq!(
-            cfg.router_track_prefill_tokens,
-            base.router_track_prefill_tokens
-        );
-        assert_eq!(cfg.router_assume_kv_reuse, base.router_assume_kv_reuse);
-    }
+    fn decode_carries_the_runtime_decode_override_and_the_other_roles_none() {
+        let decode = router_config_override_for_role(WorkerRole::Decode).expect("decode override");
+        assert_eq!(decode.overlap_score_credit, Some(0.0));
+        assert_eq!(decode.assume_kv_reuse, Some(false));
+        assert_eq!(decode.track_prefill_tokens, Some(false));
+        assert!(decode.prefill_load_scale.is_none());
+        assert!(decode.router_temperature.is_none());
+        assert!(decode.shared_cache_multiplier.is_none());
 
-    #[test]
-    fn prefill_keeps_the_base_selection_profile() {
-        // Prefill is the role that still scores on prefix overlap, so none of
-        // the four knobs may be forced here.
-        let base = base();
-        let cfg = kv_router_config_for_role(&base, WorkerRole::Prefill);
-        assert!(cfg.use_kv_events);
-        assert_eq!(cfg.overlap_score_credit, base.overlap_score_credit);
-        assert!(cfg.router_track_prefill_tokens);
-        assert!(cfg.router_assume_kv_reuse);
-    }
-
-    #[test]
-    fn decode_drops_overlap_and_prefill_accounting() {
-        let cfg = kv_router_config_for_role(&base(), WorkerRole::Decode);
-        assert!(!cfg.use_kv_events);
-        assert_eq!(cfg.overlap_score_credit, 0.0);
-        assert!(!cfg.router_track_prefill_tokens);
-        assert!(!cfg.router_assume_kv_reuse);
+        assert!(router_config_override_for_role(WorkerRole::Prefill).is_none());
+        assert!(router_config_override_for_role(WorkerRole::Aggregated).is_none());
     }
 
     #[test]
     fn decode_clears_predicted_ttl_so_the_service_can_build() {
-        // Left set, `validate_kv_router_config` rejects the pair and the decode
-        // instance never constructs — taking the whole EPP down at startup.
-        let mut base = base();
-        base.router_predicted_ttl_secs = Some(120.0);
+        let base = KvRouterConfig {
+            router_predicted_ttl_secs: Some(120.0),
+            ..Default::default()
+        };
 
-        let cfg = kv_router_config_for_role(&base, WorkerRole::Decode);
-        assert!(cfg.router_predicted_ttl_secs.is_none());
-        assert!(cfg.validate_config().is_ok(), "decode config must build");
-
-        // Prefill still consumes events, so its TTL is left alone.
-        let prefill = kv_router_config_for_role(&base, WorkerRole::Prefill);
-        assert_eq!(prefill.router_predicted_ttl_secs, Some(120.0));
+        let decode = kv_router_config_for_role(&base, WorkerRole::Decode);
+        assert!(decode.router_predicted_ttl_secs.is_none());
+        assert!(decode.validate_config().is_ok(), "decode config must build");
+        assert_eq!(
+            kv_router_config_for_role(&base, WorkerRole::Prefill).router_predicted_ttl_secs,
+            Some(120.0)
+        );
     }
 
     #[test]
-    fn decode_clears_the_other_settings_its_own_overrides_would_invalidate() {
-        // `router_prefill_load_model` requires `router_track_prefill_tokens` and
-        // `serve_indexer` requires `overlap_score_credit > 0` -- both of which
-        // the decode arm turns off. A base that sets them is valid on its own,
-        // so the failure would land on the decode selector at startup.
-        let mut base = base();
-        base.router_prefill_load_model = RouterPrefillLoadModel::Aic;
-        base.serve_indexer = true;
+    fn decode_inherits_prefill_load_model_and_serve_indexer_and_still_validates() {
+        // Both were once cleared to satisfy cross-field rules against static
+        // knobs the decode arm no longer touches.
+        let base = KvRouterConfig {
+            router_prefill_load_model: RouterPrefillLoadModel::Aic,
+            serve_indexer: true,
+            ..Default::default()
+        };
         assert!(
             base.validate_config().is_ok(),
             "the base itself must be valid"
         );
 
-        let cfg = kv_router_config_for_role(&base, WorkerRole::Decode);
-        assert!(!cfg.router_prefill_load_model.is_enabled());
-        assert!(!cfg.serve_indexer);
-        assert!(cfg.validate_config().is_ok(), "decode config must build");
-
-        // Prefill keeps both: it tracks prefill tokens and scores overlap.
-        let prefill = kv_router_config_for_role(&base, WorkerRole::Prefill);
-        assert_eq!(
-            prefill.router_prefill_load_model,
-            RouterPrefillLoadModel::Aic
-        );
-        assert!(prefill.serve_indexer);
-        assert!(prefill.validate_config().is_ok());
-    }
-
-    #[test]
-    fn every_role_config_passes_the_builders_validation() {
-        for role in [
-            WorkerRole::Aggregated,
-            WorkerRole::Prefill,
-            WorkerRole::Decode,
-        ] {
-            let cfg = kv_router_config_for_role(&base(), role);
-            assert!(
-                cfg.validate_config().is_ok(),
-                "{role} config must satisfy the same validation SelectionServiceBuilder runs"
-            );
-        }
-    }
-
-    #[test]
-    fn prefill_inherits_an_explicit_kv_events_opt_out() {
-        // Not an override: `should_subscribe_to_kv_events` is
-        // `use_kv_events && overlap_score_credit > 0`, so forcing either back on
-        // would resurrect a subscription the operator removed.
-        let mut base = base();
-        base.use_kv_events = false;
-        assert!(!kv_router_config_for_role(&base, WorkerRole::Prefill).use_kv_events);
-
-        let mut base = self::base();
-        base.overlap_score_credit = 0.0;
-        assert_eq!(
-            kv_router_config_for_role(&base, WorkerRole::Prefill).overlap_score_credit,
-            0.0
-        );
+        let decode = kv_router_config_for_role(&base, WorkerRole::Decode);
+        assert!(decode.router_prefill_load_model.is_enabled());
+        assert!(decode.serve_indexer);
+        assert!(decode.validate_config().is_ok(), "decode config must build");
     }
 
     #[test]
     fn conditional_disagg_is_rejected_only_under_disaggregated() {
-        let mut base = base();
-        base.conditional_disagg_enabled = true;
+        let default = KvRouterConfig::default();
+        let enabled = KvRouterConfig {
+            conditional_disagg_enabled: true,
+            ..Default::default()
+        };
 
-        let error = reject_unsupported_router_config(EppTopologyMode::Disaggregated, &base)
-            .expect_err("conditional disagg is not supported by the standalone selector")
-            .to_string();
-        assert!(error.contains(DYN_ROUTER_CONDITIONAL_DISAGG), "{error}");
-        assert!(error.contains(DISAGGREGATED_TOPOLOGY), "{error}");
-
-        // Aggregated never builds a decode profile, so the flag is not our
-        // business there.
-        assert!(reject_unsupported_router_config(EppTopologyMode::Aggregated, &base).is_ok());
-    }
-
-    #[test]
-    fn a_default_router_config_is_accepted() {
-        assert!(reject_unsupported_router_config(EppTopologyMode::Disaggregated, &base()).is_ok());
-    }
-
-    #[test]
-    fn a_disabled_track_active_blocks_warns_but_does_not_reject() {
-        // The flag is a no-op on the selection path, so rejecting would block a
-        // deployment over a setting that changes nothing; the warning is the
-        // whole remedy until the lib/kv-router gap is closed.
-        let mut base = base();
-        base.router_track_active_blocks = false;
-        assert!(reject_unsupported_router_config(EppTopologyMode::Disaggregated, &base).is_ok());
+        let cases = [
+            (EppTopologyMode::Disaggregated, &enabled, false),
+            (EppTopologyMode::Aggregated, &enabled, true),
+            (EppTopologyMode::Disaggregated, &default, true),
+            (EppTopologyMode::Aggregated, &default, true),
+        ];
+        for (topology, base, ok) in cases {
+            let result = reject_unsupported_router_config(topology, base);
+            assert_eq!(
+                result.is_ok(),
+                ok,
+                "{topology:?} conditional={}",
+                base.conditional_disagg_enabled
+            );
+            if let Err(error) = result {
+                let error = error.to_string();
+                assert!(error.contains(DYN_ROUTER_CONDITIONAL_DISAGG), "{error}");
+                assert!(error.contains(DISAGGREGATED_TOPOLOGY), "{error}");
+            }
+        }
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/role_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/role_config.rs
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-role router configuration for the disaggregated standalone EPP.
+//!
+//! The two roles need genuinely different selection behavior, and every knob
+//! that expresses the difference lives on [`KvRouterConfig`], which a
+//! `SelectionService` takes once at construction. That is why disaggregated mode
+//! builds two services rather than one service with two partitions: a single
+//! config cannot describe both roles.
+//!
+//! The split mirrors what the full Dynamo runtime does for the same two legs:
+//!
+//! | knob | prefill | decode |
+//! |---|---|---|
+//! | `use_kv_events` | on | off |
+//! | `overlap_score_credit` | base | `0.0` |
+//! | `router_track_prefill_tokens` | base | off |
+//! | `router_assume_kv_reuse` | base | off |
+//!
+//! In words: prefill scores on prefix overlap and does not model long-lived
+//! block occupancy; decode ignores overlap and models occupancy. A decode worker
+//! did not compute the prompt, so charging it prefill work would mis-rank it,
+//! and crediting it for a prefix it never cached would be a fiction.
+
+use anyhow::Result;
+use dynamo_kv_router::config::KvRouterConfig;
+
+use crate::epp_standalone_config::{DISAGGREGATED_TOPOLOGY, EppTopologyMode};
+use crate::worker_role::WorkerRole;
+
+/// Env var that enables conditional disaggregation, rejected below.
+const DYN_ROUTER_CONDITIONAL_DISAGG: &str = "DYN_ROUTER_CONDITIONAL_DISAGG";
+/// Env var whose value the decode role must clear; named in the warning.
+const DYN_ROUTER_PREDICTED_TTL_SECS: &str = "DYN_ROUTER_PREDICTED_TTL_SECS";
+/// Env var the standalone selector cannot honor; warned about, not rejected.
+const DYN_ROUTER_TRACK_ACTIVE_BLOCKS: &str = "DYN_ROUTER_TRACK_ACTIVE_BLOCKS";
+
+/// Reject router settings the standalone EPP cannot honor under a role split.
+///
+/// Separate from [`kv_router_config_for_role`] so it can fail loudly at startup
+/// instead of silently producing a config that means something else.
+pub(crate) fn reject_unsupported_router_config(
+    topology: EppTopologyMode,
+    base: &KvRouterConfig,
+) -> Result<()> {
+    if !topology.is_disaggregated() {
+        return Ok(());
+    }
+
+    if !base.router_track_active_blocks {
+        // Not an error, because the flag is currently a no-op on this path: the
+        // selection service computes tracking hashes directly rather than
+        // through the `KvRouterConfig` wrapper that honors it. Worth saying out
+        // loud, though — an operator who set this expects load accounting to be
+        // off, and under a role split active-block occupancy is the decode
+        // selector's only remaining load signal.
+        tracing::warn!(
+            "{DYN_ROUTER_TRACK_ACTIVE_BLOCKS}=false has no effect on the standalone selector; \
+             active-block accounting stays on, and it is the decode role's only load signal \
+             once overlap scoring and prefill-token tracking are disabled for it"
+        );
+    }
+
+    if base.conditional_disagg_enabled {
+        // Conditional disaggregation inverts the decode role's whole profile: it
+        // needs decode-side KV events to decide whether to bypass prefill at
+        // all, and the bypass itself is orchestration `SelectionService` does not
+        // perform. Honoring the flag would be a lie; ignoring it silently would
+        // be worse.
+        anyhow::bail!(
+            "{DYN_ROUTER_CONDITIONAL_DISAGG} is not supported with \
+             DYN_EPP_TOPOLOGY_MODE={DISAGGREGATED_TOPOLOGY}: conditional disaggregation requires \
+             decode-side KV events and bypass orchestration the standalone selector does not \
+             provide"
+        );
+    }
+
+    Ok(())
+}
+
+/// Derive the config for one role from the process-wide base.
+///
+/// Prefill *inherits* rather than overrides when the base already disables
+/// KV-aware selection: an operator who turned it off meant it, and
+/// `should_subscribe_to_kv_events()` is `use_kv_events && overlap_score_credit > 0`,
+/// so either switch alone is a complete opt-out. Re-enabling one of them here
+/// would resurrect a subscription the operator deliberately removed.
+pub(crate) fn kv_router_config_for_role(base: &KvRouterConfig, role: WorkerRole) -> KvRouterConfig {
+    let mut cfg = base.clone();
+
+    match role {
+        // Aggregated is the untouched base: this is what keeps aggregated mode
+        // byte-identical to its previous behavior.
+        WorkerRole::Aggregated => {}
+
+        WorkerRole::Prefill => {
+            if !kv_aware_selection_enabled(base) {
+                tracing::warn!(
+                    role = %WorkerRole::Prefill,
+                    use_kv_events = base.use_kv_events,
+                    overlap_score_credit = base.overlap_score_credit,
+                    "KV-aware prefill selection is disabled by the base router config; \
+                     the prefill catalog will select on load alone"
+                );
+            }
+        }
+
+        WorkerRole::Decode => {
+            cfg.use_kv_events = false;
+            cfg.overlap_score_credit = 0.0;
+            cfg.router_track_prefill_tokens = false;
+            cfg.router_assume_kv_reuse = false;
+
+            // `SelectionServiceBuilder::build` validates the config before it
+            // constructs anything, and predicted-TTL pruning requires the event
+            // stream this role just turned off. Clearing it is the only reading
+            // that keeps both settings meaningful.
+            if cfg.router_predicted_ttl_secs.take().is_some() {
+                tracing::warn!(
+                    role = %WorkerRole::Decode,
+                    "Clearing {DYN_ROUTER_PREDICTED_TTL_SECS} for the decode selector: it prunes \
+                     a KV-event-fed index, and the decode role consumes no KV events"
+                );
+            }
+        }
+    }
+
+    cfg
+}
+
+/// Whether the base config leaves prefix-overlap selection switched on at all.
+fn kv_aware_selection_enabled(base: &KvRouterConfig) -> bool {
+    base.use_kv_events && base.overlap_score_credit > 0.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> KvRouterConfig {
+        KvRouterConfig::default()
+    }
+
+    #[test]
+    fn aggregated_is_the_untouched_base() {
+        let base = base();
+        let cfg = kv_router_config_for_role(&base, WorkerRole::Aggregated);
+        assert_eq!(cfg.use_kv_events, base.use_kv_events);
+        assert_eq!(cfg.overlap_score_credit, base.overlap_score_credit);
+        assert_eq!(
+            cfg.router_track_prefill_tokens,
+            base.router_track_prefill_tokens
+        );
+        assert_eq!(cfg.router_assume_kv_reuse, base.router_assume_kv_reuse);
+    }
+
+    #[test]
+    fn prefill_keeps_the_base_selection_profile() {
+        // Prefill is the role that still scores on prefix overlap, so none of
+        // the four knobs may be forced here.
+        let base = base();
+        let cfg = kv_router_config_for_role(&base, WorkerRole::Prefill);
+        assert!(cfg.use_kv_events);
+        assert_eq!(cfg.overlap_score_credit, base.overlap_score_credit);
+        assert!(cfg.router_track_prefill_tokens);
+        assert!(cfg.router_assume_kv_reuse);
+    }
+
+    #[test]
+    fn decode_drops_overlap_and_prefill_accounting() {
+        let cfg = kv_router_config_for_role(&base(), WorkerRole::Decode);
+        assert!(!cfg.use_kv_events);
+        assert_eq!(cfg.overlap_score_credit, 0.0);
+        assert!(!cfg.router_track_prefill_tokens);
+        assert!(!cfg.router_assume_kv_reuse);
+    }
+
+    #[test]
+    fn decode_clears_predicted_ttl_so_the_service_can_build() {
+        // Left set, `validate_kv_router_config` rejects the pair and the decode
+        // instance never constructs — taking the whole EPP down at startup.
+        let mut base = base();
+        base.router_predicted_ttl_secs = Some(120.0);
+
+        let cfg = kv_router_config_for_role(&base, WorkerRole::Decode);
+        assert!(cfg.router_predicted_ttl_secs.is_none());
+        assert!(cfg.validate_config().is_ok(), "decode config must build");
+
+        // Prefill still consumes events, so its TTL is left alone.
+        let prefill = kv_router_config_for_role(&base, WorkerRole::Prefill);
+        assert_eq!(prefill.router_predicted_ttl_secs, Some(120.0));
+    }
+
+    #[test]
+    fn every_role_config_passes_the_builders_validation() {
+        for role in [
+            WorkerRole::Aggregated,
+            WorkerRole::Prefill,
+            WorkerRole::Decode,
+        ] {
+            let cfg = kv_router_config_for_role(&base(), role);
+            assert!(
+                cfg.validate_config().is_ok(),
+                "{role} config must satisfy the same validation SelectionServiceBuilder runs"
+            );
+        }
+    }
+
+    #[test]
+    fn prefill_inherits_an_explicit_kv_events_opt_out() {
+        // Not an override: `should_subscribe_to_kv_events` is
+        // `use_kv_events && overlap_score_credit > 0`, so forcing either back on
+        // would resurrect a subscription the operator removed.
+        let mut base = base();
+        base.use_kv_events = false;
+        assert!(!kv_router_config_for_role(&base, WorkerRole::Prefill).use_kv_events);
+
+        let mut base = self::base();
+        base.overlap_score_credit = 0.0;
+        assert_eq!(
+            kv_router_config_for_role(&base, WorkerRole::Prefill).overlap_score_credit,
+            0.0
+        );
+    }
+
+    #[test]
+    fn conditional_disagg_is_rejected_only_under_disaggregated() {
+        let mut base = base();
+        base.conditional_disagg_enabled = true;
+
+        let error = reject_unsupported_router_config(EppTopologyMode::Disaggregated, &base)
+            .expect_err("conditional disagg is not supported by the standalone selector")
+            .to_string();
+        assert!(error.contains(DYN_ROUTER_CONDITIONAL_DISAGG), "{error}");
+        assert!(error.contains(DISAGGREGATED_TOPOLOGY), "{error}");
+
+        // Aggregated never builds a decode profile, so the flag is not our
+        // business there.
+        assert!(reject_unsupported_router_config(EppTopologyMode::Aggregated, &base).is_ok());
+    }
+
+    #[test]
+    fn a_default_router_config_is_accepted() {
+        assert!(reject_unsupported_router_config(EppTopologyMode::Disaggregated, &base()).is_ok());
+    }
+
+    #[test]
+    fn a_disabled_track_active_blocks_warns_but_does_not_reject() {
+        // The flag is a no-op on the selection path, so rejecting would block a
+        // deployment over a setting that changes nothing; the warning is the
+        // whole remedy until the lib/kv-router gap is closed.
+        let mut base = base();
+        base.router_track_active_blocks = false;
+        assert!(reject_unsupported_router_config(EppTopologyMode::Disaggregated, &base).is_ok());
+    }
+}

--- a/deploy/inference-gateway/ext-proc/src/runner.rs
+++ b/deploy/inference-gateway/ext-proc/src/runner.rs
@@ -18,6 +18,9 @@ use tokio::task::JoinHandle;
 use tokio_rustls::TlsAcceptor;
 use tokio_util::sync::CancellationToken;
 
+use crate::epp_standalone_config::{
+    DISAGGREGATED_TOPOLOGY, DYN_EPP_MODE, DYN_EPP_TOPOLOGY_MODE, EppTopologyMode, STANDALONE_MODE,
+};
 use crate::{EppMode, EppStandaloneConfig, ExtProcServer, Router, metrics};
 
 const GRPC_PORT: u16 = 9002;
@@ -137,6 +140,18 @@ pub async fn run(policy_registry: Option<WorkerSelectionPolicyRegistry>) -> Resu
     run_inner(mode, policy_registry.unwrap_or_default()).await
 }
 
+/// A role split only exists in standalone mode; the Dynamo-runtime path has its
+/// own disaggregation story and never reads this setting.
+fn reject_disaggregated_outside_standalone(mode: EppMode, topology: EppTopologyMode) -> Result<()> {
+    if topology.is_disaggregated() && !matches!(mode, EppMode::Standalone) {
+        anyhow::bail!(
+            "{DYN_EPP_TOPOLOGY_MODE}={DISAGGREGATED_TOPOLOGY} requires \
+             {DYN_EPP_MODE}={STANDALONE_MODE}; the Dynamo-runtime EPP does not read it"
+        );
+    }
+    Ok(())
+}
+
 fn init_tracing() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(
@@ -194,6 +209,12 @@ impl BackgroundTasks {
 
 async fn run_inner(mode: EppMode, policy_registry: WorkerSelectionPolicyRegistry) -> Result<()> {
     let standalone = matches!(mode, EppMode::Standalone);
+
+    // Read before the mode branch: `EppStandaloneConfig::from_env` is only
+    // reached inside it, so a disaggregated topology set alongside the default
+    // runtime mode would otherwise be silently ignored — and every pool-selected
+    // pod, prefill included, would stay a routable destination.
+    reject_disaggregated_outside_standalone(mode, EppTopologyMode::from_env()?)?;
 
     let config = Config::from_env();
 
@@ -534,5 +555,28 @@ mod tests {
             result.unwrap_err().to_string(),
             "linked worker-selection policies require DYN_EPP_MODE=standalone"
         );
+    }
+
+    #[test]
+    fn disaggregated_requires_standalone_mode() {
+        // The failure this guards is silent by construction: without it the
+        // setting is simply never read.
+        let error = reject_disaggregated_outside_standalone(
+            EppMode::DynamoRuntime,
+            EppTopologyMode::Disaggregated,
+        )
+        .expect_err("disaggregated must not be silently ignored under the runtime mode")
+        .to_string();
+        assert!(error.contains(DYN_EPP_MODE), "{error}");
+        assert!(error.contains(STANDALONE_MODE), "{error}");
+
+        // The other three combinations are all legitimate.
+        for (mode, topology) in [
+            (EppMode::Standalone, EppTopologyMode::Disaggregated),
+            (EppMode::Standalone, EppTopologyMode::Aggregated),
+            (EppMode::DynamoRuntime, EppTopologyMode::Aggregated),
+        ] {
+            assert!(reject_disaggregated_outside_standalone(mode, topology).is_ok());
+        }
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/runner.rs
+++ b/deploy/inference-gateway/ext-proc/src/runner.rs
@@ -18,9 +18,6 @@ use tokio::task::JoinHandle;
 use tokio_rustls::TlsAcceptor;
 use tokio_util::sync::CancellationToken;
 
-use crate::epp_standalone_config::{
-    DISAGGREGATED_TOPOLOGY, DYN_EPP_MODE, DYN_EPP_TOPOLOGY_MODE, EppTopologyMode, STANDALONE_MODE,
-};
 use crate::{EppMode, EppStandaloneConfig, ExtProcServer, Router, metrics};
 
 const GRPC_PORT: u16 = 9002;
@@ -140,16 +137,15 @@ pub async fn run(policy_registry: Option<WorkerSelectionPolicyRegistry>) -> Resu
     run_inner(mode, policy_registry.unwrap_or_default()).await
 }
 
-/// A role split only exists in standalone mode; the Dynamo-runtime path has its
-/// own disaggregation story and never reads this setting.
-fn reject_disaggregated_outside_standalone(mode: EppMode, topology: EppTopologyMode) -> Result<()> {
-    if topology.is_disaggregated() && !matches!(mode, EppMode::Standalone) {
-        anyhow::bail!(
-            "{DYN_EPP_TOPOLOGY_MODE}={DISAGGREGATED_TOPOLOGY} requires \
-             {DYN_EPP_MODE}={STANDALONE_MODE}; the Dynamo-runtime EPP does not read it"
+/// The role split is a deployment-level limitation until pair selection lands:
+/// the prefill catalog is populated but nothing selects from it yet.
+fn warn_if_disaggregated_incomplete(cfg: &EppStandaloneConfig) {
+    if cfg.topology_mode.is_disaggregated() {
+        tracing::warn!(
+            "DYN_EPP_TOPOLOGY_MODE=disaggregated: prefill/decode pair selection is not implemented \
+             yet, so decode workers still perform the whole prefill"
         );
     }
-    Ok(())
 }
 
 fn init_tracing() {
@@ -209,12 +205,6 @@ impl BackgroundTasks {
 
 async fn run_inner(mode: EppMode, policy_registry: WorkerSelectionPolicyRegistry) -> Result<()> {
     let standalone = matches!(mode, EppMode::Standalone);
-
-    // Read before the mode branch: `EppStandaloneConfig::from_env` is only
-    // reached inside it, so a disaggregated topology set alongside the default
-    // runtime mode would otherwise be silently ignored — and every pool-selected
-    // pod, prefill included, would stay a routable destination.
-    reject_disaggregated_outside_standalone(mode, EppTopologyMode::from_env()?)?;
 
     let config = Config::from_env();
 
@@ -299,6 +289,7 @@ async fn run_inner(mode: EppMode, policy_registry: WorkerSelectionPolicyRegistry
     let result = async {
         if standalone {
             let selector_cfg = EppStandaloneConfig::from_env()?;
+            warn_if_disaggregated_incomplete(&selector_cfg);
             tracing::info!(
                 inference_pool_name = %selector_cfg.inference_pool_name,
                 model_name = %selector_cfg.model_name,
@@ -555,28 +546,5 @@ mod tests {
             result.unwrap_err().to_string(),
             "linked worker-selection policies require DYN_EPP_MODE=standalone"
         );
-    }
-
-    #[test]
-    fn disaggregated_requires_standalone_mode() {
-        // The failure this guards is silent by construction: without it the
-        // setting is simply never read.
-        let error = reject_disaggregated_outside_standalone(
-            EppMode::DynamoRuntime,
-            EppTopologyMode::Disaggregated,
-        )
-        .expect_err("disaggregated must not be silently ignored under the runtime mode")
-        .to_string();
-        assert!(error.contains(DYN_EPP_MODE), "{error}");
-        assert!(error.contains(STANDALONE_MODE), "{error}");
-
-        // The other three combinations are all legitimate.
-        for (mode, topology) in [
-            (EppMode::Standalone, EppTopologyMode::Disaggregated),
-            (EppMode::Standalone, EppTopologyMode::Aggregated),
-            (EppMode::DynamoRuntime, EppTopologyMode::Aggregated),
-        ] {
-            assert!(reject_disaggregated_outside_standalone(mode, topology).is_ok());
-        }
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 use anyhow::{Context, Result, anyhow};
 
 use dynamo_kv_router::WorkerType;
-use dynamo_kv_router::config::{KvRouterConfig, try_kv_router_config_from_dynamo_env};
+use dynamo_kv_router::config::{
+    KvRouterConfig, RouterConfigOverride, try_kv_router_config_from_dynamo_env,
+};
 use dynamo_kv_router::protocols::RoutingConstraints;
 use dynamo_kv_router::services::selection::{
     PromptRequest, SelectAndReserveRequest as CoreSelectAndReserveRequest, SelectionError,
@@ -25,6 +27,7 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use crate::epp_standalone_config::EppStandaloneConfig;
+use crate::role_config::router_config_override_for_role;
 use crate::worker_role::WorkerRole;
 
 const DEFAULT_ROUTING_GROUP: &str = "default";
@@ -83,6 +86,9 @@ pub struct Selector {
     /// `Drop` tears down its core + replica-sync tasks.
     cancel: CancellationToken,
     reconcile_state: Mutex<ReconcileState>,
+    /// Per-request selection semantics for this selector's role, supplied on
+    /// every selection and booking; `None` for prefill and aggregated.
+    router_config_override: Option<RouterConfigOverride>,
 }
 
 /// Local bookkeeping for desired-state reconciliation.
@@ -147,9 +153,8 @@ impl Selector {
             .await?;
         }
 
-        // The decode selector's index is never fed — it consumes no KV events,
-        // and this crate's selection service has no approximate fallback that
-        // would populate it — so extra indexer threads there would only idle.
+        // Decode runs with KV events off, so its index is never fed and extra
+        // indexer threads would only idle.
         let indexer_threads = match role {
             WorkerRole::Decode => 1,
             _ => cfg.selector_threads,
@@ -191,6 +196,7 @@ impl Selector {
             service,
             cancel,
             reconcile_state: Mutex::new(ReconcileState::default()),
+            router_config_override: router_config_override_for_role(role),
         })
     }
 
@@ -315,7 +321,7 @@ impl Selector {
                 token_ids: Some(req.token_ids),
                 ..Default::default()
             },
-            router_config_override: None,
+            router_config_override: self.router_config_override.clone(),
             expected_output_tokens: None,
             session_id: None,
             priority_jump: req.priority_jump,
@@ -961,5 +967,43 @@ worker_selection:
             .expect_err("duplicate IDs must be rejected");
         assert!(error.to_string().contains("duplicate worker_id 1"));
         assert!(selector.service.list_workers(None, None).is_empty());
+    }
+
+    /// The role's override reaches the core's booking path: decode carries
+    /// `track_prefill_tokens: Some(false)`, so the same 16-token prompt books
+    /// no prefill load there and all 16 tokens on prefill.
+    #[tokio::test]
+    async fn decode_selector_books_no_prefill_load_and_prefill_selector_books_it() {
+        use crate::role_config::kv_router_config_for_role;
+
+        let base = KvRouterConfig::default();
+        for (role, expected) in [(WorkerRole::Prefill, 16usize), (WorkerRole::Decode, 0usize)] {
+            let selector = Selector::new_with_kv_router_config(
+                &test_config(),
+                role,
+                kv_router_config_for_role(&base, role),
+                WorkerSelectionPolicyRegistry::default(),
+            )
+            .await
+            .expect("role selector should build");
+            selector
+                .reconcile(&[schedulable_registration(1)])
+                .await
+                .expect("reconcile");
+            selector
+                .select_and_reserve(select_request("res"))
+                .await
+                .expect("reserve");
+
+            let booked = selector
+                .service
+                .loads(Some("test-model"), Some(DEFAULT_ROUTING_GROUP))
+                .iter()
+                .flat_map(|model| model.loads.iter())
+                .find(|load| load.worker_id == 1)
+                .expect("worker load")
+                .potential_prefill_tokens;
+            assert_eq!(booked, expected, "{role}");
+        }
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -132,7 +132,7 @@ impl Selector {
         Self::validate_queueing_requirements(cfg, role, queueing_enabled)?;
 
         // Every role resolves its worker-selection policy on the aggregated
-        // stage; per-role policies are #13407's to wire.
+        // stage; per-role policies are not wired yet.
         warn_for_unserved_worker_selection_policies(&kv_router_config, &[WorkerType::Aggregated])?;
         let peer_replication = cfg.peer_replication.as_ref();
         let peer_client = if peer_replication.is_some() {
@@ -379,12 +379,9 @@ impl Selector {
     }
 
     /// How many workers this selector can currently schedule for `model_name`.
-    ///
-    /// Each selector serves exactly one role, so this needs no role argument —
-    /// and that is also what makes the cross-catalog assertion in tests direct
-    /// rather than tautological: asking the decode selector what it holds cannot
-    /// be answered with "nothing, because I filtered by decode".
-    pub fn schedulable_count(&self, model_name: &str) -> usize {
+    /// Each selector serves exactly one role, so no role argument is needed.
+    #[cfg(test)]
+    pub(crate) fn schedulable_count(&self, model_name: &str) -> usize {
         self.schedulable_records(model_name).count()
     }
 
@@ -396,6 +393,7 @@ impl Selector {
             .collect()
     }
 
+    #[cfg(test)]
     fn schedulable_records(
         &self,
         model_name: &str,
@@ -409,10 +407,6 @@ impl Selector {
 
 /// The selectors this EPP owns — one in aggregated topology, one per role in
 /// disaggregated.
-///
-/// `Clone` is required because the same value must reach both the spawned
-/// reconcile task and the router; the payload is only `Arc`s, so cloning is a
-/// refcount bump, exactly as passing the single `Arc<Selector>` was before.
 #[derive(Clone)]
 pub enum RoleSelectors {
     Aggregated(Arc<Selector>),
@@ -425,8 +419,8 @@ pub enum RoleSelectors {
 impl RoleSelectors {
     /// The selector that answers requests.
     ///
-    /// Disaggregated serves from decode: a prefill worker is a selection input
-    /// for the pairing #13407 will add, never a gateway destination.
+    /// Disaggregated serves from decode: a prefill worker is never a gateway
+    /// destination.
     pub fn serving(&self) -> &Arc<Selector> {
         match self {
             Self::Aggregated(selector) => selector,

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -25,6 +25,7 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use crate::epp_standalone_config::EppStandaloneConfig;
+use crate::worker_role::WorkerRole;
 
 const DEFAULT_ROUTING_GROUP: &str = "default";
 
@@ -103,16 +104,29 @@ impl Selector {
     ) -> Result<Self> {
         let kv_router_config =
             try_kv_router_config_from_dynamo_env().map_err(anyhow::Error::msg)?;
-        Self::new_with_kv_router_config(cfg, kv_router_config, policy_registry).await
+        Self::new_with_kv_router_config(
+            cfg,
+            WorkerRole::Aggregated,
+            kv_router_config,
+            policy_registry,
+        )
+        .await
     }
 
-    async fn new_with_kv_router_config(
+    /// Build one role's selector from an already-derived router config.
+    pub(crate) async fn new_with_kv_router_config(
         cfg: &EppStandaloneConfig,
+        role: WorkerRole,
         kv_router_config: KvRouterConfig,
         policy_registry: WorkerSelectionPolicyRegistry,
     ) -> Result<Self> {
-        Self::validate_queueing_worker_capacity(cfg, &kv_router_config)?;
+        let queueing_enabled = kv_router_config
+            .queueing_enabled(Some(&cfg.model_name))
+            .map_err(|e| anyhow!("resolving router policy for model {}: {e}", cfg.model_name))?;
+        Self::validate_queueing_requirements(cfg, role, queueing_enabled)?;
 
+        // Every role resolves its worker-selection policy on the aggregated
+        // stage; per-role policies are #13407's to wire.
         warn_for_unserved_worker_selection_policies(&kv_router_config, &[WorkerType::Aggregated])?;
         let peer_replication = cfg.peer_replication.as_ref();
         let peer_client = if peer_replication.is_some() {
@@ -133,9 +147,17 @@ impl Selector {
             .await?;
         }
 
+        // The decode selector's index is never fed — it consumes no KV events,
+        // and this crate's selection service has no approximate fallback that
+        // would populate it — so extra indexer threads there would only idle.
+        let indexer_threads = match role {
+            WorkerRole::Decode => 1,
+            _ => cfg.selector_threads,
+        };
+
         let mut builder =
             SelectionServiceBuilder::new(kv_router_config, WorkerType::Aggregated, policy_registry)
-                .indexer_threads(cfg.selector_threads);
+                .indexer_threads(indexer_threads);
         if let Some(peer_replication) = peer_replication {
             builder = builder.replica_sync(peer_replication.sync_port, Vec::new());
         }
@@ -161,6 +183,7 @@ impl Selector {
         }
         tracing::info!(
             replicated = peer_replication.is_some(),
+            role = %role,
             "Initialized in-process selection service"
         );
 
@@ -171,17 +194,22 @@ impl Selector {
         })
     }
 
-    fn validate_queueing_worker_capacity(
+    /// Fail fast when the policy queues but the role has no capacity figure.
+    ///
+    /// Kept a hard startup error rather than a warning: without it the service
+    /// still builds, every worker upsert then comes back `Incomplete`, the
+    /// catalog stays empty, health stays SERVING, and every request 503s with
+    /// only per-worker warns to explain it.
+    fn validate_queueing_requirements(
         cfg: &EppStandaloneConfig,
-        kv_router_config: &KvRouterConfig,
+        role: WorkerRole,
+        queueing_enabled: bool,
     ) -> Result<()> {
-        let queueing_enabled = kv_router_config
-            .queueing_enabled(Some(&cfg.model_name))
-            .map_err(|e| anyhow!("resolving router policy for model {}: {e}", cfg.model_name))?;
-        if queueing_enabled && cfg.max_num_batched_tokens.unwrap_or(0) == 0 {
+        if queueing_enabled && cfg.max_num_batched_tokens_for(role).unwrap_or(0) == 0 {
+            let var = EppStandaloneConfig::max_num_batched_tokens_env_for(role);
             anyhow::bail!(
-                "DYN_EPP_MAX_NUM_BATCHED_TOKENS is required (and must be > 0) because the router \
-                 scheduling policy enables queueing for model {}; set it to the engine's \
+                "{var} is required (and must be > 0) because the router scheduling policy enables \
+                 queueing for model {} on the {role} selector; set it to that role's engine \
                  --max-num-batched-tokens",
                 cfg.model_name
             );
@@ -343,6 +371,83 @@ impl Selector {
     pub async fn any_ready(&self) -> bool {
         self.service.ready().ready
     }
+
+    /// How many workers this selector can currently schedule for `model_name`.
+    ///
+    /// Each selector serves exactly one role, so this needs no role argument —
+    /// and that is also what makes the cross-catalog assertion in tests direct
+    /// rather than tautological: asking the decode selector what it holds cannot
+    /// be answered with "nothing, because I filtered by decode".
+    pub fn schedulable_count(&self, model_name: &str) -> usize {
+        self.schedulable_records(model_name).count()
+    }
+
+    /// The worker ids this selector can currently schedule for `model_name`.
+    #[cfg(test)]
+    pub(crate) fn schedulable_worker_ids(&self, model_name: &str) -> HashSet<u64> {
+        self.schedulable_records(model_name)
+            .map(|record| record.worker_id)
+            .collect()
+    }
+
+    fn schedulable_records(
+        &self,
+        model_name: &str,
+    ) -> impl Iterator<Item = dynamo_kv_router::services::selection::WorkerCatalogRecord> {
+        self.service
+            .list_workers(Some(model_name), Some(DEFAULT_ROUTING_GROUP))
+            .into_iter()
+            .filter(|record| record.lifecycle == WorkerLifecycle::Schedulable)
+    }
+}
+
+/// The selectors this EPP owns — one in aggregated topology, one per role in
+/// disaggregated.
+///
+/// `Clone` is required because the same value must reach both the spawned
+/// reconcile task and the router; the payload is only `Arc`s, so cloning is a
+/// refcount bump, exactly as passing the single `Arc<Selector>` was before.
+#[derive(Clone)]
+pub enum RoleSelectors {
+    Aggregated(Arc<Selector>),
+    Disaggregated {
+        prefill: Arc<Selector>,
+        decode: Arc<Selector>,
+    },
+}
+
+impl RoleSelectors {
+    /// The selector that answers requests.
+    ///
+    /// Disaggregated serves from decode: a prefill worker is a selection input
+    /// for the pairing #13407 will add, never a gateway destination.
+    pub fn serving(&self) -> &Arc<Selector> {
+        match self {
+            Self::Aggregated(selector) => selector,
+            Self::Disaggregated { decode, .. } => decode,
+        }
+    }
+
+    /// The role [`Self::serving`] belongs to.
+    pub fn serving_role(&self) -> WorkerRole {
+        match self {
+            Self::Aggregated(_) => WorkerRole::Aggregated,
+            Self::Disaggregated { .. } => WorkerRole::Decode,
+        }
+    }
+
+    /// Every selector with its role, for fan-out over the whole topology.
+    pub fn each(&self) -> Vec<(WorkerRole, Arc<Selector>)> {
+        match self {
+            Self::Aggregated(selector) => {
+                vec![(WorkerRole::Aggregated, selector.clone())]
+            }
+            Self::Disaggregated { prefill, decode } => vec![
+                (WorkerRole::Prefill, prefill.clone()),
+                (WorkerRole::Decode, decode.clone()),
+            ],
+        }
+    }
 }
 
 impl Drop for Selector {
@@ -409,23 +514,7 @@ models:
     /// `max_num_batched_tokens` is set so `Selector::new` never fails its
     /// fast-fail check regardless of the ambient router policy.
     fn test_config() -> EppStandaloneConfig {
-        EppStandaloneConfig {
-            selector_threads: 1,
-            peer_replication: None,
-            inference_pool_name: "test-pool".to_string(),
-            namespace: "test-ns".to_string(),
-            model_name: "test-model".to_string(),
-            tokenizer_service_url: "http://vllm-render:8000".to_string(),
-            tokenizer_protocol: crate::epp_standalone_config::TokenizerProtocol::VllmRender,
-            tokenizer_max_response_bytes: 16 * 1024 * 1024,
-            tokenization_timeout_ms: 5_000,
-            block_size: 16,
-            kv_event_port: 5557,
-            replay_port: None,
-            total_kv_blocks: None,
-            max_num_batched_tokens: Some(8192),
-            max_inflight_requests: 1024,
-        }
+        EppStandaloneConfig::for_test()
     }
 
     /// A registration the core marks `Incomplete`: `block_size = 0` fails the
@@ -556,6 +645,7 @@ worker_selection:
             .expect("register policy provider");
         let selector = Selector::new_with_kv_router_config(
             &test_config(),
+            WorkerRole::Aggregated,
             router_config_with_policy(&policy_file),
             registry,
         )
@@ -826,6 +916,7 @@ worker_selection:
 
         let error = Selector::new_with_kv_router_config(
             &cfg,
+            WorkerRole::Aggregated,
             router_config_with_policy(&policy_file),
             WorkerSelectionPolicyRegistry::default(),
         )
@@ -849,6 +940,7 @@ worker_selection:
 
         Selector::new_with_kv_router_config(
             &cfg,
+            WorkerRole::Aggregated,
             router_config_with_policy(&policy_file),
             WorkerSelectionPolicyRegistry::default(),
         )

--- a/deploy/inference-gateway/ext-proc/src/server.rs
+++ b/deploy/inference-gateway/ext-proc/src/server.rs
@@ -933,7 +933,9 @@ struct ExtProcError {
 impl ExtProcError {
     fn from_pick_error(e: PickError) -> Self {
         match e {
-            PickError::NoEndpoints => Self {
+            // Both mean "nothing to route to right now"; the role variant only
+            // carries a more specific message for the client.
+            PickError::NoEndpoints | PickError::RoleCatalogEmpty(_) => Self {
                 status_code: StatusCode::ServiceUnavailable,
                 message: e.to_string(),
             },
@@ -1587,5 +1589,17 @@ mod tests {
     fn overloaded_pick_error_maps_to_503() {
         let err = ExtProcError::from_pick_error(PickError::Overloaded);
         assert_eq!(err.status_code, StatusCode::ServiceUnavailable);
+    }
+
+    #[test]
+    fn empty_role_catalog_maps_to_503_and_names_the_role() {
+        // Same status as an empty pool, but the message says which role is
+        // missing — the only place that distinction reaches the caller, since
+        // pick errors are never logged.
+        let err = ExtProcError::from_pick_error(PickError::RoleCatalogEmpty(
+            crate::worker_role::WorkerRole::Decode,
+        ));
+        assert_eq!(err.status_code, StatusCode::ServiceUnavailable);
+        assert!(err.message.contains("decode"), "{}", err.message);
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/server.rs
+++ b/deploy/inference-gateway/ext-proc/src/server.rs
@@ -1582,24 +1582,28 @@ mod tests {
         assert_eq!(unique_prefilled, unique);
     }
 
-    /// A shed `PickError::Overloaded` maps to a retryable 503 (not a 4xx), so
-    /// clients back off and retry rather than treating the load-shed as their
-    /// own error.
+    /// Pick errors are never logged, so the 503 body is the only place the
+    /// role distinction reaches the caller.
     #[test]
-    fn overloaded_pick_error_maps_to_503() {
-        let err = ExtProcError::from_pick_error(PickError::Overloaded);
-        assert_eq!(err.status_code, StatusCode::ServiceUnavailable);
-    }
+    fn retryable_pick_errors_map_to_503_with_client_safe_message() {
+        use crate::worker_role::WorkerRole;
 
-    #[test]
-    fn empty_role_catalog_maps_to_503_and_names_the_role() {
-        // Same status as an empty pool, but the message says which role is
-        // missing — the only place that distinction reaches the caller, since
-        // pick errors are never logged.
-        let err = ExtProcError::from_pick_error(PickError::RoleCatalogEmpty(
-            crate::worker_role::WorkerRole::Decode,
-        ));
-        assert_eq!(err.status_code, StatusCode::ServiceUnavailable);
-        assert!(err.message.contains("decode"), "{}", err.message);
+        let cases = [
+            ("overloaded", PickError::Overloaded, "overloaded"),
+            (
+                "empty decode catalog",
+                PickError::RoleCatalogEmpty(WorkerRole::Decode),
+                "decode",
+            ),
+        ];
+        for (label, pick_error, want_fragment) in cases {
+            let err = ExtProcError::from_pick_error(pick_error);
+            assert_eq!(err.status_code, StatusCode::ServiceUnavailable, "{label}");
+            assert!(
+                err.message.contains(want_fragment),
+                "{label}: {:?} should contain {want_fragment:?}",
+                err.message
+            );
+        }
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -29,12 +29,7 @@ impl RegistrationDefaults {
         Self::for_role(cfg, WorkerRole::Aggregated)
     }
 
-    /// Catalog metadata for a worker in `role`.
-    ///
-    /// Capacity is per-role because disaggregated fleets size prefill and decode
-    /// differently — shipped recipes differ by 8-16x on batched tokens — and that
-    /// value is the denominator of the scheduler's busy test, so one shared
-    /// number mis-sizes whichever role did not set it.
+    /// Catalog metadata for a worker in `role`; batched-token capacity is per-role.
     pub fn for_role(cfg: &EppStandaloneConfig, role: WorkerRole) -> Self {
         Self {
             model_name: cfg.model_name.clone(),
@@ -123,9 +118,6 @@ async fn reconcile_once(
             apply(selector, *role, desired).await;
         }
         RoleSelectors::Disaggregated { prefill, decode } => {
-            // One snapshot for both roles. Reading them through two calls would
-            // take two locks and observe two generations, and a role flip
-            // between them would put one worker into both desired sets.
             let sets = reflector.ready_workers_by_role();
             for (role, workers) in [
                 (WorkerRole::Prefill, sets.prefill),
@@ -235,6 +227,19 @@ mod tests {
             "tcp://10.0.0.1:5557"
         );
         assert_eq!(reg.total_kv_blocks, Some(1000));
+
+        let cfg = EppStandaloneConfig {
+            prefill_max_num_batched_tokens: Some(16384),
+            decode_max_num_batched_tokens: Some(2048),
+            ..disagg_config()
+        };
+        for (role, want) in [
+            (WorkerRole::Prefill, Some(16384)),
+            (WorkerRole::Decode, Some(2048)),
+        ] {
+            let got = RegistrationDefaults::for_role(&cfg, role).max_num_batched_tokens;
+            assert_eq!(got, want, "{role} max_num_batched_tokens");
+        }
     }
 
     #[tokio::test]
@@ -372,8 +377,7 @@ mod tests {
         let RoleSelectors::Disaggregated { prefill, decode } = &selectors else {
             unreachable!()
         };
-        // The invariant, asserted directly: each instance is one role, so asking
-        // decode what it holds cannot be answered by a role filter.
+        // Asserted directly, not via a role filter: each instance holds one role.
         assert_eq!(decode.schedulable_worker_ids(&model), HashSet::from([2]));
         assert_eq!(prefill.schedulable_worker_ids(&model), HashSet::from([1]));
 
@@ -397,8 +401,6 @@ mod tests {
 
     #[tokio::test]
     async fn decode_workers_are_schedulable_without_kv_event_endpoints() {
-        // The whole reason discovery leaves decode's endpoint `None`: the decode
-        // instance runs with KV events off, so schedulability must not demand one.
         let cfg = disagg_config();
         let selectors = role_selectors(&cfg).await;
         let RoleSelectors::Disaggregated { decode, .. } = &selectors else {
@@ -419,20 +421,5 @@ mod tests {
             .await
             .expect("reconcile should succeed");
         assert_eq!(decode.schedulable_count(&cfg.model_name), 1);
-    }
-
-    #[test]
-    fn per_role_defaults_take_that_role_capacity() {
-        let cfg = EppStandaloneConfig {
-            prefill_max_num_batched_tokens: Some(16384),
-            decode_max_num_batched_tokens: Some(2048),
-            ..disagg_config()
-        };
-
-        let prefill = RegistrationDefaults::for_role(&cfg, WorkerRole::Prefill);
-        assert_eq!(prefill.max_num_batched_tokens, Some(16384));
-
-        let decode = RegistrationDefaults::for_role(&cfg, WorkerRole::Decode);
-        assert_eq!(decode.max_num_batched_tokens, Some(2048));
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -8,13 +8,13 @@
 //! set to the [`Selector`].
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use tokio_util::sync::CancellationToken;
 
 use crate::epp_standalone_config::EppStandaloneConfig;
 use crate::pod_discovery::{PodDiscovery, RawWorker};
-use crate::selector::{Selector, WorkerRegistration};
+use crate::selector::{RoleSelectors, Selector, WorkerRegistration};
+use crate::worker_role::WorkerRole;
 
 #[derive(Debug, Clone)]
 pub struct RegistrationDefaults {
@@ -26,11 +26,21 @@ pub struct RegistrationDefaults {
 
 impl RegistrationDefaults {
     pub fn from_config(cfg: &EppStandaloneConfig) -> Self {
+        Self::for_role(cfg, WorkerRole::Aggregated)
+    }
+
+    /// Catalog metadata for a worker in `role`.
+    ///
+    /// Capacity is per-role because disaggregated fleets size prefill and decode
+    /// differently — shipped recipes differ by 8-16x on batched tokens — and that
+    /// value is the denominator of the scheduler's busy test, so one shared
+    /// number mis-sizes whichever role did not set it.
+    pub fn for_role(cfg: &EppStandaloneConfig, role: WorkerRole) -> Self {
         Self {
             model_name: cfg.model_name.clone(),
             block_size: cfg.block_size,
-            total_kv_blocks: cfg.total_kv_blocks,
-            max_num_batched_tokens: cfg.max_num_batched_tokens,
+            total_kv_blocks: cfg.total_kv_blocks_for(role),
+            max_num_batched_tokens: cfg.max_num_batched_tokens_for(role),
         }
     }
 }
@@ -45,15 +55,22 @@ pub struct TopologyAdapter {
 impl TopologyAdapter {
     pub fn spawn(
         reflector: PodDiscovery,
-        selector: Arc<Selector>,
-        defaults: RegistrationDefaults,
+        selectors: RoleSelectors,
+        cfg: &EppStandaloneConfig,
     ) -> Self {
+        // Resolved once: the defaults are per-role but static for the process.
+        let defaults: Vec<(WorkerRole, RegistrationDefaults)> = selectors
+            .each()
+            .into_iter()
+            .map(|(role, _)| (role, RegistrationDefaults::for_role(cfg, role)))
+            .collect();
+
         let cancel = CancellationToken::new();
         let cancel_child = cancel.clone();
         tokio::spawn(async move {
             let mut pod_changes = reflector.subscribe_changes();
             loop {
-                reconcile_once(&reflector, selector.as_ref(), &defaults).await;
+                reconcile_once(&reflector, &selectors, &defaults).await;
                 tokio::select! {
                     _ = cancel_child.cancelled() => break,
                     // Re-reconcile on a pod change. Exit if the sender drops
@@ -63,11 +80,16 @@ impl TopologyAdapter {
                             tracing::warn!(
                                 "Reflector change channel closed; clearing selector topology"
                             );
-                            if let Err(e) = selector.reconcile(&[]).await {
-                                tracing::warn!(
-                                    error = %e,
-                                    "Failed to clear selector topology after reflector stopped"
-                                );
+                            // Every role's catalog, not just the serving one:
+                            // a stale prefill catalog would outlive the watch.
+                            for (role, selector) in selectors.each() {
+                                if let Err(e) = selector.reconcile(&[]).await {
+                                    tracing::warn!(
+                                        error = %e,
+                                        role = %role,
+                                        "Failed to clear selector topology after reflector stopped"
+                                    );
+                                }
                             }
                             break;
                         }
@@ -85,27 +107,72 @@ impl Drop for TopologyAdapter {
     }
 }
 
-/// Run one reconcile pass: build the desired catalog from the Ready pods and
-/// hand it to the selector, which owns the actual-vs-desired diff.
+/// Run one reconcile pass: build each role's desired catalog from the Ready pods
+/// and hand it to that role's selector, which owns the actual-vs-desired diff.
 async fn reconcile_once(
     reflector: &PodDiscovery,
-    selector: &Selector,
-    defaults: &RegistrationDefaults,
+    selectors: &RoleSelectors,
+    defaults: &[(WorkerRole, RegistrationDefaults)],
 ) {
-    let desired: Vec<WorkerRegistration> = reflector
-        .ready_workers()
+    match selectors {
+        RoleSelectors::Aggregated(selector) => {
+            let Some((role, defaults)) = defaults.first() else {
+                return;
+            };
+            let desired = registrations(reflector.ready_workers(), defaults);
+            apply(selector, *role, desired).await;
+        }
+        RoleSelectors::Disaggregated { prefill, decode } => {
+            // One snapshot for both roles. Reading them through two calls would
+            // take two locks and observe two generations, and a role flip
+            // between them would put one worker into both desired sets.
+            let sets = reflector.ready_workers_by_role();
+            for (role, workers) in [
+                (WorkerRole::Prefill, sets.prefill),
+                (WorkerRole::Decode, sets.decode),
+            ] {
+                let Some((_, role_defaults)) = defaults.iter().find(|(r, _)| *r == role) else {
+                    continue;
+                };
+                let selector = match role {
+                    WorkerRole::Prefill => prefill,
+                    _ => decode,
+                };
+                apply(selector, role, registrations(workers, role_defaults)).await;
+            }
+        }
+    }
+}
+
+fn registrations(
+    workers: Vec<RawWorker>,
+    defaults: &RegistrationDefaults,
+) -> Vec<WorkerRegistration> {
+    workers
         .into_iter()
         .map(|w| build_registration(w, defaults))
-        .collect();
+        .collect()
+}
 
+async fn apply(selector: &Selector, role: WorkerRole, desired: Vec<WorkerRegistration>) {
     if let Err(e) = selector.reconcile(&desired).await {
-        tracing::warn!(error = %e, "Selector reconcile failed; will retry on next change");
+        tracing::warn!(
+            error = %e,
+            role = %role,
+            "Selector reconcile failed; will retry on next change"
+        );
     }
 }
 
 fn build_registration(w: RawWorker, defaults: &RegistrationDefaults) -> WorkerRegistration {
     let mut kv_events_endpoints = HashMap::new();
-    kv_events_endpoints.insert(0u32, w.kv_events_endpoint);
+    // A decode worker has no endpoint: its `SelectionService` runs with KV
+    // events off, so leaving the map empty is exactly what keeps the worker
+    // schedulable there — `missing_schedulable_metadata` only demands an
+    // endpoint per dp_rank when that instance consumes KV events.
+    if let Some(endpoint) = w.kv_events_endpoint {
+        kv_events_endpoints.insert(0u32, endpoint);
+    }
 
     WorkerRegistration {
         worker_id: w.worker_id,
@@ -121,28 +188,17 @@ fn build_registration(w: RawWorker, defaults: &RegistrationDefaults) -> WorkerRe
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+    use std::sync::Arc;
     use std::time::Duration;
 
     use super::*;
-    use crate::epp_standalone_config::TokenizerProtocol;
 
     fn config() -> EppStandaloneConfig {
         EppStandaloneConfig {
-            selector_threads: 1,
-            peer_replication: None,
-            inference_pool_name: "test-pool".to_string(),
-            namespace: "test-ns".to_string(),
             model_name: "Qwen/Qwen3-0.6B".to_string(),
-            tokenizer_service_url: "http://vllm-render:8000".to_string(),
-            tokenizer_protocol: TokenizerProtocol::VllmRender,
-            tokenizer_max_response_bytes: 16 * 1024 * 1024,
-            tokenization_timeout_ms: 5_000,
-            block_size: 16,
-            kv_event_port: 5557,
-            replay_port: None,
             total_kv_blocks: Some(1000),
-            max_num_batched_tokens: Some(8192),
-            max_inflight_requests: 1024,
+            ..EppStandaloneConfig::for_test()
         }
     }
 
@@ -160,8 +216,9 @@ mod tests {
             worker_id: id,
             pod_name: format!("vllm-{id}"),
             pod_ip: ip.to_string(),
+            role: WorkerRole::Aggregated,
             http_endpoint: format!("http://{ip}:8000"),
-            kv_events_endpoint: format!("tcp://{ip}:5557"),
+            kv_events_endpoint: Some(format!("tcp://{ip}:5557")),
             replay_endpoint: None,
         }
     }
@@ -191,7 +248,11 @@ mod tests {
             .expect("selector should build"),
         );
         let (discovery, changes_tx) = PodDiscovery::for_test(vec![worker(7, "10.0.0.1")]);
-        let adapter = TopologyAdapter::spawn(discovery, selector.clone(), defaults());
+        let adapter = TopologyAdapter::spawn(
+            discovery,
+            RoleSelectors::Aggregated(selector.clone()),
+            &config(),
+        );
 
         tokio::time::timeout(Duration::from_secs(1), async {
             while !selector.any_ready().await {
@@ -213,5 +274,169 @@ mod tests {
         .expect("terminal empty topology was not reconciled");
 
         drop(adapter);
+    }
+
+    // --- disaggregated fan-out ---------------------------------------------
+
+    fn disagg_config() -> EppStandaloneConfig {
+        EppStandaloneConfig {
+            topology_mode: crate::epp_standalone_config::EppTopologyMode::Disaggregated,
+            model_name: "test-model".to_string(),
+            ..EppStandaloneConfig::for_test()
+        }
+    }
+
+    fn role_worker(id: u64, ip: &str, role: WorkerRole) -> RawWorker {
+        RawWorker {
+            worker_id: id,
+            pod_name: format!("w-{id}"),
+            pod_ip: ip.to_string(),
+            role,
+            http_endpoint: format!("http://{ip}:8000"),
+            // Mirrors what discovery produces: only prefill carries an endpoint.
+            kv_events_endpoint: (role != WorkerRole::Decode).then(|| format!("tcp://{ip}:5557")),
+            replay_endpoint: None,
+        }
+    }
+
+    /// Two real `SelectionService`s configured exactly as production does.
+    async fn role_selectors(cfg: &EppStandaloneConfig) -> RoleSelectors {
+        use crate::role_config::kv_router_config_for_role;
+        use dynamo_kv_router::config::KvRouterConfig;
+        use dynamo_kv_router::services::selection::WorkerSelectionPolicyRegistry;
+
+        let base = KvRouterConfig::default();
+        async fn build(
+            cfg: &EppStandaloneConfig,
+            base: &KvRouterConfig,
+            role: WorkerRole,
+        ) -> Arc<Selector> {
+            Arc::new(
+                Selector::new_with_kv_router_config(
+                    cfg,
+                    role,
+                    kv_router_config_for_role(base, role),
+                    WorkerSelectionPolicyRegistry::default(),
+                )
+                .await
+                .expect("role selector should build"),
+            )
+        }
+        RoleSelectors::Disaggregated {
+            prefill: build(cfg, &base, WorkerRole::Prefill).await,
+            decode: build(cfg, &base, WorkerRole::Decode).await,
+        }
+    }
+
+    async fn await_counts(selectors: &RoleSelectors, model: &str, prefill: usize, decode: usize) {
+        let RoleSelectors::Disaggregated {
+            prefill: p,
+            decode: d,
+        } = selectors
+        else {
+            panic!("expected a disaggregated topology");
+        };
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while p.schedulable_count(model) != prefill || d.schedulable_count(model) != decode {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "catalogs did not converge to prefill={prefill} decode={decode}; \
+                 got prefill={} decode={}",
+                p.schedulable_count(model),
+                d.schedulable_count(model)
+            )
+        });
+    }
+
+    #[tokio::test]
+    async fn disaggregated_reconcile_splits_add_flip_and_remove() {
+        let cfg = disagg_config();
+        let model = cfg.model_name.clone();
+        let selectors = role_selectors(&cfg).await;
+
+        let (discovery, changes_tx) = PodDiscovery::for_test(vec![]);
+        let adapter = TopologyAdapter::spawn(discovery.clone(), selectors.clone(), &cfg);
+
+        // Add: one worker of each role lands in its own instance.
+        discovery.set_workers(vec![
+            role_worker(1, "10.0.0.1", WorkerRole::Prefill),
+            role_worker(2, "10.0.0.2", WorkerRole::Decode),
+        ]);
+        changes_tx.send(1).expect("adapter is listening");
+        await_counts(&selectors, &model, 1, 1).await;
+
+        let RoleSelectors::Disaggregated { prefill, decode } = &selectors else {
+            unreachable!()
+        };
+        // The invariant, asserted directly: each instance is one role, so asking
+        // decode what it holds cannot be answered by a role filter.
+        assert_eq!(decode.schedulable_worker_ids(&model), HashSet::from([2]));
+        assert_eq!(prefill.schedulable_worker_ids(&model), HashSet::from([1]));
+
+        // Role flip: the same worker_id moves between instances.
+        discovery.set_workers(vec![
+            role_worker(1, "10.0.0.1", WorkerRole::Decode),
+            role_worker(2, "10.0.0.2", WorkerRole::Decode),
+        ]);
+        changes_tx.send(2).expect("adapter is listening");
+        await_counts(&selectors, &model, 0, 2).await;
+        assert_eq!(decode.schedulable_worker_ids(&model), HashSet::from([1, 2]));
+
+        // Remove: dropping one decode worker leaves the other untouched.
+        discovery.set_workers(vec![role_worker(2, "10.0.0.2", WorkerRole::Decode)]);
+        changes_tx.send(3).expect("adapter is listening");
+        await_counts(&selectors, &model, 0, 1).await;
+        assert_eq!(decode.schedulable_worker_ids(&model), HashSet::from([2]));
+
+        drop(adapter);
+    }
+
+    #[tokio::test]
+    async fn decode_workers_are_schedulable_without_kv_event_endpoints() {
+        // The whole reason discovery leaves decode's endpoint `None`: the decode
+        // instance runs with KV events off, so schedulability must not demand one.
+        let cfg = disagg_config();
+        let selectors = role_selectors(&cfg).await;
+        let RoleSelectors::Disaggregated { decode, .. } = &selectors else {
+            unreachable!()
+        };
+
+        let registration = build_registration(
+            role_worker(9, "10.0.0.9", WorkerRole::Decode),
+            &RegistrationDefaults::for_role(&cfg, WorkerRole::Decode),
+        );
+        assert!(
+            registration.kv_events_endpoints.is_empty(),
+            "a decode registration carries no kv-events endpoint"
+        );
+
+        decode
+            .reconcile(&[registration])
+            .await
+            .expect("reconcile should succeed");
+        assert_eq!(decode.schedulable_count(&cfg.model_name), 1);
+    }
+
+    #[test]
+    fn per_role_defaults_take_that_role_capacity() {
+        let cfg = EppStandaloneConfig {
+            prefill_max_num_batched_tokens: Some(16384),
+            decode_max_num_batched_tokens: Some(2048),
+            prefill_total_kv_blocks: Some(4000),
+            decode_total_kv_blocks: Some(1000),
+            ..disagg_config()
+        };
+
+        let prefill = RegistrationDefaults::for_role(&cfg, WorkerRole::Prefill);
+        assert_eq!(prefill.max_num_batched_tokens, Some(16384));
+        assert_eq!(prefill.total_kv_blocks, Some(4000));
+
+        let decode = RegistrationDefaults::for_role(&cfg, WorkerRole::Decode);
+        assert_eq!(decode.max_num_batched_tokens, Some(2048));
+        assert_eq!(decode.total_kv_blocks, Some(1000));
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -39,7 +39,7 @@ impl RegistrationDefaults {
         Self {
             model_name: cfg.model_name.clone(),
             block_size: cfg.block_size,
-            total_kv_blocks: cfg.total_kv_blocks_for(role),
+            total_kv_blocks: cfg.total_kv_blocks,
             max_num_batched_tokens: cfg.max_num_batched_tokens_for(role),
         }
     }
@@ -426,17 +426,13 @@ mod tests {
         let cfg = EppStandaloneConfig {
             prefill_max_num_batched_tokens: Some(16384),
             decode_max_num_batched_tokens: Some(2048),
-            prefill_total_kv_blocks: Some(4000),
-            decode_total_kv_blocks: Some(1000),
             ..disagg_config()
         };
 
         let prefill = RegistrationDefaults::for_role(&cfg, WorkerRole::Prefill);
         assert_eq!(prefill.max_num_batched_tokens, Some(16384));
-        assert_eq!(prefill.total_kv_blocks, Some(4000));
 
         let decode = RegistrationDefaults::for_role(&cfg, WorkerRole::Decode);
         assert_eq!(decode.max_num_batched_tokens, Some(2048));
-        assert_eq!(decode.total_kv_blocks, Some(1000));
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/worker_role.rs
+++ b/deploy/inference-gateway/ext-proc/src/worker_role.rs
@@ -16,15 +16,13 @@ use std::str::FromStr;
 
 use dynamo_kv_router::WorkerType;
 
-/// Default pod label key naming a worker's role, per DEP #11661's environment
-/// contract. Overridable with `DYN_EPP_WORKER_ROLE_LABEL`.
+/// Default pod label key naming a worker's role; `DYN_EPP_WORKER_ROLE_LABEL`
+/// overrides it, for example to reuse the operator's component-type label.
 ///
-/// Deliberately not the operator's `nvidia.com/dynamo-component-type`: that key
-/// is the operator's own workload-selector contract and admits the value
-/// `worker`, which names no disaggregated stage. The standalone path fronts
-/// user-managed raw engine Deployments that carry no `nvidia.com/*` labels at
-/// all, so the operator's key would match nothing anyway.
-pub const DEFAULT_WORKER_ROLE_LABEL: &str = "nvidia.com/role";
+/// Not the operator's `nvidia.com/dynamo-component-type` by default: that key
+/// admits the value `worker`, which names no disaggregated stage, and the raw
+/// engine Deployments this path fronts do not carry it.
+pub const DEFAULT_WORKER_ROLE_LABEL: &str = "nvidia.com/dynamo-worker-role";
 
 /// The stage a discovered worker serves.
 ///

--- a/deploy/inference-gateway/ext-proc/src/worker_role.rs
+++ b/deploy/inference-gateway/ext-proc/src/worker_role.rs
@@ -3,12 +3,7 @@
 
 //! Worker roles for the standalone EPP's disaggregated topology.
 //!
-//! In `DYN_EPP_TOPOLOGY_MODE=disaggregated` every pod selected by the
-//! `InferencePool` must carry a role label whose value names the stage that pod
-//! serves. The EPP splits the pool on that label into a prefill catalog and a
-//! decode catalog, each backing its own embedded `SelectionService`.
-//!
-//! In `aggregated` mode the label is never read and every eligible pod is
+//! In `aggregated` topology the label is never read and every eligible pod is
 //! [`WorkerRole::Aggregated`].
 
 use std::fmt;
@@ -57,12 +52,8 @@ impl WorkerRole {
         }
     }
 
-    /// Resolve a role from a pod label value.
-    ///
-    /// Delegates to [`WorkerType::from_str`] — which trims and lowercases — so
-    /// the accepted vocabulary cannot drift from the operator's component-type
-    /// enum, then narrows to the two stages a disaggregated pool may contain.
-    /// `encode` and `aggregated` parse as worker types but are not roles here.
+    /// Delegates to [`WorkerType::from_str`] so the accepted vocabulary cannot
+    /// drift from the operator's component-type enum.
     pub fn from_pod_label(value: &str) -> Result<Self, RoleLabelError> {
         match WorkerType::from_str(value) {
             Ok(WorkerType::Prefill) => Ok(Self::Prefill),
@@ -159,90 +150,62 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_the_two_disaggregated_stages() {
-        assert_eq!(
-            WorkerRole::from_pod_label("prefill").unwrap(),
-            WorkerRole::Prefill
-        );
-        assert_eq!(
-            WorkerRole::from_pod_label("decode").unwrap(),
-            WorkerRole::Decode
-        );
+    fn from_pod_label_narrows_worker_type_to_the_two_stages() {
+        // Label values cannot carry whitespace, but the vocabulary is delegated
+        // to `WorkerType::from_str`, so pin the trim/lowercase leniency inherited
+        // from it. `encode` and `aggregated` are valid WorkerTypes; the
+        // narrowing is what rejects them.
+        let invalid = |token: &str| -> Result<WorkerRole, RoleLabelError> {
+            Err(RoleLabelError::Invalid {
+                token: token.to_string(),
+            })
+        };
+        let cases = [
+            ("prefill", Ok(WorkerRole::Prefill)),
+            ("decode", Ok(WorkerRole::Decode)),
+            (" Decode ", Ok(WorkerRole::Decode)),
+            ("PREFILL", Ok(WorkerRole::Prefill)),
+            ("encode", invalid("encode")),
+            ("aggregated", invalid("aggregated")),
+            ("worker", invalid("worker")),
+            ("", invalid("")),
+            ("gibberish", invalid("gibberish")),
+            // The token keeps the original spelling, not the normalized form.
+            (" Prefil ", invalid(" Prefil ")),
+        ];
+        for (input, want) in cases {
+            let got = WorkerRole::from_pod_label(input);
+            assert_eq!(got, want, "{input:?}");
+            if let Err(error) = got {
+                assert_eq!(error.reason(), "role_label_invalid", "{input:?}");
+            }
+        }
     }
 
     #[test]
-    fn parsing_trims_and_lowercases_via_worker_type() {
-        // Kubernetes label values cannot actually carry surrounding whitespace,
-        // but the vocabulary is delegated to `WorkerType::from_str`, so this
-        // pins the leniency we inherit rather than leaving it undiscovered.
-        assert_eq!(
-            WorkerRole::from_pod_label(" Decode ").unwrap(),
-            WorkerRole::Decode
-        );
-        assert_eq!(
-            WorkerRole::from_pod_label("PREFILL").unwrap(),
-            WorkerRole::Prefill
-        );
-    }
-
-    #[test]
-    fn rejects_values_that_name_no_disaggregated_stage() {
-        // `encode` and `aggregated` are valid WorkerTypes; the narrowing is what
-        // rejects them. `worker` is the operator's component-type value.
-        for value in ["encode", "aggregated", "worker", "", "gibberish"] {
-            let error = WorkerRole::from_pod_label(value)
-                .expect_err("value should not resolve to a disaggregated role");
-            assert_eq!(error.reason(), "role_label_invalid");
+    fn display_matches_as_str_and_only_stages_round_trip() {
+        let cases = [
+            (WorkerRole::Aggregated, "aggregated", false),
+            (WorkerRole::Prefill, "prefill", true),
+            (WorkerRole::Decode, "decode", true),
+        ];
+        for (role, text, round_trips) in cases {
+            assert_eq!(role.as_str(), text, "{text}");
+            assert_eq!(role.to_string(), text, "{text}");
             assert_eq!(
-                error,
-                RoleLabelError::Invalid {
-                    token: value.into()
-                }
+                WorkerRole::from_pod_label(text).ok(),
+                round_trips.then_some(role),
+                "{text}"
             );
         }
-    }
 
-    #[test]
-    fn invalid_token_preserves_the_original_spelling() {
-        // The operator needs to see what they actually wrote, not a normalized
-        // form, to spot a typo or a stray character.
-        let error = WorkerRole::from_pod_label(" Prefil ").unwrap_err();
-        assert_eq!(
-            error,
-            RoleLabelError::Invalid {
-                token: " Prefil ".to_string()
-            }
-        );
-    }
-
-    #[test]
-    fn aggregated_is_display_only_and_does_not_round_trip() {
-        // `as_str` feeds logs and the RoleCatalogEmpty message; it is not a
-        // label serializer. Guarding this stops a future round-trip test or a
-        // label built from `as_str()` from silently accepting `aggregated`.
-        assert_eq!(WorkerRole::Aggregated.as_str(), "aggregated");
-        assert!(WorkerRole::from_pod_label(WorkerRole::Aggregated.as_str()).is_err());
-
-        for role in [WorkerRole::Prefill, WorkerRole::Decode] {
-            assert_eq!(WorkerRole::from_pod_label(role.as_str()).unwrap(), role);
-        }
-    }
-
-    #[test]
-    fn display_matches_as_str() {
-        assert_eq!(WorkerRole::Prefill.to_string(), "prefill");
-        assert_eq!(WorkerRole::Decode.to_string(), "decode");
-    }
-
-    #[test]
-    fn missing_and_invalid_have_distinct_reasons() {
         assert_eq!(RoleLabelError::Missing.reason(), "role_label_missing");
-        assert_eq!(
+        assert_ne!(
+            RoleLabelError::Missing.reason(),
             RoleLabelError::Invalid {
                 token: "x".to_string()
             }
-            .reason(),
-            "role_label_invalid"
+            .reason()
         );
     }
 
@@ -260,12 +223,13 @@ mod tests {
         counts.remove(WorkerRole::Prefill);
         assert_eq!(counts.get(WorkerRole::Prefill), 1);
         assert_eq!(counts.get(WorkerRole::Decode), 1);
-    }
 
-    #[test]
-    fn removing_below_zero_saturates() {
-        let mut counts = RoleCounts::default();
         counts.remove(WorkerRole::Decode);
-        assert_eq!(counts.get(WorkerRole::Decode), 0);
+        counts.remove(WorkerRole::Decode);
+        assert_eq!(
+            counts.get(WorkerRole::Decode),
+            0,
+            "remove saturates at zero"
+        );
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/worker_role.rs
+++ b/deploy/inference-gateway/ext-proc/src/worker_role.rs
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Worker roles for the standalone EPP's disaggregated topology.
+//!
+//! In `DYN_EPP_TOPOLOGY_MODE=disaggregated` every pod selected by the
+//! `InferencePool` must carry a role label whose value names the stage that pod
+//! serves. The EPP splits the pool on that label into a prefill catalog and a
+//! decode catalog, each backing its own embedded `SelectionService`.
+//!
+//! In `aggregated` mode the label is never read and every eligible pod is
+//! [`WorkerRole::Aggregated`].
+
+use std::fmt;
+use std::str::FromStr;
+
+use dynamo_kv_router::WorkerType;
+
+/// Default pod label key naming a worker's role, per DEP #11661's environment
+/// contract. Overridable with `DYN_EPP_WORKER_ROLE_LABEL`.
+///
+/// Deliberately not the operator's `nvidia.com/dynamo-component-type`: that key
+/// is the operator's own workload-selector contract and admits the value
+/// `worker`, which names no disaggregated stage. The standalone path fronts
+/// user-managed raw engine Deployments that carry no `nvidia.com/*` labels at
+/// all, so the operator's key would match nothing anyway.
+pub const DEFAULT_WORKER_ROLE_LABEL: &str = "nvidia.com/role";
+
+/// The stage a discovered worker serves.
+///
+/// `PartialEq`/`Eq` are load-bearing, not conveniences: `RawWorker` and
+/// `WorkerEntry` derive them, and the pod watch loop decides whether the derived
+/// index changed by comparing whole entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WorkerRole {
+    /// Serves prefill and decode in one process. The only role in `aggregated`
+    /// topology, and never produced in `disaggregated` topology.
+    Aggregated,
+    /// Computes prompt KV and hands it off. A selection input only — never a
+    /// gateway destination.
+    Prefill,
+    /// Receives transferred KV and generates tokens. The gateway destination in
+    /// `disaggregated` topology.
+    Decode,
+}
+
+impl WorkerRole {
+    /// Canonical lowercase form, for logs and error messages.
+    ///
+    /// This is **not** the inverse of [`WorkerRole::from_pod_label`].
+    /// `Aggregated.as_str()` is `"aggregated"`, but that value is rejected as a
+    /// pod label: it describes an EPP-wide topology, not a stage a pod can
+    /// claim. Only `prefill` and `decode` round-trip.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Aggregated => "aggregated",
+            Self::Prefill => "prefill",
+            Self::Decode => "decode",
+        }
+    }
+
+    /// Resolve a role from a pod label value.
+    ///
+    /// Delegates to [`WorkerType::from_str`] — which trims and lowercases — so
+    /// the accepted vocabulary cannot drift from the operator's component-type
+    /// enum, then narrows to the two stages a disaggregated pool may contain.
+    /// `encode` and `aggregated` parse as worker types but are not roles here.
+    pub fn from_pod_label(value: &str) -> Result<Self, RoleLabelError> {
+        match WorkerType::from_str(value) {
+            Ok(WorkerType::Prefill) => Ok(Self::Prefill),
+            Ok(WorkerType::Decode) => Ok(Self::Decode),
+            Ok(_) | Err(_) => Err(RoleLabelError::Invalid {
+                token: value.to_string(),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for WorkerRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Why an otherwise-eligible pod could not be assigned a role.
+///
+/// Only reachable in `disaggregated` topology: `aggregated` never reads the
+/// label.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RoleLabelError {
+    /// The pod carries no value for the configured role-label key.
+    Missing,
+    /// The pod carries a value that names no disaggregated stage.
+    Invalid { token: String },
+}
+
+impl RoleLabelError {
+    /// Bounded, pod-independent discriminant for structured logs.
+    pub const fn reason(&self) -> &'static str {
+        match self {
+            Self::Missing => "role_label_missing",
+            Self::Invalid { .. } => "role_label_invalid",
+        }
+    }
+}
+
+impl fmt::Display for RoleLabelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Missing => f.write_str("role label is missing"),
+            Self::Invalid { token } => {
+                write!(f, "role label value {token:?} names no worker role")
+            }
+        }
+    }
+}
+
+/// Ready-worker count per role, maintained alongside the worker index.
+///
+/// Exists so the per-request emptiness check stays O(1) after the index gains a
+/// role dimension; scanning the map instead would put an O(workers) pass on
+/// every pick.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct RoleCounts {
+    pub aggregated: usize,
+    pub prefill: usize,
+    pub decode: usize,
+}
+
+impl RoleCounts {
+    pub const fn get(self, role: WorkerRole) -> usize {
+        match role {
+            WorkerRole::Aggregated => self.aggregated,
+            WorkerRole::Prefill => self.prefill,
+            WorkerRole::Decode => self.decode,
+        }
+    }
+
+    pub fn add(&mut self, role: WorkerRole) {
+        *self.slot(role) += 1;
+    }
+
+    /// Saturating so a bookkeeping slip cannot underflow into a huge count and
+    /// make an empty catalog look occupied.
+    pub fn remove(&mut self, role: WorkerRole) {
+        let slot = self.slot(role);
+        *slot = slot.saturating_sub(1);
+    }
+
+    fn slot(&mut self, role: WorkerRole) -> &mut usize {
+        match role {
+            WorkerRole::Aggregated => &mut self.aggregated,
+            WorkerRole::Prefill => &mut self.prefill,
+            WorkerRole::Decode => &mut self.decode,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_the_two_disaggregated_stages() {
+        assert_eq!(
+            WorkerRole::from_pod_label("prefill").unwrap(),
+            WorkerRole::Prefill
+        );
+        assert_eq!(
+            WorkerRole::from_pod_label("decode").unwrap(),
+            WorkerRole::Decode
+        );
+    }
+
+    #[test]
+    fn parsing_trims_and_lowercases_via_worker_type() {
+        // Kubernetes label values cannot actually carry surrounding whitespace,
+        // but the vocabulary is delegated to `WorkerType::from_str`, so this
+        // pins the leniency we inherit rather than leaving it undiscovered.
+        assert_eq!(
+            WorkerRole::from_pod_label(" Decode ").unwrap(),
+            WorkerRole::Decode
+        );
+        assert_eq!(
+            WorkerRole::from_pod_label("PREFILL").unwrap(),
+            WorkerRole::Prefill
+        );
+    }
+
+    #[test]
+    fn rejects_values_that_name_no_disaggregated_stage() {
+        // `encode` and `aggregated` are valid WorkerTypes; the narrowing is what
+        // rejects them. `worker` is the operator's component-type value.
+        for value in ["encode", "aggregated", "worker", "", "gibberish"] {
+            let error = WorkerRole::from_pod_label(value)
+                .expect_err("value should not resolve to a disaggregated role");
+            assert_eq!(error.reason(), "role_label_invalid");
+            assert_eq!(
+                error,
+                RoleLabelError::Invalid {
+                    token: value.into()
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_token_preserves_the_original_spelling() {
+        // The operator needs to see what they actually wrote, not a normalized
+        // form, to spot a typo or a stray character.
+        let error = WorkerRole::from_pod_label(" Prefil ").unwrap_err();
+        assert_eq!(
+            error,
+            RoleLabelError::Invalid {
+                token: " Prefil ".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn aggregated_is_display_only_and_does_not_round_trip() {
+        // `as_str` feeds logs and the RoleCatalogEmpty message; it is not a
+        // label serializer. Guarding this stops a future round-trip test or a
+        // label built from `as_str()` from silently accepting `aggregated`.
+        assert_eq!(WorkerRole::Aggregated.as_str(), "aggregated");
+        assert!(WorkerRole::from_pod_label(WorkerRole::Aggregated.as_str()).is_err());
+
+        for role in [WorkerRole::Prefill, WorkerRole::Decode] {
+            assert_eq!(WorkerRole::from_pod_label(role.as_str()).unwrap(), role);
+        }
+    }
+
+    #[test]
+    fn display_matches_as_str() {
+        assert_eq!(WorkerRole::Prefill.to_string(), "prefill");
+        assert_eq!(WorkerRole::Decode.to_string(), "decode");
+    }
+
+    #[test]
+    fn missing_and_invalid_have_distinct_reasons() {
+        assert_eq!(RoleLabelError::Missing.reason(), "role_label_missing");
+        assert_eq!(
+            RoleLabelError::Invalid {
+                token: "x".to_string()
+            }
+            .reason(),
+            "role_label_invalid"
+        );
+    }
+
+    #[test]
+    fn counts_track_each_role_independently() {
+        let mut counts = RoleCounts::default();
+        counts.add(WorkerRole::Prefill);
+        counts.add(WorkerRole::Prefill);
+        counts.add(WorkerRole::Decode);
+
+        assert_eq!(counts.get(WorkerRole::Prefill), 2);
+        assert_eq!(counts.get(WorkerRole::Decode), 1);
+        assert_eq!(counts.get(WorkerRole::Aggregated), 0);
+
+        counts.remove(WorkerRole::Prefill);
+        assert_eq!(counts.get(WorkerRole::Prefill), 1);
+        assert_eq!(counts.get(WorkerRole::Decode), 1);
+    }
+
+    #[test]
+    fn removing_below_zero_saturates() {
+        let mut counts = RoleCounts::default();
+        counts.remove(WorkerRole::Decode);
+        assert_eq!(counts.get(WorkerRole::Decode), 0);
+    }
+}

--- a/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
@@ -499,8 +499,8 @@ selectors would bind the same replica-sync port.
 | `DYN_KV_CACHE_BLOCK_SIZE` | Yes | Must equal vLLM `--block-size`. |
 | `DYN_EPP_TOPOLOGY_MODE` | No | `aggregated` (default) treats every worker as a routable target. `disaggregated` splits the pool by worker role; see the note below. Any other value fails startup. |
 | `DYN_EPP_WORKER_ROLE_LABEL` | No | Pod label key naming a worker's role; defaults to `nvidia.com/dynamo-worker-role`. Read only under `disaggregated`, where every pool pod must carry it with the value `prefill` or `decode`. |
-| `DYN_EPP_KV_EVENT_PORT` | No | Per-pod vLLM KV event port; defaults to `5557`. |
-| `DYN_EPP_KV_EVENT_REPLAY_PORT` | No | Per-pod replay port for KV event gap recovery. |
+| `DYN_EPP_KV_EVENT_PORT` | No | Per-pod vLLM KV event port; defaults to `5557`. Under `disaggregated` it applies to prefill workers only; decode workers consume no KV events. |
+| `DYN_EPP_KV_EVENT_REPLAY_PORT` | No | Per-pod replay port for KV event gap recovery. Under `disaggregated` it applies to prefill workers only. |
 | `DYN_EPP_MAX_NUM_BATCHED_TOKENS` | Policy-dependent | Must equal vLLM `--max-num-batched-tokens`; required when router queue thresholds are enabled. Under `disaggregated` this is the fallback for both roles. |
 | `DYN_EPP_PREFILL_MAX_NUM_BATCHED_TOKENS` | No | Prefill-worker override; defaults to `DYN_EPP_MAX_NUM_BATCHED_TOKENS`. |
 | `DYN_EPP_DECODE_MAX_NUM_BATCHED_TOKENS` | No | Decode-worker override; defaults to `DYN_EPP_MAX_NUM_BATCHED_TOKENS`. |

--- a/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
@@ -504,9 +504,7 @@ selectors would bind the same replica-sync port.
 | `DYN_EPP_MAX_NUM_BATCHED_TOKENS` | Policy-dependent | Must equal vLLM `--max-num-batched-tokens`; required when router queue thresholds are enabled. Under `disaggregated` this is the fallback for both roles. |
 | `DYN_EPP_PREFILL_MAX_NUM_BATCHED_TOKENS` | No | Prefill-worker override; defaults to `DYN_EPP_MAX_NUM_BATCHED_TOKENS`. |
 | `DYN_EPP_DECODE_MAX_NUM_BATCHED_TOKENS` | No | Decode-worker override; defaults to `DYN_EPP_MAX_NUM_BATCHED_TOKENS`. |
-| `DYN_EPP_TOTAL_KV_BLOCKS` | No | Optional per-worker total KV block hint. Under `disaggregated` this is the fallback for both roles. |
-| `DYN_EPP_PREFILL_TOTAL_KV_BLOCKS` | No | Prefill-worker override; defaults to `DYN_EPP_TOTAL_KV_BLOCKS`. |
-| `DYN_EPP_DECODE_TOTAL_KV_BLOCKS` | No | Decode-worker override; defaults to `DYN_EPP_TOTAL_KV_BLOCKS`. |
+| `DYN_EPP_TOTAL_KV_BLOCKS` | No | Optional per-worker total KV block hint. |
 | `DYN_EPP_SELECTION_INDEXER_THREADS` | No | KV indexer thread count; defaults to `4`. Under `disaggregated` it applies to the prefill selector only: the decode selector consumes no KV events, so its index is never fed and it is pinned to one thread. |
 | `DYN_EPP_TOKENIZATION_TIMEOUT_MS` | No | Render request timeout; defaults to `5000`. |
 | `DYN_EPP_TOKENIZER_MAX_RESPONSE_BYTES` | No | Maximum render response size; defaults to `16777216`. |
@@ -516,8 +514,8 @@ selectors would bind the same replica-sync port.
 | `POD_IP` | With peer service | EPP pod IP used to exclude the local replica from its peer set. |
 
 <Note>
-`DYN_EPP_TOPOLOGY_MODE=disaggregated` requires `DYN_EPP_MODE=standalone` and is incompatible with
-`DYN_EPP_PEER_SERVICE`; both combinations fail startup. It builds the prefill and decode worker
+`DYN_EPP_TOPOLOGY_MODE=disaggregated` is incompatible with `DYN_EPP_PEER_SERVICE`; setting both
+fails startup. It builds the prefill and decode worker
 catalogs but does not yet select a prefill/decode pair, so decode workers still perform the whole
 prefill. The end-to-end path lands with
 [#13405](https://github.com/ai-dynamo/dynamo/issues/13405) and

--- a/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
@@ -498,7 +498,7 @@ selectors would bind the same replica-sync port.
 | `DYN_EPP_TOKENIZER_PROTOCOL=vllm-render` | Yes | Tokenizer wire protocol; this is the only supported value. |
 | `DYN_KV_CACHE_BLOCK_SIZE` | Yes | Must equal vLLM `--block-size`. |
 | `DYN_EPP_TOPOLOGY_MODE` | No | `aggregated` (default) treats every worker as a routable target. `disaggregated` splits the pool by worker role; see the note below. Any other value fails startup. |
-| `DYN_EPP_WORKER_ROLE_LABEL` | No | Pod label key naming a worker's role; defaults to `nvidia.com/role`. Read only under `disaggregated`, where every pool pod must carry it with the value `prefill` or `decode`. |
+| `DYN_EPP_WORKER_ROLE_LABEL` | No | Pod label key naming a worker's role; defaults to `nvidia.com/dynamo-worker-role`. Read only under `disaggregated`, where every pool pod must carry it with the value `prefill` or `decode`. |
 | `DYN_EPP_KV_EVENT_PORT` | No | Per-pod vLLM KV event port; defaults to `5557`. |
 | `DYN_EPP_KV_EVENT_REPLAY_PORT` | No | Per-pod replay port for KV event gap recovery. |
 | `DYN_EPP_MAX_NUM_BATCHED_TOKENS` | Policy-dependent | Must equal vLLM `--max-num-batched-tokens`; required when router queue thresholds are enabled. Under `disaggregated` this is the fallback for both roles. |

--- a/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
@@ -483,6 +483,8 @@ from live worker events and optional replay. For consistency details, see
 [Standalone Selection Service](../../developer-guide/knowledge-base/modular-components/router/standalone-selection.md).
 
 For a single EPP replica, set `spec.replicas: 1` and remove `DYN_EPP_PEER_SERVICE` and `POD_IP`.
+`DYN_EPP_PEER_SERVICE` is rejected under `DYN_EPP_TOPOLOGY_MODE=disaggregated`: both role
+selectors would bind the same replica-sync port.
 
 ## Standalone EPP Configuration Reference
 
@@ -495,10 +497,16 @@ For a single EPP replica, set `spec.replicas: 1` and remove `DYN_EPP_PEER_SERVIC
 | `DYN_EPP_TOKENIZER_SERVICE_URL` | Yes | Base URL of the vLLM render Service. |
 | `DYN_EPP_TOKENIZER_PROTOCOL=vllm-render` | Yes | Tokenizer wire protocol; this is the only supported value. |
 | `DYN_KV_CACHE_BLOCK_SIZE` | Yes | Must equal vLLM `--block-size`. |
+| `DYN_EPP_TOPOLOGY_MODE` | No | `aggregated` (default) treats every worker as a routable target. `disaggregated` splits the pool by worker role; see the note below. Any other value fails startup. |
+| `DYN_EPP_WORKER_ROLE_LABEL` | With `disaggregated` | Pod label key naming a worker's role; defaults to `nvidia.com/role`. Values must be `prefill` or `decode`. |
 | `DYN_EPP_KV_EVENT_PORT` | No | Per-pod vLLM KV event port; defaults to `5557`. |
 | `DYN_EPP_KV_EVENT_REPLAY_PORT` | No | Per-pod replay port for KV event gap recovery. |
-| `DYN_EPP_MAX_NUM_BATCHED_TOKENS` | Policy-dependent | Must equal vLLM `--max-num-batched-tokens`; required when router queue thresholds are enabled. |
-| `DYN_EPP_TOTAL_KV_BLOCKS` | No | Optional per-worker total KV block hint. |
+| `DYN_EPP_MAX_NUM_BATCHED_TOKENS` | Policy-dependent | Must equal vLLM `--max-num-batched-tokens`; required when router queue thresholds are enabled. Under `disaggregated` this is the fallback for both roles. |
+| `DYN_EPP_PREFILL_MAX_NUM_BATCHED_TOKENS` | No | Prefill-worker override; defaults to `DYN_EPP_MAX_NUM_BATCHED_TOKENS`. |
+| `DYN_EPP_DECODE_MAX_NUM_BATCHED_TOKENS` | No | Decode-worker override; defaults to `DYN_EPP_MAX_NUM_BATCHED_TOKENS`. |
+| `DYN_EPP_TOTAL_KV_BLOCKS` | No | Optional per-worker total KV block hint. Under `disaggregated` this is the fallback for both roles. |
+| `DYN_EPP_PREFILL_TOTAL_KV_BLOCKS` | No | Prefill-worker override; defaults to `DYN_EPP_TOTAL_KV_BLOCKS`. |
+| `DYN_EPP_DECODE_TOTAL_KV_BLOCKS` | No | Decode-worker override; defaults to `DYN_EPP_TOTAL_KV_BLOCKS`. |
 | `DYN_EPP_SELECTION_INDEXER_THREADS` | No | KV indexer thread count; defaults to `4`. |
 | `DYN_EPP_TOKENIZATION_TIMEOUT_MS` | No | Render request timeout; defaults to `5000`. |
 | `DYN_EPP_TOKENIZER_MAX_RESPONSE_BYTES` | No | Maximum render response size; defaults to `16777216`. |
@@ -506,6 +514,15 @@ For a single EPP replica, set `spec.replicas: 1` and remove `DYN_EPP_PEER_SERVIC
 | `DYN_EPP_PEER_SERVICE` | No | Existing EPP Service used to discover sibling replicas. Enables replica sync. |
 | `DYN_EPP_REPLICA_SYNC_PORT` | No | ZMQ port every replica binds and dials for replica sync; defaults to `9092`. All replicas selected by `DYN_EPP_PEER_SERVICE` must use the same value. |
 | `POD_IP` | With peer service | EPP pod IP used to exclude the local replica from its peer set. |
+
+<Note>
+`DYN_EPP_TOPOLOGY_MODE=disaggregated` requires `DYN_EPP_MODE=standalone` and is incompatible with
+`DYN_EPP_PEER_SERVICE`; both combinations fail startup. It builds the prefill and decode worker
+catalogs but does not yet select a prefill/decode pair, so decode workers still perform the whole
+prefill. The end-to-end path lands with
+[#13405](https://github.com/ai-dynamo/dynamo/issues/13405) and
+[#13407](https://github.com/ai-dynamo/dynamo/issues/13407).
+</Note>
 
 ## Scope and Limitations
 
@@ -526,10 +543,11 @@ operator-generated resource contract; that contract does not configure standalon
 | EPP stays not ready | Confirm the pool exists, its selector is valid, at least one matching pod is Ready, and EPP RBAC can watch pods and `InferencePool` resources. |
 | EPP replicas do not sync active load | Confirm `DYN_EPP_PEER_SERVICE` names the EPP Service and EPP RBAC grants `list` and `watch` access to `EndpointSlice` resources. |
 | EPP exits while validating its peer Service | Confirm the Service exists and EPP RBAC grants `get` access to Services. |
-| EPP reports no schedulable workers | Set `DYN_EPP_MAX_NUM_BATCHED_TOKENS` to the vLLM `--max-num-batched-tokens` value when queueing is enabled. |
+| EPP reports no schedulable workers | Set `DYN_EPP_MAX_NUM_BATCHED_TOKENS` to the vLLM `--max-num-batched-tokens` value when queueing is enabled. Under `disaggregated` the startup error names the role-specific variable to set. |
 | Route has no accepted parent | Confirm `parentRefs[].namespace` names the Gateway namespace, `sectionName` names its listener, and the listener allows routes from the workload namespace. |
 | Tokenization fails | Check the render Service endpoints and call `/v1/chat/completions/render` from the EPP namespace. |
 | Prefix locality does not improve | Confirm the vLLM event publisher and EPP event port match, and that the EPP block size equals vLLM `--block-size`. |
+| Every request fails under `disaggregated` | Confirm each pool-selected pod carries the worker-role label with value `prefill` or `decode`. Pods without a resolvable role are excluded from both catalogs and logged at warn. |
 
 Follow the full request path when debugging:
 

--- a/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
@@ -498,7 +498,7 @@ selectors would bind the same replica-sync port.
 | `DYN_EPP_TOKENIZER_PROTOCOL=vllm-render` | Yes | Tokenizer wire protocol; this is the only supported value. |
 | `DYN_KV_CACHE_BLOCK_SIZE` | Yes | Must equal vLLM `--block-size`. |
 | `DYN_EPP_TOPOLOGY_MODE` | No | `aggregated` (default) treats every worker as a routable target. `disaggregated` splits the pool by worker role; see the note below. Any other value fails startup. |
-| `DYN_EPP_WORKER_ROLE_LABEL` | With `disaggregated` | Pod label key naming a worker's role; defaults to `nvidia.com/role`. Values must be `prefill` or `decode`. |
+| `DYN_EPP_WORKER_ROLE_LABEL` | No | Pod label key naming a worker's role; defaults to `nvidia.com/role`. Read only under `disaggregated`, where every pool pod must carry it with the value `prefill` or `decode`. |
 | `DYN_EPP_KV_EVENT_PORT` | No | Per-pod vLLM KV event port; defaults to `5557`. |
 | `DYN_EPP_KV_EVENT_REPLAY_PORT` | No | Per-pod replay port for KV event gap recovery. |
 | `DYN_EPP_MAX_NUM_BATCHED_TOKENS` | Policy-dependent | Must equal vLLM `--max-num-batched-tokens`; required when router queue thresholds are enabled. Under `disaggregated` this is the fallback for both roles. |
@@ -507,7 +507,7 @@ selectors would bind the same replica-sync port.
 | `DYN_EPP_TOTAL_KV_BLOCKS` | No | Optional per-worker total KV block hint. Under `disaggregated` this is the fallback for both roles. |
 | `DYN_EPP_PREFILL_TOTAL_KV_BLOCKS` | No | Prefill-worker override; defaults to `DYN_EPP_TOTAL_KV_BLOCKS`. |
 | `DYN_EPP_DECODE_TOTAL_KV_BLOCKS` | No | Decode-worker override; defaults to `DYN_EPP_TOTAL_KV_BLOCKS`. |
-| `DYN_EPP_SELECTION_INDEXER_THREADS` | No | KV indexer thread count; defaults to `4`. |
+| `DYN_EPP_SELECTION_INDEXER_THREADS` | No | KV indexer thread count; defaults to `4`. Under `disaggregated` it applies to the prefill selector only: the decode selector consumes no KV events, so its index is never fed and it is pinned to one thread. |
 | `DYN_EPP_TOKENIZATION_TIMEOUT_MS` | No | Render request timeout; defaults to `5000`. |
 | `DYN_EPP_TOKENIZER_MAX_RESPONSE_BYTES` | No | Maximum render response size; defaults to `16777216`. |
 | `DYN_EPP_MAX_INFLIGHT_REQUESTS` | No | Concurrent EPP request guardrail; defaults to `1024`, and excess requests receive `503`. |


### PR DESCRIPTION
## Summary

Closes #13406 (DEP #11661, Milestone 5). With
`DYN_EPP_TOPOLOGY_MODE=disaggregated`, the standalone Rust EPP splits the pods selected by one
`InferencePool` into prefill and decode catalogs using a configurable worker-role label, and drives
two independent embedded `SelectionService` instances from them.

**Two instances, not one instance with two routing groups.** `use_kv_events` is fixed when a
`SelectionService` is built and differs per role, and the two catalogs must be disjoint so a decode
pick can never see a prefill worker. Everything else that separates the roles is *per-request*: the
decode selector carries the same `RouterConfigOverride` the Dynamo-runtime EPP applies to its decode
leg (`decode_router_config_override`, shared from `epp.rs`) and supplies it on every selection and
booking; prefill and aggregated carry none.

| | prefill | decode |
|---|---|---|
| static `use_kv_events` | base | `false` |
| static `router_predicted_ttl_secs` | base | cleared (needs events) |
| per-request `RouterConfigOverride` | none | `overlap_score_credit: 0.0`, `assume_kv_reuse: false`, `track_prefill_tokens: false` |

Prefill scores prefix overlap and does not model long-lived block occupancy; decode ignores overlap
and does model occupancy. A decode worker did not compute the prompt, so charging it prefill work
would mis-rank it, and crediting it for a prefix it never cached would be a fiction. Decode workers
therefore carry no `kv_events_endpoint` and no `replay_endpoint`, which is exactly what makes them
Schedulable under `use_kv_events=false`.

**Prefill is a selection input only.** All five reflector reads on the request path are scoped to the
serving role, and an empty decode catalog returns the new `PickError::RoleCatalogEmpty` (503)
instead of falling back to a prefill endpoint. `build_request_header_response` is the sole producer
of `x-gateway-destination-endpoint` and is reachable only through `pick()`, so scoping `pick()`
scopes the whole surface.

**Aggregated mode is unchanged.** The role label is never read, one catalog is built, and the
existing single-selector path runs byte-identically.

### Requirement-by-requirement

| # | Issue requirement | Where |
|---|---|---|
| 1 | Topology configuration + worker-role label contract | `epp_standalone_config.rs` — `EppTopologyMode`, `DYN_EPP_WORKER_ROLE_LABEL` (default `nvidia.com/dynamo-worker-role`), label-key syntax validation |
| 2 | Split eligible pool pods into prefill/decode sets | `pod_discovery.rs` — `raw_worker_from_pod` resolves the role after the existing eligibility gates |
| 3 | Role-scoped catalogs, KV-event inputs, readiness, selector config | `pod_discovery.rs` (`IndexState`/`RoleCounts`), `role_config.rs`, `selector.rs`, `topology_adapter.rs` |
| 4 | Prefill never selected as a destination | `epp_router.rs` `serving_role`, `picker.rs` `RoleCatalogEmpty`, `server.rs` 503 mapping |
| 5 | Unit + integration coverage | 18 net new test functions over `main` (table-style; 161 in the crate) across role changes, missing/invalid labels, add/remove reconciliation, and the routing invariant |

### New environment variables

`DYN_EPP_TOPOLOGY_MODE`, `DYN_EPP_WORKER_ROLE_LABEL`, and two per-role capacity overrides
(`DYN_EPP_{PREFILL,DECODE}_MAX_NUM_BATCHED_TOKENS`) that fall back to the shared value. Real P/D
fleets differ by 8–16× here, and `max_num_batched_tokens` is the denominator of
`PolicyClassConfig::worker_is_busy`. Per-role KV-block totals are deliberately not added: nothing in
this split consumes distinct totals yet.

Two configurations are rejected at startup rather than silently reinterpreted: `DYN_EPP_PEER_SERVICE`
with `disaggregated` (both instances would bind the one hardcoded `replica-agg` port; Milestone 8 /
#13418 owns multi-replica disagg), and `DYN_ROUTER_CONDITIONAL_DISAGG` (it requires decode-side KV
events and bypass orchestration `SelectionService` does not perform).
`DYN_EPP_TOPOLOGY_MODE` is standalone-only configuration like its siblings; the Dynamo-runtime mode
ignores it.

### DEP #11661 corrections this surfaced

- The two per-role `max_num_batched_tokens` env vars are missing from the Environment Contract.
- The role label key is now `nvidia.com/dynamo-worker-role`; the DEP says `nvidia.com/role` in four places.
- `DYN_EPP_KV_EVENT_PORT` / `DYN_EPP_KV_EVENT_REPLAY_PORT` apply to prefill only under disaggregated.
- Decode workers have no `kv_events_endpoints` and no `replay_endpoint`.
- `DYN_EPP_WORKER_ROLE_LABEL` is optional-with-default, not "Conditional" required.
- Conditional disaggregation is rejected by the standalone EPP; the DEP marks it "Needs design".

### Deliberately not in this change

Owned by the sibling issues: prefill/decode pair selection and reservation (#13407), the
decode-sidecar request contract (#13405), NIXL handoff (#13404), and manifests / e2e / benchmarking
(#13408). Per-role policy and queue configuration is recorded against #13407; metrics are
Milestone 9. Until #13405 and #13407 land the prefill catalog is populated but nothing selects from
it, so the EPP logs that at startup and the docs carry the same note.
## Validation

* `cargo fmt -p dynamo-ext-proc -- --check`
* `cargo clippy -p dynamo-ext-proc --all-targets -- -D warnings`
* `cargo test -p dynamo-ext-proc` — **161 passed, 0 failed**
* Focused areas: worker role (9), per-role router config (10), standalone config (18 new), pod
  discovery (14 new), topology adapter (3 new), plus the existing aggregated suite unchanged

============

## Kubernetes Validation Summary

> Revision 1 run. The revision-2 rerun (new label key, override refactor, guard removal) is in the
> follow-up comment below.

Tested on a real Kubernetes cluster — throwaway k3s v1.34.2 in Docker, Gateway API v1.5.1 + GAIE
CRDs v1.2.1 + agentgateway v1.0.0 — installed with **this repo's own documented procedure**,
`deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh` per
[Install Gateway API Inference Extension](docs/fern/pages/kubernetes/installation/gateway-api-routing.mdx).

GPU-less setup: the workers are `traefik/whoami` echo servers carrying the `nvidia.com/role` label,
and the EPP runs off-cluster against the same API server with a stub standing in for vLLM's
`/v1/chat/completions/render`. Everything the gateway itself touches — `InferencePool`, `HTTPRoute`,
the EPP `Service` — is exactly what `deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml`
ships. Echo workers are enough here because this issue is about *which* endpoint the EPP hands the
gateway, not about what the endpoint computes.

* **Role split from one InferencePool** — 2 prefill + 2 decode pods, two `SelectionService`
  instances, two policy classes, independent readiness per role.
* **KV events are prefill-only** — ZMQ listeners start for the prefill pod IPs and no others, and
  follow the label across role changes.
* **The gateway never receives a prefill endpoint** — 100/100 requests landed on decode-role pods,
  cross-checked against each pod's live label.
* **Empty decode catalog fails closed** — `503 no decode workers available` instead of falling back
  to a prefill endpoint.
* **Live role changes reconcile** — flips in both directions, label removal, and an unparseable
  label value, each with an attributable log line.
* **Aggregated mode is unchanged** — same pool, same labels, one catalog, all pods serving.

### Step 1: install the gateway with the documented script

```
$ NAMESPACE=epp-disagg AGW_NAMESPACE=agentgateway-system \
    ./deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
...
agentgatewayparameters.agentgateway.dev/inference-gateway-params serverside-applied
gateway.gateway.networking.k8s.io/inference-gateway created
gateway.gateway.networking.k8s.io/inference-gateway condition met

$ kubectl get gatewayclass
NAME           CONTROLLER                      ACCEPTED   AGE
agentgateway   agentgateway.dev/agentgateway   True       12s

$ kubectl get gateway inference-gateway -n agentgateway-system
NAME                CLASS          ADDRESS   PROGRAMMED   AGE
inference-gateway   agentgateway             True         10s
```

### Step 2: apply the disaggregated workload

```
$ kubectl -n epp-disagg get pods -o custom-columns='NAME:.metadata.name,IP:.status.podIP,ROLE:.metadata.labels.nvidia\.com/role,READY:...'
NAME                            IP          ROLE      READY
vllm-decode-944754ff7-f87cw     10.42.0.9   decode    True
vllm-decode-944754ff7-pnsls     10.42.0.8   decode    True
vllm-prefill-68cb66cf4d-kxwbl   10.42.0.7   prefill   True
vllm-prefill-68cb66cf4d-ljtnm   10.42.0.6   prefill   True

$ kubectl -n epp-disagg get httproute vllm-qwen-route -o jsonpath=...
agentgateway.dev/agentgateway Accepted=True ResolvedRefs=True
```

### Step 3: EPP startup — two catalogs, and ZMQ only for prefill 🔥

Prefill pods are `10.42.0.6` and `10.42.0.7`; decode pods are `10.42.0.8` and `10.42.0.9`. Only the
prefill pair gets a KV-event subscription, which is the whole point of `use_kv_events=false` and
`kv_events_endpoint: None` on the decode role.

```
INFO dynamo_ext_proc::runner: Listening for ext_proc connections (TLS) addr=0.0.0.0:9002
INFO dynamo_ext_proc::pod_discovery: Role has ready workers role="prefill" ready=2
INFO dynamo_ext_proc::pod_discovery: Role has ready workers role="decode" ready=2
INFO ...indexer::listener: ZMQ listener starting worker_id=6967477426482853 endpoint="tcp://10.42.0.6:5557"
INFO ...indexer::listener: ZMQ listener starting worker_id=1819057378898784 endpoint="tcp://10.42.0.7:5557"
WARN dynamo_ext_proc::epp_router: DYN_EPP_TOPOLOGY_MODE=disaggregated is incomplete until
     ai-dynamo/dynamo#13405 and #13407 land: the prefill catalog is populated but nothing selects
     from it yet, so decode workers still perform the whole prefill
```

### Step 4: end-to-end request through the gateway

The echo worker reflects the headers it received, so the EPP's decision is visible in the response
body itself.

```
$ curl -i http://<gateway>/v1/chat/completions -H 'content-type: application/json' \
    -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"hello world from the gateway"}]}'
HTTP/1.1 200 OK

Hostname: vllm-decode-944754ff7-pnsls
IP: 10.42.0.8
RemoteAddr: 10.42.0.5:54164
POST /v1/chat/completions HTTP/1.1
X-Gateway-Destination-Endpoint: 10.42.0.8:8000
```

### Step 5: 100 requests, destinations cross-checked against live role labels 🔥

Run after several role flips, so two pods carry a name from the opposite Deployment. Routing follows
the **label**, not the name — which is what the issue asks for.

```
$ kubectl -n epp-disagg get pods -o custom-columns='NAME,IP,ROLE'
vllm-prefill-68cb66cf4d-kxwbl   10.42.0.7    decode
vllm-decode-944754ff7-qv4p5     10.42.0.12   decode
vllm-decode-944754ff7-zvlzm     10.42.0.13   decode
vllm-prefill-68cb66cf4d-ljtnm   10.42.0.6    prefill
vllm-decode-944754ff7-nx6hq     10.42.0.11   prefill
vllm-prefill-68cb66cf4d-rk75z   10.42.0.10   prefill

$ # 100 requests; tally X-Gateway-Destination-Endpoint against the live label
40 requests -> 10.42.0.12 role=decode
31 requests -> 10.42.0.13 role=decode
29 requests -> 10.42.0.7 role=decode
```

**0 of 100 reached a prefill-role pod.** Same result on the earlier 60-request runs.

### Step 6: drain decode, prefill still Ready

The decode pods are confirmed gone from the API server, not merely terminating, and the pool still
holds two eligible Ready prefill pods — so this is an empty *role catalog*, not an empty pool.

```
$ kubectl -n epp-disagg scale deploy/vllm-decode --replicas=0
$ kubectl -n epp-disagg wait --for=delete pod -l nvidia.com/role=decode --timeout=90s
pod/vllm-decode-944754ff7-f87cw condition met
pod/vllm-decode-944754ff7-pnsls condition met

$ kubectl -n epp-disagg get pods
vllm-prefill-68cb66cf4d-kxwbl   prefill   Running
vllm-prefill-68cb66cf4d-ljtnm   prefill   Running

$ curl -i http://<gateway>/v1/chat/completions -d '{...}'
HTTP/1.1 503 Service Unavailable
content-length: 27

no decode workers available
```

The EPP confirms the same thing independently: both decode workers are removed from the decode
selector, and the request that follows produces **no `Selected worker` and no `Request routed`
line** — `pick()` short-circuits on `has_ready_workers(Decode)` before it ever reaches the selector,
which is exactly `PickError::RoleCatalogEmpty(Decode)`.

```
06:09:34.352529 WARN ...sequences::multi_worker: Removing worker WorkerWithDpRank { worker_id: 4220446411653535 }  # 10.42.0.8
06:09:34.353019 WARN ...pod_discovery: Role has no ready workers; requests needing it will fail
                     until one appears role="decode"
06:09:34.353328 WARN ...sequences::multi_worker: Removing worker WorkerWithDpRank { worker_id: 6957111713067280 }  # 10.42.0.9

06:09:38.028162 DEBUG ...server: Received RequestHeaders from Envoy
06:09:38.028270 DEBUG ...server: Received RequestBody from Envoy body_len=83
06:09:38.028292 DEBUG ...server: Received RequestBody from Envoy eos=true
                       # no Selected worker, no Request routed -- compare Step 4
```

Deleting the pods leaves one confound: it does not separate "the decode catalog is empty" from "the
pod is not there". Step 8's label removal closes that — the pod stays Running, Ready and
pool-selected, and only its role label goes away, reaching the identical 503 through a completely
different path.

Fails closed with an attributable body, rather than falling back to a prefill endpoint.

### Step 7: live role changes

`prefill → decode`: the pod moves catalogs in place, starts serving immediately, and its KV-event
subscription is torn down.

```
$ kubectl -n epp-disagg label pod vllm-prefill-68cb66cf4d-kxwbl nvidia.com/role=decode --overwrite
Hostname: vllm-prefill-68cb66cf4d-kxwbl      # x3, it is now the only decode worker
```
```
INFO ...indexer::listener: ZMQ listener exiting after cancellation self.worker_id=1819057378898784
```

`decode → prefill`: the pod stops receiving traffic and gains a subscription.

```
$ kubectl -n epp-disagg label pod vllm-decode-944754ff7-nx6hq nvidia.com/role=prefill --overwrite
$ # 30 requests
     11 vllm-decode-944754ff7-zvlzm
     10 vllm-decode-944754ff7-qv4p5
      9 vllm-prefill-68cb66cf4d-kxwbl     # nx6hq: 0
```
```
INFO ...indexer::listener: ZMQ listener starting worker_id=8935336512433373 endpoint="tcp://10.42.0.11:5557"
```

### Step 8: missing and invalid role labels

```
$ kubectl label pod ... nvidia.com/role-                       -> 503 no decode workers available
$ kubectl label pod ... nvidia.com/role=encode --overwrite     -> 503 no decode workers available
$ kubectl label pod ... nvidia.com/role=decode --overwrite     -> 200
```
```
WARN ...pod_discovery: Pod is pool-selected and Ready but has no usable worker role; excluding it
     pod="vllm-prefill-68cb66cf4d-kxwbl" reason="role_label_missing" error=role label is missing
WARN ...pod_discovery: Pod is pool-selected and Ready but has no usable worker role; excluding it
     pod="vllm-prefill-68cb66cf4d-kxwbl" reason="role_label_invalid"
     error=role label value "encode" names no worker role
```

Startup never fails on this — a rolling update transiently produces such pods.

### Step 9: a client cannot force a prefill endpoint

In GAIE the EPP answers the gateway with an `x-gateway-destination-endpoint` header and the gateway
forwards there. So the cheapest way to defeat requirement #4 needs no bug in the catalog logic at
all: the **client** sets that header itself and names a prefill pod. `envoy_helpers.rs:54-58` argues
this cannot work — the header is deliberately kept out of `STRIPPED_REQUEST_HEADERS` because the EPP
writes it with `OverwriteIfExistsOrAdd`, which already replaces any client value, and stripping it
as well would make the outcome depend on Envoy's set-vs-remove ordering. This step checks that
argument against a real gateway.

Each row is one `curl` carrying a forged header. Pod names are unreliable after Step 7's flips, so
both role columns are the **live label**, which is what actually decides.

| forged header the client sent | role of *that* pod | endpoint the EPP returned | pod that served the request | role of *that* pod |
|---|---|---|---|---|
| `10.42.0.6:8000` | `prefill` | `10.42.0.11:8000` | `vllm-decode-944754ff7-nx6hq` | `decode` |
| `10.42.0.10:8000` | `prefill` | `10.42.0.7:8000` | `vllm-prefill-68cb66cf4d-kxwbl` | `decode` |

The two role columns are the test's precondition and its assertion:

* **Column 2 must be `prefill`.** Forging a decode IP would prove nothing — override and no-override
  produce the same landing pod, so the test would have no discriminating power.
* **Column 5 must be `decode`.** That is the pass condition. Had the spoof worked, the response
  would have come from `vllm-prefill-…-ljtnm` or `vllm-prefill-…-rk75z`, the two pods actually
  labelled `prefill` at that moment.

Row 2 is why names cannot be trusted: `vllm-prefill-…-kxwbl` reads like a prefill pod but was
flipped to `decode` in Step 7, and the Deployment name never changed.

```
06:11:24.061149 INFO ...selector: Selected worker worker_id=8935336512433373
06:11:24.061409 INFO ...server: Request routed endpoint=10.42.0.11:8000
06:11:24.061449 DEBUG ...envoy_helpers: [FINAL-MUTATION] set_headers
                key=x-gateway-destination-endpoint value=10.42.0.11:8000 append_action=2

06:11:24.109389 INFO ...selector: Selected worker worker_id=1819057378898784
06:11:24.109524 INFO ...server: Request routed endpoint=10.42.0.7:8000
06:11:24.109550 DEBUG ...envoy_helpers: [FINAL-MUTATION] set_headers
                key=x-gateway-destination-endpoint value=10.42.0.7:8000 append_action=2
```

`append_action=2` is `OverwriteIfExistsOrAdd`. What this run establishes is the end-to-end property
— a client-supplied value does not change the destination. It does not distinguish whether the
forged header was dropped before ext_proc or overwritten after it, and it does not need to.

### Step 10: aggregated parity, same cluster and same labels

Restart the EPP with `DYN_EPP_TOPOLOGY_MODE` unset against the identical pool. The role label is
never read, all 6 pods form one catalog, all 6 get KV-event listeners, all 6 serve.

```
INFO dynamo_ext_proc::pod_discovery: Role has ready workers role="aggregated" ready=6
INFO ...indexer::listener: ZMQ listener starting endpoint="tcp://10.42.0.6:5557"
INFO ...indexer::listener: ZMQ listener starting endpoint="tcp://10.42.0.7:5557"
INFO ...indexer::listener: ZMQ listener starting endpoint="tcp://10.42.0.10:5557"
INFO ...indexer::listener: ZMQ listener starting endpoint="tcp://10.42.0.11:5557"
INFO ...indexer::listener: ZMQ listener starting endpoint="tcp://10.42.0.12:5557"
INFO ...indexer::listener: ZMQ listener starting endpoint="tcp://10.42.0.13:5557"
```
```
$ # 60 requests
     14 vllm-prefill-68cb66cf4d-kxwbl
     14 vllm-decode-944754ff7-zvlzm
     12 vllm-decode-944754ff7-qv4p5
      8 vllm-prefill-68cb66cf4d-ljtnm
      8 vllm-decode-944754ff7-nx6hq
      4 vllm-prefill-68cb66cf4d-rk75z
```

### Not covered by this run

Real vLLM workers, real KV-cache events (the ZMQ sockets connect but no worker publishes), NIXL
transfer, and prefill/decode pairing — pairing is #13407 and is what makes the prefill catalog do
anything, so it cannot be exercised until that lands. Multi-replica EPP under `disaggregated` is
rejected at startup and is Milestone 8 (#13418).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
