### PR TITLE
test(deploy): run tool-execution scenarios against any recipe on any cluster (OPS-8418)

### DIFF
--- a/tests/deploy/conftest.py
+++ b/tests/deploy/conftest.py
@@ -100,6 +100,27 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="Model snapshot path inside --model-cache-pvc.",
     )
     parser.addoption(
+        "--recipe",
+        type=str,
+        default=None,
+        help="Path to any DynamoGraphDeployment manifest (for example "
+        "recipes/<model>/<backend>/<profile>/deploy.yaml) to deploy and run "
+        "recipe-scoped tests against. The cluster is chosen by KUBECONFIG.",
+    )
+    parser.addoption(
+        "--recipe-model",
+        type=str,
+        default=None,
+        help="Served model name to send in requests. Defaults to the model "
+        "parsed out of the --recipe manifest's worker args.",
+    )
+    parser.addoption(
+        "--recipe-deploy-timeout",
+        type=int,
+        default=1800,
+        help="Seconds to wait for a --recipe deployment to become ready.",
+    )
+    parser.addoption(
         "--dgdr-total-gpus",
         type=int,
         default=0,

--- a/tests/deploy/dgd_utils.py
+++ b/tests/deploy/dgd_utils.py
@@ -485,9 +485,33 @@ class DeploymentSpec:
     def __init__(
         self, base: str, endpoint="/v1/chat/completions", port=8000, system_port=9090
     ):
-        """Load the deployment YAML file"""
+        """Load the deployment YAML file.
+
+        Recipe manifests are frequently multi-document -- a DynamoGraphDeployment
+        alongside ConfigMaps, Services or PVCs. Select the DGD document rather
+        than assuming a single-document file, otherwise ``yaml.safe_load``
+        raises ComposerError on the majority of ``recipes/*/deploy.yaml``.
+        """
         with open(base, "r") as f:
-            self._deployment_spec = yaml.safe_load(f)
+            docs = [d for d in yaml.safe_load_all(f) if isinstance(d, dict)]
+        graph_deployments = [
+            d for d in docs if d.get("kind") == "DynamoGraphDeployment"
+        ]
+        if len(graph_deployments) > 1:
+            raise ValueError(
+                f"{base} contains {len(graph_deployments)} DynamoGraphDeployment "
+                "documents; expected exactly one"
+            )
+        if graph_deployments:
+            self._deployment_spec = graph_deployments[0]
+        elif len(docs) == 1:
+            # Preserve the original behaviour for manifests that omit `kind`.
+            self._deployment_spec = docs[0]
+        else:
+            raise ValueError(
+                f"{base} contains no DynamoGraphDeployment document "
+                f"(found kinds: {sorted({d.get('kind') for d in docs})})"
+            )
         self._endpoint = endpoint
         self._port = port
         self._system_port = system_port

--- a/tests/deploy/test_dgd_utils.py
+++ b/tests/deploy/test_dgd_utils.py
@@ -28,3 +28,47 @@ def test_logging_config_reads_existing_v1beta1_env(tmp_path) -> None:
     deployment_spec = DeploymentSpec(str(manifest_path))
 
     assert deployment_spec.get_logging_config()["jsonl_enabled"] is True
+
+
+def test_multi_document_manifest_selects_the_graph_deployment(tmp_path) -> None:
+    """Recipe manifests bundle the DGD with ConfigMaps and friends.
+
+    Most files under ``recipes/`` are multi-document; loading them with
+    ``yaml.safe_load`` raises ComposerError, which previously made the majority
+    of the recipe corpus unusable with DeploymentSpec.
+    """
+    config_map = {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": "engine-config"},
+        "data": {"engine.yaml": "tensor_parallel_size: 1\n"},
+    }
+    graph_deployment = {
+        "apiVersion": "nvidia.com/v1beta1",
+        "kind": "DynamoGraphDeployment",
+        "metadata": {"name": "multi-doc-test"},
+        "spec": {"components": []},
+    }
+    manifest_path = tmp_path / "deploy.yaml"
+    manifest_path.write_text(yaml.safe_dump_all([config_map, graph_deployment]))
+
+    deployment_spec = DeploymentSpec(str(manifest_path))
+
+    assert deployment_spec.name == "multi-doc-test"
+    assert deployment_spec.schema == "v1beta1"
+
+
+def test_manifest_without_a_graph_deployment_is_rejected(tmp_path) -> None:
+    """A manifest carrying no DGD must fail loudly, not silently pick a Service."""
+    manifest_path = tmp_path / "deploy.yaml"
+    manifest_path.write_text(
+        yaml.safe_dump_all(
+            [
+                {"apiVersion": "v1", "kind": "Service", "metadata": {"name": "svc"}},
+                {"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "cm"}},
+            ]
+        )
+    )
+
+    with pytest.raises(ValueError, match="no DynamoGraphDeployment"):
+        DeploymentSpec(str(manifest_path))

--- a/tests/deploy/test_recipe_tool_execution.py
+++ b/tests/deploy/test_recipe_tool_execution.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end tool execution against a live DynamoGraphDeployment.
+
+Runs the same scenarios as ``tests/frontend/test_tool_calling_sglang.py``, but
+against a recipe deployed on a real cluster instead of locally spawned
+processes. Both the recipe and the cluster are chosen at run time:
+
+```bash
+KUBECONFIG=/path/to/kubeconfig python -m pytest \\
+  tests/deploy/test_recipe_tool_execution.py \\
+  --recipe recipes/gpt-oss-120b/vllm/agg-h200-agentic/deploy.yaml \\
+  --namespace dynamo -m "k8s and deploy" -v -s
+```
+
+Nothing about the scenarios is Kubernetes-specific -- they need only an
+OpenAI-compatible client and a model name (see ``tests/utils/tool_calling.py``).
+The tools they invoke run as subprocesses **in the pytest process**, not in the
+cluster, which is what keeps them meaningful regardless of where Dynamo runs.
+
+Two gates decide whether this module can say anything at all about a recipe:
+
+* **Precondition** -- the manifest must configure a tool-call parser. Without
+  one the frontend cannot emit ``tool_calls`` and a failure would say nothing
+  about the model or the deployment. Missing parser => skip, not fail.
+* **Capability** -- chaining two tools is a property of the *model*, not of the
+  serving stack. Qwen3-0.6B and Qwen3-8B both fail it while handling the
+  protocol perfectly; Kimi-K2.5 passes. It is therefore recorded as a
+  capability result rather than asserted, so pointing this module at a weaker
+  recipe reports the limitation instead of manufacturing a red build.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import Any, Optional
+
+import pytest
+import requests
+
+from tests.deploy.dgd_utils import DeploymentSpec, ManagedDeployment
+from tests.utils.client import wait_for_model_availability
+from tests.utils.tool_calling import (
+    assert_chained_tools_thread_real_output,
+    assert_executes_real_tool_and_uses_output,
+)
+
+openai = pytest.importorskip("openai")
+OpenAI = openai.OpenAI
+
+logger = logging.getLogger(__name__)
+
+# Flags that make a Dynamo frontend/worker emit OpenAI `tool_calls`. Either the
+# frontend declares the parser directly, or the worker declares it and the
+# frontend picks it up from the runtime config registered at discovery time.
+_TOOL_PARSER_FLAGS = ("--dyn-tool-call-parser", "--tool-call-parser")
+
+
+def _declared_tool_call_parser(spec: DeploymentSpec) -> Optional[str]:
+    """Return the tool-call parser a manifest configures, or None.
+
+    Scans every service's args, since which component carries the flag differs
+    between the frontend-parser and worker-declared topologies.
+    """
+    for service in spec.services:
+        try:
+            args = service._get_args() or []
+        except Exception:  # noqa: BLE001 - a malformed service must not abort the scan
+            continue
+        for i, arg in enumerate(args):
+            for flag in _TOOL_PARSER_FLAGS:
+                if arg == flag and i + 1 < len(args):
+                    return args[i + 1]
+                if arg.startswith(f"{flag}="):
+                    return arg.split("=", 1)[1]
+    return None
+
+
+def _served_model(spec: DeploymentSpec) -> Optional[str]:
+    """Best-effort model name from the manifest's worker args.
+
+    Only about a third of the recipe corpus passes ``--model`` on the command
+    line; the rest configure it through an engine config file or ConfigMap. For
+    those, ``_model_from_endpoint`` reads it back off the running deployment
+    instead, which is authoritative anyway.
+    """
+    for service in spec.services:
+        try:
+            if service.model:
+                return service.model
+        except Exception:  # noqa: BLE001
+            continue
+    return None
+
+
+def _model_from_endpoint(
+    base_url: str, attempts: int = 30, delay: float = 10.0
+) -> Optional[str]:
+    """Read the served model id back off a running frontend's /v1/models.
+
+    Polls, because the frontend answers before any worker has registered and
+    reports an empty list until one has.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            response = requests.get(f"{base_url}/v1/models", timeout=30)
+            response.raise_for_status()
+            entries = (response.json() or {}).get("data") or []
+        except (requests.RequestException, ValueError) as exc:
+            logger.debug("attempt %d: /v1/models not ready: %s", attempt, exc)
+            entries = []
+        for entry in entries:
+            model_id = (entry or {}).get("id")
+            if model_id:
+                logger.info("discovered served model %r from /v1/models", model_id)
+                return model_id
+        time.sleep(delay)
+    return None
+
+
+@pytest.mark.framework_only
+@pytest.mark.k8s
+@pytest.mark.deploy
+@pytest.mark.e2e
+@pytest.mark.timeout(2400)
+async def test_recipe_executes_tools_end_to_end(
+    request: pytest.FixtureRequest,
+    image: Optional[str],
+    namespace: str,
+    record_property: Any,
+):
+    """Deploy --recipe, then prove the model actually uses real tool output."""
+    recipe = request.config.getoption("--recipe")
+    if not recipe:
+        pytest.skip("--recipe not provided; nothing to deploy")
+
+    deployment_spec = DeploymentSpec(recipe)
+
+    parser = _declared_tool_call_parser(deployment_spec)
+    if parser is None:
+        pytest.skip(
+            f"{recipe} configures no tool-call parser "
+            f"(looked for {' / '.join(_TOOL_PARSER_FLAGS)}), so the frontend "
+            "cannot emit tool_calls. This is a deployment precondition, not a "
+            "defect -- re-run against a recipe that enables tool calling."
+        )
+
+    model_hint = request.config.getoption("--recipe-model") or _served_model(
+        deployment_spec
+    )
+
+    if image:
+        deployment_spec.set_image(image)
+
+    # Unique name so concurrent runs against one cluster do not collide.
+    deployment_spec.name = f"{deployment_spec.name}-tx-{uuid.uuid4().hex[:6]}"
+
+    record_property("recipe", recipe)
+    record_property("tool_call_parser", parser)
+
+    logger.info(
+        "Deploying recipe=%s name=%s namespace=%s model=%s parser=%s",
+        recipe,
+        deployment_spec.name,
+        namespace,
+        model_hint or "<from /v1/models>",
+        parser,
+    )
+
+    async with ManagedDeployment(
+        log_dir=request.node.name,
+        deployment_spec=deployment_spec,
+        namespace=namespace,
+        readiness_timeout=request.config.getoption("--recipe-deploy-timeout"),
+    ) as deployment:
+        frontend_pods = deployment.get_pods([deployment.frontend_service_name]).get(
+            deployment.frontend_service_name, []
+        )
+        assert frontend_pods, f"no frontend pods for {deployment_spec.name}"
+
+        port_forward = deployment.port_forward(frontend_pods[0], deployment_spec.port)
+        assert port_forward is not None, (
+            f"failed to port-forward to {frontend_pods[0].name}:"
+            f"{deployment_spec.port}"
+        )
+
+        base_url = f"http://localhost:{port_forward.local_port}"
+        logger.info("Frontend reachable at %s", base_url)
+
+        model = model_hint or _model_from_endpoint(base_url)
+        assert model, (
+            f"could not determine the served model for {recipe}: it is not in "
+            "the manifest args and /v1/models never reported one. Pass "
+            "--recipe-model explicitly."
+        )
+        record_property("model", model)
+
+        assert wait_for_model_availability(
+            url=base_url,
+            endpoint=deployment_spec.endpoint,
+            model=model,
+            logger=logger,
+            max_attempts=30,
+        ), f"model {model} never became available at {base_url}"
+
+        client = OpenAI(api_key="EMPTY", base_url=f"{base_url}/v1")
+
+        # Requirement: a real subprocess runs and the model reports back a
+        # secret that appears in no prompt. Any deployment serving a
+        # tool-calling model must satisfy this.
+        assert_executes_real_tool_and_uses_output(client, model)
+        logger.info("single-tool execution: PASS")
+
+        # Capability probe: threading one tool's real output into the next
+        # call. Recorded, not asserted -- see the module docstring.
+        try:
+            assert_chained_tools_thread_real_output(client, model)
+            chained = "pass"
+            logger.info("chained-tool execution: PASS")
+        except AssertionError as exc:
+            chained = f"unsupported: {exc}"
+            logger.warning(
+                "chained-tool execution: NOT SUPPORTED by %s -- %s", model, exc
+            )
+        record_property("chained_tool_capability", chained)

--- a/tests/frontend/test_tool_calling_sglang.py
+++ b/tests/frontend/test_tool_calling_sglang.py
@@ -22,11 +22,7 @@ import logging
 import os
 import shutil
 import signal
-import subprocess
-import sys
 import time
-import uuid
-from dataclasses import dataclass
 from typing import Any, Generator
 
 import psutil
@@ -37,6 +33,15 @@ from tests.utils.gpu_args import build_gpu_mem_args
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_models_api
 from tests.utils.port_utils import allocate_ports
+from tests.utils.tool_calling import (
+    assert_chained_tools_thread_real_output,
+    assert_executes_real_tool_and_uses_output,
+    assert_finish_reason,
+    assistant_tool_message_from_result,
+    parse_and_validate_tool_call,
+    stream_chat,
+    tool_schema_map,
+)
 
 openai = pytest.importorskip("openai")
 OpenAI = openai.OpenAI
@@ -485,179 +490,6 @@ TOOLS_GET_TIME = [
 # ---------------------------------------------------------------------------
 
 
-def tool_schema_map(tools: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
-    out: dict[str, dict[str, Any]] = {}
-    for tool in tools:
-        fn = tool["function"]
-        out[fn["name"]] = fn["parameters"]
-    return out
-
-
-@dataclass
-class StreamResult:
-    content: str
-    reasoning_content: str
-    tool_calls: list[dict[str, Any]]
-    finish_reason: str | None
-    model: str
-    chunks: int
-    ttft_ms: float
-    raw_chunks: list[Any]
-
-
-def collect_stream(stream) -> StreamResult:
-    content_parts: list[str] = []
-    reasoning_parts: list[str] = []
-    tool_calls_by_index: dict[int, dict[str, Any]] = {}
-    finish_reason = None
-    model = ""
-    chunk_count = 0
-    raw_chunks: list[Any] = []
-    t0 = time.monotonic()
-    ttft_ms = 0.0
-
-    for chunk in stream:
-        raw_chunks.append(chunk)
-        chunk_count += 1
-        if chunk_count == 1:
-            ttft_ms = (time.monotonic() - t0) * 1000.0
-        model = chunk.model
-
-        for choice in chunk.choices:
-            delta = choice.delta
-
-            if getattr(delta, "content", None):
-                content_parts.append(delta.content)
-
-            if getattr(delta, "reasoning_content", None):
-                reasoning_parts.append(delta.reasoning_content)
-
-            if getattr(delta, "tool_calls", None):
-                for tc in delta.tool_calls:
-                    idx = tc.index
-                    entry = tool_calls_by_index.setdefault(
-                        idx,
-                        {
-                            "id": "",
-                            "type": "function",
-                            "function": {"name": "", "arguments": ""},
-                        },
-                    )
-
-                    if tc.id:
-                        if entry["id"] and entry["id"] != tc.id:
-                            raise AssertionError(
-                                f"Tool call id changed within same index {idx}: "
-                                f"{entry['id']} -> {tc.id}"
-                            )
-                        entry["id"] = tc.id
-
-                    if tc.type:
-                        entry["type"] = tc.type
-
-                    if tc.function:
-                        if tc.function.name:
-                            if (
-                                entry["function"]["name"]
-                                and entry["function"]["name"] != tc.function.name
-                            ):
-                                raise AssertionError(
-                                    f"Tool name changed within same index {idx}: "
-                                    f"{entry['function']['name']} -> {tc.function.name}"
-                                )
-                            entry["function"]["name"] = tc.function.name
-
-                        if tc.function.arguments:
-                            entry["function"]["arguments"] += tc.function.arguments
-
-            if choice.finish_reason:
-                finish_reason = choice.finish_reason
-
-    ordered_tool_calls = [tool_calls_by_index[i] for i in sorted(tool_calls_by_index)]
-    return StreamResult(
-        content="".join(content_parts),
-        reasoning_content="".join(reasoning_parts),
-        tool_calls=ordered_tool_calls,
-        finish_reason=finish_reason,
-        model=model,
-        chunks=chunk_count,
-        ttft_ms=ttft_ms,
-        raw_chunks=raw_chunks,
-    )
-
-
-def stream_chat(
-    client: OpenAI,
-    model: str,
-    *,
-    messages: list[dict[str, Any]],
-    tools: list[dict[str, Any]] | None = None,
-    max_tokens: int = 4096,
-    **kwargs,
-) -> StreamResult:
-    req: dict[str, Any] = {
-        "model": model,
-        "messages": messages,
-        "stream": True,
-        "max_tokens": max_tokens,
-    }
-    if tools is not None:
-        req["tools"] = tools
-    req.update(kwargs)
-    stream = client.chat.completions.create(**req)
-    return collect_stream(stream)
-
-
-def parse_and_validate_tool_call(
-    tc: dict[str, Any],
-    schema_by_name: dict[str, dict[str, Any]],
-    *,
-    expected_name: str | None = None,
-) -> dict[str, Any]:
-    assert tc["type"] == "function", f"unexpected tool type: {tc['type']!r}"
-    assert tc["id"], "tool call id must be non-empty"
-    fn_name = tc["function"]["name"]
-    assert fn_name, "tool call function name must be non-empty"
-
-    if expected_name is not None:
-        assert fn_name == expected_name, f"expected {expected_name!r}, got {fn_name!r}"
-
-    assert fn_name in schema_by_name, f"unknown tool name {fn_name!r}"
-    args_str = tc["function"]["arguments"]
-    assert args_str, "tool call arguments must be non-empty"
-
-    try:
-        args = json.loads(args_str)
-    except json.JSONDecodeError as e:
-        raise AssertionError(f"arguments are not valid JSON: {args_str!r}") from e
-
-    assert isinstance(args, dict), f"arguments must decode to object, got {type(args)}"
-
-    validator = Draft7Validator(schema_by_name[fn_name])
-    errors = sorted(validator.iter_errors(args), key=lambda e: list(e.path))
-    if errors:
-        rendered = "; ".join(
-            f"path={list(err.path)} message={err.message}" for err in errors
-        )
-        raise AssertionError(f"arguments failed schema validation: {rendered}")
-
-    return args
-
-
-def assert_finish_reason(result: StreamResult, allowed: set[str]) -> None:
-    assert (
-        result.finish_reason in allowed
-    ), f"unexpected finish_reason={result.finish_reason!r}, allowed={sorted(allowed)}"
-
-
-def assistant_tool_message_from_result(result: StreamResult) -> dict[str, Any]:
-    return {
-        "role": "assistant",
-        "content": result.content or None,
-        "tool_calls": result.tool_calls,
-    }
-
-
 # ---------------------------------------------------------------------------
 # Protocol / contract tests
 # ---------------------------------------------------------------------------
@@ -1044,97 +876,16 @@ class TestToolCallingMultiTurn:
 # ---------------------------------------------------------------------------
 # End-to-end tool execution
 # ---------------------------------------------------------------------------
-# Everything above tests the tool-calling *protocol*: that a well-formed
-# tool_calls object comes back, and that a hand-written `role: tool` message is
-# consumed. Nothing is executed -- the "tool result" is a literal the test
-# author typed, so a model that ignored the result entirely and produced a
-# plausible-looking answer would still pass.
+# Everything above tests the tool-calling *protocol*: a well-formed tool_calls
+# object comes back, and a hand-written `role: tool` message is consumed.
+# Nothing is executed -- the "tool result" is a literal the test author typed,
+# so a model that ignored it entirely and produced a plausible-looking answer
+# would still pass.
 #
-# The tests below close that loop. A real subprocess runs, and the value it
-# returns is generated per run and never appears in any prompt. The model
-# cannot reach it by guessing, memorisation or reasoning; the only path from
-# the question to the answer runs through the tool actually executing.
-
-MAX_TOOL_TURNS = 6
-
-# These shell out deliberately. An in-process Python function would leave
-# "did anything outside the test actually run?" unanswered.
-_LOOKUP_CODE = (
-    "import os, sys; "
-    "print(os.environ['ACCESS_CODE'] if sys.argv[1].strip().lower() == 'alice' "
-    "else 'DENIED')"
-)
-_LOOKUP_ID = (
-    "import os, sys; "
-    "print(os.environ['USER_ID'] if sys.argv[1].strip().lower() == 'alice' "
-    "else 'UNKNOWN')"
-)
-_LOOKUP_QUOTA = (
-    "import os, sys; "
-    "print(os.environ['QUOTA'] if sys.argv[1].strip() == os.environ['USER_ID'] "
-    "else '-1')"
-)
-
-
-def run_tool_cli(script: str, arg: str, env_extra: dict[str, str]) -> str:
-    result = subprocess.run(
-        [sys.executable, "-c", script, arg],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        env={**os.environ, **env_extra},
-        check=True,
-    )
-    return result.stdout.strip()
-
-
-def run_tool_loop(
-    client: OpenAI,
-    model: str,
-    messages: list[dict[str, Any]],
-    tools: list[dict[str, Any]],
-    dispatch: dict[str, Any],
-    max_turns: int = MAX_TOOL_TURNS,
-) -> tuple[str, list[dict[str, Any]]]:
-    """Drive a real tool-execution loop until the model answers with text.
-
-    Returns (final_text, calls), where `calls` records every tool the model
-    asked for and what that tool actually returned -- so a test can assert the
-    tool ran, not merely that the final answer looks right.
-    """
-    calls: list[dict[str, Any]] = []
-    convo = list(messages)
-    for _ in range(max_turns):
-        result = stream_chat(client, model, messages=convo, tools=tools)
-        if not result.tool_calls:
-            return (result.content or ""), calls
-
-        # Echo the assistant turn back, tool_calls included, or the model has
-        # no record of having asked.
-        convo.append(assistant_tool_message_from_result(result))
-        for tc in result.tool_calls:
-            name = tc["function"]["name"]
-            try:
-                args = json.loads(tc["function"]["arguments"] or "{}")
-            except json.JSONDecodeError as e:
-                raise AssertionError(
-                    f"model emitted unparseable arguments for {name}: "
-                    f"{tc['function']['arguments']!r}"
-                ) from e
-            assert name in dispatch, (
-                f"model called {name!r}, which was never offered. "
-                f"Offered: {sorted(dispatch)}"
-            )
-            output = dispatch[name](args)  # the tool really runs here
-            calls.append({"name": name, "args": args, "output": output})
-            convo.append(
-                {"role": "tool", "tool_call_id": tc["id"], "content": str(output)}
-            )
-
-    raise AssertionError(
-        f"model never produced a final text answer within {max_turns} turns; "
-        f"calls so far: {calls}"
-    )
+# The scenarios below close that loop. They live in tests/utils/tool_calling.py
+# because they depend only on (client, model) and are therefore reusable by any
+# deployment topology; see tests/deploy/test_recipe_tool_execution.py for the
+# same scenarios driven against a live Kubernetes DynamoGraphDeployment.
 
 
 class TestToolExecutionE2E:
@@ -1142,67 +893,7 @@ class TestToolExecutionE2E:
     def test_model_call_executes_a_real_tool_and_uses_its_output(
         self, client: OpenAI, model: str
     ):
-        """The answer must contain a secret only the executed tool could supply.
-
-        The secret is generated per run and never appears in any prompt, so the
-        assertion cannot be satisfied by hallucination, memorisation or luck.
-        """
-        secret = uuid.uuid4().hex[:12]
-        tools = [
-            {
-                "type": "function",
-                "function": {
-                    "name": "lookup_access_code",
-                    "description": (
-                        "Look up the access code for a user. This is the only "
-                        "way to obtain an access code."
-                    ),
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "user": {"type": "string", "description": "the username"}
-                        },
-                        "required": ["user"],
-                    },
-                },
-            }
-        ]
-
-        def lookup_access_code(args: dict[str, Any]) -> str:
-            return run_tool_cli(
-                _LOOKUP_CODE, str(args.get("user", "")), {"ACCESS_CODE": secret}
-            )
-
-        text, calls = run_tool_loop(
-            client,
-            model,
-            [
-                {
-                    "role": "user",
-                    "content": (
-                        "Look up the access code for user alice, then tell me "
-                        "the code exactly as returned."
-                    ),
-                }
-            ],
-            tools,
-            {"lookup_access_code": lookup_access_code},
-        )
-
-        assert calls, "the model never called the tool, so nothing was executed"
-        assert calls[0]["name"] == "lookup_access_code"
-        assert calls[0]["args"].get("user", "").strip().lower() == "alice", (
-            f"model passed an unusable argument: {calls[0]['args']!r} -- "
-            "schema-valid but wrong, which protocol-only tests cannot catch"
-        )
-        assert calls[0]["output"] == secret, (
-            f"tool returned {calls[0]['output']!r}, expected the generated "
-            "secret; the subprocess did not get the argument it should have"
-        )
-        assert secret in text, (
-            "final answer did not contain the executed tool's output.\n"
-            f"secret={secret!r}\nanswer={text[:400]!r}"
-        )
+        assert_executes_real_tool_and_uses_output(client, model)
 
     @pytest.mark.xfail(
         strict=False,
@@ -1220,88 +911,4 @@ class TestToolExecutionE2E:
     def test_chained_tools_second_call_uses_first_calls_real_output(
         self, client: OpenAI, model: str
     ):
-        """Two real executions, the second satisfiable only via the first.
-
-        get_quota returns -1 unless handed the exact id get_user_id produced,
-        and both values are random per run. A correct final number therefore
-        proves the model threaded real output from one execution into the next.
-        """
-        user_id = f"U-{uuid.uuid4().hex[:8]}"
-        quota = str(uuid.uuid4().int % 9000 + 1000)  # 4 digits, unguessable
-        tools = [
-            {
-                "type": "function",
-                "function": {
-                    "name": "get_user_id",
-                    "description": "Resolve a username to its internal user id.",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {"name": {"type": "string"}},
-                        "required": ["name"],
-                    },
-                },
-            },
-            {
-                "type": "function",
-                "function": {
-                    "name": "get_quota",
-                    "description": (
-                        "Get the storage quota for an internal user id. "
-                        "Requires the id from get_user_id, not a username."
-                    ),
-                    "parameters": {
-                        "type": "object",
-                        "properties": {"user_id": {"type": "string"}},
-                        "required": ["user_id"],
-                    },
-                },
-            },
-        ]
-
-        dispatch = {
-            "get_user_id": lambda a: run_tool_cli(
-                _LOOKUP_ID, str(a.get("name", "")), {"USER_ID": user_id}
-            ),
-            "get_quota": lambda a: run_tool_cli(
-                _LOOKUP_QUOTA,
-                str(a.get("user_id", "")),
-                {"USER_ID": user_id, "QUOTA": quota},
-            ),
-        }
-
-        text, calls = run_tool_loop(
-            client,
-            model,
-            [
-                {
-                    "role": "user",
-                    "content": (
-                        "What is alice's storage quota? Look up her user id "
-                        "first, then use that id to get the quota. Report the "
-                        "number."
-                    ),
-                }
-            ],
-            tools,
-            dispatch,
-        )
-
-        names = [c["name"] for c in calls]
-        assert "get_user_id" in names, f"never resolved the id; calls={names}"
-        assert "get_quota" in names, f"never fetched the quota; calls={names}"
-        assert names.index("get_user_id") < names.index(
-            "get_quota"
-        ), f"called get_quota before get_user_id: {names}"
-
-        quota_call = calls[names.index("get_quota")]
-        assert quota_call["args"].get("user_id") == user_id, (
-            f"second call used {quota_call['args'].get('user_id')!r} instead of "
-            f"the id the first call actually returned ({user_id!r})"
-        )
-        assert (
-            quota_call["output"] == quota
-        ), f"get_quota returned {quota_call['output']!r} -- it was handed the wrong id"
-        assert quota in text, (
-            "final answer omitted the quota the tool actually returned.\n"
-            f"quota={quota!r}\nanswer={text[:400]!r}"
-        )
+        assert_chained_tools_thread_real_output(client, model)

--- a/tests/utils/tool_calling.py
+++ b/tests/utils/tool_calling.py
@@ -1,0 +1,458 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Transport-agnostic tool-calling helpers and end-to-end tool-execution scenarios.
+
+Everything here depends only on an OpenAI-compatible ``client`` and a ``model``
+name. Nothing knows how the endpoint came to exist -- a locally spawned worker,
+a container, or a DynamoGraphDeployment on a Kubernetes cluster all work
+identically. That is what lets the same scenarios run from
+``tests/frontend/test_tool_calling_sglang.py`` (local processes) and
+``tests/deploy/test_recipe_tool_execution.py`` (live cluster).
+
+The ``assert_*`` scenarios execute real subprocesses **in the pytest process**,
+not in the cluster, and the value each returns is generated per run and never
+appears in any prompt. That is deliberate: it keeps the tests valid regardless
+of where Dynamo itself is running, while still making hallucination unable to
+satisfy the assertion.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+openai = pytest.importorskip("openai")
+OpenAI = openai.OpenAI
+jsonschema = pytest.importorskip("jsonschema")
+Draft7Validator = jsonschema.Draft7Validator
+
+
+# ---------------------------------------------------------------------------
+# Streaming helpers
+# ---------------------------------------------------------------------------
+
+
+def tool_schema_map(tools: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for tool in tools:
+        fn = tool["function"]
+        out[fn["name"]] = fn["parameters"]
+    return out
+
+
+@dataclass
+class StreamResult:
+    content: str
+    reasoning_content: str
+    tool_calls: list[dict[str, Any]]
+    finish_reason: str | None
+    model: str
+    chunks: int
+    ttft_ms: float
+    raw_chunks: list[Any]
+
+
+def collect_stream(stream) -> StreamResult:
+    content_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    tool_calls_by_index: dict[int, dict[str, Any]] = {}
+    finish_reason = None
+    model = ""
+    chunk_count = 0
+    raw_chunks: list[Any] = []
+    t0 = time.monotonic()
+    ttft_ms = 0.0
+
+    for chunk in stream:
+        raw_chunks.append(chunk)
+        chunk_count += 1
+        if chunk_count == 1:
+            ttft_ms = (time.monotonic() - t0) * 1000.0
+        model = chunk.model
+
+        for choice in chunk.choices:
+            delta = choice.delta
+
+            if getattr(delta, "content", None):
+                content_parts.append(delta.content)
+
+            if getattr(delta, "reasoning_content", None):
+                reasoning_parts.append(delta.reasoning_content)
+
+            if getattr(delta, "tool_calls", None):
+                for tc in delta.tool_calls:
+                    idx = tc.index
+                    entry = tool_calls_by_index.setdefault(
+                        idx,
+                        {
+                            "id": "",
+                            "type": "function",
+                            "function": {"name": "", "arguments": ""},
+                        },
+                    )
+
+                    if tc.id:
+                        if entry["id"] and entry["id"] != tc.id:
+                            raise AssertionError(
+                                f"Tool call id changed within same index {idx}: "
+                                f"{entry['id']} -> {tc.id}"
+                            )
+                        entry["id"] = tc.id
+
+                    if tc.type:
+                        entry["type"] = tc.type
+
+                    if tc.function:
+                        if tc.function.name:
+                            if (
+                                entry["function"]["name"]
+                                and entry["function"]["name"] != tc.function.name
+                            ):
+                                raise AssertionError(
+                                    f"Tool name changed within same index {idx}: "
+                                    f"{entry['function']['name']} -> {tc.function.name}"
+                                )
+                            entry["function"]["name"] = tc.function.name
+
+                        if tc.function.arguments:
+                            entry["function"]["arguments"] += tc.function.arguments
+
+            if choice.finish_reason:
+                finish_reason = choice.finish_reason
+
+    ordered_tool_calls = [tool_calls_by_index[i] for i in sorted(tool_calls_by_index)]
+    return StreamResult(
+        content="".join(content_parts),
+        reasoning_content="".join(reasoning_parts),
+        tool_calls=ordered_tool_calls,
+        finish_reason=finish_reason,
+        model=model,
+        chunks=chunk_count,
+        ttft_ms=ttft_ms,
+        raw_chunks=raw_chunks,
+    )
+
+
+def stream_chat(
+    client: OpenAI,
+    model: str,
+    *,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None = None,
+    max_tokens: int = 4096,
+    **kwargs,
+) -> StreamResult:
+    req: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "stream": True,
+        "max_tokens": max_tokens,
+    }
+    if tools is not None:
+        req["tools"] = tools
+    req.update(kwargs)
+    stream = client.chat.completions.create(**req)
+    return collect_stream(stream)
+
+
+def parse_and_validate_tool_call(
+    tc: dict[str, Any],
+    schema_by_name: dict[str, dict[str, Any]],
+    *,
+    expected_name: str | None = None,
+) -> dict[str, Any]:
+    assert tc["type"] == "function", f"unexpected tool type: {tc['type']!r}"
+    assert tc["id"], "tool call id must be non-empty"
+    fn_name = tc["function"]["name"]
+    assert fn_name, "tool call function name must be non-empty"
+
+    if expected_name is not None:
+        assert fn_name == expected_name, f"expected {expected_name!r}, got {fn_name!r}"
+
+    assert fn_name in schema_by_name, f"unknown tool name {fn_name!r}"
+    args_str = tc["function"]["arguments"]
+    assert args_str, "tool call arguments must be non-empty"
+
+    try:
+        args = json.loads(args_str)
+    except json.JSONDecodeError as e:
+        raise AssertionError(f"arguments are not valid JSON: {args_str!r}") from e
+
+    assert isinstance(args, dict), f"arguments must decode to object, got {type(args)}"
+
+    validator = Draft7Validator(schema_by_name[fn_name])
+    errors = sorted(validator.iter_errors(args), key=lambda e: list(e.path))
+    if errors:
+        rendered = "; ".join(
+            f"path={list(err.path)} message={err.message}" for err in errors
+        )
+        raise AssertionError(f"arguments failed schema validation: {rendered}")
+
+    return args
+
+
+def assert_finish_reason(result: StreamResult, allowed: set[str]) -> None:
+    assert (
+        result.finish_reason in allowed
+    ), f"unexpected finish_reason={result.finish_reason!r}, allowed={sorted(allowed)}"
+
+
+def assistant_tool_message_from_result(result: StreamResult) -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": result.content or None,
+        "tool_calls": result.tool_calls,
+    }
+
+
+MAX_TOOL_TURNS = 6
+
+# These shell out deliberately. An in-process Python function would leave
+# "did anything outside the test actually run?" unanswered.
+_LOOKUP_CODE = (
+    "import os, sys; "
+    "print(os.environ['ACCESS_CODE'] if sys.argv[1].strip().lower() == 'alice' "
+    "else 'DENIED')"
+)
+_LOOKUP_ID = (
+    "import os, sys; "
+    "print(os.environ['USER_ID'] if sys.argv[1].strip().lower() == 'alice' "
+    "else 'UNKNOWN')"
+)
+_LOOKUP_QUOTA = (
+    "import os, sys; "
+    "print(os.environ['QUOTA'] if sys.argv[1].strip() == os.environ['USER_ID'] "
+    "else '-1')"
+)
+
+
+def run_tool_cli(script: str, arg: str, env_extra: dict[str, str]) -> str:
+    result = subprocess.run(
+        [sys.executable, "-c", script, arg],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, **env_extra},
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def run_tool_loop(
+    client: OpenAI,
+    model: str,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    dispatch: dict[str, Any],
+    max_turns: int = MAX_TOOL_TURNS,
+) -> tuple[str, list[dict[str, Any]]]:
+    """Drive a real tool-execution loop until the model answers with text.
+
+    Returns (final_text, calls), where `calls` records every tool the model
+    asked for and what that tool actually returned -- so a test can assert the
+    tool ran, not merely that the final answer looks right.
+    """
+    calls: list[dict[str, Any]] = []
+    convo = list(messages)
+    for _ in range(max_turns):
+        result = stream_chat(client, model, messages=convo, tools=tools)
+        if not result.tool_calls:
+            return (result.content or ""), calls
+
+        # Echo the assistant turn back, tool_calls included, or the model has
+        # no record of having asked.
+        convo.append(assistant_tool_message_from_result(result))
+        for tc in result.tool_calls:
+            name = tc["function"]["name"]
+            try:
+                args = json.loads(tc["function"]["arguments"] or "{}")
+            except json.JSONDecodeError as e:
+                raise AssertionError(
+                    f"model emitted unparseable arguments for {name}: "
+                    f"{tc['function']['arguments']!r}"
+                ) from e
+            assert name in dispatch, (
+                f"model called {name!r}, which was never offered. "
+                f"Offered: {sorted(dispatch)}"
+            )
+            output = dispatch[name](args)  # the tool really runs here
+            calls.append({"name": name, "args": args, "output": output})
+            convo.append(
+                {"role": "tool", "tool_call_id": tc["id"], "content": str(output)}
+            )
+
+    raise AssertionError(
+        f"model never produced a final text answer within {max_turns} turns; "
+        f"calls so far: {calls}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tool-execution scenarios
+# ---------------------------------------------------------------------------
+# These are plain functions rather than test methods so that any deployment
+# topology can drive them with its own (client, model) pair. Each raises
+# AssertionError with a diagnostic message on failure, so callers can wrap them
+# in flaky/xfail markers appropriate to their lane.
+
+
+def assert_executes_real_tool_and_uses_output(client: OpenAI, model: str) -> None:
+    """The answer must contain a secret only the executed tool could supply.
+
+    The secret is generated per call and never appears in any prompt, so the
+    assertion cannot be satisfied by hallucination, memorisation or luck.
+    """
+    secret = uuid.uuid4().hex[:12]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup_access_code",
+                "description": (
+                    "Look up the access code for a user. This is the only "
+                    "way to obtain an access code."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "user": {"type": "string", "description": "the username"}
+                    },
+                    "required": ["user"],
+                },
+            },
+        }
+    ]
+
+    def lookup_access_code(args: dict[str, Any]) -> str:
+        return run_tool_cli(
+            _LOOKUP_CODE, str(args.get("user", "")), {"ACCESS_CODE": secret}
+        )
+
+    text, calls = run_tool_loop(
+        client,
+        model,
+        [
+            {
+                "role": "user",
+                "content": (
+                    "Look up the access code for user alice, then tell me "
+                    "the code exactly as returned."
+                ),
+            }
+        ],
+        tools,
+        {"lookup_access_code": lookup_access_code},
+    )
+
+    assert calls, "the model never called the tool, so nothing was executed"
+    assert calls[0]["name"] == "lookup_access_code"
+    assert calls[0]["args"].get("user", "").strip().lower() == "alice", (
+        f"model passed an unusable argument: {calls[0]['args']!r} -- "
+        "schema-valid but wrong, which protocol-only tests cannot catch"
+    )
+    assert calls[0]["output"] == secret, (
+        f"tool returned {calls[0]['output']!r}, expected the generated "
+        "secret; the subprocess did not get the argument it should have"
+    )
+    assert secret in text, (
+        "final answer did not contain the executed tool's output.\n"
+        f"secret={secret!r}\nanswer={text[:400]!r}"
+    )
+
+
+def assert_chained_tools_thread_real_output(client: OpenAI, model: str) -> None:
+    """Two real executions, the second satisfiable only via the first.
+
+    ``get_quota`` returns -1 unless handed the exact id ``get_user_id``
+    produced, and both values are random per call. A correct final number
+    therefore proves the model threaded real output from one execution into the
+    next -- the capability that distinguishes models here.
+    """
+    user_id = f"U-{uuid.uuid4().hex[:8]}"
+    quota = str(uuid.uuid4().int % 9000 + 1000)  # 4 digits, unguessable
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_user_id",
+                "description": "Resolve a username to its internal user id.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "get_quota",
+                "description": (
+                    "Get the storage quota for an internal user id. "
+                    "Requires the id from get_user_id, not a username."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {"user_id": {"type": "string"}},
+                    "required": ["user_id"],
+                },
+            },
+        },
+    ]
+
+    dispatch = {
+        "get_user_id": lambda a: run_tool_cli(
+            _LOOKUP_ID, str(a.get("name", "")), {"USER_ID": user_id}
+        ),
+        "get_quota": lambda a: run_tool_cli(
+            _LOOKUP_QUOTA,
+            str(a.get("user_id", "")),
+            {"USER_ID": user_id, "QUOTA": quota},
+        ),
+    }
+
+    text, calls = run_tool_loop(
+        client,
+        model,
+        [
+            {
+                "role": "user",
+                "content": (
+                    "What is alice's storage quota? Look up her user id "
+                    "first, then use that id to get the quota. Report the "
+                    "number."
+                ),
+            }
+        ],
+        tools,
+        dispatch,
+    )
+
+    names = [c["name"] for c in calls]
+    assert "get_user_id" in names, f"never resolved the id; calls={names}"
+    assert "get_quota" in names, f"never fetched the quota; calls={names}"
+    assert names.index("get_user_id") < names.index(
+        "get_quota"
+    ), f"called get_quota before get_user_id: {names}"
+
+    quota_call = calls[names.index("get_quota")]
+    assert quota_call["args"].get("user_id") == user_id, (
+        f"second call used {quota_call['args'].get('user_id')!r} instead of "
+        f"the id the first call actually returned ({user_id!r})"
+    )
+    assert (
+        quota_call["output"] == quota
+    ), f"get_quota returned {quota_call['output']!r} -- it was handed the wrong id"
+    assert quota in text, (
+        "final answer omitted the quota the tool actually returned.\n"
+        f"quota={quota!r}\nanswer={text[:400]!r}"
+    )


### PR DESCRIPTION
## Summary

Stacked on #13979 (base: `dtokarev/tool-execution-e2e`) — review that first.

#13979 added end-to-end tool-execution tests but could only run them against locally spawned processes, because they lived inside the SGLang module and used its fixtures. Nothing about the scenarios is local: they need only an OpenAI-compatible client and a model name, and the tools they invoke run as subprocesses **in the pytest process**, not in the deployment. That is precisely what makes them portable.

This makes them so, and adds a Kubernetes lane where the **recipe and the cluster are both chosen at run time**:

```bash
KUBECONFIG=/path/to/kubeconfig python -m pytest \
  tests/deploy/test_recipe_tool_execution.py \
  --recipe recipes/<model>/<backend>/<profile>/deploy.yaml \
  --namespace dynamo -m "k8s and deploy" -v -s
```

No recipe is special-cased. Existing `--image` / `--namespace` options are reused.

## The blocker that actually mattered

I originally estimated this as mostly-plumbing. It wasn't. `DeploymentSpec` used `yaml.safe_load`, which raises `ComposerError` on any multi-document file — and most recipe manifests bundle the DGD with ConfigMaps/Services. **Over half the recipe corpus could not be loaded at all.**

| over `recipes/` | before | after |
|---|---:|---:|
| manifests containing a DGD | 148 | 148 |
| `DeploymentSpec` loads OK | 70 | **148** |
| declare a tool-call parser | 15 | **67** |

The parser count moves because the flag often lives in a document that was previously unreachable — no manifest changed. This fix is a separate first commit and stands on its own; happy to split it into its own PR if reviewers prefer.

## Two gates that keep results honest

- **Precondition** — the manifest must configure a tool-call parser. Without one the frontend cannot emit `tool_calls`, so a failure would say nothing about the model. Missing parser skips *before* deploying rather than burning a deployment on a confusing failure.
- **Capability** — chaining two tools is a property of the *model*, not the serving stack. It is recorded via `record_property`, not asserted, so pointing this at a weaker recipe reports the limitation instead of manufacturing a red build.

Model name comes from the manifest when it passes `--model` (74/148 manifests); otherwise it is read back off `/v1/models` on the running deployment, which is authoritative anyway.

## Validation

Single-node **k3s-in-Docker on an RTX 6000 Ada**, built without root on the host (no passwordless sudo available): NVIDIA device plugin, `dynamo-platform` chart (operator + etcd + NATS), nvidia set as containerd's default runtime so recipe manifests need no `runtimeClassName`.

| check | result |
|---|---|
| Qwen3-0.6B vLLM agg DGD → Ready | ~70 s |
| single-tool execution | **PASS** |
| chained-tool execution | NOT SUPPORTED (recorded) |
| GPU peak during run | **46,078 MiB** |
| independent repeat runs agreeing | 2 |
| unmodified `examples/backends/vllm/deploy/agg.yaml` | **skipped** via precondition gate, no deploy |

The GPU figure matters: it confirms requests were served by a GPU-backed worker in-cluster rather than a CPU fallback. I sampled it concurrently after an earlier post-teardown reading misled me into thinking nothing had run.

The chained scenario failed by passing `'alice'` instead of the id the first tool returned — the same hallucinated-placeholder signature measured for Qwen3-0.6B locally in #13979, reproduced independently through Kubernetes.

**No regression to the local suite**: `tests/frontend/test_tool_calling_sglang.py` still reports **24 passed, 2 xfailed in 94 s** on the GPU box, matching its pre-refactor result exactly.

## Notes for reviewers

- Operator image **1.4.1** was pinned locally because 1.5.0 is unpublished. It watches `podsnapshotcontents`, which main's chart RBAC does not grant, so the operator crashloops until that is added. That is chart/operator version drift in my local rig, not something this PR introduces — but worth confirming the released pairing is consistent.
- **No in-repo `examples/backends/**` DGD enables a tool-call parser**, so the positive path was validated against a variant of `agg.yaml` with `--dyn-tool-call-parser qwen25` added. Shipping such an example would give this lane something to run in CI; I did not add one here to keep the diff scoped.
- This lane is nightly/on-demand, not pre-merge: real recipes are multi-node H100/GB200 and take 10–40 min to reach ready.

Linear: OPS-8418

🤖 Generated with [Claude Code](https://claude.com/claude-code)
