### PR TITLE
ci: preserve post-merge builds for docs-only changes

### DIFF
--- a/.github/FILTERS.md
+++ b/.github/FILTERS.md
@@ -20,6 +20,7 @@ When you open a PR, CI checks which files changed and runs only relevant jobs:
 | `sample` | Sample-backend unified test (piggybacks on vllm image) |
 | `efa` | EFA runtime image builds for vLLM, SGLang, TRT-LLM (`container/templates/aws.Dockerfile` change) |
 | `docs` | Nothing (classification only) |
+| `post_merge_docs` | Skips post-merge tests only when every changed path matches; image builds still run |
 | `fern_components` | Parse custom MDX components (a step inside Fern Configuration Check) |
 | `examples` | Recipe Kustomize generation and unit checks |
 | `ignore` | Nothing (classification only) |

--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -73,6 +73,9 @@ outputs:
   docs:
     description: 'Whether docs files changed'
     value: ${{ steps.filter.outputs.docs_any_modified }}
+  post_merge_docs_only:
+    description: 'Whether only post-merge documentation paths changed'
+    value: ${{ steps.filter.outputs.post_merge_docs_only_modified }}
   examples:
     description: 'Whether examples, recipes, or recipe validation helpers changed'
     value: ${{ steps.filter.outputs.examples_any_modified }}
@@ -158,6 +161,7 @@ runs:
         echo "=== Filter Results ==="
         echo "api_docs: ${{ steps.filter.outputs.api_docs_any_modified }}"
         echo "docs: ${{ steps.filter.outputs.docs_any_modified }}"
+        echo "post_merge_docs_only: ${{ steps.filter.outputs.post_merge_docs_only_modified }}"
         echo "examples: ${{ steps.filter.outputs.examples_any_modified }}"
         echo "fern_components: ${{ steps.filter.outputs.fern_components_any_modified }}"
         echo "ci: ${{ steps.filter.outputs.ci_any_modified }}"
@@ -185,6 +189,7 @@ runs:
         echo "=== Files Matching Each Filter ==="
         echo "api_docs: ${{ steps.filter.outputs.api_docs_all_modified_files }}"
         echo "docs: ${{ steps.filter.outputs.docs_all_modified_files }}"
+        echo "post_merge_docs: ${{ steps.filter.outputs.post_merge_docs_all_modified_files }}"
         echo "examples: ${{ steps.filter.outputs.examples_all_modified_files }}"
         echo "ci: ${{ steps.filter.outputs.ci_all_modified_files }}"
         echo "core: ${{ steps.filter.outputs.core_all_modified_files }}"
@@ -212,7 +217,7 @@ runs:
       shell: bash
       run: |
         # Combine all filter-specific files into one list
-        COVERED_FILES=$(echo "${{ steps.filter.outputs.api_docs_all_modified_files }} ${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.dev_images_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.snapshot_all_modified_files }} ${{ steps.filter.outputs.snapshot_vllm_all_modified_files }} ${{ steps.filter.outputs.snapshot_sglang_all_modified_files }} ${{ steps.filter.outputs.snapshot_trtllm_all_modified_files }} ${{ steps.filter.outputs.power_agent_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.dgdr_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.sidecar_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }} ${{ steps.filter.outputs.sample_all_modified_files }} ${{ steps.filter.outputs.frontend_all_modified_files }} ${{ steps.filter.outputs.benchmarks_all_modified_files }} ${{ steps.filter.outputs.efa_all_modified_files }} ${{ steps.filter.outputs.rust_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
+        COVERED_FILES=$(echo "${{ steps.filter.outputs.api_docs_all_modified_files }} ${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.post_merge_docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.dev_images_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.snapshot_all_modified_files }} ${{ steps.filter.outputs.snapshot_vllm_all_modified_files }} ${{ steps.filter.outputs.snapshot_sglang_all_modified_files }} ${{ steps.filter.outputs.snapshot_trtllm_all_modified_files }} ${{ steps.filter.outputs.power_agent_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.dgdr_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.sidecar_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }} ${{ steps.filter.outputs.sample_all_modified_files }} ${{ steps.filter.outputs.frontend_all_modified_files }} ${{ steps.filter.outputs.benchmarks_all_modified_files }} ${{ steps.filter.outputs.efa_all_modified_files }} ${{ steps.filter.outputs.rust_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
 
         # Get all modified files
         ALL_FILES=$(echo "${{ steps.filter.outputs.all_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -18,12 +18,21 @@
 #   examples -> recipe-check (Kustomize recipe generation and unit tests)
 #   sidecar  -> classification only; source and proto files also match rust
 #   docs     -> fern docs lint, sync, and version release (docs/ directory)
+#   post_merge_docs -> skip post-merge tests only when every changed path matches
 #
 # Filters for coverage only (no CI triggered):
 #   examples, ignore, sidecar
 
 all:
   - '**'
+
+# Exact match for the paths that previously suppressed the entire post-merge
+# workflow. The caller uses `only_modified` so mixed changes still run tests.
+post_merge_docs:
+  - 'docs/**'
+  - 'fern/**'
+  - '**.md'
+  - '**.rst'
 
 # Fern component sources only. The docs filter matches 458 of the last 1172
 # commits on main, but only 21 of those touched a component source, so a step

--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -49,6 +49,11 @@ on:
         required: false
         type: string
         default: ''
+      run_tests:
+        description: 'Run checks and tests after building the runtime images.'
+        required: false
+        type: boolean
+        default: true
       cpu_parallel_test_markers:
         required: true
         type: string
@@ -94,6 +99,7 @@ jobs:
   # aren't reproducible on plain ubuntu-latest runners.
   rust-gpu:
     needs: image
+    if: inputs.run_tests
     runs-on: prod-tester-amd-gpu-v2
     container:
       image: ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY }}:${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}-${{ needs.image.outputs.target_tag_plain }}${{ (inputs.cuda_version != '' && !startsWith(inputs.cuda_version, '13.')) && format('-cuda{0}', startsWith(inputs.cuda_version, '12.') && '12' || inputs.cuda_version) || '' }}${{ inputs.image_tag_suffix }}-test
@@ -169,6 +175,7 @@ jobs:
 
   mypy:
     needs: image
+    if: inputs.run_tests
     runs-on: prod-tester-amd-v2
     container:
       image: ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY }}:${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}-${{ needs.image.outputs.target_tag_plain }}${{ (inputs.cuda_version != '' && !startsWith(inputs.cuda_version, '13.')) && format('-cuda{0}', startsWith(inputs.cuda_version, '12.') && '12' || inputs.cuda_version) || '' }}${{ inputs.image_tag_suffix }}-test
@@ -204,6 +211,7 @@ jobs:
   parallel:
     name: test
     needs: image
+    if: inputs.run_tests
     uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: dynamo
@@ -225,6 +233,7 @@ jobs:
   sequential:
     name: test
     needs: image
+    if: inputs.run_tests
     uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: dynamo
@@ -246,6 +255,7 @@ jobs:
   gpu:
     name: test
     needs: image
+    if: inputs.run_tests
     uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: dynamo

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -8,12 +8,6 @@ on:
     branches:
       - main
       - 'release/*.*.*'
-    # Documentation changes are validated before merge and do not affect images or GPU tests.
-    paths-ignore:
-      - 'docs/**'
-      - 'fern/**'
-      - '**.md'
-      - '**.rst'
   workflow_dispatch:
     inputs:
       framework:
@@ -30,6 +24,40 @@ permissions:
   actions: read
 
 jobs:
+  changed-files:
+    name: Changed files
+    runs-on: ubuntu-latest
+    outputs:
+      run_tests: ${{ steps.policy.outputs.run_tests }}
+    steps:
+      - name: Checkout code
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Check for changes
+        id: changes
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: $/.github/actions/changed-files
+        with:
+          gh_token: ${{ github.token }}
+      - name: Set test policy
+        id: policy
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DETECTOR_OUTCOME: ${{ steps.changes.outcome }}
+          DOCS_ONLY: ${{ steps.changes.outputs.post_merge_docs_only }}
+        run: |
+          if [[ "$DETECTOR_OUTCOME" == "failure" ]]; then
+            echo "::warning title=Changed-file detection failed::Running the full post-merge test suite."
+          fi
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$DETECTOR_OUTCOME" != "success" || "$DOCS_ONLY" != "true" ]]; then
+            echo "run_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_tests=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # ============================================================================
   # DISPATCH CONFIG
   # On workflow_dispatch, narrows the run to a single framework.
@@ -61,10 +89,13 @@ jobs:
   # ============================================================================
   dynamo-pipeline:
     name: dynamo-runtime
-    if: github.event_name != 'workflow_dispatch'
+    needs: [changed-files]
+    if: always() && !cancelled() && github.event_name != 'workflow_dispatch'
     uses: $/.github/workflows/dynamo-pipeline.yml
     with:
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
+      # A detector failure must not suppress release-required image artifacts.
+      run_tests: ${{ needs.changed-files.outputs.run_tests == 'true' }}
       # TODO: widen to include `post_merge` — today it picks up tests
       # (e.g. fault_tolerance/deploy/*) that fail in this container-only
       # context. Matches the coverage of the old container-validation-dynamo
@@ -121,7 +152,8 @@ jobs:
 
   power-agent:
     name: Power Agent
-    if: github.event_name != 'workflow_dispatch'
+    needs: [changed-files]
+    if: always() && !cancelled() && github.event_name != 'workflow_dispatch'
     runs-on: prod-default-v2
     steps:
       - name: Checkout code
@@ -143,6 +175,7 @@ jobs:
           extra_tags: |
             ${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ github.sha }}-power-agent
       - name: Refresh BuildKit builder
+        if: needs.changed-files.outputs.run_tests == 'true'
         # The runtime build above can leave the remote BuildKit connection stale;
         # re-establish it (re-routing only if unhealthy) before the test build.
         uses: $/.github/actions/builder-refresher
@@ -152,6 +185,7 @@ jobs:
           arch: linux/amd64
           namespace: ${{ vars.BUILDKIT_NAMESPACE }}
       - name: Run unit tests inside the container image
+        if: needs.changed-files.outputs.run_tests == 'true'
         # Build the Dockerfile `test` stage (FROM runtime): its RUN pytest runs
         # the suite against the exact shipped image (Python 3.12 + baked deps),
         # validating the container itself rather than a pip-installed runner env.
@@ -166,10 +200,12 @@ jobs:
             --build-arg DOCKER_PROXY=${ECR_HOSTNAME}/dockerhub/ \
             -f deploy/power-agent/Dockerfile deploy/power-agent
       - name: Set up Helm
+        if: needs.changed-files.outputs.run_tests == 'true'
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
         with:
           version: 'v3.17.3'  # match deploy/operator/Makefile HELM_VERSION
       - name: Lint and test Helm chart
+        if: needs.changed-files.outputs.run_tests == 'true'
         run: make -C deploy/helm/charts/power-agent lint test
 
   # ============================================================================
@@ -422,7 +458,8 @@ jobs:
 
   vllm-test:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
-    needs: [vllm-build]
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.run_tests == 'true'
     uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
@@ -445,7 +482,8 @@ jobs:
 
   vllm-multi-gpu-test:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
-    needs: [vllm-build]
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.run_tests == 'true'
     uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
@@ -462,7 +500,8 @@ jobs:
 
   vllm-4-gpu-test:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
-    needs: [vllm-build]
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.run_tests == 'true'
     uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
@@ -479,7 +518,8 @@ jobs:
 
   vllm-efa-test:
     name: vllm-runtime-efa
-    needs: [vllm-efa-build]
+    needs: [changed-files, vllm-efa-build]
+    if: needs.changed-files.outputs.run_tests == 'true'
     uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
@@ -496,8 +536,10 @@ jobs:
 
   vllm-kvbm-tests:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
-    needs: [config, vllm-build]
-    if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_vllm == 'true'
+    needs: [changed-files, config, vllm-build]
+    if: |
+      needs.changed-files.outputs.run_tests == 'true' &&
+      (github.event_name != 'workflow_dispatch' || needs.config.outputs.run_vllm == 'true')
     uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
@@ -520,7 +562,8 @@ jobs:
 
   sglang-test:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
-    needs: [sglang-build]
+    needs: [changed-files, sglang-build]
+    if: needs.changed-files.outputs.run_tests == 'true'
     uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
@@ -543,7 +586,8 @@ jobs:
 
   sglang-multi-gpu-test:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
-    needs: [sglang-build]
+    needs: [changed-files, sglang-build]
+    if: needs.changed-files.outputs.run_tests == 'true'
     uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
@@ -560,7 +604,8 @@ jobs:
 
   trtllm-test:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
-    needs: [trtllm-build]
+    needs: [changed-files, trtllm-build]
+    if: needs.changed-files.outputs.run_tests == 'true'
     uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
@@ -583,7 +628,8 @@ jobs:
 
   trtllm-multi-gpu-test:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
-    needs: [trtllm-build]
+    needs: [changed-files, trtllm-build]
+    if: needs.changed-files.outputs.run_tests == 'true'
     uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
@@ -600,7 +646,8 @@ jobs:
 
   trtllm-efa-test:
     name: trtllm-runtime-efa
-    needs: [trtllm-efa-build]
+    needs: [changed-files, trtllm-efa-build]
+    if: needs.changed-files.outputs.run_tests == 'true'
     uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
@@ -617,7 +664,8 @@ jobs:
 
   planner-test:
     name: planner # This name overlaps with other planner jobs to group them in the UI
-    needs: [planner-build]
+    needs: [changed-files, planner-build]
+    if: needs.changed-files.outputs.run_tests == 'true'
     uses: $/.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
@@ -641,8 +689,10 @@ jobs:
 
   vllm-test-xpu:
     name: vllm-xpu
-    needs: [config]
-    if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_vllm == 'true'
+    needs: [changed-files, config]
+    if: |
+      needs.changed-files.outputs.run_tests == 'true' &&
+      (github.event_name != 'workflow_dispatch' || needs.config.outputs.run_vllm == 'true')
     uses: $/.github/workflows/xpu-ci.yaml
     with:
       framework: vllm
@@ -874,7 +924,8 @@ jobs:
   # ============================================================================
 
   deploy-operator:
-    needs: [operator]
+    needs: [changed-files, operator]
+    if: needs.changed-files.outputs.run_tests == 'true'
     runs-on: prod-deploy-tester-v1
     outputs:
       namespace: ${{ steps.setup.outputs.namespace }}
@@ -955,8 +1006,10 @@ jobs:
 
   deploy-operator-checkpoint-vllm:
     name: vLLM DynamoCheckpoint Operator Setup
-    needs: [operator]
-    if: github.event_name != 'workflow_dispatch'
+    needs: [changed-files, operator]
+    if: |
+      needs.changed-files.outputs.run_tests == 'true' &&
+      github.event_name != 'workflow_dispatch'
     runs-on: prod-deploy-tester-v1
     permissions:
       contents: read
@@ -985,8 +1038,10 @@ jobs:
 
   deploy-operator-checkpoint-sglang:
     name: SGLang DynamoCheckpoint Operator Setup
-    needs: [operator]
-    if: github.event_name != 'workflow_dispatch'
+    needs: [changed-files, operator]
+    if: |
+      needs.changed-files.outputs.run_tests == 'true' &&
+      github.event_name != 'workflow_dispatch'
     runs-on: prod-deploy-tester-v1
     permissions:
       contents: read
@@ -1015,8 +1070,10 @@ jobs:
 
   deploy-operator-checkpoint-trtllm:
     name: TRTLLM DynamoCheckpoint Operator Setup
-    needs: [operator]
-    if: github.event_name != 'workflow_dispatch'
+    needs: [changed-files, operator]
+    if: |
+      needs.changed-files.outputs.run_tests == 'true' &&
+      github.event_name != 'workflow_dispatch'
     runs-on: prod-deploy-tester-v1
     permissions:
       contents: read
@@ -1374,8 +1431,10 @@ jobs:
             --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ needs.frontend-copy-to-acr.outputs.image_tag }}
 
   deploy-cleanup:
-    if: always()
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-dgdr, deploy-test-gaie]
+    if: |
+      always() &&
+      needs.changed-files.outputs.run_tests == 'true'
+    needs: [changed-files, deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-dgdr, deploy-test-gaie]
     runs-on: prod-deploy-tester-v1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -1390,8 +1449,11 @@ jobs:
 
   deploy-cleanup-checkpoint-vllm:
     name: vLLM DynamoCheckpoint Cleanup
-    if: always() && github.event_name != 'workflow_dispatch'
-    needs: [deploy-operator-checkpoint-vllm, deploy-snapshot-agent-checkpoint-vllm, deploy-test-checkpoint-vllm]
+    if: |
+      always() &&
+      github.event_name != 'workflow_dispatch' &&
+      needs.changed-files.outputs.run_tests == 'true'
+    needs: [changed-files, deploy-operator-checkpoint-vllm, deploy-snapshot-agent-checkpoint-vllm, deploy-test-checkpoint-vllm]
     runs-on: prod-deploy-tester-v1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -1403,8 +1465,11 @@ jobs:
 
   deploy-cleanup-checkpoint-sglang:
     name: SGLang DynamoCheckpoint Cleanup
-    if: always() && github.event_name != 'workflow_dispatch'
-    needs: [deploy-operator-checkpoint-sglang, deploy-snapshot-agent-checkpoint-sglang, deploy-test-checkpoint-sglang]
+    if: |
+      always() &&
+      github.event_name != 'workflow_dispatch' &&
+      needs.changed-files.outputs.run_tests == 'true'
+    needs: [changed-files, deploy-operator-checkpoint-sglang, deploy-snapshot-agent-checkpoint-sglang, deploy-test-checkpoint-sglang]
     runs-on: prod-deploy-tester-v1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -1416,8 +1481,11 @@ jobs:
 
   deploy-cleanup-checkpoint-trtllm:
     name: TRTLLM DynamoCheckpoint Cleanup
-    if: always() && github.event_name != 'workflow_dispatch'
-    needs: [deploy-operator-checkpoint-trtllm, deploy-snapshot-agent-checkpoint-trtllm, deploy-test-checkpoint-trtllm]
+    if: |
+      always() &&
+      github.event_name != 'workflow_dispatch' &&
+      needs.changed-files.outputs.run_tests == 'true'
+    needs: [changed-files, deploy-operator-checkpoint-trtllm, deploy-snapshot-agent-checkpoint-trtllm, deploy-test-checkpoint-trtllm]
     runs-on: prod-deploy-tester-v1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -1530,7 +1598,7 @@ jobs:
     name: Clean K8s builder if exists
     runs-on: prod-default-small-v2
     if: always()
-    needs: [vllm-build, sglang-build, trtllm-build, vllm-dev-build, sglang-dev-build, trtllm-dev-build, vllm-efa-build, sglang-efa-build, trtllm-efa-build, operator, snapshot-placeholder-vllm, snapshot-placeholder-sglang, snapshot-placeholder-trtllm, power-agent, frontend-build, planner-build]
+    needs: [dynamo-pipeline, vllm-build, sglang-build, trtllm-build, vllm-dev-build, sglang-dev-build, trtllm-dev-build, vllm-efa-build, sglang-efa-build, trtllm-efa-build, operator, snapshot-placeholder-vllm, snapshot-placeholder-sglang, snapshot-placeholder-trtllm, power-agent, frontend-build, planner-build]
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -1550,7 +1618,26 @@ jobs:
   ############################## SLACK NOTIFICATION ##############################
   notify-slack:
     if: always() && github.event_name != 'workflow_dispatch'
-    needs: [ deploy-status-check ]
+    needs:
+      - deploy-status-check
+      - clean-k8s-builder
+      - dynamo-pipeline
+      - planner-compliance
+      - planner-test
+      - vllm-test
+      - vllm-multi-gpu-test
+      - vllm-4-gpu-test
+      - vllm-efa-test
+      - vllm-kvbm-tests
+      - sglang-test
+      - sglang-multi-gpu-test
+      - trtllm-test
+      - trtllm-multi-gpu-test
+      - trtllm-efa-test
+      - vllm-test-xpu
+      - vllm-dev-copy-to-acr
+      - sglang-dev-copy-to-acr
+      - trtllm-dev-copy-to-acr
     permissions:
       contents: read
       actions: read   # grant the reusable notifier read access to list this run's jobs


### PR DESCRIPTION
## Summary

- always start post-merge CI on `main` and `release/*` so every commit retains the exact-SHA images required by release staging
- classify docs-only pushes with the shared changed-files action, while treating mixed changes, manual dispatches, and detector failures as full-test runs
- skip nested Dynamo checks, backend GPU/XPU tests, Power Agent test steps, and deployment tests for docs-only pushes while keeping image builds, copies, and compliance jobs running
- preserve cancellation cleanup behavior and wait for every terminal job before sending the Slack notification

Follow-up to #13909.

Linear: OPS-8401

## Validation

- `pre-commit run --files .github/FILTERS.md .github/actions/changed-files/action.yml .github/filters.yaml .github/workflows/dynamo-pipeline.yml .github/workflows/post-merge-ci.yml`
- `(cd .github/scripts && npm test)` (37/37 filter tests passed)
- docs-only and mixed-change truth-table checks for `post_merge_docs`
- workflow graph assertions for test/deploy gates, unconditional builds, cleanup, and terminal notification ordering
- actionlint 1.7.12 on both changed workflows, excluding existing unknown custom-runner-label diagnostics
- `git diff --check`

## Rollout

- backport this workflow change to active release branches that require exact-SHA staging
