### PR TITLE
fix(sidecar): preserve Python CLI exit behavior

### DIFF
--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1989,6 +1989,7 @@ dependencies = [
  "dynamo-parsers",
  "dynamo-runtime",
  "dynamo-sglang-sidecar",
+ "dynamo-sidecar-common",
  "dynamo-worker-selection-policy-catalog",
  "futures",
  "once_cell",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -64,6 +64,7 @@ dynamo-runtime = { path = "../../runtime" }
 dynamo-mocker = { path = "../../mocker" }
 dynamo-parsers = { version = "8.1.0" }
 dynamo-backend-common = { path = "../../backend-common" }
+dynamo-sidecar-common = { path = "../../sidecar/common" }
 dynamo-sglang-sidecar = { path = "../../sidecar/sglang" }
 
 anyhow = { version = "1" }

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -100,9 +100,7 @@ fn sglang_sidecar_argv(argv: Vec<String>) -> Vec<String> {
 fn _run_sglang_sidecar(py: Python<'_>, argv: Option<Vec<String>>) -> PyResult<()> {
     let cli_argv = sglang_sidecar_argv(argv.unwrap_or_default());
     let (engine, config) = py
-        .allow_threads(move || {
-            dynamo_sglang_sidecar::SglangSidecarEngine::from_args(Some(cli_argv))
-        })
+        .allow_threads(move || dynamo_sglang_sidecar::SglangSidecarEngine::try_from_args(cli_argv))
         .map_err(sidecar_startup_to_pyerr)?;
 
     py.allow_threads(move || dynamo_backend_common::run(Arc::new(engine), config))

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -100,7 +100,9 @@ fn sglang_sidecar_argv(argv: Vec<String>) -> Vec<String> {
 fn _run_sglang_sidecar(py: Python<'_>, argv: Option<Vec<String>>) -> PyResult<()> {
     let cli_argv = sglang_sidecar_argv(argv.unwrap_or_default());
     let (engine, config) = py
-        .allow_threads(move || dynamo_sglang_sidecar::SglangSidecarEngine::try_from_args(cli_argv))
+        .allow_threads(move || {
+            dynamo_sglang_sidecar::SglangSidecarEngine::from_args(Some(cli_argv))
+        })
         .map_err(sidecar_startup_to_pyerr)?;
 
     py.allow_threads(move || dynamo_backend_common::run(Arc::new(engine), config))

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -34,6 +34,7 @@ use dynamo_llm::local_model::runtime_config::{
 use dynamo_llm::model_type::ModelInput as RsModelInput;
 use dynamo_runtime as rs;
 use dynamo_runtime::logging::{DistributedTraceContext, get_distributed_tracing_context};
+use dynamo_sidecar_common::SidecarStartupError;
 use futures::stream::{BoxStream, StreamExt};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyModule};
@@ -46,6 +47,18 @@ use crate::errors::{extract_http_like_error, py_exception_to_backend_error};
 use crate::llm::kv::KvEventPublisher as PyKvEventPublisher;
 use crate::llm::preprocessor::{MediaDecoder, MediaFetcher};
 use crate::to_pyerr;
+
+fn sidecar_startup_to_pyerr(error: SidecarStartupError) -> PyErr {
+    match error {
+        SidecarStartupError::Cli(error) => {
+            let _ = error.print();
+            pyo3::exceptions::PySystemExit::new_err(error.exit_code())
+        }
+        SidecarStartupError::Dynamo(error) => {
+            pyo3::exceptions::PyValueError::new_err(error.to_string())
+        }
+    }
+}
 
 /// Register `dynamo._core.backend` and its classes on the parent `_core` module.
 pub fn add_to_module(parent: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -87,10 +100,8 @@ fn sglang_sidecar_argv(argv: Vec<String>) -> Vec<String> {
 fn _run_sglang_sidecar(py: Python<'_>, argv: Option<Vec<String>>) -> PyResult<()> {
     let cli_argv = sglang_sidecar_argv(argv.unwrap_or_default());
     let (engine, config) = py
-        .allow_threads(move || {
-            dynamo_sglang_sidecar::SglangSidecarEngine::from_args(Some(cli_argv))
-        })
-        .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
+        .allow_threads(move || dynamo_sglang_sidecar::SglangSidecarEngine::try_from_args(cli_argv))
+        .map_err(sidecar_startup_to_pyerr)?;
 
     py.allow_threads(move || dynamo_backend_common::run(Arc::new(engine), config))
         .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))

--- a/lib/sidecar/common/src/error.rs
+++ b/lib/sidecar/common/src/error.rs
@@ -11,6 +11,15 @@ pub enum SidecarStartupError {
     Dynamo(DynamoError),
 }
 
+impl SidecarStartupError {
+    pub fn into_dynamo(self) -> DynamoError {
+        match self {
+            Self::Cli(error) => invalid_argument(error.to_string()),
+            Self::Dynamo(error) => error,
+        }
+    }
+}
+
 impl fmt::Display for SidecarStartupError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/lib/sidecar/common/src/error.rs
+++ b/lib/sidecar/common/src/error.rs
@@ -11,15 +11,6 @@ pub enum SidecarStartupError {
     Dynamo(DynamoError),
 }
 
-impl SidecarStartupError {
-    pub fn into_dynamo(self) -> DynamoError {
-        match self {
-            Self::Cli(error) => invalid_argument(error.to_string()),
-            Self::Dynamo(error) => error,
-        }
-    }
-}
-
 impl fmt::Display for SidecarStartupError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/lib/sidecar/common/src/error.rs
+++ b/lib/sidecar/common/src/error.rs
@@ -1,7 +1,54 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fmt;
+
 use dynamo_backend_common::{BackendError, DynamoError, ErrorType};
+
+#[derive(Debug)]
+pub enum SidecarStartupError {
+    Cli(clap::Error),
+    Dynamo(DynamoError),
+}
+
+impl SidecarStartupError {
+    pub fn into_dynamo(self) -> DynamoError {
+        match self {
+            Self::Cli(error) => invalid_argument(error.to_string()),
+            Self::Dynamo(error) => error,
+        }
+    }
+}
+
+impl fmt::Display for SidecarStartupError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cli(error) => error.fmt(formatter),
+            Self::Dynamo(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for SidecarStartupError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Cli(error) => Some(error),
+            Self::Dynamo(error) => Some(error),
+        }
+    }
+}
+
+impl From<clap::Error> for SidecarStartupError {
+    fn from(error: clap::Error) -> Self {
+        Self::Cli(error)
+    }
+}
+
+impl From<DynamoError> for SidecarStartupError {
+    fn from(error: DynamoError) -> Self {
+        Self::Dynamo(error)
+    }
+}
 
 fn backend(kind: BackendError, message: impl Into<String>) -> DynamoError {
     DynamoError::builder()

--- a/lib/sidecar/common/src/lib.rs
+++ b/lib/sidecar/common/src/lib.rs
@@ -11,7 +11,7 @@ mod transport;
 pub use args::{GrpcTransportArgs, GrpcTransportConfig, SidecarArgs};
 pub use endpoint::{GrpcEndpoint, HttpEndpoint};
 pub use error::{
-    cannot_connect, connection_timeout, engine_shutdown, invalid_argument, protocol_error,
-    status_to_dynamo,
+    SidecarStartupError, cannot_connect, connection_timeout, engine_shutdown, invalid_argument,
+    protocol_error, status_to_dynamo,
 };
 pub use transport::{DEFAULT_MAX_GRPC_MESSAGE_SIZE, GrpcChannelPool};

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -13,7 +13,7 @@ use dynamo_backend_common::{
     KvEventSource, LLMEngine, LLMEngineOutput, LLMEngineOutputExt, LlmRegistration, ModelInput,
     PreprocessedRequest, WorkerConfig, usage,
 };
-use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
+use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig, SidecarStartupError};
 use futures::stream::BoxStream;
 use serde_json::Value;
 use tokio::sync::OnceCell;
@@ -54,12 +54,18 @@ struct DiscoveredKvEventSource {
 
 impl SglangSidecarEngine {
     pub fn from_args(argv: Option<Vec<String>>) -> Result<(Self, WorkerConfig), DynamoError> {
-        let args = match argv {
-            Some(args) => <Args as clap::Parser>::try_parse_from(args)
-                .map_err(|err| client::invalid_arg(err.to_string()))?,
-            None => <Args as clap::Parser>::parse(),
-        };
+        match argv {
+            Some(argv) => Self::try_from_args(argv).map_err(SidecarStartupError::into_dynamo),
+            None => Self::from_parsed(<Args as clap::Parser>::parse()),
+        }
+    }
 
+    pub fn try_from_args(argv: Vec<String>) -> Result<(Self, WorkerConfig), SidecarStartupError> {
+        let args = <Args as clap::Parser>::try_parse_from(argv)?;
+        Self::from_parsed(args).map_err(Into::into)
+    }
+
+    fn from_parsed(args: Args) -> Result<(Self, WorkerConfig), DynamoError> {
         if args.sidecar.common.route_to_encoder {
             return Err(client::invalid_arg(
                 "route-to-encoder is not supported by the SGLang sidecar",

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -53,13 +53,19 @@ struct DiscoveredKvEventSource {
 }
 
 impl SglangSidecarEngine {
-    pub fn from_args(
-        argv: Option<Vec<String>>,
-    ) -> Result<(Self, WorkerConfig), SidecarStartupError> {
-        let args = match argv {
-            Some(argv) => <Args as clap::Parser>::try_parse_from(argv)?,
-            None => <Args as clap::Parser>::parse(),
-        };
+    pub fn from_args(argv: Option<Vec<String>>) -> Result<(Self, WorkerConfig), DynamoError> {
+        match argv {
+            Some(argv) => Self::try_from_args(argv).map_err(SidecarStartupError::into_dynamo),
+            None => Self::from_parsed(<Args as clap::Parser>::parse()),
+        }
+    }
+
+    /// Parse injected arguments while retaining Clap's structured exit error.
+    ///
+    /// Embedded callers use this to distinguish help and version output from
+    /// Dynamo startup failures without changing `from_args`'s error contract.
+    pub fn try_from_args(argv: Vec<String>) -> Result<(Self, WorkerConfig), SidecarStartupError> {
+        let args = <Args as clap::Parser>::try_parse_from(argv)?;
         Self::from_parsed(args).map_err(Into::into)
     }
 

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -53,15 +53,13 @@ struct DiscoveredKvEventSource {
 }
 
 impl SglangSidecarEngine {
-    pub fn from_args(argv: Option<Vec<String>>) -> Result<(Self, WorkerConfig), DynamoError> {
-        match argv {
-            Some(argv) => Self::try_from_args(argv).map_err(SidecarStartupError::into_dynamo),
-            None => Self::from_parsed(<Args as clap::Parser>::parse()),
-        }
-    }
-
-    pub fn try_from_args(argv: Vec<String>) -> Result<(Self, WorkerConfig), SidecarStartupError> {
-        let args = <Args as clap::Parser>::try_parse_from(argv)?;
+    pub fn from_args(
+        argv: Option<Vec<String>>,
+    ) -> Result<(Self, WorkerConfig), SidecarStartupError> {
+        let args = match argv {
+            Some(argv) => <Args as clap::Parser>::try_parse_from(argv)?,
+            None => <Args as clap::Parser>::parse(),
+        };
         Self::from_parsed(args).map_err(Into::into)
     }
 

--- a/tests/wheels/smoke_install.py
+++ b/tests/wheels/smoke_install.py
@@ -382,6 +382,24 @@ assert metadata.version("ai-dynamo") == metadata.version("ai-dynamo-runtime")
     run([str(venv_python), "-c", code])
 
 
+def run_sidecar_help_smoke(venv_python: Path) -> None:
+    module = "dynamo.sglang.sidecar"
+    command = [str(venv_python), "-m", module, "--help"]
+    print("+", " ".join(command), flush=True)
+    proc = subprocess.run(
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    print(proc.stdout)
+    if proc.returncode != 0:
+        raise AssertionError(f"{module} --help exited {proc.returncode}")
+    if "Usage: dynamo-sglang-sidecar" not in proc.stdout:
+        raise AssertionError(f"{module} --help did not print its Clap usage")
+
+
 def run_aic_core_import_smoke(venv_python: Path) -> None:
     code = r"""
 import os
@@ -485,6 +503,7 @@ def install_core(
         pip_check(venv_python)
         assert_dynamo_local_install(venv_python, wheelhouse, ai_dynamo, runtime)
         run_core_import_smoke(venv_python)
+        run_sidecar_help_smoke(venv_python)
 
         for dist, wheel in also_wheels.items():
             assert_local_direct_url(venv_python, dist, wheel, wheelhouse)

--- a/tests/wheels/smoke_install.py
+++ b/tests/wheels/smoke_install.py
@@ -382,24 +382,6 @@ assert metadata.version("ai-dynamo") == metadata.version("ai-dynamo-runtime")
     run([str(venv_python), "-c", code])
 
 
-def run_sidecar_help_smoke(venv_python: Path) -> None:
-    module = "dynamo.sglang.sidecar"
-    command = [str(venv_python), "-m", module, "--help"]
-    print("+", " ".join(command), flush=True)
-    proc = subprocess.run(
-        command,
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
-    print(proc.stdout)
-    if proc.returncode != 0:
-        raise AssertionError(f"{module} --help exited {proc.returncode}")
-    if "Usage: dynamo-sglang-sidecar" not in proc.stdout:
-        raise AssertionError(f"{module} --help did not print its Clap usage")
-
-
 def run_aic_core_import_smoke(venv_python: Path) -> None:
     code = r"""
 import os
@@ -503,7 +485,6 @@ def install_core(
         pip_check(venv_python)
         assert_dynamo_local_install(venv_python, wheelhouse, ai_dynamo, runtime)
         run_core_import_smoke(venv_python)
-        run_sidecar_help_smoke(venv_python)
 
         for dist, wheel in also_wheels.items():
             assert_local_direct_url(venv_python, dist, wheel, wheelhouse)


### PR DESCRIPTION
## Overview:

Make the wheel-installed SGLang sidecar launcher preserve native Clap exit behavior so `python -m dynamo.sglang.sidecar --help` prints help and exits successfully.

## Summary:

- Preserve Clap errors separately from Dynamo startup errors.
- Convert Clap exits into Python `SystemExit` using the native exit code.
- Preserve the existing `from_args`/`DynamoError` factory contract while exposing a typed path for embedded callers.

## Details:

The existing `from_args` constructor continues returning `DynamoError` for Rust callers. A separate documented `try_from_args` path retains `clap::Error` for embedded callers; the PyO3 boundary prints the Clap diagnostic and raises `SystemExit(error.exit_code())`, while discovery and startup failures remain Python exceptions.

## Where should the reviewer start?

- `lib/sidecar/common/src/error.rs` for the typed startup error.
- `lib/sidecar/sglang/src/engine.rs` for argument parsing and engine construction.
- `lib/bindings/python/rust/backend.rs` for the Clap-to-Python conversion.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Validation:

- `cargo check --manifest-path lib/bindings/python/Cargo.toml --lib`
- `cargo check --locked -p dynamo-sglang-sidecar --all-targets`
- `cargo test --locked -p dynamo-sidecar-common --lib`
- `cargo fmt --all --check`
- locally built and installed `ai-dynamo-runtime` with Maturin
- `python -m dynamo.sglang.sidecar --help` exits 0 and prints `Usage: dynamo-sglang-sidecar`
