### PR TITLE
feat(trtllm): log the Dynamo-to-engine request ID mapping at submit

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1252,6 +1252,31 @@ class HandlerBase(BaseGenerativeHandler):
                 cache_salt=cache_salt,
             )
 
+            # Log the Dynamo-to-engine request-ID mapping exactly once per
+            # request, immediately after submission. This is the only place the
+            # Dynamo request UUID, the TRT-LLM executor client ID, and (in
+            # disaggregated mode) the cross-phase disagg_request_id coexist, and
+            # none of them is persisted together anywhere else. The line makes
+            # every engine-side per-request record (e.g. a perf-metrics JSONL
+            # keyed by the executor client ID, or requestStats keyed by the
+            # disagg ID) joinable to Dynamo traces, spans, and logs offline.
+            # Notes for consumers: the client ID is a per-worker-process
+            # counter, so join it only within this worker's own log; logging
+            # before the response iteration starts means cancelled requests
+            # still leave their mapping behind.
+            # context.id() is the canonical request UUID (the payload's id field
+            # is not guaranteed on every path: observed absent on 1789/1789
+            # requests of a real GB300 run), and this handler already treats it
+            # as authoritative elsewhere.
+            logging.info(
+                "Engine ID map: request_id=%s trtllm_client_id=%s disagg_request_id=%s",
+                context.id(),
+                getattr(generation_result, "request_id", None),
+                disaggregated_params.disagg_request_id
+                if disaggregated_params
+                else None,
+            )
+
             # In disagg decode mode with remote prefill, wrap abort() to defer
             # until the first token is received (KV transfer complete).
             abort_guard = (

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1265,9 +1265,8 @@ class HandlerBase(BaseGenerativeHandler):
             # before the response iteration starts means cancelled requests
             # still leave their mapping behind.
             # context.id() is the canonical request UUID (the payload's id field
-            # is not guaranteed on every path: observed absent on 1789/1789
-            # requests of a real GB300 run), and this handler already treats it
-            # as authoritative elsewhere.
+            # is not guaranteed on every path), and this handler already treats
+            # it as authoritative elsewhere.
             logging.info(
                 "Engine ID map: request_id=%s trtllm_client_id=%s disagg_request_id=%s",
                 context.id(),

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import logging
 import re as re_mod
 from copy import deepcopy
 from dataclasses import dataclass
@@ -1544,3 +1545,90 @@ class TestConversationAffinity:
             ):
                 pass
         handler.engine.llm.generate_async.assert_not_called()
+
+
+class TestEngineIdMapLogging:
+    """The submit-time "Engine ID map" INFO line is the only artifact that pairs
+    the Dynamo request UUID with the TRT-LLM executor client ID (and, on the
+    disaggregated path, the cross-phase disagg_request_id). Offline joins between
+    Dynamo traces and engine-side per-request records key on its exact shape, so
+    the format is a contract: assert the rendered message, not just that a log
+    happened."""
+
+    def _make_handler(self) -> HandlerBase:
+        config = MagicMock()
+        config.shutdown_event = None
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        config.conversation_affinity = False
+        handler = _ConcreteHandler(config)
+        handler.publisher = None
+        handler.multimodal_processor = None
+        handler.additional_metrics = None
+        handler.max_seq_len = None
+        handler.default_sampling_params = MockSamplingParams()
+        handler._conversation_affinity = False
+        return handler
+
+    def _make_mock_generation_result(self):
+        output = MagicMock()
+        output.token_ids = [42]
+        output.finish_reason = "stop"
+        output.stop_reason = None
+        output.request_perf_metrics = None
+
+        res = MagicMock()
+        res.outputs = [output]
+        res.finished = True
+
+        generation_result = MagicMock()
+        generation_result.abort = MagicMock()
+        # The executor assigns the client ID inside submit(), so it is readable
+        # synchronously on the object generate_async returns.
+        generation_result.request_id = 51420
+
+        async def mock_aiter(self_mock):
+            yield res
+
+        generation_result.__aiter__ = mock_aiter
+        return generation_result
+
+    def _make_context(self):
+        context = MagicMock()
+        never_resolve = asyncio.get_event_loop().create_future()
+        context.async_killed_or_stopped.return_value = never_resolve
+        # The mapping line must use the Context UUID, not the request payload:
+        # real-run data showed payload ids are absent on some paths.
+        context.id.return_value = "11111111-2222-3333-4444-555555555555"
+        return context
+
+    @pytest.mark.asyncio
+    async def test_mapping_logged_once_at_submit(self, caplog):
+        handler = self._make_handler()
+        handler.engine.llm.generate_async = MagicMock(
+            return_value=self._make_mock_generation_result()
+        )
+        # Deliberately NO id field in the payload -- the line must still carry
+        # the Context UUID.
+        request = {
+            "token_ids": [1, 2, 3],
+            "stop_conditions": {"max_tokens": 10},
+            "sampling_options": {"temperature": 0.7},
+        }
+
+        with caplog.at_level(logging.INFO):
+            chunks = [
+                c async for c in handler.generate_locally(request, self._make_context())
+            ]
+
+        assert chunks, "the mocked engine result should still yield a chunk"
+        maps = [
+            r.getMessage()
+            for r in caplog.records
+            if r.getMessage().startswith("Engine ID map:")
+        ]
+        assert len(maps) == 1, f"expected exactly one mapping line, got {maps}"
+        # The rendered message is the offline-join contract.
+        assert "request_id=11111111-2222-3333-4444-555555555555" in maps[0]
+        assert "trtllm_client_id=51420" in maps[0]
+        # Aggregated mode carries no cross-phase disagg id.
+        assert "disagg_request_id=None" in maps[0]


### PR DESCRIPTION
## Summary

Dynamo and TRT-LLM keep disjoint per-request ID namespaces, and today no artifact on either side records a pair from both: Dynamo's request-trace rows, spans, and logs carry the Dynamo request UUID, while every engine-side per-request record is keyed by TRT-LLM's executor client ID (e.g. a perf-metrics record) or by the disaggregated request ID (`requestStats`, the native KV-transfer logger). We checked three real disaggregated runs: zero log lines, trace rows, or metrics pair the namespaces. That makes any per-request TTFT decomposition that needs engine-internal timing — engine queue, prefill compute, measured KV-cache transfer — impossible to join offline.

This PR emits one INFO line per request in the TRT-LLM handler, immediately after `generate_async()` returns:

```
Engine ID map: request_id=<uuid> trtllm_client_id=<int> disagg_request_id=<int|None>
```

Design points:

- **This is the only point where all three identifiers coexist.** The executor assigns the client ID inside `submit()`, so it is readable synchronously on the returned object before any output arrives (`tensorrt_llm/executor/base_worker.py`, `result.py::request_id`).
- **Logged before response iteration starts**, so a cancelled request still leaves its mapping behind.
- **The UUID comes from the runtime `Context`, not the request payload**: on a real GB300 disaggregated run the payload `id` field was absent on 1,789/1,789 requests while `context.id()` carried the UUID on all of them.
- The client ID is a per-worker-process counter — consumers join it only within that worker's own log file. In aggregated mode `disagg_request_id` is `None` and the client ID still joins engine-side records.
- Lazy `%`-style formatting per `.ai/python-guidelines.md`; one ~120-byte line per request (worker logs already carry 2–3 INFO lines per request from the push handler).

The rendered message is an offline-join **contract**, so the new test asserts the exact rendered shape — one line per request, all three `key=value` fields, UUID sourced from the Context with no payload id present — rather than merely that a log record exists.

## Validation

- `pre-commit` clean on both files (ruff, black, flake8, isort, codespell, marker report).
- New test `TestEngineIdMapLogging::test_mapping_logged_once_at_submit` follows the file's existing mock-engine harness; the module is GPU-gated so it runs in the GPU CI stages.
- **Validated end to end on two real GB300 AgentX c3 runs** (7-node disaggregated DeepSeek-V4, 1 prefill × 3 decode workers): the line was emitted for every request on every worker (3,378 and 3,628 lines), and joining engine-side per-request records to Dynamo request-trace rows through this contract covered **1,689/1,689 and 1,814/1,814 requests with zero ID disagreements** (independently cross-checked against records carrying the UUID in-band).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added clearer request-tracking logs that associate each request with its context, execution client, and disaggregation identifiers.
  * Logs now use the context request ID when available, with a fallback for reliability.
* **Tests**
  * Added coverage to verify that request mappings are logged once and include the expected identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->