### PR TITLE
fix(thunderagent): make program scheduling DP-rank aware

### DIFF
--- a/components/src/dynamo/thunderagent_router/__main__.py
+++ b/components/src/dynamo/thunderagent_router/__main__.py
@@ -38,6 +38,7 @@ from dynamo.thunderagent_router.args import (
     parse_args,
 )
 from dynamo.thunderagent_router.capacity import WorkerCapacityProvider
+from dynamo.thunderagent_router.program_state import ReplicaKey
 from dynamo.thunderagent_router.router import ThunderAgentScheduler
 
 configure_dynamo_logging()
@@ -217,9 +218,11 @@ class ThunderAgentRouterHandler:
                 if proof is not None:
                     if first_chunk:
                         first_chunk = False
-                        selected_worker = self._extract_worker_id(chunk)
-                        if selected_worker is not None:
-                            proof["selected_worker_id"] = selected_worker
+                        selected_worker_info = self._extract_worker_info(chunk)
+                        if selected_worker_info is not None:
+                            proof["selected_worker_id"] = selected_worker_info[0]
+                            if selected_worker_info[1] is not None:
+                                proof["selected_dp_rank"] = selected_worker_info[1]
                     _inject_thunderagent_route_proof(chunk, proof)
                 yield chunk
             return
@@ -233,14 +236,22 @@ class ThunderAgentRouterHandler:
             program_id,
             estimated_prompt_tokens=estimated_prompt_tokens,
         )
-        worker_pin = decision.assigned_worker_hint
+        replica_pin = getattr(decision, "assigned_replica_hint", None)
+        if replica_pin is None:
+            worker_hint = getattr(decision, "assigned_worker_hint", None)
+            dp_rank_hint = getattr(decision, "assigned_dp_rank", None)
+            if worker_hint is not None and dp_rank_hint is not None:
+                replica_pin = (worker_hint, dp_rank_hint)
+        worker_pin = replica_pin[0] if replica_pin is not None else None
+        dp_rank_pin = replica_pin[1] if replica_pin is not None else None
         logger.debug(
             "thunderagent.route path=program program=%s prompt_tokens=%d "
-            "worker_hint=%s waited_seconds=%.4f was_paused=%s "
+            "worker_hint=%s dp_rank_hint=%s waited_seconds=%.4f was_paused=%s "
             "soft_demoted=%s priority_jump=%.3f",
             program_id,
             estimated_prompt_tokens,
             worker_pin,
+            dp_rank_pin,
             decision.waited_seconds,
             decision.was_paused,
             decision.was_soft_demoted,
@@ -257,6 +268,7 @@ class ThunderAgentRouterHandler:
         if worker_pin is not None:
             routing = preprocessed.get("routing") or {}
             routing["backend_instance_id"] = worker_pin
+            routing["dp_rank"] = dp_rank_pin
             preprocessed["routing"] = routing
 
         prompt_tokens_seen = 0
@@ -264,6 +276,7 @@ class ThunderAgentRouterHandler:
         usage_completion_seen = False
         first_chunk = True
         selected_worker_id = None
+        selected_dp_rank = None
         proof = (
             {
                 "handled_by": "thunderagent_router",
@@ -275,6 +288,7 @@ class ThunderAgentRouterHandler:
                 "waited_seconds": decision.waited_seconds,
                 "priority_jump": decision.priority_jump,
                 "assigned_worker_hint": worker_pin,
+                "assigned_dp_rank": dp_rank_pin,
             }
             if want_route_proof
             else None
@@ -283,20 +297,62 @@ class ThunderAgentRouterHandler:
             async for chunk in await self._kv_router.generate_from_request(
                 preprocessed  # type: ignore[arg-type]
             ):
-                if first_chunk and worker_pin is None:
+                if first_chunk and replica_pin is None:
                     first_chunk = False
-                    selected_worker = self._extract_worker_id(chunk)
-                    if selected_worker is not None:
-                        await self._scheduler.assign_worker(program_id, selected_worker)
-                        selected_worker_id = selected_worker
+                    selected_worker_info = self._extract_worker_info(chunk)
+                    if (
+                        selected_worker_info is not None
+                        and selected_worker_info[1] is not None
+                    ):
+                        selected_replica = (
+                            selected_worker_info[0],
+                            selected_worker_info[1],
+                        )
+                        await self._scheduler.assign_replica(
+                            program_id, selected_replica
+                        )
+                        selected_worker_id, selected_dp_rank = selected_replica
                         if proof is not None:
-                            proof["selected_worker_id"] = selected_worker
+                            proof["selected_worker_id"] = selected_worker_id
+                            proof["selected_dp_rank"] = selected_dp_rank
                         logger.debug(
                             "thunderagent.route_selected program=%s worker=%s "
-                            "source=first_chunk",
+                            "dp_rank=%s source=first_chunk",
                             program_id,
-                            selected_worker,
+                            selected_worker_id,
+                            selected_dp_rank,
                         )
+                    else:
+                        # N-2 compatibility for workers whose WorkerIdInfo omits
+                        # DP-rank fields. Remove this fallback when those workers
+                        # leave the N-2 window; the scheduler resolves only an
+                        # explicitly advertised single-rank worker.
+                        selected_worker = (
+                            selected_worker_info[0]
+                            if selected_worker_info is not None
+                            else None
+                        )
+                        if selected_worker is not None:
+                            assign_worker = getattr(
+                                self._scheduler, "assign_worker", None
+                            )
+                            assigned_replica = (
+                                await assign_worker(program_id, selected_worker)
+                                if assign_worker is not None
+                                else None
+                            )
+                            if assigned_replica is not None:
+                                selected_worker_id, selected_dp_rank = assigned_replica
+                                if proof is not None:
+                                    proof["selected_worker_id"] = selected_worker_id
+                                    proof["selected_dp_rank"] = selected_dp_rank
+                                logger.debug(
+                                    "thunderagent.route_selected program=%s worker=%s "
+                                    "dp_rank=%s source=legacy_worker_id",
+                                    program_id,
+                                    selected_worker_id,
+                                    selected_dp_rank,
+                                )
 
                 usage = (
                     chunk.get("completion_usage") if isinstance(chunk, dict) else None
@@ -333,12 +389,15 @@ class ThunderAgentRouterHandler:
             )
             logger.debug(
                 "thunderagent.request_complete program=%s prompt_tokens=%d "
-                "completion_tokens=%d worker_hint=%s selected_worker=%s",
+                "completion_tokens=%d worker_hint=%s dp_rank_hint=%s "
+                "selected_worker=%s selected_dp_rank=%s",
                 program_id,
                 prompt_tokens_seen,
                 completion_tokens_seen,
                 worker_pin,
+                dp_rank_pin,
                 selected_worker_id,
+                selected_dp_rank,
             )
 
     async def status(self, request: Optional[dict[str, Any]] = None):
@@ -382,11 +441,8 @@ class ThunderAgentRouterHandler:
             "workers": scheduler_metrics["workers"],
         }
 
-    def _extract_worker_id(self, chunk: Any) -> Optional[int]:
-        # Expects the shape set by ``inject_worker_id_from_tracker`` in the Python
-        # bindings: worker attribution rides ``routing_data.worker_id``. Log once if the
-        # shape no longer matches; silent extraction failure here means we lose
-        # worker-affinity on pin.
+    def _extract_worker_info(self, chunk: Any) -> Optional[tuple[int, Optional[int]]]:
+        """Extract worker and optional rank from a binding response payload."""
         if not isinstance(chunk, dict):
             self._warn_unexpected_chunk_shape("not a dict")
             return None
@@ -394,27 +450,67 @@ class ThunderAgentRouterHandler:
         if not isinstance(routing_data, dict):
             self._warn_unexpected_chunk_shape("no routing_data dict")
             return None
+
         info = routing_data.get("worker_id")
         if isinstance(info, dict):
-            # ``WorkerIdInfo`` carries prefill/decode IDs (and DP ranks); there is no
-            # nested ``worker_id`` key. The sticky pin is applied as
-            # ``backend_instance_id``, which the frontend resolves to the decode/backend
-            # worker, so prefer ``decode_worker_id`` and fall back to
-            # ``prefill_worker_id`` (identical in aggregated mode).
-            worker_id = info.get("decode_worker_id")
-            if not isinstance(worker_id, int):
-                worker_id = info.get("prefill_worker_id")
-            if isinstance(worker_id, int):
-                return worker_id
+            decode_worker_id = info.get("decode_worker_id")
+            if (
+                isinstance(decode_worker_id, int)
+                and not isinstance(decode_worker_id, bool)
+                and decode_worker_id >= 0
+            ):
+                decode_dp_rank = info.get("decode_dp_rank")
+                if (
+                    isinstance(decode_dp_rank, int)
+                    and not isinstance(decode_dp_rank, bool)
+                    and decode_dp_rank >= 0
+                ):
+                    return (decode_worker_id, decode_dp_rank)
+                # Preserve the original decode-worker preference when an
+                # older binding omitted only the rank field.
+                return (decode_worker_id, None)
+
+            prefill_worker_id = info.get("prefill_worker_id")
+            if (
+                isinstance(prefill_worker_id, int)
+                and not isinstance(prefill_worker_id, bool)
+                and prefill_worker_id >= 0
+            ):
+                prefill_dp_rank = info.get("prefill_dp_rank")
+                if (
+                    isinstance(prefill_dp_rank, int)
+                    and not isinstance(prefill_dp_rank, bool)
+                    and prefill_dp_rank >= 0
+                ):
+                    return (prefill_worker_id, prefill_dp_rank)
+                return (prefill_worker_id, None)
         self._warn_unexpected_chunk_shape("worker_id payload shape changed")
         return None
+
+    def _extract_worker_replica(self, chunk: Any) -> Optional[ReplicaKey]:
+        # Expects the shape set by ``inject_worker_id_from_tracker`` in the Python
+        # bindings: worker attribution rides ``routing_data.worker_id``.  Keep the
+        # worker and its DP rank together so a later sticky pin is unambiguous.
+        info = self._extract_worker_info(chunk)
+        if info is None:
+            return None
+        worker_id, dp_rank = info
+        if dp_rank is None:
+            self._warn_unexpected_chunk_shape("worker_id payload has no dp_rank")
+            return None
+        return (worker_id, dp_rank)
+
+    def _extract_worker_id(self, chunk: Any) -> Optional[int]:
+        """Return only the worker ID for legacy callers."""
+        info = self._extract_worker_info(chunk)
+        return info[0] if info is not None else None
 
     def _warn_unexpected_chunk_shape(self, reason: str) -> None:
         if self._worker_id_extract_warned:
             return
         self._worker_id_extract_warned = True
         logger.warning(
-            "ThunderAgent worker-id extraction failed (%s); subsequent "
+            "ThunderAgent worker/DP-rank extraction failed (%s); subsequent "
             "requests will lose sticky pinning until the binding shape is "
             "fixed.",
             reason,

--- a/components/src/dynamo/thunderagent_router/capacity.py
+++ b/components/src/dynamo/thunderagent_router/capacity.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Per-worker retention budget derived from worker model deployment cards.
+"""Per-replica retention budget derived from worker model deployment cards.
 
 The device KV pool is always ``block_size * total_kv_blocks``. Backends may
 publish additional native offloading capacity through common runtime metadata.
@@ -17,6 +17,7 @@ from typing import Optional
 from dynamo.common.native_offloading import get_native_offloading_capacity_tokens
 from dynamo.llm import FpmEventSubscriber
 from dynamo.runtime import Client, Endpoint
+from dynamo.thunderagent_router.program_state import ReplicaKey
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,7 @@ class WorkerCapacityProvider:
         # Cache parsed cards keyed on the raw JSON string so a subsequent
         # snapshot() call avoids re-parsing on the request hot path.
         self._parsed: dict[str, Optional[int]] = {}
+        self._parsed_dp_ranges: dict[str, tuple[int, int]] = {}
 
     def start(self) -> None:
         if self._subscriber is not None:
@@ -48,7 +50,7 @@ class WorkerCapacityProvider:
             logger.warning("WorkerCapacityProvider shutdown error: %s", exc)
         self._subscriber = None
 
-    def snapshot(self) -> dict[int, int]:
+    def snapshot(self) -> dict[ReplicaKey, int]:
         if self._subscriber is None:
             return {}
         try:
@@ -57,7 +59,7 @@ class WorkerCapacityProvider:
             logger.debug("WorkerCapacityProvider snapshot error: %s", exc)
             return {}
 
-        out: dict[int, int] = {}
+        out: dict[ReplicaKey, int] = {}
         for worker_id_str, card_json in cards.items():
             try:
                 worker_id = int(worker_id_str)
@@ -65,7 +67,9 @@ class WorkerCapacityProvider:
                 continue
             retention_tokens = self._parse_pool_tokens(card_json)
             if retention_tokens is not None:
-                out[worker_id] = retention_tokens
+                dp_start, dp_size = self._parse_dp_range(card_json)
+                for dp_rank in range(dp_start, dp_start + dp_size):
+                    out[(worker_id, dp_rank)] = retention_tokens
         return out
 
     def live_worker_ids(self) -> set[int]:
@@ -101,4 +105,40 @@ class WorkerCapacityProvider:
                 if offloaded_tokens is not None:
                     result += offloaded_tokens
         self._parsed[card_json] = result
+        return result
+
+    def _parse_dp_range(self, card_json: str) -> tuple[int, int]:
+        """Return the global DP rank range advertised by an MDC card.
+
+        Older cards do not include DP metadata, so they represent one replica
+        at rank zero.  Invalid metadata is treated the same way; retaining a
+        single conservative replica is safer than inventing a multi-rank
+        topology from malformed input.
+        """
+        cached = self._parsed_dp_ranges.get(card_json)
+        if cached is not None:
+            return cached
+
+        result = (0, 1)
+        try:
+            card = json.loads(card_json)
+        except json.JSONDecodeError:
+            card = None
+        if isinstance(card, dict):
+            runtime_config = card.get("runtime_config")
+            if isinstance(runtime_config, dict):
+                start = runtime_config.get("data_parallel_start_rank", 0)
+                size = runtime_config.get("data_parallel_size", 1)
+                valid_start = (
+                    isinstance(start, int)
+                    and not isinstance(start, bool)
+                    and start >= 0
+                )
+                valid_size = (
+                    isinstance(size, int) and not isinstance(size, bool) and size > 0
+                )
+                if valid_start and valid_size:
+                    result = (start, size)
+
+        self._parsed_dp_ranges[card_json] = result
         return result

--- a/components/src/dynamo/thunderagent_router/program_state.py
+++ b/components/src/dynamo/thunderagent_router/program_state.py
@@ -16,6 +16,12 @@ from enum import Enum
 from typing import Optional
 
 
+# A router-visible replica is identified by the worker process and its global
+# data-parallel rank.  Keep this alias in the state module so the scheduler and
+# capacity provider share one lightweight type without importing runtime code.
+ReplicaKey = tuple[int, int]
+
+
 class ProgramStatus(Enum):
     REASONING = "reasoning"
     ACTING = "acting"
@@ -35,6 +41,7 @@ class Program:
     lifecycle: ProgramLifecycle = ProgramLifecycle.ACTIVE
 
     assigned_worker_id: Optional[int] = None
+    assigned_dp_rank: Optional[int] = None
 
     token_total: int = 0
 
@@ -59,6 +66,7 @@ class RequestSnapshot:
     status: ProgramStatus
     lifecycle: ProgramLifecycle
     assigned_worker_id: Optional[int]
+    assigned_dp_rank: Optional[int]
     token_total: int
     step_count: int
     marked_for_pause: bool
@@ -101,6 +109,7 @@ class ProgramTable:
             status=program.status,
             lifecycle=program.lifecycle,
             assigned_worker_id=program.assigned_worker_id,
+            assigned_dp_rank=program.assigned_dp_rank,
             token_total=program.token_total,
             step_count=program.step_count,
             marked_for_pause=program.marked_for_pause,
@@ -127,6 +136,7 @@ class ProgramTable:
         program.status = snapshot.status
         program.lifecycle = snapshot.lifecycle
         program.assigned_worker_id = snapshot.assigned_worker_id
+        program.assigned_dp_rank = snapshot.assigned_dp_rank
         program.token_total = snapshot.token_total
         program.step_count = snapshot.step_count
         program.marked_for_pause = snapshot.marked_for_pause

--- a/components/src/dynamo/thunderagent_router/router.py
+++ b/components/src/dynamo/thunderagent_router/router.py
@@ -282,14 +282,27 @@ class ThunderAgentScheduler:
             program.waiting = program.waiting or asyncio.Event()
             return program.waiting, True
 
+        # Keep one capacity view for both sticky-pin validation and admission.
+        # A live worker can change its advertised DP range without changing
+        # its instance ID; an empty or worker-missing snapshot still means
+        # the MDC view is temporarily incomplete, so preserve the existing pin.
+        capacities = self._normalize_capacities(self._capacity.snapshot())
         needs_assignment = not self._has_replica_assignment(program)
         stale_replacement = False
         live_worker_ids: set[int] = set()
         if program.assigned_worker_id is not None:
             live_worker_ids = self._capacity.live_worker_ids()
+            assigned_replica = self._program_replica(program)
+            worker_has_advertised_replica = any(
+                replica[0] == program.assigned_worker_id for replica in capacities
+            )
             if (
-                not live_worker_ids or program.assigned_worker_id in live_worker_ids
-            ) and self._has_replica_assignment(program):
+                (not live_worker_ids or program.assigned_worker_id in live_worker_ids)
+                and assigned_replica is not None
+                and (
+                    not worker_has_advertised_replica or assigned_replica in capacities
+                )
+            ):
                 return None, False
             stale_worker_id = program.assigned_worker_id
             program.assigned_worker_id = None
@@ -309,7 +322,6 @@ class ThunderAgentScheduler:
         if not needs_assignment:
             return None, False
 
-        capacities = self._normalize_capacities(self._capacity.snapshot())
         if stale_replacement:
             capacities = {
                 replica: capacity

--- a/components/src/dynamo/thunderagent_router/router.py
+++ b/components/src/dynamo/thunderagent_router/router.py
@@ -22,6 +22,7 @@ from dynamo.thunderagent_router.program_state import (
     ProgramLifecycle,
     ProgramStatus,
     ProgramTable,
+    ReplicaKey,
     RequestSnapshot,
 )
 
@@ -35,7 +36,28 @@ class PauseDecision:
     waited_seconds: float = 0.0
     was_paused: bool = False
     was_soft_demoted: bool = False
+    # Keep the worker-only field for callers of the original scheduler API;
+    # new routing code consumes the complete replica hint below.
     assigned_worker_hint: Optional[int] = None
+    assigned_dp_rank: Optional[int] = None
+    assigned_replica_hint: Optional[ReplicaKey] = None
+
+    def __post_init__(self) -> None:
+        if self.assigned_replica_hint is None:
+            if (
+                self.assigned_worker_hint is not None
+                and self.assigned_dp_rank is not None
+            ):
+                self.assigned_replica_hint = (
+                    self.assigned_worker_hint,
+                    self.assigned_dp_rank,
+                )
+            return
+        worker_id, dp_rank = self.assigned_replica_hint
+        if self.assigned_worker_hint is None:
+            self.assigned_worker_hint = worker_id
+        if self.assigned_dp_rank is None:
+            self.assigned_dp_rank = dp_rank
 
 
 @dataclass
@@ -156,10 +178,10 @@ class ThunderAgentScheduler:
                             program is not None
                             and program.lifecycle == ProgramLifecycle.PAUSED
                         ):
-                            worker_id = self._least_loaded_worker_locked(
+                            replica = self._least_loaded_replica_locked(
                                 self._capacity.snapshot()
                             )
-                            self._resume_program(program, worker_id)
+                            self._resume_program(program, replica)
                             self._stat_forced_resumes += 1
 
             waited = time.monotonic() - wait_started
@@ -184,7 +206,7 @@ class ThunderAgentScheduler:
                     waited_seconds=waited,
                     was_paused=was_paused,
                     was_soft_demoted=soft_demoted,
-                    assigned_worker_hint=program.assigned_worker_id,
+                    assigned_replica_hint=self._program_replica(program),
                 )
         except asyncio.CancelledError:
             # Admission mutates shared state before the first cancellable wait.
@@ -260,17 +282,22 @@ class ThunderAgentScheduler:
             program.waiting = program.waiting or asyncio.Event()
             return program.waiting, True
 
-        needs_assignment = was_new and program.assigned_worker_id is None
+        needs_assignment = not self._has_replica_assignment(program)
         stale_replacement = False
         live_worker_ids: set[int] = set()
         if program.assigned_worker_id is not None:
             live_worker_ids = self._capacity.live_worker_ids()
-            if not live_worker_ids or program.assigned_worker_id in live_worker_ids:
+            if (
+                not live_worker_ids or program.assigned_worker_id in live_worker_ids
+            ) and self._has_replica_assignment(program):
                 return None, False
             stale_worker_id = program.assigned_worker_id
             program.assigned_worker_id = None
+            program.assigned_dp_rank = None
             needs_assignment = True
-            stale_replacement = True
+            stale_replacement = bool(live_worker_ids) and (
+                stale_worker_id not in live_worker_ids
+            )
             logger.info(
                 "thunderagent.worker stale_pin program=%s old_worker=%s "
                 "available_workers=%s",
@@ -282,27 +309,27 @@ class ThunderAgentScheduler:
         if not needs_assignment:
             return None, False
 
-        capacities = self._capacity.snapshot()
+        capacities = self._normalize_capacities(self._capacity.snapshot())
         if stale_replacement:
             capacities = {
-                worker_id: capacity
-                for worker_id, capacity in capacities.items()
-                if worker_id in live_worker_ids
+                replica: capacity
+                for replica, capacity in capacities.items()
+                if replica[0] in live_worker_ids
             }
 
         if not capacities:
             # Cold start: MDC hasn't published yet. Let the request flow
-            # through with no pin; the chunk-loop callback will populate
-            # ``assigned_worker_id`` once the engine picks a worker, and
-            # subsequent turns get the sticky pin.
+            # through with no pin; the chunk-loop callback will populate the
+            # worker and DP rank once the engine picks a replica, and subsequent
+            # turns get the sticky pin.
             return None, False
-        worker_id = self._select_worker_for_admission_locked(
+        replica = self._select_replica_for_admission_locked(
             capacities,
             program.token_total,
             queue_behind_paused=not stale_replacement,
         )
-        if worker_id is not None:
-            program.assigned_worker_id = worker_id
+        if replica is not None:
+            program.assigned_worker_id, program.assigned_dp_rank = replica
             self._stat_worker_assignments += 1
             return None, False
 
@@ -348,12 +375,76 @@ class ThunderAgentScheduler:
         if do_pause:
             await self._pause_acting(program_id)
 
-    async def assign_worker(self, program_id: str, worker_id: int) -> None:
+    @staticmethod
+    def _normalize_capacities(
+        capacities: dict[Any, int],
+    ) -> dict[ReplicaKey, int]:
+        """Normalize legacy worker-only capacity maps to replica keys."""
+        normalized: dict[ReplicaKey, int] = {}
+        for key, capacity in capacities.items():
+            if (
+                isinstance(key, tuple)
+                and len(key) == 2
+                and all(
+                    isinstance(part, int) and not isinstance(part, bool) for part in key
+                )
+            ):
+                normalized[(key[0], key[1])] = capacity
+            elif isinstance(key, int) and not isinstance(key, bool):
+                normalized[(key, 0)] = capacity
+        return normalized
+
+    @staticmethod
+    def _program_replica(program: Program) -> Optional[ReplicaKey]:
+        if program.assigned_worker_id is None or program.assigned_dp_rank is None:
+            return None
+        return (program.assigned_worker_id, program.assigned_dp_rank)
+
+    @classmethod
+    def _has_replica_assignment(cls, program: Program) -> bool:
+        return cls._program_replica(program) is not None
+
+    async def assign_replica(self, program_id: str, replica: ReplicaKey) -> None:
+        """Record the worker and DP rank selected by the backend."""
+        worker_id, dp_rank = replica
         async with self._lock:
             program = self._table.programs.get(program_id)
             if program is not None:
                 program.assigned_worker_id = worker_id
+                program.assigned_dp_rank = dp_rank
                 self._stat_worker_assignments += 1
+
+    async def assign_worker(
+        self,
+        program_id: str,
+        worker_id: int,
+        dp_rank: Optional[int] = None,
+    ) -> Optional[ReplicaKey]:
+        """Compatibility wrapper for callers that only know a worker ID.
+
+        A worker-only assignment is accepted only when its capacity snapshot
+        identifies exactly one replica. Multi-rank and unknown workers must
+        provide the rank so a request is never pinned ambiguously.
+        """
+        async with self._lock:
+            program = self._table.programs.get(program_id)
+            if program is None:
+                return None
+            if dp_rank is None:
+                capacities = self._normalize_capacities(self._capacity.snapshot())
+                replicas = [key for key in capacities if key[0] == worker_id]
+                if len(replicas) == 1:
+                    dp_rank = replicas[0][1]
+                else:
+                    logger.warning(
+                        "Ignoring ambiguous worker-only assignment for worker=%s",
+                        worker_id,
+                    )
+                    return None
+            program.assigned_worker_id = worker_id
+            program.assigned_dp_rank = dp_rank
+            self._stat_worker_assignments += 1
+            return (worker_id, dp_rank)
 
     async def _scheduler_loop(self) -> None:
         consecutive_failures = 0
@@ -376,7 +467,7 @@ class ThunderAgentScheduler:
             return
 
     async def _scheduler_tick(self) -> None:
-        capacities = self._capacity.snapshot()
+        capacities = self._normalize_capacities(self._capacity.snapshot())
         if not capacities:
             return
         # Upstream TA ordering: resume first, then pause -- a program paused
@@ -398,7 +489,61 @@ class ThunderAgentScheduler:
         )
         return int(program.token_total * (2.0 ** (-(idle / tau))))
 
+    def _active_programs_for_replica(self, replica: ReplicaKey | int) -> list[Program]:
+        if isinstance(replica, tuple):
+            worker_id, dp_rank = replica
+        else:
+            worker_id, dp_rank = replica, 0
+        return [
+            p
+            for p in self._table.programs.values()
+            if p.lifecycle == ProgramLifecycle.ACTIVE
+            and p.assigned_worker_id == worker_id
+            and p.assigned_dp_rank == dp_rank
+        ]
+
+    def _replica_used(self, replica: ReplicaKey | int, *, decayed: bool = False) -> int:
+        programs = self._active_programs_for_replica(replica)
+        tokens = sum(self._program_tokens(p, decayed=decayed) for p in programs)
+        return tokens + len(programs) * self._cfg.buffer_per_program
+
+    def _least_loaded_replica_locked(
+        self, capacities: dict[Any, int]
+    ) -> Optional[ReplicaKey]:
+        capacities = self._normalize_capacities(capacities)
+        if not capacities:
+            return None
+        return max(
+            capacities,
+            key=lambda replica: (
+                capacities[replica] - self._replica_used(replica, decayed=True)
+            ),
+        )
+
+    def _select_replica_for_admission_locked(
+        self,
+        capacities: dict[Any, int],
+        estimated_tokens: int,
+        *,
+        queue_behind_paused: bool,
+    ) -> Optional[ReplicaKey]:
+        capacities = self._normalize_capacities(capacities)
+        # Fairness: new programs queue behind any existing paused program.
+        if queue_behind_paused and self._table.paused:
+            return None
+        buffer = self._cfg.buffer_per_program
+        required = estimated_tokens + buffer
+        candidates = [
+            (replica, self._replica_used(replica))
+            for replica, capacity in capacities.items()
+            if capacity - self._replica_used(replica) >= required
+        ]
+        if not candidates:
+            return None
+        return min(candidates, key=lambda item: item[1])[0]
+
     def _active_programs_for_worker(self, worker_id: int) -> list[Program]:
+        """Return all active programs on a worker (legacy aggregate view)."""
         return [
             p
             for p in self._table.programs.values()
@@ -407,64 +552,60 @@ class ThunderAgentScheduler:
         ]
 
     def _worker_used(self, worker_id: int, *, decayed: bool = False) -> int:
+        """Return aggregate usage across a worker's replicas.
+
+        Admission and pressure decisions use ``_replica_used``; this helper is
+        retained for compatibility with existing operational callers.
+        """
         programs = self._active_programs_for_worker(worker_id)
         tokens = sum(self._program_tokens(p, decayed=decayed) for p in programs)
         return tokens + len(programs) * self._cfg.buffer_per_program
 
-    def _least_loaded_worker_locked(self, capacities: dict[int, int]) -> Optional[int]:
-        if not capacities:
-            return None
-        return max(
-            capacities,
-            key=lambda w: capacities[w] - self._worker_used(w, decayed=True),
-        )
+    def _least_loaded_worker_locked(self, capacities: dict[Any, int]) -> Optional[int]:
+        replica = self._least_loaded_replica_locked(capacities)
+        return replica[0] if replica is not None else None
 
     def _select_worker_for_admission_locked(
         self,
-        capacities: dict[int, int],
+        capacities: dict[Any, int],
         estimated_tokens: int,
         *,
         queue_behind_paused: bool,
     ) -> Optional[int]:
-        # Fairness: new programs queue behind any existing paused program.
-        if queue_behind_paused and self._table.paused:
-            return None
-        buffer = self._cfg.buffer_per_program
-        required = estimated_tokens + buffer
-        candidates = [
-            (w, self._worker_used(w))
-            for w, c in capacities.items()
-            if c - self._worker_used(w) >= required
-        ]
-        if not candidates:
-            return None
-        return min(candidates, key=lambda item: item[1])[0]
+        replica = self._select_replica_for_admission_locked(
+            capacities,
+            estimated_tokens,
+            queue_behind_paused=queue_behind_paused,
+        )
+        return replica[0] if replica is not None else None
 
-    def _apply_soft_demotes(self, capacities: dict[int, int]) -> None:
+    def _apply_soft_demotes(self, capacities: dict[Any, int]) -> None:
+        capacities = self._normalize_capacities(capacities)
         soft_until = time.monotonic() + self._cfg.scheduler_interval_seconds * 1.5
-        for worker_id, capacity in capacities.items():
-            util = self._worker_used(worker_id) / capacity
+        for replica, capacity in capacities.items():
+            util = self._replica_used(replica) / capacity
             if not (
                 self._cfg.soft_demote_threshold <= util < self._cfg.pause_threshold
             ):
                 continue
-            for program in self._active_programs_for_worker(worker_id):
+            for program in self._active_programs_for_replica(replica):
                 if (
                     not program.marked_for_pause
                     and program.soft_demoted_until < soft_until
                 ):
                     program.soft_demoted_until = soft_until
 
-    async def _pause_until_safe(self, capacities: dict[int, int]) -> None:
+    async def _pause_until_safe(self, capacities: dict[Any, int]) -> None:
+        capacities = self._normalize_capacities(capacities)
         threshold = self._cfg.pause_threshold
         pause_target = min(self._cfg.pause_target, threshold)
 
-        for worker_id, capacity in capacities.items():
-            # Hold the lock for the entire per-worker decision so the snapshot
-            # of program state used by _smallest_candidates / _worker_used
+        for replica, capacity in capacities.items():
+            # Hold the lock for the entire per-replica decision so the snapshot
+            # of program state used by _smallest_candidates / _replica_used
             # cannot race with concurrent before_request admissions.
             async with self._lock:
-                base_used = self._worker_used(worker_id)
+                base_used = self._replica_used(replica)
                 if base_used <= capacity * threshold:
                     continue
 
@@ -474,9 +615,9 @@ class ThunderAgentScheduler:
                 # Bound the inner loop by total program count so a candidate
                 # transitioning out from under us can't spin the tick.
                 for _ in range(len(self._table.programs) + 1):
-                    if self._worker_used(worker_id) <= target_limit:
+                    if self._replica_used(replica) <= target_limit:
                         break
-                    acting, reasoning = self._smallest_candidates(worker_id)
+                    acting, reasoning = self._smallest_candidates(replica)
                     if acting is not None:
                         if self._pause_acting_locked(acting.program_id):
                             paused_this_tick += 1
@@ -493,12 +634,14 @@ class ThunderAgentScheduler:
                         continue
                     break
 
-                final_used = self._worker_used(worker_id)
+                final_used = self._replica_used(replica)
 
             if paused_this_tick or marked_this_tick:
                 logger.info(
-                    "scheduler.tick worker=%s paused=%d marked=%d util=%.4f -> %.4f",
-                    worker_id,
+                    "scheduler.tick worker=%s dp_rank=%s paused=%d marked=%d "
+                    "util=%.4f -> %.4f",
+                    replica[0],
+                    replica[1],
                     paused_this_tick,
                     marked_this_tick,
                     base_used / capacity,
@@ -506,12 +649,19 @@ class ThunderAgentScheduler:
                 )
 
     def _smallest_candidates(
-        self, worker_id: int
+        self, replica: ReplicaKey | int
     ) -> tuple[Optional[Program], Optional[Program]]:
+        if isinstance(replica, tuple):
+            worker_id, dp_rank = replica
+        else:
+            worker_id, dp_rank = replica, 0
         smallest_acting: Optional[Program] = None
         smallest_reasoning: Optional[Program] = None
         for program in self._table.programs.values():
-            if program.assigned_worker_id != worker_id:
+            if (
+                program.assigned_worker_id != worker_id
+                or program.assigned_dp_rank != dp_rank
+            ):
                 continue
             if program.lifecycle != ProgramLifecycle.ACTIVE:
                 continue
@@ -545,6 +695,7 @@ class ThunderAgentScheduler:
             return False
         program.lifecycle = ProgramLifecycle.PAUSED
         program.assigned_worker_id = None
+        program.assigned_dp_rank = None
         if program.waiting is None:
             program.waiting = asyncio.Event()
         else:
@@ -584,7 +735,8 @@ class ThunderAgentScheduler:
             )
             return True
 
-    async def _greedy_resume(self, capacities: dict[int, int]) -> None:
+    async def _greedy_resume(self, capacities: dict[Any, int]) -> None:
+        capacities = self._normalize_capacities(capacities)
         if not self._table.paused:
             return
 
@@ -610,11 +762,17 @@ class ThunderAgentScheduler:
                 0.0, self._cfg.pause_threshold - self._cfg.resume_hysteresis
             )
             backend_caps = [
-                (w, int(c * resume_ceiling) - self._worker_used(w, decayed=False))
-                for w, c in capacities.items()
+                (
+                    replica,
+                    int(capacity * resume_ceiling)
+                    - self._replica_used(replica, decayed=False),
+                )
+                for replica, capacity in capacities.items()
             ]
             backend_caps = [
-                (w, r) for w, r in backend_caps if r > self._cfg.buffer_per_program
+                (replica, remaining)
+                for replica, remaining in backend_caps
+                if remaining > self._cfg.buffer_per_program
             ]
             if not backend_caps:
                 return
@@ -643,17 +801,17 @@ class ThunderAgentScheduler:
             for program in resumable_programs:
                 if not backend_caps:
                     break
-                worker_id, remaining = backend_caps[0]
+                replica, remaining = backend_caps[0]
                 if min_required > remaining:
                     break
                 required = program.token_total + self._cfg.buffer_per_program
                 if required > remaining:
                     continue
-                self._resume_program(program, worker_id)
+                self._resume_program(program, replica)
                 resumed_this_tick += 1
                 updated_remaining = remaining - required
                 if updated_remaining > self._cfg.buffer_per_program:
-                    backend_caps[0] = (worker_id, updated_remaining)
+                    backend_caps[0] = (replica, updated_remaining)
                     backend_caps.sort(key=lambda x: -x[1])
                 else:
                     backend_caps.pop(0)
@@ -666,14 +824,32 @@ class ThunderAgentScheduler:
                 )
 
     def _resume_program(
-        self, program: Program, target_worker_id: Optional[int]
+        self,
+        program: Program,
+        target_replica: Optional[ReplicaKey | int] = None,
+        *,
+        target_worker_id: Optional[int] = None,
+        target_dp_rank: Optional[int] = None,
     ) -> None:
         # Caller holds self._lock.
         if program.lifecycle != ProgramLifecycle.PAUSED:
             return
+        if isinstance(target_replica, int):
+            target_replica = (
+                target_replica,
+                0 if target_dp_rank is None else target_dp_rank,
+            )
+        if target_replica is None and target_worker_id is not None:
+            target_replica = (
+                target_worker_id,
+                0 if target_dp_rank is None else target_dp_rank,
+            )
         program.lifecycle = ProgramLifecycle.ACTIVE
-        program.assigned_worker_id = target_worker_id
-        if target_worker_id is not None:
+        if target_replica is None:
+            program.assigned_worker_id = None
+            program.assigned_dp_rank = None
+        else:
+            program.assigned_worker_id, program.assigned_dp_rank = target_replica
             self._stat_worker_assignments += 1
         notify = program.waiting
         program.waiting = None
@@ -682,38 +858,52 @@ class ThunderAgentScheduler:
             notify.set()
         self._stat_resumes += 1
         logger.info(
-            "thunderagent.program resumed program=%s worker=%s tokens=%d paused=%d",
+            "thunderagent.program resumed program=%s worker=%s dp_rank=%s "
+            "tokens=%d paused=%d",
             program.program_id,
-            target_worker_id,
+            target_replica[0] if target_replica is not None else None,
+            target_replica[1] if target_replica is not None else None,
             program.token_total,
             len(self._table.paused),
         )
 
     def _worker_snapshot_locked(
-        self, capacities: dict[int, int]
+        self, capacities: dict[Any, int]
     ) -> dict[str, dict[str, Any]]:
-        """Build worker metrics while the scheduler lock is held."""
-        used = dict.fromkeys(capacities, 0)
-        used_decayed = dict.fromkeys(capacities, 0)
-        active_programs = dict.fromkeys(capacities, 0)
+        """Build worker metrics from per-replica accounting while holding the lock."""
+        capacities = self._normalize_capacities(capacities)
+        replica_rows: dict[ReplicaKey, dict[str, Any]] = {}
+        for replica, capacity in capacities.items():
+            programs = self._active_programs_for_replica(replica)
+            active_count = len(programs)
+            buffer_tokens = active_count * self._cfg.buffer_per_program
+            used = sum(self._program_tokens(p) for p in programs) + buffer_tokens
+            used_decayed = (
+                sum(self._program_tokens(p, decayed=True) for p in programs)
+                + buffer_tokens
+            )
+            replica_rows[replica] = {
+                "worker_id": replica[0],
+                "dp_rank": replica[1],
+                "capacity": capacity,
+                "used": used,
+                "used_decayed": used_decayed,
+                "utilization": used / capacity if capacity else None,
+                "utilization_decayed": used_decayed / capacity if capacity else None,
+                "active_programs": active_count,
+            }
 
-        for program in self._table.programs.values():
-            worker_id = program.assigned_worker_id
-            if (
-                program.lifecycle != ProgramLifecycle.ACTIVE
-                or worker_id is None
-                or worker_id not in capacities
-            ):
-                continue
-            active_programs[worker_id] += 1
-            used[worker_id] += self._program_tokens(program)
-            used_decayed[worker_id] += self._program_tokens(program, decayed=True)
-
-        workers = {}
-        for worker_id, capacity in capacities.items():
-            buffer_tokens = active_programs[worker_id] * self._cfg.buffer_per_program
-            worker_used = used[worker_id] + buffer_tokens
-            worker_used_decayed = used_decayed[worker_id] + buffer_tokens
+        workers: dict[str, dict[str, Any]] = {}
+        for worker_id in dict.fromkeys(replica[0] for replica in capacities):
+            replicas = {
+                str(replica[1]): row
+                for replica, row in replica_rows.items()
+                if replica[0] == worker_id
+            }
+            capacity = sum(row["capacity"] for row in replicas.values())
+            worker_used = sum(row["used"] for row in replicas.values())
+            worker_used_decayed = sum(row["used_decayed"] for row in replicas.values())
+            active_count = sum(row["active_programs"] for row in replicas.values())
             workers[str(worker_id)] = {
                 "capacity": capacity,
                 "used": worker_used,
@@ -722,7 +912,7 @@ class ThunderAgentScheduler:
                 "utilization_decayed": worker_used_decayed / capacity
                 if capacity
                 else None,
-                "active_programs": active_programs[worker_id],
+                "active_programs": active_count,
             }
         return workers
 
@@ -742,6 +932,7 @@ class ThunderAgentScheduler:
                         "lifecycle": program.lifecycle.value,
                         "status": program.status.value,
                         "assigned_worker_id": program.assigned_worker_id,
+                        "assigned_dp_rank": program.assigned_dp_rank,
                         "token_total": program.token_total,
                         "step_count": program.step_count,
                         "marked_for_pause": program.marked_for_pause,

--- a/components/src/dynamo/thunderagent_router/tests/test_capacity.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_capacity.py
@@ -49,12 +49,21 @@ def _card(
     block_size: Optional[int],
     total_blocks: Optional[int],
     host_total_tokens: Optional[int] = None,
+    dp_start: Optional[int] = None,
+    dp_size: Optional[int] = None,
 ) -> str:
     body: dict = {}
     if block_size is not None:
         body["kv_cache_block_size"] = block_size
     if total_blocks is not None:
         body["runtime_config"] = {"total_kv_blocks": total_blocks}
+    if dp_start is not None or dp_size is not None:
+        body.setdefault("runtime_config", {})["data_parallel_start_rank"] = (
+            0 if dp_start is None else dp_start
+        )
+        body.setdefault("runtime_config", {})["data_parallel_size"] = (
+            1 if dp_size is None else dp_size
+        )
     if host_total_tokens is not None:
         body.setdefault("runtime_config", {}).setdefault("runtime_data", {})[
             "native_offloading_capacity"
@@ -64,12 +73,12 @@ def _card(
 
 def test_snapshot_extracts_kv_pool_tokens():
     provider, _ = _make_provider({"1": _card(16, 1000), "2": _card(8, 2000)})
-    assert provider.snapshot() == {1: 16_000, 2: 16_000}
+    assert provider.snapshot() == {(1, 0): 16_000, (2, 0): 16_000}
 
 
 def test_snapshot_adds_native_offloading_tokens_to_retention_budget():
     provider, _ = _make_provider({"1": _card(16, 1_000, host_total_tokens=300)})
-    assert provider.snapshot() == {1: 16_300}
+    assert provider.snapshot() == {(1, 0): 16_300}
 
 
 def test_snapshot_ignores_invalid_native_offloading_capacity():
@@ -78,7 +87,7 @@ def test_snapshot_ignores_invalid_native_offloading_capacity():
         "native_offloading_capacity": {"total_tokens": "300"}
     }
     provider, _ = _make_provider({"1": json.dumps(card)})
-    assert provider.snapshot() == {1: 16_000}
+    assert provider.snapshot() == {(1, 0): 16_000}
 
 
 def test_snapshot_skips_malformed_cards():
@@ -92,12 +101,36 @@ def test_snapshot_skips_malformed_cards():
             "6": _card(16, "abc"),  # type: ignore[arg-type]
         }
     )
-    assert provider.snapshot() == {1: 16_000}
+    assert provider.snapshot() == {(1, 0): 16_000}
 
 
 def test_snapshot_skips_unparseable_worker_ids():
     provider, _ = _make_provider({"not-an-int": _card(16, 1000)})
     assert provider.snapshot() == {}
+
+
+def test_snapshot_expands_capacity_for_each_data_parallel_rank():
+    provider, _ = _make_provider(
+        {
+            "7": _card(16, 1000, dp_start=2, dp_size=3),
+            "8": _card(8, 2000, dp_size=2),
+        }
+    )
+    assert provider.snapshot() == {
+        (7, 2): 16_000,
+        (7, 3): 16_000,
+        (7, 4): 16_000,
+        (8, 0): 16_000,
+        (8, 1): 16_000,
+    }
+
+
+def test_snapshot_uses_single_rank_for_invalid_data_parallel_metadata():
+    card = json.loads(_card(16, 1000))
+    card["runtime_config"]["data_parallel_start_rank"] = -1
+    card["runtime_config"]["data_parallel_size"] = 4
+    provider, _ = _make_provider({"1": json.dumps(card)})
+    assert provider.snapshot() == {(1, 0): 16_000}
 
 
 def test_parsed_cards_cache_hits_on_repeat_snapshot():
@@ -110,7 +143,7 @@ def test_parsed_cards_cache_hits_on_repeat_snapshot():
     # Second snapshot returns same result without touching json.loads;
     # we sentinel-check by mutating the cached value.
     provider._parsed[cards["1"]] = 999_999
-    assert provider.snapshot() == {1: 999_999}
+    assert provider.snapshot() == {(1, 0): 999_999}
 
 
 def test_snapshot_returns_empty_when_subscriber_unset():

--- a/components/src/dynamo/thunderagent_router/tests/test_main.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_main.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused tests for replica attribution on the router response path."""
+
+from __future__ import annotations
+
+import pytest
+
+from dynamo.thunderagent_router.__main__ import ThunderAgentRouterHandler
+from dynamo.thunderagent_router.router import PauseDecision
+
+pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
+
+
+def _handler() -> ThunderAgentRouterHandler:
+    handler = object.__new__(ThunderAgentRouterHandler)
+    handler._worker_id_extract_warned = False
+    return handler
+
+
+def test_extract_worker_replica_prefers_decode_attribution():
+    chunk = {
+        "routing_data": {
+            "worker_id": {
+                "prefill_worker_id": 10,
+                "prefill_dp_rank": 1,
+                "decode_worker_id": 11,
+                "decode_dp_rank": 3,
+            }
+        }
+    }
+
+    assert _handler()._extract_worker_replica(chunk) == (11, 3)
+
+
+def test_extract_worker_replica_falls_back_to_prefill_attribution():
+    chunk = {
+        "routing_data": {
+            "worker_id": {
+                "prefill_worker_id": 10,
+                "prefill_dp_rank": 1,
+            }
+        }
+    }
+
+    assert _handler()._extract_worker_replica(chunk) == (10, 1)
+
+
+def test_extract_worker_id_accepts_legacy_worker_without_rank():
+    chunk = {"routing_data": {"worker_id": {"decode_worker_id": 11}}}
+
+    handler = _handler()
+
+    assert handler._extract_worker_replica(chunk) is None
+    assert handler._extract_worker_id(chunk) == 11
+
+
+def test_extract_worker_replica_keeps_decode_preference_when_rank_is_missing():
+    chunk = {
+        "routing_data": {
+            "worker_id": {
+                "decode_worker_id": 11,
+                "prefill_worker_id": 10,
+                "prefill_dp_rank": 1,
+            }
+        }
+    }
+
+    assert _handler()._extract_worker_replica(chunk) is None
+
+
+class _FakeScheduler:
+    def __init__(self, replica: tuple[int, int] | None) -> None:
+        self._replica = replica
+        self.assigned: list[tuple[str, tuple[int, int]]] = []
+
+    async def before_request(self, program_id: str, **_kwargs) -> PauseDecision:
+        return PauseDecision(program_id, assigned_replica_hint=self._replica)
+
+    async def assign_replica(self, program_id: str, replica: tuple[int, int]) -> None:
+        self.assigned.append((program_id, replica))
+
+    def record_output_tokens(self, _program_id: str, _tokens: int) -> None:
+        pass
+
+    async def after_request(self, *_args) -> None:
+        pass
+
+
+class _FakeKvRouter:
+    def __init__(self, response_replica: tuple[int, int]) -> None:
+        self._response_replica = response_replica
+        self.request = None
+
+    async def generate_from_request(self, request):
+        self.request = request
+        worker_id, dp_rank = self._response_replica
+
+        async def response_stream():
+            yield {
+                "token_ids": [42],
+                "routing_data": {
+                    "worker_id": {
+                        "decode_worker_id": worker_id,
+                        "decode_dp_rank": dp_rank,
+                    }
+                },
+            }
+
+        return response_stream()
+
+
+def _initialized_handler(
+    scheduler: _FakeScheduler, kv_router: _FakeKvRouter
+) -> ThunderAgentRouterHandler:
+    handler = _handler()
+    handler._scheduler = scheduler  # type: ignore[assignment]
+    handler._kv_router = kv_router  # type: ignore[assignment]
+    handler._stat_requests_total = 0
+    handler._stat_program_requests = 0
+    handler._stat_passthrough_requests = 0
+    handler._stat_session_final_requests = 0
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_program_request_pins_worker_and_data_parallel_rank():
+    scheduler = _FakeScheduler((11, 3))
+    kv_router = _FakeKvRouter((11, 3))
+    handler = _initialized_handler(scheduler, kv_router)
+
+    chunks = [
+        chunk
+        async for chunk in handler.generate(
+            {"token_ids": [1, 2], "agent_context": {"session_id": "p1"}}
+        )
+    ]
+
+    assert chunks
+    assert kv_router.request["routing"] == {
+        "backend_instance_id": 11,
+        "dp_rank": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_cold_start_records_selected_worker_and_data_parallel_rank():
+    scheduler = _FakeScheduler(None)
+    kv_router = _FakeKvRouter((21, 2))
+    handler = _initialized_handler(scheduler, kv_router)
+
+    _ = [
+        chunk
+        async for chunk in handler.generate(
+            {"token_ids": [1], "agent_context": {"session_id": "p1"}}
+        )
+    ]
+
+    assert scheduler.assigned == [("p1", (21, 2))]

--- a/components/src/dynamo/thunderagent_router/tests/test_program_state.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_program_state.py
@@ -111,6 +111,23 @@ def test_snapshot_and_rollback_track_the_admission_epoch():
     assert program.admission_epoch == 1
 
 
+def test_snapshot_and_rollback_preserve_replica_assignment():
+    table = ProgramTable()
+    program = table.begin_request("p1")
+    program.assigned_worker_id = 4
+    program.assigned_dp_rank = 3
+
+    snapshot = table.snapshot_request("p1")
+    assert snapshot is not None
+
+    program.assigned_worker_id = 8
+    program.assigned_dp_rank = 1
+    table.rollback_request("p1", snapshot)
+
+    assert program.assigned_worker_id == 4
+    assert program.assigned_dp_rank == 3
+
+
 def test_rollback_clears_a_wait_event_the_resume_had_set():
     table = ProgramTable()
     table.begin_request("p1")

--- a/components/src/dynamo/thunderagent_router/tests/test_router.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_router.py
@@ -12,7 +12,11 @@ from typing import Optional
 
 import pytest
 
-from dynamo.thunderagent_router.program_state import ProgramLifecycle, ProgramStatus
+from dynamo.thunderagent_router.program_state import (
+    ProgramLifecycle,
+    ProgramStatus,
+    ReplicaKey,
+)
 from dynamo.thunderagent_router.router import ThunderAgentConfig, ThunderAgentScheduler
 
 pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
@@ -20,22 +24,22 @@ pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
 
 @dataclass
 class FakeCapacity:
-    """Stand-in for WorkerCapacityProvider with configurable worker state."""
+    """Stand-in for WorkerCapacityProvider with configurable replica state."""
 
-    workers: dict[int, int] = field(default_factory=dict)
+    workers: dict[ReplicaKey | int, int] = field(default_factory=dict)
     live_workers: Optional[set[int]] = None
 
-    def snapshot(self) -> dict[int, int]:
+    def snapshot(self) -> dict[ReplicaKey | int, int]:
         return dict(self.workers)
 
     def live_worker_ids(self) -> set[int]:
         if self.live_workers is not None:
             return set(self.live_workers)
-        return set(self.workers)
+        return {key[0] if isinstance(key, tuple) else key for key in self.workers}
 
 
 def make_router(
-    capacity_workers: Optional[dict[int, int]] = None,
+    capacity_workers: Optional[dict[ReplicaKey | int, int]] = None,
     config: Optional[ThunderAgentConfig] = None,
 ) -> tuple[ThunderAgentScheduler, FakeCapacity]:
     capacity = FakeCapacity(workers=capacity_workers or {})
@@ -131,9 +135,88 @@ async def test_before_request_records_exact_prompt_estimate_before_admission():
 async def test_assigned_worker_hint_reflects_sticky_assignment():
     router, _ = make_router()
     await router.before_request("p1", estimated_prompt_tokens=100)
-    await router.assign_worker("p1", 3)
+    await router.assign_replica("p1", (3, 0))
     decision = await router.before_request("p1", estimated_prompt_tokens=100)
     assert decision.assigned_worker_hint == 3
+
+
+@pytest.mark.asyncio
+async def test_worker_only_assignment_requires_one_advertised_replica():
+    router, capacity = make_router()
+    await router.before_request("p1")
+
+    assert await router.assign_worker("p1", 3) is None
+    assert router._table.programs["p1"].assigned_worker_id is None
+
+    capacity.workers = {(3, 2): 1_000}
+    assert await router.assign_worker("p1", 3) == (3, 2)
+    assert router._table.programs["p1"].assigned_dp_rank == 2
+
+
+@pytest.mark.asyncio
+async def test_admission_accounts_for_each_data_parallel_replica():
+    router, _ = make_router(
+        capacity_workers={(7, 0): 1_000, (7, 1): 1_000},
+    )
+
+    first = await router.before_request("p1", estimated_prompt_tokens=100)
+    second = await router.before_request("p2", estimated_prompt_tokens=100)
+
+    assert first.assigned_replica_hint == (7, 0)
+    assert second.assigned_replica_hint == (7, 1)
+    assert router._table.programs["p1"].assigned_dp_rank == 0
+    assert router._table.programs["p2"].assigned_dp_rank == 1
+    assert router._replica_used((7, 0)) == 200
+    assert router._replica_used((7, 1)) == 200
+
+
+@pytest.mark.asyncio
+async def test_pressure_control_is_scoped_to_one_data_parallel_replica():
+    cfg = ThunderAgentConfig(
+        pause_threshold=0.80,
+        pause_target=0.80,
+        acting_token_weight=1.0,
+        scheduler_interval_seconds=10.0,
+    )
+    router, _ = make_router(
+        capacity_workers={(7, 0): 1_000, (7, 1): 1_000},
+        config=cfg,
+    )
+
+    for pid, replica, prompt_tokens in [
+        ("hot_big", (7, 0), 700),
+        ("hot_small", (7, 0), 200),
+        ("cold", (7, 1), 700),
+    ]:
+        await router.before_request(pid)
+        await router.assign_replica(pid, replica)
+        await router.after_request(
+            pid, prompt_tokens=prompt_tokens, completion_tokens=0
+        )
+
+    await router._pause_until_safe(router._capacity.snapshot())
+
+    assert router._table.programs["hot_small"].lifecycle == ProgramLifecycle.PAUSED
+    assert router._table.programs["hot_big"].lifecycle == ProgramLifecycle.ACTIVE
+    assert router._table.programs["cold"].lifecycle == ProgramLifecycle.ACTIVE
+    assert router._table.programs["cold"].assigned_dp_rank == 1
+
+
+@pytest.mark.asyncio
+async def test_resume_assigns_both_worker_and_data_parallel_rank():
+    router, _ = make_router()
+    await router.before_request("p1")
+    await router.assign_replica("p1", (3, 2))
+    await router.after_request("p1", prompt_tokens=100, completion_tokens=10)
+    await router._pause_acting("p1")
+
+    async with router._lock:
+        router._resume_program(router._table.programs["p1"], (3, 2))
+
+    program = router._table.programs["p1"]
+    assert program.lifecycle == ProgramLifecycle.ACTIVE
+    assert program.assigned_worker_id == 3
+    assert program.assigned_dp_rank == 2
 
 
 @pytest.mark.asyncio
@@ -189,7 +272,7 @@ async def test_pause_acting_then_before_request_blocks_until_resume():
     router, _ = make_router(config=cfg)
 
     await router.before_request("p1")
-    await router.assign_worker("p1", 0)
+    await router.assign_replica("p1", (0, 0))
     await router.after_request("p1", prompt_tokens=100, completion_tokens=10)
     await router._pause_acting("p1")
     assert router._table.programs["p1"].lifecycle == ProgramLifecycle.PAUSED
@@ -217,7 +300,7 @@ async def test_forced_resume_after_timeout():
     )
     router, _ = make_router(config=cfg)
     await router.before_request("p1")
-    await router.assign_worker("p1", 0)
+    await router.assign_replica("p1", (0, 0))
     await router.after_request("p1", prompt_tokens=100, completion_tokens=10)
     await router._pause_acting("p1")
     decision = await router.before_request("p1")
@@ -369,7 +452,7 @@ async def test_pause_drives_util_to_pause_target_not_threshold():
     for i in range(10):
         pid = f"p{i}"
         await router.before_request(pid)
-        await router.assign_worker(pid, 1)
+        await router.assign_replica(pid, (1, 0))
         await router.after_request(pid, prompt_tokens=100_000, completion_tokens=0)
 
     await router._pause_until_safe(router._capacity.snapshot())
@@ -406,7 +489,7 @@ async def test_scheduler_tick_resumes_before_pausing_new_overload():
     for i in range(10):
         pid = f"p{i}"
         await router.before_request(pid)
-        await router.assign_worker(pid, 1)
+        await router.assign_replica(pid, (1, 0))
         await router.after_request(pid, prompt_tokens=100, completion_tokens=0)
         router._table.programs[pid].acting_since = time.monotonic() - 10.0
 
@@ -476,7 +559,7 @@ async def test_cancelled_admission_of_existing_program_restores_prior_turn():
     router, _ = make_router(config=cfg)
 
     await router.before_request("p1")
-    await router.assign_worker("p1", 1)
+    await router.assign_replica("p1", (1, 0))
     await router.after_request("p1", prompt_tokens=100, completion_tokens=10)
     await router._pause_acting("p1")
 
@@ -572,7 +655,7 @@ async def test_cancelled_admission_serializes_a_later_turn():
     router, _ = make_router(config=cfg)
 
     await router.before_request("p1")
-    await router.assign_worker("p1", 1)
+    await router.assign_replica("p1", (1, 0))
     await router.after_request("p1", prompt_tokens=100, completion_tokens=10)
     await router._pause_acting("p1")
     program = router._table.programs["p1"]

--- a/components/src/dynamo/thunderagent_router/tests/test_router.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_router.py
@@ -241,6 +241,24 @@ async def test_stale_worker_assignment_moves_to_replacement():
 
 
 @pytest.mark.asyncio
+async def test_stale_data_parallel_rank_is_reassigned_when_worker_remains_live():
+    router, capacity = make_router(capacity_workers={(7, 0): 1000})
+    decision = await router.before_request("p1", estimated_prompt_tokens=100)
+    assert decision.assigned_replica_hint == (7, 0)
+    await router.after_request("p1", prompt_tokens=100, completion_tokens=0)
+
+    # The worker process is still live, but its advertised DP range no longer
+    # contains the rank used by the previous turn.
+    capacity.workers = {(7, 1): 1000}
+    capacity.live_workers = {7}
+
+    decision = await router.before_request("p1", estimated_prompt_tokens=100)
+
+    assert decision.assigned_replica_hint == (7, 1)
+    assert router._table.programs["p1"].assigned_dp_rank == 1
+
+
+@pytest.mark.asyncio
 async def test_stale_replacement_bypasses_new_program_fairness_gate():
     router, capacity = make_router(capacity_workers={1: 300})
     decision = await router.before_request("active", estimated_prompt_tokens=100)


### PR DESCRIPTION
## Overview

Fix ThunderAgent program scheduling for workers that expose multiple data-parallel ranks by carrying the selected rank through admission, response attribution, and sticky routing.

## Summary

- Model per-rank retention capacity from worker deployment cards.
- Account for admission, pressure, and resume decisions by `(worker_id, dp_rank)`.
- Forward the selected backend instance and DP rank for subsequent turns.

## Details

ThunderAgent previously modeled capacity and affinity by worker ID only. KV routing identifies each replica by `(worker_id, dp_rank)` and rejects a worker-only pin when it owns multiple ranks. The scheduler now expands each model card's per-rank retention budget, accounts for programs independently per replica, preserves rank in program snapshots and resume decisions, and forwards `backend_instance_id` with `dp_rank`. Response attribution reads the decode/prefill rank from `WorkerIdInfo`, with a narrow legacy fallback that only resolves a uniquely advertised rank.

## Validation

Focused ThunderAgent checks, syntax compilation, formatting, targeted lint, and whitespace checks pass, including coverage that reassigns a live worker when its advertised rank range changes. The project's broader pre-merge and GPU-backed checks remain to be completed online; they require native runtime/build dependencies and GPUs not present in this local environment.

## Where should the reviewer start?

- `components/src/dynamo/thunderagent_router/capacity.py` and `router.py` for per-replica capacity, admission, and pressure accounting.
- `components/src/dynamo/thunderagent_router/__main__.py` for rank propagation and response attribution.
- Focused tests under `components/src/dynamo/thunderagent_router/tests/`.

## Related Issues

- Closes #13968


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added data-parallel-aware request routing for more precise replica selection and assignment.
  * Capacity, admission, pausing, resuming, and utilization tracking now operate per worker replica and data-parallel rank.
  * Route proofs, request logs, and status information include selected data-parallel rank details.
  * Added validation and reassignment for unavailable or outdated replica assignments.

* **Bug Fixes**
  * Preserved compatibility with older worker-only routing metadata and assignments.
  * Improved fallback handling when data-parallel metadata is missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->