### PR TITLE
fix(docs): restore community and publication layouts

### DIFF
--- a/docs/fern/components/CustomFooter.tsx
+++ b/docs/fern/components/CustomFooter.tsx
@@ -32,6 +32,15 @@ const SITE_CSS = `
  * its affiliates is strictly prohibited.
  */
 
+/*
+ * Local and unthemed fallback only.
+ *
+ * The publishing workflow injects Fern's NVIDIA organization theme into hosted
+ * builds. That theme replaces this project CSS entry and the custom footer.
+ * Local Fern development uses this checked-in approximation instead, so it can
+ * drift from the organization theme.
+ */
+
 /* Color themes for light and dark modes */
 :root {
     /* Brand Colors */
@@ -1287,19 +1296,6 @@ a.fern-card:hover{
 .dark .mermaid-container-expanded svg :is(.marker, marker path, marker polygon) {
   fill: #76b900 !important;
   stroke: #76b900 !important;
-}
-
-
-/* ===================== Community page ===================== */
-
-:root {
-  --dynamo-community-green: #76b900;
-  --dynamo-community-green-bright: #8ed600;
-  --dynamo-community-ink: var(--grayscale-a12);
-  --dynamo-community-muted: var(--grayscale-a10);
-  --dynamo-community-rule: color-mix(in srgb, var(--grayscale-a12) 14%, transparent);
-  --dynamo-community-soft: #f3f4f3;
-  --dynamo-community-titlebar-text: #555755;
 }
 `;
 // sync-site-css:end

--- a/docs/fern/components/LandingStyles.tsx
+++ b/docs/fern/components/LandingStyles.tsx
@@ -5,20 +5,15 @@
  * Landing page component styles (Home and Community).
  *
  * Styles for WelcomeHero, WhyDynamo, EventsCalendar and CommunityLanding.
- * This block is their only home -- main.css carries none of these rules, so
- * there is no fallback baseline. If this block does not render, both pages
- * render unstyled. (CustomFooter.tsx is the one that genuinely mirrors
- * main.css, enforced by the `sync-site-css` pre-commit hook.)
+ * This block is their hosted-build delivery path. The shared NVIDIA global theme
+ * replaces the project `css:` entry and custom footer at publish (#11952), so
+ * production ships neither the main.css link nor CustomFooter's mirrored copy.
  *
- * Delivered as a page-level <style> block (NOT via the docs.yml `css:` field)
- * so it survives the shared NVIDIA global theme, which replaces project `css`
- * at publish (#11952) -- production ships no main.css <link> at all. Same
- * pattern as ReferenceStyles.tsx and RecipeStyles.tsx.
- *
- * main.css content does still reach production, mirrored verbatim into
- * CustomFooter.tsx's SITE_CSS by sync_site_css.py, and that block does render
- * on these pages. It is not somewhere to put landing rules, though: it is
- * generated, so any hand edit is overwritten on the next sync.
+ * main.css remains the stylesheet for local `fern docs dev` and other builds
+ * that do not inject the global theme. Keep site-wide local-preview rules there,
+ * but keep landing-page rules and variables in this component so the rendered
+ * pages are self-contained. Same pattern as ReferenceStyles.tsx and
+ * RecipeStyles.tsx.
  *
  * Injected via dangerouslySetInnerHTML, like RecipeStyles.tsx, not as a text
  * child like ReferenceStyles.tsx. A text child is escaped on render, which
@@ -1600,18 +1595,30 @@ article:has(.dynamo-welcome) > header .fern-page-subtitle p {
   }
 }
 
+.dynamo-community-page {
+  --dynamo-community-green: #76b900;
+  --dynamo-community-green-bright: #8ed600;
+  --dynamo-community-ink: var(--grayscale-a12);
+  --dynamo-community-muted: var(--grayscale-a10);
+  --dynamo-community-rule: color-mix(in srgb, var(--grayscale-a12) 14%, transparent);
+  --dynamo-community-soft: #f3f4f3;
+  --dynamo-community-titlebar-text: #555755;
+  color: var(--dynamo-community-ink);
+}
+
 article:has(.dynamo-community-page) {
   width: 100% !important;
   max-width: 1200px !important;
-  margin-inline: auto;
+  /* Fern centers the article in the viewport area left after the sidebar.
+     On very wide screens that separates the content from its navigation.
+     Anchor this custom layout to the sidebar-side content rail instead. */
+  margin-inline: 0 auto;
 }
 
 .dark .dynamo-community-page {
   --dynamo-community-soft: #2b2c2b;
   --dynamo-community-titlebar-text: #d4d5d4;
 }
-
-.dynamo-community-page { color: var(--dynamo-community-ink); }
 
 .dynamo-community-page h2, .dynamo-community-page h3, .dynamo-community-page p { margin-top: 0; }
 

--- a/docs/fern/components/PublicationsStyles.tsx
+++ b/docs/fern/components/PublicationsStyles.tsx
@@ -14,6 +14,13 @@
  * page rendering this must render <BlogStyles /> too.
  */
 const PUBLICATIONS_CSS = `
+/* Keep the publication cards visually attached to the Blog navigation on wide
+   screens. Fern otherwise centers the article in all space remaining to the
+   right of the sidebar, so the gap grows with the viewport. */
+article:has(.dynamo-pubs__section) {
+  margin-inline: 0 auto;
+}
+
 .dynamo-pubs {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/docs/fern/main.css
+++ b/docs/fern/main.css
@@ -10,6 +10,15 @@
  * its affiliates is strictly prohibited.
  */
 
+/*
+ * Local and unthemed fallback only.
+ *
+ * The publishing workflow injects Fern's NVIDIA organization theme into hosted
+ * builds. That theme replaces this project CSS entry and the custom footer.
+ * Local Fern development uses this checked-in approximation instead, so it can
+ * drift from the organization theme.
+ */
+
 /* Color themes for light and dark modes */
 :root {
     /* Brand Colors */
@@ -1265,17 +1274,4 @@ a.fern-card:hover{
 .dark .mermaid-container-expanded svg :is(.marker, marker path, marker polygon) {
   fill: #76b900 !important;
   stroke: #76b900 !important;
-}
-
-
-/* ===================== Community page ===================== */
-
-:root {
-  --dynamo-community-green: #76b900;
-  --dynamo-community-green-bright: #8ed600;
-  --dynamo-community-ink: var(--grayscale-a12);
-  --dynamo-community-muted: var(--grayscale-a10);
-  --dynamo-community-rule: color-mix(in srgb, var(--grayscale-a12) 14%, transparent);
-  --dynamo-community-soft: #f3f4f3;
-  --dynamo-community-titlebar-text: #555755;
 }

--- a/docs/fern/pages/community/contributing/documentation/building-and-publishing.md
+++ b/docs/fern/pages/community/contributing/documentation/building-and-publishing.md
@@ -371,6 +371,20 @@ Install the Fern CLI globally via npm:
 npm install -g fern-api
 ```
 
+### Generate local API references
+
+Python and Rust API pages are generated during the publish workflow and are not committed. Generate
+them before running Fern locally from a fresh checkout:
+
+```bash
+uv run --no-project --python 3.13 --with 'griffe==2.1.0' \
+  python3 docs/fern/scripts/gen_python_api.py
+python3 docs/fern/scripts/gen_rust_api.py
+```
+
+The generated pages are gitignored. If they are absent, Fern reports missing paths under
+`pages/reference/api/python/` and `pages/reference/api/rust/`.
+
 ### Validate configuration
 
 Run `fern check` from `docs/fern/` to validate that `docs/fern/docs.yml`,
@@ -415,8 +429,13 @@ cd docs/fern
 fern docs dev
 ```
 
-The local server lets you see exactly how pages will look on the live site,
-including navigation, version dropdowns, and custom styling.
+The local server loads `main.css`, which approximates the private NVIDIA organization theme. It is
+suitable for content, layout, interaction, and page-level component-style checks, but it is not
+pixel-identical to a hosted build. The publishing workflow injects `global-theme: nvidia`, which can
+replace project-level CSS and custom footer configuration.
+
+Use the hosted pull request preview for the final visual check because it uses the same theme
+delivery path as the live site.
 
 ---
 

--- a/docs/fern/scripts/check_published_styles.py
+++ b/docs/fern/scripts/check_published_styles.py
@@ -18,13 +18,15 @@
 Production sets `global-theme: nvidia`, which overrides the project `css:` and
 `js:` entries and the custom `footer:` (Fern's docs.yml schema documents the
 override). Components that deliver their CSS through a page-level <style>
-block survive it; anything relying on main.css does not. That failure is
-invisible before merge -- PR previews delete the theme -- so this runs against
-the published site after publish.
+block survive it; anything relying on main.css does not. Hosted pull request
+previews use the same theme and should catch that failure before merge; this
+published-site check remains the post-publish backstop.
 
-Each check asserts a selector appears as a CSS *rule* (followed by `{` or `,`),
-not merely as a class name in markup. A page can be full of `class="foo"` while
-the rule that styles it is absent, which is exactly the failure mode.
+Selector checks assert that a selector appears as a CSS *rule* (followed by
+`{` or `,`), not merely as a class name in markup. Declaration checks assert
+that required CSS custom properties are present too. A page can carry all of
+its selectors while declarations that depend on an undefined custom property
+silently become invalid, which is the community-widget failure this also guards.
 
 CDN propagation and Fern's publish pipeline can lag, so the CDN returns HTTP
 200 with the *previous* HTML while the new page is still propagating. `fetch()`
@@ -67,6 +69,11 @@ CHECKS: list[tuple[str, str, str]] = [
     ("", ".dynamo-story-windowbar", "LandingStyles"),
     ("", ".dynamo-welcome__terminal", "LandingStyles"),
     ("community", ".dynamo-community-page", "LandingStyles"),
+    (
+        "external-publications",
+        "article:has(.dynamo-pubs__section)",
+        "PublicationsStyles",
+    ),
     ("digest", ".dynamo-blog-art__grid", "BlogStyles"),
     ("reference/compatibility", ".dynref-panel", "ReferenceStyles"),
     # URL from the nav's explicit slugs (section `benchmarks`, page
@@ -76,6 +83,11 @@ CHECKS: list[tuple[str, str, str]] = [
         ".dynamo-benchmark-grid",
         "RecipeStyles",
     ),
+]
+
+# (page path, CSS declaration that must exist, component that owns it)
+DECLARATION_CHECKS: list[tuple[str, str, str]] = [
+    ("community", "--dynamo-community-rule:", "LandingStyles"),
 ]
 
 # Minified CSS keeps only mandatory whitespace, so match `.foo{` and `.foo,`
@@ -94,6 +106,11 @@ def in_markup_count(selector: str, html: str) -> int:
     if not selector.startswith("."):
         return 0
     return len(re.findall(r'class="[^"]*' + re.escape(selector[1:]), html))
+
+
+def declaration_count(declaration: str, html: str) -> int:
+    """Return definitions of a required CSS custom property."""
+    return html.count(declaration)
 
 
 def url_from_base(base: str, path: str) -> str:
@@ -138,6 +155,43 @@ def probe(url: str, selector: str, retries: int, delay: float) -> tuple[str, int
     raise SystemExit(f"could not fetch {url}: {last}")
 
 
+def probe_declaration(
+    url: str, declaration: str, retries: int, delay: float
+) -> tuple[str, int]:
+    """Fetch ``url`` and retry until a required declaration is present."""
+    last: Exception | None = None
+    html = ""
+    for attempt in range(1, retries + 1):
+        try:
+            html = fetch_once(url)
+        except (urllib.error.URLError, TimeoutError) as exc:
+            last = exc
+            if attempt < retries:
+                time.sleep(delay)
+            continue
+        count = declaration_count(declaration, html)
+        if count or attempt == retries:
+            return html, count
+        time.sleep(delay)
+    raise SystemExit(f"could not fetch {url}: {last}")
+
+
+def report_declaration(
+    check: tuple[str, str, str], base: str, retries: int, delay: float
+) -> str | None:
+    """Run one DECLARATION_CHECKS entry; return an error on failure."""
+    path, declaration, owner = check
+    url = url_from_base(base, path)
+    _, count = probe_declaration(url, declaration, retries, delay)
+    if count:
+        print(f"ok    {url}  {declaration} ({count} declarations, {owner})")
+        return None
+    return (
+        f"{url}\n      required declaration {declaration!r} is absent.\n"
+        f"      {owner} reached the page without all CSS variables its rules use."
+    )
+
+
 def report(
     check: tuple[str, str, str], base: str, retries: int, delay: float
 ) -> str | None:
@@ -174,6 +228,28 @@ CSS_RULE_CASES: list[tuple[str, str, str, int, int]] = [
     ),
     ("class attribute list", ".foo", '<div class="bar foo baz">x</div>', 0, 1),
     ("double-underscore selector", ".dyn__pt", ".dyn__pt{color:red}", 1, 0),
+    (
+        "functional pseudo-class selector",
+        "article:has(.dynamo-pubs__section)",
+        "article:has(.dynamo-pubs__section){margin-inline:0 auto}",
+        1,
+        0,
+    ),
+]
+
+DECLARATION_CASES: list[tuple[str, str, str, int]] = [
+    (
+        "custom property definition",
+        "--dynamo-community-rule:",
+        ".page{--dynamo-community-rule:rgba(0,0,0,.2)}",
+        1,
+    ),
+    (
+        "custom property usage is not a definition",
+        "--dynamo-community-rule:",
+        ".page{border:1px solid var(--dynamo-community-rule)}",
+        0,
+    ),
 ]
 
 
@@ -191,7 +267,16 @@ def run_tests() -> int:
             f"    as_rule_count:   expected {want_rule}, got {rule}\n"
             f"    in_markup_count: expected {want_markup}, got {markup}"
         )
-    total = len(CSS_RULE_CASES)
+    for name, declaration, html, want in DECLARATION_CASES:
+        count = declaration_count(declaration, html)
+        if count == want:
+            print(f"  PASS: {name}")
+            continue
+        failed += 1
+        print(
+            f"  FAIL: {name}\n" f"    declaration_count: expected {want}, got {count}"
+        )
+    total = len(CSS_RULE_CASES) + len(DECLARATION_CASES)
     print(f"\n{total - failed}/{total} passed")
     return 1 if failed else 0
 
@@ -211,13 +296,19 @@ def main() -> int:
         failure = report(check, args.base, args.retries, args.delay)
         if failure is not None:
             failures.append(failure)
+    for check in DECLARATION_CHECKS:
+        failure = report_declaration(check, args.base, args.retries, args.delay)
+        if failure is not None:
+            failures.append(failure)
 
     if failures:
         print("\nFAIL: published pages are missing component CSS\n", file=sys.stderr)
         for failure in failures:
             print(f"  - {failure}", file=sys.stderr)
         return 1
-    print(f"\nall {len(CHECKS)} published style checks passed")
+    print(
+        f"\nall {len(CHECKS) + len(DECLARATION_CHECKS)} published style checks passed"
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary

- keep Community page variables and hosted-build CSS in `LandingStyles`
- align Community and External Publications layouts with the navigation rail on wide screens
- expand published-style checks to cover the restored layouts and document local-versus-hosted theme behavior

## Validation

- `python3 docs/fern/scripts/sync_site_css.py --check`
- `python3 docs/fern/scripts/check_asset_paths.py`
- `python3 docs/fern/scripts/check_style_components.py`
- `python3 docs/fern/scripts/check_agent_twins.py`
- `python3 docs/fern/scripts/check_published_styles.py --test`
- `uvx --from 'ruff==0.5.2' ruff check docs/fern/scripts/check_published_styles.py`
- `fern check` (0 errors)
- `fern docs broken-links` (reports four existing errors in the unchanged `qwen-3-8-2-4t-a95b-fp8.mdx` page)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added local preview guidance for generating API reference pages.
  * Clarified differences between local preview styling and hosted builds.
  * Documented the role of fallback CSS and hosted theme delivery.

* **Style**
  * Improved alignment for community and publications pages.
  * Added scoped styling for community pages.

* **Tests**
  * Expanded published-style checks to validate required CSS declarations and selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->