### PR TITLE
fix: install auditwheel for xpu wheel build

### DIFF
--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -595,7 +595,10 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     cd /opt/dynamo/lib/bindings/python && \
 {% if framework == "sglang" %}    maturin build --release --features "kv-indexer,slot-tracker,select-service,mm-routing,aic-forward-pass,request-trace-s3" --out /opt/dynamo/dist && \
 {% else %}    if [ "$ENABLE_MEDIA_FFMPEG" = "true" ]; then \
-        # Skip maturin's built-in repair: it would graft the in-tree libav* into the
+{% if device == "xpu" %}        # The XPU builder is Ubuntu 24.04, whose libc is newer than manylinux_2_28.
+    # Keep the native linux tag instead of falsely relabeling this wheel as manylinux.
+    maturin build --release --features "media-ffmpeg,kv-indexer,slot-tracker,select-service,mm-routing,aic-forward-pass,request-trace-s3" --auditwheel skip --out /opt/dynamo/dist; \
+{% else %}        # Skip maturin's built-in repair: it would graft the in-tree libav* into the
         # wheel, which the codec gate rejects. Repair with those sonames excluded so
         # they stay external and resolve to the image's /usr/local/lib copies. This
         # media-enabled wheel is intentionally image-only and non-self-contained.
@@ -616,6 +619,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
             --plat manylinux_2_28_${ARCH_ALT} \
             --wheel-dir /opt/dynamo/dist \
             target/wheels/ai_dynamo_runtime-*.whl; \
+{% endif %}    \
     else \
         maturin build --release --features "kv-indexer,slot-tracker,select-service,mm-routing,aic-forward-pass,request-trace-s3" --out /opt/dynamo/dist; \
     fi && \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -236,7 +236,7 @@ ENV VIRTUAL_ENV=/workspace/.venv
 RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=shared \
     export UV_CACHE_DIR=/root/.cache/uv UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv venv ${VIRTUAL_ENV} --python $PYTHON_VERSION --seed && \
-    uv pip install --upgrade meson pybind11 patchelf maturin[patchelf] tomlkit pyyaml
+    uv pip install --upgrade auditwheel meson pybind11 patchelf maturin[patchelf] tomlkit pyyaml
 
 ARG NIXL_UCX_REF
 

--- a/tests/wheels/smoke_install.py
+++ b/tests/wheels/smoke_install.py
@@ -120,9 +120,13 @@ def assert_core_wheel_metadata(wheelhouse: Path, target_arch: str | None) -> Non
     runtime_py_tag, runtime_abi_tag, runtime_platform_tag = wheel_tags(runtime)
     if runtime_abi_tag != "abi3":
         raise AssertionError(f"{runtime.name} should use abi3, got {runtime_abi_tag}")
-    if MANYLINUX_POLICY not in runtime_platform_tag:
+    if (
+        MANYLINUX_POLICY not in runtime_platform_tag
+        and runtime_platform_tag != "linux_x86_64"
+    ):
         raise AssertionError(
-            f"{runtime.name} should target {MANYLINUX_POLICY}, got {runtime_platform_tag}"
+            f"{runtime.name} should target {MANYLINUX_POLICY} or linux_x86_64, "
+            f"got {runtime_platform_tag}"
         )
     if runtime_py_tag not in RUNTIME_PY_TAGS:
         raise AssertionError(
@@ -190,6 +194,9 @@ def binary_wheels(wheelhouse: Path) -> list[Path]:
 
 def assert_auditwheel_show(wheelhouse: Path) -> None:
     for wheel in binary_wheels(wheelhouse):
+        _, _, platform_tag = wheel_tags(wheel)
+        if MANYLINUX_POLICY not in platform_tag:
+            continue
         proc = run(
             [sys.executable, "-m", "auditwheel", "show", str(wheel)],
             stdout=subprocess.PIPE,
@@ -237,6 +244,9 @@ def assert_glibc_floor(wheelhouse: Path) -> None:
         tmp_path = Path(tmp)
         offenders: list[str] = []
         for wheel in binary_wheels(wheelhouse):
+            _, _, platform_tag = wheel_tags(wheel)
+            if MANYLINUX_POLICY not in platform_tag:
+                continue
             wheel_tmp = tmp_path / wheel.name.removesuffix(".whl")
             shared_libraries = extracted_shared_libraries(wheel, wheel_tmp)
             if not shared_libraries:


### PR DESCRIPTION
## Overview:

Fix XPU runtime wheel packaging so images can build successfully when the wheel is compiled on the Ubuntu 24.04 XPU builder.

## Details:

- Build media-enabled `ai-dynamo-runtime` wheels for XPU with `maturin --auditwheel skip`.
  - The XPU builder's newer glibc is incompatible with relabeling the wheel as `manylinux_2_28`.
  - The resulting wheel keeps its native `linux_x86_64` platform tag instead of claiming manylinux compatibility.
- Preserve the existing `auditwheel repair` flow for non-XPU media-enabled builds.
- Update wheel smoke checks to accept native `linux_x86_64` ABI3 runtime wheels.
- Run `auditwheel` and GLIBC-floor assertions only for wheels tagged `manylinux_2_28`.

## Where should the reviewer start?

- `container/templates/wheel_builder.Dockerfile`
- `tests/wheels/smoke_install.py`

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
