### PR TITLE
fix(sglang): stop swallowing worker cancellation during metrics teardown

### DIFF
--- a/components/src/dynamo/sglang/init_diffusion.py
+++ b/components/src/dynamo/sglang/init_diffusion.py
@@ -20,6 +20,7 @@ from dynamo.sglang.health_check import (
     VideoGenerationHealthCheckPayload,
 )
 from dynamo.sglang.publisher import (
+    finish_worker_teardown,
     handle_non_leader_node,
     set_forward_pass_metrics_worker_id,
     setup_sgl_metrics,
@@ -92,6 +93,7 @@ async def init_llm_diffusion(
         f"Registering diffusion model with endpoint types: {dynamo_args.endpoint_types}"
     )
 
+    body_failed = True
     try:
         await asyncio.gather(
             generate_endpoint.serve_endpoint(
@@ -114,17 +116,15 @@ async def init_llm_diffusion(
     except Exception as e:
         logging.error(f"Failed to serve diffusion endpoints: {e}")
         raise
+    else:
+        body_failed = False
     finally:
-        metrics_task.cancel()
-        try:
-            await metrics_task
-        except asyncio.CancelledError:
-            logging.info("Metrics task successfully cancelled")
-            pass
-        handler.cleanup()
-        if run_deferred_handlers is not None:
-            logging.info("Running deferred handlers")
-            await run_deferred_handlers()
+        await finish_worker_teardown(
+            metrics_task,
+            handler.cleanup,
+            run_deferred_handlers,
+            body_failed=body_failed,
+        )
 
 
 async def init_image_diffusion(

--- a/components/src/dynamo/sglang/init_embedding.py
+++ b/components/src/dynamo/sglang/init_embedding.py
@@ -14,6 +14,7 @@ from dynamo.runtime import DistributedRuntime
 from dynamo.sglang.args import Config
 from dynamo.sglang.health_check import SglangHealthCheckPayload
 from dynamo.sglang.publisher import (
+    finish_worker_teardown,
     set_forward_pass_metrics_worker_id,
     setup_sgl_metrics,
 )
@@ -73,6 +74,8 @@ async def init_embedding(
     ).to_dict()
 
     register_model_taint_route(runtime, generate_endpoint)
+
+    body_failed = True
     try:
         await asyncio.gather(
             generate_endpoint.serve_endpoint(
@@ -96,14 +99,12 @@ async def init_embedding(
     except Exception as e:
         logging.error(f"Failed to serve embedding endpoints: {e}")
         raise
+    else:
+        body_failed = False
     finally:
-        metrics_task.cancel()
-        try:
-            await metrics_task
-        except asyncio.CancelledError:
-            logging.info("Metrics task successfully cancelled")
-            pass
-        handler.cleanup()
-        if run_deferred_handlers is not None:
-            logging.info("Running deferred handlers")
-            await run_deferred_handlers()
+        await finish_worker_teardown(
+            metrics_task,
+            handler.cleanup,
+            run_deferred_handlers,
+            body_failed=body_failed,
+        )

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -21,6 +21,7 @@ from dynamo.sglang.health_check import (
     SglangPrefillHealthCheckPayload,
 )
 from dynamo.sglang.publisher import (
+    finish_worker_teardown,
     handle_non_leader_node,
     set_forward_pass_metrics_worker_id,
     setup_sgl_metrics,
@@ -144,6 +145,7 @@ async def init_decode(
             "The chat template will be loaded but the /v1/chat/completions endpoint will not be available."
         )
 
+    body_failed = True
     try:
         gather_tasks = [
             generate_endpoint.serve_endpoint(
@@ -185,17 +187,15 @@ async def init_decode(
     except Exception as e:
         logging.error(f"Failed to serve endpoints: {e}")
         raise
+    else:
+        body_failed = False
     finally:
-        metrics_task.cancel()
-        try:
-            await metrics_task
-        except asyncio.CancelledError:
-            logging.info("Metrics task successfully cancelled")
-            pass
-        handler.cleanup()
-        if run_deferred_handlers is not None:
-            logging.info("Running deferred handlers")
-            await run_deferred_handlers()
+        await finish_worker_teardown(
+            metrics_task,
+            handler.cleanup,
+            run_deferred_handlers,
+            body_failed=body_failed,
+        )
 
 
 async def init_prefill(
@@ -281,6 +281,7 @@ async def init_prefill(
 
     ready_event = asyncio.Event()
 
+    body_failed = True
     try:
         await asyncio.gather(
             generate_endpoint.serve_endpoint(
@@ -329,14 +330,12 @@ async def init_prefill(
     except Exception as e:
         logging.error(f"Failed to serve endpoints: {e}")
         raise
+    else:
+        body_failed = False
     finally:
-        metrics_task.cancel()
-        try:
-            await metrics_task
-        except asyncio.CancelledError:
-            logging.info("Metrics task successfully cancelled")
-            pass
-        handler.cleanup()
-        if run_deferred_handlers is not None:
-            logging.info("Running deferred handlers")
-            await run_deferred_handlers()
+        await finish_worker_teardown(
+            metrics_task,
+            handler.cleanup,
+            run_deferred_handlers,
+            body_failed=body_failed,
+        )

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -150,7 +150,14 @@ async def worker(argv: list[str] | None = None):
 
 
 def main():
-    uvloop.run(worker())
+    try:
+        uvloop.run(worker())
+    except asyncio.CancelledError:
+        # Teardown re-raised the cancellation that stopped the worker; that is
+        # a clean shutdown, and exiting non-zero would read as a crash to K8s.
+        # An error-initiated shutdown must force its own non-zero exit at the
+        # failure site (as vLLM/TensorRT-LLM do), since this cannot tell them apart.
+        logger.info("Worker cancelled; shutdown complete")
 
 
 if __name__ == "__main__":

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -583,7 +583,8 @@ async def cancel_metrics_task(metrics_task: asyncio.Task) -> None:
 
     ``await metrics_task`` cannot tell the task's own cancellation from the
     caller's. ``asyncio.wait`` never raises on behalf of the task it waits on,
-    so any ``CancelledError`` escaping here is the caller's.
+    so any ``CancelledError`` escaping here is the caller's. Classifying on
+    ``metrics_task.done()`` instead looks equivalent but swallows the caller's.
     """
     metrics_task.cancel()
     await asyncio.wait([metrics_task])

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -6,7 +6,16 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Coroutine,
+    List,
+    Optional,
+    Tuple,
+)
 from urllib.parse import urlparse
 
 import sglang as sgl
@@ -564,6 +573,101 @@ async def setup_sgl_metrics(
     return publisher, task, metrics_labels
 
 
+# Teardown is never abandoned, so a metrics task that ignores cancel() can hang
+# shutdown. Warn on this interval so it is visible rather than silent.
+_TEARDOWN_WARN_INTERVAL_S = 30.0
+
+
+async def cancel_metrics_task(metrics_task: asyncio.Task) -> None:
+    """Cancel the metrics task and wait for it to finish unwinding.
+
+    ``await metrics_task`` cannot tell the task's own cancellation from the
+    caller's. ``asyncio.wait`` never raises on behalf of the task it waits on,
+    so any ``CancelledError`` escaping here is the caller's.
+    """
+    metrics_task.cancel()
+    await asyncio.wait([metrics_task])
+    if metrics_task.cancelled():
+        logging.info("Metrics task successfully cancelled")
+        return
+    exc = metrics_task.exception()
+    if exc is not None:
+        raise exc
+
+
+async def run_to_completion(coro: Coroutine[Any, Any, None]) -> bool:
+    """Run ``coro`` to completion even if the calling task is cancelled.
+
+    Returns ``True`` if a cancellation was aimed at the caller while waiting.
+    Never raises ``CancelledError``; the caller decides when to re-raise.
+    """
+    task = asyncio.ensure_future(coro)
+    loop = asyncio.get_running_loop()
+    outer_cancelled = False
+    t0 = loop.time()
+    next_warn_at = _TEARDOWN_WARN_INTERVAL_S
+    while not task.done():
+        try:
+            await asyncio.wait([task], timeout=_TEARDOWN_WARN_INTERVAL_S)
+        except asyncio.CancelledError:
+            # No Task.uncancel(); it is 3.11+ and requires-python is >=3.10.
+            # Revisit if a caller above starts using TaskGroup or asyncio.timeout.
+            outer_cancelled = True
+        # Elapsed wall time, checked unconditionally: repeated cancellation
+        # would otherwise keep resetting asyncio.wait's timer before it fires.
+        elapsed = loop.time() - t0
+        if not task.done() and elapsed >= next_warn_at:
+            logging.warning("Worker teardown still running after %.0fs", elapsed)
+            next_warn_at += _TEARDOWN_WARN_INTERVAL_S
+    if task.cancelled():
+        logging.error("Worker teardown was itself cancelled; cleanup is incomplete")
+        return True
+    exc = task.exception()
+    if exc is not None:
+        raise exc
+    return outer_cancelled
+
+
+async def finish_worker_teardown(
+    metrics_task: asyncio.Task,
+    cleanup: Callable[[], None],
+    run_deferred_handlers: Callable[[], Awaitable[None]] | None = None,
+    *,
+    body_failed: bool = False,
+) -> None:
+    """Run worker teardown to completion, then honour any cancellation.
+
+    The cancellation is absorbed until teardown finishes; re-raising earlier
+    would skip the deferred handlers that reap SGLang's scheduler subprocesses.
+    When the worker body already failed, that exception stays the reported one.
+    """
+
+    async def _teardown() -> None:
+        metrics_exc: Exception | None = None
+        try:
+            await cancel_metrics_task(metrics_task)
+        except Exception as exc:
+            logging.exception("Metrics task failed during teardown; continuing")
+            metrics_exc = exc
+        cleanup()
+        if run_deferred_handlers is not None:
+            logging.info("Running deferred handlers")
+            await run_deferred_handlers()
+        # Surfaced only once cleanup is done, and never over a body failure.
+        if metrics_exc is not None and not body_failed:
+            raise metrics_exc
+
+    outer_cancelled = await run_to_completion(_teardown())
+    if outer_cancelled:
+        if body_failed:
+            logging.warning(
+                "Worker cancelled during teardown; an earlier exception is "
+                "already propagating"
+            )
+        else:
+            raise asyncio.CancelledError
+
+
 async def handle_non_leader_node(
     engine: sgl.Engine,
     publisher: DynamoSglangPublisher,
@@ -583,6 +687,7 @@ async def handle_non_leader_node(
         "Running with metrics and KV event publishing for local DP ranks."
     )
 
+    body_failed = True
     try:
         if publisher.dynamo_args.use_kv_events and publishes_kv_events(
             publisher.server_args
@@ -597,9 +702,6 @@ async def handle_non_leader_node(
 
         await asyncio.Event().wait()
     finally:
-        metrics_task.cancel()
-        try:
-            await metrics_task
-        except asyncio.CancelledError:
-            pass
-        publisher.cleanup()
+        await finish_worker_teardown(
+            metrics_task, publisher.cleanup, body_failed=body_failed
+        )

--- a/components/src/dynamo/sglang/tests/test_sglang_publisher.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_publisher.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -13,8 +14,11 @@ from dynamo.sglang._disagg import SGLANG_WORKER_GROUP_ID_KEY, get_sglang_worker_
 from dynamo.sglang.publisher import (
     DynamoSglangPublisher,
     _resolve_multinode_leader_worker_id,
+    cancel_metrics_task,
+    finish_worker_teardown,
     get_local_dp_rank_range,
     handle_non_leader_node,
+    run_to_completion,
     set_forward_pass_metrics_worker_id,
     setup_sgl_metrics,
 )
@@ -740,3 +744,190 @@ async def test_setup_sgl_metrics_returns_publisher_for_chat_worker(monkeypatch):
             await task
         except asyncio.CancelledError:
             pass
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_cancel_metrics_task_waits_for_a_real_shaped_task():
+    """The real metrics tasks (publisher.run, _idle) park on a single await and
+    unwind with no further awaits after cancel(). Cancelling one must leave it
+    done and cancelled, and must not raise at the caller."""
+
+    async def metrics_loop():
+        await asyncio.Event().wait()
+
+    metrics_task = asyncio.create_task(metrics_loop())
+    await asyncio.sleep(0)
+
+    await cancel_metrics_task(metrics_task)
+
+    assert metrics_task.done()
+    assert metrics_task.cancelled()
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_cancel_metrics_task_propagates_a_real_failure():
+    """A non-cancellation failure inside the metrics task still surfaces."""
+
+    async def metrics_loop():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise RuntimeError("zmq close blew up") from None
+
+    metrics_task = asyncio.create_task(metrics_loop())
+    await asyncio.sleep(0)
+
+    with pytest.raises(RuntimeError, match="zmq close blew up"):
+        await cancel_metrics_task(metrics_task)
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_cancel_metrics_task_propagates_a_caller_cancellation():
+    """The discriminator: a cancellation aimed at the caller while it is
+    genuinely suspended inside cancel_metrics_task must reach the caller.
+    Both the original #12672 swallow-everything shape (`metrics_task.cancel()`
+    then a bare `except asyncio.CancelledError: pass` around
+    `await metrics_task`) and the rejected `metrics_task.done()`-classification
+    shape absorb this cancellation instead of propagating it, and fail this
+    test."""
+
+    async def metrics_loop():
+        # Takes several event-loop ticks to unwind after cancel(), so the
+        # caller is still suspended inside cancel_metrics_task -- not
+        # already past it -- when the caller's own cancellation lands.
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            for _ in range(3):
+                await asyncio.sleep(0)
+            raise
+
+    metrics_task = asyncio.create_task(metrics_loop())
+    await asyncio.sleep(0)
+
+    async def caller():
+        await cancel_metrics_task(metrics_task)
+
+    outer = asyncio.create_task(caller())
+    await asyncio.sleep(0)  # outer cancels metrics_task, then suspends inside
+    # cancel_metrics_task's await -- genuinely parked there, not finished.
+    outer.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await outer
+
+    try:
+        await metrics_task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_run_to_completion_finishes_the_body_when_the_caller_is_cancelled():
+    """The whole point: a cancellation aimed at the caller must not truncate
+    the teardown body, and must be reported rather than raised."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+    steps = []
+
+    async def body():
+        steps.append("first")
+        started.set()
+        await release.wait()
+        steps.append("second")
+
+    result = {}
+
+    async def caller():
+        result["cancelled"] = await run_to_completion(body())
+
+    outer = asyncio.create_task(caller())
+    await started.wait()
+    outer.cancel()
+    release.set()
+
+    await outer
+
+    assert result["cancelled"] is True
+    assert steps == ["first", "second"]
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_run_to_completion_propagates_a_body_failure():
+    """A teardown step blowing up is a real error and must not be swallowed."""
+
+    async def body():
+        raise RuntimeError("cleanup blew up")
+
+    with pytest.raises(RuntimeError, match="cleanup blew up"):
+        await run_to_completion(body())
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_run_to_completion_warns_under_repeated_cancellation(caplog, monkeypatch):
+    """Repeated cancellation must not silence the "teardown is taking a
+    while" warning -- this is the exact scenario it exists for. Before the
+    fix, every absorbed CancelledError skipped the warning check entirely,
+    and even when it didn't, each new asyncio.wait restarted its own timeout
+    from scratch, so a caller cancelling faster than the interval produced
+    zero warnings no matter how long teardown was wedged."""
+    monkeypatch.setattr(publisher_mod, "_TEARDOWN_WARN_INTERVAL_S", 0.1)
+
+    release = asyncio.Event()
+
+    async def body():
+        await release.wait()
+
+    async def caller():
+        return await run_to_completion(body())
+
+    outer = asyncio.create_task(caller())
+    await asyncio.sleep(0)
+
+    with caplog.at_level(logging.WARNING):
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 0.6
+        while loop.time() < deadline:
+            outer.cancel()
+            await asyncio.sleep(0.09)  # faster than the 0.1s interval
+
+    release.set()
+    await outer
+
+    assert "still running" in caplog.text
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_finish_worker_teardown_continues_after_metrics_task_failure():
+    """A metrics task that fails (not just cancels) during teardown -- e.g. a
+    real ZMQ error -- must not skip cleanup() and run_deferred_handlers(), and
+    must still surface once they have run."""
+
+    async def failing_metrics_loop():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise RuntimeError("zmq close blew up") from None
+
+    metrics_task = asyncio.create_task(failing_metrics_loop())
+    await asyncio.sleep(0)
+
+    steps = []
+
+    def cleanup():
+        steps.append("cleanup")
+
+    async def run_deferred_handlers():
+        steps.append("run_deferred_handlers")
+
+    with pytest.raises(RuntimeError, match="zmq close blew up"):
+        await finish_worker_teardown(metrics_task, cleanup, run_deferred_handlers)
+
+    assert steps == ["cleanup", "run_deferred_handlers"]

--- a/components/src/dynamo/sglang/tests/test_sglang_publisher.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_publisher.py
@@ -786,13 +786,8 @@ async def test_cancel_metrics_task_propagates_a_real_failure():
 @pytest.mark.timeout(5)
 @pytest.mark.asyncio
 async def test_cancel_metrics_task_propagates_a_caller_cancellation():
-    """The discriminator: a cancellation aimed at the caller while it is
-    genuinely suspended inside cancel_metrics_task must reach the caller.
-    Both the original #12672 swallow-everything shape (`metrics_task.cancel()`
-    then a bare `except asyncio.CancelledError: pass` around
-    `await metrics_task`) and the rejected `metrics_task.done()`-classification
-    shape absorb this cancellation instead of propagating it, and fail this
-    test."""
+    """A cancellation aimed at the caller while it is suspended inside
+    cancel_metrics_task must reach the caller."""
 
     async def metrics_loop():
         # Takes several event-loop ticks to unwind after cancel(), so the
@@ -871,12 +866,8 @@ async def test_run_to_completion_propagates_a_body_failure():
 @pytest.mark.timeout(5)
 @pytest.mark.asyncio
 async def test_run_to_completion_warns_under_repeated_cancellation(caplog, monkeypatch):
-    """Repeated cancellation must not silence the "teardown is taking a
-    while" warning -- this is the exact scenario it exists for. Before the
-    fix, every absorbed CancelledError skipped the warning check entirely,
-    and even when it didn't, each new asyncio.wait restarted its own timeout
-    from scratch, so a caller cancelling faster than the interval produced
-    zero warnings no matter how long teardown was wedged."""
+    """A caller cancelling faster than the warn interval must still get the
+    "teardown is taking a while" warning."""
     monkeypatch.setattr(publisher_mod, "_TEARDOWN_WARN_INTERVAL_S", 0.1)
 
     release = asyncio.Event()

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -3,6 +3,7 @@
 
 """Unit tests for SGLang backend components."""
 
+import asyncio
 import logging
 import os
 import re
@@ -39,6 +40,7 @@ from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
     SglangPrefillHealthCheckPayload,
 )
+from dynamo.sglang.publisher import finish_worker_teardown
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
 from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
 from dynamo.sglang.tests.conftest import make_cli_args_fixture
@@ -1486,3 +1488,124 @@ async def test_lora_registration_model_type_gate(
     assert captured["kv_cache_block_size"] == 32
     assert captured["runtime_config"] is lora_runtime_config
     assert "token_budget" in captured["runtime_config"].runtime_data
+
+
+async def _real_shaped_metrics_task() -> asyncio.Task:
+    """A metrics task shaped like publisher.run()/_idle(): parked on one await,
+    with no cleanup work after cancellation."""
+
+    async def metrics_loop():
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(metrics_loop())
+    await asyncio.sleep(0)  # let it reach the await
+    return task
+
+
+def _fake_teardown_targets(steps):
+    """A fake handler.cleanup + run_deferred_handlers pair for
+    finish_worker_teardown tests."""
+
+    def cleanup():
+        steps.append("handler.cleanup")
+
+    async def run_deferred_handlers():
+        await asyncio.sleep(0)  # stands in for the await in real deferred handlers
+        steps.append("run_deferred_handlers")
+
+    return cleanup, run_deferred_handlers
+
+
+@pytest.mark.parametrize("cancel_after_ticks", range(4))
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_worker_teardown_always_completes(cancel_after_ticks):
+    """However the cancellation is timed against teardown, both cleanup steps
+    run. An implementation that raises from inside the teardown leaves `steps`
+    partial and fails this for the early tick counts."""
+    metrics_task = await _real_shaped_metrics_task()
+    steps = []
+    cleanup, run_deferred_handlers = _fake_teardown_targets(steps)
+
+    outer = asyncio.create_task(
+        finish_worker_teardown(metrics_task, cleanup, run_deferred_handlers)
+    )
+    # Let the teardown coroutine start before the sweep. Cancelling a task that
+    # has never been stepped throws CancelledError into an unstarted coroutine,
+    # so its body never runs at all -- that is asyncio behaviour rather than a
+    # teardown defect, and it is not the scenario under test.
+    await asyncio.sleep(0)
+    for _ in range(cancel_after_ticks):
+        await asyncio.sleep(0)
+    outer.cancel()
+
+    try:
+        await outer
+    except asyncio.CancelledError:
+        pass
+
+    assert steps == ["handler.cleanup", "run_deferred_handlers"]
+    assert metrics_task.done()
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_worker_teardown_surfaces_the_cancellation():
+    """A cancellation arriving during teardown must reach the caller, not be
+    logged as a success. This is the bug in #12672."""
+    metrics_task = await _real_shaped_metrics_task()
+    steps = []
+    cleanup, run_deferred_handlers = _fake_teardown_targets(steps)
+
+    outer = asyncio.create_task(
+        finish_worker_teardown(metrics_task, cleanup, run_deferred_handlers)
+    )
+    await asyncio.sleep(0)
+    outer.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await outer
+
+    assert steps == ["handler.cleanup", "run_deferred_handlers"]
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_worker_teardown_is_silent_when_nothing_cancels():
+    """The ordinary shutdown path: teardown runs, nothing is raised."""
+    metrics_task = await _real_shaped_metrics_task()
+    steps = []
+    cleanup, run_deferred_handlers = _fake_teardown_targets(steps)
+
+    await finish_worker_teardown(metrics_task, cleanup, run_deferred_handlers)
+
+    assert steps == ["handler.cleanup", "run_deferred_handlers"]
+    assert metrics_task.cancelled()
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_worker_teardown_keeps_the_body_failure(caplog):
+    """When the worker body already failed, that exception is the diagnostic;
+    the cancellation is logged instead of replacing it."""
+    metrics_task = await _real_shaped_metrics_task()
+    steps = []
+    cleanup, run_deferred_handlers = _fake_teardown_targets(steps)
+
+    async def failing_worker():
+        try:
+            raise RuntimeError("nats is down")
+        finally:
+            await finish_worker_teardown(
+                metrics_task, cleanup, run_deferred_handlers, body_failed=True
+            )
+
+    outer = asyncio.create_task(failing_worker())
+    await asyncio.sleep(0)
+    outer.cancel()
+
+    with pytest.raises(RuntimeError, match="nats is down"):
+        await outer
+
+    assert steps == ["handler.cleanup", "run_deferred_handlers"]
+    assert "an earlier exception is already propagating" in caplog.text

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -1516,7 +1516,7 @@ def _fake_teardown_targets(steps):
     return cleanup, run_deferred_handlers
 
 
-@pytest.mark.parametrize("cancel_after_ticks", range(4))
+@pytest.mark.parametrize("cancel_after_ticks", range(1, 4))
 @pytest.mark.timeout(5)
 @pytest.mark.asyncio
 async def test_worker_teardown_always_completes(cancel_after_ticks):


### PR DESCRIPTION
## Overview:

Fixes the swallowed outer-task cancellation in the SGLang worker teardown, following the approach the issue asks for: shield the metrics-task cancel/await so it runs to completion, then re-raise the outer cancellation once cleanup has finished. No use of `Task.cancelling()`.

## Details:

Five worker-init paths ended in the same verbatim-duplicated `finally` block that cancelled the metrics task and awaited it inside a bare `except asyncio.CancelledError`. That catch cannot tell two things apart:

1. the metrics task finishing its own cancellation, which is what the log line means, and
2. a `CancelledError` injected because the outer worker task was cancelled while suspended at that `await`.

Case 2 is swallowed and logged as "Metrics task successfully cancelled", so the worker returns as though it completed normally and the shutdown request is lost.

`Task.cancelling()` would separate the two, but it is 3.11+ and `requires-python` is `>=3.10`. The discriminator used instead is that `asyncio.wait()` never raises on behalf of the task it waits on, so any `CancelledError` escaping `await asyncio.wait([metrics_task])` is unambiguously the caller's.

Detecting it is only half of it. Re-raising immediately would skip `run_deferred_handlers()`, which reaps SGLang's scheduler subprocesses, so the cancellation is absorbed until teardown completes and only then replayed. `main.py` catches the now-propagating `CancelledError` at `uvloop.run`, since otherwise an ordinary SIGTERM shutdown would exit non-zero and Kubernetes would read it as a crash.

Three helpers land in `publisher.py` and all five call sites are converted: `init_decode`, `init_prefill`, `init_embedding`, `init_llm_diffusion`, `handle_non_leader_node`.

One deliberate behaviour change, flagging it rather than burying it: the old code let a cancellation break the caller out of a wedged `await metrics_task` and step over to `cleanup()`. Finishing teardown is the point of this fix, so that escape hatch is gone, and a metrics task that ignores `cancel()` can now hang shutdown where it previously got stepped over. `run_to_completion` warns every 30s instead of going quiet.

On #12669: this PR now includes prefill-warmup metrics cleanup for timeout, ordinary failure, and cancellation. Its shared teardown helpers cover all five worker call sites, superseding #12669's overlapping teardown helper; the broader #12669 refactor is not copied here. If #12669 lands first, this branch will need a conflict-aware rebase.

## Where should the reviewer start?

`components/src/dynamo/sglang/publisher.py`, the three new helpers. `cancel_metrics_task` is where the `asyncio.wait` discriminator lives, and `run_to_completion` is where the cancellation is absorbed and replayed. The four `init_*` call sites are mechanical once those two read correctly.

The `body_failed` flag threaded through the call sites is worth a look: it exists so that when the worker body already raised, that exception stays the reported one and the cancellation is logged instead of replacing it.

## Validation

- Final diff adds 15 test functions / 16 cases after parametrization. This includes metrics-unwind and deferred-cleanup cancellation phases, both `main()` outcomes, and prefill-warmup timeout, ordinary-error, and cancellation cleanup.
- Linux CI pre-commit passed at `23a10f4fb`, including `pytest-marker-report` collection. Local applicable hooks, Python compilation, DCO sign-offs, and `git diff --check` passed; the local Windows marker hook cannot run because it imports Unix-only `fcntl`.
- Repository pytest was attempted on Windows Python 3.10.11 but stopped before collection: `pytest_benchmark` is missing; SGLang and uvloop are also unavailable locally. **No repository pytest pass is claimed.** Isolated AST checks are supplemental and are not a substitute for this suite.
- Official SGLang repository pytest for `23a10f4fb` is pending in a supported environment. Record the job URL, exact collected/passed/skipped/failed counts, and Python/SGLang/uvloop versions here after it runs. A Python 3.10-compatible run is still required.
- No mutation result is claimed for the final head; the earlier four-test mutation claim has not been rerun.
## Related Issues

- Closes #12672


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker shutdown reliability when cancellation occurs.
  * Ensured cleanup, metrics shutdown, and deferred handlers complete before workers exit.
  * Preserved and correctly propagated worker errors during shutdown.
  * Added clean handling and logging for expected cancellation during process termination.
* **Tests**
  * Expanded coverage for cancellation, cleanup ordering, failure propagation, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->