### PR TITLE
fix(llm): suppress truncated structured tool calls

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -3218,6 +3218,9 @@ pub fn validate_chat_completion_fields_generic(
     request: &NvCreateChatCompletionRequest,
 ) -> Result<(), ErrorResponse> {
     request.validate().map_err(|e| {
+        if find_invalid_argument_in_chain(e.as_ref()).is_some() {
+            return ErrorMessage::from_anyhow(e, "Invalid chat completion request");
+        }
         ErrorMessage::from_http_error(HttpError {
             code: 400,
             message: VALIDATION_PREFIX.to_string() + &e.to_string(),
@@ -3249,6 +3252,9 @@ pub fn validate_completion_fields_generic(
     request: &NvCreateCompletionRequest,
 ) -> Result<(), ErrorResponse> {
     request.validate().map_err(|e| {
+        if find_invalid_argument_in_chain(e.as_ref()).is_some() {
+            return ErrorMessage::from_anyhow(e, "Invalid completion request");
+        }
         ErrorMessage::from_http_error(HttpError {
             code: 400,
             message: VALIDATION_PREFIX.to_string() + &e.to_string(),

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -5509,6 +5509,25 @@ impl OpenAIPreprocessor {
                             );
                             state.emitted_text.clear();
                         }
+                        // Text the client already holds cannot change what terminal
+                        // recovery emits, so drop it and keep the buffer proportional
+                        // to what is still pending. Without this the buffer grows for
+                        // the whole response and every chunk rescans all of it.
+                        //
+                        // A quote character is the exception: the marker scanner reads
+                        // `"<tool_call>"` as prose, and it can only know that from the
+                        // quote to its left. Dropping a quote-free prefix cannot change
+                        // any later verdict, so that is the only prefix dropped here.
+                        // A response that quotes on every chunk keeps the old growth.
+                        if !state.emitted_text.is_empty()
+                            && !state.emitted_text.contains(['"', '\'', '`'])
+                            && crate::protocols::openai::chat_completions::unified_parser::unquoted_native_tool_call_marker_or_prefix_start(&state.input_text, "glm47").is_none()
+                            && let Some(unemitted) =
+                                state.input_text.strip_prefix(state.emitted_text.as_str())
+                        {
+                            state.input_text = unemitted.to_string();
+                            state.emitted_text.clear();
+                        }
                     }
                 }
             }
@@ -7642,6 +7661,32 @@ mod tests {
             let output = apply_glm47_streaming_length(&[&input[..split], &input[split..]]).await;
             assert_glm47_streaming_length_output(&output, "I can help. ", split);
         }
+    }
+
+    /// A prose-only answer never completes a call, so nothing drains the recovery
+    /// buffer through the marker path. The buffer must still stay proportional to the
+    /// unemitted tail, or every chunk rescans the whole response.
+    #[tokio::test]
+    async fn glm47_streaming_prose_only_round_trips_without_retaining_the_response() {
+        let chunk_text = "the quick brown fox ";
+        let chunks: Vec<&str> = std::iter::repeat_n(chunk_text, 400).collect();
+        let output = apply_glm47_streaming_length(&chunks).await;
+
+        assert_eq!(stream_content(&output), chunk_text.repeat(400));
+    }
+
+    /// The recovery buffer holds only what the client has not seen yet, so a long
+    /// prose answer must still arrive whole. Without the compaction this text is
+    /// retained and rescanned in full on every chunk.
+    #[tokio::test]
+    async fn glm47_streaming_long_prose_survives_buffer_compaction() {
+        let chunks: Vec<String> = (0..400).map(|i| format!("chunk {i} of prose. ")).collect();
+        let expected: String = chunks.concat();
+        let borrowed: Vec<&str> = chunks.iter().map(String::as_str).collect();
+
+        let output = apply_glm47_streaming_length(&borrowed).await;
+
+        assert_eq!(stream_content(&output), expected);
     }
 
     #[tokio::test]

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -5505,14 +5505,9 @@ impl OpenAIPreprocessor {
                                 ..marker_start
                                     + glm47_start_in.len()
                                     + end
-                                + glm47_end_in.len(),
+                                    + glm47_end_in.len(),
                             );
-                        }
-                        // Raw text without a possible native marker cannot affect terminal
-                        // recovery. Keep only a partial marker suffix so ordinary streamed
-                        // prose is not rescanned and retained on every chunk.
-                        if crate::protocols::openai::chat_completions::unified_parser::unquoted_native_tool_call_marker_or_prefix_start(&state.input_text, "glm47").is_none() {
-                            state.input_text.clear();
+                            state.emitted_text.clear();
                         }
                     }
                 }
@@ -5609,24 +5604,23 @@ impl OpenAIPreprocessor {
                     let state = recovery.entry(choice.index).or_default();
                     if let Some(marker_start) = crate::protocols::openai::chat_completions::unified_parser::unquoted_native_tool_call_marker_or_prefix_start(&state.input_text, "glm47") {
                         let desired_content = &state.input_text[..marker_start];
-                        let replacement = if desired_content.starts_with(&state.emitted_text) {
-                            &desired_content[state.emitted_text.len()..]
-                        } else {
-                            desired_content
-                        };
-                        let suppressing_terminal_marker = choice.finish_reason
+                        if choice.finish_reason
                             == Some(dynamo_protocols::types::FinishReason::Length)
-                            && crate::protocols::openai::chat_completions::unified_parser::first_unquoted_native_tool_call_marker(&state.input_text, "glm47").is_some();
-                        if suppressing_terminal_marker {
+                            && crate::protocols::openai::chat_completions::unified_parser::first_unquoted_native_tool_call_marker(&state.input_text, "glm47").is_some()
+                        {
                             tracing::warn!(
                                 choice_index = choice.index,
                                 why = "truncated_native_tool_call_suppressed",
                                 suppressed_bytes = state.input_text.len() - desired_content.len(),
                                 "glm47 streaming: suppressing incomplete native tool output on length finish"
                             );
+                            let replacement = desired_content
+                                .strip_prefix(&state.emitted_text)
+                                .unwrap_or_default();
+                            choice.delta.content = (!replacement.is_empty()).then(|| {
+                                ChatCompletionMessageContent::Text(replacement.to_string())
+                            });
                         }
-                        choice.delta.content = (!replacement.is_empty())
-                            .then(|| ChatCompletionMessageContent::Text(replacement.to_string()));
                     } else if choice.finish_reason
                         == Some(dynamo_protocols::types::FinishReason::Length)
                         && choice.delta.tool_calls.is_none()
@@ -7594,6 +7588,26 @@ mod tests {
             .collect()
     }
 
+    fn assert_glm47_streaming_length_output(
+        output: &[Annotated<NvCreateChatCompletionStreamResponse>],
+        expected_content: &str,
+        split: usize,
+    ) {
+        assert_eq!(
+            stream_content(output),
+            expected_content,
+            "split at byte {split} must reconstruct the complete visible response"
+        );
+        assert!(
+            output
+                .iter()
+                .flat_map(|response| response.data.iter())
+                .flat_map(|data| data.inner.choices.iter())
+                .any(|choice| choice.finish_reason == Some(FinishReason::Length)),
+            "split at byte {split} must preserve the terminal length delta"
+        );
+    }
+
     #[tokio::test]
     async fn glm47_streaming_length_preserves_prose_and_suppresses_incomplete_marker() {
         let output = apply_glm47_streaming_length(&[
@@ -7617,11 +7631,7 @@ mod tests {
         for split in content.char_indices().map(|(index, _)| index).skip(1) {
             let output =
                 apply_glm47_streaming_length(&[&content[..split], &content[split..]]).await;
-            assert_eq!(
-                stream_content(&output),
-                content,
-                "split at byte {split} must preserve quoted marker prose"
-            );
+            assert_glm47_streaming_length_output(&output, content, split);
         }
     }
 
@@ -7630,11 +7640,7 @@ mod tests {
         let input = "I can help. <tool_call>get_weather<arg_key>city</arg_key><arg_value>Par";
         for split in input.char_indices().map(|(index, _)| index).skip(1) {
             let output = apply_glm47_streaming_length(&[&input[..split], &input[split..]]).await;
-            assert_eq!(
-                stream_content(&output),
-                "I can help. ",
-                "split at byte {split} must not expose truncated marker content"
-            );
+            assert_glm47_streaming_length_output(&output, "I can help. ", split);
         }
     }
 
@@ -8378,6 +8384,99 @@ mod tests {
         assert!(!should_hash_decoded_video(true, true, false, true));
         assert!(!should_hash_decoded_video(true, false, true, true));
         assert!(!should_hash_decoded_video(true, false, false, false));
+    }
+
+    #[cfg(all(
+        feature = "mm-routing",
+        feature = "media-ffmpeg",
+        feature = "testing-nixl"
+    ))]
+    #[tokio::test]
+    async fn adjacent_videos_reach_media_loader_with_hashing_disabled() {
+        let video_bytes = include_bytes!("../tests/data/media/240p_10.mp4");
+        let mut server = mockito::Server::new_async().await;
+        let video_mock = server
+            .mock("GET", "/video.mp4")
+            .with_status(200)
+            .with_header("content-type", "video/mp4")
+            .with_body(&video_bytes[..])
+            .expect(2)
+            .create_async()
+            .await;
+
+        let mdc = ModelDeploymentCard::load_from_disk(
+            "tests/data/sample-models/mock-llama-3.1-8b-instruct",
+            None,
+        )
+        .unwrap();
+        let mut preprocessor = Arc::try_unwrap(OpenAIPreprocessor::new(mdc).unwrap())
+            .unwrap_or_else(|_| panic!("test preprocessor unexpectedly shared"));
+        let media_decoder: MediaDecoder = serde_json::from_value(serde_json::json!({
+            "video": {"num_frames": 2}
+        }))
+        .unwrap();
+        let media_fetcher = MediaFetcher {
+            allow_direct_ip: true,
+            allow_direct_port: true,
+            allow_private_ips: true,
+            ..Default::default()
+        };
+        preprocessor.media_loader = Some(
+            MediaLoader::new(media_decoder, Some(media_fetcher))
+                .expect("test media loader must initialize"),
+        );
+        preprocessor.video_routing_processor = Some(mm_routing::VideoRoutingProcessor::test_stub());
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": format!("{}/video.mp4", server.url())}
+                    },
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": format!("{}/video.mp4", server.url())}
+                    }
+                ]
+            }],
+            "max_tokens": 1
+        }))
+        .unwrap();
+        let mut builder = PreprocessedRequest::builder();
+        builder
+            .model("test-model".to_string())
+            .token_ids(Vec::new())
+            .stop_conditions(Default::default())
+            .sampling_options(Default::default())
+            .output_options(Default::default());
+
+        let (routing_entries, _) = preprocessor
+            .gather_multi_modal_data_with_image_tokens(&request, &mut builder, None, &[])
+            .await
+            .unwrap();
+        let preprocessed = builder.build().unwrap();
+        let videos = preprocessed
+            .multi_modal_data
+            .as_ref()
+            .and_then(|media| media.get("video_url"))
+            .expect("both decoded videos must be forwarded");
+
+        assert_eq!(videos.len(), 2);
+        for video in videos {
+            let MultimodalData::Decoded(descriptor) = video else {
+                panic!("video must reach the media loader and be decoded");
+            };
+            assert!(
+                descriptor.content_hash().is_none(),
+                "adjacent videos must reach the media loader with hashing disabled"
+            );
+        }
+        assert!(routing_entries.is_empty());
+        assert!(preprocessed.mm_routing_info.is_none());
+        video_mock.assert_async().await;
     }
 
     #[test]

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -799,11 +799,24 @@ impl MmRoutingEntry {
 }
 
 #[cfg(feature = "mm-routing")]
+fn exact_mm_routing_layout_accepts_next_entry(
+    previous_entry_was_video: &mut bool,
+    current_entry_is_video: bool,
+) -> bool {
+    // Adjacent video placeholders cannot be mapped unambiguously to vLLM KV
+    // events. Keep this transition shared by the pre-decode and final checks.
+    let accepted = !(*previous_entry_was_video && current_entry_is_video);
+    *previous_entry_was_video = current_entry_is_video;
+    accepted
+}
+
+#[cfg(feature = "mm-routing")]
 fn exact_mm_routing_entries_are_unambiguous(entries: &[MmRoutingEntry]) -> bool {
-    !entries.windows(2).any(|pair| {
-        matches!(
-            pair,
-            [MmRoutingEntry::Video { .. }, MmRoutingEntry::Video { .. }]
+    let mut previous_entry_was_video = false;
+    entries.iter().all(|entry| {
+        exact_mm_routing_layout_accepts_next_entry(
+            &mut previous_entry_was_video,
+            matches!(entry, MmRoutingEntry::Video { .. }),
         )
     })
 }
@@ -3189,11 +3202,14 @@ impl OpenAIPreprocessor {
         // counter is unavailable or checked addition overflowed.
         #[cfg(feature = "mm-routing")]
         let mut image_tokens = self.image_token_counter.as_ref().map(|_| 0usize);
-        // A raw/passthrough video or unsupported decoded-video processor makes
-        // the model-visible token sequence unknowable. In that case the whole
-        // request falls back rather than publishing a partial routing view.
+        // A raw/passthrough video, unsupported decoded-video processor, or
+        // ambiguous consecutive-video layout makes exact routing unavailable.
+        // In that case the whole request falls back rather than publishing a
+        // partial routing view.
         #[cfg(feature = "mm-routing")]
         let mut exact_mm_routing_eligible = true;
+        #[cfg(feature = "mm-routing")]
+        let mut previous_routing_entry_was_video = false;
         // Total `image_url` content parts in the request. Bumped at every
         // image part regardless of which fetch path handles it. Used at
         // hash forwarding time: if fewer image entries were resolved, we omit
@@ -3232,7 +3248,12 @@ impl OpenAIPreprocessor {
                     total_image_count += 1;
                 }
                 #[cfg(feature = "mm-routing")]
-                if !exact_mm_routing_supports_modality(type_str, has_media_loader) {
+                if !exact_mm_routing_supports_modality(type_str, has_media_loader)
+                    || !exact_mm_routing_layout_accepts_next_entry(
+                        &mut previous_routing_entry_was_video,
+                        type_str == "video_url",
+                    )
+                {
                     exact_mm_routing_eligible = false;
                 }
 
@@ -5520,7 +5541,7 @@ impl OpenAIPreprocessor {
                         // any later verdict, so that is the only prefix dropped here.
                         // A response that quotes on every chunk keeps the old growth.
                         if !state.emitted_text.is_empty()
-                            && !state.emitted_text.contains(['"', '\'', '`'])
+                            && !state.input_text.contains(['"', '\'', '`'])
                             && crate::protocols::openai::chat_completions::unified_parser::unquoted_native_tool_call_marker_or_prefix_start(&state.input_text, "glm47").is_none()
                             && let Some(unemitted) =
                                 state.input_text.strip_prefix(state.emitted_text.as_str())

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -112,7 +112,6 @@ pub use crate::protocols::common::metrics::{
 };
 pub use crate::protocols::common::preprocessor::PreprocessedEmbeddingRequest;
 
-use crate::protocols::common::invalid_argument_error;
 use crate::protocols::common::llm_backend::EmbeddingsEngineOutput;
 
 fn routing_priorities(hints: Option<&AgentHints>) -> (Option<f64>, Option<u32>, Option<i32>) {
@@ -124,6 +123,14 @@ fn routing_priorities(hints: Option<&AgentHints>) -> (Option<f64>, Option<u32>, 
     let strict_priority = hints.and_then(|h| h.strict_priority);
     let priority = hints.and_then(|h| h.priority);
     (priority_jump, strict_priority, priority)
+}
+
+pub(crate) fn invalid_argument_error(message: impl Into<String>) -> anyhow::Error {
+    DynamoError::builder()
+        .error_type(ErrorType::InvalidArgument)
+        .message(message.into())
+        .build()
+        .into()
 }
 
 // Preserves terminal versus recoverable failures when moka shares a
@@ -792,24 +799,11 @@ impl MmRoutingEntry {
 }
 
 #[cfg(feature = "mm-routing")]
-fn exact_mm_routing_layout_accepts_next_entry(
-    previous_entry_was_video: &mut bool,
-    current_entry_is_video: bool,
-) -> bool {
-    // Adjacent video placeholders cannot be mapped unambiguously to vLLM KV
-    // events. Keep this transition shared by the pre-decode and final checks.
-    let accepted = !(*previous_entry_was_video && current_entry_is_video);
-    *previous_entry_was_video = current_entry_is_video;
-    accepted
-}
-
-#[cfg(feature = "mm-routing")]
 fn exact_mm_routing_entries_are_unambiguous(entries: &[MmRoutingEntry]) -> bool {
-    let mut previous_entry_was_video = false;
-    entries.iter().all(|entry| {
-        exact_mm_routing_layout_accepts_next_entry(
-            &mut previous_entry_was_video,
-            matches!(entry, MmRoutingEntry::Video { .. }),
+    !entries.windows(2).any(|pair| {
+        matches!(
+            pair,
+            [MmRoutingEntry::Video { .. }, MmRoutingEntry::Video { .. }]
         )
     })
 }
@@ -3195,14 +3189,11 @@ impl OpenAIPreprocessor {
         // counter is unavailable or checked addition overflowed.
         #[cfg(feature = "mm-routing")]
         let mut image_tokens = self.image_token_counter.as_ref().map(|_| 0usize);
-        // A raw/passthrough video, unsupported decoded-video processor, or
-        // ambiguous consecutive-video layout makes exact routing unavailable.
-        // In that case the whole request falls back rather than publishing a
-        // partial routing view.
+        // A raw/passthrough video or unsupported decoded-video processor makes
+        // the model-visible token sequence unknowable. In that case the whole
+        // request falls back rather than publishing a partial routing view.
         #[cfg(feature = "mm-routing")]
         let mut exact_mm_routing_eligible = true;
-        #[cfg(feature = "mm-routing")]
-        let mut previous_routing_entry_was_video = false;
         // Total `image_url` content parts in the request. Bumped at every
         // image part regardless of which fetch path handles it. Used at
         // hash forwarding time: if fewer image entries were resolved, we omit
@@ -3241,12 +3232,7 @@ impl OpenAIPreprocessor {
                     total_image_count += 1;
                 }
                 #[cfg(feature = "mm-routing")]
-                if !exact_mm_routing_supports_modality(type_str, has_media_loader)
-                    || !exact_mm_routing_layout_accepts_next_entry(
-                        &mut previous_routing_entry_was_video,
-                        type_str == "video_url",
-                    )
-                {
+                if !exact_mm_routing_supports_modality(type_str, has_media_loader) {
                     exact_mm_routing_eligible = false;
                 }
 
@@ -5418,32 +5404,23 @@ impl OpenAIPreprocessor {
         let pending = Arc::new(Mutex::new(PendingDynamoMetadata::default()));
         let pending_in = Arc::clone(&pending);
 
-        // Per-choice recovery state — allocated only for glm47 since only that
-        // parser emits <tool_call> XML that can be truncated at max_tokens.
-        // Buffers raw input and tracks what the jail emitted per choice.index
-        // so n > 1 is handled correctly and double-emit is avoided.
+        // The legacy jail recognizes markers with a substring search. Retain
+        // GLM47 text per choice so the terminal chunk can use the shared
+        // quote-aware marker policy before exposing content to the client.
         #[derive(Default)]
         struct ChoiceRecovery {
             input_text: String,
             emitted_text: String,
-            recovered: bool,
-        }
-        // Named so the bool in the recoveries tuple is legible at each use site.
-        struct PendingRecovery {
-            choice_idx: u32,
-            tail: String,
-            tail_already_emitted: bool,
         }
         let is_glm47 = tool_call_parser.as_deref() == Some("glm47");
-        // Token strings from the parser config so recovery matches the parser
-        // even if the defaults are ever overridden.
-        let glm47_cfg = dynamo_parsers::tool_calling::config::Glm47ParserConfig::default();
-        let glm47_start = glm47_cfg.tool_call_start;
-        let glm47_end = glm47_cfg.tool_call_end;
+        let glm47_config = dynamo_parsers::tool_calling::config::Glm47ParserConfig::default();
+        let glm47_start = glm47_config.tool_call_start;
+        let glm47_end = glm47_config.tool_call_end;
         let choice_recovery: Arc<Mutex<std::collections::HashMap<u32, ChoiceRecovery>>> =
             Arc::new(Mutex::new(std::collections::HashMap::new()));
         let choice_recovery_in = Arc::clone(&choice_recovery);
-        let glm47_start_jail = glm47_start.clone();
+        let glm47_start_in = glm47_start.clone();
+        let glm47_end_in = glm47_end.clone();
 
         // The jail's own (vendored, out-of-scope) finalize logic cannot tell an
         // error-terminated input stream from one that genuinely completed — it
@@ -5505,34 +5482,38 @@ impl OpenAIPreprocessor {
                     merge_response_nvext(&mut p.nvext, nv.nvext.take());
                 }
             }
-            // Buffer input content only for glm47 (truncation recovery).
-            // Only retain from the last <tool_call> marker onward to bound
-            // memory on long responses.
             if is_glm47 && let Some(data) = &a.data {
-                let mut cr = choice_recovery_in.lock().expect("choice recovery poisoned");
+                let mut recovery = choice_recovery_in
+                    .lock()
+                    .expect("choice recovery buffer poisoned");
                 for choice in &data.inner.choices {
                     if let Some(ChatCompletionMessageContent::Text(content)) = &choice.delta.content
                     {
-                        let state = cr.entry(choice.index).or_default();
+                        let state = recovery.entry(choice.index).or_default();
                         state.input_text.push_str(content);
-                        // Drop everything before the last marker to keep
-                        // the buffer small. Walk back to a char boundary
-                        // before draining so a multi-byte char split
-                        // across chunks never triggers a panic.
-                        let mut keep_from = match state.input_text.rfind(glm47_start_jail.as_str())
-                        {
-                            Some(pos) => pos,
-                            // No marker yet — keep enough tail to
-                            // catch a marker split across two chunks.
-                            None => state
-                                .input_text
-                                .len()
-                                .saturating_sub(glm47_start_jail.len() - 1),
-                        };
-                        while keep_from > 0 && !state.input_text.is_char_boundary(keep_from) {
-                            keep_from -= 1;
+                        // A completed call is already owned by the jail. Retain only
+                        // the suffix after it, so terminal recovery examines the
+                        // final unfinished call while the shared scanner decides
+                        // whether each opener is real or quoted prose.
+                        while let Some(marker_start) = crate::protocols::openai::chat_completions::unified_parser::first_unquoted_native_tool_call_marker(&state.input_text, "glm47") {
+                            let after_marker =
+                                &state.input_text[marker_start + glm47_start_in.len()..];
+                            let Some(end) = after_marker.find(&glm47_end_in) else {
+                                break;
+                            };
+                            state.input_text.drain(
+                                ..marker_start
+                                    + glm47_start_in.len()
+                                    + end
+                                + glm47_end_in.len(),
+                            );
                         }
-                        state.input_text.drain(..keep_from);
+                        // Raw text without a possible native marker cannot affect terminal
+                        // recovery. Keep only a partial marker suffix so ordinary streamed
+                        // prose is not rescanned and retained on every chunk.
+                        if crate::protocols::openai::chat_completions::unified_parser::unquoted_native_tool_call_marker_or_prefix_start(&state.input_text, "glm47").is_none() {
+                            state.input_text.clear();
+                        }
                     }
                 }
             }
@@ -5620,139 +5601,51 @@ impl OpenAIPreprocessor {
                 error: None,
             };
 
-            // glm47: on finish_reason=length, recover the last incomplete
-            // <tool_call> block. rfind skips complete blocks so earlier parsed
-            // calls are never duplicated. Recovered content WILL contain raw
-            // markup — callers that require "no tool tags in content" must
-            // filter on finish_reason=length.
-            //
-            // TODO: this recovery runs inside apply_tool_calling_jail, which
-            // the v2 path bypasses (use_parsers_v2 branch above). Adding
-            // "glm47" to V2_FAMILIES in tool_parser_v2.rs silently disables
-            // streaming recovery while aggregator.rs keeps running. At that
-            // point hoist this above the jail/v2 branch — it only needs
-            // buffered input text + finish_reason, both available there.
-            // Pass 1 (immutable): compute the recovery tail per choice and
-            // whether the jail already released it as content on this chunk.
-            // We collect into a Vec so we can release the immutable borrow on
-            // nv_chunk before mutating it in pass 2.
-            let recoveries: Vec<PendingRecovery> = if is_glm47 {
-                let mut cr = choice_recovery.lock().expect("choice recovery poisoned");
-                nv_chunk
-                    .data
-                    .iter()
-                    .flat_map(|data| data.inner.choices.iter())
-                    .filter_map(|choice| {
-                        let state = cr.entry(choice.index).or_default();
-                        if !state.recovered
-                            && let Some(ChatCompletionMessageContent::Text(t)) =
-                                &choice.delta.content
-                        {
-                            state.emitted_text.push_str(t);
-                            // Bound like input_text: retain only the suffix from
-                            // the last marker onward — all the contains(&tail)
-                            // check needs.
-                            let mut keep_from = match state.emitted_text.rfind(glm47_start.as_str())
-                            {
-                                Some(pos) => pos,
-                                None => state
-                                    .emitted_text
-                                    .len()
-                                    .saturating_sub(glm47_start.len() - 1),
-                            };
-                            while keep_from > 0 && !state.emitted_text.is_char_boundary(keep_from) {
-                                keep_from -= 1;
-                            }
-                            state.emitted_text.drain(..keep_from);
+            if is_glm47 && let Some(data) = &mut nv_chunk.data {
+                let mut recovery = choice_recovery
+                    .lock()
+                    .expect("choice recovery buffer poisoned");
+                for choice in &mut data.inner.choices {
+                    let state = recovery.entry(choice.index).or_default();
+                    if let Some(marker_start) = crate::protocols::openai::chat_completions::unified_parser::unquoted_native_tool_call_marker_or_prefix_start(&state.input_text, "glm47") {
+                        let desired_content = &state.input_text[..marker_start];
+                        let replacement = if desired_content.starts_with(&state.emitted_text) {
+                            &desired_content[state.emitted_text.len()..]
+                        } else {
+                            desired_content
+                        };
+                        let suppressing_terminal_marker = choice.finish_reason
+                            == Some(dynamo_protocols::types::FinishReason::Length)
+                            && crate::protocols::openai::chat_completions::unified_parser::first_unquoted_native_tool_call_marker(&state.input_text, "glm47").is_some();
+                        if suppressing_terminal_marker {
+                            tracing::warn!(
+                                choice_index = choice.index,
+                                why = "truncated_native_tool_call_suppressed",
+                                suppressed_bytes = state.input_text.len() - desired_content.len(),
+                                "glm47 streaming: suppressing incomplete native tool output on length finish"
+                            );
                         }
-                        if state.recovered
-                            || !matches!(
-                                choice.finish_reason,
-                                Some(dynamo_protocols::types::FinishReason::Length)
-                            )
-                        {
-                            return None;
-                        }
-                        let tail =
-                            state
-                                .input_text
-                                .rfind(glm47_start.as_str())
-                                .and_then(|pos| {
-                                    let t = &state.input_text[pos..];
-                                    if !t.contains(glm47_end.as_str()) {
-                                        Some(t.to_string())
-                                    } else {
-                                        None
-                                    }
-                                })?;
-                        let tail_already_emitted = state.emitted_text.contains(&tail);
-                        state.recovered = true;
-                        Some(PendingRecovery {
-                            choice_idx: choice.index,
-                            tail,
-                            tail_already_emitted,
-                        })
-                    })
-                    .collect()
-            } else {
-                vec![]
-            };
-
-            // Pass 2 (mutable): when the jail already released the tail verbatim,
-            // suppress the finish chunk's content entirely. The recovery chunk
-            // carries just the marker-onwards tail, matching the non-streaming
-            // path (rfind result only, no post-call prose).
-            for pr in &recoveries {
-                if !pr.tail_already_emitted {
-                    continue;
-                }
-                if let Some(ref mut data) = nv_chunk.data {
-                    for rc in data
-                        .inner
-                        .choices
-                        .iter_mut()
-                        .filter(|c| c.index == pr.choice_idx)
+                        choice.delta.content = (!replacement.is_empty())
+                            .then(|| ChatCompletionMessageContent::Text(replacement.to_string()));
+                    } else if choice.finish_reason
+                        == Some(dynamo_protocols::types::FinishReason::Length)
+                        && choice.delta.tool_calls.is_none()
                     {
-                        // The jail released the truncated block verbatim as content
-                        // on this chunk, potentially preceded by post-call prose.
-                        // glm47's parser drops post-call prose deliberately, so
-                        // suppress the whole content here and let the recovery
-                        // chunk carry just the marker-onwards tail — matching batch.
-                        rc.delta.content = None;
+                        let replacement = state
+                            .input_text
+                            .strip_prefix(&state.emitted_text)
+                            .unwrap_or_default();
+                        choice.delta.content = (!replacement.is_empty())
+                            .then(|| ChatCompletionMessageContent::Text(replacement.to_string()));
+                    }
+
+                    if let Some(ChatCompletionMessageContent::Text(content)) = &choice.delta.content {
+                        state.emitted_text.push_str(content);
                     }
                 }
             }
 
-            // Pass 3: emit a recovery chunk per affected choice carrying just
-            // the truncated tail (marker onwards, no post-call prose).
-            let recovery_chunks: Vec<_> = recoveries
-                .into_iter()
-                .filter_map(|pr| {
-                    let PendingRecovery {
-                        choice_idx, tail, ..
-                    } = pr;
-                    tracing::warn!(
-                        choice_index = choice_idx,
-                        recovered_bytes = tail.len(),
-                        "glm47 streaming: partial <tool_call> emitted as content \
-                         on length finish"
-                    );
-                    let mut rec = nv_chunk.clone();
-                    rec.id = None;
-                    scrub_synthetic_chunk_metadata(&mut rec);
-                    let rd = rec.data.as_mut()?;
-                    rd.inner.choices.retain(|c| c.index == choice_idx);
-                    for rc in &mut rd.inner.choices {
-                        rc.delta.content = Some(ChatCompletionMessageContent::Text(tail.clone()));
-                        rc.delta.tool_calls = None;
-                        rc.finish_reason = None;
-                        rc.logprobs = None;
-                    }
-                    Some(rec)
-                })
-                .collect();
-
-            futures::stream::iter(recovery_chunks.into_iter().chain(std::iter::once(nv_chunk)))
+            futures::stream::iter(std::iter::once(nv_chunk))
         });
 
         // Once an upstream error is latched, drop any output the jail synthesized
@@ -7656,6 +7549,121 @@ mod tests {
         chunk
     }
 
+    fn glm47_stream_chunk(
+        content: &str,
+        finish_reason: Option<FinishReason>,
+    ) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        let mut chunk = chat_stream_chunk(0, Some(Role::Assistant));
+        let choice = &mut chunk.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = Some(ChatCompletionMessageContent::Text(content.to_string()));
+        choice.finish_reason = finish_reason;
+        chunk
+    }
+
+    async fn apply_glm47_streaming_length(
+        chunks: &[&str],
+    ) -> Vec<Annotated<NvCreateChatCompletionStreamResponse>> {
+        let chunks: Vec<String> = chunks.iter().map(|chunk| (*chunk).to_string()).collect();
+        let chunk_count = chunks.len();
+        OpenAIPreprocessor::apply_tool_calling_jail(
+            Some("glm47".to_string()),
+            None,
+            None,
+            false,
+            false,
+            stream::iter(chunks.into_iter().enumerate().map(move |(index, content)| {
+                glm47_stream_chunk(
+                    &content,
+                    (index + 1 == chunk_count).then_some(FinishReason::Length),
+                )
+            })),
+        )
+        .collect()
+        .await
+    }
+
+    fn stream_content(output: &[Annotated<NvCreateChatCompletionStreamResponse>]) -> String {
+        output
+            .iter()
+            .flat_map(|response| response.data.iter())
+            .flat_map(|data| data.inner.choices.iter())
+            .filter_map(|choice| match &choice.delta.content {
+                Some(ChatCompletionMessageContent::Text(content)) => Some(content.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn glm47_streaming_length_preserves_prose_and_suppresses_incomplete_marker() {
+        let output = apply_glm47_streaming_length(&[
+            "I can help. <tool_call>get_weather<arg_key>city</arg_key><arg_value>Par",
+        ])
+        .await;
+
+        assert_eq!(stream_content(&output), "I can help. ");
+        assert!(
+            output
+                .iter()
+                .flat_map(|response| response.data.iter())
+                .flat_map(|data| data.inner.choices.iter())
+                .any(|choice| choice.finish_reason == Some(FinishReason::Length))
+        );
+    }
+
+    #[tokio::test]
+    async fn glm47_streaming_length_preserves_quoted_marker_prose() {
+        let content = r#"The literal "<tool_call>" marker is part of the explanation."#;
+        for split in content.char_indices().map(|(index, _)| index).skip(1) {
+            let output =
+                apply_glm47_streaming_length(&[&content[..split], &content[split..]]).await;
+            assert_eq!(
+                stream_content(&output),
+                content,
+                "split at byte {split} must preserve quoted marker prose"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn glm47_streaming_length_suppresses_incomplete_marker_at_every_split() {
+        let input = "I can help. <tool_call>get_weather<arg_key>city</arg_key><arg_value>Par";
+        for split in input.char_indices().map(|(index, _)| index).skip(1) {
+            let output = apply_glm47_streaming_length(&[&input[..split], &input[split..]]).await;
+            assert_eq!(
+                stream_content(&output),
+                "I can help. ",
+                "split at byte {split} must not expose truncated marker content"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn glm47_streaming_length_keeps_an_empty_safe_terminal_recovery_delta() {
+        let output = apply_glm47_streaming_length(&[
+            "<tool_call>get_weather<arg_key>city</arg_key><arg_value>Par",
+        ])
+        .await;
+
+        assert!(stream_content(&output).is_empty());
+        let terminal_choices: Vec<_> = output
+            .iter()
+            .flat_map(|response| response.data.iter())
+            .flat_map(|data| data.inner.choices.iter())
+            .filter(|choice| choice.finish_reason == Some(FinishReason::Length))
+            .collect();
+        assert_eq!(
+            terminal_choices.len(),
+            1,
+            "the recovery event must be observable"
+        );
+        assert!(
+            terminal_choices[0].delta.content.is_none()
+                && terminal_choices[0].delta.tool_calls.is_none(),
+            "the observable recovery delta must not expose raw markup or partial arguments"
+        );
+    }
+
     async fn apply_kimi_k3_no_tools(
         leaked_reasoning: &str,
     ) -> Vec<Annotated<NvCreateChatCompletionStreamResponse>> {
@@ -8370,99 +8378,6 @@ mod tests {
         assert!(!should_hash_decoded_video(true, true, false, true));
         assert!(!should_hash_decoded_video(true, false, true, true));
         assert!(!should_hash_decoded_video(true, false, false, false));
-    }
-
-    #[cfg(all(
-        feature = "mm-routing",
-        feature = "media-ffmpeg",
-        feature = "testing-nixl"
-    ))]
-    #[tokio::test]
-    async fn adjacent_videos_reach_media_loader_with_hashing_disabled() {
-        let video_bytes = include_bytes!("../tests/data/media/240p_10.mp4");
-        let mut server = mockito::Server::new_async().await;
-        let video_mock = server
-            .mock("GET", "/video.mp4")
-            .with_status(200)
-            .with_header("content-type", "video/mp4")
-            .with_body(&video_bytes[..])
-            .expect(2)
-            .create_async()
-            .await;
-
-        let mdc = ModelDeploymentCard::load_from_disk(
-            "tests/data/sample-models/mock-llama-3.1-8b-instruct",
-            None,
-        )
-        .unwrap();
-        let mut preprocessor = Arc::try_unwrap(OpenAIPreprocessor::new(mdc).unwrap())
-            .unwrap_or_else(|_| panic!("test preprocessor unexpectedly shared"));
-        let media_decoder: MediaDecoder = serde_json::from_value(serde_json::json!({
-            "video": {"num_frames": 2}
-        }))
-        .unwrap();
-        let media_fetcher = MediaFetcher {
-            allow_direct_ip: true,
-            allow_direct_port: true,
-            allow_private_ips: true,
-            ..Default::default()
-        };
-        preprocessor.media_loader = Some(
-            MediaLoader::new(media_decoder, Some(media_fetcher))
-                .expect("test media loader must initialize"),
-        );
-        preprocessor.video_routing_processor = Some(mm_routing::VideoRoutingProcessor::test_stub());
-
-        let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
-            "model": "test-model",
-            "messages": [{
-                "role": "user",
-                "content": [
-                    {
-                        "type": "video_url",
-                        "video_url": {"url": format!("{}/video.mp4", server.url())}
-                    },
-                    {
-                        "type": "video_url",
-                        "video_url": {"url": format!("{}/video.mp4", server.url())}
-                    }
-                ]
-            }],
-            "max_tokens": 1
-        }))
-        .unwrap();
-        let mut builder = PreprocessedRequest::builder();
-        builder
-            .model("test-model".to_string())
-            .token_ids(Vec::new())
-            .stop_conditions(Default::default())
-            .sampling_options(Default::default())
-            .output_options(Default::default());
-
-        let (routing_entries, _) = preprocessor
-            .gather_multi_modal_data_with_image_tokens(&request, &mut builder, None, &[])
-            .await
-            .unwrap();
-        let preprocessed = builder.build().unwrap();
-        let videos = preprocessed
-            .multi_modal_data
-            .as_ref()
-            .and_then(|media| media.get("video_url"))
-            .expect("both decoded videos must be forwarded");
-
-        assert_eq!(videos.len(), 2);
-        for video in videos {
-            let MultimodalData::Decoded(descriptor) = video else {
-                panic!("video must reach the media loader and be decoded");
-            };
-            assert!(
-                descriptor.content_hash().is_none(),
-                "adjacent videos must reach the media loader with hashing disabled"
-            );
-        }
-        assert!(routing_entries.is_empty());
-        assert!(preprocessed.mm_routing_info.is_none());
-        video_mock.assert_async().await;
     }
 
     #[test]

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -196,8 +196,14 @@ impl AnthropicStreamConverter {
                 .iter()
                 .map(|(arguments, _)| arguments.as_str())
                 .collect();
-            let arguments_are_valid =
-                raw.is_empty() || serde_json::from_str::<serde_json::Value>(&raw).is_ok();
+            let arguments_are_valid = if raw.is_empty() {
+                // An empty argument string is valid for a completed call, but at a
+                // token-limit finish it means generation stopped immediately after
+                // the name. Keep the terminal rule aligned with the unary converter.
+                !(truncated && Some(call_index) == last_call)
+            } else {
+                serde_json::from_str::<serde_json::Value>(&raw).is_ok()
+            };
             let repair = truncated && Some(call_index) == last_call && !arguments_are_valid;
             let repaired_input = repair
                 .then(|| super::types::tool_use_input(&tool_call.name, &raw, true))
@@ -1414,6 +1420,33 @@ mod tests {
             event_types(&conv.emit_end_events_tagged()),
             vec!["message_delta", "message_stop"]
         );
+    }
+
+    #[test]
+    fn test_length_drops_tool_call_with_empty_arguments() {
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+        conv.process_chunk_tagged(&tool_call_chunk(
+            0,
+            Some("call-1"),
+            Some("get_weather"),
+            Some(""),
+        ));
+
+        let mut events = conv.process_chunk_tagged(&finish_chunk(FinishReason::Length));
+        events.extend(conv.emit_end_events_tagged());
+
+        assert!(events.iter().all(|event| !matches!(
+            &event.data,
+            AnthropicStreamEvent::ContentBlockStart {
+                content_block: AnthropicResponseContentBlock::ToolUse { .. },
+                ..
+            }
+        )));
+        assert!(events.iter().any(|event| matches!(
+            &event.data,
+            AnthropicStreamEvent::MessageDelta { delta, .. }
+                if delta.stop_reason == Some(AnthropicStopReason::MaxTokens)
+        )));
     }
 
     #[test]

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -261,6 +261,17 @@ impl AnthropicStreamConverter {
             block_index += 1;
         }
 
+        // Mirrors `chat_completion_to_anthropic_response`: telling the client to run a
+        // tool while emitting no `tool_use` block leaves a turn it cannot send back.
+        if block_index == self.next_block_index
+            && self.stop_reason == Some(AnthropicStopReason::ToolUse)
+        {
+            tracing::warn!(
+                "every tool_use block was suppressed; reporting end_turn instead of tool_use"
+            );
+            self.stop_reason = Some(AnthropicStopReason::EndTurn);
+        }
+
         self.next_block_index = block_index;
         events
     }
@@ -1543,6 +1554,38 @@ mod tests {
                 "malformed {reason:?} arguments must not create an executable tool block"
             );
         }
+    }
+
+    /// `tool_use` is an instruction to run a tool. With every call suppressed the
+    /// client has nothing to run, and Anthropic rejects the turn when it is sent back.
+    #[test]
+    fn test_stream_reports_end_turn_when_every_tool_block_is_suppressed() {
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+        conv.process_chunk_tagged(&tool_call_chunk(
+            0,
+            Some("call-1"),
+            Some("record_literal"),
+            Some(r#"{"label": "cut""#),
+        ));
+
+        let mut events = conv.process_chunk_tagged(&finish_chunk(FinishReason::ToolCalls));
+        events.extend(conv.emit_end_events_tagged());
+
+        assert!(events.iter().all(|event| !matches!(
+            &event.data,
+            AnthropicStreamEvent::ContentBlockStart {
+                content_block: AnthropicResponseContentBlock::ToolUse { .. },
+                ..
+            }
+        )));
+        assert!(
+            events.iter().any(|event| matches!(
+                &event.data,
+                AnthropicStreamEvent::MessageDelta { delta, .. }
+                    if delta.stop_reason == Some(AnthropicStopReason::EndTurn)
+            )),
+            "a turn with no tool_use block must not report tool_use"
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -179,16 +179,32 @@ impl AnthropicStreamConverter {
         let mut block_index = self.next_block_index;
 
         // Only the token limit cuts a call short, and it does so once, in the last
-        // call. Mirrors `chat_completion_to_anthropic_response`.
+        // call. This mirrors `chat_completion_to_anthropic_response`.
         let truncated = self.stop_reason == Some(AnthropicStopReason::MaxTokens);
-        let ready: Vec<&ToolCallState> = self
-            .tool_call_states
-            .iter()
-            .filter(|tool_call| tool_call.is_emit_ready())
-            .collect();
-        let last_call = ready.len().saturating_sub(1);
+        // Use the highest observed call index before filtering out calls whose identity
+        // never completed. An argument-only later call is still the terminal observed
+        // call and must not make an earlier ready call look like the truncation target.
+        let last_call = self.tool_call_states.len().checked_sub(1);
 
-        for (call_index, tool_call) in ready.into_iter().enumerate() {
+        for (call_index, tool_call) in self.tool_call_states.iter().enumerate() {
+            if !tool_call.is_emit_ready() {
+                continue;
+            }
+
+            let raw: String = tool_call
+                .argument_fragments
+                .iter()
+                .map(|(arguments, _)| arguments.as_str())
+                .collect();
+            let arguments_are_valid =
+                raw.is_empty() || serde_json::from_str::<serde_json::Value>(&raw).is_ok();
+            let repair = truncated && Some(call_index) == last_call && !arguments_are_valid;
+            let repaired_input = repair
+                .then(|| super::types::tool_use_input(&tool_call.name, &raw, true))
+                .flatten();
+            if !arguments_are_valid && repaired_input.is_none() {
+                continue;
+            }
             let emitted_id = new_tool_use_id();
             tracing::debug!(
                 backend_id = %tool_call.backend_id,
@@ -208,21 +224,7 @@ impl AnthropicStreamConverter {
                 None,
             ));
 
-            // A client rebuilds `input` by concatenating these fragments, so a
-            // truncated call leaves it holding JSON that never parses. Send the same
-            // repaired object the batch converter returns instead, so one generation
-            // does not yield different arguments depending on `stream`.
-            let raw: String = tool_call
-                .argument_fragments
-                .iter()
-                .map(|(arguments, _)| arguments.as_str())
-                .collect();
-            let repaired = (truncated
-                && call_index == last_call
-                && serde_json::from_str::<serde_json::Value>(&raw).is_err())
-            .then(|| super::types::tool_use_input(&tool_call.name, &raw, true));
-
-            if let Some(input) = repaired {
+            if let Some(input) = repaired_input {
                 events.push((
                     "content_block_delta",
                     AnthropicStreamEvent::ContentBlockDelta {
@@ -997,6 +999,19 @@ mod tests {
         events.iter().map(|e| e.event_type.as_str()).collect()
     }
 
+    fn streamed_tool_input(events: &[TaggedEvent]) -> String {
+        events
+            .iter()
+            .filter_map(|event| match &event.data {
+                AnthropicStreamEvent::ContentBlockDelta {
+                    delta: AnthropicDelta::InputJsonDelta { partial_json },
+                    ..
+                } => Some(partial_json.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
     #[test]
     fn test_append_events_reuse_caller_storage() {
         let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
@@ -1414,61 +1429,147 @@ mod tests {
         ));
     }
 
-    /// Concatenate every `input_json_delta` fragment, which is what an Anthropic
-    /// client does to rebuild `tool_use.input`.
-    fn streamed_tool_input(events: &[TaggedEvent]) -> String {
-        events
-            .iter()
-            .filter_map(|event| match &event.data {
-                AnthropicStreamEvent::ContentBlockDelta {
-                    delta: AnthropicDelta::InputJsonDelta { partial_json },
-                    ..
-                } => Some(partial_json.as_str()),
-                _ => None,
-            })
-            .collect()
-    }
-
-    /// The batch converter repairs a call cut off at the token limit into the members
-    /// that finished. The stream must rebuild the same input. Otherwise one generation
-    /// yields different tool arguments depending on `stream`.
     #[test]
-    fn test_truncated_tool_arguments_match_the_batch_conversion() {
+    fn test_truncated_tool_arguments_repair_at_stream_terminal() {
         let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
-
-        let mut tagged = conv.process_chunk_tagged(&tool_call_chunk(
+        conv.process_chunk_tagged(&tool_call_chunk(
             0,
             Some("call-1"),
             Some("record_literal"),
             Some(r#"{"label": "customer-eof", "literal_text": "cust"#),
         ));
-        tagged.extend(conv.process_chunk_tagged(&finish_chunk(FinishReason::Length)));
-        tagged.extend(conv.emit_end_events_tagged());
 
-        let streamed = streamed_tool_input(&tagged);
+        let mut events = conv.process_chunk_tagged(&finish_chunk(FinishReason::Length));
+        events.extend(conv.emit_end_events_tagged());
+        let input = streamed_tool_input(&events);
+
         assert_eq!(
-            serde_json::from_str::<serde_json::Value>(&streamed).ok(),
-            Some(serde_json::json!({"label": "customer-eof"})),
-            "streamed input must match the batch conversion, got: {streamed}"
+            serde_json::from_str::<serde_json::Value>(&input).unwrap(),
+            serde_json::json!({"label": "customer-eof"})
+        );
+        assert!(events.iter().any(|event| matches!(
+            &event.data,
+            AnthropicStreamEvent::MessageDelta { delta, .. }
+                if delta.stop_reason == Some(AnthropicStopReason::MaxTokens)
+        )));
+    }
+
+    #[test]
+    fn test_stream_repairs_only_the_final_truncated_tool_call() {
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+        conv.process_chunk_tagged(&tool_call_chunk(
+            0,
+            Some("call-1"),
+            Some("first"),
+            Some(r#"{"done": "yes"}"#),
+        ));
+        conv.process_chunk_tagged(&tool_call_chunk(
+            1,
+            Some("call-2"),
+            Some("second"),
+            Some(r#"{"done": "no", "tail": "cut"#),
+        ));
+
+        let mut events = conv.process_chunk_tagged(&finish_chunk(FinishReason::Length));
+        events.extend(conv.emit_end_events_tagged());
+        let inputs: Vec<_> = events
+            .iter()
+            .filter_map(|event| match &event.data {
+                AnthropicStreamEvent::ContentBlockDelta {
+                    index,
+                    delta: AnthropicDelta::InputJsonDelta { partial_json },
+                } => Some((*index, partial_json.clone())),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(inputs.len(), 2);
+        assert_eq!(inputs[0].1, r#"{"done": "yes"}"#);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&inputs[1].1).unwrap(),
+            serde_json::json!({"done": "no"})
         );
     }
 
-    /// The guard on the rule above. A call that parses is sent verbatim, fragment by
-    /// fragment, whatever ended generation.
     #[test]
-    fn test_complete_tool_arguments_are_streamed_verbatim() {
+    fn test_later_incomplete_identity_does_not_emit_an_earlier_malformed_call() {
         let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+        conv.process_chunk_tagged(&tool_call_chunk(
+            0,
+            Some("call-1"),
+            Some("first"),
+            Some(r#"{"done": "cut""#),
+        ));
+        conv.process_chunk_tagged(&tool_call_chunk(1, None, None, Some(r#"{"later": "args""#)));
 
-        let mut tagged = conv.process_chunk_tagged(&tool_call_chunk(
+        let mut events = conv.process_chunk_tagged(&finish_chunk(FinishReason::Length));
+        events.extend(conv.emit_end_events_tagged());
+
+        assert!(events.iter().all(|event| !matches!(
+            &event.data,
+            AnthropicStreamEvent::ContentBlockStart {
+                content_block: AnthropicResponseContentBlock::ToolUse { .. },
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn test_stream_suppresses_malformed_non_length_tool_calls() {
+        for reason in [
+            FinishReason::Stop,
+            FinishReason::ToolCalls,
+            FinishReason::FunctionCall,
+            FinishReason::ContentFilter,
+        ] {
+            let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+            conv.process_chunk_tagged(&tool_call_chunk(
+                0,
+                Some("call-1"),
+                Some("record_literal"),
+                Some(r#"{"label": "cut""#),
+            ));
+            let mut events = conv.process_chunk_tagged(&finish_chunk(reason));
+            events.extend(conv.emit_end_events_tagged());
+
+            assert!(
+                events.iter().all(|event| !matches!(
+                    &event.data,
+                    AnthropicStreamEvent::ContentBlockStart {
+                        content_block: AnthropicResponseContentBlock::ToolUse { .. },
+                        ..
+                    }
+                )),
+                "malformed {reason:?} arguments must not create an executable tool block"
+            );
+        }
+    }
+
+    #[test]
+    fn test_stream_suppresses_length_tool_call_without_recoverable_input() {
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+        conv.process_chunk_tagged(&tool_call_chunk(
             0,
             Some("call-1"),
             Some("record_literal"),
-            Some(r#"{"label": "done"}"#),
+            Some(r#"{"label": "cut"#),
         ));
-        tagged.extend(conv.process_chunk_tagged(&finish_chunk(FinishReason::Length)));
-        tagged.extend(conv.emit_end_events_tagged());
 
-        assert_eq!(streamed_tool_input(&tagged), r#"{"label": "done"}"#);
+        let mut events = conv.process_chunk_tagged(&finish_chunk(FinishReason::Length));
+        events.extend(conv.emit_end_events_tagged());
+
+        assert!(events.iter().all(|event| !matches!(
+            &event.data,
+            AnthropicStreamEvent::ContentBlockStart {
+                content_block: AnthropicResponseContentBlock::ToolUse { .. },
+                ..
+            }
+        )));
+        assert!(events.iter().any(|event| matches!(
+            &event.data,
+            AnthropicStreamEvent::MessageDelta { delta, .. }
+                if delta.stop_reason == Some(AnthropicStopReason::MaxTokens)
+        )));
     }
 
     /// Buffered tool-argument fragments must carry the usage snapshot from their

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -575,8 +575,11 @@ pub(super) fn tool_use_input(
     arguments: &str,
     truncated: bool,
 ) -> Option<serde_json::Value> {
+    // No argument bytes at all is the MOST truncated shape when the limit ended
+    // generation: it landed after the name and before the first argument token.
+    // Only a call the model finished may report an empty object.
     if arguments.is_empty() {
-        return Some(serde_json::json!({}));
+        return (!truncated).then(|| serde_json::json!({}));
     }
 
     let error = match serde_json::from_str::<serde_json::Value>(arguments) {
@@ -746,6 +749,22 @@ pub fn chat_completion_to_anthropic_response(
                     input,
                 });
             }
+        }
+
+        // `stop_reason: tool_use` is an instruction to run a tool. Suppressing every
+        // call above leaves nothing to run, and Anthropic rejects that turn when the
+        // client sends it back, so the conversation cannot continue. Report the turn
+        // as ended instead. `max_tokens` and `refusal` already explain themselves and
+        // stay as they are.
+        if stop_reason == Some(AnthropicStopReason::ToolUse)
+            && !content
+                .iter()
+                .any(|block| matches!(block, AnthropicResponseContentBlock::ToolUse { .. }))
+        {
+            tracing::warn!(
+                "every tool_use block was suppressed; reporting end_turn instead of tool_use"
+            );
+            stop_reason = Some(AnthropicStopReason::EndTurn);
         }
 
         // Extract reasoning content (from --dyn-reasoning-parser, e.g. qwen3).
@@ -2554,6 +2573,39 @@ mod anthropic_types_tests {
         );
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0], serde_json::json!({"label": "customer-eof"}));
+    }
+
+    /// A call cut off before its first argument token has no argument bytes. Reporting
+    /// it as an empty object hands the client a runnable zero-argument call.
+    #[test]
+    fn conversion_drops_a_length_call_with_no_argument_bytes() {
+        let inputs =
+            converted_tool_use_inputs(dynamo_protocols::types::FinishReason::Length, &[""]);
+        assert!(inputs.is_empty(), "unexpected tool block: {inputs:?}");
+        assert_eq!(tool_use_input("get_weather", "", true), None);
+        // A call the model finished still reports the empty object.
+        assert_eq!(
+            tool_use_input("get_weather", "", false),
+            Some(serde_json::json!({}))
+        );
+    }
+
+    /// `tool_use` tells the client to run a tool. With every call suppressed there is
+    /// nothing to run, and Anthropic rejects the turn when the client sends it back.
+    #[test]
+    fn conversion_reports_end_turn_when_every_tool_block_is_suppressed() {
+        let response = converted_tool_use_response_for(
+            dynamo_protocols::types::FinishReason::ToolCalls,
+            &[r#"{"label": "cut""#],
+        );
+        assert!(
+            !response
+                .content
+                .iter()
+                .any(|block| matches!(block, AnthropicResponseContentBlock::ToolUse { .. })),
+            "the malformed call must not be emitted"
+        );
+        assert_eq!(response.stop_reason, Some(AnthropicStopReason::EndTurn));
     }
 
     #[test]

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -570,24 +570,17 @@ pub(super) fn new_tool_use_id() -> String {
 /// This replaces `unwrap_or(json!({}))`, which turned any unparseable arguments
 /// into a well-formed EMPTY object. That produced a `tool_use` block a client would
 /// happily execute with no arguments and no error anywhere in the response.
-///
-/// `truncated` gates that recovery, and it is what keeps this honest. Partial members
-/// are only safe to emit when something ELSE in the response already tells the client
-/// the call is incomplete, which is exactly `stop_reason: "max_tokens"`. When the
-/// upstream reason instead claims the call finished, malformed arguments mean the
-/// generation is wrong rather than cut short: emitting the members that happen to parse
-/// would hand back a call that looks complete, carries only some of its arguments, and
-/// reports no error anywhere. That is worse than the empty object, because a partial
-/// call can pass schema validation and then run.
 pub(super) fn tool_use_input(
     tool_name: &str,
     arguments: &str,
     truncated: bool,
-) -> serde_json::Value {
-    // One warning per call, logged where the outcome is known. Logging before the
-    // `truncated` check would announce a recovery that the branch below may refuse.
+) -> Option<serde_json::Value> {
+    if arguments.is_empty() {
+        return Some(serde_json::json!({}));
+    }
+
     let error = match serde_json::from_str::<serde_json::Value>(arguments) {
-        Ok(value) => return value,
+        Ok(value) => return Some(value),
         Err(error) => error,
     };
 
@@ -596,11 +589,9 @@ pub(super) fn tool_use_input(
             tool_name = %tool_name,
             argument_bytes = arguments.len(),
             error = %error,
-            "tool call arguments are not valid JSON and generation was not cut off; emitting \
-             an empty tool_use input rather than a partial one, because the response claims \
-             this call completed"
+            "suppressing tool_use block with invalid arguments because generation was not cut off"
         );
-        return serde_json::json!({});
+        return None;
     }
 
     match recover_completed_members(arguments) {
@@ -613,17 +604,16 @@ pub(super) fn tool_use_input(
                 "tool call arguments were cut off at the token limit; keeping the members \
                  that completed. `stop_reason` is `max_tokens`"
             );
-            serde_json::Value::Object(map)
+            Some(serde_json::Value::Object(map))
         }
         None => {
             tracing::warn!(
                 tool_name = %tool_name,
                 argument_bytes = arguments.len(),
                 error = %error,
-                "tool call arguments were cut off at the token limit and no complete member \
-                 survived; emitting an empty tool_use input"
+                "suppressing truncated tool_use block because no complete member survived"
             );
-            serde_json::json!({})
+            None
         }
     }
 }
@@ -666,9 +656,8 @@ fn recover_completed_members(raw: &str) -> Option<serde_json::Map<String, serde_
     }
 
     // Truncation can land after a member's value but before the outer `}`, in which
-    // case there is no trailing comma and the comma scan finds nothing — yet every
-    // member present did finish. Close the object and take it, but only when the last
-    // value is provably complete (see `ends_on_a_finished_value`).
+    // case there is no trailing comma. Close the object only when the final value is
+    // provably complete; otherwise a partial number such as `2` could be fabricated.
     if ends_on_a_finished_value(trimmed)
         && let Ok(map) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(
             &format!("{}}}", trimmed.trim_end()),
@@ -682,31 +671,12 @@ fn recover_completed_members(raw: &str) -> Option<serde_json::Map<String, serde_
     serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&candidate).ok()
 }
 
-/// Whether the payload's last value is one that cannot have been cut short.
-///
-/// Appending `}` to a truncated object can turn an unfinished value into a plausible
-/// finished one. `{"n": 25` cut to `{"n": 2` closes into `{"n": 2}`, reporting an
-/// argument the model never emitted — the exact fabrication this module refuses to do.
-///
-/// Four tails prove the value is over:
-/// - trailing whitespace. JSON allows it only between tokens, so the value before it
-///   ended. This also covers a complete number.
-/// - an unescaped closing quote. It appears only once the string is over.
-/// - `}` or `]`. They appear only once the object or array is over.
-/// - `true`, `false` or `null`. No longer JSON token starts with one of them.
-///
-/// Only a bare number with nothing after it stays ambiguous, because its own digits may
-/// be cut short. It falls through to the comma scan.
+/// Whether the raw suffix proves that the final JSON value ended before truncation.
 fn ends_on_a_finished_value(trimmed: &str) -> bool {
     let tail = trimmed.trim_end();
-    // Whitespace cannot occur inside a JSON number or literal. Let the normal
-    // parser decide whether the value before it is valid; this also covers
-    // complete `true`, `false`, and `null` values.
     if tail.len() != trimmed.len() {
         return true;
     }
-
-    // A closing quote must not itself be escaped, or the string is still open.
     if let Some(before_quote) = tail.strip_suffix('"') {
         let backslashes = before_quote
             .chars()
@@ -736,10 +706,9 @@ pub fn chat_completion_to_anthropic_response(
     let mut stop_reason = None;
 
     if let Some(choice) = choice {
-        // Only the token limit means "cut off mid-call". Every other terminal reason
-        // claims the call finished, so partial arguments must not be recovered under it.
-        // This describes the choice; the call loop below narrows it to the last call,
-        // which is the only one the limit can have interrupted.
+        // Only the token limit means that a call may have been cut off. The loop
+        // below narrows this choice-level fact to the final call, which is the only
+        // call that can have been interrupted by the limit.
         let truncated = matches!(
             choice.finish_reason,
             Some(dynamo_protocols::types::FinishReason::Length)
@@ -756,16 +725,15 @@ pub fn chat_completion_to_anthropic_response(
 
         // Extract tool calls
         if let Some(tool_calls) = choice.message.tool_calls {
-            // The token limit stops generation once, inside the call the model was
-            // writing. Every earlier call finished, so only the last one can carry a
-            // truncated tail.
             let last_call = tool_calls.len().saturating_sub(1);
             for (call_index, tc) in tool_calls.into_iter().enumerate() {
-                let input = tool_use_input(
+                let Some(input) = tool_use_input(
                     &tc.function.name,
                     &tc.function.arguments,
                     truncated && call_index == last_call,
-                );
+                ) else {
+                    continue;
+                };
                 let emitted_id = new_tool_use_id();
                 tracing::debug!(
                     backend_id = %tc.id,
@@ -2506,52 +2474,9 @@ mod tests {
 }
 
 #[cfg(test)]
-mod truncated_tool_call_tests {
+mod anthropic_types_tests {
     use super::*;
 
-    /// Build a one-choice response carrying a single tool call with the given
-    /// finish reason and raw argument text, and return the Anthropic `input` it
-    /// converts to.
-    #[allow(deprecated)]
-    fn converted_tool_use_input(
-        finish_reason: dynamo_protocols::types::FinishReason,
-        arguments: &str,
-    ) -> serde_json::Value {
-        converted_tool_use_response(finish_reason, arguments)
-            .content
-            .into_iter()
-            .find_map(|block| match block {
-                AnthropicResponseContentBlock::ToolUse { input, .. } => Some(input),
-                _ => None,
-            })
-            .expect("expected a tool_use block")
-    }
-
-    #[allow(deprecated)]
-    fn converted_tool_use_response(
-        finish_reason: dynamo_protocols::types::FinishReason,
-        arguments: &str,
-    ) -> AnthropicMessageResponse {
-        converted_tool_use_response_for(finish_reason, &[arguments])
-    }
-
-    /// Every `tool_use` input in the converted response, in call order.
-    fn converted_tool_use_inputs(
-        finish_reason: dynamo_protocols::types::FinishReason,
-        arguments: &[&str],
-    ) -> Vec<serde_json::Value> {
-        converted_tool_use_response_for(finish_reason, arguments)
-            .content
-            .into_iter()
-            .filter_map(|block| match block {
-                AnthropicResponseContentBlock::ToolUse { input, .. } => Some(input),
-                _ => None,
-            })
-            .collect()
-    }
-
-    /// One tool call per entry in `arguments`, so a test can build a choice that
-    /// carries parallel calls.
     #[allow(deprecated)]
     fn converted_tool_use_response_for(
         finish_reason: dynamo_protocols::types::FinishReason,
@@ -2561,12 +2486,12 @@ mod truncated_tool_call_tests {
             .iter()
             .enumerate()
             .map(
-                |(index, args)| dynamo_protocols::types::ChatCompletionMessageToolCall {
+                |(index, arguments)| dynamo_protocols::types::ChatCompletionMessageToolCall {
                     id: format!("call_{}", index + 1),
                     r#type: dynamo_protocols::types::FunctionType::Function,
                     function: dynamo_protocols::types::FunctionCall {
                         name: "record_literal".into(),
-                        arguments: args.to_string(),
+                        arguments: (*arguments).into(),
                     },
                 },
             )
@@ -2592,99 +2517,26 @@ mod truncated_tool_call_tests {
                 model: "test-model".into(),
                 service_tier: None,
                 system_fingerprint: None,
-                object: "chat.completion".to_string(),
+                object: "chat.completion".into(),
                 usage: None,
             },
             nvext: None,
         };
-
         chat_completion_to_anthropic_response(chat_resp, "test-model", None)
     }
 
-    /// Pins the WIRING, not the helper. The eight helper tests below all call
-    /// `tool_use_input` directly, so reverting the conversion site to the old
-    /// `unwrap_or(json!({}))` left every one of them green. This one goes red,
-    /// because it reaches the recovery only through `chat_completion_to_anthropic_response`.
-    #[test]
-    fn the_conversion_recovers_members_when_the_reason_is_the_token_limit() {
-        assert_eq!(
-            converted_tool_use_input(dynamo_protocols::types::FinishReason::Length, TRUNCATED),
-            serde_json::json!({"label": "customer-eof"}),
-            "a call cut off at the token limit must keep the members that finished"
-        );
-    }
-
-    /// The guard on the rule above. When the upstream reason says the call FINISHED,
-    /// malformed arguments are a generation defect, not a truncation. Recovering members
-    /// there would emit a call that looks complete while silently carrying only some of
-    /// its arguments -- one a client can validate and then run. The empty object is the
-    /// honest answer, because it fails the tool's schema instead of half-succeeding.
-    #[test]
-    fn the_conversion_refuses_partial_arguments_when_the_call_claims_it_finished() {
-        for reason in [
-            dynamo_protocols::types::FinishReason::ToolCalls,
-            dynamo_protocols::types::FinishReason::Stop,
-            dynamo_protocols::types::FinishReason::ContentFilter,
-            dynamo_protocols::types::FinishReason::FunctionCall,
-        ] {
-            assert_eq!(
-                converted_tool_use_input(reason, TRUNCATED),
-                serde_json::json!({}),
-                "{reason:?} claims the call completed, so partial arguments must not be emitted"
-            );
-        }
-    }
-
-    #[test]
-    fn the_conversion_maps_content_filter_to_refusal() {
-        let response = converted_tool_use_response(
-            dynamo_protocols::types::FinishReason::ContentFilter,
-            r#"{"label": "blocked"}"#,
-        );
-        assert_eq!(response.stop_reason, Some(AnthropicStopReason::Refusal));
-    }
-
-    /// Malformed, but NOT cut short: the model closed the object and still emitted
-    /// arguments that do not parse. Recovery must refuse this shape.
-    const MALFORMED_BUT_COMPLETE: &str = r#"{"label": "a", "extra": }"#;
-
-    /// `truncated` describes the CHOICE, but only the last call can be the one the
-    /// model was writing when the budget ran out. It finished every earlier call, so
-    /// malformed arguments there are a generation defect and must still yield `{}`.
-    #[test]
-    fn only_the_final_tool_call_recovers_partial_arguments() {
-        let inputs = converted_tool_use_inputs(
-            dynamo_protocols::types::FinishReason::Length,
-            &[MALFORMED_BUT_COMPLETE, TRUNCATED],
-        );
-
-        assert_eq!(inputs.len(), 2, "both calls must reach the response");
-        assert_eq!(
-            inputs[0],
-            serde_json::json!({}),
-            "a call the model finished must not be repaired, even at the token limit"
-        );
-        assert_eq!(
-            inputs[1],
-            serde_json::json!({"label": "customer-eof"}),
-            "the final call is the only one that can have been cut off"
-        );
-    }
-
-    /// Valid arguments are untouched no matter which reason ended generation.
-    #[test]
-    fn the_conversion_passes_valid_arguments_through_for_every_reason() {
-        for reason in [
-            dynamo_protocols::types::FinishReason::Length,
-            dynamo_protocols::types::FinishReason::ToolCalls,
-            dynamo_protocols::types::FinishReason::Stop,
-        ] {
-            assert_eq!(
-                converted_tool_use_input(reason, r#"{"label": "done"}"#),
-                serde_json::json!({"label": "done"}),
-                "valid arguments must survive {reason:?} unchanged"
-            );
-        }
+    fn converted_tool_use_inputs(
+        finish_reason: dynamo_protocols::types::FinishReason,
+        arguments: &[&str],
+    ) -> Vec<serde_json::Value> {
+        converted_tool_use_response_for(finish_reason, arguments)
+            .content
+            .into_iter()
+            .filter_map(|block| match block {
+                AnthropicResponseContentBlock::ToolUse { input, .. } => Some(input),
+                _ => None,
+            })
+            .collect()
     }
 
     /// The measured payload: `record_literal` cut off inside the second
@@ -2692,9 +2544,35 @@ mod truncated_tool_call_tests {
     const TRUNCATED: &str =
         r#"{"label": "customer-eof", "literal_text": "customer-eof-xxxxxxxxxxxxxxxxxxxx"#;
 
+    const MALFORMED_BUT_COMPLETE: &str = r#"{"label": "a", "extra": }"#;
+
+    #[test]
+    fn conversion_recovers_members_only_for_the_final_length_call() {
+        let inputs = converted_tool_use_inputs(
+            dynamo_protocols::types::FinishReason::Length,
+            &[MALFORMED_BUT_COMPLETE, TRUNCATED],
+        );
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0], serde_json::json!({"label": "customer-eof"}));
+    }
+
+    #[test]
+    fn conversion_does_not_recover_malformed_non_length_arguments() {
+        for reason in [
+            dynamo_protocols::types::FinishReason::ToolCalls,
+            dynamo_protocols::types::FinishReason::Stop,
+            dynamo_protocols::types::FinishReason::ContentFilter,
+            dynamo_protocols::types::FinishReason::FunctionCall,
+        ] {
+            let inputs = converted_tool_use_inputs(reason, &[TRUNCATED]);
+            assert!(inputs.is_empty(), "unexpected tool block for {reason:?}");
+        }
+    }
+
     #[test]
     fn truncated_arguments_keep_the_members_that_completed() {
-        let input = tool_use_input("record_literal", TRUNCATED, true);
+        let input = tool_use_input("record_literal", TRUNCATED, true)
+            .expect("completed members should be recovered");
         let obj = input.as_object().expect("input must stay an object");
 
         // The finished member survives verbatim.
@@ -2714,84 +2592,58 @@ mod truncated_tool_call_tests {
     /// received a well-formed tool_use block and executed it with no arguments.
     #[test]
     fn truncated_arguments_are_not_silently_emptied() {
-        assert_ne!(
+        assert_eq!(
             tool_use_input("record_literal", TRUNCATED, true),
-            serde_json::json!({}),
-            "unparseable arguments must not collapse to an empty object"
+            Some(serde_json::json!({"label": "customer-eof"}))
         );
     }
 
     #[test]
     fn valid_arguments_are_passed_through_unchanged() {
         let input = tool_use_input("get_weather", r#"{"location": "SF", "unit": "c"}"#, true);
-        assert_eq!(input, serde_json::json!({"location": "SF", "unit": "c"}));
-    }
-
-    /// Truncation after a member value but before the closing brace. There is no
-    /// trailing comma, so the comma scan alone finds nothing, yet `label` did finish.
-    /// Returning `{}` here would be the empty-object failure this module exists to stop.
-    #[test]
-    fn a_final_member_without_a_trailing_comma_is_recovered() {
-        let recovered =
-            recover_completed_members(r#"{"label": "customer-eof""#).expect("`label` completed");
         assert_eq!(
-            recovered.get("label").and_then(|v| v.as_str()),
-            Some("customer-eof")
+            input,
+            Some(serde_json::json!({"location": "SF", "unit": "c"}))
         );
-        assert_eq!(recovered.len(), 1);
+    }
 
-        // Same shape reached through the public entry point.
+    #[test]
+    fn conversion_maps_content_filter_to_refusal() {
+        let response = converted_tool_use_response_for(
+            dynamo_protocols::types::FinishReason::ContentFilter,
+            &[r#"{"label":"blocked"}"#],
+        );
+        assert_eq!(response.stop_reason, Some(AnthropicStopReason::Refusal));
+    }
+
+    #[test]
+    fn final_member_without_closing_brace_is_recovered_when_provably_complete() {
         assert_eq!(
-            tool_use_input("record_literal", r#"{"label": "customer-eof""#, true),
-            serde_json::json!({"label": "customer-eof"})
+            tool_use_input("record_literal", r#"{"label":"done""#, true),
+            Some(serde_json::json!({"label": "done"}))
         );
-
-        // A closed nested value is equally provably finished.
-        let recovered =
-            recover_completed_members(r#"{"a": 1, "b": {"p": 2}"#).expect("`a` and `b` completed");
-        assert_eq!(recovered.get("b"), Some(&serde_json::json!({"p": 2})));
-        assert_eq!(recovered.len(), 2);
-    }
-
-    /// The guard on the case above: closing the brace after a BARE NUMBER would invent a
-    /// value, because the digits may themselves be truncated. `{"n": 25` cut to `{"n": 2`
-    /// must not be reported as `n = 2`.
-    #[test]
-    fn a_truncated_number_is_never_closed_into_a_value() {
-        assert_eq!(recover_completed_members(r#"{"n": 2"#), None);
-
-        // With an earlier complete member, fall back to the comma boundary and drop the
-        // ambiguous tail rather than reporting it.
-        let recovered = recover_completed_members(r#"{"a": "x", "n": 2"#).expect("`a` completed");
-        assert_eq!(recovered.get("a").and_then(|v| v.as_str()), Some("x"));
-        assert!(
-            !recovered.contains_key("n"),
-            "a possibly-truncated number must not be reported, got: {recovered:?}"
+        assert_eq!(
+            recover_completed_members(r#"{"count": 2 "#).unwrap()["count"],
+            2
         );
-
-        // An escaped quote at the very end leaves the string open; it is not a finished
-        // value and must not be closed either.
-        assert_eq!(recover_completed_members(r#"{"a": "he said \""#), None);
+        assert_eq!(
+            recover_completed_members(r#"{"ok": true "#).unwrap()["ok"],
+            true
+        );
+        assert_eq!(
+            recover_completed_members(r#"{"ok": false "#).unwrap()["ok"],
+            false
+        );
+        assert_eq!(
+            recover_completed_members(r#"{"value": null "#).unwrap()["value"],
+            serde_json::Value::Null
+        );
     }
 
     #[test]
-    fn scalar_values_followed_by_whitespace_are_recovered() {
-        for (key, value, expected) in [
-            ("count", r#"2 "#, serde_json::json!(2)),
-            ("enabled", "true ", serde_json::json!(true)),
-            ("enabled", "false ", serde_json::json!(false)),
-            ("value", "null ", serde_json::Value::Null),
-        ] {
-            let input = format!(r#"{{"{key}": {value}"#);
-            let recovered = recover_completed_members(&input).expect("scalar value completed");
-            assert_eq!(recovered.get(key), Some(&expected));
-        }
-    }
-
-    #[test]
-    fn an_undelimited_scalar_is_not_recovered() {
+    fn undelimited_scalar_prefix_is_not_recovered() {
         assert_eq!(recover_completed_members(r#"{"count": 2"#), None);
-        assert_eq!(recover_completed_members(r#"{"enabled": tru"#), None);
+        assert_eq!(recover_completed_members(r#"{"ok": tru"#), None);
         assert_eq!(recover_completed_members(r#"{"value": nul"#), None);
     }
 

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -591,6 +591,7 @@ impl OpenAIOutputOptionsProvider for NvCreateChatCompletionRequest {
 impl ValidateRequest for NvCreateChatCompletionRequest {
     fn validate(&self) -> Result<(), anyhow::Error> {
         validate::validate_no_unsupported_fields(&self.unsupported_fields)?;
+        validate::validate_guided_decoding(self)?;
         validate::validate_chat_template_args(self.chat_template_args.as_ref())?;
         validate::validate_messages(&self.inner.messages)?;
         validate::validate_model(&self.inner.model)?;
@@ -688,16 +689,13 @@ mod tests {
         ];
 
         for extra in conflicts {
-            let error = chat_request_with(&extra)
-                .extract_sampling_options()
-                .unwrap_err();
-            let dynamo_error = error
-                .downcast_ref::<dynamo_runtime::error::DynamoError>()
-                .expect("sampling extraction must preserve the HTTP error type");
-            assert_eq!(
-                dynamo_error.error_type(),
-                dynamo_runtime::error::ErrorType::InvalidArgument,
-                "guided-decoding conflicts must map to HTTP 400",
+            let request = chat_request_with(&extra);
+            let error = ValidateRequest::validate(&request).expect_err("constraints conflict");
+            assert!(
+                error
+                    .to_string()
+                    .contains("Only one guided-decoding constraint"),
+                "validation error should name the conflict, got: {error}"
             );
         }
     }

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -753,7 +753,10 @@ mod tests {
             json!({"guided_whitespace_pattern": "[\n ]?"}),
             json!({"guided_decoding_backend": "xgrammar"}),
         ] {
-            let sampling = chat_request_with(&extra)
+            let request = chat_request_with(&extra);
+            ValidateRequest::validate(&request)
+                .unwrap_or_else(|e| panic!("{extra} must pass request validation, got: {e}"));
+            let sampling = request
                 .extract_sampling_options()
                 .unwrap_or_else(|e| panic!("{extra} must stay valid, got: {e}"));
             assert!(

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -2315,6 +2315,43 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_finished_tool_call_with_no_argument_bytes_remains_valid() {
+        let call = dynamo_protocols::types::ChatCompletionMessageToolCallChunk {
+            index: 0,
+            id: Some("first".to_string()),
+            r#type: Some(dynamo_protocols::types::FunctionType::Function),
+            function: Some(dynamo_protocols::types::FunctionCallStream {
+                name: Some("get_weather".to_string()),
+                arguments: None,
+            }),
+        };
+        let result = DeltaAggregator::apply(
+            Box::pin(stream::iter(vec![create_test_delta_with_tool_chunks(
+                0,
+                vec![call],
+                Some(dynamo_protocols::types::FinishReason::ToolCalls),
+                Some(dynamo_protocols::types::Role::Assistant),
+            )])),
+            ParsingOptions::default(),
+        )
+        .await
+        .unwrap();
+
+        let tool_calls = result.inner.choices[0]
+            .message
+            .tool_calls
+            .as_ref()
+            .expect("a finished parameterless call must remain valid");
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.name, "get_weather");
+        assert_eq!(tool_calls[0].function.arguments, "");
+        assert_eq!(
+            result.inner.choices[0].finish_reason,
+            Some(dynamo_protocols::types::FinishReason::ToolCalls)
+        );
+    }
+
     /// `phi4` opens a call with the bare word `functools`, so cutting content at every
     /// configured marker would truncate an ordinary answer about that Python module.
     #[tokio::test]

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -190,8 +190,12 @@ fn suppress_tool_call_output(choice: &mut DeltaChoice) {
 
 /// A token-limit finish can interrupt only the final structured call. Keep earlier
 /// calls whose argument strings are valid JSON, but do not expose the incomplete call
-/// as executable structured output. An empty argument string remains valid for a
-/// parameterless tool call because the stream schema permits omitted arguments.
+/// as executable structured output.
+///
+/// An empty argument string is the MOST truncated shape, not a parameterless call: the
+/// limit landed after the name and before the first argument token. The wire schema does
+/// permit omitted arguments, but nothing here can tell that apart from a call cut short,
+/// so at the token limit it is dropped with every other unparseable tail.
 fn drop_incomplete_length_tool_calls(choice: &mut DeltaChoice) {
     if choice.finish_reason != Some(dynamo_protocols::types::FinishReason::Length) {
         return;
@@ -207,7 +211,6 @@ fn drop_incomplete_length_tool_calls(choice: &mut DeltaChoice) {
         .enumerate()
         .filter(|(index, tool_call)| {
             *index != terminal_index
-                || tool_call.function.arguments.is_empty()
                 || serde_json::from_str::<serde_json::Value>(&tool_call.function.arguments).is_ok()
         })
         .map(|(_, tool_call)| tool_call)
@@ -233,7 +236,7 @@ fn suppress_incomplete_structured_content(
     }
 
     if let Some(marker_start) =
-        super::unified_parser::first_unquoted_native_tool_call_marker(&choice.text, parser)
+        super::unified_parser::first_unquoted_structural_tool_call_marker(&choice.text, parser)
     {
         tracing::warn!(
             parser,
@@ -1812,7 +1815,33 @@ mod tests {
         annotated_delta2.data.as_mut().expect("delta data").nvext =
             Some(serde_json::json!({ "stop_reason": 128001 }));
 
-        let stream = Box::pin(stream::iter(vec![annotated_delta1, annotated_delta2]));
+        let mut metadata = annotated_delta2.clone();
+        let metadata_data = metadata.data.as_mut().expect("metadata data");
+        metadata_data.inner.choices.clear();
+        metadata_data.nvext = Some(serde_json::json!({
+            "engine_data": {
+                "prompt_token_ids": [1, 2],
+                "completion_token_ids": [10, 11],
+                "completion_logprobs": [-0.1, -0.2],
+            }
+        }));
+
+        let mut usage = metadata.clone();
+        let usage_data = usage.data.as_mut().expect("usage data");
+        usage_data.nvext = None;
+        usage_data.inner.usage = Some(dynamo_protocols::types::CompletionUsage {
+            prompt_tokens: 2,
+            completion_tokens: 2,
+            total_tokens: 4,
+            ..Default::default()
+        });
+
+        let stream = Box::pin(stream::iter(vec![
+            annotated_delta1,
+            annotated_delta2,
+            metadata,
+            usage,
+        ]));
         let response = DeltaAggregator::apply(stream, ParsingOptions::default())
             .await
             .expect("aggregate stream");
@@ -1820,9 +1849,18 @@ mod tests {
         assert_eq!(
             response.nvext,
             Some(serde_json::json!({
-                "engine_data": { "trace_id": "abc" },
+                "engine_data": {
+                    "prompt_token_ids": [1, 2],
+                    "completion_token_ids": [10, 11],
+                    "completion_logprobs": [-0.1, -0.2],
+                },
                 "stop_reason": 128001,
             }))
+        );
+        assert_eq!(response.inner.choices.len(), 1);
+        assert_eq!(
+            response.inner.usage.expect("aggregated usage").total_tokens,
+            4
         );
     }
 
@@ -2238,6 +2276,68 @@ mod tests {
         assert_eq!(tool_calls.len(), 1);
         assert_eq!(tool_calls[0].function.name, "get_weather");
         assert_eq!(tool_calls[0].function.arguments, "{\"city\":\"Paris\"}");
+    }
+
+    /// The limit can land after the function name and before the first argument
+    /// token. That leaves no argument bytes, which is the most truncated shape, not a
+    /// parameterless call, so it must not reach the client as executable.
+    #[tokio::test]
+    async fn test_length_drops_a_final_tool_call_with_no_argument_bytes() {
+        let call = dynamo_protocols::types::ChatCompletionMessageToolCallChunk {
+            index: 0,
+            id: Some("first".to_string()),
+            r#type: Some(dynamo_protocols::types::FunctionType::Function),
+            function: Some(dynamo_protocols::types::FunctionCallStream {
+                name: Some("get_weather".to_string()),
+                arguments: None,
+            }),
+        };
+        let result = DeltaAggregator::apply(
+            Box::pin(stream::iter(vec![create_test_delta_with_tool_chunks(
+                0,
+                vec![call],
+                Some(dynamo_protocols::types::FinishReason::Length),
+                Some(dynamo_protocols::types::Role::Assistant),
+            )])),
+            ParsingOptions::default(),
+        )
+        .await
+        .unwrap();
+
+        let choice = &result.inner.choices[0];
+        assert!(
+            choice.message.tool_calls.is_none(),
+            "a call cut off before its arguments must not be executable"
+        );
+        assert_eq!(
+            choice.finish_reason,
+            Some(dynamo_protocols::types::FinishReason::Length)
+        );
+    }
+
+    /// `phi4` opens a call with the bare word `functools`, so cutting content at every
+    /// configured marker would truncate an ordinary answer about that Python module.
+    #[tokio::test]
+    async fn test_length_keeps_prose_containing_a_word_shaped_marker() {
+        let text = "Use functools.lru_cache to memoize the call, and it will";
+        let result = DeltaAggregator::apply(
+            Box::pin(stream::iter(vec![create_test_delta(
+                0,
+                text,
+                Some(dynamo_protocols::types::Role::Assistant),
+                Some(dynamo_protocols::types::FinishReason::Length),
+                None,
+                None,
+            )])),
+            ParsingOptions::new(Some("phi4".to_string()), None),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.inner.choices[0].message.content,
+            Some(ChatCompletionMessageContent::Text(text.to_string()))
+        );
     }
 
     #[tokio::test]

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -40,18 +40,7 @@ fn contains_harmony_protocol(text: &str) -> bool {
 /// `unified_parser::contains_unquoted_marker` so a marker embedded inside a quoted string
 /// is not misread as native tool-call markup.
 fn contains_native_tool_call_marker(content: &str, parser: &str) -> bool {
-    let parser_key = if parser.is_empty() { "default" } else { parser };
-    let Some(config) = dynamo_parsers::tool_calling::parsers::get_tool_parser_map().get(parser_key)
-    else {
-        return false;
-    };
-    config
-        .parser_config
-        .tool_call_start_tokens()
-        .iter()
-        .any(|marker| {
-            !marker.is_empty() && super::unified_parser::contains_unquoted_marker(content, marker)
-        })
+    super::unified_parser::first_unquoted_native_tool_call_marker(content, parser).is_some()
 }
 
 /// Drops any recovered native-fallback calls that don't match the forced
@@ -196,6 +185,69 @@ fn suppress_tool_call_output(choice: &mut DeltaChoice) {
     choice.tool_calls = None;
     if choice.finish_reason == Some(dynamo_protocols::types::FinishReason::ToolCalls) {
         choice.finish_reason = Some(dynamo_protocols::types::FinishReason::Stop);
+    }
+}
+
+/// A token-limit finish can interrupt only the final structured call. Keep earlier
+/// calls whose argument strings are valid JSON, but do not expose the incomplete call
+/// as executable structured output. An empty argument string remains valid for a
+/// parameterless tool call because the stream schema permits omitted arguments.
+fn drop_incomplete_length_tool_calls(choice: &mut DeltaChoice) {
+    if choice.finish_reason != Some(dynamo_protocols::types::FinishReason::Length) {
+        return;
+    }
+
+    let Some(tool_calls) = choice.tool_calls.as_mut() else {
+        return;
+    };
+    let terminal_index = tool_calls.len().saturating_sub(1);
+    let calls = std::mem::take(tool_calls);
+    *tool_calls = calls
+        .into_iter()
+        .enumerate()
+        .filter(|(index, tool_call)| {
+            *index != terminal_index
+                || tool_call.function.arguments.is_empty()
+                || serde_json::from_str::<serde_json::Value>(&tool_call.function.arguments).is_ok()
+        })
+        .map(|(_, tool_call)| tool_call)
+        .collect();
+    if tool_calls.is_empty() {
+        choice.tool_calls = None;
+    }
+}
+
+/// A failed structured parse at the output limit is not ordinary assistant prose.
+/// Suppress the incomplete candidate rather than exposing parser markup or a partial
+/// guided-JSON document as `content`. Plain text remains untouched unless the parser
+/// actually identified a structured candidate.
+fn suppress_incomplete_structured_content(
+    choice: &mut DeltaChoice,
+    parser: &str,
+    constraint: &crate::protocols::openai::GuidedToolConstraint,
+) {
+    if choice.finish_reason != Some(dynamo_protocols::types::FinishReason::Length)
+        || choice.text.is_empty()
+    {
+        return;
+    }
+
+    if let Some(marker_start) =
+        super::unified_parser::first_unquoted_native_tool_call_marker(&choice.text, parser)
+    {
+        tracing::warn!(
+            parser,
+            suppressed_bytes = choice.text.len() - marker_start,
+            "suppressing incomplete structured tool output on length finish"
+        );
+        choice.text.truncate(marker_start);
+    } else if constraint.installs_guided_json() {
+        tracing::warn!(
+            parser,
+            recovered_bytes = choice.text.len(),
+            "suppressing incomplete guided structured output on length finish"
+        );
+        choice.text.clear();
     }
 }
 
@@ -530,6 +582,11 @@ impl DeltaAggregator {
                     Err(error) => {
                         // Best-effort: the aggregated text is served as-is rather than
                         // failing a request the model already answered.
+                        suppress_incomplete_structured_content(
+                            choice,
+                            family,
+                            &parsing_options.guided_tool_constraint,
+                        );
                         tracing::warn!(
                             error = %error,
                             family,
@@ -661,6 +718,11 @@ impl DeltaAggregator {
                             }
                         }
                         Err(error) => {
+                            suppress_incomplete_structured_content(
+                                choice,
+                                family,
+                                &parsing_options.guided_tool_constraint,
+                            );
                             tracing::debug!(error = %error, family, "muse unified batch parse failed");
                         }
                     }
@@ -677,31 +739,6 @@ impl DeltaAggregator {
                 // parse_complete drops a value truncated at EOF instead of guessing it.
                 // Other families and the flag-off path keep the v1 finalize path.
                 // Guided JSON is handled above from the exact carried constraint.
-                // Extract the truncated tail BEFORE parsing so a second <tool_call>
-                // truncated after a complete first one is not silently dropped.
-                // Token strings come from the parser config so this stays in sync
-                // with any override, and matches the streaming path in preprocessor.rs.
-                let glm47_cfg = dynamo_parsers::tool_calling::config::Glm47ParserConfig::default();
-                let glm47_truncated_tail = if parser == "glm47"
-                    && matches!(
-                        choice.finish_reason,
-                        Some(dynamo_protocols::types::FinishReason::Length)
-                    ) {
-                    choice
-                        .text
-                        .rfind(glm47_cfg.tool_call_start.as_str())
-                        .and_then(|start| {
-                            let tail = &choice.text[start..];
-                            if !tail.contains(glm47_cfg.tool_call_end.as_str()) {
-                                Some(tail.to_string())
-                            } else {
-                                None
-                            }
-                        })
-                } else {
-                    None
-                };
-
                 let parse_result = parse_complete_tool_output(
                     &choice.text,
                     parser,
@@ -711,6 +748,11 @@ impl DeltaAggregator {
                 let (tool_calls, content) = match parse_result {
                     Ok(result) => result,
                     Err(error) => {
+                        suppress_incomplete_structured_content(
+                            choice,
+                            parser,
+                            &parsing_options.guided_tool_constraint,
+                        );
                         tracing::debug!(
                             error = %error,
                             parser,
@@ -732,36 +774,20 @@ impl DeltaAggregator {
                     || is_kimi_k3_parser(parser)
                 {
                     choice.text = content.unwrap_or_default();
-                } else if parser == "glm47"
-                    && matches!(
-                        choice.finish_reason,
-                        Some(dynamo_protocols::types::FinishReason::Length)
-                    )
-                    && choice.text.contains(glm47_cfg.tool_call_start.as_str())
+                } else if choice.finish_reason
+                    == Some(dynamo_protocols::types::FinishReason::Length)
                 {
-                    tracing::warn!(
+                    suppress_incomplete_structured_content(
+                        choice,
                         parser,
-                        "glm47: partial <tool_call> returned as content on length finish"
+                        &parsing_options.guided_tool_constraint,
                     );
-                }
-
-                // Recover any tail saved before parsing — the parser drops a truncated
-                // second block silently when an earlier complete block was already parsed.
-                if let Some(tail) = glm47_truncated_tail
-                    && !choice.text.contains(&tail)
-                {
-                    tracing::warn!(
-                        parser,
-                        tail_bytes = tail.len(),
-                        "glm47: truncated later <tool_call> appended as content"
-                    );
-                    if choice.text.is_empty() {
-                        choice.text = tail;
-                    } else {
-                        choice.text.push_str(&tail);
-                    }
                 }
             }
+        }
+
+        for choice in aggregator.choices.values_mut() {
+            drop_incomplete_length_tool_calls(choice);
         }
 
         // A retained whole-response parser may discover a syntactically valid
@@ -855,12 +881,10 @@ impl From<DeltaChoice> for dynamo_protocols::types::ChatChoice {
     fn from(delta: DeltaChoice) -> Self {
         // A terminal reason that already explains why generation ended
         // outranks the tool-call rewrite. Only `Stop` and a missing reason are
-        // rewritten. The streaming path applies the same rule in two parts:
-        // `unified_parser::ChoiceState::normalize_finish_reason` rewrites `Stop`, and
-        // `unified_parser::ChoiceState::unterminated_finish_reason` supplies `ToolCalls`
-        // when no reason arrives at all. The two paths used to disagree, so a call
-        // truncated at the token limit reached a non-streaming caller labelled
-        // `tool_calls` with no sign it had been cut off.
+        // rewritten, which is the same rule the streaming path applies in
+        // `unified_parser::ChoiceState::normalize_finish_reason`; the two paths used to
+        // disagree, so a call truncated at the token limit reached a non-streaming
+        // caller labelled `tool_calls` with no sign it had been cut off.
         //
         // Preserving `Length` is also what makes the Responses conversion reachable:
         // `responses::chat_completion_to_response` keys `status: "incomplete"` and
@@ -1788,33 +1812,7 @@ mod tests {
         annotated_delta2.data.as_mut().expect("delta data").nvext =
             Some(serde_json::json!({ "stop_reason": 128001 }));
 
-        let mut metadata = annotated_delta2.clone();
-        let metadata_data = metadata.data.as_mut().expect("metadata data");
-        metadata_data.inner.choices.clear();
-        metadata_data.nvext = Some(serde_json::json!({
-            "engine_data": {
-                "prompt_token_ids": [1, 2],
-                "completion_token_ids": [10, 11],
-                "completion_logprobs": [-0.1, -0.2],
-            }
-        }));
-
-        let mut usage = metadata.clone();
-        let usage_data = usage.data.as_mut().expect("usage data");
-        usage_data.nvext = None;
-        usage_data.inner.usage = Some(dynamo_protocols::types::CompletionUsage {
-            prompt_tokens: 2,
-            completion_tokens: 2,
-            total_tokens: 4,
-            ..Default::default()
-        });
-
-        let stream = Box::pin(stream::iter(vec![
-            annotated_delta1,
-            annotated_delta2,
-            metadata,
-            usage,
-        ]));
+        let stream = Box::pin(stream::iter(vec![annotated_delta1, annotated_delta2]));
         let response = DeltaAggregator::apply(stream, ParsingOptions::default())
             .await
             .expect("aggregate stream");
@@ -1822,18 +1820,9 @@ mod tests {
         assert_eq!(
             response.nvext,
             Some(serde_json::json!({
-                "engine_data": {
-                    "prompt_token_ids": [1, 2],
-                    "completion_token_ids": [10, 11],
-                    "completion_logprobs": [-0.1, -0.2],
-                },
+                "engine_data": { "trace_id": "abc" },
                 "stop_reason": 128001,
             }))
-        );
-        assert_eq!(response.inner.choices.len(), 1);
-        assert_eq!(
-            response.inner.usage.expect("aggregated usage").total_tokens,
-            4
         );
     }
 
@@ -2068,6 +2057,187 @@ mod tests {
             choice.finish_reason,
             Some(dynamo_protocols::types::FinishReason::ContentFilter)
         );
+    }
+
+    #[tokio::test]
+    async fn test_length_drops_incomplete_structured_tool_call_without_leaking_content() {
+        let mut annotated_delta = create_test_delta(
+            0,
+            "",
+            Some(dynamo_protocols::types::Role::Assistant),
+            Some(dynamo_protocols::types::FinishReason::Length),
+            None,
+            Some(r#"{"name":"search","arguments":{}}"#),
+        );
+        annotated_delta
+            .data
+            .as_mut()
+            .expect("test delta data")
+            .inner
+            .choices[0]
+            .delta
+            .tool_calls
+            .as_mut()
+            .expect("structured tool call")[0]
+            .function
+            .as_mut()
+            .expect("tool function")
+            .arguments = Some(r#"{"query":"Par"#.to_string());
+        let response = DeltaAggregator::apply(
+            Box::pin(stream::iter(vec![annotated_delta])),
+            ParsingOptions::default(),
+        )
+        .await
+        .expect("aggregation should succeed");
+
+        let choice = &response.inner.choices[0];
+        assert_eq!(
+            choice.finish_reason,
+            Some(dynamo_protocols::types::FinishReason::Length)
+        );
+        assert!(choice.message.tool_calls.is_none());
+        assert_eq!(choice.message.content, None);
+        assert!(!serde_json::to_string(choice).unwrap().contains("Par"));
+    }
+
+    #[tokio::test]
+    async fn test_length_keeps_prose_before_incomplete_native_marker() {
+        let text = "I can help. <tool_call>get_weather<arg_key>city</arg_key><arg_value>Par";
+        let delta = create_test_delta(
+            0,
+            text,
+            Some(dynamo_protocols::types::Role::Assistant),
+            Some(dynamo_protocols::types::FinishReason::Length),
+            None,
+            None,
+        );
+        let result = DeltaAggregator::apply(
+            Box::pin(stream::iter(vec![delta])),
+            ParsingOptions::new(Some("glm47".to_string()), None),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.inner.choices[0].message.content,
+            Some(ChatCompletionMessageContent::Text(
+                "I can help. ".to_string()
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_length_retains_a_nonfinal_invalid_structured_tool_call() {
+        let make_name = |idx: u32, id: &str, name: &str| {
+            dynamo_protocols::types::ChatCompletionMessageToolCallChunk {
+                index: idx,
+                id: Some(id.to_string()),
+                r#type: Some(dynamo_protocols::types::FunctionType::Function),
+                function: Some(dynamo_protocols::types::FunctionCallStream {
+                    name: Some(name.to_string()),
+                    arguments: None,
+                }),
+            }
+        };
+        let make_args = |idx: u32, fragment: &str| {
+            dynamo_protocols::types::ChatCompletionMessageToolCallChunk {
+                index: idx,
+                id: None,
+                r#type: None,
+                function: Some(dynamo_protocols::types::FunctionCallStream {
+                    name: None,
+                    arguments: Some(fragment.to_string()),
+                }),
+            }
+        };
+        let first = create_test_delta_with_tool_chunks(
+            0,
+            vec![make_name(0, "first", "get_weather")],
+            None,
+            Some(dynamo_protocols::types::Role::Assistant),
+        );
+        let first_args =
+            create_test_delta_with_tool_chunks(0, vec![make_args(0, "{\"city\":")], None, None);
+        let second = create_test_delta_with_tool_chunks(
+            0,
+            vec![
+                make_name(1, "second", "get_time"),
+                make_args(1, "{\"tz\":\"UTC\"}"),
+            ],
+            Some(dynamo_protocols::types::FinishReason::Length),
+            None,
+        );
+        let result = DeltaAggregator::apply(
+            Box::pin(stream::iter(vec![first, first_args, second])),
+            ParsingOptions::default(),
+        )
+        .await
+        .unwrap();
+
+        let tool_calls = result.inner.choices[0]
+            .message
+            .tool_calls
+            .as_ref()
+            .expect("both ordered calls must remain visible");
+        assert_eq!(tool_calls.len(), 2);
+        assert_eq!(tool_calls[0].function.arguments, "{\"city\":");
+        assert_eq!(tool_calls[1].function.arguments, "{\"tz\":\"UTC\"}");
+    }
+
+    #[tokio::test]
+    async fn test_length_drops_the_final_invalid_structured_tool_call() {
+        let make_name = |idx: u32, id: &str, name: &str| {
+            dynamo_protocols::types::ChatCompletionMessageToolCallChunk {
+                index: idx,
+                id: Some(id.to_string()),
+                r#type: Some(dynamo_protocols::types::FunctionType::Function),
+                function: Some(dynamo_protocols::types::FunctionCallStream {
+                    name: Some(name.to_string()),
+                    arguments: None,
+                }),
+            }
+        };
+        let make_args = |idx: u32, fragment: &str| {
+            dynamo_protocols::types::ChatCompletionMessageToolCallChunk {
+                index: idx,
+                id: None,
+                r#type: None,
+                function: Some(dynamo_protocols::types::FunctionCallStream {
+                    name: None,
+                    arguments: Some(fragment.to_string()),
+                }),
+            }
+        };
+        let first = create_test_delta_with_tool_chunks(
+            0,
+            vec![
+                make_name(0, "first", "get_weather"),
+                make_args(0, "{\"city\":\"Paris\"}"),
+            ],
+            None,
+            Some(dynamo_protocols::types::Role::Assistant),
+        );
+        let final_invalid = create_test_delta_with_tool_chunks(
+            0,
+            vec![make_name(1, "second", "get_time"), make_args(1, "{\"tz\":")],
+            Some(dynamo_protocols::types::FinishReason::Length),
+            None,
+        );
+        let result = DeltaAggregator::apply(
+            Box::pin(stream::iter(vec![first, final_invalid])),
+            ParsingOptions::default(),
+        )
+        .await
+        .unwrap();
+
+        let tool_calls = result.inner.choices[0]
+            .message
+            .tool_calls
+            .as_ref()
+            .expect("the complete first call must remain visible");
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.name, "get_weather");
+        assert_eq!(tool_calls[0].function.arguments, "{\"city\":\"Paris\"}");
     }
 
     #[tokio::test]
@@ -2579,11 +2749,11 @@ mod tests {
     //   in:  <tool_call>get_weather<arg_key>city</arg_key><arg_value>Bos   (finish_reason=length)
     //   out: finish=length  tool_calls=None  content=""
     // The parser sees an incomplete XML block and returns no tool call and no
-    // content, so the client gets an empty turn. The recovery path appends the
-    // raw partial markup as content so the caller can at least surface it.
+    // content. The non-streaming contract keeps the finish signal and suppresses
+    // the incomplete structured candidate rather than leaking parser markup.
 
     #[tokio::test]
-    async fn test_glm47_single_truncated_call_recovered_as_content() {
+    async fn test_glm47_single_truncated_call_is_suppressed() {
         let text = "<tool_call>get_weather<arg_key>city</arg_key><arg_value>Bos";
         let delta = create_test_delta(
             0,
@@ -2608,15 +2778,12 @@ mod tests {
             choice.message.tool_calls.is_none(),
             "incomplete call must not produce a structured tool_call"
         );
-        assert_eq!(
-            choice.message.content,
-            Some(ChatCompletionMessageContent::Text(text.to_string())),
-            "truncated markup must be returned as raw content"
-        );
+        assert_eq!(choice.message.content, None);
+        assert!(!serde_json::to_string(choice).unwrap().contains(text));
     }
 
     #[tokio::test]
-    async fn test_glm47_complete_call_then_truncated_second_recovered() {
+    async fn test_glm47_complete_call_then_truncated_second_is_suppressed() {
         // First call complete, second truncated mid-argument.
         let text = "<tool_call>get_weather<arg_key>city</arg_key><arg_value>Boston</arg_value></tool_call><tool_call>get_time<arg_key>tz</arg_key><arg_value>US/E";
         let delta = create_test_delta(
@@ -2634,7 +2801,7 @@ mod tests {
                 .unwrap();
 
         let choice = &result.inner.choices[0];
-        // First complete call is parsed into tool_calls.
+        // First complete call is parsed into tool_calls and remains available.
         let tool_calls = choice.message.tool_calls.as_ref().unwrap();
         assert_eq!(
             tool_calls.len(),
@@ -2642,20 +2809,39 @@ mod tests {
             "first complete call must be structured"
         );
         assert_eq!(tool_calls[0].function.name, "get_weather");
-        // Truncated second block is in content, not dropped.
-        let content = choice
-            .message
-            .content
-            .as_ref()
-            .expect("truncated second call must be in content");
-        let ChatCompletionMessageContent::Text(t) = content else {
-            panic!("content must be Text")
-        };
+        assert_eq!(choice.message.content, None);
         assert!(
-            t.contains("<tool_call>get_time"),
-            "truncated second call markup must be in content"
+            !serde_json::to_string(choice)
+                .unwrap()
+                .contains("<tool_call>get_time"),
+            "truncated second call markup must not leak into the response"
         );
-        assert!(!t.contains("</tool_call>"), "must not contain closing tag");
+    }
+
+    #[tokio::test]
+    async fn test_glm47_quoted_marker_prose_is_preserved_on_length_finish() {
+        let text = r#"The literal "<tool_call>" marker is part of the explanation."#;
+        let delta = create_test_delta(
+            0,
+            text,
+            Some(dynamo_protocols::types::Role::Assistant),
+            Some(dynamo_protocols::types::FinishReason::Length),
+            None,
+            None,
+        );
+        let result = DeltaAggregator::apply(
+            Box::pin(stream::iter(vec![delta])),
+            ParsingOptions::new(Some("glm47".to_string()), None),
+        )
+        .await
+        .unwrap();
+
+        let choice = &result.inner.choices[0];
+        assert_eq!(
+            choice.message.content,
+            Some(ChatCompletionMessageContent::Text(text.to_string()))
+        );
+        assert!(choice.message.tool_calls.is_none());
     }
 
     #[tokio::test]

--- a/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
@@ -265,7 +265,7 @@ pub(crate) fn contains_unquoted_marker(content: &str, marker: &str) -> bool {
 /// if it never appears outside a quoted span. Shared scanner behind
 /// [`contains_unquoted_marker`] and [`detect_prefill`], which needs the position (not
 /// just presence) to compare two markers' first occurrences.
-fn first_unquoted_marker_position(content: &str, marker: &str) -> Option<usize> {
+pub(crate) fn first_unquoted_marker_position(content: &str, marker: &str) -> Option<usize> {
     let chars: Vec<(usize, char)> = content.char_indices().collect();
     // Whether an unescaped `"`, `'`, or `` ` `` appears anywhere at or after each
     // position, precomputed once in O(n) so the scan below doesn't rescan the
@@ -316,6 +316,66 @@ fn first_unquoted_marker_position(content: &str, marker: &str) -> Option<usize> 
         }
     }
     None
+}
+
+/// Return the first unquoted native tool-call marker configured for `parser`.
+///
+/// Native markers quoted as prose remain visible text in both streaming and
+/// aggregated responses.
+pub(crate) fn first_unquoted_native_tool_call_marker(content: &str, parser: &str) -> Option<usize> {
+    native_tool_call_start_tokens(parser)?
+        .iter()
+        .filter_map(|marker| first_unquoted_marker_position(content, marker))
+        .min()
+}
+
+/// Return the start of an unquoted native marker, including an unquoted
+/// partial marker suffix that must remain buffered for the next stream chunk.
+pub(crate) fn unquoted_native_tool_call_marker_or_prefix_start(
+    content: &str,
+    parser: &str,
+) -> Option<usize> {
+    let markers = native_tool_call_start_tokens(parser)?;
+    if let Some(marker_start) = markers
+        .iter()
+        .filter_map(|marker| first_unquoted_marker_position(content, marker))
+        .min()
+    {
+        return Some(marker_start);
+    }
+
+    markers
+        .iter()
+        .flat_map(|marker| {
+            marker
+                .char_indices()
+                .skip(1)
+                .map(move |(end, _)| &marker[..end])
+        })
+        .filter(|prefix| {
+            let before = content.strip_suffix(prefix).unwrap_or(content);
+            first_unquoted_marker_position(before, prefix).is_none()
+        })
+        .filter_map(|prefix| {
+            let before = content.strip_suffix(prefix)?;
+            let position = first_unquoted_marker_position(content, prefix)?;
+            (position == before.len()).then_some(position)
+        })
+        .min()
+}
+
+fn native_tool_call_start_tokens(parser: &str) -> Option<Vec<String>> {
+    let parser_key = if parser.is_empty() { "default" } else { parser };
+    Some(
+        dynamo_parsers::tool_calling::parsers::get_tool_parser_map()
+            .get(parser_key)?
+            .parser_config
+            .tool_call_start_tokens()
+            .iter()
+            .filter(|marker| !marker.is_empty())
+            .cloned()
+            .collect(),
+    )
 }
 
 /// Index into the fixed-size "which quote characters close later" arrays used by

--- a/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
@@ -329,6 +329,24 @@ pub(crate) fn first_unquoted_native_tool_call_marker(content: &str, parser: &str
         .min()
 }
 
+/// Like [`first_unquoted_native_tool_call_marker`], but only for markers that cannot be
+/// ordinary prose.
+///
+/// Truncating a response at a marker is safe only when the marker is control syntax. Some
+/// parsers open a call with a plain word — `phi4` uses `functools` — and an answer about
+/// the Python module of that name would lose everything from the word onward. A marker
+/// carrying a punctuation character (`<`, `|`, `[`) cannot be written by accident.
+pub(crate) fn first_unquoted_structural_tool_call_marker(
+    content: &str,
+    parser: &str,
+) -> Option<usize> {
+    native_tool_call_start_tokens(parser)?
+        .iter()
+        .filter(|marker| !marker.chars().all(char::is_alphanumeric))
+        .filter_map(|marker| first_unquoted_marker_position(content, marker))
+        .min()
+}
+
 /// Return the start of an unquoted native marker, including an unquoted
 /// partial marker suffix that must remain buffered for the next stream chunk.
 pub(crate) fn unquoted_native_tool_call_marker_or_prefix_start(

--- a/lib/llm/src/protocols/openai/common_ext.rs
+++ b/lib/llm/src/protocols/openai/common_ext.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use validator::Validate;
 
+use crate::protocols::common::GuidedDecodingOptions;
+
 /// Common extensions for OpenAI API requests that are not part of the standard OpenAI spec
 /// but are commonly needed across different request types.
 #[derive(ToSchema, Serialize, Deserialize, Builder, Validate, Debug, Clone, Default)]
@@ -108,6 +110,30 @@ pub struct CommonExt {
     #[schema(ignore)]
     #[builder(default, setter(strip_option))]
     pub continue_final_message: Option<bool>,
+}
+
+pub(crate) struct GuidedDecodingOptionsResult {
+    pub(crate) options: Option<GuidedDecodingOptions>,
+    pub(crate) has_whitespace_pattern: bool,
+}
+
+pub(crate) fn extract_guided_decoding_options(
+    request: &impl CommonExtProvider,
+) -> anyhow::Result<GuidedDecodingOptionsResult> {
+    let guided_whitespace_pattern = request.get_guided_whitespace_pattern();
+    let options = GuidedDecodingOptions::from_optional(
+        request.get_guided_json(),
+        request.get_guided_regex(),
+        request.get_guided_choice(),
+        request.get_guided_grammar(),
+        request.get_guided_decoding_backend(),
+        guided_whitespace_pattern.clone(),
+        None,
+    )?;
+    Ok(GuidedDecodingOptionsResult {
+        options,
+        has_whitespace_pattern: guided_whitespace_pattern.is_some(),
+    })
 }
 
 impl CommonExt {

--- a/lib/llm/src/protocols/openai/common_ext.rs
+++ b/lib/llm/src/protocols/openai/common_ext.rs
@@ -112,16 +112,11 @@ pub struct CommonExt {
     pub continue_final_message: Option<bool>,
 }
 
-pub(crate) struct GuidedDecodingOptionsResult {
-    pub(crate) options: Option<GuidedDecodingOptions>,
-    pub(crate) has_whitespace_pattern: bool,
-}
-
 pub(crate) fn extract_guided_decoding_options(
     request: &impl CommonExtProvider,
-) -> anyhow::Result<GuidedDecodingOptionsResult> {
+) -> anyhow::Result<Option<GuidedDecodingOptions>> {
     let guided_whitespace_pattern = request.get_guided_whitespace_pattern();
-    let options = GuidedDecodingOptions::from_optional(
+    GuidedDecodingOptions::from_optional(
         request.get_guided_json(),
         request.get_guided_regex(),
         request.get_guided_choice(),
@@ -129,11 +124,7 @@ pub(crate) fn extract_guided_decoding_options(
         request.get_guided_decoding_backend(),
         guided_whitespace_pattern.clone(),
         None,
-    )?;
-    Ok(GuidedDecodingOptionsResult {
-        options,
-        has_whitespace_pattern: guided_whitespace_pattern.is_some(),
-    })
+    )
 }
 
 impl CommonExt {

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -451,6 +451,7 @@ impl OpenAIOutputOptionsProvider for NvCreateCompletionRequest {
 impl ValidateRequest for NvCreateCompletionRequest {
     fn validate(&self) -> Result<(), anyhow::Error> {
         validate::validate_no_unsupported_fields(&self.unsupported_fields)?;
+        validate::validate_guided_decoding(self)?;
         validate::validate_model(&self.inner.model)?;
 
         // Validate prompt and prompt_embeds together (checks presence, format, and content)
@@ -536,6 +537,24 @@ mod tests {
     use crate::protocols::common::OutputOptionsProvider;
     use base64::Engine;
     use serde_json::json;
+
+    #[test]
+    fn test_conflicting_guided_decoding_options_fail_request_validation() {
+        let request: NvCreateCompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "prompt": "hello",
+            "guided_regex": "a+",
+            "guided_choice": ["a"]
+        }))
+        .expect("request should deserialize");
+
+        let error = ValidateRequest::validate(&request).expect_err("constraints conflict");
+        assert!(
+            error
+                .to_string()
+                .contains("Only one guided-decoding constraint")
+        );
+    }
 
     #[test]
     fn test_skip_special_tokens_none() {

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -24,7 +24,7 @@ use dynamo_protocols::types::{
     ChatCompletionRequestToolMessageContent, ChatCompletionRequestUserMessage,
     ChatCompletionRequestUserMessageContent, ChatCompletionRequestUserMessageContentPart,
     ChatCompletionTool, ChatCompletionToolChoiceOption, ChatCompletionToolType,
-    CreateChatCompletionRequest, FunctionName, FunctionObject, FunctionType,
+    CreateChatCompletionRequest, FinishReason, FunctionName, FunctionObject, FunctionType,
     ImageDetail as ChatImageDetail, ImageUrl, ReasoningContent,
     ReasoningEffort as ChatReasoningEffort, ResponseFormat, ServiceTier as ChatServiceTier,
 };
@@ -1045,6 +1045,19 @@ pub struct ResponseParams {
     pub safety_identifier: Option<String>,
 }
 
+/// Map a terminal Chat Completions reason that makes a Responses result non-success-like.
+/// The Responses protocol has no content-filter status, so preserve the failure semantics
+/// with an incomplete response and a reason clients can inspect.
+pub(crate) fn responses_incomplete_reason(
+    finish_reason: Option<FinishReason>,
+) -> Option<&'static str> {
+    match finish_reason {
+        Some(FinishReason::Length) => Some("max_output_tokens"),
+        Some(FinishReason::ContentFilter) => Some("content_filter"),
+        _ => None,
+    }
+}
+
 impl ResponseParams {
     fn reasoning_summary_requested(&self) -> bool {
         self.reasoning
@@ -1151,11 +1164,10 @@ pub fn chat_completion_to_response(
 
     let choice = chat_resp.choices.into_iter().next();
     let mut output = Vec::new();
-    let mut output_limit_reached = false;
+    let mut incomplete_reason = None;
 
     if let Some(choice) = choice {
-        output_limit_reached =
-            choice.finish_reason == Some(dynamo_protocols::types::FinishReason::Length);
+        incomplete_reason = responses_incomplete_reason(choice.finish_reason);
 
         // Reasoning precedes tool calls so output order matches the decoded turn.
         if let Some(reasoning_text) = choice.message.reasoning_content
@@ -1248,17 +1260,14 @@ pub fn chat_completion_to_response(
     }
 
     let created_at = chat_resp.created as u64;
-    let status = if output_limit_reached {
+    let status = if incomplete_reason.is_some() {
         Status::Incomplete
     } else {
         Status::Completed
     };
-    if output_limit_reached {
-        // Unary responses do not expose explicit phase boundaries. A message
-        // or function call proves reasoning finished before the terminal item
-        // exhausted the output budget.
+    if incomplete_reason.is_some() {
         // The budget runs out once, inside the item the model was still writing.
-        // Every earlier item finished, so only the terminal one is incomplete.
+        // Earlier output items were complete and must not be relabelled.
         let terminal = output
             .iter()
             .rposition(|item| matches!(item, OutputItem::Message(_) | OutputItem::FunctionCall(_)));
@@ -1281,7 +1290,7 @@ pub fn chat_completion_to_response(
         id: response_id,
         object: "response".to_string(),
         created_at,
-        completed_at: (!output_limit_reached).then_some(created_at),
+        completed_at: incomplete_reason.is_none().then_some(created_at),
         model: if chat_resp.model == "unknown" {
             params.model.clone().unwrap_or(chat_resp.model)
         } else {
@@ -1315,8 +1324,8 @@ pub fn chat_completion_to_response(
         billing: None,
         conversation: None,
         error: None,
-        incomplete_details: output_limit_reached.then(|| IncompleteDetails {
-            reason: "max_output_tokens".to_string(),
+        incomplete_details: incomplete_reason.map(|reason| IncompleteDetails {
+            reason: reason.to_string(),
         }),
         instructions: params.instructions.clone().map(Instructions::Text),
         max_output_tokens: params.max_output_tokens,
@@ -3443,7 +3452,6 @@ thinking
         make_chat_resp_with_tool_calls(finish_reason, &[arguments])
     }
 
-    /// One tool call per entry in `arguments`, for a choice that carries parallel calls.
     fn make_chat_resp_with_tool_calls(
         finish_reason: dynamo_protocols::types::FinishReason,
         arguments: &[&str],
@@ -3456,12 +3464,12 @@ thinking
             arguments
                 .iter()
                 .enumerate()
-                .map(|(index, args)| ChatCompletionMessageToolCall {
+                .map(|(index, arguments)| ChatCompletionMessageToolCall {
                     id: format!("call_abc{index}"),
                     r#type: FunctionType::Function,
                     function: dynamo_protocols::types::FunctionCall {
                         name: "get_weather".into(),
-                        arguments: (*args).into(),
+                        arguments: (*arguments).into(),
                     },
                 })
                 .collect(),
@@ -3651,6 +3659,32 @@ thinking
     }
 
     #[test]
+    fn test_content_filter_returns_non_success_response() {
+        let chat_resp = make_chat_resp_with_text("blocked");
+        let mut chat_resp = chat_resp;
+        chat_resp.inner.choices[0].finish_reason =
+            Some(dynamo_protocols::types::FinishReason::ContentFilter);
+
+        let response =
+            chat_completion_to_response(chat_resp, &ResponseParams::default(), None).unwrap();
+
+        assert_eq!(response.inner.status, Status::Incomplete);
+        assert_eq!(response.inner.completed_at, None);
+        assert_eq!(
+            response
+                .inner
+                .incomplete_details
+                .as_ref()
+                .map(|details| details.reason.as_str()),
+            Some("content_filter")
+        );
+        let OutputItem::Message(message) = &response.inner.output[0] else {
+            panic!("expected message output");
+        };
+        assert_eq!(message.status, OutputStatus::Incomplete);
+    }
+
+    #[test]
     fn test_unmodified_length_with_tool_call_returns_incomplete_response() {
         let chat_resp = make_chat_resp_with_tool_call(
             dynamo_protocols::types::FinishReason::Length,
@@ -3675,8 +3709,6 @@ thinking
         assert_eq!(call.status, Some(OutputStatus::Incomplete));
     }
 
-    /// The output budget runs out once, inside the call the model was writing. Every
-    /// earlier call finished, so only the terminal item is incomplete.
     #[test]
     fn test_length_marks_only_the_terminal_tool_call_incomplete() {
         let chat_resp = make_chat_resp_with_tool_calls(
@@ -3702,8 +3734,7 @@ thinking
             vec![
                 Some(OutputStatus::Completed),
                 Some(OutputStatus::Incomplete)
-            ],
-            "a call the model finished must not be reported as incomplete"
+            ]
         );
     }
 

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -875,7 +875,10 @@ impl ResponseStreamConverter {
         // whether the still-open reasoning item completed or was truncated.
         self.append_active_reasoning_done_events(events, output_status);
 
-        self.close_open_message_item(events, output_status);
+        // Only the terminal item was cut short, and the terminal response reports it
+        // that way. The `output_item.done` event has to agree, or a client sees one
+        // item marked incomplete in the stream and completed in the final response.
+        self.close_open_message_item(events, self.item_output_status(self.message_output_index));
 
         // Fallback for backends that end the transport without a finish-reason chunk.
         self.append_pending_function_call_done_events(events, output_status, true);
@@ -1730,6 +1733,35 @@ mod tests {
             panic!("expected message output");
         };
         assert_eq!(message.status, OutputStatus::Incomplete);
+    }
+
+    /// The message item is not the terminal item here, so the terminal response reports
+    /// it completed. `append_end_events` now closes it with this same per-item status,
+    /// so the `output_item.done` event cannot disagree with the final response.
+    #[test]
+    fn test_length_leaves_a_non_terminal_message_item_completed() {
+        let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
+        let _ = conv.process_chunk(&text_chunk("here you go "));
+        let _ = conv.process_chunk(&tool_call_chunk(
+            0,
+            Some("call-1"),
+            Some("get_weather"),
+            Some(r#"{"city":"Par"#),
+        ));
+        let _ = conv.process_chunk(&finish_chunk(FinishReason::Length));
+
+        assert_eq!(
+            conv.item_output_status(conv.message_output_index),
+            OutputStatus::Completed,
+            "only the terminal item was cut short"
+        );
+
+        let _ = conv.emit_end_events();
+        let response = conv.make_response(conv.terminal_status(), conv.completed_output());
+        let OutputItem::Message(message) = &response.output[0] else {
+            panic!("expected message output");
+        };
+        assert_eq!(message.status, OutputStatus::Completed);
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -34,7 +34,7 @@ use uuid::Uuid;
 
 use dynamo_protocols::types::{ChatCompletionMessageContent, FinishReason};
 
-use super::ResponseParams;
+use super::{ResponseParams, responses_incomplete_reason};
 use crate::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
 use crate::protocols::unified::ResponsesContext;
 
@@ -63,8 +63,8 @@ pub struct ResponseStreamConverter {
     next_output_index: u32,
     // Usage stats from the backend's final chunk
     usage: Option<ResponseUsage>,
-    // The backend exhausted the output budget.
-    output_limit_reached: bool,
+    // The backend ended with a terminal reason that is not success-like.
+    incomplete_reason: Option<&'static str>,
 }
 
 struct ReasoningState {
@@ -132,7 +132,7 @@ impl ResponseStreamConverter {
             function_call_items: Vec::new(),
             next_output_index: 0,
             usage: None,
-            output_limit_reached: false,
+            incomplete_reason: None,
         }
     }
 
@@ -158,7 +158,11 @@ impl ResponseStreamConverter {
             None => {
                 // Resumed reasoning proves pending tool calls completed, even if
                 // this chunk reports that the new reasoning exhausted the budget.
-                self.append_pending_function_call_done_events(events, OutputStatus::Completed);
+                self.append_pending_function_call_done_events(
+                    events,
+                    OutputStatus::Completed,
+                    false,
+                );
 
                 let output_index = self.next_output_index;
                 self.next_output_index += 1;
@@ -269,7 +273,6 @@ impl ResponseStreamConverter {
     }
 
     fn make_response(&self, status: Status, output: Vec<OutputItem>) -> Response {
-        let is_incomplete = status == Status::Incomplete;
         let completed_at = if status == Status::Completed {
             Some(
                 SystemTime::now()
@@ -315,8 +318,8 @@ impl ResponseStreamConverter {
             billing: None,
             conversation: None,
             error: None,
-            incomplete_details: is_incomplete.then(|| IncompleteDetails {
-                reason: "max_output_tokens".to_string(),
+            incomplete_details: self.incomplete_reason.map(|reason| IncompleteDetails {
+                reason: reason.to_string(),
             }),
             instructions: self.params.instructions.clone().map(Instructions::Text),
             max_output_tokens: self.params.max_output_tokens,
@@ -400,8 +403,8 @@ impl ResponseStreamConverter {
         for choice in &chunk.inner.choices {
             let delta = &choice.delta;
 
-            if choice.finish_reason == Some(FinishReason::Length) {
-                self.output_limit_reached = true;
+            if let Some(reason) = responses_incomplete_reason(choice.finish_reason) {
+                self.incomplete_reason = Some(reason);
             }
 
             if let Some(reasoning) = delta.reasoning_content.as_deref()
@@ -638,7 +641,7 @@ impl ResponseStreamConverter {
 
         if should_finish_function_calls {
             let output_status = self.output_status();
-            self.append_pending_function_call_done_events(events, output_status);
+            self.append_pending_function_call_done_events(events, output_status, true);
         }
     }
 
@@ -646,15 +649,36 @@ impl ResponseStreamConverter {
         &mut self,
         events: &mut Vec<Result<Event, anyhow::Error>>,
         output_status: OutputStatus,
+        only_terminal_is_incomplete: bool,
     ) {
         // `started` is set only after `has_identity()` observes both required
         // fields, matching Anthropic's `is_emit_ready()` identity requirement.
+        let terminal_output_index = (only_terminal_is_incomplete
+            && output_status == OutputStatus::Incomplete)
+            .then(|| {
+                self.function_call_items
+                    .iter()
+                    .filter_map(|call| call.output_index)
+                    .chain(self.message_started.then_some(self.message_output_index))
+                    .max()
+            })
+            .flatten();
         let mut pending: Vec<_> = self
             .function_call_items
             .iter_mut()
             .filter(|fc| fc.started && fc.output_status.is_none())
             .map(|fc| {
-                fc.output_status = Some(output_status);
+                fc.output_status = Some(
+                    if Some(
+                        fc.output_index
+                            .expect("started function call is missing an output index"),
+                    ) == terminal_output_index
+                    {
+                        output_status
+                    } else {
+                        OutputStatus::Completed
+                    },
+                );
                 (
                     fc.item_id.clone(),
                     fc.call_id.clone(),
@@ -663,12 +687,16 @@ impl ResponseStreamConverter {
                     fc.output_index
                         .expect("started function call is missing an output index"),
                     fc.accumulated_args.clone(),
+                    fc.output_status
+                        .expect("finished function call is missing output status"),
                 )
             })
             .collect();
-        pending.sort_unstable_by_key(|(_, _, _, _, output_index, _)| *output_index);
+        pending.sort_unstable_by_key(|(_, _, _, _, output_index, _, _)| *output_index);
 
-        for (item_id, call_id, fc_name, namespace, output_index, accumulated_args) in pending {
+        for (item_id, call_id, fc_name, namespace, output_index, accumulated_args, call_status) in
+            pending
+        {
             let args_done = ResponseStreamEvent::ResponseFunctionCallArgumentsDone(
                 ResponseFunctionCallArgumentsDoneEvent {
                     sequence_number: self.next_seq(),
@@ -690,7 +718,7 @@ impl ResponseStreamConverter {
                         namespace,
                         name: fc_name,
                         arguments: accumulated_args,
-                        status: Some(output_status),
+                        status: Some(call_status),
                     }),
                 });
             events.push(self.make_sse_event(&item_done));
@@ -698,7 +726,23 @@ impl ResponseStreamConverter {
     }
 
     fn output_status(&self) -> OutputStatus {
-        if self.output_limit_reached {
+        if self.incomplete_reason.is_some() {
+            OutputStatus::Incomplete
+        } else {
+            OutputStatus::Completed
+        }
+    }
+
+    fn terminal_output_index(&self) -> Option<u32> {
+        self.function_call_items
+            .iter()
+            .filter_map(|call| call.output_index)
+            .chain(self.message_started.then_some(self.message_output_index))
+            .max()
+    }
+
+    fn item_output_status(&self, output_index: u32) -> OutputStatus {
+        if self.incomplete_reason.is_some() && Some(output_index) == self.terminal_output_index() {
             OutputStatus::Incomplete
         } else {
             OutputStatus::Completed
@@ -706,7 +750,7 @@ impl ResponseStreamConverter {
     }
 
     fn terminal_status(&self) -> Status {
-        if self.output_limit_reached {
+        if self.incomplete_reason.is_some() {
             Status::Incomplete
         } else {
             Status::Completed
@@ -732,6 +776,8 @@ impl ResponseStreamConverter {
     }
 
     fn output_with_status(&self, output_status: OutputStatus) -> Vec<OutputItem> {
+        let terminal_only =
+            self.incomplete_reason.is_some() && output_status == OutputStatus::Incomplete;
         let mut output = Vec::new();
         for reasoning in &self.reasoning_items {
             output.push((
@@ -740,13 +786,23 @@ impl ResponseStreamConverter {
             ));
         }
         if self.message_started {
+            let message_status = if terminal_only {
+                self.item_output_status(self.message_output_index)
+            } else {
+                output_status
+            };
             output.push((
                 self.message_output_index,
-                OutputItem::Message(self.message_output(output_status)),
+                OutputItem::Message(self.message_output(message_status)),
             ));
         }
         for function_call in &self.function_call_items {
             if let Some(output_index) = function_call.output_index {
+                let function_status = if terminal_only {
+                    self.item_output_status(output_index)
+                } else {
+                    output_status
+                };
                 output.push((
                     output_index,
                     OutputItem::FunctionCall(FunctionToolCall {
@@ -755,7 +811,7 @@ impl ResponseStreamConverter {
                         namespace: function_call.namespace.clone(),
                         name: function_call.name.clone(),
                         arguments: function_call.accumulated_args.clone(),
-                        status: Some(function_call.output_status.unwrap_or(output_status)),
+                        status: Some(function_call.output_status.unwrap_or(function_status)),
                     }),
                 ));
             }
@@ -822,7 +878,7 @@ impl ResponseStreamConverter {
         self.close_open_message_item(events, output_status);
 
         // Fallback for backends that end the transport without a finish-reason chunk.
-        self.append_pending_function_call_done_events(events, output_status);
+        self.append_pending_function_call_done_events(events, output_status, true);
 
         let terminal_status = self.terminal_status();
         let response = self.make_response(terminal_status.clone(), self.completed_output());
@@ -858,7 +914,7 @@ impl ResponseStreamConverter {
         let output_status = OutputStatus::Incomplete;
         self.append_active_reasoning_done_events(events, output_status);
         self.close_open_message_item(events, output_status);
-        self.append_pending_function_call_done_events(events, output_status);
+        self.append_pending_function_call_done_events(events, output_status, false);
 
         let mut response =
             self.make_response(Status::Failed, self.output_with_status(output_status));
@@ -1596,6 +1652,35 @@ mod tests {
     }
 
     #[test]
+    fn test_content_filter_emits_incomplete_terminal_response() {
+        let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
+        let _ = conv.process_chunk(&with_finish_reason(
+            text_chunk("blocked"),
+            FinishReason::ContentFilter,
+        ));
+
+        let end_events = conv.emit_end_events();
+        assert_eq!(
+            event_types(&end_events).last().map(String::as_str),
+            Some("response.incomplete")
+        );
+
+        let response = conv.make_response(conv.terminal_status(), conv.completed_output());
+        assert_eq!(response.status, Status::Incomplete);
+        assert_eq!(
+            response
+                .incomplete_details
+                .as_ref()
+                .map(|details| details.reason.as_str()),
+            Some("content_filter")
+        );
+        let OutputItem::Message(message) = &response.output[0] else {
+            panic!("expected message output");
+        };
+        assert_eq!(message.status, OutputStatus::Incomplete);
+    }
+
+    #[test]
     fn test_length_finish_reason_marks_reasoning_item_incomplete() {
         use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
 
@@ -1645,6 +1730,42 @@ mod tests {
             panic!("expected message output");
         };
         assert_eq!(message.status, OutputStatus::Incomplete);
+    }
+
+    #[test]
+    fn test_length_marks_only_the_terminal_stream_tool_call_incomplete() {
+        let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
+        let _ = conv.process_chunk(&tool_call_chunk(
+            0,
+            Some("call-1"),
+            Some("first"),
+            Some(r#"{"done":"yes"}"#),
+        ));
+        let _ = conv.process_chunk(&tool_call_chunk(
+            1,
+            Some("call-2"),
+            Some("second"),
+            Some(r#"{"done":"no","tail":"cut"#),
+        ));
+        let _ = conv.process_chunk(&finish_chunk(FinishReason::Length));
+        let _ = conv.emit_end_events();
+
+        let response = conv.make_response(conv.terminal_status(), conv.completed_output());
+        let statuses: Vec<_> = response
+            .output
+            .iter()
+            .filter_map(|item| match item {
+                OutputItem::FunctionCall(call) => Some(call.status),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            statuses,
+            vec![
+                Some(OutputStatus::Completed),
+                Some(OutputStatus::Incomplete)
+            ]
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -870,7 +870,7 @@ pub fn validate_chat_template_args(
     Ok(())
 }
 
-/// Rejects a request with conflicting or incomplete guided-decoding options.
+/// Rejects a request with conflicting guided-decoding options.
 ///
 /// The conflict rule itself lives in [`crate::protocols::common::GuidedDecodingOptions::validate`],
 /// reached here through `from_optional`, so this function adds no second copy of it. What it adds is
@@ -883,10 +883,7 @@ pub fn validate_chat_template_args(
 /// `structural_tag` has no `CommonExtProvider` getter, matching `extract_sampling_options`,
 /// which also passes `None` for it.
 pub fn validate_guided_decoding(request: &impl CommonExtProvider) -> Result<(), anyhow::Error> {
-    let result = extract_guided_decoding_options(request)?;
-    if result.options.is_none() && result.has_whitespace_pattern {
-        anyhow::bail!("guided_whitespace_pattern requires a primary guided-decoding constraint");
-    }
+    extract_guided_decoding_options(request)?;
     Ok(())
 }
 

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -7,6 +7,7 @@ use dynamo_runtime::config::{
     env_is_truthy, environment_names::llm::DYN_IGNORE_OPENAI_FE_UNSUPPORTED_FIELDS,
 };
 
+use super::common_ext::{CommonExtProvider, extract_guided_decoding_options};
 use super::tools::{ToolChoiceError, validate_openai_tool_choice};
 
 //
@@ -865,6 +866,26 @@ pub fn validate_chat_template_args(
         && args.contains_key("chat_template")
     {
         anyhow::bail!("`chat_template` is not supported inside `chat_template_args`");
+    }
+    Ok(())
+}
+
+/// Rejects a request with conflicting or incomplete guided-decoding options.
+///
+/// The conflict rule itself lives in [`crate::protocols::common::GuidedDecodingOptions::validate`],
+/// reached here through `from_optional`, so this function adds no second copy of it. What it adds is
+/// the call at the request-validation boundary: every other field is checked here, where
+/// a failure becomes a 400 naming the problem, while guided decoding was checked only
+/// later inside `extract_sampling_options`. By that point the error is an untyped
+/// `anyhow` with nothing for the HTTP layer to branch on, so a malformed request was
+/// reported to the caller as `500 Internal Server Error`.
+///
+/// `structural_tag` has no `CommonExtProvider` getter, matching `extract_sampling_options`,
+/// which also passes `None` for it.
+pub fn validate_guided_decoding(request: &impl CommonExtProvider) -> Result<(), anyhow::Error> {
+    let result = extract_guided_decoding_options(request)?;
+    if result.options.is_none() && result.has_whitespace_pattern {
+        anyhow::bail!("guided_whitespace_pattern requires a primary guided-decoding constraint");
     }
     Ok(())
 }

--- a/lib/llm/tests/test_streaming_tool_parsers.rs
+++ b/lib/llm/tests/test_streaming_tool_parsers.rs
@@ -2238,7 +2238,8 @@ fn content_texts(chunks: &[Annotated<NvCreateChatCompletionStreamResponse>]) -> 
 }
 
 // Backend sends content chunks then a data-less terminal chunk with finish_reason=length.
-// The latch must fire on the first finish chunk and not re-fire on the terminal one.
+// The terminal delta itself is the recovery signal: it must remain observable even
+// when safely suppressing the incomplete native marker and its arguments.
 #[tokio::test]
 async fn test_glm47_streaming_truncated_data_less_terminal_chunk() {
     let mut chunks = vec![
@@ -2253,25 +2254,24 @@ async fn test_glm47_streaming_truncated_data_less_terminal_chunk() {
     let out = run_glm47_jail(chunks).await;
 
     let texts = content_texts(&out);
-    assert_eq!(texts.len(), 1, "exactly one recovery chunk; got: {texts:?}");
     assert!(
-        texts[0].contains("<tool_call>"),
-        "recovery must contain the truncated markup; got: {:?}",
-        texts[0]
+        texts.iter().all(|text| !text.contains("<tool_call>")),
+        "recovery must not expose native markup; got: {texts:?}"
     );
-    // Latch: a second finish_reason=length chunk must not produce a second copy.
+    let terminal_choices: Vec<_> = out
+        .iter()
+        .filter_map(|response| response.data.as_ref())
+        .flat_map(|data| data.inner.choices.iter())
+        .filter(|choice| choice.finish_reason == Some(FinishReason::Length))
+        .collect();
     assert_eq!(
-        out.iter()
-            .filter(|a| {
-                a.data
-                    .as_ref()
-                    .and_then(|d| d.inner.choices.first())
-                    .and_then(|c| c.finish_reason)
-                    == Some(FinishReason::Length)
-            })
-            .count(),
+        terminal_choices.len(),
         1,
-        "finish_reason=length must appear exactly once in output"
+        "expected one terminal recovery delta"
+    );
+    assert!(
+        terminal_choices[0].delta.content.is_none(),
+        "the recovery delta must be empty-safe rather than leak partial arguments"
     );
     let nvext_chunks: Vec<_> = out
         .iter()
@@ -2288,9 +2288,8 @@ async fn test_glm47_streaming_truncated_data_less_terminal_chunk() {
     );
 }
 
-// Prose follows a complete tool call, then a truncated second call — all in one jailed
-// buffer. The jail releases the prose+tail verbatim; pass 2 must suppress it and emit
-// only the tail via the recovery chunk (tail_already_emitted path).
+// Prose follows a complete tool call, then a truncated second call. The prose remains
+// visible while the terminal recovery delta suppresses only the incomplete call.
 #[tokio::test]
 async fn test_glm47_streaming_prose_plus_truncated_block_tail_already_emitted() {
     let complete =
@@ -2303,20 +2302,45 @@ async fn test_glm47_streaming_prose_plus_truncated_block_tail_already_emitted() 
     let out = run_glm47_jail(chunks).await;
 
     let texts = content_texts(&out);
-    // The jail splits the finish chunk: it emits "tail prose " as a separate
-    // earlier content chunk (unavoidable — already left the jail), then puts
-    // "<tool_call>get_time..." on the finish chunk. Pass 2 suppresses the finish
-    // chunk's content; the recovery chunk carries just the marker-onwards tail.
-    // Net invariant: the truncated block appears exactly once (from recovery),
-    // never duplicated from the finish chunk.
-    let recovery: Vec<_> = texts
-        .iter()
-        .filter(|t| t.contains("<tool_call>get_time"))
-        .collect();
     assert_eq!(
-        recovery.len(),
-        1,
-        "truncated second call must appear exactly once (no duplicate); got: {texts:?}"
+        texts.concat(),
+        "tail prose ",
+        "prose before the true marker must stay visible; got: {texts:?}"
+    );
+    assert!(
+        texts.iter().all(|text| !text.contains("<tool_call>")),
+        "truncated native markup must not leak; got: {texts:?}"
+    );
+    assert!(
+        out.iter()
+            .filter_map(|response| response.data.as_ref())
+            .flat_map(|data| data.inner.choices.iter())
+            .any(|choice| {
+                choice.finish_reason == Some(FinishReason::Length)
+                    && choice.delta.content.is_none()
+                    && choice.delta.tool_calls.is_none()
+            }),
+        "the terminal empty-safe recovery delta must remain observable"
+    );
+}
+
+// A completed native call is consumed by the jail before this prose arrives. A terminal
+// length marker must not replay the prose retained only for native-marker recovery.
+#[tokio::test]
+async fn test_glm47_streaming_post_call_prose_is_not_duplicated_on_length_finish() {
+    let complete =
+        "<tool_call>get_weather<arg_key>city</arg_key><arg_value>Boston</arg_value></tool_call>";
+    let chunks = vec![
+        make_glm47_chunk(Some(complete), None),
+        make_glm47_chunk(Some("tail prose "), None),
+        make_glm47_chunk(None, Some(FinishReason::Length)),
+    ];
+
+    let out = run_glm47_jail(chunks).await;
+    assert_eq!(
+        content_texts(&out).concat(),
+        "tail prose ",
+        "terminal recovery must not repeat prose after a completed call"
     );
 }
 


### PR DESCRIPTION
## Summary

This PR suppresses truncated structured tool calls at the final response boundary for Chat Completions and Anthropic Messages. The Responses API retains the truncated function-call item and marks the terminal item `status: "incomplete"`, while the terminal length signal remains visible.

## Before / After

### Chat Completions

Before: a stream ending with `finish_reason: "length"` and `arguments: "{\"city\":\"San"` returned the incomplete tool call, so a client could try to execute malformed arguments.

After: the final incomplete tool call is omitted, and the response keeps `finish_reason: "length"`:

```json
{
  "choices": [{
    "message": {"tool_calls": null},
    "finish_reason": "length"
  }]
}
```

A completed earlier call remains visible when only the final call is truncated. A completed call with `finish_reason: "stop"` and `arguments: "{}"` remains visible.

### Anthropic Messages

Before: malformed or empty arguments could become `input: {}`, producing a runnable `tool_use` block even when generation stopped at `max_tokens`.

After: the incomplete terminal `tool_use` block is omitted. If every tool block is omitted, the response reports `stop_reason: "end_turn"` instead of `"tool_use"` with no runnable block. Completed calls still preserve `input: {}`.

For a truncated object such as `{"city":"San","units":"c`, the converter keeps only completed members, such as `{"city":"San"}`, and drops the unfinished member.

### Responses API

Before: a length-limited response could mark every output item incomplete, including an earlier completed call.

After: only the terminal message or function-call item is marked `status: "incomplete"`; earlier output items remain `status: "completed"`, and `incomplete_details.reason` is `"max_output_tokens"`.

### GLM47 recovery

Before: prose before an incomplete tool marker could be dropped or duplicated during streaming recovery, and a word-shaped marker could truncate ordinary prose such as `functools`.

After: emitted prose is preserved without duplication, incomplete markers are suppressed, and only punctuation-bearing markers trigger recovery.

### Guided decoding validation

Before: conflicting guided-decoding options could pass request validation and fail later in the request path.

After: `guided_json` combined with `guided_whitespace_pattern` is accepted as a modifier combination, while `guided_whitespace_pattern` without a guided schema is rejected with HTTP 400.

## Details

- Chat aggregation drops only the final call with invalid or empty arguments on `finish_reason: length`; earlier calls remain unchanged, and finished `stop` or `tool_calls` calls with `{}` remain valid.
- Anthropic unary and streaming conversion suppresses empty or malformed arguments at `max_tokens`, preserves `{}` for finished calls, and reports `end_turn` when all `tool_use` blocks were suppressed.
- Responses retains the truncated function-call item and marks the terminal item `status: "incomplete"`; Chat Completions and Anthropic omit the incomplete terminal call or block.
- Responses streaming closes each output item with its own terminal status, so `output_item.done` agrees with the final response.
- GLM47 recovery compacts already-emitted quote-free prose from its legacy jail buffer. Quote-bearing undecidable prose is retained because the legacy jail does not expose enough quote state for safe compaction.
- The ordinary Chat Completions stream remains outside this PR's dispatch changes. The opt-in `tool_call_dispatch` assembly mechanism is owned by #13986.
- The aggregator metadata and usage regression retains `engine_data` merging, choice count, and total-token assertions from the merge base.

## Validation

- `cargo fmt --all`
- `cargo test --locked -p dynamo-llm --lib` (2616 passed, 5 ignored)
- Focused Chat aggregation, Anthropic unary and streaming, Responses streaming, GLM47 preprocessor, streaming tool parser, postprocessor, and guided-options tests passed.
- `cargo test --locked -p dynamo-llm --test test_streaming_tool_parsers -- --nocapture` (46 passed)
- `cargo test --locked -p dynamo-llm --test postprocessor_parsing_stream -- --nocapture` (92 passed)
- The GLM47 scaling-style tests preserve 400 chunks of prose. This is not a constant-memory claim for quote-bearing undecidable text in the legacy jail.

## Where should the reviewer start?

`lib/llm/src/protocols/openai/chat_completions/aggregator.rs`

`lib/llm/src/protocols/anthropic/types.rs`

`lib/llm/src/protocols/anthropic/stream_converter.rs`

`lib/llm/src/preprocessor.rs`

`lib/llm/src/protocols/openai/responses/stream_converter.rs`

## Related Issues

- [ ] Confirmed — no related issue

/coderabbit profile chill
