### PR TITLE
docs: align platform install release example

### DIFF
--- a/docs/fern/pages/kubernetes/installation/install-dynamo.md
+++ b/docs/fern/pages/kubernetes/installation/install-dynamo.md
@@ -121,11 +121,13 @@ For a complete deployment, see [Deploy on Intel GPUs with DRA](../model-deployme
 
 <Step title="Install the Dynamo Platform">
 
-Set your environment variables:
+Set `RELEASE_VERSION` to the Dynamo release you plan to install. The following example matches the
+current [Kubernetes Quickstart](../getting-started/quickstart.mdx). See
+[Release Artifacts](../../reference/general/release-artifacts.mdx) for the available versions.
 
 ```bash
 export NAMESPACE=dynamo-system
-export RELEASE_VERSION=1.2.1  # match a version from https://github.com/ai-dynamo/dynamo/releases
+export RELEASE_VERSION=1.4.1
 ```
 
 ```bash


### PR DESCRIPTION
## Summary

Align the Kubernetes Installation Guide's platform release example with the current Quickstart and point readers to the release inventory before installation.

## Overview

The Kubernetes Installation Guide pins `RELEASE_VERSION=1.2.1`, while the current Kubernetes Quickstart selects Dynamo 1.4.1. This change aligns the installation example with the current Quickstart and directs readers to the release inventory before they install the platform chart.

## Details

- Change the example platform release from 1.2.1 to 1.4.1.
- Explain that readers should choose the Dynamo release they intend to install.
- Link the Kubernetes Quickstart and Release Artifacts pages instead of leaving version discovery in an inline shell comment.

## Validation

- `git diff --check origin/main...HEAD`
- `python3 docs/fern/scripts/check_component_imports.py`
- Full `fern check` and `fern docs broken-links` were not run because the Fern CLI is not installed locally.

## Where should the reviewer start?

Review the `Install the Dynamo Platform` step in `docs/fern/pages/kubernetes/installation/install-dynamo.md`, especially the release-selection text and `RELEASE_VERSION` example.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
