### PR TITLE
fix(llm): return 400 for conflicting guided-decoding options

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -329,10 +329,10 @@ def _build_assistant_guided_decoding(
     # request outright, so `guided_json` + `guided_regex` is a 400 through the Rust
     # frontend and a silent single-constraint request here. Rejecting is the
     # correct behavior; it is left as-is only to avoid adding a second new 400 to
-    # this change. Note that validate() also counts whitespace_pattern toward its
-    # exclusivity limit, so the {"json": ..., "whitespace_pattern": ...} pair built
-    # below is accepted here and rejected there -- whitespace_pattern modifies a
-    # grammar rather than being one, so that counter is the side that is wrong.
+    # this change. The {"json": ..., "whitespace_pattern": ...} pair built below is
+    # now accepted on both sides: validate() no longer counts whitespace_pattern
+    # toward its exclusivity limit, because it modifies a grammar rather than being
+    # one.
     legacy_guidance: dict[str, Any] = {}
     for key, value in (
         ("json", request_extra.get("guided_json")),

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -36,6 +36,7 @@ from dynamo.common.utils.guided_json import admits_only_empty_object
 from dynamo.llm.exceptions import InvalidArgument
 
 from .thinking import apply_default_thinking_mode_to_template_kwargs
+from .utils import legacy_guided_decoding
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig
@@ -320,29 +321,7 @@ def _build_assistant_guided_decoding(
     request_extra = request.model_extra or {}
     # Match GuidedDecodingOptions::validate: modifiers are allowed alongside one
     # constraint, but multiple legacy constraints must not be silently discarded.
-    legacy_constraints = [
-        ("json", request_extra.get("guided_json") is not None),
-        ("regex", request_extra.get("guided_regex") is not None),
-        ("grammar", request_extra.get("guided_grammar") is not None),
-        ("choice", bool(request_extra.get("guided_choice"))),
-    ]
-    active_constraints = [name for name, is_set in legacy_constraints if is_set]
-    if len(active_constraints) > 1:
-        raise InvalidArgument(
-            "Only one guided-decoding constraint can be set; received: "
-            + ", ".join(active_constraints)
-        )
-
-    legacy_guidance: dict[str, Any] = {}
-    for key, value in (
-        ("json", request_extra.get("guided_json")),
-        ("regex", request_extra.get("guided_regex")),
-        ("grammar", request_extra.get("guided_grammar")),
-        ("choice", request_extra.get("guided_choice") or None),
-    ):
-        if value is not None:
-            legacy_guidance = {key: value}
-            break
+    legacy_guidance = legacy_guided_decoding(request_extra)
     if legacy_guidance:
         # Legacy guided_* takes precedence over structured_outputs (prior
         # behavior), but as a single constraint.

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -318,21 +318,21 @@ def _build_assistant_guided_decoding(
     )
 
     request_extra = request.model_extra or {}
-    # Pick a single legacy guided_* constraint by precedence rather than merging
-    # several keys into one dict, because guided_decoding carries exactly one
-    # constraint and the elif chain above already honors that for
-    # structured_outputs.
-    #
-    # TODO: first-match-wins silently discards the other constraints the caller
-    # explicitly set, with no error and no annotation.
-    # GuidedDecodingOptions::validate in protocols/common.rs rejects the same
-    # request outright, so `guided_json` + `guided_regex` is a 400 through the Rust
-    # frontend and a silent single-constraint request here. Rejecting is the
-    # correct behavior; it is left as-is only to avoid adding a second new 400 to
-    # this change. The {"json": ..., "whitespace_pattern": ...} pair built below is
-    # now accepted on both sides: validate() no longer counts whitespace_pattern
-    # toward its exclusivity limit, because it modifies a grammar rather than being
-    # one.
+    # Match GuidedDecodingOptions::validate: modifiers are allowed alongside one
+    # constraint, but multiple legacy constraints must not be silently discarded.
+    legacy_constraints = [
+        ("json", request_extra.get("guided_json") is not None),
+        ("regex", request_extra.get("guided_regex") is not None),
+        ("grammar", request_extra.get("guided_grammar") is not None),
+        ("choice", bool(request_extra.get("guided_choice"))),
+    ]
+    active_constraints = [name for name, is_set in legacy_constraints if is_set]
+    if len(active_constraints) > 1:
+        raise InvalidArgument(
+            "Only one guided-decoding constraint can be set; received: "
+            + ", ".join(active_constraints)
+        )
+
     legacy_guidance: dict[str, Any] = {}
     for key, value in (
         ("json", request_extra.get("guided_json")),

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -325,10 +325,8 @@ def _build_assistant_guided_decoding(
     if legacy_guidance:
         # Legacy guided_* takes precedence over structured_outputs (prior
         # behavior), but as a single constraint.
+        # legacy_guided_decoding already carried whitespace_pattern across.
         guided_decoding = legacy_guidance
-        whitespace_pattern = request_extra.get("guided_whitespace_pattern")
-        if whitespace_pattern is not None:
-            guided_decoding["whitespace_pattern"] = whitespace_pattern
     return guided_decoding
 
 

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -32,7 +32,7 @@ from dynamo.common.utils.engine_response import trailing_stop_prefix_len
 from dynamo.common.utils.guided_json import admits_only_empty_object
 
 from .thinking import apply_default_thinking_mode_to_template_kwargs
-from .utils import PreprocessError, random_call_id
+from .utils import PreprocessError, legacy_guided_decoding, random_call_id
 
 logger = logging.getLogger(__name__)
 
@@ -746,6 +746,7 @@ def preprocess_chat_request(
     Synchronous -- suitable for both main-process and worker-process execution.
     """
     request = _with_thinking_template_kwargs(request, default_thinking_mode)
+    legacy_guidance = legacy_guided_decoding(request)
     messages = _materialize_messages(request.get("messages", []))
 
     # Generation mode is independent of whether the client wants reasoning
@@ -844,9 +845,8 @@ def preprocess_chat_request(
     # message the model returns to the user, not to tool calls, so the tool
     # constraint is the one that must survive.
     #
-    # This path also never reads the legacy guided_json / guided_regex /
-    # guided_grammar / guided_choice fields at all, so those are dropped silently
-    # while both other paths honor them (and reject them against a forced choice).
+    # Explicit legacy constraints take precedence over automatic guidance, matching
+    # the vLLM processor's request precedence.
     if (
         response_format_guided_decoding is not None
         and tool_call_guided_decoding is not None
@@ -854,7 +854,9 @@ def preprocess_chat_request(
         logger.warning(
             "Tool-call guided decoding will be ignored because of response_format already exists."
         )
-    guided_decoding = response_format_guided_decoding or tool_call_guided_decoding
+    guided_decoding = (
+        legacy_guidance or response_format_guided_decoding or tool_call_guided_decoding
+    )
 
     return SglangPreprocessResult(
         prompt_token_ids=prompt_token_ids,

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -30,6 +30,7 @@ from sglang.srt.parser.reasoning_parser import ReasoningParser
 
 from dynamo.common.utils.engine_response import trailing_stop_prefix_len
 from dynamo.common.utils.guided_json import admits_only_empty_object
+from dynamo.llm.exceptions import InvalidArgument
 
 from .thinking import apply_default_thinking_mode_to_template_kwargs
 from .utils import PreprocessError, legacy_guided_decoding, random_call_id
@@ -747,6 +748,17 @@ def preprocess_chat_request(
     """
     request = _with_thinking_template_kwargs(request, default_thinking_mode)
     legacy_guidance = legacy_guided_decoding(request)
+    # A forced tool choice constrains the same token stream a legacy guided_*
+    # constraint would, so only one of them can be honored. Reject rather than
+    # drop one silently, matching prepost.py and preprocessor/tool_choice.rs.
+    tool_choice = request.get("tool_choice")
+    if legacy_guidance and (
+        tool_choice == "required" or _is_named_tool_choice(tool_choice)
+    ):
+        raise InvalidArgument(
+            "tool_choice forces a tool call and cannot be combined with an "
+            "explicit guided_* constraint."
+        )
     messages = _materialize_messages(request.get("messages", []))
 
     # Generation mode is independent of whether the client wants reasoning
@@ -845,8 +857,6 @@ def preprocess_chat_request(
     # message the model returns to the user, not to tool calls, so the tool
     # constraint is the one that must survive.
     #
-    # Explicit legacy constraints take precedence over automatic guidance, matching
-    # the vLLM processor's request precedence.
     if (
         response_format_guided_decoding is not None
         and tool_call_guided_decoding is not None
@@ -854,6 +864,9 @@ def preprocess_chat_request(
         logger.warning(
             "Tool-call guided decoding will be ignored because of response_format already exists."
         )
+    # Explicit legacy constraints outrank automatic guidance, matching the vLLM
+    # processor. The forced-tool-choice collision is rejected above rather than
+    # resolved here, so anything reaching this point is safe to order.
     guided_decoding = (
         legacy_guidance or response_format_guided_decoding or tool_call_guided_decoding
     )

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -748,17 +748,6 @@ def preprocess_chat_request(
     """
     request = _with_thinking_template_kwargs(request, default_thinking_mode)
     legacy_guidance = legacy_guided_decoding(request)
-    # A forced tool choice constrains the same token stream a legacy guided_*
-    # constraint would, so only one of them can be honored. Reject rather than
-    # drop one silently, matching prepost.py and preprocessor/tool_choice.rs.
-    tool_choice = request.get("tool_choice")
-    if legacy_guidance and (
-        tool_choice == "required" or _is_named_tool_choice(tool_choice)
-    ):
-        raise InvalidArgument(
-            "tool_choice forces a tool call and cannot be combined with an "
-            "explicit guided_* constraint."
-        )
     messages = _materialize_messages(request.get("messages", []))
 
     # Generation mode is independent of whether the client wants reasoning
@@ -864,9 +853,32 @@ def preprocess_chat_request(
         logger.warning(
             "Tool-call guided decoding will be ignored because of response_format already exists."
         )
+    # A forced tool choice and a legacy guided_* constrain the same token stream,
+    # so honoring the guided_* would drop the tool constraint while the forced-tool
+    # parser stays selected. Reject that rather than drop one silently, matching
+    # prepost.py and preprocessor/tool_choice.rs.
+    #
+    # Only when they actually differ. A named zero-argument tool builds
+    # {"regex": r"\{\}"} above, and a caller may send exactly that as
+    # guided_regex; nothing is displaced, and named_zero_arg_tool below still
+    # recognizes it. Rejecting an identical constraint would refuse a request the
+    # two paths agree on.
+    tool_choice = request.get("tool_choice", "auto")
+    if (
+        legacy_guidance
+        and tool_call_guided_decoding is not None
+        and legacy_guidance != tool_call_guided_decoding
+        and (tool_choice == "required" or _is_named_tool_choice(tool_choice))
+    ):
+        raise InvalidArgument(
+            "tool_choice forces a tool call and cannot be combined with an "
+            "explicit guided_* constraint."
+        )
+
     # Explicit legacy constraints outrank automatic guidance, matching the vLLM
-    # processor. The forced-tool-choice collision is rejected above rather than
-    # resolved here, so anything reaching this point is safe to order.
+    # processor. response_format is NOT covered by the check above -- see the TODO
+    # further up: it still wins over a forced tool choice here, unlike the other
+    # two paths.
     guided_decoding = (
         legacy_guidance or response_format_guided_decoding or tool_call_guided_decoding
     )

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -639,6 +639,8 @@ class SglangProcessor:
                 preproc_result: SglangPreprocessWorkerResult = (
                     await asyncio.wrap_future(future)
                 )
+        except InvalidArgument:
+            raise
         except PreprocessError as exc:
             raise InvalidArgument(str(exc)) from exc
         except Exception as exc:

--- a/components/src/dynamo/frontend/tests/test_frontend_utils.py
+++ b/components/src/dynamo/frontend/tests/test_frontend_utils.py
@@ -64,12 +64,16 @@ class TestValidateLegacyGuidedDecodingConstraints:
             }
         )
 
-    @pytest.mark.parametrize(
-        "payload",
-        [{"guided_choice": []}, {"guided_choice": "yes"}],
-    )
-    def test_non_list_or_empty_choice_is_not_an_active_constraint(self, payload):
-        validate_legacy_guided_decoding_constraints(payload)
+    def test_empty_choice_is_not_an_active_constraint(self):
+        # An empty list is a caller supplying no choices, which is no constraint.
+        validate_legacy_guided_decoding_constraints({"guided_choice": []})
+
+    @pytest.mark.parametrize("choice", ["yes", ("x", "y"), 5])
+    def test_non_list_choice_is_rejected(self, choice):
+        # Ignoring a malformed choice would generate unconstrained text for a
+        # caller who believes it constrained the output.
+        with pytest.raises(InvalidArgument, match="guided_choice must be a list"):
+            validate_legacy_guided_decoding_constraints({"guided_choice": choice})
 
     def test_empty_string_message_uses_fallback(self):
         resp = {"status": "error", "message": ""}

--- a/components/src/dynamo/frontend/tests/test_frontend_utils.py
+++ b/components/src/dynamo/frontend/tests/test_frontend_utils.py
@@ -11,7 +11,9 @@ from dynamo.frontend.utils import (
     make_backend_error,
     make_internal_error,
     resolve_chat_template,
+    validate_legacy_guided_decoding_constraints,
 )
+from dynamo.llm.exceptions import InvalidArgument
 
 pytestmark = [
     pytest.mark.unit,
@@ -36,6 +38,38 @@ class TestMakeBackendError:  # FRONTEND.8 — BackendError construction
         resp = {"status": "error"}
         err = make_backend_error(resp)
         assert err["error"]["message"] == "unknown backend error"
+
+
+class TestValidateLegacyGuidedDecodingConstraints:
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"guided_json": {"type": "object"}, "guided_regex": "a+"},
+            {"guided_regex": "a+", "guided_grammar": 'root ::= "a"'},
+        ],
+    )
+    def test_rejects_multiple_constraints(self, payload):
+        with pytest.raises(
+            InvalidArgument,
+            match="Only one guided-decoding constraint can be set; received:",
+        ):
+            validate_legacy_guided_decoding_constraints(payload)
+
+    def test_accepts_one_constraint_and_ignores_modifiers(self):
+        validate_legacy_guided_decoding_constraints(
+            {
+                "guided_json": {"type": "object"},
+                "guided_whitespace_pattern": r"[\n ]?",
+                "guided_decoding_backend": "xgrammar",
+            }
+        )
+
+    @pytest.mark.parametrize(
+        "payload",
+        [{"guided_choice": []}, {"guided_choice": "yes"}],
+    )
+    def test_non_list_or_empty_choice_is_not_an_active_constraint(self, payload):
+        validate_legacy_guided_decoding_constraints(payload)
 
     def test_empty_string_message_uses_fallback(self):
         resp = {"status": "error", "message": ""}

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -66,6 +66,7 @@ from dynamo.frontend.utils import (
     random_call_id,
     random_uuid,
 )
+from dynamo.llm.exceptions import InvalidArgument
 
 # Needs sglang packages (gpu_1 container), but does not allocate GPU VRAM.
 pytestmark = [
@@ -1848,6 +1849,57 @@ class TestRuntimeConfigParserName:  # FRONTEND.2 — parser name resolution from
 
 class TestPreprocessChatRequest:  # FRONTEND.1 — chat-template input preprocessing (multi-turn assistant tool_calls, role handling)
     """Test end-to-end preprocessing with a real tokenizer."""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"guided_json": {"type": "object"}, "guided_regex": "a+"},
+            {"guided_regex": "a+", "guided_grammar": 'root ::= "a"'},
+        ],
+    )
+    def test_legacy_guided_constraints_reject_conflicts(self, tokenizer, payload):
+        with pytest.raises(
+            InvalidArgument,
+            match="Only one guided-decoding constraint can be set; received:",
+        ):
+            preprocess_chat_request(
+                {
+                    "model": MODEL,
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    **payload,
+                },
+                tokenizer=tokenizer,
+                tool_call_parser_name=None,
+                reasoning_parser_name=None,
+            )
+
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            (
+                {"guided_json": {"type": "object"}},
+                {"json": {"type": "object"}},
+            ),
+            ({"guided_regex": "a+"}, {"regex": "a+"}),
+            ({"guided_grammar": 'root ::= "a"'}, {"grammar": 'root ::= "a"'}),
+            ({"guided_choice": ["a", "b"]}, {"choice": ["a", "b"]}),
+        ],
+    )
+    def test_legacy_guided_constraints_are_forwarded(
+        self, tokenizer, payload, expected
+    ):
+        result = preprocess_chat_request(
+            {
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "Hello"}],
+                **payload,
+            },
+            tokenizer=tokenizer,
+            tool_call_parser_name=None,
+            reasoning_parser_name=None,
+        )
+
+        assert result.guided_decoding == expected
 
     def test_basic_chat(self, tokenizer):
         """Simple user message preprocesses to non-empty token IDs."""

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -1874,6 +1874,45 @@ class TestPreprocessChatRequest:  # FRONTEND.1 — chat-template input preproces
             )
 
     @pytest.mark.parametrize(
+        "tool_choice",
+        ["required", {"type": "function", "function": {"name": "get_weather"}}],
+    )
+    def test_legacy_guided_constraint_conflicts_with_forced_tool_choice(
+        self, tokenizer, tool_choice
+    ):
+        """A forced tool choice and a legacy guided_* constrain the same tokens.
+
+        Honoring the guided_* constraint would drop the tool constraint while the
+        forced-tool response parser stays selected, so the model's output could not
+        satisfy the parser. prepost.py and preprocessor/tool_choice.rs both reject
+        this combination; SGLang must agree.
+        """
+        with pytest.raises(
+            InvalidArgument,
+            match="tool_choice forces a tool call",
+        ):
+            preprocess_chat_request(
+                {
+                    "model": MODEL,
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "parameters": {"type": "object", "properties": {}},
+                            },
+                        }
+                    ],
+                    "tool_choice": tool_choice,
+                    "guided_regex": "foo",
+                },
+                tokenizer=tokenizer,
+                tool_call_parser_name=None,
+                reasoning_parser_name=None,
+            )
+
+    @pytest.mark.parametrize(
         ("payload", "expected"),
         [
             (

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -1873,6 +1873,46 @@ class TestPreprocessChatRequest:  # FRONTEND.1 — chat-template input preproces
                 reasoning_parser_name=None,
             )
 
+    def test_legacy_guided_constraint_matching_forced_tool_is_allowed(self, tokenizer):
+        """An explicit constraint identical to the generated one displaces nothing.
+
+        A named zero-argument tool builds {"regex": r"\\{\\}"}, and a caller may send
+        exactly that as guided_regex. Rejecting it would refuse a request both
+        sides agree on, and would break the named_zero_arg_tool reconstruction
+        that keys off this exact value.
+        """
+        result = preprocess_chat_request(
+            {
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_server_time",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {},
+                                "required": [],
+                                "additionalProperties": False,
+                            },
+                        },
+                    }
+                ],
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "get_server_time"},
+                },
+                "guided_regex": r"\{\}",
+            },
+            tokenizer=tokenizer,
+            tool_call_parser_name=None,
+            reasoning_parser_name=None,
+        )
+
+        assert result.guided_decoding == {"regex": r"\{\}"}
+        assert result.named_zero_arg_tool == "get_server_time"
+
     @pytest.mark.parametrize(
         "tool_choice",
         ["required", {"type": "function", "function": {"name": "get_weather"}}],

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -2670,25 +2670,28 @@ class TestToolCallGuidedDecoding:
         assert prepost_module._is_named_tool_choice(tool_choice) is False
         assert prepost_module._is_forced_tool_choice(tool_choice) is False
 
-    # Legacy guided_* must resolve to a single constraint, not a merged dict.
+    # Legacy guided_* conflicts must be rejected rather than silently discarded.
     @pytest.mark.asyncio
-    async def test_legacy_guided_fields_yield_single_constraint(self, tokenizer):
-        result = await prepost_module.preprocess_chat_request(
-            {
-                "model": MODEL,
-                "messages": [{"role": "user", "content": "Hello"}],
-                "guided_json": {"type": "object"},
-                "guided_regex": "\\d+",
-            },
-            tokenizer=tokenizer,
-            renderer=SimpleNamespace(
-                render_messages_async=AsyncMock(
-                    return_value=(None, {"prompt_token_ids": [1]})
-                )
-            ),
-            tool_parser_class=None,
-        )
-        assert result.guided_decoding == {"json": {"type": "object"}}
+    async def test_legacy_guided_fields_reject_conflicts(self, tokenizer):
+        with pytest.raises(
+            InvalidArgument,
+            match="Only one guided-decoding constraint can be set; received: json, regex",
+        ):
+            await prepost_module.preprocess_chat_request(
+                {
+                    "model": MODEL,
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "guided_json": {"type": "object"},
+                    "guided_regex": "\\d+",
+                },
+                tokenizer=tokenizer,
+                renderer=SimpleNamespace(
+                    render_messages_async=AsyncMock(
+                        return_value=(None, {"prompt_token_ids": [1]})
+                    )
+                ),
+                tool_parser_class=None,
+            )
 
     # Keep vLLM's guidance decisions aligned with the shared backend matrix.
     @pytest.mark.parametrize(

--- a/components/src/dynamo/frontend/utils.py
+++ b/components/src/dynamo/frontend/utils.py
@@ -9,12 +9,48 @@ import os
 import uuid
 from typing import Any, Literal
 
-from dynamo.llm.exceptions import HttpError
+from dynamo.llm.exceptions import HttpError, InvalidArgument
 
 _MASK_64_BITS = (1 << 64) - 1
 
 
 ChatProcessorBackend = Literal["vllm", "sglang"]
+
+
+def validate_legacy_guided_decoding_constraints(request: dict[str, Any]) -> None:
+    """Reject multiple legacy guided-decoding constraints before preprocessing."""
+    choice = request.get("guided_choice")
+    constraints = (
+        ("json", request.get("guided_json") is not None),
+        ("regex", request.get("guided_regex") is not None),
+        ("grammar", request.get("guided_grammar") is not None),
+        ("choice", isinstance(choice, list) and bool(choice)),
+    )
+    active_constraints = [name for name, is_set in constraints if is_set]
+    if len(active_constraints) > 1:
+        raise InvalidArgument(
+            "Only one guided-decoding constraint can be set; received: "
+            + ", ".join(active_constraints)
+        )
+
+
+def legacy_guided_decoding(request: dict[str, Any]) -> dict[str, Any] | None:
+    """Convert one legacy guided-decoding constraint and its modifier to a dict."""
+    validate_legacy_guided_decoding_constraints(request)
+    choice = request.get("guided_choice")
+    for key, value in (
+        ("json", request.get("guided_json")),
+        ("regex", request.get("guided_regex")),
+        ("grammar", request.get("guided_grammar")),
+        ("choice", choice if isinstance(choice, list) and choice else None),
+    ):
+        if value is not None:
+            guidance = {key: value}
+            whitespace_pattern = request.get("guided_whitespace_pattern")
+            if whitespace_pattern is not None:
+                guidance["whitespace_pattern"] = whitespace_pattern
+            return guidance
+    return None
 
 
 def read_jinja_chat_template(

--- a/components/src/dynamo/frontend/utils.py
+++ b/components/src/dynamo/frontend/utils.py
@@ -18,13 +18,23 @@ ChatProcessorBackend = Literal["vllm", "sglang"]
 
 
 def validate_legacy_guided_decoding_constraints(request: dict[str, Any]) -> None:
-    """Reject multiple legacy guided-decoding constraints before preprocessing."""
+    """Reject malformed or multiple legacy guided-decoding constraints."""
     choice = request.get("guided_choice")
+    # An empty list is a caller saying "no choices", which is simply no
+    # constraint. Any other non-list is malformed: silently ignoring it would
+    # generate unconstrained text for a caller who believes it constrained the
+    # output. The Rust frontend types this field as Option<Vec<String>> and
+    # rejects a scalar, so rejecting here keeps the two paths in step.
+    if choice is not None and not isinstance(choice, list):
+        raise InvalidArgument(
+            "guided_choice must be a list of strings; received "
+            f"{type(choice).__name__}"
+        )
     constraints = (
         ("json", request.get("guided_json") is not None),
         ("regex", request.get("guided_regex") is not None),
         ("grammar", request.get("guided_grammar") is not None),
-        ("choice", isinstance(choice, list) and bool(choice)),
+        ("choice", bool(choice)),
     )
     active_constraints = [name for name, is_set in constraints if is_set]
     if len(active_constraints) > 1:
@@ -42,7 +52,7 @@ def legacy_guided_decoding(request: dict[str, Any]) -> dict[str, Any] | None:
         ("json", request.get("guided_json")),
         ("regex", request.get("guided_regex")),
         ("grammar", request.get("guided_grammar")),
-        ("choice", choice if isinstance(choice, list) and choice else None),
+        ("choice", choice or None),
     ):
         if value is not None:
             guidance = {key: value}

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -1182,13 +1182,11 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
                                     structural_tag
                                 )
 
-            for source_key, target_key in (
-                ("whitespace_pattern", "whitespace_pattern"),
-                ("backend", "guided_decoding_backend"),
-            ):
-                value = guided_decoding.get(source_key)
-                if value is not None:
-                    params[target_key] = value
+            # whitespace_pattern and backend are deliberately not forwarded.
+            # SGLang exposes both as server options
+            # (server_args.constrained_json_whitespace_pattern and the
+            # --grammar-backend flag); SamplingParams has no field for either, and
+            # it raises TypeError on an unknown key rather than ignoring it.
             return params
         return {}
 

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import logging
 import random
+import re
 import threading
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
@@ -1151,16 +1152,44 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
     ) -> Dict[str, Any]:
         """Extract guided decoding params (e.g. json_schema) for SGLang sampling_params."""
         if isinstance(guided_decoding, dict):
+            params: Dict[str, Any] = {}
             json_schema = guided_decoding.get("json")
             if json_schema is not None:
                 reject_nonprogressing_guided_json_ref_cycles(json_schema)
-                return {"json_schema": json.dumps(json_schema)}
-            regex = guided_decoding.get("regex")
-            if regex is not None:
-                return {"regex": regex}
-            structural_tag = guided_decoding.get("structural_tag")
-            if structural_tag is not None:
-                return {"structural_tag": serialize_structural_tag(structural_tag)}
+                params["json_schema"] = json.dumps(json_schema)
+            else:
+                regex = guided_decoding.get("regex")
+                if regex is not None:
+                    params["regex"] = regex
+                else:
+                    choice = guided_decoding.get("choice")
+                    if choice:
+                        choices = [str(value) for value in choice if value is not None]
+                        if choices:
+                            params["regex"] = (
+                                "("
+                                + "|".join(re.escape(value) for value in choices)
+                                + ")"
+                            )
+                    else:
+                        grammar = guided_decoding.get("grammar")
+                        if grammar is not None:
+                            params["ebnf"] = grammar
+                        else:
+                            structural_tag = guided_decoding.get("structural_tag")
+                            if structural_tag is not None:
+                                params["structural_tag"] = serialize_structural_tag(
+                                    structural_tag
+                                )
+
+            for source_key, target_key in (
+                ("whitespace_pattern", "whitespace_pattern"),
+                ("backend", "guided_decoding_backend"),
+            ):
+                value = guided_decoding.get(source_key)
+                if value is not None:
+                    params[target_key] = value
+            return params
         return {}
 
     @staticmethod

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -1150,44 +1150,48 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
     def _get_guided_decoding_params(
         guided_decoding: Optional[Dict[str, Any]],
     ) -> Dict[str, Any]:
-        """Extract guided decoding params (e.g. json_schema) for SGLang sampling_params."""
-        if isinstance(guided_decoding, dict):
-            params: Dict[str, Any] = {}
-            json_schema = guided_decoding.get("json")
-            if json_schema is not None:
-                reject_nonprogressing_guided_json_ref_cycles(json_schema)
-                params["json_schema"] = json.dumps(json_schema)
-            else:
-                regex = guided_decoding.get("regex")
-                if regex is not None:
-                    params["regex"] = regex
-                else:
-                    choice = guided_decoding.get("choice")
-                    if choice:
-                        choices = [str(value) for value in choice if value is not None]
-                        if choices:
-                            params["regex"] = (
-                                "("
-                                + "|".join(re.escape(value) for value in choices)
-                                + ")"
-                            )
-                    else:
-                        grammar = guided_decoding.get("grammar")
-                        if grammar is not None:
-                            params["ebnf"] = grammar
-                        else:
-                            structural_tag = guided_decoding.get("structural_tag")
-                            if structural_tag is not None:
-                                params["structural_tag"] = serialize_structural_tag(
-                                    structural_tag
-                                )
+        """Map one guided-decoding constraint to SGLang sampling_params.
 
-            # whitespace_pattern and backend are deliberately not forwarded.
-            # SGLang exposes both as server options
-            # (server_args.constrained_json_whitespace_pattern and the
-            # --grammar-backend flag); SamplingParams has no field for either, and
-            # it raises TypeError on an unknown key rather than ignoring it.
-            return params
+        Upstream validation admits at most one constraint, so the order below is a
+        formality rather than a precedence policy.
+
+        whitespace_pattern and backend are deliberately absent. SGLang exposes both
+        as server options (server_args.constrained_json_whitespace_pattern and the
+        --grammar-backend flag); SamplingParams has no field for either and raises
+        TypeError on an unknown keyword rather than ignoring it.
+        """
+        if not isinstance(guided_decoding, dict):
+            return {}
+
+        json_schema = guided_decoding.get("json")
+        if json_schema is not None:
+            reject_nonprogressing_guided_json_ref_cycles(json_schema)
+            return {"json_schema": json.dumps(json_schema)}
+
+        regex = guided_decoding.get("regex")
+        if regex is not None:
+            return {"regex": regex}
+
+        # SGLang has no choice constraint, so an alternation stands in for one.
+        # Its regex is a full-match FSM, so no anchors are needed.
+        choices = [
+            str(value)
+            for value in guided_decoding.get("choice") or []
+            if value is not None
+        ]
+        if choices:
+            return {
+                "regex": "(" + "|".join(re.escape(value) for value in choices) + ")"
+            }
+
+        grammar = guided_decoding.get("grammar")
+        if grammar is not None:
+            return {"ebnf": grammar}
+
+        structural_tag = guided_decoding.get("structural_tag")
+        if structural_tag is not None:
+            return {"structural_tag": serialize_structural_tag(structural_tag)}
+
         return {}
 
     @staticmethod

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -786,17 +786,26 @@ def test_build_sampling_params_maps_guided_decoding_to_json_schema():
     )
 
 
-def test_build_sampling_params_maps_guided_decoding_to_regex():
+@pytest.mark.parametrize(
+    "guided_decoding, expected",
+    [
+        ({"regex": "a+"}, {"regex": "a+"}),
+        ({"choice": ["yes", "no"]}, {"regex": "(yes|no)"}),
+        ({"grammar": 'root ::= "a"'}, {"ebnf": 'root ::= "a"'}),
+    ],
+)
+def test_build_sampling_params_maps_non_json_guided_decoding(guided_decoding, expected):
     handler = _new_decode_handler(use_sglang_tokenizer=False)
 
     sampling_params = handler._build_sampling_params(
         {
-            "sampling_options": {"guided_decoding": {"regex": r"\{\}"}},
+            "sampling_options": {"guided_decoding": guided_decoding},
             "stop_conditions": {"max_tokens": 8},
         }
     )
 
-    assert sampling_params["regex"] == r"\{\}"
+    for key, value in expected.items():
+        assert sampling_params[key] == value
 
 
 def test_build_sampling_params_maps_min_tokens_for_token_requests():

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -808,6 +808,26 @@ def test_build_sampling_params_maps_non_json_guided_decoding(guided_decoding, ex
         assert sampling_params[key] == value
 
 
+def test_build_sampling_params_degenerate_choice_does_not_hide_later_constraint():
+    """A choice list that filters to nothing must not consume the constraint slot.
+
+    The nested cascade this replaced entered the choice branch on a truthy list,
+    filtered it empty, and then skipped grammar and structural_tag entirely.
+    """
+    handler = _new_decode_handler(use_sglang_tokenizer=False)
+
+    sampling_params = handler._build_sampling_params(
+        {
+            "sampling_options": {
+                "guided_decoding": {"choice": [None], "grammar": 'root ::= "a"'}
+            },
+            "stop_conditions": {"max_tokens": 8},
+        }
+    )
+
+    assert sampling_params["ebnf"] == 'root ::= "a"'
+
+
 @pytest.mark.parametrize(
     "guided_decoding",
     [

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -808,6 +808,40 @@ def test_build_sampling_params_maps_non_json_guided_decoding(guided_decoding, ex
         assert sampling_params[key] == value
 
 
+@pytest.mark.parametrize(
+    "guided_decoding",
+    [
+        {"json": {"type": "object"}},
+        {"regex": "a+"},
+        {"choice": ["yes", "no"]},
+        {"grammar": 'root ::= "a"'},
+        # Modifiers ride along with a constraint on the wire. SGLang has no
+        # SamplingParams field for either, so they must not be forwarded.
+        {"json": {"type": "object"}, "whitespace_pattern": "[\n ]?"},
+        {"regex": "a+", "backend": "xgrammar"},
+    ],
+)
+def test_guided_decoding_params_are_accepted_by_sglang(guided_decoding):
+    """Every key we emit must exist on SGLang's SamplingParams.
+
+    SamplingParams raises TypeError on an unknown keyword rather than ignoring
+    it, and the dict built here is passed straight to engine.async_generate,
+    which splats it into that constructor. Asserting only on the dict we return
+    cannot catch a key SGLang does not accept, so construct it for real.
+    """
+    from sglang.srt.sampling.sampling_params import SamplingParams
+
+    handler = _new_decode_handler(use_sglang_tokenizer=False)
+    sampling_params = handler._build_sampling_params(
+        {
+            "sampling_options": {"guided_decoding": guided_decoding},
+            "stop_conditions": {"max_tokens": 8},
+        }
+    )
+
+    SamplingParams(**sampling_params)
+
+
 def test_build_sampling_params_maps_min_tokens_for_token_requests():
     handler = _new_decode_handler(use_sglang_tokenizer=False)
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -5090,8 +5090,8 @@ mod tests {
 
     use super::*;
     use crate::discovery::ModelManagerError;
-    use crate::protocols::common::StopConditionsProvider;
     use crate::protocols::common::extensions::{AgentCompaction, NvExt};
+    use crate::protocols::common::{SamplingOptionsProvider, StopConditionsProvider};
     use crate::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
     use crate::protocols::openai::common_ext::CommonExt;
     use crate::protocols::openai::completions::NvCreateCompletionRequest;
@@ -5635,6 +5635,29 @@ mod tests {
         let response = ErrorMessage::from_anyhow(err, BACKUP_ERROR_MESSAGE);
         assert_eq!(response.0, StatusCode::BAD_REQUEST);
         assert_eq!(response.1.message, "custom error message");
+    }
+
+    #[test]
+    fn guided_decoding_conflict_maps_to_bounded_bad_request() {
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "guided_json": {
+                "type": "object",
+                "description": "x".repeat(1_200_000),
+            },
+            "guided_regex": "a+",
+        }))
+        .expect("request should deserialize");
+
+        let error = request.extract_sampling_options().unwrap_err();
+        let response = ErrorMessage::from_anyhow(error, BACKUP_ERROR_MESSAGE);
+
+        assert_eq!(response.0, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response.1.message,
+            "Only one guided-decoding constraint can be set; received: json, regex"
+        );
     }
 
     #[test]

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -108,6 +108,7 @@ pub use crate::protocols::common::metrics::{
 };
 pub use crate::protocols::common::preprocessor::PreprocessedEmbeddingRequest;
 
+use crate::protocols::common::invalid_argument_error;
 use crate::protocols::common::llm_backend::EmbeddingsEngineOutput;
 
 fn routing_priorities(hints: Option<&AgentHints>) -> (Option<f64>, Option<u32>, Option<i32>) {
@@ -119,14 +120,6 @@ fn routing_priorities(hints: Option<&AgentHints>) -> (Option<f64>, Option<u32>, 
     let strict_priority = hints.and_then(|h| h.strict_priority);
     let priority = hints.and_then(|h| h.priority);
     (priority_jump, strict_priority, priority)
-}
-
-pub(crate) fn invalid_argument_error(message: impl Into<String>) -> anyhow::Error {
-    DynamoError::builder()
-        .error_type(ErrorType::InvalidArgument)
-        .message(message.into())
-        .build()
-        .into()
 }
 
 // Preserves terminal versus recoverable failures when moka shares a

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -121,7 +121,7 @@ fn routing_priorities(hints: Option<&AgentHints>) -> (Option<f64>, Option<u32>, 
     (priority_jump, strict_priority, priority)
 }
 
-fn invalid_argument_error(message: impl Into<String>) -> anyhow::Error {
+pub(crate) fn invalid_argument_error(message: impl Into<String>) -> anyhow::Error {
     DynamoError::builder()
         .error_type(ErrorType::InvalidArgument)
         .message(message.into())

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -441,7 +441,9 @@ pub struct SamplingOptions {
 
 /// Guided Decoding Options
 ///
-/// Only one of `json`, `regex`, `choice`, or `grammar` should be set.
+/// Only one constraint may be set: `json`, `regex`, `choice`, `grammar` or
+/// `structural_tag`. `backend` and `whitespace_pattern` are modifiers rather than
+/// constraints, so either may accompany a constraint. See [`Self::validate`].
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct GuidedDecodingOptions {
     /// If specified, the output will follow the JSON schema. Can be a string, an object, or null.

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -15,6 +15,7 @@
 
 use anyhow::Result;
 use derive_builder::Builder;
+use dynamo_runtime::error::{DynamoError, ErrorType};
 use serde::{Deserialize, Serialize};
 
 use super::TokenIdType;
@@ -22,6 +23,14 @@ use dynamo_protocols::types::StopReason;
 
 /// Maximum nesting depth allowed in guided_grammar EBNF strings.
 const MAX_GRAMMAR_NESTING_DEPTH: usize = 500;
+
+pub(crate) fn invalid_argument_error(message: impl Into<String>) -> anyhow::Error {
+    DynamoError::builder()
+        .error_type(ErrorType::InvalidArgument)
+        .message(message.into())
+        .build()
+        .into()
+}
 
 pub mod extensions;
 pub mod input_trigger;
@@ -551,22 +560,26 @@ impl GuidedDecodingOptions {
     /// the error text below never named it, and while the Python frontend
     /// (`components/src/dynamo/frontend/prepost.py`) builds exactly that pair on purpose.
     pub fn validate(&self) -> Result<()> {
-        let count = [
-            self.json.is_some(),
-            self.regex.is_some(),
-            self.choice.as_ref().is_some_and(|v| !v.is_empty()),
-            self.grammar.is_some(),
-            self.structural_tag.is_some(),
-        ]
-        .iter()
-        .filter(|&&v| v)
-        .count();
+        let constraints = [
+            ("json", self.json.is_some()),
+            ("regex", self.regex.is_some()),
+            (
+                "choice",
+                self.choice.as_ref().is_some_and(|value| !value.is_empty()),
+            ),
+            ("grammar", self.grammar.is_some()),
+            ("structural_tag", self.structural_tag.is_some()),
+        ];
 
-        if count > 1 {
-            return Err(anyhow::anyhow!(
-                "Only one of json, regex, choice, grammar, or structural_tag can be set, but multiple are specified: {:?}",
-                self
-            ));
+        if constraints.iter().filter(|(_, is_set)| *is_set).count() > 1 {
+            let active_constraints = constraints
+                .into_iter()
+                .filter_map(|(name, is_set)| is_set.then_some(name))
+                .collect::<Vec<_>>();
+            return Err(invalid_argument_error(format!(
+                "Only one guided-decoding constraint can be set; received: {}",
+                active_constraints.join(", ")
+            )));
         }
 
         if let Some(ref grammar) = self.grammar {
@@ -592,11 +605,10 @@ impl GuidedDecodingOptions {
                 }
             }
             if max > MAX_GRAMMAR_NESTING_DEPTH {
-                return Err(anyhow::anyhow!(
+                return Err(invalid_argument_error(format!(
                     "guided_grammar exceeds maximum nesting depth of {} (got {})",
-                    MAX_GRAMMAR_NESTING_DEPTH,
-                    max
-                ));
+                    MAX_GRAMMAR_NESTING_DEPTH, max
+                )));
             }
         }
 
@@ -1164,12 +1176,49 @@ mod tests {
     }
 
     #[test]
+    fn test_guided_decoding_conflict_is_typed_and_bounded() {
+        let large_schema = serde_json::json!({
+            "type": "object",
+            "description": "x".repeat(1_200_000),
+        });
+        let error = GuidedDecodingOptions::validated(
+            Some(large_schema),
+            Some("a+".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
+
+        let dynamo_error = error
+            .downcast_ref::<dynamo_runtime::error::DynamoError>()
+            .expect("guided-decoding conflicts must remain typed for HTTP 400 mapping");
+        assert_eq!(
+            dynamo_error.error_type(),
+            dynamo_runtime::error::ErrorType::InvalidArgument
+        );
+        assert_eq!(
+            dynamo_error.message(),
+            "Only one guided-decoding constraint can be set; received: json, regex"
+        );
+    }
+
+    #[test]
     fn test_guided_grammar_deep_nesting_rejected() {
         let grammar = "(".repeat(501) + "a" + &")".repeat(501);
         let result =
             GuidedDecodingOptions::validated(None, None, None, Some(grammar), None, None, None);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("nesting depth"));
+        let error = result.unwrap_err();
+        let dynamo_error = error
+            .downcast_ref::<dynamo_runtime::error::DynamoError>()
+            .expect("guided grammar depth must remain typed for HTTP 400 mapping");
+        assert_eq!(
+            dynamo_error.error_type(),
+            dynamo_runtime::error::ErrorType::InvalidArgument
+        );
+        assert!(dynamo_error.message().contains("nesting depth"));
     }
 
     #[test]

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -533,7 +533,6 @@ impl GuidedDecodingOptions {
             && regex.is_none()
             && is_empty_choice
             && grammar.is_none()
-            && whitespace_pattern.is_none()
             && structural_tag.is_none()
         {
             return Ok(None);
@@ -559,6 +558,10 @@ impl GuidedDecodingOptions {
     /// `whitespace_pattern` made `guided_json` + `guided_whitespace_pattern` fail while
     /// the error text below never named it, and while the Python frontend
     /// (`components/src/dynamo/frontend/prepost.py`) builds exactly that pair on purpose.
+    ///
+    /// `from_optional` above skips the same two fields when it decides whether any
+    /// constraint was requested at all, so a request carrying only a modifier engages no
+    /// guided decoding rather than building a constraint-less object.
     pub fn validate(&self) -> Result<()> {
         let constraints = [
             ("json", self.json.is_some()),
@@ -1154,6 +1157,22 @@ mod tests {
         // Choice set but empty vector should not count as set
         let opts =
             GuidedDecodingOptions::from_optional(None, None, Some(vec![]), None, None, None, None);
+        assert!(opts.is_ok());
+        let val = opts.unwrap();
+        assert!(val.is_none());
+
+        // whitespace_pattern modifies a constraint rather than being one, so on its own it
+        // must not engage guided decoding. Returning Some here would hand the backend a
+        // constraint-less object, which vLLM rejects and which disables request migration.
+        let opts = GuidedDecodingOptions::from_optional(
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(r"[\n ]?".to_string()),
+            None,
+        );
         assert!(opts.is_ok());
         let val = opts.unwrap();
         assert!(val.is_none());

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -543,13 +543,19 @@ impl GuidedDecodingOptions {
 
     /// Validate that only one guided decoding option is set, and that
     /// grammar nesting depth is bounded.
+    ///
+    /// `whitespace_pattern` and `backend` are deliberately absent from the count. Both
+    /// modify how a constraint is applied rather than being a constraint themselves, so
+    /// pairing either with `json` is a normal request, not a conflict. Counting
+    /// `whitespace_pattern` made `guided_json` + `guided_whitespace_pattern` fail while
+    /// the error text below never named it, and while the Python frontend
+    /// (`components/src/dynamo/frontend/prepost.py`) builds exactly that pair on purpose.
     pub fn validate(&self) -> Result<()> {
         let count = [
             self.json.is_some(),
             self.regex.is_some(),
             self.choice.as_ref().is_some_and(|v| !v.is_empty()),
             self.grammar.is_some(),
-            self.whitespace_pattern.is_some(),
             self.structural_tag.is_some(),
         ]
         .iter()

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -10,7 +10,6 @@ use super::{
     ContentProvider,
     common::{self, OutputOptionsProvider, SamplingOptionsProvider, StopConditionsProvider},
 };
-use crate::preprocessor::invalid_argument_error;
 use crate::protocols::common::extensions::NvExt;
 use crate::protocols::openai::common_ext::CommonExtProvider;
 use crate::types::TokenIdType;
@@ -162,7 +161,7 @@ impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvid
         let guided_grammar = self.get_guided_grammar();
         let guided_choice = self.get_guided_choice();
         let guided_whitespace_pattern = self.get_guided_whitespace_pattern();
-        let guided_decoding = match common::GuidedDecodingOptions::from_optional(
+        let guided_decoding = common::GuidedDecodingOptions::from_optional(
             guided_json,
             guided_regex,
             guided_choice,
@@ -170,23 +169,7 @@ impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvid
             guided_decoding_backend,
             guided_whitespace_pattern,
             None,
-        ) {
-            Ok(options) => options,
-            Err(e) => {
-                // A caller sending two constraints is an expected outcome with a known
-                // reason, not an internal fault, so it leaves here typed. Without the
-                // `InvalidArgument` marker the HTTP layer has nothing to branch on and
-                // falls through to its internal-error path, which is how this surfaced
-                // as `500 Internal Server Error`.
-                //
-                // `ValidateRequest::validate` now runs the same check at the request
-                // boundary, so an HTTP request is rejected before reaching here. This
-                // arm still matters for entry points that build sampling options
-                // without that boundary, and as the invariant guard for this function.
-                tracing::error!("Invalid guided decoding options: {:?}", e);
-                return Err(invalid_argument_error(e.to_string()));
-            }
-        };
+        )?;
         Ok(common::SamplingOptions {
             n,
             best_of,

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -10,6 +10,7 @@ use super::{
     ContentProvider,
     common::{self, OutputOptionsProvider, SamplingOptionsProvider, StopConditionsProvider},
 };
+use crate::preprocessor::invalid_argument_error;
 use crate::protocols::common::extensions::NvExt;
 use crate::protocols::openai::common_ext::CommonExtProvider;
 use crate::types::TokenIdType;
@@ -172,9 +173,18 @@ impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvid
         ) {
             Ok(options) => options,
             Err(e) => {
-                // Handle the validation error (log, return error, etc.)
+                // A caller sending two constraints is an expected outcome with a known
+                // reason, not an internal fault, so it leaves here typed. Without the
+                // `InvalidArgument` marker the HTTP layer has nothing to branch on and
+                // falls through to its internal-error path, which is how this surfaced
+                // as `500 Internal Server Error`.
+                //
+                // `ValidateRequest::validate` now runs the same check at the request
+                // boundary, so an HTTP request is rejected before reaching here. This
+                // arm still matters for entry points that build sampling options
+                // without that boundary, and as the invariant guard for this function.
                 tracing::error!("Invalid guided decoding options: {:?}", e);
-                return Err(e);
+                return Err(invalid_argument_error(e.to_string()));
             }
         };
         Ok(common::SamplingOptions {

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -591,6 +591,7 @@ impl OpenAIOutputOptionsProvider for NvCreateChatCompletionRequest {
 impl ValidateRequest for NvCreateChatCompletionRequest {
     fn validate(&self) -> Result<(), anyhow::Error> {
         validate::validate_no_unsupported_fields(&self.unsupported_fields)?;
+        validate::validate_guided_decoding(self)?;
         validate::validate_chat_template_args(self.chat_template_args.as_ref())?;
         validate::validate_messages(&self.inner.messages)?;
         validate::validate_model(&self.inner.model)?;
@@ -653,6 +654,72 @@ mod tests {
     };
     use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolType, FunctionObject};
     use serde_json::json;
+
+    /// Two guided-decoding constraints in one request is a malformed
+    /// request, and it has to be rejected at the request-validation boundary so the
+    /// HTTP layer answers 400 with the conflict named. Before this ran here, the
+    /// conflict was only caught later inside `extract_sampling_options`, where the
+    /// error reached the HTTP layer untyped and became a 500.
+    #[test]
+    fn test_conflicting_guided_decoding_options_fail_request_validation() {
+        // Each pair is two constraints set at once; every one of them must be rejected.
+        let conflicts = [
+            json!({"guided_json": {"type": "object"}, "guided_whitespace_pattern": "[\n ]?"}),
+            json!({"guided_json": {"type": "object"}, "guided_regex": "a+"}),
+            json!({"guided_regex": "a+", "guided_choice": ["x", "y"]}),
+            json!({"guided_grammar": "root ::= \"a\"", "guided_json": {"type": "object"}}),
+        ];
+
+        for extra in conflicts {
+            let mut body = json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 20
+            });
+            for (key, value) in extra.as_object().expect("conflict fixture is an object") {
+                body[key] = value.clone();
+            }
+
+            let request: NvCreateChatCompletionRequest =
+                serde_json::from_value(body.clone()).expect("Failed to deserialize request");
+
+            let error = ValidateRequest::validate(&request)
+                .expect_err(&format!("expected {body} to fail validation"));
+            // The caller has to be told which rule it broke, not just that something
+            // was wrong -- that reason text is what the HTTP 400 body carries.
+            assert!(
+                error.to_string().contains("Only one of"),
+                "validation error should name the conflict, got: {error}"
+            );
+        }
+    }
+
+    /// The guard for the above: a request with exactly ONE guided-decoding constraint
+    /// is legal and must keep validating, so the new check cannot be satisfied by
+    /// rejecting guided decoding outright.
+    #[test]
+    fn test_single_guided_decoding_option_passes_request_validation() {
+        for extra in [
+            json!({"guided_json": {"type": "object"}}),
+            json!({"guided_regex": "a+"}),
+            json!({"guided_choice": ["x", "y"]}),
+            json!({"guided_whitespace_pattern": "[\n ]?"}),
+        ] {
+            let mut body = json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 20
+            });
+            for (key, value) in extra.as_object().expect("fixture is an object") {
+                body[key] = value.clone();
+            }
+
+            let request: NvCreateChatCompletionRequest =
+                serde_json::from_value(body.clone()).expect("Failed to deserialize request");
+            ValidateRequest::validate(&request)
+                .unwrap_or_else(|e| panic!("{body} must stay valid, got: {e}"));
+        }
+    }
 
     #[test]
     fn test_top_k_sentinel_contract() {

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -649,10 +649,24 @@ mod tests {
     use super::*;
     use crate::engines::ValidateRequest;
     use crate::protocols::common::{
-        OutputOptionsProvider, SamplingOptionsProvider, StopConditionsProvider,
+        GuidedDecodingOptions, OutputOptionsProvider, SamplingOptionsProvider,
+        StopConditionsProvider,
     };
     use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolType, FunctionObject};
     use serde_json::json;
+
+    /// Builds a minimal chat request and merges `extra` into its top-level fields.
+    fn chat_request_with(extra: &serde_json::Value) -> NvCreateChatCompletionRequest {
+        let mut body = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 20
+        });
+        for (key, value) in extra.as_object().expect("fixture is an object") {
+            body[key] = value.clone();
+        }
+        serde_json::from_value(body).expect("Failed to deserialize request")
+    }
 
     #[test]
     fn test_conflicting_guided_decoding_options_return_invalid_argument() {
@@ -664,19 +678,9 @@ mod tests {
         ];
 
         for extra in conflicts {
-            let mut body = json!({
-                "model": "test-model",
-                "messages": [{"role": "user", "content": "hi"}],
-                "max_tokens": 20
-            });
-            for (key, value) in extra.as_object().expect("conflict fixture is an object") {
-                body[key] = value.clone();
-            }
-
-            let request: NvCreateChatCompletionRequest =
-                serde_json::from_value(body.clone()).expect("Failed to deserialize request");
-
-            let error = request.extract_sampling_options().unwrap_err();
+            let error = chat_request_with(&extra)
+                .extract_sampling_options()
+                .unwrap_err();
             let dynamo_error = error
                 .downcast_ref::<dynamo_runtime::error::DynamoError>()
                 .expect("sampling extraction must preserve the HTTP error type");
@@ -688,41 +692,74 @@ mod tests {
         }
     }
 
-    /// The guard for the above: a request with exactly ONE guided-decoding constraint
-    /// is legal and must keep validating, so the new check cannot be satisfied by
-    /// rejecting guided decoding outright.
+    /// The guard for the above: a legal request must keep validating, so the conflict
+    /// check cannot be satisfied by rejecting guided decoding outright.
     ///
-    /// This also covers `guided_whitespace_pattern` paired with a constraint.
-    /// `GuidedDecodingOptions::validate` used to count it toward the exclusivity limit,
-    /// which rejected `guided_json` + `guided_whitespace_pattern` even though the error
-    /// text never named `whitespace_pattern` and the Python frontend
-    /// (`components/src/dynamo/frontend/prepost.py`) builds that exact pair.
+    /// `whitespace_pattern` is a modifier, not a constraint -- it changes how a JSON
+    /// grammar is applied. `GuidedDecodingOptions::validate` used to count it toward the
+    /// exclusivity limit, which rejected `guided_json` + `guided_whitespace_pattern` even
+    /// though the error text never named `whitespace_pattern` and the Python frontend
+    /// (`components/src/dynamo/frontend/prepost.py`) builds that exact pair. Each case
+    /// below asserts the resulting options, not merely that extraction returned `Ok`.
     #[test]
-    fn test_single_guided_decoding_option_passes_sampling_extraction() {
-        for extra in [
-            json!({"guided_json": {"type": "object"}}),
-            json!({"guided_regex": "a+"}),
-            json!({"guided_choice": ["x", "y"]}),
-            json!({"guided_whitespace_pattern": "[\n ]?"}),
+    fn test_guided_decoding_constraint_with_modifier_stays_valid() {
+        let cases: [(serde_json::Value, fn(&GuidedDecodingOptions)); 5] = [
+            (json!({"guided_json": {"type": "object"}}), |guided| {
+                assert!(guided.json.is_some())
+            }),
+            (json!({"guided_regex": "a+"}), |guided| {
+                assert_eq!(guided.regex.as_deref(), Some("a+"))
+            }),
+            (json!({"guided_choice": ["x", "y"]}), |guided| {
+                assert_eq!(guided.choice.as_deref(), Some(&["x".to_string(), "y".to_string()][..]))
+            }),
             // The companion pair: whitespace_pattern modifies the JSON grammar rather
             // than being a second grammar, so setting both is one constraint, not two.
-            json!({"guided_json": {"type": "object"}, "guided_whitespace_pattern": "[\n ]?"}),
-            json!({"guided_regex": "a+", "guided_whitespace_pattern": "[\n ]?"}),
-        ] {
-            let mut body = json!({
-                "model": "test-model",
-                "messages": [{"role": "user", "content": "hi"}],
-                "max_tokens": 20
-            });
-            for (key, value) in extra.as_object().expect("fixture is an object") {
-                body[key] = value.clone();
-            }
+            (
+                json!({"guided_json": {"type": "object"}, "guided_whitespace_pattern": "[\n ]?"}),
+                |guided| {
+                    assert!(guided.json.is_some());
+                    assert_eq!(guided.whitespace_pattern.as_deref(), Some("[\n ]?"));
+                },
+            ),
+            (
+                json!({"guided_regex": "a+", "guided_whitespace_pattern": "[\n ]?"}),
+                |guided| {
+                    assert_eq!(guided.regex.as_deref(), Some("a+"));
+                    assert_eq!(guided.whitespace_pattern.as_deref(), Some("[\n ]?"));
+                },
+            ),
+        ];
 
-            let request: NvCreateChatCompletionRequest =
-                serde_json::from_value(body.clone()).expect("Failed to deserialize request");
-            request
+        for (extra, check) in cases {
+            let request = chat_request_with(&extra);
+            let sampling = request
                 .extract_sampling_options()
-                .unwrap_or_else(|e| panic!("{body} must stay valid, got: {e}"));
+                .unwrap_or_else(|e| panic!("{extra} must stay valid, got: {e}"));
+            let guided = sampling
+                .guided_decoding
+                .unwrap_or_else(|| panic!("{extra} must produce guided decoding options"));
+            check(&guided);
+        }
+    }
+
+    /// A modifier on its own describes how to apply a constraint that was never supplied.
+    /// It must engage no guided decoding at all: emitting a constraint-less
+    /// `GuidedDecodingOptions` makes vLLM raise `ValueError` on the worker and disables
+    /// request migration, for a request the caller never meant as structured output.
+    #[test]
+    fn test_guided_decoding_modifier_alone_engages_nothing() {
+        for extra in [
+            json!({"guided_whitespace_pattern": "[\n ]?"}),
+            json!({"guided_decoding_backend": "xgrammar"}),
+        ] {
+            let sampling = chat_request_with(&extra)
+                .extract_sampling_options()
+                .unwrap_or_else(|e| panic!("{extra} must stay valid, got: {e}"));
+            assert!(
+                sampling.guided_decoding.is_none(),
+                "{extra} sets no constraint, so guided decoding must not be engaged",
+            );
         }
     }
 

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -591,7 +591,6 @@ impl OpenAIOutputOptionsProvider for NvCreateChatCompletionRequest {
 impl ValidateRequest for NvCreateChatCompletionRequest {
     fn validate(&self) -> Result<(), anyhow::Error> {
         validate::validate_no_unsupported_fields(&self.unsupported_fields)?;
-        validate::validate_guided_decoding(self)?;
         validate::validate_chat_template_args(self.chat_template_args.as_ref())?;
         validate::validate_messages(&self.inner.messages)?;
         validate::validate_model(&self.inner.model)?;
@@ -655,13 +654,8 @@ mod tests {
     use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolType, FunctionObject};
     use serde_json::json;
 
-    /// Two guided-decoding constraints in one request is a malformed
-    /// request, and it has to be rejected at the request-validation boundary so the
-    /// HTTP layer answers 400 with the conflict named. Before this ran here, the
-    /// conflict was only caught later inside `extract_sampling_options`, where the
-    /// error reached the HTTP layer untyped and became a 500.
     #[test]
-    fn test_conflicting_guided_decoding_options_fail_request_validation() {
+    fn test_conflicting_guided_decoding_options_return_invalid_argument() {
         // Each pair is two constraints set at once; every one of them must be rejected.
         let conflicts = [
             json!({"guided_json": {"type": "object"}, "guided_regex": "a+"}),
@@ -682,13 +676,14 @@ mod tests {
             let request: NvCreateChatCompletionRequest =
                 serde_json::from_value(body.clone()).expect("Failed to deserialize request");
 
-            let error = ValidateRequest::validate(&request)
-                .expect_err(&format!("expected {body} to fail validation"));
-            // The caller has to be told which rule it broke, not just that something
-            // was wrong -- that reason text is what the HTTP 400 body carries.
-            assert!(
-                error.to_string().contains("Only one of"),
-                "validation error should name the conflict, got: {error}"
+            let error = request.extract_sampling_options().unwrap_err();
+            let dynamo_error = error
+                .downcast_ref::<dynamo_runtime::error::DynamoError>()
+                .expect("sampling extraction must preserve the HTTP error type");
+            assert_eq!(
+                dynamo_error.error_type(),
+                dynamo_runtime::error::ErrorType::InvalidArgument,
+                "guided-decoding conflicts must map to HTTP 400",
             );
         }
     }
@@ -703,7 +698,7 @@ mod tests {
     /// text never named `whitespace_pattern` and the Python frontend
     /// (`components/src/dynamo/frontend/prepost.py`) builds that exact pair.
     #[test]
-    fn test_single_guided_decoding_option_passes_request_validation() {
+    fn test_single_guided_decoding_option_passes_sampling_extraction() {
         for extra in [
             json!({"guided_json": {"type": "object"}}),
             json!({"guided_regex": "a+"}),
@@ -725,7 +720,8 @@ mod tests {
 
             let request: NvCreateChatCompletionRequest =
                 serde_json::from_value(body.clone()).expect("Failed to deserialize request");
-            ValidateRequest::validate(&request)
+            request
+                .extract_sampling_options()
                 .unwrap_or_else(|e| panic!("{body} must stay valid, got: {e}"));
         }
     }

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -668,6 +668,16 @@ mod tests {
         serde_json::from_value(body).expect("Failed to deserialize request")
     }
 
+    /// Extracts sampling options for `extra` and returns the guided-decoding options it
+    /// produced, failing if extraction rejected the request or engaged nothing.
+    fn guided_for(extra: &serde_json::Value) -> GuidedDecodingOptions {
+        chat_request_with(extra)
+            .extract_sampling_options()
+            .unwrap_or_else(|e| panic!("{extra} must stay valid, got: {e}"))
+            .guided_decoding
+            .unwrap_or_else(|| panic!("{extra} must produce guided decoding options"))
+    }
+
     #[test]
     fn test_conflicting_guided_decoding_options_return_invalid_argument() {
         // Each pair is two constraints set at once; every one of them must be rejected.
@@ -699,48 +709,40 @@ mod tests {
     /// grammar is applied. `GuidedDecodingOptions::validate` used to count it toward the
     /// exclusivity limit, which rejected `guided_json` + `guided_whitespace_pattern` even
     /// though the error text never named `whitespace_pattern` and the Python frontend
-    /// (`components/src/dynamo/frontend/prepost.py`) builds that exact pair. Each case
-    /// below asserts the resulting options, not merely that extraction returned `Ok`.
+    /// (`components/src/dynamo/frontend/prepost.py`) builds that exact pair. Every case
+    /// asserts the resulting options, not merely that extraction returned `Ok`.
     #[test]
     fn test_guided_decoding_constraint_with_modifier_stays_valid() {
-        let cases: [(serde_json::Value, fn(&GuidedDecodingOptions)); 5] = [
-            (json!({"guided_json": {"type": "object"}}), |guided| {
-                assert!(guided.json.is_some())
-            }),
-            (json!({"guided_regex": "a+"}), |guided| {
-                assert_eq!(guided.regex.as_deref(), Some("a+"))
-            }),
-            (json!({"guided_choice": ["x", "y"]}), |guided| {
-                assert_eq!(guided.choice.as_deref(), Some(&["x".to_string(), "y".to_string()][..]))
-            }),
-            // The companion pair: whitespace_pattern modifies the JSON grammar rather
-            // than being a second grammar, so setting both is one constraint, not two.
-            (
-                json!({"guided_json": {"type": "object"}, "guided_whitespace_pattern": "[\n ]?"}),
-                |guided| {
-                    assert!(guided.json.is_some());
-                    assert_eq!(guided.whitespace_pattern.as_deref(), Some("[\n ]?"));
-                },
-            ),
-            (
-                json!({"guided_regex": "a+", "guided_whitespace_pattern": "[\n ]?"}),
-                |guided| {
-                    assert_eq!(guided.regex.as_deref(), Some("a+"));
-                    assert_eq!(guided.whitespace_pattern.as_deref(), Some("[\n ]?"));
-                },
-            ),
-        ];
+        let json_only = guided_for(&json!({"guided_json": {"type": "object"}}));
+        assert!(json_only.json.is_some());
 
-        for (extra, check) in cases {
-            let request = chat_request_with(&extra);
-            let sampling = request
-                .extract_sampling_options()
-                .unwrap_or_else(|e| panic!("{extra} must stay valid, got: {e}"));
-            let guided = sampling
-                .guided_decoding
-                .unwrap_or_else(|| panic!("{extra} must produce guided decoding options"));
-            check(&guided);
-        }
+        let regex_only = guided_for(&json!({"guided_regex": "a+"}));
+        assert_eq!(regex_only.regex.as_deref(), Some("a+"));
+
+        let choice_only = guided_for(&json!({"guided_choice": ["x", "y"]}));
+        assert_eq!(
+            choice_only.choice,
+            Some(vec!["x".to_string(), "y".to_string()])
+        );
+
+        // The companion pair: whitespace_pattern modifies the JSON grammar rather than
+        // being a second grammar, so setting both is one constraint, not two.
+        let json_with_modifier = guided_for(
+            &json!({"guided_json": {"type": "object"}, "guided_whitespace_pattern": "[\n ]?"}),
+        );
+        assert!(json_with_modifier.json.is_some());
+        assert_eq!(
+            json_with_modifier.whitespace_pattern.as_deref(),
+            Some("[\n ]?")
+        );
+
+        let regex_with_modifier =
+            guided_for(&json!({"guided_regex": "a+", "guided_whitespace_pattern": "[\n ]?"}));
+        assert_eq!(regex_with_modifier.regex.as_deref(), Some("a+"));
+        assert_eq!(
+            regex_with_modifier.whitespace_pattern.as_deref(),
+            Some("[\n ]?")
+        );
     }
 
     /// A modifier on its own describes how to apply a constraint that was never supplied.

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -664,7 +664,6 @@ mod tests {
     fn test_conflicting_guided_decoding_options_fail_request_validation() {
         // Each pair is two constraints set at once; every one of them must be rejected.
         let conflicts = [
-            json!({"guided_json": {"type": "object"}, "guided_whitespace_pattern": "[\n ]?"}),
             json!({"guided_json": {"type": "object"}, "guided_regex": "a+"}),
             json!({"guided_regex": "a+", "guided_choice": ["x", "y"]}),
             json!({"guided_grammar": "root ::= \"a\"", "guided_json": {"type": "object"}}),
@@ -697,6 +696,12 @@ mod tests {
     /// The guard for the above: a request with exactly ONE guided-decoding constraint
     /// is legal and must keep validating, so the new check cannot be satisfied by
     /// rejecting guided decoding outright.
+    ///
+    /// This also covers `guided_whitespace_pattern` paired with a constraint.
+    /// `GuidedDecodingOptions::validate` used to count it toward the exclusivity limit,
+    /// which rejected `guided_json` + `guided_whitespace_pattern` even though the error
+    /// text never named `whitespace_pattern` and the Python frontend
+    /// (`components/src/dynamo/frontend/prepost.py`) builds that exact pair.
     #[test]
     fn test_single_guided_decoding_option_passes_request_validation() {
         for extra in [
@@ -704,6 +709,10 @@ mod tests {
             json!({"guided_regex": "a+"}),
             json!({"guided_choice": ["x", "y"]}),
             json!({"guided_whitespace_pattern": "[\n ]?"}),
+            // The companion pair: whitespace_pattern modifies the JSON grammar rather
+            // than being a second grammar, so setting both is one constraint, not two.
+            json!({"guided_json": {"type": "object"}, "guided_whitespace_pattern": "[\n ]?"}),
+            json!({"guided_regex": "a+", "guided_whitespace_pattern": "[\n ]?"}),
         ] {
             let mut body = json!({
                 "model": "test-model",

--- a/lib/llm/src/protocols/openai/common_ext.rs
+++ b/lib/llm/src/protocols/openai/common_ext.rs
@@ -72,7 +72,6 @@ pub struct CommonExt {
     /// If specified, the output will follow the whitespace pattern. Can be a string or null.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
-    #[allow(unused)] // Not used
     pub guided_whitespace_pattern: Option<String>,
 
     /// Whether to skip special tokens in the decoded output.

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Context;
 use derive_builder::Builder;
 use dynamo_runtime::protocols::annotated::AnnotationsProvider;
 use serde::{Deserialize, Serialize};
@@ -358,15 +359,15 @@ impl TryFrom<NvCreateCompletionRequest> for common::CompletionRequest {
 
         let stop_conditions = request
             .extract_stop_conditions()
-            .map_err(|e| anyhow::anyhow!("Failed to extract stop conditions: {}", e))?;
+            .context("Failed to extract stop conditions")?;
 
         let sampling_options = request
             .extract_sampling_options()
-            .map_err(|e| anyhow::anyhow!("Failed to extract sampling options: {}", e))?;
+            .context("Failed to extract sampling options")?;
 
         let output_options = request
             .extract_output_options()
-            .map_err(|e| anyhow::anyhow!("Failed to extract output options: {}", e))?;
+            .context("Failed to extract output options")?;
 
         let prompt = common::PromptType::Completion(common::CompletionContext {
             prompt: prompt_to_string(&request.inner.prompt),
@@ -496,6 +497,35 @@ impl ValidateRequest for NvCreateCompletionRequest {
             self.common.continue_final_message,
         )?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod conversion_error_tests {
+    use super::*;
+
+    /// `anyhow!("{e}")` builds a fresh error with no source, which drops the
+    /// `DynamoError` and sends a caller error to `ErrorMessage::from_anyhow` as a 500.
+    /// `.context()` keeps the chain, so the conflict still maps to 400 here.
+    #[test]
+    fn guided_decoding_conflict_stays_typed_through_conversion() {
+        let request: NvCreateCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "prompt": "hi",
+            "guided_json": {"type": "object"},
+            "guided_regex": "a+",
+        }))
+        .expect("request should deserialize");
+
+        let error = common::CompletionRequest::try_from(request).unwrap_err();
+        let dynamo_error = error
+            .chain()
+            .find_map(|source| source.downcast_ref::<dynamo_runtime::error::DynamoError>())
+            .expect("conversion must preserve the HTTP error type");
+        assert_eq!(
+            dynamo_error.error_type(),
+            dynamo_runtime::error::ErrorType::InvalidArgument
+        );
     }
 }
 

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -450,7 +450,6 @@ impl OpenAIOutputOptionsProvider for NvCreateCompletionRequest {
 impl ValidateRequest for NvCreateCompletionRequest {
     fn validate(&self) -> Result<(), anyhow::Error> {
         validate::validate_no_unsupported_fields(&self.unsupported_fields)?;
-        validate::validate_guided_decoding(self)?;
         validate::validate_model(&self.inner.model)?;
 
         // Validate prompt and prompt_embeds together (checks presence, format, and content)

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -450,6 +450,7 @@ impl OpenAIOutputOptionsProvider for NvCreateCompletionRequest {
 impl ValidateRequest for NvCreateCompletionRequest {
     fn validate(&self) -> Result<(), anyhow::Error> {
         validate::validate_no_unsupported_fields(&self.unsupported_fields)?;
+        validate::validate_guided_decoding(self)?;
         validate::validate_model(&self.inner.model)?;
 
         // Validate prompt and prompt_embeds together (checks presence, format, and content)

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -7,7 +7,9 @@ use dynamo_runtime::config::{
     env_is_truthy, environment_names::llm::DYN_IGNORE_OPENAI_FE_UNSUPPORTED_FIELDS,
 };
 
+use super::common_ext::CommonExtProvider;
 use super::tools::{ToolChoiceError, validate_openai_tool_choice};
+use crate::protocols::common::GuidedDecodingOptions;
 
 //
 // Hyperparameter Contraints
@@ -900,6 +902,31 @@ pub fn validate_chat_only_generation_flags(
             "`add_generation_prompt` and `continue_final_message` are only supported on /v1/chat/completions"
         );
     }
+    Ok(())
+}
+
+/// Rejects a request that sets more than one guided-decoding constraint.
+///
+/// The conflict rule itself lives in [`GuidedDecodingOptions::validate`], reached here
+/// through `from_optional`, so this function adds no second copy of it. What it adds is
+/// the call at the request-validation boundary: every other field is checked here, where
+/// a failure becomes a 400 naming the problem, while guided decoding was checked only
+/// later inside `extract_sampling_options`. By that point the error is an untyped
+/// `anyhow` with nothing for the HTTP layer to branch on, so a malformed request was
+/// reported to the caller as `500 Internal Server Error`.
+///
+/// `structural_tag` has no `CommonExtProvider` getter, matching `extract_sampling_options`,
+/// which also passes `None` for it.
+pub fn validate_guided_decoding(request: &impl CommonExtProvider) -> Result<(), anyhow::Error> {
+    GuidedDecodingOptions::from_optional(
+        request.get_guided_json(),
+        request.get_guided_regex(),
+        request.get_guided_choice(),
+        request.get_guided_grammar(),
+        request.get_guided_decoding_backend(),
+        request.get_guided_whitespace_pattern(),
+        None,
+    )?;
     Ok(())
 }
 

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -7,9 +7,7 @@ use dynamo_runtime::config::{
     env_is_truthy, environment_names::llm::DYN_IGNORE_OPENAI_FE_UNSUPPORTED_FIELDS,
 };
 
-use super::common_ext::CommonExtProvider;
 use super::tools::{ToolChoiceError, validate_openai_tool_choice};
-use crate::protocols::common::GuidedDecodingOptions;
 
 //
 // Hyperparameter Contraints

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -7,9 +7,7 @@ use dynamo_runtime::config::{
     env_is_truthy, environment_names::llm::DYN_IGNORE_OPENAI_FE_UNSUPPORTED_FIELDS,
 };
 
-use super::common_ext::CommonExtProvider;
 use super::tools::{ToolChoiceError, validate_openai_tool_choice};
-use crate::protocols::common::GuidedDecodingOptions;
 
 //
 // Hyperparameter Contraints
@@ -902,31 +900,6 @@ pub fn validate_chat_only_generation_flags(
             "`add_generation_prompt` and `continue_final_message` are only supported on /v1/chat/completions"
         );
     }
-    Ok(())
-}
-
-/// Rejects a request that sets more than one guided-decoding constraint.
-///
-/// The conflict rule itself lives in [`GuidedDecodingOptions::validate`], reached here
-/// through `from_optional`, so this function adds no second copy of it. What it adds is
-/// the call at the request-validation boundary: every other field is checked here, where
-/// a failure becomes a 400 naming the problem, while guided decoding was checked only
-/// later inside `extract_sampling_options`. By that point the error is an untyped
-/// `anyhow` with nothing for the HTTP layer to branch on, so a malformed request was
-/// reported to the caller as `500 Internal Server Error`.
-///
-/// `structural_tag` has no `CommonExtProvider` getter, matching `extract_sampling_options`,
-/// which also passes `None` for it.
-pub fn validate_guided_decoding(request: &impl CommonExtProvider) -> Result<(), anyhow::Error> {
-    GuidedDecodingOptions::from_optional(
-        request.get_guided_json(),
-        request.get_guided_regex(),
-        request.get_guided_choice(),
-        request.get_guided_grammar(),
-        request.get_guided_decoding_backend(),
-        request.get_guided_whitespace_pattern(),
-        None,
-    )?;
     Ok(())
 }
 

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -7,7 +7,9 @@ use dynamo_runtime::config::{
     env_is_truthy, environment_names::llm::DYN_IGNORE_OPENAI_FE_UNSUPPORTED_FIELDS,
 };
 
+use super::common_ext::CommonExtProvider;
 use super::tools::{ToolChoiceError, validate_openai_tool_choice};
+use crate::protocols::common::GuidedDecodingOptions;
 
 //
 // Hyperparameter Contraints

--- a/lib/llm/tests/chat_template_render_errors.rs
+++ b/lib/llm/tests/chat_template_render_errors.rs
@@ -1,11 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! End-to-end coverage for chat template rendering failures over HTTP.
+//! End-to-end coverage for preprocessor-raised client errors over HTTP.
 //!
 //! Rendering only consumes the request, so a template that refuses to render is a client
 //! error: the frontend must answer 400 with a JSON body on both the streaming and the
 //! non-streaming path, and must not reject inputs the model's own template accepts.
+//!
+//! Guided-decoding conflicts are the same class. Both are raised inside
+//! `OpenAIPreprocessor` and typed `InvalidArgument`, and both depend on that type
+//! surviving the operator chain to reach `ErrorMessage::from_anyhow`. Unit tests that
+//! call `extract_sampling_options` and `from_anyhow` directly pin the two ends and not
+//! the pipeline between them, so a `map_err` anywhere in the middle that rebuilds the
+//! error with `anyhow!("{e}")` would drop the source chain and silently restore the 500.
 
 use std::sync::Arc;
 
@@ -221,6 +228,25 @@ impl TestService {
             .expect("POST /v1/chat/completions failed")
     }
 
+    async fn post_conflicting_guided_decoding(&self, stream: bool) -> reqwest::Response {
+        self.client
+            .post(format!(
+                "http://127.0.0.1:{}/v1/chat/completions",
+                self.port
+            ))
+            .json(&serde_json::json!({
+                "model": ACCEPTING_MODEL,
+                "stream": stream,
+                "max_tokens": 1,
+                "messages": [{"role": "user", "content": "hi"}],
+                "guided_json": {"type": "object"},
+                "guided_regex": "a+"
+            }))
+            .send()
+            .await
+            .expect("POST /v1/chat/completions failed")
+    }
+
     async fn shutdown(self) {
         self.cancel.cancel();
         self.join
@@ -274,6 +300,42 @@ async fn assistant_only_history_succeeds_when_template_accepts_it() {
     assert_eq!(response.status(), StatusCode::OK);
     let body: serde_json::Value = response.json().await.expect("response body was not JSON");
     assert_eq!(body["choices"][0]["message"]["content"], "ok", "{body}");
+
+    service.shutdown().await;
+}
+
+#[tokio::test]
+async fn guided_decoding_conflict_returns_400_json_not_sse() {
+    let service = TestService::start().await;
+
+    // The model's template accepts this message list, so the only thing that can fail is
+    // the guided-decoding conflict, raised while the preprocessor builds sampling options.
+    for stream in [false, true] {
+        let response = service.post_conflicting_guided_decoding(stream).await;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "stream={stream}"
+        );
+        assert_eq!(
+            response.headers().get(reqwest::header::CONTENT_TYPE),
+            Some(&reqwest::header::HeaderValue::from_static(
+                "application/json"
+            )),
+            "stream={stream}"
+        );
+
+        let body: serde_json::Value = response.json().await.expect("error body was not JSON");
+        assert_eq!(body["code"], 400, "stream={stream}");
+        // Naming the conflicting fields is the point: the caller has to be able to tell
+        // which options collided, and the schema must not be echoed back into the body.
+        assert_eq!(
+            body["message"],
+            "Only one guided-decoding constraint can be set; received: json, regex",
+            "stream={stream}, body={body}"
+        );
+    }
 
     service.shutdown().await;
 }


### PR DESCRIPTION
#### Overview:

This PR makes a request that sets two guided-decoding options at once fail with `400 Bad Request` naming the conflict, instead of `500 Internal Server Error`. Affects all models and all backends — it is request validation, not model-specific. Callers currently cannot tell their own malformed request from a server outage, and a 500 tends to trigger retry and alerting paths for a request that will never succeed.

#### Example (before → after):

Input: `{"guided_json": {"type": "object"}, "guided_regex": "a+"}` on `/v1/chat/completions`

```
before:  HTTP 500  {"message":"Failed to generate completions","type":"Internal Server Error","code":500}
after:   HTTP 400  "Only one of json, regex, choice, grammar, or structural_tag can be set, but multiple are specified: ..."
```

The frontend already diagnosed this correctly in its own logs and then lost the diagnosis on the way out.

#### Details:

- Dynamo already validates ~30 request fields at a boundary that returns 400 (`ValidateRequest::validate`, mapped by `validate_chat_completion_fields_generic`). Guided decoding was the one field not checked there — its conflict rule only ran later inside `extract_sampling_options`, past the point where a caller error is still distinguishable from an internal fault. This adds the missing call; it reuses `GuidedDecodingOptions::from_optional`, so there is no second copy of the rule and the caller now gets the exact reason text that was already being logged.
- `extract_sampling_options` also returns a typed `InvalidArgument` now, so entry points that build sampling options without passing through HTTP validation get the same mapping.
- `whitespace_pattern` no longer counts toward the conflict rule. It was counted, so `guided_json` + `guided_whitespace_pattern` was rejected -- but the struct doc says "Only one of `json`, `regex`, `choice`, or `grammar`", the error text never names `whitespace_pattern`, and `components/src/dynamo/frontend/prepost.py` builds that exact pair on purpose. `whitespace_pattern` modifies how a grammar is applied rather than being a grammar, which is why `backend` was already excluded from the same count; it now follows `backend`. This matters here specifically because turning the late 500 into an authoritative 400 would have made a legitimate request fail harder.
- Two tests: three conflicting pairs must fail validation with the reason named, and six single-constraint requests -- including `guided_json` and `guided_regex` each paired with `guided_whitespace_pattern` -- must stay valid.

#### Validation:

`cargo test -p dynamo-llm --lib` — 2354 passed, 0 failed. Verified red before green twice: with the new `validate_guided_decoding` call removed, the conflict test fails; and with `whitespace_pattern` put back into the exclusivity count, the single-constraint test fails on `guided_json` + `guided_whitespace_pattern`. Both pass restored. Note `kv_router::...::direct_zmq_multi_node_replacement_isolated_by_global_rank` is flaky in parallel runs at roughly the same rate on this branch and on unmodified `main` (2/6 runs on `main`), so it is pre-existing and untouched here.

#### Where should the reviewer start?

`lib/llm/src/protocols/openai/validate.rs`, then `lib/llm/src/protocols/openai.rs`

/coderabbit profile chill

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for guided-decoding settings across chat and completion requests.
  * Conflicting or invalid guided-decoding options now return clear invalid-argument errors.
  * Requests using exactly one supported guided-decoding option are accepted correctly.
  * Validation now checks guided-decoding configuration before model and prompt details, providing more consistent error reporting.

* **Tests**
  * Added coverage for conflicting options, supported configurations, backend settings, and whitespace settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
