### PR TITLE
test(bindings): deflake test_kv_router_propagates_stream_errors (OPS-8410)

### DIFF
--- a/lib/bindings/python/tests/test_kv_router_stream_errors.py
+++ b/lib/bindings/python/tests/test_kv_router_stream_errors.py
@@ -63,6 +63,40 @@ async def error_router_endpoint(temp_file_store):
         worker_runtime.shutdown()
 
 
+async def _drain_once(router, response_buffer_size):
+    stream = await router.generate(
+        [1, 2, 3],
+        "test-model",
+        response_buffer_size=response_buffer_size,
+    )
+    return [response async for response in stream]
+
+
+async def _drain_when_routable(router, response_buffer_size, timeout=10.0):
+    """Drain the router once it has a worker to route to.
+
+    The endpoint fixture waits on discovery, but KvRouter tracks workers on its
+    own background task, so a generate() issued right after construction can lose
+    that race and fail with "no endpoints available to route work" instead of the
+    stream error under test. Retry only that condition; every other exception --
+    including the intentional failure this test asserts on -- propagates
+    immediately, so a genuine regression still fails the test.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        try:
+            return await _drain_once(router, response_buffer_size)
+        except Exception as exc:
+            if "no endpoints available to route work" not in str(exc):
+                raise
+            if loop.time() >= deadline:
+                raise AssertionError(
+                    f"KvRouter never discovered a worker within {timeout}s: {exc}"
+                ) from exc
+            await asyncio.sleep(0.02)
+
+
 @pytest.mark.asyncio
 @pytest.mark.timeout(30)
 @pytest.mark.parametrize("response_buffer_size", [0, 100])
@@ -76,9 +110,4 @@ async def test_kv_router_propagates_stream_errors(
     )
 
     with pytest.raises(ValueError, match="intentional KV-router failure"):
-        stream = await router.generate(
-            [1, 2, 3],
-            "test-model",
-            response_buffer_size=response_buffer_size,
-        )
-        _ = [response async for response in stream]
+        await _drain_when_routable(router, response_buffer_size)

--- a/lib/bindings/python/tests/test_kv_router_stream_errors.py
+++ b/lib/bindings/python/tests/test_kv_router_stream_errors.py
@@ -30,7 +30,14 @@ async def _generate_error(_request, _context=None):
 
 
 @pytest.fixture
-async def error_router_endpoint(temp_file_store):
+async def error_router_endpoint(temp_file_store, monkeypatch):
+    # KvRouter tracks workers on a background task, so a generate() issued right
+    # after construction can beat that set being populated and fail with "no
+    # endpoints available to route work" instead of the stream error under test.
+    # The router's startup gate exists for exactly this but defaults to 0
+    # (DYN_ROUTER_MIN_INITIAL_WORKERS); require one worker, as
+    # tests/router/test_kv_router_gil_release.py already does.
+    monkeypatch.setenv("DYN_ROUTER_MIN_INITIAL_WORKERS", "1")
     endpoint_path = f"error-router-{uuid.uuid4().hex}.worker.generate"
     loop = asyncio.get_running_loop()
     worker_runtime = DistributedRuntime(loop, "file", "tcp")
@@ -63,40 +70,6 @@ async def error_router_endpoint(temp_file_store):
         worker_runtime.shutdown()
 
 
-async def _drain_once(router, response_buffer_size):
-    stream = await router.generate(
-        [1, 2, 3],
-        "test-model",
-        response_buffer_size=response_buffer_size,
-    )
-    return [response async for response in stream]
-
-
-async def _drain_when_routable(router, response_buffer_size, timeout=10.0):
-    """Drain the router once it has a worker to route to.
-
-    The endpoint fixture waits on discovery, but KvRouter tracks workers on its
-    own background task, so a generate() issued right after construction can lose
-    that race and fail with "no endpoints available to route work" instead of the
-    stream error under test. Retry only that condition; every other exception --
-    including the intentional failure this test asserts on -- propagates
-    immediately, so a genuine regression still fails the test.
-    """
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout
-    while True:
-        try:
-            return await _drain_once(router, response_buffer_size)
-        except Exception as exc:
-            if "no endpoints available to route work" not in str(exc):
-                raise
-            if loop.time() >= deadline:
-                raise AssertionError(
-                    f"KvRouter never discovered a worker within {timeout}s: {exc}"
-                ) from exc
-            await asyncio.sleep(0.02)
-
-
 @pytest.mark.asyncio
 @pytest.mark.timeout(30)
 @pytest.mark.parametrize("response_buffer_size", [0, 100])
@@ -110,4 +83,9 @@ async def test_kv_router_propagates_stream_errors(
     )
 
     with pytest.raises(ValueError, match="intentional KV-router failure"):
-        await _drain_when_routable(router, response_buffer_size)
+        stream = await router.generate(
+            [1, 2, 3],
+            "test-model",
+            response_buffer_size=response_buffer_size,
+        )
+        _ = [response async for response in stream]


### PR DESCRIPTION
## Summary

`test_kv_router_propagates_stream_errors` fails intermittently in `dynamo-runtime / test / sequential cuda13.0` (seen on arm64, e.g. [run 33193467369](https://github.com/ai-dynamo/dynamo/actions/runs/33193467369)):

```
lib/bindings/python/tests/test_kv_router_stream_errors.py:79: in test_kv_router_propagates_stream_errors
    stream = await router.generate(
E   Exception: no endpoints available to route work
```

The test synchronises on the wrong readiness signal. Its fixture waits for **discovery**:

```python
instances = await client.wait_for_instances()
assert len(instances) == 1
```

but `KvRouter` populates its own scheduler worker-set on a background task, and the test calls `generate()` immediately after constructing the router. When the router loses that race it raises `Exception("no endpoints available to route work")` (`lib/kv-router/src/scheduling/types.rs:69`) rather than the expected `ValueError("intentional KV-router failure")`, so `pytest.raises` doesn't match.

The CI log has the two events 188 µs apart, in the wrong order:

```
17:18:01.913633  wait_for_instances: Found 1 instance(s) for endpoint: .../worker/generate
17:18:01.917042  WARN scheduling failed: no endpoints available to route work
17:18:01.917230  WARN Adding worker WorkerWithDpRank { worker_id: 17344006804092454523 }
```

### What this changes

Set `DYN_ROUTER_MIN_INITIAL_WORKERS=1` on the fixture via `monkeypatch`. That is the router's own startup gate (`lib/llm/src/kv_router.rs:720`), which waits for the worker-set to populate before the constructor returns. `tests/router/test_kv_router_gil_release.py` already does exactly this.

Test-file only: no Rust, no bindings, no production code. `monkeypatch` scopes the variable per-test, verified not to leak to the parent process.

### Why not a retry loop

The first revision of this PR wrapped `generate()` in a bounded retry that ignored `"no endpoints available to route work"`. Both approaches measure identically (below), so this picks the smaller one — 8 lines in the fixture instead of a 35-line helper, using a documented knob rather than matching on the text of an error message.

## Validation

60 runs per variant **inside the dynamo-runtime CI image the failing job used** (`b355f4eb59…-dynamo-runtime-test`):

| variant | passed | failed | timeouts | `no endpoints` |
|---|---|---|---|---|
| unpatched (main) | 24 | **36** | 0 | 36 |
| retry helper | **60** | 0 | 0 | 0 |
| **startup gate (this PR)** | **60** | **0** | **0** | **0** |

Repeated in an sglang runtime image: gate 60/60, retry 59/60, unpatched 29/60. Combined across both images: **gate 120/120, retry 119/120, unpatched 53/120**.

`pre-commit run --files <changed>` passes.

### A correction worth recording

An earlier single-arm run in the sglang image showed 4/100 `Timeout (>30.0s)` failures with the gate, and I read that as the gate converting fast failures into hangs. Running all three variants at equal scale disproves it: those timeouts appear at 1/60 in the **unpatched** and **retry** variants too, and the dynamo-runtime image produces **none at all** in any variant. They were noise in that image, not an effect of the gate.

## Not the root fix

`KvRouter.generate()` hard-failing when its worker-set hasn't populated — while discovery already reports the worker — is arguably a router-side problem, and every caller currently has to work around it. The standalone `dynamo.router` is exposed to the same race in production and had no flag to raise the gate; that is addressed separately in #13977. A router-side fix would touch `lib/kv-router/src/scheduling/` and is deliberately out of scope here.

Internal tracking: OPS-8410. Related: OPS-8411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
