### PR TITLE
feat(router): expose --router-min-initial-workers on the standalone router (OPS-8411)

### DIFF
--- a/components/src/dynamo/router/__main__.py
+++ b/components/src/dynamo/router/__main__.py
@@ -14,6 +14,7 @@ routing decisions.
 
 import asyncio
 import logging
+import os
 from typing import Optional
 
 import uvloop
@@ -30,6 +31,8 @@ from dynamo.runtime.logging import configure_dynamo_logging
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
+
+MIN_INITIAL_WORKERS_ENV = "DYN_ROUTER_MIN_INITIAL_WORKERS"
 
 
 class StandaloneRouterHandler:
@@ -223,6 +226,11 @@ async def worker(runtime: DistributedRuntime):
         config.router_ttl_secs,
         config.router_approximate_cache_policy,
     )
+
+    # Read by the Rust router's startup gate, which is the only thing that keeps
+    # KvRouter from serving before its worker set is populated. Must be set
+    # before the KvRouter is constructed. Mirrors dynamo.frontend.
+    os.environ[MIN_INITIAL_WORKERS_ENV] = str(config.min_initial_workers)
 
     kv_router_config = build_kv_router_config(config)
     aic_perf_config = build_aic_perf_config(config)

--- a/components/src/dynamo/router/args.py
+++ b/components/src/dynamo/router/args.py
@@ -28,6 +28,7 @@ class DynamoRouterConfig(KvRouterConfigBase, AicPerfConfigBase):
     endpoint: str
     router_block_size: int
     serve_indexer: bool = False
+    min_initial_workers: int = 0
 
     def validate(self) -> None:
         """Validate config invariants (aligned with Rust KvRouterConfig where applicable)."""
@@ -120,6 +121,23 @@ class DynamoRouterArgGroup(ArgGroup):
             default=False,
             help="Serve this router's local KV indexer over the request plane.",
             dest="serve_indexer",
+        )
+
+        add_argument(
+            g,
+            flag_name="--router-min-initial-workers",
+            env_var="DYN_ROUTER_MIN_INITIAL_WORKERS",
+            default=0,
+            help=(
+                "Minimum number of workers required before the router starts serving. "
+                "KvRouter tracks workers on a background task, so with 0 the router can "
+                "accept a request before that set is populated and answer it with "
+                "'no endpoints available to route work'. Waiting is event-driven and "
+                "costs nothing per request. Set to 0 to disable the startup wait. "
+                "dynamo.frontend exposes the same flag."
+            ),
+            arg_type=int,
+            dest="min_initial_workers",
         )
 
         # KV router options (shared with dynamo.frontend)


### PR DESCRIPTION
## Summary

`KvRouter::new()` returns a router that cannot yet route. `KvRouter` tracks workers on a background task, so a request arriving right after construction can be answered with `no endpoints available to route work` even though discovery already reports the worker.

A startup gate for exactly this already exists — it's just off by default:

```rust
// lib/kv-router/src/scheduling/config.rs:65
Err(VarError::NotPresent) => Ok(0),   // DYN_ROUTER_MIN_INITIAL_WORKERS

// lib/llm/src/kv_router.rs:720
if min_initial_workers > 0 && !kv_router_config.skip_initial_worker_wait { ... }
```

The Python binding even releases the GIL with the comment *"The initial-worker wait can be unbounded"* — for a wait that by default never runs.

`--router-min-initial-workers` is defined in `router_args.py` behind `include_frontend_only`, so only `dynamo.frontend` ever received it. The standalone router constructs a `KvRouter` and immediately serves `generate()`, with no flag to raise the gate and no export of the environment variable the Rust side reads — so it runs at `0` permanently, and an operator has no way to change that.

Two other places already worked around this independently: the C bindings (`// …to avoid NoEndpoints on the first request`) and `tests/router/test_kv_router_gil_release.py`, which sets the env var to `1`.

### What this changes

Expose the flag on `DynamoRouterArgGroup` and export it before the router is constructed, mirroring `dynamo/frontend/main.py:407`. **The default stays `0`**, so nothing changes for existing deployments until an operator opts in.

### Why this shape, and not a retry

This was chosen specifically for having the lowest runtime cost:

- `RuntimeConfigWatch` is a `tokio::sync::watch::Receiver`, so `wait_for` is **event-driven** — it parks until the config lands. No polling, no timer.
- The gate is evaluated **once, in the constructor**. Enabling it adds **no code to any request path**; the branch already exists and is already compiled in.

A retry inside `generate()` would instead put work on the request path, pay the cost per affected request as TTFT, and turn a genuinely empty worker pool from a fast failure into a hang.

## Validation

Bench constructing `KvRouter` against an already-registered worker, 12 rounds, in a Dynamo runtime image:

| | ctor median | ctor p90 | first request succeeded |
|---|---|---|---|
| default (gate off) | 0.59 ms | 0.72 ms | **7 / 12** |
| `DYN_ROUTER_MIN_INITIAL_WORKERS=1` | 0.74 ms | 0.89 ms | **12 / 12** |

**~0.15 ms once per router, nothing per request** — and it removes the ~40% of first requests that fail today.

Flag wiring verified against the built package:

| invocation | result |
|---|---|
| no flag, no env | `min_initial_workers=0` (unchanged default) |
| `--router-min-initial-workers 3` | `3` |
| `DYN_ROUTER_MIN_INITIAL_WORKERS=2` | `2` |
| flag `5` + env `2` | `5` (flag wins) |

`pre-commit run --files <changed>` passes.

## Not in this PR

Whether the default should become `1` repo-wide. That trades "starts and 503s" for "blocks until a worker appears" — better behind a readiness probe, but a behaviour change, and the wait is unbounded by design (the C bindings note *"no timeout - controlled by K8s StartupProbe"*). That call belongs to a maintainer.

Also worth stating plainly: I proved the race and the fix against the Python `KvRouter` directly and read the code path showing the standalone router is exposed. I have **not** reproduced a failing request against a live standalone router — that part is inference from the code.

Internal tracking: OPS-8411. Related: OPS-8410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable minimum worker count for the Dynamo Router before it begins serving requests.
  - The setting can be configured through the `--router-min-initial-workers` command-line option or the `DYN_ROUTER_MIN_INITIAL_WORKERS` environment variable.
  - The default minimum worker count remains zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->