### PR TITLE
refactor(ext-proc): construct selection service from policy registry

### DIFF
--- a/deploy/inference-gateway/ext-proc/src/bin/dynamo-ext-proc.rs
+++ b/deploy/inference-gateway/ext-proc/src/bin/dynamo-ext-proc.rs
@@ -3,5 +3,5 @@
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    dynamo_ext_proc::run().await
+    dynamo_ext_proc::run(None).await
 }

--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -70,7 +70,7 @@ impl EppRouter {
     /// Assemble the standalone runtime from the validated selector config.
     pub async fn from_selector(
         cfg: EppStandaloneConfig,
-        policy_registry: Option<WorkerSelectionPolicyRegistry>,
+        policy_registry: WorkerSelectionPolicyRegistry,
     ) -> Result<Self> {
         let selector = Arc::new(Selector::new(&cfg, policy_registry).await?);
         let renderer = VllmRenderClient::new(

--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -26,7 +26,7 @@ use std::time::Duration;
 use anyhow::Result;
 use tokio::sync::Semaphore;
 
-use dynamo_kv_router::services::selection::SelectionService;
+use dynamo_kv_router::services::selection::WorkerSelectionPolicyRegistry;
 use dynamo_llm::protocols::common::extensions::{
     AgentHints, HEADER_REQUEST_PRIORITY, HEADER_REQUEST_STRICT_PRIORITY, resolve_request_priority,
 };
@@ -68,24 +68,11 @@ pub struct EppRouter {
 
 impl EppRouter {
     /// Assemble the standalone runtime from the validated selector config.
-    pub async fn from_selector(cfg: EppStandaloneConfig) -> Result<Self> {
-        let selector = Arc::new(Selector::new(&cfg).await?);
-        let (renderer, reflector, reflector_ready) = Self::dependencies(&cfg).await?;
-        Ok(Self::from_selector_parts(
-            cfg,
-            renderer,
-            reflector,
-            reflector_ready,
-            selector,
-        ))
-    }
-
-    /// Assemble a custom EPP image around a prebuilt selection service.
-    pub async fn from_selection_service(
+    pub async fn from_selector(
         cfg: EppStandaloneConfig,
-        service: SelectionService,
+        policy_registry: Option<WorkerSelectionPolicyRegistry>,
     ) -> Result<Self> {
-        let selector = Arc::new(Selector::from_service(&cfg, service).await?);
+        let selector = Arc::new(Selector::new(&cfg, policy_registry).await?);
         let (renderer, reflector, reflector_ready) = Self::dependencies(&cfg).await?;
         Ok(Self::from_selector_parts(
             cfg,

--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -73,7 +73,13 @@ impl EppRouter {
         policy_registry: Option<WorkerSelectionPolicyRegistry>,
     ) -> Result<Self> {
         let selector = Arc::new(Selector::new(&cfg, policy_registry).await?);
-        let (renderer, reflector, reflector_ready) = Self::dependencies(&cfg).await?;
+        let renderer = VllmRenderClient::new(
+            &cfg.tokenizer_service_url,
+            Duration::from_millis(cfg.tokenization_timeout_ms),
+            cfg.tokenizer_max_response_bytes,
+        )?;
+        let (reflector, reflector_ready) = PodDiscovery::spawn(&cfg).await?;
+        let reflector = Arc::new(reflector);
         let peer_ready = selector.peer_ready();
         let defaults = RegistrationDefaults::from_config(&cfg);
         let adapter =
@@ -92,21 +98,6 @@ impl EppRouter {
             model_name: cfg.model_name,
             inflight: Arc::new(Semaphore::new(cfg.max_inflight_requests)),
         })
-    }
-
-    async fn dependencies(
-        cfg: &EppStandaloneConfig,
-    ) -> Result<(VllmRenderClient, Arc<PodDiscovery>, Arc<AtomicBool>)> {
-        let renderer = VllmRenderClient::new(
-            &cfg.tokenizer_service_url,
-            Duration::from_millis(cfg.tokenization_timeout_ms),
-            cfg.tokenizer_max_response_bytes,
-        )?;
-
-        let (reflector, reflector_ready) = PodDiscovery::spawn(cfg).await?;
-        let reflector = Arc::new(reflector);
-
-        Ok((renderer, reflector, reflector_ready))
     }
 
     /// Overall EPP readiness for the gRPC health signal: the pod reflector is

--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -74,13 +74,24 @@ impl EppRouter {
     ) -> Result<Self> {
         let selector = Arc::new(Selector::new(&cfg, policy_registry).await?);
         let (renderer, reflector, reflector_ready) = Self::dependencies(&cfg).await?;
-        Ok(Self::from_selector_parts(
-            cfg,
+        let peer_ready = selector.peer_ready();
+        let defaults = RegistrationDefaults::from_config(&cfg);
+        let adapter =
+            TopologyAdapter::spawn(reflector.as_ref().clone(), selector.clone(), defaults);
+
+        // Readiness is driven solely by the live pod+pool signal (see `is_ready`);
+        // we do not block startup on a schedulable worker. A valid, empty pool is
+        // ready immediately and returns 503 per-request until capacity appears.
+        Ok(Self {
             renderer,
             reflector,
-            reflector_ready,
             selector,
-        ))
+            _adapter: adapter,
+            reflector_ready,
+            peer_ready,
+            model_name: cfg.model_name,
+            inflight: Arc::new(Semaphore::new(cfg.max_inflight_requests)),
+        })
     }
 
     async fn dependencies(
@@ -96,34 +107,6 @@ impl EppRouter {
         let reflector = Arc::new(reflector);
 
         Ok((renderer, reflector, reflector_ready))
-    }
-
-    fn from_selector_parts(
-        cfg: EppStandaloneConfig,
-        renderer: VllmRenderClient,
-        reflector: Arc<PodDiscovery>,
-        reflector_ready: Arc<AtomicBool>,
-        selector: Arc<Selector>,
-    ) -> Self {
-        let peer_ready = selector.peer_ready();
-
-        let defaults = RegistrationDefaults::from_config(&cfg);
-        let adapter =
-            TopologyAdapter::spawn(reflector.as_ref().clone(), selector.clone(), defaults);
-
-        // Readiness is driven solely by the live pod+pool signal (see `is_ready`);
-        // we do not block startup on a schedulable worker. A valid, empty pool is
-        // ready immediately and returns 503 per-request until capacity appears.
-        Self {
-            renderer,
-            reflector,
-            selector,
-            _adapter: adapter,
-            reflector_ready,
-            peer_ready,
-            model_name: cfg.model_name,
-            inflight: Arc::new(Semaphore::new(cfg.max_inflight_requests)),
-        }
     }
 
     /// Overall EPP readiness for the gRPC health signal: the pod reflector is

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -34,7 +34,7 @@ pub use epp_standalone_config::{EppMode, EppStandaloneConfig, TokenizerProtocol}
 pub use inference_pool::PoolState;
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo, ResponseUsage};
 pub use pod_discovery::{PodDiscovery, RawWorker};
-pub use runner::{run, run_with_selection_service, run_with_worker_selection_policy_registry};
+pub use runner::run;
 pub use selector::{OverlapSummary, SelectRequest, SelectResponse, Selector, WorkerRegistration};
 pub use server::ExtProcServer;
 pub use topology_adapter::{RegistrationDefaults, TopologyAdapter};

--- a/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
@@ -515,19 +515,26 @@ mod tests {
     /// wiring that consumes `peer_ips`, which the predicate tests above do not.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn reconcile_retains_draining_peer_until_it_stops_serving() {
+        use dynamo_kv_router::WorkerType;
         use dynamo_kv_router::config::kv_router_config_from_dynamo_env;
-        use dynamo_kv_router::services::selection::SelectionServiceBuilder;
+        use dynamo_kv_router::services::selection::{
+            SelectionServiceBuilder, WorkerSelectionPolicyRegistry,
+        };
 
         // A real replica-sync-enabled service. `register_replica_peer` is a lazy
         // ZMQ connect, so no live sibling is needed — we assert only the peer set
         // that reconcile maintains via `list_replica_peers`.
         let service = Arc::new(
-            SelectionServiceBuilder::new(kv_router_config_from_dynamo_env())
-                .indexer_threads(1)
-                .replica_sync(free_tcp_port(), Vec::new())
-                .build()
-                .await
-                .expect("build replica-sync selection service"),
+            SelectionServiceBuilder::new(
+                kv_router_config_from_dynamo_env(),
+                WorkerType::Aggregated,
+                WorkerSelectionPolicyRegistry::default(),
+            )
+            .indexer_threads(1)
+            .replica_sync(free_tcp_port(), Vec::new())
+            .build()
+            .await
+            .expect("build replica-sync selection service"),
         );
 
         let self_ip = "10.0.0.1";

--- a/deploy/inference-gateway/ext-proc/src/runner.rs
+++ b/deploy/inference-gateway/ext-proc/src/runner.rs
@@ -147,85 +147,6 @@ fn init_tracing() {
         .try_init();
 }
 
-#[cfg(test)]
-mod tests {
-    use std::sync::{Arc, Mutex};
-
-    use dynamo_kv_router::WorkerSelectionPolicyFactory;
-    use dynamo_kv_router::services::selection::WorkerSelectionPolicyProviderError;
-    use tokio::sync::mpsc;
-
-    use super::*;
-    use crate::epp_standalone_config::{DYN_EPP_MODE, DYNAMO_RUNTIME_MODE};
-
-    static EPP_MODE_ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    #[tokio::test]
-    async fn background_tasks_shutdown_aborts_and_joins_every_task() {
-        let (sender, mut receiver) = mpsc::channel::<()>(1);
-        let health_task = tokio::spawn({
-            let sender = sender.clone();
-            async move {
-                let _sender = sender;
-                std::future::pending::<()>().await;
-            }
-        });
-        let metrics_task = tokio::spawn({
-            let sender = sender.clone();
-            async move {
-                let _sender = sender;
-                std::future::pending::<()>().await;
-            }
-        });
-        let shutdown_task = tokio::spawn(async move {
-            let _sender = sender;
-            std::future::pending::<()>().await;
-        });
-
-        BackgroundTasks {
-            health_task,
-            metrics_task: Some(metrics_task),
-            shutdown_task,
-        }
-        .shutdown()
-        .await;
-
-        assert!(receiver.recv().await.is_none());
-    }
-
-    #[tokio::test]
-    async fn linked_policy_registry_requires_standalone_mode() {
-        let mut registry = WorkerSelectionPolicyRegistry::default();
-        registry
-            .register(
-                "test",
-                Arc::new(
-                    |_| -> std::result::Result<
-                        WorkerSelectionPolicyFactory,
-                        WorkerSelectionPolicyProviderError,
-                    > {
-                        Err(WorkerSelectionPolicyProviderError::new("not invoked"))
-                    },
-                ),
-            )
-            .unwrap();
-
-        let _lock = EPP_MODE_ENV_LOCK.lock().unwrap();
-        let previous = std::env::var_os(DYN_EPP_MODE);
-        unsafe { std::env::set_var(DYN_EPP_MODE, DYNAMO_RUNTIME_MODE) };
-        let result = run(Some(registry)).await;
-        match previous {
-            Some(value) => unsafe { std::env::set_var(DYN_EPP_MODE, value) },
-            None => unsafe { std::env::remove_var(DYN_EPP_MODE) },
-        }
-
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "linked worker-selection policies require DYN_EPP_MODE=standalone"
-        );
-    }
-}
-
 /// Wait for SIGTERM (kubelet pod termination) or SIGINT (Ctrl-C).
 async fn wait_for_shutdown_signal() {
     #[cfg(unix)]
@@ -568,5 +489,84 @@ async fn serve<P: crate::EndpointPicker>(
         readiness_task.abort();
         let _ = readiness_task.await;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use dynamo_kv_router::WorkerSelectionPolicyFactory;
+    use dynamo_kv_router::services::selection::WorkerSelectionPolicyProviderError;
+    use tokio::sync::{Mutex, mpsc};
+
+    use super::*;
+    use crate::epp_standalone_config::{DYN_EPP_MODE, DYNAMO_RUNTIME_MODE};
+
+    static EPP_MODE_ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+    #[tokio::test]
+    async fn background_tasks_shutdown_aborts_and_joins_every_task() {
+        let (sender, mut receiver) = mpsc::channel::<()>(1);
+        let health_task = tokio::spawn({
+            let sender = sender.clone();
+            async move {
+                let _sender = sender;
+                std::future::pending::<()>().await;
+            }
+        });
+        let metrics_task = tokio::spawn({
+            let sender = sender.clone();
+            async move {
+                let _sender = sender;
+                std::future::pending::<()>().await;
+            }
+        });
+        let shutdown_task = tokio::spawn(async move {
+            let _sender = sender;
+            std::future::pending::<()>().await;
+        });
+
+        BackgroundTasks {
+            health_task,
+            metrics_task: Some(metrics_task),
+            shutdown_task,
+        }
+        .shutdown()
+        .await;
+
+        assert!(receiver.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn linked_policy_registry_requires_standalone_mode() {
+        let mut registry = WorkerSelectionPolicyRegistry::default();
+        registry
+            .register(
+                "test",
+                Arc::new(
+                    |_| -> std::result::Result<
+                        WorkerSelectionPolicyFactory,
+                        WorkerSelectionPolicyProviderError,
+                    > {
+                        Err(WorkerSelectionPolicyProviderError::new("not invoked"))
+                    },
+                ),
+            )
+            .unwrap();
+
+        let _lock = EPP_MODE_ENV_LOCK.lock().await;
+        let previous = std::env::var_os(DYN_EPP_MODE);
+        unsafe { std::env::set_var(DYN_EPP_MODE, DYNAMO_RUNTIME_MODE) };
+        let result = run(Some(registry)).await;
+        match previous {
+            Some(value) => unsafe { std::env::set_var(DYN_EPP_MODE, value) },
+            None => unsafe { std::env::remove_var(DYN_EPP_MODE) },
+        }
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "linked worker-selection policies require DYN_EPP_MODE=standalone"
+        );
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/runner.rs
+++ b/deploy/inference-gateway/ext-proc/src/runner.rs
@@ -498,45 +498,12 @@ mod tests {
 
     use dynamo_kv_router::WorkerSelectionPolicyFactory;
     use dynamo_kv_router::services::selection::WorkerSelectionPolicyProviderError;
-    use tokio::sync::{Mutex, mpsc};
+    use tokio::sync::Mutex;
 
     use super::*;
     use crate::epp_standalone_config::{DYN_EPP_MODE, DYNAMO_RUNTIME_MODE};
 
     static EPP_MODE_ENV_LOCK: Mutex<()> = Mutex::const_new(());
-
-    #[tokio::test]
-    async fn background_tasks_shutdown_aborts_and_joins_every_task() {
-        let (sender, mut receiver) = mpsc::channel::<()>(1);
-        let health_task = tokio::spawn({
-            let sender = sender.clone();
-            async move {
-                let _sender = sender;
-                std::future::pending::<()>().await;
-            }
-        });
-        let metrics_task = tokio::spawn({
-            let sender = sender.clone();
-            async move {
-                let _sender = sender;
-                std::future::pending::<()>().await;
-            }
-        });
-        let shutdown_task = tokio::spawn(async move {
-            let _sender = sender;
-            std::future::pending::<()>().await;
-        });
-
-        BackgroundTasks {
-            health_task,
-            metrics_task: Some(metrics_task),
-            shutdown_task,
-        }
-        .shutdown()
-        .await;
-
-        assert!(receiver.recv().await.is_none());
-    }
 
     #[tokio::test]
     async fn linked_policy_registry_requires_standalone_mode() {

--- a/deploy/inference-gateway/ext-proc/src/runner.rs
+++ b/deploy/inference-gateway/ext-proc/src/runner.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use dynamo_kv_router::services::selection::WorkerSelectionPolicyRegistry;
 use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
 use tokio_rustls::TlsAcceptor;
 use tokio_util::sync::CancellationToken;
 
@@ -152,11 +153,45 @@ mod tests {
 
     use dynamo_kv_router::WorkerSelectionPolicyFactory;
     use dynamo_kv_router::services::selection::WorkerSelectionPolicyProviderError;
+    use tokio::sync::mpsc;
 
     use super::*;
     use crate::epp_standalone_config::{DYN_EPP_MODE, DYNAMO_RUNTIME_MODE};
 
     static EPP_MODE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[tokio::test]
+    async fn background_tasks_shutdown_aborts_and_joins_every_task() {
+        let (sender, mut receiver) = mpsc::channel::<()>(1);
+        let health_task = tokio::spawn({
+            let sender = sender.clone();
+            async move {
+                let _sender = sender;
+                std::future::pending::<()>().await;
+            }
+        });
+        let metrics_task = tokio::spawn({
+            let sender = sender.clone();
+            async move {
+                let _sender = sender;
+                std::future::pending::<()>().await;
+            }
+        });
+        let shutdown_task = tokio::spawn(async move {
+            let _sender = sender;
+            std::future::pending::<()>().await;
+        });
+
+        BackgroundTasks {
+            health_task,
+            metrics_task: Some(metrics_task),
+            shutdown_task,
+        }
+        .shutdown()
+        .await;
+
+        assert!(receiver.recv().await.is_none());
+    }
 
     #[tokio::test]
     async fn linked_policy_registry_requires_standalone_mode() {
@@ -208,6 +243,35 @@ async fn wait_for_shutdown_signal() {
     }
 }
 
+/// Tasks started before router initialization that must not outlive a failed run.
+struct BackgroundTasks {
+    health_task: JoinHandle<()>,
+    metrics_task: Option<JoinHandle<()>>,
+    shutdown_task: JoinHandle<()>,
+}
+
+impl BackgroundTasks {
+    async fn shutdown(self) {
+        let Self {
+            health_task,
+            metrics_task,
+            shutdown_task,
+        } = self;
+
+        health_task.abort();
+        if let Some(task) = &metrics_task {
+            task.abort();
+        }
+        shutdown_task.abort();
+
+        let _ = health_task.await;
+        if let Some(task) = metrics_task {
+            let _ = task.await;
+        }
+        let _ = shutdown_task.await;
+    }
+}
+
 async fn run_inner(mode: EppMode, policy_registry: WorkerSelectionPolicyRegistry) -> Result<()> {
     let standalone = matches!(mode, EppMode::Standalone);
 
@@ -230,24 +294,29 @@ async fn run_inner(mode: EppMode, policy_registry: WorkerSelectionPolicyRegistry
 
     let health_addr = format!("0.0.0.0:{HEALTH_PORT}").parse()?;
     tracing::info!(%health_addr, "Starting gRPC health server (plaintext)");
-    tokio::spawn(
-        tonic::transport::Server::builder()
+    let health_task = tokio::spawn(async move {
+        if let Err(error) = tonic::transport::Server::builder()
             .add_service(health_service)
-            .serve(health_addr),
-    );
+            .serve(health_addr)
+            .await
+        {
+            tracing::error!(%error, "Health server exited");
+        }
+    });
 
     // Start before router init so scrapes during a slow discovery bootstrap
     // return an empty exposition rather than a connection refusal.
     let metrics_port = parse_env(metrics::METRICS_PORT_ENV, metrics::DEFAULT_METRICS_PORT);
-    if metrics_port == 0 {
+    let metrics_task = if metrics_port == 0 {
         tracing::info!("Metrics server disabled");
+        None
     } else {
-        tokio::spawn(async move {
+        Some(tokio::spawn(async move {
             if let Err(e) = metrics::serve(metrics_port).await {
                 tracing::error!(error = %e, port = metrics_port, "Metrics server exited");
             }
-        });
-    }
+        }))
+    };
 
     // Shutdown coordination: on SIGTERM/SIGINT, flip health to NOT_SERVING
     // (the gateway stops routing new requests to this EPP), allow the endpoint
@@ -256,7 +325,7 @@ async fn run_inner(mode: EppMode, policy_registry: WorkerSelectionPolicyRegistry
     // connections are handled by the follow-up connection-lifecycle work.
     let draining = CancellationToken::new();
     let shutdown = CancellationToken::new();
-    {
+    let shutdown_task = {
         let draining = draining.clone();
         let shutdown = shutdown.clone();
         tokio::spawn(async move {
@@ -278,62 +347,72 @@ async fn run_inner(mode: EppMode, policy_registry: WorkerSelectionPolicyRegistry
             tokio::time::sleep(std::time::Duration::from_secs(propagation_secs)).await;
             shutdown.cancel();
             tracing::info!("EPP endpoint propagation complete; stopping accepts");
-        });
-    }
+        })
+    };
+    let background_tasks = BackgroundTasks {
+        health_task,
+        metrics_task,
+        shutdown_task,
+    };
 
-    if standalone {
-        let selector_cfg = EppStandaloneConfig::from_env()?;
-        tracing::info!(
-            inference_pool_name = %selector_cfg.inference_pool_name,
-            model_name = %selector_cfg.model_name,
-            block_size = selector_cfg.block_size,
-            "Initializing standalone selector mode (no Dynamo runtime)..."
-        );
-        metrics::set_served_model(&selector_cfg.model_name);
-        let router = tokio::select! {
-            _ = draining.cancelled() => {
-                tracing::info!("Shutdown received during standalone EPP initialization");
+    let result = async {
+        if standalone {
+            let selector_cfg = EppStandaloneConfig::from_env()?;
+            tracing::info!(
+                inference_pool_name = %selector_cfg.inference_pool_name,
+                model_name = %selector_cfg.model_name,
+                block_size = selector_cfg.block_size,
+                "Initializing standalone selector mode (no Dynamo runtime)..."
+            );
+            metrics::set_served_model(&selector_cfg.model_name);
+            let router = tokio::select! {
+                _ = draining.cancelled() => {
+                    tracing::info!("Shutdown received during standalone EPP initialization");
+                    return Ok(());
+                }
+                router = crate::EppRouter::from_selector(selector_cfg, policy_registry) => Arc::new(router?),
+            };
+            if draining.is_cancelled() {
+                tracing::info!("Shutdown received before standalone EPP serving started");
                 return Ok(());
             }
-            router = crate::EppRouter::from_selector(selector_cfg, policy_registry) => Arc::new(router?),
-        };
-        if draining.is_cancelled() {
-            tracing::info!("Shutdown received before standalone EPP serving started");
-            return Ok(());
-        }
-        let ready_router = router.clone();
-        serve(
-            router,
-            move || ready_router.is_ready(),
-            health_reporter,
-            draining,
-            shutdown,
-        )
-        .await
-    } else {
-        tracing::info!("Initializing KV-aware router from discovery...");
-        let router = tokio::select! {
-            _ = draining.cancelled() => {
-                tracing::info!("Shutdown received during Dynamo discovery initialization");
+            let ready_router = router.clone();
+            serve(
+                router,
+                move || ready_router.is_ready(),
+                health_reporter,
+                draining,
+                shutdown,
+            )
+            .await
+        } else {
+            tracing::info!("Initializing KV-aware router from discovery...");
+            let router = tokio::select! {
+                _ = draining.cancelled() => {
+                    tracing::info!("Shutdown received during Dynamo discovery initialization");
+                    return Ok(());
+                }
+                router = Router::from_discovery(&config.namespace, &config.component) => router?,
+            };
+            if draining.is_cancelled() {
+                tracing::info!("Shutdown received before Dynamo discovery serving started");
                 return Ok(());
             }
-            router = Router::from_discovery(&config.namespace, &config.component) => router?,
-        };
-        if draining.is_cancelled() {
-            tracing::info!("Shutdown received before Dynamo discovery serving started");
-            return Ok(());
+            metrics::set_served_model(router.served_model());
+            let ready = router.pod_store_ready();
+            serve(
+                Arc::new(router),
+                move || ready.load(std::sync::atomic::Ordering::Acquire),
+                health_reporter,
+                draining,
+                shutdown,
+            )
+            .await
         }
-        metrics::set_served_model(router.served_model());
-        let ready = router.pod_store_ready();
-        serve(
-            Arc::new(router),
-            move || ready.load(std::sync::atomic::Ordering::Acquire),
-            health_reporter,
-            draining,
-            shutdown,
-        )
-        .await
     }
+    .await;
+    background_tasks.shutdown().await;
+    result
 }
 
 /// Mirror the picker's live readiness onto the gRPC health status, then serve

--- a/deploy/inference-gateway/ext-proc/src/runner.rs
+++ b/deploy/inference-gateway/ext-proc/src/runner.rs
@@ -146,6 +146,51 @@ fn init_tracing() {
         .try_init();
 }
 
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use dynamo_kv_router::WorkerSelectionPolicyFactory;
+    use dynamo_kv_router::services::selection::WorkerSelectionPolicyProviderError;
+
+    use super::*;
+    use crate::epp_standalone_config::{DYN_EPP_MODE, DYNAMO_RUNTIME_MODE};
+
+    static EPP_MODE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[tokio::test]
+    async fn linked_policy_registry_requires_standalone_mode() {
+        let mut registry = WorkerSelectionPolicyRegistry::default();
+        registry
+            .register(
+                "test",
+                Arc::new(
+                    |_| -> std::result::Result<
+                        WorkerSelectionPolicyFactory,
+                        WorkerSelectionPolicyProviderError,
+                    > {
+                        Err(WorkerSelectionPolicyProviderError::new("not invoked"))
+                    },
+                ),
+            )
+            .unwrap();
+
+        let _lock = EPP_MODE_ENV_LOCK.lock().unwrap();
+        let previous = std::env::var_os(DYN_EPP_MODE);
+        unsafe { std::env::set_var(DYN_EPP_MODE, DYNAMO_RUNTIME_MODE) };
+        let result = run(Some(registry)).await;
+        match previous {
+            Some(value) => unsafe { std::env::set_var(DYN_EPP_MODE, value) },
+            None => unsafe { std::env::remove_var(DYN_EPP_MODE) },
+        }
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "linked worker-selection policies require DYN_EPP_MODE=standalone"
+        );
+    }
+}
+
 /// Wait for SIGTERM (kubelet pod termination) or SIGINT (Ctrl-C).
 async fn wait_for_shutdown_signal() {
     #[cfg(unix)]

--- a/deploy/inference-gateway/ext-proc/src/runner.rs
+++ b/deploy/inference-gateway/ext-proc/src/runner.rs
@@ -127,20 +127,14 @@ fn create_tls_acceptor() -> Result<TlsAcceptor> {
 pub async fn run(policy_registry: Option<WorkerSelectionPolicyRegistry>) -> Result<()> {
     init_tracing();
     let mode = EppMode::from_env()?;
-    require_standalone_mode_for_linked_worker_selection_policy(mode, policy_registry.as_ref())?;
-    run_inner(mode, policy_registry).await
-}
-
-fn require_standalone_mode_for_linked_worker_selection_policy(
-    mode: EppMode,
-    policy_registry: Option<&WorkerSelectionPolicyRegistry>,
-) -> Result<()> {
-    if matches!(mode, EppMode::Standalone)
-        || policy_registry.is_none_or(WorkerSelectionPolicyRegistry::is_empty)
+    if !matches!(mode, EppMode::Standalone)
+        && policy_registry
+            .as_ref()
+            .is_some_and(|registry| !registry.is_empty())
     {
-        return Ok(());
+        anyhow::bail!("linked worker-selection policies require DYN_EPP_MODE=standalone")
     }
-    anyhow::bail!("linked worker-selection policies require DYN_EPP_MODE=standalone")
+    run_inner(mode, policy_registry).await
 }
 
 fn init_tracing() {
@@ -453,61 +447,5 @@ async fn serve<P: crate::EndpointPicker>(
         readiness_task.abort();
         let _ = readiness_task.await;
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use dynamo_kv_router::scheduling::selector::WorkerSelectionPolicy;
-
-    use super::*;
-
-    fn nonempty_registry() -> WorkerSelectionPolicyRegistry {
-        let mut registry = WorkerSelectionPolicyRegistry::default();
-        registry
-            .register(
-                "test",
-                Arc::new(|_| {
-                    Ok(Arc::new(|config, worker_type, _partition| {
-                        WorkerSelectionPolicy::default(
-                            config.clone(),
-                            worker_type.default_selector_label(),
-                        )
-                    }))
-                }),
-            )
-            .unwrap();
-        registry
-    }
-
-    #[test]
-    fn nonempty_registry_requires_standalone_epp() {
-        let registry = nonempty_registry();
-        assert!(
-            require_standalone_mode_for_linked_worker_selection_policy(
-                EppMode::Standalone,
-                Some(&registry),
-            )
-            .is_ok()
-        );
-        assert!(
-            require_standalone_mode_for_linked_worker_selection_policy(
-                EppMode::DynamoRuntime,
-                Some(&registry),
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn empty_registry_allows_dynamo_runtime() {
-        let registry = WorkerSelectionPolicyRegistry::default();
-        assert!(
-            require_standalone_mode_for_linked_worker_selection_policy(
-                EppMode::DynamoRuntime,
-                Some(&registry),
-            )
-            .is_ok()
-        );
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/runner.rs
+++ b/deploy/inference-gateway/ext-proc/src/runner.rs
@@ -134,7 +134,7 @@ pub async fn run(policy_registry: Option<WorkerSelectionPolicyRegistry>) -> Resu
     {
         anyhow::bail!("linked worker-selection policies require DYN_EPP_MODE=standalone")
     }
-    run_inner(mode, policy_registry).await
+    run_inner(mode, policy_registry.unwrap_or_default()).await
 }
 
 fn init_tracing() {
@@ -163,10 +163,7 @@ async fn wait_for_shutdown_signal() {
     }
 }
 
-async fn run_inner(
-    mode: EppMode,
-    policy_registry: Option<WorkerSelectionPolicyRegistry>,
-) -> Result<()> {
+async fn run_inner(mode: EppMode, policy_registry: WorkerSelectionPolicyRegistry) -> Result<()> {
     let standalone = matches!(mode, EppMode::Standalone);
 
     let config = Config::from_env();

--- a/deploy/inference-gateway/ext-proc/src/runner.rs
+++ b/deploy/inference-gateway/ext-proc/src/runner.rs
@@ -13,14 +13,12 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use dynamo_kv_router::WorkerSelectionPolicyFactory;
-use dynamo_kv_router::config::{KvRouterConfig, try_kv_router_config_from_dynamo_env};
-use dynamo_kv_router::services::selection::{SelectionService, WorkerSelectionPolicyRegistry};
+use dynamo_kv_router::services::selection::WorkerSelectionPolicyRegistry;
 use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 use tokio_util::sync::CancellationToken;
 
-use crate::{EppMode, EppStandaloneConfig, ExtProcServer, Router, Selector, metrics};
+use crate::{EppMode, EppStandaloneConfig, ExtProcServer, Router, metrics};
 
 const GRPC_PORT: u16 = 9002;
 const HEALTH_PORT: u16 = 9003;
@@ -46,15 +44,6 @@ const TLS_HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 struct Config {
     namespace: String,
     component: String,
-}
-
-enum StandaloneSelectionService {
-    Default,
-    Existing(SelectionService),
-    LinkedWorkerSelectionPolicy {
-        kv_router_config: Box<KvRouterConfig>,
-        factory: WorkerSelectionPolicyFactory,
-    },
 }
 
 impl Config {
@@ -134,84 +123,21 @@ fn create_tls_acceptor() -> Result<TlsAcceptor> {
     Ok(TlsAcceptor::from(Arc::new(tls_config)))
 }
 
-/// Run the stock EPP until it exits.
-pub async fn run() -> Result<()> {
+/// Run EPP until it exits.
+pub async fn run(policy_registry: Option<WorkerSelectionPolicyRegistry>) -> Result<()> {
     init_tracing();
     let mode = EppMode::from_env()?;
-    if matches!(mode, EppMode::Standalone) {
-        let kv_router_config =
-            try_kv_router_config_from_dynamo_env().map_err(anyhow::Error::msg)?;
-        reject_unlinked_worker_selection_policy(&kv_router_config)?;
-    }
-    run_inner(mode, StandaloneSelectionService::Default).await
+    require_standalone_mode_for_linked_worker_selection_policy(mode, policy_registry.as_ref())?;
+    run_inner(mode, policy_registry).await
 }
 
-fn reject_unlinked_worker_selection_policy(config: &KvRouterConfig) -> Result<()> {
-    if let Some(instance) = config
-        .selected_worker_selection_policy_instance_for(dynamo_kv_router::WorkerType::Aggregated)?
-    {
-        anyhow::bail!(
-            "worker-selection instance {instance:?} is configured, but this stock EPP has no linked worker-selection policy catalog; run a custom EPP binary that links the catalog"
-        );
-    }
-    warn_if_epp_ignores_stage_policies(config)?;
-    Ok(())
-}
-
-fn warn_if_epp_ignores_stage_policies(config: &KvRouterConfig) -> Result<()> {
-    if config.has_explicit_stage_worker_selection_policy()? {
-        tracing::warn!(
-            "worker_selection.prefill, worker_selection.decode, worker_selection.encode, DYN_ROUTER_PREFILL_POLICY, and DYN_ROUTER_DECODE_POLICY are ignored by aggregated EPP selection"
-        );
-    }
-    Ok(())
-}
-
-/// Run the standalone EPP around a caller-built selection service.
-pub async fn run_with_selection_service(service: SelectionService) -> Result<()> {
-    init_tracing();
-    run_inner(
-        EppMode::Standalone,
-        StandaloneSelectionService::Existing(service),
-    )
-    .await
-}
-
-/// Run EPP with linked policy types and the aggregated instance selected from YAML.
-///
-/// Standalone EPP ignores and does not resolve prefill, decode, or encode selections.
-pub async fn run_with_worker_selection_policy_registry(
-    registry: WorkerSelectionPolicyRegistry,
+fn require_standalone_mode_for_linked_worker_selection_policy(
+    mode: EppMode,
+    policy_registry: Option<&WorkerSelectionPolicyRegistry>,
 ) -> Result<()> {
-    init_tracing();
-    let mode = EppMode::from_env()?;
-    let kv_router_config = try_kv_router_config_from_dynamo_env().map_err(anyhow::Error::msg)?;
-    warn_if_epp_ignores_stage_policies(&kv_router_config)?;
-    if kv_router_config
-        .selected_worker_selection_policy_instance_for(dynamo_kv_router::WorkerType::Aggregated)?
-        .is_none()
+    if matches!(mode, EppMode::Standalone)
+        || policy_registry.is_none_or(WorkerSelectionPolicyRegistry::is_empty)
     {
-        return run_inner(mode, StandaloneSelectionService::Default).await;
-    }
-    // TODO: Resolve the stage-specific roles when EPP supports disaggregated worker pools.
-    let Some(factory) = registry
-        .resolve_for_worker_type(&kv_router_config, dynamo_kv_router::WorkerType::Aggregated)?
-    else {
-        return run_inner(mode, StandaloneSelectionService::Default).await;
-    };
-    require_standalone_mode_for_linked_worker_selection_policy(mode)?;
-    run_inner(
-        mode,
-        StandaloneSelectionService::LinkedWorkerSelectionPolicy {
-            kv_router_config: Box::new(kv_router_config),
-            factory,
-        },
-    )
-    .await
-}
-
-fn require_standalone_mode_for_linked_worker_selection_policy(mode: EppMode) -> Result<()> {
-    if matches!(mode, EppMode::Standalone) {
         return Ok(());
     }
     anyhow::bail!("linked worker-selection policies require DYN_EPP_MODE=standalone")
@@ -245,7 +171,7 @@ async fn wait_for_shutdown_signal() {
 
 async fn run_inner(
     mode: EppMode,
-    standalone_selection_service: StandaloneSelectionService,
+    policy_registry: Option<WorkerSelectionPolicyRegistry>,
 ) -> Result<()> {
     let standalone = matches!(mode, EppMode::Standalone);
 
@@ -333,29 +259,7 @@ async fn run_inner(
                 tracing::info!("Shutdown received during standalone EPP initialization");
                 return Ok(());
             }
-            router = async {
-                Ok::<_, anyhow::Error>(Arc::new(match standalone_selection_service {
-                    StandaloneSelectionService::Default => {
-                        crate::EppRouter::from_selector(selector_cfg).await?
-                    }
-                    StandaloneSelectionService::Existing(service) => {
-                        crate::EppRouter::from_selection_service(selector_cfg, service).await?
-                    }
-                    StandaloneSelectionService::LinkedWorkerSelectionPolicy {
-                        kv_router_config,
-                        factory,
-                    } => {
-                        let service =
-                            Selector::build_selection_service_with_worker_selection_policy_factory(
-                                &selector_cfg,
-                                *kv_router_config,
-                                factory,
-                            )
-                            .await?;
-                        crate::EppRouter::from_selection_service(selector_cfg, service).await?
-                    }
-                }))
-            } => router?,
+            router = crate::EppRouter::from_selector(selector_cfg, policy_registry) => Arc::new(router?),
         };
         if draining.is_cancelled() {
             tracing::info!("Shutdown received before standalone EPP serving started");
@@ -554,49 +458,56 @@ async fn serve<P: crate::EndpointPicker>(
 
 #[cfg(test)]
 mod tests {
+    use dynamo_kv_router::scheduling::selector::WorkerSelectionPolicy;
+
     use super::*;
 
+    fn nonempty_registry() -> WorkerSelectionPolicyRegistry {
+        let mut registry = WorkerSelectionPolicyRegistry::default();
+        registry
+            .register(
+                "test",
+                Arc::new(|_| {
+                    Ok(Arc::new(|config, worker_type, _partition| {
+                        WorkerSelectionPolicy::default(
+                            config.clone(),
+                            worker_type.default_selector_label(),
+                        )
+                    }))
+                }),
+            )
+            .unwrap();
+        registry
+    }
+
     #[test]
-    fn linked_policy_requires_standalone_epp() {
+    fn nonempty_registry_requires_standalone_epp() {
+        let registry = nonempty_registry();
         assert!(
-            require_standalone_mode_for_linked_worker_selection_policy(EppMode::Standalone).is_ok()
+            require_standalone_mode_for_linked_worker_selection_policy(
+                EppMode::Standalone,
+                Some(&registry),
+            )
+            .is_ok()
         );
         assert!(
-            require_standalone_mode_for_linked_worker_selection_policy(EppMode::DynamoRuntime)
-                .is_err()
+            require_standalone_mode_for_linked_worker_selection_policy(
+                EppMode::DynamoRuntime,
+                Some(&registry),
+            )
+            .is_err()
         );
     }
 
     #[test]
-    fn stock_epp_rejects_custom_worker_selection_policy() {
-        let policy_file = tempfile::NamedTempFile::new().unwrap();
-        std::fs::write(
-            policy_file.path(),
-            r#"
-worker_selection:
-  aggregated: custom
-  instances:
-    - name: custom
-      type: acme
-      parameters: {}
-"#,
-        )
-        .unwrap();
-        let config = KvRouterConfig {
-            router_policy_config: Some(policy_file.path().display().to_string()),
-            ..Default::default()
-        };
-
-        assert!(reject_unlinked_worker_selection_policy(&config).is_err());
-    }
-
-    #[test]
-    fn stock_epp_ignores_embedded_stage_policy() {
-        let config = KvRouterConfig {
-            router_prefill_policy: Some("embedded-only".to_string()),
-            ..Default::default()
-        };
-
-        assert!(reject_unlinked_worker_selection_policy(&config).is_ok());
+    fn empty_registry_allows_dynamo_runtime() {
+        let registry = WorkerSelectionPolicyRegistry::default();
+        assert!(
+            require_standalone_mode_for_linked_worker_selection_policy(
+                EppMode::DynamoRuntime,
+                Some(&registry),
+            )
+            .is_ok()
+        );
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -13,12 +13,13 @@ use std::sync::atomic::AtomicBool;
 
 use anyhow::{Result, anyhow};
 
-use dynamo_kv_router::config::{KvRouterConfig, kv_router_config_from_dynamo_env};
+use dynamo_kv_router::WorkerType;
+use dynamo_kv_router::config::{KvRouterConfig, try_kv_router_config_from_dynamo_env};
 use dynamo_kv_router::protocols::RoutingConstraints;
 use dynamo_kv_router::services::selection::{
     PromptRequest, SelectAndReserveRequest as CoreSelectAndReserveRequest, SelectionError,
     SelectionService, SelectionServiceBuilder, WorkerLifecycle, WorkerRequest as CoreWorkerRequest,
-    WorkerSelectionPolicyFactory,
+    WorkerSelectionPolicyRegistry,
 };
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
@@ -115,42 +116,39 @@ impl Selector {
         Ok(())
     }
 
-    pub async fn new(cfg: &EppStandaloneConfig) -> Result<Self> {
-        Self::new_with_kv_router_config(cfg, kv_router_config_from_dynamo_env()).await
-    }
-
-    /// Build a selection service using the custom policy compiled into this EPP image.
-    pub(crate) async fn build_selection_service_with_worker_selection_policy_factory(
+    pub async fn new(
         cfg: &EppStandaloneConfig,
-        kv_router_config: KvRouterConfig,
-        factory: WorkerSelectionPolicyFactory,
-    ) -> Result<SelectionService> {
-        Self::build_selection_service(cfg, kv_router_config, Some(factory)).await
+        policy_registry: Option<WorkerSelectionPolicyRegistry>,
+    ) -> Result<Self> {
+        let kv_router_config =
+            try_kv_router_config_from_dynamo_env().map_err(anyhow::Error::msg)?;
+        Self::new_with_kv_router_config(cfg, kv_router_config, policy_registry).await
     }
 
     async fn new_with_kv_router_config(
         cfg: &EppStandaloneConfig,
         kv_router_config: KvRouterConfig,
+        policy_registry: Option<WorkerSelectionPolicyRegistry>,
     ) -> Result<Self> {
-        let service = Self::build_selection_service(cfg, kv_router_config, None).await?;
+        let service = Self::build_selection_service(cfg, kv_router_config, policy_registry).await?;
         Self::from_service(cfg, service).await
     }
 
     async fn build_selection_service(
         cfg: &EppStandaloneConfig,
         kv_router_config: KvRouterConfig,
-        factory: Option<WorkerSelectionPolicyFactory>,
+        policy_registry: Option<WorkerSelectionPolicyRegistry>,
     ) -> Result<SelectionService> {
-        // If queueing is enabled, we need to validate that the max_num_batched_tokens is set.
-        // Done once at startup to avoid validating on every reconcile.
-        let queueing_enabled = kv_router_config
-            .queueing_enabled(Some(&cfg.model_name))
-            .map_err(|e| anyhow!("resolving router policy for model {}: {e}", cfg.model_name))?;
-        Self::validate_queueing_requirements(cfg, queueing_enabled)?;
+        if kv_router_config.has_explicit_stage_worker_selection_policy()? {
+            tracing::warn!(
+                "worker_selection.prefill, worker_selection.decode, worker_selection.encode, DYN_ROUTER_PREFILL_POLICY, and DYN_ROUTER_DECODE_POLICY are ignored by aggregated EPP selection"
+            );
+        }
 
         let mut builder = SelectionServiceBuilder::new(kv_router_config)
-            .indexer_threads(cfg.selector_threads)
-            .resolved_worker_selection_policy_factory(factory);
+            .worker_type(WorkerType::Aggregated)
+            .worker_selection_policy_registry(policy_registry)
+            .indexer_threads(cfg.selector_threads);
         let replication = Self::replication(cfg).await?;
 
         if let Some((_, peer_sync_port)) = &replication {
@@ -163,11 +161,7 @@ impl Selector {
             .map_err(|e| anyhow!("building embedded selection service: {e}"))
     }
 
-    /// Wrap a prebuilt selection service for use by a custom EPP image.
-    pub(crate) async fn from_service(
-        cfg: &EppStandaloneConfig,
-        service: SelectionService,
-    ) -> Result<Self> {
+    async fn from_service(cfg: &EppStandaloneConfig, service: SelectionService) -> Result<Self> {
         let service = Arc::new(service);
         let queueing_enabled = service
             .queueing_enabled(&cfg.model_name)
@@ -414,9 +408,12 @@ impl Drop for Selector {
 
 #[cfg(test)]
 mod tests {
+    use dynamo_kv_router::services::selection::{
+        WorkerSelectionPolicyParameters, WorkerSelectionPolicyProviderError,
+    };
     use dynamo_kv_router::{
         WorkerInputView, WorkerPicker, WorkerSelectionContext, WorkerSelectionPolicy,
-        WorkerSelectionPolicyError,
+        WorkerSelectionPolicyError, WorkerSelectionPolicyFactory,
     };
 
     use super::*;
@@ -432,6 +429,20 @@ mod tests {
             assert!(!input.candidates().is_empty());
             Ok(0)
         }
+    }
+
+    fn first_eligible_provider(
+        _parameters: &WorkerSelectionPolicyParameters,
+    ) -> std::result::Result<WorkerSelectionPolicyFactory, WorkerSelectionPolicyProviderError> {
+        Ok(Arc::new(|config, worker_type, _partition| {
+            assert_eq!(worker_type, WorkerType::Aggregated);
+            WorkerSelectionPolicy::new(
+                config.clone(),
+                worker_type.as_str(),
+                Vec::new(),
+                Box::new(FirstEligiblePicker),
+            )
+        }))
     }
 
     fn model_policy_file() -> tempfile::NamedTempFile {
@@ -553,7 +564,7 @@ models:
     /// Reconcile a single schedulable worker into a fresh selector, asserting the
     /// core admitted it (so the reserve paths below actually book).
     async fn selector_with_schedulable_worker() -> Selector {
-        let selector = Selector::new(&test_config())
+        let selector = Selector::new(&test_config(), None)
             .await
             .expect("selector should build");
         selector
@@ -568,24 +579,31 @@ models:
     }
 
     #[tokio::test]
-    async fn prebuilt_service_runs_custom_policy_through_reservation() {
-        let service = Selector::build_selection_service(
+    async fn registered_policy_runs_through_reservation() {
+        let policy_file = tempfile::NamedTempFile::new().expect("create policy file");
+        std::fs::write(
+            policy_file.path(),
+            r#"
+worker_selection:
+  aggregated: first-eligible
+  instances:
+    - name: first-eligible
+      type: first-eligible
+      parameters: {}
+"#,
+        )
+        .expect("write policy file");
+        let mut registry = WorkerSelectionPolicyRegistry::default();
+        registry
+            .register("first-eligible", Arc::new(first_eligible_provider))
+            .expect("register policy provider");
+        let selector = Selector::new_with_kv_router_config(
             &test_config(),
-            KvRouterConfig::default(),
-            Some(Arc::new(|config, worker_type, _partition| {
-                WorkerSelectionPolicy::new(
-                    config.clone(),
-                    worker_type.as_str(),
-                    Vec::new(),
-                    Box::new(FirstEligiblePicker),
-                )
-            })),
+            router_config_with_policy(&policy_file),
+            Some(registry),
         )
         .await
         .expect("custom selection service should build");
-        let selector = Selector::from_service(&test_config(), service)
-            .await
-            .expect("selector should accept a prebuilt service");
         selector
             .reconcile(&[schedulable_registration(1)])
             .await
@@ -723,7 +741,7 @@ models:
     /// so a worker exists in the catalog but is never schedulable.
     #[tokio::test]
     async fn select_and_reserve_errors_without_a_schedulable_worker() {
-        let selector = Selector::new(&test_config())
+        let selector = Selector::new(&test_config(), None)
             .await
             .expect("selector should build");
         selector
@@ -749,7 +767,7 @@ models:
     /// `prefill_complete` treat an unknown id as success (NotFound → Ok).
     #[tokio::test]
     async fn free_and_prefill_of_unknown_reservation_are_noops() {
-        let selector = Selector::new(&test_config())
+        let selector = Selector::new(&test_config(), None)
             .await
             .expect("selector should build");
         selector
@@ -764,7 +782,7 @@ models:
 
     #[tokio::test]
     async fn incomplete_worker_is_not_cached_as_reconciled() {
-        let selector = Selector::new(&test_config())
+        let selector = Selector::new(&test_config(), None)
             .await
             .expect("selector should build");
 
@@ -800,7 +818,7 @@ models:
 
     #[tokio::test]
     async fn stale_incomplete_worker_is_deleted() {
-        let selector = Selector::new(&test_config())
+        let selector = Selector::new(&test_config(), None)
             .await
             .expect("selector should build");
 
@@ -832,11 +850,14 @@ models:
         cfg.model_name = "queueing-model".to_string();
         cfg.max_num_batched_tokens = None;
 
-        let error =
-            Selector::new_with_kv_router_config(&cfg, router_config_with_policy(&policy_file))
-                .await
-                .err()
-                .expect("queueing model must reject missing capacity");
+        let error = Selector::new_with_kv_router_config(
+            &cfg,
+            router_config_with_policy(&policy_file),
+            None,
+        )
+        .await
+        .err()
+        .expect("queueing model must reject missing capacity");
         assert!(
             error
                 .to_string()
@@ -852,7 +873,7 @@ models:
         cfg.model_name = "threshold-free-model".to_string();
         cfg.max_num_batched_tokens = None;
 
-        Selector::new_with_kv_router_config(&cfg, router_config_with_policy(&policy_file))
+        Selector::new_with_kv_router_config(&cfg, router_config_with_policy(&policy_file), None)
             .await
             .expect("threshold-free model should allow missing capacity");
     }
@@ -906,7 +927,7 @@ models:
 
     #[tokio::test]
     async fn duplicate_worker_ids_are_rejected_before_reconciliation() {
-        let selector = Selector::new(&test_config())
+        let selector = Selector::new(&test_config(), None)
             .await
             .expect("selector should build");
         let duplicate = incomplete_registration(1);

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -130,12 +130,6 @@ impl Selector {
         kv_router_config: KvRouterConfig,
         policy_registry: Option<WorkerSelectionPolicyRegistry>,
     ) -> Result<Self> {
-        if kv_router_config.has_explicit_stage_worker_selection_policy()? {
-            tracing::warn!(
-                "worker_selection.prefill, worker_selection.decode, worker_selection.encode, DYN_ROUTER_PREFILL_POLICY, and DYN_ROUTER_DECODE_POLICY are ignored by aggregated EPP selection"
-            );
-        }
-
         let replication = Self::replication(cfg).await?;
         let mut builder = SelectionServiceBuilder::new(kv_router_config)
             .worker_type(WorkerType::Aggregated)

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -118,7 +118,7 @@ impl Selector {
 
     pub async fn new(
         cfg: &EppStandaloneConfig,
-        policy_registry: Option<WorkerSelectionPolicyRegistry>,
+        policy_registry: WorkerSelectionPolicyRegistry,
     ) -> Result<Self> {
         let kv_router_config =
             try_kv_router_config_from_dynamo_env().map_err(anyhow::Error::msg)?;
@@ -128,14 +128,13 @@ impl Selector {
     async fn new_with_kv_router_config(
         cfg: &EppStandaloneConfig,
         kv_router_config: KvRouterConfig,
-        policy_registry: Option<WorkerSelectionPolicyRegistry>,
+        policy_registry: WorkerSelectionPolicyRegistry,
     ) -> Result<Self> {
         warn_for_unserved_worker_selection_policies(&kv_router_config, &[WorkerType::Aggregated])?;
         let replication = Self::replication(cfg).await?;
-        let mut builder = SelectionServiceBuilder::new(kv_router_config)
-            .worker_type(WorkerType::Aggregated)
-            .worker_selection_policy_registry(policy_registry)
-            .indexer_threads(cfg.selector_threads);
+        let mut builder =
+            SelectionServiceBuilder::new(kv_router_config, WorkerType::Aggregated, policy_registry)
+                .indexer_threads(cfg.selector_threads);
         if let Some((_, peer_sync_port)) = &replication {
             builder = builder.replica_sync(*peer_sync_port, Vec::new());
         }
@@ -535,7 +534,7 @@ models:
     /// Reconcile a single schedulable worker into a fresh selector, asserting the
     /// core admitted it (so the reserve paths below actually book).
     async fn selector_with_schedulable_worker() -> Selector {
-        let selector = Selector::new(&test_config(), None)
+        let selector = Selector::new(&test_config(), WorkerSelectionPolicyRegistry::default())
             .await
             .expect("selector should build");
         selector
@@ -571,7 +570,7 @@ worker_selection:
         let selector = Selector::new_with_kv_router_config(
             &test_config(),
             router_config_with_policy(&policy_file),
-            Some(registry),
+            registry,
         )
         .await
         .expect("custom selection service should build");
@@ -712,7 +711,7 @@ worker_selection:
     /// so a worker exists in the catalog but is never schedulable.
     #[tokio::test]
     async fn select_and_reserve_errors_without_a_schedulable_worker() {
-        let selector = Selector::new(&test_config(), None)
+        let selector = Selector::new(&test_config(), WorkerSelectionPolicyRegistry::default())
             .await
             .expect("selector should build");
         selector
@@ -738,7 +737,7 @@ worker_selection:
     /// `prefill_complete` treat an unknown id as success (NotFound → Ok).
     #[tokio::test]
     async fn free_and_prefill_of_unknown_reservation_are_noops() {
-        let selector = Selector::new(&test_config(), None)
+        let selector = Selector::new(&test_config(), WorkerSelectionPolicyRegistry::default())
             .await
             .expect("selector should build");
         selector
@@ -753,7 +752,7 @@ worker_selection:
 
     #[tokio::test]
     async fn incomplete_worker_is_not_cached_as_reconciled() {
-        let selector = Selector::new(&test_config(), None)
+        let selector = Selector::new(&test_config(), WorkerSelectionPolicyRegistry::default())
             .await
             .expect("selector should build");
 
@@ -789,7 +788,7 @@ worker_selection:
 
     #[tokio::test]
     async fn stale_incomplete_worker_is_deleted() {
-        let selector = Selector::new(&test_config(), None)
+        let selector = Selector::new(&test_config(), WorkerSelectionPolicyRegistry::default())
             .await
             .expect("selector should build");
 
@@ -824,7 +823,7 @@ worker_selection:
         let error = Selector::new_with_kv_router_config(
             &cfg,
             router_config_with_policy(&policy_file),
-            None,
+            WorkerSelectionPolicyRegistry::default(),
         )
         .await
         .err()
@@ -844,14 +843,18 @@ worker_selection:
         cfg.model_name = "threshold-free-model".to_string();
         cfg.max_num_batched_tokens = None;
 
-        Selector::new_with_kv_router_config(&cfg, router_config_with_policy(&policy_file), None)
-            .await
-            .expect("threshold-free model should allow missing capacity");
+        Selector::new_with_kv_router_config(
+            &cfg,
+            router_config_with_policy(&policy_file),
+            WorkerSelectionPolicyRegistry::default(),
+        )
+        .await
+        .expect("threshold-free model should allow missing capacity");
     }
 
     #[tokio::test]
     async fn duplicate_worker_ids_are_rejected_before_reconciliation() {
-        let selector = Selector::new(&test_config(), None)
+        let selector = Selector::new(&test_config(), WorkerSelectionPolicyRegistry::default())
             .await
             .expect("selector should build");
         let duplicate = incomplete_registration(1);

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -19,7 +19,7 @@ use dynamo_kv_router::protocols::RoutingConstraints;
 use dynamo_kv_router::services::selection::{
     PromptRequest, SelectAndReserveRequest as CoreSelectAndReserveRequest, SelectionError,
     SelectionService, SelectionServiceBuilder, WorkerLifecycle, WorkerRequest as CoreWorkerRequest,
-    WorkerSelectionPolicyRegistry,
+    WorkerSelectionPolicyRegistry, warn_for_unserved_worker_selection_policies,
 };
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
@@ -130,6 +130,7 @@ impl Selector {
         kv_router_config: KvRouterConfig,
         policy_registry: Option<WorkerSelectionPolicyRegistry>,
     ) -> Result<Self> {
+        warn_for_unserved_worker_selection_policies(&kv_router_config, &[WorkerType::Aggregated])?;
         let replication = Self::replication(cfg).await?;
         let mut builder = SelectionServiceBuilder::new(kv_router_config)
             .worker_type(WorkerType::Aggregated)

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -115,17 +115,7 @@ impl Selector {
         kv_router_config: KvRouterConfig,
         policy_registry: WorkerSelectionPolicyRegistry,
     ) -> Result<Self> {
-        let queueing_enabled = kv_router_config
-            .queueing_enabled(Some(&cfg.model_name))
-            .map_err(|e| anyhow!("resolving router policy for model {}: {e}", cfg.model_name))?;
-        if queueing_enabled && cfg.max_num_batched_tokens.unwrap_or(0) == 0 {
-            anyhow::bail!(
-                "DYN_EPP_MAX_NUM_BATCHED_TOKENS is required (and must be > 0) because the router \
-                 scheduling policy enables queueing for model {}; set it to the engine's \
-                 --max-num-batched-tokens",
-                cfg.model_name
-            );
-        }
+        Self::validate_queueing_worker_capacity(cfg, &kv_router_config)?;
 
         warn_for_unserved_worker_selection_policies(&kv_router_config, &[WorkerType::Aggregated])?;
         let replication = Self::replication(cfg).await?;
@@ -142,6 +132,24 @@ impl Selector {
                 .map_err(|e| anyhow!("building embedded selection service: {e}"))?,
         );
         Self::from_service_with_replication(cfg, service, replication).await
+    }
+
+    fn validate_queueing_worker_capacity(
+        cfg: &EppStandaloneConfig,
+        kv_router_config: &KvRouterConfig,
+    ) -> Result<()> {
+        let queueing_enabled = kv_router_config
+            .queueing_enabled(Some(&cfg.model_name))
+            .map_err(|e| anyhow!("resolving router policy for model {}: {e}", cfg.model_name))?;
+        if queueing_enabled && cfg.max_num_batched_tokens.unwrap_or(0) == 0 {
+            anyhow::bail!(
+                "DYN_EPP_MAX_NUM_BATCHED_TOKENS is required (and must be > 0) because the router \
+                 scheduling policy enables queueing for model {}; set it to the engine's \
+                 --max-num-batched-tokens",
+                cfg.model_name
+            );
+        }
+        Ok(())
     }
 
     async fn replication(cfg: &EppStandaloneConfig) -> Result<Option<(String, u16)>> {

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -101,21 +101,6 @@ struct ReconcileState {
 }
 
 impl Selector {
-    fn validate_queueing_requirements(
-        cfg: &EppStandaloneConfig,
-        queueing_enabled: bool,
-    ) -> Result<()> {
-        if queueing_enabled && cfg.max_num_batched_tokens.unwrap_or(0) == 0 {
-            anyhow::bail!(
-                "DYN_EPP_MAX_NUM_BATCHED_TOKENS is required (and must be > 0) because the router \
-                 scheduling policy enables queueing for model {}; set it to the engine's \
-                 --max-num-batched-tokens",
-                cfg.model_name
-            );
-        }
-        Ok(())
-    }
-
     pub async fn new(
         cfg: &EppStandaloneConfig,
         policy_registry: WorkerSelectionPolicyRegistry,
@@ -130,6 +115,18 @@ impl Selector {
         kv_router_config: KvRouterConfig,
         policy_registry: WorkerSelectionPolicyRegistry,
     ) -> Result<Self> {
+        let queueing_enabled = kv_router_config
+            .queueing_enabled(Some(&cfg.model_name))
+            .map_err(|e| anyhow!("resolving router policy for model {}: {e}", cfg.model_name))?;
+        if queueing_enabled && cfg.max_num_batched_tokens.unwrap_or(0) == 0 {
+            anyhow::bail!(
+                "DYN_EPP_MAX_NUM_BATCHED_TOKENS is required (and must be > 0) because the router \
+                 scheduling policy enables queueing for model {}; set it to the engine's \
+                 --max-num-batched-tokens",
+                cfg.model_name
+            );
+        }
+
         warn_for_unserved_worker_selection_policies(&kv_router_config, &[WorkerType::Aggregated])?;
         let replication = Self::replication(cfg).await?;
         let mut builder =
@@ -144,10 +141,6 @@ impl Selector {
                 .await
                 .map_err(|e| anyhow!("building embedded selection service: {e}"))?,
         );
-        let queueing_enabled = service
-            .queueing_enabled(&cfg.model_name)
-            .map_err(|e| anyhow!("resolving router policy for model {}: {e}", cfg.model_name))?;
-        Self::validate_queueing_requirements(cfg, queueing_enabled)?;
         Self::from_service_with_replication(cfg, service, replication).await
     }
 
@@ -827,11 +820,12 @@ worker_selection:
     }
 
     #[tokio::test]
-    async fn queueing_model_requires_max_num_batched_tokens_at_startup() {
+    async fn queueing_model_rejects_missing_capacity_before_peer_discovery() {
         let policy_file = model_policy_file();
         let mut cfg = test_config();
         cfg.model_name = "queueing-model".to_string();
         cfg.max_num_batched_tokens = None;
+        cfg.peer_service = Some("unreachable-peer-service".to_string());
 
         let error = Selector::new_with_kv_router_config(
             &cfg,

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -130,54 +130,30 @@ impl Selector {
         kv_router_config: KvRouterConfig,
         policy_registry: Option<WorkerSelectionPolicyRegistry>,
     ) -> Result<Self> {
-        let service = Self::build_selection_service(cfg, kv_router_config, policy_registry).await?;
-        Self::from_service(cfg, service).await
-    }
-
-    async fn build_selection_service(
-        cfg: &EppStandaloneConfig,
-        kv_router_config: KvRouterConfig,
-        policy_registry: Option<WorkerSelectionPolicyRegistry>,
-    ) -> Result<SelectionService> {
         if kv_router_config.has_explicit_stage_worker_selection_policy()? {
             tracing::warn!(
                 "worker_selection.prefill, worker_selection.decode, worker_selection.encode, DYN_ROUTER_PREFILL_POLICY, and DYN_ROUTER_DECODE_POLICY are ignored by aggregated EPP selection"
             );
         }
 
+        let replication = Self::replication(cfg).await?;
         let mut builder = SelectionServiceBuilder::new(kv_router_config)
             .worker_type(WorkerType::Aggregated)
             .worker_selection_policy_registry(policy_registry)
             .indexer_threads(cfg.selector_threads);
-        let replication = Self::replication(cfg).await?;
-
         if let Some((_, peer_sync_port)) = &replication {
             builder = builder.replica_sync(*peer_sync_port, Vec::new());
         }
-
-        builder
-            .build()
-            .await
-            .map_err(|e| anyhow!("building embedded selection service: {e}"))
-    }
-
-    async fn from_service(cfg: &EppStandaloneConfig, service: SelectionService) -> Result<Self> {
-        let service = Arc::new(service);
+        let service = Arc::new(
+            builder
+                .build()
+                .await
+                .map_err(|e| anyhow!("building embedded selection service: {e}"))?,
+        );
         let queueing_enabled = service
             .queueing_enabled(&cfg.model_name)
             .map_err(|e| anyhow!("resolving router policy for model {}: {e}", cfg.model_name))?;
         Self::validate_queueing_requirements(cfg, queueing_enabled)?;
-        let replication = match &cfg.peer_service {
-            Some(name) => Some((
-                name.clone(),
-                service.replica_sync_port().ok_or_else(|| {
-                    anyhow!(
-                        "DYN_EPP_PEER_SERVICE requires a prebuilt SelectionService with replica sync enabled"
-                    )
-                })?,
-            )),
-            None => None,
-        };
         Self::from_service_with_replication(cfg, service, replication).await
     }
 
@@ -876,53 +852,6 @@ worker_selection:
         Selector::new_with_kv_router_config(&cfg, router_config_with_policy(&policy_file), None)
             .await
             .expect("threshold-free model should allow missing capacity");
-    }
-
-    #[tokio::test]
-    async fn prebuilt_service_rejects_missing_queue_capacity() {
-        let policy_file = model_policy_file();
-        let router_config = router_config_with_policy(&policy_file);
-        let service = SelectionServiceBuilder::new(router_config)
-            .indexer_threads(1)
-            .build()
-            .await
-            .expect("selection service should build");
-        let mut cfg = test_config();
-        cfg.model_name = "queueing-model".to_string();
-        cfg.max_num_batched_tokens = None;
-
-        let error = Selector::from_service(&cfg, service)
-            .await
-            .err()
-            .expect("queueing model must reject missing capacity");
-        assert!(
-            error
-                .to_string()
-                .contains("DYN_EPP_MAX_NUM_BATCHED_TOKENS is required"),
-            "{error}"
-        );
-    }
-
-    #[tokio::test]
-    async fn prebuilt_service_rejects_peer_discovery_without_replica_sync() {
-        let service = SelectionServiceBuilder::new(KvRouterConfig::default())
-            .indexer_threads(1)
-            .build()
-            .await
-            .expect("selection service should build");
-        let mut cfg = test_config();
-        cfg.peer_service = Some("does-not-exist".to_string());
-
-        let error = Selector::from_service(&cfg, service)
-            .await
-            .err()
-            .expect("peer discovery must require replica sync");
-        assert!(
-            error
-                .to_string()
-                .contains("SelectionService with replica sync enabled"),
-            "{error}"
-        );
     }
 
     #[tokio::test]

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -378,42 +378,15 @@ impl Drop for Selector {
 
 #[cfg(test)]
 mod tests {
-    use dynamo_kv_router::services::selection::{
-        WorkerSelectionPolicyParameters, WorkerSelectionPolicyProviderError,
-    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use dynamo_kv_router::services::selection::WorkerSelectionPolicyParameters;
     use dynamo_kv_router::{
         WorkerInputView, WorkerPicker, WorkerSelectionContext, WorkerSelectionPolicy,
         WorkerSelectionPolicyError, WorkerSelectionPolicyFactory,
     };
 
     use super::*;
-
-    struct FirstEligiblePicker;
-
-    impl WorkerPicker for FirstEligiblePicker {
-        fn pick(
-            &mut self,
-            _context: &WorkerSelectionContext<'_>,
-            input: WorkerInputView<'_>,
-        ) -> Result<usize, WorkerSelectionPolicyError> {
-            assert!(!input.candidates().is_empty());
-            Ok(0)
-        }
-    }
-
-    fn first_eligible_provider(
-        _parameters: &WorkerSelectionPolicyParameters,
-    ) -> std::result::Result<WorkerSelectionPolicyFactory, WorkerSelectionPolicyProviderError> {
-        Ok(Arc::new(|config, worker_type, _partition| {
-            assert_eq!(worker_type, WorkerType::Aggregated);
-            WorkerSelectionPolicy::new(
-                config.clone(),
-                worker_type.as_str(),
-                Vec::new(),
-                Box::new(FirstEligiblePicker),
-            )
-        }))
-    }
 
     fn model_policy_file() -> tempfile::NamedTempFile {
         let policy_file = tempfile::NamedTempFile::new().expect("create policy file");
@@ -550,6 +523,19 @@ models:
 
     #[tokio::test]
     async fn registered_policy_runs_through_reservation() {
+        struct FirstEligiblePicker;
+
+        impl WorkerPicker for FirstEligiblePicker {
+            fn pick(
+                &mut self,
+                _context: &WorkerSelectionContext<'_>,
+                input: WorkerInputView<'_>,
+            ) -> Result<usize, WorkerSelectionPolicyError> {
+                assert!(!input.candidates().is_empty());
+                Ok(0)
+            }
+        }
+
         let policy_file = tempfile::NamedTempFile::new().expect("create policy file");
         std::fs::write(
             policy_file.path(),
@@ -563,9 +549,33 @@ worker_selection:
 "#,
         )
         .expect("write policy file");
+        let provider_calls = Arc::new(AtomicUsize::new(0));
+        let factory_calls = Arc::new(AtomicUsize::new(0));
         let mut registry = WorkerSelectionPolicyRegistry::default();
         registry
-            .register("first-eligible", Arc::new(first_eligible_provider))
+            .register(
+                "first-eligible",
+                Arc::new({
+                    let provider_calls = Arc::clone(&provider_calls);
+                    let factory_calls = Arc::clone(&factory_calls);
+                    move |_parameters: &WorkerSelectionPolicyParameters| {
+                        provider_calls.fetch_add(1, Ordering::Relaxed);
+                        let factory_calls = Arc::clone(&factory_calls);
+                        let factory: WorkerSelectionPolicyFactory =
+                            Arc::new(move |config, worker_type, _partition| {
+                                factory_calls.fetch_add(1, Ordering::Relaxed);
+                                assert_eq!(worker_type, WorkerType::Aggregated);
+                                WorkerSelectionPolicy::new(
+                                    config.clone(),
+                                    worker_type.as_str(),
+                                    Vec::new(),
+                                    Box::new(FirstEligiblePicker),
+                                )
+                            });
+                        Ok(factory)
+                    }
+                }),
+            )
             .expect("register policy provider");
         let selector = Selector::new_with_kv_router_config(
             &test_config(),
@@ -574,10 +584,13 @@ worker_selection:
         )
         .await
         .expect("custom selection service should build");
+        assert_eq!(provider_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(factory_calls.load(Ordering::Relaxed), 0);
         selector
             .reconcile(&[schedulable_registration(1)])
             .await
             .expect("worker should register");
+        assert_eq!(factory_calls.load(Ordering::Relaxed), 1);
 
         let response = selector
             .select_and_reserve(select_request("custom-policy"))

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -183,9 +183,12 @@ mod tests {
     #[tokio::test]
     async fn channel_close_clears_selector_topology() {
         let selector = Arc::new(
-            Selector::new(&config(), None)
-                .await
-                .expect("selector should build"),
+            Selector::new(
+                &config(),
+                dynamo_kv_router::services::selection::WorkerSelectionPolicyRegistry::default(),
+            )
+            .await
+            .expect("selector should build"),
         );
         let (discovery, changes_tx) = PodDiscovery::for_test(vec![worker(7, "10.0.0.1")]);
         let adapter = TopologyAdapter::spawn(discovery, selector.clone(), defaults());

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -183,7 +183,7 @@ mod tests {
     #[tokio::test]
     async fn channel_close_clears_selector_topology() {
         let selector = Arc::new(
-            Selector::new(&config())
+            Selector::new(&config(), None)
                 .await
                 .expect("selector should build"),
         );

--- a/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx
+++ b/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx
@@ -429,14 +429,14 @@ cargo add --manifest-path "$POLICY_DIR/epp/Cargo.toml" --path "$DYNAMO_DIR/deplo
 Register the catalog before the standard runner starts:
 
 ```rust
-use dynamo_ext_proc::run_with_worker_selection_policy_registry;
+use dynamo_ext_proc::run;
 use dynamo_kv_router::services::selection::WorkerSelectionPolicyRegistry;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let mut registry = WorkerSelectionPolicyRegistry::default();
     acme_routing_catalog::register(&mut registry)?;
-    run_with_worker_selection_policy_registry(registry).await
+    run(Some(registry)).await
 }
 ```
 

--- a/examples/router/custom-policy-example/README.md
+++ b/examples/router/custom-policy-example/README.md
@@ -236,7 +236,7 @@ The example EPP links the example catalog and registers it before the standard r
 ```rust
 let mut registry = WorkerSelectionPolicyRegistry::default();
 dynamo_custom_policy_example_catalog::register(&mut registry)?;
-run_with_worker_selection_policy_registry(registry).await
+run(Some(registry)).await
 ```
 
 Run the binary in standalone mode:

--- a/examples/router/custom-policy-example/epp/src/main.rs
+++ b/examples/router/custom-policy-example/epp/src/main.rs
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_ext_proc::run_with_worker_selection_policy_registry;
+use dynamo_ext_proc::run;
 use dynamo_kv_router::services::selection::WorkerSelectionPolicyRegistry;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let mut registry = WorkerSelectionPolicyRegistry::default();
     dynamo_custom_policy_example_catalog::register(&mut registry)?;
-    run_with_worker_selection_policy_registry(registry).await
+    run(Some(registry)).await
 }

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -293,15 +293,18 @@ pub(crate) fn worker_selection_policy_factory(
 }
 
 #[cfg(feature = "select-service")]
-pub(crate) fn linked_worker_selection_policy_registry() -> Option<WorkerSelectionPolicyRegistry> {
+pub(crate) fn linked_worker_selection_policy_registry() -> WorkerSelectionPolicyRegistry {
     #[cfg(feature = "custom-policy")]
     {
-        WORKER_SELECTION_POLICY_REGISTRY.get().cloned()
+        WORKER_SELECTION_POLICY_REGISTRY
+            .get()
+            .cloned()
+            .unwrap_or_default()
     }
 
     #[cfg(not(feature = "custom-policy"))]
     {
-        None
+        WorkerSelectionPolicyRegistry::default()
     }
 }
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -38,7 +38,7 @@ use dynamo_runtime::{
     traits::DistributedRuntimeProvider,
 };
 
-#[cfg(feature = "custom-policy")]
+#[cfg(any(feature = "custom-policy", feature = "select-service"))]
 use dynamo_kv_router::services::selection::WorkerSelectionPolicyRegistry;
 use dynamo_kv_router::{KvRouterConfig, WorkerSelectionPolicyFactory};
 use dynamo_llm::entrypoint::RouterConfig;
@@ -293,45 +293,15 @@ pub(crate) fn worker_selection_policy_factory(
 }
 
 #[cfg(feature = "select-service")]
-pub(crate) fn warn_if_standalone_ignores_stage_policies(
-    config: &KvRouterConfig,
-) -> anyhow::Result<()> {
-    if config.has_explicit_stage_worker_selection_policy()? {
-        tracing::warn!(
-            "prefill, decode, and encode worker-selection policies are ignored by aggregated standalone selection hosts"
-        );
-    }
-    Ok(())
-}
-
-#[cfg(feature = "select-service")]
-/// Resolve only the aggregated policy used by standalone selection hosts.
-pub(crate) fn standalone_worker_selection_policy_factory(
-    config: &KvRouterConfig,
-) -> anyhow::Result<Option<WorkerSelectionPolicyFactory>> {
-    warn_if_standalone_ignores_stage_policies(config)?;
-
+pub(crate) fn linked_worker_selection_policy_registry() -> Option<WorkerSelectionPolicyRegistry> {
     #[cfg(feature = "custom-policy")]
     {
-        Ok(WORKER_SELECTION_POLICY_REGISTRY
-            .get()
-            .map(|registry| {
-                registry.resolve_for_worker_type(config, dynamo_kv_router::WorkerType::Aggregated)
-            })
-            .transpose()?
-            .flatten())
+        WORKER_SELECTION_POLICY_REGISTRY.get().cloned()
     }
 
     #[cfg(not(feature = "custom-policy"))]
     {
-        if let Some(instance) = config.selected_worker_selection_policy_instance_for(
-            dynamo_kv_router::WorkerType::Aggregated,
-        )? {
-            anyhow::bail!(
-                "worker-selection instance {instance:?} is configured, but this Dynamo build has no linked worker-selection policy catalog; rebuild with --features custom-policy"
-            );
-        }
-        Ok(None)
+        None
     }
 }
 
@@ -420,10 +390,7 @@ fn run_slot_tracker(py: Python<'_>, argv: Option<Vec<String>>) -> PyResult<()> {
 fn run_select_service(py: Python<'_>, argv: Option<Vec<String>>) -> PyResult<()> {
     let argv = argv.unwrap_or_default();
     py.allow_threads(move || {
-        llm::kv::run_select_service_cli_with_worker_selection_policy_factory(
-            argv,
-            standalone_worker_selection_policy_factory,
-        )
+        llm::kv::run_select_service_cli(argv, linked_worker_selection_policy_registry())
     })
     .map_err(standalone_to_pyerr)
 }

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -457,7 +457,7 @@ where
 #[cfg(feature = "select-service")]
 pub(crate) fn run_select_service_cli<I, T>(
     args: I,
-    policy_registry: Option<WorkerSelectionPolicyRegistry>,
+    policy_registry: WorkerSelectionPolicyRegistry,
 ) -> anyhow::Result<()>
 where
     I: IntoIterator<Item = T>,
@@ -498,10 +498,7 @@ where
             cli.selection_cache_max_bytes,
         ),
     };
-    let builder = config
-        .service_builder()
-        .worker_type(WorkerType::Aggregated)
-        .worker_selection_policy_registry(policy_registry);
+    let builder = config.service_builder(WorkerType::Aggregated, policy_registry);
     let rt = tokio::runtime::Runtime::new()?;
     let service = rt.block_on(builder.build())?;
     rt.block_on(selection::run_server(config.port, service))
@@ -604,10 +601,12 @@ impl SelectionService {
             &[WorkerType::Aggregated],
         )
         .map_err(to_pyerr)?;
-        let mut builder = SelectionServiceBuilder::new(kv_router_config)
-            .worker_type(WorkerType::Aggregated)
-            .worker_selection_policy_registry(crate::linked_worker_selection_policy_registry())
-            .indexer_threads(indexer_threads)
+        let mut builder = SelectionServiceBuilder::new(
+            kv_router_config,
+            WorkerType::Aggregated,
+            crate::linked_worker_selection_policy_registry(),
+        )
+        .indexer_threads(indexer_threads)
             .indexer_peers(indexer_peers.unwrap_or_default())
             .selection_cache(selection_cache.unwrap_or_default().inner);
         if let Some(port) = replica_sync_port {

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -38,6 +38,7 @@ use dynamo_kv_router::services::selection::{
     SelectRequest, SelectionCacheConfig as RsSelectionCacheConfig, SelectionError,
     SelectionService as RustSelectionService, SelectionServiceBuilder, SelectionServiceConfig,
     WorkerPatchRequest, WorkerRequest, WorkerSelectionPolicyRegistry,
+    warn_for_unserved_worker_selection_policies,
 };
 #[cfg(feature = "slot-tracker")]
 use dynamo_kv_router::services::slot_tracker::{self, SlotTrackerConfig};
@@ -483,6 +484,7 @@ where
     if let Some(key_id) = cli.router_tracking_key_id {
         kv_router_config.router_tracking_key_id = Some(key_id);
     }
+    warn_for_unserved_worker_selection_policies(&kv_router_config, &[WorkerType::Aggregated])?;
     let config = SelectionServiceConfig {
         port: cli.port,
         threads: cli.threads,
@@ -597,6 +599,11 @@ impl SelectionService {
         }
         let kv_router_config =
             try_kv_router_config_from_dynamo_env().map_err(PyValueError::new_err)?;
+        warn_for_unserved_worker_selection_policies(
+            &kv_router_config,
+            &[WorkerType::Aggregated],
+        )
+        .map_err(to_pyerr)?;
         let mut builder = SelectionServiceBuilder::new(kv_router_config)
             .worker_type(WorkerType::Aggregated)
             .worker_selection_policy_registry(crate::linked_worker_selection_policy_registry())

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -20,8 +20,6 @@ use crate::Endpoint;
     feature = "select-service"
 ))]
 use clap::Parser;
-#[cfg(feature = "select-service")]
-use dynamo_kv_router::{TrackingHashAlgorithm, WorkerType};
 #[cfg(feature = "custom-policy")]
 use dynamo_kv_router::WorkerSelectionPolicy;
 use dynamo_kv_router::WorkerSelectionPolicyFactory;
@@ -42,6 +40,8 @@ use dynamo_kv_router::services::selection::{
 };
 #[cfg(feature = "slot-tracker")]
 use dynamo_kv_router::services::slot_tracker::{self, SlotTrackerConfig};
+#[cfg(feature = "select-service")]
+use dynamo_kv_router::{TrackingHashAlgorithm, WorkerType};
 use rs::pipeline::{AsyncEngine, SingleIn};
 use rs::protocols::annotated::Annotated as RsAnnotated;
 use tracing;
@@ -596,19 +596,16 @@ impl SelectionService {
         }
         let kv_router_config =
             try_kv_router_config_from_dynamo_env().map_err(PyValueError::new_err)?;
-        warn_for_unserved_worker_selection_policies(
-            &kv_router_config,
-            &[WorkerType::Aggregated],
-        )
-        .map_err(to_pyerr)?;
+        warn_for_unserved_worker_selection_policies(&kv_router_config, &[WorkerType::Aggregated])
+            .map_err(to_pyerr)?;
         let mut builder = SelectionServiceBuilder::new(
             kv_router_config,
             WorkerType::Aggregated,
             crate::linked_worker_selection_policy_registry(),
         )
         .indexer_threads(indexer_threads)
-            .indexer_peers(indexer_peers.unwrap_or_default())
-            .selection_cache(selection_cache.unwrap_or_default().inner);
+        .indexer_peers(indexer_peers.unwrap_or_default())
+        .selection_cache(selection_cache.unwrap_or_default().inner);
         if let Some(port) = replica_sync_port {
             builder = builder.replica_sync(port, replica_sync_peers);
         }

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -21,7 +21,7 @@ use crate::Endpoint;
 ))]
 use clap::Parser;
 #[cfg(feature = "select-service")]
-use dynamo_kv_router::TrackingHashAlgorithm;
+use dynamo_kv_router::{TrackingHashAlgorithm, WorkerType};
 #[cfg(feature = "custom-policy")]
 use dynamo_kv_router::WorkerSelectionPolicy;
 use dynamo_kv_router::WorkerSelectionPolicyFactory;
@@ -37,7 +37,7 @@ use dynamo_kv_router::services::selection::{
     self, OverlapScoresRequest, PotentialLoadsRequest, ReservationRequest, SelectAndReserveRequest,
     SelectRequest, SelectionCacheConfig as RsSelectionCacheConfig, SelectionError,
     SelectionService as RustSelectionService, SelectionServiceBuilder, SelectionServiceConfig,
-    WorkerPatchRequest, WorkerRequest,
+    WorkerPatchRequest, WorkerRequest, WorkerSelectionPolicyRegistry,
 };
 #[cfg(feature = "slot-tracker")]
 use dynamo_kv_router::services::slot_tracker::{self, SlotTrackerConfig};
@@ -454,14 +454,13 @@ where
 }
 
 #[cfg(feature = "select-service")]
-pub(crate) fn run_select_service_cli_with_worker_selection_policy_factory<I, T, F>(
+pub(crate) fn run_select_service_cli<I, T>(
     args: I,
-    resolve_policy: F,
+    policy_registry: Option<WorkerSelectionPolicyRegistry>,
 ) -> anyhow::Result<()>
 where
     I: IntoIterator<Item = T>,
     T: Into<OsString>,
-    F: FnOnce(&KvRouterConfig) -> anyhow::Result<Option<WorkerSelectionPolicyFactory>>,
 {
     let cli = SelectServiceCli::try_parse_from(
         std::iter::once(OsString::from("python -m dynamo.select_service"))
@@ -499,7 +498,8 @@ where
     };
     let builder = config
         .service_builder()
-        .resolved_worker_selection_policy_factory(resolve_policy(&config.kv_router_config)?);
+        .worker_type(WorkerType::Aggregated)
+        .worker_selection_policy_registry(policy_registry);
     let rt = tokio::runtime::Runtime::new()?;
     let service = rt.block_on(builder.build())?;
     rt.block_on(selection::run_server_with_service(config.port, service))
@@ -597,13 +597,12 @@ impl SelectionService {
         }
         let kv_router_config =
             try_kv_router_config_from_dynamo_env().map_err(PyValueError::new_err)?;
-        let factory = crate::standalone_worker_selection_policy_factory(&kv_router_config)
-            .map_err(to_pyerr)?;
         let mut builder = SelectionServiceBuilder::new(kv_router_config)
+            .worker_type(WorkerType::Aggregated)
+            .worker_selection_policy_registry(crate::linked_worker_selection_policy_registry())
             .indexer_threads(indexer_threads)
             .indexer_peers(indexer_peers.unwrap_or_default())
-            .selection_cache(selection_cache.unwrap_or_default().inner)
-            .resolved_worker_selection_policy_factory(factory);
+            .selection_cache(selection_cache.unwrap_or_default().inner);
         if let Some(port) = replica_sync_port {
             builder = builder.replica_sync(port, replica_sync_peers);
         }

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -504,7 +504,7 @@ where
         .worker_selection_policy_registry(policy_registry);
     let rt = tokio::runtime::Runtime::new()?;
     let service = rt.block_on(builder.build())?;
-    rt.block_on(selection::run_server_with_service(config.port, service))
+    rt.block_on(selection::run_server(config.port, service))
 }
 
 /// Map a [`SelectionError`] to a Python exception: invalid input becomes a

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -1183,12 +1183,13 @@ impl KvRouterConfig {
         })
     }
 
-    /// Return whether a custom stage-specific worker-selection setting was configured.
+    /// Return whether a custom worker-selection setting was configured for another worker role.
     ///
-    /// Standalone hosts use this to warn that prefill, decode, and encode settings only apply to
-    /// typed worker pools in the embedded frontend.
-    pub fn has_explicit_stage_worker_selection_policy(
+    /// Single-role hosts use this to warn about policy settings that their selection service does
+    /// not consume.
+    pub fn has_explicit_worker_selection_policy_for_other_worker_types(
         &self,
+        worker_type: WorkerType,
     ) -> Result<bool, WorkerSelectionPolicyConfigError> {
         fn is_custom(value: Option<&str>) -> bool {
             value.is_some_and(|name| {
@@ -1197,12 +1198,24 @@ impl KvRouterConfig {
             })
         }
 
+        let configured_for_other_worker_type = |configured_worker_type, value| {
+            configured_worker_type != worker_type && is_custom(value)
+        };
         let policy_config = self
             .worker_selection_config()
             .map_err(|source| WorkerSelectionPolicyConfigError::Config { source })?;
-        Ok(is_custom(self.router_prefill_policy.as_deref())
-            || is_custom(self.router_decode_policy.as_deref())
-            || policy_config.is_some_and(|config| config.has_explicit_stage_selection()))
+        Ok(configured_for_other_worker_type(
+            WorkerType::Prefill,
+            self.router_prefill_policy.as_deref(),
+        ) || configured_for_other_worker_type(
+            WorkerType::Decode,
+            self.router_decode_policy.as_deref(),
+        ) || policy_config.is_some_and(|config| {
+            configured_for_other_worker_type(WorkerType::Aggregated, config.aggregated_instance())
+                || configured_for_other_worker_type(WorkerType::Prefill, config.prefill_instance())
+                || configured_for_other_worker_type(WorkerType::Decode, config.decode_instance())
+                || configured_for_other_worker_type(WorkerType::Encode, config.encode_instance())
+        }))
     }
 
     #[cfg(test)]
@@ -1959,7 +1972,16 @@ worker_selection:
             }
         );
 
-        assert!(config.has_explicit_stage_worker_selection_policy().unwrap());
+        assert!(
+            config
+                .has_explicit_worker_selection_policy_for_other_worker_types(WorkerType::Aggregated)
+                .unwrap()
+        );
+        assert!(
+            config
+                .has_explicit_worker_selection_policy_for_other_worker_types(WorkerType::Prefill)
+                .unwrap()
+        );
 
         assert_eq!(
             config
@@ -1969,10 +1991,14 @@ worker_selection:
         );
 
         config.router_policy_config = None;
-        assert!(config.has_explicit_stage_worker_selection_policy().unwrap());
+        assert!(
+            config
+                .has_explicit_worker_selection_policy_for_other_worker_types(WorkerType::Aggregated)
+                .unwrap()
+        );
         assert!(
             !KvRouterConfig::default()
-                .has_explicit_stage_worker_selection_policy()
+                .has_explicit_worker_selection_policy_for_other_worker_types(WorkerType::Aggregated)
                 .unwrap()
         );
 
@@ -1995,7 +2021,22 @@ worker_selection:
         };
         assert!(
             !default_config
-                .has_explicit_stage_worker_selection_policy()
+                .has_explicit_worker_selection_policy_for_other_worker_types(WorkerType::Aggregated)
+                .unwrap()
+        );
+
+        let prefill_only_config = KvRouterConfig {
+            router_prefill_policy: Some("custom".to_string()),
+            ..Default::default()
+        };
+        assert!(
+            prefill_only_config
+                .has_explicit_worker_selection_policy_for_other_worker_types(WorkerType::Aggregated)
+                .unwrap()
+        );
+        assert!(
+            !prefill_only_config
+                .has_explicit_worker_selection_policy_for_other_worker_types(WorkerType::Prefill)
                 .unwrap()
         );
     }

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -1183,49 +1183,37 @@ impl KvRouterConfig {
         })
     }
 
-    /// Return worker roles with an explicit non-default policy selection.
-    ///
-    /// Global worker-selection policy overrides apply to every role and are not returned.
+    /// Return worker roles with a non-default policy selected after applying standard precedence.
     pub fn explicit_worker_selection_policy_types(
         &self,
     ) -> Result<Vec<WorkerType>, WorkerSelectionPolicyConfigError> {
-        fn is_custom(value: Option<&str>) -> bool {
-            value.is_some_and(|name| {
-                let name = name.trim();
-                !name.is_empty() && name != "default"
-            })
-        }
-
-        let policy_config = self
-            .worker_selection_config()
-            .map_err(|source| WorkerSelectionPolicyConfigError::Config { source })?;
-        let mut worker_types = Vec::new();
-        let mut push_if_custom = |worker_type, value| {
-            if is_custom(value) && !worker_types.contains(&worker_type) {
-                worker_types.push(worker_type);
-            }
+        let selected = match env::var(DYN_ROUTER_WORKER_SELECTION_POLICY) {
+            Ok(name) => Ok(Some(name)),
+            Err(VarError::NotPresent) => Ok(None),
+            Err(source) => Err(source),
         };
-        push_if_custom(
-            WorkerType::Aggregated,
-            policy_config.and_then(|config| config.aggregated_instance()),
-        );
-        push_if_custom(
-            WorkerType::Prefill,
-            self.router_prefill_policy
-                .as_deref()
-                .or_else(|| policy_config.and_then(|config| config.prefill_instance())),
-        );
-        push_if_custom(
-            WorkerType::Decode,
-            self.router_decode_policy
-                .as_deref()
-                .or_else(|| policy_config.and_then(|config| config.decode_instance())),
-        );
-        push_if_custom(
-            WorkerType::Encode,
-            policy_config.and_then(|config| config.encode_instance()),
-        );
-        Ok(worker_types)
+        self.explicit_worker_selection_policy_types_from(selected)
+    }
+
+    fn explicit_worker_selection_policy_types_from(
+        &self,
+        selected: Result<Option<String>, VarError>,
+    ) -> Result<Vec<WorkerType>, WorkerSelectionPolicyConfigError> {
+        let WorkerSelectionPolicySelections {
+            aggregated,
+            prefill,
+            decode,
+            encode,
+        } = self.selected_worker_selection_policy_instances_from(selected)?;
+        Ok([
+            (WorkerType::Aggregated, aggregated),
+            (WorkerType::Prefill, prefill),
+            (WorkerType::Decode, decode),
+            (WorkerType::Encode, encode),
+        ]
+        .into_iter()
+        .filter_map(|(worker_type, selection)| selection.map(|_| worker_type))
+        .collect())
     }
 
     #[cfg(test)]
@@ -2010,25 +1998,67 @@ worker_selection:
             router_prefill_policy: Some("custom".to_string()),
             ..Default::default()
         };
-        for (name, config, expected) in [
+        let blank_prefill_override_config = KvRouterConfig {
+            router_policy_config: Some(policy_file.path().display().to_string()),
+            router_prefill_policy: Some(" ".to_string()),
+            ..Default::default()
+        };
+        let global_only_config = KvRouterConfig::default();
+        for (name, config, global, expected) in [
             (
                 "stage default disables YAML policy",
                 &config,
+                None,
                 vec![
                     WorkerType::Aggregated,
                     WorkerType::Prefill,
                     WorkerType::Encode,
                 ],
             ),
-            ("defaults only", &default_config, Vec::new()),
+            ("defaults only", &default_config, None, Vec::new()),
             (
                 "prefill override only",
                 &prefill_only_config,
+                None,
                 vec![WorkerType::Prefill],
+            ),
+            (
+                "global custom policy applies to every role",
+                &global_only_config,
+                Some("global"),
+                vec![
+                    WorkerType::Aggregated,
+                    WorkerType::Prefill,
+                    WorkerType::Decode,
+                    WorkerType::Encode,
+                ],
+            ),
+            (
+                "stage overrides take precedence over global policy",
+                &config,
+                Some("global"),
+                vec![
+                    WorkerType::Aggregated,
+                    WorkerType::Prefill,
+                    WorkerType::Encode,
+                ],
+            ),
+            (
+                "blank stage override falls through to YAML",
+                &blank_prefill_override_config,
+                None,
+                vec![
+                    WorkerType::Aggregated,
+                    WorkerType::Prefill,
+                    WorkerType::Decode,
+                    WorkerType::Encode,
+                ],
             ),
         ] {
             assert_eq!(
-                config.explicit_worker_selection_policy_types().unwrap(),
+                config
+                    .explicit_worker_selection_policy_types_from(Ok(global.map(str::to_owned)))
+                    .unwrap(),
                 expected,
                 "{name}"
             );

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -1183,14 +1183,12 @@ impl KvRouterConfig {
         })
     }
 
-    /// Return whether a custom worker-selection setting was configured for another worker role.
+    /// Return worker roles with an explicit non-default policy selection.
     ///
-    /// Single-role hosts use this to warn about policy settings that their selection service does
-    /// not consume.
-    pub fn has_explicit_worker_selection_policy_for_other_worker_types(
+    /// Global worker-selection policy overrides apply to every role and are not returned.
+    pub fn explicit_worker_selection_policy_types(
         &self,
-        worker_type: WorkerType,
-    ) -> Result<bool, WorkerSelectionPolicyConfigError> {
+    ) -> Result<Vec<WorkerType>, WorkerSelectionPolicyConfigError> {
         fn is_custom(value: Option<&str>) -> bool {
             value.is_some_and(|name| {
                 let name = name.trim();
@@ -1198,24 +1196,24 @@ impl KvRouterConfig {
             })
         }
 
-        let configured_for_other_worker_type = |configured_worker_type, value| {
-            configured_worker_type != worker_type && is_custom(value)
-        };
         let policy_config = self
             .worker_selection_config()
             .map_err(|source| WorkerSelectionPolicyConfigError::Config { source })?;
-        Ok(configured_for_other_worker_type(
-            WorkerType::Prefill,
-            self.router_prefill_policy.as_deref(),
-        ) || configured_for_other_worker_type(
-            WorkerType::Decode,
-            self.router_decode_policy.as_deref(),
-        ) || policy_config.is_some_and(|config| {
-            configured_for_other_worker_type(WorkerType::Aggregated, config.aggregated_instance())
-                || configured_for_other_worker_type(WorkerType::Prefill, config.prefill_instance())
-                || configured_for_other_worker_type(WorkerType::Decode, config.decode_instance())
-                || configured_for_other_worker_type(WorkerType::Encode, config.encode_instance())
-        }))
+        let mut worker_types = Vec::new();
+        let mut push_if_custom = |worker_type, value| {
+            if is_custom(value) && !worker_types.contains(&worker_type) {
+                worker_types.push(worker_type);
+            }
+        };
+        if let Some(config) = policy_config {
+            push_if_custom(WorkerType::Aggregated, config.aggregated_instance());
+            push_if_custom(WorkerType::Prefill, config.prefill_instance());
+            push_if_custom(WorkerType::Decode, config.decode_instance());
+            push_if_custom(WorkerType::Encode, config.encode_instance());
+        }
+        push_if_custom(WorkerType::Prefill, self.router_prefill_policy.as_deref());
+        push_if_custom(WorkerType::Decode, self.router_decode_policy.as_deref());
+        Ok(worker_types)
     }
 
     #[cfg(test)]
@@ -1972,15 +1970,14 @@ worker_selection:
             }
         );
 
-        assert!(
-            config
-                .has_explicit_worker_selection_policy_for_other_worker_types(WorkerType::Aggregated)
-                .unwrap()
-        );
-        assert!(
-            config
-                .has_explicit_worker_selection_policy_for_other_worker_types(WorkerType::Prefill)
-                .unwrap()
+        assert_eq!(
+            config.explicit_worker_selection_policy_types().unwrap(),
+            vec![
+                WorkerType::Aggregated,
+                WorkerType::Prefill,
+                WorkerType::Decode,
+                WorkerType::Encode,
+            ]
         );
 
         assert_eq!(
@@ -1988,18 +1985,6 @@ worker_selection:
                 .selected_worker_selection_policy_instance_for(WorkerType::Encode)
                 .unwrap(),
             Some("yaml-encode".to_string())
-        );
-
-        config.router_policy_config = None;
-        assert!(
-            config
-                .has_explicit_worker_selection_policy_for_other_worker_types(WorkerType::Aggregated)
-                .unwrap()
-        );
-        assert!(
-            !KvRouterConfig::default()
-                .has_explicit_worker_selection_policy_for_other_worker_types(WorkerType::Aggregated)
-                .unwrap()
         );
 
         let default_policy_file = tempfile::NamedTempFile::new().unwrap();
@@ -2020,24 +2005,21 @@ worker_selection:
             ..Default::default()
         };
         assert!(
-            !default_config
-                .has_explicit_worker_selection_policy_for_other_worker_types(WorkerType::Aggregated)
+            default_config
+                .explicit_worker_selection_policy_types()
                 .unwrap()
+                .is_empty()
         );
 
         let prefill_only_config = KvRouterConfig {
             router_prefill_policy: Some("custom".to_string()),
             ..Default::default()
         };
-        assert!(
+        assert_eq!(
             prefill_only_config
-                .has_explicit_worker_selection_policy_for_other_worker_types(WorkerType::Aggregated)
-                .unwrap()
-        );
-        assert!(
-            !prefill_only_config
-                .has_explicit_worker_selection_policy_for_other_worker_types(WorkerType::Prefill)
-                .unwrap()
+                .explicit_worker_selection_policy_types()
+                .unwrap(),
+            vec![WorkerType::Prefill]
         );
     }
 

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -1205,14 +1205,26 @@ impl KvRouterConfig {
                 worker_types.push(worker_type);
             }
         };
-        if let Some(config) = policy_config {
-            push_if_custom(WorkerType::Aggregated, config.aggregated_instance());
-            push_if_custom(WorkerType::Prefill, config.prefill_instance());
-            push_if_custom(WorkerType::Decode, config.decode_instance());
-            push_if_custom(WorkerType::Encode, config.encode_instance());
-        }
-        push_if_custom(WorkerType::Prefill, self.router_prefill_policy.as_deref());
-        push_if_custom(WorkerType::Decode, self.router_decode_policy.as_deref());
+        push_if_custom(
+            WorkerType::Aggregated,
+            policy_config.and_then(|config| config.aggregated_instance()),
+        );
+        push_if_custom(
+            WorkerType::Prefill,
+            self.router_prefill_policy
+                .as_deref()
+                .or_else(|| policy_config.and_then(|config| config.prefill_instance())),
+        );
+        push_if_custom(
+            WorkerType::Decode,
+            self.router_decode_policy
+                .as_deref()
+                .or_else(|| policy_config.and_then(|config| config.decode_instance())),
+        );
+        push_if_custom(
+            WorkerType::Encode,
+            policy_config.and_then(|config| config.encode_instance()),
+        );
         Ok(worker_types)
     }
 
@@ -1971,16 +1983,6 @@ worker_selection:
         );
 
         assert_eq!(
-            config.explicit_worker_selection_policy_types().unwrap(),
-            vec![
-                WorkerType::Aggregated,
-                WorkerType::Prefill,
-                WorkerType::Decode,
-                WorkerType::Encode,
-            ]
-        );
-
-        assert_eq!(
             config
                 .selected_worker_selection_policy_instance_for(WorkerType::Encode)
                 .unwrap(),
@@ -2004,23 +2006,33 @@ worker_selection:
             router_decode_policy: Some("default".to_string()),
             ..Default::default()
         };
-        assert!(
-            default_config
-                .explicit_worker_selection_policy_types()
-                .unwrap()
-                .is_empty()
-        );
-
         let prefill_only_config = KvRouterConfig {
             router_prefill_policy: Some("custom".to_string()),
             ..Default::default()
         };
-        assert_eq!(
-            prefill_only_config
-                .explicit_worker_selection_policy_types()
-                .unwrap(),
-            vec![WorkerType::Prefill]
-        );
+        for (name, config, expected) in [
+            (
+                "stage default disables YAML policy",
+                &config,
+                vec![
+                    WorkerType::Aggregated,
+                    WorkerType::Prefill,
+                    WorkerType::Encode,
+                ],
+            ),
+            ("defaults only", &default_config, Vec::new()),
+            (
+                "prefill override only",
+                &prefill_only_config,
+                vec![WorkerType::Prefill],
+            ),
+        ] {
+            assert_eq!(
+                config.explicit_worker_selection_policy_types().unwrap(),
+                expected,
+                "{name}"
+            );
+        }
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/selector/policy.rs
+++ b/lib/kv-router/src/scheduling/selector/policy.rs
@@ -436,8 +436,7 @@ impl WorkerSelectionPolicy {
 
     /// Wrap Dynamo's built-in selector for a host that uses the policy selector type.
     ///
-    /// `worker_label` selects the built-in scoring and logging contract. Typed hosts use
-    /// [`crate::WorkerType::default_selector_label`] to preserve Dynamo's historical behavior.
+    /// `worker_label` selects the built-in scoring and logging contract.
     pub fn default(kv_router_config: KvRouterConfig, worker_label: &'static str) -> Self {
         let picker = DefaultWorkerPicker::new(kv_router_config.router_temperature);
         Self {

--- a/lib/kv-router/src/scheduling/selector/policy.rs
+++ b/lib/kv-router/src/scheduling/selector/policy.rs
@@ -436,7 +436,8 @@ impl WorkerSelectionPolicy {
 
     /// Wrap Dynamo's built-in selector for a host that uses the policy selector type.
     ///
-    /// `worker_label` selects the built-in scoring and logging contract.
+    /// `worker_label` selects the built-in scoring and logging contract. Typed hosts use
+    /// [`crate::WorkerType::default_selector_label`] to preserve Dynamo's historical behavior.
     pub fn default(kv_router_config: KvRouterConfig, worker_label: &'static str) -> Self {
         let picker = DefaultWorkerPicker::new(kv_router_config.router_temperature);
         Self {

--- a/lib/kv-router/src/scheduling/worker_selection_config.rs
+++ b/lib/kv-router/src/scheduling/worker_selection_config.rs
@@ -16,7 +16,6 @@ pub struct WorkerSelectionConfig {
     prefill: Option<String>,
     decode: Option<String>,
     encode: Option<String>,
-    has_explicit_stage_selection: bool,
     instances: HashMap<String, WorkerSelectionInstance>,
 }
 
@@ -36,10 +35,6 @@ impl WorkerSelectionConfig {
 
     pub(crate) fn encode_instance(&self) -> Option<&str> {
         self.encode.as_deref()
-    }
-
-    pub(crate) fn has_explicit_stage_selection(&self) -> bool {
-        self.has_explicit_stage_selection
     }
 
     /// Look up one named instance.
@@ -146,21 +141,11 @@ impl RawWorkerSelectionConfig {
             }
         }
 
-        let has_explicit_stage_selection = [
-            self.prefill.as_deref(),
-            self.decode.as_deref(),
-            self.encode.as_deref(),
-        ]
-        .into_iter()
-        .flatten()
-        .any(|selected| selected != "default");
-
         Ok(WorkerSelectionConfig {
             aggregated: self.aggregated,
             prefill: self.prefill,
             decode: self.decode,
             encode: self.encode,
-            has_explicit_stage_selection,
             instances,
         })
     }

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -189,31 +189,8 @@ impl SelectionCore {
         ))
     }
 
-    pub(super) fn new_managed(
-        kv_router_config: crate::config::KvRouterConfig,
-        indexer_threads: usize,
-        cancel_token: CancellationToken,
-        replica_config: Option<ReplicaSyncConfig>,
-        worker_selection_policy_factory: Option<WorkerSelectionPolicyFactory>,
-        worker_type: WorkerType,
-        cache_config: SelectionCacheConfig,
-        tracking_hash: Arc<TrackingHashContext>,
-    ) -> Self {
-        Self::new_inner(
-            kv_router_config,
-            indexer_threads,
-            cancel_token,
-            replica_config,
-            worker_selection_policy_factory,
-            worker_type,
-            false,
-            cache_config,
-            tracking_hash,
-        )
-    }
-
     #[allow(clippy::too_many_arguments)]
-    fn new_inner(
+    pub(super) fn new_inner(
         kv_router_config: crate::config::KvRouterConfig,
         indexer_threads: usize,
         cancel_token: CancellationToken,

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -43,7 +43,7 @@ use super::pending::{PendingSelection, SelectionCache, SelectionCacheConfig};
 use super::types::{
     ModelLoadResponse, OverlapScoresRequest, OverlapScoresResponse, PotentialLoadsRequest,
     ReadyResponse, ReservationRequest, ReservationResponse, SelectAndReserveRequest, SelectRequest,
-    SelectResponse, SelectionWorkerConfig, WORKER_TYPE, WorkerCatalogRecord, WorkerLifecycle,
+    SelectResponse, SelectionWorkerConfig, WorkerCatalogRecord, WorkerLifecycle,
     WorkerPatchRequest, WorkerRequest,
 };
 use crate::WorkerSelectionPolicyFactory;
@@ -454,13 +454,14 @@ impl SelectionCore {
                 let (workers_tx, workers_rx) = watch::channel(HashMap::new());
                 let scoped_replica_sync =
                     setup_scoped_replica_sync(self.replica_config.as_ref(), &key, block_size);
+                let worker_label = self.worker_type.default_selector_label();
                 let slots = Arc::new(ActiveSequencesMultiWorker::new_with_replica_worker_policy(
                     scoped_replica_sync.publisher,
                     block_size as usize,
                     HashMap::new(),
                     scoped_replica_sync.enabled,
                     scoped_replica_sync.process_id,
-                    WORKER_TYPE,
+                    worker_label,
                     ReplicaWorkerPolicy::RequireRegistered,
                 ));
                 let replica_tx = scoped_replica_sync.channel.map(|(replica_tx, subscriber)| {
@@ -480,7 +481,7 @@ impl SelectionCore {
                     block_size,
                 ));
                 let selector = self.worker_selection_policy_factory.as_ref().map_or_else(
-                    || WorkerSelectionPolicy::default(self.kv_router_config.clone(), WORKER_TYPE),
+                    || WorkerSelectionPolicy::default(self.kv_router_config.clone(), worker_label),
                     |factory| factory(&self.kv_router_config, self.worker_type, key.as_ref()),
                 );
                 let profile = self
@@ -501,7 +502,7 @@ impl SelectionCore {
                     self.kv_router_config.router_queue_recheck_interval(),
                     self.kv_router_config.router_track_prefill_tokens,
                     self.cancel_token.child_token(),
-                    WORKER_TYPE,
+                    worker_label,
                     true,
                 )?;
                 Ok(Arc::new(SelectionEntry {
@@ -1366,6 +1367,42 @@ mod tests {
         assert!(!core.cancel_token.is_cancelled());
         parent.cancel();
         assert!(core.cancel_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn selection_setup_uses_default_label_for_worker_type() {
+        for (worker_type, expected_label) in [
+            (WorkerType::Prefill, "prefill"),
+            (WorkerType::Decode, "decode"),
+            (WorkerType::Encode, "decode"),
+        ] {
+            let config = test_config(false);
+            let tracking_hash = Arc::new(
+                TrackingHashContext::from_config(&config)
+                    .expect("valid tracking hash configuration"),
+            );
+            let core = SelectionCore::new_inner(
+                config,
+                1,
+                CancellationToken::new(),
+                None,
+                None,
+                worker_type,
+                true,
+                SelectionCacheConfig::default(),
+                tracking_hash,
+            );
+
+            core.upsert_worker(worker(1)).await.expect("worker upsert");
+            let entry = core
+                .entry(&RoutingPartitionId::new("model", "default"))
+                .expect("selection entry");
+            assert_eq!(
+                entry.scheduler.worker_type(),
+                expected_label,
+                "{worker_type}"
+            );
+        }
     }
 
     #[test]

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -143,13 +143,6 @@ impl SelectionCore {
             .collect()
     }
 
-    pub(super) fn queueing_enabled(
-        &self,
-        model_name: &str,
-    ) -> Result<bool, crate::scheduling::RouterPolicyConfigError> {
-        self.kv_router_config.queueing_enabled(Some(model_name))
-    }
-
     /// Create an intentionally local selector without replica synchronization
     /// or startup recovery.
     ///

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -1370,11 +1370,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn selection_setup_uses_default_label_for_worker_type() {
+    async fn selection_setup_uses_worker_type_label() {
         for (worker_type, expected_label) in [
             (WorkerType::Prefill, "prefill"),
             (WorkerType::Decode, "decode"),
-            (WorkerType::Encode, "decode"),
+            (WorkerType::Encode, "encode"),
+            (WorkerType::Aggregated, "aggregated"),
         ] {
             let config = test_config(false);
             let tracking_hash = Arc::new(

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -118,6 +118,7 @@ pub struct SelectionCore {
     indexer_registry: Arc<WorkerRegistry>,
     kv_router_config: crate::config::KvRouterConfig,
     worker_selection_policy_factory: Option<WorkerSelectionPolicyFactory>,
+    worker_type: WorkerType,
     cancel_token: CancellationToken,
     replica_config: Option<ReplicaSyncConfig>,
     /// Booking inputs captured by `select`, keyed by `selection_id`, so a later
@@ -188,6 +189,7 @@ impl SelectionCore {
             cancel_token,
             None,
             None,
+            WorkerType::Aggregated,
             true,
             cache_config,
             tracking_hash,
@@ -200,6 +202,7 @@ impl SelectionCore {
         cancel_token: CancellationToken,
         replica_config: Option<ReplicaSyncConfig>,
         worker_selection_policy_factory: Option<WorkerSelectionPolicyFactory>,
+        worker_type: WorkerType,
         cache_config: SelectionCacheConfig,
         tracking_hash: Arc<TrackingHashContext>,
     ) -> Self {
@@ -209,6 +212,7 @@ impl SelectionCore {
             cancel_token,
             replica_config,
             worker_selection_policy_factory,
+            worker_type,
             false,
             cache_config,
             tracking_hash,
@@ -222,6 +226,7 @@ impl SelectionCore {
         cancel_token: CancellationToken,
         replica_config: Option<ReplicaSyncConfig>,
         worker_selection_policy_factory: Option<WorkerSelectionPolicyFactory>,
+        worker_type: WorkerType,
         signal_indexer_ready: bool,
         cache_config: SelectionCacheConfig,
         tracking_hash: Arc<TrackingHashContext>,
@@ -240,6 +245,7 @@ impl SelectionCore {
             indexer_registry,
             kv_router_config,
             worker_selection_policy_factory,
+            worker_type,
             cancel_token,
             replica_config,
             selection_cache: SelectionCache::new(&cache_config),
@@ -505,7 +511,7 @@ impl SelectionCore {
                 ));
                 let selector = self.worker_selection_policy_factory.as_ref().map_or_else(
                     || WorkerSelectionPolicy::default(self.kv_router_config.clone(), WORKER_TYPE),
-                    |factory| factory(&self.kv_router_config, WorkerType::Aggregated, key.as_ref()),
+                    |factory| factory(&self.kv_router_config, self.worker_type, key.as_ref()),
                 );
                 let profile = self
                     .kv_router_config

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -454,7 +454,7 @@ impl SelectionCore {
                 let (workers_tx, workers_rx) = watch::channel(HashMap::new());
                 let scoped_replica_sync =
                     setup_scoped_replica_sync(self.replica_config.as_ref(), &key, block_size);
-                let worker_label = self.worker_type.default_selector_label();
+                let worker_label = self.worker_type.as_str();
                 let slots = Arc::new(ActiveSequencesMultiWorker::new_with_replica_worker_policy(
                     scoped_replica_sync.publisher,
                     block_size as usize,

--- a/lib/kv-router/src/services/selection/mod.rs
+++ b/lib/kv-router/src/services/selection/mod.rs
@@ -32,7 +32,9 @@ pub use policy_registry::{
     WorkerSelectionPolicyRegistryError,
 };
 pub use server::{AppState, run_server, run_server_with_service};
-pub use service::{SelectionService, SelectionServiceBuilder};
+pub use service::{
+    SelectionService, SelectionServiceBuilder, warn_for_unserved_worker_selection_policies,
+};
 pub use types::{
     ModelLoadResponse, OutputBlockRequest, OverlapScoresRequest, OverlapScoresResponse,
     PotentialLoadsRequest, ReadyResponse, ReservationRequest, ReservationResponse,

--- a/lib/kv-router/src/services/selection/mod.rs
+++ b/lib/kv-router/src/services/selection/mod.rs
@@ -31,7 +31,7 @@ pub use policy_registry::{
     WorkerSelectionPolicyProviderError, WorkerSelectionPolicyRegistry,
     WorkerSelectionPolicyRegistryError,
 };
-pub use server::{AppState, run_server, run_server_with_service};
+pub use server::{AppState, run_server};
 pub use service::{
     SelectionService, SelectionServiceBuilder, warn_for_unserved_worker_selection_policies,
 };

--- a/lib/kv-router/src/services/selection/policy_registry.rs
+++ b/lib/kv-router/src/services/selection/policy_registry.rs
@@ -91,6 +91,11 @@ pub enum WorkerSelectionPolicyRegistryError {
 }
 
 impl WorkerSelectionPolicyRegistry {
+    /// Whether this image has no linked custom worker-selection policy types.
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+    }
+
     /// Register a policy type supplied by a linked policy crate.
     pub fn register(
         &mut self,

--- a/lib/kv-router/src/services/selection/policy_registry.rs
+++ b/lib/kv-router/src/services/selection/policy_registry.rs
@@ -183,7 +183,7 @@ impl WorkerSelectionPolicyRegistry {
                 Some(factory) => factory(config, worker_type, partition),
                 None => WorkerSelectionPolicy::default(
                     config.clone(),
-                    worker_type.default_selector_label(),
+                    worker_type.as_str(),
                 ),
             }
         })))

--- a/lib/kv-router/src/services/selection/policy_registry.rs
+++ b/lib/kv-router/src/services/selection/policy_registry.rs
@@ -183,7 +183,7 @@ impl WorkerSelectionPolicyRegistry {
                 Some(factory) => factory(config, worker_type, partition),
                 None => WorkerSelectionPolicy::default(
                     config.clone(),
-                    worker_type.as_str(),
+                    worker_type.default_selector_label(),
                 ),
             }
         })))

--- a/lib/kv-router/src/services/selection/server.rs
+++ b/lib/kv-router/src/services/selection/server.rs
@@ -16,7 +16,6 @@ use tokio::net::TcpListener;
 use crate::protocols::WorkerId;
 use crate::services::common::replica_sync::ReplicaPeerError;
 
-use super::core::SelectionServiceConfig;
 use super::service::SelectionService;
 use super::types::{
     OutputBlockRequest, OverlapScoresRequest, PotentialLoadsRequest, REQUEST_BODY_LIMIT_BYTES,
@@ -343,13 +342,8 @@ pub(crate) fn create_router(state: Arc<AppState>) -> Router {
         .with_state(state)
 }
 
-pub async fn run_server(config: SelectionServiceConfig) -> anyhow::Result<()> {
-    let service = config.service_builder().build().await?;
-    run_server_with_service(config.port, service).await
-}
-
 /// Serve a caller-built selection service until shutdown.
-pub async fn run_server_with_service(port: u16, service: SelectionService) -> anyhow::Result<()> {
+pub async fn run_server(port: u16, service: SelectionService) -> anyhow::Result<()> {
     tracing::info!(port, "Starting Dynamo selection service");
     let listener = TcpListener::bind(("0.0.0.0", port)).await?;
     let service = Arc::new(service);

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -117,13 +117,14 @@ impl SelectionServiceBuilder {
             );
         }
         let replica_config = replica_runtime.as_ref().map(ReplicaSyncRuntime::config);
-        let core = Arc::new(SelectionCore::new_managed(
+        let core = Arc::new(SelectionCore::new_inner(
             self.kv_router_config,
             self.indexer_threads,
             cancel_token.clone(),
             replica_config,
             worker_selection_policy_factory,
             self.worker_type,
+            false,
             self.selection_cache,
             tracking_hash,
         ));

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -18,6 +18,7 @@ use crate::tracking_hash::TrackingHashContext;
 use super::core::{SelectionCore, SelectionServiceConfig};
 use super::error::SelectionError;
 use super::pending::SelectionCacheConfig;
+use super::policy_registry::WorkerSelectionPolicyRegistry;
 use super::types::{
     ModelLoadResponse, OverlapScoresRequest, OverlapScoresResponse, PotentialLoadsRequest,
     ReadyResponse, ReservationRequest, ReservationResponse, SelectAndReserveRequest, SelectRequest,
@@ -32,6 +33,8 @@ pub struct SelectionServiceBuilder {
     replica_sync_port: Option<u16>,
     replica_sync_peers: Vec<String>,
     selection_cache: SelectionCacheConfig,
+    worker_type: WorkerType,
+    worker_selection_policy_registry: Option<WorkerSelectionPolicyRegistry>,
     worker_selection_policy_factory: Option<WorkerSelectionPolicyFactory>,
 }
 
@@ -44,6 +47,8 @@ impl SelectionServiceBuilder {
             replica_sync_port: None,
             replica_sync_peers: Vec::new(),
             selection_cache: SelectionCacheConfig::default(),
+            worker_type: WorkerType::Aggregated,
+            worker_selection_policy_registry: None,
             worker_selection_policy_factory: None,
         }
     }
@@ -66,6 +71,24 @@ impl SelectionServiceBuilder {
 
     pub fn selection_cache(mut self, config: SelectionCacheConfig) -> Self {
         self.selection_cache = config;
+        self
+    }
+
+    /// Set the role of the worker pool this service owns.
+    ///
+    /// The role is passed to a custom worker-selection policy factory when a
+    /// routing partition is first created. It defaults to aggregated workers.
+    pub fn worker_type(mut self, worker_type: WorkerType) -> Self {
+        self.worker_type = worker_type;
+        self
+    }
+
+    /// Resolve the configured custom policy for this service's worker role.
+    pub fn worker_selection_policy_registry(
+        mut self,
+        registry: Option<WorkerSelectionPolicyRegistry>,
+    ) -> Self {
+        self.worker_selection_policy_registry = registry;
         self
     }
 
@@ -96,6 +119,30 @@ impl SelectionServiceBuilder {
         self.kv_router_config
             .validate_config()
             .map_err(anyhow::Error::msg)?;
+        let worker_selection_policy_factory = match (
+            self.worker_selection_policy_factory,
+            self.worker_selection_policy_registry.as_ref(),
+        ) {
+            (Some(_), Some(_)) => anyhow::bail!(
+                "worker-selection policy factory and policy registry cannot both be configured"
+            ),
+            (Some(factory), None) => Some(factory),
+            (None, Some(registry)) => registry
+                .resolve_for_worker_type(&self.kv_router_config, self.worker_type)
+                .map_err(anyhow::Error::from)?,
+            (None, None) => {
+                if let Some(instance) = self
+                    .kv_router_config
+                    .selected_worker_selection_policy_instance_for(self.worker_type)?
+                {
+                    anyhow::bail!(
+                        "worker-selection instance {instance:?} is configured for {}, but no linked worker-selection policy registry was supplied",
+                        self.worker_type
+                    );
+                }
+                None
+            }
+        };
         let tracking_hash = Arc::new(TrackingHashContext::from_config(&self.kv_router_config)?);
         let cancel_token = CancellationToken::new();
         let mut startup_guard = StartupGuard::new(cancel_token.clone());
@@ -117,7 +164,8 @@ impl SelectionServiceBuilder {
             self.indexer_threads,
             cancel_token.clone(),
             replica_config,
-            self.worker_selection_policy_factory,
+            worker_selection_policy_factory,
+            self.worker_type,
             self.selection_cache,
             tracking_hash,
         ));
@@ -439,6 +487,42 @@ mod tests {
             .local_addr()
             .unwrap()
             .port()
+    }
+
+    #[tokio::test]
+    async fn configured_custom_policy_requires_registry_at_construction() {
+        let policy_file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            policy_file.path(),
+            r#"
+worker_selection:
+  prefill: custom
+  instances:
+    - name: custom
+      type: acme
+      parameters: {}
+"#,
+        )
+        .unwrap();
+        let config = KvRouterConfig {
+            router_policy_config: Some(policy_file.path().display().to_string()),
+            ..test_config()
+        };
+
+        let error = match SelectionServiceBuilder::new(config)
+            .worker_type(WorkerType::Prefill)
+            .build()
+            .await
+        {
+            Ok(_) => panic!("a configured custom policy needs a linked registry"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("no linked worker-selection policy registry"),
+            "{error}"
+        );
     }
 
     async fn build_on_port(port: u16) -> SelectionService {

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -252,14 +252,6 @@ impl SelectionService {
         self.core.upsert_worker(req).await
     }
 
-    /// Whether the configured scheduling policy enables queueing for `model_name`.
-    pub fn queueing_enabled(
-        &self,
-        model_name: &str,
-    ) -> Result<bool, crate::scheduling::RouterPolicyConfigError> {
-        self.core.queueing_enabled(model_name)
-    }
-
     /// The port this service uses for replica synchronization, if enabled.
     pub fn replica_sync_port(&self) -> Option<u16> {
         self.replica_sync_port

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -38,6 +38,26 @@ pub struct SelectionServiceBuilder {
     worker_selection_policy_factory: Option<WorkerSelectionPolicyFactory>,
 }
 
+/// Warn when a host does not construct workers for explicitly configured policy roles.
+pub fn warn_for_unserved_worker_selection_policies(
+    kv_router_config: &KvRouterConfig,
+    served_worker_types: &[WorkerType],
+) -> anyhow::Result<()> {
+    let unserved_worker_types = kv_router_config
+        .explicit_worker_selection_policy_types()?
+        .into_iter()
+        .filter(|worker_type| !served_worker_types.contains(worker_type))
+        .collect::<Vec<_>>();
+    if !unserved_worker_types.is_empty() {
+        tracing::warn!(
+            ?served_worker_types,
+            ?unserved_worker_types,
+            "worker-selection policies configured for unserved worker types are ignored"
+        );
+    }
+    Ok(())
+}
+
 impl SelectionServiceBuilder {
     pub fn new(kv_router_config: KvRouterConfig) -> Self {
         Self {
@@ -111,15 +131,6 @@ impl SelectionServiceBuilder {
         self.kv_router_config
             .validate_config()
             .map_err(anyhow::Error::msg)?;
-        if self
-            .kv_router_config
-            .has_explicit_worker_selection_policy_for_other_worker_types(self.worker_type)?
-        {
-            tracing::warn!(
-                worker_type = %self.worker_type,
-                "worker-selection policies configured for other worker types are ignored by this selection service"
-            );
-        }
         let worker_selection_policy_factory = match (
             self.worker_selection_policy_factory,
             self.worker_selection_policy_registry.as_ref(),

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -6,10 +6,8 @@ use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use crate::config::KvRouterConfig;
-use crate::identity::RoutingPartitionRef;
 use crate::protocols::WorkerId;
 use crate::scheduling::PotentialLoad;
-use crate::scheduling::selector::WorkerSelectionPolicy;
 use crate::services::common::replica_sync::{
     PeerManager, ReplicaPeerError, ReplicaSyncRuntime, setup_replica_sync,
 };
@@ -24,7 +22,7 @@ use super::types::{
     ReadyResponse, ReservationRequest, ReservationResponse, SelectAndReserveRequest, SelectRequest,
     SelectResponse, WorkerCatalogRecord, WorkerPatchRequest, WorkerRequest,
 };
-use crate::{WorkerSelectionPolicyFactory, WorkerType};
+use crate::WorkerType;
 
 pub struct SelectionServiceBuilder {
     kv_router_config: KvRouterConfig,
@@ -35,7 +33,6 @@ pub struct SelectionServiceBuilder {
     selection_cache: SelectionCacheConfig,
     worker_type: WorkerType,
     worker_selection_policy_registry: Option<WorkerSelectionPolicyRegistry>,
-    worker_selection_policy_factory: Option<WorkerSelectionPolicyFactory>,
 }
 
 /// Warn when a host does not construct workers for explicitly configured policy roles.
@@ -69,7 +66,6 @@ impl SelectionServiceBuilder {
             selection_cache: SelectionCacheConfig::default(),
             worker_type: WorkerType::Aggregated,
             worker_selection_policy_registry: None,
-            worker_selection_policy_factory: None,
         }
     }
 
@@ -112,37 +108,15 @@ impl SelectionServiceBuilder {
         self
     }
 
-    pub fn worker_selection_policy_factory<F>(mut self, factory: F) -> Self
-    where
-        F: for<'a> Fn(
-                &KvRouterConfig,
-                WorkerType,
-                RoutingPartitionRef<'a>,
-            ) -> WorkerSelectionPolicy
-            + Send
-            + Sync
-            + 'static,
-    {
-        self.worker_selection_policy_factory = Some(Arc::new(factory));
-        self
-    }
-
     pub async fn build(self) -> anyhow::Result<SelectionService> {
         self.kv_router_config
             .validate_config()
             .map_err(anyhow::Error::msg)?;
-        let worker_selection_policy_factory = match (
-            self.worker_selection_policy_factory,
-            self.worker_selection_policy_registry.as_ref(),
-        ) {
-            (Some(_), Some(_)) => anyhow::bail!(
-                "worker-selection policy factory and policy registry cannot both be configured"
-            ),
-            (Some(factory), None) => Some(factory),
-            (None, Some(registry)) => registry
+        let worker_selection_policy_factory = match self.worker_selection_policy_registry.as_ref() {
+            Some(registry) => registry
                 .resolve_for_worker_type(&self.kv_router_config, self.worker_type)
                 .map_err(anyhow::Error::from)?,
-            (None, None) => {
+            None => {
                 if let Some(instance) = self
                     .kv_router_config
                     .selected_worker_selection_policy_instance_for(self.worker_type)?

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -92,7 +92,7 @@ impl SelectionServiceBuilder {
         self
     }
 
-    pub fn worker_selection_policy_factory<F>(self, factory: F) -> Self
+    pub fn worker_selection_policy_factory<F>(mut self, factory: F) -> Self
     where
         F: for<'a> Fn(
                 &KvRouterConfig,
@@ -103,15 +103,7 @@ impl SelectionServiceBuilder {
             + Sync
             + 'static,
     {
-        self.resolved_worker_selection_policy_factory(Some(Arc::new(factory)))
-    }
-
-    /// Use a factory already resolved from worker-selection configuration.
-    pub fn resolved_worker_selection_policy_factory(
-        mut self,
-        factory: Option<WorkerSelectionPolicyFactory>,
-    ) -> Self {
-        self.worker_selection_policy_factory = factory;
+        self.worker_selection_policy_factory = Some(Arc::new(factory));
         self
     }
 
@@ -119,6 +111,15 @@ impl SelectionServiceBuilder {
         self.kv_router_config
             .validate_config()
             .map_err(anyhow::Error::msg)?;
+        if self
+            .kv_router_config
+            .has_explicit_worker_selection_policy_for_other_worker_types(self.worker_type)?
+        {
+            tracing::warn!(
+                worker_type = %self.worker_type,
+                "worker-selection policies configured for other worker types are ignored by this selection service"
+            );
+        }
         let worker_selection_policy_factory = match (
             self.worker_selection_policy_factory,
             self.worker_selection_policy_registry.as_ref(),

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -32,7 +32,7 @@ pub struct SelectionServiceBuilder {
     replica_sync_peers: Vec<String>,
     selection_cache: SelectionCacheConfig,
     worker_type: WorkerType,
-    worker_selection_policy_registry: Option<WorkerSelectionPolicyRegistry>,
+    worker_selection_policy_registry: WorkerSelectionPolicyRegistry,
 }
 
 /// Warn when a host does not construct workers for explicitly configured policy roles.
@@ -56,7 +56,11 @@ pub fn warn_for_unserved_worker_selection_policies(
 }
 
 impl SelectionServiceBuilder {
-    pub fn new(kv_router_config: KvRouterConfig) -> Self {
+    pub fn new(
+        kv_router_config: KvRouterConfig,
+        worker_type: WorkerType,
+        worker_selection_policy_registry: WorkerSelectionPolicyRegistry,
+    ) -> Self {
         Self {
             kv_router_config,
             indexer_threads: 4,
@@ -64,8 +68,8 @@ impl SelectionServiceBuilder {
             replica_sync_port: None,
             replica_sync_peers: Vec::new(),
             selection_cache: SelectionCacheConfig::default(),
-            worker_type: WorkerType::Aggregated,
-            worker_selection_policy_registry: None,
+            worker_type,
+            worker_selection_policy_registry,
         }
     }
 
@@ -90,45 +94,13 @@ impl SelectionServiceBuilder {
         self
     }
 
-    /// Set the role of the worker pool this service owns.
-    ///
-    /// The role is passed to a custom worker-selection policy factory when a
-    /// routing partition is first created. It defaults to aggregated workers.
-    pub fn worker_type(mut self, worker_type: WorkerType) -> Self {
-        self.worker_type = worker_type;
-        self
-    }
-
-    /// Resolve the configured custom policy for this service's worker role.
-    pub fn worker_selection_policy_registry(
-        mut self,
-        registry: Option<WorkerSelectionPolicyRegistry>,
-    ) -> Self {
-        self.worker_selection_policy_registry = registry;
-        self
-    }
-
     pub async fn build(self) -> anyhow::Result<SelectionService> {
         self.kv_router_config
             .validate_config()
             .map_err(anyhow::Error::msg)?;
-        let worker_selection_policy_factory = match self.worker_selection_policy_registry.as_ref() {
-            Some(registry) => registry
-                .resolve_for_worker_type(&self.kv_router_config, self.worker_type)
-                .map_err(anyhow::Error::from)?,
-            None => {
-                if let Some(instance) = self
-                    .kv_router_config
-                    .selected_worker_selection_policy_instance_for(self.worker_type)?
-                {
-                    anyhow::bail!(
-                        "worker-selection instance {instance:?} is configured for {}, but no linked worker-selection policy registry was supplied",
-                        self.worker_type
-                    );
-                }
-                None
-            }
-        };
+        let worker_selection_policy_factory = self
+            .worker_selection_policy_registry
+            .resolve_for_worker_type(&self.kv_router_config, self.worker_type)?;
         let tracking_hash = Arc::new(TrackingHashContext::from_config(&self.kv_router_config)?);
         let cancel_token = CancellationToken::new();
         let mut startup_guard = StartupGuard::new(cancel_token.clone());
@@ -198,11 +170,19 @@ impl SelectionServiceBuilder {
 }
 
 impl SelectionServiceConfig {
-    pub fn service_builder(&self) -> SelectionServiceBuilder {
-        let mut builder = SelectionServiceBuilder::new(self.kv_router_config.clone())
-            .indexer_threads(self.threads)
-            .indexer_peers(self.indexer_peers.clone())
-            .selection_cache(self.selection_cache.clone());
+    pub fn service_builder(
+        &self,
+        worker_type: WorkerType,
+        worker_selection_policy_registry: WorkerSelectionPolicyRegistry,
+    ) -> SelectionServiceBuilder {
+        let mut builder = SelectionServiceBuilder::new(
+            self.kv_router_config.clone(),
+            worker_type,
+            worker_selection_policy_registry,
+        )
+        .indexer_threads(self.threads)
+        .indexer_peers(self.indexer_peers.clone())
+        .selection_cache(self.selection_cache.clone());
         if let Some(port) = self.replica_sync_port {
             builder = builder.replica_sync(port, self.replica_sync_peers.clone());
         }
@@ -476,7 +456,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn configured_custom_policy_requires_registry_at_construction() {
+    async fn configured_custom_policy_requires_linked_policy_type_at_construction() {
         let policy_file = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(
             policy_file.path(),
@@ -495,18 +475,21 @@ worker_selection:
             ..test_config()
         };
 
-        let error = match SelectionServiceBuilder::new(config)
-            .worker_type(WorkerType::Prefill)
-            .build()
-            .await
+        let error = match SelectionServiceBuilder::new(
+            config,
+            WorkerType::Prefill,
+            WorkerSelectionPolicyRegistry::default(),
+        )
+        .build()
+        .await
         {
-            Ok(_) => panic!("a configured custom policy needs a linked registry"),
+            Ok(_) => panic!("a configured custom policy needs a linked policy type"),
             Err(error) => error,
         };
         assert!(
             error
                 .to_string()
-                .contains("no linked worker-selection policy registry"),
+                .contains("unknown worker-selection policy type \"acme\""),
             "{error}"
         );
     }
@@ -514,11 +497,15 @@ worker_selection:
     async fn build_on_port(port: u16) -> SelectionService {
         tokio::time::timeout(Duration::from_secs(5), async move {
             loop {
-                match SelectionServiceBuilder::new(test_config())
-                    .indexer_threads(1)
-                    .replica_sync(port, Vec::new())
-                    .build()
-                    .await
+                match SelectionServiceBuilder::new(
+                    test_config(),
+                    WorkerType::Aggregated,
+                    WorkerSelectionPolicyRegistry::default(),
+                )
+                .indexer_threads(1)
+                .replica_sync(port, Vec::new())
+                .build()
+                .await
                 {
                     Ok(service) => return service,
                     Err(_) => tokio::time::sleep(Duration::from_millis(20)).await,
@@ -532,11 +519,15 @@ worker_selection:
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn startup_and_shutdown_release_replica_resources() {
         let port = reserve_tcp_port();
-        let failed = SelectionServiceBuilder::new(test_config())
-            .indexer_threads(1)
-            .replica_sync(port, vec!["invalid".to_string()])
-            .build()
-            .await;
+        let failed = SelectionServiceBuilder::new(
+            test_config(),
+            WorkerType::Aggregated,
+            WorkerSelectionPolicyRegistry::default(),
+        )
+        .indexer_threads(1)
+        .replica_sync(port, vec!["invalid".to_string()])
+        .build()
+        .await;
         assert!(failed.is_err());
 
         let service = build_on_port(port).await;
@@ -583,10 +574,14 @@ worker_selection:
         let server = tokio::spawn(async move { axum::serve(listener, app).await });
 
         let build = tokio::spawn(
-            SelectionServiceBuilder::new(test_config())
-                .indexer_threads(1)
-                .indexer_peers(vec![peer_url])
-                .build(),
+            SelectionServiceBuilder::new(
+                test_config(),
+                WorkerType::Aggregated,
+                WorkerSelectionPolicyRegistry::default(),
+            )
+            .indexer_threads(1)
+            .indexer_peers(vec![peer_url])
+            .build(),
         );
         tokio::time::timeout(Duration::from_secs(3), gate.requested.notified())
             .await

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -238,7 +238,7 @@ impl FactoryRendezvous {
     }
 }
 
-async fn native_policy_app<F>(factory: F) -> Router
+async fn native_policy_app<F>(worker_type: crate::WorkerType, factory: F) -> Router
 where
     F: for<'a> Fn(
             &crate::config::KvRouterConfig,
@@ -250,17 +250,12 @@ where
         + 'static,
 {
     let mut policy_file = NamedTempFile::new().expect("create worker-selection policy config");
-    policy_file
-        .write_all(
-            br#"
-worker_selection:
-  aggregated: test
-  instances:
-    - name: test
-      type: test
-"#,
-        )
-        .expect("write worker-selection policy config");
+    write!(
+        policy_file,
+        "\nworker_selection:\n  {}: test\n  instances:\n    - name: test\n      type: test\n",
+        worker_type.as_str(),
+    )
+    .expect("write worker-selection policy config");
     let config = crate::config::KvRouterConfig {
         router_policy_config: Some(policy_file.path().display().to_string()),
         ..test_config()
@@ -276,7 +271,7 @@ worker_selection:
         )
         .expect("register test worker-selection policy");
 
-    let service = SelectionServiceBuilder::new(config, crate::WorkerType::Aggregated, registry)
+    let service = SelectionServiceBuilder::new(config, worker_type, registry)
         .indexer_threads(1)
         .build()
         .await
@@ -316,19 +311,22 @@ async fn custom_worker_selection_policy_is_per_partition_composes_filter_scorer_
     let partitions = Arc::clone(&factory_partitions);
     let worker_types = Arc::clone(&factory_worker_types);
     let rendezvous = Arc::clone(&factory_rendezvous);
-    let app = native_policy_app(move |config, worker_type, partition| {
-        calls.fetch_add(1, Ordering::Relaxed);
-        partitions.lock().unwrap().push(partition.into_owned());
-        worker_types.lock().unwrap().push(worker_type);
-        rendezvous.wait_for_peer();
-        WorkerSelectionPolicy::new_with_filters(
-            config.clone(),
-            worker_type.as_str(),
-            vec![Box::new(RejectWorker(1))],
-            vec![Box::new(WorkerIdScorer)],
-            Box::new(LowestCostPicker),
-        )
-    })
+    let app = native_policy_app(
+        crate::WorkerType::Prefill,
+        move |config, worker_type, partition| {
+            calls.fetch_add(1, Ordering::Relaxed);
+            partitions.lock().unwrap().push(partition.into_owned());
+            worker_types.lock().unwrap().push(worker_type);
+            rendezvous.wait_for_peer();
+            WorkerSelectionPolicy::new_with_filters(
+                config.clone(),
+                worker_type.as_str(),
+                vec![Box::new(RejectWorker(1))],
+                vec![Box::new(WorkerIdScorer)],
+                Box::new(LowestCostPicker),
+            )
+        },
+    )
     .await;
 
     let model_registration = tokio::spawn(register_worker_id(app.clone(), 1, None));
@@ -385,20 +383,23 @@ async fn custom_worker_selection_policy_is_per_partition_composes_filter_scorer_
     assert_eq!(factory_calls.load(Ordering::Relaxed), 2);
     assert_eq!(
         *factory_worker_types.lock().unwrap(),
-        vec![crate::WorkerType::Aggregated; 2]
+        vec![crate::WorkerType::Prefill; 2]
     );
 }
 
 #[tokio::test]
 async fn native_worker_selection_policy_rejects_non_finite_costs_before_booking() {
-    let app = native_policy_app(|config, worker_type, _partition| {
-        WorkerSelectionPolicy::new(
-            config.clone(),
-            worker_type.as_str(),
-            vec![Box::new(NonFiniteScorer)],
-            Box::new(LowestCostPicker),
-        )
-    })
+    let app = native_policy_app(
+        crate::WorkerType::Aggregated,
+        |config, worker_type, _partition| {
+            WorkerSelectionPolicy::new(
+                config.clone(),
+                worker_type.as_str(),
+                vec![Box::new(NonFiniteScorer)],
+                Box::new(LowestCostPicker),
+            )
+        },
+    )
     .await;
     assert_eq!(
         register_worker_id(app.clone(), 1, None).await.status(),
@@ -423,14 +424,17 @@ async fn native_worker_selection_policy_rejects_non_finite_costs_before_booking(
 
 #[tokio::test]
 async fn native_worker_selection_policy_rejects_invalid_rows_before_booking() {
-    let app = native_policy_app(|config, worker_type, _partition| {
-        WorkerSelectionPolicy::new(
-            config.clone(),
-            worker_type.as_str(),
-            Vec::new(),
-            Box::new(InvalidRowPicker),
-        )
-    })
+    let app = native_policy_app(
+        crate::WorkerType::Aggregated,
+        |config, worker_type, _partition| {
+            WorkerSelectionPolicy::new(
+                config.clone(),
+                worker_type.as_str(),
+                Vec::new(),
+                Box::new(InvalidRowPicker),
+            )
+        },
+    )
     .await;
     assert_eq!(
         register_worker_id(app.clone(), 1, None).await.status(),
@@ -455,15 +459,18 @@ async fn native_worker_selection_policy_rejects_invalid_rows_before_booking() {
 
 #[tokio::test]
 async fn worker_selection_filter_returns_unavailable_without_booking() {
-    let app = native_policy_app(|config, worker_type, _partition| {
-        WorkerSelectionPolicy::new_with_filters(
-            config.clone(),
-            worker_type.as_str(),
-            vec![Box::new(RejectAllFilter)],
-            Vec::new(),
-            Box::new(LowestCostPicker),
-        )
-    })
+    let app = native_policy_app(
+        crate::WorkerType::Aggregated,
+        |config, worker_type, _partition| {
+            WorkerSelectionPolicy::new_with_filters(
+                config.clone(),
+                worker_type.as_str(),
+                vec![Box::new(RejectAllFilter)],
+                Vec::new(),
+                Box::new(LowestCostPicker),
+            )
+        },
+    )
     .await;
     assert_eq!(
         register_worker_id(app.clone(), 1, None).await.status(),

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -249,9 +249,36 @@ where
         + Sync
         + 'static,
 {
-    let service = SelectionServiceBuilder::new(test_config())
+    let mut policy_file = NamedTempFile::new().expect("create worker-selection policy config");
+    policy_file
+        .write_all(
+            br#"
+worker_selection:
+  aggregated: test
+  instances:
+    - name: test
+      type: test
+"#,
+        )
+        .expect("write worker-selection policy config");
+    let config = crate::config::KvRouterConfig {
+        router_policy_config: Some(policy_file.path().display().to_string()),
+        ..test_config()
+    };
+    let factory: crate::WorkerSelectionPolicyFactory = Arc::new(factory);
+    let mut registry = WorkerSelectionPolicyRegistry::default();
+    registry
+        .register(
+            "test",
+            Arc::new(move |_| -> Result<_, WorkerSelectionPolicyProviderError> {
+                Ok(Arc::clone(&factory))
+            }),
+        )
+        .expect("register test worker-selection policy");
+
+    let service = SelectionServiceBuilder::new(config)
         .indexer_threads(1)
-        .worker_selection_policy_factory(factory)
+        .worker_selection_policy_registry(Some(registry))
         .build()
         .await
         .expect("build selection service");
@@ -281,8 +308,7 @@ async fn active_requests(app: Router, worker_id: WorkerId) -> u64 {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn worker_selection_policy_factory_is_per_partition_composes_filter_scorer_picker_and_books()
-{
+async fn custom_worker_selection_policy_is_per_partition_composes_filter_scorer_picker_and_books() {
     let factory_calls = Arc::new(AtomicUsize::new(0));
     let factory_partitions = Arc::new(Mutex::new(Vec::new()));
     let factory_worker_types = Arc::new(Mutex::new(Vec::new()));
@@ -291,27 +317,20 @@ async fn worker_selection_policy_factory_is_per_partition_composes_filter_scorer
     let partitions = Arc::clone(&factory_partitions);
     let worker_types = Arc::clone(&factory_worker_types);
     let rendezvous = Arc::clone(&factory_rendezvous);
-    let service = SelectionServiceBuilder::new(test_config())
-        .indexer_threads(1)
-        .worker_selection_policy_factory(move |config, worker_type, partition| {
-            calls.fetch_add(1, Ordering::Relaxed);
-            partitions.lock().unwrap().push(partition.into_owned());
-            worker_types.lock().unwrap().push(worker_type);
-            rendezvous.wait_for_peer();
-            WorkerSelectionPolicy::new_with_filters(
-                config.clone(),
-                worker_type.as_str(),
-                vec![Box::new(RejectWorker(1))],
-                vec![Box::new(WorkerIdScorer)],
-                Box::new(LowestCostPicker),
-            )
-        })
-        .build()
-        .await
-        .expect("build selection service");
-    let app = create_router(Arc::new(AppState {
-        service: Arc::new(service),
-    }));
+    let app = native_policy_app(move |config, worker_type, partition| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        partitions.lock().unwrap().push(partition.into_owned());
+        worker_types.lock().unwrap().push(worker_type);
+        rendezvous.wait_for_peer();
+        WorkerSelectionPolicy::new_with_filters(
+            config.clone(),
+            worker_type.as_str(),
+            vec![Box::new(RejectWorker(1))],
+            vec![Box::new(WorkerIdScorer)],
+            Box::new(LowestCostPicker),
+        )
+    })
+    .await;
 
     let model_registration = tokio::spawn(register_worker_id(app.clone(), 1, None));
     let other_app = app.clone();

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -276,9 +276,8 @@ worker_selection:
         )
         .expect("register test worker-selection policy");
 
-    let service = SelectionServiceBuilder::new(config)
+    let service = SelectionServiceBuilder::new(config, crate::WorkerType::Aggregated, registry)
         .indexer_threads(1)
-        .worker_selection_policy_registry(Some(registry))
         .build()
         .await
         .expect("build selection service");
@@ -1795,14 +1794,27 @@ async fn selector_replica_sync_propagates_request_lifecycle() {
         kv_router_config: test_config(),
         selection_cache: SelectionCacheConfig::default(),
     };
-    let service_a = Arc::new(config_a.service_builder().build().await.unwrap());
-    let service_b = Arc::new(
-        SelectionServiceBuilder::new(test_config())
-            .indexer_threads(1)
-            .replica_sync(port_b, Vec::new())
+    let service_a = Arc::new(
+        config_a
+            .service_builder(
+                crate::WorkerType::Aggregated,
+                WorkerSelectionPolicyRegistry::default(),
+            )
             .build()
             .await
             .unwrap(),
+    );
+    let service_b = Arc::new(
+        SelectionServiceBuilder::new(
+            test_config(),
+            crate::WorkerType::Aggregated,
+            WorkerSelectionPolicyRegistry::default(),
+        )
+        .indexer_threads(1)
+        .replica_sync(port_b, Vec::new())
+        .build()
+        .await
+        .unwrap(),
     );
     service_b
         .register_replica_peer(format!("tcp://127.0.0.1:{port_a}"))

--- a/lib/kv-router/src/services/selection/types.rs
+++ b/lib/kv-router/src/services/selection/types.rs
@@ -17,7 +17,6 @@ use crate::services::overlap::MooncakeOverlapSummary;
 use super::input::PromptRequest;
 
 const DEFAULT_MODEL_NAME: &str = "default";
-pub(super) const WORKER_TYPE: &str = "select";
 pub(super) const REQUEST_BODY_LIMIT_BYTES: usize = 8 * 1024 * 1024;
 
 fn default_model_name() -> String {

--- a/lib/kv-router/src/worker_type.rs
+++ b/lib/kv-router/src/worker_type.rs
@@ -33,16 +33,6 @@ impl WorkerType {
         }
     }
 
-    /// Pool label expected by Dynamo's built-in worker selector.
-    ///
-    /// The built-in selector historically distinguishes only prefill pools from all other pools.
-    /// Keep that scoring and metric-label contract while typed roles select custom policies.
-    pub const fn default_selector_label(&self) -> &'static str {
-        match self {
-            Self::Prefill => "prefill",
-            Self::Decode | Self::Encode | Self::Aggregated => "decode",
-        }
-    }
 }
 
 impl fmt::Display for WorkerType {
@@ -91,20 +81,6 @@ mod tests {
         assert_eq!(WorkerType::Decode.to_string(), "decode");
         assert_eq!(WorkerType::Encode.to_string(), "encode");
         assert_eq!(WorkerType::Aggregated.to_string(), "aggregated");
-    }
-
-    #[test]
-    fn as_str_keeps_the_borrowed_receiver_api() {
-        let as_str: fn(&WorkerType) -> &'static str = WorkerType::as_str;
-        assert_eq!(as_str(&WorkerType::Prefill), "prefill");
-    }
-
-    #[test]
-    fn built_in_selector_preserves_prefill_and_decode_pool_labels() {
-        assert_eq!(WorkerType::Prefill.default_selector_label(), "prefill");
-        assert_eq!(WorkerType::Decode.default_selector_label(), "decode");
-        assert_eq!(WorkerType::Encode.default_selector_label(), "decode");
-        assert_eq!(WorkerType::Aggregated.default_selector_label(), "decode");
     }
 
     #[test]

--- a/lib/kv-router/src/worker_type.rs
+++ b/lib/kv-router/src/worker_type.rs
@@ -33,6 +33,16 @@ impl WorkerType {
         }
     }
 
+    /// Pool label expected by Dynamo's built-in worker selector.
+    ///
+    /// The built-in selector historically distinguishes only prefill pools from all other pools.
+    /// Keep that scoring and metric-label contract while typed roles select custom policies.
+    pub const fn default_selector_label(&self) -> &'static str {
+        match self {
+            Self::Prefill => "prefill",
+            Self::Decode | Self::Encode | Self::Aggregated => "decode",
+        }
+    }
 }
 
 impl fmt::Display for WorkerType {
@@ -81,6 +91,14 @@ mod tests {
         assert_eq!(WorkerType::Decode.to_string(), "decode");
         assert_eq!(WorkerType::Encode.to_string(), "encode");
         assert_eq!(WorkerType::Aggregated.to_string(), "aggregated");
+    }
+
+    #[test]
+    fn built_in_selector_preserves_prefill_and_decode_pool_labels() {
+        assert_eq!(WorkerType::Prefill.default_selector_label(), "prefill");
+        assert_eq!(WorkerType::Decode.default_selector_label(), "decode");
+        assert_eq!(WorkerType::Encode.default_selector_label(), "decode");
+        assert_eq!(WorkerType::Aggregated.default_selector_label(), "decode");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Simplify EPP startup around a single public `run()` path and selector-based `EPPRouter` construction, removing unused runner variants and one-use helpers.
- Move role-scoped worker-selection policy resolution, linking validation, and factory construction from EPP into `SelectionServiceBuilder`, where `WorkerType` is required.

## Code changed

- `deploy/inference-gateway/ext-proc/src/runner.rs`
  - Consolidate EPP startup and reject linked policies outside standalone mode.
  - Clean up health, metrics, and signal tasks on startup failure or shutdown.

- `deploy/inference-gateway/ext-proc/src/epp_router.rs` and `selector.rs`
  - Remove redundant constructor/helper layers.
  - Keep one EPP path to an aggregated `SelectionService`.
  - Validate queue capacity before peer discovery or service startup.

- `lib/kv-router/src/services/selection/`
  - Require a policy registry and `WorkerType` at builder construction.
  - Resolve the role’s policy while constructing the service.
  - Remove externally supplied selection factories and redundant server construction paths.

- `lib/kv-router/src/scheduling/config.rs`
  - Use the same global/stage/YAML policy precedence for unserved-role warnings and actual policy resolution.

- `lib/bindings/python/rust/`, `examples/router/custom-policy-example/`, and `docs/fern/`
  - Update direct selection-service entrypoints and custom-policy examples for builder-owned policy initialization.

- Tests
  - Cover role-specific initialization, policy precedence, early queue-capacity failure, and startup task cleanup.

## Validation

- `cargo test -p dynamo-ext-proc`
- `cargo test -p dynamo-kv-router --features standalone-selection`
- `cargo check --manifest-path examples/router/custom-policy-example/epp/Cargo.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom worker-selection policies are now applied consistently across standalone routing and select-service deployments.
  * Policies can be selected by worker type, including aggregated, prefill, decode, and encode workers.
  * Configuration now reports which worker types use explicit custom policies.

* **Bug Fixes**
  * Added validation and warnings for policies that do not match available worker types.
  * Improved shutdown handling so background tasks terminate cleanly.

* **Documentation**
  * Updated custom-policy examples and developer guidance to use the unified runner configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->