### PR TITLE
feat(operator): isolate rollout cohort routing

### DIFF
--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -41,6 +41,9 @@ const (
 	KubeLabelDynamoSelector = "nvidia.com/selector"
 
 	KubeAnnotationEnableGrove = "nvidia.com/enable-grove"
+	// KubeAnnotationRolloutCohortRouting opts Grove frontends into exact
+	// worker-hash namespace discovery during coherent rollouts.
+	KubeAnnotationRolloutCohortRouting = "nvidia.com/rollout-cohort-routing"
 
 	// KubeAnnotationWorkloadProvider records the controller-owned immutable graph-level workload provider.
 	KubeAnnotationWorkloadProvider = "nvidia.com/workload-provider"

--- a/deploy/operator/internal/controller/dgd_grove_workload_renderer.go
+++ b/deploy/operator/internal/controller/dgd_grove_workload_renderer.go
@@ -166,7 +166,10 @@ func applyGroveWorkerHashSuffix(
 	}
 	for i := range renderDeployment.Spec.Components {
 		component := &renderDeployment.Spec.Components[i]
-		if !dynamo.IsWorkerComponent(string(component.ComponentType)) {
+		isWorker := dynamo.IsWorkerComponent(string(component.ComponentType))
+		isCohortFrontend := component.ComponentType == nvidiacomv1beta1.ComponentTypeFrontend &&
+			rolloutCohortRoutingEnabled(renderDeployment)
+		if !isWorker && !isCohortFrontend {
 			continue
 		}
 		if component.PodTemplate == nil {
@@ -178,6 +181,13 @@ func applyGroveWorkerHashSuffix(
 		component.PodTemplate.Labels[commonconsts.KubeLabelDynamoWorkerHash] = workerHash
 	}
 	return nil
+}
+
+func rolloutCohortRoutingEnabled(dgd *nvidiacomv1beta1.DynamoGraphDeployment) bool {
+	return strings.EqualFold(
+		dgd.Annotations[commonconsts.KubeAnnotationRolloutCohortRouting],
+		commonconsts.KubeLabelValueTrue,
+	)
 }
 
 func shouldRenderGroveWorkerHashSuffix(

--- a/deploy/operator/internal/controller/dgd_grove_workload_renderer.go
+++ b/deploy/operator/internal/controller/dgd_grove_workload_renderer.go
@@ -164,11 +164,14 @@ func applyGroveWorkerHashSuffix(
 	if err != nil {
 		return fmt.Errorf("compute Grove worker hash suffix: %w", err)
 	}
+	rolloutCohortRouting := rolloutCohortRoutingEnabled(renderDeployment)
+
 	for i := range renderDeployment.Spec.Components {
 		component := &renderDeployment.Spec.Components[i]
+		// Select every worker plus the frontend that routes to this worker cohort.
 		isWorker := dynamo.IsWorkerComponent(string(component.ComponentType))
 		isCohortFrontend := component.ComponentType == nvidiacomv1beta1.ComponentTypeFrontend &&
-			rolloutCohortRoutingEnabled(renderDeployment)
+			rolloutCohortRouting
 		if !isWorker && !isCohortFrontend {
 			continue
 		}
@@ -179,6 +182,12 @@ func applyGroveWorkerHashSuffix(
 			component.PodTemplate.Labels = make(map[string]string)
 		}
 		component.PodTemplate.Labels[commonconsts.KubeLabelDynamoWorkerHash] = workerHash
+		if rolloutCohortRouting {
+			if component.PodTemplate.Annotations == nil {
+				component.PodTemplate.Annotations = make(map[string]string)
+			}
+			component.PodTemplate.Annotations[commonconsts.KubeAnnotationRolloutCohortRouting] = commonconsts.KubeLabelValueTrue
+		}
 	}
 	return nil
 }

--- a/deploy/operator/internal/controller/dgd_worker_rollout_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_worker_rollout_reconciler_test.go
@@ -260,6 +260,11 @@ func TestGroveRenderDeploymentWorkerHashSuffix(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, worker.PodTemplate)
 				assert.Equal(t, wantHash, worker.PodTemplate.Labels[consts.KubeLabelDynamoWorkerHash])
+				if tt.rolloutCohortRouting {
+					assert.Equal(t, consts.KubeLabelValueTrue, worker.PodTemplate.Annotations[consts.KubeAnnotationRolloutCohortRouting])
+				} else {
+					assert.NotContains(t, worker.PodTemplate.Annotations, consts.KubeAnnotationRolloutCohortRouting)
+				}
 			} else {
 				assert.Nil(t, worker.PodTemplate)
 			}
@@ -268,6 +273,10 @@ func TestGroveRenderDeploymentWorkerHashSuffix(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, frontend.PodTemplate)
 				assert.Equal(t, wantHash, frontend.PodTemplate.Labels[consts.KubeLabelDynamoWorkerHash])
+				assert.Equal(t, consts.KubeLabelValueTrue, frontend.PodTemplate.Annotations[consts.KubeAnnotationRolloutCohortRouting])
+
+				t.Log("Verify the DGD annotation produces exact frontend discovery in the final Grove PodSpec")
+				assertGroveCohortFrontendEnv(t, rendered, wantHash)
 			} else {
 				assert.Nil(t, frontend.PodTemplate)
 			}
@@ -275,6 +284,47 @@ func TestGroveRenderDeploymentWorkerHashSuffix(t *testing.T) {
 			assert.Nil(t, dgd.GetComponentByName("frontend").PodTemplate)
 		})
 	}
+}
+
+func assertGroveCohortFrontendEnv(t *testing.T, dgd *nvidiacomv1beta1.DynamoGraphDeployment, workerHash string) {
+	t.Helper()
+	pcs, err := dynamo.GenerateGrovePodCliqueSet(
+		context.Background(),
+		dgd,
+		&configv1alpha1.OperatorConfiguration{},
+		&commonController.RuntimeConfig{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	var frontend *grovev1alpha1.PodCliqueTemplateSpec
+	for _, clique := range pcs.Spec.Template.Cliques {
+		if clique.Labels[consts.KubeLabelDynamoComponent] == "frontend" {
+			frontend = clique
+			break
+		}
+	}
+	require.NotNil(t, frontend)
+
+	var main *corev1.Container
+	for i := range frontend.Spec.PodSpec.Containers {
+		if frontend.Spec.PodSpec.Containers[i].Name == consts.MainContainerName {
+			main = &frontend.Spec.PodSpec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, main)
+
+	envs := make(map[string]string, len(main.Env))
+	for _, env := range main.Env {
+		envs[env.Name] = env.Value
+	}
+	assert.Equal(t, "default-test-dgd-"+workerHash, envs[consts.DynamoNamespaceEnvVar])
+	assert.NotContains(t, envs, consts.DynamoNamespacePrefixEnvVar)
 }
 
 func TestShouldTriggerRollingUpdate(t *testing.T) {

--- a/deploy/operator/internal/controller/dgd_worker_rollout_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_worker_rollout_reconciler_test.go
@@ -212,12 +212,20 @@ func TestPlanUnsupportedWorkerHashTransitionDoesNotCommit(t *testing.T) {
 
 func TestGroveRenderDeploymentWorkerHashSuffix(t *testing.T) {
 	tests := []struct {
-		name             string
-		workerHashSuffix bool
+		name                   string
+		workerHashSuffix       bool
+		rolloutCohortRouting   bool
+		wantFrontendWorkerHash bool
 	}{
 		{
 			name:             "enabled",
 			workerHashSuffix: true,
+		},
+		{
+			name:                   "rollout cohort routing",
+			workerHashSuffix:       true,
+			rolloutCohortRouting:   true,
+			wantFrontendWorkerHash: true,
 		},
 		{
 			name: "disabled",
@@ -228,14 +236,23 @@ func TestGroveRenderDeploymentWorkerHashSuffix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Log("Build a DGD with the requested Grove worker suffix state")
 			dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-				"worker": {ComponentType: consts.ComponentTypeWorker},
+				"frontend": {ComponentType: consts.ComponentTypeFrontend},
+				"worker":   {ComponentType: consts.ComponentTypeWorker},
 			})
+			if tt.rolloutCohortRouting {
+				if dgd.Annotations == nil {
+					dgd.Annotations = make(map[string]string)
+				}
+				dgd.Annotations[consts.KubeAnnotationRolloutCohortRouting] = consts.KubeLabelValueTrue
+			}
 
 			t.Log("Render the Grove deployment")
 			rendered, err := groveRenderDeployment(dgd, nil, tt.workerHashSuffix)
 			require.NoError(t, err)
 			worker := rendered.GetComponentByName("worker")
 			require.NotNil(t, worker)
+			frontend := rendered.GetComponentByName("frontend")
+			require.NotNil(t, frontend)
 
 			t.Log("Verify the rendered suffix and source DGD immutability")
 			if tt.workerHashSuffix {
@@ -246,7 +263,16 @@ func TestGroveRenderDeploymentWorkerHashSuffix(t *testing.T) {
 			} else {
 				assert.Nil(t, worker.PodTemplate)
 			}
+			if tt.wantFrontendWorkerHash {
+				wantHash, err := dynamo.ComputeDGDWorkersSpecHash(dgd)
+				require.NoError(t, err)
+				require.NotNil(t, frontend.PodTemplate)
+				assert.Equal(t, wantHash, frontend.PodTemplate.Labels[consts.KubeLabelDynamoWorkerHash])
+			} else {
+				assert.Nil(t, frontend.PodTemplate)
+			}
 			assert.Nil(t, dgd.GetComponentByName("worker").PodTemplate)
+			assert.Nil(t, dgd.GetComponentByName("frontend").PodTemplate)
 		})
 	}
 }

--- a/deploy/operator/internal/dynamo/component_common.go
+++ b/deploy/operator/internal/dynamo/component_common.go
@@ -67,6 +67,7 @@ type ComponentContext struct {
 	Discovery                      DiscoveryContext
 	EPPConfig                      *v1beta1.EPPConfig
 	WorkerHashSuffix               string
+	RolloutCohortRouting           bool
 }
 
 func (b *BaseComponentDefaults) GetBaseContainer(context ComponentContext) (corev1.Container, error) {

--- a/deploy/operator/internal/dynamo/component_frontend.go
+++ b/deploy/operator/internal/dynamo/component_frontend.go
@@ -24,6 +24,12 @@ func NewFrontendDefaults() *FrontendDefaults {
 
 func (f *FrontendDefaults) GetBaseContainer(context ComponentContext) (corev1.Container, error) {
 	// Frontend doesn't need backend-specific config
+	// A rollout cohort frontend uses exact namespace discovery. The worker hash
+	// is stamped on its PodTemplate by the Grove renderer so it rolls together
+	// with, and only discovers, the matching worker cohort.
+	if context.RolloutCohortRouting && context.WorkerHashSuffix != "" {
+		context.DynamoNamespace = fmt.Sprintf("%s-%s", context.DynamoNamespace, context.WorkerHashSuffix)
+	}
 	container := f.getCommonContainer(context)
 
 	// Set default command and args
@@ -76,11 +82,13 @@ func (f *FrontendDefaults) GetBaseContainer(context ComponentContext) (corev1.Co
 			Name:  "DYN_HTTP_PORT", // TODO: need to reconcile DYNAMO_PORT and DYN_HTTP_PORT
 			Value: fmt.Sprintf("%d", commonconsts.DynamoServicePort),
 		},
-		{
+	}...)
+	if !context.RolloutCohortRouting || context.WorkerHashSuffix == "" {
+		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  commonconsts.DynamoNamespacePrefixEnvVar,
 			Value: context.DynamoNamespace,
-		},
-	}...)
+		})
+	}
 
 	return container, nil
 }

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1985,6 +1985,8 @@ func mergeFrontendSidecarDefaults(podSpec *corev1.PodSpec, sidecarName string, p
 			ParentGraphDeploymentNamespace: parentContext.ParentGraphDeploymentNamespace,
 			Discovery:                      parentContext.Discovery,
 			DynamoNamespace:                parentContext.DynamoNamespace,
+			WorkerHashSuffix:               parentContext.WorkerHashSuffix,
+			RolloutCohortRouting:           parentContext.RolloutCohortRouting,
 		}
 		frontendDefaults := NewFrontendDefaults()
 		base, err := frontendDefaults.GetBaseContainer(frontendContext)
@@ -2039,7 +2041,9 @@ func generateComponentContext(component *v1beta1.DynamoComponentDeploymentShared
 	dynamoNamespace := v1beta1.ComputeDynamoNamespace(component.GlobalDynamoNamespace, namespace, parentGraphDeploymentName)
 	var workerHashSuffix string
 	labels := GetPodTemplateLabels(component)
-	if workerHash := labels[commonconsts.KubeLabelDynamoWorkerHash]; IsWorkerComponent(string(component.ComponentType)) && workerHash != "" {
+	annotations := GetPodTemplateAnnotations(component)
+	if workerHash := labels[commonconsts.KubeLabelDynamoWorkerHash]; workerHash != "" &&
+		(IsWorkerComponent(string(component.ComponentType)) || component.ComponentType == v1beta1.ComponentTypeFrontend) {
 		workerHashSuffix = workerHash
 	}
 
@@ -2052,6 +2056,10 @@ func generateComponentContext(component *v1beta1.DynamoComponentDeploymentShared
 		DynamoNamespace:                dynamoNamespace,
 		EPPConfig:                      component.EPPConfig,
 		WorkerHashSuffix:               workerHashSuffix,
+		RolloutCohortRouting: strings.EqualFold(
+			annotations[commonconsts.KubeAnnotationRolloutCohortRouting],
+			commonconsts.KubeLabelValueTrue,
+		),
 	}
 	return componentContext
 }

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -9492,13 +9492,15 @@ func TestGenerateComponentContext_WorkerHashSuffix(t *testing.T) {
 	compCtxLegacy := generateComponentContext(betaComponent(t, componentLegacy), "dgd", "ns", 1, DiscoveryContext{Backend: "kubernetes", Mode: configv1alpha1.KubeDiscoveryModePod})
 	assert.Equal(t, commonconsts.LegacyWorkerHash, compCtxLegacy.WorkerHashSuffix)
 
-	// Frontend never gets WorkerHashSuffix, even with the label
+	// A frontend stamped with the worker hash belongs to the same rollout cohort.
 	component3 := &v1alpha1.DynamoComponentDeploymentSharedSpec{
 		ComponentType: commonconsts.ComponentTypeFrontend,
 		Labels:        map[string]string{commonconsts.KubeLabelDynamoWorkerHash: "abc123"},
+		Annotations:   map[string]string{commonconsts.KubeAnnotationRolloutCohortRouting: "TRUE"},
 	}
 	compCtx3 := generateComponentContext(betaComponent(t, component3), "dgd", "ns", 1, DiscoveryContext{Backend: "kubernetes", Mode: configv1alpha1.KubeDiscoveryModePod})
-	assert.Empty(t, compCtx3.WorkerHashSuffix)
+	assert.Equal(t, "abc123", compCtx3.WorkerHashSuffix)
+	assert.True(t, compCtx3.RolloutCohortRouting)
 }
 
 func TestWorkerDefaults_WorkerHashSuffixEnvVar(t *testing.T) {
@@ -9547,6 +9549,28 @@ func TestFrontendDefaults_NamespacePrefixEnvVar(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "DYN_NAMESPACE_PREFIX should be set on frontend")
+}
+
+func TestFrontendDefaults_RolloutCohortNamespace(t *testing.T) {
+	f := NewFrontendDefaults()
+	container, err := f.GetBaseContainer(ComponentContext{
+		DynamoNamespace:      "myns-mydgd",
+		ComponentType:        commonconsts.ComponentTypeFrontend,
+		WorkerHashSuffix:     "abc123",
+		RolloutCohortRouting: true,
+	})
+	require.NoError(t, err)
+
+	foundNamespace := false
+	for _, env := range container.Env {
+		assert.NotEqual(t, commonconsts.DynamoNamespacePrefixEnvVar, env.Name,
+			"cohort routing must not use prefix discovery")
+		if env.Name == commonconsts.DynamoNamespaceEnvVar {
+			assert.Equal(t, "myns-mydgd-abc123", env.Value)
+			foundNamespace = true
+		}
+	}
+	assert.True(t, foundNamespace, "DYN_NAMESPACE should be set on frontend")
 }
 
 func TestBaseComponentDefaults_ContainerNameOnlyInContainerDiscoveryMode(t *testing.T) {
@@ -9607,6 +9631,7 @@ func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 		wantSidecarImage        string
 		wantSidecarArgs         []string
 		wantSidecarEnvVars      map[string]string
+		wantSidecarEnvAbsent    []string
 		wantSidecarEnvFrom      int
 		wantSidecarProbes       bool
 		wantSidecarPorts        bool
@@ -9669,6 +9694,28 @@ func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 			wantSidecarEnvFrom: 1,
 			wantSidecarProbes:  true,
 			wantSidecarPorts:   true,
+		},
+		{
+			name: "frontendSidecar uses exact rollout cohort namespace",
+			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: commonconsts.ComponentTypeWorker,
+				Labels: map[string]string{
+					commonconsts.KubeLabelDynamoWorkerHash: "abc123",
+				},
+				Annotations: map[string]string{
+					commonconsts.KubeAnnotationRolloutCohortRouting: commonconsts.KubeLabelValueTrue,
+				},
+				FrontendSidecar: &v1alpha1.FrontendSidecarSpec{Image: "my-frontend:latest"},
+			},
+			parentDGDName:    "test-dgd",
+			namespace:        "test-ns",
+			wantSidecarCount: 2,
+			wantSidecarName:  commonconsts.FrontendSidecarContainerName,
+			wantSidecarImage: "my-frontend:latest",
+			wantSidecarEnvVars: map[string]string{
+				commonconsts.DynamoNamespaceEnvVar: "test-ns-test-dgd-abc123",
+			},
+			wantSidecarEnvAbsent: []string{commonconsts.DynamoNamespacePrefixEnvVar},
 		},
 		{
 			name: "frontendSidecar with custom env vars",
@@ -9843,6 +9890,11 @@ func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 				}
 				for k, v := range tt.wantSidecarEnvVars {
 					assert.Equal(t, v, envVars[k], "sidecar env var %s", k)
+				}
+			}
+			for _, absentName := range tt.wantSidecarEnvAbsent {
+				for _, env := range sidecar.Env {
+					assert.NotEqual(t, absentName, env.Name, "sidecar env var %s must be absent", absentName)
 				}
 			}
 

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -9492,7 +9492,7 @@ func TestGenerateComponentContext_WorkerHashSuffix(t *testing.T) {
 	compCtxLegacy := generateComponentContext(betaComponent(t, componentLegacy), "dgd", "ns", 1, DiscoveryContext{Backend: "kubernetes", Mode: configv1alpha1.KubeDiscoveryModePod})
 	assert.Equal(t, commonconsts.LegacyWorkerHash, compCtxLegacy.WorkerHashSuffix)
 
-	// A frontend stamped with the worker hash belongs to the same rollout cohort.
+	t.Log("Verify a frontend stamped with the worker hash joins the rollout cohort")
 	component3 := &v1alpha1.DynamoComponentDeploymentSharedSpec{
 		ComponentType: commonconsts.ComponentTypeFrontend,
 		Labels:        map[string]string{commonconsts.KubeLabelDynamoWorkerHash: "abc123"},
@@ -9552,6 +9552,7 @@ func TestFrontendDefaults_NamespacePrefixEnvVar(t *testing.T) {
 }
 
 func TestFrontendDefaults_RolloutCohortNamespace(t *testing.T) {
+	t.Log("Build frontend defaults for an enabled worker-hash cohort")
 	f := NewFrontendDefaults()
 	container, err := f.GetBaseContainer(ComponentContext{
 		DynamoNamespace:      "myns-mydgd",
@@ -9561,6 +9562,7 @@ func TestFrontendDefaults_RolloutCohortNamespace(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	t.Log("Verify exact namespace discovery replaces prefix discovery")
 	foundNamespace := false
 	for _, env := range container.Env {
 		assert.NotEqual(t, commonconsts.DynamoNamespacePrefixEnvVar, env.Name,
@@ -9609,6 +9611,15 @@ func envVarsToMap(envs []corev1.EnvVar) map[string]string {
 		out[env.Name] = env.Value
 	}
 	return out
+}
+
+func assertEnvVarsAbsent(t *testing.T, envs []corev1.EnvVar, absentNames ...string) {
+	t.Helper()
+	for _, absentName := range absentNames {
+		for _, env := range envs {
+			assert.NotEqual(t, absentName, env.Name, "env var %s must be absent", absentName)
+		}
+	}
 }
 
 func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
@@ -9892,11 +9903,7 @@ func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 					assert.Equal(t, v, envVars[k], "sidecar env var %s", k)
 				}
 			}
-			for _, absentName := range tt.wantSidecarEnvAbsent {
-				for _, env := range sidecar.Env {
-					assert.NotEqual(t, absentName, env.Name, "sidecar env var %s must be absent", absentName)
-				}
-			}
+			assertEnvVarsAbsent(t, sidecar.Env, tt.wantSidecarEnvAbsent...)
 
 			if tt.wantSidecarEnvFrom > 0 {
 				assert.Equal(t, tt.wantSidecarEnvFrom, len(sidecar.EnvFrom), "sidecar envFrom count")


### PR DESCRIPTION
## Summary

- add an opt-in nvidia.com/rollout-cohort-routing annotation for Grove deployments
- stamp the canonical worker hash and cohort annotation onto frontend PodTemplates and scope frontend discovery to the exact suffixed worker namespace
- support both standalone frontends and worker-local frontend sidecars while preserving prefix discovery by default

## Background

During a coherent cross-version rollout, old and new frontend/router instances may coexist. Prefix-based discovery lets both versions discover worker namespaces from both generations, which can mix traffic across incompatible cohorts. This change gives each frontend the same canonical worker hash as its worker cohort and uses exact namespace discovery so old routers stay with old workers and new routers stay with new workers.

This is the Dynamo data-plane part of the rollout isolation design. End-to-end grouped replacement still depends on Grove coherent update support.

## Where should the reviewer start?

- deploy/operator/internal/controller/dgd_grove_workload_renderer.go for cohort identity propagation
- deploy/operator/internal/dynamo/component_frontend.go for exact namespace discovery
- deploy/operator/internal/controller/dgd_worker_rollout_reconciler_test.go for the DGD annotation to final Grove PodSpec test

## Validation

- GOCACHE=/private/tmp/dynamo-go-cache GOLANGCI_LINT_CACHE=/private/tmp/dynamo-golangci-cache make lint
- GOCACHE=/private/tmp/dynamo-go-cache go test ./api/v1alpha1 ./api/v1beta1 ./internal/dynamo
- GOCACHE=/private/tmp/dynamo-go-cache go test ./internal/controller
- GOCACHE=/private/tmp/dynamo-go-cache make fmt vet

## Related Issues

- Relates to #13825

## Related work

- Dynamo [#12769](https://github.com/ai-dynamo/dynamo/pull/12769)
- Grove [#640](https://github.com/ai-dynamo/grove/pull/640): coherent update GREP
- Grove [#649](https://github.com/ai-dynamo/grove/pull/649): coherent rolling update implementation
- Grove [#778](https://github.com/ai-dynamo/grove/pull/778): coherent update prerequisite 1
- Grove [#792](https://github.com/ai-dynamo/grove/pull/792): coherent update prerequisite 2