### PR TITLE
feat(global-planner): order pair partners by pool priority

### DIFF
--- a/components/src/dynamo/global_planner/README.md
+++ b/components/src/dynamo/global_planner/README.md
@@ -218,9 +218,27 @@ declares one is rejected at startup rather than silently treated as
 always-matching. The structure is in place so adding them does not change the
 declaration surface or any caller.
 
-> **Not consumed yet.** This release only declares and resolves priorities;
-> budget arbitration does not read them. Setting them changes nothing about
-> scaling decisions today.
+### How priorities affect scaling
+
+Priorities order **pair-partner selection**, which is how the Global Planner
+moves capacity between pools when one alone would breach the budget band. The
+ordering inverts with the direction of the transfer:
+
+| Request | Partners are | Served first |
+|---------|--------------|--------------|
+| Scale-up (needs GPUs) | donors giving GPUs up | the **least** important pool (lowest number) |
+| Scale-down below the floor (frees GPUs) | recipients taking GPUs on | the **most** important pool (highest number) |
+
+Priority is the leading term, ahead of the preference for keeping a transfer
+inside one DGD. When every pool resolves to the same priority the term is
+constant, so an unconfigured Global Planner arbitrates exactly as it did before
+priorities existed.
+
+Priority does **not** add new denials. Pairing only ever consumes a scale
+*intent a pool already published*, so a high-priority pool never has capacity
+taken from it against its will — it is only paired when it had already decided
+to scale down. Taking capacity from a pool that did not ask to give it up is
+proactive reclaim, which is not implemented.
 
 ## Behavior
 

--- a/components/src/dynamo/global_planner/__main__.py
+++ b/components/src/dynamo/global_planner/__main__.py
@@ -81,6 +81,7 @@ async def main(runtime: DistributedRuntime, config: GlobalPlannerConfig):
         max_total_gpus=config.max_total_gpus,
         min_total_gpus=config.min_total_gpus,
         intent_cache_ttl_seconds=config.intent_cache_ttl_seconds,
+        priority_config=config.priority,
     )
 
     logger.info("Serving endpoints...")

--- a/components/src/dynamo/global_planner/orchestrator.py
+++ b/components/src/dynamo/global_planner/orchestrator.py
@@ -34,6 +34,11 @@ from dynamo.global_planner.capacity_manager import (
     PoolSnapshot,
     PoolSpec,
 )
+from dynamo.global_planner.priority import (
+    PriorityContext,
+    PriorityResolver,
+    ResolvedPriority,
+)
 from dynamo.planner import SubComponentType, TargetReplica
 from dynamo.planner.connectors.protocol import ScaleStatus
 from dynamo.planner.core import budget
@@ -125,8 +130,16 @@ class Orchestrator:
         intent_cache_ttl_seconds: float = 360.0,
         now: Callable[[], float] = time.time,
         use_lock: bool = True,
+        priority_resolver: Optional[PriorityResolver] = None,
     ):
         self.capacity_manager = capacity_manager
+
+        # Pool priorities order partner selection under contention. Defaulting
+        # to an empty resolver gives every pool the same priority, which makes
+        # the priority term constant and collapses the sort back to exactly the
+        # pre-priority ordering -- an unconfigured GlobalPlanner arbitrates
+        # identically to one built before priorities existed.
+        self.priority_resolver = priority_resolver or PriorityResolver()
 
         # TODO(global-planner): Validate configuration and requests at the
         # boundary: reject min > max and invalid TTLs, preserve an explicit empty
@@ -450,6 +463,7 @@ class Orchestrator:
         ``log_*`` values are used only for parity-identical log lines.
         """
         pools = all_pools.get(participant_id, {})
+        ctx = PriorityContext()
 
         # Always update the intent cache with this request's targets, regardless
         # of decision. A later request from a complementary pool may need to pair
@@ -522,6 +536,8 @@ class Orchestrator:
             )
             partners_desc = ", ".join(
                 f"{p.participant_id}/{p.sub_type}={p.applied_desired}"
+                f" (priority "
+                f"{self.priority_resolver.resolve(p.participant_id, p.sub_type, ctx).priority})"
                 for p in selected_partners
             )
             logger.info(
@@ -545,8 +561,10 @@ class Orchestrator:
         else:
             # Budget breach: standalone out-of-bounds and no feasible partner set
             # found.
+            requester = self._summarize_request_priority(participant_id, targets, ctx)
             logger.warning(
-                f"Rejecting scale request from {log_caller_name}: "
+                f"Rejecting scale request from {log_caller_name} "
+                f"(priority {requester.priority} via {requester.selector}): "
                 f"{standalone_reason}; no feasible pair packing"
             )
             # Soft denial: budget breach is an expected operational outcome in
@@ -559,6 +577,29 @@ class Orchestrator:
                     f"GPU budget breach: {standalone_reason}; no feasible pair packing"
                 ),
             )
+
+    def _summarize_request_priority(
+        self,
+        participant_id: str,
+        targets: list[TargetReplica],
+        ctx: PriorityContext,
+    ) -> ResolvedPriority:
+        """Pick one priority to name in a log line for a multi-pool request.
+
+        **Reporting only** -- this does not participate in matching. Each pool
+        still resolves independently through its own most-specific selector; a
+        request that spans several pools simply needs one of those results to
+        print, and the pool that outranks the rest is the informative choice.
+        """
+        resolved = [
+            self.priority_resolver.resolve(
+                participant_id, target.sub_component_type.value, ctx
+            )
+            for target in targets
+        ]
+        if not resolved:
+            return self.priority_resolver.resolve(participant_id, "", ctx)
+        return max(resolved, key=lambda r: r.priority)
 
     def _total_gpus_from_snapshot(
         self,
@@ -798,17 +839,34 @@ class Orchestrator:
                 c.applied_desired - c.spec.current_replicas
             ) * c.spec.gpu_per_replica
 
-        # Same-participant partners first, then ascending |delta_gpu| — smaller
-        # pieces overshoot less. The participant term is the primary key on
-        # purpose: an intra-participant partner merges into the request's single
-        # atomic set_component_replicas call, while a cross-participant partner
-        # needs its own patch and can leave a half-applied transfer behind when a
-        # later patch fails (see _observe_decide_apply). Sorting on |delta_gpu|
-        # alone silently discarded that preference, because a cross-participant
-        # candidate with a smaller delta sorted ahead of every intra-participant
-        # one.
+        # Resolve each candidate's priority once; the sort would otherwise
+        # re-resolve on every comparison.
+        ctx = PriorityContext()
+        priorities = {
+            (c.participant_id, c.sub_type): self.priority_resolver.resolve(
+                c.participant_id, c.sub_type, ctx
+            )
+            for c in all_candidates
+        }
+
+        # Priority leads, and its sign depends on which way capacity is moving.
+        # A scale-up request is served by donors giving GPUs up, so take from
+        # the LEAST important pool first. A scale-down request below the floor
+        # is paired with recipients taking GPUs on, so give to the MOST
+        # important pool first. Priorities are higher-is-more-important, so
+        # ascending order serves donors and descending serves recipients.
+        # Getting this backwards still produces in-band totals, so it would not
+        # fail loudly -- the two ordering tests cover both directions.
+        direction = 1 if request_net_delta_gpu > 0 else -1
+
+        # Then same-participant, which keeps the transfer in one atomic
+        # set_component_replicas call, then ascending |delta_gpu| since smaller
+        # pieces overshoot less. With no priority config every candidate
+        # resolves to the same value, so the leading term is constant and this
+        # is exactly the previous ordering.
         all_candidates.sort(
             key=lambda c: (
+                direction * priorities[(c.participant_id, c.sub_type)].priority,
                 c.participant_id != request_participant_id,
                 abs(cand_delta(c)),
             )

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -17,9 +17,11 @@ Behavior is unchanged from the pre-refactor monolithic handler.
 """
 
 import logging
+from typing import Optional
 
 from dynamo.global_planner.kubernetes_capacity_manager import KubernetesCapacityManager
 from dynamo.global_planner.orchestrator import Orchestrator
+from dynamo.global_planner.priority import PriorityConfig, PriorityResolver
 from dynamo.planner.connectors.protocol import ScaleRequest, ScaleResponse, ScaleStatus
 from dynamo.planner.errors import DynamoGraphDeploymentNotReadyError
 from dynamo.runtime import DistributedRuntime, dynamo_endpoint
@@ -54,6 +56,7 @@ class ScaleRequestHandler:
         max_total_gpus: int = -1,
         min_total_gpus: int = -1,
         intent_cache_ttl_seconds: float = 360.0,
+        priority_config: Optional[PriorityConfig] = None,
     ):
         """Initialize the scale request handler.
 
@@ -66,6 +69,8 @@ class ScaleRequestHandler:
             min_total_gpus: Minimum total GPUs across all managed pools (-1 = no floor)
             intent_cache_ttl_seconds: How long a cached scale intent from a pool
                 is considered fresh for pairing
+            priority_config: Pool priorities used to order partner selection
+                under contention (None = every pool equally important)
         """
         self.runtime = runtime
         self.no_operation = no_operation
@@ -83,6 +88,7 @@ class ScaleRequestHandler:
             min_total_gpus=min_total_gpus,
             intent_cache_ttl_seconds=intent_cache_ttl_seconds,
             use_lock=True,
+            priority_resolver=PriorityResolver(priority_config),
         )
 
         if managed_namespaces:

--- a/components/src/dynamo/global_planner/tests/unit/test_orchestrator.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_orchestrator.py
@@ -14,6 +14,7 @@ import pytest
 
 from dynamo.global_planner.capacity_manager import CapacityManager, PoolSpec
 from dynamo.global_planner.orchestrator import Orchestrator
+from dynamo.global_planner.priority import PriorityConfig, PriorityResolver
 from dynamo.planner import SubComponentType, TargetReplica
 from dynamo.planner.connectors.protocol import ScaleStatus
 
@@ -175,6 +176,88 @@ def test_falls_back_to_cross_participant_when_no_intra_candidate():
         "decode",
         3,
     )
+
+
+def _priority(**kwargs) -> PriorityResolver:
+    return PriorityResolver(PriorityConfig(**kwargs))
+
+
+def test_scale_up_takes_from_the_least_important_donor_first():
+    """A scale-up is served by donors, so the expendable pool should give first.
+
+    Also pins that priority outranks the intra-participant preference: ns/b is
+    a separate participant and would lose the tiebreak on atomicity grounds,
+    but the operator declared it expendable and ns/a important.
+    """
+    pools = _pools(ns__a=(2, 5, 1), ns__b=(None, 5, 1))  # 2 + 5 + 5 = 12
+
+    def run(resolver):
+        orch = _decider(
+            max_total_gpus=12, min_total_gpus=12, priority_resolver=resolver
+        )
+        # Two equally sized pending scale-downs, one per participant.
+        orch.update_intent_cache("ns/a", _targets(decode=3), pools["ns/a"])
+        orch.update_intent_cache("ns/b", _targets(decode=3), pools["ns/b"])
+        return _mediate(orch, "ns/a", _targets(prefill=4), pools)  # +2
+
+    # Control: with no priorities declared, the intra-participant partner wins.
+    assert run(_priority()).selected_partners[0].participant_id == "ns/a"
+
+    # ns/b is declared expendable, so it donates before the important pool.
+    resolver = _priority(
+        pools=[
+            {"selector": "ns/a", "priority": 900},
+            {"selector": "ns/b", "priority": 10},
+        ]
+    )
+    assert run(resolver).selected_partners[0].participant_id == "ns/b"
+
+
+def test_scale_down_gives_to_the_most_important_recipient_first():
+    """A scale-down below the floor is paired with recipients, so the ordering
+    must invert: freed capacity goes to the most important pool first."""
+    pools = _pools(ns__a=(None, 3, 1), ns__b=(None, 3, 1), ns__c=(None, 3, 1))  # 9
+
+    def run(resolver):
+        orch = _decider(max_total_gpus=9, min_total_gpus=9, priority_resolver=resolver)
+        # Two equally sized pending scale-ups competing for the freed GPUs.
+        orch.update_intent_cache("ns/b", _targets(decode=5), pools["ns/b"])
+        orch.update_intent_cache("ns/c", _targets(decode=5), pools["ns/c"])
+        return _mediate(orch, "ns/a", _targets(decode=1), pools)  # -2
+
+    # No unprioritized control here: with equal priorities the two candidates
+    # tie on every sort term, and _iter_pair_partners yields in unspecified
+    # order, so pinning the winner would test an unsupported behavior.
+    resolver = _priority(
+        pools=[
+            {"selector": "ns/b", "priority": 10},
+            {"selector": "ns/c", "priority": 900},
+        ]
+    )
+    result = run(resolver)
+    assert [p.participant_id for p in result.selected_partners] == ["ns/c"]
+
+
+def test_unconfigured_priorities_leave_arbitration_unchanged():
+    """Every pool resolving to the same priority must make the leading sort term
+    constant, so an unconfigured GlobalPlanner arbitrates exactly as before."""
+    pools = _pools(ns__a=(2, 5, 1), ns__b=(None, 5, 1))
+
+    def run(resolver):
+        orch = _decider(
+            max_total_gpus=12, min_total_gpus=12, priority_resolver=resolver
+        )
+        orch.update_intent_cache("ns/a", _targets(decode=1), pools["ns/a"])
+        orch.update_intent_cache("ns/b", _targets(decode=4), pools["ns/b"])
+        res = _mediate(orch, "ns/a", _targets(prefill=4), pools)
+        return [
+            (p.participant_id, p.sub_type, p.applied_desired)
+            for p in res.selected_partners
+        ]
+
+    # A uniform non-default value must behave the same as declaring nothing.
+    uniform = _priority(pools=[{"selector": "ns/*", "priority": 42}])
+    assert run(_priority()) == run(uniform)
 
 
 def test_intent_cache_ttl_expiry_blocks_pairing():

--- a/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from dynamo.global_planner.orchestrator import PoolIntent
+from dynamo.global_planner.priority import PriorityConfig
 from dynamo.global_planner.scale_handler import ScaleRequestHandler
 from dynamo.planner import KubernetesConnector, SubComponentType, TargetReplica
 from dynamo.planner.connectors.protocol import ScaleRequest
@@ -1788,3 +1789,99 @@ async def test_untyped_worker_in_other_dgd_counts_toward_budget(mock_runtime):
     )
     assert results[0]["status"] == "rejected"
     connector_a.set_component_replicas.assert_not_called()
+
+
+# ---------------------------------------------------------------------------- #
+# Pool priority, end to end through the scale_request endpoint                 #
+# ---------------------------------------------------------------------------- #
+
+
+def _priority_handler(mock_runtime, pools):
+    """Handler with a fixed 12-GPU budget and a pool priority table."""
+    return ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-prod", "default-batch"],
+        k8s_namespace="default",
+        min_total_gpus=12,
+        max_total_gpus=12,
+        priority_config=PriorityConfig(pools=pools),
+    )
+
+
+async def _run_priority_transfer(mock_runtime, pools):
+    """Drive one over-ceiling scale-up against two equally-sized DGDs.
+
+    Both DGDs hold a pending scale-down, so packing must choose which one
+    absorbs the larger cut. Returns the targets each DGD was patched with.
+    """
+    handler = _priority_handler(mock_runtime, pools)
+    prod = _install_connector(
+        handler,
+        "default/prod",
+        _dgd_spec(prefill_replicas=3, decode_replicas=3),
+        parent_dgd_name="prod",
+    )
+    batch = _install_connector(
+        handler,
+        "default/batch",
+        _dgd_spec(prefill_replicas=3, decode_replicas=3),
+        parent_dgd_name="batch",
+    )
+
+    # Equal pending scale-downs, one per DGD: 3 -> 1 decode replicas.
+    now = time.time()
+    handler.orchestrator._intent_cache["default/prod/decode"] = PoolIntent(
+        last_desired=1, last_seen_at=now
+    )
+    handler.orchestrator._intent_cache["default/batch/decode"] = PoolIntent(
+        last_desired=1, last_seen_at=now
+    )
+
+    # prod wants two more prefill replicas: 14 GPUs standalone, over the ceiling.
+    results = await _run(
+        handler, _scale_req(dgd="prod", caller_ns="default-prod", prefill=5)
+    )
+    assert results[0]["status"] == "success", results[0]
+
+    def targets(connector):
+        return {
+            t.sub_component_type.value: t.desired_replicas
+            for t in connector.set_component_replicas.call_args[0][0]
+        }
+
+    return targets(prod), targets(batch)
+
+
+@pytest.mark.asyncio
+async def test_expendable_pool_absorbs_the_larger_cut(mock_runtime):
+    """End to end: the pool the operator marked expendable gives up more GPUs.
+
+    Both DGDs are identical and both have an equal pending scale-down, so the
+    only thing distinguishing them is the declared priority.
+    """
+    prod, batch = await _run_priority_transfer(
+        mock_runtime,
+        [
+            {"selector": "default/prod", "priority": 900},
+            {"selector": "default/batch", "priority": 10},
+        ],
+    )
+    # prod grows by 2 and gives back only 1 decode replica; batch gives 2.
+    assert prod == {"prefill": 5, "decode": 2}
+    assert batch == {"decode": 1}
+
+
+@pytest.mark.asyncio
+async def test_reversing_priorities_reverses_who_pays(mock_runtime):
+    """Same topology with the priorities swapped moves the cut to the other DGD,
+    which is what proves the outcome is driven by priority and not by
+    participant identity or observation order."""
+    prod, batch = await _run_priority_transfer(
+        mock_runtime,
+        [
+            {"selector": "default/prod", "priority": 10},
+            {"selector": "default/batch", "priority": 900},
+        ],
+    )
+    assert prod == {"prefill": 5, "decode": 1}
+    assert batch == {"decode": 2}


### PR DESCRIPTION
## Overview:

**Stack 4/6** — pool prioritization for the Global Planner (`LLM-177`). Based on #14037.

Wires the resolver from #14037 into budget arbitration. First PR in the stack where priorities actually affect scaling.

## Details:

Priority becomes the leading term when ordering pair-partner candidates, ahead of the intra-participant preference from #14036 and the `abs(delta_gpu)` tiebreak: keeping a transfer atomic is a mechanism concern, while priority is the business decision the operator declared.

**The ordering inverts with the direction of the transfer.** This is the part worth reviewing closely:

| Request | Partners are | Served first |
|---------|--------------|--------------|
| Scale-up (needs GPUs) | donors giving GPUs up | the **least** important pool (lowest number) |
| Scale-down below the floor (frees GPUs) | recipients taking GPUs on | the **most** important pool (highest number) |

Both directions produce in-band totals either way, so an inverted sign would not fail loudly. Flipping the direction term makes both ordering tests fail.

**An unconfigured GlobalPlanner is unaffected.** Every pool resolves to the same priority, the leading term is constant, and the sort collapses to exactly the previous ordering. A test pins that a uniform non-default priority produces the same packing as declaring nothing.

**This adds no new denials.** Pairing only ever consumes a scale intent a pool *already published*, so a high-priority pool is never drained against its will. Taking capacity from a pool that did not ask to give it up is proactive reclaim, which is not implemented here.

## Where should the reviewer start?

- `orchestrator.py::_find_pair_partner_set` — the `direction` term and the sort key.
- `tests/unit/test_scale_request_handler.py::test_expendable_pool_absorbs_the_larger_cut` and its `test_reversing_priorities_reverses_who_pays` sibling — end to end through the real `scale_request` endpoint across two DGDs, asserting on the actual `set_component_replicas` patches. Two identical DGDs with equal pending scale-downs, so priority is the only thing distinguishing them; reversing the priorities reverses which one pays.

## Testing

3 ordering tests plus 2 end-to-end. Full `planner` + `global_planner` suites pass locally (1321 passed, 8 skipped).

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — tracked in Linear as LLM-177

🤖 Generated with [Claude Code](https://claude.com/claude-code)