### PR TITLE
refactor(sidecar): unify gRPC endpoint configuration

### DIFF
--- a/lib/mocker/servers/sglang/README.md
+++ b/lib/mocker/servers/sglang/README.md
@@ -30,7 +30,7 @@ Point the existing sidecar at it:
 
 ```bash
 cargo run -p dynamo-sglang-sidecar --bin dynamo-sglang-sidecar -- \
-  --sglang-endpoint http://127.0.0.1:30001
+  --grpc-endpoint http://127.0.0.1:30001
 ```
 
 `--extra-engine-args` accepts inline JSON or a JSON file path. The server adds
@@ -62,13 +62,13 @@ bootstrap host. Run each sidecar in a separate terminal:
 
 ```bash
 cargo run -p dynamo-sglang-sidecar --bin dynamo-sglang-sidecar -- \
-  --sglang-endpoint http://127.0.0.1:30001 \
+  --grpc-endpoint http://127.0.0.1:30001 \
   --bootstrap-host 127.0.0.1
 ```
 
 ```bash
 cargo run -p dynamo-sglang-sidecar --bin dynamo-sglang-sidecar -- \
-  --sglang-endpoint http://127.0.0.1:30002
+  --grpc-endpoint http://127.0.0.1:30002
 ```
 
 The prefill response carries SGLang's bootstrap host, port, and room through

--- a/lib/mocker/servers/sglang/tests/sidecar.rs
+++ b/lib/mocker/servers/sglang/tests/sidecar.rs
@@ -78,7 +78,7 @@ fn fast_engine_args() -> MockEngineArgs {
 async fn sidecar(endpoint: &str, mode: DisaggregationMode) -> SglangSidecarEngine {
     let mut argv = vec![
         "dynamo-sglang-sidecar".to_string(),
-        "--sglang-endpoint".to_string(),
+        "--grpc-endpoint".to_string(),
         endpoint.to_string(),
         "--grpc-connections".to_string(),
         "1".to_string(),

--- a/lib/mocker/servers/vllm/README.md
+++ b/lib/mocker/servers/vllm/README.md
@@ -24,7 +24,7 @@ Point the existing Dynamo sidecar at it:
 
 ```bash
 cargo run -p dynamo-vllm-sidecar --bin dynamo-vllm-sidecar -- \
-  --vllm-endpoint 127.0.0.1:50051
+  --grpc-endpoint 127.0.0.1:50051
 ```
 
 `--extra-engine-args` accepts inline JSON or a JSON file path. The values use
@@ -56,11 +56,11 @@ Then start one sidecar for each endpoint:
 
 ```bash
 cargo run -p dynamo-vllm-sidecar --bin dynamo-vllm-sidecar -- \
-  --vllm-endpoint 127.0.0.1:50051 \
+  --grpc-endpoint 127.0.0.1:50051 \
   --disaggregation-mode prefill
 
 cargo run -p dynamo-vllm-sidecar --bin dynamo-vllm-sidecar -- \
-  --vllm-endpoint 127.0.0.1:50052 \
+  --grpc-endpoint 127.0.0.1:50052 \
   --disaggregation-mode decode
 ```
 

--- a/lib/mocker/servers/vllm/tests/sidecar.rs
+++ b/lib/mocker/servers/vllm/tests/sidecar.rs
@@ -87,7 +87,7 @@ fn fast_engine_args() -> MockEngineArgs {
 async fn sidecar(endpoint: &str, mode: DisaggregationMode) -> VllmSidecarEngine {
     let mut argv = vec![
         "dynamo-vllm-sidecar".to_string(),
-        "--vllm-endpoint".to_string(),
+        "--grpc-endpoint".to_string(),
         endpoint.to_string(),
         "--grpc-connections".to_string(),
         "1".to_string(),

--- a/lib/sidecar/common/src/args.rs
+++ b/lib/sidecar/common/src/args.rs
@@ -7,10 +7,16 @@ use std::time::Duration;
 use clap::Args;
 use dynamo_backend_common::CommonArgs;
 
+use crate::GrpcEndpoint;
+
 const DEFAULT_GRPC_CONNECT_ATTEMPT_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_GRPC_CONNECTIONS: NonZeroUsize = NonZeroUsize::new(8).unwrap();
 const DEFAULT_GRPC_RETRY_INTERVAL_SECS: u64 = 1;
 const DEFAULT_GRPC_STARTUP_DEADLINE_SECS: u64 = 300;
+
+fn parse_grpc_endpoint(raw: &str) -> Result<GrpcEndpoint, String> {
+    GrpcEndpoint::parse(raw, "--grpc-endpoint").map_err(|error| error.to_string())
+}
 
 /// CLI flags shared by gRPC sidecars.
 #[derive(Args, Clone, Debug)]
@@ -70,6 +76,14 @@ pub struct SidecarArgs {
     #[command(flatten)]
     pub common: CommonArgs,
 
+    /// Engine gRPC endpoint as `host:port` or a plaintext gRPC/HTTP URL.
+    #[arg(
+        long,
+        env = "DYN_SIDECAR_GRPC_ENDPOINT",
+        value_parser = parse_grpc_endpoint
+    )]
+    pub grpc_endpoint: GrpcEndpoint,
+
     #[command(flatten)]
     pub grpc: GrpcTransportArgs,
 }
@@ -109,7 +123,8 @@ mod tests {
 
     #[test]
     fn parses_defaults_and_overrides() {
-        let defaults = TestArgs::try_parse_from(["test"]).expect("parse defaults");
+        let defaults = TestArgs::try_parse_from(["test", "--grpc-endpoint", "127.0.0.1:50051"])
+            .expect("parse defaults");
         let config = defaults.sidecar.grpc.config();
         assert_eq!(config.connections.get(), 8);
         assert_eq!(config.connect_attempt_timeout, Duration::from_secs(30));
@@ -118,6 +133,8 @@ mod tests {
 
         let overrides = TestArgs::try_parse_from([
             "test",
+            "--grpc-endpoint",
+            "127.0.0.1:50051",
             "--grpc-connections",
             "2",
             "--grpc-connect-attempt-timeout-secs",
@@ -143,7 +160,12 @@ mod tests {
             "--grpc-retry-interval-secs",
             "--grpc-startup-deadline-secs",
         ] {
-            assert!(TestArgs::try_parse_from(["test", flag, "0"]).is_err());
+            assert!(
+                TestArgs::try_parse_from(
+                    ["test", "--grpc-endpoint", "127.0.0.1:50051", flag, "0",]
+                )
+                .is_err()
+            );
         }
     }
 }

--- a/lib/sidecar/sglang/README.md
+++ b/lib/sidecar/sglang/README.md
@@ -18,13 +18,13 @@ Build and run it directly from the Dynamo workspace:
 ```bash
 cargo build --release -p dynamo-sglang-sidecar
 ./target/release/dynamo-sglang-sidecar \
-    --sglang-endpoint http://127.0.0.1:30001
+    --grpc-endpoint http://127.0.0.1:30001
 ```
 
 There is no published image yet; the "Deploy on Kubernetes" section below builds
 a minimal one from `Dockerfile`. Official packaging is deferred to a follow-up.
 
-Use `SGLANG_GRPC_ENDPOINT` instead of `--sglang-endpoint` when the endpoint is provided through the environment.
+Use `DYN_SIDECAR_GRPC_ENDPOINT` instead of `--grpc-endpoint` when the endpoint is provided through the environment.
 
 The sidecar discovers the model and tokenizer paths, served model name, parser defaults, worker role, context length, KV capacity, scheduler limits, data-parallel topology, and KV-event sources through SGLang's native discovery RPCs. Explicit Dynamo parser options override parser names discovered from SGLang.
 

--- a/lib/sidecar/sglang/deploy/agg.yaml
+++ b/lib/sidecar/sglang/deploy/agg.yaml
@@ -95,7 +95,7 @@ spec:
           command:
           - dynamo-sglang-sidecar
           args:
-          - --sglang-endpoint
+          - --grpc-endpoint
           - 127.0.0.1:30001
           envFrom:
           - secretRef:

--- a/lib/sidecar/sglang/deploy/disagg.yaml
+++ b/lib/sidecar/sglang/deploy/disagg.yaml
@@ -116,7 +116,7 @@ spec:
           command:
           - dynamo-sglang-sidecar
           args:
-          - --sglang-endpoint
+          - --grpc-endpoint
           - 127.0.0.1:30001
           env:
           # Advertise this pod's IP as the bootstrap host decode workers dial.
@@ -204,7 +204,7 @@ spec:
           command:
           - dynamo-sglang-sidecar
           args:
-          - --sglang-endpoint
+          - --grpc-endpoint
           - 127.0.0.1:30001
           envFrom:
           - secretRef:

--- a/lib/sidecar/sglang/launch/agg.sh
+++ b/lib/sidecar/sglang/launch/agg.sh
@@ -86,6 +86,6 @@ CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" \
 
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT:-8081}" \
     dynamo-sglang-sidecar \
-    --sglang-endpoint "${SGLANG_HOST}:${SGLANG_GRPC_PORT}" &
+    --grpc-endpoint "${SGLANG_HOST}:${SGLANG_GRPC_PORT}" &
 
 wait_any_exit

--- a/lib/sidecar/sglang/launch/agg_kv_router.sh
+++ b/lib/sidecar/sglang/launch/agg_kv_router.sh
@@ -118,11 +118,11 @@ CUDA_VISIBLE_DEVICES="$SGLANG_WORKER2_GPU" \
 OTEL_SERVICE_NAME=dynamo-worker-1 \
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT1:-8081}" \
     dynamo-sglang-sidecar \
-    --sglang-endpoint "${SGLANG_HOST}:${SGLANG_WORKER1_GRPC_PORT}" &
+    --grpc-endpoint "${SGLANG_HOST}:${SGLANG_WORKER1_GRPC_PORT}" &
 
 OTEL_SERVICE_NAME=dynamo-worker-2 \
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT2:-8082}" \
     dynamo-sglang-sidecar \
-    --sglang-endpoint "${SGLANG_HOST}:${SGLANG_WORKER2_GRPC_PORT}" &
+    --grpc-endpoint "${SGLANG_HOST}:${SGLANG_WORKER2_GRPC_PORT}" &
 
 wait_any_exit

--- a/lib/sidecar/sglang/launch/disagg.sh
+++ b/lib/sidecar/sglang/launch/disagg.sh
@@ -116,12 +116,12 @@ CUDA_VISIBLE_DEVICES="$SGLANG_DECODE_GPU" \
 OTEL_SERVICE_NAME=dynamo-worker-prefill \
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT1:-8081}" \
     dynamo-sglang-sidecar \
-    --sglang-endpoint "${SGLANG_HOST}:${SGLANG_PREFILL_GRPC_PORT}" \
+    --grpc-endpoint "${SGLANG_HOST}:${SGLANG_PREFILL_GRPC_PORT}" \
     --bootstrap-host "$SGLANG_BOOTSTRAP_HOST" &
 
 OTEL_SERVICE_NAME=dynamo-worker-decode \
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT2:-8082}" \
     dynamo-sglang-sidecar \
-    --sglang-endpoint "${SGLANG_HOST}:${SGLANG_DECODE_GRPC_PORT}" &
+    --grpc-endpoint "${SGLANG_HOST}:${SGLANG_DECODE_GRPC_PORT}" &
 
 wait_any_exit

--- a/lib/sidecar/sglang/src/args.rs
+++ b/lib/sidecar/sglang/src/args.rs
@@ -15,10 +15,6 @@ pub struct Args {
     #[command(flatten)]
     pub sidecar: SidecarArgs,
 
-    /// `host:port` (or URL) of SGLang's native `sglang.runtime.v1` service.
-    #[arg(long, visible_alias = "grpc-endpoint", env = "SGLANG_GRPC_ENDPOINT")]
-    pub sglang_endpoint: String,
-
     /// Reachable host that decode workers use to connect to a prefill worker's
     /// SGLang disaggregation bootstrap port. By default this is derived from
     /// SGLang's concrete `host`, then `dist_init_addr`, then a routable local

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -82,7 +82,7 @@ impl SglangSidecarEngine {
             ));
         }
 
-        let endpoint = GrpcEndpoint::parse(&args.sglang_endpoint, "--sglang-endpoint")?;
+        let endpoint = args.sidecar.grpc_endpoint;
         let transport = args.sidecar.grpc.config();
         let discovery = bootstrap_discover(&endpoint, &transport)?;
         let disaggregation_mode = discovery_mode(&discovery)?;

--- a/lib/sidecar/sglang/tests/executable.rs
+++ b/lib/sidecar/sglang/tests/executable.rs
@@ -17,8 +17,8 @@ fn executable_exposes_sglang_and_shared_sidecar_contracts() {
     );
     let stdout = String::from_utf8(output.stdout).expect("help output is UTF-8");
     for expected in [
-        "--sglang-endpoint",
-        "SGLANG_GRPC_ENDPOINT",
+        "--grpc-endpoint",
+        "DYN_SIDECAR_GRPC_ENDPOINT",
         "--grpc-connections",
         "DYN_SIDECAR_GRPC_CONNECTIONS",
         "--grpc-connect-attempt-timeout-secs",

--- a/lib/sidecar/trtllm/README.md
+++ b/lib/sidecar/trtllm/README.md
@@ -46,11 +46,11 @@ Start the Dynamo worker:
 
 ```bash
 dynamo-trtllm-sidecar \
-  --trtllm-endpoint 127.0.0.1:50051 \
+  --grpc-endpoint 127.0.0.1:50051 \
   --model-path <model>
 ```
 
-Use `TRTLLM_GRPC_ENDPOINT` instead of `--trtllm-endpoint` when the endpoint is
+Use `DYN_SIDECAR_GRPC_ENDPOINT` instead of `--grpc-endpoint` when the endpoint is
 provided through the environment.
 
 ## Deploy on Kubernetes (quick start)

--- a/lib/sidecar/trtllm/deploy/agg.yaml
+++ b/lib/sidecar/trtllm/deploy/agg.yaml
@@ -104,7 +104,7 @@ spec:
           command:
           - dynamo-trtllm-sidecar
           args:
-          - --trtllm-endpoint
+          - --grpc-endpoint
           - 127.0.0.1:50051
           - --model-path
           - Qwen/Qwen3-0.6B

--- a/lib/sidecar/trtllm/launch/agg.sh
+++ b/lib/sidecar/trtllm/launch/agg.sh
@@ -91,7 +91,7 @@ CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" \
 
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT:-8081}" \
     dynamo-trtllm-sidecar \
-    --trtllm-endpoint "127.0.0.1:${TRTLLM_GRPC_PORT}" \
+    --grpc-endpoint "127.0.0.1:${TRTLLM_GRPC_PORT}" \
     --model-path "$MODEL" \
     --context-length "$TRTLLM_CONTEXT_LENGTH" &
 

--- a/lib/sidecar/trtllm/src/args.rs
+++ b/lib/sidecar/trtllm/src/args.rs
@@ -12,10 +12,6 @@ pub(crate) struct Args {
     #[command(flatten)]
     pub sidecar: SidecarArgs,
 
-    /// TensorRT-LLM gRPC endpoint as host:port or an http:// URL.
-    #[arg(long, env = "TRTLLM_GRPC_ENDPOINT")]
-    pub trtllm_endpoint: String,
-
     /// Hugging Face model ID or local path used for tokenization and templates.
     #[arg(long)]
     pub model_path: String,

--- a/lib/sidecar/trtllm/src/engine.rs
+++ b/lib/sidecar/trtllm/src/engine.rs
@@ -87,7 +87,7 @@ impl TrtllmSidecarEngine {
             ));
         }
 
-        let endpoint = GrpcEndpoint::parse(&args.trtllm_endpoint, "--trtllm-endpoint")?;
+        let endpoint = args.sidecar.grpc_endpoint;
         let transport = args.sidecar.grpc.config();
         let model = ConfiguredModel {
             source: args.model_path,

--- a/lib/sidecar/trtllm/src/tests.rs
+++ b/lib/sidecar/trtllm/src/tests.rs
@@ -257,7 +257,7 @@ fn transport(connections: usize) -> GrpcTransportConfig {
 
 fn engine(endpoint: &str, connections: usize) -> TrtllmSidecarEngine {
     TrtllmSidecarEngine::new(
-        GrpcEndpoint::parse(endpoint, "--trtllm-endpoint").expect("valid test endpoint"),
+        GrpcEndpoint::parse(endpoint, "--grpc-endpoint").expect("valid test endpoint"),
         transport(connections),
         ConfiguredModel {
             source: "model-source".to_string(),
@@ -723,7 +723,7 @@ async fn unsupported_features_fail_before_rpc_submission() {
 async fn pool_uses_each_configured_connection() {
     let server = FakeServer::start(FakeTrtllm::default()).await;
     let endpoint =
-        GrpcEndpoint::parse(&server.endpoint, "--trtllm-endpoint").expect("valid endpoint");
+        GrpcEndpoint::parse(&server.endpoint, "--grpc-endpoint").expect("valid endpoint");
     let client = TrtllmClient::connect(&endpoint, transport(2))
         .await
         .expect("connect pool");

--- a/lib/sidecar/trtllm/tests/executable.rs
+++ b/lib/sidecar/trtllm/tests/executable.rs
@@ -16,7 +16,8 @@ fn executable_exposes_native_grpc_configuration() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8(output.stdout).expect("help output is UTF-8");
-    for flag in ["--trtllm-endpoint", "--model-path", "--disaggregation-mode"] {
+    for flag in ["--grpc-endpoint", "--model-path", "--disaggregation-mode"] {
         assert!(stdout.contains(flag), "missing {flag} in help output");
     }
+    assert!(stdout.contains("DYN_SIDECAR_GRPC_ENDPOINT"));
 }

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -51,10 +51,10 @@ Start the Dynamo worker explicitly:
 
 ```bash
 dynamo-vllm-sidecar \
-  --vllm-endpoint 127.0.0.1:50051
+  --grpc-endpoint 127.0.0.1:50051
 ```
 
-Use `VLLM_GRPC_ENDPOINT` instead of `--vllm-endpoint` when the endpoint is
+Use `DYN_SIDECAR_GRPC_ENDPOINT` instead of `--grpc-endpoint` when the endpoint is
 provided through the environment.
 
 ### RL workflows
@@ -69,7 +69,7 @@ vllm-rs serve Qwen/Qwen3-0.6B \
   --weight-transfer-config '{"backend":"nccl"}'
 
 DYN_SYSTEM_PORT=8081 dynamo-vllm-sidecar \
-  --vllm-endpoint 127.0.0.1:50051 \
+  --grpc-endpoint 127.0.0.1:50051 \
   --enable-rl
 ```
 
@@ -108,7 +108,7 @@ cargo run -p dynamo-vllm-mocker --bin dynamo-vllm-mocker-server -- \
   --extra-engine-args '{"speedup_ratio":1000}'
 
 cargo run -p dynamo-vllm-sidecar --bin dynamo-vllm-sidecar -- \
-  --vllm-endpoint 127.0.0.1:50051
+  --grpc-endpoint 127.0.0.1:50051
 ```
 
 The mocker does not advertise RL capabilities; use a compatible vLLM server for RL route testing.

--- a/lib/sidecar/vllm/deploy/agg.yaml
+++ b/lib/sidecar/vllm/deploy/agg.yaml
@@ -92,7 +92,7 @@ spec:
           command:
           - dynamo-vllm-sidecar
           args:
-          - --vllm-endpoint
+          - --grpc-endpoint
           - 127.0.0.1:50051
           envFrom:
           - secretRef:

--- a/lib/sidecar/vllm/deploy/disagg.yaml
+++ b/lib/sidecar/vllm/deploy/disagg.yaml
@@ -135,7 +135,7 @@ spec:
           command:
           - dynamo-vllm-sidecar
           args:
-          - --vllm-endpoint
+          - --grpc-endpoint
           - 127.0.0.1:50051
           - --disaggregation-mode
           - prefill
@@ -226,7 +226,7 @@ spec:
           command:
           - dynamo-vllm-sidecar
           args:
-          - --vllm-endpoint
+          - --grpc-endpoint
           - 127.0.0.1:50051
           - --disaggregation-mode
           - decode

--- a/lib/sidecar/vllm/launch/agg.sh
+++ b/lib/sidecar/vllm/launch/agg.sh
@@ -91,6 +91,6 @@ vllm-rs serve "$MODEL" \
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
     dynamo-vllm-sidecar \
-    --vllm-endpoint "127.0.0.1:${VLLM_GRPC_PORT}" &
+    --grpc-endpoint "127.0.0.1:${VLLM_GRPC_PORT}" &
 
 wait_any_exit

--- a/lib/sidecar/vllm/launch/disagg.sh
+++ b/lib/sidecar/vllm/launch/disagg.sh
@@ -124,14 +124,14 @@ vllm-rs serve "$MODEL" \
 OTEL_SERVICE_NAME=dynamo-worker-decode \
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT1:-8081}" \
     dynamo-vllm-sidecar \
-    --vllm-endpoint "127.0.0.1:${VLLM_DECODE_GRPC_PORT}" \
+    --grpc-endpoint "127.0.0.1:${VLLM_DECODE_GRPC_PORT}" \
     --disaggregation-mode decode &
 
 # Register prefill separately so the frontend routes each disaggregated stage.
 OTEL_SERVICE_NAME=dynamo-worker-prefill \
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT2:-8082}" \
     dynamo-vllm-sidecar \
-    --vllm-endpoint "127.0.0.1:${VLLM_PREFILL_GRPC_PORT}" \
+    --grpc-endpoint "127.0.0.1:${VLLM_PREFILL_GRPC_PORT}" \
     --component prefill \
     --disaggregation-mode prefill &
 

--- a/lib/sidecar/vllm/src/args.rs
+++ b/lib/sidecar/vllm/src/args.rs
@@ -11,8 +11,4 @@ use dynamo_sidecar_common::SidecarArgs;
 pub(crate) struct Args {
     #[command(flatten)]
     pub sidecar: SidecarArgs,
-
-    /// vLLM gRPC endpoint as host:port or an http:// URL.
-    #[arg(long, env = "VLLM_GRPC_ENDPOINT")]
-    pub vllm_endpoint: String,
 }

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -100,7 +100,7 @@ impl VllmSidecarEngine {
             ));
         }
 
-        let endpoint = GrpcEndpoint::parse(&args.vllm_endpoint, "--vllm-endpoint")?;
+        let endpoint = args.sidecar.grpc_endpoint;
         let transport = args.sidecar.grpc.config();
         let bootstrap_deadline = client::startup_deadline(transport.startup_deadline)?;
         eprintln!(

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -747,7 +747,7 @@ fn engine_with_server_info(
         ..Default::default()
     };
     VllmSidecarEngine::new(
-        GrpcEndpoint::parse(endpoint, "--vllm-endpoint").expect("valid test endpoint"),
+        GrpcEndpoint::parse(endpoint, "--grpc-endpoint").expect("valid test endpoint"),
         DiscoveredModel::from_proto(model, server).expect("valid discovery"),
         mode,
         transport,
@@ -759,7 +759,7 @@ async fn engine_from_args(
 ) -> (VllmSidecarEngine, dynamo_backend_common::WorkerConfig) {
     let argv = vec![
         "dynamo-vllm-sidecar".to_string(),
-        "--vllm-endpoint".to_string(),
+        "--grpc-endpoint".to_string(),
         endpoint.to_string(),
         "--grpc-connections".to_string(),
         "2".to_string(),
@@ -1365,7 +1365,7 @@ async fn component_honors_config_for_aggregated_but_fixes_disagg_roles() {
     ] {
         let mut argv = vec![
             "dynamo-vllm-sidecar".to_string(),
-            "--vllm-endpoint".to_string(),
+            "--grpc-endpoint".to_string(),
             server.endpoint.clone(),
             "--component".to_string(),
             "custom".to_string(),
@@ -1389,7 +1389,7 @@ async fn pool_uses_each_configured_connection() {
         connections: NonZeroUsize::new(2).unwrap(),
         ..Default::default()
     };
-    let endpoint = GrpcEndpoint::parse(&server.endpoint, "--vllm-endpoint").unwrap();
+    let endpoint = GrpcEndpoint::parse(&server.endpoint, "--grpc-endpoint").unwrap();
     let deadline = crate::client::startup_deadline(transport.startup_deadline).unwrap();
     let client = VllmClient::connect(&endpoint, transport, deadline)
         .await

--- a/lib/sidecar/vllm/tests/executable.rs
+++ b/lib/sidecar/vllm/tests/executable.rs
@@ -17,7 +17,7 @@ fn executable_exposes_native_grpc_configuration() {
     );
     let stdout = String::from_utf8(output.stdout).expect("help output is UTF-8");
     for flag in [
-        "--vllm-endpoint",
+        "--grpc-endpoint",
         "--grpc-connections",
         "--disaggregation-mode",
         "--grpc-connect-attempt-timeout-secs",
@@ -27,6 +27,7 @@ fn executable_exposes_native_grpc_configuration() {
         assert!(stdout.contains(flag), "missing {flag} in help output");
     }
     for env in [
+        "DYN_SIDECAR_GRPC_ENDPOINT",
         "DYN_SIDECAR_GRPC_CONNECTIONS",
         "DYN_SIDECAR_GRPC_CONNECT_ATTEMPT_TIMEOUT_SECS",
         "DYN_SIDECAR_GRPC_RETRY_INTERVAL_SECS",


### PR DESCRIPTION
## Overview

Standardize engine gRPC endpoint configuration across the vLLM, SGLang, and TensorRT-LLM sidecars.

## Summary

- Move engine gRPC endpoint parsing into the shared SidecarArgs.
- Replace the engine-specific flags and environment variables with --grpc-endpoint and DYN_SIDECAR_GRPC_ENDPOINT.
- Update launch scripts, Kubernetes manifests, mockers, READMEs, and executable CLI contract tests.

## Details

The existing --endpoint flag remains unchanged because it names the Dynamo registration endpoint. The new shared --grpc-endpoint flag is parsed once into GrpcEndpoint and consumed consistently by every engine sidecar.

## Where should the reviewer start?

- lib/sidecar/common/src/args.rs for the shared CLI contract.
- lib/sidecar/{vllm,sglang,trtllm}/src/engine.rs for engine consumption.
- lib/sidecar/*/tests/executable.rs for the user-visible CLI contract.

## Validation

- cargo fmt --all -- --check
- cargo test -p dynamo-sidecar-common
- cargo test -p dynamo-vllm-sidecar -p dynamo-sglang-sidecar -p dynamo-trtllm-sidecar
- cargo test -p dynamo-vllm-mocker -p dynamo-sglang-mocker --test sidecar
- bash -n on all modified launch scripts
- pre-commit run --files on all modified files
- git diff --check

## Related Issues

- Relates to #13781
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared gRPC endpoint configuration for all sidecar types.
  * Supports the `--grpc-endpoint` option and `DYN_SIDECAR_GRPC_ENDPOINT` environment variable.

* **Bug Fixes**
  * Updated SGLang, vLLM, and TensorRT-LLM launch, deployment, and mock server configurations to use the unified endpoint setting.

* **Documentation**
  * Refreshed startup examples and help output to reflect the new configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->