### PR TITLE
docs(developer-guide): organize Router documentation

### DIFF
--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -183,6 +183,10 @@ redirects:
   - source: "/dynamo/dev/advanced-customizations/writing-custom-backends/:slug*"
     destination: "/dynamo/dev/backends/writing-custom-backends/:slug*"
 
+  # Custom routing strategies now live with the Router developer documentation.
+  - source: "/dynamo/dev/advanced-customizations/write-custom-routing-strategies"
+    destination: "/dynamo/dev/knowledge-base/modular-components/router/write-custom-routing-strategies"
+
   # The per-class NIXL Connect pages were replaced by the generated Python API
   # reference, which covers the same classes from source plus seven more.
   # Keep their published URLs serving, anchored at the matching class.

--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -461,44 +461,72 @@ navigation:
               - section: Router
                 collapsed: true
                 contents:
-                  - page: Overview
-                    path: pages/developer-guide/knowledge-base/modular-components/router/overview.md
-                  - page: Router Guide
-                    path: pages/developer-guide/knowledge-base/modular-components/router/router-guide.md
-                  - page: Routing Concepts
-                    path: pages/developer-guide/knowledge-base/modular-components/router/routing-concepts.md
-                  - page: Router Filtering
-                    path: pages/developer-guide/knowledge-base/modular-components/router/worker-filtering.md
-                  - page: Configuration and Tuning
-                    path: pages/developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md
-                  - page: Deficit Round Robin
-                    path: pages/developer-guide/knowledge-base/modular-components/router/deficit-round-robin.md
-                  - page: Disaggregated Serving
-                    path: pages/developer-guide/knowledge-base/modular-components/router/disaggregated-serving.md
-                  - page: Offloading Support Matrix
-                    path: pages/developer-guide/knowledge-base/modular-components/router/offloading-support-matrix.md
-                  - page: Topology-Aware KV Transfer
-                    path: pages/developer-guide/knowledge-base/modular-components/router/topology-aware-kv-transfer.md
-                  - page: Multi-DC KV Routing
-                    path: pages/developer-guide/knowledge-base/modular-components/router/multi-dc-kv-routing.md
-                  - page: Router Operations
-                    path: pages/developer-guide/knowledge-base/modular-components/router/router-operations.md
-                  - page: Router Testing
-                    path: pages/developer-guide/knowledge-base/modular-components/router/router-testing.md
-                  - page: Router Examples
-                    path: pages/developer-guide/knowledge-base/modular-components/router/router-examples.md
-                  - page: Global Router Configuration
-                    path: pages/reference/components/global-router-configuration.mdx
-                  - page: Standalone Indexer
-                    path: pages/developer-guide/knowledge-base/modular-components/router/standalone-indexer.md
-                  - page: Standalone Slot Tracker
-                    path: pages/developer-guide/knowledge-base/modular-components/router/standalone-slot-tracker.md
-                  - page: Standalone Selection
-                    path: pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md
-                  - page: KV Event Replay Comparison
-                    path: pages/developer-guide/knowledge-base/modular-components/router/kv-event-replay-comparison.md
-                  - page: Router Design
-                    path: pages/developer-guide/knowledge-base/modular-components/router/router-design.md
+                  - section: Get Started
+                    skip-slug: true
+                    collapsed: open-by-default
+                    contents:
+                      - page: Overview
+                        path: pages/developer-guide/knowledge-base/modular-components/router/overview.md
+                      - page: Router Guide
+                        path: pages/developer-guide/knowledge-base/modular-components/router/router-guide.md
+                  - section: Understand Routing
+                    skip-slug: true
+                    collapsed: true
+                    contents:
+                      - page: Routing Concepts
+                        path: pages/developer-guide/knowledge-base/modular-components/router/routing-concepts.md
+                      - page: Router Filtering
+                        path: pages/developer-guide/knowledge-base/modular-components/router/worker-filtering.md
+                      - page: Deficit Round Robin
+                        path: pages/developer-guide/knowledge-base/modular-components/router/deficit-round-robin.md
+                  - section: Configure and Operate
+                    skip-slug: true
+                    collapsed: true
+                    contents:
+                      - page: Configuration and Tuning
+                        path: pages/developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md
+                      - page: Router Operations
+                        path: pages/developer-guide/knowledge-base/modular-components/router/router-operations.md
+                      - page: KV Event Replay Comparison
+                        path: pages/developer-guide/knowledge-base/modular-components/router/kv-event-replay-comparison.md
+                      - page: Global Router Configuration
+                        path: pages/reference/components/global-router-configuration.mdx
+                  - section: Distributed Deployments
+                    skip-slug: true
+                    collapsed: true
+                    contents:
+                      - page: Disaggregated Serving
+                        path: pages/developer-guide/knowledge-base/modular-components/router/disaggregated-serving.md
+                      - page: Topology-Aware KV Transfer
+                        path: pages/developer-guide/knowledge-base/modular-components/router/topology-aware-kv-transfer.md
+                      - page: Offloading Support Matrix
+                        path: pages/developer-guide/knowledge-base/modular-components/router/offloading-support-matrix.md
+                      - page: Multi-DC KV Routing (Experimental)
+                        slug: multi-dc-kv-routing
+                        path: pages/developer-guide/knowledge-base/modular-components/router/multi-dc-kv-routing.md
+                  - section: Standalone Services
+                    skip-slug: true
+                    collapsed: true
+                    contents:
+                      - page: Standalone Indexer
+                        path: pages/developer-guide/knowledge-base/modular-components/router/standalone-indexer.md
+                      - page: Standalone Slot Tracker
+                        path: pages/developer-guide/knowledge-base/modular-components/router/standalone-slot-tracker.md
+                      - page: Standalone Selection
+                        path: pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md
+                  - section: Develop the Router
+                    skip-slug: true
+                    collapsed: true
+                    contents:
+                      - page: Write Custom Routing Strategies
+                        slug: write-custom-routing-strategies
+                        path: pages/developer-guide/knowledge-base/modular-components/router/custom-worker-selection.mdx
+                      - page: Router Examples
+                        path: pages/developer-guide/knowledge-base/modular-components/router/router-examples.md
+                      - page: Router Testing
+                        path: pages/developer-guide/knowledge-base/modular-components/router/router-testing.md
+                      - page: Router Design
+                        path: pages/developer-guide/knowledge-base/modular-components/router/router-design.md
               - section: Planner
                 collapsed: true
                 contents:
@@ -525,8 +553,6 @@ navigation:
         slug: advanced-customizations
         icon: sliders
         contents:
-          - page: Write Custom Routing Strategies
-            path: pages/developer-guide/advanced-customizations/custom-worker-selection.mdx
           - page: Conditional Disaggregation
             path: pages/developer-guide/advanced-customizations/conditional-disaggregation.md
           - page: Building from Source

--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -361,12 +361,12 @@ navigation:
             contents:
               - page: Architecture
                 path: pages/developer-guide/knowledge-base/concepts/system-architecture/architecture.md
-              - page: Sidecar Backends (Experimental)
-                slug: system-architecture/sidecar-backends
-                path: pages/developer-guide/knowledge-base/concepts/system-architecture/sidecar-backends.md
               - page: Disaggregated Serving
                 slug: system-architecture/disaggregated-serving
                 path: pages/developer-guide/knowledge-base/concepts/system-architecture/disaggregated-serving.md
+              - page: KV-Aware Routing
+                slug: system-architecture/kv-aware-routing
+                path: pages/developer-guide/knowledge-base/concepts/system-architecture/kv-aware-routing.md
               - section: Simulation
                 collapsed: true
                 contents:
@@ -440,6 +440,9 @@ navigation:
                     path: pages/developer-guide/knowledge-base/concepts/fault-tolerance/graceful-shutdown-architecture.md
                   - page: Fault Tolerance Testing
                     path: pages/developer-guide/knowledge-base/concepts/fault-tolerance/fault-tolerance-testing.md
+              - page: Sidecar Backends (Experimental)
+                slug: system-architecture/sidecar-backends
+                path: pages/developer-guide/knowledge-base/concepts/system-architecture/sidecar-backends.md
           - section: Modular Components
             collapsed: open-by-default
             contents:
@@ -518,16 +521,16 @@ navigation:
                     path: pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
                   - page: Profiler Examples
                     path: pages/developer-guide/knowledge-base/modular-components/profiler/profiler-examples.md
-      - section: Advanced Customizations
+      - section: Developing and Extending Dynamo
         slug: advanced-customizations
         icon: sliders
         contents:
-          - page: Building from Source
-            path: pages/developer-guide/advanced-customizations/building-from-source.md
           - page: Write Custom Routing Strategies
             path: pages/developer-guide/advanced-customizations/custom-worker-selection.mdx
           - page: Conditional Disaggregation
             path: pages/developer-guide/advanced-customizations/conditional-disaggregation.md
+          - page: Building from Source
+            path: pages/developer-guide/advanced-customizations/building-from-source.md
           - page: Metrics Developer Guide
             path: pages/developer-guide/advanced-customizations/metrics-developer-guide.md
           - page: Developing with Tilt

--- a/docs/fern/pages/cli/kv-aware-routing/overview.mdx
+++ b/docs/fern/pages/cli/kv-aware-routing/overview.mdx
@@ -87,6 +87,6 @@ Once a routed deployment is running, try adding another worker — the frontend 
 
 ## See also
 
-- **[Router Guide](../../developer-guide/knowledge-base/modular-components/router/router-guide.md)** — router modes and configuration
+- **[Router Guide](../../developer-guide/knowledge-base/modular-components/router/router-guide.md)** — deployment topologies and routing modes
 - **[Disaggregated Serving](../disaggregated-serving/overview.mdx)** — split prefill and decode across workers
 - **[vLLM local deployment examples](../../recipes/cli-templates/vllm.mdx)** — copyable commands for KV-routing launch scripts

--- a/docs/fern/pages/developer-guide/knowledge-base/concepts/system-architecture/kv-aware-routing.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/concepts/system-architecture/kv-aware-routing.md
@@ -1,0 +1,61 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: KV-Aware Routing
+subtitle: Select workers using reusable KV cache state and projected active load.
+---
+
+KV-aware routing chooses the worker that can serve a request at the lowest projected cost. It combines reusable key-value (KV) cache state with active prefill and decode load, reducing repeated prompt computation without concentrating work on cache-rich workers.
+
+## Why KV State Affects Routing
+
+Two requests with the same prompt can have very different costs on different workers. A worker that already holds the request prefix can reuse its cached attention state and avoid recomputing that portion of prefill. A worker with no matching prefix must compute the whole prompt.
+
+Round-robin and load-only policies do not account for that difference. KV-aware routing does, while still charging workers for in-flight prompt and decode work so that cache locality does not create a hot spot.
+
+## Selection and Feedback Loop
+
+```mermaid
+flowchart LR
+  C["Client request"] --> H["Dynamo Frontend or EPP"]
+  H --> T["Tokenize and normalize"]
+  T --> R["KV router"]
+  I["KV cache index"] --> R
+  L["Active-load tracker"] --> R
+  R --> W["Selected worker"]
+  W --> E["KV lifecycle events"]
+  E --> I
+```
+
+The request host tokenizes and normalizes the request before the router evaluates candidate workers. The KV cache index reports prefix overlap for each worker, and the active-load tracker accounts for work already assigned there. The router filters ineligible workers, scores the remaining candidates, and chooses one target.
+
+Workers publish KV creation and release events that keep the index current. When a deployment cannot publish KV events, the router can instead use predicted cache state; see [Configuration and Tuning](../../modular-components/router/configuration-and-tuning.md#kv-event-transport) for the operational tradeoff.
+
+## Cache Locality and Load Work Together
+
+The router estimates the prompt work that a worker can reuse, then combines the remaining prompt work with projected decode load. A large cache overlap lowers the prefill part of the score. Active prefill, active decode blocks, and optional active-request accounting raise it.
+
+This makes routing a placement decision, not an unconditional affinity rule. A cache-hot worker can lose to a colder worker when its active load makes the total cost higher. For the cost model, worker filters, and configuration surface, see [Routing Concepts](../../modular-components/router/routing-concepts.md) and [Router Filtering](../../modular-components/router/worker-filtering.md).
+
+## Request-Path Hosts
+
+Dynamo uses the same selection behavior in several request-path topologies:
+
+- **Dynamo Frontend** hosts the OpenAI-compatible request path and selects a worker directly.
+- **Endpoint Picker Plugin (EPP)** hosts selection behind Gateway API Inference Extension when a Kubernetes Gateway owns request entry.
+- **Standalone router services** expose router functions to custom request paths and multi-tier deployments.
+
+The host determines where selection runs; it does not change the cache-and-load model. For the Kubernetes topology choices, see [KV-Aware Routing on Kubernetes](../../../../kubernetes/kv-aware-routing/overview.md). For deployment modes and standalone services, see the [Router Guide](../../modular-components/router/router-guide.md).
+
+## Relationship to Disaggregated Serving
+
+In an aggregated deployment, KV-aware routing selects the worker that runs both prefill and decode. In a disaggregated deployment, it selects from separate prefill and decode pools and incorporates cache state appropriate to each hop.
+
+Selection and transfer are separate responsibilities. The router chooses the prefill and decode workers; backend transfer mechanisms such as NIXL move KV state between them. See [Disaggregated Serving](disaggregated-serving.md) for the serving architecture and [Router Design](../../modular-components/router/router-design.md) for router internals.
+
+## Related Documentation
+
+- [Router Overview](../../modular-components/router/overview.md)
+- [Routing Concepts](../../modular-components/router/routing-concepts.md)
+- [Router Design](../../modular-components/router/router-design.md)
+- [KV-Aware Routing on Kubernetes](../../../../kubernetes/kv-aware-routing/overview.md)

--- a/docs/fern/pages/developer-guide/knowledge-base/concepts/system-architecture/kv-aware-routing.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/concepts/system-architecture/kv-aware-routing.md
@@ -29,7 +29,7 @@ flowchart LR
 
 The request host tokenizes and normalizes the request before the router evaluates candidate workers. The KV cache index reports prefix overlap for each worker, and the active-load tracker accounts for work already assigned there. The router filters ineligible workers, scores the remaining candidates, and chooses one target.
 
-Workers publish KV creation and release events that keep the index current. When a deployment cannot publish KV events, the router can instead use predicted cache state; see [Configuration and Tuning](../../modular-components/router/configuration-and-tuning.md#kv-event-transport) for the operational tradeoff.
+Workers publish KV creation and release events that keep the index current. When a deployment cannot publish KV events, set `--no-router-kv-events` to predict cache state from routing decisions; otherwise `kv` mode uses load-only scoring. See [Configuration and Tuning](../../modular-components/router/configuration-and-tuning.md#kv-event-transport) for the operational tradeoff.
 
 ## Cache Locality and Load Work Together
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/vllm/native-kv-offloading.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/vllm/native-kv-offloading.md
@@ -168,6 +168,6 @@ Queried lower-tier indexer storage_tier=HostPinned queried_workers=2 matched_wor
 - [Offloading Support Matrix](../../router/offloading-support-matrix.md) — cross-framework support matrix for KV routing with offloading
 - [vLLM KV offloading guide](https://docs.vllm.ai/en/latest/features/kv_offloading_usage/) — connector configuration reference
 - [Configuration and Tuning](../../router/configuration-and-tuning.md) — full router flag reference, including lower-tier cache-hit weights
-- [Router Guide](../../router/router-guide.md) — routing modes and deployment matrix
+- [Router Guide](../../router/router-guide.md) — routing modes and deployment topologies
 - [KV Cache Offloading](kv-cache-offloading.md) — LMCache and FlexKV offloading backends for vLLM
 - [Using HiCache](../sglang/hicache.md) — the SGLang counterpart: tier-aware routing with HiCache

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md
@@ -11,6 +11,16 @@ boolean forms, use the [Frontend Configuration Reference](../../../../reference/
 For the routing cost model and worker-selection behavior, see
 [Routing Concepts](routing-concepts.md).
 
+## Configuration Scope and Precedence
+
+The Frontend configuration is the default for worker sets that do not advertise router settings. A worker set that advertises router configuration replaces that default for requests routed to the set; it does not merge individual settings with the Frontend configuration.
+
+Every replica in a worker set must advertise the same routing configuration. A worker set is defined by namespace, component, endpoint, model, and worker type. Mixed router settings split the set into conflicting cohorts, so Dynamo admits no instances from that set.
+
+When a worker set advertises `--router-mode kv`, restate every non-default setting that it needs. An omitted worker flag selects the shared default, not the Frontend's tuned value. This distinction matters most when the Frontend and workers receive different environment variables, such as separate Kubernetes services.
+
+For example, if the Frontend sets `--router-kv-overlap-score-credit 2.5` but a worker set advertises only `--router-mode kv`, the worker set uses the default overlap credit of `1.0`. If both processes inherit the same environment variable, they resolve to the same value. Check the `Activating prefill router` log line to confirm the resolved configuration for each hop.
+
 ## Routing Behavior
 
 - `--router-kv-overlap-score-credit`: Device-local prefix-overlap credit multiplier in the prefill cost calculation. It must be finite and nonnegative. Values greater than `1.0` give overlap extra credit, but the adjusted prefill contribution is clamped at zero. When set to `0`, the router ignores prefix caches and skips creating a local indexer. Defaults to `1.0`.
@@ -26,7 +36,7 @@ For the routing cost model and worker-selection behavior, see
 - `--router-prefill-load-model`: Selects the router's prompt-side load model. `none` keeps the existing static prompt load accounting. `aic` predicts one expected prefill duration per admitted request and lazily decays only the oldest active prefill request on each worker.
 - `--router-queue-threshold`: Optional queue threshold fraction for prefill token capacity. Queueing is disabled by default; setting a numeric value enables it. The router holds incoming requests in a priority queue while all eligible workers exceed `threshold * max_num_batched_tokens`, releasing them when capacity frees up. This defers dispatch rather than rejecting work, so routing decisions use the freshest load metrics at the moment a request is sent to a worker. `nvext.agent_hints.strict_priority` selects an absolute pending-queue tier, while `nvext.agent_hints.priority` adjusts ordering within the configured policy. Must be greater than or equal to 0; use `0.0` for maximum queueing sensitivity. See the SGLang note under [Tuning Guidelines](#tuning-guidelines) for caveats around how `max_num_batched_tokens` is populated on that backend, and see [Priority Scheduling](../../../../use-cases/agents/priority-scheduling.md) for how router priority differs from backend engine priority.
 - `--router-queue-policy`: Scheduling policy for the router queue: `fcfs` (default) or `wspt`.
-- `--router-policy-config`: Startup-only YAML path for policy-class queues and custom worker-selection instances. When omitted, `--router-queue-threshold` and `--router-queue-policy` define one synthetic policy class. The equivalent environment variable is `DYN_ROUTER_POLICY_CONFIG`. See [Write Custom Routing Strategies](../../../advanced-customizations/custom-worker-selection.mdx) for the linked-policy schema.
+- `--router-policy-config`: Startup-only YAML path for policy-class queues and custom worker-selection instances. When omitted, `--router-queue-threshold` and `--router-queue-policy` define one synthetic policy class. The equivalent environment variable is `DYN_ROUTER_POLICY_CONFIG`. See [Write Custom Routing Strategies](custom-worker-selection.mdx) for the linked-policy schema.
 
 For how queue backpressure differs from candidate filtering and busy-threshold overload handling, see [Router Filtering](worker-filtering.md).
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/custom-worker-selection.mdx
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/custom-worker-selection.mdx
@@ -468,4 +468,4 @@ Standalone EPP supplies `WorkerType::Aggregated` because it selects from one ful
 - Build the policy against the same Dynamo revision as the frontend or EPP.
 - If a signal adds work, storage, allocation, or another scan, run the worker-selection benchmark.
 
-The [example README](https://github.com/ai-dynamo/dynamo/blob/main/examples/router/custom-policy-example/README.md) contains the in-tree package names and build-check commands. For the built-in cost model, see [Routing Concepts](../knowledge-base/modular-components/router/routing-concepts.md). For the standalone selection lifecycle, see [Standalone Selection Service](../knowledge-base/modular-components/router/standalone-selection.md).
+The [example README](https://github.com/ai-dynamo/dynamo/blob/main/examples/router/custom-policy-example/README.md) contains the in-tree package names and build-check commands. For the built-in cost model, see [Routing Concepts](routing-concepts.md). For the standalone selection lifecycle, see [Standalone Selection Service](standalone-selection.md).

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/kv-event-replay-comparison.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/kv-event-replay-comparison.md
@@ -111,6 +111,6 @@ For deployments using Dynamo's KV-aware routing, the local indexer is used autom
 ## See Also
 
 - **[KV Router Index Data Structures](https://github.com/ai-dynamo/dynamo/blob/main/lib/kv-router/src/indexer/README.md)**: `RadixTree`, `ConcurrentRadixTree`, and `PositionalIndexer` internals
-- **[Router Guide](router-guide.md)**: Deployment modes and quick start for KV-aware routing
+- **[Router Guide](router-guide.md)**: Deployment topologies and worker-set configuration
 - **[Configuration and Tuning](configuration-and-tuning.md)**: Router flags and tuning details
 - **[Router Design](router-design.md)**: Architecture details and event transport modes

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/overview.md
@@ -25,7 +25,7 @@ For a topology comparison and the configuration boundary between the Frontend an
 1. The request host tokenizes and normalizes the request.
 2. The router filters workers that cannot serve it.
 3. The router scores eligible workers using cache overlap and projected load.
-4. The selected worker runs the request and publishes KV lifecycle events for future selections.
+4. Aggregated deployments run on the selected worker, while disaggregated deployments select separate prefill and decode workers. Workers publish KV lifecycle events when available; set `--no-router-kv-events` to predict cache state when the router cannot consume them.
 
 Read [KV-Aware Routing](../../concepts/system-architecture/kv-aware-routing.md) for the architecture-level flow. Read [Routing Concepts](routing-concepts.md) for the cost model, [Router Filtering](worker-filtering.md) for eligibility, and [Deficit Round Robin Queue Scheduling](deficit-round-robin.md) for policy-class arbitration.
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/overview.md
@@ -57,6 +57,7 @@ For basic model registration without KV routing, use `--router-mode round-robin`
 
 ## Next Steps
 
+- **[KV-Aware Routing](../../concepts/system-architecture/kv-aware-routing.md)**: Architecture, state flow, and request-path hosts
 - **[Router Guide](router-guide.md)**: Deployment modes, quick start, and page map
 - **[Routing Concepts](routing-concepts.md)**: Cost model and worker-selection behavior
 - **[Router Filtering](worker-filtering.md)**: Candidate eligibility, DP-rank filtering, and busy-threshold overload handling

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/overview.md
@@ -2,75 +2,41 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Router
-subtitle: KV cache-aware router that picks workers by combined prefill and decode cost to maximize throughput and minimize latency.
+subtitle: Choose a request path, understand worker selection, and operate KV-aware routing.
 ---
 
-The Dynamo KV Router intelligently routes requests by evaluating their computational costs across different workers. It considers both decoding costs (from active blocks) and prefill costs (from newly computed blocks), using KV cache overlap to minimize redundant computation. Optimizing the KV Router is critical for achieving maximum throughput and minimum latency in distributed inference setups.
+The Dynamo KV router selects an eligible worker using reusable KV cache state and projected active load. Use it when prefix reuse should influence placement; use a non-KV routing mode when your deployment needs only load balancing or an externally selected worker.
 
-## Quick Start
+## Start With Your Request Path
 
-To launch the Dynamo frontend with the KV Router:
+Choose the page that matches where requests enter Dynamo:
 
-```bash
-python -m dynamo.frontend --router-mode kv --http-port 8000
-```
+| Request path | Start here |
+| --- | --- |
+| Local Dynamo Frontend | [KV-Aware Routing for the CLI](../../../../cli/kv-aware-routing/overview.mdx) |
+| Dynamo Frontend on Kubernetes | [Dynamo Frontend Routing](../../../../kubernetes/kv-aware-routing/dynamo-frontend.md) |
+| Kubernetes Gateway API | [KV-Aware Routing on Kubernetes](../../../../kubernetes/kv-aware-routing/overview.md) |
+| Custom or multi-tier request path | [Standalone Router](../../../../cli/kv-aware-routing/standalone-router.md) |
 
-The [Frontend Configuration Reference](../../../../reference/components/frontend-configuration.mdx#router) is the
-canonical reference for embedded-router flags, environment variables, defaults, and
-boolean forms. See [Configuration and Tuning](configuration-and-tuning.md) for behavioral
-guidance.
+For a topology comparison and the configuration boundary between the Frontend and workers, see the [Router Guide](router-guide.md).
 
-> [!IMPORTANT]
-> `--router-mode kv` (or `DYN_ROUTER_MODE=kv`) enables KV routing on the
-> frontend, but it does not enable KV event publishing on backend workers. With
-> the default `--router-kv-events` setting, missing publishers leave the router
-> in event-driven mode without real cache state; the router does not
-> automatically switch to approximate prediction. Configure the backend-specific
-> publishing flags in [Router Operations](router-operations.md#additional-notes).
-> If workers will not publish events, use `--no-router-kv-events` for approximate
-> cache prediction or `--load-aware` for load-only routing.
+## Follow a Request Through the Router
 
-For Kubernetes, set `DYN_ROUTER_MODE=kv` on the Frontend service.
+1. The request host tokenizes and normalizes the request.
+2. The router filters workers that cannot serve it.
+3. The router scores eligible workers using cache overlap and projected load.
+4. The selected worker runs the request and publishes KV lifecycle events for future selections.
 
-### Standalone Router
+Read [KV-Aware Routing](../../concepts/system-architecture/kv-aware-routing.md) for the architecture-level flow. Read [Routing Concepts](routing-concepts.md) for the cost model, [Router Filtering](worker-filtering.md) for eligibility, and [Deficit Round Robin Queue Scheduling](deficit-round-robin.md) for policy-class arbitration.
 
-You can also run the KV router as a standalone service (without the Dynamo frontend). See the [Standalone Router component](https://github.com/ai-dynamo/dynamo/tree/main/components/src/dynamo/router/) for more details.
+## Continue by Task
 
-For deployment modes and quick start steps, see the [Router Guide](router-guide.md). For tuning guidelines, see [Configuration and Tuning](configuration-and-tuning.md). For A/B benchmarking, see the [KV Router A/B Benchmarking Guide](../../../../recipes/feature-benchmarks/kv-router-a-b-testing.md).
+| Need | Use |
+| --- | --- |
+| Tune cache and load tradeoffs | [Configuration and Tuning](configuration-and-tuning.md) |
+| Run separate prefill and decode pools | [Disaggregated Serving](disaggregated-serving.md) |
+| Recover router state or run replicas | [Router Operations](router-operations.md) |
+| Run router primitives outside the Frontend | [Standalone Services](standalone-indexer.md) |
+| Change or test router behavior | [Develop the Router](router-design.md) |
 
-## Prerequisites and Limitations
-
-**Requirements:**
-- **Dynamic endpoints only**: KV router requires `register_model()` with `model_input=ModelInput.Tokens`. Your backend handler receives pre-tokenized requests with `token_ids` instead of raw text.
-- Backend workers must call `register_model()` with `model_input=ModelInput.Tokens` (see [Backend Guide](../../../advanced-customizations/writing-custom-backends/writing-python-workers.md))
-- Use dynamic discovery with KV routing so the router can track worker instances and KV cache state
-
-**Multimodal Support:**
-- **Image routing via multimodal hashes**: Supported in the documented SGLang, TRT-LLM, and vLLM router paths. SGLang needs the hash-forwarding patch that Dynamo's own image ships; a custom build without it serves the request but routes on the text prefix alone.
-- **Other backend or modality combinations**: Check the backend-specific multimodal docs before relying on multimodal hash routing.
-
-**Limitations:**
-- Static endpoints are not supported with KV routing; use dynamic discovery so the router can track worker instances and KV cache state
-- With `DYN_LORA_ENABLED`, only KV, random, and round-robin routing are LoRA-aware. Direct, power-of-two, least-loaded, and device-aware-weighted modes fail startup. Session affinity is supported with LoRA only in KV mode; LoRA plus random or round-robin affinity is rejected.
-
-For basic model registration without KV routing, use `--router-mode round-robin`, `--router-mode random`, `--router-mode power-of-two`, `--router-mode least-loaded`, or `--router-mode device-aware-weighted` with both static and dynamic endpoints.
-
-## Next Steps
-
-- **[KV-Aware Routing](../../concepts/system-architecture/kv-aware-routing.md)**: Architecture, state flow, and request-path hosts
-- **[Router Guide](router-guide.md)**: Deployment modes, quick start, and page map
-- **[Routing Concepts](routing-concepts.md)**: Cost model and worker-selection behavior
-- **[Router Filtering](worker-filtering.md)**: Candidate eligibility, DP-rank filtering, and busy-threshold overload handling
-- **[Frontend Configuration Reference](../../../../reference/components/frontend-configuration.mdx#router)**: Canonical embedded-router flags and environment variables
-- **[Configuration and Tuning](configuration-and-tuning.md)**: Router behavior, transport modes, and tuning guidance
-- **[Deficit Round Robin Queue Scheduling](deficit-round-robin.md)**: Weighted policy-class arbitration, cursor movement, and bulk virtual rounds
-- **[Priority Scheduling](../../../../use-cases/agents/priority-scheduling.md)**: Router queue, backend engine, and cache priority behavior
-- **[Disaggregated Serving](disaggregated-serving.md)**: Prefill and decode routing setups
-- **[Router Operations](router-operations.md)**: Replicas, persistence, and recovery
-- **[Router Examples](router-examples.md)**: Python API usage, K8s examples, and custom routing patterns
-- **[Router Testing](router-testing.md)**: Test layers from Rust unit tests to fixture-backed replay and full process E2E
-- **[Multi-DC KV Routing](multi-dc-kv-routing.md)**: Cross-datacenter KV routing and the DC Relay (experimental)
-- **[Standalone Indexer](standalone-indexer.md)**: Run the KV indexer as a separate service for independent scaling
-- **[Standalone Selection Service](standalone-selection.md)**: Expose KV-aware selection and reservation accounting over HTTP
-- **[Standalone Slot Tracker](standalone-slot-tracker.md)**: Run active-request load accounting as a separate HTTP service
-- **[Router Design](router-design.md)**: Architecture details, algorithms, and event transport modes
+The [Frontend Configuration Reference](../../../../reference/components/frontend-configuration.mdx#router) is the canonical source for embedded-router flags, environment variables, defaults, and boolean forms.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-examples.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-examples.md
@@ -120,7 +120,7 @@ if __name__ == "__main__":
 
 ## K8s Examples
 
-For basic Kubernetes deployment with the KV Router, see the [Kubernetes Deployment section](router-guide.md#kubernetes-deployment) in the Router Guide.
+For basic Kubernetes deployment with the KV Router, see [Dynamo Frontend Routing](../../../../kubernetes/kv-aware-routing/dynamo-frontend.md).
 
 ### Complete K8s Examples
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-guide.md
@@ -2,218 +2,40 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Router Guide
-subtitle: Deployment modes, quick start, and page map for Dynamo routing docs
+subtitle: Choose where routing runs and how worker-set configuration takes effect.
 ---
 
-## Overview
+Use this guide to choose a router deployment topology. It does not replace the local or Kubernetes setup guides, which own the commands and manifests for each request path.
 
-The Dynamo KV Router intelligently routes requests by evaluating their computational costs across different workers. It considers both decoding costs (from active blocks) and prefill costs (from newly computed blocks), using KV cache overlap to minimize redundant computation. Optimizing the KV Router is critical for achieving maximum throughput and minimum latency in distributed inference setups.
-This guide helps you get started with using the Dynamo router and points to the pages that cover routing concepts, configuration, disaggregated serving, and operations in more detail.
+## Choose a Deployment Topology
 
-## Quick Start
+| Topology | Where selection runs | Use it when | Setup guide |
+| --- | --- | --- | --- |
+| Frontend-embedded | Dynamo Frontend | Clients can call one Dynamo service directly. | [KV-Aware Routing for the CLI](../../../../cli/kv-aware-routing/overview.mdx) or [Dynamo Frontend Routing](../../../../kubernetes/kv-aware-routing/dynamo-frontend.md) |
+| Gateway API | Dynamo Endpoint Picker Plugin (EPP) | A Kubernetes Gateway owns ingress policy and endpoint selection. | [KV-Aware Routing on Kubernetes](../../../../kubernetes/kv-aware-routing/overview.md) |
+| Standalone | Dynamo router service | A custom request path or multi-tier architecture needs selection outside the Frontend. | [Standalone Router](../../../../cli/kv-aware-routing/standalone-router.md) |
 
-The router can be deployed using [Python / CLI](#python--cli-deployment), [Kubernetes](#kubernetes-deployment), or as a [standalone component](#standalone-router).
+The Frontend and EPP use the same worker selection behavior. Do not configure the Frontend to make another selection after an EPP has selected a worker.
 
-### Python / CLI Deployment
+## Choose a Routing Mode
 
-To launch the Dynamo frontend with the KV Router:
+Use `kv` mode when cache reuse should affect placement. Workers publish KV lifecycle events so the router can measure per-worker prefix overlap; when events are unavailable, approximate mode predicts cache state from prior router decisions.
 
-```bash
-python -m dynamo.frontend --router-mode kv --http-port 8000
-```
-
-This command:
-- Launches the Dynamo frontend service with KV routing enabled
-- Exposes the service on port 8000 (configurable)
-- Automatically handles all backend workers registered to the Dynamo endpoint
-
-Backend workers register themselves using the `register_model` API. For accurate prefix-cache state, workers must also publish KV cache events with the backend-specific event flags; otherwise the router can run in approximate mode with `--no-router-kv-events`.
-
-The [Frontend Configuration Reference](../../../../reference/components/frontend-configuration.mdx#router) is the
-canonical list of embedded-router CLI arguments, environment variables, defaults,
-and boolean forms. Use [Configuration and Tuning](configuration-and-tuning.md) for
-workload-specific guidance, [Router Filtering](worker-filtering.md) for candidate
-eligibility, and [Routing Concepts](routing-concepts.md#active-load-modeling) for the
-prefill and decode cost model.
-
-### Kubernetes Deployment
-
-To enable the KV Router in Kubernetes, add the `DYN_ROUTER_MODE` environment variable to your frontend service:
-
-```yaml
-apiVersion: nvidia.com/v1alpha1
-kind: DynamoGraphDeployment
-metadata:
-  name: my-deployment
-spec:
-  services:
-    Frontend:
-      componentType: frontend
-      replicas: 1
-      envs:
-        - name: DYN_ROUTER_MODE
-          value: kv  # Enable KV Smart Router
-```
-
-**Key Points:**
-- Set `DYN_ROUTER_MODE=kv` on the **Frontend** service only
-- Configure worker-side KV event publishing when you want event-driven prefix-cache state
-- Use `--no-router-kv-events` for approximate cache-state prediction when workers are not publishing events
-
-For exact environment-variable mappings, see the
-[Frontend Configuration Reference](../../../../reference/components/frontend-configuration.mdx#router). For complete
-Kubernetes examples and tuning guidance, see
-[Kubernetes Examples](router-examples.md#k8s-examples) and
-[Configuration and Tuning](configuration-and-tuning.md).
-For A/B testing and advanced K8s setup, see the [KV Router A/B Benchmarking Guide](../../../../recipes/feature-benchmarks/kv-router-a-b-testing.md).
-
-### Standalone Router
-
-You can also run the KV router as a standalone service without the Dynamo frontend for disaggregated serving, multi-tier architectures, or custom routing pipelines. See [Standalone Router](../../../../cli/kv-aware-routing/standalone-router.md) for the Fern guide.
-
-#### Frontend-Embedded vs. Standalone Router
-
-| Deployment | Process | Metrics Port | Use Case |
-|------------|---------|--------------|----------|
-| **Frontend-embedded** | `python -m dynamo.frontend --router-mode kv` | Frontend HTTP port (default 8000) | Standard deployment; router runs inside the frontend process |
-| **Standalone** | `python -m dynamo.router` | `DYN_SYSTEM_PORT` (if set) | Multi-tier architectures, advanced disaggregated prefill routing, custom pipelines |
-
-The standalone router does not include the HTTP frontend and does not expose `/v1/chat/completions`. It exposes routing endpoints through the Dynamo runtime and, when configured, router metrics through the system status server.
-
-## Deployment Modes
-
-The Dynamo router can be deployed in several configurations. The table below shows common combinations and when to use them:
-
-| Mode | Command | Routing Logic | KV Events | Topology | Use Case |
-|------|---------|---------------|-----------|----------|----------|
-| **Frontend + Round-Robin** | `python -m dynamo.frontend --router-mode round-robin` | Cycles through workers | None | Aggregated | Simplest baseline; no KV awareness |
-| **Frontend + Random** | `python -m dynamo.frontend --router-mode random` | Random worker selection | None | Aggregated | Stateless load balancing |
-| **Frontend + Power of Two** | `python -m dynamo.frontend --router-mode power-of-two` | Samples two workers and chooses the less loaded one | None | Aggregated or disaggregated fallback | Low-overhead load balancing with better distribution than random selection |
-| **Frontend + KV (Aggregated)** | `python -m dynamo.frontend --router-mode kv` | KV cache overlap + load | NATS Core / ZMQ / Approx | Aggregated | Production single-pool serving with cache reuse |
-| **Frontend + KV (Disaggregated)** | `python -m dynamo.frontend --router-mode kv` with prefill + decode workers | KV cache overlap + load | NATS Core / ZMQ / Approx | Disaggregated (prefill + decode pools) | Separate prefill/decode for large-scale serving |
-| **Frontend + Least-Loaded** | `python -m dynamo.frontend --router-mode least-loaded` | Fewest active connections | None | Aggregated or disaggregated fallback | Simple load-aware balancing without KV awareness |
-| **Frontend + Device-Aware Weighted** | `python -m dynamo.frontend --router-mode device-aware-weighted` | Device-aware budget + least-loaded within selected device group | None | Aggregated or disaggregated fallback | Heterogeneous fleet balancing (CPU/non-CPU); degenerates to least-loaded when only one device class is present |
-| **Frontend + Direct** | `python -m dynamo.frontend --router-mode direct` | Worker ID from request hints | None | Aggregated | External orchestrator (e.g., EPP/GAIE) selects workers |
-| **Standalone Router** | `python -m dynamo.router` | KV cache overlap + load | NATS Core / ZMQ | Any | Routing without the HTTP frontend (multi-tier, custom pipelines) |
+Use `round-robin`, `random`, `power-of-two`, `least-loaded`, or `device-aware-weighted` when cache state is not part of the decision. Use `direct` when an upstream component has already selected a worker. See [Routing Concepts](routing-concepts.md#basic-routing) for policy behavior and [Configuration and Tuning](configuration-and-tuning.md#kv-event-transport) for event transport.
 
 > [!IMPORTANT]
-> With `DYN_LORA_ENABLED`, use KV, random, or round-robin routing. Direct,
-> power-of-two, least-loaded, and device-aware-weighted modes are not LoRA-aware
-> and fail startup. Session affinity with LoRA is supported only in KV mode;
-> random and round-robin plus affinity are rejected.
+> With `DYN_LORA_ENABLED`, use KV, random, or round-robin routing. Direct, power-of-two, least-loaded, and device-aware-weighted modes are not LoRA-aware and fail startup. Session affinity with LoRA is supported only in KV mode; random and round-robin plus affinity are rejected.
 
-### Routing Modes (`--router-mode`)
+## Configure Worker Sets Consistently
 
-| Mode | Value | How Workers Are Selected |
-|------|-------|-------------------------|
-| **Round-Robin** | `round-robin` (default) | Cycles through available workers in order |
-| **Random** | `random` | Selects a random worker for each request |
-| **Power of Two** | `power-of-two` | Samples two workers and routes to the one with fewer in-flight requests; in disaggregated prefill paths it falls back to synchronous prefill |
-| **KV** | `kv` | Evaluates KV cache overlap and decode load per worker; picks lowest cost |
-| **Least-Loaded** | `least-loaded` | Routes to the worker with fewest active connections; in disaggregated prefill paths it skips bootstrap optimization and falls back to synchronous prefill |
-| **Device-Aware Weighted** | `device-aware-weighted` | Partitions workers into CPU and non-CPU groups, applies capability-normalized ratio budgeting using `DYN_ENCODER_CUDA_TO_CPU_RATIO` to decide which group receives the request, then selects the least-loaded worker within that group |
-| **Direct** | `direct` | Reads the target `worker_id` from the request's routing hints; no selection logic |
+The Frontend's `--router-mode` sets the default routing configuration. A worker set can advertise its own router configuration, which replaces the Frontend configuration for requests routed to that set.
 
-### Device-Aware Weighted Routing
+A worker set contains replicas with the same namespace, component, endpoint, model, and worker type. Every replica in a set must publish the same router configuration. If replicas disagree, Dynamo treats the set as a conflict and does not admit any of its instances.
 
-`device-aware-weighted` is designed for heterogeneous fleets where workers of different compute capability, for example CPU embedding encoders alongside GPU embedding encoders, share the same endpoint.
+Worker-set configuration replaces rather than merges with the Frontend configuration. When a worker advertises `--router-mode kv`, restate every non-default router setting that it needs; omitting a setting selects that setting's default instead of inheriting the Frontend value. See [Configuration Scope and Precedence](configuration-and-tuning.md#configuration-scope-and-precedence) for examples and environment-variable implications.
 
-Workers are split into CPU and non-CPU groups. The router compares a capability-normalized load across the two groups:
+## Choose Distributed Features Deliberately
 
-```text
-normalized_load = total_inflight(group) / (instance_count(group) x throughput_weight)
-```
+Use [Disaggregated Serving](disaggregated-serving.md) for separate prefill and decode pools. Add [Topology-Aware KV Transfer](topology-aware-kv-transfer.md) when decode selection must honor transfer locality, and use the [Offloading Support Matrix](offloading-support-matrix.md) when lower cache tiers should influence routing.
 
-The throughput weight is `1` for CPU workers and `DYN_ENCODER_CUDA_TO_CPU_RATIO` for non-CPU workers. The next request is routed to the group with the lower normalized load, then to the least-loaded worker inside that group.
-
-For multimodal requests, a full embedding-cache hit on one or more workers bypasses the CPU-to-non-CPU ratio. The router selects the least-loaded worker among those that hold every distinct embedding-cache key in the request. Partial hits continue through the normal weighted group selection. See [Embedding Cache](../../../../use-cases/multimodal-serving/embedding-cache.md#configuration).
-
-Use `DYN_ENCODER_CUDA_TO_CPU_RATIO` to approximate the throughput ratio of a non-CPU worker relative to one CPU worker. The default is `8`.
-
-When only one device class is present, the policy degenerates to standard least-loaded routing.
-
-### KV Event Transport Modes (within `--router-mode kv`)
-
-When using KV routing, the router needs to know what each worker has cached. There are three ways to get this information:
-
-| Event Mode | How to Enable | Description |
-|------------|---------------|-------------|
-| **ZMQ (local indexer)** | Router default (no router flag) | Workers maintain a local indexer and publish KV events via ZMQ PUB sockets; the router recovers state by querying live workers. This is the default event plane for all backends |
-| **NATS Core (local indexer)** | `--event-plane nats` (or `DYN_EVENT_PLANE=nats`) | Same local-indexer model, but events flow over NATS Core instead of ZMQ. |
-| **Approximate (no events)** | `--no-router-kv-events` | No events consumed; router predicts cache state from its own routing decisions. Retention defaults to TTL; experimental `--router-approximate-cache-policy lru` uses advertised per-rank KV capacity. |
-
-### Aggregated vs. Disaggregated Topology
-
-| Topology | Workers | How It Works |
-|----------|---------|--------------|
-| **Aggregated** | Single pool (prefill + decode in one process) | All workers handle the full request lifecycle |
-| **Disaggregated** | Separate prefill and decode pools | Frontend routes to a prefill worker first, then to a decode worker; requires workers registered with `WorkerType.Prefill` |
-
-Disaggregated mode is activated automatically when prefill workers register alongside decode workers. See [Disaggregated Serving](disaggregated-serving.md) for details.
-
-## Per-Worker Router Configuration
-
-`--router-mode` on the frontend sets the default for every worker. A worker set can override it for itself by declaring its own routing in its model deployment card, which the frontend then uses in place of its own configuration when routing to that set. This lets one deployment serve worker sets that want different strategies — for example a heterogeneous CPU/GPU encoder pool on `device-aware-weighted` while everything else stays round-robin.
-
-Workers accept the same flags as the frontend, on vLLM, SGLang, TensorRT-LLM, and the mocker:
-
-```bash
-# Frontend default for the deployment
-python -m dynamo.frontend --router-mode round-robin --http-port 8000
-
-# Worker set A -- overrides to KV. Every replica is launched with the same flags.
-python -m dynamo.vllm --model Qwen/Qwen3-0.6B --router-mode kv --router-kv-overlap-score-credit 2.0
-python -m dynamo.vllm --model Qwen/Qwen3-0.6B --router-mode kv --router-kv-overlap-score-credit 2.0
-
-# Worker set B -- a different model, no router flags, so it inherits round-robin
-python -m dynamo.vllm --model meta-llama/Llama-3.1-8B-Instruct
-
-# Worker set C -- a different model again, on its own strategy
-python -m dynamo.vllm --model BAAI/bge-m3 --router-mode device-aware-weighted
-```
-
-Sets A, B, and C are distinct because a worker set is keyed on model name as well as endpoint and worker type. Each carries its own routing configuration and the three do not interact.
-
-A worker that omits `--router-mode`, like set B, advertises nothing and inherits the frontend's configuration. That is the default, and it is what every deployment written before this option did.
-
-### The override is per worker set, not per worker
-
-Workers that share a namespace, component, endpoint, model type, and worker type form a single worker set, and a worker set has one routing configuration. Two replicas of the same model launched with different router flags are not two independently routed workers — they are one set whose members disagree.
-
-> [!WARNING]
-> Every worker in a set must be launched with identical router flags. The frontend fingerprints each worker's card together with its effective routing configuration, so mismatched flags split the set into two cohorts. A split set is treated as a conflict: **no instances are admitted and the set stops serving**. It does not fall back to one worker's configuration or to the frontend's.
-
-This is not specific to router flags — any card difference splits a set the same way — but router flags are easy to apply to one replica by mistake. Two practical consequences:
-
-- **Changing the routing of a running fleet is a card change.** Roll the whole set rather than mixing old and new replicas, the same as any other change that alters the card.
-- **Applying the flag to only some replicas of a set splits it.** Whether by flag or by an exported `DYN_ROUTER_MODE` that reaches some processes and not others, every member of a set must end up with the same value.
-
-> [!IMPORTANT]
-> An advertised configuration **replaces** the frontend's for that worker set rather than merging with it. On a worker, a flag you do not pass means **the default**, not "inherit the frontend's value". If the frontend was tuned with `--router-kv-overlap-score-credit 2.5` and a worker advertises only `--router-mode kv`, that worker set routes with the default `1.0` — the tuning is not inherited, it is replaced. Restate on the worker every flag that matters for it.
-
-Merging is not offered because it cannot be done correctly: the KV tuning is flat concrete values with no record of which ones were set explicitly, so a deliberate `1.0` is indistinguishable from a default `1.0`.
-
-Workers and the frontend share defaults exactly — both build their configuration from the same argument groups — so the values only diverge when the frontend is tuned and the worker is not.
-
-The flags also read the same environment variables, and this changes the answer depending on how you deploy. If the frontend's tuning comes from the environment and the worker shares that environment — a single shell starting both — the worker picks the tuning up and nothing is lost. Kubernetes scopes environment per service, so there the worker sees only its own flags. The same intent can therefore produce different routing in the two setups. `--router-mode` itself is the exception in the other direction: a shared `DYN_ROUTER_MODE` makes a worker advertise when you meant it to inherit.
-
-The `Activating prefill router` log line reports the configuration each hop actually resolved — mode, block size, session TTL, and KV tuning — which is the quickest way to confirm what a worker set ended up with.
-
-The frontend-only options (`--router-min-initial-workers`, `--enforce-disagg`, `--admission-control`) are not accepted by workers, since a model card does not carry them.
-
-Advertised configuration applies to the worker sets the frontend routes to directly — aggregated and decode. See [Frontend Configuration Reference](../../../../reference/components/frontend-configuration.mdx#router) for the full flag list.
-
-## More Router Docs
-
-- **[Routing Concepts](routing-concepts.md)**: Cost model, worker selection, and routing primitives
-- **[Frontend Configuration Reference](../../../../reference/components/frontend-configuration.mdx#router)**: Canonical router flags, environment variables, defaults, and boolean forms
-- **[Configuration and Tuning](configuration-and-tuning.md)**: Router behavior, transport modes, load tracking, and tuning guidance
-- **[Disaggregated Serving](disaggregated-serving.md)**: Prefill and decode routing setups
-- **[Topology-Aware KV Transfer](topology-aware-kv-transfer.md)**: Runtime metadata and decode routing constraints for topology-aware prefill/decode handoff
-- **[Router Operations](router-operations.md)**: Replicas, remote indexers, persistence, and recovery
-- **[Router Examples](router-examples.md)**: Python API usage, K8s examples, and custom routing patterns
-- **[Router Testing](router-testing.md)**: Recommended test layers for non-trivial router changes
-- **[Standalone Indexer](standalone-indexer.md)**: Run the KV indexer as a separate service
-- **[Standalone Selection Service](standalone-selection.md)**: Select workers and account for reservations without forwarding requests
-- **[Standalone Slot Tracker](standalone-slot-tracker.md)**: Run active-request accounting as a separate service
-- **[KV Event Replay — Dynamo vs vLLM](kv-event-replay-comparison.md)**: Gap detection and replay behavior
+For replicas, event recovery, and remote indexers, see [Router Operations](router-operations.md). For APIs that separate index, selection, or load tracking from the router process, see [Standalone Services](standalone-indexer.md).

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-guide.md
@@ -19,7 +19,7 @@ The Frontend and EPP use the same worker selection behavior. Do not configure th
 
 ## Choose a Routing Mode
 
-Use `kv` mode when cache reuse should affect placement. Workers publish KV lifecycle events so the router can measure per-worker prefix overlap; when events are unavailable, approximate mode predicts cache state from prior router decisions.
+Use `kv` mode when cache reuse should affect placement. Workers publish KV lifecycle events so the router can measure per-worker prefix overlap. Without worker events, `kv` mode uses load-only scoring; set `--no-router-kv-events` to predict cache state from routing decisions instead.
 
 Use `round-robin`, `random`, `power-of-two`, `least-loaded`, or `device-aware-weighted` when cache state is not part of the decision. Use `direct` when an upstream component has already selected a worker. See [Routing Concepts](routing-concepts.md#basic-routing) for policy behavior and [Configuration and Tuning](configuration-and-tuning.md#kv-event-transport) for event transport.
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/routing-concepts.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/routing-concepts.md
@@ -67,7 +67,7 @@ The router selects the worker with the lowest cost. When `router_temperature` is
 
 Before scoring, the router filters candidates by request allow-lists, exact pins, DP-rank bounds, required taints, and busy-threshold overload state. For those hard eligibility rules, see [Router Filtering](worker-filtering.md).
 
-To replace only the scoring and picking stage with statically linked Rust code, see [Write Custom Routing Strategies](../../../advanced-customizations/custom-worker-selection.mdx).
+To replace only the scoring and picking stage with statically linked Rust code, see [Write Custom Routing Strategies](custom-worker-selection.mdx).
 
 When requests wait in policy-class queues, weighted
 [Deficit Round Robin Queue Scheduling](deficit-round-robin.md) selects the

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md
@@ -54,7 +54,7 @@ invalid configuration. Production integrations should use
 `SelectionServiceBuilder` so startup recovery, readiness, and background-task
 lifecycle remain consistent with the standalone service.
 
-To inject native Rust scorers and a picker while retaining those service-owned capabilities, see [Write Custom Routing Strategies](../../../advanced-customizations/custom-worker-selection.mdx).
+To inject native Rust scorers and a picker while retaining those service-owned capabilities, see [Write Custom Routing Strategies](custom-worker-selection.mdx).
 
 The C and Go bindings do not currently expose `SelectionService`. An EPP
 integration requires separate FFI lifecycle, error-mapping, worker, and peer
@@ -218,7 +218,7 @@ implement session affinity by preferring the worker a session used previously.
 > `session_id` is an input to policy, not an affinity mechanism in itself. The
 > built-in selector ignores it, so it changes the chosen worker only when you
 > supply a custom picker or scorer that reads it. See
-> [Write Custom Routing Strategies](../../../advanced-customizations/custom-worker-selection.mdx).
+> [Write Custom Routing Strategies](custom-worker-selection.mdx).
 > It is also distinct from the frontend's own session affinity, which binds
 > sessions from request headers rather than from this API; see
 > [Configuration and Tuning](configuration-and-tuning.md).

--- a/docs/fern/pages/kubernetes/kv-aware-routing/dynamo-frontend.md
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/dynamo-frontend.md
@@ -8,7 +8,7 @@ subtitle: Configure the Dynamo Frontend to select the worker most likely to have
 
 In this topology, the Dynamo Frontend receives each request and selects the worker most likely to already hold the prompt's KV cache prefix. Use it when clients send requests directly to a Dynamo Frontend Service. If a Kubernetes Gateway receives requests first, use [GAIE with Dynamo](gateway-api.mdx) instead.
 
-Turning it on in a DynamoGraphDeployment (DGD) takes two steps: switch the **Frontend** into KV mode, and have the **workers** publish KV cache events so the router knows what each worker has cached. This is a [how-to](../model-deployment/deploy-with-dgd.md) for an existing deployment. For the routing cost model and concepts, see [Routing Concepts](../../developer-guide/knowledge-base/modular-components/router/routing-concepts.md); for the full flag and env reference, see the [Router Guide](../../developer-guide/knowledge-base/modular-components/router/router-guide.md).
+Turning it on in a DynamoGraphDeployment (DGD) takes two steps: switch the **Frontend** into KV mode, and have the **workers** publish KV cache events so the router knows what each worker has cached. This is a [how-to](../model-deployment/deploy-with-dgd.md) for an existing deployment. For the routing cost model and concepts, see [Routing Concepts](../../developer-guide/knowledge-base/modular-components/router/routing-concepts.md); for the full flag and environment-variable reference, see the [Frontend Configuration Reference](../../reference/components/frontend-configuration.mdx#router).
 
 <Steps toc={true} tocDepth={2}>
 
@@ -60,7 +60,7 @@ For the router to track which blocks each worker holds, workers must publish KV 
           - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
 ```
 
-This is the half that the [Router Guide](../../developer-guide/knowledge-base/modular-components/router/router-guide.md) does not show. Without it, the router falls back to load-only decisions even in `kv` mode.
+Setting the Frontend to `kv` mode alone does not provide worker cache state. Without worker KV events, the router falls back to load-only decisions.
 
 The Frontend and worker snippets above are drawn from the [disagg-kv-router recipe](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml), where six prefill workers publish KV events and the Frontend routes across them.
 
@@ -104,6 +104,7 @@ In a disaggregated graph, the router operates over prefill and decode workers se
 
 - [KV-Aware Routing on Kubernetes](overview.md) — compare the Frontend and GAIE topologies.
 - [Using GAIE with Dynamo](gateway-api.mdx) — place endpoint selection in the Dynamo EPP.
-- [Router Guide](../../developer-guide/knowledge-base/modular-components/router/router-guide.md) — deployment modes, full CLI and env reference.
+- [Router Guide](../../developer-guide/knowledge-base/modular-components/router/router-guide.md) — deployment topologies and worker-set configuration.
+- [Frontend Configuration Reference](../../reference/components/frontend-configuration.mdx#router) — canonical flags, environment variables, and defaults.
 - [Routing Concepts](../../developer-guide/knowledge-base/modular-components/router/routing-concepts.md) — cost model and worker selection.
 - [Router with Disaggregated Serving](../../developer-guide/knowledge-base/modular-components/router/disaggregated-serving.md) — prefill/decode routing.

--- a/docs/fern/pages/kubernetes/kv-aware-routing/dynamo-frontend.md
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/dynamo-frontend.md
@@ -60,7 +60,7 @@ For the router to track which blocks each worker holds, workers must publish KV 
           - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
 ```
 
-Setting the Frontend to `kv` mode alone does not provide worker cache state. Without worker KV events, the router falls back to load-only decisions.
+Setting the Frontend to `kv` mode alone does not provide worker cache state. Without worker KV events, `kv` mode uses load-only scoring. To predict cache state from routing decisions instead, set `--no-router-kv-events` on the Frontend.
 
 The Frontend and worker snippets above are drawn from the [disagg-kv-router recipe](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml), where six prefill workers publish KV events and the Frontend routes across them.
 

--- a/docs/fern/pages/reference/components/frontend-configuration.mdx
+++ b/docs/fern/pages/reference/components/frontend-configuration.mdx
@@ -297,7 +297,7 @@ router. See [Router Guide](../../developer-guide/knowledge-base/modular-componen
 <ParamField path="--router-policy-config" type="string" default="null">
   Startup-only YAML for policy-class queues and custom worker-selection instances. When omitted,
   `--router-queue-threshold` and `--router-queue-policy` define one synthetic policy class.
-  Queueing remains disabled until a threshold is configured. See [Policy-class queues](../../developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md#policy-class-queues) and [Write Custom Routing Strategies](../../developer-guide/advanced-customizations/custom-worker-selection.mdx).
+  Queueing remains disabled until a threshold is configured. See [Policy-class queues](../../developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md#policy-class-queues) and [Write Custom Routing Strategies](../../developer-guide/knowledge-base/modular-components/router/custom-worker-selection.mdx).
 
   Environment variable: `DYN_ROUTER_POLICY_CONFIG`
 </ParamField>

--- a/docs/fern/pages/reference/components/global-router-configuration.mdx
+++ b/docs/fern/pages/reference/components/global-router-configuration.mdx
@@ -383,8 +383,8 @@ The router validates the configuration at startup and exits if any rule is viola
   <Card title="Global Planner Guide" icon="book" href="../../developer-guide/knowledge-base/modular-components/planner/global-planner-guide.md">
     How to deploy a single-endpoint multi-pool topology with GlobalRouter and GlobalPlanner, including the ConfigMap + DGD assembly workflow.
   </Card>
-  <Card title="Router Guide" icon="route" href="../../developer-guide/knowledge-base/modular-components/router/router-guide.md">
-    Concepts, routing modes, and operational details for the Dynamo router family.
+  <Card title="Router Overview" icon="route" href="../../developer-guide/knowledge-base/modular-components/router/overview.md">
+    Choose a request path, understand worker selection, and find router operations and development guidance.
   </Card>
   <Card title="Planner Configuration" icon="gear" href="planner-configuration.mdx">
     Field reference for the PlannerConfig JSON object used by pool-local Planners in a GlobalPlanner deployment.


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Adds a KV-aware routing architecture page and reorganizes Router documentation around the reader's task. The result gives operational, deployment, standalone-service, and extension guidance clear homes without changing established Router URLs.

### How This Was Implemented
- Added the Concepts-level KV-Aware Routing page and ordered Concepts around Dynamo's main architecture: Architecture, Disaggregated Serving, KV-Aware Routing, Simulation, Fault Tolerance, and experimental Sidecar Backends.
- Grouped the Router corpus into six URL-neutral sections: Get Started, Understand Routing, Configure and Operate, Distributed Deployments, Standalone Services, and Develop the Router.
- Reduced the Router landing pages to path selection and ownership boundaries, moving the duplicated worker-set precedence explanation to Configuration and Tuning.
- Moved Write Custom Routing Strategies into Develop the Router, repaired its incoming and local links, and redirected its former Advanced Customizations URL.
- Clarified that missing worker KV events leave `kv` mode load-only unless `--no-router-kv-events` opts into predicted cache state.

### Related Issues

No related issues.

### Where to Start Reviewing

- [Router overview](docs/fern/pages/developer-guide/knowledge-base/modular-components/router/overview.md) for the reader-path and request-flow changes.
- [Router Guide](docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-guide.md) and [Dynamo Frontend Routing](docs/fern/pages/kubernetes/kv-aware-routing/dynamo-frontend.md) for deployment and eventless-routing semantics.

<details>
<summary>Walkthrough</summary>

#### Mental model

The Router navigation now follows a reader journey. A user first selects an ingress path, then learns worker selection, configures and operates that decision, applies distributed or standalone variants, or extends the selection policy.

#### Navigation and URL stability

Each new Router subsection uses Fern's `skip-slug: true`, so the existing URLs for the grouped Router pages do not gain a navigation segment. The custom strategy page is the only moved URL; its original `/advanced-customizations/write-custom-routing-strategies` route redirects to `/knowledge-base/modular-components/router/write-custom-routing-strategies`.

#### Content ownership

The Router overview sends deployment-specific setup to the CLI, Kubernetes, Gateway API, and standalone-router guides. Router Guide owns topology and worker-set configuration scope; Configuration and Tuning owns configuration precedence and flag behavior; the component pages retain the cost model, filtering, operations, and service-specific details.

#### Boundaries and limitations

This is a documentation reorganization. Routing modes and configuration semantics remain unchanged; the clarified eventless path makes their existing distinction explicit. The Backends tab, including Writing Custom Backends, is unchanged. Full Fern validation remains CI-only because the Fern CLI is not installed locally.

</details>

### Validation
- `git diff --check`
- `python3 .github/workflows/detect_broken_links.py docs/fern/pages/developer-guide/knowledge-base/concepts/system-architecture docs/fern/pages/developer-guide/knowledge-base/modular-components/router docs/fern/pages/kubernetes/kv-aware-routing --format json`
- Parsed `docs/fern/docs.yml` and `docs/fern/index.yml` with PyYAML; verified the 19 Router pages, one configuration reference, URL-neutral sections, redirect, and moved-page relative links.
<!-- codex-pr-description:end -->

## Summary
- add a KV-aware routing architecture page and place it after disaggregated serving
- order Concepts as architecture, disaggregation, KV-aware routing, simulation, fault tolerance, and experimental sidecars
- rename Advanced Customizations to Developing and Extending Dynamo while preserving its URL slug

## Validation
- `python3 .github/workflows/detect_broken_links.py docs/fern/pages/developer-guide/knowledge-base/concepts/system-architecture docs/fern/pages/developer-guide/knowledge-base/modular-components/router --format json`
- `git diff --check`
- Fern CLI unavailable locally; CI will run `fern check` and `fern docs broken-links`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for KV-aware routing, including worker selection, cache state, load balancing, and deployment behavior.
  * Reorganized Router documentation with clearer navigation, decision guides, configuration guidance, and specialized setup pages.
  * Clarified configuration precedence, worker-set consistency, routing fallbacks, and deployment topologies.
  * Updated links and added a redirect to preserve access to previously published documentation URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
