### PR TITLE
fix(container): patch vLLM 0.26.0 DSpark rejection sampler and FlashMLA empty prefill chunks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -962,7 +962,6 @@ jobs:
     with:
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]' # Deploy tests only use CUDA 13
-      override_arch: amd64 # We are using AMD64 images only on the rest of the clusters.
       copy_timeout_minutes: 10
     secrets: inherit
 

--- a/container/deps/vllm/patches/01-dspark-rejection-sampler-nan-oob.patch
+++ b/container/deps/vllm/patches/01-dspark-rejection-sampler-nan-oob.patch
@@ -1,0 +1,106 @@
+--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
++++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+@@ -108,7 +108,12 @@
+         mask=blocks_mask,
+         other=float("-inf"),
+     )
++    # PR #50183: NaN local maxes make tl.argmax return an out-of-range block
++    # index (into the padded region), causing an OOB read. Map NaN to -inf
++    # and clamp the block index so it stays in range.
++    local_max = tl.where(local_max != local_max, float("-inf"), local_max)
+     max_block_idx = tl.argmax(local_max, axis=0)
++    max_block_idx = tl.minimum(max_block_idx, vocab_num_blocks - 1)
+     return tl.load(
+         target_local_argmax_ptr + logit_idx * target_local_argmax_stride + max_block_idx
+     ).to(tl.int64)
+@@ -508,6 +513,7 @@
+     # [num_logits, num_blocks]
+     local_residual_mass_ptr,
+     local_residual_mass_stride,
++    vocab_size,
+     vocab_num_blocks,
+     PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+     HAS_DRAFT_LOGITS: tl.constexpr,
+@@ -573,6 +579,13 @@
+                     logit_idx,
+                     vocab_num_blocks,
+                     PADDED_VOCAB_NUM_BLOCKS,
++                )
++                # Issue #53029: bounds-validate before the store so an OOB
++                # token id can never escape into the sampled buffer.
++                target_argmax = tl.where(
++                    (target_argmax < 0) | (target_argmax >= vocab_size),
++                    0,
++                    target_argmax,
+                 )
+                 if SYNTHETIC_MODE:
+                     rate = tl.load(synthetic_conditional_rates_ptr + i)
+@@ -822,6 +835,7 @@
+     expanded_idx_mapping_ptr,
+     # [max_num_reqs]
+     temp_ptr,
++    vocab_size,
+     PADDED_RESAMPLE_NUM_BLOCKS: tl.constexpr,
+ ):
+     req_idx = tl.program_id(0)
+@@ -848,13 +862,33 @@
+         resampled_local_max_ptr + req_idx * resampled_local_max_stride + block,
+         mask=mask,
+         other=float("-inf"),
++    )
++    # PR #50183: NaN max values (from NaN target logits) make tl.argmax
++    # return an out-of-range block index (into the padded region), causing
++    # an OOB read of resampled_local_argmax. Map NaN to -inf and clamp the
++    # block index so argmax stays in range.
++    resampled_local_max = tl.where(
++        resampled_local_max != resampled_local_max,
++        float("-inf"),
++        resampled_local_max,
+     )
+     resampled_max_block_idx = tl.argmax(resampled_local_max, axis=0)
++    resampled_max_block_idx = tl.minimum(
++        resampled_max_block_idx, resample_num_blocks - 1
++    )
+     resampled = tl.load(
+         resampled_local_argmax_ptr
+         + req_idx * resampled_local_argmax_stride
+         + resampled_max_block_idx,
+     )
++    # Issue #53029: the resample path can produce token id == vocab_size
++    # (or other OOB ids). Bounds-validate at the store and substitute a
++    # valid fallback token (0) so downstream index_select cannot assert.
++    resampled = tl.where(
++        (resampled < 0) | (resampled >= vocab_size),
++        0,
++        resampled,
++    )
+     tl.store(
+         sampled_ptr + req_idx * sampled_stride + num_sampled,
+         resampled,
+@@ -888,6 +922,10 @@
+     use_fp64: bool = False,
+     use_block_verification: bool = False,
+ ) -> tuple[torch.Tensor, torch.Tensor]:
++    assert target_logits.ndim == 2 and target_logits.stride(-1) == 1
++    assert draft_logits is None or (
++        draft_logits.ndim == 3 and draft_logits.stride(-1) == 1
++    )
+     num_reqs = cu_num_logits.shape[0] - 1
+     num_logits, vocab_size = target_logits.shape
+     draft_logits_stride_0 = 0
+@@ -1060,6 +1098,7 @@
+         cumulative_log_p,
+         local_residual_mass,
+         local_residual_mass.stride(0) if local_residual_mass is not None else 0,
++        vocab_size,
+         vocab_num_blocks,
+         PADDED_VOCAB_NUM_BLOCKS=padded_vocab_num_blocks,
+         HAS_DRAFT_LOGITS=has_draft_logits,
+@@ -1120,6 +1159,7 @@
+         cu_num_logits,
+         expanded_idx_mapping,
+         temperature,
++        vocab_size,
+         PADDED_RESAMPLE_NUM_BLOCKS=padded_resample_num_blocks,
+     )
+     return sampled, num_sampled

--- a/container/deps/vllm/patches/02-flashmla-skip-empty-prefill-chunks.patch
+++ b/container/deps/vllm/patches/02-flashmla-skip-empty-prefill-chunks.patch
@@ -1,0 +1,15 @@
+--- a/vllm/models/deepseek_v4/nvidia/flashmla.py
++++ b/vllm/models/deepseek_v4/nvidia/flashmla.py
+@@ -322,6 +322,12 @@
+             query_end = (
+                 query_start_loc_cpu[num_decodes + chunk_end] - prefill_token_base
+             )
++            # vLLM PR #49961 / issue #49922: a fully cached request enters
++            # prefill with query_len == 0. The empty chunk builds a degenerate
++            # TMA descriptor (gmem_address=0) and FlashMLA sparse_prefill_fwd
++            # asserts. Skip the chunk; it has no tokens to process.
++            if query_start == query_end:
++                continue
+ 
+             combined_indices, combined_lens = combine_topk_swa_indices(
+                 topk_indices[query_start:query_end],

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -246,6 +246,23 @@ RUN --mount=type=bind,source=./container/deps/vllm/protected_packages.txt,target
     export VLLM_OMNI_TARGET_DEVICE={{ device }}; \
     bash /tmp/install_vllm_omni.sh
 
+{% if device == "cuda" %}
+# Apply vLLM hotfixes to the installed package tree. A failed patch must fail
+# the build: without set -e a for-loop only reports the last iteration status,
+# so a silently unpatched image could ship. The greps assert the patched text
+# is actually present and that no rejects were produced.
+RUN --mount=type=bind,source=./container/deps/vllm/patches,target=/tmp/vllm_patches,readonly \
+    set -eu && \
+    SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])')" && \
+    for p in /tmp/vllm_patches/*.patch; do \
+        echo "applying $(basename "$p")"; \
+        patch --fuzz=5 -p1 -d "${SITE_PACKAGES}" < "$p"; \
+    done && \
+    grep -q 'local_max != local_max' "${SITE_PACKAGES}/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py" && \
+    grep -q 'if query_start == query_end' "${SITE_PACKAGES}/vllm/models/deepseek_v4/nvidia/flashmla.py" && \
+    ! find "${SITE_PACKAGES}" -name '*.rej' | grep -q .
+{% endif %}
+
 {% if device == "xpu" %}
 # Remove conflicting standard triton package for XPU and reinstall triton-xpu
 # This must be done after vLLM-Omni installation to ensure no dependencies re-install triton


### PR DESCRIPTION
Adds two vLLM hotfixes to the 1.4.0 runtime image (vLLM v0.26.0), plus the patch-application step in the vLLM runtime Dockerfile.

## Patches

**`01-dspark-rejection-sampler-nan-oob.patch`** — same patch as `e3ca1b40` (PR #13616), which applied it to 0.27.1. Upstream vllm-project/vllm#50183 NaN guards plus #53029 clamp-at-store. DSpark speculative decoding with real rejection sampling kills the engine after roughly 25 minutes without these.

**`02-flashmla-skip-empty-prefill-chunks.patch`** — upstream vllm-project/vllm#49961, for issue #49922. A fully cached request enters prefill with `query_len == 0`. The empty chunk builds a degenerate TMA descriptor (`gmem_address=0`) and FlashMLA `sparse_prefill_fwd` asserts:

```
Assertion `res == CUresult::CUDA_SUCCESS` failed
  .../flashmla-src/csrc/sm100/prefill/sparse/fwd/head64/phase1.cuh:651
  flash_mla_sparse_fwd -> flash_mla_cuda.sparse_prefill_fwd
```

The guard skips the chunk, which has no tokens to process. Issue #49922 is a v0.26.0 regression from v0.25.0, confirmed by a third party on sm103/B300, and is still open — the fix never landed in 0.26.0.

## Why

On GB200, DeepSeek-V4-Pro-0813 scores measurably higher on vLLM 0.26.0 than on 0.27.x. Measured with the same `nemo-evaluator ns_gpqa` harness, pass@1 avg-of-4, raw upstream TP8:

| vLLM | pass@1 | no_answer |
|---|---|---|
| 0.26.0 | 88.26 | 5.05% |
| 0.27.0 | 84.47 | 8.59% |
| 0.27.1 | 81.94 | 10.98% |

0.26.0 is 6.3 pt better, but currently unusable with our recipe because of the FlashMLA assert. These two patches are what a 0.26.0-based image needs to run it.

## Notes

- No `context.yaml` change: `release/1.4.0` already pins vLLM 0.26.0 with a version-matched `vllm_omni_ref: v0.26.0rc1`.
- The Dockerfile hunk is the same mechanism already on `main` (from `7648332c`) — applies `patches/*.patch` in sorted order with `--fuzz=5`.
- Both patches verified to apply cleanly against vLLM v0.26.0 sources (`patch --dry-run`, no fuzz, no rejects).
- Draft: needs a CI image build to validate, then a GPQA and mooncake run on GB200 agg and disagg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inference stability by handling invalid numerical values and out-of-range token indices safely.
  * Prevented failures when processing requests with empty prefill sections.
  * Added validation for logits dimensions and memory layout.

* **Maintenance**
  * Updated runtime images to the 0.26.0 vLLM release line across supported hardware targets.
  * Applied runtime compatibility fixes automatically during CUDA image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->