### PR TITLE
fix(global-planner): prefer intra-participant pair partners

### DIFF
--- a/components/src/dynamo/global_planner/orchestrator.py
+++ b/components/src/dynamo/global_planner/orchestrator.py
@@ -649,27 +649,26 @@ class Orchestrator:
 
     def _iter_pair_partners(
         self,
-        request_participant_id: str,
         request_pool_keys: set[tuple[str, str]],
         all_pools: PoolSnapshot,
         request_net_delta_gpu: int,
     ) -> Iterator[PartnerTransfer]:
-        """Yield qualifying pair-partner candidates, same-participant first.
+        """Yield qualifying pair-partner candidates in unspecified order.
 
         A candidate qualifies when it (a) is not in the requesting pool set, (b)
         has a fresh cached intent (within TTL) whose desired differs from current
         replicas, and (c) the partner delta points opposite to the request's net
         delta.
 
-        Yields in two passes: same-participant candidates first (atomic-patch
-        preference), then cross-participant candidates. The caller picks the first
-        one whose pair total actually lands in the budget band.
+        Ordering belongs to :meth:`_find_pair_partner_set`, which sorts these
+        candidates before packing them. This used to yield same-participant
+        candidates ahead of cross-participant ones, but that grouping was
+        discarded by the caller's sort, so the preference now lives in the sort
+        key where it actually takes effect.
         """
         if request_net_delta_gpu == 0:
             return
         now = self._now()
-        same: list[PartnerTransfer] = []
-        cross: list[PartnerTransfer] = []
         for pid, pools in all_pools.items():
             for sub_type, spec in pools.items():
                 if (pid, sub_type) in request_pool_keys:
@@ -692,13 +691,7 @@ class Orchestrator:
                     request_net_delta_gpu < 0 and partner_delta_gpu <= 0
                 ):
                     continue
-                candidate = PartnerTransfer(pid, sub_type, intent.last_desired, spec)
-                if pid == request_participant_id:
-                    same.append(candidate)
-                else:
-                    cross.append(candidate)
-        yield from same
-        yield from cross
+                yield PartnerTransfer(pid, sub_type, intent.last_desired, spec)
 
     def _partial_partner(
         self,
@@ -785,7 +778,6 @@ class Orchestrator:
 
         all_candidates = list(
             self._iter_pair_partners(
-                request_participant_id,
                 request_pool_keys,
                 all_pools,
                 request_net_delta_gpu,
@@ -801,13 +793,26 @@ class Orchestrator:
             + [s.gpu_per_replica for s in candidate_specs]
         )
 
-        # Sort ascending by |delta_gpu| — smaller pieces overshoot less.
         def cand_delta(c: PartnerTransfer) -> int:
             return (
                 c.applied_desired - c.spec.current_replicas
             ) * c.spec.gpu_per_replica
 
-        all_candidates.sort(key=lambda c: abs(cand_delta(c)))
+        # Same-participant partners first, then ascending |delta_gpu| — smaller
+        # pieces overshoot less. The participant term is the primary key on
+        # purpose: an intra-participant partner merges into the request's single
+        # atomic set_component_replicas call, while a cross-participant partner
+        # needs its own patch and can leave a half-applied transfer behind when a
+        # later patch fails (see _observe_decide_apply). Sorting on |delta_gpu|
+        # alone silently discarded that preference, because a cross-participant
+        # candidate with a smaller delta sorted ahead of every intra-participant
+        # one.
+        all_candidates.sort(
+            key=lambda c: (
+                c.participant_id != request_participant_id,
+                abs(cand_delta(c)),
+            )
+        )
 
         selected: list[PartnerTransfer] = []
         overrides = dict(standalone_overrides)

--- a/components/src/dynamo/global_planner/tests/unit/test_orchestrator.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_orchestrator.py
@@ -130,6 +130,53 @@ def test_floor_pairs_scale_down_across_participants():
     )
 
 
+def test_prefers_intra_participant_partner_over_smaller_cross_participant():
+    """Partner packing must prefer a partner inside the requesting participant.
+
+    Regression: candidates were sorted on ``abs(delta_gpu)`` alone, so a
+    cross-participant candidate with a smaller delta sorted ahead of every
+    intra-participant one. That splits an otherwise-atomic transfer into two
+    patches, and a failure on the second leaves the first already applied.
+    """
+    # Fixed total of 12 GPUs; every pool is 1 GPU/replica so tolerance is 1.
+    orch = _decider(max_total_gpus=12, min_total_gpus=12)
+    pools = _pools(ns__a=(2, 5, 1), ns__b=(None, 5, 1))  # 2 + 5 + 5 = 12
+
+    # Two pending scale-downs. The cross-participant one is *smaller*, so under
+    # the old |delta_gpu|-only sort it was consumed first.
+    orch.update_intent_cache("ns/a", _targets(decode=1), pools["ns/a"])  # -4
+    orch.update_intent_cache("ns/b", _targets(decode=4), pools["ns/b"])  # -1
+
+    res = _mediate(orch, "ns/a", _targets(prefill=4), pools)  # +2, breaches ceiling
+
+    assert res.approved
+    assert [p.participant_id for p in res.selected_partners] == ["ns/a"]
+    partner = res.selected_partners[0]
+    # Partially consumed: 5 -> 2 lands the total at the floor edge (11) rather
+    # than overshooting to 10 by applying the full cached intent of 1.
+    assert (partner.sub_type, partner.applied_desired) == ("decode", 2)
+
+
+def test_falls_back_to_cross_participant_when_no_intra_candidate():
+    """Preferring intra-participant partners must not disable cross-participant
+    pairing when the requesting participant has nothing pending."""
+    orch = _decider(max_total_gpus=12, min_total_gpus=12)
+    pools = _pools(ns__a=(2, 5, 1), ns__b=(None, 5, 1))  # 2 + 5 + 5 = 12
+
+    orch.update_intent_cache("ns/b", _targets(decode=3), pools["ns/b"])  # -2
+
+    res = _mediate(orch, "ns/a", _targets(prefill=4), pools)  # +2
+
+    assert res.approved
+    assert len(res.selected_partners) == 1
+    partner = res.selected_partners[0]
+    assert (partner.participant_id, partner.sub_type, partner.applied_desired) == (
+        "ns/b",
+        "decode",
+        3,
+    )
+
+
 def test_intent_cache_ttl_expiry_blocks_pairing():
     clock = {"t": 1000.0}
     orch = _decider(


### PR DESCRIPTION
## Overview:

**Stack 2/5** — pool prioritization for the Global Planner (`LLM-174`). Based on #14035.

Fixes a pre-existing bug in pair-partner selection. Standalone fix, no priority concept involved — but it lands before the priority work so that PR adds a sort key to correct code rather than compounding this.

## Details:

`_iter_pair_partners` deliberately yielded same-participant candidates ahead of cross-participant ones. An intra-participant partner merges into the request's single atomic `set_component_replicas` call, while a cross-participant partner needs its own patch and can leave a half-applied transfer behind when a later patch fails (see `_observe_decide_apply`).

`_find_pair_partner_set` then discarded that grouping entirely by sorting on `abs(delta_gpu)` alone. Python's sort is stable, so the preference survived only among exact ties — any cross-participant candidate with a smaller delta sorted ahead of every intra-participant one. There is an existing `TODO(global-planner)` naming this.

Makes the participant term the primary sort key with `abs(delta_gpu)` as the tiebreak.

> ⚠️ **This changes live arbitration for every deployment**, not just ones adopting priorities later in the stack. It is the riskiest commit in the stack despite being the smallest.

Since ordering now lives entirely in the sort key, the iterator's two-pass accumulation and its now-unused `request_participant_id` parameter are dropped rather than left looking load-bearing.

## Where should the reviewer start?

- `orchestrator.py::_find_pair_partner_set` — the sort key.
- `tests/unit/test_orchestrator.py::test_prefers_intra_participant_partner_over_smaller_cross_participant` — reverting the sort key makes this fail, showing the old code producing a two-patch cross-participant transfer where one atomic patch suffices. A second test pins that cross-participant pairing still happens when the requesting participant has nothing pending, guarding against over-correction.

## Testing

2 new tests. Full `planner` + `global_planner` suites pass locally (1294 passed, 8 skipped).

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — tracked in Linear as LLM-175

🤖 Generated with [Claude Code](https://claude.com/claude-code)