### PR TITLE
test(router): add RoutingHost policy microbenchmark

### DIFF
--- a/lib/llm/src/kv_router/routing_host/builtin.rs
+++ b/lib/llm/src/kv_router/routing_host/builtin.rs
@@ -16,6 +16,9 @@ pub(super) struct BuiltinWorkerSelector {
     picker: BuiltinRoutePicker,
 }
 
+#[cfg(all(test, feature = "bench"))]
+mod benchmarks;
+
 impl BuiltinWorkerSelector {
     pub(super) fn new(mode: RouterMode) -> Option<Self> {
         let picker = match mode {

--- a/lib/llm/src/kv_router/routing_host/builtin/benchmarks.rs
+++ b/lib/llm/src/kv_router/routing_host/builtin/benchmarks.rs
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Microbenchmarks for built-in `RoutingHost` policy overhead.
+//!
+//! Run an individual case with:
+//!
+//! ```text
+//! DYN_BENCH_POLICY=round-robin DYN_BENCH_WORKERS=256 \
+//! DYN_BENCH_ITERS=100000 cargo test --release -p dynamo-llm \
+//! --features bench routing_host_microbench -- --ignored --nocapture
+//! ```
+
+use std::{hint::black_box, sync::Arc, time::Instant};
+
+use dynamo_kv_router::DefaultWorkerSelector;
+use dynamo_runtime::{
+    DistributedRuntime, Runtime,
+    component::Instance,
+    distributed::DistributedConfig,
+    pipeline::{
+        AddressedRequest, Context, ManyIn, PushRouter, RouterMode, StreamingDispatch, async_trait,
+    },
+};
+
+use super::*;
+
+#[derive(Default)]
+struct BenchmarkDispatch;
+
+#[async_trait]
+impl StreamingDispatch<PreprocessedRequest, Annotated<LLMEngineOutput>> for BenchmarkDispatch {
+    async fn generate(
+        &self,
+        _request: SingleIn<AddressedRequest<PreprocessedRequest>>,
+    ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+        unreachable!("RoutingHost microbenchmark excludes transport")
+    }
+
+    async fn generate_bidirectional(
+        &self,
+        _instance: Instance,
+        _address: String,
+        _input: ManyIn<PreprocessedRequest>,
+    ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+        unreachable!("RoutingHost microbenchmark excludes transport")
+    }
+}
+
+fn benchmark_mode(policy: &str) -> RouterMode {
+    match policy {
+        "round-robin" => RouterMode::RoundRobin,
+        "random" => RouterMode::Random,
+        "power-of-two" => RouterMode::PowerOfTwoChoices,
+        "least-loaded" => RouterMode::LeastLoaded,
+        other => panic!("unsupported built-in benchmark policy: {other}"),
+    }
+}
+
+fn benchmark_env() -> (String, usize, usize, usize) {
+    let policy = std::env::var("DYN_BENCH_POLICY").unwrap_or_else(|_| "round-robin".into());
+    let workers = std::env::var("DYN_BENCH_WORKERS")
+        .unwrap_or_else(|_| "32".into())
+        .parse()
+        .unwrap();
+    let iterations: usize = std::env::var("DYN_BENCH_ITERS")
+        .unwrap_or_else(|_| "100000".into())
+        .parse()
+        .unwrap();
+    let warmup = std::env::var("DYN_BENCH_WARMUP")
+        .unwrap_or_else(|_| (iterations / 20).max(1000).to_string())
+        .parse()
+        .unwrap();
+    assert!(workers > 0 && iterations > 0);
+    (policy, workers, iterations, warmup)
+}
+
+fn benchmark_request() -> PreprocessedRequest {
+    PreprocessedRequest::builder()
+        .model("benchmark".to_string())
+        .token_ids(vec![1])
+        .stop_conditions(Default::default())
+        .sampling_options(Default::default())
+        .output_options(Default::default())
+        .build()
+        .unwrap()
+}
+
+async fn lifecycle_iteration(host: &RoutingHost) {
+    let request = Context::new(benchmark_request());
+    let HostedSelection {
+        initial_worker,
+        occupancy_reservation,
+        ..
+    } = host.select_hosted_worker(&request, None).unwrap();
+    black_box(initial_worker);
+    let mut guard: RequestGuard<DefaultWorkerSelector> = RequestGuard::new_builtin(
+        host.request_metrics.clone(),
+        initial_worker,
+        occupancy_reservation,
+        None,
+        &request,
+    );
+    guard.abort().await;
+}
+
+async fn benchmark_builtin(
+    policy: &str,
+    worker_count: usize,
+    iterations: usize,
+    warmup: usize,
+) -> f64 {
+    let mode = benchmark_mode(policy);
+    let runtime = Runtime::from_current().unwrap();
+    let distributed = DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+        .await
+        .unwrap();
+    let endpoint = distributed
+        .namespace(format!("routing-host-microbench-{}", std::process::id()))
+        .unwrap()
+        .component("workers".to_string())
+        .unwrap()
+        .endpoint("generate".to_string());
+    let client = endpoint.client().await.unwrap();
+    let worker_ids = (1..=worker_count as u64).collect::<Vec<_>>();
+    client.override_discovered_instances(worker_ids.clone());
+    client.override_instance_avail(worker_ids);
+    let dispatch = Arc::new(BenchmarkDispatch);
+    let inner = PushRouter::from_client_with_dispatch(
+        client,
+        mode,
+        dispatch as Arc<dyn StreamingDispatch<_, _>>,
+    )
+    .await
+    .unwrap();
+    let host = RoutingHost::<DefaultWorkerSelector>::new_builtin(inner).unwrap();
+
+    for _ in 0..warmup {
+        lifecycle_iteration(&host).await;
+    }
+    let started = Instant::now();
+    for _ in 0..iterations {
+        lifecycle_iteration(&host).await;
+    }
+    let ns_per_op = started.elapsed().as_nanos() as f64 / iterations as f64;
+    black_box(&host);
+    runtime.shutdown();
+    ns_per_op
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "microbenchmark; run explicitly"]
+#[serial_test::serial]
+async fn routing_host_microbench() {
+    let (policy, workers, iterations, warmup) = benchmark_env();
+    let ns_per_op = benchmark_builtin(&policy, workers, iterations, warmup).await;
+    println!(
+        "ROUTING_HOST_BENCH\tpolicy={policy}\tworkers={workers}\titerations={iterations}\twarmup={warmup}\tns_per_op={ns_per_op:.3}"
+    );
+}


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This adds an opt-in microbenchmark for built-in `RoutingHost` policy overhead. It matters because routing refactors can now be checked for worker-count scaling and per-request lifecycle regressions without HTTP, tokenizer, transport, or Mocker noise.

### How This Was Implemented

- Gated the benchmark behind both `#[cfg(test)]` and the existing `bench` feature, so normal builds and tests do not compile it.
- Constructed synthetic discovered workers around the real private hosted selector, occupancy reservation, and `RequestGuard` cleanup path.
- Added environment controls for policy, worker count, iterations, and warmup while keeping the test ignored by default.

<details>
<summary>Walkthrough</summary>

#### Mental model

Each iteration creates a minimal request, selects through the same built-in host path used by production, reserves occupancy when the policy requires it, and releases that state through `RequestGuard`.

```mermaid
flowchart LR
    E["Benchmark inputs"] --> H["RoutingHost"]
    H --> S["RR / Random / P2C / LeastLoaded"]
    S --> R["Optional occupancy reservation"]
    R --> G["RequestGuard cleanup"]
```

#### Boundaries and limitations

The benchmark deliberately excludes transport and response streaming, so synthetic workers do not need callable endpoints and the result isolates host-owned routing work. It is an ignored test rather than a public benchmark target because the measured selector and lifecycle helpers are private implementation details; exposing them solely for benchmarking would widen the production API.

</details>

### Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `DYN_BENCH_POLICY=round-robin DYN_BENCH_WORKERS=32 DYN_BENCH_ITERS=10000 DYN_BENCH_WARMUP=1000 cargo test --locked -p dynamo-llm --features bench --lib routing_host_microbench -- --ignored --nocapture --test-threads=1`
- Five paired parent/head repetitions for all four built-in policies at 32, 256, and 1,024 workers.
- P2C peak-RSS comparison at 100k and 1M request lifecycles.

### Benchmark Results

The parent (`64b1ac377a`) and cleanup head (`044ac058b3`) ran on one pinned CPU with order alternated. Lower is better; each cell is the cleanup-head median in µs/request with the median paired delta versus the parent.

| Policy / profile | 32 workers | 256 workers | 1,024 workers |
|---|---:|---:|---:|
| Round-robin / dev | 8.31 (+4.34%) | 8.15 (+2.78%) | 8.35 (+2.85%) |
| Random / dev | 8.66 (+3.25%) | 8.67 (+2.60%) | 8.63 (+1.25%) |
| P2C / dev | 17.04 (+1.71%) | 18.64 (+1.51%) | 24.13 (+1.05%) |
| Least-loaded / dev | 33.58 (-0.38%) | 161.75 (+0.33%) | 593.69 (-1.77%) |
| KV control / release | 26.95 (-0.94%) | 47.17 (-0.01%) | 125.82 (-0.41%) |

The expected scaling is unchanged and no severe routing-host regression appears. Peak RSS also stayed flat from 100k to 1M P2C lifecycles: parent 70,380 → 70,512 KiB and cleanup head 70,120 → 69,768 KiB.
<!-- codex-pr-description:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->