### PR TITLE
docs: fix Qwen recipe quickstart link

### DIFF
--- a/docs/fern/pages/recipes/model-recipes/qwen-3-8-2-4t-a95b-fp8.mdx
+++ b/docs/fern/pages/recipes/model-recipes/qwen-3-8-2-4t-a95b-fp8.mdx
@@ -81,7 +81,7 @@ Each target below is a Dynamo + vLLM or SGLang deployment of [Qwen3.8-2.4T-A95B]
 
 <div data-sku="gb300">
 
-- A Kubernetes cluster with the Dynamo platform installed and GB300 GPUs available — 16x (4 nodes). See the [Kubernetes Deployment Guide](../kubernetes/quickstart.mdx).
+- A Kubernetes cluster with the Dynamo platform installed and GB300 GPUs available — 16x (4 nodes). See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - The NVIDIA DRA driver with ComputeDomain support installed (required for multi-node NVLink).
 - A Hugging Face token with access to `Qwen/Qwen3.8-2.4T-A95B-FP8`.
 
@@ -89,7 +89,7 @@ Each target below is a Dynamo + vLLM or SGLang deployment of [Qwen3.8-2.4T-A95B]
 
 <div data-sku="gb200">
 
-- A Kubernetes cluster with the Dynamo platform installed and GB200 GPUs available — 16x (4 nodes) for aggregated; 48x (12 nodes, 2×4 prefill + 4 decode) for 2P1D disaggregated. See the [Kubernetes Deployment Guide](../kubernetes/quickstart.mdx).
+- A Kubernetes cluster with the Dynamo platform installed and GB200 GPUs available — 16x (4 nodes) for aggregated; 48x (12 nodes, 2×4 prefill + 4 decode) for 2P1D disaggregated. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - The NVIDIA DRA driver with ComputeDomain support installed (required for multi-node NVLink).
 - A Hugging Face token with access to `Qwen/Qwen3.8-2.4T-A95B-FP8`.
 - The `model-cache` PVC, populated by the model-download Job (see step 3 below).


### PR DESCRIPTION
## Summary

Repair the two broken Kubernetes Quickstart links in the Qwen3.8-2.4T-A95B recipe prerequisites.

## Overview

The Qwen3.8-2.4T-A95B recipe links both GB300 and GB200 prerequisite readers to a nonexistent Kubernetes Quickstart path. This change corrects both relative links to the current Quickstart source page.

## Details

- Update the GB300 prerequisite link from `../kubernetes/quickstart.mdx` to `../../kubernetes/getting-started/quickstart.mdx`.
- Apply the same correction to the GB200 prerequisite link.
- Leave the recipe content and deployment assets unchanged.

## Validation

- Confirmed `docs/fern/pages/kubernetes/getting-started/quickstart.mdx` exists.
- `git diff --check origin/main...HEAD`
- `python3 docs/fern/scripts/check_component_imports.py`
- `python3 docs/fern/pages/recipes/_catalog/validate.py`
- Full `fern check` and `fern docs broken-links` were not run because the Fern CLI is not installed locally.

## Where should the reviewer start?

Review the two `Kubernetes Deployment Guide` links under `## Prerequisites` in `docs/fern/pages/recipes/model-recipes/qwen-3-8-2-4t-a95b-fp8.mdx`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
