### PR TITLE
ci: pin GitHub Actions to commit SHAs and guard against regression [OPS-8393]

### DIFF
--- a/.github/actions/check-deploy-component/action.yml
+++ b/.github/actions/check-deploy-component/action.yml
@@ -38,13 +38,13 @@ runs:
 
     - name: Set up Go
       if: ${{ inputs.component == 'operator' }}
-      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
       with:
         go-version: '1.26.6'
 
     - name: Set up Python
       if: ${{ inputs.component == 'operator' }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: "3.11"
 

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -47,7 +47,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
       with:
         driver: docker-container
         # Enable BuildKit for enhanced metadata
@@ -59,7 +59,7 @@ runs:
       run: |
         docker system prune -af
     - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: '3.12'
         pip-install: jinja2 pyyaml
@@ -358,7 +358,7 @@ runs:
 
     # Upload comprehensive build metrics as artifact
     - name: Upload Comprehensive Build Metrics
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       if: always()
       with:
         name: build-metrics-${{ inputs.framework }}-${{ inputs.target }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}

--- a/.github/actions/docker-remote-build/action.yml
+++ b/.github/actions/docker-remote-build/action.yml
@@ -338,7 +338,7 @@ runs:
 
     # Upload comprehensive build metrics as artifact
     - name: Upload Comprehensive Build Metrics
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
       if: always()
       with:
         name: build-metrics-${{ inputs.framework }}-${{ inputs.target }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}

--- a/.github/actions/dynamo-deploy-test/action.yml
+++ b/.github/actions/dynamo-deploy-test/action.yml
@@ -208,7 +208,7 @@ runs:
         echo "name=${TEST_NAME}" >> $GITHUB_OUTPUT
 
     - name: Upload Test Results
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
       if: always()
       with:
         name: test-results-${{ steps.test-name.outputs.name }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
@@ -216,7 +216,7 @@ runs:
         retention-days: 7
 
     - name: Upload Pod Logs
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
       if: always()
       with:
         name: pod-logs-${{ steps.test-name.outputs.name }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
@@ -225,7 +225,7 @@ runs:
         retention-days: 7
 
     - name: Upload Allure Results
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
       if: always()
       with:
         name: allure-results-${{ steps.test-name.outputs.name }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -129,6 +129,7 @@ ignore:
   - 'container/deps/trtllm/**'
   - 'scripts/dco_check.py'
   - 'scripts/validate_skills.py'
+  - 'scripts/check_action_pins.py'
   # CODEOWNERS generation tooling (data + scripts). Validated by its own
   # codeowners.yml workflow (triggers on '**'); no backend CI needed here.
   - '.github/codeowners/**'

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -23,11 +23,11 @@ jobs:
   codeowners:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - run: pip install pyyaml pytest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,13 +22,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@42947a340483f03ba47bb1a039b2c519aab3df85  # v3.37.8
         with:
             languages: ${{matrix.language}}
             queries: +security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@42947a340483f03ba47bb1a039b2c519aab3df85  # v3.37.8
         with:
             category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/community-events-refresh.yml
+++ b/.github/workflows/community-events-refresh.yml
@@ -72,7 +72,7 @@ jobs:
           token: ${{ secrets.OPS_BOT_PAT }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '22'
 

--- a/.github/workflows/dco_comment.yml
+++ b/.github/workflows/dco_comment.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Get DCO status
         id: dco
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -29,7 +29,7 @@ jobs:
 
       - name: Comment if DCO failed (deduped)
         if: steps.dco.outputs.conclusion == 'failure'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Restore lychee cache
         id: restore-cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.run_id }}
@@ -27,7 +27,7 @@ jobs:
 
       - name: Check documentation links with lychee (first attempt)
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2.9.0
         with:
           args: &lychee_args >-
             --cache
@@ -63,7 +63,7 @@ jobs:
 
       - name: Retry documentation links with lychee
         if: steps.lychee.outputs.exit_code != '0'
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2.9.0
         with:
           args: *lychee_args
           fail: true
@@ -88,7 +88,7 @@ jobs:
           fi
 
       - name: Save lychee cache
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
         if: always() && github.ref == 'refs/heads/main'
         with:
           path: .lycheecache
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -159,7 +159,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '22'
 
@@ -1024,7 +1024,7 @@ jobs:
           yq '.versions' "$DOCS_FILE"
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '22'
 

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  # v5.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Run Linear Release
         # Pinned to an audited commit SHA (not a mutable @v0 tag) since this step
         # receives LINEAR_ACCESS_KEY. Bump deliberately after reviewing upstream.
-        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f  # v0.14.5
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: ${{ steps.params.outputs.command }}

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Validate PR title and add label
     runs-on: ubuntu-latest
     steps:
-      - uses:  ytanikin/pr-conventional-commits@b628c5a234cc32513014b7bfdd1e47b532124d98
+      - uses: ytanikin/pr-conventional-commits@b628c5a234cc32513014b7bfdd1e47b532124d98  # v1.3.0
         with:
           task_types: '["feat", "fix", "docs", "test", "ci", "refactor", "perf", "chore", "revert", "style", "build"]'
           add_label: 'true'

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -85,7 +85,7 @@ jobs:
           fi
       - name: Notify Slack
         if: steps.failed-jobs.outputs.has_failures == 'true'
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a #v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_NOTIFY_NIGHTLY_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/pr_full_ci_reminder.yaml
+++ b/.github/workflows/pr_full_ci_reminder.yaml
@@ -47,7 +47,7 @@ jobs:
           fi
       - name: Reminder to run full CI on PR
         if: steps.contributor_check.outputs.is_trusted != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         env:
           REPOSITORY: ${{ github.repository }}
           CONTRIBUTOR: ${{ github.actor }}
@@ -66,7 +66,7 @@ jobs:
                 '🚀'
             })
       - name: Add contribution labels to PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         env:
           IS_TRUSTED: ${{ steps.contributor_check.outputs.is_trusted }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
-    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
       timeout-minutes: 3
 
   recipe-check:
@@ -181,7 +181,7 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
       with:
         node-version: '22'
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
@@ -274,7 +274,7 @@ jobs:
     # docs-website and runs fern check on the composed result.
     - name: Fetch docs-website
       run: git fetch --no-tags --depth=1 origin docs-website:refs/remotes/origin/docs-website
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
       with:
         node-version: '22'
     - name: Install Fern CLI
@@ -311,7 +311,7 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
       with:
         node-version: '22'
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
@@ -341,7 +341,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 0  # clustertest derives its alpha version from v1.3.0
-    - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
+    - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
     - name: Run operator checks
       uses: $/.github/actions/check-deploy-component
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1284,7 +1284,7 @@ jobs:
       - name: Sync issues to Linear release
         # Pinned to an audited commit SHA (not a mutable @v0 tag) since this step
         # receives LINEAR_ACCESS_KEY. Bump deliberately after reviewing upstream.
-        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f  # v0.14.5
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           version: ${{ needs.prepare-release.outputs.version }}

--- a/.github/workflows/stale_cleaner.yml
+++ b/.github/workflows/stale_cleaner.yml
@@ -25,7 +25,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days. As a reminder, please use backlog label to avoid issues being marked as stale.'
           close-issue-message: 'This issue has been closed due to inactivity. If you believe this issue is still relevant, please feel free to reopen it with additional context or information.'

--- a/.github/workflows/test_report.yaml
+++ b/.github/workflows/test_report.yaml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Download and Extract Artifacts
-        uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc # v8
+        uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc  # v8
         with:
            run_id: ${{ github.event.workflow_run.id }}
            path: artifacts
@@ -97,7 +97,7 @@ jobs:
       - name: Complete report test status
         if: always()
         id: report_test_status
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -52,12 +52,12 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Detect source code changes
       id: src_changes
-      uses: dorny/paths-filter@v3
+      uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad  # v3.0.4
       with:
         filters: .github/filters.yaml
     - name: Check if Validation Workflow has run
       id: check_workflow
-      uses: actions/github-script@v6
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410  # v6.4.1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/xpu-ci.yaml
+++ b/.github/workflows/xpu-ci.yaml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload build log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: xpu-build-log
           path: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -188,6 +188,21 @@ repos:
       pass_filenames: false
       additional_dependencies:
         - pyyaml
+    - id: check-action-pins
+      name: GitHub Actions pinned to a commit SHA with a version comment
+      entry: python3 scripts/check_action_pins.py
+      language: system
+      # Coarse trigger on purpose. DEFAULT_GLOBS in the script is the single
+      # definition of what gets scanned; enumerating the same paths here would
+      # be a second copy to keep in sync. Full scan is well under 0.1s.
+      files: ^\.github/
+      pass_filenames: false
+    - id: check-action-pins-selftest
+      name: Self-test the action-pin matcher
+      entry: python3 scripts/check_action_pins.py --test
+      language: system
+      files: ^scripts/check_action_pins\.py$
+      pass_filenames: false
     - id: DCO check
       name: Checks the commit message for a developer certificate of origin signature
       entry: python3 scripts/dco_check.py

--- a/scripts/check_action_pins.py
+++ b/scripts/check_action_pins.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Check that every external GitHub Action is pinned to a commit SHA.
+
+A `uses:` reference to a mutable tag (`@v4`) or a branch resolves at run time
+to whatever commit that ref points at. An upstream account compromise or a
+re-pointed tag then executes attacker-controlled code inside CI, with access to
+repository secrets (CWE-829). Pinning to a full 40-character commit SHA makes
+the reference immutable.
+
+The SHA alone is unreadable, so this also requires the trailing version comment
+that makes a pin auditable and upgradable by a human:
+
+    uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+Exactly two spaces before `#`, one space after, and a full `vMAJOR.MINOR.PATCH`
+version. A bare major (`# v6`) is rejected: it cannot be checked against the
+SHA, which is the only reason to write the comment at all.
+
+Not checked, because neither is an external tag reference:
+  - local composite actions   (`uses: ./.github/actions/foo`)
+  - same-repo reusable workflows and any `${{ }}` expression ref
+
+Usage:
+  check_action_pins.py [repo_root]   scan and report violations
+  check_action_pins.py --test        run the self-test cases
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# The single definition of what gets scanned. The pre-commit hook triggers on a
+# coarser path pattern on purpose; duplicating this list there would be a second
+# copy to keep in sync.
+DEFAULT_GLOBS = (
+    ".github/workflows/*.yml",
+    ".github/workflows/*.yaml",
+    ".github/actions/**/action.yml",
+    ".github/actions/**/action.yaml",
+)
+
+# Upstreams that publish major-only tags (v8, v24) and no vMAJOR.MINOR.PATCH at
+# all, so the full-semver comment is impossible rather than merely absent. The
+# pin is still a real SHA; only the comment is relaxed. Keep this list short and
+# justified - each entry is a check that is not being performed.
+MAJOR_ONLY_UPSTREAMS = {
+    # Tags are v5 ... v24; no patch-level tags exist.
+    "dawidd6/action-download-artifact",
+    # Tags omit the leading v (1.5.2), so the comment says v1.3.0 by convention.
+    "ytanikin/pr-conventional-commits",
+}
+
+USES = re.compile(
+    r"^(?P<indent>[ \t]*(?:-[ \t]+)?)uses:(?P<sep>[ \t]*)(?P<ref>\S+)(?P<rest>.*)$"
+)
+ACTION = re.compile(
+    r"^(?P<action>[A-Za-z0-9][\w.-]*/[\w.-]+(?:/[\w./-]+)?)@(?P<ref>.+)$"
+)
+SHA = re.compile(r"^[0-9a-f]{40}$")
+FULL_SEMVER = re.compile(r"^ {2}# v\d+\.\d+\.\d+$")
+MAJOR_ONLY = re.compile(r"^ {2}# v\d+$")
+
+
+def check_line(line: str) -> str | None:
+    """Return an error message for one line, or None if it is fine.
+
+    Anything that is not an external action reference returns None.
+    """
+    m = USES.match(line.rstrip("\n"))
+    if not m:
+        return None
+    ref, rest = m.group("ref"), m.group("rest")
+
+    # Local composite actions and expression refs are not external tags.
+    if ref.startswith("./") or ref.startswith("$") or "${{" in ref or "${{" in rest:
+        return None
+
+    am = ACTION.match(ref)
+    if not am:
+        return None
+    action, at = am.group("action"), am.group("ref")
+
+    if not SHA.match(at):
+        hint = at if at.startswith("v") else "vX.Y.Z"
+        return (
+            f"{action} is pinned to the mutable ref '{at}'. "
+            f"Pin it to the full 40-character commit SHA of the tag and keep the "
+            f"version in a comment: uses: {action}@<sha>  # {hint}"
+        )
+
+    owner_repo = "/".join(action.split("/")[:2])
+    if not rest.strip():
+        return f"{action} is pinned but has no version comment. Append two spaces then '# vX.Y.Z'."
+
+    if owner_repo in MAJOR_ONLY_UPSTREAMS:
+        if FULL_SEMVER.match(rest) or MAJOR_ONLY.match(rest):
+            return None
+        return (
+            f"{action} comment must be exactly two spaces then '# vN' or '# vX.Y.Z' "
+            f"(upstream publishes major-only tags); found '{rest.strip()}'."
+        )
+
+    if FULL_SEMVER.match(rest):
+        return None
+    if MAJOR_ONLY.match(rest):
+        return (
+            f"{action} has a bare-major comment '{rest.strip()}'. Use the full version the "
+            f"SHA resolves to ('# vX.Y.Z') so the comment can be checked against the pin."
+        )
+    return f"{action} comment must be exactly two spaces then '# vX.Y.Z'; found '{rest.strip()}'."
+
+
+def scan(root: Path) -> list[str]:
+    problems: list[str] = []
+    for pattern in DEFAULT_GLOBS:
+        for path in sorted(root.glob(pattern)):
+            for lineno, line in enumerate(path.read_text().splitlines(), 1):
+                err = check_line(line)
+                if err:
+                    problems.append(f"{path.relative_to(root)}:{lineno}: {err}")
+    return problems
+
+
+CASES: list[tuple[str, bool]] = [
+    # (line, should_report_a_problem)
+    (
+        "      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2",
+        False,
+    ),
+    (
+        "    uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2",
+        False,
+    ),
+    (
+        "      uses: github/codeql-action/init@42947a340483f03ba47bb1a039b2c519aab3df85  # v3.37.8",
+        False,
+    ),
+    # Not external references.
+    ("      - uses: ./.github/actions/pytest", False),
+    (
+        "    uses: ${{ github.repository }}/.github/workflows/shared-test.yml@main",
+        False,
+    ),
+    ("      uses: ./.github/actions/docker-build", False),
+    ("        run: echo 'uses: actions/checkout@v4 in a string'", False),
+    # Mutable refs.
+    ("      - uses: actions/checkout@v4", True),
+    ("      uses: actions/setup-node@v4.4.0", True),
+    ("      uses: actions/checkout@main", True),
+    # Comment problems.
+    ("      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd", True),
+    (
+        "      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2",
+        True,
+    ),
+    (
+        "      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  #v6.0.2",
+        True,
+    ),
+    (
+        "      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6",
+        True,
+    ),
+    (
+        "      uses: actions/checkout@DE0FAC2E4500DABE0009E67214FF5F5447CE83DD  # v6.0.2",
+        True,
+    ),
+    # Major-only upstreams keep a bare major, but still need the spacing.
+    (
+        "      uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc  # v8",
+        False,
+    ),
+    (
+        "      uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc # v8",
+        True,
+    ),
+    (
+        "      uses: ytanikin/pr-conventional-commits@b628c5a234cc32513014b7bfdd1e47b532124d98  # v1.3.0",
+        False,
+    ),
+]
+
+
+def selftest() -> int:
+    failures = 0
+    for line, should_fail in CASES:
+        got = check_line(line)
+        if bool(got) != should_fail:
+            failures += 1
+            want = "a problem" if should_fail else "no problem"
+            print(
+                f"FAIL: expected {want} for:\n  {line}\n  got: {got}", file=sys.stderr
+            )
+    if failures:
+        print(f"{failures} of {len(CASES)} self-test cases failed", file=sys.stderr)
+        return 1
+    print(f"check_action_pins self-test: {len(CASES)} cases passed")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--test" in argv:
+        return selftest()
+    root = Path(argv[1]) if len(argv) > 1 else Path(__file__).resolve().parent.parent
+    problems = scan(root)
+    if not problems:
+        return 0
+    print(
+        "GitHub Actions must be pinned to a commit SHA with a version comment:\n",
+        file=sys.stderr,
+    )
+    for p in problems:
+        print(f"  {p}", file=sys.stderr)
+    print(
+        "\nResolve a tag to its commit SHA with:\n"
+        "  gh api repos/<owner>/<repo>/tags --jq '.[] | select(.name==\"<tag>\") | .commit.sha'",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check_action_pins.py
+++ b/scripts/check_action_pins.py
@@ -147,6 +147,9 @@ CASES: list[tuple[str, bool]] = [
         False,
     ),
     ("      uses: ./.github/actions/docker-build", False),
+    # The repo's self-repository shorthand; see .github/actionlint.yaml.
+    ("    uses: $/.github/workflows/shared-test.yml", False),
+    ("      - uses: $/.github/actions/pytest", False),
     ("        run: echo 'uses: actions/checkout@v4 in a string'", False),
     # Mutable refs.
     ("      - uses: actions/checkout@v4", True),

--- a/scripts/check_action_pins.py
+++ b/scripts/check_action_pins.py
@@ -49,10 +49,9 @@ DEFAULT_GLOBS = (
 # pin is still a real SHA; only the comment is relaxed. Keep this list short and
 # justified - each entry is a check that is not being performed.
 MAJOR_ONLY_UPSTREAMS = {
-    # Tags are v5 ... v24; no patch-level tags exist.
+    # Tags v4 and later are major-only (v4 ... v24); patch-level tags exist
+    # only up to v3.1.4, so no v8.Y.Z exists for the pinned major.
     "dawidd6/action-download-artifact",
-    # Tags omit the leading v (1.5.2), so the comment says v1.3.0 by convention.
-    "ytanikin/pr-conventional-commits",
 }
 
 USES = re.compile(
@@ -75,6 +74,12 @@ def check_line(line: str) -> str | None:
     if not m:
         return None
     ref, rest = m.group("ref"), m.group("rest")
+
+    # A quoted YAML scalar keeps its quotes inside \S+, which would fall through the
+    # ACTION match below and read as "not an external reference" - letting a quoted
+    # mutable tag pass the check this script exists to enforce.
+    if len(ref) > 1 and ref[0] in "\"'" and ref[-1] == ref[0]:
+        ref = ref[1:-1]
 
     # Local composite actions and expression refs are not external tags.
     if ref.startswith("./") or ref.startswith("$") or "${{" in ref or "${{" in rest:
@@ -151,6 +156,13 @@ CASES: list[tuple[str, bool]] = [
     ("    uses: $/.github/workflows/shared-test.yml", False),
     ("      - uses: $/.github/actions/pytest", False),
     ("        run: echo 'uses: actions/checkout@v4 in a string'", False),
+    # Quoted YAML scalars are still external references.
+    ('      uses: "actions/checkout@v4"', True),
+    ("      uses: 'actions/checkout@main'", True),
+    (
+        '      uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2',
+        False,
+    ),
     # Mutable refs.
     ("      - uses: actions/checkout@v4", True),
     ("      uses: actions/setup-node@v4.4.0", True),


### PR DESCRIPTION
## Summary

Linear: OPS-8393 (subissue of OPS-8265)

GitHub Actions referenced by a mutable tag (`@v4`, `@v7`) resolve at run time to whatever commit that tag currently points at. An upstream account compromise or a re-pointed tag runs attacker-controlled code inside our CI, with access to repository secrets. Pinning to a full 40-character commit SHA makes the reference immutable.

Scanned `.github/` on `main`: **182 external action references, 158 already pinned, 24 still on mutable tags.**

This change pins those 24 and normalizes every external reference to one format:

```yaml
uses: owner/repo@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
```

### Newly pinned (24 sites, 15 actions)

Every action stays on the major version it already used, moving only to the latest minor/patch inside that major. **No action changes major version, so no behaviour changes.**

| Action | Was | Now | Sites |
| --- | --- | --- | --- |
| `actions/github-script` | `@v7` | `f28e40c7f34bde8b3046d885e986cb6290c5673b` — v7.1.0 | 4 |
| `actions/setup-python` | `@v5` | `a26af69be951a213d495a4c3e4e4022e16d87065` — v5.6.0 | 3 |
| `actions/setup-node` | `@v4` | `49933ea5288caeca8642d1e84afbd3f7d6820020` — v4.4.0 | 3 |
| `lycheeverse/lychee-action` | `@v2` | `e7477775783ea5526144ba13e8db5eec57747ce8` — v2.9.0 | 2 |
| `actions/upload-artifact` | `@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` — v4.6.2 | 2 |
| `peter-evans/create-or-update-comment` | `@v4` | `71345be0265236311c031f5c7866368bd1eff043` — v4.0.0 | 1 |
| `github/codeql-action/init` | `@v3` | `42947a340483f03ba47bb1a039b2c519aab3df85` — v3.37.8 | 1 |
| `github/codeql-action/analyze` | `@v3` | `42947a340483f03ba47bb1a039b2c519aab3df85` — v3.37.8 | 1 |
| `dorny/paths-filter` | `@v3` | `0e4a8c6effa4802afeda77dc8d303f8176d7dfad` — v3.0.4 | 1 |
| `actions/stale` | `@v9` | `5bef64f19d7facfb25b37b414482c7164d639639` — v9.1.0 | 1 |
| `actions/labeler` | `@v5` | `8558fd74291d67161a8a78ce36a881fa63b766a9` — v5.0.0 | 1 |
| `actions/github-script` | `@v6` | `d7906e4ad0b1822421a7e6a35d5ca353c962f410` — v6.4.1 | 1 |
| `actions/checkout` | `@v4` | `11d5960a326750d5838078e36cf38b85af677262` — v4.4.0 | 1 |
| `actions/cache/save` | `@v5` | `caa296126883cff596d87d8935842f9db880ef25` — v5.1.0 | 1 |
| `actions/cache/restore` | `@v5` | `caa296126883cff596d87d8935842f9db880ef25` — v5.1.0 | 1 |

Four of these SHAs are ones the repo already pins elsewhere (`setup-python` v5.6.0, `upload-artifact` v4.6.2, `setup-node` v4.4.0), so this converges those actions on a single SHA rather than introducing new ones.

> [!NOTE]
> `actions/github-script@v6` and `actions/checkout@v4` stay on v6 and v4 even though other call sites here already use v7 and v6. Major upgrades are deliberately out of scope — several are behaviour-affecting and belong in their own reviewable change.

### Comment-only (17 sites)

**No SHA changes.** These fix formatting drift and imprecision:

- Whitespace: `#v6` and ` # v3.0.1` become `  # v6.0.0` and `  # v3.0.1`.
- Bare majors replaced with the version the SHA actually resolves to — `# v4` → `# v4.3.1` (checkout), `# v4` → `# v4.4.0` (setup-node), `# v7` → `# v7.0.11` (create-pull-request), `#v6` → `# v6.0.0` (upload-artifact). A bare major defeats the comment's purpose, which is to let a reader audit the SHA.
- `ytanikin/pr-conventional-commits` carried **no version comment at all**; its SHA resolves to `1.3.0`.

Every version comment was produced by resolving the SHA against the upstream tag list, not by trusting the existing comment.

### One upstream cannot use `vX.Y.Z`

- `dawidd6/action-download-artifact` is major-only from v4 onward (`v4` … `v24`); patch-level tags exist only up to `v3.1.4`, so no `v8.Y.Z` exists for the pinned major. The pinned SHA is exactly `v8`, so the comment stays `# v8`.

`ytanikin/pr-conventional-commits` looks like a second case but is not. Its upstream tags omit the leading `v` (`1.3.0`), which is why the comment reads `# v1.3.0` — but the checker only ever inspects the comment, never the upstream tag format, so a full-semver comment satisfies it with no exception at all.

## Validation

- **No pinned SHA moved.** Diffed every changed `uses:` line old-vs-new: 17 already-pinned lines touched, **0 SHA changes** among them. The only SHAs introduced are on the 24 lines that previously had no SHA at all.
- **Every SHA verified upstream.** Each was resolved through the GitHub tags API to a real release tag in the same major — none hand-copied.
- **YAML parses.** All 21 changed files validate.
- **Format compliance.** All 182 external references now match `uses: <owner>/<repo>@<40-hex>  # v<semver>`; a scan for non-conforming lines returns none.
- **`pre-commit run --files`** on all changed files: `check yaml`, `codespell`, `trim trailing whitespace`, `mixed line ending`, `check for merge conflicts` all pass.

Local composite actions (`./.github/actions/*`) and same-repo reusable workflow calls are referenced by path or ref rather than external tag, so they are not part of this finding and are untouched.

---

## Guardrail: `scripts/check_action_pins.py`

Pinning the existing references stops today's exposure; nothing stopped the next mutable tag from landing. The second commit adds the check that does.

### Where it runs

The `pre-commit` job in `pre-merge.yml` is ungated and `pre-merge-status-check` lists it in `needs:`, so **a hook in `.pre-commit-config.yaml` is automatically a blocking Pre Merge check**. One definition gives both the local `git commit` gate and the CI gate — no new job, no new workflow, no new third-party action dependency.

```yaml
    - id: check-action-pins
      name: GitHub Actions pinned to a commit SHA with a version comment
      entry: python3 scripts/check_action_pins.py
      language: system
      files: ^\.github/
      pass_filenames: false
```

### Why not zizmor or actionlint

**Neither enforces the version comment.** They check pinning; nothing off-the-shelf checks `  # vX.Y.Z`. That gap matters here — of the 41 lines the first commit corrected, **17 were comment drift rather than missing pins**, so a pinning-only check would let the more common failure straight back in.

zizmor additionally audits template injection, permissions, and credential persistence. Valuable, but switching it on surfaces a backlog that must be triaged before it can block, which turns a regression gate into a remediation project. Worth doing as its own effort.

Using a third-party action to enforce supply-chain hygiene also adds a supply-chain dependency, and the check is 0.04s of stdlib regex.

### What it enforces

- External `uses:` must be a full 40-character lowercase commit SHA — mutable tags (`@v4`), branches (`@main`), and partial versions (`@v4.4.0`) are all rejected.
- The comment must be exactly two spaces, `# `, then a full `vMAJOR.MINOR.PATCH`. A bare major (`# v6`) is rejected: it cannot be checked against the SHA, which is the comment's only purpose.
- Local composite actions (`./.github/actions/*`) and `${{ }}` expression refs are ignored — neither is an external tag.
- Quoted YAML scalars are unwrapped before matching, so `uses: "actions/checkout@v4"` is caught rather than read as a non-reference.
- Errors name the file, line, and the `gh api` command that resolves a tag to its SHA.

`MAJOR_ONLY_UPSTREAMS` holds exactly one entry — `dawidd6/action-download-artifact` — with its reason inline, so the single relaxation is visible in review rather than hidden inside a loosened pattern.

### Self-test

Because the CI job runs `--all-files`, **a false positive blocks every PR in the repo**, not only ones touching workflows. The matcher therefore ships with 23 cases behind its own hook, gated on the script's own path — the same pattern as the existing `check-asset-paths-selftest`.

### Guardrail validation

- **Catches exactly what this PR fixed.** Run against the pre-fix tree, the check reports **41 problems: the 24 mutable refs and the 17 comment defects** the first commit corrected — and nothing else. Against the fixed tree it exits 0.
- **Negative test.** Reintroducing a single `github/codeql-action/init@v3` fails the hook with the resolved-SHA hint; restoring the pin passes again.
- **Self-test:** 23/23 cases pass, including the quoted-scalar forms and a quoted *valid* pin, which is the regression the unwrap could plausibly have introduced.
- **Cost:** full scan is 0.04s against that job's `timeout-minutes: 3`.

> [!NOTE]
> There is no `.github/dependabot.yml` in this repo. A guardrail stops regression but not rot — that is how `ytanikin` sits at 1.3.0 against 1.5.2 upstream and `dawidd6` at v8 against v24. Dependabot's `github-actions` ecosystem understands SHA pins with `# vX.Y.Z` comments and bumps both together. Deliberately left out of this PR because enabling it immediately opens update PRs across the repo, which is a team decision rather than part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

