### PR TITLE
test(sglang): wait for cancellable response readiness

### DIFF
--- a/tests/fault_tolerance/cancellation/utils.py
+++ b/tests/fault_tolerance/cancellation/utils.py
@@ -73,6 +73,7 @@ class CancellableRequest:
         self.session = requests.Session()
         self.response = None
         self.exception = None
+        self._response_ready = threading.Event()
         self._cancelled = False
         self._request_thread = None
         self._lock = threading.Lock()
@@ -105,6 +106,7 @@ class CancellableRequest:
                         and socket.socket == self.__class__._global_tracked_socket
                     ):
                         socket.socket = self.__class__._original_socket  # type: ignore[assignment,misc]
+                self._response_ready.set()
 
         with self._lock:
             if self._request_thread is not None:
@@ -179,8 +181,12 @@ class CancellableRequest:
                 f"HTTP {status_code}: {response_body}"
             )
 
-    def get_response(self):
-        """Get the response or raise exception if there was one"""
+    def get_response(self, timeout: float = 30.0):
+        """Wait for the request to produce a response or raise an exception."""
+        if not self._response_ready.wait(timeout):
+            raise requests.exceptions.Timeout(
+                f"Timed out after {timeout}s waiting for the HTTP response"
+            )
         if self._cancelled:
             raise requests.exceptions.RequestException("Request was cancelled")
         if self.exception:


### PR DESCRIPTION
## Overview:

Fix a race in the shared cancellation-test helper that can make SGLang decode-cancellation coverage fail before the test actually cancels a request.

`CancellableRequest.post()` performs the HTTP request on a background thread. The test can observe the request in the decode and prefill worker logs and then call `get_response()` before that background thread has stored the streaming `Response`. In that timing window, `get_response()` returns `None`, and `read_streaming_responses()` fails with `Failed to get streaming response: response is None`.

The observed `test_request_cancellation_sglang_decode_cancel[nats]` failure occurred at this point, before `cancel()` or any cancellation assertions ran. Its automatic retry passed.

## Details:

- Add a `threading.Event` that is set after the background HTTP request produces either a response or an exception.
- Make `get_response()` wait for that signal instead of immediately reading a potentially transient `None` value.
- Bound the wait at 30 seconds so a genuinely stuck request produces a clear timeout instead of hanging indefinitely.

This changes only test synchronization; it does not modify Dynamo or SGLang cancellation behavior.

## Where should the reviewer start?

`tests/fault_tolerance/cancellation/utils.py`, specifically `CancellableRequest.post()` and `CancellableRequest.get_response()`.

## Validation

- Exercised a delayed mock response and confirmed `get_response()` waits until it is available.
- Exercised a missing response and confirmed the bounded timeout is raised.
- `git diff --check` passes.

The full two-GPU SGLang test was not run locally.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cancellable requests by waiting for request completion before returning results.
  * Added timeout support, including a clear timeout error when a request does not finish within the specified period.
  * Preserved existing cancellation and request-error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->