### PR TITLE
fix(vllm): use one prefill handoff for parallel choices

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3722,6 +3722,11 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             kv_protocol.prefill_request_kv_transfer_params(),
             preserve_router_hint=True,
         )
+        # Remote prefill builds one shared prompt KV handoff; decode owns fan-out.
+        sampling_params.n = 1
+        if hasattr(sampling_params, "best_of"):
+            sampling_params.best_of = 1
+
         # Override for prefill: only generate 1 token
         sampling_params.max_tokens = 1
         sampling_params.min_tokens = 1

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -9,6 +9,7 @@
 
 import asyncio
 import base64
+import copy
 import json
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
@@ -978,6 +979,142 @@ async def test_prefill_delegates_mode_policy_to_shared_processor():
         log_prefix="Prefill ",
         mm_processor_kwargs=mm_processor_kwargs,
     )
+
+
+@pytest.mark.asyncio
+async def test_parallel_choices_prefill_once_and_fan_out_on_decode():
+    from vllm.sampling_params import SamplingParams
+
+    sampling_options = {"n": 3}
+    supports_best_of = hasattr(SamplingParams(), "best_of")
+    if supports_best_of:
+        sampling_options["best_of"] = 4
+
+    request = {
+        "model": "test-model",
+        "token_ids": [1, 2, 3],
+        "sampling_options": sampling_options,
+        "stop_conditions": {"max_tokens": 8},
+        "output_options": {},
+        "routing": {},
+    }
+    original_request = copy.deepcopy(request)
+
+    @asynccontextmanager
+    async def no_abort(*args, **kwargs):
+        yield None
+
+    prefill_handler = mod.PrefillWorkerHandler.__new__(mod.PrefillWorkerHandler)
+    prefill_handler.config = SimpleNamespace(enable_rl=False)
+    prefill_handler.default_sampling_params = {}
+    prefill_handler.model_max_len = 128
+    prefill_handler._multimodal_request_processor = SimpleNamespace(
+        prepare_input=AsyncMock(
+            return_value=PreparedMultimodalInput(
+                request=request,
+                multi_modal_data=None,
+                mm_processor_kwargs=None,
+            )
+        ),
+        build_prefill_handoff=MagicMock(return_value=None),
+    )
+    prefill_handler._build_prompt_from_request = MagicMock(
+        return_value={"prompt_token_ids": request["token_ids"]}
+    )
+    prefill_handler._resolve_lora_request = MagicMock(return_value=None)
+    prefill_handler._to_local_dp_rank = MagicMock(return_value=None)
+    prefill_handler._abort_monitor = no_abort
+
+    def generate_with_lora_admission_lock(_lora_request, create_generator):
+        return create_generator(None)
+
+    prefill_handler._generate_with_lora_admission_lock = (
+        generate_with_lora_admission_lock
+    )
+    prefill_handler.engine_client = SimpleNamespace(vllm_config=MagicMock())
+    captured_prefill_params = []
+
+    async def prefill_generate(prompt, sampling_params, request_id, **kwargs):
+        captured_prefill_params.append(sampling_params)
+        for index in range(sampling_params.n):
+            yield SimpleNamespace(
+                kv_transfer_params={"remote_request_id": f"{index}_{request_id}"},
+                outputs=[SimpleNamespace(token_ids=[100 + index])],
+                prompt_token_ids=list(prompt["prompt_token_ids"]),
+                num_cached_tokens=None,
+            )
+
+    prefill_handler.engine_client.generate = prefill_generate
+    kv_protocol = SimpleNamespace(
+        prefill_request_kv_transfer_params=lambda: {"do_remote_prefill": True},
+        decode_request_kv_transfer_params=lambda response: response.kv_transfer_params,
+    )
+    context = MagicMock()
+    context.trace_headers.return_value = {}
+
+    with patch.object(mod, "make_kv_connector_protocol", return_value=kv_protocol):
+        prefill_outputs = [
+            output
+            async for output in prefill_handler._generate_token_mode(
+                request,
+                context,
+                "req",
+            )
+        ]
+
+    assert len(captured_prefill_params) == 1
+    assert captured_prefill_params[0].n == 1
+    assert len(prefill_outputs) == 1
+    if supports_best_of:
+        assert captured_prefill_params[0].best_of == 1
+    assert request == original_request
+
+    decode_request = copy.deepcopy(request)
+    decode_request["prefill_result"] = prefill_outputs[0]
+    decode_handler = _make_decode_handler(disaggregation_mode="DECODE")
+    decode_handler.config.enable_rl = False
+    decode_handler.engine_client = MagicMock()
+    decode_handler._multimodal_request_processor = SimpleNamespace(
+        prepare_input=AsyncMock(
+            return_value=PreparedMultimodalInput(
+                request=decode_request,
+                multi_modal_data=None,
+                mm_processor_kwargs=None,
+            )
+        )
+    )
+    decode_handler._build_prompt_from_request = MagicMock(
+        return_value={"prompt_token_ids": decode_request["token_ids"]}
+    )
+    decode_handler._resolve_lora_request = MagicMock(return_value=None)
+    decode_handler._to_local_dp_rank = MagicMock(return_value=None)
+    decode_handler._abort_monitor = no_abort
+    decode_handler._shutdown_on_engine_dead = MagicMock()
+    captured_decode_params = []
+
+    async def decode_generate_tokens(prompt, sampling_params, request_id, **kwargs):
+        captured_decode_params.append(sampling_params)
+        for index in range(sampling_params.n):
+            yield {"index": index, "token_ids": [200 + index]}
+
+    decode_handler.generate_tokens = decode_generate_tokens
+    original_decode_sampling = copy.deepcopy(decode_request["sampling_options"])
+    with patch.object(mod, "_deferred_abort_guard", no_abort):
+        decode_outputs = [
+            output
+            async for output in decode_handler._generate_token_mode(
+                decode_request,
+                context,
+                "req",
+            )
+        ]
+
+    assert len(captured_decode_params) == 1
+    assert captured_decode_params[0].n == 3
+    assert len(decode_outputs) == 3
+    if supports_best_of:
+        assert captured_decode_params[0].best_of == 4
+    assert decode_request["sampling_options"] == original_decode_sampling
 
 
 @pytest.mark.asyncio

--- a/lib/llm/src/kv_router/prefill_router/admission.rs
+++ b/lib/llm/src/kv_router/prefill_router/admission.rs
@@ -77,13 +77,19 @@ where
                         Some(Box::new(error)),
                     ));
                 }
-                if let Some(output) = next.data.as_ref()
-                    && prompt_tokens_details.is_none()
-                {
-                    prompt_tokens_details = output
-                        .completion_usage
-                        .as_ref()
-                        .and_then(|usage| usage.prompt_tokens_details.clone());
+                if let Some(output) = next.data.as_ref() {
+                    if output.disaggregated_params.is_some() {
+                        return Err(PrefillError::PrefillError(
+                            "Prefill router returned multiple handoff payloads".to_string(),
+                            None,
+                        ));
+                    }
+                    if prompt_tokens_details.is_none() {
+                        prompt_tokens_details = output
+                            .completion_usage
+                            .as_ref()
+                            .and_then(|usage| usage.prompt_tokens_details.clone());
+                    }
                 }
             }
         } else {
@@ -173,6 +179,7 @@ where
 #[cfg(test)]
 mod tests {
     use dynamo_kv_router::selector::DefaultWorkerSelector;
+    use dynamo_protocols::types::{CompletionUsage, PromptTokensDetails};
     use futures::stream;
     use serde_json::json;
 
@@ -266,6 +273,74 @@ mod tests {
 
         assert!(result.is_err());
         assert!(!tracker.record_prefill_complete());
+    }
+
+    #[tokio::test]
+    async fn later_handoff_payload_is_rejected_instead_of_silently_dropped() {
+        let result = PrefillRouter::<DefaultWorkerSelector>::consume_prefill_stream(
+            prefill_stream(vec![
+                Annotated::from_data(LLMEngineOutput {
+                    disaggregated_params: Some(json!({"remote_request_id": "0_req"})),
+                    ..Default::default()
+                }),
+                Annotated::from_data(LLMEngineOutput {
+                    disaggregated_params: Some(json!({"remote_request_id": "1_req"})),
+                    ..Default::default()
+                }),
+            ]),
+            None,
+            None,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(PrefillError::PrefillError(message, None))
+                if message.contains("multiple handoff payloads")
+        ));
+    }
+
+    #[tokio::test]
+    async fn later_output_without_handoff_is_still_drained() {
+        let result = PrefillRouter::<DefaultWorkerSelector>::consume_prefill_stream(
+            prefill_stream(vec![
+                Annotated::from_data(LLMEngineOutput {
+                    disaggregated_params: Some(json!({"remote_request_id": "req"})),
+                    ..Default::default()
+                }),
+                Annotated::from_data(LLMEngineOutput {
+                    completion_usage: Some(CompletionUsage {
+                        prompt_tokens: 3,
+                        completion_tokens: 0,
+                        total_tokens: 3,
+                        prompt_tokens_details: Some(PromptTokensDetails {
+                            audio_tokens: None,
+                            cached_tokens: Some(2),
+                        }),
+                        completion_tokens_details: None,
+                    }),
+                    ..Default::default()
+                }),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let PrefillCompletion::Handoff { result, .. } = result else {
+            panic!("expected prefill handoff");
+        };
+        assert_eq!(
+            result.disaggregated_params,
+            json!({"remote_request_id": "req"})
+        );
+        assert_eq!(
+            result
+                .prompt_tokens_details
+                .and_then(|details| details.cached_tokens),
+            Some(2)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Overview:

Fix disaggregated vLLM requests with parallel choices by building one shared
prompt KV handoff during prefill while leaving choice fan-out to decode.

## Details:

- Normalize prefill-only sampling fan-out to one without changing the original
  decode request.
- Reject any additional handoff payload instead of silently discarding it.
- Cover the prefill/decode choice split, duplicate-handoff failure, and normal
  later usage-data drain.

## Where should the reviewer start?

- `components/src/dynamo/vllm/handlers.py`: prefill-only sampling normalization.
- `components/src/dynamo/vllm/tests/test_vllm_worker_handler.py`: parallel-choice
  prefill/decode regression.
- `lib/llm/src/kv_router/prefill_router/admission.rs`: single-handoff invariant
  and regression coverage.

## Validation

- The repository handler regression drives `n=3` through prefill and decode,
  asserting one shared prefill handoff and all three requested decode choices.
- The paired before/after handler check confirmed that this one-handoff
  condition fails on the parent revision and passes after the fix, with both
  supported sampling-parameter shapes.
- `cargo fmt --all -- --check`
- Python source compilation
- `python3 scripts/validate_agent_instructions.py`
- The vLLM test job and broader Rust unit suite remain delegated to CI. The
  local Python environment lacks pytest, and the offline Cargo cache lacks
  `aligned-vec`; neither check reached a branch-owned failure.

## Related Issues

**🔗 This PR is linked to an issue:**

- Closes #14018
