### PR TITLE
test(sglang): restore decode migration coverage

### DIFF
--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -693,7 +693,9 @@ def test_request_migration_sglang_decode(
                 max_tokens=DECODE_MAX_TOKENS,
                 wait_for_new_response_before_stop=True,
                 expected_ongoing_request_count=1,
-                graceful_shutdown_endpoint=("backend", "generate"),
-                wait_for_worker_health_shutdown=True,
+                graceful_shutdown=lambda worker: _sglang_graceful_shutdown(
+                    frontend, worker
+                ),
                 verify_replacement_worker=True,
+                force_max_output_tokens=True,
             )

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -608,7 +608,7 @@ def test_request_migration_sglang_kv_transfer(
                     )
 
 
-@pytest.mark.timeout(150)  # >3x the measured 40-44s local runtime
+@pytest.mark.timeout(SGLANG_MIGRATION_TEST_TIMEOUT_S)
 @pytest.mark.nightly
 @pytest.mark.profiled_vram_gib(8.0)  # measured NVML peak with three workers
 @pytest.mark.requested_sglang_kv_tokens(1024)
@@ -642,6 +642,7 @@ def test_request_migration_sglang_decode(
         request,
         migration_limit=migration_limit,
         migration_max_seq_len=migration_max_seq_len,
+        startup_timeout_s=SGLANG_MIGRATION_FRONTEND_STARTUP_TIMEOUT_S,
     ) as frontend:
         logger.info("Frontend started successfully")
 

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -695,4 +695,5 @@ def test_request_migration_sglang_decode(
                 expected_ongoing_request_count=1,
                 graceful_shutdown_endpoint=("backend", "generate"),
                 wait_for_worker_health_shutdown=True,
+                verify_replacement_worker=True,
             )

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -39,6 +39,8 @@ logger = logging.getLogger(__name__)
 
 AGGREGATED_MAX_MODEL_LEN = 1024
 AGGREGATED_MAX_TOKENS = 64
+DECODE_MAX_MODEL_LEN = 1024
+DECODE_MAX_TOKENS = 64
 
 SGLANG_MIGRATION_FRONTEND_STARTUP_TIMEOUT_S = 60
 # Last-resort ceiling; individual operations have their own bounded waits.
@@ -169,6 +171,44 @@ MIGRATION_CASES = [
     ),
 ]
 
+# Decode migration must be streaming so the fault can be injected after
+# generation starts. Retain one case for every migration-policy outcome while
+# balancing shutdown lifecycle, API, and request-plane transport.
+DECODE_MIGRATION_CASES = [
+    pytest.param(
+        3,
+        None,
+        True,
+        "chat",
+        "nats",
+        id="migration_enabled-worker_failure-chat-stream-nats",
+    ),
+    pytest.param(
+        0,
+        None,
+        False,
+        "completion",
+        "nats",
+        id="migration_disabled-graceful_shutdown-completion-stream-nats",
+    ),
+    pytest.param(
+        3,
+        1,
+        True,
+        "completion",
+        "tcp",
+        id="max_seq_len_exceeded-worker-failure-completion-stream-tcp",
+    ),
+    pytest.param(
+        3,
+        1_000_000,
+        False,
+        "chat",
+        "tcp",
+        id="max_seq_len_not_exceeded-graceful-shutdown-chat-stream-tcp",
+    ),
+]
+
 MIGRATION_PARAMETERS = pytest.mark.parametrize(
     (
         "migration_limit",
@@ -179,6 +219,18 @@ MIGRATION_PARAMETERS = pytest.mark.parametrize(
         "request_plane",
     ),
     MIGRATION_CASES,
+    indirect=["request_plane"],
+)
+
+DECODE_MIGRATION_PARAMETERS = pytest.mark.parametrize(
+    (
+        "migration_limit",
+        "migration_max_seq_len",
+        "immediate_kill",
+        "request_api",
+        "request_plane",
+    ),
+    DECODE_MIGRATION_CASES,
     indirect=["request_plane"],
 )
 
@@ -556,9 +608,11 @@ def test_request_migration_sglang_kv_transfer(
                     )
 
 
-@pytest.mark.timeout(230)  # 3x average
-@pytest.mark.nightly
-@legacy_migration_parameters
+@pytest.mark.timeout(150)  # >3x the measured 40-44s local runtime
+@pytest.mark.pre_merge
+@pytest.mark.profiled_vram_gib(8.0)  # measured NVML peak with three workers
+@pytest.mark.requested_sglang_kv_tokens(1024)
+@DECODE_MIGRATION_PARAMETERS
 def test_request_migration_sglang_decode(
     request,
     runtime_services_dynamic_ports,
@@ -568,25 +622,21 @@ def test_request_migration_sglang_decode(
     migration_max_seq_len,
     immediate_kill,
     request_api,
-    stream,
     tmp_path,
 ):
     """
     End-to-end test for decode worker request migration in disaggregated mode.
 
-    Setup: 1 prefill worker + 2 decode workers
+    Setup: 1 prefill worker + 2 decode workers.
+    The request is streamed so the test can inject a fault after decode starts.
 
     Parameters:
         immediate_kill: True for abrupt kill (SIGKILL), False for graceful shutdown (SIGTERM)
         migration_limit: > 0 to verify migration succeeds, 0 to verify request fails
         request_api: "chat" for chat completion API, "completion" for completion API
-        stream: True for streaming, False for non-streaming
+    This target is always streaming; unary responses finish before a decode
+    fault can be injected and are already covered by aggregate migration.
     """
-    if not stream:
-        pytest.skip(
-            "Decode test requires streaming to wait for response before stopping worker"
-        )
-
     # Step 1: Start the frontend
     with DynamoFrontendProcess(
         request,
@@ -595,45 +645,54 @@ def test_request_migration_sglang_decode(
     ) as frontend:
         logger.info("Frontend started successfully")
 
-        # Step 2: Start prefill worker first
-        with DynamoWorkerProcess(
+        # Step 2: Start the independent prefill and decode workers concurrently.
+        prefill_worker = DynamoWorkerProcess(
             request,
             "worker0",
             frontend.frontend_port,
             tmp_path,
             disagg_mode="prefill",
-        ) as prefill_worker:
-            logger.info(f"Prefill Worker PID: {prefill_worker.get_pid()}")
-
-            # Step 3: Start 2 decode workers
-            with DynamoWorkerProcess(
-                request,
-                "worker1",
+            max_model_len=DECODE_MAX_MODEL_LEN,
+        )
+        decode1 = DynamoWorkerProcess(
+            request,
+            "worker1",
+            frontend.frontend_port,
+            tmp_path,
+            disagg_mode="decode",
+            max_model_len=DECODE_MAX_MODEL_LEN,
+        )
+        decode2 = DynamoWorkerProcess(
+            request,
+            "worker2",
+            frontend.frontend_port,
+            tmp_path,
+            disagg_mode="decode",
+            max_model_len=DECODE_MAX_MODEL_LEN,
+        )
+        with managed_processes_concurrently(prefill_worker, decode1, decode2):
+            logger.info("Prefill Worker PID: %s", prefill_worker.get_pid())
+            logger.info("Decode Worker 1 PID: %s", decode1.get_pid())
+            logger.info("Decode Worker 2 PID: %s", decode2.get_pid())
+            wait_for_endpoint_instances(
                 frontend.frontend_port,
-                tmp_path,
-                disagg_mode="decode",
-            ) as decode1:
-                logger.info(f"Decode Worker 1 PID: {decode1.get_pid()}")
+                {("prefill", "generate"): 1, ("backend", "generate"): 2},
+            )
 
-                with DynamoWorkerProcess(
-                    request,
-                    "worker2",
-                    frontend.frontend_port,
-                    tmp_path,
-                    disagg_mode="decode",
-                ) as decode2:
-                    logger.info(f"Decode Worker 2 PID: {decode2.get_pid()}")
-
-                    # Step 4: Run migration test
-                    run_migration_test(
-                        frontend,
-                        decode1,
-                        decode2,
-                        receiving_pattern="New Request ID: ",
-                        migration_limit=migration_limit,
-                        migration_max_seq_len=migration_max_seq_len,
-                        immediate_kill=immediate_kill,
-                        use_chat_completion=(request_api == "chat"),
-                        stream=stream,
-                        wait_for_new_response_before_stop=True,
-                    )
+            # Step 3: Run migration test
+            run_migration_test(
+                frontend,
+                decode1,
+                decode2,
+                receiving_pattern="New Request ID: ",
+                migration_limit=migration_limit,
+                migration_max_seq_len=migration_max_seq_len,
+                immediate_kill=immediate_kill,
+                use_chat_completion=(request_api == "chat"),
+                stream=True,
+                max_tokens=DECODE_MAX_TOKENS,
+                wait_for_new_response_before_stop=True,
+                expected_ongoing_request_count=1,
+                graceful_shutdown_endpoint=("backend", "generate"),
+                wait_for_worker_health_shutdown=True,
+            )

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -609,7 +609,7 @@ def test_request_migration_sglang_kv_transfer(
 
 
 @pytest.mark.timeout(150)  # >3x the measured 40-44s local runtime
-@pytest.mark.pre_merge
+@pytest.mark.nightly
 @pytest.mark.profiled_vram_gib(8.0)  # measured NVML peak with three workers
 @pytest.mark.requested_sglang_kv_tokens(1024)
 @DECODE_MIGRATION_PARAMETERS

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -103,6 +103,7 @@ def start_completion_request(
     use_long_prompt: bool = False,
     max_tokens: int | None = None,
     long_prompt_repetitions: int = 8_000,
+    force_max_output_tokens: bool = False,
 ) -> tuple:
     """
     Start a long-running completion request in a separate thread.
@@ -116,6 +117,8 @@ def start_completion_request(
         use_long_prompt: Whether to use a long prompt (~8000 tokens)
         max_tokens: Explicit output-token cap, or the backend default when unset
         long_prompt_repetitions: Number of repeated words in the long prompt
+        force_max_output_tokens: Disable EOS and require the full output-token
+            budget. Requires max_tokens.
 
     Returns:
         tuple: (request_thread, response_list) where response_list contains
@@ -149,6 +152,13 @@ def start_completion_request(
             }
             if max_tokens is not None:
                 request_args["max_tokens"] = max_tokens
+            if force_max_output_tokens:
+                if max_tokens is None:
+                    raise ValueError("force_max_output_tokens requires max_tokens")
+                request_args["extra_body"] = {
+                    "ignore_eos": True,
+                    "min_tokens": max_tokens,
+                }
             if stream:
                 for chunk in client.completions.create(**request_args):
                     text = chunk.choices[0].text if chunk.choices else None
@@ -179,6 +189,7 @@ def start_chat_completion_request(
     use_long_prompt: bool = False,
     max_tokens: int | None = None,
     long_prompt_repetitions: int = 8_000,
+    force_max_output_tokens: bool = False,
 ) -> tuple:
     """
     Start a long-running chat completion request in a separate thread.
@@ -192,6 +203,8 @@ def start_chat_completion_request(
         use_long_prompt: Whether to use a long prompt (~8000 tokens)
         max_tokens: Explicit output-token cap, or the backend default when unset
         long_prompt_repetitions: Number of repeated words in the long prompt
+        force_max_output_tokens: Disable EOS and require the full output-token
+            budget. Requires max_tokens.
 
     Returns:
         tuple: (request_thread, response_list) where response_list contains
@@ -225,6 +238,13 @@ def start_chat_completion_request(
             }
             if max_tokens is not None:
                 request_args["max_tokens"] = max_tokens
+            if force_max_output_tokens:
+                if max_tokens is None:
+                    raise ValueError("force_max_output_tokens requires max_tokens")
+                request_args["extra_body"] = {
+                    "ignore_eos": True,
+                    "min_tokens": max_tokens,
+                }
             if stream:
                 for chunk in client.chat.completions.create(**request_args):
                     content = chunk.choices[0].delta.content if chunk.choices else None
@@ -706,6 +726,7 @@ def run_migration_test(
     graceful_shutdown: Callable[[ManagedProcess], AbstractContextManager[None]]
     | None = None,
     verify_replacement_worker: bool = False,
+    force_max_output_tokens: bool = False,
 ) -> None:
     """
     Run the common migration test flow after frontend and workers are started.
@@ -733,6 +754,8 @@ def run_migration_test(
         verify_replacement_worker: Require the surviving worker to accept the
             exact request ID and expose one completed generate request with
             nonzero response bytes. Intended for isolated per-test workers.
+        force_max_output_tokens: Disable EOS and require the request's full
+            max_tokens budget so fault injection cannot race an early EOS.
     """
     # Step 1: Send the request
     if use_chat_completion:
@@ -742,6 +765,7 @@ def run_migration_test(
             use_long_prompt=use_long_prompt,
             max_tokens=max_tokens,
             long_prompt_repetitions=long_prompt_repetitions,
+            force_max_output_tokens=force_max_output_tokens,
         )
     else:
         request_thread, response_list = start_completion_request(
@@ -750,6 +774,7 @@ def run_migration_test(
             use_long_prompt=use_long_prompt,
             max_tokens=max_tokens,
             long_prompt_repetitions=long_prompt_repetitions,
+            force_max_output_tokens=force_max_output_tokens,
         )
 
     # Step 2: Determine which worker received the request


### PR DESCRIPTION
## Summary

Linear: [DYN-4165](https://linear.app/nvidia/issue/DYN-4165/restore-sglang-decode-migration-nightly-coverage)

- replace the skipped 96-case SGLang decode migration Cartesian product with four explicit policy cases
- cover migration enabled/disabled, sequence cap exceeded/not exceeded, abrupt/graceful shutdown, chat/completion, and NATS/TCP
- start the prefill and two decode workers concurrently while preserving normal managed-process teardown
- synchronize on frontend discovery, an absolute response-chunk count, endpoint withdrawal, and the semantic request outcome rather than fixed sleeps
- prove the same request reaches the replacement worker and produces one completed non-empty response
- validate exact migration metrics and cap the model context/output at 1,024/64 tokens

## Why

Streaming is the applicable response mode for decode fault injection because the test must interrupt an in-flight decode. Unary behavior is already covered by aggregate and KV-transfer cases. Four rows retain every distinct decode migration policy outcome without multiplying unrelated dimensions into 96 cases.

The target cases passed pre-merge qualification and are restored to `nightly` in the final stack.

## Stack

1. [#13925](https://github.com/ai-dynamo/dynamo/pull/13925) — aggregate migration matrix
2. [#13926](https://github.com/ai-dynamo/dynamo/pull/13926) — remove unsupported prefill migration test
3. **#13927 (this PR)** — decode migration coverage (base: `codex/sglang-prefill-migration`)
4. [#13928](https://github.com/ai-dynamo/dynamo/pull/13928) — KV-transfer migration coverage

## Validation

- decode layer: **4 passed**, no retries, **3m04s** while co-scheduled with the aggregate and KV groups
- final top-of-stack SGLang migration suite: **14 passed**, no retries, **4m48s** with three-way GPU-aware scheduling
- the test container used `PYTHONPATH=/workspace/components/src` so qualification exercised this stack's SGLang shutdown handler rather than the installed base-image package
- the graceful/TCP case turns only SGLang's terminal shutdown `abort` result into typed `EngineShutdown`, retries the exact request ID on the survivor, and completes all 64 requested output tokens
- shared phase-derived **780-second** whole-test ceiling; inner behavioral waits remain tight
- peak VRAM: **8.0 GiB** with no residual allocation
- Python compilation, Black, isort, Ruff, flake8, and codespell
- independent adversarial rereview: no material correctness, semantics, or flake concerns
