### PR TITLE
fix(operator): wait for frontend admission during rollout

### DIFF
--- a/deploy/helm/charts/platform/components/operator/files/manager-role.yaml
+++ b/deploy/helm/charts/platform/components/operator/files/manager-role.yaml
@@ -290,6 +290,14 @@ rules:
 - apiGroups:
   - nvidia.com
   resources:
+  - dynamoworkermetadatas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - nvidia.com
+  resources:
   - podsnapshots
   verbs:
   - create

--- a/deploy/operator/config/rbac/role.yaml
+++ b/deploy/operator/config/rbac/role.yaml
@@ -290,6 +290,14 @@ rules:
 - apiGroups:
   - nvidia.com
   resources:
+  - dynamoworkermetadatas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - nvidia.com
+  resources:
   - podsnapshots
   verbs:
   - create

--- a/deploy/operator/internal/controller/dgd_frontend_admission.go
+++ b/deploy/operator/internal/controller/dgd_frontend_admission.go
@@ -1,0 +1,291 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
+)
+
+const (
+	frontendModelAdmissionTopic    = "frontend-model-admission"
+	frontendModelAdmissionProtocol = "v1"
+)
+
+var (
+	dynamoWorkerMetadataGVK = schema.GroupVersionKind{
+		Group: "nvidia.com", Version: "v1alpha1", Kind: "DynamoWorkerMetadata",
+	}
+	dynamoWorkerMetadataListGVK = schema.GroupVersionKind{
+		Group: "nvidia.com", Version: "v1alpha1", Kind: "DynamoWorkerMetadataList",
+	}
+)
+
+type frontendAdmissionSnapshot struct {
+	capable bool
+	members map[string]struct{}
+}
+
+func newDynamoWorkerMetadata() *unstructured.Unstructured {
+	metadata := &unstructured.Unstructured{}
+	metadata.SetGroupVersionKind(dynamoWorkerMetadataGVK)
+	return metadata
+}
+
+func newDynamoWorkerMetadataList() *unstructured.UnstructuredList {
+	metadata := &unstructured.UnstructuredList{}
+	metadata.SetGroupVersionKind(dynamoWorkerMetadataListGVK)
+	return metadata
+}
+
+func (r *DynamoGraphDeploymentReconciler) mapDynamoWorkerMetadataToDGDRequests(
+	ctx context.Context,
+	obj client.Object,
+) []ctrl.Request {
+	for _, owner := range obj.GetOwnerReferences() {
+		if owner.APIVersion != "v1" || owner.Kind != "Pod" || owner.Name == "" {
+			continue
+		}
+		pod := &corev1.Pod{}
+		if err := r.Get(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: owner.Name}, pod); err != nil {
+			return nil
+		}
+		dgdName := pod.Labels[consts.KubeLabelDynamoGraphDeploymentName]
+		if dgdName == "" {
+			return nil
+		}
+		return []ctrl.Request{{NamespacedName: types.NamespacedName{
+			Namespace: obj.GetNamespace(),
+			Name:      dgdName,
+		}}}
+	}
+	return nil
+}
+
+func dgdHasServingFrontend(dgd *nvidiacomv1beta1.DynamoGraphDeployment) bool {
+	for i := range dgd.Spec.Components {
+		component := &dgd.Spec.Components[i]
+		if string(component.ComponentType) != consts.ComponentTypeFrontend {
+			continue
+		}
+		replicas := int32(1)
+		if component.Replicas != nil {
+			replicas = *component.Replicas
+		}
+		if replicas > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func podReadyForTraffic(pod *corev1.Pod) bool {
+	if !pod.DeletionTimestamp.IsZero() || isTerminalPhase(pod.Status.Phase) {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func metadataByOwningPod(items []unstructured.Unstructured) map[string][]unstructured.Unstructured {
+	byPod := make(map[string][]unstructured.Unstructured)
+	for i := range items {
+		metadata := items[i]
+		for _, owner := range metadata.GetOwnerReferences() {
+			if owner.APIVersion == "v1" && owner.Kind == "Pod" && owner.Name != "" {
+				byPod[owner.Name] = append(byPod[owner.Name], metadata)
+				break
+			}
+		}
+	}
+	return byPod
+}
+
+func frontendAdmissionFromMetadata(
+	items []unstructured.Unstructured,
+	runtimeNamespace string,
+) frontendAdmissionSnapshot {
+	snapshot := frontendAdmissionSnapshot{members: make(map[string]struct{})}
+	for i := range items {
+		sources, found, _ := unstructured.NestedMap(
+			items[i].Object, "spec", "data", "event_sources",
+		)
+		if !found {
+			continue
+		}
+		for _, rawSource := range sources {
+			source, ok := rawSource.(map[string]any)
+			if !ok || source["topic"] != frontendModelAdmissionTopic {
+				continue
+			}
+			metadata, ok := source["metadata"].(map[string]any)
+			if !ok || metadata["protocol"] != frontendModelAdmissionProtocol {
+				continue
+			}
+			if capability, ok := metadata["capability"].(bool); ok && capability {
+				snapshot.capable = true
+			}
+			scope, ok := source["scope"].(map[string]any)
+			if !ok || scope["kind"] != "namespace" || scope["name"] != runtimeNamespace {
+				continue
+			}
+			members, ok := metadata["members"].([]any)
+			if !ok {
+				continue
+			}
+			for _, member := range members {
+				if member, ok := member.(string); ok {
+					snapshot.members[member] = struct{}{}
+				}
+			}
+		}
+	}
+	return snapshot
+}
+
+func baseModelCardsFromMetadata(
+	items []unstructured.Unstructured,
+	runtimeNamespace string,
+) map[string]struct{} {
+	cards := make(map[string]struct{})
+	for i := range items {
+		modelCards, found, _ := unstructured.NestedMap(
+			items[i].Object, "spec", "data", "model_cards",
+		)
+		if !found {
+			continue
+		}
+		for path, rawCard := range modelCards {
+			card, ok := rawCard.(map[string]any)
+			if !ok || card["type"] != "Model" || card["namespace"] != runtimeNamespace {
+				continue
+			}
+			if suffix, present := card["model_suffix"]; present && suffix != nil {
+				continue
+			}
+			cards[path] = struct{}{}
+		}
+	}
+	return cards
+}
+
+func containsAllMembers(admitted, required map[string]struct{}) bool {
+	for member := range required {
+		if _, ok := admitted[member]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// frontendAdmittedReplicas returns how many locally available replacement
+// workers every traffic-serving frontend has committed. The second return
+// value is false for older frontends that do not advertise this protocol, so
+// an operator-only upgrade preserves the legacy rollout behavior.
+func (r *dgdWorkerRolloutReconciler) frontendAdmittedReplicas(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	newDCD *nvidiacomv1beta1.DynamoComponentDeployment,
+	locallyAvailable int32,
+) (int32, bool, error) {
+	if locallyAvailable == 0 || !dgdHasServingFrontend(dgd) {
+		return locallyAvailable, false, nil
+	}
+
+	metadataList := newDynamoWorkerMetadataList()
+	if err := r.List(ctx, metadataList, client.InNamespace(dgd.Namespace)); err != nil {
+		if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
+			return locallyAvailable, false, nil
+		}
+		return 0, true, err
+	}
+	metadataByPod := metadataByOwningPod(metadataList.Items)
+	runtimeNamespace := dynamo.GetDCDRuntimeNamespace(newDCD)
+	if newDCD.Status.Component != nil && newDCD.Status.Component.RuntimeNamespace != "" {
+		runtimeNamespace = newDCD.Status.Component.RuntimeNamespace
+	}
+
+	frontendPods := &corev1.PodList{}
+	if err := r.List(ctx, frontendPods,
+		client.InNamespace(dgd.Namespace),
+		client.MatchingLabels{
+			consts.KubeLabelDynamoGraphDeploymentName: dgd.Name,
+			consts.KubeLabelDynamoComponentType:       consts.ComponentTypeFrontend,
+		},
+	); err != nil {
+		return 0, true, err
+	}
+	frontends := make([]frontendAdmissionSnapshot, 0, len(frontendPods.Items))
+	protocolActive := false
+	for i := range frontendPods.Items {
+		pod := &frontendPods.Items[i]
+		if !podReadyForTraffic(pod) {
+			continue
+		}
+		snapshot := frontendAdmissionFromMetadata(metadataByPod[pod.Name], runtimeNamespace)
+		protocolActive = protocolActive || snapshot.capable
+		frontends = append(frontends, snapshot)
+	}
+	if !protocolActive {
+		return locallyAvailable, false, nil
+	}
+	for _, frontend := range frontends {
+		if !frontend.capable {
+			return 0, true, nil
+		}
+	}
+
+	workerPods := &corev1.PodList{}
+	if err := r.List(ctx, workerPods,
+		client.InNamespace(dgd.Namespace),
+		client.MatchingLabels{
+			consts.KubeLabelDynamoGraphDeploymentName: dgd.Name,
+			consts.KubeLabelDynamoComponent:           dynamo.GetDCDComponentName(newDCD),
+			consts.KubeLabelDynamoWorkerHash:          newDCD.Labels[consts.KubeLabelDynamoWorkerHash],
+		},
+	); err != nil {
+		return 0, true, err
+	}
+
+	var admitted int32
+	for i := range workerPods.Items {
+		pod := &workerPods.Items[i]
+		if !podReadyForTraffic(pod) {
+			continue
+		}
+		cards := baseModelCardsFromMetadata(metadataByPod[pod.Name], runtimeNamespace)
+		if len(cards) == 0 {
+			continue
+		}
+		admittedByAll := true
+		for _, frontend := range frontends {
+			if !containsAllMembers(frontend.members, cards) {
+				admittedByAll = false
+				break
+			}
+		}
+		if admittedByAll {
+			admitted++
+		}
+	}
+	return min(admitted, locallyAvailable), true, nil
+}

--- a/deploy/operator/internal/controller/dgd_worker_rollout_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_worker_rollout_reconciler.go
@@ -1505,10 +1505,12 @@ func (r *dgdWorkerRolloutReconciler) buildRollingUpdateContext(
 		}
 
 		var newState dcdComponentState
+		var newDCDExists bool
 		newDCDName := dynamo.GetDCDResourceName(dgd, componentName, newWorkerHash)
 		newDCD := &nvidiacomv1beta1.DynamoComponentDeployment{}
 		if err := r.Get(ctx, types.NamespacedName{Name: newDCDName, Namespace: dgd.Namespace}, newDCD); err == nil {
 			newState = dcdComponentStateFromDCD(newDCD)
+			newDCDExists = true
 		} else if !apierrors.IsNotFound(err) {
 			return dynamo.RollingUpdateContext{}, fmt.Errorf("failed to get new worker DCD %s: %w", newDCDName, err)
 		}
@@ -1536,18 +1538,41 @@ func (r *dgdWorkerRolloutReconciler) buildRollingUpdateContext(
 		default:
 			maxSurge, maxUnavailable = resolveRollingUpdateParams(annotations, desired)
 			minAvailable = desired - maxUnavailable
+			rolloutNewState := newState
+			frontendAdmissionActive := false
+			if newDCDExists && newState.Available > 0 {
+				admitted, active, err := r.frontendAdmittedReplicas(
+					ctx, dgd, newDCD, newState.Available,
+				)
+				if err != nil {
+					return dynamo.RollingUpdateContext{}, fmt.Errorf(
+						"check frontend admission for new worker DCD %s: %w", newDCDName, err,
+					)
+				}
+				frontendAdmissionActive = active
+				if active {
+					rolloutNewState.Available = admitted
+				}
+			}
 
-			newUnavailable := max(int32(0), newState.Spec-newState.Available)
+			newUnavailable := max(int32(0), rolloutNewState.Spec-rolloutNewState.Available)
 			// maxScaledDown is the maximum number of old replicas that can be scaled down
-			maxScaledDown := max(int32(0), (oldState.Spec+newState.Spec)-minAvailable-newUnavailable)
+			maxScaledDown := max(int32(0), (oldState.Spec+rolloutNewState.Spec)-minAvailable-newUnavailable)
 			oldUnhealthy := max(int32(0), oldState.Spec-oldState.Available)
 			// availableSurplus is how many extra available replicas we have above minAvailable (min 0)
-			availableSurplus := max(int32(0), (oldState.Available+newState.Available)-minAvailable)
+			availableSurplus := max(int32(0), (oldState.Available+rolloutNewState.Available)-minAvailable)
 			oldTarget = max(int32(0), oldState.Spec-min(maxScaledDown, oldUnhealthy+availableSurplus))
 
 			// Surge budget uses Spec (declared intent) like K8s Deployment controller; scheduler enforces actual resource constraints.
 			scaleUpBudget := max(int32(0), desired+maxSurge-oldState.Spec-newState.Spec)
 			newTarget = min(desired, newState.Spec+scaleUpBudget)
+
+			if frontendAdmissionActive && rolloutNewState.Available < newState.Available {
+				logger.V(1).Info("Waiting for frontend admission before scaling down old workers",
+					"component", componentName,
+					"locallyAvailable", newState.Available,
+					"frontendAdmitted", rolloutNewState.Available)
+			}
 		}
 
 		oldWorkerComponentReplicas[componentName] = oldTarget

--- a/deploy/operator/internal/controller/dgd_worker_rollout_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_worker_rollout_reconciler_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
@@ -3904,7 +3905,7 @@ func TestListDGDComponentPodsUsesCompositeIndex(t *testing.T) {
 	assert.Equal(t, []string{"matching-a", "matching-b"}, names)
 }
 
-func TestDGDWorkerPodEventPredicate(t *testing.T) {
+func TestDGDRolloutPodEventPredicate(t *testing.T) {
 	newPod := func(phase corev1.PodPhase) *corev1.Pod {
 		return &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -3921,7 +3922,7 @@ func TestDGDWorkerPodEventPredicate(t *testing.T) {
 		}
 	}
 
-	pred := dgdWorkerPodEventPredicate()
+	pred := dgdRolloutPodEventPredicate()
 	running := newPod(corev1.PodRunning)
 	failed := newPod(corev1.PodFailed)
 	succeeded := newPod(corev1.PodSucceeded)
@@ -3931,11 +3932,16 @@ func TestDGDWorkerPodEventPredicate(t *testing.T) {
 	delete(unrelated.Labels, consts.KubeLabelDynamoSelector)
 	frontend := running.DeepCopy()
 	frontend.Labels[consts.KubeLabelDynamoComponentType] = consts.ComponentTypeFrontend
+	delete(frontend.Labels, consts.KubeLabelDynamoSelector)
+	readyFrontend := frontend.DeepCopy()
+	readyFrontend.Status.Conditions = []corev1.PodCondition{{
+		Type: corev1.PodReady, Status: corev1.ConditionTrue,
+	}}
 	moved := running.DeepCopy()
 	moved.Labels[consts.KubeLabelDynamoSelector] = "another-old-worker"
 
 	assert.True(t, pred.Create(event.CreateEvent{Object: running}), "pod creation changes drain membership")
-	assert.False(t, pred.Create(event.CreateEvent{Object: frontend}), "non-worker pods must be ignored")
+	assert.True(t, pred.Create(event.CreateEvent{Object: frontend}), "frontend creation changes admission membership")
 	assert.True(t, pred.Delete(event.DeleteEvent{Object: running}), "pod deletion can unblock a drain")
 	assert.False(t, pred.Delete(event.DeleteEvent{Object: unrelated}), "unmanaged pods must be ignored")
 	assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: running, ObjectNew: failed}), "transition to Failed can unblock a drain")
@@ -3944,10 +3950,12 @@ func TestDGDWorkerPodEventPredicate(t *testing.T) {
 	assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: failed, ObjectNew: succeeded}), "terminal-to-terminal transitions are irrelevant")
 	assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: running, ObjectNew: moved}), "selector changes move the pod between drain memberships")
 	assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: unrelated, ObjectNew: running}), "becoming a managed worker pod changes drain membership")
+	assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: frontend, ObjectNew: readyFrontend}), "frontend readiness changes admission")
+	assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: frontend, ObjectNew: frontend.DeepCopy()}), "unchanged frontend readiness is irrelevant")
 	assert.False(t, pred.Generic(event.GenericEvent{Object: running}))
 }
 
-func TestMapDGDWorkerPodToRequests(t *testing.T) {
+func TestMapDGDRolloutPodToRequests(t *testing.T) {
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 		Name:      "worker",
 		Namespace: "default",
@@ -3959,12 +3967,16 @@ func TestMapDGDWorkerPodToRequests(t *testing.T) {
 		},
 	}}
 
-	requests := mapDGDWorkerPodToRequests(context.Background(), pod)
+	requests := mapDGDRolloutPodToRequests(context.Background(), pod)
 	require.Len(t, requests, 1)
 	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "test-dgd"}, requests[0].NamespacedName)
 
+	pod.Labels[consts.KubeLabelDynamoComponentType] = consts.ComponentTypeFrontend
+	delete(pod.Labels, consts.KubeLabelDynamoSelector)
+	assert.Len(t, mapDGDRolloutPodToRequests(context.Background(), pod), 1)
+
 	delete(pod.Labels, consts.KubeLabelDynamoGraphDeploymentName)
-	assert.Empty(t, mapDGDWorkerPodToRequests(context.Background(), pod))
+	assert.Empty(t, mapDGDRolloutPodToRequests(context.Background(), pod))
 }
 
 // --- reconcileRollingUpdate state machine tests ---
@@ -4787,6 +4799,161 @@ func TestBuildRollingUpdateContext_NoNewDCDExists(t *testing.T) {
 	// Math runs with newState={0,0,0}: drain old to minAvailable, surge new from zero.
 	assert.Equal(t, int32(8), result.OldWorkerReplicaTargetsByComponent["worker"])
 	assert.Equal(t, int32(3), result.NewWorkerReplicaTargetsByComponent["worker"])
+}
+
+func TestBuildRollingUpdateContext_WaitsForEveryFrontendToAdmitNewWorker(t *testing.T) {
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"frontend": {
+			ComponentType: consts.ComponentTypeFrontend,
+			Replicas:      ptr.To(int32(2)),
+		},
+		"worker": {
+			ComponentType: consts.ComponentTypeWorker,
+			Replicas:      ptr.To(int32(2)),
+			Annotations: map[string]string{
+				KubeAnnotationDeploymentRollingUpdateMaxSurge:       "0",
+				KubeAnnotationDeploymentRollingUpdateMaxUnavailable: "1",
+			},
+		},
+	})
+	dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHashV2: testOldWorkerHash}
+	newHash := betaDGDWorkersSpecHash(t, dgd)
+	runtimeNamespace := "test-dgd-" + newHash[:8]
+
+	makeDCD := func(hash string, replicas, available int32) *nvidiacomv1beta1.DynamoComponentDeployment {
+		dcd := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dynamo.GetDCDResourceName(dgd, "worker", hash),
+				Namespace: dgd.Namespace,
+				Labels: map[string]string{
+					consts.KubeLabelDynamoGraphDeploymentName: dgd.Name,
+					consts.KubeLabelDynamoWorkerHash:          hash,
+				},
+			},
+			Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+				DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+					ComponentType: consts.ComponentTypeWorker,
+					ServiceName:   "worker",
+					Replicas:      ptr.To(replicas),
+				},
+			},
+			Status: nvidiacomv1alpha1.DynamoComponentDeploymentStatus{
+				Service: &nvidiacomv1alpha1.ServiceReplicaStatus{
+					Replicas:          replicas,
+					AvailableReplicas: ptr.To(available),
+				},
+			},
+		})
+		if hash == newHash {
+			dcd.Status.Component.RuntimeNamespace = runtimeNamespace
+		}
+		return dcd
+	}
+	readyPod := func(name, component, componentType, hash string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: dgd.Namespace,
+				UID:       types.UID(name + "-uid"),
+				Labels: map[string]string{
+					consts.KubeLabelDynamoGraphDeploymentName: dgd.Name,
+					consts.KubeLabelDynamoComponent:           component,
+					consts.KubeLabelDynamoComponentType:       componentType,
+					consts.KubeLabelDynamoWorkerHash:          hash,
+					consts.KubeLabelDynamoSelector:            dgd.Name + "-" + component,
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{{
+					Type: corev1.PodReady, Status: corev1.ConditionTrue,
+				}},
+			},
+		}
+	}
+	makeMetadata := func(pod *corev1.Pod, data map[string]any) *unstructured.Unstructured {
+		metadata := newDynamoWorkerMetadata()
+		metadata.SetName(pod.Name)
+		metadata.SetNamespace(pod.Namespace)
+		metadata.SetOwnerReferences([]metav1.OwnerReference{{
+			APIVersion: "v1", Kind: "Pod", Name: pod.Name, UID: pod.UID,
+		}})
+		metadata.Object["spec"] = map[string]any{"data": data}
+		return metadata
+	}
+	capability := func() map[string]any {
+		return map[string]any{
+			"type": "EventSource", "topic": frontendModelAdmissionTopic,
+			"scope": map[string]any{"kind": "namespace", "name": dgd.Name},
+			"metadata": map[string]any{
+				"protocol": frontendModelAdmissionProtocol, "capability": true,
+			},
+		}
+	}
+	admission := func(member string) map[string]any {
+		return map[string]any{
+			"type": "EventSource", "topic": frontendModelAdmissionTopic,
+			"scope": map[string]any{"kind": "namespace", "name": runtimeNamespace},
+			"metadata": map[string]any{
+				"protocol": frontendModelAdmissionProtocol,
+				"members":  []any{member},
+			},
+		}
+	}
+
+	oldDCD := makeDCD(testOldWorkerHash, 1, 1)
+	newDCD := makeDCD(newHash, 1, 1)
+	workerPod := readyPod("new-worker", "worker", consts.ComponentTypeWorker, newHash)
+	frontendA := readyPod("frontend-a", "frontend", consts.ComponentTypeFrontend, "")
+	frontendB := readyPod("frontend-b", "frontend", consts.ComponentTypeFrontend, "")
+	modelCardPath := runtimeNamespace + "/backend/generate/101"
+	workerMetadata := makeMetadata(workerPod, map[string]any{
+		"model_cards": map[string]any{
+			modelCardPath: map[string]any{
+				"type": "Model", "namespace": runtimeNamespace,
+			},
+		},
+	})
+	frontendAMetadata := makeMetadata(frontendA, map[string]any{
+		"event_sources": map[string]any{
+			"capability": capability(), "group": admission(modelCardPath),
+		},
+	})
+	frontendBMetadata := makeMetadata(frontendB, map[string]any{
+		"event_sources": map[string]any{"capability": capability()},
+	})
+
+	r := createTestReconcilerWithStatus(dgd, withObjects(
+		oldDCD, newDCD, workerPod, frontendA, frontendB,
+		workerMetadata, frontendAMetadata, frontendBMetadata,
+	))
+
+	t.Log("Keep the last old worker while one ready frontend has not committed the replacement")
+	result, err := r.buildRollingUpdateContext(context.Background(), dgd)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), result.OldWorkerReplicaTargetsByComponent["worker"])
+
+	t.Log("Allow scale-down after every ready frontend publishes the exact replacement model card")
+	frontendBMetadata.Object["spec"] = map[string]any{"data": map[string]any{
+		"event_sources": map[string]any{
+			"capability": capability(), "group": admission(modelCardPath),
+		},
+	}}
+	require.NoError(t, r.Update(context.Background(), frontendBMetadata))
+	result, err = r.buildRollingUpdateContext(context.Background(), dgd)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), result.OldWorkerReplicaTargetsByComponent["worker"])
+
+	t.Log("Preserve legacy rollout behavior when no frontend advertises the admission protocol")
+	for _, metadata := range []*unstructured.Unstructured{frontendAMetadata, frontendBMetadata} {
+		metadata.Object["spec"] = map[string]any{"data": map[string]any{
+			"event_sources": map[string]any{},
+		}}
+		require.NoError(t, r.Update(context.Background(), metadata))
+	}
+	result, err = r.buildRollingUpdateContext(context.Background(), dgd)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), result.OldWorkerReplicaTargetsByComponent["worker"])
 }
 
 func TestBuildRollingUpdateContext_ListOldDCDsError(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -27,6 +27,7 @@ import (
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/events"
@@ -84,6 +85,7 @@ type DynamoGraphDeploymentReconciler struct {
 // +kubebuilder:rbac:groups=nvidia.com,resources=dynamographdeployments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=nvidia.com,resources=dynamographdeployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=nvidia.com,resources=dynamographdeploymentscalingadapters,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=nvidia.com,resources=dynamoworkermetadatas,verbs=get;list;watch
 // +kubebuilder:rbac:groups=grove.io,resources=podcliquesets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=grove.io,resources=podcliques,verbs=get;list;watch
 // +kubebuilder:rbac:groups=grove.io,resources=podcliques/scale,verbs=get;update;patch
@@ -256,8 +258,8 @@ func (r *DynamoGraphDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) err
 		).
 		Watches(
 			&corev1.Pod{},
-			handler.EnqueueRequestsFromMapFunc(mapDGDWorkerPodToRequests),
-			builder.WithPredicates(dgdWorkerPodEventPredicate()),
+			handler.EnqueueRequestsFromMapFunc(mapDGDRolloutPodToRequests),
+			builder.WithPredicates(dgdRolloutPodEventPredicate()),
 		).
 		Owns(&nvidiacomv1beta1.DynamoComponentDeployment{}, builder.WithPredicates(predicate.Funcs{
 			// ignore creation cause we don't want to be called again after we create the deployment
@@ -291,6 +293,23 @@ func (r *DynamoGraphDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) err
 			GenericFunc: func(ge event.GenericEvent) bool { return true },
 		})).
 		WithEventFilter(deploymentEventFilter(r.Config, r.RuntimeConfig))
+	if _, err := mgr.GetRESTMapper().RESTMapping(dynamoWorkerMetadataGVK.GroupKind(), dynamoWorkerMetadataGVK.Version); err != nil {
+		if !meta.IsNoMatchError(err) {
+			return fmt.Errorf("discover DynamoWorkerMetadata API: %w", err)
+		}
+		log.Log.Info("DynamoWorkerMetadata API unavailable; using legacy rollout availability")
+	} else {
+		ctrlBuilder = ctrlBuilder.Watches(
+			newDynamoWorkerMetadata(),
+			handler.EnqueueRequestsFromMapFunc(r.mapDynamoWorkerMetadataToDGDRequests),
+			builder.WithPredicates(predicate.Funcs{
+				CreateFunc:  func(ce event.CreateEvent) bool { return true },
+				DeleteFunc:  func(de event.DeleteEvent) bool { return true },
+				UpdateFunc:  func(ue event.UpdateEvent) bool { return true },
+				GenericFunc: func(ge event.GenericEvent) bool { return false },
+			}),
+		)
+	}
 	if r.RuntimeConfig.Gate.Enabled(features.DRA) {
 		ctrlBuilder = ctrlBuilder.Watches(
 			&resourcev1.ResourceClaim{},
@@ -329,16 +348,22 @@ func (r *DynamoGraphDeploymentReconciler) GetRecorder() events.EventRecorder {
 	return r.Recorder
 }
 
-func isDGDManagedWorkerPod(obj client.Object) bool {
+func isDGDManagedRolloutPod(obj client.Object) bool {
 	pod, ok := obj.(*corev1.Pod)
 	if !ok || pod == nil {
 		return false
 	}
 	labels := pod.GetLabels()
-	return labels[consts.KubeLabelDynamoGraphDeploymentName] != "" &&
-		labels[consts.KubeLabelDynamoComponent] != "" &&
-		labels[consts.KubeLabelDynamoSelector] != "" &&
-		dynamo.IsWorkerComponent(labels[consts.KubeLabelDynamoComponentType])
+	if labels[consts.KubeLabelDynamoGraphDeploymentName] == "" ||
+		labels[consts.KubeLabelDynamoComponent] == "" {
+		return false
+	}
+	componentType := labels[consts.KubeLabelDynamoComponentType]
+	if componentType == consts.ComponentTypeFrontend {
+		return true
+	}
+	return labels[consts.KubeLabelDynamoSelector] != "" &&
+		dynamo.IsWorkerComponent(componentType)
 }
 
 func dgdComponentPodIndexValues(obj client.Object) []string {
@@ -361,21 +386,19 @@ func dgdComponentPodIndexValue(dgdName, componentName string) string {
 	return dgdName + "/" + componentName
 }
 
-// dgdWorkerPodEventPredicate admits only events that can change whether a
-// Recreate rollout is blocked by an old pod. Creation and deletion change pod
-// membership; updates matter only when membership or terminality changes. A
-// deletion timestamp alone leaves the pod non-terminal and does not enqueue.
-func dgdWorkerPodEventPredicate() predicate.Predicate {
+// dgdRolloutPodEventPredicate admits worker drain changes and frontend traffic
+// readiness changes that can unblock a rollout.
+func dgdRolloutPodEventPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return isDGDManagedWorkerPod(e.Object)
+			return isDGDManagedRolloutPod(e.Object)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return isDGDManagedWorkerPod(e.Object)
+			return isDGDManagedRolloutPod(e.Object)
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldManaged := isDGDManagedWorkerPod(e.ObjectOld)
-			newManaged := isDGDManagedWorkerPod(e.ObjectNew)
+			oldManaged := isDGDManagedRolloutPod(e.ObjectOld)
+			newManaged := isDGDManagedRolloutPod(e.ObjectNew)
 			if oldManaged != newManaged {
 				return true
 			}
@@ -386,8 +409,12 @@ func dgdWorkerPodEventPredicate() predicate.Predicate {
 			newPod := e.ObjectNew.(*corev1.Pod)
 			if oldPod.Labels[consts.KubeLabelDynamoGraphDeploymentName] != newPod.Labels[consts.KubeLabelDynamoGraphDeploymentName] ||
 				oldPod.Labels[consts.KubeLabelDynamoComponent] != newPod.Labels[consts.KubeLabelDynamoComponent] ||
+				oldPod.Labels[consts.KubeLabelDynamoComponentType] != newPod.Labels[consts.KubeLabelDynamoComponentType] ||
 				oldPod.Labels[consts.KubeLabelDynamoSelector] != newPod.Labels[consts.KubeLabelDynamoSelector] {
 				return true
+			}
+			if newPod.Labels[consts.KubeLabelDynamoComponentType] == consts.ComponentTypeFrontend {
+				return podReadyForTraffic(oldPod) != podReadyForTraffic(newPod)
 			}
 			return isTerminalPhase(oldPod.Status.Phase) != isTerminalPhase(newPod.Status.Phase)
 		},
@@ -397,8 +424,8 @@ func dgdWorkerPodEventPredicate() predicate.Predicate {
 	}
 }
 
-func mapDGDWorkerPodToRequests(_ context.Context, obj client.Object) []ctrl.Request {
-	if !isDGDManagedWorkerPod(obj) {
+func mapDGDRolloutPodToRequests(_ context.Context, obj client.Object) []ctrl.Request {
+	if !isDGDManagedRolloutPod(obj) {
 		return nil
 	}
 	dgdName := obj.GetLabels()[consts.KubeLabelDynamoGraphDeploymentName]

--- a/lib/llm/src/discovery/controller.rs
+++ b/lib/llm/src/discovery/controller.rs
@@ -31,6 +31,13 @@ pub(crate) struct GroupKey {
     pub(crate) worker_set_key: String,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CommittedModelGroup {
+    pub(crate) namespace: String,
+    pub(crate) group_id: String,
+    pub(crate) members: BTreeSet<String>,
+}
+
 impl GroupKey {
     pub(crate) fn id(&self) -> String {
         serde_json::to_string(&(&self.model_name, &self.worker_set_key))
@@ -98,6 +105,8 @@ pub(crate) trait ControllerHost: Send + Sync + 'static {
     fn remove_group(&self, key: &GroupKey);
 
     fn discard_prepared(&self, prepared: Self::Prepared);
+
+    fn replace_committed_groups(&self, groups: Vec<CommittedModelGroup>);
 
     async fn list_instances(&self) -> anyhow::Result<Vec<DiscoveryInstance>>;
 }
@@ -269,9 +278,42 @@ impl<H: ControllerHost> ModelDiscoveryController<H> {
                     self.release_due_retries();
                 }
             }
+            self.publish_committed_groups();
         }
 
+        self.host.replace_committed_groups(Vec::new());
         self.shutdown_builds().await;
+    }
+
+    fn publish_committed_groups(&self) {
+        let mut committed = self
+            .groups
+            .iter()
+            .filter_map(|(key, group)| {
+                let members = match &group.status {
+                    GroupStatus::Ready {
+                        committed_members, ..
+                    }
+                    | GroupStatus::BlockedReady {
+                        committed_members, ..
+                    } => committed_members,
+                    _ => return None,
+                };
+                let namespace = members
+                    .iter()
+                    .find_map(|member| self.desired.get(member))?
+                    .mcid
+                    .namespace
+                    .clone();
+                Some(CommittedModelGroup {
+                    namespace,
+                    group_id: key.id(),
+                    members: members.clone(),
+                })
+            })
+            .collect::<Vec<_>>();
+        committed.sort_by(|left, right| left.group_id.cmp(&right.group_id));
+        self.host.replace_committed_groups(committed);
     }
 
     fn apply_event(&mut self, event: DiscoveryEvent, namespace_filter: &NamespaceFilter) {
@@ -935,6 +977,7 @@ mod tests {
         committed: Mutex<HashMap<String, BTreeSet<String>>>,
         adapters: Mutex<HashMap<String, BTreeSet<String>>>,
         adapter_projections: Mutex<HashMap<String, HashMap<String, String>>>,
+        committed_groups: Mutex<Vec<CommittedModelGroup>>,
         removed_groups: AtomicUsize,
         discarded: AtomicUsize,
     }
@@ -953,6 +996,7 @@ mod tests {
                     committed: Mutex::new(HashMap::new()),
                     adapters: Mutex::new(HashMap::new()),
                     adapter_projections: Mutex::new(HashMap::new()),
+                    committed_groups: Mutex::new(Vec::new()),
                     removed_groups: AtomicUsize::new(0),
                     discarded: AtomicUsize::new(0),
                 }),
@@ -999,6 +1043,10 @@ mod tests {
                     .map(|adapter| (adapter.key.clone(), adapter.projection_fingerprint.clone()))
                     .collect(),
             );
+        }
+
+        fn committed_groups(&self) -> Vec<CommittedModelGroup> {
+            self.committed_groups.lock().unwrap().clone()
         }
     }
 
@@ -1129,6 +1177,10 @@ mod tests {
             self.discarded.fetch_add(1, Ordering::SeqCst);
         }
 
+        fn replace_committed_groups(&self, groups: Vec<CommittedModelGroup>) {
+            *self.committed_groups.lock().unwrap() = groups;
+        }
+
         async fn list_instances(&self) -> anyhow::Result<Vec<DiscoveryInstance>> {
             Ok(Vec::new())
         }
@@ -1212,6 +1264,35 @@ mod tests {
         controller.apply_removed(&third.key);
         assert_eq!(host.members(&group_key()), BTreeSet::from([second.key]));
         assert_eq!(host.starts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn frontend_admission_tracks_only_committed_model_groups() {
+        let (host, mut starts) = FakeHost::new();
+        let mut controller = ModelDiscoveryController::new(host.clone());
+        let first = instance(1, "same");
+
+        controller.apply_added(first.clone());
+        controller.publish_committed_groups();
+        assert!(host.committed_groups().is_empty());
+
+        controller.start_queued_builds();
+        starts.recv().await.unwrap();
+        host.release.add_permits(1);
+        finish_build(&mut controller).await;
+        controller.publish_committed_groups();
+        assert_eq!(
+            host.committed_groups(),
+            vec![CommittedModelGroup {
+                namespace: "namespace".to_string(),
+                group_id: group_key().id(),
+                members: BTreeSet::from([first.key.clone()]),
+            }]
+        );
+
+        controller.apply_removed(&first.key);
+        controller.publish_committed_groups();
+        assert!(host.committed_groups().is_empty());
     }
 
     #[tokio::test]

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet, hash_map::DefaultHasher};
+use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{Notify, mpsc::Sender};
+use tokio::sync::{Notify, mpsc::Sender, watch};
 
 use anyhow::Context as _;
 use async_trait::async_trait;
@@ -16,7 +17,10 @@ use dynamo_kv_router::{
 };
 use dynamo_runtime::{
     DistributedRuntime,
-    discovery::{DiscoveryInstance, DiscoveryQuery, DiscoveryStream, ModelCardInstanceId},
+    discovery::{
+        DiscoveryInstance, DiscoveryQuery, DiscoverySpec, DiscoveryStream, EventScope,
+        EventSourceQuery, ModelCardInstanceId,
+    },
     pipeline::{
         ManyOut, Operator, RouterMode, SegmentSource, ServiceBackend, SingleIn, Source,
         network::egress::push_router::PushRouter,
@@ -63,9 +67,12 @@ use crate::{
 use super::readiness::normalize_legacy_prefill_topology;
 use super::{
     ModelManager,
-    controller::{ControllerHost, DesiredInstance, GroupKey, GroupSpec, ModelDiscoveryController},
+    controller::{
+        CommittedModelGroup, ControllerHost, DesiredInstance, GroupKey, GroupSpec,
+        ModelDiscoveryController,
+    },
 };
-use crate::namespace::NamespaceFilter;
+use crate::namespace::{GLOBAL_NAMESPACE, NamespaceFilter};
 use tokio_util::sync::CancellationToken;
 
 /// Constructs a collision-free WorkerSet storage key from its exact endpoint,
@@ -124,6 +131,215 @@ fn model_card_instance_id(instance: &DiscoveryInstance) -> anyhow::Result<ModelC
             model_suffix: model_suffix.clone(),
         }),
         _ => anyhow::bail!("Unexpected discovery instance type (expected ModelCard)"),
+    }
+}
+
+const FRONTEND_MODEL_ADMISSION_TOPIC: &str = "frontend-model-admission";
+const FRONTEND_MODEL_ADMISSION_PROTOCOL: &str = "v1";
+const FRONTEND_ADMISSION_STARTUP_WAIT: Duration = Duration::from_secs(5);
+const FRONTEND_ADMISSION_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+const FRONTEND_ADMISSION_VERIFY_INTERVAL: Duration = Duration::from_secs(30);
+const JSON_SAFE_PUBLISHER_ID_MASK: u64 = (1 << 53) - 1;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FrontendAdmissionSource {
+    scope: EventScope,
+    publisher_id: u64,
+    metadata: serde_json::Value,
+}
+
+impl FrontendAdmissionSource {
+    fn spec(&self) -> DiscoverySpec {
+        DiscoverySpec::EventSource {
+            scope: self.scope.clone(),
+            topic: FRONTEND_MODEL_ADMISSION_TOPIC.to_string(),
+            publisher_id: self.publisher_id,
+            metadata: self.metadata.clone(),
+        }
+    }
+}
+
+fn frontend_admission_publisher_id(connection_id: u64, key: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    connection_id.hash(&mut hasher);
+    key.hash(&mut hasher);
+    hasher.finish() & JSON_SAFE_PUBLISHER_ID_MASK
+}
+
+fn desired_frontend_admission_sources(
+    connection_id: u64,
+    frontend_namespace: &str,
+    groups: &[CommittedModelGroup],
+) -> BTreeMap<String, FrontendAdmissionSource> {
+    let mut desired = BTreeMap::new();
+    desired.insert(
+        "capability".to_string(),
+        FrontendAdmissionSource {
+            scope: EventScope::Namespace {
+                name: frontend_namespace.to_string(),
+            },
+            publisher_id: frontend_admission_publisher_id(connection_id, "capability"),
+            metadata: serde_json::json!({
+                "protocol": FRONTEND_MODEL_ADMISSION_PROTOCOL,
+                "capability": true,
+            }),
+        },
+    );
+    for group in groups {
+        let key = format!("group:{}", group.group_id);
+        desired.insert(
+            key.clone(),
+            FrontendAdmissionSource {
+                scope: EventScope::Namespace {
+                    name: group.namespace.clone(),
+                },
+                publisher_id: frontend_admission_publisher_id(connection_id, &key),
+                metadata: serde_json::json!({
+                    "protocol": FRONTEND_MODEL_ADMISSION_PROTOCOL,
+                    "group_id": group.group_id.clone(),
+                    "members": group.members.clone(),
+                }),
+            },
+        );
+    }
+    desired
+}
+
+async fn reconcile_frontend_admission_sources(
+    drt: &DistributedRuntime,
+    frontend_namespace: &str,
+    groups: &[CommittedModelGroup],
+    active: &mut BTreeMap<String, (FrontendAdmissionSource, DiscoveryInstance)>,
+) -> bool {
+    let desired =
+        desired_frontend_admission_sources(drt.connection_id(), frontend_namespace, groups);
+    let stale = active
+        .iter()
+        .filter_map(|(key, (source, _))| (desired.get(key) != Some(source)).then_some(key.clone()))
+        .collect::<Vec<_>>();
+    for key in stale {
+        let Some((source, instance)) = active.remove(&key) else {
+            continue;
+        };
+        if let Err(error) = drt.discovery().unregister(instance.clone()).await {
+            tracing::warn!(%error, admission = key, "Failed to withdraw frontend model admission; retrying");
+            active.insert(key, (source, instance));
+        }
+    }
+
+    for (key, source) in desired {
+        if active.contains_key(&key) {
+            continue;
+        }
+        match drt.discovery().register(source.spec()).await {
+            Ok(instance) => {
+                active.insert(key, (source, instance));
+            }
+            Err(error) => {
+                tracing::warn!(%error, admission = key, "Failed to publish frontend model admission; retrying");
+            }
+        }
+    }
+
+    active.contains_key("capability")
+}
+
+async fn remove_missing_frontend_admission_sources(
+    drt: &DistributedRuntime,
+    active: &mut BTreeMap<String, (FrontendAdmissionSource, DiscoveryInstance)>,
+) {
+    let published = match drt
+        .discovery()
+        .list(DiscoveryQuery::EventSources(EventSourceQuery::all()))
+        .await
+    {
+        Ok(published) => published,
+        Err(error) => {
+            tracing::warn!(%error, "Failed to verify frontend model admissions; retrying");
+            return;
+        }
+    };
+    active.retain(|key, (_, instance)| {
+        let present = published.contains(instance);
+        if !present {
+            tracing::warn!(
+                admission = key,
+                "Frontend model admission disappeared; republishing"
+            );
+        }
+        present
+    });
+}
+
+async fn run_frontend_admission_publisher(
+    drt: DistributedRuntime,
+    frontend_namespace: String,
+    mut groups_rx: watch::Receiver<Vec<CommittedModelGroup>>,
+    cancellation: CancellationToken,
+    ready_tx: tokio::sync::oneshot::Sender<()>,
+) {
+    let mut active = BTreeMap::new();
+    let ready = loop {
+        let groups = groups_rx.borrow().clone();
+        let published = tokio::select! {
+            _ = cancellation.cancelled() => break false,
+            published = reconcile_frontend_admission_sources(
+                &drt,
+                &frontend_namespace,
+                &groups,
+                &mut active,
+            ) => published,
+        };
+        if published {
+            break true;
+        }
+        tokio::select! {
+            _ = cancellation.cancelled() => break false,
+            _ = tokio::time::sleep(FRONTEND_ADMISSION_RETRY_INTERVAL) => {}
+        }
+    };
+    if ready {
+        let _ = ready_tx.send(());
+    }
+
+    let mut retry_interval = tokio::time::interval(FRONTEND_ADMISSION_RETRY_INTERVAL);
+    retry_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut verify_interval = tokio::time::interval_at(
+        tokio::time::Instant::now() + FRONTEND_ADMISSION_VERIFY_INTERVAL,
+        FRONTEND_ADMISSION_VERIFY_INTERVAL,
+    );
+    verify_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    if ready {
+        loop {
+            let verify = tokio::select! {
+                _ = cancellation.cancelled() => break,
+                changed = groups_rx.changed() => {
+                    if changed.is_err() {
+                        break;
+                    }
+                    false
+                }
+                _ = retry_interval.tick() => false,
+                _ = verify_interval.tick() => true,
+            };
+            if verify {
+                remove_missing_frontend_admission_sources(&drt, &mut active).await;
+            }
+            let groups = groups_rx.borrow().clone();
+            let _ = reconcile_frontend_admission_sources(
+                &drt,
+                &frontend_namespace,
+                &groups,
+                &mut active,
+            )
+            .await;
+        }
+    }
+
+    for (_, (_, instance)) in active {
+        if let Err(error) = drt.discovery().unregister(instance).await {
+            tracing::warn!(%error, "Failed to withdraw frontend model admission during shutdown");
+        }
     }
 }
 
@@ -194,6 +410,7 @@ where
     model_update_tx: Option<Sender<ModelUpdate>>,
     model_update_dispatch:
         parking_lot::Mutex<Option<tokio::sync::mpsc::UnboundedSender<ModelUpdate>>>,
+    committed_groups_tx: watch::Sender<Vec<CommittedModelGroup>>,
     chat_engine_factory: Option<ChatEngineFactoryCallback>,
     prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
     metrics: Arc<Metrics>,
@@ -337,6 +554,7 @@ where
         require_typed_worker_role: bool,
         worker_selector_factory: WorkerSelectorFactory<Sel>,
     ) -> Self {
+        let (committed_groups_tx, _) = watch::channel(Vec::new());
         Self {
             manager: model_manager,
             drt: runtime,
@@ -346,6 +564,7 @@ where
             notify_on_model: Notify::new(),
             model_update_tx: None,
             model_update_dispatch: parking_lot::Mutex::new(None),
+            committed_groups_tx,
             chat_engine_factory,
             prefill_load_estimator,
             metrics,
@@ -423,9 +642,44 @@ where
             })
         });
 
+        let admission_namespace = match &namespace_filter {
+            NamespaceFilter::Exact(namespace) | NamespaceFilter::Prefix(namespace) => {
+                namespace.clone()
+            }
+            NamespaceFilter::Global => GLOBAL_NAMESPACE.to_string(),
+        };
+        let admission_cancellation = CancellationToken::new();
+        let (admission_ready_tx, admission_ready_rx) = tokio::sync::oneshot::channel();
+        let admission_handle = tokio::spawn(run_frontend_admission_publisher(
+            self.drt.clone(),
+            admission_namespace,
+            self.committed_groups_tx.subscribe(),
+            admission_cancellation.clone(),
+            admission_ready_tx,
+        ));
+        match tokio::time::timeout(FRONTEND_ADMISSION_STARTUP_WAIT, admission_ready_rx).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => tracing::warn!(
+                %error,
+                "Frontend admission publisher stopped before startup; continuing model discovery"
+            ),
+            Err(_) => tracing::warn!(
+                "Frontend admission publication timed out; continuing model discovery while it retries"
+            ),
+        }
+
         ModelDiscoveryController::new(Arc::clone(&self))
             .run(discovery_stream, namespace_filter)
             .await;
+
+        admission_cancellation.cancel();
+        let mut admission_handle = admission_handle;
+        if tokio::time::timeout(Duration::from_secs(2), &mut admission_handle)
+            .await
+            .is_err()
+        {
+            admission_handle.abort();
+        }
 
         self.model_update_dispatch.lock().take();
         if let Some(mut dispatch_handle) = dispatch_handle
@@ -1211,6 +1465,16 @@ where
         drop(prepared);
     }
 
+    fn replace_committed_groups(&self, groups: Vec<CommittedModelGroup>) {
+        self.committed_groups_tx.send_if_modified(|current| {
+            if current == &groups {
+                return false;
+            }
+            *current = groups;
+            true
+        });
+    }
+
     async fn list_instances(&self) -> anyhow::Result<Vec<DiscoveryInstance>> {
         self.drt.discovery().list(DiscoveryQuery::AllModels).await
     }
@@ -1349,6 +1613,61 @@ mod tests {
             component: "workers".to_string(),
             name: name.to_string(),
         }
+    }
+
+    #[test]
+    fn frontend_admission_source_carries_exact_committed_members() {
+        let member = "workers/backend/generate/7".to_string();
+        let sources = desired_frontend_admission_sources(
+            11,
+            "frontend",
+            &[CommittedModelGroup {
+                namespace: "workers".to_string(),
+                group_id: "group".to_string(),
+                members: std::collections::BTreeSet::from([member.clone()]),
+            }],
+        );
+
+        assert_eq!(sources["capability"].metadata["capability"], true);
+        let group = &sources["group:group"];
+        assert_eq!(
+            group.scope,
+            EventScope::Namespace {
+                name: "workers".to_string()
+            }
+        );
+        assert_eq!(
+            group.metadata["protocol"],
+            FRONTEND_MODEL_ADMISSION_PROTOCOL
+        );
+        assert_eq!(group.metadata["members"], serde_json::json!([member]));
+    }
+
+    #[tokio::test]
+    async fn missing_frontend_admission_is_republished() {
+        use dynamo_runtime::{Runtime, distributed::DistributedConfig};
+
+        let runtime = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let mut active = BTreeMap::new();
+
+        assert!(reconcile_frontend_admission_sources(&drt, "frontend", &[], &mut active).await);
+        let original = active["capability"].1.clone();
+        drt.discovery().unregister(original).await.unwrap();
+
+        remove_missing_frontend_admission_sources(&drt, &mut active).await;
+        assert!(active.is_empty());
+        assert!(reconcile_frontend_admission_sources(&drt, "frontend", &[], &mut active).await);
+        let published = drt
+            .discovery()
+            .list(DiscoveryQuery::EventSources(EventSourceQuery::all()))
+            .await
+            .unwrap();
+        assert!(published.contains(&active["capability"].1));
+
+        runtime.shutdown();
     }
 
     #[test]


### PR DESCRIPTION
## Overview:

Prevent constrained worker rolling updates from deleting the last old routable worker before the Dynamo frontend has committed the replacement worker's model metadata.

## Details:

- Publish a versioned frontend-admission capability and the exact committed model-card members through the frontend pod's existing `DynamoWorkerMetadata` resource.
- Watch `DynamoWorkerMetadata` from the DGD controller and count a locally ready replacement replica as available for old-worker scale-down only after every ready frontend has admitted its model cards.
- Keep the legacy rollout calculation when deployed frontends do not advertise the admission protocol, preserving operator-only upgrade compatibility.
- Retry admission publication and withdrawal, and publish model groups only after the frontend model manager has committed them.
- Add focused coverage for pre-commit state, model removal, exact admission metadata, multi-frontend admission, and legacy fallback.
- Grant the operator read-only access to `DynamoWorkerMetadata`; no CRD schema or worker readiness contract changes are introduced.

## Where should the reviewer start?

- `deploy/operator/internal/controller/dgd_frontend_admission.go` implements the operator-side admission calculation.
- `deploy/operator/internal/controller/dgd_worker_rollout_reconciler.go` applies admitted availability to rollout scale-down math.
- `lib/llm/src/discovery/controller.rs` and `lib/llm/src/discovery/watcher.rs` publish admission only for model groups that the frontend has committed.

## Related Issues

- Closes #13622

## Validation

AKS end-to-end validation used two A100 nodes, Qwen/Qwen3-0.6B, two worker replicas pinned one per node, and `maxSurge: 0` / `maxUnavailable: 1`.

- Baseline Dynamo v1.4.1 reproduced the gap: 9,337 of 9,350 requests returned HTTP 200, followed by 13 consecutive HTTP 404 responses during a roughly 250 ms zero-routable-worker interval.
- Patched current `main` completed two independent five-minute constrained rollouts with 56,563 of 56,563 requests returning HTTP 200 and no failure streaks.
- During both fixed rollouts, operator logs showed the old worker being retained while the replacement was locally available but not yet frontend-admitted; scale-down proceeded after every ready frontend published the exact replacement model-card members.

Local validation:

- `cargo check -p dynamo-llm --no-default-features`
- `cargo clippy -p dynamo-llm --no-default-features -- -D warnings`
- `cargo test -q -p dynamo-llm --no-default-features discovery::controller::tests` (14 passed)
- `cargo test -q -p dynamo-llm --no-default-features discovery::watcher::tests` (20 passed)
- `go test ./internal/controller -count=1`
- `go vet ./internal/controller`
- `make manifests`
- pre-commit checks on all changed files

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added frontend-aware worker rollout coordination.
  * Rollouts now wait until all ready frontends approve replacement workers before scaling down existing workers.
  * Added discovery metadata for frontend capabilities and committed model members.
  * Added monitoring of worker metadata changes to trigger reconciliation.

* **Bug Fixes**
  * Preserved legacy rollout behavior when frontend admission metadata is unavailable.

* **Tests**
  * Added coverage for multi-frontend admission, delayed scale-down, and legacy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->