### PR TITLE
ci: fix docs website fetch race

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -273,7 +273,8 @@ jobs:
     # than the tree that actually publishes. This replays both jobs against
     # docs-website and runs fern check on the composed result.
     - name: Fetch docs-website
-      run: git fetch --no-tags --depth=1 origin docs-website:refs/remotes/origin/docs-website
+      # Force only this ephemeral tracking ref in case docs-website advances during checkout.
+      run: git fetch --no-tags --depth=1 origin +docs-website:refs/remotes/origin/docs-website
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
       with:
         node-version: '22'


### PR DESCRIPTION
## Summary

Make the docs composition pre-merge check tolerate `docs-website` advancing while the PR checkout
is in progress.

## Overview

PR #14084 exposed a race in the `Docs Website Composition Check`. `actions/checkout` fetched all
branches, the CI-managed `docs-website` branch advanced, and the subsequent depth-one fetch tried to
update the existing remote-tracking ref without a forced refspec. Because the shallow fetch hid the
new tip's ancestry, Git rejected the legitimate branch advance as non-fast-forward before any
composition validation ran. The unchanged rerun passed after the branch stopped moving.

## Details

- Add `+` to the source side of the explicit `docs-website` fetch refspec.
- Limit the force-update to the workflow runner's ephemeral
  `refs/remotes/origin/docs-website` tracking ref.
- Preserve the existing behavior of composing against the latest published branch tip.
- Add a comment explaining why the forced refspec is required.

## Where should the reviewer start?

Review the `Fetch docs-website` step in `.github/workflows/pre-merge.yml`.

## Validation

- Reproduced the race with a local bare remote: the existing unforced depth-one fetch exits 1 with
  `non-fast-forward` after `docs-website` advances.
- Repeated the same fetch with `+docs-website:refs/remotes/origin/docs-website`: it exits 0 and the
  tracking ref matches the new remote tip exactly.
- `uvx pre-commit run --files .github/workflows/pre-merge.yml` passes.
- The workflow parses as YAML.
- `git diff --check` passes.
- On PR #14084, attempt 1 failed in `Fetch docs-website` with this exact rejection; the unchanged
  attempt 2 passed the fetch and the complete composition check.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation-site branch fetching during pre-merge checks to ensure the latest branch state is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->