### PR TITLE
build(sglang): drop the unused Nsight efa_metrics sampler from the runtime image

### DIFF
--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -230,6 +230,18 @@ RUN set -eux; \
     ldconfig
 {% endif %}
 
+# Drop the Nsight efa_metrics plugin the CUDA floor carries: a Go NIC sampler
+# nothing in the serving path loads. On this image it arrives under Nsight
+# Compute rather than Nsight Systems, and both roots move with every base bump,
+# so the paths are globbed and the removal is asserted rather than pinned. This
+# stage has no overlay rebase -- `runtime` is FROM pre_runtime -- so one
+# deletion here ships.
+RUN rm -rf \
+        /usr/local/cuda-*/NsightSystems-cli-*/target-linux-*/plugins/efa_metrics \
+        /opt/nvidia/nsight-systems-cli/*/target-linux-*/plugins/efa_metrics \
+        /opt/nvidia/nsight-compute/*/host/target-linux-*/plugins/efa_metrics && \
+    [ -z "$(find /usr/local /opt -xdev -type d -name efa_metrics 2>/dev/null)" ]
+
 {% if device == "cuda" %}
 # Copy the in-tree VP9 ffmpeg from wheel_builder: versioned shared libs
 # (libav*.so*, libsw*.so*) + libvpx + the in-tree CLI binary that imageio targets


### PR DESCRIPTION
Companion to #13743, which dropped the Nsight `efa_metrics` sampler from the TensorRT-LLM runtime image. This does the same for the SGLang runtime image.

## Why

The CUDA floor ships an optional Nsight `efa_metrics` plugin: a static Go NIC sampler for EFA network counters. Nothing in the Dynamo serving path loads it, and AWS EFA confirmed on 2026-08-18 that they do not use it. Because it is a static Go binary it carries its own copy of the Go standard library, so it acts as a carrier for Critical and High findings that no Dynamo code can reach.

## How

On this image the plugin arrives under Nsight Compute rather than Nsight Systems, so all three roots are globbed:

- `/usr/local/cuda-*/NsightSystems-cli-*/target-linux-*/plugins/efa_metrics`
- `/opt/nvidia/nsight-systems-cli/*/target-linux-*/plugins/efa_metrics`
- `/opt/nvidia/nsight-compute/*/host/target-linux-*/plugins/efa_metrics`

Both roots embed versions that move with every base bump, so the removal is asserted rather than pinned:

```
[ -z "$(find /usr/local /opt -xdev -type d -name efa_metrics 2>/dev/null)" ]
```

The assertion is the point of the change, not decoration. A glob that silently matched nothing after a base bump would leave the finding in place while the build stayed green.

Placement: the deletion sits in `pre_runtime`. `runtime` is `FROM pre_runtime` with no overlay rebase in this file, so a single deletion here ships. This differs from `trtllm_runtime.Dockerfile`, where #13743 had to place the removal *after* the `COPY --from=runtime_full / /` overlay because a pre-overlay whiteout would be reinstated.

## Provenance

The hunk is taken verbatim from @jh-nv's #13751, which targets `release/1.4.2`. Opening it against `main` first gives that cherry-pick a main-side ancestor, so the fix does not regress in the next minor.

Note on scope: #13751 also touches `deploy/snapshot/Dockerfile`, which has no counterpart here. `deploy/snapshot/` was removed from `main` in #13177 when the snapshot agent was migrated out of this repo, so that hunk is legitimately release-branch-only.

## Verification

- [ ] `sglang-runtime` builds on main
- [ ] Compliance audit reflects the removal

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unwanted `efa_metrics` plugin directories from the CUDA runtime image.
  * Added validation to ensure these directories are not present in standard installation locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->