### PR TITLE
docs: document supported kubectl version skew

### DIFF
--- a/docs/fern/pages/kubernetes/getting-started/quickstart.mdx
+++ b/docs/fern/pages/kubernetes/getting-started/quickstart.mdx
@@ -19,7 +19,8 @@ follow that tab throughout the guide. The Intel GPU path uses the XPU runtime an
         You need:
 
         - A Kubernetes v1.30 or later cluster with NVIDIA GPU nodes
-        - `kubectl` v1.30 or later configured for the cluster
+        - `kubectl` v1.30 or later, configured for the cluster and within one minor version of the
+          Kubernetes API server according to the [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/#kubectl)
         - Helm v3 or later
       </Tab>
       <Tab title="Intel GPU">
@@ -32,6 +33,11 @@ follow that tab throughout the guide. The Intel GPU path uses the XPU runtime an
         - A local clone of the Dynamo repository
       </Tab>
     </Tabs>
+
+```bash
+kubectl version
+helm version
+```
   </Step>
 
   <Step title="Install accelerator support">

--- a/docs/fern/pages/kubernetes/installation/install-dynamo.md
+++ b/docs/fern/pages/kubernetes/installation/install-dynamo.md
@@ -18,7 +18,8 @@ cluster:
 - A Kubernetes 1.30 or later cluster with NVIDIA GPU nodes. See the cloud provider guides if you need to create one:
   - [Amazon EKS](managed-kubernetes/eks/eks-setup.mdx) | [Azure AKS](managed-kubernetes/azure/aks-setup.mdx) | [Google GKE](managed-kubernetes/gcp/gke-setup.mdx)
   - For local development: [Minikube Setup](../../cli/installation/minikube-setup.mdx)
-- `kubectl` 1.30 or later.
+- `kubectl` 1.30 or later and within one minor version of the Kubernetes API server, as required by
+  the [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/#kubectl).
 
 > [!IMPORTANT]
 > The GPU Operator in the first installation step can install NVIDIA drivers. Do not also enable
@@ -39,10 +40,10 @@ cluster:
 </Tab>
 </Tabs>
 
-Verify the client tools:
+Verify the client tools and the Kubernetes API server version:
 
 ```bash
-kubectl version --client
+kubectl version
 helm version
 ```
 


### PR DESCRIPTION
## Summary

Document Kubernetes' supported `kubectl` client/server version skew and make both installation entry points display the API server version during verification.

## Overview

The NVIDIA GPU prerequisite currently accepts any `kubectl` version at or above 1.30. That allows unsupported client/server combinations to pass the documented gate. This change adds the upstream Kubernetes version-skew requirement and makes both entry points display the API server version during verification.

## Details

- Require the NVIDIA GPU path's `kubectl` client to be within one minor version of the Kubernetes API server.
- Link the upstream Kubernetes version-skew policy.
- Run `kubectl version` instead of `kubectl version --client` in the Installation Guide.
- Add the same client/server verification commands to the Kubernetes Quickstart.
- Preserve the stricter exact-minor requirement already documented for Intel GPU clusters.

## Validation

- Reproduced the gap with a v1.32.2 client and v1.34.9 API server: the current `>=1.30` text passes, while `kubectl version` reports unsupported skew.
- Verified a v1.34.9 client against the same v1.34.9 API server.
- `git diff --check origin/main...HEAD`
- `python3 docs/fern/scripts/check_component_imports.py`
- Full `fern check` and `fern docs broken-links` were not run because the Fern CLI is not installed locally.

## Where should the reviewer start?

Start with the NVIDIA GPU prerequisite list and verification command in `docs/fern/pages/kubernetes/getting-started/quickstart.mdx`, then compare the matching changes in `docs/fern/pages/kubernetes/installation/install-dynamo.md`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
