### PR TITLE
fix(vllm): remove sidecar OTEL labels

### DIFF
--- a/lib/sidecar/vllm/launch/disagg.sh
+++ b/lib/sidecar/vllm/launch/disagg.sh
@@ -121,14 +121,12 @@ vllm-rs serve "$MODEL" \
     $GPU_MEM_ARGS \
     "${EXTRA_ARGS[@]}" &
 
-OTEL_SERVICE_NAME=dynamo-worker-decode \
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT1:-8081}" \
     dynamo-vllm-sidecar \
     --grpc-endpoint "127.0.0.1:${VLLM_DECODE_GRPC_PORT}" \
     --disaggregation-mode decode &
 
 # Register prefill separately so the frontend routes each disaggregated stage.
-OTEL_SERVICE_NAME=dynamo-worker-prefill \
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT2:-8082}" \
     dynamo-vllm-sidecar \
     --grpc-endpoint "127.0.0.1:${VLLM_PREFILL_GRPC_PORT}" \


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Remove unused OpenTelemetry service-name labels from the vLLM disaggregated sidecar launcher.

## Details:

<!-- Describe the changes made in this PR. -->

- Stop setting `OTEL_SERVICE_NAME` on the decode and prefill sidecar processes.
- Preserve the existing system-port, endpoint, component, and disaggregation-mode configuration.
- Confirm no standard vLLM sidecar launcher retains an `OTEL_SERVICE_NAME` assignment.
- Validate the script with `bash -n`, ShellCheck, help-output checks, and the applicable pre-commit hooks.

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

`lib/sidecar/vllm/launch/disagg.sh`

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary service-name configuration from decode and prefill sidecars.
  * Sidecar startup and routing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->