### PR TITLE
chore(container): [cherry-pick 1.4.2] update to EFA Installer 1.50 (#13690)

### DIFF
--- a/container/compliance/native_packages.yaml
+++ b/container/compliance/native_packages.yaml
@@ -35,7 +35,7 @@
 packages:
   # --- EFA (Elastic Fabric Adapter) components ---
   - name: libfabric
-    version: 2.4.0amzn5.0
+    version: 2.6.0amzn1.0
     license: BSD-2-Clause
     source: https://github.com/aws/libfabric
     images:
@@ -44,7 +44,7 @@ packages:
       - sglang-runtime-efa
 
   - name: aws-ofi-nccl
-    version: 1.20.0
+    version: 1.21.1
     license: Apache-2.0
     source: https://github.com/aws/aws-ofi-nccl
     images:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -59,7 +59,7 @@ dynamo:
   nv_codec_headers_ref: "n13.0.19.0"
   libvpx_ref: "v1.14.1"
   sccache_version: "v0.14.0"
-  efa_version: 1.49.0
+  efa_version: 1.50.0
 
 vllm:
   cuda13.0:


### PR DESCRIPTION
Cherry-pick of #13690 onto `release/1.4.2`.

Original commit: ff959852b740ee5981e58a5fcf18d0d4ca2d5079 (merged to `main` Aug 25)
Type: chore — dependency version bump, no functional change
Author: @erezzarum (external contributor, AWS), co-authored by Jie Hao and Anant Sharma

## What Changed

Moves the AWS EFA installer from 1.49.0 to 1.50.0 in `container/context.yaml`, and syncs `container/compliance/native_packages.yaml` for the two packages that installer carries:

| Package | Before | After |
|---|---|---|
| `efa_version` | 1.49.0 | 1.50.0 |
| `libfabric` | 2.4.0amzn5.0 | 2.6.0amzn1.0 |
| `aws-ofi-nccl` | 1.20.0 | 1.21.1 |

## Why It Is in 1.4.2

1.4.2 is a CVE-remediation release. Keeping the EFA path on the current installer keeps the container compliance manifest accurate against what the image actually ships, which matters for the release scan.

## Conflict Report

Clean cherry-pick, no conflicts. Both files auto-merged. Applied with `git cherry-pick -x --signoff` so provenance is recorded in the commit message.

## Verification

- [ ] Container build passes on `release/1.4.2`
- [ ] Compliance scan reflects the updated `native_packages.yaml`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->