### PR TITLE
fix: preserve generated prefix identity in request replay

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/concepts/simulation/dynosim-architecture.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/concepts/simulation/dynosim-architecture.md
@@ -53,6 +53,10 @@ Mooncake-compatible formats carry request timing, token lengths, prefix hashes, 
 or dependency fields. Dynamo request traces are loaded directly from one or more JSONL or JSONL.GZ
 shards. The loader maps Dynamo's sequence-aware hashes to compact replay IDs without writing an
 intermediate Mooncake file and validates that every shard uses the same embedded trace block size.
+When a request trace includes optional completion-sequence hashes, the loader also reconstructs
+privacy-safe synthetic output tokens. A later request containing that exact generated continuation
+therefore reuses the same simulated cache blocks. Older traces without completion hashes retain the
+historical deterministic synthetic-output behavior.
 
 Context-free Dynamo records become independent requests. When every request contains
 `agent_context`, the loader reconstructs session dependencies and tool waits. It rejects mixed traces

--- a/docs/fern/pages/use-cases/agents/agent-tracing.md
+++ b/docs/fern/pages/use-cases/agents/agent-tracing.md
@@ -170,6 +170,11 @@ Dynamo emits `request_end` after an eligible response stream finishes or is drop
       "input_sequence_hashes": [
         14879255164371896291,
         274632075616497421
+      ],
+      "completion_sequence_hashes": [
+        14879255164371896291,
+        274632075616497421,
+        1380959123701298937
       ]
     }
   }
@@ -177,6 +182,11 @@ Dynamo emits `request_end` after an eligible response stream finishes or is drop
 ```
 
 </details>
+
+`completion_sequence_hashes` is optional and contains sequence-aware hashes for the input plus the
+exact generated tokens observed when the request ends. It lets replay reproduce cache reuse when a
+later turn includes the generated answer, without recording the answer or its token IDs. Traces from
+older Dynamo versions omit the field and keep the historical synthetic-output behavior.
 
 ### Compaction Metadata
 

--- a/lib/data-gen/src/request_trace/agentic.rs
+++ b/lib/data-gen/src/request_trace/agentic.rs
@@ -10,6 +10,7 @@ use crate::{AgenticMooncakeRow, AgenticToolEvent, RollingHashIdMapper};
 use anyhow::{Context, Result, anyhow, bail};
 
 use super::load::{LoadedAgentTrace, RequestEntry, ToolEntry};
+use super::mooncake::replay_hash_ids_and_output_tokens;
 
 /// Streams agentic Mooncake-compatible rows into the replay builder.
 ///
@@ -261,14 +262,20 @@ where
     }
 
     let mut mapper = RollingHashIdMapper::new(trace_block_size);
+    for request in &loaded.requests {
+        mapper.ids_for_sequence_hashes(&request.replay.input_sequence_hashes);
+    }
     for (idx, request) in loaded.requests.iter().enumerate() {
-        let hash_ids = mapper.ids_for_sequence_hashes(&request.replay.input_sequence_hashes);
         let output_length = request.request.output_tokens.ok_or_else(|| {
             anyhow!(
                 "request {} is missing output length",
                 request.request.request_id
             )
         })?;
+        let output_length =
+            usize::try_from(output_length).context("output length does not fit in usize")?;
+        let (hash_ids, output_token_ids) =
+            replay_hash_ids_and_output_tokens(&mut mapper, &request.replay, output_length)?;
         let session_id = session_id_for(request);
         let dep_end_ms = wait_for[idx]
             .iter()
@@ -311,10 +318,8 @@ where
                 request_id: request.request.request_id.clone(),
                 session_id: Some(session_id.clone()),
                 input_length: Some(request.replay.input_length),
-                output_length: Some(
-                    usize::try_from(output_length)
-                        .context("output length does not fit in usize")?,
-                ),
+                output_length: Some(output_length),
+                output_token_ids,
                 hash_ids: Some(hash_ids),
                 request_kind: Some(
                     if background_sessions.contains(&session_id) {
@@ -517,6 +522,7 @@ mod tests {
                 trace_block_size: 2,
                 input_length: sequence_hashes.len() * 2,
                 input_sequence_hashes: sequence_hashes,
+                completion_sequence_hashes: None,
             },
         }
     }

--- a/lib/data-gen/src/request_trace/load.rs
+++ b/lib/data-gen/src/request_trace/load.rs
@@ -125,6 +125,8 @@ pub(crate) struct RequestTraceReplayMetrics {
     pub(crate) trace_block_size: usize,
     pub(crate) input_length: usize,
     pub(crate) input_sequence_hashes: Vec<u64>,
+    #[serde(default)]
+    pub(crate) completion_sequence_hashes: Option<Vec<u64>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -395,6 +397,30 @@ fn request_entry(record: RequestTraceRecord) -> Result<RequestEntry> {
     }
     if request.output_tokens.is_none() {
         bail!("request trace is missing output_tokens");
+    }
+    if let Some(completion_hashes) = replay.completion_sequence_hashes.as_ref() {
+        let output_tokens = usize::try_from(request.output_tokens.unwrap_or_default())
+            .context("output_tokens does not fit in usize")?;
+        let completion_length = replay
+            .input_length
+            .checked_add(output_tokens)
+            .context("request replay completion length overflow")?;
+        let expected_completion_hashes = completion_length.div_ceil(replay.trace_block_size);
+        if completion_hashes.len() != expected_completion_hashes {
+            bail!(
+                "completion length {} with trace_block_size {} requires exactly {} replay hashes, got {}",
+                completion_length,
+                replay.trace_block_size,
+                expected_completion_hashes,
+                completion_hashes.len()
+            );
+        }
+        let full_input_blocks = replay.input_length / replay.trace_block_size;
+        if completion_hashes[..full_input_blocks]
+            != replay.input_sequence_hashes[..full_input_blocks]
+        {
+            bail!("completion replay hashes do not preserve the full input-block prefix");
+        }
     }
 
     let (start_ms, end_ms) = request_times(record.event_time_unix_ms, &request);

--- a/lib/data-gen/src/request_trace/mooncake.rs
+++ b/lib/data-gen/src/request_trace/mooncake.rs
@@ -6,6 +6,37 @@ use anyhow::{Context, Result, anyhow, bail};
 
 use super::load::RequestEntry;
 
+pub(crate) fn replay_hash_ids_and_output_tokens(
+    mapper: &mut RollingHashIdMapper,
+    replay: &super::load::RequestTraceReplayMetrics,
+    output_length: usize,
+) -> Result<(Vec<u64>, Option<Vec<u32>>)> {
+    let mut input_hash_ids = mapper.ids_for_sequence_hashes(&replay.input_sequence_hashes);
+    let Some(completion_sequence_hashes) = replay.completion_sequence_hashes.as_ref() else {
+        return Ok((input_hash_ids, None));
+    };
+
+    let completion_hash_ids = mapper.ids_for_sequence_hashes(completion_sequence_hashes);
+    let partial_input_block = !replay.input_length.is_multiple_of(replay.trace_block_size);
+    let first_output_block = replay.input_length / replay.trace_block_size;
+    if partial_input_block && output_length > 0 {
+        input_hash_ids[first_output_block] = completion_hash_ids[first_output_block];
+    }
+
+    let output_token_ids = (0..output_length)
+        .map(|offset| {
+            let sequence_position = replay
+                .input_length
+                .checked_add(offset)
+                .context("request replay output position overflow")?;
+            let block_index = sequence_position / replay.trace_block_size;
+            u32::try_from(completion_hash_ids[block_index])
+                .context("request replay hash ID does not fit in u32")
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok((input_hash_ids, Some(output_token_ids)))
+}
+
 /// Streams each request through a Mooncake-compatible row into the replay builder.
 ///
 /// This is an in-memory compatibility layer; it does not write a Mooncake trace.
@@ -38,23 +69,30 @@ where
     });
 
     let mut mapper = RollingHashIdMapper::new(trace_block_size);
+    // Seed only authored input hashes first. The downstream Mooncake interner
+    // sees these rows in the same order, so the compact IDs remain stable when
+    // completion hashes are lowered into synthetic output token IDs.
+    for request in &requests {
+        mapper.ids_for_sequence_hashes(&request.replay.input_sequence_hashes);
+    }
     for request in requests {
-        let hash_ids = mapper.ids_for_sequence_hashes(&request.replay.input_sequence_hashes);
         let output_length = request.request.output_tokens.ok_or_else(|| {
             anyhow!(
                 "request {} is missing output length",
                 request.request.request_id
             )
         })?;
+        let output_length =
+            usize::try_from(output_length).context("output length does not fit in usize")?;
+        let (hash_ids, output_token_ids) =
+            replay_hash_ids_and_output_tokens(&mut mapper, &request.replay, output_length)?;
         emit(
             trace_block_size,
             MooncakeRow {
                 session_id: None,
                 input_length: Some(request.replay.input_length),
-                output_length: Some(
-                    usize::try_from(output_length)
-                        .context("output length does not fit in usize")?,
-                ),
+                output_length: Some(output_length),
+                output_token_ids,
                 hash_ids: Some(hash_ids),
                 timestamp: Some((request.start_ms - global_start_ms) as f64),
                 delay: None,
@@ -94,6 +132,7 @@ mod tests {
                 trace_block_size: 2,
                 input_length: sequence_hashes.len() * 2,
                 input_sequence_hashes: sequence_hashes,
+                completion_sequence_hashes: None,
             },
         }
     }
@@ -123,5 +162,79 @@ mod tests {
             entries[0].hash_ids.as_ref().unwrap()[0],
             entries[2].hash_ids.as_ref().unwrap()[0]
         );
+    }
+
+    #[test]
+    fn lowering_makes_an_exact_generated_continuation_reusable() {
+        let mut first = request("req-parent", 1_000, 1_100, vec![11]);
+        first.request.output_tokens = Some(2);
+        first.replay.completion_sequence_hashes = Some(vec![11, 22]);
+
+        let mut second = request("req-child", 1_200, 1_300, vec![11, 22]);
+        second.request.output_tokens = Some(1);
+        second.replay.completion_sequence_hashes = Some(vec![11, 22, 33]);
+
+        let mut rows = Vec::new();
+        lower_mooncake_rows(vec![first, second], |_, row| {
+            rows.push(row);
+            Ok(())
+        })
+        .unwrap();
+
+        let parent_prompt = rows[0]
+            .hash_ids
+            .as_ref()
+            .unwrap()
+            .iter()
+            .flat_map(|hash_id| [*hash_id as u32; 2])
+            .collect::<Vec<_>>();
+        let mut completed_parent = parent_prompt;
+        completed_parent.extend(rows[0].output_token_ids.as_ref().unwrap());
+        let child_prompt = rows[1]
+            .hash_ids
+            .as_ref()
+            .unwrap()
+            .iter()
+            .flat_map(|hash_id| [*hash_id as u32; 2])
+            .collect::<Vec<_>>();
+
+        assert_eq!(completed_parent, child_prompt);
+    }
+
+    #[test]
+    fn lowering_completes_a_partial_input_block_with_generated_tokens() {
+        let mut first = request("req-parent", 1_000, 1_100, vec![11, 12]);
+        first.replay.input_length = 3;
+        first.request.output_tokens = Some(1);
+        first.replay.completion_sequence_hashes = Some(vec![11, 22]);
+
+        let mut second = request("req-child", 1_200, 1_300, vec![11, 22]);
+        second.request.output_tokens = Some(1);
+        second.replay.completion_sequence_hashes = Some(vec![11, 22, 33]);
+
+        let mut rows = Vec::new();
+        lower_mooncake_rows(vec![first, second], |_, row| {
+            rows.push(row);
+            Ok(())
+        })
+        .unwrap();
+
+        let parent_hash_ids = rows[0].hash_ids.as_ref().unwrap();
+        let parent_output_ids = rows[0].output_token_ids.as_ref().unwrap();
+        let child_hash_ids = rows[1].hash_ids.as_ref().unwrap();
+        assert_eq!(parent_hash_ids[1], child_hash_ids[1]);
+        assert_eq!(u64::from(parent_output_ids[0]), child_hash_ids[1]);
+    }
+
+    #[test]
+    fn lowering_preserves_legacy_synthetic_output_behavior() {
+        let mut rows = Vec::new();
+        lower_mooncake_rows(vec![request("legacy", 1_000, 1_100, vec![11])], |_, row| {
+            rows.push(row);
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(rows[0].output_token_ids.is_none());
     }
 }

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -6410,8 +6410,18 @@ impl
 
         // forward the common completion request to the next operator
         let response_stream = next.generate(common_request).await?;
-        // Extract context once
+        // Extract context before wrapping the stream.
         let context = response_stream.context();
+        let trace_output_token_ids = crate::request_trace::output_token_ids_handle(&trace_state);
+        let response_stream = response_stream.map(move |response| {
+            if let Some(output) = response.data.as_ref() {
+                crate::request_trace::record_output_token_ids(
+                    trace_output_token_ids.as_ref(),
+                    &output.token_ids,
+                );
+            }
+            response
+        });
 
         // transform the postprocessor stream (no boxing yet) - detokenize
         let stream = Self::transform_postprocessor_stream_with_image_tokens(
@@ -6600,9 +6610,18 @@ impl
 
         // forward the common completion request to the next operator
         let response_stream = next.generate(common_request).await?;
-
-        // Extract context once
+        // Extract context before wrapping the stream.
         let context = response_stream.context();
+        let trace_output_token_ids = crate::request_trace::output_token_ids_handle(&trace_state);
+        let response_stream = response_stream.map(move |response| {
+            if let Some(output) = response.data.as_ref() {
+                crate::request_trace::record_output_token_ids(
+                    trace_output_token_ids.as_ref(),
+                    &output.token_ids,
+                );
+            }
+            response
+        });
 
         // transform the postprocessor stream. Legacy `/v1/completions` is
         // text-only, so multimodal counts are always zero here.

--- a/lib/llm/src/request_trace/integration.rs
+++ b/lib/llm/src/request_trace/integration.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use dynamo_runtime::pipeline::Context;
 use dynamo_runtime::protocols::annotated::Annotated;
 use futures::{Stream, StreamExt};
+use parking_lot::Mutex;
 
 use crate::protocols::common::preprocessor::PreprocessedRequest;
 use crate::protocols::common::timing::RequestTracker;
@@ -20,7 +21,11 @@ use crate::request_trace::{
 struct RequestTraceRequestEndState {
     request_tracker: Arc<RequestTracker>,
     replay_metrics: Arc<RequestReplayMetrics>,
+    input_token_ids: Arc<[crate::protocols::TokenIdType]>,
+    output_token_ids: SharedOutputTokenIds,
 }
+
+type SharedOutputTokenIds = Arc<Mutex<Vec<crate::protocols::TokenIdType>>>;
 
 pub(crate) struct RequestEndTraceState {
     agent: Option<AgentContextTraceState>,
@@ -120,9 +125,47 @@ fn build_request_end_trace_state_for_policy(
     let request = RequestTraceRequestEndState {
         request_tracker,
         replay_metrics,
+        input_token_ids: Arc::from(common_request.token_ids.clone()),
+        output_token_ids: SharedOutputTokenIds::default(),
     };
 
     Some(RequestEndTraceState { agent, request })
+}
+
+pub(crate) fn output_token_ids_handle(
+    trace_state: &Option<RequestEndTraceState>,
+) -> Option<SharedOutputTokenIds> {
+    trace_state
+        .as_ref()
+        .map(|state| Arc::clone(&state.request.output_token_ids))
+}
+
+pub(crate) fn record_output_token_ids(
+    output_token_ids: Option<&SharedOutputTokenIds>,
+    chunk_token_ids: &[crate::protocols::TokenIdType],
+) {
+    let Some(output_token_ids) = output_token_ids else {
+        return;
+    };
+    output_token_ids.lock().extend_from_slice(chunk_token_ids);
+}
+
+fn completed_replay_metrics(state: RequestTraceRequestEndState) -> RequestReplayMetrics {
+    let mut replay = super::into_owned_replay_metrics(state.replay_metrics);
+    let output_token_ids = state.output_token_ids.lock();
+    let mut completed_token_ids = Vec::with_capacity(
+        state
+            .input_token_ids
+            .len()
+            .saturating_add(output_token_ids.len()),
+    );
+    completed_token_ids.extend_from_slice(&state.input_token_ids);
+    completed_token_ids.extend_from_slice(&output_token_ids);
+    replay.completion_sequence_hashes = Some(super::replay::input_sequence_hashes(
+        &completed_token_ids,
+        replay.trace_block_size,
+    ));
+    replay
 }
 
 pub(crate) fn finish_reason_metadata_handle(
@@ -153,15 +196,14 @@ where
         if let Some(agent_state) = trace_state.agent {
             let (agent_context, mut metrics) =
                 super::request_metrics_from_agent_state(agent_state, request_id.clone());
-            metrics.replay = Some(super::into_owned_replay_metrics(
-                request_state.replay_metrics,
-            ));
+            metrics.replay = Some(completed_replay_metrics(request_state));
             super::record::emit_agent_request_end(agent_context, metrics);
         } else {
+            let tracker = Arc::clone(&request_state.request_tracker);
             super::record::emit_request_end(
                 request_id.clone(),
-                &request_state.request_tracker,
-                super::into_owned_replay_metrics(request_state.replay_metrics),
+                &tracker,
+                completed_replay_metrics(request_state),
             );
         }
     });
@@ -326,7 +368,10 @@ mod tests {
                     trace_block_size: 2,
                     input_length: 2,
                     input_sequence_hashes: vec![11],
+                    completion_sequence_hashes: None,
                 }),
+                input_token_ids: Arc::from(vec![1_u32, 2]),
+                output_token_ids: SharedOutputTokenIds::default(),
             },
         };
         let stream = TrackerDropStream {
@@ -355,6 +400,31 @@ mod tests {
         let request = record.request.as_ref().expect("request payload");
         assert!(dropped.load(Ordering::Acquire));
         assert_eq!(request.output_tokens, Some(9));
+    }
+
+    #[test]
+    fn completion_hashes_include_captured_generated_tokens() {
+        let input_token_ids = vec![10_u32, 11, 12];
+        let replay_metrics = shared_replay_metrics(&input_token_ids, 2).unwrap();
+        let output_token_ids = SharedOutputTokenIds::default();
+        record_output_token_ids(Some(&output_token_ids), &[20, 21]);
+        record_output_token_ids(Some(&output_token_ids), &[22]);
+        let state = RequestTraceRequestEndState {
+            request_tracker: Arc::new(RequestTracker::new()),
+            replay_metrics,
+            input_token_ids: Arc::from(input_token_ids.clone()),
+            output_token_ids,
+        };
+
+        let completed = completed_replay_metrics(state);
+        let expected = input_token_ids
+            .into_iter()
+            .chain([20, 21, 22])
+            .collect::<Vec<_>>();
+        assert_eq!(
+            completed.completion_sequence_hashes,
+            Some(super::super::replay::input_sequence_hashes(&expected, 2))
+        );
     }
 
     #[tokio::test]

--- a/lib/llm/src/request_trace/mod.rs
+++ b/lib/llm/src/request_trace/mod.rs
@@ -34,8 +34,8 @@ pub use config::{
     is_enabled, policy,
 };
 pub(crate) use integration::{
-    build_request_end_trace_state, finish_reason_metadata_handle, wrap_chat_request_end_stream,
-    wrap_completion_request_end_stream,
+    build_request_end_trace_state, finish_reason_metadata_handle, output_token_ids_handle,
+    record_output_token_ids, wrap_chat_request_end_stream, wrap_completion_request_end_stream,
 };
 pub(crate) use record::{publish_tool_record, validate_tool_record};
 pub(crate) use replay::replay_metrics;

--- a/lib/llm/src/request_trace/record.rs
+++ b/lib/llm/src/request_trace/record.rs
@@ -205,6 +205,7 @@ mod tests {
                 trace_block_size: 2,
                 input_length: 3,
                 input_sequence_hashes: vec![11, 22],
+                completion_sequence_hashes: None,
             },
         );
 

--- a/lib/llm/src/request_trace/replay.rs
+++ b/lib/llm/src/request_trace/replay.rs
@@ -26,6 +26,7 @@ pub(crate) fn replay_metrics(
         trace_block_size,
         input_length: token_ids.len(),
         input_sequence_hashes: input_sequence_hashes(token_ids, trace_block_size),
+        completion_sequence_hashes: None,
     })
 }
 

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -333,6 +333,7 @@ mod tests {
                     trace_block_size: 2,
                     input_length: 3,
                     input_sequence_hashes: vec![11, 22],
+                    completion_sequence_hashes: None,
                 }),
                 finish_reason_metadata: None,
             }),

--- a/lib/llm/src/request_trace/types.rs
+++ b/lib/llm/src/request_trace/types.rs
@@ -123,6 +123,12 @@ pub struct RequestReplayMetrics {
     pub trace_block_size: usize,
     pub input_length: usize,
     pub input_sequence_hashes: Vec<u64>,
+    /// Sequence-aware hashes for the full input plus generated output at request completion.
+    ///
+    /// Older traces omit this field. Replay then retains its historical deterministic
+    /// synthetic-output behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion_sequence_hashes: Option<Vec<u64>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -338,6 +344,7 @@ mod tests {
                     trace_block_size: 2,
                     input_length: 4,
                     input_sequence_hashes: vec![11, 22],
+                    completion_sequence_hashes: None,
                 }),
                 finish_reason_metadata: None,
             }),

--- a/lib/mocker/src/replay/entrypoints.rs
+++ b/lib/mocker/src/replay/entrypoints.rs
@@ -2383,6 +2383,55 @@ mod tests {
     }
 
     #[test]
+    fn exact_generated_continuation_is_reused_after_parent_completes() {
+        let trace = Trace {
+            block_size: 4,
+            sessions: vec![SessionTrace {
+                session_id: "session_1".to_string(),
+                first_arrival_timestamp_ms: Some(0.0),
+                turns: vec![
+                    TurnTrace {
+                        input_length: 4,
+                        max_output_tokens: 8,
+                        output_token_ids: Some(vec![2; 4].into_iter().chain(vec![3; 4]).collect()),
+                        hash_ids: vec![1],
+                        delay_after_previous_ms: 0.0,
+                        ..Default::default()
+                    },
+                    TurnTrace {
+                        input_length: 12,
+                        max_output_tokens: 1,
+                        hash_ids: vec![1, 2, 3],
+                        delay_after_previous_ms: 0.0,
+                        ..Default::default()
+                    },
+                ],
+            }],
+        };
+
+        let report = simulate_loaded_trace_live_with_router_mode_and_options(
+            MockEngineArgs {
+                enable_prefix_caching: true,
+                ..replay_test_args()
+            },
+            None,
+            None,
+            trace,
+            1,
+            1.0,
+            ReplayRouterMode::RoundRobin,
+            true,
+            SlaThresholds::default(),
+        )
+        .unwrap();
+
+        let parent = &report.per_request[0];
+        let child = &report.per_request[1];
+        assert!(child.first_admit_ms.unwrap() >= parent.terminal_time_ms);
+        assert_eq!(child.reused_input_tokens, 8);
+    }
+
+    #[test]
     fn loaded_dynamo_disagg_trace_validates_timestamps() {
         let error = simulate_loaded_trace_disagg_with_router_mode_and_options(
             disagg_test_config(),


### PR DESCRIPTION
Request traces currently retain prompt block hashes and output length, but not the generated token identity. DynoSim therefore invents output tokens, so a later turn containing the real generated continuation cannot reuse those cache blocks.

This change:
- records optional sequence-aware hashes for input plus generated output at request completion, without serializing response text or token IDs
- lowers those hashes into deterministic synthetic output IDs that share the prompt hash-ID domain
- validates full-input prefix continuity and completion length
- preserves historical behavior for older rows without the optional field
- covers aligned and partial blocks plus post-completion cache reuse in the simulator

Tests:
- `cargo check -p dynamo-llm --lib --no-default-features`
- `cargo test -p dynamo-llm --lib request_trace --no-default-features` (63 passed)
- `cargo test -p dynamo-data-gen request_trace` (23 passed)
- `cargo test -p dynamo-mocker exact_generated_continuation_is_reused_after_parent_completes` (1 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replay simulations can now reuse cached blocks when requests share the same generated continuation.
  * Request tracing captures generated output information to support more accurate replay behavior.
  * Privacy-safe completion hashes enable continuation reuse without storing response text or token identifiers.
  * Existing traces without completion hashes continue to use the previous deterministic behavior.

* **Documentation**
  * Updated tracing and simulation architecture guidance with completion-hash configuration and compatibility details.

* **Bug Fixes**
  * Improved replay handling for completed continuations and partially completed input blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->