### PR TITLE
docs(bindings): stop unregister_model's docstring emitting an H1

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -792,12 +792,12 @@ fn register_model<'p>(
 ///
 /// This removes an LLM deployment from the discovery system.
 ///
-/// # Arguments
+/// **Arguments**
 ///
 /// * `endpoint` - The endpoint where the model is registered
 /// * `lora_name` - Optional LoRA adapter name (if unregistering a LoRA deployment)
 ///
-/// # MDC Path Format
+/// **MDC Path Format**
 ///
 /// - Base model: `v1/mdc/{namespace}/{component}/{endpoint}/{instance_id}`
 /// - LoRA model: `v1/mdc/{namespace}/{component}/{endpoint}/{instance_id}/{lora_slug}`


### PR DESCRIPTION
## Summary

The doc comment on `unregister_model` is the `__doc__` of a `#[pyfunction]`, so it is not only rustdoc. `docs/fern/scripts/gen_python_api.py` reads it back off the compiled module and renders it into the generated Fern pages for `dynamo._core` and `dynamo.llm`, inside the `<Accordion>` for the symbol:

```
<Accordion id="api-dynamo-core-unregister-model" title="unregister_model (function)">
Unregister a Model Deployment Card (MDC) from the service registry
...
# Arguments

* `endpoint` - The endpoint where the model is registered
...
# MDC Path Format
```

rustdoc's `# Arguments` convention becomes a Markdown H1 there. That breaks the page's heading outline, since an H1 nested inside a component competes with the title Fern renders from the nav, and it is the exact thing the documentation style guide forbids in a body. `docs/fern/scripts/tests/test_gen_python_api.py::test_render_module_page_is_native_mdx` asserts it:

```python
assert not any(
    ln.strip().startswith("# ") for ln in body_lines
), "body must not contain an H1 (Fern renders the title from the nav)"
```

**Why CI is green on this.** The `Test generated API references` job in `pre-merge.yml` installs `griffe` and the pytest deps, but not the built bindings. Without the compiled `dynamo._core`, griffe never sees these docstrings, so the assertion passes on a surface that does not include them. The failure only appears once the extension is actually installed.

Scope: I rendered every module page and counted headings of all levels. These are the only four in the entire generated Python API surface, all from this one docstring, appearing twice because the function is re-exported. No other docstring sets a precedent, so bold labels match what every neighbouring symbol already does and read the same under rustdoc.

There are six other `/// # ` headings in the bindings crate (`http.rs`, `engine.rs`, `llm/kv.rs` x2, `llm/fpm.rs`, and a `#` inside a code block in `push_egress.rs`). None of them reach a rendered page body today, so I left them alone rather than change docstrings with no observable defect.

## Validation

Built the bindings with `maturin develop --uv` so the real `__doc__` is what gets rendered, which is the only way to see this at all.

Before, on `upstream/main`:

```
FAILED test_render_module_page_is_native_mdx[dynamo._core]
FAILED test_render_module_page_is_native_mdx[dynamo.llm]
E   AssertionError: body must not contain an H1 (Fern renders the title from the nav)
```

and a scan of every rendered module body:

```
heading levels across ALL rendered module bodies: {'#': 4}
```

After, same tree, bindings rebuilt:

```
104 passed
headings now: none
```

`pre-commit run --files lib/bindings/python/rust/lib.rs`: 0 failing hooks. `cargo fmt --check`: clean. Doc comment only, so there is no behaviour change to test.

Not verified here: the published docs build itself, which runs in `fern-docs.yml` against the branch being published.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved `unregister_model` documentation formatting with clearer section headings.
  * No changes to runtime behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->