### PR TITLE
docs(llm): correct what an undeclared worker_type does to readiness

### DIFF
--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -906,12 +906,15 @@ pub struct ModelDeploymentCard {
     /// Orthogonal to `model_type` (which describes endpoints exposed).
     ///
     /// Every worker must set this explicitly. `None` means the worker has
-    /// not declared a worker type and is treated as misconfiguration:
-    /// `Model::ws_type_and_needs` returns `None`, the serving-readiness
-    /// gate refuses to vouch for the namespace, and `register_model`
-    /// rejects such cards outright. The `Option<>` type and
-    /// `#[serde(default)]` are kept so older cards still deserialize, but
-    /// downstream readers treat them as not-ready.
+    /// not declared a worker type: `Model::ws_type_and_needs` returns
+    /// `None`, which puts the namespace on the cross-version compat path in
+    /// `evaluate_readiness`, and `register_model` rejects the card when
+    /// `require_typed_worker_role` is set. The `Option<>` type and
+    /// `#[serde(default)]` are kept so older cards still deserialize.
+    ///
+    /// Note that the compat path *relaxes* readiness rather than failing it:
+    /// one legacy card disables strict per-type gating for the whole
+    /// namespace, which is then ready as soon as any worker is live.
     #[serde(default)]
     pub worker_type: Option<crate::worker_type::WorkerType>,
 


### PR DESCRIPTION
## Summary

The doc comment on `ModelDeploymentCard::worker_type` describes what happens when a worker does not declare one:

> `Model::ws_type_and_needs` returns `None`, the serving-readiness gate refuses to vouch for the namespace, and `register_model` rejects such cards outright.

The first clause is right. The other two are not, and the readiness one is wrong in the direction that matters.

`evaluate_readiness` returns early as soon as any unit is legacy:

```rust
// COMPAT branch: a legacy card disables strict gating; the disaggregated
// worker types can't be reconstructed, so ready iff any worker is live.
if has_legacy {
    return ReadinessEval {
        ready: has_live_worker,
        ...
    };
}
```

So one undeclared card does not make the namespace unready. It *relaxes* the gate: strict per-type checking is skipped for the whole namespace, which is then ready the moment any worker is live. `evaluate_namespace` feeds every untyped card in as `ReadinessUnit { worker_type: None, .. }`, and `is_workers_ready`'s own comment says the same thing, that a legacy card "bypasses the strict check".

The `register_model` claim is conditional rather than outright:

```rust
if require_typed_worker_role && card.worker_type.is_none() {
```

Reading the old comment, someone reasoning about whether a pre-`worker_type` worker can take traffic would conclude it cannot. It can, and it also switches its namespace off strict gating. That is worth stating plainly next to the field, because the field is the thing people read when deciding whether an old binary is safe to leave in a namespace.

Comment only, no behaviour change.

## Summary of change

Replaces the two inaccurate clauses with what the code does, and adds one note that the compat path loosens readiness rather than failing it.

## Validation

`cargo build -p dynamo-llm --no-default-features` clean, `cargo fmt` clean, `pre-commit run --files lib/llm/src/model_card.rs` clean.

Verified against the code rather than against the neighbouring comments, since two of them disagreed and that is what prompted this:

- `lib/llm/src/discovery/readiness.rs` `evaluate_readiness`, the `if has_legacy` early return
- `lib/llm/src/discovery/model.rs` `evaluate_namespace`, which maps an untyped card to `worker_type: None`
- `lib/llm/src/discovery/watcher.rs` `validate_selector_worker_role`, gated on `require_typed_worker_role`

No test accompanies this because nothing executable changed; the behaviour it now describes is already covered by the readiness tests in `discovery/readiness.rs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified behavior for deployments with missing worker types during cross-version compatibility checks.
  * Documented that typed-role registration may still reject these deployments.
  * Clarified readiness behavior when relying on any live worker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->