### PR TITLE
perf(trtllm): disable engine perf metrics by default, gate request metrics on KV publishing

### DIFF
--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -512,20 +512,21 @@ async def init_llm_worker(
         )
     default_sampling_params = SamplingParams()
 
-    # Per-request perf metrics feed `prompt_tokens_details.cached_tokens` and the
-    # KV-transfer histograms, but TRT-LLM fills `request_perf_metrics` on every
-    # decode step while Dynamo only reads it on finish. Follow the engine flag
-    # instead of forcing it on: `arg_map` is fully resolved here, so this also
-    # honours `--trtllm.return_perf_metrics false` and `override_engine_args`.
-    request_perf_metrics = bool(arg_map.get("return_perf_metrics", False))
+    # Follow the engine flag rather than forcing this on. The only reader of
+    # `request_perf_metrics` in this backend is the KV-transfer histogram in
+    # HandlerBase, whose collector is built only when publish_events_and_metrics
+    # is set -- so with publishing off nothing reads it. `cached_tokens` comes
+    # from `res.cached_tokens`, which is independent of these flags.
+    #
+    # `arg_map` is fully resolved here (extra/override engine args already
+    # merged), so this honours `--trtllm.return_perf_metrics` too. Compare with
+    # `is True` rather than `bool()`: override_engine_args arrives via
+    # json.loads, so a JSON string "false" would be truthy while pydantic
+    # coerces it to False. Erring toward False is safe -- TRT-LLM computes
+    # `sampling or engine`, so an engine-level True still turns it back on.
     if hasattr(default_sampling_params, "return_perf_metrics"):
-        default_sampling_params.return_perf_metrics = request_perf_metrics
-    if not request_perf_metrics:
-        logging.info(
-            "Per-request perf metrics are disabled (return_perf_metrics=False); "
-            "usage.prompt_tokens_details.cached_tokens will not be reported. "
-            "Enable --publish-kv-events, or set return_perf_metrics: true in "
-            "extra engine args, to turn them back on."
+        default_sampling_params.return_perf_metrics = (
+            arg_map.get("return_perf_metrics") is True
         )
     model_input = ModelInput.Tokens
 

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -353,7 +353,14 @@ async def init_llm_worker(
         "max_seq_len": config.max_seq_len,
         "max_beam_width": config.max_beam_width,
         "max_batch_size": config.max_batch_size,
-        "return_perf_metrics": config.publish_events_and_metrics,
+        # Engine-level perf metrics turn on the PyExecutor detailed per-step timing
+        # collector: growing `step_metrics` / `ctx_chunk_metrics` lists that get
+        # attached to the final response, then pickled for the rank gather and again
+        # for worker->proxy IPC under attention DP. Nothing in Dynamo reads
+        # `time_breakdown_metrics`, so keep this off unconditionally. An explicit
+        # `return_perf_metrics: true` in extra/override engine args still wins --
+        # those are merged into `arg_map` after this dict is built.
+        "return_perf_metrics": False,
         # enable_iter_perf_stats is required for PyTorch backend to compute iteration-level
         # stats (KV cache utilization, hit rate). TensorRT backend always has this enabled.
         # See TRT-LLM PR #11243: MetricsCollector.log_iteration_stats() needs these stats.
@@ -512,16 +519,18 @@ async def init_llm_worker(
         )
     default_sampling_params = SamplingParams()
 
-    # Follow the engine flag: with publishing off, nothing reads
-    # `request_perf_metrics` -- its one consumer, the KV-transfer histogram, is
-    # publish-gated. `cached_tokens` is unaffected (it reads `res.cached_tokens`).
-    # `is True` guards against override_engine_args passing the JSON string
-    # "false", which `bool()` would accept; under-reading is safe because
-    # TRT-LLM computes `sampling or engine`.
+    # Request-level perf metrics are a *separate* switch that merely shares the
+    # engine flag's name. Tie it to KV-event publishing, not to the engine flag
+    # (now always False above): its one consumer is the KV-transfer histogram in
+    # HandlerBase, whose AdditionalMetricsCollector is built only under
+    # `if config.publish_events_and_metrics`. So with publishing off nothing reads
+    # `request_perf_metrics` and filling it is pure waste. `cached_tokens` is
+    # unaffected either way -- it comes from `res.cached_tokens`, not from
+    # `request_perf_metrics`. An explicit engine-level override still forces these
+    # back on: TRT-LLM resolves the effective value as `sampling or engine` in
+    # `LLM._prepare_sampling_params`.
     if hasattr(default_sampling_params, "return_perf_metrics"):
-        default_sampling_params.return_perf_metrics = (
-            arg_map.get("return_perf_metrics") is True
-        )
+        default_sampling_params.return_perf_metrics = config.publish_events_and_metrics
     model_input = ModelInput.Tokens
 
     # Set model type based on disaggregation mode. Prefill and encode workers

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -512,18 +512,12 @@ async def init_llm_worker(
         )
     default_sampling_params = SamplingParams()
 
-    # Follow the engine flag rather than forcing this on. The only reader of
-    # `request_perf_metrics` in this backend is the KV-transfer histogram in
-    # HandlerBase, whose collector is built only when publish_events_and_metrics
-    # is set -- so with publishing off nothing reads it. `cached_tokens` comes
-    # from `res.cached_tokens`, which is independent of these flags.
-    #
-    # `arg_map` is fully resolved here (extra/override engine args already
-    # merged), so this honours `--trtllm.return_perf_metrics` too. Compare with
-    # `is True` rather than `bool()`: override_engine_args arrives via
-    # json.loads, so a JSON string "false" would be truthy while pydantic
-    # coerces it to False. Erring toward False is safe -- TRT-LLM computes
-    # `sampling or engine`, so an engine-level True still turns it back on.
+    # Follow the engine flag: with publishing off, nothing reads
+    # `request_perf_metrics` -- its one consumer, the KV-transfer histogram, is
+    # publish-gated. `cached_tokens` is unaffected (it reads `res.cached_tokens`).
+    # `is True` guards against override_engine_args passing the JSON string
+    # "false", which `bool()` would accept; under-reading is safe because
+    # TRT-LLM computes `sampling or engine`.
     if hasattr(default_sampling_params, "return_perf_metrics"):
         default_sampling_params.return_perf_metrics = (
             arg_map.get("return_perf_metrics") is True

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -357,9 +357,10 @@ async def init_llm_worker(
         # collector: growing `step_metrics` / `ctx_chunk_metrics` lists that get
         # attached to the final response, then pickled for the rank gather and again
         # for worker->proxy IPC under attention DP. Nothing in Dynamo reads
-        # `time_breakdown_metrics`, so keep this off unconditionally. An explicit
-        # `return_perf_metrics: true` in extra/override engine args still wins --
-        # those are merged into `arg_map` after this dict is built.
+        # `time_breakdown_metrics`, so default it off rather than tying it to
+        # publishing. This is a default, not a hard disable: `--extra-engine-args`
+        # and `--override-engine-args` are merged over `arg_map` below and can set
+        # it back to true for custom instrumentation.
         "return_perf_metrics": False,
         # enable_iter_perf_stats is required for PyTorch backend to compute iteration-level
         # stats (KV cache utilization, hit rate). TensorRT backend always has this enabled.
@@ -521,8 +522,8 @@ async def init_llm_worker(
 
     # Request-level perf metrics are a *separate* switch that merely shares the
     # engine flag's name. Tie it to KV-event publishing, not to the engine flag
-    # (now always False above): its one consumer is the KV-transfer histogram in
-    # HandlerBase, whose AdditionalMetricsCollector is built only under
+    # (which now defaults to False above): its one consumer is the KV-transfer
+    # histogram in HandlerBase, whose AdditionalMetricsCollector is built only under
     # `if config.publish_events_and_metrics`. So with publishing off nothing reads
     # `request_perf_metrics` and filling it is pure waste. `cached_tokens` is
     # unaffected either way -- it comes from `res.cached_tokens`, not from

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -512,9 +512,21 @@ async def init_llm_worker(
         )
     default_sampling_params = SamplingParams()
 
-    # Enable perf metrics so prompt_tokens_details can be returned
+    # Per-request perf metrics feed `prompt_tokens_details.cached_tokens` and the
+    # KV-transfer histograms, but TRT-LLM fills `request_perf_metrics` on every
+    # decode step while Dynamo only reads it on finish. Follow the engine flag
+    # instead of forcing it on: `arg_map` is fully resolved here, so this also
+    # honours `--trtllm.return_perf_metrics false` and `override_engine_args`.
+    request_perf_metrics = bool(arg_map.get("return_perf_metrics", False))
     if hasattr(default_sampling_params, "return_perf_metrics"):
-        default_sampling_params.return_perf_metrics = True
+        default_sampling_params.return_perf_metrics = request_perf_metrics
+    if not request_perf_metrics:
+        logging.info(
+            "Per-request perf metrics are disabled (return_perf_metrics=False); "
+            "usage.prompt_tokens_details.cached_tokens will not be reported. "
+            "Enable --publish-kv-events, or set return_perf_metrics: true in "
+            "extra engine args, to turn them back on."
+        )
     model_input = ModelInput.Tokens
 
     # Set model type based on disaggregation mode. Prefill and encode workers

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/observability.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/observability.md
@@ -211,8 +211,9 @@ TensorRT-LLM provides extensive performance data beyond the basic Prometheus met
 
 - **Prometheus Integration**: Uses the `MetricsCollector` class from `tensorrt_llm.metrics` (see [collector.py](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/metrics/collector.py))
 - **Dynamo Integration**: Uses `register_engine_metrics_callback()` function with `metric_prefix_filter=["trtllm_"]`
-- **Engine Configuration**: `return_perf_metrics` set to `True` when `--publish-events-and-metrics` is enabled
-- **Per-request Metrics**: The default `SamplingParams.return_perf_metrics` follows the resolved engine setting, so requests only ask TensorRT-LLM to fill `request_perf_metrics` when the engine was built to collect it. Token usage reporting, including `usage.prompt_tokens_details.cached_tokens`, is unaffected — it comes from the engine's own cached-token count.
+- **Engine Configuration**: `LlmArgs.return_perf_metrics` is always `False`. It enables TensorRT-LLM's detailed per-step timing collector, whose `time_breakdown_metrics` payload Dynamo never reads, and which costs measurable throughput. Set `return_perf_metrics: true` in extra or override engine args to turn it back on for custom instrumentation.
+- **Per-request Metrics**: `SamplingParams.return_perf_metrics` is a separate switch that shares the same name. It follows `--publish-kv-events`, because its only consumer — the KV-transfer histogram — is registered only when publishing is enabled. Token usage reporting, including `usage.prompt_tokens_details.cached_tokens`, is unaffected either way: it comes from the engine's own cached-token count, not from `request_perf_metrics`.
+- **Request Arrival Timestamp**: With engine-level metrics off, TensorRT-LLM stamps request arrival during C++ request construction rather than at Python submission, so E2E latency, TTFT, and queue time exclude some submission and IPC time. Other request timing fields keep their existing anchors.
 - **Initialization**: Metrics appear after TensorRT-LLM engine initialization completes
 - **Metadata**: `MetricsCollector` initialized with model metadata (model name, engine type)
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/observability.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/observability.md
@@ -211,9 +211,9 @@ TensorRT-LLM provides extensive performance data beyond the basic Prometheus met
 
 - **Prometheus Integration**: Uses the `MetricsCollector` class from `tensorrt_llm.metrics` (see [collector.py](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/metrics/collector.py))
 - **Dynamo Integration**: Uses `register_engine_metrics_callback()` function with `metric_prefix_filter=["trtllm_"]`
-- **Engine Configuration**: `LlmArgs.return_perf_metrics` is always `False`. It enables TensorRT-LLM's detailed per-step timing collector, whose `time_breakdown_metrics` payload Dynamo never reads, and which costs measurable throughput. Set `return_perf_metrics: true` in extra or override engine args to turn it back on for custom instrumentation.
+- **Engine Configuration**: `LlmArgs.return_perf_metrics` defaults to `False`. It enables TensorRT-LLM's detailed per-step timing collector, whose `time_breakdown_metrics` payload Dynamo never reads, and which costs measurable throughput. Set `return_perf_metrics: true` in `--extra-engine-args` or `--override-engine-args` to re-enable engine-level collection for custom worker instrumentation.
 - **Per-request Metrics**: `SamplingParams.return_perf_metrics` is a separate switch that shares the same name. It follows `--publish-kv-events`, because its only consumer — the KV-transfer histogram — is registered only when publishing is enabled. Token usage reporting, including `usage.prompt_tokens_details.cached_tokens`, is unaffected either way: it comes from the engine's own cached-token count, not from `request_perf_metrics`.
-- **Request Arrival Timestamp**: With engine-level metrics off, TensorRT-LLM stamps request arrival during C++ request construction rather than at Python submission, so E2E latency, TTFT, and queue time exclude some submission and IPC time. Other request timing fields keep their existing anchors.
+- **Request Arrival Timestamp**: When engine-level metrics are off, TensorRT-LLM stamps request arrival during C++ request construction rather than at Python submission, so E2E latency, TTFT, and queue time exclude some submission and IPC time. Other request timing fields keep their existing anchors.
 - **Initialization**: Metrics appear after TensorRT-LLM engine initialization completes
 - **Metadata**: `MetricsCollector` initialized with model metadata (model name, engine type)
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/observability.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/observability.md
@@ -212,7 +212,7 @@ TensorRT-LLM provides extensive performance data beyond the basic Prometheus met
 - **Prometheus Integration**: Uses the `MetricsCollector` class from `tensorrt_llm.metrics` (see [collector.py](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/metrics/collector.py))
 - **Dynamo Integration**: Uses `register_engine_metrics_callback()` function with `metric_prefix_filter=["trtllm_"]`
 - **Engine Configuration**: `return_perf_metrics` set to `True` when `--publish-events-and-metrics` is enabled
-- **Per-request Metrics**: The default `SamplingParams.return_perf_metrics` follows the resolved engine setting, so requests only ask TensorRT-LLM to fill `request_perf_metrics` when the engine was built to collect it. With it disabled, `usage.prompt_tokens_details.cached_tokens` is not reported.
+- **Per-request Metrics**: The default `SamplingParams.return_perf_metrics` follows the resolved engine setting, so requests only ask TensorRT-LLM to fill `request_perf_metrics` when the engine was built to collect it. Token usage reporting, including `usage.prompt_tokens_details.cached_tokens`, is unaffected — it comes from the engine's own cached-token count.
 - **Initialization**: Metrics appear after TensorRT-LLM engine initialization completes
 - **Metadata**: `MetricsCollector` initialized with model metadata (model name, engine type)
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/observability.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/observability.md
@@ -212,6 +212,7 @@ TensorRT-LLM provides extensive performance data beyond the basic Prometheus met
 - **Prometheus Integration**: Uses the `MetricsCollector` class from `tensorrt_llm.metrics` (see [collector.py](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/metrics/collector.py))
 - **Dynamo Integration**: Uses `register_engine_metrics_callback()` function with `metric_prefix_filter=["trtllm_"]`
 - **Engine Configuration**: `return_perf_metrics` set to `True` when `--publish-events-and-metrics` is enabled
+- **Per-request Metrics**: The default `SamplingParams.return_perf_metrics` follows the resolved engine setting, so requests only ask TensorRT-LLM to fill `request_perf_metrics` when the engine was built to collect it. With it disabled, `usage.prompt_tokens_details.cached_tokens` is not reported.
 - **Initialization**: Metrics appear after TensorRT-LLM engine initialization completes
 - **Metadata**: `MetricsCollector` initialized with model metadata (model name, engine type)
 


### PR DESCRIPTION
## Summary

Combines this PR with #13869. Both TensorRT-LLM `return_perf_metrics` switches are handled, each on its own merits, per @jthomson04's proposal in the review discussion:

1. **Engine-level `LlmArgs.return_perf_metrics` → `False` by default** (from #13869). Previously it followed `--publish-kv-events`. Explicit `--extra-engine-args` / `--override-engine-args` still re-enable it.
2. **Request-level `SamplingParams.return_perf_metrics` → follows `--publish-kv-events`.** Previously hardcoded `True`.

This replaces the original framing of this PR, which incorrectly derived the request-level flag from the engine-level one.

## Why

The two flags share a name but are unrelated, which is what made this confusing.

**Engine-level** turns on the PyExecutor detailed per-step timing collector. It builds growing `step_metrics` / `ctx_chunk_metrics` lists, attaches the whole `time_breakdown_metrics` payload to the final response, and under attention DP that variable-size payload is pickled for the rank gather and again for worker→proxy IPC. Nothing in Dynamo reads `time_breakdown_metrics` — not metrics, traces, logs, responses, or `nvext.engine_data`. This is the path behind the throughput regression reported in #13869; the analysis and the change are @jthomson04's, carried here with co-authorship.

**Request-level** is what Dynamo actually consumes, but only in one place: the KV-transfer histogram in `HandlerBase` (`handler_base.py:1398`). Its `AdditionalMetricsCollector` is constructed only under `if config.publish_events_and_metrics:` in `llm_worker.py`. So when publishing is off, `request_perf_metrics` is filled on every request and read by nobody.

Tying request-level to `--publish-kv-events` rather than to the engine flag keeps that observability intact exactly when it is consumed, and drops the bookkeeping when it is not.

### The engine flag is a default, not a hard disable

`arg_map` is built with `return_perf_metrics: False`, then `--extra-engine-args` (YAML) and `--override-engine-args` (JSON) are merged over it at `llm_worker.py:389-402`. Setting `return_perf_metrics: true` through either flag restores engine-level collection for custom worker instrumentation, exactly as #13869 intended.

That override also reaches the request level: `LLM._prepare_sampling_params` resolves the effective value as `sampling_params.return_perf_metrics or self.args.return_perf_metrics` (`llmapi/llm.py:1500`), so one override turns both levels back on.

### `cached_tokens` is not affected by either switch

An earlier revision of this PR claimed disabling the request-level flag would drop `usage.prompt_tokens_details.cached_tokens`. That was wrong. Verified against TensorRT-LLM `main`:

- `tensorrt_llm/executor/result.py` — `GenerationResultBase._handle_response` does `self.cached_tokens = getattr(response_result, "cached_tokens", 0)` unconditionally, not off `request_perf_metrics`.
- `tensorrt_llm/_torch/pyexecutor/llm_request.py` — `LlmRequest.cached_tokens` is a plain property/setter guarded only by `_cached_tokens_set`.
- Dynamo reads `res.cached_tokens` directly (`handler_base.py:1363`), never `res.request_perf_metrics`.

## Telemetry impact

One timing semantic changes when engine-level metrics are off: TensorRT-LLM stamps request arrival during C++ request construction rather than at Python submission (`llmapi/llm.py:827`), so E2E latency, TTFT, and request queue time exclude some Python submission and IPC time. Other request timing fields keep their existing anchors. Documented in the observability page.

`enable_iter_perf_stats` is unchanged — it still follows `--publish-kv-events` and is what `MetricsCollector.log_iteration_stats()` needs for KV cache utilization and hit rate.

## Validation

- `pre-commit run --files components/src/dynamo/trtllm/workers/llm_worker.py docs/.../observability.md` — all hooks pass.
- No unit test asserts on either `return_perf_metrics` value (`git grep return_perf_metrics -- components/src/dynamo/trtllm/tests tests` returns nothing), so no test needed updating.
- Not benchmarked in this PR; the throughput claim rests on the analysis in #13869.

## Where should the reviewer start?

`components/src/dynamo/trtllm/workers/llm_worker.py` — the two hunks are the whole change. The comment at each site records why the flags are decoupled.

## Related

- Supersedes #13869, whose engine-level change is included here with `Co-authored-by`. #13869 can close once this lands, or this can be reduced to the request-level line if #13869 goes first — @jthomson04's call.

## Related Issues

- [x] Confirmed - no related issue
