### PR TITLE
fix(container): enable NVDEC bitstream filters

### DIFF
--- a/components/src/dynamo/common/tests/multimodal/test_nvdec_decoder_gpu.py
+++ b/components/src/dynamo/common/tests/multimodal/test_nvdec_decoder_gpu.py
@@ -25,7 +25,9 @@ import pytest
 
 pytestmark = [
     pytest.mark.integration,
-    pytest.mark.post_merge,
+    # TODO: revert to pytest.mark.post_merge after pre_merge validation
+    # on this PR (see .ai/ci-guidelines.md).
+    pytest.mark.pre_merge,
     pytest.mark.gpu_1,
     pytest.mark.vllm,
 ]

--- a/components/src/dynamo/common/tests/multimodal/test_nvdec_decoder_gpu.py
+++ b/components/src/dynamo/common/tests/multimodal/test_nvdec_decoder_gpu.py
@@ -25,9 +25,7 @@ import pytest
 
 pytestmark = [
     pytest.mark.integration,
-    # TODO: revert to pytest.mark.post_merge after pre_merge validation
-    # on this PR (see .ai/ci-guidelines.md).
-    pytest.mark.pre_merge,
+    pytest.mark.post_merge,
     pytest.mark.gpu_1,
     pytest.mark.vllm,
 ]

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -383,6 +383,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
         --disable-x86asm \
         --disable-network \
         --disable-bsfs \
+        --enable-bsf=h264_mp4toannexb,hevc_mp4toannexb \
         --disable-devices \
         --disable-libdrm \
         --enable-shared \


### PR DESCRIPTION
## Summary

- enable the H.264 and HEVC MP4-to-Annex-B bitstream filters in the in-tree FFmpeg build
- keep software H.264/HEVC encoders, decoders, and parsers disabled
- restore PyNvVideoCodec NVDEC construction after the media-ffmpeg binding loads the in-tree FFmpeg first

Linear: [DIS-2796](https://linear.app/nvidia/issue/DIS-2796/fix-post-merge-nvdec-bitstream-filter-failure)

Failing post-merge job: [vllm-runtime / Test cuda13.0, amd64](https://github.com/ai-dynamo/dynamo/actions/runs/33109597071/job/98651232682)

## Validation

- `git diff --check`
- `python3 -m pytest -q container/compliance/tests/test_scan_codecs.py` (22 passed)
- `pre-commit run --files container/templates/wheel_builder.Dockerfile`
- rendered the vLLM CUDA 13.0 amd64 runtime Dockerfile and verified both requested filters are present
- FFmpeg 8.1.2 configure probe: both filters enabled while H.264/HEVC decoders and parsers remain disabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for H.264 and HEVC MP4-to-Annex B bitstream conversion in FFmpeg, improving compatibility with supported video processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->