### PR TITLE
perf(trtllm): default per-request SamplingParams.return_perf_metrics to off (1.4.x)

### DIFF
--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -479,9 +479,17 @@ async def init_llm_worker(
         )
     default_sampling_params = SamplingParams()
 
-    # Enable perf metrics so prompt_tokens_details can be returned
+    # Do NOT enable per-request perf metrics by default. With this flag set,
+    # TRT-LLM collects request perf metrics on the executor loop and, in
+    # attention-DP multiprocess paths, pickles the payload on that same loop —
+    # measured at ~2.5% end-to-end output throughput on a large disaggregated
+    # deployment, with the engine-level `return_perf_metrics` already false in
+    # both arms of the A/B. trtllm-serve does not set it. Deployments that
+    # need `prompt_tokens_details` can force it back on via an explicit
+    # engine-level override (TRT-LLM resolves the effective value as
+    # `sampling or engine`).
     if hasattr(default_sampling_params, "return_perf_metrics"):
-        default_sampling_params.return_perf_metrics = True
+        default_sampling_params.return_perf_metrics = False
     model_input = ModelInput.Tokens
 
     # Set model type based on disaggregation mode. Prefill and encode workers


### PR DESCRIPTION
## Summary

One-line change: stop setting `return_perf_metrics = True` unconditionally on the worker's default `SamplingParams` (`workers/llm_worker.py`).

## Why

With this flag on, TRT-LLM collects per-request perf metrics on the executor-loop thread and, in attention-DP multiprocess paths, pickles the payload on that same loop. Dynamo does not consume the detailed payload (see #13869's analysis of `time_breakdown_metrics`).

**Measured impact (controlled A/B).** Large disaggregated deployment, 9 prefill workers (TP4) + 1 decode worker (TP16), agentic multi-turn workload at ~3.6k concurrent sessions, same node set, engine-level `return_perf_metrics: false` in **both** arms — the only delta is this request-level default:

| | request-level flag ON (unpatched) | OFF (this change) |
|---|---|---|
| Output tok/s (server-reported) | 134,761 | **138,079 (+2.46%)** |
| TTFT p50 | 2.33 s | **2.21 s** |
| Errors | 1,871 | 1,876 (≈) |

This also closed most of a dynamo-vs-native-`trtllm-serve` gap on the same engine build: native `trtllm-serve` never sets this flag, so the unconditional default was a silent configuration asymmetry in any such comparison.

## Relationship to existing work

- **main** already gates this site on `publish_events_and_metrics` (no longer unconditional), so this backport targets the `release/1.4.x` lineage where the unconditional `True` still ships.
- **#13869** disables the engine-level default on main but keeps the request-level flag on, on the reasoning that the request-level path is fixed-size and cheap. The A/B above is direct evidence that on at least some TRT-LLM builds the request-level flag **alone** (engine-level already off) costs ~2.5% end-to-end — sharing it here and in that PR's review.
- Deployments that need `prompt_tokens_details` or the KV-transfer request metrics can force the flag back on with an explicit engine-level override; TRT-LLM resolves the effective value as `sampling or engine`.

## Draft status

Opened as a draft for public review of the change + evidence. Single-run A/B (one healthy run per arm); happy to add repeats before undrafting.