### PR TITLE
fix(planner): export router request duration for router-sourced traffic

### DIFF
--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -270,15 +270,8 @@ class PrometheusAPIClient:
 
     def get_avg_request_duration(self, interval: str, model_name: str):
         if self.metrics_source == "router":
-            # TODO: Replace work_handler.REQUEST_DURATION_SECONDS with
-            #       prometheus_names.router.REQUEST_DURATION_SECONDS once
-            #       RouterRequestMetrics in lib/llm/src/kv_router/metrics.rs
-            #       registers dynamo_component_router_request_duration_seconds.
-            #       Until then this queries a non-existent metric and returns 0,
-            #       which causes throughput planning to see
-            #       concurrency=0 (under-estimated), inflating replica recommendations.
             return self._get_average_metric(
-                f"{prometheus_names.name_prefix.COMPONENT}_{prometheus_names.work_handler.REQUEST_DURATION_SECONDS}",
+                f"{prometheus_names.name_prefix.COMPONENT}_{prometheus_names.router.REQUEST_DURATION_SECONDS}",
                 interval,
                 "avg request duration",
             )

--- a/components/src/dynamo/planner/tests/unit/test_prometheus.py
+++ b/components/src/dynamo/planner/tests/unit/test_prometheus.py
@@ -549,6 +549,17 @@ class TestPrometheusAPIClientRouterSource:
         expected_metric = f"{prometheus_names.name_prefix.COMPONENT}_{prometheus_names.router.TIME_TO_FIRST_TOKEN_SECONDS}"
         assert expected_metric in call_args
 
+    def test_get_avg_request_duration_dispatches_to_router_histogram(
+        self, router_client
+    ):
+        """Router-source duration must come from the router request lifecycle."""
+        result = router_client.get_avg_request_duration("60s", "mymodel")
+        assert result == 42.0
+
+        call_args = str(router_client.prom.custom_query.call_args)
+        expected_metric = f"{prometheus_names.name_prefix.COMPONENT}_{prometheus_names.router.REQUEST_DURATION_SECONDS}"
+        assert expected_metric in call_args
+
     def test_get_avg_input_sequence_tokens_dispatches_to_router_histogram(
         self, router_client
     ):

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
@@ -231,7 +231,7 @@ Planner can read these traffic signals from either the public `Frontend` or a po
 | Request count | `dynamo_frontend_requests_started_total` | `dynamo_component_router_requests_started_total` |
 | TTFT | `dynamo_frontend_time_to_first_token_seconds` | `dynamo_component_router_time_to_first_token_seconds` |
 | ITL | `dynamo_frontend_inter_token_latency_seconds` | `dynamo_component_router_inter_token_latency_seconds` |
-| Request duration | `dynamo_frontend_request_duration_seconds` | `dynamo_component_request_duration_seconds` until router-specific duration metrics are available |
+| Request duration | `dynamo_frontend_request_duration_seconds` | `dynamo_component_router_request_duration_seconds` |
 | Input sequence length / ISL | `dynamo_frontend_input_sequence_tokens` | `dynamo_component_router_input_sequence_tokens` |
 | Output sequence length / OSL | `dynamo_frontend_output_sequence_tokens` | `dynamo_component_router_output_sequence_tokens` |
 | KV hit rate | `dynamo_component_router_kv_hit_rate` | `dynamo_component_router_kv_hit_rate` |

--- a/docs/fern/pages/reference/observability/metrics-catalog.mdx
+++ b/docs/fern/pages/reference/observability/metrics-catalog.mdx
@@ -267,6 +267,10 @@ The router exposes metrics for routing decisions and overhead. Not every metric 
   Total requests processed by the router.
 </ParamField>
 
+<ParamField path="dynamo_component_router_request_duration_seconds" type="histogram">
+  Duration in seconds from router admission to request completion or termination.
+</ParamField>
+
 <ParamField path="dynamo_component_router_time_to_first_token_seconds" type="histogram">
   Time to first token in seconds.
 </ParamField>

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -448,6 +448,8 @@ class router:
     REQUESTS_STARTED_TOTAL = "router_requests_started_total"
     # Total number of requests processed by the router
     REQUESTS_TOTAL = "router_requests_total"
+    # Duration of requests observed by the router (seconds)
+    REQUEST_DURATION_SECONDS = "router_request_duration_seconds"
     # Total number of remote indexer overlap queries that failed
     REMOTE_INDEXER_QUERY_FAILURES_TOTAL = "router_remote_indexer_query_failures_total"
     # Total number of remote indexer routing-decision writes that failed

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -17,8 +17,8 @@
 //!   - Frontend (aggregated and disaggregated): available on default port 8000
 //!   - Standalone router: not created (frontend-only)
 //!
-//! - [`RouterRequestMetrics`]: Per-request aggregate histograms and counters (TTFT, ITL,
-//!   tokens, KV hit rate, and non-max-overlap routing decisions).
+//! - [`RouterRequestMetrics`]: Per-request aggregate histograms and counters (duration,
+//!   TTFT, ITL, tokens, KV hit rate, and non-max-overlap routing decisions).
 //!   Registered on the DRT `MetricsRegistry` hierarchy via `Component::metrics()`.
 //!   Eagerly created so they appear as zeros before any requests arrive.
 //!   Populated by `RoutingHost::generate()` and its `RequestGuard` as it observes
@@ -833,6 +833,7 @@ impl RoutingOverheadMetrics {
 /// independently.
 pub struct RouterRequestMetrics {
     pub requests_total: prometheus::IntCounter,
+    pub request_duration_seconds: prometheus::Histogram,
     pub time_to_first_token_seconds: prometheus::Histogram,
     pub inter_token_latency_seconds: prometheus::Histogram,
     pub input_sequence_tokens: prometheus::Histogram,
@@ -895,6 +896,14 @@ impl RouterRequestMetrics {
                         extra_labels,
                     )
                     .expect("failed to create router_requests_total");
+                let request_duration_seconds = metrics
+                    .create_histogram(
+                        &router_metric(frontend_service::REQUEST_DURATION_SECONDS),
+                        "Duration of dispatched requests observed at the router",
+                        extra_labels,
+                        Some(generate_log_buckets(1.0, 512.0, 10)),
+                    )
+                    .expect("failed to create router_request_duration_seconds");
                 let time_to_first_token_seconds = metrics
                     .create_histogram(
                         &router_metric(frontend_service::TIME_TO_FIRST_TOKEN_SECONDS),
@@ -980,6 +989,7 @@ impl RouterRequestMetrics {
                 overlap_blocks_lost.with_label_values(&[WORKER_TYPE_PREFILL]);
                 Arc::new(Self {
                     requests_total,
+                    request_duration_seconds,
                     time_to_first_token_seconds,
                     inter_token_latency_seconds,
                     input_sequence_tokens,

--- a/lib/llm/src/kv_router/routing_host/request_guard.rs
+++ b/lib/llm/src/kv_router/routing_host/request_guard.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use crate::{
     kv_router::{KvRouter, metrics::RouterRequestMetrics, scheduler::DefaultWorkerSelector},
@@ -244,6 +244,7 @@ impl CanonicalOutputTracker {
 struct RequestObservability {
     tracker: Option<Arc<RequestTracker>>,
     request_metrics: Arc<RouterRequestMetrics>,
+    started_at: Instant,
     cumulative_osl: usize,
     metrics_recorded: bool,
     first_token_recorded: bool,
@@ -259,6 +260,7 @@ impl RequestObservability {
         Self {
             tracker,
             request_metrics,
+            started_at: Instant::now(),
             cumulative_osl: 0,
             metrics_recorded: false,
             first_token_recorded: false,
@@ -354,6 +356,9 @@ impl RequestObservability {
                 .output_sequence_tokens
                 .observe(self.cumulative_osl as f64);
         }
+        self.request_metrics
+            .request_duration_seconds
+            .observe(self.started_at.elapsed().as_secs_f64());
         self.request_metrics.requests_total.inc();
     }
 }

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -736,6 +736,7 @@ async fn router_request_counters_follow_admission_and_completion_lifecycle() {
     let metrics = router.request_metrics.clone();
     let started_before = metrics.requests_started_total().get();
     let completed_before = metrics.requests_total.get();
+    let duration_before = metrics.request_duration_seconds.get_sample_count();
 
     let controller = Controller::new("pre-admission-cancellation".to_string());
     controller.stop();
@@ -763,6 +764,10 @@ async fn router_request_counters_follow_admission_and_completion_lifecycle() {
     drop(cancelled_guard);
     assert_eq!(metrics.requests_started_total().get(), started_before + 1);
     assert_eq!(metrics.requests_total.get(), completed_before);
+    assert_eq!(
+        metrics.request_duration_seconds.get_sample_count(),
+        duration_before
+    );
 
     let mut failed_input = request();
     failed_input.migration_state = Some(Default::default());
@@ -794,6 +799,10 @@ async fn router_request_counters_follow_admission_and_completion_lifecycle() {
     drop(completed_guard);
     assert_eq!(metrics.requests_started_total().get(), started_before + 3);
     assert_eq!(metrics.requests_total.get(), completed_before + 1);
+    assert_eq!(
+        metrics.request_duration_seconds.get_sample_count(),
+        duration_before + 1
+    );
 
     let mut builtin_guard = RequestGuard::<DefaultWorkerSelector>::new_builtin(
         Arc::clone(&metrics),
@@ -806,6 +815,10 @@ async fn router_request_counters_follow_admission_and_completion_lifecycle() {
     builtin_guard.abort().await;
     drop(builtin_guard);
     assert_eq!(metrics.requests_total.get(), completed_before + 1);
+    assert_eq!(
+        metrics.request_duration_seconds.get_sample_count(),
+        duration_before + 1
+    );
 
     drop(router);
     runtime.shutdown();

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -635,6 +635,9 @@ pub mod router {
     /// Total number of requests processed by the router
     pub const REQUESTS_TOTAL: &str = "router_requests_total";
 
+    /// Duration of requests observed by the router (seconds)
+    pub const REQUEST_DURATION_SECONDS: &str = "router_request_duration_seconds";
+
     /// Total number of remote indexer overlap queries that failed
     pub const REMOTE_INDEXER_QUERY_FAILURES_TOTAL: &str =
         "router_remote_indexer_query_failures_total";


### PR DESCRIPTION
## Overview:

Export a LocalRouter-owned request-duration histogram and use it when the
Planner is configured with `throughput_metrics_source="router"`.

This completes the end-to-end follow-up documented in the review of #6500:
register the Rust histogram, generate the Python metric constant, switch the
Planner query, and add test coverage.

## Details:

### Problem

The router-source path currently queries
`dynamo_component_request_duration_seconds`. A standalone LocalRouter does not
own that work-handler metric, and it does not export a router-specific duration
histogram, so the Planner reports request duration as zero under traffic.

### Changes

- register `dynamo_component_router_request_duration_seconds` in
  `RouterRequestMetrics`
- observe one duration sample for every dispatched request that reaches a
  terminal path
- generate the Python router metric constant and use it for the Planner query
- document the metric and cover the Rust request lifecycle and PromQL contract

### Semantics

The timer starts when the router creates the request guard after worker
selection. It is observed at the existing idempotent terminal metrics hook.
Pre-dispatch cancellation does not produce a sample; dispatched completion or
termination does. This keeps the histogram count aligned with
`dynamo_component_router_requests_total`.

### Validation

- baseline Planner contract test failed as expected because the router duration
  constant/metric was absent
- focused Planner router duration, TTFT, and ITL query tests: 3 passed
- `cargo test -p dynamo-llm --no-default-features --lib router_request_counters_follow_admission_and_completion_lifecycle -- --nocapture`: 1 passed
- `cargo test -p dynamo-codegen --bin gen-python-prometheus-names`: 3 passed
- `cargo fmt --all -- --check`
- Ruff format check and `E4,E7,E9,F` checks on changed Python files
- `git diff --check`

The umbrella `pre-commit` command did not reach hook execution because its
initial `git diff --quiet --no-ext-diff .pre-commit-config.yaml` read stalled in
the local partial checkout. The equivalent targeted format, lint, test, and diff
checks above completed successfully.

No GPU or distributed serving run was used: this is an engine-independent
control-plane metric contract.

## Where should the reviewer start?

1. `lib/llm/src/kv_router/routing_host/request_guard.rs` for duration lifecycle
   semantics
2. `lib/llm/src/kv_router/metrics.rs` for histogram registration
3. `components/src/dynamo/planner/monitoring/traffic_metrics.py` for the Planner
   query switch

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added router request-duration metrics, tracking requests from admission through completion or termination.
  * Exposed the new metric in the observability metrics catalog.
* **Bug Fixes**
  * Router monitoring now reports request duration using the correct router metric.
* **Documentation**
  * Updated Planner monitoring guidance to reference the router-specific request-duration metric.
* **Tests**
  * Added coverage confirming duration samples are recorded only for successfully completed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->