### PR TITLE
feat(frontend): support prompt_cache_key in chat requests

### DIFF
--- a/lib/llm/benches/request_trace_finish_metadata.rs
+++ b/lib/llm/benches/request_trace_finish_metadata.rs
@@ -94,6 +94,7 @@ fn chat_request() -> NvCreateChatCompletionRequest {
         chat_template_args: None,
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
+        prompt_cache_key: None,
         unsupported_fields: Default::default(),
     }
 }

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1615,6 +1615,7 @@ mod tests {
                 thinking: None,
                 media_io_kwargs: None,
                 return_tokens_as_token_ids: None,
+                prompt_cache_key: None,
                 unsupported_fields: Default::default(),
             };
             assert!(engine.generate(SingleIn::new(request)).await.is_err());

--- a/lib/llm/src/entrypoint/input/text.rs
+++ b/lib/llm/src/entrypoint/input/text.rs
@@ -117,6 +117,7 @@ async fn main_loop(
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         };
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -6354,6 +6354,7 @@ mod tests {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_required_fields(&request);
@@ -6388,6 +6389,7 @@ mod tests {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_required_fields(&request);
@@ -6636,6 +6638,7 @@ mod tests {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         };
 
@@ -6668,6 +6671,7 @@ mod tests {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);
@@ -6699,6 +6703,7 @@ mod tests {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);
@@ -6730,6 +6735,7 @@ mod tests {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);
@@ -6763,6 +6769,7 @@ mod tests {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);
@@ -6794,6 +6801,7 @@ mod tests {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         };
         let result = validate_chat_completion_fields_generic(&request);

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -173,6 +173,7 @@ impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         })
     }

--- a/lib/llm/src/protocols/common/input_trigger.rs
+++ b/lib/llm/src/protocols/common/input_trigger.rs
@@ -141,6 +141,7 @@ mod tests {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         }
     }

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -123,6 +123,11 @@ pub struct NvCreateChatCompletionRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub return_tokens_as_token_ids: Option<bool>,
 
+    /// Stable key used by OpenAI-compatible clients to improve prompt cache hits.
+    /// Dynamo preserves this field for request tracing but does not interpret it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_key: Option<String>,
+
     /// Catch-all for unsupported fields - checked during validation
     #[serde(flatten, default, skip_serializing)]
     pub unsupported_fields: std::collections::HashMap<String, serde_json::Value>,

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -411,6 +411,7 @@ mod tests {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         }
     }
@@ -604,6 +605,7 @@ mod tests {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         }
     }

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -908,6 +908,7 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: resp.inner.prompt_cache_key,
             unsupported_fields: Default::default(),
         })
     }

--- a/lib/llm/src/protocols/unified.rs
+++ b/lib/llm/src/protocols/unified.rs
@@ -551,6 +551,7 @@ mod tests {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         };
 

--- a/lib/llm/src/request_trace/types.rs
+++ b/lib/llm/src/request_trace/types.rs
@@ -308,6 +308,7 @@ pub enum RequestTraceToolStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engines::ValidateRequest;
 
     #[test]
     fn request_trace_has_only_replay_fields() {
@@ -361,9 +362,12 @@ mod tests {
         let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
             "model": "test-model",
             "messages": [{"role": "user", "content": "hello"}],
-            "store": true
+            "store": true,
+            "prompt_cache_key": "tenant-42"
         }))
         .unwrap();
+        assert!(request.unsupported_fields.is_empty());
+        ValidateRequest::validate(&request).unwrap();
         let response: NvCreateChatCompletionResponse = serde_json::from_value(serde_json::json!({
             "id": "chatcmpl-test",
             "object": "chat.completion",
@@ -404,6 +408,7 @@ mod tests {
         assert!(value["payload"].get("requested_streaming").is_none());
         assert_eq!(value["payload"]["payload_complete"], true);
         assert_eq!(value["payload"]["request"]["model"], "test-model");
+        assert_eq!(value["payload"]["request"]["prompt_cache_key"], "tenant-42");
         assert_eq!(
             value["payload"]["response"]["choices"][0]["message"]["content"],
             "hi"

--- a/lib/llm/tests/parallel_tool_call_integration.rs
+++ b/lib/llm/tests/parallel_tool_call_integration.rs
@@ -94,6 +94,7 @@ fn create_mock_chat_completion_request() -> NvCreateChatCompletionRequest {
         thinking: None,
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
+        prompt_cache_key: None,
         unsupported_fields: Default::default(),
     }
 }

--- a/lib/llm/tests/preprocessor.rs
+++ b/lib/llm/tests/preprocessor.rs
@@ -264,6 +264,7 @@ impl Request {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         }
     }
@@ -852,6 +853,7 @@ mod context_length_validation {
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
+            prompt_cache_key: None,
             unsupported_fields: Default::default(),
         }
     }

--- a/lib/llm/tests/test_common_ext.rs
+++ b/lib/llm/tests/test_common_ext.rs
@@ -71,6 +71,7 @@ fn test_sampling_parameters_include_stop_str_in_output_extraction() {
         thinking: None,
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
+        prompt_cache_key: None,
         unsupported_fields: Default::default(),
     };
 
@@ -341,6 +342,7 @@ fn test_serialization_preserves_structure() {
         thinking: None,
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
+        prompt_cache_key: None,
         unsupported_fields: Default::default(),
     };
 
@@ -395,6 +397,7 @@ fn test_sampling_parameters_extraction() {
         thinking: None,
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
+        prompt_cache_key: None,
         unsupported_fields: Default::default(),
     };
 

--- a/lib/llm/tests/test_streaming_usage.rs
+++ b/lib/llm/tests/test_streaming_usage.rs
@@ -207,6 +207,7 @@ fn create_chat_request(
         thinking: None,
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
+        prompt_cache_key: None,
         unsupported_fields: Default::default(),
     }
 }
@@ -799,6 +800,7 @@ fn create_nonstreaming_chat_request() -> NvCreateChatCompletionRequest {
         thinking: None,
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
+        prompt_cache_key: None,
         unsupported_fields: Default::default(),
     }
 }

--- a/lib/llm/tests/tool_choice.rs
+++ b/lib/llm/tests/tool_choice.rs
@@ -70,6 +70,7 @@ fn create_test_request() -> NvCreateChatCompletionRequest {
         thinking: None,
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
+        prompt_cache_key: None,
         unsupported_fields: Default::default(),
     }
 }

--- a/lib/llm/tests/tool_choice_finish_reasons.rs
+++ b/lib/llm/tests/tool_choice_finish_reasons.rs
@@ -35,6 +35,7 @@ fn create_test_request() -> NvCreateChatCompletionRequest {
         thinking: None,
         media_io_kwargs: None,
         return_tokens_as_token_ids: None,
+        prompt_cache_key: None,
         unsupported_fields: Default::default(),
     }
 }


### PR DESCRIPTION
## Summary

- recognize the OpenAI `prompt_cache_key` field on Chat Completions requests instead of treating it as unsupported
- preserve the field in Dynamo request-payload trace serialization
- carry the existing Responses API value through its internal Chat Completions conversion
- leave cache and routing behavior unchanged; this field is currently observability-only

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p dynamo-llm --lib --no-default-features`
- `cargo test -p dynamo-llm --lib request_trace --no-default-features` (62 passed)
- `cargo test -p dynamo-llm --tests --no-run --no-default-features`
- `cargo check -p dynamo-llm --benches --no-default-features`
- focused trace-schema test verifies `payload.request.prompt_cache_key` is serialized and the request passes normal validation