### PR TITLE
fix(runtime): honor configured Python client routing

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -31,8 +31,8 @@ use dynamo_runtime::config;
 use dynamo_runtime::{
     self as rs, logging,
     pipeline::{
-        AsyncEngineContextProvider, EngineStream, ManyOut, SingleIn, context::Context as RsContext,
-        network::egress::push_router::RouterMode as RsRouterMode,
+        AsyncEngine, AsyncEngineContextProvider, EngineStream, ManyOut, SingleIn,
+        context::Context as RsContext, network::egress::push_router::RouterMode as RsRouterMode,
     },
     protocols::annotated::Annotated as RsAnnotated,
     traits::DistributedRuntimeProvider,
@@ -1812,7 +1812,28 @@ impl Client {
         annotated: Option<bool>,
         context: Option<context::Context>,
     ) -> PyResult<Bound<'p, PyAny>> {
-        self.random(py, request, annotated, context)
+        let request: rmpv::Value = pythonize::depythonize(&request.into_bound(py))?;
+        let request_ctx = create_request_context(request, &context);
+        let annotated = annotated.unwrap_or(false);
+
+        let (tx, rx) = tokio::sync::mpsc::channel(32);
+        let client = self.router.clone();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let stream = match context {
+                Some(context) => {
+                    let span = get_span_for_context(&context, "generate");
+                    client
+                        .generate(request_ctx)
+                        .instrument(span)
+                        .await
+                        .map_err(to_pyerr)?
+                }
+                _ => client.generate(request_ctx).await.map_err(to_pyerr)?,
+            };
+            tokio::spawn(process_stream(stream, tx));
+            Ok(AsyncResponseStream::new(rx, annotated))
+        })
     }
 
     /// Send a request to the next endpoint in a round-robin fashion.

--- a/lib/bindings/python/tests/test_request_plane_python_payload.py
+++ b/lib/bindings/python/tests/test_request_plane_python_payload.py
@@ -3,8 +3,12 @@
 
 import asyncio
 import contextlib
+from typing import Any
+from uuid import uuid4
 
 import pytest
+
+from dynamo._core import RouterMode
 
 pytestmark = [
     pytest.mark.gpu_0,
@@ -150,3 +154,14 @@ async def test_python_request_plane_plain_annotated_error_and_malformed_frames(
         with pytest.raises(ValueError, match=message):
             async for _ in stream:
                 pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+async def test_client_generate_honors_configured_router_mode(runtime: Any) -> None:
+    endpoint = runtime.endpoint(f"configured-direct-{uuid4().hex}.backend.generate")
+    client = await endpoint.client(RouterMode.Direct)
+
+    with pytest.raises(Exception, match="Direct routing should not call generate"):
+        await client.generate({"value": "hello"})


### PR DESCRIPTION
_Tracks [DIS-2797](https://linear.app/nvidia/issue/DIS-2797/fix-honor-configured-routermode-in-python-clientgenerate)._

## Why

`Endpoint.client(router_mode=...)` stores a routing policy on `PushRouter`, but Python `Client.generate()` currently bypasses it by calling `random()`. This makes the default round-robin contract and every configured supported policy ineffective for callers using the generic method. Delegating to `PushRouter.generate()` restores the existing routing abstraction without changing explicit selection methods.

## What Change

- Dispatch `Client.generate()` through its configured `PushRouter`.
- Preserve context propagation, tracing, annotations, and bounded stream forwarding.
- Add a deterministic configured-mode regression test.

## Test Plan

- Rust format, check, clippy, and applicable pre-commit hooks pass.
- Regression coverage distinguishes configured routing from hard-coded random dispatch.