### PR TITLE
fix(sglang): backport config parser compatibility

### DIFF
--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -34,6 +34,21 @@ except ImportError:
     # Fallback for SGLang <= 0.5.17. Remove when min supported version is 0.5.18+.
     from sglang.srt.server_args_config_parser import ConfigArgumentMerger
 
+try:
+    from sglang.srt.arg_groups.overrides import model_config_of as _model_config_of
+except ImportError:
+    _model_config_of = None
+
+
+def get_sglang_model_config(server_args: Any) -> Any:
+    """Return the resolved model config across SGLang ServerArgs APIs."""
+    legacy_getter = getattr(server_args, "get_model_config", None)
+    if legacy_getter is not None:
+        return legacy_getter()
+    if _model_config_of is None:
+        raise AttributeError("SGLang does not expose a model config accessor")
+    return _model_config_of(server_args)
+
 
 @lru_cache(maxsize=1)
 def _warn_require_reasoning_unsupported() -> None:

--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -28,6 +28,12 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+try:
+    from sglang.srt.utils.server_args_config_parser import ConfigArgumentMerger
+except ImportError:
+    # Fallback for SGLang <= 0.5.17. Remove when min supported version is 0.5.18+.
+    from sglang.srt.server_args_config_parser import ConfigArgumentMerger
+
 
 @lru_cache(maxsize=1)
 def _warn_require_reasoning_unsupported() -> None:
@@ -174,6 +180,7 @@ def require_reasoning_kwargs(engine: Any, request: Mapping[str, Any]) -> dict[st
 
 
 __all__ = [
+    "ConfigArgumentMerger",
     "ensure_sglang_tensor_image_size",
     "ensure_sglang_top_level_exports",
     "filter_supported_async_generate_kwargs",

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, Generator, Optional
 
 import yaml
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.server_args_config_parser import ConfigArgumentMerger
 
 from dynamo.common.config_dump import register_encoder
 from dynamo.common.configuration.groups import DynamoRuntimeConfig
@@ -29,7 +28,7 @@ from dynamo.common.snapshot.lifecycle import (
 )
 from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.runtime.logging import configure_dynamo_logging
-from dynamo.sglang._compat import ensure_sglang_tensor_image_size
+from dynamo.sglang._compat import ConfigArgumentMerger, ensure_sglang_tensor_image_size
 from dynamo.sglang.backend_args import DynamoSGLangArgGroup, DynamoSGLangConfig
 
 configure_dynamo_logging()

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -28,7 +28,11 @@ from dynamo.common.snapshot.lifecycle import (
 )
 from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.runtime.logging import configure_dynamo_logging
-from dynamo.sglang._compat import ConfigArgumentMerger, ensure_sglang_tensor_image_size
+from dynamo.sglang._compat import (
+    ConfigArgumentMerger,
+    ensure_sglang_tensor_image_size,
+    get_sglang_model_config,
+)
 from dynamo.sglang.backend_args import DynamoSGLangArgGroup, DynamoSGLangConfig
 
 configure_dynamo_logging()
@@ -555,7 +559,7 @@ async def parse_args(args: list[str]) -> Config:
         # Dynamo expects disjoint output_ids; ServerArgs is read-only after resolution.
         parsed_args.incremental_streaming_output = True
         server_args = ServerArgs.from_cli_args(parsed_args)
-        if server_args.get_model_config().is_multimodal:
+        if get_sglang_model_config(server_args).is_multimodal:
             ensure_sglang_tensor_image_size()
 
     if getattr(server_args, "schedule_low_priority_values_first", False):

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -23,6 +23,7 @@ from dynamo.sglang._compat import (
     ensure_sglang_tensor_image_size,
     ensure_sglang_top_level_exports,
     filter_supported_async_generate_kwargs,
+    get_sglang_model_config,
     require_reasoning_kwargs,
 )
 from dynamo.sglang.args import (
@@ -151,6 +152,30 @@ def test_compat_restores_sglang_top_level_exports():
                 delattr(sgl, "ServerArgs")
         else:
             sgl.ServerArgs = original_server_args
+
+
+def test_compat_uses_current_sglang_model_config_accessor(monkeypatch):
+    expected = SimpleNamespace(is_multimodal=True)
+    server_args = SimpleNamespace()
+    monkeypatch.setattr(
+        sglang_compat,
+        "_model_config_of",
+        lambda value: expected if value is server_args else None,
+    )
+
+    assert get_sglang_model_config(server_args) is expected
+
+
+def test_compat_uses_legacy_sglang_model_config_accessor(monkeypatch):
+    expected = SimpleNamespace(is_multimodal=False)
+    server_args = SimpleNamespace(get_model_config=lambda: expected)
+    monkeypatch.setattr(
+        sglang_compat,
+        "_model_config_of",
+        lambda _: pytest.fail("current accessor should not run for legacy ServerArgs"),
+    )
+
+    assert get_sglang_model_config(server_args) is expected
 
 
 def test_compat_supports_tensor_image_sizes_and_is_idempotent(caplog, monkeypatch):


### PR DESCRIPTION
## Summary

- prefer the relocated `sglang.srt.utils.server_args_config_parser` import used by current SGLang nightly builds while retaining the legacy fallback
- use the current `model_config_of` accessor when available while retaining the legacy `get_model_config` fallback
- keep both compatibility boundaries in `dynamo.sglang._compat`

This is a narrow `release/1.4.2` backport for current SGLang nightly containers. It does not pull in the newer `main` dependency set.

## Validation

- targeted dual-path harnesses for both import and model-config accessor compatibility on Python 3.12
- `uvx pre-commit run --files components/src/dynamo/sglang/_compat.py components/src/dynamo/sglang/args.py components/src/dynamo/sglang/engine.py`
- `python3 -m py_compile components/src/dynamo/sglang/_compat.py components/src/dynamo/sglang/args.py components/src/dynamo/sglang/engine.py`
- exact `lmsysorg/sglang:nightly-dev-cu13-20260831-bb5e6198` source-install validation with PP-prefill + disaggregation + MTP reached SGLang engine initialization for all 3 prefill and 2 decode workers without a Dynamo import/accessor failure
- a code-identical pre-signoff tree completed a 900-second 3P2D AgentX canary with 25,515 profiled requests and zero request errors; the submitted head differs only by the missing DCO sign-off metadata
- InferenceMAX PR [NVIDIA/InferenceMAX#258](https://github.com/NVIDIA/InferenceMAX/pull/258) pins this exact head for its two PP AgentX points

Related current-main PR: #14054
