### PR TITLE
fix(kvbm): remove the transfer batch size knob that nothing reads

### DIFF
--- a/docs/fern/pages/reference/components/kvbm-configuration.mdx
+++ b/docs/fern/pages/reference/components/kvbm-configuration.mdx
@@ -50,15 +50,11 @@ KVBM offloads KV blocks GPU (G1) → host/CPU (G2) → disk (G3) → object stor
   Minimum prefix priority a block must have to be offloaded to the host tier. Raises the bar for what gets offloaded.
 </ParamField>
 
-<ParamField path="DYN_KVBM_TRANSFER_BATCH_SIZE" type="integer" default="unset">
+<ParamField path="DYN_KVBM_MAX_TRANSFER_BATCH_SIZE" type="integer" default="16">
   Maximum number of blocks per transfer batch.
 </ParamField>
 
-<ParamField path="DYN_KVBM_MAX_TRANSFER_BATCH_SIZE" type="integer" default="unset">
-  Upper bound on the transfer batch size.
-</ParamField>
-
-<ParamField path="DYN_KVBM_MAX_CONCURRENT_TRANSFERS" type="integer" default="unset">
+<ParamField path="DYN_KVBM_MAX_CONCURRENT_TRANSFERS" type="integer" default="4">
   Maximum number of block transfers in flight at once.
 </ParamField>
 

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -283,12 +283,6 @@ pub mod kvbm {
         /// Number of blocks to store in object storage
         pub const DYN_KVBM_OBJECT_NUM_BLOCKS: &str = "DYN_KVBM_OBJECT_NUM_BLOCKS";
     }
-    /// Transfer configuration
-    pub mod transfer {
-        /// Maximum number of blocks per transfer batch
-        pub const DYN_KVBM_TRANSFER_BATCH_SIZE: &str = "DYN_KVBM_TRANSFER_BATCH_SIZE";
-    }
-
     /// KVBM leader (distributed mode) configuration
     pub mod leader {
         /// Timeout in seconds for KVBM leader and worker initialization


### PR DESCRIPTION
## Summary

`DYN_KVBM_TRANSFER_BATCH_SIZE` is declared in `environment_names.rs` and documented in the KVBM configuration reference as "Maximum number of blocks per transfer batch". Nothing reads it. The only two references in the repository are the constant and the docs entry:

```
docs/fern/pages/reference/components/kvbm-configuration.mdx:53
lib/runtime/src/config/environment_names.rs:289
```

The knob that actually works is `DYN_KVBM_MAX_TRANSFER_BATCH_SIZE`, added by #7527 and read through `offload.rs::max_transfer_batch_size`.

This matters because of where the dead name sits. The reference lists the two adjacently with near-identical descriptions, "Maximum number of blocks per transfer batch" for the dead one and "Upper bound on the transfer batch size" for the live one, so the dead name is arguably the more natural one to reach for. Setting it changes nothing and warns about nothing.

Removed rather than wired up: the live knob already covers the behaviour, and inventing semantics for a second one would add a tuning surface nobody asked for.

While in the same three entries, the defaults are also wrong. `offload.rs` defaults `DYN_KVBM_MAX_TRANSFER_BATCH_SIZE` to 16 and `DYN_KVBM_MAX_CONCURRENT_TRANSFERS` to 4, and the reference lists both as `unset`.

## Validation

Local, on macOS.

- `cargo build -p dynamo-runtime` clean.
- `cargo test -p dynamo-runtime --lib config::environment_names` is 2 passed, 0 failed, covering `test_no_duplicate_env_var_names` and `test_naming_conventions`.
- `cargo fmt --all -- --check` clean, `cargo clippy -p dynamo-runtime --lib` clean.
- `pre-commit run --files <the two files>` passes every hook that applies, including the Fern asset-path check. `pytest-marker-report` fails identically on an untouched `README.md` here because vLLM and TensorRT-LLM are not installed.

The removed module was unreferenced: `grep -rn "kvbm::transfer\|transfer::DYN_KVBM" --include='*.rs' lib` returns nothing, which is also what the clean build confirms.

I did not add a test. The removal is covered by the build, and the two corrected defaults are documentation values with the constants `DEFAULT_MAX_TRANSFER_BATCH_SIZE = 16` and `DEFAULT_MAX_CONCURRENT_TRANSFERS = 4` as their source of truth in `offload.rs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated transfer-batch configuration to use `DYN_KVBM_MAX_TRANSFER_BATCH_SIZE`.
  * The default maximum batch size is now 16.
  * Removed the previous transfer-batch configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->