### PR TITLE
fix(sglang): map multi-node DP KV event hosts

### DIFF
--- a/lib/sidecar/sglang/src/args.rs
+++ b/lib/sidecar/sglang/src/args.rs
@@ -22,4 +22,10 @@ pub struct Args {
     /// wildcard addresses.
     #[arg(long, env = "SGLANG_DISAGGREGATION_BOOTSTRAP_HOST")]
     pub bootstrap_host: Option<String>,
+
+    /// Reachable KV-event publisher host for each global SGLang DP rank.
+    /// Required for multi-node DP because native discovery reports ports by
+    /// rank but cannot identify the node hosting each publisher.
+    #[arg(long, value_delimiter = ',', env = "SGLANG_KV_EVENT_HOSTS")]
+    pub kv_event_hosts: Vec<String>,
 }

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -727,6 +727,7 @@ fn discover_kv_event_sources(
             kv_event_hosts.len()
         )));
     }
+    validate_configured_kv_event_hosts(kv_event_hosts, grpc_endpoint)?;
 
     let default_connect_host = kv_event_connect_host(endpoint_host, grpc_endpoint)?;
     let mut sources = Vec::with_capacity(dp_size as usize);
@@ -758,6 +759,23 @@ fn discover_kv_event_sources(
         "discovered SGLang ZMQ KV-event sources"
     );
     Ok(sources)
+}
+
+/// Require configured rank mappings to name explicit, reachable publisher hosts.
+fn validate_configured_kv_event_hosts(
+    kv_event_hosts: &[String],
+    grpc_endpoint: &GrpcEndpoint,
+) -> Result<(), DynamoError> {
+    for host in kv_event_hosts {
+        let bare_host = host.trim().trim_matches(&['[', ']'][..]);
+        if bare_host.is_empty() || matches!(bare_host, "*" | "0.0.0.0" | "::") {
+            return Err(client::protocol_error(format!(
+                "--kv-event-hosts entries must be explicit reachable hosts, got `{host}`"
+            )));
+        }
+        kv_event_connect_host(host, grpc_endpoint)?;
+    }
+    Ok(())
 }
 
 fn kv_event_connect_host(
@@ -1060,5 +1078,42 @@ mod tests {
         assert_eq!(sources[4].endpoint, "tcp://node1:5561");
         assert_eq!(sources[4].dp_rank, 4);
         assert_eq!(sources.len(), 8);
+    }
+
+    #[test]
+    fn rejects_non_explicit_configured_kv_event_hosts() {
+        let discovery = discovery(json!({
+            "page_size": 64,
+            "dp_size": 2,
+            "enable_dp_attention": true,
+            "nnodes": 2,
+            "kv_events": {
+                "publisher": "zmq",
+                "endpoint_host": "*",
+                "endpoint_port_base": 5557,
+                "topic": "kv-events",
+                "block_size": 64,
+                "dp_size": 2
+            }
+        }));
+        let config = build_engine_config(
+            &discovery,
+            DisaggregationMode::Prefill,
+            Some("node0".into()),
+            Some(7200),
+        )
+        .unwrap();
+        let endpoint = GrpcEndpoint::parse("http://node0:50051", "test").unwrap();
+
+        for invalid in ["*", "0.0.0.0", "::", " "] {
+            let hosts = [invalid.to_string(), "node1".to_string()];
+            let error =
+                discover_kv_event_sources(&discovery, &config, &endpoint, &hosts).unwrap_err();
+
+            assert!(
+                error.to_string().contains("explicit reachable hosts"),
+                "unexpected error for {invalid:?}: {error}"
+            );
+        }
     }
 }

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -35,6 +35,7 @@ pub struct SglangSidecarEngine {
     disaggregation_mode: DisaggregationMode,
     bootstrap_host: Option<String>,
     bootstrap_port: Option<u16>,
+    kv_event_hosts: Vec<String>,
     state: OnceCell<StartedState>,
     cancel: CancellationToken,
 }
@@ -135,6 +136,7 @@ impl SglangSidecarEngine {
                 disaggregation_mode,
                 bootstrap_host,
                 bootstrap_port,
+                kv_event_hosts: args.kv_event_hosts,
                 state: OnceCell::new(),
                 cancel: CancellationToken::new(),
             },
@@ -220,7 +222,8 @@ impl LLMEngine for SglangSidecarEngine {
                 .runtime_data
                 .insert("sglang_generate".into(), true.into());
         }
-        let kv_event_sources = discover_kv_event_sources(&discovery, &config, &self.endpoint)?;
+        let kv_event_sources =
+            discover_kv_event_sources(&discovery, &config, &self.endpoint, &self.kv_event_hosts)?;
         let connection_count = pool.len();
         let kv_event_source_count = kv_event_sources.len();
         self.state
@@ -617,6 +620,7 @@ fn discover_kv_event_sources(
     discovery: &Discovery,
     engine_config: &EngineConfig,
     grpc_endpoint: &GrpcEndpoint,
+    kv_event_hosts: &[String],
 ) -> Result<Vec<DiscoveredKvEventSource>, DynamoError> {
     let Some(descriptor) = discovery.server_info.get("kv_events") else {
         return Ok(Vec::new());
@@ -712,15 +716,25 @@ fn discover_kv_event_sources(
     let nnodes = client::json_u32(&discovery.server_info, "nnodes")
         .unwrap_or(1)
         .max(1);
-    if nnodes > 1 && dp_size > 1 {
+    if nnodes > 1 && dp_size > 1 && kv_event_hosts.is_empty() {
         return Err(client::protocol_error(format!(
-            "SGLang KV events for multi-node DP are unsupported because GetServerInfo does not map DP ranks to publisher hosts (nnodes={nnodes}, dp_size={dp_size})"
+            "SGLang KV events for multi-node DP require --kv-event-hosts because GetServerInfo does not map DP ranks to publisher hosts (nnodes={nnodes}, dp_size={dp_size})"
+        )));
+    }
+    if !kv_event_hosts.is_empty() && kv_event_hosts.len() != reported_dp_size as usize {
+        return Err(client::protocol_error(format!(
+            "--kv-event-hosts supplied {} hosts but SGLang reports {reported_dp_size} DP ranks",
+            kv_event_hosts.len()
         )));
     }
 
-    let connect_host = kv_event_connect_host(endpoint_host, grpc_endpoint)?;
+    let default_connect_host = kv_event_connect_host(endpoint_host, grpc_endpoint)?;
     let mut sources = Vec::with_capacity(dp_size as usize);
     for dp_rank in dp_start..dp_end {
+        let connect_host = match kv_event_hosts.get(dp_rank as usize) {
+            Some(host) => kv_event_connect_host(host, grpc_endpoint)?,
+            None => default_connect_host.clone(),
+        };
         let port = u32::from(base_port)
             .checked_add(dp_rank)
             .filter(|port| *port <= u32::from(u16::MAX))
@@ -991,7 +1005,7 @@ mod tests {
             build_engine_config(&discovery, DisaggregationMode::Aggregated, None, None).unwrap();
         let endpoint = GrpcEndpoint::parse("http://worker.example:30001", "test").unwrap();
 
-        let sources = discover_kv_event_sources(&discovery, &config, &endpoint).unwrap();
+        let sources = discover_kv_event_sources(&discovery, &config, &endpoint, &[]).unwrap();
 
         assert_eq!(
             sources,
@@ -1008,5 +1022,43 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn maps_multi_node_dp_kv_event_sources_to_rank_hosts() {
+        let discovery = discovery(json!({
+            "page_size": 64,
+            "dp_size": 8,
+            "enable_dp_attention": true,
+            "nnodes": 2,
+            "kv_events": {
+                "publisher": "zmq",
+                "endpoint_host": "*",
+                "endpoint_port_base": 5557,
+                "topic": "kv-events",
+                "block_size": 64,
+                "dp_size": 8
+            }
+        }));
+        let config = build_engine_config(
+            &discovery,
+            DisaggregationMode::Prefill,
+            Some("node0".into()),
+            Some(7200),
+        )
+        .unwrap();
+        let endpoint = GrpcEndpoint::parse("http://node0:50051", "test").unwrap();
+        let hosts = [
+            "node0", "node0", "node0", "node0", "node1", "node1", "node1", "node1",
+        ]
+        .map(str::to_string);
+
+        let sources = discover_kv_event_sources(&discovery, &config, &endpoint, &hosts).unwrap();
+
+        assert_eq!(sources[3].endpoint, "tcp://node0:5560");
+        assert_eq!(sources[3].dp_rank, 3);
+        assert_eq!(sources[4].endpoint, "tcp://node1:5561");
+        assert_eq!(sources[4].dp_rank, 4);
+        assert_eq!(sources.len(), 8);
     }
 }


### PR DESCRIPTION
## Overview:

Enable native SGLang sidecars to consume KV-routing events from multi-node data-parallel SGLang deployments.

## Details:

- Add `--kv-event-hosts` / `SGLANG_KV_EVENT_HOSTS` as one reachable publisher host per global DP rank.
- Map each discovered KV-event rank to its configured host while preserving SGLang's reported base port and topic.
- Fail closed when multi-node DP discovery lacks a host mapping or the mapping cardinality differs from the reported DP size.
- Reject empty, wildcard, and otherwise invalid configured hosts before constructing endpoints.
- Keep the existing single-node discovery behavior unchanged.

## Where should the reviewer start?

- `lib/sidecar/sglang/src/engine.rs`: rank mapping, validation, and regression coverage.
- `lib/sidecar/sglang/src/args.rs`: CLI/environment interface.

## Validation:

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-sglang-sidecar` — 34 passed.
- Lyris GB300 c80 startup: the prefill sidecar discovered all 8 multi-node DP publishers with rank-specific hosts; AgentX measured traffic is running with zero request errors.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue