### PR TITLE
fix(sidecar): update vLLM KV-router gRPC endpoint flag

### DIFF
--- a/lib/sidecar/vllm/launch/agg_kv_router.sh
+++ b/lib/sidecar/vllm/launch/agg_kv_router.sh
@@ -132,10 +132,10 @@ vllm-rs serve "$MODEL" \
 
 DYN_SYSTEM_PORT="$SYSTEM_PORT1" \
     dynamo-vllm-sidecar \
-    --vllm-endpoint "${VLLM_HOST}:${VLLM_WORKER1_GRPC_PORT}" &
+    --grpc-endpoint "${VLLM_HOST}:${VLLM_WORKER1_GRPC_PORT}" &
 
 DYN_SYSTEM_PORT="$SYSTEM_PORT2" \
     dynamo-vllm-sidecar \
-    --vllm-endpoint "${VLLM_HOST}:${VLLM_WORKER2_GRPC_PORT}" &
+    --grpc-endpoint "${VLLM_HOST}:${VLLM_WORKER2_GRPC_PORT}" &
 
 wait_any_exit

--- a/lib/sidecar/vllm/launch/disagg_kv_router.sh
+++ b/lib/sidecar/vllm/launch/disagg_kv_router.sh
@@ -191,23 +191,23 @@ vllm-rs serve "$MODEL" \
 
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT1:-8081}" \
     dynamo-vllm-sidecar \
-    --vllm-endpoint "${VLLM_HOST}:${VLLM_DECODE1_GRPC_PORT}" \
+    --grpc-endpoint "${VLLM_HOST}:${VLLM_DECODE1_GRPC_PORT}" \
     --disaggregation-mode decode &
 
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT2:-8082}" \
     dynamo-vllm-sidecar \
-    --vllm-endpoint "${VLLM_HOST}:${VLLM_DECODE2_GRPC_PORT}" \
+    --grpc-endpoint "${VLLM_HOST}:${VLLM_DECODE2_GRPC_PORT}" \
     --disaggregation-mode decode &
 
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT3:-8083}" \
     dynamo-vllm-sidecar \
-    --vllm-endpoint "${VLLM_HOST}:${VLLM_PREFILL1_GRPC_PORT}" \
+    --grpc-endpoint "${VLLM_HOST}:${VLLM_PREFILL1_GRPC_PORT}" \
     --component prefill \
     --disaggregation-mode prefill &
 
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT4:-8084}" \
     dynamo-vllm-sidecar \
-    --vllm-endpoint "${VLLM_HOST}:${VLLM_PREFILL2_GRPC_PORT}" \
+    --grpc-endpoint "${VLLM_HOST}:${VLLM_PREFILL2_GRPC_PORT}" \
     --component prefill \
     --disaggregation-mode prefill &
 


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Align vLLM KV-router sidecars with unified gRPC endpoint configuration

## Details:

<!-- Describe the changes made in this PR. -->

PR #13797 renamed and removed  `--vllm-endpoint`  during unified sidecar gRPC endpoint configuration; 

the KV-router scripts introduced in PR #13735 still used that invalid flag and must use equivalent  `--grpc-endpoint`  instead

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated vLLM sidecar routing to use the correct gRPC endpoint configuration.
  * Preserved existing decode and prefill assignments, ports, and routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->