### PR TITLE
fix(router): reject an unrecognized KV event source mode in transfer hints

### DIFF
--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -86,7 +86,7 @@ use crate::{
         scheduler::{DefaultWorkerSelector, KvScheduler, PotentialLoad},
         sequence::{SequenceError, SequenceRequest},
     },
-    local_model::runtime_config::ModelRuntimeConfig,
+    local_model::runtime_config::{ModelRuntimeConfig, worker_event_source_eligible},
     worker_type::WorkerType,
 };
 use route_lookup::{
@@ -1039,7 +1039,7 @@ where
                     KvTransferCandidateSource::Worker(worker) => {
                         worker != target
                             && configs.get(&worker.worker_id).is_some_and(|config| {
-                                config.kv_event_source_mode.as_deref() != Some("state_agent_v2")
+                                worker_event_source_eligible(config.kv_event_source_mode.as_deref())
                                     && config
                                         .kv_hint_transfer_metadata_for_dp_rank(worker.dp_rank)
                                         .is_some_and(|source_metadata| {
@@ -3106,6 +3106,63 @@ mod tests {
         let mut stale_source_config =
             transfer_hint_runtime_config(Some("tcp://stale-worker-endpoint:23280"));
         stale_source_config.kv_event_source_mode = Some("state_agent_v2".to_string());
+        workers.insert(8, stale_source_config);
+        let router = make_test_router_with_workers(
+            InspectingSelector {
+                expected_hits: None,
+                selected_worker: target,
+            },
+            None,
+            workers,
+        )
+        .await;
+        let owner = router_hint_cache_owner();
+        let owner_key = ResidencyOwner::cache_owner(owner).compact_key();
+        let candidates = KvTransferCandidates {
+            block_hashes: vec![
+                ExternalSequenceBlockHash(101),
+                ExternalSequenceBlockHash(102),
+            ],
+            owner_prefix_blocks: vec![
+                (KvTransferCandidateSource::Worker(stale_source), 2),
+                (KvTransferCandidateSource::CacheOwner(owner_key), 2),
+            ],
+            routing_snapshot: Some(Arc::new(ResidencyRoutingSnapshot::new(
+                ResidencyProjection::default(),
+                [(
+                    owner,
+                    RouterHintSourceMetadata {
+                        source_control_endpoint: "tcp://persistent-owner:23280".to_string(),
+                        worker_type: "prefill".to_string(),
+                    },
+                    None,
+                )],
+            ))),
+        };
+
+        assert_eq!(
+            router.transfer_hint_for_selection(target, 0, Some(&candidates)),
+            Some(KvSourceLocationsPayload {
+                source_control_endpoint: "tcp://persistent-owner:23280".to_string(),
+                block_hashes: vec![
+                    ExternalSequenceBlockHash(101),
+                    ExternalSequenceBlockHash(102),
+                ],
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn kv_transfer_ignores_worker_source_with_unrecognized_event_source_mode() {
+        let target = WorkerWithDpRank::new(7, 0);
+        let stale_source = WorkerWithDpRank::new(8, 0);
+        let mut workers = HashMap::new();
+        workers.insert(7, transfer_hint_runtime_config(None));
+        let mut stale_source_config =
+            transfer_hint_runtime_config(Some("tcp://stale-worker-endpoint:23280"));
+        // An unrecognized explicit mode must disable KV-aware routing rather than
+        // falling back to the legacy Worker path (see `kv_event_source_mode`).
+        stale_source_config.kv_event_source_mode = Some("framework_v2".to_string());
         workers.insert(8, stale_source_config);
         let router = make_test_router_with_workers(
             InspectingSelector {

--- a/lib/llm/src/kv_router/indexer/recovery/state_agent.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/state_agent.rs
@@ -52,6 +52,7 @@ use crate::discovery::kv_state_agent::{
 use crate::{
     discovery::{KvSourceMembershipView, KvSourceMembershipWatch, KvSourceStatus},
     kv_router::Indexer,
+    local_model::runtime_config::worker_event_source_eligible,
 };
 
 use super::{
@@ -361,12 +362,7 @@ fn source_mode_suppressed_workers(view: &KvSourceMembershipView) -> HashSet<Work
     view.sources
         .keys()
         .copied()
-        .filter(|worker| {
-            !matches!(
-                view.kv_event_source_mode(worker.worker_id),
-                None | Some("framework_v1")
-            )
-        })
+        .filter(|worker| !worker_event_source_eligible(view.kv_event_source_mode(worker.worker_id)))
         .collect()
 }
 

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -349,6 +349,17 @@ pub struct ModelRuntimeConfig {
     pub max_gpu_lora_count: Option<u32>,
 }
 
+/// Whether a worker's declared [`ModelRuntimeConfig::kv_event_source_mode`] makes it
+/// eligible for the Worker KV event path.
+///
+/// `None` is the legacy Worker-only source and `framework_v1` is the only accepted
+/// explicit value. Per that field's contract, any other explicit value must disable
+/// KV-aware routing rather than falling back within the same worker lifecycle, so an
+/// unrecognized mode is deliberately treated as ineligible rather than as legacy.
+pub fn worker_event_source_eligible(mode: Option<&str>) -> bool {
+    matches!(mode, None | Some("framework_v1"))
+}
+
 const fn default_data_parallel_start_rank() -> u32 {
     0
 }


### PR DESCRIPTION
## Summary

`ModelRuntimeConfig::kv_event_source_mode` states its own contract:

> Accepted values are `framework_v1` and `state_agent_v2`. Missing means the legacy Worker-only source. Unknown explicit values must disable KV-aware routing rather than falling back within the same worker lifecycle.

Two consumers read that field and disagreed on what satisfies it:

| Site | Test | Unrecognized mode |
|------|------|-------------------|
| `state_agent.rs` `source_mode_suppressed_workers` | allowlist `None \| Some("framework_v1")` | suppressed (correct) |
| `kv_router.rs` `transfer_hint_for_selection` | denylist `!= Some("state_agent_v2")` | **still eligible** |

So a worker advertising a mode this router does not recognize -- a newer engine rolled out ahead of the router, or a typo in the field -- gets suppressed from the state-agent indexer while still being picked as a KV transfer hint source. The router hands a client the `source_control_endpoint` of a worker whose KV state it has deliberately stopped tracking, and nothing logs it.

The fix routes both consumers through one predicate defined next to the field, so the contract has a single definition rather than two that can drift. That also deletes the duplicated `matches!` in `state_agent.rs`.

This replaces the original version of this PR. That one predated #13134, which reshaped this code into the typed KV hint contract and removed `router_hint_metadata_for_dp_rank` entirely; the denylist above is where the same defect now lives, so the fix was rewritten against current `main` rather than rebased.

## Validation

Rebased onto `61c37bc33c`. `cargo test -p dynamo-llm --no-default-features --lib`: **2424 passed, 0 failed, 3 ignored**. `cargo clippy -p dynamo-llm --no-default-features --lib` clean on the touched files (the one remaining warning is pre-existing in `lib/mocker/src/common/utils.rs:114`).

The new test fails on the unfixed code. Reverting only the one-line predicate swap at the fix site and keeping the test:

```
test kv_router::tests::kv_transfer_ignores_worker_source_with_unrecognized_event_source_mode ... FAILED

assertion `left == right` failed
  left: Some(KvSourceLocationsPayload { source_control_endpoint: "tcp://stale-worker-endpoint:23280", ... })
 right: Some(KvSourceLocationsPayload { source_control_endpoint: "tcp://persistent-owner:23280", ... })
```

That is the bug stated as output: the worker with the unrecognized mode wins the hint over the eligible persistent owner. The test mirrors the existing `kv_transfer_resolves_persistent_owner_without_state_agent_fallback` and changes one literal, so it covers the unrecognized-mode case beside the known-mode case it was modeled on.

GPU, multi-node, and live-engine paths were not exercised; this is a CPU-only unit-level change.
