### PR TITLE
fix(llm): preserve length finish reason on truncated tool calls

### DIFF
--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -386,7 +386,7 @@ impl AnthropicStreamConverter {
                         AnthropicStopReason::ToolUse
                     }
                     dynamo_protocols::types::FinishReason::ContentFilter => {
-                        AnthropicStopReason::EndTurn
+                        AnthropicStopReason::Refusal
                     }
                     dynamo_protocols::types::FinishReason::FunctionCall => {
                         AnthropicStopReason::ToolUse
@@ -693,7 +693,7 @@ impl AnthropicStreamConverter {
                         AnthropicStopReason::ToolUse
                     }
                     dynamo_protocols::types::FinishReason::ContentFilter => {
-                        AnthropicStopReason::EndTurn
+                        AnthropicStopReason::Refusal
                     }
                     dynamo_protocols::types::FinishReason::FunctionCall => {
                         AnthropicStopReason::ToolUse

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -178,11 +178,17 @@ impl AnthropicStreamConverter {
         let mut events = Vec::new();
         let mut block_index = self.next_block_index;
 
-        for tool_call in &self.tool_call_states {
-            if !tool_call.is_emit_ready() {
-                continue;
-            }
+        // Only the token limit cuts a call short, and it does so once, in the last
+        // call. Mirrors `chat_completion_to_anthropic_response`.
+        let truncated = self.stop_reason == Some(AnthropicStopReason::MaxTokens);
+        let ready: Vec<&ToolCallState> = self
+            .tool_call_states
+            .iter()
+            .filter(|tool_call| tool_call.is_emit_ready())
+            .collect();
+        let last_call = ready.len().saturating_sub(1);
 
+        for (call_index, tool_call) in ready.into_iter().enumerate() {
             let emitted_id = new_tool_use_id();
             tracing::debug!(
                 backend_id = %tool_call.backend_id,
@@ -202,17 +208,47 @@ impl AnthropicStreamConverter {
                 None,
             ));
 
-            for (arguments, usage_snapshot) in &tool_call.argument_fragments {
+            // A client rebuilds `input` by concatenating these fragments, so a
+            // truncated call leaves it holding JSON that never parses. Send the same
+            // repaired object the batch converter returns instead, so one generation
+            // does not yield different arguments depending on `stream`.
+            let raw: String = tool_call
+                .argument_fragments
+                .iter()
+                .map(|(arguments, _)| arguments.as_str())
+                .collect();
+            let repaired = (truncated
+                && call_index == last_call
+                && serde_json::from_str::<serde_json::Value>(&raw).is_err())
+            .then(|| super::types::tool_use_input(&tool_call.name, &raw, true));
+
+            if let Some(input) = repaired {
                 events.push((
                     "content_block_delta",
                     AnthropicStreamEvent::ContentBlockDelta {
                         index: block_index,
                         delta: AnthropicDelta::InputJsonDelta {
-                            partial_json: arguments.clone(),
+                            partial_json: input.to_string(),
                         },
                     },
-                    Some(usage_snapshot.clone()),
+                    tool_call
+                        .argument_fragments
+                        .last()
+                        .map(|(_, usage)| usage.clone()),
                 ));
+            } else {
+                for (arguments, usage_snapshot) in &tool_call.argument_fragments {
+                    events.push((
+                        "content_block_delta",
+                        AnthropicStreamEvent::ContentBlockDelta {
+                            index: block_index,
+                            delta: AnthropicDelta::InputJsonDelta {
+                                partial_json: arguments.clone(),
+                            },
+                        },
+                        Some(usage_snapshot.clone()),
+                    ));
+                }
             }
 
             events.push((
@@ -1376,6 +1412,63 @@ mod tests {
                 ..
             } if partial_json == "{}"
         ));
+    }
+
+    /// Concatenate every `input_json_delta` fragment, which is what an Anthropic
+    /// client does to rebuild `tool_use.input`.
+    fn streamed_tool_input(events: &[TaggedEvent]) -> String {
+        events
+            .iter()
+            .filter_map(|event| match &event.data {
+                AnthropicStreamEvent::ContentBlockDelta {
+                    delta: AnthropicDelta::InputJsonDelta { partial_json },
+                    ..
+                } => Some(partial_json.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The batch converter repairs a call cut off at the token limit into the members
+    /// that finished. The stream must rebuild the same input. Otherwise one generation
+    /// yields different tool arguments depending on `stream`.
+    #[test]
+    fn test_truncated_tool_arguments_match_the_batch_conversion() {
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+
+        let mut tagged = conv.process_chunk_tagged(&tool_call_chunk(
+            0,
+            Some("call-1"),
+            Some("record_literal"),
+            Some(r#"{"label": "customer-eof", "literal_text": "cust"#),
+        ));
+        tagged.extend(conv.process_chunk_tagged(&finish_chunk(FinishReason::Length)));
+        tagged.extend(conv.emit_end_events_tagged());
+
+        let streamed = streamed_tool_input(&tagged);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&streamed).ok(),
+            Some(serde_json::json!({"label": "customer-eof"})),
+            "streamed input must match the batch conversion, got: {streamed}"
+        );
+    }
+
+    /// The guard on the rule above. A call that parses is sent verbatim, fragment by
+    /// fragment, whatever ended generation.
+    #[test]
+    fn test_complete_tool_arguments_are_streamed_verbatim() {
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+
+        let mut tagged = conv.process_chunk_tagged(&tool_call_chunk(
+            0,
+            Some("call-1"),
+            Some("record_literal"),
+            Some(r#"{"label": "done"}"#),
+        ));
+        tagged.extend(conv.process_chunk_tagged(&finish_chunk(FinishReason::Length)));
+        tagged.extend(conv.emit_end_events_tagged());
+
+        assert_eq!(streamed_tool_input(&tagged), r#"{"label": "done"}"#);
     }
 
     /// Buffered tool-argument fragments must carry the usage snapshot from their

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -570,7 +570,16 @@ pub(super) fn new_tool_use_id() -> String {
 /// This replaces `unwrap_or(json!({}))`, which turned any unparseable arguments
 /// into a well-formed EMPTY object. That produced a `tool_use` block a client would
 /// happily execute with no arguments and no error anywhere in the response.
-fn tool_use_input(tool_name: &str, arguments: &str) -> serde_json::Value {
+///
+/// `truncated` gates that recovery, and it is what keeps this honest. Partial members
+/// are only safe to emit when something ELSE in the response already tells the client
+/// the call is incomplete, which is exactly `stop_reason: "max_tokens"`. When the
+/// upstream reason instead claims the call finished, malformed arguments mean the
+/// generation is wrong rather than cut short: emitting the members that happen to parse
+/// would hand back a call that looks complete, carries only some of its arguments, and
+/// reports no error anywhere. That is worse than the empty object, because a partial
+/// call can pass schema validation and then run.
+fn tool_use_input(tool_name: &str, arguments: &str, truncated: bool) -> serde_json::Value {
     match serde_json::from_str::<serde_json::Value>(arguments) {
         Ok(value) => return value,
         Err(error) => {
@@ -582,6 +591,17 @@ fn tool_use_input(tool_name: &str, arguments: &str) -> serde_json::Value {
                  completed. Check `stop_reason` — `max_tokens` means the call was truncated"
             );
         }
+    }
+
+    if !truncated {
+        tracing::warn!(
+            tool_name = %tool_name,
+            argument_bytes = arguments.len(),
+            "tool call arguments are malformed but generation was not cut off; emitting an \
+             empty tool_use input rather than a partial one, because the response claims \
+             this call completed"
+        );
+        return serde_json::json!({});
     }
 
     match recover_completed_members(arguments) {
@@ -687,6 +707,13 @@ pub fn chat_completion_to_anthropic_response(
     let mut stop_reason = None;
 
     if let Some(choice) = choice {
+        // Only the token limit means "cut off mid-call". Every other terminal reason
+        // claims the call finished, so partial arguments must not be recovered under it.
+        let truncated = matches!(
+            choice.finish_reason,
+            Some(dynamo_protocols::types::FinishReason::Length)
+        );
+
         // Map finish_reason
         stop_reason = choice.finish_reason.map(|fr| match fr {
             dynamo_protocols::types::FinishReason::Stop => AnthropicStopReason::EndTurn,
@@ -699,7 +726,7 @@ pub fn chat_completion_to_anthropic_response(
         // Extract tool calls
         if let Some(tool_calls) = choice.message.tool_calls {
             for tc in tool_calls {
-                let input = tool_use_input(&tc.function.name, &tc.function.arguments);
+                let input = tool_use_input(&tc.function.name, &tc.function.arguments, truncated);
                 let emitted_id = new_tool_use_id();
                 tracing::debug!(
                     backend_id = %tc.id,
@@ -2440,8 +2467,113 @@ mod tests {
 }
 
 #[cfg(test)]
-mod dis2780_tests {
+mod truncated_tool_call_tests {
     use super::*;
+
+    /// Build a one-choice response carrying a single tool call with the given
+    /// finish reason and raw argument text, and return the Anthropic `input` it
+    /// converts to.
+    #[allow(deprecated)]
+    fn converted_tool_use_input(
+        finish_reason: dynamo_protocols::types::FinishReason,
+        arguments: &str,
+    ) -> serde_json::Value {
+        let chat_resp = NvCreateChatCompletionResponse {
+            inner: dynamo_protocols::types::CreateChatCompletionResponse {
+                id: "chatcmpl-wiring".into(),
+                choices: vec![dynamo_protocols::types::ChatChoice {
+                    index: 0,
+                    message: dynamo_protocols::types::ChatCompletionResponseMessage {
+                        content: None,
+                        refusal: None,
+                        tool_calls: Some(vec![
+                            dynamo_protocols::types::ChatCompletionMessageToolCall {
+                                id: "call_1".into(),
+                                r#type: dynamo_protocols::types::FunctionType::Function,
+                                function: dynamo_protocols::types::FunctionCall {
+                                    name: "record_literal".into(),
+                                    arguments: arguments.to_string(),
+                                },
+                            },
+                        ]),
+                        role: dynamo_protocols::types::Role::Assistant,
+                        function_call: None,
+                        audio: None,
+                        reasoning_content: None,
+                    },
+                    finish_reason: Some(finish_reason),
+                    logprobs: None,
+                }],
+                created: 1726000000,
+                model: "test-model".into(),
+                service_tier: None,
+                system_fingerprint: None,
+                object: "chat.completion".to_string(),
+                usage: None,
+            },
+            nvext: None,
+        };
+
+        let response = chat_completion_to_anthropic_response(chat_resp, "test-model", None);
+        match response
+            .content
+            .into_iter()
+            .find(|block| matches!(block, AnthropicResponseContentBlock::ToolUse { .. }))
+        {
+            Some(AnthropicResponseContentBlock::ToolUse { input, .. }) => input,
+            other => panic!("expected a tool_use block, got: {other:?}"),
+        }
+    }
+
+    /// Pins the WIRING, not the helper. The eight helper tests below all call
+    /// `tool_use_input` directly, so reverting the conversion site to the old
+    /// `unwrap_or(json!({}))` left every one of them green. This one goes red,
+    /// because it reaches the recovery only through `chat_completion_to_anthropic_response`.
+    #[test]
+    fn the_conversion_recovers_members_when_the_reason_is_the_token_limit() {
+        assert_eq!(
+            converted_tool_use_input(dynamo_protocols::types::FinishReason::Length, TRUNCATED),
+            serde_json::json!({"label": "customer-eof"}),
+            "a call cut off at the token limit must keep the members that finished"
+        );
+    }
+
+    /// The guard on the rule above. When the upstream reason says the call FINISHED,
+    /// malformed arguments are a generation defect, not a truncation. Recovering members
+    /// there would emit a call that looks complete while silently carrying only some of
+    /// its arguments -- one a client can validate and then run. The empty object is the
+    /// honest answer, because it fails the tool's schema instead of half-succeeding.
+    #[test]
+    fn the_conversion_refuses_partial_arguments_when_the_call_claims_it_finished() {
+        for reason in [
+            dynamo_protocols::types::FinishReason::ToolCalls,
+            dynamo_protocols::types::FinishReason::Stop,
+            dynamo_protocols::types::FinishReason::ContentFilter,
+            dynamo_protocols::types::FinishReason::FunctionCall,
+        ] {
+            assert_eq!(
+                converted_tool_use_input(reason, TRUNCATED),
+                serde_json::json!({}),
+                "{reason:?} claims the call completed, so partial arguments must not be emitted"
+            );
+        }
+    }
+
+    /// Valid arguments are untouched no matter which reason ended generation.
+    #[test]
+    fn the_conversion_passes_valid_arguments_through_for_every_reason() {
+        for reason in [
+            dynamo_protocols::types::FinishReason::Length,
+            dynamo_protocols::types::FinishReason::ToolCalls,
+            dynamo_protocols::types::FinishReason::Stop,
+        ] {
+            assert_eq!(
+                converted_tool_use_input(reason, r#"{"label": "done"}"#),
+                serde_json::json!({"label": "done"}),
+                "valid arguments must survive {reason:?} unchanged"
+            );
+        }
+    }
 
     /// The measured payload: `record_literal` cut off inside the second
     /// argument's string value. `label` finished, `literal_text` did not.
@@ -2450,7 +2582,7 @@ mod dis2780_tests {
 
     #[test]
     fn truncated_arguments_keep_the_members_that_completed() {
-        let input = tool_use_input("record_literal", TRUNCATED);
+        let input = tool_use_input("record_literal", TRUNCATED, true);
         let obj = input.as_object().expect("input must stay an object");
 
         // The finished member survives verbatim.
@@ -2471,7 +2603,7 @@ mod dis2780_tests {
     #[test]
     fn truncated_arguments_are_not_silently_emptied() {
         assert_ne!(
-            tool_use_input("record_literal", TRUNCATED),
+            tool_use_input("record_literal", TRUNCATED, true),
             serde_json::json!({}),
             "unparseable arguments must not collapse to an empty object"
         );
@@ -2479,7 +2611,7 @@ mod dis2780_tests {
 
     #[test]
     fn valid_arguments_are_passed_through_unchanged() {
-        let input = tool_use_input("get_weather", r#"{"location": "SF", "unit": "c"}"#);
+        let input = tool_use_input("get_weather", r#"{"location": "SF", "unit": "c"}"#, true);
         assert_eq!(input, serde_json::json!({"location": "SF", "unit": "c"}));
     }
 
@@ -2498,7 +2630,7 @@ mod dis2780_tests {
 
         // Same shape reached through the public entry point.
         assert_eq!(
-            tool_use_input("record_literal", r#"{"label": "customer-eof""#),
+            tool_use_input("record_literal", r#"{"label": "customer-eof""#, true),
             serde_json::json!({"label": "customer-eof"})
         );
 

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -554,6 +554,91 @@ pub(super) fn new_tool_use_id() -> String {
     format!("toolu_{}", Uuid::new_v4().simple())
 }
 
+/// Decide what an Anthropic `tool_use` block shows for a call whose `arguments` do not
+/// parse, which happens when generation was cut off mid-call at the token limit.
+///
+/// Anthropic's `input` is a typed object, so it cannot carry the raw truncated bytes the
+/// way OpenAI's string-valued `arguments` does. The signal that the call is incomplete
+/// lives in `stop_reason: "max_tokens"` — the value Anthropic's own guidance tells
+/// clients to check before acting on a trailing `tool_use` block — so this function only
+/// decides how much of the call survives in the block.
+///
+/// It keeps the members the model finished writing and drops the one it was still
+/// writing. Nothing is invented: a truncated value is discarded rather than closed with a
+/// guessed quote or brace, so the block never reports a value the model did not emit.
+///
+/// This replaces `unwrap_or(json!({}))`, which turned any unparseable arguments
+/// into a well-formed EMPTY object. That produced a `tool_use` block a client would
+/// happily execute with no arguments and no error anywhere in the response.
+fn tool_use_input(tool_name: &str, arguments: &str) -> serde_json::Value {
+    match serde_json::from_str::<serde_json::Value>(arguments) {
+        Ok(value) => return value,
+        Err(error) => {
+            tracing::warn!(
+                tool_name = %tool_name,
+                argument_bytes = arguments.len(),
+                error = %error,
+                "tool call arguments are not valid JSON; recovering the members that \
+                 completed. Check `stop_reason` — `max_tokens` means the call was truncated"
+            );
+        }
+    }
+
+    match recover_completed_members(arguments) {
+        Some(map) => serde_json::Value::Object(map),
+        None => {
+            tracing::warn!(
+                tool_name = %tool_name,
+                argument_bytes = arguments.len(),
+                "no complete argument member survived; emitting an empty tool_use input"
+            );
+            serde_json::json!({})
+        }
+    }
+}
+
+/// Return the members of a truncated JSON object that finished, or `None` when none did.
+///
+/// One forward scan tracking string and nesting state, recording the offset of every
+/// top-level `,`. Each such comma is a point where the object was syntactically whole, so
+/// the text before it plus a closing brace is valid JSON built only from bytes the model
+/// actually produced. The last such point is the most that can be recovered.
+///
+/// Returns `None` for a non-object payload, and for an object truncated before its first
+/// member closed — there is nothing to recover, and guessing would invent content.
+fn recover_completed_members(raw: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
+    let trimmed = raw.trim_start();
+    if !trimmed.starts_with('{') {
+        return None;
+    }
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut last_boundary: Option<usize> = None;
+
+    for (index, ch) in trimmed.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' if in_string => escaped = true,
+            '"' => in_string = !in_string,
+            _ if in_string => {}
+            '{' | '[' => depth += 1,
+            '}' | ']' => depth -= 1,
+            // A top-level comma separates two members, so everything before it is a
+            // complete member list. Depth is 1 while inside the object's own braces.
+            ',' if depth == 1 => last_boundary = Some(index),
+            _ => {}
+        }
+    }
+
+    let boundary = last_boundary?;
+    let candidate = format!("{}}}", &trimmed[..boundary]);
+    serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&candidate).ok()
+}
+
 /// Convert a completed chat completion response into an Anthropic Messages response.
 pub fn chat_completion_to_anthropic_response(
     chat_resp: NvCreateChatCompletionResponse,
@@ -580,8 +665,7 @@ pub fn chat_completion_to_anthropic_response(
         // Extract tool calls
         if let Some(tool_calls) = choice.message.tool_calls {
             for tc in tool_calls {
-                let input: serde_json::Value =
-                    serde_json::from_str(&tc.function.arguments).unwrap_or(serde_json::json!({}));
+                let input = tool_use_input(&tc.function.name, &tc.function.arguments);
                 let emitted_id = new_tool_use_id();
                 tracing::debug!(
                     backend_id = %tc.id,
@@ -2318,5 +2402,94 @@ mod tests {
             &chat_req.inner.messages[3],
             ChatCompletionRequestMessage::Tool(_)
         ));
+    }
+}
+
+#[cfg(test)]
+mod dis2780_tests {
+    use super::*;
+
+    /// The measured payload: `record_literal` cut off inside the second
+    /// argument's string value. `label` finished, `literal_text` did not.
+    const TRUNCATED: &str =
+        r#"{"label": "customer-eof", "literal_text": "customer-eof-xxxxxxxxxxxxxxxxxxxx"#;
+
+    #[test]
+    fn truncated_arguments_keep_the_members_that_completed() {
+        let input = tool_use_input("record_literal", TRUNCATED);
+        let obj = input.as_object().expect("input must stay an object");
+
+        // The finished member survives verbatim.
+        assert_eq!(
+            obj.get("label").and_then(|v| v.as_str()),
+            Some("customer-eof")
+        );
+        // The member still being written is dropped rather than closed with a guess.
+        assert!(
+            !obj.contains_key("literal_text"),
+            "a truncated value must not be reported, got: {input}"
+        );
+        assert_eq!(obj.len(), 1);
+    }
+
+    /// The defect this replaced: every unparseable payload became `{}`, so a client
+    /// received a well-formed tool_use block and executed it with no arguments.
+    #[test]
+    fn truncated_arguments_are_not_silently_emptied() {
+        assert_ne!(
+            tool_use_input("record_literal", TRUNCATED),
+            serde_json::json!({}),
+            "unparseable arguments must not collapse to an empty object"
+        );
+    }
+
+    #[test]
+    fn valid_arguments_are_passed_through_unchanged() {
+        let input = tool_use_input("get_weather", r#"{"location": "SF", "unit": "c"}"#);
+        assert_eq!(input, serde_json::json!({"location": "SF", "unit": "c"}));
+    }
+
+    #[test]
+    fn nothing_is_recovered_before_the_first_member_closes() {
+        // Truncated inside the FIRST value: no member ever completed, so there is
+        // nothing to show and inventing one would fabricate an argument.
+        assert_eq!(recover_completed_members(r#"{"label": "customer-eo"#), None);
+        assert_eq!(recover_completed_members("{"), None);
+        assert_eq!(recover_completed_members(""), None);
+        // Not an object at all.
+        assert_eq!(recover_completed_members(r#"["a", "b""#), None);
+    }
+
+    #[test]
+    fn commas_inside_strings_and_nested_values_are_not_member_boundaries() {
+        // A comma inside a string value must not be mistaken for a member boundary.
+        let raw = r#"{"a": "x, y", "b": "unterminated"#;
+        let recovered = recover_completed_members(raw).expect("`a` completed");
+        assert_eq!(recovered.get("a").and_then(|v| v.as_str()), Some("x, y"));
+        assert_eq!(recovered.len(), 1);
+
+        // A comma inside a nested object or array belongs to that value, not the
+        // top-level member list.
+        let raw = r#"{"a": {"p": 1, "q": 2}, "b": [1, 2], "c": "cut"#;
+        let recovered = recover_completed_members(raw).expect("`a` and `b` completed");
+        assert_eq!(
+            recovered.get("a"),
+            Some(&serde_json::json!({"p": 1, "q": 2}))
+        );
+        assert_eq!(recovered.get("b"), Some(&serde_json::json!([1, 2])));
+        assert!(!recovered.contains_key("c"));
+    }
+
+    #[test]
+    fn escaped_quotes_do_not_end_the_string() {
+        // The `\"` must not be read as closing the value, which would make the
+        // following comma look like a top-level boundary.
+        let raw = r#"{"a": "he said \"hi\", ok", "b": "cut"#;
+        let recovered = recover_completed_members(raw).expect("`a` completed");
+        assert_eq!(
+            recovered.get("a").and_then(|v| v.as_str()),
+            Some(r#"he said "hi", ok"#)
+        );
+        assert_eq!(recovered.len(), 1);
     }
 }

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -634,9 +634,43 @@ fn recover_completed_members(raw: &str) -> Option<serde_json::Map<String, serde_
         }
     }
 
+    // Truncation can land after a member's value but before the outer `}`, in which
+    // case there is no trailing comma and the comma scan finds nothing — yet every
+    // member present did finish. Close the object and take it, but only when the last
+    // value is provably complete (see `ends_on_a_finished_value`).
+    if ends_on_a_finished_value(trimmed)
+        && let Ok(map) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(
+            &format!("{}}}", trimmed.trim_end()),
+        )
+    {
+        return Some(map);
+    }
+
     let boundary = last_boundary?;
     let candidate = format!("{}}}", &trimmed[..boundary]);
     serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&candidate).ok()
+}
+
+/// Whether the payload's last value is one that cannot have been cut short.
+///
+/// Appending `}` to a truncated object can turn an unfinished value into a plausible
+/// finished one. `{"n": 25` cut to `{"n": 2` closes into `{"n": 2}`, reporting an
+/// argument the model never emitted — the exact fabrication this module refuses to do.
+/// A closing quote, brace or bracket is different: those characters only appear once the
+/// value is over, so a payload ending in one has no half-written tail. Bare numbers and
+/// bare literals are ambiguous by construction and fall through to the comma scan.
+fn ends_on_a_finished_value(trimmed: &str) -> bool {
+    let tail = trimmed.trim_end();
+    // A closing quote must not itself be escaped, or the string is still open.
+    if tail.ends_with('"') {
+        let backslashes = tail[..tail.len() - 1]
+            .chars()
+            .rev()
+            .take_while(|ch| *ch == '\\')
+            .count();
+        return backslashes % 2 == 0;
+    }
+    tail.ends_with('}') || tail.ends_with(']')
 }
 
 /// Convert a completed chat completion response into an Anthropic Messages response.
@@ -2447,6 +2481,53 @@ mod dis2780_tests {
     fn valid_arguments_are_passed_through_unchanged() {
         let input = tool_use_input("get_weather", r#"{"location": "SF", "unit": "c"}"#);
         assert_eq!(input, serde_json::json!({"location": "SF", "unit": "c"}));
+    }
+
+    /// Truncation after a member value but before the closing brace. There is no
+    /// trailing comma, so the comma scan alone finds nothing, yet `label` did finish.
+    /// Returning `{}` here would be the empty-object failure this module exists to stop.
+    #[test]
+    fn a_final_member_without_a_trailing_comma_is_recovered() {
+        let recovered =
+            recover_completed_members(r#"{"label": "customer-eof""#).expect("`label` completed");
+        assert_eq!(
+            recovered.get("label").and_then(|v| v.as_str()),
+            Some("customer-eof")
+        );
+        assert_eq!(recovered.len(), 1);
+
+        // Same shape reached through the public entry point.
+        assert_eq!(
+            tool_use_input("record_literal", r#"{"label": "customer-eof""#),
+            serde_json::json!({"label": "customer-eof"})
+        );
+
+        // A closed nested value is equally provably finished.
+        let recovered =
+            recover_completed_members(r#"{"a": 1, "b": {"p": 2}"#).expect("`a` and `b` completed");
+        assert_eq!(recovered.get("b"), Some(&serde_json::json!({"p": 2})));
+        assert_eq!(recovered.len(), 2);
+    }
+
+    /// The guard on the case above: closing the brace after a BARE NUMBER would invent a
+    /// value, because the digits may themselves be truncated. `{"n": 25` cut to `{"n": 2`
+    /// must not be reported as `n = 2`.
+    #[test]
+    fn a_truncated_number_is_never_closed_into_a_value() {
+        assert_eq!(recover_completed_members(r#"{"n": 2"#), None);
+
+        // With an earlier complete member, fall back to the comma boundary and drop the
+        // ambiguous tail rather than reporting it.
+        let recovered = recover_completed_members(r#"{"a": "x", "n": 2"#).expect("`a` completed");
+        assert_eq!(recovered.get("a").and_then(|v| v.as_str()), Some("x"));
+        assert!(
+            !recovered.contains_key("n"),
+            "a possibly-truncated number must not be reported, got: {recovered:?}"
+        );
+
+        // An escaped quote at the very end leaves the string open; it is not a finished
+        // value and must not be closed either.
+        assert_eq!(recover_completed_members(r#"{"a": "he said \""#), None);
     }
 
     #[test]

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -662,8 +662,8 @@ fn recover_completed_members(raw: &str) -> Option<serde_json::Map<String, serde_
 fn ends_on_a_finished_value(trimmed: &str) -> bool {
     let tail = trimmed.trim_end();
     // A closing quote must not itself be escaped, or the string is still open.
-    if tail.ends_with('"') {
-        let backslashes = tail[..tail.len() - 1]
+    if let Some(before_quote) = tail.strip_suffix('"') {
+        let backslashes = before_quote
             .chars()
             .rev()
             .take_while(|ch| *ch == '\\')

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -584,37 +584,44 @@ pub(super) fn tool_use_input(
     arguments: &str,
     truncated: bool,
 ) -> serde_json::Value {
-    match serde_json::from_str::<serde_json::Value>(arguments) {
+    // One warning per call, logged where the outcome is known. Logging before the
+    // `truncated` check would announce a recovery that the branch below may refuse.
+    let error = match serde_json::from_str::<serde_json::Value>(arguments) {
         Ok(value) => return value,
-        Err(error) => {
-            tracing::warn!(
-                tool_name = %tool_name,
-                argument_bytes = arguments.len(),
-                error = %error,
-                "tool call arguments are not valid JSON; recovering the members that \
-                 completed. Check `stop_reason` — `max_tokens` means the call was truncated"
-            );
-        }
-    }
+        Err(error) => error,
+    };
 
     if !truncated {
         tracing::warn!(
             tool_name = %tool_name,
             argument_bytes = arguments.len(),
-            "tool call arguments are malformed but generation was not cut off; emitting an \
-             empty tool_use input rather than a partial one, because the response claims \
+            error = %error,
+            "tool call arguments are not valid JSON and generation was not cut off; emitting \
+             an empty tool_use input rather than a partial one, because the response claims \
              this call completed"
         );
         return serde_json::json!({});
     }
 
     match recover_completed_members(arguments) {
-        Some(map) => serde_json::Value::Object(map),
+        Some(map) => {
+            tracing::warn!(
+                tool_name = %tool_name,
+                argument_bytes = arguments.len(),
+                recovered_members = map.len(),
+                error = %error,
+                "tool call arguments were cut off at the token limit; keeping the members \
+                 that completed. `stop_reason` is `max_tokens`"
+            );
+            serde_json::Value::Object(map)
+        }
         None => {
             tracing::warn!(
                 tool_name = %tool_name,
                 argument_bytes = arguments.len(),
-                "no complete argument member survived; emitting an empty tool_use input"
+                error = %error,
+                "tool call arguments were cut off at the token limit and no complete member \
+                 survived; emitting an empty tool_use input"
             );
             serde_json::json!({})
         }
@@ -680,9 +687,16 @@ fn recover_completed_members(raw: &str) -> Option<serde_json::Map<String, serde_
 /// Appending `}` to a truncated object can turn an unfinished value into a plausible
 /// finished one. `{"n": 25` cut to `{"n": 2` closes into `{"n": 2}`, reporting an
 /// argument the model never emitted — the exact fabrication this module refuses to do.
-/// A closing quote, brace or bracket is different: those characters only appear once the
-/// value is over, so a payload ending in one has no half-written tail. Bare numbers and
-/// bare literals are ambiguous by construction and fall through to the comma scan.
+///
+/// Four tails prove the value is over:
+/// - trailing whitespace. JSON allows it only between tokens, so the value before it
+///   ended. This also covers a complete number.
+/// - an unescaped closing quote. It appears only once the string is over.
+/// - `}` or `]`. They appear only once the object or array is over.
+/// - `true`, `false` or `null`. No longer JSON token starts with one of them.
+///
+/// Only a bare number with nothing after it stays ambiguous, because its own digits may
+/// be cut short. It falls through to the comma scan.
 fn ends_on_a_finished_value(trimmed: &str) -> bool {
     let tail = trimmed.trim_end();
     // Whitespace cannot occur inside a JSON number or literal. Let the normal

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -720,6 +720,8 @@ pub fn chat_completion_to_anthropic_response(
     if let Some(choice) = choice {
         // Only the token limit means "cut off mid-call". Every other terminal reason
         // claims the call finished, so partial arguments must not be recovered under it.
+        // This describes the choice; the call loop below narrows it to the last call,
+        // which is the only one the limit can have interrupted.
         let truncated = matches!(
             choice.finish_reason,
             Some(dynamo_protocols::types::FinishReason::Length)
@@ -736,8 +738,16 @@ pub fn chat_completion_to_anthropic_response(
 
         // Extract tool calls
         if let Some(tool_calls) = choice.message.tool_calls {
-            for tc in tool_calls {
-                let input = tool_use_input(&tc.function.name, &tc.function.arguments, truncated);
+            // The token limit stops generation once, inside the call the model was
+            // writing. Every earlier call finished, so only the last one can carry a
+            // truncated tail.
+            let last_call = tool_calls.len().saturating_sub(1);
+            for (call_index, tc) in tool_calls.into_iter().enumerate() {
+                let input = tool_use_input(
+                    &tc.function.name,
+                    &tc.function.arguments,
+                    truncated && call_index == last_call,
+                );
                 let emitted_id = new_tool_use_id();
                 tracing::debug!(
                     backend_id = %tc.id,
@@ -2504,6 +2514,45 @@ mod truncated_tool_call_tests {
         finish_reason: dynamo_protocols::types::FinishReason,
         arguments: &str,
     ) -> AnthropicMessageResponse {
+        converted_tool_use_response_for(finish_reason, &[arguments])
+    }
+
+    /// Every `tool_use` input in the converted response, in call order.
+    fn converted_tool_use_inputs(
+        finish_reason: dynamo_protocols::types::FinishReason,
+        arguments: &[&str],
+    ) -> Vec<serde_json::Value> {
+        converted_tool_use_response_for(finish_reason, arguments)
+            .content
+            .into_iter()
+            .filter_map(|block| match block {
+                AnthropicResponseContentBlock::ToolUse { input, .. } => Some(input),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// One tool call per entry in `arguments`, so a test can build a choice that
+    /// carries parallel calls.
+    #[allow(deprecated)]
+    fn converted_tool_use_response_for(
+        finish_reason: dynamo_protocols::types::FinishReason,
+        arguments: &[&str],
+    ) -> AnthropicMessageResponse {
+        let tool_calls = arguments
+            .iter()
+            .enumerate()
+            .map(
+                |(index, args)| dynamo_protocols::types::ChatCompletionMessageToolCall {
+                    id: format!("call_{}", index + 1),
+                    r#type: dynamo_protocols::types::FunctionType::Function,
+                    function: dynamo_protocols::types::FunctionCall {
+                        name: "record_literal".into(),
+                        arguments: args.to_string(),
+                    },
+                },
+            )
+            .collect();
         let chat_resp = NvCreateChatCompletionResponse {
             inner: dynamo_protocols::types::CreateChatCompletionResponse {
                 id: "chatcmpl-wiring".into(),
@@ -2512,16 +2561,7 @@ mod truncated_tool_call_tests {
                     message: dynamo_protocols::types::ChatCompletionResponseMessage {
                         content: None,
                         refusal: None,
-                        tool_calls: Some(vec![
-                            dynamo_protocols::types::ChatCompletionMessageToolCall {
-                                id: "call_1".into(),
-                                r#type: dynamo_protocols::types::FunctionType::Function,
-                                function: dynamo_protocols::types::FunctionCall {
-                                    name: "record_literal".into(),
-                                    arguments: arguments.to_string(),
-                                },
-                            },
-                        ]),
+                        tool_calls: Some(tool_calls),
                         role: dynamo_protocols::types::Role::Assistant,
                         function_call: None,
                         audio: None,
@@ -2584,6 +2624,33 @@ mod truncated_tool_call_tests {
             r#"{"label": "blocked"}"#,
         );
         assert_eq!(response.stop_reason, Some(AnthropicStopReason::Refusal));
+    }
+
+    /// Malformed, but NOT cut short: the model closed the object and still emitted
+    /// arguments that do not parse. Recovery must refuse this shape.
+    const MALFORMED_BUT_COMPLETE: &str = r#"{"label": "a", "extra": }"#;
+
+    /// `truncated` describes the CHOICE, but only the last call can be the one the
+    /// model was writing when the budget ran out. It finished every earlier call, so
+    /// malformed arguments there are a generation defect and must still yield `{}`.
+    #[test]
+    fn only_the_final_tool_call_recovers_partial_arguments() {
+        let inputs = converted_tool_use_inputs(
+            dynamo_protocols::types::FinishReason::Length,
+            &[MALFORMED_BUT_COMPLETE, TRUNCATED],
+        );
+
+        assert_eq!(inputs.len(), 2, "both calls must reach the response");
+        assert_eq!(
+            inputs[0],
+            serde_json::json!({}),
+            "a call the model finished must not be repaired, even at the token limit"
+        );
+        assert_eq!(
+            inputs[1],
+            serde_json::json!({"label": "customer-eof"}),
+            "the final call is the only one that can have been cut off"
+        );
     }
 
     /// Valid arguments are untouched no matter which reason ended generation.

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -681,6 +681,13 @@ fn recover_completed_members(raw: &str) -> Option<serde_json::Map<String, serde_
 /// bare literals are ambiguous by construction and fall through to the comma scan.
 fn ends_on_a_finished_value(trimmed: &str) -> bool {
     let tail = trimmed.trim_end();
+    // Whitespace cannot occur inside a JSON number or literal. Let the normal
+    // parser decide whether the value before it is valid; this also covers
+    // complete `true`, `false`, and `null` values.
+    if tail.len() != trimmed.len() {
+        return true;
+    }
+
     // A closing quote must not itself be escaped, or the string is still open.
     if let Some(before_quote) = tail.strip_suffix('"') {
         let backslashes = before_quote
@@ -690,7 +697,11 @@ fn ends_on_a_finished_value(trimmed: &str) -> bool {
             .count();
         return backslashes % 2 == 0;
     }
-    tail.ends_with('}') || tail.ends_with(']')
+    tail.ends_with('}')
+        || tail.ends_with(']')
+        || tail.ends_with("true")
+        || tail.ends_with("false")
+        || tail.ends_with("null")
 }
 
 /// Convert a completed chat completion response into an Anthropic Messages response.
@@ -719,7 +730,7 @@ pub fn chat_completion_to_anthropic_response(
             dynamo_protocols::types::FinishReason::Stop => AnthropicStopReason::EndTurn,
             dynamo_protocols::types::FinishReason::Length => AnthropicStopReason::MaxTokens,
             dynamo_protocols::types::FinishReason::ToolCalls => AnthropicStopReason::ToolUse,
-            dynamo_protocols::types::FinishReason::ContentFilter => AnthropicStopReason::EndTurn,
+            dynamo_protocols::types::FinishReason::ContentFilter => AnthropicStopReason::Refusal,
             dynamo_protocols::types::FinishReason::FunctionCall => AnthropicStopReason::ToolUse,
         });
 
@@ -2478,6 +2489,21 @@ mod truncated_tool_call_tests {
         finish_reason: dynamo_protocols::types::FinishReason,
         arguments: &str,
     ) -> serde_json::Value {
+        converted_tool_use_response(finish_reason, arguments)
+            .content
+            .into_iter()
+            .find_map(|block| match block {
+                AnthropicResponseContentBlock::ToolUse { input, .. } => Some(input),
+                _ => None,
+            })
+            .expect("expected a tool_use block")
+    }
+
+    #[allow(deprecated)]
+    fn converted_tool_use_response(
+        finish_reason: dynamo_protocols::types::FinishReason,
+        arguments: &str,
+    ) -> AnthropicMessageResponse {
         let chat_resp = NvCreateChatCompletionResponse {
             inner: dynamo_protocols::types::CreateChatCompletionResponse {
                 id: "chatcmpl-wiring".into(),
@@ -2514,15 +2540,7 @@ mod truncated_tool_call_tests {
             nvext: None,
         };
 
-        let response = chat_completion_to_anthropic_response(chat_resp, "test-model", None);
-        match response
-            .content
-            .into_iter()
-            .find(|block| matches!(block, AnthropicResponseContentBlock::ToolUse { .. }))
-        {
-            Some(AnthropicResponseContentBlock::ToolUse { input, .. }) => input,
-            other => panic!("expected a tool_use block, got: {other:?}"),
-        }
+        chat_completion_to_anthropic_response(chat_resp, "test-model", None)
     }
 
     /// Pins the WIRING, not the helper. The eight helper tests below all call
@@ -2557,6 +2575,15 @@ mod truncated_tool_call_tests {
                 "{reason:?} claims the call completed, so partial arguments must not be emitted"
             );
         }
+    }
+
+    #[test]
+    fn the_conversion_maps_content_filter_to_refusal() {
+        let response = converted_tool_use_response(
+            dynamo_protocols::types::FinishReason::ContentFilter,
+            r#"{"label": "blocked"}"#,
+        );
+        assert_eq!(response.stop_reason, Some(AnthropicStopReason::Refusal));
     }
 
     /// Valid arguments are untouched no matter which reason ended generation.
@@ -2660,6 +2687,27 @@ mod truncated_tool_call_tests {
         // An escaped quote at the very end leaves the string open; it is not a finished
         // value and must not be closed either.
         assert_eq!(recover_completed_members(r#"{"a": "he said \""#), None);
+    }
+
+    #[test]
+    fn scalar_values_followed_by_whitespace_are_recovered() {
+        for (key, value, expected) in [
+            ("count", r#"2 "#, serde_json::json!(2)),
+            ("enabled", "true ", serde_json::json!(true)),
+            ("enabled", "false ", serde_json::json!(false)),
+            ("value", "null ", serde_json::Value::Null),
+        ] {
+            let input = format!(r#"{{"{key}": {value}"#);
+            let recovered = recover_completed_members(&input).expect("scalar value completed");
+            assert_eq!(recovered.get(key), Some(&expected));
+        }
+    }
+
+    #[test]
+    fn an_undelimited_scalar_is_not_recovered() {
+        assert_eq!(recover_completed_members(r#"{"count": 2"#), None);
+        assert_eq!(recover_completed_members(r#"{"enabled": tru"#), None);
+        assert_eq!(recover_completed_members(r#"{"value": nul"#), None);
     }
 
     #[test]

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -579,7 +579,11 @@ pub(super) fn new_tool_use_id() -> String {
 /// would hand back a call that looks complete, carries only some of its arguments, and
 /// reports no error anywhere. That is worse than the empty object, because a partial
 /// call can pass schema validation and then run.
-fn tool_use_input(tool_name: &str, arguments: &str, truncated: bool) -> serde_json::Value {
+pub(super) fn tool_use_input(
+    tool_name: &str,
+    arguments: &str,
+    truncated: bool,
+) -> serde_json::Value {
     match serde_json::from_str::<serde_json::Value>(arguments) {
         Ok(value) => return value,
         Err(error) => {

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -853,16 +853,25 @@ impl From<DeltaChoice> for dynamo_protocols::types::ChatChoice {
     /// # Note
     /// The `function_call` field is deprecated.
     fn from(delta: DeltaChoice) -> Self {
-        // TODO: Revisit whether tool calls produced at the output-token limit should
-        // preserve Length and yield an incomplete Responses result.
-        let finish_reason = if delta
+        // A terminal reason that already explains why generation ended
+        // outranks the tool-call rewrite. Only `Stop` and a missing reason are
+        // rewritten, which is the same rule the streaming path applies in
+        // `unified_parser::ChoiceState::normalize_finish_reason`; the two paths used to
+        // disagree, so a call truncated at the token limit reached a non-streaming
+        // caller labelled `tool_calls` with no sign it had been cut off.
+        //
+        // Preserving `Length` is also what makes the Responses conversion reachable:
+        // `responses::chat_completion_to_response` keys `status: "incomplete"` and
+        // `incomplete_details.reason: "max_output_tokens"` off this exact value.
+        let has_tool_calls = delta
             .tool_calls
             .as_ref()
-            .is_some_and(|calls| !calls.is_empty())
-        {
-            Some(dynamo_protocols::types::FinishReason::ToolCalls)
-        } else {
-            delta.finish_reason
+            .is_some_and(|calls| !calls.is_empty());
+        let finish_reason = match delta.finish_reason {
+            Some(dynamo_protocols::types::FinishReason::Stop) | None if has_tool_calls => {
+                Some(dynamo_protocols::types::FinishReason::ToolCalls)
+            }
+            other => other,
         };
 
         // Determine content format based on what we accumulated
@@ -1941,9 +1950,17 @@ mod tests {
         );
     }
 
+    /// `Length` must survive a tool call, because it is the only thing
+    /// telling the caller that generation was cut off before the call finished.
+    ///
+    /// This test previously asserted the opposite. That made it contradict
+    /// `tool_choice_finish_reasons.rs::test_required_tool_choice_preserves_length_finish_reason`,
+    /// which feeds the same truncated `required` payload through the streaming path and
+    /// requires `Length` to be preserved. Both passed, because they exercised different
+    /// stages of the same request.
     #[tokio::test]
-    async fn test_tool_calling_finish_reason_override_from_length() {
-        // Test that when tool calls are present but finish reason is Length, it gets overridden to ToolCalls
+    async fn test_tool_calling_finish_reason_preserves_length() {
+        // Tool calls are present AND generation hit the token limit: `Length` wins.
         let tool_call_json = r#"{"name": "search", "arguments": {"query": "rust programming"}}"#;
 
         let annotated_delta = create_test_delta(
@@ -1981,10 +1998,38 @@ mod tests {
             dynamo_protocols::types::FunctionType::Function
         );
 
-        // Verify that finish reason was overridden to ToolCalls despite original being Length
+        // The terminal reason explains why generation stopped and is not replaced.
         assert_eq!(
             choice.finish_reason,
-            Some(dynamo_protocols::types::FinishReason::ToolCalls)
+            Some(dynamo_protocols::types::FinishReason::Length)
+        );
+    }
+
+    /// The guard for the rule above: `ContentFilter` is also a terminal reason that
+    /// explains itself, so it must survive a tool call for the same reason `Length` does.
+    #[tokio::test]
+    async fn test_tool_calling_finish_reason_preserves_content_filter() {
+        let tool_call_json = r#"{"name": "search", "arguments": {"query": "rust programming"}}"#;
+
+        let annotated_delta = create_test_delta(
+            0,
+            "Let me search for that.",
+            Some(dynamo_protocols::types::Role::Assistant),
+            Some(dynamo_protocols::types::FinishReason::ContentFilter),
+            None,
+            Some(tool_call_json),
+        );
+
+        let stream = Box::pin(stream::iter(vec![annotated_delta]));
+        let response = DeltaAggregator::apply(stream, ParsingOptions::default())
+            .await
+            .expect("aggregation should succeed");
+
+        let choice = &response.inner.choices[0];
+        assert!(choice.message.tool_calls.is_some());
+        assert_eq!(
+            choice.finish_reason,
+            Some(dynamo_protocols::types::FinishReason::ContentFilter)
         );
     }
 

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -855,10 +855,12 @@ impl From<DeltaChoice> for dynamo_protocols::types::ChatChoice {
     fn from(delta: DeltaChoice) -> Self {
         // A terminal reason that already explains why generation ended
         // outranks the tool-call rewrite. Only `Stop` and a missing reason are
-        // rewritten, which is the same rule the streaming path applies in
-        // `unified_parser::ChoiceState::normalize_finish_reason`; the two paths used to
-        // disagree, so a call truncated at the token limit reached a non-streaming
-        // caller labelled `tool_calls` with no sign it had been cut off.
+        // rewritten. The streaming path applies the same rule in two parts:
+        // `unified_parser::ChoiceState::normalize_finish_reason` rewrites `Stop`, and
+        // `unified_parser::ChoiceState::unterminated_finish_reason` supplies `ToolCalls`
+        // when no reason arrives at all. The two paths used to disagree, so a call
+        // truncated at the token limit reached a non-streaming caller labelled
+        // `tool_calls` with no sign it had been cut off.
         //
         // Preserving `Length` is also what makes the Responses conversion reachable:
         // `responses::chat_completion_to_response` keys `status: "incomplete"` and

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -1238,14 +1238,20 @@ pub fn chat_completion_to_response(
         // Unary responses do not expose explicit phase boundaries. A message
         // or function call proves reasoning finished before the terminal item
         // exhausted the output budget.
-        let reasoning_completed = output
+        // The budget runs out once, inside the item the model was still writing.
+        // Every earlier item finished, so only the terminal one is incomplete.
+        let terminal = output
             .iter()
-            .any(|item| matches!(item, OutputItem::Message(_) | OutputItem::FunctionCall(_)));
-        for item in &mut output {
+            .rposition(|item| matches!(item, OutputItem::Message(_) | OutputItem::FunctionCall(_)));
+        for (index, item) in output.iter_mut().enumerate() {
             match item {
-                OutputItem::Message(message) => message.status = OutputStatus::Incomplete,
-                OutputItem::FunctionCall(call) => call.status = Some(OutputStatus::Incomplete),
-                OutputItem::Reasoning(reasoning) if !reasoning_completed => {
+                OutputItem::Message(message) if Some(index) == terminal => {
+                    message.status = OutputStatus::Incomplete
+                }
+                OutputItem::FunctionCall(call) if Some(index) == terminal => {
+                    call.status = Some(OutputStatus::Incomplete)
+                }
+                OutputItem::Reasoning(reasoning) if terminal.is_none() => {
                     reasoning.status = Some(OutputStatus::Incomplete)
                 }
                 _ => {}
@@ -3347,18 +3353,32 @@ thinking
         finish_reason: dynamo_protocols::types::FinishReason,
         arguments: &str,
     ) -> NvCreateChatCompletionResponse {
+        make_chat_resp_with_tool_calls(finish_reason, &[arguments])
+    }
+
+    /// One tool call per entry in `arguments`, for a choice that carries parallel calls.
+    fn make_chat_resp_with_tool_calls(
+        finish_reason: dynamo_protocols::types::FinishReason,
+        arguments: &[&str],
+    ) -> NvCreateChatCompletionResponse {
         let mut response = make_chat_resp_with_text("");
         let choice = &mut response.inner.choices[0];
         choice.finish_reason = Some(finish_reason);
         choice.message.content = None;
-        choice.message.tool_calls = Some(vec![ChatCompletionMessageToolCall {
-            id: "call_abc".into(),
-            r#type: FunctionType::Function,
-            function: dynamo_protocols::types::FunctionCall {
-                name: "get_weather".into(),
-                arguments: arguments.into(),
-            },
-        }]);
+        choice.message.tool_calls = Some(
+            arguments
+                .iter()
+                .enumerate()
+                .map(|(index, args)| ChatCompletionMessageToolCall {
+                    id: format!("call_abc{index}"),
+                    r#type: FunctionType::Function,
+                    function: dynamo_protocols::types::FunctionCall {
+                        name: "get_weather".into(),
+                        arguments: (*args).into(),
+                    },
+                })
+                .collect(),
+        );
         response
     }
 
@@ -3578,6 +3598,38 @@ thinking
             panic!("expected function call output");
         };
         assert_eq!(call.status, Some(OutputStatus::Incomplete));
+    }
+
+    /// The output budget runs out once, inside the call the model was writing. Every
+    /// earlier call finished, so only the terminal item is incomplete.
+    #[test]
+    fn test_length_marks_only_the_terminal_tool_call_incomplete() {
+        let chat_resp = make_chat_resp_with_tool_calls(
+            dynamo_protocols::types::FinishReason::Length,
+            &[r#"{"location":"SF"}"#, r#"{"location":"NY"#],
+        );
+
+        let response =
+            chat_completion_to_response(chat_resp, &ResponseParams::default(), None).unwrap();
+
+        assert_eq!(response.inner.status, Status::Incomplete);
+        let statuses: Vec<_> = response
+            .inner
+            .output
+            .iter()
+            .filter_map(|item| match item {
+                OutputItem::FunctionCall(call) => Some(call.status),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            statuses,
+            vec![
+                Some(OutputStatus::Completed),
+                Some(OutputStatus::Incomplete)
+            ],
+            "a call the model finished must not be reported as incomplete"
+        );
     }
 
     #[test]


### PR DESCRIPTION
#### Overview:

PR #13791 fixes truncated tool calls on the shared non-streaming path: when generation reaches `max_tokens`, the response now keeps `finish_reason: "length"` instead of claiming the tool call completed. This affects all models on that path. It does not clear either `customer_truncated_tool_markup_hidden` harness failure because OpenAI `arguments` remain invalid JSON by design.

#### Example (before → after):

Input: `tool_choice: "required"`, `max_tokens: 32`, and a `record_literal(label, literal_text)` call truncated inside `literal_text`.

```text
OpenAI /v1/chat/completions, non-streaming
before: finish_reason = "tool_calls"; arguments = unterminated JSON
after:  finish_reason = "length";     arguments = the same unterminated JSON
```

The caller now has a truncation signal and can skip execution. After #13791, non-streaming and streaming both report `length`. Passing this case requires an OpenAI-surface contract decision outside this PR.

#### Changes:

- Preserve `Length` and `ContentFilter` when a tool call is present; only `Stop` and a missing reason become `ToolCalls`. Responses can now report `status: "incomplete"` with `max_output_tokens`.
- For Anthropic, report `stop_reason: "max_tokens"` and recover only completed top-level input members. Invalid arguments still become `{}` when the finish reason claims the call completed.
- Add regressions for finish-reason normalization and truncated Anthropic input, including nested values, commas, and escaped quotes.

#### Harness result:

The [ibhosale Qwen3.6-27B custom suite](http://ibhosale.nvidia.com/ci/jobs/20260826-001521-82b4f113/models/qwen36-27b-v2/variants/dynamo-vllm/suites/custom/) job `20260826-001521` built `044c0fd1`, which does not contain #13791.

| `customer_truncated_tool_markup_hidden` | Without #13791 | With #13791 |
| -- | -- | -- |
| Non-streaming | FAIL: `invalid_arguments_json`; finish reason `tool_calls` | Not run |
| Streaming | FAIL: `invalid_arguments_json`; finish reason `length` | Not run |

#13791 clears neither failure. Streaming already returned `length` and still failed; `tool_calls_with_non_tool_finish` is only a warning, while `invalid_arguments_json` is fatal. The other two Dynamo/API failures are `named_no_argument_server_time`; they belong to DIS-2779 and PR #13785.

#### Verification:

At reviewed head `cc47e484`: `truncated_tool_call_tests` 11 passed; aggregator finish-reason tests 5 passed; `--test tool_choice_finish_reasons` 6 passed; `cargo test -p dynamo-llm --lib` 2,364 passed, 0 failed. Reverting the call-site gate makes the refusal test fail with `left: {"label": "customer-eof"}` against `right: {}`.

#### Where should the reviewer start?

`lib/llm/src/protocols/openai/chat_completions/aggregator.rs`, then `lib/llm/src/protocols/anthropic/types.rs`

Related: DIS-2780, #13790, #13792

/coderabbit profile chill

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of truncated tool-call arguments for Anthropic responses, preserving valid completed data and safely discarding incomplete content.
  * Added more reliable recovery for nested values, commas, and escaped quotes in partially received tool arguments.
  * Preserved accurate completion reasons, including length limits and content filtering, when OpenAI responses include tool calls.
  * Unrecoverable or malformed tool arguments now fall back safely instead of causing inconsistent response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
