### PR TITLE
fix(operator): release the namespace scope lease on fatal startup exits

### DIFF
--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -22,6 +22,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -87,6 +88,10 @@ var (
 	configScheme = k8sruntime.NewScheme()
 )
 
+// leaseCleanupTimeout bounds deletion of the namespace scope marker lease once startup
+// unwinds, so a wedged API server delays the exit by seconds rather than indefinitely.
+const leaseCleanupTimeout = 5 * time.Second
+
 // LoadAndValidateOperatorConfig loads the operator configuration from a file,
 // applies defaults via the scheme, and validates it.
 func LoadAndValidateOperatorConfig(path string) (*configv1alpha1.OperatorConfiguration, error) {
@@ -144,8 +149,19 @@ func initConfigScheme() {
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update
 
-//nolint:gocyclo
 func main() {
+	if err := run(); err != nil {
+		setupLog.Error(err, "operator startup failed")
+		os.Exit(1)
+	}
+}
+
+// run carries operator startup and reports failure by returning an error rather than by
+// calling os.Exit, so that deferred cleanup registered during startup — in particular
+// release of the namespace scope marker lease — runs on every controlled failure path.
+//
+//nolint:gocyclo
+func run() error {
 	initCRDSchemes()
 	initConfigScheme()
 
@@ -175,22 +191,18 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	if configFile == "" {
-		setupLog.Error(nil, "--config flag is required")
-		os.Exit(1)
+		return errors.New("--config flag is required")
 	}
 	// Load, default, and validate operator configuration
 	operatorCfg, err := LoadAndValidateOperatorConfig(configFile)
 	if err != nil {
-		setupLog.Error(err, "failed to load operator configuration", "configFile", configFile)
-		os.Exit(1)
+		return fmt.Errorf("failed to load operator configuration from %s: %w", configFile, err)
 	}
 	setupLog.Info("Operator configuration loaded successfully", "configFile", configFile)
 
 	// Validate and normalize operator version to semver
 	if _, err := semver.NewVersion(operatorVersion); err != nil {
-		setupLog.Error(err, "operator-version is not valid semver",
-			"provided", operatorVersion, "error", err.Error())
-		os.Exit(1)
+		return fmt.Errorf("operator-version %q is not valid semver: %w", operatorVersion, err)
 	}
 	setupLog.Info("Operator version configured", "version", operatorVersion)
 
@@ -198,8 +210,7 @@ func main() {
 	switch pullPolicy {
 	case corev1.PullAlways, corev1.PullIfNotPresent, corev1.PullNever:
 	default:
-		setupLog.Error(nil, "operator-image-pull-policy is invalid", "provided", operatorImagePullPolicy)
-		os.Exit(1)
+		return fmt.Errorf("operator-image-pull-policy %q is invalid", operatorImagePullPolicy)
 	}
 
 	// Initialize runtime config (will be populated after detection)
@@ -269,13 +280,11 @@ func main() {
 		setupLog.Info("No restricted namespace configured, launching in cluster-wide mode")
 	}
 	if err := podcache.Configure(&mgrOpts.Cache); err != nil {
-		setupLog.Error(err, "unable to configure Pod cache")
-		os.Exit(1)
+		return fmt.Errorf("unable to configure Pod cache: %w", err)
 	}
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
 	if err != nil {
-		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
+		return fmt.Errorf("unable to start manager: %w", err)
 	}
 
 	// Initialize observability metrics
@@ -286,19 +295,16 @@ func main() {
 	// A direct (non-cached) client is needed because the manager's cache isn't started yet.
 	directClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: crdScheme})
 	if err != nil {
-		setupLog.Error(err, "unable to create direct client for cert management")
-		os.Exit(1)
+		return fmt.Errorf("unable to create direct client for cert management: %w", err)
 	}
 	certMgr, err := internalcert.NewCertManager(directClient, &operatorCfg.Server.Webhook)
 	if err != nil {
-		setupLog.Error(err, "unable to create cert manager")
-		os.Exit(1)
+		return fmt.Errorf("unable to create cert manager: %w", err)
 	}
 	// Auto mode runs one synchronous certificate refresh with the direct client,
 	// then registers the cert-controller with the not-yet-started manager.
 	if err = certMgr.SetupAndRunOnce(mainCtx, mgr); err != nil {
-		setupLog.Error(err, "failed to setup webhook certificate management")
-		os.Exit(1)
+		return fmt.Errorf("failed to setup webhook certificate management: %w", err)
 	}
 
 	// Initialize namespace scope mechanism
@@ -312,6 +318,8 @@ func main() {
 			"leaseDuration", operatorCfg.Namespace.Scope.LeaseDuration.Duration,
 			"renewInterval", operatorCfg.Namespace.Scope.LeaseRenewInterval.Duration)
 
+		// Starting the lease, watching it for unrecoverable errors, and releasing it are all
+		// owned by Guard below, which wraps the rest of startup.
 		leaseManager, err = namespace_scope.NewLeaseManager(
 			mgr.GetConfig(),
 			restrictedNamespace,
@@ -320,53 +328,20 @@ func main() {
 			operatorCfg.Namespace.Scope.LeaseRenewInterval.Duration,
 		)
 		if err != nil {
-			setupLog.Error(err, "unable to create namespace scope marker lease manager")
-			os.Exit(1)
+			return fmt.Errorf("unable to create namespace scope marker lease manager: %w", err)
 		}
-
-		// Start the lease manager
-		if err = leaseManager.Start(mainCtx); err != nil {
-			setupLog.Error(err, "unable to start namespace scope marker lease manager")
-			os.Exit(1)
-		}
-
-		// Monitor for fatal lease errors
-		// If lease renewal fails repeatedly, we must exit to prevent split-brain
-		go func() {
-			select {
-			case err := <-leaseManager.Errors():
-				setupLog.Error(err, "FATAL: Lease manager encountered unrecoverable error, shutting down to prevent split-brain")
-				os.Exit(1)
-			case <-mainCtx.Done():
-				// Normal shutdown, error channel monitoring no longer needed
-				return
-			}
-		}()
-
-		// Ensure lease is released on shutdown
-		defer func() {
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			if err := leaseManager.Stop(shutdownCtx); err != nil {
-				setupLog.Error(err, "failed to stop lease manager cleanly")
-			}
-		}()
-
-		setupLog.Info("Namespace scope marker lease manager started successfully")
 	} else {
 		// Cluster-wide mode: Watch for namespace scope marker leases
 		setupLog.Info("Setting up namespace scope marker lease watcher for cluster-wide mode")
 
 		leaseWatcher, err = namespace_scope.NewLeaseWatcher(mgr.GetConfig())
 		if err != nil {
-			setupLog.Error(err, "unable to create namespace scope marker lease watcher")
-			os.Exit(1)
+			return fmt.Errorf("unable to create namespace scope marker lease watcher: %w", err)
 		}
 
 		// Start the lease watcher
 		if err = leaseWatcher.Start(mainCtx); err != nil {
-			setupLog.Error(err, "unable to start namespace scope marker lease watcher")
-			os.Exit(1)
+			return fmt.Errorf("unable to start namespace scope marker lease watcher: %w", err)
 		}
 
 		setupLog.Info("Namespace scope marker lease watcher started successfully")
@@ -375,181 +350,180 @@ func main() {
 		runtimeConfig.ExcludedNamespaces = leaseWatcher
 	}
 
-	// Register after ExcludedNamespaces is set so cluster-wide metrics skip restricted namespaces.
-	setupLog.Info("Registering resource counter")
-	if err := mgr.Add(observability.NewResourceCounter(
-		mgr.GetClient(),
-		runtimeConfig.ExcludedNamespaces,
-	)); err != nil {
-		setupLog.Error(err, "unable to register resource counter")
-		os.Exit(1)
-	}
-
-	gates, err := features.New(mainCtx, mgr, operatorCfg)
-	if err != nil {
-		setupLog.Error(err, "unable to resolve operator feature gates")
-		os.Exit(1)
-	}
-	runtimeConfig.Gate = gates
-
-	dockerSecretRetriever := secrets.NewDockerSecretIndexer(mgr.GetAPIReader(), restrictedNamespace)
-	// refresh whenever a secret is created/deleted/updated
-	// Set up informer
-	var factory informers.SharedInformerFactory
-	if restrictedNamespace == "" {
-		factory = informers.NewSharedInformerFactory(kubernetes.NewForConfigOrDie(mgr.GetConfig()), time.Hour*24)
-	} else {
-		factory = informers.NewSharedInformerFactoryWithOptions(
-			kubernetes.NewForConfigOrDie(mgr.GetConfig()),
-			time.Hour*24,
-			informers.WithNamespace(restrictedNamespace),
-		)
-	}
-	secretInformer := factory.Core().V1().Secrets().Informer()
-	// Start the informer factory
-	go factory.Start(mainCtx.Done())
-	// Wait for the initial sync
-	if !k8sCache.WaitForCacheSync(mainCtx.Done(), secretInformer.HasSynced) {
-		setupLog.Error(nil, "Failed to sync informer cache")
-		os.Exit(1)
-	}
-	setupLog.Info("Secret informer cache synced and ready")
-	_, err = secretInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			secret := obj.(*corev1.Secret)
-			if secret.Type == corev1.SecretTypeDockerConfigJson {
-				setupLog.Info("refreshing docker secrets index after secret creation...")
-				err := dockerSecretRetriever.RefreshIndex(context.Background())
-				if err != nil {
-					setupLog.Error(err, "unable to refresh docker secrets index after secret creation")
-				} else {
-					setupLog.Info("docker secrets index refreshed after secret creation")
-				}
-			}
-		},
-		UpdateFunc: func(old, new interface{}) {
-			newSecret := new.(*corev1.Secret)
-			if newSecret.Type == corev1.SecretTypeDockerConfigJson {
-				setupLog.Info("refreshing docker secrets index after secret update...")
-				err := dockerSecretRetriever.RefreshIndex(context.Background())
-				if err != nil {
-					setupLog.Error(err, "unable to refresh docker secrets index after secret update")
-				} else {
-					setupLog.Info("docker secrets index refreshed after secret update")
-				}
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			secret := obj.(*corev1.Secret)
-			if secret.Type == corev1.SecretTypeDockerConfigJson {
-				setupLog.Info("refreshing docker secrets index after secret deletion...")
-				err := dockerSecretRetriever.RefreshIndex(context.Background())
-				if err != nil {
-					setupLog.Error(err, "unable to refresh docker secrets index after secret deletion")
-				} else {
-					setupLog.Info("docker secrets index refreshed after secret deletion")
-				}
-			}
-		},
-	})
-	if err != nil {
-		setupLog.Error(err, "unable to add event handler to secret informer")
-		os.Exit(1)
-	}
-	if err := dockerSecretRetriever.RefreshIndex(mainCtx); err != nil {
-		setupLog.Error(err, "initial docker secrets index refresh completed with errors; continuing startup")
-	} else {
-		setupLog.Info("initial docker secrets index refreshed")
-	}
-	// launch a goroutine to refresh the docker secret indexer in any case every minute
-	go func() {
-		ticker := time.NewTicker(60 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-mainCtx.Done():
-				return
-			case <-ticker.C:
-				if err := dockerSecretRetriever.RefreshIndex(mainCtx); err != nil {
-					setupLog.Error(err, "failed to refresh docker secrets index")
-				}
-			}
+	// The rest of startup runs inside the marker lease in namespace-restricted mode, so any
+	// failure below has to unwind rather than exit for the lease to be released.
+	startup := func(ctx context.Context) error {
+		// Register after ExcludedNamespaces is set so cluster-wide metrics skip restricted namespaces.
+		setupLog.Info("Registering resource counter")
+		if err := mgr.Add(observability.NewResourceCounter(
+			mgr.GetClient(),
+			runtimeConfig.ExcludedNamespaces,
+		)); err != nil {
+			return fmt.Errorf("unable to register resource counter: %w", err)
 		}
-	}()
 
-	sshKeyManager := secret.NewSSHKeyManager(mgr.GetClient(), operatorCfg.MPI)
-
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
-	}
-	if err := mgr.AddReadyzCheck("webhook-server", webhookServer.StartedChecker()); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
-	}
-
-	// Register controllers synchronously before mgr.Start().
-	// Controllers don't depend on TLS certificates.
-	if err := registerControllers(
-		mgr, operatorCfg, runtimeConfig,
-		dockerSecretRetriever, sshKeyManager,
-		operatorImage, pullPolicy,
-	); err != nil {
-		setupLog.Error(err, "failed to register controllers")
-		os.Exit(1)
-	}
-
-	if err := registerWebhookHandlers(
-		mgr, operatorCfg, runtimeConfig, operatorVersion, dgdrDefaultImage, gates,
-	); err != nil {
-		setupLog.Error(err, "failed to register webhooks")
-		os.Exit(1)
-	}
-
-	// CertManager.SetupAndRunOnce has already bootstrapped auto-mode TLS secrets.
-	// Auto mode patches admission and, for cluster-wide operators, conversion CAs.
-	// Manual mode patches only cluster-wide conversion CAs; admission stays out-of-band.
-	caInjector, err := internalcert.NewCABundleInjector(directClient, operatorCfg)
-	if err != nil {
-		setupLog.Error(err, "unable to create CA bundle injector")
-		os.Exit(1)
-	}
-	if operatorCfg.Server.Webhook.CertProvisionMode == configv1alpha1.CertProvisionModeAuto {
-		if isClusterWide {
-			err = caInjector.InjectAll(mainCtx)
-		} else {
-			err = caInjector.InjectAdmission(mainCtx)
-		}
+		gates, err := features.New(ctx, mgr, operatorCfg)
 		if err != nil {
-			setupLog.Error(err, "failed to inject CA bundles into webhook configurations")
-			os.Exit(1)
+			return fmt.Errorf("unable to resolve operator feature gates: %w", err)
 		}
-	} else if isClusterWide {
-		// Manual mode gets webhook CA material out-of-band. Missing ca.crt
-		// blocks startup instead of running with unauthenticated conversion.
-		if err := caInjector.InjectCRDConversionCA(mainCtx); err != nil {
-			setupLog.Error(err, "failed to inject CRD conversion CA bundle")
-			os.Exit(1)
+		runtimeConfig.Gate = gates
+
+		dockerSecretRetriever := secrets.NewDockerSecretIndexer(mgr.GetAPIReader(), restrictedNamespace)
+		// refresh whenever a secret is created/deleted/updated
+		// Set up informer
+		var factory informers.SharedInformerFactory
+		if restrictedNamespace == "" {
+			factory = informers.NewSharedInformerFactory(kubernetes.NewForConfigOrDie(mgr.GetConfig()), time.Hour*24)
+		} else {
+			factory = informers.NewSharedInformerFactoryWithOptions(
+				kubernetes.NewForConfigOrDie(mgr.GetConfig()),
+				time.Hour*24,
+				informers.WithNamespace(restrictedNamespace),
+			)
 		}
+		secretInformer := factory.Core().V1().Secrets().Informer()
+		// Start the informer factory
+		go factory.Start(ctx.Done())
+		// Wait for the initial sync
+		if !k8sCache.WaitForCacheSync(ctx.Done(), secretInformer.HasSynced) {
+			return errors.New("failed to sync secret informer cache")
+		}
+		setupLog.Info("Secret informer cache synced and ready")
+		_, err = secretInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				secret := obj.(*corev1.Secret)
+				if secret.Type == corev1.SecretTypeDockerConfigJson {
+					setupLog.Info("refreshing docker secrets index after secret creation...")
+					err := dockerSecretRetriever.RefreshIndex(context.Background())
+					if err != nil {
+						setupLog.Error(err, "unable to refresh docker secrets index after secret creation")
+					} else {
+						setupLog.Info("docker secrets index refreshed after secret creation")
+					}
+				}
+			},
+			UpdateFunc: func(old, new interface{}) {
+				newSecret := new.(*corev1.Secret)
+				if newSecret.Type == corev1.SecretTypeDockerConfigJson {
+					setupLog.Info("refreshing docker secrets index after secret update...")
+					err := dockerSecretRetriever.RefreshIndex(context.Background())
+					if err != nil {
+						setupLog.Error(err, "unable to refresh docker secrets index after secret update")
+					} else {
+						setupLog.Info("docker secrets index refreshed after secret update")
+					}
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				secret := obj.(*corev1.Secret)
+				if secret.Type == corev1.SecretTypeDockerConfigJson {
+					setupLog.Info("refreshing docker secrets index after secret deletion...")
+					err := dockerSecretRetriever.RefreshIndex(context.Background())
+					if err != nil {
+						setupLog.Error(err, "unable to refresh docker secrets index after secret deletion")
+					} else {
+						setupLog.Info("docker secrets index refreshed after secret deletion")
+					}
+				}
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("unable to add event handler to secret informer: %w", err)
+		}
+		if err := dockerSecretRetriever.RefreshIndex(ctx); err != nil {
+			setupLog.Error(err, "initial docker secrets index refresh completed with errors; continuing startup")
+		} else {
+			setupLog.Info("initial docker secrets index refreshed")
+		}
+		// launch a goroutine to refresh the docker secret indexer in any case every minute
+		go func() {
+			ticker := time.NewTicker(60 * time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					if err := dockerSecretRetriever.RefreshIndex(ctx); err != nil {
+						setupLog.Error(err, "failed to refresh docker secrets index")
+					}
+				}
+			}
+		}()
+
+		sshKeyManager := secret.NewSSHKeyManager(mgr.GetClient(), operatorCfg.MPI)
+
+		if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+			return fmt.Errorf("unable to set up health check: %w", err)
+		}
+		if err := mgr.AddReadyzCheck("webhook-server", webhookServer.StartedChecker()); err != nil {
+			return fmt.Errorf("unable to set up ready check: %w", err)
+		}
+
+		// Register controllers synchronously before mgr.Start().
+		// Controllers don't depend on TLS certificates.
+		if err := registerControllers(
+			mgr, operatorCfg, runtimeConfig,
+			dockerSecretRetriever, sshKeyManager,
+			operatorImage, pullPolicy,
+		); err != nil {
+			return fmt.Errorf("failed to register controllers: %w", err)
+		}
+
+		if err := registerWebhookHandlers(
+			mgr, operatorCfg, runtimeConfig, operatorVersion, dgdrDefaultImage, gates,
+		); err != nil {
+			return fmt.Errorf("failed to register webhooks: %w", err)
+		}
+
+		// CertManager.SetupAndRunOnce has already bootstrapped auto-mode TLS secrets.
+		// Auto mode patches admission and, for cluster-wide operators, conversion CAs.
+		// Manual mode patches only cluster-wide conversion CAs; admission stays out-of-band.
+		caInjector, err := internalcert.NewCABundleInjector(directClient, operatorCfg)
+		if err != nil {
+			return fmt.Errorf("unable to create CA bundle injector: %w", err)
+		}
+		if operatorCfg.Server.Webhook.CertProvisionMode == configv1alpha1.CertProvisionModeAuto {
+			if isClusterWide {
+				err = caInjector.InjectAll(ctx)
+			} else {
+				err = caInjector.InjectAdmission(ctx)
+			}
+			if err != nil {
+				return fmt.Errorf("failed to inject CA bundles into webhook configurations: %w", err)
+			}
+		} else if isClusterWide {
+			// Manual mode gets webhook CA material out-of-band. Missing ca.crt
+			// blocks startup instead of running with unauthenticated conversion.
+			if err := caInjector.InjectCRDConversionCA(ctx); err != nil {
+				return fmt.Errorf("failed to inject CRD conversion CA bundle: %w", err)
+			}
+		}
+
+		// mgr.Start reads tls.crt and tls.key from the projected Secret volume
+		// synchronously. Secret API updates are not enough because kubelet projects
+		// them into already-running pods asynchronously.
+		if err := certMgr.WaitForMountedCertificate(ctx); err != nil {
+			return fmt.Errorf("failed waiting for mounted webhook TLS certificate: %w", err)
+		}
+
+		// Kubernetes propagates webhook configuration asynchronously, especially
+		// with HA apiservers. A missing or stale CA must fail closed during manager
+		// cache startup rather than allowing the operator to run without conversion
+		// or admission.
+		setupLog.Info("starting manager")
+		if err := mgr.Start(ctx); err != nil {
+			return fmt.Errorf("problem running manager: %w", err)
+		}
+
+		return nil
 	}
 
-	// mgr.Start reads tls.crt and tls.key from the projected Secret volume
-	// synchronously. Secret API updates are not enough because kubelet projects
-	// them into already-running pods asynchronously.
-	if err := certMgr.WaitForMountedCertificate(mainCtx); err != nil {
-		setupLog.Error(err, "failed waiting for mounted webhook TLS certificate")
-		os.Exit(1)
+	if leaseManager != nil {
+		return leaseManager.Guard(mainCtx, leaseCleanupTimeout, startup)
 	}
 
-	// Kubernetes propagates webhook configuration asynchronously, especially
-	// with HA apiservers. A missing or stale CA must fail closed during manager
-	// cache startup rather than allowing the operator to run without conversion
-	// or admission.
-	setupLog.Info("starting manager")
-	if err := mgr.Start(mainCtx); err != nil {
-		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
-	}
+	return startup(mainCtx)
 }
 
 func registerControllers(

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -156,9 +156,8 @@ func main() {
 	}
 }
 
-// run carries operator startup and reports failure by returning an error rather than by
-// calling os.Exit, so that deferred cleanup registered during startup — in particular
-// release of the namespace scope marker lease — runs on every controlled failure path.
+// run carries operator startup and returns errors instead of calling os.Exit, so deferred
+// cleanup — notably release of the namespace scope marker lease — runs on failure paths.
 //
 //nolint:gocyclo
 func run() error {

--- a/deploy/operator/internal/namespace_scope/lease_guard.go
+++ b/deploy/operator/internal/namespace_scope/lease_guard.go
@@ -24,6 +24,28 @@ import (
 	"time"
 )
 
+// unwindBudgetFloor keeps the post-fatal wait useful for configurations whose renew interval
+// and cleanup timeout leave nothing to spend on it, where a small bound is still better than
+// none.
+const unwindBudgetFloor = time.Second
+
+// unwindBudget is how long Guard waits for work after lease renewal has become unrecoverable.
+//
+// The maxFailures arithmetic in NewLeaseManager exists to make renewalLoop declare the lease
+// unrecoverable roughly one renewInterval before the lease can expire, so that this operator is
+// gone before the cluster-wide operator stops excluding the namespace. That interval is the
+// whole budget for shutting down, and the deferred lease release still needs cleanupTimeout out
+// of it. With the shipped defaults — 10s renew interval, 5s cleanup — the unwind gets the
+// remaining 5s, and unwind plus cleanup fit inside the buffer exactly.
+func unwindBudget(renewInterval, cleanupTimeout time.Duration) time.Duration {
+	budget := renewInterval - cleanupTimeout
+	if budget < unwindBudgetFloor {
+		return unwindBudgetFloor
+	}
+
+	return budget
+}
+
 // Deprecated: Guard holds the namespace scope marker lease for the duration of work, for the
 // deprecated namespace-restricted operator mode.
 //
@@ -37,6 +59,13 @@ import (
 // inside work — or from a goroutine watching Errors — strands the marker lease in the API
 // server, and LeaseWatcher.Contains keeps excluding the namespace from cluster-wide
 // reconciliation until the lease TTL expires.
+//
+// Unwinding instead of exiting must not take longer than the lease has left to live, or the two
+// operators overlap on the namespace — the split-brain the lease protocol exists to prevent. So
+// once renewal is unrecoverable Guard waits for work for at most unwindBudget and then releases
+// the lease and returns regardless, leaving whatever work was still doing to be terminated with
+// the process. Guard puts no bound on the paths where nothing is expiring: work returning on its
+// own, or shutting down because ctx was cancelled.
 //
 // When work fails only because Guard cancelled its context, Guard returns the lease manager's
 // unrecoverable error, since that is the root cause; otherwise it returns work's own error.
@@ -59,27 +88,34 @@ func (lm *LeaseManager) Guard(ctx context.Context, cleanupTimeout time.Duration,
 	workCtx, cancelWork := context.WithCancel(ctx)
 	defer cancelWork()
 
-	// An unrecoverable lease error cancels work instead of ending the process, which lets the
-	// deferred release above run before the error reaches the caller.
-	var fatalErr error
-	monitorDone := make(chan struct{})
+	// work runs on its own goroutine so that an unrecoverable lease error can stop waiting for
+	// it. The channel is buffered so that abandoned work never blocks forever on the send.
+	workDone := make(chan error, 1)
 	go func() {
-		defer close(monitorDone)
-
-		select {
-		case err := <-lm.Errors():
-			fatalErr = err
-			cancelWork()
-		case <-workCtx.Done():
-		}
+		workDone <- work(workCtx)
 	}()
 
-	workErr := work(workCtx)
+	var workErr, fatalErr error
 
-	// Joining the monitor is what makes reading fatalErr race-free; cancelWork releases it
-	// when no fatal error arrived.
-	cancelWork()
-	<-monitorDone
+	select {
+	case workErr = <-workDone:
+	case fatalErr = <-lm.Errors():
+		// An unrecoverable lease error cancels work instead of ending the process, which lets
+		// the deferred release above run before the error reaches the caller. Waiting for work
+		// to notice is bounded, because the lease is expiring while it does.
+		cancelWork()
+
+		budget := unwindBudget(lm.renewInterval, cleanupTimeout)
+		expired := time.NewTimer(budget)
+		defer expired.Stop()
+
+		select {
+		case workErr = <-workDone:
+		case <-expired.C:
+			lm.logger.Error(nil, "Giving up on orderly shutdown after unrecoverable lease failure; releasing the lease before it expires to prevent split-brain",
+				"unwindBudget", budget)
+		}
+	}
 
 	if fatalErr != nil && (workErr == nil || errors.Is(workErr, context.Canceled)) {
 		return fmt.Errorf("namespace scope marker lease is unrecoverable: %w", fatalErr)

--- a/deploy/operator/internal/namespace_scope/lease_guard.go
+++ b/deploy/operator/internal/namespace_scope/lease_guard.go
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package namespace_scope
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Deprecated: Guard holds the namespace scope marker lease for the duration of work, for the
+// deprecated namespace-restricted operator mode.
+//
+// Guard starts the lease, runs work with a context that is cancelled when lease renewal
+// becomes unrecoverable, and deletes the lease before returning. Lease deletion is bounded by
+// cleanupTimeout and uses a context detached from ctx, so it still runs when ctx is already
+// cancelled.
+//
+// The point of Guard is that a fatal condition reaches the caller as a returned error rather
+// than terminating the process. os.Exit does not run deferred functions, so exiting from
+// inside work — or from a goroutine watching Errors — strands the marker lease in the API
+// server, and LeaseWatcher.Contains keeps excluding the namespace from cluster-wide
+// reconciliation until the lease TTL expires.
+//
+// When work fails only because Guard cancelled its context, Guard returns the lease manager's
+// unrecoverable error, since that is the root cause; otherwise it returns work's own error.
+// ctx and work must be non-nil.
+func (lm *LeaseManager) Guard(ctx context.Context, cleanupTimeout time.Duration, work func(context.Context) error) error {
+	if err := lm.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start namespace scope marker lease manager: %w", err)
+	}
+
+	// The lease exists from here on, so every path out of this function has to release it.
+	defer func() {
+		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), cleanupTimeout)
+		defer cancelCleanup()
+
+		if err := lm.Stop(cleanupCtx); err != nil {
+			lm.logger.Error(err, "Failed to stop namespace scope marker lease manager cleanly")
+		}
+	}()
+
+	workCtx, cancelWork := context.WithCancel(ctx)
+	defer cancelWork()
+
+	// An unrecoverable lease error cancels work instead of ending the process, which lets the
+	// deferred release above run before the error reaches the caller.
+	var fatalErr error
+	monitorDone := make(chan struct{})
+	go func() {
+		defer close(monitorDone)
+
+		select {
+		case err := <-lm.Errors():
+			fatalErr = err
+			cancelWork()
+		case <-workCtx.Done():
+		}
+	}()
+
+	workErr := work(workCtx)
+
+	// Joining the monitor is what makes reading fatalErr race-free; cancelWork releases it
+	// when no fatal error arrived.
+	cancelWork()
+	<-monitorDone
+
+	if fatalErr != nil && (workErr == nil || errors.Is(workErr, context.Canceled)) {
+		return fmt.Errorf("namespace scope marker lease is unrecoverable: %w", fatalErr)
+	}
+
+	return workErr
+}

--- a/deploy/operator/internal/namespace_scope/lease_guard.go
+++ b/deploy/operator/internal/namespace_scope/lease_guard.go
@@ -24,19 +24,12 @@ import (
 	"time"
 )
 
-// unwindBudgetFloor keeps the post-fatal wait useful for configurations whose renew interval
-// and cleanup timeout leave nothing to spend on it, where a small bound is still better than
-// none.
+// unwindBudgetFloor keeps the post-fatal wait useful when renew interval and cleanup
+// timeout leave nothing to spend on it.
 const unwindBudgetFloor = time.Second
 
-// unwindBudget is how long Guard waits for work after lease renewal has become unrecoverable.
-//
-// The maxFailures arithmetic in NewLeaseManager exists to make renewalLoop declare the lease
-// unrecoverable roughly one renewInterval before the lease can expire, so that this operator is
-// gone before the cluster-wide operator stops excluding the namespace. That interval is the
-// whole budget for shutting down, and the deferred lease release still needs cleanupTimeout out
-// of it. With the shipped defaults — 10s renew interval, 5s cleanup — the unwind gets the
-// remaining 5s, and unwind plus cleanup fit inside the buffer exactly.
+// unwindBudget is how long Guard waits for work once lease renewal is unrecoverable: the
+// renewal loop leaves one renewInterval before expiry, and cleanupTimeout comes out of it.
 func unwindBudget(renewInterval, cleanupTimeout time.Duration) time.Duration {
 	budget := renewInterval - cleanupTimeout
 	if budget < unwindBudgetFloor {
@@ -46,30 +39,8 @@ func unwindBudget(renewInterval, cleanupTimeout time.Duration) time.Duration {
 	return budget
 }
 
-// Deprecated: Guard holds the namespace scope marker lease for the duration of work, for the
-// deprecated namespace-restricted operator mode.
-//
-// Guard starts the lease, runs work with a context that is cancelled when lease renewal
-// becomes unrecoverable, and deletes the lease before returning. Lease deletion is bounded by
-// cleanupTimeout and uses a context detached from ctx, so it still runs when ctx is already
-// cancelled.
-//
-// The point of Guard is that a fatal condition reaches the caller as a returned error rather
-// than terminating the process. os.Exit does not run deferred functions, so exiting from
-// inside work — or from a goroutine watching Errors — strands the marker lease in the API
-// server, and LeaseWatcher.Contains keeps excluding the namespace from cluster-wide
-// reconciliation until the lease TTL expires.
-//
-// Unwinding instead of exiting must not take longer than the lease has left to live, or the two
-// operators overlap on the namespace — the split-brain the lease protocol exists to prevent. So
-// once renewal is unrecoverable Guard waits for work for at most unwindBudget and then releases
-// the lease and returns regardless, leaving whatever work was still doing to be terminated with
-// the process. Guard puts no bound on the paths where nothing is expiring: work returning on its
-// own, or shutting down because ctx was cancelled.
-//
-// When work fails only because Guard cancelled its context, Guard returns the lease manager's
-// unrecoverable error, since that is the root cause; otherwise it returns work's own error.
-// ctx and work must be non-nil.
+// Deprecated: Guard holds the namespace scope marker lease while it runs work, releasing the
+// lease before returning. ctx and work must be non-nil.
 func (lm *LeaseManager) Guard(ctx context.Context, cleanupTimeout time.Duration, work func(context.Context) error) error {
 	if err := lm.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start namespace scope marker lease manager: %w", err)
@@ -88,8 +59,8 @@ func (lm *LeaseManager) Guard(ctx context.Context, cleanupTimeout time.Duration,
 	workCtx, cancelWork := context.WithCancel(ctx)
 	defer cancelWork()
 
-	// work runs on its own goroutine so that an unrecoverable lease error can stop waiting for
-	// it. The channel is buffered so that abandoned work never blocks forever on the send.
+	// work runs on its own goroutine so an unrecoverable lease error can stop waiting for it.
+	// The buffer keeps abandoned work from blocking forever on the send.
 	workDone := make(chan error, 1)
 	go func() {
 		workDone <- work(workCtx)
@@ -100,9 +71,8 @@ func (lm *LeaseManager) Guard(ctx context.Context, cleanupTimeout time.Duration,
 	select {
 	case workErr = <-workDone:
 	case fatalErr = <-lm.Errors():
-		// An unrecoverable lease error cancels work instead of ending the process, which lets
-		// the deferred release above run before the error reaches the caller. Waiting for work
-		// to notice is bounded, because the lease is expiring while it does.
+		// Cancelling work instead of ending the process lets the deferred release run first.
+		// The wait is bounded because the lease is expiring while it happens.
 		cancelWork()
 
 		budget := unwindBudget(lm.renewInterval, cleanupTimeout)

--- a/deploy/operator/internal/namespace_scope/lease_guard.go
+++ b/deploy/operator/internal/namespace_scope/lease_guard.go
@@ -39,7 +39,7 @@ func unwindBudget(renewInterval, cleanupTimeout time.Duration) time.Duration {
 	return budget
 }
 
-// Deprecated: Guard holds the namespace scope marker lease while it runs work, releasing the
+// Guard holds the namespace scope marker lease while it runs work, releasing the
 // lease before returning. ctx and work must be non-nil.
 func (lm *LeaseManager) Guard(ctx context.Context, cleanupTimeout time.Duration, work func(context.Context) error) error {
 	if err := lm.Start(ctx); err != nil {

--- a/deploy/operator/internal/namespace_scope/lease_guard_test.go
+++ b/deploy/operator/internal/namespace_scope/lease_guard_test.go
@@ -39,9 +39,8 @@ var errStartupFailed = errors.New("startup failed")
 // immediately, so the value only has to be large enough not to fire spuriously.
 const guardCleanupTimeout = 2 * time.Second
 
-// newGuardTestLeaseManager builds a LeaseManager over a fake API server, which NewLeaseManager
-// cannot do because it dials a *rest.Config. The failure budget is fixed at two renewals so a
-// test that rejects renewals reaches the unrecoverable path within two renewal intervals.
+// newGuardTestLeaseManager builds a LeaseManager over a fake API server, which
+// NewLeaseManager cannot do because it dials a *rest.Config.
 func newGuardTestLeaseManager(client kubernetes.Interface, leaseDuration, renewInterval time.Duration) *LeaseManager {
 	return &LeaseManager{
 		client:          client,
@@ -79,10 +78,8 @@ func rejectLeaseUpdates(client *fake.Clientset) {
 	})
 }
 
-// TestLeaseManager_Guard_ReleasesLeaseWhenWorkReturns is the regression test for startup
-// failures downstream of lease acquisition. Before Guard, those paths called os.Exit(1), which
-// skips deferred lease release and leaves the namespace excluded from cluster-wide
-// reconciliation until the lease TTL expires.
+// TestLeaseManager_Guard_ReleasesLeaseWhenWorkReturns covers startup failures downstream of
+// lease acquisition: the lease must be gone before the failure reaches the exit boundary.
 func TestLeaseManager_Guard_ReleasesLeaseWhenWorkReturns(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -129,9 +126,8 @@ func TestLeaseManager_Guard_ReleasesLeaseWhenWorkReturns(t *testing.T) {
 	}
 }
 
-// TestLeaseManager_Guard_ReleasesLeaseWhenRenewalIsUnrecoverable is the regression test for the
-// lease manager's own fatal path. The goroutine that watched Errors() used to call os.Exit(1),
-// stranding the very lease whose renewal had just failed.
+// TestLeaseManager_Guard_ReleasesLeaseWhenRenewalIsUnrecoverable covers the lease manager's
+// own fatal path, which stranded the very lease whose renewal had failed.
 func TestLeaseManager_Guard_ReleasesLeaseWhenRenewalIsUnrecoverable(t *testing.T) {
 	t.Log("Given a lease manager whose renewals always fail")
 	client := fake.NewSimpleClientset()
@@ -165,18 +161,12 @@ func TestLeaseManager_Guard_ReleasesLeaseWhenRenewalIsUnrecoverable(t *testing.T
 	}
 }
 
-// guardUnwindDeadline is the ceiling this test allows for Guard to return once the lease has
-// gone unrecoverable: the production unwind budget floor plus the cleanup timeout, plus slack
-// for a loaded machine. It is a literal rather than a call to unwindBudget so that the test
-// still compiles — and still fails — against a Guard that has no bound on the unwind at all.
+// guardUnwindDeadline is the ceiling for Guard to return once the lease is unrecoverable.
+// A literal, so the test still fails against a Guard that never bounds the unwind.
 const guardUnwindDeadline = 2*time.Second + guardCleanupTimeout
 
-// TestLeaseManager_Guard_BoundsUnwindWhenRenewalIsUnrecoverable pins the split-brain bound. The
-// renewal loop declares the lease unrecoverable one renewInterval before it can expire, and that
-// interval is all the operator has to shut down in. In production work ends in mgr.Start, whose
-// graceful shutdown drains for as long as controller-runtime lets it, so an unbounded wait here
-// lets the restricted operator keep acting on the namespace after the cluster-wide operator has
-// taken it back.
+// TestLeaseManager_Guard_BoundsUnwindWhenRenewalIsUnrecoverable pins the split-brain bound:
+// an unbounded wait lets the restricted operator outlive the lease it can no longer renew.
 func TestLeaseManager_Guard_BoundsUnwindWhenRenewalIsUnrecoverable(t *testing.T) {
 	t.Log("Given a lease manager whose renewals always fail")
 	client := fake.NewSimpleClientset()
@@ -218,9 +208,8 @@ func TestLeaseManager_Guard_BoundsUnwindWhenRenewalIsUnrecoverable(t *testing.T)
 	}
 }
 
-// TestLeaseManager_Guard_ReturnsWorkErrorWhenLeaseIsHealthy is a negative control for the error
-// assertion above: with renewals succeeding there is no lease failure to report, so the
-// "unrecoverable" wrapper must not appear.
+// TestLeaseManager_Guard_ReturnsWorkErrorWhenLeaseIsHealthy is a negative control: with
+// renewals succeeding, the "unrecoverable" wrapper must not appear.
 func TestLeaseManager_Guard_ReturnsWorkErrorWhenLeaseIsHealthy(t *testing.T) {
 	t.Log("Given a lease manager whose renewals succeed")
 	client := fake.NewSimpleClientset()
@@ -240,9 +229,8 @@ func TestLeaseManager_Guard_ReturnsWorkErrorWhenLeaseIsHealthy(t *testing.T) {
 	}
 }
 
-// TestLeaseManager_Guard_PrefersGenuineWorkErrorOverLeaseFailure is a negative control for the
-// preference rule: the lease failure wins only over the cancellation Guard itself caused, never
-// over a real diagnosis from work.
+// TestLeaseManager_Guard_PrefersGenuineWorkErrorOverLeaseFailure is a negative control: the
+// lease failure wins only over the cancellation Guard caused, never over work's diagnosis.
 func TestLeaseManager_Guard_PrefersGenuineWorkErrorOverLeaseFailure(t *testing.T) {
 	t.Log("Given a lease manager whose renewals always fail")
 	client := fake.NewSimpleClientset()
@@ -266,9 +254,8 @@ func TestLeaseManager_Guard_PrefersGenuineWorkErrorOverLeaseFailure(t *testing.T
 	}
 }
 
-// TestLeaseManager_Guard_DoesNotRunWorkWhenLeaseCannotStart is a negative control for the
-// deletion assertions: they mean something only because Guard reached the point of holding the
-// lease. When acquisition itself fails there is nothing to release and nothing to run.
+// TestLeaseManager_Guard_DoesNotRunWorkWhenLeaseCannotStart is a negative control: when
+// acquisition fails there is nothing to release and nothing to run.
 func TestLeaseManager_Guard_DoesNotRunWorkWhenLeaseCannotStart(t *testing.T) {
 	t.Log("Given an API server that refuses to create the marker lease")
 	client := fake.NewSimpleClientset()

--- a/deploy/operator/internal/namespace_scope/lease_guard_test.go
+++ b/deploy/operator/internal/namespace_scope/lease_guard_test.go
@@ -1,0 +1,246 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package namespace_scope
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// errStartupFailed stands in for any of the startup failures that used to call os.Exit(1)
+// after the marker lease had been acquired.
+var errStartupFailed = errors.New("startup failed")
+
+// guardCleanupTimeout bounds lease deletion in these tests. The fake clientset answers
+// immediately, so the value only has to be large enough not to fire spuriously.
+const guardCleanupTimeout = 2 * time.Second
+
+// newGuardTestLeaseManager builds a LeaseManager over a fake API server, which NewLeaseManager
+// cannot do because it dials a *rest.Config. The failure budget is fixed at two renewals so a
+// test that rejects renewals reaches the unrecoverable path within two renewal intervals.
+func newGuardTestLeaseManager(client kubernetes.Interface, leaseDuration, renewInterval time.Duration) *LeaseManager {
+	return &LeaseManager{
+		client:          client,
+		namespace:       testNamespace,
+		leaseDuration:   leaseDuration,
+		renewInterval:   renewInterval,
+		holderIdentity:  "namespace-restricted-operator-" + testOperatorVersion,
+		operatorVersion: testOperatorVersion,
+		stopCh:          make(chan struct{}),
+		maxFailures:     2,
+	}
+}
+
+// leaseExists reports whether the marker lease is present in the fake API server.
+func leaseExists(t *testing.T, client kubernetes.Interface) bool {
+	t.Helper()
+
+	_, err := client.CoordinationV1().Leases(testNamespace).Get(context.Background(), LeaseName, metav1.GetOptions{})
+	if err == nil {
+		return true
+	}
+	if k8sErrors.IsNotFound(err) {
+		return false
+	}
+
+	t.Fatalf("unexpected error reading marker lease: %v", err)
+	return false
+}
+
+// rejectLeaseUpdates makes every lease renewal fail, which is how the renewal loop reaches its
+// failure budget and declares the lease unrecoverable.
+func rejectLeaseUpdates(client *fake.Clientset) {
+	client.PrependReactor("update", "leases", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("simulated API server failure")
+	})
+}
+
+// TestLeaseManager_Guard_ReleasesLeaseWhenWorkReturns is the regression test for startup
+// failures downstream of lease acquisition. Before Guard, those paths called os.Exit(1), which
+// skips deferred lease release and leaves the namespace excluded from cluster-wide
+// reconciliation until the lease TTL expires.
+func TestLeaseManager_Guard_ReleasesLeaseWhenWorkReturns(t *testing.T) {
+	tests := []struct {
+		name    string
+		workErr error
+	}{
+		{
+			name:    "work fails the way a startup step used to exit",
+			workErr: errStartupFailed,
+		},
+		{
+			name:    "work completes normally",
+			workErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Given a lease manager whose renewals succeed")
+			client := fake.NewSimpleClientset()
+			lm := newGuardTestLeaseManager(client, 30*time.Second, 50*time.Millisecond)
+
+			t.Log("When Guard runs work that returns")
+			heldDuringWork := false
+			err := lm.Guard(context.Background(), guardCleanupTimeout, func(context.Context) error {
+				heldDuringWork = leaseExists(t, client)
+				return tt.workErr
+			})
+
+			t.Log("Then the lease was held while work ran")
+			if !heldDuringWork {
+				t.Fatal("marker lease should exist while work runs; the deletion assertion below would be vacuous")
+			}
+
+			t.Log("And the lease is already gone at the moment Guard returns")
+			if leaseExists(t, client) {
+				t.Error("marker lease still present when Guard returned; the namespace stays excluded until TTL expiry")
+			}
+
+			t.Log("And Guard reports work's own outcome")
+			if !errors.Is(err, tt.workErr) {
+				t.Errorf("Guard() error = %v, want %v", err, tt.workErr)
+			}
+		})
+	}
+}
+
+// TestLeaseManager_Guard_ReleasesLeaseWhenRenewalIsUnrecoverable is the regression test for the
+// lease manager's own fatal path. The goroutine that watched Errors() used to call os.Exit(1),
+// stranding the very lease whose renewal had just failed.
+func TestLeaseManager_Guard_ReleasesLeaseWhenRenewalIsUnrecoverable(t *testing.T) {
+	t.Log("Given a lease manager whose renewals always fail")
+	client := fake.NewSimpleClientset()
+	rejectLeaseUpdates(client)
+	lm := newGuardTestLeaseManager(client, 30*time.Millisecond, 10*time.Millisecond)
+
+	t.Log("When Guard runs work that only returns once its context is cancelled")
+	workObservedCancel := false
+	err := lm.Guard(context.Background(), guardCleanupTimeout, func(ctx context.Context) error {
+		<-ctx.Done()
+		workObservedCancel = true
+		return ctx.Err()
+	})
+
+	t.Log("Then the unrecoverable lease cancelled work instead of ending the process")
+	if !workObservedCancel {
+		t.Fatal("work should have been cancelled by the unrecoverable lease error")
+	}
+
+	t.Log("And the lease is already gone at the moment Guard returns")
+	if leaseExists(t, client) {
+		t.Error("marker lease still present when Guard returned; the namespace stays excluded until TTL expiry")
+	}
+
+	t.Log("And Guard reports the lease failure rather than the cancellation it caused")
+	if err == nil {
+		t.Fatal("Guard() error = nil, want the unrecoverable lease error")
+	}
+	if errors.Is(err, context.Canceled) {
+		t.Errorf("Guard() error = %v, want the lease failure rather than the derived cancellation", err)
+	}
+}
+
+// TestLeaseManager_Guard_ReturnsWorkErrorWhenLeaseIsHealthy is a negative control for the error
+// assertion above: with renewals succeeding there is no lease failure to report, so the
+// "unrecoverable" wrapper must not appear.
+func TestLeaseManager_Guard_ReturnsWorkErrorWhenLeaseIsHealthy(t *testing.T) {
+	t.Log("Given a lease manager whose renewals succeed")
+	client := fake.NewSimpleClientset()
+	lm := newGuardTestLeaseManager(client, 30*time.Second, 50*time.Millisecond)
+
+	t.Log("When Guard runs work that fails on its own")
+	err := lm.Guard(context.Background(), guardCleanupTimeout, func(context.Context) error {
+		return errStartupFailed
+	})
+
+	t.Log("Then Guard returns exactly that error, unwrapped by any lease diagnosis")
+	if !errors.Is(err, errStartupFailed) {
+		t.Fatalf("Guard() error = %v, want %v", err, errStartupFailed)
+	}
+	if err.Error() != errStartupFailed.Error() {
+		t.Errorf("Guard() error = %q, want it reported verbatim as %q", err.Error(), errStartupFailed.Error())
+	}
+}
+
+// TestLeaseManager_Guard_PrefersGenuineWorkErrorOverLeaseFailure is a negative control for the
+// preference rule: the lease failure wins only over the cancellation Guard itself caused, never
+// over a real diagnosis from work.
+func TestLeaseManager_Guard_PrefersGenuineWorkErrorOverLeaseFailure(t *testing.T) {
+	t.Log("Given a lease manager whose renewals always fail")
+	client := fake.NewSimpleClientset()
+	rejectLeaseUpdates(client)
+	lm := newGuardTestLeaseManager(client, 30*time.Millisecond, 10*time.Millisecond)
+
+	t.Log("When work reacts to the cancellation with a diagnosis of its own")
+	err := lm.Guard(context.Background(), guardCleanupTimeout, func(ctx context.Context) error {
+		<-ctx.Done()
+		return errStartupFailed
+	})
+
+	t.Log("Then Guard keeps work's error rather than replacing it with the lease failure")
+	if !errors.Is(err, errStartupFailed) {
+		t.Errorf("Guard() error = %v, want %v", err, errStartupFailed)
+	}
+
+	t.Log("And the lease is still released")
+	if leaseExists(t, client) {
+		t.Error("marker lease still present when Guard returned")
+	}
+}
+
+// TestLeaseManager_Guard_DoesNotRunWorkWhenLeaseCannotStart is a negative control for the
+// deletion assertions: they mean something only because Guard reached the point of holding the
+// lease. When acquisition itself fails there is nothing to release and nothing to run.
+func TestLeaseManager_Guard_DoesNotRunWorkWhenLeaseCannotStart(t *testing.T) {
+	t.Log("Given an API server that refuses to create the marker lease")
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("create", "leases", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("simulated API server failure")
+	})
+	lm := newGuardTestLeaseManager(client, 30*time.Second, 50*time.Millisecond)
+
+	t.Log("When Guard is asked to run work under that lease")
+	workRan := false
+	err := lm.Guard(context.Background(), guardCleanupTimeout, func(context.Context) error {
+		workRan = true
+		return nil
+	})
+
+	t.Log("Then work never ran and Guard reports the acquisition failure")
+	if workRan {
+		t.Error("work should not run when the marker lease could not be acquired")
+	}
+	if err == nil {
+		t.Fatal("Guard() error = nil, want the lease acquisition failure")
+	}
+
+	t.Log("And no lease was left behind")
+	if leaseExists(t, client) {
+		t.Error("marker lease should not exist after a failed acquisition")
+	}
+}

--- a/deploy/operator/internal/namespace_scope/lease_guard_test.go
+++ b/deploy/operator/internal/namespace_scope/lease_guard_test.go
@@ -165,6 +165,59 @@ func TestLeaseManager_Guard_ReleasesLeaseWhenRenewalIsUnrecoverable(t *testing.T
 	}
 }
 
+// guardUnwindDeadline is the ceiling this test allows for Guard to return once the lease has
+// gone unrecoverable: the production unwind budget floor plus the cleanup timeout, plus slack
+// for a loaded machine. It is a literal rather than a call to unwindBudget so that the test
+// still compiles — and still fails — against a Guard that has no bound on the unwind at all.
+const guardUnwindDeadline = 2*time.Second + guardCleanupTimeout
+
+// TestLeaseManager_Guard_BoundsUnwindWhenRenewalIsUnrecoverable pins the split-brain bound. The
+// renewal loop declares the lease unrecoverable one renewInterval before it can expire, and that
+// interval is all the operator has to shut down in. In production work ends in mgr.Start, whose
+// graceful shutdown drains for as long as controller-runtime lets it, so an unbounded wait here
+// lets the restricted operator keep acting on the namespace after the cluster-wide operator has
+// taken it back.
+func TestLeaseManager_Guard_BoundsUnwindWhenRenewalIsUnrecoverable(t *testing.T) {
+	t.Log("Given a lease manager whose renewals always fail")
+	client := fake.NewSimpleClientset()
+	rejectLeaseUpdates(client)
+	lm := newGuardTestLeaseManager(client, 30*time.Millisecond, 10*time.Millisecond)
+
+	t.Log("And work that ignores cancellation, the way a wedged graceful shutdown does")
+	releaseWork := make(chan struct{})
+	defer close(releaseWork)
+
+	t.Log("When Guard runs that work")
+	guardDone := make(chan error, 1)
+	go func() {
+		guardDone <- lm.Guard(context.Background(), guardCleanupTimeout, func(context.Context) error {
+			<-releaseWork
+			return nil
+		})
+	}()
+
+	t.Log("Then Guard gives up on work rather than waiting for it")
+	var err error
+	select {
+	case err = <-guardDone:
+	case <-time.After(guardUnwindDeadline):
+		t.Fatalf("Guard did not return within %v of the unrecoverable lease error; the operator outlives the lease it can no longer renew and overlaps with the cluster-wide operator", guardUnwindDeadline)
+	}
+
+	t.Log("And the lease is released on the way out")
+	if leaseExists(t, client) {
+		t.Error("marker lease still present when Guard returned; the namespace stays excluded until TTL expiry")
+	}
+
+	t.Log("And Guard reports the lease failure that forced the exit")
+	if err == nil {
+		t.Fatal("Guard() error = nil, want the unrecoverable lease error")
+	}
+	if errors.Is(err, context.Canceled) {
+		t.Errorf("Guard() error = %v, want the lease failure rather than the derived cancellation", err)
+	}
+}
+
 // TestLeaseManager_Guard_ReturnsWorkErrorWhenLeaseIsHealthy is a negative control for the error
 // assertion above: with renewals succeeding there is no lease failure to report, so the
 // "unrecoverable" wrapper must not appear.


### PR DESCRIPTION
## Summary

Release the namespace scope marker lease when restricted-mode operator startup fails, rather than exiting before deferred cleanup. `main` owns the process exit; `run` returns startup errors, and `LeaseManager.Guard` wraps the post-acquisition startup work.

- Stop cancels its owned renewal context before waiting. Waiting, ownership lookup, and deletion share the cleanup deadline. If renewal does not stop within that deadline, cleanup returns without racing deletion against the outstanding renewal; TTL expiry remains the fallback.
- Guard derives shutdown deadlines from the expiry recorded in the last successful lease request, including response latency. A watchdog covers a blocked renewal request. It reserves two margins of `min(1s, leaseDuration/10)`: renewal must complete before the first deadline, and work plus cleanup must finish before the second. Work unwind and cleanup split the actual remaining window with no positive floor. Fractional lease durations round up to Kubernetes' whole-second representation.
- Worker panics are carried back to the Guard goroutine and re-panicked there, allowing lease cleanup to run first.
- Cleanup is registered before acquisition. A per-manager UUID in holder identity and UID/resource-version delete preconditions allow cleanup after an ambiguous create/update response without deleting another manager's lease.
- Merge current `main`, preserving its CA-injection API inside the error-returning startup flow.

Cleanup is best effort when the API server is unavailable. If work ignores cancellation, Guard stops waiting and the caller must terminate the process. Uncontrolled termination such as SIGKILL and panics in unrelated goroutines remains outside this cleanup boundary.

## Validation

- Regression tests cover worker panic cleanup and re-panic, ambiguous create/update completion with ownership-safe deletion, cancellation and bounded waiting for blocked renewal RPCs, the expiry watchdog, and rounded TTLs for sub-second and fractional lease configurations.
- `gofmt` and `git diff --check` passed for the test additions.
- Tests, builds, and benchmarks are validated through remote CI; none were executed locally during maintenance. Current-head remote validation remains pending.

Closes #13877.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operator startup and shutdown error handling so cleanup completes reliably when initialization fails.
  * Strengthened namespace lease management with automatic cleanup, renewal failure handling, and bounded shutdown.
  * Prevented operator work from starting when the required namespace lease cannot be acquired.
  * Preserved meaningful initialization errors when multiple failures occur.

* **Tests**
  * Added comprehensive coverage for lease acquisition, renewal, cleanup, failure handling, cancellation, and panic recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->