### PR TITLE
test: stabilize SGLang multi-result synthesis

### DIFF
--- a/tests/frontend/test_tool_calling_sglang.py
+++ b/tests/frontend/test_tool_calling_sglang.py
@@ -1028,6 +1028,7 @@ class TestToolCallingMultiTurn:
                 },
             ],
             tools=TOOLS_WEATHER,
+            temperature=0,
         )
         assert_finish_reason(result, {"stop"})
         assert result.tool_calls == []


### PR DESCRIPTION
## Overview:

Stabilize `TestToolCallingMultiTurn::test_multiple_prior_tool_results_synthesize_to_text[chat_processor_frontend]` (SGL-CI-018) without disabling Qwen3 thinking or weakening the user-visible final-answer assertions.

## Details:

The newest failure completed normally with `finish_reason=stop` and no tool calls, but Qwen3 placed the entire synthesis in `reasoning_content` and emitted no `content`. The request was using Qwen3's default sampled decoding (`temperature=0.6`, `top_k=20`, `top_p=0.95`), so the real-model response could vary between executions.

Set `temperature=0` only for this request. Greedy decoding removes that sampling variance while preserving the behavior under test: Dynamo must stream and parse a final response that synthesizes multiple prior tool results into user-visible text. Thinking remains enabled, and the existing assertions remain unchanged: the response must stop without another tool call, contain non-empty user-visible content, and mention Tokyo or Paris.

For this fixed prompt and model/runtime, `temperature=0` reproducibly produces the verified expected behavior: the prior tool results are synthesized into final `content` while reasoning remains active. We intentionally preserve that determinism so a future failure indicates a change in the Dynamo/model integration behavior under test, rather than a different random sampling path.

Pinning a seed alone was not sufficient in the representative SGLang server path: repeated requests with the same seeds produced different answer and reasoning hashes. Therefore this change does not rely on a seed to stabilize sampled generation.

Datadog frozen window (2026-08-24 00:42:25 UTC to 2026-08-31 00:42:25 UTC): original failures 2 / 104; retry recovery 1 / 3. One original failure was shared infrastructure run #4289; the distinct recurrence was pipeline 4354, job 98990518592, commit `4dca1626b2708383514fcd65ac816ba7429c05a4`.

## Where should the reviewer start?

`tests/frontend/test_tool_calling_sglang.py`, in `test_multiple_prior_tool_results_synthesize_to_text`.

## Validation

- Representative future-CI runtime: H100, `lmsysorg/sglang:v0.5.18-cu130-runtime`, Qwen3-0.6B, `qwen25` tool parser, and `qwen3` reasoning parser.
- Same multi-prior-tool-result synthesis scenario with `temperature=0`: 5 / 5 requests passed the existing behavioral assertions and a stronger check requiring both cities and both temperatures.
- All five runs produced identical answer and reasoning hashes; a fresh SGLang server process reproduced both hashes.
- Thinking remained active: `reasoning_content` was non-empty (433 characters in the validated response).
- Seed-only controls remained variable: `seed=1` produced 17 answer hashes and 20 reasoning hashes across 20 runs; `seed=42` produced 5 of each across 5 runs.
- `git diff --check`
- `python3 -m py_compile tests/frontend/test_tool_calling_sglang.py`
- Full Dynamo pytest execution was not run locally because it requires the GPU integration topology. A queued literal-fixture replay could not acquire the validated H100 preset; the standalone replay used the same message/tool-result flow with an equivalent weather-tool schema.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
