### PR TITLE
fix(recipe): correct max model len for gb300 in recipe readme

### DIFF
--- a/recipes/qwen3.8-2.4t-a95b-fp8/README.md
+++ b/recipes/qwen3.8-2.4t-a95b-fp8/README.md
@@ -78,7 +78,7 @@ Dynamo + SGLang chat deployment profiles:
 | **Routing**              | KV-aware                                             | KV-aware                                                  | KV-aware                                             | KV-aware, load-balanced across prefill replicas           |
 | **Prefix caching**       | Enabled (radix cache)                                | Prefill-side only                                         | Enabled (radix cache)                                | Prefill-side only                                         |
 | **KV transfer**          | —                                                    | NIXL over MNNVL                                           | —                                                    | NIXL over cuda_ipc + MNNVL (~900 GB/s/GPU)               |
-| **Context length**       | 278,528                                              | 278,528 both roles                                        | 262,144                                              | 262,144                                                   |
+| **Context length**       | 262,144                                              | 262,144                                                   | 262,144                                              | 262,144                                                   |
 | **Watchdog timeout**     | 900s                                                 | 900s                                                      | 900s                                                 | 7200s (breakable graph capture takes 30–60 min)           |
 
 ## Supported features


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the SGLang chat configuration to reflect a 262,144-token context length for GB300 aggregated and disaggregated profiles.
  * GB200 configuration values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->