### PR TITLE
test(replay): cover overlapping Dynamo trace arrivals

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/traffic.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/traffic.md
@@ -25,8 +25,8 @@ fixed number of requests are kept in flight; a new one starts as one finishes).
 
 | # | Shape | Set | Loop | Driven by |
 |---|---|---|---|---|
-| 1 | **mooncake trace** | `trace_path` | open-loop (default) | the trace's arrival timestamps, scaled by `arrival_speedup_ratio` |
-| 1c | **mooncake trace, capped** | `trace_path` + `replay_concurrency` | closed-loop | cap N in flight; **trace timestamps ignored** |
+| 1 | **timestamped trace** | `trace_path` | open-loop (default) | the trace's arrival timestamps, scaled by `arrival_speedup_ratio` |
+| 1c | **timestamped trace, capped** | `trace_path` + `replay_concurrency` | closed-loop | cap N in flight; **trace timestamps ignored** |
 | 2 | **synthetic request-rate** | `request_rate` (+ `isl`/`osl`/`num_request_ratio`) | open-loop | a fixed QPS (`synthetic_arrival_interval_ms = 1000 / request_rate`) |
 | 3 | **synthetic concurrency** | `concurrency` (+ `isl`/`osl`/`num_request_ratio`) | closed-loop | cap N in flight |
 | 4 | **synthetic KV load** | `kv_load_ratio` (+ `isl`/`osl`/`num_request_ratio`) | closed-loop | derive N from each candidate's aggregate decode/agg KV capacity |
@@ -35,6 +35,12 @@ fixed number of requests are kept in flight; a new one starts as one finishes).
 `trace_path` selects shape 1; otherwise it is synthetic and **exactly one** of
 `request_rate` (shape 2), `concurrency` (shape 3), or `kv_load_ratio` (shape 4) selects the
 sub-shape.
+
+Open-loop Mooncake and `dynamo.request.trace.v1` inputs preserve relative request arrival
+times. A request arrives when its timestamp is reached even if earlier requests are still
+running; admission can happen later when the scheduler has capacity. Replay models each
+request's prefill, decode, and terminal lifecycle, so a recorded request end time does not force
+the simulated duration.
 
 The closed-loop in-flight cap is resolved by `effective_in_flight_cap()` (`None` = open-loop):
 

--- a/lib/mocker/src/replay/entrypoints.rs
+++ b/lib/mocker/src/replay/entrypoints.rs
@@ -2235,7 +2235,7 @@ pub fn simulate_concurrency_live_workload_with_router_mode_and_options(
 mod tests {
     use super::*;
     use crate::common::protocols::{EngineType, SglangArgs, WorkerType};
-    use crate::loadgen::{SessionTrace, TurnTrace};
+    use crate::loadgen::{DynamoRequestTrace, SessionTrace, TurnTrace};
     use rstest::rstest;
     use std::io::Write;
     use tempfile::NamedTempFile;
@@ -2398,6 +2398,68 @@ mod tests {
         .unwrap_err();
 
         assert!(error.to_string().contains("first_arrival_timestamp_ms"));
+    }
+
+    #[test]
+    fn loaded_dynamo_trace_preserves_overlapping_arrivals() {
+        let mut file = NamedTempFile::new().unwrap();
+        for (request_id, received_ms, hash) in [("first", 1_000, 11), ("second", 1_001, 22)] {
+            writeln!(
+                file,
+                "{}",
+                serde_json::json!({
+                    "schema": "dynamo.request.trace.v1",
+                    "event_type": "request_end",
+                    "event_time_unix_ms": received_ms + 100,
+                    "request": {
+                        "request_id": request_id,
+                        "request_received_ms": received_ms,
+                        "output_tokens": 8,
+                        "replay": {
+                            "trace_block_size": 4,
+                            "input_length": 64,
+                            "input_sequence_hashes": vec![hash; 16],
+                        },
+                    },
+                })
+            )
+            .unwrap();
+        }
+
+        let trace =
+            DynamoRequestTrace::from_request_trace_files(&[file.path().to_path_buf()], Some(4))
+                .unwrap();
+        let DynamoRequestTrace::Standard(trace) = trace else {
+            panic!("single-turn request records must produce a standard trace");
+        };
+        let report = simulate_loaded_trace_with_router_mode_and_options(
+            MockEngineArgs::builder()
+                .block_size(4)
+                .num_gpu_blocks(256)
+                .max_num_batched_tokens(Some(64))
+                .max_num_seqs(Some(8))
+                .speedup_ratio(0.001)
+                .build()
+                .unwrap(),
+            None,
+            None,
+            trace,
+            1,
+            1.0,
+            ReplayRouterMode::RoundRobin,
+            true,
+            None,
+            SlaThresholds::default(),
+        )
+        .unwrap();
+
+        let mut records = report.per_request;
+        records.sort_by(|left, right| left.arrival_time_ms.total_cmp(&right.arrival_time_ms));
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].arrival_time_ms, 0.0);
+        assert_eq!(records[1].arrival_time_ms, 1.0);
+        assert!(records[1].first_admit_ms.unwrap() < records[0].terminal_time_ms);
+        assert!(records[0].terminal_time_ms > 100.0);
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

- verify `dynamo.request.trace.v1` arrival offsets survive the full loader and offline replay path
- prove a later request enters the simulated lifecycle before the earlier request terminates
- document open-loop arrival behavior and clarify that replay models request duration instead of forcing the recorded end time

## Validation

- `cargo test -p dynamo-mocker loaded_dynamo_trace_preserves_overlapping_arrivals -- --nocapture`
- `cargo test -p dynamo-mocker native_vllm_kv_router_does_not_observe_blocks_before_pass_completion -- --nocapture`
- `cargo test -p dynamo-data-gen lowering_preserves_timestamp_offsets_and_parallel_requests -- --nocapture`
- `cargo fmt --all --check`
- `uvx pre-commit run --files lib/mocker/src/replay/entrypoints.rs docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/traffic.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology from “mooncake trace” to “timestamped trace.”
  * Clarified how timestamped inputs preserve arrival timing and simulate request lifecycles.

* **Bug Fixes**
  * Improved offline replay of overlapping request records, preserving arrival order and concurrent execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->