### PR TITLE
test(container): assert the NVDEC bitstream filters stay enabled

### DIFF
--- a/tests/dependencies/test_no_software_video_codecs.py
+++ b/tests/dependencies/test_no_software_video_codecs.py
@@ -63,6 +63,22 @@ _REQUIRED = ("vp9",)
 
 _SURFACES = ("encoders", "decoders", "parsers")
 
+# Bitstream filters PyNvVideoCodec needs to feed NVDEC. It calls
+# av_bsf_get_by_name("h264_mp4toannexb") to reframe MP4/AVCC into Annex-B before
+# handing the stream to the hardware decoder, so their absence breaks hardware
+# H.264/H.265 decode outright -- and does so from inside a vendored library, as
+# "SimpleDecoder constructor failed: av_bsf_get_by_name() failed", which points
+# nowhere near this build.
+#
+# Collected for presence only and deliberately NOT added to _SURFACES: these
+# names contain "h264"/"hevc" and would trip _DISALLOWED_RE, yet they carry no
+# codec implementation -- they reframe an already-encoded stream. That is the
+# same distinction the build-time guard in wheel_builder.Dockerfile draws when
+# it scans encoders/decoders/parsers and skips -bsfs.
+_REQUIRED_BSFS = ("h264_mp4toannexb", "hevc_mp4toannexb")
+
+_PRESENCE_SURFACES = _SURFACES + ("bsfs",)
+
 
 def _ffmpeg() -> str:
     """Resolve FFmpeg the way the encode path does."""
@@ -87,7 +103,7 @@ def _surface(exe: str, surface: str) -> str:
 def _surfaces() -> dict[str, str]:
     exe = _ffmpeg()
     try:
-        out = {s: _surface(exe, s) for s in _SURFACES}
+        out = {s: _surface(exe, s) for s in _PRESENCE_SURFACES}
     except (OSError, FileNotFoundError) as exc:
         pytest.fail(f"could not run the shipped ffmpeg ({exe}): {exc}")
     if not any(out.values()):
@@ -102,6 +118,25 @@ def _assert_required_codecs_present(surfaces: dict[str, str]) -> None:
         assert name in listing, (
             f"{name} missing from the shipped ffmpeg -- the build is broken, and "
             "the absence assertions here would pass vacuously"
+        )
+
+
+def _assert_required_bsfs_present(surfaces: dict[str, str]) -> None:
+    """The NVDEC feed path must keep its bitstream filters.
+
+    Paired with the absence checks below on purpose: this file asserts what the
+    images may not carry, and hardware decode is the reason H.264/H.265 may be
+    absent in software at all. If these filters go, the justification goes with
+    them, quietly.
+    """
+    listing = surfaces.get("bsfs", "").lower()
+    for name in _REQUIRED_BSFS:
+        assert name in listing, (
+            f"{name} missing from the shipped ffmpeg -- PyNvVideoCodec cannot "
+            "build its NVDEC pipeline without it, and hardware H.264/H.265 "
+            "decode fails at runtime with 'av_bsf_get_by_name() failed'. It is "
+            "enabled in wheel_builder.Dockerfile via --enable-bsf; a blanket "
+            "--disable-bsfs would drop it again."
         )
 
 
@@ -231,6 +266,7 @@ def _assert_bundled_libavcodecs_carry_no_software_codecs() -> None:
 def _check_image() -> None:
     surfaces = _surfaces()
     _assert_required_codecs_present(surfaces)
+    _assert_required_bsfs_present(surfaces)
     _assert_no_software_codecs(surfaces)
     _assert_python_carriers_absent()
     _assert_bundled_libavcodecs_carry_no_software_codecs()


### PR DESCRIPTION
## Summary

Follow-up to #13936, which enabled `h264_mp4toannexb` and `hevc_mp4toannexb` in the in-tree FFmpeg. Nothing currently pins them, so a later `--disable-bsfs` cleanup drops them again silently.

PyNvVideoCodec calls `av_bsf_get_by_name("h264_mp4toannexb")` to reframe MP4/AVCC into Annex-B before handing a stream to NVDEC. Without the filter, hardware H.264/H.265 decode fails from inside a vendored library as:

```
SimpleDecoder constructor failed: av_bsf_get_by_name() failed
```

which names neither this build nor the flag that was removed. That is an expensive thing to diagnose twice.

This adds the missing positive assertion next to the existing `vp9` one. The file already states the principle it follows — *"Every negative assertion here is paired with a positive one"* — and hardware decode is the reason H.264/H.265 may be absent in software at all, so the two belong together: if the filters go, the justification for the absence goes with them.

### One design note worth reviewing

Bitstream filters are collected for **presence only** and deliberately kept out of `_SURFACES`. Their names contain `h264`/`hevc`, so scanning them for disallowed formats would fire `_DISALLOWED_RE` on a surface that carries no codec implementation. I verified the exclusion is load-bearing rather than incidental — the regex *does* match `h264_mp4toannexb`.

That mirrors the distinction `wheel_builder.Dockerfile`'s build-time guard already draws when it scans `encoders/decoders/parsers` and explicitly skips `-bsfs`.

No change to what the images may contain: `_SURFACES`, `_DISALLOWED_RE`, and every absence assertion are untouched.

## Validation

- `pre-commit run --files tests/dependencies/test_no_software_video_codecs.py` — clean
- Positive + negative unit check of the new helper, and confirmed `_DISALLOWED_RE` *would* match `h264_mp4toannexb` — so keeping `bsfs` out of `_SURFACES` is load-bearing, not incidental

Both directions exercised against real images on a GPU box:

| Image | `-bsfs` listing | Result |
|---|---|---|
| pre-#13936 vLLM (`ea1dd14bbf`) | `aac_adtstoasc pgs_frame_merge vp9_superframe vp9_superframe_split` | **fails** — the assertion fires as intended |
| post-#13936 vLLM (`c1b6cce1d5`, current main) | adds `h264_mp4toannexb hevc_mp4toannexb` | **1 passed** |

The passing run also covers the design note above on a real image rather than synthetically: both new filter names appear in `-bsfs`, and the disallow scan does not trip on them.

Related: #13936, DIS-2796.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated validation for hardware-accelerated H.264 and HEVC video decoding.
  - Added checks to ensure required video processing capabilities remain available in supported images.
  - Improved detection of missing media components before release, helping prevent video playback regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


