### PR TITLE
fix(vllm): stop DYN_VLLM_KV_EVENT_PORT being silently ignored

### DIFF
--- a/examples/backends/vllm/launch/disagg_flexkv.sh
+++ b/examples/backends/vllm/launch/disagg_flexkv.sh
@@ -30,7 +30,7 @@ CUDA_VISIBLE_DEVICES=1 \
   --disaggregation-mode prefill \
   --disable-hybrid-kv-cache-manager \
   --kv-transfer-config '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}' \
-  --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}' &
+  --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${DYN_VLLM_KV_EVENT_PORT:-20081}\",\"enable_kv_cache_events\":true}" &
 
 # Exit on first worker failure; kill 0 in the EXIT trap tears down the rest
 wait_any_exit

--- a/examples/backends/vllm/launch/disagg_flexkv.sh
+++ b/examples/backends/vllm/launch/disagg_flexkv.sh
@@ -6,6 +6,11 @@ trap 'echo Cleaning up...; kill 0' EXIT
 
 MODEL="Qwen/Qwen3-0.6B"
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+# Resolve once. The assignment on the prefill worker below only reaches that
+# process's environment, while the endpoint in --kv-events-config is expanded by
+# this shell first, so defaulting separately in each place lets an
+# operator-supplied port land in one and not the other.
+KV_EVENT_PORT="${DYN_VLLM_KV_EVENT_PORT:-20081}"
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "$SCRIPT_DIR/../../../common/launch_utils.sh"
 
@@ -20,7 +25,7 @@ python -m dynamo.frontend &
 CUDA_VISIBLE_DEVICES=0 python -m dynamo.vllm --model $MODEL --disaggregation-mode decode --disable-hybrid-kv-cache-manager --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' &
 
 # Run prefill worker with FlexKV
-DYN_VLLM_KV_EVENT_PORT=20081 \
+DYN_VLLM_KV_EVENT_PORT=$KV_EVENT_PORT \
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 DYNAMO_USE_FLEXKV=1 \
 FLEXKV_CPU_CACHE_GB=32 \
@@ -30,7 +35,7 @@ CUDA_VISIBLE_DEVICES=1 \
   --disaggregation-mode prefill \
   --disable-hybrid-kv-cache-manager \
   --kv-transfer-config '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}' \
-  --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${DYN_VLLM_KV_EVENT_PORT:-20081}\",\"enable_kv_cache_events\":true}" &
+  --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${KV_EVENT_PORT}\",\"enable_kv_cache_events\":true}" &
 
 # Exit on first worker failure; kill 0 in the EXIT trap tears down the rest
 wait_any_exit

--- a/recipes/qwen3-vl-32b-fp8/vllm/hetero_hardware_disagg/deploy.yaml
+++ b/recipes/qwen3-vl-32b-fp8/vllm/hetero_hardware_disagg/deploy.yaml
@@ -147,8 +147,6 @@ spec:
               value: /opt/models
             - name: DYN_VLLM_EMBEDDING_TRANSFER_MODE
               value: "nixl-read"
-            - name: DYN_VLLM_KV_EVENT_PORT
-              value: "20080"
             - name: ENABLE_ENCODER_CACHE
               value: "0"
             - name: VLLM_NIXL_SIDE_CHANNEL_PORT


### PR DESCRIPTION
## Summary

`DYN_VLLM_KV_EVENT_PORT` is set in two places where nothing reads it. vLLM stopped honouring the variable directly in #7591; it now takes the endpoint from `--kv-events-config`, and `create_kv_events_config` returns `None` unless that flag is present.

**`examples/backends/vllm/launch/disagg_flexkv.sh`** exports it and then hardcodes the same port in the flag:

```bash
DYN_VLLM_KV_EVENT_PORT=20081 \
...
  --kv-events-config '{... "endpoint":"tcp://*:20081" ...}' &
```

so setting the variable does nothing. Its sibling `disagg_same_gpu.sh` already does it correctly:

```bash
--kv-events-config "{... \"endpoint\":\"tcp://*:${DYN_VLLM_KV_EVENT_PORT:-20081}\" ...}"
```

and `docs/fern/pages/recipes/cli-templates/vllm.mdx` lists the variable as configurable for these templates. This makes the two scripts agree, so the documented knob works in both.

**`recipes/qwen3-vl-32b-fp8/vllm/hetero_hardware_disagg/deploy.yaml`** sets it as a pod env var and contains no `--kv-events-config` anywhere, so it is inert. Removed, rather than leaving something that reads as configuration.

**One thing worth a maintainer's eye, which I have not changed.** That recipe now publishes no KV events at all, which is what it already did; removing the variable only makes that visible. 45 recipes under `recipes/` do pass `--kv-events-config`, and this is a disaggregated deployment with a `Frontend`, so the omission may be an oversight rather than a choice. Adding the flag is a behaviour change on a deployment I cannot run, so I have not guessed at it. Happy to add it if that was the intent.

Related: #14005 removes the same dead variable from the operator's vLLM failover path.

## Validation

Shell change verified by expansion rather than by inspection:

```
DYN_VLLM_KV_EVENT_PORT=29999 -> {"endpoint":"tcp://*:29999"}
unset                        -> {"endpoint":"tcp://*:20081"}
```

so the override is honoured and the previous default is preserved when it is unset. `bash -n` clean.

Recipe change: YAML still parses, and the variable is gone from the file.

`pre-commit run --files` on both: one failure, `pytest-marker-report`, which fails the same way on a clean tree in my environment because `tqdm` is missing from that hook's isolated venv. Unrelated to this diff, which touches no Python.

Not verified here: no GPU and no cluster, so neither the script nor the recipe was executed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the prefill worker’s KV-events port through an environment variable, with port 20081 retained as the default.
* **Bug Fixes**
  * Simplified NVIDIA GPU decode worker configuration by removing an unnecessary KV-events port setting, improving consistency across deployment setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->