### PR TITLE
docs: add Dynamo Enterprise section

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -55,3 +55,8 @@
 # The v1.4.0 release entry lands with the current-release promotion; the tag
 # URL 404s from CI until v1.4.0 is cut. Remove after the tag exists.
 ^https://github\.com/ai-dynamo/dynamo/releases/tag/v1\.4\.0$
+
+# The Dynamo Enterprise NGC collection is not published on the public catalog
+# yet, so the canonical collection URL 404s from CI. The org and team segments
+# are correct; only the collection is missing. Remove once it is live.
+^https://catalog\.ngc\.nvidia\.com/orgs/nvidia/ai-dynamo/collections/dynamo-enterprise

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -60,3 +60,8 @@
 # yet, so the canonical collection URL 404s from CI. The org and team segments
 # are correct; only the collection is missing. Remove once it is live.
 ^https://catalog\.ngc\.nvidia\.com/orgs/nvidia/ai-dynamo/collections/dynamo-enterprise
+
+# The Dynamo Enterprise container pages are not published on the public
+# catalog yet, so their Security Scanning tab URLs 404 from CI. Remove once
+# the enterprise containers are live.
+^https://catalog\.ngc\.nvidia\.com/orgs/nvidia/teams/ai-dynamo/containers/[a-z-]+-enterprise/security$

--- a/docs/fern/components/LandingStyles.tsx
+++ b/docs/fern/components/LandingStyles.tsx
@@ -288,6 +288,18 @@ article:has(.dynamo-welcome) > header .fern-page-subtitle p {
   outline-offset: 4px;
 }
 
+.dynamo-welcome__cta--secondary {
+  background: transparent;
+  border-color: #76b900;
+  color: #d8e8c0 !important;
+}
+
+.dynamo-welcome__cta--secondary:hover {
+  background: rgba(118, 185, 0, 0.12);
+  border-color: #76b900;
+  box-shadow: none;
+}
+
 .dynamo-welcome__cta svg {
   width: 1rem;
   height: 1rem;

--- a/docs/fern/components/WelcomeHero.tsx
+++ b/docs/fern/components/WelcomeHero.tsx
@@ -203,6 +203,15 @@ export function WelcomeHero({ src }: WelcomeHeroProps) {
               <path d="m9 18 6-6-6-6" />
             </svg>
           </a>
+          <a
+            className="dynamo-welcome__cta dynamo-welcome__cta--secondary"
+            href="/dynamo/dev/reference/enterprise/overview"
+          >
+            Dynamo Enterprise
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="m9 18 6-6-6-6" />
+            </svg>
+          </a>
         </div>
       </section>
 

--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -99,6 +99,9 @@ redirects:
   # Reference variant-to-section redirects.
   - source: "/dynamo/dev/reference/releases/release-history"
     destination: "/dynamo/dev/reference/releases"
+  # Dynamo Enterprise moved out of Reference into its own top-level tab.
+  - source: "/dynamo/dev/reference/dynamo-enterprise"
+    destination: "/dynamo/dev/enterprise/overview"
   - source: "/dynamo/dev/reference/kubernetes-api"
     destination: "/dynamo/dev/reference/api/kubernetes/dynamo-graph-deployment"
   - source: "/dynamo/dev/reference/kubernetes-api/dynamo-graph-deployment"

--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -99,9 +99,9 @@ redirects:
   # Reference variant-to-section redirects.
   - source: "/dynamo/dev/reference/releases/release-history"
     destination: "/dynamo/dev/reference/releases"
-  # Dynamo Enterprise moved out of Reference into its own top-level tab.
+  # Dynamo Enterprise expanded from a single page into a Reference section.
   - source: "/dynamo/dev/reference/dynamo-enterprise"
-    destination: "/dynamo/dev/enterprise/overview"
+    destination: "/dynamo/dev/reference/enterprise/overview"
   - source: "/dynamo/dev/reference/kubernetes-api"
     destination: "/dynamo/dev/reference/api/kubernetes/dynamo-graph-deployment"
   - source: "/dynamo/dev/reference/kubernetes-api/dynamo-graph-deployment"

--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -59,6 +59,10 @@ tabs:
     display-name: Community
     icon: users
     skip-slug: true
+  enterprise:
+    display-name: Enterprise
+    icon: badge-check
+    slug: enterprise
 
 navigation:
   - tab: home
@@ -1269,3 +1273,36 @@ navigation:
               - page: Building and Publishing
                 path: pages/community/contributing/documentation/building-and-publishing.md
                 slug: building-and-publishing
+
+  # ==================== Enterprise ====================
+  # The Dynamo release artifacts that are eligible for NVIDIA Enterprise
+  # Support. These carry the -enterprise suffix and have no functional or
+  # binary differences from their open-source counterparts. Commercial
+  # support requires an NVIDIA AI Enterprise subscription; the artifacts
+  # themselves are free to download and run.
+  - tab: enterprise
+    layout:
+      - page: Overview
+        icon: circle-info
+        path: pages/enterprise/overview.mdx
+        slug: overview
+
+      - page: Supported Artifacts
+        icon: cubes
+        path: pages/enterprise/supported-artifacts.mdx
+        slug: supported-artifacts
+
+      - page: Install
+        icon: download
+        path: pages/enterprise/install.mdx
+        slug: install
+
+      - page: Support Coverage
+        icon: life-ring
+        path: pages/enterprise/support-coverage.mdx
+        slug: support-coverage
+
+      - page: Scope Boundaries
+        icon: list-check
+        path: pages/enterprise/scope-boundaries.mdx
+        slug: scope-boundaries

--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -59,10 +59,6 @@ tabs:
     display-name: Community
     icon: users
     skip-slug: true
-  enterprise:
-    display-name: Enterprise
-    icon: badge-check
-    slug: enterprise
 
 navigation:
   - tab: home
@@ -1195,6 +1191,32 @@ navigation:
           - page: Overview
             path: pages/reference/nixl-connect/overview.mdx
 
+      # The Dynamo release artifacts eligible for NVIDIA Enterprise Support.
+      # Same binaries as the open-source artifacts; the -enterprise suffix
+      # marks the curated publication channel and the commercial support
+      # boundary. Commercial support requires an NVIDIA AI Enterprise
+      # subscription; the artifacts are free to download and run.
+      - section: Enterprise
+        icon: badge-check
+        slug: enterprise
+        collapsed: true
+        contents:
+          - page: Overview
+            path: pages/enterprise/overview.mdx
+            slug: overview
+          - page: Supported Artifacts
+            path: pages/enterprise/supported-artifacts.mdx
+            slug: supported-artifacts
+          - page: Install
+            path: pages/enterprise/install.mdx
+            slug: install
+          - page: Support Coverage
+            path: pages/enterprise/support-coverage.mdx
+            slug: support-coverage
+          - page: Scope Boundaries
+            path: pages/enterprise/scope-boundaries.mdx
+            slug: scope-boundaries
+
       - page: Glossary
         icon: book-open
         path: pages/reference/general/glossary.md
@@ -1273,36 +1295,3 @@ navigation:
               - page: Building and Publishing
                 path: pages/community/contributing/documentation/building-and-publishing.md
                 slug: building-and-publishing
-
-  # ==================== Enterprise ====================
-  # The Dynamo release artifacts that are eligible for NVIDIA Enterprise
-  # Support. These carry the -enterprise suffix and have no functional or
-  # binary differences from their open-source counterparts. Commercial
-  # support requires an NVIDIA AI Enterprise subscription; the artifacts
-  # themselves are free to download and run.
-  - tab: enterprise
-    layout:
-      - page: Overview
-        icon: circle-info
-        path: pages/enterprise/overview.mdx
-        slug: overview
-
-      - page: Supported Artifacts
-        icon: cubes
-        path: pages/enterprise/supported-artifacts.mdx
-        slug: supported-artifacts
-
-      - page: Install
-        icon: download
-        path: pages/enterprise/install.mdx
-        slug: install
-
-      - page: Support Coverage
-        icon: life-ring
-        path: pages/enterprise/support-coverage.mdx
-        slug: support-coverage
-
-      - page: Scope Boundaries
-        icon: list-check
-        path: pages/enterprise/scope-boundaries.mdx
-        slug: scope-boundaries

--- a/docs/fern/pages/enterprise/install.mdx
+++ b/docs/fern/pages/enterprise/install.mdx
@@ -1,0 +1,95 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Install
+subtitle: Pull the enterprise images and Helm chart, and reference them from your deployments.
+---
+
+The Dynamo Enterprise install path parallels the open-source install path. It uses the same Kubernetes shape, the same values, and the same operational surface. The substantive differences are the container image references and the Helm chart name.
+
+For the full walkthrough of cluster prerequisites, accelerator support, optional multinode orchestration, RDMA, Prometheus, and shared model storage, follow the [Kubernetes Installation Guide](../kubernetes/installation/install-dynamo.md). The steps below cover only what changes for the enterprise images and chart.
+
+## Container Images
+
+The enterprise images are public. Anonymous `docker pull` works from any host with network access to `nvcr.io`. Environments that require authenticated pulls (a bastion registry, an air-gapped mirror, or a policy that blocks anonymous access to `nvcr.io`) can configure an NGC API key on the pulling host; see the [NGC User Guide](https://docs.nvidia.com/ngc/ngc-catalog-user-guide/index.html) for the API-key workflow.
+
+```bash
+docker pull nvcr.io/nvidia/dynamo-enterprise/sglang-runtime-enterprise:1.4.1
+docker pull nvcr.io/nvidia/dynamo-enterprise/tensorrtllm-runtime-enterprise:1.4.1
+docker pull nvcr.io/nvidia/dynamo-enterprise/vllm-runtime-enterprise:1.4.1
+docker pull nvcr.io/nvidia/dynamo-enterprise/dynamo-frontend-enterprise:1.4.1
+docker pull nvcr.io/nvidia/dynamo-enterprise/kubernetes-operator-enterprise:1.4.1
+```
+
+Kubernetes clusters that already pull from `nvcr.io` need no additional pull secret for the enterprise images. Air-gapped and internal-mirror installs should retag these into the internal registry using the same repository names and versions to keep the manifests portable.
+
+## Platform Helm Chart
+
+The enterprise Helm chart installs the Dynamo Operator, using the enterprise Operator image. etcd, NATS, KAI Scheduler, Grove, and Snapshot ship as bundled subcharts that are all disabled by default; enable the ones a deployment needs, or point the operator at instances you already run. The chart shape, its values, and its Kubernetes surface match the open-source `dynamo-platform` chart. The differences are the chart name and the default image references the chart resolves to.
+
+```bash
+export NAMESPACE=dynamo-system
+export RELEASE_VERSION=1.4.1
+
+helm fetch https://helm.ngc.nvidia.com/nvidia/dynamo-enterprise/charts/dynamo-platform-enterprise-$RELEASE_VERSION.tgz
+helm install dynamo-platform dynamo-platform-enterprise-$RELEASE_VERSION.tgz \
+  --namespace $NAMESPACE \
+  --create-namespace
+```
+
+Verify the operator:
+
+```bash
+kubectl get crd | grep dynamo
+kubectl get pods -n $NAMESPACE
+```
+
+The expected CRDs and pods are the same as in the open-source install; see the [Kubernetes Installation Guide](../kubernetes/installation/install-dynamo.md) for the full verification and troubleshooting steps, and for the values that enable the optional subcharts.
+
+## Runtime Images in Deployments
+
+The Dynamo Operator watches `DynamoGraphDeployment` (DGD) resources. Deployments that must run on the enterprise runtime images reference them by their full `dynamo-enterprise` path in the DGD spec. A minimal example:
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: my-agg-deployment
+  namespace: dynamo-system
+spec:
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/dynamo-enterprise/dynamo-frontend-enterprise:1.4.1
+    - name: VllmWorker
+      type: worker
+      replicas: 1
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/dynamo-enterprise/vllm-runtime-enterprise:1.4.1
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              command:
+                - python3
+                - -m
+                - dynamo.vllm
+              args:
+                - --model
+                - your-org/your-model
+```
+
+For the full DGD walkthrough (choosing a model, sizing parallelism, applying and testing the deployment), see [Deploy with DGD](../kubernetes/model-deployment/deploy-with-dgd.md).
+
+## Differences from the Open-Source Install
+
+- **Image references.** Enterprise images resolve under `nvcr.io/nvidia/dynamo-enterprise/`; open-source images resolve under `nvcr.io/nvidia/ai-dynamo/`. The enterprise repository names also carry an `-enterprise` suffix.
+- **Helm chart.** Enterprise chart: `dynamo-platform-enterprise`. Open-source chart: `dynamo-platform`. The values schema is the same.
+- **Support scope.** Only the images and chart listed above are eligible for commercial support. The Python wheels, Rust crates, and non-listed component containers in the same release remain community-supported.

--- a/docs/fern/pages/enterprise/install.mdx
+++ b/docs/fern/pages/enterprise/install.mdx
@@ -14,11 +14,11 @@ For the full walkthrough of cluster prerequisites, accelerator support, optional
 The enterprise images are public. Anonymous `docker pull` works from any host with network access to `nvcr.io`. Environments that require authenticated pulls (a bastion registry, an air-gapped mirror, or a policy that blocks anonymous access to `nvcr.io`) can configure an NGC API key on the pulling host; see the [NGC User Guide](https://docs.nvidia.com/ngc/ngc-catalog-user-guide/index.html) for the API-key workflow.
 
 ```bash
-docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime-enterprise:1.4.1
-docker pull nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime-enterprise:1.4.1
-docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime-enterprise:1.4.1
-docker pull nvcr.io/nvidia/ai-dynamo/dynamo-frontend-enterprise:1.4.1
-docker pull nvcr.io/nvidia/ai-dynamo/kubernetes-operator-enterprise:1.4.1
+docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime-enterprise:1.4.2
+docker pull nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime-enterprise:1.4.2
+docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime-enterprise:1.4.2
+docker pull nvcr.io/nvidia/ai-dynamo/dynamo-frontend-enterprise:1.4.2
+docker pull nvcr.io/nvidia/ai-dynamo/kubernetes-operator-enterprise:1.4.2
 ```
 
 Kubernetes clusters that already pull from `nvcr.io` need no additional pull secret for the enterprise images. Air-gapped and internal-mirror installs should retag these into the internal registry using the same repository names and versions to keep the manifests portable.
@@ -29,7 +29,7 @@ The enterprise Helm chart installs the Dynamo Operator, using the enterprise Ope
 
 ```bash
 export NAMESPACE=dynamo-system
-export RELEASE_VERSION=1.4.1
+export RELEASE_VERSION=1.4.2
 
 helm fetch https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-enterprise-$RELEASE_VERSION.tgz
 helm install dynamo-platform dynamo-platform-enterprise-$RELEASE_VERSION.tgz \
@@ -65,7 +65,7 @@ spec:
         spec:
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend-enterprise:1.4.1
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend-enterprise:1.4.2
     - name: VllmWorker
       type: worker
       replicas: 1
@@ -73,7 +73,7 @@ spec:
         spec:
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-enterprise:1.4.1
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-enterprise:1.4.2
               envFrom:
                 - secretRef:
                     name: hf-token-secret

--- a/docs/fern/pages/enterprise/install.mdx
+++ b/docs/fern/pages/enterprise/install.mdx
@@ -14,11 +14,11 @@ For the full walkthrough of cluster prerequisites, accelerator support, optional
 The enterprise images are public. Anonymous `docker pull` works from any host with network access to `nvcr.io`. Environments that require authenticated pulls (a bastion registry, an air-gapped mirror, or a policy that blocks anonymous access to `nvcr.io`) can configure an NGC API key on the pulling host; see the [NGC User Guide](https://docs.nvidia.com/ngc/ngc-catalog-user-guide/index.html) for the API-key workflow.
 
 ```bash
-docker pull nvcr.io/nvidia/dynamo-enterprise/sglang-runtime-enterprise:1.4.1
-docker pull nvcr.io/nvidia/dynamo-enterprise/tensorrtllm-runtime-enterprise:1.4.1
-docker pull nvcr.io/nvidia/dynamo-enterprise/vllm-runtime-enterprise:1.4.1
-docker pull nvcr.io/nvidia/dynamo-enterprise/dynamo-frontend-enterprise:1.4.1
-docker pull nvcr.io/nvidia/dynamo-enterprise/kubernetes-operator-enterprise:1.4.1
+docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime-enterprise:1.4.1
+docker pull nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime-enterprise:1.4.1
+docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime-enterprise:1.4.1
+docker pull nvcr.io/nvidia/ai-dynamo/dynamo-frontend-enterprise:1.4.1
+docker pull nvcr.io/nvidia/ai-dynamo/kubernetes-operator-enterprise:1.4.1
 ```
 
 Kubernetes clusters that already pull from `nvcr.io` need no additional pull secret for the enterprise images. Air-gapped and internal-mirror installs should retag these into the internal registry using the same repository names and versions to keep the manifests portable.
@@ -31,7 +31,7 @@ The enterprise Helm chart installs the Dynamo Operator, using the enterprise Ope
 export NAMESPACE=dynamo-system
 export RELEASE_VERSION=1.4.1
 
-helm fetch https://helm.ngc.nvidia.com/nvidia/dynamo-enterprise/charts/dynamo-platform-enterprise-$RELEASE_VERSION.tgz
+helm fetch https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-enterprise-$RELEASE_VERSION.tgz
 helm install dynamo-platform dynamo-platform-enterprise-$RELEASE_VERSION.tgz \
   --namespace $NAMESPACE \
   --create-namespace
@@ -48,7 +48,7 @@ The expected CRDs and pods are the same as in the open-source install; see the [
 
 ## Runtime Images in Deployments
 
-The Dynamo Operator watches `DynamoGraphDeployment` (DGD) resources. Deployments that must run on the enterprise runtime images reference them by their full `dynamo-enterprise` path in the DGD spec. A minimal example:
+The Dynamo Operator watches `DynamoGraphDeployment` (DGD) resources. Deployments that must run on the enterprise runtime images reference them by their full `-enterprise` image path in the DGD spec. A minimal example:
 
 ```yaml
 apiVersion: nvidia.com/v1beta1
@@ -65,7 +65,7 @@ spec:
         spec:
           containers:
             - name: main
-              image: nvcr.io/nvidia/dynamo-enterprise/dynamo-frontend-enterprise:1.4.1
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend-enterprise:1.4.1
     - name: VllmWorker
       type: worker
       replicas: 1
@@ -73,7 +73,7 @@ spec:
         spec:
           containers:
             - name: main
-              image: nvcr.io/nvidia/dynamo-enterprise/vllm-runtime-enterprise:1.4.1
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-enterprise:1.4.1
               envFrom:
                 - secretRef:
                     name: hf-token-secret
@@ -90,6 +90,6 @@ For the full DGD walkthrough (choosing a model, sizing parallelism, applying and
 
 ## Differences from the Open-Source Install
 
-- **Image references.** Enterprise images resolve under `nvcr.io/nvidia/dynamo-enterprise/`; open-source images resolve under `nvcr.io/nvidia/ai-dynamo/`. The enterprise repository names also carry an `-enterprise` suffix.
+- **Image references.** Enterprise and open-source images both resolve under `nvcr.io/nvidia/ai-dynamo/`. The enterprise repository names carry an `-enterprise` suffix, which is the only difference.
 - **Helm chart.** Enterprise chart: `dynamo-platform-enterprise`. Open-source chart: `dynamo-platform`. The values schema is the same.
 - **Support scope.** Only the images and chart listed above are eligible for commercial support. The Python wheels, Rust crates, and non-listed component containers in the same release remain community-supported.

--- a/docs/fern/pages/enterprise/overview.mdx
+++ b/docs/fern/pages/enterprise/overview.mdx
@@ -19,7 +19,7 @@ Dynamo Enterprise covers a defined set of container images and the platform Helm
 | --- | --- |
 | Commercial support for the six artifacts listed under [Supported Artifacts](supported-artifacts.mdx), under an active NVAIE subscription | Every other Dynamo container, wheel, chart, or crate, and model deployment recipes (see [Recipes and Validated Configurations](scope-boundaries.mdx#recipes-and-validated-configurations)) |
 | Fix-forward defect resolution on the supported release line | Backports to earlier releases and on-demand off-cycle releases |
-| The hardware, operating systems, and architectures listed in the published [Compatibility](https://docs.nvidia.com/dynamo/latest/reference/compatibility) matrix | Individual models, and platforms outside the Compatibility matrix |
+| The hardware, operating systems, and architectures listed in the published [Compatibility](../reference/general/compatibility.mdx) matrix | Individual models, and platforms outside the Compatibility matrix |
 
 ## Access and Support
 
@@ -41,6 +41,6 @@ Binary equivalence does not extend commercial support to an unlisted artifact, t
 
 ## Get Help
 
-- **Commercial support cases.** Open cases through [NVIDIA Enterprise Support](https://www.nvidia.com/en-us/data-center/products/ai-enterprise-suite/support/) with an active NVAIE subscription. Route Dynamo Enterprise cases against the Dynamo product designation so they reach the Dynamo support pool.
+- **Commercial support cases.** Open cases through the [NVIDIA Enterprise Support portal](https://enterprise-support.nvidia.com/s/create-case) with an active NVAIE subscription. Route Dynamo Enterprise cases against the Dynamo product designation so they reach the Dynamo support pool.
 - **Subscription and account questions.** For NVIDIA AI Enterprise subscription management, portal access, and account-level questions, see the [NVIDIA AI Enterprise documentation](https://docs.nvidia.com/ai-enterprise/).
 - **Community and open-source discussion.** For questions and discussion that fall outside the commercial support scope, use the [ai-dynamo GitHub repository](https://github.com/ai-dynamo/dynamo) and the channels on the [Community](../community/community.mdx) page.

--- a/docs/fern/pages/enterprise/overview.mdx
+++ b/docs/fern/pages/enterprise/overview.mdx
@@ -1,0 +1,47 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Overview
+subtitle: Commercial support for a curated set of NVIDIA Dynamo release artifacts.
+---
+
+Dynamo Enterprise identifies a curated set of NVIDIA Dynamo release artifacts that are eligible for NVIDIA Enterprise Support. It is a publishing and support designation, not a separate Dynamo fork, feature tier, or runtime implementation.
+
+<Info>
+Only the exact artifacts and versions listed in [Supported Artifacts](supported-artifacts.mdx) are included in the Dynamo Enterprise support scope. Every other Dynamo artifact, including the additional tags published in the corresponding open-source repositories, is out of scope for commercial support.
+</Info>
+
+## Scope
+
+Dynamo Enterprise covers a defined set of container images and the platform Helm chart that installs the Dynamo Operator for a Kubernetes deployment. It does not add features and it does not replace the open-source Dynamo distribution.
+
+| In scope | Out of scope |
+| --- | --- |
+| The six enterprise artifacts listed under [Supported Artifacts](supported-artifacts.mdx) | Every other Dynamo container, wheel, chart, or crate |
+| Commercial support for those artifacts under an active NVAIE subscription | Model deployment recipes (see [Recipes and Validated Configurations](scope-boundaries.mdx#recipes-and-validated-configurations)) |
+| Fix-forward defect resolution on the supported release line | Backports to earlier releases and on-demand off-cycle releases |
+| Blackwell and GB200 systems | Every other GPU generation and platform |
+
+## Access and Support
+
+Dynamo Enterprise artifacts are published on NVIDIA NGC as public images. Downloading and running them does not require an [NVIDIA AI Enterprise](https://docs.nvidia.com/ai-enterprise/) subscription. An active NVIDIA AI Enterprise subscription is required to open commercial support cases against those artifacts.
+
+| Activity | Requirement |
+| --- | --- |
+| Access and download Dynamo Enterprise artifacts | No NVIDIA AI Enterprise subscription required |
+| Use the artifacts in development or production | Available at no charge; applicable license terms apply |
+| Open a commercial support case | Active NVIDIA AI Enterprise subscription required |
+
+## Relationship to Open-Source Artifacts
+
+For the same release version, a Dynamo Enterprise artifact contains the same release binaries as its corresponding open-source artifact. The `-enterprise` suffix identifies the curated publication channel and the commercial support boundary; it does not identify a separately compiled or forked build.
+
+The open-source repositories can carry additional container tags for special-purpose builds, such as dated snapshots and nightly builds. Only the tags designated for commercial support are in the enterprise support scope.
+
+Binary equivalence does not extend commercial support to an unlisted artifact, tag, component, or configuration. When commercial support is required, pull the exact `-enterprise` artifact and version listed for the applicable release.
+
+## Get Help
+
+- **Commercial support cases.** Open cases through [NVIDIA Enterprise Experience (NVEX)](https://enterprise.nvidia.com/) with an active NVAIE subscription. Route Dynamo Enterprise cases against the Dynamo product designation so they reach the Dynamo support pool.
+- **Subscription and account questions.** For NVIDIA AI Enterprise subscription management, portal access, and account-level questions, see the [NVIDIA AI Enterprise documentation](https://docs.nvidia.com/ai-enterprise/).
+- **Community and open-source discussion.** For questions and discussion that fall outside the commercial support scope, use the [ai-dynamo GitHub repository](https://github.com/ai-dynamo/dynamo) and the channels on the [Community](../community/community.mdx) page.

--- a/docs/fern/pages/enterprise/overview.mdx
+++ b/docs/fern/pages/enterprise/overview.mdx
@@ -17,10 +17,9 @@ Dynamo Enterprise covers a defined set of container images and the platform Helm
 
 | In scope | Out of scope |
 | --- | --- |
-| The six enterprise artifacts listed under [Supported Artifacts](supported-artifacts.mdx) | Every other Dynamo container, wheel, chart, or crate |
-| Commercial support for those artifacts under an active NVAIE subscription | Model deployment recipes (see [Recipes and Validated Configurations](scope-boundaries.mdx#recipes-and-validated-configurations)) |
+| Commercial support for the six artifacts listed under [Supported Artifacts](supported-artifacts.mdx), under an active NVAIE subscription | Every other Dynamo container, wheel, chart, or crate, and model deployment recipes (see [Recipes and Validated Configurations](scope-boundaries.mdx#recipes-and-validated-configurations)) |
 | Fix-forward defect resolution on the supported release line | Backports to earlier releases and on-demand off-cycle releases |
-| Blackwell and GB200 systems | Every other GPU generation and platform |
+| The hardware, operating systems, and architectures listed in the published [Compatibility](https://docs.nvidia.com/dynamo/latest/reference/compatibility) matrix | Individual models, and platforms outside the Compatibility matrix |
 
 ## Access and Support
 
@@ -42,6 +41,6 @@ Binary equivalence does not extend commercial support to an unlisted artifact, t
 
 ## Get Help
 
-- **Commercial support cases.** Open cases through [NVIDIA Enterprise Experience (NVEX)](https://enterprise.nvidia.com/) with an active NVAIE subscription. Route Dynamo Enterprise cases against the Dynamo product designation so they reach the Dynamo support pool.
+- **Commercial support cases.** Open cases through [NVIDIA Enterprise Support](https://www.nvidia.com/en-us/data-center/products/ai-enterprise-suite/support/) with an active NVAIE subscription. Route Dynamo Enterprise cases against the Dynamo product designation so they reach the Dynamo support pool.
 - **Subscription and account questions.** For NVIDIA AI Enterprise subscription management, portal access, and account-level questions, see the [NVIDIA AI Enterprise documentation](https://docs.nvidia.com/ai-enterprise/).
 - **Community and open-source discussion.** For questions and discussion that fall outside the commercial support scope, use the [ai-dynamo GitHub repository](https://github.com/ai-dynamo/dynamo) and the channels on the [Community](../community/community.mdx) page.

--- a/docs/fern/pages/enterprise/overview.mdx
+++ b/docs/fern/pages/enterprise/overview.mdx
@@ -39,6 +39,12 @@ The open-source repositories can carry additional container tags for special-pur
 
 Binary equivalence does not extend commercial support to an unlisted artifact, tag, component, or configuration. When commercial support is required, pull the exact `-enterprise` artifact and version listed for the applicable release.
 
+## Security Vulnerabilities in Open Source Packages
+
+Please review the Security Scanning tab on each Dynamo Enterprise container page for the latest security scan results: [vllm-runtime-enterprise](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/vllm-runtime-enterprise/security), [sglang-runtime-enterprise](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/sglang-runtime-enterprise/security), [tensorrtllm-runtime-enterprise](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/tensorrtllm-runtime-enterprise/security), [kubernetes-operator-enterprise](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/kubernetes-operator-enterprise/security), and [dynamo-frontend-enterprise](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/dynamo-frontend-enterprise/security).
+
+For certain open-source vulnerabilities listed in the scan results, NVIDIA provides a response in the form of a Vulnerability Exploitability eXchange (VEX) document. The VEX information can be reviewed and downloaded from the same Security Scanning tab.
+
 ## Get Help
 
 - **Commercial support cases.** Open cases through the [NVIDIA Enterprise Support portal](https://enterprise-support.nvidia.com/s/create-case) with an active NVAIE subscription. Route Dynamo Enterprise cases against the Dynamo product designation so they reach the Dynamo support pool.

--- a/docs/fern/pages/enterprise/scope-boundaries.mdx
+++ b/docs/fern/pages/enterprise/scope-boundaries.mdx
@@ -7,16 +7,14 @@ subtitle: What sits outside the Dynamo Enterprise support scope, and how it rela
 
 ## Recipes and Validated Configurations
 
-All deployment recipes published in the [Dynamo recipes repository](https://github.com/ai-dynamo/dynamo/tree/main/recipes) are validated by NVIDIA at initial publication. Validation is not the distinction between them; support is. Recipes fall outside the Dynamo Enterprise support scope, which covers the artifacts listed under [Supported Artifacts](supported-artifacts.mdx).
-
-A subset of recipes graduates to **certified recipes**, which are versioned, maintained month to month with CVE patching, and carry commercial support separately from this program. Open-source recipes ship at model release and are not maintained long-term.
-
-Treat an open-source recipe as a deployment example. Validation at initial publication does not extend commercial support to:
+All open-source deployment recipes published in the [Dynamo recipes repository](https://github.com/ai-dynamo/dynamo/tree/main/recipes) are validated by NVIDIA at initial publication. Treat an open-source recipe as a deployment example. Validation at initial publication does not extend commercial support to:
 
 - The recipe itself.
 - Every parameter or customization in the recipe.
 - Every model, hardware, runtime, topology, and workload combination the recipe touches.
 - A configuration derived from the recipe.
+
+In the future, we expect to add commercial support for a selected set of recipes. Once added, the list of supported recipes appears under [Supported Artifacts](supported-artifacts.mdx).
 
 See [Recipes](../recipes/model-recipes/overview.mdx) to browse the recipe set.
 

--- a/docs/fern/pages/enterprise/scope-boundaries.mdx
+++ b/docs/fern/pages/enterprise/scope-boundaries.mdx
@@ -7,7 +7,7 @@ subtitle: What sits outside the Dynamo Enterprise support scope, and how it rela
 
 ## Recipes and Validated Configurations
 
-All open-source deployment recipes published in the [Dynamo recipes repository](https://github.com/ai-dynamo/dynamo/tree/main/recipes) are validated by NVIDIA at initial publication. Treat an open-source recipe as a deployment example. Validation at initial publication does not extend commercial support to:
+Deployment recipes published in the [Dynamo recipes repository](https://github.com/ai-dynamo/dynamo/tree/main/recipes) carry a status of validated or experimental. A validated recipe was exercised by NVIDIA at initial publication. An experimental recipe was not. Treat an open-source recipe as a deployment example. Validation at initial publication does not extend commercial support to:
 
 - The recipe itself.
 - Every parameter or customization in the recipe.

--- a/docs/fern/pages/enterprise/scope-boundaries.mdx
+++ b/docs/fern/pages/enterprise/scope-boundaries.mdx
@@ -1,0 +1,27 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Scope Boundaries
+subtitle: What sits outside the Dynamo Enterprise support scope, and how it relates to what is inside.
+---
+
+## Recipes and Validated Configurations
+
+All deployment recipes published in the [Dynamo recipes repository](https://github.com/ai-dynamo/dynamo/tree/main/recipes) are validated by NVIDIA at initial publication. Validation is not the distinction between them; support is. Recipes fall outside the Dynamo Enterprise support scope, which covers the artifacts listed under [Supported Artifacts](supported-artifacts.mdx).
+
+A subset of recipes graduates to **certified recipes**, which are versioned, maintained month to month with CVE patching, and carry commercial support separately from this program. Open-source recipes ship at model release and are not maintained long-term.
+
+Treat an open-source recipe as a deployment example. Validation at initial publication does not extend commercial support to:
+
+- The recipe itself.
+- Every parameter or customization in the recipe.
+- Every model, hardware, runtime, topology, and workload combination the recipe touches.
+- A configuration derived from the recipe.
+
+See [Recipes](../recipes/model-recipes/overview.mdx) to browse the recipe set.
+
+## Additional Components
+
+NVIDIA plans to expand the Dynamo Enterprise support scope as additional Dynamo components complete the required productization, validation, documentation, and support-readiness work.
+
+A component is in the support scope only when its exact artifact and version are listed under [Supported Artifacts](supported-artifacts.mdx). Availability in the open-source repository, publication in a stable release, inclusion in a recipe, a maturity label, or successful operation in a customer-specific configuration does not independently establish commercial support.

--- a/docs/fern/pages/enterprise/support-coverage.mdx
+++ b/docs/fern/pages/enterprise/support-coverage.mdx
@@ -5,7 +5,7 @@ title: Support Coverage
 subtitle: What NVIDIA Enterprise Support commits to for the covered Dynamo artifacts.
 ---
 
-This page summarizes the parts of the NVIDIA Enterprise Support policy that a customer plans around. An active NVIDIA AI Enterprise subscription is required for commercial support.
+This page states what NVIDIA Enterprise Support commits to for the supported Dynamo Enterprise artifacts: how support cases are opened, the CVE remediation window, how fixes are delivered, the hardware scope, and the lifecycle policy. An active NVIDIA AI Enterprise subscription is required for commercial support.
 
 ## Support Case Intake
 
@@ -24,10 +24,6 @@ Defect fixes ship as new releases on the supported release line. NVIDIA does not
 
 Bug-fix patch releases on the supported line inherit the release line's support scope. A patch does not always carry a full QA validation pass. Design changes and new feature work land in the next release, not in a patch.
 
-## Third-Party Package Support Boundary
-
-Open-source packages that ship inside the supported enterprise artifacts are covered under this program only within a supported Dynamo release. Feature Branch previews (for example, upstream release-candidate versions integrated into a Dynamo Feature Branch build) are not covered; coverage of a package begins when the Dynamo release containing that package is designated as a Production Branch.
-
 ## Hardware Scope
 
 Support covers the hardware, operating systems, and architectures listed in the published [Compatibility](https://docs.nvidia.com/dynamo/latest/reference/compatibility) matrix and is not scoped to individual models.
@@ -42,6 +38,6 @@ For end-of-life notices across NVIDIA AI Enterprise, see [End of Life Notices](h
 
 ## Get Help
 
-- **Commercial support cases.** Open cases through [NVIDIA Enterprise Experience (NVEX)](https://enterprise.nvidia.com/) with an active NVAIE subscription. Route Dynamo Enterprise cases against the Dynamo product designation so they reach the Dynamo support pool.
+- **Commercial support cases.** Open cases through [NVIDIA Enterprise Support](https://www.nvidia.com/en-us/data-center/products/ai-enterprise-suite/support/) with an active NVAIE subscription. Route Dynamo Enterprise cases against the Dynamo product designation so they reach the Dynamo support pool.
 - **Subscription and account questions.** For NVIDIA AI Enterprise subscription management, portal access, and account-level questions, see the [NVIDIA AI Enterprise documentation](https://docs.nvidia.com/ai-enterprise/).
 - **Community and open-source discussion.** For questions and discussion that fall outside the commercial support scope, use the [ai-dynamo GitHub repository](https://github.com/ai-dynamo/dynamo) and the channels on the [Community](../community/community.mdx) page.

--- a/docs/fern/pages/enterprise/support-coverage.mdx
+++ b/docs/fern/pages/enterprise/support-coverage.mdx
@@ -35,17 +35,11 @@ Dynamo Enterprise coverage is currently scoped to Blackwell and GB200 systems. O
 
 ## Lifecycle and End-of-Life
 
-Dynamo Enterprise follows the [NVIDIA AI Enterprise Lifecycle Policy](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/index.html), under the terms for [Application Layer Software](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/application-software.html), which covers AI frameworks and SDKs. That policy defines three branch types with different support windows:
+Dynamo Enterprise is an NVIDIA AI Enterprise Feature Branch and follows the [NVIDIA AI Enterprise Lifecycle Policy](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/index.html) under the terms for [Application Layer Software](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/application-software.html).
 
-| Branch Type | Support Window | Release Cadence |
-|---|---|---|
-| Feature Branch (FB) | One month per branch | New FB monthly |
-| Production Branch (PB) | Nine months, with monthly bug fixes and security updates for high and critical vulnerabilities | New PB every six months |
-| Long-Term Support Branch (LTSB) | Extended API stability for regulated or long-certification environments | See the policy |
+Each Feature Branch is supported for one month, and NVIDIA publishes a new Feature Branch monthly. Dynamo feature releases follow roughly the same monthly cadence, so each one supersedes the previous Feature Branch and carries support forward. Bug fixes and security updates ship in subsequent releases rather than as backports to an earlier one. Because Feature Branch releases are superseded monthly, the NGC catalog collection reflects the current Feature Branch release rather than an archive of prior ones.
 
-Dynamo Enterprise is currently designated a Feature Branch. Because Feature Branch releases are superseded monthly, the NGC catalog collection reflects the current Feature Branch release rather than an archive of prior ones.
-
-For end-of-life notices across NVIDIA AI Enterprise, see [End of Life Notices](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/eol-notices.html). For guidance on which branch type fits a deployment, see [Choosing the Right Release Branch](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/choosing-a-branch.html).
+For end-of-life notices across NVIDIA AI Enterprise, see [End of Life Notices](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/eol-notices.html).
 
 ## Get Help
 

--- a/docs/fern/pages/enterprise/support-coverage.mdx
+++ b/docs/fern/pages/enterprise/support-coverage.mdx
@@ -9,7 +9,7 @@ This page states what NVIDIA Enterprise Support commits to for the supported Dyn
 
 ## Support Case Intake
 
-Commercial support cases are opened through NVIDIA Enterprise Experience (NVEX) using an active NVAIE subscription. See [Get Help](#get-help) for the entry points.
+Commercial support cases are opened through NVIDIA Enterprise Support using an active NVAIE subscription. See [Get Help](#get-help) for the entry points.
 
 ## Remediation Time on Critical and High CVEs
 
@@ -22,11 +22,11 @@ CVEs affecting the supported artifacts carry a 30-day remediation commitment for
 
 Defect fixes ship as new releases on the supported release line. NVIDIA does not backport fixes to earlier releases and does not cut on-demand off-cycle releases in response to individual cases. Cadence follows the standard Dynamo release train.
 
-Bug-fix patch releases on the supported line inherit the release line's support scope. A patch does not always carry a full QA validation pass. Design changes and new feature work land in the next release, not in a patch.
+Bug-fix patch releases on the supported line inherit the release line's support scope once their artifacts are published through the enterprise channel and listed under [Supported Artifacts](supported-artifacts.mdx). A patch does not always carry a full QA validation pass. Design changes and new feature work land in the next release, not in a patch.
 
 ## Hardware Scope
 
-Support covers the hardware, operating systems, and architectures listed in the published [Compatibility](https://docs.nvidia.com/dynamo/latest/reference/compatibility) matrix and is not scoped to individual models.
+Support covers the hardware, operating systems, and architectures listed in the published [Compatibility](../reference/general/compatibility.mdx) matrix and is not scoped to individual models.
 
 ## Lifecycle and End-of-Life
 
@@ -38,6 +38,6 @@ For end-of-life notices across NVIDIA AI Enterprise, see [End of Life Notices](h
 
 ## Get Help
 
-- **Commercial support cases.** Open cases through [NVIDIA Enterprise Support](https://www.nvidia.com/en-us/data-center/products/ai-enterprise-suite/support/) with an active NVAIE subscription. Route Dynamo Enterprise cases against the Dynamo product designation so they reach the Dynamo support pool.
+- **Commercial support cases.** Open cases through the [NVIDIA Enterprise Support portal](https://enterprise-support.nvidia.com/s/create-case) with an active NVAIE subscription. Route Dynamo Enterprise cases against the Dynamo product designation so they reach the Dynamo support pool.
 - **Subscription and account questions.** For NVIDIA AI Enterprise subscription management, portal access, and account-level questions, see the [NVIDIA AI Enterprise documentation](https://docs.nvidia.com/ai-enterprise/).
 - **Community and open-source discussion.** For questions and discussion that fall outside the commercial support scope, use the [ai-dynamo GitHub repository](https://github.com/ai-dynamo/dynamo) and the channels on the [Community](../community/community.mdx) page.

--- a/docs/fern/pages/enterprise/support-coverage.mdx
+++ b/docs/fern/pages/enterprise/support-coverage.mdx
@@ -5,18 +5,17 @@ title: Support Coverage
 subtitle: What NVIDIA Enterprise Support commits to for the covered Dynamo artifacts.
 ---
 
-This page states what NVIDIA Enterprise Support commits to for the supported Dynamo Enterprise artifacts: how support cases are opened, the CVE remediation window, how fixes are delivered, the hardware scope, and the lifecycle policy. An active NVIDIA AI Enterprise subscription is required for commercial support.
+This page states what NVIDIA Enterprise Support commits to for the supported Dynamo Enterprise artifacts: how support cases are opened, how security findings are remediated, how fixes are delivered, the hardware scope, and the lifecycle policy. An active NVIDIA AI Enterprise subscription is required for commercial support.
 
 ## Support Case Intake
 
 Commercial support cases are opened through NVIDIA Enterprise Support using an active NVAIE subscription. See [Get Help](#get-help) for the entry points.
 
-## Remediation Time on Critical and High CVEs
+## Security Remediation
 
-CVEs affecting the supported artifacts carry a 30-day remediation commitment for Critical and High severity findings. Medium and Low severity findings are addressed on a best-effort basis. Two qualifiers apply:
+Critical and High severity CVEs affecting the supported artifacts are prioritized for remediation and ship in subsequent releases on the supported line. Medium and Low severity findings are addressed on a best-effort basis.
 
-- **Clock starts at identification.** The 30-day window begins when the vulnerability is identified against a supported artifact. It does not wait on public disclosure or upstream patch availability.
-- **PSIRT track for NVIDIA-owned code.** Vulnerabilities in NVIDIA-owned code that ships inside the supported artifacts are handled through the NVIDIA Product Security Incident Response Team (PSIRT) process, on the PSIRT schedule, separate from this window. The 30-day commitment applies to vulnerabilities in the open-source packages that ship inside the supported artifacts.
+- **PSIRT track for NVIDIA-owned code.** Vulnerabilities in NVIDIA-owned code that ships inside the supported artifacts are handled through the NVIDIA Product Security Incident Response Team (PSIRT) process, on the PSIRT schedule. The remediation practice above applies to vulnerabilities in the open-source packages that ship inside the supported artifacts.
 
 ## Fix-Forward Delivery
 

--- a/docs/fern/pages/enterprise/support-coverage.mdx
+++ b/docs/fern/pages/enterprise/support-coverage.mdx
@@ -1,0 +1,46 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Support Coverage
+subtitle: What NVIDIA Enterprise Support commits to for the covered Dynamo artifacts.
+---
+
+This page summarizes the parts of the NVIDIA Enterprise Support policy that a customer plans around. A live subscription and the terms in the applicable license agreement govern the specifics.
+
+## Support Case Intake
+
+Commercial support cases are opened through NVIDIA Enterprise Experience (NVEX) using an active NVAIE subscription. See [Get Help](#get-help) for the entry points.
+
+## Response Time on Critical and High CVEs
+
+CVEs affecting the supported artifacts carry a 30-day response commitment for Critical and High severity findings. Three qualifiers apply:
+
+- **Response, not fix.** The commitment sets the time by which NVIDIA acknowledges and begins triaging the vulnerability, not the time by which a fix is available.
+- **Clock starts at identification.** The 30-day window begins when the vulnerability is identified against a supported artifact. It does not wait on public disclosure or upstream patch availability.
+- **PSIRT track for NVIDIA-owned code.** Vulnerabilities in NVIDIA-owned code that ships inside the supported artifacts are handled through the NVIDIA Product Security Incident Response Team (PSIRT) process, on the PSIRT schedule, separate from this window. The 30-day commitment applies to vulnerabilities in the open-source packages that ship inside the supported artifacts.
+
+## Fix-Forward Delivery
+
+Defect fixes ship as new releases on the supported release line. NVIDIA does not backport fixes to earlier releases and does not cut on-demand off-cycle releases in response to individual cases. Cadence follows the standard Dynamo release train.
+
+Bug-fix patch releases on the supported line inherit the release line's support scope and do not carry a separate QA validation pass. Design changes and new feature work land in the next release, not in a patch.
+
+## Third-Party Package Support Boundary
+
+Open-source packages that ship inside the supported enterprise artifacts are covered under this program only within a supported Dynamo release. Feature Branch previews (for example, upstream release-candidate versions integrated into a Dynamo Feature Branch build) are not covered; coverage of a package begins when the Dynamo release containing that package is designated as a Production Branch.
+
+## Hardware Scope
+
+Dynamo Enterprise coverage is currently scoped to Blackwell and GB200 systems. Other GPU generations are not in scope.
+
+## Lifecycle and End-of-Life
+
+An end-of-life policy for supported Dynamo Enterprise releases has not yet been published. Plan lifecycle and long-term support commitments through NVIDIA Enterprise Support until this policy is available.
+
+{/* TODO: Replace this paragraph with a link to a published EOL and lifecycle policy once available. */}
+
+## Get Help
+
+- **Commercial support cases.** Open cases through [NVIDIA Enterprise Experience (NVEX)](https://enterprise.nvidia.com/) with an active NVAIE subscription. Route Dynamo Enterprise cases against the Dynamo product designation so they reach the Dynamo support pool.
+- **Subscription and account questions.** For NVIDIA AI Enterprise subscription management, portal access, and account-level questions, see the [NVIDIA AI Enterprise documentation](https://docs.nvidia.com/ai-enterprise/).
+- **Community and open-source discussion.** For questions and discussion that fall outside the commercial support scope, use the [ai-dynamo GitHub repository](https://github.com/ai-dynamo/dynamo) and the channels on the [Community](../community/community.mdx) page.

--- a/docs/fern/pages/enterprise/support-coverage.mdx
+++ b/docs/fern/pages/enterprise/support-coverage.mdx
@@ -35,9 +35,17 @@ Dynamo Enterprise coverage is currently scoped to Blackwell and GB200 systems. O
 
 ## Lifecycle and End-of-Life
 
-An end-of-life policy for supported Dynamo Enterprise releases has not yet been published. Plan lifecycle and long-term support commitments through NVIDIA Enterprise Support until this policy is available.
+Dynamo Enterprise follows the [NVIDIA AI Enterprise Lifecycle Policy](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/index.html), under the terms for [Application Layer Software](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/application-software.html), which covers AI frameworks and SDKs. That policy defines three branch types with different support windows:
 
-{/* TODO: Replace this paragraph with a link to a published EOL and lifecycle policy once available. */}
+| Branch Type | Support Window | Release Cadence |
+|---|---|---|
+| Feature Branch (FB) | One month per branch | New FB monthly |
+| Production Branch (PB) | Nine months, with monthly bug fixes and security updates for high and critical vulnerabilities | New PB every six months |
+| Long-Term Support Branch (LTSB) | Extended API stability for regulated or long-certification environments | See the policy |
+
+Dynamo Enterprise is currently designated a Feature Branch. Because Feature Branch releases are superseded monthly, the NGC catalog collection reflects the current Feature Branch release rather than an archive of prior ones.
+
+For end-of-life notices across NVIDIA AI Enterprise, see [End of Life Notices](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/eol-notices.html). For guidance on which branch type fits a deployment, see [Choosing the Right Release Branch](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/choosing-a-branch.html).
 
 ## Get Help
 

--- a/docs/fern/pages/enterprise/support-coverage.mdx
+++ b/docs/fern/pages/enterprise/support-coverage.mdx
@@ -30,7 +30,7 @@ Support covers the hardware, operating systems, and architectures listed in the 
 
 ## Lifecycle and End-of-Life
 
-Dynamo Enterprise is an NVIDIA AI Enterprise Feature Branch and follows the [NVIDIA AI Enterprise Lifecycle Policy](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/index.html) under the terms for [Application Layer Software](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/application-software.html).
+Dynamo Enterprise is an NVIDIA AI Enterprise Feature Branch and follows the [NVIDIA AI Enterprise Lifecycle Policy](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/index.html) under the terms for [Application Layer Software](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/application-software.html). These terms apply to all six supported artifacts. The Dynamo Kubernetes Operator and the platform Helm chart are application-specific components versioned in lockstep with each Dynamo release; they follow the Dynamo product lifecycle, not the [Infrastructure Branch lifecycle](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/infrastructure-software.html) that covers cluster-wide components such as the GPU Operator.
 
 Each Feature Branch is supported for one month, and NVIDIA publishes a new Feature Branch monthly. Dynamo feature releases follow roughly the same monthly cadence, so each one supersedes the previous Feature Branch and carries support forward. Bug fixes and security updates ship in subsequent releases rather than as backports to an earlier one. Because Feature Branch releases are superseded monthly, the NGC catalog collection reflects the current Feature Branch release rather than an archive of prior ones.
 

--- a/docs/fern/pages/enterprise/support-coverage.mdx
+++ b/docs/fern/pages/enterprise/support-coverage.mdx
@@ -5,17 +5,16 @@ title: Support Coverage
 subtitle: What NVIDIA Enterprise Support commits to for the covered Dynamo artifacts.
 ---
 
-This page summarizes the parts of the NVIDIA Enterprise Support policy that a customer plans around. A live subscription and the terms in the applicable license agreement govern the specifics.
+This page summarizes the parts of the NVIDIA Enterprise Support policy that a customer plans around. An active NVIDIA AI Enterprise subscription is required for commercial support.
 
 ## Support Case Intake
 
 Commercial support cases are opened through NVIDIA Enterprise Experience (NVEX) using an active NVAIE subscription. See [Get Help](#get-help) for the entry points.
 
-## Response Time on Critical and High CVEs
+## Remediation Time on Critical and High CVEs
 
-CVEs affecting the supported artifacts carry a 30-day response commitment for Critical and High severity findings. Three qualifiers apply:
+CVEs affecting the supported artifacts carry a 30-day remediation commitment for Critical and High severity findings. Medium and Low severity findings are addressed on a best-effort basis. Two qualifiers apply:
 
-- **Response, not fix.** The commitment sets the time by which NVIDIA acknowledges and begins triaging the vulnerability, not the time by which a fix is available.
 - **Clock starts at identification.** The 30-day window begins when the vulnerability is identified against a supported artifact. It does not wait on public disclosure or upstream patch availability.
 - **PSIRT track for NVIDIA-owned code.** Vulnerabilities in NVIDIA-owned code that ships inside the supported artifacts are handled through the NVIDIA Product Security Incident Response Team (PSIRT) process, on the PSIRT schedule, separate from this window. The 30-day commitment applies to vulnerabilities in the open-source packages that ship inside the supported artifacts.
 
@@ -23,7 +22,7 @@ CVEs affecting the supported artifacts carry a 30-day response commitment for Cr
 
 Defect fixes ship as new releases on the supported release line. NVIDIA does not backport fixes to earlier releases and does not cut on-demand off-cycle releases in response to individual cases. Cadence follows the standard Dynamo release train.
 
-Bug-fix patch releases on the supported line inherit the release line's support scope and do not carry a separate QA validation pass. Design changes and new feature work land in the next release, not in a patch.
+Bug-fix patch releases on the supported line inherit the release line's support scope. A patch does not always carry a full QA validation pass. Design changes and new feature work land in the next release, not in a patch.
 
 ## Third-Party Package Support Boundary
 
@@ -31,7 +30,7 @@ Open-source packages that ship inside the supported enterprise artifacts are cov
 
 ## Hardware Scope
 
-Dynamo Enterprise coverage is currently scoped to Blackwell and GB200 systems. Other GPU generations are not in scope.
+Support covers the hardware, operating systems, and architectures listed in the published [Compatibility](https://docs.nvidia.com/dynamo/latest/reference/compatibility) matrix and is not scoped to individual models.
 
 ## Lifecycle and End-of-Life
 

--- a/docs/fern/pages/enterprise/supported-artifacts.mdx
+++ b/docs/fern/pages/enterprise/supported-artifacts.mdx
@@ -1,0 +1,29 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Supported Artifacts
+subtitle: The exact container images and Helm chart eligible for NVIDIA Enterprise Support.
+---
+
+The Dynamo 1.4 release line is the current supported release. The following artifacts are published for it. Commercial support is limited to this exact set.
+
+| Component | Artifact |
+| --- | --- |
+| SGLang runtime | `nvcr.io/nvidia/dynamo-enterprise/sglang-runtime-enterprise:1.4.1` |
+| TensorRT-LLM runtime | `nvcr.io/nvidia/dynamo-enterprise/tensorrtllm-runtime-enterprise:1.4.1` |
+| vLLM runtime | `nvcr.io/nvidia/dynamo-enterprise/vllm-runtime-enterprise:1.4.1` |
+| Dynamo Frontend | `nvcr.io/nvidia/dynamo-enterprise/dynamo-frontend-enterprise:1.4.1` |
+| Dynamo Kubernetes Operator | `nvcr.io/nvidia/dynamo-enterprise/kubernetes-operator-enterprise:1.4.1` |
+| Dynamo Platform Helm chart | `dynamo-platform-enterprise`, version `1.4.1` |
+
+Both parts of the path carry `enterprise`: the team segment is `dynamo-enterprise` and the repository name ends in `-enterprise`. They change together; changing only one resolves to a different image or fails.
+
+EFA-optimized tags are not in the NVIDIA Enterprise Support scope for this release.
+
+The [Dynamo Enterprise collection on NVIDIA NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/dynamo-enterprise/collections/dynamo-enterprise) lists these artifacts in one place. The Dynamo Enterprise support designation is a label on each artifact repository. The collection page aggregates the labels from its underlying repositories; it does not carry a support label of its own.
+
+<Note>
+The exact list of patch versions within a supported release line that are in scope for NVIDIA Enterprise Support is being finalized. The `1.4.1` artifacts published here are the current launch artifacts for the Dynamo 1.4 release line. When in doubt for a specific subscription and workload, confirm the covered artifact list through NVIDIA Enterprise Support (see [Get Help](overview.mdx#get-help)).
+</Note>
+
+See [Release Artifacts](../reference/general/release-artifacts.mdx) for the full stable-release artifact inventory across the open-source distribution, and [Compatibility](../reference/general/compatibility.mdx) for hardware, platform, and backend feature support.

--- a/docs/fern/pages/enterprise/supported-artifacts.mdx
+++ b/docs/fern/pages/enterprise/supported-artifacts.mdx
@@ -9,18 +9,18 @@ The Dynamo 1.4 release line is the current supported release. The following arti
 
 | Component | Artifact |
 | --- | --- |
-| SGLang runtime | `nvcr.io/nvidia/dynamo-enterprise/sglang-runtime-enterprise:1.4.1` |
-| TensorRT-LLM runtime | `nvcr.io/nvidia/dynamo-enterprise/tensorrtllm-runtime-enterprise:1.4.1` |
-| vLLM runtime | `nvcr.io/nvidia/dynamo-enterprise/vllm-runtime-enterprise:1.4.1` |
-| Dynamo Frontend | `nvcr.io/nvidia/dynamo-enterprise/dynamo-frontend-enterprise:1.4.1` |
-| Dynamo Kubernetes Operator | `nvcr.io/nvidia/dynamo-enterprise/kubernetes-operator-enterprise:1.4.1` |
+| SGLang runtime | `nvcr.io/nvidia/ai-dynamo/sglang-runtime-enterprise:1.4.1` |
+| TensorRT-LLM runtime | `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime-enterprise:1.4.1` |
+| vLLM runtime | `nvcr.io/nvidia/ai-dynamo/vllm-runtime-enterprise:1.4.1` |
+| Dynamo Frontend | `nvcr.io/nvidia/ai-dynamo/dynamo-frontend-enterprise:1.4.1` |
+| Dynamo Kubernetes Operator | `nvcr.io/nvidia/ai-dynamo/kubernetes-operator-enterprise:1.4.1` |
 | Dynamo Platform Helm chart | `dynamo-platform-enterprise`, version `1.4.1` |
 
-Both parts of the path carry `enterprise`: the team segment is `dynamo-enterprise` and the repository name ends in `-enterprise`. They change together; changing only one resolves to a different image or fails.
+The team segment is `ai-dynamo`, the same team as the open-source artifacts. Only the repository name carries the `-enterprise` suffix, so dropping that suffix resolves to the open-source image instead of the supported one.
 
 EFA-optimized tags are not in the NVIDIA Enterprise Support scope for this release.
 
-The [Dynamo Enterprise collection on NVIDIA NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/dynamo-enterprise/collections/dynamo-enterprise) lists these artifacts in one place. The Dynamo Enterprise support designation is a label on each artifact repository. The collection page aggregates the labels from its underlying repositories; it does not carry a support label of its own.
+The [Dynamo Enterprise collection on NVIDIA NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/ai-dynamo/collections/dynamo-enterprise) lists these artifacts in one place. The Dynamo Enterprise support designation is a label on each artifact repository. The collection page aggregates the labels from its underlying repositories; it does not carry a support label of its own.
 
 <Note>
 The exact list of patch versions within a supported release line that are in scope for NVIDIA Enterprise Support is being finalized. The `1.4.1` artifacts published here are the current launch artifacts for the Dynamo 1.4 release line. When in doubt for a specific subscription and workload, confirm the covered artifact list through NVIDIA Enterprise Support (see [Get Help](overview.mdx#get-help)).

--- a/docs/fern/pages/enterprise/supported-artifacts.mdx
+++ b/docs/fern/pages/enterprise/supported-artifacts.mdx
@@ -9,12 +9,12 @@ The Dynamo 1.4 release line is the current supported release. The following arti
 
 | Component | Artifact |
 | --- | --- |
-| SGLang runtime | `nvcr.io/nvidia/ai-dynamo/sglang-runtime-enterprise:1.4.1` |
-| TensorRT-LLM runtime | `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime-enterprise:1.4.1` |
-| vLLM runtime | `nvcr.io/nvidia/ai-dynamo/vllm-runtime-enterprise:1.4.1` |
-| Dynamo Frontend | `nvcr.io/nvidia/ai-dynamo/dynamo-frontend-enterprise:1.4.1` |
-| Dynamo Kubernetes Operator | `nvcr.io/nvidia/ai-dynamo/kubernetes-operator-enterprise:1.4.1` |
-| Dynamo Platform Helm chart | `dynamo-platform-enterprise`, version `1.4.1` |
+| SGLang runtime | `nvcr.io/nvidia/ai-dynamo/sglang-runtime-enterprise:1.4.2` |
+| TensorRT-LLM runtime | `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime-enterprise:1.4.2` |
+| vLLM runtime | `nvcr.io/nvidia/ai-dynamo/vllm-runtime-enterprise:1.4.2` |
+| Dynamo Frontend | `nvcr.io/nvidia/ai-dynamo/dynamo-frontend-enterprise:1.4.2` |
+| Dynamo Kubernetes Operator | `nvcr.io/nvidia/ai-dynamo/kubernetes-operator-enterprise:1.4.2` |
+| Dynamo Platform Helm chart | `dynamo-platform-enterprise`, version `1.4.2` |
 
 The team segment is `ai-dynamo`, the same team as the open-source artifacts. Only the repository name carries the `-enterprise` suffix, so dropping that suffix resolves to the open-source image instead of the supported one.
 
@@ -23,7 +23,7 @@ EFA-optimized tags are not in the NVIDIA Enterprise Support scope for this relea
 The [Dynamo Enterprise collection on NVIDIA NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/ai-dynamo/collections/dynamo-enterprise) lists these artifacts in one place. The Dynamo Enterprise support designation is a label on each artifact repository. The collection page aggregates the labels from its underlying repositories; it does not carry a support label of its own.
 
 <Note>
-The exact list of patch versions within a supported release line that are in scope for NVIDIA Enterprise Support is being finalized. The `1.4.1` artifacts published here are the current launch artifacts for the Dynamo 1.4 release line. When in doubt for a specific subscription and workload, confirm the covered artifact list through NVIDIA Enterprise Support (see [Get Help](overview.mdx#get-help)).
+The exact list of patch versions within a supported release line that are in scope for NVIDIA Enterprise Support is being finalized. The `1.4.2` artifacts published here are the current launch artifacts for the Dynamo 1.4 release line. When in doubt for a specific subscription and workload, confirm the covered artifact list through NVIDIA Enterprise Support (see [Get Help](overview.mdx#get-help)).
 </Note>
 
 See [Release Artifacts](../reference/general/release-artifacts.mdx) for the full stable-release artifact inventory across the open-source distribution, and [Compatibility](../reference/general/compatibility.mdx) for hardware, platform, and backend feature support.

--- a/docs/fern/pages/reference/general/release-artifacts.mdx
+++ b/docs/fern/pages/reference/general/release-artifacts.mdx
@@ -17,7 +17,7 @@ import { TagLookup } from "@/components/TagLookup";
 This page lists the published NVIDIA Dynamo release artifacts for the current stable release and where to find each one. Container images live on NVIDIA NGC under `nvcr.io/nvidia/ai-dynamo/`; every tag and install command below is click-to-copy.
 
 <Note>
-See [Compatibility](compatibility.mdx) for hardware, platform, and backend feature support, and [Model Early Access Builds](model-early-access-builds.mdx) for per-model early access container builds.
+See [Compatibility](compatibility.mdx) for hardware, platform, and backend feature support, [Dynamo Enterprise](../../enterprise/overview.mdx) for NVIDIA Enterprise Support coverage, and [Model Early Access Builds](model-early-access-builds.mdx) for per-model early access container builds.
 </Note>
 
 ## Current Release


### PR DESCRIPTION
## Summary

Adds an **Enterprise** section under the Reference tab documenting the Dynamo release artifacts that are eligible for NVIDIA Enterprise Support, plus a **Dynamo Enterprise** button on the docs home page beside Get started. Placement per the product decision (home-page entry point + Reference section, no separate top-level tab, keeping the primary navigation focused on the open-source audience).

Five pages:

- **Overview** — what the collection contains, and that artifacts carry the `-enterprise` suffix with no functional or binary differences from their open-source counterparts
- **Supported Artifacts** — the six artifacts with full pull paths
- **Install** — NGC access, image pulls, the enterprise Helm chart, and DGD image references
- **Support Coverage** — support case intake, CVE remediation timing, fix-forward delivery, hardware scope, and lifecycle
- **Scope Boundaries** — what falls outside support

Also cross-references the new section from the release artifacts page.

## Lifecycle terms

Dynamo Enterprise is an NVIDIA AI Enterprise Feature Branch, so the lifecycle section states the Feature Branch terms from the published [NVIDIA AI Enterprise Lifecycle Policy](https://docs.nvidia.com/ai-enterprise/lifecycle/latest/application-software.html): one month of support per branch, with a new branch published monthly. Dynamo feature releases follow roughly the same monthly cadence, so each release supersedes the previous Feature Branch and carries support forward.

Production Branch and Long-Term Support Branch terms are omitted because they do not apply to this designation.

## Test plan

- [x] `fern generate --docs --preview` builds with no errors
- [x] All five pages render and return 200 on the preview
- [x] Enterprise tab renders in the navigation
- [x] External policy links resolve
