### PR TITLE
recipes: add DeepSeek-V4-Pro-0813 vLLM recipes for H200 (agg/disagg × agentic/1M)

### DIFF
--- a/recipes/deepseek-v4/deepseek-v4-pro-0813/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-pro-0813/README.md
@@ -1,0 +1,38 @@
+# DeepSeek-V4-Pro-0813
+
+Recipes for the `deepseek-ai/DeepSeek-V4-Pro-0813` checkpoint.
+
+> This is a **different checkpoint** from `deepseek-ai/DeepSeek-V4-Pro` used by the sibling
+> `../deepseek-v4-pro` recipes. Do not mix the two model caches or deploy configs.
+
+## Layout
+
+```
+deepseek-v4-pro-0813/
+├── model-cache/
+│   ├── model-cache.yaml       # PVC (1200Gi; checkpoint is ~832 GiB)
+│   └── model-download.yaml    # populates the PVC from HF
+└── vllm/                      # deploy.yaml per SKU x topology (added separately)
+```
+
+## Quick start
+
+```bash
+kubectl apply -f model-cache/model-cache.yaml
+kubectl apply -f model-download.yaml   # requires an hf-token-secret in the namespace
+kubectl wait --for=condition=complete job/model-download --timeout=6h
+```
+
+The download job pulls the default revision. The H200 configs in this directory were validated
+against revision `72e1d3230f6c080a530b0a1d46f8eb4602340597`; pin `--revision` in the deploy if
+you need to reproduce those numbers exactly.
+
+## Status
+
+| SKU | Topology | Workload | State |
+|-----|----------|----------|-------|
+| H200 x8  | agg    | agentic 64K | validated |
+| H200 x16 | disagg | agentic 64K | validated |
+| H200 x8  | agg    | 1M context  | validated |
+| H200 x16 | disagg | 1M context  | validated |
+| GB200    | -      | -           | separate contribution |

--- a/recipes/deepseek-v4/deepseek-v4-pro-0813/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-pro-0813/README.md
@@ -12,8 +12,27 @@ deepseek-v4-pro-0813/
 ├── model-cache/
 │   ├── model-cache.yaml       # PVC (1200Gi; checkpoint is ~832 GiB)
 │   └── model-download.yaml    # populates the PVC from HF
-└── vllm/                      # deploy.yaml per SKU x topology (added separately)
+└── vllm/
+    ├── agg-h200-agentic/       # 8x H200,  64K agentic
+    ├── disagg-h200-agentic/    # 16x H200, 64K agentic  (best density)
+    ├── agg-h200-1m/            # 8x H200,  1M context   (batch)
+    └── disagg-h200-1m/         # 16x H200, 1M context   (batch)
 ```
+
+## Config matrix
+
+|                | Aggregated (8x H200)                    | Disaggregated (16x H200)                  |
+|----------------|-----------------------------------------|-------------------------------------------|
+| **Agentic 64K**| `agg-h200-agentic` <br> C=2, E2E 56.40 tok/s/user, 11.85 tok/s/GPU | `disagg-h200-agentic` <br> C~7.95, E2E 50, ~24 tok/s/GPU |
+| **1M context** | `agg-h200-1m` <br> 998,218 tokens, TTFT ~202 s | `disagg-h200-1m` <br> 1,033,872 tokens, TTFT ~146 s |
+
+Agentic workload is 64K ISL / 400 OSL / 90% prefix reuse; the SLA gate is
+E2E >= 50 tok/s/user **and** TTFT p50 < 5 s, jointly, where
+`E2E = OSL / (TTFT + OSL x ITL)`. The 1M configs are a batch capability, not
+interactive -- time-to-first-token is minutes at that length.
+
+Accuracy on the agentic configs: `gpqa_diamond` 88.26 (agg) / 88.38 (disagg),
+`ifeval` 94.48 (agg) / 94.29 (disagg) -- disaggregation does not cost accuracy.
 
 ## Quick start
 

--- a/recipes/deepseek-v4/deepseek-v4-pro-0813/model-cache/model-cache.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro-0813/model-cache/model-cache.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1200Gi
+  # Edit this
+  storageClassName: "your-storage-class-name"

--- a/recipes/deepseek-v4/deepseek-v4-pro-0813/model-cache/model-download.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro-0813/model-cache/model-download.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          image: python:3.10-slim
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["sh", "-c"]
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: MODEL_NAME
+              value: deepseek-ai/DeepSeek-V4-Pro-0813
+            - name: HF_HOME
+              value: /model-cache
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub==1.16.4
+              hf download $MODEL_NAME
+          resources:
+            requests:
+              cpu: "8"
+              memory: "128Gi"
+            limits:
+              cpu: "8"
+              memory: "128Gi"
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-cache
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache

--- a/recipes/deepseek-v4/deepseek-v4-pro-0813/vllm/agg-h200-1m/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro-0813/vllm/agg-h200-1m/deploy.yaml
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Aggregated, 8x H200, 1M context. Batch capability, NOT interactive: TTFT ~202 s at 1M.
+# Verified by needle-in-haystack to 998,218 tokens.
+# CPU offload is MANDATORY here: GPU-resident KV caps at 86,016 tokens on 8x H200.
+# Requires ~1.4 TB host RAM for the offload tier; size the node accordingly.
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: deepseek-v4-pro-0813-vllm-h200-agg-1m
+spec:
+  backendFramework: vllm
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0@sha256:8401411dc8e968eff9310462102491509e3f93d3ce03d6febc8d5566f067a7b1
+          imagePullPolicy: Always
+          workingDir: /workspace
+          command:
+          - python3
+          args:
+          - -m
+          - dynamo.frontend
+          - --trust-remote-code
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 15
+            failureThreshold: 200
+  - name: VllmDecodeWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0@sha256:8401411dc8e968eff9310462102491509e3f93d3ce03d6febc8d5566f067a7b1
+          imagePullPolicy: Always
+          workingDir: /workspace
+          command:
+          - /bin/bash
+          - -lc
+          args:
+          - |
+            python3 -m dynamo.vllm \
+              --model deepseek-ai/DeepSeek-V4-Pro-0813 \
+              --served-model-name deepseek-ai/DeepSeek-V4-Pro-0813 \
+              --trust-remote-code \
+              --tokenizer-mode deepseek_v4 \
+              --dyn-tool-call-parser deepseek_v4 \
+              --dyn-reasoning-parser deepseek_v4 \
+              --kv-cache-dtype fp8 \
+              --block-size 256 \
+              --tensor-parallel-size 8 \
+              --enable-expert-parallel \
+              --moe-backend marlin \
+              --enable-prefix-caching \
+              --no-enable-flashinfer-autotune \
+              --max-model-len 1048576 \
+              --max-num-seqs 128 \
+              --max-num-batched-tokens 4096 \
+              --gpu-memory-utilization 0.97 \
+              --kv-transfer-config '{"kv_connector":"SimpleCPUOffloadConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":1400000000000}}' \
+              --compilation-config '{"mode":0,"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1,2,4,8,10,12,16,32,64,80,96,128],"max_cudagraph_capture_size":128}'
+          env:
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          resources:
+            limits:
+              nvidia.com/gpu: "8"
+            requests:
+              cpu: "16"
+              memory: 1500Gi
+              nvidia.com/gpu: "8"
+          startupProbe:
+            httpGet:
+              path: /live
+              port: 9090
+            periodSeconds: 15
+            failureThreshold: 200
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+          - mountPath: /dev/shm
+            name: dshm
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi

--- a/recipes/deepseek-v4/deepseek-v4-pro-0813/vllm/agg-h200-agentic/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro-0813/vllm/agg-h200-agentic/deploy.yaml
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Aggregated, 8x H200. Agentic workload: 64K ISL / 400 OSL / 90% prefix reuse.
+# Validated operating point C=2: E2E 56.40 tok/s/user, TTFT 1.64 s, 11.85 tok/s/GPU.
+# The joint SLA gate (E2E >= 50 tok/s/user AND TTFT p50 < 5 s) fails at C=4.
+# gpqa_diamond 88.26 / ifeval 94.48 measured on this exact config.
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: deepseek-v4-pro-0813-vllm-h200-agg-agentic
+spec:
+  backendFramework: vllm
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0@sha256:8401411dc8e968eff9310462102491509e3f93d3ce03d6febc8d5566f067a7b1
+          imagePullPolicy: Always
+          workingDir: /workspace
+          command:
+          - python3
+          args:
+          - -m
+          - dynamo.frontend
+          - --trust-remote-code
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 15
+            failureThreshold: 200
+  - name: VllmDecodeWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0@sha256:8401411dc8e968eff9310462102491509e3f93d3ce03d6febc8d5566f067a7b1
+          imagePullPolicy: Always
+          workingDir: /workspace
+          command:
+          - /bin/bash
+          - -lc
+          args:
+          - |
+            python3 -m dynamo.vllm \
+              --model deepseek-ai/DeepSeek-V4-Pro-0813 \
+              --served-model-name deepseek-ai/DeepSeek-V4-Pro-0813 \
+              --trust-remote-code \
+              --tokenizer-mode deepseek_v4 \
+              --dyn-tool-call-parser deepseek_v4 \
+              --dyn-reasoning-parser deepseek_v4 \
+              --kv-cache-dtype fp8 \
+              --block-size 256 \
+              --tensor-parallel-size 8 \
+              --enable-expert-parallel \
+              --moe-backend marlin \
+              --enable-prefix-caching \
+              --no-enable-flashinfer-autotune \
+              --max-model-len 86016 \
+              --max-num-seqs 128 \
+              --max-num-batched-tokens 4096 \
+              --gpu-memory-utilization 0.97 \
+              --compilation-config '{"mode":0,"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1,2,4,8,10,12,16,32,64,80,96,128],"max_cudagraph_capture_size":128}'
+          env:
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          resources:
+            limits:
+              nvidia.com/gpu: "8"
+            requests:
+              cpu: "16"
+              memory: 256Gi
+              nvidia.com/gpu: "8"
+          startupProbe:
+            httpGet:
+              path: /live
+              port: 9090
+            periodSeconds: 15
+            failureThreshold: 200
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+          - mountPath: /dev/shm
+            name: dshm
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi

--- a/recipes/deepseek-v4/deepseek-v4-pro-0813/vllm/disagg-h200-1m/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro-0813/vllm/disagg-h200-1m/deploy.yaml
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Disaggregated 1P1D, 16x H200, 1M context. Batch capability: TTFT ~146 s at 1M.
+# Verified by needle-in-haystack to 1,033,872 tokens.
+# The KV transport slot is held by NIXL, so the offload tier is stacked via MultiConnector
+# on the DECODE worker only; prefill stays NIXL-only.
+# NOTE prefill needs mnbt 4096 + gpu-mu 0.97: at mnbt 16384 it cannot start (24.06 GiB KV
+# needed for one 1M request vs 20.75 GiB available). That check is GPU-KV only -- the host
+# tier extends what you can HOLD, not whether the engine will START.
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: deepseek-v4-pro-0813-vllm-h200-disagg-1m
+spec:
+  backendFramework: vllm
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0@sha256:8401411dc8e968eff9310462102491509e3f93d3ce03d6febc8d5566f067a7b1
+          imagePullPolicy: Always
+          workingDir: /workspace
+          command:
+          - python3
+          args:
+          - -m
+          - dynamo.frontend
+          - --trust-remote-code
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 15
+            failureThreshold: 200
+  - name: VllmPrefillWorker
+    type: prefill
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0@sha256:8401411dc8e968eff9310462102491509e3f93d3ce03d6febc8d5566f067a7b1
+          imagePullPolicy: Always
+          workingDir: /workspace
+          command:
+          - /bin/bash
+          - -lc
+          args:
+          - |
+            python3 -m dynamo.vllm \
+              --model deepseek-ai/DeepSeek-V4-Pro-0813 \
+              --served-model-name deepseek-ai/DeepSeek-V4-Pro-0813 \
+              --trust-remote-code \
+              --tokenizer-mode deepseek_v4 \
+              --dyn-tool-call-parser deepseek_v4 \
+              --dyn-reasoning-parser deepseek_v4 \
+              --kv-cache-dtype fp8 \
+              --block-size 256 \
+              --tensor-parallel-size 8 \
+              --enable-expert-parallel \
+              --moe-backend marlin \
+              --enable-prefix-caching \
+              --no-enable-flashinfer-autotune \
+              --max-model-len 1048576 \
+              --max-num-seqs 16 \
+              --max-num-batched-tokens 4096 \
+              --gpu-memory-utilization 0.97 \
+              --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
+              --compilation-config '{"mode":0,"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1,2,4,8,10,12,16,32,64,80,96,128],"max_cudagraph_capture_size":128}'
+          env:
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          resources:
+            limits:
+              nvidia.com/gpu: "8"
+            requests:
+              cpu: "16"
+              memory: 1500Gi
+              nvidia.com/gpu: "8"
+          startupProbe:
+            httpGet:
+              path: /live
+              port: 9090
+            periodSeconds: 15
+            failureThreshold: 200
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+          - mountPath: /dev/shm
+            name: dshm
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+  - name: VllmDecodeWorker
+    type: decode
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0@sha256:8401411dc8e968eff9310462102491509e3f93d3ce03d6febc8d5566f067a7b1
+          imagePullPolicy: Always
+          workingDir: /workspace
+          command:
+          - /bin/bash
+          - -lc
+          args:
+          - |
+            python3 -m dynamo.vllm \
+              --model deepseek-ai/DeepSeek-V4-Pro-0813 \
+              --served-model-name deepseek-ai/DeepSeek-V4-Pro-0813 \
+              --trust-remote-code \
+              --tokenizer-mode deepseek_v4 \
+              --dyn-tool-call-parser deepseek_v4 \
+              --dyn-reasoning-parser deepseek_v4 \
+              --kv-cache-dtype fp8 \
+              --block-size 256 \
+              --tensor-parallel-size 8 \
+              --enable-expert-parallel \
+              --moe-backend marlin \
+              --enable-prefix-caching \
+              --no-enable-flashinfer-autotune \
+              --max-model-len 1048576 \
+              --max-num-seqs 128 \
+              --max-num-batched-tokens 4096 \
+              --gpu-memory-utilization 0.95 \
+              --kv-transfer-config '{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_both"},{"kv_connector":"SimpleCPUOffloadConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":1400000000000}}]}}' \
+              --compilation-config '{"mode":0,"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1,2,4,8,10,12,16,32,64,80,96,128],"max_cudagraph_capture_size":128}'
+          env:
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          resources:
+            limits:
+              nvidia.com/gpu: "8"
+            requests:
+              cpu: "16"
+              memory: 1500Gi
+              nvidia.com/gpu: "8"
+          startupProbe:
+            httpGet:
+              path: /live
+              port: 9090
+            periodSeconds: 15
+            failureThreshold: 200
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+          - mountPath: /dev/shm
+            name: dshm
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi

--- a/recipes/deepseek-v4/deepseek-v4-pro-0813/vllm/disagg-h200-agentic/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro-0813/vllm/disagg-h200-agentic/deploy.yaml
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Disaggregated 1P1D, 16x H200. Agentic workload: 64K ISL / 400 OSL / 90% prefix reuse.
+# SLA crossing at C ~ 7.95: E2E 50 tok/s/user at ~24 tok/s/GPU, ~2x the aggregated density.
+# Gate holds at C=5,6,7; cliff is C=7->8.
+# gpqa_diamond 88.38 / ifeval 94.29 -- matches aggregated, so the NIXL KV path is clean.
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: deepseek-v4-pro-0813-vllm-h200-disagg-agentic
+spec:
+  backendFramework: vllm
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0@sha256:8401411dc8e968eff9310462102491509e3f93d3ce03d6febc8d5566f067a7b1
+          imagePullPolicy: Always
+          workingDir: /workspace
+          command:
+          - python3
+          args:
+          - -m
+          - dynamo.frontend
+          - --trust-remote-code
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 15
+            failureThreshold: 200
+  - name: VllmPrefillWorker
+    type: prefill
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0@sha256:8401411dc8e968eff9310462102491509e3f93d3ce03d6febc8d5566f067a7b1
+          imagePullPolicy: Always
+          workingDir: /workspace
+          command:
+          - /bin/bash
+          - -lc
+          args:
+          - |
+            python3 -m dynamo.vllm \
+              --model deepseek-ai/DeepSeek-V4-Pro-0813 \
+              --served-model-name deepseek-ai/DeepSeek-V4-Pro-0813 \
+              --trust-remote-code \
+              --tokenizer-mode deepseek_v4 \
+              --dyn-tool-call-parser deepseek_v4 \
+              --dyn-reasoning-parser deepseek_v4 \
+              --kv-cache-dtype fp8 \
+              --block-size 256 \
+              --tensor-parallel-size 8 \
+              --enable-expert-parallel \
+              --moe-backend marlin \
+              --enable-prefix-caching \
+              --no-enable-flashinfer-autotune \
+              --max-model-len 86016 \
+              --max-num-seqs 16 \
+              --max-num-batched-tokens 16384 \
+              --gpu-memory-utilization 0.95 \
+              --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
+              --compilation-config '{"mode":0,"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1,2,4,8,10,12,16,32,64,80,96,128],"max_cudagraph_capture_size":128}'
+          env:
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          resources:
+            limits:
+              nvidia.com/gpu: "8"
+            requests:
+              cpu: "16"
+              memory: 256Gi
+              nvidia.com/gpu: "8"
+          startupProbe:
+            httpGet:
+              path: /live
+              port: 9090
+            periodSeconds: 15
+            failureThreshold: 200
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+          - mountPath: /dev/shm
+            name: dshm
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+  - name: VllmDecodeWorker
+    type: decode
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0@sha256:8401411dc8e968eff9310462102491509e3f93d3ce03d6febc8d5566f067a7b1
+          imagePullPolicy: Always
+          workingDir: /workspace
+          command:
+          - /bin/bash
+          - -lc
+          args:
+          - |
+            python3 -m dynamo.vllm \
+              --model deepseek-ai/DeepSeek-V4-Pro-0813 \
+              --served-model-name deepseek-ai/DeepSeek-V4-Pro-0813 \
+              --trust-remote-code \
+              --tokenizer-mode deepseek_v4 \
+              --dyn-tool-call-parser deepseek_v4 \
+              --dyn-reasoning-parser deepseek_v4 \
+              --kv-cache-dtype fp8 \
+              --block-size 256 \
+              --tensor-parallel-size 8 \
+              --enable-expert-parallel \
+              --moe-backend marlin \
+              --enable-prefix-caching \
+              --no-enable-flashinfer-autotune \
+              --max-model-len 86016 \
+              --max-num-seqs 128 \
+              --max-num-batched-tokens 4096 \
+              --gpu-memory-utilization 0.95 \
+              --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
+              --compilation-config '{"mode":0,"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1,2,4,8,10,12,16,32,64,80,96,128],"max_cudagraph_capture_size":128}'
+          env:
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          resources:
+            limits:
+              nvidia.com/gpu: "8"
+            requests:
+              cpu: "16"
+              memory: 256Gi
+              nvidia.com/gpu: "8"
+          startupProbe:
+            httpGet:
+              path: /live
+              port: 9090
+            periodSeconds: 15
+            failureThreshold: 200
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+          - mountPath: /dev/shm
+            name: dshm
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi


### PR DESCRIPTION
## What

Adds Dynamo serving recipes for the **`deepseek-ai/DeepSeek-V4-Pro-0813`** checkpoint on **H200**.

> **Note:** 0813 is a *different checkpoint* from `deepseek-ai/DeepSeek-V4-Pro` used by the sibling
> `recipes/deepseek-v4/deepseek-v4-pro/` recipes (different HF repo id), so it gets its own directory
> rather than another variant inside the existing one. Happy to fold it in if the team considers them
> the same model.

GB200 recipes for this checkpoint are a **separate contribution from a teammate**; this PR is H200 only
and deliberately leaves the directory structure open for a `*-gb200-*` sibling.

## Config matrix

|                 | Aggregated (8× H200)                                        | Disaggregated (16× H200)                                     |
|-----------------|-------------------------------------------------------------|--------------------------------------------------------------|
| **Agentic 64K** | `agg-h200-agentic`<br>C=2 · E2E 56.40 tok/s/user · 11.85 tok/s/GPU | `disagg-h200-agentic`<br>C≈7.95 · E2E 50.0 · **~24 tok/s/GPU** |
| **1M context**  | `agg-h200-1m`<br>998,218 tokens · TTFT ~202 s               | `disagg-h200-1m`<br>1,033,872 tokens · TTFT ~146 s            |

Agentic workload is 64K ISL / 400 OSL / 90% prefix reuse. Gate is **E2E ≥ 50 tok/s/user AND TTFT p50 < 5 s**,
jointly, where `E2E = OSL / (TTFT + OSL × ITL)`. The 1M configs are a **batch capability, not interactive** —
time-to-first-token is minutes at that length.

## Accuracy

Measured on the agentic configs, identical harness both sides (`nemo-skills:26.03`, 4 repeats, temp 0.6):

| Gate | agg | disagg |
|---|---|---|
| `gpqa_diamond` pass@1 | 88.26 | 88.38 |
| `ifeval` prompt-level strict | 94.48 | 94.29 |

**Disaggregation costs no accuracy** — worth stating because disagg moves KV between workers over NIXL, a
correctness-relevant path aggregated serving never exercises, and neither throughput benchmarks nor
needle-in-haystack can detect subtle corruption there.

## Engine choices — each A/B'd, not inherited

- **`cudagraph_mode: FULL_AND_PIECEWISE`**, not `FULL_DECODE_ONLY`: **−11% TTFT, +4.8% tok/s/GPU**.
  The sibling `deepseek-v4-pro` H200 recipe still carries `FULL_DECODE_ONLY`, inherited from the upstream
  Preview recipe and — as far as I can tell — never A/B'd. **This may be a free win there too**, though I
  have not measured it on that checkpoint and am not claiming it.
- **`--moe-backend marlin`** retained. `auto` is a wash and *cancels* the FULL_AND_PIECEWISE gain when combined.
- **No speculative decoding.** DSpark measured a large regression on this model.
- **1M on agg needs `SimpleCPUOffloadConnector`** — GPU-resident KV caps at 86,016 tokens on 8× H200.
- **1M on disagg** — the KV transport slot is already held by `NixlConnector`, so the offload tier is stacked
  via `MultiConnector` on the **decode worker only**; prefill stays NIXL-only.
- **`disagg-h200-1m` prefill uses mnbt 4096 + gpu-mu 0.97.** At mnbt 16384 it *cannot start*: 24.06 GiB KV
  needed for a single 1M request vs 20.75 GiB available. That startup check is **GPU-KV only** — a host
  offload tier extends what you can *hold*, not whether the engine will *start*.

## Best-practices compliance

Follows `nim-turbo-recipe-best-practices`: no taints/tolerations/node pinning, no NGC or HF secrets, no
JIT/CG cache overrides, no debug env vars, image **pinned by digest** with `imagePullPolicy: Always`,
`DYN_ROUTER_MODE` set explicitly, checkpoint loaded from the `model-cache` PVC with `HF_HUB_OFFLINE=1`, and
reasoning/tool-call parsers **consistent across all four recipes**.

The image digest was taken from the `imageID` of the pods that actually produced these numbers, so it is
provably the image benchmarked.

## Caveats reviewers should weigh

- **`disagg-h200-agentic` C≈7.95 is interpolated from N=1.** Run-to-run variance on this setup measures
  **17%**; C=7 and C=8 should be repeated to N≥3 before the operating point is quoted precisely. The
  *shape* (gate holds at C=5,6,7; cliff at C=7→8) is robust across five consecutive points.
- **`disagg-h200-1m` may not need `MultiConnector` at all.** GPU KV is 2.7–3.1 M tokens, far above the
  1.03 M served, so the 1.30 TB host tier was loaded but almost certainly never spilled. A NIXL-only A/B
  should decide whether to drop it.
- **Frontend router mode**: the skill mandates `DYN_ROUTER_MODE`, while the sibling `deepseek-v4-pro`
  recipe uses `--router-mode kv` CLI flags. I followed the skill; say the word if consistency with the
  sibling is preferred.
- **No `perf/` directory yet** (no `perf.yaml` / benchmark docs) and **no `sglang/` variants**. Happy to add.

## Test plan

All four configs were deployed and exercised on 8×/16× H200 (`vllm-runtime:1.4.0`, vLLM 0.26.0):
`aiperf` sweeps at the agentic profile, needle-in-haystack ladders for the 1M configs (lengths read from
the server's `usage.prompt_tokens`, not client-side estimates), and the two accuracy gates above.
360/360 and 300/300 benchmark requests valid with zero errors; 792/792 and 2,164/2,164 accuracy requests
successful.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek-V4-Pro-0813 deployment recipes for aggregated and disaggregated vLLM workloads.
  * Added configurations supporting 1M-token contexts, agentic workloads, FP8 KV caching, and CPU KV-cache offload.
  * Added automated model caching and download setup with persistent storage.
  * Added Kubernetes deployment guidance, configuration matrices, performance metrics, and validation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->