### PR TITLE
docs: verify pull request handoffs

### DIFF
--- a/.agents/skills/dynamo-docs/SKILL.md
+++ b/.agents/skills/dynamo-docs/SKILL.md
@@ -414,10 +414,12 @@ when the user has requested or authorized the external contribution.
      --json url,state,isDraft,body,baseRefName,headRefName,headRefOid
    ```
 
-   Confirm that `state` is `OPEN`, the URL contains `/pull/<number>`, the base, head branch, and commit
-   are the intended ones, and the body contains no template placeholders before handing it off. If the
-   PR is closed, reopen it when appropriate or create a new PR; if it is merged, create a new PR for
-   remaining changes or report that no active PR exists. Never present an inactive PR as reviewable.
+   Confirm that `state` is `OPEN`, `isDraft` matches the intended draft or ready-for-review state, the
+   URL contains `/pull/<number>`, and the base, head branch, and commit are the intended ones. Confirm
+   that the submitted body contains explicit `Summary` and `Validation` sections, every other
+   applicable template section, and no template placeholders. If the PR is closed, reopen it when
+   appropriate or create a new PR; if it is merged, create a new PR for remaining changes or report
+   that no active PR exists. Never present an inactive PR as reviewable.
 5. Report the PR's actual review and check state. Use the `pr-monitor` skill when CI diagnosis or
    continued monitoring is requested.
 

--- a/.agents/skills/dynamo-docs/SKILL.md
+++ b/.agents/skills/dynamo-docs/SKILL.md
@@ -393,6 +393,25 @@ git add docs/ docs/fern/docs.yml          # also recipes/ examples/ docs/fern/ma
 git commit -s -m "docs: <add|update|move|remove> <page-title>"
 ```
 
+## Pull Request Handoff
+
+Creating or handing off a pull request is separate from committing and pushing a branch. Do it only
+when the user has requested or authorized the external contribution.
+
+1. Read the root `AGENTS.md` pull-request conventions and the current
+   `.github/pull_request_template.md`; treat the repository template as authoritative for the body.
+2. Confirm whether a pull-request object exists for the head branch. A pushed branch and a
+   `/pull/new/<branch>` URL are not pull requests; never report either one as a created PR.
+3. When creating or updating the PR, complete every applicable template section, remove instructional
+   comments and unused alternatives, report the validation actually run and its limitations, and do
+   not invent a related issue.
+4. Verify the submitted PR with `gh pr view` (including `url`, `state`, `isDraft`, `body`,
+   `headRefName`, and `headRefOid`). Confirm that the URL contains `/pull/<number>`, the head branch
+   and commit are the intended ones, and the body contains no template placeholders before handing it
+   off.
+5. Report the PR's actual review and check state. Use the `pr-monitor` skill when CI diagnosis or
+   continued monitoring is requested.
+
 ## Debugging
 
 | Symptom | Fix |

--- a/.agents/skills/dynamo-docs/SKILL.md
+++ b/.agents/skills/dynamo-docs/SKILL.md
@@ -401,16 +401,18 @@ when the user has requested or authorized the external contribution.
 1. Read the root `AGENTS.md` pull-request conventions and the current
    `.github/pull_request_template.md`; satisfy both. Repository-wide requirements remain mandatory
    when the template omits them.
-2. Confirm whether a pull-request object exists for the head branch. A pushed branch and a
+2. Confirm whether an active pull-request object exists for the head branch. A pushed branch and a
    `/pull/new/<branch>` URL are not pull requests; never report either one as a created PR.
 3. When creating or updating the PR, complete every applicable template section and include explicit
    `Summary` and `Validation` sections as required by the root `AGENTS.md`; do not assume `Overview`
    substitutes for `Summary`. Remove instructional comments and unused alternatives, report the
    validation actually run and its limitations, and do not invent a related issue.
 4. Verify the submitted PR with `gh pr view` (including `url`, `state`, `isDraft`, `body`,
-   `headRefName`, and `headRefOid`). Confirm that the URL contains `/pull/<number>`, the head branch
-   and commit are the intended ones, and the body contains no template placeholders before handing it
-   off.
+   `baseRefName`, `headRefName`, and `headRefOid`). Confirm that `state` is `OPEN`, the URL contains
+   `/pull/<number>`, the base, head branch, and commit are the intended ones, and the body contains no
+   template placeholders before handing it off. If the PR is closed, reopen it when appropriate or
+   create a new PR; if it is merged, create a new PR for remaining changes or report that no active PR
+   exists. Never present an inactive PR as reviewable.
 5. Report the PR's actual review and check state. Use the `pr-monitor` skill when CI diagnosis or
    continued monitoring is requested.
 

--- a/.agents/skills/dynamo-docs/SKILL.md
+++ b/.agents/skills/dynamo-docs/SKILL.md
@@ -411,7 +411,7 @@ when the user has requested or authorized the external contribution.
 
    ```bash
    gh pr view <number-or-branch> --repo ai-dynamo/dynamo \
-     --json url,state,isDraft,body,baseRefName,headRefName,headRefOid
+     --json url,state,isDraft,body,baseRefName,headRefName,headRefOid,reviewDecision
    ```
 
    Confirm that `state` is `OPEN`, `isDraft` matches the intended draft or ready-for-review state, the
@@ -420,8 +420,16 @@ when the user has requested or authorized the external contribution.
    applicable template section, and no template placeholders. If the PR is closed, reopen it when
    appropriate or create a new PR; if it is merged, create a new PR for remaining changes or report
    that no active PR exists. Never present an inactive PR as reviewable.
-5. Report the PR's actual review and check state. Use the `pr-monitor` skill when CI diagnosis or
-   continued monitoring is requested.
+5. Query the submitted PR's current checks:
+
+   ```bash
+   gh pr checks <number-or-branch> --repo ai-dynamo/dynamo
+   ```
+
+   Report the `reviewDecision` from step 4 and the current check states from this command.
+   `gh pr checks` exits nonzero when checks are pending or failing; treat that as state to report,
+   not as a query failure. Use the `pr-monitor` skill when CI diagnosis or continued monitoring is
+   requested.
 
 ## Debugging
 

--- a/.agents/skills/dynamo-docs/SKILL.md
+++ b/.agents/skills/dynamo-docs/SKILL.md
@@ -399,12 +399,14 @@ Creating or handing off a pull request is separate from committing and pushing a
 when the user has requested or authorized the external contribution.
 
 1. Read the root `AGENTS.md` pull-request conventions and the current
-   `.github/pull_request_template.md`; treat the repository template as authoritative for the body.
+   `.github/pull_request_template.md`; satisfy both. Repository-wide requirements remain mandatory
+   when the template omits them.
 2. Confirm whether a pull-request object exists for the head branch. A pushed branch and a
    `/pull/new/<branch>` URL are not pull requests; never report either one as a created PR.
-3. When creating or updating the PR, complete every applicable template section, remove instructional
-   comments and unused alternatives, report the validation actually run and its limitations, and do
-   not invent a related issue.
+3. When creating or updating the PR, complete every applicable template section and include explicit
+   `Summary` and `Validation` sections as required by the root `AGENTS.md`; do not assume `Overview`
+   substitutes for `Summary`. Remove instructional comments and unused alternatives, report the
+   validation actually run and its limitations, and do not invent a related issue.
 4. Verify the submitted PR with `gh pr view` (including `url`, `state`, `isDraft`, `body`,
    `headRefName`, and `headRefOid`). Confirm that the URL contains `/pull/<number>`, the head branch
    and commit are the intended ones, and the body contains no template placeholders before handing it

--- a/.agents/skills/dynamo-docs/SKILL.md
+++ b/.agents/skills/dynamo-docs/SKILL.md
@@ -407,12 +407,17 @@ when the user has requested or authorized the external contribution.
    `Summary` and `Validation` sections as required by the root `AGENTS.md`; do not assume `Overview`
    substitutes for `Summary`. Remove instructional comments and unused alternatives, report the
    validation actually run and its limitations, and do not invent a related issue.
-4. Verify the submitted PR with `gh pr view` (including `url`, `state`, `isDraft`, `body`,
-   `baseRefName`, `headRefName`, and `headRefOid`). Confirm that `state` is `OPEN`, the URL contains
-   `/pull/<number>`, the base, head branch, and commit are the intended ones, and the body contains no
-   template placeholders before handing it off. If the PR is closed, reopen it when appropriate or
-   create a new PR; if it is merged, create a new PR for remaining changes or report that no active PR
-   exists. Never present an inactive PR as reviewable.
+4. Query the submitted PR's verification fields explicitly:
+
+   ```bash
+   gh pr view <number-or-branch> --repo ai-dynamo/dynamo \
+     --json url,state,isDraft,body,baseRefName,headRefName,headRefOid
+   ```
+
+   Confirm that `state` is `OPEN`, the URL contains `/pull/<number>`, the base, head branch, and commit
+   are the intended ones, and the body contains no template placeholders before handing it off. If the
+   PR is closed, reopen it when appropriate or create a new PR; if it is merged, create a new PR for
+   remaining changes or report that no active PR exists. Never present an inactive PR as reviewable.
 5. Report the PR's actual review and check state. Use the `pr-monitor` skill when CI diagnosis or
    continued monitoring is requested.
 


### PR DESCRIPTION
## Summary

Add pull-request handoff safeguards to the `dynamo-docs` skill so agents distinguish a pushed branch from a submitted PR, satisfy both repository-wide PR conventions and the current template, and verify the live PR before reporting success.

## Overview

The `dynamo-docs` skill currently ends after committing a documentation change. It does not distinguish a pushed branch or `/pull/new/<branch>` creation page from an actual pull request, nor does it require the submitted PR body and head commit to be verified before handoff.

This change adds that missing contribution boundary and verification step.

## Details

- Require explicit user authorization before creating or handing off an external contribution.
- Require the PR body to satisfy both the root repository conventions and the current pull-request template.
- Require explicit `Summary` and `Validation` sections even when the template omits them; do not treat `Overview` as a substitute for `Summary`.
- State that a pushed branch and `/pull/new/<branch>` URL are not created PRs.
- Require completed template sections, accurate validation limitations, and removal of unused template alternatives.
- Verify the submitted PR URL, open state, draft status, body, base branch, head branch, and head commit with an explicit `gh pr view --json` query before reporting success.
- Require the live draft/ready state to match intent and revalidate `Summary`, `Validation`, every applicable template section, and placeholder removal in the submitted body.
- Require a closed PR to be reopened or replaced when appropriate, and never present a closed or merged PR as reviewable.
- Route continued CI diagnosis to the existing `pr-monitor` skill.

## Validation

- `git diff --check`
- Skill Creator `quick_validate.py` against `.agents/skills/dynamo-docs` (`Skill is valid!`)
- `uv run --no-project --with pyyaml python scripts/validate_skills.py` (`validated 26 skills: OK`)
- `pre-commit` was not run locally because the executable is not installed; the GitHub pre-commit check will validate the updated head.

## Where should the reviewer start?

Review the new `Pull Request Handoff` section in `.agents/skills/dynamo-docs/SKILL.md`, especially the distinction between a pushed branch and a submitted PR, the combined repository/template requirements, and the post-creation verification requirements.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for handing off pull requests.
  * Documented authorization checks, template compliance, PR verification, validation steps, and reporting of review and check status.
  * Added instructions for using PR monitoring when requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
