### PR TITLE
fix(gms): apply the AF_UNIX length limit to the V0 socket path too

### DIFF
--- a/lib/gpu_memory_service/common/utils.py
+++ b/lib/gpu_memory_service/common/utils.py
@@ -96,9 +96,7 @@ def get_socket_path(device: int, tag: str = "weights") -> str:
             pynvml.nvmlShutdown()
         _uuid_cache[device] = uuid
     socket_dir = os.environ.get("GMS_SOCKET_DIR") or tempfile.gettempdir()
-    return ensure_af_unix_path_fits(
-        os.path.join(socket_dir, f"gms_{uuid}_{tag}.sock")
-    )
+    return ensure_af_unix_path_fits(os.path.join(socket_dir, f"gms_{uuid}_{tag}.sock"))
 
 
 def align_to_granularity(size: int, granularity: int) -> int:

--- a/lib/gpu_memory_service/common/utils.py
+++ b/lib/gpu_memory_service/common/utils.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+import sys
 import tempfile
 from typing import NoReturn
 
@@ -23,6 +24,27 @@ ENV_VMM_GRANULARITY = "DYN_GMS_VMM_GRANULARITY"
 GMS_TAGS = ("weights", "kv_cache")
 
 _TRUTHY = ("true", "1", "yes")
+
+# sun_path is 104 bytes on Darwin and 108 on Linux, including the terminator.
+# Shared by both socket-path builders so the two cannot disagree about it.
+AF_UNIX_PATH_LIMIT = 104 if sys.platform == "darwin" else 108
+
+
+def ensure_af_unix_path_fits(path: str) -> str:
+    """Return path, or raise ValueError if it cannot be bound as an AF_UNIX socket.
+
+    bind() reports an over-long path as a bare ``OSError: AF_UNIX path too long``
+    from wherever the socket is created, which does not say which path or what
+    the limit was. Callers build these from ``GMS_SOCKET_DIR``, so the value is
+    operator-supplied and worth naming.
+    """
+    path_bytes = len(os.fsencode(path))
+    if path_bytes >= AF_UNIX_PATH_LIMIT:
+        raise ValueError(
+            "GMS socket path is too long for AF_UNIX "
+            f"({path_bytes} bytes, limit {AF_UNIX_PATH_LIMIT - 1}): {path}"
+        )
+    return path
 
 
 def is_truthy_env(name: str) -> bool:
@@ -74,7 +96,9 @@ def get_socket_path(device: int, tag: str = "weights") -> str:
             pynvml.nvmlShutdown()
         _uuid_cache[device] = uuid
     socket_dir = os.environ.get("GMS_SOCKET_DIR") or tempfile.gettempdir()
-    return os.path.join(socket_dir, f"gms_{uuid}_{tag}.sock")
+    return ensure_af_unix_path_fits(
+        os.path.join(socket_dir, f"gms_{uuid}_{tag}.sock")
+    )
 
 
 def align_to_granularity(size: int, granularity: int) -> int:

--- a/lib/gpu_memory_service/tests/test_cli_server.py
+++ b/lib/gpu_memory_service/tests/test_cli_server.py
@@ -17,6 +17,7 @@ if not HAS_GMS:
     )
 
 from gpu_memory_service.cli import runner, server
+from gpu_memory_service.common import utils as common_utils
 from gpu_memory_service.v1 import device as v1_device
 
 pytestmark = [
@@ -33,6 +34,17 @@ def test_v1_socket_path_rejects_af_unix_overflow(monkeypatch):
 
     with pytest.raises(ValueError, match="too long for AF_UNIX"):
         v1_device.get_socket_path(0, "weights")
+
+
+def test_v0_socket_path_rejects_af_unix_overflow(monkeypatch):
+    # server.py picks between this builder and the V1 one on args.use_v1, and
+    # this is the branch that names the socket after the full GPU UUID, so it
+    # produces the longer of the two paths for the same GMS_SOCKET_DIR.
+    monkeypatch.setenv("GMS_SOCKET_DIR", "/" + "s" * 200)
+    monkeypatch.setitem(common_utils._uuid_cache, 0, "GPU-0")
+
+    with pytest.raises(ValueError, match="too long for AF_UNIX"):
+        common_utils.get_socket_path(0, "weights")
 
 
 class _Process:

--- a/lib/gpu_memory_service/tests/test_cli_server.py
+++ b/lib/gpu_memory_service/tests/test_cli_server.py
@@ -40,11 +40,19 @@ def test_v0_socket_path_rejects_af_unix_overflow(monkeypatch):
     # server.py picks between this builder and the V1 one on args.use_v1, and
     # this is the branch that names the socket after the full GPU UUID, so it
     # produces the longer of the two paths for the same GMS_SOCKET_DIR.
-    monkeypatch.setenv("GMS_SOCKET_DIR", "/" + "s" * 200)
+    socket_dir = "/" + "s" * 200
+    monkeypatch.setenv("GMS_SOCKET_DIR", socket_dir)
     monkeypatch.setitem(common_utils._uuid_cache, 0, "GPU-0")
 
-    with pytest.raises(ValueError, match="too long for AF_UNIX"):
+    with pytest.raises(ValueError, match="too long for AF_UNIX") as excinfo:
         common_utils.get_socket_path(0, "weights")
+
+    # The path and the limit are the actionable half of the message: the
+    # operator has to see which path was built and what it has to fit in.
+    # The limit is read from the constant because it is platform-dependent.
+    message = str(excinfo.value)
+    assert f"{socket_dir}/gms_GPU-0_weights.sock" in message
+    assert f"limit {common_utils.AF_UNIX_PATH_LIMIT - 1}" in message
 
 
 class _Process:

--- a/lib/gpu_memory_service/v1/device.py
+++ b/lib/gpu_memory_service/v1/device.py
@@ -19,7 +19,6 @@ except ImportError:
     cuda = None
 
 
-
 def _check_cuda(result, operation: str) -> None:
     if cuda is None:
         raise RuntimeError(

--- a/lib/gpu_memory_service/v1/device.py
+++ b/lib/gpu_memory_service/v1/device.py
@@ -6,11 +6,11 @@
 from __future__ import annotations
 
 import os
-import sys
 import tempfile
 from functools import cache
 from uuid import UUID
 
+from gpu_memory_service.common.utils import ensure_af_unix_path_fits
 from gpu_memory_service.common.vmm.cuda_utils import cuda_ensure_initialized
 
 try:
@@ -18,7 +18,6 @@ try:
 except ImportError:
     cuda = None
 
-_AF_UNIX_PATH_LIMIT = 104 if sys.platform == "darwin" else 108
 
 
 def _check_cuda(result, operation: str) -> None:
@@ -69,10 +68,5 @@ def get_socket_path(device: int, tag: str = "weights") -> str:
         socket_dir,
         f"gms_{device}_{tag}.sock",
     )
-    path_bytes = len(os.fsencode(path))
-    if path_bytes >= _AF_UNIX_PATH_LIMIT:
-        raise ValueError(
-            "GMS socket path is too long for AF_UNIX "
-            f"({path_bytes} bytes, limit {_AF_UNIX_PATH_LIMIT - 1}): {path}"
-        )
+    ensure_af_unix_path_fits(path)
     return path


### PR DESCRIPTION
## Summary

`cli/server.py` builds the GMS socket path from one of two functions, chosen by `args.use_v1`:

```python
from gpu_memory_service.common.utils import get_socket_path
from gpu_memory_service.v1.device import get_socket_path as v1_get_socket_path
```

The V1 one refuses a path that cannot be bound, and says which path and what the limit was. The V0 one does not check at all. That is the wrong way round: V0 names the socket after the full GPU UUID rather than the device ordinal, so for the same `GMS_SOCKET_DIR` it produces the **longer** of the two paths.

```
gms_GPU-12345678-1234-1234-1234-123456789abc_weights.sock   57 bytes
gms_0_weights.sock                                          18 bytes
```

`sun_path` is 108 bytes on Linux and 104 on Darwin, including the terminator, and `GMS_SOCKET_DIR` is operator-supplied. A Kubernetes emptyDir mount is enough on its own:

```
GMS_SOCKET_DIR=/var/lib/kubelet/pods/<uid>/volumes/kubernetes.io~empty-dir/gms   94 bytes
full V0 path                                                                    152 bytes
```

With no check, that surfaces as a bare `OSError: AF_UNIX path too long` raised from inside `asyncio.start_unix_server`, naming neither the path nor the limit, on a value the operator chose. The V1 branch of the same command already fails with a message that names both.

#13156 added the check when it moved V1 to device ordinals, and scoped it to V1. This applies the same rule to the branch that still builds the longer name.

The constant and the check move into `common/utils.py`, which `v1/device.py` already imports from, and both call it. One definition, so the two builders cannot drift apart on the limit.

## Validation

The repository already asserts this behaviour for V1, in `test_cli_server.py`:

```python
def test_v1_socket_path_rejects_af_unix_overflow(monkeypatch):
    monkeypatch.setenv("GMS_SOCKET_DIR", "/" + "s" * 200)
    ...
    with pytest.raises(ValueError, match="too long for AF_UNIX"):
        v1_device.get_socket_path(0, "weights")
```

Added the V0 twin next to it. It fails on the unfixed tree, with the two source files reverted and the test kept:

```
FAILED lib/gpu_memory_service/tests/test_cli_server.py::test_v0_socket_path_rejects_af_unix_overflow
1 failed, 4 passed
```

and passes with the change:

```
5 passed
```

Whole suite, macOS arm64, Python 3.12: **88 passed**, 1 skipped, 2 failed. Both failures are pre-existing and unrelated to this change: `test_process_death_releases` is the raw-fd-under-spawn issue in #13796, and `test_large_allocation_unblocks_after_export_fd_holder_dies` needs NVML. `--basetemp` is short because the default macOS temp path itself exceeds 104 bytes.

`pre-commit run --files` on all three changed files: 0 failing hooks.

Not verified here: no GPU, so `get_socket_path` was exercised with the device UUID cache pre-populated rather than through `pynvml`, which is what the existing V1 test does as well.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added platform-aware validation for GPU memory service socket paths.
  * Oversized socket paths now produce a clear error before socket creation, preventing binding failures.
  * Validation is consistently applied across service versions and supported platforms.

* **Tests**
  * Added coverage for rejecting socket directories that exceed the operating system’s path limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->