### PR TITLE
feat(trtllm): add Python sidecar launcher

### DIFF
--- a/components/src/dynamo/trtllm/sidecar.py
+++ b/components/src/dynamo/trtllm/sidecar.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python launcher for Dynamo's native TensorRT-LLM sidecar."""
+
+import sys
+
+from dynamo._core import backend as _backend
+from dynamo.runtime.logging import configure_dynamo_logging
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the Dynamo sidecar against a TensorRT-LLM gRPC endpoint."""
+    configure_dynamo_logging(service_name="dynamo.trtllm.sidecar")
+    _backend._run_trtllm_sidecar(sys.argv[1:] if argv is None else argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1990,6 +1990,7 @@ dependencies = [
  "dynamo-runtime",
  "dynamo-sglang-sidecar",
  "dynamo-sidecar-common",
+ "dynamo-trtllm-sidecar",
  "dynamo-vllm-sidecar",
  "dynamo-worker-selection-policy-catalog",
  "futures",
@@ -2193,6 +2194,26 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
  "xxhash-rust",
+]
+
+[[package]]
+name = "dynamo-trtllm-sidecar"
+version = "1.5.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "clap",
+ "dynamo-backend-common",
+ "dynamo-sidecar-common",
+ "futures",
+ "prost 0.13.5",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
+ "tracing",
 ]
 
 [[package]]

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -66,6 +66,7 @@ dynamo-parsers = { version = "8.1.0" }
 dynamo-backend-common = { path = "../../backend-common" }
 dynamo-sidecar-common = { path = "../../sidecar/common" }
 dynamo-sglang-sidecar = { path = "../../sidecar/sglang" }
+dynamo-trtllm-sidecar = { path = "../../sidecar/trtllm" }
 dynamo-vllm-sidecar = { path = "../../sidecar/vllm" }
 
 anyhow = { version = "1" }

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -154,8 +154,8 @@ fn trtllm_sidecar_argv(argv: Vec<String>) -> Vec<String> {
 fn _run_trtllm_sidecar(py: Python<'_>, argv: Option<Vec<String>>) -> PyResult<()> {
     let cli_argv = trtllm_sidecar_argv(argv.unwrap_or_default());
     let (engine, config) = py
-        .allow_threads(move || dynamo_trtllm_sidecar::TrtllmSidecarEngine::from_args(cli_argv))
-        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
+        .allow_threads(move || dynamo_trtllm_sidecar::TrtllmSidecarEngine::try_from_args(cli_argv))
+        .map_err(sidecar_startup_to_pyerr)?;
 
     py.allow_threads(move || dynamo_backend_common::run(Arc::new(engine), config))
         .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -65,6 +65,7 @@ pub fn add_to_module(parent: &Bound<'_, PyModule>) -> PyResult<()> {
     let py = parent.py();
     let m = PyModule::new(py, "backend")?;
     m.add_function(wrap_pyfunction!(_run_sglang_sidecar, &m)?)?;
+    m.add_function(wrap_pyfunction!(_run_trtllm_sidecar, &m)?)?;
     m.add_function(wrap_pyfunction!(_run_vllm_sidecar, &m)?)?;
     m.add_class::<DisaggregationMode>()?;
     m.add_class::<EngineConfig>()?;
@@ -129,6 +130,32 @@ fn _run_vllm_sidecar(py: Python<'_>, argv: Option<Vec<String>>) -> PyResult<()> 
     let (engine, config) = py
         .allow_threads(move || dynamo_vllm_sidecar::VllmSidecarEngine::try_from_args(cli_argv))
         .map_err(sidecar_startup_to_pyerr)?;
+
+    py.allow_threads(move || dynamo_backend_common::run(Arc::new(engine), config))
+        .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))
+}
+
+const TRTLLM_SIDECAR_PROGRAM_NAME: &str = "dynamo-trtllm-sidecar";
+
+fn trtllm_sidecar_argv(argv: Vec<String>) -> Vec<String> {
+    let mut cli_argv = Vec::with_capacity(argv.len() + 1);
+    cli_argv.push(TRTLLM_SIDECAR_PROGRAM_NAME.to_string());
+    cli_argv.extend(argv);
+    cli_argv
+}
+
+/// Run the native TensorRT-LLM sidecar in the current process.
+///
+/// Python's module launcher passes only option arguments, while clap's
+/// `try_parse_from` expects the program name at index zero. Add that stable
+/// name here so Python callers use ordinary `sys.argv[1:]` semantics.
+#[pyfunction]
+#[pyo3(signature = (argv=None))]
+fn _run_trtllm_sidecar(py: Python<'_>, argv: Option<Vec<String>>) -> PyResult<()> {
+    let cli_argv = trtllm_sidecar_argv(argv.unwrap_or_default());
+    let (engine, config) = py
+        .allow_threads(move || dynamo_trtllm_sidecar::TrtllmSidecarEngine::from_args(cli_argv))
+        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
 
     py.allow_threads(move || dynamo_backend_common::run(Arc::new(engine), config))
         .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -154,7 +154,7 @@ fn trtllm_sidecar_argv(argv: Vec<String>) -> Vec<String> {
 fn _run_trtllm_sidecar(py: Python<'_>, argv: Option<Vec<String>>) -> PyResult<()> {
     let cli_argv = trtllm_sidecar_argv(argv.unwrap_or_default());
     let (engine, config) = py
-        .allow_threads(move || dynamo_trtllm_sidecar::TrtllmSidecarEngine::from_args(cli_argv))
+        .allow_threads(move || dynamo_trtllm_sidecar::TrtllmSidecarEngine::try_from_args(cli_argv))
         .map_err(sidecar_startup_to_pyerr)?;
 
     py.allow_threads(move || dynamo_backend_common::run(Arc::new(engine), config))

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -154,7 +154,7 @@ fn trtllm_sidecar_argv(argv: Vec<String>) -> Vec<String> {
 fn _run_trtllm_sidecar(py: Python<'_>, argv: Option<Vec<String>>) -> PyResult<()> {
     let cli_argv = trtllm_sidecar_argv(argv.unwrap_or_default());
     let (engine, config) = py
-        .allow_threads(move || dynamo_trtllm_sidecar::TrtllmSidecarEngine::try_from_args(cli_argv))
+        .allow_threads(move || dynamo_trtllm_sidecar::TrtllmSidecarEngine::from_args(cli_argv))
         .map_err(sidecar_startup_to_pyerr)?;
 
     py.allow_threads(move || dynamo_backend_common::run(Arc::new(engine), config))

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -3337,6 +3337,11 @@ class backend:
         ...
 
     @staticmethod
+    def _run_trtllm_sidecar(argv: Optional[List[str]] = None) -> None:
+        """Run the native TensorRT-LLM sidecar with CLI-style arguments."""
+        ...
+
+    @staticmethod
     def _run_vllm_sidecar(argv: Optional[List[str]] = None) -> None:
         """Run the native vLLM sidecar with CLI-style arguments."""
         ...

--- a/lib/sidecar/trtllm/README.md
+++ b/lib/sidecar/trtllm/README.md
@@ -6,15 +6,17 @@ SPDX-License-Identifier: Apache-2.0
 # TensorRT-LLM sidecar
 
 > [!WARNING]
-> **Experimental.** This sidecar and its deployment example are experimental and
-> not yet packaged for distribution (see [Packaging](#packaging)). The manifest,
-> flags, and behavior may change without notice.
+> **Experimental.** This sidecar and its deployment example are experimental.
+> The Python launcher ships in the `ai-dynamo` and `ai-dynamo-runtime` wheel
+> pair, but the container image is not yet packaged for distribution. The
+> manifest, flags, and behavior may change without notice.
 
 `dynamo-trtllm-sidecar` connects a Dynamo worker to TensorRT-LLM's native
 `trtllm.TrtllmService` gRPC `Generate` service. It is a standalone Rust
-executable composed with `dynamo_backend_common::run`: TensorRT-LLM runs as its
-own process while the sidecar owns Dynamo worker registration, request
-conversion, transport, cancellation, and abort.
+executable composed with `dynamo_backend_common::run` and is also compiled into
+`ai-dynamo-runtime` for the importable `dynamo.trtllm.sidecar` launcher.
+TensorRT-LLM runs as its own process while the sidecar owns Dynamo worker
+registration, request conversion, transport, cancellation, and abort.
 
 ## Supported
 
@@ -46,6 +48,14 @@ Start the Dynamo worker:
 
 ```bash
 dynamo-trtllm-sidecar \
+  --grpc-endpoint 127.0.0.1:50051 \
+  --model-path <model>
+```
+
+After installing `ai-dynamo`, the Python module runs the same native worker:
+
+```bash
+python -m dynamo.trtllm.sidecar \
   --grpc-endpoint 127.0.0.1:50051 \
   --model-path <model>
 ```

--- a/lib/sidecar/trtllm/src/engine.rs
+++ b/lib/sidecar/trtllm/src/engine.rs
@@ -10,7 +10,7 @@ use dynamo_backend_common::{
     AsyncEngineContext, DisaggregationMode, DynamoError, EngineConfig, GenerateContext, LLMEngine,
     LLMEngineOutput, LLMEngineOutputExt, PreprocessedRequest, WorkerConfig, usage,
 };
-use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
+use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig, SidecarStartupError};
 use futures::stream::BoxStream;
 use tokio::sync::OnceCell;
 use tokio_util::sync::CancellationToken;
@@ -61,9 +61,13 @@ impl TrtllmSidecarEngine {
     }
 
     pub fn from_args(argv: Vec<String>) -> Result<(Self, WorkerConfig), DynamoError> {
-        let args = <Args as clap::Parser>::try_parse_from(argv)
-            .map_err(|err| client::invalid_argument(err.to_string()))?;
-        Self::from_parsed(args)
+        Self::try_from_args(argv).map_err(SidecarStartupError::into_dynamo)
+    }
+
+    /// Parse explicit arguments without terminating the process on Clap exits.
+    pub fn try_from_args(argv: Vec<String>) -> Result<(Self, WorkerConfig), SidecarStartupError> {
+        let args = <Args as clap::Parser>::try_parse_from(argv)?;
+        Self::from_parsed(args).map_err(Into::into)
     }
 
     fn from_parsed(args: Args) -> Result<(Self, WorkerConfig), DynamoError> {

--- a/lib/sidecar/trtllm/src/engine.rs
+++ b/lib/sidecar/trtllm/src/engine.rs
@@ -60,12 +60,7 @@ impl TrtllmSidecarEngine {
         Self::from_parsed(<Args as clap::Parser>::parse())
     }
 
-    pub fn from_args(argv: Vec<String>) -> Result<(Self, WorkerConfig), DynamoError> {
-        Self::try_from_args(argv).map_err(SidecarStartupError::into_dynamo)
-    }
-
-    /// Parse explicit arguments without terminating the process on Clap exits.
-    pub fn try_from_args(argv: Vec<String>) -> Result<(Self, WorkerConfig), SidecarStartupError> {
+    pub fn from_args(argv: Vec<String>) -> Result<(Self, WorkerConfig), SidecarStartupError> {
         let args = <Args as clap::Parser>::try_parse_from(argv)?;
         Self::from_parsed(args).map_err(Into::into)
     }

--- a/lib/sidecar/trtllm/src/engine.rs
+++ b/lib/sidecar/trtllm/src/engine.rs
@@ -60,7 +60,15 @@ impl TrtllmSidecarEngine {
         Self::from_parsed(<Args as clap::Parser>::parse())
     }
 
-    pub fn from_args(argv: Vec<String>) -> Result<(Self, WorkerConfig), SidecarStartupError> {
+    pub fn from_args(argv: Vec<String>) -> Result<(Self, WorkerConfig), DynamoError> {
+        Self::try_from_args(argv).map_err(SidecarStartupError::into_dynamo)
+    }
+
+    /// Parse injected arguments while retaining Clap's structured exit error.
+    ///
+    /// Embedded callers use this to distinguish help and version output from
+    /// Dynamo startup failures without changing `from_args`'s error contract.
+    pub fn try_from_args(argv: Vec<String>) -> Result<(Self, WorkerConfig), SidecarStartupError> {
         let args = <Args as clap::Parser>::try_parse_from(argv)?;
         Self::from_parsed(args).map_err(Into::into)
     }

--- a/tests/wheels/smoke_install.py
+++ b/tests/wheels/smoke_install.py
@@ -382,6 +382,29 @@ assert metadata.version("ai-dynamo") == metadata.version("ai-dynamo-runtime")
     run([str(venv_python), "-c", code])
 
 
+def run_sidecar_help_smoke(venv_python: Path) -> None:
+    modules = (
+        ("dynamo.sglang.sidecar", "dynamo-sglang-sidecar"),
+        ("dynamo.trtllm.sidecar", "dynamo-trtllm-sidecar"),
+        ("dynamo.vllm.sidecar", "dynamo-vllm-sidecar"),
+    )
+    for module, program in modules:
+        command = [str(venv_python), "-m", module, "--help"]
+        print("+", " ".join(command), flush=True)
+        proc = subprocess.run(
+            command,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        print(proc.stdout)
+        if proc.returncode != 0:
+            raise AssertionError(f"{module} --help exited {proc.returncode}")
+        if f"Usage: {program}" not in proc.stdout:
+            raise AssertionError(f"{module} --help did not print its Clap usage")
+
+
 def run_aic_core_import_smoke(venv_python: Path) -> None:
     code = r"""
 import os
@@ -485,6 +508,7 @@ def install_core(
         pip_check(venv_python)
         assert_dynamo_local_install(venv_python, wheelhouse, ai_dynamo, runtime)
         run_core_import_smoke(venv_python)
+        run_sidecar_help_smoke(venv_python)
 
         for dist, wheel in also_wheels.items():
             assert_local_direct_url(venv_python, dist, wheel, wheelhouse)

--- a/tests/wheels/smoke_install.py
+++ b/tests/wheels/smoke_install.py
@@ -382,29 +382,6 @@ assert metadata.version("ai-dynamo") == metadata.version("ai-dynamo-runtime")
     run([str(venv_python), "-c", code])
 
 
-def run_sidecar_help_smoke(venv_python: Path) -> None:
-    modules = (
-        ("dynamo.sglang.sidecar", "dynamo-sglang-sidecar"),
-        ("dynamo.trtllm.sidecar", "dynamo-trtllm-sidecar"),
-        ("dynamo.vllm.sidecar", "dynamo-vllm-sidecar"),
-    )
-    for module, program in modules:
-        command = [str(venv_python), "-m", module, "--help"]
-        print("+", " ".join(command), flush=True)
-        proc = subprocess.run(
-            command,
-            check=False,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
-        print(proc.stdout)
-        if proc.returncode != 0:
-            raise AssertionError(f"{module} --help exited {proc.returncode}")
-        if f"Usage: {program}" not in proc.stdout:
-            raise AssertionError(f"{module} --help did not print its Clap usage")
-
-
 def run_aic_core_import_smoke(venv_python: Path) -> None:
     code = r"""
 import os
@@ -508,7 +485,6 @@ def install_core(
         pip_check(venv_python)
         assert_dynamo_local_install(venv_python, wheelhouse, ai_dynamo, runtime)
         run_core_import_smoke(venv_python)
-        run_sidecar_help_smoke(venv_python)
 
         for dist, wheel in also_wheels.items():
             assert_local_direct_url(venv_python, dist, wheel, wheelhouse)


### PR DESCRIPTION
## Overview:

Make the native TensorRT-LLM sidecar runnable from an `ai-dynamo` wheel installation through `python -m dynamo.trtllm.sidecar`, including normal CLI help behavior.

## Summary:

- Add the wheel-installed `dynamo.trtllm.sidecar` Python launcher.
- Link the native TensorRT-LLM sidecar into `ai-dynamo-runtime` and expose it through the PyO3 backend module.
- Preserve Clap help, version, and argument-error exit codes at the Python boundary.
- Update the TensorRT-LLM sidecar documentation.

## Details:

The Python module forwards CLI arguments to `_run_trtllm_sidecar`. The native binding supplies the Clap program name, parses through the typed startup-error path from #13929, constructs `TrtllmSidecarEngine`, releases the GIL, and runs the existing unified worker lifecycle.

This PR is stacked on #13929 so the shared Python CLI exit handling can be reviewed once.

## Where should the reviewer start?

- `components/src/dynamo/trtllm/sidecar.py` for the Python module UX.
- `lib/bindings/python/rust/backend.rs` for the native launcher boundary.
- `lib/sidecar/trtllm/src/engine.rs` for typed argument parsing.

## Related Issues

Depends on #13929.

## Validation:

- `cargo check --manifest-path lib/bindings/python/Cargo.toml --lib`
- `cargo fmt --manifest-path lib/bindings/python/Cargo.toml --check`
- `cargo fmt --all --check`
- `python3 -m py_compile components/src/dynamo/trtllm/sidecar.py tests/wheels/smoke_install.py`
- locally built and installed `ai-dynamo-runtime` with Maturin
- `python -m dynamo.trtllm.sidecar --help` exits 0 and prints `Usage: dynamo-trtllm-sidecar`
- `git diff --check`
