### PR TITLE
feat(global-planner): declare GPU cost for pools whose DGD requests none

### DIFF
--- a/components/src/dynamo/global_planner/README.md
+++ b/components/src/dynamo/global_planner/README.md
@@ -153,6 +153,38 @@ and then misbehaved at request time are now startup failures:
 - `intent_cache_ttl_seconds <= 0` — no cached intent is ever fresh, silently
   disabling all pool pairing.
 
+## Declared GPU Costs
+
+The GPU budget is computed from each pool's `gpu_per_replica`, read from the
+DGD's `resources.limits["nvidia.com/gpu"]`. A pool that requests no GPU has no
+cost to read — and with a budget enabled that fails the whole snapshot, so every
+scale request errors. That rules out **mocker topologies**, which exist to
+exercise a deployment without hardware but could not take part in the budget
+they are meant to help test.
+
+Declare what such a pool costs instead:
+
+```yaml
+gpu_cost:
+  pools:
+    - selector: sachalm/dsv4-**
+      gpu_per_replica: 8
+    - selector: sachalm/gpt-oss-**
+      gpu_per_replica: 4
+```
+
+Selectors work exactly as they do for priorities below — same syntax, same
+most-specific-wins rule, same shared implementation.
+
+**A declared cost is a fallback, not an override.** It applies only where the DGD
+is silent, so a pool that really does request GPUs is always charged what the
+cluster says and a stale config can never make the planner under-count real
+hardware. An explicit `gpu_per_replica: 0` is different from declaring nothing:
+zero keeps a pool out of budget totals, while undeclared leaves it unreadable.
+
+This mirrors the local planner, whose `_initialize_gpu_counts` already falls back
+to configured GPU counts for "mockers that don't specify GPU resources".
+
 ## Pool Priorities
 
 Pool priorities declare which pools should be served first when several compete

--- a/components/src/dynamo/global_planner/__main__.py
+++ b/components/src/dynamo/global_planner/__main__.py
@@ -82,6 +82,7 @@ async def main(runtime: DistributedRuntime, config: GlobalPlannerConfig):
         min_total_gpus=config.min_total_gpus,
         intent_cache_ttl_seconds=config.intent_cache_ttl_seconds,
         priority_config=config.priority,
+        gpu_cost_config=config.gpu_cost,
     )
 
     logger.info("Serving endpoints...")

--- a/components/src/dynamo/global_planner/config.py
+++ b/components/src/dynamo/global_planner/config.py
@@ -30,6 +30,7 @@ from typing import Literal, Optional
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from dynamo.global_planner.gpu_cost import GpuCostConfig
 from dynamo.global_planner.priority import PriorityConfig
 
 logger = logging.getLogger(__name__)
@@ -97,6 +98,15 @@ class GlobalPlannerConfig(BaseModel):
             "partner. Should be at least 2x the slowest local planner tick so "
             "opposite-direction intents can overlap; throughput scaling ticks "
             "every 180s by default, so 360 covers two ticks."
+        ),
+    )
+
+    gpu_cost: GpuCostConfig = Field(
+        default_factory=GpuCostConfig,
+        description=(
+            "GPU cost per replica for pools whose DGD requests no GPUs, so "
+            "GPU-free deployments such as mocker topologies can take part in "
+            "the budget. A declared cost is a fallback, never an override."
         ),
     )
 
@@ -216,6 +226,13 @@ class GlobalPlannerConfig(BaseModel):
         # pairing, so log it whenever either bound is active.
         if self.budget_enforcement_enabled():
             logger.info(f"Intent cache TTL seconds: {self.intent_cache_ttl_seconds}")
+
+        if self.gpu_cost.pools:
+            logger.info(f"Declared GPU costs: {len(self.gpu_cost.pools)}")
+            for entry in self.gpu_cost.pools:
+                logger.info(f"  {entry.selector} -> {entry.gpu_per_replica} GPU/replica")
+        else:
+            logger.info("Declared GPU costs: none (all pools priced by their DGD)")
 
         logger.info(f"Default pool priority: {self.priority.default}")
         if self.priority.pools:

--- a/components/src/dynamo/global_planner/gpu_cost.py
+++ b/components/src/dynamo/global_planner/gpu_cost.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Declared GPU cost per pool, for pools whose DGD does not request GPUs.
+
+The GPU budget is computed from each pool's ``gpu_per_replica``, read from the
+DGD's ``resources.limits["nvidia.com/gpu"]``. A pool that requests no GPU has no
+cost to read, and :meth:`Service.get_gpu_count` raises -- so with a budget
+enabled the whole snapshot fails and every scale request errors, and with the
+budget disabled there is no arbitration at all.
+
+That rules out the entire class of GPU-free deployments, most importantly
+**mocker-based testing**: mockers exist precisely so a topology can be exercised
+without hardware, but they cannot participate in the budget they are meant to
+help test.
+
+This table closes that gap by letting an operator declare what a pool *costs*
+without its DGD requesting real hardware:
+
+.. code-block:: yaml
+
+    gpu_cost:
+      pools:
+        - selector: "sachalm/dsv4-**"
+          gpu_per_replica: 8
+        - selector: "sachalm/gpt-oss-**"
+          gpu_per_replica: 4
+
+**A declared cost is a fallback, not an override.** It applies only where the
+DGD is silent. A pool that really does request GPUs is always charged what the
+cluster says, so a stale or wrong config can never cause the planner to
+under-count real hardware.
+
+The local planner already works this way -- ``_initialize_gpu_counts`` falls
+back to configured GPU counts when the DGD read fails, noting it is "useful for
+mockers that don't specify GPU resources". This is the same idea on the global
+side.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from dynamo.global_planner.pool_selectors import (
+    PoolSelector,
+    first_match,
+    order_by_specificity,
+    reject_duplicate_selectors,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PoolGpuCost(PoolSelector):
+    """GPUs charged per replica for the pools this selector covers."""
+
+    gpu_per_replica: int = Field(
+        ge=0,
+        description=(
+            "GPUs to charge per replica for matching pools whose DGD does not "
+            "request GPUs. 0 excludes them from budget totals entirely."
+        ),
+    )
+
+
+class GpuCostConfig(BaseModel):
+    """Declared GPU costs, most specific selector wins."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pools: list[PoolGpuCost] = Field(
+        default_factory=list,
+        description="Selector-scoped GPU costs for pools the DGD prices at nothing.",
+    )
+
+    @model_validator(mode="after")
+    def _reject_duplicate_selectors(self) -> "GpuCostConfig":
+        reject_duplicate_selectors(self.pools)
+        return self
+
+
+class GpuCostResolver:
+    """Resolves a pool's declared GPU cost from a :class:`GpuCostConfig`."""
+
+    def __init__(self, config: Optional[GpuCostConfig] = None):
+        self.config = config or GpuCostConfig()
+        self._ordered = order_by_specificity(self.config.pools)
+
+    def resolve(self, participant_id: str, sub_type: str) -> Optional[int]:
+        """Declared GPUs per replica for one pool, or ``None`` if undeclared.
+
+        ``None`` means "no opinion" and leaves the caller to fail the way it
+        would have without this table at all, rather than silently pricing an
+        unknown pool at zero and quietly shrinking the budget.
+        """
+        entry = first_match(self._ordered, participant_id, sub_type)
+        return entry.gpu_per_replica if entry is not None else None
+
+    def declared(self) -> bool:
+        """Whether any cost is declared at all."""
+        return bool(self._ordered)

--- a/components/src/dynamo/global_planner/kubernetes_capacity_manager.py
+++ b/components/src/dynamo/global_planner/kubernetes_capacity_manager.py
@@ -24,6 +24,7 @@ from dynamo.global_planner.capacity_manager import (
     PoolSnapshot,
     PoolSpec,
 )
+from dynamo.global_planner.gpu_cost import GpuCostResolver
 from dynamo.planner import KubernetesConnector, TargetReplica
 from dynamo.planner.connectors.clients.kubernetes_api import KubernetesAPI
 from dynamo.planner.monitoring.dgd_services import (
@@ -44,8 +45,16 @@ class KubernetesCapacityManager(CapacityManager):
     ``KubernetesConnector`` is cached per participant.
     """
 
-    def __init__(self, namespace: str):
+    def __init__(
+        self,
+        namespace: str,
+        gpu_cost: Optional[GpuCostResolver] = None,
+    ):
         self.namespace = namespace
+        # Declared GPU costs for pools whose DGD requests no GPUs. Defaulting to
+        # an empty resolver preserves the previous behavior exactly: an
+        # unpriced pool still fails the read.
+        self._gpu_cost = gpu_cost or GpuCostResolver()
         # participant_id -> KubernetesConnector
         self.connectors: dict[str, KubernetesConnector] = {}
         # participant_id -> {component_name: planner_role}. Generic ``worker``
@@ -158,6 +167,33 @@ class KubernetesCapacityManager(CapacityManager):
     # Observe                                                            #
     # ------------------------------------------------------------------ #
 
+    def _resolve_gpu_per_replica(
+        self,
+        participant_id: str,
+        pool_key: str,
+        component: dict,
+        service: Service,
+    ) -> int:
+        """GPUs per replica from the DGD, falling back to a declared cost.
+
+        The DGD always wins where it speaks, so a stale or wrong ``gpu_cost``
+        entry can never make the planner under-count real hardware. When
+        neither source has an answer, the original error is re-raised with the
+        second remedy named, since an operator hitting this on a mocker
+        deployment has no way to add GPU limits.
+        """
+        try:
+            return self._gpu_per_replica(component, service)
+        except ValueError as exc:
+            declared = self._gpu_cost.resolve(participant_id, pool_key)
+            if declared is not None:
+                return declared
+            raise ValueError(
+                f"{exc} Alternatively, declare a cost for this pool under "
+                f"'gpu_cost' in the GlobalPlanner config with a selector "
+                f"matching '{participant_id}/{pool_key}'."
+            ) from exc
+
     def observe(self, require_complete: bool = False) -> PoolSnapshot:
         """Read current pool state for every known deployment.
 
@@ -174,7 +210,7 @@ class KubernetesCapacityManager(CapacityManager):
         for key, connector in list(self.connectors.items()):
             try:
                 all_pools[key] = self._read_pools(
-                    connector, self._component_roles.get(key)
+                    key, connector, self._component_roles.get(key)
                 )
             except Exception as e:
                 if require_complete:
@@ -231,6 +267,7 @@ class KubernetesCapacityManager(CapacityManager):
 
     def _read_pools(
         self,
+        participant_id: str,
         connector: KubernetesConnector,
         role_hints: Optional[dict[str, str]] = None,
     ) -> dict[str, PoolSpec]:
@@ -254,7 +291,9 @@ class KubernetesCapacityManager(CapacityManager):
                 V1BETA1_GENERIC_WORKER_COMPONENT_TYPE,
             ):
                 try:
-                    gpu_per_replica = self._gpu_per_replica(component, service)
+                    gpu_per_replica = self._resolve_gpu_per_replica(
+                        participant_id, component_name, component, service
+                    )
                 except ValueError:
                     if component_type == "":
                         # An untyped non-worker component is not a pool.
@@ -276,7 +315,9 @@ class KubernetesCapacityManager(CapacityManager):
                 gpu_per_replica=(
                     gpu_per_replica
                     if gpu_per_replica is not None
-                    else self._gpu_per_replica(component, service)
+                    else self._resolve_gpu_per_replica(
+                        participant_id, pool_key, component, service
+                    )
                 ),
             )
         return pools

--- a/components/src/dynamo/global_planner/pool_selectors.py
+++ b/components/src/dynamo/global_planner/pool_selectors.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pool selector matching, shared by every selector-keyed config table.
+
+A **selector** is a slash-separated path matched against a pool's identity,
+``"<participant_id>/<sub_type>"`` -- today ``"<k8s namespace>/<deployment>/<sub_type>"``,
+though nothing here depends on that depth.
+
+- ``*`` matches exactly one segment.
+- ``**`` matches any number of segments, including none. It is only special as
+  a *whole* segment: inside one, as in ``gpt-oss-**``, it is an ordinary glob
+  star and still matches within that single segment only.
+- A selector shorter than the pool path covers everything beneath it, so
+  ``prod/chat`` selects every pool of that deployment while
+  ``prod/chat/prefill`` selects one.
+
+When several selectors match, the most specific wins, ranked by how many
+segments are named exactly and then by depth -- independent of the order
+entries appear in the config file. Ties fall back to declaration order.
+
+Named ``pool_selectors`` rather than ``selectors`` on purpose: the latter
+would shadow the Python standard library's ``selectors`` module for any tool or
+script whose working directory puts this package on ``sys.path``, breaking
+``asyncio`` and anything else that imports it.
+
+This lives apart from any one table so pool priorities
+(:mod:`~dynamo.global_planner.priority`) and declared GPU costs
+(:mod:`~dynamo.global_planner.gpu_cost`) cannot drift into subtly different
+matching rules.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from typing import Optional, Sequence, TypeVar
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+_WILDCARD_CHARS = "*?["
+
+
+class PoolSelector(BaseModel):
+    """Base for a config entry scoped to a set of pools by path pattern."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    selector: str = Field(
+        description=(
+            "Slash-separated path matched against '<participant_id>/<sub_type>'. "
+            "'*' matches exactly one segment, '**' matches any number, and a "
+            "selector shorter than the pool path covers everything beneath it."
+        )
+    )
+
+    @model_validator(mode="after")
+    def _validate_selector(self) -> "PoolSelector":
+        segments = self.selector.split("/")
+        if not segments or any(not seg for seg in segments):
+            raise ValueError(
+                f"selector {self.selector!r} must be a slash-separated path with "
+                f"no empty segments"
+            )
+        return self
+
+    @property
+    def _segments(self) -> tuple[str, ...]:
+        return tuple(self.selector.split("/"))
+
+    @property
+    def _pattern(self) -> tuple[str, ...]:
+        """Declared segments, implicitly covering everything beneath them.
+
+        A selector shorter than a pool path should select every pool under it,
+        which is exactly "match the declared segments, then anything" -- so a
+        trailing ``**`` is appended unless one is already there.
+        """
+        segments = self._segments
+        if segments[-1] == "**":
+            return segments
+        return segments + ("**",)
+
+    @staticmethod
+    def _match_segments(pattern: tuple[str, ...], path: tuple[str, ...]) -> bool:
+        """Glob a segment path, where a whole ``**`` segment spans any number.
+
+        Wildcards never span a ``/`` unless the segment is exactly ``**``, so
+        ``a/*/prefill`` matches ``a/b/prefill`` but not ``a/b/c/prefill``,
+        while ``a/**/prefill`` matches both. A ``**`` embedded in a longer
+        segment is just a glob star within that segment.
+        """
+        if not pattern:
+            return not path
+        head, rest = pattern[0], pattern[1:]
+        if head == "**":
+            # Try consuming 0, 1, 2 ... segments here.
+            return any(
+                PoolSelector._match_segments(rest, path[i:])
+                for i in range(len(path) + 1)
+            )
+        if not path:
+            return False
+        if not fnmatch.fnmatchcase(path[0], head):
+            return False
+        return PoolSelector._match_segments(rest, path[1:])
+
+    def matches(self, participant_id: str, sub_type: str) -> bool:
+        """Whether this selector covers the pool ``participant_id``/``sub_type``."""
+        path = tuple(participant_id.split("/")) + (sub_type,)
+        return self._match_segments(self._pattern, path)
+
+    @property
+    def specificity(self) -> tuple[int, int]:
+        """Sort key ranking selectors most-specific first (smaller wins).
+
+        Ranked by how many segments are named exactly, then by depth. So
+        ``prod/chat/prefill`` beats ``prod/chat``, which beats ``prod/*``,
+        which beats ``**``.
+        """
+        exact = sum(
+            1 for seg in self._segments if not any(c in seg for c in _WILDCARD_CHARS)
+        )
+        return (-exact, -len(self._segments))
+
+
+EntryT = TypeVar("EntryT", bound=PoolSelector)
+
+
+def order_by_specificity(entries: Sequence[EntryT]) -> list[EntryT]:
+    """Order entries most-specific first, ties broken by declaration order.
+
+    Ordering once at construction keeps resolution deterministic and
+    independent of how the config file happened to be written.
+    """
+    return [
+        entry
+        for _, entry in sorted(
+            enumerate(entries), key=lambda pair: (pair[1].specificity, pair[0])
+        )
+    ]
+
+
+def reject_duplicate_selectors(entries: Sequence[PoolSelector]) -> None:
+    """Raise if two entries declare the same selector.
+
+    Only one of them could ever take effect, so a duplicate is a config
+    mistake rather than a precedence question.
+    """
+    seen: set[str] = set()
+    for entry in entries:
+        if entry.selector in seen:
+            raise ValueError(
+                f"duplicate selector {entry.selector!r}: merge the entries, "
+                f"since only one of them could ever take effect"
+            )
+        seen.add(entry.selector)
+
+
+def first_match(
+    ordered: Sequence[EntryT], participant_id: str, sub_type: str
+) -> Optional[EntryT]:
+    """Most specific entry covering this pool, or ``None``."""
+    for entry in ordered:
+        if entry.matches(participant_id, sub_type):
+            return entry
+    return None

--- a/components/src/dynamo/global_planner/priority.py
+++ b/components/src/dynamo/global_planner/priority.py
@@ -55,13 +55,18 @@ the requester's -- a partner's context comes from the intent it published, so
 
 from __future__ import annotations
 
-import fnmatch
 import logging
 import math
 from dataclasses import dataclass
 from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from dynamo.global_planner.pool_selectors import (
+    PoolSelector,
+    order_by_specificity,
+    reject_duplicate_selectors,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -237,7 +242,7 @@ class PriorityRule(BaseModel):
         return self.when is None or self.when.matches(ctx)
 
 
-class PoolPriorityPolicy(BaseModel):
+class PoolPriorityPolicy(PoolSelector):
     """A selector bound to an ordered, first-match-wins list of rules.
 
     ``priority`` is shorthand for a single unconditional rule; it and ``rules``
@@ -246,17 +251,6 @@ class PoolPriorityPolicy(BaseModel):
     sees exactly one shape.
     """
 
-    model_config = ConfigDict(extra="forbid")
-
-    selector: str = Field(
-        description=(
-            "Slash-separated path matched against '<participant_id>/<sub_type>'. "
-            "'*' matches exactly one segment, '**' matches any number, and a "
-            "selector shorter than the pool path covers everything beneath it -- "
-            "so 'prod/chat' selects every pool of that deployment while "
-            "'prod/chat/prefill' selects one."
-        )
-    )
     priority: Optional[int] = Field(default=None, ge=LOWEST_PRIORITY)
     rules: Optional[list[PriorityRule]] = Field(default=None)
 
@@ -285,74 +279,7 @@ class PoolPriorityPolicy(BaseModel):
                 f"so every context resolves to a priority"
             )
 
-        segments = self.selector.split("/")
-        if not segments or any(not seg for seg in segments):
-            raise ValueError(
-                f"selector {self.selector!r} must be a slash-separated path with "
-                f"no empty segments"
-            )
         return self
-
-    # ------------------------------------------------------------------ #
-    # Matching                                                           #
-    # ------------------------------------------------------------------ #
-
-    @property
-    def _segments(self) -> tuple[str, ...]:
-        return tuple(self.selector.split("/"))
-
-    @property
-    def _pattern(self) -> tuple[str, ...]:
-        """Declared segments, implicitly covering everything beneath them.
-
-        A selector shorter than a pool path should select every pool under it,
-        which is exactly "match the declared segments, then anything" -- so a
-        trailing ``**`` is appended unless one is already there.
-        """
-        segments = self._segments
-        if segments[-1] == "**":
-            return segments
-        return segments + ("**",)
-
-    @staticmethod
-    def _match_segments(pattern: tuple[str, ...], path: tuple[str, ...]) -> bool:
-        """Glob a segment path, where ``**`` spans any number of segments.
-
-        Wildcards other than ``**`` never span a ``/``, so ``a/*/prefill``
-        matches ``a/b/prefill`` but not ``a/b/c/prefill``; ``a/**/prefill``
-        matches both.
-        """
-        if not pattern:
-            return not path
-        head, rest = pattern[0], pattern[1:]
-        if head == "**":
-            # Try consuming 0, 1, 2 ... segments here.
-            return any(
-                PoolPriorityPolicy._match_segments(rest, path[i:])
-                for i in range(len(path) + 1)
-            )
-        if not path:
-            return False
-        if not fnmatch.fnmatchcase(path[0], head):
-            return False
-        return PoolPriorityPolicy._match_segments(rest, path[1:])
-
-    def matches(self, participant_id: str, sub_type: str) -> bool:
-        """Whether this selector covers the pool ``participant_id``/``sub_type``."""
-        path = tuple(participant_id.split("/")) + (sub_type,)
-        return self._match_segments(self._pattern, path)
-
-    @property
-    def specificity(self) -> tuple[int, int]:
-        """Sort key ranking selectors most-specific first (smaller wins).
-
-        Ranked by how many segments are named exactly, then by depth. So
-        ``prod/chat/prefill`` beats ``prod/chat``, which beats ``prod/*``,
-        which beats ``**``. Ties fall back to declaration order in
-        :class:`PriorityResolver`.
-        """
-        exact = sum(1 for seg in self._segments if not any(c in seg for c in "*?["))
-        return (-exact, -len(self._segments))
 
     def resolve(self, ctx: PriorityContext) -> Optional[tuple[int, int]]:
         """First applicable rule as ``(priority, rule_index)``, else ``None``."""
@@ -383,14 +310,7 @@ class PriorityConfig(BaseModel):
 
     @model_validator(mode="after")
     def _reject_duplicate_selectors(self) -> "PriorityConfig":
-        seen: set[str] = set()
-        for policy in self.pools:
-            if policy.selector in seen:
-                raise ValueError(
-                    f"duplicate selector {policy.selector!r}: merge the entries, "
-                    f"since only one of them could ever take effect"
-                )
-            seen.add(policy.selector)
+        reject_duplicate_selectors(self.pools)
         return self
 
 
@@ -409,10 +329,7 @@ class PriorityResolver:
 
     def __init__(self, config: Optional[PriorityConfig] = None):
         self.config = config or PriorityConfig()
-        self._ordered = sorted(
-            enumerate(self.config.pools),
-            key=lambda pair: (pair[1].specificity, pair[0]),
-        )
+        self._ordered = order_by_specificity(self.config.pools)
 
     def resolve(
         self,
@@ -426,7 +343,7 @@ class PriorityResolver:
         which is the normal path for a pool the operator never named.
         """
         context = ctx if ctx is not None else PriorityContext()
-        for _, policy in self._ordered:
+        for policy in self._ordered:
             if not policy.matches(participant_id, sub_type):
                 continue
             outcome = policy.resolve(context)

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -19,6 +19,7 @@ Behavior is unchanged from the pre-refactor monolithic handler.
 import logging
 from typing import Optional
 
+from dynamo.global_planner.gpu_cost import GpuCostConfig, GpuCostResolver
 from dynamo.global_planner.kubernetes_capacity_manager import KubernetesCapacityManager
 from dynamo.global_planner.orchestrator import Orchestrator
 from dynamo.global_planner.priority import (
@@ -61,6 +62,7 @@ class ScaleRequestHandler:
         min_total_gpus: int = -1,
         intent_cache_ttl_seconds: float = 360.0,
         priority_config: Optional[PriorityConfig] = None,
+        gpu_cost_config: Optional[GpuCostConfig] = None,
     ):
         """Initialize the scale request handler.
 
@@ -75,6 +77,8 @@ class ScaleRequestHandler:
                 is considered fresh for pairing
             priority_config: Pool priorities used to order partner selection
                 under contention (None = every pool equally important)
+            gpu_cost_config: Declared GPU cost per replica for pools whose DGD
+                requests no GPUs (None = every pool priced by its DGD)
         """
         self.runtime = runtime
         self.no_operation = no_operation
@@ -84,7 +88,10 @@ class ScaleRequestHandler:
         # managed_namespaces and a namespace-prefix convention.
         # The wire vocabulary (K8s namespace / DGD name) is mapped here onto the
         # orchestrator's neutral vocabulary; the orchestrator is a no-K8s zone.
-        capacity_manager = KubernetesCapacityManager(namespace=k8s_namespace)
+        capacity_manager = KubernetesCapacityManager(
+            namespace=k8s_namespace,
+            gpu_cost=GpuCostResolver(gpu_cost_config),
+        )
         self.orchestrator = Orchestrator(
             capacity_manager=capacity_manager,
             managed_deployments=managed_namespaces,

--- a/components/src/dynamo/global_planner/tests/unit/test_gpu_cost.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_gpu_cost.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for declared GPU costs.
+
+The point of this table is that a GPU-free deployment -- above all a mocker
+topology -- can take part in the GPU budget it exists to help test.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from dynamo.global_planner.gpu_cost import GpuCostConfig, GpuCostResolver
+from dynamo.global_planner.kubernetes_capacity_manager import KubernetesCapacityManager
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+def _resolver(**kwargs) -> GpuCostResolver:
+    return GpuCostResolver(GpuCostConfig(**kwargs))
+
+
+def _component(name, replicas, gpu, ctype):
+    """A v1beta1 component; ``gpu=None`` declares no nvidia.com/gpu (a mocker)."""
+    resources = {"limits": {"nvidia.com/gpu": gpu}} if gpu is not None else {}
+    return {
+        "name": name,
+        "type": ctype,
+        "replicas": replicas,
+        "podTemplate": {
+            "spec": {"containers": [{"name": "main", "resources": resources}]}
+        },
+    }
+
+
+def _manager(components, gpu_cost=None, dgd="dsv4-flash"):
+    manager = KubernetesCapacityManager(
+        "sachalm", gpu_cost=GpuCostResolver(gpu_cost)
+    )
+    connector = MagicMock()
+    connector.parent_dgd_name = dgd
+    connector.kube_api.get_graph_deployment.return_value = {
+        "spec": {"components": components}
+    }
+    manager.connectors[f"sachalm/{dgd}"] = connector
+    return manager
+
+
+# ---------------------------------------------------------------------------- #
+# Resolution                                                                   #
+# ---------------------------------------------------------------------------- #
+
+
+def test_undeclared_pool_resolves_to_none():
+    # None means "no opinion", not "free" -- pricing an unknown pool at zero
+    # would silently shrink the budget.
+    assert _resolver().resolve("ns/a", "prefill") is None
+
+
+def test_most_specific_selector_wins():
+    resolver = _resolver(
+        pools=[
+            {"selector": "sachalm/**", "gpu_per_replica": 1},
+            {"selector": "sachalm/dsv4-flash", "gpu_per_replica": 8},
+            {"selector": "sachalm/dsv4-flash/prefill", "gpu_per_replica": 4},
+        ]
+    )
+    assert resolver.resolve("sachalm/dsv4-flash", "prefill") == 4
+    assert resolver.resolve("sachalm/dsv4-flash", "decode") == 8
+    assert resolver.resolve("sachalm/gpt-oss", "decode") == 1
+
+
+def test_selector_semantics_match_the_priority_table():
+    # Both tables share pool_selectors.py; this guards against them drifting apart.
+    resolver = _resolver(pools=[{"selector": "a/*/prefill", "gpu_per_replica": 2}])
+    assert resolver.resolve("a/b", "prefill") == 2
+    assert resolver.resolve("a/b/c", "prefill") is None
+    assert resolver.resolve("a/b", "decode") is None
+
+
+def test_zero_cost_is_allowed():
+    # An explicit 0 keeps a pool out of budget totals, which is different from
+    # not declaring it at all.
+    assert _resolver(pools=[{"selector": "ns/a", "gpu_per_replica": 0}]).resolve(
+        "ns/a", "decode"
+    ) == 0
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"selector": "ns/a", "gpu_per_replica": -1},
+        {"selector": "a//b", "gpu_per_replica": 1},
+        {"selector": "ns/a"},
+    ],
+)
+def test_invalid_entries_are_rejected(entry):
+    with pytest.raises(ValidationError):
+        GpuCostConfig(pools=[entry])
+
+
+def test_duplicate_selectors_are_rejected():
+    with pytest.raises(ValidationError, match="duplicate selector"):
+        GpuCostConfig(
+            pools=[
+                {"selector": "ns/a", "gpu_per_replica": 1},
+                {"selector": "ns/a", "gpu_per_replica": 2},
+            ]
+        )
+
+
+# ---------------------------------------------------------------------------- #
+# Effect on reading pool state                                                 #
+# ---------------------------------------------------------------------------- #
+
+
+def test_mocker_pools_are_unreadable_without_a_declared_cost():
+    """The gap this table closes: with a budget enabled, an unpriced pool fails
+    the whole snapshot, so every scale request errors out."""
+    manager = _manager(
+        [
+            _component("prefill-svc", 2, None, "prefill"),
+            _component("decode-svc", 3, None, "decode"),
+        ]
+    )
+    with pytest.raises(RuntimeError, match="Failed to read deployment"):
+        manager.observe(require_complete=True)
+
+
+def test_declared_cost_lets_mocker_pools_join_the_budget():
+    manager = _manager(
+        [
+            _component("prefill-svc", 2, None, "prefill"),
+            _component("decode-svc", 3, None, "decode"),
+        ],
+        gpu_cost=GpuCostConfig(
+            pools=[{"selector": "sachalm/dsv4-**", "gpu_per_replica": 8}]
+        ),
+    )
+    pools = manager.observe(require_complete=True)["sachalm/dsv4-flash"]
+    assert (pools["prefill"].current_replicas, pools["prefill"].gpu_per_replica) == (2, 8)
+    assert (pools["decode"].current_replicas, pools["decode"].gpu_per_replica) == (3, 8)
+
+
+def test_the_dgd_wins_where_it_declares_gpus():
+    """A declared cost is a fallback, never an override, so a stale config can
+    never make the planner under-count real hardware."""
+    manager = _manager(
+        [
+            _component("prefill-svc", 1, 4, "prefill"),  # DGD says 4
+            _component("decode-svc", 1, None, "decode"),  # DGD silent
+        ],
+        gpu_cost=GpuCostConfig(
+            pools=[{"selector": "sachalm/**", "gpu_per_replica": 1}]
+        ),
+    )
+    pools = manager.observe(require_complete=True)["sachalm/dsv4-flash"]
+    assert pools["prefill"].gpu_per_replica == 4  # DGD, not the declared 1
+    assert pools["decode"].gpu_per_replica == 1  # fallback applies
+
+
+def test_unpriced_pool_error_names_both_remedies():
+    manager = _manager([_component("prefill-svc", 1, None, "prefill")])
+    with pytest.raises(RuntimeError) as excinfo:
+        manager.observe(require_complete=True)
+    message = str(excinfo.value)
+    assert "resources.limits.nvidia.com/gpu" in message
+    assert "gpu_cost" in message

--- a/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from dynamo.global_planner.gpu_cost import GpuCostConfig
 from dynamo.global_planner.orchestrator import PoolIntent
 from dynamo.global_planner.priority import PriorityConfig
 from dynamo.global_planner.scale_handler import ScaleRequestHandler
@@ -1265,9 +1266,12 @@ def test_read_all_pools_tolerates_concurrent_connector_insert(mock_runtime):
     # the iteration to simulate a concurrent first-time request.
     original = handler.orchestrator.capacity_manager._read_pools
 
-    def _mutating_read(connector):
+    calls: list[str] = []
+
+    def _mutating_read(participant_id, connector, role_hints=None):
         # Inject a new connector mid-iteration. Without the list() snapshot
         # this raises RuntimeError: dictionary changed size during iteration.
+        calls.append(participant_id)
         new_conn = MagicMock()
         new_conn.parent_dgd_name = "racy-dgd"
         new_conn.kube_api = MagicMock()
@@ -1277,12 +1281,17 @@ def test_read_all_pools_tolerates_concurrent_connector_insert(mock_runtime):
         handler.orchestrator.capacity_manager.connectors.setdefault(
             "default/racy-dgd", new_conn
         )
-        return original(connector)
+        return original(participant_id, connector, role_hints)
 
     handler.orchestrator.capacity_manager._read_pools = _mutating_read  # type: ignore[method-assign]
 
     # Should not raise.
     snapshot = handler.orchestrator.capacity_manager.observe()
+    # observe() swallows per-participant read errors, so a monkeypatch whose
+    # signature does not match would silently never run and this test would
+    # pass while exercising nothing. Assert it actually fired.
+    assert calls, "_read_pools monkeypatch never ran — signature drift"
+    assert "default/racy-dgd" in handler.orchestrator.capacity_manager.connectors
     # The pre-existing key is in the snapshot; the mid-iteration insert
     # may or may not appear (depends on snapshot timing) but the call
     # must complete cleanly.
@@ -1992,3 +2001,92 @@ async def test_busy_pool_is_protected_by_its_condition(mock_runtime):
     prod, batch = await _run_conditional_transfer(mock_runtime, batch_num_requests=900)
     assert prod == {"prefill": 5, "decode": 1}
     assert batch == {"decode": 2}
+
+
+# ---------------------------------------------------------------------------- #
+# Mocker topologies: GPU-free pools taking part in the budget                   #
+# ---------------------------------------------------------------------------- #
+
+# Two mocker DGDs, neither requesting GPUs, priced only by declared cost:
+#   dsv4-flash  2 prefill + 2 decode @ 8 GPU/replica = 32
+#   gpt-oss-120b 2 prefill + 2 decode @ 4 GPU/replica = 16
+# Fixed total of 48, tolerance 8 (the largest per-replica cost) -> band [40, 48].
+_MOCKER_GPU_COST = GpuCostConfig(
+    pools=[
+        {"selector": "default/dsv4-**", "gpu_per_replica": 8},
+        {"selector": "default/gpt-oss-**", "gpu_per_replica": 4},
+    ]
+)
+
+
+def _mocker_handler(mock_runtime, gpu_cost):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-dsv4-flash", "default-gpt-oss-120b"],
+        k8s_namespace="default",
+        min_total_gpus=48,
+        max_total_gpus=48,
+        gpu_cost_config=gpu_cost,
+        priority_config=PriorityConfig(
+            pools=[
+                {"selector": "default/dsv4-**", "priority": 900},
+                {"selector": "default/gpt-oss-**", "priority": 10},
+            ]
+        ),
+    )
+    # gpu=None -> the DGD declares no nvidia.com/gpu, exactly like a mocker.
+    dsv4 = _install_connector(
+        handler,
+        "default/dsv4-flash",
+        _dgd_spec(2, 2, prefill_gpu=None, decode_gpu=None),
+        parent_dgd_name="dsv4-flash",
+    )
+    gpt = _install_connector(
+        handler,
+        "default/gpt-oss-120b",
+        _dgd_spec(2, 2, prefill_gpu=None, decode_gpu=None),
+        parent_dgd_name="gpt-oss-120b",
+    )
+    return handler, dsv4, gpt
+
+
+@pytest.mark.asyncio
+async def test_mocker_pools_cannot_be_budgeted_without_declared_cost(mock_runtime):
+    """Without a declared cost a GPU-free pool cannot be read at all, so every
+    scale request fails. This is the gap that made mocker-based testing of the
+    budget impossible."""
+    handler, _, _ = _mocker_handler(mock_runtime, gpu_cost=None)
+    results = await _run(
+        handler, _scale_req(dgd="dsv4-flash", caller_ns="default-dsv4-flash", decode=3)
+    )
+    assert results[0]["status"] == "error"
+    assert "No GPU count specified" in results[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_mocker_pools_arbitrate_once_costs_are_declared(mock_runtime):
+    """End to end on a GPU-free topology: an over-ceiling request from the
+    important model is admitted by taking capacity from the expendable one, and
+    the cluster total is unchanged."""
+    handler, dsv4, gpt = _mocker_handler(mock_runtime, gpu_cost=_MOCKER_GPU_COST)
+
+    # gpt-oss has a pending scale-down worth 8 GPUs (2 decode replicas @ 4).
+    handler.orchestrator._intent_cache["default/gpt-oss-120b/decode"] = PoolIntent(
+        last_desired=0, last_seen_at=time.time()
+    )
+
+    # dsv4 wants a third decode replica: +8 GPUs, which alone would hit 56 > 48.
+    results = await _run(
+        handler, _scale_req(dgd="dsv4-flash", caller_ns="default-dsv4-flash", decode=3)
+    )
+    assert results[0]["status"] == "success", results[0]
+
+    def targets(connector):
+        return {
+            t.sub_component_type.value: t.desired_replicas
+            for t in connector.set_component_replicas.call_args[0][0]
+        }
+
+    assert targets(dsv4) == {"decode": 3}
+    assert targets(gpt) == {"decode": 0}
+    # dsv4 (2 + 3) * 8 = 40, gpt-oss-120b (2 + 0) * 4 = 8 -> 48, exactly the budget.


### PR DESCRIPTION
## Overview:

**Stack 6/6** — pool prioritization for the Global Planner (`LLM-179`). Based on #14039.

Lets a GPU-free deployment take part in the GPU budget. Without this, **mocker topologies cannot be used to test arbitration at all** — which is why the shipped mocker example runs with `no_operation` and never exercised the budget.

## Details:

The budget is computed from each pool's `gpu_per_replica`, read from the DGD's `resources.limits["nvidia.com/gpu"]`. A pool that requests no GPU has no cost to read and `Service.get_gpu_count` raises. So today:

| Budget | Result with GPU-free pools |
|--------|----------------------------|
| enabled | `observe()` needs a complete snapshot → `RuntimeError` → **every scale request errors** |
| disabled | read failure swallowed, pools empty → **no arbitration to test** |

This adds a selector-keyed `gpu_cost` table:

```yaml
gpu_cost:
  pools:
    - selector: sachalm/dsv4-**
      gpu_per_replica: 8
    - selector: sachalm/gpt-oss-**
      gpu_per_replica: 4
```

**A declared cost is a fallback, never an override.** It applies only where the DGD is silent, so a pool that really does request GPUs is always charged what the cluster says and a stale config can never make the planner under-count real hardware. An explicit `0` differs from declaring nothing — zero keeps a pool out of budget totals, undeclared leaves it unreadable. When neither source has an answer the original error is re-raised naming both remedies, since an operator hitting this on a mocker cannot add GPU limits.

This mirrors the local planner, whose `_initialize_gpu_counts` already falls back to configured counts for "mockers that don't specify GPU resources".

Selector matching moves into `pool_selectors.py` so the priority and cost tables cannot drift into subtly different rules. **The module is deliberately not named `selectors.py`** — that shadows the standard library's `selectors` module for any tool whose working directory puts this package on `sys.path`, and it broke `black` outright before the rename.

Also repairs the concurrent-insert regression test: its `_read_pools` monkeypatch signature had drifted, and since `observe()` swallows per-participant read errors the resulting `TypeError` vanished — the test passed while exercising nothing. There was already a TODO about it.

## Where should the reviewer start?

- `gpu_cost.py` — the fallback-not-override semantics.
- `kubernetes_capacity_manager._resolve_gpu_per_replica` — where the DGD and the declared cost meet.
- `tests/unit/test_scale_request_handler.py::test_mocker_pools_arbitrate_once_costs_are_declared` — two GPU-free mocker DGDs under a fixed 48-GPU budget, where the expendable model gives up capacity so the important one can grow. Its sibling pins that the same request errors without a declared cost.

## Testing

12 new tests in `tests/unit/test_gpu_cost.py`, 2 end-to-end in `test_scale_request_handler.py`. Full `planner` + `global_planner` suites pass locally (1321 passed, 8 skipped).

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — tracked in Linear as LLM-179

🤖 Generated with [Claude Code](https://claude.com/claude-code)