### PR TITLE
fix(sglang): map min_tokens to min_new_tokens

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -304,6 +304,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             param_mapping = {
                 "n": sampling_opts.get("n"),
                 "max_new_tokens": stop_conditions.get("max_tokens"),
+                "min_new_tokens": stop_conditions.get("min_tokens"),
                 "ignore_eos": stop_conditions.get("ignore_eos"),
                 "stop_token_ids": stop_token_ids,
                 **_sampling_option_params(sampling_opts),
@@ -316,6 +317,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             param_mapping = {
                 "n": request.get("n"),
                 "max_new_tokens": request.get("max_tokens"),
+                "min_new_tokens": request.get("min_tokens"),
                 **_sampling_option_params(request),
                 **_openai_stop_sampling_params(request),
                 **self._get_guided_decoding_params(request.get("guided_decoding")),

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -93,6 +93,8 @@ class SglangUtils:
             sampling_params["n"] = sampling_options.n
         if stop_conditions.max_tokens:
             sampling_params["max_new_tokens"] = stop_conditions.max_tokens
+        if stop_conditions.min_tokens:
+            sampling_params["min_new_tokens"] = stop_conditions.min_tokens
         if stop_conditions.ignore_eos:
             sampling_params["ignore_eos"] = stop_conditions.ignore_eos
 

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -12,6 +12,12 @@ from dynamo.sglang.engine_generate import (
     build_native_generate_request,
     native_generate_stream,
 )
+from dynamo.sglang.protocol import (
+    PreprocessedRequest,
+    SamplingOptions,
+    SglangMultimodalRequest,
+    StopConditions,
+)
 from dynamo.sglang.request_handlers.llm.decode_handler import (
     DecodeWorkerHandler,
     _extract_sglang_stop_reason,
@@ -25,6 +31,7 @@ from dynamo.sglang.request_handlers.llm.mm_disagg_utils import (
     raise_if_unextracted_multimodal,
 )
 from dynamo.sglang.request_handlers.llm.prefill_handler import PrefillWorkerHandler
+from dynamo.sglang.request_handlers.multimodal.worker_handler import SglangUtils
 
 pytestmark = [
     pytest.mark.unit,
@@ -639,6 +646,74 @@ def test_build_sampling_params_maps_guided_decoding_to_json_schema():
     assert sampling_params["json_schema"] == (
         '{"type": "object", "properties": {"city": {"type": "string"}}}'
     )
+
+
+def test_build_sampling_params_maps_min_tokens_for_token_requests():
+    handler = _new_decode_handler(use_sglang_tokenizer=False)
+
+    sampling_params = handler._build_sampling_params(
+        {
+            "sampling_options": {},
+            "stop_conditions": {
+                "max_tokens": 64,
+                "min_tokens": 64,
+                "ignore_eos": True,
+            },
+        }
+    )
+
+    assert sampling_params["min_new_tokens"] == 64
+    assert sampling_params["max_new_tokens"] == 64
+    assert sampling_params["ignore_eos"] is True
+
+
+def test_build_sampling_params_maps_min_tokens_for_sglang_tokenizer_requests():
+    handler = _new_decode_handler(use_sglang_tokenizer=True)
+
+    sampling_params = handler._build_sampling_params(
+        {"max_tokens": 64, "min_tokens": 16}
+    )
+
+    assert sampling_params["min_new_tokens"] == 16
+    assert sampling_params["max_new_tokens"] == 64
+
+
+def test_build_sampling_params_omits_min_new_tokens_when_min_tokens_absent():
+    handler = _new_decode_handler(use_sglang_tokenizer=False)
+
+    sampling_params = handler._build_sampling_params(
+        {"sampling_options": {}, "stop_conditions": {"max_tokens": 8}}
+    )
+
+    assert "min_new_tokens" not in sampling_params
+
+
+def test_build_sampling_params_forwards_explicit_zero_min_tokens():
+    handler = _new_decode_handler(use_sglang_tokenizer=False)
+
+    sampling_params = handler._build_sampling_params(
+        {"sampling_options": {}, "stop_conditions": {"max_tokens": 8, "min_tokens": 0}}
+    )
+
+    assert sampling_params["min_new_tokens"] == 0
+
+
+def test_multimodal_build_sampling_params_maps_min_tokens():
+    request = SglangMultimodalRequest(
+        request=PreprocessedRequest(
+            token_ids=[1, 2, 3],
+            stop_conditions=StopConditions(
+                max_tokens=64, min_tokens=64, ignore_eos=True
+            ),
+            sampling_options=SamplingOptions(),
+        )
+    )
+
+    sampling_params = SglangUtils.build_sampling_params(request)
+
+    assert sampling_params["min_new_tokens"] == 64
+    assert sampling_params["max_new_tokens"] == 64
+    assert sampling_params["ignore_eos"] is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Overview:

SGLang backend accepts min_tokens and never maps it to min_new_tokens. 

'min_tokens' should reach SGLang as 'min_new_tokens', which suppresses EOS until the floor is met. This is consistent with the other backends (vllm, trtllm, tokenspeed). 'min_tokens' is partially enforced by Dynamo's decoder, which suppresses stop-sequence and stop-token-id until the floor is reached but cannot suppress an SGLang-omitted EOS.

## Details:
- `min_tokens` is accepted at Dynamo's HTTP boundary as a root-level extension (`lib/llm/src/protocols/openai/common_ext.rs`), carried through `StopConditions` (`lib/llm/src/protocols/common.rs`), always populated by the SGLang frontend processor (`components/src/dynamo/frontend/sglang_processor.py`, defaulting to `0`), and re-declared in the SGLang backend's own Pydantic model (`components/src/dynamo/sglang/protocol.py`) where it is then never read.
- `DecodeWorkerHandler._build_sampling_params` maps `max_tokens`, `ignore_eos` and `stop_token_ids` but not `min_tokens`, in both the token-based and OpenAI-format branches, and the dict it returns is passed verbatim to `sgl.Engine.async_generate(sampling_params=...)`.  
- `SglangUtils.build_sampling_params` on the multimodal path has the same omission.

This PR maps it to SGLang's `min_new_tokens` in all three places.

  ## Where should the reviewer start?

  - **`components/src/dynamo/sglang/request_handlers/llm/decode_handler.py`** —
    `_build_sampling_params`, one line added to each of the two `param_mapping` branches.
  - **`components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py`** —
    `SglangUtils.build_sampling_params`, same fix in the surrounding truthy-guard style.
  - **`components/src/dynamo/sglang/tests/test_sglang_decode_handler.py`** — five new tests:
    both request formats, absent-key, the explicit-zero passthrough, and the multimodal builder.

## Related Issues

- [ x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Minimum token settings are now correctly applied to text and multimodal generation requests.
  - Explicit zero values and omitted settings are preserved as configured.
  - Existing maximum token limits and end-of-sequence handling remain unchanged.

- **Tests**
  - Added coverage for minimum-token mapping across supported request formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->