### PR TITLE
feat(global-planner): add pool priority model and resolver

### DIFF
--- a/components/src/dynamo/global_planner/README.md
+++ b/components/src/dynamo/global_planner/README.md
@@ -153,6 +153,75 @@ and then misbehaved at request time are now startup failures:
 - `intent_cache_ttl_seconds <= 0` — no cached intent is ever fresh, silently
   disabling all pool pairing.
 
+## Pool Priorities
+
+Pool priorities declare which pools should be served first when several compete
+for one GPU budget. They are declared at server start, in `--config`:
+
+```yaml
+priority:
+  default: 100                       # pools no selector matches
+  pools:
+    - selector: prod/chat            # participant: every pool under it
+      priority: 900
+    - selector: prod/chat/prefill    # one pool: overrides the line above
+      priority: 950
+    - selector: dev/*                # any deployment in the dev namespace
+      priority: 10
+```
+
+**Higher numbers are more important.** This matches Kubernetes `PriorityClass`
+and `nvext.agent_hints.priority`. It is the opposite of the plugin-stage
+`priority` in `dynamo.planner`, where smaller is more authoritative — that one
+orders pipeline stages, this one orders capacity allocation between pools.
+
+### Selectors
+
+A selector is a slash-separated path matched against `<participant_id>/<sub_type>`
+— today `<k8s namespace>/<deployment>/<sub_type>`, though nothing hard-codes that
+depth.
+
+| Pattern | Matches |
+|---------|---------|
+| `*` | exactly one segment |
+| `**` | any number of segments, including none |
+| a selector shorter than the pool path | everything beneath it |
+
+So `prod/chat` selects every pool of that deployment, `prod/chat/prefill` selects
+one, `dev/*` selects every deployment in `dev`, and `a/*/prefill` matches
+`a/b/prefill` but not `a/b/c/prefill` — a single `*` never spans a `/`. Use `**`
+when you do want it to: `a/**/prefill` matches both. Deeper hierarchies work
+without special-casing, e.g.
+`global-pool/east-coast-regions/*/long-context/*`.
+
+The most specific match wins, independent of the order entries appear in the
+file. Specificity is the number of segments named exactly, then depth — so
+`prod/chat/prefill` beats `prod/chat`, which beats `prod/*`, which beats `**`.
+Ties fall back to declaration order. Pools matching nothing take
+`priority.default`, which is also what a pool this GlobalPlanner has never seen
+receives.
+
+### Conditional priorities
+
+A policy is always an ordered, first-match-wins list of rules whose final rule is
+unconditional. `priority: <n>` is shorthand for exactly one such rule:
+
+```yaml
+    - selector: prod/chat
+      rules:
+        - priority: 900
+```
+
+Rule *conditions* — "this priority while traffic is above X", "that priority
+while the pool is breaching its SLA" — are not implemented yet, and a config that
+declares one is rejected at startup rather than silently treated as
+always-matching. The structure is in place so adding them does not change the
+declaration surface or any caller.
+
+> **Not consumed yet.** This release only declares and resolves priorities;
+> budget arbitration does not read them. Setting them changes nothing about
+> scaling decisions today.
+
 ## Behavior
 
 - If `managed_namespaces` is set and `caller_namespace` is not authorized, Global Planner returns `error` and does not scale.

--- a/components/src/dynamo/global_planner/config.py
+++ b/components/src/dynamo/global_planner/config.py
@@ -30,6 +30,8 @@ from typing import Literal, Optional
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from dynamo.global_planner.priority import PriorityConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -95,6 +97,15 @@ class GlobalPlannerConfig(BaseModel):
             "partner. Should be at least 2x the slowest local planner tick so "
             "opposite-direction intents can overlap; throughput scaling ticks "
             "every 180s by default, so 360 covers two ticks."
+        ),
+    )
+
+    priority: PriorityConfig = Field(
+        default_factory=PriorityConfig,
+        description=(
+            "Pool priorities used to arbitrate between competing scale "
+            "requests. Higher is more important; pools no selector matches "
+            "take 'priority.default'."
         ),
     )
 
@@ -205,3 +216,13 @@ class GlobalPlannerConfig(BaseModel):
         # pairing, so log it whenever either bound is active.
         if self.budget_enforcement_enabled():
             logger.info(f"Intent cache TTL seconds: {self.intent_cache_ttl_seconds}")
+
+        logger.info(f"Default pool priority: {self.priority.default}")
+        if self.priority.pools:
+            logger.info(f"Pool priority selectors: {len(self.priority.pools)}")
+            for policy in self.priority.pools:
+                assert policy.rules is not None
+                values = ", ".join(str(rule.priority) for rule in policy.rules)
+                logger.info(f"  {policy.selector} -> {values}")
+        else:
+            logger.info("Pool priority selectors: none (every pool takes the default)")

--- a/components/src/dynamo/global_planner/priority.py
+++ b/components/src/dynamo/global_planner/priority.py
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pool priority declaration and resolution for the GlobalPlanner.
+
+The GlobalPlanner is a *scaling mediator*: when several pools compete for one
+GPU budget it has to decide who is served. Priority is the operator's way of
+encoding that business decision. This module owns the declaration surface and
+the resolution logic; it is pure and infrastructure-free, and nothing here
+reads or writes cluster state.
+
+**Polarity: higher numbers are more important.** This matches Kubernetes
+``PriorityClass`` and ``nvext.agent_hints.priority``, so an operator carrying
+over intuitions from either lands in the right place. Note it is the *opposite*
+of the plugin-stage ``priority`` in ``dynamo.planner``, where smaller is more
+authoritative -- that one orders pipeline stages, this one orders capacity
+allocation between pools. Use :func:`outranks` rather than open-coding a
+comparison.
+
+Declaration is coarse, resolution is fine
+-----------------------------------------
+Business priority is usually a property of a deployment, but the unit the budget
+arbitration actually manipulates is a *pool* -- one ``sub_type`` within one
+participant. So a selector may name either, and the most specific match wins:
+
+.. code-block:: yaml
+
+    priority:
+      default: 100                     # pools this GlobalPlanner has not seen
+      pools:
+        - selector: "prod/chat"          # participant: every pool under it
+          priority: 900
+        - selector: "prod/chat/prefill"  # one pool: overrides the above
+          priority: 950
+        - selector: "dev/*"              # any deployment in the dev namespace
+          priority: 10
+
+Static priorities are degenerate conditionals
+---------------------------------------------
+A policy is *always* an ordered list of rules resolved first-match-wins, whose
+final rule is unconditional. Today every rule is unconditional, so a policy is
+just a constant -- but :meth:`PriorityResolver.resolve` already takes a
+:class:`PriorityContext`, so adding real predicates later is a new
+:class:`PriorityCondition` field and nothing else. Callers do not change.
+
+``PriorityCondition`` forbids unknown fields, so a config that tries to declare
+a condition today fails loudly at startup instead of silently always-matching.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+logger = logging.getLogger(__name__)
+
+#: Floor of the priority range. Nothing is less important than this.
+LOWEST_PRIORITY = 0
+
+#: Applied to any pool no selector matches. Deliberately mid-range so operators
+#: can declare both more- and less-important pools without renumbering.
+DEFAULT_POOL_PRIORITY = 100
+
+#: Reported as the matched selector when a pool fell through to the default.
+DEFAULT_SELECTOR = "<default>"
+
+
+def outranks(a: int, b: int) -> bool:
+    """Whether priority ``a`` is more important than priority ``b``.
+
+    Exists so call sites read as intent rather than as a bare comparison whose
+    direction has to be re-derived, and so the polarity lives in exactly one
+    place if it ever moves again.
+    """
+    return a > b
+
+
+# ---------------------------------------------------------------------------- #
+# Runtime context                                                              #
+# ---------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class PriorityContext:
+    """Signals a conditional rule may test when resolving a pool's priority.
+
+    Empty today: every rule is unconditional, so resolution ignores it. It is
+    threaded through :meth:`PriorityResolver.resolve` from the start precisely
+    so that populating it later does not touch any call site.
+    """
+
+
+@dataclass(frozen=True)
+class ResolvedPriority:
+    """A pool's effective priority plus where it came from.
+
+    ``selector`` and ``rule_index`` are provenance for logs: when a scale
+    request is denied on priority grounds the operator needs to see *which*
+    line of their config produced the number, not just the number.
+    """
+
+    priority: int
+    selector: str
+    rule_index: int
+
+
+# ---------------------------------------------------------------------------- #
+# Declaration surface                                                          #
+# ---------------------------------------------------------------------------- #
+
+
+class PriorityCondition(BaseModel):
+    """Predicates gating a :class:`PriorityRule`.
+
+    No predicate fields exist yet. ``extra="forbid"`` means a config declaring
+    one is rejected at startup rather than parsed into a condition that
+    silently matches everything.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    def matches(self, ctx: PriorityContext) -> bool:
+        """Whether this condition holds for ``ctx``. Vacuously true today."""
+        return True
+
+
+class PriorityRule(BaseModel):
+    """One priority value, optionally gated by a condition."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    when: Optional[PriorityCondition] = Field(
+        default=None,
+        description="Condition gating this rule. None means it always applies.",
+    )
+    priority: int = Field(
+        ge=LOWEST_PRIORITY,
+        description="Priority value. Higher is more important.",
+    )
+
+    def applies(self, ctx: PriorityContext) -> bool:
+        return self.when is None or self.when.matches(ctx)
+
+
+class PoolPriorityPolicy(BaseModel):
+    """A selector bound to an ordered, first-match-wins list of rules.
+
+    ``priority`` is shorthand for a single unconditional rule; it and ``rules``
+    are mutually exclusive. Validation normalizes the shorthand into ``rules``
+    and clears it, so downstream code -- and any ``model_dump()`` round trip --
+    sees exactly one shape.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    selector: str = Field(
+        description=(
+            "Slash-separated path matched against '<participant_id>/<sub_type>'. "
+            "'*' matches exactly one segment, '**' matches any number, and a "
+            "selector shorter than the pool path covers everything beneath it -- "
+            "so 'prod/chat' selects every pool of that deployment while "
+            "'prod/chat/prefill' selects one."
+        )
+    )
+    priority: Optional[int] = Field(default=None, ge=LOWEST_PRIORITY)
+    rules: Optional[list[PriorityRule]] = Field(default=None)
+
+    @model_validator(mode="after")
+    def _normalize(self) -> "PoolPriorityPolicy":
+        if (self.priority is None) == (self.rules is None):
+            raise ValueError(
+                f"selector {self.selector!r} must set exactly one of "
+                f"'priority' (a constant) or 'rules' (a conditional list)"
+            )
+
+        if self.priority is not None:
+            # Normalize the shorthand away entirely rather than leaving both
+            # fields populated: GlobalPlannerConfig round-trips through
+            # model_dump() -> model_validate() when merging CLI flags, and a
+            # dump carrying both would fail the "exactly one of" check above.
+            self.rules = [PriorityRule(priority=self.priority)]
+            self.priority = None
+
+        assert self.rules is not None
+        if not self.rules:
+            raise ValueError(f"selector {self.selector!r} has an empty 'rules' list")
+        if self.rules[-1].when is not None:
+            raise ValueError(
+                f"selector {self.selector!r} must end with an unconditional rule "
+                f"so every context resolves to a priority"
+            )
+
+        segments = self.selector.split("/")
+        if not segments or any(not seg for seg in segments):
+            raise ValueError(
+                f"selector {self.selector!r} must be a slash-separated path with "
+                f"no empty segments"
+            )
+        return self
+
+    # ------------------------------------------------------------------ #
+    # Matching                                                           #
+    # ------------------------------------------------------------------ #
+
+    @property
+    def _segments(self) -> tuple[str, ...]:
+        return tuple(self.selector.split("/"))
+
+    @property
+    def _pattern(self) -> tuple[str, ...]:
+        """Declared segments, implicitly covering everything beneath them.
+
+        A selector shorter than a pool path should select every pool under it,
+        which is exactly "match the declared segments, then anything" -- so a
+        trailing ``**`` is appended unless one is already there.
+        """
+        segments = self._segments
+        if segments[-1] == "**":
+            return segments
+        return segments + ("**",)
+
+    @staticmethod
+    def _match_segments(pattern: tuple[str, ...], path: tuple[str, ...]) -> bool:
+        """Glob a segment path, where ``**`` spans any number of segments.
+
+        Wildcards other than ``**`` never span a ``/``, so ``a/*/prefill``
+        matches ``a/b/prefill`` but not ``a/b/c/prefill``; ``a/**/prefill``
+        matches both.
+        """
+        if not pattern:
+            return not path
+        head, rest = pattern[0], pattern[1:]
+        if head == "**":
+            # Try consuming 0, 1, 2 ... segments here.
+            return any(
+                PoolPriorityPolicy._match_segments(rest, path[i:])
+                for i in range(len(path) + 1)
+            )
+        if not path:
+            return False
+        if not fnmatch.fnmatchcase(path[0], head):
+            return False
+        return PoolPriorityPolicy._match_segments(rest, path[1:])
+
+    def matches(self, participant_id: str, sub_type: str) -> bool:
+        """Whether this selector covers the pool ``participant_id``/``sub_type``."""
+        path = tuple(participant_id.split("/")) + (sub_type,)
+        return self._match_segments(self._pattern, path)
+
+    @property
+    def specificity(self) -> tuple[int, int]:
+        """Sort key ranking selectors most-specific first (smaller wins).
+
+        Ranked by how many segments are named exactly, then by depth. So
+        ``prod/chat/prefill`` beats ``prod/chat``, which beats ``prod/*``,
+        which beats ``**``. Ties fall back to declaration order in
+        :class:`PriorityResolver`.
+        """
+        exact = sum(1 for seg in self._segments if not any(c in seg for c in "*?["))
+        return (-exact, -len(self._segments))
+
+    def resolve(self, ctx: PriorityContext) -> Optional[tuple[int, int]]:
+        """First applicable rule as ``(priority, rule_index)``, else ``None``."""
+        assert self.rules is not None
+        for index, rule in enumerate(self.rules):
+            if rule.applies(ctx):
+                return rule.priority, index
+        return None
+
+
+class PriorityConfig(BaseModel):
+    """Declarative pool priorities for one GlobalPlanner process."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    default: int = Field(
+        default=DEFAULT_POOL_PRIORITY,
+        ge=LOWEST_PRIORITY,
+        description=(
+            "Priority for pools no selector matches, including ones this "
+            "GlobalPlanner has never received a scale request from."
+        ),
+    )
+    pools: list[PoolPriorityPolicy] = Field(
+        default_factory=list,
+        description="Selector-scoped policies, most specific match wins.",
+    )
+
+    @model_validator(mode="after")
+    def _reject_duplicate_selectors(self) -> "PriorityConfig":
+        seen: set[str] = set()
+        for policy in self.pools:
+            if policy.selector in seen:
+                raise ValueError(
+                    f"duplicate selector {policy.selector!r}: merge the entries, "
+                    f"since only one of them could ever take effect"
+                )
+            seen.add(policy.selector)
+        return self
+
+
+# ---------------------------------------------------------------------------- #
+# Resolution                                                                   #
+# ---------------------------------------------------------------------------- #
+
+
+class PriorityResolver:
+    """Resolves a pool's effective priority from a :class:`PriorityConfig`.
+
+    Policies are ordered once at construction by specificity, then by
+    declaration order, so resolution is deterministic and independent of how
+    the config file happened to be written.
+    """
+
+    def __init__(self, config: Optional[PriorityConfig] = None):
+        self.config = config or PriorityConfig()
+        self._ordered = sorted(
+            enumerate(self.config.pools),
+            key=lambda pair: (pair[1].specificity, pair[0]),
+        )
+
+    def resolve(
+        self,
+        participant_id: str,
+        sub_type: str,
+        ctx: Optional[PriorityContext] = None,
+    ) -> ResolvedPriority:
+        """Effective priority for one pool.
+
+        Falls back to :attr:`PriorityConfig.default` when no selector matches,
+        which is the normal path for a pool the operator never named.
+        """
+        context = ctx if ctx is not None else PriorityContext()
+        for _, policy in self._ordered:
+            if not policy.matches(participant_id, sub_type):
+                continue
+            outcome = policy.resolve(context)
+            if outcome is None:
+                # Unreachable while every policy ends unconditional, but a
+                # future condition set could make it reachable; prefer falling
+                # through to the next selector over raising mid-arbitration.
+                logger.debug(
+                    f"Selector {policy.selector!r} matched "
+                    f"{participant_id}/{sub_type} but no rule applied"
+                )
+                continue
+            priority, rule_index = outcome
+            return ResolvedPriority(priority, policy.selector, rule_index)
+
+        return ResolvedPriority(self.config.default, DEFAULT_SELECTOR, 0)

--- a/components/src/dynamo/global_planner/tests/unit/test_config.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_config.py
@@ -17,6 +17,7 @@ from dynamo.global_planner.argparse_config import (
     resolve_config,
 )
 from dynamo.global_planner.config import GlobalPlannerConfig
+from dynamo.global_planner.priority import DEFAULT_POOL_PRIORITY
 
 pytestmark = [
     pytest.mark.gpu_0,
@@ -186,3 +187,38 @@ def test_config_file_path_accepted_by_parser(tmp_path):
     path.write_text("intent_cache_ttl_seconds: 720\n")
     config = _resolve("--config", str(path))
     assert config.intent_cache_ttl_seconds == 720
+
+
+# ---------------------------------------------------------------------------- #
+# Pool priorities                                                              #
+# ---------------------------------------------------------------------------- #
+
+
+def test_priority_defaults_when_unconfigured():
+    config = GlobalPlannerConfig()
+    assert config.priority.default == DEFAULT_POOL_PRIORITY
+    assert config.priority.pools == []
+
+
+def test_priority_table_from_yaml(tmp_path):
+    path = tmp_path / "gp.yaml"
+    path.write_text(
+        "max_total_gpus: 32\n"
+        "priority:\n"
+        "  default: 250\n"
+        "  pools:\n"
+        "    - selector: prod/chat\n"
+        "      priority: 900\n"
+        "    - selector: dev/*\n"
+        "      priority: 10\n"
+    )
+    config = GlobalPlannerConfig.from_config_arg(str(path))
+    assert config.priority.default == 250
+    assert [p.selector for p in config.priority.pools] == ["prod/chat", "dev/*"]
+
+
+def test_invalid_priority_in_config_is_rejected():
+    with pytest.raises(ValidationError):
+        GlobalPlannerConfig.from_config_arg(
+            json.dumps({"priority": {"pools": [{"selector": "a//b", "priority": 0}]}})
+        )

--- a/components/src/dynamo/global_planner/tests/unit/test_priority.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_priority.py
@@ -1,0 +1,267 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for pool priority declaration and resolution."""
+
+import pytest
+from pydantic import ValidationError
+
+from dynamo.global_planner.priority import (
+    DEFAULT_POOL_PRIORITY,
+    DEFAULT_SELECTOR,
+    LOWEST_PRIORITY,
+    PriorityConfig,
+    PriorityContext,
+    PriorityResolver,
+    outranks,
+)
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+def _resolver(**kwargs) -> PriorityResolver:
+    return PriorityResolver(PriorityConfig(**kwargs))
+
+
+# ---------------------------------------------------------------------------- #
+# Polarity                                                                     #
+# ---------------------------------------------------------------------------- #
+
+
+def test_higher_priority_is_more_important():
+    assert LOWEST_PRIORITY == 0
+    assert outranks(1, 0)
+    assert outranks(100, 10)
+    assert not outranks(0, 1)
+    assert not outranks(5, 5)
+
+
+def test_negative_priority_is_rejected():
+    with pytest.raises(ValidationError):
+        PriorityConfig(pools=[{"selector": "ns/a", "priority": -1}])
+    with pytest.raises(ValidationError):
+        PriorityConfig(default=-1)
+
+
+# ---------------------------------------------------------------------------- #
+# Defaults for unseen pools                                                    #
+# ---------------------------------------------------------------------------- #
+
+
+def test_unmatched_pool_takes_the_default():
+    resolved = _resolver().resolve("ns/never-seen", "prefill")
+    assert resolved.priority == DEFAULT_POOL_PRIORITY
+    assert resolved.selector == DEFAULT_SELECTOR
+
+
+def test_default_is_configurable():
+    assert _resolver(default=7).resolve("ns/a", "decode").priority == 7
+
+
+# ---------------------------------------------------------------------------- #
+# Declare coarse, resolve fine                                                 #
+# ---------------------------------------------------------------------------- #
+
+
+def test_participant_selector_covers_every_pool_under_it():
+    resolver = _resolver(pools=[{"selector": "prod/chat", "priority": 900}])
+    assert resolver.resolve("prod/chat", "prefill").priority == 900
+    assert resolver.resolve("prod/chat", "decode").priority == 900
+    assert resolver.resolve("prod/batch", "decode").priority == DEFAULT_POOL_PRIORITY
+
+
+def test_pool_selector_overrides_participant_selector():
+    resolver = _resolver(
+        pools=[
+            {"selector": "prod/chat", "priority": 900},
+            {"selector": "prod/chat/prefill", "priority": 950},
+        ]
+    )
+    assert resolver.resolve("prod/chat", "prefill").priority == 950
+    assert resolver.resolve("prod/chat", "decode").priority == 900
+
+
+def test_specificity_beats_declaration_order():
+    # Same policies, reversed in the file: resolution must not change.
+    forward = _resolver(
+        pools=[
+            {"selector": "prod/*", "priority": 200},
+            {"selector": "prod/chat", "priority": 900},
+        ]
+    )
+    reverse = _resolver(
+        pools=[
+            {"selector": "prod/chat", "priority": 900},
+            {"selector": "prod/*", "priority": 200},
+        ]
+    )
+    for resolver in (forward, reverse):
+        assert resolver.resolve("prod/chat", "decode").priority == 900
+        assert resolver.resolve("prod/other", "decode").priority == 200
+
+
+def test_pool_glob_is_more_specific_than_participant_glob():
+    resolver = _resolver(
+        pools=[
+            {"selector": "dev/*", "priority": 300},
+            {"selector": "dev/*/prefill", "priority": 90},
+        ]
+    )
+    assert resolver.resolve("dev/x", "prefill").priority == 90
+    assert resolver.resolve("dev/x", "decode").priority == 300
+
+
+def test_single_star_does_not_span_a_slash():
+    # The trailing segment forces '*' to be the only thing between 'a' and
+    # 'prefill'; a whole-string glob would also match the deeper path.
+    resolver = _resolver(pools=[{"selector": "a/*/prefill", "priority": 42}])
+    assert resolver.resolve("a/b", "prefill").priority == 42
+    assert resolver.resolve("a/b/c", "prefill").priority == DEFAULT_POOL_PRIORITY
+
+
+def test_double_star_spans_any_number_of_segments():
+    resolver = _resolver(pools=[{"selector": "a/**/prefill", "priority": 42}])
+    assert resolver.resolve("a/b", "prefill").priority == 42
+    assert resolver.resolve("a/b/c/d", "prefill").priority == 42
+    assert resolver.resolve("a/b/c/d", "decode").priority == DEFAULT_POOL_PRIORITY
+
+
+def test_selectors_may_be_any_depth():
+    # Participant ids are '<k8s_ns>/<dgd>' today, but the matcher must not
+    # hard-code that shape -- deeper hierarchies are on the roadmap.
+    resolver = _resolver(
+        pools=[
+            {
+                "selector": "global-pool/east-coast-regions/*/long-context/*",
+                "priority": 950,
+            }
+        ]
+    )
+    deep = "global-pool/east-coast-regions/us-east-1/long-context"
+    assert resolver.resolve(deep, "decode").priority == 950
+    assert resolver.resolve(deep, "prefill").priority == 950
+    other = "global-pool/east-coast-regions/us-east-1/short-context"
+    assert resolver.resolve(other, "decode").priority == DEFAULT_POOL_PRIORITY
+
+
+def test_bare_double_star_matches_everything_and_ranks_last():
+    resolver = _resolver(
+        pools=[
+            {"selector": "**", "priority": 1},
+            {"selector": "prod/chat", "priority": 900},
+        ]
+    )
+    assert resolver.resolve("anything/at-all", "decode").priority == 1
+    assert resolver.resolve("prod/chat", "decode").priority == 900
+
+
+def test_resolution_reports_provenance():
+    resolver = _resolver(pools=[{"selector": "prod/chat", "priority": 300}])
+    resolved = resolver.resolve("prod/chat", "prefill")
+    assert (resolved.selector, resolved.rule_index) == ("prod/chat", 0)
+
+
+# ---------------------------------------------------------------------------- #
+# Static priorities are degenerate conditionals                                #
+# ---------------------------------------------------------------------------- #
+
+
+def test_shorthand_normalizes_into_a_single_unconditional_rule():
+    policy = PriorityConfig(pools=[{"selector": "ns/a", "priority": 4}]).pools[0]
+    assert policy.priority is None
+    assert len(policy.rules) == 1
+    assert policy.rules[0].when is None
+    assert policy.rules[0].priority == 4
+
+
+def test_config_survives_a_model_dump_round_trip():
+    # resolve_config() merges CLI flags via model_dump() -> model_validate();
+    # a shorthand left alongside 'rules' would fail revalidation there.
+    config = PriorityConfig(default=9, pools=[{"selector": "ns/a", "priority": 1}])
+    assert PriorityConfig.model_validate(config.model_dump()) == config
+
+
+def test_explicit_rules_are_accepted():
+    resolver = _resolver(
+        pools=[
+            {
+                "selector": "ns/a",
+                "rules": [{"when": {}, "priority": 2}, {"priority": 8}],
+            }
+        ]
+    )
+    resolved = resolver.resolve("ns/a", "decode", PriorityContext())
+    assert (resolved.priority, resolved.rule_index) == (2, 0)
+
+
+def test_conditions_are_not_supported_yet_and_fail_loudly():
+    # Guards the dangerous alternative: parsing an unknown predicate into a
+    # condition that silently matches everything.
+    with pytest.raises(ValidationError):
+        PriorityConfig(
+            pools=[
+                {
+                    "selector": "ns/a",
+                    "rules": [
+                        {"when": {"predicted_requests_above": 100}, "priority": 0},
+                        {"priority": 50},
+                    ],
+                }
+            ]
+        )
+
+
+def test_rules_must_end_unconditional():
+    with pytest.raises(ValidationError, match="unconditional rule"):
+        PriorityConfig(
+            pools=[{"selector": "ns/a", "rules": [{"when": {}, "priority": 0}]}]
+        )
+
+
+# ---------------------------------------------------------------------------- #
+# Config validation                                                            #
+# ---------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"selector": "ns/a"},  # neither priority nor rules
+        {"selector": "ns/a", "priority": 1, "rules": [{"priority": 2}]},  # both
+        {"selector": "ns/a", "rules": []},  # empty
+    ],
+)
+def test_policy_must_declare_exactly_one_form(entry):
+    with pytest.raises(ValidationError):
+        PriorityConfig(pools=[entry])
+
+
+@pytest.mark.parametrize("selector", ["ns//prefill", ""])
+def test_selectors_with_empty_segments_are_rejected(selector):
+    with pytest.raises(ValidationError):
+        PriorityConfig(pools=[{"selector": selector, "priority": 0}])
+
+
+@pytest.mark.parametrize("selector", ["ns", "ns/a", "ns/a/prefill", "a/b/c/d/e"])
+def test_selectors_of_any_depth_are_accepted(selector):
+    assert PriorityConfig(pools=[{"selector": selector, "priority": 0}])
+
+
+def test_duplicate_selectors_are_rejected():
+    with pytest.raises(ValidationError, match="duplicate selector"):
+        PriorityConfig(
+            pools=[
+                {"selector": "ns/a", "priority": 900},
+                {"selector": "ns/a", "priority": 5},
+            ]
+        )
+
+
+def test_unknown_config_field_is_rejected():
+    with pytest.raises(ValidationError):
+        PriorityConfig(defualt=5)  # codespell:ignore defualt


### PR DESCRIPTION
## Overview:

**Stack 3/6** — pool prioritization for the Global Planner (`LLM-176`). Based on #14036.

Declares which pools should be served first when several compete for one GPU budget. **Nothing consumes this yet** — arbitration is untouched — so the declaration surface can be reviewed on its own. This is the PR worth the most scrutiny; the config shape is the expensive thing to get wrong.

## Details:

```yaml
priority:
  default: 100                       # pools no selector matches
  pools:
    - selector: prod/chat            # participant: every pool under it
      priority: 900
    - selector: prod/chat/prefill    # one pool: overrides the line above
      priority: 950
    - selector: dev/*                # any deployment in the dev namespace
      priority: 10
```

**Higher numbers are more important**, matching Kubernetes `PriorityClass` and `nvext.agent_hints.priority`. That is the opposite of the plugin-stage `priority` in `dynamo.planner`, where smaller is more authoritative, so `outranks()` keeps the comparison in one place.

**Declare coarse, resolve fine.** A selector is a slash-separated path matched against `<participant_id>/<sub_type>`. `*` matches exactly one segment, `**` matches any number, and a selector shorter than the pool path covers everything beneath it. Depth is not fixed — participant ids are `<k8s ns>/<dgd>` today, but a deeper hierarchy such as `global-pool/east-coast-regions/*/long-context/*` matches without special-casing. The most specific match wins independent of declaration order, ranked by exactly-named segments then depth.

**Static priorities are degenerate conditionals.** A policy is always an ordered first-match-wins rule list ending in an unconditional rule, and `resolve()` already takes a `PriorityContext`. Adding real predicates (#14039) is a new `PriorityCondition` field and nothing else — no call site changes. `PriorityCondition` forbids unknown fields, so a config declaring a condition at this point in the stack fails at startup instead of parsing into one that always matches.

## Where should the reviewer start?

- `priority.py` — the whole surface.
- `PoolPriorityPolicy._normalize` — the `priority: <n>` shorthand is normalized into `rules` **and cleared**, not left beside it, so the model round-trips through `model_dump()` → `model_validate()` cleanly.

## Verified on a cluster

Deployed on `dynamo-planner:1.4.2` in a real namespace; the priority table parses and logs in-container, including a mid-path `*` and a `**`:

```
Default pool priority: 100
Pool priority selectors: 3
  sachalm/qwen3-0-6b-batch -> 900
  sachalm/*/prefill -> 50
  dev/** -> 10, 100
```

## Testing

Tests in `tests/unit/test_priority.py` and `test_config.py`. Full `planner` + `global_planner` suites pass locally (1321 passed, 8 skipped).

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — tracked in Linear as LLM-176

🤖 Generated with [Claude Code](https://claude.com/claude-code)