### PR TITLE
feat(vllm): add Python sidecar launcher

### DIFF
--- a/components/src/dynamo/vllm/sidecar.py
+++ b/components/src/dynamo/vllm/sidecar.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python launcher for Dynamo's native vLLM sidecar."""
+
+import sys
+
+from dynamo._core import backend as _backend
+from dynamo.runtime.logging import configure_dynamo_logging
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the Dynamo sidecar against a vLLM gRPC endpoint."""
+    configure_dynamo_logging(service_name="dynamo.vllm.sidecar")
+    _backend._run_vllm_sidecar(sys.argv[1:] if argv is None else argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1989,6 +1989,7 @@ dependencies = [
  "dynamo-parsers",
  "dynamo-runtime",
  "dynamo-sglang-sidecar",
+ "dynamo-vllm-sidecar",
  "dynamo-worker-selection-policy-catalog",
  "futures",
  "once_cell",
@@ -2198,6 +2199,28 @@ name = "dynamo-truthy"
 version = "1.5.0"
 dependencies = [
  "anyhow",
+]
+
+[[package]]
+name = "dynamo-vllm-sidecar"
+version = "1.5.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "clap",
+ "dynamo-backend-common",
+ "dynamo-sidecar-common",
+ "futures",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
+ "tonic-health",
+ "tracing",
 ]
 
 [[package]]
@@ -8073,6 +8096,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -8292,6 +8316,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb87334d340313fefa513b6e60794d44a86d5f039b523229c99c323e4e19ca4b"
+dependencies = [
+ "prost 0.13.5",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.13.1",
 ]
 
 [[package]]

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -65,6 +65,7 @@ dynamo-mocker = { path = "../../mocker" }
 dynamo-parsers = { version = "8.1.0" }
 dynamo-backend-common = { path = "../../backend-common" }
 dynamo-sglang-sidecar = { path = "../../sidecar/sglang" }
+dynamo-vllm-sidecar = { path = "../../sidecar/vllm" }
 
 anyhow = { version = "1" }
 async-stream = { version = "0.3" }

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -52,6 +52,7 @@ pub fn add_to_module(parent: &Bound<'_, PyModule>) -> PyResult<()> {
     let py = parent.py();
     let m = PyModule::new(py, "backend")?;
     m.add_function(wrap_pyfunction!(_run_sglang_sidecar, &m)?)?;
+    m.add_function(wrap_pyfunction!(_run_vllm_sidecar, &m)?)?;
     m.add_class::<DisaggregationMode>()?;
     m.add_class::<EngineConfig>()?;
     m.add_class::<LlmRegistration>()?;
@@ -90,6 +91,32 @@ fn _run_sglang_sidecar(py: Python<'_>, argv: Option<Vec<String>>) -> PyResult<()
         .allow_threads(move || {
             dynamo_sglang_sidecar::SglangSidecarEngine::from_args(Some(cli_argv))
         })
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
+
+    py.allow_threads(move || dynamo_backend_common::run(Arc::new(engine), config))
+        .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))
+}
+
+const VLLM_SIDECAR_PROGRAM_NAME: &str = "dynamo-vllm-sidecar";
+
+fn vllm_sidecar_argv(argv: Vec<String>) -> Vec<String> {
+    let mut cli_argv = Vec::with_capacity(argv.len() + 1);
+    cli_argv.push(VLLM_SIDECAR_PROGRAM_NAME.to_string());
+    cli_argv.extend(argv);
+    cli_argv
+}
+
+/// Run the native vLLM sidecar in the current process.
+///
+/// Python's module launcher passes only option arguments, while clap's
+/// `try_parse_from` expects the program name at index zero. Add that stable
+/// name here so Python callers use ordinary `sys.argv[1:]` semantics.
+#[pyfunction]
+#[pyo3(signature = (argv=None))]
+fn _run_vllm_sidecar(py: Python<'_>, argv: Option<Vec<String>>) -> PyResult<()> {
+    let cli_argv = vllm_sidecar_argv(argv.unwrap_or_default());
+    let (engine, config) = py
+        .allow_threads(move || dynamo_vllm_sidecar::VllmSidecarEngine::from_args(Some(cli_argv)))
         .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
 
     py.allow_threads(move || dynamo_backend_common::run(Arc::new(engine), config))

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -3336,6 +3336,11 @@ class backend:
         """Run the native SGLang sidecar with CLI-style arguments."""
         ...
 
+    @staticmethod
+    def _run_vllm_sidecar(argv: Optional[List[str]] = None) -> None:
+        """Run the native vLLM sidecar with CLI-style arguments."""
+        ...
+
     class DisaggregationMode:
         # Mirrors `dynamo_backend_common::DisaggregationMode`. Engines consult
         # this on the WorkerConfig to switch their per-mode protocol behavior;

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -6,9 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 # vLLM sidecar
 
 > [!WARNING]
-> **Experimental.** This sidecar and its deployment examples are experimental
-> and not yet packaged for distribution. The manifests, flags, and behavior may
-> change without notice.
+> **Experimental.** This sidecar and its deployment examples are experimental.
+> The Python launcher ships in the `ai-dynamo` and `ai-dynamo-runtime` wheel
+> pair, but the container image is not yet packaged for distribution. The
+> manifests, flags, and behavior may change without notice.
 
 `dynamo-vllm-sidecar` connects a Dynamo worker to vLLM's native gRPC services:
 
@@ -16,7 +17,8 @@ SPDX-License-Identifier: Apache-2.0
 - `vllm.Control` for model and server discovery
 - Standard gRPC health for startup readiness
 
-It is a standalone Rust executable.
+It is a standalone Rust executable and is also compiled into
+`ai-dynamo-runtime` for the importable `dynamo.vllm.sidecar` launcher.
 
 ## Supported
 
@@ -55,6 +57,13 @@ Start the Dynamo worker explicitly:
 
 ```bash
 dynamo-vllm-sidecar \
+  --grpc-endpoint 127.0.0.1:50051
+```
+
+After installing `ai-dynamo`, the Python module runs the same native worker:
+
+```bash
+python -m dynamo.vllm.sidecar \
   --grpc-endpoint 127.0.0.1:50051
 ```
 


### PR DESCRIPTION
## Overview:

Make the native vLLM sidecar runnable from an `ai-dynamo` wheel installation through `python -m dynamo.vllm.sidecar`, including normal CLI help behavior.

## Summary:

- Add the wheel-installed `dynamo.vllm.sidecar` Python launcher.
- Link the native vLLM sidecar into `ai-dynamo-runtime` and expose it through the PyO3 backend module.
- Preserve Clap help, version, and argument-error exit codes at the Python boundary.
- Update the vLLM sidecar documentation.

## Details:

The Python module forwards CLI arguments to `_run_vllm_sidecar`. The native binding supplies the Clap program name, parses through the typed startup-error path from #13929, constructs `VllmSidecarEngine`, releases the GIL, and runs the existing unified worker lifecycle.

This PR is stacked on #13929 so the shared Python CLI exit handling can be reviewed once.

## Where should the reviewer start?

- `components/src/dynamo/vllm/sidecar.py` for the Python module UX.
- `lib/bindings/python/rust/backend.rs` for the native launcher boundary.
- `lib/sidecar/vllm/src/engine.rs` for typed argument parsing.

## Related Issues

Depends on #13929.

## Validation:

- `cargo check --manifest-path lib/bindings/python/Cargo.toml --lib`
- `cargo fmt --manifest-path lib/bindings/python/Cargo.toml --check`
- `cargo fmt --all --check`
- `python3 -m py_compile components/src/dynamo/vllm/sidecar.py tests/wheels/smoke_install.py`
- locally built and installed `ai-dynamo-runtime` with Maturin
- `python -m dynamo.vllm.sidecar --help` exits 0 and prints `Usage: dynamo-vllm-sidecar`
- `git diff --check`
