### PR TITLE
docs: correct outdated nightly release information

### DIFF
--- a/docs/fern/components/releases.data.ts
+++ b/docs/fern/components/releases.data.ts
@@ -1369,22 +1369,21 @@ export const RELEASE_STATS: Record<string, ReleaseStats> = {
 
 export const NIGHTLY_BUILDS: NightlyBuild[] = [
   {
-    version: "1.4.0.dev20260803",
-    date: "Aug 3, 2026",
+    version: "1.5.0.dev20260826",
+    date: "Aug 26, 2026",
     packages: ["ai-dynamo", "ai-dynamo-runtime", "kvbm"],
   },
   {
-    version: "1.4.0.dev20260802",
-    date: "Aug 2, 2026",
+    version: "1.5.0.dev20260825",
+    date: "Aug 25, 2026",
     packages: ["ai-dynamo", "ai-dynamo-runtime", "kvbm"],
   },
   {
-    version: "1.4.0.dev20260730",
-    date: "Jul 30, 2026",
-    packages: ["ai-dynamo", "ai-dynamo-runtime"],
-    note: "kvbm was not published for this nightly.",
+    version: "1.5.0.dev20260823",
+    date: "Aug 23, 2026",
+    packages: ["ai-dynamo", "ai-dynamo-runtime", "kvbm"],
   },
 ];
 
 export const NIGHTLIES_NOTE =
-  "ai-dynamo, ai-dynamo-runtime, and kvbm nightly builds from main publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026). Install with pip or uv using `--pre` and the NVIDIA extra-index pattern shown above. Runtime containers use rolling `*-runtime-nightly:latest` tags on NGC.";
+  "ai-dynamo, ai-dynamo-runtime, and kvbm nightly builds from main publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026). Install with pip or uv using `--pre` and the NVIDIA extra-index pattern shown above. Runtime containers publish to the `*-runtime-nightly` repositories on NGC, under a dated `YYYYMMDD-<shortsha>` tag plus rolling `latest` and `nightly` tags.";

--- a/docs/fern/components/releases.data.ts
+++ b/docs/fern/components/releases.data.ts
@@ -1369,21 +1369,21 @@ export const RELEASE_STATS: Record<string, ReleaseStats> = {
 
 export const NIGHTLY_BUILDS: NightlyBuild[] = [
   {
-    version: "1.5.0.dev20260826",
-    date: "Aug 26, 2026",
+    version: "1.5.0.dev20260831",
+    date: "Aug 31, 2026",
     packages: ["ai-dynamo", "ai-dynamo-runtime", "kvbm"],
   },
   {
-    version: "1.5.0.dev20260825",
-    date: "Aug 25, 2026",
+    version: "1.5.0.dev20260830",
+    date: "Aug 30, 2026",
     packages: ["ai-dynamo", "ai-dynamo-runtime", "kvbm"],
   },
   {
-    version: "1.5.0.dev20260823",
-    date: "Aug 23, 2026",
+    version: "1.5.0.dev20260829",
+    date: "Aug 29, 2026",
     packages: ["ai-dynamo", "ai-dynamo-runtime", "kvbm"],
   },
 ];
 
 export const NIGHTLIES_NOTE =
-  "ai-dynamo, ai-dynamo-runtime, and kvbm nightly builds from main publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026). Install with pip or uv using `--pre` and the NVIDIA extra-index pattern shown above. Runtime containers publish to the `*-runtime-nightly` repositories on NGC, under a dated `YYYYMMDD-<shortsha>` tag plus rolling `latest` and `nightly` tags.";
+  "ai-dynamo and ai-dynamo-runtime nightly builds from main publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026); kvbm joined the nightly train on Aug 2, 2026. Install with pip or uv using `--pre` and the NVIDIA extra-index pattern shown above. Runtime containers publish to the `*-runtime-nightly` repositories on NGC, under a dated `YYYYMMDD-<shortsha>` tag plus a rolling `latest` tag.";

--- a/docs/fern/pages/reference/general/nightly-releases.md
+++ b/docs/fern/pages/reference/general/nightly-releases.md
@@ -27,8 +27,9 @@ Every night, the [Nightly CI pipeline](https://github.com/ai-dynamo/dynamo/blob/
 - **Runtime container images (CUDA 13):** `vllm-runtime-nightly`, `sglang-runtime-nightly`, and `tensorrtllm-runtime-nightly` to NGC, each with an EFA variant under a `-efa` tag suffix.
 - **Component container images:** `kubernetes-operator-nightly`, `dynamo-planner-nightly`, and `dynamo-frontend-nightly` to NGC.
 - **Python wheels:** `ai-dynamo`, `ai-dynamo-runtime`, and `kvbm` to the NVIDIA prerelease index at [pypi.nvidia.com](https://pypi.nvidia.com/).
+- **Helm chart:** [`dynamo-platform-nightly`](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/helm-charts/dynamo-platform-nightly) to the NGC Helm registry, kept separate from the stable `dynamo-platform` chart.
 
-Nightly does not publish Helm charts or Rust crates — for those, use a [stable or pre-release build](release-artifacts.mdx).
+Nightly does not publish Rust crates — for those, use a [stable or pre-release build](release-artifacts.mdx).
 
 ## Installing Nightly Containers
 

--- a/docs/fern/pages/reference/general/nightly-releases.md
+++ b/docs/fern/pages/reference/general/nightly-releases.md
@@ -27,9 +27,8 @@ Every night, the [Nightly CI pipeline](https://github.com/ai-dynamo/dynamo/blob/
 - **Runtime container images (CUDA 13):** `vllm-runtime-nightly`, `sglang-runtime-nightly`, and `tensorrtllm-runtime-nightly` to NGC, each with an EFA variant under a `-efa` tag suffix.
 - **Component container images:** `kubernetes-operator-nightly`, `dynamo-planner-nightly`, and `dynamo-frontend-nightly` to NGC.
 - **Python wheels:** `ai-dynamo`, `ai-dynamo-runtime`, and `kvbm` to the NVIDIA prerelease index at [pypi.nvidia.com](https://pypi.nvidia.com/).
-- **Helm chart:** `dynamo-platform` at a dated pre-release version, `X.Y.Z-dev.YYYYMMDD.g<shortsha>`.
 
-The three runtime images and the wheels gate the release: if one of them fails to build, the whole nightly is held back. The component images and the Helm chart are staged fail-soft, so a failure there skips only that artifact for that night. Nightly does not publish Rust crates — for those, use a [stable or pre-release build](release-artifacts.mdx).
+The three runtime images and the wheels gate the release: if one of them fails to build, the whole nightly is held back. The component images are staged fail-soft, so a failure there skips only that image for that night. Nightly does not publish Helm charts or Rust crates — for those, use a [stable or pre-release build](release-artifacts.mdx).
 
 ## Installing Nightly Containers
 

--- a/docs/fern/pages/reference/general/nightly-releases.md
+++ b/docs/fern/pages/reference/general/nightly-releases.md
@@ -28,7 +28,7 @@ Every night, the [Nightly CI pipeline](https://github.com/ai-dynamo/dynamo/blob/
 - **Component container images:** `kubernetes-operator-nightly`, `dynamo-planner-nightly`, and `dynamo-frontend-nightly` to NGC.
 - **Python wheels:** `ai-dynamo`, `ai-dynamo-runtime`, and `kvbm` to the NVIDIA prerelease index at [pypi.nvidia.com](https://pypi.nvidia.com/).
 
-The three runtime images and the wheels gate the release: if one of them fails to build, the whole nightly is held back. The component images are staged fail-soft, so a failure there skips only that image for that night. Nightly does not publish Helm charts or Rust crates — for those, use a [stable or pre-release build](release-artifacts.mdx).
+Nightly does not publish Helm charts or Rust crates — for those, use a [stable or pre-release build](release-artifacts.mdx).
 
 ## Installing Nightly Containers
 

--- a/docs/fern/pages/reference/general/nightly-releases.md
+++ b/docs/fern/pages/reference/general/nightly-releases.md
@@ -24,23 +24,32 @@ Dynamo publishes nightly builds from `main`. Nightlies let you try the latest fe
 
 Every night, the [Nightly CI pipeline](https://github.com/ai-dynamo/dynamo/blob/main/.github/workflows/nightly-ci.yml) builds `main` and publishes:
 
-- **Container images (CUDA 13):** `vllm-runtime-nightly`, `sglang-runtime-nightly`, and `tensorrtllm-runtime-nightly` to NGC.
+- **Runtime container images (CUDA 13):** `vllm-runtime-nightly`, `sglang-runtime-nightly`, and `tensorrtllm-runtime-nightly` to NGC, each with an EFA variant under a `-efa` tag suffix.
+- **Component container images:** `kubernetes-operator-nightly`, `dynamo-planner-nightly`, and `dynamo-frontend-nightly` to NGC.
 - **Python wheels:** `ai-dynamo`, `ai-dynamo-runtime`, and `kvbm` to the NVIDIA prerelease index at [pypi.nvidia.com](https://pypi.nvidia.com/).
+- **Helm chart:** `dynamo-platform` at a dated pre-release version, `X.Y.Z-dev.YYYYMMDD.g<shortsha>`.
 
-Nightly deliberately does **not** publish EFA image variants, `dynamo-frontend`, `kubernetes-operator`, `dynamo-planner`, `snapshot-agent`, Helm charts, or Rust crates. For those, use a [stable or pre-release build](release-artifacts.mdx).
+The three runtime images and the wheels gate the release: if one of them fails to build, the whole nightly is held back. The component images and the Helm chart are staged fail-soft, so a failure there skips only that artifact for that night. Nightly does not publish Rust crates — for those, use a [stable or pre-release build](release-artifacts.mdx).
 
 ## Installing Nightly Containers
 
-Nightly images live in their own `-nightly` NGC repositories so they cannot be pulled accidentally in place of a stable image. Runtime containers use a floating `:latest` tag for the most recent nightly build.
+Nightly images live in their own `-nightly` NGC repositories so they cannot be pulled accidentally in place of a stable image. Every nightly build pushes an immutable `YYYYMMDD-<shortsha>` tag, and the `latest` and `nightly` tags both float to the most recent build.
 
 ```bash
-# Always the latest nightly
+# Most recent nightly
 docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime-nightly:latest
 docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime-nightly:latest
 docker pull nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime-nightly:latest
+
+# Pin one nightly build
+docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime-nightly:20260826-27f09d5
+
+# EFA variant, floating or pinned
+docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime-nightly:latest-efa
+docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime-nightly:20260826-27f09d5-efa
 ```
 
-The old nightly docs also described immutable `:YYYYMMDD-<shortsha>` container tags. Those tags are not currently visible for the recent NGC nightly images, so use `:latest` unless you have a specific tag from the publish job.
+Pin the dated tag for anything you need to reproduce later: `latest` and `nightly` move every night, so the image behind them changes underneath you. The component repositories use the same tag scheme, without the EFA variants.
 
 ## Installing Nightly Wheels
 
@@ -54,7 +63,7 @@ uv pip install --pre --extra-index-url https://pypi.nvidia.com/ ai-dynamo
 pip install --pre --extra-index-url https://pypi.nvidia.com/ ai-dynamo
 
 # Pin a specific nightly wheel
-uv pip install --pre --extra-index-url https://pypi.nvidia.com/ "ai-dynamo[vllm]==1.4.0.dev20260803"
+uv pip install --pre --extra-index-url https://pypi.nvidia.com/ "ai-dynamo[vllm]==1.5.0.dev20260826"
 ```
 
 Backend extras such as `ai-dynamo[vllm]` and `ai-dynamo[sglang]` use the same flags. For TensorRT-LLM, use the nightly container rather than a PyPI extra.

--- a/docs/fern/pages/reference/general/nightly-releases.md
+++ b/docs/fern/pages/reference/general/nightly-releases.md
@@ -24,16 +24,18 @@ Dynamo publishes nightly builds from `main`. Nightlies let you try the latest fe
 
 Every night, the [Nightly CI pipeline](https://github.com/ai-dynamo/dynamo/blob/main/.github/workflows/nightly-ci.yml) builds `main` and publishes:
 
-- **Runtime container images (CUDA 13):** `vllm-runtime-nightly`, `sglang-runtime-nightly`, and `tensorrtllm-runtime-nightly` to NGC, each with an EFA variant under a `-efa` tag suffix.
+- **Runtime container images (CUDA 13):** `vllm-runtime-nightly`, `sglang-runtime-nightly`, and `tensorrtllm-runtime-nightly` to NGC, each with an Elastic Fabric Adapter (EFA) variant under a `-efa` tag suffix.
 - **Component container images:** `kubernetes-operator-nightly`, `dynamo-planner-nightly`, and `dynamo-frontend-nightly` to NGC.
 - **Python wheels:** `ai-dynamo`, `ai-dynamo-runtime`, and `kvbm` to the NVIDIA prerelease index at [pypi.nvidia.com](https://pypi.nvidia.com/).
 - **Helm chart:** [`dynamo-platform-nightly`](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/helm-charts/dynamo-platform-nightly) to the NGC Helm registry, kept separate from the stable `dynamo-platform` chart.
+
+The runtime images and the wheels gate the release: if any of them fails to build, that night publishes nothing. The component images, the EFA variants, and the Helm chart stage fail-soft, so a flake in one of them skips that artifact for the night without holding back the rest.
 
 Nightly does not publish Rust crates — for those, use a [stable or pre-release build](release-artifacts.mdx).
 
 ## Installing Nightly Containers
 
-Nightly images live in their own `-nightly` NGC repositories so they cannot be pulled accidentally in place of a stable image. Every nightly build pushes an immutable `YYYYMMDD-<shortsha>` tag, and the `latest` and `nightly` tags both float to the most recent build.
+Nightly images live in their own `-nightly` NGC repositories so they cannot be pulled accidentally in place of a stable image. Every nightly build pushes an immutable `YYYYMMDD-<shortsha>` tag and moves the `latest` tag to that build.
 
 ```bash
 # Most recent nightly
@@ -42,14 +44,14 @@ docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime-nightly:latest
 docker pull nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime-nightly:latest
 
 # Pin one nightly build
-docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime-nightly:20260826-27f09d5
+docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime-nightly:20260830-4c7e981
 
 # EFA variant, floating or pinned
 docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime-nightly:latest-efa
-docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime-nightly:20260826-27f09d5-efa
+docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime-nightly:20260830-4c7e981-efa
 ```
 
-Pin the dated tag for anything you need to reproduce later: `latest` and `nightly` move every night, so the image behind them changes underneath you. The component repositories use the same tag scheme, without the EFA variants.
+Pin the dated tag for anything you need to reproduce later: `latest` moves every night, so the image behind it changes underneath you. The runtime repositories also carry a `nightly` tag, but it stopped tracking `main` in July 2026 — use `latest` or a dated tag instead. The component repositories publish the same dated tags and a `latest` float, without the `nightly` alias or the EFA variants.
 
 ## Installing Nightly Wheels
 
@@ -63,7 +65,7 @@ uv pip install --pre --extra-index-url https://pypi.nvidia.com/ ai-dynamo
 pip install --pre --extra-index-url https://pypi.nvidia.com/ ai-dynamo
 
 # Pin a specific nightly wheel
-uv pip install --pre --extra-index-url https://pypi.nvidia.com/ "ai-dynamo[vllm]==1.5.0.dev20260826"
+uv pip install --pre --extra-index-url https://pypi.nvidia.com/ "ai-dynamo[vllm]==1.5.0.dev20260831"
 ```
 
 Backend extras such as `ai-dynamo[vllm]` and `ai-dynamo[sglang]` use the same flags. For TensorRT-LLM, use the nightly container rather than a PyPI extra.

--- a/docs/fern/pages/reference/general/release-artifacts.mdx
+++ b/docs/fern/pages/reference/general/release-artifacts.mdx
@@ -58,7 +58,7 @@ uv pip install --pre --extra-index-url https://pypi.nvidia.com/ ai-dynamo==1.3.0
 pip install --pre --extra-index-url https://pypi.nvidia.com ai-dynamo==1.3.0.dev1
 ```
 
-**Nightlies:** `ai-dynamo` and `ai-dynamo-runtime` nightly builds from `main` publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026). Install with the same `--pre` + extra-index pattern.
+**Nightlies:** `ai-dynamo`, `ai-dynamo-runtime`, and `kvbm` nightly builds from `main` publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026). Install with the same `--pre` + extra-index pattern. See [Nightly Releases](nightly-releases.md) for the full artifact list and container tags.
 
 </Accordion>
 
@@ -142,11 +142,11 @@ Current stable release: v1.4.1 (container tag `1.4.1`, wheel version `1.4.1`).
 
 | Version | Date | Packages | Notes |
 | --- | --- | --- | --- |
-| 1.4.0.dev20260803 | Aug 3, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
-| 1.4.0.dev20260802 | Aug 2, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
-| 1.4.0.dev20260730 | Jul 30, 2026 | ai-dynamo, ai-dynamo-runtime | kvbm was not published for this nightly. |
+| 1.5.0.dev20260826 | Aug 26, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
+| 1.5.0.dev20260825 | Aug 25, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
+| 1.5.0.dev20260823 | Aug 23, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
 
-ai-dynamo, ai-dynamo-runtime, and kvbm nightly builds from main publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026). Install with pip or uv using `--pre` and the NVIDIA extra-index pattern shown above. Runtime containers use rolling `*-runtime-nightly:latest` tags on NGC.
+ai-dynamo, ai-dynamo-runtime, and kvbm nightly builds from main publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026). Install with pip or uv using `--pre` and the NVIDIA extra-index pattern shown above. Runtime containers publish to the `*-runtime-nightly` repositories on NGC, under a dated `YYYYMMDD-<shortsha>` tag plus rolling `latest` and `nightly` tags.
 
 **Crates: first published version on crates.io**
 

--- a/docs/fern/pages/reference/general/release-artifacts.mdx
+++ b/docs/fern/pages/reference/general/release-artifacts.mdx
@@ -58,7 +58,7 @@ uv pip install --pre --extra-index-url https://pypi.nvidia.com/ ai-dynamo==1.3.0
 pip install --pre --extra-index-url https://pypi.nvidia.com ai-dynamo==1.3.0.dev1
 ```
 
-**Nightlies:** `ai-dynamo`, `ai-dynamo-runtime`, and `kvbm` nightly builds from `main` publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026). Install with the same `--pre` + extra-index pattern. See [Nightly Releases](nightly-releases.md) for the full artifact list and container tags.
+**Nightlies:** `ai-dynamo` and `ai-dynamo-runtime` nightly builds from `main` publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026); `kvbm` joined the nightly train on Aug 2, 2026. Install with the same `--pre` + extra-index pattern. See [Nightly Releases](nightly-releases.md) for the full artifact list and container tags.
 
 </Accordion>
 
@@ -142,11 +142,11 @@ Current stable release: v1.4.1 (container tag `1.4.1`, wheel version `1.4.1`).
 
 | Version | Date | Packages | Notes |
 | --- | --- | --- | --- |
-| 1.5.0.dev20260826 | Aug 26, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
-| 1.5.0.dev20260825 | Aug 25, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
-| 1.5.0.dev20260823 | Aug 23, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
+| 1.5.0.dev20260831 | Aug 31, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
+| 1.5.0.dev20260830 | Aug 30, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
+| 1.5.0.dev20260829 | Aug 29, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
 
-ai-dynamo, ai-dynamo-runtime, and kvbm nightly builds from main publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026). Install with pip or uv using `--pre` and the NVIDIA extra-index pattern shown above. Runtime containers publish to the `*-runtime-nightly` repositories on NGC, under a dated `YYYYMMDD-<shortsha>` tag plus rolling `latest` and `nightly` tags.
+ai-dynamo and ai-dynamo-runtime nightly builds from main publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026); kvbm joined the nightly train on Aug 2, 2026. Install with pip or uv using `--pre` and the NVIDIA extra-index pattern shown above. Runtime containers publish to the `*-runtime-nightly` repositories on NGC, under a dated `YYYYMMDD-<shortsha>` tag plus a rolling `latest` tag.
 
 **Crates: first published version on crates.io**
 

--- a/docs/fern/pages/reference/general/releases-machine-readable.mdx
+++ b/docs/fern/pages/reference/general/releases-machine-readable.mdx
@@ -270,12 +270,12 @@ Release highlights (stable releases):
 
 ## Nightlies
 
-ai-dynamo, ai-dynamo-runtime, and kvbm nightly builds from main publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026). Install with pip or uv using `--pre` and the NVIDIA extra-index pattern shown above. Runtime containers use rolling `*-runtime-nightly:latest` tags on NGC.
+ai-dynamo, ai-dynamo-runtime, and kvbm nightly builds from main publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026). Install with pip or uv using `--pre` and the NVIDIA extra-index pattern shown above. Runtime containers publish to the `*-runtime-nightly` repositories on NGC, under a dated `YYYYMMDD-<shortsha>` tag plus rolling `latest` and `nightly` tags.
 
 | Version | Date | Packages | Notes |
 | --- | --- | --- | --- |
-| 1.4.0.dev20260803 | Aug 3, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
-| 1.4.0.dev20260802 | Aug 2, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
-| 1.4.0.dev20260730 | Jul 30, 2026 | ai-dynamo, ai-dynamo-runtime | kvbm was not published for this nightly. |
+| 1.5.0.dev20260826 | Aug 26, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
+| 1.5.0.dev20260825 | Aug 25, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
+| 1.5.0.dev20260823 | Aug 23, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
 
 {/* llms-tables:end */}

--- a/docs/fern/pages/reference/general/releases-machine-readable.mdx
+++ b/docs/fern/pages/reference/general/releases-machine-readable.mdx
@@ -270,12 +270,12 @@ Release highlights (stable releases):
 
 ## Nightlies
 
-ai-dynamo, ai-dynamo-runtime, and kvbm nightly builds from main publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026). Install with pip or uv using `--pre` and the NVIDIA extra-index pattern shown above. Runtime containers publish to the `*-runtime-nightly` repositories on NGC, under a dated `YYYYMMDD-<shortsha>` tag plus rolling `latest` and `nightly` tags.
+ai-dynamo and ai-dynamo-runtime nightly builds from main publish wheels tagged `*.devYYYYMMDD` (since Apr 24, 2026); kvbm joined the nightly train on Aug 2, 2026. Install with pip or uv using `--pre` and the NVIDIA extra-index pattern shown above. Runtime containers publish to the `*-runtime-nightly` repositories on NGC, under a dated `YYYYMMDD-<shortsha>` tag plus a rolling `latest` tag.
 
 | Version | Date | Packages | Notes |
 | --- | --- | --- | --- |
-| 1.5.0.dev20260826 | Aug 26, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
-| 1.5.0.dev20260825 | Aug 25, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
-| 1.5.0.dev20260823 | Aug 23, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
+| 1.5.0.dev20260831 | Aug 31, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
+| 1.5.0.dev20260830 | Aug 30, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
+| 1.5.0.dev20260829 | Aug 29, 2026 | ai-dynamo, ai-dynamo-runtime, kvbm | - |
 
 {/* llms-tables:end */}


### PR DESCRIPTION
Nightly publishes the EFA runtime variants, the operator, planner, and frontend images, and a dated dynamo-platform Helm chart. The page listed all of those as deliberately not published, and told readers the dated YYYYMMDD-<shortsha> container tags were unavailable when they are in fact the way to pin a nightly build.

- Rewrite the published-artifact list, and note which artifacts gate the release versus which stage fail-soft
- Document the dated, latest, nightly, and -efa container tags
- Refresh NIGHTLY_BUILDS to the current 1.5.0.dev train and re-splice the generated release tables
- Add kvbm to the nightly wheel list on the release artifacts page

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated nightly release listings with newer August 2026 builds, including `kvbm`.
  - Documented runtime, component, Helm, wheel, and EFA artifacts.
  - Clarified dated, immutable, and rolling container tags, including `latest` and `nightly`.
  - Added guidance on release gating and fail-soft handling for non-critical artifacts.
  - Refreshed pinned nightly installation examples and cross-references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->