### PR TITLE
feat(router): connect request classifier lifecycle

### DIFF
--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -98,3 +98,7 @@ harness = false
 [[bench]]
 name = "worker_selection"
 harness = false
+
+[[bench]]
+name = "request_classifier"
+harness = false

--- a/lib/kv-router/benches/request_classifier.rs
+++ b/lib/kv-router/benches/request_classifier.rs
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Scheduler overhead with classification disabled or using a pass-through classifier.
+//!
+//! Run with: `cargo bench -p dynamo-kv-router --bench request_classifier`
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use dynamo_kv_router::protocols::{RoutingConstraints, WorkerConfigLike};
+use dynamo_kv_router::scheduling::{
+    OverlapSignals, PolicyProfile, RequestClassifier, ScheduleMode, ScheduleRequest,
+};
+use dynamo_kv_router::{
+    ActiveSequencesMultiWorker, DefaultWorkerSelector, LocalScheduler, NoopSequencePublisher,
+    RouterQueuePolicy,
+};
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+
+const REQUESTS_PER_BATCH: usize = 128;
+static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+
+type BenchScheduler = LocalScheduler<NoopSequencePublisher, BenchWorkerConfig>;
+
+#[derive(Clone, Default, PartialEq, Eq)]
+struct BenchWorkerConfig {
+    max_num_batched_tokens: Option<u64>,
+    taints: HashSet<String>,
+}
+
+impl WorkerConfigLike for BenchWorkerConfig {
+    fn data_parallel_start_rank(&self) -> u32 {
+        0
+    }
+
+    fn data_parallel_size(&self) -> u32 {
+        1
+    }
+
+    fn max_num_batched_tokens(&self) -> Option<u64> {
+        self.max_num_batched_tokens
+    }
+
+    fn total_kv_blocks(&self) -> Option<u64> {
+        None
+    }
+
+    fn taints(&self) -> &HashSet<String> {
+        &self.taints
+    }
+}
+
+struct PassThroughClassifier;
+
+impl RequestClassifier for PassThroughClassifier {}
+
+async fn make_scheduler(classifier_enabled: bool) -> (Arc<BenchScheduler>, CancellationToken) {
+    let workers = HashMap::from([(
+        0,
+        BenchWorkerConfig {
+            max_num_batched_tokens: Some(4_096),
+            ..Default::default()
+        },
+    )]);
+    let slots = Arc::new(ActiveSequencesMultiWorker::new(
+        NoopSequencePublisher,
+        64,
+        HashMap::from([(0, (0, 1))]),
+        false,
+        0,
+        "request-classifier-benchmark",
+    ));
+    let (_workers_tx, workers_rx) = watch::channel(workers);
+    let cancellation = CancellationToken::new();
+    let profile = PolicyProfile::synthetic(None, RouterQueuePolicy::Fcfs);
+
+    let scheduler = if classifier_enabled {
+        LocalScheduler::new_with_policy_profile_and_request_classifier(
+            slots,
+            workers_rx,
+            profile,
+            64,
+            DefaultWorkerSelector::new(None, "request-classifier-benchmark"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Duration::from_secs(60),
+            true,
+            cancellation.clone(),
+            "request-classifier-benchmark",
+            false,
+            Box::new(PassThroughClassifier),
+        )
+        .unwrap()
+    } else {
+        LocalScheduler::new_without_overlap_refresh_with_policy_profile(
+            slots,
+            workers_rx,
+            profile,
+            64,
+            DefaultWorkerSelector::new(None, "request-classifier-benchmark"),
+            None,
+            None,
+            None,
+            Duration::from_secs(60),
+            true,
+            cancellation.clone(),
+            "request-classifier-benchmark",
+            false,
+        )
+        .unwrap()
+    };
+
+    (Arc::new(scheduler), cancellation)
+}
+
+fn request(mode: ScheduleMode) -> ScheduleRequest {
+    ScheduleRequest {
+        mode,
+        token_seq: None,
+        block_hashes: None,
+        isl_tokens: 64,
+        lora_name: None,
+        expected_output_tokens: None,
+        pinned_worker: None,
+        allowed_worker_ids: None,
+        routing_constraints: RoutingConstraints::default(),
+        router_config_override: None,
+        priority_jump: 0.0,
+        strict_priority: 0,
+        policy_class: None,
+        session_context: None,
+        overlap: OverlapSignals::default(),
+        router_hint_candidates: None,
+        retain_router_hint_chain: false,
+        shared_cache_hits: None,
+    }
+}
+
+async fn route_batch(scheduler: &BenchScheduler, lifecycle: bool) {
+    for _ in 0..REQUESTS_PER_BATCH {
+        let request_id = format!(
+            "request-classifier-benchmark-{}",
+            NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed)
+        );
+        let mut request_lifecycle = lifecycle
+            .then(|| scheduler.begin_request_lifecycle(&request_id))
+            .transpose()
+            .unwrap()
+            .flatten();
+        let mode = if request_lifecycle.is_some() {
+            ScheduleMode::TrackedWithLifecycle {
+                request_id: request_id.clone(),
+            }
+        } else {
+            ScheduleMode::Tracked {
+                request_id: request_id.clone(),
+            }
+        };
+        let response = scheduler.schedule_request(request(mode)).await.unwrap();
+        if let Some(request_lifecycle) = request_lifecycle.as_mut() {
+            request_lifecycle.selected(response.best_worker);
+            request_lifecycle.sent(response.best_worker);
+            request_lifecycle.received();
+            request_lifecycle.responding();
+            request_lifecycle.complete(Some(65));
+        }
+        black_box(response.best_worker);
+        scheduler.free(&request_id).await.unwrap();
+    }
+}
+
+fn request_classifier(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let (disabled, disabled_cancel) = runtime.block_on(make_scheduler(false));
+    let (pass_through, pass_through_cancel) = runtime.block_on(make_scheduler(true));
+
+    let mut group = c.benchmark_group("request_classifier/schedule");
+    group.throughput(Throughput::Elements(REQUESTS_PER_BATCH as u64));
+    group.bench_function("disabled", |b| {
+        b.iter(|| runtime.block_on(route_batch(&disabled, false)));
+    });
+    group.bench_function("pass_through", |b| {
+        b.iter(|| runtime.block_on(route_batch(&pass_through, false)));
+    });
+    group.finish();
+
+    let mut group = c.benchmark_group("request_classifier/full_lifecycle");
+    group.throughput(Throughput::Elements(REQUESTS_PER_BATCH as u64));
+    group.bench_function("disabled", |b| {
+        b.iter(|| runtime.block_on(route_batch(&disabled, true)));
+    });
+    group.bench_function("pass_through", |b| {
+        b.iter(|| runtime.block_on(route_batch(&pass_through, true)));
+    });
+    group.finish();
+
+    disabled_cancel.cancel();
+    pass_through_cancel.cancel();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(50)
+        .warm_up_time(Duration::from_secs(2))
+        .measurement_time(Duration::from_secs(5))
+        .noise_threshold(0.03);
+    targets = request_classifier
+}
+criterion_main!(benches);

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -992,6 +992,13 @@ where
         self.required_worker_inputs
     }
 
+    pub(crate) fn begin_request_lifecycle(
+        &self,
+        request_id: &str,
+    ) -> Result<Option<scheduling::RequestLifecycle>, KvSchedulerError> {
+        self.scheduler.begin_request_lifecycle(request_id)
+    }
+
     /// Cancel background work and wait for KV event ingestion to stop.
     pub async fn shutdown(mut self) {
         self.cancellation_token.cancel();

--- a/lib/llm/src/kv_router/routing_host.rs
+++ b/lib/llm/src/kv_router/routing_host.rs
@@ -90,12 +90,18 @@ where
         let stopped = context.stopped();
         tokio::pin!(stopped);
 
+        let mut terminal_handled = false;
         let completed = loop {
             tokio::select! {
                 biased;
 
                 _ = &mut stopped => {
                     tracing::debug!(request_id = context.id(), "Request cancelled, ending stream");
+                    let error = DynamoError::builder()
+                        .error_type(ErrorType::Cancelled)
+                        .message(format!("Request {} was cancelled", context.id()))
+                        .build();
+                    guard.abort_with_error(Some(&error)).await;
                     break false;
                 }
 
@@ -110,7 +116,14 @@ where
                         // Release the failed attempt before Migration can observe
                         // the item and start another one. This keeps serialized
                         // retries free of stale-cleanup ABA races.
-                        guard.abort().await;
+                        let retryable = item
+                            .error
+                            .as_ref()
+                            .is_some_and(|error| crate::migration::is_migratable(error));
+                        if !retryable || !guard.release_for_retry().await {
+                            guard.abort_with_error(item.error.as_ref()).await;
+                        }
+                        terminal_handled = true;
                         yield item;
                         break false;
                     }
@@ -121,7 +134,7 @@ where
 
         if completed {
             guard.finish().await;
-        } else {
+        } else if !terminal_handled {
             guard.abort().await;
         }
     }

--- a/lib/llm/src/kv_router/routing_host/kv.rs
+++ b/lib/llm/src/kv_router/routing_host/kv.rs
@@ -46,10 +46,53 @@ where
         phase: RequestPhase,
         is_query_only: bool,
     ) -> Result<(WorkerSelection, Option<AffinityAcquire>), Error> {
-        self.select_with_session_affinity(request, phase, is_query_only, |target| {
-            self.select_request(request, phase, is_query_only, target)
-        })
-        .await
+        let mut request_lifecycle = if is_query_only {
+            None
+        } else {
+            request
+                .migration_state
+                .as_ref()
+                .and_then(|state| state.take_request_lifecycle())
+        };
+        if !is_query_only && request_lifecycle.is_none() {
+            request_lifecycle = self
+                .kv_router()
+                .begin_request_lifecycle(request.context().id())
+                .map_err(anyhow::Error::from)?;
+        }
+
+        let selection_result = self
+            .select_with_session_affinity(request, phase, is_query_only, |target| {
+                self.select_request(request, phase, is_query_only, target)
+            })
+            .await;
+        let (mut selection, affinity_acquire) = match selection_result {
+            Ok(selection) => selection,
+            Err(error) => {
+                if let Some(mut lifecycle) = request_lifecycle.take() {
+                    if crate::migration::is_migratable(error.as_ref())
+                        && let Some(state) = request.migration_state.as_ref()
+                    {
+                        lifecycle.prepare_retry();
+                        state.store_request_lifecycle(lifecycle);
+                    } else {
+                        let typed_error = error
+                            .chain()
+                            .find_map(|cause| cause.downcast_ref::<DynamoError>());
+                        lifecycle
+                            .abort(typed_error.map(|error| {
+                                error as &dynamo_kv_router::scheduling::ClassifyError
+                            }));
+                    }
+                }
+                return Err(error);
+            }
+        };
+        if let Some(lifecycle) = request_lifecycle.as_mut() {
+            lifecycle.selected(selection.worker);
+        }
+        selection.lifecycle = request_lifecycle;
+        Ok((selection, affinity_acquire))
     }
 
     pub(super) async fn track_selection(
@@ -71,6 +114,7 @@ where
             selected_worker,
             request,
             !is_query_only,
+            selection.lifecycle.take(),
         );
 
         let record_result: Result<(), Error> = async {
@@ -149,7 +193,10 @@ where
         .await;
 
         if let Err(error) = record_result {
-            guard.abort().await;
+            let typed_error = error
+                .chain()
+                .find_map(|cause| cause.downcast_ref::<DynamoError>().cloned());
+            guard.abort_with_error(typed_error.as_ref()).await;
             return Err(error);
         }
         Ok(guard)
@@ -225,8 +272,12 @@ where
                 let typed_error = error
                     .chain()
                     .find_map(|cause| cause.downcast_ref::<DynamoError>().cloned());
-                guard.record_migration_failure(typed_error);
-                guard.abort().await;
+                guard.record_migration_failure(typed_error.clone());
+                if !crate::migration::is_migratable(error.as_ref())
+                    || !guard.release_for_retry().await
+                {
+                    guard.abort_with_error(typed_error.as_ref()).await;
+                }
                 return Err(error);
             }
         };

--- a/lib/llm/src/kv_router/routing_host/kv_selection.rs
+++ b/lib/llm/src/kv_router/routing_host/kv_selection.rs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, time::Instant};
-
 use dynamo_kv_router::{
     RouterConfigOverride,
     indexer::RoutingDecisionHashes,
@@ -12,6 +10,8 @@ use dynamo_kv_router::{
     selector::WorkerSelector,
 };
 use dynamo_runtime::{dynamo_nvtx_range, pipeline::Error};
+use std::collections::HashSet;
+use std::time::Instant;
 
 use crate::{
     kv_router::{
@@ -34,6 +34,7 @@ pub(super) struct WorkerSelection {
     pub(super) cached_tokens: usize,
     pub(super) routing_hashes: Option<RoutingDecisionHashes>,
     pub(super) router_hint: Option<RouterHint>,
+    pub(super) lifecycle: Option<dynamo_kv_router::scheduling::RequestLifecycle>,
 }
 
 #[derive(Clone, Copy)]
@@ -132,6 +133,7 @@ where
                 cached_tokens,
                 routing_hashes,
                 router_hint,
+                lifecycle: None,
             }),
             FindBestMatchOutcome::QueueRejected { rejection } => Err(rejection.into()),
         }

--- a/lib/llm/src/kv_router/routing_host/request_guard.rs
+++ b/lib/llm/src/kv_router/routing_host/request_guard.rs
@@ -22,6 +22,7 @@ use dynamo_kv_router::{
         BlockExtraInfo, BlockHashOptions, WorkerWithDpRank, compute_block_hash_for_seq,
         compute_next_seq_hash,
     },
+    scheduling::{ClassifyError, RequestLifecycle},
     selector::WorkerSelector,
 };
 use dynamo_runtime::{
@@ -575,6 +576,9 @@ where
     record_itl_at_completion: bool,
     prefill_marked: bool,
     migration_state: Option<MigrationState>,
+    request_lifecycle: Option<RequestLifecycle>,
+    lifecycle_input_tokens: usize,
+    authoritative_context_tokens: Option<usize>,
     _lora_load: Option<LoraLoadGuard>,
 }
 
@@ -589,11 +593,13 @@ where
         worker: WorkerWithDpRank,
         request: &PreprocessedRequest,
         scheduler_tracked: bool,
+        request_lifecycle: Option<RequestLifecycle>,
     ) -> Self {
         // Snapshot request-scoped inputs now so the guard can outlive the
         // PreprocessedRequest after it is moved into backend dispatch.
         let block_size = chooser.block_size() as usize;
         let isl_tokens = request.token_ids.len();
+        let lifecycle_input_tokens = request.input_token_count();
         let expected_output_tokens = request
             .routing
             .as_ref()
@@ -635,6 +641,9 @@ where
             record_itl_at_completion: false,
             prefill_marked: false,
             migration_state: request.migration_state.clone(),
+            request_lifecycle,
+            lifecycle_input_tokens,
+            authoritative_context_tokens: None,
             _lora_load: None,
         }
     }
@@ -664,6 +673,9 @@ where
             record_itl_at_completion: true,
             prefill_marked: false,
             migration_state: request.migration_state.clone(),
+            request_lifecycle: None,
+            lifecycle_input_tokens: request.input_token_count(),
+            authoritative_context_tokens: None,
             _lora_load: lora_load,
         }
     }
@@ -692,6 +704,16 @@ where
 
     pub(super) fn mark_dispatched(&mut self) {
         self.observability.mark_dispatched();
+        if let Some(lifecycle) = self.request_lifecycle.as_mut() {
+            let worker = match &self.cleanup {
+                RequestCleanup::Kv(cleanup) => cleanup.worker,
+                RequestCleanup::Stateless { worker_id }
+                | RequestCleanup::Occupancy { worker_id, .. } => {
+                    WorkerWithDpRank::from_worker_id(*worker_id)
+                }
+            };
+            lifecycle.sent(worker);
+        }
     }
 
     pub(super) fn has_approximate_lru(&self) -> bool {
@@ -732,9 +754,23 @@ where
     }
 
     pub(super) async fn on_item(&mut self, item: &Annotated<LLMEngineOutput>) {
+        if let Some(lifecycle) = self.request_lifecycle.as_mut() {
+            lifecycle.responding();
+        }
         self.observability.observe_response();
 
         let new_tokens = item.data.as_ref().map_or(0, |data| data.token_ids.len());
+        if let Some(total_tokens) = item
+            .data
+            .as_ref()
+            .and_then(|data| data.completion_usage.as_ref())
+            .map(|usage| usage.total_tokens as usize)
+        {
+            self.authoritative_context_tokens = Some(
+                self.authoritative_context_tokens
+                    .map_or(total_tokens, |current| current.max(total_tokens)),
+            );
+        }
         if !self.prefill_marked {
             let has_tokens = item
                 .data
@@ -799,6 +835,11 @@ where
     }
 
     pub(super) async fn finish(&mut self) {
+        if let Some(lifecycle) = self.request_lifecycle.as_mut() {
+            lifecycle.complete(Some(self.authoritative_context_tokens.unwrap_or_else(
+                || self.lifecycle_input_tokens + self.observability.cumulative_osl(),
+            )));
+        }
         // Metrics must observe the completed request before cleanup releases its state.
         self.observability
             .record_metrics(self.record_itl_at_completion);
@@ -827,6 +868,29 @@ where
     }
 
     pub(super) async fn abort(&mut self) {
+        self.abort_with_error(None).await;
+    }
+
+    pub(super) async fn release_for_retry(&mut self) -> bool {
+        let Some(migration_state) = self.migration_state.as_ref() else {
+            return false;
+        };
+        let Some(mut lifecycle) = self.request_lifecycle.take() else {
+            return false;
+        };
+        lifecycle.prepare_retry();
+        migration_state.store_request_lifecycle(lifecycle);
+        if let Some(lease) = &self.approximate_lru {
+            lease.release_now();
+        }
+        self.cleanup.finish().await;
+        true
+    }
+
+    pub(super) async fn abort_with_error(&mut self, error: Option<&DynamoError>) {
+        if let Some(lifecycle) = self.request_lifecycle.as_mut() {
+            lifecycle.abort(error.map(|error| error as &ClassifyError));
+        }
         if let Some(lease) = &self.approximate_lru {
             lease.release_now();
         }
@@ -839,6 +903,9 @@ where
     Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
 {
     fn drop(&mut self) {
+        if let Some(lifecycle) = self.request_lifecycle.as_mut() {
+            lifecycle.abort(None);
+        }
         self.observability
             .record_metrics(self.record_itl_at_completion);
         if let Some(lease) = &self.approximate_lru {
@@ -849,143 +916,5 @@ where
 }
 
 #[cfg(test)]
-mod output_hash_tests {
-    use super::*;
-    use dynamo_kv_router::protocols::{BlockMmObjectInfo, compute_seq_hash_for_block};
-
-    fn direct_blocks(
-        tokens: &[u32],
-        block_size: u32,
-        mm_infos: Option<&[Option<BlockExtraInfo>]>,
-        lora_name: Option<&str>,
-        cache_namespace: Option<&str>,
-        is_eagle: bool,
-    ) -> Vec<ApproximateLruBlock> {
-        let local_hashes = compute_block_hash_for_seq(
-            tokens,
-            block_size,
-            BlockHashOptions {
-                block_mm_infos: mm_infos,
-                lora_name,
-                cache_namespace,
-                is_eagle: Some(is_eagle),
-            },
-        );
-        let sequence_hashes = compute_seq_hash_for_block(&local_hashes);
-        local_hashes
-            .into_iter()
-            .zip(sequence_hashes)
-            .map(|(local_hash, sequence_hash)| ApproximateLruBlock {
-                local_hash,
-                sequence_hash,
-            })
-            .collect()
-    }
-
-    #[test]
-    fn streamed_chunks_complete_prompt_tail_and_extend_canonical_chain() {
-        let prompt = vec![1, 2, 3];
-        let mut tracker = CanonicalOutputTracker::from_parts(&prompt, None, 4, false, None, None);
-        tracker.set_prompt_parent(None);
-
-        let first = tracker.observe(0, &[4, 5]).unwrap();
-        assert_eq!(first.start_position, 0);
-        assert_eq!(first.private_blocks, 0);
-        let second = tracker.observe(0, &[6, 7, 8, 9]).unwrap();
-        assert_eq!(second.start_position, 1);
-        assert_eq!(second.private_blocks, 0);
-
-        let expected = direct_blocks(&[1, 2, 3, 4, 5, 6, 7, 8], 4, None, None, None, false);
-        assert_eq!(
-            first
-                .blocks
-                .into_iter()
-                .chain(second.blocks)
-                .collect::<Vec<_>>(),
-            expected
-        );
-    }
-
-    #[test]
-    fn incomplete_output_tail_is_not_materialized() {
-        let mut tracker = CanonicalOutputTracker::from_parts(&[1], None, 4, false, None, None);
-        assert!(tracker.observe(0, &[2, 3]).is_none());
-        assert_eq!(tracker.initial_private_blocks(), 1);
-    }
-
-    #[test]
-    fn aligned_prompt_reports_partial_output_as_private_occupancy() {
-        let prompt = [1, 2, 3, 4];
-        let prompt_block = direct_blocks(&prompt, 4, None, None, None, false);
-        let mut tracker = CanonicalOutputTracker::from_parts(&prompt, None, 4, false, None, None);
-        tracker.set_prompt_parent(Some(prompt_block[0].sequence_hash));
-
-        assert!(tracker.observe(0, &[5]).is_none());
-        let partial = tracker.observe(0, &[6]).unwrap();
-        assert!(partial.blocks.is_empty());
-        assert_eq!(partial.private_blocks, 1);
-
-        let completed = tracker.observe(0, &[7, 8, 9]).unwrap();
-        assert_eq!(completed.blocks.len(), 1);
-        assert_eq!(completed.private_blocks, 0);
-    }
-
-    #[test]
-    fn multiple_choice_streams_keep_independent_hash_tails() {
-        let prompt = [1, 2, 3, 4];
-        let prompt_block = direct_blocks(&prompt, 4, None, None, None, false);
-        let mut tracker = CanonicalOutputTracker::from_parts(&prompt, None, 4, false, None, None);
-        tracker.set_prompt_parent(Some(prompt_block[0].sequence_hash));
-
-        let choice_zero = tracker.observe(0, &[5, 6, 7, 8, 13]).unwrap();
-        let choice_one = tracker.observe(1, &[9, 10, 11, 12, 14]).unwrap();
-        assert_eq!(choice_zero.start_position, 1);
-        assert_eq!(choice_one.start_position, 1);
-        assert_eq!(
-            choice_zero.blocks[0],
-            direct_blocks(&[1, 2, 3, 4, 5, 6, 7, 8], 4, None, None, None, false)[1]
-        );
-        assert_eq!(
-            choice_one.blocks[0],
-            direct_blocks(&[1, 2, 3, 4, 9, 10, 11, 12], 4, None, None, None, false)[1]
-        );
-    }
-
-    #[test]
-    fn eagle_lora_namespace_and_multimodal_hashing_matches_canonical_path() {
-        let prompt = vec![10, 11, 12];
-        let mm_infos = vec![Some(BlockExtraInfo {
-            mm_objects: vec![BlockMmObjectInfo {
-                mm_hash: 42,
-                offsets: vec![(0, 2)],
-            }],
-        })];
-        let mut tracker = CanonicalOutputTracker::from_parts(
-            &prompt,
-            Some(&mm_infos),
-            4,
-            true,
-            Some("adapter-a".to_string()),
-            Some("tenant-a".to_string()),
-        );
-
-        let first = tracker.observe(0, &[13, 14]).unwrap();
-        let second = tracker.observe(0, &[15, 16, 17, 18]).unwrap();
-        let expected = direct_blocks(
-            &[10, 11, 12, 13, 14, 15, 16, 17, 18],
-            4,
-            Some(&[mm_infos[0].clone(), None]),
-            Some("adapter-a"),
-            Some("tenant-a"),
-            true,
-        );
-        assert_eq!(
-            first
-                .blocks
-                .into_iter()
-                .chain(second.blocks)
-                .collect::<Vec<_>>(),
-            expected
-        );
-    }
-}
+#[path = "request_guard/tests.rs"]
+mod tests;

--- a/lib/llm/src/kv_router/routing_host/request_guard/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/request_guard/tests.rs
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use dynamo_kv_router::protocols::{BlockMmObjectInfo, compute_seq_hash_for_block};
+
+fn direct_blocks(
+    tokens: &[u32],
+    block_size: u32,
+    mm_infos: Option<&[Option<BlockExtraInfo>]>,
+    lora_name: Option<&str>,
+    cache_namespace: Option<&str>,
+    is_eagle: bool,
+) -> Vec<ApproximateLruBlock> {
+    let local_hashes = compute_block_hash_for_seq(
+        tokens,
+        block_size,
+        BlockHashOptions {
+            block_mm_infos: mm_infos,
+            lora_name,
+            cache_namespace,
+            is_eagle: Some(is_eagle),
+        },
+    );
+    let sequence_hashes = compute_seq_hash_for_block(&local_hashes);
+    local_hashes
+        .into_iter()
+        .zip(sequence_hashes)
+        .map(|(local_hash, sequence_hash)| ApproximateLruBlock {
+            local_hash,
+            sequence_hash,
+        })
+        .collect()
+}
+
+#[test]
+fn streamed_chunks_complete_prompt_tail_and_extend_canonical_chain() {
+    let prompt = vec![1, 2, 3];
+    let mut tracker = CanonicalOutputTracker::from_parts(&prompt, None, 4, false, None, None);
+    tracker.set_prompt_parent(None);
+
+    let first = tracker.observe(0, &[4, 5]).unwrap();
+    assert_eq!(first.start_position, 0);
+    assert_eq!(first.private_blocks, 0);
+    let second = tracker.observe(0, &[6, 7, 8, 9]).unwrap();
+    assert_eq!(second.start_position, 1);
+    assert_eq!(second.private_blocks, 0);
+
+    let expected = direct_blocks(&[1, 2, 3, 4, 5, 6, 7, 8], 4, None, None, None, false);
+    assert_eq!(
+        first
+            .blocks
+            .into_iter()
+            .chain(second.blocks)
+            .collect::<Vec<_>>(),
+        expected
+    );
+}
+
+#[test]
+fn incomplete_output_tail_is_not_materialized() {
+    let mut tracker = CanonicalOutputTracker::from_parts(&[1], None, 4, false, None, None);
+    assert!(tracker.observe(0, &[2, 3]).is_none());
+    assert_eq!(tracker.initial_private_blocks(), 1);
+}
+
+#[test]
+fn aligned_prompt_reports_partial_output_as_private_occupancy() {
+    let prompt = [1, 2, 3, 4];
+    let prompt_block = direct_blocks(&prompt, 4, None, None, None, false);
+    let mut tracker = CanonicalOutputTracker::from_parts(&prompt, None, 4, false, None, None);
+    tracker.set_prompt_parent(Some(prompt_block[0].sequence_hash));
+
+    assert!(tracker.observe(0, &[5]).is_none());
+    let partial = tracker.observe(0, &[6]).unwrap();
+    assert!(partial.blocks.is_empty());
+    assert_eq!(partial.private_blocks, 1);
+
+    let completed = tracker.observe(0, &[7, 8, 9]).unwrap();
+    assert_eq!(completed.blocks.len(), 1);
+    assert_eq!(completed.private_blocks, 0);
+}
+
+#[test]
+fn multiple_choice_streams_keep_independent_hash_tails() {
+    let prompt = [1, 2, 3, 4];
+    let prompt_block = direct_blocks(&prompt, 4, None, None, None, false);
+    let mut tracker = CanonicalOutputTracker::from_parts(&prompt, None, 4, false, None, None);
+    tracker.set_prompt_parent(Some(prompt_block[0].sequence_hash));
+
+    let choice_zero = tracker.observe(0, &[5, 6, 7, 8, 13]).unwrap();
+    let choice_one = tracker.observe(1, &[9, 10, 11, 12, 14]).unwrap();
+    assert_eq!(choice_zero.start_position, 1);
+    assert_eq!(choice_one.start_position, 1);
+    assert_eq!(
+        choice_zero.blocks[0],
+        direct_blocks(&[1, 2, 3, 4, 5, 6, 7, 8], 4, None, None, None, false)[1]
+    );
+    assert_eq!(
+        choice_one.blocks[0],
+        direct_blocks(&[1, 2, 3, 4, 9, 10, 11, 12], 4, None, None, None, false)[1]
+    );
+}
+
+#[test]
+fn eagle_lora_namespace_and_multimodal_hashing_matches_canonical_path() {
+    let prompt = vec![10, 11, 12];
+    let mm_infos = vec![Some(BlockExtraInfo {
+        mm_objects: vec![BlockMmObjectInfo {
+            mm_hash: 42,
+            offsets: vec![(0, 2)],
+        }],
+    })];
+    let mut tracker = CanonicalOutputTracker::from_parts(
+        &prompt,
+        Some(&mm_infos),
+        4,
+        true,
+        Some("adapter-a".to_string()),
+        Some("tenant-a".to_string()),
+    );
+
+    let first = tracker.observe(0, &[13, 14]).unwrap();
+    let second = tracker.observe(0, &[15, 16, 17, 18]).unwrap();
+    let expected = direct_blocks(
+        &[10, 11, 12, 13, 14, 15, 16, 17, 18],
+        4,
+        Some(&[mm_infos[0].clone(), None]),
+        Some("adapter-a"),
+        Some("tenant-a"),
+        true,
+    );
+    assert_eq!(
+        first
+            .blocks
+            .into_iter()
+            .chain(second.blocks)
+            .collect::<Vec<_>>(),
+        expected
+    );
+}

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -5,14 +5,16 @@ use std::{
     collections::{HashMap, HashSet},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::{Duration, Instant},
 };
 
 use dynamo_kv_router::{
-    DefaultWorkerSelector, WorkerSelectionPolicy, config::KvRouterConfig,
+    DefaultWorkerSelector, WorkerSelectionPolicy,
+    config::KvRouterConfig,
     protocols::RoutingConstraints,
+    scheduling::{ClassifyEvent, ClassifyFuture, ClassifyRequest, RequestClassifier},
 };
 use dynamo_runtime::{
     DistributedRuntime, Runtime,
@@ -26,7 +28,7 @@ use dynamo_runtime::{
     },
     storage::kv::Selector,
 };
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 
 use super::*;
 use crate::{
@@ -35,6 +37,7 @@ use crate::{
     lora::{LoraReplicaConfig, LoraRoutingTable, LoraStateTracker},
     migration::Migration,
     protocols::common::extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
+    protocols::common::preprocessor::MmRoutingInfo,
 };
 
 fn request() -> PreprocessedRequest {
@@ -533,6 +536,7 @@ async fn terminal_item_does_not_skip_transport_eof() {
         WorkerWithDpRank::from_worker_id(0),
         &request(),
         false,
+        None,
     );
     let monitored = monitor_response_stream(source, context, guard);
     tokio::pin!(monitored);
@@ -669,6 +673,228 @@ async fn router_with_worker_configs(
         .override_discovered_instances(worker_ids.clone());
     router.inner.client.override_instance_avail(worker_ids);
     (router, runtime)
+}
+
+async fn router_with_classifier(
+    classifier: impl RequestClassifier,
+    session_affinity_ttl: Option<Duration>,
+) -> (RoutingHost, Runtime) {
+    let runtime = Runtime::from_current().unwrap();
+    let distributed = DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+        .await
+        .unwrap();
+    let endpoint = distributed
+        .namespace("request-classifier-routing-host".to_string())
+        .unwrap()
+        .component("workers".to_string())
+        .unwrap()
+        .endpoint("generate");
+    let client = endpoint.client().await.unwrap();
+    let worker_id = 7;
+    let (_tx, workers) =
+        watch::channel(HashMap::from([(worker_id, ModelRuntimeConfig::default())]));
+    let config = KvRouterConfig {
+        skip_initial_worker_wait: true,
+        use_kv_events: false,
+        router_track_active_blocks: false,
+        ..Default::default()
+    };
+    let chooser = KvRouter::new_with_request_classifier(
+        endpoint,
+        client.clone(),
+        workers,
+        None,
+        16,
+        DefaultWorkerSelector::new(Some(config.clone()), "decode"),
+        Some(config),
+        None,
+        None,
+        "decode",
+        None,
+        false,
+        None,
+        None,
+        classifier,
+    )
+    .await
+    .unwrap();
+    let inner = PushRouter::from_client(client, RouterMode::KV)
+        .await
+        .unwrap();
+    let router = RoutingHost::new(inner, Arc::new(chooser), session_affinity_ttl).unwrap();
+    router
+        .inner
+        .client
+        .override_discovered_instances(vec![worker_id]);
+    router.inner.client.override_instance_avail(vec![worker_id]);
+    (router, runtime)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ClassifierObservation {
+    Completed(usize),
+    Aborted,
+}
+
+struct RecordingClassifier {
+    calls: Arc<AtomicUsize>,
+    observations: mpsc::UnboundedSender<ClassifierObservation>,
+}
+
+impl RequestClassifier for RecordingClassifier {
+    fn classify(&self, request: ClassifyRequest) -> ClassifyFuture {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Box::pin(async move { request })
+    }
+
+    fn on_event(&mut self, event: ClassifyEvent<'_>) {
+        let observation = match event {
+            ClassifyEvent::Completed {
+                context_tokens: Some(context_tokens),
+                ..
+            } => Some(ClassifierObservation::Completed(context_tokens)),
+            ClassifyEvent::Aborted { .. } => Some(ClassifierObservation::Aborted),
+            _ => None,
+        };
+        if let Some(observation) = observation {
+            self.observations.send(observation).unwrap();
+        }
+    }
+}
+
+#[tokio::test]
+async fn stale_affinity_rebind_classifies_once_without_intermediate_abort() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (observations_tx, mut observations_rx) = mpsc::unbounded_channel();
+    let (router, runtime) = router_with_classifier(
+        RecordingClassifier {
+            calls: Arc::clone(&calls),
+            observations: observations_tx,
+        },
+        Some(Duration::from_secs(10)),
+    )
+    .await;
+    let session_id = SessionAffinityId::new("classifier-stale-affinity");
+    bind_affinity_target(&router, &session_id, AffinityTarget::new(7, Some(1))).await;
+    let mut request = Context::new(request());
+    request.insert(SESSION_AFFINITY_CONTEXT_KEY, session_id);
+
+    let (mut selection, operation) = router
+        .select_with_affinity(&request, RequestPhase::Aggregated, false)
+        .await
+        .unwrap();
+
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+    assert!(observations_rx.try_recv().is_err());
+    selection.lifecycle.take().unwrap().complete(Some(1));
+    assert_eq!(
+        observations_rx.recv().await,
+        Some(ClassifierObservation::Completed(1))
+    );
+    router.kv_router().free(request.id()).await.unwrap();
+
+    drop(operation);
+    drop(router);
+    runtime.shutdown();
+}
+
+#[tokio::test]
+async fn query_only_selection_bypasses_classifier_and_request_lifecycle() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (observations_tx, mut observations_rx) = mpsc::unbounded_channel();
+    let (router, runtime) = router_with_classifier(
+        RecordingClassifier {
+            calls: Arc::clone(&calls),
+            observations: observations_tx,
+        },
+        None,
+    )
+    .await;
+    let request = Context::new(request());
+
+    let (selection, operation) = router
+        .select_with_affinity(&request, RequestPhase::Aggregated, true)
+        .await
+        .unwrap();
+
+    assert_eq!(calls.load(Ordering::Relaxed), 0);
+    assert!(selection.lifecycle.is_none());
+    assert!(operation.is_none());
+    drop(selection);
+    assert!(observations_rx.try_recv().is_err());
+
+    drop(router);
+    runtime.shutdown();
+}
+
+struct TokenContractClassifier {
+    classified: mpsc::UnboundedSender<usize>,
+    completed: mpsc::UnboundedSender<usize>,
+}
+
+impl RequestClassifier for TokenContractClassifier {
+    fn classify(&self, request: ClassifyRequest) -> ClassifyFuture {
+        self.classified.send(request.input_tokens()).unwrap();
+        Box::pin(async move { request })
+    }
+
+    fn on_event(&mut self, event: ClassifyEvent<'_>) {
+        if let ClassifyEvent::Completed {
+            context_tokens: Some(context_tokens),
+            ..
+        } = event
+        {
+            self.completed.send(context_tokens).unwrap();
+        }
+    }
+}
+
+#[tokio::test]
+async fn classifier_and_completion_use_authoritative_multimodal_token_counts() {
+    let (classified_tx, mut classified_rx) = mpsc::unbounded_channel();
+    let (completed_tx, mut completed_rx) = mpsc::unbounded_channel();
+    let (router, runtime) = router_with_classifier(
+        TokenContractClassifier {
+            classified: classified_tx,
+            completed: completed_tx,
+        },
+        None,
+    )
+    .await;
+    let mut content = request();
+    content.mm_routing_info = Some(MmRoutingInfo {
+        routing_token_ids: vec![1, 2, 3, 4, 5, 0, 0, 0],
+        block_mm_infos: vec![None],
+        expanded_prompt_len: 5,
+    });
+    let request = Context::new(content);
+    let (mut selection, _) = router
+        .select_with_affinity(&request, RequestPhase::Aggregated, false)
+        .await
+        .unwrap();
+    assert_eq!(classified_rx.recv().await, Some(5));
+
+    let mut guard = router
+        .track_selection(&request, &mut selection, false)
+        .await
+        .unwrap();
+    guard.mark_dispatched();
+    let output = LLMEngineOutput {
+        completion_usage: Some(dynamo_protocols::types::CompletionUsage {
+            prompt_tokens: 5,
+            completion_tokens: 6,
+            total_tokens: 11,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+        }),
+        ..Default::default()
+    };
+    guard.on_item(&Annotated::from_data(output)).await;
+    guard.finish().await;
+    assert_eq!(completed_rx.recv().await, Some(11));
+
+    drop(router);
+    runtime.shutdown();
 }
 
 async fn track_request(

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -300,6 +300,13 @@ where
         response
     }
 
+    pub(crate) fn begin_request_lifecycle(
+        &self,
+        request_id: &str,
+    ) -> Result<Option<RequestLifecycle>, KvSchedulerError> {
+        self.inner.begin_request_lifecycle(request_id)
+    }
+
     pub(crate) fn has_request_classifier(&self) -> bool {
         self.inner.has_request_classifier()
     }

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -60,7 +60,7 @@ impl HasTokenIds for LLMEngineOutput {
 }
 
 /// Check if an error chain indicates the request should be migrated.
-fn is_migratable(err: &(dyn StdError + 'static)) -> bool {
+pub(crate) fn is_migratable(err: &(dyn StdError + 'static)) -> bool {
     const MIGRATABLE: &[ErrorType] = &[
         ErrorType::CannotConnect,
         ErrorType::Disconnected,
@@ -369,6 +369,11 @@ where
                         continue;
                     }
                 }
+                if let Some(error) = response.error.as_ref()
+                    && let Some(state) = self.request.migration_state.as_ref()
+                {
+                    state.abort_request_lifecycle(Some(error));
+                }
                 self.track_response(&response);
                 return Some(response);
             }
@@ -437,6 +442,12 @@ where
                 Ok(())
             }
             Some(Err(err)) => {
+                let typed_error = err
+                    .chain()
+                    .find_map(|cause| cause.downcast_ref::<DynamoError>());
+                if let Some(state) = self.request.migration_state.as_ref() {
+                    state.abort_request_lifecycle(typed_error);
+                }
                 let outcome =
                     if error::match_error_chain(err.as_ref(), &[ErrorType::Cancelled], &[]) {
                         frontend_service::migration_outcome::CANCELLED
@@ -495,16 +506,16 @@ where
         if let Some(min_tokens) = self.request.stop_conditions.min_tokens {
             self.request.stop_conditions.min_tokens = Some(min_tokens.saturating_sub(output_len));
         }
-        for token_id in token_ids.iter() {
-            self.request.token_ids.push(*token_id);
-        }
+        self.request.append_migration_output_tokens(token_ids);
     }
 
     /// Returns `true` if the tracked request token length plus `new_output_len`
     /// exceeds the configured max_seq_len, in which case migration is disabled.
     fn exceed_max_seq_len(&mut self, new_output_len: u32) -> bool {
         if let Some(max_seq_len) = self.max_seq_len {
-            let total_len = self.request.token_ids.len() as u32 + new_output_len;
+            let total_len = u32::try_from(self.request.input_token_count())
+                .unwrap_or(u32::MAX)
+                .saturating_add(new_output_len);
             if total_len > max_seq_len {
                 tracing::warn!(
                     "Sequence length {} exceeds migration max_seq_len {}, \
@@ -528,7 +539,8 @@ mod tests {
     use crate::http::service::metrics::Metrics;
     use crate::protocols::common::{
         GuidedDecodingOptions, OutputOptions, SamplingOptions, StopConditions,
-        preprocessor::RoutingHints, timing::RequestTracker,
+        preprocessor::{MmRoutingInfo, RoutingHints},
+        timing::RequestTracker,
     };
     use dynamo_runtime::error::{DynamoError, ErrorType};
     use dynamo_runtime::pipeline::AsyncEngine;
@@ -2126,7 +2138,12 @@ mod tests {
             }
         }
 
-        let request = create_mock_request(3);
+        let mut request = create_mock_request(3);
+        request.mm_routing_info = Some(MmRoutingInfo {
+            routing_token_ids: vec![10, 11, 12, 13, 14, 15, 0, 0],
+            block_mm_infos: Vec::new(),
+            expanded_prompt_len: 6,
+        });
         let next_generate: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>> =
             Arc::new(LlmEngineMock(context_id.clone()));
 
@@ -2155,6 +2172,17 @@ mod tests {
             retry_manager.request.token_ids,
             vec![1, 2, 3, 200, 201, 202]
         );
+        let mm = retry_manager
+            .request
+            .mm_routing_info
+            .as_ref()
+            .expect("multimodal routing context should be retained");
+        assert_eq!(mm.expanded_prompt_len, 9);
+        assert_eq!(
+            mm.routing_token_ids,
+            vec![10, 11, 12, 13, 14, 15, 200, 201, 202]
+        );
+        assert_eq!(retry_manager.request.input_token_count(), 9);
     }
 
     /// 2-hop migration: A → fail → B → fail → C. Each retry's

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -9,6 +9,7 @@ use dynamo_kv_router::{
     config::RouterConfigOverride,
     protocols::{BlockExtraInfo, RoutingConstraints, WorkerId},
     router_hint::{ROUTER_HINT_EXTRA_ARGS_KEY, RouterHint},
+    scheduling::{ClassifyError, RequestLifecycle},
 };
 use dynamo_runtime::error::{DynamoError, ErrorType, match_error_chain};
 use serde::{Deserialize, Serialize};
@@ -121,8 +122,9 @@ pub struct TraceLink {
 }
 
 /// Frontend-local state shared by every attempt from one migration manager.
-/// The selected router records a failed worker before the error is exposed;
-/// later attempts use the accumulated set as an attempt-local exclusion.
+///
+/// It carries attempt-local worker exclusions and, when a classifier is configured,
+/// the logical request lifecycle between serialized attempts.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct MigrationState {
     inner: Arc<OnceLock<Mutex<MigrationStateInner>>>,
@@ -132,6 +134,7 @@ pub(crate) struct MigrationState {
 struct MigrationStateInner {
     excluded_worker_ids: Vec<WorkerId>,
     last_error: Option<DynamoError>,
+    request_lifecycle: Option<RequestLifecycle>,
 }
 
 impl MigrationState {
@@ -188,6 +191,35 @@ impl MigrationState {
                 .message(message)
                 .build(),
         )
+    }
+
+    pub(crate) fn take_request_lifecycle(&self) -> Option<RequestLifecycle> {
+        self.inner
+            .get()?
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .request_lifecycle
+            .take()
+    }
+
+    pub(crate) fn store_request_lifecycle(&self, lifecycle: RequestLifecycle) {
+        let replaced = self
+            .inner
+            .get_or_init(Default::default)
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .request_lifecycle
+            .replace(lifecycle);
+        if replaced.is_some() {
+            tracing::warn!("Replacing an unclaimed request-classifier migration lifecycle");
+        }
+    }
+
+    pub(crate) fn abort_request_lifecycle(&self, error: Option<&DynamoError>) {
+        let Some(mut lifecycle) = self.take_request_lifecycle() else {
+            return;
+        };
+        lifecycle.abort(error.map(|error| error as &ClassifyError));
     }
 }
 
@@ -491,6 +523,25 @@ impl PreprocessedRequest {
             .as_ref()
             .filter(|mm| !mm.routing_token_ids.is_empty() && mm.expanded_prompt_len > 0)
             .map_or(self.token_ids.len(), |mm| mm.expanded_prompt_len)
+    }
+
+    /// Append output replayed as prompt context by a migration retry.
+    pub(crate) fn append_migration_output_tokens(&mut self, output_tokens: &[TokenIdType]) {
+        self.token_ids.extend_from_slice(output_tokens);
+        let Some(mm) = self
+            .mm_routing_info
+            .as_mut()
+            .filter(|mm| !mm.routing_token_ids.is_empty() && mm.expanded_prompt_len > 0)
+        else {
+            return;
+        };
+
+        // MM routing sequences are block-padded. Remove that synthetic tail before
+        // extending the logical model context; an incomplete new tail is intentionally
+        // left unhashed until enough replayed tokens form a complete block.
+        mm.routing_token_ids.truncate(mm.expanded_prompt_len);
+        mm.routing_token_ids.extend_from_slice(output_tokens);
+        mm.expanded_prompt_len = mm.expanded_prompt_len.saturating_add(output_tokens.len());
     }
 }
 


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Connects the classifier lifecycle from #13800 to the production KV-router request and response paths. This lets pending classifiers learn when their logical requests are sent, begin responding, complete, or abort across retries without changing worker-selection policy.

Related DEP: #13891. Stack: #13800 → **#13801** → #13802.

### How This Was Implemented

- Register one lifecycle for each tracked logical request and carry its RAII handle from routing through dispatch and response handling.
- Emit `Sent` after dispatch, `Responding` on the first response, `Completed` with authoritative context tokens when available, and `Aborted` for cancellation, errors, or abandoned streams.
- Keep classification outside native session-affinity retries so a stale affinity target is retried without classifying twice or emitting an intermediate abort.
- Preserve the lifecycle across migration retries while releasing attempt-local scheduler state before the next attempt.
- Keep advisory query-only requests outside classifier and lifecycle accounting.
- Add a Criterion benchmark for disabled versus trivial pass-through classifier paths.

<details>
<summary>Walkthrough</summary>

#### Mental model

The scheduler owns classification and queueing, while the existing response guard owns the only state that can determine terminal request outcome. A small lifecycle handle connects those owners without giving the classifier dispatch authority.

```mermaid
sequenceDiagram
    participant R as RoutingHost
    participant C as Classifier runtime
    participant S as Existing scheduler and selector
    participant G as Response guard
    R->>C: register logical request
    R->>S: classify, schedule, select
    S-->>G: worker plus lifecycle handle
    G->>C: Sent, then Responding
    G->>C: Completed or Aborted
```

#### Request lifecycle

Lifecycle registration occurs only for tracked requests. Selection records the chosen worker, addressed dispatch emits `Sent`, the first backend item emits `Responding`, and normal stream completion emits `Completed`. Backend usage metadata supplies total context tokens when present; otherwise the guard falls back to authoritative input tokens plus locally observed output tokens.

Retryable migration failures move the lifecycle into migration state after cleaning up the failed attempt. The next attempt reuses that handle and re-enters ordinary scheduling without calling `classify()` again; final failure emits one `Aborted` notification with the last known worker and typed error when available.

#### Boundaries and limitations

`on_event()` is synchronous and notification-only. `Received` remains available in the event vocabulary but is not emitted because the current transport has no authoritative receipt signal; this PR adds no affinity, placement, durable plugin state, mailbox, reconciliation protocol, or compatibility path.

</details>

### Validation

- `cargo test -q -p dynamo-llm kv_router::routing_host::tests --lib` (24 passed)
- `cargo test -q -p dynamo-llm test_retry_manager_generic_over_llm_engine_output --lib` (1 passed)
- `cargo test -q -p dynamo-llm classifier_cache_inputs_retain_cache_providers --lib` (1 passed)
- `cargo clippy -p dynamo-kv-router --all-targets -- -D warnings`
- `cargo clippy -p dynamo-llm --lib -- -D warnings`
- `git diff --check`

### Benchmark Results

`cargo bench -p dynamo-kv-router --bench request_classifier` schedules 128 tracked requests per batch and compares the disabled path with a trivial pass-through classifier in the same run.

| Path | Disabled | Pass-through | Delta |
| --- | ---: | ---: | ---: |
| Classifier scheduling | 23.945 µs/request | 23.945 µs/request | approximately 0% |
| Full lifecycle | 24.414 µs/request | 25.030 µs/request | +0.616 µs/request (+2.52%) |
<!-- codex-pr-description:end -->

