### PR TITLE
fix(sglang): preserve pause state across tagged memory resumes

### DIFF
--- a/components/src/dynamo/sglang/pause.py
+++ b/components/src/dynamo/sglang/pause.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from sglang.srt.constants import GPU_MEMORY_ALL_TYPES
 from sglang.srt.managers.io_struct import (
     ContinueGenerationReqInput,
     PauseGenerationReqInput,
@@ -21,10 +22,14 @@ class SGLangEnginePauseController:
         self._engine = engine
         self._is_paused = False
         self._generation_paused = False
+        # Tags released and not yet resumed. Empty means nothing is offloaded, which
+        # is what ``is_paused`` reports on, so a partial resume stays "paused".
+        self._released_tags: set[str] = set()
 
     @property
     def is_paused(self) -> bool:
-        return self._is_paused
+        # Keep the worker paused while any memory region remains unmapped.
+        return self._is_paused or bool(self._released_tags)
 
     @property
     def needs_resume_recovery(self) -> bool:
@@ -54,6 +59,7 @@ class SGLangEnginePauseController:
             raise
 
         self._is_paused = True
+        self._released_tags = set(tags) if tags else set(GPU_MEMORY_ALL_TYPES)
         return True
 
     async def resume(self, tags: list[str] | None = None) -> bool:
@@ -65,6 +71,11 @@ class SGLangEnginePauseController:
                 ResumeMemoryOccupationReqInput(tags=tags),
                 None,
             )
+            self._released_tags -= set(tags) if tags else set(GPU_MEMORY_ALL_TYPES)
+            if self._released_tags:
+                # Generation must stay paused until every released region is back.
+                return True
+            self._is_paused = False
         if self._generation_paused:
             await self._engine.tokenizer_manager.continue_generation(
                 ContinueGenerationReqInput()
@@ -73,5 +84,7 @@ class SGLangEnginePauseController:
         return True
 
     def mark_resumed(self) -> None:
+        if self._released_tags:
+            return
         self._is_paused = False
         self._generation_paused = False

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -726,9 +726,10 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
             try:
                 await self._pause_controller.resume(tags)
 
-                if self.generate_endpoint is not None:
-                    await self.generate_endpoint.register_endpoint_instance()
-                self._pause_controller.mark_resumed()
+                if not self._pause_controller.is_paused:
+                    if self.generate_endpoint is not None:
+                        await self.generate_endpoint.register_endpoint_instance()
+                    self._pause_controller.mark_resumed()
 
                 return {
                     "status": "ok",

--- a/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
@@ -142,6 +142,29 @@ async def test_memory_occupation_handlers_forward_tags_exactly(handler):
 
 
 @pytest.mark.asyncio
+async def test_partial_resume_waits_for_all_memory_tags(handler):
+    await handler.release_memory_occupation({})
+
+    first_resume = await handler.resume_memory_occupation({"tags": ["weights"]})
+
+    assert first_resume["status"] == "ok"
+    assert handler._pause_controller.is_paused is True
+    handler.engine.tokenizer_manager.continue_generation.assert_not_awaited()
+    handler.generate_endpoint.register_endpoint_instance.assert_not_awaited()
+
+    second_resume = await handler.resume_memory_occupation({"tags": ["kv_cache"]})
+
+    assert second_resume["status"] == "ok"
+    assert handler._pause_controller.is_paused is False
+    handler.engine.tokenizer_manager.continue_generation.assert_awaited_once()
+    handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
+    assert [
+        call.args[0].tags
+        for call in handler.engine.tokenizer_manager.resume_memory_occupation.await_args_list
+    ] == [["weights"], ["kv_cache"]]
+
+
+@pytest.mark.asyncio
 async def test_resume_recovers_generation_pause_after_failed_release_rollback(handler):
     manager = handler.engine.tokenizer_manager
     manager.release_memory_occupation = AsyncMock(


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

In the RL rollout weight-update flow, `weights` and `kv_cache` are released together before the new weights are transferred. They must be resumed in two ordered calls: `weights` first, so the new weights can be loaded, and `kv_cache` second, so its size can be recomputed from the GPU memory remaining after the weight load. This ordering is required by the RL workflow and is not equivalent to one all-tags resume call.

Previously, the first `weights` resume cleared Dynamo's single boolean pause state. The later `kv_cache` resume was therefore treated as an idempotent no-op, leaving SGLang's KV cache pages unmapped. The worker could also be re-registered with discovery between the two calls and receive traffic before it was ready, causing the first post-update prefill to fail in a Triton kernel.

co-auther: @gongshaotian 

## Details:

<!-- Describe the changes made in this PR. -->

- Track released GPU memory regions by tag in `SGLangEnginePauseController`.
- Keep the controller paused while any released tag remains unmapped, so a second tagged resume is not swallowed by the handler's idempotency check.
- Resume generation only after all released tags have been restored.
- Re-register the worker with discovery only after the final memory region is resumed, preventing routing during the partial-resume window.
- Add a regression test covering separate `weights` and `kv_cache` resumes.

### Validation

- `python -m compileall -q components/src/dynamo/sglang/pause.py components/src/dynamo/sglang/request_handlers/handler_base.py components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py`
- `git diff --check`
- Targeted SGLang unit tests were not executable in this environment because the `sglang` package is not installed; the repository test conftest skips these tests when that dependency is unavailable.
- Ruff format validation was attempted, but `uv` could not resolve the uncached `ai-dynamo-runtime==1.5.0` dependency with offline package access.

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

@galletas1712 

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.



**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

No

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pause and resume behavior for SGLang generation when GPU memory is released in multiple regions.
  * Generation now remains paused until all released memory regions are restored, preventing premature resumption.
  * Resuming selected memory regions no longer incorrectly reactivates the endpoint before recovery is complete.

* **Tests**
  * Added coverage for partial memory restoration and final endpoint reactivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->