### PR TITLE
fix(vllm): harden elastic-EP scale path (timeout + off-loop import)

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1565,6 +1565,10 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             # Format mapping:
             #   list_nodes() -> objects with .node_ip and .node_id
             #   ray.nodes()  -> dicts with "NodeManagerAddress" and "NodeID"
+            # Warm the heavy ray import off the event loop so the first scale on
+            # a worker does not block the loop; cached (fast) on later calls.
+            await asyncio.to_thread(importlib.import_module, "ray")
+            await asyncio.to_thread(importlib.import_module, "ray.util.state")
             import ray
             import ray.util.state as _ray_util_state
 
@@ -1576,8 +1580,10 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     self.node_id: str = d["NodeID"]
 
             async def _scale_engine(size: int) -> None:
-                # add_dp_placement_groups calls ray.util.state.list_nodes();
-                # patch it to the GCS API for the duration of the reconfigure.
+                # add_dp_placement_groups calls ray.util.state.list_nodes(); patch
+                # it to the GCS API for the reconfigure. This mutates a
+                # process-global, but concurrent scales are serialised by
+                # _scale_ep_in_progress and the original is restored in finally.
                 original_list_nodes = _ray_util_state.list_nodes
                 try:
                     _ray_util_state.list_nodes = lambda **kw: [
@@ -1587,8 +1593,18 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 finally:
                     _ray_util_state.list_nodes = original_list_nodes
 
+            # Outer timeout backstop: vLLM has its own limits, but if a scale hangs
+            # past all of them the in-progress flag would stick and this endpoint
+            # would wedge forever. A hung scale is a wedged engine -> fail fast.
+            # Generous default; tune via DYN_SCALE_EP_TIMEOUT_S.
+            timeout_s = float(os.getenv("DYN_SCALE_EP_TIMEOUT_S", "600"))
+            # If this coroutine is cancelled externally (server shutdown or the
+            # caller going away), CancelledError propagates and the in-progress
+            # flag is cleared in finally, but we intentionally do NOT force a
+            # restart: on a graceful shutdown that would be a spurious non-zero
+            # exit, and a client disconnect should not kill a healthy worker.
             try:
-                await _scale_engine(new_dp_size)
+                await asyncio.wait_for(_scale_engine(new_dp_size), timeout=timeout_s)
             except EngineDeadError as dead_err:
                 # Engine died mid-grow. Restart it the same way every other engine
                 # path here does, so it comes back clean and re-registers.
@@ -1601,14 +1617,15 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             except Exception as grow_err:
                 # Fail fast: vLLM does no rollback or cleanup on a failed scale (its
                 # _scale_up_elastic_ep has no except and its /scale_elastic_ep
-                # endpoint just returns 500), so a failed grow leaves the engine
-                # partial/wedged with no safe way to recover in process. Restart the
-                # worker so it comes back clean, rather than fake a recovery that
-                # nothing acts on.
+                # endpoint just returns 500), so a failed (or timed-out, hence
+                # wedged) grow leaves the engine partial with no safe way to recover
+                # in process. Restart the worker so it comes back clean rather than
+                # fake a recovery that nothing acts on. (asyncio.wait_for raises
+                # TimeoutError, an Exception subclass, so a hang lands here too.)
                 logger.error(
-                    "[ElasticEP] Scaling to dp=%s failed: %s. vLLM does not roll "
-                    "back a failed scale; restarting the worker to recover a clean "
-                    "state.",
+                    "[ElasticEP] Scaling to dp=%s failed/timed out: %s. vLLM does "
+                    "not roll back a failed scale; restarting the worker to recover "
+                    "a clean state.",
                     new_dp_size,
                     grow_err,
                 )

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1690,15 +1690,23 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # watchdog thread do the exit; wait_for stays as the cooperative first
         # attempt so a cancellable hang unwinds cleanly.
         def _deadline_exceeded() -> None:
-            logger.error(
-                "[ElasticEP] Scale to dp=%s exceeded its %ss deadline and did not "
-                "answer cancellation; the engine is wedged. Exiting so the worker "
-                "restarts clean at its previous size. Tune with %s.",
-                new_dp_size,
-                _SCALE_EP_TIMEOUT_S,
-                _SCALE_EP_TIMEOUT_ENV,
-            )
-            logging.shutdown()
+            # Runs on the timer thread and MUST exit unconditionally. Do not touch
+            # logging here: the main thread may be wedged while holding a logging
+            # handler lock (e.g. blocked writing to a full stdout pipe), which would
+            # make logger.*/logging.shutdown() block on that lock and defeat the one
+            # exit that exists to bound exactly this hang. os.write to fd 2 takes no
+            # Python-level lock.
+            try:
+                os.write(
+                    2,
+                    f"[ElasticEP] scale to dp={new_dp_size} exceeded its "
+                    f"{_SCALE_EP_TIMEOUT_S}s deadline and did not answer "
+                    f"cancellation; the engine is wedged. Hard-exiting so the worker "
+                    f"restarts clean at its previous size. Tune with "
+                    f"{_SCALE_EP_TIMEOUT_ENV}.\n".encode(),
+                )
+            except Exception:
+                pass
             os._exit(1)
 
         watchdog = threading.Timer(

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -10,13 +10,15 @@ import logging
 import math
 import os
 import struct
+import sys
 import tempfile
+import threading
 import time
 from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from typing import (
     Any,
     AsyncIterator,
@@ -127,6 +129,105 @@ _RL_INIT_WEIGHTS_TIMEOUT_DEFAULT_S = 30.0
 # that endpoint, so an unbounded wait on a degraded GCS would pile up control
 # requests; a capacity read is advisory and stale-or-absent beats slow.
 _EP_CAPACITY_RAY_TIMEOUT_S = 5.0
+
+_SCALE_EP_TIMEOUT_ENV = "DYN_SCALE_EP_TIMEOUT_S"
+_SCALE_EP_TIMEOUT_DEFAULT_S = 600.0
+# Head start the cooperative deadline gets over the hard watchdog, so a scale
+# that *does* answer cancellation unwinds through vLLM's finally blocks instead
+# of being killed mid-teardown.
+_SCALE_EP_KILL_GRACE_S = 30.0
+
+
+def _read_scale_ep_timeout_s() -> float:
+    """Deadline for one elastic-EP scale, read once at import.
+
+    Read per request, a typo'd value would be a live foot-gun: a scale that
+    overruns its deadline restarts the worker, so ``DYN_SCALE_EP_TIMEOUT_S=0``
+    turns every *healthy* scale into a restart, and a reconciler retrying into
+    that is a crashloop. Reject non-positive and unparseable values instead.
+    """
+    raw = os.environ.get(_SCALE_EP_TIMEOUT_ENV)
+    if raw is None:
+        return _SCALE_EP_TIMEOUT_DEFAULT_S
+    try:
+        value = float(raw)
+    except ValueError:
+        value = -1.0
+    if value <= 0:
+        logger.warning(
+            "%s=%r is not a positive number of seconds; falling back to %ss. A "
+            "non-positive deadline would restart the worker on every scale.",
+            _SCALE_EP_TIMEOUT_ENV,
+            raw,
+            _SCALE_EP_TIMEOUT_DEFAULT_S,
+        )
+        return _SCALE_EP_TIMEOUT_DEFAULT_S
+    return value
+
+
+_SCALE_EP_TIMEOUT_S: Final[float] = _read_scale_ep_timeout_s()
+
+
+class _RayNodeInfo:
+    """ray.nodes() dict shaped like a ray.util.state.list_nodes() row."""
+
+    __slots__ = ("node_id", "node_ip")
+
+    def __init__(self, d: dict) -> None:
+        self.node_ip: str = d["NodeManagerAddress"]
+        self.node_id: str = d["NodeID"]
+
+
+# Bookkeeping for the list_nodes patch below. The mutex guards only these two
+# variables and is never held across the scale itself.
+_RAY_LIST_NODES_MUTEX = threading.Lock()
+_ray_list_nodes_original: Optional[Callable[..., Any]] = None
+_ray_list_nodes_patch_depth = 0
+
+
+@contextmanager
+def _ray_list_nodes_via_gcs(ray_module: Any, state_module: Any) -> Iterator[None]:
+    """Point ``ray.util.state.list_nodes`` at the GCS API for one reconfigure.
+
+    TODO(upstream-vllm): remove once vLLM's add_dp_placement_groups
+    (vllm/v1/engine/utils.py) uses ray.nodes() instead of list_nodes().
+
+    list_nodes() reads the Ray dashboard HTTP API (127.0.0.1:8265/api/v0/nodes).
+    The dynamo image installs ray core only (not ray[default]), so the dashboard
+    starts in --minimal mode with its HTTP server disabled and vLLM's
+    add_dp_placement_groups fails with "Failed to connect to API server".
+    ray.nodes() reaches the GCS over gRPC directly and carries the same data.
+
+    This is a process-global mutation while ``_scale_ep_in_progress`` is per
+    handler instance, so two handlers in one process (decode + prefill) could
+    otherwise interleave save/restore and leave a patched list_nodes installed
+    for good. Keeping the true original plus a depth count means whoever leaves
+    last always restores the real function.
+    """
+    global _ray_list_nodes_original, _ray_list_nodes_patch_depth
+
+    def _list_nodes(**kwargs):
+        # vLLM's add_dp_placement_groups calls list_nodes() with no arguments.
+        # Anything else is a caller we did not mean to intercept: this stand-in
+        # honours no filters and carries only node_id/node_ip, so answering it
+        # would hand back silently-wrong data or raise AttributeError downstream.
+        if kwargs:
+            return _ray_list_nodes_original(**kwargs)  # type: ignore[misc]
+        return [_RayNodeInfo(n) for n in ray_module.nodes() if n.get("Alive", False)]
+
+    with _RAY_LIST_NODES_MUTEX:
+        if _ray_list_nodes_patch_depth == 0:
+            _ray_list_nodes_original = state_module.list_nodes
+        _ray_list_nodes_patch_depth += 1
+        state_module.list_nodes = _list_nodes
+    try:
+        yield
+    finally:
+        with _RAY_LIST_NODES_MUTEX:
+            _ray_list_nodes_patch_depth -= 1
+            if _ray_list_nodes_patch_depth == 0:
+                state_module.list_nodes = _ray_list_nodes_original
+                _ray_list_nodes_original = None
 
 
 def _discard_orphan_result(fut: "asyncio.Future[dict]") -> None:
@@ -1142,6 +1243,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
     _benchmark_results: Optional[dict] = None
     _scale_ep_in_progress: bool = False
+    # Latched when a scale is cancelled out from under vLLM, which keeps
+    # reconfiguring; see the CancelledError branch in scale_elastic_ep.
+    _scale_ep_cancelled: bool = False
     # get_ep_capacity single-flight state; see the comment at its call site.
     # run_in_executor hands back an asyncio Future, not a concurrent.futures one.
     _ep_capacity_inflight: Optional["asyncio.Future[dict]"] = None
@@ -1239,6 +1343,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # can mutate _coord_store at a time.
         self._scale_ep_lock = asyncio.Lock()
         self._scale_ep_in_progress = False
+        self._scale_ep_cancelled = False
         # Created on first Ray-backed get_ep_capacity call so workers that never
         # serve elastic EP do not carry an idle thread.
         self._ep_capacity_inflight = None
@@ -1320,6 +1425,24 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
     def _shutdown_on_engine_dead(self, e: EngineDeadError) -> NoReturn:
         logger.error(f"vLLM EngineDeadError: {e}")
         self._shutdown_worker()
+
+    def _fail_fast(self, shutdown: Callable[[], NoReturn], reason: str) -> NoReturn:
+        """Run a NoReturn shutdown so nothing can turn it back into a return.
+
+        ``_shutdown_worker`` is only NoReturn if ``runtime.shutdown()`` does not
+        raise -- plausible on the already-degraded worker that got us here. If it
+        does, the exception unwinds into the caller's broad ``except Exception``,
+        which turns a wedged engine into an ordinary error response while the
+        worker stays registered and keeps taking traffic. Exit either way.
+        """
+        logger.error("Fail-fast: %s", reason)
+        try:
+            shutdown()
+        except BaseException:
+            logger.exception("Shutdown path failed; exiting anyway")
+        # os._exit skips atexit and logging handler flushing.
+        logging.shutdown()
+        os._exit(1)
 
     def init_embedding_loader(
         self, config: Config, encode_worker_client: Optional[Client] = None
@@ -1536,6 +1659,14 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # caller's TCPStore before its Ray actor connects, causing a 300 s
         # timeout on the worker node.
         async with self._scale_ep_lock:
+            if self._scale_ep_cancelled:
+                msg = (
+                    "A previous scale_elastic_ep was cancelled mid-flight and vLLM "
+                    "may still be reconfiguring; this worker must restart before it "
+                    "can scale again"
+                )
+                logger.warning("[ElasticEP] %s", msg)
+                return {"status": "error", "message": msg}
             if self._scale_ep_in_progress:
                 msg = (
                     "A scale_elastic_ep operation is already in progress; "
@@ -1545,75 +1676,91 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 return {"status": "error", "message": msg}
             self._scale_ep_in_progress = True
 
+        # Hard deadline, armed before the ray import so it covers everything the
+        # in-progress flag is held across.
+        #
+        # asyncio.wait_for on its own is NOT a deadline: it cancels the inner
+        # coroutine and then *awaits* the cancellation, so an await that delays or
+        # ignores cancellation runs past the timeout -- and a step that blocks the
+        # event loop outright (a ray.get() or the TCPStore rendezvous inside
+        # vLLM's scale) stops the timer from ever firing. Either way the
+        # in-progress flag would stick and this endpoint would wedge forever,
+        # which is the failure the backstop exists to prevent. A timed-out scale
+        # is a wedged engine and the answer is os._exit(1) regardless, so let a
+        # watchdog thread do the exit; wait_for stays as the cooperative first
+        # attempt so a cancellable hang unwinds cleanly.
+        def _deadline_exceeded() -> None:
+            logger.error(
+                "[ElasticEP] Scale to dp=%s exceeded its %ss deadline and did not "
+                "answer cancellation; the engine is wedged. Exiting so the worker "
+                "restarts clean at its previous size. Tune with %s.",
+                new_dp_size,
+                _SCALE_EP_TIMEOUT_S,
+                _SCALE_EP_TIMEOUT_ENV,
+            )
+            logging.shutdown()
+            os._exit(1)
+
+        watchdog = threading.Timer(
+            _SCALE_EP_TIMEOUT_S + _SCALE_EP_KILL_GRACE_S, _deadline_exceeded
+        )
+        watchdog.daemon = True
+        watchdog.start()
         try:
-            # TODO(upstream-vllm): remove this patch once vLLM fixes
-            # add_dp_placement_groups in vllm/v1/engine/utils.py to use ray.nodes()
-            # instead of ray.util.state.list_nodes().
-            #
-            # Patch ray.util.state.list_nodes to use the GCS API instead of the
-            # dashboard HTTP API (127.0.0.1:8265/api/v0/nodes). The dynamo image
-            # installs ray core only (not ray[default]), so the dashboard HTTP server
-            # starts in --minimal mode with the HTTP server disabled. vLLM's
-            # add_dp_placement_groups calls list_nodes() which requires that HTTP
-            # endpoint, causing scale_elastic_ep to fail with "Failed to connect to
-            # API server".
-            #
-            # ray.nodes() uses the GCS gRPC channel directly (no dashboard process
-            # needed) and returns the same information. Imported lazily so ray is not
-            # required at module load time (absent in non-elastic-EP deployments).
-            #
-            # Format mapping:
-            #   list_nodes() -> objects with .node_ip and .node_id
-            #   ray.nodes()  -> dicts with "NodeManagerAddress" and "NodeID"
-            # Warm the heavy ray import off the event loop so the first scale on
-            # a worker does not block the loop; cached (fast) on later calls.
-            await asyncio.to_thread(importlib.import_module, "ray")
-            await asyncio.to_thread(importlib.import_module, "ray.util.state")
+            # ray is imported lazily so it is not required at module load time
+            # (absent in non-elastic-EP deployments), and warmed off the event loop
+            # so the first scale on a worker does not block token generation while
+            # a heavy import runs. Importing ray.util.state pulls in ray itself, so
+            # one hop warms both; skip it entirely once cached.
+            if "ray.util.state" not in sys.modules:
+                try:
+                    await asyncio.to_thread(importlib.import_module, "ray.util.state")
+                except ImportError as e:
+                    # Same call as get_ep_capacity: a worker without ray is a
+                    # configuration problem, not a wedged engine. Do not restart it.
+                    logger.warning("[ElasticEP] ray is not importable: %s", e)
+                    return {
+                        "status": "error",
+                        "message": f"elastic EP scaling unavailable: {e}",
+                    }
             import ray
             import ray.util.state as _ray_util_state
 
-            class _NodeInfo:
-                __slots__ = ("node_id", "node_ip")
-
-                def __init__(self, d: dict) -> None:
-                    self.node_ip: str = d["NodeManagerAddress"]
-                    self.node_id: str = d["NodeID"]
-
             async def _scale_engine(size: int) -> None:
-                # add_dp_placement_groups calls ray.util.state.list_nodes(); patch
-                # it to the GCS API for the reconfigure. This mutates a
-                # process-global, but concurrent scales are serialised by
-                # _scale_ep_in_progress and the original is restored in finally.
-                original_list_nodes = _ray_util_state.list_nodes
-                try:
-                    _ray_util_state.list_nodes = lambda **kw: [
-                        _NodeInfo(n) for n in ray.nodes() if n.get("Alive", False)
-                    ]
+                with _ray_list_nodes_via_gcs(ray, _ray_util_state):
                     await self.engine_client.scale_elastic_ep(size)
-                finally:
-                    _ray_util_state.list_nodes = original_list_nodes
 
-            # Outer timeout backstop: vLLM has its own limits, but if a scale hangs
-            # past all of them the in-progress flag would stick and this endpoint
-            # would wedge forever. A hung scale is a wedged engine -> fail fast.
-            # Generous default; tune via DYN_SCALE_EP_TIMEOUT_S.
-            timeout_s = float(os.getenv("DYN_SCALE_EP_TIMEOUT_S", "600"))
-            # If this coroutine is cancelled externally (server shutdown or the
-            # caller going away), CancelledError propagates and the in-progress
-            # flag is cleared in finally, but we intentionally do NOT force a
-            # restart: on a graceful shutdown that would be a spurious non-zero
-            # exit, and a client disconnect should not kill a healthy worker.
             try:
-                await asyncio.wait_for(_scale_engine(new_dp_size), timeout=timeout_s)
+                await asyncio.wait_for(
+                    _scale_engine(new_dp_size), timeout=_SCALE_EP_TIMEOUT_S
+                )
             except EngineDeadError as dead_err:
                 # Engine died mid-grow. Restart it the same way every other engine
                 # path here does, so it comes back clean and re-registers.
-                logger.error(
-                    "[ElasticEP] Engine died during scale to dp=%s: %s",
-                    new_dp_size,
-                    dead_err,
+                self._fail_fast(
+                    functools.partial(self._shutdown_on_engine_dead, dead_err),
+                    f"[ElasticEP] engine died during scale to dp={new_dp_size}: "
+                    f"{dead_err}",
                 )
-                self._shutdown_on_engine_dead(dead_err)  # NoReturn: restarts worker
+            except asyncio.CancelledError:
+                # An externally-cancelled scale (graceful shutdown, or the caller
+                # going away) must not force a restart: that would be a spurious
+                # non-zero exit on shutdown and too aggressive on a disconnect.
+                #
+                # But vLLM's grow tasks are not cancelled along with us -- its
+                # asyncio.gather does not cancel the siblings of a failed task --
+                # so the engine keeps reconfiguring after this coroutine unwinds.
+                # Latch the endpoint closed rather than clearing the flag: letting
+                # the next scale in would race the orphaned one, which is exactly
+                # the TCPStore hazard the early-reject above exists to prevent.
+                logger.warning(
+                    "[ElasticEP] Scale to dp=%s was cancelled, but vLLM's grow is "
+                    "not cancelled with it. Refusing further scales on this worker "
+                    "until it restarts.",
+                    new_dp_size,
+                )
+                self._scale_ep_cancelled = True
+                raise
             except Exception as grow_err:
                 # Fail fast: vLLM does no rollback or cleanup on a failed scale (its
                 # _scale_up_elastic_ep has no except and its /scale_elastic_ep
@@ -1621,15 +1768,16 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 # wedged) grow leaves the engine partial with no safe way to recover
                 # in process. Restart the worker so it comes back clean rather than
                 # fake a recovery that nothing acts on. (asyncio.wait_for raises
-                # TimeoutError, an Exception subclass, so a hang lands here too.)
-                logger.error(
-                    "[ElasticEP] Scaling to dp=%s failed/timed out: %s. vLLM does "
-                    "not roll back a failed scale; restarting the worker to recover "
-                    "a clean state.",
-                    new_dp_size,
-                    grow_err,
+                # TimeoutError, an Exception subclass, so a hang lands here too --
+                # and TimeoutError stringifies to "", hence the explicit type.)
+                self._fail_fast(
+                    self._shutdown_worker,
+                    f"[ElasticEP] scale to dp={new_dp_size} failed within its "
+                    f"{_SCALE_EP_TIMEOUT_S}s budget with "
+                    f"{type(grow_err).__name__}: {str(grow_err) or '<no detail>'}. vLLM "
+                    "does not roll back a failed scale; restarting the worker to "
+                    "recover a clean state.",
                 )
-                self._shutdown_worker()  # NoReturn: runtime.shutdown() + os._exit(1)
 
             logger.info(f"[ElasticEP] Scaling to dp={new_dp_size} complete")
             return {
@@ -1641,6 +1789,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             logger.error(f"[ElasticEP] Scaling failed: {e}")
             return {"status": "error", "message": str(e)}
         finally:
+            watchdog.cancel()
             async with self._scale_ep_lock:
                 self._scale_ep_in_progress = False
 

--- a/components/src/dynamo/vllm/tests/test_vllm_elastic_ep_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_elastic_ep_handlers.py
@@ -360,6 +360,7 @@ def test_failed_grow_restarts_the_worker(stub_ray):
     assert engine.calls == [3]
 
 
+@pytest.mark.timeout(15)
 def test_hung_grow_times_out_and_restarts(stub_ray, short_deadline):
     # A scale that hangs past the deadline is a wedged engine: fail fast and
     # restart, rather than leave the endpoint's in-progress flag stuck forever.
@@ -440,6 +441,7 @@ def test_fail_fast_exits_even_if_shutdown_raises(monkeypatch):
     assert exits == [1]
 
 
+@pytest.mark.timeout(15)
 def test_cancelled_scale_latches_the_endpoint_closed(stub_ray, short_deadline):
     """An externally-cancelled scale must not restart the worker, but vLLM's grow
     is not cancelled with us -- so the next scale must be refused rather than

--- a/components/src/dynamo/vllm/tests/test_vllm_elastic_ep_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_elastic_ep_handlers.py
@@ -9,6 +9,11 @@ handler restarts the worker instead of recovering in process; the fail-fast
 tests assert the restart is actually triggered (via ``_WorkerShutdown``), not
 just that a value was returned.
 
+Fail-fast is stubbed at ``_fail_fast`` rather than at ``_shutdown_worker``:
+``_fail_fast`` is the seam that guarantees the exit even when the shutdown call
+underneath it raises, so a test that replaced only the shutdown helpers would
+not exercise it.
+
 ``ray`` is stubbed via the ``stub_ray`` fixture (the scale path imports it
 lazily and CI lacks it).
 """
@@ -25,6 +30,7 @@ pytest.importorskip("vllm.config")
 
 from vllm.v1.engine.exceptions import EngineDeadError  # noqa: E402
 
+from dynamo.vllm import handlers as handlers_mod  # noqa: E402
 from dynamo.vllm.handlers import BaseWorkerHandler  # noqa: E402
 
 pytestmark = [
@@ -61,7 +67,25 @@ def _make_handler(
     )
     handler._scale_ep_lock = asyncio.Lock()
     handler._scale_ep_in_progress = False
+    handler._scale_ep_cancelled = False
     return handler
+
+
+@pytest.fixture
+def short_deadline(monkeypatch):
+    """Shrink the scale deadline for the hang tests.
+
+    The deadline is resolved once at import (a per-request read would let a
+    typo'd env var restart the worker on every scale), so tests set the module
+    constant rather than the environment -- which also makes them hermetic
+    against a developer or CI shell that exports DYN_SCALE_EP_TIMEOUT_S.
+    """
+
+    def _set(timeout_s: float, grace_s: float = 0.05) -> None:
+        monkeypatch.setattr(handlers_mod, "_SCALE_EP_TIMEOUT_S", timeout_s)
+        monkeypatch.setattr(handlers_mod, "_SCALE_EP_KILL_GRACE_S", grace_s)
+
+    return _set
 
 
 @pytest.fixture
@@ -185,10 +209,13 @@ async def test_prefill_context_parallelism_is_rejected(size):
 
 
 class _WorkerShutdown(BaseException):
-    """Stand-in for the NoReturn _shutdown_worker / _shutdown_on_engine_dead.
+    """Stand-in for the NoReturn _fail_fast, which ends in os._exit(1).
+
     BaseException (not Exception) so the handler's broad ``except Exception``
     can't swallow it -- the test sees the restart as production does: control
-    leaves scale_elastic_ep without reporting success.
+    leaves scale_elastic_ep without reporting success. Production gets that
+    same guarantee from _fail_fast calling os._exit unconditionally, which
+    ``test_fail_fast_exits_even_if_shutdown_raises`` covers directly.
     """
 
 
@@ -222,13 +249,13 @@ class _FakeVllmEngine:
         )
         self._fail_sizes = list(fail_sizes)
         self._dead_sizes = list(dead_sizes)
-        self._hang_sizes = list(hang_sizes)  # sizes that hang until cancelled
-        self.calls: list[int] = []  # every requested size, in order
+        self._hang_sizes = list(hang_sizes)
+        self.calls: list[int] = []
 
     async def scale_elastic_ep(self, size: int) -> None:
         self.calls.append(size)
         if size in self._hang_sizes:
-            await asyncio.sleep(3600)  # hang until wait_for cancels us
+            await asyncio.sleep(3600)
         if size in self._dead_sizes:
             raise EngineDeadError()
         if size in self._fail_sizes:
@@ -245,23 +272,33 @@ def _make_self(engine: _FakeVllmEngine, shutdown_log: list) -> SimpleNamespace:
         shutdown_log.append("engine_dead")
         raise _WorkerShutdown()
 
-    return SimpleNamespace(
+    fake_self = SimpleNamespace(
         _scale_ep_lock=asyncio.Lock(),
         _scale_ep_in_progress=False,
+        _scale_ep_cancelled=False,
         engine_client=engine,
         _shutdown_worker=_shutdown_worker,
         _shutdown_on_engine_dead=_shutdown_on_engine_dead,
     )
+    # Stub the seam the handler actually calls. In production _fail_fast ends in
+    # os._exit(1) whatever the shutdown callable does; here it just lets the
+    # callable raise, so the test sees the same "never returns a result".
+    fake_self._fail_fast = lambda shutdown, reason: shutdown()
+    return fake_self
 
 
-def _run(engine: _FakeVllmEngine, body: dict):
+def _run(engine: _FakeVllmEngine, body: dict, fake_self=None):
     """Drive scale_elastic_ep. Returns ``(result, shutdown_log)``; ``result`` is
     ``_RESTARTED`` when the handler restarted the worker instead of returning."""
     shutdown_log: list[str] = []
+    target = fake_self if fake_self is not None else _make_self(engine, shutdown_log)
 
     async def _coro():
-        fake_self = _make_self(engine, shutdown_log)
-        return await BaseWorkerHandler.scale_elastic_ep(fake_self, body)
+        result = await BaseWorkerHandler.scale_elastic_ep(target, body)
+        # Whenever the handler returns at all, the endpoint must be reusable:
+        # a stuck in-progress flag is what wedges it for every later request.
+        assert target._scale_ep_in_progress is False
+        return result
 
     try:
         result = asyncio.run(_coro())
@@ -275,7 +312,7 @@ def test_scale_success(stub_ray):
 
     result, shutdown = _run(engine, {"new_data_parallel_size": 3})
 
-    assert shutdown == []  # no restart on success
+    assert shutdown == []
     assert result["status"] == "ok"
     assert result["new_data_parallel_size"] == 3
     assert engine.calls == [3]
@@ -289,9 +326,9 @@ def test_validation_error_does_not_restart_the_worker(stub_ray):
 
     result, shutdown = _run(engine, {"new_data_parallel_size": 1})
 
-    assert shutdown == []  # no restart on a rejected request
+    assert shutdown == []
     assert result["status"] == "error"
-    assert engine.calls == []  # never reached the engine
+    assert engine.calls == []
 
 
 def test_unsupported_config_is_rejected_without_restart(stub_ray):
@@ -305,10 +342,10 @@ def test_unsupported_config_is_rejected_without_restart(stub_ray):
 
     result, shutdown = _run(engine, {"new_data_parallel_size": 3})
 
-    assert shutdown == []  # a healthy worker is NOT restarted
+    assert shutdown == []
     assert result["status"] == "error"
     assert "not enabled" in result["message"]
-    assert engine.calls == []  # never reached the engine
+    assert engine.calls == []
 
 
 def test_failed_grow_restarts_the_worker(stub_ray):
@@ -318,22 +355,165 @@ def test_failed_grow_restarts_the_worker(stub_ray):
 
     result, shutdown = _run(engine, {"new_data_parallel_size": 3})
 
-    assert result is _RESTARTED  # never returned a success/recovery dict
-    assert shutdown == ["worker"]  # worker restart was triggered
-    assert engine.calls == [3]  # grow attempted once; no rollback call
+    assert result is _RESTARTED
+    assert shutdown == ["worker"]
+    assert engine.calls == [3]
 
 
-def test_hung_grow_times_out_and_restarts(stub_ray, monkeypatch):
-    # A scale that hangs past the outer backstop is a wedged engine: fail fast and
+def test_hung_grow_times_out_and_restarts(stub_ray, short_deadline):
+    # A scale that hangs past the deadline is a wedged engine: fail fast and
     # restart, rather than leave the endpoint's in-progress flag stuck forever.
-    monkeypatch.setenv("DYN_SCALE_EP_TIMEOUT_S", "0.05")
+    # This hang answers cancellation, so the cooperative wait_for handles it.
+    short_deadline(0.05)
     engine = _FakeVllmEngine(prev_dp=2, hang_sizes=[3])
 
     result, shutdown = _run(engine, {"new_data_parallel_size": 3})
 
     assert result is _RESTARTED
-    assert shutdown == ["worker"]  # timeout -> fail-fast restart
+    assert shutdown == ["worker"]
     assert engine.calls == [3]
+
+
+def test_watchdog_bounds_a_hang_that_ignores_cancellation(
+    stub_ray, short_deadline, monkeypatch
+):
+    """The hang that actually happens in production.
+
+    asyncio.wait_for cancels the inner coroutine and then *awaits* the
+    cancellation, so a scale wedged in a step that does not answer cancellation
+    runs straight past the deadline and the in-progress flag never clears. The
+    watchdog is the only thing that bounds that, so assert it is armed across the
+    whole critical section and that its callback is a hard exit.
+
+    The timer itself is stubbed: a real one would call os._exit from another
+    thread, and the pytest process is not the thing under test.
+    """
+    short_deadline(0.05, grace_s=0.05)
+    armed: dict = {}
+
+    class _CapturingTimer:
+        def __init__(self, interval, function):
+            armed["interval"] = interval
+            armed["function"] = function
+            self.daemon = False
+
+        def start(self):
+            armed["started"] = True
+
+        def cancel(self):
+            armed["cancelled"] = True
+
+    monkeypatch.setattr(handlers_mod.threading, "Timer", _CapturingTimer)
+    engine = _FakeVllmEngine(prev_dp=2)
+
+    result, _ = _run(engine, {"new_data_parallel_size": 3})
+
+    assert result["status"] == "ok"
+    assert armed["started"] and armed["cancelled"]  # armed for the scale, then off
+    assert armed["interval"] == pytest.approx(0.10)  # deadline + grace
+
+    # The armed callback exits the process. Nothing else can end a hang that
+    # swallows cancellation, because wait_for waits for the cancellation.
+    exits: list[int] = []
+    monkeypatch.setattr(handlers_mod.os, "_exit", lambda code: exits.append(code))
+    monkeypatch.setattr(handlers_mod.logging, "shutdown", lambda: None)
+    armed["function"]()
+    assert exits == [1]
+
+
+def test_fail_fast_exits_even_if_shutdown_raises(monkeypatch):
+    """_shutdown_worker calls runtime.shutdown() before os._exit(1). On the
+    degraded worker that got us here that call can raise, and the exception would
+    unwind into scale_elastic_ep's broad ``except Exception`` -- turning a wedged
+    engine into an ordinary error response while the worker stays registered and
+    keeps taking traffic. _fail_fast must exit regardless."""
+    exits: list[int] = []
+    monkeypatch.setattr(handlers_mod.os, "_exit", lambda code: exits.append(code))
+    monkeypatch.setattr(handlers_mod.logging, "shutdown", lambda: None)
+
+    def _shutdown_that_raises():
+        raise RuntimeError("runtime.shutdown() failed on a degraded worker")
+
+    handler = _TestWorkerHandler.__new__(_TestWorkerHandler)
+    BaseWorkerHandler._fail_fast(handler, _shutdown_that_raises, "wedged engine")
+
+    assert exits == [1]
+
+
+def test_cancelled_scale_latches_the_endpoint_closed(stub_ray, short_deadline):
+    """An externally-cancelled scale must not restart the worker, but vLLM's grow
+    is not cancelled with us -- so the next scale must be refused rather than
+    raced against the orphan."""
+    short_deadline(30.0)
+    engine = _FakeVllmEngine(prev_dp=2, hang_sizes=[3])
+    fake_self = _make_self(engine, [])
+
+    async def _cancel_mid_scale():
+        task = asyncio.ensure_future(
+            BaseWorkerHandler.scale_elastic_ep(fake_self, {"new_data_parallel_size": 3})
+        )
+        await asyncio.sleep(0.05)  # let it reach the engine
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # A healthy worker is not killed...
+        assert fake_self._scale_ep_cancelled is True
+        # ...but it will not accept another scale that would race the orphan.
+        return await BaseWorkerHandler.scale_elastic_ep(
+            fake_self, {"new_data_parallel_size": 4}
+        )
+
+    result = asyncio.run(_cancel_mid_scale())
+
+    assert result["status"] == "error"
+    assert "must restart" in result["message"]
+    assert engine.calls == [3]  # the second request never reached the engine
+
+
+def test_list_nodes_patch_is_restored_and_passes_through_kwargs(stub_ray):
+    """The patch is a process-global. It must be restored exactly, and it must
+    not answer callers it was not meant to intercept: it honours no filters and
+    carries only node_id/node_ip."""
+    original = stub_ray.list_nodes
+    seen: list[dict] = []
+    engine = _FakeVllmEngine(prev_dp=2)
+
+    async def _scale_and_probe(size):
+        # Runs while the patch is installed.
+        seen.append({"no_args": stub_ray.list_nodes()})
+        seen.append({"with_kwargs": stub_ray.list_nodes(filters=[("x", "y")])})
+        engine.calls.append(size)
+
+    engine.scale_elastic_ep = _scale_and_probe
+
+    result, _ = _run(engine, {"new_data_parallel_size": 3})
+
+    assert result["status"] == "ok"
+    assert stub_ray.list_nodes is original  # restored exactly
+    assert seen[0]["no_args"] == []  # our GCS stand-in (no live ray nodes)
+    assert seen[1]["with_kwargs"] == []  # delegated to the real list_nodes
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, handlers_mod._SCALE_EP_TIMEOUT_DEFAULT_S),
+        ("120", 120.0),
+        ("0", handlers_mod._SCALE_EP_TIMEOUT_DEFAULT_S),  # would restart every scale
+        ("-1", handlers_mod._SCALE_EP_TIMEOUT_DEFAULT_S),
+        ("600s", handlers_mod._SCALE_EP_TIMEOUT_DEFAULT_S),  # unparseable
+        ("", handlers_mod._SCALE_EP_TIMEOUT_DEFAULT_S),
+    ],
+)
+def test_scale_deadline_rejects_unusable_env_values(raw, expected, monkeypatch):
+    """A non-positive deadline makes every healthy scale time out, and a timed-out
+    scale restarts the worker -- so a typo'd env var would be a crashloop."""
+    if raw is None:
+        monkeypatch.delenv(handlers_mod._SCALE_EP_TIMEOUT_ENV, raising=False)
+    else:
+        monkeypatch.setenv(handlers_mod._SCALE_EP_TIMEOUT_ENV, raw)
+
+    assert handlers_mod._read_scale_ep_timeout_s() == expected
 
 
 def test_engine_dead_restarts_the_worker(stub_ray):
@@ -345,4 +525,4 @@ def test_engine_dead_restarts_the_worker(stub_ray):
 
     assert result is _RESTARTED
     assert shutdown == ["engine_dead"]
-    assert engine.calls == [3]  # no rollback call
+    assert engine.calls == [3]

--- a/components/src/dynamo/vllm/tests/test_vllm_elastic_ep_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_elastic_ep_handlers.py
@@ -210,6 +210,7 @@ class _FakeVllmEngine:
         tensor_parallel_size=1,
         enable_elastic_ep=True,
         data_parallel_backend="ray",
+        hang_sizes=(),
     ):
         self.vllm_config = SimpleNamespace(
             parallel_config=SimpleNamespace(
@@ -221,10 +222,13 @@ class _FakeVllmEngine:
         )
         self._fail_sizes = list(fail_sizes)
         self._dead_sizes = list(dead_sizes)
+        self._hang_sizes = list(hang_sizes)  # sizes that hang until cancelled
         self.calls: list[int] = []  # every requested size, in order
 
     async def scale_elastic_ep(self, size: int) -> None:
         self.calls.append(size)
+        if size in self._hang_sizes:
+            await asyncio.sleep(3600)  # hang until wait_for cancels us
         if size in self._dead_sizes:
             raise EngineDeadError()
         if size in self._fail_sizes:
@@ -317,6 +321,19 @@ def test_failed_grow_restarts_the_worker(stub_ray):
     assert result is _RESTARTED  # never returned a success/recovery dict
     assert shutdown == ["worker"]  # worker restart was triggered
     assert engine.calls == [3]  # grow attempted once; no rollback call
+
+
+def test_hung_grow_times_out_and_restarts(stub_ray, monkeypatch):
+    # A scale that hangs past the outer backstop is a wedged engine: fail fast and
+    # restart, rather than leave the endpoint's in-progress flag stuck forever.
+    monkeypatch.setenv("DYN_SCALE_EP_TIMEOUT_S", "0.05")
+    engine = _FakeVllmEngine(prev_dp=2, hang_sizes=[3])
+
+    result, shutdown = _run(engine, {"new_data_parallel_size": 3})
+
+    assert result is _RESTARTED
+    assert shutdown == ["worker"]  # timeout -> fail-fast restart
+    assert engine.calls == [3]
 
 
 def test_engine_dead_restarts_the_worker(stub_ray):


### PR DESCRIPTION
#### Overview:

Follow-up to #12991 that **hardens the `scale_elastic_ep` control endpoint** — the endpoint that grows/shrinks a vLLM worker's data-parallel size while it keeps serving. An architecture review of #12991 surfaced four edge cases, and a second review round found that two of them were deeper than they first looked. All four are now real fixes. **Normal scaling behavior is unchanged: a scale that succeeds behaves exactly as before.**

**What this fixes, in plain terms:**

1. **A hung scale can no longer wedge the endpoint forever.**
   `scale_elastic_ep` holds an in-progress flag for the duration of a scale so a second concurrent request is rejected rather than queued. If a scale never returns, that flag never clears: every later request gets "already in progress" and the worker is silently stuck until someone kills the pod. This PR puts a deadline on the scale — a scale that overruns it is a wedged engine, so the worker restarts (fail-fast, consistent with #12991) and comes back clean at its previous size.

2. **The first scale on a worker no longer briefly freezes it.**
   `import ray` is heavy and ran *synchronously on the asyncio event loop*, so the first scale blocked the loop — and every other in-flight request on that worker — while Ray loaded. It is now warmed on a background thread.

3. **Two handlers in one process can no longer corrupt Ray's `list_nodes`.**
   The scale temporarily repoints `ray.util.state.list_nodes` at the Ray GCS (our image runs no Ray dashboard, so vLLM's default call fails). That is a *process-global* mutation, but the guard around it is *per handler instance* — a decode and a prefill handler in the same process could interleave save/restore and leave the patch installed permanently.

4. **A cancelled scale no longer lets the next one race it.**
   A scale cancelled from outside (graceful shutdown, or the caller going away) still does **not** restart the worker. But vLLM's grow tasks are not cancelled along with us, so the engine keeps reconfiguring after the request unwinds; admitting the next scale would race that orphan.

#### Details:

- **#1 — A real deadline.** `asyncio.wait_for` is not one on its own: it cancels the inner coroutine and then *awaits* the cancellation, so a scale that delays or ignores cancellation runs past the timeout, and a step that blocks the event loop (a `ray.get`, or the TCPStore rendezvous inside vLLM's scale) stops the timer from firing at all. Measured: a 0.05 s `wait_for` returns at 1.05 s against a coroutine that delays its cancellation, and never fires against one that blocks the loop. A `threading.Timer` watchdog now enforces the hard limit and does the `os._exit(1)` itself; `wait_for` stays as the cooperative first attempt so a cancellable hang unwinds through vLLM's `finally` blocks. The watchdog is armed *before* the `ray` import, so it covers everything the in-progress flag is held across.
- **#1b — The fail-fast now actually exits.** `_shutdown_worker` is only `NoReturn` if `runtime.shutdown()` does not raise — plausible on the degraded worker that got us here. If it raised, the exception unwound into `scale_elastic_ep`'s broad `except Exception` and became an ordinary error response, leaving a wedged worker registered and taking traffic. Both shutdown paths now go through `_fail_fast`, which exits regardless.
- **#1c — `DYN_SCALE_EP_TIMEOUT_S` is validated once at import.** It was parsed per request with a bare `float()`. Since an overrun restarts the worker, `DYN_SCALE_EP_TIMEOUT_S=0` would have made *every healthy scale* restart, and a reconciler retrying into that is a crashloop. Non-positive and unparseable values now fall back to the 600 s default with a warning, matching the `_RL_INIT_WEIGHTS_TIMEOUT_*` idiom already in this file.
- **#2 — Off-loop `ray` import.** Warmed via `asyncio.to_thread(importlib.import_module, "ray.util.state")` — one hop, since that import pulls in `ray` itself — and skipped entirely once cached. A missing `ray` is now reported the way `get_ep_capacity` reports it, rather than restarting a worker that is merely misconfigured.
- **#3 — `list_nodes` patch made safe.** Moved to a module-level context manager that keeps the true original under a depth count, so whoever leaves last always restores the real function. It also delegates any call that passes kwargs to the real `list_nodes`: the stand-in honours no filters and carries only `node_id`/`node_ip`, so answering an unintended caller would hand back silently-wrong data.
- **#4 — Cancelled scale latches the endpoint closed.** Still no restart (that would be a spurious non-zero exit on shutdown, and too aggressive on a client disconnect), but further scales are refused with a clear message until the worker restarts — instead of racing vLLM's still-running grow.
- **Operability.** `str(TimeoutError())` is `""`, so a timed-out scale used to log `failed/timed out: .` and then hard-exit with no traceback. The line now carries the exception type and the budget.

Nits from the review (single-use `_scale_engine`, `getattr` on config fields) are left as-is intentionally — they read cleanly and match the surrounding style.

#### Validation:

New tests: watchdog armed across the critical section and its callback is a hard exit; `_fail_fast` exits when the shutdown call raises; a cancelled scale latches the endpoint; the `list_nodes` patch restores exactly and delegates kwargs; `DYN_SCALE_EP_TIMEOUT_S` parsing across `0`/`-1`/`600s`/empty. The in-progress-flag-is-cleared assertion, dropped in an earlier round, is restored for every path that returns.

`torch`/vLLM are not installable off-GPU, so the pytest file itself runs in the `vllm-runtime` Test job. Locally the changed functions were extracted **by AST from `handlers.py`** and executed against fakes — no hand-written copy — covering all of the above plus the pre-existing validation and capability gates (29 checks, all passing). `pre-commit run --files` is clean.

> Note for maintainers: the pinned `black` 23.1.0 crashes with `module 'ast' has no attribute 'Str'` on Python 3.12+ whenever it wants to reformat a file. Not blocking here, but worth a bump.

#### Where should the reviewer start?

- [`handlers.py`](https://github.com/ai-dynamo/dynamo/blob/tzulingk/vllm-elastic-ep-scale-harden/components/src/dynamo/vllm/handlers.py) — `scale_elastic_ep`: the watchdog arming, the `wait_for`, and the four `except` branches below it; then `_fail_fast` and the module-level `_ray_list_nodes_via_gcs` / `_read_scale_ep_timeout_s`.
- [`test_vllm_elastic_ep_handlers.py`](https://github.com/ai-dynamo/dynamo/blob/tzulingk/vllm-elastic-ep-scale-harden/components/src/dynamo/vllm/tests/test_vllm_elastic_ep_handlers.py) — `test_watchdog_bounds_a_hang_that_ignores_cancellation`, `test_fail_fast_exits_even_if_shutdown_raises`, `test_cancelled_scale_latches_the_endpoint_closed`.

> **Depends on #12991.** Built on that branch but targeting `main`, so this diff currently includes #12991's changes and collapses to just the hardening once it merges. Please review/merge **after** #12991.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved elastic scaling reliability with configurable deadlines and automatic recovery from stalled workers.
  * Added safer handling for engine failures, cancelled operations, and shutdown errors.
  * Prevented unsupported elastic scaling configurations from proceeding.
* **Improvements**
  * Scaling now validates configuration and capacity constraints before starting.
  * Worker coordination during scaling is more resilient, reducing race conditions and ensuring cleanup after operations complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->