### PR TITLE
test(profiler): add Sweeper DGD comparison cases

### DIFF
--- a/components/src/dynamo/profiler/tests/sweeper/.gitignore
+++ b/components/src/dynamo/profiler/tests/sweeper/.gitignore
@@ -1,0 +1,1 @@
+cases/*/generated/

--- a/components/src/dynamo/profiler/tests/sweeper/README.md
+++ b/components/src/dynamo/profiler/tests/sweeper/README.md
@@ -1,0 +1,57 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Sweeper DGD comparison cases
+
+This directory contains inputs for learning how the existing DGDR v1beta1 profiler and the new
+AI Simulate Sweeper render the same deployment intent. It is not a golden test suite: the runner
+does not compare manifests or decide which output is correct.
+
+Each case is a directory with conventional file names:
+
+```text
+<case>/
+├── dgdr-v1beta1.yaml  # profiler input: the DGDR v1beta1 spec, without the resource wrapper
+├── sweeper.yaml       # native AI Simulate SmartSearchConfig
+└── recipe-dgd.yaml    # optional hand-tuned reference copied from recipes/
+```
+
+Run one or more cases from an environment containing Dynamo, AI Simulate, and the Planner
+dependencies:
+
+```bash
+python components/src/dynamo/profiler/tests/sweeper/run_cases.py qwen3-32b-vllm-disagg
+```
+
+With no case names, the runner executes every directory under `cases/`. One scalar sweep is
+executed per case. Its best candidate is rendered through both renderers, so renderer differences
+cannot be caused by different searches.
+
+The runner writes ignored files under `<case>/generated/`:
+
+```text
+dgdr-v1beta1-dgd.yaml
+sweeper-candidate.yaml
+sweeper-aic-dgd.yaml
+sweeper-direct-dgd.yaml
+```
+
+If a renderer cannot consume the candidate, the runner continues with the other renderer, writes
+`sweeper-<renderer>-error.txt`, and exits non-zero after all renderers have been attempted. This is
+comparison evidence too: it identifies candidate shapes that a renderer does not yet support.
+
+Compare them manually, for example:
+
+```bash
+diff -u \
+  components/src/dynamo/profiler/tests/sweeper/cases/qwen3-32b-vllm-disagg/generated/dgdr-v1beta1-dgd.yaml \
+  components/src/dynamo/profiler/tests/sweeper/cases/qwen3-32b-vllm-disagg/generated/sweeper-aic-dgd.yaml
+```
+
+`dgdr-v1beta1.yaml` intentionally matches the spec payload consumed by `python -m
+dynamo.profiler`; the Kubernetes `apiVersion`, `kind`, and metadata are not profiler inputs.
+
+Sweeper runs replay simulations and may take minutes or longer as cases grow. Keep small learning
+cases bounded with their native `sweep` settings rather than adding runner-specific sweep knobs.

--- a/components/src/dynamo/profiler/tests/sweeper/cases/qwen3-32b-vllm-disagg/dgdr-v1beta1.yaml
+++ b/components/src/dynamo/profiler/tests/sweeper/cases/qwen3-32b-vllm-disagg/dgdr-v1beta1.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Profiler input corresponding to the spec of a DGDR v1beta1 resource.
+# This Qwen3-32B/vLLM/H200 combination is one of the successful rapid-profile
+# cases reported in https://github.com/ai-dynamo/dynamo/issues/8469.
+model: Qwen/Qwen3-32B
+backend: vllm
+image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.3.0
+searchStrategy: rapid
+hardware:
+  gpuSku: h200_sxm
+  vramMb: 141120
+  totalGpus: 16
+  numGpusPerNode: 8
+  interconnect: nvlink
+  rdma: true
+workload:
+  isl: 1024
+  osl: 1024
+  requestRate: 10
+sla:
+  ttft: 2000
+  itl: 25
+  optimizationType: throughput
+autoApply: false

--- a/components/src/dynamo/profiler/tests/sweeper/cases/qwen3-32b-vllm-disagg/recipe-dgd.yaml
+++ b/components/src/dynamo/profiler/tests/sweeper/cases/qwen3-32b-vllm-disagg/recipe-dgd.yaml
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Snapshot of recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml for comparison.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: disagg-router-6p-2d
+spec:
+  pvcs:
+  - create: false
+    name: model-cache
+  - create: false
+    name: compilation-cache
+  services:
+    Frontend:
+      componentType: frontend
+      envs:
+        - name: HF_HOME
+          value: /home/dynamo/.cache/huggingface
+      extraPodSpec:
+        mainContainer:
+          args:
+            - --router-mode
+            - kv
+          command:
+            - python
+            - -m
+            - dynamo.frontend
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0
+          workingDir: /workspace
+      replicas: 1
+      resources:
+        requests:
+          cpu: "8"
+        limits:
+          cpu: "8"
+      subComponentType: null
+    VllmDecodeWorker:
+      componentType: worker
+      envFromSecret: hf-token-secret
+      extraPodSpec:
+        mainContainer:
+          args:
+          - --model
+          - Qwen/Qwen3-32B
+          - --disaggregation-mode
+          - decode
+          - --kv-transfer-config
+          - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+          - --tensor-parallel-size
+          - '2'
+          - --no-enable-log-requests
+          - --gpu-memory-utilization
+          - '0.90'
+          - --no-enable-prefix-caching
+          - --async-scheduling
+          - --block-size
+          - '64'
+          - --hf-overrides
+          - '{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":32768},"max_position_embeddings":131072}'
+          - --max-model-len
+          - '131072'
+          command:
+          - python3
+          - -m
+          - dynamo.vllm
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0
+          workingDir: /workspace
+          env:
+          - name: DYN_HEALTH_CHECK_ENABLED
+            value: "false"
+          - name: HF_HOME
+            value: /home/dynamo/.cache/huggingface
+      replicas: 2
+      resources:
+        limits:
+          gpu: '2'
+          custom:
+            rdma/ib: "2"
+        requests:
+          gpu: '2'
+      subComponentType: decode
+      volumeMounts:
+      - name: model-cache
+        mountPoint: /home/dynamo/.cache/huggingface
+      - name: compilation-cache
+        mountPoint: /home/dynamo/.cache/vllm
+        useAsCompilationCache: true
+    VllmPrefillWorker:
+      componentType: worker
+      envFromSecret: hf-token-secret
+      extraPodMetadata:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "9400"
+          prometheus.io/path: "/metrics"
+      extraPodSpec:
+        mainContainer:
+          args:
+          - --model
+          - Qwen/Qwen3-32B
+          - --disaggregation-mode
+          - prefill
+          - --kv-transfer-config
+          - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+          - --tensor-parallel-size
+          - '2'
+          - --no-enable-log-requests
+          - --gpu-memory-utilization
+          - '0.90'
+          - --async-scheduling
+          - --block-size
+          - '64'
+          - --hf-overrides
+          - '{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":32768},"max_position_embeddings":131072}'
+          - --max-model-len
+          - '131072'
+          - --kv-events-config
+          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+          command:
+          - python3
+          - -m
+          - dynamo.vllm
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0
+          env:
+          - name: DYN_HEALTH_CHECK_ENABLED
+            value: "false"
+          - name: HF_HOME
+            value: /home/dynamo/.cache/huggingface
+          workingDir: /workspace
+      replicas: 6
+      resources:
+        limits:
+          gpu: '2'
+          custom:
+            rdma/ib: "2"
+        requests:
+          gpu: '2'
+      subComponentType: prefill
+      volumeMounts:
+      - name: model-cache
+        mountPoint: /home/dynamo/.cache/huggingface
+      - name: compilation-cache
+        mountPoint: /home/dynamo/.cache/vllm
+        useAsCompilationCache: true

--- a/components/src/dynamo/profiler/tests/sweeper/cases/qwen3-32b-vllm-disagg/sweeper.yaml
+++ b/components/src/dynamo/profiler/tests/sweeper/cases/qwen3-32b-vllm-disagg/sweeper.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Native AI Simulate SmartSearchConfig for the same core intent as
+# dgdr-v1beta1.yaml. The disaggregated mode is pinned to match recipe-dgd.yaml;
+# v1beta1 has no equivalent topology constraint and may select another mode.
+search_space:
+  model_name: Qwen/Qwen3-32B
+  hardware_sku: h200_sxm
+  deployment_mode: [disagg]
+  backend: [vllm]
+  gpu_budget: 16
+  context_length: 131072
+
+workload:
+  isl: 1024
+  osl: 1024
+  request_rate: 10
+  num_request_ratio: 10
+
+goal:
+  target: goodput_per_gpu
+  sla:
+    ttft_ms: 2000
+    itl_ms: 25
+
+# Keep the first learning run short. Increase these native Sweeper controls
+# when the comparison needs a representative search rather than a smoke run.
+sweep:
+  max_rounds: 1
+  candidates_per_round: 2
+  parallel_evals: 1
+  max_eval_seconds: 120

--- a/components/src/dynamo/profiler/tests/sweeper/run_cases.py
+++ b/components/src/dynamo/profiler/tests/sweeper/run_cases.py
@@ -1,0 +1,342 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate comparable DGDs from conventional v1beta1 and Sweeper case inputs."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from dynamo.profiler.sweeper.output.atomic import replace_text
+from dynamo.profiler.sweeper.renderers import DGDGenerationOptions, render_dgd
+from dynamo.profiler.sweeper.runner import load_sweep_config, run_sweep
+
+_CASES_ROOT = Path(__file__).parent / "cases"
+_DGDR_INPUT = "dgdr-v1beta1.yaml"
+_SWEEPER_INPUT = "sweeper.yaml"
+_RENDERERS = ("aic", "direct")
+
+
+@dataclass(frozen=True)
+class ComparisonCase:
+    """One convention-based comparison case."""
+
+    name: str
+    path: Path
+    dgdr_path: Path
+    sweeper_path: Path
+    dgdr_input: dict[str, Any]
+    sweeper_input: dict[str, Any]
+    generation_options: DGDGenerationOptions
+
+    @property
+    def generated_dir(self) -> Path:
+        return self.path / "generated"
+
+    @property
+    def cache_dir(self) -> Path:
+        return self.generated_dir / ".cache"
+
+
+def _read_mapping(path: Path) -> dict[str, Any]:
+    value = yaml.safe_load(path.read_text())
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain one YAML mapping")
+    return value
+
+
+def _single_sweeper_backend(sweeper_input: dict[str, Any]) -> str:
+    search_space = sweeper_input.get("search_space")
+    if not isinstance(search_space, dict):
+        raise ValueError("sweeper.yaml must define search_space")
+    backends = search_space.get("backend")
+    if not isinstance(backends, list) or len(backends) != 1:
+        raise ValueError(
+            "comparison cases require exactly one search_space.backend so the "
+            "DGDR runtime image is unambiguous"
+        )
+    backend = backends[0]
+    if not isinstance(backend, str):
+        raise ValueError("search_space.backend entries must be strings")
+    return backend
+
+
+def _derive_runtime_image(profiler_image: str, backend: str) -> str:
+    """Use the v1 profiler's published-image convention without loading it eagerly."""
+    from dynamo.profiler.utils.profile_common import derive_backend_image
+
+    return derive_backend_image(profiler_image, backend)
+
+
+def _validate_same_intent(
+    dgdr_input: dict[str, Any], sweeper_input: dict[str, Any], backend: str
+) -> None:
+    search_space = sweeper_input["search_space"]
+    hardware = dgdr_input.get("hardware")
+    if not isinstance(hardware, dict):
+        hardware = {}
+    expected = {
+        "model_name": dgdr_input.get("model"),
+        "hardware_sku": hardware.get("gpuSku"),
+        "gpu_budget": hardware.get("totalGpus"),
+    }
+    mismatches = [
+        f"{field}: DGDR={value!r}, Sweeper={search_space.get(field)!r}"
+        for field, value in expected.items()
+        if value is None or search_space.get(field) != value
+    ]
+    dgdr_backend = dgdr_input.get("backend", "auto")
+    if backend != dgdr_backend:
+        mismatches.append(f"backend: DGDR={dgdr_backend!r}, Sweeper={backend!r}")
+
+    dgdr_workload = dgdr_input.get("workload")
+    sweeper_workload = sweeper_input.get("workload")
+    if not isinstance(sweeper_workload, dict):
+        mismatches.append("workload: Sweeper input does not define a mapping")
+    elif not isinstance(dgdr_workload, dict):
+        mismatches.append("workload: DGDR input does not define a workload")
+    else:
+        for field in ("isl", "osl"):
+            dgdr_value = dgdr_workload.get(field)
+            if sweeper_workload.get(field) != dgdr_value:
+                mismatches.append(
+                    f"workload.{field}: DGDR={dgdr_value!r}, "
+                    f"Sweeper={sweeper_workload.get(field)!r}"
+                )
+
+    if mismatches:
+        raise ValueError(
+            "case inputs describe different core intent:\n  " + "\n  ".join(mismatches)
+        )
+
+
+def load_case(case_path: Path) -> ComparisonCase:
+    """Load one case using only its directory name and conventional files."""
+    dgdr_path = case_path / _DGDR_INPUT
+    sweeper_path = case_path / _SWEEPER_INPUT
+    missing = [path.name for path in (dgdr_path, sweeper_path) if not path.is_file()]
+    if missing:
+        raise ValueError(
+            f"{case_path}: missing conventional input(s): {', '.join(missing)}"
+        )
+
+    dgdr_input = _read_mapping(dgdr_path)
+    if "spec" in dgdr_input:
+        raise ValueError(
+            f"{dgdr_path} must contain the v1beta1 spec passed to the profiler, "
+            "not a Kubernetes resource wrapper"
+        )
+    sweeper_input = _read_mapping(sweeper_path)
+    backend = _single_sweeper_backend(sweeper_input)
+    _validate_same_intent(dgdr_input, sweeper_input, backend)
+
+    image = dgdr_input.get("image")
+    if not isinstance(image, str) or not image:
+        raise ValueError(
+            f"{dgdr_path}: image is required to derive the DGD runtime image"
+        )
+    hardware = dgdr_input.get("hardware")
+    num_gpus_per_node = (
+        hardware.get("numGpusPerNode") if isinstance(hardware, dict) else None
+    )
+    if not isinstance(num_gpus_per_node, int):
+        raise ValueError(
+            f"{dgdr_path}: hardware.numGpusPerNode is required for DGD generation"
+        )
+    runtime_version_override = dgdr_input.get("runtimeVersionOverride")
+    if runtime_version_override is not None and not isinstance(
+        runtime_version_override, str
+    ):
+        raise ValueError(f"{dgdr_path}: runtimeVersionOverride must be a string")
+
+    return ComparisonCase(
+        name=case_path.name,
+        path=case_path,
+        dgdr_path=dgdr_path,
+        sweeper_path=sweeper_path,
+        dgdr_input=dgdr_input,
+        sweeper_input=sweeper_input,
+        generation_options=DGDGenerationOptions(
+            runtime_image=_derive_runtime_image(image, backend),
+            runtime_version_override=runtime_version_override,
+            num_gpus_per_node=num_gpus_per_node,
+        ),
+    )
+
+
+def _run_v1_profiler(case: ComparisonCase) -> None:
+    case.generated_dir.mkdir(parents=True, exist_ok=True)
+    output_path = case.generated_dir / "dgdr-v1beta1-dgd.yaml"
+    output_path.unlink(missing_ok=True)
+    with tempfile.TemporaryDirectory(
+        dir=case.generated_dir, prefix=".dgdr-v1beta1-"
+    ) as temporary_dir:
+        command = [
+            sys.executable,
+            "-m",
+            "dynamo.profiler",
+            "--config",
+            str(case.dgdr_path),
+            "--output-dir",
+            temporary_dir,
+        ]
+        environment = os.environ.copy()
+        environment.update(_cache_environment(case))
+        environment["DGDR_NAME"] = case.name
+        print(f"[{case.name}] v1beta1: {shlex.join(command)}", flush=True)
+        subprocess.run(command, check=True, env=environment)
+
+        final_config = Path(temporary_dir) / "final_config.yaml"
+        if not final_config.is_file():
+            raise RuntimeError(
+                f"v1beta1 profiler succeeded without writing {final_config}"
+            )
+        replace_text(
+            output_path,
+            final_config.read_text(),
+        )
+
+
+def _cache_environment(case: ComparisonCase) -> dict[str, str]:
+    return {
+        "HF_HOME": str(case.cache_dir / "huggingface"),
+        "MPLCONFIGDIR": str(case.cache_dir / "matplotlib"),
+        "XDG_CACHE_HOME": str(case.cache_dir),
+    }
+
+
+@contextmanager
+def _case_environment(case: ComparisonCase):
+    overrides = _cache_environment(case)
+    previous = {name: os.environ.get(name) for name in overrides}
+    os.environ.update(overrides)
+    try:
+        yield
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def _candidate_document(candidate: Any) -> dict[str, Any]:
+    if hasattr(candidate, "model_dump"):
+        value = candidate.model_dump(mode="json")
+        if isinstance(value, dict):
+            return value
+    return {
+        "config": candidate.config,
+        "used_gpus": candidate.used_gpus,
+        "score": candidate.score,
+        "metrics": candidate.metrics,
+        "objectives": candidate.objectives,
+    }
+
+
+def _best_scalar_candidate(candidates: list[Any]) -> Any:
+    return max(
+        candidates, key=lambda candidate: (candidate.score, -candidate.used_gpus)
+    )
+
+
+def _run_sweeper_renderers(case: ComparisonCase) -> None:
+    config = load_sweep_config(case.sweeper_path)
+    if config.goal.is_pareto:
+        raise ValueError(
+            f"{case.sweeper_path}: comparison cases currently require a scalar goal"
+        )
+
+    print(f"[{case.name}] sweeper: {case.sweeper_path}", flush=True)
+    result = run_sweep(config)
+    if not result.candidates:
+        raise RuntimeError("Sweeper returned no feasible candidate")
+    candidate = _best_scalar_candidate(result.candidates)
+    candidate_path = case.generated_dir / "sweeper-candidate.yaml"
+    candidate_path.unlink(missing_ok=True)
+    replace_text(
+        candidate_path,
+        yaml.safe_dump(_candidate_document(candidate), sort_keys=False),
+    )
+
+    failures = []
+    for renderer in _RENDERERS:
+        output_path = case.generated_dir / f"sweeper-{renderer}-dgd.yaml"
+        error_path = case.generated_dir / f"sweeper-{renderer}-error.txt"
+        output_path.unlink(missing_ok=True)
+        error_path.unlink(missing_ok=True)
+        print(f"[{case.name}] renderer: {renderer}", flush=True)
+        try:
+            rendered = render_dgd(
+                candidate,
+                config.workload,
+                case.generation_options,
+                dgd_name=case.name,
+                renderer=renderer,
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            failures.append(f"{renderer}: {exc}")
+            replace_text(error_path, f"{exc}\n")
+            print(f"[{case.name}] renderer failed: {renderer}: {exc}", file=sys.stderr)
+            continue
+        replace_text(
+            output_path,
+            rendered,
+        )
+    if failures:
+        raise RuntimeError("renderer(s) failed:\n  " + "\n  ".join(failures))
+
+
+def run_case(case: ComparisonCase) -> None:
+    """Generate v1beta1, Sweeper-AIC, and Sweeper-direct DGDs for one case."""
+    print(f"[{case.name}] output: {case.generated_dir}", flush=True)
+    with _case_environment(case):
+        _run_v1_profiler(case)
+        _run_sweeper_renderers(case)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate DGDs for manual v1beta1/Sweeper renderer comparison"
+    )
+    parser.add_argument(
+        "cases",
+        nargs="*",
+        help="case directory names (default: every case)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    names = args.cases or sorted(
+        path.name for path in _CASES_ROOT.iterdir() if path.is_dir()
+    )
+    if not names:
+        print(f"no cases found under {_CASES_ROOT}", file=sys.stderr)
+        return 2
+
+    try:
+        for name in names:
+            if Path(name).name != name or name in {".", ".."}:
+                raise ValueError(f"invalid case name: {name!r}")
+            run_case(load_case(_CASES_ROOT / name))
+    except (OSError, RuntimeError, subprocess.CalledProcessError, ValueError) as exc:
+        print(f"sweeper comparison: error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/components/src/dynamo/profiler/tests/unit/sweeper/test_case_runner.py
+++ b/components/src/dynamo/profiler/tests/unit/sweeper/test_case_runner.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from dynamo.profiler.tests.sweeper import run_cases
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.planner,
+    pytest.mark.parallel,
+]
+
+
+def _write_case(case_path, *, backend="vllm") -> None:
+    case_path.mkdir()
+    (case_path / "dgdr-v1beta1.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": "Qwen/Qwen3-32B",
+                "backend": backend,
+                "image": "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.5.0",
+                "hardware": {
+                    "gpuSku": "h200_sxm",
+                    "totalGpus": 8,
+                    "numGpusPerNode": 8,
+                },
+                "workload": {"isl": 1024, "osl": 128},
+            }
+        )
+    )
+    (case_path / "sweeper.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "search_space": {
+                    "model_name": "Qwen/Qwen3-32B",
+                    "hardware_sku": "h200_sxm",
+                    "gpu_budget": 8,
+                    "backend": [backend],
+                },
+                "workload": {"isl": 1024, "osl": 128},
+            }
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_runtime_image_derivation(monkeypatch) -> None:
+    image_names = {
+        "vllm": "vllm-runtime",
+        "sglang": "sglang-runtime",
+        "trtllm": "tensorrtllm-runtime",
+    }
+
+    def derive(image, backend):
+        prefix, _, suffix = image.rpartition("/")
+        _, _, tag = suffix.partition(":")
+        return f"{prefix}/{image_names[backend]}:{tag}"
+
+    monkeypatch.setattr(run_cases, "_derive_runtime_image", derive)
+
+
+def test_load_case_uses_conventional_files_and_derives_dgd_options(tmp_path) -> None:
+    case_path = tmp_path / "qwen"
+    _write_case(case_path)
+
+    case = run_cases.load_case(case_path)
+
+    assert case.name == "qwen"
+    assert case.generation_options.runtime_image == (
+        "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0"
+    )
+    assert case.generation_options.num_gpus_per_node == 8
+
+
+def test_case_environment_uses_generated_directory_and_restores_process(
+    monkeypatch, tmp_path
+) -> None:
+    case_path = tmp_path / "qwen"
+    _write_case(case_path)
+    case = run_cases.load_case(case_path)
+    monkeypatch.setenv("HF_HOME", "/original/huggingface")
+    monkeypatch.delenv("MPLCONFIGDIR", raising=False)
+
+    with run_cases._case_environment(case):
+        assert os.environ["HF_HOME"] == str(case.cache_dir / "huggingface")
+        assert os.environ["MPLCONFIGDIR"] == str(case.cache_dir / "matplotlib")
+        assert os.environ["XDG_CACHE_HOME"] == str(case.cache_dir)
+
+    assert os.environ["HF_HOME"] == "/original/huggingface"
+    assert "MPLCONFIGDIR" not in os.environ
+
+
+def test_load_case_rejects_different_core_intent(tmp_path) -> None:
+    case_path = tmp_path / "qwen"
+    _write_case(case_path)
+    sweeper = yaml.safe_load((case_path / "sweeper.yaml").read_text())
+    sweeper["search_space"]["gpu_budget"] = 16
+    (case_path / "sweeper.yaml").write_text(yaml.safe_dump(sweeper))
+
+    with pytest.raises(ValueError, match="gpu_budget"):
+        run_cases.load_case(case_path)
+
+
+def test_repository_learning_case_follows_the_convention() -> None:
+    case = run_cases.load_case(run_cases._CASES_ROOT / "qwen3-32b-vllm-disagg")
+
+    assert case.dgdr_input["model"] == "Qwen/Qwen3-32B"
+    assert case.sweeper_input["search_space"]["deployment_mode"] == ["disagg"]
+    assert (case.path / "recipe-dgd.yaml").is_file()
+
+
+def test_sweeper_runs_once_and_renders_same_candidate_twice(
+    monkeypatch, tmp_path
+) -> None:
+    case_path = tmp_path / "qwen"
+    _write_case(case_path)
+    case = run_cases.load_case(case_path)
+    config = SimpleNamespace(
+        goal=SimpleNamespace(is_pareto=False),
+        workload=object(),
+    )
+    candidate = SimpleNamespace(
+        config={"backend": "vllm"},
+        score=3.0,
+        used_gpus=4,
+        metrics={"throughput": 3.0},
+        objectives=None,
+    )
+    sweep_calls = []
+    render_calls = []
+
+    monkeypatch.setattr(run_cases, "load_sweep_config", lambda _path: config)
+
+    def fake_sweep(received_config):
+        sweep_calls.append(received_config)
+        return SimpleNamespace(candidates=[candidate])
+
+    def fake_render(received, workload, options, *, dgd_name, renderer):
+        render_calls.append((received, workload, options, dgd_name, renderer))
+        return f"kind: DynamoGraphDeployment\nrenderer: {renderer}\n"
+
+    monkeypatch.setattr(run_cases, "run_sweep", fake_sweep)
+    monkeypatch.setattr(run_cases, "render_dgd", fake_render)
+
+    run_cases._run_sweeper_renderers(case)
+
+    assert sweep_calls == [config]
+    assert [call[0] for call in render_calls] == [candidate, candidate]
+    assert [call[-1] for call in render_calls] == ["aic", "direct"]
+    assert (case.generated_dir / "sweeper-candidate.yaml").is_file()
+    assert (case.generated_dir / "sweeper-aic-dgd.yaml").is_file()
+    assert (case.generated_dir / "sweeper-direct-dgd.yaml").is_file()
+
+
+def test_renderer_failure_does_not_hide_other_renderer(monkeypatch, tmp_path) -> None:
+    case_path = tmp_path / "qwen"
+    _write_case(case_path)
+    case = run_cases.load_case(case_path)
+    config = SimpleNamespace(
+        goal=SimpleNamespace(is_pareto=False),
+        workload=object(),
+    )
+    candidate = SimpleNamespace(
+        config={"backend": "vllm"},
+        score=3.0,
+        used_gpus=4,
+        metrics={},
+        objectives=None,
+    )
+
+    monkeypatch.setattr(run_cases, "load_sweep_config", lambda _path: config)
+    monkeypatch.setattr(
+        run_cases,
+        "run_sweep",
+        lambda _config: SimpleNamespace(candidates=[candidate]),
+    )
+
+    def render(_candidate, _workload, _options, *, dgd_name, renderer):
+        if renderer == "aic":
+            raise RuntimeError("missing bridge")
+        return f"kind: DynamoGraphDeployment\nname: {dgd_name}\n"
+
+    monkeypatch.setattr(run_cases, "render_dgd", render)
+
+    with pytest.raises(RuntimeError, match="aic: missing bridge"):
+        run_cases._run_sweeper_renderers(case)
+
+    assert not (case.generated_dir / "sweeper-aic-dgd.yaml").exists()
+    assert (case.generated_dir / "sweeper-aic-error.txt").read_text() == (
+        "missing bridge\n"
+    )
+    assert (case.generated_dir / "sweeper-direct-dgd.yaml").is_file()
+    assert not (case.generated_dir / "sweeper-direct-error.txt").exists()


### PR DESCRIPTION
## Summary

- add a convention-based learning harness that runs equivalent DGDR v1beta1 and native AI Simulate Sweeper inputs
- render one scalar Sweeper winner through both the AIC and direct renderers without rerunning the search
- preserve partial output and renderer failures as explicit comparison artifacts instead of adding golden assertions or automatic diff policy
- seed the matrix with Qwen3-32B on vLLM/H200 plus the existing disaggregated recipe as a hand-written reference

This is a stacked PR based on #13765. Merge or rebase it after the parent PR.

## Validation

- `python -m pytest -xvv --basetemp=/tmp/pytest-sweeper-stacked-fixed components/src/dynamo/profiler/tests/unit/sweeper` — 32 passed
- `pre-commit run` on all added files
- exercised `qwen3-32b-vllm-disagg` end to end: v1 produced its DGD, Sweeper produced 2/2 feasible candidates, and the AIC renderer produced a DGD with two prefill and two decode replicas
- the direct renderer still rejects this disaggregated Candidate shape and the harness records that separate gap in `sweeper-direct-error.txt`