### PR TITLE
fix(recipes): drop DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS, which nothing reads

### DIFF
--- a/recipes/nemotron-3-ultra/vllm/agg-b200-agentic-1M-kv-router/deploy.yaml
+++ b/recipes/nemotron-3-ultra/vllm/agg-b200-agentic-1M-kv-router/deploy.yaml
@@ -54,8 +54,6 @@ spec:
     value: SD
   - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
     value: '1'
-  - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-    value: '0'
   - name: NCCL_IB_DISABLE
     value: '1'
   - name: NCCL_CUMEM_ENABLE

--- a/recipes/nemotron-3-ultra/vllm/agg-b200-agentic-256K-kv-router/deploy.yaml
+++ b/recipes/nemotron-3-ultra/vllm/agg-b200-agentic-256K-kv-router/deploy.yaml
@@ -52,8 +52,6 @@ spec:
     value: SD
   - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
     value: '1'
-  - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-    value: '0'
   - name: NCCL_IB_DISABLE
     value: '1'
   - name: NCCL_CUMEM_ENABLE

--- a/recipes/nemotron-3-ultra/vllm/agg-gb200-agentic-1M-kv-router/deploy.yaml
+++ b/recipes/nemotron-3-ultra/vllm/agg-gb200-agentic-1M-kv-router/deploy.yaml
@@ -54,8 +54,6 @@ spec:
     value: SD
   - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
     value: '1'
-  - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-    value: '0'
   - name: NCCL_CUMEM_ENABLE
     value: '1'
   - name: NCCL_NVLS_ENABLE

--- a/recipes/nemotron-3-ultra/vllm/agg-gb200-agentic-256K-kv-router/deploy.yaml
+++ b/recipes/nemotron-3-ultra/vllm/agg-gb200-agentic-256K-kv-router/deploy.yaml
@@ -52,8 +52,6 @@ spec:
     value: SD
   - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
     value: '1'
-  - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-    value: '0'
   - name: NCCL_CUMEM_ENABLE
     value: '1'
   - name: NCCL_NVLS_ENABLE

--- a/recipes/nemotron-3-ultra/vllm/agg-h200-agentic-1M-kv-router/deploy.yaml
+++ b/recipes/nemotron-3-ultra/vllm/agg-h200-agentic-1M-kv-router/deploy.yaml
@@ -67,8 +67,6 @@ spec:
     value: '1'
   - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
     value: '1'
-  - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-    value: '0'
   - name: NCCL_IB_DISABLE
     value: '1'
   - name: NCCL_CUMEM_ENABLE

--- a/recipes/nemotron-3-ultra/vllm/agg-h200-agentic-256K-kv-router/deploy.yaml
+++ b/recipes/nemotron-3-ultra/vllm/agg-h200-agentic-256K-kv-router/deploy.yaml
@@ -65,8 +65,6 @@ spec:
     value: SD
   - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
     value: '1'
-  - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-    value: '0'
   - name: NCCL_IB_DISABLE
     value: '1'
   - name: NCCL_CUMEM_ENABLE

--- a/recipes/nemotron-3-ultra/vllm/disagg-b200-agentic-1M/deploy.yaml
+++ b/recipes/nemotron-3-ultra/vllm/disagg-b200-agentic-1M/deploy.yaml
@@ -72,8 +72,6 @@ spec:
     value: '1'
   - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
     value: '1'
-  - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-    value: '0'
   - name: NCCL_CUMEM_ENABLE
     value: '1'
   - name: NCCL_NVLS_ENABLE

--- a/recipes/nemotron-3-ultra/vllm/disagg-b200-agentic-256K/deploy.yaml
+++ b/recipes/nemotron-3-ultra/vllm/disagg-b200-agentic-256K/deploy.yaml
@@ -70,8 +70,6 @@ spec:
     value: DS
   - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
     value: '1'
-  - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-    value: '0'
   - name: NCCL_CUMEM_ENABLE
     value: '1'
   - name: NCCL_NVLS_ENABLE

--- a/recipes/nemotron-3-ultra/vllm/disagg-gb200-agentic-1M/deploy.yaml
+++ b/recipes/nemotron-3-ultra/vllm/disagg-gb200-agentic-1M/deploy.yaml
@@ -75,8 +75,6 @@ spec:
       value: "1"
     - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
       value: "1"
-    - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-      value: "0"
     - name: DYN_LOG
       value: info,dynamo_kv_router=debug,dynamo_llm::kv_router=debug
     - name: NCCL_CUMEM_ENABLE

--- a/recipes/nemotron-3-ultra/vllm/disagg-gb200-agentic-256K/deploy.yaml
+++ b/recipes/nemotron-3-ultra/vllm/disagg-gb200-agentic-256K/deploy.yaml
@@ -73,8 +73,6 @@ spec:
       value: DS
     - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
       value: "1"
-    - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-      value: "0"
     - name: DYN_LOG
       value: info,dynamo_kv_router=debug,dynamo_llm::kv_router=debug
     - name: NCCL_CUMEM_ENABLE

--- a/recipes/nemotron-3-ultra/vllm/disagg-h200-agentic-1M/deploy.yaml
+++ b/recipes/nemotron-3-ultra/vllm/disagg-h200-agentic-1M/deploy.yaml
@@ -72,8 +72,6 @@ spec:
     value: '1'
   - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
     value: '1'
-  - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-    value: '0'
   - name: NCCL_CUMEM_ENABLE
     value: '1'
   - name: NCCL_NVLS_ENABLE

--- a/recipes/nemotron-3-ultra/vllm/disagg-h200-agentic-256K/deploy.yaml
+++ b/recipes/nemotron-3-ultra/vllm/disagg-h200-agentic-256K/deploy.yaml
@@ -70,8 +70,6 @@ spec:
     value: DS
   - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
     value: '1'
-  - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-    value: '0'
   - name: NCCL_CUMEM_ENABLE
     value: '1'
   - name: NCCL_NVLS_ENABLE

--- a/recipes/qwen3.5-122b/fp8/vllm/disagg-h200-agentic/deploy.yaml
+++ b/recipes/qwen3.5-122b/fp8/vllm/disagg-h200-agentic/deploy.yaml
@@ -139,8 +139,6 @@ spec:
                   value: DS
                 - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
                   value: "1"
-                - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-                  value: "0"
                 # Force GPU-local RDMA (rc_mlx5 IB) and skip the cuda_ipc slow path.
                 - name: UCX_TLS
                   value: "^cuda_ipc"
@@ -276,8 +274,6 @@ spec:
                   value: DS
                 - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
                   value: "1"
-                - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-                  value: "0"
                 - name: UCX_TLS
                   value: "^cuda_ipc"
                 - name: UCX_RNDV_SCHEME

--- a/recipes/qwen3.5-122b/nvfp4/vllm/disagg-b200-agentic/deploy.yaml
+++ b/recipes/qwen3.5-122b/nvfp4/vllm/disagg-b200-agentic/deploy.yaml
@@ -141,8 +141,6 @@ spec:
                   value: DS
                 - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
                   value: "1"
-                - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-                  value: "0"
                 # Force GPU-local RDMA (rc_mlx5 IB) and skip the cuda_ipc slow path.
                 - name: UCX_TLS
                   value: "^cuda_ipc"
@@ -289,8 +287,6 @@ spec:
                   value: DS
                 - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
                   value: "1"
-                - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
-                  value: "0"
                 - name: UCX_TLS
                   value: "^cuda_ipc"
                 - name: UCX_RNDV_SCHEME


### PR DESCRIPTION
## Summary

Fourteen Nemotron-3-Ultra and Qwen3.5-122B profiles set an environment variable that no code reads:

```yaml
- name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
  value: '0'
```

Sixteen occurrences across those fourteen files, every one set to `'0'`.

Checks I ran before concluding it is dead, because a `DYN_*` name in a manifest can legitimately be read three different ways:

1. **Direct read.** A case-insensitive search for `append_prefill` anywhere outside `recipes/` returns nothing. No Python, Rust, Go, or shell reads it.
2. **Shell interpolation.** Some recipes legitimately set a `DYN_*` variable purely to interpolate it into a flag, for example `--multimodal-embedding-cache-capacity-gb "${DYN_MULTIMODAL_EMBEDDING_CACHE_GB}"`. There is no `${DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS}` anywhere.
3. **Left behind by a rename.** `git log -S "APPEND_PREFILL_OUTPUT_TOKENS" --all` returns only recipe-addition commits. No commit ever added or removed a reader, so this was never wired up rather than orphaned by a later removal.

The uniform `'0'` is what makes removal the right fix rather than implementing something. The profiles are asking for the behaviour to be off, and it is off, because it does not exist. Deleting the lines makes the manifests say what they actually do, and stops the next person from tuning a knob that is not connected.

If this is a placeholder for work in flight, say so and I will close this instead.

## Summary of the check

| variable | in recipes | reader in source | conclusion |
|---|---|---|---|
| `DYN_MULTIMODAL_EMBEDDING_CACHE_GB` | yes | interpolated into `--multimodal-embedding-cache-capacity-gb` | legitimate, left alone |
| `DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS` | yes | none | removed here |

## Validation

Static only, since I cannot run these deployments:

- `grep -rn "APPEND_PREFILL_OUTPUT_TOKENS"` across the tree is now 0 matches, from 16.
- Each removal took the `- name:` line and its paired `value:` line, and indentation varies across these files, so I matched on the pair rather than a fixed prefix. All 14 files still parse: `yaml.safe_load_all` is clean on every one.
- `pre-commit run` over all 14 files passes every applicable hook, including `check yaml`. `pytest-marker-report` fails identically on an untouched `README.md` here because vLLM and TensorRT-LLM are not installed.

Diff is deletions only, so the behavioural question is just whether anything read the name, and nothing does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
  - Updated Nemotron and Qwen deployment recipes to remove a disabled prefill-output token setting.
  - Applied the cleanup consistently across aggregated and disaggregated serving configurations.
  - Updated both prefill and decode worker environments where applicable.
- **Bug Fixes**
  - Prevents obsolete configuration from being passed to model-serving deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->