### PR TITLE
fix(operator): stop injecting the removed DYN_VLLM_KV_EVENT_PORT

### DIFF
--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -643,6 +643,9 @@ func TestBuildFailoverPod_EngineEnvVars(t *testing.T) {
 		assert.False(t, hasOldHealth, "engine-%d should not have DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS", i)
 		_, hasHealthCheck := env["DYN_HEALTH_CHECK_ENABLED"]
 		assert.False(t, hasHealthCheck, "engine-%d should not have DYN_HEALTH_CHECK_ENABLED", i)
+		// vLLM stopped reading this in #7591; setting it staggers nothing.
+		_, hasKVEventPort := env["DYN_VLLM_KV_EVENT_PORT"]
+		assert.False(t, hasKVEventPort, "engine-%d should not have DYN_VLLM_KV_EVENT_PORT", i)
 	}
 }
 

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -643,7 +643,6 @@ func TestBuildFailoverPod_EngineEnvVars(t *testing.T) {
 		assert.False(t, hasOldHealth, "engine-%d should not have DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS", i)
 		_, hasHealthCheck := env["DYN_HEALTH_CHECK_ENABLED"]
 		assert.False(t, hasHealthCheck, "engine-%d should not have DYN_HEALTH_CHECK_ENABLED", i)
-		// vLLM stopped reading this in #7591; setting it staggers nothing.
 		_, hasKVEventPort := env["DYN_VLLM_KV_EVENT_PORT"]
 		assert.False(t, hasKVEventPort, "engine-%d should not have DYN_VLLM_KV_EVENT_PORT", i)
 	}

--- a/deploy/operator/internal/dynamo/failover_vllm.go
+++ b/deploy/operator/internal/dynamo/failover_vllm.go
@@ -18,8 +18,10 @@ const (
 )
 
 // applyVLLMOverrides injects vLLM-specific env vars into all engine containers.
-// Port staggering (NIXL side channel, KV event, master port) prevents collisions
-// between engines sharing the same pod network namespace.
+// Port staggering (NIXL side channel, master port) prevents collisions between
+// engines sharing the same pod network namespace. The KV event port is not
+// staggered here: vLLM takes it from --kv-events-config, which the operator
+// does not set.
 // For multinode deployments, it also injects NNODES so engines know the group size.
 func applyVLLMOverrides(podSpec *corev1.PodSpec, numberOfNodes int32) {
 	for i := range podSpec.Containers {
@@ -33,7 +35,6 @@ func applyVLLMOverrides(podSpec *corev1.PodSpec, numberOfNodes int32) {
 		c.Env = append(c.Env,
 			corev1.EnvVar{Name: "DYN_VLLM_GMS_SHADOW_MODE", Value: "true"},
 			corev1.EnvVar{Name: "VLLM_NIXL_SIDE_CHANNEL_PORT", Value: strconv.Itoa(5600 + engineID)},
-			corev1.EnvVar{Name: "DYN_VLLM_KV_EVENT_PORT", Value: strconv.Itoa(20080 + engineID)},
 		)
 
 		// Stagger --master-port for TP so each engine group uses a distinct


### PR DESCRIPTION
## Summary

`applyVLLMOverrides` staggers three ports per engine so that engines sharing a pod network namespace do not collide:

```go
corev1.EnvVar{Name: "DYN_VLLM_GMS_SHADOW_MODE", Value: "true"},
corev1.EnvVar{Name: "VLLM_NIXL_SIDE_CHANNEL_PORT", Value: strconv.Itoa(5600 + engineID)},
corev1.EnvVar{Name: "DYN_VLLM_KV_EVENT_PORT", Value: strconv.Itoa(20080 + engineID)},
```

Two of them work. The third does nothing.

`DYN_VLLM_KV_EVENT_PORT` was removed in #7591. The deprecations page states it directly:

> **vLLM Auto-Enable KV Events Removed** (#7591): the deprecated automatic KV-events config in vLLM is removed; the `DYN_VLLM_KV_EVENT_PORT` env var is also no longer supported.
> **Migrate:** Replace `DYN_VLLM_KV_EVENT_PORT` env var with the CLI flag.

Nothing under `lib/` or `components/src/` reads it. vLLM now takes its endpoint from `--kv-events-config`, via `create_kv_events_config` in `components/src/dynamo/vllm/args.py`, which returns `None` unless the user supplies that flag. The operator does not set it, so the injected value is discarded.

The effect is only on the comment's promise, not on behaviour: the KV event port is not staggered, and setting this variable was never going to stagger it. This removes the dead injection and says as much in the comment, so the next reader does not have to re-derive that two of the three staggers are real.

**What this does not do.** If an operator-managed pod does pass `--kv-events-config`, both engines inherit the same endpoint and would still collide on that port. Staggering it properly means rewriting the endpoint inside the user's flag per engine, the way `staggerMasterPort` already rewrites `--master-port`. That is a behaviour change rather than a deletion, so I have not folded it in here. Happy to write it as a follow-up if you want it.

## Validation

`go test ./internal/...` in `deploy/operator`: **37 packages ok**.

The assertion goes in the existing "Removed env vars should not be present" block in `TestBuildFailoverPod_EngineEnvVars`, next to the two vars already checked that way. It fails with the injection restored and the test kept:

```
--- FAIL: TestBuildFailoverPod_EngineEnvVars
    Messages: engine-0 should not have DYN_VLLM_KV_EVENT_PORT
    Messages: engine-1 should not have DYN_VLLM_KV_EVENT_PORT
```

and passes with the change.

Not verified here: no cluster, so this is the pod spec as built by `buildFailoverPod`, not an observed failover.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated vLLM failover configuration to source KV event ports from the KV events configuration.
  * Removed the obsolete KV event port environment variable from generated engine containers.
  * Preserved existing NIXL side-channel and master-port handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->