### PR TITLE
fix(lora): repair allocation simulation measurements

### DIFF
--- a/lib/llm/src/lora/controller.rs
+++ b/lib/llm/src/lora/controller.rs
@@ -219,7 +219,7 @@ impl LoraController {
                         // self-heals). `&mut controller` across the unwind boundary needs
                         // AssertUnwindSafe.
                         let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            controller.recompute_allocations();
+                            controller.recompute_allocations(Instant::now());
                         }));
                         if let Err(panic) = outcome {
                             let msg = panic
@@ -240,10 +240,20 @@ impl LoraController {
     }
 
     pub fn recompute_now(&mut self) {
-        self.recompute_allocations();
+        self.recompute_now_at(Instant::now());
     }
 
-    fn recompute_allocations(&mut self) {
+    /// Recompute allocations using an explicitly supplied instant.
+    ///
+    /// Production callers should use [`Self::recompute_now`]. This entrypoint is retained for
+    /// deterministic simulation and test harnesses that need the estimator and controller to
+    /// observe the same clock.
+    #[doc(hidden)]
+    pub fn recompute_now_at(&mut self, now: Instant) {
+        self.recompute_allocations(now);
+    }
+
+    fn recompute_allocations(&mut self, now: Instant) {
         self.tick += 1;
         let observed = self.state_tracker.snapshot();
         let incarnation = observed.incarnation();
@@ -308,8 +318,8 @@ impl LoraController {
             // other LoRA gauges) don't stay stale while capacity remains zero. No allocation ran
             // this tick, so churn/overflow are zero.
             let table_snapshot = self.routing_table.snapshot_configs();
-            let loads = self.load_estimator.get_current_load();
-            let raw_arrival_counts = self.load_estimator.get_raw_arrival_counts();
+            let loads = self.load_estimator.get_current_load_at(now);
+            let raw_arrival_counts = self.load_estimator.get_raw_arrival_counts_at(now);
             self.update_prometheus_metrics(&table_snapshot, &loads, &raw_arrival_counts);
             self.update_churn_metrics(0, 0, 0);
             tracing::debug!(
@@ -320,7 +330,7 @@ impl LoraController {
         }
 
         let worker_slot_usage = self.observed.get_worker_slot_usage();
-        let loads = self.load_estimator.get_current_load();
+        let loads = self.load_estimator.get_current_load_at(now);
         let total_load: usize = loads.values().sum();
 
         if !loads.is_empty() {
@@ -490,7 +500,7 @@ impl LoraController {
 
         // Prune the load estimator of LoRAs that are no longer loaded (and any
         // unknown/typo request names), bounding its memory over time (F12).
-        self.load_estimator.retain_known(&known_set);
+        self.load_estimator.retain_known_at(&known_set, now);
 
         tracing::debug!(
             tick = self.tick,
@@ -522,7 +532,7 @@ impl LoraController {
             }
         }
 
-        let raw_arrival_counts = self.load_estimator.get_raw_arrival_counts();
+        let raw_arrival_counts = self.load_estimator.get_raw_arrival_counts_at(now);
         self.update_prometheus_metrics(&table_snapshot, &loads, &raw_arrival_counts);
     }
 

--- a/lib/llm/src/lora/load_estimator.rs
+++ b/lib/llm/src/lora/load_estimator.rs
@@ -366,6 +366,15 @@ impl LoadEstimator {
     /// Prune tracking data (and predictors) for any LoRA not in `known`. Bounds memory
     /// against unloaded adapters and unknown/typo request names that never get allocated.
     pub fn retain_known(&self, known: &std::collections::HashSet<&str>) {
+        self.retain_known_at(known, Instant::now());
+    }
+
+    /// Prune tracking data using an explicitly supplied clock.
+    ///
+    /// This keeps deterministic simulation clocks out of the production hot path while allowing
+    /// callers that already own a clock to evaluate recent arrivals consistently.
+    #[doc(hidden)]
+    pub fn retain_known_at(&self, known: &std::collections::HashSet<&str>, now: Instant) {
         // Keep an entry if it is known, OR still has in-flight requests, OR has nonzero arrivals
         // within the current rate window. The in-flight check protects a LoRA whose arrival raced
         // this controller tick before its MDC reached the state tracker (dropping it would make
@@ -379,7 +388,6 @@ impl LoadEstimator {
         // zero and drop the very signal this protects. Once the window slides past with no further
         // arrivals and the name is still unknown, it is pruned, so memory stays bounded against
         // unknown/typo request names.
-        let now = Instant::now();
         self.data.retain(|name, data| {
             known.contains(name.as_str())
                 || data.active_count.load(Ordering::Relaxed) > 0
@@ -543,8 +551,12 @@ impl LoadEstimator {
 
     /// Increment load count for a LORA and record arrival. Lock-free for existing LoRAs.
     pub fn increment_load(&self, lora_name: &str) {
-        let now = Instant::now();
+        self.increment_load_at(lora_name, Instant::now());
+    }
 
+    /// Increment load count and record an arrival at an explicitly supplied instant.
+    #[doc(hidden)]
+    pub fn increment_load_at(&self, lora_name: &str, now: Instant) {
         // Fast path: LoRA already exists
         if let Some(entry) = self.data.get(lora_name) {
             entry.value().active_count.fetch_add(1, Ordering::Relaxed);
@@ -580,6 +592,15 @@ impl LoadEstimator {
     /// or out-of-order `Free` event when `active_count == 0` is silently
     /// ignored rather than wrapping to `usize::MAX`.
     pub fn decrement_load(&self, lora_name: &str) {
+        self.decrement_load_at(lora_name, Instant::now());
+    }
+
+    /// Decrement the in-flight count at an explicitly supplied instant.
+    ///
+    /// The counter itself is not time-dependent, but accepting the timestamp keeps simulation
+    /// request start and completion paths symmetric.
+    #[doc(hidden)]
+    pub fn decrement_load_at(&self, lora_name: &str, _now: Instant) {
         if let Some(entry) = self.data.get(lora_name) {
             entry
                 .value()
@@ -652,7 +673,12 @@ impl LoadEstimator {
 
     /// Get current load using arrival count in the sliding window.
     pub fn get_current_load(&self) -> HashMap<String, usize> {
-        let now = Instant::now();
+        self.get_current_load_at(Instant::now())
+    }
+
+    /// Get current load using an explicitly supplied instant.
+    #[doc(hidden)]
+    pub fn get_current_load_at(&self, now: Instant) -> HashMap<String, usize> {
         let cfg = self.config.read();
         let predictor_type = cfg.predictor_type;
         let ema_alpha = cfg.ema_alpha;
@@ -711,7 +737,12 @@ impl LoadEstimator {
 
     /// Get raw arrival counts from the sliding-window rate counters.
     pub fn get_raw_arrival_counts(&self) -> HashMap<String, u64> {
-        let now = Instant::now();
+        self.get_raw_arrival_counts_at(Instant::now())
+    }
+
+    /// Get raw arrival counts using an explicitly supplied instant.
+    #[doc(hidden)]
+    pub fn get_raw_arrival_counts_at(&self, now: Instant) -> HashMap<String, u64> {
         self.data
             .iter()
             .filter_map(|entry| {

--- a/lib/llm/tests/lora_simulation/csv_export.rs
+++ b/lib/llm/tests/lora_simulation/csv_export.rs
@@ -56,6 +56,7 @@ fn test_export_csv() {
         lifetime_mean: 0,
         lifetime_stddev: 0.0,
         seed: 42,
+        ..Default::default()
     };
     all_runs.push(("hot_lora_poisson", zipf_config.clone(), zipf_schedules));
 
@@ -90,6 +91,7 @@ fn test_export_csv() {
         lifetime_mean: 0,
         lifetime_stddev: 0.0,
         seed: 42,
+        ..Default::default()
     };
     all_runs.push(("daily", diurnal_config.clone(), diurnal_schedules));
 
@@ -125,6 +127,7 @@ fn test_export_csv() {
         lifetime_mean: 0,
         lifetime_stddev: 0.0,
         seed: 42,
+        ..Default::default()
     };
     all_runs.push(("spike", flash_config.clone(), flash_schedules));
 
@@ -162,6 +165,7 @@ fn test_export_csv() {
         lifetime_mean: 0,
         lifetime_stddev: 0.0,
         seed: 42,
+        ..Default::default()
     };
     all_runs.push(("mmpp", mmpp_config.clone(), mmpp_schedules));
 
@@ -362,7 +366,7 @@ fn test_export_csv() {
         writeln!(
             f,
             "scale_down_cooldown_ticks,{}",
-            COMPARISON_SCALE_DOWN_COOLDOWN_TICKS
+            config.scale_down_cooldown_ticks
         )
         .unwrap();
         writeln!(f, "seed,{}", config.seed).unwrap();

--- a/lib/llm/tests/lora_simulation/csv_export.rs
+++ b/lib/llm/tests/lora_simulation/csv_export.rs
@@ -3,6 +3,33 @@
 
 use super::*;
 
+fn percentile_99(values: &[usize]) -> usize {
+    if values.is_empty() {
+        return 0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    sorted[((sorted.len() - 1) * 99) / 100]
+}
+
+fn percentile_50_ms(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    sorted[(sorted.len() - 1) / 2]
+}
+
+fn percentile_99_ms(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    sorted[((sorted.len() - 1) * 99) / 100]
+}
+
 // ============================================================================
 // CSV Export for Visualization
 // ============================================================================
@@ -24,6 +51,22 @@ fn test_export_csv() {
     let out_dir =
         std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/lora_sim_csv");
     fs::create_dir_all(&out_dir).expect("create output dir");
+    let v2_out_dir = out_dir.join("v2");
+    fs::create_dir_all(&v2_out_dir).expect("create v2 output dir");
+    let mut timeseries =
+        fs::File::create(v2_out_dir.join("timeseries.csv")).expect("create v2 timeseries csv");
+    writeln!(
+        timeseries,
+        "scenario,algorithm,seed,tick,adapter_loads,adapter_unloads,adapter_churn,route_churn,requests,hits,hit_rate,active_loras,routing_entries,cold_start_entries,mean_occupancy,max_occupancy,worker_load_cov,solve_ms,overflow_count"
+    )
+    .unwrap();
+    let mut summary =
+        fs::File::create(v2_out_dir.join("summary.csv")).expect("create v2 summary csv");
+    writeln!(
+        summary,
+        "scenario,algorithm,seed,total_adapter_churn,total_route_churn,churn_free_ticks,churn_free_pct,peak_churn_per_tick,p99_churn_per_tick,overall_hit_rate,mean_worker_load_cov,mean_occupancy_pct,solve_ms_p50,solve_ms_p99,total_overflow,est_swap_ms"
+    )
+    .unwrap();
 
     // Fixed cluster: N=8 backends, K=4 resident LoRA slots → 32 total slots. Replica sets are
     // controller route targets; under pressure they can exceed resident capacity and trigger lazy
@@ -179,6 +222,91 @@ fn test_export_csv() {
             name, config.num_backends, config.slots_per_backend, config.total_loras
         );
         print_comparison(&hrw, &random, &mcf);
+
+        for metrics in [&hrw, &random, &mcf] {
+            for tick in 0..config.total_ticks {
+                let adapter_loads = metrics.per_tick_adapter_loads[tick];
+                let adapter_unloads = metrics.per_tick_adapter_unloads[tick];
+                let requests = metrics.per_tick_requests[tick];
+                let hits = metrics.per_tick_hits[tick];
+                let hit_rate = if requests == 0 {
+                    0.0
+                } else {
+                    hits as f64 / requests as f64
+                };
+                writeln!(
+                    timeseries,
+                    "{},{},{},{},{},{},{},{},{},{},{:.6},{},{},{},{:.6},{},{:.6},{:.6},{}",
+                    name,
+                    metrics.algorithm,
+                    config.seed,
+                    tick,
+                    adapter_loads,
+                    adapter_unloads,
+                    adapter_loads + adapter_unloads,
+                    metrics.per_tick_churn[tick],
+                    requests,
+                    hits,
+                    hit_rate,
+                    metrics.per_tick_active_loras[tick],
+                    metrics.per_tick_routing_entries[tick],
+                    metrics.per_tick_cold_start_entries[tick],
+                    metrics.per_tick_mean_occupancy[tick],
+                    metrics.per_tick_max_occupancy[tick],
+                    metrics.per_tick_worker_load_cov[tick],
+                    metrics.per_tick_solve_ms[tick],
+                    metrics.per_tick_overflow_count[tick],
+                )
+                .unwrap();
+            }
+
+            let total_loads: usize = metrics.per_tick_adapter_loads.iter().sum();
+            let total_unloads: usize = metrics.per_tick_adapter_unloads.iter().sum();
+            let total_requests: usize = metrics.per_tick_requests.iter().sum();
+            let total_hits: usize = metrics.per_tick_hits.iter().sum();
+            let mean_cov = metrics.per_tick_worker_load_cov.iter().sum::<f64>()
+                / metrics.per_tick_worker_load_cov.len() as f64;
+            let mean_occupancy_pct = metrics.per_tick_mean_occupancy.iter().sum::<f64>()
+                / metrics.per_tick_mean_occupancy.len() as f64
+                / config.slots_per_backend as f64
+                * 100.0;
+            let total_overflow: usize = metrics.per_tick_overflow_count.iter().sum();
+            let adapter_churn_per_tick: Vec<usize> = metrics
+                .per_tick_adapter_loads
+                .iter()
+                .zip(&metrics.per_tick_adapter_unloads)
+                .map(|(loads, unloads)| loads + unloads)
+                .collect();
+            let churn_free_ticks = adapter_churn_per_tick
+                .iter()
+                .filter(|&&churn| churn == 0)
+                .count();
+            writeln!(
+                summary,
+                "{},{},{},{},{},{},{:.6},{},{},{:.6},{:.6},{:.6},{:.6},{:.6},{},{}",
+                name,
+                metrics.algorithm,
+                config.seed,
+                total_loads + total_unloads,
+                metrics.total_churn,
+                churn_free_ticks,
+                churn_free_ticks as f64 / config.total_ticks as f64 * 100.0,
+                adapter_churn_per_tick.iter().copied().max().unwrap_or(0),
+                percentile_99(&adapter_churn_per_tick),
+                if total_requests == 0 {
+                    0.0
+                } else {
+                    total_hits as f64 / total_requests as f64
+                },
+                mean_cov,
+                mean_occupancy_pct,
+                percentile_50_ms(&metrics.per_tick_solve_ms),
+                percentile_99_ms(&metrics.per_tick_solve_ms),
+                total_overflow,
+                total_loads * 50,
+            )
+            .unwrap();
+        }
 
         // ── Write churn CSV (with LoRA adds/removes) ────────────────────────
         let churn_path = out_dir.join(format!("{}_churn.csv", name));
@@ -432,5 +560,12 @@ fn test_export_csv() {
     }
 
     println!("\nAll CSVs written to: {}", out_dir.display());
+    let mut meta = fs::File::create(v2_out_dir.join("meta.csv")).expect("create v2 meta csv");
+    writeln!(meta, "key,value").unwrap();
+    writeln!(meta, "timestep_secs,3").unwrap();
+    writeln!(meta, "rate_window_secs,90").unwrap();
+    writeln!(meta, "scale_down_cooldown_ticks,3").unwrap();
+    writeln!(meta, "adapter_load_cost_ms,50").unwrap();
+    writeln!(meta, "seed_count,1").unwrap();
     println!("Run: python lib/llm/tests/lora_simulation/plot_lora_churn.py");
 }

--- a/lib/llm/tests/lora_simulation/scenario_tests.rs
+++ b/lib/llm/tests/lora_simulation/scenario_tests.rs
@@ -159,6 +159,7 @@ fn test_mcf_simulation_is_repeatable() {
         lifetime_mean: 0,
         lifetime_stddev: 0.0,
         seed: 42,
+        ..Default::default()
     };
     let schedules =
         generate_zipf_poisson_schedules(config.total_loras, config.total_ticks, 1.0, 40.0, 42);
@@ -195,6 +196,7 @@ fn test_simulation_lora_pool_fits_resident_slots() {
         lifetime_mean: 0,
         lifetime_stddev: 0.0,
         seed: 42,
+        ..Default::default()
     };
     let schedules =
         generate_zipf_poisson_schedules(config.total_loras, config.total_ticks, 1.0, 40.0, 42);

--- a/lib/llm/tests/lora_simulation/scenario_tests.rs
+++ b/lib/llm/tests/lora_simulation/scenario_tests.rs
@@ -112,6 +112,34 @@ fn test_windowed_load_keeps_sparse_lora_routable() {
 }
 
 #[test]
+fn test_request_path_measures_residency_hit_after_cold_load() {
+    let config = SimConfig {
+        num_backends: 1,
+        slots_per_backend: 1,
+        total_loras: 1,
+        concurrent_loras: 1,
+        total_ticks: 2,
+        ..Default::default()
+    };
+    let schedules = vec![LoraLoadSchedule {
+        lora_name: "warm-after-first-request".to_string(),
+        active_window: (0, config.total_ticks),
+        peak_load: 1,
+        ramp_up: 0,
+        steady: 0,
+        ramp_down: 0,
+        per_tick_loads: Some(vec![1, 1]),
+    }];
+
+    let metrics = run_hrw_simulation(&config, &schedules);
+
+    assert_eq!(metrics.per_tick_adapter_loads, vec![1, 0]);
+    assert_eq!(metrics.per_tick_adapter_unloads, vec![0, 0]);
+    assert_eq!(metrics.per_tick_requests, vec![1, 1]);
+    assert_eq!(metrics.per_tick_hits, vec![0, 1]);
+}
+
+#[test]
 fn test_random_baseline_matches_overflow_routability() {
     // Three active LoRAs share only two resident slots. All controllers still retain one route
     // target per LoRA: two budgeted targets plus one soft-overflow fallback target.

--- a/lib/llm/tests/lora_simulation/scenario_tests.rs
+++ b/lib/llm/tests/lora_simulation/scenario_tests.rs
@@ -76,6 +76,42 @@ fn test_random_baseline_matches_controller_replica_budget() {
 }
 
 #[test]
+fn test_windowed_load_keeps_sparse_lora_routable() {
+    // With a 90-second rate window and three-second control ticks, one arrival every 10 ticks
+    // must keep the LoRA active between arrivals. A per-tick-only signal would remove and re-add
+    // the route on every zero-load tick.
+    let config = SimConfig {
+        num_backends: 2,
+        slots_per_backend: 2,
+        total_loras: 1,
+        concurrent_loras: 1,
+        total_ticks: 31,
+        ..Default::default()
+    };
+    let mut loads = vec![0; config.total_ticks];
+    for tick in (0..config.total_ticks).step_by(10) {
+        loads[tick] = 1;
+    }
+    let schedules = vec![LoraLoadSchedule {
+        lora_name: "sparse-lora".to_string(),
+        active_window: (0, config.total_ticks),
+        peak_load: 1,
+        ramp_up: 0,
+        steady: 0,
+        ramp_down: 0,
+        per_tick_loads: Some(loads),
+    }];
+
+    let metrics = run_hrw_simulation(&config, &schedules);
+
+    assert!(
+        metrics.per_tick_churn[1..].iter().all(|&churn| churn == 0),
+        "a sparse LoRA must stay routed while arrivals remain in the rate window: {:?}",
+        metrics.per_tick_churn
+    );
+}
+
+#[test]
 fn test_random_baseline_matches_overflow_routability() {
     // Three active LoRAs share only two resident slots. All controllers still retain one route
     // target per LoRA: two budgeted targets plus one soft-overflow fallback target.

--- a/lib/llm/tests/lora_simulation/support.rs
+++ b/lib/llm/tests/lora_simulation/support.rs
@@ -15,11 +15,12 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use dynamo_llm::kv_router::protocols::WorkerWithDpRank;
 use dynamo_llm::lora::config::LoraAllocationConfig;
 use dynamo_llm::lora::controller::LoraController;
-use dynamo_llm::lora::load_estimator::LoadEstimator;
+use dynamo_llm::lora::load_estimator::{LoadEstimator, LoadEstimatorConfig};
 use dynamo_llm::lora::routing::AllocationAlgorithmType;
 use dynamo_llm::lora::routing::table::LoraRoutingTable;
 use dynamo_llm::lora::state_tracker::LoraStateTracker;
@@ -30,9 +31,6 @@ use rand::rngs::StdRng;
 
 // Workload configuration and generators are kept separate from allocation runners.
 include!("workloads.rs");
-
-/// Keep allocator comparisons free of the controller's separate scale-down policy.
-const COMPARISON_SCALE_DOWN_COOLDOWN_TICKS: u32 = 0;
 
 // ============================================================================
 // Random Allocator (for baseline comparison)
@@ -270,17 +268,20 @@ fn run_hrw_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> Chu
     let alloc_config = LoraAllocationConfig {
         enabled: true,
         algorithm: AllocationAlgorithmType::Hrw,
-        timestep_secs: 1, // Not used in sync mode
-        // The benchmark isolates routing-target selection. Hysteresis is a separate policy
-        // that the random baseline does not implement and would confound the comparison.
-        scale_down_cooldown_ticks: COMPARISON_SCALE_DOWN_COOLDOWN_TICKS,
-        rate_window_multiplier: 5,
+        timestep_secs: config.timestep_secs,
+        scale_down_cooldown_ticks: config.scale_down_cooldown_ticks,
+        rate_window_multiplier: config.rate_window_multiplier,
         ..Default::default()
     };
 
     let routing_table = LoraRoutingTable::new();
     let state_tracker = LoraStateTracker::new();
-    let load_estimator = Arc::new(LoadEstimator::new());
+    let load_estimator = Arc::new(LoadEstimator::with_config(
+        LoadEstimatorConfig::from_controller_timestep(
+            config.timestep_secs,
+            config.rate_window_multiplier,
+        ),
+    ));
     let mut controller = LoraController::new(
         alloc_config,
         routing_table.clone(),
@@ -301,35 +302,21 @@ fn run_hrw_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> Chu
 
     let mut metrics = ChurnMetrics::new("HRW");
     let mut prev_snapshot: AllocationSnapshot = HashMap::new();
+    let base = Instant::now();
 
     for tick in 0..config.total_ticks {
-        // Fully clear the previous tick's load signal. `decrement_load` only touches the in-flight
-        // counter, not the windowed rate counter the controller actually reads via
-        // `get_current_load()`; since the whole simulation runs in one real-time instant, without
-        // `remove_lora` the rate counter would accumulate across ticks and the controller would see
-        // ever-growing load instead of this tick's pattern.
-        for name in load_estimator
-            .get_current_load()
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>()
-        {
-            load_estimator.remove_lora(&name);
-        }
+        let now = base + Duration::from_secs(tick as u64 * config.timestep_secs);
 
-        // The controller unions adapter names from the load estimator with discovery state, so
-        // active adapters do not need synthetic MDC registrations. Registering them on an
-        // arbitrary worker would consume that worker's simulated slots for HRW but not MCF.
-        // Set only this tick's demand to keep the compared allocators capacity-equivalent.
+        // The controller learns active adapters from the estimator. Virtual time gives its
+        // windowed signal the same three-second control cadence as production.
         for schedule in schedules {
             let load = schedule.load_at_tick(tick);
             for _ in 0..load {
-                load_estimator.increment_load(&schedule.lora_name);
+                load_estimator.increment_load_at(&schedule.lora_name, now);
             }
         }
 
-        // Recompute allocations
-        controller.recompute_now();
+        controller.recompute_now_at(now);
 
         // Snapshot current allocation
         let mut curr_snapshot: AllocationSnapshot = HashMap::new();
@@ -433,16 +420,20 @@ fn run_mcf_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> Chu
     let alloc_config = LoraAllocationConfig {
         enabled: true,
         algorithm: AllocationAlgorithmType::MinCostFlow,
-        timestep_secs: 1,
-        // See run_hrw_simulation: keep the comparison focused on routing-target selection.
-        scale_down_cooldown_ticks: COMPARISON_SCALE_DOWN_COOLDOWN_TICKS,
-        rate_window_multiplier: 5,
+        timestep_secs: config.timestep_secs,
+        scale_down_cooldown_ticks: config.scale_down_cooldown_ticks,
+        rate_window_multiplier: config.rate_window_multiplier,
         ..Default::default()
     };
 
     let routing_table = LoraRoutingTable::new();
     let state_tracker = LoraStateTracker::new();
-    let load_estimator = Arc::new(LoadEstimator::new());
+    let load_estimator = Arc::new(LoadEstimator::with_config(
+        LoadEstimatorConfig::from_controller_timestep(
+            config.timestep_secs,
+            config.rate_window_multiplier,
+        ),
+    ));
     let mut controller = LoraController::new(
         alloc_config,
         routing_table.clone(),
@@ -462,28 +453,18 @@ fn run_mcf_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> Chu
 
     let mut metrics = ChurnMetrics::new("MCF");
     let mut prev_snapshot: AllocationSnapshot = HashMap::new();
+    let base = Instant::now();
     for tick in 0..config.total_ticks {
-        // Fully clear the previous tick's load signal (see run_hrw_simulation: `decrement_load`
-        // leaves the windowed rate counter, which would otherwise accumulate across ticks).
-        for name in load_estimator
-            .get_current_load()
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>()
-        {
-            load_estimator.remove_lora(&name);
-        }
+        let now = base + Duration::from_secs(tick as u64 * config.timestep_secs);
 
-        // See run_hrw_simulation: use the load estimator as the active-adapter source instead of
-        // synthetic loaded locations, which would give HRW and MCF different capacity inputs.
         for schedule in schedules {
             let load = schedule.load_at_tick(tick);
             for _ in 0..load {
-                load_estimator.increment_load(&schedule.lora_name);
+                load_estimator.increment_load_at(&schedule.lora_name, now);
             }
         }
 
-        controller.recompute_now();
+        controller.recompute_now_at(now);
 
         let mut curr_snapshot: AllocationSnapshot = HashMap::new();
         for lora_name in routing_table.list_loras() {
@@ -550,8 +531,8 @@ fn print_simulation_header(config: &SimConfig) {
     }
     println!("  Max Load/LoRA:       {}", config.max_load_per_lora);
     println!(
-        "  Scale-Down Cooldown: {} (comparison mode)",
-        COMPARISON_SCALE_DOWN_COOLDOWN_TICKS
+        "  Scale-Down Cooldown: {} ticks",
+        config.scale_down_cooldown_ticks
     );
     println!("  Seed:                {}", config.seed);
     println!();

--- a/lib/llm/tests/lora_simulation/support.rs
+++ b/lib/llm/tests/lora_simulation/support.rs
@@ -107,6 +107,9 @@ struct RequestMetrics {
     adapter_unloads: usize,
     requests: usize,
     hits: usize,
+    mean_occupancy: f64,
+    max_occupancy: usize,
+    worker_load_cov: f64,
 }
 
 /// Deterministic, capacity-bounded LRU residency model for simulated workers.
@@ -143,6 +146,8 @@ impl ResidencyModel {
             .map(|worker| (worker.worker_id, worker))
             .collect();
         let mut metrics = RequestMetrics::default();
+        let mut requests_per_worker: HashMap<WorkerWithDpRank, usize> =
+            workers.iter().copied().map(|worker| (worker, 0)).collect();
 
         for schedule in schedules {
             for _ in 0..schedule.load_at_tick(tick) {
@@ -159,6 +164,7 @@ impl ResidencyModel {
                     .expect("simulation requires at least one available worker");
                 *cursor += 1;
                 let worker = worker_by_id[&candidate];
+                *requests_per_worker.entry(worker).or_default() += 1;
                 let resident = self.adapters.entry(worker).or_default();
 
                 if state_tracker.is_loaded(&schedule.lora_name, &worker) {
@@ -191,6 +197,26 @@ impl ResidencyModel {
             }
         }
 
+        let occupancy: Vec<usize> = workers
+            .iter()
+            .map(|worker| self.adapters.get(worker).map_or(0, VecDeque::len))
+            .collect();
+        metrics.mean_occupancy = occupancy.iter().sum::<usize>() as f64 / workers.len() as f64;
+        metrics.max_occupancy = occupancy.iter().copied().max().unwrap_or(0);
+        let worker_loads: Vec<f64> = workers
+            .iter()
+            .map(|worker| requests_per_worker[worker] as f64)
+            .collect();
+        let mean_load = worker_loads.iter().sum::<f64>() / worker_loads.len() as f64;
+        if mean_load > 0.0 {
+            let variance = worker_loads
+                .iter()
+                .map(|load| (load - mean_load).powi(2))
+                .sum::<f64>()
+                / worker_loads.len() as f64;
+            metrics.worker_load_cov = variance.sqrt() / mean_load;
+        }
+
         metrics
     }
 }
@@ -204,6 +230,38 @@ fn record_request_metrics(metrics: &mut ChurnMetrics, request_metrics: RequestMe
         .push(request_metrics.adapter_unloads);
     metrics.per_tick_requests.push(request_metrics.requests);
     metrics.per_tick_hits.push(request_metrics.hits);
+    metrics
+        .per_tick_mean_occupancy
+        .push(request_metrics.mean_occupancy);
+    metrics
+        .per_tick_max_occupancy
+        .push(request_metrics.max_occupancy);
+    metrics
+        .per_tick_worker_load_cov
+        .push(request_metrics.worker_load_cov);
+}
+
+fn record_routing_metrics(
+    metrics: &mut ChurnMetrics,
+    routing_table: &LoraRoutingTable,
+    solve_ms: f64,
+) {
+    let configs = routing_table.snapshot_configs();
+    metrics.per_tick_active_loras.push(
+        configs
+            .iter()
+            .filter(|(_, config)| config.is_active)
+            .count(),
+    );
+    metrics.per_tick_routing_entries.push(configs.len());
+    metrics.per_tick_cold_start_entries.push(
+        configs
+            .iter()
+            .filter(|(_, config)| !config.is_active)
+            .count(),
+    );
+    metrics.per_tick_solve_ms.push(solve_ms);
+    metrics.per_tick_overflow_count.push(0);
 }
 
 /// Compute churn between two allocation snapshots
@@ -425,7 +483,9 @@ fn run_hrw_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> Chu
             }
         }
 
+        let solve_start = Instant::now();
         controller.recompute_now_at(now);
+        let solve_ms = solve_start.elapsed().as_secs_f64() * 1_000.0;
 
         // Snapshot current allocation
         let mut curr_snapshot: AllocationSnapshot = HashMap::new();
@@ -457,6 +517,7 @@ fn run_hrw_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> Chu
             *replica_dist.entry(replica_set.len()).or_insert(0) += 1;
         }
         metrics.per_tick_replica_dist.push(replica_dist);
+        record_routing_metrics(&mut metrics, &routing_table, solve_ms);
         let request_metrics = residency.serve_tick(
             schedules,
             tick,
@@ -533,6 +594,7 @@ fn run_random_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> 
                 },
             );
         }
+        record_routing_metrics(&mut metrics, &routing_table, 0.0);
         // Compute churn
         let (loads, unloads) = compute_churn(&prev_snapshot, &curr_snapshot);
         let tick_churn = loads + unloads;
@@ -624,7 +686,9 @@ fn run_mcf_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> Chu
             }
         }
 
+        let solve_start = Instant::now();
         controller.recompute_now_at(now);
+        let solve_ms = solve_start.elapsed().as_secs_f64() * 1_000.0;
 
         let mut curr_snapshot: AllocationSnapshot = HashMap::new();
         for lora_name in routing_table.list_loras() {
@@ -652,6 +716,7 @@ fn run_mcf_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> Chu
             *replica_dist.entry(replica_set.len()).or_insert(0) += 1;
         }
         metrics.per_tick_replica_dist.push(replica_dist);
+        record_routing_metrics(&mut metrics, &routing_table, solve_ms);
         let request_metrics = residency.serve_tick(
             schedules,
             tick,

--- a/lib/llm/tests/lora_simulation/support.rs
+++ b/lib/llm/tests/lora_simulation/support.rs
@@ -13,17 +13,19 @@
 //!
 //! Run with: `cargo test --test lora_simulation -- --nocapture`
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use dynamo_llm::kv_router::protocols::WorkerWithDpRank;
 use dynamo_llm::lora::config::LoraAllocationConfig;
 use dynamo_llm::lora::controller::LoraController;
+use dynamo_llm::lora::filter::LoraFilter;
 use dynamo_llm::lora::load_estimator::{LoadEstimator, LoadEstimatorConfig};
 use dynamo_llm::lora::routing::AllocationAlgorithmType;
-use dynamo_llm::lora::routing::table::LoraRoutingTable;
+use dynamo_llm::lora::routing::table::{LoraReplicaConfig, LoraRoutingTable};
 use dynamo_llm::lora::state_tracker::LoraStateTracker;
+use dynamo_llm::model_card::LoraInfo;
 
 use rand::SeedableRng;
 use rand::prelude::*;
@@ -98,6 +100,111 @@ impl RandomAllocator {
 
 /// Snapshot of the allocation state at a given tick
 type AllocationSnapshot = HashMap<String, Vec<WorkerWithDpRank>>;
+
+#[derive(Default)]
+struct RequestMetrics {
+    adapter_loads: usize,
+    adapter_unloads: usize,
+    requests: usize,
+    hits: usize,
+}
+
+/// Deterministic, capacity-bounded LRU residency model for simulated workers.
+struct ResidencyModel {
+    adapters: HashMap<WorkerWithDpRank, VecDeque<String>>,
+    next_candidate: HashMap<String, usize>,
+}
+
+impl ResidencyModel {
+    fn new(workers: &[WorkerWithDpRank]) -> Self {
+        Self {
+            adapters: workers
+                .iter()
+                .copied()
+                .map(|worker| (worker, VecDeque::new()))
+                .collect(),
+            next_candidate: HashMap::new(),
+        }
+    }
+
+    fn serve_tick(
+        &mut self,
+        schedules: &[LoraLoadSchedule],
+        tick: usize,
+        filter: &LoraFilter,
+        workers: &[WorkerWithDpRank],
+        state_tracker: &LoraStateTracker,
+        slots_per_backend: usize,
+    ) -> RequestMetrics {
+        let available_ids: Vec<u64> = workers.iter().map(|worker| worker.worker_id).collect();
+        let worker_by_id: HashMap<u64, WorkerWithDpRank> = workers
+            .iter()
+            .copied()
+            .map(|worker| (worker.worker_id, worker))
+            .collect();
+        let mut metrics = RequestMetrics::default();
+
+        for schedule in schedules {
+            for _ in 0..schedule.load_at_tick(tick) {
+                metrics.requests += 1;
+                let candidates =
+                    filter.filter_worker_ids_for_lora(Some(&schedule.lora_name), &available_ids);
+                let cursor = self
+                    .next_candidate
+                    .entry(schedule.lora_name.clone())
+                    .or_insert(0);
+                let candidate = candidates
+                    .get(*cursor % candidates.len())
+                    .copied()
+                    .expect("simulation requires at least one available worker");
+                *cursor += 1;
+                let worker = worker_by_id[&candidate];
+                let resident = self.adapters.entry(worker).or_default();
+
+                if state_tracker.is_loaded(&schedule.lora_name, &worker) {
+                    metrics.hits += 1;
+                    if let Some(position) =
+                        resident.iter().position(|name| name == &schedule.lora_name)
+                    {
+                        let name = resident.remove(position).expect("position came from deque");
+                        resident.push_back(name);
+                    }
+                    continue;
+                }
+
+                if resident.len() >= slots_per_backend {
+                    let evicted = resident
+                        .pop_front()
+                        .expect("full resident deque is non-empty");
+                    state_tracker.handle_mdc_removal(worker, &evicted);
+                    metrics.adapter_unloads += 1;
+                }
+                resident.push_back(schedule.lora_name.clone());
+                state_tracker.handle_mdc_addition(
+                    worker,
+                    &LoraInfo {
+                        name: schedule.lora_name.clone(),
+                        max_gpu_lora_count: Some(slots_per_backend as u32),
+                    },
+                );
+                metrics.adapter_loads += 1;
+            }
+        }
+
+        metrics
+    }
+}
+
+fn record_request_metrics(metrics: &mut ChurnMetrics, request_metrics: RequestMetrics) {
+    metrics
+        .per_tick_adapter_loads
+        .push(request_metrics.adapter_loads);
+    metrics
+        .per_tick_adapter_unloads
+        .push(request_metrics.adapter_unloads);
+    metrics.per_tick_requests.push(request_metrics.requests);
+    metrics.per_tick_hits.push(request_metrics.hits);
+}
 
 /// Compute churn between two allocation snapshots
 fn compute_churn(prev: &AllocationSnapshot, curr: &AllocationSnapshot) -> (usize, usize) {
@@ -299,6 +406,8 @@ fn run_hrw_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> Chu
     for &worker in &workers {
         state_tracker.set_worker_capacity(worker, config.slots_per_backend as u32);
     }
+    let filter = LoraFilter::new(routing_table.clone(), state_tracker.clone());
+    let mut residency = ResidencyModel::new(&workers);
 
     let mut metrics = ChurnMetrics::new("HRW");
     let mut prev_snapshot: AllocationSnapshot = HashMap::new();
@@ -348,6 +457,20 @@ fn run_hrw_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> Chu
             *replica_dist.entry(replica_set.len()).or_insert(0) += 1;
         }
         metrics.per_tick_replica_dist.push(replica_dist);
+        let request_metrics = residency.serve_tick(
+            schedules,
+            tick,
+            &filter,
+            &workers,
+            &state_tracker,
+            config.slots_per_backend,
+        );
+        record_request_metrics(&mut metrics, request_metrics);
+        for schedule in schedules {
+            for _ in 0..schedule.load_at_tick(tick) {
+                load_estimator.decrement_load_at(&schedule.lora_name, now);
+            }
+        }
 
         prev_snapshot = curr_snapshot;
     }
@@ -364,6 +487,13 @@ fn run_random_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> 
     let workers: Vec<WorkerWithDpRank> = (0..config.num_backends)
         .map(|i| WorkerWithDpRank::new(i as u64, 0))
         .collect();
+    let routing_table = LoraRoutingTable::new();
+    let state_tracker = LoraStateTracker::new();
+    for &worker in &workers {
+        state_tracker.set_worker_capacity(worker, config.slots_per_backend as u32);
+    }
+    let filter = LoraFilter::new(routing_table.clone(), state_tracker.clone());
+    let mut residency = ResidencyModel::new(&workers);
 
     let mut metrics = ChurnMetrics::new("Random");
     let mut prev_snapshot: AllocationSnapshot = HashMap::new();
@@ -386,6 +516,23 @@ fn run_random_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> 
             &workers,
             config.slots_per_backend,
         );
+        for lora_name in routing_table.list_loras() {
+            if !curr_snapshot.contains_key(&lora_name) {
+                routing_table.remove_lora(&lora_name);
+            }
+        }
+        for (lora_name, replica_set) in &curr_snapshot {
+            routing_table.update_allocation(
+                lora_name.clone(),
+                LoraReplicaConfig {
+                    lora_name: lora_name.clone(),
+                    replica_factor: replica_set.len(),
+                    replica_set: replica_set.clone(),
+                    updated_at: Instant::now(),
+                    is_active: true,
+                },
+            );
+        }
         // Compute churn
         let (loads, unloads) = compute_churn(&prev_snapshot, &curr_snapshot);
         let tick_churn = loads + unloads;
@@ -407,6 +554,17 @@ fn run_random_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> 
             *replica_dist.entry(replica_set.len()).or_insert(0) += 1;
         }
         metrics.per_tick_replica_dist.push(replica_dist);
+        record_request_metrics(
+            &mut metrics,
+            residency.serve_tick(
+                schedules,
+                tick,
+                &filter,
+                &workers,
+                &state_tracker,
+                config.slots_per_backend,
+            ),
+        );
 
         prev_snapshot = curr_snapshot;
     }
@@ -450,6 +608,8 @@ fn run_mcf_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> Chu
     for &worker in &workers {
         state_tracker.set_worker_capacity(worker, config.slots_per_backend as u32);
     }
+    let filter = LoraFilter::new(routing_table.clone(), state_tracker.clone());
+    let mut residency = ResidencyModel::new(&workers);
 
     let mut metrics = ChurnMetrics::new("MCF");
     let mut prev_snapshot: AllocationSnapshot = HashMap::new();
@@ -492,6 +652,20 @@ fn run_mcf_simulation(config: &SimConfig, schedules: &[LoraLoadSchedule]) -> Chu
             *replica_dist.entry(replica_set.len()).or_insert(0) += 1;
         }
         metrics.per_tick_replica_dist.push(replica_dist);
+        let request_metrics = residency.serve_tick(
+            schedules,
+            tick,
+            &filter,
+            &workers,
+            &state_tracker,
+            config.slots_per_backend,
+        );
+        record_request_metrics(&mut metrics, request_metrics);
+        for schedule in schedules {
+            for _ in 0..schedule.load_at_tick(tick) {
+                load_estimator.decrement_load_at(&schedule.lora_name, now);
+            }
+        }
 
         prev_snapshot = curr_snapshot;
     }

--- a/lib/llm/tests/lora_simulation/workloads.rs
+++ b/lib/llm/tests/lora_simulation/workloads.rs
@@ -37,6 +37,12 @@ struct SimConfig {
     lifetime_stddev: f64,
     /// Random seed for reproducibility
     seed: u64,
+    /// Seconds represented by each simulation tick.
+    timestep_secs: u64,
+    /// Multiplier used to derive the controller's sliding rate window.
+    rate_window_multiplier: u64,
+    /// Number of control ticks to defer scale-down decisions.
+    scale_down_cooldown_ticks: u32,
 }
 
 impl SimConfig {
@@ -65,6 +71,9 @@ impl Default for SimConfig {
             lifetime_mean: 0,
             lifetime_stddev: 0.0,
             seed: 42,
+            timestep_secs: 3,
+            rate_window_multiplier: 30,
+            scale_down_cooldown_ticks: 3,
         }
     }
 }

--- a/lib/llm/tests/lora_simulation/workloads.rs
+++ b/lib/llm/tests/lora_simulation/workloads.rs
@@ -112,6 +112,14 @@ struct ChurnMetrics {
     /// Per-tick replica distribution: `per_tick_replica_dist[tick]` is a map from
     /// replica_count → number of LoRAs with that replica count at that tick.
     per_tick_replica_dist: Vec<HashMap<usize, usize>>,
+    /// Physical adapter loads observed on request routing misses.
+    per_tick_adapter_loads: Vec<usize>,
+    /// Physical adapter unloads caused by capacity-bounded LRU eviction.
+    per_tick_adapter_unloads: Vec<usize>,
+    /// Requests issued through the LoRA filter.
+    per_tick_requests: Vec<usize>,
+    /// Requests routed to a worker where the adapter was already resident.
+    per_tick_hits: Vec<usize>,
 }
 
 impl ChurnMetrics {
@@ -130,6 +138,10 @@ impl ChurnMetrics {
             per_tick_lora_removals: Vec::new(),
             total_lora_additions: 0,
             total_lora_removals: 0,
+            per_tick_adapter_loads: Vec::new(),
+            per_tick_adapter_unloads: Vec::new(),
+            per_tick_requests: Vec::new(),
+            per_tick_hits: Vec::new(),
         }
     }
 

--- a/lib/llm/tests/lora_simulation/workloads.rs
+++ b/lib/llm/tests/lora_simulation/workloads.rs
@@ -120,6 +120,19 @@ struct ChurnMetrics {
     per_tick_requests: Vec<usize>,
     /// Requests routed to a worker where the adapter was already resident.
     per_tick_hits: Vec<usize>,
+    /// Mean and maximum resident slots across workers after each tick.
+    per_tick_mean_occupancy: Vec<f64>,
+    per_tick_max_occupancy: Vec<usize>,
+    /// Coefficient of variation of requests served per worker in each tick.
+    per_tick_worker_load_cov: Vec<f64>,
+    /// Routing-table state after each control tick.
+    per_tick_active_loras: Vec<usize>,
+    per_tick_routing_entries: Vec<usize>,
+    per_tick_cold_start_entries: Vec<usize>,
+    /// Controller recompute latency. This is solver latency for MCF and full recompute latency
+    /// for the non-MCF algorithms.
+    per_tick_solve_ms: Vec<f64>,
+    per_tick_overflow_count: Vec<usize>,
 }
 
 impl ChurnMetrics {
@@ -142,6 +155,14 @@ impl ChurnMetrics {
             per_tick_adapter_unloads: Vec::new(),
             per_tick_requests: Vec::new(),
             per_tick_hits: Vec::new(),
+            per_tick_mean_occupancy: Vec::new(),
+            per_tick_max_occupancy: Vec::new(),
+            per_tick_worker_load_cov: Vec::new(),
+            per_tick_active_loras: Vec::new(),
+            per_tick_routing_entries: Vec::new(),
+            per_tick_cold_start_entries: Vec::new(),
+            per_tick_solve_ms: Vec::new(),
+            per_tick_overflow_count: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary
- drive the LoRA allocation simulation with a deterministic virtual clock and production-style rate window
- route simulated requests through `LoraFilter` and model capacity-bounded adapter residency
- export route churn, adapter churn, hits, occupancy, imbalance, and recompute-latency metrics

## Validation
- `cargo test -p dynamo-llm --test lora_simulation`
- `cargo clippy -p dynamo-llm --test lora_simulation -- -D warnings`
- `cargo test -p dynamo-llm --test lora_simulation -- test_export_csv --ignored --nocapture`

## Follow-up
The multi-seed ablation, topology, and solver-scaling experiments are intentionally left as follow-up work; the current export records the corrected single-seed baseline measurements.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added version 2 simulation CSV exports with detailed time-series and scenario metrics, including routing, occupancy, cache hits, churn, solver latency, and overflow data.
  - Added configurable simulation timing, rate windows, and scale-down cooldowns.
  - Added request-residency tracking with deterministic cache eviction and worker-balance metrics.

- **Bug Fixes**
  - Improved consistency of load and allocation calculations by using synchronized timestamps.
  - Improved sparse-load routing and repeated-request residency behavior.

- **Tests**
  - Added coverage for sparse workloads, request residency, routing metrics, and simulation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->