### PR TITLE
fix(frontend): preserve typed v1 jail errors

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2266,8 +2266,6 @@ impl BackendErrorInfo {
 fn extract_backend_error_if_present<T: serde::Serialize>(
     event: &Annotated<T>,
 ) -> Option<BackendErrorInfo> {
-    const SERIALIZED_BACKEND_INVALID_ARGUMENT_PREFIX: &str = "BackendInvalidArgument: ";
-
     #[derive(serde::Deserialize)]
     struct ErrorPayload {
         message: Option<String>,
@@ -2365,30 +2363,6 @@ fn extract_backend_error_if_present<T: serde::Serialize>(
                 status: overload_status_code(),
                 sanitized: Some(SanitizedError::Overloaded),
             });
-        }
-
-        // Some adapter paths encode a typed backend error into the message of
-        // a generic DynamoError. Recover only the exact stable discriminator;
-        // unknown errors without it remain sanitized as 500s.
-        let serialized_invalid_argument = match event.error.as_ref() {
-            Some(error)
-                if matches!(
-                    error.error_type(),
-                    ErrorType::Unknown | ErrorType::Backend(BackendError::Unknown)
-                ) =>
-            {
-                error
-                    .message()
-                    .strip_prefix(SERIALIZED_BACKEND_INVALID_ARGUMENT_PREFIX)
-            }
-            None => error_str.strip_prefix(SERIALIZED_BACKEND_INVALID_ARGUMENT_PREFIX),
-            _ => None,
-        };
-        if let Some(message) = serialized_invalid_argument {
-            return Some(BackendErrorInfo::from_status(
-                message.to_string(),
-                StatusCode::BAD_REQUEST,
-            ));
         }
 
         return Some(BackendErrorInfo::from_status(

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -4603,12 +4603,15 @@ impl OpenAIPreprocessor {
                     }
                 }
             }
+            debug_assert!(a.error.is_none(), "terminal errors must bypass the jail");
             JailAnnotated {
                 data: a.data.map(|nv| nv.inner),
                 id: a.id,
                 event: a.event,
                 comment: a.comment,
-                error: a.error.map(|e| e.to_string()),
+                // Terminal errors were removed by `take_while` above and are
+                // chained back as the original typed Dynamo annotation below.
+                error: None,
             }
         });
 
@@ -4644,6 +4647,10 @@ impl OpenAIPreprocessor {
         let pending_out = Arc::clone(&pending);
         let pending_eof = Arc::clone(&pending);
         let jailed_output = jailed.flat_map(move |a| {
+            debug_assert!(
+                a.error.is_none(),
+                "dynamo-parsers must not construct errors"
+            );
             // Metrics can ride on payload-only usage chunks because the HTTP
             // layer observes them before removing the chunk. Client-visible
             // nvext must wait for a non-payload-usage output with a choice.
@@ -4675,7 +4682,9 @@ impl OpenAIPreprocessor {
                 id: a.id,
                 event: a.event,
                 comment: a.comment,
-                error: a.error.map(DynamoError::msg),
+                // dynamo-parsers never constructs errors; Dynamo's original
+                // typed terminal annotation bypasses this conversion.
+                error: None,
             };
 
             // glm47: on finish_reason=length, recover the last incomplete

--- a/lib/llm/tests/responses_http_replay.rs
+++ b/lib/llm/tests/responses_http_replay.rs
@@ -143,13 +143,10 @@ async fn streaming_backend_error_closes_partial_output_and_counts_failure() {
             })
             .expect("text fixture has no finish-reason chunk");
         script.truncate(finish_position);
-        let typed_error = DynamoError::builder()
+        let error = DynamoError::builder()
             .error_type(DynamoErrorType::Backend(BackendError::InvalidArgument))
             .message(ERROR_MESSAGE)
             .build();
-        // The tool-enabled Python adapter path serializes the typed error into
-        // a generic error message before it reaches the HTTP frontend.
-        let error = DynamoError::msg(typed_error.to_string());
         let svc = HarnessService::start_with_backend_error(script, error).await;
 
         let response = post_responses(

--- a/lib/llm/tests/test_streaming_tool_parsers.rs
+++ b/lib/llm/tests/test_streaming_tool_parsers.rs
@@ -2429,44 +2429,67 @@ async fn test_deepseek_v4_finalize_recovers_at_bare_eof_with_no_finish_reason() 
     );
 }
 
-// Finding #6 regression: the SAME partial invoke, but the upstream stream ends in an
-// error instead of a clean EOF. The jail wrapper must yield exactly that error and
-// nothing else — no synthesized `ToolCalls` finish chunk fabricated from the jail's
-// own EOF-triggered finalize, because the request never actually completed.
+// Finding #6 regression: the SAME partial invoke, but the upstream stream ends in a
+// typed error instead of a clean EOF. The jail wrapper must yield exactly that error
+// unchanged and nothing else — no synthesized `ToolCalls` finish chunk fabricated
+// from the jail's own EOF-triggered finalize, because the request never completed.
 #[tokio::test]
-async fn test_deepseek_v4_upstream_error_suppresses_jail_finalize() {
-    let output_chunks = parse_response_stream(
-        stream::iter(vec![
-            deepseek_v4_partial_invoke_chunk(),
-            Annotated::from_error("upstream disconnected"),
-        ]),
-        true,
-        false,
-        Some("deepseek_v4".to_string()),
-        None,
-    )
-    .await;
+async fn test_deepseek_v4_upstream_typed_errors_suppress_jail_finalize() {
+    use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
 
-    assert!(
-        !output_chunks.is_empty(),
-        "the terminal error itself must still reach the caller"
-    );
-    let last = output_chunks.last().expect("non-empty output");
-    assert!(
-        last.is_error(),
-        "the terminal error must be the LAST item in the output stream; got: {output_chunks:#?}"
-    );
-    assert_eq!(
-        output_chunks.iter().filter(|a| a.is_error()).count(),
-        1,
-        "the terminal error must be surfaced exactly once; got: {output_chunks:#?}"
-    );
+    for error_type in [
+        ErrorType::Backend(BackendError::InvalidArgument),
+        ErrorType::Backend(BackendError::EngineShutdown),
+        ErrorType::Backend(BackendError::Disconnected),
+    ] {
+        let message = format!("typed {error_type} error");
+        let output_chunks = parse_response_stream(
+            stream::iter(vec![
+                deepseek_v4_partial_invoke_chunk(),
+                Annotated {
+                    data: None,
+                    id: None,
+                    event: Some("error".to_string()),
+                    comment: None,
+                    error: Some(
+                        DynamoError::builder()
+                            .error_type(error_type)
+                            .message(&message)
+                            .build(),
+                    ),
+                },
+            ]),
+            true,
+            false,
+            Some("deepseek_v4".to_string()),
+            None,
+        )
+        .await;
 
-    let aggregated = aggregate_content_from_chunks(&output_chunks);
-    assert!(
-        !aggregated.has_tool_calls,
-        "an upstream error must suppress the jail's EOF finalize entirely — no \
-         synthesized tool call may reach the caller for a request that never actually \
-         completed; got: {output_chunks:#?}"
-    );
+        assert!(
+            !output_chunks.is_empty(),
+            "the terminal error itself must still reach the caller"
+        );
+        let last = output_chunks.last().expect("non-empty output");
+        assert!(
+            last.is_error(),
+            "the terminal error must be the LAST item in the output stream; got: {output_chunks:#?}"
+        );
+        let error = last.error.as_ref().expect("terminal error must be typed");
+        assert_eq!(error.error_type(), error_type);
+        assert_eq!(error.message(), message);
+        assert_eq!(
+            output_chunks.iter().filter(|a| a.is_error()).count(),
+            1,
+            "the terminal error must be surfaced exactly once; got: {output_chunks:#?}"
+        );
+
+        let aggregated = aggregate_content_from_chunks(&output_chunks);
+        assert!(
+            !aggregated.has_tool_calls,
+            "an upstream error must suppress the jail's EOF finalize entirely — no \
+             synthesized tool call may reach the caller for a request that never actually \
+             completed; got: {output_chunks:#?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Preserve the original typed terminal `DynamoError` across the v1 tool-call jail instead of serializing it to a string and reconstructing it as `Unknown`.
- Chain terminal errors around the jail, which only processes successful data chunks.
- Remove the temporary `BackendInvalidArgument:` string-prefix recovery from the HTTP layer.
- Fixes [DIS-2778](https://linear.app/nvidia/issue/DIS-2778/preserve-typed-dynamo-errors-through-the-v1-tool-call-jail).

## Before / after

Only invalid tool-bearing multimodal requests changed internally. The public HTTP contract remains unchanged.

| Endpoint | Before | After | HTTP behavior |
|---|---|---|---|
| `/v1/chat/completions` | Error type lost as `Unknown`; message prefixed with `BackendInvalidArgument:` | Preserved as `Backend(InvalidArgument)`; clean message | Unchanged: HTTP 400, type `Bad Request`, detailed backend message |
| `/v1/responses` | Error type lost as `Unknown`; message prefixed with `BackendInvalidArgument:` | Preserved as `Backend(InvalidArgument)`; clean message | Unchanged: HTTP 400, type `Bad Request`, detailed backend message |
| `/v1/messages` | Error type lost as `Unknown`; message prefixed with `BackendInvalidArgument:` | Preserved as `Backend(InvalidArgument)`; clean message | Unchanged: HTTP 400, type `invalid_request_error`, sanitized `Bad Request` message |

Text-only and valid one-image tool calls were unchanged: HTTP 200 with a structured `get_weather` tool call before and after.

## Validation

### Focused regression tests

- `cargo test -p dynamo-llm --test test_streaming_tool_parsers test_deepseek_v4_upstream_typed_errors_suppress_jail_finalize -- --exact --nocapture`
- `cargo test -p dynamo-llm --test responses_http_replay streaming_backend_error_closes_partial_output_and_counts_failure -- --exact --nocapture`

Both pass on rebased head `0326dcea6c`.

### Live A/B deployment

Ran 18 real tool-call requests: three endpoints × text, one-image, and deliberately invalid two-image inputs × before/after builds.

- Model: `RadixArk/Qwen3.8-27B-NVFP4`
- Backend: Dynamo + vLLM 0.27.1
- GPU: NVIDIA RTX 5880 Ada Generation
- Parser: v1 `qwen3_coder` jail with experimental parsers v2 disabled
- Invalid case: two images with the worker configured for at most one image
- Backend error: `At most 1 image(s) may be provided in one prompt. (parameter=image)`

All six valid requests returned HTTP 200 with structured tool calls. All invalid requests retained their existing HTTP 400 wire behavior while changing from an internally reconstructed `Unknown` error to the original typed `Backend(InvalidArgument)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming error handling so backend errors are preserved accurately and delivered once as the final stream result.
  * Prevented tool processing from generating unintended tool calls when a stream ends with an error.
  * Corrected handling of unknown backend errors so they follow standard internal-error behavior instead of being incorrectly reported as client errors.
  * Added coverage for invalid arguments, engine shutdowns, and disconnections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Compatibility with #12442

| #12442 scenario | Result with this PR |
|---|---|
| Tool-bearing Responses request serializes `Backend(InvalidArgument)` | Fixed at the source: the typed error bypasses the v1 jail unchanged instead of being reconstructed from `BackendInvalidArgument:` text. |
| Multimodal-disabled error remains actionable | Preserved exactly in `response.failed.response.error.message`. |
| Client-error classification | Typed invalid argument maps to internal HTTP-like `400`, then Responses code `invalid_prompt`. The already-committed streaming response remains HTTP 200, matching #12442's contract. |
| Partial output before failure | Output is closed in order, marked `incomplete`, retained in `response.failed`, and no `response.completed` is emitted. |
| Completed message/tool output before later failure | Completed status remains `completed`; unfinished output becomes `incomplete`. |
| Failure metrics after normal SSE termination | Counted as an error, not success or cancellation; disconnect handling remains armed until the terminal failure event is emitted. |
| Unknown/internal failures | Still sanitized as `Internal server error`; deleting the prefix workaround does not expose backend messages. |
| Jail EOF after upstream failure | Suppressed, so no synthetic tool call is emitted after the real error. |
