### PR TITLE
test(profiler): name the errno the config path probe expects

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_main_parse_config.py
+++ b/components/src/dynamo/profiler/tests/unit/test_main_parse_config.py
@@ -3,6 +3,7 @@
 
 """Unit tests for profiler ``--config`` parsing in ``dynamo.profiler.__main__``."""
 
+import errno
 import json
 
 import pytest
@@ -47,7 +48,10 @@ def test_parse_dgdr_spec_handles_oserror_during_path_probe(monkeypatch) -> None:
     monkeypatch.setattr(profiler_main, "DynamoGraphDeploymentRequestSpec", _DummySpec)
 
     def _path_too_long(_: object) -> bool:
-        raise OSError(36, "File name too long")
+        # errno by name: 36 is ENAMETOOLONG only on Linux. On macOS it is
+        # EINPROGRESS, which Python raises as BlockingIOError, so the value the
+        # code under test compares against never matches and it re-raises.
+        raise OSError(errno.ENAMETOOLONG, "File name too long")
 
     monkeypatch.setattr(profiler_main.Path, "is_file", _path_too_long)
 


### PR DESCRIPTION
## Summary

`test_parse_dgdr_spec_handles_oserror_during_path_probe` covers the branch in `_parse_dgdr_spec` that treats an over-long `--config` string as "not a file" instead of an error, so a large inline JSON spec still parses. It simulates the probe failure with a hardcoded errno:

```python
raise OSError(36, "File name too long")
```

36 is `ENAMETOOLONG` on Linux only. On macOS 36 is `EINPROGRESS`, and two things follow from that:

- Python picks the `OSError` subclass from the errno, so the raise produces a `BlockingIOError`.
- `_parse_dgdr_spec` compares against `errno.ENAMETOOLONG`, which is 63 there, so the value does not match and the `else: raise` re-raises.

The test then fails on macOS with `BlockingIOError: [Errno 36] File name too long` escaping instead of the expected `ValueError`. It is not a flake and not a missing dependency, so it reads like a real defect to anyone running the suite there, and `docs/contribution-guide.md` and `AGENTS.md` both treat macOS as a supported development platform.

The production code is already correct: it uses the symbolic constant. Only the test hardcodes the number. Raising `errno.ENAMETOOLONG` by name is identical on Linux, where the constant is 36, and correct everywhere else.

This is the only hardcoded `OSError(<int>, ...)` in the repository, so there is no wider cleanup to do.

## Validation

On macOS (arm64, Python 3.12), before the change:

```
FAILED .../test_main_parse_config.py::test_parse_dgdr_spec_handles_oserror_during_path_probe
E       BlockingIOError: [Errno 36] File name too long
1 failed, 2 passed
```

After:

```
3 passed
```

The test still earns its place rather than just passing. Deleting the `ENAMETOOLONG` handling from `_parse_dgdr_spec` and keeping the fixed test:

```
FAILED .../test_parse_dgdr_spec_handles_oserror_during_path_probe
1 failed, 2 passed
```

Also confirmed the platform values this rests on:

```
ENAMETOOLONG on this platform = 63
errno 36 -> EINPROGRESS
OSError(36) class = BlockingIOError
```

`pre-commit run --files` on the changed file: 0 failing hooks.

Not verified here: no Linux run. On Linux `errno.ENAMETOOLONG == 36`, so the raised exception is byte-for-byte what it was before and the test's behaviour there is unchanged.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved portability of tests that verify handling of excessively long file paths.
  * Replaced a platform-specific error number with the corresponding standard system error constant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->