### PR TITLE
fix(global-router): skip model weight downloads

### DIFF
--- a/components/src/dynamo/global_router/__main__.py
+++ b/components/src/dynamo/global_router/__main__.py
@@ -100,6 +100,8 @@ async def _serve_disagg(
         f"{config.namespace}.{config.component_name}.decode_generate"
     )
 
+    # The GlobalRouter only forwards tokenized requests. It needs model metadata
+    # for its deployment cards, but never loads model weights for inference.
     logger.info("Registering as prefill worker...")
     await register_model(
         model_input=ModelInput.Tokens,
@@ -114,6 +116,7 @@ async def _serve_disagg(
         model_name=config.model_name,
         worker_type=WorkerType.Prefill,
         needs=[[WorkerType.Decode]],
+        ignore_weights=True,
     )
     logger.info(
         f"Registered prefill endpoint: {config.namespace}.{config.component_name}.prefill_generate"
@@ -128,6 +131,7 @@ async def _serve_disagg(
         model_name=config.model_name,
         worker_type=WorkerType.Decode,
         needs=[[WorkerType.Prefill]],
+        ignore_weights=True,
     )
     logger.info(
         f"Registered decode endpoint: {config.namespace}.{config.component_name}.decode_generate"
@@ -172,6 +176,8 @@ async def _serve_agg(
         f"{config.namespace}.{config.component_name}.generate"
     )
 
+    # The GlobalRouter only forwards tokenized requests. It needs model metadata
+    # for its deployment card, but never loads model weights for inference.
     logger.info("Registering as agg worker (Chat + Completions)...")
     await register_model(
         model_input=ModelInput.Tokens,
@@ -180,6 +186,7 @@ async def _serve_agg(
         model_path=config.model_name,
         model_name=config.model_name,
         worker_type=WorkerType.Aggregated,
+        ignore_weights=True,
     )
     logger.info(
         f"Registered agg endpoint: {config.namespace}.{config.component_name}.generate"

--- a/components/src/dynamo/global_router/tests/test_model_registration.py
+++ b/components/src/dynamo/global_router/tests/test_model_registration.py
@@ -1,0 +1,71 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+"""Tests for GlobalRouter model registration."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dynamo.global_router import __main__ as global_router_main
+from dynamo.llm import WorkerType
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.parallel,
+    pytest.mark.unit,
+]
+
+
+class FakeEndpoint:
+    async def serve_endpoint(self, handler, **kwargs):
+        return None
+
+
+class FakeRuntime:
+    def endpoint(self, endpoint_name):
+        return FakeEndpoint()
+
+
+@pytest.mark.asyncio
+async def test_disagg_registration_skips_model_weights(monkeypatch):
+    register_model = AsyncMock()
+    monkeypatch.setattr(global_router_main, "register_model", register_model)
+    config = SimpleNamespace(
+        model_name="test-model",
+        namespace="test-namespace",
+        component_name="global-router",
+    )
+    handler = SimpleNamespace(
+        handle_prefill=AsyncMock(),
+        handle_decode=AsyncMock(),
+    )
+
+    await global_router_main._serve_disagg(FakeRuntime(), config, handler)
+
+    assert register_model.await_count == 2
+    prefill_call, decode_call = register_model.await_args_list
+    assert prefill_call.kwargs["worker_type"] == WorkerType.Prefill
+    assert prefill_call.kwargs["ignore_weights"] is True
+    assert decode_call.kwargs["worker_type"] == WorkerType.Decode
+    assert decode_call.kwargs["ignore_weights"] is True
+
+
+@pytest.mark.asyncio
+async def test_agg_registration_skips_model_weights(monkeypatch):
+    register_model = AsyncMock()
+    monkeypatch.setattr(global_router_main, "register_model", register_model)
+    config = SimpleNamespace(
+        model_name="test-model",
+        namespace="test-namespace",
+        component_name="global-router",
+    )
+    handler = SimpleNamespace(handle_generate=AsyncMock())
+
+    await global_router_main._serve_agg(FakeRuntime(), config, handler)
+
+    register_model.assert_awaited_once()
+    assert register_model.await_args.kwargs["worker_type"] == WorkerType.Aggregated
+    assert register_model.await_args.kwargs["ignore_weights"] is True

--- a/components/src/dynamo/global_router/tests/test_model_registration.py
+++ b/components/src/dynamo/global_router/tests/test_model_registration.py
@@ -20,17 +20,24 @@ pytestmark = [
 
 
 class FakeEndpoint:
+    """Endpoint stub that completes serving immediately."""
+
     async def serve_endpoint(self, handler, **kwargs):
+        """Return without starting a network service."""
         return None
 
 
 class FakeRuntime:
+    """Runtime stub that creates in-process endpoints."""
+
     def endpoint(self, endpoint_name):
+        """Return a fake endpoint for any endpoint name."""
         return FakeEndpoint()
 
 
 @pytest.mark.asyncio
 async def test_disagg_registration_skips_model_weights(monkeypatch):
+    """Disaggregated registration retains metadata without model weights."""
     register_model = AsyncMock()
     monkeypatch.setattr(global_router_main, "register_model", register_model)
     config = SimpleNamespace(
@@ -49,12 +56,17 @@ async def test_disagg_registration_skips_model_weights(monkeypatch):
     prefill_call, decode_call = register_model.await_args_list
     assert prefill_call.kwargs["worker_type"] == WorkerType.Prefill
     assert prefill_call.kwargs["ignore_weights"] is True
+    assert prefill_call.kwargs["model_path"] == "test-model"
+    assert prefill_call.kwargs["model_name"] == "test-model"
     assert decode_call.kwargs["worker_type"] == WorkerType.Decode
     assert decode_call.kwargs["ignore_weights"] is True
+    assert decode_call.kwargs["model_path"] == "test-model"
+    assert decode_call.kwargs["model_name"] == "test-model"
 
 
 @pytest.mark.asyncio
 async def test_agg_registration_skips_model_weights(monkeypatch):
+    """Aggregated registration retains metadata without model weights."""
     register_model = AsyncMock()
     monkeypatch.setattr(global_router_main, "register_model", register_model)
     config = SimpleNamespace(
@@ -69,3 +81,5 @@ async def test_agg_registration_skips_model_weights(monkeypatch):
     register_model.assert_awaited_once()
     assert register_model.await_args.kwargs["worker_type"] == WorkerType.Aggregated
     assert register_model.await_args.kwargs["ignore_weights"] is True
+    assert register_model.await_args.kwargs["model_path"] == "test-model"
+    assert register_model.await_args.kwargs["model_name"] == "test-model"


### PR DESCRIPTION
## Summary

- register GlobalRouter deployment cards with `ignore_weights=True` in disaggregated and aggregated modes
- avoid delaying model discovery while a routing-only process downloads inference weights
- add hermetic unit coverage for all three registration paths

## Validation

- `python -m pytest -xvv components/src/dynamo/global_router/tests/test_model_registration.py` (2 passed)
- `python -m pytest -xvv components/src/dynamo/global_router/tests` (77 passed)
- `pre-commit run --files components/src/dynamo/global_router/__main__.py components/src/dynamo/global_router/tests/test_model_registration.py`

## Agentic review

An independent reviewer checked the final diff, `register_model` semantics, regression risk, and test hermeticity and reported no actionable findings.

## Where should the reviewer start?

`components/src/dynamo/global_router/__main__.py` contains the behavior change; `components/src/dynamo/global_router/tests/test_model_registration.py` covers the registration modes.

## Related Issues

- Closes #13636

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved global routing for tokenized requests by allowing model registration without loading model weights.
  * Updated prefill, decode, and aggregated worker registrations to use the appropriate lightweight registration behavior.

* **Tests**
  * Added coverage verifying correct registration for disaggregated and aggregated workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->