### PR TITLE
fix(operator): Align multi-node DGDSA selectors

### DIFF
--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -76,9 +76,9 @@ const (
 	KubeLabelDynamoComponentType    = "nvidia.com/dynamo-component-type"
 	KubeLabelDynamoSubComponentType = "nvidia.com/dynamo-sub-component-type"
 	KubeLabelDynamoComponentClass   = "nvidia.com/dynamo-component-class"
-	// KubeLabelDynamoWorkloadRole distinguishes the leader and worker Pod templates of a multi-node component.
-	// DGDSA uses the leader value so its scale selector has one representative Pod per logical component replica.
-	KubeLabelDynamoWorkloadRole     = "role"
+	// KubeLabelDynamoWorkloadRole identifies a Pod's role within its logical component replica.
+	// DGDSA combines it with provider labels to select one representative Pod per replica.
+	KubeLabelDynamoWorkloadRole     = "nvidia.com/dynamo-workload-role"
 	KubeLabelDynamoBaseModel        = "nvidia.com/dynamo-base-model"
 	KubeLabelDynamoBaseModelHash    = "nvidia.com/dynamo-base-model-hash"
 	KubeAnnotationDynamoBaseModel   = "nvidia.com/dynamo-base-model"

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -76,6 +76,9 @@ const (
 	KubeLabelDynamoComponentType    = "nvidia.com/dynamo-component-type"
 	KubeLabelDynamoSubComponentType = "nvidia.com/dynamo-sub-component-type"
 	KubeLabelDynamoComponentClass   = "nvidia.com/dynamo-component-class"
+	// KubeLabelDynamoWorkloadRole distinguishes the leader and worker Pod templates of a multi-node component.
+	// DGDSA uses the leader value so its scale selector has one representative Pod per logical component replica.
+	KubeLabelDynamoWorkloadRole     = "role"
 	KubeLabelDynamoBaseModel        = "nvidia.com/dynamo-base-model"
 	KubeLabelDynamoBaseModelHash    = "nvidia.com/dynamo-base-model-hash"
 	KubeAnnotationDynamoBaseModel   = "nvidia.com/dynamo-base-model"

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
@@ -41,8 +41,6 @@ import (
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 )
 
-const dcdWorkloadRoleLabel = "role"
-
 // dcdWorkloadRenderer contains the dependencies required to render the
 // workload-facing resources of a DynamoComponentDeployment. It deliberately
 // does not own reconciliation, watches, finalizers, or status.
@@ -127,7 +125,7 @@ func (r *dcdWorkloadRenderer) generateLeaderPodTemplateSpec(
 	}
 
 	maps.Copy(leaderPodTemplateSpec.ObjectMeta.Labels, labels)
-	leaderPodTemplateSpec.ObjectMeta.Labels[dcdWorkloadRoleLabel] = string(dynamo.RoleLeader)
+	leaderPodTemplateSpec.ObjectMeta.Labels[commonconsts.KubeLabelDynamoWorkloadRole] = string(dynamo.RoleLeader)
 	delete(leaderPodTemplateSpec.ObjectMeta.Labels, commonconsts.KubeLabelDynamoSelector)
 
 	if err := checkMainContainer(&leaderPodTemplateSpec.Spec); err != nil {
@@ -149,7 +147,7 @@ func (r *dcdWorkloadRenderer) generateWorkerPodTemplateSpec(
 	}
 
 	maps.Copy(workerPodTemplateSpec.ObjectMeta.Labels, labels)
-	workerPodTemplateSpec.ObjectMeta.Labels[dcdWorkloadRoleLabel] = string(dynamo.RoleWorker)
+	workerPodTemplateSpec.ObjectMeta.Labels[commonconsts.KubeLabelDynamoWorkloadRole] = string(dynamo.RoleWorker)
 	delete(workerPodTemplateSpec.ObjectMeta.Labels, commonconsts.KubeLabelDynamoSelector)
 
 	if err := checkMainContainer(&workerPodTemplateSpec.Spec); err != nil {
@@ -347,7 +345,7 @@ func (r *dcdWorkloadRenderer) generateService(
 		return nil, false, err
 	}
 	if dcd.IsMultinode() {
-		svc.Spec.Selector[dcdWorkloadRoleLabel] = string(dynamo.RoleLeader)
+		svc.Spec.Selector[commonconsts.KubeLabelDynamoWorkloadRole] = string(dynamo.RoleLeader)
 	}
 	return svc, false, nil
 }

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
@@ -41,6 +41,8 @@ import (
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 )
 
+const dcdWorkloadRoleLabel = "role"
+
 // dcdWorkloadRenderer contains the dependencies required to render the
 // workload-facing resources of a DynamoComponentDeployment. It deliberately
 // does not own reconciliation, watches, finalizers, or status.
@@ -125,7 +127,7 @@ func (r *dcdWorkloadRenderer) generateLeaderPodTemplateSpec(
 	}
 
 	maps.Copy(leaderPodTemplateSpec.ObjectMeta.Labels, labels)
-	leaderPodTemplateSpec.ObjectMeta.Labels[commonconsts.KubeLabelDynamoWorkloadRole] = string(dynamo.RoleLeader)
+	leaderPodTemplateSpec.ObjectMeta.Labels[dcdWorkloadRoleLabel] = string(dynamo.RoleLeader)
 	delete(leaderPodTemplateSpec.ObjectMeta.Labels, commonconsts.KubeLabelDynamoSelector)
 
 	if err := checkMainContainer(&leaderPodTemplateSpec.Spec); err != nil {
@@ -147,7 +149,7 @@ func (r *dcdWorkloadRenderer) generateWorkerPodTemplateSpec(
 	}
 
 	maps.Copy(workerPodTemplateSpec.ObjectMeta.Labels, labels)
-	workerPodTemplateSpec.ObjectMeta.Labels[commonconsts.KubeLabelDynamoWorkloadRole] = string(dynamo.RoleWorker)
+	workerPodTemplateSpec.ObjectMeta.Labels[dcdWorkloadRoleLabel] = string(dynamo.RoleWorker)
 	delete(workerPodTemplateSpec.ObjectMeta.Labels, commonconsts.KubeLabelDynamoSelector)
 
 	if err := checkMainContainer(&workerPodTemplateSpec.Spec); err != nil {
@@ -345,7 +347,7 @@ func (r *dcdWorkloadRenderer) generateService(
 		return nil, false, err
 	}
 	if dcd.IsMultinode() {
-		svc.Spec.Selector[commonconsts.KubeLabelDynamoWorkloadRole] = string(dynamo.RoleLeader)
+		svc.Spec.Selector[dcdWorkloadRoleLabel] = string(dynamo.RoleLeader)
 	}
 	return svc, false, nil
 }

--- a/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller.go
@@ -40,6 +40,7 @@ import (
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
 )
 
@@ -138,7 +139,7 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 
 	// 5. Update adapter status
 	adapter.Status.Replicas = adapter.Spec.Replicas
-	adapter.Status.Selector = r.buildPodSelector(dgd.Name, componentName)
+	adapter.Status.Selector = r.buildPodSelector(dgd.Name, component)
 
 	if err := r.Status().Update(ctx, adapter); err != nil {
 		logger.Error(err, "Failed to update adapter status")
@@ -148,15 +149,26 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 	return ctrl.Result{}, nil
 }
 
-// buildPodSelector constructs a label selector for the pods managed by this component.
-func (r *DynamoGraphDeploymentScalingAdapterReconciler) buildPodSelector(dgdName, componentName string) string {
-	// Pods are labeled with:
-	// - nvidia.com/dynamo-graph-deployment-name = dgd.Name
-	// - nvidia.com/dynamo-component = componentName
-	return labels.SelectorFromSet(labels.Set{
+// buildPodSelector constructs a replica-aligned label selector for the Pods managed by this component.
+func (r *DynamoGraphDeploymentScalingAdapterReconciler) buildPodSelector(
+	dgdName string,
+	component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+) string {
+	// Select the component's Pods on every workload provider.
+	podLabels := labels.Set{
 		consts.KubeLabelDynamoGraphDeploymentName: dgdName,
-		consts.KubeLabelDynamoComponent:           componentName,
-	}).String()
+		consts.KubeLabelDynamoComponent:           component.ComponentName,
+	}
+
+	// A multi-node replica expands into one leader and one or more worker Pods.
+	// HPA Pods metrics require one selected Pod per logical replica; otherwise
+	// worker Pods without engine metrics are treated as missing at the target
+	// value and block scale-down.
+	if component.IsMultinode() {
+		podLabels[consts.KubeLabelDynamoWorkloadRole] = string(dynamo.RoleLeader)
+	}
+
+	return labels.SelectorFromSet(podLabels).String()
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller.go
@@ -20,6 +20,7 @@ package controller
 import (
 	"context"
 
+	grovecommon "github.com/ai-dynamo/grove/operator/api/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -139,7 +140,7 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 
 	// 5. Update adapter status
 	adapter.Status.Replicas = adapter.Spec.Replicas
-	adapter.Status.Selector = r.buildPodSelector(dgd.Name, component)
+	adapter.Status.Selector = r.buildPodSelector(dgd, component)
 
 	if err := r.Status().Update(ctx, adapter); err != nil {
 		logger.Error(err, "Failed to update adapter status")
@@ -151,21 +152,30 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 
 // buildPodSelector constructs a replica-aligned label selector for the Pods managed by this component.
 func (r *DynamoGraphDeploymentScalingAdapterReconciler) buildPodSelector(
-	dgdName string,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 	component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
 ) string {
 	// Select the component's Pods on every workload provider.
 	podLabels := labels.Set{
-		consts.KubeLabelDynamoGraphDeploymentName: dgdName,
+		consts.KubeLabelDynamoGraphDeploymentName: dgd.Name,
 		consts.KubeLabelDynamoComponent:           component.ComponentName,
 	}
 
-	// A multi-node replica expands into one leader and one or more worker Pods.
-	// HPA Pods metrics require one selected Pod per logical replica; otherwise
-	// worker Pods without engine metrics are treated as missing at the target
-	// value and block scale-down.
-	if component.IsMultinode() {
-		podLabels[consts.KubeLabelDynamoWorkloadRole] = string(dynamo.RoleLeader)
+	// LWS expands a multi-node replica into one leader and multiple workers.
+	if dgd.Annotations[consts.KubeAnnotationWorkloadProvider] != consts.WorkloadProviderGrove && component.IsMultinode() {
+		podLabels[dcdWorkloadRoleLabel] = string(dynamo.RoleLeader)
+	}
+
+	// Grove scaling groups can also include GMS Pods and failover shadows.
+	// Select pod index zero from the primary engine role so one physical Pod
+	// represents each logical component replica for HPA Pods metrics.
+	if dgd.Annotations[consts.KubeAnnotationWorkloadProvider] == consts.WorkloadProviderGrove && component.UsesPCSG() {
+		role := dynamo.RoleMain
+		if component.IsMultinode() {
+			role = dynamo.RoleLeader
+		}
+		podLabels[consts.KubeLabelDynamoWorkloadRole] = string(role)
+		podLabels[grovecommon.LabelPodCliquePodIndex] = "0"
 	}
 
 	return labels.SelectorFromSet(podLabels).String()
@@ -192,14 +202,19 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) SetupWithManager(mgr ctr
 					if !okOld || !okNew {
 						return false
 					}
-					// Trigger if components changed.
-					return !componentsEqual(oldDGD.Spec.Components, newDGD.Spec.Components)
+					// Trigger if components or their workload provider changed.
+					return scalingAdapterDGDChanged(oldDGD, newDGD)
 				},
 				GenericFunc: func(ge event.GenericEvent) bool { return false },
 			}),
 		).
 		WithEventFilter(commonController.EphemeralDeploymentEventFilter(r.Config, r.RuntimeConfig)).
 		Complete(observability.NewObservedReconciler(r, consts.ResourceTypeDynamoGraphDeploymentScalingAdapter))
+}
+
+func scalingAdapterDGDChanged(oldDGD, newDGD *nvidiacomv1beta1.DynamoGraphDeployment) bool {
+	return !componentsEqual(oldDGD.Spec.Components, newDGD.Spec.Components) ||
+		oldDGD.Annotations[consts.KubeAnnotationWorkloadProvider] != newDGD.Annotations[consts.KubeAnnotationWorkloadProvider]
 }
 
 // findAdaptersForDGD maps DGD changes to adapter reconcile requests.

--- a/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
@@ -327,6 +327,46 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 	}
 }
 
+func TestDynamoGraphDeploymentScalingAdapterReconcilerBuildPodSelector(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		multinode *v1beta1.MultinodeSpec
+		wantRole  string
+	}{
+		"single-node selects the component": {},
+		"multi-node selects one leader per logical replica": {
+			multinode: &v1beta1.MultinodeSpec{NodeCount: 4},
+			wantRole:  "leader",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Log("Build the scale selector for the component topology")
+			component := &v1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: "worker",
+				Multinode:     tt.multinode,
+			}
+			got := (&DynamoGraphDeploymentScalingAdapterReconciler{}).buildPodSelector("test-dgd", component)
+
+			t.Log("Verify the selector stays replica-aligned")
+			wantLabels := labels.Set{
+				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+				consts.KubeLabelDynamoComponent:           "worker",
+			}
+			if tt.wantRole != "" {
+				wantLabels[consts.KubeLabelDynamoWorkloadRole] = tt.wantRole
+			}
+			if want := labels.SelectorFromSet(wantLabels).String(); got != want {
+				t.Fatalf("buildPodSelector() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile_NotFound(t *testing.T) {
 	// Register custom types with the scheme
 	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {

--- a/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	grovecommon "github.com/ai-dynamo/grove/operator/api/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -331,13 +332,41 @@ func TestDynamoGraphDeploymentScalingAdapterReconcilerBuildPodSelector(t *testin
 	t.Parallel()
 
 	tests := map[string]struct {
-		multinode *v1beta1.MultinodeSpec
-		wantRole  string
+		provider       string
+		multinode      *v1beta1.MultinodeSpec
+		experimental   *v1beta1.ExperimentalSpec
+		wantRole       string
+		wantLegacyRole string
+		wantPodIndex   bool
 	}{
 		"single-node selects the component": {},
-		"multi-node selects one leader per logical replica": {
-			multinode: &v1beta1.MultinodeSpec{NodeCount: 4},
-			wantRole:  "leader",
+		"LWS multi-node selects the leader": {
+			provider:       consts.WorkloadProviderComponent,
+			multinode:      &v1beta1.MultinodeSpec{NodeCount: 4},
+			wantLegacyRole: "leader",
+		},
+		"Grove multi-node selects the primary leader": {
+			provider:     consts.WorkloadProviderGrove,
+			multinode:    &v1beta1.MultinodeSpec{NodeCount: 4},
+			wantRole:     "leader",
+			wantPodIndex: true,
+		},
+		"Grove single-node GMS selects the primary engine": {
+			provider: consts.WorkloadProviderGrove,
+			experimental: &v1beta1.ExperimentalSpec{
+				GPUMemoryService: &v1beta1.GPUMemoryServiceSpec{Mode: v1beta1.GMSModeInterPod},
+				Failover:         &v1beta1.FailoverSpec{Mode: v1beta1.GMSModeInterPod, NumShadows: 1},
+			},
+			wantRole:     "main",
+			wantPodIndex: true,
+		},
+		"Grove forced scaling group selects its only Pod": {
+			provider: consts.WorkloadProviderGrove,
+			experimental: &v1beta1.ExperimentalSpec{
+				Grove: &v1beta1.GroveSpec{ForceScalingGroup: true},
+			},
+			wantRole:     "main",
+			wantPodIndex: true,
 		},
 	}
 
@@ -346,24 +375,60 @@ func TestDynamoGraphDeploymentScalingAdapterReconcilerBuildPodSelector(t *testin
 			t.Parallel()
 
 			t.Log("Build the scale selector for the component topology")
+			dgd := &v1beta1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-dgd",
+					Annotations: map[string]string{
+						consts.KubeAnnotationWorkloadProvider: tt.provider,
+					},
+				},
+			}
 			component := &v1beta1.DynamoComponentDeploymentSharedSpec{
 				ComponentName: "worker",
 				Multinode:     tt.multinode,
+				Experimental:  tt.experimental,
 			}
-			got := (&DynamoGraphDeploymentScalingAdapterReconciler{}).buildPodSelector("test-dgd", component)
+			got := (&DynamoGraphDeploymentScalingAdapterReconciler{}).buildPodSelector(dgd, component)
 
 			t.Log("Verify the selector stays replica-aligned")
 			wantLabels := labels.Set{
 				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
 				consts.KubeLabelDynamoComponent:           "worker",
 			}
+			if tt.wantLegacyRole != "" {
+				wantLabels[dcdWorkloadRoleLabel] = tt.wantLegacyRole
+			}
 			if tt.wantRole != "" {
 				wantLabels[consts.KubeLabelDynamoWorkloadRole] = tt.wantRole
+			}
+			if tt.wantPodIndex {
+				wantLabels[grovecommon.LabelPodCliquePodIndex] = "0"
 			}
 			if want := labels.SelectorFromSet(wantLabels).String(); got != want {
 				t.Fatalf("buildPodSelector() = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+func TestScalingAdapterDGDChanged(t *testing.T) {
+	t.Parallel()
+
+	t.Log("Construct equivalent DGDs with independently mutable provider metadata")
+	oldDGD := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			consts.KubeAnnotationWorkloadProvider: consts.WorkloadProviderComponent,
+		}},
+	}
+	newDGD := oldDGD.DeepCopy()
+	if scalingAdapterDGDChanged(oldDGD, newDGD) {
+		t.Fatal("equivalent DGDs should not trigger adapter reconciliation")
+	}
+
+	t.Log("Verify provider materialization triggers selector reconciliation")
+	newDGD.Annotations[consts.KubeAnnotationWorkloadProvider] = consts.WorkloadProviderGrove
+	if !scalingAdapterDGDChanged(oldDGD, newDGD) {
+		t.Fatal("workload provider change should trigger adapter reconciliation")
 	}
 }
 

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -2430,9 +2430,9 @@ func buildCliqueForRole(p cliqueParams) (*grovev1alpha1.PodCliqueTemplateSpec, e
 		return nil, fmt.Errorf("failed to generate labels: %w", err)
 	}
 	clique.Labels = labels
-	// Stamp the same role contract used by LWS so autoscalers can select one
-	// metric-emitting leader Pod for each logical multi-node component replica.
-	if p.isMultinode {
+	// Stamp operator-owned roles on scaling-group Pods so autoscalers can
+	// distinguish engine representatives from workers, shadows, and GMS Pods.
+	if p.usesPCSG {
 		clique.Labels[commonconsts.KubeLabelDynamoWorkloadRole] = string(p.r.Role)
 	}
 	if p.isInterPodFailover && p.r.Role != RoleGMS {

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -2430,6 +2430,11 @@ func buildCliqueForRole(p cliqueParams) (*grovev1alpha1.PodCliqueTemplateSpec, e
 		return nil, fmt.Errorf("failed to generate labels: %w", err)
 	}
 	clique.Labels = labels
+	// Stamp the same role contract used by LWS so autoscalers can select one
+	// metric-emitting leader Pod for each logical multi-node component replica.
+	if p.isMultinode {
+		clique.Labels[commonconsts.KubeLabelDynamoWorkloadRole] = string(p.r.Role)
+	}
 	if p.isInterPodFailover && p.r.Role != RoleGMS {
 		clique.Labels[commonconsts.KubeLabelDynamoFailoverEngineGroupMember] = commonconsts.KubeLabelValueTrue
 	}

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -8647,10 +8647,12 @@ func TestGenerateGrovePodCliqueSet_GMSPodsDoNotCarryDiscoveryLabels(t *testing.T
 		_, hasEnabled := clique.Labels[commonconsts.KubeLabelDynamoDiscoveryEnabled]
 		if strings.Contains(clique.Name, "gms") {
 			sawGMS = true
+			assert.Equal(t, string(RoleGMS), clique.Labels[commonconsts.KubeLabelDynamoWorkloadRole])
 			assert.False(t, hasBackend, "GMS clique %q must not carry KubeLabelDynamoDiscoveryBackend", clique.Name)
 			assert.False(t, hasEnabled, "GMS clique %q must not carry KubeLabelDynamoDiscoveryEnabled", clique.Name)
 		} else {
 			sawEngine = true
+			assert.Equal(t, string(RoleMain), clique.Labels[commonconsts.KubeLabelDynamoWorkloadRole])
 			assert.True(t, hasBackend, "engine clique %q must carry KubeLabelDynamoDiscoveryBackend (#8067 contract)", clique.Name)
 			assert.True(t, hasEnabled, "engine clique %q must carry KubeLabelDynamoDiscoveryEnabled (#8067 contract)", clique.Name)
 		}
@@ -9065,7 +9067,7 @@ func TestGenerateGrovePodCliqueSet_ComponentMinAvailable(t *testing.T) {
 func TestGenerateGrovePodCliqueSetMultinodeRoleLabels(t *testing.T) {
 	t.Parallel()
 
-	t.Log("Render a Grove-backed multi-node component")
+	t.Log("Render a Grove-backed multi-node component with a user-owned role label")
 	dgd := &v1alpha1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-dgd", Namespace: "test-ns"},
 		Spec: v1alpha1.DynamoGraphDeploymentSpec{
@@ -9077,6 +9079,9 @@ func TestGenerateGrovePodCliqueSetMultinodeRoleLabels(t *testing.T) {
 					Multinode:     &v1alpha1.MultinodeSpec{NodeCount: 4},
 					Resources: &v1alpha1.Resources{
 						Limits: &v1alpha1.ResourceItem{GPU: "1"},
+					},
+					ExtraPodMetadata: &v1alpha1.ExtraPodMetadata{
+						Labels: map[string]string{"role": "custom"},
 					},
 				},
 			},
@@ -9091,9 +9096,10 @@ func TestGenerateGrovePodCliqueSetMultinodeRoleLabels(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	t.Log("Verify each PodClique carries the provider-independent workload role")
+	t.Log("Verify each PodClique carries an operator role without replacing the user role")
 	roles := make(map[string]string, len(got.Spec.Template.Cliques))
 	for _, clique := range got.Spec.Template.Cliques {
+		assert.Equal(t, "custom", clique.Labels["role"])
 		roles[clique.Name] = clique.Labels[commonconsts.KubeLabelDynamoWorkloadRole]
 	}
 	assert.Equal(t, map[string]string{
@@ -9144,6 +9150,7 @@ func TestGenerateGrovePodCliqueSet_SingleNodeForceScalingGroup(t *testing.T) {
 	require.Len(t, got.Spec.Template.Cliques, 1)
 	clique := got.Spec.Template.Cliques[0]
 	assert.Equal(t, "worker", clique.Name)
+	assert.Equal(t, string(RoleMain), clique.Labels[commonconsts.KubeLabelDynamoWorkloadRole])
 	assert.EqualValues(t, 1, clique.Spec.Replicas, "engine PCLQ must hold exactly one pod per PCSG replica")
 	require.NotNil(t, clique.Spec.MinAvailable)
 	assert.EqualValues(t, 1, *clique.Spec.MinAvailable)

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -2662,6 +2662,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 									commonconsts.KubeLabelDynamoGraphDeploymentName: "test-dynamo-graph-deployment",
 									commonconsts.KubeLabelDynamoComponent:           "worker",
 									commonconsts.KubeLabelDynamoNamespace:           "test-namespace-test-dynamo-graph-deployment",
+									commonconsts.KubeLabelDynamoWorkloadRole:        string(RoleLeader),
 									"nvidia.com/label1":                             "label1",
 									"nvidia.com/label2":                             "label2",
 								},
@@ -2875,6 +2876,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 									commonconsts.KubeLabelDynamoGraphDeploymentName: "test-dynamo-graph-deployment",
 									commonconsts.KubeLabelDynamoComponent:           "worker",
 									commonconsts.KubeLabelDynamoNamespace:           "test-namespace-test-dynamo-graph-deployment",
+									commonconsts.KubeLabelDynamoWorkloadRole:        string(RoleWorker),
 									"nvidia.com/label1":                             "label1",
 									"nvidia.com/label2":                             "label2",
 								},
@@ -3684,6 +3686,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 									commonconsts.KubeLabelDynamoComponentType:       commonconsts.ComponentTypeWorker,
 									commonconsts.KubeLabelDynamoGraphDeploymentName: "test-dynamo-graph-deployment",
 									commonconsts.KubeLabelDynamoNamespace:           "test-namespace-test-dynamo-graph-deployment",
+									commonconsts.KubeLabelDynamoWorkloadRole:        string(RoleLeader),
 									"nvidia.com/label1":                             "label1",
 									"nvidia.com/label2":                             "label2",
 								},
@@ -3884,6 +3887,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 									commonconsts.KubeLabelDynamoComponent:           "worker",
 									commonconsts.KubeLabelDynamoGraphDeploymentName: "test-dynamo-graph-deployment",
 									commonconsts.KubeLabelDynamoNamespace:           "test-namespace-test-dynamo-graph-deployment",
+									commonconsts.KubeLabelDynamoWorkloadRole:        string(RoleWorker),
 									"nvidia.com/label1":                             "label1",
 									"nvidia.com/label2":                             "label2",
 								},
@@ -9056,6 +9060,46 @@ func TestGenerateGrovePodCliqueSet_ComponentMinAvailable(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateGrovePodCliqueSetMultinodeRoleLabels(t *testing.T) {
+	t.Parallel()
+
+	t.Log("Render a Grove-backed multi-node component")
+	dgd := &v1alpha1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dgd", Namespace: "test-ns"},
+		Spec: v1alpha1.DynamoGraphDeploymentSpec{
+			BackendFramework: "vllm",
+			Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: commonconsts.ComponentTypeWorker,
+					Replicas:      ptr.To(int32(2)),
+					Multinode:     &v1alpha1.MultinodeSpec{NodeCount: 4},
+					Resources: &v1alpha1.Resources{
+						Limits: &v1alpha1.ResourceItem{GPU: "1"},
+					},
+				},
+			},
+		},
+	}
+	got, err := GenerateGrovePodCliqueSet(
+		context.Background(),
+		betaDGD(t, dgd),
+		&configv1alpha1.OperatorConfiguration{},
+		&controller_common.RuntimeConfig{},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+
+	t.Log("Verify each PodClique carries the provider-independent workload role")
+	roles := make(map[string]string, len(got.Spec.Template.Cliques))
+	for _, clique := range got.Spec.Template.Cliques {
+		roles[clique.Name] = clique.Labels[commonconsts.KubeLabelDynamoWorkloadRole]
+	}
+	assert.Equal(t, map[string]string{
+		"worker-ldr": string(RoleLeader),
+		"worker-wkr": string(RoleWorker),
+	}, roles)
 }
 
 // TestGenerateGrovePodCliqueSet_SingleNodeForceScalingGroup pins the


### PR DESCRIPTION
## Overview:

Fix multi-node `DynamoGraphDeploymentScalingAdapter` (DGDSA) Pod selectors so Kubernetes HPA evaluates one metric-emitting leader Pod per logical component replica.

Previously, a multi-node DGDSA reported logical replica-group counts through its Scale subresource while its selector matched every physical leader and worker Pod. For HPA `Pods` metrics such as `vllm:kv_cache_usage_perc`, only the leader exposes the engine metric. Kubernetes treated the worker Pods as missing metrics during scale-down, conservatively assigned them the target value, and could keep the recommendation pinned at the current replica count despite idle leaders.

Single-node selector behavior remains unchanged.

## Details:

- Promote the existing `role=leader|worker` LWS label into a shared workload-role label contract.
- Stamp the same role labels on Grove multi-node PodClique templates.
- Add `role=leader` to the DGDSA selector for multi-node components.
- Preserve the existing DGD/component-only selector for single-node components.
- Add tests covering:
  - unchanged single-node selectors;
  - leader-only multi-node selectors;
  - Grove leader and worker role labels;
  - complete Grove vLLM and SGLang render fixtures.

With this change, the relevant cardinalities align:

```text
DGDSA logical replicas = N
selected leader Pods   = N
engine metric samples  = N
```

Operational note: the new role label changes Grove multi-node PodClique templates. Deploying an operator containing this change can roll existing Grove multi-node workloads so their Pods receive the label required by the new selector.

Validation completed:

- `make test`
  - CRD and RBAC generation
  - Pydantic model generation and validation
  - Go formatting and vet
  - Kubernetes envtest
  - all non-e2e operator packages
- `make lint`
- Pre-commit hooks on all changed files
- `git diff --check`

## Where should the reviewer start?

Start with:

- `deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller.go`
  - The `buildPodSelector` change contains the core selector behavior.
- `deploy/operator/internal/dynamo/graph.go`
  - `buildCliqueForRole` adds the corresponding leader/worker labels to Grove PodClique templates.
- `deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go`
  - Covers single-node preservation and multi-node leader selection.
- `deploy/operator/internal/dynamo/graph_test.go`
  - Covers role-label propagation and complete Grove render compatibility.

## Related Issues

**🚫 This PR is NOT linked to an issue**:

- [x] Confirmed — no related issue
