### PR TITLE
perf(bindings): encode push-egress token frames without serde

### DIFF
--- a/lib/bindings/python/rust/push_egress.rs
+++ b/lib/bindings/python/rust/push_egress.rs
@@ -31,7 +31,7 @@ use anyhow::Error;
 use bytes::{BufMut, Bytes, BytesMut};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::PyModule;
+use pyo3::types::{PyDict, PyModule};
 use tokio_stream::{Stream, StreamExt};
 
 use tokio::sync::mpsc;
@@ -209,11 +209,16 @@ impl std::fmt::Debug for PushFrame {
 impl PushFrame {
     /// Encode one Python response object, with the GIL held by the caller.
     ///
-    /// Both steps are shared with the pull path — `parse_python_response`
-    /// interprets the object, `write_annotated_response` produces the bytes — so
-    /// the two cannot drift. The only change from the pull path is where those
-    /// bytes land: a buffer reused across this request's frames, rather than a
-    /// fresh `Vec` each time.
+    /// Two encoders, one wire format. A steady-state token frame takes the fast
+    /// path (`try_write_token_frame`), which writes msgpack directly; everything
+    /// else falls back to the encoder shared with the pull path —
+    /// `parse_python_response` interprets the object, `write_annotated_response`
+    /// produces the bytes — so the fallback cannot drift. The fast path is held
+    /// to the same bytes by `token_frame_matches_generic_encoding`, which matters
+    /// because the two are chosen per frame *within one response stream*.
+    ///
+    /// Either way the bytes land in a buffer reused across this request's frames,
+    /// rather than a fresh `Vec` each time.
     ///
     /// ## Why `try_lock` rather than `lock`
     ///
@@ -273,6 +278,16 @@ impl PushFrame {
         codec: RequestPlanePayloadCodec,
         out: &mut BytesMut,
     ) -> PyResult<bool> {
+        if codec == RequestPlanePayloadCodec::Msgpack
+            && let Ok(dict) = obj.downcast::<PyDict>()
+            && python_payload::try_write_token_frame(dict, out)
+        {
+            // Never an error frame: a token frame has no error field, and
+            // `try_write_token_frame` only accepts dicts whose exact key set
+            // rules out an `_dynamo_annotated` envelope.
+            return Ok(false);
+        }
+
         let annotated =
             python_payload::parse_python_response(obj.clone().unbind(), py).map_err(|error| {
                 PyValueError::new_err(format!(

--- a/lib/bindings/python/rust/python_payload.rs
+++ b/lib/bindings/python/rust/python_payload.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
 use dynamo_runtime::pipeline::PipelineError;
 use dynamo_runtime::pipeline::network::{
     EncodedResponseFrame, IngressRequestDecoder, IngressResponseEncoder, NetworkStreamWrapper,
@@ -10,7 +10,7 @@ use dynamo_runtime::pipeline::network::{
 use dynamo_runtime::protocols::annotated::Annotated;
 use dynamo_runtime::protocols::maybe_error::MaybeError;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyString};
+use pyo3::types::{PyDict, PyInt, PyList, PyString};
 use pythonize::{Depythonizer, Pythonizer, depythonize};
 use serde::de::Error as _;
 use serde::ser::Error as _;
@@ -235,6 +235,152 @@ pub(crate) fn write_annotated_response<T: Serialize, W: std::io::Write>(
     Ok(is_error)
 }
 
+// ── Steady-state token-frame fast path ───────────────────────────────────────
+//
+// Writes standard TRT-LLM token frames directly to bypass costly generic
+// serialization.
+//
+// Streaming decode predominantly produces a two-key dict (`token_ids`, `index`).
+// Using the generic `pythonize` encoder creates massive overhead due to
+// sequential type-checking and integer downcasting for every single token ID.
+//
+// This fast path skips that ladder. Byte-equivalence with the generic encoder is
+// verified by the `token_frame_matches_generic_encoding` test.
+
+/// Justifies the hardcoded map lengths below based on envelope serialization:
+///
+/// * **`Annotated` (1 key):** Serializes only the `data` key (the token payload).
+///   Other fields (`id`, `event`, etc.) are `None` on token frames and skipped by `serde`.
+/// * **`NetworkStreamWrapper` (2 keys):** Serializes the `data` key (holding the
+///   `Annotated` object) plus the always-written `complete_final` boolean.
+const KEY_DATA: &str = "data";
+const KEY_COMPLETE_FINAL: &str = "complete_final";
+const KEY_TOKEN_IDS: &str = "token_ids";
+const KEY_INDEX: &str = "index";
+
+/// Try to encode a token frame straight to msgpack, skipping serde entirely.
+///
+/// Returns `true` if `dict` matched and the frame was written. Returns `false`,
+/// having written nothing, if it did not — the caller must then use the generic
+/// path. To match, `dict` must be exactly `token_ids` then `index`, holding a
+/// list of non-negative ints and a non-negative int. Msgpack only; JSON always
+/// takes the generic path.
+pub(crate) fn try_write_token_frame(dict: &Bound<'_, PyDict>, out: &mut BytesMut) -> bool {
+    // We can only tell a frame is ineligible partway through writing it — a bad
+    // token id in the middle of the list, say — so remember where the caller
+    // left off and rewind on failure. Half a frame followed by a whole one is
+    // undecodable garbage on the wire.
+    let rewind = out.len();
+    if parse_and_write_token_frame(dict, out).is_none() {
+        out.truncate(rewind);
+        return false;
+    }
+    true
+}
+
+fn parse_and_write_token_frame(dict: &Bound<'_, PyDict>, out: &mut BytesMut) -> Option<()> {
+    // Match on iteration ORDER, not by key lookup.
+    //
+    // A msgpack map stores its entries in the order the serializer visits them,
+    // which for a Python dict is insertion order. So a dict holding these same
+    // two keys the other way round has to encode the other way round too — if
+    // we matched it here, the fast and generic paths would disagree on bytes.
+    //
+    // Matching on order also makes this a *complete* check of the shape: a third
+    // key fails the `next()` below, and a `_dynamo_annotated` envelope can never
+    // match. That is what makes it safe to skip `parse_python_response`.
+    let mut entries = dict.iter();
+    let (token_ids_key, token_ids) = entries.next()?;
+    let (index_key, index) = entries.next()?;
+    if entries.next().is_some()
+        || !key_is(&token_ids_key, KEY_TOKEN_IDS)
+        || !key_is(&index_key, KEY_INDEX)
+    {
+        return None;
+    }
+
+    let token_ids = token_ids.downcast::<PyList>().ok()?;
+    let index = exact_uint(&index)?;
+
+    write_token_frame_bytes(
+        token_ids.iter().map(|token_id| exact_uint(&token_id)),
+        u32::try_from(token_ids.len()).ok()?,
+        index,
+        &mut (&mut *out).writer(),
+    )
+}
+
+/// Write the msgpack bytes for one token frame.
+///
+/// Kept separate from the Python-facing code above so the wire layout — the part
+/// that must match the generic encoder exactly — can be unit-tested. This crate
+/// builds as a PyO3 extension module and so does not link libpython, meaning
+/// `cargo test` cannot touch Python objects. See the module tests below.
+///
+/// `token_count` must equal the number of items `token_ids` yields. msgpack
+/// writes an array's length *before* its elements, so a mismatch produces a
+/// frame that cannot be decoded. A `None` item aborts the frame mid-write, which
+/// is why the caller has to be able to rewind.
+fn write_token_frame_bytes<W, I>(
+    token_ids: I,
+    token_count: u32,
+    index: u64,
+    writer: &mut W,
+) -> Option<()>
+where
+    W: std::io::Write,
+    I: Iterator<Item = Option<u64>>,
+{
+    // Three nested maps, matching what serde would emit:
+    //   NetworkStreamWrapper { data, complete_final }
+    //     -> Annotated { data }   (id/event/comment/error are None, so skipped)
+    //          -> { token_ids, index }
+    rmp::encode::write_map_len(writer, 2).ok()?;
+    rmp::encode::write_str(writer, KEY_DATA).ok()?;
+    rmp::encode::write_map_len(writer, 1).ok()?;
+    rmp::encode::write_str(writer, KEY_DATA).ok()?;
+    rmp::encode::write_map_len(writer, 2).ok()?;
+    rmp::encode::write_str(writer, KEY_TOKEN_IDS).ok()?;
+    rmp::encode::write_array_len(writer, token_count).ok()?;
+    let mut written = 0u32;
+    for token_id in token_ids {
+        rmp::encode::write_uint(writer, token_id?).ok()?;
+        written += 1;
+    }
+    if written != token_count {
+        return None;
+    }
+    rmp::encode::write_str(writer, KEY_INDEX).ok()?;
+    rmp::encode::write_uint(writer, index).ok()?;
+    rmp::encode::write_str(writer, KEY_COMPLETE_FINAL).ok()?;
+    rmp::encode::write_bool(writer, false).ok()?;
+    Some(())
+}
+
+/// Whether `key` is exactly the `str` `name`.
+fn key_is(key: &Bound<'_, PyAny>, name: &str) -> bool {
+    key.downcast_exact::<PyString>()
+        .ok()
+        .and_then(|key| key.to_str().ok())
+        .is_some_and(|key| key == name)
+}
+
+/// `value` as a `u64` — but only if the generic path would also encode it as a
+/// plain unsigned integer.
+///
+/// `downcast_exact` is load-bearing. In Python `bool` is a subclass of `int`,
+/// and pythonize checks `PyBool` *before* `PyInt`, so generically a `True` in a
+/// token list becomes a msgpack bool. It must not silently become the integer 1
+/// here. Requiring the exact type keeps bools (and any other `int` subclass) on
+/// the generic path.
+///
+/// `extract` then rejects negatives and anything larger than `u64`, which the
+/// generic path also encodes differently — as a signed int, and as msgpack
+/// *bytes* respectively.
+fn exact_uint(value: &Bound<'_, PyAny>) -> Option<u64> {
+    value.downcast_exact::<PyInt>().ok()?.extract().ok()
+}
+
 fn encode_python_response(
     payload_codec: RequestPlanePayloadCodec,
     response: PythonResponseItem,
@@ -361,7 +507,182 @@ mod tests {
 
     use super::{
         Annotated, NetworkStreamWrapper, RequestPlanePayloadCodec, encode_annotated_response,
+        write_token_frame_bytes,
     };
+    use serde::Serialize;
+
+    // ── token-frame fast path: wire equivalence ──────────────────────────────
+    //
+    // The fast path skips serde. That is only safe if it produces the SAME bytes
+    // the generic path would, so these tests encode one logical response both
+    // ways and compare.
+    //
+    // Byte equality, not just "both decode": the two paths are picked per frame
+    // *within a single response stream*, so any difference in map ordering or
+    // integer width would be a wire mismatch between consecutive frames of one
+    // response.
+    //
+    // The Python half — the shape and type checks in `parse_and_write_token_frame`
+    // — cannot be tested here, since these tests do not link libpython. It is
+    // covered by pytest against the built extension instead.
+
+    /// Stands in for the dict `handler_base.py` builds per token, with the fields
+    /// in the same order Python inserts them. msgpack writes a Rust struct as a
+    /// map, so this serializes exactly as that Python dict does.
+    ///
+    /// `u64`, not `u32`, to match what the fast path actually accepts: `exact_uint`
+    /// takes any value up to `u64::MAX`, so the comparison has to reach that far
+    /// too or the widest markers would go unchecked.
+    #[derive(Serialize)]
+    struct TokenFramePayload {
+        token_ids: Vec<u64>,
+        index: u64,
+    }
+
+    /// What the generic path puts on the wire for this frame.
+    fn generic_encoding(token_ids: &[u64], index: u64) -> Vec<u8> {
+        let (bytes, is_error) = encode_annotated_response(
+            RequestPlanePayloadCodec::Msgpack,
+            Annotated::from_data(TokenFramePayload {
+                token_ids: token_ids.to_vec(),
+                index,
+            }),
+        )
+        .expect("generic encode must succeed");
+        assert!(!is_error, "a token frame is never an error frame");
+        bytes
+    }
+
+    /// What the fast path puts on the wire for this frame.
+    fn fast_encoding(token_ids: &[u64], index: u64) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        write_token_frame_bytes(
+            token_ids.iter().copied().map(Some),
+            u32::try_from(token_ids.len()).expect("length fits u32"),
+            index,
+            &mut bytes,
+        )
+        .expect("fast encode must succeed");
+        bytes
+    }
+
+    /// Values on both sides of every msgpack uint marker boundary. msgpack picks
+    /// a different marker byte per magnitude, so these are where a hand-written
+    /// encoder would drift from `write_uint`. Runs to `u64::MAX` because that is
+    /// the largest value the fast path will accept.
+    const MAGNITUDES: [u64; 12] = [
+        0,
+        1,
+        127,           // largest positive fixint
+        128,           // first needing uint8
+        255,           // largest uint8
+        256,           // first needing uint16
+        65_535,        // largest uint16
+        65_536,        // first needing uint32
+        4_294_967_295, // largest uint32
+        4_294_967_296, // first needing uint64
+        u64::MAX - 1,
+        u64::MAX,
+    ];
+
+    fn assert_encodings_agree(token_ids: &[u64], index: u64) {
+        assert_eq!(
+            fast_encoding(token_ids, index),
+            generic_encoding(token_ids, index),
+            "fast and generic encodings diverged for token_ids={token_ids:?} index={index}"
+        );
+    }
+
+    /// Covers token id widths, plus list lengths on both sides of the fixarray
+    /// boundary where `write_array_len` switches marker.
+    #[test]
+    fn token_frame_matches_generic_encoding() {
+        let mut cases: Vec<Vec<u64>> = vec![
+            vec![],              // engine returned no new tokens
+            vec![5],             // the steady-state case
+            MAGNITUDES.to_vec(), // mixed widths in one list
+            (0..15).collect(),   // fixarray, at the limit
+            (0..16).collect(),   // first length needing array16
+            (0..40).collect(),   // comfortably past it
+        ];
+        cases.extend(MAGNITUDES.map(|magnitude| vec![magnitude]));
+
+        for token_ids in &cases {
+            assert_encodings_agree(token_ids, 0);
+        }
+    }
+
+    /// `index` is encoded independently of the token list, so it only needs its
+    /// own uint boundaries — no cross product with the cases above.
+    #[test]
+    fn token_frame_index_matches_generic_encoding() {
+        for index in MAGNITUDES {
+            assert_encodings_agree(&[5], index);
+        }
+    }
+
+    /// The frame must decode to the envelope the rest of the request plane
+    /// expects: `data` present, no error, not the end-of-stream marker.
+    ///
+    /// The byte-equality tests above compare the two paths to each other, so they
+    /// would pass if both were wrong in the same way. This one checks the result
+    /// independently.
+    #[test]
+    fn token_frame_decodes_as_a_non_terminal_data_frame() {
+        let bytes = fast_encoding(&[7, 8], 3);
+        let wrapper: NetworkStreamWrapper<Annotated<rmpv::Value>> =
+            RequestPlanePayloadCodec::Msgpack
+                .decode(&bytes)
+                .expect("fast-path frame must decode");
+
+        assert!(!wrapper.complete_final, "not the end-of-stream marker");
+        let annotated = wrapper.data.expect("frame carries data");
+        assert!(annotated.error.is_none(), "a token frame carries no error");
+        assert!(annotated.id.is_none() && annotated.event.is_none());
+
+        let data = annotated.data.expect("annotated data");
+        let fields = data.as_map().expect("payload is a map");
+        let field = |name: &str| {
+            fields
+                .iter()
+                .find(|(key, _)| key.as_str() == Some(name))
+                .map(|(_, value)| value)
+                .unwrap_or_else(|| panic!("payload must carry {name}"))
+        };
+        assert_eq!(
+            field("token_ids")
+                .as_array()
+                .expect("token_ids is an array")
+                .iter()
+                .map(|id| id.as_u64().expect("token id is a uint"))
+                .collect::<Vec<_>>(),
+            vec![7, 8]
+        );
+        assert_eq!(field("index").as_u64(), Some(3));
+    }
+
+    /// A token the Python side could not convert must abort the whole frame,
+    /// never report a partial one as written. The caller rewinds on `None`.
+    #[test]
+    fn token_frame_aborts_on_an_unconvertible_token() {
+        let mut bytes = Vec::new();
+        assert!(
+            write_token_frame_bytes([Some(1), None, Some(3)].into_iter(), 3, 0, &mut bytes)
+                .is_none(),
+            "an unconvertible token must abort the frame"
+        );
+    }
+
+    /// If the declared count and the tokens actually yielded disagree, the array
+    /// header would lie about its length and the frame would not decode.
+    #[test]
+    fn token_frame_rejects_a_token_count_mismatch() {
+        let mut bytes = Vec::new();
+        assert!(
+            write_token_frame_bytes([Some(1), Some(2)].into_iter(), 3, 0, &mut bytes).is_none(),
+            "too few tokens for the declared count must abort the frame"
+        );
+    }
 
     // ── encode_annotated_response contract ───────────────────────────────────
     //

--- a/lib/bindings/python/tests/test_push_egress_token_frame.py
+++ b/lib/bindings/python/tests/test_push_egress_token_frame.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The push-egress token-frame fast path, exercised through the real bridge.
+
+``push_egress.rs`` encodes the common per-token frame -- a dict of exactly
+``token_ids`` then ``index`` -- straight to msgpack, skipping serde and pythonize.
+
+Rust unit tests in ``python_payload.rs`` already pin the resulting bytes against
+the generic encoder.  What they cannot reach is the half that needs libpython,
+which the extension-module build does not link into ``cargo test``:
+
+* the gate that decides whether a dict is eligible for the fast path at all, and
+* the reused encode buffer, including the rewind after a frame is rejected
+  partway through being written.
+
+Both are covered here against the built extension, end to end over the request
+plane: whatever the handler pushes must be exactly what the client receives.
+
+A gate that wrongly accepted a frame would corrupt that frame's value; a rewind
+that left bytes behind would corrupt the *next* frame.  That second failure only
+shows up when the two kinds of frame are interleaved, which is what
+:func:`test_mixed_eligible_and_ineligible_frames_in_one_stream` does.
+
+Comparisons are type-strict (see :func:`_identical`), because plain ``==`` would
+miss the most interesting failure of all: ``True == 1`` in Python, so a ``bool``
+wrongly encoded as the integer ``1`` still compares equal to what was sent.
+"""
+
+import asyncio
+import contextlib
+
+import pytest
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+]
+
+
+# ---------------------------------------------------------------------------
+# Frame cases: what the handler pushes, and what the client must get back.
+# ---------------------------------------------------------------------------
+#
+# Each case is a (sent, expected) pair. `sent` is passed to
+# `response_sender.send()` verbatim; `expected` is what the client must get back,
+# or None when it is identical to `sent`.
+#
+# The two differ only where msgpack has no equivalent of the Python type: a tuple
+# has no msgpack form of its own and comes back as a list on either path.
+
+# Eligible: the fast path must take these, and they must survive it unchanged.
+_ELIGIBLE = [
+    ({"token_ids": [5], "index": 0}, None),  # the steady-state frame
+    ({"token_ids": [], "index": 0}, None),  # engine produced no new tokens
+    ({"token_ids": [1, 2, 3], "index": 2}, None),  # multi-token chunk
+    ({"token_ids": list(range(40)), "index": 0}, None),  # past the fixarray limit
+    ({"token_ids": [0, 127, 128, 255, 256, 65535, 65536], "index": 1}, None),
+    ({"token_ids": [4294967295], "index": 4294967295}, None),  # u32 bounds
+]
+
+# Ineligible: each trips a different clause of the gate and must fall back to
+# the generic encoder, which preserves the value wherever msgpack can represent
+# it at all.
+_INELIGIBLE = [
+    # In Python bool is a subclass of int, and pythonize checks PyBool before
+    # PyInt, so the generic path encodes these as msgpack bools. The fast path
+    # must not quietly flatten them to 1/0.
+    ({"token_ids": [True], "index": 0}, None),
+    ({"token_ids": [1], "index": True}, None),
+    # Generically, negatives encode as signed ints and past-u64 values as bytes,
+    # so neither may take the fast path.
+    ({"token_ids": [-1], "index": 0}, None),
+    ({"token_ids": [1], "index": -1}, None),
+    # msgpack has no uint128, so rmp-serde writes a past-u64 int as a 16-byte
+    # big-endian `bin`. That is pre-existing generic-path behaviour and is why
+    # this frame does not come back as an int on *either* path -- what matters
+    # here is only that the fast path declined it, which the bytes prove.
+    (
+        {"token_ids": [2**64], "index": 0},
+        {"token_ids": [(2**64).to_bytes(16, "big")], "index": 0},
+    ),
+    # Not a list.
+    ({"token_ids": (1, 2), "index": 0}, {"token_ids": [1, 2], "index": 0}),
+    ({"token_ids": 5, "index": 0}, None),
+    # Not exactly two keys, or not these two, or not in this order.
+    ({"token_ids": [1], "index": 0, "finish_reason": "stop"}, None),
+    ({"token_ids": [1]}, None),
+    ({"index": 0, "token_ids": [1]}, None),
+    ({"text": "hello", "index": 0}, None),
+    # A non-int in the list, rejected partway through writing the frame.
+    ({"token_ids": [1, "two", 3], "index": 0}, None),
+    ({"token_ids": [1, None], "index": 0}, None),
+    ({"token_ids": [1, 2.5], "index": 0}, None),
+    # An annotated envelope must still be unwrapped, not encoded as raw data.
+    (
+        {"_dynamo_annotated": True, "data": {"token_ids": [1], "index": 0}},
+        {"token_ids": [1], "index": 0},
+    ),
+    # Not a dict at all.
+    ("just a string", None),
+    ([1, 2, 3], None),
+]
+
+_CASES = {
+    "eligible": _ELIGIBLE,
+    "ineligible": _INELIGIBLE,
+    # Interleaved, so every rejected frame is immediately followed by one that
+    # would inherit its leftover bytes if the rewind were wrong.
+    "mixed": [
+        frame
+        for pair in zip(_ELIGIBLE, _INELIGIBLE[: len(_ELIGIBLE)])
+        for frame in pair
+    ],
+    # One long fast-path run, long enough that the encode buffer has to allocate
+    # several chunks rather than serving every frame from its first one.
+    "many": [({"token_ids": [i], "index": 0}, None) for i in range(512)],
+}
+
+
+def _sent(case: str):
+    return [sent for sent, _ in _CASES[case]]
+
+
+def _expected(case: str):
+    return [sent if expected is None else expected for sent, expected in _CASES[case]]
+
+
+def _identical(actual, expected) -> bool:
+    """Equality that does not conflate ``bool`` with ``int``.
+
+    In Python ``True == 1`` and ``False == 0``, so plain ``==`` cannot tell a
+    bool that survived correctly from one the fast path flattened to an integer
+    -- precisely the regression the gate's exact-type check exists to prevent.
+    """
+    if type(actual) is not type(expected):
+        return False
+    if isinstance(expected, dict):
+        return actual.keys() == expected.keys() and all(
+            _identical(actual[key], expected[key]) for key in expected
+        )
+    if isinstance(expected, list):
+        return len(actual) == len(expected) and all(
+            _identical(a, e) for a, e in zip(actual, expected)
+        )
+    return actual == expected
+
+
+# ---------------------------------------------------------------------------
+# Handler + endpoint
+# ---------------------------------------------------------------------------
+
+
+async def _push_handler(request, context, response_sender=None):
+    """Push every frame of the requested case, then close.
+
+    Simply declaring a ``response_sender`` parameter is what makes Rust pick the
+    push engine (see ``push_egress.rs::handler_supports_push``).  The function
+    must still be an async generator -- it just yields nothing on the push path,
+    and Rust advances it exactly once per request.
+
+    The pull arm below is reached by the health check and by in-process callers,
+    which pass no sender.  It has to keep working, so it yields the same frames.
+    """
+    frames = _sent(request["case"])
+
+    if response_sender is None:
+        for frame in frames:
+            yield frame
+        return
+
+    for frame in frames:
+        response_sender.send(frame)
+    response_sender.close()
+
+
+@pytest.fixture
+async def push_client(runtime):
+    endpoint = runtime.endpoint("push-egress-token-frame.backend.generate")
+    server_task = asyncio.ensure_future(
+        endpoint.serve_endpoint(
+            _push_handler,
+            health_check_payload={"case": "eligible"},
+        )
+    )
+    client = await endpoint.client()
+    try:
+        await client.wait_for_instances()
+        yield client
+    finally:
+        server_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await server_task
+
+
+async def _round_trip(client, case: str):
+    stream = await client.generate({"case": case})
+    return [response.data() async for response in stream]
+
+
+def _assert_round_trip(actual, case: str):
+    expected = _expected(case)
+    count_message = f"case {case!r}: expected {len(expected)} frames, got {len(actual)}"
+    assert len(actual) == len(expected), count_message
+    for position, (got, want) in enumerate(zip(actual, expected)):
+        assert _identical(got, want), (
+            f"case {case!r}: frame {position} came back as {got!r} "
+            f"(type {type(got).__name__}), expected {want!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+async def test_eligible_frames_survive_the_fast_path(push_client):
+    """Frames the fast path accepts must reach the client unchanged.
+
+    Covers the empty token list, multi-token chunks, and the list lengths and
+    integer magnitudes that cross msgpack's fixarray and uint marker
+    boundaries.
+    """
+    _assert_round_trip(await _round_trip(push_client, "eligible"), "eligible")
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+async def test_ineligible_frames_fall_back_intact(push_client):
+    """Every near-miss must fall back to the generic encoder, losing nothing.
+
+    Each entry trips a different clause of the gate: a bool where an int is
+    expected, a negative or oversized integer, a non-list, the wrong key set or
+    the wrong key order, a non-int inside the list, an annotated envelope, and
+    values that are not dicts at all.
+    """
+    _assert_round_trip(await _round_trip(push_client, "ineligible"), "ineligible")
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+async def test_mixed_eligible_and_ineligible_frames_in_one_stream(push_client):
+    """The reused encode buffer must not leak bytes between frames.
+
+    A rejected frame can be abandoned partway through being written, into the
+    very same buffer the next frame will use.  If the rewind were wrong, that
+    next frame would carry the abandoned prefix and fail to decode -- a failure
+    that only appears when the two kinds of frame are interleaved.
+    """
+    _assert_round_trip(await _round_trip(push_client, "mixed"), "mixed")
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+async def test_long_fast_path_run_refills_the_encode_buffer(push_client):
+    """A run long enough to exhaust and refill the buffer's chunk several times.
+
+    Frames are cut out of a shared chunk with ``split``, so this covers the
+    handover to a fresh chunk.  The frames are numbered, so it also proves none
+    is duplicated or dropped across that boundary.
+    """
+    _assert_round_trip(await _round_trip(push_client, "many"), "many")


### PR DESCRIPTION
#### Overview:

When a worker streams a reply, it sends **one small message per generated token**. This PR makes building that message cheaper.

Each message is a Python dict — almost always exactly `{"token_ids": [...], "index": n}` — that must be converted into msgpack bytes before it goes on the wire. Today that conversion uses a generic Python→msgpack converter (`pythonize`), which has to *discover* the type of every value at runtime: is it `None`? a bool? a string? an int? — and then narrow every integer through a chain of conversions. **Every individual token id pays that whole ladder.** Each frame also allocated a brand-new buffer and re-read the codec setting.

This PR teaches Rust to recognize that one extremely common dict shape and write its msgpack bytes by hand, skipping the generic converter entirely. Anything that doesn't match the shape exactly falls through to the existing path, unchanged.

The change is contained to Rust: no handler changes, no new Python API, and no new rules for backend authors.

#### Measured:

One step was timed on its own: turning a single Python response dict into the bytes that go on the wire. No network, no engine. Three variants, so the PR's two independent changes can be told apart.

| One message carries | before | + buffer reuse | + fast path | speedup |
|---|---|---|---|---|
| **1 token id** — ordinary streaming | 342 ns | 225 ns | **86 ns** | **4.0×** |
| 4 token ids — MTP / speculative decode | 397 ns | 290 ns | **113 ns** | 3.5× |
| 20 token ids | 657 ns | 548 ns | **252 ns** | 2.6× |
| 50 token ids — `stream_interval` bundle | 1,203 ns | 1,095 ns | **506 ns** | 2.4× |
| 100 token ids | 2,093 ns | 2,008 ns | **913 ns** | 2.3× |

Median of 3 runs of 200k messages each, spread a few percent. Apple M4 Pro, Python 3.11.14, release build.

**How to read it.** The two changes help in opposite situations. *Buffer reuse* saves one memory allocation per message, so it is worth about 46% of the win when a message carries a single token id and about 7% when it carries a hundred. *The fast path* saves work on every token id — roughly 9 ns each, against 21–24 ns before — so it keeps paying off no matter how many ids a message carries, which is why the speedup never falls below 2×.

Almost all of those 21–24 ns are type guessing: the generic converter inspects each value's type at runtime and funnels every integer through a chain of conversions. That overhead is about the same size as writing the msgpack bytes themselves.

Because this work happens while the handler holds the GIL, what is saved is GIL time every other request in that process was waiting for — roughly **2 ms per 8k-token response** when messages carry one token id.

Making the reused buffer larger (8 KB → 256 KB) changed nothing measurable, so it stays at 8 KB. The win comes from not regrowing a buffer from empty on every message, which 8 KB already prevents.

<details>
<summary>What the benchmark does not show</summary>

- **Not an end-to-end number.** Whether under a microsecond of saved GIL time per message shows up in TPOT depends on the message rate and on how contended the GIL is. A cluster run is the next step — and earlier profiling of the *pull* path's encode found it holding almost no GIL, so this deserves measuring rather than assuming.
- **No contention here.** macOS/arm64, one Python thread, no event loop. The ratios should carry; the absolute numbers will not.
- **A replica, not this diff.** The bindings crate builds as an `extension-module` and so cannot link libpython, which means the harness has to be a separate pyo3 binary. All three variants are asserted to produce identical bytes before any of them is timed — necessary because the two paths are chosen per message *within one response stream*.
- **It measures the win when the shape matches**, not how often it matches in production. A backend handing back numpy ints or a tuple would quietly fall back to the old path.

</details>

#### Details:

**1. The fast path** — `python_payload.rs`

`try_write_token_frame` checks whether a frame is the expected two-key dict and, if so, emits msgpack directly. Two details are load-bearing:

- **It matches on dict *iteration order*, not key lookup.** msgpack records map entries in visit order, so a dict with the same two keys reversed must not be encoded as if it were in this order. Matching on order also makes the check a *complete* test of the shape — a third key fails the `next()` check, and a `_dynamo_annotated` envelope can't match at all. That's what makes it safe to skip `parse_python_response`.
- **Integers use `downcast_exact`.** In Python, `bool` is a subclass of `int`, and `pythonize` tests `PyBool` before `PyInt`. A `True` in a token list must stay a msgpack bool, not silently become `1`.

**2. Byte identity** — the two paths can be chosen *per frame within a single response stream*, so it isn't enough for the fast path to be decodable; it must produce **the same bytes** the old path would. Any difference in map ordering or integer width would be a wire mismatch between consecutive frames of one response. `token_frame_matches_generic_encoding` and `token_frame_index_matches_generic_encoding` encode the same logical response both ways and compare bytes across every msgpack array-length and uint-marker boundary. Byte emission is split out from the Python-facing code so these tests run without linking libpython (which this crate's unit tests can't do).

**3. Buffer and codec reuse** — the codec is read once per *request* instead of once per *frame*, and frames are `split` out of a reused `BytesMut` instead of allocating each time. This needed a new `RequestPlanePayloadCodec::encode_into` in `dynamo-runtime` so the generic path can also write into a caller-owned buffer; a unit test pins it byte-for-byte against `encode`.

Two failure modes are handled explicitly:

- **Partial writes rewind the buffer.** A frame rejected halfway through would otherwise leave half a frame followed by a whole one — undecodable on the wire.
- **The buffer is taken with `try_lock`, never a blocking lock.** Walking a Python object can run arbitrary Python (`__bool__`, `__iter__`, `__len__`), and that Python can re-enter `send` on the same sender. Blocking would freeze the event-loop thread *while holding the GIL*. A re-entrant call falls back to a private buffer — slower for that one frame, but not a hang.

#### Where should the reviewer start?

1. **`lib/bindings/python/rust/python_payload.rs`** — the fast-path encoder, the shape gate, and the byte-identity tests. A wire-format bug would live here. The two subtle points are the iteration-order match and `downcast_exact` on integers.
2. **`lib/bindings/python/rust/push_egress.rs`** — dispatch, plus the `try_lock` re-entrancy fallback in `PushFrame::encode`.
3. **`lib/runtime/src/pipeline/network.rs`** — small and mechanical.

#### Validation

- ✅ Rust unit tests pass; `clippy --all-targets -D warnings` and `fmt` clean on both crates; pre-commit hooks pass.
- ✅ Byte-identity of the fast path against the generic encoder is pinned across every msgpack array-length and uint marker boundary, up to `u64::MAX` — the full range `exact_uint` accepts.
- ✅ `lib/bindings/python/tests/test_push_egress_token_frame.py` runs in CI. Two cases initially failed on the `{"token_ids": [2**64]}` frame, which comes back as a 16-byte msgpack `bin`. That is correct: msgpack has no uint128, so rmp-serde encodes a past-`u64` integer via `serialize_bytes`. The fast path declined the frame exactly as designed and the generic encoder did the only thing it could — the test's expectation was wrong, and is corrected in `3db35bd9ac`.
- ℹ️ Pre-existing, unrelated: `pipeline::network::egress::tcp_client::tests::test_no_recursive_retry_under_connect_contention` fails identically on the base commit with nothing applied, on macOS.

#### Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Tracked internally as DYN-4191. Happy to file a public GitHub issue instead if a reviewer would prefer one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved push-response encoding efficiency through buffer reuse and optimized token-frame handling.
  * Reduced unnecessary data copying when serializing JSON and Msgpack responses.

* **Reliability**
  * Added safer fallback handling for unsupported or malformed token frames.
  * Preserved response compatibility across pull and push processing modes.

* **Testing**
  * Expanded coverage for encoding boundaries, malformed data, buffer reuse, annotated responses, and round-trip fidelity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


