### PR TITLE
fix(kv-router): bound the state-agent host discovery wait at worker startup

### DIFF
--- a/lib/llm/src/kv_router/publisher/attachment_owner.rs
+++ b/lib/llm/src/kv_router/publisher/attachment_owner.rs
@@ -5,6 +5,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    ffi::OsString,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -25,6 +26,7 @@ use dynamo_runtime::{
     protocols::EndpointId,
     traits::DistributedRuntimeProvider,
 };
+use futures::StreamExt;
 use rand::TryRngCore;
 use tokio::{
     sync::{Mutex, oneshot},
@@ -38,6 +40,8 @@ use crate::discovery::kv_state_agent::{
 };
 
 const HOST_COMPONENT: &str = "kv_state_agent";
+const HOST_DISCOVERY_TIMEOUT_ENV: &str = "DYN_KV_STATE_AGENT_HOST_DISCOVERY_TIMEOUT_SECS";
+const DEFAULT_HOST_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 const JSON_SAFE_MASK: u64 = (1u64 << 53) - 1;
 
 #[derive(Debug, Clone)]
@@ -183,17 +187,113 @@ fn validate_descriptors(descriptors: &[KvStateAttachmentDescriptor]) -> Result<(
 async fn discover_single_host(
     component: &dynamo_runtime::component::Component,
 ) -> Result<KvStateHostAdvertisement> {
-    // NOTE: V2 assumes one host is already running and remains alive for this
-    // deployment run. TODO(#13044): watch and retry host selection when rolling
-    // host replacement and Kubernetes lifecycle are supported.
-    let instances = component
-        .drt()
-        .discovery()
-        .list(DiscoveryQuery::EventSources(EventSourceQuery::topic(
-            component.namespace().name(),
-            HOST_COMPONENT,
-            KV_STATE_HOST_TOPIC_V2,
-        )))
+    let namespace = component.namespace().name();
+    let discovery = component.drt().discovery();
+    await_single_host(
+        discovery.as_ref(),
+        &namespace,
+        host_discovery_timeout(|key| std::env::var_os(key)),
+    )
+    .await
+}
+
+fn host_discovery_timeout(mut get_env: impl FnMut(&str) -> Option<OsString>) -> Duration {
+    match get_env(HOST_DISCOVERY_TIMEOUT_ENV) {
+        None => DEFAULT_HOST_DISCOVERY_TIMEOUT,
+        Some(raw) => match raw.to_string_lossy().trim().parse::<u64>() {
+            Ok(secs) => Duration::from_secs(secs),
+            Err(_) => {
+                tracing::warn!(
+                    env = HOST_DISCOVERY_TIMEOUT_ENV,
+                    value = %raw.to_string_lossy(),
+                    default_secs = DEFAULT_HOST_DISCOVERY_TIMEOUT.as_secs(),
+                    "invalid state-agent host discovery timeout; using default"
+                );
+                DEFAULT_HOST_DISCOVERY_TIMEOUT
+            }
+        },
+    }
+}
+
+/// Wait up to `timeout` for exactly one live V2 state-agent host.
+///
+/// The `list` snapshot stays authoritative: two or more hosts fail closed
+/// immediately (misconfiguration, not a race), and the watch stream is only a
+/// wake-up to re-list while no host is advertised yet — a watch event is
+/// never trusted directly because initial-snapshot events are
+/// indistinguishable from later additions. A zero timeout preserves the
+/// original single-snapshot behavior.
+async fn await_single_host(
+    discovery: &dyn Discovery,
+    namespace: &str,
+    timeout: Duration,
+) -> Result<KvStateHostAdvertisement> {
+    // NOTE: V2 assumes one host per control scope that remains alive for the
+    // deployment run. This wait covers only start ordering: source mode is
+    // immutable for a worker lifecycle, so a worker that races the host's
+    // advertisement would otherwise serve without KV routing until it
+    // restarts. TODO(#13044): watch and reselect the host after startup when
+    // rolling host replacement and Kubernetes lifecycle are supported.
+    if let Some(host) = list_single_host(discovery, namespace).await? {
+        return Ok(host);
+    }
+    if timeout.is_zero() {
+        return Err(exactly_one_host_error(0));
+    }
+    tracing::info!(
+        namespace,
+        timeout_secs = timeout.as_secs(),
+        "KV state-agent host is not advertised yet; waiting"
+    );
+    let watch_cancel = CancellationToken::new();
+    // Cancelled on every exit path; without this the discovery watch task
+    // outlives the wait for the rest of the process.
+    let _watch_guard = watch_cancel.clone().drop_guard();
+    let expiry = tokio::time::Instant::now() + timeout;
+    // The bound covers the whole wait: watch setup and every re-list, not
+    // just the idle gaps between events.
+    let wait = async {
+        let mut events = discovery
+            .list_and_watch(host_query(namespace), Some(watch_cancel))
+            .await
+            .context("failed to watch for the KV state-agent host")?;
+        while let Some(event) = events.next().await {
+            event.context("KV state-agent host discovery watch failed")?;
+            if let Some(host) = list_single_host(discovery, namespace).await? {
+                return Ok(host);
+            }
+        }
+        anyhow::bail!("KV state-agent host discovery watch ended before a host appeared")
+    };
+    match tokio::time::timeout_at(expiry, wait).await {
+        Ok(result) => result,
+        Err(_elapsed) => anyhow::bail!(
+            "no live V2 KV state-agent host appeared within {}s \
+             (topic {KV_STATE_HOST_TOPIC_V2} on {namespace}/{HOST_COMPONENT}; \
+             set {HOST_DISCOVERY_TIMEOUT_ENV} to adjust the startup wait)",
+            timeout.as_secs()
+        ),
+    }
+}
+
+fn exactly_one_host_error(found: usize) -> anyhow::Error {
+    anyhow::anyhow!("state-agent mode requires exactly one live V2 host, found {found}")
+}
+
+fn host_query(namespace: &str) -> DiscoveryQuery {
+    DiscoveryQuery::EventSources(EventSourceQuery::topic(
+        namespace,
+        HOST_COMPONENT,
+        KV_STATE_HOST_TOPIC_V2,
+    ))
+}
+
+async fn list_single_host(
+    discovery: &dyn Discovery,
+    namespace: &str,
+) -> Result<Option<KvStateHostAdvertisement>> {
+    let instances = discovery
+        .list(host_query(namespace))
         .await
         .context("failed to discover KV state-agent host")?;
     let mut hosts = Vec::new();
@@ -220,13 +320,10 @@ async fn discover_single_host(
             hosts.push(host);
         }
     }
-    let [host] = hosts.as_slice() else {
-        anyhow::bail!(
-            "state-agent mode requires exactly one live V2 host, found {}",
-            hosts.len()
-        );
-    };
-    Ok(host.clone())
+    if hosts.len() > 1 {
+        return Err(exactly_one_host_error(hosts.len()));
+    }
+    Ok(hosts.pop())
 }
 
 async fn producer_instance(endpoint: &Endpoint) -> Result<Instance> {
@@ -585,5 +682,117 @@ mod tests {
 
         assert!(registrations.lock().await.is_empty());
         assert!(discovery.list(intent_query()).await.unwrap().is_empty());
+    }
+
+    fn mock_discovery() -> Arc<dyn Discovery> {
+        Arc::new(MockDiscovery::new(Some(1), SharedMockRegistry::new()))
+    }
+
+    async fn register_host(
+        discovery: &dyn Discovery,
+        publisher_id: u64,
+        advertisement: &KvStateHostAdvertisement,
+    ) {
+        discovery
+            .register(DiscoverySpec::EventSource {
+                scope: EventScope::Component {
+                    namespace: "ns".to_string(),
+                    component: HOST_COMPONENT.to_string(),
+                },
+                topic: KV_STATE_HOST_TOPIC_V2.to_string(),
+                publisher_id,
+                metadata: serde_json::to_value(advertisement).unwrap(),
+            })
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn host_discovery_timeout_parses_and_defaults() {
+        assert_eq!(
+            host_discovery_timeout(|_| None),
+            DEFAULT_HOST_DISCOVERY_TIMEOUT
+        );
+        assert_eq!(
+            host_discovery_timeout(|_| Some(OsString::from("5"))),
+            Duration::from_secs(5)
+        );
+        assert_eq!(
+            host_discovery_timeout(|_| Some(OsString::from(" 0 "))),
+            Duration::ZERO
+        );
+        assert_eq!(
+            host_discovery_timeout(|_| Some(OsString::from("not-a-number"))),
+            DEFAULT_HOST_DISCOVERY_TIMEOUT
+        );
+    }
+
+    #[tokio::test]
+    async fn advertised_host_is_returned_without_waiting() {
+        let discovery = mock_discovery();
+        register_host(discovery.as_ref(), 41, &host()).await;
+        let found = await_single_host(discovery.as_ref(), "ns", Duration::ZERO)
+            .await
+            .unwrap();
+        assert_eq!(found.host_instance, host().host_instance);
+    }
+
+    #[tokio::test]
+    async fn host_advertised_during_the_wait_is_discovered() {
+        let discovery = mock_discovery();
+        let register = discovery.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            register_host(register.as_ref(), 41, &host()).await;
+        });
+        let found = await_single_host(discovery.as_ref(), "ns", Duration::from_secs(5))
+            .await
+            .unwrap();
+        assert_eq!(found.host_instance, host().host_instance);
+    }
+
+    #[tokio::test]
+    async fn missing_host_fails_with_a_diagnosable_error_after_the_deadline() {
+        let discovery = mock_discovery();
+        let error = await_single_host(discovery.as_ref(), "ns", Duration::from_millis(200))
+            .await
+            .unwrap_err();
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("no live V2 KV state-agent host appeared"),
+            "{message}"
+        );
+        assert!(message.contains(HOST_DISCOVERY_TIMEOUT_ENV), "{message}");
+    }
+
+    #[tokio::test]
+    async fn zero_timeout_preserves_the_single_snapshot_failure() {
+        let discovery = mock_discovery();
+        let error = await_single_host(discovery.as_ref(), "ns", Duration::ZERO)
+            .await
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("exactly one live V2 host, found 0"));
+    }
+
+    #[tokio::test]
+    async fn two_advertised_hosts_fail_closed_before_the_deadline() {
+        let discovery = mock_discovery();
+        register_host(discovery.as_ref(), 41, &host()).await;
+        let second_instance = instance("kv_state_agent", 2);
+        let second = KvStateHostAdvertisement {
+            protocol_version: KvStateProtocolVersion::V2,
+            host_instance: second_instance.clone(),
+            control_target: second_instance,
+            max_slots: 8,
+        };
+        // Distinct publisher ids: a same-id re-register resolves to the
+        // existing instance and would silently collapse this into one host.
+        register_host(discovery.as_ref(), 42, &second).await;
+        let started = tokio::time::Instant::now();
+        let error = await_single_host(discovery.as_ref(), "ns", Duration::from_secs(30))
+            .await
+            .unwrap_err();
+        assert!(started.elapsed() < Duration::from_secs(5));
+        assert!(format!("{error:#}").contains("exactly one live V2 host, found 2"));
     }
 }

--- a/lib/llm/src/kv_router/publisher/attachment_owner.rs
+++ b/lib/llm/src/kv_router/publisher/attachment_owner.rs
@@ -692,10 +692,12 @@ mod tests {
         assert!(discovery.list(intent_query()).await.unwrap().is_empty());
     }
 
+    /// A fresh in-memory discovery backend with nothing advertised.
     fn mock_discovery() -> Arc<dyn Discovery> {
         Arc::new(MockDiscovery::new(Some(1), SharedMockRegistry::new()))
     }
 
+    /// Advertise a host on the V2 topic the way `state_agent_host` would.
     async fn register_host(
         discovery: &dyn Discovery,
         publisher_id: u64,
@@ -745,6 +747,7 @@ mod tests {
         assert_eq!(found.host_instance, host().host_instance);
     }
 
+    /// A late advertisement must wake the watch and be found by the re-list.
     #[tokio::test]
     async fn host_advertised_during_the_wait_is_discovered() {
         let discovery = mock_discovery();
@@ -784,6 +787,7 @@ mod tests {
         assert!(format!("{error:#}").contains("exactly one live V2 host, found 0"));
     }
 
+    /// Ambiguity is misconfiguration: two hosts must bail without waiting.
     #[tokio::test]
     async fn two_advertised_hosts_fail_closed_before_the_deadline() {
         let discovery = mock_discovery();

--- a/lib/llm/src/kv_router/publisher/attachment_owner.rs
+++ b/lib/llm/src/kv_router/publisher/attachment_owner.rs
@@ -20,6 +20,7 @@ use dynamo_kv_router::{
 };
 use dynamo_runtime::{
     component::{Endpoint, Instance, build_transport_type},
+    config::environment_names::llm::DYN_KV_STATE_AGENT_HOST_DISCOVERY_TIMEOUT_SECS as HOST_DISCOVERY_TIMEOUT_ENV,
     discovery::{
         Discovery, DiscoveryInstance, DiscoveryQuery, DiscoverySpec, EventScope, EventSourceQuery,
     },
@@ -40,7 +41,6 @@ use crate::discovery::kv_state_agent::{
 };
 
 const HOST_COMPONENT: &str = "kv_state_agent";
-const HOST_DISCOVERY_TIMEOUT_ENV: &str = "DYN_KV_STATE_AGENT_HOST_DISCOVERY_TIMEOUT_SECS";
 const DEFAULT_HOST_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 const JSON_SAFE_MASK: u64 = (1u64 << 53) - 1;
 
@@ -190,10 +190,12 @@ async fn discover_single_host(
 ) -> Result<KvStateHostAdvertisement> {
     let namespace = component.namespace().name();
     let discovery = component.drt().discovery();
+    let shutdown = component.drt().primary_token();
     await_single_host(
         discovery.as_ref(),
         &namespace,
         host_discovery_timeout(|key| std::env::var_os(key)),
+        &shutdown,
     )
     .await
 }
@@ -224,11 +226,12 @@ fn host_discovery_timeout(mut get_env: impl FnMut(&str) -> Option<OsString>) -> 
 /// wake-up to re-list while no host is advertised yet — a watch event is
 /// never trusted directly because initial-snapshot events are
 /// indistinguishable from later additions. A zero timeout preserves the
-/// original single-snapshot behavior.
+/// original single-snapshot behavior; cancelling `shutdown` aborts the wait.
 async fn await_single_host(
     discovery: &dyn Discovery,
     namespace: &str,
     timeout: Duration,
+    shutdown: &CancellationToken,
 ) -> Result<KvStateHostAdvertisement> {
     // NOTE: V2 assumes one host per control scope that remains alive for the
     // deployment run. This wait covers only start ordering: source mode is
@@ -236,30 +239,30 @@ async fn await_single_host(
     // advertisement would otherwise serve without KV routing until it
     // restarts. TODO(#13044): watch and reselect the host after startup when
     // rolling host replacement and Kubernetes lifecycle are supported.
-    if let Some(host) = list_single_host(discovery, namespace).await? {
-        return Ok(host);
-    }
     if timeout.is_zero() {
-        return Err(exactly_one_host_error(0));
+        return match list_single_host(discovery, namespace).await? {
+            Some(host) => Ok(host),
+            None => Err(exactly_one_host_error(0)),
+        };
     }
-    tracing::info!(
-        namespace,
-        timeout_secs = timeout.as_secs(),
-        "KV state-agent host is not advertised yet; waiting"
-    );
-    let watch_cancel = CancellationToken::new();
+    // The deadline is fixed before any backend I/O: the initial list, watch
+    // setup, and every re-list all run under it.
+    let expiry = host_discovery_expiry(timeout);
+    let watch_cancel = shutdown.child_token();
     // Cancelled on every exit path; without this the discovery watch task
     // outlives the wait for the rest of the process.
     let _watch_guard = watch_cancel.clone().drop_guard();
-    // A timeout too large for the clock is effectively unbounded, not a panic.
-    let expiry = tokio::time::Instant::now()
-        .checked_add(timeout)
-        .unwrap_or_else(|| tokio::time::Instant::now() + Duration::from_secs(u32::MAX.into()));
-    // The bound covers the whole wait: watch setup and every re-list, not
-    // just the idle gaps between events.
     let wait = async {
+        if let Some(host) = list_single_host(discovery, namespace).await? {
+            return Ok(host);
+        }
+        tracing::info!(
+            namespace,
+            timeout_secs = timeout.as_secs(),
+            "KV state-agent host is not advertised yet; waiting"
+        );
         let mut events = discovery
-            .list_and_watch(host_query(namespace), Some(watch_cancel))
+            .list_and_watch(host_query(namespace), Some(watch_cancel.clone()))
             .await
             .context("failed to watch for the KV state-agent host")?;
         while let Some(event) = events.next().await {
@@ -270,15 +273,29 @@ async fn await_single_host(
         }
         anyhow::bail!("KV state-agent host discovery watch ended before a host appeared")
     };
-    match tokio::time::timeout_at(expiry, wait).await {
-        Ok(result) => result,
-        Err(_elapsed) => anyhow::bail!(
-            "no live V2 KV state-agent host appeared within {}s \
-             (topic {KV_STATE_HOST_TOPIC_V2} on {namespace}/{HOST_COMPONENT}; \
-             set {HOST_DISCOVERY_TIMEOUT_ENV} to adjust the startup wait)",
-            timeout.as_secs()
-        ),
+    tokio::select! {
+        biased;
+        _ = watch_cancel.cancelled() => {
+            anyhow::bail!("runtime shutdown before the KV state-agent host appeared")
+        }
+        result = tokio::time::timeout_at(expiry, wait) => match result {
+            Ok(result) => result,
+            Err(_elapsed) => anyhow::bail!(
+                "no live V2 KV state-agent host appeared within {}s \
+                 (topic {KV_STATE_HOST_TOPIC_V2} on {namespace}/{HOST_COMPONENT}; \
+                 set {HOST_DISCOVERY_TIMEOUT_ENV} to adjust the startup wait)",
+                timeout.as_secs()
+            ),
+        },
     }
+}
+
+/// Absolute deadline for the wait; a span too large for the clock is
+/// effectively unbounded, not a panic.
+fn host_discovery_expiry(timeout: Duration) -> tokio::time::Instant {
+    let now = tokio::time::Instant::now();
+    now.checked_add(timeout)
+        .unwrap_or_else(|| now + Duration::from_secs(u32::MAX.into()))
 }
 
 /// Shared so the zero-timeout path stays byte-identical to the legacy error message.
@@ -741,9 +758,14 @@ mod tests {
     async fn advertised_host_is_returned_without_waiting() {
         let discovery = mock_discovery();
         register_host(discovery.as_ref(), 41, &host()).await;
-        let found = await_single_host(discovery.as_ref(), "ns", Duration::ZERO)
-            .await
-            .unwrap();
+        let found = await_single_host(
+            discovery.as_ref(),
+            "ns",
+            Duration::ZERO,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
         assert_eq!(found.host_instance, host().host_instance);
     }
 
@@ -752,24 +774,67 @@ mod tests {
     async fn host_advertised_during_the_wait_is_discovered() {
         let discovery = mock_discovery();
         let register = discovery.clone();
-        tokio::spawn(async move {
+        let registration = tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(50)).await;
             register_host(register.as_ref(), 41, &host()).await;
         });
-        // u64::MAX also proves an expiry too large for the clock waits
-        // instead of panicking.
-        let found = await_single_host(discovery.as_ref(), "ns", Duration::from_secs(u64::MAX))
-            .await
-            .unwrap();
+        // The outer timeout bounds the test if registration fails or the
+        // watch never wakes.
+        let found = tokio::time::timeout(
+            Duration::from_secs(10),
+            await_single_host(
+                discovery.as_ref(),
+                "ns",
+                Duration::from_secs(30),
+                &CancellationToken::new(),
+            ),
+        )
+        .await
+        .expect("discovery must resolve well before the outer deadline")
+        .unwrap();
+        registration.await.unwrap();
         assert_eq!(found.host_instance, host().host_instance);
+    }
+
+    #[tokio::test]
+    async fn oversized_timeout_expiry_saturates_instead_of_panicking() {
+        let expiry = host_discovery_expiry(Duration::from_secs(u64::MAX));
+        assert!(expiry > tokio::time::Instant::now());
+    }
+
+    /// Runtime shutdown must unblock the wait instead of running out the timeout.
+    #[tokio::test]
+    async fn shutdown_cancels_the_wait_before_the_timeout() {
+        let discovery = mock_discovery();
+        let shutdown = CancellationToken::new();
+        let cancel = shutdown.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            cancel.cancel();
+        });
+        let started = tokio::time::Instant::now();
+        let error = tokio::time::timeout(
+            Duration::from_secs(10),
+            await_single_host(discovery.as_ref(), "ns", Duration::from_secs(30), &shutdown),
+        )
+        .await
+        .expect("cancellation must resolve the wait")
+        .unwrap_err();
+        assert!(started.elapsed() < Duration::from_secs(5));
+        assert!(format!("{error:#}").contains("shutdown"), "{error:#}");
     }
 
     #[tokio::test]
     async fn missing_host_fails_with_a_diagnosable_error_after_the_deadline() {
         let discovery = mock_discovery();
-        let error = await_single_host(discovery.as_ref(), "ns", Duration::from_millis(200))
-            .await
-            .unwrap_err();
+        let error = await_single_host(
+            discovery.as_ref(),
+            "ns",
+            Duration::from_millis(200),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap_err();
         let message = format!("{error:#}");
         assert!(
             message.contains("no live V2 KV state-agent host appeared"),
@@ -781,9 +846,14 @@ mod tests {
     #[tokio::test]
     async fn zero_timeout_preserves_the_single_snapshot_failure() {
         let discovery = mock_discovery();
-        let error = await_single_host(discovery.as_ref(), "ns", Duration::ZERO)
-            .await
-            .unwrap_err();
+        let error = await_single_host(
+            discovery.as_ref(),
+            "ns",
+            Duration::ZERO,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap_err();
         assert!(format!("{error:#}").contains("exactly one live V2 host, found 0"));
     }
 
@@ -803,9 +873,14 @@ mod tests {
         // existing instance and would silently collapse this into one host.
         register_host(discovery.as_ref(), 42, &second).await;
         let started = tokio::time::Instant::now();
-        let error = await_single_host(discovery.as_ref(), "ns", Duration::from_secs(30))
-            .await
-            .unwrap_err();
+        let error = await_single_host(
+            discovery.as_ref(),
+            "ns",
+            Duration::from_secs(30),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap_err();
         assert!(started.elapsed() < Duration::from_secs(5));
         assert!(format!("{error:#}").contains("exactly one live V2 host, found 2"));
     }

--- a/lib/llm/src/kv_router/publisher/attachment_owner.rs
+++ b/lib/llm/src/kv_router/publisher/attachment_owner.rs
@@ -184,6 +184,7 @@ fn validate_descriptors(descriptors: &[KvStateAttachmentDescriptor]) -> Result<(
     Ok(())
 }
 
+/// Resolve the single live V2 state-agent host for this component's namespace.
 async fn discover_single_host(
     component: &dynamo_runtime::component::Component,
 ) -> Result<KvStateHostAdvertisement> {
@@ -197,6 +198,7 @@ async fn discover_single_host(
     .await
 }
 
+/// Startup wait for host discovery from the env knob; invalid values warn and use the default.
 fn host_discovery_timeout(mut get_env: impl FnMut(&str) -> Option<OsString>) -> Duration {
     match get_env(HOST_DISCOVERY_TIMEOUT_ENV) {
         None => DEFAULT_HOST_DISCOVERY_TIMEOUT,
@@ -249,7 +251,10 @@ async fn await_single_host(
     // Cancelled on every exit path; without this the discovery watch task
     // outlives the wait for the rest of the process.
     let _watch_guard = watch_cancel.clone().drop_guard();
-    let expiry = tokio::time::Instant::now() + timeout;
+    // A timeout too large for the clock is effectively unbounded, not a panic.
+    let expiry = tokio::time::Instant::now()
+        .checked_add(timeout)
+        .unwrap_or_else(|| tokio::time::Instant::now() + Duration::from_secs(u32::MAX.into()));
     // The bound covers the whole wait: watch setup and every re-list, not
     // just the idle gaps between events.
     let wait = async {
@@ -276,10 +281,12 @@ async fn await_single_host(
     }
 }
 
+/// Shared so the zero-timeout path stays byte-identical to the legacy error message.
 fn exactly_one_host_error(found: usize) -> anyhow::Error {
     anyhow::anyhow!("state-agent mode requires exactly one live V2 host, found {found}")
 }
 
+/// The one discovery query the snapshot and the watch must share.
 fn host_query(namespace: &str) -> DiscoveryQuery {
     DiscoveryQuery::EventSources(EventSourceQuery::topic(
         namespace,
@@ -288,6 +295,7 @@ fn host_query(namespace: &str) -> DiscoveryQuery {
     ))
 }
 
+/// One authoritative snapshot: `None` while no host is advertised, an error on more than one.
 async fn list_single_host(
     discovery: &dyn Discovery,
     namespace: &str,
@@ -745,7 +753,9 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(50)).await;
             register_host(register.as_ref(), 41, &host()).await;
         });
-        let found = await_single_host(discovery.as_ref(), "ns", Duration::from_secs(5))
+        // u64::MAX also proves an expiry too large for the clock waits
+        // instead of panicking.
+        let found = await_single_host(discovery.as_ref(), "ns", Duration::from_secs(u64::MAX))
             .await
             .unwrap();
         assert_eq!(found.host_instance, host().host_instance);

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -469,6 +469,13 @@ pub mod llm {
     /// EMA smoothing factor (alpha) for the EMA predictor. Range [0.0, 1.0].
     pub const DYN_LORA_ALLOCATION_EMA_ALPHA: &str = "DYN_LORA_ALLOCATION_EMA_ALPHA";
 
+    /// Bounded startup wait, in seconds, for the KV state-agent host
+    /// advertisement before an opted-in worker gives up on KV routing.
+    /// `0` fails after a single discovery snapshot; invalid values use the
+    /// 30-second default.
+    pub const DYN_KV_STATE_AGENT_HOST_DISCOVERY_TIMEOUT_SECS: &str =
+        "DYN_KV_STATE_AGENT_HOST_DISCOVERY_TIMEOUT_SECS";
+
     /// Metrics configuration
     pub mod metrics {
         /// Custom metrics prefix (overrides default "dynamo_frontend")
@@ -967,6 +974,7 @@ mod tests {
             llm::DYN_REASONING_FIELD_NAME,
             llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2,
             llm::DYN_ENABLE_GUIDED_TOOL_STREAMING,
+            llm::DYN_KV_STATE_AGENT_HOST_DISCOVERY_TIMEOUT_SECS,
             llm::DYN_LORA_ALLOCATION_ENABLED,
             llm::DYN_LORA_ALLOCATION_ALGORITHM,
             llm::DYN_LORA_ALLOCATION_TIMESTEP_SECS,


### PR DESCRIPTION
## Overview:

An opted-in vLLM worker resolves the KV state-agent host with a single discovery snapshot at startup. If the worker starts before the host's advertisement propagates, that one-shot lookup fails once, and since source mode is immutable for a worker lifecycle, the worker serves with KV routing disabled until it restarts.

## Details:

The `list()` snapshot stays authoritative: two or more hosts still fail closed immediately as a misconfig. An empty snapshot now waits under a bounded timeout, using the discovery watch stream only as a wake-up to re-list. A watch event is never trusted directly, since initial-snapshot events are indistinguishable from later additions. The whole wait (watch setup and every re-list) runs under one deadline, so the configured timeout is a hard bound.

Default 30s, configurable via `DYN_KV_STATE_AGENT_HOST_DISCOVERY_TIMEOUT_SECS`, with 0 preserving the original single-snapshot behavior exactly, including the error message.

Behavior note: a deployment whose host is genuinely absent now reaches degraded serving 30s later than before; 0 restores fail-fast.

The post-startup host re-selection stays gated on the rolling-replacement/Kubernetes work (`TODO(#13044)` retained).

## Where should the reviewer start?

`await_single_host` in `lib/llm/src/kv_router/publisher/attachment_owner.rs`, then the six tests at the bottom of the file.

## Related Issues

Refs [#13044](https://github.com/ai-dynamo/dynamo/issues/13044) (the startup-ordering half of the `attachment_owner.rs` TODO, as proposed in the issue thread)

## Validation:
New unit tests: host advertised before start, host advertised mid-wait, deadline expiry with a diagnosable error, zero-timeout legacy behavior, two-host fail-closed, env parsing
`cargo test -p dynamo-llm --no-default-features --lib kv_router` (macOS; one pre-existing parallel-execution flake in worker_query.rs direct-ZMQ tests, reproducible on unmodified main)
`cargo clippy -p dynamo-llm --no-default-features --all-targets and cargo fmt --check clean`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - KV state-agent host discovery now safely handles startup timeout values beyond the runtime clock range by treating them as effectively unlimited.
  - Delayed host advertisements continue to be handled reliably during discovery.

- **Documentation**
  - Added documentation for KV state-agent host discovery helpers and their startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->