### PR TITLE
fix(replay): reject a planner profile .npz that does not exist

### DIFF
--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -69,6 +69,14 @@ def resolve_planner_profile_data(
         return SimpleNamespace(npz_path=None)
 
     if planner_profile_data.suffix == ".npz":
+        # Existence only. Reading the file to check its contents would pull in
+        # the planner dependencies this short-circuit exists to avoid, but a
+        # path that is not there cannot be a profile under any definition, and
+        # the engine's response to one is to fall back to a synthetic model.
+        if not planner_profile_data.is_file():
+            raise FileNotFoundError(
+                f"planner profile data '{planner_profile_data}' does not exist"
+            )
         return SimpleNamespace(npz_path=planner_profile_data)
 
     try:

--- a/components/src/dynamo/replay/tests/test_main.py
+++ b/components/src/dynamo/replay/tests/test_main.py
@@ -370,3 +370,24 @@ def test_engine_and_dynamo_mains_apply_identical_aic_capacity_lowering(
     assert engine_blocks == dynamo_blocks == 444
     assert len(estimator_calls) == 2
     assert all("nextn" not in call for call in estimator_calls)
+
+
+def test_missing_npz_planner_profile_data_is_rejected(tmp_path) -> None:
+    # The .npz short-circuit exists so replay does not import planner-only
+    # dependencies. It used to report any .npz path as already resolved,
+    # including one that is not there, and the engine answers an unreadable
+    # profile by falling back to a synthetic polynomial model rather than
+    # failing, so a typo quietly changed what was being simulated.
+    missing = tmp_path / "not-there.npz"
+
+    with pytest.raises(FileNotFoundError, match="not-there.npz"):
+        replay_main.resolve_planner_profile_data(missing)
+
+
+def test_existing_npz_planner_profile_data_still_short_circuits(tmp_path) -> None:
+    # Pins the reason the suffix check exists: a real .npz is taken at its word
+    # without reading it, so no planner import happens on this path.
+    present = tmp_path / "profile.npz"
+    present.write_bytes(b"")
+
+    assert replay_main.resolve_planner_profile_data(present).npz_path == present


### PR DESCRIPTION
## Summary

`resolve_planner_profile_data` in `dynamo/replay/main.py` short-circuits on the file suffix:

```python
if planner_profile_data.suffix == ".npz":
    return SimpleNamespace(npz_path=planner_profile_data)
```

That short-circuit is deliberate. #8050 added it so replay does not import planner-only dependencies when the caller already has a resolved `.npz`. What it does not do is check the file is there, and it reports any `.npz`-suffixed path as resolved.

That is not a deferred error, which is what makes it worth fixing. The path travels on into `MockEngineArgs`, the engine cannot open it, and it recovers rather than failing:

```
INFO  dynamo_mocker::common::perf_model: Loading performance model from NPZ file: "/tmp/typo.npz"
ERROR dynamo_mocker::common::protocols: Failed to load performance model from "/tmp/typo.npz":
      Failed to open NPZ file. Falling back to polynomial model.
```

`_load_engine_args` then returns a `MockEngineArgs` with no error raised, and the replay runs to completion. A mistyped `--planner-profile-data` therefore produces a full set of results computed from a synthetic polynomial model instead of the measured profile the user asked for, and the only trace is one ERROR line in the middle of normal startup output. Nothing downstream reports that the profile was substituted.

The same typo taken through `dynamo.mocker.args.resolve_planner_profile_data` raises `FileNotFoundError` and names what it expected, so the two entry points already disagree about it.

This checks existence and nothing more. Reading the file to validate its contents would need exactly the planner dependencies the short-circuit exists to avoid, and a path that is not there is disqualifying without reading anything. The engine's polynomial fallback is untouched, since that is the mocker's own resilience choice and the place to catch this is the CLI boundary where the user's intent is known.

Note for review order: #13546 also touches `dynamo/replay/main.py`, in `_load_engine_args` and `main`. Different functions, so the two merge independently in either order.

## Validation

Reproduced on current `main` (`17583944d4`) before changing anything:

```
replay accepts missing path -> /tmp/definitely-does-not-exist-12345.npz
mocker rejects it           -> FileNotFoundError
_load_engine_args           -> MockEngineArgs (no error raised)
```

Two tests, in the module's existing test file. Reverting only `main.py` and keeping them:

```
FAILED components/src/dynamo/replay/tests/test_main.py::test_missing_npz_planner_profile_data_is_rejected
1 failed, 9 passed
```

and with the change, `10 passed`.

The second test, `test_existing_npz_planner_profile_data_still_short_circuits`, passes both before and after on purpose. It pins #8050's intent, so that a later attempt to "properly validate" this path by reading the file fails a test instead of quietly reintroducing the planner import.

`pre-commit run --files` on both changed files is clean apart from `isort` wanting to reorder an `aisimulate` import that is already in that order on `main`, which is pre-existing drift in my environment's classification and not something this PR should carry. The imports in this diff are byte-identical to `main`.

Not verified here: the published `aisimulate` wheel is not installable on this machine, so the test module resolves against a local build. That does not bear on this change; `resolve_planner_profile_data` is pure `pathlib`, and the polynomial fallback above comes from `dynamo.mocker`, the Rust bindings, which I exercised directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Planner profile paths are now validated before use.
  - Missing `.npz` profile files produce a clear file-not-found error instead of continuing unexpectedly.

- **Tests**
  - Added coverage for missing profile files.
  - Confirmed existing profile files resolve correctly without unnecessary file reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->