### PR TITLE
test(gms): signal the failover-lock child over a Pipe, not a raw fd

### DIFF
--- a/lib/gpu_memory_service/tests/test_failover_lock.py
+++ b/lib/gpu_memory_service/tests/test_failover_lock.py
@@ -13,6 +13,7 @@ import multiprocessing
 import os
 import signal
 import time
+from multiprocessing import connection
 
 import pytest
 from _deps import HAS_GMS
@@ -100,7 +101,7 @@ async def test_two_engines_contention(lock_path):
 # ── Test 3: process death releases lock ──────────────────────────────
 
 
-def _child_acquire_and_hang(lock_path: str, ready_fd: int):
+def _child_acquire_and_hang(lock_path: str, ready: connection.Connection):
     """Child process: acquire flock, signal parent, then block forever."""
     import fcntl
 
@@ -108,9 +109,11 @@ def _child_acquire_and_hang(lock_path: str, ready_fd: int):
     fcntl.flock(fd, fcntl.LOCK_EX)
     os.write(fd, b"child")
 
-    # Signal parent that we hold the lock
-    os.write(ready_fd, b"1")
-    os.close(ready_fd)
+    # Signal parent that we hold the lock. A Connection is picklable, so it
+    # reaches the child under every start method; a bare fd number only
+    # survives "fork".
+    ready.send(b"1")
+    ready.close()
 
     # Block forever (parent will SIGKILL us)
     time.sleep(3600)
@@ -119,17 +122,17 @@ def _child_acquire_and_hang(lock_path: str, ready_fd: int):
 @pytest.mark.asyncio
 async def test_process_death_releases(lock_path):
     """SIGKILL a child holding the lock. Parent should acquire."""
-    read_fd, write_fd = os.pipe()
+    read_conn, write_conn = multiprocessing.Pipe(duplex=False)
 
     child = multiprocessing.Process(
-        target=_child_acquire_and_hang, args=(lock_path, write_fd)
+        target=_child_acquire_and_hang, args=(lock_path, write_conn)
     )
     child.start()
-    os.close(write_fd)
+    write_conn.close()
 
     # Wait for child to signal it holds the lock
-    os.read(read_fd, 1)
-    os.close(read_fd)
+    read_conn.recv()
+    read_conn.close()
 
     # Child holds the lock — verify we can't acquire immediately
     lock = FlockFailoverLock(lock_path)


### PR DESCRIPTION
## Summary

`test_process_death_releases` starts a child that must acquire the flock before the parent checks it is held. It signals readiness over `os.pipe()`, and hands the child the write end as an integer:

```python
read_fd, write_fd = os.pipe()
child = multiprocessing.Process(
    target=_child_acquire_and_hang, args=(lock_path, write_fd)
)
```

A raw descriptor number only means anything in the child under the `fork` start method, where the descriptor table is inherited. Under `spawn` and `forkserver` the child is a fresh interpreter and the number refers to nothing, so:

- the child's `os.write(ready_fd, b"1")` does not reach the parent,
- the parent already closed its own copy of the write end, so `os.read(read_fd, 1)` sees EOF and returns immediately instead of blocking,
- the parent races ahead and opens a lock file the child has not created yet.

```
FileNotFoundError: [Errno 2] No such file or directory: '.../failover.lock'
```

So the synchronisation the test was written to perform silently does not happen, and what is left is a race the parent usually loses.

This is not only a macOS problem, which is what makes it worth fixing rather than skipping. macOS has defaulted to `spawn` since 3.8, so the test fails there today. Python 3.14 moves the POSIX default off `fork`, so the same failure arrives on Linux with an interpreter bump, in a test whose whole purpose is to prove the kernel releases an flock when its holder dies.

`multiprocessing.Pipe()` returns `Connection` objects, which are picklable and therefore arrive intact under every start method. What the test asserts is unchanged, and it is the only place in the repository that passes a raw fd to a `multiprocessing.Process`.

## Validation

macOS arm64, Python 3.12, run under each start method explicitly. `--basetemp` is short because the default macOS temp path exceeds the 104-byte `AF_UNIX` limit, which is unrelated to this change.

| start method | before | after |
|---|---|---|
| `fork` | passes | passes |
| `spawn` (macOS default) | **FAILED** | passes |
| `forkserver` (Linux default from 3.14) | **FAILED** | passes |

Before, under `spawn`:

```
FAILED lib/gpu_memory_service/tests/test_failover_lock.py::test_process_death_releases
E   FileNotFoundError: [Errno 2] No such file or directory: '.../failover.lock'
1 failed, 5 passed
```

After, the whole file under the macOS default:

```
6 passed
```

`pre-commit run --files lib/gpu_memory_service/tests/test_failover_lock.py`: 0 failing hooks.

Not verified here: a real Linux 3.14 interpreter. The `forkserver` row is the mechanism that 3.14 switches to, exercised on this machine rather than inferred, but it is not the same as running the version itself.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved process-death test reliability across multiprocessing start methods.
  * Updated test signaling to use a compatible inter-process communication mechanism.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->