### PR TITLE
fix(kvbm): fall back to the default leader ZMQ port on a blank or invalid value

### DIFF
--- a/lib/bindings/kvbm/python/kvbm/trtllm_integration/connector/kvbm_connector_leader.py
+++ b/lib/bindings/kvbm/python/kvbm/trtllm_integration/connector/kvbm_connector_leader.py
@@ -11,7 +11,12 @@ from kvbm.trtllm_integration.consolidator_config import get_consolidator_mode, i
 from kvbm.trtllm_integration.rust import KvbmRequest
 from kvbm.trtllm_integration.rust import KvConnectorLeader as RustKvConnectorLeader
 from kvbm.trtllm_integration.rust import SchedulerOutput as RustSchedulerOutput
-from kvbm.utils import is_dyn_runtime_enabled, nvtx_annotate
+from kvbm.utils import (
+    DEFAULT_LEADER_ZMQ_PUB_PORT,
+    get_port_from_env,
+    is_dyn_runtime_enabled,
+    nvtx_annotate,
+)
 from tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector import (
     KvCacheConnectorScheduler,
     SchedulerOutput,
@@ -67,11 +72,11 @@ class DynamoKVBMConnectorLeader(KvCacheConnectorScheduler):
                     port_num = int(zmq_port)
                     trtllm_ep = f"tcp://127.0.0.1:{port_num}"
                     # Calculate consolidator output endpoint
-                    # Derive from KVBM leader port (default 56001) + 1000 offset
-                    kvbm_pub_port_str = os.getenv(
-                        "DYN_KVBM_LEADER_ZMQ_PUB_PORT", "56001"
+                    # Derive from KVBM leader port + 1000 offset
+                    kvbm_pub_port = get_port_from_env(
+                        "DYN_KVBM_LEADER_ZMQ_PUB_PORT",
+                        DEFAULT_LEADER_ZMQ_PUB_PORT,
                     )
-                    kvbm_pub_port = int(kvbm_pub_port_str)
                     # Use 1000 as the offset. This needs to be aligned with the offset used in the consolidator config.
                     consolidator_port_offset = 1000
                     output_port = kvbm_pub_port + consolidator_port_offset

--- a/lib/bindings/kvbm/python/kvbm/trtllm_integration/connector/kvbm_connector_leader.py
+++ b/lib/bindings/kvbm/python/kvbm/trtllm_integration/connector/kvbm_connector_leader.py
@@ -11,12 +11,7 @@ from kvbm.trtllm_integration.consolidator_config import get_consolidator_mode, i
 from kvbm.trtllm_integration.rust import KvbmRequest
 from kvbm.trtllm_integration.rust import KvConnectorLeader as RustKvConnectorLeader
 from kvbm.trtllm_integration.rust import SchedulerOutput as RustSchedulerOutput
-from kvbm.utils import (
-    DEFAULT_LEADER_ZMQ_PUB_PORT,
-    get_port_from_env,
-    is_dyn_runtime_enabled,
-    nvtx_annotate,
-)
+from kvbm.utils import derive_consolidator_port, is_dyn_runtime_enabled, nvtx_annotate
 from tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector import (
     KvCacheConnectorScheduler,
     SchedulerOutput,
@@ -71,15 +66,7 @@ class DynamoKVBMConnectorLeader(KvCacheConnectorScheduler):
                 try:
                     port_num = int(zmq_port)
                     trtllm_ep = f"tcp://127.0.0.1:{port_num}"
-                    # Calculate consolidator output endpoint
-                    # Derive from KVBM leader port + 1000 offset
-                    kvbm_pub_port = get_port_from_env(
-                        "DYN_KVBM_LEADER_ZMQ_PUB_PORT",
-                        DEFAULT_LEADER_ZMQ_PUB_PORT,
-                    )
-                    # Use 1000 as the offset. This needs to be aligned with the offset used in the consolidator config.
-                    consolidator_port_offset = 1000
-                    output_port = kvbm_pub_port + consolidator_port_offset
+                    kvbm_pub_port, output_port = derive_consolidator_port()
                     consolidator_output_ep = f"tcp://0.0.0.0:{output_port}"
 
                     logger.info(

--- a/lib/bindings/kvbm/python/kvbm/trtllm_integration/consolidator_config.py
+++ b/lib/bindings/kvbm/python/kvbm/trtllm_integration/consolidator_config.py
@@ -8,7 +8,12 @@ Helper functions for KV Event Consolidator configuration for TensorRT-LLM.
 import logging
 import os
 
-from kvbm.utils import get_consolidator_mode, is_truthy
+from kvbm.utils import (
+    DEFAULT_LEADER_ZMQ_PUB_PORT,
+    get_consolidator_mode,
+    get_port_from_env,
+    is_truthy,
+)
 
 __all__ = [
     "get_consolidator_endpoints",
@@ -96,9 +101,10 @@ def get_consolidator_endpoints() -> tuple[str, str, str]:
     Returns:
         Tuple of (trtllm_endpoint, output_bind_endpoint, output_connect_endpoint)
     """
-    # Get KVBM leader ZMQ pub port (default 56001, matching vLLM)
-    kvbm_pub_port_str = os.getenv("DYN_KVBM_LEADER_ZMQ_PUB_PORT", "56001")
-    kvbm_pub_port = int(kvbm_pub_port_str)
+    # Get KVBM leader ZMQ pub port (matching vLLM)
+    kvbm_pub_port = get_port_from_env(
+        "DYN_KVBM_LEADER_ZMQ_PUB_PORT", DEFAULT_LEADER_ZMQ_PUB_PORT
+    )
 
     # Check for explicit TRTLLM port override
     trtllm_port_env = os.getenv("DYN_KVBM_TRTLLM_ZMQ_PORT")

--- a/lib/bindings/kvbm/python/kvbm/utils.py
+++ b/lib/bindings/kvbm/python/kvbm/utils.py
@@ -13,6 +13,40 @@ def is_truthy(val: str) -> bool:
     return val.strip().lower() in ("1", "true", "on", "yes")
 
 
+# Keep in sync with DEFAULT_LEADER_ZMQ_PUB_PORT in
+# lib/bindings/kvbm/src/block_manager/distributed/utils.rs.
+DEFAULT_LEADER_ZMQ_PUB_PORT = 56001
+
+
+def get_port_from_env(key: str, default_port: int) -> int:
+    """Return the TCP port configured in ``key``, or ``default_port``.
+
+    Mirrors the Rust reader in
+    ``lib/bindings/kvbm/src/block_manager/distributed/utils.rs``: a value
+    that is unset, blank, or not a port in 1-65535 falls back to the
+    documented default rather than raising. ``os.getenv(key, default)`` is
+    not enough on its own, because a variable that is set but empty yields
+    ``""`` instead of the default.
+    """
+    raw = os.getenv(key, "").strip()
+    if not raw:
+        return default_port
+
+    try:
+        port = int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r. Falling back to %d.", key, raw, default_port)
+        return default_port
+
+    if not 1 <= port <= 65535:
+        logger.warning(
+            "%s=%d is outside 1-65535. Falling back to %d.", key, port, default_port
+        )
+        return default_port
+
+    return port
+
+
 def get_consolidator_mode() -> str:
     """Return the KV event consolidator mode from DYN_KVBM_KV_EVENTS_CONSOLIDATOR_MODE.
 

--- a/lib/bindings/kvbm/python/kvbm/utils.py
+++ b/lib/bindings/kvbm/python/kvbm/utils.py
@@ -47,6 +47,33 @@ def get_port_from_env(key: str, default_port: int) -> int:
     return port
 
 
+CONSOLIDATOR_PORT_OFFSET = 1000
+
+
+def derive_consolidator_port() -> tuple[int, int]:
+    """The KVBM leader pub port and the consolidator output port derived from it.
+
+    Both integrations derive the same pair with the same offset, so it lives
+    here. Keeping two copies in step by comment is what let the TRT-LLM path
+    ship without the range check the vLLM path already had.
+
+    Raises:
+        ValueError: the derived port is above 65535. ``get_port_from_env``
+                    accepts any base in 1-65535, so a base above 64535 passes
+                    it and then overflows the offset.
+    """
+    base = get_port_from_env(
+        "DYN_KVBM_LEADER_ZMQ_PUB_PORT", DEFAULT_LEADER_ZMQ_PUB_PORT
+    )
+    output_port = base + CONSOLIDATOR_PORT_OFFSET
+    if output_port > 65535:
+        raise ValueError(
+            f"Derived consolidator port {output_port} exceeds maximum (65535). "
+            f"KVBM port {base} is too high. Use a lower base port."
+        )
+    return base, output_port
+
+
 def get_consolidator_mode() -> str:
     """Return the KV event consolidator mode from DYN_KVBM_KV_EVENTS_CONSOLIDATOR_MODE.
 

--- a/lib/bindings/kvbm/python/kvbm/vllm_integration/consolidator_config.py
+++ b/lib/bindings/kvbm/python/kvbm/vllm_integration/consolidator_config.py
@@ -9,7 +9,12 @@ import logging
 import os
 from typing import Optional, Tuple
 
-from kvbm.utils import get_consolidator_mode, is_truthy
+from kvbm.utils import (
+    DEFAULT_LEADER_ZMQ_PUB_PORT,
+    get_consolidator_mode,
+    get_port_from_env,
+    is_truthy,
+)
 from vllm.distributed.kv_events import ZmqEventPublisher
 
 __all__ = [
@@ -128,10 +133,9 @@ def get_consolidator_endpoints(vllm_config) -> Optional[Tuple[str, str, str]]:
     ).replace("*", "127.0.0.1")
 
     # Derive consolidator port deterministically from KVBM leader ZMQ pub port
-    # Default value (56001) aligns with Rust constant DEFAULT_LEADER_ZMQ_PUB_PORT defined in:
-    # dynamo/lib/bindings/python/rust/llm/block_manager/distributed/utils.rs
-    kvbm_pub_port_str = os.getenv("DYN_KVBM_LEADER_ZMQ_PUB_PORT", "56001")
-    kvbm_pub_port = int(kvbm_pub_port_str)
+    kvbm_pub_port = get_port_from_env(
+        "DYN_KVBM_LEADER_ZMQ_PUB_PORT", DEFAULT_LEADER_ZMQ_PUB_PORT
+    )
 
     # Use 1000 offset to keep ports close together
     # Example: 56001 -> 57001

--- a/lib/bindings/kvbm/python/kvbm/vllm_integration/consolidator_config.py
+++ b/lib/bindings/kvbm/python/kvbm/vllm_integration/consolidator_config.py
@@ -9,12 +9,7 @@ import logging
 import os
 from typing import Optional, Tuple
 
-from kvbm.utils import (
-    DEFAULT_LEADER_ZMQ_PUB_PORT,
-    get_consolidator_mode,
-    get_port_from_env,
-    is_truthy,
-)
+from kvbm.utils import derive_consolidator_port, get_consolidator_mode, is_truthy
 from vllm.distributed.kv_events import ZmqEventPublisher
 
 __all__ = [
@@ -132,22 +127,8 @@ def get_consolidator_endpoints(vllm_config) -> Optional[Tuple[str, str, str]]:
         data_parallel_rank=data_parallel_rank,
     ).replace("*", "127.0.0.1")
 
-    # Derive consolidator port deterministically from KVBM leader ZMQ pub port
-    kvbm_pub_port = get_port_from_env(
-        "DYN_KVBM_LEADER_ZMQ_PUB_PORT", DEFAULT_LEADER_ZMQ_PUB_PORT
-    )
-
-    # Use 1000 offset to keep ports close together
     # Example: 56001 -> 57001
-    consolidator_port_offset = 1000
-    output_port = kvbm_pub_port + consolidator_port_offset
-
-    # Validate the derived port is within valid range
-    if output_port > 65535:
-        raise ValueError(
-            f"Derived consolidator port {output_port} exceeds maximum (65535). "
-            f"KVBM port {kvbm_pub_port} is too high. Use a lower base port."
-        )
+    kvbm_pub_port, output_port = derive_consolidator_port()
 
     # Build bind and connect endpoints
     # Consolidator binds to 0.0.0.0 (all interfaces), clients connect to 127.0.0.1


### PR DESCRIPTION
## Summary

`DYN_KVBM_LEADER_ZMQ_PUB_PORT` is documented in the KVBM configuration
reference as an integer defaulting to `56001`. The Rust reader honors that:
`validated_port_from_env` in `lib/bindings/kvbm/src/block_manager/distributed/utils.rs`
trims the value, treats blank as unset, rejects anything outside 1-65535, and
falls back to `56001` with a warning.

The three Python readers of the same variable called `int()` on the raw value.
`os.getenv(key, default)` does not cover this case: a variable that is *set but
empty* returns `""`, not the default, so a blank value from `export VAR=` or a
manifest that renders an empty string reached `int("")`.

That diverged two ways, neither of them the documented default:

- `vllm_integration/consolidator_config.py` and
  `trtllm_integration/consolidator_config.py` raised an unhandled `ValueError`
  and killed the worker during startup.
- `trtllm_integration/connector/kvbm_connector_leader.py` caught it and
  silently disabled the KV event consolidator, logging only "Invalid port
  value" — the KV events keep flowing unconsolidated, so this degrades routing
  quality without an obvious failure.

Fixed by routing all three call sites through one helper in `kvbm/utils.py`,
next to the existing `get_consolidator_mode`, which already follows the same
read/validate/warn/fall-back shape. The shared `DEFAULT_LEADER_ZMQ_PUB_PORT`
constant replaces the `56001` literal that was repeated at each site.

This also corrects a stale pointer in the vLLM comment, which referenced
`lib/bindings/python/rust/llm/block_manager/distributed/utils.rs`; the Rust
constant now lives at `lib/bindings/kvbm/src/block_manager/distributed/utils.rs`.

## Validation

`kvbm` needs `nixl`, which does not build on this macOS box, so I exercised
`get_consolidator_endpoints` by loading `kvbm/utils.py` and
`trtllm_integration/consolidator_config.py` directly with `importlib`, bypassing
the `nixl`-dependent package `__init__`. Same source files, real function.

Before (source extracted from `upstream/main`):

```
set-but-empty  -> ValueError: invalid literal for int() with base 10: ''
whitespace     -> ValueError: invalid literal for int() with base 10: '  '
garbage        -> ValueError: invalid literal for int() with base 10: 'abc'
```

After:

```
set-but-empty  -> OK tcp://0.0.0.0:57001
whitespace     -> OK tcp://0.0.0.0:57001
garbage        -> OK tcp://0.0.0.0:57001
```

with `Invalid DYN_KVBM_LEADER_ZMQ_PUB_PORT='abc'. Falling back to 56001.`
logged for the third case, and no warning for blank input, matching how the
Rust reader treats blank as unset.

`pre-commit run --files <the four files>` passes every hook except
`pytest-marker-report`, which fails identically on an untouched `README.md`
here (176 collection errors because vLLM/TRT-LLM are not installed); its own
summary reports `Missing sets: 0`.

I did not add a test: the existing `tests/kvbm_integration/test_consolidator_config_unit.py`
guards its imports with `pytest.importorskip("kvbm")`, so a case added there
would skip in my environment and I would be shipping a test I could not run.
Happy to add one if you would rather have the coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration of KVBM leader and consolidator ports across integrations.
  * Invalid, missing, blank, or out-of-range port settings now safely fall back to the default port.
  * Added warnings for invalid numeric port values to make configuration issues easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->