### PR TITLE
build(vllm): bump sidecar runtime to 0.28.0

### DIFF
--- a/lib/sidecar/vllm/deploy/agg.yaml
+++ b/lib/sidecar/vllm/deploy/agg.yaml
@@ -39,10 +39,10 @@ spec:
       spec:
         # vllm-engine as a native sidecar (initContainer, restartPolicy: Always):
         # it starts before `main` and stops after it. Stock multi-arch vLLM image
-        # (v0.26.0 ships vllm-rs; its gRPC matches the sidecar's vendored proto).
+        # (v0.28.0 ships vllm-rs; its gRPC matches the sidecar's vendored proto).
         initContainers:
         - name: vllm-engine
-          image: vllm/vllm-openai:v0.26.0
+          image: vllm/vllm-openai:v0.28.0
           restartPolicy: Always
           # These lightweight lifecycle probes confirm that the loopback listener
           # accepts connections. The Dynamo sidecar independently waits for both

--- a/lib/sidecar/vllm/deploy/disagg.yaml
+++ b/lib/sidecar/vllm/deploy/disagg.yaml
@@ -59,7 +59,7 @@ spec:
             sizeLimit: 10Gi
         initContainers:
         - name: vllm-engine
-          image: vllm/vllm-openai:v0.26.0
+          image: vllm/vllm-openai:v0.28.0
           restartPolicy: Always
           # RDMA/NIXL needs pinned memory + privileged caps. runAsUser: 0 is only
           # required for the rdma/ib path; drop it if your fabric doesn't need it.
@@ -155,7 +155,7 @@ spec:
             sizeLimit: 10Gi
         initContainers:
         - name: vllm-engine
-          image: vllm/vllm-openai:v0.26.0
+          image: vllm/vllm-openai:v0.28.0
           restartPolicy: Always
           securityContext:
             runAsUser: 0


### PR DESCRIPTION
## Summary

- Update the aggregated and disaggregated vLLM sidecar engine images from v0.26.0 to v0.28.0.
- Align the sidecar examples with the core vLLM 0.28.0 bump in #13846.

## Validation

- File-scoped pre-commit checks passed with pytest-marker-report skipped because it collects the full test tree and encountered an unrelated root-owned temporary lock.
- git diff --check

## Related

- Depends on #13846.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the vLLM engine to version 0.28.0 for aggregated, prefill, and decode deployments.
  * No other deployment behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->