### PR TITLE
fix(recipes): drop the DYN_STORE_KV leftovers that nothing reads

### DIFF
--- a/examples/backends/vllm/deploy/gaie/agg.yaml
+++ b/examples/backends/vllm/deploy/gaie/agg.yaml
@@ -68,8 +68,6 @@ spec:
             value: Qwen/Qwen3-0.6B
           - name: MODEL_PATH
             value: Qwen/Qwen3-0.6B
-          - name: DYN_STORE_KV
-            value: mem
           envFrom:
           - secretRef:
               name: hf-token-secret

--- a/recipes/qwen3-0.6b/vllm/agg/gaie/deploy.yaml
+++ b/recipes/qwen3-0.6b/vllm/agg/gaie/deploy.yaml
@@ -71,8 +71,6 @@ spec:
               value: "Qwen/Qwen3-0.6B"
             - name: HF_HOME
               value: /opt/models
-            - name: DYN_STORE_KV
-              value: "mem"
           args:
           - "python3 -m dynamo.vllm --model $MODEL_PATH --served-model-name $SERVED_MODEL_NAME --tensor-parallel-size 1 --data-parallel-size 1 --gpu-memory-utilization 0.90 --enable-prefix-caching --kv-events-config '{\"enable_kv_cache_events\":true}' --block-size 16"
           command:

--- a/recipes/qwen3-vl-32b-fp8/vllm/agg/deploy.yaml
+++ b/recipes/qwen3-vl-32b-fp8/vllm/agg/deploy.yaml
@@ -27,8 +27,6 @@ spec:
       envs:
         - name: HF_HOME
           value: /opt/models
-        - name: DYN_STORE_KV
-          value: "mem"
         - name: DYN_REQUEST_PLANE
           value: "tcp"
         - name: DYN_TCP_MAX_MESSAGE_SIZE
@@ -58,8 +56,6 @@ spec:
               value: "Qwen/Qwen3-VL-32B-Instruct-FP8"
             - name: HF_HOME
               value: /opt/models
-            - name: DYN_STORE_KV
-              value: "mem"
             - name: DYN_REQUEST_PLANE
               value: "tcp"
             - name: DYN_TCP_MAX_MESSAGE_SIZE

--- a/recipes/qwen3-vl-32b-fp8/vllm/hetero_hardware_disagg/deploy.yaml
+++ b/recipes/qwen3-vl-32b-fp8/vllm/hetero_hardware_disagg/deploy.yaml
@@ -28,8 +28,6 @@ spec:
       envs:
         - name: HF_HOME
           value: /opt/models
-        - name: DYN_STORE_KV
-          value: "mem"
         - name: DYN_REQUEST_PLANE
           value: "tcp"
         - name: DYN_TCP_MAX_MESSAGE_SIZE
@@ -58,8 +56,6 @@ spec:
                 - SYS_RESOURCE
                 - NET_RAW
           env:
-            - name: DYN_STORE_KV
-              value: "mem"
             - name: DYN_REQUEST_PLANE
               value: "tcp"
             - name: DYN_TCP_MAX_MESSAGE_SIZE
@@ -133,8 +129,6 @@ spec:
                 - SYS_RESOURCE
                 - NET_RAW
           env:
-            - name: DYN_STORE_KV
-              value: "mem"
             - name: DYN_REQUEST_PLANE
               value: "tcp"
             - name: DYN_TCP_MAX_MESSAGE_SIZE


### PR DESCRIPTION
## Summary

Four deployment manifests set an environment variable that nothing has read since February:

```yaml
- name: DYN_STORE_KV
  value: "mem"
```

#6167 consolidated `DYN_KV_STORE` into `DYN_DISCOVERY_BACKEND` and renamed `--store-kv` to `--discovery-backend`. Its notes say it updated all references, but these four were missed. There is no alias: the only remaining matches in the tree are the string `dynamo_store_kv`, which is a temp directory name for the `file` backend, and help text mentioning `DYN_FILE_KV`.

So these deployments do not get `mem`. They fall through to the `DYN_DISCOVERY_BACKEND` default, which `distributed.rs` sets to `etcd`:

```rust
std::env::var("DYN_DISCOVERY_BACKEND").unwrap_or_else(|_| "etcd".to_string());
```

### Why removed and not renamed

This is the part worth pausing on, because the obvious fix is wrong.

Completing the migration, by changing the key to `DYN_DISCOVERY_BACKEND`, would break all four. `Frontend` and the worker are separate services in every one of these files, so they are separate pods. The `mem` backend keeps its registry in process, so the frontend would no longer discover the worker.

These recipes work today precisely because the variable is dead. Anyone tidying up the leftover by renaming it rather than deleting it would turn four working recipes into broken ones, which is the reason to remove it now rather than leave it sitting there looking like an easy fix.

If `mem` was in fact intended for one of these and the topology has since changed, say so and I will set `DYN_DISCOVERY_BACKEND` on that one instead.

## Validation

I cannot deploy these, so the claims here are static and I have kept them to what is checkable:

- `grep -rn "DYN_STORE_KV"` across the tree is now 0 matches, and was 7 across the 4 files.
- Each removal took the `- name:` line and its paired `value:` line. All four files still parse: `yaml.safe_load_all` is clean on each.
- `pre-commit run --files <the four>` passes every applicable hook, including `check yaml`. `pytest-marker-report` fails identically on an untouched `README.md` here because vLLM and TensorRT-LLM are not installed.
- Confirmed none of the four also sets `DYN_DISCOVERY_BACKEND`, so nothing else in these files was already supplying the value.

Diff is 14 deletions and no additions, so the only behavioural question is whether anything read the old name, and nothing does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified deployment configuration for several VLLM-based workloads by removing an explicit in-memory storage setting.
  * Updated aggregated and disaggregated deployment variants across supported model configurations.
  * All other deployment settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->