### PR TITLE
feat(router): add async request classifier seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2612,6 +2612,7 @@ dependencies = [
  "dynamo-truthy",
  "fastrand",
  "flume 0.12.0",
+ "futures-util",
  "indexmap 2.14.0",
  "once_cell",
  "ordered-float 4.6.0",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1684,6 +1684,7 @@ dependencies = [
  "dynamo-truthy",
  "fastrand",
  "flume",
+ "futures-util",
  "indexmap 2.14.0",
  "ordered-float 4.6.0",
  "parking_lot",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1741,6 +1741,7 @@ dependencies = [
  "dynamo-truthy",
  "fastrand",
  "flume",
+ "futures-util",
  "indexmap 2.14.0",
  "once_cell",
  "ordered-float 4.6.0",

--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -40,6 +40,7 @@ ordered-float = { workspace = true }
 once_cell = { version = "1", optional = true }
 derive_builder = { workspace = true }
 fastrand = "2"
+futures-util = { workspace = true }
 prometheus = { workspace = true, optional = true }
 seqlock = { workspace = true }
 serde = { workspace = true }

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant as StdInstant};
 
 use rustc_hash::FxHashMap;
 use tokio::sync::watch;
@@ -16,6 +16,9 @@ use super::overlap_refresh::{NoopOverlapScoresRefresh, OverlapScoresRefresh};
 use super::policy_config::PolicyProfile;
 use super::prefill_load::PrefillLoadEstimator;
 use super::queue::{ClassQueueStats, SchedulerQueue};
+use super::request_classifier::{
+    ClassifyRequest, RequestClassifier, RequestClassifierRuntime, RequestLifecycle,
+};
 use super::selector::{DefaultWorkerSelector, WorkerSelector};
 use super::types::{
     AdvisorySchedulingResponse, KvSchedulerError, NonMaxOverlapSelectionObserver,
@@ -48,6 +51,7 @@ where
     slots: Arc<ActiveSequencesMultiWorker<P>>,
     queue: Arc<SchedulerQueue<P, C, Sel, RF>>,
     queue_updates: watch::Sender<()>,
+    request_classifier: OnceLock<Arc<RequestClassifierRuntime>>,
     track_prefill_tokens_default: bool,
     worker_type: &'static str,
 }
@@ -303,15 +307,39 @@ where
             slots,
             queue,
             queue_updates,
+            request_classifier: OnceLock::new(),
             track_prefill_tokens_default,
             worker_type,
         })
+    }
+
+    #[doc(hidden)]
+    pub fn install_request_classifier(
+        &self,
+        classifier: Box<dyn RequestClassifier>,
+        shutdown: CancellationToken,
+    ) -> bool {
+        self.request_classifier
+            .set(RequestClassifierRuntime::new(classifier, shutdown))
+            .is_ok()
     }
 
     pub async fn schedule_request(
         &self,
         request: ScheduleRequest,
     ) -> Result<SchedulingResponse, KvSchedulerError> {
+        self.schedule_request_with_ingress_at(request, StdInstant::now())
+            .await
+    }
+
+    /// Schedule a request using the router's original ingress timestamp.
+    #[doc(hidden)]
+    pub async fn schedule_request_with_ingress_at(
+        &self,
+        request: ScheduleRequest,
+        ingress_at: StdInstant,
+    ) -> Result<SchedulingResponse, KvSchedulerError> {
+        let classified_request = self.classify_request(&request).await?;
         let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
         let lifecycle_lease = self
             .queue
@@ -320,7 +348,13 @@ where
 
         let mut lifecycle_lease = self
             .queue
-            .enqueue_with_block_hashes_and_lease(request, block_hashes, lifecycle_lease)
+            .enqueue_classified_with_block_hashes_and_lease(
+                request,
+                block_hashes,
+                lifecycle_lease,
+                classified_request,
+                ingress_at,
+            )
             .await;
 
         let response = resp_rx
@@ -330,6 +364,41 @@ where
             lease.disarm();
         }
         response
+    }
+
+    async fn classify_request(
+        &self,
+        request: &ScheduleRequest,
+    ) -> Result<Option<ClassifyRequest>, KvSchedulerError> {
+        if matches!(request.mode, ScheduleMode::QueryOnly { .. }) {
+            return Ok(None);
+        }
+        let Some(request_classifier) = self.request_classifier.get() else {
+            return Ok(None);
+        };
+        request_classifier
+            .classify_with(request.mode.request_id(), || {
+                self.queue.classify_request(request)
+            })
+            .await
+            .map(Some)
+    }
+
+    /// Begin response-path lifecycle tracking when a classifier is configured.
+    #[doc(hidden)]
+    pub fn begin_request_lifecycle(
+        &self,
+        request_id: &str,
+    ) -> Result<Option<RequestLifecycle>, KvSchedulerError> {
+        self.request_classifier
+            .get()
+            .map(|classifier| classifier.begin_request(request_id))
+            .transpose()
+    }
+
+    #[doc(hidden)]
+    pub fn has_request_classifier(&self) -> bool {
+        self.request_classifier.get().is_some()
     }
 
     /// Select a worker from current scheduler state without queue admission or booking.

--- a/lib/kv-router/src/scheduling/mod.rs
+++ b/lib/kv-router/src/scheduling/mod.rs
@@ -12,6 +12,7 @@ pub mod policy_queue;
 pub mod prefill_load;
 pub mod queue;
 mod queue_admission;
+mod request_classifier;
 pub mod selector;
 
 mod worker_selection_config;
@@ -38,4 +39,9 @@ pub use prefill_load::{
     prefill_load_hint_from_effective_tokens,
 };
 pub use queue_admission::{RequestProgress, RequestProgressUpdater, WorkerPlacement};
+#[doc(hidden)]
+pub use request_classifier::RequestLifecycle;
+pub use request_classifier::{
+    ClassifyError, ClassifyEvent, ClassifyFuture, ClassifyRequest, RequestClassifier,
+};
 pub use types::*;

--- a/lib/kv-router/src/scheduling/policy_config.rs
+++ b/lib/kv-router/src/scheduling/policy_config.rs
@@ -63,7 +63,6 @@ impl PolicyClassConfig {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PolicyProfile {
     classes: Vec<PolicyClassConfig>,
-    class_indices: HashMap<String, usize>,
     classifier: PolicyClassifier,
 }
 
@@ -102,6 +101,21 @@ impl FamilyBucketClassifier {
         let family_index = requested
             .and_then(|name| self.family_indices.get(name).copied())
             .unwrap_or(self.default_family_index);
+        self.class_index_for_family(family_index, uncached_tokens)
+    }
+
+    fn strict_class_index(&self, requested: &str, uncached_tokens: usize) -> Option<usize> {
+        self.explicit_class_indices
+            .get(requested)
+            .copied()
+            .or_else(|| {
+                self.family_indices
+                    .get(requested)
+                    .map(|family_index| self.class_index_for_family(*family_index, uncached_tokens))
+            })
+    }
+
+    fn class_index_for_family(&self, family_index: usize, uncached_tokens: usize) -> usize {
         let bucket_index = self
             .buckets
             .partition_point(|bucket| bucket.min_tokens <= uncached_tokens)
@@ -126,7 +140,6 @@ impl PolicyProfile {
             cached_token_queue_limit_per_worker: None,
         };
         Self {
-            class_indices: HashMap::from([(class.name.clone(), 0)]),
             classes: vec![class],
             classifier: PolicyClassifier::SyntheticSingle { class_index: 0 },
         }
@@ -163,8 +176,20 @@ impl PolicyProfile {
         &self.classes[index]
     }
 
-    pub(crate) fn class_index_by_name(&self, name: &str) -> Option<usize> {
-        self.class_indices.get(name).copied()
+    /// Strictly resolves a classifier-supplied family or explicit class.
+    pub(crate) fn resolve_class_index_strict(
+        &self,
+        requested: &str,
+        uncached_tokens: usize,
+    ) -> Option<usize> {
+        match &self.classifier {
+            PolicyClassifier::SyntheticSingle { class_index } => {
+                (self.classes[*class_index].name == requested).then_some(*class_index)
+            }
+            PolicyClassifier::FamilyBucket(classifier) => {
+                classifier.strict_class_index(requested, uncached_tokens)
+            }
+        }
     }
 }
 
@@ -432,14 +457,8 @@ fn resolve_profile(
         }
     }
 
-    let class_indices = classes
-        .iter()
-        .enumerate()
-        .map(|(index, class)| (class.name.clone(), index))
-        .collect();
     Ok(PolicyProfile {
         classes,
-        class_indices,
         classifier: PolicyClassifier::FamilyBucket(FamilyBucketClassifier {
             default_family_index,
             family_indices,

--- a/lib/kv-router/src/scheduling/policy_config.rs
+++ b/lib/kv-router/src/scheduling/policy_config.rs
@@ -63,6 +63,7 @@ impl PolicyClassConfig {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PolicyProfile {
     classes: Vec<PolicyClassConfig>,
+    class_indices: HashMap<String, usize>,
     classifier: PolicyClassifier,
 }
 
@@ -125,6 +126,7 @@ impl PolicyProfile {
             cached_token_queue_limit_per_worker: None,
         };
         Self {
+            class_indices: HashMap::from([(class.name.clone(), 0)]),
             classes: vec![class],
             classifier: PolicyClassifier::SyntheticSingle { class_index: 0 },
         }
@@ -159,6 +161,10 @@ impl PolicyProfile {
 
     pub fn class(&self, index: usize) -> &PolicyClassConfig {
         &self.classes[index]
+    }
+
+    pub(crate) fn class_index_by_name(&self, name: &str) -> Option<usize> {
+        self.class_indices.get(name).copied()
     }
 }
 
@@ -426,8 +432,14 @@ fn resolve_profile(
         }
     }
 
+    let class_indices = classes
+        .iter()
+        .enumerate()
+        .map(|(index, class)| (class.name.clone(), index))
+        .collect();
     Ok(PolicyProfile {
         classes,
+        class_indices,
         classifier: PolicyClassifier::FamilyBucket(FamilyBucketClassifier {
             default_family_index,
             family_indices,

--- a/lib/kv-router/src/scheduling/policy_queue.rs
+++ b/lib/kv-router/src/scheduling/policy_queue.rs
@@ -3,6 +3,7 @@
 
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, BinaryHeap};
+use std::time::Instant;
 
 use ordered_float::OrderedFloat;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -75,7 +76,18 @@ pub struct PolicyQueueStats {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct QueuePriority {
     strict_priority: u32,
+    due_at: Option<Instant>,
     policy_score: OrderedFloat<f64>,
+}
+
+#[inline]
+fn cmp_due_time(lhs: Option<Instant>, rhs: Option<Instant>) -> Ordering {
+    match (lhs, rhs) {
+        (Some(lhs), Some(rhs)) => rhs.cmp(&lhs),
+        (Some(_), None) => Ordering::Greater,
+        (None, Some(_)) => Ordering::Less,
+        (None, None) => Ordering::Equal,
+    }
 }
 
 #[inline]
@@ -85,9 +97,12 @@ fn cmp_queue_order(
     rhs_priority: QueuePriority,
     rhs_enqueue_seq: u64,
 ) -> Ordering {
-    lhs_priority
-        .strict_priority
-        .cmp(&rhs_priority.strict_priority)
+    cmp_due_time(lhs_priority.due_at, rhs_priority.due_at)
+        .then_with(|| {
+            lhs_priority
+                .strict_priority
+                .cmp(&rhs_priority.strict_priority)
+        })
         .then_with(|| lhs_priority.policy_score.cmp(&rhs_priority.policy_score))
         .then_with(|| rhs_enqueue_seq.cmp(&lhs_enqueue_seq))
 }
@@ -107,6 +122,10 @@ impl<T> PolicyQueueEntry<T> {
 
     pub fn snapshot(&self) -> QueueSnapshot {
         self.snapshot
+    }
+
+    pub(crate) fn due_at(&self) -> Option<Instant> {
+        self.priority.due_at
     }
 
     pub fn payload(&self) -> &T {
@@ -132,11 +151,12 @@ impl<T> PartialEq for PolicyQueueEntry<T> {
 
 impl<T> Ord for PolicyQueueEntry<T> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.priority
-            .strict_priority
-            .cmp(&other.priority.strict_priority)
-            .then_with(|| self.priority.policy_score.cmp(&other.priority.policy_score))
-            .then_with(|| other.enqueue_seq.cmp(&self.enqueue_seq))
+        cmp_queue_order(
+            self.priority,
+            self.enqueue_seq,
+            other.priority,
+            other.enqueue_seq,
+        )
     }
 }
 
@@ -473,6 +493,21 @@ impl<T> PolicyQueue<T> {
         })
     }
 
+    pub(crate) fn next_due_at(&self) -> Option<Instant> {
+        self.classes
+            .iter()
+            .flat_map(|class| {
+                class.pending.peek().into_iter().chain(
+                    class
+                        .ready_by_worker
+                        .values()
+                        .filter_map(|ready| ready.peek()),
+                )
+            })
+            .filter_map(PolicyQueueEntry::due_at)
+            .min()
+    }
+
     pub fn class_count(&self) -> usize {
         self.classes.len()
     }
@@ -527,6 +562,32 @@ impl<T> PolicyQueue<T> {
         placement: WorkerPlacement,
         payload: T,
     ) -> Result<(), (QueueRejection, T)> {
+        self.enqueue_with_due_at(
+            class_index,
+            worker_count,
+            snapshot,
+            arrival_offset_secs,
+            priority_jump,
+            strict_priority,
+            None,
+            placement,
+            payload,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn enqueue_with_due_at(
+        &mut self,
+        class_index: usize,
+        worker_count: usize,
+        snapshot: QueueSnapshot,
+        arrival_offset_secs: f64,
+        priority_jump: f64,
+        strict_priority: u32,
+        due_at: Option<Instant>,
+        placement: WorkerPlacement,
+        payload: T,
+    ) -> Result<(), (QueueRejection, T)> {
         let class = &mut self.classes[class_index];
         if let Some(rejection) = queue_rejection(class, worker_count) {
             return Err((rejection, payload));
@@ -538,6 +599,7 @@ impl<T> PolicyQueue<T> {
             arrival_offset_secs,
             priority_jump,
             strict_priority,
+            due_at,
             class.config.queue_policy,
             self.next_enqueue_seq,
             payload,
@@ -747,6 +809,7 @@ fn make_entry<T>(
     arrival_offset_secs: f64,
     priority_jump: f64,
     strict_priority: u32,
+    due_at: Option<Instant>,
     queue_policy: RouterQueuePolicy,
     enqueue_seq: u64,
     payload: T,
@@ -757,6 +820,7 @@ fn make_entry<T>(
         class_index,
         priority: QueuePriority {
             strict_priority,
+            due_at,
             policy_score: OrderedFloat(policy_score),
         },
         enqueue_seq,
@@ -965,6 +1029,80 @@ policy_classes:
         assert_eq!(
             queue.pop_next(|_, _, _| true).unwrap().into_payload(),
             "keep"
+        );
+    }
+
+    #[test]
+    fn earliest_due_request_precedes_fcfs_arrival_within_a_class() {
+        let mut queue = PolicyQueue::new(admission_profile());
+        let now = Instant::now();
+        queue
+            .enqueue_with_due_at(
+                0,
+                1,
+                QueueSnapshot::new(1, 0),
+                0.0,
+                0.0,
+                0,
+                Some(now + std::time::Duration::from_secs(20)),
+                WorkerPlacement::Any,
+                "later-due",
+            )
+            .unwrap();
+        queue
+            .enqueue_with_due_at(
+                0,
+                1,
+                QueueSnapshot::new(1, 0),
+                1.0,
+                0.0,
+                0,
+                Some(now + std::time::Duration::from_secs(10)),
+                WorkerPlacement::Any,
+                "earlier-due",
+            )
+            .unwrap();
+
+        assert_eq!(
+            queue.pop_next(|_, _, _| true).unwrap().into_payload(),
+            "earlier-due"
+        );
+    }
+
+    #[test]
+    fn earliest_due_request_precedes_strict_priority_within_a_class() {
+        let mut queue = PolicyQueue::new(admission_profile());
+        let now = Instant::now();
+        queue
+            .enqueue_with_due_at(
+                0,
+                1,
+                QueueSnapshot::new(1, 0),
+                0.0,
+                0.0,
+                10,
+                Some(now + std::time::Duration::from_secs(20)),
+                WorkerPlacement::Any,
+                "high-priority-later-due",
+            )
+            .unwrap();
+        queue
+            .enqueue_with_due_at(
+                0,
+                1,
+                QueueSnapshot::new(1, 0),
+                1.0,
+                0.0,
+                0,
+                Some(now + std::time::Duration::from_secs(10)),
+                WorkerPlacement::Any,
+                "low-priority-earlier-due",
+            )
+            .unwrap();
+
+        assert_eq!(
+            queue.pop_next(|_, _, _| true).unwrap().into_payload(),
+            "low-priority-earlier-due"
         );
     }
 

--- a/lib/kv-router/src/scheduling/policy_queue.rs
+++ b/lib/kv-router/src/scheduling/policy_queue.rs
@@ -438,6 +438,7 @@ pub struct PolicyQueue<T> {
     carry_class: Option<usize>,
     next_enqueue_seq: u64,
     pending_count: usize,
+    due_time_count: usize,
     candidates: Vec<Option<DispatchCandidate>>,
 }
 
@@ -464,6 +465,7 @@ impl<T> PolicyQueue<T> {
             carry_class: None,
             next_enqueue_seq: 0,
             pending_count: 0,
+            due_time_count: 0,
             candidates: vec![None; class_count],
         }
     }
@@ -494,6 +496,9 @@ impl<T> PolicyQueue<T> {
     }
 
     pub(crate) fn next_due_at(&self) -> Option<Instant> {
+        if self.due_time_count == 0 {
+            return None;
+        }
         self.classes
             .iter()
             .flat_map(|class| {
@@ -608,6 +613,7 @@ impl<T> PolicyQueue<T> {
         add_stats(&mut class.stats, snapshot);
         class.push_ready(placement, entry);
         self.pending_count += 1;
+        self.due_time_count += usize::from(due_at.is_some());
         Ok(())
     }
 
@@ -664,6 +670,7 @@ impl<T> PolicyQueue<T> {
         for entry in &removed {
             subtract_stats(&mut class.stats, entry.snapshot);
             self.pending_count -= 1;
+            self.due_time_count -= usize::from(entry.due_at().is_some());
         }
         if class.ready_is_empty() {
             class.deficit = 0;
@@ -793,6 +800,7 @@ impl<T> PolicyQueue<T> {
             .saturating_sub(entry.snapshot.scheduling_cost_tokens);
         subtract_stats(&mut class.stats, entry.snapshot);
         self.pending_count -= 1;
+        self.due_time_count -= usize::from(entry.due_at().is_some());
         if class.ready_is_empty() {
             class.deficit = 0;
         } else {
@@ -1067,6 +1075,50 @@ policy_classes:
             queue.pop_next(|_, _, _| true).unwrap().into_payload(),
             "earlier-due"
         );
+        assert_eq!(queue.due_time_count, 1);
+        assert_eq!(
+            queue.pop_next(|_, _, _| true).unwrap().into_payload(),
+            "later-due"
+        );
+        assert_eq!(queue.due_time_count, 0);
+        assert_eq!(queue.next_due_at(), None);
+    }
+
+    #[test]
+    fn deadline_count_restores_the_no_deadline_fast_path_after_removal() {
+        let mut queue = PolicyQueue::new(admission_profile());
+        let due_at = Instant::now() + std::time::Duration::from_secs(10);
+        queue
+            .enqueue(
+                0,
+                2,
+                QueueSnapshot::new(1, 0),
+                0.0,
+                0.0,
+                0,
+                WorkerPlacement::Any,
+                "no-deadline",
+            )
+            .unwrap();
+        queue
+            .enqueue_with_due_at(
+                0,
+                2,
+                QueueSnapshot::new(1, 0),
+                1.0,
+                0.0,
+                0,
+                Some(due_at),
+                WorkerPlacement::Exact(WorkerWithDpRank::new(1, 0)),
+                "deadline",
+            )
+            .unwrap();
+
+        assert_eq!(queue.next_due_at(), Some(due_at));
+        queue.retain(|payload| *payload != "deadline");
+        assert_eq!(queue.due_time_count, 0);
+        assert_eq!(queue.next_due_at(), None);
+        assert_eq!(queue.pending_count(), 1);
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -1159,6 +1159,12 @@ impl<
                 decay_now,
             )
             .await;
+            let admit_now = Instant::now();
+            if queued.due_at.is_some_and(|due_at| due_at <= admit_now) {
+                let mut request = popped.into_payload().request;
+                request.respond(Err(KvSchedulerError::DueTimeExpired));
+                continue;
+            }
             let wait_ms = queued.enqueue_at.elapsed().as_millis() as u64;
             if let Some(snapshot) = refreshed {
                 tracing::info!(
@@ -1173,7 +1179,6 @@ impl<
                     None
                 };
             }
-            let admit_now = Instant::now();
             let class_index = popped.class_index();
             let class = self.profile.class(class_index);
             let queued = popped.into_payload();
@@ -2194,6 +2199,62 @@ policy_classes:
             Err(KvSchedulerError::DueTimeExpired)
         ));
         assert_eq!(queue.pending_count(), 0);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn queued_classified_request_expires_during_overlap_refresh() {
+        let block_size = 16;
+        let isl = 64;
+        let refresher = Arc::new(BlockingRefresher::new(RefreshedOverlap::default()));
+        let (queue, slots) = make_queue_with_blocking_refresher(
+            1,
+            block_size,
+            isl,
+            Some(0.0),
+            Arc::clone(&refresher),
+            ADMISSION_CHANNEL_CAPACITY,
+        );
+
+        let (active, active_rx) = make_request("active", isl);
+        queue.enqueue(active).await;
+        active_rx.await.unwrap().unwrap();
+
+        let (queued, queued_rx) = make_request("due-during-refresh", isl);
+        let ingress_at = StdInstant::now();
+        let mut classified = queue.classify_request(&classify_source(&queued));
+        classified.set_due_at(ingress_at + Duration::from_secs(12));
+        queue
+            .enqueue_classified_with_block_hashes_and_lease(
+                queued,
+                Some(vec![LocalBlockHash(42)]),
+                None,
+                Some(classified),
+                ingress_at,
+            )
+            .await;
+        assert_eq!(queue.pending_count(), 1);
+
+        slots
+            .mark_prefill_completed(&"active".to_string(), decay_now())
+            .unwrap();
+        slots.free(&"active".to_string(), decay_now()).unwrap();
+        tokio::time::advance(Duration::from_secs(11)).await;
+
+        let update = {
+            let queue = Arc::clone(&queue);
+            tokio::spawn(async move { queue.update().await })
+        };
+        refresher.wait_for_calls(1).await;
+        tokio::time::advance(Duration::from_secs(2)).await;
+        refresher.release_one();
+        update.await.unwrap();
+
+        assert!(matches!(
+            queued_rx.await.unwrap(),
+            Err(KvSchedulerError::DueTimeExpired)
+        ));
+        assert_eq!(queue.pending_count(), 0);
+        slots.assert_completely_drained(decay_now());
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -678,10 +678,11 @@ impl<
             return Err(KvSchedulerError::DueTimeExpired);
         }
 
+        let snapshot = QueueSnapshot::new(request.isl_tokens, initial_cached_tokens);
         let class_index_override = policy_class
             .map(|policy_class| {
                 self.profile
-                    .class_index_by_name(&policy_class)
+                    .resolve_class_index_strict(&policy_class, snapshot.uncached_tokens)
                     .ok_or_else(|| {
                         KvSchedulerError::InvalidClassificationMetadata(format!(
                             "unknown policy class {policy_class:?}"
@@ -690,7 +691,6 @@ impl<
             })
             .transpose()?;
 
-        let snapshot = QueueSnapshot::new(request.isl_tokens, initial_cached_tokens);
         let class_index = class_index_override.unwrap_or_else(|| {
             self.profile
                 .resolve_class_index(request.policy_class.as_deref(), snapshot.uncached_tokens)
@@ -2128,38 +2128,83 @@ mod tests {
 default_policy_family: latency
 uncached_isl_buckets:
   - min_tokens: 0
-    bucket: all
+    bucket: cached
+  - min_tokens: 32
+    bucket: uncached
 policy_classes:
-  - name: latency
+  - name: latency_cached
     policy_family: latency
-    cache_bucket: all
+    cache_bucket: cached
     quantum: 1
-  - name: bulk
+  - name: latency_uncached
+    policy_family: latency
+    cache_bucket: uncached
+    quantum: 1
+  - name: bulk_cached
     policy_family: bulk
-    cache_bucket: all
+    cache_bucket: cached
+    quantum: 1
+  - name: bulk_uncached
+    policy_family: bulk
+    cache_bucket: uncached
+    quantum: 1
+  - name: custom_priority
     quantum: 1
 "#,
         );
         let (queue, _slots) = make_queue_with_profile(1, 16, 64, profile);
-        let (request, _rx) = make_request("classified", 64);
+        let (mut request, _rx) = make_request("classified", 16);
+        request.policy_class = Some("latency".to_string());
         let ingress_at = StdInstant::now();
         let due_at = ingress_at + Duration::from_secs(20);
 
         let mut classified = queue.classify_request(&classify_source(&request));
-        classified.set_policy_class("bulk");
+        let initial_policy_class = classified.policy_class().unwrap().to_string();
+        classified.set_policy_class(initial_policy_class);
         classified.set_due_at(due_at);
         classified.set_scheduling_cost_tokens(7);
         let metadata = queue
             .validate_classification(&request, classified, ingress_at)
             .unwrap();
-        assert_eq!(queue.profile.class(metadata.class_index).name, "bulk");
+        assert_eq!(
+            queue.profile.class(metadata.class_index).name,
+            "latency_cached"
+        );
         assert_eq!(metadata.snapshot.scheduling_cost_tokens, 7);
         assert_eq!(metadata.due_at.map(Instant::into_std), Some(due_at));
+
+        let (request, _rx) = make_request("bulk", 64);
+        let mut bulk = queue.classify_request(&classify_source(&request));
+        bulk.set_policy_class("bulk");
+        let metadata = queue
+            .validate_classification(&request, bulk, ingress_at)
+            .unwrap();
+        assert_eq!(
+            queue.profile.class(metadata.class_index).name,
+            "bulk_uncached"
+        );
+
+        let mut explicit = queue.classify_request(&classify_source(&request));
+        explicit.set_policy_class("custom_priority");
+        let metadata = queue
+            .validate_classification(&request, explicit, ingress_at)
+            .unwrap();
+        assert_eq!(
+            queue.profile.class(metadata.class_index).name,
+            "custom_priority"
+        );
 
         let mut unknown_class = queue.classify_request(&classify_source(&request));
         unknown_class.set_policy_class("missing");
         assert!(matches!(
             queue.validate_classification(&request, unknown_class, ingress_at),
+            Err(KvSchedulerError::InvalidClassificationMetadata(_))
+        ));
+
+        let mut physical_class = queue.classify_request(&classify_source(&request));
+        physical_class.set_policy_class("latency_cached");
+        assert!(matches!(
+            queue.validate_classification(&request, physical_class, ingress_at),
             Err(KvSchedulerError::InvalidClassificationMetadata(_))
         ));
 

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::{Arc, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant as StdInstant};
 
 use crossbeam_queue::SegQueue;
 use tokio::sync::{mpsc, oneshot, watch};
@@ -21,11 +21,12 @@ use super::policy_config::{PolicyClassConfig, PolicyProfile};
 use super::policy_queue::{PolicyQueue, QueueSnapshot};
 use super::prefill_load::{PrefillLoadEstimator, effective_prefill_tokens};
 use super::queue_admission::WorkerPlacement;
+use super::request_classifier::ClassifyRequest;
 use super::selector::{DefaultWorkerSelector, WorkerSelectionInput, WorkerSelector};
 use super::types::{
     AdvisorySchedulingResponse, AdvisoryWorkerLoad, KvSchedulerError, NonMaxOverlapSelection,
-    NonMaxOverlapSelectionObserver, OverloadedWorkerProvider, SchedulingContext, SchedulingRequest,
-    SchedulingResponse, WorkerAvailabilityProvider,
+    NonMaxOverlapSelectionObserver, OverloadedWorkerProvider, ScheduleRequest, SchedulingContext,
+    SchedulingRequest, SchedulingResponse, WorkerAvailabilityProvider,
 };
 use crate::protocols::{
     LocalBlockHash, PrefillLoadHint, WorkerConfigLike, WorkerId, WorkerSelectionResult,
@@ -55,7 +56,16 @@ pub struct ClassQueueStats {
 struct QueuedRequest {
     request: SchedulingRequest,
     enqueue_at: Instant,
+    due_at: Option<Instant>,
     block_hashes: Option<Vec<LocalBlockHash>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct QueueMetadata {
+    class_index: usize,
+    snapshot: QueueSnapshot,
+    due_at: Option<Instant>,
+    arrival_offset_secs: f64,
 }
 
 struct SelectedWorkerForRequest {
@@ -126,6 +136,7 @@ enum AdmissionCommand {
     Enqueue {
         request: SchedulingRequest,
         block_hashes: Option<Vec<LocalBlockHash>>,
+        queue_metadata: Option<QueueMetadata>,
         lease: Option<Box<RequestLifecycleLease>>,
         ack_tx: oneshot::Sender<Option<Box<RequestLifecycleLease>>>,
     },
@@ -259,6 +270,8 @@ pub struct SchedulerQueue<
     class_counters: Arc<Vec<ClassQueueCounters>>,
     slots: Arc<ActiveSequencesMultiWorker<P>>,
     workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
+    profile: PolicyProfile,
+    start_time: StdInstant,
     queueing_enabled: bool,
     supports_overlap_refresh: bool,
     non_max_overlap_selection_observer: Arc<OnceLock<NonMaxOverlapSelectionObserver>>,
@@ -385,17 +398,18 @@ impl<
         let (admission_tx, admission_rx) = mpsc::channel(admission_channel_capacity);
         let cleanup = Arc::new(AdmissionCleanup::default());
         let non_max_overlap_selection_observer = Arc::new(OnceLock::new());
+        let start_time = StdInstant::now();
         let actor = SchedulerQueueActor {
             pending,
             cleanup: Arc::clone(&cleanup),
             queueing_enabled,
-            profile,
+            profile: profile.clone(),
             pending_count: Arc::clone(&pending_count),
             pending_isl_tokens: Arc::clone(&pending_isl_tokens),
             class_counters: Arc::clone(&class_counters),
             slots: Arc::clone(&slots),
             workers_with_configs: workers_with_configs.clone(),
-            start_time: Instant::now(),
+            start_time: Instant::from_std(start_time),
             block_size,
             selector,
             prefill_load_estimator,
@@ -414,6 +428,8 @@ impl<
             class_counters,
             slots,
             workers_with_configs,
+            profile,
+            start_time,
             queueing_enabled,
             supports_overlap_refresh: overlap_refresh_after.is_some(),
             non_max_overlap_selection_observer,
@@ -539,9 +555,27 @@ impl<
 
     pub(crate) async fn enqueue_with_block_hashes_and_lease(
         &self,
+        request: SchedulingRequest,
+        block_hashes: Option<Vec<LocalBlockHash>>,
+        lease: Option<Box<RequestLifecycleLease>>,
+    ) -> Option<Box<RequestLifecycleLease>> {
+        self.enqueue_classified_with_block_hashes_and_lease(
+            request,
+            block_hashes,
+            lease,
+            None,
+            StdInstant::now(),
+        )
+        .await
+    }
+
+    pub(crate) async fn enqueue_classified_with_block_hashes_and_lease(
+        &self,
         mut request: SchedulingRequest,
         block_hashes: Option<Vec<LocalBlockHash>>,
         lease: Option<Box<RequestLifecycleLease>>,
+        classified_request: Option<ClassifyRequest>,
+        ingress_at: StdInstant,
     ) -> Option<Box<RequestLifecycleLease>> {
         if self.queueing_enabled && lease.is_none() && request.mode.lifecycle_request_id().is_some()
         {
@@ -550,6 +584,17 @@ impl<
             )));
             return None;
         }
+
+        let queue_metadata = match classified_request
+            .map(|classified| self.validate_classification(&request, classified, ingress_at))
+            .transpose()
+        {
+            Ok(classification) => classification,
+            Err(error) => {
+                request.respond(Err(error));
+                return None;
+            }
+        };
 
         let eligibility = request.eligibility();
 
@@ -562,6 +607,7 @@ impl<
         let command = AdmissionCommand::Enqueue {
             request,
             block_hashes: self.prepare_block_hashes_for_refresh(block_hashes),
+            queue_metadata,
             lease,
             ack_tx,
         };
@@ -581,6 +627,88 @@ impl<
                 None
             }
         }
+    }
+
+    pub(crate) fn classify_request(&self, request: &ScheduleRequest) -> ClassifyRequest {
+        let workers = self.workers_with_configs.borrow();
+        let eligibility = request.eligibility();
+        let cached_tokens = match eligibility.pinned_worker() {
+            Some(worker) => request.effective_cached_tokens_for(worker),
+            None => request
+                .overlap
+                .effective_cached_tokens
+                .iter()
+                .filter(|(worker, _)| {
+                    workers
+                        .get(&worker.worker_id)
+                        .is_some_and(|config| eligibility.allows_worker(worker.worker_id, config))
+                })
+                .map(|(_, cached_tokens)| *cached_tokens)
+                .max()
+                .unwrap_or(0),
+        };
+        let mut classification = ClassifyRequest::new(request.isl_tokens, cached_tokens);
+        if let Some(request_id) = request.mode.request_id() {
+            classification = classification.with_request_id(request_id);
+        }
+        if let Some(policy_class) = request.policy_class.as_deref() {
+            classification = classification.with_initial_policy_class(policy_class);
+        }
+        if let Some(session_context) = request.session_context.clone() {
+            classification = classification.with_session_context(session_context);
+        }
+        classification
+    }
+
+    fn validate_classification(
+        &self,
+        request: &SchedulingRequest,
+        classified_request: ClassifyRequest,
+        ingress_at: StdInstant,
+    ) -> Result<QueueMetadata, KvSchedulerError> {
+        let (policy_class, due_at, scheduling_cost_tokens, initial_cached_tokens) =
+            classified_request.into_queue_inputs();
+
+        if scheduling_cost_tokens == Some(0) {
+            return Err(KvSchedulerError::InvalidClassificationMetadata(
+                "scheduling cost must be greater than zero".to_string(),
+            ));
+        }
+        if due_at.is_some_and(|due_at| due_at <= StdInstant::now()) {
+            return Err(KvSchedulerError::DueTimeExpired);
+        }
+
+        let class_index_override = policy_class
+            .map(|policy_class| {
+                self.profile
+                    .class_index_by_name(&policy_class)
+                    .ok_or_else(|| {
+                        KvSchedulerError::InvalidClassificationMetadata(format!(
+                            "unknown policy class {policy_class:?}"
+                        ))
+                    })
+            })
+            .transpose()?;
+
+        let snapshot = QueueSnapshot::new(request.isl_tokens, initial_cached_tokens);
+        let class_index = class_index_override.unwrap_or_else(|| {
+            self.profile
+                .resolve_class_index(request.policy_class.as_deref(), snapshot.uncached_tokens)
+        });
+        let snapshot = QueueSnapshot {
+            scheduling_cost_tokens: scheduling_cost_tokens
+                .unwrap_or(snapshot.scheduling_cost_tokens),
+            ..snapshot
+        };
+
+        Ok(QueueMetadata {
+            class_index,
+            snapshot,
+            due_at: due_at.map(Instant::from_std),
+            arrival_offset_secs: ingress_at
+                .saturating_duration_since(self.start_time)
+                .as_secs_f64(),
+        })
     }
 
     pub(crate) fn new_request_lifecycle_lease(
@@ -689,7 +817,22 @@ impl<
 {
     async fn run(mut self, mut rx: mpsc::Receiver<AdmissionCommand>) {
         let mut commands_since_cleanup = 0usize;
-        while let Some(command) = rx.recv().await {
+        loop {
+            let command = match self.pending.next_due_at() {
+                Some(due_at) => {
+                    tokio::select! {
+                        command = rx.recv() => command,
+                        _ = tokio::time::sleep_until(due_at.into()) => {
+                            self.handle_update(None).await;
+                            continue;
+                        }
+                    }
+                }
+                None => rx.recv().await,
+            };
+            let Some(command) = command else {
+                break;
+            };
             let drain_cleanup = self.queueing_enabled && {
                 commands_since_cleanup += 1;
                 let drain_cleanup = rx.is_empty() || commands_since_cleanup == 256;
@@ -702,6 +845,7 @@ impl<
                 AdmissionCommand::Enqueue {
                     request,
                     block_hashes,
+                    queue_metadata,
                     mut lease,
                     ack_tx,
                 } => {
@@ -709,7 +853,7 @@ impl<
                         .as_ref()
                         .and_then(|_| request.mode.tracked_request_id().map(str::to_owned));
                     let (enqueue_ready, owns_lifecycle) =
-                        self.handle_enqueue(request, block_hashes);
+                        self.handle_enqueue(request, block_hashes, queue_metadata);
                     if let Some(lease) = lease.as_mut()
                         && owns_lifecycle
                     {
@@ -764,24 +908,51 @@ impl<
 
     fn handle_enqueue(
         &mut self,
-        request: SchedulingRequest,
+        mut request: SchedulingRequest,
         block_hashes: Option<Vec<LocalBlockHash>>,
+        queue_metadata: Option<QueueMetadata>,
     ) -> (bool, bool) {
         let decay_now = Instant::now();
-        // Synthetic and explicit selections avoid cache work. Family classification
-        // samples overlap once and reuses it if the request enters queue storage.
-        let (class_index, snapshot) = if let Some(class_index) = self
-            .profile
-            .direct_class_index(request.policy_class.as_deref())
-        {
-            (class_index, None)
-        } else {
-            let workers = self.workers_with_configs.borrow();
-            let snapshot = Self::snapshot_for_with(&request, &workers);
-            let class_index = self
-                .profile
-                .resolve_class_index(request.policy_class.as_deref(), snapshot.uncached_tokens);
-            (class_index, Some(snapshot))
+        let (class_index, snapshot, due_at, arrival_offset) = match queue_metadata {
+            Some(queue_metadata) => {
+                if queue_metadata
+                    .due_at
+                    .is_some_and(|due_at| due_at <= decay_now)
+                {
+                    request.respond(Err(KvSchedulerError::DueTimeExpired));
+                    return (false, false);
+                }
+                (
+                    queue_metadata.class_index,
+                    Some(queue_metadata.snapshot),
+                    queue_metadata.due_at,
+                    queue_metadata.arrival_offset_secs,
+                )
+            }
+            None => {
+                // Synthetic and explicit selections avoid cache work. Family classification
+                // samples overlap once and reuses it if the request enters queue storage.
+                let (class_index, snapshot) = if let Some(class_index) = self
+                    .profile
+                    .direct_class_index(request.policy_class.as_deref())
+                {
+                    (class_index, None)
+                } else {
+                    let workers = self.workers_with_configs.borrow();
+                    let snapshot = Self::snapshot_for_with(&request, &workers);
+                    let class_index = self.profile.resolve_class_index(
+                        request.policy_class.as_deref(),
+                        snapshot.uncached_tokens,
+                    );
+                    (class_index, Some(snapshot))
+                };
+                (
+                    class_index,
+                    snapshot,
+                    None,
+                    self.start_time.elapsed().as_secs_f64(),
+                )
+            }
         };
         let class = self.profile.class(class_index);
         let should_queue = self.should_queue(class_index, class, || {
@@ -793,7 +964,6 @@ impl<
 
         let snapshot = snapshot.unwrap_or_else(|| self.snapshot_for(&request));
         tracing::debug!(policy_class = class.name, "queueing request");
-        let arrival_offset = self.start_time.elapsed().as_secs_f64();
         let priority_jump = request.priority_jump;
         let strict_priority = request.strict_priority;
         let placement = request
@@ -802,16 +972,18 @@ impl<
         let queued = QueuedRequest {
             request,
             enqueue_at: decay_now,
+            due_at,
             block_hashes,
         };
         let worker_count = self.workers_with_configs.borrow().len();
-        if let Err((rejection, queued)) = self.pending.enqueue(
+        if let Err((rejection, queued)) = self.pending.enqueue_with_due_at(
             class_index,
             worker_count,
             snapshot,
             arrival_offset,
             priority_jump,
             strict_priority,
+            due_at.map(Instant::into_std),
             placement,
             queued,
         ) {
@@ -891,15 +1063,17 @@ impl<
     }
 
     fn has_dispatchable_ready_head(&self) -> bool {
-        let active_tokens = self.slots.active_tokens(Instant::now());
+        let now = Instant::now();
+        let active_tokens = self.slots.active_tokens(now);
         let configs = self.workers_with_configs.borrow();
         self.pending.any_ready_head(|_, class, queued| {
-            !Self::all_workers_prefill_busy_with(
-                &active_tokens,
-                &configs,
-                class,
-                queued.request.eligibility(),
-            )
+            queued.due_at.is_some_and(|due_at| due_at <= now)
+                || !Self::all_workers_prefill_busy_with(
+                    &active_tokens,
+                    &configs,
+                    class,
+                    queued.request.eligibility(),
+                )
         })
     }
 
@@ -934,12 +1108,13 @@ impl<
                     // TODO: This preserves head-of-line blocking within each policy
                     // class. A blocked constrained head can stall later entries in
                     // that class until a bounded non-HOL policy is introduced.
-                    !Self::all_workers_prefill_busy_with(
-                        &active_tokens,
-                        &configs,
-                        class,
-                        queued.request.eligibility(),
-                    )
+                    queued.due_at.is_some_and(|due_at| due_at <= decay_now)
+                        || !Self::all_workers_prefill_busy_with(
+                            &active_tokens,
+                            &configs,
+                            class,
+                            queued.request.eligibility(),
+                        )
                 })
             };
             let Some(mut popped) = popped else {
@@ -962,6 +1137,14 @@ impl<
             self.pending_isl_tokens
                 .fetch_sub(snapshot.raw_isl_tokens, AtomicOrdering::Relaxed);
             self.subtract_class_counters(popped.class_index(), snapshot);
+            if popped
+                .due_at()
+                .is_some_and(|due_at| due_at <= decay_now.into_std())
+            {
+                let mut request = popped.into_payload().request;
+                request.respond(Err(KvSchedulerError::DueTimeExpired));
+                continue;
+            }
             let queued = popped.payload_mut();
             // NOTE: Overlap refresh is expected to be very short. We intentionally
             // accept load crossing the class threshold during this await: busy
@@ -1908,6 +2091,109 @@ mod tests {
             resp_tx: Some(tx),
         };
         (req, rx)
+    }
+
+    fn classify_source(request: &SchedulingRequest) -> ScheduleRequest {
+        ScheduleRequest {
+            mode: request.mode.clone(),
+            token_seq: request.token_seq.clone(),
+            block_hashes: None,
+            isl_tokens: request.isl_tokens,
+            lora_name: request.lora_name.clone(),
+            expected_output_tokens: request.expected_output_tokens,
+            pinned_worker: request.pinned_worker,
+            allowed_worker_ids: request.allowed_worker_ids.clone(),
+            routing_constraints: request.routing_constraints.clone(),
+            router_config_override: request.router_config_override.clone(),
+            priority_jump: request.priority_jump,
+            strict_priority: request.strict_priority,
+            policy_class: request.policy_class.clone(),
+            session_context: request.session_context.clone(),
+            overlap: request.overlap.clone(),
+            router_hint_candidates: request.router_hint_candidates.clone(),
+            retain_router_hint_chain: request.retain_router_hint_chain,
+            shared_cache_hits: request.shared_cache_hits.clone(),
+        }
+    }
+
+    #[tokio::test]
+    async fn classifier_overrides_are_validated_before_queueing() {
+        let profile = policy_profile(
+            r#"
+default_policy_family: latency
+uncached_isl_buckets:
+  - min_tokens: 0
+    bucket: all
+policy_classes:
+  - name: latency
+    policy_family: latency
+    cache_bucket: all
+    quantum: 1
+  - name: bulk
+    policy_family: bulk
+    cache_bucket: all
+    quantum: 1
+"#,
+        );
+        let (queue, _slots) = make_queue_with_profile(1, 16, 64, profile);
+        let (request, _rx) = make_request("classified", 64);
+        let ingress_at = StdInstant::now();
+        let due_at = ingress_at + Duration::from_secs(20);
+
+        let mut classified = queue.classify_request(&classify_source(&request));
+        classified.set_policy_class("bulk");
+        classified.set_due_at(due_at);
+        classified.set_scheduling_cost_tokens(7);
+        let metadata = queue
+            .validate_classification(&request, classified, ingress_at)
+            .unwrap();
+        assert_eq!(queue.profile.class(metadata.class_index).name, "bulk");
+        assert_eq!(metadata.snapshot.scheduling_cost_tokens, 7);
+        assert_eq!(metadata.due_at.map(Instant::into_std), Some(due_at));
+
+        let mut unknown_class = queue.classify_request(&classify_source(&request));
+        unknown_class.set_policy_class("missing");
+        assert!(matches!(
+            queue.validate_classification(&request, unknown_class, ingress_at),
+            Err(KvSchedulerError::InvalidClassificationMetadata(_))
+        ));
+
+        let mut zero_cost = queue.classify_request(&classify_source(&request));
+        zero_cost.set_scheduling_cost_tokens(0);
+        assert!(matches!(
+            queue.validate_classification(&request, zero_cost, ingress_at),
+            Err(KvSchedulerError::InvalidClassificationMetadata(_))
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn queued_classified_request_expires_without_an_external_update() {
+        let (queue, _slots) = make_queue(1, 16, 64, Some(0.0));
+        let (active, active_rx) = make_request("active", 64);
+        queue.enqueue(active).await;
+        active_rx.await.unwrap().unwrap();
+
+        let (queued, queued_rx) = make_request("due", 64);
+        let ingress_at = StdInstant::now();
+        let mut classified = queue.classify_request(&classify_source(&queued));
+        classified.set_due_at(ingress_at + Duration::from_secs(1));
+        queue
+            .enqueue_classified_with_block_hashes_and_lease(
+                queued,
+                None,
+                None,
+                Some(classified),
+                ingress_at,
+            )
+            .await;
+        assert_eq!(queue.pending_count(), 1);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert!(matches!(
+            queued_rx.await.unwrap(),
+            Err(KvSchedulerError::DueTimeExpired)
+        ));
+        assert_eq!(queue.pending_count(), 0);
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -1159,8 +1159,7 @@ impl<
                 decay_now,
             )
             .await;
-            let admit_now = Instant::now();
-            if queued.due_at.is_some_and(|due_at| due_at <= admit_now) {
+            if queued.due_at.is_some_and(|due_at| due_at <= Instant::now()) {
                 let mut request = popped.into_payload().request;
                 request.respond(Err(KvSchedulerError::DueTimeExpired));
                 continue;
@@ -1179,6 +1178,7 @@ impl<
                     None
                 };
             }
+            let admit_now = Instant::now();
             let class_index = popped.class_index();
             let class = self.profile.class(class_index);
             let queued = popped.into_payload();

--- a/lib/kv-router/src/scheduling/request_classifier/mod.rs
+++ b/lib/kv-router/src/scheduling/request_classifier/mod.rs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+mod policy;
+
+pub(crate) use policy::RequestClassifierRuntime;
+pub use policy::{
+    ClassifyError, ClassifyEvent, ClassifyFuture, ClassifyRequest, RequestClassifier,
+    RequestLifecycle,
+};

--- a/lib/kv-router/src/scheduling/request_classifier/policy.rs
+++ b/lib/kv-router/src/scheduling/request_classifier/policy.rs
@@ -85,14 +85,14 @@ impl ClassifyRequest {
         self.request_id.as_deref()
     }
 
-    /// Return the effective policy class.
+    /// Return the requested policy family or explicit class.
     pub fn policy_class(&self) -> Option<&str> {
         self.policy_class_override
             .as_deref()
             .or(self.policy_class.as_deref())
     }
 
-    /// Override the policy class used by the router-owned queue.
+    /// Override the policy family or explicit class used by the router-owned queue.
     pub fn set_policy_class(&mut self, policy_class: impl Into<String>) {
         self.policy_class_override = Some(policy_class.into());
     }

--- a/lib/kv-router/src/scheduling/request_classifier/policy.rs
+++ b/lib/kv-router/src/scheduling/request_classifier/policy.rs
@@ -1,0 +1,691 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::error::Error;
+use std::future::Future;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use futures_util::FutureExt;
+use parking_lot::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use super::super::types::{KvSchedulerError, SessionContext};
+use crate::protocols::WorkerWithDpRank;
+
+static NEXT_CLASSIFICATION_ID: AtomicU64 = AtomicU64::new(1);
+
+/// An owned request view passed to a classifier before router queueing.
+///
+/// The router keeps the request payload and identity private. A classifier can
+/// inspect the request facts exposed here, override scheduling metadata, and
+/// return the same value immediately or from a pending future.
+#[derive(Debug)]
+pub struct ClassifyRequest {
+    classification_id: u64,
+    request_id: Option<String>,
+    policy_class: Option<String>,
+    policy_class_override: Option<String>,
+    due_at_override: Option<Instant>,
+    input_tokens: usize,
+    initial_cached_tokens: usize,
+    default_scheduling_cost_tokens: usize,
+    scheduling_cost_tokens_override: Option<usize>,
+    session_context: Option<SessionContext>,
+}
+
+#[derive(Clone)]
+struct ClassificationOverrides {
+    policy_class: Option<String>,
+    due_at: Option<Instant>,
+    scheduling_cost_tokens: Option<usize>,
+}
+
+impl ClassifyRequest {
+    pub(crate) fn new(input_tokens: usize, initial_cached_tokens: usize) -> Self {
+        let initial_cached_tokens = initial_cached_tokens.min(input_tokens);
+        Self {
+            classification_id: 0,
+            request_id: None,
+            policy_class: None,
+            policy_class_override: None,
+            due_at_override: None,
+            input_tokens,
+            initial_cached_tokens,
+            default_scheduling_cost_tokens: input_tokens
+                .saturating_sub(initial_cached_tokens)
+                .max(1),
+            scheduling_cost_tokens_override: None,
+            session_context: None,
+        }
+    }
+
+    pub(crate) fn with_request_id(mut self, request_id: impl Into<String>) -> Self {
+        self.request_id = Some(request_id.into());
+        self
+    }
+
+    pub(crate) fn with_initial_policy_class(mut self, policy_class: impl Into<String>) -> Self {
+        self.policy_class = Some(policy_class.into());
+        self
+    }
+
+    pub(crate) fn with_session_context(mut self, session_context: SessionContext) -> Self {
+        self.session_context = Some(session_context);
+        self
+    }
+
+    /// Return the request ID when this scheduling request carries one.
+    pub fn request_id(&self) -> Option<&str> {
+        self.request_id.as_deref()
+    }
+
+    /// Return the effective policy class.
+    pub fn policy_class(&self) -> Option<&str> {
+        self.policy_class_override
+            .as_deref()
+            .or(self.policy_class.as_deref())
+    }
+
+    /// Override the policy class used by the router-owned queue.
+    pub fn set_policy_class(&mut self, policy_class: impl Into<String>) {
+        self.policy_class_override = Some(policy_class.into());
+    }
+
+    /// Return the model input context size after preprocessing.
+    pub fn input_tokens(&self) -> usize {
+        self.input_tokens
+    }
+
+    /// Return the effective due time, if one was supplied by the classifier.
+    pub fn due_at(&self) -> Option<Instant> {
+        self.due_at_override
+    }
+
+    /// Set the due time enforced by the router-owned queue.
+    pub fn set_due_at(&mut self, due_at: Instant) {
+        self.due_at_override = Some(due_at);
+    }
+
+    /// Return the effective DRR scheduling cost in tokens.
+    pub fn scheduling_cost_tokens(&self) -> usize {
+        self.scheduling_cost_tokens_override
+            .unwrap_or(self.default_scheduling_cost_tokens)
+    }
+
+    /// Override the DRR scheduling cost in tokens.
+    pub fn set_scheduling_cost_tokens(&mut self, scheduling_cost_tokens: usize) {
+        self.scheduling_cost_tokens_override = Some(scheduling_cost_tokens);
+    }
+
+    /// Return the optional session metadata already carried by the request.
+    pub fn session_context(&self) -> Option<&SessionContext> {
+        self.session_context.as_ref()
+    }
+
+    pub(crate) fn into_queue_inputs(
+        self,
+    ) -> (Option<String>, Option<Instant>, Option<usize>, usize) {
+        (
+            self.policy_class_override,
+            self.due_at_override,
+            self.scheduling_cost_tokens_override,
+            self.initial_cached_tokens,
+        )
+    }
+
+    fn begin_classification(&mut self) -> u64 {
+        let classification_id = NEXT_CLASSIFICATION_ID.fetch_add(1, Ordering::Relaxed);
+        self.classification_id = classification_id;
+        classification_id
+    }
+
+    fn classification_overrides(&self) -> ClassificationOverrides {
+        ClassificationOverrides {
+            policy_class: self.policy_class_override.clone(),
+            due_at: self.due_at_override,
+            scheduling_cost_tokens: self.scheduling_cost_tokens_override,
+        }
+    }
+
+    fn apply_classification_overrides(&mut self, overrides: ClassificationOverrides) {
+        self.policy_class_override = overrides.policy_class;
+        self.due_at_override = overrides.due_at;
+        self.scheduling_cost_tokens_override = overrides.scheduling_cost_tokens;
+    }
+}
+
+/// Error detail returned by a classifier or attached to an aborted request.
+pub type ClassifyError = dyn Error + Send + Sync + 'static;
+
+/// Request lifecycle notifications delivered to [`RequestClassifier::on_event`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ClassifyEvent<'a> {
+    Sent {
+        request_id: &'a str,
+        worker: WorkerWithDpRank,
+    },
+    Received {
+        request_id: &'a str,
+        worker: WorkerWithDpRank,
+    },
+    Responding {
+        request_id: &'a str,
+        worker: WorkerWithDpRank,
+    },
+    Completed {
+        request_id: &'a str,
+        worker: WorkerWithDpRank,
+        context_tokens: Option<usize>,
+    },
+    Aborted {
+        request_id: &'a str,
+        worker: Option<WorkerWithDpRank>,
+        error: Option<&'a ClassifyError>,
+    },
+}
+
+/// An independently pollable classifier invocation.
+///
+/// The future owns its continuation. A pending invocation therefore does not
+/// retain a borrow or lock on the classifier and cannot block another request
+/// or lifecycle notification.
+pub type ClassifyFuture =
+    Pin<Box<dyn Future<Output = Result<ClassifyRequest, Box<ClassifyError>>> + Send + 'static>>;
+
+/// User-provided request classifier.
+pub trait RequestClassifier: Send + 'static {
+    /// Return the same logical request immediately or after a classifier-specific wait.
+    fn classify(&mut self, request: ClassifyRequest) -> ClassifyFuture {
+        Box::pin(async move { Ok(request) })
+    }
+
+    /// Observe one lifecycle transition without releasing or dispatching work directly.
+    ///
+    /// The router invokes this callback synchronously. Implementations should update
+    /// shared state, notify pending futures, and return promptly.
+    fn on_event(&mut self, _event: ClassifyEvent<'_>) {}
+}
+
+pub(crate) struct RequestClassifierRuntime {
+    classifier: Mutex<Box<dyn RequestClassifier>>,
+    live_requests: Mutex<HashMap<String, Option<ClassificationOverrides>>>,
+    shutdown: CancellationToken,
+}
+
+impl RequestClassifierRuntime {
+    pub(crate) fn new(
+        classifier: Box<dyn RequestClassifier>,
+        shutdown: CancellationToken,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            classifier: Mutex::new(classifier),
+            live_requests: Mutex::new(HashMap::new()),
+            shutdown,
+        })
+    }
+
+    pub(crate) async fn classify_with(
+        &self,
+        request_id: Option<&str>,
+        make_request: impl FnOnce() -> ClassifyRequest,
+    ) -> Result<ClassifyRequest, KvSchedulerError> {
+        if self.shutdown.is_cancelled() {
+            return Err(KvSchedulerError::SubscriberShutdown);
+        }
+
+        let cached_overrides = request_id.and_then(|request_id| {
+            self.live_requests
+                .lock()
+                .get(request_id)
+                .and_then(Clone::clone)
+        });
+        if let Some(overrides) = cached_overrides {
+            let mut request = make_request();
+            request.apply_classification_overrides(overrides);
+            return Ok(request);
+        }
+
+        let mut request = make_request();
+        let classification_id = request.begin_classification();
+        let classification = catch_unwind(AssertUnwindSafe(|| {
+            self.classifier.lock().classify(request)
+        }))
+        .map_err(|panic| KvSchedulerError::RequestClassifierPanicked(panic_message(panic)))?;
+        let classification = AssertUnwindSafe(classification).catch_unwind();
+
+        let classified_request = tokio::select! {
+            biased;
+            _ = self.shutdown.cancelled() => return Err(KvSchedulerError::SubscriberShutdown),
+            result = classification => result
+                .map_err(|panic| KvSchedulerError::RequestClassifierPanicked(panic_message(panic)))?
+                .map_err(KvSchedulerError::RequestClassifierFailed)?,
+        };
+
+        if classified_request.classification_id != classification_id {
+            return Err(KvSchedulerError::RequestClassifierReplacedRequest);
+        }
+
+        if let Some(request_id) = classified_request.request_id()
+            && let Some(cached) = self.live_requests.lock().get_mut(request_id)
+        {
+            *cached = Some(classified_request.classification_overrides());
+        }
+
+        Ok(classified_request)
+    }
+
+    pub(crate) fn begin_request(
+        self: &Arc<Self>,
+        request_id: &str,
+    ) -> Result<RequestLifecycle, KvSchedulerError> {
+        if self.shutdown.is_cancelled() {
+            return Err(KvSchedulerError::SubscriberShutdown);
+        }
+
+        let mut live_requests = self.live_requests.lock();
+        match live_requests.entry(request_id.to_owned()) {
+            std::collections::hash_map::Entry::Occupied(_) => {
+                return Err(KvSchedulerError::DuplicateClassificationRequestId(
+                    request_id.to_owned(),
+                ));
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(None);
+            }
+        }
+        drop(live_requests);
+
+        Ok(RequestLifecycle {
+            runtime: Arc::clone(self),
+            request_id: request_id.to_owned(),
+            worker: None,
+            last_worker: None,
+            context_tokens: None,
+            phase: LifecyclePhase::Registered,
+        })
+    }
+
+    fn deliver_event(&self, event: ClassifyEvent<'_>) {
+        if let Err(panic) = catch_unwind(AssertUnwindSafe(|| {
+            self.classifier.lock().on_event(event);
+        })) {
+            tracing::warn!(
+                panic = %panic_message(panic),
+                "Request classifier panicked while processing a lifecycle event"
+            );
+        }
+    }
+
+    fn finish_request(&self, request_id: &str, event: ClassifyEvent<'_>) {
+        if !self.live_requests.lock().contains_key(request_id) {
+            return;
+        }
+        self.deliver_event(event);
+        self.live_requests.lock().remove(request_id);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LifecyclePhase {
+    Registered,
+    Sent,
+    Received,
+    Responding,
+    Terminal,
+}
+
+/// Router-owned lifecycle state transferred from scheduling to response handling.
+#[doc(hidden)]
+pub struct RequestLifecycle {
+    runtime: Arc<RequestClassifierRuntime>,
+    request_id: String,
+    worker: Option<WorkerWithDpRank>,
+    last_worker: Option<WorkerWithDpRank>,
+    context_tokens: Option<usize>,
+    phase: LifecyclePhase,
+}
+
+impl std::fmt::Debug for RequestLifecycle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RequestLifecycle")
+            .field("request_id", &self.request_id)
+            .field("worker", &self.worker)
+            .field("last_worker", &self.last_worker)
+            .field("context_tokens", &self.context_tokens)
+            .field("phase", &self.phase)
+            .finish()
+    }
+}
+
+impl RequestLifecycle {
+    #[doc(hidden)]
+    pub fn selected(&mut self, worker: WorkerWithDpRank) {
+        if self.phase == LifecyclePhase::Registered {
+            self.worker = Some(worker);
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn sent(&mut self, worker: WorkerWithDpRank) {
+        if self.phase != LifecyclePhase::Registered {
+            return;
+        }
+        self.worker = Some(worker);
+        self.phase = LifecyclePhase::Sent;
+        self.runtime.deliver_event(ClassifyEvent::Sent {
+            request_id: &self.request_id,
+            worker,
+        });
+    }
+
+    #[doc(hidden)]
+    pub fn received(&mut self) {
+        if self.phase != LifecyclePhase::Sent {
+            return;
+        }
+        let Some(worker) = self.worker else {
+            return;
+        };
+        self.phase = LifecyclePhase::Received;
+        self.runtime.deliver_event(ClassifyEvent::Received {
+            request_id: &self.request_id,
+            worker,
+        });
+    }
+
+    #[doc(hidden)]
+    pub fn responding(&mut self) {
+        if !matches!(self.phase, LifecyclePhase::Sent | LifecyclePhase::Received) {
+            return;
+        }
+        let Some(worker) = self.worker else {
+            return;
+        };
+        self.phase = LifecyclePhase::Responding;
+        self.runtime.deliver_event(ClassifyEvent::Responding {
+            request_id: &self.request_id,
+            worker,
+        });
+    }
+
+    #[doc(hidden)]
+    pub fn observe_input_tokens(&mut self, input_tokens: usize) {
+        self.context_tokens = Some(
+            self.context_tokens
+                .map_or(input_tokens, |current| current.max(input_tokens)),
+        );
+    }
+
+    #[doc(hidden)]
+    pub fn observe_output_tokens(&mut self, output_tokens: usize) {
+        self.context_tokens = Some(
+            self.context_tokens
+                .unwrap_or_default()
+                .saturating_add(output_tokens),
+        );
+    }
+
+    #[doc(hidden)]
+    pub fn observe_context_tokens(&mut self, context_tokens: usize) {
+        self.context_tokens = Some(
+            self.context_tokens
+                .map_or(context_tokens, |current| current.max(context_tokens)),
+        );
+    }
+
+    /// Reset attempt-local worker state without terminating the logical request.
+    #[doc(hidden)]
+    pub fn prepare_retry(&mut self) {
+        if self.phase != LifecyclePhase::Terminal {
+            self.last_worker = self.worker.or(self.last_worker);
+            self.worker = None;
+            self.phase = LifecyclePhase::Registered;
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn complete(&mut self) {
+        if self.phase == LifecyclePhase::Terminal {
+            return;
+        }
+        let Some(worker) = self.worker else {
+            self.abort(None);
+            return;
+        };
+        self.phase = LifecyclePhase::Terminal;
+        self.runtime.finish_request(
+            &self.request_id,
+            ClassifyEvent::Completed {
+                request_id: &self.request_id,
+                worker,
+                context_tokens: self.context_tokens,
+            },
+        );
+    }
+
+    #[doc(hidden)]
+    pub fn abort(&mut self, error: Option<&ClassifyError>) {
+        if self.phase == LifecyclePhase::Terminal {
+            return;
+        }
+        self.phase = LifecyclePhase::Terminal;
+        self.runtime.finish_request(
+            &self.request_id,
+            ClassifyEvent::Aborted {
+                request_id: &self.request_id,
+                worker: self.worker.or(self.last_worker),
+                error,
+            },
+        );
+    }
+}
+
+impl Drop for RequestLifecycle {
+    fn drop(&mut self) {
+        self.abort(None);
+    }
+}
+
+fn panic_message(panic: Box<dyn Any + Send>) -> String {
+    if let Some(message) = panic.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = panic.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "request classifier panicked with a non-string payload".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use tokio::sync::{Notify, mpsc};
+
+    use super::*;
+
+    struct PassThrough;
+
+    impl RequestClassifier for PassThrough {}
+
+    #[tokio::test]
+    async fn default_classifier_returns_the_same_request_without_overrides() {
+        let request = ClassifyRequest::new(128, 32)
+            .with_request_id("request-1")
+            .with_initial_policy_class("latency");
+
+        let result = PassThrough.classify(request).await.unwrap();
+
+        assert_eq!(result.request_id(), Some("request-1"));
+        assert_eq!(result.policy_class(), Some("latency"));
+        assert_eq!(result.scheduling_cost_tokens(), 96);
+        assert_eq!(result.into_queue_inputs(), (None, None, None, 32));
+    }
+
+    struct EventReleasedClassifier {
+        entered: Arc<Notify>,
+        released: Arc<Notify>,
+    }
+
+    impl RequestClassifier for EventReleasedClassifier {
+        fn classify(&mut self, request: ClassifyRequest) -> ClassifyFuture {
+            let entered = Arc::clone(&self.entered);
+            let released = Arc::clone(&self.released);
+            Box::pin(async move {
+                entered.notify_one();
+                released.notified().await;
+                Ok(request)
+            })
+        }
+
+        fn on_event(&mut self, _event: ClassifyEvent<'_>) {
+            self.released.notify_one();
+        }
+    }
+
+    #[tokio::test]
+    async fn pending_classification_does_not_block_event_delivery() {
+        let entered = Arc::new(Notify::new());
+        let released = Arc::new(Notify::new());
+        let runtime = RequestClassifierRuntime::new(
+            Box::new(EventReleasedClassifier {
+                entered: Arc::clone(&entered),
+                released,
+            }),
+            CancellationToken::new(),
+        );
+        let mut lifecycle = runtime.begin_request("event-source").unwrap();
+        let worker = WorkerWithDpRank::new(7, 0);
+
+        let pending_runtime = Arc::clone(&runtime);
+        let pending = tokio::spawn(async move {
+            pending_runtime
+                .classify_with(None, || ClassifyRequest::new(1, 1))
+                .await
+        });
+        entered.notified().await;
+        lifecycle.sent(worker);
+
+        pending.await.unwrap().unwrap();
+        lifecycle.abort(None);
+    }
+
+    struct CountingClassifier {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl RequestClassifier for CountingClassifier {
+        fn classify(&mut self, mut request: ClassifyRequest) -> ClassifyFuture {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            request.set_scheduling_cost_tokens(7);
+            Box::pin(async move { Ok(request) })
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_reuses_classification_overrides_without_reinvoking_plugin() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let runtime = RequestClassifierRuntime::new(
+            Box::new(CountingClassifier {
+                calls: Arc::clone(&calls),
+            }),
+            CancellationToken::new(),
+        );
+        let mut lifecycle = runtime.begin_request("request-1").unwrap();
+
+        let first = runtime
+            .classify_with(Some("request-1"), || {
+                ClassifyRequest::new(10, 10).with_request_id("request-1")
+            })
+            .await
+            .unwrap();
+        let retry = runtime
+            .classify_with(Some("request-1"), || {
+                ClassifyRequest::new(20, 20).with_request_id("request-1")
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert_eq!(first.input_tokens(), 10);
+        assert_eq!(retry.input_tokens(), 20);
+        assert_eq!(retry.scheduling_cost_tokens(), 7);
+        lifecycle.abort(None);
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum RecordedEvent {
+        Sent(String, WorkerWithDpRank),
+        Completed(String, WorkerWithDpRank, Option<usize>),
+        Aborted(String, Option<WorkerWithDpRank>),
+    }
+
+    struct RecordingClassifier {
+        events: mpsc::UnboundedSender<RecordedEvent>,
+    }
+
+    impl RequestClassifier for RecordingClassifier {
+        fn on_event(&mut self, event: ClassifyEvent<'_>) {
+            let event = match event {
+                ClassifyEvent::Sent { request_id, worker } => {
+                    Some(RecordedEvent::Sent(request_id.to_owned(), worker))
+                }
+                ClassifyEvent::Completed {
+                    request_id,
+                    worker,
+                    context_tokens,
+                } => Some(RecordedEvent::Completed(
+                    request_id.to_owned(),
+                    worker,
+                    context_tokens,
+                )),
+                ClassifyEvent::Aborted {
+                    request_id, worker, ..
+                } => Some(RecordedEvent::Aborted(request_id.to_owned(), worker)),
+                ClassifyEvent::Received { .. } | ClassifyEvent::Responding { .. } => None,
+            };
+            if let Some(event) = event {
+                let _ = self.events.send(event);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn lifecycle_delivers_one_terminal_event() {
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let runtime = RequestClassifierRuntime::new(
+            Box::new(RecordingClassifier { events: event_tx }),
+            CancellationToken::new(),
+        );
+        let worker = WorkerWithDpRank::new(7, 2);
+        let mut lifecycle = runtime.begin_request("request-1").unwrap();
+
+        lifecycle.sent(worker);
+        lifecycle.observe_input_tokens(40);
+        lifecycle.observe_output_tokens(2);
+        lifecycle.complete();
+        lifecycle.abort(None);
+
+        assert_eq!(
+            event_rx.recv().await,
+            Some(RecordedEvent::Sent("request-1".to_string(), worker))
+        );
+        assert_eq!(
+            event_rx.recv().await,
+            Some(RecordedEvent::Completed(
+                "request-1".to_string(),
+                worker,
+                Some(42)
+            ))
+        );
+        assert!(event_rx.try_recv().is_err());
+    }
+}

--- a/lib/kv-router/src/scheduling/request_classifier/policy.rs
+++ b/lib/kv-router/src/scheduling/request_classifier/policy.rs
@@ -200,6 +200,10 @@ pub type ClassifyFuture =
     Pin<Box<dyn Future<Output = Result<ClassifyRequest, Box<ClassifyError>>> + Send + 'static>>;
 
 /// User-provided request classifier.
+///
+/// A panic fails the current request, but the router retains the classifier and may
+/// invoke it again. Implementations that unwind must therefore remain valid for a
+/// subsequent [`Self::classify`] or [`Self::on_event`] call.
 pub trait RequestClassifier: Send + 'static {
     /// Return the same logical request immediately or after a classifier-specific wait.
     fn classify(&mut self, request: ClassifyRequest) -> ClassifyFuture {
@@ -268,6 +272,7 @@ impl RequestClassifierRuntime {
                 .map_err(KvSchedulerError::RequestClassifierFailed)?,
         };
 
+        // Reject a classifier swapping request values between overlapping futures.
         if classified_request.classification_id != classification_id {
             return Err(KvSchedulerError::RequestClassifierReplacedRequest);
         }
@@ -515,6 +520,153 @@ mod tests {
     struct PassThrough;
 
     impl RequestClassifier for PassThrough {}
+
+    struct SynchronousPanicOnce {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl RequestClassifier for SynchronousPanicOnce {
+        fn classify(&mut self, request: ClassifyRequest) -> ClassifyFuture {
+            if self.calls.fetch_add(1, Ordering::Relaxed) == 0 {
+                panic!("synchronous classifier panic");
+            }
+            Box::pin(async move { Ok(request) })
+        }
+    }
+
+    #[tokio::test]
+    async fn synchronous_panic_fails_one_request_and_retains_the_classifier() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let runtime = RequestClassifierRuntime::new(
+            Box::new(SynchronousPanicOnce {
+                calls: Arc::clone(&calls),
+            }),
+            CancellationToken::new(),
+        );
+
+        let error = runtime
+            .classify_with(None, || ClassifyRequest::new(1, 0))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            KvSchedulerError::RequestClassifierPanicked(message)
+                if message == "synchronous classifier panic"
+        ));
+        runtime
+            .classify_with(None, || ClassifyRequest::new(2, 0))
+            .await
+            .unwrap();
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+    }
+
+    struct FuturePanicOnce {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl RequestClassifier for FuturePanicOnce {
+        fn classify(&mut self, request: ClassifyRequest) -> ClassifyFuture {
+            let should_panic = self.calls.fetch_add(1, Ordering::Relaxed) == 0;
+            Box::pin(async move {
+                assert!(!should_panic, "classifier future panic");
+                Ok(request)
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn future_panic_fails_one_request_and_retains_the_classifier() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let runtime = RequestClassifierRuntime::new(
+            Box::new(FuturePanicOnce {
+                calls: Arc::clone(&calls),
+            }),
+            CancellationToken::new(),
+        );
+
+        let error = runtime
+            .classify_with(None, || ClassifyRequest::new(1, 0))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            KvSchedulerError::RequestClassifierPanicked(message)
+                if message == "classifier future panic"
+        ));
+        runtime
+            .classify_with(None, || ClassifyRequest::new(2, 0))
+            .await
+            .unwrap();
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("classifier rejected request")]
+    struct TestClassifierError;
+
+    struct FailingClassifier;
+
+    impl RequestClassifier for FailingClassifier {
+        fn classify(&mut self, _request: ClassifyRequest) -> ClassifyFuture {
+            Box::pin(async { Err(Box::new(TestClassifierError) as Box<ClassifyError>) })
+        }
+    }
+
+    #[tokio::test]
+    async fn classifier_error_is_preserved_as_scheduler_error() {
+        let runtime =
+            RequestClassifierRuntime::new(Box::new(FailingClassifier), CancellationToken::new());
+
+        let error = runtime
+            .classify_with(None, || ClassifyRequest::new(1, 0))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            KvSchedulerError::RequestClassifierFailed(source)
+                if source.to_string() == "classifier rejected request"
+        ));
+    }
+
+    struct ReplacingClassifier;
+
+    impl RequestClassifier for ReplacingClassifier {
+        fn classify(&mut self, _request: ClassifyRequest) -> ClassifyFuture {
+            Box::pin(async { Ok(ClassifyRequest::new(2, 0)) })
+        }
+    }
+
+    #[tokio::test]
+    async fn classifier_cannot_replace_the_logical_request() {
+        let runtime =
+            RequestClassifierRuntime::new(Box::new(ReplacingClassifier), CancellationToken::new());
+
+        let error = runtime
+            .classify_with(None, || ClassifyRequest::new(1, 0))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            KvSchedulerError::RequestClassifierReplacedRequest
+        ));
+    }
+
+    #[test]
+    fn duplicate_live_request_id_is_rejected_until_lifecycle_ends() {
+        let runtime =
+            RequestClassifierRuntime::new(Box::new(PassThrough), CancellationToken::new());
+        let lifecycle = runtime.begin_request("request-1").unwrap();
+
+        let error = runtime.begin_request("request-1").unwrap_err();
+        assert!(matches!(
+            error,
+            KvSchedulerError::DuplicateClassificationRequestId(request_id)
+                if request_id == "request-1"
+        ));
+
+        drop(lifecycle);
+        runtime.begin_request("request-1").unwrap();
+    }
 
     #[tokio::test]
     async fn default_classifier_returns_the_same_request_without_overrides() {

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -95,13 +95,33 @@ pub enum KvSchedulerError {
 
     #[error(transparent)]
     WorkerSelectionPolicy(#[from] WorkerSelectionPolicyError),
+
+    #[error("request classifier panicked: {0}")]
+    RequestClassifierPanicked(String),
+
+    #[error("request classifier failed: {0}")]
+    RequestClassifierFailed(#[source] Box<super::request_classifier::ClassifyError>),
+
+    #[error("request classifier returned a different logical request")]
+    RequestClassifierReplacedRequest,
+
+    #[error("request classifier already has a live request with ID {0:?}")]
+    DuplicateClassificationRequestId(String),
+
+    #[error("request due time expired")]
+    DueTimeExpired,
+
+    #[error("invalid classifier scheduling metadata: {0}")]
+    InvalidClassificationMetadata(String),
 }
 
 impl KvSchedulerError {
     pub fn is_overload(&self) -> bool {
         matches!(
             self,
-            Self::AllEligibleWorkersOverloaded | Self::PinnedWorkerOverloaded { .. }
+            Self::AllEligibleWorkersOverloaded
+                | Self::PinnedWorkerOverloaded { .. }
+                | Self::DueTimeExpired
         )
     }
 }
@@ -267,7 +287,7 @@ impl WorkerSelectionKvHints {
     }
 }
 
-/// Session metadata supplied to a custom worker-selection policy.
+/// Session metadata supplied to request classifiers and worker-selection policies.
 ///
 /// The internal request protocol supplies these values. Optional values remain
 /// absent when the request does not include them.
@@ -281,7 +301,7 @@ pub struct SessionContext {
 }
 
 impl SessionContext {
-    /// Create the session metadata available to worker selection.
+    /// Create the session metadata available to routing extensions.
     pub fn new(
         session_id: String,
         parent_session_id: Option<String>,
@@ -347,6 +367,25 @@ pub struct ScheduleRequest {
     pub router_hint_candidates: Option<RouterHintRootCandidates>,
     pub retain_router_hint_chain: bool,
     pub shared_cache_hits: Option<SharedCacheHits>,
+}
+
+impl ScheduleRequest {
+    pub(crate) fn eligibility(&self) -> RoutingEligibility<'_> {
+        RoutingEligibility::new(
+            self.allowed_worker_ids.as_ref(),
+            None,
+            self.pinned_worker,
+            &self.routing_constraints,
+        )
+    }
+
+    pub(crate) fn effective_cached_tokens_for(&self, worker: WorkerWithDpRank) -> usize {
+        self.overlap
+            .effective_cached_tokens
+            .get(&worker)
+            .copied()
+            .unwrap_or(0)
+    }
 }
 
 /// Actor-owned admission request.

--- a/lib/kv-router/src/services/selection/error.rs
+++ b/lib/kv-router/src/services/selection/error.rs
@@ -65,9 +65,15 @@ fn scheduler_error_status(error: &KvSchedulerError) -> StatusCode {
         | KvSchedulerError::AllEligibleWorkersFiltered
         | KvSchedulerError::SubscriberShutdown
         | KvSchedulerError::InitFailed(_) => StatusCode::SERVICE_UNAVAILABLE,
-        KvSchedulerError::WorkerSelectionPolicy(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        KvSchedulerError::WorkerSelectionPolicy(_)
+        | KvSchedulerError::RequestClassifierPanicked(_)
+        | KvSchedulerError::RequestClassifierFailed(_)
+        | KvSchedulerError::RequestClassifierReplacedRequest
+        | KvSchedulerError::DuplicateClassificationRequestId(_)
+        | KvSchedulerError::InvalidClassificationMetadata(_) => StatusCode::INTERNAL_SERVER_ERROR,
         KvSchedulerError::AllEligibleWorkersOverloaded
-        | KvSchedulerError::PinnedWorkerOverloaded { .. } => StatusCode::TOO_MANY_REQUESTS,
+        | KvSchedulerError::PinnedWorkerOverloaded { .. }
+        | KvSchedulerError::DueTimeExpired => StatusCode::TOO_MANY_REQUESTS,
         KvSchedulerError::QueueRejected(_) => StatusCode::SERVICE_UNAVAILABLE,
         KvSchedulerError::PinnedWorkerNotAllowed { .. } => StatusCode::BAD_REQUEST,
         KvSchedulerError::BookingFailed(_) => StatusCode::CONFLICT,
@@ -117,6 +123,10 @@ mod tests {
         );
         assert_eq!(
             SelectionError::Scheduler(KvSchedulerError::AllEligibleWorkersOverloaded).status_code(),
+            StatusCode::TOO_MANY_REQUESTS.as_u16()
+        );
+        assert_eq!(
+            SelectionError::Scheduler(KvSchedulerError::DueTimeExpired).status_code(),
             StatusCode::TOO_MANY_REQUESTS.as_u16()
         );
     }

--- a/lib/kv-router/src/services/selection/error.rs
+++ b/lib/kv-router/src/services/selection/error.rs
@@ -129,5 +129,12 @@ mod tests {
             SelectionError::Scheduler(KvSchedulerError::DueTimeExpired).status_code(),
             StatusCode::TOO_MANY_REQUESTS.as_u16()
         );
+        assert_eq!(
+            SelectionError::Scheduler(KvSchedulerError::RequestClassifierPanicked(
+                "test panic".to_string(),
+            ))
+            .status_code(),
+            StatusCode::INTERNAL_SERVER_ERROR.as_u16()
+        );
     }
 }

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -2592,6 +2592,46 @@ mod tests {
         make_test_router_with_workers(selector, shared_cache, workers).await
     }
 
+    struct PassThroughClassifier;
+
+    impl RequestClassifier for PassThroughClassifier {}
+
+    #[tokio::test]
+    async fn classifier_fails_closed_on_the_legacy_router_entrypoint() {
+        let router = make_test_router(LoadOnlySelector, None)
+            .await
+            .with_request_classifier(PassThroughClassifier)
+            .unwrap();
+
+        let result = router
+            .find_best_match_details(
+                None,
+                &[1],
+                None,
+                None,
+                false,
+                false,
+                None,
+                None,
+                0.0,
+                0,
+                None,
+                None,
+                None,
+                RoutingConstraints::default(),
+            )
+            .await;
+        let error = match result {
+            Ok(_) => panic!("legacy entrypoint unexpectedly accepted a classifier"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "request-classifier routers must be driven through RoutingHost"
+        );
+    }
+
     fn router_hint_runtime_config(endpoint: Option<&str>) -> ModelRuntimeConfig {
         router_hint_runtime_config_with_worker_type(endpoint, "prefill")
     }

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -28,8 +28,8 @@ use dynamo_kv_router::{
     },
     router_hint::{RouterHint, RouterHintCandidateSource, RouterHintRootCandidates},
     scheduling::{
-        CacheHitEstimates, OverlapAnalysis, OverloadedWorkerProvider, ScheduleMode,
-        ScheduleRequest, TieredOverlapRefresher, WorkerAvailabilityProvider,
+        CacheHitEstimates, OverlapAnalysis, OverloadedWorkerProvider, RequestClassifier,
+        ScheduleMode, ScheduleRequest, TieredOverlapRefresher, WorkerAvailabilityProvider,
         effective_prefill_tokens, overlap::cache_hit_estimates_from_tiered_matches,
     },
     selector::WorkerInputs,
@@ -438,10 +438,9 @@ pub const RADIX_STATE_FILE: &str = "radix-state";
 pub const WORKER_KV_INDEXER_BUFFER_SIZE: usize = 1024; // store 1024 most recent events in worker buffer
 
 fn map_scheduler_error(error: scheduling::KvSchedulerError) -> anyhow::Error {
-    // Keep the two overload cases apart. A single overloaded worker can be
-    // retried elsewhere; a pool with no free worker cannot, and migrating it
-    // would just bounce the request around. A filter rejection is unavailable,
-    // not overload, and becomes HTTP 503.
+    // A single overloaded worker can be retried elsewhere; pool-wide and
+    // admission-control overloads cannot. A filter rejection is unavailable, not
+    // overload, and becomes HTTP 503.
     let (error_type, overloaded) = match error {
         scheduling::KvSchedulerError::PinnedWorkerOverloaded { .. } => {
             (ErrorType::WorkerOverloaded, true)
@@ -449,6 +448,7 @@ fn map_scheduler_error(error: scheduling::KvSchedulerError) -> anyhow::Error {
         scheduling::KvSchedulerError::AllEligibleWorkersOverloaded => {
             (ErrorType::ResourceExhausted, true)
         }
+        scheduling::KvSchedulerError::DueTimeExpired => (ErrorType::ResourceExhausted, true),
         scheduling::KvSchedulerError::AllEligibleWorkersFiltered => (ErrorType::Unavailable, false),
         _ => return error.into(),
     };
@@ -858,6 +858,20 @@ where
         })
     }
 
+    /// Attach a request classifier before placing this router into service.
+    ///
+    /// Drive the configured router through [`RoutingHost`] so response lifecycle
+    /// notifications reach the classifier.
+    pub fn with_request_classifier(self, classifier: impl RequestClassifier) -> Result<Self> {
+        if !self
+            .scheduler
+            .install_request_classifier(Box::new(classifier), self.cancellation_token.child_token())
+        {
+            anyhow::bail!("request classifier is already configured");
+        }
+        Ok(self)
+    }
+
     pub(crate) fn set_endpoint_registration(
         &mut self,
         registration: dynamo_runtime::discovery::EndpointRegistrationLease,
@@ -890,6 +904,13 @@ where
 
     pub fn required_worker_inputs(&self) -> dynamo_kv_router::selector::WorkerInputs {
         self.required_worker_inputs
+    }
+
+    pub(crate) fn begin_request_lifecycle(
+        &self,
+        request_id: &str,
+    ) -> Result<Option<scheduling::RequestLifecycle>, KvSchedulerError> {
+        self.scheduler.begin_request_lifecycle(request_id)
     }
 
     /// Cancel background work and wait for KV event ingestion to stop.
@@ -1215,10 +1236,15 @@ where
         allowed_worker_ids: Option<HashSet<WorkerId>>,
         routing_constraints: RoutingConstraints,
     ) -> anyhow::Result<FindBestMatchOutcome> {
+        if self.scheduler.has_request_classifier() {
+            anyhow::bail!("request-classifier routers must be driven through RoutingHost");
+        }
         match self
             .find_best_match_details_with_policy_class_inner(
                 context_id,
+                Instant::now(),
                 tokens,
+                tokens.len(),
                 block_mm_infos,
                 router_config_override,
                 update_states,
@@ -1268,7 +1294,9 @@ where
         match self
             .find_best_match_details_with_policy_class_inner(
                 context_id,
+                Instant::now(),
                 tokens,
+                tokens.len(),
                 block_mm_infos,
                 router_config_override,
                 false,
@@ -1298,7 +1326,9 @@ where
     async fn find_best_match_details_with_policy_class_inner(
         &self,
         context_id: Option<&str>,
+        ingress_at: Instant,
         tokens: &[u32],
+        input_tokens: usize,
         block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
         router_config_override: Option<&RouterConfigOverride>,
         update_states: bool,
@@ -1338,7 +1368,7 @@ where
                 request_id: context_id.map(str::to_string),
             },
         };
-        let isl_tokens = tokens.len();
+        let isl_tokens = input_tokens;
         let hash_options = BlockHashOptions {
             block_mm_infos,
             lora_name: lora_name.as_deref(),
@@ -1457,7 +1487,7 @@ where
         let (response, selected_worker_load) = match admission {
             FindBestMatchAdmission::WithAdmission { .. } => match self
                 .scheduler
-                .schedule_request(schedule_request)
+                .schedule_request_with_ingress_at(schedule_request, ingress_at)
                 .instrument(tracing::info_span!("kv_router.schedule"))
                 .await
             {
@@ -2111,6 +2141,16 @@ mod tests {
             .expect("filtered workers should produce a DynamoError");
 
         assert_eq!(dynamo_error.error_type(), ErrorType::Unavailable);
+    }
+
+    #[test]
+    fn classifier_rejections_map_to_resource_exhausted() {
+        let error = map_scheduler_error(KvSchedulerError::DueTimeExpired);
+        let dynamo_error = error
+            .downcast_ref::<DynamoError>()
+            .expect("classifier rejection should produce a DynamoError");
+
+        assert_eq!(dynamo_error.error_type(), ErrorType::ResourceExhausted);
     }
 
     #[test]

--- a/lib/llm/src/kv_router/routing_host.rs
+++ b/lib/llm/src/kv_router/routing_host.rs
@@ -10,6 +10,7 @@ use std::{
 
 use dynamo_kv_router::{
     protocols::{TokensWithHashes, WorkerConfigLike, WorkerWithDpRank},
+    scheduling::{ClassifyError, KvSchedulerError},
     selector::{WorkerInputs, WorkerSelector},
 };
 use dynamo_runtime::{
@@ -61,6 +62,28 @@ const OUTPUT_REPLAY_CONSUMER_RUNTIME_KEY: &str = "output_replay_consumer";
 
 fn is_cancelled(error: &Error) -> bool {
     match_error_chain(error.as_ref(), &[ErrorType::Cancelled], &[])
+}
+
+fn request_classifier_error(error: &Error) -> Option<&ClassifyError> {
+    let KvSchedulerError::RequestClassifierFailed(source) = classification_failure(error)? else {
+        return None;
+    };
+    Some(source.as_ref())
+}
+
+fn classification_failure(error: &Error) -> Option<&KvSchedulerError> {
+    error.chain().find_map(|cause| {
+        let error = cause.downcast_ref::<KvSchedulerError>()?;
+        matches!(
+            error,
+            KvSchedulerError::RequestClassifierPanicked(_)
+                | KvSchedulerError::RequestClassifierFailed(_)
+                | KvSchedulerError::RequestClassifierReplacedRequest
+                | KvSchedulerError::DuplicateClassificationRequestId(_)
+                | KvSchedulerError::InvalidClassificationMetadata(_)
+        )
+        .then_some(error)
+    })
 }
 
 fn invalidate_on_non_cancellation(operation: &mut Option<AffinityAcquire>, error: &Error) {
@@ -510,6 +533,7 @@ where
         match select(target).await {
             Ok(selection) => Ok((selection, Some(operation))),
             Err(error) if is_cancelled(&error) => Err(error),
+            Err(error) if classification_failure(&error).is_some() => Err(error),
             Err(_)
                 if explicit.is_none()
                     && target.is_some_and(|target| {

--- a/lib/llm/src/kv_router/routing_host.rs
+++ b/lib/llm/src/kv_router/routing_host.rs
@@ -90,12 +90,18 @@ where
         let stopped = context.stopped();
         tokio::pin!(stopped);
 
+        let mut terminal_handled = false;
         let completed = loop {
             tokio::select! {
                 biased;
 
                 _ = &mut stopped => {
                     tracing::debug!(request_id = context.id(), "Request cancelled, ending stream");
+                    let error = DynamoError::builder()
+                        .error_type(ErrorType::Cancelled)
+                        .message(format!("Request {} was cancelled", context.id()))
+                        .build();
+                    guard.abort_with_error(Some(&error)).await;
                     break false;
                 }
 
@@ -110,7 +116,14 @@ where
                         // Release the failed attempt before Migration can observe
                         // the item and start another one. This keeps serialized
                         // retries free of stale-cleanup ABA races.
-                        guard.abort().await;
+                        let retryable = item
+                            .error
+                            .as_ref()
+                            .is_some_and(|error| crate::migration::is_migratable(error));
+                        if !retryable || !guard.release_for_retry().await {
+                            guard.abort_with_error(item.error.as_ref()).await;
+                        }
+                        terminal_handled = true;
                         yield item;
                         break false;
                     }
@@ -121,7 +134,7 @@ where
 
         if completed {
             guard.finish().await;
-        } else {
+        } else if !terminal_handled {
             guard.abort().await;
         }
     }

--- a/lib/llm/src/kv_router/routing_host.rs
+++ b/lib/llm/src/kv_router/routing_host.rs
@@ -102,6 +102,7 @@ where
                         .message(format!("Request {} was cancelled", context.id()))
                         .build();
                     guard.abort_with_error(Some(&error)).await;
+                    terminal_handled = true;
                     break false;
                 }
 

--- a/lib/llm/src/kv_router/routing_host/kv.rs
+++ b/lib/llm/src/kv_router/routing_host/kv.rs
@@ -71,7 +71,9 @@ where
             Ok(selection) => selection,
             Err(error) => {
                 if let Some(mut lifecycle) = request_lifecycle.take() {
-                    if crate::migration::is_migratable(error.as_ref())
+                    if let Some(classifier_error) = request_classifier_error(&error) {
+                        lifecycle.abort(Some(classifier_error));
+                    } else if crate::migration::is_migratable(error.as_ref())
                         && let Some(state) = request.migration_state.as_ref()
                     {
                         lifecycle.prepare_retry();

--- a/lib/llm/src/kv_router/routing_host/kv.rs
+++ b/lib/llm/src/kv_router/routing_host/kv.rs
@@ -46,10 +46,54 @@ where
         phase: RequestPhase,
         is_query_only: bool,
     ) -> Result<(WorkerSelection, Option<AffinityAcquire>), Error> {
-        self.select_with_session_affinity(request, phase, is_query_only, |target| {
-            self.select_request(request, phase, is_query_only, target)
-        })
-        .await
+        let mut request_lifecycle = if is_query_only {
+            None
+        } else {
+            request
+                .migration_state
+                .as_ref()
+                .and_then(|state| state.take_request_lifecycle())
+        };
+        if !is_query_only && request_lifecycle.is_none() {
+            request_lifecycle = self
+                .kv_router()
+                .begin_request_lifecycle(request.context().id())
+                .map_err(anyhow::Error::from)?
+                .map(Box::new);
+        }
+
+        let selection_result = self
+            .select_with_session_affinity(request, phase, is_query_only, |target| {
+                self.select_request(request, phase, is_query_only, target)
+            })
+            .await;
+        let (mut selection, affinity_acquire) = match selection_result {
+            Ok(selection) => selection,
+            Err(error) => {
+                if let Some(mut lifecycle) = request_lifecycle.take() {
+                    if crate::migration::is_migratable(error.as_ref())
+                        && let Some(state) = request.migration_state.as_ref()
+                    {
+                        lifecycle.prepare_retry();
+                        state.store_request_lifecycle(lifecycle);
+                    } else {
+                        let typed_error = error
+                            .chain()
+                            .find_map(|cause| cause.downcast_ref::<DynamoError>());
+                        lifecycle
+                            .abort(typed_error.map(|error| {
+                                error as &dynamo_kv_router::scheduling::ClassifyError
+                            }));
+                    }
+                }
+                return Err(error);
+            }
+        };
+        if let Some(lifecycle) = request_lifecycle.as_mut() {
+            lifecycle.selected(selection.worker);
+        }
+        selection.lifecycle = request_lifecycle;
+        Ok((selection, affinity_acquire))
     }
 
     pub(super) async fn track_selection(
@@ -71,6 +115,7 @@ where
             selected_worker,
             request,
             !is_query_only,
+            selection.lifecycle.take(),
         );
 
         let record_result: Result<(), Error> = async {
@@ -149,7 +194,10 @@ where
         .await;
 
         if let Err(error) = record_result {
-            guard.abort().await;
+            let typed_error = error
+                .chain()
+                .find_map(|cause| cause.downcast_ref::<DynamoError>().cloned());
+            guard.abort_with_error(typed_error.as_ref()).await;
             return Err(error);
         }
         Ok(guard)
@@ -216,8 +264,12 @@ where
                 let typed_error = error
                     .chain()
                     .find_map(|cause| cause.downcast_ref::<DynamoError>().cloned());
-                guard.record_migration_failure(typed_error);
-                guard.abort().await;
+                guard.record_migration_failure(typed_error.clone());
+                if !crate::migration::is_migratable(error.as_ref())
+                    || !guard.release_for_retry().await
+                {
+                    guard.abort_with_error(typed_error.as_ref()).await;
+                }
                 return Err(error);
             }
         };

--- a/lib/llm/src/kv_router/routing_host/kv_selection.rs
+++ b/lib/llm/src/kv_router/routing_host/kv_selection.rs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
-
 use dynamo_kv_router::{
     RouterConfigOverride,
     indexer::RoutingDecisionHashes,
@@ -12,6 +10,8 @@ use dynamo_kv_router::{
     selector::WorkerSelector,
 };
 use dynamo_runtime::{dynamo_nvtx_range, pipeline::Error};
+use std::collections::HashSet;
+use std::time::Instant;
 
 use crate::{
     kv_router::{
@@ -34,11 +34,13 @@ pub(super) struct WorkerSelection {
     pub(super) cached_tokens: usize,
     pub(super) routing_hashes: Option<RoutingDecisionHashes>,
     pub(super) router_hint: Option<RouterHint>,
+    pub(super) lifecycle: Option<Box<dynamo_kv_router::scheduling::RequestLifecycle>>,
 }
 
 #[derive(Clone, Copy)]
 pub(super) struct RoutingRequestParts<'a> {
     pub(super) token_ids: &'a [TokenIdType],
+    pub(super) input_tokens: usize,
     pub(super) block_mm_infos: Option<&'a [Option<BlockExtraInfo>]>,
 }
 
@@ -47,6 +49,7 @@ impl<'a> RoutingRequestParts<'a> {
         let (token_ids, block_mm_infos) = request.block_mm_routing_info();
         Self {
             token_ids,
+            input_tokens: request.input_token_count(),
             block_mm_infos,
         }
     }
@@ -60,6 +63,7 @@ pub(super) struct SelectionOptions {
 
 struct BestMatchArgs<'a> {
     context_id: &'a str,
+    ingress_at: Instant,
     routing_parts: RoutingRequestParts<'a>,
     router_config_override: Option<&'a RouterConfigOverride>,
     update_states: bool,
@@ -85,7 +89,9 @@ where
             .kv_router()
             .find_best_match_details_with_policy_class_inner(
                 Some(args.context_id),
+                args.ingress_at,
                 args.routing_parts.token_ids,
+                args.routing_parts.input_tokens,
                 args.routing_parts.block_mm_infos,
                 args.router_config_override,
                 args.update_states,
@@ -127,6 +133,7 @@ where
                 cached_tokens,
                 routing_hashes,
                 router_hint,
+                lifecycle: None,
             }),
             FindBestMatchOutcome::QueueRejected { rejection } => Err(rejection.into()),
         }
@@ -143,6 +150,10 @@ where
         options: SelectionOptions,
     ) -> Result<WorkerSelection, Error> {
         let _nvtx_select = dynamo_nvtx_range!("route.select_worker");
+        let ingress_at = request
+            .tracker
+            .as_deref()
+            .map_or_else(Instant::now, |tracker| tracker.request_received());
         let routing = request.routing.as_ref();
         let explicit_pin = pinned_worker_hint(phase, routing);
         let lora_name = routing.and_then(|routing| routing.lora_name.clone());
@@ -222,6 +233,7 @@ where
             let selection = self
                 .select_best_match(BestMatchArgs {
                     context_id,
+                    ingress_at,
                     routing_parts,
                     router_config_override: request.router_config_override.as_ref(),
                     update_states: !is_query_only,
@@ -294,6 +306,7 @@ where
 
         self.select_best_match(BestMatchArgs {
             context_id,
+            ingress_at,
             routing_parts,
             router_config_override: request.router_config_override.as_ref(),
             update_states: !is_query_only,

--- a/lib/llm/src/kv_router/routing_host/request_guard.rs
+++ b/lib/llm/src/kv_router/routing_host/request_guard.rs
@@ -22,6 +22,7 @@ use dynamo_kv_router::{
         BlockExtraInfo, BlockHashOptions, WorkerWithDpRank, compute_block_hash_for_seq,
         compute_next_seq_hash,
     },
+    scheduling::{ClassifyError, RequestLifecycle},
     selector::WorkerSelector,
 };
 use dynamo_runtime::{
@@ -575,6 +576,7 @@ where
     record_itl_at_completion: bool,
     prefill_marked: bool,
     migration_state: Option<MigrationState>,
+    request_lifecycle: Option<Box<RequestLifecycle>>,
     _lora_load: Option<LoraLoadGuard>,
 }
 
@@ -589,11 +591,15 @@ where
         worker: WorkerWithDpRank,
         request: &PreprocessedRequest,
         scheduler_tracked: bool,
+        mut request_lifecycle: Option<Box<RequestLifecycle>>,
     ) -> Self {
         // Snapshot request-scoped inputs now so the guard can outlive the
         // PreprocessedRequest after it is moved into backend dispatch.
         let block_size = chooser.block_size() as usize;
         let isl_tokens = request.token_ids.len();
+        if let Some(lifecycle) = request_lifecycle.as_mut() {
+            lifecycle.observe_input_tokens(request.input_token_count());
+        }
         let expected_output_tokens = request
             .routing
             .as_ref()
@@ -635,6 +641,7 @@ where
             record_itl_at_completion: false,
             prefill_marked: false,
             migration_state: request.migration_state.clone(),
+            request_lifecycle,
             _lora_load: None,
         }
     }
@@ -664,6 +671,7 @@ where
             record_itl_at_completion: true,
             prefill_marked: false,
             migration_state: request.migration_state.clone(),
+            request_lifecycle: None,
             _lora_load: lora_load,
         }
     }
@@ -692,6 +700,16 @@ where
 
     pub(super) fn mark_dispatched(&mut self) {
         self.observability.mark_dispatched();
+        if let Some(lifecycle) = self.request_lifecycle.as_mut() {
+            let worker = match &self.cleanup {
+                RequestCleanup::Kv(cleanup) => cleanup.worker,
+                RequestCleanup::Stateless { worker_id }
+                | RequestCleanup::Occupancy { worker_id, .. } => {
+                    WorkerWithDpRank::from_worker_id(*worker_id)
+                }
+            };
+            lifecycle.sent(worker);
+        }
     }
 
     pub(super) fn has_approximate_lru(&self) -> bool {
@@ -732,9 +750,23 @@ where
     }
 
     pub(super) async fn on_item(&mut self, item: &Annotated<LLMEngineOutput>) {
+        if let Some(lifecycle) = self.request_lifecycle.as_mut() {
+            lifecycle.responding();
+        }
         self.observability.observe_response();
 
         let new_tokens = item.data.as_ref().map_or(0, |data| data.token_ids.len());
+        if let Some(lifecycle) = self.request_lifecycle.as_mut() {
+            lifecycle.observe_output_tokens(new_tokens);
+            if let Some(total_tokens) = item
+                .data
+                .as_ref()
+                .and_then(|data| data.completion_usage.as_ref())
+                .map(|usage| usage.total_tokens as usize)
+            {
+                lifecycle.observe_context_tokens(total_tokens);
+            }
+        }
         if !self.prefill_marked {
             let has_tokens = item
                 .data
@@ -799,6 +831,9 @@ where
     }
 
     pub(super) async fn finish(&mut self) {
+        if let Some(lifecycle) = self.request_lifecycle.as_mut() {
+            lifecycle.complete();
+        }
         // Metrics must observe the completed request before cleanup releases its state.
         self.observability
             .record_metrics(self.record_itl_at_completion);
@@ -827,6 +862,29 @@ where
     }
 
     pub(super) async fn abort(&mut self) {
+        self.abort_with_error(None).await;
+    }
+
+    pub(super) async fn release_for_retry(&mut self) -> bool {
+        let Some(migration_state) = self.migration_state.as_ref() else {
+            return false;
+        };
+        let Some(mut lifecycle) = self.request_lifecycle.take() else {
+            return false;
+        };
+        lifecycle.prepare_retry();
+        migration_state.store_request_lifecycle(lifecycle);
+        if let Some(lease) = &self.approximate_lru {
+            lease.release_now();
+        }
+        self.cleanup.finish().await;
+        true
+    }
+
+    pub(super) async fn abort_with_error(&mut self, error: Option<&DynamoError>) {
+        if let Some(lifecycle) = self.request_lifecycle.as_mut() {
+            lifecycle.abort(error.map(|error| error as &ClassifyError));
+        }
         if let Some(lease) = &self.approximate_lru {
             lease.release_now();
         }
@@ -839,6 +897,9 @@ where
     Sel: WorkerSelector<ModelRuntimeConfig> + Send + 'static,
 {
     fn drop(&mut self) {
+        if let Some(lifecycle) = self.request_lifecycle.as_mut() {
+            lifecycle.abort(None);
+        }
         self.observability
             .record_metrics(self.record_itl_at_completion);
         if let Some(lease) = &self.approximate_lru {

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -14,7 +14,9 @@ use dynamo_kv_router::{
     DefaultWorkerSelector, WorkerSelectionPolicy,
     config::KvRouterConfig,
     protocols::RoutingConstraints,
-    scheduling::{ClassifyEvent, ClassifyFuture, ClassifyRequest, RequestClassifier},
+    scheduling::{
+        ClassifyError, ClassifyEvent, ClassifyFuture, ClassifyRequest, RequestClassifier,
+    },
 };
 use dynamo_runtime::{
     DistributedRuntime, Runtime,
@@ -793,6 +795,90 @@ impl RequestClassifier for RecordingClassifier {
             self.observations.send(observation).unwrap();
         }
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("classifier rejected request")]
+struct ClassifierRejected;
+
+#[test]
+fn classification_failures_are_not_affinity_retryable() {
+    let failures = [
+        KvSchedulerError::RequestClassifierPanicked("panic".to_string()),
+        KvSchedulerError::RequestClassifierFailed(
+            Box::new(ClassifierRejected) as Box<ClassifyError>
+        ),
+        KvSchedulerError::RequestClassifierReplacedRequest,
+        KvSchedulerError::DuplicateClassificationRequestId("request".to_string()),
+        KvSchedulerError::InvalidClassificationMetadata("metadata".to_string()),
+    ];
+
+    for failure in failures {
+        let error = anyhow::Error::from(failure);
+        assert!(classification_failure(&error).is_some());
+    }
+    assert!(classification_failure(&anyhow::Error::from(KvSchedulerError::NoEndpoints)).is_none());
+}
+
+struct RejectingClassifier {
+    calls: Arc<AtomicUsize>,
+    observations: mpsc::UnboundedSender<Option<(bool, String)>>,
+}
+
+impl RequestClassifier for RejectingClassifier {
+    fn classify(&mut self, _request: ClassifyRequest) -> ClassifyFuture {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Box::pin(async { Err(Box::new(ClassifierRejected) as Box<ClassifyError>) })
+    }
+
+    fn on_event(&mut self, event: ClassifyEvent<'_>) {
+        if let ClassifyEvent::Aborted { error, .. } = event {
+            self.observations
+                .send(error.map(|error| {
+                    (
+                        error.downcast_ref::<ClassifierRejected>().is_some(),
+                        error.to_string(),
+                    )
+                }))
+                .unwrap();
+        }
+    }
+}
+
+#[tokio::test]
+async fn classifier_failure_aborts_once_with_original_error() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (observations_tx, mut observations_rx) = mpsc::unbounded_channel();
+    let (router, runtime) = router_with_classifier(
+        RejectingClassifier {
+            calls: Arc::clone(&calls),
+            observations: observations_tx,
+        },
+        Some(Duration::from_secs(10)),
+    )
+    .await;
+    let session_id = SessionAffinityId::new("classifier-failure-stale-affinity");
+    bind_affinity_target(&router, &session_id, AffinityTarget::new(7, Some(1))).await;
+    let mut request = Context::new(request());
+    request.insert(SESSION_AFFINITY_CONTEXT_KEY, session_id);
+
+    assert!(
+        router
+            .select_with_affinity(&request, RequestPhase::Aggregated, false)
+            .await
+            .is_err()
+    );
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), observations_rx.recv())
+            .await
+            .expect("classifier abort event timed out"),
+        Some(Some((true, "classifier rejected request".to_string())))
+    );
+    assert!(observations_rx.try_recv().is_err());
+
+    drop(router);
+    runtime.shutdown();
 }
 
 #[tokio::test]

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -5,14 +5,16 @@ use std::{
     collections::{HashMap, HashSet},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::{Duration, Instant},
 };
 
 use dynamo_kv_router::{
-    DefaultWorkerSelector, WorkerSelectionPolicy, config::KvRouterConfig,
+    DefaultWorkerSelector, WorkerSelectionPolicy,
+    config::KvRouterConfig,
     protocols::RoutingConstraints,
+    scheduling::{ClassifyEvent, ClassifyFuture, ClassifyRequest, RequestClassifier},
 };
 use dynamo_runtime::{
     DistributedRuntime, Runtime,
@@ -27,7 +29,7 @@ use dynamo_runtime::{
     storage::kv::Selector,
     traits::DistributedRuntimeProvider,
 };
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 
 use super::*;
 use crate::{
@@ -37,6 +39,7 @@ use crate::{
     lora::{LoraReplicaConfig, LoraRoutingTable, LoraStateTracker},
     migration::Migration,
     protocols::common::extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
+    protocols::common::preprocessor::MmRoutingInfo,
 };
 
 fn request() -> PreprocessedRequest {
@@ -566,6 +569,7 @@ async fn terminal_item_does_not_skip_transport_eof() {
         WorkerWithDpRank::from_worker_id(0),
         &request(),
         false,
+        None,
     );
     let monitored = monitor_response_stream(source, context, guard);
     tokio::pin!(monitored);
@@ -702,6 +706,230 @@ async fn router_with_worker_configs(
         .override_discovered_instances(worker_ids.clone());
     router.inner.client.override_instance_avail(worker_ids);
     (router, runtime)
+}
+
+async fn router_with_classifier(
+    classifier: impl RequestClassifier,
+    session_affinity_ttl: Option<Duration>,
+) -> (RoutingHost, Runtime) {
+    let runtime = Runtime::from_current().unwrap();
+    let distributed = DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+        .await
+        .unwrap();
+    let endpoint = distributed
+        .namespace("request-classifier-routing-host".to_string())
+        .unwrap()
+        .component("workers".to_string())
+        .unwrap()
+        .endpoint("generate");
+    let client = endpoint.client().await.unwrap();
+    let worker_id = 7;
+    let (_tx, workers) =
+        watch::channel(HashMap::from([(worker_id, ModelRuntimeConfig::default())]));
+    let config = KvRouterConfig {
+        skip_initial_worker_wait: true,
+        use_kv_events: false,
+        router_track_active_blocks: false,
+        ..Default::default()
+    };
+    let chooser = KvRouter::new(
+        endpoint,
+        client.clone(),
+        workers,
+        None,
+        16,
+        DefaultWorkerSelector::new(Some(config.clone()), "decode"),
+        Some(config),
+        None,
+        "decode",
+        None,
+        false,
+        None,
+        None,
+    )
+    .await
+    .unwrap()
+    .with_request_classifier(classifier)
+    .unwrap();
+    let inner = PushRouter::from_client(client, RouterMode::KV)
+        .await
+        .unwrap();
+    let router = RoutingHost::new(inner, Arc::new(chooser), session_affinity_ttl).unwrap();
+    router
+        .inner
+        .client
+        .override_discovered_instances(vec![worker_id]);
+    router.inner.client.override_instance_avail(vec![worker_id]);
+    (router, runtime)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ClassifierObservation {
+    Completed(usize),
+    Aborted,
+}
+
+struct RecordingClassifier {
+    calls: Arc<AtomicUsize>,
+    observations: mpsc::UnboundedSender<ClassifierObservation>,
+}
+
+impl RequestClassifier for RecordingClassifier {
+    fn classify(&mut self, request: ClassifyRequest) -> ClassifyFuture {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Box::pin(async move { Ok(request) })
+    }
+
+    fn on_event(&mut self, event: ClassifyEvent<'_>) {
+        let observation = match event {
+            ClassifyEvent::Completed {
+                context_tokens: Some(context_tokens),
+                ..
+            } => Some(ClassifierObservation::Completed(context_tokens)),
+            ClassifyEvent::Aborted { .. } => Some(ClassifierObservation::Aborted),
+            _ => None,
+        };
+        if let Some(observation) = observation {
+            self.observations.send(observation).unwrap();
+        }
+    }
+}
+
+#[tokio::test]
+async fn stale_affinity_rebind_classifies_once_without_intermediate_abort() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (observations_tx, mut observations_rx) = mpsc::unbounded_channel();
+    let (router, runtime) = router_with_classifier(
+        RecordingClassifier {
+            calls: Arc::clone(&calls),
+            observations: observations_tx,
+        },
+        Some(Duration::from_secs(10)),
+    )
+    .await;
+    let session_id = SessionAffinityId::new("classifier-stale-affinity");
+    bind_affinity_target(&router, &session_id, AffinityTarget::new(7, Some(1))).await;
+    let mut request = Context::new(request());
+    request.insert(SESSION_AFFINITY_CONTEXT_KEY, session_id);
+
+    let (mut selection, operation) = router
+        .select_with_affinity(&request, RequestPhase::Aggregated, false)
+        .await
+        .unwrap();
+
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+    assert!(observations_rx.try_recv().is_err());
+    let mut lifecycle = selection.lifecycle.take().unwrap();
+    lifecycle.observe_context_tokens(1);
+    lifecycle.complete();
+    assert_eq!(
+        observations_rx.recv().await,
+        Some(ClassifierObservation::Completed(1))
+    );
+    router.kv_router().free(request.id()).await.unwrap();
+
+    drop(operation);
+    drop(router);
+    runtime.shutdown();
+}
+
+#[tokio::test]
+async fn query_only_selection_bypasses_classifier_and_request_lifecycle() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (observations_tx, mut observations_rx) = mpsc::unbounded_channel();
+    let (router, runtime) = router_with_classifier(
+        RecordingClassifier {
+            calls: Arc::clone(&calls),
+            observations: observations_tx,
+        },
+        None,
+    )
+    .await;
+    let request = Context::new(request());
+
+    let (selection, operation) = router
+        .select_with_affinity(&request, RequestPhase::Aggregated, true)
+        .await
+        .unwrap();
+
+    assert_eq!(calls.load(Ordering::Relaxed), 0);
+    assert!(selection.lifecycle.is_none());
+    assert!(operation.is_none());
+    drop(selection);
+    assert!(observations_rx.try_recv().is_err());
+
+    drop(router);
+    runtime.shutdown();
+}
+
+struct TokenContractClassifier {
+    classified: mpsc::UnboundedSender<usize>,
+    completed: mpsc::UnboundedSender<usize>,
+}
+
+impl RequestClassifier for TokenContractClassifier {
+    fn classify(&mut self, request: ClassifyRequest) -> ClassifyFuture {
+        self.classified.send(request.input_tokens()).unwrap();
+        Box::pin(async move { Ok(request) })
+    }
+
+    fn on_event(&mut self, event: ClassifyEvent<'_>) {
+        if let ClassifyEvent::Completed {
+            context_tokens: Some(context_tokens),
+            ..
+        } = event
+        {
+            self.completed.send(context_tokens).unwrap();
+        }
+    }
+}
+
+#[tokio::test]
+async fn classifier_and_completion_use_authoritative_multimodal_token_counts() {
+    let (classified_tx, mut classified_rx) = mpsc::unbounded_channel();
+    let (completed_tx, mut completed_rx) = mpsc::unbounded_channel();
+    let (router, runtime) = router_with_classifier(
+        TokenContractClassifier {
+            classified: classified_tx,
+            completed: completed_tx,
+        },
+        None,
+    )
+    .await;
+    let mut content = request();
+    content.mm_routing_info = Some(MmRoutingInfo {
+        routing_token_ids: vec![1, 2, 3, 4, 5, 0, 0, 0],
+        block_mm_infos: vec![None],
+        expanded_prompt_len: 5,
+    });
+    let request = Context::new(content);
+    let (mut selection, _) = router
+        .select_with_affinity(&request, RequestPhase::Aggregated, false)
+        .await
+        .unwrap();
+    assert_eq!(classified_rx.recv().await, Some(5));
+
+    let mut guard = router
+        .track_selection(&request, &mut selection, false)
+        .await
+        .unwrap();
+    guard.mark_dispatched();
+    let output = LLMEngineOutput {
+        completion_usage: Some(dynamo_protocols::types::CompletionUsage {
+            prompt_tokens: 5,
+            completion_tokens: 6,
+            total_tokens: 11,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+        }),
+        ..Default::default()
+    };
+    guard.on_item(&Annotated::from_data(output)).await;
+    guard.finish().await;
+    assert_eq!(completed_rx.recv().await, Some(11));
+
+    drop(router);
+    runtime.shutdown();
 }
 
 async fn track_request(
@@ -1330,6 +1558,8 @@ async fn worker_overload_stream_migration_releases_and_reselects() {
         router_track_active_blocks: false,
         ..Default::default()
     };
+    let classifier_calls = Arc::new(AtomicUsize::new(0));
+    let (classifier_observations_tx, mut classifier_observations_rx) = mpsc::unbounded_channel();
     let chooser = KvRouter::new_with_worker_role_and_scheduler_load(
         endpoint,
         client.clone(),
@@ -1349,6 +1579,11 @@ async fn worker_overload_stream_migration_releases_and_reselects() {
         load_context.cancellation_token(),
     )
     .await
+    .unwrap()
+    .with_request_classifier(RecordingClassifier {
+        calls: Arc::clone(&classifier_calls),
+        observations: classifier_observations_tx,
+    })
     .unwrap();
     let dispatch = Arc::new(RejectFirstDispatch::default());
     let push_router =
@@ -1373,6 +1608,12 @@ async fn worker_overload_stream_migration_releases_and_reselects() {
     assert_eq!(responses.len(), 1);
     assert!(responses[0].error.is_none());
     assert_eq!(responses[0].data.as_ref().unwrap().token_ids, vec![2]);
+    assert_eq!(classifier_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        classifier_observations_rx.recv().await,
+        Some(ClassifierObservation::Completed(2))
+    );
+    assert!(classifier_observations_rx.try_recv().is_err());
     let attempts = {
         let attempts = dispatch.attempts.lock().unwrap();
         attempts.clone()

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -7,8 +7,8 @@ pub use dynamo_kv_router::scheduling::overlap_refresh::{
 };
 pub use dynamo_kv_router::scheduling::{
     AdvisorySchedulingResponse, KvSchedulerError, LocalScheduler, NonMaxOverlapSelectionObserver,
-    OverloadedWorkerProvider, PotentialLoad, ScheduleRequest, SchedulingRequest,
-    SchedulingResponse, TierOverlapBlocks, WorkerAvailabilityProvider,
+    OverloadedWorkerProvider, PotentialLoad, RequestClassifier, RequestLifecycle, ScheduleRequest,
+    SchedulingRequest, SchedulingResponse, TierOverlapBlocks, WorkerAvailabilityProvider,
 };
 pub use dynamo_kv_router::selector::DefaultWorkerSelector;
 use dynamo_kv_router::selector::WorkerSelector as WorkerSelectorTrait;
@@ -32,7 +32,7 @@ use dynamo_runtime::traits::DistributedRuntimeProvider;
 use dynamo_tokens::SequenceHash;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 pub struct KvScheduler<Sel = DefaultWorkerSelector, RF = NoopOverlapScoresRefresh>
@@ -185,6 +185,14 @@ where
         })
     }
 
+    pub(crate) fn install_request_classifier(
+        &self,
+        classifier: Box<dyn RequestClassifier>,
+        shutdown: CancellationToken,
+    ) -> bool {
+        self.inner.install_request_classifier(classifier, shutdown)
+    }
+
     pub async fn schedule_request(
         &self,
         request: ScheduleRequest,
@@ -192,6 +200,30 @@ where
         let response = self.inner.schedule_request(request).await;
         self.observe_schedule_result(&response);
         response
+    }
+
+    pub(super) async fn schedule_request_with_ingress_at(
+        &self,
+        request: ScheduleRequest,
+        ingress_at: Instant,
+    ) -> Result<SchedulingResponse, KvSchedulerError> {
+        let response = self
+            .inner
+            .schedule_request_with_ingress_at(request, ingress_at)
+            .await;
+        self.observe_schedule_result(&response);
+        response
+    }
+
+    pub(crate) fn begin_request_lifecycle(
+        &self,
+        request_id: &str,
+    ) -> Result<Option<RequestLifecycle>, KvSchedulerError> {
+        self.inner.begin_request_lifecycle(request_id)
+    }
+
+    pub(crate) fn has_request_classifier(&self) -> bool {
+        self.inner.has_request_classifier()
     }
 
     #[expect(clippy::too_many_arguments)]

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -60,7 +60,7 @@ impl HasTokenIds for LLMEngineOutput {
 }
 
 /// Check if an error chain indicates the request should be migrated.
-fn is_migratable(err: &(dyn StdError + 'static)) -> bool {
+pub(crate) fn is_migratable(err: &(dyn StdError + 'static)) -> bool {
     const MIGRATABLE: &[ErrorType] = &[
         ErrorType::CannotConnect,
         ErrorType::Disconnected,
@@ -369,6 +369,11 @@ where
                         continue;
                     }
                 }
+                if let Some(error) = response.error.as_ref()
+                    && let Some(state) = self.request.migration_state.as_ref()
+                {
+                    state.abort_request_lifecycle(Some(error));
+                }
                 self.track_response(&response);
                 return Some(response);
             }
@@ -437,6 +442,12 @@ where
                 Ok(())
             }
             Some(Err(err)) => {
+                let typed_error = err
+                    .chain()
+                    .find_map(|cause| cause.downcast_ref::<DynamoError>());
+                if let Some(state) = self.request.migration_state.as_ref() {
+                    state.abort_request_lifecycle(typed_error);
+                }
                 let outcome =
                     if error::match_error_chain(err.as_ref(), &[ErrorType::Cancelled], &[]) {
                         frontend_service::migration_outcome::CANCELLED

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -9,6 +9,7 @@ use dynamo_kv_router::{
     config::RouterConfigOverride,
     protocols::{BlockExtraInfo, RoutingConstraints, WorkerId},
     router_hint::{ROUTER_HINT_EXTRA_ARGS_KEY, RouterHint},
+    scheduling::{ClassifyError, RequestLifecycle},
 };
 use dynamo_runtime::error::{DynamoError, ErrorType, match_error_chain};
 use serde::{Deserialize, Serialize};
@@ -121,8 +122,9 @@ pub struct TraceLink {
 }
 
 /// Frontend-local state shared by every attempt from one migration manager.
-/// The selected router records a failed worker before the error is exposed;
-/// later attempts use the accumulated set as an attempt-local exclusion.
+///
+/// It carries attempt-local worker exclusions and, when a classifier is configured,
+/// the logical request lifecycle between serialized attempts.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct MigrationState {
     inner: Arc<OnceLock<Mutex<MigrationStateInner>>>,
@@ -132,6 +134,7 @@ pub(crate) struct MigrationState {
 struct MigrationStateInner {
     excluded_worker_ids: Vec<WorkerId>,
     last_error: Option<DynamoError>,
+    request_lifecycle: Option<Box<RequestLifecycle>>,
 }
 
 impl MigrationState {
@@ -188,6 +191,35 @@ impl MigrationState {
                 .message(message)
                 .build(),
         )
+    }
+
+    pub(crate) fn take_request_lifecycle(&self) -> Option<Box<RequestLifecycle>> {
+        self.inner
+            .get()?
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .request_lifecycle
+            .take()
+    }
+
+    pub(crate) fn store_request_lifecycle(&self, lifecycle: Box<RequestLifecycle>) {
+        let replaced = self
+            .inner
+            .get_or_init(Default::default)
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .request_lifecycle
+            .replace(lifecycle);
+        if replaced.is_some() {
+            tracing::warn!("Replacing an unclaimed request-classifier migration lifecycle");
+        }
+    }
+
+    pub(crate) fn abort_request_lifecycle(&self, error: Option<&DynamoError>) {
+        let Some(mut lifecycle) = self.take_request_lifecycle() else {
+            return;
+        };
+        lifecycle.abort(error.map(|error| error as &ClassifyError));
     }
 }
 
@@ -483,6 +515,14 @@ impl PreprocessedRequest {
             return (&self.token_ids, None);
         }
         (tokens, Some(mm.block_mm_infos.as_slice()))
+    }
+
+    /// Return the unpadded prompt size seen by the model.
+    pub(crate) fn input_token_count(&self) -> usize {
+        self.mm_routing_info
+            .as_ref()
+            .filter(|mm| !mm.routing_token_ids.is_empty() && mm.expanded_prompt_len > 0)
+            .map_or(self.token_ids.len(), |mm| mm.expanded_prompt_len)
     }
 }
 

--- a/lib/llm/src/protocols/common/timing.rs
+++ b/lib/llm/src/protocols/common/timing.rs
@@ -339,6 +339,10 @@ impl RequestTracker {
         self.request_received_epoch_ms
     }
 
+    pub(crate) fn request_received(&self) -> Instant {
+        self.request_received
+    }
+
     /// KV cache hit rate as a ratio (0.0 to 1.0).
     pub fn kv_hit_rate(&self) -> Option<f64> {
         let overlap = *self.kv_overlap_blocks.get()?;


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This adds an opt-in asynchronous request-classifier seam before Dynamo's existing policy-class scheduler, following DEP #13891. A classifier can hold one request without blocking the scheduler, then return the same request with validated class, due-time, or DRR-cost overrides while Dynamo retains queueing, placement, cancellation, and lifecycle ownership.

### How This Was Implemented
- Add an owned `ClassifyRequest` and `RequestClassifier` whose `classify(&mut self, request)` returns an independently pollable `'static` future; the default implementation returns immediately.
- Validate classifier overrides before queue admission, order dated requests by earliest due time within each class, and keep the existing cross-class DRR and worker-selection paths.
- Deliver synchronous `Sent`, optional `Received`, `Responding`, `Completed`, and `Aborted` notifications without holding the classifier lock while a classify future is pending.
- Preserve one logical classification and one terminal lifecycle across stale-affinity reselection and worker migration.
- Attach the feature through one opt-in `KvRouter::with_request_classifier(...)` method; the existing constructor and unconfigured scheduling behavior remain unchanged.

<details>
<summary>Walkthrough</summary>

#### Mental model

The router still owns scheduling and worker selection. The new plugin only decides when its request may continue and may update the scheduling metadata that the existing queue consumes.

```mermaid
flowchart LR
    A["Preprocessed router request"] --> B["RequestClassifier future"]
    E["Response lifecycle events"] --> C["Classifier-owned state"]
    C --> B
    B -->|"same request + optional overrides"| D["Policy class queue + DRR"]
    D --> F["Existing worker selection"]
    F --> G["Dispatch and response path"]
    G --> E
```

Each invocation receives an owned request view with request identity, exact input-token count, current policy class, and optional session metadata. Returning a different in-flight request is rejected using a private invocation identity; zero scheduling cost, an unknown class, and an already-expired due time are also rejected before queueing.

#### State and ordering

Pending classifier futures run in their request tasks, not in the scheduler actor. The runtime locks the plugin only long enough to construct a future or deliver one short lifecycle callback, so another request and `on_event()` can make progress while a classification waits.

Every returned request follows the existing scheduler path. The effective class selects the router-owned class queue, DRR continues to choose across classes, and the earliest due request wins within the chosen class before existing strict-priority and queue-policy tie breakers; an expired queued request is rejected even when no external queue update arrives.

#### Request lifecycle

Lifecycle ownership begins before classification. Successful dispatch emits `Sent`, the first response emits `Responding`, and normal completion emits one `Completed` notification with accumulated input-plus-output context; selection, dispatch, stream, cancellation, and drop failures converge on one `Aborted` notification.

Worker migration transfers a boxed lifecycle handle through the existing migration state. Intermediate attempts reset only attempt-local worker state, reuse the original classifier result, and do not emit a terminal event; final success or exhaustion removes the live request exactly once.

#### Boundaries and limitations

This does not change worker filter, score, or pick interfaces, add placement hints, expose worker cache/capacity snapshots, refresh overlap after a classifier wait, impose a classifier-specific pending limit, or add a ThunderAgent implementation. Classifier callbacks are synchronous and must return promptly; long waits belong inside the independently pollable classify future.

The configured router must be driven through `RoutingHost` so response-path notifications are available. Requests do not occupy a policy-class queue slot until classification returns, while request cancellation and router shutdown still drop the pending future and terminate the logical lifecycle.

</details>

### Validation
- `cargo test -p dynamo-kv-router --lib` (932 passed, 2 ignored)
- `cargo test -p dynamo-llm kv_router::routing_host::tests --lib` (24 passed)
- `cargo test -p dynamo-llm worker_overload_stream_migration_releases_and_reselects --lib`
- `cargo clippy -p dynamo-kv-router --lib -- -D warnings`
- `cargo clippy -p dynamo-llm --lib -- -D warnings`
- `cargo fmt --all`

Related to #13891
<!-- codex-pr-description:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable request classification for scheduling and routing.
  * Added request lifecycle tracking across dispatch, responses, retries, completion, and cancellation.
  * Added policy-based due times, including deadline-aware queueing and expiration handling.
  * Added support for request metadata such as policy class, token counts, and scheduling cost.

* **Bug Fixes**
  * Improved retry and migration handling for failed or cancelled requests.
  * Corrected HTTP error mapping for expired requests and classification failures.
  * Prevented duplicate cleanup during response-stream failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

CLOSES: DYN-3885