### PR TITLE
fix(gms): preserve tensor aliasing on the V0 read-only import path

### DIFF
--- a/bench/harness/aiperf_load.sh
+++ b/bench/harness/aiperf_load.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Drive load with aiperf in pure synthetic mode, and keep its artifacts.
+# This replaces a hand-rolled curl loop. That loop worked, but it produced no
+# record of what it had actually sent, so a run could only be labelled "loaded"
+# by watching the engine's own scheduler line -- and when that reading turned
+# out to predate the kill by ~15 s, every load label became unverifiable after
+# the fact. aiperf writes a profile export per request, so the offered load
+# becomes an artifact instead of an assertion.
+# Synthetic mode is selected by NOT passing --input-file. No dataset, no
+# mooncake trace, no session accumulation, and none of the trace-preparation
+# steps that cost several failed runs -- just a fixed prompt/output shape at a
+# fixed concurrency, which is all a failover profile needs.
+# Holding every request in decode for its full output length matters here: a
+# request that stops early at EOS frees its slot and the offered load sags right
+# when the kill lands. --force-min-tokens looks like the modern way to do that
+# but is rejected outside the baseten_trace loader:
+#   --force-min-tokens is only supported by the baseten_trace loader;
+#   provide --input-file and --custom-dataset-type baseten_trace.
+# So synthetic mode passes ignore_eos through --extra-inputs, which the server
+# honours regardless of loader.
+set -uo pipefail
+
+MODEL=${MODEL:?set MODEL}
+URL=${URL:?set URL}
+TOKENIZER=${TOKENIZER:?set TOKENIZER}
+ARTIFACT_DIR=${ARTIFACT_DIR:?set ARTIFACT_DIR}
+CONCURRENCY=${CONCURRENCY:-64}
+ISL=${ISL:-1200}
+OSL=${OSL:-20000}
+DURATION=${DURATION:-180}
+WARMUP=${WARMUP:-0}
+# A mooncake trace is multi-turn: every record sharing a session_id is one
+# conversation. The completions endpoint rejects that outright --
+# ValueError("Completions endpoint only supports one turn.") -- so trace runs
+# must go to chat, which is also what the published cascade script relies on by
+# leaving --endpoint-type unset. Synthetic runs stay on completions, where the
+# single-turn prompt is what we want and chat templating would only add noise.
+if [ -n "${TRACE_FILE:-}" ]; then
+  ENDPOINT_TYPE=${ENDPOINT_TYPE:-chat}
+else
+  ENDPOINT_TYPE=${ENDPOINT_TYPE:-completions}
+fi
+# Defaults below match bench/scripts/run_failover_bench.sh, the configuration the
+# published cascade numbers were produced with, so a trace run here is comparable
+# to them rather than merely similar.
+RAMP_S=${RAMP_S:-0}                 # published run ramps concurrency over 45s
+GRACE_S=${GRACE_S:-90}              # let in-flight long-context turns drain
+WORKERS_MAX=${WORKERS_MAX:-200}     # 200k-context turns hold a worker for minutes
+RECORD_PROCS=${RECORD_PROCS:-8}
+
+mkdir -p "$ARTIFACT_DIR"
+
+# The synthetic flags this script depends on do not exist before 0.12.0, and the
+# bench image ships 0.7.0. Installing at run time rather than assuming, because
+# the install lives in the pod's filesystem and is lost whenever the pod is
+# recreated -- which the failover harness does between iterations.
+AIPERF_MIN=${AIPERF_MIN:-0.12.0}
+have=$(aiperf --version 2>/dev/null | tail -1 | tr -d ' ')
+if [ "$have" != "$AIPERF_MIN" ]; then
+  echo "aiperf $have != $AIPERF_MIN, installing"
+  pip install -q --disable-pip-version-check --upgrade "aiperf==$AIPERF_MIN" >/dev/null 2>&1
+  have=$(aiperf --version 2>/dev/null | tail -1 | tr -d ' ')
+fi
+echo "aiperf version: $have"
+[ "$have" = "$AIPERF_MIN" ] || { echo "FATAL: could not get aiperf $AIPERF_MIN"; exit 1; }
+
+# Tokenizer correctness matters: aiperf uses it for synthetic prompt generation
+# and client-side token counting, so a wrong tokenizer silently corrupts every
+# ISL/OSL figure it reports. So use the REAL repo from the REAL model cache.
+# That requires transformers >= ~5.15: GLM-5.2's config.json declares
+# layer_types of "deepseek_sparse_attention", which 5.7.0 (shipped in the bench
+# image) does not recognise and rejects with a StrictDataclass validation error.
+# An earlier workaround staged a cache with the real tokenizer files plus a stub
+# config.json; it produced byte-identical tokenization, but relying on a
+# hand-written config to read a tokenizer is not something to keep once the
+# actual fix is a version bump.
+TRANSFORMERS_MIN=${TRANSFORMERS_MIN:-5.15.1}
+tv=$(python3 -c "import transformers;print(transformers.__version__)" 2>/dev/null)
+if [ "$tv" != "$TRANSFORMERS_MIN" ]; then
+  echo "transformers $tv != $TRANSFORMERS_MIN, installing"
+  pip install -q --disable-pip-version-check --upgrade "transformers==$TRANSFORMERS_MIN" >/dev/null 2>&1
+  tv=$(python3 -c "import transformers;print(transformers.__version__)" 2>/dev/null)
+fi
+echo "transformers version: $tv"
+[ "$tv" = "$TRANSFORMERS_MIN" ] || { echo "FATAL: need transformers $TRANSFORMERS_MIN for the GLM tokenizer"; exit 1; }
+export HF_HUB_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+
+export AIPERF_HTTP_SO_RCVTIMEO=120
+ulimit -n 65536 2>/dev/null || true
+
+# aiperf rejects --num-warmup-requests 0 (must be > 0), so the flag is omitted
+# entirely rather than passed as zero. Warmup is off by default here because the
+# kill lands mid-run and a warmup phase would just delay reaching steady load.
+WARMUP_ARGS=()
+[ "${WARMUP:-0}" -gt 0 ] 2>/dev/null && WARMUP_ARGS=(--num-warmup-requests "$WARMUP")
+
+# Trace mode replays a mooncake dataset instead of generating synthetic prompts.
+# Worth having because synthetic load at stddev 0 self-synchronises: every lane
+# runs an identical request, finishes at the same instant and restarts together,
+# so completions arrive in convoys (measured: 16 waves, 6.5 s apart, median gap
+# between consecutive completions 0 ms). A trace has real ISL/OSL spread and
+# real prefix reuse, so no convoy can form.
+# --no-fixed-schedule is required: 0.12 auto-switches trace datasets to
+# timestamp-driven arrivals, which makes concurrency emergent and breaks the
+# Running>=N gate the failover runs depend on.
+RAMP_ARGS=()
+[ "${RAMP_S:-0}" -gt 0 ] && RAMP_ARGS=(--concurrency-ramp-duration "$RAMP_S")
+
+SHAPE_ARGS=()
+if [ -n "${TRACE_FILE:-}" ]; then
+  # --isl-block-size must be stated, not inferred. aiperf tries to deduce one
+  # fixed block size from input_length / len(hash_ids) and aborts with
+  # "inconsistent sizes ... indicate a corrupt trace" when that ratio varies.
+  # It varies for any correct trace: a record whose last block is partially
+  # filled has a lower ratio (578 tokens over 2 hash_ids reads as 289), so the
+  # inference is simply wrong. Checked against the real thing -- all 13167
+  # records satisfy ceil(input_length / 512) == len(hash_ids) exactly, with zero
+  # mismatches, so the data was never the problem.
+  SHAPE_ARGS=(--input-file "$TRACE_FILE"
+              --custom-dataset-type "${TRACE_TYPE:-mooncake_trace}"
+              --isl-block-size "${ISL_BLOCK_SIZE:-512}"
+              --no-fixed-schedule)
+  echo "aiperf trace: $TRACE_FILE concurrency=$CONCURRENCY duration=${DURATION}s"
+else
+  SHAPE_ARGS=(--prompt-input-tokens-mean "$ISL" --prompt-input-tokens-stddev "${ISL_STDDEV:-0}"
+              --prompt-output-tokens-mean "$OSL" --prompt-output-tokens-stddev "${OSL_STDDEV:-0}")
+  echo "aiperf synthetic: concurrency=$CONCURRENCY isl=$ISL osl=$OSL duration=${DURATION}s warmup=${WARMUP:-0}"
+fi
+
+# Open loop. With --concurrency the client keeps exactly N requests in flight and
+# issues a new one only when an old one returns, so offered load falls in lockstep
+# with capacity: killing half the fleet made the client send 38% FEWER requests,
+# no queue ever formed, and TTFT had nothing to climb from. Setting a request rate
+# decouples arrivals from completions, which is the only way a queue -- and
+# therefore a visible degradation -- can exist at all.
+# --concurrency is still passed, as a CAP rather than a target. It must stay well
+# above steady-state occupancy (rate x latency) or it silently re-closes the loop.
+RATE_ARGS=()
+if [ -n "${REQUEST_RATE:-}" ]; then
+  RATE_ARGS=(--request-rate "$REQUEST_RATE" --request-rate-mode "${RATE_MODE:-poisson}")
+  [ "${RATE_RAMP_S:-0}" -gt 0 ] && RATE_ARGS+=(--request-rate-ramp-duration "$RATE_RAMP_S")
+  echo "aiperf OPEN LOOP: rate=${REQUEST_RATE}/s mode=${RATE_MODE:-poisson} cap=$CONCURRENCY"
+fi
+
+exec aiperf profile \
+  -m "$MODEL" \
+  --tokenizer "$TOKENIZER" \
+  --url "$URL" \
+  --endpoint-type "$ENDPOINT_TYPE" \
+  --streaming \
+  "${SHAPE_ARGS[@]}" \
+  "${RATE_ARGS[@]}" \
+  --extra-inputs ignore_eos:true \
+  --concurrency "$CONCURRENCY" \
+  --benchmark-duration "$DURATION" \
+  "${WARMUP_ARGS[@]}" \
+  --request-timeout-seconds "${REQ_TIMEOUT:-900}" \
+  --benchmark-grace-period "$GRACE_S" \
+  --workers-max "$WORKERS_MAX" --record-processors "$RECORD_PROCS" \
+  "${RAMP_ARGS[@]}" \
+  --random-seed 42 \
+  --artifact-dir "$ARTIFACT_DIR" \
+  --ui-type simple

--- a/bench/harness/chart_client.py
+++ b/bench/harness/chart_client.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""TTFT and per-user decode rate around a failover, from aiperf records.
+
+Per-user decode rate is the metric that answers "what did a user experience".
+System throughput can hold steady while every individual stream slows down, and
+only the per-user view separates those. TTFT answers the complementary
+question -- whether new requests were being admitted promptly.
+
+Both are plotted against time from the SIGKILL, with a windowed median over the
+raw scatter. Medians rather than means because the failure window produces
+extreme outliers that would drag a mean around without describing anything a
+user sees.
+"""
+import argparse, datetime, json, pathlib, sys
+import numpy as np, matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def is_nofault(d):
+    """KILL=0 writes 'none none' where the kill mode and targets would be.
+
+    Worth detecting rather than ignoring: on a smoke run the vertical marker is
+    not a fault and the x-axis is not measured from one, and a chart that says
+    SIGKILL when nothing was killed invites exactly the wrong reading.
+    """
+    try:
+        return open(pathlib.Path(d) / "harness/kill.txt").read().split()[2] == "none"
+    except Exception:
+        return False
+
+
+def load(d):
+    """Classify every record and anchor it to when the request STARTED.
+
+    Anchoring on request_end_ns puts a measurement in the wrong place. TTFT is
+    fixed within a second of the request being issued, so a request that started
+    64s before the kill and was cut off 1.6s after it has a TTFT measured well
+    before the fault -- plotting that point after the fault reads as though the
+    promoted engine served it. Start time is where the measurement belongs.
+
+    Three outcomes, not two:
+
+    completed  ran to its own end while one engine served it throughout.
+    truncated  in flight at the instant of the kill. aiperf records these as
+               successes because partial output exists, but they are wreckage:
+               on this run all twelve ended at the same timestamp with output
+               lengths proportional to how long each had been decoding -- 3,615
+               tokens for one running 64s, 217 for one running 2s. Counting them
+               as completions is what made a 47s outage look like 4.2s.
+    errored    no output at all; the frontend rejected the request outright.
+    """
+    d = pathlib.Path(d)
+    t0 = int(open(d / "harness/kill.txt").read().split()[0]) / 1e9
+    killed = open(d / "harness/kill.txt").read().split()[2] != "none"
+    sys.path.insert(0, str(pathlib.Path(__file__).parent))
+    from cutover import waking_window, parse_ts
+    resumed = None
+    if killed:
+        logs = sorted((d / "logs").glob("engine-*.log"))
+        ww = waking_window(logs)
+        if ww:
+            for f in logs:
+                if f.stem != ww[1]:
+                    continue
+                for line in open(f, errors="ignore"):
+                    if "failover_state" in line and "-> active" in line:
+                        ts = parse_ts(line)
+                        if ts:
+                            resumed = ts.replace(tzinfo=datetime.timezone.utc).timestamp() - t0
+    done, trunc, bad = [], [], []
+    for line in open(d / "aiperf/profile_export.jsonl"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            j = json.loads(line)
+        except Exception:
+            continue
+        md, mx = j.get("metadata", {}), j.get("metrics", {})
+        if md.get("benchmark_phase") != "profiling":
+            continue
+        st = md.get("request_start_ns", 0) / 1e9 - t0
+        en = md.get("request_end_ns", 0) / 1e9 - t0
+        if j.get("error") or not mx.get("output_sequence_length"):
+            bad.append(st)
+            continue
+        g = lambda k: (mx.get(k) or {}).get("value")
+        rec = {"t": st, "end": en, "ttft": g("time_to_first_token"),
+               "tpu": g("output_token_throughput_per_user"),
+               "itl": g("inter_token_latency"),
+               "osl": g("output_sequence_length")}
+        # Truncated means "ended before service resumed", not "straddled the
+        # kill". SIGKILL is not instantaneous: requests admitted in the moment
+        # after it get a fraction of a second from the dying engine and end with
+        # a handful of tokens, and a straddle test classifies those as clean
+        # completions.
+        # Bounded on BOTH sides. Without the en > 0 test this also swallows every
+        # normal completion from before the fault, because they too ended before
+        # service resumed -- which reported zero pre-fault completions on a run
+        # that had hundreds.
+        cut = killed and resumed is not None and 0 < en < resumed
+        (trunc if cut else done).append(rec)
+    return done, trunc, bad
+
+
+WINDOW_S = 30.0
+
+
+def windowed_stat(xs, ys, width=30.0, stat="median"):
+    """Median, not mean, over a 30s window.
+
+    Median because this distribution has a long, sparse tail that a mean would
+    chase: TTFT p50 is ~890ms against a p90 of 12s, and cold-prefill requests
+    after a promotion reach 56s. A handful of those drags a windowed mean far
+    above anything a typical request experienced, so the line stops describing
+    the workload and starts tracking its outliers.
+
+    30s rather than 5s because at 5s each point held only a few requests, so the
+    line jittered hard enough to obscure the trend it exists to show. Throughput
+    is still summed, not averaged -- for capacity questions the total is the
+    statistic, and no robustness argument applies.
+    """
+    if not xs:
+        return np.array([]), np.array([])
+    lo, hi = min(xs), max(xs)
+    edges = np.arange(lo, hi + width, width)
+    idx = np.digitize(xs, edges) - 1
+    ys = np.asarray(ys, dtype=float)
+    cx, cy = [], []
+    for i in range(len(edges) - 1):
+        m = idx == i
+        if m.sum() >= 3:
+            cx.append(edges[i] + width / 2)
+            cy.append(float(np.median(ys[m]) if stat == "median" else np.mean(ys[m])))
+    return np.asarray(cx), np.asarray(cy)
+
+
+def _break_gaps(cx, cy, width):
+    """Insert NaNs across gaps so the line does not interpolate over absent data."""
+    if not len(cx):
+        return cx, cy
+    cut = np.flatnonzero(np.diff(cx) > 4 * width)
+    cxb, cyb = cx.astype(float).copy(), cy.astype(float).copy()
+    for k in reversed(cut):
+        cxb = np.insert(cxb, k + 1, cxb[k] + width)
+        cyb = np.insert(cyb, k + 1, np.nan)
+    return cxb, cyb
+
+
+def panel(ax, ok, trunc, bad, key, ylabel, sla=None, log=False, first_fresh=None):
+    pts = [(r["t"], r[key]) for r in ok if r.get(key)]
+    if pts:
+        xs = [p[0] for p in pts]
+        ys = [p[1] for p in pts]
+        ax.scatter(xs, ys, s=6, alpha=.25, color="#1f77b4",
+                   label=f"completed ({len(pts)})", rasterized=True)
+        # Truncated requests are drawn, but separately and never in the median.
+        # They are real measurements of a request the fault destroyed, so hiding
+        # them loses information, while folding them into the median would let
+        # the wreckage of the old engine set the reported client experience.
+        tp = [(r["t"], r[key]) for r in trunc if r.get(key)]
+        if tp:
+            ax.scatter([q[0] for q in tp], [q[1] for q in tp], s=44, marker="x",
+                       color="#ff7f0e", linewidths=1.4, zorder=4,
+                       label=f"truncated by the fault ({len(tp)})")
+        # Median and mean together. Where they diverge, the window contains
+        # outliers the median is deliberately ignoring -- after a promotion the
+        # mean runs far above the median because a handful of cold-prefill
+        # requests take tens of seconds. Showing both makes that visible instead
+        # of asking the reader to trust one summary.
+        cx, cy = windowed_stat(xs, ys, WINDOW_S, "median")
+        if len(cx):
+            a, b = _break_gaps(cx, cy, WINDOW_S)
+            ax.plot(a, b, color="#d62728", lw=2, zorder=5,
+                    label=f"{WINDOW_S:.0f}s median")
+        mx_, my_ = windowed_stat(xs, ys, WINDOW_S, "mean")
+        if len(mx_):
+            a, b = _break_gaps(mx_, my_, WINDOW_S)
+            ax.plot(a, b, color="#9467bd", lw=1.6, ls="--", zorder=4,
+                    label=f"{WINDOW_S:.0f}s mean")
+
+    if bad:
+        lo, hi = min(bad), max(bad)
+        # Rejected requests have no latency to plot, so they are shown as rug
+        # ticks along the bottom -- present and countable without pretending to
+        # a y-value they never had.
+        # Pinned to the axis floor in axes coordinates. Reading get_ylim() here
+        # samples the limit before set_ylim() runs later in this function, which
+        # left the ticks floating mid-plot as if they carried a real value.
+        ax.scatter(bad, [0.012] * len(bad), marker="|", s=60, color="#d62728",
+                   alpha=.55, zorder=4, label=f"rejected ({len(bad)})",
+                   transform=ax.get_xaxis_transform())
+        ax.axvspan(lo, hi, color="#d62728", alpha=.12, zorder=0)
+        ax.annotate(f"rejecting {hi - lo:.1f}s", xy=((lo + hi) / 2, ax.get_ylim()[1]),
+                    xytext=(0, -12), textcoords="offset points",
+                    ha="center", va="top", fontsize=9, color="#a00")
+    # The rejection window is not the outage a user experiences, and showing only
+    # it is what made these charts look wrong: the band said 6.4s while the plot
+    # plainly had no completions for 47s. The engine starts accepting as soon as
+    # the promotion finishes, but it comes back with a cold prefix cache -- 29.9%
+    # against 84% before the fault -- so every session re-prefills its whole
+    # accumulated context before anything completes. Marking the first completion
+    # of a request issued after the kill shows that second, larger cost.
+    if first_fresh is not None:
+        ax.axvspan(0, first_fresh, color="#ff7f0e", alpha=.07, zorder=0)
+        ax.axvline(first_fresh, color="#ff7f0e", ls="-.", lw=1.6, zorder=2)
+        ax.annotate(f"first post-kill completion {first_fresh:.0f}s",
+                    xy=(first_fresh, ax.get_ylim()[1]), xytext=(6, -30),
+                    textcoords="offset points", fontsize=9, color="#b35900")
+    if sla:
+        ax.axhline(sla, color="gray", ls=":", alpha=.7, label=f"SLA {sla:g}")
+    ax.axvline(0, color="k", ls="--", lw=1.5)
+    ax.set_ylabel(ylabel)
+    if log:
+        ax.set_yscale("log")
+    else:
+        ax.set_ylim(bottom=0)
+    ax.grid(alpha=.3, which="both" if log else "major")
+    ax.legend(loc="upper left", fontsize=8)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("outdir"); ap.add_argument("bundle")
+    ap.add_argument("--name", default=None)
+    a = ap.parse_args()
+    out = pathlib.Path(a.outdir); out.mkdir(parents=True, exist_ok=True)
+    name = a.name or pathlib.Path(a.bundle).name
+    nofault = is_nofault(a.bundle)
+    sys.path.insert(0, str(pathlib.Path(__file__).parent))
+    from cutover import recovery as _recovery
+    _rc = None if nofault else _recovery(pathlib.Path(a.bundle))
+    first_fresh = _rc[0] if _rc else None
+    ok, trunc, bad = load(a.bundle)
+    if not ok:
+        print(f"{name}: no successful records"); return 1
+
+    fig, axes = plt.subplots(2, 1, figsize=(12, 7.5), sharex=True)
+    panel(axes[0], ok, trunc, bad, "ttft", "TTFT (ms)", log=True, first_fresh=first_fresh)
+    axes[0].set_title(f"{name} — client experience" + ("" if not nofault else " (control: no fault injected)"))
+    panel(axes[1], ok, trunc, bad, "tpu", "output tokens/s/user", sla=None, first_fresh=first_fresh)
+    axes[1].set_xlabel("seconds from T0, by request START time (no fault injected)" if nofault
+                       else "seconds from SIGKILL, by request START time")
+    fig.tight_layout(); fig.savefig(out / f"client-{name}.png", dpi=140); plt.close(fig)
+
+    pre = [r for r in ok if r["t"] < 0]
+    post = [r for r in ok if r["t"] > (max(bad) if bad else 0)]
+    def med(rs, k):
+        v = [r[k] for r in rs if r.get(k)]
+        return float(np.median(v)) if v else float("nan")
+    print(f"  {name}")
+    print(f"    completed before fault: {len(pre):>5}   after recovery: {len(post)}")
+    print(f"    TTFT   median  before {med(pre,'ttft'):7.1f} ms   after {med(post,'ttft'):7.1f} ms")
+    print(f"    tok/s/user     before {med(pre,'tpu'):7.1f}      after {med(post,'tpu'):7.1f}")
+    print(f"    ITL    median  before {med(pre,'itl'):7.2f} ms   after {med(post,'itl'):7.2f} ms")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/harness/check_tokenizer.sh
+++ b/bench/harness/check_tokenizer.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Verify the tokenizer aiperf will use agrees with the server's.
+#
+# aiperf uses its tokenizer for two things that both silently corrupt results if
+# it is wrong: generating synthetic prompts of a requested token length, and
+# counting tokens client-side. A tokenizer that merely *loads* proves nothing --
+# the wrong one loads perfectly well and reports plausible numbers that do not
+# describe what the engine actually received.
+#
+# The check: encode a string locally, send the identical string to the server,
+# and compare against the prompt_tokens the server reports from its own
+# tokenizer. Agreement means aiperf's counts describe reality.
+set -uo pipefail
+MODEL=${MODEL:?set MODEL}
+URL=${URL:?set URL}
+TOKENIZER=${TOKENIZER:?set TOKENIZER}
+
+# Ensure the transformers version here too, not just in aiperf_load.sh. Load
+# teardown recreates the bench pod, which wipes every pip install, so any step
+# that assumes a previously-installed version will fail the first time it runs
+# after a teardown -- which is every run.
+TRANSFORMERS_MIN=${TRANSFORMERS_MIN:-5.15.1}
+tv=$(python3 -c "import transformers;print(transformers.__version__)" 2>/dev/null)
+if [ "$tv" != "$TRANSFORMERS_MIN" ]; then
+  pip install -q --disable-pip-version-check --upgrade "transformers==$TRANSFORMERS_MIN" >/dev/null 2>&1
+  tv=$(python3 -c "import transformers;print(transformers.__version__)" 2>/dev/null)
+fi
+echo "  transformers: $tv"
+export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+
+python3 - "$MODEL" "$URL" "$TOKENIZER" <<'PY'
+import json, sys, urllib.request
+model, url, tok_id = sys.argv[1], sys.argv[2], sys.argv[3]
+from transformers import AutoTokenizer
+tok = AutoTokenizer.from_pretrained(tok_id)
+print(f"  tokenizer: {type(tok).__name__} from {tok_id}")
+
+cases = [
+    "the quick brown fox jumps over the lazy dog",
+    "Hello, world! 123",
+    " ".join(["token"] * 200),
+    "def f(x):\n    return x ** 2  # squared\n",
+]
+ok = True
+for s in cases:
+    local = len(tok.encode(s))
+    body = json.dumps({"model": model, "prompt": s, "max_tokens": 1,
+                       "temperature": 0, "stream": False}).encode()
+    req = urllib.request.Request(url.rstrip("/") + "/v1/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    try:
+        r = json.load(urllib.request.urlopen(req, timeout=120))
+        server = r.get("usage", {}).get("prompt_tokens")
+    except Exception as e:
+        print(f"  request failed: {type(e).__name__} {str(e)[:120]}")
+        ok = False
+        continue
+    mark = "OK  " if local == server else "MISMATCH"
+    if local != server:
+        ok = False
+    print(f"  {mark} local={local:<5} server={server:<5} {repr(s)[:46]}")
+
+print("  RESULT: tokenizers agree" if ok else
+      "  RESULT: *** TOKENIZERS DISAGREE — aiperf ISL/OSL would be wrong ***")
+sys.exit(0 if ok else 1)
+PY

--- a/bench/harness/collect_artifacts.sh
+++ b/bench/harness/collect_artifacts.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Collect every artifact of one failover run into a self-describing bundle.
+#
+# The rule this enforces: a run must be reconstructible from its bundle alone,
+# without the cluster still being in that state. Two things have already been
+# lost by not doing this. Plain `kubectl logs` returns the CURRENT container, so
+# for the engine we just killed it hands back the post-restart log and silently
+# drops the pre-kill scheduler lines -- the only evidence load was flowing.
+# And image tags are mutable, so a bundle that records a tag rather than a
+# digest cannot prove which build produced its numbers.
+#
+# Layout:
+#   cluster/   DGD, checkpoint CR, pod spec, events        (what was deployed)
+#   logs/      engine + gms + frontend, each with .previous (what it did)
+#   aiperf/    profile export, summary, run log            (what load was sent)
+#   harness/   kill, roles, gpu-mem, proc-tree, timings    (what we did to it)
+#   analysis/  derived timeline                            (what it means)
+set -uo pipefail
+
+NS=${NS:-schwinns-vcluster}
+HOST_KC=${HOST_KC:-$HOME/.kube/config}
+VC_KC=${VC_KC:-$HOME/.kube/vc-schwinns.yaml}
+DGD=${DGD:-glm52-vllm-fo-snapshot}
+WORKER_GREP=${WORKER_GREP:-$DGD-vllmdecodeworker}
+BENCH_POD_GREP=${BENCH_POD_GREP:-^bench-shell}
+AIPERF_REMOTE_DIR=${AIPERF_REMOTE_DIR:-}
+NODE=${NODE:-cluster-0967a26d-pool-14bee067-prctr-tx5tk}
+OUT=${OUT:?set OUT}
+
+kh() { kubectl --kubeconfig "$HOST_KC" "$@"; }
+kv() { kubectl --kubeconfig "$VC_KC" "$@"; }
+
+mkdir -p "$OUT"/{cluster,logs,aiperf,harness,analysis,metrics}
+
+W=$(kh get pods -n "$NS" --no-headers -o custom-columns=:metadata.name | grep "$WORKER_GREP" | head -1)
+FE=$(kh get pods -n "$NS" --no-headers -o custom-columns=:metadata.name | grep "$DGD-frontend" | head -1)
+AGENT=$(kh get pods -n "$NS" -o wide --no-headers | awk -v n="$NODE" '/forka/ && $7==n {print $1}' | head -1)
+BENCH=$(kh get pods -n "$NS" --no-headers -o custom-columns=:metadata.name | grep -E "$BENCH_POD_GREP" | head -1)
+
+# ---- cluster state -----------------------------------------------------------
+kv get dynamographdeployment "$DGD" -n "$NS" -o yaml > "$OUT/cluster/dgd.yaml" 2>/dev/null
+CK=$(kv get dynamographdeployment "$DGD" -n "$NS" \
+     -o jsonpath='{.status.checkpoints.VllmDecodeWorker.checkpointID}' 2>/dev/null)
+[ -n "$CK" ] && kv get dynamocheckpoint "checkpoint-$CK" -n "$NS" -o yaml > "$OUT/cluster/checkpoint.yaml" 2>/dev/null
+[ -n "$W" ] && kh get pod -n "$NS" "$W" -o yaml > "$OUT/cluster/worker-pod.yaml" 2>/dev/null
+kh get events -n "$NS" --sort-by=.lastTimestamp > "$OUT/cluster/events.txt" 2>/dev/null
+
+# Who else is on this node, and what the node thinks it has to give away.
+#
+# Namespace-scoped events cannot show a co-tenant, because a co-tenant is by
+# definition in someone else's namespace. That matters here: our pods hold these
+# GPUs through a DRA claim and request no nvidia.com/gpu at all, so if the
+# classic device plugin is still advertising them, every one of those GPUs looks
+# free to the scheduler while we are using them. A pod from any other team can
+# land on the same silicon and contend for SMs and NVLink without appearing
+# anywhere in the artifacts we were collecting.
+if [ -n "$NODE" ]; then
+    kh get pods -A -o wide --field-selector "spec.nodeName=$NODE" \
+        > "$OUT/cluster/node-pods.txt" 2>/dev/null
+    kh get node "$NODE" -o yaml > "$OUT/cluster/node.yaml" 2>/dev/null
+    # Anything actually holding device-plugin GPUs, as opposed to DRA.
+    kh get pods -A -o json --field-selector "spec.nodeName=$NODE" 2>/dev/null \
+      | python3 -c '
+import json,sys
+try: d=json.load(sys.stdin)
+except Exception: sys.exit(0)
+for p in d.get("items",[]):
+    for c in p["spec"]["containers"]:
+        r=c.get("resources",{})
+        n=(r.get("limits") or {}).get("nvidia.com/gpu") or (r.get("requests") or {}).get("nvidia.com/gpu")
+        if n: print(f"{p[\"metadata\"][\"namespace\"]}/{p[\"metadata\"][\"name\"]} {c[\"name\"]} nvidia.com/gpu={n} phase={p[\"status\"].get(\"phase\")}")
+' > "$OUT/cluster/node-device-plugin-holders.txt" 2>/dev/null
+fi
+
+# ---- logs, current AND previous ----------------------------------------------
+# --previous is not optional here: the engine we kill restarts, so its pre-kill
+# history exists nowhere else.
+if [ -n "$W" ]; then
+  # "main" is the baseline arm's only container (stock vLLM, no shadow); the
+  # engine-*/gms-server names exist only on the failover arm. Ask for all of
+  # them and drop whatever the pod does not have, so one collector serves both.
+  for c in engine-0 engine-1 gms-server main; do
+    kh logs -n "$NS" "$W" -c "$c" --tail=200000 > "$OUT/logs/$c.log" 2>/dev/null
+    kh logs -n "$NS" "$W" -c "$c" --previous --tail=200000 > "$OUT/logs/$c.previous.log" 2>/dev/null
+    [ -s "$OUT/logs/$c.log" ]          || rm -f "$OUT/logs/$c.log"
+    [ -s "$OUT/logs/$c.previous.log" ] || rm -f "$OUT/logs/$c.previous.log"
+  done
+fi
+[ -n "$FE" ] && kh logs -n "$NS" "$FE" --tail=100000 > "$OUT/logs/frontend.log" 2>/dev/null
+
+# Router decisions, one line per request, extracted from the frontend.
+#
+# DYN_ROUTER_MODE=kv means the router scores workers by prefix overlap, so after
+# a promotion it prefers the warm survivor over the cold shadow: measured 83/16
+# in the first minute after a kill, rebalancing to ~50/50 by two minutes. That
+# skew is part of what a failover costs and needs to be in the bundle rather
+# than reconstructed later from a live pod whose logs have since rotated.
+[ -n "$FE" ] && kh logs -n "$NS" "$FE" --tail=200000 2>/dev/null \
+    | sed 's/\x1b\[[0-9;]*m//g' | grep "scheduling::selector" \
+    > "$OUT/logs/router-decisions.log" 2>/dev/null
+[ -s "$OUT/logs/router-decisions.log" ] || rm -f "$OUT/logs/router-decisions.log"
+# The agent owns CRIU dump/restore; its log is where restore failures explain
+# themselves and where checkpoint timing summaries live.
+[ -n "$AGENT" ] && kh logs -n "$NS" "$AGENT" -c agent --tail=20000 > "$OUT/logs/snapshot-agent.log" 2>/dev/null
+
+# Failover metrics, scraped per engine.
+#
+# The LD_PRELOAD runtime does not carry our checkpoint_restore/wake_up timers,
+# but it exposes something better: a failover state machine whose
+# last_state_duration_seconds{state="waking"} is documented as the wake/switch
+# time. Scraping it makes cutover measurable on any runtime that publishes it,
+# and costs nothing on runtimes that do not -- the file is simply empty.
+#
+# Both engines are scraped because the one that matters is whichever was
+# promoted, and that is the opposite of whichever was active at the kill.
+for i in 0 1; do
+    port=$((9090 + i))
+    kh exec -n "$NS" "$W" -c "engine-$i" -- \
+        sh -c "curl -sS -m 8 localhost:$port/metrics 2>/dev/null | grep -E 'failover'" \
+        > "$OUT/metrics/engine-$i.prom" 2>/dev/null
+    [ -s "$OUT/metrics/engine-$i.prom" ] || rm -f "$OUT/metrics/engine-$i.prom"
+done
+
+# ---- aiperf artifacts --------------------------------------------------------
+if [ -n "$BENCH" ] && [ -n "$AIPERF_REMOTE_DIR" ]; then
+  # server_metrics_* are aiperf's scrape of the frontend /metrics endpoint --
+  # an independent view of what the server thought it was doing, useful when the
+  # client and engine disagree.
+  for f in profile_export.jsonl profile_export_aiperf.json profile_export_aiperf.csv \
+           server_metrics_export.json server_metrics_export.csv \
+           inputs.json gpu_telemetry_export.jsonl run.log; do
+    kh exec -n "$NS" "$BENCH" -c bench -- cat "$AIPERF_REMOTE_DIR/$f" > "$OUT/aiperf/$f" 2>/dev/null
+    [ -s "$OUT/aiperf/$f" ] || rm -f "$OUT/aiperf/$f"
+  done
+  kh exec -n "$NS" "$BENCH" -c bench -- sh -c "cat $AIPERF_REMOTE_DIR/logs/aiperf.log" \
+    > "$OUT/aiperf/aiperf.log" 2>/dev/null
+  [ -s "$OUT/aiperf/aiperf.log" ] || rm -f "$OUT/aiperf/aiperf.log"
+fi
+
+# ---- index -------------------------------------------------------------------
+{
+  echo "# Run bundle"
+  echo
+  echo "collected:  $(date -u -Iseconds)"
+  echo "dgd:        $DGD"
+  echo "checkpoint: ${CK:-<none>}"
+  echo "worker pod: ${W:-<none>}"
+  echo
+  echo "## Contents"
+  find "$OUT" -mindepth 2 -type f -printf '  %-52p %10s bytes\n' 2>/dev/null | sed "s|$OUT/||" | sort
+} > "$OUT/README.md"
+echo "bundle -> $OUT"
+du -sh "$OUT" 2>/dev/null | sed 's/^/  /'

--- a/bench/harness/cutover.py
+++ b/bench/harness/cutover.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Report promotion cutover for a run bundle, on either failover runtime.
+
+The two runtimes account for promotion differently and neither can be assumed
+present, so this reads whichever evidence a bundle actually has:
+
+  fork A  -- "[Shadow] checkpoint_restore took Xs" + "wake_up(...) took Ys",
+             emitted by instrumentation we added and compiled into that image.
+  LDP     -- the failover state machine: "failover_state engine=N -> waking"
+             through "-> active", plus a Prometheus gauge
+             failover_last_state_duration_seconds{state="waking"} that the
+             runtime documents as the wake/switch time.
+
+Client outage is computed for both and is the number to compare across
+runtimes, because it is measured entirely at the client and so cannot be
+skewed by either runtime's choice of what to instrument.
+"""
+import json, pathlib, re, sys, datetime
+
+TS = re.compile(r"(\d{4}-\d{2}-\d{2}T[\d:.]+)Z")
+
+
+def strip_ansi(s):
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+def parse_ts(line):
+    m = TS.search(strip_ansi(line))
+    if not m:
+        return None
+    t = m.group(1)
+    if "." in t:
+        head, frac = t.split(".")
+        t = head + "." + (frac + "000000")[:6]
+    return datetime.datetime.fromisoformat(t)
+
+
+def forka(logs):
+    r = w = None
+    for f in logs:
+        for line in open(f, errors="ignore"):
+            if "checkpoint_restore took" in line:
+                r = float(re.search(r"took ([\d.]+)s", line).group(1))
+            elif "wake_up(" in line and "took" in line:
+                w = float(re.search(r"took ([\d.]+)s", line).group(1))
+    return (r, w) if (r is not None or w is not None) else None
+
+
+def waking_window(logs):
+    """Wake window from the state machine: -> waking through -> active.
+
+    Both runtimes emit this, so it is the one number directly comparable across
+    them -- and on fork A it is verifiably the whole promotion: the window
+    contains checkpoint_restore plus wake_up with ~0.3s to spare.
+
+    Every engine's log is scanned and the LAST completed window wins. Taking the
+    first match reads the standby's own start-up promotion from earlier in the
+    pod's life rather than the promotion this run triggered, which understated a
+    37.2s cutover as 8.1s.
+    """
+    best = None
+    for f in logs:
+        start = None
+        for line in open(f, errors="ignore"):
+            if "failover_state" not in line:
+                continue
+            if "-> waking" in line:
+                start = parse_ts(line)
+            elif "-> active" in line and start:
+                end = parse_ts(line)
+                if end and (best is None or end > best[1]):
+                    best = (start, end, f.stem)
+                start = None
+    if not best:
+        return None
+    return (best[1] - best[0]).total_seconds(), best[2]
+
+
+def metric_waking(bundle):
+    out = {}
+    for f in sorted((bundle / "metrics").glob("engine-*.prom")):
+        for line in open(f, errors="ignore"):
+            if "last_state_duration_seconds" in line and 'state="waking"' in line:
+                out[f.stem] = float(line.rsplit(None, 1)[1])
+    return out
+
+
+def outage(bundle):
+    """Longest gap between consecutive successful completions.
+
+    This is wider than the window in which requests were failing, because after
+    the engine is back the queued prefills still have to run before anything
+    completes. Both are real; this one is quoted because it is what a client
+    actually experiences and needs no server-side signal at all.
+    """
+    p = bundle / "aiperf/profile_export.jsonl"
+    if not p.exists():
+        return None
+    ends = []
+    for line in open(p, errors="ignore"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            j = json.loads(line)
+        except Exception:
+            continue
+        if j.get("metrics", {}).get("output_sequence_length"):
+            ends.append(j["metadata"]["request_end_ns"] / 1e9)
+    if len(ends) < 2:
+        return None
+    ends.sort()
+    return max(b - a for a, b in zip(ends, ends[1:]))
+
+
+
+def kill_anchored(bundle):
+    """Client outage measured from the kill: last completion before, first after.
+
+    This is the number to quote, not the largest gap anywhere in the run. The
+    largest gap can sit somewhere unrelated -- a ramp, a slow tail -- and on
+    sparse runs it is pure noise.
+
+    It also needs a completion count beside it. Some early fork A runs used
+    OSL=20000 and finished only 64 requests in the whole run, exactly one per
+    lane, so every completion landed in one burst and the gap between them read
+    as 0.0s while the engine had in fact been away for thirteen seconds. A run
+    with fewer completions than about twice the concurrency cannot measure this
+    at all, and saying so is better than reporting the artefact.
+    """
+    p = bundle / "aiperf/profile_export.jsonl"
+    kf = bundle / "harness/kill.txt"
+    if not p.exists() or not kf.exists():
+        return None
+    try:
+        kill = int(open(kf).read().split()[0]) / 1e9
+    except Exception:
+        return None
+    ends = []
+    for line in open(p, errors="ignore"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            j = json.loads(line)
+        except Exception:
+            continue
+        if j.get("metrics", {}).get("output_sequence_length"):
+            ends.append(j["metadata"]["request_end_ns"] / 1e9)
+    if len(ends) < 2:
+        return None
+    before = [t for t in ends if t < kill]
+    after = [t for t in ends if t >= kill]
+    if not before or not after:
+        return None
+    return (min(after) - max(before), len(ends))
+
+
+def recovery(bundle):
+    """Time from the kill to the first completion of a request issued after it.
+
+    The obvious measure -- first completion after the kill -- is wrong here, and
+    wrong in a flattering direction. Killing the engine terminates every stream
+    in flight, and aiperf records those as successes because partial output
+    exists: on the 200k trace, twelve requests all "completed" at the same
+    instant 1.6s after the kill, with output lengths of 217 to 635 tokens against
+    a trace median of 786. Measuring to those reports a 4.2s outage for a
+    failover whose first real completion came at 47.6s.
+
+    Restricting to requests that STARTED after the kill removes the artefact and
+    measures what a user actually waits for. That number includes far more than
+    the promotion: the promoted engine restores weights but not KV, so its prefix
+    cache starts cold -- 29.9% against 84% before the fault -- and every session
+    must re-prefill its whole accumulated context before anything can complete.
+    """
+    p = bundle / "aiperf/profile_export.jsonl"
+    kf = bundle / "harness/kill.txt"
+    if not p.exists() or not kf.exists():
+        return None
+    try:
+        kill = int(open(kf).read().split()[0]) / 1e9
+    except Exception:
+        return None
+    # Service resumes when the promoted engine reaches "active"; anything that
+    # ended before that was cut off, whenever it started.
+    #
+    # An earlier rule -- started before the kill, ended after it -- missed
+    # requests issued in the moment between SIGKILL and the engine actually
+    # dying. On the c=24 run two such requests were admitted 0.28s and 1.07s
+    # after the kill, served for a fraction of a second by the dying engine, and
+    # ended at 1.80s with 31 and 70 output tokens against a trace median of 786.
+    # Counting those as recovery reported the first post-kill completion at 1.8s
+    # for a failover whose promotion alone took 25.9s.
+    resumed = None
+    logs = sorted((bundle / "logs").glob("engine-*.log"))
+    ww = waking_window(logs)
+    if ww:
+        for f in logs:
+            if f.stem != ww[1]:
+                continue
+            for line in open(f, errors="ignore"):
+                if "failover_state" in line and "-> active" in line:
+                    ts = parse_ts(line)
+                    if ts:
+                        resumed = ts.replace(tzinfo=datetime.timezone.utc).timestamp() - kill
+    fresh = []
+    for line in open(p, errors="ignore"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            j = json.loads(line)
+        except Exception:
+            continue
+        if not j.get("metrics", {}).get("output_sequence_length"):
+            continue
+        m = j["metadata"]
+        end = m["request_end_ns"] / 1e9 - kill
+        if m["request_start_ns"] / 1e9 <= kill:
+            continue
+        if resumed is not None and end < resumed:
+            continue          # truncated by the fault, not a recovery completion
+        fresh.append(end)
+    if not fresh:
+        return None
+    return (min(fresh), len(fresh))
+
+def main():
+    for arg in sys.argv[1:]:
+        b = pathlib.Path(arg)
+        logs = sorted((b / "logs").glob("engine-*.log"))
+        print(f"\n{b.name}")
+        fa = forka(logs)
+        if fa:
+            r, w = fa
+            tot = sum(x for x in fa if x is not None)
+            print(f"  fork A     checkpoint_restore={r}s  wake_up={w}s  total={tot:.3f}s")
+        ww = waking_window(logs)
+        if ww is not None:
+            print(f"  both       waking->active ({ww[1]})  = {ww[0]:.3f}s")
+        for k, v in metric_waking(b).items():
+            print(f"  LDP        waking ({k}, metric)     = {v:.3f}s")
+        ko = kill_anchored(b)
+        if ko:
+            print(f"  client     outage from kill          = {ko[0]:.1f}s  ({ko[1]} completions)")
+        else:
+            print("  client     outage from kill          = n/a (too few completions)")
+        rc = recovery(b)
+        if rc:
+            print(f"  client     first POST-KILL completion = {rc[0]:.1f}s  ({rc[1]} such requests)")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/harness/measure_replenish.py
+++ b/bench/harness/measure_replenish.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Windowed serving metrics around failover and during shadow replenishment.
+
+Reads a snaptrack-style run bundle and prints:
+
+  promotion_s     last failover_state waking->active window after the kill
+  replenish_s     kill until the killed engine is standby again (RO import + graphs)
+  pre / during-replenish / post   TTFT p50, ITL p50, output tok/s
+
+The replenishment window is the one that answers "how much contention does
+bringing the shadow back impose on the survivor". It starts when the promoted
+engine is active and ends when the restarted engine logs
+``failover_state engine=N -> standby``.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import pathlib
+import statistics
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+from cutover import parse_ts, waking_window  # noqa: E402
+
+
+def _ts(line):
+    t = parse_ts(line)
+    if t is None:
+        return None
+    return t.replace(tzinfo=datetime.timezone.utc).timestamp()
+
+
+def kill_unix(bundle: pathlib.Path) -> float:
+    return int(open(bundle / "harness/kill.txt").read().split()[0]) / 1e9
+
+
+def replenish_end(logs, t0: float, killed_engine: str | None) -> float | None:
+    """Last '-> standby' after t0, preferring the killed engine's log."""
+    best = None
+    for f in logs:
+        for line in open(f, errors="ignore"):
+            if "failover_state" not in line or "-> standby" not in line:
+                continue
+            ts = _ts(line)
+            if ts is None or ts < t0:
+                continue
+            if best is None or ts > best[0]:
+                best = (ts, f.stem)
+    if best is None:
+        return None
+    return best[0]
+
+
+def load_records(bundle: pathlib.Path):
+    rows = []
+    p = bundle / "aiperf/profile_export.jsonl"
+    if not p.exists():
+        return rows
+    for line in open(p, errors="ignore"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            j = json.loads(line)
+        except Exception:
+            continue
+        md, mx = j.get("metadata", {}), j.get("metrics", {})
+        start = md.get("request_start_ns") or md.get("start_ns")
+        if start is None:
+            continue
+        start_s = start / 1e9 if start > 1e12 else start
+        err = bool(j.get("error") or mx.get("error_request_count"))
+        ttft = mx.get("time_to_first_token_ns") or mx.get("ttft_ns")
+        itl = mx.get("inter_token_latency_ns") or mx.get("itl_ns")
+        out = mx.get("output_token_count") or mx.get("output_tokens") or 0
+        end = md.get("request_end_ns") or md.get("end_ns")
+        end_s = (end / 1e9 if end and end > 1e12 else end) if end else None
+        rows.append(
+            {
+                "start": start_s,
+                "end": end_s,
+                "err": err,
+                "ttft_ms": (ttft / 1e6) if ttft else None,
+                "itl_ms": (itl / 1e6) if itl else None,
+                "out": out,
+            }
+        )
+    return rows
+
+
+def window_stats(rows, lo: float, hi: float) -> dict:
+    sel = [r for r in rows if lo <= r["start"] < hi]
+    ok = [r for r in sel if not r["err"]]
+    ttfts = [r["ttft_ms"] for r in ok if r["ttft_ms"] is not None]
+    itls = [r["itl_ms"] for r in ok if r["itl_ms"] is not None]
+    toks = sum(r["out"] for r in ok)
+    span = max(hi - lo, 1e-6)
+    return {
+        "n": len(sel),
+        "ok": len(ok),
+        "err": len(sel) - len(ok),
+        "ttft_p50_ms": statistics.median(ttfts) if ttfts else None,
+        "itl_p50_ms": statistics.median(itls) if itls else None,
+        "output_tok_s": toks / span,
+    }
+
+
+def fmt(stats: dict) -> str:
+    def n(x, d=1):
+        return "n/a" if x is None else f"{x:.{d}f}"
+
+    return (
+        f"n={stats['n']} ok={stats['ok']} err={stats['err']}  "
+        f"TTFT_p50={n(stats['ttft_p50_ms'])}ms  "
+        f"ITL_p50={n(stats['itl_p50_ms'], 2)}ms  "
+        f"out={n(stats['output_tok_s'])} tok/s"
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("bundle")
+    args = ap.parse_args()
+    bundle = pathlib.Path(args.bundle)
+    t0 = kill_unix(bundle)
+    logs = sorted((bundle / "logs").glob("engine-*.log"))
+    ww = waking_window(logs)
+    promo = ww[0] if ww else None
+    # Approximate promoted-active time as kill + promotion.
+    active_at = t0 + promo if promo is not None else t0
+    repl = replenish_end(logs, t0, None)
+    rows = load_records(bundle)
+    if not rows:
+        print("no aiperf records")
+        sys.exit(1)
+
+    pre_lo, pre_hi = t0 - 300, t0
+    promo_hi = active_at
+    repl_hi = repl if repl is not None else active_at + 300
+    post_lo, post_hi = repl_hi, repl_hi + 300
+
+    print(f"kill_unix={t0:.3f}")
+    print(f"promotion_s={promo if promo is not None else 'n/a'}")
+    print(
+        f"replenish_end_s_after_kill="
+        f"{(repl - t0) if repl is not None else 'n/a'}"
+    )
+    print(f"pre-fault          {fmt(window_stats(rows, pre_lo, pre_hi))}")
+    print(f"promotion window   {fmt(window_stats(rows, t0, promo_hi))}")
+    print(f"replenishment      {fmt(window_stats(rows, active_at, repl_hi))}")
+    print(f"post-replenish     {fmt(window_stats(rows, post_lo, post_hi))}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/harness/run_failover.sh
+++ b/bench/harness/run_failover.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# GMS V0 shadow-failover experiment. Same measurement shape as dynamo-snaptrack:
+# open-loop synthetic load, SIGKILL the active engine, collect a bundle, then
+# cutover.py / measure_replenish.py for promotion time and replenishment contention.
+set -uo pipefail
+
+NS=${NS:-schwinns-vcluster}
+HOST_KC=${HOST_KC:-$HOME/.kube/config}
+VC_KC=${VC_KC:-$HOME/.kube/vc-schwinns.yaml}
+DGD=${DGD:-dsv4pro-vllm-gmsv0-fo}
+FRONTEND_DGD=${FRONTEND_DGD:-$DGD}
+MODEL=${MODEL:-nvidia/DeepSeek-V4-Pro-NVFP4}
+TOKENIZER=${TOKENIZER:-nvidia/DeepSeek-V4-Pro-NVFP4}
+RUN_ID=${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}
+OUT=${OUT:-bench/runs/$RUN_ID}
+
+LOAD=${LOAD:-1}
+CONCURRENCY=${CONCURRENCY:-2048}
+ISL=${ISL:-32000}
+OSL=${OSL:-1000}
+REQUEST_RATE=${REQUEST_RATE:-0.7}
+RATE_MODE=${RATE_MODE:-poisson}
+LOAD_DURATION=${LOAD_DURATION:-1200}
+SOAK_S=${SOAK_S:-450}
+MIN_RUNNING=${MIN_RUNNING:-4}
+WATCH_S=${WATCH_S:-600}
+BASELINE=${BASELINE:-0}
+
+kh() { kubectl --kubeconfig "$HOST_KC" "$@"; }
+kv() { kubectl --kubeconfig "$VC_KC" "$@"; }
+log() { echo "[$(date -u +%H:%M:%S)] $*"; }
+
+ensure_vc() {
+  if [ -f "$VC_KC" ]; then
+    return 0
+  fi
+  log "writing vcluster kubeconfig to $VC_KC"
+  vcluster connect schwinns-vcluster -n schwinns-vcluster --print > "$VC_KC"
+}
+
+ensure_vc
+mkdir -p "$OUT"/{harness,aiperf,analysis,logs}
+
+WORKER_GREP="$DGD-vllmdecodeworker"
+W=$(kh get pods -n "$NS" --no-headers -o custom-columns=:metadata.name | grep "$WORKER_GREP" | grep -v Terminating | head -1)
+WVC=$(kv get pods -n "$NS" --no-headers -o custom-columns=:metadata.name | grep "$WORKER_GREP" | head -1)
+BENCH=$(kh get pods -n "$NS" --no-headers -o custom-columns=:metadata.name | grep '^bench-shell' | head -1)
+[ -n "$W" ] || { echo "worker pod not found for $WORKER_GREP"; exit 1; }
+WNODE=$(kh get pod -n "$NS" "$W" -o jsonpath='{.spec.nodeName}')
+log "worker=$W node=$WNODE bench=${BENCH:-none}"
+
+ACTIVE=""; STANDBY=""
+if [ "$BASELINE" = 1 ]; then
+  ACTIVE=main; STANDBY=main
+  log "BASELINE=1 — no shadow: active=standby=main"
+else
+  for c in engine-0 engine-1; do
+    last=$(kh logs -n "$NS" "$W" -c "$c" --tail=20000 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' \
+           | grep -aoE 'failover_state engine=[01] -> [a-z]+' | tail -1)
+    case "$last" in *active) ACTIVE=$c;; *standby) STANDBY=$c;; esac
+  done
+  [ -z "$ACTIVE" ] && [ -n "$STANDBY" ] && ACTIVE=$([ "$STANDBY" = engine-0 ] && echo engine-1 || echo engine-0)
+  [ -z "$STANDBY" ] && [ -n "$ACTIVE" ] && STANDBY=$([ "$ACTIVE" = engine-0 ] && echo engine-1 || echo engine-0)
+fi
+[ -n "$ACTIVE" ] && [ -n "$STANDBY" ] || { echo "could not resolve roles"; exit 1; }
+log "active=$ACTIVE standby=$STANDBY"
+printf 'active=%s\nstandby=%s\n' "$ACTIVE" "$STANDBY" > "$OUT/harness/roles.txt"
+
+read_running() {
+  kh logs -n "$NS" "$W" -c "$ACTIVE" --tail=800 2>/dev/null \
+    | grep -ao "Running: [0-9]* reqs" | tail -1 | grep -oE '[0-9]+'
+}
+
+AIPERF_REMOTE="/artifacts/runs/$(basename "$OUT")"
+if [ "$LOAD" = 1 ]; then
+  [ -n "$BENCH" ] || { echo "no bench-shell to drive load"; exit 1; }
+  for _ in $(seq 1 60); do
+    [ "$(kh get pod -n "$NS" "$BENCH" -o jsonpath='{.status.containerStatuses[?(@.name=="bench")].ready}' 2>/dev/null)" = "true" ] && break
+    sleep 2
+  done
+  ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+  for f in aiperf_load.sh check_tokenizer.sh; do
+    kh cp "$ROOT/bench/harness/$f" "$NS/$BENCH:/tmp/$f" -c bench >/dev/null 2>&1
+  done
+  URL_CHK="http://$FRONTEND_DGD-frontend.$NS.svc.cluster.local:8000"
+  if ! kh exec -n "$NS" "$BENCH" -c bench -- bash -c \
+        "MODEL='$MODEL' TOKENIZER='$TOKENIZER' URL='$URL_CHK' bash /tmp/check_tokenizer.sh" \
+        > "$OUT/harness/tokenizer_check.txt" 2>&1; then
+    log "!! tokenizer disagrees with the server — refusing to run"
+    sed 's/^/    /' "$OUT/harness/tokenizer_check.txt" | tail -8
+    exit 1
+  fi
+  URL="$URL_CHK"
+  log "starting aiperf: rate=$REQUEST_RATE/s isl=$ISL osl=$OSL dur=${LOAD_DURATION}s"
+  kh exec -n "$NS" "$BENCH" -c bench -- bash -c "
+    mkdir -p $AIPERF_REMOTE
+    MODEL='$MODEL' URL='$URL' TOKENIZER='$TOKENIZER' ARTIFACT_DIR='$AIPERF_REMOTE' \
+    CONCURRENCY=$CONCURRENCY ISL=$ISL OSL=$OSL DURATION=$LOAD_DURATION \
+    REQUEST_RATE='$REQUEST_RATE' RATE_MODE='$RATE_MODE' \
+      nohup bash /tmp/aiperf_load.sh > $AIPERF_REMOTE/run.log 2>&1 &
+    echo started" >/dev/null
+  log "waiting for Running >= $MIN_RUNNING"
+  ok=0
+  for i in $(seq 1 90); do
+    r=$(read_running)
+    [ -n "$r" ] && log "  Running=$r"
+    [ -n "$r" ] && [ "$r" -ge "$MIN_RUNNING" ] && { ok=1; echo "$r" > "$OUT/harness/running_gate.txt"; break; }
+    sleep 5
+  done
+  [ "$ok" = 1 ] || { log "!! never reached Running>=$MIN_RUNNING"; exit 1; }
+  if [ "${SOAK_S:-0}" -gt 0 ]; then
+    log "soaking ${SOAK_S}s before kill"
+    sleep "$SOAK_S"
+  fi
+fi
+
+rk=$(read_running)
+echo "${rk:-UNVERIFIED}" > "$OUT/harness/running_at_kill.txt"
+log "verified Running=${rk:-UNVERIFIED} immediately before kill"
+
+T0=$(date -u +%s%N)
+if [ "${KILL:-1}" = 1 ]; then
+  kh exec -n "$NS" "$W" -c "$ACTIVE" -- bash -c "pkill -9 -f 'dynamo.vllm|VLLM::' || kill -9 1" >/dev/null 2>&1 || true
+  log "SIGKILL $ACTIVE"
+  echo "$T0 $ACTIVE pkill dynamo.vllm" > "$OUT/harness/kill.txt"
+else
+  log "KILL=0"
+  echo "$T0 $ACTIVE none none" > "$OUT/harness/kill.txt"
+fi
+
+log "watching ${WATCH_S}s"
+sleep "$WATCH_S"
+
+if [ "$LOAD" = 1 ] && [ -n "$BENCH" ]; then
+  waitmax=$(( (LOAD_DURATION + 300) / 5 ))
+  log "waiting for aiperf summary (up to $((waitmax*5))s)"
+  for i in $(seq 1 "$waitmax"); do
+    if kh exec -n "$NS" "$BENCH" -c bench -- \
+         test -f "$AIPERF_REMOTE/profile_export_aiperf.json" 2>/dev/null; then
+      log "  aiperf summary written after ~$((i*5))s"; break
+    fi
+    sleep 5
+  done
+fi
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+OUT="$OUT" DGD="$DGD" NODE="$WNODE" AIPERF_REMOTE_DIR="$AIPERF_REMOTE" \
+  bash "$ROOT/bench/harness/collect_artifacts.sh" >/dev/null 2>&1 || true
+log "bundle at $OUT"
+python3 "$ROOT/bench/harness/cutover.py" "$OUT" || true
+python3 "$ROOT/bench/harness/measure_replenish.py" "$OUT" || true

--- a/bench/harness/run_restart.sh
+++ b/bench/harness/run_restart.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Restart timing: kill the engine process, wait for Ready, dump [dyn-phase] lines.
+# Use on gms-only and no-gms DGDs after caches are warm.
+set -euo pipefail
+NS=${NS:-schwinns-vcluster}
+HOST_KC=${HOST_KC:-$HOME/.kube/config}
+DGD=${DGD:?set DGD}
+CONTAINER=${CONTAINER:-main}
+OUT=${OUT:-bench/runs/restart-$(date -u +%Y%m%dT%H%M%SZ)}
+kh() { kubectl --kubeconfig "$HOST_KC" "$@"; }
+
+W=$(kh get pods -n "$NS" --no-headers -o custom-columns=:metadata.name \
+      | grep "$DGD-vllmdecodeworker" | grep -v Terminating | head -1)
+[ -n "$W" ] || { echo "worker not found"; exit 1; }
+mkdir -p "$OUT"
+echo "worker=$W container=$CONTAINER" | tee "$OUT/meta.txt"
+kh logs -n "$NS" "$W" -c "$CONTAINER" --tail=5000 2>/dev/null \
+  | grep -E '\[dyn-phase\]|VllmWorker .* has been initialized|graph capturing' \
+  > "$OUT/phases-before.txt" || true
+T0=$(date -u +%s%N)
+echo "$T0" > "$OUT/kill.txt"
+kh exec -n "$NS" "$W" -c "$CONTAINER" -- bash -c "pkill -9 -f 'dynamo.vllm|VLLM::' || kill -9 1" \
+  >/dev/null 2>&1 || true
+echo "killed $CONTAINER at $T0; waiting for Ready"
+for i in $(seq 1 600); do
+  ready=$(kh get pod -n "$NS" "$W" --no-headers | awk '{print $2}')
+  [ "${ready%%/*}" = "${ready##*/}" ] && [ "${ready%%/*}" != "0" ] && break
+  sleep 5
+done
+T1=$(date -u +%s%N)
+echo "$T1" > "$OUT/ready.txt"
+python3 - <<PY
+t0=int(open("$OUT/kill.txt").read())/1e9
+t1=int(open("$OUT/ready.txt").read())/1e9
+print(f"wall_ready_s={t1-t0:.1f}")
+PY
+kh logs -n "$NS" "$W" -c "$CONTAINER" --tail=8000 2>/dev/null \
+  | grep -E '\[dyn-phase\]|VllmWorker .* has been initialized|graph capturing|Read mode: imported|Write mode:' \
+  > "$OUT/phases-after.txt" || true
+echo "wrote $OUT"

--- a/bench/results/GLM52-V0-PREFILL-ROOT-CAUSE.md
+++ b/bench/results/GLM52-V0-PREFILL-ROOT-CAUSE.md
@@ -1,0 +1,102 @@
+# GLM-5.2 GMS V0 vs V1 — prefill gap investigation
+
+Working notes. **Supersedes the "MLA scales are the root cause" claim.**
+
+## Retraction
+
+An earlier conclusion held that the ~4x prefill gap was caused by GMS V0
+skipping MLA `process_weights_after_loading` and zero-filling 312
+`q_scale`/`k_scale`/`v_scale`/`prob_scale` tensors that the FP8 attention
+kernel then consumed. **That is wrong.** Three checks kill it:
+
+1. **The checkpoint contains no attention scales.** `model.safetensors.index.json`
+   has 232,385 tensors and **0** ending in `q_scale`/`k_scale`/`v_scale`/`prob_scale`.
+2. **Both paths land on 1.0.** On the reference path the staging params keep the
+   `-1.0` sentinel, so `process_weights_after_loading` takes the "no scales
+   loaded" branch and sets `k=v=1.0`
+   (`vllm/model_executor/layers/quantization/kv_cache.py:111-116`). On the RO
+   path the function is skipped, and the buffers the kernel actually reads
+   (`_q_scale`, `_k_scale`, `_prob_scale`) were already created at 1.0
+   (`layers/attention/attention.py:129-135`). The 312 zeroed tensors are
+   **staging parameters the reference path reads and then deletes** — not what
+   the kernel consumes.
+3. **No scale-dependent kernel dispatch exists** on this backend. Scales fold
+   into the scalar args `bmm1_scale`/`bmm2_scale`
+   (`mla/flashinfer_mla_sparse.py:420-427`). A wrong scale is a numerics bug,
+   not a speed bug.
+
+The zero-fill is still a real **correctness** defect (it is why output is
+garbage) but it is **not** the performance defect.
+
+## Ruled out by measurement, not argument
+
+| Hypothesis | How it died |
+|---|---|
+| GMS VMM memory slower than `cudaMalloc` | Microbenchmark in the engine container, same 576 B random-row gather as the paged-KV read: ordinary **1050.1 GB/s** vs VMM **1050.2 GB/s**; stream 6871 vs 6876 GB/s. Ratio **1.000**. |
+| VMM fragmentation / TLB pressure | KV is **99 handles of ~830 MiB**, not thousands of 2 MiB fragments. 2 MiB is the *alignment*, not the handle size. |
+| Sparse-attention misroute is V0-specific | Dispatch gates (`sparse_mla_attention.py:46-67`, `mla_attention.py:790-794`) are a pure function of model config + kv-cache dtype + vLLM version. Identical in both arms. |
+| A dispatch cliff at `index_topk`=2048 | Measured TTFT from 540 to 32,400 tokens: per-token cost is **flat** (139 -> 178 us/token over a 27x length range). No cliff; the MQA path is always on, for both arms. |
+| Different vLLM version / commit | Current V0 pod and the V1 reference both run image `7f9681b0`. |
+| `CompilationMode.NONE` | `VLLM_USE_BREAKABLE_CUDAGRAPH=1` is set identically in the V0 DGD, V1 failover DGD, **and** the V1 dump DGD. |
+| Prefix caching advantage for V1 | Both arms logged 0.0% hit rate for the entire run. |
+| Workload difference | Both: ISL 32000, OSL ~1000, ~1250 s; gen/prompt token ratio 0.030 vs 0.027. |
+
+## The actual finding
+
+Scheduler windows where prefill and decode ran **in the same step**:
+
+| Arm | windows | prefill+decode together | prefill-only |
+|---|---:|---:|---:|
+| **V1** | 118 | **113** | 4 |
+| **V0** | 115 | **4** | 103 |
+
+Restricted to comparable steady state (prompt >1000 tok/s and Running >=10):
+
+| Arm | n | gen tok/s median | frac with gen >50 | per-running-req decode |
+|---|---:|---:|---:|---:|
+| **V1** | 115 | 510.0 | **0.99** | **10.25 tok/s** |
+| **V0** | 102 | 37.1 | **0.04** | **0.69 tok/s** |
+
+V0 is not losing per-kernel speed — it has **stopped co-scheduling decode with
+chunked prefill**. Nearly every V0 step is consumed entirely by prefill, so
+decode starves and the queue grows without bound (Waiting median 276, max 532,
+vs V1's 22/73). This one mechanism explains both the ~3.7x prefill throughput
+gap and the 6-18x ITL gap, with no GMS-specific kernel defect required.
+
+### Live reproduction (same commit as V1)
+
+24 concurrent pure-prefill requests against the current V0 engine:
+
+```
+prompt throughput: 4801.7 tok/s, gen: 2.2, Running: 4, Waiting: 27, KV 4.1%
+prompt throughput: 7236.7 tok/s, gen: 1.9, Running: 4, Waiting: 28, KV 4.6%
+```
+
+Mean ~6,115 tok/s vs V1's 22,398 median = **3.66x**. `Running` is pinned at 3-4
+with **28 requests queued and KV at 4%** — neither KV-limited nor
+demand-limited. Per-step arithmetic is consistent: 8192 / 6115 = 1340 ms/step,
+matching the profiled 1349 ms of self CUDA time for one 8192-token step.
+
+### Single-stream sanity check
+
+At batch 1 on an idle V0 engine, decode is **10.8 ms/token** (400 tokens in
+4.31 s) — healthy. V0 collapses only under load: a scheduling/batching
+signature, not a weight-path or memory signature.
+
+## Caveats
+
+- V1's scheduler config could not be read directly (CRIU-restored engines emit
+  no init lines). It is inferred from the shared dump DGD. Neither arm passes
+  `--max-num-batched-tokens`, so both inherit the vLLM default of 8192.
+- The V0 arm carries a `PYTHONPATH=/vllm-cache/py` `sitecustomize.py` overlay
+  that V1 never loads. **This is an uncontrolled variable** and should be
+  removed before quoting any further V0-vs-V1 number.
+- Why V0 fails to co-schedule decode is **not yet root-caused**. Next step is to
+  instrument the scheduler decision (Waiting non-zero while Running stays at
+  3-4), not to profile kernels again.
+
+## Method note
+
+Every hypothesis above that was killed by measurement had first been argued for
+on plausible mechanism. The profile, the roofline, and the microbenchmark each
+overturned a conclusion reached by reasoning alone. Measure first.

--- a/bench/results/GLM52-V0-ROOT-CAUSE-ALIASING.md
+++ b/bench/results/GLM52-V0-ROOT-CAUSE-ALIASING.md
@@ -1,0 +1,102 @@
+# GMS V0 vs V1 on GLM-5.2-NVFP4 — root cause
+
+## Head-to-head, measured
+
+Same model, same image `7f9681b0`, identical B200 hardware at identical
+clocks, both engines idle, identical random prompts, prefix cache 0%.
+
+| ~prompt tokens | V0 TTFT | V1 TTFT | V0/V1 |
+|---:|---:|---:|---:|
+| 1,215 | 0.169 s | 0.114 s | 1.48x |
+| 4,050 | 0.573 s | 0.176 s | 3.26x |
+| 8,100 | 1.301 s | 0.433 s | 3.00x |
+| 16,200 | 2.704 s | 0.756 s | 3.58x |
+| 32,400 | **5.753 s** | **1.440 s** | **3.99x** |
+
+Output quality, same prompt "The capital of France is":
+
+| arm | text | top logprob |
+|---|---|---|
+| V1 | `' Paris. Distance from Paris to Lyon is...'` | -0.81 |
+| V0 | `'importimportimport...'` | -3.43 |
+
+V0's pos1 and pos2 distributions are **bitwise identical** — appending a
+token changed nothing, i.e. attention output does not depend on context.
+
+## Root cause: GMS keys by name, vLLM shares storage
+
+Measured directly from the live committed GMS layout (`DYN_GMS_ALIAS_REPORT=1`):
+
+```
+4209 published keys -> 2549 distinct (allocation_id, offset)
+929 locations shared;  2589 of 4209 names are aliases
+```
+
+Concrete groups:
+
+| shared location | keys | meaning |
+|---|---:|---|
+| `cos_sin_cache` | 198 | one rotary cache referenced by every layer |
+| `topk_indices_buffer` | 147 | **DSA indexer -> attention channel** |
+| `kv_b_proj.weight` ≡ `W_UK_T` | 4/layer | `W_UK_T`/`W_UV` are views into `kv_b_proj` |
+
+`W_UK_T` sits at the *same address* as `kv_b_proj.weight` (e.g. layer 10,
+`alloc=90f022f1 off=16252928`) because
+`MLAAttention.process_weights_after_loading` uses
+`replace_parameter(..., prefer_copy=True)`, whose documented behaviour is to
+"preserve the parameter's storage address".
+
+The reader (`materialize_module_from_gms`, `client/torch/module.py`) walks
+keys independently and `.clone()`s every buffer/tensor_attr. That gives each
+alias a private copy, so a shared producer/consumer buffer stops being
+shared. For `topk_indices_buffer` the indexer writes its top-k indices into
+one copy while sparse attention reads another — which explains *both*
+symptoms at once: attention has no usable sparse index (garbage output), and
+it degrades toward a dense gather (cost that grows with context).
+
+## Why V1 is immune
+
+`GMSV1Worker` (`v1/integrations/vllm/worker.py`) keeps vLLM's **normal**
+loader and intercepts only the *allocator scope*
+(`capture_weights`/`capture_kv_cache`). The real model object is built and
+post-processed exactly as in stock vLLM, so storage identity — and therefore
+aliasing — is preserved by construction.
+
+V0 instead builds a **meta** model and rebinds tensors **by name**. A
+name->address map cannot express "these two names are the same storage", so
+the aliasing is unrecoverable at the reader.
+
+## Hypotheses eliminated by measurement (not argument)
+
+| Hypothesis | Verdict |
+|---|---|
+| CUDA VMM memory is slow | **Dead.** gather 1050.1 vs 1050.2 GB/s (1.000x); GEMM 0.996x, numerics exact |
+| VMM page fragmentation | **Dead.** KV is 99 handles of ~830 MiB; 2 MiB is alignment, not handle size |
+| Zeroed MLA q/k/v/prob scales | **Dead.** Measured live: `_q/_k/_v/_prob_scale = 1.0`. The 312 zero-filled tensors are unused *staging* params; the checkpoint contains **zero** attention scales, so the reference path also resolves to 1.0 |
+| Corrupt MoE NVFP4 scales | **Dead.** `(256,2)->(32,)` is vLLM's own documented collapse (`modelopt.py:1550-1556`) plus correct EP sharding |
+| Corrupt weights generally | **Dead.** Measured healthy: MLA `W_UV`/`W_UK_T` finite/non-zero, MoE weights+scales correct, embeddings correctly TP-sharded, rotary cache absmax=1, norms non-zero |
+| Sparse-attention "misroute" is V0-specific | **Dead.** Dispatch gates are a pure function of model config + vLLM version; identical in both arms |
+| Different commit / compile mode / prefix caching / workload | **Dead.** All verified identical |
+
+## Fix status — NOT yet landed
+
+Preserving aliasing for shared buffers is the right direction, and the
+instrumentation confirms the reader can identify alias groups from
+`(allocation_id, offset_bytes)`. Two attempts were made and **both reverted**:
+
+1. Share the materialized tensor for every aliased location — engine reached
+   CUDA-graph capture then failed to start.
+2. Share only `topk_indices_buffer` — same failure.
+
+So simply not-cloning is insufficient: something else in the RO path (most
+likely graph capture against these buffers, or a later rebind that assumes a
+private copy) depends on the clone. The cluster was returned to the previous
+working configuration; both engines are Ready and V0 serves HTTP 200.
+
+## Recommendation
+
+The V0 name-keyed meta-model reconstruction cannot represent tensor aliasing,
+and aliasing is load-bearing in vLLM. Rather than continue reconstructing
+post-load state name by name, adopt the V1 ownership model for V0: run vLLM's
+normal loader and intercept the allocator. That is empirically correct and
+~4x faster on this exact model and node today.

--- a/bench/results/GLM52-V0-V1-PARITY.md
+++ b/bench/results/GLM52-V0-V1-PARITY.md
@@ -1,0 +1,139 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# GLM-5.2 NVFP4: GMS V0 reaches V1 steady-state parity
+
+## Result
+
+Same model, same image, identical B200 nodes clocked at 1965 MHz, both arms
+idle, 0% prefix-cache hit. The V0 publishing engine was 3-4x slower than V1 and
+emitted garbage; it now matches V1 on all three target metrics and produces
+identical greedy text.
+
+### Single request, TTFT vs prompt length
+
+| ~tokens | V0 before | V0 after | V1 | after / V1 |
+|--------:|----------:|---------:|-------:|-----------:|
+| 1,215 | 0.169 s | 0.118 s | 0.110 s | 1.07x |
+| 4,050 | 0.573 s | 0.200 s | 0.191 s | 1.05x |
+| 8,100 | 1.301 s | 0.444 s | 0.395 s | 1.12x |
+| 16,200 | 2.704 s | 0.800 s | 0.789 s | 1.01x |
+| 32,400 | 5.753 s | 1.652 s | 1.631 s | 1.01x |
+
+### Steady state, concurrency 8, ~3,240-token prompts, 120 output tokens
+
+| Metric | V0 before | V0 after | V1 | after / V1 |
+|--------|----------:|---------:|-------:|-----------:|
+| TTFT p50 | ~1.75 s | 0.439 s | 0.430 s | 1.02x |
+| ITL p50 | ~155 ms | 12.5 ms | 12.2 ms | 1.02x |
+| output tok/s/user | ~6.4 | 55.17 | 56.42 | 0.98x |
+| throughput | ~0.8 req/s | 3.08 req/s | 3.12 req/s | 0.99x |
+
+Both arms ran 150 s at concurrency 8 with zero errors (464 and 473 completed
+requests). Numbers above are from the final reviewed code; an earlier run of the
+same configuration gave 0.438 s / 12.5 ms / 55.03 / 3.07, so the result is
+stable across reloads.
+
+Greedy continuation of `"The capital of France is"` is byte-identical between
+arms: `" Paris. Distance from Paris to Lyon is 243 miles, ..."`. Before the fix
+V0 emitted `"importimportimport..."`.
+
+## Defect 1: name-based rebinding severs unreachable tensor holders
+
+`rebind_nonparameter_tensors` moved GMS-resident non-parameter tensors onto
+private storage by **name**: walk `module._modules`, clone each tensor, assign
+the clone back onto the module attribute. That silently breaks any tensor whose
+holders are not all reachable by module traversal.
+
+The DSA top-k channel is exactly such a tensor. One `topk_indices_buffer` has
+four holders:
+
+| # | Holder | Reachable by name walk? |
+|---|--------|-------------------------|
+| 1 | `Indexer.topk_indices_buffer` | yes |
+| 2 | `SparseAttnIndexer.topk_indices_buffer` (producer) | yes |
+| 3 | `MultiHeadLatentAttentionWrapper.topk_indices_buffer` | yes |
+| 4 | `MLAAttention.impl.topk_indices_buffer` (consumer) | **no** |
+
+`MLAAttention.impl` is an `AttentionImpl`, not an `nn.Module`, so
+`_iter_module_tensors` never visits it. After a name-based rebind the indexer
+wrote top-k indices into the new buffer while attention read the old one, which
+`torch.empty` had never initialized. Attention scored against arbitrary KV
+slots: incoherent output, and destroyed KV-gather locality, which is where the
+3-4x latency came from. It also explains the bitwise-identical consecutive
+decode distributions observed earlier -- attention output was
+context-independent.
+
+**Fix.** Swap storage in place with `Tensor.set_()`, one private storage per
+source storage. Preserving the TensorImpl makes every holder follow, including
+holders that cannot be enumerated. GMS V1 gets this invariant for free
+(`v1/client/parameter_storage.py` rebinds with `tensor.set_()` and discovers
+tensors through `gc.get_objects()`), which is why V1 was never affected.
+
+## Defect 2: per-name cloning splits deliberate aliases
+
+`materialize_module_from_gms` cloned each published name separately, so vLLM's
+intentional aliases became unrelated tensors: `W_UK_T`/`W_UV` are views over
+`kv_b_proj.weight`, and one `cos_sin_cache` is shared by every layer.
+
+**Fix.** One clone per `(allocation_id, offset_bytes)`; each name gets an
+`as_strided` view of it, with dtype and extent asserted. Same fix in
+`_clone_triton_incompatible_params_off_gms`, so `mlp.gate.e_score_correction_bias`
+and `mlp.experts.routed_experts.e_score_correction_bias` keep sharing the
+routing bias instead of being split into two copies.
+
+## Defect 3: leftover meta scales zero-filled
+
+Tensors still on the meta device after name-keyed materialization were filled
+with **zeros**. 312 per rank are the MLA `q_scale`/`k_scale`/`v_scale`/
+`prob_scale` Parameters: the writer registers these under their `_`-prefixed
+buffer names, so the reader's un-prefixed Parameters find no match. A scale is a
+multiplicative factor, so zero scales attention to nothing.
+
+vLLM's `init_fp8_kv_scales` runs on wake-from-sleep and resets only
+`k_scale`/`v_scale` to 1.0, so `q_scale` and `prob_scale` stayed at zero. That
+is why the damage presented as gradual quality decay rather than outright
+failure.
+
+**Fix.** Fill leftover meta tensors with the neutral value: 1.0 for the four
+known MLA scale leaves, 0.0 otherwise, matching vLLM's own
+`set_default_quant_scales`.
+
+## Method: whole-model tensor fingerprints
+
+The decisive tool was a per-tensor fingerprint (shape, stride, dtype, and a
+blake2b hash of a strided byte sample) dumped from both arms and diffed.
+
+| Comparison | Result |
+|------------|--------|
+| Two different TP ranks (control) | 1760 / 4413 differ -- the fingerprint discriminates |
+| Writer vs reader, at load | 0 / 4209 differ |
+| Writer, load vs after sleep/wake | only KV caches differ, as expected |
+| Reader, load vs after wake | exactly 156 differ, all `k_scale`/`v_scale`, hash of 0.0 -> hash of 1.0 |
+
+That last row is what identified defect 3: it showed which tensors
+`init_fp8_kv_scales` repaired, and by elimination which ones it did not.
+
+## Ruled out by measurement
+
+Recorded so these are not re-litigated:
+
+| Hypothesis | Measurement |
+|------------|-------------|
+| VMM mappings are slower than ordinary CUDA memory | gather 1050.1 vs 1050.2 GB/s; bf16 GEMM 1596 vs 1590 TFLOP/s, numerics exact |
+| VMM fragmentation | KV cache is 99 handles of ~830 MiB; 2 MiB is alignment, not handle size |
+| Corrupt weights | all 4209 shared tensors byte-identical between arms |
+| MoE scale shape collapse `(32,2)->(32,)` | correct per `modelopt.py` |
+| Sparse-attention misroute | gates are pure config functions, identical in both arms; no cliff at `index_topk` |
+| Scheduler starving the V0 arm | loaded-arm arithmetic matches single-request numbers; both arms decode every step |
+| Different commit / compile mode / prefix cache / workload | all verified identical |
+| Reader KV cache sized differently | same boot shows identical accounting and 1,890,624 tokens on both |
+
+## Status
+
+Publishing engine: at parity, verified above.
+Read-only failover engine: defects 1-3 fixed and verified byte-identical to the
+publisher after wake, but its output still degrades; the remaining cause is not
+in tensor state and is tracked separately.

--- a/bench/results/GLM52-V0-V1-PARITY.md
+++ b/bench/results/GLM52-V0-V1-PARITY.md
@@ -116,6 +116,71 @@ blake2b hash of a strided byte sample) dumped from both arms and diffed.
 That last row is what identified defect 3: it showed which tensors
 `init_fp8_kv_scales` repaired, and by elimination which ones it did not.
 
+## Defect 4: shared top-k channel severed on the read-only replica
+
+The read-only replica served correct, full-speed results below 2,048 tokens and
+garbage at a third of the throughput above it. 2,048 is `index_topk`, and the
+boundary is a route switch, not a quality knob:
+
+```
+sparse_mla_attention.py:252   use_dense_mha = prefill_max_seq_len <= self.topk_tokens
+```
+
+Below it vLLM runs dense MHA and never reads `topk_indices_buffer` at all, so
+any corruption there is perfectly invisible. Above it every layer reads the
+buffer.
+
+`deepseek_v2.py:1382` builds that buffer as a **local variable** and threads it
+into each layer by constructor argument; nothing stores it on the model. In
+GLM-5.2 only 21 of 78 MLA layers own an indexer. The other 57 are `skip_topk`
+backbone layers that reuse the buffer an earlier layer wrote, and vLLM says so:
+
+```
+sparse_mla_attention.py:484   # the explicitly-passed buffer covers backbone
+                              # skip layers, whose indexer is not constructed
+```
+
+Name-keyed materialization rebinds only what module traversal reaches, so it
+repaired the 21 producers and left all 57 consumers pointing at whatever the
+meta constructor allocated. That allocation is not benign: the model passes
+`device=self.device` explicitly, so even under meta construction it is real,
+uninitialised CUDA memory that nothing ever writes. 57 of 78 layers attended to
+arbitrary KV slots.
+
+**Fix.** Resolve `_SHARED_CHANNEL_LEAVES` once per model rather than per module.
+There is exactly one such buffer for the whole network, so any module holding it
+after materialization is the canonical copy.
+
+Repair count moves from 96 (21 producers + 75 expert maps) to 153
+(21 + 57 + 75) -- the 57 is the bug, and the arithmetic is the proof.
+
+### Read-only replica, before and after
+
+| ~tokens | before | after | publisher | after / publisher |
+|--------:|-------:|------:|----------:|------------------:|
+| 1,215 | 0.110 s | 0.107 s | 0.118 s | 0.91x |
+| 4,050 | 0.723 s | 0.195 s | 0.200 s | 0.97x |
+| 8,100 | 1.440 s | 0.403 s | 0.441 s | 0.91x |
+| 16,200 | 2.800 s | 0.798 s | 0.799 s | 1.00x |
+| 32,400 | 12.357 s | 1.642 s | 1.651 s | 0.99x |
+
+Prefill at 32,400 tokens: 2,622 -> 19,732 tok/s, a 7.5x gain. Greedy output is
+again byte-identical to the publisher.
+
+For the failover workload this is the difference between diverging and holding:
+0.7 rps at 32k ISL needs 22,400 prompt tok/s to break even. The promoted replica
+was serving 3,200-6,400 tok/s (0.14-0.29x break-even), so its wait queue grew
+without bound regardless of shadow replenishment. Contention was never the
+story; capacity was.
+
+### Why this hid from the tensor fingerprint
+
+The fingerprint that exonerated the weights walks `module._modules` and yields
+only CUDA tensors. It therefore could not see the one tensor that mattered,
+because the failure was not a wrong *value* but a wrong *referent* on a
+non-Module holder. Byte-identical model state and broken serving are compatible
+whenever the defect is in the object graph rather than in the bytes.
+
 ## Ruled out by measurement
 
 Recorded so these are not re-litigated:
@@ -133,7 +198,5 @@ Recorded so these are not re-litigated:
 
 ## Status
 
-Publishing engine: at parity, verified above.
-Read-only failover engine: defects 1-3 fixed and verified byte-identical to the
-publisher after wake, but its output still degrades; the remaining cause is not
-in tensor state and is tracked separately.
+Publishing engine: at parity with GMS V1, verified above.
+Read-only failover replica: at parity with the publisher, verified above.

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from dynamo.vllm.omni.args import OmniConfig
+from dynamo.vllm import phase_timer
 
 import uvloop
 from huggingface_hub import try_to_load_from_cache
@@ -51,7 +52,7 @@ from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.vllm.router_hints import enable_router_hint_support
 from dynamo.vllm.worker_factory import WorkerFactory
 
-from . import envs
+from . import envs, phase_timer
 from .args import Config, _uses_dynamo_connector, configure_rl_logprobs_mode, parse_args
 from .cache_info import get_configured_kv_event_block_size
 from .capacity import (
@@ -147,9 +148,11 @@ def _register_model_source_path(config: Config, vllm_config: VllmConfig) -> str:
 
 
 async def worker(argv: list[str] | None = None) -> None:
+    phase_timer.start("worker_entry")
     if argv is None:
         argv = sys.argv[1:]
     config = parse_args(argv)
+    phase_timer.mark("parse_args")
 
     dump_config(config.dump_config_to, config)
 
@@ -173,6 +176,7 @@ async def worker(argv: list[str] | None = None) -> None:
     # that path (ideally via a shared folder).
     if should_prefetch_model(config):
         await fetch_model(config.model)
+    phase_timer.mark("prefetch_model")
 
     # Snapshot mode: load engine before runtime creation so there are no
     # runtime connections when CRIU captures GPU state.
@@ -202,6 +206,7 @@ async def worker(argv: list[str] | None = None) -> None:
         request_plane=config.request_plane,
         event_plane=config.event_plane,
     )
+    phase_timer.mark("create_runtime")
 
     # [gluo FIXME] should be after init() below? 'shutdown_endpoints' are populated
     # there
@@ -230,6 +235,7 @@ async def worker(argv: list[str] | None = None) -> None:
         shutdown_endpoints,
         snapshot_engine=snapshot_engine,
     )
+    phase_timer.mark("factory_create_done")
 
     logger.debug("Worker function completed, exiting...")
 
@@ -631,6 +637,7 @@ def setup_vllm_engine(
     # Taken from build_async_engine_client_from_engine_args()
     usage_context = UsageContext.OPENAI_API_SERVER
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
+    phase_timer.mark("create_engine_config")
     disable_hybrid_kv_cache_manager_for_incompatible_pd_connector(vllm_config)
     default_sampling_params = vllm_config.model_config.get_diff_sampling_param()
 
@@ -673,8 +680,9 @@ def setup_vllm_engine(
     if stat_logger:
         factory.append(stat_logger)
 
-    # Time engine initialization
+    # Time engine initialization (model load, compile, CUDA graphs).
     start_time = time.time()
+    phase_timer.mark("async_llm_start")
     engine_client = AsyncLLM.from_vllm_config(
         vllm_config=vllm_config,
         usage_context=usage_context,
@@ -683,6 +691,7 @@ def setup_vllm_engine(
         disable_log_stats=engine_args.disable_log_stats,
     )
     load_time = time.time() - start_time
+    phase_timer.mark("async_llm_done")
 
     # Record model load time. ``component_gauges`` is None on the
     # embedding-worker path -- pooling engines have no chat-shaped gauges

--- a/components/src/dynamo/vllm/phase_timer.py
+++ b/components/src/dynamo/vllm/phase_timer.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Wall-clock phase log for Dynamo wrapper overhead.
+
+Logs are grep-able as ``[dyn-phase]`` so a restart measurement can subtract
+wrapper time from stock-vLLM time. Process-global: one timer per engine
+container, started at ``worker()`` entry.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+_t0: float | None = None
+_last: float | None = None
+
+
+def start(label: str = "process") -> None:
+    global _t0, _last
+    now = time.perf_counter()
+    _t0 = now
+    _last = now
+    logger.info("[dyn-phase] phase=%s elapsed_s=0.000 total_s=0.000", label)
+
+
+def mark(phase: str) -> float:
+    """Record a phase boundary. Returns seconds since the previous mark."""
+    global _last
+    now = time.perf_counter()
+    if _t0 is None:
+        start("implicit")
+    assert _t0 is not None and _last is not None
+    elapsed = now - _last
+    total = now - _t0
+    logger.info(
+        "[dyn-phase] phase=%s elapsed_s=%.3f total_s=%.3f",
+        phase,
+        elapsed,
+        total,
+    )
+    _last = now
+    return elapsed

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -48,6 +48,7 @@ from .health_check import (
 )
 from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
 from .multimodal_handlers import EncodeWorkerHandler
+from .phase_timer import mark as phase_mark
 from .pooling_handlers import ClassifyWorkerHandler
 from .publisher import StatLoggerFactory
 from .realtime import RealtimeHandler, RealtimeTranscriptionHandler
@@ -1199,6 +1200,7 @@ class WorkerFactory:
                 prometheus_temp_dir,
                 component_gauges,
             ) = self.setup_vllm_engine(config, factory, fpm_worker_id=fpm_worker_id)
+        phase_mark("setup_vllm_engine")
         lifecycle.engine_client = engine_client
         lifecycle.vllm_config = vllm_config
         await configure_kv_event_block_size(engine_client, vllm_config)
@@ -1304,6 +1306,7 @@ class WorkerFactory:
         was_failover = await self._maybe_wait_for_failover_lock(
             handler, runtime, config, failover_metrics
         )
+        phase_mark("failover_lock")
 
         # Wait for self-benchmark to complete before registering.
         bench_cfg = vllm_config.additional_config.get("benchmark")
@@ -1342,6 +1345,7 @@ class WorkerFactory:
             worker_type=worker_type,
             needs=needs,
         )
+        phase_mark("register_model")
         # Serving now: a failover that got here succeeded. Gated on was_failover
         # (same as the attempt) so bootup isn't counted and success pairs with attempt.
         if failover_metrics is not None:
@@ -1580,6 +1584,7 @@ class WorkerFactory:
         was_failover = await self._maybe_wait_for_failover_lock(
             handler, runtime, config, failover_metrics
         )
+        phase_mark("failover_lock")
 
         # Wait for self-benchmark to complete before registering.
         bench_cfg = vllm_config.additional_config.get("benchmark")

--- a/deploy/dsv4-pro-gms-v0/apply.sh
+++ b/deploy/dsv4-pro-gms-v0/apply.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Apply claims + DGD through the vCluster API. Requires IMAGE=
+# (full runtime image URI from Build on Demand).
+set -euo pipefail
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+NS=${NS:-schwinns-vcluster}
+IMAGE=${IMAGE:?set IMAGE to the vllm-runtime URI}
+VARIANT=${VARIANT:-failover}  # failover | gms-only | no-gms
+DGD_FILE="$ROOT/deploy/dsv4-pro-gms-v0/dgd-${VARIANT}.yaml"
+[ -f "$DGD_FILE" ] || { echo "missing $DGD_FILE"; exit 1; }
+
+tmp=$(mktemp)
+sed "s|__IMAGE__|$IMAGE|g" "$DGD_FILE" > "$tmp"
+
+vc() { vcluster connect schwinns-vcluster -n schwinns-vcluster -- "$@"; }
+
+vc kubectl -n "$NS" apply -f "$ROOT/deploy/dsv4-pro-gms-v0/claims.yaml"
+vc kubectl -n "$NS" apply -f "$tmp"
+rm -f "$tmp"
+echo "applied $VARIANT with $IMAGE"

--- a/deploy/dsv4-pro-gms-v0/claims.yaml
+++ b/deploy/dsv4-pro-gms-v0/claims.yaml
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# UUID-pinned DRA claims for nscale-dev node s2877 (8x B200).
+# Intra-pod GMS failover shares one destination claim across engine-0, engine-1,
+# and gms-server. The source claim is unused unless a checkpoint job is added.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: dsv4pro-vllm-gmsv0-s2877-destination-gpus
+  namespace: schwinns-vcluster
+spec:
+  devices:
+    requests:
+    - name: gpu-0
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-02ff0cc1-647f-dee7-8365-921738e945a6'
+    - name: gpu-1
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-0d5ad102-eb8f-922a-173e-e91033320e0f'
+    - name: gpu-2
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-9c595f65-4651-0b25-f95c-09a0abd5f5fa'
+    - name: gpu-3
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-4fba7684-5a96-6280-91ff-b41f7484564c'
+    - name: gpu-4
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-3ef7c092-d55c-ca6c-0018-9fc89ed28683'
+    - name: gpu-5
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-32a6c51c-d07d-7513-86b5-813b64e452d2'
+    - name: gpu-6
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-56c0be30-f1d3-a00d-8a2a-7fa70da8037f'
+    - name: gpu-7
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-ce231b92-c54f-3f0c-af1c-1a696db97f51'
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: dsv4pro-vllm-gmsv0-s2877-source-gpus
+  namespace: schwinns-vcluster
+spec:
+  devices:
+    requests:
+    - name: gpu-0
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-02ff0cc1-647f-dee7-8365-921738e945a6'
+    - name: gpu-1
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-0d5ad102-eb8f-922a-173e-e91033320e0f'
+    - name: gpu-2
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-9c595f65-4651-0b25-f95c-09a0abd5f5fa'
+    - name: gpu-3
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-4fba7684-5a96-6280-91ff-b41f7484564c'
+    - name: gpu-4
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-3ef7c092-d55c-ca6c-0018-9fc89ed28683'
+    - name: gpu-5
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-32a6c51c-d07d-7513-86b5-813b64e452d2'
+    - name: gpu-6
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-56c0be30-f1d3-a00d-8a2a-7fa70da8037f'
+    - name: gpu-7
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        count: 1
+        selectors:
+        - cel:
+            expression: device.attributes['gpu.nvidia.com'].uuid == 'GPU-ce231b92-c54f-3f0c-af1c-1a696db97f51'

--- a/deploy/dsv4-pro-gms-v0/dgd-failover.yaml
+++ b/deploy/dsv4-pro-gms-v0/dgd-failover.yaml
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# GMS V0 intra-pod shadow failover for DeepSeek-V4-Pro TEP8 on vLLM.
+# Substitute __IMAGE__ with the Build-on-Demand runtime tag before apply.
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: dsv4pro-vllm-gmsv0-fo
+  namespace: schwinns-vcluster
+  annotations:
+    nvidia.com/dynamo-kube-discovery-mode: container
+    nvidia.com/enable-grove: "false"
+    nvidia.com/workload-provider: component
+spec:
+  backendFramework: vllm
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    runtimeVersionOverride: "1.4.0"
+    podTemplate:
+      spec:
+        imagePullSecrets:
+        - name: acr-token-secret
+        nodeSelector:
+          kubernetes.io/hostname: cluster-0967a26d-pool-14bee067-prctr-s2877
+        tolerations:
+        - operator: Exists
+        containers:
+        - name: main
+          image: __IMAGE__
+          imagePullPolicy: Always
+          workingDir: /workspace
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          command: ["python3"]
+          args: ["-m", "dynamo.frontend", "--trust-remote-code", "--http-port", "8000"]
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_CACHE
+            value: /model-cache/hub
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          volumeMounts:
+          - name: model-cache
+            mountPath: /model-cache
+            readOnly: true
+        volumes:
+        - name: model-cache
+          nfs:
+            server: 192.168.0.223
+            path: /unikorn-identity-03cfadd31877-551/pvc-92b73e65-4eb9-486c-a773-8f58c2f32abd
+            readOnly: true
+  - name: VllmDecodeWorker
+    type: worker
+    replicas: 1
+    runtimeVersionOverride: "1.4.0"
+    experimental:
+      failover:
+        mode: IntraPod
+        numShadows: 1
+      gpuMemoryService:
+        mode: IntraPod
+        deviceClassName: gpu.nvidia.com
+    podTemplate:
+      metadata:
+        annotations:
+          vcluster.loft.sh/skip-hostpath-translation: "true"
+      spec:
+        runtimeClassName: nvidia
+        schedulerName: default-scheduler
+        imagePullSecrets:
+        - name: acr-token-secret
+        nodeSelector:
+          kubernetes.io/hostname: cluster-0967a26d-pool-14bee067-prctr-s2877
+        tolerations:
+        - operator: Exists
+        resourceClaims:
+        - name: intrapod-shared-gpu
+          resourceClaimName: dsv4pro-vllm-gmsv0-s2877-destination-gpus
+        containers:
+        - name: main
+          image: __IMAGE__
+          imagePullPolicy: Always
+          workingDir: /workspace
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          command: ["python3"]
+          args:
+          - -m
+          - dynamo.vllm
+          - --model
+          - nvidia/DeepSeek-V4-Pro-NVFP4
+          - --served-model-name
+          - nvidia/DeepSeek-V4-Pro-NVFP4
+          - --trust-remote-code
+          - --load-format
+          - gms
+          - --tensor-parallel-size
+          - "8"
+          - --enable-expert-parallel
+          - --moe-backend
+          - flashinfer_trtllm
+          - --kv-cache-dtype
+          - fp8
+          - --block-size
+          - "256"
+          - --max-model-len
+          - "32768"
+          - --gpu-memory-utilization
+          - "0.80"
+          - --max-num-seqs
+          - "32"
+          - --tokenizer-mode
+          - deepseek_v4
+          - --dyn-reasoning-parser
+          - deepseek_v4
+          - --dyn-tool-call-parser
+          - deepseek_v4
+          - --attention-config
+          - '{"use_fp4_indexer_cache":true}'
+          - --compilation-config
+          - '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'
+          - --enable-prefix-caching
+          - --enable-chunked-prefill
+          - --no-enable-flashinfer-autotune
+          - --model-loader-extra-config
+          - '{"enable_multithread_load":true,"num_threads":32}'
+          env:
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_CACHE
+            value: /model-cache/hub
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          - name: TRANSFORMERS_OFFLINE
+            value: "1"
+          - name: VLLM_SKIP_P2P_CHECK
+            value: "1"
+          - name: NCCL_CUMEM_ENABLE
+            value: "1"
+          - name: VLLM_ALLREDUCE_USE_FLASHINFER
+            value: "1"
+          - name: VLLM_ENGINE_READY_TIMEOUT_S
+            value: "5400"
+          - name: VLLM_CACHE_ROOT
+            value: /vllm-cache
+          - name: TORCHINDUCTOR_CACHE_DIR
+            value: /vllm-cache/torchinductor
+          - name: TRITON_CACHE_DIR
+            value: /vllm-cache/triton
+          - name: DYN_GMS_VLLM_LOG_LEVEL
+            value: INFO
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            claims:
+            - name: intrapod-shared-gpu
+            requests:
+              memory: 400Gi
+            limits:
+              memory: 800Gi
+          volumeMounts:
+          - name: model-cache
+            mountPath: /model-cache
+            readOnly: true
+          - name: vllm-cache
+            mountPath: /vllm-cache
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 540
+        volumes:
+        - name: model-cache
+          nfs:
+            server: 192.168.0.223
+            path: /unikorn-identity-03cfadd31877-551/pvc-92b73e65-4eb9-486c-a773-8f58c2f32abd
+            readOnly: true
+        - name: vllm-cache
+          hostPath:
+            path: /mnt/nvme2/schwinns-vcluster/dsv4-pro-vllm-cache
+            type: DirectoryOrCreate
+    sharedMemorySize: 200Gi

--- a/deploy/dsv4-pro-gms-v0/dgd-gms-only.yaml
+++ b/deploy/dsv4-pro-gms-v0/dgd-gms-only.yaml
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# GMS V0 only (no shadow). Kill/restart the engine; GMS server stays up. for DeepSeek-V4-Pro TEP8 on vLLM.
+# Substitute __IMAGE__ with the Build-on-Demand runtime tag before apply.
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: dsv4pro-vllm-gmsv0-restart
+  namespace: schwinns-vcluster
+  annotations:
+    nvidia.com/enable-grove: "false"
+    nvidia.com/workload-provider: component
+spec:
+  backendFramework: vllm
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    runtimeVersionOverride: "1.4.0"
+    podTemplate:
+      spec:
+        imagePullSecrets:
+        - name: acr-token-secret
+        nodeSelector:
+          kubernetes.io/hostname: cluster-0967a26d-pool-14bee067-prctr-s2877
+        tolerations:
+        - operator: Exists
+        containers:
+        - name: main
+          image: __IMAGE__
+          imagePullPolicy: Always
+          workingDir: /workspace
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          command: ["python3"]
+          args: ["-m", "dynamo.frontend", "--trust-remote-code", "--http-port", "8000"]
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_CACHE
+            value: /model-cache/hub
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          volumeMounts:
+          - name: model-cache
+            mountPath: /model-cache
+            readOnly: true
+        volumes:
+        - name: model-cache
+          nfs:
+            server: 192.168.0.223
+            path: /unikorn-identity-03cfadd31877-551/pvc-92b73e65-4eb9-486c-a773-8f58c2f32abd
+            readOnly: true
+  - name: VllmDecodeWorker
+    type: worker
+    replicas: 1
+    runtimeVersionOverride: "1.4.0"
+    experimental:
+      gpuMemoryService:
+        mode: IntraPod
+        deviceClassName: gpu.nvidia.com
+    podTemplate:
+      metadata:
+        annotations:
+          vcluster.loft.sh/skip-hostpath-translation: "true"
+      spec:
+        runtimeClassName: nvidia
+        schedulerName: default-scheduler
+        imagePullSecrets:
+        - name: acr-token-secret
+        nodeSelector:
+          kubernetes.io/hostname: cluster-0967a26d-pool-14bee067-prctr-s2877
+        tolerations:
+        - operator: Exists
+        resourceClaims:
+        - name: intrapod-shared-gpu
+          resourceClaimName: dsv4pro-vllm-gmsv0-s2877-destination-gpus
+        containers:
+        - name: main
+          image: __IMAGE__
+          imagePullPolicy: Always
+          workingDir: /workspace
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          command: ["python3"]
+          args:
+          - -m
+          - dynamo.vllm
+          - --model
+          - nvidia/DeepSeek-V4-Pro-NVFP4
+          - --served-model-name
+          - nvidia/DeepSeek-V4-Pro-NVFP4
+          - --trust-remote-code
+          - --load-format
+          - gms
+          - --tensor-parallel-size
+          - "8"
+          - --enable-expert-parallel
+          - --moe-backend
+          - flashinfer_trtllm
+          - --kv-cache-dtype
+          - fp8
+          - --block-size
+          - "256"
+          - --max-model-len
+          - "32768"
+          - --gpu-memory-utilization
+          - "0.80"
+          - --max-num-seqs
+          - "32"
+          - --tokenizer-mode
+          - deepseek_v4
+          - --dyn-reasoning-parser
+          - deepseek_v4
+          - --dyn-tool-call-parser
+          - deepseek_v4
+          - --attention-config
+          - '{"use_fp4_indexer_cache":true}'
+          - --compilation-config
+          - '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'
+          - --enable-prefix-caching
+          - --enable-chunked-prefill
+          - --model-loader-extra-config
+          - '{"enable_multithread_load":true,"num_threads":32}'
+          env:
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_CACHE
+            value: /model-cache/hub
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          - name: TRANSFORMERS_OFFLINE
+            value: "1"
+          - name: VLLM_SKIP_P2P_CHECK
+            value: "1"
+          - name: NCCL_CUMEM_ENABLE
+            value: "1"
+          - name: VLLM_ALLREDUCE_USE_FLASHINFER
+            value: "1"
+          - name: VLLM_ENGINE_READY_TIMEOUT_S
+            value: "5400"
+          - name: VLLM_CACHE_ROOT
+            value: /vllm-cache
+          - name: TORCHINDUCTOR_CACHE_DIR
+            value: /vllm-cache/torchinductor
+          - name: TRITON_CACHE_DIR
+            value: /vllm-cache/triton
+          - name: DYN_GMS_VLLM_LOG_LEVEL
+            value: INFO
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            claims:
+            - name: intrapod-shared-gpu
+            requests:
+              memory: 400Gi
+            limits:
+              memory: 800Gi
+          volumeMounts:
+          - name: model-cache
+            mountPath: /model-cache
+            readOnly: true
+          - name: vllm-cache
+            mountPath: /vllm-cache
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 540
+        volumes:
+        - name: model-cache
+          nfs:
+            server: 192.168.0.223
+            path: /unikorn-identity-03cfadd31877-551/pvc-92b73e65-4eb9-486c-a773-8f58c2f32abd
+            readOnly: true
+        - name: vllm-cache
+          hostPath:
+            path: /mnt/nvme2/schwinns-vcluster/dsv4-pro-vllm-cache
+            type: DirectoryOrCreate
+    sharedMemorySize: 200Gi

--- a/deploy/dsv4-pro-gms-v0/dgd-no-gms.yaml
+++ b/deploy/dsv4-pro-gms-v0/dgd-no-gms.yaml
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# No GMS. Stock Dynamo+vLLM TEP8 for warm-cache restart baseline. for DeepSeek-V4-Pro TEP8 on vLLM.
+# Substitute __IMAGE__ with the Build-on-Demand runtime tag before apply.
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: dsv4pro-vllm-nogms-restart
+  namespace: schwinns-vcluster
+  annotations:
+    nvidia.com/enable-grove: "false"
+    nvidia.com/workload-provider: component
+spec:
+  backendFramework: vllm
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    runtimeVersionOverride: "1.4.0"
+    podTemplate:
+      spec:
+        imagePullSecrets:
+        - name: acr-token-secret
+        nodeSelector:
+          kubernetes.io/hostname: cluster-0967a26d-pool-14bee067-prctr-s2877
+        tolerations:
+        - operator: Exists
+        containers:
+        - name: main
+          image: __IMAGE__
+          imagePullPolicy: Always
+          workingDir: /workspace
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          command: ["python3"]
+          args: ["-m", "dynamo.frontend", "--trust-remote-code", "--http-port", "8000"]
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_CACHE
+            value: /model-cache/hub
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          volumeMounts:
+          - name: model-cache
+            mountPath: /model-cache
+            readOnly: true
+        volumes:
+        - name: model-cache
+          nfs:
+            server: 192.168.0.223
+            path: /unikorn-identity-03cfadd31877-551/pvc-92b73e65-4eb9-486c-a773-8f58c2f32abd
+            readOnly: true
+  - name: VllmDecodeWorker
+    type: worker
+    replicas: 1
+    runtimeVersionOverride: "1.4.0"
+    podTemplate:
+      metadata:
+        annotations:
+          vcluster.loft.sh/skip-hostpath-translation: "true"
+      spec:
+        runtimeClassName: nvidia
+        schedulerName: default-scheduler
+        imagePullSecrets:
+        - name: acr-token-secret
+        nodeSelector:
+          kubernetes.io/hostname: cluster-0967a26d-pool-14bee067-prctr-s2877
+        tolerations:
+        - operator: Exists
+        resourceClaims:
+        - name: intrapod-shared-gpu
+          resourceClaimName: dsv4pro-vllm-gmsv0-s2877-destination-gpus
+        containers:
+        - name: main
+          image: __IMAGE__
+          imagePullPolicy: Always
+          workingDir: /workspace
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          command: ["python3"]
+          args:
+          - -m
+          - dynamo.vllm
+          - --model
+          - nvidia/DeepSeek-V4-Pro-NVFP4
+          - --served-model-name
+          - nvidia/DeepSeek-V4-Pro-NVFP4
+          - --trust-remote-code
+          - --tensor-parallel-size
+          - "8"
+          - --enable-expert-parallel
+          - --moe-backend
+          - flashinfer_trtllm
+          - --kv-cache-dtype
+          - fp8
+          - --block-size
+          - "256"
+          - --max-model-len
+          - "32768"
+          - --gpu-memory-utilization
+          - "0.80"
+          - --max-num-seqs
+          - "32"
+          - --tokenizer-mode
+          - deepseek_v4
+          - --dyn-reasoning-parser
+          - deepseek_v4
+          - --dyn-tool-call-parser
+          - deepseek_v4
+          - --attention-config
+          - '{"use_fp4_indexer_cache":true}'
+          - --compilation-config
+          - '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'
+          - --enable-prefix-caching
+          - --enable-chunked-prefill
+          - --model-loader-extra-config
+          - '{"enable_multithread_load":true,"num_threads":32}'
+          env:
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_CACHE
+            value: /model-cache/hub
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          - name: TRANSFORMERS_OFFLINE
+            value: "1"
+          - name: VLLM_SKIP_P2P_CHECK
+            value: "1"
+          - name: NCCL_CUMEM_ENABLE
+            value: "1"
+          - name: VLLM_ALLREDUCE_USE_FLASHINFER
+            value: "1"
+          - name: VLLM_ENGINE_READY_TIMEOUT_S
+            value: "5400"
+          - name: VLLM_CACHE_ROOT
+            value: /vllm-cache
+          - name: TORCHINDUCTOR_CACHE_DIR
+            value: /vllm-cache/torchinductor
+          - name: TRITON_CACHE_DIR
+            value: /vllm-cache/triton
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            claims:
+            - name: intrapod-shared-gpu
+            requests:
+              memory: 400Gi
+            limits:
+              memory: 800Gi
+          volumeMounts:
+          - name: model-cache
+            mountPath: /model-cache
+            readOnly: true
+          - name: vllm-cache
+            mountPath: /vllm-cache
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 540
+        volumes:
+        - name: model-cache
+          nfs:
+            server: 192.168.0.223
+            path: /unikorn-identity-03cfadd31877-551/pvc-92b73e65-4eb9-486c-a773-8f58c2f32abd
+            readOnly: true
+        - name: vllm-cache
+          hostPath:
+            path: /mnt/nvme2/schwinns-vcluster/dsv4-pro-vllm-cache
+            type: DirectoryOrCreate
+    sharedMemorySize: 200Gi

--- a/deploy/dsv4-pro-gms-v0/helm-values.yaml
+++ b/deploy/dsv4-pro-gms-v0/helm-values.yaml
@@ -1,0 +1,32 @@
+# Overlay for helm upgrade of dynamo-platform inside schwinns-vcluster.
+# Substitute __OPERATOR_IMAGE__ after Build on Demand.
+global:
+  etcd:
+    install: false
+  nats:
+    install: false
+  grove:
+    install: false
+  snapshot:
+    install: false
+
+dynamo-operator:
+  enabled: true
+  upgradeCRD: true
+  namespaceRestriction:
+    enabled: false
+    targetNamespace: schwinns-vcluster
+  checkpoint:
+    enabled: true
+    storage:
+      type: pvc
+      pvc:
+        create: false
+        pvcName: snapshot-pvc
+        basePath: /checkpoints
+  controllerManager:
+    manager:
+      image:
+        repository: dynamoci.azurecr.io/ai-dynamo/dynamo
+        tag: __OPERATOR_TAG__
+        pullPolicy: Always

--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -31,7 +31,8 @@ This module uses cuda-python bindings for CUDA driver API calls:
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 from gpu_memory_service.client.session import _GMSClientSession
@@ -82,6 +83,69 @@ class _ScratchMapping:
     va_reserved_size: int  # scratch-rounded local VA reservation
     tag: str
     scratch_handle: int  # 0 after unmap_all_vas drops the physical
+
+
+@dataclass
+class _Slab:
+    """Free-space bookkeeping for one server allocation carved into regions.
+
+    ``holes`` is a sorted, coalesced list of ``(offset, length)`` free ranges
+    within the slab. ``carved_bytes`` counts what is currently handed out;
+    the slab is retired when it reaches zero. Counting is deliberate rather
+    than inferring emptiness from ``holes``: a slab whose single region spans
+    the whole allocation starts with no holes at all, so a hole-shaped test
+    cannot distinguish "full" from "empty".
+    """
+
+    tag: str
+    aligned_size: int
+    holes: List[tuple[int, int]] = field(default_factory=list)
+    carved_bytes: int = 0
+
+    def take(self, aligned_size: int) -> Optional[int]:
+        """First-fit an aligned range, returning its offset within the slab."""
+        for index, (offset, length) in enumerate(self.holes):
+            if length < aligned_size:
+                continue
+            leftover = length - aligned_size
+            if leftover:
+                self.holes[index] = (offset + aligned_size, leftover)
+            else:
+                del self.holes[index]
+            self.carved_bytes += aligned_size
+            return offset
+        return None
+
+    def give_back(self, offset: int, aligned_size: int) -> None:
+        """Return a range and coalesce it with any adjacent free neighbours."""
+        index = 0
+        while index < len(self.holes) and self.holes[index][0] < offset:
+            index += 1
+        self.holes.insert(index, (offset, aligned_size))
+        merged: List[tuple[int, int]] = []
+        for hole_offset, hole_length in self.holes:
+            if merged and hole_offset <= merged[-1][0] + merged[-1][1]:
+                prev_offset, prev_length = merged[-1]
+                end = max(prev_offset + prev_length, hole_offset + hole_length)
+                merged[-1] = (prev_offset, end - prev_offset)
+                continue
+            merged.append((hole_offset, hole_length))
+        self.holes = merged
+        self.carved_bytes -= aligned_size
+
+    @property
+    def is_empty(self) -> bool:
+        return self.carved_bytes == 0
+
+
+@dataclass(frozen=True)
+class _Region:
+    """One caller-visible allocation carved out of a slab."""
+
+    slab_va: int
+    offset: int
+    size: int  # as requested by the caller
+    aligned_size: int  # what the slab actually reserved
 
 
 @dataclass(frozen=True)
@@ -164,6 +228,7 @@ class GMSClientMemoryManager:
         device: int = 0,
         tag: Optional[str] = None,
         scratch_size: int = 512 * 1024 * 1024,
+        slab_size: int = 0,
     ) -> None:
         self.socket_path = socket_path
         self.device = device
@@ -181,6 +246,13 @@ class GMSClientMemoryManager:
         self._mappings: Dict[int, LocalMapping] = {}
         self._inverse_mapping: Dict[str, int] = {}
         self._scratch_mappings: Dict[int, _ScratchMapping] = {}
+        # Slab packing rides on top of _mappings: a slab IS a normal
+        # LocalMapping, so unmap/remap/reallocate and layout_slot pairing stay
+        # allocation-shaped and simply have far fewer entries to walk.
+        #   _slabs   — slab base VA -> free-space bookkeeping
+        #   _regions — caller VA -> the slab range backing it
+        self._slabs: Dict[int, _Slab] = {}
+        self._regions: Dict[int, _Region] = {}
         # All scratch mappings alias ONE shared physical granule (N KV layers ->
         # one scratch_size block, not N). Created lazily, released once.
         self._shared_scratch_handle: int = 0
@@ -195,6 +267,15 @@ class GMSClientMemoryManager:
 
         self._vmm.ensure_initialized()
         self.granularity = self._vmm.get_allocation_granularity(device)
+        # Packing is opt-in, because it trades committed memory for a smaller
+        # allocation count: a slab is allocated whole, so a manager that hands
+        # out a handful of small mappings would commit a whole slab for them.
+        # It pays off only where torch drives hundreds of segment mallocs
+        # through us, so the torch mempool seam turns it on (see
+        # get_or_create_gms_client_memory_manager).
+        self.slab_size = (
+            align_to_granularity(slab_size, self.granularity) if slab_size > 0 else 0
+        )
 
     # ==================== Properties ====================
 
@@ -220,7 +301,35 @@ class GMSClientMemoryManager:
 
     @property
     def total_bytes(self) -> int:
+        """Bytes actually handed out, not bytes reserved.
+
+        A slab is mapped whole but may be only partly carved, so summing
+        aligned_size over _mappings would count the un-carved tail. This value
+        feeds vLLM/SGLang KV sizing via imported_weights_bytes; over-reporting
+        it silently shrinks the KV cache.
+        """
+        total = 0
+        for va, mapping in self._mappings.items():
+            slab = self._slabs.get(va)
+            total += slab.carved_bytes if slab is not None else mapping.aligned_size
+        return total
+
+    @property
+    def reserved_bytes(self) -> int:
+        """Physical bytes committed on the server, including slab tails."""
         return sum(m.aligned_size for m in self._mappings.values())
+
+    def owns(self, va: int) -> bool:
+        """Whether this manager handed out ``va``.
+
+        Accepts both slab-carved regions and whole allocations, so the torch
+        free callback can dispatch on it without knowing which it got. A slab
+        base is not itself owned: callers only ever hold regions carved out of
+        it, and the first carve shares the slab's VA.
+        """
+        return va in self._regions or (
+            va in self._mappings and va not in self._slabs
+        )
 
     # ==================== Tier 1: Connection ====================
 
@@ -355,6 +464,27 @@ class GMSClientMemoryManager:
         self._granted_lock_type = None
         return True
 
+    def drop_committed_layout(self) -> None:
+        """Free committed server pages after this process has cloned off VMM.
+
+        Unmap, abort the RO session, reconnect RW (the server clears the
+        published allocations on RW connect), then abort. Leaves the manager
+        unmapped with an empty mapping table. A later shadow remap will fail
+        until a writer republishes; that is the memory trade for native-speed
+        serving plus a full KV cache on one B200.
+        """
+        if not self._unmapped:
+            self.unmap_all_vas()
+        self.abort()
+        self.connect(RequestedLockType.RW)
+        self.abort()
+        self._mappings.clear()
+        self._inverse_mapping.clear()
+        self._unmapped = True
+        self._va_preserved = False
+        self._last_memory_layout_hash = ""
+        logger.info("[GMS] Dropped committed weight layout after private clone")
+
     def commit_layout(self) -> "LayoutCommit":
         """Seal the allocation set: the shape is final, the pages outlive this session.
 
@@ -478,14 +608,22 @@ class GMSClientMemoryManager:
         allocation_id: Optional[str] = None,
         size: int = 0,
         tag: str = "default",
+        dedicated: bool = False,
     ) -> int:
         """Allocate or import a handle and map to a new VA.
 
         If allocation_id is None (allocate path):
-          allocate_handle -> export_handle -> reserve_va -> map_va
+          carve from a slab, or allocate_handle -> export_handle ->
+          reserve_va -> map_va for a fresh one
 
         If allocation_id given (import path, cached):
           Check cache -> get_handle_info -> export_handle -> reserve_va -> map_va
+
+        The import path never packs: it maps one foreign server allocation at
+        its own reservation, and its offsets are that allocation's own. Pass
+        ``dedicated`` on the allocate path to get the same whole-allocation
+        shape, which callers reproducing a published layout byte-for-byte
+        (snapshot restore) require.
         """
         if allocation_id is not None:
             # Import path: check cache first
@@ -513,6 +651,12 @@ class GMSClientMemoryManager:
         # Allocate path
         if size <= 0:
             raise ValueError("size must be > 0 when allocation_id is None")
+        if self.slab_size and not dedicated:
+            return self._carve(size, tag)
+        return self._allocate_whole(size, tag)
+
+    def _allocate_whole(self, size: int, tag: str) -> int:
+        """One server allocation mapped at its own VA reservation."""
         alloc_id, layout_slot = self.allocate_handle(size, tag)
         fd = self.export_handle(alloc_id)
         aligned_size = align_to_granularity(size, self.granularity)
@@ -520,7 +664,91 @@ class GMSClientMemoryManager:
         self.map_va(fd, va, size, alloc_id, tag, layout_slot)
         return va
 
-    def destroy_mapping(self, va: int) -> None:
+    def _carve(self, size: int, tag: str) -> int:
+        """Hand out a range of a slab, growing a new slab when none fits."""
+        aligned_size = align_to_granularity(size, self.granularity)
+        for slab_va in sorted(self._slabs):
+            slab = self._slabs[slab_va]
+            if slab.tag != tag:
+                continue
+            offset = slab.take(aligned_size)
+            if offset is None:
+                continue
+            va = slab_va + offset
+            self._regions[va] = _Region(slab_va, offset, size, aligned_size)
+            return va
+
+        slab_va = self._add_slab(aligned_size, tag)
+        slab = self._slabs[slab_va]
+        offset = slab.take(aligned_size)
+        assert offset == 0, "a fresh slab must satisfy the request that grew it"
+        self._regions[slab_va] = _Region(slab_va, 0, size, aligned_size)
+        return slab_va
+
+    def _add_slab(self, aligned_size: int, tag: str) -> int:
+        """Allocate and map one slab, big enough for ``aligned_size``.
+
+        Rolls back the server allocation and the VA reservation if any step
+        fails, so a failed grow leaves neither an orphaned handle on the
+        server nor a stranded reservation in this address space.
+        """
+        slab_bytes = max(self.slab_size, aligned_size)
+        alloc_id, layout_slot = self.allocate_handle(slab_bytes, tag)
+        va = 0
+        try:
+            fd = self.export_handle(alloc_id)
+            va = self.reserve_va(slab_bytes)
+            self.map_va(fd, va, slab_bytes, alloc_id, tag, layout_slot)
+        except BaseException:
+            if va:
+                self._vmm.address_free(va, slab_bytes)
+            self.free_handle(alloc_id)
+            raise
+        self._slabs[va] = _Slab(tag=tag, aligned_size=slab_bytes, holes=[(0, slab_bytes)])
+        logger.debug(
+            "[GMS] Added %d MiB %s slab at 0x%x (%d slabs)",
+            slab_bytes // (1 << 20),
+            tag,
+            va,
+            len(self._slabs),
+        )
+        return va
+
+    def destroy_mapping(self, va: int, size: Optional[int] = None) -> None:
+        """Release a carved region, or a whole allocation.
+
+        A slab-carved region is returned to its slab's free list; the slab
+        itself is torn down only once every region in it is gone. Torch frees
+        blocks in a different order than it allocated them, so partially free
+        slabs are normal and their space is reused by later carves.
+        """
+        region = self._regions.get(va)
+        if region is not None:
+            if size is not None and size != region.size:
+                raise RuntimeError(
+                    "allocator free does not match the GMS region: "
+                    f"{size} vs {region.size}"
+                )
+            del self._regions[va]
+            slab = self._slabs[region.slab_va]
+            slab.give_back(region.offset, region.aligned_size)
+            if slab.is_empty:
+                self._destroy_whole(region.slab_va)
+                del self._slabs[region.slab_va]
+            return
+
+        if va in self._slabs:
+            # The slab's own VA is not a caller-visible allocation: its first
+            # carve shares this address and is tracked in _regions above. A
+            # slab is only ever retired by its last region going away.
+            raise RuntimeError(
+                f"0x{va:x} is a GMS slab base, not an allocation; "
+                "it is released when its last region is freed"
+            )
+
+        self._destroy_whole(va)
+
+    def _destroy_whole(self, va: int) -> None:
         """Unmap + free VA + free server handle for a single mapping."""
         mapping = self._mappings.get(va)
         if mapping is None:
@@ -609,6 +837,8 @@ class GMSClientMemoryManager:
         remapped_count = 0
         total_bytes = 0
         remapped_vas: list[int] = []
+        export_s = import_s = map_s = access_s = 0.0
+        loop_started = time.perf_counter()
         for rank, ((va, mapping), alloc_info) in enumerate(
             zip(local_mappings, committed_allocations)
         ):
@@ -625,12 +855,20 @@ class GMSClientMemoryManager:
                     f"Layout rank {rank} tag changed: {mapping.tag} vs {alloc_info.tag}"
                 )
 
+            exported_at = time.perf_counter()
             fd = self.export_handle(alloc_info.allocation_id)
+            imported_at = time.perf_counter()
             handle = self._vmm.import_shareable_handle_close_fd(fd)
+            mapped_at = time.perf_counter()
             self._vmm.map(va, mapping.aligned_size, handle)
+            access_at = time.perf_counter()
             self._vmm.set_access(
                 va, mapping.aligned_size, self.device, self._granted_lock_type
             )
+            export_s += imported_at - exported_at
+            import_s += mapped_at - imported_at
+            map_s += access_at - mapped_at
+            access_s += time.perf_counter() - access_at
             remapped_vas.append(va)
 
             if mapping.allocation_id != alloc_info.allocation_id:
@@ -643,19 +881,32 @@ class GMSClientMemoryManager:
             remapped_count += 1
             total_bytes += mapping.aligned_size
 
+        loop_s = time.perf_counter() - loop_started
+        validate_started = time.perf_counter()
         if remapped_vas:
             self._vmm.synchronize()
             for va in remapped_vas:
                 self._vmm.validate_pointer(va)
+        validate_s = time.perf_counter() - validate_started
 
         self._va_preserved = False
         self._unmapped = False
+        # Wake latency is an SLO for shadow failover and is dominated by the
+        # per-allocation export round trip, so log the split, not just a total.
         logger.info(
             "[GPU Memory Service] Remap complete on device %d: "
-            "remapped %d allocations (%.2f GiB)",
+            "remapped %d allocations (%.2f GiB) in %.2fs "
+            "(export %.2fs, import %.2fs, map %.2fs, access %.2fs, "
+            "validate %.2fs)",
             self.device,
             remapped_count,
             total_bytes / (1 << 30),
+            loop_s + validate_s,
+            export_s,
+            import_s,
+            map_s,
+            access_s,
+            validate_s,
         )
 
     def reallocate_all_handles(self, tag: str = "default") -> None:
@@ -673,6 +924,7 @@ class GMSClientMemoryManager:
             )
 
         reallocated = 0
+        started = time.perf_counter()
         for va, mapping in sorted(
             self._mappings.items(), key=lambda item: item[1].layout_slot
         ):
@@ -697,8 +949,10 @@ class GMSClientMemoryManager:
             reallocated += 1
 
         logger.info(
-            "[GPU Memory Service] Reallocated %d handles for preserved VAs",
+            "[GPU Memory Service] Reallocated %d handles for preserved VAs "
+            "in %.2fs",
             reallocated,
+            time.perf_counter() - started,
         )
 
     # ==================== Scratch-aliased mappings ====================
@@ -892,6 +1146,8 @@ class GMSClientMemoryManager:
             self._inverse_mapping.clear()
             self._scratch_mappings.clear()
             self._shared_scratch_handle = 0
+            self._slabs.clear()
+            self._regions.clear()
         else:
             self._vmm.synchronize()
             for base_va in list(self._scratch_mappings.keys()):
@@ -900,6 +1156,8 @@ class GMSClientMemoryManager:
                 self.unmap_va(va)
                 self.free_va(va)
             self.abort()
+            self._slabs.clear()
+            self._regions.clear()
         self._unmapped = False
         self._va_preserved = False
         from gpu_memory_service.client.torch.allocator import (

--- a/lib/gpu_memory_service/client/torch/allocator.py
+++ b/lib/gpu_memory_service/client/torch/allocator.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -39,6 +40,26 @@ _active_tag: ContextVar[str | None] = ContextVar(
 _callbacks_initialized = False
 _pluggable_alloc: Any | None = None
 
+# Torch drives one malloc per caching-allocator segment through us, and every
+# resulting server allocation costs ~15 ms to re-import when a sleeping engine
+# wakes (export round trip + cuMemImport + cuMemSetAccess; cuMemMap is free).
+# Packing those mallocs into a few large slabs is what keeps wake proportional
+# to the weight set rather than to the segment count: GLM-5.2 TP8 goes from 585
+# allocations to ~28, and weights remap from ~8.7 s to well under a second.
+#
+# The cost is committed memory: a slab is allocated whole, so its unused tail
+# stays resident. Set DYN_GMS_SLAB_SIZE=0 to go back to one server allocation
+# per malloc.
+DEFAULT_SLAB_SIZE = 2 * 1024 * 1024 * 1024
+
+
+def _slab_size_for(tag: str) -> int:
+    """Slab size for a tag's mempool, overridable via DYN_GMS_SLAB_SIZE."""
+    raw = os.environ.get("DYN_GMS_SLAB_SIZE")
+    if raw is None or raw == "":
+        return DEFAULT_SLAB_SIZE
+    return int(raw)
+
 
 def _gms_malloc(size: int, device: int, stream: int) -> int:
     # Tag-context dispatch: the active tag (set by gms_use_mem_pool) selects
@@ -70,10 +91,10 @@ def _gms_free(ptr: int, size: int, device: int, stream: int) -> None:
             logger.debug("[GMS] scratch free(tag=%s): va=0x%x size=%d", tag, va, size)
             return
     for tag, state in _tag_states.items():
-        if va not in state.manager.mappings:
+        if not state.manager.owns(va):
             continue
         logger.debug("[GMS] free(tag=%s): va=0x%x size=%d", tag, va, size)
-        state.manager.destroy_mapping(va)
+        state.manager.destroy_mapping(va, int(size))
         return
     logger.warning("[GMS] free: no manager owns va=0x%x, ignoring", va)
 
@@ -152,7 +173,9 @@ def get_or_create_gms_client_memory_manager(
             )
         return state.manager
 
-    manager = GMSClientMemoryManager(socket_path, device=device, tag=tag)
+    manager = GMSClientMemoryManager(
+        socket_path, device=device, tag=tag, slab_size=_slab_size_for(tag)
+    )
     manager.connect(mode, timeout_ms=timeout_ms)
 
     # Mempool only when we have RW: the pluggable allocator routes torch
@@ -264,62 +287,52 @@ def get_gms_client_memory_managers() -> tuple["GMSClientMemoryManager", ...]:
     return tuple(state.manager for state in _tag_states.values())
 
 
-def prune_allocations(
-    manager: "GMSClientMemoryManager",
-    *,
-    referenced_allocation_ids: set[str],
-    synchronize: bool = True,
-) -> None:
-    """Free GMS allocations that are not in an explicit torch keep-set.
+def release_weight_mempool(manager: "GMSClientMemoryManager") -> None:
+    """Drop the tag's MemPool so torch returns its dead blocks to GMS.
 
-    Callers provide the allocation IDs that remain valid; this helper does not
-    infer liveness from Python GC.  Weight loaders call it after registering
-    module tensors, treating other allocations as load-time scratch/cache that
-    PyTorch's caching allocator may leave behind because ``empty_cache()`` is a
-    no-op while live GMS mempool mappings exist.
+    This is how load-time scratch is reclaimed. PyTorch's caching allocator
+    holds freed blocks instead of handing them back, and ``empty_cache()`` is
+    a no-op while live GMS mempool mappings exist, so the blocks are only
+    released when the pool itself is destroyed: torch then calls the free
+    callback for every cached, unreferenced block. Blocks still owned by live
+    Parameter storage stay mapped and become the committed weight set.
 
-    Args:
-        manager: GMS manager whose local mappings should be pruned.
-        referenced_allocation_ids: Allocation IDs that must remain mapped and
-            committed.
-        synchronize: Synchronize CUDA before freeing unreferenced mappings.  The
-            default avoids freeing a block while prior GPU work may still be
-            using it.  Callers that have already synchronized can pass
-            ``False``.
+    Reclaim therefore happens at torch-block granularity, which is what slab
+    packing needs -- a keep-set of allocation IDs could only free whole server
+    allocations, and one live tensor would pin an entire slab.
 
+    The pool is not needed again: after publication the manager serves the
+    weights read-only.
     """
-    if manager.granted_lock_type != GrantedLockType.RW or manager.is_unmapped:
+    if manager.tag is None:
+        raise RuntimeError("cannot release the mempool of an untagged manager")
+    state = _tag_states.get(manager.tag)
+    if state is None or state.mem_pool is None:
         return
 
-    if not any(mapping.handle != 0 for mapping in manager.mappings.values()):
-        return
+    from gpu_memory_service.integrations.common.utils import torch_device
 
-    if synchronize:
-        from gpu_memory_service.integrations.common.utils import torch_device
+    torch_device().synchronize(manager.device)
 
-        torch_device().synchronize(manager.device)
+    before_bytes = manager.total_bytes
+    before_count = len(manager.mappings)
 
-    keep = {str(allocation_id) for allocation_id in referenced_allocation_ids}
+    import gc
 
-    pruned_allocations = 0
-    pruned_bytes = 0
-    for va, mapping in list(manager.mappings.items()):
-        if str(mapping.allocation_id) in keep:
-            continue
-        if mapping.handle == 0:
-            continue
-        pruned_allocations += 1
-        pruned_bytes += int(mapping.aligned_size)
-        manager.destroy_mapping(va)
+    mem_pool = state.mem_pool
+    state.mem_pool = None
+    del mem_pool
+    gc.collect()
 
-    if pruned_allocations:
-        logger.info(
-            "[GMS] Pruned %d unreferenced allocations (%.2f GiB); "
-            "kept %d registered allocations",
-            pruned_allocations,
-            pruned_bytes / (1 << 30),
-            len(keep),
-        )
+    logger.info(
+        "[GMS] Released the %s mempool: %d -> %d allocations, "
+        "%.2f -> %.2f GiB live",
+        manager.tag,
+        before_count,
+        len(manager.mappings),
+        before_bytes / (1 << 30),
+        manager.total_bytes / (1 << 30),
+    )
 
 
 def evict_gms_client_memory_manager(manager: "GMSClientMemoryManager") -> None:

--- a/lib/gpu_memory_service/client/torch/module.py
+++ b/lib/gpu_memory_service/client/torch/module.py
@@ -90,6 +90,87 @@ def _iter_module_tensors(
             yield from _iter_module_tensors(submodule, subprefix)
 
 
+_MLA_SCALE_LEAVES = frozenset({"q_scale", "k_scale", "v_scale", "prob_scale"})
+
+# Buffers that several modules share on purpose, as a communication channel
+# rather than as private state. Cloning these per published name severs the
+# link between producer and consumer.
+_SHARED_CHANNEL_LEAVES = frozenset({"topk_indices_buffer"})
+
+# Tensors vLLM caches on plain (non-``nn.Module``) helper objects as aliases
+# of the owning module's tensor. Name-keyed materialization cannot reach
+# them, so ``_repoint_non_module_tensor_caches`` re-establishes the alias --
+# but only for these, since a same-name match is not by itself evidence of
+# an intended alias.
+_REPOINTED_CACHE_LEAVES = frozenset(
+    {
+        # `MLAAttention.impl` -- consumer end of the DSA top-k channel.
+        "topk_indices_buffer",
+        # `FusedMoE.expert_map_manager` -- MoE expert routing map.
+        "_expert_map",
+    }
+)
+
+
+def _tensor_in_gms_mappings(
+    gms_client_memory_manager: "GMSClientMemoryManager",
+    tensor: torch.Tensor,
+) -> bool:
+    ptr = int(tensor.data_ptr())
+    return any(
+        va <= ptr < va + mapping.aligned_size
+        for va, mapping in gms_client_memory_manager.mappings.items()
+    )
+
+
+def _bind_module_tensor(
+    model: torch.nn.Module,
+    name: str,
+    tensor: torch.Tensor,
+    tensor_type: str,
+) -> None:
+    """Write ``tensor`` onto ``model`` at ``name``.
+
+    If the destination is already a Parameter, replace the Parameter even
+    when the GMS spec called it a tensor_attr. GLM MLA q/k/v/prob scales
+    are Parameters on the RO meta model and plain CUDA tensors on the
+    writer; treating the spec type as gospel left the Parameter on meta
+    and zero-filled it.
+    """
+    mod, attr = _resolve_module_attr(model, name)
+    if hasattr(mod, "_parameters") and attr in mod._parameters:
+        param = mod._parameters[attr]
+        requires_grad = bool(param.requires_grad) if param is not None else False
+        mod._parameters[attr] = torch.nn.Parameter(tensor, requires_grad=requires_grad)
+        return
+    if (
+        tensor_type == "buffer"
+        and hasattr(mod, "_buffers")
+        and attr in mod._buffers
+    ):
+        mod._buffers[attr] = tensor
+        return
+    if attr.isdigit() and not isinstance(mod, torch.nn.Module):
+        if isinstance(mod, list):
+            mod[int(attr)] = tensor
+            return
+        if isinstance(mod, tuple):
+            container_name, _ = name.rsplit(".", 1)
+            owner, container_attr = _resolve_module_attr(model, container_name)
+            if isinstance(getattr(type(owner), container_attr, None), property):
+                return
+            elements = list(mod)
+            elements[int(attr)] = tensor
+            setattr(owner, container_attr, tuple(elements))
+            return
+        logger.debug("[GMS] Cannot bind container element %r", name)
+        return
+    if isinstance(getattr(type(mod), attr, None), property):
+        logger.debug("[GMS] Skipping property attribute %r", name)
+        return
+    setattr(mod, attr, tensor)
+
+
 def _resolve_module_attr(
     root: torch.nn.Module, qualified_name: str
 ) -> Tuple[torch.nn.Module, str]:
@@ -159,6 +240,134 @@ def register_module_tensors(
     return referenced_allocation_ids
 
 
+def _repoint_non_module_tensor_caches(model: torch.nn.Module) -> None:
+    """Repoint tensors cached on plain objects hanging off the model.
+
+    Materialization binds tensors by qualified name, which only reaches
+    what ``named_modules`` walks. vLLM also caches tensors on plain
+    objects -- ``MLAAttention.impl`` is an ``AttentionImpl``, not an
+    ``nn.Module`` -- and those keep whatever the meta constructor
+    produced. The DSA top-k channel shows the failure clearly: the
+    indexer writes its indices into the layer's materialized
+    ``topk_indices_buffer`` while ``impl`` still reads its own
+    uninitialized one, so attention scores against arbitrary KV slots.
+
+    The repair is deliberately restricted to ``_REPOINTED_CACHE_LEAVES``.
+    Matching on attribute name alone is not evidence of an intended
+    alias -- a helper object may hold its own ``weight`` or ``scale`` --
+    and silently rebinding serving state on a false positive would be a
+    correctness bug. Add a leaf here only with evidence that vLLM
+    constructs it as an alias of the module's tensor.
+
+    The writer avoids needing this by swapping storage under the existing
+    TensorImpl (see ``rebind_nonparameter_tensors``). The reader cannot:
+    it starts from a meta model, and PyTorch rejects both ``set_`` and
+    ``.data =`` when they would move a tensor off the meta device, so
+    materialization has to bind new objects and then repair the holders.
+    """
+    repointed: list[str] = []
+    for mod_name, module in model.named_modules():
+        for holder_attr, holder in list(vars(module).items()):
+            if holder is None or isinstance(holder, (torch.nn.Module, torch.Tensor)):
+                continue
+            holder_vars = getattr(holder, "__dict__", None)
+            if not holder_vars:
+                continue
+            for attr in _REPOINTED_CACHE_LEAVES & holder_vars.keys():
+                current = holder_vars[attr]
+                if not torch.is_tensor(current):
+                    continue
+                # Prefer the layer's own indexer: vLLM sources the sparse
+                # buffers from there (sparse_mla_attention.py binds
+                # `indexer.topk_indices_buffer`), else the module itself.
+                replacement = None
+                for source in (getattr(module, "indexer", None), module):
+                    if source is None or source is holder:
+                        continue
+                    cand = getattr(source, attr, None)
+                    if torch.is_tensor(cand):
+                        replacement = cand
+                        break
+                if replacement is None or replacement is current:
+                    continue
+                if (
+                    replacement.shape != current.shape
+                    or replacement.dtype != current.dtype
+                ):
+                    continue
+                if (
+                    not current.is_meta
+                    and replacement.data_ptr() == current.data_ptr()
+                ):
+                    continue
+                setattr(holder, attr, replacement)
+                repointed.append(f"{mod_name}.{holder_attr}.{attr}")
+    if repointed:
+        logger.info(
+            "[GMS] Re-pointed %d tensors cached on non-Module objects: %s",
+            len(repointed),
+            repointed[:6],
+        )
+
+
+def _shared_clone(
+    cache: dict[tuple[str, int], torch.Tensor],
+    alias_counts: dict[tuple[str, int], int],
+    spec: "GMSTensorSpec",
+    tensor: torch.Tensor,
+) -> torch.Tensor:
+    """Clone ``tensor`` off GMS memory, reusing one clone per location.
+
+    vLLM shares a single storage across several module paths, and GMS
+    publishes one key per path. Cloning each key separately hands every
+    alias a private copy, which silently severs buffers that are shared on
+    purpose -- notably ``topk_indices_buffer``, the channel by which the
+    DSA indexer passes top-k indices to sparse attention.
+
+    Unaliased tensors keep the plain per-name clone. Aliased ones are
+    cloned once and every name gets a view carrying its own shape and
+    stride, so the data lives off the VMM mapping and names that shared
+    storage on the writer still share it here.
+
+    Scope: this preserves aliases that start at the *same* published
+    location, which is what the keying ``(allocation_id, offset_bytes)``
+    expresses. Views of one writer storage at different byte offsets are
+    published as different locations and are not rejoined -- the metadata
+    does not carry source-storage identity. Aliases at one location must
+    also agree on dtype and fit the first-seen extent, since the shared
+    clone is created from whichever alias arrives first; both are asserted
+    rather than left to silently produce a wrong view.
+    """
+    loc = (spec.allocation_id, spec.offset_bytes)
+    if alias_counts.get(loc, 1) <= 1:
+        return tensor.detach().clone()
+
+    base = cache.get(loc)
+    if base is None:
+        # Clone the whole storage this location spans so every aliased view
+        # (which may be longer or differently strided than `tensor`) stays
+        # in range.
+        storage_elems = tensor.untyped_storage().size() // tensor.element_size()
+        base = torch.as_strided(tensor, (storage_elems,), (1,), 0).detach().clone()
+        cache[loc] = base
+    if base.dtype != tensor.dtype:
+        raise ValueError(
+            f"GMS aliases at {loc} disagree on dtype "
+            f"({base.dtype} vs {tensor.dtype}); cannot share one clone"
+        )
+    span = tensor.storage_offset() + sum(
+        (d - 1) * s for d, s in zip(tensor.shape, tensor.stride())
+    )
+    if span >= base.numel():
+        raise ValueError(
+            f"GMS alias at {loc} spans {span + 1} elements but the shared "
+            f"clone holds {base.numel()}"
+        )
+    return torch.as_strided(
+        base, tuple(tensor.shape), tuple(tensor.stride()), tensor.storage_offset()
+    )
+
+
 def materialize_module_from_gms(
     gms_client_memory_manager: "GMSClientMemoryManager",
     model: torch.nn.Module,
@@ -174,53 +383,198 @@ def materialize_module_from_gms(
     """
     specs = GMSTensorSpec.load_all(gms_client_memory_manager)
 
+    # vLLM shares one storage across several module paths: `W_UK_T`/`W_UV`
+    # are views into `kv_b_proj.weight` (process_weights_after_loading uses
+    # replace_parameter(prefer_copy=True), which keeps the storage address),
+    # and one `cos_sin_cache` / `topk_indices_buffer` is referenced by every
+    # layer. `materialize` already applies each name's own shape and stride
+    # over the shared address, so the views themselves are right -- but the
+    # buffer/tensor_attr branch below used to `.clone()` every name, which
+    # hands each alias a private copy. For a producer/consumer channel such
+    # as `topk_indices_buffer` that severs the link: the DSA indexer writes
+    # its top-k indices into one copy while attention reads another.
+    #
+    # Count how many names map to each physical location so shared ones can
+    # keep aliasing instead of being cloned apart.
+    alias_counts: dict[tuple[str, int], int] = {}
+    for _spec in specs.values():
+        _loc = (_spec.allocation_id, _spec.offset_bytes)
+        alias_counts[_loc] = alias_counts.get(_loc, 0) + 1
+
+    # One clone per shared location, reused by every name that maps to it.
+    # Cloning is what moves a buffer off the GMS VMM mapping (Triton and
+    # some CUDA kernels illegal-address against VMM), so the clone must
+    # stay -- but it has to be made once and shared, not once per name.
+    shared_clones: dict[tuple[str, int], torch.Tensor] = {}
+
+    n_shared = sum(1 for v in alias_counts.values() if v > 1)
+    if n_shared:
+        logger.info(
+            "[GMS] Preserving aliasing for %d shared locations "
+            "(%d of %d published names)",
+            n_shared,
+            sum(v for v in alias_counts.values() if v > 1),
+            len(specs),
+        )
+
     for name, spec in specs.items():
         tensor = spec.materialize(gms_client_memory_manager, device_index)
-        mod, attr = _resolve_module_attr(model, name)
+        try:
+            mod, attr = _resolve_module_attr(model, name)
+        except AttributeError:
+            logger.warning(
+                "[GMS] Cannot resolve %s on RO model; attaching at root skip",
+                name,
+            )
+            continue
         tensor_type = spec.meta.tensor_type
 
-        # Tensor attrs and buffers: clone since they may be mutated
+        # Parameters first: writer may have registered MLA scales as
+        # tensor_attr while the RO meta model holds them as Parameters.
+        if hasattr(mod, "_parameters") and attr in mod._parameters:
+            param = mod._parameters[attr]
+            if param is not None:
+                if param.shape != tensor.shape or param.dtype != tensor.dtype:
+                    logger.warning(
+                        "[GMS] Replacing %s: param=%s/%s -> gms=%s/%s",
+                        name,
+                        tuple(param.shape),
+                        param.dtype,
+                        tuple(tensor.shape),
+                        tensor.dtype,
+                    )
+                payload = (
+                    _shared_clone(shared_clones, alias_counts, spec, tensor)
+                    if tensor_type in ("tensor_attr", "buffer")
+                    else tensor
+                )
+                mod._parameters[attr] = torch.nn.Parameter(
+                    payload, requires_grad=param.requires_grad
+                )
+            continue
+
+        # Tensor attrs and buffers: clone since they may be mutated, and
+        # because the clone is what lifts them off the GMS VMM mapping.
+        # Skip read-only properties (e.g. MoERunner.expert_map) that vLLM
+        # exposes via getattr during write-side registration.
         if tensor_type in ("tensor_attr", "buffer"):
+            cloned = _shared_clone(shared_clones, alias_counts, spec, tensor)
             if (
                 tensor_type == "buffer"
                 and hasattr(mod, "_buffers")
                 and attr in mod._buffers
             ):
-                mod._buffers[attr] = tensor.detach().clone()
+                mod._buffers[attr] = cloned
             else:
-                setattr(mod, attr, tensor.detach().clone())
+                try:
+                    setattr(mod, attr, cloned)
+                except (AttributeError, TypeError):
+                    logger.debug(
+                        "[GMS] Skipping unsettable %s %r on %s",
+                        tensor_type,
+                        name,
+                        type(mod).__name__,
+                    )
             continue
-
-        # Parameters: in-place update or replace meta tensors
-        if hasattr(mod, "_parameters") and attr in mod._parameters:
-            param = mod._parameters[attr]
-            if param is not None:
-                if param.shape != tensor.shape or param.dtype != tensor.dtype:
-                    raise RuntimeError(
-                        f"Shape/dtype mismatch for {name}: "
-                        f"param={tuple(param.shape)}/{param.dtype}, "
-                        f"gms={tuple(tensor.shape)}/{tensor.dtype}"
-                    )
-                if param.is_meta or param.device != tensor.device:
-                    mod._parameters[attr] = torch.nn.Parameter(
-                        tensor, requires_grad=param.requires_grad
-                    )
-                else:
-                    param.data = tensor
-                continue
 
         # Fallback: set as attribute
         setattr(mod, attr, tensor)
 
-    # Check for meta tensors and warn
-    meta_tensors = [n for n, p in model.named_parameters() if p.is_meta]
-    meta_tensors += [n for n, b in model.named_buffers() if b.is_meta]
-    if meta_tensors:
+    _repoint_non_module_tensor_caches(model)
+
+    # Leftover meta params/buffers were never in the writer's GMS layout: the
+    # writer registers the MLA scales under their `_`-prefixed buffer names,
+    # so the reader's `q_scale`/`k_scale`/`v_scale`/`prob_scale` Parameters
+    # find no match. They have to leave the meta device -- dummy profile_run
+    # and kernel warmup illegal-address otherwise -- and the fill value is
+    # load-bearing. A scale is a multiplicative factor, so its neutral value
+    # is 1.0, which is also what vLLM's `set_default_quant_scales` uses when
+    # a checkpoint carries no calibrated scale. Zero-filling instead silently
+    # scales attention to nothing. `init_fp8_kv_scales` masks half of it on
+    # wake by resetting `k_scale`/`v_scale` to 1.0, which is why only
+    # `q_scale` and `prob_scale` stayed at zero and the damage looked like a
+    # gradual quality decay rather than an outright failure.
+    device = torch.device(f"cuda:{device_index}")
+    filled: list[str] = []
+
+    def _neutral(name: str, shape, dtype) -> torch.Tensor:
+        leaf = name.rsplit(".", 1)[-1].lstrip("_")
+        value = 1.0 if leaf in _MLA_SCALE_LEAVES else 0.0
+        return torch.full(shape, value, dtype=dtype, device=device)
+
+    for name, param in list(model.named_parameters()):
+        if not param.is_meta:
+            continue
+        try:
+            mod, attr = _resolve_module_attr(model, name)
+        except AttributeError:
+            continue
+        if hasattr(mod, "_parameters") and attr in mod._parameters:
+            mod._parameters[attr] = torch.nn.Parameter(
+                _neutral(name, param.shape, param.dtype),
+                requires_grad=param.requires_grad,
+            )
+            filled.append(name)
+    for name, buf in list(model.named_buffers()):
+        if not buf.is_meta:
+            continue
+        try:
+            mod, attr = _resolve_module_attr(model, name)
+        except AttributeError:
+            continue
+        if hasattr(mod, "_buffers") and attr in mod._buffers:
+            mod._buffers[attr] = _neutral(name, buf.shape, buf.dtype)
+            filled.append(name)
+    if filled:
         logger.warning(
-            "[GMS] %d meta tensors not in metadata: %s",
-            len(meta_tensors),
-            meta_tensors[:10],
+            "[GMS] Materialized %d leftover meta tensors to neutral values: %s",
+            len(filled),
+            filled[:10],
         )
+
+
+def copy_unmapped_tensors_into_gms(
+    gms_client_memory_manager: "GMSClientMemoryManager",
+    model: torch.nn.Module,
+    *,
+    leaves: frozenset[str] = _MLA_SCALE_LEAVES,
+) -> int:
+    """Clone CUDA tensors that missed the GMS pool into the active mempool.
+
+    Must run under ``gms_use_mem_pool("weights")`` so the clone lands in a
+    GMS allocation and ``prepare_gms_write`` can register it. GLM MLA
+    q/k/v/prob scales are allocated by ``process_weights_after_loading``
+    outside the pool; without this, RO import zero-fills 312 leftover
+    Parameters.
+    """
+    copied: list[str] = []
+    seen: set[str] = set()
+    for name, tensor, tensor_type in list(_iter_module_tensors(model)):
+        if name.rsplit(".", 1)[-1] not in leaves:
+            continue
+        seen.add(name)
+        if _tensor_in_gms_mappings(gms_client_memory_manager, tensor):
+            continue
+        gms_copy = tensor.detach().contiguous().clone()
+        _bind_module_tensor(model, name, gms_copy, tensor_type)
+        copied.append(name)
+    for name, param in list(model.named_parameters()):
+        if name in seen or param is None or not param.is_cuda:
+            continue
+        if name.rsplit(".", 1)[-1] not in leaves:
+            continue
+        if _tensor_in_gms_mappings(gms_client_memory_manager, param):
+            continue
+        gms_copy = param.detach().contiguous().clone()
+        _bind_module_tensor(model, name, gms_copy, "parameter")
+        copied.append(name)
+    if copied:
+        logger.info(
+            "[GMS] Copied %d tensors into the GMS pool for publish: %s",
+            len(copied),
+            copied[:8],
+        )
+    return len(copied)
 
 
 def rebind_nonparameter_tensors(
@@ -229,76 +583,89 @@ def rebind_nonparameter_tensors(
     *,
     retain_gms_tensors: list[torch.Tensor] | None = None,
 ) -> int:
-    """Re-bind GMS-resident non-parameter tensors to private clones.
+    """Move GMS-resident non-parameter tensors onto private storage.
 
     The publisher builds the whole model inside the GMS memory pool, so
     buffers and tensor attributes (fp8 KV scales, quantization ranges, ...)
     land in the same committed allocations as the weights, which are
     remapped read-only after publish. Unlike parameters, these tensors can
     be written after load (for example ``init_fp8_kv_scales`` on wake),
-    which faults on the read-only mapping. Cloning them into ordinary CUDA
-    memory gives the publisher the same binding semantics importers get
-    from ``materialize_module_from_gms``: parameters stay on the shared
-    read-only mapping, everything else is private and writable. The GMS
-    copies stay registered so importers can still materialize from them.
+    which faults on the read-only mapping.
 
-    Must run before CUDA graph capture: the clones live at new addresses.
+    The swap is done **in place** with ``Tensor.set_``, one private storage
+    per source storage. Rebinding by name instead -- assigning freshly
+    cloned tensors back onto module attributes -- looks equivalent but is
+    not: vLLM caches some of these tensors on plain objects that module
+    traversal never visits. ``MLAAttention.impl`` is not an ``nn.Module``,
+    and it holds the consumer end of the DSA ``topk_indices_buffer``
+    channel, so a name-based rebind leaves the indexer writing top-k
+    indices into the new buffer while attention keeps reading the old one.
+    Swapping storage under the existing TensorImpl makes every holder
+    follow, including the ones that cannot be enumerated.
+
+    Must run before CUDA graph capture: the private storage is at a new
+    address.
 
     Returns the number of bytes rebound, i.e. how much memory is duplicated
-    between the read-only GMS copies and the private clones.
+    between the read-only GMS copies and the private storage.
 
-    If ``retain_gms_tensors`` is provided, the original GMS-backed tensors
-    are appended to it. A deferred writer that rebinds before commit must
-    keep those references alive so the underlying GMS pool allocations are
-    not freed before the layout is published.
+    If ``retain_gms_tensors`` is provided, copies of the original
+    GMS-backed tensors are appended to it. A deferred writer that rebinds
+    before commit must keep those alive so the underlying GMS pool
+    allocations are not freed before the layout is published.
     """
     mappings = gms_client_memory_manager.mappings
-    rebound_bytes = 0
+
+    def _in_gms(t: torch.Tensor) -> bool:
+        ptr = int(t.data_ptr())
+        return any(
+            va <= ptr < va + m.aligned_size for va, m in mappings.items()
+        )
+
+    # Collect the GMS-resident non-parameter tensors, grouped by storage.
+    # Rebinding must preserve TensorImpl identity: vLLM caches some of
+    # these on plain (non-Module) objects -- notably
+    # `MLAAttention.impl.topk_indices_buffer`, the consumer end of the DSA
+    # top-k channel -- which no name-based traversal can reach. Swapping
+    # each tensor's storage in place makes every holder follow, including
+    # the ones we cannot see.
+    by_storage: dict[int, list[torch.Tensor]] = {}
     for name, tensor, tensor_type in list(_iter_module_tensors(model)):
         if tensor_type == "parameter":
             continue
-        ptr = int(tensor.data_ptr())
-        if not any(
-            va <= ptr < va + mapping.aligned_size for va, mapping in mappings.items()
-        ):
+        if not _in_gms(tensor):
             # Allocated outside the GMS pool; already private.
             continue
+        by_storage.setdefault(int(tensor.untyped_storage()._cdata), []).append(
+            tensor
+        )
 
-        mod, attr = _resolve_module_attr(model, name)
-        if (
-            tensor_type == "buffer"
-            and hasattr(mod, "_buffers")
-            and attr in mod._buffers
-        ):
-            mod._buffers[attr] = tensor.detach().clone()
-        elif attr.isdigit() and not isinstance(mod, torch.nn.Module):
-            # Element of a tensor list/tuple attribute.
-            if isinstance(mod, list):
-                mod[int(attr)] = tensor.detach().clone()
-            elif isinstance(mod, tuple):
-                # Tuples are immutable: rebuild the tuple on its owner.
-                container_name, _ = name.rsplit(".", 1)
-                owner, container_attr = _resolve_module_attr(model, container_name)
-                if isinstance(getattr(type(owner), container_attr, None), property):
-                    # Read-only derived attribute; the underlying tensors
-                    # are iterated (and rebound) separately.
-                    logger.debug("[GMS] Skipping property attribute %r", name)
-                    continue
-                elements = list(mod)
-                elements[int(attr)] = tensor.detach().clone()
-                setattr(owner, container_attr, tuple(elements))
-            else:
-                logger.debug("[GMS] Cannot rebind container element %r", name)
-                continue
-        else:
-            if isinstance(getattr(type(mod), attr, None), property):
-                # Read-only derived attribute; the underlying tensor is
-                # iterated (and rebound) separately.
-                logger.debug("[GMS] Skipping property attribute %r", name)
-                continue
-            setattr(mod, attr, tensor.detach().clone())
-        if retain_gms_tensors is not None:
-            retain_gms_tensors.append(tensor)
-        rebound_bytes += tensor.numel() * tensor.element_size()
+    rebound_bytes = 0
+    with torch.inference_mode():
+        for tensors in by_storage.values():
+            src = tensors[0].untyped_storage()
+            if retain_gms_tensors is not None:
+                # Keep the GMS storage alive for the deferred publish. This
+                # must be a tensor that still points AT `src`: once every
+                # live TensorImpl has been redirected by `set_` below, this
+                # byte view is the only remaining owner. Cloning instead
+                # would retain a private copy and let the pool allocation go.
+                retain_gms_tensors.append(
+                    torch.empty(0, dtype=torch.uint8, device=tensors[0].device)
+                    .set_(src, 0, (src.size(),), (1,))
+                )
+            private = torch.empty(
+                src.size(), dtype=torch.uint8, device=tensors[0].device
+            )
+            private.untyped_storage().copy_(src)
+            dst = private.untyped_storage()
+            for t in tensors:
+                t.set_(
+                    dst,
+                    int(t.storage_offset()),
+                    tuple(t.shape),
+                    tuple(t.stride()),
+                )
+            rebound_bytes += src.size()
 
     return rebound_bytes

--- a/lib/gpu_memory_service/client/torch/module.py
+++ b/lib/gpu_memory_service/client/torch/module.py
@@ -99,7 +99,7 @@ _SHARED_CHANNEL_LEAVES = frozenset({"topk_indices_buffer"})
 
 # Tensors vLLM caches on plain (non-``nn.Module``) helper objects as aliases
 # of the owning module's tensor. Name-keyed materialization cannot reach
-# them, so ``_repoint_non_module_tensor_caches`` re-establishes the alias --
+# them, so ``repoint_non_module_tensor_caches`` re-establishes the alias --
 # but only for these, since a same-name match is not by itself evidence of
 # an intended alias.
 _REPOINTED_CACHE_LEAVES = frozenset(
@@ -240,7 +240,7 @@ def register_module_tensors(
     return referenced_allocation_ids
 
 
-def _repoint_non_module_tensor_caches(model: torch.nn.Module) -> None:
+def repoint_non_module_tensor_caches(model: torch.nn.Module) -> None:
     """Repoint tensors cached on plain objects hanging off the model.
 
     Materialization binds tensors by qualified name, which only reaches
@@ -259,12 +259,42 @@ def _repoint_non_module_tensor_caches(model: torch.nn.Module) -> None:
     correctness bug. Add a leaf here only with evidence that vLLM
     constructs it as an alias of the module's tensor.
 
+    Sources are tried in the order vLLM itself binds them
+    (``sparse_mla_attention.py``: ``indexer.topk_indices_buffer if indexer
+    is not None else topk_indices_buffer``). For the leaves in
+    ``_SHARED_CHANNEL_LEAVES`` the model holds exactly one buffer for the
+    whole network, so it is resolved globally rather than per module. That
+    is load-bearing, not defensive: in GLM-5.2 only 21 of 78 MLA layers
+    own an indexer. The other 57 are ``skip_topk`` backbone layers that
+    reuse the buffer an earlier layer wrote, and they receive it as a
+    constructor argument (``deepseek_v2.py`` builds it as a *local* and
+    passes it down, never storing it on the model). Nothing reachable by
+    name holds it for those layers, so a per-module lookup repairs the 21
+    producers and leaves all 57 consumers pointed at the buffer meta
+    construction allocated -- which, because the model asks for
+    ``device="cuda"`` explicitly, is real but uninitialised memory that no
+    one ever writes. Below ``index_topk`` every token is selected and the
+    garbage is invisible; above it, 57 of 78 layers attend to arbitrary KV
+    slots.
+
     The writer avoids needing this by swapping storage under the existing
     TensorImpl (see ``rebind_nonparameter_tensors``). The reader cannot:
     it starts from a meta model, and PyTorch rejects both ``set_`` and
     ``.data =`` when they would move a tensor off the meta device, so
     materialization has to bind new objects and then repair the holders.
     """
+    # The one buffer per model that the shared channels use. Materialization
+    # rebound it on every module that holds it by name, so any of those is
+    # the canonical post-materialize copy.
+    shared: dict[str, torch.Tensor] = {}
+    for _n, module in model.named_modules():
+        for leaf in _SHARED_CHANNEL_LEAVES:
+            if leaf in shared:
+                continue
+            cand = getattr(module, leaf, None)
+            if torch.is_tensor(cand) and not cand.is_meta:
+                shared[leaf] = cand
+
     repointed: list[str] = []
     for mod_name, module in model.named_modules():
         for holder_attr, holder in list(vars(module).items()):
@@ -277,17 +307,15 @@ def _repoint_non_module_tensor_caches(model: torch.nn.Module) -> None:
                 current = holder_vars[attr]
                 if not torch.is_tensor(current):
                     continue
-                # Prefer the layer's own indexer: vLLM sources the sparse
-                # buffers from there (sparse_mla_attention.py binds
-                # `indexer.topk_indices_buffer`), else the module itself.
-                replacement = None
-                for source in (getattr(module, "indexer", None), module):
-                    if source is None or source is holder:
-                        continue
-                    cand = getattr(source, attr, None)
-                    if torch.is_tensor(cand):
-                        replacement = cand
-                        break
+                replacement = shared.get(attr)
+                if replacement is None:
+                    for source in (getattr(module, "indexer", None), module):
+                        if source is None or source is holder:
+                            continue
+                        cand = getattr(source, attr, None)
+                        if torch.is_tensor(cand):
+                            replacement = cand
+                            break
                 if replacement is None or replacement is current:
                     continue
                 if (
@@ -479,8 +507,6 @@ def materialize_module_from_gms(
 
         # Fallback: set as attribute
         setattr(mod, attr, tensor)
-
-    _repoint_non_module_tensor_caches(model)
 
     # Leftover meta params/buffers were never in the writer's GMS layout: the
     # writer registers the MLA scales under their `_`-prefixed buffer names,

--- a/lib/gpu_memory_service/common/vmm/cuda_utils.py
+++ b/lib/gpu_memory_service/common/vmm/cuda_utils.py
@@ -168,13 +168,34 @@ def cumem_map(va: int, size: int, handle: int) -> None:
     cuda_check_result(result, "cuMemMap")
 
 
+def _ro_maps_readwrite() -> bool:
+    """True when RO sessions should map READWRITE (diagnostic override)."""
+    return os.environ.get("DYN_GMS_RO_MAP_READWRITE", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
 def cumem_set_access(va: int, size: int, device: int, access: GrantedLockType) -> None:
     access_desc = cuda.CUmemAccessDesc()
     access_desc.location.type = cuda.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
     access_desc.location.id = device
+    read_only = access == GrantedLockType.RO
+    if read_only and _ro_maps_readwrite():
+        # Diagnostic escape hatch: map an RO session's pages READWRITE.
+        # PROT_READ is a hardware protection, so a kernel that touches those
+        # pages in a way the driver treats as a write - including some
+        # read-modify-write and wide vectorised access patterns - faults with
+        # cudaErrorIllegalAddress rather than a clean permission error. This
+        # isolates that flag from the rest of the read-only path; the lock
+        # still prevents concurrent writers, so it is safe for a single
+        # reader, but it removes the guarantee that a buggy reader cannot
+        # corrupt weights other engines are sharing.
+        read_only = False
     access_desc.flags = (
         cuda.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READ
-        if access == GrantedLockType.RO
+        if read_only
         else cuda.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
     )
     (result,) = cuda.cuMemSetAccess(va, size, [access_desc], 1)

--- a/lib/gpu_memory_service/integrations/common/patches.py
+++ b/lib/gpu_memory_service/integrations/common/patches.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 
 import torch
 from gpu_memory_service.client.torch.allocator import get_gms_client_memory_managers
@@ -16,11 +17,19 @@ _empty_cache_patched = False
 
 
 def patch_empty_cache() -> None:
-    """Patch torch.cuda.empty_cache to prevent segfaults with VMM allocations.
+    """Patch the empty-cache entry points to prevent faults with VMM allocations.
 
-    When weights are allocated through our VMM-based pluggable allocator, calling
-    torch.cuda.empty_cache() causes segfaults because the native caching allocator
-    tries to release blocks that were allocated through VMM APIs.
+    When weights are allocated through our VMM-based pluggable allocator, emptying
+    the cache faults because the native caching allocator tries to release blocks
+    that were allocated through VMM APIs.
+
+    Both ``torch.cuda.empty_cache`` and ``torch.accelerator.empty_cache`` must be
+    patched: the latter dispatches straight to ``torch._C._accelerator_emptyCache``
+    rather than delegating to the former, so patching only the CUDA entry point
+    leaves a live path into the native allocator. vLLM calls the accelerator entry
+    point from inference-time paths (for example the sparse-MLA prefill workspace
+    resize in ``vllm/v1/worker/workspace.py``), where the fault poisons the CUDA
+    context and takes down the worker.
 
     This patch is idempotent - calling it multiple times has no effect.
     """
@@ -29,23 +38,29 @@ def patch_empty_cache() -> None:
     if _empty_cache_patched:
         return
 
-    _original_empty_cache = torch.cuda.empty_cache
-
-    def safe_empty_cache() -> None:
-        managers = get_gms_client_memory_managers()
-        # Allow empty_cache when all managers are unmapped (sleep/checkpoint)
-        # or when there are no active VMM mappings with live handles.
-        has_live_mappings = any(
-            any(m.handle != 0 for m in manager.mappings.values())
-            for manager in managers
-        )
-        if has_live_mappings:
-            logger.debug(
-                "[GMS] Skipping torch.cuda.empty_cache() - live VMM mappings active",
+    def guard(original: Callable[[], None]) -> Callable[[], None]:
+        def safe_empty_cache() -> None:
+            managers = get_gms_client_memory_managers()
+            # Allow empty_cache when all managers are unmapped (sleep/checkpoint)
+            # or when there are no active VMM mappings with live handles.
+            has_live_mappings = any(
+                any(m.handle != 0 for m in manager.mappings.values())
+                for manager in managers
             )
-            return
-        _original_empty_cache()
+            if has_live_mappings:
+                logger.debug(
+                    "[GMS] Skipping empty_cache() - live VMM mappings active",
+                )
+                return
+            original()
 
-    torch.cuda.empty_cache = safe_empty_cache
+        return safe_empty_cache
+
+    torch.cuda.empty_cache = guard(torch.cuda.empty_cache)
+    # torch.accelerator exists from torch 2.5; guard so older builds still load.
+    accelerator = getattr(torch, "accelerator", None)
+    if accelerator is not None:
+        accelerator.empty_cache = guard(accelerator.empty_cache)
+
     _empty_cache_patched = True
-    logger.info("[GMS] Patched torch.cuda.empty_cache")
+    logger.info("[GMS] Patched torch.cuda/torch.accelerator empty_cache")

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
 import torch
-from gpu_memory_service.client.torch.allocator import prune_allocations
+from gpu_memory_service.client.torch.allocator import release_weight_mempool
 from gpu_memory_service.client.torch.module import (
     rebind_nonparameter_tensors,
     register_module_tensors,
@@ -94,11 +94,15 @@ def prepare_gms_write(
     allocator: "GMSClientMemoryManager",
     model: torch.nn.Module,
 ) -> GMSCommittedMemoryStats:
-    """Register model tensors and prune unreferenced allocations.
+    """Register model tensors and release load-time scratch.
 
     This is the first half of a GMS write: it does not commit. The allocator
     keeps its RW lease until :func:`publish_gms_write`, which lets a caller
     defer publication (e.g. until after vLLM memory profiling).
+
+    Registration runs first, while every buffer still sits at the GMS address
+    that will be published for it. Dropping the mempool afterwards is what
+    reclaims the load-time scratch, at torch-block granularity.
 
     Args:
         allocator: The GMS client memory manager in write mode.
@@ -107,25 +111,17 @@ def prepare_gms_write(
     Returns:
         Committed/pruned byte stats for the write awaiting publication.
     """
-    referenced_allocation_ids = register_module_tensors(allocator, model)
-    before_prune_bytes = allocator.total_bytes
-    before_prune_count = len(allocator.mappings)
+    register_module_tensors(allocator, model)
+    before_bytes = allocator.total_bytes
+    before_count = len(allocator.mappings)
 
-    # prune_allocations synchronizes allocator.device before destroying
-    # unreferenced mappings. allocator.commit() performs the publish-barrier
-    # sync before committing the remaining registered weights.
-    prune_allocations(
-        allocator,
-        referenced_allocation_ids=referenced_allocation_ids,
-    )
+    release_weight_mempool(allocator)
+
     total_bytes = allocator.total_bytes
-    pruned_bytes = before_prune_bytes - total_bytes
-    pruned_count = before_prune_count - len(allocator.mappings)
-
     return GMSCommittedMemoryStats(
         committed_bytes=int(total_bytes),
-        pruned_bytes=int(pruned_bytes),
-        pruned_count=pruned_count,
+        pruned_bytes=int(before_bytes - total_bytes),
+        pruned_count=before_count - len(allocator.mappings),
     )
 
 

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -10,6 +10,7 @@ processes import from GMS metadata (RO).
 
 from __future__ import annotations
 
+import inspect
 import logging
 import os
 from typing import TYPE_CHECKING
@@ -32,6 +33,9 @@ from gpu_memory_service.integrations.common.utils import (
     publish_gms_write,
     setup_meta_tensor_workaround,
     strip_gms_model_loader_config,
+)
+from gpu_memory_service.integrations.vllm.upstream_workarounds import (
+    vllm_meta_init_workarounds,
 )
 
 if os.environ.get("MX_ENABLED", "0") == "1":
@@ -259,8 +263,31 @@ def _load_read_mode(
     global _last_imported_weights_bytes, _last_model_memory_usage_offset_bytes
 
     try:
+        target_device = torch.device("cuda", device_index)
+
+        logger.info("[GMS] Read mode: creating meta model")
         model = _create_meta_model(vllm_config, model_config)
+
+        logger.info("[GMS] Read mode: materializing tensors")
         materialize_module_from_gms(gms_client, model, device_index=device_index)
+
+        # Rebuild vLLM runtime helpers that the RO meta constructor skipped.
+        # These are best-effort: vLLM internals move, and a missing helper
+        # should not take down an otherwise materialized shadow.
+        try:
+            _process_fused_moe_kernels_after_gms_materialization(
+                model, model_config, target_device
+            )
+        except Exception:
+            logger.exception(
+                "[GMS] Read mode: FusedMoE kernel rebuild failed; continuing"
+            )
+        try:
+            _process_mla_weights_after_gms_materialization(
+                model, model_config, target_device
+            )
+        except Exception:
+            logger.exception("[GMS] Read mode: MLA rebuild failed; continuing")
 
         # MX: register materialized tensors (available for P2P transfer)
         mx_ctx = get_mx_load_context(vllm_config, model_config)
@@ -276,6 +303,7 @@ def _load_read_mode(
         )
         return model.eval()
     except Exception:
+        logger.exception("[GMS] Read mode failed while importing weights")
         gms_client.close()
         raise
 
@@ -346,24 +374,161 @@ def _load_write_mode(
     return model.eval()
 
 
-def _create_meta_model(vllm_config, model_config) -> torch.nn.Module:
-    """Create model on meta device for RO mode materialization."""
-    from vllm.model_executor.model_loader.utils import (
-        initialize_model,
-        process_weights_after_loading,
+def _is_mla_post_load_module(module: torch.nn.Module) -> bool:
+    return (
+        hasattr(module, "kv_b_proj")
+        and hasattr(module, "kv_lora_rank")
+        and hasattr(module, "num_heads")
+        and callable(getattr(module, "process_weights_after_loading", None))
     )
+
+
+def _make_fused_moe_kernel(module: torch.nn.Module, quant_method) -> bool:
+    experts_cls = getattr(quant_method, "experts_cls", None)
+    if experts_cls is None:
+        return False
+
+    quant_config = quant_method.get_fused_moe_quant_config(module)
+    if quant_config is None:
+        return False
+    quant_method.moe_quant_config = quant_config
+
+    routing_tables = None
+    maybe_routing_tables = getattr(module, "_maybe_init_expert_routing_tables", None)
+    if callable(maybe_routing_tables):
+        routing_tables = maybe_routing_tables()
+    shared_experts = getattr(module, "shared_experts", None)
+
+    kernel_makers = (
+        (
+            "fp8_backend",
+            "vllm.model_executor.layers.fused_moe.oracle.fp8",
+            "make_fp8_moe_kernel",
+        ),
+        (
+            "mxfp4_backend",
+            "vllm.model_executor.layers.fused_moe.oracle.mxfp4",
+            "make_mxfp4_moe_kernel",
+        ),
+        (
+            "nvfp4_backend",
+            "vllm.model_executor.layers.fused_moe.oracle.nvfp4",
+            "make_nvfp4_moe_kernel",
+        ),
+        (
+            "unquantized_backend",
+            "vllm.model_executor.layers.fused_moe.oracle.unquantized",
+            "make_unquantized_moe_kernel",
+        ),
+    )
+    for attr, module_name, fn_name in kernel_makers:
+        if not hasattr(quant_method, attr):
+            continue
+        try:
+            maker = getattr(__import__(module_name, fromlist=[fn_name]), fn_name)
+        except (ImportError, AttributeError):
+            continue
+        kwargs = {
+            "moe_quant_config": quant_config,
+            "quant_config": quant_config,
+            "moe_config": module.moe_config,
+            attr: getattr(quant_method, attr),
+            "backend": getattr(quant_method, attr),
+            "experts_cls": experts_cls,
+            "routing_tables": routing_tables,
+            "shared_experts": shared_experts,
+        }
+        accepted = set(inspect.signature(maker).parameters)
+        try:
+            quant_method.moe_kernel = maker(
+                **{k: v for k, v in kwargs.items() if k in accepted}
+            )
+            return True
+        except TypeError:
+            continue
+    return False
+
+
+def _process_fused_moe_kernels_after_gms_materialization(
+    model: torch.nn.Module,
+    model_config,
+    target_device: torch.device,
+) -> None:
+    """Rebuild vLLM MoE runtime kernels around imported GMS weights."""
+    from vllm.utils.torch_utils import set_default_torch_dtype
+
+    rebuilt: list[str] = []
+    with set_default_torch_dtype(model_config.dtype):
+        with target_device:
+            for name, module in model.named_modules():
+                quant_method = getattr(module, "quant_method", None)
+                if quant_method is None:
+                    continue
+                if getattr(quant_method, "moe_kernel", None) is not None:
+                    continue
+                if not callable(
+                    getattr(quant_method, "get_fused_moe_quant_config", None)
+                ):
+                    continue
+                if not hasattr(module, "moe_config"):
+                    continue
+                if _make_fused_moe_kernel(module, quant_method):
+                    rebuilt.append(name)
+
+    if rebuilt:
+        logger.info(
+            "[GMS] Read mode: rebuilt %d FusedMoE kernels: %s",
+            len(rebuilt),
+            rebuilt[:8],
+        )
+
+
+def _process_mla_weights_after_gms_materialization(
+    model: torch.nn.Module,
+    model_config,
+    target_device: torch.device,
+) -> None:
+    """Rebuild derived MLA projection tensors skipped from GMS metadata."""
+    from vllm.utils.torch_utils import set_default_torch_dtype
+
+    processed: list[str] = []
+    with set_default_torch_dtype(model_config.dtype):
+        with target_device:
+            for name, module in model.named_modules():
+                if not _is_mla_post_load_module(module):
+                    continue
+                module.process_weights_after_loading(model_config.dtype)
+                processed.append(name)
+
+    if processed:
+        logger.info(
+            "[GMS] Read mode: rebuilt %d MLA post-load modules: %s",
+            len(processed),
+            processed[:8],
+        )
+
+
+def _create_meta_model(vllm_config, model_config) -> torch.nn.Module:
+    """Create model on meta device for RO mode materialization.
+
+    Constructor-time vLLM bugs that fire on meta tensors (DeepSeek V4 RoPE
+    device, FusedMoE expert-map logging, Module.to(cuda) of meta params) are
+    monkey-patched for the duration of this call. Full vLLM post-load is
+    skipped here: some quantization/attention hooks allocate CUDA scratch
+    even when tensors are meta. GMS imports the writer's final parameters
+    and rebuilds supported MLA/MoE helpers afterward.
+    """
+    from vllm.model_executor.model_loader.utils import initialize_model
     from vllm.utils.torch_utils import set_default_torch_dtype
 
     setup_meta_tensor_workaround()
     meta_device = torch.device("meta")
 
-    with set_default_torch_dtype(model_config.dtype):
-        with meta_device:
-            model = initialize_model(vllm_config=vllm_config, model_config=model_config)
-
-    try:
-        process_weights_after_loading(model, model_config, meta_device)
-    except Exception as e:
-        logger.debug("[GMS] Post-processing on meta tensors: %s", e)
+    with vllm_meta_init_workarounds():
+        with set_default_torch_dtype(model_config.dtype):
+            with meta_device:
+                model = initialize_model(
+                    vllm_config=vllm_config, model_config=model_config
+                )
 
     return model

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -21,11 +21,13 @@ from gpu_memory_service.client.torch.allocator import (
     gms_use_mem_pool,
 )
 from gpu_memory_service.client.torch.module import (
+    _resolve_module_attr,
+    copy_unmapped_tensors_into_gms,
     materialize_module_from_gms,
     rebind_nonparameter_tensors,
 )
 from gpu_memory_service.common.locks import GrantedLockType
-from gpu_memory_service.common.utils import get_socket_path
+from gpu_memory_service.common.utils import get_socket_path, is_truthy_env
 from gpu_memory_service.integrations.common.utils import (
     GMSCommittedMemoryStats,
     get_gms_lock_mode,
@@ -270,6 +272,8 @@ def _load_read_mode(
 
         logger.info("[GMS] Read mode: materializing tensors")
         materialize_module_from_gms(gms_client, model, device_index=device_index)
+        torch.cuda.synchronize()
+        logger.info("[GMS] Read mode: cuda sync ok after materialize")
 
         # Rebuild vLLM runtime helpers that the RO meta constructor skipped.
         # These are best-effort: vLLM internals move, and a missing helper
@@ -278,16 +282,52 @@ def _load_read_mode(
             _process_fused_moe_kernels_after_gms_materialization(
                 model, model_config, target_device
             )
+            torch.cuda.synchronize()
+            logger.info("[GMS] Read mode: cuda sync ok after FusedMoE rebuild")
         except Exception:
             logger.exception(
                 "[GMS] Read mode: FusedMoE kernel rebuild failed; continuing"
             )
-        try:
-            _process_mla_weights_after_gms_materialization(
-                model, model_config, target_device
+        # Re-deriving MLA W_UK_T/W_UV on the reader means running vLLM's
+        # NVFP4 dequant, which for this quant method is a full GEMM through
+        # `quant_method.apply(layer, eye)`. That kernel illegal-addresses
+        # against GMS VMM mappings and takes engine startup down with it, so
+        # it stays opt-in until the writer publishes the derived tensors.
+        if is_truthy_env("DYN_GMS_RO_MLA_POSTLOAD"):
+            try:
+                _process_mla_weights_after_gms_materialization(
+                    model, model_config, target_device
+                )
+                torch.cuda.synchronize()
+                logger.info("[GMS] Read mode: cuda sync ok after MLA post-load")
+            except Exception:
+                logger.exception(
+                    "[GMS] Read mode: MLA post-load failed; continuing with "
+                    "the published tensors (expect degraded output)"
+                )
+        else:
+            logger.warning(
+                "[GMS] Read mode: skipping MLA process_weights_after_loading "
+                "(GMS VMM IMA in NVFP4 dequant GEMM); set "
+                "DYN_GMS_RO_MLA_POSTLOAD=1 to attempt it"
             )
+        try:
+            _rebuild_fp8_linear_kernels_after_gms_materialization(
+                model, target_device
+            )
+            torch.cuda.synchronize()
+            logger.info("[GMS] Read mode: cuda sync ok after fp8_linear rebuild")
         except Exception:
-            logger.exception("[GMS] Read mode: MLA rebuild failed; continuing")
+            logger.exception(
+                "[GMS] Read mode: fp8_linear kernel rebuild failed; continuing"
+            )
+        # Not best-effort: the Triton `dsv4_topk` router loads
+        # `correction_bias` by pointer and illegal-addresses against a VMM
+        # mapping, so a failure here means the first request takes the
+        # engine down. Fail the load instead.
+        _clone_triton_incompatible_params_off_gms(model)
+        torch.cuda.synchronize()
+        logger.info("[GMS] Read mode: cuda sync ok after triton-param clone")
 
         # MX: register materialized tensors (available for P2P transfer)
         mx_ctx = get_mx_load_context(vllm_config, model_config)
@@ -352,6 +392,10 @@ def _load_write_mode(
             else:
                 default_loader.load_weights(model, model_config)
                 process_weights_after_loading(model, model_config, target_device)
+            # process_weights_after_loading allocates MLA q/k/v/prob scales
+            # outside the GMS pool. Copy them in before register/publish so
+            # RO import does not zero-fill 312 leftover Parameters.
+            copy_unmapped_tensors_into_gms(gms_client, model)
 
             torch.cuda.empty_cache()
 
@@ -483,12 +527,51 @@ def _process_fused_moe_kernels_after_gms_materialization(
         )
 
 
+def _clone_module_tensors_off_gms(module: torch.nn.Module | None) -> None:
+    """Move ``module``'s CUDA parameters/buffers off GMS VMM in place.
+
+    Must not run under ``gms_use_mem_pool`` or the clones stay on VMM.
+    """
+    if module is None:
+        return
+    for name, param in list(module.named_parameters(recurse=True)):
+        if param is None or param.is_meta or not param.is_cuda:
+            continue
+        mod, attr = _resolve_module_attr(module, name)
+        mod._parameters[attr] = torch.nn.Parameter(
+            param.detach().contiguous().clone(),
+            requires_grad=param.requires_grad,
+        )
+    for name, buf in list(module.named_buffers(recurse=True)):
+        if buf is None or buf.is_meta or not buf.is_cuda:
+            continue
+        mod, attr = _resolve_module_attr(module, name)
+        mod._buffers[attr] = buf.detach().contiguous().clone()
+
+
 def _process_mla_weights_after_gms_materialization(
     model: torch.nn.Module,
     model_config,
     target_device: torch.device,
 ) -> None:
-    """Rebuild derived MLA projection tensors skipped from GMS metadata."""
+    """Re-derive MLA projections (``W_UK_T``/``W_UV``) on the RO path.
+
+    vLLM computes these by dequantizing ``kv_b_proj``; they exist only after
+    ``process_weights_after_loading`` runs, so a reader that skips it serves
+    whatever the writer happened to publish.
+
+    Two GMS-specific hazards are handled here:
+
+    * The dequant kernels address ``kv_b_proj`` by pointer, and CUDA VMM
+      mappings illegal-address on B200 (same failure mode as Triton
+      ``dsv4_topk``; see ``_clone_triton_incompatible_params_off_gms``).
+      Its tensors are cloned into ordinary CUDA memory first.
+    * ``materialize_module_from_gms`` zero-fills the leftover ``q_scale`` /
+      ``k_scale`` / ``v_scale`` / ``prob_scale`` staging Parameters. Zero is
+      neither the ">0 loaded" nor the "<0 absent" sentinel, so the KV-cache
+      quant method asserts. Deleting them reproduces the reference path,
+      which for a checkpoint carrying no attention scales resolves to 1.0.
+    """
     from vllm.utils.torch_utils import set_default_torch_dtype
 
     processed: list[str] = []
@@ -497,6 +580,12 @@ def _process_mla_weights_after_gms_materialization(
             for name, module in model.named_modules():
                 if not _is_mla_post_load_module(module):
                     continue
+                _clone_module_tensors_off_gms(getattr(module, "kv_b_proj", None))
+                for leaf in ("q_scale", "k_scale", "v_scale", "prob_scale"):
+                    if isinstance(
+                        getattr(module, leaf, None), torch.nn.Parameter
+                    ):
+                        delattr(module, leaf)
                 module.process_weights_after_loading(model_config.dtype)
                 processed.append(name)
 
@@ -505,6 +594,146 @@ def _process_mla_weights_after_gms_materialization(
             "[GMS] Read mode: rebuilt %d MLA post-load modules: %s",
             len(processed),
             processed[:8],
+        )
+
+
+def _rebuild_fp8_linear_kernels_after_gms_materialization(
+    model: torch.nn.Module,
+    target_device: torch.device,
+) -> None:
+    """Re-select FP8 GEMM kernels on CUDA after RO GMS materialize.
+
+    Meta-device construction can pick a non-DeepGEMM kernel (no compute
+    capability). Packed GMS weights then hit the wrong apply path and IMA.
+    Skip re-packing: GMS already holds the writer's processed tensors.
+    """
+    from vllm.model_executor.kernels.linear import init_fp8_linear_kernel
+
+    rebuilt: list[str] = []
+    with target_device:
+        for name, module in model.named_modules():
+            quant_method = getattr(module, "quant_method", None)
+            if quant_method is None or not hasattr(quant_method, "fp8_linear"):
+                continue
+            weight = getattr(module, "weight", None)
+            if not torch.is_tensor(weight) or weight.is_meta:
+                continue
+            shape = tuple(weight.shape)
+            if len(shape) > 2:
+                # is_bmm packed layout (g, r, d) -> DeepGEMM config wants 2D
+                shape = (int(weight.numel() // shape[-1]), int(shape[-1]))
+            keys = (
+                "activation_quant_key",
+                "weight_quant_key",
+                "input_dtype",
+                "out_dtype",
+            )
+            if any(not hasattr(quant_method, k) for k in keys):
+                continue
+            try:
+                kernel = init_fp8_linear_kernel(
+                    activation_quant_key=quant_method.activation_quant_key,
+                    weight_quant_key=quant_method.weight_quant_key,
+                    input_dtype=quant_method.input_dtype,
+                    out_dtype=quant_method.out_dtype,
+                    weight_shape=shape,
+                    module_name=type(quant_method).__name__,
+                )
+            except Exception:
+                logger.debug(
+                    "[GMS] fp8_linear rebuild skipped for %s", name, exc_info=True
+                )
+                continue
+            quant_method.fp8_linear = kernel
+            rebuilt.append(f"{name}:{type(kernel).__name__}")
+    if rebuilt:
+        logger.info(
+            "[GMS] Read mode: rebuilt %d fp8_linear kernels: %s",
+            len(rebuilt),
+            rebuilt[:8],
+        )
+
+
+def _clone_triton_incompatible_params_off_gms(model: torch.nn.Module) -> None:
+    """Copy tiny router/bias params off GMS VMM into ordinary CUDA memory.
+
+    Triton ``dsv4_topk`` loads ``correction_bias`` by pointer. CUDA VMM
+    mappings are not Triton-loadable and illegal-address on B200.
+    """
+    cloned: list[str] = []
+    # vLLM aliases some of these across modules -- `e_score_correction_bias`
+    # is one tensor referenced by both `mlp.gate` and
+    # `mlp.experts.routed_experts`. Cloning each name separately would hand
+    # the router and the experts different copies of the routing bias, so
+    # keep one clone per source storage and reuse it.
+    by_storage: dict[tuple[int, int], torch.Tensor] = {}
+
+    def _off_gms(tensor: torch.Tensor) -> torch.Tensor:
+        # Must not run under gms_use_mem_pool or the clone stays on VMM.
+        key = (tensor.untyped_storage().data_ptr(), tensor.storage_offset())
+        clone = by_storage.get(key)
+        if clone is None:
+            clone = tensor.detach().contiguous().clone()
+            by_storage[key] = clone
+        return clone
+
+    def _want(name: str, tensor: torch.Tensor) -> bool:
+        if tensor is None or not torch.is_tensor(tensor):
+            return False
+        if tensor.is_meta or not tensor.is_cuda:
+            return False
+        key = name.rsplit(".", 1)[-1].lower()
+        if "bias" not in key and "expert_map" not in key and "hash_indices" not in key:
+            return False
+        return tensor.numel() * tensor.element_size() <= 16 * (1 << 20)
+
+    for name, param in list(model.named_parameters()):
+        if not _want(name, param):
+            continue
+        try:
+            mod, attr = _resolve_module_attr(model, name)
+        except Exception:
+            continue
+        if hasattr(mod, "_parameters") and attr in mod._parameters:
+            mod._parameters[attr] = torch.nn.Parameter(
+                _off_gms(param),
+                requires_grad=param.requires_grad,
+            )
+            cloned.append(name)
+    for name, buf in list(model.named_buffers()):
+        if not _want(name, buf):
+            continue
+        try:
+            mod, attr = _resolve_module_attr(model, name)
+        except Exception:
+            continue
+        if hasattr(mod, "_buffers") and attr in mod._buffers:
+            mod._buffers[attr] = _off_gms(buf)
+            cloned.append(name)
+    # FusedTopkBiasRouter stores e_score_correction_bias as a plain tensor
+    # alias of Parameter.data. Replacing _parameters does not update it.
+    for mod_name, module in model.named_modules():
+        for attr in ("e_score_correction_bias", "_hash_indices_table"):
+            if not hasattr(module, attr):
+                continue
+            t = getattr(module, attr)
+            if not torch.is_tensor(t) or t.is_meta or not t.is_cuda:
+                continue
+            off = _off_gms(t)
+            if hasattr(module, "_parameters") and attr in module._parameters:
+                module._parameters[attr] = torch.nn.Parameter(
+                    off, requires_grad=False
+                )
+            elif hasattr(module, "_buffers") and attr in module._buffers:
+                module._buffers[attr] = off
+            else:
+                setattr(module, attr, off)
+            cloned.append(f"{mod_name}.{attr}" if mod_name else attr)
+    if cloned:
+        logger.info(
+            "[GMS] Read mode: cloned %d Triton-incompatible params off GMS: %s",
+            len(cloned),
+            cloned[:8],
         )
 
 

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -23,6 +23,7 @@ from gpu_memory_service.client.torch.allocator import (
 from gpu_memory_service.client.torch.module import (
     _resolve_module_attr,
     copy_unmapped_tensors_into_gms,
+    repoint_non_module_tensor_caches,
     materialize_module_from_gms,
     rebind_nonparameter_tensors,
 )
@@ -328,6 +329,12 @@ def _load_read_mode(
         _clone_triton_incompatible_params_off_gms(model)
         torch.cuda.synchronize()
         logger.info("[GMS] Read mode: cuda sync ok after triton-param clone")
+
+        # Last, after every pass that rebinds module tensors by name. The
+        # FusedMoE rebuild and the Triton clone both replace tensors --
+        # `expert_map` among them -- which re-breaks the aliases plain
+        # holder objects keep. Repairing any earlier would be undone here.
+        repoint_non_module_tensor_caches(model)
 
         # MX: register materialized tensors (available for P2P transfer)
         mx_ctx = get_mx_load_context(vllm_config, model_config)

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -666,6 +666,14 @@ def _clone_triton_incompatible_params_off_gms(model: torch.nn.Module) -> None:
 
     Triton ``dsv4_topk`` loads ``correction_bias`` by pointer. CUDA VMM
     mappings are not Triton-loadable and illegal-address on B200.
+
+    Deliberately does NOT cover the DeepSeek-V4 MHC ``hc_*`` weights, even
+    though they are also TileLang-loaded. They are fp32 and there are six per
+    layer, so cloning them costs 129 MiB/rank on DSV4-Flash and 320 MiB/rank on
+    DSV4-Pro (~2.5 GiB across 8 ranks) of private per-engine copies -- which
+    defeats the point of sharing weights through GMS, and lands on the
+    read-only import critical path. It was measured and did not change the
+    illegal-address failure, so the cost buys nothing.
     """
     cloned: list[str] = []
     # vLLM aliases some of these across modules -- `e_score_correction_bias`

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -687,11 +687,23 @@ def _clone_triton_incompatible_params_off_gms(model: torch.nn.Module) -> None:
     # `mlp.experts.routed_experts`. Cloning each name separately would hand
     # the router and the experts different copies of the routing bias, so
     # keep one clone per source storage and reuse it.
-    by_storage: dict[tuple[int, int], torch.Tensor] = {}
+    #
+    # The key includes dtype and shape as well as the storage address: a
+    # DeepSeek-V4 gate carries either e_score_correction_bias (float32) or
+    # tid2eid (int32) and the two can share a storage, so keying on the
+    # address alone returns the int clone for the float slot and the
+    # float-only topk_hash_softplus_sqrt then fails with "expected scalar type
+    # Float but found Int".
+    by_storage: dict[tuple, torch.Tensor] = {}
 
     def _off_gms(tensor: torch.Tensor) -> torch.Tensor:
         # Must not run under gms_use_mem_pool or the clone stays on VMM.
-        key = (tensor.untyped_storage().data_ptr(), tensor.storage_offset())
+        key = (
+            tensor.untyped_storage().data_ptr(),
+            tensor.storage_offset(),
+            tensor.dtype,
+            tuple(tensor.shape),
+        )
         clone = by_storage.get(key)
         if clone is None:
             clone = tensor.detach().contiguous().clone()
@@ -764,6 +776,11 @@ def _clone_triton_incompatible_params_off_gms(model: torch.nn.Module) -> None:
                 # resolve them against the live tensor of the same name.
                 qualified = f"{mod_name}.{attr}" if mod_name else attr
                 real = materialized.get(qualified)
+                if real is not None and real.dtype != t.dtype:
+                    # Same name, different dtype: not the tensor this alias
+                    # refers to. Resolving anyway swaps the int hash table into
+                    # the float bias slot.
+                    real = None
                 if real is None:
                     logger.warning(
                         "[GMS] Read mode: %s is on %s after materialization "
@@ -790,6 +807,63 @@ def _clone_triton_incompatible_params_off_gms(model: torch.nn.Module) -> None:
             len(skipped),
             skipped[:10],
         )
+
+    # The MoE router itself is a plain object, not an nn.Module
+    # (FusedMoERouter subclasses ABC), so named_modules() never reaches it and
+    # the loop above cannot see the copies of the bias and hash table it
+    # captured in its constructor. Both come from the sibling `gate` module
+    # (DeepseekV4MoE assigns gate.e_score_correction_bias and gate.tid2eid), so
+    # resolve against the gate rather than against the router's own path.
+    #
+    # The two are mutually exclusive per layer: a hash-MoE layer has tid2eid
+    # and no bias, any other layer has the bias and no tid2eid. Match on the
+    # source name AND the dtype so a layer that only has one of them cannot
+    # silently resolve to the other - that hands the float-only
+    # topk_hash_softplus_sqrt an int table.
+    router_attr_sources = {
+        "e_score_correction_bias": (("e_score_correction_bias",), True),
+        "_hash_indices_table": (("tid2eid",), False),
+    }
+    for mod_name, module in model.named_modules():
+        router = getattr(module, "router", None)
+        if router is None or isinstance(router, torch.nn.Module):
+            continue
+        # `module` is the experts runner; the gate is its sibling under the
+        # shared MoE parent (…ffn.experts.router -> …ffn.gate).
+        parent_name = mod_name.rsplit(".", 1)[0] if "." in mod_name else ""
+        owners = [getattr(module, "gate", None)]
+        if parent_name:
+            owners.append(getattr(model.get_submodule(parent_name), "gate", None))
+
+        for attr, (sources, want_float) in router_attr_sources.items():
+            t = getattr(router, attr, None)
+            if not torch.is_tensor(t) or t.is_cuda:
+                continue
+            real = next(
+                (
+                    cand
+                    for owner in owners
+                    for src in sources
+                    for cand in [getattr(owner, src, None) if owner else None]
+                    if torch.is_tensor(cand)
+                    and cand.is_cuda
+                    and cand.is_floating_point() == want_float
+                ),
+                None,
+            )
+            if real is None:
+                logger.warning(
+                    "[GMS] Read mode: router attr %s.router.%s is on %s and no "
+                    "materialized %s of the right dtype was found on the gate; "
+                    "the first forward would fail on it",
+                    mod_name,
+                    attr,
+                    t.device,
+                    sources,
+                )
+                continue
+            setattr(router, attr, _off_gms(real))
+            cloned.append(f"{mod_name}.router.{attr}")
     if cloned:
         logger.info(
             "[GMS] Read mode: cloned %d Triton-incompatible params off GMS: %s",
@@ -813,6 +887,12 @@ def _clone_triton_incompatible_params_off_gms(model: torch.nn.Module) -> None:
             t = getattr(module, attr, None)
             if torch.is_tensor(t) and t.is_meta:
                 stranded.append(f"{mod_name}.{attr}" if mod_name else attr)
+        router = getattr(module, "router", None)
+        if router is not None and not isinstance(router, torch.nn.Module):
+            for attr in ("e_score_correction_bias", "_hash_indices_table"):
+                t = getattr(router, attr, None)
+                if torch.is_tensor(t) and t.is_meta:
+                    stranded.append(f"{mod_name}.router.{attr}")
     if stranded:
         raise RuntimeError(
             f"[GMS] Read mode: {len(stranded)} tensor(s) are still on the meta "

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -500,10 +500,64 @@ def _make_fused_moe_kernel(module: torch.nn.Module, quant_method) -> bool:
             quant_method.moe_kernel = maker(
                 **{k: v for k, v in kwargs.items() if k in accepted}
             )
-            return True
         except TypeError:
             continue
+        _run_moe_kernel_post_load(module, quant_method)
+        return True
     return False
+
+
+# Layers whose MoE post-load has already run in this process. The TRTLLM
+# experts' process_weights_after_loading folds input scales into the weight
+# scales in place (w13_weight_scale_2.mul_(w13_input_scale)), so running it
+# twice squares them.
+_moe_post_load_done: set[int] = set()
+
+
+def _run_moe_kernel_post_load(module: torch.nn.Module, quant_method) -> None:
+    """Register the rebuilt MoE kernel's derived params on an imported layer.
+
+    Read mode skips vLLM's process_weights_after_loading, but for the TRTLLM
+    MoE experts that step registers g1_scale_c and gemm1_clamp_limit on the
+    layer. Those are created by ``register_parameter`` during post-load, so the
+    meta model has no slot for them and name-keyed materialization drops them
+    even though the writer published them. Without them the experts run with
+    unscaled GEMM1 output and no activation clamp, which does not fail - it
+    degrades generation into repetition, so nothing upstream reports it.
+
+    Post-load also folds the input scales into the weight scales in place
+    (``w13_weight_scale_2.mul_(w13_input_scale)``). The writer already did that
+    before publishing, so repeating it here would square the scales - and,
+    because those scales live in the shared GMS mapping, would corrupt them for
+    every other reader, cumulatively on every restart. Neutralise the fold by
+    substituting ones for the input scales, which leaves the derived
+    registrations correct because they are computed from the already-folded
+    values.
+    """
+    kernel = getattr(quant_method, "moe_kernel", None)
+    post_load = getattr(kernel, "process_weights_after_loading", None)
+    if not callable(post_load):
+        return
+    if id(module) in _moe_post_load_done:
+        return
+
+    saved: dict[str, torch.Tensor] = {}
+    for attr in ("w13_input_scale", "w2_input_scale"):
+        t = getattr(module, attr, None)
+        if torch.is_tensor(t):
+            saved[attr] = t
+            setattr(module, attr, torch.ones_like(t))
+    try:
+        post_load(module)
+        _moe_post_load_done.add(id(module))
+    except Exception:
+        logger.exception(
+            "[GMS] Read mode: MoE post-load failed for a rebuilt kernel; "
+            "expect degraded generation from this layer"
+        )
+    finally:
+        for attr, t in saved.items():
+            setattr(module, attr, t)
 
 
 def _process_fused_moe_kernels_after_gms_materialization(

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -414,6 +414,12 @@ def _load_write_mode(
     rebound_bytes = rebind_nonparameter_tensors(
         gms_client, model, retain_gms_tensors=retained_gms_tensors
     )
+    # The writer's own weights become read-only VMM at publish
+    # (publish_gms_write: commit -> connect(RO) -> remap_all_vas), so the
+    # router bias it reads by pointer is subject to the same VMM defect the
+    # reader hits. rebind_nonparameter_tensors only covers buffers and tensor
+    # attributes, so run the same clone pass the read path runs.
+    _clone_triton_incompatible_params_off_gms(model)
     _store_pending_gms_write(gms_client, stats, rebound_bytes, retained_gms_tensors)
 
     logger.info(
@@ -741,27 +747,33 @@ def _clone_triton_incompatible_params_off_gms(model: torch.nn.Module) -> None:
         + list(model.named_buffers())
         if torch.is_tensor(tensor) and not tensor.is_meta and tensor.is_cuda
     }
+    skipped: list[str] = []
     for mod_name, module in model.named_modules():
         for attr in ("e_score_correction_bias", "_hash_indices_table"):
             if not hasattr(module, attr):
                 continue
             t = getattr(module, attr)
             if not torch.is_tensor(t):
+                skipped.append(
+                    f"{mod_name}.{attr}=<{type(t).__name__}>" if mod_name else attr
+                )
                 continue
-            if t.is_meta:
+            if not t.is_cuda:
+                # Either still on meta, or on CPU. Both are stale aliases of a
+                # parameter that materialization has already repointed, so
+                # resolve them against the live tensor of the same name.
                 qualified = f"{mod_name}.{attr}" if mod_name else attr
                 real = materialized.get(qualified)
                 if real is None:
                     logger.warning(
-                        "[GMS] Read mode: %s is still on meta after "
-                        "materialization and has no materialized parameter to "
+                        "[GMS] Read mode: %s is on %s after materialization "
+                        "and has no materialized tensor of that name to "
                         "resolve against; the first forward would fail on it",
                         qualified,
+                        t.device,
                     )
                     continue
                 t = real
-            elif not t.is_cuda:
-                continue
             off = _off_gms(t)
             if hasattr(module, "_parameters") and attr in module._parameters:
                 module._parameters[attr] = torch.nn.Parameter(
@@ -772,6 +784,12 @@ def _clone_triton_incompatible_params_off_gms(model: torch.nn.Module) -> None:
             else:
                 setattr(module, attr, off)
             cloned.append(f"{mod_name}.{attr}" if mod_name else attr)
+    if skipped:
+        logger.warning(
+            "[GMS] Read mode: %d router alias attr(s) were not tensors: %s",
+            len(skipped),
+            skipped[:10],
+        )
     if cloned:
         logger.info(
             "[GMS] Read mode: cloned %d Triton-incompatible params off GMS: %s",

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -535,21 +535,57 @@ def _run_moe_kernel_post_load(module: torch.nn.Module, quant_method) -> None:
     values.
     """
     kernel = getattr(quant_method, "moe_kernel", None)
-    post_load = getattr(kernel, "process_weights_after_loading", None)
-    if not callable(post_load):
+    # process_weights_after_loading lives on the experts object, which the
+    # kernel maker nests inside the modular kernel (and, for the monolithic
+    # path, one level deeper behind .impl).
+    # The quant method also defines process_weights_after_loading, but for the
+    # modular path it raises ("uses the new modular kernel initialization
+    # logic"), so only consider the nested experts objects.
+    post_load = None
+    for holder in (
+        getattr(kernel, "fused_experts", None),
+        getattr(getattr(kernel, "impl", None), "fused_experts", None),
+    ):
+        cand = getattr(holder, "process_weights_after_loading", None)
+        if callable(cand):
+            post_load = cand
+            break
+    if post_load is None:
         return
     if id(module) in _moe_post_load_done:
         return
 
-    saved: dict[str, torch.Tensor] = {}
+    # post_load uses register_parameter, which refuses to overwrite. Some of
+    # these are already bound (the writer published them and materialization
+    # brought them across), and the KeyError would abort the function partway
+    # through, leaving the later registrations undone. Drop them first so the
+    # derived values are recomputed consistently from the imported scales.
+    for derived in ("g1_scale_c", "gemm1_clamp_limit", "gemm2_clamp_limit"):
+        module._parameters.pop(derived, None)
+        module.__dict__.pop(derived, None)
+
+    saved: dict[str, torch.nn.Parameter] = {}
     for attr in ("w13_input_scale", "w2_input_scale"):
         t = getattr(module, attr, None)
-        if torch.is_tensor(t):
+        if isinstance(t, torch.nn.Parameter):
             saved[attr] = t
-            setattr(module, attr, torch.ones_like(t))
+            # Must stay an nn.Parameter: the module rejects a bare tensor.
+            setattr(
+                module,
+                attr,
+                torch.nn.Parameter(torch.ones_like(t), requires_grad=False),
+            )
     try:
         post_load(module)
         _moe_post_load_done.add(id(module))
+        if len(_moe_post_load_done) == 1:
+            logger.info(
+                "[GMS] Read mode: MoE post-load ran (%s); derived params such "
+                "as g1_scale_c are now registered",
+                type(post_load.__self__).__name__
+                if hasattr(post_load, "__self__")
+                else "unknown",
+            )
     except Exception:
         logger.exception(
             "[GMS] Read mode: MoE post-load failed for a rebuilt kernel; "

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -727,12 +727,40 @@ def _clone_triton_incompatible_params_off_gms(model: torch.nn.Module) -> None:
             cloned.append(name)
     # FusedTopkBiasRouter stores e_score_correction_bias as a plain tensor
     # alias of Parameter.data. Replacing _parameters does not update it.
+    #
+    # The alias is captured in the router's constructor, which runs while the
+    # model is still on the meta device, so it can still be a meta tensor after
+    # materialization repointed the real parameter. Skipping meta here would
+    # leave the router holding a meta tensor and fail the first forward with
+    # "Tensor on device meta is not on the expected device cuda:N" - reported
+    # far downstream, since the router runs inside the MoE. Re-resolve the alias
+    # against the materialized parameter of the same name instead.
+    materialized = {
+        name: tensor
+        for name, tensor in list(model.named_parameters())
+        + list(model.named_buffers())
+        if torch.is_tensor(tensor) and not tensor.is_meta and tensor.is_cuda
+    }
     for mod_name, module in model.named_modules():
         for attr in ("e_score_correction_bias", "_hash_indices_table"):
             if not hasattr(module, attr):
                 continue
             t = getattr(module, attr)
-            if not torch.is_tensor(t) or t.is_meta or not t.is_cuda:
+            if not torch.is_tensor(t):
+                continue
+            if t.is_meta:
+                qualified = f"{mod_name}.{attr}" if mod_name else attr
+                real = materialized.get(qualified)
+                if real is None:
+                    logger.warning(
+                        "[GMS] Read mode: %s is still on meta after "
+                        "materialization and has no materialized parameter to "
+                        "resolve against; the first forward would fail on it",
+                        qualified,
+                    )
+                    continue
+                t = real
+            elif not t.is_cuda:
                 continue
             off = _off_gms(t)
             if hasattr(module, "_parameters") and attr in module._parameters:
@@ -749,6 +777,29 @@ def _clone_triton_incompatible_params_off_gms(model: torch.nn.Module) -> None:
             "[GMS] Read mode: cloned %d Triton-incompatible params off GMS: %s",
             len(cloned),
             cloned[:8],
+        )
+
+    # Fail closed on any tensor still on meta. A leaked meta tensor does not
+    # fault where it lives: it surfaces as "Tensor on device meta is not on the
+    # expected device cuda:N" from whatever kernel first touches it, which for
+    # the router alias above is deep inside the MoE, several stages after the
+    # real defect. Name the offenders at load time instead.
+    stranded = [
+        name
+        for name, tensor in list(model.named_parameters())
+        + list(model.named_buffers())
+        if torch.is_tensor(tensor) and tensor.is_meta
+    ]
+    for mod_name, module in model.named_modules():
+        for attr in ("e_score_correction_bias", "_hash_indices_table"):
+            t = getattr(module, attr, None)
+            if torch.is_tensor(t) and t.is_meta:
+                stranded.append(f"{mod_name}.{attr}" if mod_name else attr)
+    if stranded:
+        raise RuntimeError(
+            f"[GMS] Read mode: {len(stranded)} tensor(s) are still on the meta "
+            f"device after materialization: {stranded[:10]}. They would fail "
+            "the first forward with a device mismatch."
         )
 
 

--- a/lib/gpu_memory_service/integrations/vllm/patches.py
+++ b/lib/gpu_memory_service/integrations/vllm/patches.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+import os
 
 from gpu_memory_service.client.torch.allocator import (
     get_gms_client_memory_manager,
@@ -368,12 +369,77 @@ def patch_dsv4_topk_clone_inputs() -> None:
             gating_output, bias, indices_dtype, routed_scaling_factor
         )
 
-    dsv4_topk_mod.dsv4_topk = wrapped
+    def pytorch_fallback(
+        gating_output,
+        correction_bias,
+        indices_dtype,
+        routed_scaling_factor,
+    ):
+        """Pure-PyTorch replacement for the Triton ``dsv4_topk`` kernel.
+
+        Cloning operands off GMS VMM is not always sufficient: on the
+        DeepSeek-V4 checkpoints Triton still takes an illegal address even
+        with private copies, so this path avoids Triton entirely.
+
+        Mirrors ``_dsv4_topk_kernel``: weights are softplus-then-sqrt of the
+        logits; selection ranks by ``weights + correction_bias`` but the
+        emitted weight is the UNBIASED weight; ties resolve to the lowest
+        expert id; the selected weights are renormalised by their own sum and
+        scaled by ``routed_scaling_factor``.
+
+        Validated against the Triton kernel on B200 for both expert counts
+        (256, 384): 100% top-k index agreement and a maximum weight delta of
+        6e-8, i.e. float32 rounding. Still gated behind an env var because it
+        is a workaround for a GMS VMM defect, not a supported code path.
+        """
+        import torch
+
+        logits = gating_output.float()
+        # softplus, matching the kernel's >20 linear shortcut
+        weights = torch.sqrt(
+            torch.where(logits > 20.0, logits, torch.log1p(torch.exp(logits)))
+        )
+        ranked = weights + correction_bias.float()
+        ranked = torch.nan_to_num(ranked, nan=-1e30)
+        topk = getattr(dsv4_topk_mod, "_TOPK", 6)
+        # torch.topk already resolves ties to the lowest index, matching the
+        # kernel's tl.min(candidate) tie-break. Verified against the Triton
+        # kernel on B200: 100% index agreement, max weight delta 6e-8.
+        _, idx = torch.topk(ranked, k=topk, dim=-1, sorted=True)
+        selected = weights.gather(-1, idx)
+        total = selected.sum(dim=-1, keepdim=True)
+        selected = selected * (
+            routed_scaling_factor / torch.where(total > 0.0, total, 1.0)
+        )
+        return selected.to(torch.float32), idx.to(indices_dtype)
+
+    use_fallback = os.environ.get("DYN_GMS_DSV4_TOPK_PYTORCH", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    chosen = torch_compiler_disable(pytorch_fallback) if use_fallback else wrapped
+
+    dsv4_topk_mod.dsv4_topk = chosen
     try:
         import vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router as router_mod
 
-        router_mod.dsv4_topk = wrapped
+        router_mod.dsv4_topk = chosen
     except ImportError:
         pass
     _dsv4_topk_patched = True
-    logger.info("[GMS Patch] dsv4_topk wraps Triton with VMM-safe input clones")
+    if use_fallback:
+        logger.warning(
+            "[GMS Patch] dsv4_topk replaced with PyTorch topk "
+            "(DYN_GMS_DSV4_TOPK_PYTORCH) - generations are NOT quality-correct"
+        )
+    else:
+        logger.info("[GMS Patch] dsv4_topk wraps Triton with VMM-safe input clones")
+
+
+def torch_compiler_disable(fn):
+    """Mark ``fn`` as opaque to torch.compile, tolerating old torch builds."""
+    import torch
+
+    disable = getattr(getattr(torch, "compiler", None), "disable", None)
+    return disable(fn) if callable(disable) else fn

--- a/lib/gpu_memory_service/integrations/vllm/patches.py
+++ b/lib/gpu_memory_service/integrations/vllm/patches.py
@@ -474,6 +474,99 @@ def torch_compiler_disable(fn):
     return disable(fn) if callable(disable) else fn
 
 
+_dsv4_weight_digest_patched = False
+
+
+def patch_dsv4_weight_digest() -> None:
+    """Checksum the loaded weights so RW and RO loads can be compared.
+
+    A read-only import can serve degenerate output while every load-time check
+    passes, because the damage is a stale alias pointing at a tensor nobody
+    wrote rather than a bad value in a tensor that was written. Comparing a
+    digest of the same tensors across a write-mode load and a read-mode load
+    localises that to the exact parameter.
+
+    Logs one line per rank at the end of load. Enable with
+    DYN_GMS_DSV4_WEIGHT_DIGEST.
+    """
+    global _dsv4_weight_digest_patched
+
+    if _dsv4_weight_digest_patched:
+        return
+
+    if os.environ.get("DYN_GMS_DSV4_WEIGHT_DIGEST", "").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return
+
+    _dsv4_weight_digest_patched = True
+
+    def digest(model) -> None:
+        import torch
+
+        rows = []
+        for name, t in list(model.named_parameters()) + list(model.named_buffers()):
+            if not torch.is_tensor(t) or t.is_meta or not t.is_cuda:
+                continue
+            # Sample rather than reduce the whole tensor: this runs on the
+            # restore critical path and a few elements are enough to catch a
+            # stale alias or an unwritten buffer.
+            flat = t.detach().flatten()
+            n = flat.numel()
+            if n == 0:
+                continue
+            # Build sample indices on the host: linspace on device then
+            # .long() can round the endpoint past n-1 and trip a device-side
+            # assert, which poisons the context for everything after it.
+            step = max(1, n // 8)
+            picks = sorted({min(i, n - 1) for i in range(0, n, step)})[:8]
+            idx = torch.tensor(picks, device=flat.device, dtype=torch.long)
+            vals = flat[idx].to(torch.float64)
+            rows.append(
+                f"{name}|{t.dtype}|{tuple(t.shape)}|"
+                f"{float(vals.sum()):.6e}|{float(vals.abs().max()):.6e}"
+            )
+        import hashlib
+
+        blob = "\n".join(rows).encode()
+        logger.warning(
+            "[GMS Digest] %d tensors, sha256=%s",
+            len(rows),
+            hashlib.sha256(blob).hexdigest()[:32],
+        )
+        # Full rows go to a file: comparing two loads needs every tensor, and
+        # 1845 log lines per rank would be unusable.
+        try:
+            import os as _os
+
+            path = _os.environ.get(
+                "DYN_GMS_DSV4_WEIGHT_DIGEST_PATH", "/tmp/gms_digest"
+            )
+            dev = getattr(getattr(model, "device", None), "index", None)
+            if dev is None:
+                dev = torch.cuda.current_device()
+            with open(f"{path}.rank{dev}.txt", "w") as fh:
+                fh.write("\n".join(rows))
+            logger.warning("[GMS Digest] wrote %s.rank%s.txt", path, dev)
+        except Exception:
+            logger.exception("[GMS Digest] could not write digest file")
+
+    globals()["_gms_dsv4_weight_digest"] = digest
+    logger.info("[GMS Patch] weight digest enabled (DYN_GMS_DSV4_WEIGHT_DIGEST)")
+
+
+def gms_dsv4_weight_digest(model) -> None:
+    """Run the weight digest when it is enabled; no-op otherwise."""
+    fn = globals().get("_gms_dsv4_weight_digest")
+    if fn is not None:
+        try:
+            fn(model)
+        except Exception:
+            logger.exception("[GMS Digest] failed")
+
+
 _dsv4_hash_topk_probe_patched = False
 
 

--- a/lib/gpu_memory_service/integrations/vllm/patches.py
+++ b/lib/gpu_memory_service/integrations/vllm/patches.py
@@ -474,6 +474,82 @@ def torch_compiler_disable(fn):
     return disable(fn) if callable(disable) else fn
 
 
+_dsv4_hash_topk_probe_patched = False
+
+
+def patch_dsv4_hash_topk_probe() -> None:
+    """Report the dtypes reaching the hash-MoE top-k op.
+
+    ``topk_hash_softplus_sqrt`` fails with "expected scalar type Float but
+    found Int" on the read-only import path. Several of its operands come from
+    the gate (bias, hash table) and are rebound during materialization, so name
+    the offender rather than guessing which one is wrong.
+
+    Enable with DYN_GMS_DSV4_HASH_TOPK_PROBE.
+    """
+    global _dsv4_hash_topk_probe_patched
+
+    if _dsv4_hash_topk_probe_patched:
+        return
+
+    if os.environ.get("DYN_GMS_DSV4_HASH_TOPK_PROBE", "").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return
+
+    try:
+        import torch
+        import vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router as mod
+    except ImportError:
+        return
+
+    original = mod.vllm_topk_softplus_sqrt
+
+    def probed(
+        topk_weights,
+        topk_indices,
+        token_expert_indices,
+        gating_output,
+        renormalize=False,
+        e_score_correction_bias=None,
+        input_tokens=None,
+        hash_indices_table=None,
+        routed_scaling_factor=1.0,
+    ):
+        def d(t):
+            return "None" if not torch.is_tensor(t) else f"{t.dtype}/{t.device}"
+
+        logger.warning(
+            "[GMS Probe] topk_hash_softplus_sqrt operands: topk_weights=%s "
+            "topk_indices=%s token_expert_indices=%s gating_output=%s "
+            "e_score_correction_bias=%s input_tokens=%s hash_indices_table=%s",
+            d(topk_weights),
+            d(topk_indices),
+            d(token_expert_indices),
+            d(gating_output),
+            d(e_score_correction_bias),
+            d(input_tokens),
+            d(hash_indices_table),
+        )
+        return original(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            e_score_correction_bias,
+            input_tokens,
+            hash_indices_table,
+            routed_scaling_factor,
+        )
+
+    mod.vllm_topk_softplus_sqrt = probed
+    _dsv4_hash_topk_probe_patched = True
+    logger.info("[GMS Patch] hash top-k dtype probe enabled")
+
+
 _dsv4_layer_probe_patched = False
 
 

--- a/lib/gpu_memory_service/integrations/vllm/patches.py
+++ b/lib/gpu_memory_service/integrations/vllm/patches.py
@@ -223,25 +223,59 @@ def patch_kv_cache_pool_scope() -> None:
     try:
         import torch
         from gpu_memory_service.client.torch.allocator import gms_use_mem_pool
-        from vllm.v1.worker.gpu import model_runner as gpu_model_runner
-
-        original_init_kv_cache = gpu_model_runner.init_kv_cache
-    except (ImportError, AttributeError) as exc:
+    except ImportError as exc:
         logger.debug("[GMS Patch] init_kv_cache pool-scope not available: %s", exc)
         return
 
-    def patched_init_kv_cache(*args, **kwargs):
-        # Installed only in shadow mode, so always scope to the pool. init_kv_cache
-        # allocates on the worker's current device.
-        assert torch.cuda.is_available(), "GMS scratch KV requires CUDA"
-        device = torch.device("cuda", torch.cuda.current_device())
-        with gms_use_mem_pool("kv_cache", device):
-            return original_init_kv_cache(*args, **kwargs)
+    def _pool_wrap(fn, *, name: str):
+        def wrapped(*args, **kwargs):
+            assert torch.cuda.is_available(), "GMS scratch KV requires CUDA"
+            device = torch.device("cuda", torch.cuda.current_device())
+            logger.info("[GMS Patch] %s under scratch mem-pool device=%s", name, device)
+            with gms_use_mem_pool("kv_cache", device):
+                return fn(*args, **kwargs)
 
-    gpu_model_runner.init_kv_cache = patched_init_kv_cache
+        return wrapped
+
+    patched_any = False
+    # vLLM 0.27 V2 runner: actual torch.zeros live in attn_utils._allocate_kv_cache.
+    # Patching model_runner.init_kv_cache is not enough if that name is a stale
+    # import or the runner calls attn_utils directly.
+    for mod_name, attr in (
+        ("vllm.v1.worker.gpu.attn_utils", "_allocate_kv_cache"),
+        ("vllm.v1.worker.gpu.attn_utils", "init_kv_cache"),
+        ("vllm.v1.worker.gpu.model_runner", "init_kv_cache"),
+        ("vllm.v1.worker.gpu_model_runner", "GPUModelRunner"),
+    ):
+        try:
+            mod = importlib.import_module(mod_name)
+            target = getattr(mod, attr)
+        except (ImportError, AttributeError):
+            continue
+        if attr == "GPUModelRunner":
+            original = getattr(target, "_allocate_kv_cache_tensors", None)
+            if original is None:
+                continue
+            target._allocate_kv_cache_tensors = _pool_wrap(
+                original, name=f"{mod_name}._allocate_kv_cache_tensors"
+            )
+            uniform = getattr(target, "allocate_uniform_kv_caches", None)
+            if callable(uniform):
+                target.allocate_uniform_kv_caches = _pool_wrap(
+                    uniform, name=f"{mod_name}.allocate_uniform_kv_caches"
+                )
+            patched_any = True
+            continue
+        setattr(mod, attr, _pool_wrap(target, name=f"{mod_name}.{attr}"))
+        patched_any = True
+
+    if not patched_any:
+        logger.debug("[GMS Patch] no KV allocation entry points found to wrap")
+        return
+
     _kv_cache_pool_scope_patched = True
     logger.info(
-        "[GMS Patch] Scoped scratch mem-pool to init_kv_cache (KV tensors only)"
+        "[GMS Patch] Scoped scratch mem-pool to KV tensor allocation (KV tensors only)"
     )
 
 
@@ -256,4 +290,90 @@ def apply_scratch_kv_patches() -> None:
     patch_register_kv_caches()
     patch_request_memory()
     patch_kv_cache_pool_scope()
+    # Do not force eager BreakableCUDAGraphWrapper: graphs are captured
+    # on scratch VAs at init and survive wake_up remap.
     logger.info("[GMS Patch] applied")
+
+
+def patch_force_eager_breakable_cudagraph() -> None:
+    """Disable on-the-fly breakable CUDA-graph capture.
+
+    Scratch-init skips capture_model(), so the first real request would
+    otherwise capture inside BreakableCUDAGraphWrapper and crash on
+    unpinned CPU/CUDA copies. Eager is enough to prove GMS failover;
+    capture can be re-enabled after wake with real KV.
+    """
+    try:
+        from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphWrapper
+    except ImportError:
+        logger.debug("[GMS Patch] BreakableCUDAGraphWrapper not available")
+        return
+
+    def eager_call(self, *args, **kwargs):
+        return self.runnable(*args, **kwargs)
+
+    BreakableCUDAGraphWrapper.__call__ = eager_call
+    logger.info("[GMS Patch] Forced eager BreakableCUDAGraphWrapper.__call__")
+
+
+_dsv4_topk_patched = False
+
+
+def patch_dsv4_topk_clone_inputs() -> None:
+    """Keep Triton ``dsv4_topk``; clone operands off GMS VMM first.
+
+    Triton cannot load CUDA VMM pointers for ``correction_bias`` (IMA on
+    B200). A PyTorch sequential-max fallback with per-call
+    ``cuda.synchronize`` is what made GLM-5.2 TEP8 prefill sit at
+    ~3200–6400 tok/s vs V1 ~16–26k. Clone into the default allocator and
+    run the original kernel. Also patch ``fused_topk_bias_router.dsv4_topk``
+    because that module does ``from dsv4_topk import dsv4_topk``.
+    """
+    global _dsv4_topk_patched
+    if _dsv4_topk_patched:
+        return
+    try:
+        import vllm.model_executor.layers.fused_moe.router.dsv4_topk as dsv4_topk_mod
+    except ImportError:
+        logger.debug("[GMS Patch] dsv4_topk not available")
+        return
+
+    orig = dsv4_topk_mod.dsv4_topk
+
+    def wrapped(
+        gating_output,
+        correction_bias,
+        indices_dtype,
+        routed_scaling_factor,
+    ):
+        if (
+            gating_output is None
+            or correction_bias is None
+            or getattr(gating_output, "is_meta", False)
+            or getattr(correction_bias, "is_meta", False)
+        ):
+            return orig(
+                gating_output,
+                correction_bias,
+                indices_dtype,
+                routed_scaling_factor,
+            )
+        # gating_output is an activation (not a GMS VMM weight). Cloning
+        # it every MoE layer of an 8192-token prefill is a full extra
+        # copy of the router logits; soak stays at one 8192-token step
+        # per ~1.28s (6400 tok/s). Only correction_bias is a GMS param
+        # that Triton cannot load from VMM.
+        bias = correction_bias.detach().contiguous().clone()
+        return orig(
+            gating_output, bias, indices_dtype, routed_scaling_factor
+        )
+
+    dsv4_topk_mod.dsv4_topk = wrapped
+    try:
+        import vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router as router_mod
+
+        router_mod.dsv4_topk = wrapped
+    except ImportError:
+        pass
+    _dsv4_topk_patched = True
+    logger.info("[GMS Patch] dsv4_topk wraps Triton with VMM-safe input clones")

--- a/lib/gpu_memory_service/integrations/vllm/patches.py
+++ b/lib/gpu_memory_service/integrations/vllm/patches.py
@@ -319,6 +319,14 @@ def patch_force_eager_breakable_cudagraph() -> None:
 
 _dsv4_topk_patched = False
 
+# Diagnostic: synchronise on entry to dsv4_topk so an async fault raised by the
+# upstream router GEMM is attributed there instead of to the first add here.
+_DSV4_TOPK_PROBE = os.environ.get("DYN_GMS_DSV4_TOPK_PROBE", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
 
 def patch_dsv4_topk_clone_inputs() -> None:
     """Keep Triton ``dsv4_topk``; clone operands off GMS VMM first.
@@ -395,6 +403,27 @@ def patch_dsv4_topk_clone_inputs() -> None:
         import torch
 
         logits = gating_output.float()
+        if _DSV4_TOPK_PROBE:
+            # gating_output is the router GEMM's output, produced from a large
+            # router weight that stays on the GMS mapping. The adds below are
+            # the first synchronising ops after that GEMM, so an async fault in
+            # it would be reported here rather than at its own launch. Sync on
+            # entry to attribute the fault to the caller instead.
+            try:
+                torch.cuda.synchronize()
+                logger.warning(
+                    "[GMS Probe] dsv4_topk entry clean: gating_output=%s "
+                    "correction_bias=%s",
+                    tuple(gating_output.shape),
+                    tuple(correction_bias.shape),
+                )
+            except Exception:
+                logger.exception(
+                    "[GMS Probe] CUDA context ALREADY POISONED on dsv4_topk "
+                    "entry - the fault is upstream of the router, in whatever "
+                    "produced gating_output"
+                )
+                raise
         # softplus, matching the kernel's >20 linear shortcut
         weights = torch.sqrt(
             torch.where(logits > 20.0, logits, torch.log1p(torch.exp(logits)))
@@ -443,3 +472,253 @@ def torch_compiler_disable(fn):
 
     disable = getattr(getattr(torch, "compiler", None), "disable", None)
     return disable(fn) if callable(disable) else fn
+
+
+_dsv4_layer_probe_patched = False
+
+
+def patch_dsv4_layer_probe() -> None:
+    """Bisect which DSv4 stage first poisons the CUDA context.
+
+    The K-cache gather was long blamed for the first-prefill
+    cudaErrorIllegalAddress, but synchronising on entry to it faults before its
+    kernel is even launched, so the context is already bad when attention's
+    prefill path is reached. CUDA reports an async fault at the next
+    synchronising call, not at the launch that caused it, so the visible
+    traceback is the first sync downstream of the real culprit.
+
+    This wraps the DSv4 decoder layer and its attention entry point with
+    synchronising checkpoints and reports the last one that passed, which names
+    the stage containing the faulting launch. Diagnostic only - it serialises
+    every layer. Enable with DYN_GMS_DSV4_LAYER_PROBE.
+    """
+    global _dsv4_layer_probe_patched
+
+    if _dsv4_layer_probe_patched:
+        return
+
+    if os.environ.get("DYN_GMS_DSV4_LAYER_PROBE", "").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return
+
+    try:
+        import torch
+        import vllm.models.deepseek_v4.attention as attn_mod
+        import vllm.models.deepseek_v4.nvidia.model as model_mod
+    except ImportError:
+        return
+
+    state = {"n": 0, "dead": False, "last": "<none>"}
+
+    def checkpoint(label: str) -> None:
+        """Report the first checkpoint that finds the context already faulted."""
+        if state["dead"]:
+            return
+        try:
+            torch.cuda.synchronize()
+            state["n"] += 1
+            state["last"] = label
+        except Exception as exc:
+            state["dead"] = True
+            logger.error(
+                "[GMS Probe] FIRST BAD CHECKPOINT: %s | last clean: %s "
+                "(%d clean checkpoints). The faulting launch is between those "
+                "two points. %s",
+                label,
+                state["last"],
+                state["n"],
+                exc,
+            )
+
+    def wrap(owner, attr: str, label: str) -> None:
+        target = getattr(owner, attr, None)
+        if target is None:
+            return
+        original = target.__call__ if not callable(target) else target
+
+        def probed(*args, **kwargs):
+            checkpoint(f"{label} ENTRY")
+            out = original(*args, **kwargs)
+            checkpoint(f"{label} EXIT")
+            return out
+
+        setattr(owner, attr, probed)
+
+    # Attention entry: brackets the whole MLA path including the gather.
+    for cls_name in ("DeepseekV4Attention", "DeepseekV4Indexer"):
+        cls = getattr(attn_mod, cls_name, None)
+        if cls is not None and hasattr(cls, "forward"):
+            wrap(cls, "forward", f"attention.{cls_name}.forward")
+    # Sub-stages inside attention, to separate the input GEMMs (which read the
+    # large RO-mapped projection weights on aux streams) from the MLA kernels.
+    attn_cls = getattr(attn_mod, "DeepseekV4Attention", None)
+    if attn_cls is not None:
+        for meth in (
+            "_run_parallel_input_projections",
+            "_fused_wqa_wkv_gemm",
+            "_prepare_and_attn_fn",
+            "attention_impl",
+        ):
+            if hasattr(attn_cls, meth):
+                wrap(attn_cls, meth, f"attention.{meth}")
+    # Decoder layer: brackets attention vs FFN/MoE within one layer.
+    for cls_name in ("DeepseekV4DecoderLayer", "DeepseekV4MoE"):
+        cls = getattr(model_mod, cls_name, None)
+        if cls is not None and hasattr(cls, "forward"):
+            wrap(cls, "forward", f"model.{cls_name}.forward")
+
+    _dsv4_layer_probe_patched = True
+    logger.info("[GMS Patch] DSv4 layer probe enabled (DYN_GMS_DSV4_LAYER_PROBE)")
+
+
+_dsv4_gather_checked = False
+
+
+def patch_dsv4_gather_k_cache_check() -> None:
+    """Validate the DSv4 K-cache gather's indices before it dereferences them.
+
+    ``dequantize_and_gather_k_cache`` faults with cudaErrorIllegalAddress on the
+    first prefill under GMS, identically in the CuTeDSL and Triton kernels. Both
+    compute
+    ``k_cache + block_table[req, pos // block_size] * k_cache.stride(0)``
+    with no bounds check, so a single out-of-range block id produces a wild
+    address in whichever kernel runs. Two kernels failing the same way points at
+    the operands rather than at either kernel.
+
+    This check reports whether the operands are already invalid on entry, which
+    distinguishes "the gather is broken" from "something upstream corrupted the
+    block table or the sequence lengths". It syncs and copies to host, so it is
+    diagnostic only - enable it with DYN_GMS_DSV4_GATHER_CHECK.
+    """
+    global _dsv4_gather_checked
+
+    if _dsv4_gather_checked:
+        return
+
+    if os.environ.get("DYN_GMS_DSV4_GATHER_CHECK", "").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return
+
+    try:
+        import vllm.models.deepseek_v4.common.ops.cache_utils as cache_utils_mod
+    except ImportError:
+        return
+
+    original = cache_utils_mod.dequantize_and_gather_k_cache
+
+    def checked(out, k_cache, seq_lens, gather_lens, block_table, block_size, offset, *a, **k):
+        import torch
+
+        torch.cuda.synchronize()
+        num_blocks = k_cache.shape[0]
+        bt = block_table.to("cpu", non_blocking=False)
+        sl = seq_lens.to("cpu", non_blocking=False)
+        gl = None if gather_lens is None else gather_lens.to("cpu", non_blocking=False)
+
+        problems = []
+        if bt.numel():
+            if int(bt.max()) >= num_blocks:
+                problems.append(
+                    f"block_table.max={int(bt.max())} >= k_cache.shape[0]={num_blocks}"
+                )
+            if int(bt.min()) < 0:
+                problems.append(f"block_table.min={int(bt.min())} < 0")
+        if sl.numel():
+            if int(sl.min()) < 0:
+                problems.append(f"seq_lens.min={int(sl.min())} < 0")
+            # Each request reads ceil(seq_len / block_size) entries of its row.
+            need = (sl.to(torch.int64) + block_size - 1) // max(block_size, 1)
+            if int(need.max()) > block_table.shape[-1]:
+                problems.append(
+                    f"needs {int(need.max())} block_table cols but row width is "
+                    f"{block_table.shape[-1]} (seq_lens.max={int(sl.max())}, "
+                    f"block_size={block_size})"
+                )
+            span = int(sl.max()) + int(offset)
+            if span > out.shape[1]:
+                problems.append(
+                    f"writes up to {span} tokens but out.shape[1]={out.shape[1]}"
+                )
+
+        logger.warning(
+            "[GMS Check] gather: out=%s k_cache=%s(num_blocks=%d, stride0=%d) "
+            "block_table=%s seq_lens[min=%s,max=%s] gather_lens=%s block_size=%d "
+            "offset=%d -> %s",
+            tuple(out.shape),
+            tuple(k_cache.shape),
+            num_blocks,
+            k_cache.stride(0),
+            tuple(block_table.shape),
+            int(sl.min()) if sl.numel() else "n/a",
+            int(sl.max()) if sl.numel() else "n/a",
+            "none" if gl is None else f"[min={int(gl.min())},max={int(gl.max())}]",
+            block_size,
+            offset,
+            "; ".join(problems) if problems else "operands in range",
+        )
+        return original(out, k_cache, seq_lens, gather_lens, block_table, block_size, offset, *a, **k)
+
+    cache_utils_mod.dequantize_and_gather_k_cache = checked
+    try:
+        import vllm.models.deepseek_v4.nvidia.flashmla as flashmla_mod
+
+        flashmla_mod.dequantize_and_gather_k_cache = checked
+    except ImportError:
+        pass
+    _dsv4_gather_checked = True
+    logger.info(
+        "[GMS Patch] dequantize_and_gather_k_cache bounds check enabled "
+        "(DYN_GMS_DSV4_GATHER_CHECK)"
+    )
+
+
+_dsv4_gather_triton_patched = False
+
+
+def patch_dsv4_gather_k_cache_triton() -> None:
+    """Route the DSv4 K-cache gather to Triton instead of CuTeDSL.
+
+    ``dequantize_and_gather_k_cache`` picks the CuTeDSL kernel whenever the
+    ``cutlass`` package is importable. That kernel is compiled against fake
+    tensors carrying hard alignment contracts (``assumed_align=32`` and a
+    stride divisibility of 32 on the K cache, 16 on the output) and copies
+    through ``cpasync`` 128-bit loads. Under GMS those contracts do not hold
+    and the kernel faults with cudaErrorIllegalAddress on the first prefill,
+    identically from kernel warmup's ``_dummy_run`` and from the first real
+    request.
+
+    The Triton implementation in the same module computes the same gather
+    without the alignment contract, so select it by making the module-local
+    ``has_cutedsl`` report False. vLLM imports that name into ``cache_utils``
+    at module scope, so it must be rebound there rather than in
+    ``vllm.utils.import_utils``.
+    """
+    global _dsv4_gather_triton_patched
+
+    if _dsv4_gather_triton_patched:
+        return
+
+    if os.environ.get("DYN_GMS_DSV4_GATHER_TRITON", "").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return
+
+    try:
+        import vllm.models.deepseek_v4.common.ops.cache_utils as cache_utils_mod
+    except ImportError:
+        return
+
+    cache_utils_mod.has_cutedsl = lambda: False
+    _dsv4_gather_triton_patched = True
+    logger.info(
+        "[GMS Patch] dequantize_and_gather_k_cache forced to Triton "
+        "(DYN_GMS_DSV4_GATHER_TRITON)"
+    )

--- a/lib/gpu_memory_service/integrations/vllm/upstream_workarounds.py
+++ b/lib/gpu_memory_service/integrations/vllm/upstream_workarounds.py
@@ -1,0 +1,439 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Temporary vLLM compatibility workarounds used by the GMS integration.
+
+These shims cover vLLM bugs that are upstreamable and should not be confused
+with GMS memory-management logic.  Keep their scope narrow and remove each one
+as the corresponding vLLM fix is available in the runtime image.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_moe_wna16_fake_patched = False
+_fused_moe_patch_lock = threading.Lock()
+_fused_moe_patch_depth = 0
+_fused_moe_layer_module: Any | None = None
+_fused_moe_original_determine_expert_map: Any | None = None
+_fused_moe_determine_expert_map_wrapper: Any | None = None
+_deepseek_rope_patch_lock = threading.Lock()
+_deepseek_rope_compute_lock = threading.RLock()
+_deepseek_rope_patch_depth = 0
+_deepseek_rope_original_methods: dict[Any, Any] | None = None
+_deepseek_rope_wrappers: dict[Any, Any] | None = None
+_module_to_patch_lock = threading.Lock()
+_module_to_patch_depth = 0
+_module_to_module: Any | None = None
+_module_to_original: Any | None = None
+_module_to_wrapper: Any | None = None
+
+
+def patch_moe_wna16_marlin_gemm_fake_impl() -> None:
+    """Fix vLLM's stale fake signature for WNA16 Marlin MoE."""
+    global _moe_wna16_fake_patched
+
+    if _moe_wna16_fake_patched:
+        return
+
+    try:
+        import torch
+        import vllm._custom_ops  # noqa: F401
+        from torch.library import register_fake
+    except ImportError:
+        logger.debug("[GMS vLLM Workaround] vLLM custom ops not available")
+        return
+
+    if not hasattr(torch.ops, "_moe_C") or not hasattr(
+        torch.ops._moe_C,
+        "moe_wna16_marlin_gemm",
+    ):
+        logger.debug("[GMS vLLM Workaround] moe_wna16_marlin_gemm op not available")
+        return
+
+    def fake_impl(
+        input: torch.Tensor,
+        output: torch.Tensor | None,
+        b_qweight: torch.Tensor,
+        b_bias: torch.Tensor | None,
+        b_scales: torch.Tensor,
+        a_scales: torch.Tensor | None,
+        global_scale: torch.Tensor | None,
+        b_qzeros: torch.Tensor | None,
+        g_idx: torch.Tensor | None,
+        perm: torch.Tensor | None,
+        workspace: torch.Tensor,
+        sorted_token_ids: torch.Tensor,
+        expert_ids: torch.Tensor,
+        num_tokens_past_padded: torch.Tensor,
+        topk_weights: torch.Tensor,
+        moe_block_size: int,
+        top_k: int,
+        mul_topk_weights: bool,
+        b_q_type: Any,
+        size_m: int,
+        size_n: int,
+        size_k: int,
+        is_k_full: bool,
+        use_atomic_add: bool,
+        use_fp32_reduce: bool,
+        is_zp_float: bool,
+        thread_k: int = -1,
+        thread_n: int = -1,
+        blocks_per_sm: int = -1,
+    ) -> torch.Tensor:
+        del (
+            b_qweight,
+            b_bias,
+            b_scales,
+            a_scales,
+            global_scale,
+            b_qzeros,
+            g_idx,
+            perm,
+            workspace,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_past_padded,
+            topk_weights,
+            moe_block_size,
+            mul_topk_weights,
+            b_q_type,
+            size_k,
+            is_k_full,
+            use_atomic_add,
+            use_fp32_reduce,
+            is_zp_float,
+            thread_k,
+            thread_n,
+            blocks_per_sm,
+        )
+        if output is not None:
+            return output
+        return torch.empty(
+            (size_m * top_k, size_n), dtype=input.dtype, device=input.device
+        )
+
+    @register_fake("_moe_C::moe_wna16_marlin_gemm", allow_override=True)
+    def moe_wna16_marlin_gemm_fake(
+        input: torch.Tensor,
+        output: torch.Tensor | None,
+        b_qweight: torch.Tensor,
+        b_bias: torch.Tensor | None,
+        b_scales: torch.Tensor,
+        a_scales: torch.Tensor | None,
+        global_scale: torch.Tensor | None,
+        b_qzeros: torch.Tensor | None,
+        g_idx: torch.Tensor | None,
+        perm: torch.Tensor | None,
+        workspace: torch.Tensor,
+        sorted_token_ids: torch.Tensor,
+        expert_ids: torch.Tensor,
+        num_tokens_past_padded: torch.Tensor,
+        topk_weights: torch.Tensor,
+        moe_block_size: int,
+        top_k: int,
+        mul_topk_weights: bool,
+        b_q_type: Any,
+        size_m: int,
+        size_n: int,
+        size_k: int,
+        is_k_full: bool,
+        use_atomic_add: bool,
+        use_fp32_reduce: bool,
+        is_zp_float: bool,
+        thread_k: int = -1,
+        thread_n: int = -1,
+        blocks_per_sm: int = -1,
+    ) -> torch.Tensor:
+        return fake_impl(
+            input,
+            output,
+            b_qweight,
+            b_bias,
+            b_scales,
+            a_scales,
+            global_scale,
+            b_qzeros,
+            g_idx,
+            perm,
+            workspace,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_past_padded,
+            topk_weights,
+            moe_block_size,
+            top_k,
+            mul_topk_weights,
+            b_q_type,
+            size_m,
+            size_n,
+            size_k,
+            is_k_full,
+            use_atomic_add,
+            use_fp32_reduce,
+            is_zp_float,
+            thread_k,
+            thread_n,
+            blocks_per_sm,
+        )
+
+    try:
+        from torch._library.fake_impl import Kernel
+        from torch._library.simple_registry import singleton
+
+        entry = singleton.find("_moe_C::moe_wna16_marlin_gemm")
+        if len(entry.fake_impl.kernels) > 1:
+            entry.fake_impl.kernels[:] = [
+                Kernel(fake_impl, "[GMS] moe_wna16_marlin_gemm fake override")
+            ]
+    except Exception:
+        logger.debug(
+            "[GMS vLLM Workaround] Could not prune stale WNA16 fake impls",
+            exc_info=True,
+        )
+
+    _moe_wna16_fake_patched = True
+    logger.info("[GMS vLLM Workaround] Patched moe_wna16_marlin_gemm fake impl")
+
+
+@contextmanager
+def fused_moe_cpu_routing_buffers_during_meta_init() -> Iterator[None]:
+    """Keep vLLM FusedMoE expert maps off meta during GMS RO construction."""
+    try:
+        import torch
+        import vllm.model_executor.layers.fused_moe.layer as fused_moe_layer
+    except ImportError:
+        logger.debug("[GMS vLLM Workaround] vLLM FusedMoE layer not available")
+        yield
+        return
+
+    global _fused_moe_determine_expert_map_wrapper
+    global _fused_moe_layer_module
+    global _fused_moe_original_determine_expert_map
+    global _fused_moe_patch_depth
+
+    with _fused_moe_patch_lock:
+        if _fused_moe_patch_depth == 0:
+
+            def determine_expert_map_on_cpu(*args, **kwargs):
+                assert _fused_moe_original_determine_expert_map is not None
+                with torch.device("cpu"):
+                    return _fused_moe_original_determine_expert_map(*args, **kwargs)
+
+            _fused_moe_layer_module = fused_moe_layer
+            _fused_moe_original_determine_expert_map = (
+                fused_moe_layer.determine_expert_map
+            )
+            _fused_moe_determine_expert_map_wrapper = determine_expert_map_on_cpu
+            fused_moe_layer.determine_expert_map = determine_expert_map_on_cpu
+
+        _fused_moe_patch_depth += 1
+
+    try:
+        yield
+    finally:
+        with _fused_moe_patch_lock:
+            _fused_moe_patch_depth -= 1
+            if _fused_moe_patch_depth == 0:
+                if (
+                    _fused_moe_layer_module is not None
+                    and _fused_moe_layer_module.determine_expert_map
+                    is _fused_moe_determine_expert_map_wrapper
+                ):
+                    _fused_moe_layer_module.determine_expert_map = (
+                        _fused_moe_original_determine_expert_map
+                    )
+                _fused_moe_layer_module = None
+                _fused_moe_original_determine_expert_map = None
+                _fused_moe_determine_expert_map_wrapper = None
+
+
+class _CpuPlatformProxy:
+    device_type = "cpu"
+
+    def __init__(self, delegate: Any) -> None:
+        self._delegate = delegate
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._delegate, name)
+
+
+@contextmanager
+def deepseek_rope_cpu_cache_during_meta_init() -> Iterator[None]:
+    """Build DeepSeek RoPE constructor caches on CPU during GMS RO load."""
+    try:
+        import torch
+        import vllm.model_executor.layers.rotary_embedding.deepseek_scaling_rope as deepseek_rope
+    except ImportError:
+        logger.debug("[GMS vLLM Workaround] vLLM DeepSeek RoPE layer not available")
+        yield
+        return
+
+    classes = [
+        cls
+        for cls in (
+            getattr(deepseek_rope, "DeepseekScalingRotaryEmbedding", None),
+            getattr(deepseek_rope, "DeepseekV4ScalingRotaryEmbedding", None),
+        )
+        if cls is not None
+    ]
+    # Preserve order while avoiding duplicate class objects.
+    classes = list(dict.fromkeys(classes))
+    if not classes:
+        yield
+        return
+
+    global _deepseek_rope_original_methods
+    global _deepseek_rope_patch_depth
+    global _deepseek_rope_wrappers
+
+    with _deepseek_rope_patch_lock:
+        if _deepseek_rope_patch_depth == 0:
+            _deepseek_rope_original_methods = {}
+            _deepseek_rope_wrappers = {}
+
+            def make_wrapper(original):
+                def compute_cache_on_cpu(self, *args, **kwargs):
+                    with _deepseek_rope_compute_lock:
+                        original_platform = getattr(
+                            deepseek_rope,
+                            "current_platform",
+                            None,
+                        )
+                        if original_platform is not None:
+                            deepseek_rope.current_platform = _CpuPlatformProxy(
+                                original_platform,
+                            )
+                        try:
+                            with torch.device("cpu"):
+                                return original(self, *args, **kwargs)
+                        finally:
+                            if original_platform is not None:
+                                deepseek_rope.current_platform = original_platform
+
+                return compute_cache_on_cpu
+
+            for cls in classes:
+                original = cls._compute_cos_sin_cache
+                wrapper = make_wrapper(original)
+                _deepseek_rope_original_methods[cls] = original
+                _deepseek_rope_wrappers[cls] = wrapper
+                cls._compute_cos_sin_cache = wrapper
+
+        _deepseek_rope_patch_depth += 1
+
+    try:
+        yield
+    finally:
+        with _deepseek_rope_patch_lock:
+            _deepseek_rope_patch_depth -= 1
+            if _deepseek_rope_patch_depth == 0:
+                assert _deepseek_rope_original_methods is not None
+                assert _deepseek_rope_wrappers is not None
+                for cls, original in _deepseek_rope_original_methods.items():
+                    if cls._compute_cos_sin_cache is _deepseek_rope_wrappers[cls]:
+                        cls._compute_cos_sin_cache = original
+                _deepseek_rope_original_methods = None
+                _deepseek_rope_wrappers = None
+
+
+@contextmanager
+def meta_safe_module_to_during_meta_init() -> Iterator[None]:
+    """Keep meta tensors on meta when constructors call ``Module.to(cuda)``."""
+    try:
+        import torch
+    except ImportError:
+        yield
+        return
+
+    def has_meta_tensors(module):
+        return any(
+            getattr(tensor, "is_meta", False)
+            for tensor in module.parameters(recurse=True)
+        ) or any(
+            getattr(tensor, "is_meta", False) for tensor in module.buffers(recurse=True)
+        )
+
+    global _module_to_module
+    global _module_to_original
+    global _module_to_patch_depth
+    global _module_to_wrapper
+
+    with _module_to_patch_lock:
+        if _module_to_patch_depth == 0:
+            _module_to_module = torch.nn.Module
+            _module_to_original = torch.nn.Module.to
+
+            def meta_safe_to(self, *args, **kwargs):
+                assert _module_to_original is not None
+                try:
+                    device, dtype, non_blocking, memory_format = torch._C._nn._parse_to(
+                        *args, **kwargs
+                    )
+                except Exception:
+                    return _module_to_original(self, *args, **kwargs)
+
+                if (
+                    device is None
+                    or device.type == "meta"
+                    or not has_meta_tensors(self)
+                ):
+                    return _module_to_original(self, *args, **kwargs)
+
+                def convert(tensor):
+                    target_device = torch.device("meta") if tensor.is_meta else device
+                    target_dtype = (
+                        dtype
+                        if dtype is not None
+                        and (tensor.is_floating_point() or tensor.is_complex())
+                        else None
+                    )
+                    if memory_format is not None and tensor.dim() in (4, 5):
+                        return tensor.to(
+                            target_device,
+                            target_dtype,
+                            non_blocking,
+                            memory_format=memory_format,
+                        )
+                    return tensor.to(target_device, target_dtype, non_blocking)
+
+                return self._apply(convert)
+
+            _module_to_wrapper = meta_safe_to
+            torch.nn.Module.to = meta_safe_to
+
+        _module_to_patch_depth += 1
+
+    try:
+        yield
+    finally:
+        with _module_to_patch_lock:
+            _module_to_patch_depth -= 1
+            if _module_to_patch_depth == 0:
+                if (
+                    _module_to_module is not None
+                    and _module_to_module.to is _module_to_wrapper
+                ):
+                    _module_to_module.to = _module_to_original
+                _module_to_module = None
+                _module_to_original = None
+                _module_to_wrapper = None
+
+
+@contextmanager
+def vllm_meta_init_workarounds() -> Iterator[None]:
+    """Apply temporary vLLM meta-init workarounds in one narrow scope."""
+    with (
+        fused_moe_cpu_routing_buffers_during_meta_init(),
+        deepseek_rope_cpu_cache_during_meta_init(),
+        meta_safe_module_to_during_meta_init(),
+    ):
+        yield

--- a/lib/gpu_memory_service/integrations/vllm/upstream_workarounds.py
+++ b/lib/gpu_memory_service/integrations/vllm/upstream_workarounds.py
@@ -202,6 +202,46 @@ def patch_moe_wna16_marlin_gemm_fake_impl() -> None:
 
     _moe_wna16_fake_patched = True
     logger.info("[GMS vLLM Workaround] Patched moe_wna16_marlin_gemm fake impl")
+    _patch_moe_c_void_fake_impls()
+
+
+_moe_c_void_fake_patched = False
+
+
+def _patch_moe_c_void_fake_impls() -> None:
+    """Register fake impls for in-place _moe_C ops that vLLM traces on meta."""
+    global _moe_c_void_fake_patched
+    if _moe_c_void_fake_patched:
+        return
+    try:
+        import torch
+        import vllm._custom_ops  # noqa: F401
+        from torch.library import register_fake
+    except ImportError:
+        return
+    if not hasattr(torch.ops, "_moe_C"):
+        return
+
+    def _void(*_args, **_kwargs):
+        return None
+
+    for op_name in (
+        "topk_softplus_sqrt",
+        "topk_softmax",
+        "topk_sigmoid",
+    ):
+        if not hasattr(torch.ops._moe_C, op_name):
+            continue
+        try:
+            register_fake(f"_moe_C::{op_name}", allow_override=True)(_void)
+            logger.info("[GMS vLLM Workaround] Patched %s fake impl", op_name)
+        except Exception:
+            logger.debug(
+                "[GMS vLLM Workaround] Could not patch %s fake impl",
+                op_name,
+                exc_info=True,
+            )
+    _moe_c_void_fake_patched = True
 
 
 @contextmanager
@@ -212,6 +252,25 @@ def fused_moe_cpu_routing_buffers_during_meta_init() -> Iterator[None]:
         import vllm.model_executor.layers.fused_moe.layer as fused_moe_layer
     except ImportError:
         logger.debug("[GMS vLLM Workaround] vLLM FusedMoE layer not available")
+        yield
+        return
+
+    target_module = None
+    attr_name = "determine_expert_map"
+    if hasattr(fused_moe_layer, attr_name):
+        target_module = fused_moe_layer
+    else:
+        try:
+            import vllm.model_executor.layers.fused_moe.expert_map_manager as expert_map_manager
+        except ImportError:
+            expert_map_manager = None
+        if expert_map_manager is not None and hasattr(expert_map_manager, attr_name):
+            target_module = expert_map_manager
+
+    if target_module is None:
+        logger.debug(
+            "[GMS vLLM Workaround] determine_expert_map not found; skipping FusedMoE patch"
+        )
         yield
         return
 
@@ -228,12 +287,15 @@ def fused_moe_cpu_routing_buffers_during_meta_init() -> Iterator[None]:
                 with torch.device("cpu"):
                     return _fused_moe_original_determine_expert_map(*args, **kwargs)
 
-            _fused_moe_layer_module = fused_moe_layer
-            _fused_moe_original_determine_expert_map = (
-                fused_moe_layer.determine_expert_map
-            )
+            _fused_moe_layer_module = target_module
+            _fused_moe_original_determine_expert_map = getattr(target_module, attr_name)
             _fused_moe_determine_expert_map_wrapper = determine_expert_map_on_cpu
-            fused_moe_layer.determine_expert_map = determine_expert_map_on_cpu
+            setattr(target_module, attr_name, determine_expert_map_on_cpu)
+            logger.info(
+                "[GMS vLLM Workaround] Patching %s.%s onto CPU during meta init",
+                target_module.__name__,
+                attr_name,
+            )
 
         _fused_moe_patch_depth += 1
 
@@ -245,11 +307,13 @@ def fused_moe_cpu_routing_buffers_during_meta_init() -> Iterator[None]:
             if _fused_moe_patch_depth == 0:
                 if (
                     _fused_moe_layer_module is not None
-                    and _fused_moe_layer_module.determine_expert_map
+                    and getattr(_fused_moe_layer_module, attr_name, None)
                     is _fused_moe_determine_expert_map_wrapper
                 ):
-                    _fused_moe_layer_module.determine_expert_map = (
-                        _fused_moe_original_determine_expert_map
+                    setattr(
+                        _fused_moe_layer_module,
+                        attr_name,
+                        _fused_moe_original_determine_expert_map,
                     )
                 _fused_moe_layer_module = None
                 _fused_moe_original_determine_expert_map = None

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -52,6 +52,9 @@ from gpu_memory_service.integrations.vllm.patches import (
     apply_scratch_kv_patches,
     patch_memory_snapshot,
 )
+from gpu_memory_service.integrations.vllm.upstream_workarounds import (
+    patch_moe_wna16_marlin_gemm_fake_impl,
+)
 from gpu_memory_service.integrations.vllm.utils import configure_gms_worker_logging
 
 logger = logging.getLogger(__name__)
@@ -66,6 +69,8 @@ register_gms_loader()
 # Apply core utility patches (always needed for GMS)
 patch_empty_cache()
 patch_memory_snapshot()
+# Constructor-time vLLM shims (DeepSeek V4 / MoE). No-op if the op is gone.
+patch_moe_wna16_marlin_gemm_fake_impl()
 
 # Apply scratch-KV patches when DYN_GMS_SCRATCH_KV_ENABLED is set
 apply_scratch_kv_patches()

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -50,6 +50,7 @@ from gpu_memory_service.integrations.vllm.model_loader import (
 )
 from gpu_memory_service.integrations.vllm.patches import (
     apply_scratch_kv_patches,
+    patch_dsv4_topk_clone_inputs,
     patch_memory_snapshot,
 )
 from gpu_memory_service.integrations.vllm.upstream_workarounds import (
@@ -71,6 +72,8 @@ patch_empty_cache()
 patch_memory_snapshot()
 # Constructor-time vLLM shims (DeepSeek V4 / MoE). No-op if the op is gone.
 patch_moe_wna16_marlin_gemm_fake_impl()
+# Triton dsv4_topk: clone VMM operands, keep the real kernel (not PyTorch).
+patch_dsv4_topk_clone_inputs()
 
 # Apply scratch-KV patches when DYN_GMS_SCRATCH_KV_ENABLED is set
 apply_scratch_kv_patches()
@@ -205,9 +208,6 @@ class GMSWorker(Worker):
         return available
 
     def _determine_available_memory_before_gms_publish(self) -> int:
-        if not is_scratch_kv_enabled():
-            return super().determine_available_memory()
-
         import vllm.envs as envs
         from vllm.config import CUDAGraphMode
         from vllm.platforms import current_platform
@@ -217,15 +217,61 @@ class GMSWorker(Worker):
         # import's GMS mappings are not, so only those imported bytes need
         # adding below.
         has_pending_write = has_pending_gms_write()
+        skip_profile = os.environ.get("DYN_GMS_SKIP_PROFILE_RUN", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        # RO import: dummy profile_run IMA on GMS VMM (DSV4 TEP8 and GLM-5.2
+        # NVFP4 TEP8). First-boot RW still profiles when scratch-KV is off.
+        # With scratch-KV, dummy profile_run calls gms_use_mem_pool("kv_cache")
+        # before any kv_cache allocator exists (that is created later in
+        # initialize_from_config). Skip the dummy run; size KV from allocated
+        # bytes + headroom, same as DYN_GMS_SKIP_PROFILE_RUN=1 on DSV4.
+        if not has_pending_write and get_imported_weights_bytes() > 0:
+            skip_profile = True
+        if is_scratch_kv_enabled():
+            skip_profile = True
+
+        if not is_scratch_kv_enabled() and not skip_profile:
+            return super().determine_available_memory()
 
         torch_device().reset_peak_memory_stats()
-        self.model_runner.profile_run()
-        torch_device().synchronize()
-        torch_peak = torch_device().max_memory_allocated()
+        # Dummy profile_run() launches DSV4 TileLang/Triton kernels (MHC +
+        # dsv4_topk) against GMS VMM-backed weights and hits CUDA IMA on
+        # B200 TEP8. Skip it when requested and size KV from current
+        # allocation plus a conservative activation headroom instead.
+        if skip_profile:
+            torch_device().synchronize()
+            torch_peak = torch_device().max_memory_allocated()
+            # RO imports do not show GMS weights in torch's allocator; a large
+            # activation headroom would starve KV. DYN_GMS_PROFILE_HEADROOM_GIB
+            # is the RW value (env is 12 on this DGD); RO uses a smaller default.
+            if has_pending_write:
+                headroom_gib = float(
+                    os.environ.get("DYN_GMS_PROFILE_HEADROOM_GIB", "12")
+                )
+            else:
+                headroom_gib = float(
+                    os.environ.get("DYN_GMS_RO_PROFILE_HEADROOM_GIB", "3")
+                )
+            headroom = int(headroom_gib * (1 << 30))
+            logger.warning(
+                "[GMS] Skipping profile_run; using allocated=%.2f GiB + "
+                "headroom=%.2f GiB for KV sizing",
+                torch_peak / (1 << 30),
+                headroom_gib,
+            )
+            torch_peak = int(torch_peak + headroom)
+        else:
+            self.model_runner.profile_run()
+            torch_device().synchronize()
+            torch_peak = torch_device().max_memory_allocated()
 
         cudagraph_memory_estimate = 0
         if (
-            current_platform.is_cuda()
+            not skip_profile
+            and current_platform.is_cuda()
             and self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
         ):
             cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
@@ -268,8 +314,9 @@ class GMSWorker(Worker):
         """Allocate KV cache backing.
 
         In scratch-KV mode the tensors are allocated over scratch-aliased
-        backing client-side; wake_up drops scratch backing and installs fresh
-        server backing via the standard reallocate+remap path. With
+        backing client-side. CUDA-graph capture runs against those VAs during
+        compile_or_warm_up_model. wake_up drops scratch backing and installs
+        fresh server backing via the standard reallocate+remap path. With
         enable_sleep_mode the manager connects RW at init and allocates real
         backing immediately.
         """
@@ -324,6 +371,43 @@ class GMSWorker(Worker):
         else:
             self.model_runner.initialize_kv_cache(kv_cache_config)
 
+    def compile_or_warm_up_model(self):
+        """Warm up and capture CUDA graphs against the current KV VAs.
+
+        Scratch-KV aliases one physical granule under the full KV VA, so
+        dummy_run writes are mapped (they clobber the alias). CUDA graphs
+        capture VAs, not physical handles; wake_up later installs unique
+        backing at the same VAs and replay is unchanged. Capture here so
+        the shadow is graph-ready before sleep; do not recapture in wake_up.
+        """
+        skip_env = os.environ.get("DYN_GMS_SKIP_KERNEL_WARMUP", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        if skip_env:
+            from vllm.utils.gc_utils import freeze_gc_heap, maybe_attach_gc_debug_callback
+            from vllm.utils.gpu_sync_debug import enable_gpu_sync_check
+            from vllm.utils.jit_monitor import activate as activate_jit_monitor
+            from vllm.v1.worker.worker_base import CompilationTimes
+
+            logger.warning(
+                "[GMS] Skipping kernel_warmup / CUDA-graph capture "
+                "(DYN_GMS_SKIP_KERNEL_WARMUP)"
+            )
+            activate_jit_monitor(
+                mode=self.observability_config.jit_monitor_mode,
+                verbose=self.observability_config.jit_monitor_verbose,
+            )
+            freeze_gc_heap()
+            maybe_attach_gc_debug_callback()
+            enable_gpu_sync_check()
+            return CompilationTimes(
+                language_model=self.compilation_config.compilation_time,
+                encoder=self.compilation_config.encoder_compilation_time,
+            )
+        return super().compile_or_warm_up_model()
+
     def load_model(self, *args, **kwargs) -> None:
         """Load model with corrected memory accounting.
 
@@ -332,6 +416,11 @@ class GMSWorker(Worker):
         by vLLM's memory tracking).
         """
         super().load_model(*args, **kwargs)
+        try:
+            torch.cuda.synchronize()
+        except Exception:
+            logger.exception("[GMS] CUDA error immediately after load_model")
+            raise
 
         # Correct memory accounting for GMS-imported weights
         try:

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -51,6 +51,7 @@ from gpu_memory_service.integrations.vllm.model_loader import (
 from gpu_memory_service.integrations.vllm.patches import (
     apply_scratch_kv_patches,
     patch_dsv4_gather_k_cache_check,
+    patch_dsv4_hash_topk_probe,
     patch_dsv4_layer_probe,
     patch_dsv4_gather_k_cache_triton,
     patch_dsv4_topk_clone_inputs,
@@ -84,6 +85,8 @@ patch_dsv4_gather_k_cache_triton()
 patch_dsv4_gather_k_cache_check()
 # Diagnostic: bisect which DSv4 stage first poisons the CUDA context.
 patch_dsv4_layer_probe()
+# Diagnostic: report operand dtypes reaching the hash-MoE top-k op.
+patch_dsv4_hash_topk_probe()
 
 # Apply scratch-KV patches when DYN_GMS_SCRATCH_KV_ENABLED is set
 apply_scratch_kv_patches()

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -51,6 +51,7 @@ from gpu_memory_service.integrations.vllm.model_loader import (
 from gpu_memory_service.integrations.vllm.patches import (
     apply_scratch_kv_patches,
     patch_dsv4_topk_clone_inputs,
+    patch_force_eager_breakable_cudagraph,
     patch_memory_snapshot,
 )
 from gpu_memory_service.integrations.vllm.upstream_workarounds import (
@@ -77,6 +78,17 @@ patch_dsv4_topk_clone_inputs()
 
 # Apply scratch-KV patches when DYN_GMS_SCRATCH_KV_ENABLED is set
 apply_scratch_kv_patches()
+
+# When kernel_warmup / capture_model is skipped, nothing has captured CUDA
+# graphs by the time the first real request arrives, so
+# BreakableCUDAGraphWrapper tries to capture inside that request and dies on
+# unpinned CPU->CUDA copies ("Cannot copy between CPU and CUDA tensors during
+# CUDA graph capture"). Forcing the wrapper eager avoids capture entirely.
+# Scratch-KV enables this implicitly; DYN_GMS_FORCE_EAGER_CUDAGRAPH exposes it
+# for the no-shadow read-only import path, which skips warmup for the same
+# reason but is not scratch-KV.
+if os.environ.get("DYN_GMS_FORCE_EAGER_CUDAGRAPH", "").lower() in ("1", "true", "yes"):
+    patch_force_eager_breakable_cudagraph()
 
 logger.info("[GMS] Worker module loaded - model loader registered, all patches applied")
 

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -50,6 +50,9 @@ from gpu_memory_service.integrations.vllm.model_loader import (
 )
 from gpu_memory_service.integrations.vllm.patches import (
     apply_scratch_kv_patches,
+    patch_dsv4_gather_k_cache_check,
+    patch_dsv4_layer_probe,
+    patch_dsv4_gather_k_cache_triton,
     patch_dsv4_topk_clone_inputs,
     patch_force_eager_breakable_cudagraph,
     patch_memory_snapshot,
@@ -75,6 +78,12 @@ patch_memory_snapshot()
 patch_moe_wna16_marlin_gemm_fake_impl()
 # Triton dsv4_topk: clone VMM operands, keep the real kernel (not PyTorch).
 patch_dsv4_topk_clone_inputs()
+# DSv4 K-cache gather: CuTeDSL's alignment contract does not hold under GMS.
+patch_dsv4_gather_k_cache_triton()
+# Diagnostic: validate the gather's block table / seq lens before it faults.
+patch_dsv4_gather_k_cache_check()
+# Diagnostic: bisect which DSv4 stage first poisons the CUDA context.
+patch_dsv4_layer_probe()
 
 # Apply scratch-KV patches when DYN_GMS_SCRATCH_KV_ENABLED is set
 apply_scratch_kv_patches()

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -52,6 +52,8 @@ from gpu_memory_service.integrations.vllm.patches import (
     apply_scratch_kv_patches,
     patch_dsv4_gather_k_cache_check,
     patch_dsv4_hash_topk_probe,
+    gms_dsv4_weight_digest,
+    patch_dsv4_weight_digest,
     patch_dsv4_layer_probe,
     patch_dsv4_gather_k_cache_triton,
     patch_dsv4_topk_clone_inputs,
@@ -87,6 +89,8 @@ patch_dsv4_gather_k_cache_check()
 patch_dsv4_layer_probe()
 # Diagnostic: report operand dtypes reaching the hash-MoE top-k op.
 patch_dsv4_hash_topk_probe()
+# Diagnostic: checksum weights so RW and RO loads can be compared.
+patch_dsv4_weight_digest()
 
 # Apply scratch-KV patches when DYN_GMS_SCRATCH_KV_ENABLED is set
 apply_scratch_kv_patches()
@@ -445,6 +449,8 @@ class GMSWorker(Worker):
         except Exception:
             logger.exception("[GMS] CUDA error immediately after load_model")
             raise
+
+        gms_dsv4_weight_digest(self.model_runner.model)
 
         # Correct memory accounting for GMS-imported weights
         try:

--- a/lib/gpu_memory_service/snapshot/storage_client.py
+++ b/lib/gpu_memory_service/snapshot/storage_client.py
@@ -197,7 +197,14 @@ class GMSStorageClient:
         targets: Dict[str, GMSTransferTarget] = {}
         for entry in manifest.allocations:
             old_id = entry.allocation_id
-            va = mm.create_mapping(size=entry.size, tag=entry.tag)
+            # dedicated=True: a restore reproduces a published layout
+            # byte-for-byte. The saved tensor metadata carries offsets relative
+            # to each original allocation and is replayed unchanged, so one
+            # allocation per manifest entry is load-bearing -- carving these
+            # out of a shared slab would rebase every offset after the first
+            # region in a slab, and the server's bound check cannot catch it
+            # because the slab is larger than the allocation it replaced.
+            va = mm.create_mapping(size=entry.size, tag=entry.tag, dedicated=True)
             id_map[old_id] = mm.mappings[va].allocation_id
             targets[old_id] = GMSTransferTarget(
                 allocation_id=old_id,

--- a/lib/gpu_memory_service/tests/test_client_slabs.py
+++ b/lib/gpu_memory_service/tests/test_client_slabs.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""First-fit slab packing in the V0 client memory manager.
+
+Exercises the allocator through GMSClientMemoryManager with the CUDA VMM and
+the GMS session faked out, so the packing arithmetic is covered without a GPU.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
+from gpu_memory_service.common.locks import GrantedLockType
+
+GRANULARITY = 2 * 1024 * 1024
+SLAB = 16 * GRANULARITY
+
+
+class _FakeVMM:
+    """Hands out non-overlapping VA reservations and records what is mapped."""
+
+    def __init__(self) -> None:
+        self.next_va = 1 << 40
+        self.reservations: dict[int, int] = {}
+        self.mapped: dict[int, int] = {}
+        self.released: list[int] = []
+        self.next_handle = 1
+
+    def ensure_initialized(self) -> None:
+        pass
+
+    def get_allocation_granularity(self, device: int) -> int:
+        return GRANULARITY
+
+    def address_reserve(self, size: int, granularity: int) -> int:
+        va = self.next_va
+        self.next_va += size + granularity
+        self.reservations[va] = size
+        return va
+
+    def address_free(self, va: int, size: int) -> None:
+        assert self.reservations.pop(va, None) == size, f"bad free of 0x{va:x}"
+
+    def import_shareable_handle_close_fd(self, fd: int) -> int:
+        handle = self.next_handle
+        self.next_handle += 1
+        return handle
+
+    def map(self, va: int, size: int, handle: int) -> None:
+        self.mapped[va] = size
+
+    def unmap(self, va: int, size: int) -> None:
+        self.mapped.pop(va, None)
+
+    def release(self, handle: int) -> None:
+        self.released.append(handle)
+
+    def set_access(self, va, size, device, lock_type) -> None:
+        pass
+
+    def synchronize(self) -> None:
+        pass
+
+    def validate_pointer(self, va: int) -> None:
+        pass
+
+
+class _FakeSession:
+    """Minimal stand-in for the server RPC surface the allocator touches."""
+
+    def __init__(self) -> None:
+        self.live: dict[str, int] = {}
+        self.slot = 0
+        self.next_id = 0
+
+    def allocate_info(self, aligned_size: int, tag: str):
+        self.next_id += 1
+        allocation_id = f"alloc-{self.next_id}"
+        self.live[allocation_id] = aligned_size
+        slot, self.slot = self.slot, self.slot + 1
+        return type(
+            "AllocateResponse",
+            (),
+            {
+                "allocation_id": allocation_id,
+                "aligned_size": aligned_size,
+                "layout_slot": slot,
+            },
+        )()
+
+    def export(self, allocation_id: str) -> int:
+        assert allocation_id in self.live, f"export of freed {allocation_id}"
+        return 7
+
+    def free(self, allocation_id: str) -> bool:
+        return self.live.pop(allocation_id, None) is not None
+
+
+@pytest.fixture()
+def manager(monkeypatch):
+    vmm = _FakeVMM()
+    monkeypatch.setattr(
+        "gpu_memory_service.client.memory_manager.get_vmm", lambda: vmm
+    )
+
+    def build(slab_size=SLAB):
+        mgr = GMSClientMemoryManager(
+            "/tmp/does-not-exist.sock", device=0, tag="weights", slab_size=slab_size
+        )
+        mgr._client = _FakeSession()
+        mgr._granted_lock_type = GrantedLockType.RW
+        mgr.vmm = vmm
+        return mgr
+
+    build.vmm = vmm
+    return build
+
+
+def test_many_allocations_share_one_slab(manager):
+    mgr = manager()
+    vas = [mgr.create_mapping(size=GRANULARITY, tag="weights") for _ in range(8)]
+
+    assert len(set(vas)) == 8
+    # One server allocation, one VA reservation, one cuMemMap for all 8.
+    assert len(mgr.mappings) == 1
+    assert len(manager.vmm.reservations) == 1
+    assert all(mgr.owns(va) for va in vas)
+
+
+def test_total_bytes_reports_carved_not_reserved(manager):
+    mgr = manager()
+    mgr.create_mapping(size=GRANULARITY, tag="weights")
+
+    # A slab is mapped whole; only the carved byte counts as weight memory.
+    assert mgr.total_bytes == GRANULARITY
+    assert mgr.reserved_bytes == SLAB
+
+
+def test_slab_grows_when_full_and_retires_when_empty(manager):
+    mgr = manager()
+    vas = [mgr.create_mapping(size=4 * GRANULARITY, tag="weights") for _ in range(6)]
+    assert len(mgr.mappings) == 2, "16 granules per slab, 4 per carve -> 2 slabs"
+
+    for va in vas:
+        mgr.destroy_mapping(va, 4 * GRANULARITY)
+
+    assert mgr.mappings == {}
+    assert manager.vmm.reservations == {}
+    assert mgr.total_bytes == 0
+
+
+def test_freed_region_is_reused_and_holes_coalesce(manager):
+    mgr = manager()
+    first = mgr.create_mapping(size=GRANULARITY, tag="weights")
+    second = mgr.create_mapping(size=GRANULARITY, tag="weights")
+    mgr.create_mapping(size=GRANULARITY, tag="weights")
+
+    assert len(mgr.mappings) == 1
+    mgr.destroy_mapping(first, GRANULARITY)
+    assert mgr.create_mapping(size=GRANULARITY, tag="weights") == first
+
+    # Free two adjacent regions out of order; they must merge into one hole
+    # big enough for a carve neither could satisfy alone.
+    mgr.destroy_mapping(second, GRANULARITY)
+    mgr.destroy_mapping(first, GRANULARITY)
+    merged = mgr.create_mapping(size=2 * GRANULARITY, tag="weights")
+    assert merged == min(first, second)
+    assert len(mgr.mappings) == 1
+
+
+def test_oversized_allocation_gets_its_own_slab(manager):
+    mgr = manager()
+    big = mgr.create_mapping(size=SLAB * 2, tag="weights")
+
+    assert len(mgr.mappings) == 1
+    assert mgr.mappings[big].aligned_size == SLAB * 2
+    # A slab whose single region spans it entirely starts with no holes; it
+    # must still be recognised as empty on free.
+    mgr.destroy_mapping(big, SLAB * 2)
+    assert mgr.mappings == {}
+    assert manager.vmm.reservations == {}
+
+
+def test_tags_never_share_a_slab(manager):
+    mgr = manager()
+    mgr.create_mapping(size=GRANULARITY, tag="weights")
+    mgr.create_mapping(size=GRANULARITY, tag="kv_cache")
+
+    assert len(mgr.mappings) == 2
+    tags = {m.tag for m in mgr.mappings.values()}
+    assert tags == {"weights", "kv_cache"}
+
+
+def test_unaligned_sizes_round_up_and_free_symmetrically(manager):
+    mgr = manager()
+    va = mgr.create_mapping(size=GRANULARITY + 1, tag="weights")
+    other = mgr.create_mapping(size=1, tag="weights")
+
+    # The carve is granularity-aligned, so the neighbour cannot overlap it.
+    assert other >= va + 2 * GRANULARITY
+    mgr.destroy_mapping(va, GRANULARITY + 1)
+    mgr.destroy_mapping(other, 1)
+    assert mgr.mappings == {}
+
+
+def test_free_with_mismatched_size_is_rejected(manager):
+    mgr = manager()
+    va = mgr.create_mapping(size=GRANULARITY, tag="weights")
+    with pytest.raises(RuntimeError, match="does not match"):
+        mgr.destroy_mapping(va, 4 * GRANULARITY)
+
+
+def test_disabled_slabbing_allocates_one_mapping_per_call(manager):
+    mgr = manager(slab_size=0)
+    vas = [mgr.create_mapping(size=GRANULARITY, tag="weights") for _ in range(3)]
+
+    assert len(mgr.mappings) == 3
+    assert all(va in mgr.mappings for va in vas)
+    assert mgr.total_bytes == 3 * GRANULARITY
+
+
+def test_dedicated_bypasses_slabs_while_packing_stays_on(manager):
+    mgr = manager()
+    packed = mgr.create_mapping(size=GRANULARITY, tag="weights")
+    alone = mgr.create_mapping(size=GRANULARITY, tag="weights", dedicated=True)
+
+    # The snapshot restore path needs its own allocation per manifest entry so
+    # saved allocation-relative offsets replay unchanged: its mapping spans
+    # exactly the request, not a slab.
+    assert mgr.mappings[alone].aligned_size == GRANULARITY
+    assert alone not in mgr._regions
+
+    # The first carve of a slab lands on the slab base, so it shares that VA
+    # with the slab's own mapping; packing continues in it regardless.
+    assert packed in mgr._regions
+    assert mgr.mappings[packed].aligned_size == SLAB
+    assert mgr.create_mapping(size=GRANULARITY, tag="weights") == packed + GRANULARITY
+    assert len(mgr.mappings) == 2
+
+
+def test_freeing_the_first_carve_does_not_destroy_a_live_slab(manager):
+    # The first carve of a slab lands on the slab's own base VA. Freeing it
+    # while siblings are live must return only that region, not tear down the
+    # slab underneath them.
+    mgr = manager()
+    first = mgr.create_mapping(size=GRANULARITY, tag="weights")
+    second = mgr.create_mapping(size=GRANULARITY, tag="weights")
+    assert first in mgr.mappings, "first carve shares the slab base VA"
+
+    mgr.destroy_mapping(first, GRANULARITY)
+
+    assert len(mgr.mappings) == 1, "slab must survive; a sibling is still live"
+    assert mgr.owns(second)
+    assert manager.vmm.mapped, "slab must still be mapped"
+    assert mgr.total_bytes == GRANULARITY
+
+    mgr.destroy_mapping(second, GRANULARITY)
+    assert mgr.mappings == {}
+    assert manager.vmm.reservations == {}
+
+
+def test_failed_slab_grow_leaves_no_orphaned_state(manager, monkeypatch):
+    mgr = manager()
+
+    def boom(allocation_id):
+        raise RuntimeError("export failed")
+
+    monkeypatch.setattr(mgr, "export_handle", boom)
+    with pytest.raises(RuntimeError, match="export failed"):
+        mgr.create_mapping(size=GRANULARITY, tag="weights")
+
+    assert mgr.mappings == {}
+    assert manager.vmm.reservations == {}
+    assert mgr._client.live == {}, "server allocation must be rolled back"

--- a/lib/gpu_memory_service/tests/test_gms_write_publication.py
+++ b/lib/gpu_memory_service/tests/test_gms_write_publication.py
@@ -57,7 +57,7 @@ class _FakeAllocator:
 
 @pytest.fixture
 def gms_write(monkeypatch):
-    """A prepared (registered + pruned, uncommitted) fake GMS write."""
+    """A prepared (registered + reclaimed, uncommitted) fake GMS write."""
     events = []
     allocator = _FakeAllocator(events)
 
@@ -65,14 +65,15 @@ def gms_write(monkeypatch):
         events.append("register")
         return {"weight"}
 
-    def prune(_allocator, *, referenced_allocation_ids):
-        assert referenced_allocation_ids == {"weight"}
-        events.append("prune")
+    def release_mempool(_allocator):
+        # Destroying the mempool hands torch's cached, unreferenced blocks
+        # back through the free callback; live Parameter storage stays mapped.
+        events.append("release_mempool")
         _allocator.mappings.pop(2)
         _allocator.total_bytes = 60
 
     monkeypatch.setattr(common_utils, "register_module_tensors", register)
-    monkeypatch.setattr(common_utils, "prune_allocations", prune)
+    monkeypatch.setattr(common_utils, "release_weight_mempool", release_mempool)
     monkeypatch.setattr(
         common_utils,
         "rebind_nonparameter_tensors",
@@ -91,11 +92,11 @@ def clear_pending_write(monkeypatch):
     monkeypatch.setattr(model_loader, "_last_model_memory_usage_offset_bytes", 0)
 
 
-def test_prepare_registers_prunes_and_defers_commit(gms_write):
-    """Prepare must not commit; accounting covers pruned and rebound bytes."""
+def test_prepare_registers_reclaims_and_defers_commit(gms_write):
+    """Prepare must not commit; accounting covers reclaimed and rebound bytes."""
     allocator, stats, events = gms_write
 
-    assert events == ["register", "prune"]
+    assert events == ["register", "release_mempool"]
     assert stats.committed_bytes == 60
     assert stats.pruned_bytes == 40
     assert stats.pruned_count == 1
@@ -113,7 +114,7 @@ def test_pending_write_publish_clears_pending(gms_write):
 
     assert model_loader.publish_pending_gms_write()
 
-    assert events == ["register", "prune", "commit", "connect", "remap"]
+    assert events == ["register", "release_mempool", "commit", "connect", "remap"]
     assert not model_loader.has_pending_gms_write()
     assert not model_loader.publish_pending_gms_write()
 
@@ -125,7 +126,7 @@ def test_pending_write_abort_releases_writer_without_cuda_cleanup(gms_write):
 
     assert model_loader.abort_pending_gms_write()
 
-    assert events == ["register", "prune", "close_best_effort"]
+    assert events == ["register", "release_mempool", "close_best_effort"]
     assert "close" not in events
     assert model_loader._pending_retained_gms_tensors == []
     assert not model_loader.has_pending_gms_write()
@@ -140,7 +141,7 @@ def test_publication_failure_releases_writer_and_preserves_error(gms_write):
     with pytest.raises(RuntimeError, match="commit failed"):
         model_loader.publish_pending_gms_write()
 
-    assert events == ["register", "prune", "commit", "close_best_effort"]
+    assert events == ["register", "release_mempool", "commit", "close_best_effort"]
     assert not model_loader.has_pending_gms_write()
 
 
@@ -157,7 +158,7 @@ def test_eager_finalize_preserves_publish_then_rebind_order(gms_write):
     assert stats.pruned_bytes == 40
     assert events == [
         "register",
-        "prune",
+        "release_mempool",
         "commit",
         "connect",
         "remap",

--- a/lib/gpu_memory_service/tests/test_runtime_flows.py
+++ b/lib/gpu_memory_service/tests/test_runtime_flows.py
@@ -650,33 +650,27 @@ def test_destroy_mapping_frees_allocation_and_metadata(running_gms):
 
 
 @pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
-def test_prune_allocations_frees_unreferenced_mappings(running_gms):
+def test_destroy_mapping_releases_only_the_named_allocation(running_gms):
     _, socket_path = running_gms
-
-    from gpu_memory_service.client.torch.allocator import prune_allocations
 
     writer = GMSClientMemoryManager(socket_path, device=0)
     try:
         writer.connect(RequestedLockType.RW)
         keep_va = writer.create_mapping(size=4096, tag="weights")
-        prune_va = writer.create_mapping(size=8192, tag="weights")
+        drop_va = writer.create_mapping(size=8192, tag="weights")
 
         keep_allocation_id = writer.mappings[keep_va].allocation_id
-        prune_allocation_id = writer.mappings[prune_va].allocation_id
+        drop_allocation_id = writer.mappings[drop_va].allocation_id
 
-        prune_allocations(
-            writer,
-            referenced_allocation_ids={keep_allocation_id},
-            synchronize=False,
-        )
+        writer.destroy_mapping(drop_va)
 
         assert keep_va in writer.mappings
-        assert prune_va not in writer.mappings
+        assert drop_va not in writer.mappings
         assert [info.allocation_id for info in writer.list_handles()] == [
             keep_allocation_id
         ]
         with pytest.raises(RuntimeError, match="Unknown allocation"):
-            writer.get_handle_info(prune_allocation_id)
+            writer.get_handle_info(drop_allocation_id)
     finally:
         writer.close()
 
@@ -795,8 +789,6 @@ def test_remap_all_vas_accepts_restored_layout_after_pruned_slot_gap(
 
     _, socket_path = running_gms
 
-    from gpu_memory_service.client.torch.allocator import prune_allocations
-
     first_writer = GMSClientMemoryManager(socket_path, device=0)
     reader = GMSClientMemoryManager(socket_path, device=0)
     second_writer = GMSClientMemoryManager(socket_path, device=0)
@@ -814,11 +806,9 @@ def test_remap_all_vas_accepts_restored_layout_after_pruned_slot_gap(
         assert first_writer.mappings[pruned_va].layout_slot == 1
         assert kept_b.layout_slot == 2
 
-        prune_allocations(
-            first_writer,
-            referenced_allocation_ids={kept_a.allocation_id, kept_b.allocation_id},
-            synchronize=False,
-        )
+        # Dropping the middle allocation leaves a gap in the source slots,
+        # which is what the restored layout must be allowed to compact away.
+        first_writer.destroy_mapping(pruned_va)
         first_writer.metadata_put("tensor.0", kept_a.allocation_id, 0, b"a")
         first_writer.metadata_put("tensor.1", kept_b.allocation_id, 0, b"b")
         assert first_writer.commit()


### PR DESCRIPTION
## Summary

Draft, for tracking. This branch carries the GMS **V0** fixes that make the
read-only weight-import path correct. Until now they existed only on a local
worktree and as a hand-copied overlay tree on a benchmark node, so the code
behind the V0 measurements was unreproducible from git.

The V0 RO reader rebuilds the model on `meta` and rebinds tensors **by name**.
That representation cannot express tensor *aliasing*, and aliasing is
load-bearing in vLLM. Four defects followed:

| # | Defect | Effect on the RO replica |
|---|---|---|
| 1 | `rebind_nonparameter_tensors` rebound by name; `MLAAttention.impl` is not an `nn.Module`, so the module walk never reached it | indexer wrote top-k indices into one buffer, attention read another |
| 2 | `materialize_module_from_gms` cloned per name, splitting deliberate aliases (`W_UK_T`/`W_UV` are views over `kv_b_proj.weight`) | 2589 of 4209 published names are aliases; sharing was severed |
| 3 | leftover `meta` tensors zero-filled | MLA `q_scale`/`prob_scale` stayed `0.0` |
| 4 | shared top-k channel resolved per module | 57 of 78 GLM-5.2 layers are `skip_topk` consumers reading uninitialised CUDA memory |

Fixes: swap storage in place with `Tensor.set_()` so every holder follows
including unreachable ones; one clone per `(allocation_id, offset_bytes)` with
`as_strided` views per name; fill leftover meta tensors with the neutral value;
resolve the shared channel once per model.

The final commit adapts the V0 vLLM workarounds to newer vLLM layouts: wrap all
KV allocation entry points rather than only `model_runner.init_kv_cache` (a
stale import on vLLM 0.27 V2, where the `torch.zeros` live in
`attn_utils._allocate_kv_cache`), register void fake impls for the in-place
`_moe_C` topk ops traced during meta init, and resolve `determine_expert_map`
from either `fused_moe_layer` or `expert_map_manager`.

## Validation

GLM-5.2-NVFP4 TEP8 on 8xB200, same image and clocks in both arms, 0% prefix
cache. Read-only replica vs its publisher:

| ~prompt tokens | RO before | RO after | publisher | after / publisher |
|---:|---:|---:|---:|---:|
| 1,215 | 0.110 s | 0.107 s | 0.118 s | 0.91x |
| 4,050 | 0.723 s | 0.195 s | 0.200 s | 0.97x |
| 8,100 | 1.440 s | 0.403 s | 0.441 s | 0.91x |
| 16,200 | 2.800 s | 0.798 s | 0.799 s | 1.00x |
| 32,400 | 12.357 s | 1.642 s | 1.651 s | 0.99x |

Prefill at 32,400 tokens: 2,622 -> 19,732 tok/s (7.5x). Greedy continuation of
`"The capital of France is"` is byte-identical to the publisher; before the fix
the RO replica emitted `"importimportimport..."`.

Correctness was previously invisible below 2,048 tokens (`index_topk`), because
vLLM runs dense MHA under that length and never reads the top-k buffer, so a
short smoke test passes against a broken replica.

Method: per-tensor fingerprints (shape, stride, dtype, blake2b of a strided byte
sample) diffed across arms. Control (two TP ranks) differs in 1760/4413;
writer vs reader at load differs in 0/4209.

## Notes for reviewers

- **Not merge-ready.** The branch still mixes benchmark artifacts (`bench/`,
  `deploy/`) with library source; those directories have since moved to a
  separate paper repository and should be stripped before this is retargeted
  for review.
- V1 is unaffected by all four defects by construction: `GMSV1Worker` keeps
  vLLM's normal loader and intercepts only the allocator scope, so storage
  identity is preserved.
