### PR TITLE
fix(llm): handle deserialization of bare error finish reason

### DIFF
--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -55,10 +55,9 @@ pub trait OutputOptionsProvider {
 ///
 /// Deserialization also accepts the [`Display`] form, `"error: <message>"`,
 /// since Python engine adapters (e.g. `dynamo.vllm`'s custom-encoder path)
-/// report failures that way. A bare `"error"` with no message stays
-/// rejected on purpose — producers should raise
-/// `dynamo._core.InvalidArgument` instead, which yields a 400 carrying the
-/// real message.
+/// report failures that way. A bare `"error"` is accepted defensively with a
+/// diagnostic fallback message so a malformed backend error does not become a
+/// frontend deserialization failure.
 ///
 /// [`Display`]: std::fmt::Display
 #[derive(Serialize, Debug, Clone, PartialEq, Eq)]
@@ -105,6 +104,9 @@ impl std::str::FromStr for FinishReason {
             "stop" => Ok(FinishReason::Stop),
             "cancelled" | "abort" => Ok(FinishReason::Cancelled),
             "content_filter" => Ok(FinishReason::ContentFilter),
+            "error" => Ok(FinishReason::Error(
+                "backend emitted finish_reason=error without a message".into(),
+            )),
             s if s.starts_with("error: ") => Ok(FinishReason::Error(s[7..].to_string())),
             _ => Err(anyhow::anyhow!("Invalid FinishReason variant: '{}'", s)),
         }
@@ -133,7 +135,7 @@ impl<'de> serde::de::Visitor<'de> for FinishReasonVisitor {
 
     fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(
-            r#"a finish reason: "eos", "length", "stop", "cancelled", "abort", "content_filter", "error: <message>", or {"error": "<message>"}"#,
+            r#"a finish reason: "eos", "length", "stop", "cancelled", "abort", "content_filter", "error", "error: <message>", or {"error": "<message>"}"#,
         )
     }
 
@@ -874,13 +876,18 @@ mod tests {
         );
     }
 
-    /// A bare `"error"` stays rejected on purpose. Producers emitting it are
-    /// discarding a message they hold; accepting it here would paper over that
-    /// with invented text instead of leaving the defect visible.
+    #[test]
+    fn test_finish_reason_accepts_bare_error_from_msgpack() {
+        let msgpack = rmp_serde::to_vec_named("error").unwrap();
+        assert_eq!(
+            rmp_serde::from_slice::<FinishReason>(&msgpack).unwrap(),
+            FinishReason::Error("backend emitted finish_reason=error without a message".into())
+        );
+    }
+
     #[test]
     fn test_finish_reason_rejects_unknown_forms() {
         for json in [
-            r#""error""#,
             r#""nonsense""#,
             r#"{"nonsense":"boom"}"#,
             r#"{"error":"a","stop":"b"}"#,


### PR DESCRIPTION
## Summary

- Accept bare token-protocol `finish_reason="error"` defensively as `FinishReason::Error` with a clear fallback diagnostic.
- Before: the request-plane reader failed with `Invalid FinishReason variant: 'error'`, leaving an obscure deserialization error in the server logs.
- After: normal error handling logs `backend emitted finish_reason=error without a message`; the sanitized client response remains unchanged.
- Improving the client-side error message or failure behavior requires the backend to augment the finish reason as `error: <msg>` or raise the proper exception for discovered engine failure cases.
- Case-by-case engine errors that don't have a clear error message associated with their finish_reason=error raised by the engine itself can be improved on demand, but they require that the engine bubbles up the cause either via exception or return value.
- Regardless, this scenario is still considered a 500 Internal Server Error to the client both before and after this change - this simply replaces an obscure deserialization error with a more descriptive error of what happened.
 
Fixes #8549

Linear: [DIS-2801](https://linear.app/nvidia/issue/DIS-2801/harden-finishreason-reader-for-bare-error-values)

## Validation

- `cargo test -p dynamo-llm protocols::common` (12 passed)
- vLLM 0.26 end-to-end A/B: identical sanitized client bodies (`diff` exit 0); before failed request-plane deserialization, after reached normal error handling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of error responses by accepting the bare `"error"` format.
  * Displays a diagnostic fallback message instead of rejecting these responses.
* **Documentation**
  * Updated supported response formats to include bare `"error"`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->