### PR TITLE
fix: Fix import of sglang server_args_config_parser.

### DIFF
--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -26,6 +26,15 @@ from collections.abc import Mapping
 from functools import lru_cache, wraps
 from typing import Any
 
+try:
+    from sglang.srt.utils.server_args_config_parser import ConfigArgumentMerger
+except ImportError:
+    # Fallback for sglang <= 0.5.18. Remove when min supported version includes
+    # the srt/utils move (sgl-project/sglang#36681).
+    from sglang.srt.server_args_config_parser import (  # type: ignore[no-redef]
+        ConfigArgumentMerger,
+    )
+
 logger = logging.getLogger(__name__)
 
 
@@ -177,6 +186,7 @@ def require_reasoning_kwargs(engine: Any, request: Mapping[str, Any]) -> dict[st
 
 
 __all__ = [
+    "ConfigArgumentMerger",
     "ensure_sglang_tensor_image_size",
     "filter_supported_async_generate_kwargs",
     "override_server_args",

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, Generator, Optional
 
 import yaml
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.server_args_config_parser import ConfigArgumentMerger
 
 from dynamo.common.config_dump import register_encoder
 from dynamo.common.configuration.groups import DynamoRuntimeConfig
@@ -34,7 +33,7 @@ from dynamo.common.snapshot.lifecycle import (
 )
 from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.runtime.logging import configure_dynamo_logging
-from dynamo.sglang._compat import ensure_sglang_tensor_image_size
+from dynamo.sglang._compat import ConfigArgumentMerger, ensure_sglang_tensor_image_size
 from dynamo.sglang.backend_args import DynamoSGLangArgGroup, DynamoSGLangConfig
 
 configure_dynamo_logging()

--- a/tests/report_pytest_markers.py
+++ b/tests/report_pytest_markers.py
@@ -180,6 +180,7 @@ STUB_MODULES = [
     "sglang.srt.utils",
     "sglang.srt.utils.hf_transformers_utils",
     "sglang.srt.utils.network",
+    "sglang.srt.utils.server_args_config_parser",
     "sglang.srt.utils.video_decoder",
     "sglang.srt.disaggregation",
     "sglang.srt.disaggregation.kv_events",


### PR DESCRIPTION
## Overview:

https://github.com/sgl-project/sglang/pull/36681 moved `server_args_config_parser.py` under `sglang.srt.utils`, so the current import in dynamo fails with the below error:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/sglang/lib/python3.12/site-packages/dynamo/sglang/__main__.py", line 16, in <module>
    from dynamo.sglang.main import main
  File "/opt/sglang/lib/python3.12/site-packages/dynamo/sglang/main.py", line 19, in <module>
    from dynamo.sglang.args import parse_args
  File "/opt/sglang/lib/python3.12/site-packages/dynamo/sglang/args.py", line 18, in <module>
    from sglang.srt.server_args_config_parser import ConfigArgumentMerger
ModuleNotFoundError: No module named 'sglang.srt.server_args_config_parser'
```

## Details:

Add a compatability shim for the import

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with multiple SGLang versions by supporting both current and legacy configuration parser locations.
  - Prevented marker-only test collection from failing when optional SGLang modules are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->