### PR TITLE
feat(global-planner): add load-conditional pool priorities

### DIFF
--- a/components/src/dynamo/global_planner/README.md
+++ b/components/src/dynamo/global_planner/README.md
@@ -212,11 +212,35 @@ unconditional. `priority: <n>` is shorthand for exactly one such rule:
         - priority: 900
 ```
 
-Rule *conditions* — "this priority while traffic is above X", "that priority
-while the pool is breaching its SLA" — are not implemented yet, and a config that
-declares one is rejected at startup rather than silently treated as
-always-matching. The structure is in place so adding them does not change the
-declaration surface or any caller.
+A rule may carry a `when:` block, in which case it applies only while its
+predicates hold:
+
+```yaml
+    - selector: prod/batch
+      rules:
+        - when: {predicted_requests_below: 50}   # quiet: yield to everyone
+          priority: 10
+        - priority: 100                          # busy: normal standing
+```
+
+Available predicates today, both read from the `predicted_load` a local planner
+already attaches to every scale request:
+
+| Predicate | Matches when |
+|-----------|--------------|
+| `predicted_requests_at_least` | predicted request rate is at or above the value |
+| `predicted_requests_below` | predicted request rate is strictly below the value |
+
+Two properties worth knowing. A predicate whose signal is **absent or
+unusable** — missing, wrong type, negative, NaN, or infinite — does not match,
+so a pool falls through to its unconditional rule instead of being reclassified
+on bad data. And conditions are evaluated
+against **that pool's own** signals — a partner's context comes from the intent
+it published, so "while its traffic is low" means the partner's traffic, not the
+traffic of whichever pool happens to be requesting.
+
+SLA-breach predicates are not implemented; they need signals that are not on the
+scale-request contract yet.
 
 ### How priorities affect scaling
 

--- a/components/src/dynamo/global_planner/orchestrator.py
+++ b/components/src/dynamo/global_planner/orchestrator.py
@@ -52,10 +52,17 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class PoolIntent:
-    """Most recently observed desired replica count for a pool."""
+    """Most recently observed desired replica count for a pool.
+
+    ``context`` is the priority context that pool published alongside the
+    intent. Conditional priorities for a *partner* must be evaluated against
+    the partner's own signals, not the signals of whoever happens to be asking
+    now, so the context is cached with the intent rather than recomputed.
+    """
 
     last_desired: int
     last_seen_at: float
+    context: PriorityContext = field(default_factory=PriorityContext)
 
 
 @dataclass
@@ -263,6 +270,7 @@ class Orchestrator:
         blocking: bool,
         deployment_name: str,
         caller_name: str,
+        priority_context: Optional[PriorityContext] = None,
     ) -> ScaleOutcome:
         """Arbitrate and execute one scale request.
 
@@ -275,11 +283,21 @@ class Orchestrator:
         if self._scale_lock is not None:
             async with self._scale_lock:
                 terminal = await self._observe_decide_apply(
-                    participant_id, targets, blocking, deployment_name, caller_name
+                    participant_id,
+                    targets,
+                    blocking,
+                    deployment_name,
+                    caller_name,
+                    priority_context,
                 )
         else:
             terminal = await self._observe_decide_apply(
-                participant_id, targets, blocking, deployment_name, caller_name
+                participant_id,
+                targets,
+                blocking,
+                deployment_name,
+                caller_name,
+                priority_context,
             )
 
         if terminal is not None:
@@ -301,6 +319,7 @@ class Orchestrator:
         blocking: bool,
         deployment_name: str,
         caller_name: str,
+        priority_context: Optional[PriorityContext] = None,
     ) -> Optional[ScaleOutcome]:
         """Observe all pools, decide the budget outcome, and apply it.
 
@@ -333,6 +352,7 @@ class Orchestrator:
             all_pools,
             log_deployment_name=deployment_name,
             log_caller_name=caller_name,
+            priority_context=priority_context,
         )
         if not result.approved:
             # Soft denial: budget breach is an expected operational outcome in
@@ -454,6 +474,7 @@ class Orchestrator:
         all_pools: PoolSnapshot,
         log_deployment_name: str = "",
         log_caller_name: str = "",
+        priority_context: Optional[PriorityContext] = None,
     ) -> MediationResult:
         """Decide whether ``targets`` for ``participant_id`` fit the budget.
 
@@ -463,12 +484,13 @@ class Orchestrator:
         ``log_*`` values are used only for parity-identical log lines.
         """
         pools = all_pools.get(participant_id, {})
-        ctx = PriorityContext()
+        # The requesting pool's own signals; partners use their cached ones.
+        ctx = priority_context or PriorityContext()
 
         # Always update the intent cache with this request's targets, regardless
         # of decision. A later request from a complementary pool may need to pair
         # with this intent.
-        self.update_intent_cache(participant_id, targets, pools)
+        self.update_intent_cache(participant_id, targets, pools, ctx)
 
         request_pool_keys = {
             (participant_id, t.sub_component_type.value) for t in targets
@@ -529,6 +551,14 @@ class Orchestrator:
         # 2. Else if standalone in bounds → apply standalone.
         # 3. Else deny.
         if selected_partners:
+            priorities_for_log = {
+                (p.participant_id, p.sub_type): self.priority_resolver.resolve(
+                    p.participant_id,
+                    p.sub_type,
+                    self._cached_context(p.participant_id, p.sub_type),
+                ).priority
+                for p in selected_partners
+            }
             scope = (
                 "intra-participant"
                 if all(p.participant_id == participant_id for p in selected_partners)
@@ -537,7 +567,7 @@ class Orchestrator:
             partners_desc = ", ".join(
                 f"{p.participant_id}/{p.sub_type}={p.applied_desired}"
                 f" (priority "
-                f"{self.priority_resolver.resolve(p.participant_id, p.sub_type, ctx).priority})"
+                f"{priorities_for_log[(p.participant_id, p.sub_type)]})"
                 for p in selected_partners
             )
             logger.info(
@@ -642,9 +672,11 @@ class Orchestrator:
         participant_id: str,
         targets: list[TargetReplica],
         pools: dict[str, PoolSpec],
+        priority_context: Optional[PriorityContext] = None,
     ):
-        """Record the desired replicas for each pool in this request."""
+        """Record the desired replicas and priority context for this request."""
         now = self._now()
+        context = priority_context or PriorityContext()
         for target in targets:
             sub_type = target.sub_component_type.value
             if sub_type not in pools:
@@ -655,11 +687,21 @@ class Orchestrator:
             self._intent_cache[key] = PoolIntent(
                 last_desired=target.desired_replicas,
                 last_seen_at=now,
+                context=context,
             )
 
     # ------------------------------------------------------------------ #
     # Tolerance                                                          #
     # ------------------------------------------------------------------ #
+
+    def _cached_context(self, participant_id: str, sub_type: str) -> PriorityContext:
+        """The priority context a pool published with its last intent.
+
+        Falls back to an empty context, whose effect is that every condition
+        fails to match and the pool resolves to its unconditional rule.
+        """
+        intent = self._intent_cache.get(self._pool_cache_key(participant_id, sub_type))
+        return intent.context if intent is not None else PriorityContext()
 
     def _pair_tolerance(
         self,
@@ -841,10 +883,11 @@ class Orchestrator:
 
         # Resolve each candidate's priority once; the sort would otherwise
         # re-resolve on every comparison.
-        ctx = PriorityContext()
         priorities = {
             (c.participant_id, c.sub_type): self.priority_resolver.resolve(
-                c.participant_id, c.sub_type, ctx
+                c.participant_id,
+                c.sub_type,
+                self._cached_context(c.participant_id, c.sub_type),
             )
             for c in all_candidates
         }

--- a/components/src/dynamo/global_planner/priority.py
+++ b/components/src/dynamo/global_planner/priority.py
@@ -38,19 +38,26 @@ participant. So a selector may name either, and the most specific match wins:
 Static priorities are degenerate conditionals
 ---------------------------------------------
 A policy is *always* an ordered list of rules resolved first-match-wins, whose
-final rule is unconditional. Today every rule is unconditional, so a policy is
-just a constant -- but :meth:`PriorityResolver.resolve` already takes a
-:class:`PriorityContext`, so adding real predicates later is a new
-:class:`PriorityCondition` field and nothing else. Callers do not change.
+final rule is unconditional, so ``priority: <n>`` is simply the one-rule case:
 
-``PriorityCondition`` forbids unknown fields, so a config that tries to declare
-a condition today fails loudly at startup instead of silently always-matching.
+.. code-block:: yaml
+
+    - selector: "prod/batch"
+      rules:
+        - when: {predicted_requests_below: 50}   # quiet: yield to everyone
+          priority: 800
+        - priority: 100                          # busy: normal standing
+
+Conditions are evaluated against the pool's own :class:`PriorityContext`, not
+the requester's -- a partner's context comes from the intent it published, so
+"while *its* traffic is low" means what it says.
 """
 
 from __future__ import annotations
 
 import fnmatch
 import logging
+import math
 from dataclasses import dataclass
 from typing import Optional
 
@@ -88,10 +95,52 @@ def outranks(a: int, b: int) -> bool:
 class PriorityContext:
     """Signals a conditional rule may test when resolving a pool's priority.
 
-    Empty today: every rule is unconditional, so resolution ignores it. It is
-    threaded through :meth:`PriorityResolver.resolve` from the start precisely
-    so that populating it later does not touch any call site.
+    Populated from the ``predicted_load`` a local planner already attaches to
+    every ``ScaleRequest``, so no protocol change was needed to reach them.
+    Each field is ``None`` when the caller did not supply it or supplied
+    something unusable (wrong type, negative, NaN, infinity); a condition that
+    tests a missing signal does **not** match, so a pool always falls through
+    to its unconditional rule rather than being silently reclassified on absent
+    or malformed data.
+
+    ``predicted_isl`` and ``predicted_osl`` are carried but no condition tests
+    them yet -- the context is the full signal set, conditions are the subset
+    we have designed predicates for.
     """
+
+    predicted_num_requests: Optional[float] = None
+    predicted_isl: Optional[float] = None
+    predicted_osl: Optional[float] = None
+
+    @classmethod
+    def from_predicted_load(cls, predicted_load: Optional[dict]) -> "PriorityContext":
+        """Build a context from a ``ScaleRequest.predicted_load`` payload.
+
+        Tolerates a missing payload and unexpected keys: this crosses a trust
+        boundary from a caller-supplied dict, and a malformed prediction must
+        degrade to "no signal" rather than fail a scale request.
+        """
+        if not predicted_load:
+            return cls()
+
+        def _number(key: str) -> Optional[float]:
+            value = predicted_load.get(key)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                return None
+            number = float(value)
+            # NaN and infinity are not usable signals, and a negative rate is
+            # not a rate. NaN in particular is dangerous: every comparison
+            # against it is False, so it would slip past both predicate checks
+            # and satisfy any condition rather than degrading to "no signal".
+            if not math.isfinite(number) or number < 0:
+                return None
+            return number
+
+        return cls(
+            predicted_num_requests=_number("num_requests"),
+            predicted_isl=_number("isl"),
+            predicted_osl=_number("osl"),
+        )
 
 
 @dataclass(frozen=True)
@@ -116,15 +165,57 @@ class ResolvedPriority:
 class PriorityCondition(BaseModel):
     """Predicates gating a :class:`PriorityRule`.
 
-    No predicate fields exist yet. ``extra="forbid"`` means a config declaring
-    one is rejected at startup rather than parsed into a condition that
-    silently matches everything.
+    All declared predicates must hold for the condition to match. A predicate
+    whose signal is absent from the context does **not** hold, so a rule never
+    fires on missing data. ``extra="forbid"`` keeps a typo'd predicate name
+    from parsing into a condition that silently matches everything.
     """
 
     model_config = ConfigDict(extra="forbid")
 
+    predicted_requests_at_least: Optional[float] = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Match when the caller's predicted request rate is at or above "
+            "this value -- 'this priority while traffic is high'."
+        ),
+    )
+    predicted_requests_below: Optional[float] = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Match when the caller's predicted request rate is strictly below "
+            "this value -- 'this priority while traffic is low'."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_range(self) -> "PriorityCondition":
+        low = self.predicted_requests_at_least
+        high = self.predicted_requests_below
+        if low is not None and high is not None and low >= high:
+            raise ValueError(
+                f"predicted_requests_at_least ({low}) must be below "
+                f"predicted_requests_below ({high}); as written no request "
+                f"rate can satisfy both"
+            )
+        return self
+
     def matches(self, ctx: PriorityContext) -> bool:
-        """Whether this condition holds for ``ctx``. Vacuously true today."""
+        """Whether every declared predicate holds for ``ctx``."""
+        rate = ctx.predicted_num_requests
+        if rate is not None and not math.isfinite(rate):
+            # Treat a non-finite rate as absent. Comparing against NaN yields
+            # False in both directions, which would otherwise let it satisfy
+            # every predicate instead of none of them.
+            rate = None
+        if self.predicted_requests_at_least is not None:
+            if rate is None or rate < self.predicted_requests_at_least:
+                return False
+        if self.predicted_requests_below is not None:
+            if rate is None or rate >= self.predicted_requests_below:
+                return False
         return True
 
 

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -21,7 +21,11 @@ from typing import Optional
 
 from dynamo.global_planner.kubernetes_capacity_manager import KubernetesCapacityManager
 from dynamo.global_planner.orchestrator import Orchestrator
-from dynamo.global_planner.priority import PriorityConfig, PriorityResolver
+from dynamo.global_planner.priority import (
+    PriorityConfig,
+    PriorityContext,
+    PriorityResolver,
+)
 from dynamo.planner.connectors.protocol import ScaleRequest, ScaleResponse, ScaleStatus
 from dynamo.planner.errors import DynamoGraphDeploymentNotReadyError
 from dynamo.runtime import DistributedRuntime, dynamo_endpoint
@@ -204,6 +208,12 @@ class ScaleRequestHandler:
                 blocking=request.blocking,
                 deployment_name=request.graph_deployment_name,
                 caller_name=request.caller_namespace,
+                # predicted_load is caller-supplied and optional; a missing or
+                # malformed payload degrades to "no signal", which makes every
+                # condition fail to match rather than failing the request.
+                priority_context=PriorityContext.from_predicted_load(
+                    request.predicted_load
+                ),
             )
             yield {
                 "status": outcome.status.value,

--- a/components/src/dynamo/global_planner/tests/unit/test_orchestrator.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_orchestrator.py
@@ -14,7 +14,11 @@ import pytest
 
 from dynamo.global_planner.capacity_manager import CapacityManager, PoolSpec
 from dynamo.global_planner.orchestrator import Orchestrator
-from dynamo.global_planner.priority import PriorityConfig, PriorityResolver
+from dynamo.global_planner.priority import (
+    PriorityConfig,
+    PriorityContext,
+    PriorityResolver,
+)
 from dynamo.planner import SubComponentType, TargetReplica
 from dynamo.planner.connectors.protocol import ScaleStatus
 
@@ -258,6 +262,56 @@ def test_unconfigured_priorities_leave_arbitration_unchanged():
     # A uniform non-default value must behave the same as declaring nothing.
     uniform = _priority(pools=[{"selector": "ns/*", "priority": 42}])
     assert run(_priority()) == run(uniform)
+
+
+def test_partner_conditions_use_the_partners_own_cached_context():
+    """A partner's conditional priority must be evaluated against the signals
+    *it* published, not against whoever happens to be requesting now.
+
+    ns/b is expendable only while its own traffic is low. The requester always
+    reports high traffic, so resolving partners against the requester's context
+    would classify ns/b as important in both cases and never pick it.
+    """
+    pools = _pools(ns__a=(2, 5, 1), ns__b=(None, 5, 1))  # 2 + 5 + 5 = 12
+    resolver = _priority(
+        pools=[
+            {"selector": "ns/a", "priority": 900},
+            {
+                "selector": "ns/b",
+                "rules": [
+                    {"when": {"predicted_requests_below": 50}, "priority": 10},
+                    {"priority": 900},
+                ],
+            },
+        ]
+    )
+
+    def run(partner_requests):
+        orch = _decider(
+            max_total_gpus=12, min_total_gpus=12, priority_resolver=resolver
+        )
+        orch.update_intent_cache(
+            "ns/a", _targets(decode=3), pools["ns/a"], PriorityContext()
+        )
+        orch.update_intent_cache(
+            "ns/b",
+            _targets(decode=3),
+            pools["ns/b"],
+            PriorityContext(predicted_num_requests=partner_requests),
+        )
+        result = orch.mediate(
+            "ns/a",
+            _targets(prefill=4),
+            pools,
+            # The requester is busy in both runs.
+            priority_context=PriorityContext(predicted_num_requests=500),
+        )
+        return result.selected_partners[0].participant_id
+
+    # ns/b quiet -> priority 10 -> donates before the important pool.
+    assert run(10) == "ns/b"
+    # ns/b busy -> priority 900 -> ties with ns/a, atomicity tiebreak wins.
+    assert run(500) == "ns/a"
 
 
 def test_intent_cache_ttl_expiry_blocks_pairing():

--- a/components/src/dynamo/global_planner/tests/unit/test_priority.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_priority.py
@@ -10,6 +10,7 @@ from dynamo.global_planner.priority import (
     DEFAULT_POOL_PRIORITY,
     DEFAULT_SELECTOR,
     LOWEST_PRIORITY,
+    PriorityCondition,
     PriorityConfig,
     PriorityContext,
     PriorityResolver,
@@ -199,8 +200,8 @@ def test_explicit_rules_are_accepted():
     assert (resolved.priority, resolved.rule_index) == (2, 0)
 
 
-def test_conditions_are_not_supported_yet_and_fail_loudly():
-    # Guards the dangerous alternative: parsing an unknown predicate into a
+def test_unknown_condition_fields_are_rejected():
+    # Guards the dangerous alternative: parsing a typo'd predicate into a
     # condition that silently matches everything.
     with pytest.raises(ValidationError):
         PriorityConfig(
@@ -265,3 +266,127 @@ def test_duplicate_selectors_are_rejected():
 def test_unknown_config_field_is_rejected():
     with pytest.raises(ValidationError):
         PriorityConfig(defualt=5)  # codespell:ignore defualt
+
+
+# ---------------------------------------------------------------------------- #
+# Load-conditional priorities                                                  #
+# ---------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "requests, expected",
+    [
+        (None, False),  # no signal -> never matches
+        (49.9, True),
+        (50.0, False),  # boundary is exclusive
+        (500.0, False),
+    ],
+)
+def test_predicted_requests_below(requests, expected):
+    condition = PriorityCondition(predicted_requests_below=50)
+    ctx = PriorityContext(predicted_num_requests=requests)
+    assert condition.matches(ctx) is expected
+
+
+@pytest.mark.parametrize(
+    "requests, expected",
+    [
+        (None, False),  # no signal -> never matches
+        (99.0, False),
+        (100.0, True),  # boundary is inclusive
+        (500.0, True),
+    ],
+)
+def test_predicted_requests_at_least(requests, expected):
+    condition = PriorityCondition(predicted_requests_at_least=100)
+    ctx = PriorityContext(predicted_num_requests=requests)
+    assert condition.matches(ctx) is expected
+
+
+def test_predicates_combine_as_a_band():
+    condition = PriorityCondition(
+        predicted_requests_at_least=10, predicted_requests_below=100
+    )
+    assert condition.matches(PriorityContext(predicted_num_requests=50))
+    assert not condition.matches(PriorityContext(predicted_num_requests=5))
+    assert not condition.matches(PriorityContext(predicted_num_requests=100))
+
+
+def test_unsatisfiable_band_is_rejected():
+    with pytest.raises(ValidationError, match="no request rate can satisfy"):
+        PriorityCondition(predicted_requests_at_least=100, predicted_requests_below=10)
+
+
+def test_conditional_policy_selects_the_matching_rule():
+    resolver = _resolver(
+        pools=[
+            {
+                "selector": "prod/batch",
+                "rules": [
+                    {"when": {"predicted_requests_below": 50}, "priority": 800},
+                    {"priority": 100},
+                ],
+            }
+        ]
+    )
+    quiet = resolver.resolve(
+        "prod/batch", "decode", PriorityContext(predicted_num_requests=5)
+    )
+    assert (quiet.priority, quiet.rule_index) == (800, 0)
+
+    busy = resolver.resolve(
+        "prod/batch", "decode", PriorityContext(predicted_num_requests=500)
+    )
+    assert (busy.priority, busy.rule_index) == (100, 1)
+
+    # No signal at all falls through to the unconditional rule.
+    unknown = resolver.resolve("prod/batch", "decode", PriorityContext())
+    assert (unknown.priority, unknown.rule_index) == (100, 1)
+
+
+# ---------------------------------------------------------------------------- #
+# Building a context from the wire                                             #
+# ---------------------------------------------------------------------------- #
+
+
+def test_context_from_predicted_load():
+    ctx = PriorityContext.from_predicted_load(
+        {"num_requests": 12, "isl": 2048.0, "osl": 256}
+    )
+    assert ctx.predicted_num_requests == 12.0
+    assert (ctx.predicted_isl, ctx.predicted_osl) == (2048.0, 256.0)
+
+
+@pytest.mark.parametrize("payload", [None, {}, {"num_requests": None}])
+def test_absent_predicted_load_yields_an_empty_context(payload):
+    assert PriorityContext.from_predicted_load(payload) == PriorityContext()
+
+
+@pytest.mark.parametrize("value", ["100", True, False, [1], {"a": 1}])
+def test_malformed_predicted_load_degrades_to_no_signal(value):
+    # Caller-supplied payload: a bad prediction must not fail a scale request,
+    # and bool must not sneak through as an int.
+    ctx = PriorityContext.from_predicted_load({"num_requests": value})
+    assert ctx.predicted_num_requests is None
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf"), -1.0])
+def test_unusable_numeric_rates_degrade_to_no_signal(value):
+    # NaN is the dangerous one: every comparison against it is False, so
+    # without an explicit guard it slips past both predicate checks and
+    # satisfies any condition instead of none of them.
+    assert (
+        PriorityContext.from_predicted_load(
+            {"num_requests": value}
+        ).predicted_num_requests
+        is None
+    )
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_rate_matches_nothing(value):
+    # PriorityContext is a plain dataclass, so guard at the decision point too
+    # rather than trusting only the from_predicted_load boundary.
+    ctx = PriorityContext(predicted_num_requests=value)
+    assert not PriorityCondition(predicted_requests_below=50).matches(ctx)
+    assert not PriorityCondition(predicted_requests_at_least=10).matches(ctx)

--- a/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
@@ -439,6 +439,7 @@ def _scale_req(
     decode=None,
     prefill_component_name=None,
     decode_component_name=None,
+    predicted_load=None,
 ):
     """Build a ScaleRequest with one or both pool targets set."""
     targets = []
@@ -463,6 +464,7 @@ def _scale_req(
         graph_deployment_name=dgd,
         k8s_namespace=k8s_ns,
         target_replicas=targets,
+        predicted_load=predicted_load,
     )
 
 
@@ -1883,5 +1885,110 @@ async def test_reversing_priorities_reverses_who_pays(mock_runtime):
             {"selector": "default/batch", "priority": 900},
         ],
     )
+    assert prod == {"prefill": 5, "decode": 1}
+    assert batch == {"decode": 2}
+
+
+# ---------------------------------------------------------------------------- #
+# Load-conditional priority, end to end through the scale_request endpoint     #
+# ---------------------------------------------------------------------------- #
+
+
+async def _run_conditional_transfer(mock_runtime, batch_num_requests):
+    """Same two-DGD transfer, but batch's priority depends on its own traffic.
+
+    batch publishes its pending scale-down through a real ScaleRequest carrying
+    predicted_load, so the whole path is exercised: wire DTO -> PriorityContext
+    -> intent cache -> condition evaluation at arbitration time.
+    """
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-prod", "default-batch"],
+        k8s_namespace="default",
+        min_total_gpus=12,
+        max_total_gpus=12,
+        priority_config=PriorityConfig(
+            pools=[
+                {"selector": "default/prod", "priority": 900},
+                {
+                    "selector": "default/batch",
+                    "rules": [
+                        # Expendable only while its own traffic is quiet.
+                        {"when": {"predicted_requests_below": 50}, "priority": 10},
+                        {"priority": 900},
+                    ],
+                },
+            ]
+        ),
+    )
+    prod = _install_connector(
+        handler,
+        "default/prod",
+        _dgd_spec(prefill_replicas=3, decode_replicas=3),
+        parent_dgd_name="prod",
+    )
+    batch = _install_connector(
+        handler,
+        "default/batch",
+        _dgd_spec(prefill_replicas=3, decode_replicas=3),
+        parent_dgd_name="batch",
+    )
+
+    # prod has a pending scale-down cached from an earlier tick.
+    handler.orchestrator._intent_cache["default/prod/decode"] = PoolIntent(
+        last_desired=1, last_seen_at=time.time()
+    )
+
+    # batch asks to scale down and is denied on the floor -- but the denied
+    # request still leaves its intent, and its predicted_load, behind.
+    denied = await _run(
+        handler,
+        _scale_req(
+            dgd="batch",
+            caller_ns="default-batch",
+            decode=1,
+            predicted_load={"num_requests": batch_num_requests, "isl": 512, "osl": 64},
+        ),
+    )
+    assert denied[0]["status"] == "rejected", denied[0]
+    batch.set_component_replicas.assert_not_called()
+
+    # prod now asks for two more prefill replicas, breaching the ceiling.
+    results = await _run(
+        handler,
+        _scale_req(
+            dgd="prod",
+            caller_ns="default-prod",
+            prefill=5,
+            predicted_load={"num_requests": 900, "isl": 4096, "osl": 512},
+        ),
+    )
+    assert results[0]["status"] == "success", results[0]
+
+    def targets(connector):
+        return {
+            t.sub_component_type.value: t.desired_replicas
+            for t in connector.set_component_replicas.call_args[0][0]
+        }
+
+    return targets(prod), targets(batch)
+
+
+@pytest.mark.asyncio
+async def test_quiet_pool_is_treated_as_expendable(mock_runtime):
+    """batch reports low traffic, so its conditional rule fires and it absorbs
+    the larger cut."""
+    prod, batch = await _run_conditional_transfer(mock_runtime, batch_num_requests=5)
+    assert prod == {"prefill": 5, "decode": 2}
+    assert batch == {"decode": 1}
+
+
+@pytest.mark.asyncio
+async def test_busy_pool_is_protected_by_its_condition(mock_runtime):
+    """batch reports high traffic, so it falls through to its unconditional
+    priority, ties with prod, and the atomic intra-DGD partner is preferred --
+    the same topology and the same request, decided differently purely by the
+    load signal batch published."""
+    prod, batch = await _run_conditional_transfer(mock_runtime, batch_num_requests=900)
     assert prod == {"prefill": 5, "decode": 1}
     assert batch == {"decode": 2}


### PR DESCRIPTION
## Overview:

**Stack 5/6** — pool prioritization for the Global Planner (`LLM-178`). Based on #14038.

Fills in the conditional half of the priority model from #14037. An operator can now declare "this pool yields while its traffic is quiet" rather than one standing priority for all conditions.

## Details:

```yaml
    - selector: prod/batch
      rules:
        - when: {predicted_requests_below: 50}   # quiet: yield to everyone
          priority: 10
        - priority: 100                          # busy: normal standing
```

**No protocol change was needed.** `ScaleRequest.predicted_load` already carries `{num_requests, isl, osl}` — every local planner populates it via `GlobalPlannerConnector.set_predicted_load` — and it was previously used only for logging.

**Conditions are evaluated against the pool's own context, not the requester's.** A partner's conditional priority is resolved from the context it published alongside its cached intent, so "while its traffic is low" means the partner's traffic. Resolving partners against the requesting pool's signals would be subtly wrong in a way that still produces valid totals, so a test fails if the lookup is replaced.

**A predicate whose signal is absent or unusable does not match.** `predicted_load` crosses a trust boundary as a caller-supplied dict, so `from_predicted_load` rejects wrong types, bool-as-int, negatives, **NaN, and infinity**. NaN needs the explicit guard: every comparison against it is False, so without one it slips past both predicate checks and satisfies *any* condition instead of none of them — a malformed prediction could otherwise change arbitration. The guard is repeated at the decision point because `PriorityContext` is a plain dataclass any caller can construct.

SLA-breach predicates are **not** included — they need signals the scale-request contract does not carry yet.

## Where should the reviewer start?

- `priority.py::PriorityCondition.matches` — absent-signal and non-finite semantics.
- `orchestrator.py::_cached_context` and `PoolIntent.context` — the per-pool context caching that makes partner conditions mean the right thing.
- `test_scale_request_handler.py::test_quiet_pool_is_treated_as_expendable` and its busy sibling — same topology, same request, decided differently purely by the load signal the partner published.

## Testing

Tests in `tests/unit/test_priority.py` and `test_orchestrator.py`, plus 2 end-to-end. Full `planner` + `global_planner` suites pass locally (1321 passed, 8 skipped).

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — tracked in Linear as LLM-178

🤖 Generated with [Claude Code](https://claude.com/claude-code)