### PR TITLE
fix(sglang): preserve incremental logprobs across chunks

### DIFF
--- a/components/src/dynamo/common/backend/logprobs.py
+++ b/components/src/dynamo/common/backend/logprobs.py
@@ -5,8 +5,9 @@
 
 vLLM and TRT-LLM expose logprobs through ``CompletionOutput.logprobs``
 (list aligned with ``token_ids``, dicts of ``token_id -> LogprobInfo``).
-SGLang exposes them through ``meta_info["output_token_logprobs"]`` as
-incremental tuples ``(logprob, token_id, text_or_None)``.
+SGLang exposes them through ``meta_info["output_token_logprobs"]`` as tuples
+``(logprob, token_id, text_or_None)``. Depending on the SGLang release, the
+arrays are cumulative or aligned with the current incremental output chunk.
 
 Both paths emit the same Dynamo wire format on ``GenerateChunk``:
 ``log_probs`` is a flat ``list[float]``, ``top_logprobs`` is
@@ -313,33 +314,47 @@ def build_sglang_logprob_kwargs(
 
 def extract_from_sglang_meta(
     meta_info: dict[str, Any],
+    num_output_logprobs_so_far: int = 0,
     *,
     num_output_tokens_in_chunk: Optional[int] = None,
     return_tokens_as_token_ids: bool = False,
-) -> tuple[Optional[list[float]], Optional[list[list[dict[str, Any]]]]]:
-    """Extract logprobs from SGLang's ``meta_info`` dict.
+) -> tuple[Optional[list[float]], Optional[list[list[dict[str, Any]]]], int]:
+    """Extract logprobs from SGLang ``meta_info`` across stream shapes.
 
-    The pinned SGLang release and its N-1 predecessor align
-    ``output_token_logprobs`` and ``output_top_logprobs`` with each incremental
-    ``output_ids`` chunk. When provided, ``num_output_tokens_in_chunk`` keeps
-    malformed trailing metadata out of Dynamo's response.
+    Some SGLang releases emit cumulative logprob metadata, while others emit
+    metadata aligned with only the current disjoint ``output_ids`` chunk. The
+    caller supplies both its running count and current chunk length so this
+    helper can preserve compatibility with both forms.
     """
     output_token_logprobs = meta_info.get("output_token_logprobs")
     if not output_token_logprobs:
-        return None, None
+        return None, None, num_output_logprobs_so_far
 
-    new_logprobs = output_token_logprobs
-    if num_output_tokens_in_chunk is not None:
-        new_logprobs = new_logprobs[:num_output_tokens_in_chunk]
+    per_chunk = (
+        num_output_tokens_in_chunk is not None
+        and len(output_token_logprobs) <= num_output_tokens_in_chunk
+    )
+    if per_chunk:
+        start = 0
+        end = len(output_token_logprobs)
+        next_logprobs_total = num_output_logprobs_so_far + end
+    else:
+        start = num_output_logprobs_so_far
+        end = len(output_token_logprobs)
+        if num_output_tokens_in_chunk is not None:
+            end = min(end, start + num_output_tokens_in_chunk)
+        next_logprobs_total = len(output_token_logprobs)
+
+    new_logprobs = output_token_logprobs[start:end]
     if not new_logprobs:
-        return None, None
+        return None, None, num_output_logprobs_so_far
 
     log_probs = [float(entry[0]) for entry in new_logprobs]
 
     top_logprobs: Optional[list[list[dict[str, Any]]]] = None
     output_top = meta_info.get("output_top_logprobs")
     if output_top:
-        new_top = output_top[: len(new_logprobs)]
+        new_top = output_top[start:end]
         if new_top:
             top_logprobs = []
             for position_entries in new_top:
@@ -362,4 +377,4 @@ def extract_from_sglang_meta(
                     )
                 top_logprobs.append(position_list)
 
-    return log_probs, top_logprobs
+    return log_probs, top_logprobs, next_logprobs_total

--- a/components/src/dynamo/common/backend/tests/test_logprobs.py
+++ b/components/src/dynamo/common/backend/tests/test_logprobs.py
@@ -396,7 +396,19 @@ def test_sglang_gate_reads_env(monkeypatch):
 
 
 def test_sglang_extract_returns_none_when_meta_empty():
-    assert extract_from_sglang_meta({}) == (None, None)
+    assert extract_from_sglang_meta({}) == (None, None, 0)
+
+
+def test_sglang_extract_slices_cumulative_array():
+    meta = {
+        "output_token_logprobs": [(-0.1, 1, "a"), (-0.2, 2, "b"), (-0.3, 3, "c")],
+    }
+    log_probs, top_logprobs, new_total = extract_from_sglang_meta(
+        meta, 1, num_output_tokens_in_chunk=2
+    )
+    assert log_probs == [-0.2, -0.3]
+    assert top_logprobs is None
+    assert new_total == 3
 
 
 def test_sglang_extract_supports_incremental_streaming_metadata():
@@ -405,8 +417,8 @@ def test_sglang_extract_supports_incremental_streaming_metadata():
         "output_token_logprobs": [(-0.2, 2, "b")],
         "output_top_logprobs": [[(-0.2, 2, "b"), (-1.2, 20, "B")]],
     }
-    log_probs, top_logprobs = extract_from_sglang_meta(
-        meta, num_output_tokens_in_chunk=1
+    log_probs, top_logprobs, new_total = extract_from_sglang_meta(
+        meta, 0, num_output_tokens_in_chunk=1
     )
     assert log_probs == [-0.2]
     assert top_logprobs == [
@@ -415,6 +427,27 @@ def test_sglang_extract_supports_incremental_streaming_metadata():
             {"rank": 2, "token_id": 20, "token": "B", "logprob": -1.2},
         ]
     ]
+    assert new_total == 1
+
+
+def test_sglang_extract_accepts_incremental_array_after_prior_chunk():
+    meta = {
+        "output_token_logprobs": [(-0.2, 2, "b")],
+        "output_top_logprobs": [[(-0.2, 2, "b"), (-1.2, 20, "B")]],
+    }
+
+    log_probs, top_logprobs, new_total = extract_from_sglang_meta(
+        meta, 1, num_output_tokens_in_chunk=1
+    )
+
+    assert log_probs == [-0.2]
+    assert top_logprobs == [
+        [
+            {"rank": 1, "token_id": 2, "token": "b", "logprob": -0.2},
+            {"rank": 2, "token_id": 20, "token": "B", "logprob": -1.2},
+        ]
+    ]
+    assert new_total == 2
 
 
 def test_sglang_extract_with_top():
@@ -422,7 +455,7 @@ def test_sglang_extract_with_top():
         "output_token_logprobs": [(-0.1, 101, "a")],
         "output_top_logprobs": [[(-0.1, 101, "a"), (-0.2, 102, "b")]],
     }
-    log_probs, top_logprobs = extract_from_sglang_meta(meta)
+    log_probs, top_logprobs, _ = extract_from_sglang_meta(meta)
     assert log_probs == [-0.1]
     assert top_logprobs == [
         [
@@ -437,7 +470,7 @@ def test_sglang_extract_return_tokens_as_token_ids():
         "output_token_logprobs": [(-0.1, 101, "a")],
         "output_top_logprobs": [[(-0.1, 101, "a")]],
     }
-    _, top_logprobs = extract_from_sglang_meta(meta, return_tokens_as_token_ids=True)
+    _, top_logprobs, _ = extract_from_sglang_meta(meta, return_tokens_as_token_ids=True)
     assert top_logprobs[0][0]["token"] == "token_id:101"
 
 
@@ -449,7 +482,7 @@ def test_sglang_extract_none_top_position_becomes_empty_list():
         "output_token_logprobs": [(-0.1, 101, "a"), (-0.2, 102, "b")],
         "output_top_logprobs": [None, [(-0.2, 102, "b")]],
     }
-    _, top_logprobs = extract_from_sglang_meta(meta)
+    _, top_logprobs, _ = extract_from_sglang_meta(meta)
     assert top_logprobs == [
         [],
         [{"rank": 1, "token_id": 102, "token": "b", "logprob": -0.2}],
@@ -460,8 +493,16 @@ def test_sglang_extract_clamps_metadata_to_output_chunk():
     meta = {
         "output_token_logprobs": [(-0.1, 1, "a"), (-0.2, 2, "b")],
     }
-    log_probs, _ = extract_from_sglang_meta(meta, num_output_tokens_in_chunk=1)
+    log_probs, _, _ = extract_from_sglang_meta(meta, num_output_tokens_in_chunk=1)
     assert log_probs == [-0.1]
+
+
+def test_sglang_extract_returns_cursor_unchanged_when_no_new_entries():
+    meta = {"output_token_logprobs": [(-0.1, 1, "a")]}
+    log_probs, top_logprobs, new_total = extract_from_sglang_meta(meta, 1)
+    assert log_probs is None
+    assert top_logprobs is None
+    assert new_total == 1
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -472,11 +472,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
     @staticmethod
     def _extract_logprobs(
         meta_info: Dict[str, Any],
-        num_output_tokens_in_chunk: Optional[int] = None,
+        num_output_logprobs_so_far: int = 0,
+        *,
+        num_output_tokens_in_chunk: int | None = None,
         return_tokens_as_token_ids: bool = False,
     ) -> tuple:
         return _shared_logprobs.extract_from_sglang_meta(
             meta_info,
+            num_output_logprobs_so_far,
             num_output_tokens_in_chunk=num_output_tokens_in_chunk,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
         )
@@ -773,6 +776,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         pending_log_probs_per_choice: dict[int, list[Any]] = {}
         pending_top_logprobs_per_choice: dict[int, list[Any]] = {}
         completion_tokens_per_choice: dict[int, int] = {}
+        # SGLang output_ids are disjoint deltas. Logprob metadata is cumulative
+        # on some releases and incremental on others, so retain a per-choice
+        # cursor while also passing each chunk's token count to the extractor.
+        output_logprobs_per_choice: dict[int, int] = {}
         async with self._cancellation_monitor(request_id_future, context):
             async for res in stream_source:
                 meta_info = res.get("meta_info", {})
@@ -812,11 +819,17 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 top_logprobs = None
                 if metadata_uploader is None:
                     # Extract logprobs for new tokens if available.
-                    log_probs, top_logprobs = self._extract_logprobs(
+                    (
+                        log_probs,
+                        top_logprobs,
+                        next_logprobs_total,
+                    ) = self._extract_logprobs(
                         meta_info,
+                        output_logprobs_per_choice.get(output_idx, 0),
                         num_output_tokens_in_chunk=len(raw_output_ids),
                         return_tokens_as_token_ids=return_tokens_as_token_ids,
                     )
+                    output_logprobs_per_choice[output_idx] = next_logprobs_total
 
                 output_ids = pending_stop_tokens_per_choice.pop(output_idx, [])
                 output_ids.extend(raw_output_ids)

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -1905,6 +1905,7 @@ async def test_process_token_stream_aligns_cumulative_logprobs_with_buffered_sto
         {
             "index": 0,
             "finish_reason": "stop",
+            "stop_reason": [128001, 128009],
             "token_ids": [],
             "log_probs": [],
             "top_logprobs": [],

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -931,12 +931,12 @@ def test_build_logprob_kwargs_allows_top_logprobs_with_escape_hatch(monkeypatch)
 
 
 def test_extract_logprobs_formats_top_tokens_as_token_ids():
-    log_probs, top_logprobs = DecodeWorkerHandler._extract_logprobs(
+    log_probs, top_logprobs, _ = DecodeWorkerHandler._extract_logprobs(
         {
             "output_token_logprobs": [(-0.1, 101, "a")],
             "output_top_logprobs": [[(-0.1, 101, "a"), (-0.2, 102, "b")]],
         },
-        1,
+        num_output_tokens_in_chunk=1,
         return_tokens_as_token_ids=True,
     )
 
@@ -1222,6 +1222,50 @@ async def test_process_token_stream_passes_through_encoded_routed_experts():
     )
 
     assert chunks[0]["engine_data"]["routed_experts"] == "AQIDBA=="
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_preserves_incremental_logprobs_after_interval():
+    handler = _new_decode_handler()
+    stream_items = []
+    cumulative_output_ids = []
+    for chunk_index in range(4):
+        first_token = chunk_index * 30
+        output_ids = list(range(first_token, first_token + 30))
+        cumulative_output_ids.extend(output_ids)
+        stream_items.append(
+            {
+                "index": 0,
+                "output_ids": output_ids,
+                "meta_info": {
+                    "id": "request-1",
+                    "finish_reason": None,
+                    "output_token_logprobs": [
+                        (-float(token_id + 1), token_id, f"token-{token_id}")
+                        for token_id in cumulative_output_ids
+                    ],
+                    "output_top_logprobs": [
+                        [(-float(token_id + 1), token_id, f"token-{token_id}")]
+                        for token_id in cumulative_output_ids
+                    ],
+                },
+            }
+        )
+
+    chunks = await _collect(
+        handler._process_token_stream(_stream(stream_items), _Context())
+    )
+
+    assert [len(chunk["log_probs"]) for chunk in chunks] == [30, 30, 30, 30]
+    assert [len(chunk["top_logprobs"]) for chunk in chunks] == [30, 30, 30, 30]
+    assert [value for chunk in chunks for value in chunk["log_probs"]] == [
+        -float(token_id + 1) for token_id in range(120)
+    ]
+    assert [
+        position[0]["token_id"]
+        for chunk in chunks
+        for position in chunk["top_logprobs"]
+    ] == list(range(120))
 
 
 @pytest.mark.asyncio
@@ -1798,6 +1842,72 @@ async def test_process_token_stream_buffers_split_hidden_stop_token_sequence():
             "index": 0,
             "finish_reason": "stop",
             "token_ids": [],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_aligns_cumulative_logprobs_with_buffered_stop():
+    handler = _new_decode_handler()
+    cumulative_logprobs = [
+        (-0.1, 101, "a"),
+        (-0.2, 128001, "<|im_start|>"),
+        (-0.3, 128009, "<|im_end|>"),
+    ]
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101, 128001],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": None,
+                            "output_token_logprobs": cumulative_logprobs[:2],
+                            "output_top_logprobs": [
+                                [entry] for entry in cumulative_logprobs[:2]
+                            ],
+                        },
+                    },
+                    {
+                        "index": 0,
+                        "output_ids": [128009],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {
+                                "type": "stop",
+                                "matched": [128001, 128009],
+                            },
+                            "output_token_logprobs": cumulative_logprobs,
+                            "output_top_logprobs": [
+                                [entry] for entry in cumulative_logprobs
+                            ],
+                        },
+                    },
+                ]
+            ),
+            _Context(),
+            suppressed_stop_token_ids={128001, 128009},
+        )
+    )
+
+    assert chunks == [
+        {
+            "index": 0,
+            "token_ids": [101],
+            "log_probs": [-0.1],
+            "top_logprobs": [
+                [{"rank": 1, "token_id": 101, "token": "a", "logprob": -0.1}]
+            ],
+        },
+        {
+            "index": 0,
+            "finish_reason": "stop",
+            "token_ids": [],
+            "log_probs": [],
+            "top_logprobs": [],
         },
     ]
 


### PR DESCRIPTION
## Summary

- Handle SGLang logprob metadata emitted per incremental output chunk.
- Retain compatibility with cumulative logprob metadata using the per-choice cursor and current chunk length.
- Add regression coverage for repeated stream intervals and both metadata shapes.

## Validation

- `pre-commit run black --files ...`
- `pre-commit run ruff --files ...`
- `python3 -m py_compile ...`
- Focused 120-token replay for incremental and cumulative metadata
- End-to-end validation with the patch built into an SGLang runtime:
  - OpenAI-compatible endpoint suite: 47/47 passed
  - Non-streaming: 120 completion tokens returned 120 logprob entries, with five `top_logprobs` entries for every token
  - Streaming: 120 completion tokens returned 120 logprob entries across incremental chunks `[1, 30, 30, 30, 29]`
  - Logprob metadata was explicitly verified across chunk boundaries and through token index 119

Focused pytest collection was unavailable in the local source-only environment because the complete project test dependencies are not installed; CI remains required for project-wide integration coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streamed logprob handling across output chunks.
  - Ensured cumulative and top-logprob data is correctly limited to each current chunk.
  - Preserved complete token and top-logprob results across multiple streaming intervals.
  - Added support for varied metadata formats across SGLang releases.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->