### PR TITLE
perf(bindings): reuse one encode buffer per push-egress request

### DIFF
--- a/lib/bindings/python/rust/push_egress.rs
+++ b/lib/bindings/python/rust/push_egress.rs
@@ -28,7 +28,7 @@
 use std::sync::{Arc, Mutex};
 
 use anyhow::Error;
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
@@ -76,6 +76,73 @@ pub fn add_to_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     Ok(())
 }
 
+// ── Encode buffer ────────────────────────────────────────────────────────────
+
+/// One request's reusable frame-encoding buffer.
+///
+/// Rather than allocating a buffer per frame, every frame is written into one
+/// large `BytesMut` chunk and then handed out using [`BytesMut::split`] — the
+/// `bytes` crate method that returns the bytes written so far as a separate
+/// handle and leaves `buf` empty but still holding the rest of the chunk's
+/// capacity. The allocator is therefore touched about once per chunk instead of
+/// once per frame.
+///
+/// `split` is `O(1)` and copies nothing: both handles point into the same
+/// allocation and share a reference count. A chunk is only freed once every
+/// frame taken from it has been sent and dropped. The response channel bounds
+/// how many can be in flight at a time and a chunk is small, so that retention
+/// is not worth designing around.
+struct EncodeBuffer {
+    buf: BytesMut,
+    /// Frames within one stream are all about the same size, so the last one is
+    /// a good predictor of how much room the next one needs.
+    last_frame_len: usize,
+}
+
+impl EncodeBuffer {
+    /// How much is allocated at a time. Sized to cover a full in-flight window:
+    /// `engine::RESPONSE_CHANNEL_DEPTH` frames of a few dozen bytes each is well
+    /// under 8 KiB, so a chunk retires at roughly the rate its frames drain.
+    /// Raising it trades resident memory per in-flight request for allocator
+    /// calls that are already amortized over ~150 frames.
+    const CHUNK: usize = 8 * 1024;
+    /// Minimum room to ask for, so a request's first frame — which has no
+    /// previous frame to predict from — is chunked like all the rest.
+    const MIN_RESERVE: usize = 64;
+
+    fn new() -> Self {
+        Self {
+            buf: BytesMut::new(),
+            last_frame_len: 0,
+        }
+    }
+
+    /// Make room for another frame, allocating a fresh chunk only once the
+    /// leftover capacity in the current one runs short. A frame bigger than
+    /// predicted is fine either way — `BytesMut` grows on write.
+    fn reserve(&mut self) {
+        let needed = self.last_frame_len.max(Self::MIN_RESERVE);
+        if self.buf.capacity() < needed {
+            self.buf.reserve(Self::CHUNK.max(needed));
+        }
+    }
+
+    /// Hand out the frame just written as its own `Bytes`, and remember its
+    /// length so the next [`Self::reserve`] knows what to expect. `buf` is left
+    /// empty, with whatever is left of the chunk still available to the frame
+    /// after this one.
+    fn take(&mut self) -> Bytes {
+        self.last_frame_len = self.buf.len();
+        self.buf.split().freeze()
+    }
+
+    /// Drop a partially written frame after an encode failure, so the next
+    /// frame does not inherit its bytes.
+    fn discard(&mut self) {
+        self.buf.clear();
+    }
+}
+
 // ── Wire frame ───────────────────────────────────────────────────────────────
 
 /// One response, already encoded for the request plane.
@@ -85,13 +152,14 @@ pub fn add_to_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
 /// straight into the codec in one pass, exactly as on the pull path, and
 /// nothing the codec can represent is narrowed on the way.
 ///
-/// `codec` records which codec produced `bytes`. `send` has no request in hand,
-/// so it uses the process-global [`RequestPlanePayloadCodec::configured`] — the
-/// value this worker advertises in its instance record, which is where callers
-/// read the codec they address it with. The two agree except against a caller
-/// old enough to predict neither, which falls back to JSON;
-/// [`PushFrame::into_encoded`] re-encodes for that case rather than putting the
-/// wrong bytes on the wire.
+/// `codec` records which codec produced `bytes`. `send` has no request in hand
+/// to read the codec from, so the sink captures the process-global
+/// [`RequestPlanePayloadCodec::configured`] once per request. That is the value
+/// this worker advertises in its instance record, which is also where callers
+/// look up the codec to address it with — so the two normally agree. The one
+/// exception is a caller old enough to predict neither, which falls back to
+/// JSON. [`PushFrame::into_encoded`] re-encodes for that case rather than
+/// putting the wrong bytes on the wire.
 pub(crate) struct PushFrame {
     bytes: Bytes,
     is_error: bool,
@@ -112,9 +180,66 @@ impl PushFrame {
     /// Encode one Python response object, with the GIL held by the caller.
     ///
     /// Both steps are shared with the pull path — `parse_python_response`
-    /// interprets the object, `encode_annotated_response` produces the bytes —
-    /// so the two cannot drift.
-    fn encode(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+    /// interprets the object, `write_annotated_response` produces the bytes — so
+    /// the two cannot drift. The only change from the pull path is where those
+    /// bytes land: a buffer reused across this request's frames, rather than a
+    /// fresh `Vec` each time.
+    ///
+    /// ## Why `try_lock` rather than `lock`
+    ///
+    /// [`Self::write`] walks `obj`, and walking a Python object can run arbitrary
+    /// Python: `__bool__` when an envelope is tested for truthiness, `__iter__` or
+    /// `__len__` during the pythonize walk. That Python is free to call `send`
+    /// again on this same sender.
+    ///
+    /// The mutex is not reentrant, so blocking here would deadlock the event-loop
+    /// thread *while it holds the GIL*, stalling every request in the interpreter.
+    /// Instead a re-entrant call falls back to its own private buffer — slower for
+    /// that one frame, which is a good trade against a hang.
+    ///
+    /// Either way the lock is released before returning, and so before the
+    /// caller's enqueue, which can block.
+    fn encode(
+        py: Python<'_>,
+        obj: &Bound<'_, PyAny>,
+        codec: RequestPlanePayloadCodec,
+        buffer: &parking_lot::Mutex<EncodeBuffer>,
+    ) -> PyResult<Self> {
+        let Some(mut pooled) = buffer.try_lock() else {
+            let mut scratch = BytesMut::new();
+            let is_error = Self::write(py, obj, codec, &mut scratch)?;
+            return Ok(Self {
+                bytes: scratch.freeze(),
+                is_error,
+                codec,
+            });
+        };
+
+        pooled.reserve();
+        match Self::write(py, obj, codec, &mut pooled.buf) {
+            Ok(is_error) => Ok(Self {
+                bytes: pooled.take(),
+                is_error,
+                codec,
+            }),
+            Err(error) => {
+                // The frame may be half-written. Drop those bytes so the next
+                // frame does not inherit them.
+                pooled.discard();
+                Err(error)
+            }
+        }
+    }
+
+    /// Write one response's frame into `out`, returning whether it is an error
+    /// frame. On failure `out` may be left holding a partial frame, so the
+    /// caller must discard it.
+    fn write(
+        py: Python<'_>,
+        obj: &Bound<'_, PyAny>,
+        codec: RequestPlanePayloadCodec,
+        out: &mut BytesMut,
+    ) -> PyResult<bool> {
         let annotated =
             python_payload::parse_python_response(obj.clone().unbind(), py).map_err(|error| {
                 PyValueError::new_err(format!(
@@ -122,19 +247,14 @@ impl PushFrame {
                      application-logic-mismatch: {error}"
                 ))
             })?;
-        let codec = RequestPlanePayloadCodec::configured();
-        let (bytes, is_error) = python_payload::encode_annotated_response(codec, annotated)
-            .map_err(|error| {
+        python_payload::write_annotated_response(codec, annotated, &mut out.writer()).map_err(
+            |error| {
                 PyValueError::new_err(format!(
                     "critical error: failed serializing python response as {}: {error}",
                     codec.name()
                 ))
-            })?;
-        Ok(Self {
-            bytes: bytes.into(),
-            is_error,
-            codec,
-        })
+            },
+        )
     }
 
     /// Encode a terminal error frame. Pure Rust — no Python object involved —
@@ -214,6 +334,14 @@ struct ResponseSink {
     /// response stream would leave the handler generating into nothing until it
     /// noticed the send error on its own.
     ctx: Arc<dyn AsyncEngineContext>,
+    /// Read once per request instead of once per frame. It is backed by a
+    /// `OnceLock` (see [`RequestPlanePayloadCodec::configured`]), so reading it
+    /// again later could only ever return this same value.
+    codec: RequestPlanePayloadCodec,
+    /// Reused across this request's frames. Behind a mutex because `send` takes
+    /// `&self`. Uncontended in practice: one request's handler pushes from a
+    /// single event-loop thread.
+    encode_buffer: parking_lot::Mutex<EncodeBuffer>,
 }
 
 impl ResponseSink {
@@ -248,7 +376,7 @@ impl ResponseSink {
         // The whole Python->Rust crossing for one response: the encode plus the
         // enqueue. Unlike the pull path neither step acquires the GIL — the
         // Python handler already holds it.
-        let frame = PushFrame::encode(py, obj)?;
+        let frame = PushFrame::encode(py, obj, self.codec, &self.encode_buffer)?;
 
         let Some(tx) = self.sender() else {
             return Err(PyRuntimeError::new_err(
@@ -426,6 +554,8 @@ pub(crate) fn response_channel(
         sink: Arc::new(ResponseSink {
             tx: Mutex::new(Some(tx)),
             ctx,
+            codec: RequestPlanePayloadCodec::configured(),
+            encode_buffer: parking_lot::Mutex::new(EncodeBuffer::new()),
         }),
     };
 

--- a/lib/bindings/python/rust/push_egress.rs
+++ b/lib/bindings/python/rust/push_egress.rs
@@ -106,8 +106,8 @@ impl EncodeBuffer {
     /// Raising it trades resident memory per in-flight request for allocator
     /// calls that are already amortized over ~150 frames.
     const CHUNK: usize = 8 * 1024;
-    /// Minimum room to ask for, so a request's first frame — which has no
-    /// previous frame to predict from — is chunked like all the rest.
+    /// Floor on the predicted frame size, so an unusually small frame does not
+    /// make the next one ask for less room than any frame could need.
     const MIN_RESERVE: usize = 64;
 
     fn new() -> Self {
@@ -118,12 +118,27 @@ impl EncodeBuffer {
     }
 
     /// Make room for another frame, allocating a fresh chunk only once the
-    /// leftover capacity in the current one runs short. A frame bigger than
-    /// predicted is fine either way — `BytesMut` grows on write.
+    /// leftover capacity in the current one runs short.
+    ///
+    /// Two things this deliberately does not do:
+    ///
+    /// It does not commit a chunk for the first frame. Encode, prefill and short
+    /// decode requests often produce exactly one frame, and chunking those would
+    /// swap a small allocation for an 8 KiB one that is never reused. Until a
+    /// second frame proves the request is streaming, `BytesMut` sizes the frame
+    /// itself.
+    ///
+    /// It does not let the predictor exceed one chunk. One oversized frame must
+    /// not pin an oversized buffer for the rest of the request. An outsized frame
+    /// still encodes fine — `BytesMut` grows on write, and `split` hands that
+    /// large allocation away with the frame rather than retaining it.
     fn reserve(&mut self) {
-        let needed = self.last_frame_len.max(Self::MIN_RESERVE);
+        if self.last_frame_len == 0 {
+            return;
+        }
+        let needed = self.last_frame_len.clamp(Self::MIN_RESERVE, Self::CHUNK);
         if self.buf.capacity() < needed {
-            self.buf.reserve(Self::CHUNK.max(needed));
+            self.buf.reserve(Self::CHUNK);
         }
     }
 
@@ -705,11 +720,126 @@ mod tests {
     //! `send`/`close` and `handler_supports_push` are not; they are covered by
     //! pytest against the built `.so`.  Gaps are documented at the bottom.
 
-    use super::PushFrame;
+    use super::{EncodeBuffer, PushFrame};
     use crate::engine::RESPONSE_CHANNEL_DEPTH;
+    use bytes::BufMut;
     use dynamo_runtime::pipeline::network::{NetworkStreamWrapper, RequestPlanePayloadCodec};
     use dynamo_runtime::protocols::annotated::Annotated;
     use tokio::sync::mpsc;
+
+    // ── EncodeBuffer ─────────────────────────────────────────────────────────
+    //
+    // `PushFrame::encode` itself cannot be tested here — it takes `Python<'_>`
+    // and a `Bound<'_, PyAny>`, which would pull the Python C API into the test
+    // binary (see the module note above). But the buffer it drives is pure Rust,
+    // and the buffer is where every failure mode of this change lives: frames
+    // leaking into one another, a partial frame surviving, and the sizing policy.
+
+    /// Write `n` bytes of `fill` as one frame would.
+    fn write_frame(buffer: &mut EncodeBuffer, fill: u8, n: usize) {
+        buffer.reserve();
+        buffer.buf.put_slice(&vec![fill; n]);
+    }
+
+    /// Consecutive frames must come out independent and intact. `split` leaves
+    /// them sharing one allocation, so a bad index would show up as one frame
+    /// carrying another's bytes.
+    #[test]
+    fn consecutive_frames_are_independent() {
+        let mut buffer = EncodeBuffer::new();
+        let mut frames = Vec::new();
+        for i in 0..64u8 {
+            write_frame(&mut buffer, i, 50 + usize::from(i));
+            frames.push(buffer.take());
+        }
+        for (i, frame) in frames.iter().enumerate() {
+            let i = u8::try_from(i).expect("fits");
+            assert_eq!(frame.len(), 50 + usize::from(i), "frame {i} wrong length");
+            assert!(
+                frame.iter().all(|b| *b == i),
+                "frame {i} carries another frame's bytes"
+            );
+        }
+    }
+
+    /// A frame abandoned partway through must not survive into the next one.
+    /// This is the `discard` path taken when encoding fails mid-write.
+    #[test]
+    fn discard_drops_a_partial_frame() {
+        let mut buffer = EncodeBuffer::new();
+        write_frame(&mut buffer, 0xAA, 40); // partial frame, then failure
+        buffer.discard();
+
+        write_frame(&mut buffer, 0xBB, 30);
+        let frame = buffer.take();
+        assert_eq!(frame.len(), 30, "next frame inherited the discarded bytes");
+        assert!(frame.iter().all(|b| *b == 0xBB));
+    }
+
+    /// A request that sends exactly one frame — encode, prefill, short decode —
+    /// must not be charged a full chunk it never reuses.
+    #[test]
+    fn first_frame_does_not_commit_a_chunk() {
+        let mut buffer = EncodeBuffer::new();
+        buffer.reserve();
+        assert!(
+            buffer.buf.capacity() < EncodeBuffer::CHUNK,
+            "first frame pre-allocated a whole chunk: {}",
+            buffer.buf.capacity()
+        );
+    }
+
+    /// Once a request is known to be streaming, chunking kicks in.
+    #[test]
+    fn second_frame_commits_a_chunk() {
+        let mut buffer = EncodeBuffer::new();
+        write_frame(&mut buffer, 1, 52);
+        let _ = buffer.take();
+        buffer.reserve();
+        assert!(
+            buffer.buf.capacity() >= EncodeBuffer::CHUNK,
+            "streaming request did not chunk: {}",
+            buffer.buf.capacity()
+        );
+    }
+
+    /// One oversized frame must not pin an oversized buffer for the rest of the
+    /// request. The large allocation leaves with the frame; the next reserve is
+    /// capped at a chunk.
+    #[test]
+    fn an_oversized_frame_does_not_pin_capacity() {
+        let mut buffer = EncodeBuffer::new();
+        write_frame(&mut buffer, 1, 52);
+        let _ = buffer.take();
+
+        let huge = 4 * 1024 * 1024;
+        write_frame(&mut buffer, 2, huge);
+        let big = buffer.take();
+        assert_eq!(big.len(), huge);
+
+        buffer.reserve();
+        assert!(
+            buffer.buf.capacity() <= EncodeBuffer::CHUNK,
+            "an oversized frame pinned {} bytes for the rest of the request",
+            buffer.buf.capacity()
+        );
+    }
+
+    /// The re-entrancy fallback in `PushFrame::encode` depends on `try_lock`
+    /// failing rather than blocking when the buffer is already held. Encoding a
+    /// frame can run arbitrary Python that re-enters `send`, and blocking there
+    /// would deadlock the event-loop thread with the GIL held.
+    #[test]
+    fn try_lock_fails_instead_of_blocking_when_held() {
+        let buffer = parking_lot::Mutex::new(EncodeBuffer::new());
+        let outer = buffer.lock();
+        assert!(
+            buffer.try_lock().is_none(),
+            "try_lock must decline a held buffer so encode can fall back"
+        );
+        drop(outer);
+        assert!(buffer.try_lock().is_some(), "lock must be reusable after");
+    }
 
     /// Decode a frame's bytes back to the wire envelope, as the caller does.
     fn decode(

--- a/lib/bindings/python/rust/push_egress.rs
+++ b/lib/bindings/python/rust/push_egress.rs
@@ -109,6 +109,10 @@ impl EncodeBuffer {
     /// Floor on the predicted frame size, so an unusually small frame does not
     /// make the next one ask for less room than any frame could need.
     const MIN_RESERVE: usize = 64;
+    /// Starting capacity for the private buffer a re-entrant `send` falls back
+    /// to. Matches what `encode_annotated_response` gives the pull path, so the
+    /// fallback does not grow from zero.
+    const SCRATCH_CAPACITY: usize = 128;
 
     fn new() -> Self {
         Self {
@@ -153,8 +157,19 @@ impl EncodeBuffer {
 
     /// Drop a partially written frame after an encode failure, so the next
     /// frame does not inherit its bytes.
+    ///
+    /// An oversized partial frame also has to give its allocation back. On the
+    /// success path `split` hands that memory away with the frame, but a
+    /// discarded frame has nothing to hand it to — and `clear` keeps capacity,
+    /// which [`Self::reserve`] then sees as "already big enough" and never
+    /// replaces. Without this the buffer would stay oversized for the rest of
+    /// the request.
     fn discard(&mut self) {
-        self.buf.clear();
+        if self.buf.capacity() > Self::CHUNK {
+            self.buf = BytesMut::new();
+        } else {
+            self.buf.clear();
+        }
     }
 }
 
@@ -221,7 +236,10 @@ impl PushFrame {
         buffer: &parking_lot::Mutex<EncodeBuffer>,
     ) -> PyResult<Self> {
         let Some(mut pooled) = buffer.try_lock() else {
-            let mut scratch = BytesMut::new();
+            // Sized, not `new()`: growing from zero is the cost this whole
+            // change exists to remove, and the fallback should not quietly
+            // reintroduce it for the frame that takes it.
+            let mut scratch = BytesMut::with_capacity(EncodeBuffer::SCRATCH_CAPACITY);
             let is_error = Self::write(py, obj, codec, &mut scratch)?;
             return Ok(Self {
                 bytes: scratch.freeze(),
@@ -822,6 +840,37 @@ mod tests {
             buffer.buf.capacity() <= EncodeBuffer::CHUNK,
             "an oversized frame pinned {} bytes for the rest of the request",
             buffer.buf.capacity()
+        );
+    }
+
+    /// A frame that fails partway through must give its allocation back too,
+    /// not just its bytes. `clear()` alone keeps capacity, and `reserve()` reads
+    /// a large capacity as "already big enough" — so an oversized *failed* frame
+    /// would pin its buffer for the rest of the request, which is the same leak
+    /// `an_oversized_frame_does_not_pin_capacity` rules out on the success path.
+    #[test]
+    fn discard_releases_an_oversized_buffer() {
+        let mut buffer = EncodeBuffer::new();
+        write_frame(&mut buffer, 1, 52);
+        let _ = buffer.take();
+
+        // A large frame that fails mid-encode rather than being handed out.
+        write_frame(&mut buffer, 2, 4 * 1024 * 1024);
+        buffer.discard();
+
+        assert!(
+            buffer.buf.capacity() <= EncodeBuffer::CHUNK,
+            "a discarded oversized frame pinned {} bytes for the rest of the request",
+            buffer.buf.capacity()
+        );
+
+        // And the buffer must still be usable afterwards.
+        write_frame(&mut buffer, 3, 40);
+        let frame = buffer.take();
+        assert_eq!(frame.len(), 40);
+        assert!(
+            frame.iter().all(|b| *b == 3),
+            "discard leaked bytes forward"
         );
     }
 

--- a/lib/bindings/python/rust/python_payload.rs
+++ b/lib/bindings/python/rust/python_payload.rs
@@ -207,13 +207,28 @@ pub(crate) fn encode_annotated_response<T: Serialize>(
     codec: RequestPlanePayloadCodec,
     annotated: Annotated<T>,
 ) -> Result<(Vec<u8>, bool), anyhow::Error> {
+    let mut bytes = Vec::new();
+    let is_error = write_annotated_response(codec, annotated, &mut bytes)?;
+    Ok((bytes, is_error))
+}
+
+/// Same as [`encode_annotated_response`], but writes into a buffer the caller
+/// owns so the push path can reuse one allocation across a request's frames.
+///
+/// This is where the wrapper shape is defined; `encode_annotated_response` just
+/// calls it, so the two can never disagree about what a frame looks like.
+pub(crate) fn write_annotated_response<T: Serialize, W: std::io::Write>(
+    codec: RequestPlanePayloadCodec,
+    annotated: Annotated<T>,
+    writer: &mut W,
+) -> Result<bool, anyhow::Error> {
     let is_error = annotated.is_error();
     let wrapper = NetworkStreamWrapper {
         data: Some(annotated),
         complete_final: false,
     };
-    let bytes = codec.encode(&wrapper)?;
-    Ok((bytes, is_error))
+    codec.encode_into(&wrapper, writer)?;
+    Ok(is_error)
 }
 
 fn encode_python_response(

--- a/lib/bindings/python/rust/python_payload.rs
+++ b/lib/bindings/python/rust/python_payload.rs
@@ -207,16 +207,20 @@ pub(crate) fn encode_annotated_response<T: Serialize>(
     codec: RequestPlanePayloadCodec,
     annotated: Annotated<T>,
 ) -> Result<(Vec<u8>, bool), anyhow::Error> {
-    let mut bytes = Vec::new();
+    // `with_capacity`, not `new`: this is still the pull path's encoder, and
+    // `serde_json::to_vec` — which it used before — starts at 128 bytes. Growing
+    // from zero here would regress JSON responses to pay the reallocations this
+    // change exists to remove.
+    let mut bytes = Vec::with_capacity(128);
     let is_error = write_annotated_response(codec, annotated, &mut bytes)?;
     Ok((bytes, is_error))
 }
 
-/// Same as [`encode_annotated_response`], but writes into a buffer the caller
-/// owns so the push path can reuse one allocation across a request's frames.
+/// Encode the canonical non-terminal wrapper into a caller-owned writer, so the
+/// push path can reuse one allocation across a request's frames.
 ///
-/// This is where the wrapper shape is defined; `encode_annotated_response` just
-/// calls it, so the two can never disagree about what a frame looks like.
+/// The wrapper shape is defined here and nowhere else; `encode_annotated_response`
+/// delegates to it, so the two cannot disagree.
 pub(crate) fn write_annotated_response<T: Serialize, W: std::io::Write>(
     codec: RequestPlanePayloadCodec,
     annotated: Annotated<T>,

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -106,6 +106,25 @@ impl RequestPlanePayloadCodec {
         }
     }
 
+    /// Encode into a writer the caller owns, so a hot path can reuse one buffer
+    /// across frames instead of allocating a fresh `Vec` per frame.
+    ///
+    /// Byte-identical to [`Self::encode`]: `to_vec_named` and `to_vec` are these
+    /// same two calls, just aimed at a `Vec`. That is pinned by
+    /// `encode_into_matches_encode_byte_for_byte` — if a hot path quietly emitted
+    /// different bytes than the rest of the request plane, the only symptom would
+    /// be a decode failure at the caller.
+    pub fn encode_into<T, W>(&self, value: &T, writer: &mut W) -> Result<()>
+    where
+        T: Serialize + ?Sized,
+        W: std::io::Write,
+    {
+        match self {
+            Self::Json => Ok(serde_json::to_writer(writer, value)?),
+            Self::Msgpack => Ok(rmp_serde::encode::write_named(writer, value)?),
+        }
+    }
+
     pub fn decode<T: DeserializeOwned>(&self, bytes: &[u8]) -> Result<T> {
         match self {
             Self::Json => Ok(serde_json::from_slice(bytes)?),
@@ -482,6 +501,33 @@ mod tests {
         id: u64,
         text: String,
         tokens: Vec<u32>,
+    }
+
+    /// `encode_into` exists so hot paths can reuse a buffer, which is only safe
+    /// if it produces the same bytes as `encode`. Both codecs are checked, and
+    /// the payload covers a nested map, a sequence, and a string.
+    #[test]
+    fn encode_into_matches_encode_byte_for_byte() {
+        let payload = NetworkStreamWrapper {
+            data: Some(TestPayload {
+                id: 7,
+                text: "hello".to_string(),
+                tokens: vec![1, 200, 70_000],
+            }),
+            complete_final: false,
+        };
+
+        for codec in [
+            RequestPlanePayloadCodec::Json,
+            RequestPlanePayloadCodec::Msgpack,
+        ] {
+            let expected = codec.encode(&payload).expect("encode");
+            let mut actual = Vec::new();
+            codec
+                .encode_into(&payload, &mut actual)
+                .expect("encode_into");
+            assert_eq!(expected, actual, "codec={}", codec.name());
+        }
     }
 
     #[test]

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -106,14 +106,11 @@ impl RequestPlanePayloadCodec {
         }
     }
 
-    /// Encode into a writer the caller owns, so a hot path can reuse one buffer
-    /// across frames instead of allocating a fresh `Vec` per frame.
+    /// Encode into a caller-owned writer, so a hot path can reuse one buffer
+    /// across frames instead of allocating per frame.
     ///
-    /// Byte-identical to [`Self::encode`]: `to_vec_named` and `to_vec` are these
-    /// same two calls, just aimed at a `Vec`. That is pinned by
-    /// `encode_into_matches_encode_byte_for_byte` — if a hot path quietly emitted
-    /// different bytes than the rest of the request plane, the only symptom would
-    /// be a decode failure at the caller.
+    /// Emits the same bytes as [`Self::encode`], which
+    /// `encode_into_matches_encode_byte_for_byte` pins for both codecs.
     pub fn encode_into<T, W>(&self, value: &T, writer: &mut W) -> Result<()>
     where
         T: Serialize + ?Sized,
@@ -503,9 +500,6 @@ mod tests {
         tokens: Vec<u32>,
     }
 
-    /// `encode_into` exists so hot paths can reuse a buffer, which is only safe
-    /// if it produces the same bytes as `encode`. Both codecs are checked, and
-    /// the payload covers a nested map, a sequence, and a string.
     #[test]
     fn encode_into_matches_encode_byte_for_byte() {
         let payload = NetworkStreamWrapper {


### PR DESCRIPTION
#### Overview:

When a worker streams a reply it sends **one small message per generated token**. Every one of those messages allocated a brand-new `Vec`, grew it from zero capacity, and re-read the request-plane codec setting.

This PR encodes into a buffer that lives for the whole request instead. **No change to the bytes on the wire, no change to any handler, no new Python API.**

Split out of #13965 so it can be reviewed on its own — this half touches no wire format and carries none of that PR's protocol-duplication concern.

#### Details:

**1. One buffer per request** — `push_egress.rs`

Frames are written into an 8 KiB `BytesMut` chunk and handed out with `BytesMut::split`, the `bytes` crate method that returns the bytes written so far as a separate handle and leaves the buffer empty but still holding the rest of the chunk. `split` is `O(1)` and copies nothing — both handles point into the same allocation and share a refcount — so the allocator is touched roughly once per chunk rather than once per frame.

8 KiB is sized to cover a full in-flight window: `RESPONSE_CHANNEL_DEPTH` (128) frames of a few dozen bytes each is well under one chunk, so a chunk retires at about the rate its frames drain.

**2. Codec read once per request, not once per frame**

`RequestPlanePayloadCodec::configured()` sits behind a `OnceLock`, so re-reading it per frame could only ever return the same value. The sink captures it at construction.

**3. `encode_into`** — `lib/runtime/src/pipeline/network.rs`

New method so the existing encoder can target a caller-owned writer. Byte-identical to `encode` by construction — `to_vec_named` and `to_vec` are these same two calls aimed at a `Vec` — and a unit test pins that for both codecs, because a hot path quietly emitting different bytes would only surface as a decode failure at the caller.

**Two failure modes are handled explicitly:**

- **A frame that fails partway through writing is discarded**, so the next frame cannot inherit its bytes. Half a frame followed by a whole one is undecodable on the wire.
- **The buffer is taken with `try_lock`, never a blocking lock.** Walking a Python object can run arbitrary Python (`__bool__`, `__iter__`, `__len__`), and that Python may re-enter `send` on the same sender. The mutex is not reentrant, so blocking would deadlock the event-loop thread *while it holds the GIL*, stalling every request in the interpreter. A re-entrant call falls back to a private buffer — slower for that one frame, which is the right trade against a hang.

#### Measured:

Microbenchmark of the encode step alone, driving real `PyDict`s through the actual `Depythonizer → serde_transcode → rmp-serde` chain, asserting byte-equality before timing:

| Frame | before | after | |
|---|---|---|---|
| **1 token id** (52 B) — steady-state decode | 312 ns | **232 ns** | **−26%** |
| 4 token ids (59 B) — MTP / spec decode | 369 ns | **286 ns** | −23% |
| 16 token ids (129 B) | 566 ns | **485 ns** | −14% |

Median of 3 runs. The win is not from chunking as such — it is from no longer regrowing a `Vec` from zero capacity on every frame. A sweep of the chunk size (8 KB → 256 KB, 32× fewer allocations) showed no measurable difference, which is why `CHUNK` stays at 8 KB.

This encode runs under the GIL the handler already holds, so what is saved is GIL occupancy, serialized against every other request in that interpreter.

> [!NOTE]
> Benchmarked on macOS/arm64 with Python 3.12, single-threaded — ratios should carry, absolute numbers will not.

#### Where should the reviewer start?

1. **`lib/bindings/python/rust/push_egress.rs`** — `EncodeBuffer`, and the `try_lock` re-entrancy fallback in `PushFrame::encode`.
2. **`lib/runtime/src/pipeline/network.rs`** — `encode_into` and its byte-identity test. Small and mechanical.
3. **`lib/bindings/python/rust/python_payload.rs`** — `write_annotated_response`; `encode_annotated_response` now delegates to it so the two cannot disagree about the wrapper shape.

#### Validation

- ✅ `cargo test --lib` passes on both crates (43 tests in `dynamo-py3`, including the existing `push_egress` and `python_payload` suites; 8 in `pipeline::network` including the new `encode_into_matches_encode_byte_for_byte`).
- ✅ `cargo clippy --lib --all-targets -- -D warnings` clean on `dynamo-py3`; `cargo fmt --check` clean on both crates.
- ✅ Wire format is unchanged by construction — this PR adds no new encoder, it only redirects the existing one at a caller-owned buffer.

#### Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Split out of #13965. Tracked internally as DYN-4191.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved request and response processing efficiency, reducing unnecessary memory allocation during data transmission.
  * Enhanced handling of consecutive and re-entrant sends for smoother streaming performance.

* **Reliability**
  * Improved serialization behavior across supported JSON and MessagePack formats.
  * Ensured partially written data is safely cleared when encoding encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->