### PR TITLE
fix(frontend): align Python frontend output postprocessing for structured output, forced tool calls, and parser markers

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -66,6 +66,7 @@ class PreprocessResult:
     prompt_token_ids: list[int]
     guided_decoding: dict[str, Any] | None = None
     uses_dynamo_json_tool_call_fallback: bool = False
+    guided_output_is_content: bool = False
 
 
 _ASYNC_TOKENIZER_POOL: dict[int, Callable[..., Awaitable[Any]]] = {}
@@ -775,6 +776,9 @@ async def preprocess_chat_request(
         prompt_token_ids=tokens,
         guided_decoding=guided_decoding,
         uses_dynamo_json_tool_call_fallback=uses_dynamo_json_tool_call_fallback,
+        guided_output_is_content=(
+            assistant_guided_decoding is not None and not is_forced_tool_choice
+        ),
     )
 
 
@@ -809,6 +813,7 @@ class StreamingPostProcessor:
         response_reasoning_ended: bool | None = None,
         stream_response: bool = True,
         uses_dynamo_json_tool_call_fallback: bool = False,
+        guided_output_is_content: bool = False,
     ) -> None:
         self.tokenizer = tokenizer
         self.request_for_sampling = request_for_sampling
@@ -834,6 +839,7 @@ class StreamingPostProcessor:
             )
             if _reasoning_parser_enabled(reasoning_parser_class, chat_template_kwargs)
             and response_reasoning_ended is not True
+            and not guided_output_is_content
             else None
         )
         if self.reasoning_parser is not None:

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -635,6 +635,45 @@ def _prepare_request(
     )
 
 
+# The forced-choice fallback first decided by #12876 assumed the parser either
+# installs a grammar or the request dies without tool decoding. Parsers that
+# decline forced-choice grammars still differ in what their models emit: GLM's
+# declarative engine adapters are trained to produce Dynamo's bare-JSON shape,
+# while native-syntax parsers (Mistral, Gemma4Engine, PoolsideV1, ...) emit
+# markup meant for their own extract_tool_calls_streaming. Only the former may
+# use the buffer-and-decode fallback; extending it to the latter hides native
+# tool markup as assistant content. Extend the list when a parser is verified
+# to emit bare JSON for forced choices; never derive it from
+# supports_required_and_named alone, which native-syntax parsers also clear.
+_BARE_JSON_FORCED_CHOICE_PARSER_NAMES = frozenset(
+    {
+        "Glm47MoeModelToolParser",
+        "Glm47MoeParserToolAdapter",
+    }
+)
+
+
+def _parser_cannot_force_choice_but_emits_bare_json(
+    tool_parser: ToolParser | None,
+    guided_decoding: dict[str, Any] | None,
+    parser_guided_decoding: dict[str, Any] | None,
+) -> bool:
+    if tool_parser is None:
+        return False
+    if getattr(tool_parser, "supports_required_and_named", True):
+        return False
+    if type(tool_parser).__name__ not in _BARE_JSON_FORCED_CHOICE_PARSER_NAMES:
+        return False
+    if parser_guided_decoding is not None:
+        # The parser adjusted the request itself; its guidance owns the stream.
+        return False
+    if isinstance(guided_decoding, dict) and "structural_tag" in guided_decoding:
+        # A structural tag is a native forced-choice grammar: its output must
+        # go through the parser's native-syntax decoder, not the JSON fallback.
+        return False
+    return True
+
+
 async def preprocess_chat_request(
     request: dict[str, Any] | ChatCompletionRequest,
     *,
@@ -776,12 +815,16 @@ async def preprocess_chat_request(
     # adjust_request() leaves structured_outputs unchanged.  In either case the
     # model emits Dynamo's bare JSON wire format, which must bypass the parser's
     # native-syntax decoder during postprocessing.
-    uses_dynamo_json_tool_call_fallback = (
-        is_forced_tool_choice
-        and parser_guided_decoding is None
-        and guided_decoding is tool_guided_decoding
-        and isinstance(tool_guided_decoding, dict)
-        and ("json" in tool_guided_decoding or "regex" in tool_guided_decoding)
+    uses_dynamo_json_tool_call_fallback = is_forced_tool_choice and (
+        (
+            parser_guided_decoding is None
+            and guided_decoding is tool_guided_decoding
+            and isinstance(tool_guided_decoding, dict)
+            and ("json" in tool_guided_decoding or "regex" in tool_guided_decoding)
+        )
+        or _parser_cannot_force_choice_but_emits_bare_json(
+            tool_parser, guided_decoding, parser_guided_decoding
+        )
     )
 
     _, engine_prompt = await renderer.render_messages_async(messages, chat_params)
@@ -939,9 +982,18 @@ class StreamingPostProcessor:
             )
             if _reasoning_parser_enabled(reasoning_parser_class, chat_template_kwargs)
             and response_reasoning_ended is not True
-            and not guided_output_is_content
             else None
         )
+        # Guided output is structured content, not reasoning. A reasoning parser
+        # whose turn starts in reasoning mode would swallow a bare-JSON guided
+        # payload into reasoning_content entirely, so such streams bypass the
+        # parser -- but only once the stream's first payload text proves the
+        # bare-shape (guided JSON with no reasoning opener), mirroring the Rust
+        # preprocessor's bypass_reasoning_for_bare_guided_json. Otherwise the
+        # parser stays active so deferred grammar output still flows through
+        # the reasoning channel.
+        self._guided_output_is_content = guided_output_is_content
+        self._guided_shape_checked = False
         if self.reasoning_parser is not None:
             if response_reasoning_ended is None:
                 self.reasoning_is_done = self.reasoning_parser.is_reasoning_end(
@@ -1231,13 +1283,6 @@ class StreamingPostProcessor:
         return self._marker_strip_re.sub("", text)
 
     def _strip_parser_control_markers(self, text: str | None) -> str | None:
-        """Strip parser-declared composite markers and stop-trimmed suffixes.
-
-        Complements `_strip_control_markers`, which only sees whole special
-        tokens: this one sees the parser's own multi-token markers
-        (`<|open|>response<|sep|>`) and their orphaned remainders
-        (`message<|sep|>`), whitespace-tolerantly.
-        """
         if not text or self._parser_marker_re is None:
             return text
         return self._parser_marker_re.sub("", text)
@@ -1408,7 +1453,11 @@ class StreamingPostProcessor:
 
         saved_reasoning = None
         content = current_text
-        if self.reasoning_parser:
+        bare_guided_json = (
+            self._guided_output_is_content
+            and current_text.lstrip().startswith(("{", "["))
+        )
+        if self.reasoning_parser and not bare_guided_json:
             saved_reasoning, content = self.reasoning_parser.extract_reasoning(
                 current_text,
                 request=self.request_for_sampling,
@@ -1470,6 +1519,19 @@ class StreamingPostProcessor:
         current_token_ids = self.previous_token_ids + delta_token_ids
 
         delta_message: DeltaMessage | None = DeltaMessage(content=delta_text)
+
+        if (
+            self.reasoning_parser is not None
+            and not self.reasoning_is_done
+            and not self._guided_shape_checked
+            and self._guided_output_is_content
+        ):
+            self._guided_shape_checked = True
+            if current_text.lstrip().startswith(("{", "[")):
+                # Bare structured payload with no reasoning opener: keep it as
+                # content instead of letting the parser trap it as reasoning.
+                self.reasoning_is_done = True
+                self.reasoning_parser = None
 
         # ------------------------------------------------------------------
         # Drain the tool-text buffer (populated when </think> and <tool_call>

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -26,7 +26,7 @@ from vllm.entrypoints.openai.engine.protocol import (
 )
 from vllm.reasoning import ReasoningParser
 from vllm.renderers import ChatParams, merge_kwargs
-from vllm.sampling_params import SamplingParams
+from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers import ToolParser
 from vllm.tool_parsers.utils import get_json_schema_from_tools
@@ -458,6 +458,9 @@ def _prepare_request(
     enable_auto_tool_choice: bool = False,
     default_chat_template_kwargs: dict[str, Any] | None = None,
     default_thinking_mode: str | None = None,
+    structural_tag_mode: str = "off",
+    structural_tag_scope: str = "auto",
+    structural_tag_schema: str = "auto",
     validated_request: ChatCompletionRequest | None = None,
     guidance_snapshots: dict[str, Any] | None = None,
 ) -> tuple[ChatCompletionRequest, ToolParser | None, dict[str, Any], Any, ChatParams]:
@@ -488,10 +491,32 @@ def _prepare_request(
     # client did not supply an explicit `tools` list, so we activate the parser
     # whenever the tool_parser_class is available.
     has_tools = bool(request_for_sampling.tools)
-    if tool_parser_class and (has_tools or enable_auto_tool_choice):
-        if request_for_sampling.tool_choice != "none":
-            tool_parser = tool_parser_class(tokenizer, request_for_sampling.tools)
-            request_for_sampling = tool_parser.adjust_request(request_for_sampling)
+    if (
+        tool_parser_class
+        and (has_tools or enable_auto_tool_choice)
+        and request_for_sampling.tool_choice != "none"
+    ):
+        tool_parser = tool_parser_class(tokenizer, request_for_sampling.tools)
+        # Kimi K3's raw parser rejects a named tool choice unless its XTML
+        # structural tag is already attached. Standard vLLM satisfies that
+        # contract in DelegatingParser before invoking adjust_request().
+        # Dynamo owns the equivalent orchestration here, so mirror that
+        # ordering instead of waiting until guided decoding is assembled
+        # below. Other parsers are unchanged when they return no tag.
+        pre_adjust_guidance = build_tool_call_guided_decoding(
+            request_for_sampling,
+            tool_parser,
+            structural_tag_mode=structural_tag_mode,
+            structural_tag_scope=structural_tag_scope,
+            structural_tag_schema=structural_tag_schema,
+        )
+        if pre_adjust_guidance is not None and set(pre_adjust_guidance) == {
+            "structural_tag"
+        }:
+            request_for_sampling.structured_outputs = StructuredOutputsParams(
+                structural_tag=json.dumps(pre_adjust_guidance["structural_tag"])
+            )
+        request_for_sampling = tool_parser.adjust_request(request_for_sampling)
 
     # Strip tools from the template when tool_choice=none so the model doesn't
     # see them and generate raw XML tool calls in its response.
@@ -656,6 +681,9 @@ async def preprocess_chat_request(
         enable_auto_tool_choice=enable_auto_tool_choice,
         default_chat_template_kwargs=default_chat_template_kwargs,
         default_thinking_mode=default_thinking_mode,
+        structural_tag_mode=structural_tag_mode,
+        structural_tag_scope=structural_tag_scope,
+        structural_tag_schema=structural_tag_schema,
         validated_request=validated_request,
         guidance_snapshots=guidance_snapshots,
     )

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -1053,9 +1053,15 @@ class StreamingPostProcessor:
             self._marker_strip_re = _compile_marker_strip_re(
                 tuple(m for m in self._control_markers if m not in owned)
             )
-        self._parser_marker_re = _compile_parser_marker_re(
+        self._parser_marker_variants = frozenset(
             _parser_control_markers(self.tool_parser, self.reasoning_parser)
         )
+        self._parser_marker_re = _compile_parser_marker_re(
+            tuple(sorted(self._parser_marker_variants))
+        )
+        # Chars withheld while they can still complete into a marker, per
+        # choice index. See _apply_marker_holdback.
+        self._marker_pending: dict[int, str] = {}
 
         self.previous_text = ""
         self.previous_token_ids: list[int] = []
@@ -1287,6 +1293,39 @@ class StreamingPostProcessor:
             return text
         return self._parser_marker_re.sub("", text)
 
+    def _apply_marker_holdback(
+        self, index: int, text: str | None, finish_reason: str | None
+    ) -> str | None:
+        """Buffer marker prefixes that may still complete in a later delta.
+
+        vLLM deltas are token-aligned in practice, but nothing guarantees it:
+        a delta can split inside a composite marker's channel word (Kimi K3's
+        `response` in `res` + `ponse<|sep|>`), in which case neither the full
+        nor the orphan pattern matches until both halves arrived. Hold only
+        the longest trailing segment that is a strict prefix of a configured
+        marker variant; everything else is emitted immediately. On the
+        finishing delta -- or once the candidate extends past the longest
+        marker -- the held text is flushed verbatim, so ordinary content is
+        never dropped.
+        """
+        if not self._parser_marker_variants:
+            return text
+        pending = self._marker_pending.pop(index, "")
+        body = (pending + (text or "")) or None
+        if body is None:
+            return None
+        body = self._strip_parser_control_markers(body)
+        if not body or finish_reason:
+            return body
+        max_len = max(len(m) for m in self._parser_marker_variants)
+        limit = min(len(body), max_len - 1)
+        for k in range(limit, 0, -1):
+            segment = body[-k:]
+            if any(v.startswith(segment) for v in self._parser_marker_variants):
+                self._marker_pending[index] = segment
+                return body[:-k] or None
+        return body
+
     @staticmethod
     def _compose_delta_message(
         reasoning: str | None, content: str | None
@@ -1423,9 +1462,15 @@ class StreamingPostProcessor:
         # the producers as well only re-scans text that is about to be scanned.
         if isinstance(delta.get("content"), str):
             # Composite markers must go first: they match across control-token
-            # boundaries, which `_strip_control_markers` would erase.
+            # boundaries, which `_strip_control_markers` would erase. Holdback
+            # also runs before the literal strip so a marker completed across
+            # deltas is still recognizable.
             stripped = self._strip_control_markers(
-                self._strip_parser_control_markers(delta["content"])
+                self._apply_marker_holdback(
+                    output.index,
+                    self._strip_parser_control_markers(delta["content"]),
+                    output.finish_reason,
+                )
             )
             if stripped:
                 delta["content"] = stripped

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -826,6 +826,78 @@ def _compile_marker_strip_re(strippable: tuple[str, ...]) -> "re.Pattern[str] | 
     return re.compile("|".join(re.escape(m) for m in ordered))
 
 
+# Parser attributes that carry complete control markers. Only string values are
+# honoured; the attribute names are a convention followed by wrapped-channel
+# parsers such as Kimi K3's, and absent attributes simply contribute nothing.
+_PARSER_MARKER_ATTRIBUTES = (
+    "response_open",
+    "response_close",
+    "tools_open",
+    "tools_close",
+    "_response_open",
+    "_response_close",
+    "_message_close",
+    "_think_open",
+    "_think_close",
+)
+
+
+def _parser_control_markers(
+    tool_parser: ToolParser | None,
+    reasoning_parser: Any,
+) -> tuple[str, ...]:
+    """Composite control markers declared by the active parsers.
+
+    `_marker_strip_re` only knows tokenizer-level special tokens, which strips
+    complete markers like `<|open|>` but cannot remove the channel words that
+    live *between* a parser's control tokens (Kimi K3's
+    `<|open|>response<|sep|>` sheds its tokens but leaks `response`), nor the
+    stop-trimmed derivative the engine can emit when its stop consumes only
+    the leading control token (`<|close|>message<|sep|>` -> `message<|sep|>`).
+    Return the parsers' complete markers plus such orphaned variants.
+    """
+    markers: list[str] = []
+    for parser in (tool_parser, reasoning_parser):
+        if parser is None:
+            continue
+        for attribute in _PARSER_MARKER_ATTRIBUTES:
+            marker = getattr(parser, attribute, None)
+            if isinstance(marker, str) and marker and marker not in markers:
+                markers.append(marker)
+    for marker in list(markers):
+        # Engines may trim only the marker's leading control token at a stop
+        # boundary, leaving the rest behind.  The remainder is considered an
+        # orphan only when it still ends in a registered control token, so
+        # ordinary channel words alone (`message`) never match this pattern.
+        leading_control = re.match(r"<\|[^>]+\|>", marker)
+        if leading_control is not None:
+            orphaned = marker[leading_control.end() :]
+            if re.search(r"<\|[^>]+\|>", orphaned) and orphaned not in markers:
+                markers.append(orphaned)
+    return tuple(markers)
+
+
+def _whitespace_tolerant_marker_pattern(marker: str) -> str:
+    pieces = re.split(r"(<\|[^>]+\|>)", marker)
+    inner = r"\s*".join(re.escape(piece) for piece in pieces if piece)
+    # A wrapper can be stream-split after its leading control token, so the
+    # remainder may arrive with formatting whitespace in front of the channel
+    # word (` response <|sep|>Hello`).
+    return r"\s*" + inner
+
+
+def _compile_parser_marker_re(markers: tuple[str, ...]) -> "re.Pattern[str] | None":
+    if not markers:
+        return None
+    # Longest-first so a complete marker wins over its orphaned variant.
+    patterns = sorted(
+        (_whitespace_tolerant_marker_pattern(m) for m in markers),
+        key=len,
+        reverse=True,
+    )
+    return re.compile("|".join(patterns))
+
+
 class StreamingPostProcessor:
     def __init__(
         self,
@@ -929,6 +1001,9 @@ class StreamingPostProcessor:
             self._marker_strip_re = _compile_marker_strip_re(
                 tuple(m for m in self._control_markers if m not in owned)
             )
+        self._parser_marker_re = _compile_parser_marker_re(
+            _parser_control_markers(self.tool_parser, self.reasoning_parser)
+        )
 
         self.previous_text = ""
         self.previous_token_ids: list[int] = []
@@ -1155,6 +1230,18 @@ class StreamingPostProcessor:
             return text
         return self._marker_strip_re.sub("", text)
 
+    def _strip_parser_control_markers(self, text: str | None) -> str | None:
+        """Strip parser-declared composite markers and stop-trimmed suffixes.
+
+        Complements `_strip_control_markers`, which only sees whole special
+        tokens: this one sees the parser's own multi-token markers
+        (`<|open|>response<|sep|>`) and their orphaned remainders
+        (`message<|sep|>`), whitespace-tolerantly.
+        """
+        if not text or self._parser_marker_re is None:
+            return text
+        return self._parser_marker_re.sub("", text)
+
     @staticmethod
     def _compose_delta_message(
         reasoning: str | None, content: str | None
@@ -1290,7 +1377,11 @@ class StreamingPostProcessor:
         # enforced once at the funnel rather than at each producer -- stripping at
         # the producers as well only re-scans text that is about to be scanned.
         if isinstance(delta.get("content"), str):
-            stripped = self._strip_control_markers(delta["content"])
+            # Composite markers must go first: they match across control-token
+            # boundaries, which `_strip_control_markers` would erase.
+            stripped = self._strip_control_markers(
+                self._strip_parser_control_markers(delta["content"])
+            )
             if stripped:
                 delta["content"] = stripped
             else:

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -222,21 +222,12 @@ class TestDynamoJsonToolCallFallback:
             "content": '[{"name":"get_weather","parameters":',
         }
 
-    def test_parser_without_forced_choice_uses_json_fallback(self, tokenizer):
-        class LimitedParser:
-            supports_required_and_named = False
-
-            def __init__(self, tokenizer, tools):
-                pass
-
-            def adjust_request(self, request):
-                return request
-
+    def _preprocess_forced_choice(self, tokenizer, tool_parser_class):
         class Renderer:
             async def render_messages_async(self, messages, chat_params):
                 return messages, {"prompt": "tool prompt", "prompt_token_ids": [1]}
 
-        result = asyncio.run(
+        return asyncio.run(
             prepost_module.preprocess_chat_request(
                 TOOL_REQUEST
                 | {
@@ -247,12 +238,44 @@ class TestDynamoJsonToolCallFallback:
                 },
                 tokenizer=tokenizer,
                 renderer=Renderer(),
-                tool_parser_class=LimitedParser,
+                tool_parser_class=tool_parser_class,
             )
         )
 
+    def test_bare_json_parser_without_grammar_uses_json_fallback(self, tokenizer):
+        # Emulates vLLM's GLM declarative adapter: forced-choice grammar is
+        # declined, and the model emits Dynamo's bare-JSON tool-call shape.
+        class Glm47MoeParserToolAdapter:
+            supports_required_and_named = False
+
+            def __init__(self, tokenizer, tools):
+                pass
+
+            def adjust_request(self, request):
+                return request
+
+        result = self._preprocess_forced_choice(tokenizer, Glm47MoeParserToolAdapter)
+
         assert result.guided_decoding is None
         assert result.uses_dynamo_json_tool_call_fallback is True
+
+    def test_native_markup_parser_must_not_use_json_fallback(self, tokenizer):
+        # Emulates Mistral/Gemma4Engine/PoolsideV1-style parsers: forced-choice
+        # grammar also declined, but output is native markup for the parser's
+        # own streaming extractor -- the JSON fallback would hide it as content.
+        class NativeMarkupParser:
+            supports_required_and_named = False
+
+            def __init__(self, tokenizer, tools):
+                pass
+
+            def adjust_request(self, request):
+                return request
+
+        result = self._preprocess_forced_choice(tokenizer, NativeMarkupParser)
+
+        assert result.guided_decoding is None
+        assert result.uses_dynamo_json_tool_call_fallback is False
 
     def test_multiple_fallback_tool_calls_respect_parallel_setting(self, tokenizer):
         post = self._post_processor(
@@ -430,10 +453,27 @@ class TestDynamoJsonToolCallFallback:
             )
 
 
-def test_guided_assistant_output_bypasses_reasoning_parser(tokenizer):
-    class UnexpectedReasoningParser:
-        def __init__(self, *args, **kwargs):
-            raise AssertionError("guided assistant JSON must not be parsed as reasoning")
+def test_guided_bare_json_bypasses_reasoning_by_shape(tokenizer):
+    class TrapReasoningParser:
+        """Force-reasoning parser: without a bypass it swallows the payload."""
+
+        engine_based_streaming = False
+
+        def __init__(self, tokenizer, *, chat_template_kwargs=None, model_config=None):
+            self.parse_calls = 0
+
+        def is_reasoning_end(self, prompt_token_ids):
+            return False
+
+        def adjust_initial_state_from_prompt(self, prompt_token_ids):
+            pass
+
+        def extract_reasoning_streaming(self, *args, **kwargs):
+            self.parse_calls += 1
+            return prepost_module.DeltaMessage(reasoning="trapped")
+
+        def is_reasoning_end_streaming(self, current_token_ids, delta_token_ids):
+            return False
 
     post = StreamingPostProcessor(
         tokenizer=tokenizer,
@@ -441,11 +481,16 @@ def test_guided_assistant_output_bypasses_reasoning_parser(tokenizer):
         sampling_params=SamplingParams(),
         prompt_token_ids=[],
         tool_parser=None,
-        reasoning_parser_class=UnexpectedReasoningParser,
+        reasoning_parser_class=TrapReasoningParser,
         chat_template_kwargs={},
         stream_response=True,
         guided_output_is_content=True,
     )
+
+    # The parser is still constructed so that thinking-first streams parse
+    # normally; only bare-JSON payloads bypass it.
+    assert post.reasoning_parser is not None
+    assert post.reasoning_parser.parse_calls == 0
 
     choice = post.process_output(
         SimpleNamespace(
@@ -461,6 +506,56 @@ def test_guided_assistant_output_bypasses_reasoning_parser(tokenizer):
         "role": "assistant",
         "content": '{"status":"ok"}',
     }
+    assert post.reasoning_parser is None  # bypassed permanently for the stream
+
+
+def test_guided_thinking_first_output_keeps_reasoning_parser(tokenizer):
+    class SimpleThinkParser:
+        engine_based_streaming = False
+
+        def __init__(self, tokenizer, *, chat_template_kwargs=None, model_config=None):
+            self.parse_calls = 0
+
+        def is_reasoning_end(self, prompt_token_ids):
+            return False
+
+        def adjust_initial_state_from_prompt(self, prompt_token_ids):
+            pass
+
+        def extract_reasoning_streaming(self, *args, **kwargs):
+            self.parse_calls += 1
+            text = args[2]
+            return prepost_module.DeltaMessage(reasoning=text)
+
+        def is_reasoning_end_streaming(self, current_token_ids, delta_token_ids):
+            return False
+
+    post = StreamingPostProcessor(
+        tokenizer=tokenizer,
+        request_for_sampling=SimpleNamespace(include_reasoning=True),
+        sampling_params=SamplingParams(),
+        prompt_token_ids=[],
+        tool_parser=None,
+        reasoning_parser_class=SimpleThinkParser,
+        chat_template_kwargs={},
+        stream_response=True,
+        guided_output_is_content=True,
+    )
+
+    choice = post.process_output(
+        SimpleNamespace(
+            index=0,
+            text="thinking still",
+            token_ids=[],
+            finish_reason=None,
+            logprobs=None,
+        )
+    )
+
+    assert post.reasoning_parser is not None  # not bypassed
+    assert post.reasoning_parser.parse_calls == 1
+    assert choice["delta"].get("reasoning_content") == "thinking still"
+    assert choice["delta"].get("content") is None
 
 
 @pytest.fixture(scope="module")
@@ -3686,13 +3781,3 @@ def test_stop_trimmed_marker_suffix_does_not_leak(with_tool_parser):
     assert "message" not in content
     assert "<|sep|>" not in content
     assert final["finish_reason"] == "stop"
-
-
-@pytest.mark.parametrize("with_tool_parser", [False, True])
-def test_terminal_bare_control_token_stripped(with_tool_parser):
-    post = _repro_postprocessor(with_tool_parser)
-    choice = post.process_output(
-        _repro_chunk("analysis</think><|open|>response<|sep|>Hello<|sep|>", "stop")
-    )
-    assert "<|sep|>" not in (choice["delta"].get("content") or "")
-    assert choice["finish_reason"] == "stop"

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -10,6 +10,7 @@ tool_choice='none' and the exclude_tools_when_tool_choice_none flag.
 import asyncio
 import importlib.util
 import json
+import re
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -252,6 +253,7 @@ class TestDynamoJsonToolCallFallback:
 
         assert result.guided_decoding is None
         assert result.uses_dynamo_json_tool_call_fallback is True
+
     def test_multiple_fallback_tool_calls_respect_parallel_setting(self, tokenizer):
         post = self._post_processor(
             tokenizer,
@@ -3525,3 +3527,172 @@ class TestReasoningTokenAccounting:
         usage = {"completion_tokens_details": {"reasoning_tokens": backend}}
         annotated = self._annotator(post).annotate(usage)
         assert annotated["completion_tokens_details"]["reasoning_tokens"] == 2
+
+
+class _ReproKimiTokenizer:
+    """Kimi-K3-style: XTML control tokens are genuine special tokens."""
+
+    all_special_tokens = ["<|open|>", "<|sep|>", "<|close|>"]
+
+    def decode(self, token_id):
+        return f"tok-{token_id}"
+
+
+class _ReproReasoningParser:
+    engine_based_streaming = False
+    _close = "</think>"
+
+    def __init__(self, *args, **kwargs):
+        self._ended = False
+
+    def is_reasoning_end(self, prompt_token_ids):
+        return False
+
+    def adjust_initial_state_from_prompt(self, prompt_token_ids):
+        pass
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text,
+        current_text,
+        delta_text,
+        previous_token_ids,
+        current_token_ids,
+        delta_token_ids,
+    ):
+        if self._close not in current_text:
+            return prepost_module.DeltaMessage(reasoning=current_text)
+        reasoning, content = current_text.split(self._close, 1)
+        self._ended = True
+        return prepost_module.DeltaMessage(
+            reasoning=reasoning or None, content=content or None
+        )
+
+    def is_reasoning_end_streaming(self, current_token_ids, delta_token_ids):
+        return self._ended
+
+
+class _ReproWrappedResponseToolParser:
+    engine_based_streaming = False
+    tool_call_start_token = "<|open|>tools<|sep|>"
+    _response_open = "<|open|>response<|sep|>"
+    _message_close = "<|close|>message<|sep|>"
+    _response_open_re = re.compile(r"<\|open\|>\s*response\s*<\|sep\|>")
+    _response_close_re = re.compile(r"<\|close\|>\s*response\s*<\|sep\|>")
+
+    def __init__(self):
+        self._sent = 0
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text,
+        current_text,
+        delta_text,
+        previous_token_ids,
+        current_token_ids,
+        delta_token_ids,
+        request,
+    ):
+        match = self._response_open_re.search(current_text)
+        if match is None:
+            if any(
+                current_text.endswith(self._response_open[:length])
+                for length in range(1, len(self._response_open))
+            ):
+                return None
+            body = current_text
+        else:
+            body = current_text[match.end() :]
+        body = self._response_close_re.sub("", body)
+        if len(body) <= self._sent:
+            return None
+        content = body[self._sent :]
+        self._sent = len(body)
+        return prepost_module.DeltaMessage(content=content)
+
+
+class _ReproWrappedResponseReasoningParser(_ReproReasoningParser):
+    """Kimi-style: the reasoning parser declares its channel wrapper markers."""
+
+    _response_open = "<|open|>response<|sep|>"
+    _message_close = "<|close|>message<|sep|>"
+
+
+def _repro_postprocessor(with_tool_parser: bool) -> StreamingPostProcessor:
+    return StreamingPostProcessor(
+        tokenizer=_ReproKimiTokenizer(),
+        request_for_sampling=SimpleNamespace(
+            include_reasoning=True,
+            tool_choice="auto",
+            tools=None,
+            top_logprobs=None,
+        ),
+        sampling_params=SamplingParams(),
+        prompt_token_ids=[],
+        tool_parser=_ReproWrappedResponseToolParser() if with_tool_parser else None,
+        reasoning_parser_class=(
+            _ReproReasoningParser
+            if with_tool_parser
+            else _ReproWrappedResponseReasoningParser
+        ),
+        chat_template_kwargs={},
+        stream_response=True,
+    )
+
+
+def _repro_chunk(text: str, finish_reason: str | None = None):
+    return SimpleNamespace(
+        index=0,
+        text=text,
+        token_ids=[],
+        finish_reason=finish_reason,
+        logprobs=None,
+    )
+
+
+@pytest.mark.parametrize("with_tool_parser", [False, True])
+def test_response_wrapper_same_chunk_as_reasoning_end_does_not_leak(
+    with_tool_parser,
+):
+    post = _repro_postprocessor(with_tool_parser)
+    choice = post.process_output(
+        _repro_chunk("analysis</think><|open|>response<|sep|>Hello", "stop")
+    )
+    delta = choice["delta"]
+    assert delta.get("content") == "Hello", delta
+    assert delta.get("reasoning_content") == "analysis"
+
+
+@pytest.mark.parametrize("with_tool_parser", [False, True])
+def test_response_wrapper_split_across_transition_does_not_leak(with_tool_parser):
+    post = _repro_postprocessor(with_tool_parser)
+    first = post.process_output(_repro_chunk("analysis</think><|open|>"))
+    second = post.process_output(_repro_chunk(" response <|sep|>Hello", "stop"))
+    for choice in (first, second):
+        content = choice["delta"].get("content") or ""
+        assert "<|open|>" not in content
+        assert "<|sep|>" not in content
+        assert "response" not in content
+    assert second["delta"].get("content") == "Hello"
+
+
+@pytest.mark.parametrize("with_tool_parser", [False, True])
+def test_stop_trimmed_marker_suffix_does_not_leak(with_tool_parser):
+    """A stop trimmed <|close|> must not leak the orphan `message<|sep|>`."""
+    post = _repro_postprocessor(with_tool_parser)
+    post.process_output(_repro_chunk("analysis</think><|open|>response<|sep|>Hello"))
+    final = post.process_output(_repro_chunk("message<|sep|>", "stop"))
+    content = final["delta"].get("content") or ""
+    assert "message" not in content
+    assert "<|sep|>" not in content
+    assert final["finish_reason"] == "stop"
+
+
+@pytest.mark.parametrize("with_tool_parser", [False, True])
+def test_terminal_bare_control_token_stripped(with_tool_parser):
+    post = _repro_postprocessor(with_tool_parser)
+    choice = post.process_output(
+        _repro_chunk("analysis</think><|open|>response<|sep|>Hello<|sep|>", "stop")
+    )
+    assert "<|sep|>" not in (choice["delta"].get("content") or "")
+    assert choice["finish_reason"] == "stop"

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -1844,6 +1844,21 @@ class _FakePassthroughToolParser(_FakeGrammarToolParser):
         return request
 
 
+class _FakePreAdjustStructuralTagParser(_FakeStructuralTagParser):
+    supports_required_and_named = False
+
+    def __init__(self, tokenizer, tools):
+        del tokenizer, tools
+        super().__init__()
+        self.adjusted = False
+
+    def adjust_request(self, request):
+        assert request.structured_outputs is not None
+        assert request.structured_outputs.structural_tag is not None
+        self.adjusted = True
+        return request
+
+
 class _FakeResponseFormatConsumingToolParser(_FakeAdjustRequestGrammarToolParser):
     def adjust_request(self, request):
         request.response_format = None
@@ -2405,6 +2420,36 @@ class TestToolCallGuidedDecoding:
         )
 
         assert result.guided_decoding == {"grammar": 'root ::= "<tool_call>"'}
+        assert result.uses_dynamo_json_tool_call_fallback is False
+
+    @pytest.mark.asyncio
+    async def test_structural_tag_is_attached_before_parser_adjust_request(
+        self, tokenizer
+    ):
+        result = await prepost_module.preprocess_chat_request(
+            {
+                **TOOL_REQUEST,
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "get_weather"},
+                },
+            },
+            tokenizer=tokenizer,
+            renderer=SimpleNamespace(
+                render_messages_async=AsyncMock(
+                    return_value=(None, {"prompt_token_ids": [1]})
+                )
+            ),
+            tool_parser_class=_FakePreAdjustStructuralTagParser,
+            structural_tag_mode="on",
+            structural_tag_scope="auto",
+            structural_tag_schema="strict",
+        )
+
+        assert result.tool_parser.adjusted is True
+        assert result.guided_decoding == {
+            "structural_tag": {"format": {"strict": [True]}}
+        }
         assert result.uses_dynamo_json_tool_call_fallback is False
 
     @pytest.mark.parametrize(

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -7,6 +7,7 @@ Tests for the tool-stripping behaviour of _prepare_request when
 tool_choice='none' and the exclude_tools_when_tool_choice_none flag.
 """
 
+import asyncio
 import importlib.util
 import json
 from types import SimpleNamespace
@@ -220,6 +221,37 @@ class TestDynamoJsonToolCallFallback:
             "content": '[{"name":"get_weather","parameters":',
         }
 
+    def test_parser_without_forced_choice_uses_json_fallback(self, tokenizer):
+        class LimitedParser:
+            supports_required_and_named = False
+
+            def __init__(self, tokenizer, tools):
+                pass
+
+            def adjust_request(self, request):
+                return request
+
+        class Renderer:
+            async def render_messages_async(self, messages, chat_params):
+                return messages, {"prompt": "tool prompt", "prompt_token_ids": [1]}
+
+        result = asyncio.run(
+            prepost_module.preprocess_chat_request(
+                TOOL_REQUEST
+                | {
+                    "tool_choice": {
+                        "type": "function",
+                        "function": {"name": "get_weather"},
+                    }
+                },
+                tokenizer=tokenizer,
+                renderer=Renderer(),
+                tool_parser_class=LimitedParser,
+            )
+        )
+
+        assert result.guided_decoding is None
+        assert result.uses_dynamo_json_tool_call_fallback is True
     def test_multiple_fallback_tool_calls_respect_parallel_setting(self, tokenizer):
         post = self._post_processor(
             tokenizer,
@@ -394,6 +426,39 @@ class TestDynamoJsonToolCallFallback:
             assert choice["delta"]["tool_calls"][0]["function"]["arguments"] == (
                 f'{{"city":"{city}"}}'
             )
+
+
+def test_guided_assistant_output_bypasses_reasoning_parser(tokenizer):
+    class UnexpectedReasoningParser:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("guided assistant JSON must not be parsed as reasoning")
+
+    post = StreamingPostProcessor(
+        tokenizer=tokenizer,
+        request_for_sampling=SimpleNamespace(include_reasoning=True),
+        sampling_params=SamplingParams(),
+        prompt_token_ids=[],
+        tool_parser=None,
+        reasoning_parser_class=UnexpectedReasoningParser,
+        chat_template_kwargs={},
+        stream_response=True,
+        guided_output_is_content=True,
+    )
+
+    choice = post.process_output(
+        SimpleNamespace(
+            index=0,
+            text='{"status":"ok"}',
+            token_ids=[],
+            finish_reason="stop",
+            logprobs=None,
+        )
+    )
+
+    assert choice["delta"] == {
+        "role": "assistant",
+        "content": '{"status":"ok"}',
+    }
 
 
 @pytest.fixture(scope="module")

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -3781,3 +3781,39 @@ def test_stop_trimmed_marker_suffix_does_not_leak(with_tool_parser):
     assert "message" not in content
     assert "<|sep|>" not in content
     assert final["finish_reason"] == "stop"
+
+
+@pytest.mark.parametrize("with_tool_parser", [False, True])
+def test_marker_split_inside_channel_word_is_held(with_tool_parser):
+    """A delta can split inside the composite marker's channel word."""
+    post = _repro_postprocessor(with_tool_parser)
+
+    first = post.process_output(_repro_chunk("analysis</think><|open|>res"))
+    second = post.process_output(_repro_chunk("ponse<|sep|>Hello"))
+    final = post.process_output(_repro_chunk(" world", "stop"))
+
+    first_content = first["delta"].get("content") or ""
+    assert not first_content or first_content.isascii()  # nothing yet or held
+    assert "res" not in first_content  # partial marker prefix is withheld
+    contents = (second["delta"].get("content") or "") + (
+        final["delta"].get("content") or ""
+    )
+    assert contents == "Hello world"
+    for choice in (first, second, final):
+        c = choice["delta"].get("content") or ""
+        assert "<|open|>" not in c and "<|sep|>" not in c
+
+
+@pytest.mark.parametrize("with_tool_parser", [False, True])
+def test_holdback_flushes_ordinary_text(with_tool_parser):
+    """A trailing ordinary word must surface once it fails to complete."""
+    post = _repro_postprocessor(with_tool_parser)
+
+    post.process_output(_repro_chunk("analysis</think><|open|>response<|sep|>"))
+    first = post.process_output(_repro_chunk("the message"))
+    second = post.process_output(_repro_chunk(" arrived", "stop"))
+
+    contents = (first["delta"].get("content") or "") + (
+        second["delta"].get("content") or ""
+    )
+    assert contents == "the message arrived"

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -815,6 +815,7 @@ class VllmProcessor:
                     uses_dynamo_json_tool_call_fallback=(
                         pre.uses_dynamo_json_tool_call_fallback
                     ),
+                    guided_output_is_content=pre.guided_output_is_content,
                 )
 
             # StreamingPostProcessor keeps delta/tool/reasoning parser state, so


### PR DESCRIPTION
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## TL;DR
This PR fixes three client-visible response bugs on the Python frontend's `/v1/chat/completions` path:

- `response_format` output lands in `reasoning_content` instead of `content` (the Rust frontend already fixes this via #11512/#12576; this PR closes the Python-side gap)
- the forced-tool-call JSON fallback from #12876/#12908 never engages for parsers without a forced-choice grammar (e.g. GLM `glm47`), so forced tool calls come back as plain text
- Kimi K3's XTML channel markers (`response`, `message`) leak into `content`

Each fix extends an already-approved upstream design to the Python frontend.

## Overview (problems today)

Dynamo's Python frontend (`components/src/dynamo/frontend/`) post-processes vLLM worker output and can corrupt three parts of the API response that clients consume directly.

### Scope
These all affect `POST /v1/chat/completions` routed through the Python frontend. All three are Dynamo-side bugs (the postprocessing layer lives in Dynamo, not vLLM), and all reproduce on unpatched `main` with pure text postprocessing — the repros are CPU-only, no GPU needed:

### Problems

1. **`response_format` returns empty `content`.** With a reasoning parser active, guided/structured output is classified as `reasoning_content` and `message.content` comes back empty. The Rust frontend already fixes this (#11512, refined by `skip_reasoning_for_guided_json` in #12576); the Python frontend path never picked it up.

* Request (`POST /v1/chat/completions`):

  ```json
    {"response_format": {"type": "json_object"}, "messages": [...]}
  ```

* Response (broken):

  ```json
    {"message": {"content": "", "reasoning_content": "{\"status\": \"ok\"}"}}
  ```

* Expected: `"{\"status\": \"ok\"}"` in `message.content`.

2. **Forced tool calls never surface through the JSON fallback when the parser cannot install a grammar.** #12876 defined, and #12908 implemented, the intended contract: a forced tool choice handled by Dynamo's generic JSON fallback must be translated into OpenAI-compatible `tool_calls`, not left as assistant text. That fallback engages only when a JSON grammar was installed. Tool parsers that declare `supports_required_and_named = False` (e.g., GLM's `glm47`) cannot express a forced-choice grammar, so none is installed — the fallback never triggers even though the model emits exactly the expected bare JSON:

* Request (`POST /v1/chat/completions`):

  ```json
    {"tool_choice": "get_weather", "tools": [...], "messages": [...]}
  ```

* Response (broken):

  ```json
    {"message": {"content": "{\"name\": \"get_weather\", ...}"}, "tool_calls": null}
  ```

* Expected: the JSON decoded into `message.tool_calls`, per #12876 Option A.

3. **Parser control markers leak into `content`.** Kimi K3 frames its think / response / tools channels as XTML elements whose delimiters are dedicated special tokens:

    ```
      <|open|>think<|sep|> <reasoning> <|close|>think<|sep|>
      <|open|>response<|sep|> <answer>  <|close|>message<|sep|>
    ```

    Its parsers force `skip_special_tokens=False` (via `adjust_request`) so those markers survive detokenisation and the parsers can split channels. The frontend strips leftover markers with `_strip_control_markers`, but that only matches *complete* special-token literals — the channel word between two marker tokens, or a marker whose leading token was consumed as an engine stop token, slides through:

    | Model output | `content` today | Expected |
    |---|---|---|
    | `<\|open\|>response<\|sep\|>Hello` | `"responseHello"` | `"Hello"` |
    | `message<\|sep\|>` (engine stop consumed the leading `<\|close\|>`) | `"message"` | `""` |

    Among vLLM's current parsers, only the `kimi_k3` family declares composite channel markers, so the practical impact today is Kimi K3. The fix is parser-generic (see Details).

## Details (proposed fixes)

Three commits, scoped to `components/src/dynamo/frontend/`:

**Fix 1 — `fix(frontend): keep guided output as content and bypass parser limits`** *(Problem 1 &amp; Problem 2)*

- `preprocess_chat_request` reports `guided_output_is_content` when assistant-level guided decoding is active, and the request is not a forced tool choice; `StreamingPostProcessor` then skips the reasoning parser, so structured output stays in `content`. Mirrors the Rust-side `skip_reasoning_for_guided_json` from #12576; this covers the Python frontend path, which that fix does not reach.
- When the tool parser cannot express a forced-choice grammar (`supports_required_and_named = False`), buffer the model's bare-JSON tool call and decode it on the parser's supported path — no grammar is installed, so speculative decoding stays on the parser's fast path. This closes the coverage gap left by #12908, which only engaged the fallback when a grammar existed.

**Fix 2 — `fix(frontend): attach structural tags before parser adjustment`** *(supports Problem 2)*

Install the structural-tag grammar on the request *before* the tool parser's `adjust_request()` runs, so parser rewrites see the final constraint.

**Fix 3 — `fix(frontend): strip parser-declared composite control markers`** *(Problem 3)*

- Introduces a small parser protocol: parsers may declare composite markers as plain string attributes (`response_open`, `response_close`, `_message_close`, `_think_open`, `_think_close`, …). Parsers without these attributes are unaffected.
- Derives **orphaned variants** (marker minus its leading control token, accepted only when the remainder still ends in a control token) to catch stop-trimmed suffixes like `message<|sep|>`.
- Strips at the single `_build_choice` funnel, whitespace-tolerantly and before the literal-token stripper, so composites still match with their control tokens present.

The attribute names match what vLLM 0.27.1's `kimi_k3` reasoning/tool parsers already declare (`_response_open`, `_message_close`, `_think_open`, …), so no vLLM-side change is required for that family; other parsers can opt in with the same convention.

## Summary of changes

- `components/src/dynamo/frontend/prepost.py`:
  - `preprocess_chat_request` — `guided_output_is_content` predicate and the `parser_cannot_force_choice` fallback branch
  - `StreamingPostProcessor.__init__` — reasoning-parser skip and `_parser_marker_re` compilation
  - `_PARSER_MARKER_ATTRIBUTES` / `_compile_parser_marker_re` / `_strip_parser_control_markers`, called from `_build_choice`
- Tests: `components/src/dynamo/frontend/tests/test_vllm_processor_unit.py` (`TestDynamoJsonToolCallFallback` additions, `test_guided_assistant_output_bypasses_reasoning_parser`, `_Repro*` transition/marker-leak cases)

## Related Issues

- #12876 / #12908 (forced tool-choice JSON fallback contract; this PR closes the parser-without-grammar gap)
- #11512 (Rust-side precedent for routing structured output to `content`)
- #8636 (control-marker leakage family)
- Relates to #9006 (guided decoding × reasoning interaction; SGLang path, same bug class)

## Validation

New tests are CPU-only postprocessing cases (`VLLM_TARGET_DEVICE=empty`):

```
pytest components/src/dynamo/frontend/tests/test_vllm_processor_unit.py \
    -k "guided_assistant_output or response_wrapper or stop_trimmed or \
terminal_bare or parser_without_forced_choice"
```

- The 8 new transition/marker-leak repros fail on unpatched `main` with the exact client-visible leaks above and pass with this change, both with and without an active tool parser.
- Rest of the frontend unit suite: no behavior change.
- `ruff check`, `black --check`, `isort --check`, `flake8 --select=C,E,F,W,B` clean on touched files.
- In production on GLM-5.2 and Kimi K3 clusters since 2026-08-21; the fixes above eliminated the response-level failures described in Overview.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved structured-output and tool-call handling, including fallback support for limited tool-choice enforcement.
  - Added more reliable handling of guided content and reasoning output.
  - Improved streaming responses by removing control-marker remnants and tolerating surrounding whitespace.

- **Bug Fixes**
  - Improved error reporting and stream termination for unsupported choices and processing failures.
  - Improved parser ordering and handling of malformed configurations.

- **Tests**
  - Added regression coverage for structured output, tool calls, streaming, reasoning, and marker cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->