### PR TITLE
feat(llm): integrate structural tags with parsers v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,9 +2852,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.3.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2277648c57af9f41943c1c6abf573ed42ddbad9d05f2e4053e9d66e9a41182"
+checksum = "5d226a63f9de7827b2b1a8a55289875ad42dad1fd43fcf320a8f72d8ea29d536"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ dynamo-parsers = { version = "8.1.0" }
 # Published on crates.io. To see all available versions:
 #   web:          https://crates.io/crates/dynamo-parsers-v2/versions
 #   sparse index: curl https://index.crates.io/dy/na/dynamo-parsers-v2   (one JSON line per release; read the "vers" field)
-dynamo-parsers-v2 = { version = "0.3.2" }
+dynamo-parsers-v2 = { version = "0.5.1" }
 dynamo-backend-common = { path = "lib/backend-common", version = "1.5.0" }
 dynamo-sidecar-common = { path = "lib/sidecar/common", version = "1.5.0" }
 fastokens = { version = "0.2.0" }

--- a/components/src/dynamo/common/backend/tests/test_backend_bindings.py
+++ b/components/src/dynamo/common/backend/tests/test_backend_bindings.py
@@ -239,9 +239,14 @@ def test_python_worker_config_from_runtime_config_copies_parser_settings():
     runtime_cfg.dyn_default_thinking_mode = "disabled"
     runtime_cfg.exclude_tools_when_tool_choice_none = False
     runtime_cfg.enable_local_indexer = False
-    runtime_cfg.dyn_enable_structural_tag = True
-    runtime_cfg.dyn_structural_tag_scope = "always"
-    runtime_cfg.dyn_structural_tag_schema = "strict"
+    runtime_cfg.structural_tag = {
+        "scope": "always",
+        "schema": "strict",
+        "allow_tool_calls_with_structured_output": True,
+        "exclude_special_tokens": False,
+        "reasoning_boundary": "structural_tag",
+        "tool_arguments_any_order": False,
+    }
     # MagicMock auto-attrs would be rejected as a foreign type by the
     # strict coercer; pin them to None.
     runtime_cfg.disaggregation_mode = None
@@ -254,9 +259,7 @@ def test_python_worker_config_from_runtime_config_copies_parser_settings():
     assert config.default_thinking_mode == "disabled"
     assert config.exclude_tools_when_tool_choice_none is False
     assert config.enable_local_indexer is False
-    assert config.structural_tag_mode == "on"
-    assert config.structural_tag_scope == "always"
-    assert config.structural_tag_schema == "strict"
+    assert config.structural_tag == runtime_cfg.structural_tag
 
 
 @pytest.mark.unified
@@ -277,9 +280,7 @@ def test_python_worker_config_from_runtime_config_applies_defaults_when_fields_a
     assert cfg.use_kv_events is False
     assert cfg.custom_jinja_template is None
     assert cfg.default_thinking_mode is None
-    assert cfg.structural_tag_mode == "off"
-    assert cfg.structural_tag_scope == "auto"
-    assert cfg.structural_tag_schema == "auto"
+    assert cfg.structural_tag is None
 
 
 @pytest.mark.unified

--- a/components/src/dynamo/common/backend/worker.py
+++ b/components/src/dynamo/common/backend/worker.py
@@ -131,9 +131,7 @@ class WorkerConfig:
     # Operator override; when set, the Rust Worker uses this instead of
     # `engine.health_check_payload()`. Populated by `from_runtime_config`.
     health_check_payload: Optional[dict] = None
-    structural_tag_mode: str = "off"
-    structural_tag_scope: str = "auto"
-    structural_tag_schema: str = "auto"
+    structural_tag: Optional[dict[str, object]] = None
     # When True, this worker declares an upstream Encode peer in its
     # topology `needs`. Meaningful only on AGGREGATED/PREFILL roles;
     # the Rust validator rejects DECODE/ENCODE + True with InvalidArgument.
@@ -185,17 +183,7 @@ class WorkerConfig:
             ),
             "enable_local_indexer": getattr(runtime_cfg, "enable_local_indexer", True),
             "enable_kv_routing": getattr(runtime_cfg, "enable_kv_routing", True),
-            "structural_tag_mode": (
-                "on"
-                if getattr(runtime_cfg, "dyn_enable_structural_tag", False)
-                else "off"
-            ),
-            "structural_tag_scope": getattr(
-                runtime_cfg, "dyn_structural_tag_scope", "auto"
-            ),
-            "structural_tag_schema": getattr(
-                runtime_cfg, "dyn_structural_tag_schema", "auto"
-            ),
+            "structural_tag": getattr(runtime_cfg, "structural_tag", None),
             "route_to_encoder": getattr(runtime_cfg, "route_to_encoder", False),
         }
         # Skip the probe when an override is supplied so callers with a foreign
@@ -277,9 +265,7 @@ class Worker:
                 self.config.disaggregation_mode
             ),
             health_check_payload=self.config.health_check_payload,
-            structural_tag_mode=self.config.structural_tag_mode,
-            structural_tag_scope=self.config.structural_tag_scope,
-            structural_tag_schema=self.config.structural_tag_schema,
+            structural_tag=self.config.structural_tag,
             runtime=runtime_cfg,
             route_to_encoder=self.config.route_to_encoder,
             media_decoder=self.config.media_decoder,

--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -9,6 +9,7 @@ import os
 from typing import List, Literal, Optional
 
 import msgspec
+
 from dynamo._core import get_reasoning_parser_names, get_tool_parser_names
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase

--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -31,7 +31,7 @@ class StructuralTagConfig(msgspec.Struct, forbid_unknown_fields=True):
     schema: Literal["auto", "strict"] = "auto"
     allow_tool_calls_with_structured_output: bool = False
     exclude_special_tokens: Optional[bool] = None
-    reasoning_boundary: Literal["structural_tag", "backend"] = "structural_tag"
+    reasoning_boundary: Literal["auto", "structural_tag", "backend"] = "auto"
     tool_arguments_any_order: bool = False
 
 

--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -6,18 +6,47 @@
 import argparse
 import logging
 import os
-from typing import List, Optional
+from typing import List, Literal, Optional
 
+import msgspec
 from dynamo._core import get_reasoning_parser_names, get_tool_parser_names
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase
-from dynamo.common.configuration.utils import add_argument, add_negatable_bool_argument
+from dynamo.common.configuration.utils import (
+    add_argument,
+    add_negatable_bool_argument,
+    env_or_default,
+)
 from dynamo.common.utils.namespace import get_worker_namespace
 from dynamo.common.utils.output_modalities import OutputModality
 
 logger = logging.getLogger(__name__)
 _FPM_TRACE_VALUES = {"1", "0", "true", "false", "on", "off", "yes", "no"}
 _fpm_trace_invalid_warning_emitted = False
+
+
+class StructuralTagConfig(msgspec.Struct, forbid_unknown_fields=True):
+    scope: Literal["auto", "always"] = "auto"
+    schema: Literal["auto", "strict"] = "auto"
+    allow_tool_calls_with_structured_output: bool = False
+    exclude_special_tokens: Optional[bool] = None
+    reasoning_boundary: Literal["structural_tag", "backend"] = "structural_tag"
+    tool_arguments_any_order: bool = False
+
+
+_STRUCTURAL_TAG_CONFIG_DECODER = msgspec.json.Decoder(type=StructuralTagConfig)
+
+
+def _parse_structural_tag(value: str) -> StructuralTagConfig | bool:
+    normalized = value.strip().lower()
+    if normalized in {"true", "1", "yes", "on"}:
+        return StructuralTagConfig()
+    if normalized in {"false", "0", "no", "off"}:
+        return False
+    try:
+        return _STRUCTURAL_TAG_CONFIG_DECODER.decode(value)
+    except msgspec.DecodeError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
 
 
 class DynamoRuntimeConfig(ConfigBase):
@@ -40,9 +69,11 @@ class DynamoRuntimeConfig(ConfigBase):
     dyn_reasoning_parser: Optional[str] = None
     dyn_default_thinking_mode: Optional[str] = None
     exclude_tools_when_tool_choice_none: bool = True
-    dyn_enable_structural_tag: bool = False
-    dyn_structural_tag_scope: str = "auto"
-    dyn_structural_tag_schema: str = "auto"
+    dyn_enable_structural_tag: Optional[bool] = None
+    dyn_structural_tag_scope: Optional[str] = None
+    dyn_structural_tag_schema: Optional[str] = None
+    dyn_structural_tag: Optional[StructuralTagConfig | bool] = None
+    structural_tag: Optional[dict[str, object]] = None
     custom_jinja_template: Optional[str] = None
     endpoint_types: str
     dump_config_to: Optional[str] = None
@@ -75,6 +106,7 @@ class DynamoRuntimeConfig(ConfigBase):
 
     def validate(self) -> None:
         self.namespace = get_worker_namespace(self.namespace)
+        self.structural_tag = resolve_structural_tag_config(self)
 
         # The Rust FPM sink reads this setting from the process environment.
         # Canonicalize the resolved CLI/env value before the runtime or backend
@@ -289,37 +321,35 @@ class DynamoRuntimeArgGroup(ArgGroup):
             help="Exclude tool definitions from the chat template when tool_choice='none'. "
             "Prevents models from generating raw XML tool calls in the content field.",
         )
-        add_negatable_bool_argument(
+        g.add_argument(
+            "--dyn-enable-structural-tag",
+            action=argparse.BooleanOptionalAction,
+            default=env_or_default("DYN_ENABLE_STRUCTURAL_TAG", None, value_type=bool),
+            help=argparse.SUPPRESS,
+        )
+        g.add_argument(
+            "--dyn-structural-tag-scope",
+            default=env_or_default("DYN_STRUCTURAL_TAG_SCOPE", None, value_type=str),
+            choices=["auto", "always"],
+            help=argparse.SUPPRESS,
+        )
+        g.add_argument(
+            "--dyn-structural-tag-schema",
+            default=env_or_default("DYN_STRUCTURAL_TAG_SCHEMA", None, value_type=str),
+            choices=["auto", "strict"],
+            help=argparse.SUPPRESS,
+        )
+        add_argument(
             g,
-            flag_name="--dyn-enable-structural-tag",
-            env_var="DYN_ENABLE_STRUCTURAL_TAG",
-            default=False,
-            help="Enable structural tag guided decoding for tool calls. "
+            flag_name="--dyn-structural-tag",
+            env_var="DYN_STRUCTURAL_TAG",
+            default=None,
+            arg_type=_parse_structural_tag,
+            nargs="?",
+            const="true",
+            help="Enable structural tag guided decoding, optionally configured with a JSON object. "
             "Named Kimi K3 tool_choice requests always activate their required "
             "XTML structural tag even when this flag is off.",
-        )
-        add_argument(
-            g,
-            flag_name="--dyn-structural-tag-scope",
-            env_var="DYN_STRUCTURAL_TAG_SCOPE",
-            default="auto",
-            choices=["auto", "always"],
-            help="Controls when structural tags are activated. "
-            "'auto': for required/named tool_choice, and if any tool has strict=true "
-            "or parallel_tool_calls is false. "
-            "'always': also for auto without those conditions. "
-            "tool_choice none is unaffected by auto vs always.",
-        )
-        add_argument(
-            g,
-            flag_name="--dyn-structural-tag-schema",
-            env_var="DYN_STRUCTURAL_TAG_SCHEMA",
-            default="auto",
-            choices=["auto", "strict"],
-            help="Controls parameter schema strictness inside structural tags. "
-            "'auto': real schema only for tools with strict=true; "
-            "syntactically constrained but schema-unconstrained for all other tools. "
-            "'strict': real parameter schema for all tools.",
         )
         add_argument(
             g,
@@ -526,3 +556,63 @@ class DynamoRuntimeArgGroup(ArgGroup):
             default=None,
             help="Path to PEM private key for the NATS client certificate (mTLS).",
         )
+
+
+def resolve_structural_tag_config(
+    runtime_config: object,
+) -> Optional[dict[str, object]]:
+    """Normalize the public setting and hidden legacy flags."""
+
+    structural_tag_setting = getattr(runtime_config, "dyn_structural_tag", None)
+    legacy_enable = getattr(runtime_config, "dyn_enable_structural_tag", None)
+    legacy_scope = getattr(runtime_config, "dyn_structural_tag_scope", None)
+    legacy_schema = getattr(runtime_config, "dyn_structural_tag_schema", None)
+
+    legacy_options = []
+    if legacy_enable is not None:
+        legacy_options.append(
+            "--dyn-enable-structural-tag"
+            if legacy_enable
+            else "--no-dyn-enable-structural-tag"
+        )
+    if legacy_scope is not None:
+        legacy_options.append("--dyn-structural-tag-scope")
+    if legacy_schema is not None:
+        legacy_options.append("--dyn-structural-tag-schema")
+    if legacy_options:
+        logger.warning(
+            "%s deprecated; use --dyn-structural-tag instead",
+            ", ".join(legacy_options),
+        )
+
+    if structural_tag_setting is not None:
+        enabled = structural_tag_setting is not False
+        conflicting_options = []
+        if legacy_enable is not None and legacy_enable != enabled:
+            conflicting_options.append(
+                "--dyn-enable-structural-tag"
+                if legacy_enable
+                else "--no-dyn-enable-structural-tag"
+            )
+        if legacy_scope is not None:
+            conflicting_options.append("--dyn-structural-tag-scope")
+        if legacy_schema is not None:
+            conflicting_options.append("--dyn-structural-tag-schema")
+        if conflicting_options:
+            raise ValueError(
+                "--dyn-structural-tag cannot be combined with legacy option(s): "
+                + ", ".join(conflicting_options)
+            )
+        if not enabled:
+            return None
+        return msgspec.to_builtins(structural_tag_setting)
+
+    if legacy_enable is not True:
+        return None
+
+    return msgspec.to_builtins(
+        StructuralTagConfig(
+            scope=legacy_scope if legacy_scope is not None else "auto",
+            schema=legacy_schema if legacy_schema is not None else "auto",
+        )
+    )

--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -560,14 +560,14 @@ class DynamoRuntimeArgGroup(ArgGroup):
 
 
 def resolve_structural_tag_config(
-    runtime_config: object,
+    runtime_config: DynamoRuntimeConfig,
 ) -> Optional[dict[str, object]]:
     """Normalize the public setting and hidden legacy flags."""
 
-    structural_tag_setting = getattr(runtime_config, "dyn_structural_tag", None)
-    legacy_enable = getattr(runtime_config, "dyn_enable_structural_tag", None)
-    legacy_scope = getattr(runtime_config, "dyn_structural_tag_scope", None)
-    legacy_schema = getattr(runtime_config, "dyn_structural_tag_schema", None)
+    structural_tag_setting = runtime_config.dyn_structural_tag
+    legacy_enable = runtime_config.dyn_enable_structural_tag
+    legacy_scope = runtime_config.dyn_structural_tag_scope
+    legacy_schema = runtime_config.dyn_structural_tag_schema
 
     legacy_options = []
     if legacy_enable is not None:

--- a/components/src/dynamo/common/tests/configuration/test_runtime_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_runtime_args.py
@@ -144,6 +144,130 @@ def test_fpm_trace_help_lists_flag_and_env(monkeypatch):
     assert "DYN_FPM_TRACE" in help_text
 
 
+def _clear_structural_tag_env(monkeypatch):
+    for name in (
+        "DYN_ENABLE_STRUCTURAL_TAG",
+        "DYN_STRUCTURAL_TAG_SCOPE",
+        "DYN_STRUCTURAL_TAG_SCHEMA",
+        "DYN_STRUCTURAL_TAG",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_structural_tags_are_disabled_by_default(monkeypatch):
+    _clear_structural_tag_env(monkeypatch)
+
+    config, _ = _parse_runtime_args([])
+
+    assert config.structural_tag is None
+
+
+def test_structural_tag_flag_uses_default_config(monkeypatch):
+    _clear_structural_tag_env(monkeypatch)
+
+    config, help_text = _parse_runtime_args(["--dyn-structural-tag"])
+
+    assert config.structural_tag == {
+        "scope": "auto",
+        "schema": "auto",
+        "allow_tool_calls_with_structured_output": False,
+        "exclude_special_tokens": None,
+        "reasoning_boundary": "structural_tag",
+        "tool_arguments_any_order": False,
+    }
+    assert "DYN_STRUCTURAL_TAG" in help_text
+    assert "--dyn-enable-structural-tag" not in help_text
+
+
+def test_structural_tag_json_config_enables_and_fills_defaults(monkeypatch):
+    _clear_structural_tag_env(monkeypatch)
+
+    config, _ = _parse_runtime_args(
+        [
+            "--dyn-structural-tag",
+            '{"scope":"always","schema":"strict",'
+            '"allow_tool_calls_with_structured_output":true,'
+            '"exclude_special_tokens":false,'
+            '"reasoning_boundary":"backend",'
+            '"tool_arguments_any_order":true}',
+        ]
+    )
+
+    assert config.structural_tag == {
+        "scope": "always",
+        "schema": "strict",
+        "allow_tool_calls_with_structured_output": True,
+        "exclude_special_tokens": False,
+        "reasoning_boundary": "backend",
+        "tool_arguments_any_order": True,
+    }
+
+
+def test_structural_tag_environment_is_supported(monkeypatch):
+    _clear_structural_tag_env(monkeypatch)
+    monkeypatch.setenv(
+        "DYN_STRUCTURAL_TAG",
+        '{"scope":"always","schema":"strict"}',
+    )
+
+    config, _ = _parse_runtime_args([])
+
+    assert config.structural_tag is not None
+    assert config.structural_tag["scope"] == "always"
+    assert config.structural_tag["schema"] == "strict"
+
+
+def test_legacy_structural_tag_options_resolve_to_canonical_config(monkeypatch, caplog):
+    _clear_structural_tag_env(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger=runtime_args.__name__):
+        config, _ = _parse_runtime_args(
+            [
+                "--dyn-enable-structural-tag",
+                "--dyn-structural-tag-scope",
+                "always",
+                "--dyn-structural-tag-schema",
+                "strict",
+            ]
+        )
+
+    assert config.structural_tag is not None
+    assert config.structural_tag["scope"] == "always"
+    assert config.structural_tag["schema"] == "strict"
+    assert "deprecated" in caplog.text
+
+
+def test_structural_tag_json_rejects_legacy_tuning(monkeypatch):
+    _clear_structural_tag_env(monkeypatch)
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        _parse_runtime_args(
+            [
+                "--dyn-structural-tag",
+                "{}",
+                "--dyn-structural-tag-scope",
+                "always",
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    "raw_config",
+    [
+        "{",
+        "[]",
+        '{"unknown":true}',
+        '{"scope":"sometimes"}',
+        '{"allow_tool_calls_with_structured_output":"yes"}',
+    ],
+)
+def test_structural_tag_json_config_is_strict(monkeypatch, raw_config):
+    _clear_structural_tag_env(monkeypatch)
+
+    with pytest.raises(SystemExit):
+        _parse_runtime_args(["--dyn-structural-tag", raw_config])
+
+
 @pytest.mark.parametrize("mode", ["enabled", "disabled"])
 def test_default_thinking_mode_cli(mode, monkeypatch):
     monkeypatch.delenv("DYN_DEFAULT_THINKING_MODE", raising=False)

--- a/components/src/dynamo/common/tests/configuration/test_runtime_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_runtime_args.py
@@ -172,7 +172,7 @@ def test_structural_tag_flag_uses_default_config(monkeypatch):
         "schema": "auto",
         "allow_tool_calls_with_structured_output": False,
         "exclude_special_tokens": None,
-        "reasoning_boundary": "structural_tag",
+        "reasoning_boundary": "auto",
         "tool_arguments_any_order": False,
     }
     assert "DYN_STRUCTURAL_TAG" in help_text

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -605,14 +605,10 @@ def build_tool_call_guided_decoding(
             ),
         )
     # TODO: this applies a structural-tag constraint for tool_choice="auto"
-    # whenever a tool-call parser is configured, and reads NONE of
-    # structural_tag_mode / structural_tag_scope / structural_tag_schema. Those
-    # knobs are accepted on the CLI and published into the model card by
-    # sglang/register.py, so an operator setting the mode to "off" still gets a
-    # constraint on this path. prepost.py requires structural_tag_mode == "on"
-    # (_should_build_tool_call_guidance) and preprocessor/structural_tag.rs
-    # requires StructuralTagMode != Off, so at the default mode ("off") the same
-    # request is unconstrained on both of those paths and constrained here.
+    # whenever a tool-call parser is configured, without consulting the
+    # worker's structural-tag policy. An operator who leaves the policy disabled
+    # still gets a constraint on this path, while prepost.py and the Rust
+    # preprocessor leave the same request unconstrained.
     # Also unlike them, "auto" is never gated on scope/strict, so this behaves as
     # scope="always" with no way to narrow it.
     elif tool_call_parser_name:

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -605,10 +605,14 @@ def build_tool_call_guided_decoding(
             ),
         )
     # TODO: this applies a structural-tag constraint for tool_choice="auto"
-    # whenever a tool-call parser is configured, without consulting the
-    # worker's structural-tag policy. An operator who leaves the policy disabled
-    # still gets a constraint on this path, while prepost.py and the Rust
-    # preprocessor leave the same request unconstrained.
+    # whenever a tool-call parser is configured, and reads NONE of
+    # structural_tag_mode / structural_tag_scope / structural_tag_schema. Those
+    # knobs are accepted on the CLI and published into the model card by
+    # sglang/register.py, so an operator setting the mode to "off" still gets a
+    # constraint on this path. prepost.py requires structural_tag_mode == "on"
+    # (_should_build_tool_call_guidance) and preprocessor/structural_tag.rs
+    # requires StructuralTagMode != Off, so at the default mode ("off") the same
+    # request is unconstrained on both of those paths and constrained here.
     # Also unlike them, "auto" is never gated on scope/strict, so this behaves as
     # scope="always" with no way to narrow it.
     elif tool_call_parser_name:

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -3039,20 +3039,31 @@ def test_runtime_config_context_length(vllm_processor_module, runtime_config, ex
     assert vllm_processor_module._runtime_config_context_length(mdc) == expected
 
 
-def test_runtime_config_structural_tag_options(vllm_processor_module):
-    mdc = SimpleNamespace(
-        runtime_config=lambda: {
-            "structural_tag_mode": "on",
-            "structural_tag_scope": "always",
-            "structural_tag_schema": "strict",
-        }
-    )
+@pytest.mark.parametrize(
+    ("runtime_config", "expected"),
+    [
+        (
+            {"structural_tag": {"scope": "always", "schema": "strict"}},
+            ("on", "always", "strict"),
+        ),
+        (
+            {
+                "structural_tag_mode": "on",
+                "structural_tag_scope": "always",
+                "structural_tag_schema": "strict",
+            },
+            ("off", "auto", "auto"),
+        ),
+        ({}, ("off", "auto", "auto")),
+        (None, ("off", "auto", "auto")),
+    ],
+)
+def test_runtime_config_structural_tag_options(
+    vllm_processor_module, runtime_config, expected
+):
+    mdc = SimpleNamespace(runtime_config=lambda: runtime_config)
 
-    assert vllm_processor_module._runtime_config_structural_tag_options(mdc) == (
-        "on",
-        "always",
-        "strict",
-    )
+    assert vllm_processor_module._runtime_config_structural_tag_options(mdc) == expected
 
 
 # Regression: MistralTokenizer (--tokenizer-mode mistral) has no chat_template

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -148,10 +148,13 @@ def _runtime_config_structural_tag_options(
     runtime_config = mdc.runtime_config()
     if not isinstance(runtime_config, dict):
         return "off", "auto", "auto"
+    structural_tag = runtime_config.get("structural_tag")
+    if not isinstance(structural_tag, dict):
+        return "off", "auto", "auto"
     return (
-        runtime_config.get("structural_tag_mode", "off"),
-        runtime_config.get("structural_tag_scope", "auto"),
-        runtime_config.get("structural_tag_schema", "auto"),
+        "on",
+        structural_tag.get("scope", "auto"),
+        structural_tag.get("schema", "auto"),
     )
 
 

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -151,6 +151,21 @@ def _runtime_config_structural_tag_options(
     structural_tag = runtime_config.get("structural_tag")
     if not isinstance(structural_tag, dict):
         return "off", "auto", "auto"
+    unsupported_options = [
+        name
+        for name, default in (
+            ("allow_tool_calls_with_structured_output", False),
+            ("exclude_special_tokens", None),
+            ("reasoning_boundary", "auto"),
+            ("tool_arguments_any_order", False),
+        )
+        if structural_tag.get(name, default) != default
+    ]
+    if unsupported_options:
+        logger.warning(
+            "vLLM chat processor ignores unsupported structural-tag option(s): %s",
+            ", ".join(unsupported_options),
+        )
     return (
         "on",
         structural_tag.get("scope", "auto"),

--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -348,6 +348,16 @@ def require_reasoning_kwargs(engine: Any, request: Mapping[str, Any]) -> dict[st
     return kwargs
 
 
+def supports_require_reasoning(engine: Any) -> bool:
+    """Return whether this SGLang engine supports the reasoning-gate argument."""
+    if not hasattr(engine, "async_generate"):
+        return False
+    return "require_reasoning" in filter_supported_async_generate_kwargs(
+        engine,
+        {"require_reasoning": False},
+    )
+
+
 __all__ = [
     "ConfigArgumentMerger",
     "ensure_sglang_tensor_image_size",
@@ -361,4 +371,5 @@ __all__ = [
     "require_reasoning_kwargs",
     "resolved_server_args",
     "sglang_uses_mla_backend",
+    "supports_require_reasoning",
 ]

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -416,11 +416,7 @@ async def get_runtime_config(
     runtime_config.exclude_tools_when_tool_choice_none = (
         dynamo_args.exclude_tools_when_tool_choice_none
     )
-    runtime_config.set_structural_tag_mode(
-        "on" if dynamo_args.dyn_enable_structural_tag else "off"
-    )
-    runtime_config.set_structural_tag_scope(dynamo_args.dyn_structural_tag_scope)
-    runtime_config.set_structural_tag_schema(dynamo_args.dyn_structural_tag_schema)
+    runtime_config.set_structural_tag(dynamo_args.structural_tag)
     # Decode workers don't create the WorkerKvQuery endpoint, so don't advertise local indexer
     is_decode_worker = server_args.disaggregation_mode == "decode"
     runtime_config.enable_local_indexer = (

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -30,7 +30,7 @@ from dynamo.llm import (
     WorkerType,
     register_model,
 )
-from dynamo.sglang._compat import sglang_uses_mla_backend
+from dynamo.sglang._compat import sglang_uses_mla_backend, supports_require_reasoning
 from dynamo.sglang._disagg import SGLANG_WORKER_GROUP_ID_KEY, get_sglang_worker_group_id
 from dynamo.sglang.args import DynamoConfig, use_modelexpress_remote_instance
 from dynamo.sglang.capacity import (
@@ -44,6 +44,17 @@ from dynamo.sglang.engine_generate import SGLANG_GENERATE_CAPABILITY
 
 SGLANG_HICACHE_MOONCAKE_RUNTIME_KEY = "sglang_hicache_mooncake"
 SPEC_DECODE_RUNTIME_KEY = "spec_decode"
+TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY = (
+    "tool_call_structural_tag_excludes_reasoning"
+)
+
+
+def _backend_excludes_reasoning_from_structural_tag(
+    engine: Optional[sgl.Engine], server_args: ServerArgs
+) -> bool:
+    return bool(getattr(server_args, "reasoning_parser", None)) and (
+        supports_require_reasoning(engine)
+    )
 
 
 def _supports_engine_generate(
@@ -417,6 +428,12 @@ async def get_runtime_config(
         dynamo_args.exclude_tools_when_tool_choice_none
     )
     runtime_config.set_structural_tag(dynamo_args.structural_tag)
+    runtime_config.set_engine_specific(
+        TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY,
+        json.dumps(
+            _backend_excludes_reasoning_from_structural_tag(engine, server_args)
+        ),
+    )
     # Decode workers don't create the WorkerKvQuery endpoint, so don't advertise local indexer
     is_decode_worker = server_args.disaggregation_mode == "decode"
     runtime_config.enable_local_indexer = (

--- a/components/src/dynamo/sglang/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/sglang/tests/test_runtime_metadata.py
@@ -24,6 +24,37 @@ pytestmark = [
 
 
 @pytest.mark.parametrize(
+    ("engine_supports_gate", "reasoning_parser", "expected"),
+    [
+        (True, "glm45", True),
+        (True, None, False),
+        (False, "glm45", False),
+        (False, None, False),
+    ],
+)
+def test_structural_tag_reasoning_policy_requires_parser_and_gate_support(
+    engine_supports_gate, reasoning_parser, expected
+):
+    from dynamo.sglang import register
+
+    class ReasoningEngine:
+        async def async_generate(self, require_reasoning=False):
+            return None
+
+    class OldEngine:
+        async def async_generate(self, input_ids=None):
+            return None
+
+    engine = ReasoningEngine() if engine_supports_gate else OldEngine()
+
+    server_args = SimpleNamespace(reasoning_parser=reasoning_parser)
+    assert (
+        register._backend_excludes_reasoning_from_structural_tag(engine, server_args)
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
     "server_args, expected",
     [
         (SimpleNamespace(page_size=64), 64),

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -785,11 +785,7 @@ async def init_llm_worker(
         runtime_config.exclude_tools_when_tool_choice_none = (
             config.exclude_tools_when_tool_choice_none
         )
-        runtime_config.set_structural_tag_mode(
-            "on" if config.dyn_enable_structural_tag else "off"
-        )
-        runtime_config.set_structural_tag_scope(config.dyn_structural_tag_scope)
-        runtime_config.set_structural_tag_schema(config.dyn_structural_tag_schema)
+        runtime_config.set_structural_tag(config.structural_tag)
         # Decode workers don't create the WorkerKvQuery endpoint, so don't advertise local indexer
         runtime_config.enable_local_indexer = (
             config.enable_local_indexer

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -907,11 +907,7 @@ async def register_vllm_model(
     runtime_config.exclude_tools_when_tool_choice_none = (
         config.exclude_tools_when_tool_choice_none
     )
-    runtime_config.set_structural_tag_mode(
-        "on" if config.dyn_enable_structural_tag else "off"
-    )
-    runtime_config.set_structural_tag_scope(config.dyn_structural_tag_scope)
-    runtime_config.set_structural_tag_schema(config.dyn_structural_tag_schema)
+    runtime_config.set_structural_tag(config.structural_tag)
 
     # Propagate stream_interval so the frontend can respect --stream-interval.
     # set_engine_specific requires a JSON-encoded string (the Rust binding

--- a/docs/fern/pages/reference/components/runtime-configuration.mdx
+++ b/docs/fern/pages/reference/components/runtime-configuration.mdx
@@ -13,7 +13,7 @@ subtitle: Field reference for the cross-cutting Dynamo runtime CLI flags and env
 
 ## How the config is loaded
 
-Unless a field is marked environment-only, it has both a CLI flag and an environment variable. The CLI flag takes precedence; the environment variable is the fallback. Boolean fields are negatable — `--dyn-enable-structural-tag` sets it on, `--no-dyn-enable-structural-tag` sets it off.
+Unless a field is marked environment-only, it has both a CLI flag and an environment variable. The CLI flag takes precedence; the environment variable is the fallback. Boolean fields are negatable — for example, `--enable-local-indexer` sets it on and `--no-enable-local-indexer` sets it off.
 
 <Card>
 <Tabs>
@@ -198,26 +198,10 @@ Unless a field is marked environment-only, it has both a CLI flag and an environ
   Environment variable: `DYN_EXCLUDE_TOOLS_WHEN_TOOL_CHOICE_NONE`
 </ParamField>
 
-<ParamField path="--dyn-enable-structural-tag" type="boolean" default="false">
-  Enable structural tag guided decoding for tool calls. When enabled, configure activation scope and parameter schema strictness with `--dyn-structural-tag-scope` and `--dyn-structural-tag-schema`.
+<ParamField path="--dyn-structural-tag" type="JSON object" default="unset">
+  Enable structural tag guided decoding for tool calls. Pass the flag without a value to use the default policy, or provide a JSON object for advanced options. See [Structural Tag](../../use-cases/tool-calling-and-reasoning/structural-tag.md) for the complete configuration.
 
-  Environment variable: `DYN_ENABLE_STRUCTURAL_TAG`
-</ParamField>
-
-<ParamField path="--dyn-structural-tag-scope" type="string" default="auto">
-  Controls when structural tags are activated. `auto` activates them for required or named `tool_choice`, or when any tool has `strict=true` or `parallel_tool_calls` is false. `always` additionally activates them for `tool_choice=auto` without those conditions. `tool_choice=none` is unaffected by either setting. Only meaningful when `--dyn-enable-structural-tag` is set.
-
-  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>auto</Badge> <Badge intent="note" minimal>always</Badge></span>
-
-  Environment variable: `DYN_STRUCTURAL_TAG_SCOPE`
-</ParamField>
-
-<ParamField path="--dyn-structural-tag-schema" type="string" default="auto">
-  Controls parameter schema strictness inside structural tags. `auto` applies the real parameter schema only to tools with `strict=true`, leaving all other tools syntactically constrained but schema-unconstrained. `strict` applies the real parameter schema to every tool. Only meaningful when `--dyn-enable-structural-tag` is set.
-
-  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>auto</Badge> <Badge intent="note" minimal>strict</Badge></span>
-
-  Environment variable: `DYN_STRUCTURAL_TAG_SCHEMA`
+  Environment variable: `DYN_STRUCTURAL_TAG`
 </ParamField>
 
 <ParamField path="--custom-jinja-template" type="string" default="null">

--- a/docs/fern/pages/use-cases/tool-calling-and-reasoning/structural-tag.md
+++ b/docs/fern/pages/use-cases/tool-calling-and-reasoning/structural-tag.md
@@ -19,9 +19,9 @@ Benefits:
   JSON schema.
 - **Single-call enforcement** — `parallel_tool_calls=false` is enforced via
   `stop_after_first` in the grammar, not just by convention.
-- **Tool call ban** — when `tool_choice="none"`, specific tokenizer tokens can be
-  banned so the model cannot start native tool-call syntax (see
-  [trade-offs](#tool_choicenone-and-token-banning)).
+- **Tool call ban** — when `tool_choice="none"`, parser-specific strings can be
+  excluded so the model cannot complete native tool-call syntax (see
+  [trade-offs](#tool_choicenone-and-marker-exclusion)).
 
 ## Prerequisites
 
@@ -31,7 +31,7 @@ Benefits:
 
 ## Quick Start
 
-Enable structural tags on the **worker** with `--dyn-enable-structural-tag`, alongside the tool-call parser. The Frontend needs no extra flags:
+Enable structural tags on the **worker** with `--dyn-structural-tag`, alongside the tool-call parser. The Frontend needs no extra flags:
 
 ```yaml
 apiVersion: nvidia.com/v1beta1
@@ -70,7 +70,7 @@ spec:
           - Qwen/Qwen3.5-4B
           - --dyn-tool-call-parser
           - qwen3_coder
-          - --dyn-enable-structural-tag
+          - --dyn-structural-tag
 ```
 
 Eligible tool-calling requests will now use xgrammar structural tags for guided
@@ -80,9 +80,32 @@ decoding. See [Activation Scope](#activation-scope) for the exact policy.
 
 | Flag | Values | Default | Description |
 |---|---|---|---|
-| `--dyn-enable-structural-tag` | bool | `false` | Master switch. When disabled, tool calling works the same as without structural tags. |
-| `--dyn-structural-tag-scope` | `auto`, `always` | `auto` | Controls when structural tags are activated (see [Activation Scope](#activation-scope)). |
-| `--dyn-structural-tag-schema` | `auto`, `strict` | `auto` | Controls parameter schema strictness inside structural tags (see [Schema Modes](#schema-modes)). |
+| `--dyn-structural-tag` | optional JSON object | unset | Enable structural tags, optionally with advanced configuration. |
+
+The flag without a value uses the defaults below. Every field is optional:
+
+```json
+{
+  "scope": "always",
+  "schema": "strict",
+  "allow_tool_calls_with_structured_output": true,
+  "exclude_special_tokens": false,
+  "reasoning_boundary": "backend",
+  "tool_arguments_any_order": true
+}
+```
+
+| Field | Values | Default | Description |
+|---|---|---|---|
+| `scope` | `auto`, `always` | `auto` | Selects eligible tool-calling requests. |
+| `schema` | `auto`, `strict` | `auto` | Selects which tool argument schemas are enforced. |
+| `allow_tool_calls_with_structured_output` | boolean | `false` | Lets `tool_choice="auto"` choose between tool calls and a schema-constrained final response. Requires parsers v2. |
+| `exclude_special_tokens` | boolean, `null` | `null` | Controls reasoning and tool-call marker exclusions. `null` preserves the model-family default. Requires parsers v2. |
+| `reasoning_boundary` | `structural_tag`, `backend` | `structural_tag` | Selects whether the structural tag closes prompt-opened reasoning or the inference engine activates the post-reasoning grammar. `backend` requires parsers v2 and backend support. |
+| `tool_arguments_any_order` | boolean | `false` | Allows tool argument properties in any order. This weakens required-property and duplicate-key validation and requires parsers v2. Structured-output schemas are unaffected. |
+
+`DYN_STRUCTURAL_TAG` accepts `true`, `false`, or the same JSON object. Unknown
+fields and invalid values are rejected during worker startup.
 
 ## Supported Parsers
 
@@ -95,12 +118,16 @@ Currently tested and supported:
 - `qwen3_coder`, `nemotron_nano`
 - `hermes`, `qwen25`
 - `deepseek_v3_2`, `deepseek_v4`
+- `glm47` with parsers v2
+
+The parsers-v2 builders for `qwen3_coder`, `deepseek_v4`, and `glm47` require
+`DYN_ENABLE_EXPERIMENTAL_PARSERS_V2=1` in the worker and frontend processes.
 
 Contributions adding structural tag support for new parsers are welcome.
 
 ## Activation Scope
 
-The `--dyn-structural-tag-scope` flag controls when structural tags are used
+The `scope` field controls when structural tags are used
 based on the request's `tool_choice`:
 
 ### `auto` (default)
@@ -109,7 +136,7 @@ based on the request's `tool_choice`:
 |---|---|
 | `required` / `named` | Always |
 | `auto` | Only when any tool has `strict: true` or `parallel_tool_calls` is `false` |
-| `none` | Exclusion tag only (bans tool call tokens, see [below](#tool_choicenone-and-token-banning)) |
+| `none` | Exclusion tag only (excludes tool-call markers, see [below](#tool_choicenone-and-marker-exclusion)) |
 
 ### `always`
 
@@ -122,7 +149,7 @@ based on the request's `tool_choice`:
 
 ## Schema Modes
 
-The `--dyn-structural-tag-schema` flag controls what JSON schema is used for
+The `schema` field controls what JSON schema is used for
 tool arguments inside the structural tag:
 
 ### `auto` (default)
@@ -136,11 +163,11 @@ tool arguments inside the structural tag:
 - All tools use their actual parameter schema regardless of the `strict`
   flag.
 
-## `tool_choice="none"` and Token Banning
+## `tool_choice="none"` and Marker Exclusion
 
 When `tool_choice="none"` and structural tags are enabled, Dynamo injects an
-exclusion structural tag that bans parser-specific tool-call start tokens (for
-example `<tool_call>`) so the model cannot start native tool-call syntax.
+exclusion structural tag that excludes parser-specific tool-call markers (for
+example `<tool_call>`) so the model cannot complete native tool-call syntax.
 
 **Quality trade-off**. If tools remain in the prompt on `none` (often via
 `--no-exclude-tools-when-tool-choice-none` to keep the chat prefix stable for KV
@@ -158,18 +185,18 @@ This interacts with the `--exclude-tools-when-tool-choice-none` flag (default:
 | `exclude-tools-when-tool-choice-none` | Structural tag | Effect |
 |---|---|---|
 | `true` (default) | off | Tools removed from prompt. Model doesn't know about tools. Prompt changes break KV cache prefix sharing. |
-| `true` | on | Tools removed from prompt; tokens also banned. Prompt changes break KV cache prefix sharing. |
-| `false` | on | Tools stay in prompt; guided decoding bans tokens. Model sees tools but cannot emit banned openings. Stable KV cache prefix across different `tool_choice` values. |
+| `true` | on | Tools removed from prompt; tool-call markers are also excluded. Prompt changes break KV cache prefix sharing. |
+| `false` | on | Tools stay in prompt; guided decoding excludes tool-call markers. Model sees tools but cannot complete a native tool-call opening. Stable KV cache prefix across different `tool_choice` values. |
 | `false` | off | Tools stay in prompt; no token ban. Same response shaping as above: no structured `tool_calls` for explicit `none`. Tool-like text may still appear in `content`. |
 
 For multi-turn conversations where `tool_choice` changes between turns,
 consider `--no-exclude-tools-when-tool-choice-none` combined with
-`--dyn-enable-structural-tag` to keep the prompt stable and benefit from
+`--dyn-structural-tag` to keep the prompt stable and benefit from
 KV cache reuse.
 
 ## Example
 
-To pin the scope and schema, add `--dyn-structural-tag-scope` and `--dyn-structural-tag-schema` to the worker `args:` alongside the parser and master switch:
+To pin the scope and schema, pass a JSON value to `--dyn-structural-tag`:
 
 ```yaml
   - name: SGLangWorker
@@ -194,11 +221,8 @@ To pin the scope and schema, add `--dyn-structural-tag-scope` and `--dyn-structu
           - Qwen/Qwen3.5-4B
           - --dyn-tool-call-parser
           - qwen3_coder
-          - --dyn-enable-structural-tag
-          - --dyn-structural-tag-scope
-          - always
-          - --dyn-structural-tag-schema
-          - strict
+          - --dyn-structural-tag
+          - '{"scope":"always","schema":"strict","allow_tool_calls_with_structured_output":true}'
 ```
 
 ## See Also

--- a/docs/fern/pages/use-cases/tool-calling-and-reasoning/structural-tag.md
+++ b/docs/fern/pages/use-cases/tool-calling-and-reasoning/structural-tag.md
@@ -101,8 +101,13 @@ The flag without a value uses the defaults below. Every field is optional:
 | `schema` | `auto`, `strict` | `auto` | Selects which tool argument schemas are enforced. |
 | `allow_tool_calls_with_structured_output` | boolean | `false` | Lets `tool_choice="auto"` choose between tool calls and a schema-constrained final response. Requires parsers v2. |
 | `exclude_special_tokens` | boolean, `null` | `null` | Controls reasoning and tool-call marker exclusions. `null` preserves the model-family default. Requires parsers v2. |
-| `reasoning_boundary` | `structural_tag`, `backend` | `structural_tag` | Selects whether the structural tag closes prompt-opened reasoning or the inference engine activates the post-reasoning grammar. `backend` requires parsers v2 and backend support. |
+| `reasoning_boundary` | `auto`, `structural_tag`, `backend` | `auto` | Selects whether the structural tag closes prompt-opened reasoning or the inference engine activates the post-reasoning grammar. `auto` follows the backend's advertised policy. `backend` requires parsers v2. |
 | `tool_arguments_any_order` | boolean | `false` | Allows tool argument properties in any order. This weakens required-property and duplicate-key validation and requires parsers v2. Structured-output schemas are unaffected. |
+
+If the backend advertises that it owns reasoning-aware grammar activation,
+explicitly selecting `structural_tag` is rejected to avoid applying both
+reasoning gates. Explicit `backend` selection assumes the inference engine is
+configured accordingly.
 
 `DYN_STRUCTURAL_TAG` accepts `true`, `false`, or the same JSON object. Unknown
 fields and invalid values are rejected during worker startup.

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -15,8 +15,7 @@ use std::time::Duration;
 
 use dynamo_llm::first_token::FirstTokenSource;
 use dynamo_llm::local_model::runtime_config::{
-    DisaggregatedEndpoint, ModelRuntimeConfig, StructuralTagMode, StructuralTagSchemaMode,
-    StructuralTagScope, TOPOLOGY_TAINT_PREFIX,
+    DisaggregatedEndpoint, ModelRuntimeConfig, StructuralTagConfig, TOPOLOGY_TAINT_PREFIX,
 };
 use dynamo_llm::local_model::{LocalModel, LocalModelBuilder, update_model_taints};
 use dynamo_llm::model_type::{ModelInput, ModelType};
@@ -178,12 +177,8 @@ pub struct WorkerConfig {
     /// Python sets this via `--health-check-payload` / env; Rust-only
     /// engines leave it `None` and let `Worker` read the env directly.
     pub health_check_payload: Option<serde_json::Value>,
-    /// Structural tag guided decoding mode.
-    pub structural_tag_mode: StructuralTagMode,
-    /// Structural tag activation scope.
-    pub structural_tag_scope: StructuralTagScope,
-    /// Structural tag schema strictness.
-    pub structural_tag_schema: StructuralTagSchemaMode,
+    /// Structural-tag guided-decoding policy. Presence enables structural tags.
+    pub structural_tag: Option<StructuralTagConfig>,
     /// Runtime / transport overrides applied via env vars before the
     /// `DistributedRuntime` is constructed.
     pub runtime: RuntimeConfig,
@@ -235,9 +230,7 @@ impl Default for WorkerConfig {
             metrics_labels: Vec::new(),
             disaggregation_mode: DisaggregationMode::Aggregated,
             health_check_payload: None,
-            structural_tag_mode: StructuralTagMode::Off,
-            structural_tag_scope: StructuralTagScope::Auto,
-            structural_tag_schema: StructuralTagSchemaMode::Auto,
+            structural_tag: None,
             runtime: RuntimeConfig::default(),
             route_to_encoder: false,
             enable_rl: false,
@@ -2057,9 +2050,7 @@ async fn build_local_model(
         tool_call_parser: config.tool_call_parser.clone(),
         reasoning_parser: config.reasoning_parser.clone(),
         exclude_tools_when_tool_choice_none: config.exclude_tools_when_tool_choice_none,
-        structural_tag_mode: config.structural_tag_mode,
-        structural_tag_scope: config.structural_tag_scope,
-        structural_tag_schema: config.structural_tag_schema,
+        structural_tag: config.structural_tag.clone(),
         enable_local_indexer,
         kv_state_endpoint: config.kv_state_endpoint.clone(),
         disaggregated_endpoint,

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -2285,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.3.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2277648c57af9f41943c1c6abf573ed42ddbad9d05f2e4053e9d66e9a41182"
+checksum = "5d226a63f9de7827b2b1a8a55289875ad42dad1fd43fcf320a8f72d8ea29d536"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2337,9 +2337,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.3.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2277648c57af9f41943c1c6abf573ed42ddbad9d05f2e4053e9d66e9a41182"
+checksum = "5d226a63f9de7827b2b1a8a55289875ad42dad1fd43fcf320a8f72d8ea29d536"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -27,10 +27,7 @@ use dynamo_backend_common::{
     PreprocessedRequest, RawEngine, RuntimeConfig as RsRuntimeConfig,
     SnapshotPublisher as RsSnapshotPublisher, Worker as RsWorker, WorkerConfig as RsWorkerConfig,
 };
-use dynamo_llm::local_model::runtime_config::{
-    StructuralTagMode as RsStructuralTagMode, StructuralTagSchemaMode as RsStructuralTagSchemaMode,
-    StructuralTagScope as RsStructuralTagScope,
-};
+use dynamo_llm::local_model::runtime_config::StructuralTagConfig as RsStructuralTagConfig;
 use dynamo_llm::model_type::ModelInput as RsModelInput;
 use dynamo_runtime as rs;
 use dynamo_runtime::logging::{DistributedTraceContext, get_distributed_tracing_context};
@@ -424,9 +421,7 @@ impl WorkerConfig {
         runtime = None,
         disaggregation_mode = DisaggregationMode::Aggregated,
         health_check_payload = None,
-        structural_tag_mode = "off".to_string(),
-        structural_tag_scope = "auto".to_string(),
-        structural_tag_schema = "auto".to_string(),
+        structural_tag = None,
         route_to_encoder = false,
         media_decoder = None,
         media_fetcher = None,
@@ -453,9 +448,7 @@ impl WorkerConfig {
         runtime: Option<RuntimeConfig>,
         disaggregation_mode: DisaggregationMode,
         health_check_payload: Option<PyObject>,
-        structural_tag_mode: String,
-        structural_tag_scope: String,
-        structural_tag_schema: String,
+        structural_tag: Option<&Bound<'_, PyDict>>,
         route_to_encoder: bool,
         media_decoder: Option<MediaDecoder>,
         media_fetcher: Option<MediaFetcher>,
@@ -488,33 +481,14 @@ impl WorkerConfig {
             }
             _ => None,
         };
-        let st_mode = match structural_tag_mode.as_str() {
-            "off" => RsStructuralTagMode::Off,
-            "on" => RsStructuralTagMode::On,
-            other => {
-                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Invalid structural_tag_mode: {other}. Expected 'off' or 'on'."
-                )));
-            }
-        };
-        let st_scope = match structural_tag_scope.as_str() {
-            "auto" => RsStructuralTagScope::Auto,
-            "always" => RsStructuralTagScope::Always,
-            other => {
-                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Invalid structural_tag_scope: {other}. Expected 'auto' or 'always'."
-                )));
-            }
-        };
-        let st_schema = match structural_tag_schema.as_str() {
-            "auto" => RsStructuralTagSchemaMode::Auto,
-            "strict" => RsStructuralTagSchemaMode::Strict,
-            other => {
-                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Invalid structural_tag_schema: {other}. Expected 'auto' or 'strict'."
-                )));
-            }
-        };
+        let structural_tag = structural_tag
+            .map(|config| depythonize::<RsStructuralTagConfig>(config))
+            .transpose()
+            .map_err(|error| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid structural_tag config: {error}"
+                ))
+            })?;
         Ok(Self {
             inner: RsWorkerConfig {
                 namespace,
@@ -537,9 +511,7 @@ impl WorkerConfig {
                 metrics_labels,
                 disaggregation_mode: disaggregation_mode.into(),
                 health_check_payload,
-                structural_tag_mode: st_mode,
-                structural_tag_scope: st_scope,
-                structural_tag_schema: st_schema,
+                structural_tag,
                 runtime: runtime.map(|r| r.inner).unwrap_or_default(),
                 route_to_encoder,
                 // Python vLLM owns and serves its existing `.rl` endpoint.

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -308,10 +308,7 @@ impl ModelRuntimeConfig {
     }
 
     #[pyo3(signature = (structural_tag=None))]
-    fn set_structural_tag(
-        &mut self,
-        structural_tag: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<()> {
+    fn set_structural_tag(&mut self, structural_tag: Option<&Bound<'_, PyDict>>) -> PyResult<()> {
         let structural_tag = structural_tag
             .map(|config| pythonize::depythonize::<RsStructuralTagConfig>(config))
             .transpose()

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -10,9 +10,7 @@ use dynamo_kv_router::protocols::{
 use dynamo_runtime::protocols::EndpointId;
 use llm_rs::local_model::runtime_config::DisaggregatedEndpoint as RsDisaggregatedEndpoint;
 use llm_rs::local_model::runtime_config::ModelRuntimeConfig as RsModelRuntimeConfig;
-use llm_rs::local_model::runtime_config::StructuralTagMode as RsStructuralTagMode;
-use llm_rs::local_model::runtime_config::StructuralTagSchemaMode as RsStructuralTagSchemaMode;
-use llm_rs::local_model::runtime_config::StructuralTagScope as RsStructuralTagScope;
+use llm_rs::local_model::runtime_config::StructuralTagConfig as RsStructuralTagConfig;
 use llm_rs::local_model::runtime_config::TokenizerBackend as RsTokenizerBackend;
 use llm_rs::protocols::tensor::TensorModelConfig;
 use pyo3::exceptions::PyValueError;
@@ -284,6 +282,19 @@ impl ModelRuntimeConfig {
     }
 
     #[getter]
+    fn structural_tag(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+        self.inner
+            .structural_tag
+            .as_ref()
+            .map(|config| {
+                pythonize::pythonize(py, config)
+                    .map(|value| value.unbind())
+                    .map_err(to_pyerr)
+            })
+            .transpose()
+    }
+
+    #[getter]
     fn runtime_data(&self, py: Python<'_>) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         for (key, value) in self.inner.runtime_data.clone() {
@@ -296,44 +307,18 @@ impl ModelRuntimeConfig {
         self.inner.get_engine_specific(key).map_err(to_pyerr)
     }
 
-    fn set_structural_tag_mode(&mut self, mode: &str) -> PyResult<()> {
-        self.inner.structural_tag_mode = match mode {
-            "off" => RsStructuralTagMode::Off,
-            "on" => RsStructuralTagMode::On,
-            _ => {
-                return Err(PyErr::new::<PyException, _>(format!(
-                    "Invalid structural_tag_mode: {mode}. Expected 'off' or 'on'."
-                )));
-            }
-        };
-        Ok(())
-    }
-
-    /// Set the structural tag scope ("auto" or "always").
-    fn set_structural_tag_scope(&mut self, scope: &str) -> PyResult<()> {
-        self.inner.structural_tag_scope = match scope {
-            "auto" => RsStructuralTagScope::Auto,
-            "always" => RsStructuralTagScope::Always,
-            _ => {
-                return Err(PyErr::new::<PyException, _>(format!(
-                    "Invalid structural_tag_scope: {scope}. Expected 'auto' or 'always'."
-                )));
-            }
-        };
-        Ok(())
-    }
-
-    /// Set the structural tag schema mode ("auto" or "strict").
-    fn set_structural_tag_schema(&mut self, schema: &str) -> PyResult<()> {
-        self.inner.structural_tag_schema = match schema {
-            "auto" => RsStructuralTagSchemaMode::Auto,
-            "strict" => RsStructuralTagSchemaMode::Strict,
-            _ => {
-                return Err(PyErr::new::<PyException, _>(format!(
-                    "Invalid structural_tag_schema: {schema}. Expected 'auto' or 'strict'."
-                )));
-            }
-        };
+    #[pyo3(signature = (structural_tag=None))]
+    fn set_structural_tag(
+        &mut self,
+        structural_tag: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<()> {
+        let structural_tag = structural_tag
+            .map(|config| pythonize::depythonize::<RsStructuralTagConfig>(config))
+            .transpose()
+            .map_err(|error| {
+                PyValueError::new_err(format!("Invalid structural_tag config: {error}"))
+            })?;
+        self.inner.structural_tag = structural_tag;
         Ok(())
     }
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -874,6 +874,7 @@ class ModelRuntimeConfig:
     tool_call_parser: str | None
     reasoning_parser: str | None
     tokenizer_backend: str | None
+    structural_tag: dict[str, Any] | None
     exclude_tools_when_tool_choice_none: bool
     data_parallel_start_rank: int
     data_parallel_size: int
@@ -902,16 +903,8 @@ class ModelRuntimeConfig:
         """Get an engine-specific runtime configuration value"""
         ...
 
-    def set_structural_tag_mode(self, mode: str) -> None:
-        """Set structural tag mode ("off" or "on")."""
-        ...
-
-    def set_structural_tag_scope(self, scope: str) -> None:
-        """Set structural tag scope ("auto" or "always")."""
-        ...
-
-    def set_structural_tag_schema(self, schema: str) -> None:
-        """Set structural tag schema mode ("auto" or "strict")."""
+    def set_structural_tag(self, structural_tag: dict[str, Any] | None) -> None:
+        """Set the structural-tag policy, or disable it with ``None``."""
         ...
 
     def set_disaggregated_endpoint(
@@ -3450,9 +3443,7 @@ class backend:
             runtime: Optional["backend.RuntimeConfig"] = None,
             disaggregation_mode: "backend.DisaggregationMode" = ...,
             health_check_payload: Optional[Dict[str, Any]] = None,
-            structural_tag_mode: str = ...,
-            structural_tag_scope: str = ...,
-            structural_tag_schema: str = ...,
+            structural_tag: Optional[Dict[str, Any]] = None,
             route_to_encoder: bool = ...,
             media_decoder: Optional[MediaDecoder] = None,
             media_fetcher: Optional[MediaFetcher] = None,

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -354,8 +354,7 @@ impl WorkerSet {
     /// Build ParsingOptions from this WorkerSet's card configuration.
     pub fn parsing_options(&self) -> crate::protocols::openai::ParsingOptions {
         crate::protocols::openai::ParsingOptions {
-            structural_tag_mode: self.card.runtime_config.structural_tag_mode,
-            structural_tag_scope: self.card.runtime_config.structural_tag_scope,
+            structural_tag: self.card.runtime_config.structural_tag.clone(),
             exclude_tools_when_tool_choice_none: self
                 .card
                 .runtime_config

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -63,13 +63,19 @@ fn apply_request_tool_call_parsing_options(
     let converted_tool_choice = crate::preprocessor::tool_choice::convert_tool_choice(tool_choice);
     let tools = request.inner.tools.as_deref().unwrap_or(&[]);
     let converted_tools = crate::preprocessor::tool_choice::convert_tools(tools);
+    let structural_tag_config = parsing_options.structural_tag.as_ref();
+    let has_structured_output = request
+        .inner
+        .response_format
+        .as_ref()
+        .is_some_and(|format| !matches!(format, dynamo_protocols::types::ResponseFormat::Text));
     let uses_structural_tag = crate::preprocessor::structural_tag::structural_tag_decision(
         parsing_options.tool_call_parser.as_deref(),
         &converted_tool_choice,
         &converted_tools,
         request.inner.parallel_tool_calls,
-        parsing_options.structural_tag_mode,
-        parsing_options.structural_tag_scope,
+        structural_tag_config,
+        has_structured_output,
         parsing_options.exclude_tools_when_tool_choice_none,
     )?
     .is_required();
@@ -172,15 +178,14 @@ mod tests {
     // The registry-builder gap this test suite exists to close: a non-Kimi parser
     // (qwen3_coder, which the parser registry does register a structural-tag builder
     // for) with a forced tool_choice must still resolve to `StructuralTag` once the
-    // operator has globally enabled structural-tag mode — matching the real
-    // preprocessing path (`apply_tool_choice_structural_tag`'s
-    // `structural_tag_mode != Off` branch), not the narrower Kimi-only reconstruction
-    // this helper used before this fix.
+    // operator has configured structural tags — matching the real preprocessing
+    // path, not the narrower Kimi-only reconstruction this helper used before
+    // this fix.
     #[test]
     fn operator_enabled_mode_resolves_structural_tag_for_a_non_kimi_parser() {
         let parsing_options = ParsingOptions {
             tool_call_parser: Some("qwen3_coder".to_string()),
-            structural_tag_mode: crate::local_model::runtime_config::StructuralTagMode::On,
+            structural_tag: Some(Default::default()),
             ..Default::default()
         };
         let result =
@@ -189,14 +194,14 @@ mod tests {
         assert_eq!(
             result.guided_tool_constraint,
             GuidedToolConstraint::StructuralTag,
-            "an operator-enabled structural_tag_mode must apply to any registry-supported \
+            "an operator-configured structural tag must apply to any registry-supported \
              parser, not only the Kimi-intrinsic case"
         );
     }
 
-    // With the operator default (`structural_tag_mode = Off`), the same non-Kimi
-    // parser must NOT get a structural tag — confirms the mode gate above is real,
-    // not a permanently-on regression.
+    // Without an operator configuration, the same non-Kimi parser must NOT get a
+    // structural tag — confirms the gate above is real, not a permanently-on
+    // regression.
     #[test]
     fn operator_default_mode_off_does_not_resolve_structural_tag_for_a_non_kimi_parser() {
         let parsing_options = ParsingOptions {
@@ -212,8 +217,40 @@ mod tests {
         );
     }
 
+    #[test]
+    fn tools_with_structured_output_are_classified_as_structural_tag() {
+        let mut request = request(json!("auto"));
+        request.inner.response_format = Some(
+            serde_json::from_value(json!({
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "response",
+                    "schema": {"type": "object"}
+                }
+            }))
+            .expect("response_format must deserialize"),
+        );
+        let config = crate::local_model::runtime_config::StructuralTagConfig {
+            allow_tool_calls_with_structured_output: true,
+            ..Default::default()
+        };
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("qwen3_coder".to_string()),
+            structural_tag: Some(config),
+            ..Default::default()
+        };
+
+        let result = apply_request_tool_call_parsing_options(parsing_options, &request)
+            .expect("tools with structured output must resolve a constraint");
+
+        assert_eq!(
+            result.guided_tool_constraint,
+            GuidedToolConstraint::StructuralTag
+        );
+    }
+
     // `tool_choice: none` must never leave the client able to observe a tool call or
-    // a tool-call finish reason, regardless of the operator's structural-tag mode or
+    // a tool-call finish reason, regardless of the operator's structural-tag policy or
     // exclusion setting. The real preprocessing path may install a ban tag at
     // generation time for `none` (which is a request-time generation constraint on
     // the engine, tracked separately from this field), but that must not surface as
@@ -228,7 +265,7 @@ mod tests {
         for exclude_tools_when_tool_choice_none in [true, false] {
             let parsing_options = ParsingOptions {
                 tool_call_parser: Some("qwen3_coder".to_string()),
-                structural_tag_mode: crate::local_model::runtime_config::StructuralTagMode::On,
+                structural_tag: Some(Default::default()),
                 exclude_tools_when_tool_choice_none,
                 ..Default::default()
             };
@@ -428,7 +465,7 @@ mod tests {
     }
 
     // Same gap, operator-enabled path: qwen3_coder only gets a structural tag when
-    // `structural_tag_mode = On` (it is not Kimi-intrinsic). Confirms the fix isn't
+    // structural tags are configured (it is not Kimi-intrinsic). Confirms the fix isn't
     // narrowly scoped to the two Kimi-intrinsic parsers.
     #[test]
     fn operator_enabled_qwen3_coder_required_with_empty_tools_is_rejected() {
@@ -442,7 +479,7 @@ mod tests {
             serde_json::from_value(value).expect("request must deserialize");
         let parsing_options = ParsingOptions {
             tool_call_parser: Some("qwen3_coder".to_string()),
-            structural_tag_mode: crate::local_model::runtime_config::StructuralTagMode::On,
+            structural_tag: Some(Default::default()),
             ..Default::default()
         };
         let result = apply_request_tool_call_parsing_options(parsing_options, &request);
@@ -475,7 +512,7 @@ mod tests {
             serde_json::from_value(value).expect("request must deserialize");
         let parsing_options = ParsingOptions {
             tool_call_parser: Some("qwen3_coder".to_string()),
-            structural_tag_mode: crate::local_model::runtime_config::StructuralTagMode::On,
+            structural_tag: Some(Default::default()),
             ..Default::default()
         };
         let result = apply_request_tool_call_parsing_options(parsing_options, &request);

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -79,8 +79,10 @@ pub enum StructuralTagScope {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum StructuralTagReasoningBoundary {
-    /// Include reasoning and its closing marker in the structural tag.
+    /// Follow the reasoning-boundary policy advertised by the inference backend.
     #[default]
+    Auto,
+    /// Include reasoning and its closing marker in the structural tag.
     StructuralTag,
     /// Let the inference backend activate a suffix-only structural tag after reasoning.
     Backend,
@@ -787,6 +789,11 @@ mod tests {
 
     #[test]
     fn structural_tag_config_round_trips_and_rejects_unknown_fields() {
+        assert_eq!(
+            StructuralTagConfig::default().reasoning_boundary,
+            StructuralTagReasoningBoundary::Auto
+        );
+
         let config = StructuralTagConfig {
             scope: StructuralTagScope::Always,
             schema: StructuralTagSchemaMode::Strict,

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -790,6 +790,10 @@ mod tests {
     #[test]
     fn structural_tag_config_round_trips_and_rejects_unknown_fields() {
         assert_eq!(
+            serde_json::from_value::<StructuralTagConfig>(serde_json::json!({})).unwrap(),
+            StructuralTagConfig::default()
+        );
+        assert_eq!(
             StructuralTagConfig::default().reasoning_boundary,
             StructuralTagReasoningBoundary::Auto
         );

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -66,15 +66,6 @@ pub fn topology_taint(domain: &str, value: &str) -> String {
     format!("{TOPOLOGY_TAINT_PREFIX}{domain}={value}")
 }
 
-/// Master switch for structural tag guided decoding.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum StructuralTagMode {
-    #[default]
-    Off,
-    On,
-}
-
 /// Controls when structural tags are activated based on `tool_choice`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -82,6 +73,32 @@ pub enum StructuralTagScope {
     #[default]
     Auto,
     Always,
+}
+
+/// Controls which layer owns a reasoning boundary before structural-tag output.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum StructuralTagReasoningBoundary {
+    /// Include reasoning and its closing marker in the structural tag.
+    #[default]
+    StructuralTag,
+    /// Let the inference backend activate a suffix-only structural tag after reasoning.
+    Backend,
+}
+
+/// Structural-tag guided-decoding policy for tool-calling requests.
+///
+/// Presence enables structural tags; absence disables operator-controlled tags.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct StructuralTagConfig {
+    pub scope: StructuralTagScope,
+    pub schema: StructuralTagSchemaMode,
+    pub allow_tool_calls_with_structured_output: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exclude_special_tokens: Option<bool>,
+    pub reasoning_boundary: StructuralTagReasoningBoundary,
+    pub tool_arguments_any_order: bool,
 }
 
 pub const ENV_TOKENIZER_BACKEND: &str = "DYN_TOKENIZER";
@@ -239,17 +256,10 @@ pub struct ModelRuntimeConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tokenizer_fallback_enabled: Option<bool>,
 
-    /// Whether structural tag guided decoding is enabled for tool calls.
-    #[serde(default)]
-    pub structural_tag_mode: StructuralTagMode,
-
-    /// Controls when structural tags are activated based on tool_choice.
-    #[serde(default)]
-    pub structural_tag_scope: StructuralTagScope,
-
-    /// Controls whether tools get real or generic schemas in structural tags.
-    #[serde(default)]
-    pub structural_tag_schema: StructuralTagSchemaMode,
+    /// Structural-tag policy used by the preprocessor. Presence enables
+    /// operator-controlled structural tags.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub structural_tag: Option<StructuralTagConfig>,
 
     /// When true, strip tool definitions from the chat template when tool_choice is "none".
     #[serde(default = "default_exclude_tools_when_tool_choice_none")]
@@ -381,9 +391,7 @@ impl Default for ModelRuntimeConfig {
             tool_call_arguments_format: ToolCallArgumentsFormat::JsonString,
             tokenizer_backend: None,
             tokenizer_fallback_enabled: None,
-            structural_tag_mode: StructuralTagMode::Off,
-            structural_tag_scope: StructuralTagScope::Auto,
-            structural_tag_schema: StructuralTagSchemaMode::Auto,
+            structural_tag: None,
             exclude_tools_when_tool_choice_none: default_exclude_tools_when_tool_choice_none(),
             data_parallel_start_rank: default_data_parallel_start_rank(),
             data_parallel_size: default_data_parallel_size(),
@@ -776,6 +784,27 @@ mod tests {
     use super::*;
 
     use crate::protocols::openai::chat_completions::tool_parser_v2::V2_FAMILIES;
+
+    #[test]
+    fn structural_tag_config_round_trips_and_rejects_unknown_fields() {
+        let config = StructuralTagConfig {
+            scope: StructuralTagScope::Always,
+            schema: StructuralTagSchemaMode::Strict,
+            allow_tool_calls_with_structured_output: true,
+            exclude_special_tokens: Some(false),
+            reasoning_boundary: StructuralTagReasoningBoundary::Backend,
+            tool_arguments_any_order: true,
+        };
+        let value = serde_json::to_value(&config).unwrap();
+        assert_eq!(
+            serde_json::from_value::<StructuralTagConfig>(value).unwrap(),
+            config
+        );
+        assert!(
+            serde_json::from_value::<StructuralTagConfig>(serde_json::json!({"unexpected": true}))
+                .is_err()
+        );
+    }
 
     // Env-touching tests use `temp_env` (snapshot + restore around the closure) and
     // `#[serial_test::serial]` (serialize against every other env-touching test in the

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1556,6 +1556,7 @@ pub struct OpenAIPreprocessor {
     lora_name: Option<String>,
     /// Per-model runtime configuration propagated to response generator (e.g., reasoning/tool parser)
     runtime_config: crate::local_model::runtime_config::ModelRuntimeConfig,
+    structural_tag_reasoning_boundary: structural_tag::ResolvedReasoningBoundary,
     /// KV cache block size published in the model deployment card.
     kv_cache_block_size: usize,
     tool_call_parser: Option<String>,
@@ -2275,7 +2276,8 @@ impl OpenAIPreprocessor {
 
         // // Initialize runtime config from the ModelDeploymentCard
         let runtime_config = mdc.runtime_config.clone();
-        structural_tag::validate_runtime_config(&runtime_config)?;
+        let structural_tag_reasoning_boundary =
+            structural_tag::validate_runtime_config(&runtime_config)?;
         let token_budget = match runtime_config
             .get_engine_specific::<TokenBudget>(TOKEN_BUDGET_RUNTIME_KEY)
         {
@@ -2557,6 +2559,7 @@ impl OpenAIPreprocessor {
             mdcsum,
             lora_name,
             runtime_config,
+            structural_tag_reasoning_boundary,
             kv_cache_block_size,
             tool_call_parser,
             normalize_tool_call_args,

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2275,6 +2275,7 @@ impl OpenAIPreprocessor {
 
         // // Initialize runtime config from the ModelDeploymentCard
         let runtime_config = mdc.runtime_config.clone();
+        structural_tag::validate_runtime_config(&runtime_config)?;
         let token_budget = match runtime_config
             .get_engine_specific::<TokenBudget>(TOKEN_BUDGET_RUNTIME_KEY)
         {
@@ -4570,11 +4571,11 @@ impl OpenAIPreprocessor {
         if let Some(parser_name) = effective_tool_call_parser.as_deref()
             && tool_parser_v2::enabled()
             && tool_parser_v2::supports_family(parser_name)
-            && !uses_tool_call_structural_tag
-            && matches!(
-                request.inner.tool_choice.as_ref(),
-                None | Some(ChatCompletionToolChoiceOption::Auto)
-            )
+            && (uses_tool_call_structural_tag
+                || matches!(
+                    request.inner.tool_choice.as_ref(),
+                    None | Some(ChatCompletionToolChoiceOption::Auto)
+                ))
         {
             Ok(ToolProcessingRoute::ParserV2(parser_name.to_string()))
         } else {

--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -3,14 +3,60 @@
 
 //! Structural tag policy for chat tool-call guided decoding.
 
+mod v1;
+mod v2;
+
 use crate::local_model::runtime_config::{
-    StructuralTagMode, StructuralTagScope, TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY,
+    ModelRuntimeConfig, StructuralTagConfig, StructuralTagReasoningBoundary, StructuralTagScope,
+    TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY,
 };
 use crate::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
 use crate::protocols::openai::tools::{ToolChoiceValidation, validate_tool_choice_against_names};
 
-use dynamo_parsers::tool_calling::{ToolChoice, ToolDefinition};
+use dynamo_parsers::tool_calling::{StructuralTagSchemaMode, ToolChoice, ToolDefinition};
+use dynamo_runtime::config::environment_names::llm as env_llm;
 use dynamo_runtime::error::{DynamoError, ErrorType};
+
+struct StructuralTagBuildRequest<'a> {
+    tool_choice: &'a ToolChoice,
+    tools: &'a [ToolDefinition],
+    parallel_tool_calls: Option<bool>,
+    schema_mode: StructuralTagSchemaMode,
+    exclude_special_tokens: Option<bool>,
+    reasoning_boundary: StructuralTagReasoningBoundary,
+    tool_arguments_any_order: bool,
+    starts_in_reasoning: bool,
+    structured_output_schema: Option<&'a serde_json::Value>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum SelectedStructuralTagBuilder {
+    V1(v1::StructuralTagBuilder),
+    V2(v2::StructuralTagBuilder),
+}
+
+impl SelectedStructuralTagBuilder {
+    fn for_parser(parser_name: &str) -> Option<Self> {
+        if v2::enabled()
+            && v2::supports_family(parser_name)
+            && let Some(builder) = v2::StructuralTagBuilder::for_parser(parser_name)
+        {
+            return Some(Self::V2(builder));
+        }
+
+        v1::StructuralTagBuilder::for_parser(parser_name).map(Self::V1)
+    }
+
+    fn build(
+        self,
+        request: &StructuralTagBuildRequest<'_>,
+    ) -> anyhow::Result<Option<serde_json::Value>> {
+        match self {
+            Self::V1(builder) => builder.build(request),
+            Self::V2(builder) => builder.build(request),
+        }
+    }
+}
 
 /// Validate a forced `tool_choice` against the request's actual `tools` list.
 ///
@@ -64,19 +110,20 @@ fn should_skip_tool_call_ban(exclude_tools_when_none: bool, tool_choice: &ToolCh
 /// parser registry can actually build one.
 ///
 /// This is the single owner of "is a structural tag applicable and available" —
-/// covering model-family/tool-choice intrinsic eligibility, the operator's global
-/// `structural_tag_mode`/`structural_tag_scope`, the `tool_choice=None` ban-tag
-/// exclusion, and real parser-registry builder availability. A caller can only
-/// reach `Required` by way of a real, registered
-/// [`dynamo_parsers::tool_calling::StructuralTagBuilder`] — it cannot ask for the
-/// eligibility half of this decision without also getting the registry-availability
-/// proof in the same value. Both the real preprocessing path
+/// covering model-family/tool-choice intrinsic eligibility, the configured
+/// structural-tag policy, tools-with-structured-output composition, the
+/// `tool_choice=None` ban-tag exclusion, and real parser-registry builder
+/// availability. A caller can only reach `Required` with a registered builder
+/// selected for the active parser generation — it cannot ask for the eligibility
+/// half of this decision without also getting the registry-availability proof in
+/// the same value. Both the real
+/// preprocessing path
 /// (`apply_tool_choice_structural_tag`) and the HTTP-layer reconstruction
 /// (`http::service::apply_request_tool_call_parsing_options`) must consult this
 /// function; neither may re-derive eligibility, mode, scope, or registry
 /// availability independently.
 pub(crate) enum StructuralTagDecision {
-    Required(&'static dynamo_parsers::tool_calling::StructuralTagBuilder),
+    Required(SelectedStructuralTagBuilder),
     NotApplicable,
 }
 
@@ -96,25 +143,40 @@ impl StructuralTagDecision {
 /// (`http::service::apply_request_tool_call_parsing_options`) must propagate
 /// this error rather than falling back to `NotApplicable`, or an invalid forced
 /// choice would silently install a structural tag anyway.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn structural_tag_decision(
     parser_name: Option<&str>,
     tool_choice: &ToolChoice,
     tools: &[ToolDefinition],
     parallel_tool_calls: Option<bool>,
-    mode: StructuralTagMode,
-    scope: StructuralTagScope,
+    config: Option<&StructuralTagConfig>,
+    has_structured_output: bool,
     exclude_tools_when_tool_choice_none: bool,
 ) -> Result<StructuralTagDecision, DynamoError> {
     // Validate before any mode or family gate. Kimi K3 required requests use a
     // prompt-level XTML path, but they still need an actual tool to require.
     validate_forced_tool_choice(tool_choice, tools)?;
 
-    if mode == StructuralTagMode::Off
-        && !requires_intrinsic_structural_tag(parser_name, tool_choice)
-    {
+    if config.is_none() && !requires_intrinsic_structural_tag(parser_name, tool_choice) {
         return Ok(StructuralTagDecision::NotApplicable);
     }
+
+    let requires_tool_calls_with_structured_output = if has_structured_output {
+        match tool_choice {
+            ToolChoice::Auto => {
+                if config.is_some_and(|config| config.allow_tool_calls_with_structured_output)
+                    && !tools.is_empty()
+                {
+                    true
+                } else {
+                    return Ok(StructuralTagDecision::NotApplicable);
+                }
+            }
+            ToolChoice::None => return Ok(StructuralTagDecision::NotApplicable),
+            ToolChoice::Required | ToolChoice::Named(_) => false,
+        }
+    } else {
+        false
+    };
 
     if should_skip_tool_call_ban(exclude_tools_when_tool_choice_none, tool_choice) {
         // The prompt formatter already omits tools for this request. Avoid
@@ -131,7 +193,7 @@ pub(crate) fn structural_tag_decision(
         return Ok(StructuralTagDecision::NotApplicable);
     };
 
-    let Some(builder) = OpenAIPreprocessor::structural_tag_builder_for_parser(parser_name) else {
+    let Some(builder) = SelectedStructuralTagBuilder::for_parser(parser_name) else {
         return Ok(StructuralTagDecision::NotApplicable);
     };
 
@@ -141,6 +203,12 @@ pub(crate) fn structural_tag_decision(
         }
         return Ok(StructuralTagDecision::Required(builder));
     }
+
+    if requires_tool_calls_with_structured_output {
+        return Ok(StructuralTagDecision::Required(builder));
+    }
+
+    let scope = config.map_or_else(Default::default, |config| config.scope);
 
     if !OpenAIPreprocessor::should_apply_tool_call_format(
         scope,
@@ -162,45 +230,69 @@ impl OpenAIPreprocessor {
         tools: &[ToolDefinition],
         parallel_tool_calls: Option<bool>,
         prompt_injected_reasoning: bool,
+        structured_output_schema: Option<&serde_json::Value>,
         preprocessed_request: &mut PreprocessedRequest,
     ) -> Result<bool, DynamoError> {
         let parser_name = self.tool_call_parser.as_deref();
+        let explicit_config = self.runtime_config.structural_tag.as_ref();
+
+        let mut config = explicit_config.cloned().unwrap_or_default();
+        if explicit_config.is_none() && self.backend_excludes_reasoning_from_structural_tag() {
+            config.reasoning_boundary = StructuralTagReasoningBoundary::Backend;
+        }
         let StructuralTagDecision::Required(builder) = structural_tag_decision(
             parser_name,
             tool_choice,
             tools,
             parallel_tool_calls,
-            self.runtime_config.structural_tag_mode,
-            self.runtime_config.structural_tag_scope,
+            explicit_config,
+            structured_output_schema.is_some(),
             self.runtime_config.exclude_tools_when_tool_choice_none,
         )?
         else {
             return Ok(false);
         };
-        // `structural_tag_decision` only returns `Required` once `parser_name` is
-        // confirmed `Some` (it is the source of the registry lookup that produced
-        // `builder`), so this is a real value, not a placeholder.
         let parser_name = parser_name.expect("Required decision implies a parser name");
 
-        if matches!(tool_choice, ToolChoice::None) {
-            return Self::apply_tool_call_ban(builder, preprocessed_request);
-        }
+        let structured_output_schema = if matches!(tool_choice, ToolChoice::Auto)
+            && config.allow_tool_calls_with_structured_output
+        {
+            structured_output_schema
+        } else {
+            None
+        };
 
-        // `structural_tag_decision` already confirmed `should_apply_tool_call_format`
-        // for this non-None tool_choice before returning `Required`.
-        let ctx = dynamo_parsers::tool_calling::ToolCallFormatBuildContext {
+        let request = StructuralTagBuildRequest {
             tool_choice,
             tools,
             parallel_tool_calls,
-            schema_mode: self.runtime_config.structural_tag_schema,
-            starts_in_reasoning: prompt_injected_reasoning
-                && !self.tool_call_structural_tag_excludes_reasoning(),
+            schema_mode: config.schema,
+            exclude_special_tokens: config.exclude_special_tokens,
+            reasoning_boundary: config.reasoning_boundary,
+            tool_arguments_any_order: config.tool_arguments_any_order,
+            starts_in_reasoning: prompt_injected_reasoning,
+            structured_output_schema,
         };
 
-        Self::apply_tool_call_format(parser_name, builder, &ctx, preprocessed_request)
+        let applied =
+            apply_structural_tag(parser_name, builder.build(&request), preprocessed_request)?;
+        if applied && structured_output_schema.is_some() {
+            // Request preprocessing materializes `response_format` as guided JSON.
+            // The composite structural tag now owns that schema.
+            preprocessed_request
+                .sampling_options
+                .guided_decoding
+                .get_or_insert_default()
+                .json = None;
+        }
+        if applied && prompt_injected_reasoning {
+            preprocessed_request.require_reasoning =
+                config.reasoning_boundary == StructuralTagReasoningBoundary::Backend;
+        }
+        Ok(applied)
     }
 
-    fn tool_call_structural_tag_excludes_reasoning(&self) -> bool {
+    fn backend_excludes_reasoning_from_structural_tag(&self) -> bool {
         match self
             .runtime_config
             .get_engine_specific::<bool>(TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY)
@@ -211,88 +303,11 @@ impl OpenAIPreprocessor {
                 tracing::warn!(
                     %error,
                     key = TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY,
-                    "Ignoring invalid structural-tag reasoning metadata; using the compatibility behavior"
+                    "Ignoring invalid structural-tag reasoning metadata"
                 );
                 false
             }
         }
-    }
-
-    /// Find the structural tag builder for a parser, if supported.
-    fn structural_tag_builder_for_parser(
-        parser_name: &str,
-    ) -> Option<&'static dynamo_parsers::tool_calling::StructuralTagBuilder> {
-        let parser_map = dynamo_parsers::tool_calling::parsers::get_tool_parser_map();
-        let builder = parser_map
-            .get(parser_name)
-            .and_then(|tc| tc.structural_tag_builder.as_ref());
-
-        if builder.is_none() {
-            tracing::warn!(
-                parser = parser_name,
-                "Structural tag enabled but parser does not support it; \
-                 falling back to default behaviour"
-            );
-        }
-
-        builder
-    }
-
-    /// Apply the `tool_choice=none` ban tag, if configured.
-    fn apply_tool_call_ban(
-        builder: &dynamo_parsers::tool_calling::StructuralTagBuilder,
-        common_request: &mut PreprocessedRequest,
-    ) -> Result<bool, DynamoError> {
-        if let Some(ban_tag) = builder.build_tool_call_ban().map_err(|e| {
-            DynamoError::builder()
-                .error_type(ErrorType::Unknown)
-                .message(format!("failed to build tool-call ban structural tag: {e}"))
-                .build()
-        })? {
-            let gd = common_request
-                .sampling_options
-                .guided_decoding
-                .get_or_insert_default();
-            gd.structural_tag = Some(ban_tag);
-            Ok(true)
-        } else {
-            Ok(false)
-        }
-    }
-
-    /// Build and inject the tool-call format tag, if one is needed.
-    fn apply_tool_call_format(
-        parser_name: &str,
-        builder: &dynamo_parsers::tool_calling::StructuralTagBuilder,
-        ctx: &dynamo_parsers::tool_calling::ToolCallFormatBuildContext<'_>,
-        common_request: &mut PreprocessedRequest,
-    ) -> Result<bool, DynamoError> {
-        let structural_tag = match builder.build_tool_call_format(ctx) {
-            Ok(Some(tag)) => tag,
-            Ok(None) => {
-                tracing::debug!(
-                    parser = parser_name,
-                    "Builder returned None for structural_tag (tool_choice={:?})",
-                    ctx.tool_choice,
-                );
-                return Ok(false);
-            }
-            Err(e) => {
-                return Err(DynamoError::builder()
-                    .error_type(ErrorType::Unknown)
-                    .message(format!(
-                        "failed to build structural_tag for parser '{parser_name}': {e}"
-                    ))
-                    .build());
-            }
-        };
-
-        let gd = common_request
-            .sampling_options
-            .guided_decoding
-            .get_or_insert_default();
-        gd.structural_tag = Some(structural_tag);
-        Ok(true)
     }
 
     /// Decide whether this request should use a tool-call format tag.
@@ -316,11 +331,95 @@ impl OpenAIPreprocessor {
     }
 }
 
+fn apply_structural_tag(
+    parser_name: &str,
+    structural_tag: anyhow::Result<Option<serde_json::Value>>,
+    request: &mut PreprocessedRequest,
+) -> Result<bool, DynamoError> {
+    let structural_tag = match structural_tag {
+        Ok(Some(tag)) => tag,
+        Ok(None) => return Ok(false),
+        Err(error) => {
+            return Err(DynamoError::builder()
+                .error_type(ErrorType::Unknown)
+                .message(format!(
+                    "failed to build structural_tag for parser '{parser_name}': {error}"
+                ))
+                .build());
+        }
+    };
+
+    let guided_decoding = request
+        .sampling_options
+        .guided_decoding
+        .get_or_insert_default();
+    guided_decoding.structural_tag = Some(structural_tag);
+    Ok(true)
+}
+
+pub(super) fn validate_runtime_config(runtime_config: &ModelRuntimeConfig) -> anyhow::Result<()> {
+    let Some(config) = runtime_config.structural_tag.as_ref() else {
+        return Ok(());
+    };
+
+    let v2_only_option = config
+        .allow_tool_calls_with_structured_output
+        .then_some("allow_tool_calls_with_structured_output")
+        .or(config
+            .exclude_special_tokens
+            .is_some()
+            .then_some("exclude_special_tokens"))
+        .or(
+            (config.reasoning_boundary == StructuralTagReasoningBoundary::Backend)
+                .then_some("reasoning_boundary"),
+        )
+        .or(config
+            .tool_arguments_any_order
+            .then_some("tool_arguments_any_order"));
+    let Some(v2_only_option) = v2_only_option else {
+        return Ok(());
+    };
+
+    anyhow::ensure!(
+        v2::enabled(),
+        "structural_tag.{v2_only_option} requires {}=1",
+        env_llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2,
+    );
+    let parser_name = runtime_config.tool_call_parser.as_deref().ok_or_else(|| {
+        anyhow::anyhow!("structural_tag.{v2_only_option} requires a tool-call parser")
+    })?;
+    anyhow::ensure!(
+        v2::supports_family(parser_name),
+        "structural_tag.{v2_only_option} is not supported by parser '{parser_name}'"
+    );
+    anyhow::ensure!(
+        v2::StructuralTagBuilder::for_parser(parser_name).is_some(),
+        "parser '{parser_name}' does not provide a parsers-v2 structural-tag builder"
+    );
+
+    if config.reasoning_boundary == StructuralTagReasoningBoundary::Backend {
+        anyhow::ensure!(
+            runtime_config.reasoning_parser.is_some(),
+            "structural_tag.reasoning_boundary=backend requires a reasoning parser"
+        );
+        let capability = runtime_config
+            .get_engine_specific::<bool>(TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY)?
+            .unwrap_or(false);
+        anyhow::ensure!(
+            capability,
+            "structural_tag.reasoning_boundary=backend is not supported by this backend"
+        );
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::{path::PathBuf, sync::Arc};
 
     use crate::{
+        local_model::runtime_config::StructuralTagConfig,
         model_card::ModelDeploymentCard,
         protocols::common::{OutputOptions, SamplingOptions, StopConditions},
     };
@@ -331,7 +430,7 @@ mod tests {
         let model_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/data/sample-models/mock-llama-3.1-8b-instruct");
         let mut mdc = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
-        mdc.runtime_config.structural_tag_mode = StructuralTagMode::On;
+        mdc.runtime_config.structural_tag = Some(StructuralTagConfig::default());
         mdc.runtime_config.tool_call_parser = Some("qwen3_coder".to_string());
         mdc.runtime_config.exclude_tools_when_tool_choice_none = exclude_tools_when_none;
 
@@ -353,7 +452,7 @@ mod tests {
         let model_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/data/sample-models/mock-llama-3.1-8b-instruct");
         let mut mdc = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
-        mdc.runtime_config.structural_tag_mode = StructuralTagMode::On;
+        mdc.runtime_config.structural_tag = Some(StructuralTagConfig::default());
         mdc.runtime_config.tool_call_parser = Some("kimi_k2".to_string());
         if let Some(excludes_reasoning) = excludes_reasoning {
             mdc.runtime_config
@@ -371,7 +470,6 @@ mod tests {
         let model_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/data/sample-models/mock-llama-3.1-8b-instruct");
         let mut mdc = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
-        mdc.runtime_config.structural_tag_mode = StructuralTagMode::Off;
         mdc.runtime_config.tool_call_parser = Some("kimi_k3".to_string());
         OpenAIPreprocessor::new(mdc).unwrap()
     }
@@ -392,6 +490,7 @@ mod tests {
                     &tools,
                     None,
                     true,
+                    None,
                     &mut request,
                 )
                 .unwrap()
@@ -465,7 +564,7 @@ mod tests {
                 "test fixture drifted: '{parser}' + {choice:?} is no longer intrinsic"
             );
             assert!(
-                OpenAIPreprocessor::structural_tag_builder_for_parser(parser).is_some(),
+                SelectedStructuralTagBuilder::for_parser(parser).is_some(),
                 "'{parser}' is intrinsic per the predicate but the parser registry has \
                  no structural-tag builder for it — the predicate and the registry have \
                  drifted apart"
@@ -490,11 +589,107 @@ mod tests {
     }
 
     #[test]
+    fn tools_with_structured_output_require_a_tag_independently_of_scope() {
+        let tools = [ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: None,
+            strict: None,
+        }];
+        let config = StructuralTagConfig {
+            scope: StructuralTagScope::Auto,
+            allow_tool_calls_with_structured_output: true,
+            ..Default::default()
+        };
+
+        let decision = structural_tag_decision(
+            Some("qwen3_coder"),
+            &ToolChoice::Auto,
+            &tools,
+            None,
+            Some(&config),
+            true,
+            true,
+        )
+        .unwrap();
+
+        assert!(decision.is_required());
+    }
+
+    #[test]
+    fn structured_output_requires_explicit_tool_call_composition_opt_in() {
+        let tools = [ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: None,
+            strict: None,
+        }];
+
+        for scope in [StructuralTagScope::Auto, StructuralTagScope::Always] {
+            let config = StructuralTagConfig {
+                scope,
+                allow_tool_calls_with_structured_output: false,
+                ..Default::default()
+            };
+            let decision = structural_tag_decision(
+                Some("qwen3_coder"),
+                &ToolChoice::Auto,
+                &tools,
+                None,
+                Some(&config),
+                true,
+                true,
+            )
+            .unwrap();
+
+            assert!(!decision.is_required());
+        }
+
+        let config = StructuralTagConfig {
+            scope: StructuralTagScope::Auto,
+            allow_tool_calls_with_structured_output: true,
+            ..Default::default()
+        };
+        let decision = structural_tag_decision(
+            Some("qwen3_coder"),
+            &ToolChoice::Auto,
+            &tools,
+            None,
+            Some(&config),
+            false,
+            true,
+        )
+        .unwrap();
+
+        assert!(!decision.is_required());
+    }
+
+    #[test]
+    fn structured_output_takes_precedence_over_a_tool_call_ban() {
+        let tools = [ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: None,
+            strict: None,
+        }];
+        let config = StructuralTagConfig::default();
+
+        let decision = structural_tag_decision(
+            Some("qwen3_coder"),
+            &ToolChoice::None,
+            &tools,
+            None,
+            Some(&config),
+            true,
+            false,
+        )
+        .unwrap();
+
+        assert!(!decision.is_required());
+    }
+
+    #[test]
     fn kimi_k2_required_installs_native_tag_when_global_mode_is_off() {
         let model_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/data/sample-models/mock-llama-3.1-8b-instruct");
         let mut mdc = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
-        mdc.runtime_config.structural_tag_mode = StructuralTagMode::Off;
         mdc.runtime_config.tool_call_parser = Some("kimi_k2".to_string());
         let preprocessor = OpenAIPreprocessor::new(mdc).unwrap();
         let tools = [ToolDefinition {
@@ -514,6 +709,7 @@ mod tests {
                 &tools,
                 None,
                 false,
+                None,
                 &mut request,
             )
             .unwrap();
@@ -557,6 +753,7 @@ mod tests {
                 &tools,
                 None,
                 false,
+                None,
                 &mut request,
             )
             .unwrap();
@@ -579,7 +776,14 @@ mod tests {
         let mut request = preprocessed_request();
 
         let err = preprocessor
-            .apply_tool_choice_structural_tag(&ToolChoice::Required, &[], None, false, &mut request)
+            .apply_tool_choice_structural_tag(
+                &ToolChoice::Required,
+                &[],
+                None,
+                false,
+                None,
+                &mut request,
+            )
             .expect_err(
                 "kimi_k2 + required with no tools must be rejected, not silently \
                  resolved to a structural tag",
@@ -594,7 +798,14 @@ mod tests {
         let mut request = preprocessed_request();
 
         let err = preprocessor
-            .apply_tool_choice_structural_tag(&ToolChoice::Required, &[], None, false, &mut request)
+            .apply_tool_choice_structural_tag(
+                &ToolChoice::Required,
+                &[],
+                None,
+                false,
+                None,
+                &mut request,
+            )
             .expect_err("required with no tools must be rejected before Kimi K3's XTML path");
         assert_eq!(err.error_type(), ErrorType::InvalidArgument);
         assert!(request.sampling_options.guided_decoding.is_none());
@@ -616,6 +827,7 @@ mod tests {
                 &tools,
                 None,
                 false,
+                None,
                 &mut request,
             )
             .expect_err(
@@ -632,9 +844,16 @@ mod tests {
         let mut request = preprocessed_request();
 
         let err = preprocessor
-            .apply_tool_choice_structural_tag(&ToolChoice::Required, &[], None, false, &mut request)
+            .apply_tool_choice_structural_tag(
+                &ToolChoice::Required,
+                &[],
+                None,
+                false,
+                None,
+                &mut request,
+            )
             .expect_err(
-                "operator-enabled structural_tag_mode must not let required-with-no-tools \
+                "operator-configured structural tags must not let required-with-no-tools \
                  through for a non-Kimi registry-supported parser either",
             );
         assert_eq!(err.error_type(), ErrorType::InvalidArgument);
@@ -657,6 +876,7 @@ mod tests {
                 &tools,
                 None,
                 false,
+                None,
                 &mut request,
             )
             .expect_err(
@@ -675,13 +895,27 @@ mod tests {
 
         let mut request = preprocessed_request();
         let applied = preprocessor
-            .apply_tool_choice_structural_tag(&ToolChoice::None, &[], None, false, &mut request)
+            .apply_tool_choice_structural_tag(
+                &ToolChoice::None,
+                &[],
+                None,
+                false,
+                None,
+                &mut request,
+            )
             .unwrap();
         assert!(!applied);
 
         let mut request = preprocessed_request();
         let applied = preprocessor
-            .apply_tool_choice_structural_tag(&ToolChoice::Auto, &[], None, false, &mut request)
+            .apply_tool_choice_structural_tag(
+                &ToolChoice::Auto,
+                &[],
+                None,
+                false,
+                None,
+                &mut request,
+            )
             .unwrap();
         assert!(!applied);
     }
@@ -697,7 +931,14 @@ mod tests {
         let preprocessor = structural_tag_preprocessor(true);
         let mut request = preprocessed_request();
         let applied = preprocessor
-            .apply_tool_choice_structural_tag(&ToolChoice::None, &tools, None, false, &mut request)
+            .apply_tool_choice_structural_tag(
+                &ToolChoice::None,
+                &tools,
+                None,
+                false,
+                None,
+                &mut request,
+            )
             .unwrap();
 
         assert!(!applied);
@@ -706,7 +947,14 @@ mod tests {
         let preprocessor = structural_tag_preprocessor(false);
         let mut request = preprocessed_request();
         let applied = preprocessor
-            .apply_tool_choice_structural_tag(&ToolChoice::None, &tools, None, false, &mut request)
+            .apply_tool_choice_structural_tag(
+                &ToolChoice::None,
+                &tools,
+                None,
+                false,
+                None,
+                &mut request,
+            )
             .unwrap();
 
         assert!(applied);

--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -23,10 +23,33 @@ struct StructuralTagBuildRequest<'a> {
     parallel_tool_calls: Option<bool>,
     schema_mode: StructuralTagSchemaMode,
     exclude_special_tokens: Option<bool>,
-    reasoning_boundary: StructuralTagReasoningBoundary,
+    reasoning_boundary: ResolvedReasoningBoundary,
     tool_arguments_any_order: bool,
     starts_in_reasoning: bool,
     structured_output_schema: Option<&'a serde_json::Value>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ResolvedReasoningBoundary {
+    StructuralTag,
+    Backend,
+}
+
+fn resolve_reasoning_boundary(
+    configured: StructuralTagReasoningBoundary,
+    backend_excludes_reasoning: bool,
+) -> Result<ResolvedReasoningBoundary, &'static str> {
+    match (configured, backend_excludes_reasoning) {
+        (StructuralTagReasoningBoundary::Auto, false)
+        | (StructuralTagReasoningBoundary::StructuralTag, false) => {
+            Ok(ResolvedReasoningBoundary::StructuralTag)
+        }
+        (StructuralTagReasoningBoundary::Auto, true)
+        | (StructuralTagReasoningBoundary::Backend, _) => Ok(ResolvedReasoningBoundary::Backend),
+        (StructuralTagReasoningBoundary::StructuralTag, true) => Err(
+            "structural_tag.reasoning_boundary=structural_tag conflicts with the backend's reasoning-aware guided-decoding policy; use 'auto' or 'backend'",
+        ),
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -236,10 +259,8 @@ impl OpenAIPreprocessor {
         let parser_name = self.tool_call_parser.as_deref();
         let explicit_config = self.runtime_config.structural_tag.as_ref();
 
-        let mut config = explicit_config.cloned().unwrap_or_default();
-        if explicit_config.is_none() && self.backend_excludes_reasoning_from_structural_tag() {
-            config.reasoning_boundary = StructuralTagReasoningBoundary::Backend;
-        }
+        let config = explicit_config.cloned().unwrap_or_default();
+        let reasoning_boundary = self.structural_tag_reasoning_boundary;
         let StructuralTagDecision::Required(builder) = structural_tag_decision(
             parser_name,
             tool_choice,
@@ -268,7 +289,7 @@ impl OpenAIPreprocessor {
             parallel_tool_calls,
             schema_mode: config.schema,
             exclude_special_tokens: config.exclude_special_tokens,
-            reasoning_boundary: config.reasoning_boundary,
+            reasoning_boundary,
             tool_arguments_any_order: config.tool_arguments_any_order,
             starts_in_reasoning: prompt_injected_reasoning,
             structured_output_schema,
@@ -287,27 +308,9 @@ impl OpenAIPreprocessor {
         }
         if applied && prompt_injected_reasoning {
             preprocessed_request.require_reasoning =
-                config.reasoning_boundary == StructuralTagReasoningBoundary::Backend;
+                reasoning_boundary == ResolvedReasoningBoundary::Backend;
         }
         Ok(applied)
-    }
-
-    fn backend_excludes_reasoning_from_structural_tag(&self) -> bool {
-        match self
-            .runtime_config
-            .get_engine_specific::<bool>(TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY)
-        {
-            Ok(Some(excludes_reasoning)) => excludes_reasoning,
-            Ok(None) => false,
-            Err(error) => {
-                tracing::warn!(
-                    %error,
-                    key = TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY,
-                    "Ignoring invalid structural-tag reasoning metadata"
-                );
-                false
-            }
-        }
     }
 
     /// Decide whether this request should use a tool-call format tag.
@@ -357,10 +360,43 @@ fn apply_structural_tag(
     Ok(true)
 }
 
-pub(super) fn validate_runtime_config(runtime_config: &ModelRuntimeConfig) -> anyhow::Result<()> {
-    let Some(config) = runtime_config.structural_tag.as_ref() else {
-        return Ok(());
+pub(super) fn validate_runtime_config(
+    runtime_config: &ModelRuntimeConfig,
+) -> anyhow::Result<ResolvedReasoningBoundary> {
+    let backend_excludes_reasoning = match runtime_config
+        .get_engine_specific::<bool>(TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY)
+    {
+        Ok(value) => value.unwrap_or(false),
+        Err(error) if runtime_config.structural_tag.is_none() => {
+            tracing::warn!(
+                %error,
+                key = TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY,
+                "Ignoring invalid structural-tag reasoning metadata"
+            );
+            false
+        }
+        Err(error) => return Err(error),
     };
+    let configured_boundary = runtime_config
+        .structural_tag
+        .as_ref()
+        .map_or(StructuralTagReasoningBoundary::default(), |config| {
+            config.reasoning_boundary
+        });
+    let reasoning_boundary =
+        resolve_reasoning_boundary(configured_boundary, backend_excludes_reasoning)
+            .map_err(anyhow::Error::msg)?;
+
+    let Some(config) = runtime_config.structural_tag.as_ref() else {
+        return Ok(reasoning_boundary);
+    };
+
+    if config.reasoning_boundary == StructuralTagReasoningBoundary::Backend {
+        anyhow::ensure!(
+            runtime_config.reasoning_parser.is_some(),
+            "structural_tag.reasoning_boundary=backend requires a reasoning parser"
+        );
+    }
 
     let v2_only_option = config
         .allow_tool_calls_with_structured_output
@@ -377,7 +413,7 @@ pub(super) fn validate_runtime_config(runtime_config: &ModelRuntimeConfig) -> an
             .tool_arguments_any_order
             .then_some("tool_arguments_any_order"));
     let Some(v2_only_option) = v2_only_option else {
-        return Ok(());
+        return Ok(reasoning_boundary);
     };
 
     anyhow::ensure!(
@@ -397,21 +433,7 @@ pub(super) fn validate_runtime_config(runtime_config: &ModelRuntimeConfig) -> an
         "parser '{parser_name}' does not provide a parsers-v2 structural-tag builder"
     );
 
-    if config.reasoning_boundary == StructuralTagReasoningBoundary::Backend {
-        anyhow::ensure!(
-            runtime_config.reasoning_parser.is_some(),
-            "structural_tag.reasoning_boundary=backend requires a reasoning parser"
-        );
-        let capability = runtime_config
-            .get_engine_specific::<bool>(TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY)?
-            .unwrap_or(false);
-        anyhow::ensure!(
-            capability,
-            "structural_tag.reasoning_boundary=backend is not supported by this backend"
-        );
-    }
-
-    Ok(())
+    Ok(reasoning_boundary)
 }
 
 #[cfg(test)]
@@ -521,6 +543,62 @@ mod tests {
             format["elements"][0]["value"],
             "<|tool_calls_section_begin|>"
         );
+    }
+
+    #[test]
+    fn reasoning_boundary_resolution_follows_backend_policy_and_rejects_conflicts() {
+        assert_eq!(
+            resolve_reasoning_boundary(StructuralTagReasoningBoundary::Auto, false).unwrap(),
+            ResolvedReasoningBoundary::StructuralTag
+        );
+        assert_eq!(
+            resolve_reasoning_boundary(StructuralTagReasoningBoundary::Auto, true).unwrap(),
+            ResolvedReasoningBoundary::Backend
+        );
+        assert_eq!(
+            resolve_reasoning_boundary(StructuralTagReasoningBoundary::Backend, false).unwrap(),
+            ResolvedReasoningBoundary::Backend
+        );
+        assert!(
+            resolve_reasoning_boundary(StructuralTagReasoningBoundary::StructuralTag, true)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn reasoning_boundary_is_resolved_when_the_preprocessor_is_created() {
+        assert_eq!(
+            kimi_k2_preprocessor(None).structural_tag_reasoning_boundary,
+            ResolvedReasoningBoundary::StructuralTag
+        );
+        assert_eq!(
+            kimi_k2_preprocessor(Some(true)).structural_tag_reasoning_boundary,
+            ResolvedReasoningBoundary::Backend
+        );
+    }
+
+    #[test]
+    fn conflicting_reasoning_boundary_is_rejected_when_the_preprocessor_is_created() {
+        let model_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/sample-models/mock-llama-3.1-8b-instruct");
+        let mut mdc = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
+        mdc.runtime_config.structural_tag = Some(StructuralTagConfig {
+            reasoning_boundary: StructuralTagReasoningBoundary::StructuralTag,
+            ..Default::default()
+        });
+        mdc.runtime_config
+            .set_engine_specific(
+                TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY,
+                true,
+            )
+            .unwrap();
+
+        let error = OpenAIPreprocessor::new(mdc)
+            .err()
+            .expect("the conflicting boundary must fail during preprocessor initialization");
+        assert!(error.to_string().contains(
+            "structural_tag.reasoning_boundary=structural_tag conflicts with the backend"
+        ));
     }
 
     #[test]

--- a/lib/llm/src/preprocessor/structural_tag/v1.rs
+++ b/lib/llm/src/preprocessor/structural_tag/v1.rs
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_parsers::tool_calling::{
+    StructuralTagBuilder as InnerBuilder, ToolCallFormatBuildContext,
+};
+
+use super::{StructuralTagBuildRequest, StructuralTagReasoningBoundary};
+
+#[derive(Clone, Copy)]
+pub(crate) struct StructuralTagBuilder(&'static InnerBuilder);
+
+impl StructuralTagBuilder {
+    pub(super) fn for_parser(parser_name: &str) -> Option<Self> {
+        dynamo_parsers::tool_calling::parsers::get_tool_parser_map()
+            .get(parser_name)
+            .and_then(|config| config.structural_tag_builder.as_ref())
+            .map(Self)
+    }
+
+    pub(super) fn build(
+        self,
+        request: &StructuralTagBuildRequest<'_>,
+    ) -> anyhow::Result<Option<serde_json::Value>> {
+        anyhow::ensure!(
+            request.structured_output_schema.is_none(),
+            "tool calls with structured output require parsers v2"
+        );
+
+        if matches!(
+            request.tool_choice,
+            dynamo_parsers::tool_calling::ToolChoice::None
+        ) {
+            return self.0.build_tool_call_ban();
+        }
+
+        self.0.build_tool_call_format(&ToolCallFormatBuildContext {
+            tool_choice: request.tool_choice,
+            tools: request.tools,
+            parallel_tool_calls: request.parallel_tool_calls,
+            schema_mode: request.schema_mode,
+            starts_in_reasoning: request.starts_in_reasoning
+                && request.reasoning_boundary == StructuralTagReasoningBoundary::StructuralTag,
+        })
+    }
+}

--- a/lib/llm/src/preprocessor/structural_tag/v1.rs
+++ b/lib/llm/src/preprocessor/structural_tag/v1.rs
@@ -5,7 +5,7 @@ use dynamo_parsers::tool_calling::{
     StructuralTagBuilder as InnerBuilder, ToolCallFormatBuildContext,
 };
 
-use super::{StructuralTagBuildRequest, StructuralTagReasoningBoundary};
+use super::{ResolvedReasoningBoundary, StructuralTagBuildRequest};
 
 #[derive(Clone, Copy)]
 pub(crate) struct StructuralTagBuilder(&'static InnerBuilder);
@@ -40,7 +40,7 @@ impl StructuralTagBuilder {
             parallel_tool_calls: request.parallel_tool_calls,
             schema_mode: request.schema_mode,
             starts_in_reasoning: request.starts_in_reasoning
-                && request.reasoning_boundary == StructuralTagReasoningBoundary::StructuralTag,
+                && request.reasoning_boundary == ResolvedReasoningBoundary::StructuralTag,
         })
     }
 }

--- a/lib/llm/src/preprocessor/structural_tag/v2.rs
+++ b/lib/llm/src/preprocessor/structural_tag/v2.rs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_parsers::tool_calling::{ToolChoice, ToolDefinition};
+use dynamo_parsers_v2::Tool;
+use dynamo_parsers_v2::structural_tag::{
+    ReasoningBoundary as ReasoningBoundaryV2, StructuralTagBuilder as InnerBuilder,
+    StructuralTagContext, StructuralTagOptions,
+    StructuralTagSchemaMode as StructuralTagSchemaModeV2,
+    StructuralTagToolChoice as StructuralTagToolChoiceV2,
+};
+
+use crate::protocols::openai::chat_completions::tool_parser_v2;
+
+use super::StructuralTagBuildRequest;
+
+#[derive(Clone, Copy)]
+pub(crate) struct StructuralTagBuilder(&'static InnerBuilder);
+
+impl StructuralTagBuilder {
+    pub(super) fn for_parser(parser_name: &str) -> Option<Self> {
+        dynamo_parsers_v2::structural_tag_builder_for_family(tool_parser_v2::canonical_family(
+            parser_name,
+        ))
+        .map(Self)
+    }
+
+    pub(super) fn build(
+        self,
+        request: &StructuralTagBuildRequest<'_>,
+    ) -> anyhow::Result<Option<serde_json::Value>> {
+        let tools = request.tools.iter().map(to_v2_tool).collect::<Vec<_>>();
+        let tool_choice = match request.tool_choice {
+            ToolChoice::None => StructuralTagToolChoiceV2::None,
+            ToolChoice::Auto => StructuralTagToolChoiceV2::Auto,
+            ToolChoice::Required => StructuralTagToolChoiceV2::Required,
+            ToolChoice::Named(name) => StructuralTagToolChoiceV2::Named(name),
+        };
+        let schema_mode = match request.schema_mode {
+            dynamo_parsers::tool_calling::StructuralTagSchemaMode::Auto => {
+                StructuralTagSchemaModeV2::Auto
+            }
+            dynamo_parsers::tool_calling::StructuralTagSchemaMode::Strict => {
+                StructuralTagSchemaModeV2::Strict
+            }
+        };
+        let reasoning_boundary = match request.reasoning_boundary {
+            crate::local_model::runtime_config::StructuralTagReasoningBoundary::StructuralTag => {
+                ReasoningBoundaryV2::StructuralTag
+            }
+            crate::local_model::runtime_config::StructuralTagReasoningBoundary::Backend => {
+                ReasoningBoundaryV2::External
+            }
+        };
+
+        self.0.build_with_options(
+            &StructuralTagContext {
+                tool_choice,
+                tools: &tools,
+                parallel_tool_calls: request.parallel_tool_calls,
+                schema_mode,
+                structured_output_schema: request.structured_output_schema,
+                starts_in_reasoning: request.starts_in_reasoning,
+            },
+            &StructuralTagOptions {
+                exclude_special_tokens: request.exclude_special_tokens,
+                reasoning_boundary,
+                tool_arguments_any_order: request.tool_arguments_any_order,
+            },
+        )
+    }
+}
+
+fn to_v2_tool(tool: &ToolDefinition) -> Tool {
+    Tool {
+        name: tool.name.clone(),
+        description: None,
+        parameters: tool.parameters.clone().unwrap_or(serde_json::Value::Null),
+        strict: tool.strict,
+    }
+}
+
+pub(super) fn enabled() -> bool {
+    tool_parser_v2::enabled()
+}
+
+pub(super) fn supports_family(parser_name: &str) -> bool {
+    StructuralTagBuilder::for_parser(parser_name).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deepseek_v4_engine_aliases_select_the_structural_tag_builder() {
+        for alias in ["deepseek_v4", "deepseek-v4", "deepseekv4"] {
+            assert!(supports_family(alias), "unsupported alias: {alias}");
+            assert!(StructuralTagBuilder::for_parser(alias).is_some());
+        }
+    }
+}

--- a/lib/llm/src/preprocessor/structural_tag/v2.rs
+++ b/lib/llm/src/preprocessor/structural_tag/v2.rs
@@ -45,12 +45,8 @@ impl StructuralTagBuilder {
             }
         };
         let reasoning_boundary = match request.reasoning_boundary {
-            crate::local_model::runtime_config::StructuralTagReasoningBoundary::StructuralTag => {
-                ReasoningBoundaryV2::StructuralTag
-            }
-            crate::local_model::runtime_config::StructuralTagReasoningBoundary::Backend => {
-                ReasoningBoundaryV2::External
-            }
+            super::ResolvedReasoningBoundary::StructuralTag => ReasoningBoundaryV2::StructuralTag,
+            super::ResolvedReasoningBoundary::Backend => ReasoningBoundaryV2::External,
         };
 
         self.0.build_with_options(

--- a/lib/llm/src/preprocessor/tool_choice.rs
+++ b/lib/llm/src/preprocessor/tool_choice.rs
@@ -4,11 +4,11 @@
 //! Tool-choice guided decoding policy for OpenAI chat requests.
 
 use crate::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
-use crate::protocols::openai::GuidedToolConstraint;
 use crate::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
 use crate::protocols::openai::tools::{
     ToolChoiceGuidance, get_tool_choice_guidance_from_tools, validate_openai_tool_choice,
 };
+use crate::protocols::openai::{GuidedToolConstraint, validate};
 
 use dynamo_parsers::tool_calling::{ToolChoice, ToolDefinition};
 use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolChoiceOption, ResponseFormat};
@@ -74,6 +74,13 @@ impl OpenAIPreprocessor {
         );
         let has_explicit_guided_decoding = has_explicit_guided_decoding(request);
         let has_response_format_constraint = has_response_format_constraint(request);
+        let structured_output_schema = response_format_json_schema(request);
+
+        validate::validate_response_format_conflicts(
+            &request.inner.response_format,
+            &request.common,
+        )
+        .map_err(|error| invalid_argument(error.to_string()))?;
 
         if is_forced_tool_choice && has_explicit_guided_decoding {
             return Err(invalid_argument(concat!(
@@ -82,11 +89,9 @@ impl OpenAIPreprocessor {
             )));
         }
 
-        // For non-forced tool choice, explicit guided decoding and response_format
-        // constrain assistant content, so tool-choice guided decoding stays inactive.
-        let has_assistant_constraint =
-            has_explicit_guided_decoding || has_response_format_constraint;
-        if !is_forced_tool_choice && has_assistant_constraint {
+        // Explicit guided decoding constrains assistant content and cannot be
+        // composed with structural-tag tool calls.
+        if !is_forced_tool_choice && has_explicit_guided_decoding {
             return Ok(GuidedToolConstraint::None);
         }
 
@@ -103,9 +108,16 @@ impl OpenAIPreprocessor {
             &convert_tools(tools),
             request.inner.parallel_tool_calls,
             prompt_injected_reasoning,
+            structured_output_schema.as_ref(),
             common_request,
         )? {
             return Ok(GuidedToolConstraint::StructuralTag);
+        }
+
+        // If the structural-tag layer did not compose this response format with
+        // auto tool calls, it remains the sole assistant-output constraint.
+        if !is_forced_tool_choice && has_response_format_constraint {
+            return Ok(GuidedToolConstraint::None);
         }
 
         let uses_kimi_k3_parser = uses_kimi_k3_parser(
@@ -176,6 +188,16 @@ fn has_response_format_constraint(request: &NvCreateChatCompletionRequest) -> bo
         .response_format
         .as_ref()
         .is_some_and(|format| !matches!(format, ResponseFormat::Text))
+}
+
+fn response_format_json_schema(
+    request: &NvCreateChatCompletionRequest,
+) -> Option<serde_json::Value> {
+    match request.inner.response_format.as_ref()? {
+        ResponseFormat::Text => None,
+        ResponseFormat::JsonObject => Some(serde_json::json!({"type": "object"})),
+        ResponseFormat::JsonSchema { json_schema } => Some(json_schema.schema.clone()),
+    }
 }
 
 pub(crate) fn convert_tool_choice(tool_choice: &ChatCompletionToolChoiceOption) -> ToolChoice {

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -418,16 +418,11 @@ pub struct ParsingOptions {
     #[serde(default)]
     pub move_reasoning_to_content_when_empty: bool,
 
-    /// The worker's operator-configured structural-tag policy. Carried through so
-    /// the HTTP-layer tool-call-gate reconstruction
-    /// (`http::service::apply_request_tool_call_parsing_options`) can consult the
-    /// same structural-tag contract the real preprocessing path uses, instead of
-    /// only recognizing intrinsically-forced model families.
-    #[serde(default)]
-    pub structural_tag_mode: crate::local_model::runtime_config::StructuralTagMode,
-
-    #[serde(default)]
-    pub structural_tag_scope: crate::local_model::runtime_config::StructuralTagScope,
+    /// The worker's structural-tag policy. Carried through so the HTTP-layer
+    /// tool-call-gate reconstruction consults the same configuration as the
+    /// request preprocessor. Presence enables operator-controlled tags.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub structural_tag: Option<crate::local_model::runtime_config::StructuralTagConfig>,
 
     #[serde(
         default = "crate::local_model::runtime_config::default_exclude_tools_when_tool_choice_none"
@@ -461,8 +456,7 @@ impl ParsingOptions {
             guided_tool_constraint: GuidedToolConstraint::None,
             parallel_tool_calls: None,
             move_reasoning_to_content_when_empty: false,
-            structural_tag_mode: crate::local_model::runtime_config::StructuralTagMode::default(),
-            structural_tag_scope: crate::local_model::runtime_config::StructuralTagScope::default(),
+            structural_tag: None,
             exclude_tools_when_tool_choice_none:
                 crate::local_model::runtime_config::default_exclude_tools_when_tool_choice_none(),
             tools: Vec::new(),

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -616,6 +616,7 @@ impl ValidateRequest for NvCreateChatCompletionRequest {
         // none for audio
         validate::validate_presence_penalty(self.inner.presence_penalty)?;
         validate::validate_response_format(&self.inner.response_format)?;
+        validate::validate_response_format_conflicts(&self.inner.response_format, &self.common)?;
         // none for seed
         validate::validate_service_tier(&self.inner.service_tier)?;
         validate::validate_stop(&self.inner.stop)?;

--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -10,10 +10,12 @@
 //! `JailedStream`: the v2 parser owns incremental
 //! tool-call emission and drops a parameter value truncated at EOF rather than
 //! guessing it. The jail is never built for these families in either path
-//! (`apply_stream` for streaming, `parse_complete` for batch). Other families, and
-//! non-`auto` tool_choice, keep the v1 jail / aggregate-finalize path. The parser is
-//! selected by family name via `dynamo_parsers_v2::create_tool_parser_for_family`, so
-//! adding a family is a one-line change here plus support in that crate.
+//! (`apply_stream` for streaming, `parse_complete` for batch). Other families and
+//! non-`auto` requests without structural tags keep the v1 jail / aggregate-finalize
+//! path. Structural-tag requests emit native markup and use v2 parsing for every
+//! tool choice. The parser is selected by family name via
+//! `dynamo_parsers_v2::create_tool_parser_for_family`, so adding a family is a
+//! one-line change here plus support in that crate.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
@@ -52,6 +54,15 @@ use super::{NvCreateChatCompletionStreamResponse, stream_choice_chunk_from_templ
 /// dynamo's `tool_call_parser` names so a parser name maps straight to a v2 family.
 pub(crate) const V2_FAMILIES: &[&str] = &["qwen3_coder", "deepseek_v4"];
 
+/// Map engine-facing parser aliases onto the family keys used by
+/// `dynamo-parsers-v2`.
+pub(crate) fn canonical_family(family: &str) -> &str {
+    match family {
+        "deepseek-v4" | "deepseekv4" => "deepseek_v4",
+        family => family,
+    }
+}
+
 /// Whether the experimental v2 tool-parser routing is enabled. Read once from
 /// [`DYN_ENABLE_EXPERIMENTAL_PARSERS_V2`](env_llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2) —
 /// env vars are fixed for the process lifetime, so the result is cached.
@@ -63,7 +74,7 @@ pub(crate) fn enabled() -> bool {
 
 /// Whether `family` has a v2 parser and should bypass the v1 jail when [`enabled`].
 pub(crate) fn supports_family(family: &str) -> bool {
-    V2_FAMILIES.contains(&family)
+    V2_FAMILIES.contains(&canonical_family(family))
 }
 
 /// Families served by the v2 UNIFIED parser (reasoning + content + tool calls in
@@ -124,7 +135,7 @@ pub(crate) fn parse_complete(
     family: &str,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, String)> {
     let v2_tools = to_v2_tools(tools);
-    let mut parser = create_tool_parser_for_family(family, &v2_tools)?;
+    let mut parser = create_tool_parser_for_family(canonical_family(family), &v2_tools)?;
     let result = parser.parse_complete(content)?;
 
     let tool_calls = result
@@ -422,6 +433,7 @@ pub(crate) fn apply_stream<S>(
 where
     S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
 {
+    let family = canonical_family(&family).to_string();
     let v2_tools = to_v2_tools(tool_definitions.as_deref());
     stream! {
         // The caller only routes supported families here, but if a parser cannot be
@@ -773,6 +785,14 @@ mod tests {
     const MUSE_REASONING: &str = "<|start|>assistant to=self<|message|>Look it up.<|eom|>";
     const MUSE_TOOL: &str = "<|start|>assistant to=get_weather<|message|><atem:invoke name=\"get_weather\"><atem:parameter name=\"location\">Paris</atem:parameter></atem:invoke><|eom|>";
     const MUSE_ANSWER: &str = "<|start|>assistant to=user<|message|>It's 18C.<|eot|>";
+
+    #[test]
+    fn deepseek_v4_engine_aliases_select_the_v2_family() {
+        for alias in ["deepseek_v4", "deepseek-v4", "deepseekv4"] {
+            assert!(supports_family(alias), "unsupported alias: {alias}");
+            assert_eq!(canonical_family(alias), "deepseek_v4");
+        }
+    }
 
     fn muse_turn() -> String {
         format!("{MUSE_REASONING}{MUSE_TOOL}{MUSE_ANSWER}")

--- a/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
@@ -1685,6 +1685,7 @@ mod tests {
             tool_index,
             name: name.map(str::to_string),
             arguments: arguments.to_string(),
+            complete: true,
         })
     }
 

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -7,7 +7,10 @@ use dynamo_runtime::config::{
     env_is_truthy, environment_names::llm::DYN_IGNORE_OPENAI_FE_UNSUPPORTED_FIELDS,
 };
 
-use super::tools::{ToolChoiceError, validate_openai_tool_choice};
+use super::{
+    common_ext::CommonExt,
+    tools::{ToolChoiceError, validate_openai_tool_choice},
+};
 
 //
 // Hyperparameter Contraints
@@ -221,6 +224,34 @@ pub fn validate_response_format(
             Ok(())
         }
     }
+}
+
+/// Reject multiple independent constraints on assistant output.
+pub fn validate_response_format_conflicts(
+    response_format: &Option<dynamo_protocols::types::ResponseFormat>,
+    common: &CommonExt,
+) -> Result<(), anyhow::Error> {
+    use dynamo_protocols::types::ResponseFormat;
+
+    let has_response_format_constraint = response_format
+        .as_ref()
+        .is_some_and(|format| !matches!(format, ResponseFormat::Text));
+    let has_explicit_guided_decoding = common.guided_json.is_some()
+        || common.guided_regex.is_some()
+        || common
+            .guided_choice
+            .as_ref()
+            .is_some_and(|choices| !choices.is_empty())
+        || common.guided_grammar.is_some();
+
+    if has_response_format_constraint && has_explicit_guided_decoding {
+        anyhow::bail!(
+            "`response_format` cannot be used together with `guided_json`, `guided_regex`, \
+             `guided_choice`, or `guided_grammar`"
+        );
+    }
+
+    Ok(())
 }
 
 /// Validates the temperature parameter
@@ -913,6 +944,61 @@ mod tests {
 
     fn unknown_fields() -> HashMap<String, serde_json::Value> {
         HashMap::from([("experimental_field".to_string(), json!("value"))])
+    }
+
+    fn explicit_guided_decoding_options() -> Vec<CommonExt> {
+        vec![
+            CommonExt {
+                guided_json: Some(json!({"type": "object"})),
+                ..Default::default()
+            },
+            CommonExt {
+                guided_regex: Some("[a-z]+".to_string()),
+                ..Default::default()
+            },
+            CommonExt {
+                guided_choice: Some(vec!["yes".to_string(), "no".to_string()]),
+                ..Default::default()
+            },
+            CommonExt {
+                guided_grammar: Some("root ::= 'yes'".to_string()),
+                ..Default::default()
+            },
+        ]
+    }
+
+    #[test]
+    fn structured_response_format_rejects_explicit_guided_decoding() {
+        let response_format = Some(dynamo_protocols::types::ResponseFormat::JsonObject);
+
+        for common in explicit_guided_decoding_options() {
+            let error = validate_response_format_conflicts(&response_format, &common).unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                "`response_format` cannot be used together with `guided_json`, `guided_regex`, \
+                 `guided_choice`, or `guided_grammar`"
+            );
+        }
+    }
+
+    #[test]
+    fn text_response_format_allows_explicit_guided_decoding() {
+        let response_format = Some(dynamo_protocols::types::ResponseFormat::Text);
+
+        for common in explicit_guided_decoding_options() {
+            validate_response_format_conflicts(&response_format, &common).unwrap();
+        }
+    }
+
+    #[test]
+    fn empty_guided_choice_does_not_conflict_with_response_format() {
+        let response_format = Some(dynamo_protocols::types::ResponseFormat::JsonObject);
+        let common = CommonExt {
+            guided_choice: Some(Vec::new()),
+            ..Default::default()
+        };
+
+        validate_response_format_conflicts(&response_format, &common).unwrap();
     }
 
     #[test]

--- a/tests/frontend/vllm_prepost_worker.py
+++ b/tests/frontend/vllm_prepost_worker.py
@@ -76,9 +76,7 @@ async def main():
     runtime = DistributedRuntime(asyncio.get_running_loop(), "etcd", "tcp")
     endpoint = runtime.endpoint("test.vllm-prepost.generate")
     runtime_config = ModelRuntimeConfig()
-    runtime_config.set_structural_tag_mode("on")
-    runtime_config.set_structural_tag_scope("always")
-    runtime_config.set_structural_tag_schema("strict")
+    runtime_config.set_structural_tag({"scope": "always", "schema": "strict"})
     await register_model(
         ModelInput.Tokens,
         ModelType.Chat,


### PR DESCRIPTION
## Overview:

This PR integrates parsers-v2 structural-tag builders into Dynamo, enabling structural-tag-guided tool calling and optional composition of tool calls with schema-constrained final responses.

It provides the Dynamo-side integration for the builders added in [frontend-crates#189](https://github.com/ai-dynamo/frontend-crates/pull/189). Structural tags were already supported through v1. This PR adds the corresponding v2 path and consolidates configuration into a single CLI option.

## Details:

`--dyn-structural-tag` enables structural tags on the worker. Set `DYN_ENABLE_EXPERIMENTAL_PARSERS_V2=1` in both worker and frontend processes to use the v2 builders. Parser families without a v2 builder continue to use v1 where available.

Structural-tag applicability, request validation, reasoning-boundary resolution, and v1/v2 builder selection are centralized in the Rust preprocessor.

### Configuration

The new `--dyn-structural-tag` option acts as both the feature switch and an optional JSON configuration. It becomes the primary public interface instead of exposing each new structural-tag setting as a separate CLI flag.

```bash
# Enable with defaults
--dyn-structural-tag

# Enable with explicit configuration
--dyn-structural-tag '{
  "scope": "always",
  "schema": "strict",
  "allow_tool_calls_with_structured_output": true,
  "reasoning_boundary": "backend",
  "exclude_special_tokens": false,
  "tool_arguments_any_order": true
}'
```

Every field is optional. The full example above uses non-default settings and requires parsers v2, a supported tool-call parser, and a reasoning parser with the inference engine configured to activate guided decoding after reasoning.

`scope` and `schema` preserve the existing v1 policies:

- `scope`: `auto` (default) or `always`; controls which tool-calling requests receive structural tags.
- `schema`: `auto` (default) or `strict`; enforces argument schemas only for tools marked strict, or for every tool, respectively.

The following options are specific to the v2 builders:

- `allow_tool_calls_with_structured_output` (default: `false`): allows a request with `tool_choice="auto"`, tools, and `response_format` to choose between a tool call and a final response constrained by the response schema. When enabled, this composition applies independently of `scope`.
- `reasoning_boundary`: `auto` (default), `structural_tag`, or `backend`; selects whether the structural tag handles prompt-opened reasoning or the inference engine activates the grammar after reasoning. `auto` follows the backend’s advertised policy. Explicit `backend` requires a reasoning parser and assumes the inference engine is configured accordingly. Explicit `structural_tag` is rejected if it conflicts with the backend’s advertised policy.
- `exclude_special_tokens`: controls model-specific reasoning and tool-call marker exclusions. Omitted or `null` uses the model-family default. The v2 implementation uses string exclusions rather than tokenizer-specific token bans.
- `tool_arguments_any_order` (default: `false`): allows tool arguments to appear in an order different from their declaration. This weakens required-property and duplicate-key validation for tool arguments. Structured-output schemas are unaffected.

### Compatibility

The previous `--dyn-enable-structural-tag`, `--dyn-structural-tag-scope`, and `--dyn-structural-tag-schema` options remain accepted, but are hidden and deprecated.

The new option cannot be combined with legacy scope/schema options or a conflicting legacy enablement setting. Configurations using only the legacy options continue to work.

### Testing

The integration was tested end-to-end with `Qwen/Qwen3.6-35B-A3B-FP8`, `deepseek-ai/DeepSeek-V4-Flash-0731`, and `zai-org/GLM-5.2-FP8`, covering `tool_choice`, parallel tool calls, and tool calls combined with structured output.

## Where should the reviewer start?

Start with `lib/llm/src/preprocessor/structural_tag.rs`, which owns applicability policy, runtime validation, reasoning-boundary resolution, and v1/v2 builder selection.

Then see:

- `lib/llm/src/preprocessor/structural_tag/v2.rs` for the adapter to `dynamo-parsers-v2`;
- `lib/llm/src/local_model/runtime_config.rs` for the typed runtime configuration;
- `components/src/dynamo/common/configuration/groups/runtime_args.py` for the public CLI and legacy compatibility handling;
- `components/src/dynamo/sglang/register.py` for SGLang reasoning-boundary capability publication.

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Structural-tag settings now use one JSON configuration with options for scope, schema, reasoning boundaries, special tokens, structured output, and tool-argument ordering.
  - Added support for parser v2 structural tags, including DeepSeek-V4 aliases and expanded tool-calling/structured-output combinations.
  - Added backend-aware reasoning behavior and improved tool-choice handling.

- **Bug Fixes**
  - Added validation for conflicting response formats and guided-decoding settings.
  - Improved validation and error reporting for malformed structural-tag configurations.

- **Documentation**
  - Updated configuration and structural-tag guides with the unified option and environment-variable support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->