### PR TITLE
docs(sglang): name SGLang, not TensorRT-LLM, for MAX_TOTAL_TOKENS

### DIFF
--- a/docs/fern/pages/recipes/cli-templates/sglang.mdx
+++ b/docs/fern/pages/recipes/cli-templates/sglang.mdx
@@ -253,7 +253,7 @@ The default model is `Qwen/Qwen3-0.6B`.
 | --- | --- | --- |
 | `CONTEXT_LENGTH` | `4096` | Context length configured for the model. |
 | `MAX_RUNNING_REQUESTS` | `2` | Maximum number of requests run concurrently. |
-| `MAX_TOTAL_TOKENS` | `25000` | TensorRT-LLM KV-cache token capacity per worker. |
+| `MAX_TOTAL_TOKENS` | `25000` | SGLang KV-cache token capacity per worker. |
 | `CUDA_VISIBLE_DEVICES` | `0` | GPU devices visible to the launched worker processes. |
 | `DYN_DISAGG_BOOTSTRAP_PORT` | `12345` | Bootstrap port used to establish disaggregated worker connections. |
 | `DYN_HTTP_PORT` | `8000` | HTTP port exposed by the Dynamo frontend. |


### PR DESCRIPTION
## Summary

The SGLang CLI-template page describes `MAX_TOTAL_TOKENS` as a TensorRT-LLM setting:

```
| `MAX_TOTAL_TOKENS` | `25000` | TensorRT-LLM KV-cache token capacity per worker. |
```

That row documents the "Prefill and Decode on One GPU" template, which is `examples/backends/sglang/launch/disagg_same_gpu.sh`, and the variable is fed to SGLang's own flag there:

```bash
MAX_TOTAL_TOKENS="${MAX_TOTAL_TOKENS:-25000}"
GPU_MEM_ARGS="--max-total-tokens $MAX_TOTAL_TOKENS"
```

The identical row on the TensorRT-LLM template page is correct, so this reads as a copy between pages. Only the backend name was wrong: the variable name, the `25000` default and the description of what it does all match the script.

Small, but a reader tuning an SGLang deployment is told the knob belongs to a different engine, and the docs guide calls out backend naming specifically.

## Validation

Documentation only, one line.

- Confirmed on current `main` (`bbb5885773`) that the row still reads TensorRT-LLM and that `disagg_same_gpu.sh:66` still passes `--max-total-tokens`.
- Checked the rest of that table against the script rather than fixing one row and leaving others wrong: all nine variables it lists are genuinely referenced by `disagg_same_gpu.sh`, and the two rows documented as `Empty` are accurate, because the script guards them (`if [[ -n "${DYN_CHAT_PROCESSOR:-}" ]]`) and passes the flag only when set.
- Swept all three CLI-template pages for other cross-backend descriptions. This was the only one: `vllm.mdx` has no foreign-backend mentions, and the TensorRT-LLM page's occurrence is correct in context.
- `pre-commit run --files docs/fern/pages/recipes/cli-templates/sglang.mdx` passes every applicable hook including the Fern asset-path check. `pytest-marker-report` fails identically on an untouched `README.md` here because vLLM and TensorRT-LLM are not installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `MAX_TOTAL_TOKENS` description for single-GPU disaggregated SGLang deployments to use accurate SGLang terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->