### PR TITLE
fix(router): make prefill start phase-aware

### DIFF
--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -530,6 +530,7 @@ where
     workers_with_configs: RuntimeConfigWatch,
     block_size: u32,
     kv_router_config: KvRouterConfig,
+    worker_role: Option<WorkerType>,
     prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
     cancellation_token: CancellationToken,
     client: Client,
@@ -841,6 +842,7 @@ where
             workers_with_configs,
             block_size,
             kv_router_config,
+            worker_role,
             prefill_load_estimator,
             cancellation_token,
             client,
@@ -1738,6 +1740,11 @@ where
         self.scheduler.worker_type()
     }
 
+    /// Return the typed role of the worker set this router targets, when discovery supplied one.
+    pub(crate) fn worker_role(&self) -> Option<WorkerType> {
+        self.worker_role
+    }
+
     /// Return the worker's unique global DP rank when it owns exactly one rank.
     pub fn unique_dp_rank_for_worker(&self, worker_id: WorkerId) -> Option<u32> {
         let configs = self.workers_with_configs.borrow();
@@ -2435,6 +2442,7 @@ mod tests {
         let router = make_router_without_membership(Some(WorkerType::Decode))
             .await
             .expect("ordinary decode must not require KV source membership");
+        assert_eq!(router.worker_role(), Some(WorkerType::Decode));
         assert!(router.kv_event_subscription.is_none());
 
         let error = make_router_without_membership(None)

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -33,7 +33,10 @@ use crate::{
     kv_router::{RoutingHost, WorkerSelectorFactory},
     local_model::runtime_config::ModelRuntimeConfig,
     protocols::common::{
-        extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
+        extensions::{
+            LOCAL_PREFILL_EXECUTION_CONTEXT_KEY, LocalPrefillExecution,
+            SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId,
+        },
         llm_backend::{LLMEngineOutput, PreprocessedRequest},
         preprocessor::{BootstrapInfo, PrefillResult, TraceLink},
         timing::{RequestPhase, RequestTracker},
@@ -282,7 +285,7 @@ where
         next: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>>,
     ) -> Result<ManyOut<Annotated<LLMEngineOutput>>> {
         // Extract request data while preserving context
-        let (mut req, context) = request.into_parts();
+        let (mut req, mut context) = request.into_parts();
         let request_id = context.id().to_string();
         let metadata = context.metadata().clone();
         let policy_class = context.metadata().get("policy-class").cloned();
@@ -301,6 +304,7 @@ where
         // deactivated (all prefill workers died), route directly to the backend. Model admission
         // remains gated by the registered worker topology before the request reaches this stage.
         if self.lifecycle_state() != PrefillLifecycleState::Active {
+            context.insert(LOCAL_PREFILL_EXECUTION_CONTEXT_KEY, LocalPrefillExecution);
             return next.generate(context.map(|_| req)).await;
         }
 
@@ -700,7 +704,14 @@ fn merge_decode_topology_constraints(
 mod tests {
     use super::*;
     use dynamo_kv_router::config::RouterConfigOverride;
-    use std::collections::{HashMap, HashSet};
+    use dynamo_runtime::{
+        engine::AsyncEngine,
+        pipeline::{Error, ResponseStream},
+    };
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::atomic::{AtomicBool, Ordering},
+    };
 
     use crate::protocols::common::{
         FinishReason,
@@ -708,6 +719,32 @@ mod tests {
     };
 
     const MAX_ROOM: u64 = i64::MAX as u64;
+
+    #[derive(Default)]
+    struct LocalPrefillCapture {
+        saw_local_prefill: AtomicBool,
+    }
+
+    #[async_trait]
+    impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
+        for LocalPrefillCapture
+    {
+        async fn generate(
+            &self,
+            request: SingleIn<PreprocessedRequest>,
+        ) -> std::result::Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+            let saw_local_prefill = request
+                .get_optional::<LocalPrefillExecution>(LOCAL_PREFILL_EXECUTION_CONTEXT_KEY)
+                .expect("local-prefill context marker must have the expected type")
+                .is_some();
+            self.saw_local_prefill
+                .store(saw_local_prefill, Ordering::Relaxed);
+            Ok(ResponseStream::new(
+                Box::pin(futures::stream::empty()),
+                request.context(),
+            ))
+        }
+    }
 
     #[test]
     fn decode_router_override_disables_overlap_and_prefill_tracking() {
@@ -863,6 +900,30 @@ mod tests {
                 assert_eq!(constraints.preferred_taints["user.preferred"], 0.25);
             }
         }
+    }
+
+    #[tokio::test]
+    async fn unavailable_prefill_router_marks_downstream_local_prefill() {
+        let router = PrefillRouter::disabled(
+            Arc::new(crate::discovery::ModelManager::new()),
+            RouterMode::RoundRobin,
+            None,
+        );
+        let downstream = Arc::new(LocalPrefillCapture::default());
+        let next: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>> =
+            downstream.clone();
+        let tracker = Arc::new(RequestTracker::new());
+        let _phase_permit = tracker.set_phase(RequestPhase::Decode).await;
+        let mut request = request_with_constraints(None);
+        request.tracker = Some(Arc::clone(&tracker));
+
+        router
+            .generate(Context::new(request), next)
+            .await
+            .expect("inactive prefill router should dispatch to the downstream worker");
+
+        assert!(downstream.saw_local_prefill.load(Ordering::Relaxed));
+        assert_eq!(tracker.phase(), RequestPhase::Decode);
     }
 
     #[tokio::test]

--- a/lib/llm/src/kv_router/routing_host.rs
+++ b/lib/llm/src/kv_router/routing_host.rs
@@ -26,14 +26,15 @@ use tracing::Instrument;
 
 use crate::{
     kv_router::{
-        KvRouter, metrics::RouterRequestMetrics, scheduler::DefaultWorkerSelector,
-        to_worker_selection_session_context,
+        KvRouter, metrics::RouterRequestMetrics, prefill_router::BYPASS_REMOTE_PREFILL_ANNOTATION,
+        scheduler::DefaultWorkerSelector, to_worker_selection_session_context,
     },
     local_model::runtime_config::ModelRuntimeConfig,
     lora::{LoadEstimator, LoraFilter},
     preprocessor::PreprocessedRequest,
     protocols::common::{
         FinishReason,
+        extensions::{LOCAL_PREFILL_EXECUTION_CONTEXT_KEY, LocalPrefillExecution},
         llm_backend::LLMEngineOutput,
         timing::{RequestPhase, RoutingData, WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL},
     },
@@ -41,6 +42,7 @@ use crate::{
         AffinityAcquire, AffinityCoordinator, AffinityTarget, affinity_id, explicit_target,
         invalid_argument,
     },
+    worker_type::WorkerType,
 };
 
 mod builtin;
@@ -58,6 +60,48 @@ use request_guard::{LoraLoadGuard, RequestGuard};
 
 const OUTPUT_REPLAY_ID_ANNOTATION_KEY: &str = "output_replay_id";
 const OUTPUT_REPLAY_CONSUMER_RUNTIME_KEY: &str = "output_replay_consumer";
+
+fn dispatch_includes_prefill(
+    request: &SingleIn<PreprocessedRequest>,
+    phase: RequestPhase,
+    worker_role: Option<WorkerType>,
+) -> bool {
+    let includes_prefill = match phase {
+        RequestPhase::Prefill => true,
+        RequestPhase::Decode => false,
+        // Standalone routers recreate the skipped tracker with its default phase. The target
+        // worker role recovers the split topology without putting the tracker on the wire.
+        RequestPhase::Aggregated => match worker_role {
+            Some(WorkerType::Decode) => false,
+            Some(WorkerType::Prefill | WorkerType::Aggregated | WorkerType::Encode) => true,
+            None => request.prefill_result.is_none(),
+        },
+    };
+    if includes_prefill {
+        return true;
+    }
+
+    // These markers identify decode-shaped dispatches that execute prefill locally.
+    if request
+        .annotations
+        .iter()
+        .any(|annotation| annotation == BYPASS_REMOTE_PREFILL_ANNOTATION)
+    {
+        return true;
+    }
+
+    match request.get_optional::<LocalPrefillExecution>(LOCAL_PREFILL_EXECUTION_CONTEXT_KEY) {
+        Ok(marker) => marker.is_some(),
+        Err(error) => {
+            tracing::warn!(
+                request_id = request.context().id(),
+                %error,
+                "Ignoring invalid local-prefill context marker"
+            );
+            false
+        }
+    }
+}
 
 fn is_cancelled(error: &Error) -> bool {
     match_error_chain(error.as_ref(), &[ErrorType::Cancelled], &[])
@@ -393,6 +437,16 @@ where
             | RoutingPolicy::Direct
             | RoutingPolicy::DeviceAwareWeighted => None,
         }
+    }
+
+    fn dispatch_worker_role(&self) -> Option<WorkerType> {
+        self.kv_router_if_enabled()
+            .and_then(|router| router.worker_role())
+            .or_else(|| {
+                self.routing_context
+                    .as_ref()
+                    .map(|context| context.source().worker_type())
+            })
     }
 
     pub(crate) fn peek_next_worker(&self) -> Option<u64> {

--- a/lib/llm/src/kv_router/routing_host/builtin.rs
+++ b/lib/llm/src/kv_router/routing_host/builtin.rs
@@ -333,7 +333,7 @@ where
         drop(route_guard);
 
         guard.start_dispatch(&phase_label);
-        guard.record_prefill_start();
+        guard.record_prefill_start(phase);
         let dispatch_result = if is_direct && !has_affinity_session {
             let target = target_constraint.expect("Direct routing requires an explicit target");
             cancel_on_stop(

--- a/lib/llm/src/kv_router/routing_host/builtin.rs
+++ b/lib/llm/src/kv_router/routing_host/builtin.rs
@@ -333,7 +333,11 @@ where
         drop(route_guard);
 
         guard.start_dispatch(&phase_label);
-        guard.record_prefill_start(&request, phase);
+        guard.record_prefill_start(dispatch_includes_prefill(
+            &request,
+            phase,
+            self.dispatch_worker_role(),
+        ));
         let dispatch_result = if is_direct && !has_affinity_session {
             let target = target_constraint.expect("Direct routing requires an explicit target");
             cancel_on_stop(

--- a/lib/llm/src/kv_router/routing_host/builtin.rs
+++ b/lib/llm/src/kv_router/routing_host/builtin.rs
@@ -333,7 +333,7 @@ where
         drop(route_guard);
 
         guard.start_dispatch(&phase_label);
-        guard.record_prefill_start(phase);
+        guard.record_prefill_start(&request, phase);
         let dispatch_result = if is_direct && !has_affinity_session {
             let target = target_constraint.expect("Direct routing requires an explicit target");
             cancel_on_stop(

--- a/lib/llm/src/kv_router/routing_host/kv.rs
+++ b/lib/llm/src/kv_router/routing_host/kv.rs
@@ -191,8 +191,8 @@ where
                 "Failed to attach router_hint to backend request"
             );
         }
+        guard.record_prefill_start(&backend_input, phase);
         let updated_request = context.map(|_| backend_input);
-        guard.record_prefill_start(phase);
 
         let dispatch = self
             .inner

--- a/lib/llm/src/kv_router/routing_host/kv.rs
+++ b/lib/llm/src/kv_router/routing_host/kv.rs
@@ -192,7 +192,7 @@ where
             );
         }
         let updated_request = context.map(|_| backend_input);
-        guard.record_prefill_start();
+        guard.record_prefill_start(phase);
 
         let dispatch = self
             .inner

--- a/lib/llm/src/kv_router/routing_host/kv.rs
+++ b/lib/llm/src/kv_router/routing_host/kv.rs
@@ -171,6 +171,8 @@ where
         let phase_label = phase.to_string();
         guard.start_dispatch(&phase_label);
         self.warn_if_output_replay_annotation_ignored(&request, &selection);
+        let includes_prefill =
+            dispatch_includes_prefill(&request, phase, self.dispatch_worker_role());
 
         let (mut backend_input, context) = request.into_parts();
         backend_input.routing_mut().dp_rank = Some(selection.worker.dp_rank);
@@ -191,7 +193,7 @@ where
                 "Failed to attach router_hint to backend request"
             );
         }
-        guard.record_prefill_start(&backend_input, phase);
+        guard.record_prefill_start(includes_prefill);
         let updated_request = context.map(|_| backend_input);
 
         let dispatch = self

--- a/lib/llm/src/kv_router/routing_host/request_guard.rs
+++ b/lib/llm/src/kv_router/routing_host/request_guard.rs
@@ -4,10 +4,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
-    kv_router::{
-        KvRouter, metrics::RouterRequestMetrics, prefill_router::BYPASS_REMOTE_PREFILL_ANNOTATION,
-        scheduler::DefaultWorkerSelector,
-    },
+    kv_router::{KvRouter, metrics::RouterRequestMetrics, scheduler::DefaultWorkerSelector},
     local_model::runtime_config::ModelRuntimeConfig,
     lora::LoadEstimator,
     preprocessor::PreprocessedRequest,
@@ -689,13 +686,8 @@ where
         self.observability.start_dispatch(phase_label);
     }
 
-    pub(super) fn record_prefill_start(&self, request: &PreprocessedRequest, phase: RequestPhase) {
-        if phase != RequestPhase::Decode
-            || request
-                .annotations
-                .iter()
-                .any(|annotation| annotation == BYPASS_REMOTE_PREFILL_ANNOTATION)
-        {
+    pub(super) fn record_prefill_start(&self, dispatch_includes_prefill: bool) {
+        if dispatch_includes_prefill {
             self.observability.record_prefill_start();
         }
     }

--- a/lib/llm/src/kv_router/routing_host/request_guard.rs
+++ b/lib/llm/src/kv_router/routing_host/request_guard.rs
@@ -4,7 +4,10 @@
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
-    kv_router::{KvRouter, metrics::RouterRequestMetrics, scheduler::DefaultWorkerSelector},
+    kv_router::{
+        KvRouter, metrics::RouterRequestMetrics, prefill_router::BYPASS_REMOTE_PREFILL_ANNOTATION,
+        scheduler::DefaultWorkerSelector,
+    },
     local_model::runtime_config::ModelRuntimeConfig,
     lora::LoadEstimator,
     preprocessor::PreprocessedRequest,
@@ -275,14 +278,9 @@ impl RequestObservability {
         self.dispatch_guard = Some(StageGuard::new(STAGE_DISPATCH, phase_label));
     }
 
-    fn record_prefill_start(&self, phase: RequestPhase) {
-        match phase {
-            RequestPhase::Prefill | RequestPhase::Aggregated => {
-                if let Some(tracker) = &self.tracker {
-                    tracker.record_prefill_start();
-                }
-            }
-            RequestPhase::Decode => {}
+    fn record_prefill_start(&self) {
+        if let Some(tracker) = &self.tracker {
+            tracker.record_prefill_start();
         }
     }
 
@@ -691,8 +689,15 @@ where
         self.observability.start_dispatch(phase_label);
     }
 
-    pub(super) fn record_prefill_start(&self, phase: RequestPhase) {
-        self.observability.record_prefill_start(phase);
+    pub(super) fn record_prefill_start(&self, request: &PreprocessedRequest, phase: RequestPhase) {
+        if phase != RequestPhase::Decode
+            || request
+                .annotations
+                .iter()
+                .any(|annotation| annotation == BYPASS_REMOTE_PREFILL_ANNOTATION)
+        {
+            self.observability.record_prefill_start();
+        }
     }
 
     pub(super) fn mark_dispatched(&mut self) {

--- a/lib/llm/src/kv_router/routing_host/request_guard.rs
+++ b/lib/llm/src/kv_router/routing_host/request_guard.rs
@@ -275,9 +275,14 @@ impl RequestObservability {
         self.dispatch_guard = Some(StageGuard::new(STAGE_DISPATCH, phase_label));
     }
 
-    fn record_prefill_start(&self) {
-        if let Some(tracker) = &self.tracker {
-            tracker.record_prefill_start();
+    fn record_prefill_start(&self, phase: RequestPhase) {
+        match phase {
+            RequestPhase::Prefill | RequestPhase::Aggregated => {
+                if let Some(tracker) = &self.tracker {
+                    tracker.record_prefill_start();
+                }
+            }
+            RequestPhase::Decode => {}
         }
     }
 
@@ -686,8 +691,8 @@ where
         self.observability.start_dispatch(phase_label);
     }
 
-    pub(super) fn record_prefill_start(&self) {
-        self.observability.record_prefill_start();
+    pub(super) fn record_prefill_start(&self, phase: RequestPhase) {
+        self.observability.record_prefill_start(phase);
     }
 
     pub(super) fn mark_dispatched(&mut self) {

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -36,7 +36,10 @@ use crate::{
     local_model::runtime_config::ModelRuntimeConfig,
     lora::{LoraReplicaConfig, LoraRoutingTable, LoraStateTracker},
     migration::Migration,
-    protocols::common::extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
+    protocols::common::{
+        extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
+        timing::RequestTracker,
+    },
 };
 
 fn request() -> PreprocessedRequest {
@@ -724,6 +727,66 @@ async fn track_request(
 async fn session_affinity_disabled_does_not_create_coordinator() {
     let (router, runtime) = router(None).await;
     assert!(router.affinity.is_none());
+
+    drop(router);
+    runtime.shutdown();
+}
+
+#[tokio::test]
+async fn prefill_start_recording_is_phase_aware() {
+    let (router, runtime) = router(None).await;
+
+    // KV and hosted-policy dispatch share this RequestGuard transition.
+    for (phase, expected) in [
+        (RequestPhase::Prefill, true),
+        (RequestPhase::Aggregated, true),
+        (RequestPhase::Decode, false),
+    ] {
+        let tracker = Arc::new(RequestTracker::new());
+        let _phase_permit = tracker.set_phase(phase).await;
+        let mut tracked_request = request();
+        tracked_request.tracker = Some(Arc::clone(&tracker));
+        let mut guard = RequestGuard::new_kv(
+            Arc::clone(router.kv_router()),
+            Arc::clone(&router.request_metrics),
+            format!("prefill-start-{phase}"),
+            WorkerWithDpRank::new(7, 0),
+            &tracked_request,
+            false,
+        );
+
+        guard.record_prefill_start(tracker.phase());
+        assert_eq!(
+            tracker.prefill_wait_time_ms().is_some(),
+            expected,
+            "unexpected prefill-start state for {phase}"
+        );
+        guard.abort().await;
+    }
+
+    let tracker = Arc::new(RequestTracker::new());
+    let mut tracked_request = request();
+    tracked_request.tracker = Some(Arc::clone(&tracker));
+    let mut guard = RequestGuard::new_kv(
+        Arc::clone(router.kv_router()),
+        Arc::clone(&router.request_metrics),
+        "prefill-start-prefill-decode".to_string(),
+        WorkerWithDpRank::new(7, 0),
+        &tracked_request,
+        false,
+    );
+
+    let prefill_permit = tracker.set_phase(RequestPhase::Prefill).await;
+    guard.record_prefill_start(tracker.phase());
+    let prefill_start = tracker
+        .prefill_wait_time_ms()
+        .expect("prefill phase should record prefill start");
+    drop(prefill_permit);
+
+    let _decode_permit = tracker.set_phase(RequestPhase::Decode).await;
+    guard.record_prefill_start(tracker.phase());
+    assert_eq!(tracker.prefill_wait_time_ms(), Some(prefill_start));
+    guard.abort().await;
 
     drop(router);
     runtime.shutdown();

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -37,9 +37,14 @@ use crate::{
     lora::{LoraReplicaConfig, LoraRoutingTable, LoraStateTracker},
     migration::Migration,
     protocols::common::{
-        extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
+        extensions::{
+            LOCAL_PREFILL_EXECUTION_CONTEXT_KEY, LocalPrefillExecution,
+            SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId,
+        },
+        preprocessor::PrefillResult,
         timing::RequestTracker,
     },
+    worker_type::WorkerType,
 };
 
 fn request() -> PreprocessedRequest {
@@ -732,47 +737,88 @@ async fn session_affinity_disabled_does_not_create_coordinator() {
     runtime.shutdown();
 }
 
-#[tokio::test]
-async fn prefill_start_recording_is_phase_aware() {
-    let (router, runtime) = router(None).await;
+#[test]
+fn dispatch_prefill_classification_uses_phase_and_topology() {
+    let normal_request = Context::new(request());
 
-    // KV and hosted-policy dispatch share this RequestGuard transition.
-    for (phase, is_remote_prefill_bypassed, expected) in [
-        (RequestPhase::Prefill, false, true),
-        (RequestPhase::Aggregated, false, true),
-        (RequestPhase::Decode, false, false),
-        (RequestPhase::Decode, true, true),
+    for (phase, worker_role, expected) in [
+        (RequestPhase::Prefill, Some(WorkerType::Decode), true),
+        (RequestPhase::Decode, Some(WorkerType::Decode), false),
+        (RequestPhase::Aggregated, Some(WorkerType::Aggregated), true),
+        (RequestPhase::Aggregated, Some(WorkerType::Prefill), true),
+        (RequestPhase::Aggregated, None, true),
     ] {
-        let tracker = Arc::new(RequestTracker::new());
-        let _phase_permit = tracker.set_phase(phase).await;
-        let mut tracked_request = request();
-        tracked_request.tracker = Some(Arc::clone(&tracker));
-        if is_remote_prefill_bypassed {
-            tracked_request
-                .annotations
-                .push(BYPASS_REMOTE_PREFILL_ANNOTATION.to_string());
-        }
-        let mut guard = RequestGuard::new_kv(
-            Arc::clone(router.kv_router()),
-            Arc::clone(&router.request_metrics),
-            format!("prefill-start-{phase}"),
-            WorkerWithDpRank::new(7, 0),
-            &tracked_request,
-            false,
-        );
-
-        guard.record_prefill_start(&tracked_request, tracker.phase());
         assert_eq!(
-            tracker.prefill_wait_time_ms().is_some(),
+            dispatch_includes_prefill(&normal_request, phase, worker_role),
             expected,
-            "unexpected prefill-start state for {phase}, bypass={is_remote_prefill_bypassed}"
+            "unexpected classification for {phase}, role={worker_role:?}"
         );
-        guard.abort().await;
     }
+
+    let mut legacy_handoff = Context::new(request());
+    legacy_handoff.prefill_result = Some(PrefillResult {
+        disaggregated_params: serde_json::json!({}),
+        prompt_tokens_details: None,
+    });
+    assert!(!dispatch_includes_prefill(
+        &legacy_handoff,
+        RequestPhase::Aggregated,
+        None,
+    ));
+}
+
+#[tokio::test]
+async fn split_decode_router_recovers_phase_from_worker_role() {
+    let tracker = Arc::new(RequestTracker::new());
+    let _phase_permit = tracker.set_phase(RequestPhase::Decode).await;
+    let mut frontend_request = request();
+    frontend_request.tracker = Some(tracker);
+    let wire_request = serde_json::to_value(frontend_request).unwrap();
+    let router_request: PreprocessedRequest = serde_json::from_value(wire_request).unwrap();
+
+    assert!(router_request.tracker.is_none());
+    let router_request = Context::new(router_request);
+    let phase = router_request
+        .tracker
+        .as_ref()
+        .map(|tracker| tracker.phase())
+        .unwrap_or(RequestPhase::Aggregated);
+    assert!(!dispatch_includes_prefill(
+        &router_request,
+        phase,
+        Some(WorkerType::Decode),
+    ));
+}
+
+#[test]
+fn explicit_local_prefill_signals_override_decode_phase() {
+    let mut bypass = Context::new(request());
+    bypass
+        .annotations
+        .push(BYPASS_REMOTE_PREFILL_ANNOTATION.to_string());
+    assert!(dispatch_includes_prefill(
+        &bypass,
+        RequestPhase::Decode,
+        Some(WorkerType::Decode),
+    ));
+
+    let mut fallback = Context::new(request());
+    fallback.insert(LOCAL_PREFILL_EXECUTION_CONTEXT_KEY, LocalPrefillExecution);
+    assert!(dispatch_includes_prefill(
+        &fallback,
+        RequestPhase::Decode,
+        Some(WorkerType::Decode),
+    ));
+}
+
+#[tokio::test]
+async fn prefill_start_recording_is_phase_aware_and_first_write_wins() {
+    let (router, runtime) = router(None).await;
 
     let tracker = Arc::new(RequestTracker::new());
     let mut tracked_request = request();
     tracked_request.tracker = Some(Arc::clone(&tracker));
+    let tracked_request = Context::new(tracked_request);
     let mut guard = RequestGuard::new_kv(
         Arc::clone(router.kv_router()),
         Arc::clone(&router.request_metrics),
@@ -783,14 +829,22 @@ async fn prefill_start_recording_is_phase_aware() {
     );
 
     let prefill_permit = tracker.set_phase(RequestPhase::Prefill).await;
-    guard.record_prefill_start(&tracked_request, tracker.phase());
+    guard.record_prefill_start(dispatch_includes_prefill(
+        &tracked_request,
+        tracker.phase(),
+        None,
+    ));
     let prefill_start = tracker
         .prefill_wait_time_ms()
         .expect("prefill phase should record prefill start");
     drop(prefill_permit);
 
     let _decode_permit = tracker.set_phase(RequestPhase::Decode).await;
-    guard.record_prefill_start(&tracked_request, tracker.phase());
+    guard.record_prefill_start(dispatch_includes_prefill(
+        &tracked_request,
+        tracker.phase(),
+        None,
+    ));
     assert_eq!(tracker.prefill_wait_time_ms(), Some(prefill_start));
     guard.abort().await;
 

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -32,7 +32,7 @@ use tokio::sync::watch;
 use super::*;
 use crate::{
     http::service::metrics::Metrics,
-    kv_router::RoutingLoadContext,
+    kv_router::{RoutingLoadContext, prefill_router::BYPASS_REMOTE_PREFILL_ANNOTATION},
     local_model::runtime_config::ModelRuntimeConfig,
     lora::{LoraReplicaConfig, LoraRoutingTable, LoraStateTracker},
     migration::Migration,
@@ -737,15 +737,21 @@ async fn prefill_start_recording_is_phase_aware() {
     let (router, runtime) = router(None).await;
 
     // KV and hosted-policy dispatch share this RequestGuard transition.
-    for (phase, expected) in [
-        (RequestPhase::Prefill, true),
-        (RequestPhase::Aggregated, true),
-        (RequestPhase::Decode, false),
+    for (phase, is_remote_prefill_bypassed, expected) in [
+        (RequestPhase::Prefill, false, true),
+        (RequestPhase::Aggregated, false, true),
+        (RequestPhase::Decode, false, false),
+        (RequestPhase::Decode, true, true),
     ] {
         let tracker = Arc::new(RequestTracker::new());
         let _phase_permit = tracker.set_phase(phase).await;
         let mut tracked_request = request();
         tracked_request.tracker = Some(Arc::clone(&tracker));
+        if is_remote_prefill_bypassed {
+            tracked_request
+                .annotations
+                .push(BYPASS_REMOTE_PREFILL_ANNOTATION.to_string());
+        }
         let mut guard = RequestGuard::new_kv(
             Arc::clone(router.kv_router()),
             Arc::clone(&router.request_metrics),
@@ -755,11 +761,11 @@ async fn prefill_start_recording_is_phase_aware() {
             false,
         );
 
-        guard.record_prefill_start(tracker.phase());
+        guard.record_prefill_start(&tracked_request, tracker.phase());
         assert_eq!(
             tracker.prefill_wait_time_ms().is_some(),
             expected,
-            "unexpected prefill-start state for {phase}"
+            "unexpected prefill-start state for {phase}, bypass={is_remote_prefill_bypassed}"
         );
         guard.abort().await;
     }
@@ -777,14 +783,14 @@ async fn prefill_start_recording_is_phase_aware() {
     );
 
     let prefill_permit = tracker.set_phase(RequestPhase::Prefill).await;
-    guard.record_prefill_start(tracker.phase());
+    guard.record_prefill_start(&tracked_request, tracker.phase());
     let prefill_start = tracker
         .prefill_wait_time_ms()
         .expect("prefill phase should record prefill start");
     drop(prefill_permit);
 
     let _decode_permit = tracker.set_phase(RequestPhase::Decode).await;
-    guard.record_prefill_start(tracker.phase());
+    guard.record_prefill_start(&tracked_request, tracker.phase());
     assert_eq!(tracker.prefill_wait_time_ms(), Some(prefill_start));
     guard.abort().await;
 

--- a/lib/llm/src/kv_router/routing_load.rs
+++ b/lib/llm/src/kv_router/routing_load.rs
@@ -47,6 +47,15 @@ impl RouterLoadSource {
         }
     }
 
+    pub(crate) const fn worker_type(self) -> WorkerType {
+        match self {
+            Self::Decode => WorkerType::Decode,
+            Self::Aggregated => WorkerType::Aggregated,
+            Self::Prefill => WorkerType::Prefill,
+            Self::Encode => WorkerType::Encode,
+        }
+    }
+
     pub(crate) fn from_worker_role_or_metric(
         worker_role: Option<WorkerType>,
         metric_worker_type: &'static str,

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -393,6 +393,15 @@ pub const AGENT_CONTEXT_CONTEXT_KEY: &str = "dynamo.llm.agent_context";
 
 pub const SESSION_AFFINITY_CONTEXT_KEY: &str = "dynamo.llm.session_affinity";
 
+/// In-process marker for a request that bypassed an unavailable prefill router and will run
+/// prefill locally on the downstream worker. This lives in the pipeline context registry rather
+/// than [`PreprocessedRequest`](super::preprocessor::PreprocessedRequest), so it is never
+/// serialized across process boundaries.
+pub(crate) const LOCAL_PREFILL_EXECUTION_CONTEXT_KEY: &str = "dynamo.llm.local_prefill_execution";
+
+#[derive(Debug)]
+pub(crate) struct LocalPrefillExecution;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionAffinityId(String);
 


### PR DESCRIPTION
## Summary

- Make prefill-start timing depend on whether the selected dispatch actually executes prefill.
- Skip normal decode-only dispatches, including a standalone split decode router whose deserialized `RequestTracker` is recreated with the default `Aggregated` phase.
- Preserve prefill timing for conditional-disaggregation bypass and for unavailable-prefill fallback, where a decode worker performs prefill locally.
- Use one classifier in both KV and hosted-policy dispatch paths.
- Keep worker selection, admission, phase accounting, backend behavior, and the serialized request contract unchanged.

Supersedes #13738, which closed when its stacked base branch from #13491 was merged and deleted.

Fixes #13731.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-llm kv_router::routing_host::tests --lib` — 25 passed
- `cargo test -p dynamo-llm kv_router::prefill_router::tests --lib` — 13 passed
- `cargo test -p dynamo-llm constructor_skips_sources_for_decode_but_preserves_unknown_behavior --lib` — 1 passed

No performance or benchmark tests were run.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->