### PR TITLE
docs: add Kubernetes Quickstart next steps

### DIFF
--- a/docs/fern/pages/kubernetes/getting-started/quickstart.mdx
+++ b/docs/fern/pages/kubernetes/getting-started/quickstart.mdx
@@ -217,6 +217,26 @@ curl --silent --show-error http://localhost:8000/v1/chat/completions \
 - Created either a DGDR that generated a DGD, or a DGD directly.
 - Sent an OpenAI-compatible request to the deployed model.
 
+## Next Steps
+
+Use the running deployment for observability or benchmarking. To choose another deployment path or
+plan a production environment, review the corresponding guides.
+
+<CardGroup cols={2}>
+  <Card title="Choose a Deployment Workflow" icon="regular circle-info" href="../model-deployment/introduction.mdx">
+    Compare direct DGD deployment with DGDR auto deployment.
+  </Card>
+  <Card title="Review Production Prerequisites" icon="regular gears" href="../installation/install-dynamo.md#overview">
+    Review networking, storage, scheduling, and observability requirements before creating a production environment.
+  </Card>
+  <Card title="Observe the Deployment" icon="regular chart-line" href="../operations/observability.mdx">
+    Collect metrics, logs, traces, and health status.
+  </Card>
+  <Card title="Benchmark the Deployment" icon="regular stopwatch" href="../operations/benchmarking-with-aiperf.mdx">
+    Measure latency and throughput with AIPerf.
+  </Card>
+</CardGroup>
+
 ## Clean Up
 
 Stop the port-forward and remove the quickstart deployment:


### PR DESCRIPTION
## Summary

Add a direct handoff from the Kubernetes Quickstart to the deployment, production-planning,
observability, and benchmarking guides that readers need after their first successful request.

## Overview:

The Kubernetes Quickstart currently ends with a summary and cleanup commands. Readers who keep the
deployment running receive no direct path to the guides for observing or benchmarking it, and no
handoff to the deployment-workflow or production-prerequisite guidance.

This change adds a focused Next Steps section before cleanup without expanding the Quickstart itself
into production setup or operations documentation.

## Details:

- Link the model deployment overview for readers choosing between direct DGD and DGDR workflows.
- Link directly to the Installation Guide overview for production prerequisite planning, rather than
  presenting a fresh installation flow as a continuation of the running Quickstart.
- Link the Kubernetes observability and AIPerf benchmarking guides for actions that use the running
  deployment.
- Keep the existing cleanup flow unchanged.

## Validation

- `git diff --check`
- Focused pre-commit run for `docs/fern/pages/kubernetes/getting-started/quickstart.mdx` (passed)
- Generated the publish-time Python and Rust API pages, then ran Fern configuration validation
  (0 errors)
- Verified all four relative targets and the Installation Guide `#overview` anchor
- `python3 docs/fern/scripts/check_component_imports.py` (`checked 42 component source(s): no unbundleable specifiers`)
- Fern broken-link validation reported only 10 existing errors in unrelated TLS and Qwen recipe pages;
  it reported no error for the Quickstart or any new target

## Where should the reviewer start?

Review the new `Next Steps` section in
`docs/fern/pages/kubernetes/getting-started/quickstart.mdx`, especially the distinction between using
the running deployment and reviewing production prerequisites before creating a production
environment.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Next Steps” section to the Kubernetes quickstart.
  * Included links covering deployment workflows, production prerequisites, observability, and benchmarking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->