### PR TITLE
feat: standalone EPP self-calibrates the KV event block size from live events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2561,6 +2561,7 @@ dependencies = [
  "prost-types 0.13.5",
  "rcgen",
  "reqwest 0.12.28",
+ "rmp-serde",
  "rustls 0.23.40",
  "rustls-pemfile",
  "serde",
@@ -2578,6 +2579,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "validator",
+ "zmq",
 ]
 
 [[package]]

--- a/deploy/inference-gateway/ext-proc/Cargo.toml
+++ b/deploy/inference-gateway/ext-proc/Cargo.toml
@@ -52,8 +52,10 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 uuid = { workspace = true }
 validator = { workspace = true }
+zmq = "0.10"
 
 [dev-dependencies]
+rmp-serde = { workspace = true }
 tempfile = { workspace = true }
 
 [package.metadata.cargo-machete]

--- a/deploy/inference-gateway/ext-proc/src/block_size_calibration.rs
+++ b/deploy/inference-gateway/ext-proc/src/block_size_calibration.rs
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Self-calibration of the KV event block size from live engine events.
+//!
+//! vLLM aligns the attention block size at engine boot for hybrid Mamba models
+//! ("attention page size >= mamba page size"), so the true KV event block size
+//! is only knowable from the running engine. The full dynamo vLLM worker reads
+//! it via `get_kv_cache_group_metadata`; the standalone EPP has no engine
+//! handle, so a misconfigured `DYN_KV_CACHE_BLOCK_SIZE` silently drops every
+//! event and degrades routing to load-only (the `Block not published` warning
+//! in `zmq_wire::convert`).
+//!
+//! In auto mode (`DYN_KV_CACHE_BLOCK_SIZE` unset or `0`), the calibrator opens
+//! one ZMQ SUB socket, connects it to every discovered worker's KV event
+//! endpoint, and adopts the block size of the first main-attention
+//! `BlockStored` event. Workers are registered with a provisional block size
+//! until then (scheduling works, KV overlap scoring stays off), and
+//! re-registered with the observed size by the next topology reconcile.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::mpsc;
+
+use dynamo_kv_router::zmq_wire::{KvCacheSpecKind, RawKvEvent, decode_event_batch};
+use tokio::sync::watch;
+
+/// Reads the block size persisted by a previous calibration, if any.
+/// The selection service pins the block size per model for the process
+/// lifetime, so a calibration lands by persisting the value and restarting;
+/// this is the read side used at boot.
+pub fn read_persisted_block_size(path: &str) -> Option<u32> {
+    let content = std::fs::read_to_string(Path::new(path)).ok()?;
+    content.trim().parse::<u32>().ok().filter(|v| *v > 0)
+}
+
+/// Persists the calibrated block size for the next boot to pick up.
+pub fn persist_block_size(path: &str, block_size: u32) -> std::io::Result<()> {
+    std::fs::write(Path::new(path), format!("{block_size}\n"))
+}
+
+/// Block size workers are registered with while auto-calibration is pending.
+/// Matches vLLM's default cache block size; mismatched events are dropped by
+/// the indexer until the observed size replaces it, which is the pre-existing
+/// load-only behavior.
+pub const PROVISIONAL_BLOCK_SIZE: u32 = 16;
+
+const POLL_TIMEOUT_MS: i64 = 1_000;
+
+/// Handle owned by the topology adapter: feeds worker endpoints to the probe
+/// thread and exposes the observed block size as a watch channel.
+pub struct BlockSizeCalibration {
+    endpoints_tx: mpsc::Sender<String>,
+    observed_rx: watch::Receiver<u32>,
+}
+
+impl BlockSizeCalibration {
+    /// Start the probe thread. It runs until the first main-attention
+    /// `BlockStored` event is observed, then publishes the size and exits.
+    pub fn start() -> Self {
+        let (endpoints_tx, endpoints_rx) = mpsc::channel::<String>();
+        let (observed_tx, observed_rx) = watch::channel(0u32);
+        std::thread::Builder::new()
+            .name("kv-block-size-probe".into())
+            .spawn(move || probe_loop(&endpoints_rx, &observed_tx))
+            .expect("spawning the calibration probe thread");
+        Self {
+            endpoints_tx,
+            observed_rx,
+        }
+    }
+
+    /// Observed block size; `None` until the first event calibrates it.
+    pub fn observed(&self) -> Option<u32> {
+        match *self.observed_rx.borrow() {
+            0 => None,
+            v => Some(v),
+        }
+    }
+
+    /// Watch channel so the topology reconcile can wake up on calibration.
+    pub fn subscribe(&self) -> watch::Receiver<u32> {
+        self.observed_rx.clone()
+    }
+
+    /// Connect the probe to a worker's KV event endpoint. Duplicates are fine,
+    /// the probe tracks what it already connected. No-op once calibrated.
+    pub fn add_endpoint(&self, endpoint: &str) {
+        let _ = self.endpoints_tx.send(endpoint.to_string());
+    }
+}
+
+fn probe_loop(endpoints_rx: &mpsc::Receiver<String>, observed_tx: &watch::Sender<u32>) {
+    let ctx = zmq::Context::new();
+    let socket = match ctx.socket(zmq::SUB) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(error = %e, "Calibration probe failed to create its SUB socket");
+            return;
+        }
+    };
+    if let Err(e) = socket.set_subscribe(b"") {
+        tracing::error!(error = %e, "Calibration probe failed to subscribe");
+        return;
+    }
+
+    let mut connected: HashSet<String> = HashSet::new();
+    loop {
+        // Drain newly discovered endpoints; stop once the owning adapter is
+        // gone and no stream can ever deliver an event.
+        loop {
+            match endpoints_rx.try_recv() {
+                Ok(ep) => {
+                    if connected.insert(ep.clone())
+                        && let Err(e) = socket.connect(&ep)
+                    {
+                        tracing::warn!(endpoint = %ep, error = %e, "Calibration probe connect failed");
+                        connected.remove(&ep);
+                    }
+                }
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    if connected.is_empty() {
+                        return;
+                    }
+                    break;
+                }
+            }
+        }
+
+        match socket.poll(zmq::POLLIN, POLL_TIMEOUT_MS) {
+            Ok(0) => continue,
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(error = %e, "Calibration probe poll failed");
+                continue;
+            }
+        }
+        let Ok(frames) = socket.recv_multipart(0) else {
+            continue;
+        };
+        // Live event frames are [topic, seq, payload].
+        if frames.len() != 3 {
+            continue;
+        }
+        if let Some(size) = main_attention_block_size(&frames[2]) {
+            tracing::info!(
+                block_size = size,
+                "Calibrated KV event block size from live engine events"
+            );
+            let _ = observed_tx.send(size);
+            return;
+        }
+    }
+}
+
+/// Block size of the first main-attention `BlockStored` event in the batch.
+fn main_attention_block_size(payload: &[u8]) -> Option<u32> {
+    let batch = decode_event_batch(payload).ok()?;
+    batch.events.iter().find_map(|event| match event {
+        RawKvEvent::BlockStored {
+            block_size,
+            kv_cache_spec_kind,
+            ..
+        } if is_main_attention(kv_cache_spec_kind.as_ref()) => u32::try_from(*block_size).ok(),
+        _ => None,
+    })
+}
+
+/// Mirrors `MAIN_ATTENTION_KV_CACHE_KINDS` in the dynamo vLLM worker's
+/// `cache_info`. Untagged events come from single-group engines where every
+/// event carries the one true block size.
+fn is_main_attention(kind: Option<&KvCacheSpecKind>) -> bool {
+    matches!(
+        kind,
+        None | Some(
+            KvCacheSpecKind::FullAttention
+                | KvCacheSpecKind::MlaAttention
+                | KvCacheSpecKind::SinkFullAttention
+        )
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stored_event_payload(block_size: usize, kind: Option<&str>) -> Vec<u8> {
+        let mut event = serde_json::json!({
+            "type": "BlockStored",
+            "block_hashes": [1u64],
+            "parent_block_hash": null,
+            "token_ids": (0..block_size as u32).collect::<Vec<u32>>(),
+            "block_size": block_size,
+        });
+        if let Some(kind) = kind {
+            event["kv_cache_spec_kind"] = serde_json::json!(kind);
+        }
+        let batch = serde_json::json!([0.0, [event], null]);
+        rmp_serde::to_vec_named(&batch).expect("serializing test event batch")
+    }
+
+    #[test]
+    fn adopts_main_attention_block_size() {
+        let payload = stored_event_payload(2096, Some("full_attention"));
+        assert_eq!(main_attention_block_size(&payload), Some(2096));
+    }
+
+    #[test]
+    fn adopts_untagged_single_group_events() {
+        let payload = stored_event_payload(16, None);
+        assert_eq!(main_attention_block_size(&payload), Some(16));
+    }
+
+    #[test]
+    fn ignores_mamba_group_events() {
+        let payload = stored_event_payload(2096, Some("mamba"));
+        assert_eq!(main_attention_block_size(&payload), None);
+    }
+
+    #[test]
+    fn calibration_publishes_through_the_watch() {
+        let calibration = BlockSizeCalibration::start();
+        assert_eq!(calibration.observed(), None);
+    }
+}

--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -32,6 +32,7 @@ use dynamo_llm::protocols::common::extensions::{
 };
 use serde::Deserialize;
 
+use crate::block_size_calibration::BlockSizeCalibration;
 use crate::epp_standalone_config::EppStandaloneConfig;
 use crate::picker::{Endpoint, EndpointPicker, PickError, PickResult, RequestInfo};
 use crate::pod_discovery::PodDiscovery;
@@ -82,8 +83,15 @@ impl EppRouter {
         let reflector = Arc::new(reflector);
         let peer_ready = selector.peer_ready();
         let defaults = RegistrationDefaults::from_config(&cfg);
-        let adapter =
-            TopologyAdapter::spawn(reflector.as_ref().clone(), selector.clone(), defaults);
+        // Block size 0 = auto: probe the workers' KV event streams and adopt
+        // the observed main-attention block size.
+        let calibration = (cfg.block_size == 0).then(BlockSizeCalibration::start);
+        let adapter = TopologyAdapter::spawn(
+            reflector.as_ref().clone(),
+            selector.clone(),
+            defaults,
+            calibration,
+        );
 
         // Readiness is driven solely by the live pod+pool signal (see `is_ready`);
         // we do not block startup on a schedulable worker. A valid, empty pool is

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -24,6 +24,7 @@ const DEFAULT_TOKENIZER_MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 /// bodies so a burst can't exhaust memory. HTTP/2 stream multiplexing means the
 /// TCP-connection cap does not bound requests, so this is the actual guardrail.
 const DEFAULT_MAX_INFLIGHT_REQUESTS: usize = 1024;
+const DEFAULT_BLOCK_SIZE_STATE_FILE: &str = "/tmp/dyn-epp-calibrated-block-size";
 
 /// Environment variable that selects the EPP operating mode.
 pub const DYN_EPP_MODE: &str = "DYN_EPP_MODE";
@@ -112,8 +113,15 @@ pub struct EppStandaloneConfig {
     #[validate(range(min = 1, message = "DYN_EPP_TOKENIZER_MAX_RESPONSE_BYTES must be >= 1"))]
     pub tokenizer_max_response_bytes: usize,
     /// KV-cache block size; MUST equal the inference engine block size.
-    #[validate(range(min = 1, message = "DYN_KV_CACHE_BLOCK_SIZE must be >= 1"))]
+    /// `0` (the default) self-calibrates from the first observed KV event,
+    /// covering engines whose real block size is only known at boot (hybrid
+    /// Mamba models align it upward). A non-zero value pins it explicitly.
     pub block_size: u32,
+    /// Where the calibrated block size is persisted across restarts: the
+    /// selection service pins the block size per model for the process
+    /// lifetime, so adopting a calibrated value means persisting it here and
+    /// exiting; the next boot reads it back.
+    pub block_size_state_file: String,
     /// KV zmq event port.
     #[validate(range(min = 1))]
     pub kv_event_port: u16,
@@ -170,6 +178,8 @@ impl EppStandaloneConfig {
             )?
             .unwrap_or(DEFAULT_TOKENIZER_MAX_RESPONSE_BYTES),
             block_size: opt_parse::<u32>(get, "DYN_KV_CACHE_BLOCK_SIZE")?.unwrap_or(0),
+            block_size_state_file: get("DYN_EPP_BLOCK_SIZE_STATE_FILE")
+                .unwrap_or_else(|| DEFAULT_BLOCK_SIZE_STATE_FILE.to_string()),
             kv_event_port: opt_parse::<u16>(get, "DYN_EPP_KV_EVENT_PORT")?
                 .unwrap_or(DEFAULT_KV_EVENT_PORT),
             replay_port: opt_parse::<u16>(get, "DYN_EPP_KV_EVENT_REPLAY_PORT")?,
@@ -181,6 +191,17 @@ impl EppStandaloneConfig {
     }
 
     /// Enforce the `validator` constraints, mapping the failure to `anyhow`.
+    /// Block size workers are registered with at boot: the pinned value when
+    /// configured, else the persisted calibration from a previous run, else
+    /// the provisional default (load-only routing until calibration lands).
+    pub fn effective_block_size(&self) -> u32 {
+        if self.block_size > 0 {
+            return self.block_size;
+        }
+        crate::block_size_calibration::read_persisted_block_size(&self.block_size_state_file)
+            .unwrap_or(crate::block_size_calibration::PROVISIONAL_BLOCK_SIZE)
+    }
+
     pub fn validate_config(&self) -> anyhow::Result<()> {
         self.validate()
             .map_err(|e| anyhow::anyhow!("invalid {STANDALONE_MODE} EPP config: {e}"))
@@ -357,18 +378,19 @@ mod tests {
     }
 
     #[test]
-    fn zero_block_size_fails() {
-        assert!(
-            parse_cfg(&[
-                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
-                ("POD_NAMESPACE", "inference"),
-                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-                ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
-                ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
-                ("DYN_KV_CACHE_BLOCK_SIZE", "0"),
-            ])
-            .is_err()
-        );
+    fn zero_block_size_means_auto() {
+        let cfg = parse_cfg(&[
+            ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+            ("POD_NAMESPACE", "inference"),
+            ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+            ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+            ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
+            ("DYN_KV_CACHE_BLOCK_SIZE", "0"),
+        ])
+        .expect("config should parse");
+        assert_eq!(cfg.block_size, 0);
+        cfg.validate_config()
+            .expect("block size 0 is auto-calibration, not an error");
     }
 
     #[test]

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -12,6 +12,7 @@
 //! Envoy ──ext-proc──▶ ExtProcServer<epp::Router> ──EndpointPicker──▶ Dynamo KV Router
 //! ```
 
+pub mod block_size_calibration;
 pub mod envoy_helpers;
 pub mod epp;
 pub mod epp_router;
@@ -28,6 +29,7 @@ pub mod server;
 pub mod topology_adapter;
 pub mod vllm_render_client;
 
+pub use block_size_calibration::BlockSizeCalibration;
 pub use epp::Router;
 pub use epp_router::EppRouter;
 pub use epp_standalone_config::{EppMode, EppStandaloneConfig, TokenizerProtocol};

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -444,6 +444,7 @@ models:
             tokenizer_max_response_bytes: 16 * 1024 * 1024,
             tokenization_timeout_ms: 5_000,
             block_size: 16,
+            block_size_state_file: "/tmp/test-epp-block-size".to_string(),
             kv_event_port: 5557,
             replay_port: None,
             total_kv_blocks: None,

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 
 use tokio_util::sync::CancellationToken;
 
+use crate::block_size_calibration::BlockSizeCalibration;
 use crate::epp_standalone_config::EppStandaloneConfig;
 use crate::pod_discovery::{PodDiscovery, RawWorker};
 use crate::selector::{Selector, WorkerRegistration};
@@ -22,15 +23,17 @@ pub struct RegistrationDefaults {
     pub block_size: u32,
     pub total_kv_blocks: Option<u64>,
     pub max_num_batched_tokens: Option<u64>,
+    pub block_size_state_file: String,
 }
 
 impl RegistrationDefaults {
     pub fn from_config(cfg: &EppStandaloneConfig) -> Self {
         Self {
             model_name: cfg.model_name.clone(),
-            block_size: cfg.block_size,
+            block_size: cfg.effective_block_size(),
             total_kv_blocks: cfg.total_kv_blocks,
             max_num_batched_tokens: cfg.max_num_batched_tokens,
+            block_size_state_file: cfg.block_size_state_file.clone(),
         }
     }
 }
@@ -47,15 +50,56 @@ impl TopologyAdapter {
         reflector: PodDiscovery,
         selector: Arc<Selector>,
         defaults: RegistrationDefaults,
+        calibration: Option<BlockSizeCalibration>,
     ) -> Self {
         let cancel = CancellationToken::new();
         let cancel_child = cancel.clone();
         tokio::spawn(async move {
             let mut pod_changes = reflector.subscribe_changes();
+            let mut observed_changes = calibration.as_ref().map(BlockSizeCalibration::subscribe);
             loop {
-                reconcile_once(&reflector, selector.as_ref(), &defaults).await;
+                // The selection service pins the block size per model for the
+                // process lifetime (scheduler, slots and indexer are built once
+                // per model), so a newly calibrated size cannot be adopted live:
+                // persist it and exit; the next boot registers with it directly.
+                if let Some(observed) = calibration
+                    .as_ref()
+                    .and_then(BlockSizeCalibration::observed)
+                    && observed != defaults.block_size
+                {
+                    tracing::info!(
+                        previous = defaults.block_size,
+                        block_size = observed,
+                        state_file = %defaults.block_size_state_file,
+                        "Calibrated block size differs; persisting and restarting to adopt it"
+                    );
+                    match crate::block_size_calibration::persist_block_size(
+                        &defaults.block_size_state_file,
+                        observed,
+                    ) {
+                        Ok(()) => std::process::exit(0),
+                        Err(e) => {
+                            tracing::error!(error = %e, "Failed to persist calibrated block size");
+                        }
+                    }
+                }
+                reconcile_once(
+                    &reflector,
+                    selector.as_ref(),
+                    &defaults,
+                    calibration.as_ref(),
+                )
+                .await;
                 tokio::select! {
                     _ = cancel_child.cancelled() => break,
+                    // Re-register workers once calibration observes the real
+                    // block size (or stop watching if the probe went away).
+                    changed = async { observed_changes.as_mut().expect("guarded by if").changed().await },
+                        if observed_changes.is_some() => {
+                        if changed.is_err() {
+                            observed_changes = None;
+                        }
+                    }
                     // Re-reconcile on a pod change. Exit if the sender drops
                     // (reflector gone).
                     changed = pod_changes.changed() => {
@@ -91,9 +135,17 @@ async fn reconcile_once(
     reflector: &PodDiscovery,
     selector: &Selector,
     defaults: &RegistrationDefaults,
+    calibration: Option<&BlockSizeCalibration>,
 ) {
-    let desired: Vec<WorkerRegistration> = reflector
-        .ready_workers()
+    let workers = reflector.ready_workers();
+    if let Some(calibration) = calibration
+        && calibration.observed().is_none()
+    {
+        for w in &workers {
+            calibration.add_endpoint(&w.kv_events_endpoint);
+        }
+    }
+    let desired: Vec<WorkerRegistration> = workers
         .into_iter()
         .map(|w| build_registration(w, defaults))
         .collect();
@@ -138,6 +190,7 @@ mod tests {
             tokenizer_max_response_bytes: 16 * 1024 * 1024,
             tokenization_timeout_ms: 5_000,
             block_size: 16,
+            block_size_state_file: "/tmp/test-epp-block-size".to_string(),
             kv_event_port: 5557,
             replay_port: None,
             total_kv_blocks: Some(1000),
@@ -152,6 +205,7 @@ mod tests {
             block_size: 16,
             total_kv_blocks: Some(1000),
             max_num_batched_tokens: None,
+            block_size_state_file: "/tmp/test-epp-block-size".to_string(),
         }
     }
 
@@ -191,7 +245,7 @@ mod tests {
             .expect("selector should build"),
         );
         let (discovery, changes_tx) = PodDiscovery::for_test(vec![worker(7, "10.0.0.1")]);
-        let adapter = TopologyAdapter::spawn(discovery, selector.clone(), defaults());
+        let adapter = TopologyAdapter::spawn(discovery, selector.clone(), defaults(), None);
 
         tokio::time::timeout(Duration::from_secs(1), async {
             while !selector.any_ready().await {


### PR DESCRIPTION
## What

`DYN_KV_CACHE_BLOCK_SIZE=0` (or unset) now puts the standalone EPP in auto mode: it learns the KV event block size from the first main-attention `BlockStored` event instead of requiring the operator to know it in advance. A non-zero value still pins it explicitly.

## Why

For hybrid Mamba models, vLLM aligns the attention block size upward at engine boot ("attention page size >= mamba page size": 528/1056/2096 depending on the model), so the true value is only knowable from the running engine. The dynamo vLLM worker reads it via `get_kv_cache_group_metadata`, but the standalone EPP has no engine handle: a mismatched `DYN_KV_CACHE_BLOCK_SIZE` makes the router silently drop every event (`Block not published. Block size must be N`) and degrade to load-only routing. Same family of problem as #9376, on the standalone path.

## How

- `block_size_calibration.rs`: a probe SUB socket connects to every discovered worker's KV event endpoint and takes the block size of the first main-attention `BlockStored` (the wire events carry `block_size` and `kv_cache_spec_kind`; mamba groups are filtered out, mirroring the worker's `MAIN_ATTENTION_KV_CACHE_KINDS`).
- Until calibrated, workers are registered with a provisional block size (16) so the EPP keeps serving: scheduling works, KV overlap scoring is off, mismatched events are dropped, which is the pre-existing behavior.
- The selection service pins the block size per model for the process lifetime (`SelectionEntry` is built once per model), so a calibrated value cannot be adopted live: it is persisted to `DYN_EPP_BLOCK_SIZE_STATE_FILE` and the process exits cleanly; the next boot registers with it directly. On Kubernetes this is a sub-second container restart, and the state file survives it on an emptyDir. The probe keeps running after the restart, so a model that later changes block size re-calibrates the same way.

Zero changes outside `deploy/inference-gateway/ext-proc`.

## Validation

On a 2-replica hybrid Mamba deployment (nemotron nano, real vLLM, kv events enabled): boot at 16 -> `Calibrated KV event block size from live engine events block_size=2096` -> persist + restart (0.6s) -> `Creating indexer ... block_size=2096` -> zero `Block not published` drops, events indexed, no restart loop (observed == active after reboot). `cargo test -p dynamo-ext-proc` green (121 tests, 4 new).