### PR TITLE
build(snapshot): drop the unused Nsight efa_metrics sampler from the agent image

### DIFF
--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -217,6 +217,27 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     util-linux \
     && rm -rf /var/lib/apt/lists/*
 
+# The CUDA base ships an optional efa_metrics sampler under the Nsight Systems
+# CLI, for EFA network counters. Nothing in the Dynamo tree references it, and
+# AWS EFA confirmed on 2026-08-18 that they do not use it. It is a static Go
+# binary, so it carries its own copy of the Go standard library and is the sole
+# carrier for every Critical and High finding on this image, 36 in total.
+#
+# Removed in agent_pre so the agent, licenses and sources_collect stages all
+# inherit it. The glob spans the CUDA version, the Nsight version and the target
+# architecture, all of which move with AGENT_BASE_IMAGE.
+#
+# The guard is the point of the change, not decoration: a glob that silently
+# matches nothing after a base bump would leave the findings in place while the
+# build stayed green.
+RUN rm -rf /usr/local/cuda-*/NsightSystems-cli-*/target-linux-*/plugins/efa_metrics; \
+    if find /usr/local -type d -name efa_metrics 2>/dev/null | grep -q .; then \
+        echo "ERROR: an efa_metrics plugin directory survived removal; the glob no" >&2; \
+        echo "       longer matches the base image's Nsight layout." >&2; \
+        find /usr/local -type d -name efa_metrics >&2; \
+        exit 1; \
+    fi
+
 # Copy CRIU from builder
 COPY --from=criu-builder /criu-install/usr/local /usr/local
 COPY --from=criu-builder /tmp/criu/COPYING /legal/CRIU/COPYING


### PR DESCRIPTION
Companion to #13746, covering the image that PR could not reach.

## Why this is a separate PR with no main counterpart

`deploy/snapshot/` was removed from `main` for 1.5.0, so **1.4.2 is the last release that builds this image**. There is nothing to land on main and nothing to cherry-pick from; this targets `release/1.4.2` directly.

## The finding

`AGENT_BASE_IMAGE` is `cuda-dl-base:25.11-cuda13.0-devel-ubuntu24.04`, which ships an optional `efa_metrics` plugin under the Nsight Systems CLI:

```
/usr/local/cuda-13.0/NsightSystems-cli-2025.5.1/target-linux-x64/plugins/efa_metrics/nic_sampler
```

Nothing in the Dynamo tree references it. AWS EFA confirmed on 2026-08-18 that they do not use it.

It is a static Go binary, so it carries its own copy of the Go standard library.

## Impact, measured against the 1.4.1 scan

| | count |
|---|---|
| Critical/High findings touching the plugin | 36 |
| **sole-carrier, clear on removal** | **36** |
| blocked by another carrier | 0 |

Every finding on this image is carried by that one binary and nothing else. That set includes **all three Criticals in 1.4.2 scope**, two of which — `GO-2025-3563` and `GO-2026-4337` — appear on no other image and so cannot clear anywhere else.

For contrast, the equivalent change on `tensorrtllm-runtime` (#13746) clears 17 of 24, with the remainder sharing a carrier with the mooncake wheel.

## Placement

Removed in `agent_pre` so the `agent`, `licenses` and `sources_collect` stages all inherit it. This Dockerfile has no `runtime_full`-style overlay, so the whiteout ordering concern that applies to #13746 does not apply here.

## The guard

The glob spans the CUDA version, the Nsight version and the target architecture, all of which move with `AGENT_BASE_IMAGE`. A glob that silently stops matching is the real risk, so the change asserts its own post-condition and fails the build if any `efa_metrics` directory survives.

## Verification

Not build-verified locally. CI builds the image, and the guard turns a non-matching glob into a build failure rather than a silent no-op.

Related: DYN-4021
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->