### PR TITLE
docs(frontend): correct the endpoint path env var names

### DIFF
--- a/docs/fern/pages/reference/components/frontend-configuration.mdx
+++ b/docs/fern/pages/reference/components/frontend-configuration.mdx
@@ -741,15 +741,19 @@ All endpoint paths can be overridden via environment variables:
 
 | Env Var | Default Path |
 |---------|-------------|
-| `DYN_HTTP_SVC_CHAT_PATH_ENV` | `/v1/chat/completions` |
-| `DYN_HTTP_SVC_CMP_PATH_ENV` | `/v1/completions` |
-| `DYN_HTTP_SVC_EMB_PATH_ENV` | `/v1/embeddings` |
-| `DYN_HTTP_SVC_RESPONSES_PATH_ENV` | `/v1/responses` |
-| `DYN_HTTP_SVC_MODELS_PATH_ENV` | `/v1/models` |
-| `DYN_HTTP_SVC_ANTHROPIC_PATH_ENV` | `/v1/messages` |
-| `DYN_HTTP_SVC_HEALTH_PATH_ENV` | `/health` |
-| `DYN_HTTP_SVC_LIVE_PATH_ENV` | `/live` |
-| `DYN_HTTP_SVC_METRICS_PATH_ENV` | `/metrics` |
+| `DYN_HTTP_SVC_CHAT_PATH` | `/v1/chat/completions` |
+| `DYN_HTTP_SVC_CMP_PATH` | `/v1/completions` |
+| `DYN_HTTP_SVC_EMB_PATH` | `/v1/embeddings` |
+| `DYN_HTTP_SVC_RESPONSES_PATH` | `/v1/responses` |
+| `DYN_HTTP_SVC_MODELS_PATH` | `/v1/models` |
+| `DYN_HTTP_SVC_CLASSIFY_PATH` | `/v1/classify` |
+| `DYN_HTTP_SVC_POOLING_PATH` | `/v1/pooling` |
+| `DYN_HTTP_SVC_FILES_PATH` | `/v1/files` |
+| `DYN_HTTP_SVC_BATCHES_PATH` | `/v1/batches` |
+| `DYN_HTTP_SVC_ANTHROPIC_PATH` | `/v1/messages` |
+| `DYN_HTTP_SVC_HEALTH_PATH` | `/health` |
+| `DYN_HTTP_SVC_LIVE_PATH` | `/live` |
+| `DYN_HTTP_SVC_METRICS_PATH` | `/metrics` |
 
 ## Deprecated
 

--- a/docs/fern/pages/reference/components/frontend-configuration.mdx
+++ b/docs/fern/pages/reference/components/frontend-configuration.mdx
@@ -737,23 +737,34 @@ truthy value (`1`, `true`, `yes`, or `on`, case-insensitive) to disable the corr
 
 ### Endpoint path customization
 
-All endpoint paths can be overridden via environment variables:
+Endpoint paths are overridden via environment variables. An override only takes
+effect when its route is registered, so the routes that are off by default need
+their feature enabled as well as the path set.
 
-| Env Var | Default Path |
-|---------|-------------|
-| `DYN_HTTP_SVC_CHAT_PATH` | `/v1/chat/completions` |
-| `DYN_HTTP_SVC_CMP_PATH` | `/v1/completions` |
-| `DYN_HTTP_SVC_EMB_PATH` | `/v1/embeddings` |
-| `DYN_HTTP_SVC_RESPONSES_PATH` | `/v1/responses` |
-| `DYN_HTTP_SVC_MODELS_PATH` | `/v1/models` |
-| `DYN_HTTP_SVC_CLASSIFY_PATH` | `/v1/classify` |
-| `DYN_HTTP_SVC_POOLING_PATH` | `/v1/pooling` |
-| `DYN_HTTP_SVC_FILES_PATH` | `/v1/files` |
-| `DYN_HTTP_SVC_BATCHES_PATH` | `/v1/batches` |
-| `DYN_HTTP_SVC_ANTHROPIC_PATH` | `/v1/messages` |
-| `DYN_HTTP_SVC_HEALTH_PATH` | `/health` |
-| `DYN_HTTP_SVC_LIVE_PATH` | `/live` |
-| `DYN_HTTP_SVC_METRICS_PATH` | `/metrics` |
+| Env Var | Default Path | Takes effect when |
+|---------|-------------|-------------------|
+| `DYN_HTTP_SVC_CHAT_PATH` | `/v1/chat/completions` | Always |
+| `DYN_HTTP_SVC_CMP_PATH` | `/v1/completions` | Always |
+| `DYN_HTTP_SVC_EMB_PATH` | `/v1/embeddings` | Always |
+| `DYN_HTTP_SVC_RESPONSES_PATH` | `/v1/responses` | Always |
+| `DYN_HTTP_SVC_MODELS_PATH` | `/v1/models` | Always |
+| `DYN_HTTP_SVC_CLASSIFY_PATH` | `/v1/classify` | Always |
+| `DYN_HTTP_SVC_POOLING_PATH` | `/v1/pooling` | Always |
+| `DYN_HTTP_SVC_ANTHROPIC_PATH` | `/v1/messages` | `--enable-anthropic-api` (`DYN_ENABLE_ANTHROPIC_API`) |
+| `DYN_HTTP_SVC_VLLM_GENERATE_PATH` | `/inference/v1/generate` | `DYN_VLLM_ENABLE_INFERENCE_V1_GENERATE` |
+| `DYN_HTTP_SVC_SGLANG_GENERATE_PATH` | `/generate` | `DYN_SGLANG_ENABLE_GENERATE` |
+| `DYN_HTTP_SVC_FILES_PATH` | `/v1/files` | Batch endpoints, see the note below |
+| `DYN_HTTP_SVC_BATCHES_PATH` | `/v1/batches` | Batch endpoints, see the note below |
+| `DYN_HTTP_SVC_HEALTH_PATH` | `/health` | Always |
+| `DYN_HTTP_SVC_LIVE_PATH` | `/live` | Always |
+| `DYN_HTTP_SVC_METRICS_PATH` | `/metrics` | Always |
+
+<Note>
+The Batch API is a placeholder. Its routes are off by default, there is no flag or
+environment variable that turns them on, and the handlers return `501` when they are
+enabled in-process. `DYN_HTTP_SVC_FILES_PATH` and `DYN_HTTP_SVC_BATCHES_PATH` are
+therefore inert in a normal deployment and are listed here for completeness.
+</Note>
 
 ## Deprecated
 


### PR DESCRIPTION
## Summary

The endpoint-path table in the frontend configuration reference lists Rust static identifiers rather than the environment variables those statics hold. Every row carried a spurious `_ENV` suffix.

The table says `DYN_HTTP_SVC_CHAT_PATH_ENV`. `service_v2.rs` says:

```rust
static HTTP_SVC_CHAT_PATH_ENV: &str = "DYN_HTTP_SVC_CHAT_PATH";
```

and the router passes that static's *value* to `var()`:

```rust
super::openai::classify_router(state.clone(), var(HTTP_SVC_CLASSIFY_PATH_ENV).ok());
```

So the documented name is read by nothing. Someone following this page to move `/v1/chat/completions` sets `DYN_HTTP_SVC_CHAT_PATH_ENV`, the path does not move, and nothing warns, because there is no reader to warn. All nine rows had it.

The table also claimed "All endpoint paths can be overridden" while omitting four routes that are registered unconditionally and read exactly the same way, so those are added: classify, pooling, files and batches.

Left out deliberately: `DYN_HTTP_SVC_VLLM_GENERATE_PATH` and `DYN_HTTP_SVC_SGLANG_GENERATE_PATH`. Those routes only exist when `DYN_VLLM_ENABLE_INFERENCE_V1_GENERATE` or `DYN_SGLANG_ENABLE_GENERATE` opts in, so listing them beside the always-on routes would imply they work by default. Happy to add them with that caveat if you would rather have them here.

## Validation

Documentation only.

Rather than eyeball thirteen rows, I checked the table against the source programmatically: parse every `` `DYN_HTTP_SVC_*` `` name and default out of the rendered table, parse `static HTTP_SVC_*_ENV: &str = "..."` and its `(default: ...)` doc comment out of `service_v2.rs`, and compare. All 13 names exist in the code and all 13 defaults agree. The only two real variables not in the table are the two opt-in generate paths above.

`pre-commit run --files docs/fern/pages/reference/components/frontend-configuration.mdx` passes every applicable hook, including the Fern asset-path check. `pytest-marker-report` fails identically on an untouched `README.md` here because vLLM and TensorRT-LLM are not installed.

I could not exercise this against a running frontend: the prebuilt bindings in this checkout are stale against current `main` and the rebuild does not link here, so the evidence above is source-level rather than a live request. The name mismatch is a direct read of two lines, so I do not think a live run changes the conclusion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated endpoint customization guidance to use the current environment variable names.
  - Added documentation for configuring classify, pooling, files, and batches endpoint paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->