### PR TITLE
fix(frontend): stop tool_call_dispatch handing harnesses truncated arguments

### DIFF
--- a/docs/fern/pages/blog/2026/agentic-harness-support.mdx
+++ b/docs/fern/pages/blog/2026/agentic-harness-support.mdx
@@ -183,6 +183,8 @@ data: {"choice_index":0,"tool_call":{"index":0,"id":"call-...","type":"function"
 
 That event tells the harness, in one shot, that the tool call is ready to execute. No harness-side delta assembly, no guessing whether the arguments are complete, and no custom parser living inside the harness. This makes Dynamo more easily compatible with custom harnesses.
 
+Getting that guarantee right depends on where Dynamo decides a call is complete. Producers fragment a single tool call across several deltas: one delta opens the call with `id`, `type`, and `function.name`, and later deltas carry `function.arguments` a piece at a time. Dynamo assembles those deltas per request, keyed by the choice index and the tool call's own `index`, and only dispatches once the accumulated `arguments` are a complete JSON value — tracked incrementally, so a `}` inside a string literal does not end the call early. Absent or empty `arguments`, which is how a parameterless tool arrives, resolve at `finish_reason: "tool_calls"` instead. Each tool call dispatches at most once per request, and a call whose arguments never become valid JSON, or whose identity fields disagree between deltas, is never dispatched at all: the harness still sees it through the ordinary tool-call deltas, which the side channel never replaces.
+
 ![Tool dispatch timing on a single turn. Standard servers surface the tool call only after the entire stream finishes; Dynamo emits a typed tool_call_dispatch event the moment the call is parsed, so the tool can run in parallel with the rest of the stream. Δt is the time saved per tool call.](../_assets/agentic-inference/images/fig-3-streaming-dispatch-timeline.svg)
 
 ## Anthropic API Fidelity for Claude Code and OpenClaw

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2747,9 +2747,8 @@ impl JsonStructureScanner {
             if !self.root_started {
                 self.root_started = true;
                 if byte == b'}' || byte == b']' {
-                    // A closing token with nothing open — this is what makes
-                    // `}{"x":1}` a permanent non-dispatch rather than a call
-                    // that reads complete after clamping depth to zero.
+                    // A closing token with nothing open: `}{"x":1}` is a
+                    // permanent non-dispatch, not a depth-clamped completion.
                     self.malformed = true;
                     break;
                 }
@@ -2865,9 +2864,8 @@ fn update_tool_call_assembly(
     let entry = assemblies
         .entry((choice_index, chunk.index))
         .or_insert_with(|| ToolCallAssembly {
-            // An entry is created for *every* chunk. Requiring id and name to
-            // coexist in the chunk that opens the entry is the bug this
-            // replaces: arguments legally arrive before identity.
+            // An entry is created for *every* chunk: arguments legally
+            // arrive before identity.
             accumulated: ChatCompletionMessageToolCallChunk {
                 index: chunk.index,
                 id: None,
@@ -2882,11 +2880,8 @@ fn update_tool_call_assembly(
     match entry.state {
         AssemblyState::Invalid => return,
         AssemblyState::Emitted => {
-            // An exact replay of an already-dispatched chunk is the
-            // pre-existing duplicate-backend-chunk case and stays silent. A
-            // *different* continuation after emission is a producer violation:
-            // an SSE event that has already gone out cannot be retracted, so
-            // log and suppress.
+            // An exact replay is the duplicate-backend-chunk case; an emitted
+            // SSE event cannot be retracted, so a differing continuation is dropped.
             if !is_exact_replay(entry, chunk) {
                 tracing::warn!(
                     choice_index,
@@ -2900,9 +2895,8 @@ fn update_tool_call_assembly(
         AssemblyState::Accumulating => {}
     }
 
-    // Scan only the bytes of the arriving fragment, never the accumulated
-    // buffer. `merge_tool_call_chunk` is the same first-wins identity /
-    // concatenated-arguments policy the non-streaming aggregator uses.
+    // Scan only the arriving fragment's bytes, never the accumulated buffer.
+    // `merge_tool_call_chunk` is the aggregator's own first-wins policy.
     let fragment = chunk
         .function
         .as_ref()
@@ -2991,9 +2985,8 @@ fn finalize_choice_assemblies(
         }
 
         if finish_reason != FinishReason::ToolCalls {
-            // `length`, a backend error, a content filter: nothing valid is
-            // lost by clearing, because a syntactically complete call would
-            // already have dispatched early.
+            // `length`, a backend error, a content filter: a syntactically
+            // complete call would already have dispatched, so nothing is lost.
             entry.state = AssemblyState::Invalid;
             continue;
         }
@@ -3004,9 +2997,8 @@ fn finalize_choice_assemblies(
             .as_ref()
             .and_then(|f| f.arguments.as_deref());
         let usable = match accumulated_args {
-            // Absent or empty-string arguments for a parameterless tool. This
-            // is the only place that compatibility is safe: the choice has
-            // definitively stopped producing arguments.
+            // Absent or empty arguments for a parameterless tool: only safe
+            // here, where the choice has stopped producing arguments.
             None | Some("") => true,
             Some(args) => {
                 entry.json_confirmed || serde_json::from_str::<serde_json::Value>(args).is_ok()
@@ -8485,11 +8477,8 @@ mod tests {
 
     #[test]
     fn test_tool_dispatch_empty_arguments_dispatch_at_terminal_pass() {
-        // `arguments: Some("")` used to be treated as complete on arrival. It
-        // is ambiguous mid-stream — a parameterless call, or an empty opener
-        // about to be followed by real fragments — so the parameterless
-        // compatibility now resolves at `finish_reason: "tool_calls"`, where
-        // the choice has definitively stopped producing arguments.
+        // `Some("")` is ambiguous mid-stream, so the parameterless-tool
+        // compatibility resolves at `finish_reason: "tool_calls"`.
         let events = drive_to_tool_calls_finish(
             vec![make_choice_with_tool_call(
                 0,
@@ -8568,10 +8557,7 @@ mod tests {
     }
 
     // ── #13972: fragmented tool-call assembly ──
-    //
-    // The dispatcher assembles `function.arguments` across deltas instead of
-    // requiring id, name, and arguments on one chunk. Cases below are numbered
-    // to match the issue's regression list.
+    // Case numbers below match the issue's regression list.
 
     /// Read the assembled arguments for a key directly, so quoted-brace
     /// payloads never go through `extract_sse_data_json`'s brace-only,
@@ -8688,9 +8674,8 @@ mod tests {
         );
     }
 
-    // Case 5: quoted braces, escaped quotes, and a backslash split across
-    // fragments must not create a false boundary. Asserted on typed state, not
-    // on `extract_sse_data_json`.
+    // Case 5: quoted braces, escaped quotes, and a split backslash must not
+    // create a false boundary. Asserted on typed state.
     #[test]
     fn test_13972_quoted_and_escaped_braces_do_not_close_early() {
         let (events, assemblies) = feed_fragments(&[

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2828,7 +2828,6 @@ fn is_exact_replay(entry: &ToolCallAssembly, chunk: &ChatCompletionMessageToolCa
     accumulated_args == incoming_args
 }
 
-/// Emit the dispatch event for `entry` and tombstone it.
 fn emit_tool_call_dispatch(
     choice_index: u32,
     entry: &mut ToolCallAssembly,
@@ -2937,7 +2936,7 @@ fn update_tool_call_assembly(
                     .as_ref()
                     .and_then(|f| f.arguments.as_deref())
                     .unwrap_or("");
-                if serde_json::from_str::<serde_json::Value>(accumulated_args).is_err() {
+                if serde_json::from_str::<serde::de::IgnoredAny>(accumulated_args).is_err() {
                     tracing::warn!(
                         choice_index,
                         tool_call_index = chunk.index,
@@ -3004,7 +3003,7 @@ fn finalize_choice_assemblies(
             // here, where the choice has stopped producing arguments.
             None | Some("") => true,
             Some(args) => {
-                entry.json_confirmed || serde_json::from_str::<serde_json::Value>(args).is_ok()
+                entry.json_confirmed || serde_json::from_str::<serde::de::IgnoredAny>(args).is_ok()
             }
         };
 
@@ -8168,7 +8167,6 @@ mod tests {
         }
     }
 
-    /// Build a choice carrying the given tool-call chunks and finish reason.
     fn make_choice_with_tool_calls(
         index: u32,
         tool_calls: Vec<ChatCompletionMessageToolCallChunk>,
@@ -8194,13 +8192,10 @@ mod tests {
         }
     }
 
-    /// A choice whose only content is a terminal `finish_reason`.
     fn make_finish_choice(index: u32, finish: FinishReason) -> ChatChoiceStream {
         make_choice_with_tool_calls(index, vec![], Some(finish))
     }
 
-    /// Feed one delta and then a `finish_reason: "tool_calls"` terminator,
-    /// returning the events from both, in order.
     fn drive_to_tool_calls_finish(
         choices: Vec<ChatChoiceStream>,
         finish_choice_index: u32,
@@ -8559,8 +8554,6 @@ mod tests {
         assert!(events.is_empty(), "duplicate id should not dispatch twice");
     }
 
-    // ── #13972: fragmented tool-call assembly ──
-
     /// Read the assembled arguments for a key directly, so quoted-brace
     /// payloads never go through `extract_sse_data_json`'s brace-only,
     /// string-unaware scan.
@@ -8586,7 +8579,6 @@ mod tests {
         (events, assemblies)
     }
 
-    // Case 2: an identity opener followed by argument-only fragments.
     #[test]
     fn test_13972_identity_opener_then_argument_fragments() {
         let (events, assemblies) = feed_fragments(&[
@@ -8612,7 +8604,6 @@ mod tests {
         );
     }
 
-    // Case 6 (truncated JSON): the prefix must never dispatch on its own.
     #[test]
     fn test_13972_truncated_prefix_never_dispatches() {
         let (events, _) = feed_fragments(&[(
@@ -8626,7 +8617,6 @@ mod tests {
         );
     }
 
-    // Case 3: `Some("")` is an opener, not a completion.
     #[test]
     fn test_13972_empty_opener_then_fragments_does_not_dispatch_early() {
         let (events, assemblies) = feed_fragments(&[
@@ -8643,7 +8633,6 @@ mod tests {
         );
     }
 
-    // Case 4: id, name, and arguments arriving on three different chunks.
     #[test]
     fn test_13972_identity_after_arguments_still_assembles() {
         let (events, _) = feed_fragments(&[
@@ -8662,7 +8651,43 @@ mod tests {
         assert_eq!(json["tool_call"]["function"]["arguments"], r#"{"a":1}"#);
     }
 
-    // Case 4 (second half): a conflicting repeated identity fails closed.
+    // A magnitude `f64` cannot hold is still valid JSON syntax. Confirmation
+    // is a syntax check, so such a call dispatches; deserializing into
+    // `serde_json::Value` would reject it as `number out of range` and drop a
+    // call the model legitimately made.
+    #[test]
+    fn test_13972_out_of_range_exponent_dispatches() {
+        let (early, _) = feed_fragments(&[(Some("call_1"), Some("f"), Some(r#"{"a":1e400}"#))]);
+        assert_eq!(
+            early.len(),
+            1,
+            "an out-of-range exponent is syntactically valid and must dispatch early"
+        );
+        let json = extract_sse_data_json(early[0].as_ref().unwrap());
+        assert_eq!(
+            json["tool_call"]["function"]["arguments"], r#"{"a":1e400}"#,
+            "the argument string is forwarded verbatim, not renormalized"
+        );
+
+        // The terminal pass confirms independently when the scanner never
+        // reached a candidate boundary, so it needs the same syntax-only rule.
+        let terminal = drive_to_tool_calls_finish(
+            vec![make_choice_with_tool_call(
+                0,
+                0,
+                Some("call_2"),
+                Some("f"),
+                Some("-1e400"),
+            )],
+            0,
+        );
+        assert_eq!(
+            terminal.len(),
+            1,
+            "a top-level out-of-range scalar resolves at the terminal pass"
+        );
+    }
+
     #[test]
     fn test_13972_conflicting_identity_fails_closed() {
         let (events, _) = feed_fragments(&[
@@ -8676,8 +8701,8 @@ mod tests {
         );
     }
 
-    // Case 5: quoted braces, escaped quotes, and a split backslash must not
-    // create a false boundary. Asserted on typed state.
+    // Quoted braces, escaped quotes, and a split backslash must not create a
+    // false boundary. Asserted on typed state.
     #[test]
     fn test_13972_quoted_and_escaped_braces_do_not_close_early() {
         let (events, assemblies) = feed_fragments(&[
@@ -8692,7 +8717,6 @@ mod tests {
         );
     }
 
-    // Case 5 (containers): nested objects and a top-level array.
     #[test]
     fn test_13972_nested_and_array_roots_complete() {
         let (nested, _) = feed_fragments(&[
@@ -8708,7 +8732,6 @@ mod tests {
         assert_eq!(array.len(), 1, "a top-level array is self-delimiting");
     }
 
-    // Case 6: trailing junk in the completing fragment never dispatches.
     #[test]
     fn test_13972_trailing_junk_never_dispatches() {
         let (events, _) = feed_fragments(&[(Some("call_1"), Some("f"), Some("{}junk"))]);
@@ -8718,8 +8741,8 @@ mod tests {
         );
     }
 
-    // Case 6: mismatched containers. `}{\"x\":1}` read as complete under
-    // #6845's depth-clamping scanner; it must be a permanent non-dispatch.
+    // `}{\"x\":1}` read as complete under #6845's depth-clamping scanner; it
+    // must be a permanent non-dispatch.
     #[test]
     fn test_13972_mismatched_containers_never_dispatch() {
         let (early, _) = feed_fragments(&[(Some("call_1"), Some("f"), Some(r#"}{"x":1}"#))]);
@@ -8742,14 +8765,12 @@ mod tests {
         );
     }
 
-    // Case 6: leading junk never dispatches.
     #[test]
     fn test_13972_leading_junk_never_dispatches() {
         let (events, _) = feed_fragments(&[(Some("call_1"), Some("f"), Some(r#"junk{"a":1}"#))]);
         assert!(events.is_empty(), "leading junk must not dispatch");
     }
 
-    // Case 2/6 boundary: a canonical parameterless `{}` may dispatch early.
     #[test]
     fn test_13972_canonical_empty_object_dispatches_early() {
         let (events, _) = feed_fragments(&[(Some("call_1"), Some("no_params"), Some("{}"))]);
@@ -8760,7 +8781,6 @@ mod tests {
         );
     }
 
-    // Case 7: two calls in one choice interleave and complete in reverse order.
     #[test]
     fn test_13972_interleaved_inner_indexes_complete_out_of_order() {
         let mut assemblies = ToolCallAssemblies::new();
@@ -8802,7 +8822,6 @@ mod tests {
         assert_eq!(second["tool_call"]["function"]["arguments"], r#"{"a":1}"#);
     }
 
-    // Case 8: two choices sharing inner index 0 and the same call id.
     #[test]
     fn test_13972_same_id_and_inner_index_across_choices_do_not_collide() {
         let mut assemblies = ToolCallAssemblies::new();
@@ -8906,7 +8925,6 @@ mod tests {
             "truncated arguments must not dispatch on a `Stop` finish either"
         );
 
-        // Invalid non-empty JSON does not.
         let invalid = drive_to_tool_calls_finish(
             vec![make_choice_with_tool_call(
                 0,
@@ -8939,41 +8957,8 @@ mod tests {
         );
     }
 
-    // Case 12: ordering. Every ordinary fragment stays an ordinary event, and
-    // exactly one dispatch event precedes the fragment that closes the JSON.
-    #[test]
-    fn test_13972_dispatch_event_precedes_the_completing_fragment() {
-        let mut assemblies = ToolCallAssemblies::new();
-        let fragments = [
-            (Some("call_1"), Some("create_file"), None),
-            (None, None, Some(r#"{"path""#)),
-            (None, None, Some(r#":"/a/very"#)),
-            (None, None, Some(r#"/long/file"}"#)),
-        ];
-
-        // Mirrors the handler loop: side-channel events are collected first,
-        // then the ordinary data event is appended.
-        let mut wire: Vec<String> = Vec::new();
-        for (i, (id, name, args)) in fragments.iter().enumerate() {
-            let response =
-                make_stream_response(vec![make_choice_with_tool_call(0, 0, *id, *name, *args)]);
-            let side = collect_tool_dispatch_events(&response, &mut assemblies);
-            for event in &side {
-                assert_event_type(event.as_ref().unwrap(), "tool_call_dispatch");
-                wire.push("tool_call_dispatch".to_string());
-            }
-            wire.push(format!("data:{i}"));
-        }
-
-        assert_eq!(
-            wire,
-            vec!["data:0", "data:1", "data:2", "tool_call_dispatch", "data:3",],
-            "the dispatch event precedes the ordinary fragment that completes the JSON, \
-             and every ordinary fragment survives"
-        );
-    }
-
-    // ── JsonStructureScanner unit coverage ──
+    // Ordering is a property of the handler loop rather than of assembly, so it
+    // is covered over real SSE frames in `tests/streaming_tool_dispatch_http.rs`.
 
     fn scan_all(fragments: &[&str]) -> ScanOutcome {
         let mut scanner = JsonStructureScanner::default();

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2984,9 +2984,12 @@ fn finalize_choice_assemblies(
             continue;
         }
 
-        if finish_reason != FinishReason::ToolCalls {
-            // `length`, a backend error, a content filter: a syntactically
-            // complete call would already have dispatched, so nothing is lost.
+        // A tool-call turn arrives under either reason: the aggregator rewrites
+        // `Stop` to `ToolCalls` for exactly that case, and a parameterless call
+        // never reaches `RootClosed`, so it depends on this pass. `length`, a
+        // backend error, and a content filter stay fail-closed; the `usable`
+        // check below still rejects incomplete arguments.
+        if !matches!(finish_reason, FinishReason::ToolCalls | FinishReason::Stop) {
             entry.state = AssemblyState::Invalid;
             continue;
         }
@@ -8557,7 +8560,6 @@ mod tests {
     }
 
     // ── #13972: fragmented tool-call assembly ──
-    // Case numbers below match the issue's regression list.
 
     /// Read the assembled arguments for a key directly, so quoted-brace
     /// payloads never go through `extract_sse_data_json`'s brace-only,
@@ -8764,7 +8766,6 @@ mod tests {
         let mut assemblies = ToolCallAssemblies::new();
         let mut events = Vec::new();
 
-        // Both calls open, index 0 first.
         let opener = make_stream_response(vec![make_choice_with_tool_calls(
             0,
             vec![
@@ -8776,7 +8777,6 @@ mod tests {
         events.extend(collect_tool_dispatch_events(&opener, &mut assemblies));
         assert!(events.is_empty(), "neither call is complete yet");
 
-        // Inner index 1 completes first.
         let close_1 = make_stream_response(vec![make_choice_with_tool_calls(
             0,
             vec![tool_call_chunk(1, None, None, Some("2}"))],
@@ -8789,7 +8789,6 @@ mod tests {
             "call_1"
         );
 
-        // Then inner index 0.
         let close_0 = make_stream_response(vec![make_choice_with_tool_calls(
             0,
             vec![tool_call_chunk(0, None, None, Some("1}"))],
@@ -8837,26 +8836,6 @@ mod tests {
         );
     }
 
-    // Case 9: a call filtered out by `parallel_tool_calls=false` is never even
-    // accumulated, because filtering runs before the dispatcher sees the chunk.
-    #[test]
-    fn test_13972_filtered_higher_index_call_is_never_accumulated() {
-        let mut assemblies = ToolCallAssemblies::new();
-        // Post-filter shape: only inner index 0 survives.
-        let response = make_stream_response(vec![make_choice_with_tool_calls(
-            0,
-            vec![tool_call_chunk(0, Some("call_0"), Some("f"), Some("{}"))],
-            None,
-        )]);
-        let events = collect_tool_dispatch_events(&response, &mut assemblies);
-        assert_eq!(events.len(), 1);
-        assert!(
-            !assemblies.contains_key(&(0, 1)),
-            "no state for a filtered inner index"
-        );
-    }
-
-    // Case 10: terminal outcomes.
     #[test]
     fn test_13972_terminal_pass_outcomes() {
         // Valid JSON that only closes on the terminating chunk is not lost.
@@ -8892,6 +8871,40 @@ mod tests {
             0,
         );
         assert_eq!(absent.len(), 1, "absent arguments dispatch at the terminal");
+
+        // A producer may report a tool-call turn as `Stop`; a parameterless
+        // call never closes a JSON root, so it depends on the terminal pass.
+        let mut assemblies = ToolCallAssemblies::new();
+        let open = make_stream_response(vec![make_choice_with_tool_call(
+            0,
+            0,
+            Some("call_1"),
+            Some("no_params"),
+            None,
+        )]);
+        assert!(collect_tool_dispatch_events(&open, &mut assemblies).is_empty());
+        let stop = make_stream_response(vec![make_finish_choice(0, FinishReason::Stop)]);
+        assert_eq!(
+            collect_tool_dispatch_events(&stop, &mut assemblies).len(),
+            1,
+            "a parameterless call dispatches on a `Stop` finish"
+        );
+
+        // `Stop` stays fail-closed for arguments that never became valid JSON.
+        let mut assemblies = ToolCallAssemblies::new();
+        let open = make_stream_response(vec![make_choice_with_tool_call(
+            0,
+            0,
+            Some("call_1"),
+            Some("f"),
+            Some(r#"{"a":"#),
+        )]);
+        assert!(collect_tool_dispatch_events(&open, &mut assemblies).is_empty());
+        let stop = make_stream_response(vec![make_finish_choice(0, FinishReason::Stop)]);
+        assert!(
+            collect_tool_dispatch_events(&stop, &mut assemblies).is_empty(),
+            "truncated arguments must not dispatch on a `Stop` finish either"
+        );
 
         // Invalid non-empty JSON does not.
         let invalid = drive_to_tool_calls_finish(

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -60,6 +60,9 @@ use crate::protocols::common::input_trigger::{
     classify_chat_request, classify_completion_request, classify_response_request,
 };
 use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;
+use crate::protocols::openai::chat_completions::tool_call_merge::{
+    ToolCallMergeOutcome, merge_tool_call_chunk,
+};
 use crate::protocols::openai::{
     ParsingOptions,
     audios::{NvAudioSpeechResponse, NvCreateAudioSpeechRequest},
@@ -89,6 +92,7 @@ use dynamo_protocols::types::ChatCompletionMessageContent;
 use dynamo_protocols::types::ChatCompletionMessageToolCallChunk;
 use dynamo_protocols::types::ChatCompletionStreamResponseDelta;
 use dynamo_protocols::types::Choice;
+use dynamo_protocols::types::FinishReason;
 use dynamo_protocols::types::responses::{
     CountInputTokensRequest, CountInputTokensResponse, ErrorObject,
 };
@@ -2666,20 +2670,392 @@ fn is_empty_completion_stream_response(resp: &NvCreateCompletionResponse) -> boo
         })
 }
 
-/// Emits early `event: tool_call_dispatch` SSE events for any complete tool calls found in a
-/// streaming response chunk, when `DYN_ENABLE_STREAMING_TOOL_DISPATCH` is enabled.
+/// Outcome of feeding one argument fragment to [`JsonStructureScanner`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScanOutcome {
+    /// The accumulated argument string is not yet a self-delimiting root value.
+    Incomplete,
+    /// The root container closed and only whitespace followed it. This is a
+    /// *candidate* boundary; `serde_json` still has to confirm it.
+    RootClosed,
+    /// The accumulated argument string can never become valid JSON. Sticky.
+    Malformed,
+}
+
+/// Incremental, O(total argument bytes) structural scanner over a tool call's
+/// `function.arguments` fragments.
 ///
-/// Dynamo backends emit each tool call as a single complete chunk (id + name + arguments
-/// all present), so we can dispatch immediately upon seeing the chunk rather than waiting
-/// for `finish_reason="tool_calls"` to arrive. Each event payload includes `choice_index`
-/// for correct disambiguation when `n > 1`.
+/// Each fragment is scanned exactly once, and container-depth / in-string /
+/// pending-escape state is carried across fragment boundaries, so a quoted
+/// brace, an escaped quote, or a backslash split across two chunks cannot
+/// create a false boundary. Re-running `serde_json::from_str` over the whole
+/// accumulated buffer on every fragment would be quadratic in exactly the
+/// long-argument case that motivates this change, so structural scanning
+/// *proposes* a boundary and `serde_json` *confirms* it, once.
 ///
-/// Dedup is keyed by `(choice_index, tool_call_id)`, not by id alone: with `n > 1` the
-/// backend may reuse the same tool call id across choices, and keying on the id alone
-/// would silently drop every choice after the first.
+/// Only a top-level object or array is treated as self-delimiting. A top-level
+/// scalar is never an early-dispatch candidate: `1` may still legally receive
+/// a further `2`. Such a value waits for the terminal `finish_reason` pass.
+#[derive(Debug, Default)]
+struct JsonStructureScanner {
+    /// Open `{`/`[` containers not yet closed.
+    depth: u32,
+    in_string: bool,
+    pending_escape: bool,
+    /// The first non-whitespace byte has been seen.
+    root_started: bool,
+    /// The root value is a top-level scalar (or leading junk), so no early
+    /// dispatch is possible and scanning stops.
+    scalar_root: bool,
+    /// The root container opened and closed.
+    root_closed: bool,
+    /// Sticky: the accumulated string is structurally impossible.
+    malformed: bool,
+}
+
+impl JsonStructureScanner {
+    /// Consume one fragment in full and report the state of the accumulated
+    /// argument string. The *entire* fragment is consumed before a candidate
+    /// is declared, so `{}junk` cannot be reported complete at the first `}`.
+    fn consume(&mut self, fragment: &str) -> ScanOutcome {
+        for byte in fragment.bytes() {
+            if self.malformed {
+                break;
+            }
+            if self.scalar_root {
+                // Nothing a scalar root can do makes it an early candidate.
+                break;
+            }
+            if self.in_string {
+                if self.pending_escape {
+                    self.pending_escape = false;
+                } else if byte == b'\\' {
+                    self.pending_escape = true;
+                } else if byte == b'"' {
+                    self.in_string = false;
+                }
+                continue;
+            }
+            if byte.is_ascii_whitespace() {
+                continue;
+            }
+            if self.root_closed {
+                // Trailing junk after a closed root: `{}junk`, `{}{}`.
+                self.malformed = true;
+                break;
+            }
+            if !self.root_started {
+                self.root_started = true;
+                if byte == b'}' || byte == b']' {
+                    // A closing token with nothing open — this is what makes
+                    // `}{"x":1}` a permanent non-dispatch rather than a call
+                    // that reads complete after clamping depth to zero.
+                    self.malformed = true;
+                    break;
+                }
+                if byte != b'{' && byte != b'[' {
+                    // Top-level scalar, or leading junk. Either way the
+                    // terminal pass — not the scanner — decides.
+                    self.scalar_root = true;
+                    break;
+                }
+            }
+            match byte {
+                b'"' => self.in_string = true,
+                b'{' | b'[' => self.depth += 1,
+                b'}' | b']' => {
+                    if self.depth == 0 {
+                        self.malformed = true;
+                        break;
+                    }
+                    self.depth -= 1;
+                    if self.depth == 0 {
+                        self.root_closed = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if self.malformed {
+            ScanOutcome::Malformed
+        } else if self.root_closed && self.depth == 0 && !self.in_string {
+            ScanOutcome::RootClosed
+        } else {
+            ScanOutcome::Incomplete
+        }
+    }
+}
+
+/// Lifecycle of one `(choice.index, tool_call_chunk.index)` assembly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AssemblyState {
+    /// Still collecting fragments.
+    Accumulating,
+    /// Failed closed — a producer violation or unparseable arguments. Never
+    /// emits, and later fragments for the key are ignored.
+    Invalid,
+    /// Tombstone: the dispatch event was emitted. Exactly-once emission comes
+    /// from this, not from a separate set of already-dispatched ids.
+    Emitted,
+}
+
+/// Request-local assembly state for a single streamed tool call.
+#[derive(Debug)]
+struct ToolCallAssembly {
+    /// Merged identity plus the concatenated argument string, and the payload
+    /// the dispatch event borrows. Never fed back into the ordinary deltas.
+    accumulated: ChatCompletionMessageToolCallChunk,
+    scanner: JsonStructureScanner,
+    state: AssemblyState,
+    /// `serde_json` has already confirmed the accumulated arguments, so the
+    /// confirmation pass does not repeat while identity is still missing.
+    json_confirmed: bool,
+}
+
+/// Request-local assembly state for the whole stream, keyed by
+/// `(choice.index, tool_call_chunk.index)`.
+type ToolCallAssemblies = HashMap<(u32, u32), ToolCallAssembly>;
+
+/// True when `chunk` is a byte-identical replay of what has already been
+/// emitted for its key, rather than a continuation of it.
+fn is_exact_replay(entry: &ToolCallAssembly, chunk: &ChatCompletionMessageToolCallChunk) -> bool {
+    let accumulated_args = entry
+        .accumulated
+        .function
+        .as_ref()
+        .and_then(|f| f.arguments.as_deref());
+    let incoming_args = chunk.function.as_ref().and_then(|f| f.arguments.as_deref());
+    accumulated_args == incoming_args
+}
+
+/// Emit the dispatch event for `entry` and tombstone it.
+fn emit_tool_call_dispatch(
+    choice_index: u32,
+    entry: &mut ToolCallAssembly,
+    out: &mut Vec<Result<Event, axum::Error>>,
+) {
+    let payload = ToolCallDispatchPayload {
+        choice_index,
+        tool_call: &entry.accumulated,
+    };
+    push_dispatch_event("tool_call_dispatch", &payload, out);
+    entry.state = AssemblyState::Emitted;
+}
+
+/// True once the accumulated call carries both an id and a function name.
+/// Assembly proceeds without them; emission does not.
+fn assembly_has_identity(entry: &ToolCallAssembly) -> bool {
+    entry.accumulated.id.is_some()
+        && entry
+            .accumulated
+            .function
+            .as_ref()
+            .is_some_and(|f| f.name.is_some())
+}
+
+/// Fold one incoming tool-call chunk into its assembly, emitting the dispatch
+/// event if this fragment completed the call.
+fn update_tool_call_assembly(
+    choice_index: u32,
+    chunk: &ChatCompletionMessageToolCallChunk,
+    assemblies: &mut ToolCallAssemblies,
+    out: &mut Vec<Result<Event, axum::Error>>,
+) {
+    let entry = assemblies
+        .entry((choice_index, chunk.index))
+        .or_insert_with(|| ToolCallAssembly {
+            // An entry is created for *every* chunk. Requiring id and name to
+            // coexist in the chunk that opens the entry is the bug this
+            // replaces: arguments legally arrive before identity.
+            accumulated: ChatCompletionMessageToolCallChunk {
+                index: chunk.index,
+                id: None,
+                r#type: None,
+                function: None,
+            },
+            scanner: JsonStructureScanner::default(),
+            state: AssemblyState::Accumulating,
+            json_confirmed: false,
+        });
+
+    match entry.state {
+        AssemblyState::Invalid => return,
+        AssemblyState::Emitted => {
+            // An exact replay of an already-dispatched chunk is the
+            // pre-existing duplicate-backend-chunk case and stays silent. A
+            // *different* continuation after emission is a producer violation:
+            // an SSE event that has already gone out cannot be retracted, so
+            // log and suppress.
+            if !is_exact_replay(entry, chunk) {
+                tracing::warn!(
+                    choice_index,
+                    tool_call_index = chunk.index,
+                    "tool_call_dispatch: continuation after the call was already \
+                     dispatched; suppressing"
+                );
+            }
+            return;
+        }
+        AssemblyState::Accumulating => {}
+    }
+
+    // Scan only the bytes of the arriving fragment, never the accumulated
+    // buffer. `merge_tool_call_chunk` is the same first-wins identity /
+    // concatenated-arguments policy the non-streaming aggregator uses.
+    let fragment = chunk
+        .function
+        .as_ref()
+        .and_then(|f| f.arguments.as_deref())
+        .unwrap_or("");
+
+    if let ToolCallMergeOutcome::IdentityConflict { field } =
+        merge_tool_call_chunk(&mut entry.accumulated, chunk.clone())
+    {
+        tracing::warn!(
+            choice_index,
+            tool_call_index = chunk.index,
+            field = field.as_str(),
+            "tool_call_dispatch: conflicting tool call identity; failing closed"
+        );
+        entry.state = AssemblyState::Invalid;
+        return;
+    }
+
+    match entry.scanner.consume(fragment) {
+        ScanOutcome::Malformed => {
+            tracing::warn!(
+                choice_index,
+                tool_call_index = chunk.index,
+                "tool_call_dispatch: tool call arguments are structurally invalid; \
+                 will not dispatch"
+            );
+            entry.state = AssemblyState::Invalid;
+        }
+        ScanOutcome::Incomplete => {}
+        ScanOutcome::RootClosed => {
+            // Structural scanning proposed the boundary; `serde_json` confirms
+            // it once, over the whole accumulated string.
+            if !entry.json_confirmed {
+                let accumulated_args = entry
+                    .accumulated
+                    .function
+                    .as_ref()
+                    .and_then(|f| f.arguments.as_deref())
+                    .unwrap_or("");
+                if serde_json::from_str::<serde_json::Value>(accumulated_args).is_err() {
+                    tracing::warn!(
+                        choice_index,
+                        tool_call_index = chunk.index,
+                        "tool_call_dispatch: tool call arguments closed but did not \
+                         parse; will not dispatch"
+                    );
+                    entry.state = AssemblyState::Invalid;
+                    return;
+                }
+                entry.json_confirmed = true;
+            }
+            // Syntax only. This does not validate the arguments against the
+            // requested tool schema, and does not authorize execution.
+            if assembly_has_identity(entry) {
+                emit_tool_call_dispatch(choice_index, entry, out);
+            }
+        }
+    }
+}
+
+/// Terminal pass for one choice. `finish_reason` ends the *choice*, not each
+/// individual call, so this is the only point at which a call that never
+/// produced a self-delimiting root value can be resolved.
+fn finalize_choice_assemblies(
+    choice_index: u32,
+    finish_reason: FinishReason,
+    assemblies: &mut ToolCallAssemblies,
+    out: &mut Vec<Result<Event, axum::Error>>,
+) {
+    // Deterministic emission order for a choice that finishes with several
+    // calls still open; `HashMap` iteration order is not stable.
+    let mut keys: Vec<(u32, u32)> = assemblies
+        .keys()
+        .filter(|(ci, _)| *ci == choice_index)
+        .copied()
+        .collect();
+    keys.sort_unstable();
+
+    for key in keys {
+        let Some(entry) = assemblies.get_mut(&key) else {
+            continue;
+        };
+        if entry.state != AssemblyState::Accumulating {
+            continue;
+        }
+
+        if finish_reason != FinishReason::ToolCalls {
+            // `length`, a backend error, a content filter: nothing valid is
+            // lost by clearing, because a syntactically complete call would
+            // already have dispatched early.
+            entry.state = AssemblyState::Invalid;
+            continue;
+        }
+
+        let accumulated_args = entry
+            .accumulated
+            .function
+            .as_ref()
+            .and_then(|f| f.arguments.as_deref());
+        let usable = match accumulated_args {
+            // Absent or empty-string arguments for a parameterless tool. This
+            // is the only place that compatibility is safe: the choice has
+            // definitively stopped producing arguments.
+            None | Some("") => true,
+            Some(args) => {
+                entry.json_confirmed || serde_json::from_str::<serde_json::Value>(args).is_ok()
+            }
+        };
+
+        if !usable {
+            tracing::warn!(
+                choice_index,
+                tool_call_index = key.1,
+                "tool_call_dispatch: choice finished with incomplete tool call \
+                 arguments; will not dispatch"
+            );
+            entry.state = AssemblyState::Invalid;
+            continue;
+        }
+
+        if assembly_has_identity(entry) {
+            // The accumulated argument string is emitted verbatim; model
+            // output is never rewritten.
+            emit_tool_call_dispatch(choice_index, entry, out);
+        } else {
+            entry.state = AssemblyState::Invalid;
+        }
+    }
+}
+
+/// Emits `event: tool_call_dispatch` SSE events for tool calls assembled out of
+/// the streamed deltas, when `DYN_ENABLE_STREAMING_TOOL_DISPATCH` is enabled.
+///
+/// Chat Completions has no per-tool-call `done` bit — `finish_reason` ends the
+/// choice, not each call — so JSON closure is a Dynamo early-dispatch
+/// convention rather than proof supplied by the OpenAI protocol. A call is
+/// dispatched as soon as its accumulated `function.arguments` form a
+/// self-delimiting root value that `serde_json` accepts and its id and name are
+/// known, and otherwise at the terminal `finish_reason: "tool_calls"` pass.
+///
+/// State is keyed by `(choice.index, tool_call_chunk.index)`, not by id: with
+/// `n > 1` the backend may reuse both the same id and the same inner index
+/// across choices, and keying on either alone would silently drop every choice
+/// after the first. Exactly-once emission comes from the per-key `Emitted`
+/// tombstone.
+///
+/// This function only *observes*. It never consumes, rewrites, duplicates, or
+/// re-aggregates the ordinary deltas, which continue through `EventConverter`
+/// untouched.
 fn streaming_tool_dispatch_events(
     response: &crate::types::Annotated<NvCreateChatCompletionStreamResponse>,
-    dispatched_ids: &mut HashSet<(u32, String)>,
+    assemblies: &mut ToolCallAssemblies,
     out: &mut Vec<Result<Event, axum::Error>>,
 ) {
     let Some(data) = &response.data else {
@@ -2687,29 +3063,13 @@ fn streaming_tool_dispatch_events(
     };
 
     for choice in &data.inner.choices {
-        let Some(tool_calls) = &choice.delta.tool_calls else {
-            continue;
-        };
-        for chunk in tool_calls {
-            // Only dispatch when the tool call is fully formed (id + name + arguments)
-            let has_name_and_args = chunk
-                .function
-                .as_ref()
-                .is_some_and(|f| f.name.is_some() && f.arguments.is_some());
-
-            if let (true, Some(id)) = (has_name_and_args, &chunk.id) {
-                // Skip already-dispatched tool calls (dedup guard, matches
-                // the stopped/done flags in Anthropic/Responses converters).
-                // Scoped per choice so repeated ids across choices still dispatch.
-                if !dispatched_ids.insert((choice.index, id.clone())) {
-                    continue;
-                }
-                let payload = ToolCallDispatchPayload {
-                    choice_index: choice.index,
-                    tool_call: chunk,
-                };
-                push_dispatch_event("tool_call_dispatch", &payload, out);
+        if let Some(tool_calls) = &choice.delta.tool_calls {
+            for chunk in tool_calls {
+                update_tool_call_assembly(choice.index, chunk, assemblies, out);
             }
+        }
+        if let Some(finish_reason) = choice.finish_reason {
+            finalize_choice_assemblies(choice.index, finish_reason, assemblies, out);
         }
     }
 }
@@ -2971,7 +3331,9 @@ async fn chat_completions(
         let reasoning_dispatch_enabled = state.streaming_reasoning_dispatch_enabled();
         let reasoning_field = state.reasoning_field();
         let mut reasoning_buffer: HashMap<u32, String> = HashMap::new();
-        let mut dispatched_tool_ids: HashSet<(u32, String)> = HashSet::new();
+        // Request-local tool-call assembly, keyed by
+        // `(choice.index, tool_call_chunk.index)`. Dies with the HTTP stream.
+        let mut tool_call_assemblies: ToolCallAssemblies = HashMap::new();
         let mut emitted_roles: HashSet<u32> = HashSet::new();
 
         // Optionally prepend extra SSE events before each regular chunk:
@@ -3024,7 +3386,7 @@ async fn chat_completions(
                 if tool_dispatch_enabled {
                     streaming_tool_dispatch_events(
                         &response,
-                        &mut dispatched_tool_ids,
+                        &mut tool_call_assemblies,
                         &mut events,
                     );
                 }
@@ -7786,10 +8148,76 @@ mod tests {
 
     fn collect_tool_dispatch_events(
         response: &Annotated<NvCreateChatCompletionStreamResponse>,
-        dispatched_ids: &mut HashSet<(u32, String)>,
+        assemblies: &mut ToolCallAssemblies,
     ) -> Vec<Result<Event, axum::Error>> {
         let mut events = Vec::new();
-        streaming_tool_dispatch_events(response, dispatched_ids, &mut events);
+        streaming_tool_dispatch_events(response, assemblies, &mut events);
+        events
+    }
+
+    /// Build a tool-call delta chunk at an explicit inner tool-call index.
+    fn tool_call_chunk(
+        tool_call_index: u32,
+        id: Option<&str>,
+        name: Option<&str>,
+        arguments: Option<&str>,
+    ) -> ChatCompletionMessageToolCallChunk {
+        ChatCompletionMessageToolCallChunk {
+            index: tool_call_index,
+            id: id.map(|s| s.to_string()),
+            r#type: Some(FunctionType::Function),
+            function: Some(FunctionCallStream {
+                name: name.map(|s| s.to_string()),
+                arguments: arguments.map(|s| s.to_string()),
+            }),
+        }
+    }
+
+    /// Build a choice carrying the given tool-call chunks and finish reason.
+    fn make_choice_with_tool_calls(
+        index: u32,
+        tool_calls: Vec<ChatCompletionMessageToolCallChunk>,
+        finish: Option<FinishReason>,
+    ) -> ChatChoiceStream {
+        #[allow(deprecated)]
+        ChatChoiceStream {
+            index,
+            delta: ChatCompletionStreamResponseDelta {
+                content: None,
+                function_call: None,
+                tool_calls: if tool_calls.is_empty() {
+                    None
+                } else {
+                    Some(tool_calls)
+                },
+                role: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason: finish,
+            logprobs: None,
+        }
+    }
+
+    /// A choice whose only content is a terminal `finish_reason`.
+    fn make_finish_choice(index: u32, finish: FinishReason) -> ChatChoiceStream {
+        make_choice_with_tool_calls(index, vec![], Some(finish))
+    }
+
+    /// Feed one delta and then a `finish_reason: "tool_calls"` terminator,
+    /// returning the events from both, in order.
+    fn drive_to_tool_calls_finish(
+        choices: Vec<ChatChoiceStream>,
+        finish_choice_index: u32,
+    ) -> Vec<Result<Event, axum::Error>> {
+        let mut assemblies = ToolCallAssemblies::new();
+        let mut events =
+            collect_tool_dispatch_events(&make_stream_response(choices), &mut assemblies);
+        let terminator = make_stream_response(vec![make_finish_choice(
+            finish_choice_index,
+            FinishReason::ToolCalls,
+        )]);
+        events.extend(collect_tool_dispatch_events(&terminator, &mut assemblies));
         events
     }
 
@@ -7823,35 +8251,20 @@ mod tests {
         }
     }
 
+    /// `tool_call_index` is explicit so that two calls in one choice, and a
+    /// call filtered out by `parallel_tool_calls=false`, are both expressible.
     fn make_choice_with_tool_call(
         index: u32,
+        tool_call_index: u32,
         id: Option<&str>,
         name: Option<&str>,
         arguments: Option<&str>,
     ) -> ChatChoiceStream {
-        let tool_call = ChatCompletionMessageToolCallChunk {
-            index: 0,
-            id: id.map(|s| s.to_string()),
-            r#type: Some(FunctionType::Function),
-            function: Some(FunctionCallStream {
-                name: name.map(|s| s.to_string()),
-                arguments: arguments.map(|s| s.to_string()),
-            }),
-        };
-        #[allow(deprecated)]
-        ChatChoiceStream {
+        make_choice_with_tool_calls(
             index,
-            delta: ChatCompletionStreamResponseDelta {
-                content: None,
-                function_call: None,
-                tool_calls: Some(vec![tool_call]),
-                role: None,
-                refusal: None,
-                reasoning_content: None,
-            },
-            finish_reason: None,
-            logprobs: None,
-        }
+            vec![tool_call_chunk(tool_call_index, id, name, arguments)],
+            None,
+        )
     }
 
     // ── streaming_tool_dispatch_events tests ──
@@ -7860,12 +8273,13 @@ mod tests {
     fn test_tool_dispatch_emits_event_for_complete_tool_call() {
         let response = make_stream_response(vec![make_choice_with_tool_call(
             0,
+            0,
             Some("call_123"),
             Some("get_weather"),
             Some(r#"{"city":"Paris"}"#),
         )]);
 
-        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut ToolCallAssemblies::new());
         assert_eq!(events.len(), 1);
 
         let event = events[0].as_ref().unwrap();
@@ -7884,12 +8298,13 @@ mod tests {
     fn test_tool_dispatch_skips_incomplete_tool_call_no_id() {
         let response = make_stream_response(vec![make_choice_with_tool_call(
             0,
+            0,
             None, // no id
             Some("get_weather"),
             Some(r#"{"city":"Paris"}"#),
         )]);
 
-        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut ToolCallAssemblies::new());
         assert!(events.is_empty(), "should not dispatch without id");
     }
 
@@ -7897,12 +8312,13 @@ mod tests {
     fn test_tool_dispatch_skips_incomplete_tool_call_no_name() {
         let response = make_stream_response(vec![make_choice_with_tool_call(
             0,
+            0,
             Some("call_123"),
             None, // no name
             Some(r#"{"city":"Paris"}"#),
         )]);
 
-        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut ToolCallAssemblies::new());
         assert!(events.is_empty(), "should not dispatch without name");
     }
 
@@ -7910,12 +8326,13 @@ mod tests {
     fn test_tool_dispatch_skips_incomplete_tool_call_no_arguments() {
         let response = make_stream_response(vec![make_choice_with_tool_call(
             0,
+            0,
             Some("call_123"),
             Some("get_weather"),
             None, // no arguments
         )]);
 
-        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut ToolCallAssemblies::new());
         assert!(events.is_empty(), "should not dispatch without arguments");
     }
 
@@ -7955,7 +8372,7 @@ mod tests {
         };
 
         let response = make_stream_response(vec![choice]);
-        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut ToolCallAssemblies::new());
         assert_eq!(events.len(), 2, "should dispatch both tool calls");
 
         // Verify each dispatched event has the correct tool call data
@@ -7977,14 +8394,14 @@ mod tests {
             comment: None,
             error: None,
         };
-        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut ToolCallAssemblies::new());
         assert!(events.is_empty());
     }
 
     #[test]
     fn test_tool_dispatch_empty_choices() {
         let response = make_stream_response(vec![]);
-        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut ToolCallAssemblies::new());
         assert!(events.is_empty());
     }
 
@@ -8026,7 +8443,7 @@ mod tests {
         };
 
         let response = make_stream_response(vec![choice]);
-        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut ToolCallAssemblies::new());
         assert_eq!(
             events.len(),
             1,
@@ -8062,23 +8479,32 @@ mod tests {
         };
 
         let response = make_stream_response(vec![choice]);
-        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut ToolCallAssemblies::new());
         assert!(events.is_empty(), "function: None should not dispatch");
     }
 
     #[test]
-    fn test_tool_dispatch_empty_arguments_still_dispatches() {
-        // arguments: Some("") is considered complete — intentional.
-        // Some backends emit empty-string arguments for parameterless tools.
-        let response = make_stream_response(vec![make_choice_with_tool_call(
+    fn test_tool_dispatch_empty_arguments_dispatch_at_terminal_pass() {
+        // `arguments: Some("")` used to be treated as complete on arrival. It
+        // is ambiguous mid-stream — a parameterless call, or an empty opener
+        // about to be followed by real fragments — so the parameterless
+        // compatibility now resolves at `finish_reason: "tool_calls"`, where
+        // the choice has definitively stopped producing arguments.
+        let events = drive_to_tool_calls_finish(
+            vec![make_choice_with_tool_call(
+                0,
+                0,
+                Some("call_empty"),
+                Some("no_params_tool"),
+                Some(""),
+            )],
             0,
-            Some("call_empty"),
-            Some("no_params_tool"),
-            Some(""),
-        )]);
-
-        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
-        assert_eq!(events.len(), 1, "empty arguments should still dispatch");
+        );
+        assert_eq!(
+            events.len(),
+            1,
+            "empty arguments dispatch exactly once, at the terminal pass"
+        );
 
         let json = extract_sse_data_json(events[0].as_ref().unwrap());
         assert_eq!(json["tool_call"]["id"], "call_empty");
@@ -8092,19 +8518,21 @@ mod tests {
         // choices must each dispatch with their own choice_index.
         let choice_0 = make_choice_with_tool_call(
             0,
+            0,
             Some("call_1"),
             Some("get_weather"),
             Some(r#"{"city":"Paris"}"#),
         );
         let choice_1 = make_choice_with_tool_call(
             1,
+            0,
             Some("call_1"),
             Some("get_time"),
             Some(r#"{"tz":"UTC"}"#),
         );
 
         let response = make_stream_response(vec![choice_0, choice_1]);
-        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut ToolCallAssemblies::new());
         assert_eq!(events.len(), 2, "should dispatch from both choices");
 
         let json0 = extract_sse_data_json(events[0].as_ref().unwrap());
@@ -8119,23 +8547,464 @@ mod tests {
     #[test]
     fn test_tool_dispatch_dedup_skips_already_dispatched_id() {
         // Simulate a backend that sends the same complete tool call in two consecutive chunks.
-        // The HashSet should prevent the second dispatch.
+        // The per-key `Emitted` tombstone prevents the second dispatch.
         let response = make_stream_response(vec![make_choice_with_tool_call(
+            0,
             0,
             Some("call_dup"),
             Some("get_weather"),
             Some(r#"{"city":"Paris"}"#),
         )]);
 
-        let mut dispatched = HashSet::new();
+        let mut assemblies = ToolCallAssemblies::new();
 
         // First call — should dispatch
-        let events = collect_tool_dispatch_events(&response, &mut dispatched);
+        let events = collect_tool_dispatch_events(&response, &mut assemblies);
         assert_eq!(events.len(), 1);
 
         // Second call with same response — should be deduped
-        let events = collect_tool_dispatch_events(&response, &mut dispatched);
+        let events = collect_tool_dispatch_events(&response, &mut assemblies);
         assert!(events.is_empty(), "duplicate id should not dispatch twice");
+    }
+
+    // ── #13972: fragmented tool-call assembly ──
+    //
+    // The dispatcher assembles `function.arguments` across deltas instead of
+    // requiring id, name, and arguments on one chunk. Cases below are numbered
+    // to match the issue's regression list.
+
+    /// Read the assembled arguments for a key directly, so quoted-brace
+    /// payloads never go through `extract_sse_data_json`'s brace-only,
+    /// string-unaware scan.
+    fn assembled_arguments(assemblies: &ToolCallAssemblies, key: (u32, u32)) -> Option<String> {
+        assemblies
+            .get(&key)
+            .and_then(|e| e.accumulated.function.as_ref())
+            .and_then(|f| f.arguments.clone())
+    }
+
+    /// Feed a sequence of deltas for choice 0 / inner index 0, where each entry
+    /// is `(id, name, arguments)`, and return the events plus the final state.
+    fn feed_fragments(
+        fragments: &[(Option<&str>, Option<&str>, Option<&str>)],
+    ) -> (Vec<Result<Event, axum::Error>>, ToolCallAssemblies) {
+        let mut assemblies = ToolCallAssemblies::new();
+        let mut events = Vec::new();
+        for (id, name, args) in fragments {
+            let response =
+                make_stream_response(vec![make_choice_with_tool_call(0, 0, *id, *name, *args)]);
+            events.extend(collect_tool_dispatch_events(&response, &mut assemblies));
+        }
+        (events, assemblies)
+    }
+
+    // Case 2: an identity opener followed by argument-only fragments.
+    #[test]
+    fn test_13972_identity_opener_then_argument_fragments() {
+        let (events, assemblies) = feed_fragments(&[
+            (Some("call_1"), Some("create_file"), None),
+            (None, None, Some(r#"{"path":"/a/very"#)),
+            (None, None, Some(r#"/long/file"}"#)),
+        ]);
+        assert_eq!(
+            events.len(),
+            1,
+            "exactly one dispatch, on the fragment that closes the JSON"
+        );
+
+        let json = extract_sse_data_json(events[0].as_ref().unwrap());
+        assert_eq!(json["choice_index"], 0);
+        assert_eq!(json["tool_call"]["index"], 0);
+        assert_eq!(json["tool_call"]["id"], "call_1");
+        assert_eq!(json["tool_call"]["type"], "function");
+        assert_eq!(json["tool_call"]["function"]["name"], "create_file");
+        assert_eq!(
+            assembled_arguments(&assemblies, (0, 0)).as_deref(),
+            Some(r#"{"path":"/a/very/long/file"}"#)
+        );
+    }
+
+    // Case 6 (truncated JSON): the prefix must never dispatch on its own.
+    #[test]
+    fn test_13972_truncated_prefix_never_dispatches() {
+        let (events, _) = feed_fragments(&[(
+            Some("call_1"),
+            Some("create_file"),
+            Some(r#"{"path":"/a/very"#),
+        )]);
+        assert!(
+            events.is_empty(),
+            "a truncated argument prefix must not dispatch"
+        );
+    }
+
+    // Case 3: `Some("")` is an opener, not a completion.
+    #[test]
+    fn test_13972_empty_opener_then_fragments_does_not_dispatch_early() {
+        let (events, assemblies) = feed_fragments(&[
+            (Some("call_1"), Some("search"), Some("")),
+            (None, None, Some(r#"{"q":"#)),
+        ]);
+        assert!(
+            events.is_empty(),
+            "the empty opener must not dispatch, and the prefix is incomplete"
+        );
+        assert_eq!(
+            assembled_arguments(&assemblies, (0, 0)).as_deref(),
+            Some(r#"{"q":"#)
+        );
+    }
+
+    // Case 4: id, name, and arguments arriving on three different chunks.
+    #[test]
+    fn test_13972_identity_after_arguments_still_assembles() {
+        let (events, _) = feed_fragments(&[
+            (None, None, Some(r#"{"a":1}"#)),
+            (Some("call_1"), None, None),
+            (None, Some("calculator"), None),
+        ]);
+        assert_eq!(
+            events.len(),
+            1,
+            "arguments may precede identity; dispatch waits for both"
+        );
+        let json = extract_sse_data_json(events[0].as_ref().unwrap());
+        assert_eq!(json["tool_call"]["id"], "call_1");
+        assert_eq!(json["tool_call"]["function"]["name"], "calculator");
+        assert_eq!(json["tool_call"]["function"]["arguments"], r#"{"a":1}"#);
+    }
+
+    // Case 4 (second half): a conflicting repeated identity fails closed.
+    #[test]
+    fn test_13972_conflicting_identity_fails_closed() {
+        let (events, _) = feed_fragments(&[
+            (Some("call_1"), Some("calculator"), Some(r#"{"a":"#)),
+            (Some("call_2"), None, None),
+            (None, None, Some("1}")),
+        ]);
+        assert!(
+            events.is_empty(),
+            "a conflicting id must fail closed, not dispatch on either identity"
+        );
+    }
+
+    // Case 5: quoted braces, escaped quotes, and a backslash split across
+    // fragments must not create a false boundary. Asserted on typed state, not
+    // on `extract_sse_data_json`.
+    #[test]
+    fn test_13972_quoted_and_escaped_braces_do_not_close_early() {
+        let (events, assemblies) = feed_fragments(&[
+            (Some("call_1"), Some("write"), Some(r#"{"body":"a } b \"#)),
+            (None, None, Some(r#""quoted\" }"#)),
+            (None, None, Some(r#""}"#)),
+        ]);
+        assert_eq!(events.len(), 1, "only the real closing brace completes");
+        assert_eq!(
+            assembled_arguments(&assemblies, (0, 0)).as_deref(),
+            Some(r#"{"body":"a } b \"quoted\" }"}"#)
+        );
+    }
+
+    // Case 5 (containers): nested objects and a top-level array.
+    #[test]
+    fn test_13972_nested_and_array_roots_complete() {
+        let (nested, _) = feed_fragments(&[
+            (Some("call_1"), Some("f"), Some(r#"{"a":{"b":[1,2]"#)),
+            (None, None, Some("}}")),
+        ]);
+        assert_eq!(nested.len(), 1, "nested mixed containers complete");
+
+        let (array, _) = feed_fragments(&[
+            (Some("call_2"), Some("g"), Some("[1, {\"a\": 2}")),
+            (None, None, Some("]")),
+        ]);
+        assert_eq!(array.len(), 1, "a top-level array is self-delimiting");
+    }
+
+    // Case 6: trailing junk in the completing fragment never dispatches.
+    #[test]
+    fn test_13972_trailing_junk_never_dispatches() {
+        let (events, _) = feed_fragments(&[(Some("call_1"), Some("f"), Some("{}junk"))]);
+        assert!(
+            events.is_empty(),
+            "the whole fragment is consumed before a candidate is declared"
+        );
+    }
+
+    // Case 6: mismatched containers. `}{\"x\":1}` read as complete under
+    // #6845's depth-clamping scanner; it must be a permanent non-dispatch.
+    #[test]
+    fn test_13972_mismatched_containers_never_dispatch() {
+        let (early, _) = feed_fragments(&[(Some("call_1"), Some("f"), Some(r#"}{"x":1}"#))]);
+        assert!(early.is_empty(), "a leading close must not dispatch");
+
+        // Not even the terminal pass rescues it.
+        let terminal = drive_to_tool_calls_finish(
+            vec![make_choice_with_tool_call(
+                0,
+                0,
+                Some("call_1"),
+                Some("f"),
+                Some(r#"}{"x":1}"#),
+            )],
+            0,
+        );
+        assert!(
+            terminal.is_empty(),
+            "a structurally invalid call stays a non-dispatch through the terminal pass"
+        );
+    }
+
+    // Case 6: leading junk never dispatches.
+    #[test]
+    fn test_13972_leading_junk_never_dispatches() {
+        let (events, _) = feed_fragments(&[(Some("call_1"), Some("f"), Some(r#"junk{"a":1}"#))]);
+        assert!(events.is_empty(), "leading junk must not dispatch");
+    }
+
+    // Case 2/6 boundary: a canonical parameterless `{}` may dispatch early.
+    #[test]
+    fn test_13972_canonical_empty_object_dispatches_early() {
+        let (events, _) = feed_fragments(&[(Some("call_1"), Some("no_params"), Some("{}"))]);
+        assert_eq!(
+            events.len(),
+            1,
+            "an empty JSON object is a complete root value"
+        );
+    }
+
+    // Case 7: two calls in one choice interleave and complete in reverse order.
+    #[test]
+    fn test_13972_interleaved_inner_indexes_complete_out_of_order() {
+        let mut assemblies = ToolCallAssemblies::new();
+        let mut events = Vec::new();
+
+        // Both calls open, index 0 first.
+        let opener = make_stream_response(vec![make_choice_with_tool_calls(
+            0,
+            vec![
+                tool_call_chunk(0, Some("call_0"), Some("slow"), Some(r#"{"a":"#)),
+                tool_call_chunk(1, Some("call_1"), Some("fast"), Some(r#"{"b":"#)),
+            ],
+            None,
+        )]);
+        events.extend(collect_tool_dispatch_events(&opener, &mut assemblies));
+        assert!(events.is_empty(), "neither call is complete yet");
+
+        // Inner index 1 completes first.
+        let close_1 = make_stream_response(vec![make_choice_with_tool_calls(
+            0,
+            vec![tool_call_chunk(1, None, None, Some("2}"))],
+            None,
+        )]);
+        events.extend(collect_tool_dispatch_events(&close_1, &mut assemblies));
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            extract_sse_data_json(events[0].as_ref().unwrap())["tool_call"]["id"],
+            "call_1"
+        );
+
+        // Then inner index 0.
+        let close_0 = make_stream_response(vec![make_choice_with_tool_calls(
+            0,
+            vec![tool_call_chunk(0, None, None, Some("1}"))],
+            None,
+        )]);
+        events.extend(collect_tool_dispatch_events(&close_0, &mut assemblies));
+        assert_eq!(events.len(), 2);
+        let second = extract_sse_data_json(events[1].as_ref().unwrap());
+        assert_eq!(second["tool_call"]["id"], "call_0");
+        assert_eq!(second["tool_call"]["index"], 0);
+        assert_eq!(second["tool_call"]["function"]["arguments"], r#"{"a":1}"#);
+    }
+
+    // Case 8: two choices sharing inner index 0 and the same call id.
+    #[test]
+    fn test_13972_same_id_and_inner_index_across_choices_do_not_collide() {
+        let mut assemblies = ToolCallAssemblies::new();
+        let mut events = Vec::new();
+
+        let opener = make_stream_response(vec![
+            make_choice_with_tool_call(0, 0, Some("call_1"), Some("f"), Some(r#"{"choice":"#)),
+            make_choice_with_tool_call(1, 0, Some("call_1"), Some("f"), Some(r#"{"choice":"#)),
+        ]);
+        events.extend(collect_tool_dispatch_events(&opener, &mut assemblies));
+        assert!(events.is_empty());
+
+        let closer = make_stream_response(vec![
+            make_choice_with_tool_call(0, 0, None, None, Some("0}")),
+            make_choice_with_tool_call(1, 0, None, None, Some("1}")),
+        ]);
+        events.extend(collect_tool_dispatch_events(&closer, &mut assemblies));
+        assert_eq!(events.len(), 2, "each choice dispatches independently");
+
+        let json0 = extract_sse_data_json(events[0].as_ref().unwrap());
+        assert_eq!(json0["choice_index"], 0);
+        assert_eq!(
+            json0["tool_call"]["function"]["arguments"],
+            r#"{"choice":0}"#
+        );
+        let json1 = extract_sse_data_json(events[1].as_ref().unwrap());
+        assert_eq!(json1["choice_index"], 1);
+        assert_eq!(
+            json1["tool_call"]["function"]["arguments"],
+            r#"{"choice":1}"#
+        );
+    }
+
+    // Case 9: a call filtered out by `parallel_tool_calls=false` is never even
+    // accumulated, because filtering runs before the dispatcher sees the chunk.
+    #[test]
+    fn test_13972_filtered_higher_index_call_is_never_accumulated() {
+        let mut assemblies = ToolCallAssemblies::new();
+        // Post-filter shape: only inner index 0 survives.
+        let response = make_stream_response(vec![make_choice_with_tool_calls(
+            0,
+            vec![tool_call_chunk(0, Some("call_0"), Some("f"), Some("{}"))],
+            None,
+        )]);
+        let events = collect_tool_dispatch_events(&response, &mut assemblies);
+        assert_eq!(events.len(), 1);
+        assert!(
+            !assemblies.contains_key(&(0, 1)),
+            "no state for a filtered inner index"
+        );
+    }
+
+    // Case 10: terminal outcomes.
+    #[test]
+    fn test_13972_terminal_pass_outcomes() {
+        // Valid JSON that only closes on the terminating chunk is not lost.
+        let mut assemblies = ToolCallAssemblies::new();
+        let open = make_stream_response(vec![make_choice_with_tool_call(
+            0,
+            0,
+            Some("call_1"),
+            Some("f"),
+            Some(r#"{"a":"#),
+        )]);
+        assert!(collect_tool_dispatch_events(&open, &mut assemblies).is_empty());
+        let close = make_stream_response(vec![make_choice_with_tool_calls(
+            0,
+            vec![tool_call_chunk(0, None, None, Some("1}"))],
+            Some(FinishReason::ToolCalls),
+        )]);
+        assert_eq!(
+            collect_tool_dispatch_events(&close, &mut assemblies).len(),
+            1,
+            "closing on the terminal chunk dispatches exactly once"
+        );
+
+        // Absent arguments dispatch under the parameterless compatibility rule.
+        let absent = drive_to_tool_calls_finish(
+            vec![make_choice_with_tool_call(
+                0,
+                0,
+                Some("call_1"),
+                Some("no_params"),
+                None,
+            )],
+            0,
+        );
+        assert_eq!(absent.len(), 1, "absent arguments dispatch at the terminal");
+
+        // Invalid non-empty JSON does not.
+        let invalid = drive_to_tool_calls_finish(
+            vec![make_choice_with_tool_call(
+                0,
+                0,
+                Some("call_1"),
+                Some("f"),
+                Some(r#"{"a":"#),
+            )],
+            0,
+        );
+        assert!(
+            invalid.is_empty(),
+            "truncated arguments must not dispatch at the terminal pass"
+        );
+
+        // `finish_reason: "length"` clears without emitting.
+        let mut assemblies = ToolCallAssemblies::new();
+        let open = make_stream_response(vec![make_choice_with_tool_call(
+            0,
+            0,
+            Some("call_1"),
+            Some("f"),
+            Some(r#"{"a":"#),
+        )]);
+        assert!(collect_tool_dispatch_events(&open, &mut assemblies).is_empty());
+        let truncated = make_stream_response(vec![make_finish_choice(0, FinishReason::Length)]);
+        assert!(
+            collect_tool_dispatch_events(&truncated, &mut assemblies).is_empty(),
+            "a truncated stream must not dispatch"
+        );
+    }
+
+    // Case 12: ordering. Every ordinary fragment stays an ordinary event, and
+    // exactly one dispatch event precedes the fragment that closes the JSON.
+    #[test]
+    fn test_13972_dispatch_event_precedes_the_completing_fragment() {
+        let mut assemblies = ToolCallAssemblies::new();
+        let fragments = [
+            (Some("call_1"), Some("create_file"), None),
+            (None, None, Some(r#"{"path""#)),
+            (None, None, Some(r#":"/a/very"#)),
+            (None, None, Some(r#"/long/file"}"#)),
+        ];
+
+        // Mirrors the handler loop: side-channel events are collected first,
+        // then the ordinary data event is appended.
+        let mut wire: Vec<String> = Vec::new();
+        for (i, (id, name, args)) in fragments.iter().enumerate() {
+            let response =
+                make_stream_response(vec![make_choice_with_tool_call(0, 0, *id, *name, *args)]);
+            let side = collect_tool_dispatch_events(&response, &mut assemblies);
+            for event in &side {
+                assert_event_type(event.as_ref().unwrap(), "tool_call_dispatch");
+                wire.push("tool_call_dispatch".to_string());
+            }
+            wire.push(format!("data:{i}"));
+        }
+
+        assert_eq!(
+            wire,
+            vec!["data:0", "data:1", "data:2", "tool_call_dispatch", "data:3",],
+            "the dispatch event precedes the ordinary fragment that completes the JSON, \
+             and every ordinary fragment survives"
+        );
+    }
+
+    // ── JsonStructureScanner unit coverage ──
+
+    fn scan_all(fragments: &[&str]) -> ScanOutcome {
+        let mut scanner = JsonStructureScanner::default();
+        let mut last = ScanOutcome::Incomplete;
+        for fragment in fragments {
+            last = scanner.consume(fragment);
+        }
+        last
+    }
+
+    #[test]
+    fn test_json_scanner_boundaries() {
+        assert_eq!(scan_all(&[r#"{"a":1}"#]), ScanOutcome::RootClosed);
+        assert_eq!(scan_all(&["[", "1,2", "]"]), ScanOutcome::RootClosed);
+        assert_eq!(scan_all(&[r#"{"a":"}"#, r#"" }"#]), ScanOutcome::RootClosed);
+        // Backslash split across fragments: the `"` that follows is escaped.
+        assert_eq!(
+            scan_all(&[r#"{"a":"x\"#, r#""y"}"#]),
+            ScanOutcome::RootClosed
+        );
+        assert_eq!(scan_all(&[r#"{"a":1"#]), ScanOutcome::Incomplete);
+        assert_eq!(scan_all(&["{}junk"]), ScanOutcome::Malformed);
+        assert_eq!(scan_all(&[r#"}{"x":1}"#]), ScanOutcome::Malformed);
+        assert_eq!(scan_all(&["{}", "{}"]), ScanOutcome::Malformed);
+        // Trailing whitespace after the root is allowed.
+        assert_eq!(scan_all(&["{}", "  \n"]), ScanOutcome::RootClosed);
+        // A top-level scalar is never an early candidate.
+        assert_eq!(scan_all(&["1"]), ScanOutcome::Incomplete);
+        assert_eq!(scan_all(&["1", "2"]), ScanOutcome::Incomplete);
     }
 
     // ── accumulate_reasoning_dispatch tests ──

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -21,6 +21,7 @@ use crate::protocols::common::extensions::{
 
 pub mod aggregator;
 mod delta;
+pub(crate) mod tool_call_merge;
 pub mod tool_parser_v2;
 pub(crate) mod unified_parser;
 

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -367,10 +367,8 @@ impl DeltaAggregator {
                                             function: None,
                                         }
                                     });
-                                // The merge outcome is deliberately ignored here:
-                                // aggregation stays first-wins and lossless exactly
-                                // as it was in #8582/#8640. Only the streaming
-                                // dispatch side channel acts on identity conflicts.
+                                // The merge outcome is ignored: only the streaming
+                                // dispatch acts on identity conflicts.
                                 let _ = merge_tool_call_chunk(entry, chunk);
                             }
                         }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -367,8 +367,7 @@ impl DeltaAggregator {
                                             function: None,
                                         }
                                     });
-                                // The merge outcome is ignored: only the streaming
-                                // dispatch acts on identity conflicts.
+                                // Only the streaming dispatch acts on identity conflicts.
                                 let _ = merge_tool_call_chunk(entry, chunk);
                             }
                         }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -248,7 +248,8 @@ fn finalize_merged_tool_chunk(
         // Use the merged r#type if the stream carried one. Falls back to
         // `Function` — today the only variant in the OpenAI schema, but
         // threading the merged value keeps us forward-compat if variants
-        // are added later and avoids dead state in `merge_tool_call_chunk`.
+        // are added later and avoids dead state in
+        // `super::tool_call_merge::merge_tool_call_chunk`.
         r#type: chunk
             .r#type
             .unwrap_or(dynamo_protocols::types::FunctionType::Function),

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -6,6 +6,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use dynamo_parsers::tool_calling::try_tool_call_parse_aggregate_finalize;
 
+use super::tool_call_merge::merge_tool_call_chunk;
 use super::{NvCreateChatCompletionResponse, NvCreateChatCompletionStreamResponse};
 use crate::protocols::{
     Annotated,
@@ -172,7 +173,8 @@ struct DeltaChoice {
     // keyed by `index` so chunks that carry only argument fragments can be
     // merged into the entry created by the initial (id + name) chunk.
     // BTreeMap preserves deterministic iteration order on the index dimension.
-    // See [`merge_tool_call_chunk`] for per-field merge semantics.
+    // See [`super::tool_call_merge::merge_tool_call_chunk`] for per-field merge
+    // semantics, shared with the streaming `tool_call_dispatch` side channel.
     // #8640: replaces the old `Option<Vec<ChatCompletionMessageToolCall>>`
     // which required id/name/arguments to all be set on the same chunk.
     tool_call_chunks: BTreeMap<u32, dynamo_protocols::types::ChatCompletionMessageToolCallChunk>,
@@ -203,53 +205,6 @@ impl Default for DeltaAggregator {
     /// Provides a default implementation for `DeltaAggregator` by calling [`DeltaAggregator::new`].
     fn default() -> Self {
         Self::new()
-    }
-}
-
-/// Merge an incoming chunk into the per-index accumulator.
-///
-/// #8640: the prior implementation required `id`, `name`, and `arguments`
-/// all on the same chunk, and thus the argument-fragment deltas were dropped
-/// and the client saw `arguments: ""`.
-///
-/// The fix here merges by `index` across deltas: `id`, `type`, `function.name`
-/// first-wins; `function.arguments` concatenated across fragments. This matches
-/// the OpenAI streaming spec and vLLM/SGLang hermes emission:
-///
-/// * delta 1: `{index, id, type, function: { name }}`
-/// * delta 2..N: `{index, function: { arguments: "<fragment>" }}`
-fn merge_tool_call_chunk(
-    existing: &mut dynamo_protocols::types::ChatCompletionMessageToolCallChunk,
-    incoming: dynamo_protocols::types::ChatCompletionMessageToolCallChunk,
-) {
-    if existing.id.is_none()
-        && let Some(id) = incoming.id
-    {
-        existing.id = Some(id);
-    }
-    if existing.r#type.is_none()
-        && let Some(ty) = incoming.r#type
-    {
-        existing.r#type = Some(ty);
-    }
-    let Some(incoming_fn) = incoming.function else {
-        return;
-    };
-    match &mut existing.function {
-        None => existing.function = Some(incoming_fn),
-        Some(existing_fn) => {
-            if existing_fn.name.is_none()
-                && let Some(name) = incoming_fn.name
-            {
-                existing_fn.name = Some(name);
-            }
-            if let Some(args_fragment) = incoming_fn.arguments {
-                existing_fn
-                    .arguments
-                    .get_or_insert_with(String::new)
-                    .push_str(&args_fragment);
-            }
-        }
     }
 }
 
@@ -411,7 +366,11 @@ impl DeltaAggregator {
                                             function: None,
                                         }
                                     });
-                                merge_tool_call_chunk(entry, chunk);
+                                // The merge outcome is deliberately ignored here:
+                                // aggregation stays first-wins and lossless exactly
+                                // as it was in #8582/#8640. Only the streaming
+                                // dispatch side channel acts on identity conflicts.
+                                let _ = merge_tool_call_chunk(entry, chunk);
                             }
                         }
 

--- a/lib/llm/src/protocols/openai/chat_completions/tool_call_merge.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_call_merge.rs
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared merge policy for streamed tool-call chunks.
+//!
+//! Both the non-streaming aggregator
+//! ([`super::aggregator`]) and the streaming `tool_call_dispatch`
+//! side channel (`crate::http::service::openai`) have to reassemble a single
+//! logical tool call out of the per-index delta chunks a producer emits. They
+//! must agree on that policy exactly, otherwise the typed dispatch event and
+//! the aggregated response could disagree about the same tool call.
+
+use dynamo_protocols::types::ChatCompletionMessageToolCallChunk;
+
+/// Identity field on which two chunks for the same `index` disagreed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolCallIdentityField {
+    Id,
+    Type,
+    Name,
+}
+
+impl ToolCallIdentityField {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Id => "id",
+            Self::Type => "type",
+            Self::Name => "function.name",
+        }
+    }
+}
+
+/// Result of merging one incoming chunk into an accumulator.
+///
+/// The merge itself is infallible: identity stays first-wins and argument
+/// fragments are always concatenated. The outcome is *reporting only*, so a
+/// caller that ignores it observes exactly the pre-existing behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolCallMergeOutcome {
+    /// The incoming chunk was consistent with what had already accumulated.
+    Merged,
+    /// The incoming chunk carried a *different* non-empty value for an
+    /// identity field that had already been established. First-wins was
+    /// applied and the incoming value discarded; the field is named so the
+    /// caller can log or fail-closed as it sees fit.
+    IdentityConflict { field: ToolCallIdentityField },
+}
+
+/// Merge an incoming chunk into the per-index accumulator.
+///
+/// #8640: the prior implementation required `id`, `name`, and `arguments`
+/// all on the same chunk, and thus the argument-fragment deltas were dropped
+/// and the client saw `arguments: ""`.
+///
+/// The fix here merges by `index` across deltas: `id`, `type`, `function.name`
+/// first-wins; `function.arguments` concatenated across fragments. This matches
+/// the OpenAI streaming spec and vLLM/SGLang hermes emission:
+///
+/// * delta 1: `{index, id, type, function: { name }}`
+/// * delta 2..N: `{index, function: { arguments: "<fragment>" }}`
+///
+/// Returns the first identity conflict observed, if any. Conflicts do not
+/// change what is merged; see [`ToolCallMergeOutcome`].
+pub(crate) fn merge_tool_call_chunk(
+    existing: &mut ChatCompletionMessageToolCallChunk,
+    incoming: ChatCompletionMessageToolCallChunk,
+) -> ToolCallMergeOutcome {
+    let mut conflict: Option<ToolCallIdentityField> = None;
+
+    // Record the first conflicting field only; later fields are still merged
+    // first-wins regardless.
+    let mut note = |field: ToolCallIdentityField| {
+        if conflict.is_none() {
+            conflict = Some(field);
+        }
+    };
+
+    match (&existing.id, incoming.id) {
+        (None, Some(id)) => existing.id = Some(id),
+        // An empty later value is a producer no-op, not a disagreement.
+        (Some(current), Some(id)) if !id.is_empty() && *current != id => {
+            note(ToolCallIdentityField::Id)
+        }
+        _ => {}
+    }
+    match (&existing.r#type, incoming.r#type) {
+        (None, Some(ty)) => existing.r#type = Some(ty),
+        (Some(current), Some(ty)) if *current != ty => note(ToolCallIdentityField::Type),
+        _ => {}
+    }
+
+    let Some(incoming_fn) = incoming.function else {
+        return outcome(conflict);
+    };
+    match &mut existing.function {
+        None => existing.function = Some(incoming_fn),
+        Some(existing_fn) => {
+            match (&existing_fn.name, incoming_fn.name) {
+                (None, Some(name)) => existing_fn.name = Some(name),
+                (Some(current), Some(name)) if !name.is_empty() && *current != name => {
+                    note(ToolCallIdentityField::Name)
+                }
+                _ => {}
+            }
+            if let Some(args_fragment) = incoming_fn.arguments {
+                existing_fn
+                    .arguments
+                    .get_or_insert_with(String::new)
+                    .push_str(&args_fragment);
+            }
+        }
+    }
+
+    outcome(conflict)
+}
+
+fn outcome(conflict: Option<ToolCallIdentityField>) -> ToolCallMergeOutcome {
+    match conflict {
+        None => ToolCallMergeOutcome::Merged,
+        Some(field) => ToolCallMergeOutcome::IdentityConflict { field },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_protocols::types::{FunctionCallStream, FunctionType};
+
+    fn chunk(
+        index: u32,
+        id: Option<&str>,
+        name: Option<&str>,
+        arguments: Option<&str>,
+    ) -> ChatCompletionMessageToolCallChunk {
+        ChatCompletionMessageToolCallChunk {
+            index,
+            id: id.map(str::to_string),
+            r#type: id.map(|_| FunctionType::Function),
+            function: Some(FunctionCallStream {
+                name: name.map(str::to_string),
+                arguments: arguments.map(str::to_string),
+            }),
+        }
+    }
+
+    #[test]
+    fn concatenates_argument_fragments_and_reports_merged() {
+        let mut acc = chunk(0, Some("call-1"), Some("calculator"), Some("{\"a\""));
+        assert_eq!(
+            merge_tool_call_chunk(&mut acc, chunk(0, None, None, Some(":1}"))),
+            ToolCallMergeOutcome::Merged
+        );
+        let f = acc.function.unwrap();
+        assert_eq!(f.arguments.as_deref(), Some("{\"a\":1}"));
+        assert_eq!(f.name.as_deref(), Some("calculator"));
+    }
+
+    #[test]
+    fn identity_is_first_wins_and_conflict_is_reported() {
+        let mut acc = chunk(0, Some("call-1"), Some("calculator"), Some("{}"));
+        let outcome = merge_tool_call_chunk(&mut acc, chunk(0, Some("call-2"), Some("other"), None));
+        // First conflicting field wins the report; `id` is checked first.
+        assert_eq!(
+            outcome,
+            ToolCallMergeOutcome::IdentityConflict {
+                field: ToolCallIdentityField::Id
+            }
+        );
+        // ...but the merge result is unchanged from the pre-extraction behaviour.
+        assert_eq!(acc.id.as_deref(), Some("call-1"));
+        assert_eq!(acc.function.unwrap().name.as_deref(), Some("calculator"));
+    }
+
+    #[test]
+    fn empty_later_identity_value_is_not_a_conflict() {
+        let mut acc = chunk(0, Some("call-1"), Some("calculator"), None);
+        assert_eq!(
+            merge_tool_call_chunk(&mut acc, chunk(0, Some(""), Some(""), Some("{}"))),
+            ToolCallMergeOutcome::Merged
+        );
+        assert_eq!(acc.id.as_deref(), Some("call-1"));
+    }
+
+    #[test]
+    fn name_conflict_is_named_when_id_agrees() {
+        let mut acc = chunk(0, Some("call-1"), Some("calculator"), None);
+        assert_eq!(
+            merge_tool_call_chunk(&mut acc, chunk(0, Some("call-1"), Some("other"), None)),
+            ToolCallMergeOutcome::IdentityConflict {
+                field: ToolCallIdentityField::Name
+            }
+        );
+    }
+}

--- a/lib/llm/src/protocols/openai/chat_completions/tool_call_merge.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_call_merge.rs
@@ -33,9 +33,9 @@ impl ToolCallIdentityField {
 
 /// Result of merging one incoming chunk into an accumulator.
 ///
-/// The merge itself is infallible: identity stays first-wins and argument
-/// fragments are always concatenated. The outcome is *reporting only*, so a
-/// caller that ignores it observes exactly the pre-existing behaviour.
+/// The merge itself is infallible: the first *non-empty* value of each identity
+/// field wins and argument fragments are always concatenated. The outcome is
+/// *reporting only* — a caller that ignores it still gets the merged chunk.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ToolCallMergeOutcome {
     /// The incoming chunk was consistent with what had already accumulated.
@@ -53,8 +53,10 @@ pub(crate) enum ToolCallMergeOutcome {
 /// all on the same chunk, and thus the argument-fragment deltas were dropped
 /// and the client saw `arguments: ""`.
 ///
-/// The fix here merges by `index` across deltas: `id`, `type`, `function.name`
-/// first-wins; `function.arguments` concatenated across fragments. This matches
+/// The fix here merges by `index` across deltas: the first non-empty `id`,
+/// `type`, and `function.name` win; `function.arguments` are concatenated
+/// across fragments. An empty identity value is treated as absent rather than
+/// established, because consumers test identity by presence alone. This matches
 /// the OpenAI streaming spec and vLLM/SGLang hermes emission:
 ///
 /// * delta 1: `{index, id, type, function: { name }}`
@@ -76,14 +78,16 @@ pub(crate) fn merge_tool_call_chunk(
         }
     };
 
-    match (&existing.id, incoming.id) {
-        (None, Some(id)) => existing.id = Some(id),
-        // An empty value on *either* side is a producer no-op, not a
-        // disagreement, so the guard is symmetric.
-        (Some(current), Some(id)) if !current.is_empty() && !id.is_empty() && *current != id => {
-            note(ToolCallIdentityField::Id)
+    // An empty incoming value is a producer no-op rather than a disagreement,
+    // and an empty accumulated value is not yet an identity: consumers test
+    // only for presence, so letting `Some("")` stand would dispatch a call
+    // whose id and name are blank and suppress the real ones.
+    if let Some(id) = incoming.id.filter(|id| !id.is_empty()) {
+        match existing.id.as_deref() {
+            None | Some("") => existing.id = Some(id),
+            Some(current) if current != id => note(ToolCallIdentityField::Id),
+            Some(_) => {}
         }
-        _ => {}
     }
     match (&existing.r#type, incoming.r#type) {
         (None, Some(ty)) => existing.r#type = Some(ty),
@@ -93,21 +97,25 @@ pub(crate) fn merge_tool_call_chunk(
         _ => {}
     }
 
-    let Some(incoming_fn) = incoming.function else {
+    let Some(mut incoming_fn) = incoming.function else {
         return outcome(conflict);
     };
     match &mut existing.function {
-        None => existing.function = Some(incoming_fn),
+        None => {
+            // Adopting the first `function` wholesale would smuggle in an empty
+            // name that the arm below would have refused.
+            if incoming_fn.name.as_deref() == Some("") {
+                incoming_fn.name = None;
+            }
+            existing.function = Some(incoming_fn);
+        }
         Some(existing_fn) => {
-            match (&existing_fn.name, incoming_fn.name) {
-                (None, Some(name)) => existing_fn.name = Some(name),
-                // Symmetric with the `id` arm above.
-                (Some(current), Some(name))
-                    if !current.is_empty() && !name.is_empty() && *current != name =>
-                {
-                    note(ToolCallIdentityField::Name)
+            if let Some(name) = incoming_fn.name.filter(|name| !name.is_empty()) {
+                match existing_fn.name.as_deref() {
+                    None | Some("") => existing_fn.name = Some(name),
+                    Some(current) if current != name => note(ToolCallIdentityField::Name),
+                    Some(_) => {}
                 }
-                _ => {}
             }
             if let Some(args_fragment) = incoming_fn.arguments {
                 existing_fn
@@ -174,7 +182,6 @@ mod tests {
                 field: ToolCallIdentityField::Id
             }
         );
-        // ...but the merge result is unchanged from the pre-extraction behaviour.
         assert_eq!(acc.id.as_deref(), Some("call-1"));
         assert_eq!(acc.function.unwrap().name.as_deref(), Some("calculator"));
     }
@@ -190,16 +197,29 @@ mod tests {
     }
 
     #[test]
-    fn empty_established_identity_value_is_not_a_conflict() {
-        // An empty opener followed by the real id is not a disagreement;
-        // first-wins still keeps the empty opener.
+    fn empty_established_identity_value_is_replaced_by_the_real_one() {
+        // An empty opener carries no identity, so the real id and name that
+        // follow it fill the accumulator instead of being discarded.
         let mut acc = chunk(0, Some(""), Some(""), None);
         assert_eq!(
             merge_tool_call_chunk(&mut acc, chunk(0, Some("call-1"), Some("calculator"), None)),
             ToolCallMergeOutcome::Merged
         );
-        assert_eq!(acc.id.as_deref(), Some(""));
-        assert_eq!(acc.function.unwrap().name.as_deref(), Some(""));
+        assert_eq!(acc.id.as_deref(), Some("call-1"));
+        assert_eq!(acc.function.unwrap().name.as_deref(), Some("calculator"));
+    }
+
+    #[test]
+    fn an_only_ever_empty_identity_never_becomes_established() {
+        // Consumers test identity by presence alone, so an empty value must
+        // leave the accumulator without one rather than pass as an identity.
+        let mut acc = chunk(0, None, None, None);
+        assert_eq!(
+            merge_tool_call_chunk(&mut acc, chunk(0, Some(""), Some(""), Some("{}"))),
+            ToolCallMergeOutcome::Merged
+        );
+        assert_eq!(acc.id, None);
+        assert_eq!(acc.function.unwrap().name, None);
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/chat_completions/tool_call_merge.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_call_merge.rs
@@ -21,10 +21,7 @@ pub(crate) enum ToolCallIdentityField {
 }
 
 impl ToolCallIdentityField {
-    // TODO: drop this `allow` once the streaming `tool_call_dispatch` assembly
-    // state machine lands and logs the conflicting field name; it is the only
-    // intended caller.
-    #[allow(dead_code)]
+    /// Field name for the streaming `tool_call_dispatch` fail-closed log line.
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::Id => "id",

--- a/lib/llm/src/protocols/openai/chat_completions/tool_call_merge.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_call_merge.rs
@@ -78,11 +78,8 @@ pub(crate) fn merge_tool_call_chunk(
 
     match (&existing.id, incoming.id) {
         (None, Some(id)) => existing.id = Some(id),
-        // An empty value on *either* side is a producer no-op rather than a
-        // disagreement: a producer may open the call with `id: ""` and carry
-        // the real value in a later delta, or repeat the field as an empty
-        // placeholder once it has already been established. Both orderings are
-        // the same non-event, so the guard is symmetric.
+        // An empty value on *either* side is a producer no-op, not a
+        // disagreement, so the guard is symmetric.
         (Some(current), Some(id)) if !current.is_empty() && !id.is_empty() && *current != id => {
             note(ToolCallIdentityField::Id)
         }
@@ -90,10 +87,8 @@ pub(crate) fn merge_tool_call_chunk(
     }
     match (&existing.r#type, incoming.r#type) {
         (None, Some(ty)) => existing.r#type = Some(ty),
-        // Forward-compat only: `FunctionType` has exactly one variant in the
-        // OpenAI schema today, so this arm cannot fire and `Type` cannot be
-        // reported. It is kept so that a second variant does not silently
-        // acquire unreported first-wins semantics.
+        // Forward-compat only: `FunctionType` has one variant today, so this
+        // arm cannot fire. Kept so a second variant is not silently unreported.
         (Some(current), Some(ty)) if *current != ty => note(ToolCallIdentityField::Type),
         _ => {}
     }
@@ -196,10 +191,8 @@ mod tests {
 
     #[test]
     fn empty_established_identity_value_is_not_a_conflict() {
-        // A producer that opens the call with `id: ""` and carries the real id
-        // in a later delta is not disagreeing with itself. First-wins still
-        // keeps the empty opener, exactly as it did before conflict reporting
-        // existed; only the report changes.
+        // An empty opener followed by the real id is not a disagreement;
+        // first-wins still keeps the empty opener.
         let mut acc = chunk(0, Some(""), Some(""), None);
         assert_eq!(
             merge_tool_call_chunk(&mut acc, chunk(0, Some("call-1"), Some("calculator"), None)),

--- a/lib/llm/src/protocols/openai/chat_completions/tool_call_merge.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_call_merge.rs
@@ -21,6 +21,10 @@ pub(crate) enum ToolCallIdentityField {
 }
 
 impl ToolCallIdentityField {
+    // TODO: drop this `allow` once the streaming `tool_call_dispatch` assembly
+    // state machine lands and logs the conflicting field name; it is the only
+    // intended caller.
+    #[allow(dead_code)]
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::Id => "id",
@@ -77,14 +81,22 @@ pub(crate) fn merge_tool_call_chunk(
 
     match (&existing.id, incoming.id) {
         (None, Some(id)) => existing.id = Some(id),
-        // An empty later value is a producer no-op, not a disagreement.
-        (Some(current), Some(id)) if !id.is_empty() && *current != id => {
+        // An empty value on *either* side is a producer no-op rather than a
+        // disagreement: a producer may open the call with `id: ""` and carry
+        // the real value in a later delta, or repeat the field as an empty
+        // placeholder once it has already been established. Both orderings are
+        // the same non-event, so the guard is symmetric.
+        (Some(current), Some(id)) if !current.is_empty() && !id.is_empty() && *current != id => {
             note(ToolCallIdentityField::Id)
         }
         _ => {}
     }
     match (&existing.r#type, incoming.r#type) {
         (None, Some(ty)) => existing.r#type = Some(ty),
+        // Forward-compat only: `FunctionType` has exactly one variant in the
+        // OpenAI schema today, so this arm cannot fire and `Type` cannot be
+        // reported. It is kept so that a second variant does not silently
+        // acquire unreported first-wins semantics.
         (Some(current), Some(ty)) if *current != ty => note(ToolCallIdentityField::Type),
         _ => {}
     }
@@ -97,7 +109,10 @@ pub(crate) fn merge_tool_call_chunk(
         Some(existing_fn) => {
             match (&existing_fn.name, incoming_fn.name) {
                 (None, Some(name)) => existing_fn.name = Some(name),
-                (Some(current), Some(name)) if !name.is_empty() && *current != name => {
+                // Symmetric with the `id` arm above.
+                (Some(current), Some(name))
+                    if !current.is_empty() && !name.is_empty() && *current != name =>
+                {
                     note(ToolCallIdentityField::Name)
                 }
                 _ => {}
@@ -158,7 +173,8 @@ mod tests {
     #[test]
     fn identity_is_first_wins_and_conflict_is_reported() {
         let mut acc = chunk(0, Some("call-1"), Some("calculator"), Some("{}"));
-        let outcome = merge_tool_call_chunk(&mut acc, chunk(0, Some("call-2"), Some("other"), None));
+        let outcome =
+            merge_tool_call_chunk(&mut acc, chunk(0, Some("call-2"), Some("other"), None));
         // First conflicting field wins the report; `id` is checked first.
         assert_eq!(
             outcome,
@@ -179,6 +195,21 @@ mod tests {
             ToolCallMergeOutcome::Merged
         );
         assert_eq!(acc.id.as_deref(), Some("call-1"));
+    }
+
+    #[test]
+    fn empty_established_identity_value_is_not_a_conflict() {
+        // A producer that opens the call with `id: ""` and carries the real id
+        // in a later delta is not disagreeing with itself. First-wins still
+        // keeps the empty opener, exactly as it did before conflict reporting
+        // existed; only the report changes.
+        let mut acc = chunk(0, Some(""), Some(""), None);
+        assert_eq!(
+            merge_tool_call_chunk(&mut acc, chunk(0, Some("call-1"), Some("calculator"), None)),
+            ToolCallMergeOutcome::Merged
+        );
+        assert_eq!(acc.id.as_deref(), Some(""));
+        assert_eq!(acc.function.unwrap().name.as_deref(), Some(""));
     }
 
     #[test]

--- a/lib/llm/tests/streaming_tool_dispatch_http.rs
+++ b/lib/llm/tests/streaming_tool_dispatch_http.rs
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Stream-level coverage for `event: tool_call_dispatch`.
+//!
+//! These tests drive the real chat-completions streaming handler over HTTP and
+//! read the SSE frames a client actually receives, so they observe where the
+//! handler places the dispatch event relative to the ordinary data frames
+//! produced by `EventConverter`, and that no ordinary frame is lost.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use dynamo_llm::http::service::service_v2::HttpService;
+use dynamo_llm::model_card::ModelDeploymentCard;
+use dynamo_llm::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
+use dynamo_protocols::types::{
+    ChatChoiceStream, ChatCompletionMessageToolCallChunk, ChatCompletionRequestMessage,
+    ChatCompletionRequestUserMessage, ChatCompletionRequestUserMessageContent,
+    ChatCompletionStreamResponseDelta, CreateChatCompletionRequestArgs,
+    CreateChatCompletionStreamResponse, FinishReason, FunctionCallStream, FunctionType,
+};
+use dynamo_runtime::CancellationToken;
+
+// The shared modules are included by several test binaries; this one does not
+// use every helper they offer.
+#[allow(dead_code)]
+#[path = "common/ports.rs"]
+mod ports;
+#[allow(dead_code)]
+#[path = "common/scripted_chat_engine.rs"]
+mod scripted_chat_engine;
+
+use ports::bind_random_port;
+use scripted_chat_engine::{Script, ScriptedChatEngine};
+
+const MODEL: &str = "tool-dispatch-model";
+
+/// A delta carrying one tool-call fragment for choice 0, inner index 0.
+fn fragment(
+    id: Option<&str>,
+    name: Option<&str>,
+    arguments: Option<&str>,
+) -> NvCreateChatCompletionStreamResponse {
+    chunk(choice(
+        Some(vec![ChatCompletionMessageToolCallChunk {
+            index: 0,
+            id: id.map(str::to_string),
+            r#type: Some(FunctionType::Function),
+            function: Some(FunctionCallStream {
+                name: name.map(str::to_string),
+                arguments: arguments.map(str::to_string),
+            }),
+        }]),
+        None,
+    ))
+}
+
+/// A delta whose only content is the terminal `finish_reason`.
+fn finish(reason: FinishReason) -> NvCreateChatCompletionStreamResponse {
+    chunk(choice(None, Some(reason)))
+}
+
+#[allow(deprecated)]
+fn choice(
+    tool_calls: Option<Vec<ChatCompletionMessageToolCallChunk>>,
+    finish_reason: Option<FinishReason>,
+) -> ChatChoiceStream {
+    ChatChoiceStream {
+        index: 0,
+        delta: ChatCompletionStreamResponseDelta {
+            content: None,
+            function_call: None,
+            tool_calls,
+            role: None,
+            refusal: None,
+            reasoning_content: None,
+        },
+        finish_reason,
+        logprobs: None,
+    }
+}
+
+fn chunk(choice: ChatChoiceStream) -> NvCreateChatCompletionStreamResponse {
+    NvCreateChatCompletionStreamResponse {
+        inner: CreateChatCompletionStreamResponse {
+            id: "tool-dispatch-stream".to_string(),
+            choices: vec![choice],
+            created: 1234567890,
+            model: MODEL.to_string(),
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: None,
+            service_tier: None,
+        },
+        nvext: None,
+        llm_metrics: None,
+    }
+}
+
+/// Run `script` through a real streaming request and label every SSE frame the
+/// client receives, in wire order.
+///
+/// Ordinary frames are labelled by what the client can see in them, so a lost or
+/// reordered frame changes the label sequence rather than only its length.
+async fn wire_labels(script: Script) -> Vec<String> {
+    let (listener, port) = bind_random_port().await;
+    let service = HttpService::builder()
+        .port(port)
+        .host("127.0.0.1")
+        .enable_chat_endpoints(true)
+        .enable_streaming_tool_dispatch(true)
+        .build()
+        .expect("failed to build HTTP service");
+
+    let card = ModelDeploymentCard::with_name_only(MODEL);
+    service
+        .model_manager()
+        .add_chat_completions_model(
+            MODEL,
+            card.mdcsum(),
+            Arc::new(ScriptedChatEngine::new([script])),
+        )
+        .expect("failed to register scripted model");
+
+    let cancel = CancellationToken::new();
+    let task = service.spawn_with_listener(cancel.clone(), listener).await;
+
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("failed to build HTTP client");
+    let base_url = format!("http://127.0.0.1:{port}");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while client
+            .get(format!("{base_url}/health"))
+            .send()
+            .await
+            .is_err()
+        {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("HTTP service did not become ready");
+
+    let mut request = CreateChatCompletionRequestArgs::default()
+        .model(MODEL)
+        .messages(vec![ChatCompletionRequestMessage::User(
+            ChatCompletionRequestUserMessage {
+                content: ChatCompletionRequestUserMessageContent::Text("hi".to_string()),
+                name: None,
+            },
+        )])
+        .build()
+        .expect("failed to build request");
+    request.stream = Some(true);
+
+    let response = client
+        .post(format!("{base_url}/v1/chat/completions"))
+        .json(&request)
+        .send()
+        .await
+        .expect("streaming request failed");
+    assert!(response.status().is_success(), "{response:?}");
+    let body = tokio::time::timeout(Duration::from_secs(10), response.text())
+        .await
+        .expect("stream did not finish")
+        .expect("failed to read SSE body");
+
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(2), task).await;
+
+    let labels = label_frames(&body);
+    assert!(
+        !labels.is_empty(),
+        "no SSE frames were received. Body:\n{body}"
+    );
+    labels
+}
+
+fn label_frames(body: &str) -> Vec<String> {
+    let mut labels = Vec::new();
+    for raw in body.split("\n\n") {
+        let mut event = None;
+        let mut data: Option<String> = None;
+        for line in raw.lines() {
+            if let Some(rest) = line.strip_prefix("event:") {
+                event = Some(rest.trim().to_string());
+            } else if let Some(rest) = line.strip_prefix("data:") {
+                data.get_or_insert_with(String::new).push_str(rest.trim());
+            }
+        }
+        // Keep-alive frames are bare `:` comments and carry no data.
+        let Some(data) = data else { continue };
+        labels.push(match event.as_deref() {
+            Some(name) => format!("{name}:{}", dispatched_arguments(&data)),
+            None if data == "[DONE]" => "done".to_string(),
+            None => format!("data:{}", delta_summary(&data)),
+        });
+    }
+    labels
+}
+
+/// The assembled argument string a dispatch event carries.
+fn dispatched_arguments(data: &str) -> String {
+    let json: serde_json::Value =
+        serde_json::from_str(data).unwrap_or_else(|e| panic!("dispatch frame is not JSON: {e}"));
+    json["tool_call"]["function"]["arguments"]
+        .as_str()
+        .unwrap_or("<missing>")
+        .to_string()
+}
+
+/// What an ordinary chat-completion chunk shows the client.
+fn delta_summary(data: &str) -> String {
+    let json: serde_json::Value =
+        serde_json::from_str(data).unwrap_or_else(|e| panic!("data frame is not JSON: {e}"));
+    let choice = &json["choices"][0];
+    if let Some(reason) = choice["finish_reason"].as_str() {
+        return format!("finish={reason}");
+    }
+    let call = &choice["delta"]["tool_calls"][0];
+    match call["function"]["arguments"].as_str() {
+        Some(arguments) => format!("args={arguments}"),
+        None => format!("open={}", call["function"]["name"].as_str().unwrap_or("?")),
+    }
+}
+
+/// Argument fragments that only become valid JSON on the last one. The dispatch
+/// event must reach the client before the ordinary frame carrying that last
+/// fragment, and every ordinary frame must still be delivered, in order.
+#[tokio::test]
+async fn dispatch_event_precedes_the_completing_frame_on_the_wire() {
+    let labels = wire_labels(vec![
+        fragment(Some("call_1"), Some("create_file"), None),
+        fragment(None, None, Some(r#"{"path""#)),
+        fragment(None, None, Some(r#":"/a/very"#)),
+        fragment(None, None, Some(r#"/long/file"}"#)),
+        finish(FinishReason::ToolCalls),
+    ])
+    .await;
+
+    assert_eq!(
+        labels,
+        vec![
+            "data:open=create_file",
+            r#"data:args={"path""#,
+            r#"data:args=:"/a/very"#,
+            r#"tool_call_dispatch:{"path":"/a/very/long/file"}"#,
+            r#"data:args=/long/file"}"#,
+            "data:finish=tool_calls",
+            "done",
+        ],
+    );
+}
+
+/// Truncated arguments never become valid JSON, so no dispatch event may appear,
+/// while the ordinary frames carrying the fragments are still all delivered.
+#[tokio::test]
+async fn truncated_arguments_never_dispatch_on_the_wire() {
+    let labels = wire_labels(vec![
+        fragment(Some("call_1"), Some("create_file"), None),
+        fragment(None, None, Some(r#"{"path""#)),
+        finish(FinishReason::Length),
+    ])
+    .await;
+
+    assert_eq!(
+        labels,
+        vec![
+            "data:open=create_file",
+            r#"data:args={"path""#,
+            "data:finish=length",
+            "done",
+        ],
+    );
+}


### PR DESCRIPTION
## Summary

The opt-in `tool_call_dispatch` SSE extension could dispatch a tool call as soon as one streamed delta contained an id, name, and an arguments fragment. Since providers may split JSON arguments across deltas, consumers could receive truncated arguments and later completed fragments were suppressed.

The dispatcher now assembles each request's tool calls by choice and call index, using the same merge policy as the OpenAI delta aggregator. It emits a dispatch event once the assembled arguments form one valid JSON value, preserves deterministic terminal ordering, and accepts terminal `tool_calls` and `stop` handling for completed calls. Contradictory identity fields and malformed argument streams fail closed without dispatching.

## Limits

The ordinary OpenAI SSE stream is unchanged. Dispatch remains opt-in through `--enable-streaming-tool-dispatch` or `DYN_ENABLE_STREAMING_TOOL_DISPATCH` and is disabled by default. Calls with incomplete or invalid JSON arguments are not dispatched through the extension.

## Validation

- Nursery repairs: exact replay detection compares the call index, ID, type, function name, and argument text. The HTTP fixture now supplies annotated chunks and a successful Result to the updated scripted engine API.
- Merged main after remote Clippy exposed the fixture API mismatch in the current-base merge; the existing test assertions and upstream terminal-length filtering are preserved.
- Rustfmt 1.96.1 (`--edition 2024 --check`) passed for the Rust files in the PR diff; `git diff --check` passed.
- No local tests, builds, benchmarks, or new tests in this nursery pass. Remote Pre Merge CI passed on `4aa5dc191982e925bcc262c4e06ffdd2cfc3a4f3`, including both existing HTTP streaming-dispatch tests. Full CI was authorized on September 17, 2026 and ran on this head. The Rust GPU job timed out during self-hosted container initialization before checkout or tests, causing `dynamo-status-check` to fail. A targeted rerun was denied with HTTP 403 (repository admin rights required); all remaining backend GPU checks have now passed. The workflow is terminal with conclusion `cancelled`, and no checks remain pending. Full CI is blocked on runner recovery and an authorized rerun.

## Related Issues

- Closes #13972


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved streaming tool-call handling for fragmented and interleaved responses.
  * Tool calls are dispatched once their arguments form valid JSON, including complete objects and arrays.
  * Prevented duplicate dispatches and rejected conflicting, malformed, or truncated tool calls.
  * Parameterless tool calls are dispatched only at the end of a response.

* **Documentation**
  * Added documentation describing streaming tool-call dispatch behavior and guarantees.

* **Tests**
  * Expanded coverage for ordering, fragmentation, malformed input, terminal events, and duplicate prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->