### PR TITLE
fix(frontend): stop tool-call arguments arriving in one frame at the end

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -1488,8 +1488,7 @@ class StreamingPostProcessor:
                     choice = self._build_choice(output, delta)
             elif delta_message.tool_calls:
                 if self.in_progress_tool_calls:
-                    # Emit every parser delta immediately: inside a long string
-                    # argument the parser never falls silent. See https://github.com/ai-dynamo/dynamo/issues/13821
+                    # Emit each parser delta instead of waiting for a quiet chunk.
                     choice = self._emit_tool_calls_choice(output)
             elif self.in_progress_tool_calls:
                 choice = self._emit_tool_calls_choice(output)

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -1488,12 +1488,8 @@ class StreamingPostProcessor:
                     choice = self._build_choice(output, delta)
             elif delta_message.tool_calls:
                 if self.in_progress_tool_calls:
-                    # Emit every parser delta immediately, the same way plain
-                    # content streams. Inside a long string argument the parser
-                    # produces a delta for nearly every token and never falls
-                    # silent, so gating this on a quiet chunk or on
-                    # finish_reason withholds the whole argument until the turn
-                    # ends. See https://github.com/ai-dynamo/dynamo/issues/13821
+                    # Emit every parser delta immediately: inside a long string
+                    # argument the parser never falls silent. See https://github.com/ai-dynamo/dynamo/issues/13821
                     choice = self._emit_tool_calls_choice(output)
             elif self.in_progress_tool_calls:
                 choice = self._emit_tool_calls_choice(output)

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -1487,10 +1487,13 @@ class StreamingPostProcessor:
                 if len(delta) > 1:
                     choice = self._build_choice(output, delta)
             elif delta_message.tool_calls:
-                if output.finish_reason and self.in_progress_tool_calls:
-                    # Tool calls and finish_reason arrived in the same chunk.
-                    # Emit now — there will be no subsequent process_output call
-                    # to drain the buffer.
+                if self.in_progress_tool_calls:
+                    # Emit every parser delta immediately, the same way plain
+                    # content streams. Inside a long string argument the parser
+                    # produces a delta for nearly every token and never falls
+                    # silent, so gating this on a quiet chunk or on
+                    # finish_reason withholds the whole argument until the turn
+                    # ends. See https://github.com/ai-dynamo/dynamo/issues/13821
                     choice = self._emit_tool_calls_choice(output)
             elif self.in_progress_tool_calls:
                 choice = self._emit_tool_calls_choice(output)

--- a/tests/frontend/test_prepost.py
+++ b/tests/frontend/test_prepost.py
@@ -2079,6 +2079,150 @@ def test_streaming_parallel_tool_calls_no_think(
 
 
 # ---------------------------------------------------------------------------
+# Cadence of tool-call argument deltas.
+# See https://github.com/ai-dynamo/dynamo/issues/13821
+#
+# The vLLM streaming tool parser produces an argument delta for nearly every
+# token, so the chunks inside a long string value are *consecutive*
+# tool-call-only deltas with no quiet chunk between them. That is the shape
+# that starved the old flush condition, which published the accumulator only
+# when the parser fell silent or at finish_reason.
+#
+# Token IDs are arbitrary non-special ints — the hermes parser operates on the
+# text attribute, not decoded tokens.
+# ---------------------------------------------------------------------------
+_LONG_ARGUMENT_FRAGMENTS = [
+    "James",
+    " Joyce",
+    " Dubliners",
+    " Ulysses",
+    " Finnegans",
+    " Wake",
+    " Portrait",
+    " of",
+    " the",
+    " Artist",
+]
+
+_LONG_ARGUMENT_CHUNK_TEXTS = [
+    '<tool_call>\n{"name": "search_gutenberg_books", '
+    '"arguments": {"search_terms": ["',
+    *_LONG_ARGUMENT_FRAGMENTS,
+    '"]}}\n</tool_call>',
+]
+
+OUTPUTS_LONG_STRING_ARGUMENT = [
+    CompletionOutput(
+        index=0,
+        text=text,
+        token_ids=list(range(1000 + i * 4, 1000 + i * 4 + 4)),
+        cumulative_logprob=None,
+        logprobs=None,
+        finish_reason=("stop" if i == len(_LONG_ARGUMENT_CHUNK_TEXTS) - 1 else None),
+    )
+    for i, text in enumerate(_LONG_ARGUMENT_CHUNK_TEXTS)
+]
+
+
+@pytest.mark.vllm
+def test_streaming_tool_call_arguments_are_not_withheld(
+    tokenizer, request_for_sampling, sampling_params
+):
+    """Every parser tool-call delta must reach the client as its own frame.
+
+    See https://github.com/ai-dynamo/dynamo/issues/13821
+
+    Pre-fix, ``StreamingPostProcessor`` published ``in_progress_tool_calls``
+    only on a chunk where the parser produced nothing, or at ``finish_reason``.
+    Inside a long string argument the parser never falls silent, so every chunk
+    below except the last returned ``None`` and the whole argument arrived in a
+    single terminal frame after an arbitrarily long silence.
+    """
+    tool_parser = Hermes2ProToolParser(tokenizer)
+    proc = StreamingPostProcessor(
+        tokenizer=tokenizer,
+        request_for_sampling=request_for_sampling,
+        sampling_params=sampling_params,
+        prompt_token_ids=PROMPT_TOKEN_IDS,
+        tool_parser=tool_parser,
+        reasoning_parser_class=_resolve_qwen3_reasoning_parser_class(),
+        chat_template_kwargs={"enable_thinking": False},
+    )
+
+    outputs = OUTPUTS_LONG_STRING_ARGUMENT
+    results = [proc.process_output(output) for output in outputs]
+
+    def _tool_calls_of(result):
+        if result is None:
+            return None
+        return result.get("delta", {}).get("tool_calls")
+
+    # -- 1. no tool-call-only chunk is withheld -----------------------------
+    # These are the chunks the parser fed a delta for while finish_reason was
+    # still None; pre-fix every one of them returned None.
+    withheld = [
+        i
+        for i, (output, result) in enumerate(zip(outputs, results))
+        if output.finish_reason is None and not _tool_calls_of(result)
+    ]
+    assert not withheld, (
+        f"process_output withheld a tool_call delta on chunk(s) {withheld} of "
+        f"{len(outputs)}. The parser produced an argument delta for each, so "
+        "each must be published immediately rather than held until the parser "
+        "falls silent or finish_reason arrives."
+    )
+
+    # -- 2. cadence tracks the parser, it does not collapse to one frame ----
+    frames = [r for r in results if _tool_calls_of(r)]
+    assert len(frames) > 1, (
+        "The whole argument arrived in a single frame; argument deltas must "
+        "stream the way plain content does."
+    )
+    assert len(frames) == len(outputs), (
+        f"Expected one tool_call frame per parser delta ({len(outputs)}); got "
+        f"{len(frames)}."
+    )
+
+    # -- 3. cadence changed, content did not ---------------------------------
+    tool_calls = _collect_tool_calls([r for r in results if r is not None])
+    assert len(tool_calls) == 1
+    assert json.loads(tool_calls[0]["function"]["arguments"]) == {
+        "search_terms": ["".join(_LONG_ARGUMENT_FRAGMENTS)]
+    }
+
+    # -- 4. OpenAI delta semantics survive the extra frames ------------------
+    # id, type and function.name belong on the first frame only; every later
+    # frame carries index plus an arguments fragment.
+    id_frames = [
+        i for i, r in enumerate(frames) if r["delta"]["tool_calls"][0].get("id")
+    ]
+    type_frames = [
+        i for i, r in enumerate(frames) if r["delta"]["tool_calls"][0].get("type")
+    ]
+    name_frames = [
+        i
+        for i, r in enumerate(frames)
+        if r["delta"]["tool_calls"][0].get("function", {}).get("name")
+    ]
+    assert id_frames == [0], f"'id' must appear on exactly one frame; got {id_frames}"
+    assert type_frames == [
+        0
+    ], f"'type' must appear on exactly one frame; got {type_frames}"
+    assert name_frames == [
+        0
+    ], f"'function.name' must appear on exactly one frame; got {name_frames}"
+
+    # -- 5. finish_reason is still remapped exactly once ---------------------
+    # See https://github.com/ai-dynamo/dynamo/issues/8636
+    finish_reasons = [
+        r["finish_reason"] for r in results if r and r.get("finish_reason")
+    ]
+    assert finish_reasons == [
+        "tool_calls"
+    ], f"Expected finish_reason=['tool_calls']; got {finish_reasons}"
+
+
+# ---------------------------------------------------------------------------
 # Reasoning-parser adjust_request wiring
 # ---------------------------------------------------------------------------
 @pytest.fixture

--- a/tests/frontend/test_prepost.py
+++ b/tests/frontend/test_prepost.py
@@ -2114,6 +2114,7 @@ def _long_string_argument_outputs():
         for i, text in enumerate(_LONG_ARGUMENT_CHUNK_TEXTS)
     ]
 
+
 def test_streaming_tool_call_arguments_are_not_withheld(
     tokenizer, request_for_sampling, sampling_params
 ):

--- a/tests/frontend/test_prepost.py
+++ b/tests/frontend/test_prepost.py
@@ -2078,7 +2078,7 @@ def test_streaming_parallel_tool_calls_no_think(
     ], f"Expected finish_reason=['tool_calls']; got {finish_reasons}"
 
 
-_LONG_ARGUMENT_FRAGMENTS = [
+_LONG_ARGUMENT_FRAGMENTS = (
     "James",
     " Joyce",
     " Dubliners",
@@ -2089,26 +2089,29 @@ _LONG_ARGUMENT_FRAGMENTS = [
     " of",
     " the",
     " Artist",
-]
+)
 
-_LONG_ARGUMENT_CHUNK_TEXTS = [
+_LONG_ARGUMENT_CHUNK_TEXTS = (
     '<tool_call>\n{"name": "search_gutenberg_books", '
     '"arguments": {"search_terms": ["',
     *_LONG_ARGUMENT_FRAGMENTS,
     '"]}}\n</tool_call>',
-]
+)
 
-OUTPUTS_LONG_STRING_ARGUMENT = [
-    CompletionOutput(
-        index=0,
-        text=text,
-        token_ids=list(range(1000 + i * 4, 1000 + i * 4 + 4)),
-        cumulative_logprob=None,
-        logprobs=None,
-        finish_reason=("stop" if i == len(_LONG_ARGUMENT_CHUNK_TEXTS) - 1 else None),
-    )
-    for i, text in enumerate(_LONG_ARGUMENT_CHUNK_TEXTS)
-]
+def _long_string_argument_outputs():
+    return [
+        CompletionOutput(
+            index=0,
+            text=text,
+            token_ids=list(range(1000 + i * 4, 1000 + i * 4 + 4)),
+            cumulative_logprob=None,
+            logprobs=None,
+            finish_reason=(
+                "stop" if i == len(_LONG_ARGUMENT_CHUNK_TEXTS) - 1 else None
+            ),
+        )
+        for i, text in enumerate(_LONG_ARGUMENT_CHUNK_TEXTS)
+    ]
 
 
 @pytest.mark.vllm
@@ -2127,7 +2130,7 @@ def test_streaming_tool_call_arguments_are_not_withheld(
         chat_template_kwargs={"enable_thinking": False},
     )
 
-    outputs = OUTPUTS_LONG_STRING_ARGUMENT
+    outputs = _long_string_argument_outputs()
     results = [proc.process_output(output) for output in outputs]
 
     def _tool_calls_of(result):

--- a/tests/frontend/test_prepost.py
+++ b/tests/frontend/test_prepost.py
@@ -2114,7 +2114,11 @@ def _long_string_argument_outputs():
     ]
 
 
+@pytest.mark.pre_merge
+@pytest.mark.gpu_0
+@pytest.mark.unit
 @pytest.mark.vllm
+@pytest.mark.core
 def test_streaming_tool_call_arguments_are_not_withheld(
     tokenizer, request_for_sampling, sampling_params
 ):

--- a/tests/frontend/test_prepost.py
+++ b/tests/frontend/test_prepost.py
@@ -2098,6 +2098,7 @@ _LONG_ARGUMENT_CHUNK_TEXTS = (
     '"]}}\n</tool_call>',
 )
 
+
 def _long_string_argument_outputs():
     return [
         CompletionOutput(
@@ -2113,12 +2114,6 @@ def _long_string_argument_outputs():
         for i, text in enumerate(_LONG_ARGUMENT_CHUNK_TEXTS)
     ]
 
-
-@pytest.mark.pre_merge
-@pytest.mark.gpu_0
-@pytest.mark.unit
-@pytest.mark.vllm
-@pytest.mark.core
 def test_streaming_tool_call_arguments_are_not_withheld(
     tokenizer, request_for_sampling, sampling_params
 ):

--- a/tests/frontend/test_prepost.py
+++ b/tests/frontend/test_prepost.py
@@ -2078,8 +2078,6 @@ def test_streaming_parallel_tool_calls_no_think(
     ], f"Expected finish_reason=['tool_calls']; got {finish_reasons}"
 
 
-# Consecutive tool-call-only parser deltas with no quiet chunk between them.
-# Token IDs are arbitrary; the hermes parser reads text, not decoded tokens.
 _LONG_ARGUMENT_FRAGMENTS = [
     "James",
     " Joyce",
@@ -2117,16 +2115,7 @@ OUTPUTS_LONG_STRING_ARGUMENT = [
 def test_streaming_tool_call_arguments_are_not_withheld(
     tokenizer, request_for_sampling, sampling_params
 ):
-    """Every parser tool-call delta must reach the client as its own frame.
-
-    See https://github.com/ai-dynamo/dynamo/issues/13821
-
-    Pre-fix, ``StreamingPostProcessor`` published ``in_progress_tool_calls``
-    only on a chunk where the parser produced nothing, or at ``finish_reason``.
-    Inside a long string argument the parser never falls silent, so every chunk
-    below except the last returned ``None`` and the whole argument arrived in a
-    single terminal frame after an arbitrarily long silence.
-    """
+    """Stream every tool-call argument delta in its own frame."""
     tool_parser = Hermes2ProToolParser(tokenizer)
     proc = StreamingPostProcessor(
         tokenizer=tokenizer,
@@ -2146,7 +2135,6 @@ def test_streaming_tool_call_arguments_are_not_withheld(
             return None
         return result.get("delta", {}).get("tool_calls")
 
-    # -- 1. no tool-call-only chunk is withheld -----------------------------
     withheld = [
         i
         for i, (output, result) in enumerate(zip(outputs, results))
@@ -2159,7 +2147,6 @@ def test_streaming_tool_call_arguments_are_not_withheld(
         "falls silent or finish_reason arrives."
     )
 
-    # -- 2. cadence tracks the parser, it does not collapse to one frame ----
     frames = [r for r in results if _tool_calls_of(r)]
     assert len(frames) > 1, (
         "The whole argument arrived in a single frame; argument deltas must "
@@ -2170,15 +2157,12 @@ def test_streaming_tool_call_arguments_are_not_withheld(
         f"{len(frames)}."
     )
 
-    # -- 3. cadence changed, content did not ---------------------------------
     tool_calls = _collect_tool_calls([r for r in results if r is not None])
     assert len(tool_calls) == 1
     assert json.loads(tool_calls[0]["function"]["arguments"]) == {
         "search_terms": ["".join(_LONG_ARGUMENT_FRAGMENTS)]
     }
 
-    # -- 4. OpenAI delta semantics survive the extra frames ------------------
-    # id, type and function.name belong on the first frame only.
     id_frames = [
         i for i, r in enumerate(frames) if r["delta"]["tool_calls"][0].get("id")
     ]
@@ -2198,8 +2182,6 @@ def test_streaming_tool_call_arguments_are_not_withheld(
         0
     ], f"'function.name' must appear on exactly one frame; got {name_frames}"
 
-    # -- 5. finish_reason is still remapped exactly once ---------------------
-    # See https://github.com/ai-dynamo/dynamo/issues/8636
     finish_reasons = [
         r["finish_reason"] for r in results if r and r.get("finish_reason")
     ]

--- a/tests/frontend/test_prepost.py
+++ b/tests/frontend/test_prepost.py
@@ -2078,19 +2078,8 @@ def test_streaming_parallel_tool_calls_no_think(
     ], f"Expected finish_reason=['tool_calls']; got {finish_reasons}"
 
 
-# ---------------------------------------------------------------------------
-# Cadence of tool-call argument deltas.
-# See https://github.com/ai-dynamo/dynamo/issues/13821
-#
-# The vLLM streaming tool parser produces an argument delta for nearly every
-# token, so the chunks inside a long string value are *consecutive*
-# tool-call-only deltas with no quiet chunk between them. That is the shape
-# that starved the old flush condition, which published the accumulator only
-# when the parser fell silent or at finish_reason.
-#
-# Token IDs are arbitrary non-special ints — the hermes parser operates on the
-# text attribute, not decoded tokens.
-# ---------------------------------------------------------------------------
+# Consecutive tool-call-only parser deltas with no quiet chunk between them.
+# Token IDs are arbitrary; the hermes parser reads text, not decoded tokens.
 _LONG_ARGUMENT_FRAGMENTS = [
     "James",
     " Joyce",
@@ -2158,8 +2147,6 @@ def test_streaming_tool_call_arguments_are_not_withheld(
         return result.get("delta", {}).get("tool_calls")
 
     # -- 1. no tool-call-only chunk is withheld -----------------------------
-    # These are the chunks the parser fed a delta for while finish_reason was
-    # still None; pre-fix every one of them returned None.
     withheld = [
         i
         for i, (output, result) in enumerate(zip(outputs, results))
@@ -2191,8 +2178,7 @@ def test_streaming_tool_call_arguments_are_not_withheld(
     }
 
     # -- 4. OpenAI delta semantics survive the extra frames ------------------
-    # id, type and function.name belong on the first frame only; every later
-    # frame carries index plus an arguments fragment.
+    # id, type and function.name belong on the first frame only.
     id_frames = [
         i for i, r in enumerate(frames) if r["delta"]["tool_calls"][0].get("id")
     ]


### PR DESCRIPTION
## Summary

Streaming vLLM tool-call deltas were buffered until a later quiet chunk, so consecutive argument-only deltas could be withheld and then delivered together at the end of a completion.

The frontend now emits pending tool-call deltas on each parser delta. Tool-call metadata remains on the delta that supplied it, argument fragments retain parser order and can be reconstructed by call index, and finish-reason remapping remains intact.

## Limits

This changes visible SSE frame cadence: consumers that assumed one tool-call frame per completion now receive the provider's incremental frames. The change is limited to the affected vLLM preprocessing path.

## Validation

- Ran `git diff --check` for the PR range.
- Tests, builds, benchmarks, and hooks were not run by this nursery pass.

## Related Issues

- Closes #13821