### PR TITLE
ci: move GitHub Actions off end-of-life Node runtimes

### DIFF
--- a/.github/actions/build-deploy-component/action.yml
+++ b/.github/actions/build-deploy-component/action.yml
@@ -462,7 +462,7 @@ runs:
 
     - name: Upload compliance artifact (NOTICES + CSV + CycloneDX)
       if: ${{ steps.settings.outputs.run_compliance == 'true' && always() }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         # compliance-<git-sha>-<component> (artifact_tag falls back to image_tag,
         # which is already <github.sha>-<component>), matching the framework
@@ -474,7 +474,7 @@ runs:
 
     - name: Upload /sources/ archive (opt-in via archive_sources)
       if: ${{ steps.settings.outputs.run_compliance == 'true' && inputs.archive_sources == 'true' }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: compliance-${{ inputs.artifact_tag != '' && inputs.artifact_tag || inputs.image_tag }}-sources
         path: /tmp/sources/

--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -129,7 +129,7 @@ runs:
         fi
 
     - name: Check for changes
-      uses: tj-actions/changed-files@aa08304bd477b800d468db44fe10f6c61f7f7b11  # v42.1.0
+      uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
       id: filter
       with:
         files_yaml_from_source_file: .github/filters.yaml

--- a/.github/actions/check-deploy-component/action.yml
+++ b/.github/actions/check-deploy-component/action.yml
@@ -38,13 +38,13 @@ runs:
 
     - name: Set up Go
       if: ${{ inputs.component == 'operator' }}
-      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
       with:
         go-version: '1.26.6'
 
     - name: Set up Python
       if: ${{ inputs.component == 'operator' }}
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: "3.11"
 

--- a/.github/actions/compliance-extract/action.yml
+++ b/.github/actions/compliance-extract/action.yml
@@ -401,7 +401,7 @@ runs:
 
     - name: Upload compliance artifact (NOTICES + CSV + CycloneDX)
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         # compliance-<git-sha>-<container>. artifact_name_prefix == target_tag_plain
         # == the container name (e.g. vllm-runtime, vllm-runtime-efa, dynamo-planner);
@@ -413,7 +413,7 @@ runs:
 
     - name: Upload /sources/ tarball (post-merge / RC / release only)
       if: ${{ inputs.archive_sources == 'true' && always() }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: compliance-${{ inputs.git_sha }}-${{ inputs.artifact_name_prefix }}-sources
         path: /tmp/sources/sources.zip

--- a/.github/actions/compliance-scan/action.yml
+++ b/.github/actions/compliance-scan/action.yml
@@ -43,7 +43,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: '3.12'
         pip-install: pyyaml
@@ -127,7 +127,7 @@ runs:
 
     - name: Upload attribution artifacts
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: ${{ inputs.artifact_name }}
         path: ${{ inputs.artifact_name }}*.csv

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -47,7 +47,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
       with:
         driver: docker-container
         # Enable BuildKit for enhanced metadata
@@ -59,7 +59,7 @@ runs:
       run: |
         docker system prune -af
     - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: '3.12'
         pip-install: jinja2 pyyaml
@@ -358,7 +358,7 @@ runs:
 
     # Upload comprehensive build metrics as artifact
     - name: Upload Comprehensive Build Metrics
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always()
       with:
         name: build-metrics-${{ inputs.framework }}-${{ inputs.target }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}

--- a/.github/actions/docker-remote-build/action.yml
+++ b/.github/actions/docker-remote-build/action.yml
@@ -338,7 +338,7 @@ runs:
 
     # Upload comprehensive build metrics as artifact
     - name: Upload Comprehensive Build Metrics
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always()
       with:
         name: build-metrics-${{ inputs.framework }}-${{ inputs.target }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}

--- a/.github/actions/dynamo-deploy-test/action.yml
+++ b/.github/actions/dynamo-deploy-test/action.yml
@@ -85,7 +85,7 @@ runs:
         kubectl config get-contexts
 
     - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: '3.12'
         cache: 'pip'
@@ -208,7 +208,7 @@ runs:
         echo "name=${TEST_NAME}" >> $GITHUB_OUTPUT
 
     - name: Upload Test Results
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always()
       with:
         name: test-results-${{ steps.test-name.outputs.name }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
@@ -216,7 +216,7 @@ runs:
         retention-days: 7
 
     - name: Upload Pod Logs
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always()
       with:
         name: pod-logs-${{ steps.test-name.outputs.name }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
@@ -225,7 +225,7 @@ runs:
         retention-days: 7
 
     - name: Upload Allure Results
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always()
       with:
         name: allure-results-${{ steps.test-name.outputs.name }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -374,7 +374,7 @@ runs:
         docker rm -f dynamo-minio-test 2>/dev/null || true
 
     - name: Upload Test Results
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always()  # Always upload test results, even if tests failed
       with:
         name: test-results-${{ inputs.test_suite_name }}-${{ env.STR_TEST_TYPE }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}
@@ -382,7 +382,7 @@ runs:
         retention-days: 7
 
     - name: Upload Coverage Data
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always() && inputs.enable_coverage == 'true'
       with:
         name: coverage-python-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}
@@ -391,7 +391,7 @@ runs:
         retention-days: 7
 
     - name: Upload Allure Results
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always()
       with:
         name: allure-results-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/auto-dep-upgrade-complete.yml
+++ b/.github/workflows/auto-dep-upgrade-complete.yml
@@ -87,7 +87,7 @@ jobs:
           echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
 
       - name: Slack notification
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
           webhook: ${{ secrets.SLACK_NOTIFY_NIGHTLY_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/auto-dep-upgrade-trigger.yml
+++ b/.github/workflows/auto-dep-upgrade-trigger.yml
@@ -35,7 +35,7 @@ jobs:
           token: ${{ secrets.OPS_BOT_PAT }}
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -23,11 +23,11 @@ jobs:
   codeowners:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
       - run: pip install pyyaml pytest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,13 +22,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@42947a340483f03ba47bb1a039b2c519aab3df85  # v3.37.8
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
         with:
             languages: ${{matrix.language}}
             queries: +security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@42947a340483f03ba47bb1a039b2c519aab3df85  # v3.37.8
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
         with:
             category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/community-events-refresh.yml
+++ b/.github/workflows/community-events-refresh.yml
@@ -72,7 +72,7 @@ jobs:
           token: ${{ secrets.OPS_BOT_PAT }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '22'
 

--- a/.github/workflows/compliance-base-drift.yml
+++ b/.github/workflows/compliance-base-drift.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/dco_comment.yml
+++ b/.github/workflows/dco_comment.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Get DCO status
         id: dco
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -29,7 +29,7 @@ jobs:
 
       - name: Comment if DCO failed (deduped)
         if: steps.dco.outputs.conclusion == 'failure'
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9  # v5.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -132,7 +132,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Python for API reference generation
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.13'
 
@@ -159,7 +159,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '22'
 
@@ -745,7 +745,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Python for API reference generation
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.13'
 
@@ -1024,7 +1024,7 @@ jobs:
           yq '.versions' "$DOCS_FILE"
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '22'
 

--- a/.github/workflows/generate-allure-report.yml
+++ b/.github/workflows/generate-allure-report.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Download Allure Results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           run-id: ${{ inputs.run_id }}
           pattern: allure-results-*

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  # v5.0.0
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13  # v7.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Validate PR title and add label
     runs-on: ubuntu-latest
     steps:
-      - uses: ytanikin/pr-conventional-commits@b628c5a234cc32513014b7bfdd1e47b532124d98  # v1.3.0
+      - uses: ytanikin/pr-conventional-commits@639145d78959c53c43112365837e3abd21ed67c1  # v1.5.2
         with:
           task_types: '["feat", "fix", "docs", "test", "ci", "refactor", "perf", "chore", "revert", "style", "build"]'
           add_label: 'true'

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -1149,7 +1149,7 @@ jobs:
         export PATH="$PATH:$HOME/.local/bin"
         protoc --version
     - name: Cache cargo artifacts
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
       with:
         path: |
           ~/.cargo/bin/
@@ -1178,7 +1178,7 @@ jobs:
         SAFE_DIR=$(echo "${{ matrix.dir }}" | sed 's|^\.$|root|' | tr '/' '-')
         echo "RUST_COV_ARTIFACT_NAME=coverage-rust-${SAFE_DIR}-${{ github.run_id }}" >> $GITHUB_ENV
     - name: Upload Rust Coverage Data
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always()
       with:
         name: ${{ env.RUST_COV_ARTIFACT_NAME }}
@@ -1263,7 +1263,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
 
@@ -1274,14 +1274,14 @@ jobs:
           echo "✅ Coverage tools installed"
 
       - name: Download All Python Coverage Artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: coverage-python-*
           path: coverage-artifacts/
           merge-multiple: false
 
       - name: Download All Rust Coverage Artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         continue-on-error: true
         with:
           pattern: coverage-rust-*
@@ -1439,7 +1439,7 @@ jobs:
         run: cat coverage-summary.md >> $GITHUB_STEP_SUMMARY
 
       - name: Upload Coverage Reports
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: coverage-reports-${{ github.run_id }}

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -85,7 +85,7 @@ jobs:
           fi
       - name: Notify Slack
         if: steps.failed-jobs.outputs.has_failures == 'true'
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
           webhook: ${{ secrets.SLACK_NOTIFY_NIGHTLY_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/pr-xpu.yaml
+++ b/.github/workflows/pr-xpu.yaml
@@ -56,7 +56,7 @@ jobs:
       sglang: ${{ steps.changes.outputs.sglang }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Check for changes

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -697,7 +697,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: deploy/operator/go.mod
           cache-dependency-path: deploy/operator/go.sum

--- a/.github/workflows/pr_full_ci_reminder.yaml
+++ b/.github/workflows/pr_full_ci_reminder.yaml
@@ -47,7 +47,7 @@ jobs:
           fi
       - name: Reminder to run full CI on PR
         if: steps.contributor_check.outputs.is_trusted != 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           REPOSITORY: ${{ github.repository }}
           CONTRIBUTOR: ${{ github.actor }}
@@ -66,7 +66,7 @@ jobs:
                 '🚀'
             })
       - name: Add contribution labels to PR
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           IS_TRUSTED: ${{ steps.contributor_check.outputs.is_trusted }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -62,7 +62,7 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
       timeout-minutes: 3
 
@@ -76,7 +76,7 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: '3.13'
     - name: Install recipe check dependencies
@@ -105,7 +105,7 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: '3.13'
     - name: Install API docs test dependencies
@@ -181,10 +181,10 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
       with:
         node-version: '22'
-    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: '3.13'
     - name: Generate API reference pages
@@ -202,7 +202,7 @@ jobs:
       run: fern check
     - name: Cache the npm store for esbuild
       if: needs.changed-files.outputs.fern_components == 'true'
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
       with:
         path: ~/.npm
         # Keyed on the pinned version, so bumping esbuild misses the cache
@@ -274,7 +274,7 @@ jobs:
     # docs-website and runs fern check on the composed result.
     - name: Fetch docs-website
       run: git fetch --no-tags --depth=1 origin docs-website:refs/remotes/origin/docs-website
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
       with:
         node-version: '22'
     - name: Install Fern CLI
@@ -287,7 +287,7 @@ jobs:
         wget -qO "$RUNNER_TEMP/bin/yq" https://github.com/mikefarah/yq/releases/download/v4.52.5/yq_linux_amd64
         chmod +x "$RUNNER_TEMP/bin/yq"
         echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
-    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: '3.13'
     - name: Install replay dependencies
@@ -311,10 +311,10 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
       with:
         node-version: '22'
-    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: '3.13'
     - name: Generate API reference pages
@@ -341,7 +341,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 0  # clustertest derives its alpha version from v1.3.0
-    - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
+    - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
     - name: Run operator checks
       uses: $/.github/actions/check-deploy-component
       with:
@@ -378,7 +378,7 @@ jobs:
         export PATH="$PATH:$HOME/.local/bin"
         protoc --version
     - name: Cache cargo artifacts
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
       with:
         path: |
           ~/.cargo/bin/
@@ -475,7 +475,7 @@ jobs:
         export PATH="$PATH:$HOME/.local/bin"
         protoc --version
     - name: Cache cargo artifacts
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
       with:
         path: |
           ~/.cargo/bin/

--- a/.github/workflows/shared-compliance-audit.yml
+++ b/.github/workflows/shared-compliance-audit.yml
@@ -120,7 +120,7 @@ jobs:
             echo "baseline=" >> "$GITHUB_OUTPUT"
           fi
       - name: Download build compliance artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: ${{ steps.resolve.outputs.artifact }}
           path: /tmp/compliance
@@ -161,7 +161,7 @@ jobs:
             --report /tmp/audit-report.txt -v
       - name: Upload audit report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           # compliance-audit-<git-sha>-<container>[-cudaN] (image_tag already carries all three).
           name: compliance-audit-${{ steps.resolve.outputs.image_tag }}

--- a/.github/workflows/stale_cleaner.yml
+++ b/.github/workflows/stale_cleaner.yml
@@ -25,7 +25,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93  # v11.0.0
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days. As a reminder, please use backlog label to avoid issues being marked as stale.'
           close-issue-message: 'This issue has been closed due to inactivity. If you believe this issue is still relevant, please feel free to reopen it with additional context or information.'

--- a/.github/workflows/test_report.yaml
+++ b/.github/workflows/test_report.yaml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Download and Extract Artifacts
-        uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc  # v8
+        uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7  # v24
         with:
            run_id: ${{ github.event.workflow_run.id }}
            path: artifacts
@@ -97,7 +97,7 @@ jobs:
       - name: Complete report test status
         if: always()
         id: report_test_status
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -52,12 +52,12 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Detect source code changes
       id: src_changes
-      uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad  # v3.0.4
+      uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
       with:
         filters: .github/filters.yaml
     - name: Check if Validation Workflow has run
       id: check_workflow
-      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410  # v6.4.1
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/xpu-ci.yaml
+++ b/.github/workflows/xpu-ci.yaml
@@ -66,7 +66,7 @@ jobs:
     runs-on: xpu
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.SOURCE_REF }}
           lfs: true
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload build log
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: xpu-build-log
           path: |
@@ -149,7 +149,7 @@ jobs:
       TEST_IMAGE_TAG: dynamo-${{ inputs.framework || 'vllm' }}-${{ inputs.target || 'runtime' }}-xpu:${{ github.run_id }}-${{ inputs.source_ref || github.sha }}-test
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.SOURCE_REF }}
           lfs: true
@@ -212,7 +212,7 @@ jobs:
       TEST_IMAGE_TAG: dynamo-${{ inputs.framework || 'vllm' }}-${{ inputs.target || 'runtime' }}-xpu:${{ github.run_id }}-${{ inputs.source_ref || github.sha }}-test
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.SOURCE_REF }}
           lfs: true


### PR DESCRIPTION
## Summary

- Upgrade every pinned GitHub Action still declaring Node 16 or Node 20 to a Node 24-compatible release.
- Consolidate duplicated action families, including `actions/checkout`, on one supported immutable SHA.
- Add weekly Dependabot updates for the `github-actions` ecosystem.

The resulting runtime audit covers 182 action call sites: 175 use Node 24, 6 are composite actions, 1 is a Docker action, and none use Node 16 or Node 20.

Tracks OPS-8394.

## Validation

- `python3 scripts/check_action_pins.py --test`
- `python3 scripts/check_action_pins.py`
- Live `runs.using` audit against every pinned action SHA
- `pre-commit run --files <changed .github files>`
- `actionlint` on changed workflows, excluding the repository's known custom-runner and pre-existing warning classes
