### PR TITLE
Aws gb300 runner smoketest

### DIFF
--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: ''
   vcluster_namespace:
-    description: 'Host namespace where the vCluster will be created. When empty, aws-dev-01 and aws-dev-02 use the shared deploy-test namespace and other clusters use a per-run namespace.'
+    description: 'Host namespace where the vCluster will be created. When empty, aws-dev-01, aws-dev-02, and dynamo-aws-gb300 use the shared deploy-test namespace and other clusters use a per-run namespace.'
     required: false
     default: ''
   registry:
@@ -51,7 +51,7 @@ inputs:
     required: false
     default: ''
   vcluster_host_priority_class:
-    description: 'Host PriorityClass to set on pods synced from the vCluster. Use auto to set ci-nightly-high-priority only when the active kube context targets aws-dev-01 or aws-dev-02; use an empty value to disable.'
+    description: 'Host PriorityClass to set on pods synced from the vCluster. Use auto to set ci-nightly-high-priority only when the active kube context targets aws-dev-01, aws-dev-02, or dynamo-aws-gb300; use an empty value to disable.'
     required: false
     default: 'auto'
   reset_existing:
@@ -126,7 +126,11 @@ runs:
           CURRENT_CONTEXT="$(kubectl config current-context 2>/dev/null || true)"
         fi
 
-        if [[ -z "${INPUT_NAMESPACE}" && ( "${CURRENT_CONTEXT}" == *aws-dev-01* || "${CURRENT_CONTEXT}" == *aws-dev-02* ) ]]; then
+        if [[ -z "${INPUT_NAMESPACE}" && (
+              "${CURRENT_CONTEXT}" == *aws-dev-01* ||
+              "${CURRENT_CONTEXT}" == *aws-dev-02* ||
+              "${CURRENT_CONTEXT}" == *dynamo-aws-gb300*
+            ) ]]; then
           echo "namespace=dynamo-deploy-test" >> "$GITHUB_OUTPUT"
         elif [ -n "${INPUT_NAMESPACE}" ]; then
           echo "namespace=${INPUT_NAMESPACE}" >> "$GITHUB_OUTPUT"
@@ -230,7 +234,9 @@ runs:
 
         if [ "${PRIORITY_CLASS}" = "auto" ]; then
           PRIORITY_CLASS=""
-          if [[ "${CURRENT_CONTEXT}" == *aws-dev-01* || "${CURRENT_CONTEXT}" == *aws-dev-02* ]]; then
+          if [[ "${CURRENT_CONTEXT}" == *aws-dev-01* ||
+                "${CURRENT_CONTEXT}" == *aws-dev-02* ||
+                "${CURRENT_CONTEXT}" == *dynamo-aws-gb300* ]]; then
             PRIORITY_CLASS="ci-nightly-high-priority"
           fi
         fi

--- a/.github/workflows/aws-gb300-runner-smoketest.yml
+++ b/.github/workflows/aws-gb300-runner-smoketest.yml
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: AWS GB300 runner smoke test
+
+on:
+  push:
+    branches:
+      - "aws-gb300-runner-smoketest"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aws-gb300-runner-smoketest-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CUDA_IMAGE: nvcr.io/nvidia/cuda@sha256:605fb0c8acf8674e164d822da8a8521f3a655056e569f0899e72ae940e1fe7dc
+
+jobs:
+  arc-runner-smoke:
+    name: ARC runner using ${{ matrix.gpu_count }} GPU(s)
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        gpu_count: [1, 2]
+    runs-on: aws-gb300-tester-amd-gpu-v2
+    timeout-minutes: 15
+    container:
+      image: nvcr.io/nvidia/cuda@sha256:605fb0c8acf8674e164d822da8a8521f3a655056e569f0899e72ae940e1fe7dc
+      env:
+        HOME: /__w/dynamo/dynamo
+        USER: dynamo
+    steps:
+      - name: Validate runner, GPUs, and mounts
+        shell: bash
+        env:
+          GPU_COUNT: ${{ matrix.gpu_count }}
+        run: |
+          set -euo pipefail
+
+          test "$(uname -m)" = "x86_64"
+
+          mapfile -t gpu_names < <(nvidia-smi --query-gpu=name --format=csv,noheader)
+          # The ARC hook intentionally reserves two GPUs for every job. The
+          # matrix cases exercise either the first device or both devices.
+          test "${#gpu_names[@]}" -eq 2
+          if printf '%s\n' "${gpu_names[@]}" | grep -vq "GB300"; then
+            printf 'Unexpected GPU type:\n%s\n' "${gpu_names[@]}" >&2
+            exit 1
+          fi
+
+          for gpu_index in $(seq 0 $((GPU_COUNT - 1))); do
+            nvidia-smi --id="${gpu_index}" \
+              --query-gpu=index,name,uuid,memory.total \
+              --format=csv,noheader
+          done
+
+          test -d /models
+          test -d /scratch
+          test -d /dev/shm
+
+          scratch_probe="/scratch/aws-gb300-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GPU_COUNT}"
+          work_probe="${GITHUB_WORKSPACE}/.aws-gb300-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GPU_COUNT}"
+          touch "${scratch_probe}" "${work_probe}"
+          rm -f "${scratch_probe}" "${work_probe}"
+
+          shm_bytes="$(df --output=size -B1 /dev/shm | tail -1 | tr -d ' ')"
+          test "${shm_bytes}" -ge $((18 * 1024 * 1024 * 1024))
+          df -h /models /scratch /dev/shm "${GITHUB_WORKSPACE}"
+
+  prod-runner-smoke:
+    name: Prod runner creates ${{ matrix.gpu_count }}-GPU Job
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        gpu_count: [1, 2]
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 20
+    env:
+      KUBE_CONTEXT: nv-prd-dgxc.teleport.sh-dynamo-aws-gb300
+      KUBE_NAMESPACE: dynamo-deploy-test
+      GPU_COUNT: ${{ matrix.gpu_count }}
+      JOB_NAME: gb300-prod-smoke-${{ matrix.gpu_count }}-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout workflow actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Select dynamo-aws-gb300 through tbot
+        uses: $/.github/actions/set-kube-context
+
+      - name: Validate cluster access
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          kubectl get namespace "${KUBE_NAMESPACE}"
+          kubectl get priorityclass ci-nightly-high-priority
+          kubectl get pvc shared-model-cache --namespace "${KUBE_NAMESPACE}"
+          kubectl auth can-i create jobs --namespace "${KUBE_NAMESPACE}" | grep -qx yes
+          kubectl get nodes \
+            -l nvidia.com/gpu.product=NVIDIA-GB300 \
+            -o custom-columns='NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
+
+      - name: Run GPU smoke Job
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          kubectl delete job "${JOB_NAME}" \
+            --namespace "${KUBE_NAMESPACE}" \
+            --ignore-not-found=true \
+            --wait=true
+
+          kubectl apply -f - <<EOF
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: ${JOB_NAME}
+            namespace: ${KUBE_NAMESPACE}
+            labels:
+              app.kubernetes.io/name: aws-gb300-runner-smoke
+              app.kubernetes.io/part-of: dynamo-ci
+          spec:
+            activeDeadlineSeconds: 900
+            backoffLimit: 0
+            completions: 1
+            parallelism: 1
+            ttlSecondsAfterFinished: 300
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: aws-gb300-runner-smoke
+                  app.kubernetes.io/instance: ${JOB_NAME}
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: gpu-smoke
+                    image: ${CUDA_IMAGE}
+                    imagePullPolicy: IfNotPresent
+                    command: ["/bin/bash", "-ceu"]
+                    args:
+                      - |
+                        nvidia-smi
+                        gpu_count="\$(nvidia-smi --query-gpu=uuid --format=csv,noheader | wc -l | tr -d '[:space:]')"
+                        gpu_names="\$(nvidia-smi --query-gpu=name --format=csv,noheader)"
+                        test "\${gpu_count}" = "${GPU_COUNT}"
+                        if grep -vq "GB300" <<< "\${gpu_names}"; then
+                          echo "Unexpected GPU type: \${gpu_names}" >&2
+                          exit 1
+                        fi
+                        test -d /models
+                        df -h /models
+                        echo "GB300 ${GPU_COUNT}-GPU smoke passed: \${gpu_names}"
+                    resources:
+                      requests:
+                        nvidia.com/gpu: "${GPU_COUNT}"
+                      limits:
+                        nvidia.com/gpu: "${GPU_COUNT}"
+                    volumeMounts:
+                      - name: models
+                        mountPath: /models
+                volumes:
+                  - name: models
+                    persistentVolumeClaim:
+                      claimName: shared-model-cache
+          EOF
+
+          pod_name=""
+          for _ in $(seq 1 60); do
+            pod_name="$(kubectl get pods \
+              --namespace "${KUBE_NAMESPACE}" \
+              -l "job-name=${JOB_NAME}" \
+              -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+            if [ -n "${pod_name}" ]; then
+              break
+            fi
+            sleep 2
+          done
+
+          if [ -z "${pod_name}" ]; then
+            echo "::error::No pod was created for Job ${JOB_NAME}"
+            kubectl describe job "${JOB_NAME}" --namespace "${KUBE_NAMESPACE}" || true
+            exit 1
+          fi
+
+          pod_json="$(kubectl get pod "${pod_name}" --namespace "${KUBE_NAMESPACE}" -o json)"
+          jq -e '.spec.nodeSelector["nvidia.com/gpu.product"] == "NVIDIA-GB300"' <<< "${pod_json}"
+          jq -e '.spec.priorityClassName == "ci-nightly-high-priority"' <<< "${pod_json}"
+          jq -e '
+            all(
+              .spec.tolerations[]?;
+              .key != "dedicated" and
+              .key != "github-runners" and
+              .key != "nvidia.com/gpu"
+            )
+          ' <<< "${pod_json}"
+          jq -e --arg gpu_count "${GPU_COUNT}" '
+            any(
+              .spec.containers[];
+              .name == "gpu-smoke" and
+              .resources.requests["nvidia.com/gpu"] == $gpu_count and
+              .resources.limits["nvidia.com/gpu"] == $gpu_count
+            )
+          ' <<< "${pod_json}"
+
+          if ! kubectl wait \
+            --namespace "${KUBE_NAMESPACE}" \
+            --for=condition=complete \
+            "job/${JOB_NAME}" \
+            --timeout=15m; then
+            kubectl get pod "${pod_name}" --namespace "${KUBE_NAMESPACE}" -o wide || true
+            kubectl describe pod "${pod_name}" --namespace "${KUBE_NAMESPACE}" || true
+            kubectl logs "${pod_name}" --namespace "${KUBE_NAMESPACE}" --all-containers || true
+            exit 1
+          fi
+
+          kubectl logs "${pod_name}" --namespace "${KUBE_NAMESPACE}" --all-containers
+          node_name="$(kubectl get pod "${pod_name}" \
+            --namespace "${KUBE_NAMESPACE}" \
+            -o jsonpath='{.spec.nodeName}')"
+
+          {
+            echo "### AWS GB300 ${GPU_COUNT}-GPU smoke passed"
+            echo "- Context: \`${KUBE_CONTEXT}\`"
+            echo "- Namespace: \`${KUBE_NAMESPACE}\`"
+            echo "- Job: \`${JOB_NAME}\`"
+            echo "- Node: \`${node_name}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Cleanup smoke Job
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${KUBECONFIG:-}" ] || [ ! -f "${KUBECONFIG}" ]; then
+            echo "Kubeconfig was not initialized; nothing to clean up"
+            exit 0
+          fi
+
+          kubectl delete job "${JOB_NAME}" \
+            --namespace "${KUBE_NAMESPACE}" \
+            --ignore-not-found=true \
+            --wait=true \
+            --timeout=2m

--- a/.github/workflows/aws-gb300-runner-smoketest.yml
+++ b/.github/workflows/aws-gb300-runner-smoketest.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CUDA_IMAGE: nvcr.io/nvidia/cuda@sha256:605fb0c8acf8674e164d822da8a8521f3a655056e569f0899e72ae940e1fe7dc
+  CUDA_IMAGE: nvcr.io/nvidia/cuda@sha256:1ca86773be1716af6cfff3d2eb8cd10d4d9cac181931d1ee9be792d3e33c7322
 
 jobs:
   arc-runner-smoke:
@@ -29,7 +29,7 @@ jobs:
     runs-on: aws-gb300-tester-amd-gpu-v2
     timeout-minutes: 15
     container:
-      image: nvcr.io/nvidia/cuda@sha256:605fb0c8acf8674e164d822da8a8521f3a655056e569f0899e72ae940e1fe7dc
+      image: nvcr.io/nvidia/cuda@sha256:1ca86773be1716af6cfff3d2eb8cd10d4d9cac181931d1ee9be792d3e33c7322
       env:
         HOME: /__w/dynamo/dynamo
         USER: dynamo
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          test "$(uname -m)" = "x86_64"
+          test "$(uname -m)" = "aarch64"
 
           mapfile -t gpu_names < <(nvidia-smi --query-gpu=name --format=csv,noheader)
           # The ARC hook intentionally reserves two GPUs for every job. The

--- a/.github/workflows/aws-gb300-runner-smoketest.yml
+++ b/.github/workflows/aws-gb300-runner-smoketest.yml
@@ -106,6 +106,11 @@ jobs:
           kubectl get nodes \
             -l nvidia.com/gpu.product=NVIDIA-GB300 \
             -o custom-columns='NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
+          gb300_nodes_json="$(kubectl get nodes \
+            -l nvidia.com/gpu.product=NVIDIA-GB300 \
+            -o json)"
+          jq -e '.items | length > 0' <<< "${gb300_nodes_json}"
+          jq -e 'all(.items[]; ((.spec.taints // []) | length) == 0)' <<< "${gb300_nodes_json}"
 
       - name: Run GPU smoke Job
         shell: bash
@@ -192,12 +197,25 @@ jobs:
           pod_json="$(kubectl get pod "${pod_name}" --namespace "${KUBE_NAMESPACE}" -o json)"
           jq -e '.spec.nodeSelector["nvidia.com/gpu.product"] == "NVIDIA-GB300"' <<< "${pod_json}"
           jq -e '.spec.priorityClassName == "ci-nightly-high-priority"' <<< "${pod_json}"
+          # Kubernetes injects the GPU toleration for pods requesting the
+          # nvidia.com/gpu extended resource. Allow that and the two default
+          # NoExecute tolerations, but reject any configured runner toleration.
           jq -e '
             all(
               .spec.tolerations[]?;
-              .key != "dedicated" and
-              .key != "github-runners" and
-              .key != "nvidia.com/gpu"
+              (
+                .key == "node.kubernetes.io/not-ready" and
+                .operator == "Exists" and
+                .effect == "NoExecute"
+              ) or (
+                .key == "node.kubernetes.io/unreachable" and
+                .operator == "Exists" and
+                .effect == "NoExecute"
+              ) or (
+                .key == "nvidia.com/gpu" and
+                .operator == "Exists" and
+                .effect == "NoSchedule"
+              )
             )
           ' <<< "${pod_json}"
           jq -e --arg gpu_count "${GPU_COUNT}" '

--- a/.github/workflows/aws-gb300-runner-smoketest.yml
+++ b/.github/workflows/aws-gb300-runner-smoketest.yml
@@ -6,7 +6,7 @@ name: AWS GB300 runner smoke test
 on:
   push:
     branches:
-      - "aws-gb300-runner-smoketest"
+      - "pull-request/[0-9]+"
 
 permissions:
   contents: read

--- a/.github/workflows/aws-gb300-runner-smoketest.yml
+++ b/.github/workflows/aws-gb300-runner-smoketest.yml
@@ -26,7 +26,7 @@ jobs:
       max-parallel: 2
       matrix:
         gpu_count: [1, 2]
-    runs-on: aws-gb300-tester-amd-gpu-v2
+    runs-on: aws-gb300-tester-arm-gpu-v2
     timeout-minutes: 15
     container:
       image: nvcr.io/nvidia/cuda@sha256:1ca86773be1716af6cfff3d2eb8cd10d4d9cac181931d1ee9be792d3e33c7322
@@ -110,7 +110,7 @@ jobs:
             -l nvidia.com/gpu.product=NVIDIA-GB300 \
             -o json)"
           jq -e '.items | length > 0' <<< "${gb300_nodes_json}"
-          jq -e 'all(.items[]; ((.spec.taints // []) | length) == 0)' <<< "${gb300_nodes_json}"
+          jq -e 'any(.items[]; ((.spec.taints // []) | length) == 0)' <<< "${gb300_nodes_json}"
 
       - name: Run GPU smoke Job
         shell: bash

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -785,6 +785,94 @@ jobs:
           vcluster_namespace: ${{ needs.efa-deploy-operator.outputs.namespace }}
 
   # ============================================================================
+  # GB300 DEPLOY TEST
+  # ============================================================================
+  # The production deploy runner receives a multi-context kubeconfig from tbot.
+  # Select the GB300 context in every job so concurrent deploy tests cannot race
+  # through the shared kubeconfig or accidentally target another cluster.
+  gb300-deploy-operator:
+    name: vLLM GB300 Deploy Operator
+    needs: [compute-release-mode, operator-build, resolve-source-sha]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    runs-on: prod-deploy-tester-v1
+    permissions:
+      contents: read
+    env:
+      KUBE_CONTEXT: nv-prd-dgxc.teleport.sh-dynamo-aws-gb300
+    outputs:
+      namespace: ${{ steps.setup.outputs.namespace }}
+      vcluster_name: ${{ steps.setup.outputs.vcluster_name }}
+      operator_tag: ${{ steps.setup.outputs.operator_tag }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+
+      - name: Set kubectl context to dynamo-aws-gb300
+        uses: $/.github/actions/set-kube-context
+
+      - name: Setup vCluster and operator
+        id: setup
+        uses: $/.github/actions/setup-dynamo-operator
+        with:
+          # An empty vcluster_namespace resolves to dynamo-deploy-test for this
+          # context, and the run-scoped name keeps concurrent nightlies isolated.
+          vcluster_name: nightly-gb300-${{ github.run_id }}
+          registry: ${{ vars.ECR_REGISTRY }}
+          repository: ${{ vars.ECR_REPOSITORY }}
+          operator_tag: ${{ needs.operator-build.outputs.operator_default_tag }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+  gb300-deploy-test-vllm:
+    name: vLLM GB300 Deploy Test
+    needs: [compute-release-mode, operator-build, resolve-source-sha, vllm-build, gb300-deploy-operator]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: $/.github/workflows/shared-deploy-test.yml
+    with:
+      framework: vllm
+      profiles: '["agg", "disagg"]'
+      image_tag: ${{ format('{0}-{1}-nightly', needs.resolve-source-sha.outputs.source_sha, needs.vllm-build.outputs.target_tag_plain) }}
+      namespace: ${{ needs.gb300-deploy-operator.outputs.namespace }}
+      vcluster_name: ${{ needs.gb300-deploy-operator.outputs.vcluster_name }}
+      operator_tag: ${{ needs.gb300-deploy-operator.outputs.operator_tag }}
+      kube_context: nv-prd-dgxc.teleport.sh-dynamo-aws-gb300
+      operator_registry: ${{ vars.ECR_REGISTRY }}
+      operator_repository: ${{ vars.ECR_REPOSITORY }}
+      runtime_image_repository: ${{ format('{0}/{1}', vars.ECR_REGISTRY, vars.ECR_REPOSITORY) }}
+      platform_arch: amd64
+      # The FSx shared-model-cache PVC is host-side. It is mounted by the
+      # cluster-local GB300 runner hook, but is not mapped into this vCluster.
+      mount_model_cache: false
+    secrets: inherit
+
+  gb300-deploy-cleanup:
+    name: vLLM GB300 Deploy Cleanup
+    if: always()
+    needs: [gb300-deploy-operator, gb300-deploy-test-vllm]
+    runs-on: prod-deploy-tester-v1
+    permissions:
+      contents: read
+    env:
+      KUBE_CONTEXT: nv-prd-dgxc.teleport.sh-dynamo-aws-gb300
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set kubectl context to dynamo-aws-gb300
+        uses: $/.github/actions/set-kube-context
+
+      - name: Teardown vCluster
+        if: needs.gb300-deploy-operator.outputs.vcluster_name != '' && needs.gb300-deploy-operator.outputs.namespace != ''
+        uses: $/.github/actions/teardown-dynamo-operator
+        with:
+          vcluster_name: ${{ needs.gb300-deploy-operator.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.gb300-deploy-operator.outputs.namespace }}
+
+  # ============================================================================
   # COMPLIANCE
   # ============================================================================
   # Compliance extract + verify now runs as an inline step INSIDE each build job
@@ -896,6 +984,33 @@ jobs:
       image_tag_suffix: '-nightly'
     secrets: inherit
 
+  vllm-gb300-test:
+    name: vllm-runtime
+    needs: [vllm-build, resolve-source-sha, compute-release-mode]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: $/.github/workflows/shared-test.yml
+    with:
+      dd_env: nightly
+      dd_flaky_retry_enabled: 'false'
+      test_suite_name: vllm
+      test_type: GB300 Test
+      # The ARC hook requests exactly two GB300 GPUs for every workflow pod.
+      amd_runner: aws-gb300-tester-amd-gpu-v2
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64"]'
+      enable_coverage: true
+      run_sanity_check: false
+      gpu_test_markers: vllm and (gpu_1 or gpu_2)
+      gpu_test_timeout_minutes: 240
+      run_gpu_parallel_tests: true
+      # Keep the initial lane at the already profiled H100 ceiling; the hook
+      # still provides both full GB300 devices to tests that need them.
+      gpu_parallel_max_vram_gib: '80'
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
+    secrets: inherit
+
   sglang-test:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [sglang-build, resolve-source-sha, compute-release-mode]
@@ -995,6 +1110,30 @@ jobs:
       image_tag_suffix: '-nightly'
     secrets: inherit
 
+  sglang-gb300-test:
+    name: sglang-runtime
+    needs: [sglang-build, resolve-source-sha, compute-release-mode]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: $/.github/workflows/shared-test.yml
+    with:
+      dd_env: nightly
+      dd_flaky_retry_enabled: 'false'
+      test_suite_name: sglang
+      test_type: GB300 Test
+      amd_runner: aws-gb300-tester-amd-gpu-v2
+      target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64"]'
+      enable_coverage: true
+      run_sanity_check: false
+      gpu_test_markers: sglang and (gpu_1 or gpu_2)
+      gpu_test_timeout_minutes: 240
+      run_gpu_parallel_tests: true
+      gpu_parallel_max_vram_gib: '80'
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
+    secrets: inherit
+
   trtllm-test:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [trtllm-build, resolve-source-sha, compute-release-mode]
@@ -1065,6 +1204,30 @@ jobs:
       gpu_test_markers: trtllm and (gpu_1 or gpu_2)
       gpu_test_timeout_minutes: 240
       # 80 GiB H100 admits more of the profiled pool per slot than the 24 GiB lanes.
+      run_gpu_parallel_tests: true
+      gpu_parallel_max_vram_gib: '80'
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
+    secrets: inherit
+
+  trtllm-gb300-test:
+    name: trtllm-runtime
+    needs: [trtllm-build, resolve-source-sha, compute-release-mode]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: $/.github/workflows/shared-test.yml
+    with:
+      dd_env: nightly
+      dd_flaky_retry_enabled: 'false'
+      test_suite_name: trtllm
+      test_type: GB300 Test
+      amd_runner: aws-gb300-tester-amd-gpu-v2
+      target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
+      cuda_version: '["13.1"]'
+      platform: '["amd64"]'
+      enable_coverage: true
+      run_sanity_check: false
+      gpu_test_markers: trtllm and (gpu_1 or gpu_2)
+      gpu_test_timeout_minutes: 240
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '80'
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
@@ -1255,7 +1418,7 @@ jobs:
   coverage-report:
     name: Generate Coverage Report
     runs-on: ubuntu-latest
-    needs: [vllm-test, vllm-multi-gpu-test, vllm-4-gpu-test, vllm-h100-test, sglang-test, sglang-multi-gpu-test, sglang-4-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, trtllm-h100-test, rust-tests]
+    needs: [vllm-test, vllm-multi-gpu-test, vllm-4-gpu-test, vllm-h100-test, vllm-gb300-test, sglang-test, sglang-multi-gpu-test, sglang-4-gpu-test, sglang-h100-test, sglang-gb300-test, trtllm-test, trtllm-multi-gpu-test, trtllm-h100-test, trtllm-gb300-test, rust-tests]
     if: always()
     permissions:
       contents: read
@@ -1482,7 +1645,7 @@ jobs:
   ############################## SLACK NOTIFICATION ##############################
   notify-slack:
     if: always()
-    needs: [vllm-test, vllm-multi-gpu-test, vllm-4-gpu-test, vllm-h100-test, sglang-test, sglang-multi-gpu-test, sglang-4-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, trtllm-h100-test, deploy-cleanup, rust-tests]
+    needs: [vllm-test, vllm-multi-gpu-test, vllm-4-gpu-test, vllm-h100-test, vllm-gb300-test, sglang-test, sglang-multi-gpu-test, sglang-4-gpu-test, sglang-h100-test, sglang-gb300-test, trtllm-test, trtllm-multi-gpu-test, trtllm-h100-test, trtllm-gb300-test, deploy-cleanup, gb300-deploy-cleanup, rust-tests]
     permissions:
       contents: read
       actions: read   # grant the reusable notifier read access to list this run's jobs

--- a/.github/workflows/shared-deploy-test.yml
+++ b/.github/workflows/shared-deploy-test.yml
@@ -30,6 +30,36 @@ on:
         description: 'Operator image tag'
         type: string
         required: true
+      kube_context:
+        description: 'Teleport kube context to target. Empty keeps the runner default context.'
+        type: string
+        required: false
+        default: ''
+      operator_registry:
+        description: 'Operator registry override. Empty uses AZURE_ACR_HOSTNAME.'
+        type: string
+        required: false
+        default: ''
+      operator_repository:
+        description: 'Operator repository override. Empty uses ACR_REPOSITORY.'
+        type: string
+        required: false
+        default: ''
+      runtime_image_repository:
+        description: 'Runtime image repository override without a tag. Empty uses the configured ACR repository.'
+        type: string
+        required: false
+        default: ''
+      platform_arch:
+        description: 'Architecture of the cluster under test (amd64 or arm64).'
+        type: string
+        required: false
+        default: 'amd64'
+      mount_model_cache:
+        description: 'Create and mount the reusable workflow model-cache PVC.'
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   deploy-test:
@@ -37,6 +67,10 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
+    env:
+      # setup-dynamo-operator also reads this to select the shared deploy-test
+      # namespace and host PriorityClass on explicitly targeted AWS clusters.
+      KUBE_CONTEXT: ${{ inputs.kube_context }}
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -46,6 +80,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Set kubectl context
+        if: inputs.kube_context != ''
+        uses: $/.github/actions/set-kube-context
       - name: Check if vCluster exists
         id: vcluster-check
         uses: $/.github/actions/check-vcluster-exists
@@ -58,14 +95,14 @@ jobs:
         with:
           vcluster_name: ${{ inputs.vcluster_name }}
           vcluster_namespace: ${{ inputs.namespace }}
-          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          repository: ${{ vars.ACR_REPOSITORY }}
+          registry: ${{ inputs.operator_registry != '' && inputs.operator_registry || secrets.AZURE_ACR_HOSTNAME }}
+          repository: ${{ inputs.operator_repository != '' && inputs.operator_repository || vars.ACR_REPOSITORY }}
           operator_tag: ${{ inputs.operator_tag }}
           hf_token: ${{ secrets.HF_TOKEN }}
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-          model_cache_server: ${{ vars.AZURE_MODEL_CACHE_SERVER }}
-          model_cache_path: ${{ vars.AZURE_MODEL_CACHE_PATH }}
+          model_cache_server: ${{ inputs.mount_model_cache && vars.AZURE_MODEL_CACHE_SERVER || '' }}
+          model_cache_path: ${{ inputs.mount_model_cache && vars.AZURE_MODEL_CACHE_PATH || '' }}
       - name: Connect to vCluster
         id: connect-vcluster
         uses: $/.github/actions/connect-vcluster
@@ -78,14 +115,14 @@ jobs:
         with:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
-          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          registry: ${{ inputs.operator_registry != '' && inputs.operator_registry || secrets.AZURE_ACR_HOSTNAME }}
           operator_tag: ${{ inputs.operator_tag }}
           hf_token: ${{ secrets.HF_TOKEN }}
           framework: ${{ inputs.framework }}
           profile: ${{ matrix.profile }}
-          image: ${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ inputs.image_tag }}
-          platform_arch: amd64
+          image: ${{ format('{0}:{1}', inputs.runtime_image_repository != '' && inputs.runtime_image_repository || format('{0}/{1}', secrets.AZURE_ACR_HOSTNAME, vars.ACR_REPOSITORY), inputs.image_tag) }}
+          platform_arch: ${{ inputs.platform_arch }}
           extra_pytest_args: -m framework_only
           # Mount the shared model cache only when both endpoint vars are set
           # (matches the PV/PVC creation gate); otherwise workers download from HF.
-          model_cache_pvc: ${{ vars.AZURE_MODEL_CACHE_SERVER != '' && vars.AZURE_MODEL_CACHE_PATH != '' && 'model-cache' || '' }}
+          model_cache_pvc: ${{ inputs.mount_model_cache && vars.AZURE_MODEL_CACHE_SERVER != '' && vars.AZURE_MODEL_CACHE_PATH != '' && 'model-cache' || '' }}


### PR DESCRIPTION
## Overview:

  Adds CI coverage for the AWS GB300 cluster using both the cluster-local GB300 runners and the production deploy runners.

  ## Details:

  - Adds a push-triggered smoke-test workflow for reviewed `pull-request/<number>` branches.
  - Validates one- and two-GPU jobs on `aws-gb300-tester-amd-gpu-v2`.
  - Uses `prod-deploy-tester-v1` with the tbot-provided GB300 Kubernetes context to create and validate GPU jobs remotely.
  - Adds nightly vLLM, SGLang, and TensorRT-LLM GB300 test lanes.
  - Adds GB300 vLLM aggregate and disaggregate deployment tests.
  - Uses the shared `dynamo-deploy-test` namespace and `ci-nightly-high-priority` priority class.
  - Extends the shared deployment workflow with configurable Kubernetes context, registry, architecture, and model-cache behavior.
  - Includes the GB300 jobs in coverage reporting and nightly notifications.

  ## Where should the reviewer start?

  Please start with:

  - `.github/workflows/aws-gb300-runner-smoketest.yml` for the runner and remote-cluster smoke tests.
  - `.github/workflows/nightly-ci.yml` for the new GB300 nightly test and deployment jobs.
  - `.github/workflows/shared-deploy-test.yml` for the reusable workflow changes supporting AWS GB300.
  - `.github/actions/setup-dynamo-operator/action.yml` for GB300 namespace and priority-class selection.

  ## Related Issues

  **🚫 This PR is NOT linked to an issue**:

  - [x] Confirmed — no related issue