### PR TITLE
test(sglang): make chained tool use deterministic

### DIFF
--- a/tests/frontend/test_tool_calling_sglang.py
+++ b/tests/frontend/test_tool_calling_sglang.py
@@ -923,11 +923,17 @@ class TestToolCallingMultiTurn:
         ]
 
         step1 = stream_chat(
-            client, model, messages=messages, tools=TOOLS_SEARCH + TOOLS_CALCULATOR
+            client,
+            model,
+            messages=messages,
+            tools=TOOLS_SEARCH + TOOLS_CALCULATOR,
+            tool_choice={"type": "function", "function": {"name": "search_web"}},
         )
         assert_finish_reason(step1, {"tool_calls"})
         assert len(step1.tool_calls) >= 1
-        parse_and_validate_tool_call(step1.tool_calls[0], schemas)
+        parse_and_validate_tool_call(
+            step1.tool_calls[0], schemas, expected_name="search_web"
+        )
 
         messages.append(assistant_tool_message_from_result(step1))
         messages.append(
@@ -945,41 +951,36 @@ class TestToolCallingMultiTurn:
         )
 
         step2 = stream_chat(
-            client, model, messages=messages, tools=TOOLS_SEARCH + TOOLS_CALCULATOR
+            client,
+            model,
+            messages=messages,
+            tools=TOOLS_SEARCH + TOOLS_CALCULATOR,
+            tool_choice={"type": "function", "function": {"name": "calculate"}},
         )
-        # Small models sometimes short-circuit and compute the answer in
-        # their reasoning instead of chaining a second tool call. Accept
-        # either path: (a) another tool call to `calculate`, or (b) a
-        # direct text answer containing the correct result.
-        assert_finish_reason(step2, {"tool_calls", "stop"})
-        if step2.finish_reason == "tool_calls":
-            assert len(step2.tool_calls) >= 1
-            args2 = parse_and_validate_tool_call(step2.tool_calls[0], schemas)
-            assert step2.tool_calls[0]["function"]["name"] == "calculate"
-            assert "13960000" in args2["expression"].replace(
-                ",", ""
-            ) or "1396000" in args2["expression"].replace(",", "")
+        assert_finish_reason(step2, {"tool_calls"})
+        assert len(step2.tool_calls) >= 1
+        parse_and_validate_tool_call(
+            step2.tool_calls[0], schemas, expected_name="calculate"
+        )
 
-            messages.append(assistant_tool_message_from_result(step2))
-            messages.append(
-                {
-                    "role": "tool",
-                    "tool_call_id": step2.tool_calls[0]["id"],
-                    "content": "1396000",
-                }
-            )
+        messages.append(assistant_tool_message_from_result(step2))
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": step2.tool_calls[0]["id"],
+                "content": json.dumps({"result": "1,396,000"}),
+            }
+        )
 
-            step3 = stream_chat(
-                client, model, messages=messages, tools=TOOLS_SEARCH + TOOLS_CALCULATOR
-            )
-            assert_finish_reason(step3, {"stop"})
-            assert step3.tool_calls == []
-            assert "1396000" in step3.content.replace(",", "")
-        else:
-            # Short-circuit path: model did the math itself. Just verify
-            # the final answer is present in the text.
-            assert step2.tool_calls == []
-            assert "1396000" in step2.content.replace(",", "")
+        step3 = stream_chat(
+            client,
+            model,
+            messages=messages,
+            tools=TOOLS_SEARCH + TOOLS_CALCULATOR,
+        )
+        assert_finish_reason(step3, {"stop"})
+        assert step3.tool_calls == []
+        assert "1396000" in step3.content.replace(",", "")
 
     @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
     def test_multiple_prior_tool_results_synthesize_to_text(


### PR DESCRIPTION
## Context

`TestToolCallingMultiTurn::test_chained_tool_use_search_then_calculate` exercises a multi-turn tool conversation through Dynamo’s SGLang integration. The same test body runs against both the SGLang chat-processor frontend and the Rust frontend with worker-advertised parsers.

The intended flow is:

1. The user asks to search for Tokyo’s population and calculate 10% of it.
2. Dynamo returns a `search_web` tool call.
3. The test injects a search result containing `13,960,000`.
4. Dynamo returns a `calculate` tool call.
5. The test injects the calculator result, `1,396,000`.
6. Dynamo returns a final text response that consumes that result.

This exercises Dynamo’s handling of parsed tool calls, tool-call IDs, conversation history, tool results, and the transition back to a normal assistant response.

## Flaky failure

Previously, both tools were offered with the default automatic tool selection. The test therefore depended on Qwen3-0.6B to choose the intended tools and generate a mathematically correct calculator expression.

In the observed Rust-parser failure, Dynamo successfully returned and parsed a schema-valid `calculate` call, but the model generated `2,396,000` instead of an expression based on `13,960,000` or the correct result `1,396,000`. The assertion failed even though the Dynamo parsing and multi-turn protocol path worked. The automatic retry passed, which is consistent with nondeterministic model output.

## Change

- Explicitly select `search_web` for the first turn and `calculate` for the second.
- Validate that each parsed call has the expected function name and matches its JSON schema.
- Remove the assertion that asks the small model to perform or reproduce the arithmetic correctly.
- Inject a known calculator result and verify that the final response contains it without making another tool call.

## Why this scope makes sense

The test now focuses on the Dynamo behavior its multi-turn structure can verify reliably: carrying a conversation through two tool calls and consuming their results correctly. It no longer makes that protocol coverage depend on automatic tool selection or small-model arithmetic quality.

This deliberately narrows this specific test: it verifies deterministic multi-turn tool handling, not whether the model independently decides to use the right tools. That separation prevents model-quality variance from appearing as a Dynamo/Rust-parser regression.

## Testing

- `git diff --check`
- GPU integration test not run locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved chained tool-use test coverage by enforcing the expected search and calculation steps.
  * Added validation for each selected function and ensured the final text response is always executed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->