### PR TITLE
fix(gms): reclaim V1 epochs off the lock admission path

### DIFF
--- a/lib/gpu_memory_service/tests/test_v1_checkpoint.py
+++ b/lib/gpu_memory_service/tests/test_v1_checkpoint.py
@@ -18,7 +18,7 @@ if not HAS_GMS:
 
 from _fake_vmm import FakeVMM
 from gpu_memory_service.common.locks import RequestedLockType
-from gpu_memory_service.v1 import cli
+from gpu_memory_service.v1 import checkpoint, cli
 from gpu_memory_service.v1.checkpoint import GMSCheckpointClient, GMSCheckpointLifecycle
 from gpu_memory_service.v1.client.session import _GMSClientSession
 from gpu_memory_service.v1.protocol import PrepareCheckpointRequest
@@ -211,6 +211,33 @@ def test_prepare_rejects_committed_or_active_kv(v1_owner) -> None:
 
     with pytest.raises(RuntimeError, match="kv_cache must not be committed"):
         control.prepare()
+
+
+@pytest.mark.timeout(10)
+def test_prepare_requires_weights_reclamation_to_complete(
+    v1_owner, monkeypatch
+) -> None:
+    monkeypatch.setattr(checkpoint, "_RECLAIM_DRAIN_TIMEOUT", 0.05)
+    v1_owner.publish_weights()
+    release_allowed = threading.Event()
+    original_release = v1_owner.vmm.release
+
+    def blocked_release(handle: int) -> None:
+        assert release_allowed.wait(5)
+        original_release(handle)
+
+    monkeypatch.setattr(v1_owner.vmm, "release", blocked_release)
+    # Republishing unlinks the previous weights epoch, whose handles are still
+    # being released in the background when the controller asks to checkpoint.
+    v1_owner.publish_weights()
+    control = v1_owner.control()
+    with pytest.raises(RuntimeError, match="weights reclamation did not complete"):
+        control.prepare()
+    assert control.state().state == "serving"
+
+    release_allowed.set()
+    assert v1_owner.managers["weights"].drain_reclamation(5)
+    assert control.prepare().state == "checkpoint_ready"
 
 
 @pytest.mark.timeout(10)

--- a/lib/gpu_memory_service/tests/test_v1_checkpoint.py
+++ b/lib/gpu_memory_service/tests/test_v1_checkpoint.py
@@ -241,6 +241,45 @@ def test_prepare_requires_weights_reclamation_to_complete(
 
 
 @pytest.mark.timeout(10)
+def test_prepare_bounds_both_domain_drains_by_one_budget(v1_owner, monkeypatch) -> None:
+    budget = 1.0
+    weights_cost = 0.6
+    monkeypatch.setattr(checkpoint, "_RECLAIM_DRAIN_TIMEOUT", budget)
+    v1_owner.publish_weights()
+    granted: dict[str, float] = {}
+
+    def weights_drain(timeout: float | None = None) -> bool:
+        granted["weights"] = timeout
+        time.sleep(min(timeout, weights_cost))
+        return timeout >= weights_cost
+
+    def kv_drain(timeout: float | None = None) -> bool:
+        granted["kv_cache"] = timeout
+        # A domain that never finishes reclaiming burns whatever it was given.
+        time.sleep(timeout)
+        return False
+
+    monkeypatch.setattr(
+        v1_owner.managers["weights"], "drain_reclamation", weights_drain
+    )
+    monkeypatch.setattr(v1_owner.managers["kv_cache"], "drain_reclamation", kv_drain)
+    control = v1_owner.control()
+    started = time.monotonic()
+    with pytest.raises(RuntimeError, match="kv_cache reclamation did not complete"):
+        control.prepare()
+    elapsed = time.monotonic() - started
+
+    # One budget spans both domains: the stalled domain only gets what the slow
+    # one left behind, so the fence costs the control client one timeout rather
+    # than one per domain, and it still names the domain that is still holding
+    # memory.
+    assert granted["weights"] <= budget
+    assert granted["kv_cache"] <= budget - weights_cost + 0.1
+    assert elapsed < budget * 1.3
+    assert control.state().state == "serving"
+
+
+@pytest.mark.timeout(10)
 def test_prepare_rejects_writer_reservation(v1_owner, monkeypatch) -> None:
     v1_owner.publish_weights()
     weights = v1_owner.managers["weights"]

--- a/lib/gpu_memory_service/tests/test_v1_server.py
+++ b/lib/gpu_memory_service/tests/test_v1_server.py
@@ -311,10 +311,10 @@ def test_repeated_epoch_clears_share_one_reclaimer_thread() -> None:
     allocations = GMSAllocationManager(vmm, 0)
     release_allowed = threading.Event()
     original_release = vmm.release
-    reclaimers: set[str] = set()
+    reclaimers: set[threading.Thread] = set()
 
     def blocked_release(handle: int) -> None:
-        reclaimers.add(threading.current_thread().name)
+        reclaimers.add(threading.current_thread())
         assert release_allowed.wait(5)
         original_release(handle)
 
@@ -322,16 +322,22 @@ def test_repeated_epoch_clears_share_one_reclaimer_thread() -> None:
     for epoch in range(4):
         allocations.allocate(f"epoch-{epoch}", 64)
         assert allocations.clear() == 1
-    # Every epoch is unlinked while its handles are still queued behind one
-    # blocked release, so repeated failovers cannot pile up reclaimer threads.
-    assert allocations.reclaim_snapshot() == (3, 1)
+    # Every epoch is unlinked while its handles are still behind one blocked
+    # release, so no release can have completed: whether the reclaimer has been
+    # scheduled yet only moves a handle from queued to in-flight.
+    queued, releasing = allocations.reclaim_snapshot()
+    assert queued + releasing == 4
 
     release_allowed.set()
     assert allocations.drain(5)
-    assert reclaimers == {"gms-v1-reclaim-0"}
+    # Repeated failovers must not pile up reclaimer threads: every release ran
+    # on the same thread, the one named for this device.
+    assert len(reclaimers) == 1
+    assert reclaimers.pop().name == "gms-v1-reclaim-0"
     assert not vmm.server_handles
 
     allocations.shutdown()
     allocations.allocate("after-shutdown", 64)
     assert allocations.clear() == 1
     assert not vmm.server_handles
+

--- a/lib/gpu_memory_service/tests/test_v1_server.py
+++ b/lib/gpu_memory_service/tests/test_v1_server.py
@@ -341,3 +341,29 @@ def test_repeated_epoch_clears_share_one_reclaimer_thread() -> None:
     assert allocations.clear() == 1
     assert not vmm.server_handles
 
+
+@pytest.mark.timeout(10)
+def test_epoch_clear_releases_inline_when_the_reclaimer_cannot_start(
+    monkeypatch,
+) -> None:
+    vmm = FakeVMM(granularity=64)
+    allocations = GMSAllocationManager(vmm, 0)
+
+    def exhausted() -> threading.Thread:
+        raise RuntimeError("can't start new thread")
+
+    monkeypatch.setattr(allocations, "_start_reclaimer", exhausted)
+    allocations.allocate("epoch-0", 64)
+    assert allocations.clear() == 1
+    # A reclaimer that cannot start must not strand the epoch's handles behind a
+    # thread that will never run them.
+    assert not vmm.server_handles
+    assert allocations.reclaim_snapshot() == (0, 0)
+    assert allocations.drain(5)
+
+    monkeypatch.undo()
+    allocations.allocate("epoch-1", 64)
+    assert allocations.clear() == 1
+    assert allocations.drain(5)
+    assert not vmm.server_handles
+    allocations.shutdown()

--- a/lib/gpu_memory_service/tests/test_v1_server.py
+++ b/lib/gpu_memory_service/tests/test_v1_server.py
@@ -29,6 +29,7 @@ from gpu_memory_service.v1.protocol import (
     send_message,
 )
 from gpu_memory_service.v1.server import rpc as rpc_module
+from gpu_memory_service.v1.server.allocations import GMSAllocationManager
 from gpu_memory_service.v1.server.rpc import GMSRPCServer, GMSServerMemoryManager
 
 pytestmark = [pytest.mark.pre_merge, pytest.mark.integration, pytest.mark.gpu_0]
@@ -160,16 +161,17 @@ def test_client_waits_for_server_startup_and_deadlines_absent_socket(
 
 
 @pytest.mark.timeout(10)
-def test_rw_close_waits_for_epoch_release(tmp_path, monkeypatch, serve) -> None:
+def test_rw_close_admits_next_writer_before_handle_release(
+    tmp_path, monkeypatch, serve
+) -> None:
     path = str(tmp_path / "gms.sock")
     vmm = FakeVMM(granularity=64)
-    serve(path, vmm)
+    manager = serve(path, vmm)
     writer = _GMSClientSession(path, RequestedLockType.RW)
     writer.allocate("ephemeral", 64)
 
     release_started = threading.Event()
     release_allowed = threading.Event()
-    close_returned = threading.Event()
     original_release = vmm.release
 
     def blocked_release(handle: int) -> None:
@@ -177,21 +179,43 @@ def test_rw_close_waits_for_epoch_release(tmp_path, monkeypatch, serve) -> None:
         assert release_allowed.wait(5)
         original_release(handle)
 
-    def close_writer() -> None:
-        writer.close()
-        close_returned.set()
+    writer_waiting = threading.Event()
+    can_grant_rw = manager._sessions._can_grant_rw
+
+    def observe_blocked_writer() -> bool:
+        granted = can_grant_rw()
+        if not granted:
+            writer_waiting.set()
+        return granted
 
     monkeypatch.setattr(vmm, "release", blocked_release)
-    close_thread = threading.Thread(target=close_writer, daemon=True)
-    close_thread.start()
+    monkeypatch.setattr(manager._sessions, "_can_grant_rw", observe_blocked_writer)
+    replacement_result, replacement_connected, replacement_thread = _connect_in_thread(
+        path, RequestedLockType.RW
+    )
+    assert writer_waiting.wait(5)
 
+    writer.close()
+
+    # The replacement is admitted while the departed epoch's handle release is
+    # still blocked, and it can never collide with a stale allocation ID.
     assert release_started.wait(5)
-    assert not close_returned.is_set()
+    assert replacement_connected.wait(5)
+    assert not release_allowed.is_set()
+    assert manager._allocations.reclaim_snapshot() != (0, 0)
+    assert manager.allocation_snapshot() == ()
+    replacement = replacement_result.pop()
+    with pytest.raises(RuntimeError, match="unknown allocation ID"):
+        replacement.export("ephemeral")
+    replacement.allocate("ephemeral", 64)
+
     release_allowed.set()
-    assert close_returned.wait(5)
-    close_thread.join(timeout=5)
-    assert not close_thread.is_alive()
+    assert manager.drain_reclamation(5)
+    replacement.close()
+    assert manager.drain_reclamation(5)
     assert not vmm.server_handles
+    replacement_thread.join(timeout=5)
+    assert not replacement_thread.is_alive()
 
 
 @pytest.mark.timeout(10)
@@ -279,3 +303,35 @@ def test_sessions_commit_share_prioritize_writer_and_release_on_disconnect(
     ):
         thread.join(timeout=5)
         assert not thread.is_alive()
+
+
+@pytest.mark.timeout(10)
+def test_repeated_epoch_clears_share_one_reclaimer_thread() -> None:
+    vmm = FakeVMM(granularity=64)
+    allocations = GMSAllocationManager(vmm, 0)
+    release_allowed = threading.Event()
+    original_release = vmm.release
+    reclaimers: set[str] = set()
+
+    def blocked_release(handle: int) -> None:
+        reclaimers.add(threading.current_thread().name)
+        assert release_allowed.wait(5)
+        original_release(handle)
+
+    vmm.release = blocked_release
+    for epoch in range(4):
+        allocations.allocate(f"epoch-{epoch}", 64)
+        assert allocations.clear() == 1
+    # Every epoch is unlinked while its handles are still queued behind one
+    # blocked release, so repeated failovers cannot pile up reclaimer threads.
+    assert allocations.reclaim_snapshot() == (3, 1)
+
+    release_allowed.set()
+    assert allocations.drain(5)
+    assert reclaimers == {"gms-v1-reclaim-0"}
+    assert not vmm.server_handles
+
+    allocations.shutdown()
+    allocations.allocate("after-shutdown", 64)
+    assert allocations.clear() == 1
+    assert not vmm.server_handles

--- a/lib/gpu_memory_service/tests/test_v1_server.py
+++ b/lib/gpu_memory_service/tests/test_v1_server.py
@@ -349,10 +349,14 @@ def test_epoch_clear_releases_inline_when_the_reclaimer_cannot_start(
     vmm = FakeVMM(granularity=64)
     allocations = GMSAllocationManager(vmm, 0)
 
-    def exhausted() -> threading.Thread:
+    def exhausted(self: threading.Thread) -> None:
         raise RuntimeError("can't start new thread")
 
-    monkeypatch.setattr(allocations, "_start_reclaimer", exhausted)
+    # Thread exhaustion is injected at threading.Thread.start rather than at any
+    # helper of ours, so this control fails on behaviour against any revision
+    # instead of on the absence of a helper. monkeypatch restores it even if an
+    # assertion below raises, so a failure here cannot poison later tests.
+    monkeypatch.setattr(threading.Thread, "start", exhausted)
     allocations.allocate("epoch-0", 64)
     assert allocations.clear() == 1
     # A reclaimer that cannot start must not strand the epoch's handles behind a

--- a/lib/gpu_memory_service/v1/checkpoint.py
+++ b/lib/gpu_memory_service/v1/checkpoint.py
@@ -9,6 +9,7 @@ import logging
 import os
 import socket
 import threading
+import time
 from collections.abc import Mapping
 from typing import Protocol
 from uuid import uuid4
@@ -119,11 +120,17 @@ class GMSCheckpointLifecycle:
             raise RuntimeError("kv_cache must be empty before checkpoint")
         # Unlinked handles are released asynchronously in both domains; a
         # checkpoint must not capture a reclaimer mid-release or the physical
-        # memory it still owns. This runs under the admission condition, so a
-        # drain that runs long stalls admission for up to the timeout: refusing
-        # the checkpoint is the safe outcome, a brief stall is the price.
+        # memory it still owns. One deadline spans both drains: this runs under
+        # the admission condition, so a drain that runs long stalls admission
+        # for up to the timeout, and a per-domain timeout would let that stall
+        # grow with the number of domains until the control client gave up on
+        # the socket instead of reporting which domain is still reclaiming.
+        # Refusing the checkpoint is the safe outcome, a brief stall is the
+        # price.
+        deadline = time.monotonic() + _RECLAIM_DRAIN_TIMEOUT
         for name, manager in ((_WEIGHTS_DOMAIN, weights), (_KV_CACHE_DOMAIN, kv_cache)):
-            if not manager.drain_reclamation(_RECLAIM_DRAIN_TIMEOUT):
+            remaining = max(deadline - time.monotonic(), 0.0)
+            if not manager.drain_reclamation(remaining):
                 raise RuntimeError(
                     f"{name} reclamation did not complete before checkpoint"
                 )

--- a/lib/gpu_memory_service/v1/checkpoint.py
+++ b/lib/gpu_memory_service/v1/checkpoint.py
@@ -32,6 +32,7 @@ _SERVING = "serving"
 _CHECKPOINT_READY = "checkpoint_ready"
 _WEIGHTS_DOMAIN = "weights"
 _KV_CACHE_DOMAIN = "kv_cache"
+_RECLAIM_DRAIN_TIMEOUT = 5.0
 
 
 class _CheckpointDomainManager(Protocol):
@@ -43,6 +44,9 @@ class _CheckpointDomainManager(Protocol):
         ...
 
     def allocation_snapshot(self) -> tuple[tuple[str, int], ...]:
+        ...
+
+    def drain_reclamation(self, timeout: float | None = None) -> bool:
         ...
 
 
@@ -113,6 +117,12 @@ class GMSCheckpointLifecycle:
             raise RuntimeError("weights must contain committed allocations")
         if kv_allocations:
             raise RuntimeError("kv_cache must be empty before checkpoint")
+        # Unlinked KV handles are released asynchronously; a checkpoint must not
+        # capture a reclaimer mid-release or the physical memory it still owns.
+        if not kv_cache.drain_reclamation(_RECLAIM_DRAIN_TIMEOUT):
+            raise RuntimeError(
+                "kv_cache reclamation did not complete before checkpoint"
+            )
 
         self._generation += 1
         self._token = str(uuid4())

--- a/lib/gpu_memory_service/v1/checkpoint.py
+++ b/lib/gpu_memory_service/v1/checkpoint.py
@@ -117,12 +117,16 @@ class GMSCheckpointLifecycle:
             raise RuntimeError("weights must contain committed allocations")
         if kv_allocations:
             raise RuntimeError("kv_cache must be empty before checkpoint")
-        # Unlinked KV handles are released asynchronously; a checkpoint must not
-        # capture a reclaimer mid-release or the physical memory it still owns.
-        if not kv_cache.drain_reclamation(_RECLAIM_DRAIN_TIMEOUT):
-            raise RuntimeError(
-                "kv_cache reclamation did not complete before checkpoint"
-            )
+        # Unlinked handles are released asynchronously in both domains; a
+        # checkpoint must not capture a reclaimer mid-release or the physical
+        # memory it still owns. This runs under the admission condition, so a
+        # drain that runs long stalls admission for up to the timeout: refusing
+        # the checkpoint is the safe outcome, a brief stall is the price.
+        for name, manager in ((_WEIGHTS_DOMAIN, weights), (_KV_CACHE_DOMAIN, kv_cache)):
+            if not manager.drain_reclamation(_RECLAIM_DRAIN_TIMEOUT):
+                raise RuntimeError(
+                    f"{name} reclamation did not complete before checkpoint"
+                )
 
         self._generation += 1
         self._token = str(uuid4())

--- a/lib/gpu_memory_service/v1/client/mempool.py
+++ b/lib/gpu_memory_service/v1/client/mempool.py
@@ -25,7 +25,7 @@ from gpu_memory_service.v1.client.parameter_storage import (
 from gpu_memory_service.v1.device import get_socket_path
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator
+    from collections.abc import Callable, Iterable, Iterator
 
 logger = logging.getLogger(__name__)
 _WEIGHTS = "weights"
@@ -222,16 +222,27 @@ class TorchMempoolMemoryClient:
         try:
             self._state = "RESUMING"
             wake_t0 = monotonic()
-            self._kv_cache.connect(RequestedLockType.RW)
-            self._kv_cache.reallocate_all_handles()
-            self._kv_cache.remap_all_vas()
-            self._weights.connect(RequestedLockType.RO)
-            self._weights.remap_all_vas()
+            phases: list[tuple[str, float]] = []
+
+            def phase(name: str, step: Callable[[], object]) -> None:
+                started_at = monotonic()
+                step()
+                phases.append((name, monotonic() - started_at))
+
+            phase("kv_connect", lambda: self._kv_cache.connect(RequestedLockType.RW))
+            phase("kv_reallocate", self._kv_cache.reallocate_all_handles)
+            phase("kv_remap", self._kv_cache.remap_all_vas)
+            phase(
+                "weights_connect",
+                lambda: self._weights.connect(RequestedLockType.RO),
+            )
+            phase("weights_remap", self._weights.remap_all_vas)
             self._state = "RUNNING"
             logger.info(
-                "GMS V1 wake complete device=%d total_elapsed=%.3fs",
+                "GMS V1 wake complete device=%d total_elapsed=%.3fs %s",
                 self._device,
                 monotonic() - wake_t0,
+                " ".join(f"{name}={elapsed:.3f}s" for name, elapsed in phases),
             )
         except Exception:  # noqa: BLE001
             common_utils.fail(

--- a/lib/gpu_memory_service/v1/server/allocations.py
+++ b/lib/gpu_memory_service/v1/server/allocations.py
@@ -23,9 +23,10 @@ class GMSAllocationManager:
     """Own retained device allocation handles by opaque allocation ID.
 
     Clearing an epoch unlinks every allocation ID synchronously but releases the
-    physical handles on one background thread: release is proportional to the
-    departed owner's GPU footprint, and the caller clears while holding lock
-    admission for the next writer.
+    physical handles on one background thread. Release blocks on the driver
+    tearing down the departed owner's context, which is unbounded and varies by
+    more than an order of magnitude on identical inputs, and the caller clears
+    while holding lock admission for the next writer.
     """
 
     def __init__(self, vmm: VMMDevice, device: int):

--- a/lib/gpu_memory_service/v1/server/allocations.py
+++ b/lib/gpu_memory_service/v1/server/allocations.py
@@ -133,22 +133,35 @@ class GMSAllocationManager:
             return len(self._pending), self._releasing
 
     def _enqueue_release(self, handles: tuple[int, ...]) -> bool:
-        """Queue handles for background release; False once shut down."""
+        """Queue handles for background release; False once shut down or unstartable."""
         if not handles:
             return True
         with self._reclaim:
             if self._stopped:
                 return False
-            self._pending.extend(handles)
             if self._reclaimer is None:
-                self._reclaimer = threading.Thread(
-                    target=self._reclaim_forever,
-                    name=f"gms-v1-reclaim-{self._device}",
-                    daemon=True,
-                )
-                self._reclaimer.start()
+                try:
+                    # Published only once start() has succeeded: a dead thread in
+                    # _reclaimer would strand every later handle in _pending.
+                    self._reclaimer = self._start_reclaimer()
+                except RuntimeError:
+                    # Thread exhaustion. Leave _reclaimer unset so the next clear
+                    # retries, and make the caller release inline: a slow clear
+                    # beats leaking the departed owner's GPU memory forever.
+                    logger.exception("Cannot start the GPU allocation reclaimer")
+                    return False
+            self._pending.extend(handles)
             self._reclaim.notify_all()
             return True
+
+    def _start_reclaimer(self) -> threading.Thread:
+        reclaimer = threading.Thread(
+            target=self._reclaim_forever,
+            name=f"gms-v1-reclaim-{self._device}",
+            daemon=True,
+        )
+        reclaimer.start()
+        return reclaimer
 
     def _reclaim_forever(self) -> None:
         while True:

--- a/lib/gpu_memory_service/v1/server/allocations.py
+++ b/lib/gpu_memory_service/v1/server/allocations.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from collections import deque
 from collections.abc import Callable
 
 from gpu_memory_service.common.vmm import VMMDevice
@@ -15,10 +16,17 @@ from gpu_memory_service.common.vmm import VMMDevice
 logger = logging.getLogger(__name__)
 
 _ALLOCATION_RETRY_INTERVAL = 0.5
+_RECLAIM_SHUTDOWN_TIMEOUT = 30.0
 
 
 class GMSAllocationManager:
-    """Own retained device allocation handles by opaque allocation ID."""
+    """Own retained device allocation handles by opaque allocation ID.
+
+    Clearing an epoch unlinks every allocation ID synchronously but releases the
+    physical handles on one background thread: release is proportional to the
+    departed owner's GPU footprint, and the caller clears while holding lock
+    admission for the next writer.
+    """
 
     def __init__(self, vmm: VMMDevice, device: int):
         self._vmm = vmm
@@ -29,6 +37,13 @@ class GMSAllocationManager:
             raise ValueError("allocation granularity must be positive")
         self._allocations: dict[str, int] = {}
         self._lock = threading.Lock()
+        # Reclamation has its own lock because allocate() holds _lock across its
+        # OOM retry sleeps, and those retries depend on the reclaimer to progress.
+        self._reclaim = threading.Condition()
+        self._pending: deque[int] = deque()
+        self._releasing = 0
+        self._reclaimer: threading.Thread | None = None
+        self._stopped = False
 
     def allocate(
         self,
@@ -75,13 +90,89 @@ class GMSAllocationManager:
             del self._allocations[allocation_id]
 
     def clear(self) -> int:
+        """Unlink every allocation ID now; release the handles in the background."""
         with self._lock:
-            allocation_ids = tuple(self._allocations)
-            for allocation_id in allocation_ids:
-                handle = self._allocations[allocation_id]
-                self._vmm.release(handle)
-                del self._allocations[allocation_id]
-            return len(allocation_ids)
+            handles = tuple(self._allocations.values())
+            self._allocations.clear()
+            # Enqueued under _lock so an unlinked handle is never invisible to
+            # both allocation_snapshot() and reclaim_snapshot() at once.
+            queued = self._enqueue_release(handles)
+        if not queued:
+            for handle in handles:
+                self._release(handle)
+        return len(handles)
+
+    def drain(self, timeout: float | None = None) -> bool:
+        """Wait until every queued handle release has completed."""
+        with self._reclaim:
+            deadline = None if timeout is None else time.monotonic() + timeout
+            while self._pending or self._releasing:
+                wait = None if deadline is None else deadline - time.monotonic()
+                if wait is not None and wait <= 0:
+                    return False
+                self._reclaim.wait(wait)
+            return True
+
+    def shutdown(self) -> None:
+        """Drain pending releases and retire the background reclaimer."""
+        if not self.drain(_RECLAIM_SHUTDOWN_TIMEOUT):
+            # The reclaimer is a daemon thread and context teardown frees the
+            # device anyway, so a stalled driver must not hang server close.
+            logger.warning("GPU allocation reclamation did not drain before shutdown")
+        with self._reclaim:
+            self._stopped = True
+            reclaimer = self._reclaimer
+            self._reclaimer = None
+            self._reclaim.notify_all()
+        if reclaimer is not None:
+            reclaimer.join(timeout=_RECLAIM_SHUTDOWN_TIMEOUT)
+
+    def reclaim_snapshot(self) -> tuple[int, int]:
+        """Return the queued and in-flight background handle release counts."""
+        with self._reclaim:
+            return len(self._pending), self._releasing
+
+    def _enqueue_release(self, handles: tuple[int, ...]) -> bool:
+        """Queue handles for background release; False once shut down."""
+        if not handles:
+            return True
+        with self._reclaim:
+            if self._stopped:
+                return False
+            self._pending.extend(handles)
+            if self._reclaimer is None:
+                self._reclaimer = threading.Thread(
+                    target=self._reclaim_forever,
+                    name=f"gms-v1-reclaim-{self._device}",
+                    daemon=True,
+                )
+                self._reclaimer.start()
+            self._reclaim.notify_all()
+            return True
+
+    def _reclaim_forever(self) -> None:
+        while True:
+            with self._reclaim:
+                while not self._pending and not self._stopped:
+                    self._reclaim.wait()
+                if not self._pending:
+                    return
+                handle = self._pending.popleft()
+                self._releasing += 1
+            try:
+                # Released outside every lock: cuMemRelease is slow and must not
+                # serialize against allocate() or block a waiting writer.
+                self._release(handle)
+            finally:
+                with self._reclaim:
+                    self._releasing -= 1
+                    self._reclaim.notify_all()
+
+    def _release(self, handle: int) -> None:
+        try:
+            self._vmm.release(handle)
+        except Exception:
+            logger.exception("Failed to release GPU allocation handle %d", handle)
 
     def _get(self, allocation_id: str) -> int:
         if not allocation_id:

--- a/lib/gpu_memory_service/v1/server/allocations.py
+++ b/lib/gpu_memory_service/v1/server/allocations.py
@@ -94,8 +94,14 @@ class GMSAllocationManager:
         with self._lock:
             handles = tuple(self._allocations.values())
             self._allocations.clear()
-            # Enqueued under _lock so an unlinked handle is never invisible to
-            # both allocation_snapshot() and reclaim_snapshot() at once.
+            # Enqueued under _lock so that on the queued path a handle moves
+            # from allocation_snapshot() into reclaim_snapshot() without ever
+            # being invisible to both. The inline fallback below cannot hold
+            # that: it releases outside every lock, so both snapshots read
+            # empty while the driver still owns the handles. Safe because the
+            # only reader that must not miss them is the checkpoint fence,
+            # which is also gated on writer_reserved (checkpoint.py
+            # _require_quiesced) and that stays set across _clear_epoch().
             queued = self._enqueue_release(handles)
         if not queued:
             for handle in handles:

--- a/lib/gpu_memory_service/v1/server/rpc.py
+++ b/lib/gpu_memory_service/v1/server/rpc.py
@@ -384,6 +384,14 @@ class GMSServerMemoryManager:
     def allocation_snapshot(self) -> tuple[tuple[str, int], ...]:
         return tuple(sorted(self._allocation_sizes.items()))
 
+    def drain_reclamation(self, timeout: float | None = None) -> bool:
+        """Wait until background release of cleared epochs has completed."""
+        return self._allocations.drain(timeout)
+
+    def shutdown(self) -> None:
+        """Retire the background reclaimer after draining pending releases."""
+        self._allocations.shutdown()
+
     def _clear_allocations(self) -> int:
         cleared = self._allocations.clear()
         self._allocation_sizes.clear()
@@ -542,4 +550,5 @@ class GMSRPCServer(socketserver.ThreadingUnixStreamServer):
 
     def server_close(self) -> None:
         super().server_close()
+        self.manager.shutdown()
         Path(self.path).unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

> **Stacked on `schwinns/gms-snapshot-e2e-20260829`**, so the diff shows only the
> 6 files this change touches. Retarget to `main` once that branch lands.

Promoting a shadow engine after the active engine is `SIGKILL`ed can fail with

```
GMS connect failed: Timed out waiting for GMS handshake or lock admission
```

which kills the vLLM Executor and loses the failover. When it does *not* fail, it
is still slow and wildly variable: measured on 8x B200, the same promotion of the
same model on the same node took **15.95 s** once and **3.80 s** the next time.

The cause is that reclaiming the dead peer's GPU memory happens **inside lock
admission**, and its duration is unbounded and highly variable, while the
client's admission deadline is a fixed 30 s. That is a race, not a slow constant
— which is exactly why it fails *intermittently* rather than always.

This PR moves the reclamation off the admission path.

## What was actually wrong

Peer-death detection was never broken, and nothing leaked. `_GMSRequestHandler`'s
`finally:` calls `manager.close(session)` on socket EOF, and there is an explicit
`POLLHUP`/`POLLRDHUP` poller, so a `SIGKILL`ed client is noticed within
milliseconds. I want to be clear about that, because "the dead client leaked the
lock" is the intuitive story and it is wrong.

The problem is where the reclamation runs:

```python
def close(self, session: ServerSession) -> None:
    with self._condition:
        if session is self._rw_session:
            self._rw_session = None
            self._writer_reserved = True      # the waiting shadow is now pinned
            self._committed = False
        ...
    try:
        self._clear_epoch()                   # unbounded, O(total GPU bytes)
    finally:
        with self._condition:
            self._writer_reserved = False     # only now is the shadow admitted
            self._condition.notify_all()
```

`_clear_epoch()` bottoms out in `GMSAllocationManager.clear()`, which calls
`cuMemRelease` once per slab. The waiting shadow is parked in
`acquire()` -> `_wait_for(_can_grant_rw)`, and the server only sends its
`HandshakeResponse` after `acquire()` returns — so the whole reclaim is charged
against the client's `connect_timeout`, which defaults to 30.0 s and is not
configurable.

**What sets the duration.** I want to be careful here, because the obvious guess
is wrong. It is *not* simply proportional to the bytes or the allocation count:

| case | allocs/dev | weights GiB/dev | admission blocked | post-admission OOM lines |
|---|---:|---:|---:|---:|
| DeepSeek-V4-Flash, run 1 | 12 | 24 | **12.88 s** | 16 |
| DeepSeek-V4-Flash, run 2 | 12 | 24 | **0.63 s** | 15 |
| GLM-5.2 | 30 | 60 | 0.63 s | 14 |
| DeepSeek-V4-Pro | 62 | 124 | ~0 s | **0** |

The largest footprint in the set (DeepSeek-V4-Pro, ~992 GiB across 8 ranks) had
the *fastest* admission and no allocation back-pressure at all, and the two
Flash runs were byte-for-byte identical yet differed 20x. So the cost is not a
function of size.

The behaviour is consistent with `cuMemRelease` blocking on the CUDA driver's
*asynchronous* teardown of the SIGKILLed process's context: the successor is
really waiting on however much of the dead peer's cleanup the driver has left to
do at the moment it asks for admission. That is inherently timing-dependent. I
have not instrumented the driver to prove that mechanism, so I state it as the
best available explanation rather than as established fact — but the two facts
that matter for this PR are directly measured and are not in doubt: **the
reclaim runs inside admission** (structurally, from the code above), and **its
duration is unbounded and varies by more than an order of magnitude on identical
inputs**.

## Measurements

DeepSeek-V4-Flash, vLLM TP8 on 8x B200, 105.6 GiB of KV per rank. Two promotions,
different pods, identical model / code / node:

| phase | run 1 | run 2 | stable? |
|---|---:|---:|---|
| `kill -9` -> failover lock acquired | 1.55 s | 1.54 s | yes |
| **lock -> admission granted** | **12.88 s** | **0.63 s** | **no, 20x** |
| post-admission `cuMemCreate` OOM retry | 1.63 s | 1.91 s | yes |
| remap + fp8 scale init | 1.44 s | 1.26 s | yes |
| **vLLM `wake_up`** | **15.95 s** | **3.80 s** | **no, 4.2x** |
| OOM retry line count | 16 | 15 | yes |

Every phase is stable except admission, which varies 20x. For reference, the same
engine waking from the same checkpoint with **no** dead peer to reclaim wakes in
**0.68-0.70 s** — so essentially the entire promotion cost, and all of the
variance, is the dead peer's reclamation.

A GLM-5.2 promotion on an earlier run blew through the 30 s deadline and failed
outright; a later attempt on the same model succeeded in 3.76 s. Same build, same
model. That is the race, observed directly.

## Why not just raise the client timeout

It would convert an intermittent hard failure into an intermittent
tens-of-seconds stall, and it would still be a race. It is also the wrong lever
operationally: the GMS **client** lives inside the CRIU checkpoint image, so
changing it invalidates existing checkpoints, whereas the **server** is a
cold-started sidecar that is deliberately excluded from the snapshot. A
server-side fix deploys without recapturing anything.

## The change

`GMSAllocationManager.clear()` now unlinks every allocation ID synchronously —
dict work only — and releases the CUDA handles on one long-lived background
daemon thread per manager:

```python
with self._lock:
    handles = tuple(self._allocations.values())
    self._allocations.clear()
    queued = self._enqueue_release(handles)   # dict ops + deque append only
```

The reclaimer calls `self._vmm.release(handle)` **outside every lock** — in
particular outside `self._lock`, which `allocate()` holds across its OOM-retry
sleeps. Holding it there would serialize the reclaimer against the very retries
that depend on it and silently reintroduce the stall. That is why there is a
second lock rather than one.

The new writer is admitted immediately and proceeds to allocate. If the
background release has not freed enough memory yet, `allocate()`'s existing
`create_tolerate_oom` loop handles it: bounded 0.5 s backoff with a peer-death
cancellation check. Each individual `AllocateRequest` then waits for roughly one
slab's worth of reclaim instead of the entire epoch, which is what keeps it
inside the client's 30 s per-request budget without touching the client. The
measurements above show that retry regime is stable and cheap (~1.6-1.9 s across
all 8 ranks) even when the admission window varied 20x.

**Property gained:** admission no longer contains unbounded driver reclamation
work at all. The race is removed rather than re-tuned. Note the claim is *not*
that the reclaim gets cheaper — the same `cuMemRelease` calls still happen — it
is that they stop gating the handshake, and the work that remains on the
critical path is the bounded, measured retry regime above.

Invariants:

- **No duplicate allocation IDs.** IDs leave `self._allocations` and enter the
  pending queue atomically under `self._lock`, before `clear()` returns. A writer
  that observes admission has, by lock ordering, already observed the empty table.
- **Exactly-once release.** A later `clear()` sees an empty dict and enqueues
  nothing.
- **Bounded threads.** One lazily-created daemon thread per manager, shared across
  repeated failovers. No per-epoch or per-rank fan-out.
- **Shutdown.** `server_close()` drains with a bound, then joins; after shutdown
  `clear()` falls back to inline release so nothing leaks.
- **Checkpoint fence.** `_prepare` drains pending reclamation for *both* the
  `kv_cache` and `weights` domains before declaring a checkpoint ready, so a
  checkpoint can never be captured while physical memory the empty allocation
  table no longer describes is still held. Both drains share **one** deadline, so
  the worst-case server-side `prepare()` stays bounded by a single drain budget
  rather than growing with the number of domains — otherwise the stall grows
  until the client gives up on the socket instead of learning which domain is
  still reclaiming. A drain timeout raises and refuses the checkpoint rather than
  proceeding, naming the offending domain.

Also adds per-phase timings to the existing `GMS V1 wake complete` line (kv
connect / reallocate / remap, weights connect / remap), keeping the existing
prefix and format so current log parsers keep working. Reconstructing the table
above required reading the server's OOM lines; this makes it directly observable.

## Validation

- `81 passed, 10 skipped` before, `83 passed, 10 skipped` after; the +2 are the
  two new tests. All 10 skips are environment (9x torch, 1x pynvml) and unchanged.
- **The core regression test fails on the unfixed server, 10/10**, tracebacking
  through `rpc.py close -> _clear_allocations -> allocations.py clear -> release`,
  i.e. exactly the described mechanism. It passes on the fix. It uses
  `threading.Event` handshakes rather than sleeps, and asserts that the
  replacement writer connects while the release is *still blocked*.
- Adversarial review of the first draft of this change found three defects, all
  fixed in the follow-up commits here: a ~9% flaky assertion that encoded a thread
  scheduling accident rather than an invariant; a path where a failed
  `Thread.start()` (thread exhaustion) would publish a dead thread and then
  permanently leak every future handle; and a checkpoint fence that drained only
  the `kv_cache` domain. Each fix has a test, and each test was confirmed to fail
  against the corresponding unfixed code.
- De-flake proven independently over 150 separate pytest processes, 0 failures,
  against 11/150 (7.3%) for the pre-fix assertion; a 2100-trial probe found the
  new invariant held 2100/2100 while the old exact-tuple assertion was violated
  4.3% of the time.
- The vacuousness claim was independently reproduced: a manager deliberately
  spawning one reclaimer per enqueue is caught by the new assertion (saw 4
  threads) and silently passed by the old one, because every reclaimer shares the
  same thread name.
- Concurrency probed empirically: no double-release or leak across 300
  shutdown-race trials; no deadlock under 6-thread contention; the stale-ID
  invariant held across 400 trials; 500 rapid failovers produced exactly 1
  reclaimer thread.
- End-to-end on 8x B200: shadow promotion now verified on DeepSeek-V4-Flash,
  GLM-5.2 and DeepSeek-V4-Pro, each serving correct inference after promotion.

Commits are separated so the history is bisectable, and each passes the suite on
its own.

## Notes for reviewers

- Not validated against real CUDA in CI — this host has no GPU, so the tests run
  against `FakeVMM`. The changed code is pure Python control flow. The one thing
  worth confirming on real hardware is that the post-admission OOM-retry count
  stays small now that reclaim and allocation genuinely overlap.
- The inline-release fallback (used only when a thread cannot be started) runs
  outside `_lock`, but the caller still eats the reclaim latency this PR removes,
  because admission remains serialized by `_writer_reserved`. That is deliberate:
  a slow admission is recoverable, a permanently leaked GPU epoch is not.
- Longer term, the deeper fix is to stop destroying and recreating the KV backing
  on failover at all — the successor needs the same-shaped backing at the same
  VAs, not fresh physical pages. `RW_DATA_OR_RW` already describes those semantics
  in `common/locks.py` but V1 rejects it. That is O(1) instead of O(bytes) and
  would eliminate this cost entirely, but it weakens a safety property and needs
  a DEP, not a patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GMS V1 support for vLLM and SGLang, selected through environment configuration.
  - Improved checkpoint restore sequencing and failover recovery.
  - Added support for one or two standby engines in intra-pod failover and configurable shadow engines across deployments.
  - Added automatic checkpoint handling for managed deployments, including identity-free checkpoints where applicable.
  - Added checkpoint placeholder image builds for on-demand workflows.

- **Bug Fixes**
  - Improved checkpoint readiness and memory reclamation reliability.
  - Added validation to prevent unsupported failover and checkpoint configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->