### PR TITLE
ci: parallelize router and vLLM test paths

### DIFF
--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -42,6 +42,18 @@ inputs:
     description: 'Parallelization mode: auto (use all cores), none/0 (sequential), or a number of workers'
     required: false
     default: 'auto'
+  parallel_dist:
+    description: 'pytest-xdist distribution mode (for example: loadscope or load)'
+    required: false
+    default: 'loadscope'
+  dynamo_runtime_num_worker_threads:
+    description: 'Optional Tokio worker-thread cap inherited by Dynamo test subprocesses'
+    required: false
+    default: ''
+  dynamo_runtime_max_blocking_threads:
+    description: 'Optional Tokio blocking-thread cap inherited by Dynamo test subprocesses'
+    required: false
+    default: ''
   max_vram_gib:
     description: 'Per-test VRAM budget in GiB. When set together with parallel_mode!=none, runs GPU tests as VRAM-aware concurrent subprocesses via the orchestrator in tests/utils/pytest_parallel_gpu.py. Tests without @pytest.mark.profiled_vram_gib(N) are deselected by tests/conftest.py.'
     required: false
@@ -118,9 +130,34 @@ runs:
         DYNAMO_TEST_WORKFLOW: ${{ github.workflow }}
         DYNAMO_TEST_FRAMEWORK: ${{ inputs.framework }}
         HF_XET_HIGH_PERFORMANCE: 1
+        INPUT_DYN_RUNTIME_NUM_WORKER_THREADS: ${{ inputs.dynamo_runtime_num_worker_threads }}
+        INPUT_DYN_RUNTIME_MAX_BLOCKING_THREADS: ${{ inputs.dynamo_runtime_max_blocking_threads }}
       run: |
         # Run pytest with detailed output and JUnit XML
         set +e  # Don't exit on test failures
+
+        case "${INPUT_DYN_RUNTIME_NUM_WORKER_THREADS}" in
+          '') ;;
+          0*|*[!0-9]*)
+            echo "::error::dynamo_runtime_num_worker_threads must be a positive integer"
+            exit 1
+            ;;
+          *)
+            export DYN_RUNTIME_NUM_WORKER_THREADS="${INPUT_DYN_RUNTIME_NUM_WORKER_THREADS}"
+            echo "Dynamo Tokio worker threads: ${DYN_RUNTIME_NUM_WORKER_THREADS}"
+            ;;
+        esac
+        case "${INPUT_DYN_RUNTIME_MAX_BLOCKING_THREADS}" in
+          '') ;;
+          0*|*[!0-9]*)
+            echo "::error::dynamo_runtime_max_blocking_threads must be a positive integer"
+            exit 1
+            ;;
+          *)
+            export DYN_RUNTIME_MAX_BLOCKING_THREADS="${INPUT_DYN_RUNTIME_MAX_BLOCKING_THREADS}"
+            echo "Dynamo Tokio max blocking threads: ${DYN_RUNTIME_MAX_BLOCKING_THREADS}"
+            ;;
+        esac
 
         # Get absolute path for test-results directory and ensure it has proper permissions.
         # Artifacts go to the GitHub Actions checkout so upload-artifact can find them.
@@ -210,8 +247,10 @@ runs:
             DIST_OPTS=""
             echo "🧮 GPU-parallel mode: --max-vram-gib=${{ inputs.max_vram_gib }} (xdist replaced by VRAM-aware orchestrator)"
           else
-            # --dist=loadscope groups tests by module/class to prevent race conditions in stateful tests
-            DIST_OPTS="--dist=loadscope"
+            # loadscope remains the conservative default for stateful tests. Suites
+            # with independently isolated cases can opt into load balancing across
+            # individual tests via parallel_dist=load.
+            DIST_OPTS="--dist=${{ inputs.parallel_dist }}"
           fi
 
           # Add coverage flags if enabled

--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'Run pytest in dry-run mode (collect tests only, do not execute)'
     required: false
     default: 'false'
+  allow_no_tests:
+    description: 'Treat pytest exit code 5 (no tests collected) as success'
+    required: false
+    default: 'false'
   start_minio:
     description: 'Start MinIO service for LoRA tests (true/false)'
     required: false
@@ -272,6 +276,10 @@ runs:
         bash -c "${PYTEST_CMD}"
 
         TEST_EXIT_CODE=$?
+        if [[ "${TEST_EXIT_CODE}" -eq 5 && "${{ inputs.allow_no_tests }}" == "true" ]]; then
+          echo "ℹ️ No tests matched this optional stage; accepting pytest exit code 5"
+          TEST_EXIT_CODE=0
+        fi
         echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV
         echo "🧪 Tests completed with exit code: ${TEST_EXIT_CODE}"
 

--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -52,6 +52,20 @@ on:
       cpu_parallel_test_markers:
         required: true
         type: string
+      cpu_sequential_test_markers:
+        description: 'CPU tests owned by the sequential stage; callers exclude any dedicated suites they schedule separately'
+        required: true
+        type: string
+      cpu_sequential_test_timeout_minutes:
+        description: 'Timeout for the sequential CPU test stage'
+        required: false
+        type: number
+        default: 45
+      run_router_tests:
+        description: 'Run the dedicated xdist router shard'
+        required: false
+        type: boolean
+        default: false
       gpu_test_markers:
         required: true
         type: string
@@ -222,6 +236,38 @@ jobs:
       image_tag_suffix: ${{ inputs.image_tag_suffix }}
     secrets: inherit
 
+  # Router process E2Es are independently namespaced. Most mocker cases share one
+  # session-scoped NATS/etcd pair; restart and NATS-free cases retain isolated
+  # services. Use per-test load balancing: loadscope would pin their large test
+  # module to one worker and serialize nearly all of the runtime.
+  router:
+    name: test
+    needs: image
+    if: inputs.run_router_tests
+    uses: $/.github/workflows/shared-test.yml
+    with:
+      test_suite_name: dynamo
+      test_type: router
+      amd_runner: prod-tester-amd-v2
+      target_tag_plain: ${{ needs.image.outputs.target_tag_plain }}
+      cuda_version: '["${{ inputs.cuda_version }}"]'
+      platform: '["amd64", "arm64"]'
+      run_sanity_check: false
+      run_cpu_only_tests: true
+      cpu_only_test_markers: 'pre_merge and router and not (planner or vllm or sglang or trtllm) and (gpu_0)'
+      cpu_only_test_timeout_minutes: 15
+      cpu_parallel_mode: '4'
+      cpu_parallel_dist: 'load'
+      # Each E2E starts several Dynamo processes. Without caps, every process
+      # sizes Tokio from the whole runner and the 4-worker shard exceeds 1,500
+      # observed threads without improving wall time.
+      cpu_dynamo_runtime_num_worker_threads: '2'
+      cpu_dynamo_runtime_max_blocking_threads: '4'
+      run_gpu_tests: false
+      source_ref: ${{ inputs.source_ref }}
+      image_tag_suffix: ${{ inputs.image_tag_suffix }}
+    secrets: inherit
+
   sequential:
     name: test
     needs: image
@@ -235,8 +281,8 @@ jobs:
       platform: '["amd64", "arm64"]'
       run_sanity_check: false
       run_cpu_only_tests: true
-      cpu_only_test_markers: 'pre_merge and not parallel and not defaulted and not (vllm or sglang or trtllm) and (gpu_0)'
-      cpu_only_test_timeout_minutes: 45
+      cpu_only_test_markers: ${{ inputs.cpu_sequential_test_markers }}
+      cpu_only_test_timeout_minutes: ${{ inputs.cpu_sequential_test_timeout_minutes }}
       cpu_parallel_mode: 'none'
       run_gpu_tests: false
       source_ref: ${{ inputs.source_ref }}

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -1110,6 +1110,9 @@ jobs:
       # parallel-safety or split them into their own job -- unlike `parallel`,
       # `defaulted` is not an author's claim that the test is parallel-safe.
       cpu_parallel_test_markers: 'pre_merge and (parallel or defaulted) and not (vllm or sglang or trtllm) and (gpu_0)'
+      # Nightly builds a planner image but does not have a dedicated planner test
+      # job, so planner coverage intentionally remains in this runtime pipeline.
+      cpu_sequential_test_markers: 'pre_merge and not parallel and not defaulted and not (vllm or sglang or trtllm) and (gpu_0)'
       gpu_test_markers: 'pre_merge and none and gpu_1'
       dev_version_suffix: ${{ needs.compute-dev-version.outputs.dev_suffix }}
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -77,7 +77,8 @@ jobs:
       # only picks the pod. Before enabling real xdist here, vet these tests for
       # parallel-safety or split them into their own job -- unlike `parallel`,
       # `defaulted` is not an author's claim that the test is parallel-safe.
-      cpu_parallel_test_markers: 'pre_merge and (parallel or defaulted) and not (vllm or sglang or trtllm) and (gpu_0)'
+      cpu_parallel_test_markers: 'pre_merge and (parallel or defaulted) and not (planner or vllm or sglang or trtllm) and (gpu_0)'
+      cpu_sequential_test_markers: 'pre_merge and not parallel and not defaulted and not (planner or vllm or sglang or trtllm) and (gpu_0)'
       gpu_test_markers: 'pre_merge and none and gpu_1'
     secrets: inherit
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -775,6 +775,10 @@ jobs:
       # 24 GiB is the per-test admission threshold; the scheduler packs tests
       # against the runner's detected free-memory budget (19 GiB in recent CI).
       run_gpu_parallel_tests: true
+      # Every current non-multimodal test is VRAM-profiled, so the fallback is
+      # empty today. Keep it enabled for future unprofiled tests, but accept its
+      # specific no-tests-collected exit code rather than failing the job.
+      gpu_sequential_allow_no_tests: true
       gpu_parallel_max_vram_gib: '24'
     secrets: inherit
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -950,7 +950,10 @@ jobs:
       # only picks the pod. Before enabling real xdist here, vet these tests for
       # parallel-safety or split them into their own job -- unlike `parallel`,
       # `defaulted` is not an author's claim that the test is parallel-safe.
-      cpu_parallel_test_markers: 'pre_merge and (parallel or defaulted) and not (vllm or sglang or trtllm) and (gpu_0)'
+      cpu_parallel_test_markers: 'pre_merge and (parallel or defaulted) and not (planner or router or vllm or sglang or trtllm) and (gpu_0)'
+      cpu_sequential_test_markers: 'pre_merge and not parallel and not defaulted and not (planner or router or vllm or sglang or trtllm) and (gpu_0)'
+      cpu_sequential_test_timeout_minutes: 15
+      run_router_tests: true
       gpu_test_markers: 'pre_merge and none and gpu_1'
     secrets: inherit
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -137,6 +137,8 @@ jobs:
       - trtllm-local-dev-build
       - vllm-dev-build
       - vllm-test
+      - vllm-multimodal-test
+      - vllm-cpu-test
       - vllm-multi-gpu-test
       - vllm-copy-to-acr
       - sglang-build
@@ -763,15 +765,54 @@ jobs:
       amd_runner: prod-tester-amd-gpu-v2 # This runner is overridden for ARM platform
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
-      platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
-      run_cpu_only_tests: true
-      cpu_only_test_markers: pre_merge and vllm and gpu_0
-      gpu_test_markers: pre_merge and vllm and gpu_1
+      platform: '["amd64"]'
+      run_cpu_only_tests: false
+      # Multimodal tests carry 46% of the measured single-GPU critical path.
+      # Run them on their own L4 below instead of serializing both resource pools.
+      gpu_test_markers: pre_merge and vllm and gpu_1 and not multimodal
       gpu_test_timeout_minutes: 45
       # Profiled tests run in the parallel stage; unprofiled fall through to sequential.
-      # 24 GiB admits all currently profiled vLLM tests (max is ~20.4 GiB) on a 48 GiB GPU.
+      # 24 GiB is the per-test admission threshold; the scheduler packs tests
+      # against the runner's detected free-memory budget (19 GiB in recent CI).
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
+    secrets: inherit
+
+  vllm-multimodal-test:
+    name: vllm-runtime-multimodal
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true' || needs.changed-files.outputs.sample == 'true'
+    uses: $/.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: Multimodal Test
+      amd_runner: prod-tester-amd-gpu-v2
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64"]'
+      run_sanity_check: false
+      run_cpu_only_tests: false
+      gpu_test_markers: pre_merge and vllm and gpu_1 and multimodal
+      gpu_test_timeout_minutes: 45
+      run_gpu_parallel_tests: true
+      gpu_parallel_max_vram_gib: '24'
+    secrets: inherit
+
+  vllm-cpu-test:
+    name: vllm-runtime-cpu
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true' || needs.changed-files.outputs.sample == 'true'
+    uses: $/.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: CPU Test
+      amd_runner: prod-tester-amd-v2
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '[""]'
+      platform: '["amd64", "arm64"]'
+      run_cpu_only_tests: true
+      cpu_only_test_markers: pre_merge and vllm and gpu_0
+      run_gpu_tests: false
     secrets: inherit
 
   vllm-multi-gpu-test:
@@ -1980,6 +2021,8 @@ jobs:
       - operator
       - vllm-build
       - vllm-test
+      - vllm-multimodal-test
+      - vllm-cpu-test
       - vllm-multi-gpu-test
       - vllm-copy-to-acr
       - sglang-build

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -103,6 +103,11 @@ on:
         required: false
         type: boolean
         default: false
+      gpu_sequential_allow_no_tests:
+        description: 'Allow the sequential GPU fallback to succeed when its marker expression collects no tests. Other pytest errors still fail.'
+        required: false
+        type: boolean
+        default: false
       gpu_parallel_max_vram_gib:
         description: 'Per-test VRAM budget in GiB for the parallel stage. Caps which profiled tests are admitted and feeds the orchestrator scheduler (tests/utils/pytest_parallel_gpu.py).'
         required: false
@@ -272,5 +277,6 @@ jobs:
           platform_arch: ${{ matrix.platform }}
           hf_token: ${{ secrets.HF_TOKEN }}
           parallel_mode: 'none'
+          allow_no_tests: ${{ inputs.gpu_sequential_allow_no_tests }}
           enable_coverage: ${{ inputs.enable_coverage }}
           gpu_tests: 'true'

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -69,6 +69,21 @@ on:
         required: false
         type: string
         default: 'auto'
+      cpu_parallel_dist:
+        description: 'pytest-xdist distribution mode for CPU-only tests'
+        required: false
+        type: string
+        default: 'loadscope'
+      cpu_dynamo_runtime_num_worker_threads:
+        description: 'Optional Tokio worker-thread cap for Dynamo CPU test processes'
+        required: false
+        type: string
+        default: ''
+      cpu_dynamo_runtime_max_blocking_threads:
+        description: 'Optional Tokio blocking-thread cap for Dynamo CPU test processes'
+        required: false
+        type: string
+        default: ''
       run_gpu_tests:
         description: 'Whether to run GPU tests'
         required: false
@@ -218,6 +233,9 @@ jobs:
           platform_arch: ${{ matrix.platform }}
           hf_token: ${{ secrets.HF_TOKEN }}
           parallel_mode: ${{ inputs.cpu_parallel_mode }}
+          parallel_dist: ${{ inputs.cpu_parallel_dist }}
+          dynamo_runtime_num_worker_threads: ${{ inputs.cpu_dynamo_runtime_num_worker_threads }}
+          dynamo_runtime_max_blocking_threads: ${{ inputs.cpu_dynamo_runtime_max_blocking_threads }}
           enable_coverage: ${{ inputs.enable_coverage }}
           gpu_tests: 'false'
       - name: Run GPU tests (parallel)

--- a/tests/README.md
+++ b/tests/README.md
@@ -392,16 +392,22 @@ pytest tests/serve/test_sglang.py::test_sglang_deployment[aggregated-2] -v --tb=
 pytest tests/serve/test_trtllm.py::test_deployment[aggregated-2] -v --tb=short
 ```
 
-**Pre-merge CI equivalent** -- this is what [`pr.yaml`](../.github/workflows/pr.yaml) runs via [`dynamo-pipeline.yml`](../.github/workflows/dynamo-pipeline.yml) on every PR. Tests marked `parallel` run with `pytest-xdist`; the rest run sequentially:
+**Pre-merge CI equivalent** -- for relevant runtime changes, [`pr.yaml`](../.github/workflows/pr.yaml) runs the general, router, and core-sequential stages via [`dynamo-pipeline.yml`](../.github/workflows/dynamo-pipeline.yml). Planner is a sibling `pr.yaml` job that runs from the planner image. These jobs are path-gated. Functional areas with their own jobs are excluded from the general CPU stages:
 ```bash
-# Parallel pre-merge tests (4 workers, CPU-only; typically <5min)
-pytest -m "pre_merge and parallel and not (vllm or sglang or trtllm) and gpu_0" -n 4 --dist=loadscope -v --tb=short
+# General parallel/defaulted placement stage (currently sequential)
+pytest -m "pre_merge and (parallel or defaulted) and not (planner or router or vllm or sglang or trtllm) and gpu_0" -n 0 --dist=loadscope -v --tb=short
 
-# Sequential pre-merge tests (CPU-only; typically <10min)
-pytest -m "pre_merge and not parallel and not (vllm or sglang or trtllm) and gpu_0" -v --tb=short
+# Router stage (4 workers, balanced by individual test)
+DYN_RUNTIME_NUM_WORKER_THREADS=2 DYN_RUNTIME_MAX_BLOCKING_THREADS=4 pytest -m "pre_merge and router and not (planner or vllm or sglang or trtllm) and gpu_0" -n 4 --dist=load -v --tb=short
+
+# Core sequential stage
+pytest -m "pre_merge and not parallel and not defaulted and not (planner or router or vllm or sglang or trtllm) and gpu_0" -n 0 --dist=loadscope -v --tb=short
+
+# Planner stage (runs in the planner image)
+pytest -m "pre_merge and planner and gpu_0" -n 2 --dist=loadscope -v --tb=short
 ```
 
-> **Parallel vs sequential:** CPU-only tests (`gpu_0`) marked `parallel` run with `pytest-xdist` (`-n auto` or `-n <workers>`, `--dist=loadscope`). GPU tests (`gpu_1`, `gpu_2`, etc.) run sequentially by default, but can run in parallel with `--max-vram-gib=N -n auto` (uses a custom VRAM-aware scheduler, not xdist). See [`.github/actions/pytest/action.yml`](../.github/actions/pytest/action.yml).
+> **Parallel vs sequential:** The router stage uses pytest-xdist with `--dist=load`, because its process E2Es live in one large module; `loadscope` would pin that module to one worker. Router cases use unique namespaces, and isolation-sensitive cases retain per-test services. The general parallel/defaulted stage is currently a placement boundary only and runs with `-n 0`. GPU tests (`gpu_1`, `gpu_2`, etc.) run sequentially by default, but can run in parallel with `--max-vram-gib=N -n auto` (uses a custom VRAM-aware scheduler, not xdist). See [`.github/actions/pytest-local/action.yml`](../.github/actions/pytest-local/action.yml).
 
 **Full E2E suite** -- launches engines for every test configuration; slowest, requires GPU and a framework container (typically <30min depending on framework and model):
 ```bash
@@ -457,11 +463,11 @@ Source workflow files (see [`.github/workflows/`](../.github/workflows/) for the
 - **Pre-merge (Python):** [`.github/workflows/pr.yaml`](../.github/workflows/pr.yaml) -> [`.github/workflows/dynamo-pipeline.yml`](../.github/workflows/dynamo-pipeline.yml)
 - **Post-merge:** [`.github/workflows/post-merge-ci.yml`](../.github/workflows/post-merge-ci.yml)
 - **Nightly:** [`.github/workflows/nightly-ci.yml`](../.github/workflows/nightly-ci.yml)
-- **Pytest action:** [`.github/actions/pytest/action.yml`](../.github/actions/pytest/action.yml)
+- **Pytest action:** [`.github/actions/pytest-local/action.yml`](../.github/actions/pytest-local/action.yml)
 
 ### Pre-merge (every PR)
 
-Two workflows run on every PR. See [`pre-merge.yml`](../.github/workflows/pre-merge.yml) and [`pr.yaml`](../.github/workflows/pr.yaml).
+Two workflows are triggered on every PR, with individual jobs gated by changed paths. See [`pre-merge.yml`](../.github/workflows/pre-merge.yml) and [`pr.yaml`](../.github/workflows/pr.yaml).
 
 **Rust checks** (only if Rust files changed) -- runs `pre-commit`, then the full sequence from [Running Rust Checks and Tests](#running-rust-checks-and-tests) across 4 workspace dirs (`.`, `lib/bindings/python`, `lib/runtime/examples`, `lib/bindings/kvbm`): format, clippy, cargo-deny, machete, compile, doc tests, unit tests.
 
@@ -469,8 +475,10 @@ Two workflows run on every PR. See [`pre-merge.yml`](../.github/workflows/pre-me
 
 | Stage | Marker expression | Local equivalent |
 |-------|------------------|-----------------|
-| Parallel (xdist, 4 workers) | `pre_merge and parallel and not (vllm or sglang or trtllm) and gpu_0` | `pytest -m "pre_merge and parallel and not (vllm or sglang or trtllm) and gpu_0" -n 4 --dist=loadscope -v --tb=short` |
-| Sequential | `pre_merge and not parallel and not (vllm or sglang or trtllm) and gpu_0` | `pytest -m "pre_merge and not parallel and not (vllm or sglang or trtllm) and gpu_0" -v --tb=short` |
+| Parallel/defaulted placement (currently `-n 0`) | `pre_merge and (parallel or defaulted) and not (planner or router or vllm or sglang or trtllm) and gpu_0` | `pytest -m "pre_merge and (parallel or defaulted) and not (planner or router or vllm or sglang or trtllm) and gpu_0" -n 0 --dist=loadscope -v --tb=short` |
+| Router (xdist, 4 workers; Tokio 2/4) | `pre_merge and router and not (planner or vllm or sglang or trtllm) and gpu_0` | `DYN_RUNTIME_NUM_WORKER_THREADS=2 DYN_RUNTIME_MAX_BLOCKING_THREADS=4 pytest -m "pre_merge and router and not (planner or vllm or sglang or trtllm) and gpu_0" -n 4 --dist=load -v --tb=short` |
+| Core sequential | `pre_merge and not parallel and not defaulted and not (planner or router or vllm or sglang or trtllm) and gpu_0` | `pytest -m "pre_merge and not parallel and not defaulted and not (planner or router or vllm or sglang or trtllm) and gpu_0" -n 0 --dist=loadscope -v --tb=short` |
+| Planner (xdist, 2 workers) | `pre_merge and planner and gpu_0` | `pytest -m "pre_merge and planner and gpu_0" -n 2 --dist=loadscope -v --tb=short` |
 
 ### Post-merge (push to release branches)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -983,7 +983,14 @@ class SharedManagedProcess:
         self.resource_name = resource_name
         self._server: Optional[ManagedProcess] = None
 
-        root_tmp = Path(tempfile.gettempdir()) / "pytest_shared_services"
+        # All xdist workers for one invocation have sibling basetemp directories
+        # (``.../popen-gw0``, ``.../popen-gw1``, ...). Coordinate through their
+        # parent so workers share services without reusing stale state from a
+        # different pytest invocation in the same container.
+        root_tmp = tmp_path_factory.getbasetemp()
+        if hasattr(request.config, "workerinput"):
+            root_tmp = root_tmp.parent
+        root_tmp = root_tmp / "shared_services"
         root_tmp.mkdir(parents=True, exist_ok=True)
 
         self.port_file = root_tmp / f"{resource_name}_port"
@@ -1036,10 +1043,16 @@ class SharedManagedProcess:
                     logging.warning(
                         f"[{self.resource_name}] Stale port file: port {stored_port} not in use, starting fresh"
                     )
-                self.port = allocate_port(self.start_port)
-                self._write_port(self.port)
-                self._server = self._create_server(self.port)
+                # Passing port=0 lets each service allocate every port it needs.
+                # In particular, EtcdServer allocates both its client and peer
+                # listeners; passing only an explicit client port would make all
+                # xdist workers contend for etcd's default peer port 2380.
+                self._server = self._create_server(0)
                 self._server.__enter__()
+                self.port = self._server.port
+                # Publish only a healthy server. Writing before __enter__ succeeds
+                # leaves a stale port that makes the next worker retry needlessly.
+                self._write_port(self.port)
                 logging.info(
                     f"[{self.resource_name}] Started process on port {self.port}"
                 )
@@ -1052,7 +1065,7 @@ class SharedManagedProcess:
 
 
 class SharedEtcdServer(SharedManagedProcess):
-    """EtcdServer with file-based reference counting for multi-process sharing."""
+    """EtcdServer shared across xdist workers through a lock and port file."""
 
     def __init__(self, request, tmp_path_factory, start_port=2380, timeout=300):
         super().__init__(request, tmp_path_factory, "etcd", start_port, timeout)
@@ -1062,13 +1075,17 @@ class SharedEtcdServer(SharedManagedProcess):
     def _create_server(self, port: int) -> ManagedProcess:
         """Create EtcdServer instance."""
         server = EtcdServer(self.request, port=port, timeout=self.timeout)
+        # Shared services run alongside function-scoped instances under xdist.
+        # EtcdServer treats an explicit nonzero port as a legacy singleton and
+        # otherwise kills every matching process name before startup.
+        server.terminate_all_matching_process_names = False
         # Override log_dir since request.node.name is empty in session scope
         server.log_dir = self._log_dir
         return server
 
 
 class SharedNatsServer(SharedManagedProcess):
-    """NatsServer with file-based reference counting for multi-process sharing."""
+    """NatsServer shared across xdist workers through a lock and port file."""
 
     def __init__(
         self,
@@ -1091,6 +1108,9 @@ class SharedNatsServer(SharedManagedProcess):
             timeout=self.timeout,
             disable_jetstream=self._disable_jetstream,
         )
+        # Do not let first-worker startup kill per-test NATS servers owned by
+        # other xdist workers merely because this wrapper chose the shared port.
+        server.terminate_all_matching_process_names = False
         # Override log_dir since request.node.name is empty in session scope
         server.log_dir = self._log_dir
         return server

--- a/tests/router/test_policy_class.py
+++ b/tests/router/test_policy_class.py
@@ -21,8 +21,8 @@ from tests.router.mocker_process import MockerProcess
 from tests.utils.constants import ROUTER_MODEL_NAME
 from tests.utils.managed_process import DynamoFrontendProcess
 
-# Do not add pytest.mark.parallel: existing Mocker Router tests document races in
-# process-global DistributedRuntime state under pytest-xdist.
+# Router process E2Es are scheduled by the dedicated, capped router shard. Keep this
+# out of the general ``parallel`` marker pool so it does not inherit unbounded xdist.
 pytestmark = [
     pytest.mark.pre_merge,
     pytest.mark.gpu_0,

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -1,12 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# NOTE: These tests run reliably in serial but have encountered intermittent failures
-# under pytest-xdist parallel execution (-n auto). Each test spawns its own
-# DistributedRuntime with isolated etcd/NATS and unique namespaces, but the Rust
-# runtime may use process-global state (e.g. lazy_static / OnceLock singletons for
-# endpoint tables) that races under concurrent xdist workers. Do not add
-# @pytest.mark.parallel until DRT endpoint registration is confirmed thread-safe.
+# NOTE: The dedicated router CI shard runs this module with four xdist workers and
+# per-test load balancing. Cases use unique namespaces; most reuse invocation-scoped
+# NATS/etcd services, while tests that restart services or require NATS-free execution
+# retain isolated fixtures. Keep these tests out of the general ``parallel`` marker
+# pool: unbounded ``-n auto`` multiplies every E2E's subprocess/thread fan-out.
 #
 import asyncio
 import contextlib
@@ -397,7 +396,7 @@ class CounterWorkerProcess:
 )
 def test_mocker_kv_event_publisher_disabled_diagnostic(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
     topology,
     request_plane,
@@ -476,7 +475,7 @@ def test_mocker_kv_event_publisher_disabled_diagnostic(
 @pytest.mark.skip(reason=ROUND_ROBIN_MOCKER_SKIP_REASON)
 def test_mocker_router(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
     router_mode,
     request_plane,
@@ -486,7 +485,7 @@ def test_mocker_router(
 
     Covers kv, round-robin, and random routing. Tests both NATS and TCP request planes.
     """
-    # runtime_services starts etcd and optionally nats based on request_plane
+    # Shared runtime services are safe because MockerProcess uses a unique namespace.
     logger.info(
         f"Starting mocker router test: router_mode={router_mode}, request_plane={request_plane}"
     )
@@ -520,7 +519,7 @@ def test_mocker_router(
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
 def test_mocker_router_soak(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
     router_mode,
     request_plane,
@@ -548,22 +547,24 @@ def test_mocker_router_soak(
     )
 
 
-@pytest.mark.parametrize("store_backend", ["etcd", "file"])
 @pytest.mark.timeout(180)  # bumped for xdist contention (was 60s; ~19.86s serial avg)
 def test_mocker_two_kv_router(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
-    file_storage_backend,
-    store_backend,
 ):
     """
     Test with two KV routers and multiple mocker engine instances.
     Alternates requests between the two routers to test load distribution.
-    Tests with both etcd and file storage backends.
+
+    File discovery is covered by the focused per-worker configuration test.
+    This multi-frontend load-distribution case exercises the distributed etcd
+    deployment used in production.
     """
 
-    # runtime_services starts etcd and nats
+    store_backend = "etcd"
+
+    # Shared runtime services are safe because MockerProcess uses a unique namespace.
     logger.info(
         f"Starting mocker two KV router test with {store_backend} storage backend"
     )
@@ -598,16 +599,14 @@ def test_mocker_two_kv_router(
         )
 
 
-@pytest.mark.parametrize("store_backend", ["etcd", "file"])
 @pytest.mark.timeout(180)
 def test_mocker_session_affinity(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
-    file_storage_backend,
-    store_backend,
 ):
     """Replica affinity overrides conflicting per-frontend KV-prefix placement."""
+    store_backend = "etcd"
     mocker_args = {
         "speedup_ratio": SPEEDUP_RATIO,
         "block_size": BLOCK_SIZE,
@@ -633,7 +632,7 @@ def test_mocker_session_affinity(
 @pytest.mark.timeout(45)  # ~3x average (~13.10s), rounded up (when enabled)
 def test_mocker_kv_router_overload_529(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
     monkeypatch,
     overload_config,
@@ -668,7 +667,7 @@ def test_mocker_kv_router_overload_529(
 
 @pytest.mark.timeout(45)
 def test_mocker_kv_router_threshold_none_disables_rejection(
-    request, runtime_services_dynamic_ports, predownload_tokenizers
+    request, runtime_services_session, predownload_tokenizers
 ):
     """Test that explicit CLI None thresholds disable KV router overload rejection."""
     logger.info("Starting mocker KV router explicit-None threshold test")
@@ -698,7 +697,7 @@ def test_mocker_kv_router_threshold_none_disables_rejection(
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
 def test_kv_router_bindings(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
     request_plane,
 ):
@@ -737,18 +736,7 @@ def test_kv_router_bindings(
         )
 
 
-@pytest.mark.parametrize(
-    "store_backend,request_plane",
-    [
-        ("etcd", "tcp"),
-        ("file", "nats"),
-    ],
-    ids=[
-        "etcd",
-        "file",
-    ],
-    indirect=["request_plane"],
-)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 @pytest.mark.parametrize("event_plane", ["nats"], indirect=True)
 # Known flake: Router and Standalone indexer occasionally
 # disagree on event count by 3-4 events (e.g. "Router 1 has 105 events, Standalone A
@@ -759,8 +747,6 @@ def test_indexers_sync(
     request,
     runtime_services_dynamic_ports,
     predownload_tokenizers,
-    file_storage_backend,
-    store_backend,
     request_plane,
     event_plane,
 ):
@@ -768,8 +754,10 @@ def test_indexers_sync(
     Test that two KV routers have synchronized indexer states after processing requests.
     This test verifies that both routers converge to the same internal state.
 
-    Tests with etcd and file discovery backends.
+    File discovery is covered by other focused router tests; this recovery path
+    exercises the distributed etcd configuration used in deployments.
     """
+    store_backend = "etcd"
     logger.info(
         f"Starting indexers sync test: store_backend={store_backend}, "
         f"request_plane={request_plane}"
@@ -808,7 +796,7 @@ def test_indexers_sync(
 
 @pytest.mark.timeout(120)  # bumped for xdist contention (was 42s; ~13.80s serial avg)
 def test_query_instance_id_returns_worker_and_tokens(
-    request, runtime_services_dynamic_ports, predownload_tokenizers
+    request, runtime_services_session, predownload_tokenizers
 ):
     """Test query_instance_id annotation with mocker engines."""
     logger.info("Starting KV router query_instance_id annotation test")
@@ -964,7 +952,7 @@ def test_router_decisions(
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 def test_router_decisions_router_aic(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
     request_plane,
 ):
@@ -1109,7 +1097,7 @@ async def _wait_for_expected_disagg_worker_ids(
 @pytest.mark.timeout(120)
 def test_mocker_disagg_startup_lifecycle(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
     monkeypatch,
     startup_order,
@@ -1188,7 +1176,7 @@ def test_mocker_disagg_startup_lifecycle(
 @pytest.mark.timeout(180)  # bumped for xdist contention (was 59s; ~19.51s serial avg)
 def test_router_decisions_disagg(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
     enable_disagg_bootstrap,
 ):
@@ -1200,7 +1188,7 @@ def test_router_decisions_disagg(
     Parameterized with and without bootstrap rendezvous. Startup lifecycle
     ordering is covered separately by ``test_mocker_disagg_startup_lifecycle``.
     """
-    # runtime_services_dynamic_ports handles NATS and etcd startup
+    # Session services are safe because this test uses a unique namespace.
     logger.info(
         "Starting disaggregated router prefix reuse test "
         f"(bootstrap={enable_disagg_bootstrap})"
@@ -1240,7 +1228,7 @@ def test_router_decisions_disagg(
 @pytest.mark.timeout(120)
 def test_mocker_disagg_router_overload_529(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
     monkeypatch,
     overload_case,
@@ -1295,13 +1283,13 @@ def test_mocker_disagg_router_overload_529(
 @pytest.mark.timeout(180)
 def test_disagg_topology_required_prefill_pin_match_and_mismatch(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
     tmp_path,
 ):
     """Validate required KV-transfer topology policy from pinned prefill workers."""
     logger.info("Starting disaggregated topology-aware prefill pin test")
-    _ = (runtime_services_dynamic_ports, predownload_tokenizers)
+    _ = (runtime_services_session, predownload_tokenizers)
 
     namespace_suffix = generate_random_suffix()
     shared_namespace = f"test-namespace-{namespace_suffix}"
@@ -1385,7 +1373,7 @@ def test_disagg_topology_required_prefill_pin_match_and_mismatch(
 @pytest.mark.timeout(180)
 def test_router_decisions_disagg_round_robin_prefill_dp_rank(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
     enable_disagg_bootstrap,
 ):
@@ -1436,7 +1424,7 @@ def test_router_decisions_disagg_round_robin_prefill_dp_rank(
 @pytest.mark.timeout(180)
 def test_disagg_per_role_router_modes(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
 ):
     """KV-routed prefill in front of round-robin decode, via per-role MDC config.
@@ -1478,7 +1466,7 @@ def test_disagg_per_role_router_modes(
 @pytest.mark.timeout(180)
 def test_disagg_per_role_session_affinity(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
 ):
     """Session affinity is configured per hop: prefill pins, decode does not.
@@ -1523,7 +1511,7 @@ def test_disagg_per_role_session_affinity(
 @pytest.mark.timeout(180)
 def test_router_decisions_disagg_router_aic(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
 ):
     """Validate disagg KV-router decisions with router-side AIC enabled on the default startup path."""
@@ -1564,7 +1552,7 @@ def test_router_decisions_disagg_router_aic(
 @pytest.mark.timeout(120)  # bumped for xdist contention (was 39s; ~12.84s serial avg)
 def test_busy_threshold_endpoint(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
     request_plane,
 ):
@@ -1577,7 +1565,7 @@ def test_busy_threshold_endpoint(
 
     For now, this test only verifies the endpoint is accessible and returns valid responses.
     """
-    # runtime_services_dynamic_ports handles NATS and etcd startup
+    # Session services are safe because MockerProcess uses a unique namespace.
     logger.info(
         f"Starting busy_threshold endpoint test with request_plane={request_plane}"
     )
@@ -1611,7 +1599,7 @@ def test_busy_threshold_endpoint(
 @pytest.mark.timeout(180)
 def test_disagg_direct_mode_epp_headers(
     request,
-    runtime_services_dynamic_ports,
+    runtime_services_session,
     predownload_tokenizers,
 ):
     """E2E: disaggregated serving with Direct routing mode (simulating GAIE EPP).
@@ -1658,8 +1646,10 @@ def test_disagg_direct_mode_epp_headers(
 
 def test_router_per_worker_config(
     request,
-    runtime_services_dynamic_ports,
-    file_storage_backend,
+    runtime_services_session,
+    predownload_tokenizers,
+    tmp_path,
+    monkeypatch,
 ):
     """Test that per-worker RouterConfig(DeviceAwareWeighted) overrides the frontend's
     global round-robin mode. GPU worker receives all requests; CPU worker receives none.
@@ -1671,7 +1661,12 @@ def test_router_per_worker_config(
     """
     logger.info("Starting per-worker router config override test")
 
-    with CounterWorkerProcess(request) as workers:
+    # Keep one focused file-discovery E2E without the flaky multi-frontend file
+    # cross-products removed from the broader router scenarios above. A pytest
+    # temp path survives function teardown, unlike TemporaryDirectory, so any
+    # asynchronously shutting-down file-store watcher can finish quietly.
+    monkeypatch.setenv("DYN_FILE_KV", str(tmp_path))
+    with CounterWorkerProcess(request, store_backend="file") as workers:
         frontend_port = allocate_frontend_ports(request, 1)[0]
         _test_router_override_router_config(
             endpoint=workers.endpoint_path,
@@ -1682,6 +1677,7 @@ def test_router_per_worker_config(
             num_requests=5,
             cpu_count_file=workers.cpu_count_file,
             gpu_count_file=workers.gpu_count_file,
+            store_backend="file",
         )
 
 


### PR DESCRIPTION
## Summary

- add a dedicated four-worker CPU router shard instead of serializing router process E2Es in the core lane
- make invocation-scoped NATS and etcd services safe to share across pytest-xdist workers
- cap Dynamo Tokio worker and blocking threads for the router shard
- remove duplicate file/etcd cross-products while retaining focused file-discovery coverage
- split vLLM CPU tests and the profiled GPU pool into concurrent CPU, multimodal-GPU, and non-multimodal-GPU jobs
- preserve the unprofiled GPU fallback while allowing a known-empty optional stage to accept pytest's no-tests exit code
- expose reusable pytest distribution and runtime-thread controls in the shared CI actions

## Why

Router process E2Es were a major CPU CI long pole. Most cases are independently namespaced, but running them under unbounded xdist creates excessive subprocess/thread fan-out. This introduces a bounded, isolated shard and preserves dedicated services for restart-sensitive cases.

The stable vLLM GPU pool takes 28:29 versus SGLang's 18:30 of total GPU pytest. vLLM carries 3.6x the raw profiled GPU work; its final Gemma/video/MM-router chain occupies 13 minutes, or 46% of the makespan. The existing `multimodal` marker provides an exhaustive, disjoint resource shard without dropping coverage: 8 multimodal tests plus 37 non-multimodal tests preserve all 45 selected GPU tests.

The final fixed-head run matched the scheduler replay. The multimodal job passed in 24:14 end to end (8 tests in 19:12 scheduler time), comparable to the 23:37 SGLang reference and below the 25-minute target despite a cold image pull. A prior warm run finished in 23:22. The non-multimodal job passed all 37 tests in 10:58 scheduler time and 14:55 end to end. Its empty sequential fallback returned pytest exit code 5, logged the explicit optional-stage allowance, and completed successfully while remaining enabled for future unprofiled tests. CPU jobs passed on both architectures.

## Validation

- all repository pre-commit hooks passed during commit
- workflow YAML parsing passed
- GitHub Action pin validation passed
- two shared-service router process E2Es passed concurrently with `pytest -n 2 --dist=load` in the exact vLLM CI test container
- exact-container collection confirmed the vLLM partition is exhaustive and disjoint: 8 multimodal + 37 non-multimodal = 45 tests
- fixed-head CI: [multimodal](https://github.com/ai-dynamo/dynamo/actions/runs/33236499900/job/99059998003) passed in 24:14, with 8/8 profiled tests passing in 19:12
- fixed-head CI: [non-multimodal](https://github.com/ai-dynamo/dynamo/actions/runs/33236499900/job/99059997983) passed in 14:55, with 37/37 profiled tests passing in 10:58 and the optional empty fallback succeeding
- fixed-head CI: CPU jobs passed 1,441 tests + 10 skips on [amd64](https://github.com/ai-dynamo/dynamo/actions/runs/33236499900/job/99059998006) and [arm64](https://github.com/ai-dynamo/dynamo/actions/runs/33236499900/job/99059998012)
- `git diff --check origin/main...HEAD` passed
