### PR TITLE
feat: expose model readiness metric

### DIFF
--- a/docs/fern/pages/reference/observability/metrics-catalog.mdx
+++ b/docs/fern/pages/reference/observability/metrics-catalog.mdx
@@ -171,9 +171,15 @@ Counters for requests that end early: [cancellations](../../developer-guide/know
   Last observed inter-token latency per worker, in seconds.
 </ParamField>
 
-### Model configuration metrics
+### Model metrics
 
-`dynamo_frontend_model_*` gauges are populated from worker backend registration and all carry a `model` label. When multiple workers register the same model name, only the first instance's configuration is recorded.
+All `dynamo_frontend_model_*` gauges carry a `model` label.
+
+<ParamField path="dynamo_frontend_model_ready" type="gauge">
+  Whether the frontend can currently route at least one inference request for the model. A value of `1` means at least one complete serving topology with a live worker and serving engine is available; `0` means the model is registered but not currently routable. The frontend evaluates this gauge from its live routing catalog at scrape time, so worker registration and removal are reflected in the next scrape.
+</ParamField>
+
+The remaining model gauges are populated from worker backend registration. When multiple workers register the same model name, only the first instance's configuration is recorded.
 
 <ParamField path="dynamo_frontend_model_total_kv_blocks" type="gauge">
   Total KV blocks available for a worker serving the model.

--- a/docs/fern/pages/reference/observability/metrics-catalog.mdx
+++ b/docs/fern/pages/reference/observability/metrics-catalog.mdx
@@ -16,7 +16,7 @@ The `type` on each field below is a [Prometheus metric type](https://prometheus.
 - **histogram** — samples observations into configurable buckets and exposes `_bucket`, `_sum`, and `_count` series, e.g. request duration. Labeled histograms/counters/gauges register a metric *family*, not one series.
 
 <Info>
-  Labeled metrics (`HistogramVec`, `CounterVec`, `GaugeVec`) register a metric *family*, not individual time series. A series for a given label combination appears at `/metrics` only after the first request that populates it. A freshly-started process therefore shows empty families until the first matching request — this is expected Prometheus client behavior, not a missing metric.
+  Labeled metrics (`HistogramVec`, `CounterVec`, `GaugeVec`) register a metric *family*, not individual time series. For request-populated metrics, a series for a given label combination appears at `/metrics` only after the first matching request. Other families create or remove series from runtime state; their entries below document those semantics.
 </Info>
 
 ## Where each family is exposed
@@ -176,7 +176,7 @@ Counters for requests that end early: [cancellations](../../developer-guide/know
 All `dynamo_frontend_model_*` gauges carry a `model` label.
 
 <ParamField path="dynamo_frontend_model_ready" type="gauge">
-  Whether the frontend can currently route at least one inference request for the model. A value of `1` means at least one complete serving topology with a live worker and serving engine is available; `0` means the model is registered but not currently routable. The frontend evaluates this gauge from its live routing catalog at scrape time, so worker registration and removal are reflected in the next scrape.
+  Whether the frontend can currently route at least one inference request for the model. A value of `1` means at least one complete serving topology with a live worker and serving engine is available; `0` means the model is registered but not currently routable. The frontend evaluates this gauge from its live routing catalog at scrape time, so worker registration and removal are reflected in the next scrape. Unlike request-populated metrics, the series appears when the model registers without requiring an inference request. The series is absent while the model is not registered, and the entire family is absent when no models are registered. Detect this state with `absent(dynamo_frontend_model_ready{model="<model>"})`; a `== 0` comparison does not match an absent series.
 </ParamField>
 
 The remaining model gauges are populated from worker backend registration. When multiple workers register the same model name, only the first instance's configuration is recorded.

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -91,6 +91,8 @@ class frontend_service:
 
     # Environment variable that overrides the default metric prefix
     METRICS_PREFIX_ENV = "DYN_METRICS_PREFIX"
+    # Whether the frontend can route at least one inference request for a model
+    MODEL_READY = "model_ready"
     # Total number of LLM requests processed
     REQUESTS_TOTAL = "requests_total"
     # Total number of LLM requests accepted by the frontend handler

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -1031,6 +1031,22 @@ impl ModelManager {
             .is_some_and(|m| m.is_ready_to_serve())
     }
 
+    /// Snapshot the serving readiness of every registered model.
+    ///
+    /// Each value is derived from [`Model::is_ready_to_serve`], the same
+    /// selection gate used by request routing and KServe model readiness.
+    /// Results are sorted by model name so scrape output is deterministic.
+    pub(crate) fn registered_model_readiness(&self) -> Vec<(String, bool)> {
+        let catalog = self.catalog.load();
+        let mut readiness = catalog
+            .models
+            .iter()
+            .map(|(name, model)| (name.clone(), model.is_ready_to_serve()))
+            .collect::<Vec<_>>();
+        readiness.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+        readiness
+    }
+
     /// Whether any registered model can serve at least one inference request
     /// right now. See [`Model::is_ready_to_serve`].
     pub fn has_any_ready_model(&self) -> bool {

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -16,6 +16,8 @@ use dynamo_runtime::{
 };
 use prometheus::{
     Encoder, GaugeVec, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts,
+    core::{Collector, Desc},
+    proto::{Gauge, LabelPair, Metric, MetricFamily, MetricType},
 };
 use serde::Serialize;
 use std::{
@@ -23,6 +25,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::discovery::ModelManager;
 use crate::local_model::runtime_config::ModelRuntimeConfig;
 use crate::model_card::ModelDeploymentCard;
 use crate::protocols::{
@@ -68,6 +71,80 @@ use super::RouteDoc;
 pub use crate::discovery::{WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL};
 const UNSET_DP_RANK_LABEL: &str = "none";
 const ITL_LOCAL_FLUSH_TOKENS: u64 = 64;
+
+const MODEL_READY_HELP: &str = "Whether the frontend can route at least one inference request for the model (1 = ready, 0 = not ready)";
+
+fn model_ready_metric_name() -> String {
+    format!(
+        "{}_{}",
+        name_prefix::FRONTEND,
+        frontend_service::MODEL_READY
+    )
+}
+
+/// Collects current model readiness directly from the frontend's routing catalog.
+///
+/// This is evaluated at scrape time so worker registration and removal are
+/// reflected without maintaining a second, potentially stale readiness state.
+struct ModelReadyCollector {
+    manager: Arc<ModelManager>,
+    desc: Desc,
+}
+
+impl ModelReadyCollector {
+    fn new(manager: Arc<ModelManager>) -> Result<Self, prometheus::Error> {
+        let desc = Desc::new(
+            model_ready_metric_name(),
+            MODEL_READY_HELP.to_string(),
+            vec!["model".to_string()],
+            Default::default(),
+        )?;
+        Ok(Self { manager, desc })
+    }
+}
+
+impl Collector for ModelReadyCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        vec![&self.desc]
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        let readiness = self.manager.registered_model_readiness();
+        if readiness.is_empty() {
+            return Vec::new();
+        }
+
+        let mut metrics = Vec::with_capacity(readiness.len());
+        for (model, ready) in readiness {
+            let mut model_label = LabelPair::default();
+            model_label.set_name("model".to_string());
+            model_label.set_value(model);
+
+            let mut gauge = Gauge::default();
+            gauge.set_value(if ready { 1.0 } else { 0.0 });
+
+            let mut metric = Metric::default();
+            metric.set_label(vec![model_label]);
+            metric.set_gauge(gauge);
+            metrics.push(metric);
+        }
+
+        let mut family = MetricFamily::default();
+        family.set_name(model_ready_metric_name());
+        family.set_help(MODEL_READY_HELP.to_string());
+        family.set_field_type(MetricType::GAUGE);
+        family.set_metric(metrics);
+        vec![family]
+    }
+}
+
+/// Register the scrape-time model readiness collector with the frontend registry.
+pub fn register_model_ready_metric(
+    registry: &Registry,
+    manager: Arc<ModelManager>,
+) -> Result<(), prometheus::Error> {
+    registry.register(Box::new(ModelReadyCollector::new(manager)?))
+}
 
 /// Global Prometheus gauge for last observed TTFT per worker (in seconds)
 /// Labels: worker_id, dp_rank, worker_type
@@ -2283,6 +2360,52 @@ async fn handler_metrics(State(state): State<Arc<MetricsHandlerState>>) -> impl 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn model_ready_value(registry: &Registry, model: &str) -> Option<f64> {
+        registry
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == model_ready_metric_name())?
+            .get_metric()
+            .iter()
+            .find(|metric| {
+                metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "model" && label.value() == model)
+            })
+            .map(|metric| metric.get_gauge().value())
+    }
+
+    #[test]
+    fn model_ready_metric_tracks_live_routing_catalog() {
+        let manager = Arc::new(ModelManager::new());
+        let registry = Registry::new();
+        register_model_ready_metric(&registry, manager.clone()).unwrap();
+
+        assert_eq!(model_ready_value(&registry, "test-model"), None);
+
+        let mut card = ModelDeploymentCard::default();
+        card.worker_type = Some(crate::worker_type::WorkerType::Aggregated);
+        let mut worker_set = crate::discovery::WorkerSet::new(
+            "watched".to_string(),
+            "watched-mdc".to_string(),
+            card,
+        );
+        let (worker_tx, worker_rx) = tokio::sync::watch::channel(Vec::new());
+        worker_set.set_instance_watcher(worker_rx);
+        worker_set.chat_engine = Some(Arc::new(crate::engines::StreamingEngineAdapter::new(
+            crate::engines::make_echo_engine(),
+        )));
+        assert!(manager.add_worker_set("test-model", "watched", worker_set));
+        assert_eq!(model_ready_value(&registry, "test-model"), Some(0.0));
+
+        worker_tx.send(vec![1]).unwrap();
+        assert_eq!(model_ready_value(&registry, "test-model"), Some(1.0));
+
+        worker_tx.send(Vec::new()).unwrap();
+        assert_eq!(model_ready_value(&registry, "test-model"), Some(0.0));
+    }
 
     #[test]
     fn test_round_to_sig_figs() {

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -74,12 +74,10 @@ const ITL_LOCAL_FLUSH_TOKENS: u64 = 64;
 
 const MODEL_READY_HELP: &str = "Whether the frontend can route at least one inference request for the model (1 = ready, 0 = not ready)";
 
-fn model_ready_metric_name() -> String {
-    format!(
-        "{}_{}",
-        name_prefix::FRONTEND,
-        frontend_service::MODEL_READY
-    )
+fn model_ready_metric_name(metrics_prefix: Option<&str>) -> String {
+    let prefix =
+        sanitize_frontend_prometheus_prefix(metrics_prefix.unwrap_or(name_prefix::FRONTEND));
+    format!("{}_{}", prefix, frontend_service::MODEL_READY)
 }
 
 /// Collects current model readiness directly from the frontend's routing catalog.
@@ -89,17 +87,26 @@ fn model_ready_metric_name() -> String {
 struct ModelReadyCollector {
     manager: Arc<ModelManager>,
     desc: Desc,
+    metric_name: String,
 }
 
 impl ModelReadyCollector {
-    fn new(manager: Arc<ModelManager>) -> Result<Self, prometheus::Error> {
+    fn new(
+        manager: Arc<ModelManager>,
+        metrics_prefix: Option<String>,
+    ) -> Result<Self, prometheus::Error> {
+        let metric_name = model_ready_metric_name(metrics_prefix.as_deref());
         let desc = Desc::new(
-            model_ready_metric_name(),
+            metric_name.clone(),
             MODEL_READY_HELP.to_string(),
             vec!["model".to_string()],
             Default::default(),
         )?;
-        Ok(Self { manager, desc })
+        Ok(Self {
+            manager,
+            desc,
+            metric_name,
+        })
     }
 }
 
@@ -130,7 +137,7 @@ impl Collector for ModelReadyCollector {
         }
 
         let mut family = MetricFamily::default();
-        family.set_name(model_ready_metric_name());
+        family.set_name(self.metric_name.clone());
         family.set_help(MODEL_READY_HELP.to_string());
         family.set_field_type(MetricType::GAUGE);
         family.set_metric(metrics);
@@ -142,8 +149,9 @@ impl Collector for ModelReadyCollector {
 pub fn register_model_ready_metric(
     registry: &Registry,
     manager: Arc<ModelManager>,
+    metrics_prefix: Option<String>,
 ) -> Result<(), prometheus::Error> {
-    registry.register(Box::new(ModelReadyCollector::new(manager)?))
+    registry.register(Box::new(ModelReadyCollector::new(manager, metrics_prefix)?))
 }
 
 /// Global Prometheus gauge for last observed TTFT per worker (in seconds)
@@ -2361,11 +2369,15 @@ async fn handler_metrics(State(state): State<Arc<MetricsHandlerState>>) -> impl 
 mod tests {
     use super::*;
 
-    fn model_ready_value(registry: &Registry, model: &str) -> Option<f64> {
+    fn model_ready_value_with_name(
+        registry: &Registry,
+        metric_name: &str,
+        model: &str,
+    ) -> Option<f64> {
         registry
             .gather()
             .into_iter()
-            .find(|family| family.name() == model_ready_metric_name())?
+            .find(|family| family.name() == metric_name)?
             .get_metric()
             .iter()
             .find(|metric| {
@@ -2377,11 +2389,15 @@ mod tests {
             .map(|metric| metric.get_gauge().value())
     }
 
+    fn model_ready_value(registry: &Registry, model: &str) -> Option<f64> {
+        model_ready_value_with_name(registry, &model_ready_metric_name(None), model)
+    }
+
     #[test]
     fn model_ready_metric_tracks_live_routing_catalog() {
         let manager = Arc::new(ModelManager::new());
         let registry = Registry::new();
-        register_model_ready_metric(&registry, manager.clone()).unwrap();
+        register_model_ready_metric(&registry, manager.clone(), None).unwrap();
 
         assert_eq!(model_ready_value(&registry, "test-model"), None);
 
@@ -2399,6 +2415,23 @@ mod tests {
         )));
         assert!(manager.add_worker_set("test-model", "watched", worker_set));
         assert_eq!(model_ready_value(&registry, "test-model"), Some(0.0));
+
+        let custom_registry = Registry::new();
+        register_model_ready_metric(
+            &custom_registry,
+            manager.clone(),
+            Some("custom_frontend".to_string()),
+        )
+        .unwrap();
+        assert_eq!(
+            model_ready_value_with_name(
+                &custom_registry,
+                "custom_frontend_model_ready",
+                "test-model"
+            ),
+            Some(0.0)
+        );
+        assert_eq!(model_ready_value(&custom_registry, "test-model"), None);
 
         worker_tx.send(vec![1]).unwrap();
         assert_eq!(model_ready_value(&registry, "test-model"), Some(1.0));

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -1113,6 +1113,7 @@ impl HttpServiceConfigBuilder {
     pub fn build(self) -> Result<HttpService, anyhow::Error> {
         let config: HttpServiceConfig = self.build_internal()?;
         let metrics_config = config.metrics_config.clone();
+        let model_ready_metrics_prefix = metrics_config.prefix();
         let frontend_api_config = config.frontend_api_config.clone();
         let anthropic_endpoints_enabled = frontend_api_config.anthropic().enabled();
         let vllm_generate_enabled =
@@ -1184,7 +1185,7 @@ impl HttpServiceConfigBuilder {
         state.metrics_clone().register(&registry)?;
 
         // Readiness is evaluated from the live routing catalog at scrape time.
-        register_model_ready_metric(&registry, state.manager_clone())?;
+        register_model_ready_metric(&registry, state.manager_clone(), model_ready_metrics_prefix)?;
 
         // Register worker load metrics (active_decode_blocks, active_prefill_tokens per worker)
         // These are updated by KvWorkerMonitor when receiving ActiveLoad events

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -21,7 +21,9 @@ use super::frontend_extension::{
     FrontendExtensionContext, FrontendRouteExtension, FrontendRouteSet,
 };
 use super::metrics;
-use super::metrics::{register_lora_allocation_metrics, register_worker_timing_metrics};
+use super::metrics::{
+    register_lora_allocation_metrics, register_model_ready_metric, register_worker_timing_metrics,
+};
 use crate::discovery::ModelManager;
 use crate::endpoint_type::EndpointType;
 use crate::kv_router::metrics::{
@@ -1180,6 +1182,9 @@ impl HttpServiceConfigBuilder {
         // enable prometheus metrics
         let registry = metrics::Registry::new();
         state.metrics_clone().register(&registry)?;
+
+        // Readiness is evaluated from the live routing catalog at scrape time.
+        register_model_ready_metric(&registry, state.manager_clone())?;
 
         // Register worker load metrics (active_decode_blocks, active_prefill_tokens per worker)
         // These are updated by KvWorkerMonitor when receiving ActiveLoad events

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -171,6 +171,9 @@ pub mod frontend_service {
     /// Environment variable that overrides the default metric prefix
     pub const METRICS_PREFIX_ENV: &str = "DYN_METRICS_PREFIX";
 
+    /// Whether the frontend can route at least one inference request for a model
+    pub const MODEL_READY: &str = "model_ready";
+
     /// Total number of LLM requests processed
     pub const REQUESTS_TOTAL: &str = "requests_total";
 


### PR DESCRIPTION
## Overview:

Adds a frontend-authoritative Prometheus metric indicating whether Dynamo can currently route requests for a model. This gives external dispatchers a reliable capacity signal so they can preserve queued work when no serving capacity is ready and resume dispatch as soon as the first complete serving unit becomes routable.

## Details:

- Adds `dynamo_frontend_model_ready{model}`:
  - `1` when the frontend can route requests for the model through at least one complete serving topology.
  - `0` when the model remains in the routing catalog but is not currently routable.
  - Absent when the model is not registered in the routing catalog; the entire metric family is absent when no models are registered. The series appears on model registration and does not require an inference request.
  - Consumers should treat both 0 and absence as no dispatchable capacity. PromQL alerts must check `absent(...)` explicitly because `== 0` does not match a missing series.
- Computes the metric at scrape time from the live `ModelManager` state and the same `is_ready_to_serve()` check used by request routing and KServe readiness.
- Supports both round-robin and KV-aware routing
- Adds the metric to the observability catalog and regenerates the Python Prometheus-name constants.

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Relates to #10265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Prometheus gauge reporting whether each model is ready to serve requests.
  * Readiness reflects the live routing state and updates as available workers change.
  * Added model labels and deterministic reporting for easier monitoring.
* **Documentation**
  * Documented the new model-readiness metric, including its semantics and scrape-time behavior.
  * Clarified how other model metrics are registered and configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->