### PR TITLE
feat(openengine): add TRT-LLM sidecar

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -89,6 +89,7 @@ areas:
   - components/src/dynamo/trtllm/utils/
   - components/src/dynamo/trtllm/workers/
   - examples/backends/trtllm/
+  - lib/sidecar/openengine/
   - lib/sidecar/trtllm/
 - label: backend-sglang
   github_team: '@ai-dynamo/dynamo-backend-sglang-codeowners'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -90,6 +90,7 @@
 
 # === backend-trtllm  (@ai-dynamo/dynamo-backend-trtllm-codeowners) ===
 /lib/sidecar/trtllm/                                                         @ai-dynamo/dynamo-backend-trtllm-codeowners
+/lib/sidecar/openengine/                                                     @ai-dynamo/dynamo-backend-trtllm-codeowners
 /examples/backends/trtllm/                                                   @ai-dynamo/dynamo-backend-trtllm-codeowners
 /components/src/dynamo/trtllm/                                               @ai-dynamo/dynamo-backend-trtllm-codeowners
 /components/src/dynamo/trtllm/tests/                                         @ai-dynamo/dynamo-backend-trtllm-codeowners

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,6 +2829,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynamo-openengine-sidecar"
+version = "1.5.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "clap",
+ "dynamo-backend-common",
+ "dynamo-sidecar-common",
+ "futures",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
+ "tracing",
+]
+
+[[package]]
 name = "dynamo-parsers"
 version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "lib/backend-common",
     "lib/backend-common/examples/mocker",
     "lib/sidecar/common",
+    "lib/sidecar/openengine",
     "lib/sidecar/vllm",
     "lib/mocker/servers/vllm",
     "lib/sidecar/sglang",
@@ -213,4 +214,3 @@ lto = "thin"
 inherits = "release"
 debug = true
 strip = false
-

--- a/lib/sidecar/Dockerfile
+++ b/lib/sidecar/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# CPU-only image containing the vLLM, SGLang, and TensorRT-LLM Rust sidecars.
+# CPU-only image containing the OpenEngine, vLLM, SGLang, and TensorRT-LLM Rust sidecars.
 # The dynamo-sidecar entrypoint selects an engine-specific binary; the GPU
 # engine continues to run in a separate container.
 #
@@ -42,7 +42,7 @@ FROM builder-base AS vllm-builder
 
 ARG TARGETARCH
 
-# The three builders share one target cache per architecture, so each backend
+# The four builders share one target cache per architecture, so each backend
 # reuses the dependency artifacts the previous one compiled. sharing=locked
 # serializes them, which is required for correctness — cargo's .package-cache
 # lock lives in $CARGO_HOME, outside these mounts, so it cannot coordinate
@@ -56,6 +56,18 @@ RUN --mount=type=cache,id=dynamo-sidecar-cargo-registry-${TARGETARCH},target=/us
     cargo build --release --locked -p dynamo-vllm-sidecar \
     && strip target/release/dynamo-vllm-sidecar \
     && install -D target/release/dynamo-vllm-sidecar /out/dynamo-vllm-sidecar
+
+# ---- OpenEngine builder -----------------------------------------------------
+FROM builder-base AS openengine-builder
+
+ARG TARGETARCH
+
+RUN --mount=type=cache,id=dynamo-sidecar-cargo-registry-${TARGETARCH},target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=dynamo-sidecar-cargo-git-${TARGETARCH},target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=dynamo-sidecar-target-${TARGETARCH},target=/src/target,sharing=locked \
+    cargo build --release --locked -p dynamo-openengine-sidecar \
+    && strip target/release/dynamo-openengine-sidecar \
+    && install -D target/release/dynamo-openengine-sidecar /out/dynamo-openengine-sidecar
 
 # ---- SGLang builder ---------------------------------------------------------
 FROM builder-base AS sglang-builder
@@ -94,6 +106,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && useradd --create-home --uid 1000 --gid 0 dynamo
 
 COPY --from=vllm-builder /out/dynamo-vllm-sidecar /usr/local/bin/
+COPY --from=openengine-builder /out/dynamo-openengine-sidecar /usr/local/bin/
 COPY --from=sglang-builder /out/dynamo-sglang-sidecar /usr/local/bin/
 COPY --from=trtllm-builder /out/dynamo-trtllm-sidecar /usr/local/bin/
 

--- a/lib/sidecar/README.md
+++ b/lib/sidecar/README.md
@@ -6,11 +6,12 @@ runs in a separate process.
 
 ```text
 common/         Shared gRPC arguments, transport, and errors
+openengine/     OpenEngine sidecar
 sglang/         SGLang sidecar
 trtllm/         TensorRT-LLM sidecar
 vllm/           vLLM sidecar
-Dockerfile      Builds all three sidecar executables into a CPU-only image
-dynamo-sidecar  Convenience entrypoint mapping vllm/sglang/trtllm to the above
+Dockerfile      Builds all four sidecar executables into a CPU-only image
+dynamo-sidecar  Convenience entrypoint selecting one of the above
 ```
 
 Engine protocols and request conversion remain in each engine's crate.
@@ -18,8 +19,9 @@ Engine protocols and request conversion remain in each engine's crate.
 ## Build the image
 
 There is no published sidecar image yet. `Dockerfile` builds one CPU-only image
-carrying all three engine-specific executables — `dynamo-vllm-sidecar`,
-`dynamo-sglang-sidecar`, and `dynamo-trtllm-sidecar` — in `/usr/local/bin`.
+carrying all four sidecar executables — `dynamo-openengine-sidecar`,
+`dynamo-vllm-sidecar`, `dynamo-sglang-sidecar`, and
+`dynamo-trtllm-sidecar` — in `/usr/local/bin`.
 Official packaging is deferred to a follow-up change.
 
 Build a multi-arch image from the repository root so it runs on any node —
@@ -56,6 +58,7 @@ ad-hoc `docker run` needs only the engine name. Deployments override it with
 docker run --rm <your-registry>/dynamo-sidecar:1.3.0 vllm --help
 docker run --rm <your-registry>/dynamo-sidecar:1.3.0 sglang --help
 docker run --rm <your-registry>/dynamo-sidecar:1.3.0 trtllm --help
+docker run --rm <your-registry>/dynamo-sidecar:1.3.0 openengine --help
 ```
 
 Plain `docker run` with no arguments uses the image `CMD` of `--help`, prints

--- a/lib/sidecar/dynamo-sidecar
+++ b/lib/sidecar/dynamo-sidecar
@@ -9,15 +9,20 @@ usage() {
 Usage: dynamo-sidecar <engine> [OPTIONS]
 
 Engines:
-  vllm     Run the vLLM sidecar
-  sglang   Run the SGLang sidecar
-  trtllm   Run the TensorRT-LLM sidecar
+  openengine  Run the OpenEngine sidecar
+  vllm        Run the vLLM sidecar
+  sglang      Run the SGLang sidecar
+  trtllm      Run the TensorRT-LLM sidecar
 EOF
 }
 
 engine="${1:-}"
 
 case "$engine" in
+    openengine)
+        shift
+        exec dynamo-openengine-sidecar "$@"
+        ;;
     vllm)
         shift
         exec dynamo-vllm-sidecar "$@"

--- a/lib/sidecar/openengine/Cargo.toml
+++ b/lib/sidecar/openengine/Cargo.toml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "dynamo-openengine-sidecar"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Dynamo sidecar backend for out-of-process OpenEngine gRPC servers."
+
+[package.metadata.cargo-machete]
+# Referenced by protobuf code generated into OUT_DIR.
+ignored = ["prost"]
+
+[[bin]]
+name = "dynamo-openengine-sidecar"
+path = "src/main.rs"
+
+[dependencies]
+dynamo-backend-common = { workspace = true }
+dynamo-sidecar-common = { workspace = true }
+
+anyhow = { workspace = true }
+async-stream = { workspace = true }
+async-trait = { workspace = true }
+clap = { version = "4", features = ["derive", "env"] }
+futures = { workspace = true }
+prost = { version = "0.13.5" }
+prost-types = { version = "0.13.5" }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tonic = { version = "0.13.1" }
+tracing = { workspace = true }
+
+[build-dependencies]
+tonic-build = { version = "0.13.1" }

--- a/lib/sidecar/openengine/README.md
+++ b/lib/sidecar/openengine/README.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > **Experimental.** This initial sidecar targets OpenEngine v0.1.0 and the TensorRT-LLM OpenEngine server. Its supported request surface is intentionally small.
 
-`dynamo-openengine-sidecar` connects a Dynamo worker to an out-of-process OpenEngine gRPC server. It uses the shared sidecar worker and transport arguments, discovers the server role through `GetServerInfo`, and supports aggregated generation plus context-first prefill/decode handoff.
+`dynamo-openengine-sidecar` connects a Dynamo worker to an out-of-process OpenEngine gRPC server. It uses the shared sidecar worker and transport arguments, discovers the server role and model through `GetServerInfo` and `GetModelInfo`, and supports aggregated generation plus context-first prefill/decode handoff.
 
 ## Run
 
@@ -27,17 +27,17 @@ dynamo-openengine-sidecar \
   --grpc-endpoint 127.0.0.1:50051
 ```
 
-Pass `--model-path <hf-id-or-local-path>` when the model advertised by the server is not directly usable by the sidecar for tokenization and templates. All standard worker and gRPC transport options come from `dynamo_sidecar_common::SidecarArgs`.
+The sidecar discovers the canonical model source and served name from TensorRT-LLM. All standard worker and gRPC transport options come from `dynamo_sidecar_common::SidecarArgs`.
 
 For disaggregated serving, start TensorRT-LLM with `--server_role context` or `--server_role generation`, then run one sidecar beside each server. The OpenEngine server role is authoritative; the inherited `--disaggregation-mode` option is not used.
 
 ## Initial scope
 
-- OpenEngine v0.1.0 `Generate` and `GetServerInfo`
+- OpenEngine v0.1.0 `Generate`, `GetServerInfo`, and `GetModelInfo`
 - Token-ID input, one output sequence, sampling, stopping, output logprobs, priority, and DP-rank metadata
 - Aggregated and context-first prefill/decode serving
 - Opaque `KvSessionRef` preservation through Dynamo's prefill handoff
 
-The initial TensorRT-LLM server leaves the other OpenEngine control RPCs unimplemented. This sidecar therefore does not call health, model-info, load, abort, LoRA, or KV-event RPCs. Multimodal input, guided decoding, prompt logprobs, LoRA selection, RL controls, encode workers, beam search, and `n > 1` are rejected locally.
+The initial TensorRT-LLM server leaves the other OpenEngine control RPCs unimplemented. This sidecar therefore does not call health, load, abort, LoRA, or KV-event RPCs. Multimodal input, guided decoding, prompt logprobs, LoRA selection, RL controls, encode workers, beam search, and `n > 1` are rejected locally.
 
 The vendored schema provenance is recorded in [`proto/README.md`](proto/README.md).

--- a/lib/sidecar/openengine/README.md
+++ b/lib/sidecar/openengine/README.md
@@ -1,0 +1,43 @@
+# OpenEngine sidecar
+
+> [!WARNING]
+> **Experimental.** This initial sidecar targets OpenEngine v0.1.0 and the TensorRT-LLM OpenEngine server. Its supported request surface is intentionally small.
+
+`dynamo-openengine-sidecar` connects a Dynamo worker to an out-of-process OpenEngine gRPC server. It uses the shared sidecar worker and transport arguments, discovers the server role through `GetServerInfo`, and supports aggregated generation plus context-first prefill/decode handoff.
+
+## Run
+
+Install TensorRT-LLM's optional OpenEngine bindings, then start an aggregated server:
+
+```bash
+python -m pip install --extra-index-url https://buf.build/gen/python \
+  "tensorrt_llm[openengine]"
+
+trtllm-serve <model> \
+  --grpc \
+  --grpc-protocol openengine \
+  --host 127.0.0.1 \
+  --port 50051
+```
+
+Start the Dynamo worker:
+
+```bash
+dynamo-openengine-sidecar \
+  --grpc-endpoint 127.0.0.1:50051
+```
+
+Pass `--model-path <hf-id-or-local-path>` when the model advertised by the server is not directly usable by the sidecar for tokenization and templates. All standard worker and gRPC transport options come from `dynamo_sidecar_common::SidecarArgs`.
+
+For disaggregated serving, start TensorRT-LLM with `--server_role context` or `--server_role generation`, then run one sidecar beside each server. The OpenEngine server role is authoritative; the inherited `--disaggregation-mode` option is not used.
+
+## Initial scope
+
+- OpenEngine v0.1.0 `Generate` and `GetServerInfo`
+- Token-ID input, one output sequence, sampling, stopping, output logprobs, priority, and DP-rank metadata
+- Aggregated and context-first prefill/decode serving
+- Opaque `KvSessionRef` preservation through Dynamo's prefill handoff
+
+The initial TensorRT-LLM server leaves the other OpenEngine control RPCs unimplemented. This sidecar therefore does not call health, model-info, load, abort, LoRA, or KV-event RPCs. Multimodal input, guided decoding, prompt logprobs, LoRA selection, RL controls, encode workers, beam search, and `n > 1` are rejected locally.
+
+The vendored schema provenance is recorded in [`proto/README.md`](proto/README.md).

--- a/lib/sidecar/openengine/build.rs
+++ b/lib/sidecar/openengine/build.rs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Compiles client stubs from the vendored OpenEngine v0.1.0 contract.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile_protos(&["proto/openengine/v1/openengine.proto"], &["proto"])?;
+    println!("cargo:rerun-if-changed=proto/openengine/v1");
+    Ok(())
+}

--- a/lib/sidecar/openengine/proto/README.md
+++ b/lib/sidecar/openengine/proto/README.md
@@ -1,0 +1,10 @@
+# OpenEngine protocol source
+
+The files under `openengine/v1` are copied without modification from the OpenEngine v0.1.0 release:
+
+- Repository: `https://github.com/ai-dynamo/openengine`
+- Git commit: `b5f2bd93721f7b888d3e2440679e0ae7012939d1`
+- BSR module: `buf.build/openengine/openengine`
+- BSR commit: `768a93c7b44e40f28c692ad0b471a8f2`
+
+Keep the complete package together when updating the contract. `openengine.proto` imports the message definitions from the sibling files.

--- a/lib/sidecar/openengine/proto/openengine/v1/error.proto
+++ b/lib/sidecar/openengine/proto/openengine/v1/error.proto
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Terminal errors for accepted streaming requests.
+
+syntax = "proto3";
+
+package openengine.v1;
+
+// Accepted failures emit one terminal EngineError and close with OK.
+// Validation and transport failures use non-OK gRPC status instead.
+message EngineError {
+  ErrorCode code = 1;
+  string message = 2;
+  bool retryable = 3; // Retry may succeed without changing the request.
+}
+
+enum ErrorCode {
+  ERROR_CODE_UNSPECIFIED = 0;
+  ERROR_CODE_INVALID_ARGUMENT = 1;
+  ERROR_CODE_UNSUPPORTED_FEATURE = 2;
+  ERROR_CODE_ROLE_MISMATCH = 3;
+  ERROR_CODE_MODEL_NOT_FOUND = 4;
+  ERROR_CODE_OVERLOADED = 5;
+  ERROR_CODE_REQUEST_NOT_FOUND = 6;
+  ERROR_CODE_DUPLICATE_REQUEST = 7;
+  ERROR_CODE_KV_SESSION_NOT_FOUND = 8;
+  ERROR_CODE_KV_TRANSFER_FAILED = 9;
+  ERROR_CODE_CANCELLED = 10;
+  ERROR_CODE_INTERNAL = 11;
+}

--- a/lib/sidecar/openengine/proto/openengine/v1/generation.proto
+++ b/lib/sidecar/openengine/proto/openengine/v1/generation.proto
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Generation inputs, requests, streamed events, and usage.
+
+syntax = "proto3";
+
+package openengine.v1;
+
+import "google/protobuf/struct.proto";
+import "openengine/v1/error.proto";
+import "openengine/v1/kv.proto";
+
+message TokenIds {
+  repeated uint32 ids = 1;
+}
+
+// Multimodal modality discriminator. UNSPECIFIED means the sender left it unset.
+enum Modality {
+  MODALITY_UNSPECIFIED = 0;
+  MODALITY_IMAGE = 1;
+  MODALITY_VIDEO = 2;
+  MODALITY_AUDIO = 3;
+}
+
+// A single multimodal input. Exactly one `source` should be set. The engine
+// owns fetch, decode, and preprocessing, so pre-decoded or RDMA media
+// descriptors are not represented here.
+message MediaItem {
+  Modality modality = 1;
+  oneof source {
+    string url = 2; // http(s):// -- engine fetches
+    string data_uri = 3; // data:<mime>;base64,<...> -- engine decodes
+    bytes raw_bytes = 4; // pre-fetched bytes -- engine still preprocesses
+  }
+  string mime_type = 5; // optional, hints raw_bytes decode
+  string uuid = 6; // optional caller id / mm_hash
+}
+
+message GenerateRequest {
+  string request_id = 1;
+  string model = 2;
+
+  oneof input {
+    string prompt = 3;
+    TokenIds token_ids = 4;
+  }
+
+  SamplingParams sampling = 5;
+  StoppingOptions stopping = 6;
+  ResponseOptions response = 7;
+  KvOptions kv = 8;
+  GuidedDecoding guided = 9;
+
+  // Multimodal inputs. Order is significant: the i-th item aligns with the
+  // i-th (un-expanded) placeholder marker carried in the prompt/token_ids.
+  // The engine fetches/decodes and preprocesses each item, then expands the
+  // marker into the model's replacement run. Empty for text-only requests.
+  repeated MediaItem media = 10;
+
+  // Loaded LoRA adapter name to apply to this request. Empty = base model.
+  // ModelInfo.supports_lora advertises whether lifecycle and selection are
+  // available through OpenEngine.
+  string lora_name = 11;
+
+  // Engine-specific request parameters that have no portable field above (e.g.
+  // an experimental sampler knob). NOT part of the portable contract: an engine
+  // MAY ignore keys it does not recognize, and a request MUST remain valid with
+  // this field empty. Clients treat it as best-effort and never depend on it
+  // for correctness. Carried as a Struct so JSON types survive the wire.
+  google.protobuf.Struct extra = 12;
+}
+
+message SamplingParams {
+  optional double temperature = 1;
+  optional double top_p = 2;
+  optional int32 top_k = 3;
+  optional double min_p = 4;
+  optional double frequency_penalty = 5;
+  optional double presence_penalty = 6;
+  optional double repetition_penalty = 7;
+  optional uint64 seed = 8;
+  optional uint32 num_sequences = 9;
+}
+
+message StoppingOptions {
+  optional uint32 max_tokens = 1;
+  optional uint32 min_tokens = 2;
+  repeated StopCondition conditions = 3;
+  optional bool ignore_eos = 4;
+  optional bool include_stop_in_output = 5;
+}
+
+message ResponseOptions {
+  optional bool return_prompt_logprobs = 1;
+  CandidateTokenSelection prompt_candidates = 2;
+  optional bool return_output_logprobs = 3;
+  CandidateTokenSelection output_candidates = 4;
+  optional uint32 prompt_logprob_start = 5;
+}
+
+message CandidateTokenSelection {
+  oneof selection {
+    uint32 top_n = 1;
+    TokenIds token_ids = 2;
+    AllCandidates all = 3;
+  }
+}
+
+message AllCandidates {}
+
+message KvOptions {
+  KvSessionRef session = 1;
+  optional bool bypass_prefix_cache = 2;
+  optional string cache_salt = 3;
+}
+
+message StopCondition {
+  oneof condition {
+    string stop_text = 1;
+    uint32 stop_token_id = 2;
+  }
+}
+
+// Constrained / guided decoding spec. At most one of `guide` should be set.
+// The engine enforces the constraint during sampling via its grammar backend
+// (xgrammar / outlines / llguidance); clients cannot apply it post-hoc.
+message GuidedDecoding {
+  oneof guide {
+    string json_schema = 1; // output conforms to this JSON schema
+    string regex = 2; // output matches this regex
+    string ebnf_grammar = 3; // output follows this EBNF / context-free grammar
+    string structural_tag = 4; // xgrammar structural-tag constraint (JSON string)
+    ChoiceConstraint choice = 5;
+    JsonObjectConstraint json_object = 6;
+  }
+  // Optional grammar backend override (e.g. "xgrammar", "outlines",
+  // "llguidance"). Empty = engine default.
+  string backend = 7;
+}
+
+message ChoiceConstraint {
+  repeated string choices = 1;
+}
+
+message JsonObjectConstraint {}
+
+message GenerateResponse {
+  string request_id = 1;
+
+  // PromptOutput, PrefillReady, and EngineError are request-scoped.
+  // TokenOutput and GenerationFinished are output-scoped.
+  oneof event {
+    PromptOutput prompt = 2;
+    TokenOutput token = 3;
+    PrefillReady prefill_ready = 4;
+    GenerationFinished finished = 5;
+    EngineError error = 6;
+  }
+
+  Usage usage = 10; // Cumulative request usage; only set on the final response.
+}
+
+// Request-scoped prompt token information, emitted at most once.
+message PromptOutput {
+  repeated TokenInfo tokens = 1;
+}
+
+// An incremental output delta. Tokens and text are never cumulative.
+message TokenOutput {
+  optional uint32 output_index = 1; // Required, including for output zero.
+  repeated TokenInfo tokens = 2;
+  string text = 3;
+}
+
+message TokenInfo {
+  uint32 token_id = 1;
+  string token = 2;
+  optional double logprob = 3;
+  optional uint32 rank = 4;
+  repeated LogProb candidates = 5;
+}
+
+message LogProb {
+  uint32 token_id = 1;
+  double logprob = 2;
+  string token = 3;
+  optional uint32 rank = 4;
+}
+
+message PrefillReady {
+  KvSessionRef kv_session = 1;
+}
+
+message GenerationFinished {
+  optional uint32 output_index = 1; // Required, including for output zero.
+  FinishReason reason = 2;
+  string message = 3;
+  StopMatch stop_match = 4;
+}
+
+message StopMatch {
+  oneof match {
+    uint32 stop_token_id = 1;
+    string stop_text = 2;
+    uint32 eos_token_id = 3;
+  }
+}
+
+enum FinishReason {
+  FINISH_REASON_UNSPECIFIED = 0;
+  FINISH_REASON_STOP = 1;
+  FINISH_REASON_LENGTH = 2;
+  FINISH_REASON_CANCELLED = 3;
+}
+
+message Usage {
+  uint32 prompt_tokens = 1;
+  uint32 completion_tokens = 2;
+  uint32 total_tokens = 3;
+  optional uint32 cached_prompt_tokens = 4;
+  optional uint32 reasoning_tokens = 5;
+}

--- a/lib/sidecar/openengine/proto/openengine/v1/kv.proto
+++ b/lib/sidecar/openengine/proto/openengine/v1/kv.proto
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// KV sessions, connector discovery, and cache events.
+
+syntax = "proto3";
+
+package openengine.v1;
+
+import "google/protobuf/struct.proto";
+import "openengine/v1/error.proto";
+
+message KvSessionRef {
+  string session_id = 1;
+  string transfer_backend = 2;
+  repeated KvEndpoint endpoints = 3;
+  uint32 dp_rank = 4;
+  // Engine-specific KV-transfer and rendezvous parameters, carried as a Struct
+  // so numbers, booleans, and arrays survive the wire with their JSON type
+  // intact. Struct numbers are IEEE-754 doubles (exact only to 2^53); carry
+  // larger integer values as decimal strings.
+  google.protobuf.Struct attributes_struct = 5;
+}
+
+message KvEndpoint {
+  string host = 1;
+  uint32 port = 2;
+  string protocol = 3; // grpc, nixl, ucx, tcp, shm, etc.
+}
+
+message KvConnectorInfo {
+  optional bool enabled = 1;
+  string transfer_backend = 2;
+  repeated KvEndpoint local_endpoints = 3;
+  repeated string supported_protocols = 4;
+  optional bool supports_remote_prefill = 5;
+  optional bool supports_decode_pull = 6;
+  optional bool supports_abort_cleanup = 7;
+  optional uint32 schema_version = 8;
+}
+
+message GetKvEventSourcesRequest {
+  repeated uint32 data_parallel_ranks = 1;
+}
+
+message GetKvEventSourcesResponse {
+  repeated KvEventSource sources = 1;
+}
+
+message KvEventSource {
+  string transport = 1; // grpc, zmq
+  // Connectable address. MUST use a routable host, never a bind wildcard.
+  KvEndpoint endpoint_addr = 2;
+  string topic = 3;
+  string replay_endpoint = 4; // optional, for ZMQ replay
+  optional uint32 data_parallel_rank = 5;
+  string encoding = 6; // protobuf, msgpack
+  optional uint32 schema_version = 7;
+  optional uint32 buffer_steps = 8;
+  optional uint32 hwm = 9;
+  optional uint32 max_queue_size = 10;
+}
+
+message SubscribeKvEventsRequest {
+  repeated uint32 data_parallel_ranks = 1;
+  bool include_snapshot = 2;
+  uint64 start_sequence_number = 3;
+}
+
+message SubscribeKvEventsResponse {
+  oneof event {
+    KvEventBatch batch = 1;
+    EngineError error = 2; // Terminal.
+  }
+}
+
+message KvEventBatch {
+  uint64 sequence_number = 1;
+  uint64 timestamp_unix_nanos = 2;
+  uint32 data_parallel_rank = 3;
+  repeated KvEvent events = 4;
+}
+
+message KvEvent {
+  string request_id = 1;
+  KvSessionRef kv_session = 2;
+
+  oneof event {
+    BlockStored block_stored = 10;
+    BlockRemoved block_removed = 11;
+    AllBlocksCleared all_blocks_cleared = 12;
+  }
+}
+
+message BlockStored {
+  repeated KvBlockHash block_hashes = 1;
+  KvBlockHash parent_block_hash = 2;
+  repeated uint32 token_ids = 3;
+  uint32 block_size = 4;
+  int64 lora_id = 5;
+  string lora_name = 6;
+  StorageMedium medium = 7;
+
+  // vLLM-compatible optional metadata for reconstructing block keys.
+  repeated OpaqueKeyTuple extra_keys = 20;
+  uint32 group_idx = 21;
+  string kv_cache_spec_kind = 22;
+  uint32 kv_cache_spec_sliding_window = 23;
+}
+
+message BlockRemoved {
+  repeated KvBlockHash block_hashes = 1;
+  StorageMedium medium = 2;
+  uint32 group_idx = 3;
+}
+
+message AllBlocksCleared {}
+
+message KvBlockHash {
+  bytes value = 1;
+  string encoding = 2; // int64, string, bytes, engine_specific
+}
+
+message OpaqueKeyTuple {
+  repeated string values = 1;
+}
+
+enum StorageMedium {
+  STORAGE_MEDIUM_UNSPECIFIED = 0;
+  STORAGE_MEDIUM_GPU = 1;
+  STORAGE_MEDIUM_CPU_PINNED = 2;
+  STORAGE_MEDIUM_DISK = 3;
+  STORAGE_MEDIUM_EXTERNAL = 4;
+}

--- a/lib/sidecar/openengine/proto/openengine/v1/lifecycle.proto
+++ b/lib/sidecar/openengine/proto/openengine/v1/lifecycle.proto
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Health and abort operations.
+
+syntax = "proto3";
+
+package openengine.v1;
+
+import "openengine/v1/kv.proto";
+import "openengine/v1/server.proto";
+
+message HealthRequest {
+  // False means a lightweight readiness/liveness check. True asks the engine to
+  // run a role-appropriate minimal inference probe and report it as a check.
+  bool include_inference_probe = 1;
+
+  // Optional. Used when include_inference_probe is true. Empty means engine
+  // default served model.
+  string model = 2;
+
+  // Optional expected role for role-specific inference probes.
+  EngineRole role = 3;
+}
+
+message HealthResponse {
+  HealthState state = 1;
+  repeated HealthCheck checks = 2;
+}
+
+enum HealthState {
+  HEALTH_STATE_UNSPECIFIED = 0;
+  HEALTH_STATE_STARTING = 1;
+  HEALTH_STATE_READY = 2;
+  HEALTH_STATE_DEGRADED = 3;
+  HEALTH_STATE_NOT_READY = 4;
+}
+
+message HealthCheck {
+  string name = 1; // grpc, scheduler, model, kv_connector, role, inference_probe
+  HealthState state = 2;
+  string message = 3;
+}
+
+message AbortRequest {
+  oneof target {
+    string request_id = 1;
+    KvSessionRef kv_session = 2;
+    AllRequests all_requests = 3;
+  }
+}
+
+message AllRequests {}
+
+message AbortResponse {
+  AbortStatus status = 1;
+  string message = 2;
+}
+
+enum AbortStatus {
+  ABORT_STATUS_UNSPECIFIED = 0;
+  ABORT_STATUS_ABORTED = 1;
+  ABORT_STATUS_ALREADY_FINISHED = 2;
+}

--- a/lib/sidecar/openengine/proto/openengine/v1/lora.proto
+++ b/lib/sidecar/openengine/proto/openengine/v1/lora.proto
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// LoRA adapter lifecycle messages.
+
+syntax = "proto3";
+
+package openengine.v1;
+
+message LoraAdapter {
+  int64 lora_id = 1;
+  string lora_name = 2;
+  string source_path = 3;
+}
+
+message LoadLoraRequest {
+  LoraAdapter adapter = 1;
+}
+
+message LoadLoraResponse {
+  LoraAdapter adapter = 1;
+  bool already_loaded = 2;
+}
+
+message UnloadLoraRequest {
+  string lora_name = 1;
+}
+
+message UnloadLoraResponse {
+  LoraAdapter adapter = 1;
+}
+
+message ListLorasRequest {}
+
+message ListLorasResponse {
+  repeated LoraAdapter adapters = 1;
+}

--- a/lib/sidecar/openengine/proto/openengine/v1/model.proto
+++ b/lib/sidecar/openengine/proto/openengine/v1/model.proto
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Model metadata and portable inference capabilities.
+
+syntax = "proto3";
+
+package openengine.v1;
+
+import "google/protobuf/struct.proto";
+
+message GetModelInfoRequest {
+  string model = 1;
+}
+
+message ModelInfo {
+  string model_id = 1;
+  string served_model_name = 2;
+  repeated string served_model_aliases = 3;
+  optional uint32 max_context_length = 4; // Effective context-window limit in this deployment.
+  optional uint32 max_output_tokens = 5; // Effective generated-token limit in this deployment.
+  repeated string tokenizer_modes = 10;
+
+  optional bool supports_text_input = 20;
+  optional bool supports_token_ids_input = 21;
+  GenerationCapabilities generation = 22;
+  optional bool supports_lora = 23;
+  optional bool supports_multimodal = 24;
+
+  // Engine-advertised response parser names. Clients can apply these to a
+  // model's output stream for tool-call extraction or reasoning separation.
+  // Empty means no parser is configured for this model.
+  string reasoning_parser = 25;
+  string tool_call_parser = 26;
+
+  // Engine-specific model metadata with no portable field (e.g. kv-cache dtype,
+  // quantization, capabilities not yet standardized). NOT part of the portable
+  // contract: clients read it opportunistically and never depend on it for
+  // correctness. Carried as a Struct so JSON types survive the wire.
+  google.protobuf.Struct extra = 28;
+}
+
+message GenerationCapabilities {
+  LogprobCapabilities prompt_logprobs = 1;
+  LogprobCapabilities output_logprobs = 2;
+  GuidedDecodingCapabilities guided_decoding = 3;
+  optional uint32 max_num_sequences = 4;
+  optional bool supports_priority = 5;
+  optional bool supports_stop_in_output = 6;
+  optional bool supports_cache_salt = 7;
+  optional bool supports_prefix_cache_bypass = 8;
+}
+
+message LogprobCapabilities {
+  optional bool supported = 1;
+  repeated CandidateTokenSelectionMode candidate_selection_modes = 2;
+  optional uint32 max_top_n = 3;
+}
+
+enum CandidateTokenSelectionMode {
+  CANDIDATE_TOKEN_SELECTION_MODE_UNSPECIFIED = 0;
+  CANDIDATE_TOKEN_SELECTION_MODE_TOP_N = 1;
+  CANDIDATE_TOKEN_SELECTION_MODE_TOKEN_IDS = 2;
+  CANDIDATE_TOKEN_SELECTION_MODE_ALL = 3;
+}
+
+message GuidedDecodingCapabilities {
+  optional bool supported = 1;
+  repeated GuidedDecodingMode modes = 2;
+}
+
+enum GuidedDecodingMode {
+  GUIDED_DECODING_MODE_UNSPECIFIED = 0;
+  GUIDED_DECODING_MODE_JSON_SCHEMA = 1;
+  GUIDED_DECODING_MODE_REGEX = 2;
+  GUIDED_DECODING_MODE_EBNF_GRAMMAR = 3;
+  GUIDED_DECODING_MODE_STRUCTURAL_TAG = 4;
+  GUIDED_DECODING_MODE_CHOICE = 5;
+  GUIDED_DECODING_MODE_JSON_OBJECT = 6;
+}

--- a/lib/sidecar/openengine/proto/openengine/v1/openengine.proto
+++ b/lib/sidecar/openengine/proto/openengine/v1/openengine.proto
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// OpenEngine API v1 -- vendor-neutral runtime API between model engines (e.g.
+// vLLM, SGLang, TensorRT-LLM) and clients, including direct applications and
+// distributed frameworks (e.g. Dynamo).
+//
+// The files in this package are the canonical contract and single source of
+// truth for the wire shape. Implementations should generate client and server
+// bindings from the complete openengine/v1 package at a known revision.
+//
+// Human-readable reference:
+// https://github.com/ai-dynamo/openengine/blob/main/docs/api.md
+
+syntax = "proto3";
+
+package openengine.v1;
+
+import "openengine/v1/generation.proto";
+import "openengine/v1/kv.proto";
+import "openengine/v1/lifecycle.proto";
+import "openengine/v1/lora.proto";
+import "openengine/v1/model.proto";
+import "openengine/v1/server.proto";
+
+// Standard ASCII gRPC request metadata:
+// - openengine-routing-key: opaque application routing key.
+// - openengine-target-dp-rank: base-10 uint32 routing target. This does not
+//   establish KV affinity; KvSessionRef.dp_rank is authoritative for a session.
+// - openengine-priority: base-10 int32 admission priority; higher values have
+//   higher priority.
+// - traceparent and tracestate: W3C Trace Context.
+//
+// The openengine- prefix is reserved for metadata defined by this protocol.
+// Routing and admission keys apply to Inference RPCs. Trace Context applies to
+// every RPC and should be propagated across downstream calls.
+
+service Inference {
+  // Core inference path.
+  rpc Generate(GenerateRequest) returns (stream GenerateResponse);
+}
+
+service Control {
+  // Runtime metadata and scheduling state.
+  rpc GetServerInfo(GetServerInfoRequest) returns (ServerInfo);
+  rpc GetModelInfo(GetModelInfoRequest) returns (ModelInfo);
+  rpc GetLoad(GetLoadRequest) returns (LoadInfo);
+
+  // Health and lifecycle.
+  rpc Health(HealthRequest) returns (HealthResponse);
+  rpc Abort(AbortRequest) returns (AbortResponse);
+
+  // LoRA lifecycle.
+  rpc LoadLora(LoadLoraRequest) returns (LoadLoraResponse);
+  rpc UnloadLora(UnloadLoraRequest) returns (UnloadLoraResponse);
+  rpc ListLoras(ListLorasRequest) returns (ListLorasResponse);
+
+  // Disaggregated serving / KV transfer. Connector info: ServerInfo.kv_connector.
+  rpc GetKvEventSources(GetKvEventSourcesRequest) returns (GetKvEventSourcesResponse);
+  rpc SubscribeKvEvents(SubscribeKvEventsRequest) returns (stream SubscribeKvEventsResponse);
+}

--- a/lib/sidecar/openengine/proto/openengine/v1/server.proto
+++ b/lib/sidecar/openengine/proto/openengine/v1/server.proto
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Server identity, deployment capacity, roles, parallelism, and load.
+
+syntax = "proto3";
+
+package openengine.v1;
+
+import "google/protobuf/struct.proto";
+import "openengine/v1/kv.proto";
+
+enum EngineRole {
+  ENGINE_ROLE_UNSPECIFIED = 0;
+  ENGINE_ROLE_AGGREGATED = 1;
+  ENGINE_ROLE_PREFILL = 2;
+  ENGINE_ROLE_DECODE = 3;
+}
+
+message GetServerInfoRequest {}
+
+message ServerInfo {
+  string engine_name = 1; // sglang, vllm, tensorrt_llm, etc.
+  string engine_version = 2;
+  EngineRole engine_role = 3;
+  string instance_id = 4;
+  repeated string supported_models = 5;
+  ParallelismInfo parallelism = 6;
+  KvConnectorInfo kv_connector = 7;
+  uint32 schema_revision = 8; // Contract revision implemented; zero is invalid.
+  uint32 minimum_client_revision = 9; // Oldest compatible contract revision.
+  // Immutable BSR module commit; unpublished builds may use a source commit.
+  string schema_release = 10;
+  DeploymentCapacity capacity = 11; // Configured capacity for this deployed server.
+
+  // Engine-specific server metadata with no portable field (e.g. attention
+  // backend, build flags, experimental capabilities). NOT part of the portable
+  // contract: clients read it opportunistically and never depend on it for
+  // correctness. Carried as a Struct so JSON types survive the wire.
+  google.protobuf.Struct extra = 12;
+}
+
+message DeploymentCapacity {
+  optional uint32 kv_block_size = 1; // Tokens per deployed KV-cache block.
+  optional uint64 total_kv_blocks = 2; // Allocatable KV blocks in the reporting scope.
+  optional uint64 max_running_requests = 3; // Concurrent running-request ceiling.
+  optional uint64 max_batched_tokens = 4; // Scheduler token ceiling per batch.
+  optional uint32 max_loras = 5; // Maximum simultaneously resident LoRA adapters.
+}
+
+message ParallelismInfo {
+  optional uint32 tensor_parallel_size = 1;
+  optional uint32 pipeline_parallel_size = 2;
+  optional uint32 data_parallel_size = 3;
+  optional uint32 data_parallel_rank = 4;
+  optional uint32 data_parallel_start_rank = 5;
+  optional uint32 decode_context_parallel_size = 6; // Ranks per decode-context group; at least 1.
+}
+
+message GetLoadRequest {
+  bool include_per_rank = 1;
+}
+
+message LoadInfo {
+  string instance_id = 1;
+  optional uint64 timestamp_unix_nanos = 2;
+  optional uint32 running_requests = 3;
+  optional uint32 queued_requests = 4;
+  optional uint32 active_kv_sessions = 5;
+  optional uint64 used_kv_blocks = 6;
+  optional uint64 total_kv_blocks = 7;
+  optional uint64 running_tokens = 8;
+  optional uint64 waiting_tokens = 9;
+  optional uint32 prefill_batch_size = 10;
+  optional uint32 decode_batch_size = 11;
+  repeated RankLoadInfo ranks = 20;
+  google.protobuf.Struct attributes = 30;
+}
+
+message RankLoadInfo {
+  optional uint32 data_parallel_rank = 1;
+  optional uint32 running_requests = 2;
+  optional uint32 queued_requests = 3;
+  optional uint64 used_kv_blocks = 4;
+  optional uint64 total_kv_blocks = 5;
+  optional uint32 prefill_batch_size = 6;
+  optional uint32 decode_batch_size = 7;
+}

--- a/lib/sidecar/openengine/src/args.rs
+++ b/lib/sidecar/openengine/src/args.rs
@@ -11,9 +11,4 @@ use dynamo_sidecar_common::SidecarArgs;
 pub(crate) struct Args {
     #[command(flatten)]
     pub sidecar: SidecarArgs,
-
-    /// Hugging Face model ID or local path used for tokenization and templates.
-    /// Defaults to the single model advertised by OpenEngine GetServerInfo.
-    #[arg(long)]
-    pub model_path: Option<String>,
 }

--- a/lib/sidecar/openengine/src/args.rs
+++ b/lib/sidecar/openengine/src/args.rs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_sidecar_common::SidecarArgs;
+
+#[derive(clap::Parser, Clone, Debug)]
+#[command(
+    name = "dynamo-openengine-sidecar",
+    about = "Run a Dynamo worker against an OpenEngine gRPC server"
+)]
+pub(crate) struct Args {
+    #[command(flatten)]
+    pub sidecar: SidecarArgs,
+
+    /// Hugging Face model ID or local path used for tokenization and templates.
+    /// Defaults to the single model advertised by OpenEngine GetServerInfo.
+    #[arg(long)]
+    pub model_path: Option<String>,
+}

--- a/lib/sidecar/openengine/src/client.rs
+++ b/lib/sidecar/openengine/src/client.rs
@@ -68,6 +68,28 @@ impl OpenEngineClient {
         .map_err(|status| status_to_dynamo("GetServerInfo", status))
     }
 
+    pub(crate) async fn model_info(
+        &self,
+        model: &str,
+        timeout: Duration,
+    ) -> Result<pb::ModelInfo, DynamoError> {
+        tokio::time::timeout(
+            timeout,
+            self.control_client()
+                .get_model_info(pb::GetModelInfoRequest {
+                    model: model.to_string(),
+                }),
+        )
+        .await
+        .map_err(|_| {
+            connection_timeout(format!(
+                "OpenEngine GetModelInfo did not respond within {timeout:?}"
+            ))
+        })?
+        .map(tonic::Response::into_inner)
+        .map_err(|status| status_to_dynamo("GetModelInfo", status))
+    }
+
     pub(crate) async fn generate(
         &self,
         request: tonic::Request<pb::GenerateRequest>,

--- a/lib/sidecar/openengine/src/client.rs
+++ b/lib/sidecar/openengine/src/client.rs
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Thin client for the OpenEngine Inference and Control services.
+
+use std::time::Duration;
+
+use dynamo_backend_common::DynamoError;
+use dynamo_sidecar_common::{
+    DEFAULT_MAX_GRPC_MESSAGE_SIZE, GrpcChannelPool, GrpcEndpoint, GrpcTransportConfig,
+    connection_timeout,
+};
+use tonic::transport::Channel;
+
+pub(crate) use dynamo_sidecar_common::{
+    engine_shutdown, invalid_argument, protocol_error as sidecar_protocol_error, status_to_dynamo,
+};
+
+use crate::proto as pb;
+use crate::proto::control_client::ControlClient;
+use crate::proto::inference_client::InferenceClient;
+
+pub(crate) struct OpenEngineClient {
+    pool: GrpcChannelPool,
+}
+
+impl OpenEngineClient {
+    pub(crate) async fn connect(
+        endpoint: &GrpcEndpoint,
+        transport: GrpcTransportConfig,
+    ) -> Result<Self, DynamoError> {
+        let pool = GrpcChannelPool::connect("OpenEngine", endpoint, transport).await?;
+        Ok(Self { pool })
+    }
+
+    pub(crate) fn connection_count(&self) -> usize {
+        self.pool.len()
+    }
+
+    fn control_client(&self) -> ControlClient<Channel> {
+        ControlClient::new(self.pool.next_channel())
+            .max_decoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
+            .max_encoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
+    }
+
+    fn inference_client(&self) -> InferenceClient<Channel> {
+        InferenceClient::new(self.pool.next_channel())
+            .max_decoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
+            .max_encoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
+    }
+
+    pub(crate) async fn server_info(
+        &self,
+        timeout: Duration,
+    ) -> Result<pb::ServerInfo, DynamoError> {
+        tokio::time::timeout(
+            timeout,
+            self.control_client()
+                .get_server_info(pb::GetServerInfoRequest {}),
+        )
+        .await
+        .map_err(|_| {
+            connection_timeout(format!(
+                "OpenEngine GetServerInfo did not respond within {timeout:?}"
+            ))
+        })?
+        .map(tonic::Response::into_inner)
+        .map_err(|status| status_to_dynamo("GetServerInfo", status))
+    }
+
+    pub(crate) async fn generate(
+        &self,
+        request: tonic::Request<pb::GenerateRequest>,
+    ) -> Result<tonic::Streaming<pb::GenerateResponse>, DynamoError> {
+        self.inference_client()
+            .generate(request)
+            .await
+            .map(tonic::Response::into_inner)
+            .map_err(|status| status_to_dynamo("Generate", status))
+    }
+}
+
+pub(crate) fn protocol_error(message: impl Into<String>) -> DynamoError {
+    sidecar_protocol_error("OpenEngine", message)
+}

--- a/lib/sidecar/openengine/src/convert.rs
+++ b/lib/sidecar/openengine/src/convert.rs
@@ -1,0 +1,645 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Conversion between Dynamo requests and OpenEngine v0.1.0 messages.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use dynamo_backend_common::{
+    DisaggregationMode, DynamoError, FinishReason, LLMEngineOutput, PreprocessedRequest,
+    StopReason, TopLogprob, usage,
+};
+use tonic::metadata::{Ascii, MetadataKey, MetadataMap, MetadataValue};
+
+use crate::client;
+use crate::proto as pb;
+
+pub(crate) fn generate_metadata(
+    request: &PreprocessedRequest,
+    context: &BTreeMap<String, String>,
+    mode: DisaggregationMode,
+) -> Result<MetadataMap, DynamoError> {
+    let mut metadata = MetadataMap::new();
+    for key in ["traceparent", "tracestate"] {
+        if let Some(value) = context.get(key) {
+            insert_metadata(&mut metadata, key, value)?;
+        }
+    }
+    if let Some(routing) = request.routing.as_ref() {
+        if let Some(priority) = routing.priority {
+            insert_metadata(&mut metadata, "openengine-priority", &priority.to_string())?;
+        }
+        // A decode KvSessionRef carries the authoritative rank. Omitting the
+        // metadata lets the server route from that opaque handoff.
+        let rank = match mode {
+            DisaggregationMode::Prefill => routing.prefill_dp_rank.or(routing.dp_rank),
+            DisaggregationMode::Aggregated => routing.dp_rank,
+            DisaggregationMode::Decode | DisaggregationMode::Encode => None,
+        };
+        if let Some(rank) = rank {
+            insert_metadata(
+                &mut metadata,
+                "openengine-target-dp-rank",
+                &rank.to_string(),
+            )?;
+        }
+    }
+    Ok(metadata)
+}
+
+fn insert_metadata(metadata: &mut MetadataMap, key: &str, value: &str) -> Result<(), DynamoError> {
+    let key = MetadataKey::<Ascii>::from_bytes(key.as_bytes()).map_err(|error| {
+        client::invalid_argument(format!("invalid OpenEngine metadata key `{key}`: {error}"))
+    })?;
+    let value = MetadataValue::<Ascii>::try_from(value).map_err(|error| {
+        client::invalid_argument(format!("invalid OpenEngine metadata value: {error}"))
+    })?;
+    metadata.insert(key, value);
+    Ok(())
+}
+
+pub(crate) fn build_generate_request(
+    request: &PreprocessedRequest,
+    request_id: &str,
+    model: &str,
+    mode: DisaggregationMode,
+) -> Result<pb::GenerateRequest, DynamoError> {
+    validate_request(request, mode)?;
+
+    let sampling = &request.sampling_options;
+    let stopping = &request.stop_conditions;
+    let output = &request.output_options;
+    let mut stop_token_ids = BTreeSet::new();
+    for ids in [
+        stopping.stop_token_ids.as_ref(),
+        stopping.stop_token_ids_hidden.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        stop_token_ids.extend(ids.iter().copied());
+    }
+    let conditions = stopping
+        .stop
+        .iter()
+        .flatten()
+        .cloned()
+        .map(|value| pb::StopCondition {
+            condition: Some(pb::stop_condition::Condition::StopText(value)),
+        })
+        .chain(stop_token_ids.into_iter().map(|value| pb::StopCondition {
+            condition: Some(pb::stop_condition::Condition::StopTokenId(value)),
+        }))
+        .collect();
+
+    let session = match mode {
+        DisaggregationMode::Decode => Some(disagg_json_to_kv_session(
+            &request
+                .prefill_result
+                .as_ref()
+                .ok_or_else(|| {
+                    client::invalid_argument(
+                        "decode request is missing the prefill_result KV session",
+                    )
+                })?
+                .disaggregated_params,
+        )?),
+        DisaggregationMode::Aggregated | DisaggregationMode::Prefill => None,
+        DisaggregationMode::Encode => unreachable!("encode rejected by validate_request"),
+    };
+    let routing = request.routing.as_ref();
+
+    Ok(pb::GenerateRequest {
+        request_id: request_id.to_string(),
+        model: model.to_string(),
+        input: Some(pb::generate_request::Input::TokenIds(pb::TokenIds {
+            ids: request.token_ids.clone(),
+        })),
+        sampling: Some(pb::SamplingParams {
+            temperature: sampling.temperature.map(f64::from),
+            top_p: sampling.top_p.map(f64::from),
+            top_k: normalize_top_k(sampling.top_k)?,
+            min_p: sampling.min_p.map(f64::from),
+            frequency_penalty: sampling.frequency_penalty.map(f64::from),
+            presence_penalty: sampling.presence_penalty.map(f64::from),
+            repetition_penalty: sampling.repetition_penalty.map(f64::from),
+            seed: normalize_seed(sampling.seed)?,
+            num_sequences: sampling.n.map(u32::from),
+        }),
+        stopping: Some(pb::StoppingOptions {
+            max_tokens: if mode.is_prefill() {
+                Some(1)
+            } else {
+                stopping.max_tokens
+            },
+            min_tokens: stopping.min_tokens,
+            conditions,
+            ignore_eos: stopping.ignore_eos,
+            include_stop_in_output: sampling.include_stop_str_in_output,
+        }),
+        response: Some(pb::ResponseOptions {
+            return_prompt_logprobs: None,
+            prompt_candidates: None,
+            return_output_logprobs: output.logprobs.map(|_| true),
+            output_candidates: output.logprobs.map(top_n_candidates),
+            prompt_logprob_start: None,
+        }),
+        kv: Some(pb::KvOptions {
+            session,
+            bypass_prefix_cache: prefix_cache_bypass(request),
+            cache_salt: routing.and_then(|value| value.cache_namespace.clone()),
+        }),
+        guided: None,
+        media: Vec::new(),
+        lora_name: String::new(),
+        extra: None,
+    })
+}
+
+fn top_n_candidates(top_n: u32) -> pb::CandidateTokenSelection {
+    pb::CandidateTokenSelection {
+        selection: Some(pb::candidate_token_selection::Selection::TopN(top_n)),
+    }
+}
+
+fn normalize_top_k(top_k: Option<i32>) -> Result<Option<i32>, DynamoError> {
+    match top_k {
+        None | Some(-1) | Some(0) => Ok(None),
+        Some(value) if value > 0 => Ok(Some(value)),
+        Some(value) => Err(client::invalid_argument(format!(
+            "top_k must be -1, 0, or positive; got {value}"
+        ))),
+    }
+}
+
+fn normalize_seed(seed: Option<i64>) -> Result<Option<u64>, DynamoError> {
+    seed.map(|value| {
+        u64::try_from(value).map_err(|_| {
+            client::invalid_argument(format!("seed must be non-negative; got {value}"))
+        })
+    })
+    .transpose()
+}
+
+fn prefix_cache_bypass(request: &PreprocessedRequest) -> Option<bool> {
+    request.extra_args.as_ref().and_then(|args| {
+        args.get("bypass_prefix_cache")
+            .and_then(serde_json::Value::as_bool)
+            .or_else(|| {
+                args.get("disable_prefix_cache")
+                    .and_then(serde_json::Value::as_bool)
+            })
+    })
+}
+
+fn validate_request(
+    request: &PreprocessedRequest,
+    mode: DisaggregationMode,
+) -> Result<(), DynamoError> {
+    if mode.is_encode() {
+        return Err(client::invalid_argument(
+            "encode mode is not supported by the OpenEngine sidecar",
+        ));
+    }
+    if request.token_ids.is_empty() {
+        return Err(client::invalid_argument("token_ids must not be empty"));
+    }
+    if request.prompt_embeds.is_some() {
+        return Err(client::invalid_argument(
+            "prompt embeddings are not supported by this OpenEngine sidecar",
+        ));
+    }
+    if request.multi_modal_data.is_some()
+        || request.mm_routing_info.is_some()
+        || request.encoder_result.is_some()
+    {
+        return Err(client::invalid_argument(
+            "multimodal and encoder handoff inputs are not supported by this OpenEngine sidecar",
+        ));
+    }
+    if mode.is_decode() != request.prefill_result.is_some() {
+        return Err(client::invalid_argument(if mode.is_decode() {
+            "decode requests require a prefill_result KV session"
+        } else {
+            "only decode requests may carry a prefill_result KV session"
+        }));
+    }
+    if request.output_options.prompt_logprobs.is_some() {
+        return Err(client::invalid_argument(
+            "prompt logprobs are not supported by this OpenEngine sidecar",
+        ));
+    }
+    if request.sampling_options.guided_decoding.is_some() {
+        return Err(client::invalid_argument(
+            "guided decoding is not implemented by the TensorRT-LLM OpenEngine server",
+        ));
+    }
+    if request
+        .routing
+        .as_ref()
+        .and_then(|routing| routing.lora_name.as_deref())
+        .is_some_and(|name| !name.is_empty())
+    {
+        return Err(client::invalid_argument(
+            "LoRA selection is not implemented by the TensorRT-LLM OpenEngine server",
+        ));
+    }
+    if request
+        .stop_conditions
+        .stop_token_ids_visible
+        .as_ref()
+        .is_some_and(|ids| !ids.is_empty())
+    {
+        return Err(client::invalid_argument(
+            "visible stop token IDs cannot be represented by OpenEngine's global stop-output flag",
+        ));
+    }
+    if prefix_cache_bypass(request) == Some(true) {
+        return Err(client::invalid_argument(
+            "prefix-cache bypass is not implemented by the TensorRT-LLM OpenEngine server",
+        ));
+    }
+    if request.stop_conditions.max_thinking_tokens.is_some() {
+        return Err(client::invalid_argument(
+            "max_thinking_tokens is not supported by OpenEngine v0.1.0",
+        ));
+    }
+    let sampling = &request.sampling_options;
+    if sampling.n.unwrap_or(1) != 1 {
+        return Err(client::invalid_argument("n must be 1"));
+    }
+    if sampling.best_of.unwrap_or(1) != 1 {
+        return Err(client::invalid_argument("best_of must be 1"));
+    }
+    if sampling.use_beam_search.unwrap_or(false) {
+        return Err(client::invalid_argument("beam search is not supported"));
+    }
+    Ok(())
+}
+
+pub(crate) struct ResponseState {
+    mode: DisaggregationMode,
+    prompt_tokens: u32,
+    completion_tokens: u32,
+}
+
+impl ResponseState {
+    pub(crate) fn new(mode: DisaggregationMode, prompt_tokens: u32) -> Self {
+        Self {
+            mode,
+            prompt_tokens,
+            completion_tokens: 0,
+        }
+    }
+
+    pub(crate) fn prompt_tokens(&self) -> u32 {
+        self.prompt_tokens
+    }
+
+    pub(crate) fn completion_tokens(&self) -> u32 {
+        self.completion_tokens
+    }
+
+    pub(crate) fn convert(
+        &mut self,
+        response: pb::GenerateResponse,
+        request_id: &str,
+    ) -> Result<Option<LLMEngineOutput>, DynamoError> {
+        if response.request_id != request_id {
+            return Err(client::protocol_error(format!(
+                "Generate returned request_id `{}` on stream `{request_id}`",
+                response.request_id
+            )));
+        }
+        if let Some(value) = response.usage.as_ref() {
+            self.prompt_tokens = value.prompt_tokens;
+            self.completion_tokens = value.completion_tokens;
+        }
+        match response.event {
+            Some(pb::generate_response::Event::Token(token)) => {
+                if self.mode.is_prefill() || response.usage.is_some() {
+                    return Err(client::protocol_error(
+                        "Generate returned a token event for prefill or with terminal usage",
+                    ));
+                }
+                let output_index = token.output_index.ok_or_else(|| {
+                    client::protocol_error("token event omitted required output_index")
+                })?;
+                if output_index != 0 {
+                    return Err(client::protocol_error(format!(
+                        "received unsupported output index {output_index}"
+                    )));
+                }
+                self.completion_tokens = self
+                    .completion_tokens
+                    .saturating_add(token.tokens.len() as u32);
+                Ok(token_output(token))
+            }
+            Some(pb::generate_response::Event::PrefillReady(prefill)) => {
+                if !self.mode.is_prefill() {
+                    return Err(client::protocol_error(
+                        "Generate returned PrefillReady for a non-prefill worker",
+                    ));
+                }
+                let session = prefill.kv_session.ok_or_else(|| {
+                    client::protocol_error("PrefillReady omitted required kv_session")
+                })?;
+                let wire_usage = response
+                    .usage
+                    .ok_or_else(|| client::protocol_error("PrefillReady omitted terminal usage"))?;
+                let mut output = LLMEngineOutput::stop();
+                output.completion_usage = Some(usage(
+                    wire_usage.prompt_tokens,
+                    wire_usage.completion_tokens,
+                ));
+                output.disaggregated_params = Some(kv_session_to_disagg_json(session));
+                Ok(Some(output))
+            }
+            Some(pb::generate_response::Event::Finished(finished)) => {
+                if self.mode.is_prefill() {
+                    return Err(client::protocol_error(
+                        "Generate returned GenerationFinished for a prefill worker",
+                    ));
+                }
+                let output_index = finished.output_index.ok_or_else(|| {
+                    client::protocol_error("GenerationFinished omitted required output_index")
+                })?;
+                if output_index != 0 {
+                    return Err(client::protocol_error(format!(
+                        "received unsupported output index {output_index}"
+                    )));
+                }
+                let wire_usage = response.usage.ok_or_else(|| {
+                    client::protocol_error("GenerationFinished omitted terminal usage")
+                })?;
+                let reason = pb::FinishReason::try_from(finished.reason).map_err(|_| {
+                    client::protocol_error(format!(
+                        "unknown OpenEngine finish reason {}",
+                        finished.reason
+                    ))
+                })?;
+                let mut output = finished_output(reason, finished.stop_match)?;
+                output.index = Some(output_index);
+                output.completion_usage = Some(usage(
+                    wire_usage.prompt_tokens,
+                    wire_usage.completion_tokens,
+                ));
+                Ok(Some(output))
+            }
+            Some(pb::generate_response::Event::Error(error)) => Err(client::protocol_error(
+                format!("server error {:?}: {}", error.code(), error.message),
+            )),
+            Some(pb::generate_response::Event::Prompt(_)) => Err(client::protocol_error(
+                "Generate returned prompt logprobs that were not requested",
+            )),
+            None => Err(client::protocol_error("Generate response carried no event")),
+        }
+    }
+}
+
+fn token_output(value: pb::TokenOutput) -> Option<LLMEngineOutput> {
+    if value.tokens.is_empty() && value.text.is_empty() {
+        return None;
+    }
+    let has_logprobs = value.tokens.iter().any(|token| token.logprob.is_some());
+    Some(LLMEngineOutput {
+        token_ids: value.tokens.iter().map(|token| token.token_id).collect(),
+        tokens: Some(
+            value
+                .tokens
+                .iter()
+                .map(|token| (!token.token.is_empty()).then(|| token.token.clone()))
+                .collect(),
+        ),
+        text: (!value.text.is_empty()).then_some(value.text),
+        log_probs: has_logprobs.then(|| {
+            value
+                .tokens
+                .iter()
+                .map(|token| token.logprob.unwrap_or(f64::NEG_INFINITY))
+                .collect()
+        }),
+        top_logprobs: has_logprobs.then(|| {
+            value
+                .tokens
+                .iter()
+                .map(|token| {
+                    token
+                        .candidates
+                        .iter()
+                        .map(|candidate| TopLogprob {
+                            rank: candidate.rank.unwrap_or(0),
+                            token_id: candidate.token_id,
+                            token: (!candidate.token.is_empty()).then(|| candidate.token.clone()),
+                            logprob: candidate.logprob,
+                            bytes: None,
+                        })
+                        .collect()
+                })
+                .collect()
+        }),
+        index: value.output_index,
+        ..Default::default()
+    })
+}
+
+fn finished_output(
+    reason: pb::FinishReason,
+    stop_match: Option<pb::StopMatch>,
+) -> Result<LLMEngineOutput, DynamoError> {
+    let finish_reason = match reason {
+        pb::FinishReason::Stop => FinishReason::Stop,
+        pb::FinishReason::Length => FinishReason::Length,
+        pb::FinishReason::Cancelled => FinishReason::Cancelled,
+        pb::FinishReason::Unspecified => {
+            return Err(client::protocol_error(
+                "GenerationFinished used an unspecified finish reason",
+            ));
+        }
+    };
+    let stop_reason = stop_match.and_then(|value| match value.r#match {
+        Some(pb::stop_match::Match::StopTokenId(id))
+        | Some(pb::stop_match::Match::EosTokenId(id)) => Some(StopReason::Int(i64::from(id))),
+        Some(pb::stop_match::Match::StopText(value)) => Some(StopReason::String(value)),
+        None => None,
+    });
+    Ok(LLMEngineOutput {
+        finish_reason: Some(finish_reason),
+        stop_reason,
+        ..Default::default()
+    })
+}
+
+pub(crate) fn kv_session_to_disagg_json(value: pb::KvSessionRef) -> serde_json::Value {
+    serde_json::json!({
+        "session_id": value.session_id,
+        "transfer_backend": value.transfer_backend,
+        "endpoints": value.endpoints.into_iter().map(|endpoint| serde_json::json!({
+            "host": endpoint.host,
+            "port": endpoint.port,
+            "protocol": endpoint.protocol,
+        })).collect::<Vec<_>>(),
+        "dp_rank": value.dp_rank,
+        "attributes_struct": value.attributes_struct.as_ref().map(prost_struct_to_json),
+    })
+}
+
+pub(crate) fn disagg_json_to_kv_session(
+    value: &serde_json::Value,
+) -> Result<pb::KvSessionRef, DynamoError> {
+    let object = value.as_object().ok_or_else(|| {
+        client::invalid_argument("prefill_result.disaggregated_params must be an object")
+    })?;
+    let required_string = |key: &str| -> Result<String, DynamoError> {
+        object
+            .get(key)
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .ok_or_else(|| {
+                client::invalid_argument(format!("handoff `{key}` must be a non-empty string"))
+            })
+    };
+    let endpoints = object
+        .get("endpoints")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| client::invalid_argument("handoff `endpoints` must be an array"))?
+        .iter()
+        .map(endpoint_from_json)
+        .collect::<Result<Vec<_>, _>>()?;
+    let attributes_struct = match object.get("attributes_struct") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(value @ serde_json::Value::Object(_)) => json_to_prost_struct(value),
+        Some(_) => {
+            return Err(client::invalid_argument(
+                "handoff `attributes_struct` must be an object or null",
+            ));
+        }
+    };
+    let dp_rank = object
+        .get("dp_rank")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+        .ok_or_else(|| client::invalid_argument("handoff `dp_rank` must be a uint32"))?;
+    Ok(pb::KvSessionRef {
+        session_id: required_string("session_id")?,
+        transfer_backend: required_string("transfer_backend")?,
+        endpoints,
+        dp_rank,
+        attributes_struct,
+    })
+}
+
+fn endpoint_from_json(value: &serde_json::Value) -> Result<pb::KvEndpoint, DynamoError> {
+    let endpoint = value
+        .as_object()
+        .ok_or_else(|| client::invalid_argument("handoff endpoint must be an object"))?;
+    let host = endpoint
+        .get("host")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| client::invalid_argument("handoff endpoint host must be non-empty"))?;
+    let port = endpoint
+        .get("port")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+        .ok_or_else(|| client::invalid_argument("handoff endpoint port must be a uint32"))?;
+    let protocol = endpoint
+        .get("protocol")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| client::invalid_argument("handoff endpoint protocol must be non-empty"))?;
+    Ok(pb::KvEndpoint {
+        host: host.to_string(),
+        port,
+        protocol: protocol.to_string(),
+    })
+}
+
+fn json_to_prost_struct(value: &serde_json::Value) -> Option<prost_types::Struct> {
+    let serde_json::Value::Object(fields) = value else {
+        return None;
+    };
+    Some(prost_types::Struct {
+        fields: fields
+            .iter()
+            .map(|(key, value)| (key.clone(), json_to_prost_value(value)))
+            .collect(),
+    })
+}
+
+fn json_to_prost_value(value: &serde_json::Value) -> prost_types::Value {
+    use prost_types::value::Kind;
+    let kind = match value {
+        serde_json::Value::Null => Kind::NullValue(0),
+        serde_json::Value::Bool(value) => Kind::BoolValue(*value),
+        serde_json::Value::Number(value) => Kind::NumberValue(value.as_f64().unwrap_or_default()),
+        serde_json::Value::String(value) => Kind::StringValue(value.clone()),
+        serde_json::Value::Array(values) => Kind::ListValue(prost_types::ListValue {
+            values: values.iter().map(json_to_prost_value).collect(),
+        }),
+        serde_json::Value::Object(fields) => Kind::StructValue(prost_types::Struct {
+            fields: fields
+                .iter()
+                .map(|(key, value)| (key.clone(), json_to_prost_value(value)))
+                .collect(),
+        }),
+    };
+    prost_types::Value { kind: Some(kind) }
+}
+
+fn prost_struct_to_json(value: &prost_types::Struct) -> serde_json::Value {
+    serde_json::Value::Object(
+        value
+            .fields
+            .iter()
+            .map(|(key, value)| (key.clone(), prost_value_to_json(value)))
+            .collect(),
+    )
+}
+
+fn prost_value_to_json(value: &prost_types::Value) -> serde_json::Value {
+    use prost_types::value::Kind;
+    match value.kind.as_ref() {
+        None | Some(Kind::NullValue(_)) => serde_json::Value::Null,
+        Some(Kind::BoolValue(value)) => serde_json::Value::Bool(*value),
+        Some(Kind::NumberValue(value)) if value.fract() == 0.0 => {
+            serde_json::Value::Number((*value as i64).into())
+        }
+        Some(Kind::NumberValue(value)) => serde_json::Number::from_f64(*value)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        Some(Kind::StringValue(value)) => serde_json::Value::String(value.clone()),
+        Some(Kind::ListValue(value)) => {
+            serde_json::Value::Array(value.values.iter().map(prost_value_to_json).collect())
+        }
+        Some(Kind::StructValue(value)) => prost_struct_to_json(value),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{disagg_json_to_kv_session, json_to_prost_struct, kv_session_to_disagg_json};
+    use crate::proto as pb;
+
+    #[test]
+    fn preserves_opaque_trtllm_kv_session_across_dynamo_handoff() {
+        let session = pb::KvSessionRef {
+            session_id: "42".to_string(),
+            transfer_backend: "tensorrt_llm".to_string(),
+            endpoints: Vec::new(),
+            dp_rank: 3,
+            attributes_struct: json_to_prost_struct(&serde_json::json!({
+                "tensorrt_llm.disaggregated_params.v1": {
+                    "ctx_request_id": "42",
+                    "ctx_dp_rank": 3,
+                    "schedule_style": "context_first",
+                    "draft_tokens": [7, 8]
+                }
+            })),
+        };
+
+        let handoff = kv_session_to_disagg_json(session.clone());
+        assert_eq!(disagg_json_to_kv_session(&handoff).unwrap(), session);
+    }
+}

--- a/lib/sidecar/openengine/src/convert.rs
+++ b/lib/sidecar/openengine/src/convert.rs
@@ -347,7 +347,7 @@ impl ResponseState {
                 let wire_usage = response
                     .usage
                     .ok_or_else(|| client::protocol_error("PrefillReady omitted terminal usage"))?;
-                let mut output = LLMEngineOutput::stop();
+                let mut output = LLMEngineOutput::length();
                 output.completion_usage = Some(usage(
                     wire_usage.prompt_tokens,
                     wire_usage.completion_tokens,
@@ -619,8 +619,44 @@ fn prost_value_to_json(value: &prost_types::Value) -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
-    use super::{disagg_json_to_kv_session, json_to_prost_struct, kv_session_to_disagg_json};
+    use dynamo_backend_common::{DisaggregationMode, FinishReason};
+
+    use super::{
+        ResponseState, disagg_json_to_kv_session, json_to_prost_struct, kv_session_to_disagg_json,
+    };
     use crate::proto as pb;
+
+    #[test]
+    fn prefill_ready_is_a_decode_handoff_not_a_terminal_stop() {
+        let mut state = ResponseState::new(DisaggregationMode::Prefill, 5);
+        let output = state
+            .convert(
+                pb::GenerateResponse {
+                    request_id: "request-1".to_string(),
+                    event: Some(pb::generate_response::Event::PrefillReady(
+                        pb::PrefillReady {
+                            kv_session: Some(pb::KvSessionRef {
+                                session_id: "42".to_string(),
+                                transfer_backend: "tensorrt_llm".to_string(),
+                                ..Default::default()
+                            }),
+                        },
+                    )),
+                    usage: Some(pb::Usage {
+                        prompt_tokens: 5,
+                        completion_tokens: 0,
+                        total_tokens: 5,
+                        ..Default::default()
+                    }),
+                },
+                "request-1",
+            )
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(output.finish_reason, Some(FinishReason::Length));
+        assert!(output.disaggregated_params.is_some());
+    }
 
     #[test]
     fn preserves_opaque_trtllm_kv_session_across_dynamo_handoff() {

--- a/lib/sidecar/openengine/src/engine.rs
+++ b/lib/sidecar/openengine/src/engine.rs
@@ -1,0 +1,385 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+
+use async_trait::async_trait;
+use dynamo_backend_common::{
+    DisaggregationMode, DynamoError, EngineConfig, GenerateContext, LLMEngine, LLMEngineOutput,
+    LLMEngineOutputExt, LlmRegistration, PreprocessedRequest, WorkerConfig, usage,
+};
+use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig, SidecarStartupError};
+use futures::stream::BoxStream;
+use tokio::sync::OnceCell;
+use tokio_util::sync::CancellationToken;
+
+use crate::OPENENGINE_SCHEMA_RELEASE;
+use crate::args::Args;
+use crate::client::{self, OpenEngineClient};
+use crate::convert::{self, ResponseState};
+use crate::proto as pb;
+
+const SCHEMA_REVISION: u32 = 1;
+
+#[derive(Clone, Debug)]
+struct Discovery {
+    info: pb::ServerInfo,
+    role: pb::EngineRole,
+    mode: DisaggregationMode,
+    model_source: String,
+    remote_model: String,
+}
+
+impl Discovery {
+    fn from_server_info(
+        info: pb::ServerInfo,
+        model_path: Option<String>,
+    ) -> Result<Self, DynamoError> {
+        if info.engine_name.trim().is_empty() {
+            return Err(client::protocol_error(
+                "GetServerInfo returned an empty engine_name",
+            ));
+        }
+        if info.schema_revision < SCHEMA_REVISION || info.minimum_client_revision > SCHEMA_REVISION
+        {
+            return Err(client::protocol_error(format!(
+                "incompatible schema revisions: server={}, minimum_client={}, client={SCHEMA_REVISION}",
+                info.schema_revision, info.minimum_client_revision
+            )));
+        }
+        if info.schema_release != OPENENGINE_SCHEMA_RELEASE {
+            return Err(client::protocol_error(format!(
+                "server schema_release `{}` does not match `{OPENENGINE_SCHEMA_RELEASE}`",
+                info.schema_release
+            )));
+        }
+        let role = pb::EngineRole::try_from(info.engine_role).map_err(|_| {
+            client::protocol_error(format!("unknown engine role {}", info.engine_role))
+        })?;
+        let mode = match role {
+            pb::EngineRole::Aggregated => DisaggregationMode::Aggregated,
+            pb::EngineRole::Prefill => DisaggregationMode::Prefill,
+            pb::EngineRole::Decode => DisaggregationMode::Decode,
+            pb::EngineRole::Unspecified => {
+                return Err(client::protocol_error(
+                    "GetServerInfo returned an unspecified engine role",
+                ));
+            }
+        };
+        let [remote_model] = info.supported_models.as_slice() else {
+            return Err(client::protocol_error(format!(
+                "this initial sidecar requires exactly one supported model; server returned {}",
+                info.supported_models.len()
+            )));
+        };
+        if remote_model.trim().is_empty() {
+            return Err(client::protocol_error(
+                "GetServerInfo returned an empty supported model",
+            ));
+        }
+        if mode != DisaggregationMode::Aggregated {
+            let connector = info.kv_connector.as_ref().ok_or_else(|| {
+                client::protocol_error("disaggregated server omitted kv_connector")
+            })?;
+            if connector.enabled != Some(true) || connector.transfer_backend.trim().is_empty() {
+                return Err(client::protocol_error(
+                    "disaggregated server did not advertise an enabled KV transfer backend",
+                ));
+            }
+        }
+        let model_source = model_path.unwrap_or_else(|| remote_model.clone());
+        if model_source.trim().is_empty() {
+            return Err(client::invalid_argument("model-path must not be empty"));
+        }
+        Ok(Self {
+            remote_model: remote_model.clone(),
+            model_source,
+            info,
+            role,
+            mode,
+        })
+    }
+
+    fn ensure_same_server(&self, observed: &Self) -> Result<(), DynamoError> {
+        if self.info.engine_name != observed.info.engine_name
+            || self.info.schema_release != observed.info.schema_release
+            || self.role != observed.role
+            || self.remote_model != observed.remote_model
+        {
+            return Err(client::protocol_error(
+                "OpenEngine identity, role, schema, or model changed during startup",
+            ));
+        }
+        Ok(())
+    }
+
+    fn engine_config(&self) -> EngineConfig {
+        let mut runtime_data = HashMap::new();
+        runtime_data.insert(
+            "grpc_service".to_string(),
+            serde_json::Value::String("openengine.v1.Inference".to_string()),
+        );
+        runtime_data.insert(
+            "openengine_schema_release".to_string(),
+            serde_json::Value::String(self.info.schema_release.clone()),
+        );
+        runtime_data.insert(
+            "engine_name".to_string(),
+            serde_json::Value::String(self.info.engine_name.clone()),
+        );
+
+        let capacity = self.info.capacity.as_ref();
+        let parallelism = self.info.parallelism.as_ref();
+        EngineConfig {
+            model: self.model_source.clone(),
+            served_model_name: Some(self.remote_model.clone()),
+            model_aliases: Vec::new(),
+            runtime_data,
+            llm: Some(LlmRegistration {
+                context_length: None,
+                kv_cache_block_size: capacity.and_then(|value| value.kv_block_size),
+                total_kv_blocks: capacity.and_then(|value| value.total_kv_blocks),
+                max_num_seqs: capacity.and_then(|value| value.max_running_requests),
+                max_num_batched_tokens: capacity.and_then(|value| value.max_batched_tokens),
+                data_parallel_size: parallelism
+                    .and_then(|value| value.data_parallel_size)
+                    .filter(|value| *value > 0),
+                data_parallel_start_rank: parallelism
+                    .and_then(|value| value.data_parallel_start_rank.or(value.data_parallel_rank)),
+                bootstrap_host: None,
+                bootstrap_port: None,
+            }),
+        }
+    }
+}
+
+pub struct OpenEngineSidecarEngine {
+    endpoint: GrpcEndpoint,
+    transport: GrpcTransportConfig,
+    discovery: Discovery,
+    client: OnceCell<OpenEngineClient>,
+    cancel: CancellationToken,
+}
+
+impl OpenEngineSidecarEngine {
+    pub fn from_env() -> Result<(Self, WorkerConfig), DynamoError> {
+        Self::from_parsed(<Args as clap::Parser>::parse())
+    }
+
+    pub fn from_args(argv: Vec<String>) -> Result<(Self, WorkerConfig), DynamoError> {
+        Self::try_from_args(argv).map_err(SidecarStartupError::into_dynamo)
+    }
+
+    pub fn try_from_args(argv: Vec<String>) -> Result<(Self, WorkerConfig), SidecarStartupError> {
+        let args = <Args as clap::Parser>::try_parse_from(argv)?;
+        Self::from_parsed(args).map_err(Into::into)
+    }
+
+    fn from_parsed(args: Args) -> Result<(Self, WorkerConfig), DynamoError> {
+        if args.sidecar.common.route_to_encoder {
+            return Err(client::invalid_argument(
+                "route-to-encoder is not supported by the OpenEngine sidecar",
+            ));
+        }
+        if args.sidecar.common.enable_rl {
+            return Err(client::invalid_argument(
+                "RL control is not implemented by the TensorRT-LLM OpenEngine server",
+            ));
+        }
+        if args
+            .model_path
+            .as_ref()
+            .is_some_and(|value| value.trim().is_empty())
+        {
+            return Err(client::invalid_argument("model-path must not be empty"));
+        }
+
+        let endpoint = args.sidecar.grpc_endpoint;
+        let transport = args.sidecar.grpc.config();
+        eprintln!(
+            "Discovering OpenEngine metadata from {endpoint}; startup deadline: {:?}",
+            transport.startup_deadline
+        );
+        let discovery = bootstrap_discover(&endpoint, transport, args.model_path)?;
+        let mode = discovery.mode;
+        let engine = Self {
+            endpoint,
+            transport,
+            discovery: discovery.clone(),
+            client: OnceCell::new(),
+            cancel: CancellationToken::new(),
+        };
+        let config = WorkerConfig {
+            namespace: args.sidecar.common.namespace,
+            component: if mode == DisaggregationMode::Aggregated {
+                args.sidecar.common.component
+            } else {
+                mode.discovery_component().to_string()
+            },
+            endpoint: args.sidecar.common.endpoint,
+            endpoint_types: args.sidecar.common.endpoint_types,
+            custom_jinja_template: args.sidecar.common.custom_jinja_template,
+            model_name: discovery.model_source.clone(),
+            served_model_name: Some(discovery.remote_model.clone()),
+            tool_call_parser: args.sidecar.common.dyn_tool_call_parser,
+            reasoning_parser: args.sidecar.common.dyn_reasoning_parser,
+            exclude_tools_when_tool_choice_none: args
+                .sidecar
+                .common
+                .exclude_tools_when_tool_choice_none,
+            enable_kv_routing: false,
+            disaggregation_mode: mode,
+            route_to_encoder: false,
+            enable_rl: false,
+            ..Default::default()
+        };
+        Ok((engine, config))
+    }
+}
+
+#[async_trait]
+impl LLMEngine for OpenEngineSidecarEngine {
+    async fn start(&self, _worker_id: u64) -> Result<EngineConfig, DynamoError> {
+        if self.client.initialized() {
+            return Err(client::engine_shutdown(
+                "OpenEngine sidecar has already started",
+            ));
+        }
+        tracing::info!(
+            endpoint = %self.endpoint,
+            connections = self.transport.connections,
+            mode = %self.discovery.mode,
+            "connecting to OpenEngine gRPC"
+        );
+        let client = OpenEngineClient::connect(&self.endpoint, self.transport).await?;
+        let info = client
+            .server_info(self.transport.connect_attempt_timeout)
+            .await?;
+        let observed =
+            Discovery::from_server_info(info, Some(self.discovery.model_source.clone()))?;
+        self.discovery.ensure_same_server(&observed)?;
+        let connections = client.connection_count();
+        self.client
+            .set(client)
+            .map_err(|_| client::engine_shutdown("OpenEngine sidecar has already started"))?;
+        tracing::info!(
+            endpoint = %self.endpoint,
+            connections,
+            engine = %self.discovery.info.engine_name,
+            model = %self.discovery.remote_model,
+            mode = %self.discovery.mode,
+            "OpenEngine gRPC is ready"
+        );
+        Ok(observed.engine_config())
+    }
+
+    async fn generate(
+        &self,
+        request: PreprocessedRequest,
+        ctx: GenerateContext,
+    ) -> Result<BoxStream<'static, Result<LLMEngineOutput, DynamoError>>, DynamoError> {
+        let client = self
+            .client
+            .get()
+            .ok_or_else(|| client::engine_shutdown("OpenEngine sidecar is not started"))?;
+        let request_id = ctx.id().to_string();
+        let proto_request = convert::build_generate_request(
+            &request,
+            &request_id,
+            &self.discovery.remote_model,
+            self.discovery.mode,
+        )?;
+        let metadata = convert::generate_metadata(&request, ctx.metadata(), self.discovery.mode)?;
+        let mut grpc_request = tonic::Request::new(proto_request);
+        *grpc_request.metadata_mut() = metadata;
+        let mut state = ResponseState::new(self.discovery.mode, request.token_ids.len() as u32);
+        let cancel = self.cancel.clone();
+
+        let stream = tokio::select! {
+            biased;
+            _ = ctx.stopped() => None,
+            _ = cancel.cancelled() => None,
+            result = client.generate(grpc_request) => Some(result?),
+        };
+        let Some(mut stream) = stream else {
+            let output = LLMEngineOutput::cancelled()
+                .with_usage(usage(state.prompt_tokens(), state.completion_tokens()));
+            return Ok(Box::pin(futures::stream::once(async move { Ok(output) })));
+        };
+
+        Ok(Box::pin(async_stream::stream! {
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = ctx.stopped() => {
+                        yield Ok(LLMEngineOutput::cancelled()
+                            .with_usage(usage(state.prompt_tokens(), state.completion_tokens())));
+                        break;
+                    }
+                    _ = cancel.cancelled() => {
+                        yield Ok(LLMEngineOutput::cancelled()
+                            .with_usage(usage(state.prompt_tokens(), state.completion_tokens())));
+                        break;
+                    }
+                    message = stream.message() => {
+                        match message {
+                            Ok(Some(response)) => match state.convert(response, &request_id) {
+                                Ok(Some(output)) => {
+                                    let terminal = output.finish_reason.is_some();
+                                    yield Ok(output);
+                                    if terminal {
+                                        break;
+                                    }
+                                }
+                                Ok(None) => {}
+                                Err(error) => {
+                                    yield Err(error);
+                                    break;
+                                }
+                            },
+                            Ok(None) => {
+                                yield Err(client::protocol_error(
+                                    "Generate ended before a terminal response",
+                                ));
+                                break;
+                            }
+                            Err(status) => {
+                                yield Err(client::status_to_dynamo("Generate stream", status));
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+    }
+
+    async fn cleanup(&self) -> Result<(), DynamoError> {
+        self.cancel.cancel();
+        tracing::info!("OpenEngine sidecar shutdown complete");
+        Ok(())
+    }
+}
+
+fn bootstrap_discover(
+    endpoint: &GrpcEndpoint,
+    transport: GrpcTransportConfig,
+    model_path: Option<String>,
+) -> Result<Discovery, DynamoError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| client::engine_shutdown(format!("bootstrap runtime: {error}")))?;
+    runtime.block_on(async move {
+        let bootstrap_transport = GrpcTransportConfig {
+            connections: NonZeroUsize::new(1).expect("one is non-zero"),
+            ..transport
+        };
+        let client = OpenEngineClient::connect(endpoint, bootstrap_transport).await?;
+        let info = client
+            .server_info(transport.connect_attempt_timeout)
+            .await?;
+        Discovery::from_server_info(info, model_path)
+    })
+}

--- a/lib/sidecar/openengine/src/engine.rs
+++ b/lib/sidecar/openengine/src/engine.rs
@@ -25,17 +25,13 @@ const SCHEMA_REVISION: u32 = 1;
 #[derive(Clone, Debug)]
 struct Discovery {
     info: pb::ServerInfo,
+    model: pb::ModelInfo,
     role: pb::EngineRole,
     mode: DisaggregationMode,
-    model_source: String,
-    remote_model: String,
 }
 
 impl Discovery {
-    fn from_server_info(
-        info: pb::ServerInfo,
-        model_path: Option<String>,
-    ) -> Result<Self, DynamoError> {
+    fn from_responses(info: pb::ServerInfo, model: pb::ModelInfo) -> Result<Self, DynamoError> {
         if info.engine_name.trim().is_empty() {
             return Err(client::protocol_error(
                 "GetServerInfo returned an empty engine_name",
@@ -67,17 +63,7 @@ impl Discovery {
                 ));
             }
         };
-        let [remote_model] = info.supported_models.as_slice() else {
-            return Err(client::protocol_error(format!(
-                "this initial sidecar requires exactly one supported model; server returned {}",
-                info.supported_models.len()
-            )));
-        };
-        if remote_model.trim().is_empty() {
-            return Err(client::protocol_error(
-                "GetServerInfo returned an empty supported model",
-            ));
-        }
+        let advertised_model = advertised_model(&info)?;
         if mode != DisaggregationMode::Aggregated {
             let connector = info.kv_connector.as_ref().ok_or_else(|| {
                 client::protocol_error("disaggregated server omitted kv_connector")
@@ -88,14 +74,43 @@ impl Discovery {
                 ));
             }
         }
-        let model_source = model_path.unwrap_or_else(|| remote_model.clone());
-        if model_source.trim().is_empty() {
-            return Err(client::invalid_argument("model-path must not be empty"));
+        if model.model_id.trim().is_empty() {
+            return Err(client::protocol_error(
+                "GetModelInfo returned an empty model_id",
+            ));
+        }
+        if model.served_model_name.trim().is_empty() {
+            return Err(client::protocol_error(
+                "GetModelInfo returned an empty served_model_name",
+            ));
+        }
+        if model.supports_token_ids_input != Some(true) {
+            return Err(client::protocol_error(
+                "the discovered model does not support token-ID input",
+            ));
+        }
+        if model
+            .served_model_aliases
+            .iter()
+            .any(|alias| alias.trim().is_empty())
+        {
+            return Err(client::protocol_error(
+                "GetModelInfo returned an empty served model alias",
+            ));
+        }
+        if advertised_model != model.served_model_name
+            && !model
+                .served_model_aliases
+                .iter()
+                .any(|alias| alias == advertised_model)
+        {
+            return Err(client::protocol_error(format!(
+                "GetModelInfo did not recognize advertised model `{advertised_model}`"
+            )));
         }
         Ok(Self {
-            remote_model: remote_model.clone(),
-            model_source,
             info,
+            model,
             role,
             mode,
         })
@@ -105,7 +120,9 @@ impl Discovery {
         if self.info.engine_name != observed.info.engine_name
             || self.info.schema_release != observed.info.schema_release
             || self.role != observed.role
-            || self.remote_model != observed.remote_model
+            || self.model.model_id != observed.model.model_id
+            || self.model.served_model_name != observed.model.served_model_name
+            || self.model.served_model_aliases != observed.model.served_model_aliases
         {
             return Err(client::protocol_error(
                 "OpenEngine identity, role, schema, or model changed during startup",
@@ -132,12 +149,12 @@ impl Discovery {
         let capacity = self.info.capacity.as_ref();
         let parallelism = self.info.parallelism.as_ref();
         EngineConfig {
-            model: self.model_source.clone(),
-            served_model_name: Some(self.remote_model.clone()),
-            model_aliases: Vec::new(),
+            model: self.model.model_id.clone(),
+            served_model_name: Some(self.model.served_model_name.clone()),
+            model_aliases: self.model.served_model_aliases.clone(),
             runtime_data,
             llm: Some(LlmRegistration {
-                context_length: None,
+                context_length: self.model.max_context_length,
                 kv_cache_block_size: capacity.and_then(|value| value.kv_block_size),
                 total_kv_blocks: capacity.and_then(|value| value.total_kv_blocks),
                 max_num_seqs: capacity.and_then(|value| value.max_running_requests),
@@ -187,21 +204,13 @@ impl OpenEngineSidecarEngine {
                 "RL control is not implemented by the TensorRT-LLM OpenEngine server",
             ));
         }
-        if args
-            .model_path
-            .as_ref()
-            .is_some_and(|value| value.trim().is_empty())
-        {
-            return Err(client::invalid_argument("model-path must not be empty"));
-        }
-
         let endpoint = args.sidecar.grpc_endpoint;
         let transport = args.sidecar.grpc.config();
         eprintln!(
             "Discovering OpenEngine metadata from {endpoint}; startup deadline: {:?}",
             transport.startup_deadline
         );
-        let discovery = bootstrap_discover(&endpoint, transport, args.model_path)?;
+        let discovery = bootstrap_discover(&endpoint, transport)?;
         let mode = discovery.mode;
         let engine = Self {
             endpoint,
@@ -220,8 +229,8 @@ impl OpenEngineSidecarEngine {
             endpoint: args.sidecar.common.endpoint,
             endpoint_types: args.sidecar.common.endpoint_types,
             custom_jinja_template: args.sidecar.common.custom_jinja_template,
-            model_name: discovery.model_source.clone(),
-            served_model_name: Some(discovery.remote_model.clone()),
+            model_name: discovery.model.model_id.clone(),
+            served_model_name: Some(discovery.model.served_model_name.clone()),
             tool_call_parser: args.sidecar.common.dyn_tool_call_parser,
             reasoning_parser: args.sidecar.common.dyn_reasoning_parser,
             exclude_tools_when_tool_choice_none: args
@@ -253,11 +262,7 @@ impl LLMEngine for OpenEngineSidecarEngine {
             "connecting to OpenEngine gRPC"
         );
         let client = OpenEngineClient::connect(&self.endpoint, self.transport).await?;
-        let info = client
-            .server_info(self.transport.connect_attempt_timeout)
-            .await?;
-        let observed =
-            Discovery::from_server_info(info, Some(self.discovery.model_source.clone()))?;
+        let observed = discover(&client, self.transport.connect_attempt_timeout).await?;
         self.discovery.ensure_same_server(&observed)?;
         let connections = client.connection_count();
         self.client
@@ -267,7 +272,7 @@ impl LLMEngine for OpenEngineSidecarEngine {
             endpoint = %self.endpoint,
             connections,
             engine = %self.discovery.info.engine_name,
-            model = %self.discovery.remote_model,
+            model = %self.discovery.model.served_model_name,
             mode = %self.discovery.mode,
             "OpenEngine gRPC is ready"
         );
@@ -287,7 +292,7 @@ impl LLMEngine for OpenEngineSidecarEngine {
         let proto_request = convert::build_generate_request(
             &request,
             &request_id,
-            &self.discovery.remote_model,
+            &self.discovery.model.served_model_name,
             self.discovery.mode,
         )?;
         let metadata = convert::generate_metadata(&request, ctx.metadata(), self.discovery.mode)?;
@@ -365,7 +370,6 @@ impl LLMEngine for OpenEngineSidecarEngine {
 fn bootstrap_discover(
     endpoint: &GrpcEndpoint,
     transport: GrpcTransportConfig,
-    model_path: Option<String>,
 ) -> Result<Discovery, DynamoError> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -377,9 +381,66 @@ fn bootstrap_discover(
             ..transport
         };
         let client = OpenEngineClient::connect(endpoint, bootstrap_transport).await?;
-        let info = client
-            .server_info(transport.connect_attempt_timeout)
-            .await?;
-        Discovery::from_server_info(info, model_path)
+        discover(&client, transport.connect_attempt_timeout).await
     })
+}
+
+async fn discover(
+    client: &OpenEngineClient,
+    timeout: std::time::Duration,
+) -> Result<Discovery, DynamoError> {
+    let info = client.server_info(timeout).await?;
+    let model_name = advertised_model(&info)?.to_string();
+    let model = client.model_info(&model_name, timeout).await?;
+    Discovery::from_responses(info, model)
+}
+
+fn advertised_model(info: &pb::ServerInfo) -> Result<&str, DynamoError> {
+    let [model] = info.supported_models.as_slice() else {
+        return Err(client::protocol_error(format!(
+            "this initial sidecar requires exactly one supported model; server returned {}",
+            info.supported_models.len()
+        )));
+    };
+    if model.trim().is_empty() {
+        return Err(client::protocol_error(
+            "GetServerInfo returned an empty supported model",
+        ));
+    }
+    Ok(model)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Discovery, OPENENGINE_SCHEMA_RELEASE, SCHEMA_REVISION, pb};
+
+    #[test]
+    fn discovery_preserves_canonical_and_served_model_identity() {
+        let discovery = Discovery::from_responses(
+            pb::ServerInfo {
+                engine_name: "tensorrt_llm".to_string(),
+                engine_role: pb::EngineRole::Aggregated as i32,
+                supported_models: vec!["served-alias".to_string()],
+                schema_revision: SCHEMA_REVISION,
+                minimum_client_revision: SCHEMA_REVISION,
+                schema_release: OPENENGINE_SCHEMA_RELEASE.to_string(),
+                ..Default::default()
+            },
+            pb::ModelInfo {
+                model_id: "org/model".to_string(),
+                served_model_name: "served-alias".to_string(),
+                served_model_aliases: vec!["org/model".to_string()],
+                max_context_length: Some(8192),
+                supports_token_ids_input: Some(true),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let config = discovery.engine_config();
+        assert_eq!(config.model, "org/model");
+        assert_eq!(config.served_model_name.as_deref(), Some("served-alias"));
+        assert_eq!(config.model_aliases, ["org/model"]);
+        assert_eq!(config.llm.unwrap().context_length, Some(8192));
+    }
 }

--- a/lib/sidecar/openengine/src/lib.rs
+++ b/lib/sidecar/openengine/src/lib.rs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Dynamo sidecar for the OpenEngine gRPC contract.
+
+mod args;
+mod client;
+mod convert;
+mod engine;
+mod proto;
+
+pub use engine::OpenEngineSidecarEngine;
+
+/// Immutable OpenEngine schema used to generate this client.
+pub const OPENENGINE_SCHEMA_RELEASE: &str = "768a93c7b44e40f28c692ad0b471a8f2";

--- a/lib/sidecar/openengine/src/main.rs
+++ b/lib/sidecar/openengine/src/main.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+fn main() -> anyhow::Result<()> {
+    let (engine, config) = dynamo_openengine_sidecar::OpenEngineSidecarEngine::from_env()?;
+    dynamo_backend_common::run(Arc::new(engine), config)
+}

--- a/lib/sidecar/openengine/src/proto.rs
+++ b/lib/sidecar/openengine/src/proto.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generated protobuf and gRPC types for OpenEngine v0.1.0.
+
+#![allow(clippy::all)]
+#![allow(missing_docs)]
+
+tonic::include_proto!("openengine.v1");

--- a/lib/sidecar/sglang/README.md
+++ b/lib/sidecar/sglang/README.md
@@ -23,7 +23,7 @@ cargo build --release -p dynamo-sglang-sidecar
 
 There is no published image yet; see
 [Build the image](../README.md#build-the-image), which produces one image
-containing all three sidecar executables. Official packaging is deferred to a
+containing all four sidecar executables. Official packaging is deferred to a
 follow-up.
 
 Use `DYN_SIDECAR_GRPC_ENDPOINT` instead of `--grpc-endpoint` when the endpoint is provided through the environment.
@@ -66,7 +66,7 @@ that colocates the sidecar with an SGLang engine). `deploy/disagg.yaml` runs
 disaggregated prefill/decode with NIXL KV transfer.
 
 There is no published sidecar image yet, so build and push the image from
-`lib/sidecar/Dockerfile`. It contains all three engine-specific sidecar
+`lib/sidecar/Dockerfile`. It contains all four sidecar
 executables; these manifests run `dynamo-sglang-sidecar` as the container
 command.
 

--- a/lib/sidecar/trtllm/README.md
+++ b/lib/sidecar/trtllm/README.md
@@ -69,7 +69,7 @@ provided through the environment.
 sidecar next to a TensorRT-LLM engine and serves `Qwen/Qwen3-0.6B` on one GPU.
 
 There is no published sidecar image yet (see [Packaging](#packaging)), so build
-and push the image from `lib/sidecar/Dockerfile`. It contains all three
+and push the image from `lib/sidecar/Dockerfile`. It contains all four
 engine-specific sidecar executables; this manifest runs `dynamo-trtllm-sidecar`
 as the container command.
 

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -137,7 +137,7 @@ that colocates the sidecar with a vLLM engine). `deploy/disagg.yaml` runs
 disaggregated prefill/decode with NIXL KV transfer.
 
 There is no published sidecar image yet, so build and push the image from
-`lib/sidecar/Dockerfile`. It contains the vLLM, SGLang, and TensorRT-LLM
+`lib/sidecar/Dockerfile`. It contains the OpenEngine, vLLM, SGLang, and TensorRT-LLM
 sidecar executables; these manifests run `dynamo-vllm-sidecar` as the container
 command.
 


### PR DESCRIPTION
## Overview:

Add an initial Rust OpenEngine sidecar compatible with TensorRT-LLM's OpenEngine aggregated and context-first disaggregated server.

## Details:

- Reuse `dynamo_sidecar_common::SidecarArgs`, gRPC connection pooling, and `dynamo_backend_common::run`.
- Call only the two RPCs implemented by the initial TensorRT-LLM server: `GetServerInfo` and streaming `Generate`.
- Discover aggregated, prefill, or decode role from the server and preserve its opaque `KvSessionRef` through Dynamo's prefill/decode handoff.
- Compile the complete OpenEngine v0.1.0 schema pinned to BSR commit `768a93c7b44e40f28c692ad0b471a8f2`.
- Package `dynamo-openengine-sidecar` in the existing CPU-only sidecar image and dispatcher.
- Keep the first integration text-only and single-sequence; unsupported control-plane and generation features are rejected locally.

## Where should the reviewer start?

- `lib/sidecar/openengine/src/engine.rs` for discovery, role registration, and stream lifecycle.
- `lib/sidecar/openengine/src/convert.rs` for request/response conversion and the opaque disaggregation handoff.

## Validation:

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-openengine-sidecar` (1 focused handoff regression test passed)
- `cargo clippy -p dynamo-openengine-sidecar --all-targets -- -D warnings`
- `cargo metadata --locked --format-version 1 --no-deps`
- CODEOWNERS strict validation: 100% explicit coverage
- Vendored protobuf files diff cleanly against OpenEngine v0.1.0

The single new test protects the compatibility-critical opaque `KvSessionRef` round trip without adding broader sidecar tests to CI.

## Related Issues

- Relates to [NVIDIA/TensorRT-LLM#17016](https://github.com/NVIDIA/TensorRT-LLM/issues/17016)
- Depends on [connorcarpenter15/TensorRT-LLM#3](https://github.com/connorcarpenter15/TensorRT-LLM/pull/3)
