### PR TITLE
fix(profiler): materialize the evaluated Candidate's model, replicas, scheduler limits, and attention-DP mode, not the template's defaults

### DIFF
--- a/components/src/dynamo/profiler/sweeper/renderers/direct/materializer.py
+++ b/components/src/dynamo/profiler/sweeper/renderers/direct/materializer.py
@@ -125,6 +125,11 @@ def materialize_dgd_from_candidate(
             prefix_caching=candidate_config["agg_enable_prefix_caching"],
             component_type=component_type,
         )
+        config = modifier.set_config_model(               # <-- add these 4 lines
+            config,
+            model_name=candidate_config["model_name"],
+            component_type=component_type,
+        )
     except NotImplementedError as exc:
         # e.g. TRT-LLM's set_config_tep_size: confirmed real and reachable --
         # a real Sweeper-produced Candidate (strategy="tep", backend="trtllm")

--- a/components/src/dynamo/profiler/sweeper/renderers/direct/materializer.py
+++ b/components/src/dynamo/profiler/sweeper/renderers/direct/materializer.py
@@ -19,15 +19,50 @@ from dynamo.planner.config.defaults import SubComponentType
 from dynamo.profiler.utils.config import update_image
 from dynamo.profiler.utils.config_modifiers import CONFIG_MODIFIERS
 
-# Candidate.config fields that describe the deployment shape and have a
-# direct, confirmed CONFIG_MODIFIERS destination. Everything else on
-# Candidate.config is evaluation context (see EVALUATION_CONTEXT_FIELDS)
-# and is preserved in `experimental` for renderer comparison.
 _STRATEGY_SETTERS = {
     "tp": "set_config_tp_size",
     "tep": "set_config_tep_size",
     "dep": "set_config_dep_size",
 }
+
+# Candidate.config's key names for one worker's shape/kv-cache/scheduler/
+# replica/attention-dp fields, by deployment mode. Confirmed against
+# aisimulate.sweeper.sample.unroll_sample/_unroll_parallel: agg mode uses a
+# mix of bare keys (tp, replicas, strategy, attention_dp, moe_tp, moe_ep) and
+# "agg_"-prefixed keys (agg_block_size, agg_max_num_seqs, ...) -- NOT a
+# uniform prefix. Disagg mode uses a uniform "{role}_" prefix for every one
+# of these fields instead (prefill_tp, decode_replicas, ...), with role in
+# ("prefill", "decode"). model_name is shared across roles either way.
+_AGG_KEYS = {
+    "strategy": "strategy",
+    "tp": "tp",
+    "moe_tp": "moe_tp",
+    "moe_ep": "moe_ep",
+    "block_size": "agg_block_size",
+    "gpu_memory_utilization": "agg_gpu_memory_utilization",
+    "enable_prefix_caching": "agg_enable_prefix_caching",
+    "max_num_seqs": "agg_max_num_seqs",
+    "max_num_batched_tokens": "agg_max_num_batched_tokens",
+    "replicas": "replicas",
+    "attention_dp": "attention_dp",
+}
+
+
+def _role_keys(role: str) -> dict[str, str]:
+    return {
+        "strategy": f"{role}_strategy",
+        "tp": f"{role}_tp",
+        "moe_tp": f"{role}_moe_tp",
+        "moe_ep": f"{role}_moe_ep",
+        "block_size": f"{role}_block_size",
+        "gpu_memory_utilization": f"{role}_gpu_memory_utilization",
+        "enable_prefix_caching": f"{role}_enable_prefix_caching",
+        "max_num_seqs": f"{role}_max_num_seqs",
+        "max_num_batched_tokens": f"{role}_max_num_batched_tokens",
+        "replicas": f"{role}_replicas",
+        "attention_dp": f"{role}_attention_dp",
+    }
+
 
 # Fields on Candidate.config that describe *what the candidate was evaluated
 # against*, not the deployment itself. Confirmed via a real Pareto search
@@ -60,6 +95,83 @@ class MaterializationResult:
     experimental: dict[str, Any] = field(default_factory=dict)
 
 
+def _materialize_worker(
+    config: dict,
+    modifier: Any,
+    candidate_config: dict[str, Any],
+    keys: dict[str, str],
+    *,
+    backend: str,
+    component_type: SubComponentType,
+    num_gpus_per_node: int,
+) -> dict:
+    """Run the full per-worker setter chain for one role (agg's single
+    worker, or one side of a disagg pair), using ``keys`` to look up that
+    role's field names on ``candidate_config``. Shared by both deployment
+    modes so the chain -- and any future fix to it -- only needs to be
+    correct in one place.
+    """
+    strategy = candidate_config[keys["strategy"]]
+    setter_name = _STRATEGY_SETTERS.get(strategy)
+    if setter_name is None:
+        raise MaterializationError(f"unknown parallelism strategy {strategy!r}")
+    setter = getattr(modifier, setter_name, None)
+    if setter is None:
+        raise MaterializationError(
+            f"{backend} modifier has no {setter_name} implementation"
+        )
+
+    if strategy == "tp":
+        config = setter(config, candidate_config[keys["tp"]], component_type)
+    else:
+        # TEP/DEP setters need the physical node boundary in addition to
+        # the parallel shape carried by the Candidate.
+        tp_or_ep_key = keys["moe_tp"] if strategy == "tep" else keys["moe_ep"]
+        config = setter(
+            config,
+            candidate_config[tp_or_ep_key],
+            num_gpus_per_node=num_gpus_per_node,
+            component_type=component_type,
+        )
+
+    config = modifier.set_config_kv_cache(
+        config,
+        block_size=candidate_config[keys["block_size"]],
+        memory_fraction=candidate_config[keys["gpu_memory_utilization"]],
+        prefix_caching=candidate_config[keys["enable_prefix_caching"]],
+        component_type=component_type,
+    )
+    config = modifier.set_prefill_config(
+        config,
+        max_batch_size=candidate_config[keys["max_num_seqs"]],
+        max_num_tokens=candidate_config[keys["max_num_batched_tokens"]],
+        component_type=component_type,
+    )
+    config = modifier.set_config_model(
+        config,
+        model_name=candidate_config["model_name"],  # shared across roles
+        component_type=component_type,
+    )
+    config = modifier.set_config_replicas(
+        config,
+        replicas=candidate_config[keys["replicas"]],
+        component_type=component_type,
+    )
+    # TRT-LLM-only: neither vLLM nor SGLang's base templates reference the
+    # extra-engine-args file this derives from, so this is not part of the
+    # shared ConfigModifierProtocol -- guard with hasattr rather than a
+    # backend name check, matching how other backend-specific capability
+    # gaps are already handled in this codebase (e.g. set_config_tep_size
+    # raising NotImplementedError for TRT-LLM).
+    if hasattr(modifier, "set_config_attention_dp"):
+        config = modifier.set_config_attention_dp(
+            config,
+            attention_dp=candidate_config.get(keys["attention_dp"], 1),
+            component_type=component_type,
+        )
+    return config
+
+
 def materialize_dgd_from_candidate(
     candidate_config: dict[str, Any],
     *,
@@ -74,6 +186,16 @@ def materialize_dgd_from_candidate(
     concern -- confirmed absent from build_dgd_config and everywhere else in
     this package -- and deliberately not this function's job.
 
+    ``component_type`` only applies to agg mode (it picks which generic
+    worker service load_default_config's template exposes -- matching
+    BaseConfigModifier._resolve_component_name's own agg fallback: "try the
+    standard DECODE lookup, then fall back to any non-Frontend/Planner
+    service"). Disagg mode ignores it: both PREFILL and DECODE are always
+    materialized, using their own role-prefixed fields from
+    candidate_config (confirmed via aisimulate.sweeper.sample.py: a disagg
+    Candidate.config has no bare tp/strategy/replicas/agg_* keys at all --
+    everything is prefill_*/decode_*-prefixed).
+
     Raises MaterializationError for a known, explicit gap (e.g. an
     unsupported strategy/backend combination) rather than letting the
     underlying NotImplementedError/KeyError surface directly, so callers get
@@ -82,7 +204,6 @@ def materialize_dgd_from_candidate(
     """
     backend = candidate_config.get("backend")
     mode = candidate_config.get("deployment_mode")
-    strategy = candidate_config.get("strategy")
 
     modifier = CONFIG_MODIFIERS.get(backend)
     if modifier is None:
@@ -90,71 +211,41 @@ def materialize_dgd_from_candidate(
     if mode not in ("agg", "disagg"):
         raise MaterializationError(f"unsupported deployment_mode {mode!r}")
 
-    setter_name = _STRATEGY_SETTERS.get(strategy)
-    if setter_name is None:
-        raise MaterializationError(f"unknown parallelism strategy {strategy!r}")
-    setter = getattr(modifier, setter_name, None)
-    if setter is None:
-        raise MaterializationError(
-            f"{backend} modifier has no {setter_name} implementation"
-        )
-
     try:
         config = modifier.load_default_config(mode=mode)
         config = update_image(config, image)
 
-        if strategy == "tp":
-            config = setter(config, candidate_config["tp"], component_type)
-        else:
-            # TEP/DEP setters need the physical node boundary in addition to
-            # the parallel shape carried by the Candidate.
-            tp_or_ep_size = candidate_config[
-                "moe_tp" if strategy == "tep" else "moe_ep"
-            ]
-            config = setter(
+        if mode == "agg":
+            config = _materialize_worker(
                 config,
-                tp_or_ep_size,
+                modifier,
+                candidate_config,
+                _AGG_KEYS,
+                backend=backend,
+                component_type=component_type,
                 num_gpus_per_node=num_gpus_per_node,
-                component_type=component_type,
             )
-
-        config = modifier.set_config_kv_cache(
-            config,
-            block_size=candidate_config["agg_block_size"],
-            memory_fraction=candidate_config["agg_gpu_memory_utilization"],
-            prefix_caching=candidate_config["agg_enable_prefix_caching"],
-            component_type=component_type,
-        )
-        config = modifier.set_prefill_config(
-            config,
-            max_batch_size=candidate_config["agg_max_num_seqs"],
-            max_num_tokens=candidate_config["agg_max_num_batched_tokens"],
-            component_type=component_type,
-        )
-        config = modifier.set_config_model(               # <-- add these 4 lines
-            config,
-            model_name=candidate_config["model_name"],
-            component_type=component_type,
-        )
-        config = modifier.set_config_replicas(
-            config,
-            replicas=candidate_config["replicas"],
-            component_type=component_type,
-        )
-        if hasattr(modifier, "set_config_attention_dp"):
-            config = modifier.set_config_attention_dp(
-                config,
-                attention_dp=candidate_config.get("attention_dp", 1),
-                component_type=component_type,
-            )
-        
+        else:  # disagg
+            for role, role_component_type in (
+                ("prefill", SubComponentType.PREFILL),
+                ("decode", SubComponentType.DECODE),
+            ):
+                config = _materialize_worker(
+                    config,
+                    modifier,
+                    candidate_config,
+                    _role_keys(role),
+                    backend=backend,
+                    component_type=role_component_type,
+                    num_gpus_per_node=num_gpus_per_node,
+                )
     except NotImplementedError as exc:
         # e.g. TRT-LLM's set_config_tep_size: confirmed real and reachable --
         # a real Sweeper-produced Candidate (strategy="tep", backend="trtllm")
         # hits exactly this path. This is the DEP's "materialization failure"
         # case, not a bug in this function.
         raise MaterializationError(
-            f"{backend}/{strategy} materialization not supported: {exc}"
+            f"{backend}/{mode} materialization not supported: {exc}"
         ) from exc
     except KeyError as exc:
         raise MaterializationError(

--- a/components/src/dynamo/profiler/sweeper/renderers/direct/materializer.py
+++ b/components/src/dynamo/profiler/sweeper/renderers/direct/materializer.py
@@ -125,11 +125,29 @@ def materialize_dgd_from_candidate(
             prefix_caching=candidate_config["agg_enable_prefix_caching"],
             component_type=component_type,
         )
+        config = modifier.set_prefill_config(
+            config,
+            max_batch_size=candidate_config["agg_max_num_seqs"],
+            max_num_tokens=candidate_config["agg_max_num_batched_tokens"],
+            component_type=component_type,
+        )
         config = modifier.set_config_model(               # <-- add these 4 lines
             config,
             model_name=candidate_config["model_name"],
             component_type=component_type,
         )
+        config = modifier.set_config_replicas(
+            config,
+            replicas=candidate_config["replicas"],
+            component_type=component_type,
+        )
+        if hasattr(modifier, "set_config_attention_dp"):
+            config = modifier.set_config_attention_dp(
+                config,
+                attention_dp=candidate_config.get("attention_dp", 1),
+                component_type=component_type,
+            )
+        
     except NotImplementedError as exc:
         # e.g. TRT-LLM's set_config_tep_size: confirmed real and reachable --
         # a real Sweeper-produced Candidate (strategy="tep", backend="trtllm")

--- a/components/src/dynamo/profiler/tests/unit/sweeper/test_renderer_direct.py
+++ b/components/src/dynamo/profiler/tests/unit/sweeper/test_renderer_direct.py
@@ -91,6 +91,39 @@ def test_tp_strategy_materializes_successfully_on_all_three_backends() -> None:
         assert args, f"no args materialized for {backend}"
 
 
+def test_evaluated_model_is_written_into_the_dgd_not_the_template_placeholder() -> None:
+    """Regression test for a real bug found running a live end-to-end sweep:
+    the sweep evaluated and scored Qwen/Qwen3-8B, but the materialized DGD
+    contained Qwen/Qwen3-0.6B -- the base template's example placeholder --
+    because materialize_dgd_from_candidate never read candidate_config
+    ["model_name"] at all. Checks all three backends, since each uses a
+    different flag name (vLLM: --model; SGLang/TRT-LLM: --model-path) via
+    cls.WORKER_MODEL_PATH_ARG, and the bug could plausibly be fixed for one
+    backend while remaining broken for the others.
+    """
+    for backend in ("vllm", "sglang", "trtllm"):
+        candidate = dict(
+            REAL_CANDIDATE_TEP_TRTLLM,
+            backend=backend,
+            strategy="tp",
+            model_name="Qwen/Qwen3-8B",
+        )
+        result = materialize_dgd_from_candidate(candidate, image=_IMAGE)
+
+        worker = next(
+            c for c in result.dgd["spec"]["components"] if c.get("type") == "worker"
+        )
+        args = worker["podTemplate"]["spec"]["containers"][0]["args"]
+        args_text = " ".join(args)
+
+        assert "Qwen/Qwen3-8B" in args_text, (
+            f"{backend}: evaluated model_name missing from materialized args: {args}"
+        )
+        assert "Qwen3-0.6B" not in args_text, (
+            f"{backend}: template placeholder model leaked into materialized "
+            f"args (the real bug this test guards against): {args}"
+        )
+
 def test_evaluation_context_fields_never_appear_in_the_dgd_spec() -> None:
     """The identity-collision-relevant fields (concurrency, kv_load_ratio,
     ...) must land in `.experimental`, never as a CLI flag in the DGD spec

--- a/components/src/dynamo/profiler/tests/unit/sweeper/test_renderer_direct.py
+++ b/components/src/dynamo/profiler/tests/unit/sweeper/test_renderer_direct.py
@@ -182,3 +182,129 @@ def test_missing_required_field_raises_materialization_error() -> None:
     del candidate["agg_block_size"]
     with pytest.raises(MaterializationError, match="missing required field"):
         materialize_dgd_from_candidate(candidate, image=_IMAGE)
+
+def test_total_gpu_footprint_matches_the_evaluated_candidate_not_just_tp() -> None:
+    """Regression test for a review-reported gap: a real 4-GPU candidate
+    (Llama-3.3-70B FP8 / vLLM / 4xH200, tp=2 x replicas=2) materialized as a
+    2-GPU DGD, because replicas was never propagated from candidate_config
+    into component.replicas -- it silently stayed at the base template's
+    hardcoded `replicas: 1` regardless of the candidate's real replica
+    count. gpus-per-worker (via tp/tep/dep) was already correct; only the
+    replica multiplier was missing, so total footprint (replicas x
+    gpus-per-worker) could be silently wrong even when the per-worker
+    GPU count looked right on its own.
+    """
+    candidate = dict(
+        REAL_CANDIDATE_TEP_TRTLLM,
+        backend="vllm",
+        strategy="tp",
+        tp=2,
+        replicas=2,
+        used_gpus=4,
+        model_name="meta-llama/Llama-3.3-70B-Instruct-FP8",
+    )
+    result = materialize_dgd_from_candidate(candidate, image=_IMAGE)
+
+    worker = next(
+        c for c in result.dgd["spec"]["components"] if c.get("type") == "worker"
+    )
+    replicas = worker["replicas"]
+    gpus_per_worker = int(
+        worker["podTemplate"]["spec"]["containers"][0]["resources"]["limits"][
+            "nvidia.com/gpu"
+        ]
+    )
+
+    assert replicas == 2, f"replicas not propagated from candidate: got {replicas}"
+    assert gpus_per_worker == 2
+    assert replicas * gpus_per_worker == candidate["used_gpus"], (
+        f"materialized total GPU footprint ({replicas} x {gpus_per_worker}) "
+        f"does not match the evaluated candidate's used_gpus "
+        f"({candidate['used_gpus']})"
+    )
+
+def test_scheduler_limits_materialize_the_evaluated_candidates_values() -> None:
+    """Regression test for the most significant gap found in this pass:
+    materialize_dgd_from_candidate never called set_prefill_config on any
+    backend, so agg_max_num_seqs/agg_max_num_batched_tokens -- real search
+    dimensions Sweeper evaluates and scores candidates by -- were never
+    materialized at all. Every DGD silently kept the base template's fixed
+    scheduler defaults regardless of what was actually searched, on every
+    backend, since this materializer's very first version.
+    """
+    for backend in ("vllm", "sglang", "trtllm"):
+        candidate = dict(
+            REAL_CANDIDATE_TEP_TRTLLM,
+            backend=backend,
+            strategy="tp",
+            agg_max_num_seqs=999,
+            agg_max_num_batched_tokens=12345,
+        )
+        result = materialize_dgd_from_candidate(candidate, image=_IMAGE)
+        worker = next(
+            c for c in result.dgd["spec"]["components"] if c.get("type") == "worker"
+        )
+        args_text = " ".join(worker["podTemplate"]["spec"]["containers"][0]["args"])
+        assert "999" in args_text, f"{backend}: agg_max_num_seqs missing: {args_text}"
+        assert "12345" in args_text, (
+            f"{backend}: agg_max_num_batched_tokens missing: {args_text}"
+        )
+
+
+def test_attention_dp_enabled_when_candidate_selected_it_trtllm_only() -> None:
+    """Regression test: examples/backends/trtllm/engine_configs/qwen3/agg.yaml
+    (the extra-engine-args file every TRT-LLM agg deployment references)
+    hardcodes enable_attention_dp: false. Nothing overrode it before this
+    fix -- a candidate genuinely evaluated with attention_dp > 1 would
+    silently materialize with attention-DP off. TRT-LLM-only: vLLM/SGLang
+    don't reference this file, so their modifiers correctly have no
+    set_config_attention_dp at all (checked via hasattr, matching how
+    materializer.py gates the call).
+    """
+    candidate = dict(
+        REAL_CANDIDATE_TEP_TRTLLM, backend="trtllm", strategy="tp", attention_dp=4
+    )
+    result = materialize_dgd_from_candidate(candidate, image=_IMAGE)
+    worker = next(
+        c for c in result.dgd["spec"]["components"] if c.get("type") == "worker"
+    )
+    args = " ".join(worker["podTemplate"]["spec"]["containers"][0]["args"])
+    assert "enable_attention_dp" in args and "true" in args.lower(), args
+
+    from dynamo.profiler.utils.config_modifiers import CONFIG_MODIFIERS
+
+    assert not hasattr(CONFIG_MODIFIERS["vllm"], "set_config_attention_dp")
+    assert not hasattr(CONFIG_MODIFIERS["sglang"], "set_config_attention_dp")
+
+
+def test_attention_dp_left_disabled_when_candidate_did_not_select_it() -> None:
+    candidate = dict(
+        REAL_CANDIDATE_TEP_TRTLLM, backend="trtllm", strategy="tp", attention_dp=1
+    )
+    result = materialize_dgd_from_candidate(candidate, image=_IMAGE)
+    worker = next(
+        c for c in result.dgd["spec"]["components"] if c.get("type") == "worker"
+    )
+    args = " ".join(worker["podTemplate"]["spec"]["containers"][0]["args"])
+    assert "enable_attention_dp" in args and "false" in args.lower(), args
+
+
+def test_cuda_graph_batch_size_mirrors_engine_max_batch_size_trtllm() -> None:
+    """cuda_graph_config.max_batch_size is a separate key from top-level
+    max_batch_size in the base template; confirmed it was never otherwise
+    overridden and stayed fixed at the template's default (16) regardless
+    of the real candidate."""
+    candidate = dict(
+        REAL_CANDIDATE_TEP_TRTLLM,
+        backend="trtllm",
+        strategy="tp",
+        agg_max_num_seqs=777,
+    )
+    result = materialize_dgd_from_candidate(candidate, image=_IMAGE)
+    worker = next(
+        c for c in result.dgd["spec"]["components"] if c.get("type") == "worker"
+    )
+    args = worker["podTemplate"]["spec"]["containers"][0]["args"]
+    args_text = " ".join(args)
+    assert "cuda_graph_config.max_batch_size" in args_text
+    assert "777" in args_text

--- a/components/src/dynamo/profiler/tests/unit/sweeper/test_renderer_direct.py
+++ b/components/src/dynamo/profiler/tests/unit/sweeper/test_renderer_direct.py
@@ -63,6 +63,51 @@ REAL_CANDIDATE_TEP_TRTLLM = {
 
 _IMAGE = "my-registry/tensorrtllm-runtime:1.3.0rc10"
 
+# Built directly from the confirmed field-naming rules in
+# aisimulate.sweeper.sample.py's unroll_sample/_unroll_parallel: disagg mode
+# has NO bare tp/strategy/replicas/agg_* keys at all -- every shape/kv-cache
+# /scheduler/replica/attention-dp field is uniformly "{role}_"-prefixed
+# ("prefill_"/"decode_"), unlike agg's bare-vs-"agg_"-prefixed mix.
+# model_name/backend/deployment_mode/hardware_sku/gpu_budget are shared,
+# not role-prefixed, matching _DEPLOYMENT_PINNED.
+REAL_SHAPED_DISAGG_CANDIDATE = {
+    "deployment_mode": "disagg",
+    "backend": "vllm",
+    "model_name": "deepseek-ai/DeepSeek-V3",
+    "hardware_sku": "gb200",
+    "gpu_budget": 32,
+    "min_gpu_budget": None,
+    "context_length": None,
+    "startup_time": None,
+    "aic_nextn": None,
+    "prefill_tp": 2,
+    "prefill_pp": 1,
+    "prefill_attention_dp": 1,
+    "prefill_moe_tp": 1,
+    "prefill_moe_ep": 1,
+    "prefill_strategy": "tp",
+    "prefill_replicas": 2,
+    "prefill_max_num_batched_tokens": 16384,
+    "prefill_max_num_seqs": 4,
+    "prefill_block_size": 64,
+    "prefill_gpu_memory_utilization": 0.9,
+    "prefill_enable_prefix_caching": True,
+    "decode_tp": 4,
+    "decode_pp": 1,
+    "decode_attention_dp": 1,
+    "decode_moe_tp": 1,
+    "decode_moe_ep": 4,
+    "decode_strategy": "tep",
+    "decode_replicas": 1,
+    "decode_max_num_batched_tokens": 8192,
+    "decode_max_num_seqs": 512,
+    "decode_block_size": 64,
+    "decode_gpu_memory_utilization": 0.85,
+    "decode_enable_prefix_caching": False,
+    "used_gpus": 8,
+    "backend_version": "0.24.0",
+    "concurrency": 128,
+}
 
 def test_real_candidate_strategy_tep_on_trtllm_raises_materialization_error() -> None:
     """Confirms a real gap, not a hypothetical one.
@@ -308,3 +353,69 @@ def test_cuda_graph_batch_size_mirrors_engine_max_batch_size_trtllm() -> None:
     args_text = " ".join(args)
     assert "cuda_graph_config.max_batch_size" in args_text
     assert "777" in args_text
+
+def test_disagg_materializes_both_prefill_and_decode_with_their_own_shapes() -> None:
+    """The core disagg test: prefill and decode must each get their own
+    tp/kv-cache/scheduler/replicas from their own {role}_-prefixed fields --
+    not share one shape, and not silently fall back to agg's bare/agg_*
+    keys (which don't exist on a real disagg Candidate.config at all)."""
+    result = materialize_dgd_from_candidate(
+        REAL_SHAPED_DISAGG_CANDIDATE, image=_IMAGE
+    )
+    components = {
+        c["type"]: c
+        for c in result.dgd["spec"]["components"]
+        if c.get("type") in ("prefill", "decode")
+    }
+    assert set(components) == {"prefill", "decode"}
+
+    prefill_args = " ".join(
+        components["prefill"]["podTemplate"]["spec"]["containers"][0]["args"]
+    )
+    decode_args = " ".join(
+        components["decode"]["podTemplate"]["spec"]["containers"][0]["args"]
+    )
+
+    # Prefill: tp=2, replicas=2, max_num_seqs=4, deepseek-ai/DeepSeek-V3
+    assert "--tensor-parallel-size 2" in prefill_args
+    assert components["prefill"]["replicas"] == 2
+    assert "deepseek-ai/DeepSeek-V3" in prefill_args
+
+    # Decode: tep strategy (moe_tp=1), replicas=1, distinct from prefill
+    assert components["decode"]["replicas"] == 1
+    assert "deepseek-ai/DeepSeek-V3" in decode_args
+
+    # The two roles must not have collapsed onto identical materialized args
+    # -- this is the actual failure mode a broken/incomplete disagg
+    # implementation could produce (e.g. accidentally reusing agg's single-
+    # pass logic for both roles).
+    assert prefill_args != decode_args
+
+
+def test_disagg_prefix_caching_differs_correctly_by_role() -> None:
+    """prefill_enable_prefix_caching=True, decode_enable_prefix_caching=False
+    on the fixture -- must materialize differently per role, not share one
+    value (a plausible copy-paste bug: reading only one role's field for
+    both)."""
+    result = materialize_dgd_from_candidate(
+        REAL_SHAPED_DISAGG_CANDIDATE, image=_IMAGE
+    )
+    components = {
+        c["type"]: c
+        for c in result.dgd["spec"]["components"]
+        if c.get("type") in ("prefill", "decode")
+    }
+    prefill_args = components["prefill"]["podTemplate"]["spec"]["containers"][0]["args"]
+    decode_args = components["decode"]["podTemplate"]["spec"]["containers"][0]["args"]
+
+    assert "--enable-prefix-caching" in prefill_args
+    assert "--no-enable-prefix-caching" in decode_args
+
+
+def test_disagg_missing_role_field_raises_materialization_error() -> None:
+    """Confirms disagg reads {role}_-prefixed keys for real -- deleting one
+    must fail, not silently fall back to agg's differently-named field."""
+    candidate = dict(REAL_SHAPED_DISAGG_CANDIDATE)
+    del candidate["decode_max_num_seqs"]
+    with pytest.raises(MaterializationError, match="decode_max_num_seqs"):
+        materialize_dgd_from_candidate(candidate, image=_IMAGE)

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -822,3 +822,40 @@ class BaseConfigModifier:
             agg_gpus,
             num_gpus_per_node=num_gpus_per_node,
         )
+
+    @classmethod
+    def set_config_replicas(
+        cls,
+        config: dict,
+        replicas: int,
+        component_type: SubComponentType = SubComponentType.DECODE,
+    ) -> dict:
+        """Apply the evaluated Candidate's replica count to the worker component.
+
+        Backend-agnostic (component.replicas is a plain Kubernetes field, no
+        CLI flag involved), unlike set_config_model/set_config_kv_cache, so
+        this lives once here rather than duplicated per backend. Mirrors the
+        one relevant line of _apply_worker_config (component.replicas =
+        replicas) without touching CLI args or GPU resources, since those
+        are already set by set_config_tp_size/tep/dep separately.
+
+        Without this call, a candidate's total materialized GPU footprint
+        (replicas x gpus-per-worker) silently diverges from what was
+        actually evaluated: setup_worker_component_resources correctly sets
+        gpus-per-worker via the tp/tep/dep setters, but replicas is left at
+        whatever the base template hardcodes (confirmed: replicas: 1 in
+        every agg.yaml template), regardless of the candidate's real
+        replicas value. Confirmed in review: a real 4-GPU candidate
+        (tp=2, replicas=2) materialized as a 2-GPU DGD (tp=2, replicas=1).
+        """
+        cfg = Config.model_validate(config)
+        component_name = cls._resolve_component_name(cfg, component_type)
+        component = (
+            get_component_by_name(cfg, component_name) if component_name else None
+        )
+        if component is None:
+            raise ValueError(
+                f"could not find worker component for {component_type} to set replicas"
+            )
+        component.replicas = replicas
+        return cfg.model_dump()

--- a/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
@@ -494,3 +494,29 @@ class SGLangConfigModifier(BaseConfigModifier):
 
         get_main_container(worker_service).args = args
         return cfg.model_dump()
+
+    @classmethod
+    def set_config_model(
+        cls,
+        config: dict,
+        model_name: str,
+        component_type: SubComponentType = SubComponentType.DECODE,
+    ) -> dict:
+        """Apply the evaluated Candidate's model to the worker's CLI args.
+
+        See VllmV1ConfigModifier.set_config_model for why this call exists:
+        without it, the base template's placeholder model name survives
+        untouched into the materialized DGD.
+        """
+        cfg = Config.model_validate(config)
+        worker_service = get_worker_component_from_config(
+            cfg, backend="sglang", sub_component_type=component_type
+        )
+        args = validate_and_get_worker_args(worker_service, backend="sglang")
+        args = break_arguments(args)
+
+        args = set_argument_value(args, cls.WORKER_MODEL_PATH_ARG, model_name)
+        args = set_argument_value(args, cls.WORKER_SERVED_MODEL_NAME_ARG, model_name)
+
+        get_main_container(worker_service).args = args
+        return cfg.model_dump()

--- a/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
@@ -19,6 +19,7 @@ from dynamo.profiler.utils.config import (
     get_worker_component_from_config,
     parse_override_engine_args,
     remove_valued_arguments,
+    set_argument_value,
     setup_worker_component_resources,
     update_image,
     validate_and_get_worker_args,
@@ -590,6 +591,35 @@ class TrtllmConfigModifier(BaseConfigModifier):
                 "kv_cache_config.enable_block_reuse": bool(prefix_caching),
             },
         )
+
+        get_main_container(worker_service).args = args
+        return cfg.model_dump()
+
+    @classmethod
+    def set_config_model(
+        cls,
+        config: dict,
+        model_name: str,
+        component_type: SubComponentType = SubComponentType.DECODE,
+    ) -> dict:
+        """Apply the evaluated Candidate's model to the worker's CLI args.
+
+        --model-path / --served-model-name are plain CLI flags in TRT-LLM's
+        base template (confirmed: unlike kv_cache_config.*, they are not
+        routed through _merge_overrides_into_args' dotted-key/engine-args
+        mechanism), so set_argument_value applies directly here, same as
+        vLLM/SGLang. See VllmV1ConfigModifier.set_config_model for why this
+        call exists at all.
+        """
+        cfg = Config.model_validate(config)
+        worker_service = get_worker_component_from_config(
+            cfg, backend="trtllm", sub_component_type=component_type
+        )
+        args = validate_and_get_worker_args(worker_service, backend="trtllm")
+        args = break_arguments(args)
+
+        args = set_argument_value(args, cls.WORKER_MODEL_PATH_ARG, model_name)
+        args = set_argument_value(args, cls.WORKER_SERVED_MODEL_NAME_ARG, model_name)
 
         get_main_container(worker_service).args = args
         return cfg.model_dump()

--- a/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
@@ -550,6 +550,12 @@ class TrtllmConfigModifier(BaseConfigModifier):
             {
                 "max_batch_size": int(max_batch_size),
                 "max_num_tokens": int(max_num_tokens),
+                # Mirror engine max_batch_size onto CUDA graph capture size.
+                # cuda_graph_config.max_batch_size is a *separate* key from
+                # top-level max_batch_size in the base template; confirmed
+                # it was never otherwise overridden and stayed fixed at the
+                # template's default (16) regardless of the real candidate.
+                "cuda_graph_config.max_batch_size": int(max_batch_size),
             },
         )
 
@@ -595,6 +601,48 @@ class TrtllmConfigModifier(BaseConfigModifier):
         get_main_container(worker_service).args = args
         return cfg.model_dump()
 
+    @classmethod
+    def set_config_attention_dp(
+        cls,
+        config: dict,
+        attention_dp: int,
+        component_type: SubComponentType = SubComponentType.DECODE,
+    ) -> dict:
+        """Apply the evaluated Candidate's attention-DP mode.
+
+        TRT-LLM-only: neither vLLM nor SGLang's base templates reference
+        the extra-engine-args file this derives from, so this method is not
+        part of the shared ConfigModifierProtocol.
+
+        Confirmed against a real production config (deepseek-v32-fp4/trtllm
+        /agg-round-robin/deploy.yaml): enable_attention_dp needs no separate
+        DP-degree field -- TRT-LLM implicitly uses tensor_parallel_size as
+        the DP degree once this flag is set. So the only thing to derive is
+        the boolean itself: attention_dp > 1 means the candidate's search
+        selected data-parallel attention over the same tp_size.
+
+        Without this call, the base template's `enable_attention_dp: false`
+        default (from examples/backends/trtllm/engine_configs/qwen3/agg.yaml)
+        is never overridden -- a winning candidate evaluated with
+        attention_dp > 1 would silently materialize with attention-DP
+        disabled, deploying a structurally different configuration than the
+        one actually searched and scored.
+        """
+        cfg = Config.model_validate(config)
+        worker_service = get_worker_component_from_config(
+            cfg, backend="trtllm", sub_component_type=component_type
+        )
+        args = validate_and_get_worker_args(worker_service, backend="trtllm")
+        args = break_arguments(args)
+
+        args = _merge_overrides_into_args(
+            args,
+            {"enable_attention_dp": bool(attention_dp and attention_dp > 1)},
+        )
+
+        get_main_container(worker_service).args = args
+        return cfg.model_dump()
+        
     @classmethod
     def set_config_model(
         cls,

--- a/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
@@ -695,3 +695,34 @@ class VllmV1ConfigModifier(BaseConfigModifier):
 
         get_main_container(worker_service).args = args
         return cfg.model_dump()
+
+    @classmethod
+    def set_config_model(
+        cls,
+        config: dict,
+        model_name: str,
+        component_type: SubComponentType = SubComponentType.DECODE,
+    ) -> dict:
+        """Apply the evaluated Candidate's model to the worker's CLI args.
+
+        Uses cls.WORKER_MODEL_PATH_ARG / cls.WORKER_SERVED_MODEL_NAME_ARG so
+        the correct per-backend flag name is picked automatically (vLLM
+        overrides WORKER_MODEL_PATH_ARG to "--model"; other backends use
+        "--model-path"). Without this call, the base template's placeholder
+        model name survives untouched into the materialized DGD -- confirmed
+        via a real end-to-end sweep where the evaluated/scored model
+        (Qwen/Qwen3-8B) did not match the model written into the output DGD
+        (the template's example placeholder, Qwen/Qwen3-0.6B).
+        """
+        cfg = Config.model_validate(config)
+        worker_service = get_worker_component_from_config(
+            cfg, backend="vllm", sub_component_type=component_type
+        )
+        args = validate_and_get_worker_args(worker_service, backend="vllm")
+        args = break_arguments(args)
+
+        args = set_argument_value(args, cls.WORKER_MODEL_PATH_ARG, model_name)
+        args = set_argument_value(args, cls.WORKER_SERVED_MODEL_NAME_ARG, model_name)
+
+        get_main_container(worker_service).args = args
+        return cfg.model_dump()


### PR DESCRIPTION
## Summary

`dynamo.profiler.sweeper --renderer direct` silently deployed DGDs that didn't match what Sweeper actually searched and scored, and couldn't materialize disagg candidates at all. Same root cause throughout: `materialize_dgd_from_candidate` never called several setters (some new, some pre-existing but unused) with the right per-candidate data. Silent correctness bugs, not crashes — the CLI reports success and writes a DGD that looks valid. Three commits.

## What was broken, and the fix, per field

| Field | Root cause | Fix |
|---|---|---|
| **Model name** (commit 1) | `model_name` never read; every worker kept the template's placeholder (`Qwen/Qwen3-0.6B`) regardless of what was searched. `build_dgd_config` — this materializer's own reference implementation — already had the correct logic (`WORKER_MODEL_PATH_ARG`/`WORKER_SERVED_MODEL_NAME_ARG`, per-backend); it just wasn't called. | New `set_config_model` on all three backends, reusing those existing constants. `trtllm.py` also needed the missing `set_argument_value` import added. |
| **Replicas** (commit 2, found in review) | `component.replicas` never set; stayed at template default (`1`). Total GPUs = `replicas x gpus-per-worker`, so e.g. `tp=2, replicas=2` (4 GPUs) materialized as 2 GPUs. Real case: Llama-3.3-70B FP8/vLLM/4×H200 materialized as 2 GPUs, not 4. | New `set_config_replicas`, shared once in `protocol.py` (no backend-specific flag involved, unlike model/kv-cache). |
| **Scheduler limits** (commit 2, largest gap) | `set_prefill_config` — an existing method — was never called by this function at all, on any backend, since its first version. `agg_max_num_seqs`/`agg_max_num_batched_tokens` never materialized; every DGD kept fixed template defaults regardless of what Sweeper actually searched. | One new call to the existing `set_prefill_config`. No new method needed. |
| **Attention-DP** (commit 2, TRT-LLM only) | TRT-LLM's `qwen3/agg.yaml` engine-args file hardcodes `enable_attention_dp: false`, never overridden. Confirmed most of that file's other defaults *are* correctly overridden by existing `--trtllm.*` flags — this was the one real exception. A candidate with `attention_dp > 1` would silently deploy with DP off. | New `set_config_attention_dp`, TRT-LLM-only (confirmed against a real prod config: no separate DP-degree field needed, just `attention_dp > 1`). Gated via `hasattr()` in the materializer. |
| **CUDA graph batch size** (commit 2, TRT-LLM only) | `cuda_graph_config.max_batch_size` is a separate key from top-level `max_batch_size`, never mirrored — stayed at template default (`16`). | Added to the same override call `set_prefill_config` already makes, so both stay in sync by construction. |
| **Disagg mode** (commit 3) | Not a field-mapping gap — `deployment_mode="disagg"` wasn't materializable at all. Every disagg candidate failed immediately (`unknown parallelism strategy None`), because disagg `Candidate.config` uses `prefill_*`/`decode_*`-prefixed fields exclusively (confirmed against `aisimulate.sweeper.sample.py`) — none of the bare/`agg_*` keys this function read. `CONFIG_MODIFIERS` already supported `component_type=PREFILL/DECODE`; this function just never called the chain twice. | Refactored the whole per-worker setter chain into a shared `_materialize_worker`, parameterized by a `keys` dict — one fixed mapping for agg (bare + `agg_`-prefixed, matching prior behavior exactly), one generated per-role for disagg (`{role}_`-prefixed uniformly). Disagg now runs the same chain twice, once per role. |
