### PR TITLE
chore(codeowners): assign ownership-policy sources to process

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -365,6 +365,8 @@ areas:
   - .agents/
   - .ai/
   - .claude/
+  - .github/codeowners/areas.yaml
+  - .github/codeowners/external_contributors.yaml
   - AGENTS.md
   - ATTRIBUTIONS-Go.md
   - ATTRIBUTIONS-Python.md

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -508,6 +508,7 @@
 /lib/llm/src/block_manager.rs                                                @ai-dynamo/dynamo-kv-memory-codeowners
 /tests/benchmarks/multimodal/                                                @ai-dynamo/dynamo-multimodal-codeowners
 /tests/serve/test_vllm_xpu.py                                                @ai-dynamo/dynamo-xpu-codeowners
+/.github/codeowners/areas.yaml                                               @ai-dynamo/dynamo-process-codeowners
 /.github/workflows/pr-xpu.yaml                                               @ai-dynamo/dynamo-xpu-codeowners
 /.github/workflows/xpu-ci.yaml                                               @ai-dynamo/dynamo-xpu-codeowners
 /deploy/operator/internal/gms/                                               @ai-dynamo/dynamo-gms-codeowners
@@ -572,6 +573,7 @@
 /components/src/dynamo/vllm/multimodal_utils/                                @ai-dynamo/dynamo-multimodal-codeowners
 /lib/bindings/python/src/dynamo/nixl_connect/                                @ai-dynamo/dynamo-kv-memory-codeowners
 /lib/llm/tests/test_streaming_tool_parsers.rs                                @ai-dynamo/dynamo-frontend-codeowners
+/.github/codeowners/external_contributors.yaml                               @ai-dynamo/dynamo-process-codeowners
 /tests/router/test_router_e2e_with_vllm_xpu.py                               @ai-dynamo/dynamo-xpu-codeowners
 /components/src/dynamo/vllm/multimodal_handlers/                             @ai-dynamo/dynamo-multimodal-codeowners
 /components/src/dynamo/common/tests/test_snapshot*                           @ai-dynamo/dynamo-gms-codeowners


### PR DESCRIPTION
## Why

`.github/codeowners/areas.yaml` and `external_contributors.yaml` are the hand-edited sources that generate `CODEOWNERS` and `CONTRIBUTORS.md`. Process already owns both generated outputs, but the sources were ops-owned — not deliberately, just by inheritance from the blanket `/.github/` rule. So the file that decides review routing and the file it produces end up with different reviewers.

Because the code-owner gate is evaluated per file, that also means a PR whose entire content is ownership policy needs two teams to approve. #13882 is a plain example: it changed `areas.yaml` and the regenerated `CODEOWNERS`, nothing else, and still needed ops alongside process. 32 of the 33 commits touching `areas.yaml` in the last six months changed nothing but policy.

Scoped to the two data files on purpose — the generator scripts in the same directory are build machinery and stay with ops.

## Effect

Required approvals for a pure ownership-policy PR, using #13882's exact file set:

```
                                   before          after
.github/codeowners/areas.yaml      ops             process
CODEOWNERS                         process         process
                                   ───────────     ───────────
minimal approver set               2 teams         1 team
```

## What Change

- Add the two data files to the process area's `path_globs`.
- `/.github/` is untouched — the new rules are more specific and supersede it by last-match, for those two paths only.
- Regenerate `CODEOWNERS` — two rules added, `CONTRIBUTORS.md` unchanged.

## Test Plan

- Full-tree coverage gate, drift check, and 93 tooling unit tests pass.
- `who_owns.py`: data files resolve to process; scripts, README, and `filters.yaml` unchanged at ops.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership rules for selected configuration files.
  * Ensured changes to these files are automatically routed to the appropriate review team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->