### PR TITLE
fix(frontend): Return 400 for unsupported multimodal content

### DIFF
--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -144,6 +144,7 @@ async fn anthropic_error_middleware(request: Request<Body>, next: Next) -> Respo
 enum AnthropicRequestValidationError {
     InvalidArgument(String),
     NotImplemented(String),
+    UnsupportedContent(String),
 }
 
 impl AnthropicRequestValidationError {
@@ -151,13 +152,16 @@ impl AnthropicRequestValidationError {
         match self {
             Self::InvalidArgument(_) => StatusCode::BAD_REQUEST,
             Self::NotImplemented(_) => StatusCode::NOT_IMPLEMENTED,
+            Self::UnsupportedContent(_) => StatusCode::BAD_REQUEST,
         }
     }
 
+    // 400 from status(). Dashboard should seperate unsupported content from not implemented.
     fn metric_error_type(&self) -> ErrorType {
         match self {
             Self::InvalidArgument(_) => ErrorType::Validation,
             Self::NotImplemented(_) => ErrorType::NotImplemented,
+            Self::UnsupportedContent(_) => ErrorType::NotImplemented,
         }
     }
 
@@ -165,12 +169,15 @@ impl AnthropicRequestValidationError {
         match self {
             Self::InvalidArgument(_) => "invalid_request_error",
             Self::NotImplemented(_) => "api_error",
+            Self::UnsupportedContent(_) => "invalid_request_error",
         }
     }
 
     fn message(&self) -> &str {
         match self {
-            Self::InvalidArgument(message) | Self::NotImplemented(message) => message,
+            Self::InvalidArgument(message)
+            | Self::NotImplemented(message)
+            | Self::UnsupportedContent(message) => message,
         }
     }
 }
@@ -209,9 +216,11 @@ fn validate_anthropic_messages(
                         "messages[{message_index}].content[{block_index}].type: must be a non-empty string"
                     )));
                 };
-                return Err(AnthropicRequestValidationError::NotImplemented(format!(
-                    "messages[{message_index}].content[{block_index}]: content block type \"{block_type}\" is not supported"
-                )));
+                return Err(AnthropicRequestValidationError::UnsupportedContent(
+                    format!(
+                        "messages[{message_index}].content[{block_index}]: content block type \"{block_type}\" is not supported"
+                    ),
+                ));
             }
         }
     }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -507,11 +507,9 @@ impl ErrorMessage {
         )
     }
 
-    /// Unsupported Content Error
-    /// Return this error when the client sends content that is not supported by the server.
-    /// This should be used for cases where the server cannot process the content type or format.
-    /// This is explicitly used for unsupported content types or formats for multimodal
-    /// and is intended to return a 400, as 500/501s are considered server errors in practice.
+    /// Unsupported multimodal content is a client error: no retry can make the
+    /// request succeed, and infrastructure above the frontend counts 5xx as a
+    /// server-side fault. Answered 400 where `not_implemented_error` answers 501.
     pub fn unsupported_content_error<T: Display>(msg: T) -> ErrorResponse {
         tracing::debug!("Unsupported Content error: {msg}");
         let code = StatusCode::BAD_REQUEST;

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -241,8 +241,10 @@ fn responses_conversion_error_response(error: anyhow::Error) -> ErrorResponse {
             invalid_argument(format!("{CONTEXT}: {message}")).into(),
             CONTEXT,
         ),
-        Some(ResponsesConversionError::NotImplemented(message)) => {
-            ErrorMessage::not_implemented_error(format!("{VALIDATION_PREFIX}{CONTEXT}: {message}"))
+        Some(ResponsesConversionError::UnsupportedContent(message)) => {
+            ErrorMessage::unsupported_content_error(format!(
+                "{VALIDATION_PREFIX}{CONTEXT}: {message}"
+            ))
         }
         None => ErrorMessage::from_anyhow(error, CONTEXT),
     }
@@ -488,6 +490,27 @@ impl ErrorMessage {
                 code: code.as_u16(),
                 details: None,
                 metric_error_type: None,
+            }),
+        )
+    }
+
+    /// Unsupported Content Error
+    /// Return this error when the client sends content that is not supported by the server.
+    /// This should be used for cases where the server cannot process the content type or format.
+    /// This is explicitly used for unsupported content types or formats for multimodal
+    /// and is intended to return a 400, as 500/501s are considered server errors in practice.
+    pub fn unsupported_content_error<T: Display>(msg: T) -> ErrorResponse {
+        tracing::debug!("Unsupported Content error: {msg}");
+        let code = StatusCode::BAD_REQUEST;
+        let error_type = map_error_code_to_error_type(code);
+        (
+            code,
+            Json(ErrorMessage {
+                message: msg.to_string(),
+                error_type,
+                code: code.as_u16(),
+                details: None,
+                metric_error_type: Some(ErrorType::NotImplemented),
             }),
         )
     }
@@ -7572,6 +7595,20 @@ mod tests {
     #[test]
     fn test_extract_error_type_from_response_not_implemented() {
         let response = ErrorMessage::not_implemented_error("Feature not available");
+        assert_eq!(
+            extract_error_type_from_response(&response),
+            ErrorType::NotImplemented
+        );
+    }
+
+    #[test]
+    fn unsupported_content_responses_conversion_errors_are_not_implemented() {
+        let response = responses_conversion_error_response(
+            ResponsesConversionError::UnsupportedContent("feature not available".to_string())
+                .into(),
+        );
+
+        assert_eq!(response.0, StatusCode::BAD_REQUEST);
         assert_eq!(
             extract_error_type_from_response(&response),
             ErrorType::NotImplemented

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -182,6 +182,19 @@ fn unavailable_error_type() -> String {
         .to_string()
 }
 
+/// `error_type` for a genuine 400 that is not a load-shed rejection. Same
+/// reasoning as `unavailable_error_type`: `map_error_code_to_error_type`
+/// checks `code == overload_status_code()` first, and an operator can
+/// configure `DYN_HTTP_OVERLOAD_STATUS_CODE=400`, which would otherwise
+/// label unsupported content "Overloaded" — telling clients to retry a
+/// request that can never succeed.
+fn bad_request_error_type() -> String {
+    StatusCode::BAD_REQUEST
+        .canonical_reason()
+        .expect("400 is IANA-registered")
+        .to_string()
+}
+
 /// `error_type` for a genuine 500 (unhandled panic, bug, misconfiguration)
 /// that is not a load-shed rejection. Same reasoning as `unavailable_error_type`:
 /// `map_error_code_to_error_type` checks `code == overload_status_code()`
@@ -502,7 +515,7 @@ impl ErrorMessage {
     pub fn unsupported_content_error<T: Display>(msg: T) -> ErrorResponse {
         tracing::debug!("Unsupported Content error: {msg}");
         let code = StatusCode::BAD_REQUEST;
-        let error_type = map_error_code_to_error_type(code);
+        let error_type = bad_request_error_type();
         (
             code,
             Json(ErrorMessage {
@@ -7609,6 +7622,7 @@ mod tests {
         );
 
         assert_eq!(response.0, StatusCode::BAD_REQUEST);
+        assert_eq!(response.1.error_type, "Bad Request");
         assert_eq!(
             extract_error_type_from_response(&response),
             ErrorType::NotImplemented

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -242,7 +242,7 @@ pub(crate) enum ResponsesConversionError {
     #[error("{0}")]
     InvalidArgument(String),
     #[error("{0}")]
-    NotImplemented(String),
+    UnsupportedContent(String),
 }
 
 /// Convert a Responses API ImageDetail to the Chat Completions ImageDetail.
@@ -299,7 +299,7 @@ fn convert_input_content_to_user_content(
                         .into());
                     }
                     (Some(_), None) => {
-                        return Err(ResponsesConversionError::NotImplemented(
+                        return Err(ResponsesConversionError::UnsupportedContent(
                             "Image input by file_id is not yet supported".to_string(),
                         )
                         .into());
@@ -350,7 +350,7 @@ fn convert_input_content_to_user_content(
                     })?;
                 }
 
-                return Err(ResponsesConversionError::NotImplemented(
+                return Err(ResponsesConversionError::UnsupportedContent(
                     "File input content is not yet supported".to_string(),
                 )
                 .into());

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -476,18 +476,6 @@ async fn anthropic_content_validation_applies_to_messages_and_count_tokens() {
                 ExpectedError::UnsupportedContent,
                 "content block type \"future_block_type\"",
             ),
-            (
-                "/v1/messages/count_tokens",
-                json!({
-                    "model": MODEL,
-                    "messages": [{
-                        "role": "user",
-                        "content": [{"type": "future_block_type", "value": 1}]
-                    }]
-                }),
-                ExpectedError::UnsupportedContent,
-                "content block type \"future_block_type\"",
-            ),
         ] {
             let response = post_json(&svc, path, body).await;
             assert_anthropic_error(response, expected, message).await;

--- a/lib/llm/tests/frontend_protocol_validation_http.rs
+++ b/lib/llm/tests/frontend_protocol_validation_http.rs
@@ -47,6 +47,7 @@ async fn post_json(svc: &HarnessService, path: &str, body: Value) -> reqwest::Re
 enum ExpectedError {
     Validation,
     NotImplemented,
+    UnsupportedContent,
 }
 
 impl ExpectedError {
@@ -54,6 +55,7 @@ impl ExpectedError {
         match self {
             Self::Validation => reqwest::StatusCode::BAD_REQUEST,
             Self::NotImplemented => reqwest::StatusCode::NOT_IMPLEMENTED,
+            Self::UnsupportedContent => reqwest::StatusCode::BAD_REQUEST,
         }
     }
 
@@ -61,6 +63,7 @@ impl ExpectedError {
         match self {
             Self::Validation => "invalid_request_error",
             Self::NotImplemented => "api_error",
+            Self::UnsupportedContent => "invalid_request_error",
         }
     }
 }
@@ -204,7 +207,7 @@ async fn responses_conversion_distinguishes_invalid_from_unsupported() {
             (
                 true,
                 json!({"type": "input_image", "file_id": "file_123"}),
-                ExpectedError::NotImplemented,
+                ExpectedError::UnsupportedContent,
                 "image input by file_id",
             ),
             (
@@ -213,7 +216,7 @@ async fn responses_conversion_distinguishes_invalid_from_unsupported() {
                     "type": "input_file",
                     "file_url": "https://example.com/report.pdf"
                 }),
-                ExpectedError::NotImplemented,
+                ExpectedError::UnsupportedContent,
                 "file input content",
             ),
             (
@@ -470,7 +473,7 @@ async fn anthropic_content_validation_applies_to_messages_and_count_tokens() {
                         ]
                     }]
                 }),
-                ExpectedError::NotImplemented,
+                ExpectedError::UnsupportedContent,
                 "content block type \"future_block_type\"",
             ),
             (
@@ -482,7 +485,7 @@ async fn anthropic_content_validation_applies_to_messages_and_count_tokens() {
                         "content": [{"type": "future_block_type", "value": 1}]
                     }]
                 }),
-                ExpectedError::NotImplemented,
+                ExpectedError::UnsupportedContent,
                 "content block type \"future_block_type\"",
             ),
         ] {


### PR DESCRIPTION
## Overview:

Change Multimodal errors to return 400 instead of 501 for the sake of downstream applications as 5xx status codes are counted as server errors. This means these errors relating to not yet implemented functions are materially affecting SLI/SLOs.

First PR! 👋 Github is reporting email as unverified as I signed it with my CoreWeave email instead of personal.

## Details:

Scoped to just multi-modal errors. Server Tool Type errors still map to 501. Adds a `UnsupportedContent` ErrorType that returns 400 Bad Request. Prometheus labels mapped to `not_implemented` to avoid confusion in dashboards, if not explicitly mapped, will fall back to `Internal` label. Anthropic error type mapped to `invalid_request_error`.

### Live behavior:

```
  -d '{
    "model": "MiniMaxAI/MiniMax-M3",
    "input": [{
      "role": "user",
      "content": [{"type": "input_image", "file_id": "file_123"}]
    }]
  }'
{"message":"Validation: Failed to convert responses request: Image input by file_id is not yet supported","type":"Not Implemented","code":501}
```

## Intended Behavior change:

| Endpoint | Payload | Before | After |
|--------|--------|--------|--------|
| /v1/responses | `input_image` by `file_id` | 501 | 400 |
| /v1/responses | `input_file` | 501 | 400 |
| /v1/messages | unknown block | 501 | 400 |
| /v1/messages/count_tokens | unknown block | 501 | 400 |

## Validation:

```
cargo test -p dynamo-llm --no-default-features --lib http::service
test result: ok. 269 passed; 0 failed; 0 ignored; 0 measured; 1959 filtered out; finished in 0.29s

cargo test -p dynamo-llm --no-default-features --test frontend_protocol_validation_http
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
```

## Where should the reviewer start?

`openai.rs`

## Related Issues

Relates to: https://github.com/ai-dynamo/dynamo/pull/12809 

**🚫 This PR is NOT linked to an issue**:
- [x ] Confirmed — no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unsupported image, file, and content block inputs now return clear HTTP 400 validation errors.
  * Anthropic requests report these issues as `invalid_request_error` responses.
  * Error classifications are now consistent across supported API protocols.
  * Added regression coverage to verify status codes and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->