### PR TITLE
fix(trtllm): Forward mm_processor_kwargs to the engine

### DIFF
--- a/components/src/dynamo/trtllm/encode_helper.py
+++ b/components/src/dynamo/trtllm/encode_helper.py
@@ -12,6 +12,7 @@ import torch
 
 import dynamo.nixl_connect as nixl_connect
 from dynamo.common.multimodal.image_loader import ImageLoader
+from dynamo.trtllm.multimodal_processor import resolve_mm_processor_kwargs
 from dynamo.trtllm.utils.disagg_utils import DisaggregatedParamsCodec
 
 
@@ -289,6 +290,7 @@ class EncodeHelper:
         model_dir: str,
         model_type: str,
         engine,
+        mm_processor_kwargs: Optional[dict] = None,
     ):
         """
         Process image URLs via TRT-LLM's MultimodalEncoder (full EPD flow).
@@ -321,7 +323,7 @@ class EncodeHelper:
             {
                 "prompt_token_ids": prompt_token_ids_from_request,
                 "multi_modal_data": processed_mm_data,
-                "mm_processor_kwargs": {},
+                "mm_processor_kwargs": mm_processor_kwargs or {},
             }
         ]
 
@@ -447,6 +449,12 @@ class EncodeHelper:
             # chat template and tokenized; token_ids then include image placeholder tokens
             # if the model's tokenizer_config chat template emits them).
             token_ids = request.get("token_ids")
+            epd_mm_kwargs = resolve_mm_processor_kwargs(request)
+            if epd_mm_kwargs is not None and not isinstance(epd_mm_kwargs, dict):
+                yield {
+                    "error": "Malformed mm_processor_kwargs field: expected an object"
+                }
+                return
             async for response in EncodeHelper._process_full_epd_flow(
                 token_ids,  # type: ignore
                 image_urls,
@@ -454,6 +462,7 @@ class EncodeHelper:
                 model_dir,
                 model_type,
                 engine,
+                epd_mm_kwargs,
             ):
                 yield response
 

--- a/components/src/dynamo/trtllm/encode_helper.py
+++ b/components/src/dynamo/trtllm/encode_helper.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Optional, Union
 import torch
 
 import dynamo.nixl_connect as nixl_connect
+from dynamo.common.http import HttpStatusError
 from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.trtllm.multimodal_processor import resolve_mm_processor_kwargs
 from dynamo.trtllm.utils.disagg_utils import DisaggregatedParamsCodec
@@ -451,10 +452,14 @@ class EncodeHelper:
             token_ids = request.get("token_ids")
             epd_mm_kwargs = resolve_mm_processor_kwargs(request)
             if epd_mm_kwargs is not None and not isinstance(epd_mm_kwargs, dict):
-                yield {
-                    "error": "Malformed mm_processor_kwargs field: expected an object"
-                }
-                return
+                # Raise rather than yield an error payload: a yielded dict reads as a
+                # normal encoder response, so the caller reports missing embeddings as
+                # an internal failure. Matches the aggregated path's 400.
+                raise HttpStatusError(
+                    400,
+                    "Malformed mm_processor_kwargs field: expected an object",
+                    str(epd_mm_kwargs),
+                )
             async for response in EncodeHelper._process_full_epd_flow(
                 token_ids,  # type: ignore
                 image_urls,

--- a/components/src/dynamo/trtllm/multimodal/embedding_fetcher.py
+++ b/components/src/dynamo/trtllm/multimodal/embedding_fetcher.py
@@ -8,6 +8,7 @@ Provides utility functions for fetching image embeddings from remote encoder
 with per-URL caching support.
 """
 
+import json
 import logging
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -152,8 +153,19 @@ async def _fetch_embeddings_with_cache(
     uncached_indices = []
     uncached_hashes = []
 
+    # Overrides change the embeddings for a URL, so they are part of cache
+    # identity; without them the hash is unchanged, so existing entries stay valid.
+    mm_kwargs = (
+        request.get("mm_processor_kwargs") if isinstance(request, dict) else None
+    )
+    if not isinstance(mm_kwargs, dict):
+        mm_kwargs = None
+    kwargs_salt = (
+        json.dumps(mm_kwargs, sort_keys=True, default=str) if mm_kwargs else ""
+    )
+
     for i, url in enumerate(image_urls):
-        url_hash = MultimodalHasher.hash_bytes(url.encode())
+        url_hash = MultimodalHasher.hash_bytes((url + kwargs_salt).encode())
         cached = cache.get(url_hash)
         if cached is not None:
             embeddings_with_index.append((i, cached.tensor))

--- a/components/src/dynamo/trtllm/multimodal/embedding_fetcher.py
+++ b/components/src/dynamo/trtllm/multimodal/embedding_fetcher.py
@@ -21,6 +21,7 @@ from dynamo.common.memory.multimodal_embedding_cache_manager import (
 )
 from dynamo.trtllm.multimodal.cuda_ipc import extract_embeddings_from_handles
 from dynamo.trtllm.multimodal.hasher import MultimodalHasher
+from dynamo.trtllm.multimodal_processor import resolve_mm_processor_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -156,7 +157,7 @@ async def _fetch_embeddings_with_cache(
     # Overrides change the embeddings for a URL, so they are part of cache
     # identity; without them the hash is unchanged, so existing entries stay valid.
     mm_kwargs = (
-        request.get("mm_processor_kwargs") if isinstance(request, dict) else None
+        resolve_mm_processor_kwargs(request) if isinstance(request, dict) else None
     )
     if not isinstance(mm_kwargs, dict):
         mm_kwargs = None

--- a/components/src/dynamo/trtllm/multimodal/embedding_fetcher.py
+++ b/components/src/dynamo/trtllm/multimodal/embedding_fetcher.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import torch
 from tensorrt_llm.llmapi import DisaggregatedParams
 
+from dynamo.common.http import HttpStatusError
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     CachedEmbedding,
     MultimodalEmbeddingCacheManager,
@@ -159,7 +160,16 @@ async def _fetch_embeddings_with_cache(
     mm_kwargs = (
         resolve_mm_processor_kwargs(request) if isinstance(request, dict) else None
     )
-    if not isinstance(mm_kwargs, dict) or not mm_kwargs:
+    # Reject before the lookup, not after: normalizing a malformed value to None
+    # would hash the plain URL and serve a cache hit with 200, while the
+    # aggregated path 400s on the same input.
+    if mm_kwargs is not None and not isinstance(mm_kwargs, dict):
+        raise HttpStatusError(
+            400,
+            "Malformed mm_processor_kwargs field: expected an object",
+            str(mm_kwargs),
+        )
+    if not mm_kwargs:
         mm_kwargs = None
 
     def _cache_key(url: str) -> str:

--- a/components/src/dynamo/trtllm/multimodal/embedding_fetcher.py
+++ b/components/src/dynamo/trtllm/multimodal/embedding_fetcher.py
@@ -159,14 +159,21 @@ async def _fetch_embeddings_with_cache(
     mm_kwargs = (
         resolve_mm_processor_kwargs(request) if isinstance(request, dict) else None
     )
-    if not isinstance(mm_kwargs, dict):
+    if not isinstance(mm_kwargs, dict) or not mm_kwargs:
         mm_kwargs = None
-    kwargs_salt = (
-        json.dumps(mm_kwargs, sort_keys=True, default=str) if mm_kwargs else ""
-    )
+
+    def _cache_key(url: str) -> str:
+        # JSON-encode the pair rather than concatenating: `url + salt` is ambiguous,
+        # so a URL ending in another request's serialized overrides would collide
+        # with it and be served the wrong embeddings.
+        if mm_kwargs is None:
+            return MultimodalHasher.hash_bytes(url.encode())
+        return MultimodalHasher.hash_bytes(
+            json.dumps([url, mm_kwargs], sort_keys=True, default=str).encode()
+        )
 
     for i, url in enumerate(image_urls):
-        url_hash = MultimodalHasher.hash_bytes((url + kwargs_salt).encode())
+        url_hash = _cache_key(url)
         cached = cache.get(url_hash)
         if cached is not None:
             embeddings_with_index.append((i, cached.tensor))

--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -89,6 +89,17 @@ class TokenizerProtocol(Protocol):
         ...
 
 
+def resolve_mm_processor_kwargs(request: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Per-request processor overrides, canonical field first.
+
+    Presence-based: an explicit top-level {} must not fall through to extra_args.
+    """
+    mm_kwargs = request.get("mm_processor_kwargs")
+    if mm_kwargs is None:
+        mm_kwargs = (request.get("extra_args") or {}).get("mm_processor_kwargs")
+    return mm_kwargs
+
+
 class MultimodalRequestProcessor:
     """Simple processor for OpenAI format multimodal requests."""
 
@@ -136,8 +147,34 @@ class MultimodalRequestProcessor:
         except Exception as e:
             logging.warning("Input processor unavailable for max_tokens sizing: %s", e)
 
+    def _known_processor_kwargs(
+        self, mm_kwargs: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """The subset of mm_kwargs the HF image processor declares valid.
+
+        Unknown keys are dropped: sizing reaches the HF processor's
+        _get_num_multimodal_tokens(), which on some models (Gemma-4) merges
+        kwargs into class-level defaults in place, breaking later requests.
+        """
+        if not mm_kwargs:
+            return {}
+        try:
+            image_processor = getattr(
+                getattr(self.input_processor, "processor", None),
+                "image_processor",
+                None,
+            )
+            valid = getattr(image_processor, "valid_kwargs", None)
+            names = set(getattr(valid, "__annotations__", None) or {})
+        except Exception:
+            names = set()
+        return {k: v for k, v in mm_kwargs.items() if k in names}
+
     def _expanded_prompt_len(
-        self, token_ids: List[int], images: Optional[List[Any]]
+        self,
+        token_ids: List[int],
+        images: Optional[List[Any]],
+        mm_kwargs: Optional[Dict[str, Any]] = None,
     ) -> Optional[int]:
         """Post-expansion prompt length: text tokens plus per-image tokens, with
         image placeholders in token_ids replaced by their expanded token counts.
@@ -151,8 +188,13 @@ class MultimodalRequestProcessor:
             mm_ids = self.input_processor.get_mm_token_ids()
             mm_id_set = set(mm_ids.tolist()) if mm_ids is not None else set()
             num_placeholders = sum(1 for t in token_ids if t in mm_id_set)
+            sizing_kwargs = self._known_processor_kwargs(mm_kwargs)
             image_tokens = sum(
-                int(self.input_processor.get_num_tokens_per_image(image=img))
+                int(
+                    self.input_processor.get_num_tokens_per_image(
+                        image=img, **sizing_kwargs
+                    )
+                )
                 for img in images
             )
             return len(token_ids) - num_placeholders + image_tokens
@@ -341,10 +383,16 @@ class MultimodalRequestProcessor:
         # Initialize result in TokensPrompt format
         # mm_processor_kwargs must be a dict (not None) for TRT-LLM's processor
         extra_args = request.get("extra_args") or {}
-        mm_kwargs = request.get("mm_processor_kwargs") or extra_args.get(
-            "mm_processor_kwargs"
-        )
-        processed_inputs: Dict[str, Any] = {"mm_processor_kwargs": mm_kwargs or {}}
+        mm_kwargs = resolve_mm_processor_kwargs(request)
+        if mm_kwargs is not None and not isinstance(mm_kwargs, dict):
+            raise HttpStatusError(
+                400,
+                "Malformed mm_processor_kwargs field: expected an object",
+                str(mm_kwargs),
+            )
+        processed_inputs: Dict[str, Any] = {
+            "mm_processor_kwargs": mm_kwargs if mm_kwargs is not None else {}
+        }
 
         # TODO(TRTLLM-11294): Remove the fallback to text_prompt for EPD-NIXL and embeddings cases.
         # This is a temporary workaround to bypass TRT-LLM's bug where token IDs & embeddings
@@ -612,7 +660,9 @@ class MultimodalRequestProcessor:
         # against the real context usage rather than the unexpanded placeholders.
         mm_data = processed_inputs.get("multi_modal_data")
         expanded_len = self._expanded_prompt_len(
-            token_ids, mm_data.get("image") if mm_data else None
+            token_ids,
+            mm_data.get("image") if mm_data else None,
+            processed_inputs.get("mm_processor_kwargs"),
         )
         if expanded_len is not None:
             processed_inputs["expanded_prompt_len"] = expanded_len

--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -340,12 +340,15 @@ class MultimodalRequestProcessor:
 
         # Initialize result in TokensPrompt format
         # mm_processor_kwargs must be a dict (not None) for TRT-LLM's processor
-        processed_inputs: Dict[str, Any] = {"mm_processor_kwargs": {}}
+        extra_args = request.get("extra_args") or {}
+        mm_kwargs = request.get("mm_processor_kwargs") or extra_args.get(
+            "mm_processor_kwargs"
+        )
+        processed_inputs: Dict[str, Any] = {"mm_processor_kwargs": mm_kwargs or {}}
 
         # TODO(TRTLLM-11294): Remove the fallback to text_prompt for EPD-NIXL and embeddings cases.
         # This is a temporary workaround to bypass TRT-LLM's bug where token IDs & embeddings
         # are not processed correctly.
-        extra_args = request.get("extra_args") or {}
         formatted_prompt_from_frontend = extra_args.get("formatted_prompt")
 
         # EPD Flow Case 2: Embeddings received via NIXL from encode worker

--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -147,34 +147,8 @@ class MultimodalRequestProcessor:
         except Exception as e:
             logging.warning("Input processor unavailable for max_tokens sizing: %s", e)
 
-    def _known_processor_kwargs(
-        self, mm_kwargs: Optional[Dict[str, Any]]
-    ) -> Dict[str, Any]:
-        """The subset of mm_kwargs the HF image processor declares valid.
-
-        Unknown keys are dropped: sizing reaches the HF processor's
-        _get_num_multimodal_tokens(), which on some models (Gemma-4) merges
-        kwargs into class-level defaults in place, breaking later requests.
-        """
-        if not mm_kwargs:
-            return {}
-        try:
-            image_processor = getattr(
-                getattr(self.input_processor, "processor", None),
-                "image_processor",
-                None,
-            )
-            valid = getattr(image_processor, "valid_kwargs", None)
-            names = set(getattr(valid, "__annotations__", None) or {})
-        except Exception:
-            names = set()
-        return {k: v for k, v in mm_kwargs.items() if k in names}
-
     def _expanded_prompt_len(
-        self,
-        token_ids: List[int],
-        images: Optional[List[Any]],
-        mm_kwargs: Optional[Dict[str, Any]] = None,
+        self, token_ids: List[int], images: Optional[List[Any]]
     ) -> Optional[int]:
         """Post-expansion prompt length: text tokens plus per-image tokens, with
         image placeholders in token_ids replaced by their expanded token counts.
@@ -188,13 +162,8 @@ class MultimodalRequestProcessor:
             mm_ids = self.input_processor.get_mm_token_ids()
             mm_id_set = set(mm_ids.tolist()) if mm_ids is not None else set()
             num_placeholders = sum(1 for t in token_ids if t in mm_id_set)
-            sizing_kwargs = self._known_processor_kwargs(mm_kwargs)
             image_tokens = sum(
-                int(
-                    self.input_processor.get_num_tokens_per_image(
-                        image=img, **sizing_kwargs
-                    )
-                )
+                int(self.input_processor.get_num_tokens_per_image(image=img))
                 for img in images
             )
             return len(token_ids) - num_placeholders + image_tokens
@@ -659,10 +628,17 @@ class MultimodalRequestProcessor:
         # Post-expansion prompt length, so an omitted max_tokens can be sized
         # against the real context usage rather than the unexpanded placeholders.
         mm_data = processed_inputs.get("multi_modal_data")
-        expanded_len = self._expanded_prompt_len(
-            token_ids,
-            mm_data.get("image") if mm_data else None,
-            processed_inputs.get("mm_processor_kwargs"),
+        # Skipped when the request overrides the processor: the sizing
+        # calculator is not override-aware (Qwen2-VL ignores the kwargs while
+        # counting) and is not guaranteed non-mutating (Gemma-4 writes them
+        # into class-level defaults). Falling back to the engine default beats
+        # a stale or leaked estimate.
+        expanded_len = (
+            None
+            if processed_inputs.get("mm_processor_kwargs")
+            else self._expanded_prompt_len(
+                token_ids, mm_data.get("image") if mm_data else None
+            )
         )
         if expanded_len is not None:
             processed_inputs["expanded_prompt_len"] = expanded_len

--- a/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
@@ -368,6 +368,14 @@ async def test_video_missing_decoder_error_is_actionable(monkeypatch) -> None:
         ({"mm_processor_kwargs": {"num_crops": 4}}, {"num_crops": 4}),
         ({"extra_args": {"mm_processor_kwargs": {"num_crops": 4}}}, {"num_crops": 4}),
         ({}, {}),
+        # Explicit top-level {} wins over extra_args.
+        (
+            {
+                "mm_processor_kwargs": {},
+                "extra_args": {"mm_processor_kwargs": {"num_crops": 9}},
+            },
+            {},
+        ),
     ],
 )
 async def test_mm_processor_kwargs_forwarded(request_extra, expected) -> None:
@@ -387,3 +395,50 @@ async def test_mm_processor_kwargs_forwarded(request_extra, expected) -> None:
     )
 
     assert processed["mm_processor_kwargs"] == expected
+
+
+@pytest.mark.asyncio
+async def test_mm_processor_kwargs_non_object_is_rejected() -> None:
+    """A non-object value is a client error, not a silently ignored field."""
+    processor = MultimodalRequestProcessor(
+        model_type="multimodal",
+        model_dir="unused",
+        max_file_size_mb=10,
+        tokenizer=MagicMock(),
+    )
+
+    with pytest.raises(HttpStatusError) as excinfo:
+        await processor.process_openai_request(
+            {"token_ids": [1, 2, 3], "mm_processor_kwargs": "invalid"},
+            embeddings=None,
+            ep_disaggregated_params=None,
+        )
+
+    assert excinfo.value.status == 400
+
+
+def test_expanded_prompt_len_drops_unknown_processor_kwargs() -> None:
+    """Sizing forwards only kwargs the processor declares valid."""
+    processor = MultimodalRequestProcessor(
+        model_type="multimodal",
+        model_dir="unused",
+        max_file_size_mb=10,
+        tokenizer=MagicMock(),
+    )
+
+    class _ValidKwargs:
+        __annotations__ = {"max_pixels": int}
+
+    ip = MagicMock()
+    ip.processor.image_processor.valid_kwargs = _ValidKwargs
+    ip.get_mm_token_ids.return_value = None
+    ip.get_num_tokens_per_image.return_value = 4
+    processor.input_processor = ip
+
+    processor._expanded_prompt_len(
+        [1, 2, 3], ["img"], {"max_pixels": 1024, "bogus_key": 1}
+    )
+
+    _, kwargs = ip.get_num_tokens_per_image.call_args
+    assert kwargs["max_pixels"] == 1024
+    assert "bogus_key" not in kwargs

--- a/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
@@ -6,6 +6,8 @@ propagate (so the frontend returns a 4xx) instead of swallowing them to None."""
 
 from unittest.mock import AsyncMock, MagicMock
 
+import json
+
 import pytest
 import torch
 
@@ -440,3 +442,69 @@ async def test_expanded_prompt_len_skipped_when_kwargs_override() -> None:
 
     assert "expanded_prompt_len" not in processed
     ip.get_num_tokens_per_image.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_epd_non_object_kwargs_raises_client_error() -> None:
+    """The disaggregated path must raise the same 400 as the aggregated one.
+
+    Yielding an error payload instead reads as a normal encoder response, so the
+    caller surfaces a client mistake as an internal failure.
+    """
+    from dynamo.trtllm.encode_helper import EncodeHelper
+
+    with pytest.raises(HttpStatusError) as excinfo:
+        async for _ in EncodeHelper.process_encode_request(
+            request={
+                "token_ids": [1, 2, 3],
+                "image_urls": ["http://example.invalid/a.png"],
+                "mm_processor_kwargs": "invalid",
+            },
+            tokenizer=MagicMock(),
+            model_dir="unused",
+            model_type="multimodal",
+            engine=MagicMock(),
+        ):
+            pass
+
+    assert excinfo.value.status == 400
+
+
+async def _cache_keys_for(request, url):
+    """Run the real cache path and return the key it looked up."""
+    from dynamo.trtllm.multimodal import embedding_fetcher as ef
+
+    seen = []
+    cache = MagicMock()
+    cache.get.side_effect = lambda h: seen.append(h) or None
+    cache.set = MagicMock()
+
+    async def _encode(_req):
+        raise AssertionError("encode should not run in this test")
+
+    with pytest.raises(Exception):
+        await ef._fetch_embeddings_with_cache([url], request, cache, _encode)
+    return seen[0]
+
+
+@pytest.mark.asyncio
+async def test_embedding_cache_key_does_not_collide_with_plain_url() -> None:
+    """`url + salt` collided when a URL ended with another request's overrides."""
+    overrides = {"max_soft_tokens": 70}
+    salt = json.dumps(overrides, sort_keys=True, default=str)
+    url = "http://example.invalid/a.png"
+
+    salted = await _cache_keys_for({"mm_processor_kwargs": overrides}, url)
+    lookalike = await _cache_keys_for({}, url + salt)
+
+    assert salted != lookalike
+
+
+@pytest.mark.asyncio
+async def test_embedding_cache_key_unchanged_without_overrides() -> None:
+    """No overrides must hash exactly the URL, so existing entries stay valid."""
+    from dynamo.trtllm.multimodal.hasher import MultimodalHasher
+
+    url = "http://example.invalid/a.png"
+    key = await _cache_keys_for({}, url)
+    assert key == MultimodalHasher.hash_bytes(url.encode())

--- a/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
@@ -417,28 +417,26 @@ async def test_mm_processor_kwargs_non_object_is_rejected() -> None:
     assert excinfo.value.status == 400
 
 
-def test_expanded_prompt_len_drops_unknown_processor_kwargs() -> None:
-    """Sizing forwards only kwargs the processor declares valid."""
+@pytest.mark.asyncio
+async def test_expanded_prompt_len_skipped_when_kwargs_override() -> None:
+    """Overridden requests get no sizing hint: the calculator is neither
+    override-aware nor guaranteed non-mutating."""
     processor = MultimodalRequestProcessor(
         model_type="multimodal",
         model_dir="unused",
         max_file_size_mb=10,
         tokenizer=MagicMock(),
     )
-
-    class _ValidKwargs:
-        __annotations__ = {"max_pixels": int}
-
     ip = MagicMock()
-    ip.processor.image_processor.valid_kwargs = _ValidKwargs
     ip.get_mm_token_ids.return_value = None
     ip.get_num_tokens_per_image.return_value = 4
     processor.input_processor = ip
 
-    processor._expanded_prompt_len(
-        [1, 2, 3], ["img"], {"max_pixels": 1024, "bogus_key": 1}
+    processed = await processor.process_openai_request(
+        {"token_ids": [1, 2, 3], "mm_processor_kwargs": {"max_pixels": 1024}},
+        embeddings=None,
+        ep_disaggregated_params=None,
     )
 
-    _, kwargs = ip.get_num_tokens_per_image.call_args
-    assert kwargs["max_pixels"] == 1024
-    assert "bogus_key" not in kwargs
+    assert "expanded_prompt_len" not in processed
+    ip.get_num_tokens_per_image.assert_not_called()

--- a/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
@@ -453,17 +453,30 @@ async def test_epd_non_object_kwargs_raises_client_error() -> None:
     """
     from dynamo.trtllm.encode_helper import EncodeHelper
 
+    # URLs come from the processor, not the request; the engine must report an
+    # available encoder, or the flow short-circuits before the kwargs check.
+    processor = MagicMock()
+    processor.extract_prompt_and_media.return_value = (
+        "describe",
+        ["http://example.invalid/a.png"],
+        [],
+    )
+    engine = MagicMock()
+    engine.encoder_available = True
+
     with pytest.raises(HttpStatusError) as excinfo:
         async for _ in EncodeHelper.process_encode_request(
             request={
                 "token_ids": [1, 2, 3],
-                "image_urls": ["http://example.invalid/a.png"],
+                "messages": [{"role": "user", "content": "describe"}],
                 "mm_processor_kwargs": "invalid",
             },
+            multimodal_processor=processor,
+            connector=None,
             tokenizer=MagicMock(),
             model_dir="unused",
             model_type="multimodal",
-            engine=MagicMock(),
+            engine=engine,
         ):
             pass
 
@@ -508,3 +521,25 @@ async def test_embedding_cache_key_unchanged_without_overrides() -> None:
     url = "http://example.invalid/a.png"
     key = await _cache_keys_for({}, url)
     assert key == MultimodalHasher.hash_bytes(url.encode())
+
+
+@pytest.mark.asyncio
+async def test_cached_path_rejects_non_object_kwargs_on_hit() -> None:
+    """A cache hit must not mask a malformed value with a 200."""
+    from dynamo.trtllm.multimodal import embedding_fetcher as ef
+
+    url = "http://example.invalid/a.png"
+    cache = MagicMock()
+    # Pre-seeded so a plain-URL hash would hit and return early.
+    cache.get.return_value = MagicMock(tensor=torch.zeros(1))
+
+    async def _encode(_req):
+        raise AssertionError("encode must not run")
+
+    with pytest.raises(HttpStatusError) as excinfo:
+        await ef._fetch_embeddings_with_cache(
+            [url], {"mm_processor_kwargs": "invalid"}, cache, _encode
+        )
+
+    assert excinfo.value.status == 400
+    cache.get.assert_not_called()

--- a/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
@@ -4,9 +4,8 @@
 """process_openai_request must let client-error types from image loading
 propagate (so the frontend returns a 4xx) instead of swallowing them to None."""
 
-from unittest.mock import AsyncMock, MagicMock
-
 import json
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import torch

--- a/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
@@ -359,3 +359,31 @@ async def test_video_missing_decoder_error_is_actionable(monkeypatch) -> None:
     assert "install_media_decoders trtllm" in msg
     # The vendor loader's own text survives as the cause.
     assert "OpenCV (cv2) is required for video decoding" in msg
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_extra, expected",
+    [
+        ({"mm_processor_kwargs": {"num_crops": 4}}, {"num_crops": 4}),
+        ({"extra_args": {"mm_processor_kwargs": {"num_crops": 4}}}, {"num_crops": 4}),
+        ({}, {}),
+    ],
+)
+async def test_mm_processor_kwargs_forwarded(request_extra, expected) -> None:
+    """Overrides reach the engine inputs from either location; absent yields {},
+    which TRT-LLM's processor requires instead of None."""
+    processor = MultimodalRequestProcessor(
+        model_type="multimodal",
+        model_dir="unused",
+        max_file_size_mb=10,
+        tokenizer=MagicMock(),
+    )
+
+    processed = await processor.process_openai_request(
+        {"token_ids": [1, 2, 3], **request_extra},
+        embeddings=None,
+        ep_disaggregated_params=None,
+    )
+
+    assert processed["mm_processor_kwargs"] == expected


### PR DESCRIPTION
The worker hardcoded `mm_processor_kwargs` to `{}` when building the TokensPrompt, so
per-request processor overrides reached the worker and were dropped before
`generate_async`, with the request still returning 200.

Read the value from the request instead, accepting the top-level field and the
`extra_args` location with the same precedence the vLLM backend uses. An absent value
still yields `{}`, which TRT-LLM's processor requires.

## Overview:

`mm_processor_kwargs` lets a client pass per-request overrides to the multimodal
processor. The frontend forwards it and the vLLM backend consumes it, but the
TensorRT-LLM backend discarded it and still returned HTTP 200, so callers had no signal.

## Details:

`process_openai_request()` initialized the TokensPrompt with `{"mm_processor_kwargs": {}}`.
It now reads the request value, top-level first with an `extra_args` fallback, matching
vLLM's `get_mm_processor_kwargs()`. Absent still yields `{}`, not `None`.

## Where should the reviewer start?

`components/src/dynamo/trtllm/multimodal_processor.py` - 5 line-diff in this file is the whole fix.

## Testing

Unit test covers top-level, `extra_args`, and absent.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Multimodal processing now correctly forwards additional processor options supplied with requests.
  * Requests without these options continue to use an empty configuration, improving consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->