### PR TITLE
test(deploy): retry transient vCluster API failures

### DIFF
--- a/tests/deploy/dgdr_utils.py
+++ b/tests/deploy/dgdr_utils.py
@@ -16,6 +16,7 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+import aiohttp
 import yaml
 from kubernetes_asyncio import client, config
 from kubernetes_asyncio.client import exceptions
@@ -38,6 +39,8 @@ _MAX_DGDR_NAME_LENGTH = (
 )
 _MAX_LABEL_VALUE_LENGTH = 63
 _NAME_DIGEST_LENGTH = 6
+_PHASE_POLL_INTERVAL_SECONDS = 5
+_TRANSIENT_API_RETRY_LIMIT = 3
 
 PHASE_ORDER = {
     "Pending": 0,
@@ -380,8 +383,29 @@ class ManagedDGDR:
         timeout = timeout or self.config.profiling_timeout
         deadline = time.monotonic() + timeout
         last_phase: str | None = None
+        transient_api_failures = 0
         while time.monotonic() < deadline:
-            result = await self.get(name)
+            # Give the vCluster watchdog a bounded window to restore its tunnel.
+            try:
+                result = await self.get(name)
+            except (aiohttp.ClientConnectionError, asyncio.TimeoutError) as error:
+                transient_api_failures += 1
+                if transient_api_failures > _TRANSIENT_API_RETRY_LIMIT:
+                    raise
+                logger.warning(
+                    "Transient Kubernetes API error while waiting for DGDR %s/%s; "
+                    "retrying in %ss (%s/%s): %s",
+                    self.config.namespace,
+                    name,
+                    _PHASE_POLL_INTERVAL_SECONDS,
+                    transient_api_failures,
+                    _TRANSIENT_API_RETRY_LIMIT,
+                    error,
+                )
+                await asyncio.sleep(_PHASE_POLL_INTERVAL_SECONDS)
+                continue
+
+            transient_api_failures = 0
             phase = result.get("status", {}).get("phase") if result else None
             if phase != last_phase:
                 logger.info("DGDR %s/%s phase: %s", self.config.namespace, name, phase)
@@ -401,7 +425,7 @@ class ManagedDGDR:
                 )
             ):
                 return result
-            await asyncio.sleep(5)
+            await asyncio.sleep(_PHASE_POLL_INTERVAL_SECONDS)
         raise TimeoutError(
             f"Timed out after {timeout}s waiting for DGDR "
             f"{self.config.namespace}/{name} to reach {target}; last phase={last_phase}"

--- a/tests/deploy/dgdr_utils.py
+++ b/tests/deploy/dgdr_utils.py
@@ -39,9 +39,6 @@ _MAX_DGDR_NAME_LENGTH = (
 )
 _MAX_LABEL_VALUE_LENGTH = 63
 _NAME_DIGEST_LENGTH = 6
-_PHASE_POLL_INTERVAL_SECONDS = 5
-_TRANSIENT_API_RETRY_LIMIT = 3
-
 PHASE_ORDER = {
     "Pending": 0,
     "Profiling": 1,
@@ -380,32 +377,35 @@ class ManagedDGDR:
     async def _wait_for_phase(
         self, name: str, target: str, at_least: bool, timeout: int | None
     ) -> dict[str, Any]:
+        poll_interval_seconds = 5
+        vcluster_connection_retry_limit = 3
         timeout = timeout or self.config.profiling_timeout
         deadline = time.monotonic() + timeout
         last_phase: str | None = None
-        transient_api_failures = 0
+        vcluster_connection_failures = 0
         while time.monotonic() < deadline:
             # Give the vCluster watchdog a bounded window to restore its tunnel.
             try:
                 result = await self.get(name)
-            except (aiohttp.ClientConnectionError, asyncio.TimeoutError) as error:
-                transient_api_failures += 1
-                if transient_api_failures > _TRANSIENT_API_RETRY_LIMIT:
+            except aiohttp.ClientConnectorError as error:
+                vcluster_connection_failures += 1
+                if vcluster_connection_failures > vcluster_connection_retry_limit:
                     raise
                 logger.warning(
-                    "Transient Kubernetes API error while waiting for DGDR %s/%s; "
-                    "retrying in %ss (%s/%s): %s",
+                    "vCluster API connection failed while waiting for DGDR %s/%s; "
+                    "the port-forward watchdog may restore the tunnel, retrying in "
+                    "%ss (%s/%s): %s",
                     self.config.namespace,
                     name,
-                    _PHASE_POLL_INTERVAL_SECONDS,
-                    transient_api_failures,
-                    _TRANSIENT_API_RETRY_LIMIT,
+                    poll_interval_seconds,
+                    vcluster_connection_failures,
+                    vcluster_connection_retry_limit,
                     error,
                 )
-                await asyncio.sleep(_PHASE_POLL_INTERVAL_SECONDS)
+                await asyncio.sleep(poll_interval_seconds)
                 continue
 
-            transient_api_failures = 0
+            vcluster_connection_failures = 0
             phase = result.get("status", {}).get("phase") if result else None
             if phase != last_phase:
                 logger.info("DGDR %s/%s phase: %s", self.config.namespace, name, phase)
@@ -425,7 +425,7 @@ class ManagedDGDR:
                 )
             ):
                 return result
-            await asyncio.sleep(_PHASE_POLL_INTERVAL_SECONDS)
+            await asyncio.sleep(poll_interval_seconds)
         raise TimeoutError(
             f"Timed out after {timeout}s waiting for DGDR "
             f"{self.config.namespace}/{name} to reach {target}; last phase={last_phase}"

--- a/tests/deploy/test_dgdr_utils.py
+++ b/tests/deploy/test_dgdr_utils.py
@@ -6,6 +6,7 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import aiohttp
 import pytest
 from kubernetes_asyncio import config
 
@@ -194,6 +195,45 @@ async def test_lifecycle_uses_deployment_timeout_after_profiling() -> None:
     )
 
     manager.wait_for_phase.assert_awaited_once_with("request", "Deployed", 11)
+
+
+@pytest.mark.timeout(30)
+async def test_wait_for_phase_retries_transient_api_connection_errors(
+    monkeypatch,
+) -> None:
+    manager = initialized_manager()
+    manager.get = AsyncMock(
+        side_effect=[
+            aiohttp.ClientConnectionError("vCluster tunnel unavailable"),
+            {"status": {"phase": "Ready"}},
+        ]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("tests.deploy.dgdr_utils.asyncio.sleep", sleep)
+
+    result = await manager.wait_for_phase("request", "Ready", timeout=30)
+
+    assert result == {"status": {"phase": "Ready"}}
+    assert manager.get.await_count == 2
+    sleep.assert_awaited_once_with(5)
+
+
+@pytest.mark.timeout(30)
+async def test_wait_for_phase_limits_transient_api_connection_retries(
+    monkeypatch,
+) -> None:
+    manager = initialized_manager()
+    manager.get = AsyncMock(
+        side_effect=aiohttp.ClientConnectionError("vCluster tunnel unavailable")
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("tests.deploy.dgdr_utils.asyncio.sleep", sleep)
+
+    with pytest.raises(aiohttp.ClientConnectionError, match="tunnel unavailable"):
+        await manager.wait_for_phase("request", "Ready", timeout=30)
+
+    assert manager.get.await_count == 4
+    assert sleep.await_count == 3
 
 
 async def test_cleanup_reports_all_failures_and_retains_failed_names() -> None:

--- a/tests/deploy/test_dgdr_utils.py
+++ b/tests/deploy/test_dgdr_utils.py
@@ -198,13 +198,17 @@ async def test_lifecycle_uses_deployment_timeout_after_profiling() -> None:
 
 
 @pytest.mark.timeout(30)
-async def test_wait_for_phase_retries_transient_api_connection_errors(
+async def test_wait_for_phase_retries_vcluster_connection_refusals(
     monkeypatch,
 ) -> None:
     manager = initialized_manager()
+    connection_key = MagicMock(host="127.0.0.1", port=1234, ssl=False)
     manager.get = AsyncMock(
         side_effect=[
-            aiohttp.ClientConnectionError("vCluster tunnel unavailable"),
+            aiohttp.ClientConnectorError(
+                connection_key,
+                ConnectionRefusedError(111, "vCluster tunnel unavailable"),
+            ),
             {"status": {"phase": "Ready"}},
         ]
     )
@@ -219,17 +223,21 @@ async def test_wait_for_phase_retries_transient_api_connection_errors(
 
 
 @pytest.mark.timeout(30)
-async def test_wait_for_phase_limits_transient_api_connection_retries(
+async def test_wait_for_phase_limits_vcluster_connection_retries(
     monkeypatch,
 ) -> None:
     manager = initialized_manager()
+    connection_key = MagicMock(host="127.0.0.1", port=1234, ssl=False)
     manager.get = AsyncMock(
-        side_effect=aiohttp.ClientConnectionError("vCluster tunnel unavailable")
+        side_effect=aiohttp.ClientConnectorError(
+            connection_key,
+            ConnectionRefusedError(111, "vCluster tunnel unavailable"),
+        )
     )
     sleep = AsyncMock()
     monkeypatch.setattr("tests.deploy.dgdr_utils.asyncio.sleep", sleep)
 
-    with pytest.raises(aiohttp.ClientConnectionError, match="tunnel unavailable"):
+    with pytest.raises(aiohttp.ClientConnectorError, match="tunnel unavailable"):
         await manager.wait_for_phase("request", "Ready", timeout=30)
 
     assert manager.get.await_count == 4


### PR DESCRIPTION
## Summary

- retry transient vCluster API connection errors while polling DGDR phases
- give the existing port-forward watchdog up to three 5-second recovery windows
- reset the retry budget after a successful API call and preserve failures for persistent outages
- add unit coverage for recovery and retry exhaustion

## Background

This addresses a flaky DGDR lifecycle failure observed on #13824. Seven lifecycle cases passed, but the final case failed when the test hit the vCluster API during a brief port-forward outage:

- Exact failed CI job: https://github.com/ai-dynamo/dynamo/actions/runs/32957117590/job/98143500996
- Error: `ClientConnectorError: Cannot connect to host 127.0.0.1:8443 ... Connection refused`

The connect-vcluster action already checks the tunnel every five seconds and restarts `kubectl port-forward`, but the DGDR phase poll currently exits on the first connection error. This change gives the watchdog a bounded window to recover without hiding a persistent outage or a real DGDR failure.

## Validation

- `.venv/bin/python -m py_compile tests/deploy/dgdr_utils.py tests/deploy/test_dgdr_utils.py`
- `git diff --check`
- Added unit coverage for successful recovery and bounded retry exhaustion
- Targeted pytest was not completed locally because the existing virtual environment was missing the Kubernetes async test dependency; CI will run the new tests


<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment phase monitoring by retrying temporary connection and timeout failures.
  * Added a five-second interval between retry attempts.
  * Persistent connection failures now stop after the configured retry limit and report the error clearly.
* **Tests**
  * Added coverage for successful recovery after a temporary API connection failure.
  * Added coverage confirming repeated failures are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
