### PR TITLE
docs: fix typo unforseen -> unforeseen

### DIFF
--- a/tests/fault_tolerance/deploy/README.md
+++ b/tests/fault_tolerance/deploy/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 As a large scale distributed inference serving framework in addition
 to providing high throughput and low latency, Dynamo needs to
 provide fault detection, resilency, and quick recovery in the face of
-unforseen failures. In order to test Dynamo we are developing a test
+unforeseen failures. In order to test Dynamo we are developing a test
 suite to inject and measure the impact of different types of failure
 conditions.
 


### PR DESCRIPTION
One-word typo fix in `tests/fault_tolerance/deploy/README.md:23`.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in the fault tolerance test suite introduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->