### PR TITLE
perf(trtllm): disable detailed performance metrics by default

### DIFF
--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -352,7 +352,9 @@ async def init_llm_worker(
         "max_seq_len": config.max_seq_len,
         "max_beam_width": config.max_beam_width,
         "max_batch_size": config.max_batch_size,
-        "return_perf_metrics": config.publish_events_and_metrics,
+        # Detailed perf metrics add a large per-step response payload. Fixed
+        # request metrics stay enabled through default_sampling_params below.
+        "return_perf_metrics": False,
         # enable_iter_perf_stats is required for PyTorch backend to compute iteration-level
         # stats (KV cache utilization, hit rate). TensorRT backend always has this enabled.
         # See TRT-LLM PR #11243: MetricsCollector.log_iteration_stats() needs these stats.
@@ -511,7 +513,7 @@ async def init_llm_worker(
         )
     default_sampling_params = SamplingParams()
 
-    # Enable perf metrics so prompt_tokens_details can be returned
+    # Enable fixed request metrics so prompt_tokens_details can be returned.
     if hasattr(default_sampling_params, "return_perf_metrics"):
         default_sampling_params.return_perf_metrics = True
     model_input = ModelInput.Tokens

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -513,7 +513,9 @@ async def init_llm_worker(
         )
     default_sampling_params = SamplingParams()
 
-    # Enable fixed request metrics so prompt_tokens_details can be returned.
+    # Keep request metrics enabled independently of engine-level detailed timing.
+    # Dynamo consumes request_perf_metrics and metrics_dict for Prometheus and
+    # KV-transfer observability, but not time_breakdown_metrics.
     if hasattr(default_sampling_params, "return_perf_metrics"):
         default_sampling_params.return_perf_metrics = True
     model_input = ModelInput.Tokens


### PR DESCRIPTION
## Summary

- Disable engine-level `LlmArgs.return_perf_metrics` by default.
- Keep request-level `SamplingParams.return_perf_metrics` enabled. This is the metric path that Dynamo consumes.
- Keep `enable_iter_perf_stats` and explicit engine argument overrides unchanged.

## Why

Engine-level metrics enable the PyExecutor detailed timing collector. It records CPU and CUDA timing for each scheduled iteration, builds growing `step_metrics` and `ctx_chunk_metrics` lists, and attaches the complete `time_breakdown_metrics` payload to the final response. In attention data-parallel multiprocess paths, this variable-size payload can be pickled for the rank gather and again for worker-to-proxy IPC.

Dynamo does not consume or export `time_breakdown_metrics`. The TRT-LLM handler consumes only the fixed request-level data:

- `request_perf_metrics`, including request timing, KV-cache, KV-transfer, and speculative-decoding fields
- `metrics_dict`, used by the TRT-LLM Prometheus collector

The detailed engine-level payload is not copied into Dynamo metrics, traces, logs, normal responses, or `nvext.engine_data`. TRT-LLM's JSONL writer is part of `trtllm-serve`; Dynamo uses the lower-level `LLM.generate_async()` path and does not create that writer.

An explicit `--override-engine-args` value can still enable engine-level collection for custom worker instrumentation. Stock Dynamo does not provide a consumer for that detailed payload.

## Telemetry impact

The same Dynamo and TRT-LLM metric series remain available because request-level metrics and iteration statistics stay enabled. One timing semantic changes: TRT-LLM records the request arrival time later, during C++ request construction, when the engine-level flag is false. As a result, E2E latency, TTFT, and request queue time can exclude some Python submission and IPC time. Other request timing fields keep their existing anchors.

## Validation

Not run, as requested.

## Where should the reviewer start?

`components/src/dynamo/trtllm/workers/llm_worker.py`

## Related Issues

- [x] Confirmed - no related issue