### PR TITLE
fix(release): backport CI routing and planner fixes to 1.4.2

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      # actionlint 1.7.12 does not recognize GitHub's self-repository syntax yet.
+      - '^specifying action "\$/\.github/(actions|workflows)/[^"]+" in invalid format because ref is missing\.'
+      - '^reusable workflow call "\$/\.github/workflows/[^"]+" at "uses" is not following the format '
+  .github/actions/**/action.{yml,yaml}:
+    ignore:
+      - '^specifying action "\$/\.github/actions/[^"]+" in invalid format because ref is missing\.'

--- a/.github/actions/build-deploy-component/action.yml
+++ b/.github/actions/build-deploy-component/action.yml
@@ -142,14 +142,14 @@ runs:
         echo "run_compliance=${RUN_COMPLIANCE}" >> $GITHUB_OUTPUT
 
     - name: Initialize Dynamo Builder
-      uses: ./.github/actions/init-dynamo-builder
+      uses: $/.github/actions/init-dynamo-builder
       with:
         builder_name: ${{ inputs.builder_name }}
         flavor: general
         arch: ${{ steps.settings.outputs.build_platforms }}
 
     - name: Docker Login
-      uses: ./.github/actions/docker-login
+      uses: $/.github/actions/docker-login
       with:
         aws_default_region: ${{ inputs.aws_default_region }}
         aws_account_id: ${{ inputs.aws_account_id }}

--- a/.github/actions/builder-refresher/action.yml
+++ b/.github/actions/builder-refresher/action.yml
@@ -81,7 +81,7 @@ runs:
 
     - name: Re-initialize builder (if unhealthy)
       if: steps.check-health.outcome == 'failure'
-      uses: ./.github/actions/init-dynamo-builder
+      uses: $/.github/actions/init-dynamo-builder
       with:
         builder_name: ${{ inputs.builder_name }}
         flavor: ${{ inputs.flavor }}

--- a/.github/actions/check-vcluster-exists/action.yml
+++ b/.github/actions/check-vcluster-exists/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Install vCluster CLI
-      uses: ./.github/actions/install-vcluster-cli
+      uses: $/.github/actions/install-vcluster-cli
 
     - name: Check if vCluster exists
       id: check

--- a/.github/actions/compliance-scan/action.yml
+++ b/.github/actions/compliance-scan/action.yml
@@ -66,7 +66,7 @@ runs:
         fi
         echo "base_image=${BASE_IMAGE}" >> $GITHUB_OUTPUT
     - name: Initialize builder
-      uses: ./.github/actions/init-dynamo-builder
+      uses: $/.github/actions/init-dynamo-builder
       with:
         builder_name: ${{ steps.builder.outputs.name }}
         flavor: general
@@ -89,7 +89,7 @@ runs:
 
     - name: Refresh BuildKit builder
       if: ${{ inputs.target != 'dev' }}
-      uses: ./.github/actions/builder-refresher
+      uses: $/.github/actions/builder-refresher
       with:
         builder_name: ${{ steps.builder.outputs.name }}
         flavor: general

--- a/.github/actions/connect-vcluster/action.yml
+++ b/.github/actions/connect-vcluster/action.yml
@@ -29,7 +29,7 @@ runs:
         echo "KUBECONFIG=${{ github.workspace }}/.kubeconfig-host" >> $GITHUB_ENV
 
     - name: Install vCluster CLI
-      uses: ./.github/actions/install-vcluster-cli
+      uses: $/.github/actions/install-vcluster-cli
 
     - name: Connect to vCluster
       id: connect

--- a/.github/actions/init-dynamo-builder/action.yml
+++ b/.github/actions/init-dynamo-builder/action.yml
@@ -22,14 +22,14 @@ description: 'Route buildkit workers and bootstrap buildx builder for dynamo bui
 #
 # Usage examples:
 #   # Initialize for both architectures with general flavor:
-#   - uses: ./.github/actions/init-dynamo-builder
+#   - uses: $/.github/actions/init-dynamo-builder
 #     with:
 #       builder_name: my-builder
 #       flavor: general
 #       arch: 'linux/amd64,linux/arm64'
 #
 #   # Initialize for single architecture with specific flavor and CUDA version:
-#   - uses: ./.github/actions/init-dynamo-builder
+#   - uses: $/.github/actions/init-dynamo-builder
 #     with:
 #       builder_name: my-builder
 #       flavor: vllm
@@ -140,7 +140,7 @@ runs:
         fi
 
     - name: Bootstrap buildkit
-      uses: ./.github/actions/bootstrap-buildkit
+      uses: $/.github/actions/bootstrap-buildkit
       with:
         builder_name: ${{ inputs.builder_name }}
         buildkit_worker_addresses: ${{ inputs.fresh_builder != 'true' && steps.prepare.outputs.worker_addresses || '' }}

--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -133,7 +133,7 @@ runs:
         echo "operator_tag=${{ inputs.operator_tag }}" >> "$GITHUB_OUTPUT"
 
     - name: Install vCluster CLI
-      uses: ./.github/actions/install-vcluster-cli
+      uses: $/.github/actions/install-vcluster-cli
 
     - name: Create host namespace
       shell: bash
@@ -317,7 +317,7 @@ runs:
 
     - name: Connect to vCluster
       id: connect-vcluster
-      uses: ./.github/actions/connect-vcluster
+      uses: $/.github/actions/connect-vcluster
       with:
         host_kubeconfig_base64: ${{ inputs.kubeconfig_base64 }}
         vcluster_name: ${{ steps.resolve-names.outputs.vcluster_name }}

--- a/.github/actions/skopeo-copy/action.yml
+++ b/.github/actions/skopeo-copy/action.yml
@@ -67,7 +67,7 @@ runs:
   using: "composite"
   steps:
     - name: Login to Source Registry
-      uses: ./.github/actions/skopeo-login
+      uses: $/.github/actions/skopeo-login
       with:
         aws_default_region: ${{ inputs.source_aws_default_region }}
         aws_account_id: ${{ inputs.source_aws_account_id }}
@@ -76,7 +76,7 @@ runs:
         azure_acr_password: ${{ inputs.source_azure_acr_password }}
 
     - name: Login to Target Registry
-      uses: ./.github/actions/skopeo-login
+      uses: $/.github/actions/skopeo-login
       with:
         aws_default_region: ${{ inputs.target_aws_default_region }}
         aws_account_id: ${{ inputs.target_aws_account_id }}

--- a/.github/actions/teardown-dynamo-operator/action.yml
+++ b/.github/actions/teardown-dynamo-operator/action.yml
@@ -57,7 +57,7 @@ runs:
         echo "KUBECONFIG=${{ github.workspace }}/.kubeconfig" >> $GITHUB_ENV
 
     - name: Install vCluster CLI
-      uses: ./.github/actions/install-vcluster-cli
+      uses: $/.github/actions/install-vcluster-cli
 
     - name: Delete vCluster
       shell: bash

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -70,6 +70,7 @@ ignore:
   - '.github/copy-pr-bot.yaml'
   - '.github/dco.yml'
   - '.github/allurerc.mjs'
+  - '.github/actionlint.yaml'
   - 'container/Dockerfile.docs'
   - 'container/run.sh'
   - 'container/use-sccache.sh'

--- a/.github/workflows/allure-report.yml
+++ b/.github/workflows/allure-report.yml
@@ -62,7 +62,7 @@ jobs:
 
   generate-report:
     needs: resolve-params
-    uses: ./.github/workflows/generate-allure-report.yml
+    uses: $/.github/workflows/generate-allure-report.yml
     with:
       run_id: ${{ needs.resolve-params.outputs.run_id }}
       subdir: ${{ needs.resolve-params.outputs.subdir }}

--- a/.github/workflows/build-on-demand.yml
+++ b/.github/workflows/build-on-demand.yml
@@ -53,7 +53,7 @@ jobs:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [init]
     if: inputs.build_vllm
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: vllm
       target: runtime
@@ -67,7 +67,7 @@ jobs:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [init]
     if: inputs.build_sglang
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: sglang
       target: runtime
@@ -81,7 +81,7 @@ jobs:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [init]
     if: inputs.build_trtllm
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: trtllm
       target: runtime
@@ -94,7 +94,7 @@ jobs:
   vllm-copy-to-acr:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [vllm-build]
-    uses: ./.github/workflows/shared-copy.yml
+    uses: $/.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
@@ -105,7 +105,7 @@ jobs:
   sglang-copy-to-acr:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [sglang-build]
-    uses: ./.github/workflows/shared-copy.yml
+    uses: $/.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
@@ -116,7 +116,7 @@ jobs:
   trtllm-copy-to-acr:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [trtllm-build]
-    uses: ./.github/workflows/shared-copy.yml
+    uses: $/.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
@@ -141,13 +141,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Initialize Dynamo Builder
-        uses: ./.github/actions/init-dynamo-builder
+        uses: $/.github/actions/init-dynamo-builder
         with:
           builder_name: ${{ needs.init.outputs.builder_name }}
           flavor: general
           arch: 'linux/amd64,linux/arm64'
       - name: Docker Login
-        uses: ./.github/actions/docker-login
+        uses: $/.github/actions/docker-login
         with:
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
           aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
@@ -199,7 +199,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Create K8s builders (skip bootstrap)
-      uses: ./.github/actions/bootstrap-buildkit
+      uses: $/.github/actions/bootstrap-buildkit
       continue-on-error: true
       with:
         builder_name: ${{ needs.init.outputs.builder_name }}

--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -77,7 +77,7 @@ on:
 
 jobs:
   image:
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: dynamo
       target: runtime
@@ -207,7 +207,7 @@ jobs:
   parallel:
     name: test
     needs: image
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: dynamo
       test_type: parallel
@@ -228,7 +228,7 @@ jobs:
   sequential:
     name: test
     needs: image
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: dynamo
       test_type: sequential
@@ -249,7 +249,7 @@ jobs:
   gpu:
     name: test
     needs: image
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: dynamo
       test_type: gpu

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -83,7 +83,7 @@ jobs:
         # Do not use fetch-depth: 0 — changed-files now works with shallow clone
       - name: Check for changes
         id: changes
-        uses: ./.github/actions/changed-files
+        uses: $/.github/actions/changed-files
         with:
           gh_token: ${{ github.token }}
 

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo "builder_name=${{ env.BUILDER_NAME }}" >> $GITHUB_OUTPUT
       - name: Create and bootstrap fresh K8s builder
-        uses: ./.github/actions/bootstrap-buildkit
+        uses: $/.github/actions/bootstrap-buildkit
         with:
           builder_name: ${{ steps.export-builder-name.outputs.builder_name }}
           buildkit_worker_addresses: ''
@@ -250,7 +250,7 @@ jobs:
   vllm-build:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [create-fresh-builder, resolve-source-sha]
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: vllm
       target: runtime
@@ -274,7 +274,7 @@ jobs:
   sglang-build:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [create-fresh-builder, resolve-source-sha]
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: sglang
       target: runtime
@@ -295,7 +295,7 @@ jobs:
   trtllm-build:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [create-fresh-builder, resolve-source-sha]
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: trtllm
       target: runtime
@@ -341,7 +341,7 @@ jobs:
         # Do not use fetch-depth: 0 — it fetches all 1600+ branches (~3 min)
       - name: Build and push operator (nightly tag)
         id: build
-        uses: ./.github/actions/build-deploy-component
+        uses: $/.github/actions/build-deploy-component
         with:
           component: operator
           image_tag: ${{ github.sha }}-operator-nightly
@@ -360,7 +360,7 @@ jobs:
   planner-build:
     name: dynamo-planner
     needs: [create-fresh-builder, resolve-source-sha]
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: dynamo
       target: planner
@@ -398,7 +398,7 @@ jobs:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [vllm-build, resolve-source-sha, compute-release-mode]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: nightly
       dd_flaky_retry_enabled: 'false'
@@ -425,7 +425,7 @@ jobs:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [vllm-build, resolve-source-sha, compute-release-mode]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: nightly
       dd_flaky_retry_enabled: 'false'
@@ -450,7 +450,7 @@ jobs:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [vllm-build, resolve-source-sha, compute-release-mode]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: nightly
       dd_flaky_retry_enabled: 'false'
@@ -476,7 +476,7 @@ jobs:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [sglang-build, resolve-source-sha, compute-release-mode]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: nightly
       dd_flaky_retry_enabled: 'false'
@@ -505,7 +505,7 @@ jobs:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [sglang-build, resolve-source-sha, compute-release-mode]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: nightly
       dd_flaky_retry_enabled: 'false'
@@ -527,7 +527,7 @@ jobs:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [sglang-build, resolve-source-sha, compute-release-mode]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: nightly
       dd_flaky_retry_enabled: 'false'
@@ -553,7 +553,7 @@ jobs:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [trtllm-build, resolve-source-sha, compute-release-mode]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: nightly
       dd_flaky_retry_enabled: 'false'
@@ -581,7 +581,7 @@ jobs:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [trtllm-build, resolve-source-sha, compute-release-mode]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: nightly
       dd_flaky_retry_enabled: 'false'
@@ -603,7 +603,7 @@ jobs:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [trtllm-build, resolve-source-sha, compute-release-mode]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: nightly
       dd_flaky_retry_enabled: 'false'
@@ -633,7 +633,7 @@ jobs:
     name: vllm-xpu
     needs: [resolve-source-sha, compute-release-mode]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
-    uses: ./.github/workflows/xpu-ci.yaml
+    uses: $/.github/workflows/xpu-ci.yaml
     with:
       framework: vllm
       pytest_markers: 'vllm'
@@ -645,7 +645,7 @@ jobs:
   dynamo-pipeline:
     name: dynamo-runtime
     needs: [create-fresh-builder, compute-dev-version, resolve-source-sha]
-    uses: ./.github/workflows/dynamo-pipeline.yml
+    uses: $/.github/workflows/dynamo-pipeline.yml
     with:
       builder_name: ${{ needs.create-fresh-builder.outputs.builder_name }}
       fresh_builder: true
@@ -772,7 +772,7 @@ jobs:
         && needs.dynamo-pipeline.result == 'success'
         && (needs.manual-release-approval.result == 'success'
             || needs.manual-release-approval.result == 'skipped') }}
-    uses: ./.github/workflows/release.yml
+    uses: $/.github/workflows/release.yml
     with:
       commit_sha: ${{ needs.resolve-source-sha.outputs.source_sha }}
       nightly: true
@@ -1005,7 +1005,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Register K8s builder context (skip bootstrap)
-        uses: ./.github/actions/bootstrap-buildkit
+        uses: $/.github/actions/bootstrap-buildkit
         continue-on-error: true
         with:
           builder_name: ${{ needs.create-fresh-builder.outputs.builder_name }}
@@ -1023,7 +1023,7 @@ jobs:
     permissions:
       contents: read
       actions: read   # grant the reusable notifier read access to list this run's jobs
-    uses: ./.github/workflows/notify-slack.yml
+    uses: $/.github/workflows/notify-slack.yml
     with:
       pipeline_name: Nightly
       runs_on: prod-default-v2

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -1061,7 +1061,7 @@ jobs:
   ############################## SLACK NOTIFICATION ##############################
   notify-slack:
     if: always()
-    needs: [vllm-test, vllm-multi-gpu-test, vllm-4-gpu-test, vllm-h100-test, sglang-test, sglang-multi-gpu-test, sglang-4-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, trtllm-h100-test, deploy-cleanup, rust-tests]
+    needs: [vllm-test, vllm-multi-gpu-test, vllm-4-gpu-test, vllm-h100-test, sglang-test, sglang-multi-gpu-test, sglang-4-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, trtllm-h100-test, rust-tests]
     permissions:
       contents: read
       actions: read   # grant the reusable notifier read access to list this run's jobs

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -430,17 +430,37 @@ jobs:
       dd_env: nightly
       dd_flaky_retry_enabled: 'false'
       test_suite_name: vllm
-      test_type: Multi-GPU Test
+      test_type: 2-GPU Test
+      amd_runner: prod-tester-amd-gpu-2-v2
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64"]' # No ARM GPUs available
+      enable_coverage: true
+      run_sanity_check: false
+      gpu_test_markers: vllm and gpu_2 and not h100
+      gpu_test_timeout_minutes: 45
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
+    secrets: inherit
+
+  vllm-4-gpu-test:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [vllm-build, resolve-source-sha, compute-release-mode]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: $/.github/workflows/shared-test.yml
+    with:
+      dd_env: nightly
+      dd_flaky_retry_enabled: 'false'
+      test_suite_name: vllm
+      test_type: 4-GPU Test
       amd_runner: prod-tester-amd-gpu-4-v2
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
       enable_coverage: true
       run_sanity_check: false
-      # Includes elastic_ep, locally validated DP=2->4->2 on H200 GPUs with
-      # vLLM 0.24.0. That test remains pytest-skipped because this runner has
-      # 24 GiB/GPU, while its unquantized EPLB model needs >=80 GiB/GPU.
-      gpu_test_markers: vllm and (gpu_2 or gpu_4)
+      # elastic_ep remains skipped because it needs at least 80 GiB per GPU.
+      gpu_test_markers: vllm and gpu_4 and not h100
       gpu_test_timeout_minutes: 45
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
@@ -510,14 +530,36 @@ jobs:
       dd_env: nightly
       dd_flaky_retry_enabled: 'false'
       test_suite_name: sglang
-      test_type: Multi-GPU Test
+      test_type: 2-GPU Test
+      amd_runner: prod-tester-amd-gpu-2-v2
+      target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64"]' # No ARM GPUs available
+      enable_coverage: true
+      run_sanity_check: false
+      gpu_test_markers: sglang and gpu_2 and not h100
+      gpu_test_timeout_minutes: 45
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
+    secrets: inherit
+
+  sglang-4-gpu-test:
+    name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
+    needs: [sglang-build, resolve-source-sha, compute-release-mode]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: $/.github/workflows/shared-test.yml
+    with:
+      dd_env: nightly
+      dd_flaky_retry_enabled: 'false'
+      test_suite_name: sglang
+      test_type: 4-GPU Test
       amd_runner: prod-tester-amd-gpu-4-v2
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
       enable_coverage: true
       run_sanity_check: false
-      gpu_test_markers: sglang and (gpu_2 or gpu_4)
+      gpu_test_markers: sglang and gpu_4 and not h100
       gpu_test_timeout_minutes: 45
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
@@ -586,14 +628,14 @@ jobs:
       dd_env: nightly
       dd_flaky_retry_enabled: 'false'
       test_suite_name: trtllm
-      test_type: Multi-GPU Test
-      amd_runner: prod-tester-amd-gpu-4-v2
+      test_type: 2-GPU Test
+      amd_runner: prod-tester-amd-gpu-2-v2
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
       platform: '["amd64"]' # No ARM GPUs available
       enable_coverage: true
       run_sanity_check: false
-      gpu_test_markers: trtllm and (gpu_2 or gpu_4)
+      gpu_test_markers: trtllm and gpu_2 and not h100
       gpu_test_timeout_minutes: 45
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
@@ -793,7 +835,7 @@ jobs:
   coverage-report:
     name: Generate Coverage Report
     runs-on: ubuntu-latest
-    needs: [vllm-test, vllm-multi-gpu-test, vllm-h100-test, sglang-test, sglang-multi-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, trtllm-h100-test, rust-tests]
+    needs: [vllm-test, vllm-multi-gpu-test, vllm-4-gpu-test, vllm-h100-test, sglang-test, sglang-multi-gpu-test, sglang-4-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, trtllm-h100-test, rust-tests]
     if: always()
     permissions:
       contents: read
@@ -1019,7 +1061,7 @@ jobs:
   ############################## SLACK NOTIFICATION ##############################
   notify-slack:
     if: always()
-    needs: [vllm-test, vllm-multi-gpu-test, vllm-h100-test, sglang-test, sglang-multi-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, trtllm-h100-test, rust-tests]
+    needs: [vllm-test, vllm-multi-gpu-test, vllm-4-gpu-test, vllm-h100-test, sglang-test, sglang-multi-gpu-test, sglang-4-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, trtllm-h100-test, deploy-cleanup, rust-tests]
     permissions:
       contents: read
       actions: read   # grant the reusable notifier read access to list this run's jobs

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -1,6 +1,6 @@
 # Reusable Slack failure notifier shared by the Post-merge and Nightly CI pipelines.
 # Collects the calling run's failed jobs and, if any are reportable, posts an alert
-# to Slack. Called via `uses: ./.github/workflows/notify-slack.yml`.
+# to Slack. Called via `uses: $/.github/workflows/notify-slack.yml`.
 name: Notify Slack
 
 on:

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -56,7 +56,7 @@ jobs:
   dynamo-pipeline:
     name: dynamo-runtime
     if: github.event_name != 'workflow_dispatch'
-    uses: ./.github/workflows/dynamo-pipeline.yml
+    uses: $/.github/workflows/dynamo-pipeline.yml
     with:
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       # TODO: widen to include `post_merge` — today it picks up tests
@@ -82,7 +82,7 @@ jobs:
         # Do not use fetch-depth: 0 — it fetches all 1600+ branches (~3 min)
       - name: Build and push operator
         id: build
-        uses: ./.github/actions/build-deploy-component
+        uses: $/.github/actions/build-deploy-component
         with:
           component: operator
           image_tag: ${{ github.sha }}-operator
@@ -112,7 +112,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Build and push snapshot agent
-        uses: ./.github/actions/build-deploy-component
+        uses: $/.github/actions/build-deploy-component
         with:
           component: snapshot
           image_tag: ${{ github.sha }}-snapshot-agent
@@ -142,7 +142,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Build and push power agent
-        uses: ./.github/actions/build-deploy-component
+        uses: $/.github/actions/build-deploy-component
         with:
           component: power-agent
           target: runtime  # push the slim shipped stage, not the test stage
@@ -158,7 +158,7 @@ jobs:
       - name: Refresh BuildKit builder
         # The runtime build above can leave the remote BuildKit connection stale;
         # re-establish it (re-routing only if unhealthy) before the test build.
-        uses: ./.github/actions/builder-refresher
+        uses: $/.github/actions/builder-refresher
         with:
           builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
           flavor: general
@@ -192,7 +192,7 @@ jobs:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [config]
     if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_vllm == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: vllm
       target: runtime
@@ -215,7 +215,7 @@ jobs:
     name: vllm-dev
     needs: [config]
     if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_vllm == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: vllm
       target: dev
@@ -233,7 +233,7 @@ jobs:
     name: vllm-runtime-efa
     needs: [config]
     if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_vllm == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: vllm
       target: runtime
@@ -257,7 +257,7 @@ jobs:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [config]
     if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_sglang == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: sglang
       target: runtime
@@ -280,7 +280,7 @@ jobs:
     name: sglang-dev
     needs: [config]
     if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_sglang == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: sglang
       target: dev
@@ -298,7 +298,7 @@ jobs:
     name: sglang-runtime-efa
     needs: [config]
     if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_sglang == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: sglang
       target: runtime
@@ -322,7 +322,7 @@ jobs:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [config]
     if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_trtllm == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: trtllm
       target: runtime
@@ -345,7 +345,7 @@ jobs:
     name: trtllm-dev
     needs: [config]
     if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_trtllm == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: trtllm
       target: dev
@@ -363,7 +363,7 @@ jobs:
     name: trtllm-runtime-efa
     needs: [config]
     if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_trtllm == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: trtllm
       target: runtime
@@ -386,7 +386,7 @@ jobs:
   planner-build:
     name: planner # This name overlaps with other planner jobs to group them in the UI
     if: github.event_name != 'workflow_dispatch'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: dynamo
       target: planner
@@ -409,7 +409,7 @@ jobs:
     name: frontend
     needs: [config]
     if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_vllm == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: dynamo
       target: frontend
@@ -435,7 +435,7 @@ jobs:
   vllm-test:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [vllm-build]
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
       test_suite_name: vllm
@@ -458,7 +458,7 @@ jobs:
   vllm-multi-gpu-test:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [vllm-build]
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
       test_suite_name: vllm
@@ -475,7 +475,7 @@ jobs:
   vllm-efa-test:
     name: vllm-runtime-efa
     needs: [vllm-efa-build]
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
       test_suite_name: vllm-efa
@@ -493,7 +493,7 @@ jobs:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [config, vllm-build]
     if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_vllm == 'true'
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
       test_suite_name: kvbm
@@ -516,7 +516,7 @@ jobs:
   sglang-test:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [sglang-build]
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
       test_suite_name: sglang
@@ -539,7 +539,7 @@ jobs:
   sglang-multi-gpu-test:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [sglang-build]
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
       test_suite_name: sglang
@@ -556,7 +556,7 @@ jobs:
   trtllm-test:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [trtllm-build]
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
       test_suite_name: trtllm
@@ -579,7 +579,7 @@ jobs:
   trtllm-multi-gpu-test:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [trtllm-build]
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
       test_suite_name: trtllm
@@ -596,7 +596,7 @@ jobs:
   trtllm-efa-test:
     name: trtllm-runtime-efa
     needs: [trtllm-efa-build]
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
       test_suite_name: trtllm-efa
@@ -613,7 +613,7 @@ jobs:
   planner-test:
     name: planner # This name overlaps with other planner jobs to group them in the UI
     needs: [planner-build]
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
       test_suite_name: planner
@@ -638,7 +638,7 @@ jobs:
     name: vllm-xpu
     needs: [config]
     if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_vllm == 'true'
-    uses: ./.github/workflows/xpu-ci.yaml
+    uses: $/.github/workflows/xpu-ci.yaml
     with:
       framework: vllm
       pytest_markers: '(pre_merge or post_merge) and vllm'
@@ -659,7 +659,7 @@ jobs:
   planner-compliance:
     name: planner # This name overlaps with other planner jobs to group them in the UI
     needs: [planner-build]
-    uses: ./.github/workflows/shared-compliance.yml
+    uses: $/.github/workflows/shared-compliance.yml
     with:
       framework: dynamo
       target: planner
@@ -675,7 +675,7 @@ jobs:
   vllm-copy-to-acr:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [vllm-build]
-    uses: ./.github/workflows/shared-copy.yml
+    uses: $/.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]' # Deploy tests only use CUDA 13
@@ -695,7 +695,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build and push snapshot placeholder
-        uses: ./.github/actions/build-deploy-component
+        uses: $/.github/actions/build-deploy-component
         with:
           component: snapshot
           target: placeholder
@@ -714,7 +714,7 @@ jobs:
   vllm-dev-copy-to-acr:
     name: vllm-dev # This name overlaps with other vllm jobs to group them in the UI
     needs: [vllm-dev-build]
-    uses: ./.github/workflows/shared-copy.yml
+    uses: $/.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.vllm-dev-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
@@ -725,7 +725,7 @@ jobs:
   sglang-copy-to-acr:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [sglang-build]
-    uses: ./.github/workflows/shared-copy.yml
+    uses: $/.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]' # Deploy tests only use CUDA 13
@@ -745,7 +745,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build and push snapshot placeholder
-        uses: ./.github/actions/build-deploy-component
+        uses: $/.github/actions/build-deploy-component
         with:
           component: snapshot
           target: placeholder
@@ -767,7 +767,7 @@ jobs:
     if: |
       always() &&
       needs.sglang-dev-build.result == 'success'
-    uses: ./.github/workflows/shared-copy.yml
+    uses: $/.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.sglang-dev-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
@@ -778,7 +778,7 @@ jobs:
   trtllm-copy-to-acr:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [trtllm-build]
-    uses: ./.github/workflows/shared-copy.yml
+    uses: $/.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
@@ -798,7 +798,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build and push snapshot placeholder
-        uses: ./.github/actions/build-deploy-component
+        uses: $/.github/actions/build-deploy-component
         with:
           component: snapshot
           target: placeholder
@@ -820,7 +820,7 @@ jobs:
     if: |
       always() &&
       needs.trtllm-dev-build.result == 'success'
-    uses: ./.github/workflows/shared-copy.yml
+    uses: $/.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.trtllm-dev-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
@@ -831,7 +831,7 @@ jobs:
   frontend-copy-to-acr:
     name: frontend # This name overlaps with other frontend jobs to group them in the UI
     needs: [frontend-build]
-    uses: ./.github/workflows/shared-copy.yml
+    uses: $/.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.frontend-build.outputs.target_tag_plain }}
       cuda_version: '[""]'
@@ -857,7 +857,7 @@ jobs:
         persist-credentials: false
     - name: Setup vCluster and operator
       id: setup
-      uses: ./.github/actions/setup-dynamo-operator
+      uses: $/.github/actions/setup-dynamo-operator
       with:
         registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
         operator_tag: ${{ needs.operator.outputs.operator_default_tag }}
@@ -871,7 +871,7 @@ jobs:
 
   deploy-test-vllm:
     needs: [deploy-operator, vllm-copy-to-acr]
-    uses: ./.github/workflows/shared-deploy-test.yml
+    uses: $/.github/workflows/shared-deploy-test.yml
     with:
       framework: vllm
       profiles: '["agg", "agg_router", "disagg", "disagg_router"]'
@@ -883,7 +883,7 @@ jobs:
 
   deploy-test-sglang:
     needs: [deploy-operator, sglang-copy-to-acr]
-    uses: ./.github/workflows/shared-deploy-test.yml
+    uses: $/.github/workflows/shared-deploy-test.yml
     with:
       framework: sglang
       profiles: '["agg", "agg_router"]'
@@ -895,7 +895,7 @@ jobs:
 
   deploy-test-trtllm:
     needs: [deploy-operator, trtllm-copy-to-acr]
-    uses: ./.github/workflows/shared-deploy-test.yml
+    uses: $/.github/workflows/shared-deploy-test.yml
     with:
       framework: trtllm
       profiles: '["agg", "agg_router"]'
@@ -920,7 +920,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Setup vCluster and operator
       id: setup
-      uses: ./.github/actions/setup-dynamo-operator
+      uses: $/.github/actions/setup-dynamo-operator
       with:
         vcluster_name: ci-${{ github.run_id }}-checkpoint-vllm
         vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-vllm-dt
@@ -947,7 +947,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Setup vCluster and operator
       id: setup
-      uses: ./.github/actions/setup-dynamo-operator
+      uses: $/.github/actions/setup-dynamo-operator
       with:
         vcluster_name: ci-${{ github.run_id }}-checkpoint-sglang
         vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-sglang-dt
@@ -974,7 +974,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Setup vCluster and operator
       id: setup
-      uses: ./.github/actions/setup-dynamo-operator
+      uses: $/.github/actions/setup-dynamo-operator
       with:
         vcluster_name: ci-${{ github.run_id }}-checkpoint-trtllm
         vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-trtllm-dt
@@ -1002,13 +1002,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check if vCluster exists
         id: vcluster-check
-        uses: ./.github/actions/check-vcluster-exists
+        uses: $/.github/actions/check-vcluster-exists
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
@@ -1021,12 +1021,12 @@ jobs:
           checkpoint_storage_size: 64Gi
       - name: Connect to vCluster
         id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
+        uses: $/.github/actions/connect-vcluster
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
       - name: Install snapshot-agent
-        uses: ./.github/actions/setup-snapshot-agent
+        uses: $/.github/actions/setup-snapshot-agent
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
@@ -1048,13 +1048,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check if vCluster exists
         id: vcluster-check
-        uses: ./.github/actions/check-vcluster-exists
+        uses: $/.github/actions/check-vcluster-exists
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
@@ -1067,12 +1067,12 @@ jobs:
           checkpoint_storage_size: 64Gi
       - name: Connect to vCluster
         id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
+        uses: $/.github/actions/connect-vcluster
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
       - name: Install snapshot-agent
-        uses: ./.github/actions/setup-snapshot-agent
+        uses: $/.github/actions/setup-snapshot-agent
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
@@ -1094,13 +1094,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check if vCluster exists
         id: vcluster-check
-        uses: ./.github/actions/check-vcluster-exists
+        uses: $/.github/actions/check-vcluster-exists
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
@@ -1113,12 +1113,12 @@ jobs:
           checkpoint_storage_size: 64Gi
       - name: Connect to vCluster
         id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
+        uses: $/.github/actions/connect-vcluster
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
       - name: Install snapshot-agent
-        uses: ./.github/actions/setup-snapshot-agent
+        uses: $/.github/actions/setup-snapshot-agent
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
@@ -1141,13 +1141,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check if vCluster exists
         id: vcluster-check
-        uses: ./.github/actions/check-vcluster-exists
+        uses: $/.github/actions/check-vcluster-exists
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
@@ -1160,19 +1160,19 @@ jobs:
           checkpoint_storage_size: 64Gi
       - name: Connect to vCluster
         id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
+        uses: $/.github/actions/connect-vcluster
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
       - name: Install snapshot-agent (rerun bootstrap)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-snapshot-agent
+        uses: $/.github/actions/setup-snapshot-agent
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
       - name: Run DynamoCheckpoint Deploy Test
-        uses: ./.github/actions/dynamo-deploy-test
+        uses: $/.github/actions/dynamo-deploy-test
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
@@ -1205,13 +1205,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check if vCluster exists
         id: vcluster-check
-        uses: ./.github/actions/check-vcluster-exists
+        uses: $/.github/actions/check-vcluster-exists
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
@@ -1224,19 +1224,19 @@ jobs:
           checkpoint_storage_size: 64Gi
       - name: Connect to vCluster
         id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
+        uses: $/.github/actions/connect-vcluster
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
       - name: Install snapshot-agent (rerun bootstrap)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-snapshot-agent
+        uses: $/.github/actions/setup-snapshot-agent
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
       - name: Run DynamoCheckpoint Deploy Test
-        uses: ./.github/actions/dynamo-deploy-test
+        uses: $/.github/actions/dynamo-deploy-test
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
@@ -1269,13 +1269,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check if vCluster exists
         id: vcluster-check
-        uses: ./.github/actions/check-vcluster-exists
+        uses: $/.github/actions/check-vcluster-exists
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
@@ -1288,19 +1288,19 @@ jobs:
           checkpoint_storage_size: 64Gi
       - name: Connect to vCluster
         id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
+        uses: $/.github/actions/connect-vcluster
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
       - name: Install snapshot-agent (rerun bootstrap)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-snapshot-agent
+        uses: $/.github/actions/setup-snapshot-agent
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
       - name: Run DynamoCheckpoint Deploy Test
-        uses: ./.github/actions/dynamo-deploy-test
+        uses: $/.github/actions/dynamo-deploy-test
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
@@ -1326,7 +1326,7 @@ jobs:
         persist-credentials: false
     - name: Teardown vCluster
       if: needs.deploy-operator.outputs.namespace != '' && needs.deploy-operator.outputs.vcluster_name != ''
-      uses: ./.github/actions/teardown-dynamo-operator
+      uses: $/.github/actions/teardown-dynamo-operator
       with:
         vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
         vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
@@ -1339,7 +1339,7 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Teardown vCluster
-      uses: ./.github/actions/teardown-dynamo-operator
+      uses: $/.github/actions/teardown-dynamo-operator
       with:
         vcluster_name: ci-${{ github.run_id }}-checkpoint-vllm
         vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-vllm-dt
@@ -1352,7 +1352,7 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Teardown vCluster
-      uses: ./.github/actions/teardown-dynamo-operator
+      uses: $/.github/actions/teardown-dynamo-operator
       with:
         vcluster_name: ci-${{ github.run_id }}-checkpoint-sglang
         vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-sglang-dt
@@ -1365,7 +1365,7 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Teardown vCluster
-      uses: ./.github/actions/teardown-dynamo-operator
+      uses: $/.github/actions/teardown-dynamo-operator
       with:
         vcluster_name: ci-${{ github.run_id }}-checkpoint-trtllm
         vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-trtllm-dt
@@ -1385,13 +1385,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check if vCluster exists
         id: vcluster-check
-        uses: ./.github/actions/check-vcluster-exists
+        uses: $/.github/actions/check-vcluster-exists
         with:
           vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
@@ -1402,7 +1402,7 @@ jobs:
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       - name: Connect to vCluster
         id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
+        uses: $/.github/actions/connect-vcluster
         with:
           vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
@@ -1418,7 +1418,7 @@ jobs:
           rm -f ${{ github.workspace }}/.kubeconfig_gaie
       - name: Run GAIE Deploy Test
         id: deploy-test
-        uses: ./.github/actions/dynamo-deploy-test
+        uses: $/.github/actions/dynamo-deploy-test
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
@@ -1475,7 +1475,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Create K8s builders (skip bootstrap)
-      uses: ./.github/actions/bootstrap-buildkit
+      uses: $/.github/actions/bootstrap-buildkit
       continue-on-error: true
       with:
         builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
@@ -1493,7 +1493,7 @@ jobs:
     permissions:
       contents: read
       actions: read   # grant the reusable notifier read access to list this run's jobs
-    uses: ./.github/workflows/notify-slack.yml
+    uses: $/.github/workflows/notify-slack.yml
     with:
       pipeline_name: Post-Merge
       runs_on: ubuntu-slim

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -462,13 +462,30 @@ jobs:
     with:
       dd_env: post-merge
       test_suite_name: vllm
-      test_type: Multi-GPU Test
+      test_type: 2-GPU Test
+      amd_runner: prod-tester-amd-gpu-2-v2
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64"]' # No ARM GPUs available
+      run_sanity_check: false
+      gpu_test_markers: (pre_merge or post_merge) and vllm and gpu_2
+      gpu_test_timeout_minutes: 60
+    secrets: inherit
+
+  vllm-4-gpu-test:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [vllm-build]
+    uses: $/.github/workflows/shared-test.yml
+    with:
+      dd_env: post-merge
+      test_suite_name: vllm
+      test_type: 4-GPU Test
       amd_runner: prod-tester-amd-gpu-4-v2
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      gpu_test_markers: '(pre_merge or post_merge) and vllm and (gpu_2 or gpu_4)'
+      gpu_test_markers: (pre_merge or post_merge) and vllm and gpu_4
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -480,7 +497,7 @@ jobs:
       dd_env: post-merge
       test_suite_name: vllm-efa
       test_type: CPU Test
-      amd_runner: prod-tester-amd-gpu-4-v2
+      amd_runner: prod-tester-amd-v2 # EFA image validation runs gpu_0 tests only
       target_tag_plain: ${{ needs.vllm-efa-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64", "arm64"]'
@@ -543,13 +560,13 @@ jobs:
     with:
       dd_env: post-merge
       test_suite_name: sglang
-      test_type: Multi-GPU Test
-      amd_runner: prod-tester-amd-gpu-4-v2
+      test_type: 2-GPU Test
+      amd_runner: prod-tester-amd-gpu-2-v2
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      gpu_test_markers: '(pre_merge or post_merge) and sglang and (gpu_2 or gpu_4)'
+      gpu_test_markers: (pre_merge or post_merge) and sglang and gpu_2
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -583,13 +600,13 @@ jobs:
     with:
       dd_env: post-merge
       test_suite_name: trtllm
-      test_type: Multi-GPU Test
-      amd_runner: prod-tester-amd-gpu-4-v2
+      test_type: 2-GPU Test
+      amd_runner: prod-tester-amd-gpu-2-v2
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      gpu_test_markers: '(pre_merge or post_merge) and trtllm and (gpu_2 or gpu_4)'
+      gpu_test_markers: (pre_merge or post_merge) and trtllm and gpu_2
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -601,7 +618,7 @@ jobs:
       dd_env: post-merge
       test_suite_name: trtllm-efa
       test_type: CPU Test
-      amd_runner: prod-tester-amd-gpu-4-v2
+      amd_runner: prod-tester-amd-v2 # EFA image validation runs gpu_0 tests only
       target_tag_plain: ${{ needs.trtllm-efa-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
       platform: '["amd64", "arm64"]'

--- a/.github/workflows/pr-xpu.yaml
+++ b/.github/workflows/pr-xpu.yaml
@@ -61,7 +61,7 @@ jobs:
           fetch-depth: 0
       - name: Check for changes
         id: changes
-        uses: ./.github/actions/changed-files
+        uses: $/.github/actions/changed-files
         with:
           gh_token: ${{ github.token }}
 
@@ -74,7 +74,7 @@ jobs:
     if: >-
       needs.changed-files.outputs.core == 'true' ||
       needs.changed-files.outputs.vllm == 'true'
-    uses: ./.github/workflows/xpu-ci.yaml
+    uses: $/.github/workflows/xpu-ci.yaml
     with:
       framework: vllm
       pytest_markers: 'vllm and pre_merge and not multimodal'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -48,7 +48,7 @@ jobs:
         # Do not use fetch-depth: 0 — changed-files now works with shallow clone
       - name: Check for changes
         id: changes
-        uses: ./.github/actions/changed-files
+        uses: $/.github/actions/changed-files
         with:
           gh_token: ${{ github.token }}
       - name: Export builder name
@@ -170,7 +170,7 @@ jobs:
         # Do not use fetch-depth: 0 — it fetches all 1600+ branches (~3 min)
       - name: Build and push operator
         id: build
-        uses: ./.github/actions/build-deploy-component
+        uses: $/.github/actions/build-deploy-component
         with:
           component: operator
           image_tag: ${{ github.sha }}-operator
@@ -236,7 +236,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         # Do not use fetch-depth: 0 — it fetches all 1600+ branches (~3 min)
       - name: Build and push snapshot agent
-        uses: ./.github/actions/build-deploy-component
+        uses: $/.github/actions/build-deploy-component
         with:
           component: snapshot
           image_tag: ${{ github.sha }}-snapshot-agent
@@ -270,7 +270,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         # Do not use fetch-depth: 0 — it fetches all 1600+ branches (~3 min)
       - name: Build and push power agent
-        uses: ./.github/actions/build-deploy-component
+        uses: $/.github/actions/build-deploy-component
         with:
           component: power-agent
           target: runtime  # push the slim shipped stage, not the test stage
@@ -281,7 +281,7 @@ jobs:
       - name: Refresh BuildKit builder
         # The runtime build above can leave the remote BuildKit connection stale;
         # re-establish it (re-routing only if unhealthy) before the test build.
-        uses: ./.github/actions/builder-refresher
+        uses: $/.github/actions/builder-refresher
         with:
           builder_name: ${{ needs.changed-files.outputs.builder_name }}
           flavor: general
@@ -329,7 +329,7 @@ jobs:
       needs.changed-files.outputs.operator == 'true' ||
       needs.changed-files.outputs.snapshot == 'true' ||
       needs.changed-files.outputs.snapshot_vllm == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: vllm
       target: runtime
@@ -357,7 +357,7 @@ jobs:
     name: vllm-dev
     needs: [changed-files]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: vllm
       target: dev
@@ -381,7 +381,7 @@ jobs:
       needs.changed-files.outputs.operator == 'true' ||
       needs.changed-files.outputs.snapshot == 'true' ||
       needs.changed-files.outputs.snapshot_sglang == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: sglang
       target: runtime
@@ -409,7 +409,7 @@ jobs:
     name: sglang-dev
     needs: [changed-files]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: sglang
       target: dev
@@ -433,7 +433,7 @@ jobs:
       needs.changed-files.outputs.operator == 'true' ||
       needs.changed-files.outputs.snapshot == 'true' ||
       needs.changed-files.outputs.snapshot_trtllm == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: trtllm
       target: runtime
@@ -461,7 +461,7 @@ jobs:
     name: trtllm-dev
     needs: [changed-files]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.trtllm == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: trtllm
       target: dev
@@ -476,7 +476,7 @@ jobs:
     name: vllm-runtime-efa
     needs: [changed-files]
     if: needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.efa == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: vllm
       target: runtime
@@ -505,7 +505,7 @@ jobs:
     name: sglang-runtime-efa
     needs: [changed-files]
     if: needs.changed-files.outputs.sglang == 'true' || needs.changed-files.outputs.efa == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: sglang
       target: runtime
@@ -534,7 +534,7 @@ jobs:
     name: trtllm-runtime-efa
     needs: [changed-files]
     if: needs.changed-files.outputs.trtllm == 'true' || needs.changed-files.outputs.efa == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: trtllm
       target: runtime
@@ -566,7 +566,7 @@ jobs:
       needs.changed-files.outputs.core == 'true' ||
       needs.changed-files.outputs.planner == 'true' ||
       needs.changed-files.outputs.operator == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: dynamo
       target: planner
@@ -615,7 +615,7 @@ jobs:
           go-version-file: deploy/operator/go.mod
           cache-dependency-path: deploy/operator/go.sum
       - name: Log in to ECR
-        uses: ./.github/actions/docker-login
+        uses: $/.github/actions/docker-login
         with:
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
           aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
@@ -638,7 +638,7 @@ jobs:
       needs.changed-files.outputs.snapshot_sglang == 'true' ||
       needs.changed-files.outputs.snapshot_trtllm == 'true' ||
       needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-build-image.yml
+    uses: $/.github/workflows/shared-build-image.yml
     with:
       framework: dynamo
       target: frontend
@@ -670,7 +670,7 @@ jobs:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [changed-files, vllm-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true' || needs.changed-files.outputs.sample == 'true'
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: vllm
       test_type: Test
@@ -692,7 +692,7 @@ jobs:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [changed-files, vllm-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: vllm
       test_type: Multi-GPU Test
@@ -709,7 +709,7 @@ jobs:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [changed-files, sglang-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true' || needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: sglang
       test_type: Test
@@ -731,7 +731,7 @@ jobs:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [changed-files, sglang-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true' || needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: sglang
       test_type: Multi-GPU Test
@@ -748,7 +748,7 @@ jobs:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [changed-files, trtllm-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.trtllm == 'true' || needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: trtllm
       test_type: Test
@@ -770,7 +770,7 @@ jobs:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [changed-files, trtllm-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.trtllm == 'true' || needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: trtllm
       test_type: Multi-GPU Test
@@ -787,7 +787,7 @@ jobs:
     name: planner # This name overlaps with other planner jobs to group them in the UI
     needs: [changed-files, planner-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.planner == 'true'
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: planner
       test_type: CPU Test
@@ -840,7 +840,7 @@ jobs:
       needs.changed-files.outputs.sglang == 'true' ||
       needs.changed-files.outputs.trtllm == 'true' ||
       needs.changed-files.outputs.benchmarks == 'true'
-    uses: ./.github/workflows/dynamo-pipeline.yml
+    uses: $/.github/workflows/dynamo-pipeline.yml
     with:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       build_timeout_minutes: 60
@@ -870,7 +870,7 @@ jobs:
     name: vllm-runtime # grouped in the UI with other vllm jobs
     needs: [changed-files, vllm-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-compliance-audit.yml
+    uses: $/.github/workflows/shared-compliance-audit.yml
     with:
       framework: vllm
       target: runtime
@@ -884,7 +884,7 @@ jobs:
     name: sglang-runtime # grouped in the UI with other sglang jobs
     needs: [changed-files, sglang-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true' || needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-compliance-audit.yml
+    uses: $/.github/workflows/shared-compliance-audit.yml
     with:
       framework: sglang
       target: runtime
@@ -896,7 +896,7 @@ jobs:
     name: trtllm-runtime # grouped in the UI with other trtllm jobs
     needs: [changed-files, trtllm-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.trtllm == 'true' || needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-compliance-audit.yml
+    uses: $/.github/workflows/shared-compliance-audit.yml
     with:
       framework: trtllm
       target: runtime
@@ -917,7 +917,7 @@ jobs:
       needs.changed-files.outputs.snapshot_sglang == 'true' ||
       needs.changed-files.outputs.snapshot_trtllm == 'true' ||
       needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-compliance-audit.yml
+    uses: $/.github/workflows/shared-compliance-audit.yml
     with:
       framework: dynamo
       target: frontend
@@ -933,7 +933,7 @@ jobs:
     name: planner # This name overlaps with other planner jobs to group them in the UI
     needs: [changed-files, planner-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.planner == 'true'
-    uses: ./.github/workflows/shared-compliance.yml
+    uses: $/.github/workflows/shared-compliance.yml
     with:
       framework: dynamo
       target: planner
@@ -958,7 +958,7 @@ jobs:
        needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.snapshot_vllm == 'true') &&
       needs.vllm-build.result == 'success'
-    uses: ./.github/workflows/shared-copy.yml
+    uses: $/.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]' # Deploy tests only use CUDA 13
@@ -976,7 +976,7 @@ jobs:
       needs.changed-files.outputs.snapshot_sglang == 'true' ||
       needs.changed-files.outputs.snapshot_trtllm == 'true') &&
       needs.frontend-build.result == 'success'
-    uses: ./.github/workflows/shared-copy.yml
+    uses: $/.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.frontend-build.outputs.target_tag_plain }}
       cuda_version: '[""]'
@@ -1000,7 +1000,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build and push snapshot placeholder
-        uses: ./.github/actions/build-deploy-component
+        uses: $/.github/actions/build-deploy-component
         with:
           component: snapshot
           target: placeholder
@@ -1028,7 +1028,7 @@ jobs:
        needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.snapshot_sglang == 'true') &&
       needs.sglang-build.result == 'success'
-    uses: ./.github/workflows/shared-copy.yml
+    uses: $/.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]' # Deploy tests only use CUDA 13
@@ -1052,7 +1052,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build and push snapshot placeholder
-        uses: ./.github/actions/build-deploy-component
+        uses: $/.github/actions/build-deploy-component
         with:
           component: snapshot
           target: placeholder
@@ -1080,7 +1080,7 @@ jobs:
        needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.snapshot_trtllm == 'true') &&
       needs.trtllm-build.result == 'success'
-    uses: ./.github/workflows/shared-copy.yml
+    uses: $/.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
@@ -1104,7 +1104,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build and push snapshot placeholder
-        uses: ./.github/actions/build-deploy-component
+        uses: $/.github/actions/build-deploy-component
         with:
           component: snapshot
           target: placeholder
@@ -1147,7 +1147,7 @@ jobs:
           persist-credentials: false
       - name: Setup vCluster and operator
         id: setup
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
           operator_tag: ${{ needs.operator.outputs.operator_default_tag }}
@@ -1167,7 +1167,7 @@ jobs:
       (needs.changed-files.outputs.vllm == 'true' ||
        needs.changed-files.outputs.deploy == 'true' ||
        needs.changed-files.outputs.operator == 'true')
-    uses: ./.github/workflows/shared-deploy-test.yml
+    uses: $/.github/workflows/shared-deploy-test.yml
     with:
       framework: vllm
       profiles: '["agg", "agg_router", "disagg", "disagg_router"]'
@@ -1185,7 +1185,7 @@ jobs:
       (needs.changed-files.outputs.sglang == 'true' ||
        needs.changed-files.outputs.deploy == 'true' ||
        needs.changed-files.outputs.operator == 'true')
-    uses: ./.github/workflows/shared-deploy-test.yml
+    uses: $/.github/workflows/shared-deploy-test.yml
     with:
       framework: sglang
       profiles: '["agg", "agg_router"]'
@@ -1203,7 +1203,7 @@ jobs:
       (needs.changed-files.outputs.trtllm == 'true' ||
        needs.changed-files.outputs.deploy == 'true' ||
        needs.changed-files.outputs.operator == 'true')
-    uses: ./.github/workflows/shared-deploy-test.yml
+    uses: $/.github/workflows/shared-deploy-test.yml
     with:
       framework: trtllm
       profiles: '["agg", "agg_router"]'
@@ -1232,7 +1232,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Setup vCluster and operator
         id: setup
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ci-${{ github.run_id }}-checkpoint-vllm
           vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-vllm-dt
@@ -1266,7 +1266,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Setup vCluster and operator
         id: setup
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ci-${{ github.run_id }}-checkpoint-sglang
           vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-sglang-dt
@@ -1300,7 +1300,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Setup vCluster and operator
         id: setup
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ci-${{ github.run_id }}-checkpoint-trtllm
           vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-trtllm-dt
@@ -1333,13 +1333,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check if vCluster exists
         id: vcluster-check
-        uses: ./.github/actions/check-vcluster-exists
+        uses: $/.github/actions/check-vcluster-exists
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
@@ -1355,12 +1355,12 @@ jobs:
           model_cache_path: ${{ vars.AZURE_MODEL_CACHE_PATH }}
       - name: Connect to vCluster
         id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
+        uses: $/.github/actions/connect-vcluster
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
       - name: Install snapshot-agent
-        uses: ./.github/actions/setup-snapshot-agent
+        uses: $/.github/actions/setup-snapshot-agent
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
@@ -1384,13 +1384,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check if vCluster exists
         id: vcluster-check
-        uses: ./.github/actions/check-vcluster-exists
+        uses: $/.github/actions/check-vcluster-exists
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
@@ -1406,12 +1406,12 @@ jobs:
           model_cache_path: ${{ vars.AZURE_MODEL_CACHE_PATH }}
       - name: Connect to vCluster
         id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
+        uses: $/.github/actions/connect-vcluster
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
       - name: Install snapshot-agent
-        uses: ./.github/actions/setup-snapshot-agent
+        uses: $/.github/actions/setup-snapshot-agent
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
@@ -1435,13 +1435,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check if vCluster exists
         id: vcluster-check
-        uses: ./.github/actions/check-vcluster-exists
+        uses: $/.github/actions/check-vcluster-exists
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
@@ -1457,12 +1457,12 @@ jobs:
           model_cache_path: ${{ vars.AZURE_MODEL_CACHE_PATH }}
       - name: Connect to vCluster
         id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
+        uses: $/.github/actions/connect-vcluster
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
       - name: Install snapshot-agent
-        uses: ./.github/actions/setup-snapshot-agent
+        uses: $/.github/actions/setup-snapshot-agent
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
@@ -1487,13 +1487,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check if vCluster exists
         id: vcluster-check
-        uses: ./.github/actions/check-vcluster-exists
+        uses: $/.github/actions/check-vcluster-exists
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
@@ -1509,19 +1509,19 @@ jobs:
           model_cache_path: ${{ vars.AZURE_MODEL_CACHE_PATH }}
       - name: Connect to vCluster
         id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
+        uses: $/.github/actions/connect-vcluster
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
       - name: Install snapshot-agent (rerun bootstrap)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-snapshot-agent
+        uses: $/.github/actions/setup-snapshot-agent
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
       - name: Run DynamoCheckpoint Deploy Test
-        uses: ./.github/actions/dynamo-deploy-test
+        uses: $/.github/actions/dynamo-deploy-test
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
@@ -1559,13 +1559,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check if vCluster exists
         id: vcluster-check
-        uses: ./.github/actions/check-vcluster-exists
+        uses: $/.github/actions/check-vcluster-exists
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
@@ -1581,19 +1581,19 @@ jobs:
           model_cache_path: ${{ vars.AZURE_MODEL_CACHE_PATH }}
       - name: Connect to vCluster
         id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
+        uses: $/.github/actions/connect-vcluster
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
       - name: Install snapshot-agent (rerun bootstrap)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-snapshot-agent
+        uses: $/.github/actions/setup-snapshot-agent
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
       - name: Run DynamoCheckpoint Deploy Test
-        uses: ./.github/actions/dynamo-deploy-test
+        uses: $/.github/actions/dynamo-deploy-test
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
@@ -1631,13 +1631,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check if vCluster exists
         id: vcluster-check
-        uses: ./.github/actions/check-vcluster-exists
+        uses: $/.github/actions/check-vcluster-exists
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
@@ -1653,19 +1653,19 @@ jobs:
           model_cache_path: ${{ vars.AZURE_MODEL_CACHE_PATH }}
       - name: Connect to vCluster
         id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
+        uses: $/.github/actions/connect-vcluster
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
       - name: Install snapshot-agent (rerun bootstrap)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-snapshot-agent
+        uses: $/.github/actions/setup-snapshot-agent
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
       - name: Run DynamoCheckpoint Deploy Test
-        uses: ./.github/actions/dynamo-deploy-test
+        uses: $/.github/actions/dynamo-deploy-test
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
@@ -1694,7 +1694,7 @@ jobs:
           persist-credentials: false
       - name: Teardown vCluster
         if: needs.deploy-operator.outputs.namespace != '' && needs.deploy-operator.outputs.vcluster_name != ''
-        uses: ./.github/actions/teardown-dynamo-operator
+        uses: $/.github/actions/teardown-dynamo-operator
         with:
           vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
@@ -1710,7 +1710,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Teardown vCluster
-        uses: ./.github/actions/teardown-dynamo-operator
+        uses: $/.github/actions/teardown-dynamo-operator
         with:
           vcluster_name: ci-${{ github.run_id }}-checkpoint-vllm
           vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-vllm-dt
@@ -1726,7 +1726,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Teardown vCluster
-        uses: ./.github/actions/teardown-dynamo-operator
+        uses: $/.github/actions/teardown-dynamo-operator
         with:
           vcluster_name: ci-${{ github.run_id }}-checkpoint-sglang
           vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-sglang-dt
@@ -1742,7 +1742,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Teardown vCluster
-        uses: ./.github/actions/teardown-dynamo-operator
+        uses: $/.github/actions/teardown-dynamo-operator
         with:
           vcluster_name: ci-${{ github.run_id }}-checkpoint-trtllm
           vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-trtllm-dt
@@ -1776,7 +1776,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Create K8s builders (skip bootstrap)
-        uses: ./.github/actions/bootstrap-buildkit
+        uses: $/.github/actions/bootstrap-buildkit
         continue-on-error: true
         with:
           builder_name: ${{ needs.changed-files.outputs.builder_name }}
@@ -1817,7 +1817,7 @@ jobs:
     if: false
     # Disabled: gh-pages branch bloated to ~1GB after 72 commits of Allure reports
     # if: ${{ !cancelled() }}
-    uses: ./.github/workflows/generate-allure-report.yml
+    uses: $/.github/workflows/generate-allure-report.yml
     with:
       run_id: ${{ github.run_id }}
       subdir: pr

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,7 +72,6 @@ jobs:
       - vllm-dev-build
       - vllm-test
       - vllm-multi-gpu-test
-      - vllm-4-gpu-test
       - vllm-copy-to-acr
       - sglang-build
       - sglang-dev-build
@@ -703,28 +702,6 @@ jobs:
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
       gpu_test_markers: pre_merge and vllm and gpu_2
-      gpu_test_timeout_minutes: 60
-    secrets: inherit
-
-  vllm-4-gpu-test:
-    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
-    needs: [changed-files, vllm-build]
-    if: |
-      needs.changed-files.outputs.run_multigpu_tests == 'true' &&
-      (needs.changed-files.outputs.core == 'true' ||
-       needs.changed-files.outputs.vllm == 'true' ||
-       needs.changed-files.outputs.deploy == 'true')
-    uses: $/.github/workflows/shared-test.yml
-    with:
-      test_suite_name: vllm
-      test_type: 4-GPU Test
-      amd_runner: prod-tester-amd-gpu-4-v2
-      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
-      cuda_version: '["13.0"]'
-      platform: '["amd64"]' # No ARM GPUs available
-      run_sanity_check: false
-      # Exercise the only vLLM gpu_4 topology before merge.
-      gpu_test_markers: (pre_merge or post_merge) and vllm and gpu_4
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -1785,7 +1762,6 @@ jobs:
       - planner-test
       - vllm-copy-to-acr
       - vllm-multi-gpu-test
-      - vllm-4-gpu-test
       - vllm-efa-build
       - sglang-copy-to-acr
       - sglang-multi-gpu-test
@@ -1823,7 +1799,6 @@ jobs:
       - vllm-build
       - vllm-test
       - vllm-multi-gpu-test
-      - vllm-4-gpu-test
       - vllm-copy-to-acr
       - sglang-build
       - sglang-test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,6 +72,7 @@ jobs:
       - vllm-dev-build
       - vllm-test
       - vllm-multi-gpu-test
+      - vllm-4-gpu-test
       - vllm-copy-to-acr
       - sglang-build
       - sglang-dev-build
@@ -695,13 +696,35 @@ jobs:
     uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: vllm
-      test_type: Multi-GPU Test
+      test_type: 2-GPU Test
+      amd_runner: prod-tester-amd-gpu-2-v2
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64"]' # No ARM GPUs available
+      run_sanity_check: false
+      gpu_test_markers: pre_merge and vllm and gpu_2
+      gpu_test_timeout_minutes: 60
+    secrets: inherit
+
+  vllm-4-gpu-test:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [changed-files, vllm-build]
+    if: |
+      needs.changed-files.outputs.run_multigpu_tests == 'true' &&
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.vllm == 'true' ||
+       needs.changed-files.outputs.deploy == 'true')
+    uses: $/.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: 4-GPU Test
       amd_runner: prod-tester-amd-gpu-4-v2
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      gpu_test_markers: pre_merge and vllm and (gpu_2 or gpu_4)
+      # Exercise the only vLLM gpu_4 topology before merge.
+      gpu_test_markers: (pre_merge or post_merge) and vllm and gpu_4
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -734,13 +757,13 @@ jobs:
     uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: sglang
-      test_type: Multi-GPU Test
-      amd_runner: prod-tester-amd-gpu-4-v2
+      test_type: 2-GPU Test
+      amd_runner: prod-tester-amd-gpu-2-v2
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      gpu_test_markers: pre_merge and sglang and (gpu_2 or gpu_4)
+      gpu_test_markers: pre_merge and sglang and gpu_2
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -773,13 +796,13 @@ jobs:
     uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: trtllm
-      test_type: Multi-GPU Test
-      amd_runner: prod-tester-amd-gpu-4-v2
+      test_type: 2-GPU Test
+      amd_runner: prod-tester-amd-gpu-2-v2
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      gpu_test_markers: pre_merge and trtllm and (gpu_2 or gpu_4)
+      gpu_test_markers: pre_merge and trtllm and gpu_2
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -1762,6 +1785,7 @@ jobs:
       - planner-test
       - vllm-copy-to-acr
       - vllm-multi-gpu-test
+      - vllm-4-gpu-test
       - vllm-efa-build
       - sglang-copy-to-acr
       - sglang-multi-gpu-test
@@ -1799,6 +1823,7 @@ jobs:
       - vllm-build
       - vllm-test
       - vllm-multi-gpu-test
+      - vllm-4-gpu-test
       - vllm-copy-to-acr
       - sglang-build
       - sglang-test

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -41,7 +41,7 @@ jobs:
         # Do not use fetch-depth: 0 — changed-files now works with shallow clone
       - name: Check for changes
         id: changes
-        uses: ./.github/actions/changed-files
+        uses: $/.github/actions/changed-files
         with:
           gh_token: ${{ github.token }}
 
@@ -113,7 +113,7 @@ jobs:
         fetch-depth: 0  # clustertest derives its alpha version from v1.3.0
     - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
     - name: Run operator checks
-      uses: ./.github/actions/check-deploy-component
+      uses: $/.github/actions/check-deploy-component
       with:
         component: operator
         platform: linux/amd64
@@ -131,7 +131,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
     - name: Run snapshot agent checks
-      uses: ./.github/actions/check-deploy-component
+      uses: $/.github/actions/check-deploy-component
       with:
         component: snapshot
         platform: linux/amd64

--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   team-request:
-    uses: ./.github/workflows/nvskills-team-request.yml
+    uses: $/.github/workflows/nvskills-team-request.yml
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}

--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -224,7 +224,7 @@ jobs:
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
           lfs: true
       - name: Docker Login
-        uses: ./.github/actions/docker-login
+        uses: $/.github/actions/docker-login
         with:
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
           aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
@@ -299,7 +299,7 @@ jobs:
             echo "builder_flavor=${{ inputs.framework }}" >> $GITHUB_OUTPUT
           fi
       - name: Initialize Dynamo Builder
-        uses: ./.github/actions/init-dynamo-builder
+        uses: $/.github/actions/init-dynamo-builder
         with:
           builder_name: ${{ inputs.builder_name }}
           flavor: ${{ steps.calculate-builder-flavor.outputs.builder_flavor }}
@@ -439,7 +439,7 @@ jobs:
             "${GITHUB_WORKSPACE}/.epp-sbom/sbom-go-licenses" 2>/dev/null | head -40
       - name: Refresh BuildKit builder (For Frontend Only)
         if: ${{ inputs.target == 'frontend' }}
-        uses: ./.github/actions/builder-refresher
+        uses: $/.github/actions/builder-refresher
         with:
           builder_name: ${{ inputs.builder_name }}
           flavor: ${{ steps.calculate-builder-flavor.outputs.builder_flavor }}
@@ -485,7 +485,7 @@ jobs:
       - name: Build and Push Image
         id: build-image
         if: ${{ !inputs.compliance_only }}
-        uses: ./.github/actions/docker-remote-build
+        uses: $/.github/actions/docker-remote-build
         with:
           image_tag: ${{ steps.calculate-target-tag.outputs.image_uri }}
           framework: ${{ inputs.framework }}
@@ -567,7 +567,7 @@ jobs:
 
       - name: Compliance extract
         if: ${{ (inputs.compliance_only || inputs.inline_compliance) && inputs.target != 'dev' && inputs.target != 'local-dev' }}
-        uses: ./.github/actions/compliance-extract
+        uses: $/.github/actions/compliance-extract
         with:
           # Diff baseline resolved above (empty when diffing is disabled or no
           # baseline applies); gh_token lets the action fetch it cross-run.
@@ -602,7 +602,7 @@ jobs:
           archive_sources: ${{ inputs.archive_sources }}
       - name: Refresh BuildKit builder
         if: ${{ inputs.target != 'dev' && inputs.target != 'frontend' }}
-        uses: ./.github/actions/builder-refresher
+        uses: $/.github/actions/builder-refresher
         with:
           builder_name: ${{ inputs.builder_name }}
           flavor: ${{ steps.calculate-builder-flavor.outputs.builder_flavor }}

--- a/.github/workflows/shared-compliance.yml
+++ b/.github/workflows/shared-compliance.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Docker Login
-        uses: ./.github/actions/docker-login
+        uses: $/.github/actions/docker-login
         with:
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
           aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
@@ -84,7 +84,7 @@ jobs:
           RUNTIME_IMAGE=${ECR_REPOSITORY}:${IMAGE_TAG}
           echo "runtime_image=${RUNTIME_IMAGE}" >> $GITHUB_OUTPUT
       - name: Compliance scan
-        uses: ./.github/actions/compliance-scan
+        uses: $/.github/actions/compliance-scan
         with:
           image: ${{ steps.calculate-target-tag.outputs.runtime_image }}
           artifact_name: compliance-${{ inputs.target_tag_plain }}-${{ matrix.cuda_version }}-${{ matrix.platform }}

--- a/.github/workflows/shared-copy.yml
+++ b/.github/workflows/shared-copy.yml
@@ -94,7 +94,7 @@ jobs:
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
       - name: Copy image to target registry
         timeout-minutes: ${{ inputs.copy_timeout_minutes }}
-        uses: ./.github/actions/skopeo-copy
+        uses: $/.github/actions/skopeo-copy
         with:
           source_registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
           source_image: ai-dynamo/dynamo

--- a/.github/workflows/shared-deploy-test.yml
+++ b/.github/workflows/shared-deploy-test.yml
@@ -48,13 +48,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Check if vCluster exists
         id: vcluster-check
-        uses: ./.github/actions/check-vcluster-exists
+        uses: $/.github/actions/check-vcluster-exists
         with:
           vcluster_name: ${{ inputs.vcluster_name }}
           vcluster_namespace: ${{ inputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
-        uses: ./.github/actions/setup-dynamo-operator
+        uses: $/.github/actions/setup-dynamo-operator
         with:
           vcluster_name: ${{ inputs.vcluster_name }}
           vcluster_namespace: ${{ inputs.namespace }}
@@ -67,13 +67,13 @@ jobs:
           model_cache_path: ${{ vars.AZURE_MODEL_CACHE_PATH }}
       - name: Connect to vCluster
         id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
+        uses: $/.github/actions/connect-vcluster
         with:
           vcluster_name: ${{ inputs.vcluster_name }}
           vcluster_namespace: ${{ inputs.namespace }}
       - name: Run Dynamo Deploy Test
         id: deploy-test
-        uses: ./.github/actions/dynamo-deploy-test
+        uses: $/.github/actions/dynamo-deploy-test
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Run CPU-only tests (parallelized)
         if: ${{ inputs.run_cpu_only_tests }}
         timeout-minutes: ${{ inputs.cpu_only_test_timeout_minutes }}
-        uses: ./.github/actions/pytest-local
+        uses: $/.github/actions/pytest-local
         with:
           container_workspace: ${{ inputs.container_workspace }}
           pytest_marks: ${{ inputs.cpu_only_test_markers }}
@@ -220,7 +220,7 @@ jobs:
       - name: Run GPU tests (parallel)
         timeout-minutes: ${{ inputs.gpu_test_timeout_minutes }}
         if: ${{ matrix.platform == 'amd64' && inputs.run_gpu_tests && inputs.run_gpu_parallel_tests }}
-        uses: ./.github/actions/pytest-local
+        uses: $/.github/actions/pytest-local
         with:
           container_workspace: ${{ inputs.container_workspace }}
           pytest_marks: ${{ inputs.gpu_test_markers }}
@@ -241,7 +241,7 @@ jobs:
         # container/pod never coming online) skips this step cleanly instead of trying
         # to run the local pytest-local action against an un-checked-out workspace.
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' && matrix.platform == 'amd64' && inputs.run_gpu_tests }}
-        uses: ./.github/actions/pytest-local
+        uses: $/.github/actions/pytest-local
         with:
           container_workspace: ${{ inputs.container_workspace }}
           # When the parallel stage runs, exclude profiled tests here so they don't run twice.

--- a/.github/workflows/xpu-ci.yaml
+++ b/.github/workflows/xpu-ci.yaml
@@ -176,7 +176,7 @@ jobs:
           fi
 
       - name: Run XPU tests
-        uses: ./.github/actions/pytest
+        uses: $/.github/actions/pytest
         with:
           pytest_marks: '${{ inputs.pytest_markers }} and xpu_1'
           image_tag: ${{ env.TEST_IMAGE_TAG }}
@@ -224,7 +224,7 @@ jobs:
           docker rm -f "${CONTAINER_ID_PREFIX}_pytest" 2>/dev/null || true
 
       - name: Run XPU 2-card tests
-        uses: ./.github/actions/pytest
+        uses: $/.github/actions/pytest
         with:
           pytest_marks: '${{ inputs.pytest_markers }} and xpu_2'
           image_tag: ${{ env.TEST_IMAGE_TAG }}

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -15,6 +15,8 @@ filterpy==1.4.5
 grpcio>=1.63.0
 kubernetes==32.0.1
 kubernetes_asyncio==32.0.0
+# aiconfigurator calls the top-level plotext.plot_size, removed in plotext 6.
+plotext<6
 plotly>=6.0.1
 pmdarima==2.1.1
 prometheus-api-client==0.6.0

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/multimodal.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/multimodal.md
@@ -551,7 +551,7 @@ Controls how many threads the encoder uses to fetch and load images concurrently
 export SGLANG_ENCODER_MM_LOAD_WORKERS=16
 ```
 
-Only applies to the EPD encode worker (which uses [SGLang's MMEncoder](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/disaggregation/encode_server.py) internally).
+Only applies to the EPD encode worker (which uses [SGLang's MMEncoder](https://github.com/sgl-project/sglang/blob/v0.5.17/python/sglang/srt/disaggregation/encode_server.py) internally).
 
 ## Profiling
 


### PR DESCRIPTION
## Summary

- backport #13642 to resolve repository-local actions and reusable workflows from the workflow commit using `$/.github/...`
- backport #13716 to constrain `plotext<6`, preserving the `plotext.plot_size` API used by AIC configurator profiler paths
- backport #13651 to pin the SGLang MMEncoder documentation link to compatible `v0.5.17` source
- backport #13468 to route 2-GPU tests to `prod-tester-amd-gpu-2-v2` while preserving real 4-GPU vLLM and SGLang lanes
- backport #13870 to remove the redundant vLLM 4-GPU job from pre-merge while retaining scheduled post-merge and nightly coverage
- keep CPU-only EFA validation on CPU runners instead of consuming 4-GPU runners
- add the matching actionlint configuration without pulling unrelated `main` workflow changes into `release/1.4.2`

## Validation

- converted all 234 release-branch `uses: ./.github/...` references; zero legacy references remain
- `git diff --check`
- `pre-commit run --files` over every changed workflow and action file
- `pre-commit run --files` over the #13468 PR, nightly, and post-merge workflow backports
- `pre-commit run --files container/deps/requirements.planner.txt`
- YAML, requirements formatting, codespell, and merge-conflict checks passed
- validated every `needs` entry in the three modified workflows references a job present in that release workflow
- verified the PR workflow contains no 4-GPU job or stale dependency after the #13870 backport
- verified 2-GPU, 4-GPU, H100, and CPU-only EFA lanes retain distinct runner and marker routing
- verified the pinned SGLang `v0.5.17` MMEncoder link returns HTTP 200

Backports #13468, #13642, #13651, #13716, and #13870 to `release/1.4.2`.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/13857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
