### PR TITLE
fix(sglang): remove cumulative output slicing

### DIFF
--- a/components/src/dynamo/common/backend/logprobs.py
+++ b/components/src/dynamo/common/backend/logprobs.py
@@ -314,52 +314,42 @@ def build_sglang_logprob_kwargs(
 def extract_from_sglang_meta(
     meta_info: dict[str, Any],
     *,
-    num_output_tokens_in_chunk: Optional[int] = None,
     return_tokens_as_token_ids: bool = False,
 ) -> tuple[Optional[list[float]], Optional[list[list[dict[str, Any]]]]]:
     """Extract logprobs from SGLang's ``meta_info`` dict.
 
-    The pinned SGLang release and its N-1 predecessor align
-    ``output_token_logprobs`` and ``output_top_logprobs`` with each incremental
-    ``output_ids`` chunk. When provided, ``num_output_tokens_in_chunk`` keeps
-    malformed trailing metadata out of Dynamo's response.
+    Dynamo enables SGLang's incremental streaming output, so
+    ``output_token_logprobs`` and ``output_top_logprobs`` already align with
+    the current disjoint ``output_ids`` chunk and can be forwarded directly.
     """
     output_token_logprobs = meta_info.get("output_token_logprobs")
     if not output_token_logprobs:
         return None, None
 
-    new_logprobs = output_token_logprobs
-    if num_output_tokens_in_chunk is not None:
-        new_logprobs = new_logprobs[:num_output_tokens_in_chunk]
-    if not new_logprobs:
-        return None, None
-
-    log_probs = [float(entry[0]) for entry in new_logprobs]
+    log_probs = [float(entry[0]) for entry in output_token_logprobs]
 
     top_logprobs: Optional[list[list[dict[str, Any]]]] = None
     output_top = meta_info.get("output_top_logprobs")
     if output_top:
-        new_top = output_top[: len(new_logprobs)]
-        if new_top:
-            top_logprobs = []
-            for position_entries in new_top:
-                if position_entries is None:
-                    top_logprobs.append([])
-                    continue
-                position_list: list[dict[str, Any]] = []
-                for rank_idx, entry in enumerate(position_entries):
-                    tok_id = entry[1]
-                    token_str = (
-                        f"token_id:{tok_id}" if return_tokens_as_token_ids else entry[2]
-                    )
-                    position_list.append(
-                        {
-                            "rank": rank_idx + 1,
-                            "token_id": tok_id,
-                            "token": token_str,
-                            "logprob": float(entry[0]),
-                        }
-                    )
-                top_logprobs.append(position_list)
+        top_logprobs = []
+        for position_entries in output_top:
+            if position_entries is None:
+                top_logprobs.append([])
+                continue
+            position_list: list[dict[str, Any]] = []
+            for rank_idx, entry in enumerate(position_entries):
+                tok_id = entry[1]
+                token_str = (
+                    f"token_id:{tok_id}" if return_tokens_as_token_ids else entry[2]
+                )
+                position_list.append(
+                    {
+                        "rank": rank_idx + 1,
+                        "token_id": tok_id,
+                        "token": token_str,
+                        "logprob": float(entry[0]),
+                    }
+                )
+            top_logprobs.append(position_list)
 
     return log_probs, top_logprobs

--- a/components/src/dynamo/common/backend/tests/test_logprobs.py
+++ b/components/src/dynamo/common/backend/tests/test_logprobs.py
@@ -405,9 +405,7 @@ def test_sglang_extract_supports_incremental_streaming_metadata():
         "output_token_logprobs": [(-0.2, 2, "b")],
         "output_top_logprobs": [[(-0.2, 2, "b"), (-1.2, 20, "B")]],
     }
-    log_probs, top_logprobs = extract_from_sglang_meta(
-        meta, num_output_tokens_in_chunk=1
-    )
+    log_probs, top_logprobs = extract_from_sglang_meta(meta)
     assert log_probs == [-0.2]
     assert top_logprobs == [
         [
@@ -454,14 +452,6 @@ def test_sglang_extract_none_top_position_becomes_empty_list():
         [],
         [{"rank": 1, "token_id": 102, "token": "b", "logprob": -0.2}],
     ]
-
-
-def test_sglang_extract_clamps_metadata_to_output_chunk():
-    meta = {
-        "output_token_logprobs": [(-0.1, 1, "a"), (-0.2, 2, "b")],
-    }
-    log_probs, _ = extract_from_sglang_meta(meta, num_output_tokens_in_chunk=1)
-    assert log_probs == [-0.1]
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -472,12 +472,11 @@ class DecodeWorkerHandler(BaseWorkerHandler):
     @staticmethod
     def _extract_logprobs(
         meta_info: Dict[str, Any],
-        num_output_tokens_in_chunk: Optional[int] = None,
+        *,
         return_tokens_as_token_ids: bool = False,
     ) -> tuple:
         return _shared_logprobs.extract_from_sglang_meta(
             meta_info,
-            num_output_tokens_in_chunk=num_output_tokens_in_chunk,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
         )
 
@@ -814,7 +813,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     # Extract logprobs for new tokens if available.
                     log_probs, top_logprobs = self._extract_logprobs(
                         meta_info,
-                        num_output_tokens_in_chunk=len(raw_output_ids),
                         return_tokens_as_token_ids=return_tokens_as_token_ids,
                     )
 
@@ -940,10 +938,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         """
         request = request or {}
         stop_strings = _stop_strings(request)
-        # SGLang text chunks are cumulative per choice. Keep independent text
-        # offsets so interleaved n>1 choices do not compute deltas from each
-        # other's previous text.
-        text_counts_per_choice: dict[int, int] = {}
+        # SGLang text is already incremental. Buffer only a possible stop-string
+        # prefix so a marker split across chunks is not exposed to the caller.
+        pending_text_per_choice: dict[int, str] = {}
 
         # Use Future pattern for request ID - will be set when first response arrives
         request_id_future: asyncio.Future[str] = asyncio.Future()
@@ -966,7 +963,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 # Same defaulting as token mode: non-n chunks are choice 0.
                 index = res.get("index") or 0
 
-                text = res.get("text", "")
+                text = pending_text_per_choice.pop(index, "") + res.get("text", "")
 
                 finish_reason = meta_info["finish_reason"]
                 finish_reason_type = (
@@ -974,20 +971,25 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     if finish_reason
                     else None
                 )
-                next_count = len(text)
-                count = text_counts_per_choice.get(index, 0)
-                visible_text_len = next_count
                 matched = finish_reason.get("matched") if finish_reason else None
-                if (
-                    isinstance(matched, str)
-                    and matched in stop_strings
-                    and text.endswith(matched)
-                ):
-                    visible_text_len = len(text) - len(matched)
+                if isinstance(matched, str) and matched in stop_strings:
+                    if text.endswith(matched):
+                        delta = text[: -len(matched)]
+                    elif matched.startswith(text):
+                        # SGLang can trim the rest of a matched stop string from
+                        # its final delta. Drop the prefix buffered previously.
+                        delta = ""
+                    else:
+                        delta = text
                 elif not finish_reason:
-                    visible_text_len -= trailing_stop_prefix_len(text, stop_strings)
-
-                delta = text[count:visible_text_len] if visible_text_len > count else ""
+                    pending_len = trailing_stop_prefix_len(text, stop_strings)
+                    if pending_len:
+                        pending_text_per_choice[index] = text[-pending_len:]
+                        delta = text[:-pending_len]
+                    else:
+                        delta = text
+                else:
+                    delta = text
                 if res.get("output_ids") and not first_output_seen:
                     first_output_seen = True
                     context.notify_first_token()
@@ -1028,4 +1030,3 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     response["nvext"] = response_nvext
                 if not context.is_stopped():
                     yield response
-                text_counts_per_choice[index] = visible_text_len

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -924,10 +924,10 @@ def test_build_logprob_kwargs_allows_top_logprobs_with_escape_hatch(monkeypatch)
     monkeypatch.setenv("DYN_SGL_ALLOW_TOP_LOGPROBS", "1")
 
     kwargs = DecodeWorkerHandler._build_logprob_kwargs(
-        {"output_options": {"logprobs": 2}}
+        {"output_options": {"logprobs": 5}}
     )
 
-    assert kwargs == {"return_logprob": True, "top_logprobs_num": 2}
+    assert kwargs == {"return_logprob": True, "top_logprobs_num": 5}
 
 
 def test_extract_logprobs_formats_top_tokens_as_token_ids():
@@ -936,7 +936,6 @@ def test_extract_logprobs_formats_top_tokens_as_token_ids():
             "output_token_logprobs": [(-0.1, 101, "a")],
             "output_top_logprobs": [[(-0.1, 101, "a"), (-0.2, 102, "b")]],
         },
-        1,
         return_tokens_as_token_ids=True,
     )
 
@@ -1170,6 +1169,15 @@ async def test_process_token_stream_accepts_incremental_logprob_arrays():
                             "id": "request-1",
                             "finish_reason": None,
                             "output_token_logprobs": [(-0.1, 101, "")],
+                            "output_top_logprobs": [
+                                [
+                                    (-0.1, 101, "a"),
+                                    (-0.2, 201, "b"),
+                                    (-0.3, 202, "c"),
+                                    (-0.4, 203, "d"),
+                                    (-0.5, 204, "e"),
+                                ]
+                            ],
                         },
                         "engine_data": {"native_chunk": 1},
                     },
@@ -1181,6 +1189,15 @@ async def test_process_token_stream_accepts_incremental_logprob_arrays():
                             "id": "request-1",
                             "finish_reason": None,
                             "output_token_logprobs": [(-0.3, 102, "")],
+                            "output_top_logprobs": [
+                                [
+                                    (-0.3, 102, "c"),
+                                    (-0.4, 301, "d"),
+                                    (-0.5, 302, "e"),
+                                    (-0.6, 303, "f"),
+                                    (-0.7, 304, "g"),
+                                ]
+                            ],
                         },
                         "engine_data": {"native_chunk": 2},
                     },
@@ -1192,6 +1209,12 @@ async def test_process_token_stream_accepts_incremental_logprob_arrays():
 
     assert [chunk["token_ids"] for chunk in chunks] == [[101], [102]]
     assert [chunk["log_probs"] for chunk in chunks] == [[-0.1], [-0.3]]
+    assert [
+        [len(position) for position in chunk["top_logprobs"]] for chunk in chunks
+    ] == [
+        [5],
+        [5],
+    ]
     assert all("text" not in chunk for chunk in chunks)
     assert all("tokens" not in chunk for chunk in chunks)
     assert [chunk["engine_data"]["native_chunk"] for chunk in chunks] == [1, 2]
@@ -1364,7 +1387,7 @@ async def test_process_token_stream_upload_failure_blocks_final_chunk(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_process_text_stream_tracks_delta_per_choice_index():
+async def test_process_text_stream_forwards_incremental_text_per_choice():
     handler = _new_decode_handler()
 
     chunks = await _collect(
@@ -1383,12 +1406,12 @@ async def test_process_text_stream_tracks_delta_per_choice_index():
                     },
                     {
                         "index": 0,
-                        "text": "Hello",
+                        "text": "llo",
                         "meta_info": {"id": "request-1", "finish_reason": None},
                     },
                     {
                         "index": 1,
-                        "text": "Good",
+                        "text": "od",
                         "meta_info": {"id": "request-1", "finish_reason": None},
                     },
                 ]
@@ -1480,7 +1503,7 @@ async def test_process_text_stream_buffers_split_stop_string_suffix():
                     },
                     {
                         "index": 0,
-                        "text": "Hello<|user|>",
+                        "text": "er|>",
                         "meta_info": {
                             "id": "request-1",
                             "finish_reason": {
@@ -1518,7 +1541,7 @@ async def test_process_text_stream_removes_matched_stop_string_suffix():
                     },
                     {
                         "index": 0,
-                        "text": "Hello<|user|>",
+                        "text": "<|user|>",
                         "meta_info": {
                             "id": "request-1",
                             "finish_reason": {
@@ -1539,6 +1562,43 @@ async def test_process_text_stream_removes_matched_stop_string_suffix():
         "",
     ]
     assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+@pytest.mark.asyncio
+async def test_process_text_stream_drops_buffered_prefix_when_sglang_trims_stop():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_text_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "text": "Hello<|us",
+                        "meta_info": {"id": "request-1", "finish_reason": None},
+                    },
+                    {
+                        "index": 0,
+                        "text": "",
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {
+                                "type": "stop",
+                                "matched": "<|user|>",
+                            },
+                        },
+                    },
+                ]
+            ),
+            _Context(),
+            request={"stop": ["<|user|>"]},
+        )
+    )
+
+    assert [chunk["choices"][0]["delta"]["content"] for chunk in chunks] == [
+        "Hello",
+        "",
+    ]
 
 
 @pytest.mark.asyncio

--- a/lib/bindings/python/examples/hello_world/server_sglang.py
+++ b/lib/bindings/python/examples/hello_world/server_sglang.py
@@ -61,7 +61,6 @@ class RequestHandler:
             # sglang defaults this to 128
             "max_new_tokens": request["stop_conditions"]["max_tokens"],
         }
-        num_output_tokens_so_far = 0
         gen = await self.engine_client.async_generate(
             input_ids=request["token_ids"], sampling_params=sampling_params, stream=True
         )
@@ -73,10 +72,8 @@ class RequestHandler:
                 # Don't forward the stop token
                 out = {"token_ids": [], "finish_reason": finish_reason["type"]}
             else:
-                next_total_toks = len(res["output_ids"])
-                out = {"token_ids": res["output_ids"][num_output_tokens_so_far:]}
+                out = {"token_ids": res["output_ids"]}
             yield out
-            num_output_tokens_so_far = next_total_toks
 
 
 @dynamo_worker()
@@ -102,6 +99,7 @@ async def init(runtime: DistributedRuntime, config: Config):
     engine_args = ServerArgs(
         model_path=config.model,
         skip_tokenizer_init=True,
+        incremental_streaming_output=True,
     )
 
     engine_client = sglang.Engine(server_args=engine_args)


### PR DESCRIPTION
## Summary

- Remove SGLang cumulative-output compatibility from logprob and text streaming paths.
- Forward incremental `output_token_logprobs`, `output_top_logprobs`, text, and token IDs directly; retain only stop-marker prefix buffering/trimming.
- Enable incremental streaming in the Python SGLang hello-world worker and remove its output-ID cursor.
- Keep compact regression coverage for disjoint logprob chunks with five top-logprob alternatives per position.
- Supersede the cumulative/incremental dual-shape approach proposed in #13879.

Dynamo forces `incremental_streaming_output=True` before SGLang resolves `ServerArgs`. SGLang 0.5.16 and 0.5.17 therefore return disjoint text, output IDs, and output-side logprob arrays. Applying any Dynamo cursor or cumulative slice loses data.

## Where should the reviewer start?

Start with `components/src/dynamo/common/backend/logprobs.py` and `components/src/dynamo/sglang/request_handlers/llm/decode_handler.py`. They contain the removed logprob and text cursors. The tests show the incremental contract and retained stop-prefix buffering.

## Validation

- Real v1beta1 DynamoGraphDeployment on B200 with the exact affected `20260805-addcbae` image and SGLang 0.5.16:
  - Qwen3.5-397B-A17B code path, TP4 dummy weights, `stream_interval=30`, 120 generated tokens, `top_logprobs=5`.
  - Raw SGLang chunk lengths: `[1, 30, 30, 30, 29]`; 120 selected-logprob positions and five alternatives at every position.
  - A cumulative cursor reproduced the user-visible `[1, 29, 0, 0, 0]` loss; direct incremental forwarding preserved all 120 positions.
- Repository-pinned pre-commit hooks on all changed files: isort, Black, Flake8, Ruff, end-of-file, and trailing-whitespace.
- `python3 -m py_compile` on all changed Python files.
- `git diff --check`.
- Added focused unit regressions; full pytest execution is delegated to PR CI because this source-only workspace does not include Dynamo/SGLang runtime dependencies.

## Related issues

- Linear IHOC-72 (internal)
- Supersedes #13879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming text handling to prevent partial or truncated stop strings from appearing in responses.
  * Preserved complete logprob and top-candidate data across streaming intervals.
  * Improved incremental output handling for SGLang-powered streaming responses.

* **Tests**
  * Added coverage for stop-string buffering and full top-logprob preservation during streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
