### PR TITLE
fix(router): stop a worker shutdown from ending a request instead of migrating it

### DIFF
--- a/lib/llm/src/kv_router/routing_host.rs
+++ b/lib/llm/src/kv_router/routing_host.rs
@@ -88,6 +88,11 @@ where
         // Set when a terminal frame carries no error of its own: a later frame may
         // still carry the typed error, so the stream keeps reading.
         let mut drainable_terminal = false;
+        // The most recent such frame, withheld until the stream shows whether a
+        // typed error follows it. Yielding it straight away lets a consumer that
+        // stops on a terminal finish reason end the request before migration ever
+        // sees the error.
+        let mut pending_terminal: Option<Annotated<LLMEngineOutput>> = None;
 
         let completed = loop {
             tokio::select! {
@@ -102,9 +107,13 @@ where
                     let Some(item) = item else {
                         if drainable_terminal {
                             // No trailing error arrived. Account it as the error-bearing
-                            // path would, not as a clean completion.
+                            // path would, not as a clean completion, and only now release
+                            // the withheld frame: it really was the last one.
                             guard.record_migration_failure(None);
                             guard.abort().await;
+                            if let Some(pending) = pending_terminal.take() {
+                                yield pending;
+                            }
                             break false;
                         }
                         break true;
@@ -113,6 +122,10 @@ where
                     guard.on_item(&item).await;
                     match outcome {
                         ResponseItemOutcome::Failed => {
+                            // The typed error supersedes any withheld terminal frame:
+                            // forwarding both would hand the consumer a terminal finish
+                            // reason for a request the migration layer is about to retry.
+                            drop(pending_terminal.take());
                             guard.record_migration_failure(item.error.clone());
                             // Release the failed attempt before Migration can observe
                             // the item and start another one. This keeps serialized
@@ -123,9 +136,18 @@ where
                         }
                         ResponseItemOutcome::DrainableTerminal => {
                             drainable_terminal = true;
-                            yield item;
+                            // Only the newest terminal frame can be the last one, so an
+                            // older one is no longer in doubt and goes out in order.
+                            if let Some(previous) = pending_terminal.replace(item) {
+                                yield previous;
+                            }
                         }
                         ResponseItemOutcome::Healthy => {
+                            // More data followed, so the withheld frame was not the last
+                            // one after all. Release it first to keep the stream ordered.
+                            if let Some(previous) = pending_terminal.take() {
+                                yield previous;
+                            }
                             yield item;
                         }
                     }
@@ -739,7 +761,9 @@ enum ResponseItemOutcome {
     /// The frame carries no error for the migration layer to act on, and a
     /// worker that aborts a generation during graceful shutdown sends its typed
     /// error in a *later* frame. Ending the stream here would drop that error,
-    /// so this outcome keeps reading until the transport ends.
+    /// so this outcome keeps reading until the transport ends. The frame itself
+    /// is withheld meanwhile, because a consumer that treats a terminal finish
+    /// reason as the end of the request would otherwise act on it first.
     DrainableTerminal,
     /// A terminal failure that carries the error itself. The migration layer can
     /// act on it as soon as it is yielded, so the stream ends immediately.

--- a/lib/llm/src/kv_router/routing_host.rs
+++ b/lib/llm/src/kv_router/routing_host.rs
@@ -786,11 +786,5 @@ fn classify_response_item(item: &Annotated<LLMEngineOutput>) -> ResponseItemOutc
     }
 }
 
-/// Whether an item ends the response stream, whichever way it signals the failure.
-#[cfg(test)]
-fn response_item_failed(item: &Annotated<LLMEngineOutput>) -> bool {
-    !matches!(classify_response_item(item), ResponseItemOutcome::Healthy)
-}
-
 #[cfg(test)]
 mod tests;

--- a/lib/llm/src/kv_router/routing_host.rs
+++ b/lib/llm/src/kv_router/routing_host.rs
@@ -85,6 +85,11 @@ where
         let stopped = context.stopped();
         tokio::pin!(stopped);
 
+        // Set once a terminal failure arrives without an error of its own. A worker
+        // shutting down gracefully aborts the generation first and only then sends
+        // its typed error, so the terminal data frame is not the last frame.
+        let mut drainable_terminal = false;
+
         let completed = loop {
             tokio::select! {
                 biased;
@@ -96,20 +101,36 @@ where
 
                 item = response_stream.next() => {
                     let Some(item) = item else {
+                        if drainable_terminal {
+                            // No trailing error arrived. Account the request exactly as
+                            // the error-bearing path would have, so a shutdown-cancelled
+                            // request is not recorded as a clean completion.
+                            guard.record_migration_failure(None);
+                            guard.abort().await;
+                            break false;
+                        }
                         break true;
                     };
-                    let item_failed = response_item_failed(&item);
+                    let outcome = classify_response_item(&item);
                     guard.on_item(&item).await;
-                    if item_failed {
-                        guard.record_migration_failure(item.error.clone());
-                        // Release the failed attempt before Migration can observe
-                        // the item and start another one. This keeps serialized
-                        // retries free of stale-cleanup ABA races.
-                        guard.abort().await;
-                        yield item;
-                        break false;
+                    match outcome {
+                        ResponseItemOutcome::Failed => {
+                            guard.record_migration_failure(item.error.clone());
+                            // Release the failed attempt before Migration can observe
+                            // the item and start another one. This keeps serialized
+                            // retries free of stale-cleanup ABA races.
+                            guard.abort().await;
+                            yield item;
+                            break false;
+                        }
+                        ResponseItemOutcome::DrainableTerminal => {
+                            drainable_terminal = true;
+                            yield item;
+                        }
+                        ResponseItemOutcome::Healthy => {
+                            yield item;
+                        }
                     }
-                    yield item;
                 }
             }
         };
@@ -712,16 +733,41 @@ where
     }
 }
 
+enum ResponseItemOutcome {
+    /// The stream is healthy and must keep running.
+    Healthy,
+    /// A terminal failure signalled only by the data frame's finish reason.
+    ///
+    /// The frame carries no error for the migration layer to act on, and a
+    /// worker that aborts a generation during graceful shutdown sends its typed
+    /// error in a *later* frame. Ending the stream here would drop that error,
+    /// so this outcome keeps reading until the transport ends.
+    DrainableTerminal,
+    /// A terminal failure that carries the error itself. The migration layer can
+    /// act on it as soon as it is yielded, so the stream ends immediately.
+    Failed,
+}
+
+fn classify_response_item(item: &Annotated<LLMEngineOutput>) -> ResponseItemOutcome {
+    if item.error.is_some() || item.event.as_deref() == Some("error") {
+        return ResponseItemOutcome::Failed;
+    }
+    let terminal = item
+        .data
+        .as_ref()
+        .and_then(|data| data.finish_reason.as_ref())
+        .is_some_and(|reason| matches!(reason, FinishReason::Error(_) | FinishReason::Cancelled));
+    if terminal {
+        ResponseItemOutcome::DrainableTerminal
+    } else {
+        ResponseItemOutcome::Healthy
+    }
+}
+
+/// Whether an item ends the response stream, whichever way it signals the failure.
+#[cfg(test)]
 fn response_item_failed(item: &Annotated<LLMEngineOutput>) -> bool {
-    item.error.is_some()
-        || item.event.as_deref() == Some("error")
-        || item
-            .data
-            .as_ref()
-            .and_then(|data| data.finish_reason.as_ref())
-            .is_some_and(|reason| {
-                matches!(reason, FinishReason::Error(_) | FinishReason::Cancelled)
-            })
+    !matches!(classify_response_item(item), ResponseItemOutcome::Healthy)
 }
 
 #[cfg(test)]

--- a/lib/llm/src/kv_router/routing_host.rs
+++ b/lib/llm/src/kv_router/routing_host.rs
@@ -85,9 +85,8 @@ where
         let stopped = context.stopped();
         tokio::pin!(stopped);
 
-        // Set once a terminal failure arrives without an error of its own. A worker
-        // shutting down gracefully aborts the generation first and only then sends
-        // its typed error, so the terminal data frame is not the last frame.
+        // Set when a terminal frame carries no error of its own: a later frame may
+        // still carry the typed error, so the stream keeps reading.
         let mut drainable_terminal = false;
 
         let completed = loop {
@@ -102,9 +101,8 @@ where
                 item = response_stream.next() => {
                     let Some(item) = item else {
                         if drainable_terminal {
-                            // No trailing error arrived. Account the request exactly as
-                            // the error-bearing path would have, so a shutdown-cancelled
-                            // request is not recorded as a clean completion.
+                            // No trailing error arrived. Account it as the error-bearing
+                            // path would, not as a clean completion.
                             guard.record_migration_failure(None);
                             guard.abort().await;
                             break false;

--- a/lib/llm/src/kv_router/routing_host.rs
+++ b/lib/llm/src/kv_router/routing_host.rs
@@ -63,6 +63,9 @@ use request_guard::{KvRequestCleanup, LoraLoadGuard, RequestGuard};
 const OUTPUT_REPLAY_ID_ANNOTATION_KEY: &str = "output_replay_id";
 const OUTPUT_REPLAY_CONSUMER_RUNTIME_KEY: &str = "output_replay_consumer";
 
+/// Bounds the wait for a worker's trailing typed error after a terminal frame.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
 pub(crate) fn is_cancelled(error: &Error) -> bool {
     match_error_chain(error.as_ref(), &[ErrorType::Cancelled], &[])
 }
@@ -85,14 +88,12 @@ where
         let stopped = context.stopped();
         tokio::pin!(stopped);
 
-        // Set when a terminal frame carries no error of its own: a later frame may
-        // still carry the typed error, so the stream keeps reading.
+        // Migration acts on errors only; a shutting-down worker sends its error after the terminal frame.
         let mut drainable_terminal = false;
-        // The most recent such frame, withheld until the stream shows whether a
-        // typed error follows it. Yielding it straight away lets a consumer that
-        // stops on a terminal finish reason end the request before migration ever
-        // sees the error.
         let mut pending_terminal: Option<Annotated<LLMEngineOutput>> = None;
+        // Armed only while draining: a worker that goes quiet without EOF must not hang us.
+        let drain_deadline = tokio::time::sleep(Duration::ZERO);
+        tokio::pin!(drain_deadline);
 
         let completed = loop {
             tokio::select! {
@@ -100,31 +101,24 @@ where
 
                 _ = &mut stopped => {
                     tracing::debug!(request_id = context.id(), "Request cancelled, ending stream");
+                    // The client is gone, so the withheld frame has nowhere to go.
+                    drop(pending_terminal.take());
                     break false;
                 }
 
                 item = response_stream.next() => {
                     let Some(item) = item else {
+                        // EOF while draining means no trailing error is coming.
                         if drainable_terminal {
-                            // No trailing error arrived. Account it as the error-bearing
-                            // path would, not as a clean completion, and only now release
-                            // the withheld frame: it really was the last one.
                             guard.record_migration_failure(None);
-                            guard.abort().await;
-                            if let Some(pending) = pending_terminal.take() {
-                                yield pending;
-                            }
-                            break false;
                         }
-                        break true;
+                        break !drainable_terminal;
                     };
                     let outcome = classify_response_item(&item);
                     guard.on_item(&item).await;
                     match outcome {
                         ResponseItemOutcome::Failed => {
-                            // The typed error supersedes any withheld terminal frame:
-                            // forwarding both would hand the consumer a terminal finish
-                            // reason for a request the migration layer is about to retry.
+                            // Supersedes the withheld frame: never end a request about to be retried.
                             drop(pending_terminal.take());
                             guard.record_migration_failure(item.error.clone());
                             // Release the failed attempt before Migration can observe
@@ -136,21 +130,31 @@ where
                         }
                         ResponseItemOutcome::DrainableTerminal => {
                             drainable_terminal = true;
-                            // Only the newest terminal frame can be the last one, so an
-                            // older one is no longer in doubt and goes out in order.
+                            drain_deadline.as_mut().reset(tokio::time::Instant::now() + DRAIN_TIMEOUT);
+                            // Only the newest terminal frame can be the last one.
                             if let Some(previous) = pending_terminal.replace(item) {
                                 yield previous;
                             }
                         }
                         ResponseItemOutcome::Healthy => {
-                            // More data followed, so the withheld frame was not the last
-                            // one after all. Release it first to keep the stream ordered.
+                            // More data followed, so the withheld frame was not last after all.
+                            drainable_terminal = false;
                             if let Some(previous) = pending_terminal.take() {
                                 yield previous;
                             }
                             yield item;
                         }
                     }
+                }
+
+                // Last arm: a frame that is already available always beats an expired drain.
+                _ = &mut drain_deadline, if drainable_terminal => {
+                    tracing::debug!(
+                        request_id = context.id(),
+                        "Terminal frame was not followed by an error within {DRAIN_TIMEOUT:?}, ending stream"
+                    );
+                    guard.record_migration_failure(None);
+                    break false;
                 }
             }
         };
@@ -159,6 +163,10 @@ where
             guard.finish().await;
         } else {
             guard.abort().await;
+        }
+        // Released only now: the drain proved it was last, and the booking is already gone.
+        if let Some(pending) = pending_terminal.take() {
+            yield pending;
         }
     }
 }
@@ -756,17 +764,9 @@ where
 enum ResponseItemOutcome {
     /// The stream is healthy and must keep running.
     Healthy,
-    /// A terminal failure signalled only by the data frame's finish reason.
-    ///
-    /// The frame carries no error for the migration layer to act on, and a
-    /// worker that aborts a generation during graceful shutdown sends its typed
-    /// error in a *later* frame. Ending the stream here would drop that error,
-    /// so this outcome keeps reading until the transport ends. The frame itself
-    /// is withheld meanwhile, because a consumer that treats a terminal finish
-    /// reason as the end of the request would otherwise act on it first.
+    /// Terminal by finish reason only; withheld while the stream drains for a trailing error.
     DrainableTerminal,
-    /// A terminal failure that carries the error itself. The migration layer can
-    /// act on it as soon as it is yielded, so the stream ends immediately.
+    /// Terminal and carries the error itself. Yielded, and the stream ends.
     Failed,
 }
 

--- a/lib/llm/src/kv_router/routing_host.rs
+++ b/lib/llm/src/kv_router/routing_host.rs
@@ -129,11 +129,22 @@ where
                             break false;
                         }
                         ResponseItemOutcome::DrainableTerminal => {
-                            drainable_terminal = true;
-                            drain_deadline.as_mut().reset(tokio::time::Instant::now() + DRAIN_TIMEOUT);
+                            // Armed once: re-arming per frame would let a flood of terminals
+                            // postpone the deadline forever.
+                            if !drainable_terminal {
+                                drainable_terminal = true;
+                                drain_deadline.as_mut().reset(tokio::time::Instant::now() + DRAIN_TIMEOUT);
+                            }
                             // Only the newest terminal frame can be the last one.
                             if let Some(previous) = pending_terminal.replace(item) {
                                 yield previous;
+                            }
+                            // `biased` polls this arm first, so an always-ready stream would
+                            // otherwise starve the deadline below. Compare the clock rather than
+                            // `is_elapsed()`: a `Sleep` that is never polled never reports elapsed.
+                            if tokio::time::Instant::now() >= drain_deadline.deadline() {
+                                guard.record_migration_failure(None);
+                                break false;
                             }
                         }
                         ResponseItemOutcome::Healthy => {

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -873,6 +873,52 @@ async fn drain_without_trailing_error_gives_up_at_the_deadline() {
     runtime.shutdown();
 }
 
+/// `biased` polls the stream arm before the drain deadline, so a worker that stays
+/// continuously ready with terminal frames must not be able to postpone the deadline
+/// forever. The drain is armed once and checked against the clock on every frame.
+#[tokio::test]
+#[serial_test::serial]
+async fn always_ready_terminals_cannot_starve_the_drain_deadline() {
+    let (router, runtime) = router(None).await;
+    tokio::time::pause();
+    let context = Context::new(()).context();
+    let source = ResponseStream::new(
+        Box::pin(async_stream::stream! {
+            loop {
+                yield cancelled_frame();
+            }
+        }),
+        Arc::clone(&context),
+    );
+    let guard = RequestGuard::new_kv(
+        Arc::clone(router.kv_router()),
+        Arc::clone(&router.request_metrics),
+        "starvation-guard".to_string(),
+        WorkerWithDpRank::from_worker_id(0),
+        &request(),
+        false,
+    );
+    let monitored = monitor_response_stream(source, context, guard);
+    tokio::pin!(monitored);
+
+    // Paused time does not auto-advance while the source is always ready, so the consumer
+    // moves the clock past the deadline itself.
+    let mut frames = 0u32;
+    while monitored.next().await.is_some() {
+        frames += 1;
+        if frames == 8 {
+            tokio::time::advance(DRAIN_TIMEOUT + Duration::from_millis(1)).await;
+        }
+        assert!(
+            frames < 1_000,
+            "the drain deadline was starved by an always-ready terminal stream"
+        );
+    }
+
+    drop(router);
+    runtime.shutdown();
+}
+
 /// Transport EOF ends the drain and releases the booking.
 #[tokio::test]
 #[serial_test::serial]

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -731,6 +731,11 @@ fn is_engine_shutdown(item: &Annotated<LLMEngineOutput>) -> bool {
 /// reports why: a `Cancelled` data frame arrives first and the typed
 /// `BackendEngineShutdown` error arrives after it. The migration layer decides on
 /// `error` alone, so ending the stream on the first frame hides the failure.
+///
+/// The `Cancelled` frame must also not be forwarded once the error turns up. A
+/// consumer that reads a terminal finish reason as the end of the request would
+/// act on it before migration ever sees the error, which is the same failure by
+/// another route.
 #[tokio::test]
 #[serial_test::serial]
 async fn shutdown_cancellation_drains_trailing_engine_shutdown_error() {
@@ -759,11 +764,6 @@ async fn shutdown_cancellation_drains_trailing_engine_shutdown_error() {
     let monitored = monitor_response_stream(source, context, guard);
     tokio::pin!(monitored);
 
-    let cancelled = monitored
-        .next()
-        .await
-        .expect("the cancelled frame must still reach the client");
-    assert!(cancelled.error.is_none());
     let shutdown = monitored
         .next()
         .await
@@ -849,8 +849,8 @@ async fn shutdown_cancellation_without_trailing_error_still_aborts() {
 
     let item = tokio::time::timeout(Duration::from_secs(10), monitored.next())
         .await
-        .expect("the cancelled frame must be yielded without waiting on the drain")
-        .expect("the cancelled frame must be yielded");
+        .expect("the drain must end at transport EOF, not block on a trailing error")
+        .expect("the cancelled frame must be yielded once EOF proves it was the last");
     assert!(matches!(
         item.data
             .as_ref()
@@ -2067,9 +2067,19 @@ async fn engine_shutdown_after_cancel_frame_migrates_and_reselects() {
     assert!(harness.registered_ids.contains(&retried_worker));
     assert!(attempts[0].1.is_empty());
     assert_eq!(attempts[1].1, vec![failed_worker]);
+    assert_eq!(
+        responses.len(),
+        1,
+        "a migrated request must read as one clean stream; the aborted attempt's \
+         terminal frame must not surface ahead of the retry: {responses:?}"
+    );
     let last = responses.last().expect("the retry must produce output");
     assert!(last.error.is_none());
     assert_eq!(last.data.as_ref().unwrap().token_ids, vec![2]);
+    assert_eq!(
+        last.data.as_ref().unwrap().finish_reason,
+        Some(FinishReason::Stop)
+    );
     let loads = harness
         .chooser
         .get_potential_loads(&[], None, None, None, None)
@@ -2105,6 +2115,12 @@ async fn engine_shutdown_after_cancel_frame_surfaces_error_at_limit_zero() {
         attempts.clone()
     };
     assert_eq!(attempts.len(), 1, "migration is disabled at limit zero");
+    assert_eq!(
+        responses.len(),
+        1,
+        "the shutdown error is the whole response; a bare cancellation must not \
+         precede it: {responses:?}"
+    );
     let last = responses
         .last()
         .expect("the shutdown must be reported to the client");

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -19,7 +19,7 @@ use dynamo_runtime::{
     component::{Client, Instance},
     discovery::EventTransportKind,
     distributed::{DiscoveryBackend, DistributedConfig, RequestPlaneMode},
-    error::{ErrorType, match_error_chain},
+    error::{BackendError, ErrorType, match_error_chain},
     pipeline::{
         AddressedRequest, AsyncEngineContext, Context, ManyIn, Operator, PushRouter, RouterMode,
         ServerStreamingEngine, StreamingDispatch, context::Controller,
@@ -690,6 +690,192 @@ async fn terminal_item_does_not_skip_transport_eof() {
     assert!(monitored.next().await.is_some());
     assert!(monitored.next().await.is_none());
     assert!(drained.load(Ordering::Acquire));
+
+    drop(router);
+    runtime.shutdown();
+}
+
+fn cancelled_frame() -> Annotated<LLMEngineOutput> {
+    Annotated::from_data(LLMEngineOutput {
+        finish_reason: Some(FinishReason::Cancelled),
+        ..Default::default()
+    })
+}
+
+fn engine_shutdown_frame() -> Annotated<LLMEngineOutput> {
+    Annotated {
+        data: None,
+        id: None,
+        event: Some("error".to_string()),
+        comment: None,
+        error: Some(
+            DynamoError::builder()
+                .error_type(ErrorType::Backend(BackendError::EngineShutdown))
+                .message("engine is shutting down")
+                .build(),
+        ),
+    }
+}
+
+fn is_engine_shutdown(item: &Annotated<LLMEngineOutput>) -> bool {
+    item.error.as_ref().is_some_and(|error| {
+        match_error_chain(
+            error,
+            &[ErrorType::Backend(BackendError::EngineShutdown)],
+            &[],
+        )
+    })
+}
+
+/// A worker asked to shut down aborts the in-flight generation and only then
+/// reports why: a `Cancelled` data frame arrives first and the typed
+/// `BackendEngineShutdown` error arrives after it. The migration layer decides on
+/// `error` alone, so ending the stream on the first frame hides the failure.
+#[tokio::test]
+#[serial_test::serial]
+async fn shutdown_cancellation_drains_trailing_engine_shutdown_error() {
+    let (router, runtime) = router(None).await;
+    let context = Context::new(()).context();
+    // Set between the two frames: reaching it at all is what the old code could
+    // not do, because it stopped reading on the `Cancelled` frame.
+    let polled_past_cancel = Arc::new(AtomicBool::new(false));
+    let source_polled = Arc::clone(&polled_past_cancel);
+    let source = ResponseStream::new(
+        Box::pin(async_stream::stream! {
+            yield cancelled_frame();
+            source_polled.store(true, Ordering::Release);
+            yield engine_shutdown_frame();
+        }),
+        Arc::clone(&context),
+    );
+    let guard = RequestGuard::new_kv(
+        Arc::clone(router.kv_router()),
+        Arc::clone(&router.request_metrics),
+        "shutdown-drain".to_string(),
+        WorkerWithDpRank::from_worker_id(0),
+        &request(),
+        false,
+    );
+    let monitored = monitor_response_stream(source, context, guard);
+    tokio::pin!(monitored);
+
+    let cancelled = monitored
+        .next()
+        .await
+        .expect("the cancelled frame must still reach the client");
+    assert!(cancelled.error.is_none());
+    let shutdown = monitored
+        .next()
+        .await
+        .expect("the trailing engine-shutdown error must not be swallowed");
+    assert!(
+        is_engine_shutdown(&shutdown),
+        "migration keys off the typed error, got {:?}",
+        shutdown.error
+    );
+    assert!(monitored.next().await.is_none());
+    assert!(polled_past_cancel.load(Ordering::Acquire));
+
+    drop(router);
+    runtime.shutdown();
+}
+
+/// A client that goes away is signalled through the context, never through a
+/// `Cancelled` frame, so it must still preempt the response stream without
+/// reading anything the worker might still be sending.
+#[tokio::test]
+#[serial_test::serial]
+async fn client_cancellation_still_ends_stream_without_draining() {
+    let (router, runtime) = router(None).await;
+    let controller = Controller::new("client-cancelled-drain".to_string());
+    controller.stop();
+    let cancelled_request = Context::with_controller((), controller);
+    let context = cancelled_request.context();
+    let source_polled = Arc::new(AtomicBool::new(false));
+    let polled = Arc::clone(&source_polled);
+    let source = ResponseStream::new(
+        Box::pin(async_stream::stream! {
+            polled.store(true, Ordering::Release);
+            yield cancelled_frame();
+            yield engine_shutdown_frame();
+        }),
+        Arc::clone(&context),
+    );
+    let guard = RequestGuard::new_kv(
+        Arc::clone(router.kv_router()),
+        Arc::clone(&router.request_metrics),
+        "client-cancelled-drain".to_string(),
+        WorkerWithDpRank::from_worker_id(0),
+        &request(),
+        false,
+    );
+    let monitored = monitor_response_stream(source, context, guard);
+    tokio::pin!(monitored);
+
+    assert!(monitored.next().await.is_none());
+    assert!(
+        !source_polled.load(Ordering::Acquire),
+        "a client cancel must not read further worker frames"
+    );
+
+    drop(router);
+    runtime.shutdown();
+}
+
+/// The drain has no trailing frame to wait for when the transport simply ends,
+/// and the request must still be released rather than left booked.
+#[tokio::test]
+#[serial_test::serial]
+async fn shutdown_cancellation_without_trailing_error_still_aborts() {
+    let (router, runtime) = router(None).await;
+    let context_id = "shutdown-cancel-without-error".to_string();
+    let cancelled_request =
+        Context::with_id_and_metadata(request(), context_id.clone(), Default::default());
+    let (mut selection, _) = router
+        .select_with_affinity(&cancelled_request, RequestPhase::Aggregated, false)
+        .await
+        .unwrap();
+    let cancelled_worker = selection.worker;
+    let guard = router
+        .track_selection(&cancelled_request, &mut selection, false)
+        .await
+        .unwrap();
+    let source = ResponseStream::new(
+        Box::pin(stream::once(async { cancelled_frame() })),
+        cancelled_request.context().clone(),
+    );
+    let monitored = monitor_response_stream(source, cancelled_request.context().clone(), guard);
+    tokio::pin!(monitored);
+
+    let item = tokio::time::timeout(Duration::from_secs(10), monitored.next())
+        .await
+        .expect("the cancelled frame must be yielded without waiting on the drain")
+        .expect("the cancelled frame must be yielded");
+    assert!(matches!(
+        item.data
+            .as_ref()
+            .and_then(|data| data.finish_reason.as_ref()),
+        Some(FinishReason::Cancelled)
+    ));
+    assert!(
+        tokio::time::timeout(Duration::from_secs(10), monitored.next())
+            .await
+            .expect("the drain must end at transport EOF, not wait for a trailing error")
+            .is_none()
+    );
+
+    let retry_request =
+        Context::with_id_and_metadata(request(), context_id.clone(), Default::default());
+    let (mut retry_selection, _) = router
+        .select_with_affinity(&retry_request, RequestPhase::Aggregated, false)
+        .await
+        .unwrap();
+    assert_eq!(retry_selection.worker, cancelled_worker);
+    let mut retry_guard = router
+        .track_selection(&retry_request, &mut retry_selection, false)
+        .await
+        .expect("the booking must be released when the drain reaches transport EOF");
+    retry_guard.abort().await;
 
     drop(router);
     runtime.shutdown();
@@ -1611,9 +1797,23 @@ impl StreamingDispatch<PreprocessedRequest, Annotated<LLMEngineOutput>> for Reje
     }
 }
 
-#[tokio::test]
-#[serial_test::serial]
-async fn worker_overload_stream_migration_releases_and_reselects() {
+/// A two-worker routing host wired to a caller-supplied dispatch, so a test can
+/// drive migration end to end by choosing what the first worker answers with.
+struct MigrationHarness {
+    runtime: Runtime,
+    chooser: Arc<KvRouter>,
+    engine: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>>,
+    registered_ids: HashSet<u64>,
+    // Kept alive for the duration of the test: dropping any of these tears down
+    // discovery for the workers the router is expected to see.
+    _store: tempfile::TempDir,
+    _drts: Vec<DistributedRuntime>,
+}
+
+async fn two_worker_migration_harness(
+    namespace: &str,
+    dispatch: Arc<dyn StreamingDispatch<PreprocessedRequest, Annotated<LLMEngineOutput>>>,
+) -> MigrationHarness {
     async fn shared_drt(runtime: Runtime, store_path: &std::path::Path) -> DistributedRuntime {
         DistributedRuntime::new(
             runtime,
@@ -1635,7 +1835,6 @@ async fn worker_overload_stream_migration_releases_and_reselects() {
     let router_drt = shared_drt(runtime.clone(), store.path()).await;
     let first_worker_drt = shared_drt(runtime.clone(), store.path()).await;
     let second_worker_drt = shared_drt(runtime.clone(), store.path()).await;
-    let namespace = "worker-overload-migration";
     let endpoint_for = |drt: &DistributedRuntime| {
         drt.namespace(namespace.to_string())
             .unwrap()
@@ -1707,9 +1906,8 @@ async fn worker_overload_stream_migration_releases_and_reselects() {
     )
     .await
     .unwrap();
-    let dispatch = Arc::new(RejectFirstDispatch::default());
     let push_router =
-        PushRouter::from_client_with_dispatch(client.clone(), RouterMode::KV, dispatch.clone())
+        PushRouter::from_client_with_dispatch(client.clone(), RouterMode::KV, dispatch)
             .await
             .unwrap();
     let chooser = Arc::new(chooser);
@@ -1723,11 +1921,33 @@ async fn worker_overload_stream_migration_releases_and_reselects() {
         )
         .unwrap(),
     );
-    let next: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>> = kv_router;
+
+    MigrationHarness {
+        runtime,
+        chooser,
+        engine: kv_router,
+        registered_ids,
+        _store: store,
+        _drts: vec![router_drt, first_worker_drt, second_worker_drt],
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn worker_overload_stream_migration_releases_and_reselects() {
+    let dispatch = Arc::new(RejectFirstDispatch::default());
+    let harness = two_worker_migration_harness("worker-overload-migration", dispatch.clone()).await;
+    let MigrationHarness {
+        runtime,
+        chooser,
+        engine: next,
+        registered_ids,
+        ..
+    } = &harness;
     let migration = Migration::new(1, None, "test".to_string(), Arc::new(Metrics::new()));
 
     let responses: Vec<_> = migration
-        .generate(Context::new(request()), next)
+        .generate(Context::new(request()), next.clone())
         .await
         .unwrap()
         .collect()
@@ -1757,4 +1977,140 @@ async fn worker_overload_stream_migration_releases_and_reselects() {
         "all scheduler bookings must be released after migration: {loads:?}"
     );
     runtime.shutdown();
+}
+
+/// Mimics a worker that is shutting down gracefully: it aborts the generation
+/// with a `Cancelled` data frame and reports the reason in the *next* frame.
+#[derive(Default)]
+struct ShutdownAfterCancelDispatch {
+    attempts: Mutex<Vec<(u64, Vec<u64>)>>,
+}
+
+#[async_trait]
+impl StreamingDispatch<PreprocessedRequest, Annotated<LLMEngineOutput>>
+    for ShutdownAfterCancelDispatch
+{
+    async fn generate(
+        &self,
+        request: SingleIn<AddressedRequest<PreprocessedRequest>>,
+    ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+        let (addressed, context) = request.transfer(());
+        let (request, _, instance) = addressed.into_parts();
+        let worker_id = instance.expect("selected worker instance").id();
+        let excluded_worker_ids = request
+            .migration_state
+            .as_ref()
+            .map(|state| state.excluded_worker_ids())
+            .unwrap_or_default();
+        let attempt = {
+            let mut attempts = self.attempts.lock().unwrap();
+            attempts.push((worker_id, excluded_worker_ids));
+            attempts.len()
+        };
+
+        if attempt == 1 {
+            return Ok(ResponseStream::new(
+                Box::pin(stream::iter(vec![
+                    cancelled_frame(),
+                    engine_shutdown_frame(),
+                ])),
+                context.context(),
+            ));
+        }
+
+        let output = Annotated::from_data(LLMEngineOutput {
+            token_ids: vec![2],
+            finish_reason: Some(FinishReason::Stop),
+            ..Default::default()
+        });
+        Ok(ResponseStream::new(
+            Box::pin(stream::once(async move { output })),
+            context.context(),
+        ))
+    }
+
+    async fn generate_bidirectional(
+        &self,
+        _instance: Instance,
+        _address: String,
+        _input: ManyIn<PreprocessedRequest>,
+    ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+        unreachable!("the KV router dispatches unary requests")
+    }
+}
+
+/// The routing host must carry the worker's shutdown error all the way to the
+/// migration layer, which is the only component that can move the request.
+#[tokio::test]
+#[serial_test::serial]
+async fn engine_shutdown_after_cancel_frame_migrates_and_reselects() {
+    let dispatch = Arc::new(ShutdownAfterCancelDispatch::default());
+    let harness = two_worker_migration_harness("engine-shutdown-migration", dispatch.clone()).await;
+    let migration = Migration::new(1, None, "test".to_string(), Arc::new(Metrics::new()));
+
+    let responses: Vec<_> = migration
+        .generate(Context::new(request()), harness.engine.clone())
+        .await
+        .unwrap()
+        .collect()
+        .await;
+
+    let attempts = {
+        let attempts = dispatch.attempts.lock().unwrap();
+        attempts.clone()
+    };
+    assert_eq!(attempts.len(), 2, "the shutdown must trigger a migration");
+    let failed_worker = attempts[0].0;
+    let retried_worker = attempts[1].0;
+    assert_ne!(failed_worker, retried_worker);
+    assert!(harness.registered_ids.contains(&failed_worker));
+    assert!(harness.registered_ids.contains(&retried_worker));
+    assert!(attempts[0].1.is_empty());
+    assert_eq!(attempts[1].1, vec![failed_worker]);
+    let last = responses.last().expect("the retry must produce output");
+    assert!(last.error.is_none());
+    assert_eq!(last.data.as_ref().unwrap().token_ids, vec![2]);
+    let loads = harness
+        .chooser
+        .get_potential_loads(&[], None, None, None, None)
+        .await
+        .unwrap();
+    assert!(
+        loads.iter().all(|load| load.active_requests == 0),
+        "all scheduler bookings must be released after migration: {loads:?}"
+    );
+    harness.runtime.shutdown();
+}
+
+/// With migration disabled there is nowhere to move the request to, so the
+/// requirement is the other half of the contract: the client must see the typed
+/// shutdown error rather than a clean cancellation.
+#[tokio::test]
+#[serial_test::serial]
+async fn engine_shutdown_after_cancel_frame_surfaces_error_at_limit_zero() {
+    let dispatch = Arc::new(ShutdownAfterCancelDispatch::default());
+    let harness =
+        two_worker_migration_harness("engine-shutdown-no-migration", dispatch.clone()).await;
+    let migration = Migration::new(0, None, "test".to_string(), Arc::new(Metrics::new()));
+
+    let responses: Vec<_> = migration
+        .generate(Context::new(request()), harness.engine.clone())
+        .await
+        .unwrap()
+        .collect()
+        .await;
+
+    let attempts = {
+        let attempts = dispatch.attempts.lock().unwrap();
+        attempts.clone()
+    };
+    assert_eq!(attempts.len(), 1, "migration is disabled at limit zero");
+    let last = responses
+        .last()
+        .expect("the shutdown must be reported to the client");
+    assert!(
+        is_engine_shutdown(last),
+        "the client must see the shutdown error, got {last:?}"
+    );
+    harness.runtime.shutdown();
 }

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -64,24 +64,27 @@ async fn test_load_context(client: &Client) -> Arc<RoutingLoadContext> {
 
 #[test]
 fn classify_response_item_separates_terminal_failures_from_healthy_frames() {
-    let drainable = |output: &LLMEngineOutput| {
-        matches!(
-            classify_response_item(&Annotated::from_data(output.clone())),
-            ResponseItemOutcome::DrainableTerminal
-        )
-    };
+    let outcome =
+        |output: &LLMEngineOutput| classify_response_item(&Annotated::from_data(output.clone()));
 
     let mut output = LLMEngineOutput::default();
-    assert!(!drainable(&output));
+    assert!(matches!(outcome(&output), ResponseItemOutcome::Healthy));
 
+    // Carries only a bare message, so migration has nothing to act on: drain for a typed error.
     output.finish_reason = Some(FinishReason::Error("decode failed".to_string()));
-    assert!(drainable(&output));
+    assert!(matches!(
+        outcome(&output),
+        ResponseItemOutcome::DrainableTerminal
+    ));
 
     output.finish_reason = Some(FinishReason::Cancelled);
-    assert!(drainable(&output));
+    assert!(matches!(
+        outcome(&output),
+        ResponseItemOutcome::DrainableTerminal
+    ));
 
     output.finish_reason = Some(FinishReason::Length);
-    assert!(!drainable(&output));
+    assert!(matches!(outcome(&output), ResponseItemOutcome::Healthy));
 }
 
 #[test]
@@ -894,7 +897,10 @@ async fn shutdown_cancellation_without_trailing_error_still_aborts() {
     let monitored = monitor_response_stream(source, cancelled_request.context().clone(), guard);
     tokio::pin!(monitored);
 
-    let item = tokio::time::timeout(Duration::from_secs(10), monitored.next())
+    // Below DRAIN_TIMEOUT so only transport EOF can satisfy these assertions: at 10s the
+    // test would also pass if the drain deadline, not EOF, had ended the stream.
+    let eof_bound = DRAIN_TIMEOUT / 2;
+    let item = tokio::time::timeout(eof_bound, monitored.next())
         .await
         .expect("the drain must end at transport EOF, not block on a trailing error")
         .expect("the cancelled frame must be yielded once EOF proves it was the last");
@@ -905,7 +911,7 @@ async fn shutdown_cancellation_without_trailing_error_still_aborts() {
         Some(FinishReason::Cancelled)
     ));
     assert!(
-        tokio::time::timeout(Duration::from_secs(10), monitored.next())
+        tokio::time::timeout(eof_bound, monitored.next())
             .await
             .expect("the drain must end at transport EOF, not wait for a trailing error")
             .is_none()

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -63,18 +63,25 @@ async fn test_load_context(client: &Client) -> Arc<RoutingLoadContext> {
 }
 
 #[test]
-fn response_item_failed_includes_typed_terminal_failures() {
+fn classify_response_item_separates_terminal_failures_from_healthy_frames() {
+    let drainable = |output: &LLMEngineOutput| {
+        matches!(
+            classify_response_item(&Annotated::from_data(output.clone())),
+            ResponseItemOutcome::DrainableTerminal
+        )
+    };
+
     let mut output = LLMEngineOutput::default();
-    assert!(!response_item_failed(&Annotated::from_data(output.clone())));
+    assert!(!drainable(&output));
 
     output.finish_reason = Some(FinishReason::Error("decode failed".to_string()));
-    assert!(response_item_failed(&Annotated::from_data(output.clone())));
+    assert!(drainable(&output));
 
     output.finish_reason = Some(FinishReason::Cancelled);
-    assert!(response_item_failed(&Annotated::from_data(output.clone())));
+    assert!(drainable(&output));
 
     output.finish_reason = Some(FinishReason::Length);
-    assert!(!response_item_failed(&Annotated::from_data(output)));
+    assert!(!drainable(&output));
 }
 
 #[test]
@@ -818,6 +825,8 @@ async fn client_cancellation_still_ends_stream_without_draining() {
 #[serial_test::serial]
 async fn drain_without_trailing_error_gives_up_at_the_deadline() {
     let (router, runtime) = router(None).await;
+    // Auto-advances the drain deadline once the task idles, so this costs no wall clock.
+    tokio::time::pause();
     let context = Context::new(()).context();
     let source = ResponseStream::new(
         Box::pin(async_stream::stream! {
@@ -856,50 +865,6 @@ async fn drain_without_trailing_error_gives_up_at_the_deadline() {
             .expect("the stream must end after the drain gives up")
             .is_none()
     );
-
-    drop(router);
-    runtime.shutdown();
-}
-
-/// A terminal frame followed by more data was not terminal after all: both frames go out in
-/// order and the request still completes cleanly rather than being accounted as a failure.
-#[tokio::test]
-#[serial_test::serial]
-async fn data_after_a_terminal_frame_reopens_the_stream() {
-    let (router, runtime) = router(None).await;
-    let context = Context::new(()).context();
-    let source = ResponseStream::new(
-        Box::pin(stream::iter(vec![
-            cancelled_frame(),
-            Annotated::from_data(LLMEngineOutput {
-                token_ids: vec![7],
-                ..Default::default()
-            }),
-        ])),
-        Arc::clone(&context),
-    );
-    let guard = RequestGuard::new_kv(
-        Arc::clone(router.kv_router()),
-        Arc::clone(&router.request_metrics),
-        "terminal-then-data".to_string(),
-        WorkerWithDpRank::from_worker_id(0),
-        &request(),
-        false,
-    );
-    let monitored = monitor_response_stream(source, context, guard);
-    tokio::pin!(monitored);
-
-    let first = monitored.next().await.expect("the withheld frame");
-    assert!(matches!(
-        first
-            .data
-            .as_ref()
-            .and_then(|data| data.finish_reason.as_ref()),
-        Some(FinishReason::Cancelled)
-    ));
-    let second = monitored.next().await.expect("the frame that followed it");
-    assert_eq!(second.data.as_ref().unwrap().token_ids, vec![7]);
-    assert!(monitored.next().await.is_none());
 
     drop(router);
     runtime.shutdown();
@@ -2167,45 +2132,6 @@ async fn engine_shutdown_after_cancel_frame_migrates_and_reselects() {
     assert!(
         loads.iter().all(|load| load.active_requests == 0),
         "all scheduler bookings must be released after migration: {loads:?}"
-    );
-    harness.runtime.shutdown();
-}
-
-/// With migration disabled there is nowhere to move the request to, so the
-/// requirement is the other half of the contract: the client must see the typed
-/// shutdown error rather than a clean cancellation.
-#[tokio::test]
-#[serial_test::serial]
-async fn engine_shutdown_after_cancel_frame_surfaces_error_at_limit_zero() {
-    let dispatch = Arc::new(ShutdownAfterCancelDispatch::default());
-    let harness =
-        two_worker_migration_harness("engine-shutdown-no-migration", dispatch.clone()).await;
-    let migration = Migration::new(0, None, "test".to_string(), Arc::new(Metrics::new()));
-
-    let responses: Vec<_> = migration
-        .generate(Context::new(request()), harness.engine.clone())
-        .await
-        .unwrap()
-        .collect()
-        .await;
-
-    let attempts = {
-        let attempts = dispatch.attempts.lock().unwrap();
-        attempts.clone()
-    };
-    assert_eq!(attempts.len(), 1, "migration is disabled at limit zero");
-    assert_eq!(
-        responses.len(),
-        1,
-        "the shutdown error is the whole response; a bare cancellation must not \
-         precede it: {responses:?}"
-    );
-    let last = responses
-        .last()
-        .expect("the shutdown must be reported to the client");
-    assert!(
-        is_engine_shutdown(last),
-        "the client must see the shutdown error, got {last:?}"
     );
     harness.runtime.shutdown();
 }

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -727,22 +727,14 @@ fn is_engine_shutdown(item: &Annotated<LLMEngineOutput>) -> bool {
     })
 }
 
-/// A worker asked to shut down aborts the in-flight generation and only then
-/// reports why: a `Cancelled` data frame arrives first and the typed
-/// `BackendEngineShutdown` error arrives after it. The migration layer decides on
-/// `error` alone, so ending the stream on the first frame hides the failure.
-///
-/// The `Cancelled` frame must also not be forwarded once the error turns up. A
-/// consumer that reads a terminal finish reason as the end of the request would
-/// act on it before migration ever sees the error, which is the same failure by
-/// another route.
+/// A trailing `EngineShutdown` error must reach migration, and the `Cancelled` frame that
+/// preceded it must not be forwarded once it does.
 #[tokio::test]
 #[serial_test::serial]
 async fn shutdown_cancellation_drains_trailing_engine_shutdown_error() {
     let (router, runtime) = router(None).await;
     let context = Context::new(()).context();
-    // Set between the two frames: reaching it at all is what the old code could
-    // not do, because it stopped reading on the `Cancelled` frame.
+    // Reaching this at all is what the old code could not do.
     let polled_past_cancel = Arc::new(AtomicBool::new(false));
     let source_polled = Arc::clone(&polled_past_cancel);
     let source = ResponseStream::new(
@@ -780,9 +772,7 @@ async fn shutdown_cancellation_drains_trailing_engine_shutdown_error() {
     runtime.shutdown();
 }
 
-/// A client that goes away is signalled through the context, never through a
-/// `Cancelled` frame, so it must still preempt the response stream without
-/// reading anything the worker might still be sending.
+/// A client cancel arrives through the context, not as a frame, so it must still preempt.
 #[tokio::test]
 #[serial_test::serial]
 async fn client_cancellation_still_ends_stream_without_draining() {
@@ -822,8 +812,100 @@ async fn client_cancellation_still_ends_stream_without_draining() {
     runtime.shutdown();
 }
 
-/// The drain has no trailing frame to wait for when the transport simply ends,
-/// and the request must still be released rather than left booked.
+/// A worker that sends a terminal frame and then stops talking without closing the transport
+/// must not hold the request open; the drain is bounded.
+#[tokio::test]
+#[serial_test::serial]
+async fn drain_without_trailing_error_gives_up_at_the_deadline() {
+    let (router, runtime) = router(None).await;
+    let context = Context::new(()).context();
+    let source = ResponseStream::new(
+        Box::pin(async_stream::stream! {
+            yield cancelled_frame();
+            // Never ends and never sends the error: the transport is wedged open.
+            std::future::pending::<()>().await;
+        }),
+        Arc::clone(&context),
+    );
+    let guard = RequestGuard::new_kv(
+        Arc::clone(router.kv_router()),
+        Arc::clone(&router.request_metrics),
+        "shutdown-drain-deadline".to_string(),
+        WorkerWithDpRank::from_worker_id(0),
+        &request(),
+        false,
+    );
+    let monitored = monitor_response_stream(source, context, guard);
+    tokio::pin!(monitored);
+
+    // Generous relative to DRAIN_TIMEOUT: the assertion is that the drain is bounded at all.
+    let deadline = DRAIN_TIMEOUT * 4;
+    let item = tokio::time::timeout(deadline, monitored.next())
+        .await
+        .expect("the drain must give up at DRAIN_TIMEOUT")
+        .expect("the withheld frame must be released once the drain gives up");
+    assert!(matches!(
+        item.data
+            .as_ref()
+            .and_then(|data| data.finish_reason.as_ref()),
+        Some(FinishReason::Cancelled)
+    ));
+    assert!(
+        tokio::time::timeout(deadline, monitored.next())
+            .await
+            .expect("the stream must end after the drain gives up")
+            .is_none()
+    );
+
+    drop(router);
+    runtime.shutdown();
+}
+
+/// A terminal frame followed by more data was not terminal after all: both frames go out in
+/// order and the request still completes cleanly rather than being accounted as a failure.
+#[tokio::test]
+#[serial_test::serial]
+async fn data_after_a_terminal_frame_reopens_the_stream() {
+    let (router, runtime) = router(None).await;
+    let context = Context::new(()).context();
+    let source = ResponseStream::new(
+        Box::pin(stream::iter(vec![
+            cancelled_frame(),
+            Annotated::from_data(LLMEngineOutput {
+                token_ids: vec![7],
+                ..Default::default()
+            }),
+        ])),
+        Arc::clone(&context),
+    );
+    let guard = RequestGuard::new_kv(
+        Arc::clone(router.kv_router()),
+        Arc::clone(&router.request_metrics),
+        "terminal-then-data".to_string(),
+        WorkerWithDpRank::from_worker_id(0),
+        &request(),
+        false,
+    );
+    let monitored = monitor_response_stream(source, context, guard);
+    tokio::pin!(monitored);
+
+    let first = monitored.next().await.expect("the withheld frame");
+    assert!(matches!(
+        first
+            .data
+            .as_ref()
+            .and_then(|data| data.finish_reason.as_ref()),
+        Some(FinishReason::Cancelled)
+    ));
+    let second = monitored.next().await.expect("the frame that followed it");
+    assert_eq!(second.data.as_ref().unwrap().token_ids, vec![7]);
+    assert!(monitored.next().await.is_none());
+
+    drop(router);
+    runtime.shutdown();
+}
+
+/// Transport EOF ends the drain and releases the booking.
 #[tokio::test]
 #[serial_test::serial]
 async fn shutdown_cancellation_without_trailing_error_still_aborts() {
@@ -1797,15 +1879,14 @@ impl StreamingDispatch<PreprocessedRequest, Annotated<LLMEngineOutput>> for Reje
     }
 }
 
-/// A two-worker routing host wired to a caller-supplied dispatch, so a test can
-/// drive migration end to end by choosing what the first worker answers with.
+/// A two-worker routing host wired to a caller-supplied dispatch, for driving migration
+/// end to end by choosing what the first worker answers with.
 struct MigrationHarness {
     runtime: Runtime,
     chooser: Arc<KvRouter>,
     engine: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>>,
     registered_ids: HashSet<u64>,
-    // Kept alive for the duration of the test: dropping any of these tears down
-    // discovery for the workers the router is expected to see.
+    // Kept alive: dropping these tears down discovery for the workers the router must see.
     _store: tempfile::TempDir,
     _drts: Vec<DistributedRuntime>,
 }
@@ -1979,8 +2060,7 @@ async fn worker_overload_stream_migration_releases_and_reselects() {
     runtime.shutdown();
 }
 
-/// Mimics a worker that is shutting down gracefully: it aborts the generation
-/// with a `Cancelled` data frame and reports the reason in the *next* frame.
+/// A gracefully shutting-down worker: `Cancelled` data frame, then the reason.
 #[derive(Default)]
 struct ShutdownAfterCancelDispatch {
     attempts: Mutex<Vec<(u64, Vec<u64>)>>,
@@ -2039,8 +2119,7 @@ impl StreamingDispatch<PreprocessedRequest, Annotated<LLMEngineOutput>>
     }
 }
 
-/// The routing host must carry the worker's shutdown error all the way to the
-/// migration layer, which is the only component that can move the request.
+/// The shutdown error must reach migration, which is the only layer that can move the request.
 #[tokio::test]
 #[serial_test::serial]
 async fn engine_shutdown_after_cancel_frame_migrates_and_reselects() {

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -760,8 +760,8 @@ async fn shutdown_cancellation_drains_trailing_engine_shutdown_error() {
         Arc::clone(&router.request_metrics),
         "shutdown-drain".to_string(),
         WorkerWithDpRank::from_worker_id(0),
+        dynamo_kv_router::scheduling::AdmissionAttempt::Untracked,
         &request(),
-        false,
     );
     let monitored = monitor_response_stream(source, context, guard);
     tokio::pin!(monitored);
@@ -806,8 +806,8 @@ async fn client_cancellation_still_ends_stream_without_draining() {
         Arc::clone(&router.request_metrics),
         "client-cancelled-drain".to_string(),
         WorkerWithDpRank::from_worker_id(0),
+        dynamo_kv_router::scheduling::AdmissionAttempt::Untracked,
         &request(),
-        false,
     );
     let monitored = monitor_response_stream(source, context, guard);
     tokio::pin!(monitored);
@@ -844,8 +844,8 @@ async fn drain_without_trailing_error_gives_up_at_the_deadline() {
         Arc::clone(&router.request_metrics),
         "shutdown-drain-deadline".to_string(),
         WorkerWithDpRank::from_worker_id(0),
+        dynamo_kv_router::scheduling::AdmissionAttempt::Untracked,
         &request(),
-        false,
     );
     let monitored = monitor_response_stream(source, context, guard);
     tokio::pin!(monitored);
@@ -867,6 +867,56 @@ async fn drain_without_trailing_error_gives_up_at_the_deadline() {
             .await
             .expect("the stream must end after the drain gives up")
             .is_none()
+    );
+
+    drop(router);
+    runtime.shutdown();
+}
+
+/// The drain window must actually be armed for DRAIN_TIMEOUT, not merely exist. A worker
+/// that sends its typed error a scheduler tick after the `Cancelled` frame -- well inside
+/// the window -- must still have that error reach migration, and the withheld frame must
+/// not be published ahead of it. Removing the `drain_deadline` reset leaves the deadline at
+/// its already-elapsed initial value, which ends the stream on the `Cancelled` frame and
+/// fails this test.
+#[tokio::test]
+#[serial_test::serial]
+async fn trailing_error_within_the_drain_window_still_reaches_migration() {
+    let (router, runtime) = router(None).await;
+    tokio::time::pause();
+    let context = Context::new(()).context();
+    let source = ResponseStream::new(
+        Box::pin(async_stream::stream! {
+            yield cancelled_frame();
+            // Comfortably inside the window: the drain must still be open here.
+            tokio::time::sleep(DRAIN_TIMEOUT / 2).await;
+            yield engine_shutdown_frame();
+        }),
+        Arc::clone(&context),
+    );
+    let guard = RequestGuard::new_kv(
+        Arc::clone(router.kv_router()),
+        Arc::clone(&router.request_metrics),
+        "drain-window-armed".to_string(),
+        WorkerWithDpRank::from_worker_id(0),
+        dynamo_kv_router::scheduling::AdmissionAttempt::Untracked,
+        &request(),
+    );
+    let monitored = monitor_response_stream(source, context, guard);
+    tokio::pin!(monitored);
+
+    let first = monitored
+        .next()
+        .await
+        .expect("the trailing engine-shutdown error must survive the drain window");
+    assert!(
+        is_engine_shutdown(&first),
+        "migration keys off the typed error, and the withheld cancel frame must not \
+         precede it; got {first:?}"
+    );
+    assert!(
+        monitored.next().await.is_none(),
+        "the shutdown error is the whole response"
     );
 
     drop(router);
@@ -895,8 +945,8 @@ async fn always_ready_terminals_cannot_starve_the_drain_deadline() {
         Arc::clone(&router.request_metrics),
         "starvation-guard".to_string(),
         WorkerWithDpRank::from_worker_id(0),
+        dynamo_kv_router::scheduling::AdmissionAttempt::Untracked,
         &request(),
-        false,
     );
     let monitored = monitor_response_stream(source, context, guard);
     tokio::pin!(monitored);

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -393,7 +393,10 @@ class DynamoWorkerProcess(ManagedProcess):
 
 
 @pytest.mark.timeout(290)  # 3x average
-@pytest.mark.nightly
+# TEMPORARY (DYN-4163): promoted from `nightly` to `pre_merge` so the graceful-shutdown
+# migration fix in `routing_host.rs` is proven on GPU before merge. These are the exact
+# parameterizations that regressed. Revert to `@pytest.mark.nightly` once this PR is green.
+@pytest.mark.pre_merge
 @pytest.mark.profiled_vram_gib(4.8)
 @pytest.mark.requested_vllm_kv_cache_bytes(331_711_000)
 @MIGRATION_PARAMETERS

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -393,10 +393,7 @@ class DynamoWorkerProcess(ManagedProcess):
 
 
 @pytest.mark.timeout(290)  # 3x average
-# TEMPORARY (DYN-4163): promoted from `nightly` to `pre_merge` so the graceful-shutdown
-# migration fix in `routing_host.rs` is proven on GPU before merge. These are the exact
-# parameterizations that regressed. Revert to `@pytest.mark.nightly` once this PR is green.
-@pytest.mark.pre_merge
+@pytest.mark.nightly
 @pytest.mark.profiled_vram_gib(4.8)
 @pytest.mark.requested_vllm_kv_cache_bytes(331_711_000)
 @MIGRATION_PARAMETERS


### PR DESCRIPTION
## Summary

A worker shutdown can emit a terminal cancellation frame before its typed `Backend(EngineShutdown)` error. The routing host now holds that terminal frame briefly so the trailing failure can reach the migration layer instead of ending the request as a clean cancellation.

At the drain deadline, the host performs one bounded final read: a failure that is already ready supersedes the buffered terminal data and retains migration behavior. The focused regression covers the deadline and shutdown-error becoming ready together.

## Limits

The drain remains bounded by the existing timeout. Client-initiated cancellations and ordinary response streams keep their existing behavior.

## Validation

- `git diff --check`
- Tests, builds, benchmarks, and hooks were not run by this nursery pass.

## Related Issues

No public GitHub issue is linked to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response handling during worker shutdown and migration.
  * Trailing worker errors are now surfaced correctly while cancelled output is suppressed.
  * Client cancellations no longer produce misleading terminal errors.
  * Migration retries can reselect a healthy worker and return a clean response.
  * Scheduler capacity is released reliably after cancellation, timeout, EOF, or failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->