### PR TITLE
fix(epp): configure replica sync port

### DIFF
--- a/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: dynamo-epp
 ---
-# Standalone discovery reads only namespaced worker, pool, and EndpointSlice state.
+# Standalone discovery reads only namespaced worker, pool, Service, and EndpointSlice state.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -173,6 +173,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
   - apiGroups:
       - inference.networking.k8s.io
     resources:
@@ -260,8 +266,8 @@ spec:
               value: "8192"
             # Replication: watch THIS Deployment's own Service
             # (EndpointSlices) to find sibling EPP replicas and sync active load
-            # over its required named replica-agg port. Omit this env to run a
-            # single fully-local replica (and set replicas: 1).
+            # over the shared replica-sync port (9092 by default). Omit this env
+            # to run a single fully-local replica (and set replicas: 1).
             - name: DYN_EPP_PEER_SERVICE
               value: dynamo-epp
             # The reflector watches pods in the EPP's own namespace.
@@ -279,9 +285,6 @@ spec:
               containerPort: 9002
             - name: grpc-health
               containerPort: 9003
-            # ZMQ replica-sync between EPP replicas (embedded replication).
-            - name: replica-agg
-              containerPort: 9092
           readinessProbe:
             grpc:
               port: 9003
@@ -295,7 +298,7 @@ spec:
               drop:
                 - ALL
 ---
-# GAIE calls the gRPC port. EPP replicas use `replica-agg` for load-state sync.
+# GAIE calls the gRPC port. EPP replicas discover each other through this Service.
 apiVersion: v1
 kind: Service
 metadata:
@@ -308,9 +311,6 @@ spec:
       appProtocol: http2
       port: 9002
       targetPort: grpc
-    - name: replica-agg
-      port: 9092
-      targetPort: replica-agg
 ---
 # InferencePool selects the raw vLLM pods and delegates endpoint selection to
 # the EPP. The EPP reads this object (read-only) to learn the pod selector and

--- a/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
@@ -208,6 +208,20 @@ subjects:
   - kind: ServiceAccount
     name: dynamo-epp
 ---
+# GAIE calls the gRPC port. EPP replicas discover each other through this Service.
+apiVersion: v1
+kind: Service
+metadata:
+  name: dynamo-epp
+spec:
+  selector:
+    app: dynamo-epp
+  ports:
+    - name: grpc
+      appProtocol: http2
+      port: 9002
+      targetPort: grpc
+---
 # The Dynamo EPP in standalone mode with the selector EMBEDDED in-process,
 # replicated: DYN_EPP_PEER_SERVICE turns on cross-replica active-load sync so
 # these replicas do not each under-count load and herd onto the same worker.
@@ -297,20 +311,6 @@ spec:
             capabilities:
               drop:
                 - ALL
----
-# GAIE calls the gRPC port. EPP replicas discover each other through this Service.
-apiVersion: v1
-kind: Service
-metadata:
-  name: dynamo-epp
-spec:
-  selector:
-    app: dynamo-epp
-  ports:
-    - name: grpc
-      appProtocol: http2
-      port: 9002
-      targetPort: grpc
 ---
 # InferencePool selects the raw vLLM pods and delegates endpoint selection to
 # the EPP. The EPP reads this object (read-only) to learn the pod selector and

--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -47,15 +47,6 @@ pub struct EppRouter {
     // Kept alive for the lifetime of the router; the reconcile loop runs on it.
     _adapter: TopologyAdapter,
     reflector_ready: Arc<AtomicBool>,
-    /// Peer-discovery readiness (replicated mode only): `None` when replication
-    /// is off, else a flag that latches `true` after the initial peer-set sync
-    /// (EndpointSlice LIST + reconcile). ANDed with `reflector_ready` to form the
-    /// health signal, so a replica does not serve before its peers are discovered
-    /// and its replica-sync sockets are connected. Note: this proves only that
-    /// future load deltas will flow — it does NOT bootstrap the load already in
-    /// flight on peers; that converges from live deltas as pre-existing requests
-    /// drain (same warm-up shape as the KV index).
-    peer_ready: Option<Arc<AtomicBool>>,
     model_name: String,
     /// Bounds total concurrent in-flight `pick()`s. HTTP/2 stream multiplexing
     /// means the TCP-connection cap (`MAX_CONCURRENT_CONNECTIONS`) does NOT bound
@@ -80,7 +71,6 @@ impl EppRouter {
         )?;
         let (reflector, reflector_ready) = PodDiscovery::spawn(&cfg).await?;
         let reflector = Arc::new(reflector);
-        let peer_ready = selector.peer_ready();
         let defaults = RegistrationDefaults::from_config(&cfg);
         let adapter =
             TopologyAdapter::spawn(reflector.as_ref().clone(), selector.clone(), defaults);
@@ -94,20 +84,15 @@ impl EppRouter {
             selector,
             _adapter: adapter,
             reflector_ready,
-            peer_ready,
             model_name: cfg.model_name,
             inflight: Arc::new(Semaphore::new(cfg.max_inflight_requests)),
         })
     }
 
-    /// Overall EPP readiness for the gRPC health signal: the pod reflector is
-    /// ready (workers synced + pool resolved) AND, in replicated mode, the peer
-    /// set has finished its initial sync. Polled by the health mirror in `main`.
+    /// Overall EPP readiness for the gRPC health signal: the pod reflector has
+    /// synced workers and resolved its InferencePool. Polled by the health mirror in `main`.
     pub fn is_ready(&self) -> bool {
-        compute_ready(
-            self.reflector_ready.load(Ordering::Acquire),
-            self.peer_ready.as_ref().map(|p| p.load(Ordering::Acquire)),
-        )
+        self.reflector_ready.load(Ordering::Acquire)
     }
 
     /// Tokenize a chat body for routing → `(token_ids, priority_jump,
@@ -154,12 +139,6 @@ impl EppRouter {
             endpoint_in_subset(endpoint, &candidates, &candidate_ips)
         })
     }
-}
-
-/// Overall EPP health: pod readiness AND, when replicated (`peer_ready = Some`),
-/// the initial peer sync. `None` means no replication → pod readiness alone.
-fn compute_ready(pod_ready: bool, peer_ready: Option<bool>) -> bool {
-    pod_ready && peer_ready.unwrap_or(true)
 }
 
 /// True if a scheme-less `ip:port` endpoint is covered by an Envoy subset,
@@ -515,18 +494,6 @@ mod tests {
             map(StatusCode::SERVICE_UNAVAILABLE),
             PickError::TokenizerUnavailable
         ));
-    }
-
-    #[test]
-    fn compute_ready_gates_on_pod_and_peer() {
-        // No replication (peer_ready = None): readiness == pod readiness.
-        assert!(compute_ready(true, None));
-        assert!(!compute_ready(false, None));
-        // Replicated: both must be ready. A pod that is worker-ready but hasn't
-        // finished its initial peer sync stays NOT_SERVING.
-        assert!(compute_ready(true, Some(true)));
-        assert!(!compute_ready(true, Some(false)));
-        assert!(!compute_ready(false, Some(true)));
     }
 
     #[test]

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -347,74 +347,84 @@ mod tests {
     }
 
     #[test]
-    fn peer_service_config_parsed() {
-        let cfg = parse_cfg(&[
-            ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
-            ("POD_IP", "10.0.0.10"),
-            ("DYN_EPP_SELECTION_INDEXER_THREADS", "8"),
+    fn peer_replication_config() {
+        let required = [
             ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
             ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
             ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
             ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
             ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
-        ])
-        .expect("peer service config should parse");
-        assert_eq!(cfg.peer_service.as_deref(), Some("dynamo-epp"));
-        assert_eq!(cfg.pod_ip.as_deref(), Some("10.0.0.10"));
-        assert_eq!(cfg.replica_sync_port, DEFAULT_REPLICA_SYNC_PORT);
-        assert_eq!(cfg.selector_threads, 8);
-        assert_eq!(cfg.namespace, "inference");
-    }
+        ];
+        let cases: [(&str, &[(&str, &str)], Result<(u16, usize), &str>); 6] = [
+            (
+                "default port",
+                &[
+                    ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
+                    ("POD_IP", "10.0.0.10"),
+                    ("DYN_EPP_SELECTION_INDEXER_THREADS", "8"),
+                ],
+                Ok((DEFAULT_REPLICA_SYNC_PORT, 8)),
+            ),
+            (
+                "overridden port",
+                &[
+                    ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
+                    ("POD_IP", "10.0.0.10"),
+                    ("DYN_EPP_REPLICA_SYNC_PORT", "9192"),
+                ],
+                Ok((9192, DEFAULT_SELECTOR_THREADS)),
+            ),
+            (
+                "missing pod ip",
+                &[("DYN_EPP_PEER_SERVICE", "dynamo-epp")],
+                Err("POD_IP"),
+            ),
+            (
+                "blank pod ip",
+                &[("DYN_EPP_PEER_SERVICE", "dynamo-epp"), ("POD_IP", " ")],
+                Err("POD_IP"),
+            ),
+            (
+                "zero port",
+                &[
+                    ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
+                    ("POD_IP", "10.0.0.10"),
+                    ("DYN_EPP_REPLICA_SYNC_PORT", "0"),
+                ],
+                Err("DYN_EPP_REPLICA_SYNC_PORT"),
+            ),
+            (
+                "out of range port",
+                &[
+                    ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
+                    ("POD_IP", "10.0.0.10"),
+                    ("DYN_EPP_REPLICA_SYNC_PORT", "65536"),
+                ],
+                Err("DYN_EPP_REPLICA_SYNC_PORT"),
+            ),
+        ];
 
-    #[test]
-    fn replica_sync_port_can_be_overridden() {
-        let cfg = parse_cfg(&[
-            ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
-            ("POD_IP", "10.0.0.10"),
-            ("DYN_EPP_REPLICA_SYNC_PORT", "9192"),
-            ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
-            ("POD_NAMESPACE", "inference"),
-            ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-            ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
-            ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
-            ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
-        ])
-        .expect("replica sync port override should parse");
-
-        assert_eq!(cfg.replica_sync_port, 9192);
-    }
-
-    #[test]
-    fn peer_service_requires_pod_ip() {
-        let error = parse_cfg(&[
-            ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
-            ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
-            ("POD_NAMESPACE", "inference"),
-            ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-            ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
-            ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
-            ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
-        ])
-        .expect_err("peer service without POD_IP must fail");
-
-        assert!(error.to_string().contains("POD_IP"));
-    }
-
-    #[test]
-    fn zero_replica_sync_port_fails() {
-        assert!(
-            parse_cfg(&[
-                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
-                ("POD_NAMESPACE", "inference"),
-                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-                ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
-                ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
-                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
-                ("DYN_EPP_REPLICA_SYNC_PORT", "0"),
-            ])
-            .is_err()
-        );
+        for (name, extra, expected) in cases {
+            let mut env = required.to_vec();
+            env.extend_from_slice(extra);
+            match expected {
+                Ok((port, selector_threads)) => {
+                    let cfg = parse_cfg(&env).unwrap_or_else(|error| panic!("{name}: {error}"));
+                    assert_eq!(cfg.peer_service.as_deref(), Some("dynamo-epp"), "{name}");
+                    assert_eq!(cfg.pod_ip.as_deref(), Some("10.0.0.10"), "{name}");
+                    assert_eq!(cfg.replica_sync_port, port, "{name}");
+                    assert_eq!(cfg.selector_threads, selector_threads, "{name}");
+                }
+                Err(expected_error) => {
+                    let error = parse_cfg(&env).expect_err(name);
+                    assert!(
+                        error.to_string().contains(expected_error),
+                        "{name}: {error}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -83,23 +83,31 @@ impl std::str::FromStr for TokenizerProtocol {
     }
 }
 
+/// Complete replica synchronization configuration. Its presence enables
+/// replica-sync; its fields are validated together when parsing the environment.
+#[derive(Debug, Clone, Validate)]
+pub struct PeerReplicationConfig {
+    /// EPP Service used for peer discovery and state synchronization.
+    pub service_name: String,
+    /// Local EPP Pod IP from `POD_IP` (downward API), used to exclude self.
+    pub pod_ip: String,
+    /// ZMQ listener and peer dial port. Every EPP selected by `service_name`
+    /// must use the same port.
+    #[validate(range(
+        min = 1,
+        message = "DYN_EPP_REPLICA_SYNC_PORT must be greater than zero"
+    ))]
+    pub sync_port: u16,
+}
+
 #[derive(Debug, Clone, Validate)]
 pub struct EppStandaloneConfig {
     /// KV indexer thread-pool size for the in-process selector.
     #[validate(range(min = 1))]
     pub selector_threads: usize,
-    /// EPP Service for peer discovery and state synchronization.
-    pub peer_service: Option<String>,
-    /// Local EPP Pod IP (from `POD_IP`, downward API). Required when peer
-    /// discovery is enabled so this replica can exclude itself from peers.
-    pub pod_ip: Option<String>,
-    /// ZMQ listener and peer dial port for replica synchronization. Every EPP
-    /// selected by `peer_service` must use the same port.
-    #[validate(range(
-        min = 1,
-        message = "DYN_EPP_REPLICA_SYNC_PORT must be greater than zero"
-    ))]
-    pub replica_sync_port: u16,
+    /// Enables replica synchronization when set.
+    #[validate(nested)]
+    pub peer_replication: Option<PeerReplicationConfig>,
     /// `InferencePool` this EPP backs; its selector + target port drive discovery.
     #[validate(length(min = 1, message = "DYN_EPP_INFERENCE_POOL_NAME is required"))]
     pub inference_pool_name: String,
@@ -161,14 +169,30 @@ impl EppStandaloneConfig {
         let tokenizer_protocol = trimmed(get("DYN_EPP_TOKENIZER_PROTOCOL"))
             .ok_or_else(|| anyhow::anyhow!("DYN_EPP_TOKENIZER_PROTOCOL is required"))?
             .parse()?;
+        let peer_service = trimmed(get("DYN_EPP_PEER_SERVICE"));
+        let pod_ip = trimmed(get("POD_IP"));
+        let sync_port = opt_parse::<u16>(get, "DYN_EPP_REPLICA_SYNC_PORT")?
+            .unwrap_or(DEFAULT_REPLICA_SYNC_PORT);
+        let peer_replication = peer_service
+            .map(|service_name| -> anyhow::Result<_> {
+                let pod_ip = pod_ip.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "invalid {STANDALONE_MODE} EPP config: DYN_EPP_PEER_SERVICE is set but POD_IP is unavailable; \
+                         inject POD_IP via the downward API (fieldRef status.podIP)"
+                    )
+                })?;
+                Ok(PeerReplicationConfig {
+                    service_name,
+                    pod_ip,
+                    sync_port,
+                })
+            })
+            .transpose()?;
 
         Ok(Self {
             selector_threads: opt_parse::<usize>(get, "DYN_EPP_SELECTION_INDEXER_THREADS")?
                 .unwrap_or(DEFAULT_SELECTOR_THREADS),
-            peer_service: trimmed(get("DYN_EPP_PEER_SERVICE")),
-            pod_ip: trimmed(get("POD_IP")),
-            replica_sync_port: opt_parse::<u16>(get, "DYN_EPP_REPLICA_SYNC_PORT")?
-                .unwrap_or(DEFAULT_REPLICA_SYNC_PORT),
+            peer_replication,
             inference_pool_name: trimmed(get("DYN_EPP_INFERENCE_POOL_NAME")).unwrap_or_default(),
             namespace: trimmed(get("POD_NAMESPACE")).unwrap_or_default(),
             model_name: trimmed(get("DYN_MODEL_NAME")).unwrap_or_default(),
@@ -197,12 +221,6 @@ impl EppStandaloneConfig {
     pub fn validate_config(&self) -> anyhow::Result<()> {
         self.validate()
             .map_err(|e| anyhow::anyhow!("invalid {STANDALONE_MODE} EPP config: {e}"))?;
-        if self.peer_service.is_some() && self.pod_ip.is_none() {
-            anyhow::bail!(
-                "invalid {STANDALONE_MODE} EPP config: DYN_EPP_PEER_SERVICE is set but POD_IP is unavailable; \
-                 inject POD_IP via the downward API (fieldRef status.podIP)"
-            );
-        }
         Ok(())
     }
 }
@@ -310,9 +328,7 @@ mod tests {
         .expect("config should parse");
         assert_eq!(cfg.selector_threads, DEFAULT_SELECTOR_THREADS);
         // No peer service => single-replica (replica sync off).
-        assert!(cfg.peer_service.is_none());
-        assert!(cfg.pod_ip.is_none());
-        assert_eq!(cfg.replica_sync_port, DEFAULT_REPLICA_SYNC_PORT);
+        assert!(cfg.peer_replication.is_none());
         assert_eq!(cfg.inference_pool_name, "vllm-qwen-pool");
         assert_eq!(cfg.namespace, "inference");
         assert_eq!(cfg.model_name, "Qwen/Qwen3-0.6B");
@@ -415,9 +431,13 @@ mod tests {
             match expected {
                 Ok((port, selector_threads)) => {
                     let cfg = parse_cfg(&env).unwrap_or_else(|error| panic!("{name}: {error}"));
-                    assert_eq!(cfg.peer_service.as_deref(), Some("dynamo-epp"), "{name}");
-                    assert_eq!(cfg.pod_ip.as_deref(), Some("10.0.0.10"), "{name}");
-                    assert_eq!(cfg.replica_sync_port, port, "{name}");
+                    let replication = cfg
+                        .peer_replication
+                        .as_ref()
+                        .unwrap_or_else(|| panic!("{name}: replication should be enabled"));
+                    assert_eq!(replication.service_name, "dynamo-epp", "{name}");
+                    assert_eq!(replication.pod_ip, "10.0.0.10", "{name}");
+                    assert_eq!(replication.sync_port, port, "{name}");
                     assert_eq!(cfg.selector_threads, selector_threads, "{name}");
                 }
                 Err(expected_error) => {

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -90,6 +90,9 @@ pub struct EppStandaloneConfig {
     pub selector_threads: usize,
     /// EPP Service for peer discovery and state synchronization.
     pub peer_service: Option<String>,
+    /// Local EPP Pod IP (from `POD_IP`, downward API). Required when peer
+    /// discovery is enabled so this replica can exclude itself from peers.
+    pub pod_ip: Option<String>,
     /// ZMQ listener and peer dial port for replica synchronization. Every EPP
     /// selected by `peer_service` must use the same port.
     #[validate(range(
@@ -163,6 +166,7 @@ impl EppStandaloneConfig {
             selector_threads: opt_parse::<usize>(get, "DYN_EPP_SELECTION_INDEXER_THREADS")?
                 .unwrap_or(DEFAULT_SELECTOR_THREADS),
             peer_service: trimmed(get("DYN_EPP_PEER_SERVICE")),
+            pod_ip: trimmed(get("POD_IP")),
             replica_sync_port: opt_parse::<u16>(get, "DYN_EPP_REPLICA_SYNC_PORT")?
                 .unwrap_or(DEFAULT_REPLICA_SYNC_PORT),
             inference_pool_name: trimmed(get("DYN_EPP_INFERENCE_POOL_NAME")).unwrap_or_default(),
@@ -192,7 +196,14 @@ impl EppStandaloneConfig {
     /// Enforce the `validator` constraints, mapping the failure to `anyhow`.
     pub fn validate_config(&self) -> anyhow::Result<()> {
         self.validate()
-            .map_err(|e| anyhow::anyhow!("invalid {STANDALONE_MODE} EPP config: {e}"))
+            .map_err(|e| anyhow::anyhow!("invalid {STANDALONE_MODE} EPP config: {e}"))?;
+        if self.peer_service.is_some() && self.pod_ip.is_none() {
+            anyhow::bail!(
+                "invalid {STANDALONE_MODE} EPP config: DYN_EPP_PEER_SERVICE is set but POD_IP is unavailable; \
+                 inject POD_IP via the downward API (fieldRef status.podIP)"
+            );
+        }
+        Ok(())
     }
 }
 
@@ -300,6 +311,7 @@ mod tests {
         assert_eq!(cfg.selector_threads, DEFAULT_SELECTOR_THREADS);
         // No peer service => single-replica (replica sync off).
         assert!(cfg.peer_service.is_none());
+        assert!(cfg.pod_ip.is_none());
         assert_eq!(cfg.replica_sync_port, DEFAULT_REPLICA_SYNC_PORT);
         assert_eq!(cfg.inference_pool_name, "vllm-qwen-pool");
         assert_eq!(cfg.namespace, "inference");
@@ -338,6 +350,7 @@ mod tests {
     fn peer_service_config_parsed() {
         let cfg = parse_cfg(&[
             ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
+            ("POD_IP", "10.0.0.10"),
             ("DYN_EPP_SELECTION_INDEXER_THREADS", "8"),
             ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
@@ -348,6 +361,7 @@ mod tests {
         ])
         .expect("peer service config should parse");
         assert_eq!(cfg.peer_service.as_deref(), Some("dynamo-epp"));
+        assert_eq!(cfg.pod_ip.as_deref(), Some("10.0.0.10"));
         assert_eq!(cfg.replica_sync_port, DEFAULT_REPLICA_SYNC_PORT);
         assert_eq!(cfg.selector_threads, 8);
         assert_eq!(cfg.namespace, "inference");
@@ -357,6 +371,7 @@ mod tests {
     fn replica_sync_port_can_be_overridden() {
         let cfg = parse_cfg(&[
             ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
+            ("POD_IP", "10.0.0.10"),
             ("DYN_EPP_REPLICA_SYNC_PORT", "9192"),
             ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
@@ -368,6 +383,22 @@ mod tests {
         .expect("replica sync port override should parse");
 
         assert_eq!(cfg.replica_sync_port, 9192);
+    }
+
+    #[test]
+    fn peer_service_requires_pod_ip() {
+        let error = parse_cfg(&[
+            ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
+            ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+            ("POD_NAMESPACE", "inference"),
+            ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+            ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+            ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
+            ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+        ])
+        .expect_err("peer service without POD_IP must fail");
+
+        assert!(error.to_string().contains("POD_IP"));
     }
 
     #[test]

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -16,7 +16,6 @@ use validator::ValidationError;
 use crate::vllm_render_client::parse_tokenizer_service_base_url;
 
 const DEFAULT_KV_EVENT_PORT: u16 = 5557;
-/// ZMQ replica-sync port shared by every EPP selected by a peer Service.
 const DEFAULT_REPLICA_SYNC_PORT: u16 = 9092;
 const DEFAULT_SELECTOR_THREADS: usize = 4;
 const DEFAULT_TOKENIZATION_TIMEOUT_MS: u64 = 5_000;

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -348,6 +348,10 @@ mod tests {
 
     #[test]
     fn peer_replication_config() {
+        type ExtraEnv = &'static [(&'static str, &'static str)];
+        type Expected = Result<(u16, usize), &'static str>;
+        type Case = (&'static str, ExtraEnv, Expected);
+
         let required = [
             ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
@@ -356,7 +360,7 @@ mod tests {
             ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
             ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
         ];
-        let cases: [(&str, &[(&str, &str)], Result<(u16, usize), &str>); 6] = [
+        let cases: [Case; 6] = [
             (
                 "default port",
                 &[

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -16,6 +16,8 @@ use validator::ValidationError;
 use crate::vllm_render_client::parse_tokenizer_service_base_url;
 
 const DEFAULT_KV_EVENT_PORT: u16 = 5557;
+/// ZMQ replica-sync port shared by every EPP selected by a peer Service.
+const DEFAULT_REPLICA_SYNC_PORT: u16 = 9092;
 const DEFAULT_SELECTOR_THREADS: usize = 4;
 const DEFAULT_TOKENIZATION_TIMEOUT_MS: u64 = 5_000;
 const DEFAULT_TOKENIZER_MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
@@ -87,9 +89,15 @@ pub struct EppStandaloneConfig {
     /// KV indexer thread-pool size for the in-process selector.
     #[validate(range(min = 1))]
     pub selector_threads: usize,
-    /// EPP Service for peer discovery and state synchronization. The eventual
-    /// selector resolves its named `replica-agg` port from EndpointSlices.
+    /// EPP Service for peer discovery and state synchronization.
     pub peer_service: Option<String>,
+    /// ZMQ listener and peer dial port for replica synchronization. Every EPP
+    /// selected by `peer_service` must use the same port.
+    #[validate(range(
+        min = 1,
+        message = "DYN_EPP_REPLICA_SYNC_PORT must be greater than zero"
+    ))]
+    pub replica_sync_port: u16,
     /// `InferencePool` this EPP backs; its selector + target port drive discovery.
     #[validate(length(min = 1, message = "DYN_EPP_INFERENCE_POOL_NAME is required"))]
     pub inference_pool_name: String,
@@ -156,6 +164,8 @@ impl EppStandaloneConfig {
             selector_threads: opt_parse::<usize>(get, "DYN_EPP_SELECTION_INDEXER_THREADS")?
                 .unwrap_or(DEFAULT_SELECTOR_THREADS),
             peer_service: trimmed(get("DYN_EPP_PEER_SERVICE")),
+            replica_sync_port: opt_parse::<u16>(get, "DYN_EPP_REPLICA_SYNC_PORT")?
+                .unwrap_or(DEFAULT_REPLICA_SYNC_PORT),
             inference_pool_name: trimmed(get("DYN_EPP_INFERENCE_POOL_NAME")).unwrap_or_default(),
             namespace: trimmed(get("POD_NAMESPACE")).unwrap_or_default(),
             model_name: trimmed(get("DYN_MODEL_NAME")).unwrap_or_default(),
@@ -291,6 +301,7 @@ mod tests {
         assert_eq!(cfg.selector_threads, DEFAULT_SELECTOR_THREADS);
         // No peer service => single-replica (replica sync off).
         assert!(cfg.peer_service.is_none());
+        assert_eq!(cfg.replica_sync_port, DEFAULT_REPLICA_SYNC_PORT);
         assert_eq!(cfg.inference_pool_name, "vllm-qwen-pool");
         assert_eq!(cfg.namespace, "inference");
         assert_eq!(cfg.model_name, "Qwen/Qwen3-0.6B");
@@ -338,8 +349,42 @@ mod tests {
         ])
         .expect("peer service config should parse");
         assert_eq!(cfg.peer_service.as_deref(), Some("dynamo-epp"));
+        assert_eq!(cfg.replica_sync_port, DEFAULT_REPLICA_SYNC_PORT);
         assert_eq!(cfg.selector_threads, 8);
         assert_eq!(cfg.namespace, "inference");
+    }
+
+    #[test]
+    fn replica_sync_port_can_be_overridden() {
+        let cfg = parse_cfg(&[
+            ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
+            ("DYN_EPP_REPLICA_SYNC_PORT", "9192"),
+            ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+            ("POD_NAMESPACE", "inference"),
+            ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+            ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+            ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
+            ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+        ])
+        .expect("replica sync port override should parse");
+
+        assert_eq!(cfg.replica_sync_port, 9192);
+    }
+
+    #[test]
+    fn zero_replica_sync_port_fails() {
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+                ("POD_NAMESPACE", "inference"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+                ("DYN_EPP_REPLICA_SYNC_PORT", "0"),
+            ])
+            .is_err()
+        );
     }
 
     #[test]

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -30,7 +30,9 @@ pub mod vllm_render_client;
 
 pub use epp::Router;
 pub use epp_router::EppRouter;
-pub use epp_standalone_config::{EppMode, EppStandaloneConfig, TokenizerProtocol};
+pub use epp_standalone_config::{
+    EppMode, EppStandaloneConfig, PeerReplicationConfig, TokenizerProtocol,
+};
 pub use inference_pool::PoolState;
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo, ResponseUsage};
 pub use pod_discovery::{PodDiscovery, RawWorker};

--- a/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use k8s_openapi::api::core::v1::Service;
 use k8s_openapi::api::discovery::v1::EndpointSlice;
+use kube::{Api, Client};
 use tokio_util::sync::CancellationToken;
 
 use dynamo_kv_router::services::selection::SelectionService;
@@ -22,12 +23,11 @@ const SERVICE_NAME_LABEL: &str = "kubernetes.io/service-name";
 type Store = kube::runtime::reflector::Store<EndpointSlice>;
 
 /// Verifies the peer Service exists before enabling replica synchronization.
-pub(crate) async fn ensure_peer_service_exists(namespace: &str, service_name: &str) -> Result<()> {
-    use kube::{Api, Client};
-
-    let client = Client::try_default()
-        .await
-        .context("building Kubernetes client for EPP peer Service validation")?;
+pub(crate) async fn ensure_peer_service_exists(
+    client: Client,
+    namespace: &str,
+    service_name: &str,
+) -> Result<()> {
     let services: Api<Service> = Api::namespaced(client, namespace);
     services
         .get(service_name)
@@ -39,6 +39,7 @@ pub(crate) async fn ensure_peer_service_exists(namespace: &str, service_name: &s
 /// Starts peer discovery for the EPP's own Kubernetes Service, keeping
 /// replica-sync peers registered on `service` and excluding `self_ip`.
 pub async fn spawn(
+    client: Client,
     service: Arc<SelectionService>,
     namespace: &str,
     service_name: &str,
@@ -47,11 +48,7 @@ pub async fn spawn(
     cancel: CancellationToken,
 ) -> Result<()> {
     use futures::StreamExt;
-    use kube::{Api, Client, runtime::WatchStreamExt, runtime::reflector, runtime::watcher};
-
-    let client = Client::try_default()
-        .await
-        .context("building Kubernetes client for EPP peer discovery")?;
+    use kube::runtime::{WatchStreamExt, reflector, watcher};
     let slices: Api<EndpointSlice> = Api::namespaced(client, namespace);
     let cfg_watch =
         watcher::Config::default().labels(&format!("{SERVICE_NAME_LABEL}={service_name}"));
@@ -256,13 +253,21 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn reconcile_tracks_peer_membership_with_configured_port() {
+    async fn spawn_reconciles_initial_list_and_watch_update() {
+        use axum::extract::Request;
+        use axum::http::StatusCode;
+        use axum::response::IntoResponse;
+        use axum::routing::get;
+        use axum::{Json, Router};
         use dynamo_kv_router::WorkerType;
         use dynamo_kv_router::config::kv_router_config_from_dynamo_env;
         use dynamo_kv_router::services::selection::{
             SelectionServiceBuilder, WorkerSelectionPolicyRegistry,
         };
-        use kube::runtime::{reflector::store::Writer, watcher};
+        use kube::Config;
+        use tokio::net::TcpListener;
+        use tokio::sync::Notify;
+        use tokio::time::{Duration, sleep, timeout};
 
         let listener_port = std::net::TcpListener::bind("127.0.0.1:0")
             .expect("reserve a replica-sync listener port")
@@ -286,30 +291,105 @@ mod tests {
         let peer_a = "10.0.0.2";
         let peer_b = "10.0.0.3";
         let sync_port = 9192;
-        let mut known = BTreeSet::new();
-        let mut writer = Writer::<EndpointSlice>::default();
-        let store = writer.as_reader();
-
         let mut initial = slice_with(&[self_ip, peer_a], None, "IPv4");
         initial.metadata.name = Some("epp-peers".to_string());
-        writer.apply_watcher_event(&watcher::Event::Init);
-        writer.apply_watcher_event(&watcher::Event::InitApply(initial));
-        writer.apply_watcher_event(&watcher::Event::InitDone);
-        reconcile_once(&service, &store, sync_port, self_ip, &mut known).await;
-        assert_eq!(
-            service.list_replica_peers(),
-            vec![format!("tcp://{}", authority(peer_a, sync_port))]
-        );
-
         let mut updated = slice_with(&[self_ip, peer_b], None, "IPv4");
         updated.metadata.name = Some("epp-peers".to_string());
-        writer.apply_watcher_event(&watcher::Event::Apply(updated));
-        reconcile_once(&service, &store, sync_port, self_ip, &mut known).await;
-        assert_eq!(
-            service.list_replica_peers(),
-            vec![format!("tcp://{}", authority(peer_b, sync_port))]
-        );
+        updated.metadata.resource_version = Some("2".to_string());
+        let list = serde_json::json!({
+            "apiVersion": "discovery.k8s.io/v1",
+            "kind": "EndpointSliceList",
+            "metadata": {"resourceVersion": "1"},
+            "items": [initial],
+        });
+        let release_watch_update = Arc::new(Notify::new());
+        let watch_started = Arc::new(Notify::new());
+        let router = Router::new().fallback(get({
+            let release_watch_update = Arc::clone(&release_watch_update);
+            let watch_started = Arc::clone(&watch_started);
+            move |request: Request| {
+                let list = list.clone();
+                let updated = updated.clone();
+                let release_watch_update = Arc::clone(&release_watch_update);
+                let watch_started = Arc::clone(&watch_started);
+                async move {
+                    if request
+                        .uri()
+                        .query()
+                        .is_some_and(|query| query.contains("watch=true"))
+                    {
+                        watch_started.notify_one();
+                        release_watch_update.notified().await;
+                        (
+                            StatusCode::OK,
+                            format!(
+                                "{}\n",
+                                serde_json::json!({
+                                    "type": "MODIFIED",
+                                    "object": updated,
+                                })
+                            ),
+                        )
+                            .into_response()
+                    } else {
+                        Json(list).into_response()
+                    }
+                }
+            }
+        }));
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind Kubernetes API test server");
+        let address = listener.local_addr().expect("read test server address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .await
+                .expect("serve Kubernetes API test server");
+        });
+        let client = Client::try_from(Config::new(
+            format!("http://{address}")
+                .parse()
+                .expect("parse Kubernetes API URL"),
+        ))
+        .expect("build Kubernetes API test client");
+        let cancel = CancellationToken::new();
 
+        spawn(
+            client,
+            Arc::clone(&service),
+            "test-ns",
+            "epp-peers",
+            sync_port,
+            self_ip.to_string(),
+            cancel.clone(),
+        )
+        .await
+        .expect("start peer discovery");
+
+        let peer_a_endpoint = format!("tcp://{}", authority(peer_a, sync_port));
+        timeout(Duration::from_secs(2), async {
+            while service.list_replica_peers() != [peer_a_endpoint.clone()] {
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("initial EndpointSlice list should register the peer");
+
+        timeout(Duration::from_secs(2), watch_started.notified())
+            .await
+            .expect("EndpointSlice watch should begin after the initial list");
+        release_watch_update.notify_one();
+        let peer_b_endpoint = format!("tcp://{}", authority(peer_b, sync_port));
+        timeout(Duration::from_secs(2), async {
+            while service.list_replica_peers() != [peer_b_endpoint.clone()] {
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("EndpointSlice watch update should replace the peer");
+
+        cancel.cancel();
         service.shutdown().await;
+        server.abort();
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
@@ -22,10 +22,6 @@ const SERVICE_NAME_LABEL: &str = "kubernetes.io/service-name";
 type Store = kube::runtime::reflector::Store<EndpointSlice>;
 
 /// Verifies the peer Service exists before enabling replica synchronization.
-///
-/// The Service scopes EndpointSlice membership only. EPP replicas bind and
-/// dial their configured replica-sync port directly, so Service and
-/// EndpointSlice port definitions are not part of this contract.
 pub(crate) async fn ensure_peer_service_exists(namespace: &str, service_name: &str) -> Result<()> {
     use kube::{Api, Client};
 
@@ -72,10 +68,6 @@ pub async fn spawn(
         "Starting EPP peer EndpointSlice watch (embedded replication)"
     );
 
-    // Reconcile only when the reflector's Store holds a coherent snapshot:
-    // InitDone completes a LIST/relist, while Apply/Delete update a live Store.
-    // The watcher retries transient errors internally; its stream ends only when
-    // its writer drops.
     tokio::spawn(async move {
         tokio::pin!(reflect);
         let mut known = BTreeSet::new();

--- a/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
@@ -8,12 +8,10 @@
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::{Context, Result};
 use k8s_openapi::api::core::v1::Service;
 use k8s_openapi::api::discovery::v1::EndpointSlice;
-use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
 use dynamo_kv_router::services::selection::SelectionService;
@@ -44,8 +42,6 @@ pub(crate) async fn ensure_peer_service_exists(namespace: &str, service_name: &s
 
 /// Starts peer discovery for the EPP's own Kubernetes Service, keeping
 /// replica-sync peers registered on `service` and excluding `self_ip`.
-///
-/// Returns a readiness flag that becomes `true` after the initial reconciliation.
 pub async fn spawn(
     service: Arc<SelectionService>,
     namespace: &str,
@@ -53,7 +49,7 @@ pub async fn spawn(
     sync_port: u16,
     self_ip: String,
     cancel: CancellationToken,
-) -> Result<Arc<AtomicBool>> {
+) -> Result<()> {
     use futures::StreamExt;
     use kube::{Api, Client, runtime::WatchStreamExt, runtime::reflector, runtime::watcher};
 
@@ -67,7 +63,6 @@ pub async fn spawn(
     let writer = reflector::store::Writer::default();
     let store = writer.as_reader();
     let reflect = reflector::reflector(writer, watcher(slices, cfg_watch).default_backoff());
-    let (changes_tx, changes_rx) = watch::channel(0u64);
 
     tracing::info!(
         %namespace,
@@ -77,24 +72,21 @@ pub async fn spawn(
         "Starting EPP peer EndpointSlice watch (embedded replication)"
     );
 
-    // EndpointSlice reflector stream -> bump the change generation. The watcher
-    // retries transient errors internally; the stream ends only on writer drop.
-    let cancel_watch = cancel.clone();
+    // Reconcile only when the reflector's Store holds a coherent snapshot:
+    // InitDone completes a LIST/relist, while Apply/Delete update a live Store.
+    // The watcher retries transient errors internally; its stream ends only when
+    // its writer drops.
     tokio::spawn(async move {
         tokio::pin!(reflect);
-        let mut generation = 0u64;
+        let mut known = BTreeSet::new();
         loop {
             tokio::select! {
-                _ = cancel_watch.cancelled() => return,
+                _ = cancel.cancelled() => return,
                 item = reflect.next() => match item {
-                    // Skip the per-object relist events (Init/InitApply) and errors:
-                    // the store is consistent at InitDone, and Apply/Delete are
-                    // single-object deltas. Reconcile reads the store, so bumping on
-                    // partial relist state only triggers redundant reconciles.
+                    // Store state during a relist is incomplete until InitDone.
                     Some(Ok(watcher::Event::Init | watcher::Event::InitApply(_))) => {}
                     Some(Ok(_)) => {
-                        generation = generation.wrapping_add(1);
-                        let _ = changes_tx.send(generation);
+                        reconcile_once(&service, &store, sync_port, &self_ip, &mut known).await;
                     }
                     Some(Err(e)) => {
                         tracing::warn!(error = %e, "EPP peer EndpointSlice watch error");
@@ -108,67 +100,7 @@ pub async fn spawn(
         }
     });
 
-    let peer_ready = Arc::new(AtomicBool::new(false));
-
-    tokio::spawn(reconcile_loop(
-        service,
-        store,
-        sync_port,
-        self_ip,
-        changes_rx,
-        cancel,
-        peer_ready.clone(),
-    ));
-    Ok(peer_ready)
-}
-
-/// React to EndpointSlice changes: diff the live sibling set against the peers
-/// currently registered and apply the delta. Exits when `cancel` fires or the
-/// change channel closes.
-async fn reconcile_loop(
-    service: Arc<SelectionService>,
-    store: Store,
-    sync_port: u16,
-    self_ip: String,
-    mut changes_rx: watch::Receiver<u64>,
-    cancel: CancellationToken,
-    peer_ready: Arc<AtomicBool>,
-) {
-    // Block on the first authoritative LIST before the initial reconcile so we
-    // never latch readiness on an empty snapshot. The reflector retries watch
-    // errors with backoff, so this resolves once the LIST lands; a writer drop
-    // (watch task gone) means we can't sync, so bail without latching.
-    tokio::select! {
-        _ = cancel.cancelled() => return,
-        result = store.wait_until_ready() => {
-            if result.is_err() {
-                tracing::warn!(
-                    "EPP peer EndpointSlice writer dropped before initial LIST; \
-                     peer discovery never became ready"
-                );
-                return;
-            }
-        }
-    }
-
-    let mut known: BTreeSet<String> = BTreeSet::new();
-    reconcile_once(&service, &store, sync_port, &self_ip, &mut known).await;
-    // Set readiness to true after the initial reconciliation.
-    // Subsequent transient watch failures keep the last-known peers and must not clear it.
-    peer_ready.store(true, Ordering::Release);
-    tracing::info!("EPP peer discovery initial sync complete");
-
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => break,
-            changed = changes_rx.changed() => {
-                if changed.is_err() {
-                    break;
-                }
-            }
-        }
-        reconcile_once(&service, &store, sync_port, &self_ip, &mut known).await;
-    }
+    Ok(())
 }
 
 async fn reconcile_once(

--- a/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::{Context, Result};
+use k8s_openapi::api::core::v1::Service;
 use k8s_openapi::api::discovery::v1::EndpointSlice;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
@@ -20,92 +21,25 @@ use dynamo_kv_router::services::selection::SelectionService;
 /// Label Kubernetes sets on every EndpointSlice pointing back to its Service.
 const SERVICE_NAME_LABEL: &str = "kubernetes.io/service-name";
 
-/// Named Service/EndpointSlice port used for aggregated replica synchronization.
-pub const REPLICA_AGG_PORT_NAME: &str = "replica-agg";
-
 type Store = kube::runtime::reflector::Store<EndpointSlice>;
 
-/// Resolve the required aggregated replica-sync port from the peer Service's
-/// EndpointSlices. Every slice must expose the same named `replica-agg` port;
-/// missing or inconsistent ports fail EPP startup before replica sync is built.
-pub async fn resolve_replica_sync_port(namespace: &str, service_name: &str) -> Result<u16> {
-    use kube::{Api, Client, api::ListParams};
+/// Verifies the peer Service exists before enabling replica synchronization.
+///
+/// The Service scopes EndpointSlice membership only. EPP replicas bind and
+/// dial their configured replica-sync port directly, so Service and
+/// EndpointSlice port definitions are not part of this contract.
+pub(crate) async fn ensure_peer_service_exists(namespace: &str, service_name: &str) -> Result<()> {
+    use kube::{Api, Client};
 
     let client = Client::try_default()
         .await
-        .context("building Kubernetes client for EPP peer port resolution")?;
-    let slices: Api<EndpointSlice> = Api::namespaced(client, namespace);
-    let list = slices
-        .list(&ListParams::default().labels(&format!("{SERVICE_NAME_LABEL}={service_name}")))
+        .context("building Kubernetes client for EPP peer Service validation")?;
+    let services: Api<Service> = Api::namespaced(client, namespace);
+    services
+        .get(service_name)
         .await
-        .with_context(|| {
-            format!("listing EndpointSlices for EPP peer Service {namespace}/{service_name}")
-        })?;
-
-    replica_sync_port(list.items.iter()).with_context(|| {
-        format!(
-            "resolving named port {REPLICA_AGG_PORT_NAME:?} for EPP peer Service \
-             {namespace}/{service_name}"
-        )
-    })
-}
-
-fn replica_sync_port<'a>(slices: impl Iterator<Item = &'a EndpointSlice>) -> Result<u16> {
-    let mut resolved = BTreeSet::new();
-    let mut slice_count = 0usize;
-
-    for slice in slices {
-        slice_count += 1;
-        let slice_name = slice.metadata.name.as_deref().unwrap_or("<unnamed>");
-        let mut matches = slice
-            .ports
-            .as_deref()
-            .unwrap_or_default()
-            .iter()
-            // Only a TCP `replica-agg` port satisfies the contract: the replica
-            // plane binds and dials `tcp://`. Kubernetes defaults `protocol` to
-            // TCP when absent, so treat `None` as TCP and reject explicit
-            // UDP/SCTP rather than let a mismatched port through.
-            .filter(|port| {
-                port.name.as_deref() == Some(REPLICA_AGG_PORT_NAME)
-                    && port
-                        .protocol
-                        .as_deref()
-                        .is_none_or(|protocol| protocol.eq_ignore_ascii_case("TCP"))
-            });
-        let endpoint_port = matches.next().with_context(|| {
-            format!(
-                "EndpointSlice {slice_name} does not expose named port \
-                 {REPLICA_AGG_PORT_NAME:?}"
-            )
-        })?;
-        anyhow::ensure!(
-            matches.next().is_none(),
-            "EndpointSlice {slice_name} exposes named port {REPLICA_AGG_PORT_NAME:?} more than once"
-        );
-        let raw_port = endpoint_port.port.with_context(|| {
-            format!(
-                "EndpointSlice {slice_name} named port {REPLICA_AGG_PORT_NAME:?} has no port number"
-            )
-        })?;
-        let port = u16::try_from(raw_port).with_context(|| {
-            format!(
-                "EndpointSlice {slice_name} named port {REPLICA_AGG_PORT_NAME:?} has invalid port {raw_port}"
-            )
-        })?;
-        anyhow::ensure!(
-            port > 0,
-            "named port {REPLICA_AGG_PORT_NAME:?} must be greater than zero"
-        );
-        resolved.insert(port);
-    }
-
-    anyhow::ensure!(slice_count > 0, "peer Service has no EndpointSlices");
-    anyhow::ensure!(
-        resolved.len() == 1,
-        "named port {REPLICA_AGG_PORT_NAME:?} resolves to inconsistent ports {resolved:?}"
-    );
-    Ok(*resolved.first().expect("validated one resolved port"))
+        .with_context(|| format!("getting EPP peer Service {namespace}/{service_name}"))?;
+    Ok(())
 }
 
 /// Starts peer discovery for the EPP's own Kubernetes Service, keeping
@@ -318,7 +252,7 @@ fn peer_ips<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use k8s_openapi::api::discovery::v1::{Endpoint, EndpointConditions, EndpointPort};
+    use k8s_openapi::api::discovery::v1::{Endpoint, EndpointConditions};
 
     fn slice_with(ips: &[&str], terminating: bool, address_type: &str) -> EndpointSlice {
         EndpointSlice {
@@ -336,17 +270,6 @@ mod tests {
                 .collect(),
             ..Default::default()
         }
-    }
-
-    fn slice_with_replica_port(port: Option<i32>) -> EndpointSlice {
-        let mut slice = slice_with(&["10.0.0.1"], false, "IPv4");
-        slice.metadata.name = Some("epp-peers-abc".to_string());
-        slice.ports = Some(vec![EndpointPort {
-            name: Some(REPLICA_AGG_PORT_NAME.to_string()),
-            port,
-            ..Default::default()
-        }]);
-        slice
     }
 
     #[test]
@@ -416,69 +339,6 @@ mod tests {
     fn authority_brackets_ipv6_only() {
         assert_eq!(authority("10.0.0.1", 9092), "10.0.0.1:9092");
         assert_eq!(authority("fd00::1", 9092), "[fd00::1]:9092");
-    }
-
-    #[test]
-    fn resolves_replica_agg_named_port() {
-        let slices = [
-            slice_with_replica_port(Some(9092)),
-            slice_with_replica_port(Some(9092)),
-        ];
-        assert_eq!(replica_sync_port(slices.iter()).unwrap(), 9092);
-    }
-
-    #[test]
-    fn rejects_missing_replica_agg_named_port() {
-        let slices = [slice_with(&["10.0.0.1"], false, "IPv4")];
-        let error = replica_sync_port(slices.iter()).unwrap_err().to_string();
-        assert!(error.contains(REPLICA_AGG_PORT_NAME));
-    }
-
-    #[test]
-    fn rejects_inconsistent_replica_agg_named_ports() {
-        let slices = [
-            slice_with_replica_port(Some(9092)),
-            slice_with_replica_port(Some(9093)),
-        ];
-        let error = replica_sync_port(slices.iter()).unwrap_err().to_string();
-        assert!(error.contains("inconsistent ports"));
-    }
-
-    fn slice_with_replica_port_protocol(protocol: Option<&str>) -> EndpointSlice {
-        let mut slice = slice_with(&["10.0.0.1"], false, "IPv4");
-        slice.metadata.name = Some("epp-peers-proto".to_string());
-        slice.ports = Some(vec![EndpointPort {
-            name: Some(REPLICA_AGG_PORT_NAME.to_string()),
-            port: Some(9092),
-            protocol: protocol.map(str::to_string),
-            ..Default::default()
-        }]);
-        slice
-    }
-
-    #[test]
-    fn accepts_absent_or_tcp_replica_agg_protocol() {
-        // Absent protocol defaults to TCP in Kubernetes; explicit TCP is fine.
-        assert_eq!(
-            replica_sync_port([slice_with_replica_port_protocol(None)].iter()).unwrap(),
-            9092
-        );
-        assert_eq!(
-            replica_sync_port([slice_with_replica_port_protocol(Some("TCP"))].iter()).unwrap(),
-            9092
-        );
-    }
-
-    #[test]
-    fn rejects_non_tcp_replica_agg_port() {
-        // A UDP `replica-agg` port must not resolve: the replica plane dials
-        // tcp://, so treating it as valid would be a silent transport mismatch.
-        // With no TCP match left, resolution fails with the "does not expose"
-        // error naming the port.
-        let error = replica_sync_port([slice_with_replica_port_protocol(Some("UDP"))].iter())
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains(REPLICA_AGG_PORT_NAME));
     }
 
     fn free_tcp_port() -> u16 {

--- a/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
@@ -178,17 +178,18 @@ mod tests {
     use super::*;
     use k8s_openapi::api::discovery::v1::{Endpoint, EndpointConditions};
 
-    fn slice_with(ips: &[&str], terminating: bool, address_type: &str) -> EndpointSlice {
+    fn slice_with(
+        ips: &[&str],
+        conditions: Option<EndpointConditions>,
+        address_type: &str,
+    ) -> EndpointSlice {
         EndpointSlice {
             address_type: address_type.to_string(),
             endpoints: ips
                 .iter()
                 .map(|ip| Endpoint {
                     addresses: vec![ip.to_string()],
-                    conditions: Some(EndpointConditions {
-                        terminating: Some(terminating),
-                        ..Default::default()
-                    }),
+                    conditions: conditions.clone(),
                     ..Default::default()
                 })
                 .collect(),
@@ -197,49 +198,40 @@ mod tests {
     }
 
     #[test]
-    fn peer_ips_keeps_non_terminating() {
-        let slices = [slice_with(&["10.0.0.1", "10.0.0.2"], false, "IPv4")];
-        let ips = peer_ips(slices.iter(), false);
-        assert!(ips.contains("10.0.0.1"));
-        assert!(ips.contains("10.0.0.2"));
-    }
-
-    #[test]
-    fn peer_ips_preserves_terminating() {
-        let slices = [slice_with(&["10.0.0.9"], true, "IPv4")];
-        assert!(peer_ips(slices.iter(), false).contains("10.0.0.9"));
-    }
-
-    fn slice_with_serving(ip: &str, terminating: bool, serving: bool) -> EndpointSlice {
-        EndpointSlice {
-            address_type: "IPv4".to_string(),
-            endpoints: vec![Endpoint {
-                addresses: vec![ip.to_string()],
-                conditions: Some(EndpointConditions {
-                    terminating: Some(terminating),
-                    serving: Some(serving),
+    fn peer_ips_follows_membership_regardless_of_endpoint_conditions() {
+        for (name, conditions) in [
+            ("no conditions", None),
+            (
+                "not ready",
+                Some(EndpointConditions {
+                    ready: Some(false),
                     ..Default::default()
                 }),
-                ..Default::default()
-            }],
-            ..Default::default()
+            ),
+            (
+                "terminating but serving",
+                Some(EndpointConditions {
+                    terminating: Some(true),
+                    serving: Some(true),
+                    ..Default::default()
+                }),
+            ),
+            (
+                "terminating and not serving",
+                Some(EndpointConditions {
+                    terminating: Some(true),
+                    serving: Some(false),
+                    ..Default::default()
+                }),
+            ),
+        ] {
+            let slices = [slice_with(&["10.0.0.2"], conditions, "IPv4")];
+            assert_eq!(
+                peer_ips(slices.iter(), false),
+                BTreeSet::from(["10.0.0.2".to_string()]),
+                "{name}"
+            );
         }
-    }
-
-    #[test]
-    fn peer_ips_keeps_terminating_but_serving() {
-        // A terminating sibling that is still serving is draining in-flight
-        // requests and will emit final PrefillComplete/Free events; keep it so
-        // that load is not stranded in the local aggregate.
-        let slices = [slice_with_serving("10.0.0.5", true, true)];
-        assert!(peer_ips(slices.iter(), false).contains("10.0.0.5"));
-    }
-
-    #[test]
-    fn peer_ips_preserves_terminating_not_serving() {
-        // Once a terminating sibling stops serving it is truly done; drop it.
-        let slices = [slice_with_serving("10.0.0.6", true, false)];
-        assert!(peer_ips(slices.iter(), false).contains("10.0.0.6"));
     }
 
     #[test]
@@ -247,16 +239,14 @@ mod tests {
         // A dual-stack sibling is present in both an IPv4 and an IPv6 slice; only
         // the family matching our own IP is kept, so it is registered once.
         let slices = [
-            slice_with(&["10.0.0.1"], false, "IPv4"),
-            slice_with(&["fd00::1"], false, "IPv6"),
+            slice_with(&["10.0.0.1"], None, "IPv4"),
+            slice_with(&["fd00::1"], None, "IPv6"),
         ];
         let v4 = peer_ips(slices.iter(), false);
-        assert_eq!(v4.len(), 1);
-        assert!(v4.contains("10.0.0.1"));
+        assert_eq!(v4, BTreeSet::from(["10.0.0.1".to_string()]));
 
         let v6 = peer_ips(slices.iter(), true);
-        assert_eq!(v6.len(), 1);
-        assert!(v6.contains("fd00::1"));
+        assert_eq!(v6, BTreeSet::from(["fd00::1".to_string()]));
     }
 
     #[test]
@@ -265,49 +255,20 @@ mod tests {
         assert_eq!(authority("fd00::1", 9092), "[fd00::1]:9092");
     }
 
-    fn free_tcp_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .unwrap()
-            .local_addr()
-            .unwrap()
-            .port()
-    }
-
-    /// Build a reflector `Store<EndpointSlice>` from a fixed slice set (no
-    /// cluster), so `reconcile_once` can be driven over scripted transitions.
-    fn store_from_slices(slices: Vec<EndpointSlice>) -> Store {
-        use kube::runtime::watcher;
-        let mut writer = kube::runtime::reflector::store::Writer::<EndpointSlice>::default();
-        let store = writer.as_reader();
-        writer.apply_watcher_event(&watcher::Event::Init);
-        for (i, mut slice) in slices.into_iter().enumerate() {
-            // The reflector keys by name; give each slice a distinct one.
-            slice.metadata.name = Some(format!("epp-peers-{i}"));
-            writer.apply_watcher_event(&watcher::Event::InitApply(slice));
-        }
-        writer.apply_watcher_event(&watcher::Event::InitDone);
-        store
-    }
-
-    /// End-to-end at the reconcile boundary: a sibling that enters termination
-    /// while still `serving` is draining in-flight ext-proc streams and will emit
-    /// final `PrefillComplete`/`Free` events over replica sync. `reconcile_once`
-    /// must therefore keep it *registered* on the `SelectionService` (so those
-    /// events still arrive and release its load — see kv-router's
-    /// `selector_replica_sync_propagates_request_lifecycle` for the release path)
-    /// and only deregister it once it stops serving. This covers the reconcile
-    /// wiring that consumes `peer_ips`, which the predicate tests above do not.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn reconcile_retains_draining_peer_until_it_stops_serving() {
+    async fn reconcile_tracks_peer_membership_with_configured_port() {
         use dynamo_kv_router::WorkerType;
         use dynamo_kv_router::config::kv_router_config_from_dynamo_env;
         use dynamo_kv_router::services::selection::{
             SelectionServiceBuilder, WorkerSelectionPolicyRegistry,
         };
+        use kube::runtime::{reflector::store::Writer, watcher};
 
-        // A real replica-sync-enabled service. `register_replica_peer` is a lazy
-        // ZMQ connect, so no live sibling is needed — we assert only the peer set
-        // that reconcile maintains via `list_replica_peers`.
+        let listener_port = std::net::TcpListener::bind("127.0.0.1:0")
+            .expect("reserve a replica-sync listener port")
+            .local_addr()
+            .expect("read listener address")
+            .port();
         let service = Arc::new(
             SelectionServiceBuilder::new(
                 kv_router_config_from_dynamo_env(),
@@ -315,49 +276,38 @@ mod tests {
                 WorkerSelectionPolicyRegistry::default(),
             )
             .indexer_threads(1)
-            .replica_sync(free_tcp_port(), Vec::new())
+            .replica_sync(listener_port, Vec::new())
             .build()
             .await
             .expect("build replica-sync selection service"),
         );
 
         let self_ip = "10.0.0.1";
-        let peer = "10.0.0.2";
-        let sync_port = 9092; // dial port; only used to format the peer endpoint
-        let peer_endpoint = format!("tcp://{}", authority(peer, sync_port));
+        let peer_a = "10.0.0.2";
+        let peer_b = "10.0.0.3";
+        let sync_port = 9192;
         let mut known = BTreeSet::new();
+        let mut writer = Writer::<EndpointSlice>::default();
+        let store = writer.as_reader();
 
-        // 1) Sibling serving normally -> registered.
-        let store = store_from_slices(vec![slice_with_serving(peer, false, true)]);
+        let mut initial = slice_with(&[self_ip, peer_a], None, "IPv4");
+        initial.metadata.name = Some("epp-peers".to_string());
+        writer.apply_watcher_event(&watcher::Event::Init);
+        writer.apply_watcher_event(&watcher::Event::InitApply(initial));
+        writer.apply_watcher_event(&watcher::Event::InitDone);
         reconcile_once(&service, &store, sync_port, self_ip, &mut known).await;
-        assert!(
-            service.list_replica_peers().contains(&peer_endpoint),
-            "a live sibling must be registered"
+        assert_eq!(
+            service.list_replica_peers(),
+            vec![format!("tcp://{}", authority(peer_a, sync_port))]
         );
 
-        // 2) Sibling enters termination but is still serving -> RETAINED, so its
-        //    final PrefillComplete/Free events can still be delivered.
-        let store = store_from_slices(vec![slice_with_serving(peer, true, true)]);
+        let mut updated = slice_with(&[self_ip, peer_b], None, "IPv4");
+        updated.metadata.name = Some("epp-peers".to_string());
+        writer.apply_watcher_event(&watcher::Event::Apply(updated));
         reconcile_once(&service, &store, sync_port, self_ip, &mut known).await;
-        assert!(
-            service.list_replica_peers().contains(&peer_endpoint),
-            "a draining (terminating+serving) sibling must stay registered"
-        );
-
-        // 3) Sibling stops serving -> still RETAINED
-        let store = store_from_slices(vec![slice_with_serving(peer, true, false)]);
-        reconcile_once(&service, &store, sync_port, self_ip, &mut known).await;
-        assert!(
-            service.list_replica_peers().contains(&peer_endpoint),
-            "a sibling that stopped serving must stay registered"
-        );
-
-        // 4) Sibling disappears -> truly done, deregistered.
-        let store = store_from_slices(vec![]);
-        reconcile_once(&service, &store, sync_port, self_ip, &mut known).await;
-        assert!(
-            !service.list_replica_peers().contains(&peer_endpoint),
-            "a sibling that disappears must be deregistered"
+        assert_eq!(
+            service.list_replica_peers(),
+            vec![format!("tcp://{}", authority(peer_b, sync_port))]
         );
 
         service.shutdown().await;

--- a/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
@@ -144,9 +144,8 @@ fn is_ipv6(ip: &str) -> bool {
     ip.contains(':')
 }
 
-/// Collects peer IPs for the requested address family. Includes not-ready peers
-/// and terminating peers that are still serving to preserve synchronization
-/// while they start or drain.
+/// Collects peer IPs for the requested address family. Membership follows
+/// EndpointSlice membership regardless of endpoint conditions.
 fn peer_ips<'a>(
     slices: impl Iterator<Item = &'a EndpointSlice>,
     want_ipv6: bool,

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -9,7 +9,6 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 
 use anyhow::{Result, anyhow};
 
@@ -82,10 +81,6 @@ pub struct Selector {
     /// `Drop` tears down its core + replica-sync tasks.
     cancel: CancellationToken,
     reconcile_state: Mutex<ReconcileState>,
-    /// Peer-discovery readiness in replicated mode: `None` when replication is
-    /// disabled (single replica, always ready), or `Some(flag)` that latches
-    /// `true` once the initial peer-set sync completes. ANDed into EPP health.
-    peer_ready: Option<Arc<AtomicBool>>,
 }
 
 /// Local bookkeeping for desired-state reconciliation.
@@ -137,26 +132,21 @@ impl Selector {
         );
 
         let cancel = CancellationToken::new();
-        let peer_ready = if let Some(peer_service) = peer_service {
-            Some(
-                crate::peer_discovery::spawn(
-                    service.clone(),
-                    &cfg.namespace,
-                    peer_service,
-                    cfg.replica_sync_port,
-                    cfg.pod_ip
-                        .clone()
-                        .expect("validated peer discovery config must include POD_IP"),
-                    cancel.clone(),
-                )
-                .await?,
+        if let Some(peer_service) = peer_service {
+            crate::peer_discovery::spawn(
+                service.clone(),
+                &cfg.namespace,
+                peer_service,
+                cfg.replica_sync_port,
+                cfg.pod_ip
+                    .clone()
+                    .expect("validated peer discovery config must include POD_IP"),
+                cancel.clone(),
             )
-        } else {
-            None
-        };
-
+            .await?;
+        }
         tracing::info!(
-            replicated = peer_ready.is_some(),
+            replicated = peer_service.is_some(),
             "Initialized in-process selection service"
         );
 
@@ -164,7 +154,6 @@ impl Selector {
             service,
             cancel,
             reconcile_state: Mutex::new(ReconcileState::default()),
-            peer_ready,
         })
     }
 
@@ -184,10 +173,6 @@ impl Selector {
             );
         }
         Ok(())
-    }
-
-    pub fn peer_ready(&self) -> Option<Arc<AtomicBool>> {
-        self.peer_ready.clone()
     }
 
     fn worker_request(reg: &WorkerRegistration) -> CoreWorkerRequest {

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -791,6 +791,15 @@ worker_selection:
     }
 
     #[tokio::test]
+    async fn selector_without_peer_service_disables_replica_sync() {
+        let selector = Selector::new(&test_config(), WorkerSelectionPolicyRegistry::default())
+            .await
+            .expect("selector should build");
+
+        assert_eq!(selector.service.replica_sync_port(), None);
+    }
+
+    #[tokio::test]
     async fn queueing_model_rejects_missing_capacity_before_peer_discovery() {
         let policy_file = model_policy_file();
         let mut cfg = test_config();

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -154,10 +154,10 @@ impl Selector {
 
     async fn replication(cfg: &EppStandaloneConfig) -> Result<Option<(String, u16)>> {
         match &cfg.peer_service {
-            Some(name) => Ok(Some((
-                name.clone(),
-                crate::peer_discovery::resolve_replica_sync_port(&cfg.namespace, name).await?,
-            ))),
+            Some(name) => {
+                crate::peer_discovery::ensure_peer_service_exists(&cfg.namespace, name).await?;
+                Ok(Some((name.clone(), cfg.replica_sync_port)))
+            }
             None => Ok(None),
         }
     }
@@ -436,6 +436,7 @@ models:
         EppStandaloneConfig {
             selector_threads: 1,
             peer_service: None,
+            replica_sync_port: 9092,
             inference_pool_name: "test-pool".to_string(),
             namespace: "test-ns".to_string(),
             model_name: "test-model".to_string(),

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -113,16 +113,20 @@ impl Selector {
         Self::validate_queueing_worker_capacity(cfg, &kv_router_config)?;
 
         warn_for_unserved_worker_selection_policies(&kv_router_config, &[WorkerType::Aggregated])?;
-        let peer_service = cfg.peer_service.as_deref();
-        if let Some(peer_service) = peer_service {
-            crate::peer_discovery::ensure_peer_service_exists(&cfg.namespace, peer_service).await?;
+        let peer_replication = cfg.peer_replication.as_ref();
+        if let Some(peer_replication) = peer_replication {
+            crate::peer_discovery::ensure_peer_service_exists(
+                &cfg.namespace,
+                &peer_replication.service_name,
+            )
+            .await?;
         }
 
         let mut builder =
             SelectionServiceBuilder::new(kv_router_config, WorkerType::Aggregated, policy_registry)
                 .indexer_threads(cfg.selector_threads);
-        if peer_service.is_some() {
-            builder = builder.replica_sync(cfg.replica_sync_port, Vec::new());
+        if let Some(peer_replication) = peer_replication {
+            builder = builder.replica_sync(peer_replication.sync_port, Vec::new());
         }
         let service = Arc::new(
             builder
@@ -132,21 +136,19 @@ impl Selector {
         );
 
         let cancel = CancellationToken::new();
-        if let Some(peer_service) = peer_service {
+        if let Some(peer_replication) = peer_replication {
             crate::peer_discovery::spawn(
                 service.clone(),
                 &cfg.namespace,
-                peer_service,
-                cfg.replica_sync_port,
-                cfg.pod_ip
-                    .clone()
-                    .expect("validated peer discovery config must include POD_IP"),
+                &peer_replication.service_name,
+                peer_replication.sync_port,
+                peer_replication.pod_ip.clone(),
                 cancel.clone(),
             )
             .await?;
         }
         tracing::info!(
-            replicated = peer_service.is_some(),
+            replicated = peer_replication.is_some(),
             "Initialized in-process selection service"
         );
 
@@ -396,9 +398,7 @@ models:
     fn test_config() -> EppStandaloneConfig {
         EppStandaloneConfig {
             selector_threads: 1,
-            peer_service: None,
-            pod_ip: None,
-            replica_sync_port: 9092,
+            peer_replication: None,
             inference_pool_name: "test-pool".to_string(),
             namespace: "test-ns".to_string(),
             model_name: "test-model".to_string(),
@@ -791,7 +791,7 @@ worker_selection:
     }
 
     #[tokio::test]
-    async fn selector_without_peer_service_disables_replica_sync() {
+    async fn selector_without_peer_replication_disables_replica_sync() {
         let selector = Selector::new(&test_config(), WorkerSelectionPolicyRegistry::default())
             .await
             .expect("selector should build");
@@ -805,7 +805,11 @@ worker_selection:
         let mut cfg = test_config();
         cfg.model_name = "queueing-model".to_string();
         cfg.max_num_batched_tokens = None;
-        cfg.peer_service = Some("unreachable-peer-service".to_string());
+        cfg.peer_replication = Some(crate::epp_standalone_config::PeerReplicationConfig {
+            service_name: "unreachable-peer-service".to_string(),
+            pod_ip: "10.0.0.10".to_string(),
+            sync_port: 9092,
+        });
 
         let error = Selector::new_with_kv_router_config(
             &cfg,

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -170,18 +170,10 @@ impl Selector {
         let cancel = CancellationToken::new();
 
         let peer_ready = if let Some((service_name, peer_sync_port)) = replication {
-            // In replicated mode, we need to exclude ourselves from the peer set which requires the POD_IP
-            let self_ip = std::env::var("POD_IP")
-                .ok()
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .ok_or_else(|| {
-                    anyhow!(
-                        "DYN_EPP_PEER_SERVICE is set but POD_IP is unavailable; inject POD_IP \
-                         via the downward API (fieldRef status.podIP) so this replica can \
-                         exclude itself from its peer set"
-                    )
-                })?;
+            let self_ip = cfg
+                .pod_ip
+                .clone()
+                .expect("validated peer discovery config must include POD_IP");
             Some(
                 crate::peer_discovery::spawn(
                     service.clone(),
@@ -436,6 +428,7 @@ models:
         EppStandaloneConfig {
             selector_threads: 1,
             peer_service: None,
+            pod_ip: None,
             replica_sync_port: 9092,
             inference_pool_name: "test-pool".to_string(),
             namespace: "test-ns".to_string(),

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -10,7 +10,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 
 use dynamo_kv_router::WorkerType;
 use dynamo_kv_router::config::{KvRouterConfig, try_kv_router_config_from_dynamo_env};
@@ -20,6 +20,7 @@ use dynamo_kv_router::services::selection::{
     SelectionService, SelectionServiceBuilder, WorkerLifecycle, WorkerRequest as CoreWorkerRequest,
     WorkerSelectionPolicyRegistry, warn_for_unserved_worker_selection_policies,
 };
+use kube::Client;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
@@ -114,8 +115,18 @@ impl Selector {
 
         warn_for_unserved_worker_selection_policies(&kv_router_config, &[WorkerType::Aggregated])?;
         let peer_replication = cfg.peer_replication.as_ref();
-        if let Some(peer_replication) = peer_replication {
+        let peer_client = if peer_replication.is_some() {
+            Some(
+                Client::try_default()
+                    .await
+                    .context("building Kubernetes client for EPP peer replication")?,
+            )
+        } else {
+            None
+        };
+        if let (Some(peer_client), Some(peer_replication)) = (&peer_client, peer_replication) {
             crate::peer_discovery::ensure_peer_service_exists(
+                peer_client.clone(),
                 &cfg.namespace,
                 &peer_replication.service_name,
             )
@@ -136,8 +147,9 @@ impl Selector {
         );
 
         let cancel = CancellationToken::new();
-        if let Some(peer_replication) = peer_replication {
+        if let (Some(peer_client), Some(peer_replication)) = (peer_client, peer_replication) {
             crate::peer_discovery::spawn(
+                peer_client,
                 service.clone(),
                 &cfg.namespace,
                 &peer_replication.service_name,

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -118,12 +118,16 @@ impl Selector {
         Self::validate_queueing_worker_capacity(cfg, &kv_router_config)?;
 
         warn_for_unserved_worker_selection_policies(&kv_router_config, &[WorkerType::Aggregated])?;
-        let replication = Self::replication(cfg).await?;
+        let peer_service = cfg.peer_service.as_deref();
+        if let Some(peer_service) = peer_service {
+            crate::peer_discovery::ensure_peer_service_exists(&cfg.namespace, peer_service).await?;
+        }
+
         let mut builder =
             SelectionServiceBuilder::new(kv_router_config, WorkerType::Aggregated, policy_registry)
                 .indexer_threads(cfg.selector_threads);
-        if let Some((_, peer_sync_port)) = &replication {
-            builder = builder.replica_sync(*peer_sync_port, Vec::new());
+        if peer_service.is_some() {
+            builder = builder.replica_sync(cfg.replica_sync_port, Vec::new());
         }
         let service = Arc::new(
             builder
@@ -131,56 +135,18 @@ impl Selector {
                 .await
                 .map_err(|e| anyhow!("building embedded selection service: {e}"))?,
         );
-        Self::from_service_with_replication(cfg, service, replication).await
-    }
 
-    fn validate_queueing_worker_capacity(
-        cfg: &EppStandaloneConfig,
-        kv_router_config: &KvRouterConfig,
-    ) -> Result<()> {
-        let queueing_enabled = kv_router_config
-            .queueing_enabled(Some(&cfg.model_name))
-            .map_err(|e| anyhow!("resolving router policy for model {}: {e}", cfg.model_name))?;
-        if queueing_enabled && cfg.max_num_batched_tokens.unwrap_or(0) == 0 {
-            anyhow::bail!(
-                "DYN_EPP_MAX_NUM_BATCHED_TOKENS is required (and must be > 0) because the router \
-                 scheduling policy enables queueing for model {}; set it to the engine's \
-                 --max-num-batched-tokens",
-                cfg.model_name
-            );
-        }
-        Ok(())
-    }
-
-    async fn replication(cfg: &EppStandaloneConfig) -> Result<Option<(String, u16)>> {
-        match &cfg.peer_service {
-            Some(name) => {
-                crate::peer_discovery::ensure_peer_service_exists(&cfg.namespace, name).await?;
-                Ok(Some((name.clone(), cfg.replica_sync_port)))
-            }
-            None => Ok(None),
-        }
-    }
-
-    async fn from_service_with_replication(
-        cfg: &EppStandaloneConfig,
-        service: Arc<SelectionService>,
-        replication: Option<(String, u16)>,
-    ) -> Result<Self> {
         let cancel = CancellationToken::new();
-
-        let peer_ready = if let Some((service_name, peer_sync_port)) = replication {
-            let self_ip = cfg
-                .pod_ip
-                .clone()
-                .expect("validated peer discovery config must include POD_IP");
+        let peer_ready = if let Some(peer_service) = peer_service {
             Some(
                 crate::peer_discovery::spawn(
                     service.clone(),
                     &cfg.namespace,
-                    &service_name,
-                    peer_sync_port,
-                    self_ip,
+                    peer_service,
+                    cfg.replica_sync_port,
+                    cfg.pod_ip
+                        .clone()
+                        .expect("validated peer discovery config must include POD_IP"),
                     cancel.clone(),
                 )
                 .await?,
@@ -200,6 +166,24 @@ impl Selector {
             reconcile_state: Mutex::new(ReconcileState::default()),
             peer_ready,
         })
+    }
+
+    fn validate_queueing_worker_capacity(
+        cfg: &EppStandaloneConfig,
+        kv_router_config: &KvRouterConfig,
+    ) -> Result<()> {
+        let queueing_enabled = kv_router_config
+            .queueing_enabled(Some(&cfg.model_name))
+            .map_err(|e| anyhow!("resolving router policy for model {}: {e}", cfg.model_name))?;
+        if queueing_enabled && cfg.max_num_batched_tokens.unwrap_or(0) == 0 {
+            anyhow::bail!(
+                "DYN_EPP_MAX_NUM_BATCHED_TOKENS is required (and must be > 0) because the router \
+                 scheduling policy enables queueing for model {}; set it to the engine's \
+                 --max-num-batched-tokens",
+                cfg.model_name
+            );
+        }
+        Ok(())
     }
 
     pub fn peer_ready(&self) -> Option<Arc<AtomicBool>> {

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -129,9 +129,7 @@ mod tests {
     fn config() -> EppStandaloneConfig {
         EppStandaloneConfig {
             selector_threads: 1,
-            peer_service: None,
-            pod_ip: None,
-            replica_sync_port: 9092,
+            peer_replication: None,
             inference_pool_name: "test-pool".to_string(),
             namespace: "test-ns".to_string(),
             model_name: "Qwen/Qwen3-0.6B".to_string(),

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -130,6 +130,7 @@ mod tests {
         EppStandaloneConfig {
             selector_threads: 1,
             peer_service: None,
+            pod_ip: None,
             replica_sync_port: 9092,
             inference_pool_name: "test-pool".to_string(),
             namespace: "test-ns".to_string(),

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -130,6 +130,7 @@ mod tests {
         EppStandaloneConfig {
             selector_threads: 1,
             peer_service: None,
+            replica_sync_port: 9092,
             inference_pool_name: "test-pool".to_string(),
             namespace: "test-ns".to_string(),
             model_name: "Qwen/Qwen3-0.6B".to_string(),

--- a/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
@@ -177,7 +177,8 @@ creates the workload layer in `$NAMESPACE`:
 - Two stock vLLM workers with prefix caching, KV events, and readiness probes.
 - A `vllm-qwen-render` Service that selects those same workers and exposes their HTTP port for
   `/v1/chat/completions/render`.
-- Namespaced read-only RBAC for pods, `InferencePool`, and `EndpointSlice` resources.
+- Namespaced RBAC: `get`, `list`, and `watch` for pods, `InferencePool`, and `EndpointSlice`
+  resources; `get` for the EPP peer Service.
 - Two standalone EPP replicas and their gRPC and replica-synchronization Service.
 - An `InferencePool` and an `HTTPRoute` that attaches to the cross-namespace Gateway.
 
@@ -320,8 +321,9 @@ corresponding URL for the existing Service you reuse.
 ### Deploy a Replacement EPP
 
 Create a ServiceAccount with namespaced `get`, `list`, and `watch` access to pods, `InferencePool`
-resources, and `EndpointSlice` resources. Then create the replacement Deployment with the Dynamo EPP
-image. The environment variables belong to the EPP container in
+resources, and `EndpointSlice` resources. When you set `DYN_EPP_PEER_SERVICE`, also grant `get`
+access to Services. Then create the replacement Deployment with the Dynamo EPP image. The environment
+variables belong to the EPP container in
 `spec.template.spec.containers[].env`:
 
 ```yaml
@@ -522,7 +524,8 @@ operator-generated resource contract; that contract does not configure standalon
 | Symptom | Check |
 |---|---|
 | EPP exits with `standalone is not yet supported` | The image predates the standalone implementation. Build or select the required `dynamo-rust-epp` revision. |
-| EPP stays not ready | Confirm the pool exists, its selector is valid, at least one matching pod is Ready, and EPP RBAC can watch all three resource types. |
+| EPP stays not ready | Confirm the pool exists, its selector is valid, at least one matching pod is Ready, and EPP RBAC can watch pods, `InferencePool` resources, and `EndpointSlice` resources. |
+| EPP exits while validating its peer Service | Confirm the Service exists and EPP RBAC grants `get` access to Services. |
 | EPP reports no schedulable workers | Set `DYN_EPP_MAX_NUM_BATCHED_TOKENS` to the vLLM `--max-num-batched-tokens` value when queueing is enabled. |
 | Route has no accepted parent | Confirm `parentRefs[].namespace` names the Gateway namespace, `sectionName` names its listener, and the listener allows routes from the workload namespace. |
 | Tokenization fails | Check the render Service endpoints and call `/v1/chat/completions/render` from the EPP namespace. |

--- a/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
@@ -378,8 +378,8 @@ configuration.
 The model name, block size, event port, and maximum batched-token values in the example are one
 coherent configuration. Change them together when adapting another model or vLLM deployment.
 
-Create the replacement `dynamo-epp` Service with gRPC port `9002` and, for two replicas, the named
-`replica-agg` port. The complete ServiceAccount, RBAC, Deployment, and Service definitions are
+Create the replacement `dynamo-epp` Service with gRPC port `9002`. The complete ServiceAccount, RBAC,
+Deployment, and Service definitions are
 available in the
 [`agg.yaml` EPP resources](https://github.com/ai-dynamo/dynamo/blob/main/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml).
 
@@ -459,10 +459,11 @@ show no selection, the route is bypassing the `InferencePool`.
 
 ## EPP Replication
 
-Each EPP replica has an in-process selector and KV index. When `DYN_EPP_PEER_SERVICE` is set, replicas
-watch their own Service's `EndpointSlice` resources and discover its named TCP `replica-agg` port.
-They synchronize admission, prefill-complete, and free events so active-load accounting converges
-across replicas.
+Each EPP replica has an in-process selector and KV index. When `DYN_EPP_PEER_SERVICE` is set, the EPP
+validates that Service at startup, then watches its `EndpointSlice` resources for sibling Pod IPs. Each
+replica binds and dials `DYN_EPP_REPLICA_SYNC_PORT`, which defaults to TCP port `9092`; every EPP
+selected by the Service must use the same value. They synchronize admission, prefill-complete, and free
+events so active-load accounting converges across replicas.
 
 ```mermaid
 flowchart LR
@@ -473,15 +474,14 @@ flowchart LR
     Slices -. "discover sibling pod IPs" .-> ReplicaB
     Workers["Ready vLLM pods"] -. "KV events :5557<br/>independent index warm-up" .-> ReplicaA
     Workers -. "KV events :5557<br/>independent index warm-up" .-> ReplicaB
-    ReplicaA <-->|"replica-agg :9092<br/>admission, prefill-complete, free"| ReplicaB
+    ReplicaA <-->|"replica sync TCP :9092<br/>admission, prefill-complete, free"| ReplicaB
 ```
 
 Replica synchronization does not copy the full KV index to a new EPP. A new replica warms its index
 from live worker events and optional replay. For consistency details, see
 [Standalone Selection Service](../../developer-guide/knowledge-base/modular-components/router/standalone-selection.md).
 
-For a single EPP replica, set `spec.replicas: 1` and remove `DYN_EPP_PEER_SERVICE`, `POD_IP`, and the
-`replica-agg` Service port.
+For a single EPP replica, set `spec.replicas: 1` and remove `DYN_EPP_PEER_SERVICE` and `POD_IP`.
 
 ## Standalone EPP Configuration Reference
 
@@ -502,7 +502,8 @@ For a single EPP replica, set `spec.replicas: 1` and remove `DYN_EPP_PEER_SERVIC
 | `DYN_EPP_TOKENIZATION_TIMEOUT_MS` | No | Render request timeout; defaults to `5000`. |
 | `DYN_EPP_TOKENIZER_MAX_RESPONSE_BYTES` | No | Maximum render response size; defaults to `16777216`. |
 | `DYN_EPP_MAX_INFLIGHT_REQUESTS` | No | Concurrent EPP request guardrail; defaults to `1024`, and excess requests receive `503`. |
-| `DYN_EPP_PEER_SERVICE` | No | EPP Service used to discover sibling replicas. |
+| `DYN_EPP_PEER_SERVICE` | No | Existing EPP Service used to discover sibling replicas. Enables replica sync. |
+| `DYN_EPP_REPLICA_SYNC_PORT` | No | ZMQ port every replica binds and dials for replica sync; defaults to `9092`. All replicas selected by `DYN_EPP_PEER_SERVICE` must use the same value. |
 | `POD_IP` | With peer service | EPP pod IP used to exclude the local replica from its peer set. |
 
 ## Scope and Limitations

--- a/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
@@ -322,8 +322,12 @@ corresponding URL for the existing Service you reuse.
 
 Create a ServiceAccount with namespaced `get`, `list`, and `watch` access to pods, `InferencePool`
 resources, and `EndpointSlice` resources. When you set `DYN_EPP_PEER_SERVICE`, also grant `get`
-access to Services. Then create the replacement Deployment with the Dynamo EPP image. The environment
-variables belong to the EPP container in
+access to Services. Create the replacement `dynamo-epp` Service with gRPC port `9002` before its
+Deployment. The complete ServiceAccount, RBAC, Deployment, and Service definitions are available in
+the [`agg.yaml` EPP resources](https://github.com/ai-dynamo/dynamo/blob/main/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml).
+
+Then create the replacement Deployment with the Dynamo EPP image. The environment variables belong
+to the EPP container in
 `spec.template.spec.containers[].env`:
 
 ```yaml
@@ -379,11 +383,6 @@ configuration.
 
 The model name, block size, event port, and maximum batched-token values in the example are one
 coherent configuration. Change them together when adapting another model or vLLM deployment.
-
-Create the replacement `dynamo-epp` Service with gRPC port `9002`. The complete ServiceAccount, RBAC,
-Deployment, and Service definitions are
-available in the
-[`agg.yaml` EPP resources](https://github.com/ai-dynamo/dynamo/blob/main/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml).
 
 ### Connect the InferencePool
 

--- a/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
@@ -523,7 +523,8 @@ operator-generated resource contract; that contract does not configure standalon
 | Symptom | Check |
 |---|---|
 | EPP exits with `standalone is not yet supported` | The image predates the standalone implementation. Build or select the required `dynamo-rust-epp` revision. |
-| EPP stays not ready | Confirm the pool exists, its selector is valid, at least one matching pod is Ready, and EPP RBAC can watch pods, `InferencePool` resources, and `EndpointSlice` resources. |
+| EPP stays not ready | Confirm the pool exists, its selector is valid, at least one matching pod is Ready, and EPP RBAC can watch pods and `InferencePool` resources. |
+| EPP replicas do not sync active load | Confirm `DYN_EPP_PEER_SERVICE` names the EPP Service and EPP RBAC grants `list` and `watch` access to `EndpointSlice` resources. |
 | EPP exits while validating its peer Service | Confirm the Service exists and EPP RBAC grants `get` access to Services. |
 | EPP reports no schedulable workers | Set `DYN_EPP_MAX_NUM_BATCHED_TOKENS` to the vLLM `--max-num-batched-tokens` value when queueing is enabled. |
 | Route has no accepted parent | Confirm `parentRefs[].namespace` names the Gateway namespace, `sectionName` names its listener, and the listener allows routes from the workload namespace. |


### PR DESCRIPTION
## Summary

Review of [#13534](https://github.com/ai-dynamo/dynamo/pull/13534) showed that validating the named Service port `replica-agg` was not sufficient to remove the EndpointSlice startup dependency.

A Service `targetPort` may be omitted, numeric, or named. Omitted and numeric target ports provide a direct port number, but a named `targetPort` still requires an EndpointSlice to resolve the actual backend port. That reintroduces a transient startup race: EPP needs the replica-sync port before it can construct and bind `SelectionService`, while the initial EndpointSlice may not yet expose the resolved port—particularly during single-replica startup. The previous design handled this with EndpointSlice LIST/retry logic and also gated EPP readiness on the initial peer EndpointSlice sync.

This PR makes replica sync an explicit EPP contract instead:

- `DYN_EPP_REPLICA_SYNC_PORT` defines the direct peer-to-peer replica-sync port and defaults to `9092`.
- All EPP replicas selected by `DYN_EPP_PEER_SERVICE` must bind and dial that same port.
- The peer Service is validated only for existence; its `port` and `targetPort` are no longer used for direct replica-sync connections.
- EndpointSlices provide peer Pod-IP membership only, so incomplete or port-less slices cannot block startup or readiness.

## Code changes

- `deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs`
  - Adds `DYN_EPP_REPLICA_SYNC_PORT`, defaulting to `9092`.
  - Validates that `POD_IP` is present when `DYN_EPP_PEER_SERVICE` enables peer replication.

- `deploy/inference-gateway/ext-proc/src/selector.rs`
  - Verifies the configured peer Service exists at startup.
  - Configures `SelectionService` replica sync with the explicit port only when peer replication is enabled.
  - Starts peer discovery only when `DYN_EPP_PEER_SERVICE` is configured.

- `deploy/inference-gateway/ext-proc/src/peer_discovery.rs`
  - Removes Service/EndpointSlice named-port and `targetPort` resolution.
  - Watches EndpointSlices only to register and deregister peer Pod IPs, excluding the local `POD_IP`.
  - Dials peers using the configured replica-sync port.

- `deploy/inference-gateway/ext-proc/src/epp_router.rs`
  - Removes readiness gating on completion of the initial peer EndpointSlice sync.

- `deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml` and Kubernetes docs
  - Adds the required Service GET RBAC and `POD_IP` configuration.
  - Documents `DYN_EPP_REPLICA_SYNC_PORT`.
  - Removes the no-longer-meaningful named `replica-agg` container port.

- EPP unit tests
  - Consolidates peer-discovery cases and covers the fixed-port configuration, peer-service/POD_IP validation, self exclusion, and peer membership updates.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-ext-proc`
  - 110 unit tests passed
  - 1 integration test passed

Related to [#13534](https://github.com/ai-dynamo/dynamo/pull/13534).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for worker-type-specific selection policies, including custom policy registries.
  * Added configurable peer replica synchronization with improved validation and discovery.
  * Added warnings for configured worker policies that are not served.
  * Added support for policy-aware selection across aggregated, prefill, decode, and encode workers.

* **Bug Fixes**
  * Improved peer discovery and reconciliation during startup and EndpointSlice updates.
  * Ensured background tasks shut down cleanly.
  * Updated Kubernetes permissions and service ports for standalone deployments.

* **Documentation**
  * Updated deployment, configuration, troubleshooting, and custom-policy guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->