### PR TITLE
build(container): vLLM 0.26.0 + DSpark rejection-sampler patch (NOT FOR MERGE)

### DIFF
--- a/components/src/dynamo/vllm/errors.py
+++ b/components/src/dynamo/vllm/errors.py
@@ -4,10 +4,16 @@
 """Translate vLLM request errors into Dynamo's HTTP error boundary."""
 
 from vllm.exceptions import (
-    VLLMClientError,
     VLLMNotFoundError,
     VLLMUnprocessableEntityError,
 )
+
+try:
+    from vllm.exceptions import VLLMClientError
+except ImportError:  # vLLM < 0.27 has no client-error base class
+
+    class VLLMClientError(Exception):  # type: ignore[no-redef]
+        """Fallback base so worker endpoints import on vLLM < 0.27."""
 
 from dynamo.llm.exceptions import HttpError
 

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1060,9 +1060,7 @@ async def _translate_vllm_client_errors(
     generator: AsyncIterator[ResponseT],
 ) -> AsyncIterator[ResponseT]:
     """Keep request-side vLLM errors client-visible on worker endpoints."""
-    from vllm.exceptions import VLLMClientError
-
-    from .errors import vllm_client_error_to_http_error
+    from .errors import VLLMClientError, vllm_client_error_to_http_error
 
     try:
         async for chunk in generator:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -71,7 +71,7 @@ vllm:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: vllm/vllm-openai
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
-    runtime_image_tag: v0.27.1-ubuntu2404
+    runtime_image_tag: v0.26.0-ubuntu2404
     # Baseline is vllm-openai's TRUE base, nvidia/cuda:13.0.2-base-ubuntu24.04
     # (Docker Hub), NOT a self-baseline of the third-party vllm/vllm-openai image.
     # vllm-openai is built FROM nvidia/cuda, so this attributes everything vLLM
@@ -92,7 +92,7 @@ vllm:
     base_image_tag: 22.04
     runtime_image_tag: v0.27.1
     # baseline_sbom: not yet captured for cpu — runtime build runs without subtraction
-  vllm_omni_ref: "v0.27.0rc1"
+  vllm_omni_ref: "v0.26.0rc1"
   # vLLM 0.27.1 lacks the Transformers 5.15 heterogeneous Gemma 4 config
   # support that landed upstream after the release. Remove this pin when the
   # vLLM base images include https://github.com/vllm-project/vllm/pull/49797.

--- a/container/deps/vllm/patches/01-dspark-rejection-sampler-nan-oob.patch
+++ b/container/deps/vllm/patches/01-dspark-rejection-sampler-nan-oob.patch
@@ -1,0 +1,106 @@
+--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
++++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+@@ -108,7 +108,12 @@
+         mask=blocks_mask,
+         other=float("-inf"),
+     )
++    # PR #50183: NaN local maxes make tl.argmax return an out-of-range block
++    # index (into the padded region), causing an OOB read. Map NaN to -inf
++    # and clamp the block index so it stays in range.
++    local_max = tl.where(local_max != local_max, float("-inf"), local_max)
+     max_block_idx = tl.argmax(local_max, axis=0)
++    max_block_idx = tl.minimum(max_block_idx, vocab_num_blocks - 1)
+     return tl.load(
+         target_local_argmax_ptr + logit_idx * target_local_argmax_stride + max_block_idx
+     ).to(tl.int64)
+@@ -508,6 +513,7 @@
+     # [num_logits, num_blocks]
+     local_residual_mass_ptr,
+     local_residual_mass_stride,
++    vocab_size,
+     vocab_num_blocks,
+     PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+     HAS_DRAFT_LOGITS: tl.constexpr,
+@@ -573,6 +579,13 @@
+                     logit_idx,
+                     vocab_num_blocks,
+                     PADDED_VOCAB_NUM_BLOCKS,
++                )
++                # Issue #53029: bounds-validate before the store so an OOB
++                # token id can never escape into the sampled buffer.
++                target_argmax = tl.where(
++                    (target_argmax < 0) | (target_argmax >= vocab_size),
++                    0,
++                    target_argmax,
+                 )
+                 if SYNTHETIC_MODE:
+                     rate = tl.load(synthetic_conditional_rates_ptr + i)
+@@ -822,6 +835,7 @@
+     expanded_idx_mapping_ptr,
+     # [max_num_reqs]
+     temp_ptr,
++    vocab_size,
+     PADDED_RESAMPLE_NUM_BLOCKS: tl.constexpr,
+ ):
+     req_idx = tl.program_id(0)
+@@ -848,13 +862,33 @@
+         resampled_local_max_ptr + req_idx * resampled_local_max_stride + block,
+         mask=mask,
+         other=float("-inf"),
++    )
++    # PR #50183: NaN max values (from NaN target logits) make tl.argmax
++    # return an out-of-range block index (into the padded region), causing
++    # an OOB read of resampled_local_argmax. Map NaN to -inf and clamp the
++    # block index so argmax stays in range.
++    resampled_local_max = tl.where(
++        resampled_local_max != resampled_local_max,
++        float("-inf"),
++        resampled_local_max,
+     )
+     resampled_max_block_idx = tl.argmax(resampled_local_max, axis=0)
++    resampled_max_block_idx = tl.minimum(
++        resampled_max_block_idx, resample_num_blocks - 1
++    )
+     resampled = tl.load(
+         resampled_local_argmax_ptr
+         + req_idx * resampled_local_argmax_stride
+         + resampled_max_block_idx,
+     )
++    # Issue #53029: the resample path can produce token id == vocab_size
++    # (or other OOB ids). Bounds-validate at the store and substitute a
++    # valid fallback token (0) so downstream index_select cannot assert.
++    resampled = tl.where(
++        (resampled < 0) | (resampled >= vocab_size),
++        0,
++        resampled,
++    )
+     tl.store(
+         sampled_ptr + req_idx * sampled_stride + num_sampled,
+         resampled,
+@@ -888,6 +922,10 @@
+     use_fp64: bool = False,
+     use_block_verification: bool = False,
+ ) -> tuple[torch.Tensor, torch.Tensor]:
++    assert target_logits.ndim == 2 and target_logits.stride(-1) == 1
++    assert draft_logits is None or (
++        draft_logits.ndim == 3 and draft_logits.stride(-1) == 1
++    )
+     num_reqs = cu_num_logits.shape[0] - 1
+     num_logits, vocab_size = target_logits.shape
+     draft_logits_stride_0 = 0
+@@ -1060,6 +1098,7 @@
+         cumulative_log_p,
+         local_residual_mass,
+         local_residual_mass.stride(0) if local_residual_mass is not None else 0,
++        vocab_size,
+         vocab_num_blocks,
+         PADDED_VOCAB_NUM_BLOCKS=padded_vocab_num_blocks,
+         HAS_DRAFT_LOGITS=has_draft_logits,
+@@ -1120,6 +1159,7 @@
+         cu_num_logits,
+         expanded_idx_mapping,
+         temperature,
++        vocab_size,
+         PADDED_RESAMPLE_NUM_BLOCKS=padded_resample_num_blocks,
+     )
+     return sampled, num_sampled

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -259,6 +259,16 @@ RUN --mount=type=bind,source=./container/deps/vllm/protected_packages.txt,target
     export VLLM_OMNI_TARGET_DEVICE={{ device }}; \
     bash /tmp/install_vllm_omni.sh
 
+{% if device == "cuda" %}
+# Apply vLLM hotfixes to the installed package tree. Patches are applied with
+# --fuzz=5 to tolerate minor line-number drift across nightly builds.
+RUN --mount=type=bind,source=./container/deps/vllm/patches,target=/tmp/vllm_patches,readonly \
+    SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])')" && \
+    for p in $(ls /tmp/vllm_patches/*.patch 2>/dev/null | sort); do \
+        patch --fuzz=5 -p1 -d "${SITE_PACKAGES}" < "$p"; \
+    done
+{% endif %}
+
 {% if device == "xpu" %}
 # Remove conflicting standard triton package for XPU and reinstall triton-xpu
 # This must be done after vLLM-Omni installation to ensure no dependencies re-install triton


### PR DESCRIPTION
## DO NOT MERGE

Throwaway branch whose only purpose is to make CI build **one image**: vLLM **0.26.0** carrying the same DSpark rejection-sampler patch as the 0.27.1 image currently in use.

## Why

A three-arm study on GB200 (image and speculative decoding varied independently) attributes:

| comparison | isolates | GPQA | IFEval |
|---|---|---|---|
| control vs recipe | speculative decoding | +0.42 pt (0.1σ) | +0.56 pt (0.5σ) |
| baseline vs control | **image** | **−8.33 pt (2.8σ)** | **−3.61 pt (3.1σ)** |

`vllm-runtime:1.4.0` ships vLLM **0.26.0**; `1.5.0-ci` ships **0.27.1**. So that regression is a vLLM version delta, not a Dynamo one. This build isolates it — same patch, same recipe flags, only the vLLM version differs.

#13815 adds the patch mechanism properly and is the one intended to merge, but it inherits main's 0.27.1 (main bumped on 2026-08-25, 27f09d5bcd) and so cannot produce this arm.

## Changes

- `container/deps/vllm/patches/01-dspark-rejection-sampler-nan-oob.patch` — same file as #13815
- `container/templates/vllm_runtime.Dockerfile` — same patch-apply step
- `container/context.yaml` — **pins cuda13.0 runtime image and `vllm_omni_ref` back to 0.26.0** (this is the part that must not merge)

## Plan

Build → pull the ACR tag → run gpqa_diamond on GB200 agg and disagg against the 0.27.1 arm → close this PR.