### PR TITLE
docs: fix Kubernetes observability setup

### DIFF
--- a/deploy/observability/logging/grafana/loki-datasource.yaml
+++ b/deploy/observability/logging/grafana/loki-datasource.yaml
@@ -13,6 +13,7 @@ data:
       - name: Loki
         type: loki
         access: proxy
-        url: http://loki-gateway.$MONITORING_NAMESPACE.svc.cluster.local
+        # The documented stack installs Grafana and Loki in the same namespace.
+        url: http://loki-gateway
         jsonData:
           maxLines: 1000

--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -88,6 +88,8 @@ navigation:
         contents:
         - page: Install Dynamo
           path: pages/kubernetes/installation/install-dynamo.md
+        - page: Observability
+          path: pages/kubernetes/installation/observability.md
         - page: Multinode Orchestration
           path: pages/kubernetes/installation/multinode-orchestration.md
         - page: Gateway API Inference Extension

--- a/docs/fern/pages/kubernetes/installation/install-dynamo.md
+++ b/docs/fern/pages/kubernetes/installation/install-dynamo.md
@@ -257,7 +257,10 @@ helm install prometheus prometheus-community/kube-prometheus-stack \
   --set-json 'prometheus.prometheusSpec.probeNamespaceSelector={}'
 ```
 
-Then uncomment the `prometheusEndpoint` line in the Dynamo install command. The Dynamo operator automatically creates PodMonitors for its components. See [Metrics](../operations/observability.mdx) for dashboard setup and available metrics, and [Logging](observability.md) for the Grafana Loki + Alloy logging stack.
+Then uncomment the `prometheusEndpoint` line in the Dynamo install command. With the Prometheus
+Operator CRDs present, the Dynamo platform chart creates the component `PodMonitor` resources. See
+[Metrics](../operations/observability.mdx) for dashboard setup and available metrics, and
+[Logging](observability.md) for the Grafana Loki and Alloy logging stack.
 
 ### Shared Storage for Model Caching
 

--- a/docs/fern/pages/kubernetes/installation/observability.md
+++ b/docs/fern/pages/kubernetes/installation/observability.md
@@ -2,23 +2,32 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Observability
-subtitle: Install the monitoring stack and enable metrics, logging, and tracing for Dynamo deployments
+subtitle: Install Prometheus, Grafana, DCGM exporter, Loki, and Alloy for Dynamo deployments
 ---
 
-Dynamo emits three signals — **metrics** (Prometheus), **logs** (structured text or JSONL, exportable to Loki), and **traces** (OpenTelemetry, exportable to Tempo). This page installs the backends that collect them. Enabling each signal is a matter of setting a few environment variables per process or deployment.
+Dynamo emits three signals: **metrics** for Prometheus, **logs** as structured text or JSONL, and
+**traces** over OpenTelemetry Protocol (OTLP). This page installs the metrics and logging backends.
+To collect traces, provide an OTLP collector and trace backend that the Dynamo pods can reach; this
+reference stack does not install them.
 
 ## Signals at a glance
 
 | Signal | Turn it on with | Collected by |
 |--------|-----------------|--------------|
 | Metrics | `DYN_SYSTEM_PORT` (workers/router); the frontend serves metrics on its HTTP port | Prometheus |
-| Traces | `OTEL_EXPORT_ENABLED=true` + an OTLP endpoint | Tempo |
-| Logs | `DYN_LOGGING_CONSOLE_FORMAT=jsonl` for console JSONL; `OTEL_EXPORT_ENABLED=true` to export | Loki |
+| Traces | `OTEL_EXPORT_ENABLED=true` + an OTLP endpoint | User-provided collector and trace backend |
+| Logs | `DYN_LOGGING_CONSOLE_FORMAT=jsonl` for console JSONL; `OTEL_EXPORT_ENABLED=true` for OTLP export | Alloy and Loki for stdout; user-provided collector and backend for OTLP |
 | FPM traces | `DYN_FPM_TRACE=1` or `--fpm-trace` | Rotating gzip JSONL files |
 | Health status | `/live` and `/health` endpoints | Supervisors or Kubernetes probes |
 | Request traces | `DYN_REQUEST_TRACE=1` or `DYN_REQUEST_TRACE_RECORDS` | Files, NATS, stderr, or OTLP logs |
 
-`OTEL_EXPORT_ENABLED` is the master switch for both traces and logs — without it, neither leaves the process even when Tempo and Loki are healthy. Dynamo supports OTLP over `grpc` and `http/protobuf`. Use `OTEL_EXPORTER_OTLP_ENDPOINT` for a shared collector or signal-specific endpoint variables for separate destinations. For the full variable catalog — defaults, per-signal grouping, and the Kubernetes operator presets — see [Environment Variables](../../reference/observability/environment-variables.mdx).
+`OTEL_EXPORT_ENABLED` is the master switch for OTLP-exported traces and log records. It does not
+control console output: the reference logging stack collects JSONL from pod stdout with Alloy and
+sends it to Loki. Dynamo supports OTLP over `grpc` and `http/protobuf`. Use
+`OTEL_EXPORTER_OTLP_ENDPOINT` for a shared collector or signal-specific endpoint variables for
+separate destinations. For the full variable catalog, including defaults and Kubernetes operator
+presets, see
+[Environment Variables](../../reference/observability/environment-variables.mdx).
 
 For scheduler telemetry, see [Observe a Local Deployment](../../cli/operations/observability.mdx#capture-forward-pass-metrics). For replay metadata or request payload capture, see [Observe a Local Deployment](../../cli/operations/observability.mdx#capture-and-replay-requests).
 
@@ -27,11 +36,20 @@ For scheduler telemetry, see [Observe a Local Deployment](../../cli/operations/o
 
 ## Kubernetes stack
 
-On Kubernetes, install the monitoring backends once, then enable signals per deployment — see [Observability](../operations/observability.mdx) under Operations for the per-deployment steps. The Dynamo operator wires metrics scraping automatically (it adds a `PodMonitor` to every managed pod), so the only one-time work is installing Prometheus, the exporters, and the logging stack.
+On Kubernetes, install the monitoring backends once, then enable signals per deployment. See
+[Observability](../operations/observability.mdx) under Operations for the per-deployment steps. The
+Dynamo platform chart creates `PodMonitor` resources that select operator-managed pods, so the
+one-time work is installing Prometheus, the exporters, and the logging stack.
+
+If your platform already provides an OTLP collector and trace backend, use the
+[distributed trace export workflow](../operations/observability.mdx#export-distributed-traces-and-logs)
+to connect Dynamo to them.
 
 ### kube-prometheus-stack
 
-Install Prometheus, Grafana, and the Prometheus Operator. The selector flags let Prometheus discover `PodMonitor` and `ServiceMonitor` resources created outside its own Helm release (such as the ones the Dynamo operator creates):
+Install Prometheus, Grafana, and the Prometheus Operator. The selector flags let Prometheus discover
+`PodMonitor` and `ServiceMonitor` resources created outside its own Helm release, including the
+ones created by the Dynamo platform chart:
 
 ```bash
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
@@ -45,9 +63,28 @@ helm install prometheus prometheus-community/kube-prometheus-stack \
 ```
 
 > [!NOTE]
-> The Dynamo install command in the [Installation Guide](install-dynamo.md#kube-prometheus-stack) sets `dynamo-operator.dynamo.metrics.prometheusEndpoint` to point the operator at this Prometheus. Set it there, in one pass, rather than here.
+> Install Prometheus before Dynamo when possible. The Dynamo install command in the
+> [Installation Guide](install-dynamo.md#kube-prometheus-stack) sets
+> `dynamo-operator.dynamo.metrics.prometheusEndpoint`, and the platform chart detects the Prometheus
+> Operator CRDs and creates its `PodMonitor` resources in that same install.
 >
 > An older form of the discovery flags used `--set ...podMonitorNamespaceSelector.matchLabels=null` (and the same for `probeNamespaceSelector`). The `--set-json '...={}'` form above is equivalent and preferred; use one form or the other consistently, not both.
+
+If Dynamo is already installed, installing Prometheus does not retroactively create the monitors or
+configure the endpoint. Upgrade the existing platform release with the same chart version and any
+other values from its original install, adding these settings:
+
+```bash
+helm upgrade dynamo-platform dynamo-platform-$RELEASE_VERSION.tgz \
+  --namespace $NAMESPACE \
+  --reuse-values \
+  --set "dynamo-operator.dynamo.metrics.prometheusEndpoint=http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090" \
+  --set "dynamo-operator.dynamo.metrics.podMonitors.enabled=true"
+```
+
+This command uses `RELEASE_VERSION` and `NAMESPACE` from the
+[Installation Guide](install-dynamo.md#install-the-dynamo-platform). Setting `podMonitors.enabled`
+to `true` makes the upgrade explicit instead of relying on chart auto-detection.
 
 kube-prometheus-stack bundles **node-exporter** by default, which supplies the node CPU, system load, and container resource panels on the Dynamo dashboard. Verify it is running:
 
@@ -97,10 +134,11 @@ If the output is empty, install it via the GPU Operator or the standalone dcgm-e
 
 To collect pod logs into Grafana Loki, install Loki and the Grafana Alloy collector. This reference setup suits development and testing clusters (including Minikube and MicroK8s); use a high-availability configuration for production.
 
-Set the namespaces once:
+Set the namespaces once. The supplied Grafana datasource uses the in-namespace service name
+`loki-gateway`, so this reference setup keeps Grafana and Loki together in `monitoring`:
 
 ```bash
-export MONITORING_NAMESPACE=monitoring    # where Loki is installed
+export MONITORING_NAMESPACE=monitoring    # where Prometheus, Grafana, and Loki are installed
 export DYN_NAMESPACE=dynamo-system        # where Dynamo is installed
 ```
 

--- a/docs/fern/pages/kubernetes/operations/observability.mdx
+++ b/docs/fern/pages/kubernetes/operations/observability.mdx
@@ -8,7 +8,8 @@ subtitle: View Dynamo metrics, configure structured logs and distributed traces,
 Dynamo provides four core signals for running deployments:
 
 - **Metrics** expose request, latency, routing, worker, cache, and operator measurements. Metrics are
-  enabled by default, and the operator creates the resources required for Prometheus discovery.
+  enabled by default; the platform chart creates the monitors, and the operator labels managed pods
+  for Prometheus discovery.
 - **Logs** record component events on standard output. Enable structured JSONL output when you need
   reliable filtering and request correlation.
 - **Distributed traces** follow requests from the frontend through participating Dynamo components.
@@ -33,9 +34,9 @@ For exact metric names, labels, variables, schemas, and endpoint responses, use 
 
 ## View Metrics and Dashboards
 
-Application metrics are enabled by default. The operator creates a `PodMonitor` and labels managed
-pods for discovery, so a normal DynamoGraphDeployment (DGD) requires no metrics configuration.
-Operator metrics use a separate `ServiceMonitor` created by the Helm chart.
+Application metrics are enabled by default. The platform chart creates `PodMonitor` resources, and
+the operator labels managed pods for discovery, so a normal DynamoGraphDeployment (DGD) requires no
+metrics configuration. Operator metrics use a separate `ServiceMonitor` created by the Helm chart.
 
 <Steps toc={true}>
 <Step title="Verify Prometheus discovery" id="verify-prometheus-discovery">
@@ -130,20 +131,41 @@ NIXL transfer metrics are optional and are populated during disaggregated servin
 embedding transfers.
 
 <Steps toc={true}>
+<Step title="Enable NIXL scraping in the platform chart" id="enable-nixl-scraping">
+
+The worker `PodMonitor` does not include the NIXL endpoint by default. Upgrade the Dynamo platform
+release with the same chart version and values used for installation, adding the NIXL telemetry
+setting:
+
+```bash
+helm upgrade dynamo-platform dynamo-platform-$RELEASE_VERSION.tgz \
+  --namespace $NAMESPACE \
+  --reuse-values \
+  --set "dynamo-operator.dynamo.metrics.podMonitors.nixlTelemetry=true"
+```
+
+If the chart does not already create `PodMonitor` resources, also set
+`dynamo-operator.dynamo.metrics.podMonitors.enabled=true`. See
+[PodMonitors created by the Dynamo chart](../installation/observability.md#podmonitors-created-by-the-dynamo-chart)
+for the creation modes.
+
+</Step>
 <Step title="Enable telemetry on the worker" id="enable-nixl-telemetry">
 
-Add `NIXL_TELEMETRY_ENABLE` to each worker that should expose transfer metrics:
+Merge `NIXL_TELEMETRY_ENABLE` into the `main` container of each existing worker component that
+should expose transfer metrics. Keep the component's existing image and other fields:
 
 ```yaml
 spec:
-  services:
-    VllmDecodeWorker:
-      componentType: worker
-      extraPodSpec:
-        mainContainer:
-          env:
-            - name: NIXL_TELEMETRY_ENABLE
-              value: "y"
+  components:
+    - name: VllmDecodeWorker
+      podTemplate:
+        spec:
+          containers:
+          - name: main
+            env:
+              - name: NIXL_TELEMETRY_ENABLE
+                value: "y"
 ```
 
 NIXL exposes these metrics on its telemetry port, which defaults to `19090`. See
@@ -170,15 +192,12 @@ backend needs structured fields for filtering and trace correlation.
 <Steps toc={true}>
 <Step title="Enable JSONL logging" id="enable-jsonl-logging">
 
-Set the logging variables at graph level to apply them to every component:
+Merge the logging variables into the DGD's graph-level `spec.env` list to apply them to every
+component:
 
 ```yaml
-apiVersion: nvidia.com/v1alpha1
-kind: DynamoGraphDeployment
-metadata:
-  name: vllm-agg-logging
 spec:
-  envs:
+  env:
     - name: DYN_LOGGING_CONSOLE_FORMAT
       value: "jsonl"
     - name: DYN_LOG
@@ -192,18 +211,20 @@ complete configuration.
 </Step>
 <Step title="Override a component log level" id="override-component-log-level">
 
-Add a component-level value when one component needs more detail than the rest of the graph:
+When one component needs more detail than the rest of the graph, merge a component-level value into
+its existing `main` container:
 
 ```yaml
 spec:
-  services:
-    Frontend:
-      componentType: frontend
-      extraPodSpec:
-        mainContainer:
-          env:
-            - name: DYN_LOG
-              value: "info,dynamo_runtime::system_status_server:trace"
+  components:
+    - name: Frontend
+      podTemplate:
+        spec:
+          containers:
+          - name: main
+            env:
+              - name: DYN_LOG
+                value: "info,dynamo_runtime::system_status_server:trace"
 ```
 
 The component value overrides the graph-level value for that container.
@@ -245,11 +266,11 @@ The collector is responsible for routing traces and logs to the configured stora
 </Step>
 <Step title="Enable OTLP export" id="enable-otlp-export">
 
-Add the OpenTelemetry settings to the DGD:
+Merge the OpenTelemetry settings into the existing graph-level `spec.env` list:
 
 ```yaml
 spec:
-  envs:
+  env:
     - name: OTEL_EXPORT_ENABLED
       value: "true"
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -291,28 +312,32 @@ example below expects an existing PVC named `fpm-traces`.
 </Step>
 <Step title="Enable FPM tracing" id="enable-fpm-tracing">
 
-Mount the PVC on each worker that should write a trace and set the output prefix inside the mount:
+For each worker that should write a trace, merge the PVC volume, mount, and output settings into the
+existing component. Keep the component's existing image and other fields:
 
 ```yaml
 spec:
-  pvcs:
-    - create: false
-      name: fpm-traces
-  services:
-    VllmWorker:
-      volumeMounts:
-        - name: fpm-traces
-          mountPoint: /var/log/dynamo
-      extraPodSpec:
-        mainContainer:
-          env:
-            - name: DYN_FPM_TRACE
-              value: "1"
-            - name: DYN_FPM_OUTPUT_PATH
-              value: /var/log/dynamo/fpm
+  components:
+    - name: VllmWorker
+      podTemplate:
+        spec:
+          containers:
+          - name: main
+            env:
+              - name: DYN_FPM_TRACE
+                value: "1"
+              - name: DYN_FPM_OUTPUT_PATH
+                value: /var/log/dynamo/fpm
+            volumeMounts:
+              - name: fpm-traces
+                mountPath: /var/log/dynamo
+          volumes:
+            - name: fpm-traces
+              persistentVolumeClaim:
+                claimName: fpm-traces
 ```
 
-Replace `VllmWorker` with every worker service that should write scheduler telemetry.
+Replace `VllmWorker` with every worker component that should write scheduler telemetry.
 
 </Step>
 <Step title="Collect the trace files" id="collect-fpm-trace-files">
@@ -382,18 +407,14 @@ If startup is delayed by downloading model weights, prefer
 </Step>
 <Step title="Override the probes" id="override-health-probes">
 
-Set standard Kubernetes probes on the `main` container in the component's `podTemplate`. This example
-extends the startup window and allows several consecutive liveness failures:
+Merge standard Kubernetes probes into the `main` container in the existing component's
+`podTemplate`. Keep the component's image and other fields. This fragment extends the startup window
+and allows several consecutive liveness failures:
 
 ```yaml
-apiVersion: nvidia.com/v1beta1
-kind: DynamoGraphDeployment
-metadata:
-  name: my-deployment
 spec:
   components:
   - name: VllmWorker
-    type: worker
     podTemplate:
       spec:
         containers:

--- a/docs/fern/pages/reference/observability/environment-variables.mdx
+++ b/docs/fern/pages/reference/observability/environment-variables.mdx
@@ -42,29 +42,30 @@ Every Dynamo process reads its own environment at startup, so set these on each 
     Use `python -m dynamo.sglang` or `python -m dynamo.trtllm` for the other backends, and `python -m dynamo.router` for a standalone router.
   </Tab>
   <Tab title="Kubernetes">
-    Set the variables on the [`DynamoGraphDeployment`](../kubernetes-api/dynamo-graph-deployment.mdx) (DGD) — at graph level in `spec.envs` (prepended to every component) or per-component under `services.<name>.extraPodSpec.mainContainer.env`. A component-level entry overrides a graph-level one of the same name.
+    Set the variables on the [`DynamoGraphDeployment`](../kubernetes-api/dynamo-graph-deployment.mdx)
+    (DGD): at graph level in `spec.env` (prepended to every component) or per-component under the
+    `main` container in `spec.components[].podTemplate`. A component-level entry overrides a
+    graph-level one of the same name. Merge this fragment into an existing DGD and keep each
+    component's image and other fields:
 
     ```yaml
-    apiVersion: nvidia.com/v1alpha1
-    kind: DynamoGraphDeployment
-    metadata:
-      name: vllm-agg-tracing
     spec:
-      envs:                              # applied to every component
+      env:                               # applied to every component
         - name: DYN_LOGGING_CONSOLE_FORMAT
           value: "jsonl"
         - name: OTEL_EXPORT_ENABLED
           value: "true"
         - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-          value: "http://tempo.observability.svc.cluster.local:4317"
-      services:
-        Frontend:
-          componentType: frontend
-          extraPodSpec:
-            mainContainer:
-              env:                       # applied to this component only
-                - name: OTEL_SERVICE_NAME
-                  value: "dynamo-frontend"
+          value: "http://otel-collector.observability.svc.cluster.local:4317"
+      components:
+        - name: Frontend
+          podTemplate:
+            spec:
+              containers:
+                - name: main
+                  env:                    # applied to this component only
+                    - name: OTEL_SERVICE_NAME
+                      value: "dynamo-frontend"
     ```
 
     <Note>


### PR DESCRIPTION
## Summary

Fix the Kubernetes observability path so readers can find it and apply its examples to the current
`v1beta1` `DynamoGraphDeployment` API.

## Overview

The published Operations guide linked to an installation page that was absent from Fern navigation.
That page also described a trace backend the Kubernetes reference stack does not install, while its
metrics and logging instructions had ordering, ownership, and templating gaps. Several Operations
and reference examples still used legacy `v1alpha1` field paths.

## Details

- Add the Kubernetes observability installation page to Fern navigation.
- State exactly which metrics and logging components the reference stack installs, and make the
  OTLP collector and trace-backend prerequisite explicit.
- Document the Prometheus-before-Dynamo install order and the platform upgrade required when
  Prometheus is installed later.
- Correct ownership of `PodMonitor` creation and document the chart switch required to scrape NIXL
  telemetry.
- Migrate logging, OTLP, FPM, health-probe, and environment-variable examples to the current
  `v1beta1` `spec.env` and `spec.components[].podTemplate` paths.
- Replace the literal `$MONITORING_NAMESPACE` in the raw-applied Loki datasource with the valid
  same-namespace Kubernetes service name used by the documented stack.

## Where should the reviewer start?

Start with `docs/fern/pages/kubernetes/installation/observability.md` for installation ordering and
signal scope, then review `docs/fern/pages/kubernetes/operations/observability.mdx` for the current
DGD examples and NIXL prerequisite.

## Validation

- `uvx pre-commit run --files ...` passes for all six changed files.
- `npx --yes fern-api check` reports 0 errors and 2 warnings.
- All seven changed YAML code blocks parse successfully.
- A targeted check confirms that the corrected examples contain no legacy `envs`, `services`,
  `extraPodSpec`, `mainContainer`, `mountPoint`, or `pvcs` field paths.
- `git diff --check` passes.
- `npx --yes fern-api docs broken-links` adds no observability errors. It still reports 10 existing
  errors in `pages/kubernetes/installation/tls.md` and
  `pages/recipes/model-recipes/qwen-3-8-2-4t-a95b-fp8.mdx`, both outside this change.

## Related Issues

Relates to #13389


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Kubernetes observability installation guidance and navigation.
  * Clarified metrics, logging, tracing, OTLP, Alloy, and Loki configuration.
  * Updated installation instructions for PodMonitor resources and upgrade ordering.
  * Revised operational examples to use current component-based configuration.
  * Updated environment variable guidance with mergeable configuration examples.
* **Bug Fixes**
  * Corrected the Loki datasource connection for same-namespace deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->