### PR TITLE
fix(container): stop NVDEC video decode failing in the vLLM runtime image

### DIFF
--- a/container/compliance/tests/test_ffmpeg_bitstream_filters.py
+++ b/container/compliance/tests/test_ffmpeg_bitstream_filters.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the in-tree ffmpeg codec contract in the rendered vLLM Dockerfile.
+
+The contract has two halves that pull against each other, and both must hold at
+once:
+
+* The NVDEC decode path needs the ``h264_mp4toannexb`` / ``hevc_mp4toannexb``
+  bitstream filters. PyNvVideoCodec resolves them with ``av_bsf_get_by_name()``
+  against whichever ``libavcodec.so.62`` the loader mapped first, which is the
+  in-tree build; if they are not compiled in, the lookup returns NULL and
+  hardware decode fails for every codec.
+* No H.264/HEVC/AAC *encoder, decoder or parser* may be built. Those carry a
+  codec implementation; the bitstream filters do not, they only reframe an
+  already-encoded stream.
+
+Assertions run against the rendered Dockerfile rather than the template so that
+a Jinja gate which drops the ffmpeg build out of the vLLM image is caught too.
+
+Run from the repo root with the compliance package on the path:
+
+    PYTHONPATH=container python -m pytest container/compliance/tests/test_ffmpeg_bitstream_filters.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+from pathlib import Path
+
+import pytest
+import render
+import yaml
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.post_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.unit,
+]
+
+_CONTAINER = Path(__file__).resolve().parents[2]
+
+# Anything whose implementation is royalty-bearing. Matches ffmpeg's own naming
+# for the enable lists (h264, hevc, aac, and the hardware variants).
+_DISALLOWED_CODEC_RE = re.compile(r"h\.?26[45]|hevc|aac|nvenc|cuvid|nvdec", re.I)
+
+_REQUIRED_BSFS = ("h264_mp4toannexb", "hevc_mp4toannexb")
+
+
+def _render_vllm_runtime_dockerfile(out_dir: Path) -> str:
+    """Render the vLLM CUDA-13.0 amd64 runtime Dockerfile into ``out_dir``.
+
+    ``render.render()`` writes its output next to the templates it loads, so the
+    template tree is copied into ``out_dir`` first to keep the repo checkout
+    clean.
+    """
+    shutil.copytree(_CONTAINER / "templates", out_dir / "templates")
+    shutil.copy(_CONTAINER / "Dockerfile.template", out_dir / "Dockerfile.template")
+
+    args = argparse.Namespace(
+        framework="vllm",
+        device="cuda",
+        target="runtime",
+        platform="amd64",
+        cuda_version="13.0",
+        make_efa=False,
+        output_short_filename=True,
+        show_result=False,
+    )
+    render.validate_args(args)
+    context = yaml.safe_load((_CONTAINER / "context.yaml").read_text())
+    render.render(args, context, out_dir)
+    return (out_dir / "rendered.Dockerfile").read_text()
+
+
+def _ffmpeg_configure_flags(dockerfile: str) -> list[str]:
+    """Return the flags of the in-tree ffmpeg ``./configure`` invocation.
+
+    Anchored past the libvpx build, which runs its own ``./configure`` earlier in
+    the same layer. Comment lines are dropped: BuildKit strips them before the
+    shell sees the command, and the surrounding prose mentions the very flag
+    names under test.
+    """
+    anchor = "cd ffmpeg-${FFMPEG_VERSION}"
+    assert anchor in dockerfile, "no in-tree ffmpeg build in the rendered Dockerfile"
+    body = dockerfile.split(anchor, 1)[1].split("./configure", 1)
+    assert len(body) == 2, "no in-tree ffmpeg ./configure in the rendered Dockerfile"
+    flags = []
+    for raw in body[1].splitlines():
+        line = raw.strip()
+        if line.startswith("#"):
+            continue
+        line = line.rstrip("\\").strip()
+        for token in line.split():
+            if token.startswith("--"):
+                flags.append(token)
+        # The invocation ends at the first continuation that is not a flag.
+        if line and not line.startswith("--"):
+            break
+    assert flags, "could not parse the ffmpeg ./configure flags"
+    return flags
+
+
+def _enabled(flags: list[str], surface: str) -> set[str]:
+    """Collect the comma-separated values of every ``--enable-<surface>=`` flag."""
+    prefix = f"--enable-{surface}="
+    values: set[str] = set()
+    for flag in flags:
+        if flag.startswith(prefix):
+            values.update(v for v in flag[len(prefix) :].split(",") if v)
+    return values
+
+
+@pytest.fixture(scope="module")
+def configure_flags(tmp_path_factory) -> list[str]:
+    dockerfile = _render_vllm_runtime_dockerfile(
+        tmp_path_factory.mktemp("rendered") / "container"
+    )
+    return _ffmpeg_configure_flags(dockerfile)
+
+
+def test_nvdec_reframing_bitstream_filters_are_built(configure_flags):
+    # Without these two the NVDEC path's av_bsf_get_by_name() returns NULL and
+    # hardware decode fails for every codec. Nothing else pulls them in: no
+    # enabled muxer depends on them under --disable-bsfs.
+    enabled = _enabled(configure_flags, "bsf")
+    missing = [bsf for bsf in _REQUIRED_BSFS if bsf not in enabled]
+    assert not missing, (
+        f"in-tree ffmpeg would not build {missing}; "
+        f"--enable-bsf currently requests {sorted(enabled) or 'nothing'}"
+    )
+
+
+def test_bitstream_filter_baseline_stays_narrow(configure_flags):
+    # The two filters above are re-enabled on top of --disable-bsfs, not by
+    # dropping the baseline. Losing the baseline would ship ffmpeg's whole
+    # bitstream-filter set.
+    assert "--disable-bsfs" in configure_flags
+    assert "--enable-bsfs" not in configure_flags
+
+
+@pytest.mark.parametrize("surface", ["encoders", "decoders", "parsers"])
+def test_codec_surfaces_are_disabled_by_default(configure_flags, surface):
+    assert f"--disable-{surface}" in configure_flags
+
+
+@pytest.mark.parametrize("surface", ["encoder", "decoder", "parser"])
+def test_no_royalty_bearing_codec_is_enabled(configure_flags, surface):
+    # The negative control for the change above: fixing NVDEC by re-enabling a
+    # software H.264/HEVC decoder instead of a bitstream filter must fail here.
+    offenders = sorted(
+        name
+        for name in _enabled(configure_flags, surface)
+        if _DISALLOWED_CODEC_RE.search(name)
+    )
+    assert not offenders, f"--enable-{surface} names a disallowed codec: {offenders}"

--- a/container/compliance/tests/test_ffmpeg_bitstream_filters.py
+++ b/container/compliance/tests/test_ffmpeg_bitstream_filters.py
@@ -122,9 +122,8 @@ def configure_flags(tmp_path_factory) -> list[str]:
 
 
 def test_nvdec_reframing_bitstream_filters_are_built(configure_flags):
-    # Without these two the NVDEC path's av_bsf_get_by_name() returns NULL and
-    # hardware decode fails for every codec. Nothing else pulls them in: no
-    # enabled muxer depends on them under --disable-bsfs.
+    # Without these two, av_bsf_get_by_name() returns NULL on the NVDEC path
+    # and hardware decode fails for every codec.
     enabled = _enabled(configure_flags, "bsf")
     missing = [bsf for bsf in _REQUIRED_BSFS if bsf not in enabled]
     assert not missing, (
@@ -134,9 +133,8 @@ def test_nvdec_reframing_bitstream_filters_are_built(configure_flags):
 
 
 def test_bitstream_filter_baseline_stays_narrow(configure_flags):
-    # The two filters above are re-enabled on top of --disable-bsfs, not by
-    # dropping the baseline. Losing the baseline would ship ffmpeg's whole
-    # bitstream-filter set.
+    # The two filters are re-enabled on top of --disable-bsfs; dropping the
+    # baseline would ship ffmpeg's whole bitstream-filter set.
     assert "--disable-bsfs" in configure_flags
     assert "--enable-bsfs" not in configure_flags
 

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -328,6 +328,19 @@ ENV SCCACHE_BUCKET=${USE_SCCACHE:+${SCCACHE_BUCKET}} \
 # imageio encode path with "Protocol not found. Did you mean file:fd:?". Both
 # are pure fd/stream I/O and carry no codec implementation.
 #
+# BITSTREAM FILTERS: --disable-bsfs is the baseline, with exactly two
+# exceptions — h264_mp4toannexb and hevc_mp4toannexb. The NVDEC decode path
+# (PyNvVideoCodec) resolves them via av_bsf_get_by_name() to reframe AVCC-in-mp4
+# into Annex B before handing the stream to libnvcuvid, and it resolves against
+# whichever libavcodec.so.62 the loader mapped first — which is this one, since
+# dynamo._core is built with the media-ffmpeg feature, DT_NEEDEDs the plain
+# soname, and is imported before PyNvVideoCodec. They have to be requested
+# explicitly: no enabled muxer pulls them in under --disable-bsfs (that holds
+# for aac_adtstoasc, not for h264_mp4toannexb), and without them the lookup
+# returns NULL and hardware decode fails for every codec. A bitstream filter
+# reframes an already-encoded stream and carries no codec implementation, so
+# enabling these two adds no royalty-bearing surface.
+#
 # Combined with the 8.1 -> 8.1.2 bump below (an upstream maintenance release),
 # this also trims the decoder surface to what we ship.
 # Do not delete the source tarball for legal reasons.
@@ -383,6 +396,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
         --disable-x86asm \
         --disable-network \
         --disable-bsfs \
+        --enable-bsf=h264_mp4toannexb,hevc_mp4toannexb \
         --disable-devices \
         --disable-libdrm \
         --enable-shared \
@@ -405,15 +419,28 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     # leaked into the in-tree ffmpeg. By construction this build is VP9-only, so a
     # match here means a config regression. Check the implementation-carrying
     # surfaces (encoders/decoders/parsers), not -codecs (lists names even when no
-    # implementation is built) and not -bsfs: bitstream filters (e.g.
-    # aac_adtstoasc, h264_mp4toannexb) only reframe an already-encoded stream, are
-    # pulled in as mov/mp4 muxer dependencies, and carry no codec implementation.
+    # implementation is built) and not -bsfs: a bitstream filter only reframes an
+    # already-encoded stream and carries no codec implementation, so the two
+    # h264_/hevc_mp4toannexb filters are expected on that surface and are checked
+    # positively below instead.
     for surface in encoders decoders parsers; do \
         if /usr/local/bin/ffmpeg -hide_banner "-${surface}" 2>/dev/null \
              | grep -qiE 'h\.?264|h\.?265|hevc|(^| )aac|nvenc|cuvid|nvdec'; then \
             echo "ERROR: in-tree ffmpeg exposes a disallowed codec via -${surface}" >&2; \
             /usr/local/bin/ffmpeg -hide_banner "-${surface}" 2>/dev/null \
              | grep -iE 'h\.?264|h\.?265|hevc|(^| )aac|nvenc|cuvid|nvdec' >&2; \
+            exit 1; \
+        fi; \
+    done && \
+    # Positive guard: the NVDEC reframing filters must actually be built. Nothing
+    # else pulls them in under --disable-bsfs, so a configure edit that drops the
+    # --enable-bsf flag would leave av_bsf_get_by_name() returning NULL and break
+    # hardware decode at runtime with a green build. Fail here instead.
+    for bsf in h264_mp4toannexb hevc_mp4toannexb; do \
+        if ! /usr/local/bin/ffmpeg -hide_banner -bsfs 2>/dev/null \
+             | grep -q "^[[:space:]]*${bsf}$"; then \
+            echo "ERROR: in-tree ffmpeg is missing bitstream filter ${bsf}" >&2; \
+            /usr/local/bin/ffmpeg -hide_banner -bsfs 2>/dev/null | grep -v '^$' >&2; \
             exit 1; \
         fi; \
     done && \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -328,18 +328,7 @@ ENV SCCACHE_BUCKET=${USE_SCCACHE:+${SCCACHE_BUCKET}} \
 # imageio encode path with "Protocol not found. Did you mean file:fd:?". Both
 # are pure fd/stream I/O and carry no codec implementation.
 #
-# BITSTREAM FILTERS: --disable-bsfs is the baseline, with exactly two
-# exceptions — h264_mp4toannexb and hevc_mp4toannexb. The NVDEC decode path
-# (PyNvVideoCodec) resolves them via av_bsf_get_by_name() to reframe AVCC-in-mp4
-# into Annex B before handing the stream to libnvcuvid, and it resolves against
-# whichever libavcodec.so.62 the loader mapped first — which is this one, since
-# dynamo._core is built with the media-ffmpeg feature, DT_NEEDEDs the plain
-# soname, and is imported before PyNvVideoCodec. They have to be requested
-# explicitly: no enabled muxer pulls them in under --disable-bsfs (that holds
-# for aac_adtstoasc, not for h264_mp4toannexb), and without them the lookup
-# returns NULL and hardware decode fails for every codec. A bitstream filter
-# reframes an already-encoded stream and carries no codec implementation, so
-# enabling these two adds no royalty-bearing surface.
+# BITSTREAM FILTERS: h264/hevc_mp4toannexb are enabled on top of --disable-bsfs for NVDEC reframing; they carry no codec implementation.
 #
 # Combined with the 8.1 -> 8.1.2 bump below (an upstream maintenance release),
 # this also trims the decoder surface to what we ship.
@@ -419,10 +408,8 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     # leaked into the in-tree ffmpeg. By construction this build is VP9-only, so a
     # match here means a config regression. Check the implementation-carrying
     # surfaces (encoders/decoders/parsers), not -codecs (lists names even when no
-    # implementation is built) and not -bsfs: a bitstream filter only reframes an
-    # already-encoded stream and carries no codec implementation, so the two
-    # h264_/hevc_mp4toannexb filters are expected on that surface and are checked
-    # positively below instead.
+    # implementation is built) and not -bsfs: a bitstream filter carries no codec
+    # implementation. The two mp4toannexb filters are checked positively below.
     for surface in encoders decoders parsers; do \
         if /usr/local/bin/ffmpeg -hide_banner "-${surface}" 2>/dev/null \
              | grep -qiE 'h\.?264|h\.?265|hevc|(^| )aac|nvenc|cuvid|nvdec'; then \
@@ -432,10 +419,8 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
             exit 1; \
         fi; \
     done && \
-    # Positive guard: the NVDEC reframing filters must actually be built. Nothing
-    # else pulls them in under --disable-bsfs, so a configure edit that drops the
-    # --enable-bsf flag would leave av_bsf_get_by_name() returning NULL and break
-    # hardware decode at runtime with a green build. Fail here instead.
+    # Positive guard: dropping --enable-bsf would leave av_bsf_get_by_name()
+    # returning NULL and break hardware decode at runtime with a green build.
     for bsf in h264_mp4toannexb hevc_mp4toannexb; do \
         if ! /usr/local/bin/ffmpeg -hide_banner -bsfs 2>/dev/null \
              | grep -q "^[[:space:]]*${bsf}$"; then \


### PR DESCRIPTION
## Overview:

In the vLLM runtime image, hardware video decode through NVDEC fails for every
codec. PyNvVideoCodec has to reframe an AVCC-in-MP4 stream into Annex B before
it can hand the stream to `libnvcuvid`, and it looks up the filter that does
that reframing with `av_bsf_get_by_name()`. That call returns NULL, so decode
never starts.

The cause is a single missing `./configure` flag in the in-tree ffmpeg build.
`container/templates/wheel_builder.Dockerfile` configures ffmpeg with
`--disable-bsfs` and never re-enables anything, so `h264_mp4toannexb` and
`hevc_mp4toannexb` are not compiled into the library at all. The lookup is
working correctly — there is simply nothing for it to return.

The in-tree build is the one that has to carry the filters. `dynamo._core` is
built with the `media-ffmpeg` feature, links the plain `libavcodec.so.62`
soname, and is imported first, so it wins the load order over the copy
PyNvVideoCodec vendors. This change does not try to rearrange that load order;
it makes the library that wins contain the filters it needs.

## Details:

Two files change.

**`container/templates/wheel_builder.Dockerfile`**

* Adds `--enable-bsf=h264_mp4toannexb,hevc_mp4toannexb` directly after the
  existing `--disable-bsfs`. This keeps the disable-everything-then-allowlist
  shape the file already uses for encoders, decoders, parsers, muxers,
  demuxers, and protocols.
* Corrects a wrong premise in the comment on the existing negative guard. It
  claimed the reframing filters "are pulled in as mov/mp4 muxer dependencies".
  That is true of `aac_adtstoasc` and false of `h264_mp4toannexb`, and it is
  why the gap survived review the first time.
* Adds a positive post-build guard that greps `ffmpeg -bsfs` for both filters
  and fails the image build with a diagnostic dump if either is absent. Without
  it, a future configure edit that drops the flag would produce a green build
  and dead decode at runtime — exactly the failure being fixed here.

A bitstream filter reframes an already-encoded stream and carries no codec
implementation, so enabling these two adds no royalty-bearing surface. The
`--disable-bsfs` baseline stays, the encoder/decoder/parser allowlists are
byte-identical to `main`, and the pre-existing guard that greps the built
binary for H.264/HEVC/AAC/NVENC/CUVID implementations is untouched.

**`container/compliance/tests/test_ffmpeg_bitstream_filters.py`** (new)

Renders the vLLM CUDA-13.0 amd64 runtime Dockerfile through
`container/render.py`, parses the in-tree ffmpeg `./configure` flags out of the
result, and pins both halves of the contract: the two reframing filters are
requested on top of the `--disable-bsfs` baseline, and no `--enable-encoder`,
`--enable-decoder`, or `--enable-parser` names a royalty-bearing codec. It
asserts against the *rendered* Dockerfile rather than the template, so a Jinja
gate that dropped the ffmpeg build out of the vLLM image would also fail it. No
GPU, Docker, or network is required.

## Where should the reviewer start?

1. `container/templates/wheel_builder.Dockerfile:388` — the one-line configure
   change. That line is the fix; everything else guards it.
2. `container/templates/wheel_builder.Dockerfile:422-431` — the new positive
   guard. It is shell inside a `RUN`, so it runs for the first time during the
   image build in CI, not in any unit test.
3. `container/compliance/tests/test_ffmpeg_bitstream_filters.py:124` —
   `test_nvdec_reframing_bitstream_filters_are_built`, the test that fails if
   the configure flag is removed.

Overlapping work: open PR #13936 proposes the same one-line `./configure`
change under a different tracker ID. Whoever merges second should expect a
trivial conflict on that single line.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

An internal NVIDIA tracker ticket (DYN-4162) also covers this work; there is no
public GitHub issue for it.

## Validation

* The new rendered-Dockerfile test passes with the fix in place, and fails with
  `in-tree ffmpeg would not build ['h264_mp4toannexb', 'hevc_mp4toannexb']`
  when the `--enable-bsf` line alone is removed.
* The compliance half was checked the other way round: appending `h264` to
  `--enable-decoder` — the tempting wrong fix, a software decoder instead of a
  bitstream filter — fails `test_no_royalty_bearing_codec_is_enabled[decoder]`
  while every other test stays green.
* The surrounding media suites stay green: `test_nvdec_decoder.py`,
  `test_codec_errors.py`, `container/compliance/tests/test_scan_codecs.py`, and
  `test_install_media_decoders.py`.
* `pre-commit` passes over both changed files.

Not covered before merge: the image build itself. The new post-build guard and
the artifact-level claim — that the ffmpeg shipped inside the built image really
contains both filters — first execute in CI's `vllm-build`, and the end-to-end
proof is `test_nvdec_decodes_real_clips` in the post-merge `vllm-test` lane.
Please treat both as the real gate rather than the unit tests above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added support for required H.264 and HEVC FFmpeg bitstream filters.
  * Added build-time validation to ensure these filters are included.
  * Continued restricting unsupported and royalty-bearing codec implementations.

* **Tests**
  * Added compliance checks covering required filters and prohibited codec components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->