### PR TITLE
fix(llm): do not install a single-value guided schema for named zero-argument tools

### DIFF
--- a/components/src/dynamo/common/utils/guided_json.py
+++ b/components/src/dynamo/common/utils/guided_json.py
@@ -12,6 +12,48 @@ from urllib.parse import unquote
 from dynamo.llm import HttpError
 
 
+def admits_only_empty_object(schema: Any) -> bool:
+    """Return whether ``schema`` permits exactly the JSON value ``{}``."""
+    if not isinstance(schema, dict):
+        return False
+    if (
+        schema.get("type") != "object"
+        or schema.get("additionalProperties") is not False
+    ):
+        return False
+    properties = schema.get("properties", {})
+    required = schema.get("required", [])
+    if not isinstance(properties, dict) or properties:
+        return False
+    if not isinstance(required, list) or required:
+        return False
+    for key, value in schema.items():
+        if key in {
+            "type",
+            "properties",
+            "required",
+            "additionalProperties",
+            "title",
+            "description",
+        }:
+            continue
+        if key == "minProperties" and type(value) is int and value == 0:
+            continue
+        if key == "maxProperties" and type(value) is int and value >= 0:
+            continue
+        if key in {
+            "$comment",
+            "default",
+            "deprecated",
+            "examples",
+            "readOnly",
+            "writeOnly",
+        }:
+            continue
+        return False
+    return True
+
+
 def _schema_error(message: str) -> HttpError:
     return HttpError(400, f"Invalid guided_json schema: {message}")
 

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -32,6 +32,7 @@ from vllm.tool_parsers import ToolParser
 from vllm.tool_parsers.utils import get_json_schema_from_tools
 from vllm.utils.async_utils import make_async
 
+from dynamo.common.utils.guided_json import admits_only_empty_object
 from dynamo.llm.exceptions import InvalidArgument
 
 from .thinking import apply_default_thinking_mode_to_template_kwargs
@@ -267,6 +268,10 @@ def build_tool_call_guided_decoding(
         # _validate_chat_completion_request.
         json_schema = get_json_schema_from_tools(tool_choice, request.tools)
         if json_schema is not None:
+            if _is_named_tool_choice(tool_choice) and admits_only_empty_object(
+                json_schema
+            ):
+                return {"regex": r"\{\}"}
             if (
                 request.parallel_tool_calls is False
                 and json_schema.get("type") == "array"
@@ -747,7 +752,7 @@ async def preprocess_chat_request(
         and parser_guided_decoding is None
         and guided_decoding is tool_guided_decoding
         and isinstance(tool_guided_decoding, dict)
-        and "json" in tool_guided_decoding
+        and ("json" in tool_guided_decoding or "regex" in tool_guided_decoding)
     )
 
     _, engine_prompt = await renderer.render_messages_async(messages, chat_params)

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -579,6 +579,9 @@ def build_tool_call_guided_decoding(
     constraint: Any = None
 
     if tool_choice == "required" or _is_named_tool_choice(tool_choice):
+        if named_closed_zero_arg_tool(request) is not None:
+            return {"regex": r"\{\}"}
+
         # get_json_schema_constraint branches on isinstance(tool_choice,
         # ToolChoice) for the named-function case — passing our raw dict
         # would silently fall through and return None, disabling guided
@@ -625,8 +628,6 @@ def build_tool_call_guided_decoding(
 
     if isinstance(constraint, tuple) and len(constraint) == 2:
         if constraint[0] == "json_schema":
-            if named_closed_zero_arg_tool(request) is not None:
-                return {"regex": r"\{\}"}
             return {"json": constraint[1]}
         if constraint[0] == "structural_tag":
             tag_value = constraint[1]

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -29,6 +29,7 @@ from sglang.srt.parser.jinja_template_utils import (
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 
 from dynamo.common.utils.engine_response import trailing_stop_prefix_len
+from dynamo.common.utils.guided_json import admits_only_empty_object
 
 from .thinking import apply_default_thinking_mode_to_template_kwargs
 from .utils import PreprocessError, random_call_id
@@ -52,6 +53,7 @@ class SglangPreprocessResult:
     guided_decoding: dict[str, Any] | None
     request: dict[str, Any]
     force_reasoning: bool = False
+    named_zero_arg_tool: str | None = None
 
 
 # --- force_reasoning detection (mirrors sglang's template_manager) -------
@@ -328,6 +330,20 @@ def _is_named_tool_choice(tool_choice: Any) -> bool:
         and isinstance(tool_choice.get("function"), dict)
         and bool(tool_choice["function"].get("name"))
     )
+
+
+def named_closed_zero_arg_tool(request: dict[str, Any]) -> str | None:
+    """Return the named tool when its only valid argument value is ``{}``."""
+    tool_choice = request.get("tool_choice", "auto")
+    if not _is_named_tool_choice(tool_choice):
+        return None
+    chosen_name = tool_choice["function"]["name"]
+    for tool in convert_tools(request.get("tools")) or []:
+        if tool.function.name == chosen_name and admits_only_empty_object(
+            tool.function.parameters
+        ):
+            return chosen_name
+    return None
 
 
 def _guided_tool_choice_requires_reasoning(
@@ -609,6 +625,8 @@ def build_tool_call_guided_decoding(
 
     if isinstance(constraint, tuple) and len(constraint) == 2:
         if constraint[0] == "json_schema":
+            if named_closed_zero_arg_tool(request) is not None:
+                return {"regex": r"\{\}"}
             return {"json": constraint[1]}
         if constraint[0] == "structural_tag":
             tag_value = constraint[1]
@@ -844,6 +862,11 @@ def preprocess_chat_request(
         guided_decoding=guided_decoding,
         request=request,
         force_reasoning=force_reasoning,
+        named_zero_arg_tool=(
+            named_closed_zero_arg_tool(request)
+            if guided_decoding == {"regex": r"\{\}"}
+            else None
+        ),
     )
 
 
@@ -958,6 +981,7 @@ class SglangStreamingPostProcessor:
         history_tool_calls_count: int = 0,
         sglang_tools: list[SglangTool] | None = None,
         tool_call_parser_name: str | None = None,
+        named_zero_arg_tool: str | None = None,
         eos_token_ids: list[int] | None = None,
         prompt_token_ids: list[int] | None = None,
         stop_strings: set[str] | None = None,
@@ -970,6 +994,7 @@ class SglangStreamingPostProcessor:
         self._tool_call_parser_name = _normalize_sglang_parser_name(
             tool_call_parser_name
         )
+        self._named_zero_arg_tool = named_zero_arg_tool
         self._fast_plain_text = tool_call_parser is None and reasoning_parser is None
         # Preserve special tokens when a parser is active so tool-call and
         # reasoning delimiters remain visible during incremental decoding.
@@ -1409,6 +1434,9 @@ class SglangStreamingPostProcessor:
                     normal_text
                 )
             content_text = parsed_text
+            if self._named_zero_arg_tool is not None:
+                # The exact regex emits the argument object, not user-visible text.
+                content_text = ""
 
             for tc in tool_calls:
                 idx = tc.tool_index
@@ -1453,9 +1481,13 @@ class SglangStreamingPostProcessor:
             # can misidentify words in the prompt (e.g. a person's name)
             # as function names.
             known_names = (
-                {t.function.name for t in self._sglang_tools}
-                if self._sglang_tools
-                else set()
+                {self._named_zero_arg_tool}
+                if self._named_zero_arg_tool is not None
+                else (
+                    {t.function.name for t in self._sglang_tools}
+                    if self._sglang_tools
+                    else set()
+                )
             )
             if known_names:
                 for idx in list(self._tool_call_names):
@@ -1493,7 +1525,19 @@ class SglangStreamingPostProcessor:
 
             if should_reparse:
                 if self._is_json_array_parser:
-                    final_calls = _parse_json_array_buffer(full_text)
+                    if (
+                        self._named_zero_arg_tool is not None
+                        and full_text.strip() == "{}"
+                    ):
+                        final_calls = [
+                            ToolCallItem(
+                                tool_index=0,
+                                name=self._named_zero_arg_tool,
+                                parameters="{}",
+                            )
+                        ]
+                    else:
+                        final_calls = _parse_json_array_buffer(full_text)
                     # Secondary fallback: when guided decoding did not
                     # constrain the output (e.g. the backend doesn't
                     # support it), the model may have produced tool calls
@@ -1567,6 +1611,15 @@ class SglangStreamingPostProcessor:
                     "Dropping incomplete SGLang tool calls with no valid arguments: %s",
                     dropped_names,
                 )
+
+            if self._named_zero_arg_tool is not None and not self._tool_call_names:
+                # A backend that cannot enforce the regex may return ordinary text.
+                # It was held back to avoid leaking the exact `{}` argument payload,
+                # so restore it when no zero-argument tool call was recovered.
+                fallback_content = "".join(self._tool_text_parts)
+                if fallback_content.strip() != "{}":
+                    delta["content"] = fallback_content
+                    has_content = True
 
         if finish_reason and self._tool_call_names:
             tool_calls_out: list[dict[str, Any]] = []

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -285,6 +285,7 @@ class SglangPreprocessWorkerResult:
     dynamo_preproc: dict[str, Any]
     request: dict[str, Any]
     force_reasoning: bool = False
+    named_zero_arg_tool: str | None = None
     # ``effective_reasoning_parser_name`` is None when the request opted out
     # via ``separate_reasoning=False``; the main process must skip creating
     # a reasoning parser in that case so the pool path matches the inline
@@ -359,6 +360,7 @@ def _preprocess_worker(
         request=request,
         force_reasoning=pre.force_reasoning,
         effective_reasoning_parser_name=effective_reasoning_parser_name,
+        named_zero_arg_tool=pre.named_zero_arg_tool,
     )
 
 
@@ -606,6 +608,7 @@ class SglangProcessor:
             ),
             sglang_tools=convert_tools(request.get("tools")),
             tool_call_parser_name=self.tool_call_parser_name,
+            named_zero_arg_tool=pre.named_zero_arg_tool,
             eos_token_ids=self.eos_token_ids,
             prompt_token_ids=pre.prompt_token_ids,
             stop_strings=_request_stop_strings(request),
@@ -665,6 +668,7 @@ class SglangProcessor:
             ),
             sglang_tools=convert_tools(request.get("tools")),
             tool_call_parser_name=self.tool_call_parser_name,
+            named_zero_arg_tool=preproc_result.named_zero_arg_tool,
             eos_token_ids=self.eos_token_ids,
             prompt_token_ids=preproc_result.prompt_token_ids,
             stop_strings=_request_stop_strings(request),

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -1381,6 +1381,37 @@ class TestBuildToolCallGuidedDecoding:  # FRONTEND.3 — guided-decoding setup f
         assert isinstance(guided, dict)
         assert "json" in guided
 
+    def test_named_closed_zero_arg_tool_uses_exact_regex_guidance(self):
+        tools = convert_tools(
+            [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_server_time",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {},
+                            "required": [],
+                            "additionalProperties": False,
+                        },
+                    },
+                }
+            ]
+        )
+
+        guided = build_tool_call_guided_decoding(
+            {
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "get_server_time"},
+                }
+            },
+            tool_call_parser_name="hermes",
+            sglang_tools=tools,
+        )
+
+        assert guided == {"regex": r"\{\}"}
+
     def test_required_tool_choice_supports_older_sglang_constraint_signature(
         self, monkeypatch
     ):
@@ -1915,6 +1946,40 @@ class TestPreprocessChatRequest:  # FRONTEND.1 — chat-template input preproces
             "Tool-call guided decoding will be ignored because of response_format already exists."
             in caplog.text
         )
+
+    def test_response_format_disables_named_zero_arg_tool_reconstruction(
+        self, tokenizer
+    ):
+        result = preprocess_chat_request(
+            {
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "response_format": {"type": "json_object"},
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_server_time",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": False,
+                            },
+                        },
+                    }
+                ],
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "get_server_time"},
+                },
+            },
+            tokenizer=tokenizer,
+            tool_call_parser_name="hermes",
+            reasoning_parser_name=None,
+        )
+
+        assert result.guided_decoding == {"json": {"type": "object"}}
+        assert result.named_zero_arg_tool is None
 
     def test_assistant_tool_calls_with_string_arguments(self, tokenizer):
         """Multi-turn with prior assistant tool_calls renders without raising.

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -1401,10 +1401,24 @@ class TestBuildToolCallGuidedDecoding:  # FRONTEND.3 — guided-decoding setup f
 
         guided = build_tool_call_guided_decoding(
             {
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_server_time",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {},
+                                "required": [],
+                                "additionalProperties": False,
+                            },
+                        },
+                    }
+                ],
                 "tool_choice": {
                     "type": "function",
                     "function": {"name": "get_server_time"},
-                }
+                },
             },
             tool_call_parser_name="hermes",
             sglang_tools=tools,

--- a/components/src/dynamo/frontend/tests/test_sglang_tool_calls.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_tool_calls.py
@@ -551,6 +551,101 @@ class TestJsonArrayParserReparse:  # FRONTEND.4 — JSON-array parser reparse pa
         assert json.loads(tc[0]["function"]["arguments"]) == {"city": "NYC"}
         assert choice["finish_reason"] == "tool_calls"
 
+    def test_named_zero_arg_reparse(self, tokenizer):
+        """A named zero-argument regex response becomes the requested call."""
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer,
+            tool_call_parser=JsonArrayParser(),
+            reasoning_parser=None,
+            sglang_tools=TOOLS,
+            named_zero_arg_tool="get_weather",
+        )
+
+        choice = post.process_output(
+            {"token_ids": tokenizer.encode("{}"), "finish_reason": "stop"}
+        )
+
+        assert choice is not None
+        assert choice["delta"].get("content") is None
+        assert choice["finish_reason"] == "tool_calls"
+        assert choice["delta"]["tool_calls"][0]["function"] == {
+            "name": "get_weather",
+            "arguments": "{}",
+        }
+
+    def test_named_zero_arg_reparse_across_chunks(self, tokenizer):
+        """The exact regex response remains a tool call across stream boundaries."""
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer,
+            tool_call_parser=JsonArrayParser(),
+            reasoning_parser=None,
+            sglang_tools=TOOLS,
+            named_zero_arg_tool="get_weather",
+        )
+        token_ids = tokenizer.encode("{}")
+        choices = [
+            post.process_output({"token_ids": [token_id], "finish_reason": None})
+            for token_id in token_ids[:-1]
+        ]
+        choices.append(
+            post.process_output({"token_ids": token_ids[-1:], "finish_reason": "stop"})
+        )
+
+        assert all(
+            "content" not in choice.get("delta", {})
+            for choice in choices
+            if choice is not None
+        )
+        final = choices[-1]
+        assert final is not None
+        assert final["finish_reason"] == "tool_calls"
+        assert final["delta"]["tool_calls"][0]["function"] == {
+            "name": "get_weather",
+            "arguments": "{}",
+        }
+
+    def test_named_zero_arg_preserves_unconstrained_fallback_text(self, tokenizer):
+        """An engine that ignores the regex must not lose its ordinary response."""
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer,
+            tool_call_parser=JsonArrayParser(),
+            reasoning_parser=None,
+            sglang_tools=TOOLS,
+            named_zero_arg_tool="get_weather",
+        )
+
+        choice = post.process_output(
+            {
+                "token_ids": tokenizer.encode("The service is unavailable."),
+                "finish_reason": "stop",
+            }
+        )
+
+        assert choice is not None
+        assert choice["delta"]["content"] == "The service is unavailable."
+        assert "tool_calls" not in choice["delta"]
+        assert choice["finish_reason"] == "stop"
+
+    def test_named_zero_arg_rejects_other_tool_fallback(self, tokenizer):
+        """A named choice must not recover native syntax for another tool."""
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer,
+            tool_call_parser=JsonArrayParser(),
+            reasoning_parser=None,
+            sglang_tools=TOOLS,
+            tool_call_parser_name="qwen25",
+            named_zero_arg_tool="get_weather",
+        )
+        text = '[{"name": "search_gutenberg_books", "parameters": {}}]'
+
+        choice = post.process_output(
+            {"token_ids": tokenizer.encode(text), "finish_reason": "stop"}
+        )
+
+        assert choice is not None
+        assert choice["delta"]["content"] == text
+        assert "tool_calls" not in choice["delta"]
+
     def test_multiple_calls_reparse(self, tokenizer):
         """Multiple calls in one chunk; re-parse must recover all."""
         text = (

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -26,6 +26,7 @@ from transformers import AutoTokenizer
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.tool_parsers import ToolParser
 
+from dynamo.common.utils.guided_json import admits_only_empty_object
 from dynamo.frontend import prepost as prepost_module
 from dynamo.frontend.prepost import (
     StreamingPostProcessor,
@@ -2154,6 +2155,49 @@ class TestToolCallGuidedDecoding:
         assert set(guided) == {"json"}
         assert parser.requests == []
 
+    def test_named_closed_zero_arg_tool_uses_exact_regex_guidance(self, tokenizer):
+        guided = build_tool_call_guided_decoding(
+            self._request(
+                tokenizer,
+                tool_choice={"type": "function", "function": {"name": "get_weather"}},
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {},
+                                "required": [],
+                                "additionalProperties": False,
+                            },
+                        },
+                    }
+                ],
+            ),
+            tool_parser=None,
+        )
+
+        assert guided == {"regex": r"\{\}"}
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            {"minProperties": 0},
+            {"maxProperties": 1},
+            {"examples": [{}]},
+        ],
+    )
+    def test_zero_arg_schema_allows_neutral_bounds_and_annotations(self, extra):
+        assert admits_only_empty_object(
+            {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+                **extra,
+            }
+        )
+
     def test_required_choice_disables_parallel_calls_in_json_guidance(self, tokenizer):
         guided = build_tool_call_guided_decoding(
             self._request(
@@ -2290,6 +2334,63 @@ class TestToolCallGuidedDecoding:
         assert choice["delta"]["tool_calls"][0]["function"] == {
             "name": "get_weather",
             "arguments": '{"city":"Paris"}',
+        }
+
+    @pytest.mark.asyncio
+    async def test_named_closed_zero_arg_regex_becomes_a_tool_call(self, tokenizer):
+        request = json.loads(json.dumps(TOOL_REQUEST))
+        request["tool_choice"] = {
+            "type": "function",
+            "function": {"name": "get_weather"},
+        }
+        request["tools"][0]["function"]["parameters"] = {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        }
+        result = await prepost_module.preprocess_chat_request(
+            request,
+            tokenizer=tokenizer,
+            renderer=SimpleNamespace(
+                render_messages_async=AsyncMock(
+                    return_value=(None, {"prompt_token_ids": [1]})
+                )
+            ),
+            tool_parser_class=None,
+            structural_tag_mode="off",
+        )
+
+        assert result.guided_decoding == {"regex": r"\{\}"}
+        assert result.uses_dynamo_json_tool_call_fallback is True
+
+        post = StreamingPostProcessor(
+            tokenizer=tokenizer,
+            request_for_sampling=result.request_for_sampling,
+            sampling_params=SamplingParams(),
+            prompt_token_ids=result.prompt_token_ids,
+            tool_parser=result.tool_parser,
+            reasoning_parser_class=None,
+            chat_template_kwargs=result.chat_template_kwargs,
+            stream_response=False,
+            uses_dynamo_json_tool_call_fallback=(
+                result.uses_dynamo_json_tool_call_fallback
+            ),
+        )
+        choice = post.process_output(
+            SimpleNamespace(
+                index=0,
+                text="{}",
+                token_ids=[],
+                finish_reason="stop",
+                logprobs=None,
+            )
+        )
+
+        assert choice is not None
+        assert choice["finish_reason"] == "tool_calls"
+        assert choice["delta"]["tool_calls"][0]["function"] == {
+            "name": "get_weather",
+            "arguments": "{}",
         }
 
     # Explicit assistant constraints must override automatic tool-call guidance.

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -1155,6 +1155,9 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
             if json_schema is not None:
                 reject_nonprogressing_guided_json_ref_cycles(json_schema)
                 return {"json_schema": json.dumps(json_schema)}
+            regex = guided_decoding.get("regex")
+            if regex is not None:
+                return {"regex": regex}
             structural_tag = guided_decoding.get("structural_tag")
             if structural_tag is not None:
                 return {"structural_tag": serialize_structural_tag(structural_tag)}

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -700,6 +700,19 @@ def test_build_sampling_params_maps_guided_decoding_to_json_schema():
     )
 
 
+def test_build_sampling_params_maps_guided_decoding_to_regex():
+    handler = _new_decode_handler(use_sglang_tokenizer=False)
+
+    sampling_params = handler._build_sampling_params(
+        {
+            "sampling_options": {"guided_decoding": {"regex": r"\{\}"}},
+            "stop_conditions": {"max_tokens": 8},
+        }
+    )
+
+    assert sampling_params["regex"] == r"\{\}"
+
+
 def test_build_sampling_params_maps_min_tokens_for_token_requests():
     handler = _new_decode_handler(use_sglang_tokenizer=False)
 

--- a/lib/llm/src/preprocessor/tool_choice.rs
+++ b/lib/llm/src/preprocessor/tool_choice.rs
@@ -6,7 +6,9 @@
 use crate::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
 use crate::protocols::openai::GuidedToolConstraint;
 use crate::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
-use crate::protocols::openai::tools::{get_json_schema_from_tools, validate_openai_tool_choice};
+use crate::protocols::openai::tools::{
+    ToolChoiceGuidance, get_tool_choice_guidance_from_tools, validate_openai_tool_choice,
+};
 
 use dynamo_parsers::tool_calling::{ToolChoice, ToolDefinition};
 use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolChoiceOption, ResponseFormat};
@@ -125,21 +127,24 @@ impl OpenAIPreprocessor {
             return Ok(GuidedToolConstraint::None);
         }
 
-        match get_json_schema_from_tools(
+        match get_tool_choice_guidance_from_tools(
             Some(tool_choice),
             Some(tools),
             request.inner.parallel_tool_calls,
         ) {
-            Ok(Some(schema)) => {
+            Ok(Some(guidance)) => {
                 let gd = common_request
                     .sampling_options
                     .guided_decoding
                     .get_or_insert_default();
-                gd.json = Some(schema);
+                match guidance {
+                    ToolChoiceGuidance::Json(schema) => gd.json = Some(schema),
+                    ToolChoiceGuidance::Regex(regex) => gd.regex = Some(regex),
+                }
 
-                // Report the shape that was installed, not the tool_choice that
-                // asked for it. Only these two arms produce a JSON schema, so only
-                // they may be streamed as guided JSON.
+                // Report the parser constraint implied by the installed grammar,
+                // not merely the tool_choice that requested it. Both JSON and
+                // regex guidance still use the guided-JSON tool-output parser.
                 return Ok(installed_json_constraint(tool_choice));
             }
             Ok(None) => {}
@@ -242,7 +247,7 @@ pub(crate) fn guided_tool_constraint(
     // constraint for a `tool_choice` that names a tool absent from `tools` (or an
     // empty `tools` list under `tool_choice: "required"`).
     let tools = request.inner.tools.as_deref().unwrap_or(&[]);
-    match get_json_schema_from_tools(
+    match get_tool_choice_guidance_from_tools(
         Some(tool_choice),
         Some(tools),
         request.inner.parallel_tool_calls,
@@ -262,11 +267,11 @@ fn uses_kimi_k3_parser(tool_call_parser: Option<&str>, reasoning_parser: Option<
     tool_call_parser.is_some_and(is_k3) || reasoning_parser.is_some_and(is_k3)
 }
 
-/// Map a forced `tool_choice` onto the JSON shape its schema constrains output to.
+/// Map a forced `tool_choice` onto the guided-JSON parser constraint for its grammar.
 ///
-/// Only reachable once `get_json_schema_from_tools` actually produced a schema, and
-/// that function returns `None` for `Auto`/`None`, so those arms are unreachable in
-/// practice and report [`GuidedToolConstraint::None`] rather than guessing.
+/// Only reachable once `get_tool_choice_guidance_from_tools` produced either JSON or
+/// regex guidance. It returns `None` for `Auto`/`None`, so those arms are unreachable
+/// in practice and report [`GuidedToolConstraint::None`] rather than guessing.
 fn installed_json_constraint(tool_choice: &ChatCompletionToolChoiceOption) -> GuidedToolConstraint {
     match tool_choice {
         ChatCompletionToolChoiceOption::Named(named) => GuidedToolConstraint::GuidedJsonNamed {
@@ -430,6 +435,34 @@ mod tests {
             installed_json_constraint(&named("get_weather")),
             GuidedToolConstraint::GuidedJsonNamed {
                 tool_name: "get_weather".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn named_closed_zero_arg_tool_keeps_the_named_parser_constraint() {
+        let request = request(json!({
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_server_time",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": false
+                    }
+                }
+            }],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "get_server_time"}
+            }
+        }));
+
+        assert_eq!(
+            guided_tool_constraint(&request, None, None, false).expect("constraint is valid"),
+            GuidedToolConstraint::GuidedJsonNamed {
+                tool_name: "get_server_time".to_string(),
             }
         );
     }

--- a/lib/llm/src/protocols/openai/tools.rs
+++ b/lib/llm/src/protocols/openai/tools.rs
@@ -29,6 +29,13 @@ pub(crate) enum ToolChoiceValidation<'a> {
     Named(&'a str),
 }
 
+/// The guided-decoding grammar selected for a forced tool choice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolChoiceGuidance {
+    Json(Value),
+    Regex(String),
+}
+
 /// Validate the forced-choice contract shared by wire and parser-facing tool types.
 pub(crate) fn validate_tool_choice_against_names<'a>(
     tool_choice: ToolChoiceValidation<'_>,
@@ -75,12 +82,12 @@ pub(crate) fn validate_openai_tool_choice(
     }
 }
 
-/// Builds the JSON schema enforced by Guided Decoding for the given tool_choice/tools pair.
-pub fn get_json_schema_from_tools(
+/// Builds the guided-decoding grammar enforced for the given tool_choice/tools pair.
+pub fn get_tool_choice_guidance_from_tools(
     tool_choice: Option<&ChatCompletionToolChoiceOption>,
     tools: Option<&[ChatCompletionTool]>,
     parallel_tool_calls: Option<bool>,
-) -> Result<Option<Value>, ToolChoiceError> {
+) -> Result<Option<ToolChoiceGuidance>, ToolChoiceError> {
     let Some(choice) = tool_choice else {
         return Ok(None);
     };
@@ -92,17 +99,95 @@ pub fn get_json_schema_from_tools(
             let tools = tools.ok_or(ToolChoiceError::MissingTools)?;
             let tool = find_tool(tools, &named.function.name)
                 .ok_or_else(|| ToolChoiceError::ToolNotFound(named.function.name.clone()))?;
-            Ok(Some(clone_parameters(&tool.function)))
+            let parameters = clone_parameters(&tool.function);
+            if admits_only_empty_object(&parameters) {
+                // JSON schemas allow whitespace between tokens. For the single-value `{}`
+                // schema, greedy decoding can therefore emit whitespace until max_tokens.
+                // Keep the named-tool constraint and make the only legal argument value exact.
+                return Ok(Some(ToolChoiceGuidance::Regex(r"\{\}".to_string())));
+            }
+            Ok(Some(ToolChoiceGuidance::Json(parameters)))
         }
         ChatCompletionToolChoiceOption::Required => {
             let tools = tools.ok_or(ToolChoiceError::MissingTools)?;
-            build_required_schema(tools, parallel_tool_calls).map(Some)
+            build_required_schema(tools, parallel_tool_calls)
+                .map(ToolChoiceGuidance::Json)
+                .map(Some)
         }
     }
 }
 
+/// Builds the JSON-schema branch of the guided-decoding grammar.
+///
+/// Callers that install guided decoding should use `get_tool_choice_guidance_from_tools`
+/// so named zero-argument tools retain their exact regex constraint.
+pub fn get_json_schema_from_tools(
+    tool_choice: Option<&ChatCompletionToolChoiceOption>,
+    tools: Option<&[ChatCompletionTool]>,
+    parallel_tool_calls: Option<bool>,
+) -> Result<Option<Value>, ToolChoiceError> {
+    Ok(
+        get_tool_choice_guidance_from_tools(tool_choice, tools, parallel_tool_calls)?.and_then(
+            |guidance| match guidance {
+                ToolChoiceGuidance::Json(schema) => Some(schema),
+                ToolChoiceGuidance::Regex(_) => None,
+            },
+        ),
+    )
+}
+
 fn find_tool<'a>(tools: &'a [ChatCompletionTool], name: &str) -> Option<&'a ChatCompletionTool> {
     tools.iter().find(|tool| tool.function.name == name)
+}
+
+/// True when `schema` admits exactly one document, the empty object `{}`.
+///
+/// Only the fully closed, property-less object qualifies. Leaving `additionalProperties`
+/// unset admits other documents, and a schema with any property gives the grammar a
+/// required key to emit, so neither can stall. The keyword allowlist keeps an unfamiliar
+/// constraint from being read as "empty".
+fn admits_only_empty_object(schema: &Value) -> bool {
+    let Value::Object(map) = schema else {
+        return false;
+    };
+    if map.get("type").and_then(Value::as_str) != Some("object") {
+        return false;
+    }
+    if map.get("additionalProperties") != Some(&Value::Bool(false)) {
+        return false;
+    }
+    let properties_empty = match map.get("properties") {
+        None => true,
+        Some(Value::Object(properties)) => properties.is_empty(),
+        Some(_) => false,
+    };
+    if !properties_empty {
+        return false;
+    }
+    let required_empty = map
+        .get("required")
+        .is_none_or(|required| required.as_array().is_some_and(|list| list.is_empty()));
+    if !required_empty {
+        return false;
+    }
+    map.iter().all(|(key, value)| {
+        matches!(
+            key.as_str(),
+            "type"
+                | "properties"
+                | "required"
+                | "additionalProperties"
+                | "title"
+                | "description"
+                | "$comment"
+                | "default"
+                | "deprecated"
+                | "examples"
+                | "readOnly"
+                | "writeOnly"
+        ) || key == "minProperties" && value.as_u64() == Some(0)
+            || key == "maxProperties" && value.as_u64().is_some()
+    })
 }
 
 fn clone_parameters(function: &FunctionObject) -> Value {
@@ -368,6 +453,136 @@ mod tests {
                 },
             },
         ]
+    }
+
+    fn zero_arg_tool(parameters: Value) -> Vec<ChatCompletionTool> {
+        vec![ChatCompletionTool {
+            r#type: ChatCompletionToolType::Function,
+            function: FunctionObject {
+                name: "get_server_time".to_string(),
+                description: Some("Get the current server time.".to_string()),
+                parameters: Some(parameters),
+                strict: None,
+            },
+        }]
+    }
+
+    fn named_choice(name: &str) -> ChatCompletionToolChoiceOption {
+        ChatCompletionToolChoiceOption::Named(
+            dynamo_protocols::types::ChatCompletionNamedToolChoice {
+                r#type: ChatCompletionToolType::Function,
+                function: dynamo_protocols::types::FunctionName {
+                    name: name.to_string(),
+                },
+            },
+        )
+    }
+
+    /// GH-13789: a named choice on a tool whose schema admits only `{}` needs an exact regex.
+    /// JSON-schema whitespace can otherwise run to `max_tokens` before the closing brace.
+    #[test]
+    fn named_choice_on_closed_zero_arg_tool_uses_exact_regex() {
+        let tools = zero_arg_tool(json!({
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": false,
+        }));
+        let guidance = get_tool_choice_guidance_from_tools(
+            Some(&named_choice("get_server_time")),
+            Some(&tools),
+            None,
+        )
+        .expect("guidance");
+        assert_eq!(
+            guidance,
+            Some(ToolChoiceGuidance::Regex(r"\{\}".to_string())),
+            "a schema admitting only the empty object needs an exact constraint"
+        );
+    }
+
+    /// The escape hatch is deliberately narrow. Anything that admits more than `{}` keeps
+    /// its constraint, because the grammar then always has a required token to emit.
+    #[test]
+    fn named_choice_keeps_constraint_for_schemas_admitting_more_than_empty() {
+        let open = json!({"type": "object", "properties": {}});
+        let bare = json!({"type": "object"});
+        let with_property = json!({
+            "type": "object",
+            "properties": {"note": {"type": "string"}},
+            "required": [],
+            "additionalProperties": false,
+        });
+        let unknown_keyword = json!({
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": false,
+            "patternProperties": {},
+        });
+
+        for parameters in [open, bare, with_property, unknown_keyword] {
+            let tools = zero_arg_tool(parameters.clone());
+            let schema = get_json_schema_from_tools(
+                Some(&named_choice("get_server_time")),
+                Some(&tools),
+                None,
+            )
+            .expect("schema");
+            assert_eq!(
+                schema,
+                Some(parameters.clone()),
+                "constraint should survive for {parameters}"
+            );
+        }
+    }
+
+    #[test]
+    fn named_choice_uses_regex_for_zero_property_bounds_and_annotations() {
+        for (key, value) in [
+            ("minProperties", json!(0)),
+            ("maxProperties", json!(1)),
+            ("examples", json!([{}])),
+        ] {
+            let tools = zero_arg_tool(json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false,
+                key: value,
+            }));
+            assert_eq!(
+                get_tool_choice_guidance_from_tools(
+                    Some(&named_choice("get_server_time")),
+                    Some(&tools),
+                    None,
+                )
+                .expect("guidance"),
+                Some(ToolChoiceGuidance::Regex(r"\{\}".to_string()))
+            );
+        }
+    }
+
+    /// `tool_choice=required` wraps every tool with a required `name` key, so it can never
+    /// stall on whitespace and must keep its constraint even for a zero-argument tool.
+    #[test]
+    fn required_choice_on_closed_zero_arg_tool_keeps_constraint() {
+        let tools = zero_arg_tool(json!({
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": false,
+        }));
+        let schema = get_json_schema_from_tools(
+            Some(&ChatCompletionToolChoiceOption::Required),
+            Some(&tools),
+            None,
+        )
+        .expect("schema")
+        .expect("required always installs a constraint");
+
+        let item = &schema["items"]["anyOf"][0];
+        assert_eq!(item["properties"]["name"]["enum"][0], "get_server_time");
+        assert_eq!(item["required"], json!(["name", "parameters"]));
     }
 
     #[test]


### PR DESCRIPTION
## Test result: ibhosale before and after

The [ibhosale Qwen3.6-27B custom suite before #13785](http://ibhosale.nvidia.com/ci/jobs/20260824-232959-440d9257/models/qwen36-27b-v2/variants/dynamo-vllm/suites/custom/) failed `named_no_argument_server_time` in both non-streaming and streaming modes.

The [ibhosale Qwen3.6-27B Parsers V2 run with #13785](http://ibhosale.nvidia.com/ci/jobs/20260828-215539-dcf63a5f/) passed all 122 Custom-suite records with zero failures, including both modes of `named_no_argument_server_time`. It ran the exact PR image for `94d960f447` on Dynamo-vLLM.

| Where | Without #13785 | With #13785 |
| -- | -- | -- |
| ibhosale Custom suite | FAIL: non-streaming and streaming | PASS: 122/122 records, 0 failures |

The same run's BFCL qualification subset scored 40/50. Its 10 failures are separate from the Custom-suite Dynamo/API result.

## Problem

A caller selects a specific tool that takes no arguments. Dynamo returns the correct tool name, but the arguments are unusable: instead of `{}`, the response contains one opening brace followed by whitespace until the request runs out of tokens. The caller waits for the full token budget and still cannot run the tool because the arguments are not valid JSON.

This affects a named `tool_choice` such as `get_server_time`. `tool_choice: "required"` already works for the same tool.

## What #13785 fixes, and what it does not

[PR #13785](https://github.com/ai-dynamo/dynamo/pull/13785) fixes the named zero-argument path. With the PR, streaming and non-streaming requests return one `get_server_time` call with valid `{}` arguments. In the measured 200-token test, main used all 200 tokens and returned invalid JSON; the PR finished the call in 92 tokens.

The PR clears two of the four Dynamo/API harness failures: the streaming and non-streaming versions of this case.

The PR does not fix the separate truncated-tool-output case. Those two harness failures are unchanged. That work is handled separately by [PR #13791](https://github.com/ai-dynamo/dynamo/pull/13791) and [PR #13792](https://github.com/ai-dynamo/dynamo/pull/13792).

The PR also does not change `tool_choice: "required"` or named tools that have arguments. Those paths already worked and returned the same bytes before and after #13785. It does not enable a global vLLM whitespace setting.

## Input and before -> after

The tool has an empty parameter object, and `tool_choice` names it directly:

```json
{
  "messages": [{"role": "user", "content": "Call get_server_time exactly once with no arguments."}],
  "max_tokens": 200,
  "temperature": 0.0,
  "tool_choice": {"type": "function", "function": {"name": "get_server_time"}},
  "tools": [{
    "type": "function",
    "function": {
      "name": "get_server_time",
      "parameters": {
        "type": "object",
        "properties": {},
        "required": [],
        "additionalProperties": false
      }
    }
  }]
}
```

Measured result:

```text
before: tool=get_server_time  arguments="{" + 643 whitespace characters  JSON invalid  200 tokens
after:  tool=get_server_time  arguments="{}"                          JSON valid     92 tokens
```

A 4096-token harness run showed the same failure at the larger cap: one opening brace, 21,507 whitespace characters, and all 4096 completion tokens consumed.

## Why it happens

Dynamo normally gives vLLM a JSON schema to keep tool arguments valid. For this tool, the only valid argument value is `{}`. The schema still allows whitespace between the braces, and Qwen3.6-27B keeps generating whitespace instead of the closing brace.

#13785 recognizes this exact empty-schema case and skips the unnecessary argument constraint. The named tool choice still tells the model which tool to call, and the measured response returns `get_server_time` with `{}`.

## Required behavior

* Return exactly one call to the named zero-argument tool.
* Return arguments that parse as JSON and equal `{}`.
* Finish the tool call before `max_tokens`.
* Return the same logical result in streaming and non-streaming responses.
* Keep `tool_choice: "required"` and tools with parameters unchanged.

## Verification

| Case | Without #13785 | With #13785 |
| -- | -- | -- |
| Named zero-argument, non-streaming | Invalid JSON, 200 tokens, FAIL | `{}`, 92 tokens, PASS |
| Named zero-argument, streaming | Invalid JSON and wrong finish reason, FAIL | `{}`, PASS |
| `tool_choice: "required"` | `{}`, PASS | Same bytes, PASS |
| Named tool with three arguments | Valid arguments, PASS | Same bytes, PASS |
| Separate truncated-tool-output case | Invalid JSON, FAIL | Same bytes, FAIL |

The live local A/B used two frontends against one Qwen3.6-27B-FP8 worker on x86; only the frontend build changed. The arm64 ibhosale run covers the exact PR image. Other parser families are covered by parser tests rather than live generation.

All local checks exited 0: `cargo fmt --all -- --check`; `cargo test -p dynamo-llm --lib` (2,355 passed); the tool-choice, finish-reason, streaming-parser, and postprocessor test suites; and `cargo clippy -p dynamo-llm --all-targets`.

## Workaround until #13785 lands

If the request declares one tool, use `tool_choice: "required"`. The vLLM launch option `--structured-outputs-config '{"backend":"xgrammar","disable_any_whitespace":true}'` also prevents the whitespace flood, but applies to the whole engine and can change formatting for other guided JSON responses.

## Where to review

`lib/llm/src/protocols/openai/tools.rs`

## References

Closes #13789

Separate truncated-tool-output work: #13791 and #13792
