### PR TITLE
fix(kubernetes): allow public models without an HF token secret

### DIFF
--- a/components/src/dynamo/profiler/templates/dgd/mocker/disagg.yaml
+++ b/components/src/dynamo/profiler/templates/dgd/mocker/disagg.yaml
@@ -44,6 +44,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:my-tag
           name: main
           workingDir: /workspace
@@ -69,6 +70,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:my-tag
           name: main
           workingDir: /workspace

--- a/components/src/dynamo/profiler/templates/dgd/sglang/agg.yaml
+++ b/components/src/dynamo/profiler/templates/dgd/sglang/agg.yaml
@@ -19,6 +19,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: my-registry/sglang-runtime:my-tag
           name: main
     replicas: 1
@@ -45,6 +46,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: my-registry/sglang-runtime:my-tag
           name: main
           resources:

--- a/components/src/dynamo/profiler/templates/dgd/sglang/disagg.yaml
+++ b/components/src/dynamo/profiler/templates/dgd/sglang/disagg.yaml
@@ -19,6 +19,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: my-registry/sglang-runtime:my-tag
           name: main
     replicas: 1
@@ -53,6 +54,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: my-registry/sglang-runtime:my-tag
           name: main
           resources:
@@ -91,6 +93,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: my-registry/sglang-runtime:my-tag
           name: main
           resources:

--- a/components/src/dynamo/profiler/templates/dgd/trtllm/agg.yaml
+++ b/components/src/dynamo/profiler/templates/dgd/trtllm/agg.yaml
@@ -19,6 +19,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: my-registry/tensorrtllm-runtime:my-tag
           name: main
     replicas: 1
@@ -41,6 +42,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: my-registry/tensorrtllm-runtime:my-tag
           name: main
           resources:

--- a/components/src/dynamo/profiler/templates/dgd/trtllm/disagg.yaml
+++ b/components/src/dynamo/profiler/templates/dgd/trtllm/disagg.yaml
@@ -19,6 +19,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: my-registry/tensorrtllm-runtime:my-tag
           name: main
     replicas: 1
@@ -43,6 +44,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: my-registry/tensorrtllm-runtime:my-tag
           name: main
           resources:
@@ -71,6 +73,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: my-registry/tensorrtllm-runtime:my-tag
           name: main
           resources:

--- a/components/src/dynamo/profiler/templates/dgd/vllm/agg.yaml
+++ b/components/src/dynamo/profiler/templates/dgd/vllm/agg.yaml
@@ -19,6 +19,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           name: main
     replicas: 1
@@ -37,6 +38,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           name: main
           resources:

--- a/components/src/dynamo/profiler/templates/dgd/vllm/disagg.yaml
+++ b/components/src/dynamo/profiler/templates/dgd/vllm/disagg.yaml
@@ -19,6 +19,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           name: main
     replicas: 1
@@ -39,6 +40,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           name: main
           resources:
@@ -68,6 +70,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           name: main
           resources:

--- a/components/src/dynamo/profiler/tests/unit/test_dgd_template.py
+++ b/components/src/dynamo/profiler/tests/unit/test_dgd_template.py
@@ -86,7 +86,33 @@ def test_production_frontend_has_hf_token_secret(backend: str, mode: str) -> Non
     config = load_dgd_template(backend, mode)
 
     env_from = _main_container(config, "Frontend").get("envFrom", [])
-    assert {"secretRef": {"name": "hf-token-secret"}} in env_from
+    assert {"secretRef": {"name": "hf-token-secret", "optional": True}} in env_from
+
+
+@pytest.mark.parametrize(
+    ("backend", "mode"),
+    [
+        ("vllm", "agg"),
+        ("vllm", "disagg"),
+        ("sglang", "agg"),
+        ("sglang", "disagg"),
+        ("trtllm", "agg"),
+        ("trtllm", "disagg"),
+        ("mocker", "disagg"),
+    ],
+)
+def test_all_hf_token_secret_refs_are_optional(backend: str, mode: str) -> None:
+    config = load_dgd_template(backend, mode)
+
+    secret_refs = [
+        env_from["secretRef"]
+        for component in config["spec"]["components"]
+        for container in component["podTemplate"]["spec"]["containers"]
+        for env_from in container.get("envFrom", [])
+        if env_from.get("secretRef", {}).get("name") == "hf-token-secret"
+    ]
+    assert secret_refs
+    assert all(secret_ref.get("optional") is True for secret_ref in secret_refs)
 
 
 def test_vllm_decode_blueprint_does_not_enable_kv_transfer() -> None:

--- a/components/src/dynamo/profiler/tests/unit/test_dgd_template.py
+++ b/components/src/dynamo/profiler/tests/unit/test_dgd_template.py
@@ -86,7 +86,9 @@ def test_production_frontend_has_hf_token_secret(backend: str, mode: str) -> Non
     config = load_dgd_template(backend, mode)
 
     env_from = _main_container(config, "Frontend").get("envFrom", [])
-    assert {"secretRef": {"name": "hf-token-secret", "optional": True}} in env_from
+    assert any(
+        item.get("secretRef", {}).get("name") == "hf-token-secret" for item in env_from
+    )
 
 
 @pytest.mark.parametrize(

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1465,7 +1465,8 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "hf-token-secret",
 						},
-						Key: "HF_TOKEN",
+						Key:      "HF_TOKEN",
+						Optional: ptr.To(true),
 					},
 				},
 			},

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -309,6 +309,7 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 			Expect(profilerEnvNames).ShouldNot(HaveKey("NATS_SERVER"))
 			Expect(profilerEnvNames).ShouldNot(HaveKey("ETCD_ENDPOINTS"))
 			Expect(profilerEnvNames).ShouldNot(HaveKey(EnvDGDOverrideToolPath))
+			GinkgoT().Log("Verify optional Hugging Face token SecretKeyRef")
 			hfToken := findEnv(job.Spec.Template.Spec.Containers[0].Env, "HUGGING_FACE_HUB_TOKEN")
 			Expect(hfToken).ShouldNot(BeNil())
 			Expect(hfToken.ValueFrom).ShouldNot(BeNil())

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -309,6 +309,14 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 			Expect(profilerEnvNames).ShouldNot(HaveKey("NATS_SERVER"))
 			Expect(profilerEnvNames).ShouldNot(HaveKey("ETCD_ENDPOINTS"))
 			Expect(profilerEnvNames).ShouldNot(HaveKey(EnvDGDOverrideToolPath))
+			hfToken := findEnv(job.Spec.Template.Spec.Containers[0].Env, "HUGGING_FACE_HUB_TOKEN")
+			Expect(hfToken).ShouldNot(BeNil())
+			Expect(hfToken.ValueFrom).ShouldNot(BeNil())
+			Expect(hfToken.ValueFrom.SecretKeyRef).Should(Equal(&corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "hf-token-secret"},
+				Key:                  "HF_TOKEN",
+				Optional:             ptr.To(true),
+			}))
 			Expect(job.Spec.Template.Spec.InitContainers).Should(BeEmpty())
 
 			// Verify both alpha-only profiling fields were restored from the

--- a/docs/fern/pages/kubernetes/getting-started/quickstart.mdx
+++ b/docs/fern/pages/kubernetes/getting-started/quickstart.mdx
@@ -85,20 +85,6 @@ kubectl get pods --namespace "$NAMESPACE"
     For the NVIDIA GPU DGDR path, `DYNAMO_IMAGE` points to the Dynamo planner image from the selector above. The planner profiles the model and creates the worker deployment; you do not need to choose a separate runtime image for that path.
   </Step>
 
-  <Step title="Create the model access secret">
-    `Qwen/Qwen3-0.6B` is public and does not require a Hugging Face token. The DGDR profiler and
-    example DGD expect a Secret named `hf-token-secret`, so create it with an empty token:
-
-```bash
-kubectl create secret generic hf-token-secret \
-  --namespace "$NAMESPACE" \
-  --from-literal=HF_TOKEN= \
-  --dry-run=client -o yaml | kubectl apply -f -
-```
-
-    For a gated or private model, replace the empty value with your Hugging Face token.
-  </Step>
-
   <Step title="Deploy Qwen3 0.6B">
     <Tabs>
       <Tab title="NVIDIA GPU">

--- a/examples/backends/vllm/deploy/xpu/README.md
+++ b/examples/backends/vllm/deploy/xpu/README.md
@@ -31,7 +31,7 @@ Hardware-specific deployment templates for Intel XPU GPUs using Kubernetes Dynam
      -f container/vllm-runtime-xpu-amd64-rendered.Dockerfile .
    ```
    See [container/README.md](../../../../../container/README.md) for complete build instructions.
-4. **HuggingFace token secret**:
+4. **Hugging Face token secret** for gated or private models:
    ```bash
    export HF_TOKEN=your_hf_token
    kubectl create secret generic hf-token-secret \

--- a/examples/backends/vllm/deploy/xpu/agg_router_kv_approx_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/agg_router_kv_approx_xpu_dra.yaml
@@ -51,6 +51,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           imagePullPolicy: IfNotPresent
           name: main
@@ -78,6 +79,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           imagePullPolicy: IfNotPresent
           name: main

--- a/examples/backends/vllm/deploy/xpu/agg_router_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/agg_router_xpu_dra.yaml
@@ -47,6 +47,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           name: main
     replicas: 1
@@ -73,6 +74,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           name: main
           resources:

--- a/examples/backends/vllm/deploy/xpu/agg_tracing_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/agg_tracing_xpu_dra.yaml
@@ -34,6 +34,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           name: main
     replicas: 1
@@ -59,6 +60,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           name: main
           resources:

--- a/examples/backends/vllm/deploy/xpu/agg_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/agg_xpu_dra.yaml
@@ -27,6 +27,7 @@ spec:
         - envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           name: main
     replicas: 1
@@ -50,6 +51,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           name: main
           resources:

--- a/examples/backends/vllm/deploy/xpu/disagg_planner_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/disagg_planner_xpu_dra.yaml
@@ -47,6 +47,7 @@ spec:
         - envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           name: main
     replicas: 1
@@ -99,6 +100,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           name: main
           resources:
@@ -135,6 +137,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           name: main
           resources:

--- a/examples/backends/vllm/deploy/xpu/disagg_router_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/disagg_router_xpu_dra.yaml
@@ -40,6 +40,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           name: main
     replicas: 1
@@ -65,6 +66,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           name: main
           resources:
@@ -104,6 +106,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           name: main
           resources:

--- a/examples/backends/vllm/deploy/xpu/disagg_tracing_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/disagg_tracing_xpu_dra.yaml
@@ -34,6 +34,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           name: main
     replicas: 1
@@ -63,6 +64,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           name: main
           resources:
@@ -101,6 +103,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           name: main
           resources:

--- a/examples/backends/vllm/deploy/xpu/disagg_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/disagg_xpu_dra.yaml
@@ -27,6 +27,7 @@ spec:
         - envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           name: main
     replicas: 1
@@ -54,6 +55,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           name: main
           resources:
@@ -98,6 +100,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
+              optional: true
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           name: main
           resources:


### PR DESCRIPTION
## Summary

- Allow DGDR profiling and profiler-generated deployments to run public Hugging Face models without a placeholder token Secret.
- Keep token injection intact when `hf-token-secret` exists for gated or private models.
- Remove the empty-secret step from the public Qwen Kubernetes Quickstart and align the public-Qwen XPU examples.

## Overview

The Kubernetes Quickstart deploys the public `Qwen/Qwen3-0.6B` model, but the DGDR profiling Job and generated DGD blueprints currently reference `hf-token-secret` as mandatory. Kubernetes therefore blocks the workloads before model startup when the Secret is absent, so the Quickstart asks users to create an empty credential.

This change marks those references optional. When the Secret and key exist, Kubernetes still injects the token. When they do not, public models start without the environment variable.

## Details

- Mark the DGDR profiling Job's `HUGGING_FACE_HUB_TOKEN` `SecretKeySelector` optional and assert its full name/key/optional contract in envtest.
- Mark every `hf-token-secret` reference optional in the seven profiler-owned vLLM, SGLang, TensorRT-LLM, and mocker DGD blueprints; add unit coverage across all blueprints.
- Mark all 20 references optional in the Intel XPU example family, whose manifests all serve public `Qwen/Qwen3-0.6B`, and clarify that the README's secret step applies to gated or private models.
- Remove the Quickstart step that creates an empty token Secret for the public model.

## Validation

- `make envtest ENVTEST_PACKAGES=./internal/controller` with the repository's Go 1.26.6 toolchain: passed.
- Focused profiler template unit tests: 29 passed.
- Parsed all 15 profiler/XPU manifests and verified all 37 `hf-token-secret` references are optional.
- Repository pre-commit hooks against all 20 changed files: passed.
- `fern check`: 0 errors, 2 existing warnings.
- `fern docs broken-links`: reports 10 existing errors outside this change (six TLS-reference errors and four Qwen recipe links already addressed by #14067).

## Where should the reviewer start?

1. `deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go` and its envtest for the profiling Job behavior.
2. `components/src/dynamo/profiler/tests/unit/test_dgd_template.py` and the profiler-owned DGD templates for generated deployment behavior.
3. `docs/fern/pages/kubernetes/getting-started/quickstart.mdx` and `examples/backends/vllm/deploy/xpu/` for the user-facing flow.

## Related Issues

**This PR is NOT linked to an issue:**

- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployments and profiling jobs can now run without a Hugging Face token secret.
  * Hugging Face authentication remains available for gated or private models when required.

* **Documentation**
  * Updated quickstart instructions to remove the mandatory secret-creation step.
  * Clarified when an Hugging Face token is needed for XPU deployments.

* **Tests**
  * Added coverage verifying optional token-secret configuration across supported deployment modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->