### PR TITLE
fix(operator): validate an existing DGD before a DGDR adopts it

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1209,6 +1209,8 @@ func jsonSubsetDivergence(want, have any, path string) string {
 
 // failDeploymentNameCollision drives the request terminal. The status-only write preserves
 // the generated-spec annotation, so what this request meant to create stays inspectable.
+// The event follows the status write, so a failed write cannot leave a warning recorded
+// against a request that still reports Deploying and re-emit it on the next reconcile.
 func (r *DynamoGraphDeploymentRequestReconciler) failDeploymentNameCollision(
 	ctx context.Context,
 	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
@@ -1219,11 +1221,16 @@ func (r *DynamoGraphDeploymentRequestReconciler) failDeploymentNameCollision(
 
 	log.FromContext(ctx).Info("Refusing to adopt an existing DGD that failed the DGDR identity contract",
 		"dgd", liveDGD.Name, "namespace", dgdr.Namespace, "reason", mismatchReason)
-	r.Recorder.Eventf(dgdr, liveDGD, corev1.EventTypeWarning, ReasonDeploymentNameCollision, "Get", "%s", message)
 
-	return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed,
+	result, err := r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed,
 		nvidiacomv1beta1.ConditionTypeDeploymentReady, metav1.ConditionFalse,
 		ReasonDeploymentNameCollision, message)
+	if err != nil {
+		return result, err
+	}
+	r.Recorder.Eventf(dgdr, liveDGD, corev1.EventTypeWarning, ReasonDeploymentNameCollision, "Get", "%s", message)
+
+	return result, nil
 }
 
 // clearGeneratedSpecAnnotation marks the DGD as observed in the informer cache.

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -842,13 +842,8 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployingPhase(ctx contex
 		return ctrl.Result{}, err
 	}
 
-	// Validate the identity of a same-name DGD before this request adopts it.
-	//
-	// The generated-spec annotation is both the gate and the evidence: while it is
-	// non-empty this request has not yet confirmed a DGD of its own, and it still
-	// records what it meant to create. Once clearGeneratedSpecAnnotation empties it
-	// the DGD is confirmed ours and later spec drift is the DGD controller's business,
-	// not a collision.
+	// A non-empty generated-spec annotation means this request has not yet confirmed
+	// a DGD of its own, so the same-name DGD must pass the identity check first.
 	if dgdr.Annotations[AnnotationGeneratedDGDSpec] != "" {
 		generatedDGD, err := r.generatedDGDFromAnnotation(dgdr)
 		if err != nil {
@@ -1091,20 +1086,12 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 	return ctrl.Result{}, nil
 }
 
-// dgdCollisionRequeueDelay paces the retry used when the API server rejects a DGD
-// create as already existing but the cached read cannot see that object yet. The
-// foreign object carries no DGDR labels, so the DGD watch will never deliver it and
-// an explicit requeue is the only way back into the identity check.
+// dgdCollisionRequeueDelay retries the identity check after an AlreadyExists create
+// the cache cannot yet see. A foreign DGD carries no labels, so no watch delivers it.
 const dgdCollisionRequeueDelay = 5 * time.Second
 
-// generatedDGDFromAnnotation returns the DynamoGraphDeployment this request intends
-// to create, decoded from the generated-spec annotation and carrying the request's
-// runtime version override. The caller must establish that the annotation is present
-// and non-empty; an absent or unparseable annotation is returned as an error rather
-// than an empty deployment, because the two are not interchangeable here.
-//
-// The returned deployment is freshly allocated, so applying the runtime version
-// override mutates only that copy. dgdr is read but never modified.
+// generatedDGDFromAnnotation decodes the deployment this request intends to create
+// from the generated-spec annotation, applying the runtime version override to a fresh copy.
 func (r *DynamoGraphDeploymentRequestReconciler) generatedDGDFromAnnotation(
 	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
 ) (*nvidiacomv1beta1.DynamoGraphDeployment, error) {
@@ -1122,24 +1109,8 @@ func (r *DynamoGraphDeploymentRequestReconciler) generatedDGDFromAnnotation(
 	return generatedDGD, nil
 }
 
-// resolveGeneratedDGDIdentity reports whether liveDGD is the deployment dgdr created
-// from generatedDGD, and when it is not, a short phrase naming the half of the
-// identity contract that failed. All three arguments must be non-nil. The function is
-// read-only: it deep-copies before normalizing and never touches the live object.
-//
-// The contract has two halves and both are required.
-//
-// The tracking labels answer "who created this": they are written only by createDGD
-// and they name the exact request. Alone they are not enough, because a DGD left
-// behind by a deleted-and-recreated DGDR of the same name in the same namespace
-// carries labels that still match while its spec describes an unrelated deployment.
-//
-// The generated spec answers "is this the deployment we asked for": it distinguishes
-// a genuine crash-loop recovery, where the live spec is what this request generated,
-// from an unrelated workload that merely happens to occupy the name. Alone it is not
-// enough either, because two requests can legitimately generate identical specs, and
-// adopting on spec equality alone would let one request take over another's
-// deployment.
+// resolveGeneratedDGDIdentity reports whether liveDGD is the deployment dgdr created,
+// and names the failing half of the contract when it is not. Both halves are required.
 func resolveGeneratedDGDIdentity(
 	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
 	liveDGD *nvidiacomv1beta1.DynamoGraphDeployment,
@@ -1164,37 +1135,8 @@ func resolveGeneratedDGDIdentity(
 	return true, "", nil
 }
 
-// generatedSpecDivergence returns the first field path at which liveDGD fails to
-// carry what generatedDGD asks for, or the empty string when the live spec
-// satisfies the generated one. Both arguments must be non-nil and neither is
-// modified. An error means the comparison could not be made at all and the caller
-// must retry rather than conclude anything about identity.
-//
-// This is deliberately a subset test and not an equality test. Equality is wrong
-// here because the two sides have been through different numbers of defaulting
-// layers, and there is no way to run the missing ones in process:
-//
-//   - liveDGD was persisted through the API server, so it carries the DGD CRD's
-//     structural defaults — a container port's protocol, multinode.nodeCount,
-//     restart.strategy.type, and every non-zero default under experimental.
-//   - liveDGD also passed the DGD mutating webhook, so it carries defaulted
-//     replicas, Grove minimum-available replicas, and provider-override targets.
-//   - generatedDGD was decoded from an annotation this controller wrote from
-//     profiler output. It has been through neither layer.
-//
-// An earlier revision normalized both sides through the mutating webhook's own
-// defaulting. That closed the webhook gap and left the structural one wide open:
-// any request whose generated spec touched a defaulted subtree — reachable today
-// through spec.overrides.dgd — was failed terminally for colliding with the
-// deployment it had just created itself.
-//
-// Subset comparison closes both gaps at once and stays closed as either layer
-// grows, because defaulting only ever fills a field that was left unset. A live
-// value that contradicts a generated one, or a generated field the live object
-// does not have at all, is still a divergence and still rejected. What it
-// deliberately does not detect is a live object that is a strict superset of the
-// generated spec; the tracking-label half of the contract is what establishes
-// ownership, and this half only has to confirm the deployment we asked for.
+// generatedSpecDivergence returns the first field path where liveDGD fails to carry what
+// generatedDGD asks for. Subset, not equality: only liveDGD has been through defaulting.
 func generatedSpecDivergence(liveDGD, generatedDGD *nvidiacomv1beta1.DynamoGraphDeployment) (string, error) {
 	liveSpec, err := specAsJSONValue(liveDGD)
 	if err != nil {
@@ -1208,12 +1150,8 @@ func generatedSpecDivergence(liveDGD, generatedDGD *nvidiacomv1beta1.DynamoGraph
 	return jsonSubsetDivergence(generatedSpec, liveSpec, "spec"), nil
 }
 
-// specAsJSONValue renders dgd's spec as the generic JSON value the API server
-// would have seen, so that a field the Go type serializes with omitempty is
-// absent here exactly when it was absent on the wire. That correspondence is what
-// makes the subset test line up with structural defaulting, which fills a field
-// only when the submitted document omits it. dgd must not be nil and is not
-// modified.
+// specAsJSONValue renders dgd's spec as the generic JSON value the API server saw,
+// so an omitempty field is absent here exactly when it was absent on the wire.
 func specAsJSONValue(dgd *nvidiacomv1beta1.DynamoGraphDeployment) (any, error) {
 	encoded, err := json.Marshal(dgd.Spec)
 	if err != nil {
@@ -1226,15 +1164,8 @@ func specAsJSONValue(dgd *nvidiacomv1beta1.DynamoGraphDeployment) (any, error) {
 	return decoded, nil
 }
 
-// jsonSubsetDivergence returns the path of the first place where have does not
-// carry what want specifies, or the empty string when it does. Both arguments are
-// generic JSON values as produced by specAsJSONValue. path names the position
-// being compared and appears in the operator-facing collision message, so keys are
-// walked in sorted order to keep the reported path stable across runs.
-//
-// Lists compare element-wise and require equal length. Structural defaulting can
-// fill fields inside an existing element but cannot add or drop elements, so a
-// length difference is a real divergence rather than a defaulting artifact.
+// jsonSubsetDivergence returns the path of the first place where have does not carry
+// what want specifies. Keys walk in sorted order so the reported path is stable.
 func jsonSubsetDivergence(want, have any, path string) string {
 	switch wantValue := want.(type) {
 	case map[string]any:
@@ -1276,10 +1207,8 @@ func jsonSubsetDivergence(want, have any, path string) string {
 	}
 }
 
-// failDeploymentNameCollision drives the request terminal because the DGD name it
-// generated is held by a deployment it does not own. The status-only write preserves
-// the generated-spec annotation, so the evidence of what this request intended to
-// create survives for an operator to inspect.
+// failDeploymentNameCollision drives the request terminal. The status-only write preserves
+// the generated-spec annotation, so what this request meant to create stays inspectable.
 func (r *DynamoGraphDeploymentRequestReconciler) failDeploymentNameCollision(
 	ctx context.Context,
 	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -26,9 +26,11 @@ import (
 	"io"
 	"strings"
 	"text/template"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,6 +60,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gpu"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/defaulting"
 )
 
 const (
@@ -135,8 +138,13 @@ const (
 	MessageAIConfiguratorCheckFailed = "AIConfiguratorCheckFailed"
 	MessageProfilingCheckFailed      = "ProfilingCheckFailed"
 	MessageConfigMapNotFound         = "ConfigMap %s not found in namespace %s"
+	MessageDeploymentNameCollision   = "DynamoGraphDeployment %s already exists in namespace %s and was not created by this request (%s). Refusing to adopt it. Delete this DynamoGraphDeploymentRequest and create a new one whose generated deployment uses a free name."
 	MessageConfigMapKeyNotFound      = "key %s not found in ConfigMap %s"
 	MessageModelCachePVCNotFound     = "model cache PVC %s not found in namespace %s"
+
+	// ReasonDeploymentNameCollision marks the terminal failure raised when the DGD
+	// name this request generated is already taken by a deployment it does not own.
+	ReasonDeploymentNameCollision = "DeploymentNameCollision"
 )
 
 var errProfilingOutputNotReady = errors.New("profiling output is not ready")
@@ -833,6 +841,25 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployingPhase(ctx contex
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// Validate the identity of a same-name DGD before this request adopts it.
+	//
+	// The generated-spec annotation is both the gate and the evidence: while it is
+	// non-empty this request has not yet confirmed a DGD of its own, and it still
+	// records what it meant to create. Once clearGeneratedSpecAnnotation empties it
+	// the DGD is confirmed ours and later spec drift is the DGD controller's business,
+	// not a collision.
+	if dgdr.Annotations[AnnotationGeneratedDGDSpec] != "" {
+		generatedDGD, err := r.generatedDGDFromAnnotation(dgdr)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if matches, mismatchReason := resolveGeneratedDGDIdentity(dgdr, dgd, generatedDGD); !matches {
+			return r.failDeploymentNameCollision(ctx, dgdr, dgd, mismatchReason)
+		}
+	}
+
 	if err := r.clearGeneratedSpecAnnotation(ctx, dgdr); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -963,16 +990,10 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 	logger := log.FromContext(ctx)
 
 	// Extract DGD spec from annotation (stored by generateDGDSpec)
-	dgdSpecYAML, ok := dgdr.Annotations[AnnotationGeneratedDGDSpec]
-	if !ok || dgdSpecYAML == "" {
-		return ctrl.Result{}, fmt.Errorf("generated DGD spec not found in annotation %s", AnnotationGeneratedDGDSpec)
-	}
-
-	generatedDGD, err := r.extractDGDFromYAML([]byte(dgdSpecYAML))
+	generatedDGD, err := r.generatedDGDFromAnnotation(dgdr)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to unmarshal generated deployment from annotation: %w", err)
+		return ctrl.Result{}, err
 	}
-	applyDGDRRuntimeVersionOverride(dgdr, generatedDGD)
 
 	// Determine DGD name and namespace from generated deployment
 	dgdName := generatedDGD.Name
@@ -1021,6 +1042,22 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 
 	if err := r.Create(ctx, dgd); err != nil {
 		if apierrors.IsAlreadyExists(err) {
+			// Identify the object holding the name before waiting on a watch for it.
+			existingDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
+			getErr := r.Get(ctx, types.NamespacedName{Name: dgdName, Namespace: dgdNamespace}, existingDGD)
+			if apierrors.IsNotFound(getErr) {
+				// The cache has not caught up with the object the API server rejected against.
+				logger.Info("DGD already exists but is not observable yet, requeueing", "name", dgdName)
+				return ctrl.Result{RequeueAfter: dgdCollisionRequeueDelay}, nil
+			}
+			if getErr != nil {
+				return ctrl.Result{}, getErr
+			}
+
+			if matches, mismatchReason := resolveGeneratedDGDIdentity(dgdr, existingDGD, generatedDGD); !matches {
+				return r.failDeploymentNameCollision(ctx, dgdr, existingDGD, mismatchReason)
+			}
+
 			// The DGD watch reconciles again after the object is in the informer cache.
 			logger.Info("DGD already exists, waiting for informer observation")
 			return ctrl.Result{}, nil
@@ -1044,6 +1081,123 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 
 	// Keep the generated-spec marker until a cached read observes the DGD.
 	return ctrl.Result{}, nil
+}
+
+// dgdCollisionRequeueDelay paces the retry used when the API server rejects a DGD
+// create as already existing but the cached read cannot see that object yet. The
+// foreign object carries no DGDR labels, so the DGD watch will never deliver it and
+// an explicit requeue is the only way back into the identity check.
+const dgdCollisionRequeueDelay = 5 * time.Second
+
+// generatedDGDFromAnnotation returns the DynamoGraphDeployment this request intends
+// to create, decoded from the generated-spec annotation and carrying the request's
+// runtime version override. The caller must establish that the annotation is present
+// and non-empty; an absent or unparseable annotation is returned as an error rather
+// than an empty deployment, because the two are not interchangeable here.
+//
+// The returned deployment is freshly allocated, so applying the runtime version
+// override mutates only that copy. dgdr is read but never modified.
+func (r *DynamoGraphDeploymentRequestReconciler) generatedDGDFromAnnotation(
+	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
+) (*nvidiacomv1beta1.DynamoGraphDeployment, error) {
+	dgdSpecYAML := dgdr.Annotations[AnnotationGeneratedDGDSpec]
+	if dgdSpecYAML == "" {
+		return nil, fmt.Errorf("generated DGD spec not found in annotation %s", AnnotationGeneratedDGDSpec)
+	}
+
+	generatedDGD, err := r.extractDGDFromYAML([]byte(dgdSpecYAML))
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal generated deployment from annotation: %w", err)
+	}
+	applyDGDRRuntimeVersionOverride(dgdr, generatedDGD)
+
+	return generatedDGD, nil
+}
+
+// resolveGeneratedDGDIdentity reports whether liveDGD is the deployment dgdr created
+// from generatedDGD, and when it is not, a short phrase naming the half of the
+// identity contract that failed. All three arguments must be non-nil. The function is
+// read-only: it deep-copies before normalizing and never touches the live object.
+//
+// The contract has two halves and both are required.
+//
+// The tracking labels answer "who created this": they are written only by createDGD
+// and they name the exact request. Alone they are not enough, because a DGD left
+// behind by a deleted-and-recreated DGDR of the same name in the same namespace
+// carries labels that still match while its spec describes an unrelated deployment.
+//
+// The generated spec answers "is this the deployment we asked for": it distinguishes
+// a genuine crash-loop recovery, where the live spec is what this request generated,
+// from an unrelated workload that merely happens to occupy the name. Alone it is not
+// enough either, because two requests can legitimately generate identical specs, and
+// adopting on spec equality alone would let one request take over another's
+// deployment.
+func resolveGeneratedDGDIdentity(
+	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
+	liveDGD *nvidiacomv1beta1.DynamoGraphDeployment,
+	generatedDGD *nvidiacomv1beta1.DynamoGraphDeployment,
+) (matches bool, mismatchReason string) {
+	// Require the tracking labels this controller writes on every DGD it creates.
+	if liveDGD.Labels[nvidiacomv1beta1.LabelDGDRName] != dgdr.Name ||
+		liveDGD.Labels[nvidiacomv1beta1.LabelDGDRNamespace] != dgdr.Namespace ||
+		liveDGD.Labels[nvidiacomv1beta1.LabelManagedBy] != nvidiacomv1beta1.LabelValueDynamoOperator {
+		return false, "it does not carry this request's tracking labels"
+	}
+
+	// Require the live spec to be the one this request generated.
+	if !generatedSpecMatches(liveDGD, generatedDGD) {
+		return false, "its spec differs from the spec this request generated"
+	}
+
+	return true, ""
+}
+
+// generatedSpecMatches reports whether liveDGD's spec is the spec generatedDGD
+// describes, tolerating the defaults admission adds on the way in. Both arguments
+// must be non-nil and neither is modified.
+//
+// A strict comparison against the raw generated spec is wrong here. liveDGD has
+// passed through the DGD mutating webhook and so carries defaulted replicas,
+// Grove minimum-available replicas, and provider-override targets that the generated
+// spec never had; comparing the two directly reports a mismatch on every legitimate
+// recovery. Normalizing both sides through the webhook's own defaulting keeps the
+// comparison honest as those defaults grow, and cannot mask a real divergence,
+// because defaulting only fills fields that are unset.
+//
+// The provider comes from the live object's controller-owned annotation rather than
+// from a guess: when it is absent, the provider-conditional defaults are suppressed
+// on both sides instead of being invented for one of them.
+func generatedSpecMatches(liveDGD, generatedDGD *nvidiacomv1beta1.DynamoGraphDeployment) bool {
+	provider, providerSelected := liveDGD.Annotations[consts.KubeAnnotationWorkloadProvider]
+
+	// Normalize copies of both sides through the same defaults before comparing.
+	normalizedLive := liveDGD.DeepCopy()
+	normalizedGenerated := generatedDGD.DeepCopy()
+	defaulting.ApplySpecDefaults(normalizedLive, provider, providerSelected)
+	defaulting.ApplySpecDefaults(normalizedGenerated, provider, providerSelected)
+
+	return apiequality.Semantic.DeepEqual(normalizedLive.Spec, normalizedGenerated.Spec)
+}
+
+// failDeploymentNameCollision drives the request terminal because the DGD name it
+// generated is held by a deployment it does not own. The status-only write preserves
+// the generated-spec annotation, so the evidence of what this request intended to
+// create survives for an operator to inspect.
+func (r *DynamoGraphDeploymentRequestReconciler) failDeploymentNameCollision(
+	ctx context.Context,
+	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
+	liveDGD *nvidiacomv1beta1.DynamoGraphDeployment,
+	mismatchReason string,
+) (ctrl.Result, error) {
+	message := fmt.Sprintf(MessageDeploymentNameCollision, liveDGD.Name, dgdr.Namespace, mismatchReason)
+
+	log.FromContext(ctx).Info("Refusing to adopt an existing DGD that failed the DGDR identity contract",
+		"dgd", liveDGD.Name, "namespace", dgdr.Namespace, "reason", mismatchReason)
+	r.Recorder.Eventf(dgdr, liveDGD, corev1.EventTypeWarning, ReasonDeploymentNameCollision, "Get", "%s", message)
+
+	return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed,
+		nvidiacomv1beta1.ConditionTypeDeploymentReady, metav1.ConditionFalse,
+		ReasonDeploymentNameCollision, message)
 }
 
 // clearGeneratedSpecAnnotation marks the DGD as observed in the informer cache.

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -24,13 +24,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
+	"sort"
 	"strings"
 	"text/template"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,7 +61,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gpu"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/defaulting"
 )
 
 const (
@@ -855,7 +855,11 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployingPhase(ctx contex
 			return ctrl.Result{}, err
 		}
 
-		if matches, mismatchReason := resolveGeneratedDGDIdentity(dgdr, dgd, generatedDGD); !matches {
+		matches, mismatchReason, err := resolveGeneratedDGDIdentity(dgdr, dgd, generatedDGD)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if !matches {
 			return r.failDeploymentNameCollision(ctx, dgdr, dgd, mismatchReason)
 		}
 	}
@@ -1054,7 +1058,11 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 				return ctrl.Result{}, getErr
 			}
 
-			if matches, mismatchReason := resolveGeneratedDGDIdentity(dgdr, existingDGD, generatedDGD); !matches {
+			matches, mismatchReason, identityErr := resolveGeneratedDGDIdentity(dgdr, existingDGD, generatedDGD)
+			if identityErr != nil {
+				return ctrl.Result{}, identityErr
+			}
+			if !matches {
 				return r.failDeploymentNameCollision(ctx, dgdr, existingDGD, mismatchReason)
 			}
 
@@ -1136,47 +1144,136 @@ func resolveGeneratedDGDIdentity(
 	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
 	liveDGD *nvidiacomv1beta1.DynamoGraphDeployment,
 	generatedDGD *nvidiacomv1beta1.DynamoGraphDeployment,
-) (matches bool, mismatchReason string) {
+) (matches bool, mismatchReason string, err error) {
 	// Require the tracking labels this controller writes on every DGD it creates.
 	if liveDGD.Labels[nvidiacomv1beta1.LabelDGDRName] != dgdr.Name ||
 		liveDGD.Labels[nvidiacomv1beta1.LabelDGDRNamespace] != dgdr.Namespace ||
 		liveDGD.Labels[nvidiacomv1beta1.LabelManagedBy] != nvidiacomv1beta1.LabelValueDynamoOperator {
-		return false, "it does not carry this request's tracking labels"
+		return false, "it does not carry this request's tracking labels", nil
 	}
 
-	// Require the live spec to be the one this request generated.
-	if !generatedSpecMatches(liveDGD, generatedDGD) {
-		return false, "its spec differs from the spec this request generated"
+	// Require the live spec to carry everything this request asked for.
+	divergence, err := generatedSpecDivergence(liveDGD, generatedDGD)
+	if err != nil {
+		return false, "", err
+	}
+	if divergence != "" {
+		return false, fmt.Sprintf("its %s differs from the spec this request generated", divergence), nil
 	}
 
-	return true, ""
+	return true, "", nil
 }
 
-// generatedSpecMatches reports whether liveDGD's spec is the spec generatedDGD
-// describes, tolerating the defaults admission adds on the way in. Both arguments
-// must be non-nil and neither is modified.
+// generatedSpecDivergence returns the first field path at which liveDGD fails to
+// carry what generatedDGD asks for, or the empty string when the live spec
+// satisfies the generated one. Both arguments must be non-nil and neither is
+// modified. An error means the comparison could not be made at all and the caller
+// must retry rather than conclude anything about identity.
 //
-// A strict comparison against the raw generated spec is wrong here. liveDGD has
-// passed through the DGD mutating webhook and so carries defaulted replicas,
-// Grove minimum-available replicas, and provider-override targets that the generated
-// spec never had; comparing the two directly reports a mismatch on every legitimate
-// recovery. Normalizing both sides through the webhook's own defaulting keeps the
-// comparison honest as those defaults grow, and cannot mask a real divergence,
-// because defaulting only fills fields that are unset.
+// This is deliberately a subset test and not an equality test. Equality is wrong
+// here because the two sides have been through different numbers of defaulting
+// layers, and there is no way to run the missing ones in process:
 //
-// The provider comes from the live object's controller-owned annotation rather than
-// from a guess: when it is absent, the provider-conditional defaults are suppressed
-// on both sides instead of being invented for one of them.
-func generatedSpecMatches(liveDGD, generatedDGD *nvidiacomv1beta1.DynamoGraphDeployment) bool {
-	provider, providerSelected := liveDGD.Annotations[consts.KubeAnnotationWorkloadProvider]
+//   - liveDGD was persisted through the API server, so it carries the DGD CRD's
+//     structural defaults — a container port's protocol, multinode.nodeCount,
+//     restart.strategy.type, and every non-zero default under experimental.
+//   - liveDGD also passed the DGD mutating webhook, so it carries defaulted
+//     replicas, Grove minimum-available replicas, and provider-override targets.
+//   - generatedDGD was decoded from an annotation this controller wrote from
+//     profiler output. It has been through neither layer.
+//
+// An earlier revision normalized both sides through the mutating webhook's own
+// defaulting. That closed the webhook gap and left the structural one wide open:
+// any request whose generated spec touched a defaulted subtree — reachable today
+// through spec.overrides.dgd — was failed terminally for colliding with the
+// deployment it had just created itself.
+//
+// Subset comparison closes both gaps at once and stays closed as either layer
+// grows, because defaulting only ever fills a field that was left unset. A live
+// value that contradicts a generated one, or a generated field the live object
+// does not have at all, is still a divergence and still rejected. What it
+// deliberately does not detect is a live object that is a strict superset of the
+// generated spec; the tracking-label half of the contract is what establishes
+// ownership, and this half only has to confirm the deployment we asked for.
+func generatedSpecDivergence(liveDGD, generatedDGD *nvidiacomv1beta1.DynamoGraphDeployment) (string, error) {
+	liveSpec, err := specAsJSONValue(liveDGD)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode the live deployment spec for comparison: %w", err)
+	}
+	generatedSpec, err := specAsJSONValue(generatedDGD)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode the generated deployment spec for comparison: %w", err)
+	}
 
-	// Normalize copies of both sides through the same defaults before comparing.
-	normalizedLive := liveDGD.DeepCopy()
-	normalizedGenerated := generatedDGD.DeepCopy()
-	defaulting.ApplySpecDefaults(normalizedLive, provider, providerSelected)
-	defaulting.ApplySpecDefaults(normalizedGenerated, provider, providerSelected)
+	return jsonSubsetDivergence(generatedSpec, liveSpec, "spec"), nil
+}
 
-	return apiequality.Semantic.DeepEqual(normalizedLive.Spec, normalizedGenerated.Spec)
+// specAsJSONValue renders dgd's spec as the generic JSON value the API server
+// would have seen, so that a field the Go type serializes with omitempty is
+// absent here exactly when it was absent on the wire. That correspondence is what
+// makes the subset test line up with structural defaulting, which fills a field
+// only when the submitted document omits it. dgd must not be nil and is not
+// modified.
+func specAsJSONValue(dgd *nvidiacomv1beta1.DynamoGraphDeployment) (any, error) {
+	encoded, err := json.Marshal(dgd.Spec)
+	if err != nil {
+		return nil, err
+	}
+	var decoded any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, err
+	}
+	return decoded, nil
+}
+
+// jsonSubsetDivergence returns the path of the first place where have does not
+// carry what want specifies, or the empty string when it does. Both arguments are
+// generic JSON values as produced by specAsJSONValue. path names the position
+// being compared and appears in the operator-facing collision message, so keys are
+// walked in sorted order to keep the reported path stable across runs.
+//
+// Lists compare element-wise and require equal length. Structural defaulting can
+// fill fields inside an existing element but cannot add or drop elements, so a
+// length difference is a real divergence rather than a defaulting artifact.
+func jsonSubsetDivergence(want, have any, path string) string {
+	switch wantValue := want.(type) {
+	case map[string]any:
+		haveObject, isObject := have.(map[string]any)
+		if !isObject {
+			return path
+		}
+		keys := make([]string, 0, len(wantValue))
+		for key := range wantValue {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			haveChild, present := haveObject[key]
+			if !present {
+				return path + "." + key
+			}
+			if divergence := jsonSubsetDivergence(wantValue[key], haveChild, path+"."+key); divergence != "" {
+				return divergence
+			}
+		}
+		return ""
+	case []any:
+		haveList, isList := have.([]any)
+		if !isList || len(haveList) != len(wantValue) {
+			return path
+		}
+		for index := range wantValue {
+			if divergence := jsonSubsetDivergence(wantValue[index], haveList[index], fmt.Sprintf("%s[%d]", path, index)); divergence != "" {
+				return divergence
+			}
+		}
+		return ""
+	default:
+		if !reflect.DeepEqual(want, have) {
+			return path
+		}
+		return ""
+	}
 }
 
 // failDeploymentNameCollision drives the request terminal because the DGD name it

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -82,6 +82,7 @@ const (
 	// Annotation keys
 	AnnotationAdditionalResources = "dgdr.nvidia.com/additional-resources"
 	AnnotationGeneratedDGDSpec    = "nvidia.com/generated-dgd-spec"
+	AnnotationDGDRUID             = "nvidia.com/dgdr-uid"
 
 	// Size limits
 	MaxAnnotationSize = 250000 // ~250KB, below K8s 256KB limit
@@ -1021,6 +1022,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 			annotations[k] = v
 		}
 	}
+	annotations[AnnotationDGDRUID] = string(dgdr.UID)
 
 	// Create DGD from generated deployment
 	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
@@ -1121,6 +1123,9 @@ func resolveGeneratedDGDIdentity(
 		liveDGD.Labels[nvidiacomv1beta1.LabelDGDRNamespace] != dgdr.Namespace ||
 		liveDGD.Labels[nvidiacomv1beta1.LabelManagedBy] != nvidiacomv1beta1.LabelValueDynamoOperator {
 		return false, "it does not carry this request's tracking labels", nil
+	}
+	if liveDGD.Annotations[AnnotationDGDRUID] != string(dgdr.UID) {
+		return false, "it is not bound to this request's UID", nil
 	}
 
 	// Require the live spec to carry everything this request asked for.

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1124,7 +1124,8 @@ func resolveGeneratedDGDIdentity(
 		liveDGD.Labels[nvidiacomv1beta1.LabelManagedBy] != nvidiacomv1beta1.LabelValueDynamoOperator {
 		return false, "it does not carry this request's tracking labels", nil
 	}
-	if liveDGD.Annotations[AnnotationDGDRUID] != string(dgdr.UID) {
+	// DGDs created before UID binding rely on the existing labels-and-spec contract.
+	if dgdUID, bound := liveDGD.Annotations[AnnotationDGDRUID]; bound && dgdUID != string(dgdr.UID) {
 		return false, "it is not bound to this request's UID", nil
 	}
 

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -1217,12 +1217,15 @@ spec:
 			Expect(outputCM.OwnerReferences[0].Name).Should(Equal(dgdrName))
 		})
 
-		It("Should adopt additional ConfigMaps when DGD already exists", func() {
+		It("Should adopt additional ConfigMaps when the existing DGD is this request's own deployment", func() {
 			ctx := context.Background()
 			dgdrName := "test-dgdr-existing-dgd-adopt"
 			namespace := envtestNamespace
 			dgdName := dgdrName + "-dgd"
 			additionalConfigMapName := "planner-config-existing-dgd"
+
+			t := GinkgoT()
+			t.Log("Given a DGDR whose generated spec describes the DGD that already exists")
 
 			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1238,7 +1241,12 @@ spec:
   components:
   - name: worker
     type: worker
-    replicas: 1`,
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: registry.example/runtime:1.1.0`,
 					},
 				},
 				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
@@ -1253,10 +1261,17 @@ spec:
 			dgdr.Status.DGDName = dgdName
 			Expect(k8sClient.Status().Update(ctx, dgdr)).Should(Succeed())
 
+			t.Log("And the DGD carries this DGDR's tracking labels, as createDGD would have written them")
+
 			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      dgdName,
 					Namespace: namespace,
+					Labels: map[string]string{
+						nvidiacomv1beta1.LabelDGDRName:      dgdrName,
+						nvidiacomv1beta1.LabelDGDRNamespace: namespace,
+						nvidiacomv1beta1.LabelManagedBy:     nvidiacomv1beta1.LabelValueDynamoOperator,
+					},
 				},
 				Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
 					BackendFramework: "vllm",
@@ -1288,9 +1303,14 @@ spec:
 			Expect(k8sClient.Create(ctx, additionalCM)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, additionalCM) }()
 
+			t.Log("When the deploying phase runs against the interrupted create")
+
 			_, err := reconciler.handleDeployingPhase(ctx, dgdr)
 			Expect(err).NotTo(HaveOccurred())
 
+			t.Log("Then the request recovers: it adopts the DGD and reparents the additional ConfigMap")
+
+			Expect(dgdr.Status.Phase).ShouldNot(Equal(nvidiacomv1beta1.DGDRPhaseFailed))
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: additionalConfigMapName, Namespace: namespace}, additionalCM)).Should(Succeed())
 			Expect(additionalCM.OwnerReferences).Should(HaveLen(1))
 			Expect(additionalCM.OwnerReferences[0].Kind).Should(Equal("DynamoGraphDeployment"))
@@ -1372,6 +1392,132 @@ spec:
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: additionalConfigMapName, Namespace: namespace}, additionalCM)).Should(Succeed())
 			Expect(additionalCM.ResourceVersion).Should(Equal(resourceVersion))
 		})
+
+		DescribeTable("Should refuse to adopt an existing DGD that is not this request's own deployment",
+			func(nameSuffix string, trackedByThisRequest bool, liveWorkerImage string) {
+				ctx := context.Background()
+				t := GinkgoT()
+				namespace := envtestNamespace
+				dgdrName := "test-dgdr-collision-" + nameSuffix
+				dgdName := dgdrName + "-dgd"
+				additionalConfigMapName := "planner-config-collision-" + nameSuffix
+
+				t.Log("Given a DGDR deploying a generated spec it has not yet confirmed")
+
+				dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      dgdrName,
+						Namespace: namespace,
+						Annotations: map[string]string{
+							"nvidia.com/generated-dgd-spec": `apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ` + dgdName + `
+spec:
+  backendFramework: vllm
+  components:
+  - name: worker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: registry.example/runtime:1.1.0`,
+						},
+					},
+					Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+						Model:   "test-model",
+						Backend: "vllm",
+						Image:   "test-profiler:1.1.0",
+					},
+				}
+				Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
+				defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
+				dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeploying
+				dgdr.Status.DGDName = dgdName
+				Expect(k8sClient.Status().Update(ctx, dgdr)).Should(Succeed())
+
+				t.Log("And a DGD already occupying that name that fails one half of the identity contract")
+
+				labels := map[string]string{}
+				if trackedByThisRequest {
+					labels = map[string]string{
+						nvidiacomv1beta1.LabelDGDRName:      dgdrName,
+						nvidiacomv1beta1.LabelDGDRNamespace: namespace,
+						nvidiacomv1beta1.LabelManagedBy:     nvidiacomv1beta1.LabelValueDynamoOperator,
+					}
+				}
+
+				existingDGD := &nvidiacomv1beta1.DynamoGraphDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      dgdName,
+						Namespace: namespace,
+						Labels:    labels,
+					},
+					Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
+						BackendFramework: "vllm",
+						Components: []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{{
+							ComponentName: "worker",
+							ComponentType: nvidiacomv1beta1.ComponentTypeWorker,
+							Replicas:      ptr.To[int32](1),
+							PodTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: consts.MainContainerName, Image: liveWorkerImage}},
+							}},
+						}},
+					},
+				}
+				Expect(k8sClient.Create(ctx, existingDGD)).Should(Succeed())
+				defer func() { _ = k8sClient.Delete(ctx, existingDGD) }()
+
+				additionalCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      additionalConfigMapName,
+						Namespace: namespace,
+						Labels: map[string]string{
+							nvidiacomv1beta1.LabelDGDRName:      dgdrName,
+							nvidiacomv1beta1.LabelDGDRNamespace: namespace,
+							nvidiacomv1beta1.LabelManagedBy:     nvidiacomv1beta1.LabelValueDynamoOperator,
+						},
+					},
+					Data: map[string]string{"planner_config.json": "{}"},
+				}
+				Expect(k8sClient.Create(ctx, additionalCM)).Should(Succeed())
+				defer func() { _ = k8sClient.Delete(ctx, additionalCM) }()
+
+				t.Log("When the deploying phase observes the same-name DGD")
+
+				_, err := reconciler.handleDeployingPhase(ctx, dgdr)
+				Expect(err).NotTo(HaveOccurred())
+
+				t.Log("Then the request goes terminal with a name-collision condition instead of adopting")
+
+				Expect(dgdr.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseFailed))
+				condition := meta.FindStatusCondition(dgdr.Status.Conditions, nvidiacomv1beta1.ConditionTypeDeploymentReady)
+				Expect(condition).NotTo(BeNil())
+				Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
+				Expect(condition.Reason).Should(Equal(ReasonDeploymentNameCollision))
+
+				t.Log("And the generated spec survives, so the intended deployment stays recoverable")
+
+				persistedDGDR := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, persistedDGDR)).Should(Succeed())
+				Expect(persistedDGDR.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseFailed))
+				Expect(persistedDGDR.Annotations["nvidia.com/generated-dgd-spec"]).ShouldNot(BeEmpty())
+
+				t.Log("And nothing this request owns is reparented onto the foreign deployment")
+
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: additionalConfigMapName, Namespace: namespace}, additionalCM)).Should(Succeed())
+				Expect(additionalCM.OwnerReferences).Should(BeEmpty())
+
+				t.Log("And the foreign deployment itself is left exactly as it was")
+
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdName, Namespace: namespace}, existingDGD)).Should(Succeed())
+				Expect(existingDGD.Spec.Components[0].PodTemplate.Spec.Containers[0].Image).Should(Equal(liveWorkerImage))
+			},
+			Entry("when it does not carry this request's tracking labels", "foreign", false, "registry.example/runtime:1.1.0"),
+			Entry("when its spec differs from the spec this request generated", "spec-drift", true, "registry.example/other:9.9.9"),
+		)
 	})
 
 	Context("When enabling autoApply after manual review", func() {
@@ -2731,12 +2877,21 @@ spec:
 					Name:      dgdrName,
 					Namespace: namespace,
 					Annotations: map[string]string{
-						AnnotationGeneratedDGDSpec: `apiVersion: nvidia.com/v1alpha1
+						AnnotationGeneratedDGDSpec: `apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
 metadata:
   name: test-dgd-deployed
 spec:
-  services: {}`,
+  backendFramework: vllm
+  components:
+  - name: worker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: registry.example/runtime:1.1.0`,
 					},
 				},
 				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
@@ -2772,6 +2927,7 @@ spec:
 					Labels: map[string]string{
 						nvidiacomv1beta1.LabelDGDRName:      dgdrName,
 						nvidiacomv1beta1.LabelDGDRNamespace: namespace,
+						nvidiacomv1beta1.LabelManagedBy:     nvidiacomv1beta1.LabelValueDynamoOperator,
 					},
 				},
 				Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -1529,13 +1529,8 @@ spec:
 
 			t.Log("Given a generated spec that declares a container port and omits its protocol")
 
-			// A container port without an explicit protocol is the cheapest reachable
-			// instance of a whole class: the DGD CRD carries structural defaults that
-			// the API server applies on write, and the generated-spec annotation never
-			// passes through an API server. `protocol: TCP` stands in here for
-			// multinode.nodeCount, restart.strategy.type, and the experimental
-			// subtrees, all of which default the same way. spec.overrides.dgd lets a
-			// user put any of them into a generated spec.
+			// A port protocol is the cheapest reachable instance of the whole class: the
+			// CRD's structural defaults apply on write, and the annotation bypasses them.
 			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      dgdrName,

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -1518,6 +1518,138 @@ spec:
 			Entry("when it does not carry this request's tracking labels", "foreign", false, "registry.example/runtime:1.1.0"),
 			Entry("when its spec differs from the spec this request generated", "spec-drift", true, "registry.example/other:9.9.9"),
 		)
+
+		It("Should adopt an existing DGD whose live spec differs only by API-server structural defaults", func() {
+			ctx := context.Background()
+			t := GinkgoT()
+			namespace := envtestNamespace
+			dgdrName := "test-dgdr-structural-defaults"
+			dgdName := dgdrName + "-dgd"
+			additionalConfigMapName := "planner-config-structural-defaults"
+
+			t.Log("Given a generated spec that declares a container port and omits its protocol")
+
+			// A container port without an explicit protocol is the cheapest reachable
+			// instance of a whole class: the DGD CRD carries structural defaults that
+			// the API server applies on write, and the generated-spec annotation never
+			// passes through an API server. `protocol: TCP` stands in here for
+			// multinode.nodeCount, restart.strategy.type, and the experimental
+			// subtrees, all of which default the same way. spec.overrides.dgd lets a
+			// user put any of them into a generated spec.
+			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dgdrName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						AnnotationGeneratedDGDSpec: `apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ` + dgdName + `
+spec:
+  backendFramework: vllm
+  components:
+  - name: worker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: registry.example/runtime:1.1.0
+          ports:
+          - name: http
+            containerPort: 8000`,
+					},
+				},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model:   "test-model",
+					Backend: "vllm",
+					Image:   "test-profiler:1.1.0",
+				},
+			}
+			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
+			dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeploying
+			dgdr.Status.DGDName = dgdName
+			Expect(k8sClient.Status().Update(ctx, dgdr)).Should(Succeed())
+
+			t.Log("And this request's own DGD persisted from that spec, which the API server defaulted")
+
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dgdName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						nvidiacomv1beta1.LabelDGDRName:      dgdrName,
+						nvidiacomv1beta1.LabelDGDRNamespace: namespace,
+						nvidiacomv1beta1.LabelManagedBy:     nvidiacomv1beta1.LabelValueDynamoOperator,
+					},
+				},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
+					BackendFramework: "vllm",
+					Components: []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{{
+						ComponentName: "worker",
+						ComponentType: nvidiacomv1beta1.ComponentTypeWorker,
+						Replicas:      ptr.To[int32](1),
+						PodTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  consts.MainContainerName,
+								Image: "registry.example/runtime:1.1.0",
+								Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8000}},
+							}},
+						}},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, dgd)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, dgd) }()
+
+			t.Log("Then the persisted object really does carry a default the generated spec never had")
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdName, Namespace: namespace}, dgd)).Should(Succeed())
+			Expect(dgd.Spec.Components[0].PodTemplate.Spec.Containers[0].Ports[0].Protocol).
+				Should(Equal(corev1.ProtocolTCP), "the CRD's structural default must actually be applied, or this spec proves nothing")
+
+			additionalCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      additionalConfigMapName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						nvidiacomv1beta1.LabelDGDRName:      dgdrName,
+						nvidiacomv1beta1.LabelDGDRNamespace: namespace,
+						nvidiacomv1beta1.LabelManagedBy:     nvidiacomv1beta1.LabelValueDynamoOperator,
+					},
+				},
+				Data: map[string]string{"planner_config.json": "{}"},
+			}
+			Expect(k8sClient.Create(ctx, additionalCM)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, additionalCM) }()
+
+			t.Log("When the deploying phase observes the DGD this request created")
+
+			_, err := reconciler.handleDeployingPhase(ctx, dgdr)
+			Expect(err).NotTo(HaveOccurred())
+
+			t.Log("Then the request adopts its own deployment instead of colliding with it")
+
+			Expect(dgdr.Status.Phase).ShouldNot(Equal(nvidiacomv1beta1.DGDRPhaseFailed))
+			condition := meta.FindStatusCondition(dgdr.Status.Conditions, nvidiacomv1beta1.ConditionTypeDeploymentReady)
+			if condition != nil {
+				Expect(condition.Reason).ShouldNot(Equal(ReasonDeploymentNameCollision))
+			}
+
+			t.Log("And adoption really ran: the marker is cleared and the ConfigMap follows the DGD")
+
+			persistedDGDR := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, persistedDGDR)).Should(Succeed())
+			Expect(persistedDGDR.Annotations[AnnotationGeneratedDGDSpec]).Should(BeEmpty())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: additionalConfigMapName, Namespace: namespace}, additionalCM)).Should(Succeed())
+			Expect(additionalCM.OwnerReferences).Should(HaveLen(1))
+			Expect(additionalCM.OwnerReferences[0].Kind).Should(Equal("DynamoGraphDeployment"))
+			Expect(additionalCM.OwnerReferences[0].Name).Should(Equal(dgdName))
+			Expect(additionalCM.OwnerReferences[0].UID).Should(Equal(dgd.UID))
+		})
 	})
 
 	Context("When enabling autoApply after manual review", func() {

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -1616,7 +1616,7 @@ spec:
 			Expect(k8sClient.Delete(ctx, originalDGDR)).Should(Succeed())
 			Eventually(func() bool {
 				return apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}))
-			}).Should(BeTrue())
+			}, timeout, interval).Should(BeTrue())
 
 			recreatedDGDR := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
 				ObjectMeta: metav1.ObjectMeta{

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -1272,6 +1272,9 @@ spec:
 						nvidiacomv1beta1.LabelDGDRNamespace: namespace,
 						nvidiacomv1beta1.LabelManagedBy:     nvidiacomv1beta1.LabelValueDynamoOperator,
 					},
+					Annotations: map[string]string{
+						AnnotationDGDRUID: string(dgdr.UID),
+					},
 				},
 				Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
 					BackendFramework: "vllm",
@@ -1441,19 +1444,22 @@ spec:
 				t.Log("And a DGD already occupying that name that fails one half of the identity contract")
 
 				labels := map[string]string{}
+				annotations := map[string]string{}
 				if trackedByThisRequest {
 					labels = map[string]string{
 						nvidiacomv1beta1.LabelDGDRName:      dgdrName,
 						nvidiacomv1beta1.LabelDGDRNamespace: namespace,
 						nvidiacomv1beta1.LabelManagedBy:     nvidiacomv1beta1.LabelValueDynamoOperator,
 					}
+					annotations[AnnotationDGDRUID] = string(dgdr.UID)
 				}
 
 				existingDGD := &nvidiacomv1beta1.DynamoGraphDeployment{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      dgdName,
-						Namespace: namespace,
-						Labels:    labels,
+						Name:        dgdName,
+						Namespace:   namespace,
+						Labels:      labels,
+						Annotations: annotations,
 					},
 					Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
 						BackendFramework: "vllm",
@@ -1519,6 +1525,135 @@ spec:
 			Entry("when its spec differs from the spec this request generated", "spec-drift", true, "registry.example/other:9.9.9"),
 		)
 
+		It("Should refuse a recreated DGDR from adopting its prior DGD", func() {
+			ctx := context.Background()
+			t := GinkgoT()
+			namespace := envtestNamespace
+			dgdrName := "test-dgdr-recreated"
+			dgdName := dgdrName + "-dgd"
+			additionalConfigMapName := "planner-config-recreated"
+
+			t.Log("Given an original DGDR and DGD with matching labels and spec")
+
+			originalDGDR := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dgdrName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						AnnotationGeneratedDGDSpec: `apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ` + dgdName + `
+spec:
+  backendFramework: vllm
+  components:
+  - name: worker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: registry.example/runtime:1.1.0`,
+					},
+				},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model:   "test-model",
+					Backend: "vllm",
+					Image:   "test-profiler:1.1.0",
+				},
+			}
+			Expect(k8sClient.Create(ctx, originalDGDR)).Should(Succeed())
+			originalDGDR.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeploying
+			originalDGDR.Status.DGDName = dgdName
+			Expect(k8sClient.Status().Update(ctx, originalDGDR)).Should(Succeed())
+
+			priorDGD := &nvidiacomv1beta1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dgdName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						nvidiacomv1beta1.LabelDGDRName:      dgdrName,
+						nvidiacomv1beta1.LabelDGDRNamespace: namespace,
+						nvidiacomv1beta1.LabelManagedBy:     nvidiacomv1beta1.LabelValueDynamoOperator,
+					},
+					Annotations: map[string]string{
+						AnnotationDGDRUID: string(originalDGDR.UID),
+					},
+				},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
+					BackendFramework: "vllm",
+					Components: []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{{
+						ComponentName: "worker",
+						ComponentType: nvidiacomv1beta1.ComponentTypeWorker,
+						Replicas:      ptr.To[int32](1),
+						PodTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: consts.MainContainerName, Image: "registry.example/runtime:1.1.0"}},
+						}},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, priorDGD)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, priorDGD) }()
+
+			additionalCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      additionalConfigMapName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						nvidiacomv1beta1.LabelDGDRName:      dgdrName,
+						nvidiacomv1beta1.LabelDGDRNamespace: namespace,
+						nvidiacomv1beta1.LabelManagedBy:     nvidiacomv1beta1.LabelValueDynamoOperator,
+					},
+				},
+				Data: map[string]string{"planner_config.json": "{}"},
+			}
+			Expect(k8sClient.Create(ctx, additionalCM)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, additionalCM) }()
+
+			t.Log("When the original DGDR is deleted and recreated with the same name and spec")
+
+			Expect(k8sClient.Delete(ctx, originalDGDR)).Should(Succeed())
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}))
+			}).Should(BeTrue())
+
+			recreatedDGDR := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dgdrName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						AnnotationGeneratedDGDSpec: originalDGDR.Annotations[AnnotationGeneratedDGDSpec],
+					},
+				},
+				Spec: originalDGDR.Spec,
+			}
+			Expect(k8sClient.Create(ctx, recreatedDGDR)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, recreatedDGDR) }()
+			Expect(recreatedDGDR.UID).ShouldNot(Equal(originalDGDR.UID))
+			recreatedDGDR.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeploying
+			recreatedDGDR.Status.DGDName = dgdName
+			Expect(k8sClient.Status().Update(ctx, recreatedDGDR)).Should(Succeed())
+
+			t.Log("Then the recreated DGDR rejects the DGD bound to the original request")
+
+			_, err := reconciler.handleDeployingPhase(ctx, recreatedDGDR)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recreatedDGDR.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseFailed))
+			condition := meta.FindStatusCondition(recreatedDGDR.Status.Conditions, nvidiacomv1beta1.ConditionTypeDeploymentReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Reason).Should(Equal(ReasonDeploymentNameCollision))
+
+			t.Log("And the stale DGD and ConfigMap are not adopted")
+
+			persistedDGDR := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, persistedDGDR)).Should(Succeed())
+			Expect(persistedDGDR.Annotations[AnnotationGeneratedDGDSpec]).ShouldNot(BeEmpty())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: additionalConfigMapName, Namespace: namespace}, additionalCM)).Should(Succeed())
+			Expect(additionalCM.OwnerReferences).Should(BeEmpty())
+		})
+
 		It("Should adopt an existing DGD whose live spec differs only by API-server structural defaults", func() {
 			ctx := context.Background()
 			t := GinkgoT()
@@ -1578,6 +1713,9 @@ spec:
 						nvidiacomv1beta1.LabelDGDRName:      dgdrName,
 						nvidiacomv1beta1.LabelDGDRNamespace: namespace,
 						nvidiacomv1beta1.LabelManagedBy:     nvidiacomv1beta1.LabelValueDynamoOperator,
+					},
+					Annotations: map[string]string{
+						AnnotationDGDRUID: string(dgdr.UID),
 					},
 				},
 				Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler.go
@@ -83,6 +83,40 @@ func (d *DGDDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	// Resolve the authoritative or creation-time provider before applying component defaults.
 	provider, providerSelected := defaultWorkloadProvider(ctx, dgd, req.Operation)
 
+	ApplySpecDefaults(dgd, provider, providerSelected)
+
+	// Stamp creation provenance independently from level-based provider defaulting.
+	if req.Operation == admissionv1.Create {
+		// Stamp operator version on creation (don't overwrite if already set)
+		if _, exists := dgd.Annotations[consts.KubeAnnotationDynamoOperatorOriginVersion]; !exists {
+			dgd.Annotations[consts.KubeAnnotationDynamoOperatorOriginVersion] = d.OperatorVersion
+			logger.Info("stamped operator origin version on DGD",
+				"name", dgd.Name,
+				"namespace", dgd.Namespace,
+				"version", d.OperatorVersion)
+		}
+	}
+
+	return nil
+}
+
+// ApplySpecDefaults applies every spec-level default this webhook owns to dgd, in
+// place: nil component replicas, Grove's minimum available replicas, and the
+// provider target of each provider-override context. dgd must not be nil. Pass
+// providerSelected false when the provider is unknown, which suppresses the
+// provider-conditional defaults rather than guessing at them.
+//
+// This is exported because the DGDR controller has to recognize a
+// DynamoGraphDeployment it created earlier by comparing the live object against the
+// spec it generated. The live object has been through this webhook and the
+// generated spec has not, so the controller normalizes both through this function
+// before comparing them. Keeping one implementation means a default added here
+// cannot silently turn a legitimate recovery into a name collision there.
+//
+// Every default is additive and idempotent: it fills a field that is unset and
+// leaves a set field alone. Callers may therefore apply it to an object that has
+// already passed admission.
+func ApplySpecDefaults(dgd *nvidiacomv1beta1.DynamoGraphDeployment, provider string, providerSelected bool) {
 	// Persist the root target only when this provider context resolves unambiguously.
 	if dgd.Spec.ProviderOverride != nil {
 		provideroverride.DefaultTarget(dgd.Spec.ProviderOverride, provider, provideroverride.ScopeRoot, nil)
@@ -133,20 +167,6 @@ func (d *DGDDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 			}
 		}
 	}
-
-	// Stamp creation provenance independently from level-based provider defaulting.
-	if req.Operation == admissionv1.Create {
-		// Stamp operator version on creation (don't overwrite if already set)
-		if _, exists := dgd.Annotations[consts.KubeAnnotationDynamoOperatorOriginVersion]; !exists {
-			dgd.Annotations[consts.KubeAnnotationDynamoOperatorOriginVersion] = d.OperatorVersion
-			logger.Info("stamped operator origin version on DGD",
-				"name", dgd.Name,
-				"namespace", dgd.Namespace,
-				"version", d.OperatorVersion)
-		}
-	}
-
-	return nil
 }
 
 func defaultWorkloadProvider(

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler.go
@@ -83,40 +83,6 @@ func (d *DGDDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	// Resolve the authoritative or creation-time provider before applying component defaults.
 	provider, providerSelected := defaultWorkloadProvider(ctx, dgd, req.Operation)
 
-	ApplySpecDefaults(dgd, provider, providerSelected)
-
-	// Stamp creation provenance independently from level-based provider defaulting.
-	if req.Operation == admissionv1.Create {
-		// Stamp operator version on creation (don't overwrite if already set)
-		if _, exists := dgd.Annotations[consts.KubeAnnotationDynamoOperatorOriginVersion]; !exists {
-			dgd.Annotations[consts.KubeAnnotationDynamoOperatorOriginVersion] = d.OperatorVersion
-			logger.Info("stamped operator origin version on DGD",
-				"name", dgd.Name,
-				"namespace", dgd.Namespace,
-				"version", d.OperatorVersion)
-		}
-	}
-
-	return nil
-}
-
-// ApplySpecDefaults applies every spec-level default this webhook owns to dgd, in
-// place: nil component replicas, Grove's minimum available replicas, and the
-// provider target of each provider-override context. dgd must not be nil. Pass
-// providerSelected false when the provider is unknown, which suppresses the
-// provider-conditional defaults rather than guessing at them.
-//
-// This is exported because the DGDR controller has to recognize a
-// DynamoGraphDeployment it created earlier by comparing the live object against the
-// spec it generated. The live object has been through this webhook and the
-// generated spec has not, so the controller normalizes both through this function
-// before comparing them. Keeping one implementation means a default added here
-// cannot silently turn a legitimate recovery into a name collision there.
-//
-// Every default is additive and idempotent: it fills a field that is unset and
-// leaves a set field alone. Callers may therefore apply it to an object that has
-// already passed admission.
-func ApplySpecDefaults(dgd *nvidiacomv1beta1.DynamoGraphDeployment, provider string, providerSelected bool) {
 	// Persist the root target only when this provider context resolves unambiguously.
 	if dgd.Spec.ProviderOverride != nil {
 		provideroverride.DefaultTarget(dgd.Spec.ProviderOverride, provider, provideroverride.ScopeRoot, nil)
@@ -167,6 +133,20 @@ func ApplySpecDefaults(dgd *nvidiacomv1beta1.DynamoGraphDeployment, provider str
 			}
 		}
 	}
+
+	// Stamp creation provenance independently from level-based provider defaulting.
+	if req.Operation == admissionv1.Create {
+		// Stamp operator version on creation (don't overwrite if already set)
+		if _, exists := dgd.Annotations[consts.KubeAnnotationDynamoOperatorOriginVersion]; !exists {
+			dgd.Annotations[consts.KubeAnnotationDynamoOperatorOriginVersion] = d.OperatorVersion
+			logger.Info("stamped operator origin version on DGD",
+				"name", dgd.Name,
+				"namespace", dgd.Namespace,
+				"version", d.OperatorVersion)
+		}
+	}
+
+	return nil
 }
 
 func defaultWorkloadProvider(


### PR DESCRIPTION
A DGDR now rejects an unrelated same-name DGD and rejects replacement of a deployment it has already confirmed. Before first confirmation, it checks tracking labels, any existing DGDR UID stamp, and the generated spec as a subset of the admitted live spec so API defaults remain compatible. Confirmation persists the observed DGD UID on the DGDR atomically with clearing the generated-spec marker. Both `Deploying` and `Deployed` check that binding before adopting ConfigMaps or consuming deployment status.

Legacy requests without a confirmed UID bootstrap once from matching tracking metadata, including the generated-spec check when its marker remains. A missing legacy DGDR UID stamp stays compatible; an explicit mismatch is rejected. This cannot establish historical identity for a replacement that predates bootstrap and carries matching metadata, but subsequent replacements are rejected by UID. An `AlreadyExists` response schedules a bounded retry through the shared observation path. Identity collisions persist terminal `DeploymentNameCollision` status before emitting the warning event and leave ConfigMaps untouched.

Regression coverage now replaces a confirmed DGD with an identically described object carrying a different API-assigned UID in both lifecycle phases. An additional case extends the collision table with a deterministic stale read followed by a real API-server `AlreadyExists` response and the subsequent identity rejection. The full controller package passed locally with `go test ./internal/controller -count=1 -timeout=10m`; formatting, whitespace, and pre-commit checks passed. Removing the UID comparison through a temporary Go overlay caused both replacement cases to fail. Removing the collision retry caused the stale-cache case to fail on its zero retry duration. Full CI passed for commit `9f2618bc17713be6be5d3b2d60496c99526f7abd` in [run 35283765896](https://github.com/ai-dynamo/dynamo/actions/runs/35283765896). The lifecycle job passed all eight tests on a targeted retry after its first attempt encountered node `DiskPressure` evictions.

Closes #13876.
