### PR TITLE
fix(docs): center Blog publication pages on wide viewports

### DIFF
--- a/docs/fern/components/BlogStyles.tsx
+++ b/docs/fern/components/BlogStyles.tsx
@@ -76,6 +76,26 @@ article:has(.dynamo-blog-home) {
   padding: 0 clamp(0.25rem, 2vw, 1.5rem) 5rem;
 }
 
+/* Wide-screen centering for TOC-less Blog pages. Fern centers the content
+   column between two sticky asides: the sidebar absorbs the viewport's left
+   overflow past --page-width and the table-of-contents aside the right one,
+   both boxes --sticky-aside-width wide. The publication pages set hide-toc,
+   so no TOC aside renders, the content wrapper stretches into the freed
+   width, and the capped article above centers inside the stretched wrapper,
+   sitting right of the viewport center by half the freed width. Reserve the
+   TOC box again so the column lands where a TOC-bearing page puts it -- the
+   same geometry the digest landing gets from its empty TOC aside. Scoped by
+   requiring the aside to be absent, so the digest (aside present, empty) and
+   the article pages (aside with entries) keep Fern's default, and by the
+   80rem breakpoint, which is where Fern lays the TOC column out at all;
+   below it the wrapper is already full-width on TOC-bearing pages too. No
+   backticks in this comment: it sits inside the BLOG_CSS literal. */
+@media (min-width: 80rem) {
+  body:has(.dynamo-blog-home):not(:has(#fern-toc)) .fern-layout-content-wrapper {
+    margin-inline-end: var(--sticky-aside-width);
+  }
+}
+
 article:has(.dynamo-blog-home) > header {
   display: none;
 }

--- a/docs/fern/components/BlogStyles.tsx
+++ b/docs/fern/components/BlogStyles.tsx
@@ -76,20 +76,8 @@ article:has(.dynamo-blog-home) {
   padding: 0 clamp(0.25rem, 2vw, 1.5rem) 5rem;
 }
 
-/* Wide-screen centering for TOC-less Blog pages. Fern centers the content
-   column between two sticky asides: the sidebar absorbs the viewport's left
-   overflow past --page-width and the table-of-contents aside the right one,
-   both boxes --sticky-aside-width wide. The publication pages set hide-toc,
-   so no TOC aside renders, the content wrapper stretches into the freed
-   width, and the capped article above centers inside the stretched wrapper,
-   sitting right of the viewport center by half the freed width. Reserve the
-   TOC box again so the column lands where a TOC-bearing page puts it -- the
-   same geometry the digest landing gets from its empty TOC aside. Scoped by
-   requiring the aside to be absent, so the digest (aside present, empty) and
-   the article pages (aside with entries) keep Fern's default, and by the
-   80rem breakpoint, which is where Fern lays the TOC column out at all;
-   below it the wrapper is already full-width on TOC-bearing pages too. No
-   backticks in this comment: it sits inside the BLOG_CSS literal. */
+/* Reserve the absent sticky TOC column at wide breakpoints to keep Blog
+   content aligned with TOC-bearing pages. */
 @media (min-width: 80rem) {
   body:has(.dynamo-blog-home):not(:has(#fern-toc)) .fern-layout-content-wrapper {
     margin-inline-end: var(--sticky-aside-width);


### PR DESCRIPTION
## Overview

Fix the right-shifted layout on the External publications and Research publications Blog pages at wide desktop viewport sizes.

## Summary

- Restore the space normally reserved for Fern's table-of-contents column on Blog pages that use `hide-toc`.
- Scope the adjustment to `.dynamo-blog-home` pages without a rendered `#fern-toc` and to Fern's 80rem wide-layout breakpoint.
- Preserve the digest, article, and narrower viewport layouts.

## Details

Fern normally balances the main content between the sidebar and the table-of-contents column. On the two publication pages, `hide-toc` prevents that right-side column from rendering. The content wrapper then expands into the freed space, so its capped article area appears shifted to the right.

The new rule reserves the missing column width only when the Blog home marker is present and no table of contents is rendered.

## Where should the reviewer start?

`docs/fern/components/BlogStyles.tsx`

## Related Issues

- Closes #13201

## Validation

- `python3 docs/fern/scripts/check_style_components.py`
- `python3 docs/fern/scripts/check_component_imports.py`
- `python3 docs/fern/scripts/check_published_styles.py --test`
- `python3 docs/fern/scripts/check_asset_paths.py`
- `python3 docs/fern/scripts/check_agent_twins.py docs/fern/components/BlogStyles.tsx`
- `git diff --check origin/main...HEAD`
- Headless layout comparison using captured production HTML/CSS without client hydration, at 1279, 1280, 1440, 1920, and 3005 px: at 3005 px, the publication column's center offset changes from +515 px to 0 px, while the digest and article layouts remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved wide-screen blog page layout when no table of contents is present.
  * Reserved consistent space for the table of contents area on large screens, while preserving existing layouts on narrower screens and pages that include a table of contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
