### PR TITLE
fix(ci): stop mis-scheduling gpu_2 tests as single-GPU in the VRAM-aware lane

### DIFF
--- a/examples/backends/vllm/launch/agg_embed_multiworker.sh
+++ b/examples/backends/vllm/launch/agg_embed_multiworker.sh
@@ -82,8 +82,8 @@ SYSTEM_PORT2="${DYN_SYSTEM_PORT2:-8082}"
 # than fall back to two GPUs; hence ``-`` and not ``:-``.
 IFS=',' read -r -a _VISIBLE_GPUS <<< "${CUDA_VISIBLE_DEVICES-0,1}"
 if [ -z "${CUDA_VISIBLE_DEVICES-0,1}" ] || [ "${#_VISIBLE_GPUS[@]}" -lt 2 ]; then
-    echo "ERROR: this script needs 2 GPUs; CUDA_VISIBLE_DEVICES=" \
-         "'${CUDA_VISIBLE_DEVICES:-<unset>}' exposes ${#_VISIBLE_GPUS[@]}." >&2
+    echo "ERROR: this script needs 2 GPUs;" \
+         "CUDA_VISIBLE_DEVICES='${CUDA_VISIBLE_DEVICES-<unset>}' exposes ${#_VISIBLE_GPUS[@]}." >&2
     exit 1
 fi
 WORKER1_GPU="${_VISIBLE_GPUS[0]}"

--- a/examples/backends/vllm/launch/agg_embed_multiworker.sh
+++ b/examples/backends/vllm/launch/agg_embed_multiworker.sh
@@ -14,7 +14,10 @@
 #      name-keyed router (lib/llm/src/discovery/model_manager.rs) should
 #      send each request only to the worker registered for that model.
 #
-# GPUs: 2
+# GPUs: 2 -- the first two devices of the inherited
+#           CUDA_VISIBLE_DEVICES, so a caller that assigns a
+#           specific pair (the VRAM-aware test scheduler does) is
+#           honoured rather than overridden.
 #
 # Usage:
 #   agg_embed_multiworker.sh MODEL1 MODEL2 [EXTRA_DYNAMO_VLLM_ARGS...]
@@ -60,6 +63,32 @@ HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 SYSTEM_PORT1="${DYN_SYSTEM_PORT1:-${DYN_SYSTEM_PORT:-8081}}"
 SYSTEM_PORT2="${DYN_SYSTEM_PORT2:-8082}"
 
+# Pin each worker to one device of the set we were GIVEN, not to a hardcoded
+# 0 and 1.
+#
+# CUDA_VISIBLE_DEVICES is absolute: a child that sets it to "0" gets physical
+# GPU 0, whatever the parent's value was -- the parent's restriction is
+# replaced, not compounded. So hardcoding 0/1 here is only correct while the
+# caller happens to have handed us exactly those two devices. The VRAM-aware
+# test scheduler (tests/utils/pytest_parallel_gpu.py) allocates a gpu_2 test a
+# gang of any two devices on the node and exports them in
+# CUDA_VISIBLE_DEVICES, so on a node with more than two GPUs it can hand us
+# "2,3" -- and hardcoded 0/1 would then run both workers on devices the
+# scheduler has reserved for other tests, silently double-booking their VRAM.
+#
+# Unset means "no restriction" (a manual run on an unrestricted host), which
+# keeps the historical 0,1 behaviour. An explicitly EMPTY value is different --
+# in CUDA it means "no devices at all" -- so it must fail the check below rather
+# than fall back to two GPUs; hence ``-`` and not ``:-``.
+IFS=',' read -r -a _VISIBLE_GPUS <<< "${CUDA_VISIBLE_DEVICES-0,1}"
+if [ -z "${CUDA_VISIBLE_DEVICES-0,1}" ] || [ "${#_VISIBLE_GPUS[@]}" -lt 2 ]; then
+    echo "ERROR: this script needs 2 GPUs; CUDA_VISIBLE_DEVICES=" \
+         "'${CUDA_VISIBLE_DEVICES:-<unset>}' exposes ${#_VISIBLE_GPUS[@]}." >&2
+    exit 1
+fi
+WORKER1_GPU="${_VISIBLE_GPUS[0]}"
+WORKER2_GPU="${_VISIBLE_GPUS[1]}"
+
 print_launch_banner --no-curl "Launching Multi-Worker Embeddings (2 GPUs)" "${MODEL1} + ${MODEL2}" "$HTTP_PORT"
 
 print_curl_footer <<CURL
@@ -68,8 +97,8 @@ print_curl_footer <<CURL
     -d '{"model": "${MODEL1}", "input": "Hello, world!"}'
 
   # Per-worker metrics:
-  curl http://localhost:${SYSTEM_PORT1}/metrics  # worker on GPU 0 (${MODEL1})
-  curl http://localhost:${SYSTEM_PORT2}/metrics  # worker on GPU 1 (${MODEL2})
+  curl http://localhost:${SYSTEM_PORT1}/metrics  # worker on the 1st visible GPU (${MODEL1})
+  curl http://localhost:${SYSTEM_PORT2}/metrics  # worker on the 2nd visible GPU (${MODEL2})
 CURL
 
 # Frontend — same routing layer as the single-worker case; the name-keyed
@@ -112,7 +141,7 @@ common_worker_args=(
 #
 # Endpoint format is ``namespace.component.endpoint`` (dots, not slashes).
 DYN_SYSTEM_ENABLED=true DYN_SYSTEM_PORT=${SYSTEM_PORT1} \
-CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
+CUDA_VISIBLE_DEVICES="${WORKER1_GPU}" python3 -m dynamo.vllm \
     --model "$MODEL1" \
     --endpoint embed-worker-1.vllm.generate \
     "${common_worker_args[@]}" \
@@ -120,7 +149,7 @@ CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     "${EXTRA_ARGS[@]}" &
 
 DYN_SYSTEM_ENABLED=true DYN_SYSTEM_PORT=${SYSTEM_PORT2} \
-CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
+CUDA_VISIBLE_DEVICES="${WORKER2_GPU}" python3 -m dynamo.vllm \
     --model "$MODEL2" \
     --endpoint embed-worker-2.vllm.generate \
     "${common_worker_args[@]}" \

--- a/examples/common/gpu_utils.md
+++ b/examples/common/gpu_utils.md
@@ -48,10 +48,18 @@ Instead, we use **absolute KV cache caps**:
 KV cache = budget - weights - activations - overhead. Pool is fixed at startup.
 
 `--kv-cache-memory-bytes` overrides automatic sizing and **skips memory
-profiling** ([PR #21489]). The KV cache is pinned to the exact byte value —
-no profiling race, no CUDAGraph estimation errors, safe for concurrent
-instances ([#10643]). When set, `--gpu-memory-utilization` only affects
-headroom for activations, not KV cache size.
+profiling** ([PR #21489]). The KV cache is pinned to the exact byte value, so
+vLLM's own KV-pool sizing no longer races a concurrent instance's snapshot
+([#10643]) and CUDAGraph estimation errors go away.
+
+It does not make concurrent launches unconditionally safe, and this repo does
+not rely on it for that. vLLM still samples free memory against
+`--gpu-memory-utilization` *before* the byte cap applies (see the note in
+`gpu_utils.sh` on why the fraction is driven to `0.01`), and the parallel test
+scheduler admits against a live NVML reading, which is still climbing during a
+launch's allocation ramp. Pinning the pool removes the engine-internal race
+only. When set, `--gpu-memory-utilization` only affects headroom for
+activations, not KV cache size.
 
 `--max-model-len` caps sequence length. Reducing it is the fastest way to
 cut VRAM when the model fits but KV cache doesn't.

--- a/examples/common/gpu_utils.md
+++ b/examples/common/gpu_utils.md
@@ -127,4 +127,8 @@ minimum passing value, applies a 2x safety factor, outputs pytest markers
 `@pytest.mark.requested_trtllm_kv_tokens(N)`).
 
 **Scheduler** (`pytest_parallel_gpu.py`): reads the markers at runtime and
-sets the env var per-test. See `tests/README.md` for details.
+sets the env var per-test. It also reads the `gpu_N` hardware marker: a
+multi-GPU test is given that many distinct devices atomically, with
+`profiled_vram_gib` treated as the per-device peak and reserved on each of
+them, and `CUDA_VISIBLE_DEVICES` set to the whole set in ascending order.
+See `tests/README.md` for details.

--- a/tests/README.md
+++ b/tests/README.md
@@ -691,6 +691,8 @@ CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
 
 Then pass the variable to each worker: `CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES python3 -m dynamo.vllm ...`. For multi-GPU scripts that assign distinct GPUs per worker, use named env vars with defaults (e.g. `PREFILL_CUDA_VISIBLE_DEVICES="${PREFILL_CUDA_VISIBLE_DEVICES:-0}"`).
 
+> **Multi-GPU scripts must index into the gang, never name absolute devices.** The scheduler hands a `gpu_2` test a gang of *any* two devices -- `2,3` as readily as `0,1` -- in `CUDA_VISIBLE_DEVICES`. A script that writes `CUDA_VISIBLE_DEVICES=0` and `=1` for its two workers therefore lands on devices reserved for other tests and silently double-books their VRAM. Split the inherited value and index it (`IFS=',' read -r -a _GPUS <<< "${CUDA_VISIBLE_DEVICES-0,1}"`, then use `${_GPUS[0]}` / `${_GPUS[1]}`), as `examples/backends/vllm/launch/agg_embed_multiworker.sh` does.
+
 ### Engine-specific mapping
 
 Launch scripts call engine-specific functions from `examples/common/gpu_utils.sh` which check env var overrides and return the appropriate CLI flags:

--- a/tests/README.md
+++ b/tests/README.md
@@ -123,7 +123,7 @@ Markers are required for all tests. They are used for test selection in CI and l
 | Lifecycle [required]    | pre_merge, post_merge, nightly                                   | When the test should run. Aggregate pipeline budgets: pre_merge < 30 min, post_merge < 1 hr, nightly < 3 hr. See [Pipeline Time Budgets](#pipeline-time-budgets). |
 | Test Type [required]    | unit, integration, e2e, benchmark, performance, stress | Nature of the test               |
 | Hardware [required]     | gpu_0, gpu_1, gpu_2, gpu_4, gpu_8, h100                         | Number/type of GPUs required       |
-| VRAM (profiled)         | profiled_vram_gib(N)                                                         | Actual peak VRAM observed by nvidia-smi during profiling (includes CUDA overhead). Used for `--max-vram-gib=N` filtering and GPU-parallel scheduler budget tracking. |
+| VRAM (profiled)         | profiled_vram_gib(N)                                                         | Actual peak VRAM observed by nvidia-smi during profiling (includes CUDA overhead). Used for `--max-vram-gib=N` filtering and GPU-parallel scheduler budget tracking. **Per GPU**: on a multi-GPU test this is the maximum per-device peak, and the scheduler reserves it on every device the test is given. |
 | vLLM KV cache bytes     | requested_vllm_kv_cache_bytes(N)                                             | (vLLM only) Exact KV cache bytes. Sets `_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES` → `--kv-cache-memory-bytes`. Deterministic, parallel-safe. |
 | SGLang KV tokens        | requested_sglang_kv_tokens(N)                                                          | (SGLang only) Max KV cache tokens. Sets `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS` → `--max-total-tokens`. Deterministic, parallel-safe. |
 | SGLang VRAM GiB         | requested_sglang_vram_gib(N)                                                           | (SGLang only) Max VRAM in GiB. For non-text workloads (video/image diffusion) where token-based control doesn't apply. |
@@ -212,7 +212,7 @@ Markers differ by engine:
 - **`requested_trtllm_vram_gib(N)`** — max VRAM in GiB for non-text workloads (video/image diffusion). Sets `_PROFILE_OVERRIDE_TRTLLM_MAX_GPU_TOTAL_BYTES` → `KvCacheConfig.max_gpu_total_bytes` via `--override-engine-args` JSON. Note: diffusion models don't use KV cache, so this parameter may have no effect — `profiled_vram_gib` alone is sufficient for scheduler budget tracking.
 - TRT-LLM requires JSON merging for `--override-engine-args`, handled by `build_trtllm_override_args_with_mem` in `gpu_utils.sh` (separate from `build_vllm_gpu_mem_args` / `build_sglang_gpu_mem_args`).
 
-`--max-vram-gib=N` deselects tests whose `profiled_vram_gib` exceeds N. Tests without a VRAM marker are also deselected (unknown VRAM = unsafe for parallel). To add a test to the pool, profile it with `tests/utils/profile_pytest.py` (see [GPU VRAM Profiler](#gpu-vram-profiler-profile_pytestpy)).
+`--max-vram-gib=N` deselects tests whose `profiled_vram_gib` exceeds N (per GPU -- see [Multi-GPU tests](#multi-gpu-tests)). Tests without a VRAM marker are also deselected (unknown VRAM = unsafe for parallel). To add a test to the pool, profile it with `tests/utils/profile_pytest.py` (see [GPU VRAM Profiler](#gpu-vram-profiler-profile_pytestpy)).
 
 ### GPU-Parallel Execution
 
@@ -259,6 +259,35 @@ GPU parallel: 6 tests, 7 concurrent slots, GPU0 (48 GiB, 43 GiB multi-proc budge
 ...
 =============== 6 passed in 111.00s (1:51) (vs 228s seq, 2.1x) ===============
 ```
+
+#### Multi-GPU tests
+
+The scheduler understands each test's GPU count, taken from its `gpu_N` hardware marker
+(`gpu_1`, `gpu_2`, `gpu_4`, `gpu_8`; a test with none defaults to one GPU). A `gpu_2` test
+is scheduled as a **gang**: two distinct devices reserved atomically, or none at all.
+
+- `profiled_vram_gib(N)` is the **maximum per-device peak**, and `N` is reserved on *every*
+  device the test is given. Asymmetric per-device profiles are not modelled -- profile the
+  heaviest device.
+- `CUDA_VISIBLE_DEVICES` is set to the whole gang in ascending order (`0,1`), so the child's
+  logical device *i* is a stable physical GPU across runs.
+- A gang costs **one** concurrency slot (`-n`), not one per device -- it is a single pytest
+  subprocess.
+- Both the VRAM budget and the live nvidia-smi gate must pass on *every* member, and the
+  vLLM launch stagger applies to every device the gang touches.
+- Single- and multi-GPU tests co-schedule: a `gpu_1` test can pack into the budget left on a
+  card a `gpu_2` test is already using, as long as no device is over-committed.
+- A test that can never fit -- more GPUs than the node has, or a profile larger than any card
+  -- is reported and the run exits non-zero, rather than waiting for memory that is never
+  coming.
+
+```bash
+# Single- and dual-GPU vLLM tests through the same VRAM-aware stage
+python3 -m pytest --max-vram-gib=80 -n auto -m "vllm and (gpu_1 or gpu_2)" tests/serve/
+```
+
+Unprofiled tests (no `profiled_vram_gib`) are deselected from this stage and keep running in
+the sequential one, `gpu_2` included.
 
 ### Lifecycle Marker Note
 Use the marker for the earliest pipeline stage where the test must run (e.g., `@pytest.mark.pre_merge`). This ensures the test is included in that stage and all subsequent ones (e.g., nightly, release), as CI pipelines select tests marked for earlier stages.
@@ -401,7 +430,7 @@ pytest -m "pre_merge and parallel and not (vllm or sglang or trtllm) and gpu_0" 
 pytest -m "pre_merge and not parallel and not (vllm or sglang or trtllm) and gpu_0" -v --tb=short
 ```
 
-> **Parallel vs sequential:** CPU-only tests (`gpu_0`) marked `parallel` run with `pytest-xdist` (`-n auto` or `-n <workers>`, `--dist=loadscope`). GPU tests (`gpu_1`, `gpu_2`, etc.) run sequentially by default, but can run in parallel with `--max-vram-gib=N -n auto` (uses a custom VRAM-aware scheduler, not xdist). See [`.github/actions/pytest/action.yml`](../.github/actions/pytest/action.yml).
+> **Parallel vs sequential:** CPU-only tests (`gpu_0`) marked `parallel` run with `pytest-xdist` (`-n auto` or `-n <workers>`, `--dist=loadscope`). GPU tests (`gpu_1`, `gpu_2`, etc.) run sequentially by default, but profiled ones can run in parallel with `--max-vram-gib=N -n auto` (uses a custom VRAM-aware scheduler, not xdist, which reserves a whole gang of devices for multi-GPU tests -- see [Multi-GPU tests](#multi-gpu-tests)). See [`.github/actions/pytest/action.yml`](../.github/actions/pytest/action.yml).
 
 **Full E2E suite** -- launches engines for every test configuration; slowest, requires GPU and a framework container (typically <30min depending on framework and model):
 ```bash

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -705,7 +705,9 @@ def test_router_decisions_vllm_dp(
     )
 
 
-# The parallel lane reserves one GPU per test; this case requires GPUs 0 and 1.
+# This case needs two GPUs. The parallel lane can reserve a two-GPU gang, but
+# only for tests that declare profiled_vram_gib; this one does not, so it still
+# runs in the sequential stage.
 @pytest.mark.gpu_2
 @pytest.mark.nightly
 @pytest.mark.timeout(600)

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -549,9 +549,9 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 ],
                 timeout_s=600,
                 gpu_marker="gpu_2",
-                # No profiled_vram_gib: multi-GPU scheduling is not supported
-                # in the VRAM-parallel stage yet, so this runs sequentially
-                # if the skip is removed.
+                # No profiled_vram_gib yet: the VRAM-parallel stage schedules
+                # multi-GPU tests, but only profiled ones, so this runs
+                # sequentially until someone profiles it.
                 requested_vllm_kv_cache_bytes=4_318_854_000,
                 # cached_tokens-asserting payload proves MM-aware routing
                 # engaged for LLaVA-1.5 (placeholder-template `<image>` path).
@@ -606,8 +606,9 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 marks=[pytest.mark.nightly],
                 timeout_s=600,
                 gpu_marker="gpu_2",
-                # No profiled_vram_gib: multi-GPU scheduling is not supported
-                # in the VRAM-parallel stage yet, so this runs sequentially.
+                # No profiled_vram_gib yet: the VRAM-parallel stage schedules
+                # multi-GPU tests, but only profiled ones, so this runs
+                # sequentially until someone profiles it.
                 requested_vllm_kv_cache_bytes=4_308_848_000,
                 tests=[
                     MmCase(
@@ -674,9 +675,9 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 ],
                 timeout_s=600,
                 gpu_marker="gpu_2",
-                # No profiled_vram_gib: multi-GPU scheduling is not supported
-                # in the VRAM-parallel stage yet, so this runs sequentially
-                # if the skip is removed.
+                # No profiled_vram_gib yet: the VRAM-parallel stage schedules
+                # multi-GPU tests, but only profiled ones, so this runs
+                # sequentially until someone profiles it.
                 requested_vllm_kv_cache_bytes=4_318_854_000,
                 # cached_tokens-asserting payload proves MM-aware routing
                 # engaged for LLaVA-NeXT (anyres multi-crop processor).

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -9,9 +9,15 @@ Each test gets CUDA_VISIBLE_DEVICES and KV cache overrides
 (_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES / _PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS)
 so the engine allocates only its declared VRAM budget.
 
+A test needing several GPUs (``gpu_2`` and friends) is scheduled as a gang: it
+is given that many distinct devices atomically or none at all, and
+``profiled_vram_gib`` -- the maximum per-device peak -- is reserved on every one
+of them. CUDA_VISIBLE_DEVICES then lists the whole gang in ascending order.
+
 Usage (always via pytest):
     pytest --max-vram-gib=6 -n auto -m "gpu_1 and vllm" tests/serve/
     pytest --max-vram-gib=6 -n 4 -sv -m "gpu_1 and vllm" tests/serve/
+    pytest --max-vram-gib=80 -n auto -m "vllm and (gpu_1 or gpu_2)" tests/serve/
 
 Flags:
     --max-vram-gib=N   Only run tests with profiled_vram_gib <= N
@@ -32,6 +38,7 @@ import sys
 import tempfile
 import threading
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -40,6 +47,7 @@ if _repo_root not in sys.path:
     sys.path.insert(0, _repo_root)
 
 from tests.utils.vram_utils import (  # noqa: E402
+    DEFAULT_GPU_COUNT,
     VRAM_MULTI_PROC_MARGIN,
     auto_worker_count,
     detect_gpus,
@@ -62,8 +70,12 @@ class _TestEntry:
     requested_trtllm_kv_tokens: int | None = None
     requested_trtllm_vram_gib: float | None = None
     skip_reason: str | None = None
+    gpu_count: int = 1
     w_id: int = 0
-    assigned_gpu: int | None = None
+    # The GPUs this test currently holds, ascending. Empty == holds none.
+    # A multi-GPU test owns either all `gpu_count` of them or none: the
+    # scheduler never assigns a partial gang.
+    assigned_gpus: tuple[int, ...] = ()
     retries: int = 0
 
     @property
@@ -139,6 +151,13 @@ def _fmt_req(test: _TestEntry) -> str:
         gib = int(test.requested_vllm_kv_cache_bytes) / (1024**3)
         return f"req_kv={gib:.2f} GiB"
     return "req_kv=None"
+
+
+def _fmt_gpus(gpus: tuple[int, ...]) -> str:
+    """Render an assigned gang for the log: ``GPU3`` or ``GPUs 0,1``."""
+    if len(gpus) == 1:
+        return f"GPU{gpus[0]}"
+    return "GPUs " + ",".join(str(gi) for gi in gpus)
 
 
 _JUNIT_DIR = os.path.join(tempfile.gettempdir(), "gpu_parallel_junit")
@@ -267,6 +286,12 @@ _RETRYABLE_INIT_MARKERS = [
 ]
 _MAX_RETRIES = 3
 
+# vLLM needs a stagger because --gpu-memory-utilization triggers a memory
+# profiling step that snapshots free memory — concurrent launches corrupt each
+# other's snapshots (bug #10643). SGLang uses --max-total-tokens which is
+# deterministic, so no stagger is needed.
+_VLLM_LAUNCH_STAGGER_S = 5.0
+
 
 def _capture_output(pipe, captured: list[str], prefix: str | None = None) -> None:
     """Read all lines from a pipe into `captured`. Runs in a thread.
@@ -331,38 +356,143 @@ def _priority_key(test: _TestEntry) -> tuple[bool, float, float]:
     return (test.profiled_gib > 0, test.est_duration, test.profiled_gib)
 
 
+def _status_lines(
+    now: float,
+    t0: float,
+    gpu_states: dict[int, _GpuState],
+    running: dict[int, _RunningTest],
+    gpu_used_gib: Callable[[int], float],
+) -> list[str]:
+    """Per-GPU status lines for periodic output.
+
+    A test is listed under every GPU of its gang, so a multi-GPU worker shows
+    up on each device it actually occupies instead of appearing to be a
+    single-GPU test parked on one of them.
+
+    Pure apart from ``gpu_used_gib``, which is injected so the caller decides
+    whether that means NVML or a stub.
+    """
+    elapsed = int(now - t0)
+    lines = []
+    for gi in sorted(gpu_states):
+        gs = gpu_states[gi]
+        actual = gpu_used_gib(gi)
+        workers = sorted(
+            w for w, run_info in running.items() if gi in run_info.test.assigned_gpus
+        )
+        wstr = ", ".join(f"w{w}({int(now - running[w].start_time)}s)" for w in workers)
+        part = f"GPU{gi}: {actual:.1f}/{gs.total_gib:.0f} GiB"
+        if wstr:
+            part += f" [{wstr}]"
+        lines.append(f"[elapsed {elapsed}s] {part}")
+    return lines
+
+
+def _reserve_gpus(
+    test: _TestEntry, gpus: tuple[int, ...], gpu_states: dict[int, _GpuState]
+) -> None:
+    """Commit a test onto its gang, charging every device it will occupy.
+
+    ``profiled_vram_gib`` is the maximum per-device peak, so the same figure is
+    reserved on each member, and each member counts one more resident process
+    (the multi-process margin is about CUDA contexts, and a gang puts one
+    context on every GPU it touches).
+    """
+    test.assigned_gpus = tuple(sorted(gpus))
+    for gi in test.assigned_gpus:
+        gpu_states[gi].budget_used += test.profiled_gib
+        gpu_states[gi].running_count += 1
+
+
+def _release_gpus(test: _TestEntry, gpu_states: dict[int, _GpuState]) -> None:
+    """Return every device a test holds, and record that it holds none.
+
+    Idempotent by construction: the second call sees an empty gang and does
+    nothing. Every terminal path -- pass, fail, runtime skip, retry -- goes
+    through here, so a reservation is returned exactly once and no count can be
+    driven negative by a double release.
+    """
+    for gi in test.assigned_gpus:
+        gs = gpu_states[gi]
+        gs.budget_used -= test.profiled_gib
+        gs.running_count -= 1
+    test.assigned_gpus = ()
+
+
+def _unschedulable_reason(
+    test: _TestEntry, gpu_states: dict[int, _GpuState]
+) -> str | None:
+    """Why this test can never run here, or None if some future state fits it.
+
+    Pure, and deliberately independent of live usage: it asks only whether the
+    *hardware* could ever satisfy the request once every other test has
+    finished. That is the state the scheduler reaches whenever nothing is
+    running, so a test that fails this check would otherwise sit in ``pending``
+    forever while the run loop waits for memory that is never coming.
+    """
+    n_gpus = len(gpu_states)
+    if test.gpu_count > n_gpus:
+        return f"needs {test.gpu_count} GPUs, only {n_gpus} available"
+    if test.profiled_gib > 0:
+        big_enough = [
+            gi for gi, gs in gpu_states.items() if gs.total_gib >= test.profiled_gib
+        ]
+        if len(big_enough) < test.gpu_count:
+            return (
+                f"needs {test.gpu_count} GPU(s) of >= {test.profiled_gib:.1f} GiB, "
+                f"only {len(big_enough)} of {n_gpus} that large"
+            )
+    return None
+
+
 def _select_launches(
     pending: list[_TestEntry],
     gpu_states: dict[int, _GpuState],
     actual_free: dict[int, float],
     num_slots: int,
     running_count: int,
-) -> list[tuple[int, int]]:
-    """Pick which pending tests to launch this pass, and on which GPU.
+) -> list[tuple[int, tuple[int, ...]]]:
+    """Pick which pending tests to launch this pass, and on which GPUs.
 
     Pure (no NVML / no subprocesses): the caller passes the live per-GPU budget
     state and the actual free VRAM (from nvidia-smi). ``pending`` must already be
     in scheduling-priority order (VRAM tests by longest est_duration / largest
     VRAM first, zero-VRAM fillers last -- see the sort in ``run_parallel``).
 
-    Returns a list of ``(pending_index, gpu_index)`` to launch now, honoring:
+    Returns a list of ``(pending_index, assigned_gpus)`` to launch now, where
+    ``assigned_gpus`` is the complete ascending device set for that test -- one
+    GPU for a ``gpu_1`` test, ``gpu_count`` distinct GPUs for a gang. Honors:
 
-      * ``num_slots`` -- global cap on concurrently running subprocesses.
+      * ``num_slots`` -- global cap on concurrently running subprocesses. A gang
+        is one subprocess and so costs one slot however many GPUs it holds.
       * Per-GPU VRAM budget with two independent gates (same as before): a test
         fits only if BOTH the reserved-budget sum AND the actual nvidia-smi
         usage leave room under the cap. The cap is the full card for the first
         test on an idle GPU, then ``budget_multi`` once it hosts 2+ (reserving
-        the multi-process margin for CUDA context overhead).
-      * Pairing -- best-fit places each VRAM test on the GPU with the most free
-        budget, so a large test that anchored an empty GPU gets backfilled with
-        smaller tests up to the budget instead of running alone.
-      * Anti-starvation -- when the highest-priority VRAM test does not fit, the
-        GPU where it is closest to fitting is *reserved* for it. Lower-priority
-        tests may still backfill that GPU, but only up to ``cap - required`` so
-        that once the current occupants free, the reserved test is guaranteed to
-        fit (the backfill we add now can never sum past the space it needs).
-        Zero-VRAM fillers bypass the budget gates entirely (they allocate no
-        memory) so transient memory pressure can't strand an otherwise-free slot.
+        the multi-process margin for CUDA context overhead). For a gang, every
+        member must clear both gates on its own -- ``profiled_vram_gib`` is the
+        maximum per-device peak, so the same figure is reserved on each device.
+      * Atomicity -- a gang is placed only when all ``gpu_count`` devices clear
+        every gate, and then all of them are committed together. There is no
+        partial allocation.
+      * Pairing -- best-fit places each VRAM test on the GPU(s) with the most
+        free budget, so a large test that anchored an empty GPU gets backfilled
+        with smaller tests up to the budget instead of running alone.
+      * Anti-starvation -- when a VRAM test does not fit, the GPUs where it is
+        closest to fitting are *reserved* for it. Lower-priority tests may still
+        backfill those GPUs, but only up to ``cap - required`` so that once the
+        current occupants free, the reserved test fits (the backfill we add now
+        can never sum past the space it needs). A gang reserves all
+        ``gpu_count`` devices or none -- headroom held on fewer devices than it
+        needs could never assemble into a launch. Zero-VRAM fillers bypass the
+        budget gates entirely (they allocate no memory) so transient memory
+        pressure can't strand an otherwise-free slot; a zero-VRAM gang still
+        takes its full count of distinct devices, because the count is a
+        visibility requirement, not a memory one.
+
+    Note the reservation is rebuilt on every call, so it bounds backfill within
+    a pass rather than across passes; see ``run_parallel`` for the progress
+    argument this supports.
     """
     tentative = {
         gi: _TentativeGpu(
@@ -372,12 +502,18 @@ def _select_launches(
         )
         for gi, gs in gpu_states.items()
     }
+    # Rank position of each GPU, used as the deterministic tie-break between
+    # equally-good candidates. It is the caller's `gpu_states` ordering rather
+    # than the device number so that a run restricted to, say, GPUs "2,0,1"
+    # keeps picking them in the order it was given -- which is what the
+    # single-GPU best-fit scan did when it kept the first strict maximum.
+    rank = {gi: pos for pos, gi in enumerate(gpu_states)}
     # GPU -> required GiB of a blocked higher-priority VRAM test, and the budget
     # we have since added to that GPU via lower-priority backfill. Backfill is
     # capped at cap - required so the reserved test still fits once occupants free.
     reserved_req: dict[int, float] = {}
     backfill_added: dict[int, float] = {}
-    to_launch: list[tuple[int, int]] = []
+    to_launch: list[tuple[int, tuple[int, ...]]] = []
 
     def _cap(gi: int) -> float:
         # First test on an idle GPU may use the whole card; once it hosts 2+,
@@ -389,18 +525,28 @@ def _select_launches(
         if running_count + len(to_launch) >= num_slots:
             break
 
-        # Zero-VRAM filler: no budget impact, just needs a free slot. Place on
-        # the least-loaded GPU for balance; never reserves and is never blocked.
-        if test.profiled_gib <= 0:
-            gi = min(gpu_states, key=lambda g: tentative[g].count)
-            to_launch.append((idx, gi))
-            tentative[gi].count += 1
+        need = test.gpu_count
+        if need > len(gpu_states):
+            # Impossible on this node. run_parallel rejects these up front, so
+            # reaching here means the caller chose to keep going; skip rather
+            # than let the test block anything.
             continue
 
-        # VRAM test: best-fit on the GPU with the most free budget that passes
-        # both gates and respects any reservation.
-        best_gi: int | None = None
-        best_avail = -1.0
+        # Zero-VRAM filler: no budget impact, just needs a free slot and its
+        # devices. Place on the least-loaded GPUs for balance; never reserves
+        # and is never blocked.
+        if test.profiled_gib <= 0:
+            chosen = sorted(gpu_states, key=lambda g: (tentative[g].count, rank[g]))[
+                :need
+            ]
+            to_launch.append((idx, tuple(sorted(chosen))))
+            for gi in chosen:
+                tentative[gi].count += 1
+            continue
+
+        # VRAM test: collect every GPU that passes all gates on its own, then
+        # best-fit onto the `need` with the most free budget.
+        eligible: list[tuple[int, float]] = []
         for gi, gs in gpu_states.items():
             ts = tentative[gi]
             cap = _cap(gi)
@@ -414,33 +560,34 @@ def _select_launches(
                 backfill_added[gi] + test.profiled_gib > cap - reserved_req[gi]
             ):
                 continue  # would crowd out the reserved higher-priority test
-            if avail > best_avail:
-                best_gi, best_avail = gi, avail
+            eligible.append((gi, avail))
 
-        if best_gi is not None:
-            to_launch.append((idx, best_gi))
-            tentative[best_gi].budget += test.profiled_gib
-            tentative[best_gi].free -= test.profiled_gib
-            tentative[best_gi].count += 1
-            if best_gi in reserved_req:
-                backfill_added[best_gi] += test.profiled_gib
+        if len(eligible) >= need:
+            eligible.sort(key=lambda e: (-e[1], rank[e[0]]))
+            chosen = [gi for gi, _ in eligible[:need]]
+            to_launch.append((idx, tuple(sorted(chosen))))
+            for gi in chosen:
+                tentative[gi].budget += test.profiled_gib
+                tentative[gi].free -= test.profiled_gib
+                tentative[gi].count += 1
+                if gi in reserved_req:
+                    backfill_added[gi] += test.profiled_gib
             continue
 
-        # Blocked: reserve the GPU where this test is closest to fitting (most
-        # free budget), unless that GPU is already held for an even-higher-
-        # priority test. Keep scanning -- smaller tests may still fit elsewhere
-        # or backfill under the reservation, and fillers keep filling slots.
-        cand: int | None = None
-        cand_avail = -1.0
-        for gi in gpu_states:
-            if gi in reserved_req:
-                continue
-            a = _cap(gi) - tentative[gi].budget
-            if a > cand_avail:
-                cand, cand_avail = gi, a
-        if cand is not None:
-            reserved_req[cand] = test.profiled_gib
-            backfill_added[cand] = 0.0
+        # Blocked: reserve the GPUs where this test is closest to fitting (most
+        # free budget), unless they are already held for an even-higher-priority
+        # test. All-or-none -- holding headroom on fewer devices than the test
+        # needs would starve backfill without ever letting the test launch.
+        # Keep scanning -- smaller tests may still fit elsewhere or backfill
+        # under the reservation, and fillers keep filling slots.
+        unreserved = [gi for gi in gpu_states if gi not in reserved_req]
+        if len(unreserved) >= need:
+            unreserved.sort(
+                key=lambda gi: (-(_cap(gi) - tentative[gi].budget), rank[gi])
+            )
+            for gi in unreserved[:need]:
+                reserved_req[gi] = test.profiled_gib
+                backfill_added[gi] = 0.0
 
     return to_launch
 
@@ -518,6 +665,7 @@ def run_parallel(
                 requested_trtllm_kv_tokens=m.get("requested_trtllm_kv_tokens"),
                 requested_trtllm_vram_gib=m.get("requested_trtllm_vram_gib"),
                 skip_reason=m.get("skip_reason"),
+                gpu_count=m.get("gpu_count", DEFAULT_GPU_COUNT),
             )
         )
 
@@ -560,6 +708,27 @@ def run_parallel(
         for t in no_kv:
             _print(f"  {t.name}")
         _print("\nAdd the appropriate marker via profile_pytest.py, " "then rerun.")
+        return 1
+
+    # Reject tests this node can never satisfy, before anything launches.
+    # Without this the run loop would sit in `while pending or running` with
+    # nothing running and nothing launchable, printing "waiting for N GiB free"
+    # until the CI job's timeout killed it. A gang asking for more GPUs than
+    # exist is the new way to reach that state; a test profiled larger than any
+    # card was always able to.
+    impossible = []
+    for t in tests:
+        reason = _unschedulable_reason(t, gpu_states)
+        if reason is not None:
+            impossible.append((t, reason))
+    if impossible:
+        _print(f"\nERROR: {len(impossible)} test(s) cannot be scheduled on this node:")
+        for t, reason in impossible:
+            _print(f"  {t.name}  ({reason})")
+        _print(
+            "\nRun them on a node with enough GPUs, or narrow the selection "
+            "with -m / --max-vram-gib."
+        )
         return 1
 
     # Identify tests in metadata that exceed the VRAM budget
@@ -652,36 +821,17 @@ def run_parallel(
     pending = list(tests)
     running: dict[int, _RunningTest] = {}
     next_status = t0 + 10
-    # vLLM needs a stagger because --gpu-memory-utilization triggers a memory
-    # profiling step that snapshots free memory — concurrent launches corrupt
-    # each other's snapshots (bug #10643). SGLang uses --max-total-tokens
-    # which is deterministic, so no stagger is needed.
-    _VLLM_LAUNCH_STAGGER_S = 5.0
     last_vllm_launch: dict[int, float] = {}  # gpu_index -> monotonic timestamp
 
     def _build_status_lines(now: float) -> list[str]:
-        """Build per-GPU status lines for periodic output."""
-        elapsed = int(now - t0)
-        lines = []
-        for gi in sorted(gpu_states):
-            gs = gpu_states[gi]
-            actual = _get_gpu_used_gib(gi)
-            workers = sorted(
-                w for w, run_info in running.items() if run_info.test.assigned_gpu == gi
-            )
-            wstr = ", ".join(
-                f"w{w}({int(now - running[w].start_time)}s)" for w in workers
-            )
-            part = f"GPU{gi}: {actual:.1f}/{gs.total_gib:.0f} GiB"
-            if wstr:
-                part += f" [{wstr}]"
-            lines.append(f"[elapsed {elapsed}s] {part}")
-        return lines
+        return _status_lines(now, t0, gpu_states, running, _get_gpu_used_gib)
 
     def _launch_test(test: _TestEntry, env_base: dict) -> _RunningTest:
         """Build env, spawn subprocess, start output streamer thread."""
         env = env_base.copy()
-        env["CUDA_VISIBLE_DEVICES"] = str(test.assigned_gpu)
+        # The complete gang, ascending, so the child sees the same device
+        # order on every run and logical device i is a stable physical GPU.
+        env["CUDA_VISIBLE_DEVICES"] = ",".join(str(gi) for gi in test.assigned_gpus)
         if test.requested_sglang_kv_tokens is not None:
             env["_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS"] = str(
                 int(test.requested_sglang_kv_tokens)
@@ -777,7 +927,6 @@ def run_parallel(
                 duration = now - run_info.start_time
                 passed = rc == 0
                 test = run_info.test
-                gi = test.assigned_gpu
 
                 # Detect retryable init errors (profiling race, OOM at startup)
                 if not passed and test.retries < _MAX_RETRIES:
@@ -795,11 +944,8 @@ def run_parallel(
                             f"[w{w_id}] retrying ({test.retries}/{_MAX_RETRIES})"
                             f" — {matched_marker}"
                         )
-                        if gi is not None:
-                            gpu_states[gi].budget_used -= test.profiled_gib
-                            gpu_states[gi].running_count -= 1
+                        _release_gpus(test, gpu_states)
                         del running[w_id]
-                        test.assigned_gpu = None
                         pending.insert(0, test)
                         continue
 
@@ -841,9 +987,7 @@ def run_parallel(
                 else:
                     _print(f"[w{w_id}] {test.name} {status} [{duration:.0f}s]")
 
-                if gi is not None:
-                    gpu_states[gi].budget_used -= test.profiled_gib
-                    gpu_states[gi].running_count -= 1
+                _release_gpus(test, gpu_states)
                 completed.append(
                     _CompletedTest(
                         test=test,
@@ -886,42 +1030,49 @@ def run_parallel(
 
             # Pop from pending in reverse to preserve indices, then reverse
             # back so highest-priority tests launch first.
-            batch: list[_TestEntry] = []
-            for pending_idx, assigned_gpu in reversed(to_launch):
-                entry = pending.pop(pending_idx)
-                entry.assigned_gpu = assigned_gpu
-                batch.append(entry)
+            batch: list[tuple[_TestEntry, tuple[int, ...]]] = []
+            for pending_idx, assigned_gpus in reversed(to_launch):
+                batch.append((pending.pop(pending_idx), assigned_gpus))
             batch.reverse()
 
-            for entry in batch:
+            for entry, assigned_gpus in batch:
                 w_id = entry.w_id
-                gi = entry.assigned_gpu
-                assert gi is not None
                 is_vllm = (
                     entry.requested_vllm_kv_cache_bytes is not None
                     and entry.profiled_gib > 0
                 )
 
-                # Per-GPU vLLM stagger — only between vLLM tests on the
-                # same GPU.  Tests on different GPUs launch simultaneously.
+                # Per-GPU vLLM stagger — only between vLLM tests sharing a
+                # GPU. Tests on disjoint GPUs launch simultaneously. A gang
+                # has to respect the most recent launch on *any* device it is
+                # about to touch, or it would race a test that just started on
+                # one of them.
                 if is_vllm:
-                    last_t = last_vllm_launch.get(gi, 0)
+                    last_t = max(
+                        (last_vllm_launch.get(gi, 0.0) for gi in assigned_gpus),
+                        default=0.0,
+                    )
                     wait = _VLLM_LAUNCH_STAGGER_S - (time.monotonic() - last_t)
                     if wait > 0:
                         time.sleep(wait)
 
-                gpu_states[gi].budget_used += entry.profiled_gib
-                gpu_states[gi].running_count += 1
+                _reserve_gpus(entry, assigned_gpus, gpu_states)
                 run_info = _launch_test(entry, env_base)
                 running[w_id] = run_info
 
                 if is_vllm:
-                    last_vllm_launch[gi] = time.monotonic()
+                    # Stamp every member, so the next launch on any of them
+                    # waits out this test's profiling window too.
+                    stamp = time.monotonic()
+                    for gi in entry.assigned_gpus:
+                        last_vllm_launch[gi] = stamp
 
                 retry_str = f" (retry {entry.retries})" if entry.retries else ""
                 _print(
                     f"[w{w_id}] {entry.name} "
-                    f"(GPU{gi}, profiled={entry.profiled_gib:.1f} GiB, "
+                    f"({_fmt_gpus(entry.assigned_gpus)}, "
+                    f"profiled={entry.profiled_gib:.1f} GiB"
+                    f"{' per GPU' if len(entry.assigned_gpus) > 1 else ''}, "
                     f"{_fmt_req(entry)}) RUNNING{retry_str}"
                 )
 
@@ -941,8 +1092,21 @@ def run_parallel(
             if pending:
                 queued_str = ", ".join(f"w{t.w_id}" for t in pending)
                 if not running:
-                    next_needed = pending[0].profiled_gib
-                    lines[-1] += f" [waiting for {next_needed:.1f} GiB free]"
+                    # Nothing of ours is holding memory, and pre-flight proved
+                    # the budget fits, so the block is live VRAM held outside
+                    # this run rather than anything the scheduler can resolve.
+                    head = pending[0]
+                    need = head.profiled_gib
+                    devices = (
+                        f" on each of {head.gpu_count} GPUs"
+                        if head.gpu_count > 1
+                        else ""
+                    )
+                    lines[-1] += (
+                        f" [stalled: nothing running; w{head.w_id} needs "
+                        f"{need:.1f} GiB{devices} but live GPU memory is held "
+                        f"outside this run]"
+                    )
                 lines[-1] += f" [queued: {queued_str}]"
             for ln in lines:
                 _print(ln)

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -516,8 +516,9 @@ def _select_launches(
       1. at least ``k`` devices have ``r <= budget_multi``, so ``J`` can share a
          card rather than needing one to itself;
       2. at least ``k`` of those are not blocked by memory held outside this
-         run -- reservation placement cannot detect that, so such a gang waits
-         until the neighbour releases it;
+         run; holds prefer the cards that are, so foreign memory delays ``J``
+         only while it leaves fewer than ``k`` usable, and never merely because
+         it sits on a card ``J`` had no need of;
       3. the competing work is VRAM-bearing -- a zero-VRAM filler bypasses the
          budget gates yet still raises ``running_count``, and can hold off a
          gang profiled above ``budget_multi`` for its lifetime;
@@ -533,9 +534,11 @@ def _select_launches(
     members eventually satisfy the gate simultaneously.
 
     Conditions 1-4 are properties of the workload and the hardware, not of this
-    scheduler. Nothing here assumes memory held outside the run ever frees; if it
-    blocks more than ``len(gpu_states) - k`` devices, ``J`` waits, which is
-    correct because it cannot run.
+    scheduler. Nothing here assumes memory held outside the run ever frees: if it
+    leaves fewer than ``k`` devices usable, condition 2 fails and ``J`` waits,
+    which is correct because it cannot run. It waits holding the devices that
+    were usable, so it launches on the pass the neighbour releases rather than
+    re-entering the queue behind the backfill that accumulated meanwhile.
     """
     tentative = {
         gi: _TentativeGpu(
@@ -578,16 +581,37 @@ def _select_launches(
         test that clears pre-flight is never rejected here by a rounding
         difference.
 
-        Live free memory is deliberately NOT consulted. It would have to
+        Live free memory is deliberately not consulted HERE. It would have to
         distinguish memory held by a neighbour on the box, which may never free,
         from our own test overshooting its profile or still ramping, which always
         does -- and ``(total - free) - budget`` cannot tell those apart in either
-        direction. Using it would reject a card that recovers while admitting one
-        that does not, which is worse than not filtering at all. A gang blocked
-        by memory outside this run therefore waits; see the progress conditions
-        on ``_select_launches``.
+        direction. A filter built on it would reject a card that recovers, and a
+        rejection here is permanent by construction.
+
+        That reasoning bars it from the FILTER, not from the ordering. See
+        ``_usable_now``, which consults exactly that quantity to rank candidates
+        the filter has already admitted: a misjudgement there costs a card its
+        place in a list that is rebuilt next pass, never its candidacy.
         """
         return gpu_states[gi].total_gib >= required
+
+    def _usable_now(gi: int, required: float) -> bool:
+        """Could ``gi`` host a member *today*, discounting only what we cannot free?
+
+        ``_can_ever_host`` asks about the card; this asks about the card as it
+        stands. Budget we committed ourselves is excluded from the judgement
+        because our own tests end -- what remains, ``total - free - budget``, is
+        somebody else's and may not. Note the two cancel exactly against this
+        pass's tentative launches, so the answer does not drift as the pass
+        fills.
+
+        A card that fails this is never rejected, only outranked. That is the
+        whole distinction from the filter above: foreign memory is a fact about
+        right now, and the ordering is rebuilt from scratch on every pass.
+        """
+        ts = tentative[gi]
+        foreign_held = max(0.0, gpu_states[gi].total_gib - ts.free - ts.budget)
+        return gpu_states[gi].total_gib - foreign_held >= required
 
     for idx, test in enumerate(pending):
         if running_count + len(to_launch) >= num_slots:
@@ -706,9 +730,36 @@ def _select_launches(
                 gi for gi in unreserved if _can_ever_host(gi, test.profiled_gib)
             ]
         if len(unreserved) >= need:
-            unreserved.sort(
-                key=lambda gi: (-(_cap(gi) - tentative[gi].budget), rank[gi])
-            )
+            if need > 1:
+                # Headroom alone is the wrong key, for the same reason it was the
+                # wrong key before the size filter: an IDLE card scores its whole
+                # capacity, so a card sitting under somebody else's 4.5 GiB still
+                # scores a perfect 10.0 and takes a protector slot off a card
+                # that is genuinely free. Size is permanent and belongs in the
+                # filter; foreign memory is a fact about right now and belongs
+                # here, as a preference, where being wrong costs a card its place
+                # in a list rebuilt next pass rather than its candidacy. Cards
+                # that could host a member today therefore sort ahead of cards
+                # that could not, and headroom breaks ties within each group.
+                #
+                # It cannot manufacture capacity: when fewer than `need` cards
+                # are usable the gang waits, which is correct -- but it holds the
+                # ones that came back, so it launches on the pass they do.
+                req = test.profiled_gib
+
+                def _hold_key(gi: int) -> tuple[bool, float, int]:
+                    return (
+                        not _usable_now(gi, req),
+                        -(_cap(gi) - tentative[gi].budget),
+                        rank[gi],
+                    )
+
+                unreserved.sort(key=_hold_key)
+            else:
+                # gpu_1 keeps the upstream ordering, bit for bit.
+                unreserved.sort(
+                    key=lambda gi: (-(_cap(gi) - tentative[gi].budget), rank[gi])
+                )
             for gi in unreserved[:need]:
                 reserved_req[gi] = test.profiled_gib
                 backfill_added[gi] = 0.0

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -286,10 +286,22 @@ _RETRYABLE_INIT_MARKERS = [
 ]
 _MAX_RETRIES = 3
 
-# vLLM needs a stagger because --gpu-memory-utilization triggers a memory
-# profiling step that snapshots free memory — concurrent launches corrupt each
-# other's snapshots (bug #10643). SGLang uses --max-total-tokens which is
-# deterministic, so no stagger is needed.
+# vLLM launches are staggered for two independent reasons.
+#
+# The primary one is scheduler-level and holds no matter how the engine is
+# configured: profiled_vram_gib is a *peak*, so during a launch's allocation
+# ramp the live NVML reading this module admits against has not settled yet.
+# Launching two engines concurrently lets an admission decision be taken
+# against a card that is still filling. Capping the KV pool does not remove
+# this; it is a property of observing an allocation in flight.
+#
+# The secondary one is engine-internal: when --gpu-memory-utilization drives
+# vLLM's own memory-profiling step, concurrent launches corrupt each other's
+# snapshots (bug #10643). Pinning --kv-cache-memory-bytes removes that second
+# effect, and only that one.
+#
+# SGLang uses --max-total-tokens which is deterministic, so no stagger is
+# needed.
 _VLLM_LAUNCH_STAGGER_S = 5.0
 
 

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -763,10 +763,28 @@ def _select_launches(
                     #     progress until the CI wall-clock kills it. Keeping
                     #     `required` in the line unconditionally is what still
                     #     lets the gang fit the moment the neighbour leaves.
+                    #   * on a device it could NOT take today, the foreign term is
+                    #     dropped -- but the widened line still has to reserve the
+                    #     multi-process margin, because admitting anything at all is
+                    #     what costs the device that margin. With nothing resident,
+                    #     ``_cap`` is the whole card and the device becomes able to
+                    #     host a member as soon as ``foreign <= total_gib - required``.
+                    #     The first admission takes ``running_count`` to 1, ``_cap``
+                    #     falls to ``budget_multi``, and the threshold collapses to
+                    #     ``foreign <= budget_multi - committed - required``. Reserving
+                    #     exactly the forfeited margin floors that at ``total_gib -
+                    #     budget_multi``: the gang can still take the device at any
+                    #     residual foreign hold up to the multi-process margin, which
+                    #     is the guarantee -- and the limit -- of this branch. Dropping
+                    #     the term entirely bought backfill that outlived the device's
+                    #     usefulness; keeping it whole refused every test of every size
+                    #     and stopped the node.
                     committed = ts.budget + test.profiled_gib
                     line = gs.budget_multi - reserved_req[gi]
                     if _usable_now(gi, reserved_req[gi]):
                         line -= _foreign_held(gi)
+                    else:
+                        line -= gs.total_gib - gs.budget_multi
                     if committed > line:
                         continue  # would crowd out the reserved gang
                 elif backfill_added[gi] + test.profiled_gib > cap - reserved_req[gi]:

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -507,12 +507,35 @@ def _select_launches(
         therefore still be held off by fillers. That is pre-existing upstream
         behaviour for ``gpu_1`` and is not addressed here.
 
-    Gang progress guarantee: if a gang passes ``_unschedulable_reason`` and
-    every running test terminates, the gang launches in finite time. Each
-    reserved member's committed budget can only fall to ``budget_multi -
-    required`` and never rise back above it, the pre-reservation occupants all
-    finish, and the gang is scanned before every lower-priority test -- so the
-    ``gpu_count`` members eventually satisfy the gate simultaneously.
+    Gang progress, conditional. Clearing ``_unschedulable_reason`` is NOT
+    sufficient -- that check sees only hardware, and an earlier revision of this
+    code claimed finite-time progress from it alone, which was false. A gang
+    ``J`` needing ``r`` GiB on each of ``k`` devices launches in finite time when
+    all of the following hold for as long as it is queued:
+
+      1. at least ``k`` devices have ``r <= budget_multi``, so ``J`` can share a
+         card rather than needing one to itself;
+      2. at least ``k`` of those are not blocked by memory held outside this
+         run -- reservation placement cannot detect that, so such a gang waits
+         until the neighbour releases it;
+      3. the competing work is VRAM-bearing -- a zero-VRAM filler bypasses the
+         budget gates yet still raises ``running_count``, and can hold off a
+         gang profiled above ``budget_multi`` for its lifetime;
+      4. ``J`` outranks that competing work under ``_priority_key``; a test that
+         is simply lowest-priority against an unbounded stream of higher-priority
+         arrivals is not being starved by backfill, and no reservation applies;
+      5. every test this run launches terminates.
+
+    Given those: each held member's committed budget can only fall to
+    ``budget_multi - required`` and never rise back above it, holds are placed
+    only on devices ``J`` could actually occupy, the pre-hold occupants all
+    finish, and ``J`` is scanned before every lower-priority test -- so the ``k``
+    members eventually satisfy the gate simultaneously.
+
+    Conditions 1-4 are properties of the workload and the hardware, not of this
+    scheduler. Nothing here assumes memory held outside the run ever frees; if it
+    blocks more than ``len(gpu_states) - k`` devices, ``J`` waits, which is
+    correct because it cannot run.
     """
     tentative = {
         gi: _TentativeGpu(
@@ -544,6 +567,27 @@ def _select_launches(
         # reserve the multi-process margin for CUDA context overhead.
         gs = gpu_states[gi]
         return gs.total_gib if tentative[gi].count < 1 else gs.budget_multi
+
+    def _can_ever_host(gi: int, required: float) -> bool:
+        """Could a test needing ``required`` GiB per device ever run on ``gi``?
+
+        Deliberately asks only about the card's physical size, which is exact and
+        permanent: a card smaller than the requirement cannot host the test in
+        any future state, so a hold placed on it is protection that can never be
+        collected. The comparison matches ``_unschedulable_reason`` exactly, so a
+        test that clears pre-flight is never rejected here by a rounding
+        difference.
+
+        Live free memory is deliberately NOT consulted. It would have to
+        distinguish memory held by a neighbour on the box, which may never free,
+        from our own test overshooting its profile or still ramping, which always
+        does -- and ``(total - free) - budget`` cannot tell those apart in either
+        direction. Using it would reject a card that recovers while admitting one
+        that does not, which is worse than not filtering at all. A gang blocked
+        by memory outside this run therefore waits; see the progress conditions
+        on ``_select_launches``.
+        """
+        return gpu_states[gi].total_gib >= required
 
     for idx, test in enumerate(pending):
         if running_count + len(to_launch) >= num_slots:
@@ -636,6 +680,31 @@ def _select_launches(
         # Keep scanning -- smaller tests may still fit elsewhere or backfill
         # under the reservation, and fillers keep filling slots.
         unreserved = [gi for gi in gpu_states if gi not in reserved_req]
+        if need > 1:
+            # A hold is only protection if the gang could actually run there.
+            # Ranked by headroom alone, an IDLE card scores its whole capacity --
+            # often the best score on the node -- even when that capacity is
+            # below what the gang needs, or is already spoken for by a process
+            # outside this run. Such a card wins one of the `need` slots, offers
+            # no path to a launch, and costs the gang a hold on a card that
+            # would have been one; the unprotected card then saturates under the
+            # very backfill this reservation exists to bound.
+            #
+            # There is no fallback to the unfiltered list on purpose. The test
+            # is on physical size, so a card that fails it fails permanently --
+            # holding it could never turn into a launch, which is the whole
+            # defect. Reserving nothing beats reserving something useless, and
+            # `_unschedulable_reason` has already established that the node has
+            # `need` cards large enough; a shortfall here means a
+            # higher-priority test is holding them, which is correct.
+            #
+            # gpu_1 keeps the unfiltered rule: its reservation is a hint, not a
+            # liveness mechanism -- it needs one card to come free and any card
+            # will do -- so filtering there would change upstream behaviour for
+            # no correctness gain.
+            unreserved = [
+                gi for gi in unreserved if _can_ever_host(gi, test.profiled_gib)
+            ]
         if len(unreserved) >= need:
             unreserved.sort(
                 key=lambda gi: (-(_cap(gi) - tentative[gi].budget), rank[gi])

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -479,20 +479,40 @@ def _select_launches(
         free budget, so a large test that anchored an empty GPU gets backfilled
         with smaller tests up to the budget instead of running alone.
       * Anti-starvation -- when a VRAM test does not fit, the GPUs where it is
-        closest to fitting are *reserved* for it. Lower-priority tests may still
-        backfill those GPUs, but only up to ``cap - required`` so that once the
-        current occupants free, the reserved test fits (the backfill we add now
-        can never sum past the space it needs). A gang reserves all
-        ``gpu_count`` devices or none -- headroom held on fewer devices than it
-        needs could never assemble into a launch. Zero-VRAM fillers bypass the
-        budget gates entirely (they allocate no memory) so transient memory
-        pressure can't strand an otherwise-free slot; a zero-VRAM gang still
-        takes its full count of distinct devices, because the count is a
-        visibility requirement, not a memory one.
+        closest to fitting are *reserved* for it, and lower-priority tests are
+        limited in how far they may backfill those GPUs. The limit differs by
+        kind, because the two kinds need different guarantees:
 
-    Note the reservation is rebuilt on every call, so it bounds backfill within
-    a pass rather than across passes; see ``run_parallel`` for the progress
-    argument this supports.
+          - ``gpu_1`` (unchanged from upstream): backfill added *this pass* is
+            capped at ``cap - required``. Rebuilt on every call, so it bounds
+            backfill within a pass rather than across passes. The honest
+            property is finite-workload conditional progress, not starvation
+            freedom -- a single-GPU test only ever needs one card to come free
+            and any card will do, so the creep is survivable in practice.
+          - gangs: the *absolute* committed budget is capped at
+            ``budget_multi - required``. A gang needs headroom on ``gpu_count``
+            cards at the same instant, and a per-pass cap measured against
+            ``_cap`` cannot deliver that -- see the gate itself for why each
+            half matters. This makes per-card headroom monotone, which is what
+            buys the gang a finite wait.
+
+        A gang reserves all ``gpu_count`` devices or none -- headroom held on
+        fewer devices than it needs could never assemble into a launch.
+        Zero-VRAM fillers bypass the budget gates entirely (they allocate no
+        memory) so transient memory pressure can't strand an otherwise-free
+        slot; a zero-VRAM gang still takes its full count of distinct devices,
+        because the count is a visibility requirement, not a memory one. Note
+        that a filler still raises ``running_count``, which drops a card's cap
+        to ``budget_multi``; a test profiled above ``budget_multi`` can
+        therefore still be held off by fillers. That is pre-existing upstream
+        behaviour for ``gpu_1`` and is not addressed here.
+
+    Gang progress guarantee: if a gang passes ``_unschedulable_reason`` and
+    every running test terminates, the gang launches in finite time. Each
+    reserved member's committed budget can only fall to ``budget_multi -
+    required`` and never rise back above it, the pre-reservation occupants all
+    finish, and the gang is scanned before every lower-priority test -- so the
+    ``gpu_count`` members eventually satisfy the gate simultaneously.
     """
     tentative = {
         gi: _TentativeGpu(
@@ -509,10 +529,14 @@ def _select_launches(
     # single-GPU best-fit scan did when it kept the first strict maximum.
     rank = {gi: pos for pos, gi in enumerate(gpu_states)}
     # GPU -> required GiB of a blocked higher-priority VRAM test, and the budget
-    # we have since added to that GPU via lower-priority backfill. Backfill is
-    # capped at cap - required so the reserved test still fits once occupants free.
+    # we have since added to that GPU via lower-priority backfill this pass.
+    # `backfill_added` is only consulted for gpu_1 reservations; gang holds are
+    # gated on absolute committed budget instead (see the gate below).
     reserved_req: dict[int, float] = {}
     backfill_added: dict[int, float] = {}
+    # Subset of `reserved_req` held for a blocked *gang*. Gangs need a stronger
+    # gate than gpu_1 tests do -- see the reservation block below.
+    reserved_gang: set[int] = set()
     to_launch: list[tuple[int, tuple[int, ...]]] = []
 
     def _cap(gi: int) -> float:
@@ -556,10 +580,41 @@ def _select_launches(
             actual_used = gs.total_gib - ts.free
             if actual_used + test.profiled_gib > cap:
                 continue  # actual-usage gate (catches init-time spikes)
-            if gi in reserved_req and (
-                backfill_added[gi] + test.profiled_gib > cap - reserved_req[gi]
-            ):
-                continue  # would crowd out the reserved higher-priority test
+            if gi in reserved_req:
+                if gi in reserved_gang:
+                    # Gang reservations are gated on the ABSOLUTE committed
+                    # budget, in budget_multi units. Both halves are load
+                    # bearing, and the gpu_1 rule below is wrong for a gang in
+                    # both of them:
+                    #   * absolute, not per-pass: `backfill_added` is rebuilt on
+                    #     every call, so a per-pass cap lets committed budget
+                    #     creep upward one pass at a time. A gpu_1 test rides
+                    #     that out -- it needs one card to come free, and any
+                    #     card will do -- but a gang needs headroom on `k` cards
+                    #     at the same instant, and creep means the k never
+                    #     coincide. Gating on `ts.budget` (which starts from
+                    #     gpu_states, i.e. already-committed budget) makes the
+                    #     headroom monotone: once a member drops below the line
+                    #     it cannot be pushed back over it.
+                    #   * budget_multi, not `_cap(gi)`: an IDLE reserved card
+                    #     reports the whole-card cap, which is the cap for
+                    #     whoever lands first -- but the instant a filler lands,
+                    #     the gang's own cap on that card drops to budget_multi.
+                    #     Gating on `_cap` therefore over-grants by exactly
+                    #     VRAM_MULTI_PROC_MARGIN * total_gib and admits a filler
+                    #     that immediately re-blocks the gang; on a card that
+                    #     keeps draining and refilling, forever.
+                    # Together these give the gang a finite wait: every member
+                    # reaches `budget_multi - required` and stays there, so the
+                    # k members eventually hold simultaneously and the gang --
+                    # scanned before every lower-priority test -- launches.
+                    committed = ts.budget + test.profiled_gib
+                    if committed > gs.budget_multi - reserved_req[gi]:
+                        continue  # would crowd out the reserved gang
+                elif backfill_added[gi] + test.profiled_gib > cap - reserved_req[gi]:
+                    # Single-GPU reservation: unchanged per-pass semantics, so
+                    # gpu_1-only scheduling stays bit-identical to upstream.
+                    continue  # would crowd out the reserved higher-priority test
             eligible.append((gi, avail))
 
         if len(eligible) >= need:
@@ -588,6 +643,8 @@ def _select_launches(
             for gi in unreserved[:need]:
                 reserved_req[gi] = test.profiled_gib
                 backfill_added[gi] = 0.0
+                if need > 1:
+                    reserved_gang.add(gi)
 
     return to_launch
 

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -869,7 +869,7 @@ def _select_launches(
                 # ones that came back, so it launches on the pass they do.
                 req = test.profiled_gib
 
-                def _hold_key(gi: int) -> tuple[bool, float, int]:
+                def _hold_key(gi: int, req: float = req) -> tuple[bool, float, int]:
                     return (
                         not _usable_now(gi, req),
                         -(_cap(gi) - tentative[gi].budget),

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -528,10 +528,14 @@ def _select_launches(
       5. every test this run launches terminates.
 
     Given those: each held member's committed budget can only fall to
-    ``budget_multi - required`` and never rise back above it, holds are placed
-    only on devices ``J`` could actually occupy, the pre-hold occupants all
-    finish, and ``J`` is scanned before every lower-priority test -- so the ``k``
-    members eventually satisfy the gate simultaneously.
+    ``budget_multi - foreign - required`` and never rise back above it -- net of
+    memory held outside the run, because that is the quantity ``J``'s own gate
+    is denominated in, and a hold bounding anything else bounds nothing. So any
+    device admitting backfill under a hold is left able to take a member
+    immediately. Holds are placed only on devices ``J`` could actually occupy,
+    the pre-hold occupants all finish, and ``J`` is scanned before every
+    lower-priority test -- so the ``k`` members eventually satisfy the gate
+    simultaneously.
 
     Conditions 1-4 are properties of the workload and the hardware, not of this
     scheduler. Nothing here assumes memory held outside the run ever frees: if it
@@ -595,23 +599,34 @@ def _select_launches(
         """
         return gpu_states[gi].total_gib >= required
 
+    def _foreign_held(gi: int) -> float:
+        """GiB on ``gi`` held by a process outside this run.
+
+        Budget we committed ourselves is excluded because our own tests end --
+        what remains, ``total - free - budget``, is somebody else's and may not.
+        The two terms cancel exactly against this pass's tentative launches, so
+        the answer does not drift as the pass fills.
+
+        Defined once because both users of it must agree: the hold's ranking
+        (which card to protect) and the hold's admission gate (how much to let
+        in beside it). They were denominated differently once, and a hold that
+        bounds a different quantity from the one its gang is gated on bounds
+        nothing.
+        """
+        ts = tentative[gi]
+        return max(0.0, gpu_states[gi].total_gib - ts.free - ts.budget)
+
     def _usable_now(gi: int, required: float) -> bool:
         """Could ``gi`` host a member *today*, discounting only what we cannot free?
 
         ``_can_ever_host`` asks about the card; this asks about the card as it
-        stands. Budget we committed ourselves is excluded from the judgement
-        because our own tests end -- what remains, ``total - free - budget``, is
-        somebody else's and may not. Note the two cancel exactly against this
-        pass's tentative launches, so the answer does not drift as the pass
-        fills.
+        stands.
 
         A card that fails this is never rejected, only outranked. That is the
         whole distinction from the filter above: foreign memory is a fact about
         right now, and the ordering is rebuilt from scratch on every pass.
         """
-        ts = tentative[gi]
-        foreign_held = max(0.0, gpu_states[gi].total_gib - ts.free - ts.budget)
-        return gpu_states[gi].total_gib - foreign_held >= required
+        return gpu_states[gi].total_gib - _foreign_held(gi) >= required
 
     for idx, test in enumerate(pending):
         if running_count + len(to_launch) >= num_slots:
@@ -676,8 +691,26 @@ def _select_launches(
                     # reaches `budget_multi - required` and stays there, so the
                     # k members eventually hold simultaneously and the gang --
                     # scanned before every lower-priority test -- launches.
+                    #   * net of foreign memory, not gross: the gate the GANG
+                    #     must pass counts observed usage (`total - free`),
+                    #     which includes memory held outside this run; this gate
+                    #     counts only what WE committed. The two are the same
+                    #     number only when that foreign hold is zero, and for
+                    #     any F > 0 the difference is a band exactly `required`
+                    #     wide in which a filler clears this gate and then
+                    #     leaves the reserved card unable to host a member. The
+                    #     hold then bounds nothing: every reserved card carries
+                    #     a filler the gang cannot fit beside, and the gang
+                    #     waits for all `k` of them to fall clean on the same
+                    #     pass -- a coincidence whose odds drop geometrically in
+                    #     `gpu_count`. Subtracting it here is safe in a way it
+                    #     would not be in `_can_ever_host`: this is a per-pass
+                    #     admission decision, not a permanent candidacy one, so
+                    #     a card whose neighbour leaves is admitted again on the
+                    #     very next pass.
                     committed = ts.budget + test.profiled_gib
-                    if committed > gs.budget_multi - reserved_req[gi]:
+                    line = gs.budget_multi - _foreign_held(gi) - reserved_req[gi]
+                    if committed > line:
                         continue  # would crowd out the reserved gang
                 elif backfill_added[gi] + test.profiled_gib > cap - reserved_req[gi]:
                     # Single-GPU reservation: unchanged per-pass semantics, so

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -553,12 +553,14 @@ def _select_launches(
     this repo models allocation as instantaneous, so none of them can see the
     window; ``_VLLM_LAUNCH_STAGGER_S`` exists because it is real.
 
-    The term is subtracted only on devices ``J`` could occupy *today*. On a
-    device it could not, ``foreign > total_gib - required`` holds by definition,
-    so the line would be ``budget_multi - foreign - required <
-    budget_multi - total_gib < 0`` for every test of every size -- the device
-    would refuse all backfill while buying ``J`` nothing, since what gates ``J``
-    there is the neighbour retiring, which this run neither owns nor hastens.
+    The foreign term is subtracted only on devices ``J`` could occupy *today*.
+    On a device it could not, subtracting foreign as well would make the line
+    ``budget_multi - foreign - required < budget_multi - total_gib < 0`` for
+    every test of every size -- B1, a whole-node freeze at ``n == gpu_count``.
+    The unusable-card line therefore drops the foreign term but still charges
+    the multi-process margin ``total_gib - budget_multi``, so admitted backfill
+    cannot forfeit the cap drop that the first tenant causes. Residual foreign
+    above that margin is a reachable state; the progress claim does not cover it.
 
     That widening is scoped to condition 1, ``r <= budget_multi``. For a gang
     profiled above ``budget_multi`` the line is ``budget_multi - r < 0`` even on

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -520,8 +520,16 @@ def _select_launches(
          only while it leaves fewer than ``k`` usable, and never merely because
          it sits on a card ``J`` had no need of;
       3. the competing work is VRAM-bearing -- a zero-VRAM filler bypasses the
-         budget gates yet still raises ``running_count``, and can hold off a
-         gang profiled above ``budget_multi`` for its lifetime;
+         budget gates yet still raises ``running_count``, which drops ``_cap``
+         from ``total_gib`` to ``budget_multi`` and can hold off a gang whose
+         ``r`` exceeds ``budget_multi - foreign``. That threshold, not
+         ``budget_multi`` alone, is the real one: a gang profiled strictly
+         *below* ``budget_multi`` is blocked too once foreign memory takes up
+         the difference. Nor is the block bounded by one filler's lifetime --
+         fillers are placed by least load and a drained held card is
+         systematically the least loaded, so the occupancy renews. This
+         limitation is pre-existing and shared with the single-GPU path, which
+         the paragraph below declines to address for the same reason;
       4. ``J`` outranks that competing work under ``_priority_key``; a test that
          is simply lowest-priority against an unbounded stream of higher-priority
          arrivals is not being starved by backfill, and no reservation applies;
@@ -532,7 +540,38 @@ def _select_launches(
     memory held outside the run, because that is the quantity ``J``'s own gate
     is denominated in, and a hold bounding anything else bounds nothing. So any
     device admitting backfill under a hold is left able to take a member
-    immediately. Holds are placed only on devices ``J`` could actually occupy,
+    immediately.
+
+    That statement is exact only once every launched test has allocated what it
+    was profiled at. ``profiled_vram_gib`` is a *peak*, so during a launch's
+    allocation window the live free reading is higher than the settled one,
+    ``_foreign_held`` reads correspondingly lower, and the line sits above its
+    settled value -- admitting a filler the settled line would have refused. The
+    ramp is self-limiting rather than unsound: it loosens ``J``'s own
+    actual-usage gate by the same amount at the same instant, and searches
+    across ramp models found no starvation attributable to it. Every observer in
+    this repo models allocation as instantaneous, so none of them can see the
+    window; ``_VLLM_LAUNCH_STAGGER_S`` exists because it is real.
+
+    The term is subtracted only on devices ``J`` could occupy *today*. On a
+    device it could not, ``foreign > total_gib - required`` holds by definition,
+    so the line would be ``budget_multi - foreign - required <
+    budget_multi - total_gib < 0`` for every test of every size -- the device
+    would refuse all backfill while buying ``J`` nothing, since what gates ``J``
+    there is the neighbour retiring, which this run neither owns nor hastens.
+
+    That widening is scoped to condition 1, ``r <= budget_multi``. For a gang
+    profiled above ``budget_multi`` the line is ``budget_multi - r < 0`` even on
+    a device it could take today, and every backfill test is still refused --
+    correctly, and necessarily: admitting one drives ``running_count`` to 1,
+    which drops ``_cap`` from ``total_gib`` to ``budget_multi``, and a member
+    needing more than ``budget_multi`` can then never fit on that device at all.
+    Such a gang runs only by having a device to itself. The pre-flight admits
+    it (it checks physical size, not the multi-process budget), so the state is
+    reachable; it is outside the progress theorem by condition 1, and outside
+    the work-conservation claim for the same reason.
+
+    Holds are placed only on devices ``J`` could actually occupy,
     the pre-hold occupants all finish, and ``J`` is scanned before every
     lower-priority test -- so the ``k`` members eventually satisfy the gate
     simultaneously.
@@ -708,8 +747,26 @@ def _select_launches(
                     #     admission decision, not a permanent candidacy one, so
                     #     a card whose neighbour leaves is admitted again on the
                     #     very next pass.
+                    #   * the foreign term only where it can buy the gang
+                    #     something. On a card the gang could take today the
+                    #     bound above is exactly tight. On one it could not
+                    #     (`_usable_now` false) we have `foreign > total_gib -
+                    #     required`, so the line is `budget_multi - foreign -
+                    #     required < budget_multi - total_gib < 0` for every
+                    #     test of every size -- the card refuses ALL backfill
+                    #     for as long as the gang is queued. Nothing is bought
+                    #     by that: what gates the gang on such a card is the
+                    #     foreign hold retiring, which this run neither owns nor
+                    #     influences, and holding the card idle does not hasten
+                    #     it. At `n == gpu_count` -- the only topology gangs
+                    #     ship to -- every card is held and the node makes zero
+                    #     progress until the CI wall-clock kills it. Keeping
+                    #     `required` in the line unconditionally is what still
+                    #     lets the gang fit the moment the neighbour leaves.
                     committed = ts.budget + test.profiled_gib
-                    line = gs.budget_multi - _foreign_held(gi) - reserved_req[gi]
+                    line = gs.budget_multi - reserved_req[gi]
+                    if _usable_now(gi, reserved_req[gi]):
+                        line -= _foreign_held(gi)
                     if committed > line:
                         continue  # would crowd out the reserved gang
                 elif backfill_added[gi] + test.profiled_gib > cap - reserved_req[gi]:

--- a/tests/utils/test_pytest_parallel_gpu.py
+++ b/tests/utils/test_pytest_parallel_gpu.py
@@ -2287,6 +2287,131 @@ def test_gang_waits_only_while_foreign_memory_leaves_too_few_usable_cards(frees_
         )
 
 
+def test_a_gang_hold_is_denominated_in_the_units_the_gang_is_gated_in():
+    """A hold must bound backfill by what the gang has to survive, not by our share.
+
+    The hold gate counts only budget WE committed (`ts.budget + profiled <=
+    budget_multi - required`), but the gate the gang must itself pass counts
+    OBSERVED usage (`total - free + required <= cap`), which includes memory
+    held outside this run. The two are the same number only when that foreign
+    hold is zero. For any F > 0 the hold therefore admits backfill sitting
+    exactly in the band the gang cannot survive -- a band `required` wide.
+
+    Two 10 GiB cards (budget_multi 8.5), a gpu_2 gang needing 6.0, 1.0 GiB held
+    on each card from outside the run. GPU0 also carries 3.0 GiB of our own
+    work, so the gang is blocked and holds both cards. A 2.0 GiB filler clears
+    the old gate on GPU1 (0.0 + 2.0 <= 8.5 - 6.0) -- and the moment it lands the
+    gang cannot collect GPU1 either, because 1.0 + 2.0 + 6.0 > 8.5. Observed,
+    as everywhere else in this file, through what the hold refuses.
+    """
+    gpus = {
+        0: _gpu(0, 10.0, budget_used=3.0, running_count=1),
+        1: _gpu(1, 10.0),
+    }
+    # 1.0 GiB on each card belongs to a process outside this run.
+    actual_free = {0: 10.0 - 3.0 - 1.0, 1: 10.0 - 1.0}
+    gang = _t("gang", 6.0, timeout=1800, gpus=2)
+    filler = _t("filler", 2.0, timeout=15.0)
+    assert _unschedulable_reason(gang, gpus) is None
+    # The card is usable in its own right: 1.0 GiB of foreign memory leaves
+    # 9.0 free on a card that needs to fit 6.0, so condition 2 holds and the
+    # gang is squarely inside the domain the progress property claims.
+    assert 10.0 - 1.0 >= gang.profiled_gib
+
+    launches = _select_checked(
+        [gang, filler], gpus, num_slots=8, running_count=1, actual_free=actual_free
+    )
+
+    assert launches == [], (
+        "the hold admitted a filler that leaves the reserved card unable to "
+        "host a member: 1.0 foreign + 2.0 filler + 6.0 gang = 9.0 > 8.5. The "
+        "hold is gated in our-budget units and the gang in observed-usage units"
+    )
+
+
+def test_a_free_reading_that_overshoots_cannot_loosen_a_gang_hold():
+    """The negative clamp on the foreign-hold term is load bearing in the gate.
+
+    `free + budget > total` is a real, ordinary state: a test is launched and
+    charged to the budget before it has allocated anything, so the live reading
+    still shows the card almost empty. `total - free - budget` then goes
+    NEGATIVE, and without the clamp the hold's line reads
+    `budget_multi - (-x) - required` -- wider than the unheld card, so the hold
+    admits MORE the emptier the card looks.
+
+    GPU0 carries 1.0 GiB of budget for a test that has not ramped yet (free
+    still reads the whole 10.0), and GPU1 is too full for a member, so the gang
+    is blocked and holds both. A 2.0 GiB filler must not land on GPU0:
+    1.0 + 2.0 = 3.0 is already past `8.5 - 6.0`. Unclamped the term is -1.0,
+    the line becomes 3.5, and the filler is let in.
+
+    This clamp used to be an equivalent mutant -- reachable only behind
+    `_can_ever_host`, which excludes the regime where it bites. Sharing the term
+    with the admission gate, which sits behind no such filter, made it real.
+    """
+    gpus = {
+        0: _gpu(0, 10.0, budget_used=1.0, running_count=1),
+        1: _gpu(1, 10.0, budget_used=5.0, running_count=1),
+    }
+    # GPU0: charged 1.0 GiB, has allocated none of it yet -> free + budget > total.
+    actual_free = {0: 10.0, 1: 5.0}
+    gang = _t("gang", 6.0, timeout=1800, gpus=2)
+    filler = _t("filler", 2.0, timeout=15.0)
+    assert _unschedulable_reason(gang, gpus) is None
+    assert actual_free[0] + gpus[0].budget_used > gpus[0].total_gib
+
+    launches = _select_checked(
+        [gang, filler], gpus, num_slots=8, running_count=2, actual_free=actual_free
+    )
+
+    assert launches == [], (
+        "an un-ramped test made the card read emptier than empty and widened "
+        "the hold: 1.0 committed + 2.0 filler = 3.0 is past the 2.5 line"
+    )
+
+
+def test_gang_progress_survives_foreign_memory_that_leaves_every_card_usable():
+    """The multi-pass consequence of the gate above, and the reason it matters.
+
+    Identical to `test_blocked_gang_is_not_starved_by_endless_lower_priority_backfill`
+    except that 1.0 GiB is held on every card from outside the run and the
+    backfill durations do not all divide the hog's lifetime -- a single fill
+    duration makes every card fall clean on the same pass, which hides this.
+
+    Every card reads usable (10.0 - 1.0 >= 6.0), so all five progress
+    conditions hold. With the hold gated correctly the gang launches the pass
+    the hog retires. With it gated in our-budget units the hold bounds nothing:
+    each reserved card carries a filler the gang cannot fit beside, the gang
+    needs all of them clean on the same pass, and it waits on a coincidence
+    whose odds fall geometrically in `gpu_count` -- 13 of 16 seeds never
+    launched in 20,000 passes at gpu_count=4.
+    """
+    gpus = {i: _gpu(i, 10.0) for i in range(3)}
+    hogs = [_t(f"hog{i}", 3.0, timeout=127) for i in range(2)]  # est 42 passes
+    gang = _t("gang", 6.0, timeout=90, gpus=3)  # needs every card
+    assert _unschedulable_reason(gang, gpus) is None
+    # Durations 11/13/17/19/23 passes: coprime with each other and with 42, so
+    # the cards drift out of phase and no coincidence is handed to the gang.
+    durations = itertools.cycle([33.0, 39.0, 51.0, 57.0, 69.0])
+
+    started = _drive_passes(
+        gpus,
+        hogs + [gang],
+        backfill=lambda i: _t(f"fill{i}", 2.0, timeout=next(durations)),
+        passes=4000,
+        external_hold={i: 1.0 for i in range(3)},
+    )
+
+    assert "gang" in started, (
+        "gang never launched in 4000 passes while every card was usable and "
+        "lower-priority backfill kept launching -- starved"
+    )
+    assert started["gang"] <= 43, (
+        f"gang launched on pass {started['gang']}, not the pass the hogs "
+        f"retired (42) -- backfill was let in past the hold ahead of it"
+    )
+
+
 def test_a_foreign_blocked_card_never_outranks_a_usable_one_for_a_hold():
     """The ranking, isolated from the multi-pass driver.
 

--- a/tests/utils/test_pytest_parallel_gpu.py
+++ b/tests/utils/test_pytest_parallel_gpu.py
@@ -2752,6 +2752,80 @@ def test_a_hold_survives_foreign_memory_retiring_part_way_rather_than_all_at_onc
     )
 
 
+def test_unusable_card_admits_exactly_the_margin_reserved_line_and_no_more():
+    """Unusable-card admission line is B - r - M, not B - r.
+
+    2 x 80 GiB (B=68, M=12), gang r=40, foreign 45 until pass 60.
+    Cards are unusable (80-45=35 < 40). L_unusable = 68-40-12 = 16.
+
+    Threshold lock:
+      * b = 16.0  is admitted while the gang cannot use the cards.
+      * b = 16.01 is refused.
+
+    b > L_unusable is a reachable scheduler state, not an impossible one.
+    Refusing that filler is expected conservative behavior. Maximal work
+    conservation for b > L_unusable (admit every filler that would still
+    leave room for the gang after F' = 0) is not claimed. When foreign
+    clears, the gang still launches in both cases.
+    """
+
+    def run(fill):
+        gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0)}
+        gang = _t("gang", 40.0, timeout=1800, gpus=2)
+        return _drive_passes(
+            gpus,
+            [gang],
+            backfill=lambda i, f=fill: _t(f"fill{i}", f, timeout=15.0),
+            passes=200,
+            external_hold=lambda now: {0: 45.0, 1: 45.0} if now < 60 else {},
+        )
+
+    at_line = run(16.0)
+    over = run(16.01)
+    early_at = [n for n, at in at_line.items() if n != "gang" and at < 60]
+    early_over = [n for n, at in over.items() if n != "gang" and at < 60]
+    assert early_at, (
+        "16.0 GiB sits on L_unusable=16 and must be admitted while the gang "
+        "cannot use the cards"
+    )
+    assert not early_over, (
+        f"{early_over} launched before pass 60 at b=16.01 > L_unusable=16 — "
+        "expected conservative refusal of filler above the unusable-card line"
+    )
+    assert "gang" in at_line and at_line["gang"] <= 61
+    assert "gang" in over and over["gang"] <= 61
+
+
+def test_known_limitation_residual_above_margin_with_on_line_filler_delays_gang():
+    """F' > M is reachable; progress is not claimed in that region.
+
+    2 x 10 GiB (B=8.5, M=1.5), gang r=6, L_unusable = 8.5-6-1.5 = 1.0.
+    Foreign 4.5 until pass 60, then residual 3.0 (> M). A 1.0 GiB filler is
+    admitted on the line. At pass 60 the empty-card arithmetic T-F'+r = 10
+    would fit the gang; the occupied card reads 3+1+6 against cap 8.5 and
+    does not. The gang waits for the filler.
+
+    This is a known limitation / excluded guarantee region, not a scheduler
+    bug and not an unreachable state. The progress claim assumes residual
+    foreign memory eventually satisfies F' <= M. Pinning the delay here
+    keeps a later observer from mistaking it for an undiscovered regression.
+    """
+    gpus = {0: _gpu(0, 10.0), 1: _gpu(1, 10.0)}
+    gang = _t("gang", 6.0, timeout=1800, gpus=2)
+    started = _drive_passes(
+        gpus,
+        [gang],
+        backfill=lambda i: _t(f"fill{i}", 1.0, timeout=900.0),
+        passes=400,
+        external_hold=lambda now: {0: 4.5, 1: 4.5} if now < 60 else {0: 3.0, 1: 3.0},
+    )
+    assert "gang" in started, "limitation is delay, not a permanent freeze"
+    assert started["gang"] > 60, (
+        f"gang launched on pass {started['gang']}; F'=3.0 > M=1.5 with a 1.0 "
+        "on-line filler is a known limitation outside the progress guarantee"
+    )
+
+
 # --------------------------------------------------------------------------- #
 # the assignment has to survive into the WORKERS, not just be derived
 #

--- a/tests/utils/test_pytest_parallel_gpu.py
+++ b/tests/utils/test_pytest_parallel_gpu.py
@@ -13,7 +13,13 @@ from __future__ import annotations
 
 import io
 import itertools
+import json
+import os
 import random
+import re
+import shutil
+import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -29,9 +35,11 @@ from tests.utils.pytest_parallel_gpu import (
     _unschedulable_reason,
 )
 from tests.utils.vram_utils import (
+    _TEST_META_FILENAME,
     DEFAULT_GPU_COUNT,
     VRAM_MULTI_PROC_MARGIN,
     gpu_count_from_marker_names,
+    write_test_meta,
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
@@ -682,9 +690,17 @@ def test_mixed_gpu1_and_gpu2_share_a_node_without_overlapping():
 
 
 def test_gang_reservation_is_all_or_none():
-    # Two GPUs, both busy; a blocked 12 GiB gang needs headroom on BOTH. The
-    # backfill cap (cap - required = 19 - 12 = 7) therefore applies to each
-    # card, so only one 3.8 filler fits per card, not two.
+    # Two GPUs, both busy; a blocked 12 GiB gang needs headroom on BOTH, so the
+    # reservation applies to each card rather than just the better one.
+    #
+    # A gang's backfill limit is the ABSOLUTE committed budget against
+    # budget_multi: a card may hold at most `budget_multi - required`
+    # = 18.7 - 12.0 = 6.7 GiB while the gang waits on it. Both cards already
+    # hold 8.0, which is past that line, so no filler may be added to either --
+    # the gang's headroom has to be reached by attrition, not rented out again.
+    # Admitting "just one" 3.8 here is what lets committed budget creep upward
+    # one pass at a time until the gang can never assemble; see
+    # test_blocked_gang_is_not_starved_by_endless_lower_priority_backfill.
     gpus = {
         0: _gpu(0, 22.0, budget_used=8.0, running_count=1),
         1: _gpu(1, 22.0, budget_used=8.0, running_count=1),
@@ -698,10 +714,254 @@ def test_gang_reservation_is_all_or_none():
 
     launches = _select_checked(pending, gpus, num_slots=8, running_count=2)
 
-    # The gang itself cannot run yet (19 - 8 = 11 < 12).
+    # The gang itself cannot run yet (18.7 - 8.0 = 10.7 < 12).
     assert all(idx != 0 for idx, _ in launches)
-    # One filler per reserved card, and no third: 7 GiB of backfill room each.
-    assert launches == [(1, (0,)), (2, (1,))]
+    assert launches == []
+
+
+def test_gang_reservation_admits_backfill_that_still_leaves_its_headroom():
+    # The reservation throttles backfill; it does not ban it. A gang-held card
+    # may still take work while it stays inside `budget_multi - required`
+    # = 18.7 - 12.0 = 6.7 GiB.
+    #
+    # Note the two states are mutually exclusive on a single card: a card that
+    # is *blocking* the gang is by definition already past that line, so it can
+    # never also accept a filler. Backfill under a gang reservation is only
+    # reachable on a member that is NOT the blocker -- here GPU0 has room and
+    # GPU1 is the blocker, so the gang waits while GPU0 keeps working.
+    gpus = {
+        0: _gpu(0, 22.0, budget_used=1.0, running_count=1),
+        1: _gpu(1, 22.0, budget_used=8.0, running_count=1),
+    }
+    pending = [
+        _t("gang12", 12.0, timeout=1800, gpus=2),
+        _t("fill_a", 3.8),
+        _t("fill_b", 3.8),
+    ]
+
+    launches = _select_checked(pending, gpus, num_slots=8, running_count=2)
+
+    # Gang blocked by GPU1 (18.7 - 8.0 = 10.7 < 12). One filler fits on GPU0
+    # (1.0 + 3.8 = 4.8 <= 6.7); the second does not (8.6 > 6.7), and neither
+    # may touch GPU1.
+    assert launches == [(1, (0,))]
+
+
+# --------------------------------------------------------------------------- #
+# cross-pass progress -- the property a single-pass assertion cannot see
+# --------------------------------------------------------------------------- #
+def _drive_passes(gpus, seeded, *, backfill, passes, num_slots=8, queue_depth=4):
+    """Drive repeated `_select_launches` passes against live `gpu_states`.
+
+    Mirrors ``run_parallel``'s loop -- retire what finished, select, commit --
+    on an integer clock, with ``backfill(i)`` keeping the queue topped up so the
+    supply of lower-priority work never runs dry.
+
+    Every other selection test in this file asserts a property of ONE pass on a
+    hand-authored state. Starvation is not visible there by construction: it is
+    what happens on the pass after next, once ``backfill_added`` has been rebuilt
+    and the committed budget it was meant to bound has moved. This driver is the
+    only place the suite can see that.
+
+    ``run_time`` is in passes. Returns ``{name: pass index it launched on}``.
+    """
+    pending = sorted(seeded, key=_priority_key, reverse=True)
+    running: dict[str, tuple[_TestEntry, int]] = {}
+    started: dict[str, int] = {}
+    made = 0
+
+    for now in range(passes):
+        for name in [n for n, (_, end) in running.items() if end <= now]:
+            _release_gpus(running.pop(name)[0], gpus)
+
+        while len(pending) < queue_depth:
+            pending.append(backfill(made))
+            made += 1
+        pending.sort(key=_priority_key, reverse=True)
+
+        resident = {
+            gi: sum(
+                t.profiled_gib for t, _ in running.values() if gi in t.assigned_gpus
+            )
+            for gi in gpus
+        }
+        actual_free = {gi: gs.total_gib - resident[gi] for gi, gs in gpus.items()}
+        if len(running) >= num_slots:
+            continue
+        launches = _select_launches(
+            pending=pending,
+            gpu_states=gpus,
+            actual_free=actual_free,
+            num_slots=num_slots,
+            running_count=len(running),
+        )
+        batch = [(pending.pop(idx), got) for idx, got in reversed(launches)]
+        for test, got in reversed(batch):
+            _reserve_gpus(test, got, gpus)
+            running[test.name] = (test, now + max(1, int(test.est_duration)))
+            started.setdefault(test.name, now)
+
+    return started
+
+
+def test_blocked_gang_is_not_starved_by_endless_lower_priority_backfill():
+    """A feasible gpu_2 test must not be postponed forever by gpu_1 backfill.
+
+    Two 10 GiB cards (budget_multi 8.5). `hog` occupies one of them for 40
+    passes; `gang` needs 6.0 GiB on BOTH, so it is blocked from pass 0 -- the
+    idle card fits it but the hog's card does not (8.5 - 3.0 = 5.5 < 6.0).
+    Behind them is an endless queue of strictly lower-priority 2.0 GiB gpu_1
+    tests (shorter est_duration, smaller VRAM, so `_priority_key` ranks them
+    last and `gang` is always scanned first).
+
+    `gang` is feasible: `_unschedulable_reason` clears it, and with no backfill
+    at all it launches the moment the hog retires. The requirement is that the
+    backfill cannot take that away from it.
+    """
+    gpus = {0: _gpu(0, 10.0), 1: _gpu(1, 10.0)}
+    hog = _t("hog", 3.0, timeout=120)  # est 40 passes
+    gang = _t("gang", 6.0, timeout=90, gpus=2)  # est 30 passes, lower priority
+    assert _unschedulable_reason(gang, gpus) is None
+    assert _priority_key(hog) > _priority_key(gang) > _priority_key(_t("f", 2.0, 15.0))
+
+    started = _drive_passes(
+        gpus,
+        [hog, gang],
+        backfill=lambda i: _t(f"fill{i}", 2.0, timeout=15.0),
+        passes=400,
+    )
+
+    assert "gang" in started, (
+        "gpu_2 test never launched in 400 passes while lower-priority gpu_1 "
+        "tests kept launching -- starved"
+    )
+    # It must not merely launch eventually: it must launch as soon as the hog
+    # that was blocking it retires, not after some further backfill has been
+    # let in ahead of it.
+    assert started["gang"] <= 41, started["gang"]
+
+
+def test_gpu1_reservation_still_makes_progress_under_the_same_backfill():
+    """Control for the test above: the identical workload with gpu_count=1.
+
+    Confirms the gpu_2 assertion is about gang scheduling and not about the
+    driver, and pins that the unchanged single-GPU reservation path still lets
+    a blocked gpu_1 test through.
+    """
+    gpus = {0: _gpu(0, 10.0)}
+    hog = _t("hog", 3.0, timeout=120)
+    blocked = _t("blocked", 6.0, timeout=90)
+
+    started = _drive_passes(
+        gpus,
+        [hog, blocked],
+        backfill=lambda i: _t(f"fill{i}", 2.0, timeout=15.0),
+        passes=400,
+    )
+
+    assert "blocked" in started
+    assert started["blocked"] <= 41, started["blocked"]
+
+
+def test_nothing_is_admitted_past_a_gang_hold_across_passes():
+    """The invariant the progress guarantee rests on.
+
+    While a gang is blocked and holding card `g`, any test admitted to `g` must
+    leave `budget_used[g] <= budget_multi[g] - required`. That is what makes the
+    headroom monotone, and monotone headroom per card is what makes `gpu_count`
+    cards eventually satisfy the gate at the same instant -- without it each
+    card oscillates and the k of them need never coincide.
+
+    Checked as a statement about admissions under an existing hold: an increase
+    on a pass whose predecessor already had the gang blocked. The pass that
+    first creates the hold is excluded -- the blocker that causes the block is
+    legitimately placed before any hold exists.
+    """
+    gpus = {0: _gpu(0, 10.0), 1: _gpu(1, 10.0)}
+    hog = _t("hog", 3.0, timeout=120)
+    gang = _t("gang", 6.0, timeout=90, gpus=2)
+    line = {gi: gs.budget_multi - gang.profiled_gib for gi, gs in gpus.items()}
+    prev = {gi: 0.0 for gi in gpus}
+    st = {"held_last_pass": False, "ever_launched": False}
+    violations: list[tuple[int, float, float]] = []
+
+    def _watch(i):
+        # Flag only increases observed while the hold was ALREADY in place on
+        # the previous pass: the pass that creates the hold legitimately places
+        # the blocker itself. `ever_launched` latches permanently, so the free
+        # backfill that follows the gang's own run is not mistaken for a breach.
+        if gang.assigned_gpus:
+            st["ever_launched"] = True
+        holding = st["held_last_pass"] and not st["ever_launched"]
+        for gi, gs in gpus.items():
+            grew = gs.budget_used > prev[gi] + 1e-9
+            if holding and grew and gs.budget_used > line[gi] + 1e-9:
+                violations.append((gi, prev[gi], gs.budget_used))
+            prev[gi] = gs.budget_used
+        st["held_last_pass"] = bool(hog.assigned_gpus) and not st["ever_launched"]
+        return _t(f"fill{i}", 2.0, timeout=15.0)
+
+    started = _drive_passes(gpus, [hog, gang], backfill=_watch, passes=120)
+
+    assert "gang" in started
+    assert (
+        not violations
+    ), f"admitted past the gang hold (gi, before, after): {violations}"
+
+
+def test_gang_hold_admits_backfill_exactly_at_the_line():
+    """The boundary of the gang gate: at the line is admitted, over it is not.
+
+    Sized off `budget_multi` itself rather than a literal, so the equality is
+    exact whatever `total_gib * (1 - MARGIN)` rounds to. Without this the
+    comparison could be `>=` instead of `>` and every other test would still
+    pass -- the two differ only on this one state.
+    """
+    gpus = {0: _gpu(0, 10.0), 1: _gpu(1, 10.0, budget_used=3.0, running_count=1)}
+    gang = _t("gang", 6.0, timeout=1800, gpus=2)
+    exact = gpus[0].budget_multi - gang.profiled_gib  # lands exactly on the line
+    over = exact * 1.02
+
+    at_line = _select_checked(
+        [gang, _t("fill_exact", exact)],
+        gpus,
+        num_slots=8,
+        running_count=1,
+        actual_free={0: 10.0, 1: 7.0},
+    )
+    assert at_line == [(1, (0,))], "backfill landing exactly on the line must fit"
+
+    past_line = _select_checked(
+        [gang, _t("fill_over", over)],
+        gpus,
+        num_slots=8,
+        running_count=1,
+        actual_free={0: 10.0, 1: 7.0},
+    )
+    assert past_line == [], "backfill past the line must be refused"
+
+
+def test_idle_reserved_card_is_capped_at_budget_multi_not_the_whole_card():
+    # An IDLE card reserved for a blocked gang reports the whole-card cap,
+    # because that is the cap for whoever lands there first. But the instant a
+    # filler lands, the gang's own cap on that card becomes budget_multi. Gating
+    # the reservation on the whole-card cap therefore over-grants by exactly
+    # VRAM_MULTI_PROC_MARGIN * total_gib (0.15 * 22 = 3.3) and admits a filler
+    # that immediately re-blocks the gang the reservation exists to protect.
+    #
+    # GPU0 idle, GPU1 holds the gang's blocker. An 8.0 filler is inside
+    # 22.0 - 12.0 = 10.0 but outside 18.7 - 12.0 = 6.7, so it must be refused.
+    gpus = {
+        0: _gpu(0, 22.0),
+        1: _gpu(1, 22.0, budget_used=8.0, running_count=1),
+    }
+    pending = [_t("gang12", 12.0, timeout=1800, gpus=2), _t("fill8", 8.0)]
+
+    launches = _select_checked(
+        pending, gpus, num_slots=8, running_count=1, actual_free={0: 22.0, 1: 14.0}
+    )
+
+    assert launches == []
 
 
 def test_gang_does_not_reserve_when_it_cannot_hold_every_device():
@@ -888,6 +1148,234 @@ def test_gpu_count_is_absent_without_a_hardware_marker():
     assert gpu_count_from_marker_names(["unit", "pre_merge"]) is None
     assert gpu_count_from_marker_names(["gpu_0"]) is None
     assert DEFAULT_GPU_COUNT == 1
+
+
+# --------------------------------------------------------------------------- #
+# write_test_meta -- the PRODUCER half of the gpu_count path
+#
+# gpu_count_from_marker_names is well covered below, but the line that actually
+# puts its answer into the metadata file is the single point where every gpu_2
+# test can be silently downgraded to gpu_1. Deleting it, renaming its key, or
+# hardcoding it to 1 leaves the whole scheduler suite green: nothing downstream
+# can tell "no gpu_N marker" (legitimately defaults to 1) from "the marker was
+# dropped on the floor". These tests pin the producer against REAL marker
+# objects taken off real `@pytest.mark.*` decorators.
+# --------------------------------------------------------------------------- #
+@pytest.mark.gpu_2
+@pytest.mark.profiled_vram_gib(5.0)
+@pytest.mark.requested_vllm_kv_cache_bytes(559_693_824)
+@pytest.mark.timeout(420)
+def _marker_sample_gpu2():
+    """Stand-in carrying the exact marker set of the two real gpu_2 tests."""
+
+
+@pytest.mark.gpu_1
+@pytest.mark.profiled_vram_gib(4.0)
+def _marker_sample_gpu1():
+    """A single-GPU test."""
+
+
+@pytest.mark.gpu_4
+@pytest.mark.profiled_vram_gib(9.0)
+def _marker_sample_gpu4():
+    """A four-GPU test."""
+
+
+@pytest.mark.gpu_0
+@pytest.mark.profiled_vram_gib(0)
+def _marker_sample_gpu0():
+    """gpu_0 declares 'no GPU required', not a device count."""
+
+
+@pytest.mark.profiled_vram_gib(3.0)
+def _marker_sample_unmarked():
+    """No gpu_N marker at all -- the historical default."""
+
+
+class _MarkedItem:
+    """Minimal pytest item over the REAL marks of a decorated function.
+
+    `pytestmark` holds genuine `pytest.Mark` instances, so this drives
+    `write_test_meta` with the same objects a collected item would carry rather
+    than hand-written name strings. `iter_markers` yields closest-first, which
+    is pytest's own ordering and the order `get_closest_marker` depends on.
+    """
+
+    def __init__(self, nodeid: str, func):
+        self.nodeid = nodeid
+        self._marks = list(reversed(getattr(func, "pytestmark", [])))
+
+    def iter_markers(self, name: str | None = None):
+        for mark in self._marks:
+            if name is None or mark.name == name:
+                yield mark
+
+    def get_closest_marker(self, name: str):
+        return next(self.iter_markers(name), None)
+
+
+def _write_and_read(items, tmp_path) -> dict:
+    write_test_meta(items, dest_dir=str(tmp_path))
+    written = tmp_path / _TEST_META_FILENAME
+    assert written.exists(), "write_test_meta produced no metadata file"
+    return json.loads(written.read_text())
+
+
+def test_write_test_meta_serializes_gpu_count_from_a_real_gpu_2_marker(tmp_path):
+    nodeid = "tests/serve/test_vllm.py::test_embedding_multi_worker_same_model"
+    meta = _write_and_read([_MarkedItem(nodeid, _marker_sample_gpu2)], tmp_path)[nodeid]
+
+    # The producer line itself.
+    assert meta["gpu_count"] == 2
+    # And the consumer, read exactly the way run_parallel reads it.
+    assert meta.get("gpu_count", DEFAULT_GPU_COUNT) == 2
+    # The rest of the marker set must survive alongside it.
+    assert meta["profiled_vram_gib"] == 5.0
+    assert meta["requested_vllm_kv_cache_bytes"] == 559_693_824
+    assert meta["timeout"] == 420
+
+
+def test_write_test_meta_gpu_count_round_trips_into_a_scheduled_gang(tmp_path):
+    """Producer -> metadata -> _TestEntry -> a two-device selection.
+
+    Closes the loop end to end: if the serialization is dropped the entry
+    defaults to one GPU and the selection is a single device, not a gang.
+    """
+    nodeid = "tests/serve/test_vllm.py::test_gang"
+    meta = _write_and_read([_MarkedItem(nodeid, _marker_sample_gpu2)], tmp_path)[nodeid]
+
+    entry = _TestEntry(
+        id=nodeid,
+        name=nodeid,
+        profiled_gib=meta["profiled_vram_gib"],
+        timeout=meta["timeout"],
+        requested_vllm_kv_cache_bytes=meta["requested_vllm_kv_cache_bytes"],
+        gpu_count=meta.get("gpu_count", DEFAULT_GPU_COUNT),
+    )
+    assert entry.gpu_count == 2
+
+    gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0)}
+    launches = _select_checked([entry], gpus, num_slots=8)
+    assert launches == [(0, (0, 1))]
+
+
+def test_write_test_meta_gpu_count_covers_every_marker_case(tmp_path):
+    cases = {
+        "one": (_marker_sample_gpu1, 1),
+        "four": (_marker_sample_gpu4, 4),
+        # gpu_0 means "no GPU required", not a device count, so no key is
+        # written and the consumer default of 1 applies -- same as a test that
+        # declares no gpu_N marker at all, and same as a metadata file written
+        # before the field existed.
+        "zero": (_marker_sample_gpu0, None),
+        "unmarked": (_marker_sample_unmarked, None),
+    }
+    written = _write_and_read(
+        [_MarkedItem(nid, func) for nid, (func, _) in cases.items()], tmp_path
+    )
+
+    for nodeid, (_, expected) in cases.items():
+        meta = written[nodeid]
+        if expected is None:
+            assert "gpu_count" not in meta, nodeid
+            assert meta.get("gpu_count", DEFAULT_GPU_COUNT) == DEFAULT_GPU_COUNT
+        else:
+            assert meta["gpu_count"] == expected, nodeid
+
+
+def test_write_test_meta_propagates_a_marker_conflict_rather_than_guessing(tmp_path):
+    """A conflict must abort collection, not silently pick one of the two."""
+
+    @pytest.mark.gpu_1
+    @pytest.mark.gpu_2
+    @pytest.mark.profiled_vram_gib(5.0)
+    def _conflicted():
+        pass
+
+    with pytest.raises(ValueError) as excinfo:
+        write_test_meta(
+            [_MarkedItem("conflicted", _conflicted)], dest_dir=str(tmp_path)
+        )
+    assert "['gpu_1', 'gpu_2']" in str(excinfo.value)
+    assert not (tmp_path / _TEST_META_FILENAME).exists()
+
+
+# --------------------------------------------------------------------------- #
+# the gang assignment has to survive into the workers
+#
+# CUDA_VISIBLE_DEVICES is absolute, not relative: a child that sets it to "0"
+# gets physical GPU 0 whatever the parent's value was -- the parent's
+# restriction is replaced, not compounded. A launch script that hardcodes 0/1
+# therefore ignores the gang the scheduler gave it, and on a node with more
+# than two GPUs runs its workers on devices reserved for *other* tests, whose
+# VRAM the scheduler still believes is disjoint. These tests execute the real
+# lines out of the shipped script rather than asserting on its text.
+# --------------------------------------------------------------------------- #
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GANG_LAUNCH_SCRIPT = (
+    _REPO_ROOT / "examples/backends/vllm/launch/agg_embed_multiworker.sh"
+)
+
+
+def _derive_worker_gpus(cvd: str | None) -> tuple[int, str]:
+    """Run the script's own device-derivation block under a given inherited set."""
+    text = _GANG_LAUNCH_SCRIPT.read_text()
+    start = text.index("IFS=',' read -r -a _VISIBLE_GPUS")
+    end = text.index("\n", text.index('WORKER2_GPU="'))
+    snippet = text[start:end] + '\necho "${WORKER1_GPU},${WORKER2_GPU}"\n'
+
+    env = dict(os.environ)
+    env.pop("CUDA_VISIBLE_DEVICES", None)
+    if cvd is not None:
+        env["CUDA_VISIBLE_DEVICES"] = cvd
+    proc = subprocess.run(
+        ["bash", "-c", snippet], capture_output=True, text=True, env=env
+    )
+    return proc.returncode, proc.stdout.strip()
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+def test_gang_launch_script_uses_the_devices_the_scheduler_assigned():
+    if not _GANG_LAUNCH_SCRIPT.exists():
+        pytest.skip("launch script not present in this checkout")
+
+    # The case that matters: a gang other than (0,1). The scheduler hands the
+    # whole gang down in CUDA_VISIBLE_DEVICES and the workers must land on it.
+    assert _derive_worker_gpus("2,3") == (0, "2,3")
+    assert _derive_worker_gpus("5,7") == (0, "5,7")
+    # Order is the scheduler's, not re-sorted by the script.
+    assert _derive_worker_gpus("1,0") == (0, "1,0")
+    # The historical shape still works, and an unrestricted manual run still
+    # defaults to the first two devices.
+    assert _derive_worker_gpus("0,1") == (0, "0,1")
+    assert _derive_worker_gpus(None) == (0, "0,1")
+    # More devices than it needs: take the first two of the set.
+    assert _derive_worker_gpus("0,1,2,3") == (0, "0,1")
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+def test_gang_launch_script_refuses_a_device_set_it_cannot_satisfy():
+    if not _GANG_LAUNCH_SCRIPT.exists():
+        pytest.skip("launch script not present in this checkout")
+
+    # One device cannot host a two-worker gang.
+    rc, _ = _derive_worker_gpus("3")
+    assert rc != 0
+    # Empty means "no devices at all" in CUDA -- it must NOT fall back to 0,1.
+    rc, _ = _derive_worker_gpus("")
+    assert rc != 0
+
+
+def test_gang_launch_script_hardcodes_no_absolute_device():
+    if not _GANG_LAUNCH_SCRIPT.exists():
+        pytest.skip("launch script not present in this checkout")
+
+    offenders = re.findall(
+        r"^\s*CUDA_VISIBLE_DEVICES=\d.*$",
+        _GANG_LAUNCH_SCRIPT.read_text(),
+        re.MULTILINE,
+    )
+    assert not offenders, f"absolute device pinned in a gang launcher: {offenders}"
 
 
 def test_conflicting_gpu_count_markers_fail_closed():

--- a/tests/utils/test_pytest_parallel_gpu.py
+++ b/tests/utils/test_pytest_parallel_gpu.py
@@ -2209,46 +2209,119 @@ def test_making_a_gpu_larger_never_delays_a_gang():
         )
 
 
-@pytest.mark.parametrize("frees_at", [None, 40, 80])
-def test_progress_under_foreign_memory_is_conditional_on_it_being_released(frees_at):
-    """The stated limit of the progress property, pinned in both directions.
+def test_foreign_memory_on_a_card_the_gang_does_not_need_never_delays_it():
+    """Progress must not depend on a card the gang has no need of.
 
-    Reservation placement looks only at card size, never at live free memory,
-    because ``(total - free) - budget`` cannot separate a neighbour's allocation
-    -- which may never be released -- from our own test overshooting its profile
-    or still ramping, which always is. Consulting it would reject cards that
-    recover while admitting cards that do not.
+    The physical-size filter was not the whole of the defect it closed. A hold is
+    useless on any card the gang cannot occupy, and physical size is only one of
+    the two reasons a card can be unoccupiable -- memory held by a process
+    OUTSIDE this run is the other, and it produces the identical failure through
+    the identical mechanism: an idle card scores its whole capacity for a
+    protector slot precisely BECAUSE it is idle, wins one, and can never honour
+    it.
 
-    So a gang needing a card that a neighbour is holding waits, and that is the
-    honest guarantee: three 10 GiB cards, a gang wanting 6.0 on two of them, and
-    4.5 GiB held on GPU2 by something outside this run.
-
-    - held forever: the gang never launches. This is regime D -- outside the
-      claimed domain, and stated rather than papered over.
-    - released at pass 40 or 80: the gang launches on exactly that pass, so
-      nothing the scheduler did in the meantime cost it its place.
+    Three 10 GiB cards, a gpu_2 gang needing 6.0, and 4.5 GiB held forever on
+    GPU2 by something outside this run. GPU0 and GPU1 are free, permanently, and
+    two cards is exactly what the gang needs -- so it must launch as soon as the
+    hog retires. Before this was fixed the hold landed on {1, 2}, GPU0 was left
+    unprotected, the backfill took it, and the gang never launched in 400 passes.
     """
     gpus = {0: _gpu(0, 10.0), 1: _gpu(1, 10.0), 2: _gpu(2, 10.0)}
+    gang = _t("gang", 6.0, timeout=90, gpus=2)
+    assert _unschedulable_reason(gang, gpus) is None
+
     started = _drive_passes(
         gpus,
-        [_t("hog", 3.0, timeout=120), _t("gang", 6.0, timeout=90, gpus=2)],
+        [_t("hog", 3.0, timeout=120), gang],
+        backfill=lambda i: _t(f"fill{i}", 2.0, timeout=21.0),
+        passes=400,
+        external_hold=lambda now: {2: 4.5},
+    )
+
+    assert "gang" in started, (
+        "gang starved by a hold placed on the one card it can never occupy -- "
+        "two permanently free cards big enough for it were available throughout"
+    )
+    assert started["gang"] <= 41, started["gang"]
+
+
+@pytest.mark.parametrize("frees_at", [None, 60])
+def test_gang_waits_only_while_foreign_memory_leaves_too_few_usable_cards(frees_at):
+    """The honest remaining limit, pinned in both directions.
+
+    Preferring usable cards for a hold cannot manufacture capacity. When foreign
+    memory blocks so many cards that fewer than ``gpu_count`` remain, the gang
+    genuinely cannot run and waiting is correct -- that is a property of the box,
+    not of this scheduler. What it must NOT do is lose its place: the moment the
+    neighbour releases, the gang launches on that very pass, which is only true
+    if the holds were positioned on the cards that came back.
+
+    Two of three cards blocked, so exactly one is usable against a need of two.
+    """
+    gpus = {0: _gpu(0, 10.0), 1: _gpu(1, 10.0), 2: _gpu(2, 10.0)}
+    gang = _t("gang", 6.0, timeout=90, gpus=2)
+    assert _unschedulable_reason(gang, gpus) is None
+
+    started = _drive_passes(
+        gpus,
+        [_t("hog", 3.0, timeout=120), gang],
         backfill=lambda i: _t(f"fill{i}", 2.0, timeout=21.0),
         passes=400,
         external_hold=(
-            lambda now: {2: 4.5} if (frees_at is None or now < frees_at) else {}
+            lambda now: {1: 4.5, 2: 4.5}
+            if (frees_at is None or now < frees_at)
+            else {}
         ),
     )
 
     if frees_at is None:
         assert "gang" not in started, (
-            "documented limitation changed: the gang launched despite a card it "
-            "needs being held by a process outside this run"
+            "only one card was ever usable and the gang needs two -- launching "
+            "would mean the memory accounting is wrong, not that it made progress"
         )
     else:
         assert started.get("gang") == frees_at, (
             f"gang should launch the pass the foreign memory is released "
-            f"({frees_at}), got {started.get('gang')}"
+            f"({frees_at}), got {started.get('gang')} -- it was not holding the "
+            "cards that came back"
         )
+
+
+def test_a_foreign_blocked_card_never_outranks_a_usable_one_for_a_hold():
+    """The ranking, isolated from the multi-pass driver.
+
+    Headroom alone is the wrong sort key for a gang hold, and an idle card is
+    exactly where it misleads: ``_cap`` of an idle card is the whole card, so a
+    card carrying 4.5 GiB of somebody else's memory still scores a perfect 10.0
+    and takes a protector slot off a card that is genuinely free.
+
+    GPU0 is busy with our own work -- which will finish -- and GPU1/GPU2 are
+    idle, but GPU2 is holding foreign memory. The hold has to land on {0, 1}: the
+    two cards a 6.0 GiB gang member could occupy once our own test retires.
+    Observed, as everywhere else in this file, through what the hold refuses --
+    the filler can only land on the one card not protected.
+    """
+    gpus = {
+        0: _gpu(0, 10.0, budget_used=5.0, running_count=1),
+        1: _gpu(1, 10.0),
+        2: _gpu(2, 10.0),
+    }
+    # GPU2 reads 5.5 free while committing no budget of ours: 4.5 GiB is held by
+    # a process outside this run, so it cannot take a 6.0 GiB member today.
+    actual_free = {0: 5.0, 1: 10.0, 2: 5.5}
+    gang = _t("gang", 6.0, timeout=1800, gpus=2)
+    filler = _t("filler", 3.0, timeout=15.0)
+    assert _unschedulable_reason(gang, gpus) is None
+
+    launches = _select_checked(
+        [gang, filler], gpus, num_slots=8, running_count=1, actual_free=actual_free
+    )
+
+    assert launches == [(1, (2,))], (
+        "the hold went to a card holding another process's memory instead of a "
+        "card the gang could actually occupy; the filler proves which card was "
+        "left unprotected"
+    )
 
 
 def test_gpu1_control_is_unaffected_by_an_unusable_card():
@@ -2586,6 +2659,84 @@ def test_gang_falls_back_to_a_full_hold_when_only_some_cards_look_usable():
     assert started["gang"] <= 60, (
         f"gang launched on pass {started['gang']}: with only one card passing "
         "the filter it went unprotected instead of falling back to a full hold"
+    )
+
+
+def test_a_gang_holds_nothing_rather_than_hold_cards_it_can_never_run_on():
+    """The size filter still has to be load bearing on its own.
+
+    Preferring usable cards in the ordering hides the filter in every scenario
+    where a better card exists, because a card too small to host a member can
+    never be usable either -- the preference sorts it last anyway. The filter
+    earns its keep exactly where the ordering cannot help: when nothing better
+    is LEFT. Then a preference has no choice but to hand the slot over, and a
+    filter refuses.
+
+    GPU0/GPU1 are the only cards that could host this 6.0 GiB gang, and a
+    higher-priority gang has already taken them. What remains for the second
+    gang is two 5.9 GiB cards it could never run on. Holding them would bound
+    backfill that has nowhere else to go, in exchange for a launch that can
+    never happen -- so it holds nothing, and the filler lands.
+    """
+    gpus = {
+        0: _gpu(0, 10.0, budget_used=5.0, running_count=1),
+        1: _gpu(1, 10.0, budget_used=5.0, running_count=1),
+        2: _gpu(2, 5.9),
+        3: _gpu(3, 5.9),
+    }
+    actual_free = {0: 5.0, 1: 5.0, 2: 5.9, 3: 5.9}
+    first = _t("first", 6.0, timeout=1800, gpus=2)
+    second = _t("second", 6.0, timeout=90, gpus=2)
+    filler = _t("filler", 2.0, timeout=15.0)
+    assert _unschedulable_reason(second, gpus) is None
+
+    launches = _select_checked(
+        [first, second, filler],
+        gpus,
+        num_slots=8,
+        running_count=2,
+        actual_free=actual_free,
+    )
+
+    assert launches == [(2, (2,))], (
+        "the second gang took a hold on cards it can never run on, and the "
+        "filler -- which had nowhere else to go -- was blocked for a launch "
+        "that could never happen"
+    )
+
+
+def test_a_card_whose_usable_capacity_exactly_meets_the_need_is_still_preferred():
+    """The preference boundary, matching the filter's boundary.
+
+    ``_can_ever_host`` admits a card whose physical size exactly equals the
+    requirement, because pre-flight does. ``_usable_now`` has to agree at its own
+    boundary for the same reason: a card carrying foreign memory that leaves
+    exactly the requirement free is usable, and ranking it below a card that is
+    genuinely short would hand the hold to the wrong one.
+
+    GPU0 has 4.0 GiB of foreign memory on a 10.0 GiB card -- exactly 6.0 usable.
+    GPU2 is the most attractive card by headroom and the least usable. A strict
+    ``>`` at the boundary demotes GPU0 beneath it, the hold lands on {1, 2}, and
+    the filler that should have had GPU2 is refused everywhere.
+    """
+    gpus = {
+        0: _gpu(0, 10.0, budget_used=5.0, running_count=1),
+        1: _gpu(1, 10.0, budget_used=5.0, running_count=1),
+        2: _gpu(2, 10.0, running_count=1),
+    }
+    # GPU0: 4.0 GiB foreign -> exactly 6.0 usable. GPU2: 4.5 GiB foreign -> 5.5.
+    actual_free = {0: 1.0, 1: 5.0, 2: 5.5}
+    gang = _t("gang", 6.0, timeout=1800, gpus=2)
+    filler = _t("filler", 3.0, timeout=15.0)
+    assert _unschedulable_reason(gang, gpus) is None
+
+    launches = _select_checked(
+        [gang, filler], gpus, num_slots=8, running_count=3, actual_free=actual_free
+    )
+
+    assert launches == [(1, (2,))], (
+        "the hold skipped the card with exactly enough usable capacity and took "
+        "the emptiest-looking one instead, which cannot host a member at all"
     )
 
 

--- a/tests/utils/test_pytest_parallel_gpu.py
+++ b/tests/utils/test_pytest_parallel_gpu.py
@@ -2268,9 +2268,7 @@ def test_gang_waits_only_while_foreign_memory_leaves_too_few_usable_cards(frees_
         backfill=lambda i: _t(f"fill{i}", 2.0, timeout=21.0),
         passes=400,
         external_hold=(
-            lambda now: {1: 4.5, 2: 4.5}
-            if (frees_at is None or now < frees_at)
-            else {}
+            lambda now: {1: 4.5, 2: 4.5} if (frees_at is None or now < frees_at) else {}
         ),
     )
 
@@ -2499,6 +2497,188 @@ def test_gang_still_holds_its_cards_while_every_card_is_transiently_blocked():
     assert started["gang"] <= 60, (
         f"gang launched on pass {started['gang']}, long after the neighbours "
         "left on pass 40 -- its cards were given away while it was unprotected"
+    )
+
+
+def test_non_gang_work_still_launches_while_a_gang_holds_cards_it_cannot_use():
+    """A hold must not suppress work that cannot affect the gang's admission.
+
+    The suite has never asserted this. Every existing observer asks "did the
+    watched gang launch", so a hold that takes the rest of the node to zero
+    scores a clean pass -- which is how this reached a third audit.
+
+    Two 80 GiB cards (``budget_multi`` 68.0) and a gpu_2 gang wanting 40.0 on
+    each. Until pass 60 a process outside the run holds 45.0 GiB on both, so
+    neither card can host the gang: ``_usable_now`` reads 80.0 - 45.0 = 35.0,
+    short of 40.0. On such a card the hold line is
+    ``budget_multi - foreign - required`` = 68.0 - 45.0 - 40.0 = **-17.0**,
+    negative unconditionally, so every backfill test is refused for as long as
+    the gang is queued. At ``n == gpu_count`` -- the only topology this ships to
+    -- that is the whole node, and ``run_parallel``'s ``while pending or
+    running:`` has no bail-out from it.
+
+    The 10.0 GiB backfill here is *causally irrelevant* to the gang: once the
+    neighbours leave, a running filler leaves 10.0 + 40.0 = 50.0 against a cap of
+    68.0, so the gang still fits beside it. Refusing it buys the gang nothing --
+    and the second assertion proves that directly, by pinning that the gang
+    launches on the same pass either way.
+
+    This is deliberately NOT the topology of
+    ``test_gang_still_holds_its_cards_while_every_card_is_transiently_blocked``
+    above, where the backfill outlives the neighbours and genuinely does cost the
+    gang its launch. Both must hold at once: protect what the gang needs, refuse
+    nothing else.
+    """
+    gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0)}
+    gang = _t("gang", 40.0, timeout=1800, gpus=2)
+    assert _unschedulable_reason(gang, gpus) is None
+
+    started = _drive_passes(
+        gpus,
+        [gang],
+        backfill=lambda i: _t(f"fill{i}", 10.0, timeout=15.0),
+        passes=300,
+        external_hold=lambda now: {0: 45.0, 1: 45.0} if now < 60 else {},
+    )
+
+    held_window = [n for n, at in started.items() if n != "gang" and at < 60]
+    assert held_window, (
+        "no non-gang test launched in the 60 passes the gang held both cards it "
+        "could not use -- the node made zero progress while waiting"
+    )
+
+    assert "gang" in started, "gang never launched after its blocker retired"
+    assert started["gang"] <= 61, (
+        f"gang launched on pass {started['gang']}; admitting backfill the gang "
+        "cannot be harmed by must not delay it"
+    )
+
+
+def test_a_gang_hold_prefers_usable_cards_whatever_order_the_gpus_are_declared_in():
+    """The hold must rank by usability, not by however ``gpu_states`` was built.
+
+    Deleting ``unreserved.sort(key=_hold_key)`` -- the whole of the repair that
+    exists because a hold landed on a card nobody in this run could use -- leaves
+    all 100 other tests green. Every one of them happens to declare its GPUs in
+    an order where the correct hold set is already the first ``need`` entries, so
+    the sort is a no-op and its absence is invisible.
+
+    Three 10 GiB cards (``budget_multi`` 8.5) **declared 2, 1, 0**. A process
+    outside the run holds 4.5 GiB on GPU2 forever, so ``_usable_now`` reads
+    10.0 - 4.5 = 5.5 against the gang's 6.0: GPU2 cannot host a member today and
+    will not until that neighbour leaves. GPU0 carries a 5.0 GiB test of *ours*,
+    which retires -- ``_foreign_held`` is 0 there, so GPU0 is usable. The gang is
+    blocked meanwhile, needing two cards and having one.
+
+    The hold must therefore protect {GPU0, GPU1}. Taking ``unreserved[:need]`` in
+    declaration order protects {GPU2, GPU1} instead: GPU2 buys the gang nothing,
+    and GPU0 -- unprotected -- fills with backfill that renews before the hog
+    retires, so the gang never gets a second card. The assertion is on the
+    launch, not on the ordering: this is what the missing sort *does*, not that
+    it is called.
+    """
+    gpus = {gi: _gpu(gi, 10.0) for gi in (2, 1, 0)}
+    gang = _t("gang", 6.0, timeout=1800, gpus=2)
+    hog = _t("hog", 5.0, timeout=60)
+    assert _unschedulable_reason(gang, gpus) is None
+
+    # The hog is already running when the first pass is scheduled, so the gang
+    # starts blocked and the hold's choice of cards is what decides its fate.
+    _reserve_gpus(hog, (0,), gpus)
+    running: dict[str, tuple[_TestEntry, int]] = {"hog": (hog, 60)}
+    pending = [gang]
+    started: dict[str, int] = {}
+    made = 0
+
+    for now in range(600):
+        for name in [n for n, (_, end) in running.items() if end <= now]:
+            _release_gpus(running.pop(name)[0], gpus)
+        while len(pending) < 4:
+            pending.append(_t(f"fill{made}", 3.0, timeout=21.0))
+            made += 1
+        pending.sort(key=_priority_key, reverse=True)
+        resident = {
+            gi: sum(
+                t.profiled_gib for t, _ in running.values() if gi in t.assigned_gpus
+            )
+            for gi in gpus
+        }
+        actual_free = {
+            gi: gs.total_gib - resident[gi] - (4.5 if gi == 2 else 0.0)
+            for gi, gs in gpus.items()
+        }
+        for idx, got in reversed(
+            _select_launches(
+                pending=pending,
+                gpu_states=gpus,
+                actual_free=actual_free,
+                num_slots=8,
+                running_count=len(running),
+            )
+        ):
+            test = pending.pop(idx)
+            _reserve_gpus(test, got, gpus)
+            running[test.name] = (test, now + max(1, int(test.est_duration)))
+            started.setdefault(test.name, now)
+
+    assert "gang" in started, (
+        "gang never launched in 600 passes: its hold went to GPU2, which no "
+        "member can use, leaving usable GPU0 to be taken by backfill"
+    )
+    assert started["gang"] <= 61, (
+        f"gang launched on pass {started['gang']}, not on the pass its own hog "
+        "retired -- a usable card was given away while the gang waited"
+    )
+
+
+def test_a_gang_hold_admits_the_same_backfill_however_far_into_the_pass_it_is():
+    """``_foreign_held`` must not drift as a pass fills. Nothing tested this.
+
+    The helper's whole reason for existing is that the hold's *ranking* and the
+    hold's *admission gate* must read one number; they were denominated
+    differently once and that was defect 3. Its docstring states the mechanism --
+    ``total - free - budget``, where the two terms cancel exactly against this
+    pass's tentative launches -- and asserts in prose that the answer therefore
+    does not drift. Substituting the pass-invariant ``gs.budget_used`` for the
+    tentative ``ts.budget`` leaves all 101 other tests green while making the
+    estimate climb by exactly one profile per test already admitted.
+
+    Three 80 GiB cards (``budget_multi`` 68.0). GPU1 and GPU2 each carry 50.0 GiB
+    held outside the run, so neither can host a member of a 40.0 GiB/device gang
+    (80.0 - 50.0 = 30.0). GPU0 is clean and usable, so with one usable card and a
+    gang needing two, the gang is blocked and holds cards.
+
+    On GPU0 -- held, and usable, so the foreign term applies -- the line is
+    ``budget_multi - foreign - required`` = 68.0 - 0.0 - 40.0 = **28.0 GiB**, and
+    5.0 GiB backfill fits five times (25.0 <= 28.0 < 30.0). A drifting estimate
+    reads foreign as 5.0 after the first admission, 10.0 after the second, and
+    stops at three. The assertion is on how much work the card takes, not on how
+    the number is computed.
+    """
+    gpus = {gi: _gpu(gi, 80.0) for gi in range(3)}
+    gang = _t("gang", 40.0, timeout=1800, gpus=2)
+    pending = [gang] + [_t(f"fill{i}", 5.0, timeout=20.0) for i in range(24)]
+    pending.sort(key=_priority_key, reverse=True)
+
+    launched = _select_launches(
+        pending=pending,
+        gpu_states=gpus,
+        actual_free={0: 80.0, 1: 30.0, 2: 30.0},
+        num_slots=64,
+        running_count=0,
+    )
+
+    names = [pending[idx].name for idx, _ in launched]
+    assert "gang" not in names, "gang must be blocked for its hold to be under test"
+
+    on_gpu0 = sum(
+        1 for idx, got in launched if pending[idx].name != "gang" and 0 in got
+    )
+    assert on_gpu0 == 5, (
+        f"GPU0 took {on_gpu0} backfill tests, not the 5 its hold line admits "
+        "(68.0 - 0.0 - 40.0 = 28.0 GiB, five 5.0 GiB tests = 25.0): the foreign "
+        "estimate drifted upward as the pass filled, so later tests in the same "
+        "pass were gated against a larger number than earlier ones"
     )
 
 

--- a/tests/utils/test_pytest_parallel_gpu.py
+++ b/tests/utils/test_pytest_parallel_gpu.py
@@ -2682,6 +2682,76 @@ def test_a_gang_hold_admits_the_same_backfill_however_far_into_the_pass_it_is():
     )
 
 
+@pytest.mark.parametrize("filler_gib", [1.5, 2.0, 3.0])
+def test_a_hold_survives_foreign_memory_retiring_part_way_rather_than_all_at_once(
+    filler_gib,
+):
+    """Backfill admitted on an unusable card must not outlast the card's usefulness.
+
+    Every other test in this file that models foreign memory retiring retires it to
+    exactly ``{}``. Zero is the one value at which admitting up to
+    ``budget_multi - required`` on a card the gang cannot use today stays sufficient,
+    because the gang then needs only ``committed + required <= budget_multi``. For any
+    residual ``F' > 0`` it needs ``F' + committed + required <= budget_multi``, which
+    that bound does not provide.
+
+    The dominant term is not the committed GiB. Admitting *any* VRAM test drives
+    ``running_count`` from 0 to 1, which drops ``_cap`` from ``total_gib`` to
+    ``budget_multi``. The card's feasibility threshold therefore moves from
+    ``F' <= total_gib - required`` to ``F' <= budget_multi - committed - required`` --
+    it loses the multi-process margin *as well as* what was admitted.
+
+    Three 10 GiB cards (``budget_multi`` 8.5) and a gpu_2 gang wanting 6.0 on each.
+    GPU0 is clean; GPU1 and GPU2 carry foreign memory that retires in stages rather
+    than vanishing: 4.5 -> 3.0 -> 1.0 -> 0.0. With one usable card and a gang needing
+    two, the gang is blocked and holds cards.
+
+    The gang first fits at pass 40, when foreign falls to 3.0: an untouched card reads
+    ``3.0 + 6.0 = 9.0`` against the whole-card cap of 10.0. It must launch there. If any
+    test was admitted onto that card while it was unusable, the card instead reads
+    ``3.0 + committed + 6.0`` against 8.5 and the gang waits for it to drain -- which is
+    the regression this pins.
+
+    The filler size is swept because the bound is a specific quantity, not merely a
+    non-zero one. Here ``budget_multi - required - (total_gib - budget_multi)`` is
+    ``8.5 - 6.0 - 1.5 = 1.0``, so every size below refuses. Reserving only *half* the
+    margin would raise the line to 1.75 and admit the 1.5 GiB case, which then delays the
+    gang to pass 60 -- a single fixed size would not tell the two rules apart.
+    """
+    gpus = {gi: _gpu(gi, 10.0) for gi in range(3)}
+    gang = _t("gang", 6.0, timeout=1800, gpus=2)
+    assert _unschedulable_reason(gang, gpus) is None
+
+    def staged(now: int) -> dict[int, float]:
+        if now < 40:
+            held = 4.5
+        elif now < 60:
+            held = 3.0
+        elif now < 80:
+            held = 1.0
+        else:
+            held = 0.0
+        return {1: held, 2: held}
+
+    started = _drive_passes(
+        gpus,
+        [gang],
+        backfill=lambda i: _t(f"fill{i}", filler_gib, timeout=1800.0),
+        passes=400,
+        external_hold=staged,
+    )
+
+    assert (
+        "gang" in started
+    ), "gang never launched, though from pass 40 onward two cards could host a member"
+    assert started["gang"] <= 41, (
+        f"gang launched on pass {started['gang']}, not on pass 40 when foreign memory "
+        "first fell far enough for two cards to take a member. Backfill admitted while "
+        "those cards were unusable both consumed capacity and cost them the "
+        "whole-card cap, so the gang waited for it to drain instead"
+    )
+
+
 # --------------------------------------------------------------------------- #
 # the assignment has to survive into the WORKERS, not just be derived
 #

--- a/tests/utils/test_pytest_parallel_gpu.py
+++ b/tests/utils/test_pytest_parallel_gpu.py
@@ -750,7 +750,16 @@ def test_gang_reservation_admits_backfill_that_still_leaves_its_headroom():
 # --------------------------------------------------------------------------- #
 # cross-pass progress -- the property a single-pass assertion cannot see
 # --------------------------------------------------------------------------- #
-def _drive_passes(gpus, seeded, *, backfill, passes, num_slots=8, queue_depth=4):
+def _drive_passes(
+    gpus,
+    seeded,
+    *,
+    backfill,
+    passes,
+    num_slots=8,
+    queue_depth=4,
+    external_hold=None,
+):
     """Drive repeated `_select_launches` passes against live `gpu_states`.
 
     Mirrors ``run_parallel``'s loop -- retire what finished, select, commit --
@@ -764,7 +773,14 @@ def _drive_passes(gpus, seeded, *, backfill, passes, num_slots=8, queue_depth=4)
     only place the suite can see that.
 
     ``run_time`` is in passes. Returns ``{name: pass index it launched on}``.
+
+    ``external_hold`` maps a GPU index to GiB held by a process OUTSIDE this run
+    (another container on the node, a leaked engine). It is subtracted from that
+    card's live free reading and is never released, so it models the one thing
+    the scheduler's own accounting cannot see. Default ``None`` keeps the
+    historical behaviour exactly.
     """
+    external_hold = external_hold or {}
     pending = sorted(seeded, key=_priority_key, reverse=True)
     running: dict[str, tuple[_TestEntry, int]] = {}
     started: dict[str, int] = {}
@@ -785,7 +801,11 @@ def _drive_passes(gpus, seeded, *, backfill, passes, num_slots=8, queue_depth=4)
             )
             for gi in gpus
         }
-        actual_free = {gi: gs.total_gib - resident[gi] for gi, gs in gpus.items()}
+        held = external_hold(now) if callable(external_hold) else external_hold
+        actual_free = {
+            gi: gs.total_gib - resident[gi] - held.get(gi, 0.0)
+            for gi, gs in gpus.items()
+        }
         if len(running) >= num_slots:
             continue
         launches = _select_launches(
@@ -2050,3 +2070,551 @@ def test_non_vllm_tests_are_not_staggered(monkeypatch, tmp_path):
 
     assert rc == 0
     assert _staggered(harness.sleeps) == []
+
+
+# --------------------------------------------------------------------------- #
+# reservation eligibility -- a gang may only reserve GPUs it could run on
+#
+# Found by clean-room review of the first gang implementation. The blocked-gang
+# reservation ranked candidate devices by headroom magnitude but never applied
+# the eligibility THRESHOLD the launch scan applies, so a device that can never
+# host the gang -- too small, or holding memory from outside this run -- scored
+# maximum headroom precisely BECAUSE it was idle, won a protector slot, and left
+# a genuinely usable device unprotected to saturate. Reserving R outside the
+# eligible set E is fictitious protection: it spends one of the `k` all-or-none
+# slots and buys no path to launch.
+# --------------------------------------------------------------------------- #
+def test_gang_does_not_reserve_a_card_that_is_too_small_to_ever_host_it():
+    """The tightest statement of the invariant, in a single pass.
+
+    GPU0 (10 GiB, 6.0 committed to one process) can host the gang once it
+    drains. GPU1 (10 GiB, idle) can host it now. GPU2 (5 GiB) can NEVER: 5.0 is
+    below the gang's 6.0 per-device requirement.
+
+    The gang needs two devices and only GPU1 qualifies, so it blocks and
+    reserves. Ranking by headroom alone puts GPU2 (5.0 free) above GPU0 (2.5
+    free), so the hold lands on {1, 2} and leaves GPU0 -- the only other card
+    that could ever run the gang -- open for backfill.
+
+    Observable consequence: the 2.0 GiB filler. If GPU0 is left unprotected the
+    filler lands there and pushes the card further from hosting the gang. Under
+    a correct reservation the hold is {0, 1}, the filler is refused on both, and
+    it goes to GPU2, which is where work belongs -- GPU2 is useless to the gang
+    but perfectly good for a filler.
+    """
+    gpus = {
+        0: _gpu(0, 10.0, budget_used=6.0, running_count=1),
+        1: _gpu(1, 10.0),
+        2: _gpu(2, 5.0),
+    }
+    gang = _t("gang", 6.0, timeout=1800, gpus=2)
+    filler = _t("filler", 3.0, timeout=15.0)
+    assert _unschedulable_reason(gang, gpus) is None, "gang must be feasible"
+
+    launches = _select_checked([gang, filler], gpus, num_slots=8, running_count=1)
+
+    # Ranked by headroom, GPU2 (5.0 idle) outranks GPU0 (8.5 - 6.0 = 2.5), so an
+    # unfiltered reservation takes {1, 2} and leaves GPU0 open. The filler is
+    # 3.0: too big for what GPU0 has left, and refused on both held cards, so
+    # under the unfiltered rule nothing launches at all and the gang's hold is
+    # sitting on a card it can never use. Filtered, the hold is {0, 1} and GPU2
+    # -- useless to the gang, fine for a filler -- takes the work.
+    assert launches == [(1, (2,))], (
+        "the gang must hold the two cards that can actually host it (0 and 1), "
+        "leaving the 5 GiB card free for backfill; instead the hold landed on "
+        "the card that can never host the gang"
+    )
+
+
+def test_gang_is_not_starved_by_a_card_too_small_to_ever_host_it():
+    """Cross-pass form of the same defect: the gang must still launch.
+
+    Identical to test_blocked_gang_is_not_starved_by_endless_lower_priority_backfill
+    except for a third card of 5.9 GiB -- below the gang's 6.0 requirement, so it
+    can never host it -- and a filler lifetime long enough that the unprotected
+    card never drains between passes.
+    """
+    gpus = {0: _gpu(0, 10.0), 1: _gpu(1, 10.0), 2: _gpu(2, 5.9)}
+    hog = _t("hog", 3.0, timeout=120)  # est 40 passes
+    gang = _t("gang", 6.0, timeout=90, gpus=2)
+    assert _unschedulable_reason(gang, gpus) is None
+
+    started = _drive_passes(
+        gpus,
+        [hog, gang],
+        backfill=lambda i: _t(f"fill{i}", 2.0, timeout=21.0),
+        passes=400,
+    )
+
+    assert "gang" in started, (
+        "feasible gpu_2 gang never launched in 400 passes on a node with two "
+        "cards big enough for it -- starved by a reservation placed on the card "
+        "that is too small to ever host it"
+    )
+    assert started["gang"] <= 41, started["gang"]
+
+
+@pytest.mark.parametrize("third", [5.0, 5.5, 5.9, 6.0, 10.0])
+def test_gang_progress_does_not_depend_on_an_unusable_third_card(third):
+    """Sweep the third card across the feasibility boundary (requirement 6.0).
+
+    Below 6.0 the card cannot host the gang; at or above it, it can. Either way
+    two 10 GiB cards are present, so the gang is feasible throughout and must
+    launch as soon as the hog retires. Progress must not depend on the size of a
+    card the gang does not need.
+    """
+    gpus = {0: _gpu(0, 10.0), 1: _gpu(1, 10.0), 2: _gpu(2, third)}
+    hog = _t("hog", 3.0, timeout=120)
+    gang = _t("gang", 6.0, timeout=90, gpus=2)
+    assert _unschedulable_reason(gang, gpus) is None
+
+    started = _drive_passes(
+        gpus,
+        [hog, gang],
+        backfill=lambda i: _t(f"fill{i}", 2.0, timeout=21.0),
+        passes=400,
+    )
+
+    assert "gang" in started, f"starved with third card = {third} GiB"
+    assert started["gang"] <= 41, (third, started["gang"])
+
+
+def test_making_a_gpu_larger_never_delays_a_gang():
+    """Monotonicity: growing a card must not make scheduling worse.
+
+    A physically nonsensical result -- enlarging GPU2 from 5.0 to 5.9 turning a
+    launching gang into a starving one -- is exactly what the unfiltered
+    reservation ranking produced, because a larger idle card outranks a smaller
+    one for a protector slot it can still never honour.
+    """
+
+    def start_pass(third):
+        gpus = {0: _gpu(0, 10.0), 1: _gpu(1, 10.0), 2: _gpu(2, third)}
+        started = _drive_passes(
+            gpus,
+            [_t("hog", 3.0, timeout=120), _t("gang", 6.0, timeout=90, gpus=2)],
+            backfill=lambda i: _t(f"fill{i}", 2.0, timeout=21.0),
+            passes=400,
+        )
+        return started.get("gang")
+
+    sizes = [5.0, 5.5, 5.9, 6.0, 10.0]
+    starts = [start_pass(s) for s in sizes]
+
+    assert all(s is not None for s in starts), dict(zip(sizes, starts))
+    for (small, a), (large, b) in zip(zip(sizes, starts), list(zip(sizes, starts))[1:]):
+        assert b <= a, (
+            f"growing GPU2 from {small} to {large} GiB delayed the gang "
+            f"from pass {a} to pass {b}"
+        )
+
+
+@pytest.mark.parametrize("frees_at", [None, 40, 80])
+def test_progress_under_foreign_memory_is_conditional_on_it_being_released(frees_at):
+    """The stated limit of the progress property, pinned in both directions.
+
+    Reservation placement looks only at card size, never at live free memory,
+    because ``(total - free) - budget`` cannot separate a neighbour's allocation
+    -- which may never be released -- from our own test overshooting its profile
+    or still ramping, which always is. Consulting it would reject cards that
+    recover while admitting cards that do not.
+
+    So a gang needing a card that a neighbour is holding waits, and that is the
+    honest guarantee: three 10 GiB cards, a gang wanting 6.0 on two of them, and
+    4.5 GiB held on GPU2 by something outside this run.
+
+    - held forever: the gang never launches. This is regime D -- outside the
+      claimed domain, and stated rather than papered over.
+    - released at pass 40 or 80: the gang launches on exactly that pass, so
+      nothing the scheduler did in the meantime cost it its place.
+    """
+    gpus = {0: _gpu(0, 10.0), 1: _gpu(1, 10.0), 2: _gpu(2, 10.0)}
+    started = _drive_passes(
+        gpus,
+        [_t("hog", 3.0, timeout=120), _t("gang", 6.0, timeout=90, gpus=2)],
+        backfill=lambda i: _t(f"fill{i}", 2.0, timeout=21.0),
+        passes=400,
+        external_hold=(
+            lambda now: {2: 4.5} if (frees_at is None or now < frees_at) else {}
+        ),
+    )
+
+    if frees_at is None:
+        assert "gang" not in started, (
+            "documented limitation changed: the gang launched despite a card it "
+            "needs being held by a process outside this run"
+        )
+    else:
+        assert started.get("gang") == frees_at, (
+            f"gang should launch the pass the foreign memory is released "
+            f"({frees_at}), got {started.get('gang')}"
+        )
+
+
+def test_gpu1_control_is_unaffected_by_an_unusable_card():
+    """Control: the same topology must not regress single-GPU scheduling.
+
+    A gpu_1 test only ever needs one card to come free and any card will do, so
+    the unfiltered reservation never cost it progress. This pins that the repair
+    is about gangs and that gpu_1 behaviour is unchanged by it.
+    """
+    gpus = {0: _gpu(0, 10.0), 1: _gpu(1, 10.0), 2: _gpu(2, 5.9)}
+    started = _drive_passes(
+        gpus,
+        [_t("hog", 3.0, timeout=120), _t("blocked", 6.0, timeout=90)],
+        backfill=lambda i: _t(f"fill{i}", 2.0, timeout=21.0),
+        passes=400,
+    )
+
+    assert "blocked" in started
+    assert started["blocked"] <= 41, started["blocked"]
+
+
+def test_gang_still_holds_its_cards_while_every_card_is_transiently_blocked():
+    """The filter must not be able to REMOVE protection a gang already needed.
+
+    Two 16 GiB cards (budget_multi 13.6) and a gang wanting 12.0 on each. Until
+    pass 40 a neighbour holds 5.0 GiB on both, so neither card can host the gang
+    yet -- 5.0 + 12.0 > 16.0 -- and no card passes an eligibility filter. The
+    neighbours then leave and both cards become usable.
+
+    Treating the filter as an admission test drops the reservation entirely on
+    exactly the passes it is needed: the cards fill with 3.0 GiB backfill that
+    outlives the neighbours, and the gang -- which the pre-repair code launched
+    the moment they left -- waits for the backfill to drain instead. A hold is
+    protection against the future; it must not be revoked because of one live
+    reading of the present.
+    """
+    gpus = {0: _gpu(0, 16.0), 1: _gpu(1, 16.0)}
+    gang = _t("gang", 12.0, timeout=1800, gpus=2)
+    assert _unschedulable_reason(gang, gpus) is None
+
+    started = _drive_passes(
+        gpus,
+        [gang],
+        backfill=lambda i: _t(f"fill{i}", 3.0, timeout=600.0),
+        passes=400,
+        external_hold=lambda now: {0: 5.0, 1: 5.0} if now < 40 else {},
+    )
+
+    assert "gang" in started, "gang never launched after its blockers left"
+    assert started["gang"] <= 60, (
+        f"gang launched on pass {started['gang']}, long after the neighbours "
+        "left on pass 40 -- its cards were given away while it was unprotected"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# the assignment has to survive into the WORKERS, not just be derived
+#
+# The tests above execute the script's device-derivation block. They cannot see
+# what the two worker launches actually do with it: pinning both workers to the
+# same device, or dropping the pin entirely, leaves the derivation untouched and
+# every one of them green. That is the whole bug this script was changed to fix,
+# so it gets an end-to-end check -- the real script, unmodified, with a stand-in
+# for the engine.
+# --------------------------------------------------------------------------- #
+def _bash_with_wait_n() -> str | None:
+    """A bash new enough for ``wait -n``, which launch_utils.sh requires (4.3+).
+
+    macOS ships bash 3.2, so this is a skip locally unless a newer bash is on
+    PATH; CI containers run bash 5.
+    """
+    seen = []
+    for cand in ("bash", "/opt/homebrew/bin/bash", "/usr/local/bin/bash"):
+        path = shutil.which(cand) if "/" not in cand else cand
+        if not path or path in seen or not Path(path).exists():
+            continue
+        seen.append(path)
+        out = subprocess.run(
+            [path, "-c", 'echo "${BASH_VERSINFO[0]} ${BASH_VERSINFO[1]}"'],
+            capture_output=True,
+            text=True,
+        )
+        if out.returncode != 0:
+            continue
+        try:
+            major, minor = (int(x) for x in out.stdout.split())
+        except ValueError:
+            continue
+        if (major, minor) >= (4, 3):
+            return path
+    return None
+
+
+_BASH43 = _bash_with_wait_n()
+
+_STUB_GPU_UTILS = """\
+build_vllm_gpu_mem_args() { echo ""; }
+"""
+_STUB_LAUNCH_UTILS = """\
+print_launch_banner() { :; }
+print_curl_footer() { cat > /dev/null; }
+wait_any_exit() { wait; }
+"""
+_STUB_PYTHON3 = """\
+#!/bin/sh
+echo "CVD=${CUDA_VISIBLE_DEVICES-<unset>} ARGS=$*" >> "$DYN_TEST_LAUNCH_LOG"
+exit 0
+"""
+
+
+def _run_launcher(tmp_path, visible_devices):
+    """Run the REAL launch script with a stand-in engine; return its launches."""
+    root = tmp_path / "tree"
+    launch_dir = root / "examples/backends/vllm/launch"
+    common_dir = root / "examples/common"
+    bin_dir = tmp_path / "bin"
+    for d in (launch_dir, common_dir, bin_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    shutil.copy(_GANG_LAUNCH_SCRIPT, launch_dir / _GANG_LAUNCH_SCRIPT.name)
+    (common_dir / "gpu_utils.sh").write_text(_STUB_GPU_UTILS)
+    (common_dir / "launch_utils.sh").write_text(_STUB_LAUNCH_UTILS)
+    stub = bin_dir / "python3"
+    stub.write_text(_STUB_PYTHON3)
+    stub.chmod(0o755)
+
+    log = tmp_path / "launches.log"
+    log.write_text("")
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DYN_TEST_LAUNCH_LOG"] = str(log)
+    if visible_devices is None:
+        env.pop("CUDA_VISIBLE_DEVICES", None)
+    else:
+        env["CUDA_VISIBLE_DEVICES"] = visible_devices
+
+    proc = subprocess.run(
+        [_BASH43, str(launch_dir / _GANG_LAUNCH_SCRIPT.name), "model-a", "model-b"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+        # `trap 'kill 0' EXIT` in the script would otherwise signal the whole
+        # pytest process group.
+        start_new_session=True,
+    )
+    workers = {}
+    for line in log.read_text().splitlines():
+        if "dynamo.vllm" not in line:
+            continue
+        cvd = line.split("CVD=", 1)[1].split(" ARGS=", 1)[0]
+        if "embed-worker-1" in line:
+            workers["w1"] = cvd
+        elif "embed-worker-2" in line:
+            workers["w2"] = cvd
+    return proc, workers
+
+
+@pytest.mark.skipif(
+    _BASH43 is None, reason="launch_utils.sh needs bash >= 4.3 for `wait -n`"
+)
+def test_each_worker_is_pinned_to_its_own_device_of_the_assigned_gang(tmp_path):
+    """Handed the gang (2,3), the two workers must land on 2 and 3 -- not both
+    on 2, not both inheriting the whole set."""
+    proc, workers = _run_launcher(tmp_path, "2,3")
+
+    assert workers.get("w1") == "2", (proc.stderr, workers)
+    assert workers.get("w2") == "3", (proc.stderr, workers)
+    assert workers["w1"] != workers["w2"], (
+        "both vLLM workers were pinned to the same device -- the scheduler "
+        "reserved two GPUs and charged VRAM on both, so one of them is now "
+        "double-booked and the other is idle"
+    )
+
+
+@pytest.mark.skipif(
+    _BASH43 is None, reason="launch_utils.sh needs bash >= 4.3 for `wait -n`"
+)
+def test_workers_follow_a_reordered_assignment_rather_than_sorting_it(tmp_path):
+    """The launcher must not re-sort what it inherits.
+
+    The scheduler always emits an ascending gang, so it cannot itself produce
+    (3,2); this pins the launcher's half of the contract for a hand-run
+    invocation, and stops a future "tidy the list" change from silently
+    reintroducing a fixed device order.
+    """
+    _, workers = _run_launcher(tmp_path, "3,2")
+    assert (workers.get("w1"), workers.get("w2")) == ("3", "2"), workers
+
+
+@pytest.mark.skipif(
+    _BASH43 is None, reason="launch_utils.sh needs bash >= 4.3 for `wait -n`"
+)
+def test_launcher_starts_no_worker_when_it_is_handed_one_device(tmp_path):
+    """Fail closed: a single visible device must not run both workers on it."""
+    proc, workers = _run_launcher(tmp_path, "4")
+    assert proc.returncode != 0, proc.stdout
+    assert workers == {}, f"workers started despite an unusable device set: {workers}"
+
+
+def test_no_card_is_committed_past_its_multi_process_budget(monkeypatch):
+    """Once two VRAM-bearing tests share a card, the margin must hold.
+
+    The cap in force is the whole card while at most one VRAM-bearing test lives
+    there, and ``budget_multi`` once a second joins -- so a sole occupant above
+    ``budget_multi`` is correct, and only co-residency is a violation. Zero-VRAM
+    fillers raise ``running_count`` without consuming budget and are excluded by
+    design.
+
+    The regime matters. Every other sweep here derives ``actual_free`` from the
+    scheduler's own accounting, which makes the live-usage gate shadow the
+    budget gate exactly and hides any error in the intra-pass tentative charge.
+    This one reports the whole card as free, so only the budget arithmetic is
+    load bearing: dividing a gang's tentative charge across its members instead
+    of charging each one in full over-commits a card here, and is invisible in
+    the derived regime.
+    """
+    rnd = random.Random(20260823)
+    for _ in range(400):
+        n_gpus = rnd.choice([1, 2, 3, 4])
+        gpus = {
+            gi: _gpu(gi, rnd.choice([8.0, 10.0, 16.0, 24.0])) for gi in range(n_gpus)
+        }
+        running: list[list] = []
+        for _pass in range(25):
+            pending = sorted(
+                (
+                    _t(
+                        f"t{i}",
+                        rnd.choice([0.0, 1.0, 2.5, 5.0, 9.0]),
+                        timeout=rnd.choice([30.0, 300.0]),
+                        gpus=rnd.choice([1, 1, 2]),
+                    )
+                    for i in range(rnd.randint(1, 4))
+                ),
+                key=_priority_key,
+                reverse=True,
+            )
+            launches = _select_launches(
+                pending=pending,
+                gpu_states=gpus,
+                # the whole card reads free, so the live gate never substitutes
+                # for the budget gate
+                actual_free={gi: gs.total_gib for gi, gs in gpus.items()},
+                num_slots=8,
+                running_count=len(running),
+            )
+            for idx, devices in launches:
+                _reserve_gpus(pending[idx], devices, gpus)
+                running.append([pending[idx], rnd.randint(1, 3)])
+
+            for gi, gs in gpus.items():
+                bearing = sum(
+                    1
+                    for entry, _ in running
+                    if gi in entry.assigned_gpus and entry.profiled_gib > 0
+                )
+                if bearing >= 2:
+                    assert gs.budget_used <= gs.budget_multi + 1e-9, (
+                        f"GPU{gi} holds {bearing} VRAM-bearing tests totalling "
+                        f"{gs.budget_used:.2f} GiB, past its multi-process "
+                        f"budget of {gs.budget_multi:.2f} GiB"
+                    )
+
+            survivors = []
+            for record in running:
+                record[1] -= 1
+                if record[1] <= 0:
+                    _release_gpus(record[0], gpus)
+                else:
+                    survivors.append(record)
+            running = survivors
+
+
+def test_a_card_too_small_is_rejected_even_when_its_foreign_memory_reads_negative():
+    """The capacity half of the reservation filter, isolated.
+
+    ``exogenous`` is ``(total - live_free) - committed_budget``, so a test that
+    holds budget it has not finished allocating drives it NEGATIVE -- here GPU2
+    has 2.0 GiB committed but only 0.3 GiB resident, giving -1.7. The
+    foreign-memory term then reads ``-1.7 + 6.0 <= 5.9`` and would happily admit
+    a 5.9 GiB card to a gang needing 6.0 on each device. Only the hard-capacity
+    term rejects it.
+
+    Without that term the hold lands on {1, 2}, GPU0 -- the one other card that
+    could ever run this gang -- is left open, and the 3.0 GiB filler cannot fit
+    in what remains of it, so nothing launches at all.
+    """
+    gpus = {
+        0: _gpu(0, 10.0, budget_used=6.0, running_count=1),
+        1: _gpu(1, 10.0),
+        2: _gpu(2, 5.9, budget_used=2.0, running_count=1),
+    }
+    actual_free = {0: 4.0, 1: 10.0, 2: 5.6}  # GPU2 has only 0.3 GiB resident
+    gang = _t("gang", 6.0, timeout=1800, gpus=2)
+    filler = _t("filler", 3.0, timeout=15.0)
+    assert _unschedulable_reason(gang, gpus) is None
+
+    launches = _select_checked(
+        [gang, filler], gpus, num_slots=8, running_count=2, actual_free=actual_free
+    )
+
+    assert launches == [(1, (2,))], (
+        "the 5.9 GiB card cannot host a 6.0 GiB gang no matter what its live "
+        "free reading says; it must not take a reservation slot from GPU0"
+    )
+
+
+def test_gang_falls_back_to_a_full_hold_when_only_some_cards_look_usable():
+    """The fallback must trigger on ANY shortfall, not only on a total wipeout.
+
+    Three 16 GiB cards, a gang wanting 12.0 on two of them, and neighbours
+    holding 5.0 GiB on GPU0 and GPU1 until pass 40. Only GPU2 passes the
+    eligibility filter, so the preferred list has one entry for a gang that
+    needs two.
+
+    One survivor is still a shortfall: the gang must fall back to the unfiltered
+    list and hold two cards. A fallback that only fires when the filtered list is
+    completely empty leaves the gang unprotected here, and the backfill takes the
+    cards while it waits.
+    """
+    gpus = {0: _gpu(0, 16.0), 1: _gpu(1, 16.0), 2: _gpu(2, 16.0)}
+    gang = _t("gang", 12.0, timeout=1800, gpus=2)
+    assert _unschedulable_reason(gang, gpus) is None
+
+    started = _drive_passes(
+        gpus,
+        [gang],
+        backfill=lambda i: _t(f"fill{i}", 3.0, timeout=600.0),
+        passes=400,
+        external_hold=lambda now: {0: 5.0, 1: 5.0} if now < 40 else {},
+    )
+
+    assert "gang" in started, "gang never launched after its blockers left"
+    assert started["gang"] <= 60, (
+        f"gang launched on pass {started['gang']}: with only one card passing "
+        "the filter it went unprotected instead of falling back to a full hold"
+    )
+
+
+def test_a_card_exactly_the_size_of_the_requirement_can_still_be_reserved():
+    """The boundary must agree with ``_unschedulable_reason``.
+
+    Pre-flight counts a card as able to host the test when ``total_gib >=
+    profiled_gib``, so a 6.0 GiB card is feasible for a 6.0 GiB gang -- as its
+    sole occupant, since an idle card's cap is the whole card. A reservation
+    filter using a strict ``>`` would disagree with that, and on a node whose
+    only large-enough cards are exact fits it would refuse to protect a gang
+    pre-flight had just declared schedulable.
+
+    Here GPU1 and GPU2 are exact fits and GPU0 is busy and too small, so the
+    hold has to land on {1, 2} and refuse the filler both places; the only card
+    left for it is GPU0.
+    """
+    gpus = {
+        0: _gpu(0, 5.0, budget_used=2.0, running_count=1),
+        1: _gpu(1, 6.0, budget_used=1.0, running_count=1),
+        2: _gpu(2, 6.0, budget_used=1.0, running_count=1),
+    }
+    gang = _t("gang", 6.0, timeout=1800, gpus=2)
+    filler = _t("filler", 1.5, timeout=15.0)
+    assert _unschedulable_reason(gang, gpus) is None, "pre-flight must accept it"
+
+    launches = _select_checked([gang, filler], gpus, num_slots=8, running_count=3)
+
+    assert launches == [(1, (0,))], (
+        "a card whose capacity exactly equals the requirement is feasible per "
+        "_unschedulable_reason and must remain reservable"
+    )

--- a/tests/utils/test_pytest_parallel_gpu.py
+++ b/tests/utils/test_pytest_parallel_gpu.py
@@ -11,16 +11,28 @@ the VRAM-aware ordering beats the legacy timeout-sorted first-fit. No GPU or
 
 from __future__ import annotations
 
+import io
+import itertools
+import random
+
 import pytest
 
-from tests.utils import vram_utils
+from tests.utils import pytest_parallel_gpu, vram_utils
 from tests.utils.pytest_parallel_gpu import (
     _GpuState,
     _priority_key,
+    _release_gpus,
+    _reserve_gpus,
     _select_launches,
+    _status_lines,
     _TestEntry,
+    _unschedulable_reason,
 )
-from tests.utils.vram_utils import VRAM_MULTI_PROC_MARGIN
+from tests.utils.vram_utils import (
+    DEFAULT_GPU_COUNT,
+    VRAM_MULTI_PROC_MARGIN,
+    gpu_count_from_marker_names,
+)
 
 pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
 
@@ -44,8 +56,14 @@ def _gpu(
     )
 
 
-def _t(name: str, profiled: float, timeout: float = 600.0) -> _TestEntry:
-    return _TestEntry(id=name, name=name, profiled_gib=profiled, timeout=timeout)
+def _t(name: str, profiled: float, timeout: float = 600.0, gpus: int = 1) -> _TestEntry:
+    return _TestEntry(
+        id=name,
+        name=name,
+        profiled_gib=profiled,
+        timeout=timeout,
+        gpu_count=gpus,
+    )
 
 
 def _select(pending, gpus, *, num_slots, running_count=0, actual_free=None):
@@ -92,7 +110,7 @@ def test_pairs_large_with_small_on_one_gpu():
 
     launches = _select(pending, gpus, num_slots=8)
 
-    assert launches == [(0, 0), (1, 0)]
+    assert launches == [(0, (0,)), (1, (0,))]
 
 
 def test_first_test_uses_full_card_then_multi_proc_margin():
@@ -103,7 +121,7 @@ def test_first_test_uses_full_card_then_multi_proc_margin():
 
     launches = _select(pending, gpus, num_slots=8)
 
-    assert launches == [(0, 0)]
+    assert launches == [(0, (0,))]
 
 
 def test_multi_gpu_spreads_then_packs():
@@ -114,7 +132,7 @@ def test_multi_gpu_spreads_then_packs():
 
     launches = _select(pending, gpus, num_slots=8)
 
-    assert launches == [(0, 0), (1, 1), (2, 1)]
+    assert launches == [(0, (0,)), (1, (1,)), (2, (1,))]
 
 
 # --------------------------------------------------------------------------- #
@@ -128,7 +146,7 @@ def test_zero_vram_fillers_bypass_budget():
 
     launches = _select(pending, gpus, num_slots=8, running_count=1)
 
-    assert launches == [(0, 0), (1, 0)]
+    assert launches == [(0, (0,)), (1, (0,))]
 
 
 def test_slot_cap_is_global():
@@ -149,7 +167,7 @@ def test_actual_usage_gate_blocks_when_live_vram_exceeds_budget():
     pending = [_t("big", 13.0)]
 
     # Budget gate alone (actual_free defaults to total - budget = 22): launches.
-    assert _select(pending, gpus, num_slots=8) == [(0, 0)]
+    assert _select(pending, gpus, num_slots=8) == [(0, (0,))]
 
     # Only 5 GiB actually free => 17 GiB live-used; 17 + 13 = 30 > 22 cap -> the
     # actual-usage gate blocks the launch the budget gate would have allowed.
@@ -171,7 +189,7 @@ def test_reservation_keeps_room_for_blocked_high_priority_test():
 
     launches = _select(pending, gpus, num_slots=8, running_count=1)
 
-    assert launches == [(1, 0)]  # only one 3.8 backfill; room held for the 12
+    assert launches == [(1, (0,))]  # only one 3.8 backfill; room held for the 12
 
 
 def test_blocked_test_launches_once_occupant_frees():
@@ -184,7 +202,7 @@ def test_blocked_test_launches_once_occupant_frees():
 
     # 12 fits (19-3.8=15.2) and is highest priority; the extra 3.8 no longer fits
     # (19-15.8=3.2<3.8).
-    assert launches == [(0, 0)]
+    assert launches == [(0, (0,))]
 
 
 # --------------------------------------------------------------------------- #
@@ -242,7 +260,11 @@ def _build_workload() -> list[_SimTest]:
 
 def _legacy_select(pending, gpu_states, actual_free, num_slots, running_count):
     """The pre-change algorithm: first-fit (most-available-budget) over pending
-    in its given order, no filler bypass, no reservation."""
+    in its given order, no filler bypass, no reservation.
+
+    Returns the same ``(index, device tuple)`` shape as ``_select_launches`` so
+    the simulator can drive either one; it only ever assigns a single device,
+    which is all the pre-change algorithm could do."""
     tent = {
         gi: {
             "budget": gs.budget_used,
@@ -251,7 +273,7 @@ def _legacy_select(pending, gpu_states, actual_free, num_slots, running_count):
         }
         for gi, gs in gpu_states.items()
     }
-    to_launch: list[tuple[int, int]] = []
+    to_launch: list[tuple[int, tuple[int, ...]]] = []
     for i, test in enumerate(pending):
         if running_count + len(to_launch) >= num_slots:
             break
@@ -267,7 +289,7 @@ def _legacy_select(pending, gpu_states, actual_free, num_slots, running_count):
             if avail > best_avail:
                 best_gi, best_avail = gi, avail
         if best_gi is not None:
-            to_launch.append((i, best_gi))
+            to_launch.append((i, (best_gi,)))
             tent[best_gi]["budget"] += test.profiled_gib
             tent[best_gi]["free"] -= test.profiled_gib
             tent[best_gi]["count"] += 1
@@ -298,12 +320,17 @@ def _simulate_makespan(tests, *, num_slots, gpus_total, order_key, select) -> fl
             running_count=len(running),
         )
         if sel:
-            for idx, gi in sorted(sel, key=lambda x: x[0], reverse=True):
+            for idx, gpus in sorted(sel, key=lambda x: x[0], reverse=True):
                 t = pending.pop(idx)
-                gpu_states[gi].budget_used += t.profiled_gib
-                gpu_states[gi].running_count += 1
+                for gi in gpus:
+                    gpu_states[gi].budget_used += t.profiled_gib
+                    gpu_states[gi].running_count += 1
                 running.append(
-                    {"finish": now + t.runtime, "profiled": t.profiled_gib, "gpu": gi}
+                    {
+                        "finish": now + t.runtime,
+                        "profiled": t.profiled_gib,
+                        "gpus": gpus,
+                    }
                 )
             continue
         assert running, "deadlock: pending tests but nothing running"
@@ -311,8 +338,9 @@ def _simulate_makespan(tests, *, num_slots, gpus_total, order_key, select) -> fl
         still = []
         for r in running:
             if r["finish"] <= now:
-                gpu_states[r["gpu"]].budget_used -= r["profiled"]
-                gpu_states[r["gpu"]].running_count -= 1
+                for gi in r["gpus"]:
+                    gpu_states[gi].budget_used -= r["profiled"]
+                    gpu_states[gi].running_count -= 1
             else:
                 still.append(r)
         running = still
@@ -450,3 +478,1087 @@ def test_simulation_conserves_work_and_respects_budget():
 
     assert makespan >= longest
     assert makespan >= total_work / 8 - 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# multi-GPU (gang) scheduling
+#
+# A gpu_2 test needs two distinct devices at once. `profiled_vram_gib` is the
+# maximum per-device peak, so the same figure is reserved on every member --
+# see `_reserve_gpus`. These tests pin the semantics the scheduler must keep.
+# --------------------------------------------------------------------------- #
+def _snapshot(pending, gpu_states, actual_free):
+    """Deep value-copy of everything `_select_launches` is handed."""
+    return (
+        [
+            (t.id, t.profiled_gib, t.timeout, t.gpu_count, t.assigned_gpus)
+            for t in pending
+        ],
+        {
+            gi: (
+                gs.index,
+                gs.total_gib,
+                gs.budget_multi,
+                gs.budget_used,
+                gs.running_count,
+            )
+            for gi, gs in gpu_states.items()
+        },
+        dict(actual_free),
+    )
+
+
+def _assert_selection_invariants(launches, pending, gpu_states, actual_free, before):
+    """The scheduler contract, checked after any selection.
+
+    Cardinality, distinctness, stable ordering, capacity, non-negative
+    accounting, and that the selector did not mutate its inputs.
+    """
+    seen: set[int] = set()
+    added = {gi: 0.0 for gi in gpu_states}
+    counts = {gi: gs.running_count for gi, gs in gpu_states.items()}
+
+    for idx, gpus in launches:
+        assert idx not in seen, f"pending index {idx} launched twice"
+        seen.add(idx)
+        test = pending[idx]
+        # I1: a job owns exactly gpu_count distinct GPUs -- never a partial gang.
+        assert len(gpus) == test.gpu_count, f"{test.id}: gang size != gpu_count"
+        assert len(set(gpus)) == len(gpus), f"{test.id}: duplicate GPU in gang"
+        # I6: deterministic, stable device order.
+        assert list(gpus) == sorted(gpus), f"{test.id}: gang not ascending"
+        for gi in gpus:
+            assert gi in gpu_states, f"{test.id}: unknown GPU {gi}"
+            added[gi] += test.profiled_gib
+            counts[gi] += 1
+
+    for gi, gs in gpu_states.items():
+        committed = gs.budget_used + added[gi]
+        # I2: a reservation never exceeds the physical card.
+        assert committed <= gs.total_gib + 1e-9, f"GPU{gi} over capacity"
+        # I5: no resource count goes negative.
+        assert committed >= -1e-9, f"GPU{gi} negative budget"
+        assert counts[gi] >= 0, f"GPU{gi} negative process count"
+
+    # Selector purity: pure means pure.
+    assert _snapshot(pending, gpu_states, actual_free) == before
+
+
+def _select_checked(pending, gpus, *, num_slots, running_count=0, actual_free=None):
+    """`_select` plus the invariant sweep, for use by every gang test."""
+    if actual_free is None:
+        actual_free = {gi: gs.total_gib - gs.budget_used for gi, gs in gpus.items()}
+    before = _snapshot(pending, gpus, actual_free)
+    launches = _select_launches(
+        pending=pending,
+        gpu_states=gpus,
+        actual_free=actual_free,
+        num_slots=num_slots,
+        running_count=running_count,
+    )
+    _assert_selection_invariants(launches, pending, gpus, actual_free, before)
+    return launches
+
+
+def test_gpu2_takes_two_distinct_devices():
+    # The basic case: one gpu_2 test on an idle 2-GPU node takes both cards,
+    # in ascending order, as a single launch costing a single slot.
+    gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0)}
+    pending = [_t("gang", 5.0, gpus=2)]
+
+    assert _select_checked(pending, gpus, num_slots=8) == [(0, (0, 1))]
+
+
+def test_gpu2_needs_two_devices_and_waits_on_a_single_gpu_node():
+    # One card cannot host a gang however much VRAM is free. It must wait
+    # rather than be silently downgraded to a single device.
+    gpus = {0: _gpu(0, 80.0)}
+    pending = [_t("gang", 5.0, gpus=2)]
+
+    assert _select_checked(pending, gpus, num_slots=8) == []
+
+
+def test_gang_is_atomic_when_one_member_fails_the_budget_gate():
+    # GPU0 is idle; GPU1 has only 2 GiB of budget left. A 12 GiB gang must not
+    # take GPU0 alone -- a partial gang is never a valid allocation.
+    gpus = {
+        0: _gpu(0, 22.0),
+        1: _gpu(1, 22.0, budget_used=17.0, running_count=1),
+    }
+    pending = [_t("gang12", 12.0, gpus=2)]
+
+    assert _select_checked(pending, gpus, num_slots=8) == []
+
+
+def test_gang_is_atomic_when_one_member_fails_the_actual_free_gate():
+    # Both GPUs look idle by scheduler budget, so the budget gate alone would
+    # place the gang. GPU1 is actually holding 18 of its 22 GiB (an init spike
+    # or a process outside this run), so the independent actual-usage gate must
+    # veto the whole gang, not just that member.
+    gpus = {0: _gpu(0, 22.0), 1: _gpu(1, 22.0)}
+    pending = [_t("gang12", 12.0, gpus=2)]
+
+    assert _select_checked(pending, gpus, num_slots=8) == [(0, (0, 1))]
+    assert (
+        _select_checked(pending, gpus, num_slots=8, actual_free={0: 22.0, 1: 4.0}) == []
+    )
+
+
+def test_gang_picks_the_two_emptiest_of_three_gpus():
+    # Best-fit generalizes: the gang takes the two GPUs with the most free
+    # budget (1 and 2), leaving the loaded GPU0 alone.
+    gpus = {
+        0: _gpu(0, 22.0, budget_used=10.0, running_count=1),
+        1: _gpu(1, 22.0, budget_used=2.0, running_count=1),
+        2: _gpu(2, 22.0),
+    }
+    pending = [_t("gang", 5.0, gpus=2)]
+
+    assert _select_checked(pending, gpus, num_slots=8) == [(0, (1, 2))]
+
+
+def test_gang_respects_asymmetric_physical_capacities():
+    # A mixed node: only the two 80 GiB cards can hold a 30 GiB-per-device
+    # gang; the 22 GiB card is too small and must be skipped.
+    gpus = {0: _gpu(0, 22.0), 1: _gpu(1, 80.0), 2: _gpu(2, 80.0)}
+    pending = [_t("gang30", 30.0, gpus=2)]
+
+    assert _select_checked(pending, gpus, num_slots=8) == [(0, (1, 2))]
+
+
+def test_gang_ordering_is_deterministic_under_ties():
+    # All three GPUs are identical and idle, so every pair is equally good.
+    # The tie-break is the caller's gpu_states ordering, and the emitted set is
+    # ascending -- the same answer on every run, so CUDA_VISIBLE_DEVICES is
+    # reproducible.
+    for _ in range(20):
+        gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0), 2: _gpu(2, 80.0)}
+        pending = [_t("gang", 5.0, gpus=2)]
+        assert _select_checked(pending, gpus, num_slots=8) == [(0, (0, 1))]
+
+    # A non-ascending gpu_states order keeps the *caller's* preference (2 then
+    # 0 are the first two offered) while still emitting an ascending set.
+    gpus = {2: _gpu(2, 80.0), 0: _gpu(0, 80.0), 1: _gpu(1, 80.0)}
+    pending = [_t("gang", 5.0, gpus=2)]
+    assert _select_checked(pending, gpus, num_slots=8) == [(0, (0, 2))]
+
+
+def test_zero_profile_gang_still_takes_its_full_device_count():
+    # A gpu_2 test with profiled_vram_gib(0) allocates no VRAM but still needs
+    # two devices *visible*. The count is a visibility requirement, not a
+    # memory one, so the budget bypass must not collapse it to one device.
+    gpus = {0: _gpu(0, 22.0, budget_used=19.0, running_count=1), 1: _gpu(1, 22.0)}
+    pending = [_t("mock_gang", 0.0, gpus=2)]
+
+    assert _select_checked(pending, gpus, num_slots=8, running_count=1) == [(0, (0, 1))]
+
+
+def test_zero_profile_gang_blocked_when_devices_are_scarce():
+    # ...and it is still bounded by the device count, not by memory.
+    gpus = {0: _gpu(0, 22.0)}
+    pending = [_t("mock_gang", 0.0, gpus=2)]
+
+    assert _select_checked(pending, gpus, num_slots=8) == []
+
+
+def test_mixed_gpu1_and_gpu2_share_a_node_without_overlapping():
+    # The gang goes first (longest est_duration), taking both cards. The two
+    # gpu_1 tests then pack into the budget left on each card. No device is
+    # over-committed and the gang's per-device reservation is respected.
+    gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0)}
+    pending = [
+        _t("gang", 20.0, timeout=1800, gpus=2),
+        _t("single_a", 20.0, timeout=600),
+        _t("single_b", 20.0, timeout=600),
+    ]
+
+    launches = _select_checked(pending, gpus, num_slots=8)
+
+    assert launches[0] == (0, (0, 1))
+    placed = {idx: gpus_ for idx, gpus_ in launches}
+    assert set(placed) == {0, 1, 2}
+    # The two singles land on different cards -- best-fit spreads them.
+    assert placed[1] != placed[2]
+
+
+def test_gang_reservation_is_all_or_none():
+    # Two GPUs, both busy; a blocked 12 GiB gang needs headroom on BOTH. The
+    # backfill cap (cap - required = 19 - 12 = 7) therefore applies to each
+    # card, so only one 3.8 filler fits per card, not two.
+    gpus = {
+        0: _gpu(0, 22.0, budget_used=8.0, running_count=1),
+        1: _gpu(1, 22.0, budget_used=8.0, running_count=1),
+    }
+    pending = [
+        _t("gang12", 12.0, timeout=1800, gpus=2),
+        _t("fill_a", 3.8),
+        _t("fill_b", 3.8),
+        _t("fill_c", 3.8),
+    ]
+
+    launches = _select_checked(pending, gpus, num_slots=8, running_count=2)
+
+    # The gang itself cannot run yet (19 - 8 = 11 < 12).
+    assert all(idx != 0 for idx, _ in launches)
+    # One filler per reserved card, and no third: 7 GiB of backfill room each.
+    assert launches == [(1, (0,)), (2, (1,))]
+
+
+def test_gang_does_not_reserve_when_it_cannot_hold_every_device():
+    # Only one unreserved GPU is left, but the gang needs two. Holding headroom
+    # on that single card could never assemble into a launch, so it reserves
+    # nothing and leaves the card free for backfill.
+    gpus = {
+        0: _gpu(0, 22.0, budget_used=8.0, running_count=1),
+        1: _gpu(1, 22.0, budget_used=8.0, running_count=1),
+    }
+    pending = [
+        _t("blocked_single", 15.0, timeout=1800),  # reserves the better card
+        _t("blocked_gang", 15.0, timeout=1700, gpus=2),  # cannot reserve 2
+        _t("fill", 3.8),
+    ]
+
+    launches = _select_checked(pending, gpus, num_slots=8, running_count=2)
+
+    # The filler still backfills; the gang held nothing hostage.
+    assert launches == [(2, (1,))]
+
+
+def test_gang_launches_once_its_blockers_leave():
+    # Same node as the reservation test, but the 8 GiB occupants have finished.
+    # With both cards free the gang is highest priority and must launch on both.
+    gpus = {0: _gpu(0, 22.0), 1: _gpu(1, 22.0)}
+    pending = [_t("gang12", 12.0, timeout=1800, gpus=2), _t("fill", 3.8)]
+
+    launches = _select_checked(pending, gpus, num_slots=8)
+
+    assert launches[0] == (0, (0, 1))
+
+
+def test_gang_costs_one_slot_not_one_per_device():
+    # A gang is a single pytest subprocess. It must consume one concurrency
+    # slot however many GPUs it holds, or -n would silently mean something
+    # different for multi-GPU tests.
+    gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0)}
+    pending = [_t("gang", 5.0, gpus=2), _t("single", 5.0)]
+
+    assert len(_select_checked(pending, gpus, num_slots=1)) == 1
+    assert len(_select_checked(pending, gpus, num_slots=2)) == 2
+
+
+# --------------------------------------------------------------------------- #
+# unschedulable-job detection
+#
+# Without this the run loop waits for memory that is never coming: nothing is
+# running, so nothing will ever free, and `while pending or running` spins to
+# the CI timeout.
+# --------------------------------------------------------------------------- #
+def test_unschedulable_more_gpus_than_the_node_has():
+    gpus = {0: _gpu(0, 80.0)}
+    reason = _unschedulable_reason(_t("gang", 5.0, gpus=2), gpus)
+    assert reason is not None and "needs 2 GPUs" in reason
+
+
+def test_unschedulable_profiled_larger_than_every_card():
+    gpus = {0: _gpu(0, 22.0), 1: _gpu(1, 22.0)}
+    reason = _unschedulable_reason(_t("huge", 30.0), gpus)
+    assert reason is not None and "30.0 GiB" in reason
+
+
+def test_unschedulable_not_enough_large_cards_for_the_gang():
+    # One 80 GiB card is big enough, but a 2-GPU gang needs two of them.
+    gpus = {0: _gpu(0, 22.0), 1: _gpu(1, 80.0)}
+    reason = _unschedulable_reason(_t("gang30", 30.0, gpus=2), gpus)
+    assert reason is not None and "only 1 of 2 that large" in reason
+
+
+def test_schedulable_jobs_report_no_reason():
+    gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0)}
+    assert _unschedulable_reason(_t("single", 5.0), gpus) is None
+    assert _unschedulable_reason(_t("gang", 5.0, gpus=2), gpus) is None
+    # A zero-VRAM gang is bounded by device count only.
+    assert _unschedulable_reason(_t("mock", 0.0, gpus=2), gpus) is None
+    # A busy GPU does not make a job impossible -- it will free.
+    busy = {0: _gpu(0, 80.0, budget_used=79.0, running_count=3), 1: _gpu(1, 80.0)}
+    assert _unschedulable_reason(_t("gang", 5.0, gpus=2), busy) is None
+
+
+def test_impossible_job_is_detected_rather_than_deadlocking():
+    # The state the detector exists for: nothing running, nothing launchable,
+    # and no future event that could change either.
+    gpus = {0: _gpu(0, 22.0)}
+    pending = [_t("gang", 5.0, gpus=2)]
+
+    assert _select_checked(pending, gpus, num_slots=8, running_count=0) == []
+    assert _unschedulable_reason(pending[0], gpus) is not None
+
+
+# --------------------------------------------------------------------------- #
+# reservation lifecycle: conservation on every terminal path
+# --------------------------------------------------------------------------- #
+def _totals(gpu_states):
+    return {
+        gi: (round(gs.budget_used, 9), gs.running_count)
+        for gi, gs in gpu_states.items()
+    }
+
+
+def test_reserve_then_release_conserves_every_member():
+    gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0), 2: _gpu(2, 80.0)}
+    idle = _totals(gpus)
+    test = _t("gang", 5.0, gpus=2)
+
+    _reserve_gpus(test, (1, 0), gpus)
+
+    assert test.assigned_gpus == (0, 1)  # stored ascending regardless of input
+    assert _totals(gpus)[0] == (5.0, 1)
+    assert _totals(gpus)[1] == (5.0, 1)
+    assert _totals(gpus)[2] == (0.0, 0)  # untouched
+
+    _release_gpus(test, gpus)
+
+    assert test.assigned_gpus == ()
+    assert _totals(gpus) == idle
+
+
+def test_release_is_idempotent_so_a_double_terminal_path_cannot_leak():
+    # Completion, failure, runtime-skip and retry all funnel through
+    # `_release_gpus`. Releasing twice must not drive a count negative.
+    gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0)}
+    idle = _totals(gpus)
+    test = _t("gang", 5.0, gpus=2)
+
+    _reserve_gpus(test, (0, 1), gpus)
+    _release_gpus(test, gpus)
+    _release_gpus(test, gpus)
+
+    assert _totals(gpus) == idle
+    for gs in gpus.values():
+        assert gs.budget_used >= 0.0
+        assert gs.running_count >= 0
+
+
+def test_retry_cycle_conserves_across_many_rounds():
+    # A retried test is released and re-reserved, possibly onto a different
+    # gang. After the final release the node must be exactly as it started.
+    gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0), 2: _gpu(2, 80.0)}
+    idle = _totals(gpus)
+    test = _t("flaky_gang", 7.5, gpus=2)
+
+    for gang in [(0, 1), (1, 2), (0, 2), (0, 1)]:
+        _reserve_gpus(test, gang, gpus)
+        assert sum(gs.running_count for gs in gpus.values()) == 2
+        _release_gpus(test, gpus)
+        assert _totals(gpus) == idle
+
+    assert _totals(gpus) == idle
+
+
+def test_mixed_workload_release_order_does_not_matter():
+    gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0)}
+    idle = _totals(gpus)
+    gang = _t("gang", 5.0, gpus=2)
+    single = _t("single", 3.8)
+
+    _reserve_gpus(gang, (0, 1), gpus)
+    _reserve_gpus(single, (1,), gpus)
+    assert _totals(gpus)[1] == (8.8, 2)
+
+    _release_gpus(gang, gpus)  # release the gang first
+    assert _totals(gpus)[1] == (3.8, 1)
+    _release_gpus(single, gpus)
+    assert _totals(gpus) == idle
+
+
+# --------------------------------------------------------------------------- #
+# gpu_count metadata
+# --------------------------------------------------------------------------- #
+def test_gpu_count_resolves_from_the_hardware_marker():
+    assert gpu_count_from_marker_names(["gpu_1", "vllm", "e2e"]) == 1
+    assert gpu_count_from_marker_names(["e2e", "gpu_2"]) == 2
+    assert gpu_count_from_marker_names(["gpu_4"]) == 4
+    assert gpu_count_from_marker_names(["gpu_8"]) == 8
+
+
+def test_gpu_count_is_absent_without_a_hardware_marker():
+    # No gpu_N marker -> None, so the caller falls back to DEFAULT_GPU_COUNT.
+    # gpu_0 declares "no GPU needed", not a device count, so it does not
+    # participate: such tests keep being scheduled as single-device fillers.
+    assert gpu_count_from_marker_names([]) is None
+    assert gpu_count_from_marker_names(["unit", "pre_merge"]) is None
+    assert gpu_count_from_marker_names(["gpu_0"]) is None
+    assert DEFAULT_GPU_COUNT == 1
+
+
+def test_conflicting_gpu_count_markers_fail_closed():
+    # Guessing low would under-reserve devices and let another test be placed
+    # on a GPU this one is already using. The declaration is rejected instead.
+    with pytest.raises(ValueError) as excinfo:
+        gpu_count_from_marker_names(["gpu_1", "gpu_2"])
+    # The offenders must be named, not just the generic "one of gpu_1/..." hint.
+    assert "['gpu_1', 'gpu_2']" in str(excinfo.value)
+
+    # Repeating the same marker is not a conflict.
+    assert gpu_count_from_marker_names(["gpu_2", "gpu_2"]) == 2
+
+
+def test_conflicting_markers_are_named_even_from_a_generator():
+    # write_test_meta passes a generator over the item's markers, so the error
+    # path must not depend on being able to iterate the argument twice.
+    names = (n for n in ["e2e", "gpu_2", "vllm", "gpu_4"])
+    with pytest.raises(ValueError) as excinfo:
+        gpu_count_from_marker_names(names)
+    # Asserting on the rendered list, not a bare substring: the message also
+    # ends with a generic "one of gpu_1/gpu_2/gpu_4/gpu_8" hint, which would
+    # make a substring check pass even on an empty list.
+    assert "['gpu_2', 'gpu_4']" in str(excinfo.value)
+
+
+def test_metadata_without_gpu_count_defaults_to_one_gpu():
+    # Backward compatibility: a metadata file written before gpu_count existed
+    # has no such key, and must schedule exactly as it always did.
+    assert _TestEntry(id="t", name="t", profiled_gib=3.8, timeout=600).gpu_count == 1
+
+
+# --------------------------------------------------------------------------- #
+# gpu_1 regression oracle
+#
+# `_reference_single_gpu_select` is the selection algorithm exactly as it stood
+# before multi-GPU support, kept here as a frozen oracle. Generalizing to gangs
+# must not perturb any single-GPU decision, so the two are compared over a
+# bounded exhaustive state space and a seeded random sweep. If a future change
+# means to alter gpu_1 scheduling, this test fails and the oracle has to be
+# updated deliberately -- which is the point.
+# --------------------------------------------------------------------------- #
+def _reference_single_gpu_select(pending, gpu_states, actual_free, num_slots, running):
+    """Frozen pre-gang `_select_launches`; assigns exactly one GPU per test."""
+    tentative = {
+        gi: {
+            "budget": gs.budget_used,
+            "free": actual_free[gi],
+            "count": gs.running_count,
+        }
+        for gi, gs in gpu_states.items()
+    }
+    reserved_req: dict[int, float] = {}
+    backfill_added: dict[int, float] = {}
+    to_launch: list[tuple[int, int]] = []
+
+    def cap(gi):
+        gs = gpu_states[gi]
+        return gs.total_gib if tentative[gi]["count"] < 1 else gs.budget_multi
+
+    for idx, test in enumerate(pending):
+        if running + len(to_launch) >= num_slots:
+            break
+        if test.profiled_gib <= 0:
+            gi = min(gpu_states, key=lambda g: tentative[g]["count"])
+            to_launch.append((idx, gi))
+            tentative[gi]["count"] += 1
+            continue
+        best_gi, best_avail = None, -1.0
+        for gi, gs in gpu_states.items():
+            ts = tentative[gi]
+            c = cap(gi)
+            avail = c - ts["budget"]
+            if avail < test.profiled_gib:
+                continue
+            if (gs.total_gib - ts["free"]) + test.profiled_gib > c:
+                continue
+            if gi in reserved_req and (
+                backfill_added[gi] + test.profiled_gib > c - reserved_req[gi]
+            ):
+                continue
+            if avail > best_avail:
+                best_gi, best_avail = gi, avail
+        if best_gi is not None:
+            to_launch.append((idx, best_gi))
+            tentative[best_gi]["budget"] += test.profiled_gib
+            tentative[best_gi]["free"] -= test.profiled_gib
+            tentative[best_gi]["count"] += 1
+            if best_gi in reserved_req:
+                backfill_added[best_gi] += test.profiled_gib
+            continue
+        cand, cand_avail = None, -1.0
+        for gi in gpu_states:
+            if gi in reserved_req:
+                continue
+            a = cap(gi) - tentative[gi]["budget"]
+            if a > cand_avail:
+                cand, cand_avail = gi, a
+        if cand is not None:
+            reserved_req[cand] = test.profiled_gib
+            backfill_added[cand] = 0.0
+    return to_launch
+
+
+def _iter_bounded_states():
+    """A small, fully enumerated corner of the scheduler's state space.
+
+    Deliberately built from stdlib `itertools` -- the repo has no property-based
+    testing dependency, and a fixed enumeration is reproducible without one.
+    """
+    sizes = (22.0, 80.0)
+    useds = (0.0, 15.0)
+    counts = (0, 1)
+    catalog = (
+        (0.0, 1),
+        (0.0, 2),
+        (3.8, 1),
+        (12.0, 1),
+        (12.0, 2),
+        (20.0, 2),
+    )
+    for n_gpus in (1, 2, 3):
+        for per_gpu in itertools.product(
+            itertools.product(sizes, useds, counts), repeat=n_gpus
+        ):
+            gpus = {
+                gi: _gpu(gi, size, budget_used=used, running_count=count)
+                for gi, (size, used, count) in enumerate(per_gpu)
+            }
+            for job_a, job_b in itertools.product(catalog, repeat=2):
+                pending = [
+                    _t("a", job_a[0], timeout=1800, gpus=job_a[1]),
+                    _t("b", job_b[0], timeout=600, gpus=job_b[1]),
+                ]
+                for tight in (False, True):
+                    free = {
+                        gi: (
+                            gs.total_gib * 0.25
+                            if tight
+                            else gs.total_gib - gs.budget_used
+                        )
+                        for gi, gs in gpus.items()
+                    }
+                    yield pending, gpus, free
+
+
+def test_bounded_exhaustive_states_hold_every_invariant():
+    # Every reachable selection in the enumerated space satisfies gang
+    # cardinality, distinctness, ascending order, capacity, non-negative
+    # accounting, and selector purity.
+    checked = 0
+    for pending, gpus, free in _iter_bounded_states():
+        for num_slots in (1, 3):
+            _select_checked(
+                pending,
+                gpus,
+                num_slots=num_slots,
+                running_count=0,
+                actual_free=free,
+            )
+            checked += 1
+    assert checked > 2000, f"state space unexpectedly small ({checked})"
+
+
+def test_bounded_exhaustive_single_gpu_matches_the_frozen_oracle():
+    # Restricted to gpu_count == 1, the generalized selector must reproduce the
+    # pre-change algorithm decision for decision, including its tie-breaks.
+    compared = 0
+    for pending, gpus, free in _iter_bounded_states():
+        if any(t.gpu_count != 1 for t in pending):
+            continue
+        for num_slots in (1, 3):
+            for running in (0, 1):
+                new = _select_launches(
+                    pending=pending,
+                    gpu_states=gpus,
+                    actual_free=free,
+                    num_slots=num_slots,
+                    running_count=running,
+                )
+                ref = _reference_single_gpu_select(
+                    pending, gpus, free, num_slots, running
+                )
+                assert new == [
+                    (i, (gi,)) for i, gi in ref
+                ], f"gpu_1 regression: {new} != {ref}"
+                compared += 1
+    assert compared > 500, f"oracle comparison too narrow ({compared})"
+
+
+def test_randomized_single_gpu_matches_the_frozen_oracle():
+    # Wider and messier than the exhaustive sweep: shuffled gpu_states ordering
+    # (so the tie-break is exercised), mixed card sizes, and live-free readings
+    # unrelated to the reserved budget. Seeded, so a failure reproduces.
+    rng = random.Random(13647)
+    sizes = [16.0, 22.0, 24.0, 40.0, 80.0, 141.0]
+    vrams = [0.0, 0.0, 3.8, 5.0, 6.9, 7.6, 12.0, 13.0, 20.0, 30.0, 45.0]
+
+    for _ in range(3000):
+        n_gpus = rng.randint(1, 4)
+        gpus = {}
+        for gi in rng.sample(range(8), n_gpus):  # non-contiguous, out of order
+            total = rng.choice(sizes)
+            gpus[gi] = _gpu(
+                gi,
+                total,
+                budget_used=round(rng.uniform(0, total * 0.9), 2),
+                running_count=rng.randint(0, 3),
+            )
+        pending = [
+            _t(f"t{j}", rng.choice(vrams), timeout=rng.choice([140.0, 600.0, 1800.0]))
+            for j in range(rng.randint(1, 6))
+        ]
+        free = {gi: round(rng.uniform(0, gs.total_gib), 2) for gi, gs in gpus.items()}
+        num_slots = rng.randint(1, 8)
+        running = rng.randint(0, num_slots)
+
+        new = _select_launches(
+            pending=pending,
+            gpu_states=gpus,
+            actual_free=free,
+            num_slots=num_slots,
+            running_count=running,
+        )
+        ref = _reference_single_gpu_select(pending, gpus, free, num_slots, running)
+        assert new == [(i, (gi,)) for i, gi in ref]
+
+
+def test_randomized_gang_selections_hold_every_invariant():
+    # The same sweep with gangs mixed in, checked against the invariant set
+    # rather than an oracle (there is no pre-change behaviour to compare to).
+    rng = random.Random(846)
+    sizes = [22.0, 40.0, 80.0]
+    vrams = [0.0, 3.8, 12.0, 20.0, 45.0]
+
+    for _ in range(3000):
+        n_gpus = rng.randint(1, 4)
+        gpus = {}
+        for gi in rng.sample(range(8), n_gpus):
+            total = rng.choice(sizes)
+            gpus[gi] = _gpu(
+                gi,
+                total,
+                budget_used=round(rng.uniform(0, total * 0.85), 2),
+                running_count=rng.randint(0, 2),
+            )
+        pending = [
+            _t(
+                f"t{j}",
+                rng.choice(vrams),
+                timeout=rng.choice([140.0, 600.0, 1800.0]),
+                gpus=rng.choice([1, 1, 2, 2, 4]),
+            )
+            for j in range(rng.randint(1, 5))
+        ]
+        free = {gi: round(rng.uniform(0, gs.total_gib), 2) for gi, gs in gpus.items()}
+        _select_checked(
+            pending,
+            gpus,
+            num_slots=rng.randint(1, 8),
+            running_count=rng.randint(0, 3),
+            actual_free=free,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# runtime lifecycle: conservation through run_parallel itself
+#
+# The pure allocator is only half the contract. These drive the real run loop
+# with stand-in subprocesses so that every terminal path -- pass, fail, runtime
+# skip, retry -- is shown to return exactly what it reserved, on every member of
+# a gang. No GPU, no pynvml, no real pytest child.
+# --------------------------------------------------------------------------- #
+class _FakeProc:
+    """Stand-in for the pytest child: finishes immediately with a fixed result."""
+
+    def __init__(self, returncode: int, output: str, env: dict):
+        self.returncode = returncode
+        self.env = env
+        self.stdout = io.StringIO(output)
+
+    def poll(self):
+        return self.returncode
+
+
+class _RunHarness:
+    """Wires run_parallel to fake GPUs and fake subprocesses, and records both
+    every launch and the GPU accounting at each reserve/release."""
+
+    def __init__(self, monkeypatch, tmp_path, gpu_totals_gib, outcomes):
+        self.launches: list[dict] = []
+        self.ledger: list[tuple[str, str, tuple[int, ...], dict]] = []
+        self._outcomes = outcomes
+        self._attempts: dict[str, int] = {}
+        ppg = pytest_parallel_gpu
+
+        monkeypatch.setattr(
+            ppg,
+            "detect_gpus",
+            lambda: [
+                {"index": i, "name": "fake", "total_mib": int(t * 1024)}
+                for i, t in enumerate(gpu_totals_gib)
+            ],
+        )
+        monkeypatch.setattr(ppg, "effective_cpu_budget", lambda: 64)
+        monkeypatch.setattr(ppg, "_get_gpu_used_gib", lambda gi=0: 0.0)
+        self.sleeps: list[float] = []
+        monkeypatch.setattr(ppg.time, "sleep", self._sleep)
+        monkeypatch.setattr(ppg, "_JUNIT_DIR", str(tmp_path / "junit"))
+        monkeypatch.setattr(ppg, "_JUNIT_COMBINED", str(tmp_path / "junit" / "c.xml"))
+        monkeypatch.setattr(
+            ppg, "_parse_junit_skipped", lambda path: self._skip_reason(path)
+        )
+        monkeypatch.setattr(ppg.subprocess, "Popen", self._popen)
+
+        real_reserve, real_release = ppg._reserve_gpus, ppg._release_gpus
+
+        def reserve(test, gpus, gpu_states):
+            real_reserve(test, gpus, gpu_states)
+            self.ledger.append(
+                ("reserve", test.id, test.assigned_gpus, self._state(gpu_states))
+            )
+
+        def release(test, gpu_states):
+            held = test.assigned_gpus
+            real_release(test, gpu_states)
+            if held:
+                self.ledger.append(("release", test.id, held, self._state(gpu_states)))
+
+        monkeypatch.setattr(ppg, "_reserve_gpus", reserve)
+        monkeypatch.setattr(ppg, "_release_gpus", release)
+
+    def _sleep(self, seconds=0.0):
+        # Never actually sleep -- just record what the scheduler asked for, so
+        # the vLLM launch stagger is observable without slowing the suite.
+        self.sleeps.append(seconds)
+
+    @staticmethod
+    def _state(gpu_states):
+        return {
+            gi: (round(gs.budget_used, 6), gs.running_count)
+            for gi, gs in gpu_states.items()
+        }
+
+    def _test_id_from_cmd(self, cmd):
+        # `_launch_test` puts the node id straight after `-m pytest`.
+        return cmd[cmd.index("pytest") + 1]
+
+    def _skip_reason(self, junit_path):
+        for tid, spec in self._outcomes.items():
+            safe = tid.replace("/", "_").replace("::", "__")
+            if junit_path.endswith(f"{safe}.xml"):
+                return spec.get("skip_reason")
+        return None
+
+    def _popen(self, cmd, env=None, **kwargs):
+        tid = self._test_id_from_cmd(cmd)
+        spec = self._outcomes[tid]
+        attempt = self._attempts.get(tid, 0)
+        self._attempts[tid] = attempt + 1
+        self.launches.append(
+            {
+                "id": tid,
+                "attempt": attempt,
+                "cuda_visible_devices": env.get("CUDA_VISIBLE_DEVICES"),
+                "env": env,
+            }
+        )
+        rc = spec.get("returncodes", [spec.get("returncode", 0)])
+        rc = rc[min(attempt, len(rc) - 1)]
+        out = spec.get("outputs", [spec.get("output", "")])
+        out = out[min(attempt, len(out) - 1)]
+        return _FakeProc(rc, out, env)
+
+    def assert_conserved(self):
+        """Every reservation returned exactly once, nothing left held, no
+        negative accounting anywhere along the way."""
+        held: dict[str, tuple[int, ...]] = {}
+        for action, tid, gpus, state in self.ledger:
+            if action == "reserve":
+                assert tid not in held, f"{tid} reserved twice without release"
+                held[tid] = gpus
+            else:
+                assert tid in held, f"{tid} released without a reservation"
+                assert held.pop(tid) == gpus, f"{tid} released a different gang"
+            for gi, (budget, count) in state.items():
+                assert budget >= -1e-9, f"GPU{gi} negative budget: {budget}"
+                assert count >= 0, f"GPU{gi} negative process count: {count}"
+        assert not held, f"reservations never returned: {held}"
+        assert self.ledger, "harness recorded nothing"
+        final = self.ledger[-1][3]
+        assert all(
+            budget == pytest.approx(0.0, abs=1e-9) and count == 0
+            for budget, count in final.values()
+        ), f"GPUs not back to idle: {final}"
+
+
+def _meta(profiled, gpu_count=1, timeout=60):
+    m = {"profiled_vram_gib": profiled, "timeout": timeout}
+    if profiled > 0:
+        m["requested_vllm_kv_cache_bytes"] = 1_000_000
+    if gpu_count != 1:
+        m["gpu_count"] = gpu_count
+    return m
+
+
+def _run(harness_outcomes, meta, monkeypatch, tmp_path, gpu_totals=(80.0, 80.0)):
+    harness = _RunHarness(monkeypatch, tmp_path, gpu_totals, harness_outcomes)
+    rc = pytest_parallel_gpu.run_parallel(
+        test_ids=list(meta),
+        meta=meta,
+        max_vram_gib=80.0,
+        num_slots=4,
+    )
+    return harness, rc
+
+
+def test_gang_launch_sets_cuda_visible_devices_to_the_whole_gang(monkeypatch, tmp_path):
+    meta = {"t.py::gang": _meta(5.0, gpu_count=2)}
+    harness, rc = _run({"t.py::gang": {"returncode": 0}}, meta, monkeypatch, tmp_path)
+
+    assert rc == 0
+    assert len(harness.launches) == 1
+    # The complete gang, ascending -- not a single index.
+    assert harness.launches[0]["cuda_visible_devices"] == "0,1"
+    harness.assert_conserved()
+
+
+def test_single_gpu_launch_keeps_its_bare_index(monkeypatch, tmp_path):
+    # gpu_1 regression: one device still renders as a bare index, not "0,".
+    meta = {"t.py::single": _meta(5.0)}
+    harness, rc = _run({"t.py::single": {"returncode": 0}}, meta, monkeypatch, tmp_path)
+
+    assert rc == 0
+    assert harness.launches[0]["cuda_visible_devices"] == "0"
+    harness.assert_conserved()
+
+
+def test_gang_passing_releases_every_member(monkeypatch, tmp_path):
+    meta = {"t.py::gang": _meta(5.0, gpu_count=2), "t.py::single": _meta(5.0)}
+    harness, rc = _run(
+        {"t.py::gang": {"returncode": 0}, "t.py::single": {"returncode": 0}},
+        meta,
+        monkeypatch,
+        tmp_path,
+    )
+
+    assert rc == 0
+    harness.assert_conserved()
+
+
+def test_gang_failing_releases_every_member(monkeypatch, tmp_path):
+    meta = {"t.py::gang": _meta(5.0, gpu_count=2)}
+    harness, rc = _run(
+        {"t.py::gang": {"returncode": 1, "output": "E   assert False"}},
+        meta,
+        monkeypatch,
+        tmp_path,
+    )
+
+    assert rc == 1  # the failure is reported...
+    harness.assert_conserved()  # ...and both GPUs still came back
+
+
+def test_gang_runtime_skip_releases_every_member(monkeypatch, tmp_path):
+    # Exit code 0 with a skipped testcase in the JUnit XML: the run loop
+    # reclassifies it as SKIPPED, and that path must release too.
+    meta = {"t.py::gang": _meta(5.0, gpu_count=2)}
+    harness, rc = _run(
+        {"t.py::gang": {"returncode": 0, "skip_reason": "needs 2 H100s"}},
+        meta,
+        monkeypatch,
+        tmp_path,
+    )
+
+    assert rc == 0
+    harness.assert_conserved()
+
+
+def test_gang_retry_releases_and_reacquires_every_member(monkeypatch, tmp_path):
+    # First attempt trips a retryable init marker; the gang must be released in
+    # full before requeueing, then reserved again for the retry.
+    meta = {"t.py::gang": _meta(5.0, gpu_count=2)}
+    harness, rc = _run(
+        {
+            "t.py::gang": {
+                "returncodes": [1, 0],
+                "outputs": ["Error in memory profiling: boom", ""],
+            }
+        },
+        meta,
+        monkeypatch,
+        tmp_path,
+    )
+
+    assert rc == 0
+    assert len(harness.launches) == 2, "test should have been retried once"
+    assert [x["cuda_visible_devices"] for x in harness.launches] == ["0,1", "0,1"]
+    # reserve, release (retry), reserve, release (pass) -- no leak in between.
+    assert [entry[0] for entry in harness.ledger] == [
+        "reserve",
+        "release",
+        "reserve",
+        "release",
+    ]
+    harness.assert_conserved()
+
+
+def test_mixed_gang_and_single_workload_conserves_and_does_not_overlap(
+    monkeypatch, tmp_path
+):
+    meta = {
+        "t.py::gang": _meta(20.0, gpu_count=2, timeout=1800),
+        "t.py::s1": _meta(20.0, timeout=600),
+        "t.py::s2": _meta(20.0, timeout=600),
+        "t.py::filler": _meta(0.0, timeout=600),
+    }
+    outcomes = {tid: {"returncode": 0} for tid in meta}
+    harness, rc = _run(outcomes, meta, monkeypatch, tmp_path)
+
+    assert rc == 0
+    assert len(harness.launches) == 4
+    gang = next(x for x in harness.launches if x["id"] == "t.py::gang")
+    assert gang["cuda_visible_devices"] == "0,1"
+    harness.assert_conserved()
+
+
+@pytest.mark.timeout(60)
+def test_impossible_gang_is_rejected_before_anything_launches(monkeypatch, tmp_path):
+    # One GPU, a gpu_2 test: the run must fail fast with a diagnosis instead of
+    # waiting forever for a second device to appear.
+    meta = {"t.py::gang": _meta(5.0, gpu_count=2)}
+    harness, rc = _run(
+        {"t.py::gang": {"returncode": 0}},
+        meta,
+        monkeypatch,
+        tmp_path,
+        gpu_totals=(80.0,),
+    )
+
+    assert rc == 1
+    assert harness.launches == [], "nothing should have been launched"
+
+
+@pytest.mark.timeout(60)
+def test_oversized_single_gpu_test_is_rejected_before_anything_launches(
+    monkeypatch, tmp_path
+):
+    # The same detector covers the pre-existing gpu_1 case: profiled larger
+    # than any card used to spin the run loop until the CI timeout.
+    meta = {"t.py::huge": _meta(200.0)}
+    harness, rc = _run({"t.py::huge": {"returncode": 0}}, meta, monkeypatch, tmp_path)
+
+    assert rc == 1
+    assert harness.launches == []
+
+
+# --------------------------------------------------------------------------- #
+# status output
+# --------------------------------------------------------------------------- #
+def _running_entry(test, start_time=0.0):
+    return pytest_parallel_gpu._RunningTest(
+        proc=None, test=test, start_time=start_time  # type: ignore[arg-type]
+    )
+
+
+def test_status_shows_a_gang_on_every_gpu_it_occupies():
+    # A gpu_2 worker occupies both cards, so it must be listed under both. If
+    # it appeared under only one, the operator reading the log would think the
+    # other card was idle and that the test was single-GPU.
+    gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0), 2: _gpu(2, 80.0)}
+    gang = _t("gang", 5.0, gpus=2)
+    _reserve_gpus(gang, (0, 1), gpus)
+    running = {7: _running_entry(gang)}
+
+    lines = _status_lines(30.0, 0.0, gpus, running, lambda gi: 5.0)
+
+    assert "[w7(30s)]" in lines[0], lines[0]  # GPU0
+    assert "[w7(30s)]" in lines[1], lines[1]  # GPU1
+    assert "[w" not in lines[2], lines[2]  # GPU2 genuinely idle
+
+
+def test_status_lists_single_and_multi_gpu_workers_together():
+    gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0)}
+    gang = _t("gang", 5.0, gpus=2)
+    single = _t("single", 5.0)
+    _reserve_gpus(gang, (0, 1), gpus)
+    _reserve_gpus(single, (1,), gpus)
+    running = {0: _running_entry(gang), 1: _running_entry(single)}
+
+    lines = _status_lines(10.0, 0.0, gpus, running, lambda gi: 10.0)
+
+    assert "[w0(10s)]" in lines[0]  # GPU0: the gang only
+    assert "w0(10s), w1(10s)" in lines[1]  # GPU1: gang + single, sorted by w_id
+
+
+def test_status_omits_workers_from_idle_gpus():
+    gpus = {0: _gpu(0, 80.0), 1: _gpu(1, 80.0)}
+    single = _t("single", 5.0)
+    _reserve_gpus(single, (0,), gpus)
+
+    lines = _status_lines(5.0, 0.0, gpus, {3: _running_entry(single)}, lambda gi: 1.0)
+
+    assert "[w3(5s)]" in lines[0]
+    assert "[w" not in lines[1]
+
+
+# --------------------------------------------------------------------------- #
+# vLLM launch stagger across a gang
+#
+# vLLM's memory-profiling step snapshots free VRAM at startup, so two vLLM
+# processes must not start on the same device within the stagger window
+# (bug #10643). For a gang that means *every* device it touches, in both
+# directions: it waits on the most recent launch on any member, and it stamps
+# all of them when it starts.
+# --------------------------------------------------------------------------- #
+def _staggered(sleeps):
+    """Sleeps that look like the stagger rather than the 1s poll."""
+    return [d for d in sleeps if 1.5 < d <= pytest_parallel_gpu._VLLM_LAUNCH_STAGGER_S]
+
+
+def test_gang_waits_on_a_recent_launch_on_any_member(monkeypatch, tmp_path):
+    # GPU1 is the roomier card, so the single-GPU test best-fits onto it and
+    # launches first. The gang then takes (0, 1) -- its *second* member is the
+    # one that just saw a vLLM start, so it must still wait out the window.
+    meta = {
+        "t.py::single": _meta(5.0, timeout=1800),  # longest -> launches first
+        "t.py::gang": _meta(5.0, gpu_count=2, timeout=600),
+    }
+    outcomes = {tid: {"returncode": 0} for tid in meta}
+    harness, rc = _run(outcomes, meta, monkeypatch, tmp_path, gpu_totals=(40.0, 80.0))
+
+    assert rc == 0
+    single = next(x for x in harness.launches if x["id"] == "t.py::single")
+    gang = next(x for x in harness.launches if x["id"] == "t.py::gang")
+    assert single["cuda_visible_devices"] == "1"
+    assert gang["cuda_visible_devices"] == "0,1"
+    assert _staggered(
+        harness.sleeps
+    ), "gang launched without waiting out the stagger on GPU1"
+
+
+def test_gang_stamps_the_stagger_clock_on_every_member(monkeypatch, tmp_path):
+    # The gang launches first and takes both cards. The following single-GPU
+    # vLLM test best-fits onto GPU1 -- again the gang's second member -- so it
+    # must wait, which only happens if the gang stamped both devices.
+    meta = {
+        "t.py::gang": _meta(5.0, gpu_count=2, timeout=1800),  # launches first
+        "t.py::single": _meta(5.0, timeout=600),
+    }
+    outcomes = {tid: {"returncode": 0} for tid in meta}
+    harness, rc = _run(outcomes, meta, monkeypatch, tmp_path, gpu_totals=(40.0, 80.0))
+
+    assert rc == 0
+    assert harness.launches[0]["id"] == "t.py::gang"
+    single = next(x for x in harness.launches if x["id"] == "t.py::single")
+    assert single["cuda_visible_devices"] == "1"
+    assert _staggered(
+        harness.sleeps
+    ), "the gang did not stamp GPU1, so the next vLLM launch there did not wait"
+
+
+def test_non_vllm_tests_are_not_staggered(monkeypatch, tmp_path):
+    # The stagger exists for vLLM's profiling race only. A gang with no vLLM KV
+    # request must not pay it.
+    meta = {
+        "t.py::a": {"profiled_vram_gib": 0.0, "timeout": 600, "gpu_count": 2},
+        "t.py::b": {"profiled_vram_gib": 0.0, "timeout": 600},
+    }
+    outcomes = {tid: {"returncode": 0} for tid in meta}
+    harness, rc = _run(outcomes, meta, monkeypatch, tmp_path, gpu_totals=(40.0, 80.0))
+
+    assert rc == 0
+    assert _staggered(harness.sleeps) == []

--- a/tests/utils/vram_utils.py
+++ b/tests/utils/vram_utils.py
@@ -210,7 +210,12 @@ def write_test_meta(items, dest_dir: str | None = None) -> None:
     test_meta: dict[str, dict] = {}
     for item in items:
         meta: dict = {}
-        gpu_count = gpu_count_from_marker_names(m.name for m in item.iter_markers())
+        try:
+            gpu_count = gpu_count_from_marker_names(m.name for m in item.iter_markers())
+        except ValueError as exc:
+            # Raised during collection, where pytest reports an INTERNALERROR
+            # without the nodeid. Name the test so the typo is actionable.
+            raise ValueError(f"{item.nodeid}: {exc}") from exc
         if gpu_count is not None:
             meta["gpu_count"] = gpu_count
         profiled_mark = item.get_closest_marker("profiled_vram_gib")

--- a/tests/utils/vram_utils.py
+++ b/tests/utils/vram_utils.py
@@ -6,6 +6,7 @@
 Functions:
     detect_gpus()                  Enumerate GPUs via pynvml
     auto_worker_count(gpus, limit) Calculate slot count for -n auto
+    gpu_count_from_marker_names(names)  Resolve the gpu_N hardware requirement
     write_test_meta(items)         Serialize profiled/requested vram + timeout
     load_test_meta()               Read the serialized test metadata
     print_gpu_plan(gpus, limit, would_run)  Dry-run GPU plan summary
@@ -24,6 +25,7 @@ import json
 import logging
 import os
 import tempfile
+from collections.abc import Iterable
 from pathlib import Path
 
 _logger = logging.getLogger(__name__)
@@ -33,6 +35,47 @@ _logger = logging.getLogger(__name__)
 VRAM_MULTI_PROC_MARGIN = 0.15
 
 _TEST_META_FILENAME = "pytest_gpu_parallel_test_meta.json"
+
+# Hardware markers that declare how many GPUs a test needs. ``gpu_0`` is
+# deliberately absent: it declares "no GPU required", not a device count, and
+# such tests are scheduled as ordinary zero-VRAM fillers on a single device.
+# A test with none of these markers keeps the historical default of one GPU.
+GPU_COUNT_MARKERS: dict[str, int] = {
+    "gpu_1": 1,
+    "gpu_2": 2,
+    "gpu_4": 4,
+    "gpu_8": 8,
+}
+
+DEFAULT_GPU_COUNT = 1
+
+
+def gpu_count_from_marker_names(names: Iterable[str]) -> int | None:
+    """Resolve the GPU-count requirement declared by a test's marker names.
+
+    Returns ``None`` when the test declares no ``gpu_N`` marker, so the caller
+    can fall back to ``DEFAULT_GPU_COUNT`` -- which is also what a metadata file
+    written before this field existed deserializes to.
+
+    Fails closed on a test that declares two different counts (say ``gpu_1`` and
+    ``gpu_2``). Guessing the lower one would under-reserve devices and let a
+    second test be placed on a GPU this one is already using; guessing the
+    higher one would silently paper over a marker bug. Neither is safe, so the
+    declaration is rejected and named.
+    """
+    # Materialize first: callers pass a generator over the item's markers, and
+    # the error path below needs a second look at the same names.
+    declared_names = [n for n in names if n in GPU_COUNT_MARKERS]
+    declared = {GPU_COUNT_MARKERS[n] for n in declared_names}
+    if not declared:
+        return None
+    if len(declared) > 1:
+        conflicting = sorted(set(declared_names))
+        raise ValueError(
+            f"conflicting GPU-count markers {conflicting}; "
+            "a test must declare exactly one of gpu_1/gpu_2/gpu_4/gpu_8"
+        )
+    return declared.pop()
 
 
 def detect_gpus() -> list[dict]:
@@ -154,14 +197,22 @@ def effective_cpu_budget() -> int:
 
 
 def write_test_meta(items, dest_dir: str | None = None) -> None:
-    """Serialize profiled_vram_gib, timeout, and KV cache markers to JSON.
+    """Serialize gpu_count, profiled_vram_gib, timeout, and KV markers to JSON.
 
     Called from pytest_collection_modifyitems so the GPU orchestrator can
     read test metadata without re-collecting.
+
+    ``gpu_count`` is omitted for a test that declares no ``gpu_N`` marker, and
+    consumers default it to ``DEFAULT_GPU_COUNT``. That is also how metadata
+    written before this field existed deserializes, so an older file stays
+    readable.
     """
     test_meta: dict[str, dict] = {}
     for item in items:
         meta: dict = {}
+        gpu_count = gpu_count_from_marker_names(m.name for m in item.iter_markers())
+        if gpu_count is not None:
+            meta["gpu_count"] = gpu_count
         profiled_mark = item.get_closest_marker("profiled_vram_gib")
         if profiled_mark and profiled_mark.args:
             meta["profiled_vram_gib"] = profiled_mark.args[0]


### PR DESCRIPTION
## Overview

`gpu_2` tests are **already running in the VRAM-aware parallel lane, mis-accounted as single-GPU tests.** This is not a prospective feature — it is a live accounting defect in the nightly H100 lane, and this PR fixes it.

The scheduler models one device per test (`assigned_gpu: int | None`) and exports `CUDA_VISIBLE_DEVICES` as a single index. A `gpu_2` test is therefore charged its `profiled_vram_gib` against **one** card, while the launch script it drives occupies **two**.

From last night's run of `Nightly CI Pipeline` on `main` ([run 33371771283](https://github.com/ai-dynamo/dynamo/actions/runs/33371771283), job `vllm-runtime / H100 Test cuda13.0, amd64`):

```
GPU parallel: 106 tests, 96 concurrent slots, GPUs 0,1 (79 GiB each, 67 GiB multi-proc budget)

08:47:02  [w32] tests/serve/test_vllm.py::test_embedding_multi_worker_same_model_load_balance[2]
                (GPU0, profiled=5.0 GiB, req_kv=0.52 GiB) RUNNING
08:47:22  [w33] tests/serve/test_vllm.py::test_embedding_multi_worker_multi_model_dispatch[2]
                (GPU1, profiled=5.0 GiB, req_kv=0.52 GiB) RUNNING
08:49:28  [w32] ... PASSED [145s]
08:49:50  [w33] ... PASSED [148s]
```

Both tests carry `@pytest.mark.gpu_2` and `@pytest.mark.profiled_vram_gib(5.0)` on `main`, so both are eligible for the parallel lane; `nightly-ci.yml` selects `vllm and (gpu_1 or gpu_2)` with `run_gpu_parallel_tests: true`. Both drive `agg_embed_multiworker.sh`, which on `main` hardcodes `CUDA_VISIBLE_DEVICES=0` and `CUDA_VISIBLE_DEVICES=1` for its two workers. `CUDA_VISIBLE_DEVICES` is absolute, so the child replaces rather than composes the parent's restriction.

They overlapped for roughly two minutes. Each was booked on a single card and each physically occupied both. The books were wrong on both cards at once.

**Honest scope:** both tests passed. This is a latent accounting violation currently absorbed by 79 GiB of headroom on an otherwise-idle pair of cards — not an observed OOM, and I am not attributing any existing lane failure to it. The failure mode it creates is a scheduler that believes it has VRAM it does not have.

## What this PR changes

- `gpu_N` is represented as `gpu_count` in test metadata.
- A multi-GPU test reserves its complete device set **atomically**, or waits.
- `CUDA_VISIBLE_DEVICES` receives the full assigned set in stable ascending order, so the gang may be any pair (`2,3` as readily as `0,1`).
- Per-device VRAM gates (`total_gib` first tenant, `budget_multi` after) apply on every member.
- Reservation is released on pass, fail, runtime-skip, and retry.
- A blocked higher-priority gang holds eligible cards and admits lower-priority backfill only up to a documented line, so mixed `gpu_1`/`gpu_2` scheduling cannot starve the gang under the conditions stated under Known limitations.
- Example launch scripts index into the inherited `CUDA_VISIBLE_DEVICES` instead of hard-pinning absolute devices, and `tests/README.md` states that rule for future multi-GPU scripts.

## Where should the reviewer start?

`tests/utils/pytest_parallel_gpu.py` — `_select_launches` (atomic gang assignment and the unusable-card hold line). Then the boundary tests in `tests/utils/test_pytest_parallel_gpu.py`.

## Blast radius

Worth being precise about which lanes this touches, because the two halves differ:

- **`gpu_1` scheduling is covered pre-merge.** `pr.yaml` sets `run_gpu_parallel_tests: true` on the `pre_merge and <framework> and gpu_1` lanes (`gpu_parallel_max_vram_gib: '24'`). A regression in the shared scheduler path affecting single-GPU tests would be caught on every PR. The frozen-oracle tests in this PR lock exactly that behaviour.
- **Gang (`gpu_2`) scheduling runs only in nightly.** The pre-merge `2-GPU Test` lane (`gpu_test_markers: pre_merge and vllm and gpu_2`) does not set `run_gpu_parallel_tests`, and `shared-test.yml` defaults it to `false` — so `gpu_2` runs sequentially pre-merge. The only lane where a `gpu_2` test enters the parallel stage is nightly `vllm-runtime / H100` (`vllm and (gpu_1 or gpu_2)`, `run_gpu_parallel_tests: true`, `gpu_parallel_max_vram_gib: '80'`) — which is exactly the lane the log above comes from.

So the defect this fixes, and the new code that fixes it, are both nightly-only in effect. Reviewers should weigh the risk accordingly: no pre-merge job will exercise the gang path.

## Validation

Local, CPU-only, on this branch:

- `pytest tests/utils/test_pytest_parallel_gpu.py` — 107 passed. This is the one command that reproduces the whole claim.
- Coverage includes a frozen oracle locking `gpu_1` scheduling against the pre-change behaviour, and seeded sweeps over mixed `gpu_1`/`gpu_2` admission.
- 5 launcher tests `skipif` on `bash >= 4.3`; on a host without it they skip rather than fail.

**No CI job on this PR has executed a single Python test**, and no GPU has run any of it — the NVIDIA runner gate has never been opened on this branch. Real mixed `gpu_1`/`gpu_2` H100/GB200 validation remains outstanding and is the thing I would most like from a reviewer.

## Known limitations

- Backfill above the bounded hold line can be conservatively refused, even when it would be safe under a favourable future foreign-memory trajectory. This preserves the gang-progress guarantee; the PR does not claim globally maximal work conservation.
- The progress guarantee assumes residual foreign VRAM eventually falls within the documented multi-process margin. Persistent usage above that margin may delay the gang. The PR does not claim starvation-freedom under arbitrary external-memory trajectories.
- The scheduler's main `while pending or running:` loop has no bail-out for a child that outlives its timeout. That gap is pre-existing and is addressed directly by #12589 (see below).

## Interaction with open PRs

I ran the actual three-way merges rather than guessing:

- **#12589** (`hard-kill GPU-parallel test children that outlive their timeout`) — **merges clean against this branch, no conflicts.** **This PR does not solve the problem #12589 solves, and gangs make its case stronger, not weaker:** a hung `gpu_2` child strands two cards instead of one. I would rather see it land than work around it, and I am happy to rebase onto it.
- **#13683** (`centralize model selection and speed vLLM startup`) — conflicts with this branch, confined to the launch-stagger region of `pytest_parallel_gpu.py`. Its side restores `entry.assigned_gpu`, which this PR removes. If #13683 lands first I will drop the stagger generalisation and rebase; the gang admission rule does not depend on the stagger. I have also narrowed a sentence in `examples/common/gpu_utils.md` that overstated what `--kv-cache-memory-bytes` guarantees — it removes the engine-internal KV-pool profiling race, not concurrency hazards generally.
- **#13845** — no conflict; verified `git merge-file` clean on `tests/README.md` from the shared pre-image blob.
- **#12690** — `tests/README.md` only, merges clean.

## Related Issues

- Part of #13647.

Note that #13647's own motivating example, `test_router_decisions_vllm_disagg`, is **not** unblocked by this PR and is not claimed to be: it declares `gpu_2` but no `profiled_vram_gib`, so it remains ineligible for the parallel lane and continues to run in the sequential stage — which is what the issue's acceptance criteria specify for unprofiled tests. Profiling it is a separate change requiring hardware. Its stale in-file comment is corrected here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-GPU test scheduling with atomic device allocation and per-GPU memory checks.
  * Added GPU-count markers for tests requiring specific numbers of devices.
  * Worker launches now honor the inherited `CUDA_VISIBLE_DEVICES` assignments.

* **Bug Fixes**
  * Added validation for unavailable GPU counts, insufficient card capacity, and conflicting GPU declarations.
  * Improved scheduling retries, cleanup, logging, and stalled-resource diagnostics.

* **Documentation**
  * Clarified multi-GPU scheduling, memory reservation, concurrency, and execution behavior.
  * Updated configuration guidance for tests that are not yet profiled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
