### PR TITLE
fix(skills): scope and report debug bundles

### DIFF
--- a/.agents/skills/troubleshoot-dynamo/SKILL.md
+++ b/.agents/skills/troubleshoot-dynamo/SKILL.md
@@ -28,7 +28,10 @@ time.
 
 - Python 3.10+ on the operator machine.
 - `kubectl` configured with read access to the target namespace.
-- Permission to read pods, events, jobs, PVCs, and `DynamoGraphDeployment` resources (NOT secrets).
+- Permission to read pods, pod logs (`pods/log`), events, jobs, PVCs, services, and
+  `DynamoGraphDeployment` resources in the target namespace (NOT secrets).
+- Permission to read cluster-scoped nodes and storage classes. Without it, the
+  bundle is still useful but is reported as incomplete.
 - Network reachability to the cluster API server.
 
 ## Instructions
@@ -50,7 +53,15 @@ python3 scripts/collect_dynamo_debug_bundle.py \
   --deployment-name <deployment-name>
 ```
 
-Do not collect Kubernetes secrets. Do not print Hugging Face tokens.
+`--deployment-name` limits pod listings, descriptions, and logs to pods with
+the deployment's `nvidia.com/dynamo-graph-deployment-name` label. Namespace
+summaries such as Services, Jobs, and PVCs remain namespace-wide. Add
+`--selector <label-selector>` only when a narrower pod subset is useful; it is
+combined with the deployment label.
+
+Do not request Kubernetes Secret resources. Treat the bundle as sensitive:
+descriptions and logs receive best-effort redaction, but inspect the output
+before sharing it.
 
 ### 2. Classify The Failure
 
@@ -71,7 +82,7 @@ Use `references/failure-decision-tree.md` and classify into one primary bucket:
 
 Check in this order:
 
-1. namespace, storage class, GPU nodes, and HF secret existence
+1. namespace, storage class, GPU nodes, and model-access Secret requirements
 2. PVC and model-download job
 3. `DynamoGraphDeployment` status and events
 4. pod status, `describe pod`, and container logs
@@ -84,7 +95,7 @@ Check in this order:
 
 Prefer the smallest reversible change:
 
-- create missing namespace or HF secret
+- create a missing namespace or required model-access Secret
 - patch `storageClassName`
 - patch image tag or image pull secret
 - reduce GPU request only if the recipe can still be valid
@@ -97,7 +108,7 @@ After each fix, rerun the relevant readiness check before moving deeper.
 
 | Script | Purpose | Arguments |
 |---|---|---|
-| `scripts/collect_dynamo_debug_bundle.py` | Collect a read-only debug bundle (pods, events, jobs, PVCs, CR status) | `--namespace`, `--deployment-name`, `--output-dir` |
+| `scripts/collect_dynamo_debug_bundle.py` | Collect a read-only debug bundle (pods, events, jobs, PVCs, CR status) | `--namespace`, `--deployment-name`, `--outdir` (`--output-dir` alias) |
 
 Invoke via the agentskills.io `run_script()` protocol:
 
@@ -142,8 +153,17 @@ Return:
 ## Limitations
 
 - Read-only. Never mutates the cluster; remediation commands are returned, not executed.
-- Will not collect secrets or print Hugging Face tokens; some failure modes (auth) may need user-side inspection.
-- Bundle size grows with deployment size; on very large namespaces, scope with `--deployment-name`.
+- Does not request Kubernetes Secret resources. Pod descriptions and logs
+  receive best-effort redaction, but custom credential formats can evade it;
+  inspect the bundle before sharing. Some authentication failures may still
+  need user-side inspection.
+- `--deployment-name` scopes pod details and logs, but namespace summaries
+  remain namespace-wide.
+- Any failed top-level read, pod discovery, pod description, or current-log
+  read makes the script return nonzero and records its name in `summary.json`;
+  the successfully collected evidence is still preserved. Missing
+  `--previous` logs are expected for containers that have not restarted and
+  are reported separately without making the bundle incomplete.
 - Does not validate disagg transport — use `dynamo-interconnect-check` for that.
 
 ## Troubleshooting
@@ -151,6 +171,7 @@ Return:
 | Symptom | Likely cause | Next step |
 |---|---|---|
 | `kubectl` returns Forbidden on events/pods | Service account lacks read RBAC | Ask operator for read-only role binding on the namespace |
+| Bundle reports `complete: false` | One or more required collection commands failed | Inspect `failed_commands` in `summary.json` and the matching result files |
 | Bundle missing `DynamoGraphDeployment` status | Operator not installed or different namespace | Verify `dynamo-platform` operator is installed and watching the namespace |
 | Model-download job in `Pending` | PVC unbound or HF secret missing | Fix PVC binding or create the named HF secret, then rerun the job |
 | Worker pods `CrashLoopBackOff` | Image/runtime mismatch or GPU not available | Inspect container logs; check `nvidia.com/gpu` allocatable on nodes |

--- a/.agents/skills/troubleshoot-dynamo/SKILL.md
+++ b/.agents/skills/troubleshoot-dynamo/SKILL.md
@@ -63,6 +63,10 @@ Do not request Kubernetes Secret resources. Treat the bundle as sensitive:
 descriptions and logs receive best-effort redaction, but inspect the output
 before sharing it.
 
+Pass a new or empty directory to `--outdir` or `--output-dir`. The collector
+rejects nonempty directories so stale artifacts from another scope cannot be
+mistaken for current evidence.
+
 ### 2. Classify The Failure
 
 Use `references/failure-decision-tree.md` and classify into one primary bucket:
@@ -159,6 +163,8 @@ Return:
   need user-side inspection.
 - `--deployment-name` scopes pod details and logs, but namespace summaries
   remain namespace-wide.
+- User-provided output directories must be empty; the collector never deletes
+  or silently mixes existing artifacts.
 - Any failed top-level read, pod discovery, pod description, or current-log
   read makes the script return nonzero and records its name in `summary.json`;
   the successfully collected evidence is still preserved. Missing
@@ -173,7 +179,7 @@ Return:
 | `kubectl` returns Forbidden on events/pods | Service account lacks read RBAC | Ask operator for read-only role binding on the namespace |
 | Bundle reports `complete: false` | One or more required collection commands failed | Inspect `failed_commands` in `summary.json` and the matching result files |
 | Bundle missing `DynamoGraphDeployment` status | Operator not installed or different namespace | Verify `dynamo-platform` operator is installed and watching the namespace |
-| Model-download job in `Pending` | PVC unbound or HF secret missing | Fix PVC binding or create the named HF secret, then rerun the job |
+| Model-download job in `Pending` | PVC unbound or configured model-access Secret missing | Fix PVC binding or create the Secret referenced by the model-download job, then rerun the job |
 | Worker pods `CrashLoopBackOff` | Image/runtime mismatch or GPU not available | Inspect container logs; check `nvidia.com/gpu` allocatable on nodes |
 
 

--- a/.agents/skills/troubleshoot-dynamo/references/failure-decision-tree.md
+++ b/.agents/skills/troubleshoot-dynamo/references/failure-decision-tree.md
@@ -30,16 +30,21 @@ Signals:
 
 - model-download job exits quickly
 - logs show authentication, 401, 403, gated model, or missing token
-- manifest references `HF_TOKEN` but secret/key does not exist
+- manifest references a model-access credential but its Secret or key does not
+  exist
 
 Checks:
 
 ```bash
-kubectl get secret hf-token-secret -n "${NAMESPACE}"
+kubectl get job model-download -n "${NAMESPACE}" \
+  -o jsonpath='{range .spec.template.spec.containers[*].env[*]}{.name}{"\t"}{.valueFrom.secretKeyRef.name}{"\t"}{.valueFrom.secretKeyRef.key}{"\n"}{end}'
+kubectl describe pod <model-download-pod> -n "${NAMESPACE}"
 kubectl logs job/model-download -n "${NAMESPACE}" --tail=100
 ```
 
-Next action: create or fix the HF secret. Never paste the token into manifests.
+Next action: create or fix the Secret and key referenced by the model-download
+job. Never paste the credential into manifests or retrieve Secret data for a
+debug bundle.
 
 ## PVC Or Storage Class
 

--- a/.agents/skills/troubleshoot-dynamo/scripts/collect_dynamo_debug_bundle.py
+++ b/.agents/skills/troubleshoot-dynamo/scripts/collect_dynamo_debug_bundle.py
@@ -18,6 +18,7 @@ from typing import Any
 # Tunables and conventional return codes (kept here to avoid magic numbers).
 DEFAULT_KUBECTL_TIMEOUT_SEC = 30
 DEFAULT_LOG_TAIL_LINES = 200
+DGD_POD_LABEL = "nvidia.com/dynamo-graph-deployment-name"
 # POSIX-conventional return codes used when the wrapper itself fails before
 # kubectl can produce a real one.
 RETURNCODE_COMMAND_NOT_FOUND = 127  # `kubectl` not installed
@@ -25,19 +26,64 @@ RETURNCODE_TIMED_OUT = 124  # subprocess timeout
 
 # `kubectl describe` and pod logs can echo secret env values (HF tokens,
 # bearer tokens, passwords). Scrub them before anything is written to disk so
-# the bundle honors its no-secrets contract.
-_SECRET_KV_RE = re.compile(
-    r"(?i)([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|"
-    r"CREDENTIAL)[A-Z0-9_]*)(\s*[:=]\s*)(\S+)"
+# common credentials are not persisted verbatim in the bundle.
+_PLAIN_KV_RE = re.compile(r"\b([A-Za-z][A-Za-z0-9_-]*)(\s*[:=]\s*)(\S+)")
+_JSON_STRING_KV_RE = re.compile(
+    r'(?P<prefix>"(?P<key>(?:\\.|[^"])*)"\s*:\s*)' r'"(?P<value>(?:\\.|[^"])*)"'
 )
 _BEARER_RE = re.compile(r"(?i)(bearer\s+)([A-Za-z0-9._\-]+)")
 _HF_TOKEN_RE = re.compile(r"\bhf_[A-Za-z0-9]{8,}\b")
 
 
+def is_secret_key(key: str) -> bool:
+    camel_split = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", key)
+    parts = tuple(
+        part for part in re.split(r"[^A-Za-z0-9]+", camel_split.lower()) if part
+    )
+    if not parts:
+        return False
+    if parts == ("token",) or parts == ("secret",):
+        return True
+    if {"password", "passwd", "credential", "credentials", "authorization"} & set(
+        parts
+    ):
+        return True
+    if parts[-1] in {"secret", "auth"}:
+        return True
+    sensitive_key_pairs = {("api", "key"), ("access", "key"), ("private", "key")}
+    if any(pair in sensitive_key_pairs for pair in zip(parts, parts[1:])):
+        return True
+    if parts[-1] == "token":
+        telemetry_prefixes = {
+            "prompt",
+            "completion",
+            "input",
+            "output",
+            "cached",
+            "max",
+            "num",
+            "total",
+        }
+        return len(parts) == 1 or parts[-2] not in telemetry_prefixes
+    return False
+
+
 def redact(text: str) -> str:
     if not text:
         return text
-    text = _SECRET_KV_RE.sub(lambda m: f"{m.group(1)}{m.group(2)}<redacted>", text)
+
+    def redact_json_value(match: re.Match[str]) -> str:
+        if not is_secret_key(match.group("key")):
+            return match.group(0)
+        return f'{match.group("prefix")}"<redacted>"'
+
+    def redact_plain_value(match: re.Match[str]) -> str:
+        if not is_secret_key(match.group(1)):
+            return match.group(0)
+        return f"{match.group(1)}{match.group(2)}<redacted>"
+
+    text = _JSON_STRING_KV_RE.sub(redact_json_value, text)
+    text = _PLAIN_KV_RE.sub(redact_plain_value, text)
     text = _BEARER_RE.sub(lambda m: f"{m.group(1)}<redacted>", text)
     text = _HF_TOKEN_RE.sub("<redacted-hf-token>", text)
     return text
@@ -89,34 +135,53 @@ def write_result(outdir: Path, name: str, result: dict[str, Any]) -> None:
     )
 
 
-def kubectl_json(args: list[str], timeout: int) -> Any | None:
+def write_pod_discovery_result(outdir: Path, name: str, result: dict[str, Any]) -> None:
+    """Write pod-discovery status without persisting full pod specs."""
+    safe_result = dict(result)
+    safe_result["stdout"] = "<omitted: pod JSON used only for local discovery>"
+    write_result(outdir, name, safe_result)
+
+
+def kubectl_json(args: list[str], timeout: int) -> tuple[Any | None, dict[str, Any]]:
     result = run(["kubectl", *args, "-o", "json"], timeout)
     if result["returncode"] != 0:
-        return None
+        return None, result
     try:
-        return json.loads(result["stdout"])
+        return json.loads(result["stdout"]), result
     except json.JSONDecodeError:
-        return None
+        invalid_result = dict(result)
+        invalid_result["returncode"] = 1
+        invalid_result["stderr"] = (
+            str(result["stderr"]) + "\nFailed to parse kubectl JSON output."
+        ).lstrip()
+        return None, invalid_result
 
 
-def pod_names(namespace: str, selector: str | None, timeout: int) -> list[str]:
+def pod_names(
+    namespace: str, selector: str | None, timeout: int
+) -> tuple[list[str], dict[str, Any]]:
     args = ["get", "pods", "-n", namespace]
     if selector:
         args.extend(["-l", selector])
-    body = kubectl_json(args, timeout)
+    body, result = kubectl_json(args, timeout)
     if not body:
-        return []
-    return [
-        item.get("metadata", {}).get("name")
-        for item in body.get("items", [])
-        if item.get("metadata", {}).get("name")
-    ]
+        return [], result
+    return (
+        [
+            item.get("metadata", {}).get("name")
+            for item in body.get("items", [])
+            if item.get("metadata", {}).get("name")
+        ],
+        result,
+    )
 
 
-def container_names(namespace: str, pod: str, timeout: int) -> list[tuple[str, str]]:
-    body = kubectl_json(["get", "pod", pod, "-n", namespace], timeout)
+def container_names(
+    namespace: str, pod: str, timeout: int
+) -> tuple[list[tuple[str, str]], dict[str, Any]]:
+    body, result = kubectl_json(["get", "pod", pod, "-n", namespace], timeout)
     if not body:
-        return []
+        return [], result
     specs = body.get("spec", {})
     containers: list[tuple[str, str]] = []
     for kind, field in [
@@ -126,7 +191,19 @@ def container_names(namespace: str, pod: str, timeout: int) -> list[tuple[str, s
         for item in specs.get(field, []):
             if item.get("name"):
                 containers.append((kind, item["name"]))
-    return containers
+    return containers, result
+
+
+def deployment_pod_selector(
+    deployment_name: str | None, selector: str | None
+) -> str | None:
+    """Build the pod selector, scoping to the named DGD when provided."""
+    selectors = []
+    if deployment_name:
+        selectors.append(f"{DGD_POD_LABEL}={deployment_name}")
+    if selector:
+        selectors.append(selector)
+    return ",".join(selectors) or None
 
 
 def main() -> int:
@@ -140,12 +217,16 @@ def main() -> int:
     )
     parser.add_argument(
         "--outdir",
+        "--output-dir",
+        dest="outdir",
         default=None,
         help="Output dir; defaults to a private mkdtemp dynamo-debug-* directory",
     )
     parser.add_argument("--tail", type=int, default=DEFAULT_LOG_TAIL_LINES)
     parser.add_argument("--timeout", type=int, default=DEFAULT_KUBECTL_TIMEOUT_SEC)
     args = parser.parse_args()
+
+    pod_selector = deployment_pod_selector(args.deployment_name, args.selector)
 
     if args.outdir:
         outdir = Path(args.outdir).expanduser().resolve()
@@ -154,6 +235,10 @@ def main() -> int:
         # mkdtemp gives an unpredictable name with 0700 perms, unlike a
         # guessable /tmp/dynamo-debug-<timestamp> path on a shared host.
         outdir = Path(tempfile.mkdtemp(prefix="dynamo-debug-")).resolve()
+
+    pod_command = ["kubectl", "get", "pods", "-n", args.namespace, "-o", "wide"]
+    if pod_selector:
+        pod_command.extend(["-l", pod_selector])
 
     commands: list[tuple[str, list[str]]] = [
         ("context", ["kubectl", "config", "current-context"]),
@@ -172,7 +257,7 @@ def main() -> int:
                 "wide",
             ],
         ),
-        ("pods", ["kubectl", "get", "pods", "-n", args.namespace, "-o", "wide"]),
+        ("pods", pod_command),
         ("services", ["kubectl", "get", "svc", "-n", args.namespace, "-o", "wide"]),
         ("pvc", ["kubectl", "get", "pvc", "-n", args.namespace, "-o", "wide"]),
         ("jobs", ["kubectl", "get", "jobs", "-n", args.namespace, "-o", "wide"]),
@@ -206,7 +291,9 @@ def main() -> int:
     summary: dict[str, Any] = {
         "outdir": str(outdir),
         "namespace": args.namespace,
+        "pod_selector": pod_selector,
         "commands": [],
+        "detail_commands": [],
     }
     for name, cmd in commands:
         result = run(cmd, args.timeout)
@@ -215,14 +302,41 @@ def main() -> int:
             {"name": name, "cmd": cmd, "returncode": result["returncode"]}
         )
 
-    pods = pod_names(args.namespace, args.selector, args.timeout)
+    pods, pod_inventory_result = pod_names(args.namespace, pod_selector, args.timeout)
+    write_pod_discovery_result(outdir, "pods_json", pod_inventory_result)
+    summary["detail_commands"].append(
+        {
+            "name": "pods_json",
+            "cmd": pod_inventory_result["cmd"],
+            "returncode": pod_inventory_result["returncode"],
+            "required": True,
+        }
+    )
     summary["pods"] = pods
     for pod in pods:
         result = run(
             ["kubectl", "describe", "pod", pod, "-n", args.namespace], args.timeout
         )
         write_result(outdir, f"describe_pod_{pod}", result)
-        for kind, container in container_names(args.namespace, pod, args.timeout):
+        summary["detail_commands"].append(
+            {
+                "name": f"describe_pod_{pod}",
+                "cmd": result["cmd"],
+                "returncode": result["returncode"],
+                "required": True,
+            }
+        )
+        containers, pod_json_result = container_names(args.namespace, pod, args.timeout)
+        write_pod_discovery_result(outdir, f"pod_json_{pod}", pod_json_result)
+        summary["detail_commands"].append(
+            {
+                "name": f"pod_json_{pod}",
+                "cmd": pod_json_result["cmd"],
+                "returncode": pod_json_result["returncode"],
+                "required": True,
+            }
+        )
+        for kind, container in containers:
             result = run(
                 [
                     "kubectl",
@@ -236,7 +350,16 @@ def main() -> int:
                 ],
                 args.timeout,
             )
-            write_result(outdir, f"logs_{kind}_{pod}_{container}", result)
+            log_name = f"logs_{kind}_{pod}_{container}"
+            write_result(outdir, log_name, result)
+            summary["detail_commands"].append(
+                {
+                    "name": log_name,
+                    "cmd": result["cmd"],
+                    "returncode": result["returncode"],
+                    "required": True,
+                }
+            )
             previous_result = run(
                 [
                     "kubectl",
@@ -251,14 +374,41 @@ def main() -> int:
                 ],
                 args.timeout,
             )
-            write_result(
-                outdir, f"logs_previous_{kind}_{pod}_{container}", previous_result
+            previous_name = f"logs_previous_{kind}_{pod}_{container}"
+            write_result(outdir, previous_name, previous_result)
+            summary["detail_commands"].append(
+                {
+                    "name": previous_name,
+                    "cmd": previous_result["cmd"],
+                    "returncode": previous_result["returncode"],
+                    "required": False,
+                }
             )
+
+    failed_commands = [
+        item["name"]
+        for item in [*summary["commands"], *summary["detail_commands"]]
+        if item["returncode"] != 0 and item.get("required", True)
+    ]
+    summary["failed_commands"] = failed_commands
+    summary["optional_failed_commands"] = [
+        item["name"]
+        for item in summary["detail_commands"]
+        if item["returncode"] != 0 and not item["required"]
+    ]
+    summary["complete"] = not failed_commands
 
     (outdir / "summary.json").write_text(
         json.dumps(summary, indent=2), encoding="utf-8"
     )
     print(json.dumps(summary, indent=2))
+    if failed_commands:
+        print(
+            "Debug bundle is incomplete; inspect failed_commands and the matching files "
+            f"under {outdir}.",
+            file=sys.stderr,
+        )
+        return 1
     return 0
 
 

--- a/.agents/skills/troubleshoot-dynamo/scripts/collect_dynamo_debug_bundle.py
+++ b/.agents/skills/troubleshoot-dynamo/scripts/collect_dynamo_debug_bundle.py
@@ -28,9 +28,6 @@ RETURNCODE_TIMED_OUT = 124  # subprocess timeout
 # bearer tokens, passwords). Scrub them before anything is written to disk so
 # common credentials are not persisted verbatim in the bundle.
 _PLAIN_KV_RE = re.compile(r"\b([A-Za-z][A-Za-z0-9_-]*)(\s*[:=]\s*)(\S+)")
-_JSON_STRING_KV_RE = re.compile(
-    r'(?P<prefix>"(?P<key>(?:\\.|[^"])*)"\s*:\s*)' r'"(?P<value>(?:\\.|[^"])*)"'
-)
 _BEARER_RE = re.compile(r"(?i)(bearer\s+)([A-Za-z0-9._\-]+)")
 _HF_TOKEN_RE = re.compile(r"\bhf_[A-Za-z0-9]{8,}\b")
 
@@ -68,21 +65,77 @@ def is_secret_key(key: str) -> bool:
     return False
 
 
+def json_string_end(text: str, opening_quote: int) -> int | None:
+    """Return a JSON string's closing quote without regex backtracking."""
+    cursor = opening_quote + 1
+    while cursor < len(text):
+        if text[cursor] == "\\":
+            cursor += 2
+        elif text[cursor] == '"':
+            return cursor
+        else:
+            cursor += 1
+    return None
+
+
+def redact_json_string_values(text: str) -> str:
+    """Redact sensitive JSON string values embedded in arbitrary text."""
+    cursor = 0
+    unchanged_start = 0
+    chunks: list[str] = []
+    while cursor < len(text):
+        key_start = text.find('"', cursor)
+        if key_start == -1:
+            break
+        key_end = json_string_end(text, key_start)
+        if key_end is None:
+            break
+
+        separator = key_end + 1
+        while separator < len(text) and text[separator].isspace():
+            separator += 1
+        if separator >= len(text) or text[separator] != ":":
+            cursor = key_end + 1
+            continue
+
+        value_start = separator + 1
+        while value_start < len(text) and text[value_start].isspace():
+            value_start += 1
+        if value_start >= len(text) or text[value_start] != '"':
+            cursor = key_end + 1
+            continue
+
+        value_end = json_string_end(text, value_start)
+        if value_end is None:
+            break
+
+        raw_key = text[key_start : key_end + 1]
+        try:
+            key = json.loads(raw_key)
+        except json.JSONDecodeError:
+            key = text[key_start + 1 : key_end]
+        if isinstance(key, str) and is_secret_key(key):
+            chunks.append(text[unchanged_start : value_start + 1])
+            chunks.append("<redacted>")
+            unchanged_start = value_end
+        cursor = value_end + 1
+
+    if not chunks:
+        return text
+    chunks.append(text[unchanged_start:])
+    return "".join(chunks)
+
+
 def redact(text: str) -> str:
     if not text:
         return text
-
-    def redact_json_value(match: re.Match[str]) -> str:
-        if not is_secret_key(match.group("key")):
-            return match.group(0)
-        return f'{match.group("prefix")}"<redacted>"'
 
     def redact_plain_value(match: re.Match[str]) -> str:
         if not is_secret_key(match.group(1)):
             return match.group(0)
         return f"{match.group(1)}{match.group(2)}<redacted>"
 
-    text = _JSON_STRING_KV_RE.sub(redact_json_value, text)
+    text = redact_json_string_values(text)
     text = _PLAIN_KV_RE.sub(redact_plain_value, text)
     text = _BEARER_RE.sub(lambda m: f"{m.group(1)}<redacted>", text)
     text = _HF_TOKEN_RE.sub("<redacted-hf-token>", text)

--- a/.agents/skills/troubleshoot-dynamo/scripts/collect_dynamo_debug_bundle.py
+++ b/.agents/skills/troubleshoot-dynamo/scripts/collect_dynamo_debug_bundle.py
@@ -28,11 +28,12 @@ RETURNCODE_TIMED_OUT = 124  # subprocess timeout
 # bearer tokens, passwords). Scrub them before anything is written to disk so
 # common credentials are not persisted verbatim in the bundle.
 _PLAIN_KV_RE = re.compile(r"\b([A-Za-z][A-Za-z0-9_-]*)(\s*[:=]\s*)(\S+)")
-_BEARER_RE = re.compile(r"(?i)(bearer\s+)([A-Za-z0-9._\-]+)")
+_BEARER_RE = re.compile(r"(?i)(bearer\s+)(\S+)")
 _HF_TOKEN_RE = re.compile(r"\bhf_[A-Za-z0-9]{8,}\b")
 
 
 def is_secret_key(key: str) -> bool:
+    """Return whether a field name conventionally identifies a credential."""
     camel_split = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", key)
     parts = tuple(
         part for part in re.split(r"[^A-Za-z0-9]+", camel_split.lower()) if part
@@ -127,22 +128,25 @@ def redact_json_string_values(text: str) -> str:
 
 
 def redact(text: str) -> str:
+    """Redact common credentials while preserving non-secret diagnostics."""
     if not text:
         return text
 
     def redact_plain_value(match: re.Match[str]) -> str:
+        """Redact a matched plain key/value when its key is sensitive."""
         if not is_secret_key(match.group(1)):
             return match.group(0)
         return f"{match.group(1)}{match.group(2)}<redacted>"
 
     text = redact_json_string_values(text)
-    text = _PLAIN_KV_RE.sub(redact_plain_value, text)
     text = _BEARER_RE.sub(lambda m: f"{m.group(1)}<redacted>", text)
+    text = _PLAIN_KV_RE.sub(redact_plain_value, text)
     text = _HF_TOKEN_RE.sub("<redacted-hf-token>", text)
     return text
 
 
 def run(cmd: list[str], timeout: int) -> dict[str, Any]:
+    """Run one command and normalize subprocess wrapper failures."""
     try:
         proc = subprocess.run(
             cmd, text=True, capture_output=True, timeout=timeout, check=False
@@ -170,6 +174,7 @@ def run(cmd: list[str], timeout: int) -> dict[str, Any]:
 
 
 def write_result(outdir: Path, name: str, result: dict[str, Any]) -> None:
+    """Write one redacted command result into the bundle."""
     safe = name.replace("/", "_").replace(" ", "_")
     (outdir / f"{safe}.txt").write_text(
         "$ "
@@ -196,6 +201,7 @@ def write_pod_discovery_result(outdir: Path, name: str, result: dict[str, Any]) 
 
 
 def kubectl_json(args: list[str], timeout: int) -> tuple[Any | None, dict[str, Any]]:
+    """Run a kubectl JSON query and retain its normalized command result."""
     result = run(["kubectl", *args, "-o", "json"], timeout)
     if result["returncode"] != 0:
         return None, result
@@ -213,6 +219,7 @@ def kubectl_json(args: list[str], timeout: int) -> tuple[Any | None, dict[str, A
 def pod_names(
     namespace: str, selector: str | None, timeout: int
 ) -> tuple[list[str], dict[str, Any]]:
+    """Discover selected pod names and return the inventory command result."""
     args = ["get", "pods", "-n", namespace]
     if selector:
         args.extend(["-l", selector])
@@ -232,6 +239,7 @@ def pod_names(
 def container_names(
     namespace: str, pod: str, timeout: int
 ) -> tuple[list[tuple[str, str]], dict[str, Any]]:
+    """Discover a pod's init and application container names."""
     body, result = kubectl_json(["get", "pod", pod, "-n", namespace], timeout)
     if not body:
         return [], result
@@ -260,6 +268,7 @@ def deployment_pod_selector(
 
 
 def main() -> int:
+    """Collect a debug bundle and return zero only when required reads succeed."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--namespace", "-n", required=True)
     parser.add_argument(
@@ -284,6 +293,8 @@ def main() -> int:
     if args.outdir:
         outdir = Path(args.outdir).expanduser().resolve()
         outdir.mkdir(parents=True, exist_ok=True)
+        if any(outdir.iterdir()):
+            parser.error(f"--outdir must be empty: {outdir}")
     else:
         # mkdtemp gives an unpredictable name with 0700 perms, unlike a
         # guessable /tmp/dynamo-debug-<timestamp> path on a shared host.

--- a/.agents/skills/troubleshoot-dynamo/scripts/collect_dynamo_debug_bundle.py
+++ b/.agents/skills/troubleshoot-dynamo/scripts/collect_dynamo_debug_bundle.py
@@ -33,7 +33,7 @@ _HF_TOKEN_RE = re.compile(r"\bhf_[A-Za-z0-9]{8,}\b")
 
 
 def is_secret_key(key: str) -> bool:
-    """Return whether a field name conventionally identifies a credential."""
+    """Keep credential matching narrow enough to preserve token telemetry."""
     camel_split = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", key)
     parts = tuple(
         part for part in re.split(r"[^A-Za-z0-9]+", camel_split.lower()) if part
@@ -47,6 +47,8 @@ def is_secret_key(key: str) -> bool:
     ):
         return True
     if parts[-1] in {"secret", "auth"}:
+        return True
+    if {"apikey", "accesskey", "privatekey"} & set(parts):
         return True
     sensitive_key_pairs = {("api", "key"), ("access", "key"), ("private", "key")}
     if any(pair in sensitive_key_pairs for pair in zip(parts, parts[1:])):
@@ -80,7 +82,7 @@ def json_string_end(text: str, opening_quote: int) -> int | None:
 
 
 def redact_json_string_values(text: str) -> str:
-    """Redact sensitive JSON string values embedded in arbitrary text."""
+    """Scan once so malformed log fragments cannot trigger regex backtracking."""
     cursor = 0
     unchanged_start = 0
     chunks: list[str] = []
@@ -133,7 +135,6 @@ def redact(text: str) -> str:
         return text
 
     def redact_plain_value(match: re.Match[str]) -> str:
-        """Redact a matched plain key/value when its key is sensitive."""
         if not is_secret_key(match.group(1)):
             return match.group(0)
         return f"{match.group(1)}{match.group(2)}<redacted>"
@@ -146,7 +147,7 @@ def redact(text: str) -> str:
 
 
 def run(cmd: list[str], timeout: int) -> dict[str, Any]:
-    """Run one command and normalize subprocess wrapper failures."""
+    """Use shell-like 127/124 codes when kubectl cannot start or times out."""
     try:
         proc = subprocess.run(
             cmd, text=True, capture_output=True, timeout=timeout, check=False
@@ -174,7 +175,7 @@ def run(cmd: list[str], timeout: int) -> dict[str, Any]:
 
 
 def write_result(outdir: Path, name: str, result: dict[str, Any]) -> None:
-    """Write one redacted command result into the bundle."""
+    """Redact both output streams before either one reaches persistent storage."""
     safe = name.replace("/", "_").replace(" ", "_")
     (outdir / f"{safe}.txt").write_text(
         "$ "
@@ -201,7 +202,7 @@ def write_pod_discovery_result(outdir: Path, name: str, result: dict[str, Any]) 
 
 
 def kubectl_json(args: list[str], timeout: int) -> tuple[Any | None, dict[str, Any]]:
-    """Run a kubectl JSON query and retain its normalized command result."""
+    """Retain command evidence even when kubectl fails or emits invalid JSON."""
     result = run(["kubectl", *args, "-o", "json"], timeout)
     if result["returncode"] != 0:
         return None, result
@@ -219,7 +220,7 @@ def kubectl_json(args: list[str], timeout: int) -> tuple[Any | None, dict[str, A
 def pod_names(
     namespace: str, selector: str | None, timeout: int
 ) -> tuple[list[str], dict[str, Any]]:
-    """Discover selected pod names and return the inventory command result."""
+    """Keep pod specifications in memory while exposing names for collection."""
     args = ["get", "pods", "-n", namespace]
     if selector:
         args.extend(["-l", selector])
@@ -239,7 +240,7 @@ def pod_names(
 def container_names(
     namespace: str, pod: str, timeout: int
 ) -> tuple[list[tuple[str, str]], dict[str, Any]]:
-    """Discover a pod's init and application container names."""
+    """Tag init and application names so their log artifacts stay distinct."""
     body, result = kubectl_json(["get", "pod", pod, "-n", namespace], timeout)
     if not body:
         return [], result

--- a/.agents/skills/troubleshoot-dynamo/tests/test_collect_dynamo_debug_bundle.py
+++ b/.agents/skills/troubleshoot-dynamo/tests/test_collect_dynamo_debug_bundle.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "collect_dynamo_debug_bundle.py"
+SPEC = importlib.util.spec_from_file_location("collect_dynamo_debug_bundle", SCRIPT)
+assert SPEC and SPEC.loader
+bundle = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bundle)
+
+
+class DebugBundleTest(unittest.TestCase):
+    def test_redact_distinguishes_credentials_from_token_telemetry(self) -> None:
+        source = (
+            '{"api_key":"json-secret","access_token":"access-secret",'
+            '"author":"alice","tokenizer":"Qwen","prompt_tokens":128,'
+            '"token_count":4,"monkey":"banana"}\n'
+            "CUSTOM_AUTH=plain-secret\n"
+        )
+        output = bundle.redact(source)
+
+        self.assertNotIn("json-secret", output)
+        self.assertNotIn("access-secret", output)
+        self.assertNotIn("plain-secret", output)
+        self.assertIn('"author":"alice"', output)
+        self.assertIn('"tokenizer":"Qwen"', output)
+        self.assertIn('"prompt_tokens":128', output)
+        self.assertIn('"token_count":4', output)
+        self.assertIn('"monkey":"banana"', output)
+        self.assertEqual(output.count("<redacted>"), 3)
+
+    def test_pod_discovery_files_do_not_persist_pod_specs(self) -> None:
+        result = {
+            "cmd": ["kubectl", "get", "pod", "worker-0", "-o", "json"],
+            "returncode": 0,
+            "stdout": '{"env": [{"name": "CUSTOM_AUTH", "value": "sensitive"}]}',
+            "stderr": "",
+        }
+        with tempfile.TemporaryDirectory() as tempdir:
+            bundle.write_pod_discovery_result(Path(tempdir), "pod_json", result)
+            output = (Path(tempdir) / "pod_json.txt").read_text()
+
+        self.assertNotIn("sensitive", output)
+        self.assertIn("pod JSON used only for local discovery", output)
+
+    def test_deployment_and_explicit_selectors_are_combined(self) -> None:
+        self.assertEqual(
+            bundle.deployment_pod_selector("qwen", "app=worker"),
+            "nvidia.com/dynamo-graph-deployment-name=qwen,app=worker",
+        )
+
+    def test_named_deployment_scopes_pods_and_failed_reads_return_nonzero(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], timeout: int) -> dict[str, object]:
+            del timeout
+            calls.append(cmd)
+            failed = cmd[1:3] == ["get", "events"]
+            return {
+                "cmd": cmd,
+                "returncode": 1 if failed else 0,
+                "stdout": '{"items": []}' if cmd[-2:] == ["-o", "json"] else "",
+                "stderr": "forbidden" if failed else "",
+            }
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            argv = [
+                str(SCRIPT),
+                "--namespace",
+                "demo",
+                "--deployment-name",
+                "qwen",
+                "--outdir",
+                tempdir,
+            ]
+            with (
+                patch.object(sys, "argv", argv),
+                patch.object(bundle, "run", side_effect=fake_run),
+                redirect_stdout(StringIO()),
+                redirect_stderr(StringIO()),
+            ):
+                result = bundle.main()
+
+            summary = json.loads((Path(tempdir) / "summary.json").read_text())
+
+        self.assertEqual(result, 1)
+        self.assertFalse(summary["complete"])
+        self.assertEqual(summary["failed_commands"], ["events"])
+        self.assertEqual(
+            summary["pod_selector"],
+            "nvidia.com/dynamo-graph-deployment-name=qwen",
+        )
+        pod_call = next(cmd for cmd in calls if cmd[1:3] == ["get", "pods"])
+        self.assertEqual(
+            pod_call[-2:],
+            ["-l", "nvidia.com/dynamo-graph-deployment-name=qwen"],
+        )
+
+    def test_complete_top_level_collection_returns_zero(self) -> None:
+        def fake_run(cmd: list[str], timeout: int) -> dict[str, object]:
+            del timeout
+            return {
+                "cmd": cmd,
+                "returncode": 0,
+                "stdout": '{"items": []}' if cmd[-2:] == ["-o", "json"] else "",
+                "stderr": "",
+            }
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            argv = [str(SCRIPT), "--namespace", "demo", "--outdir", tempdir]
+            with (
+                patch.object(sys, "argv", argv),
+                patch.object(bundle, "run", side_effect=fake_run),
+                redirect_stdout(StringIO()),
+                redirect_stderr(StringIO()),
+            ):
+                result = bundle.main()
+            summary = json.loads((Path(tempdir) / "summary.json").read_text())
+
+        self.assertEqual(result, 0)
+        self.assertTrue(summary["complete"])
+        self.assertEqual(summary["failed_commands"], [])
+
+    def test_current_log_rbac_failure_makes_bundle_incomplete(self) -> None:
+        def fake_run(cmd: list[str], timeout: int) -> dict[str, object]:
+            del timeout
+            if cmd[1:3] == ["get", "pods"] and cmd[-2:] == ["-o", "json"]:
+                stdout = '{"items": [{"metadata": {"name": "worker-0"}}]}'
+                return {"cmd": cmd, "returncode": 0, "stdout": stdout, "stderr": ""}
+            if cmd[1:4] == ["get", "pod", "worker-0"]:
+                stdout = '{"spec": {"containers": [{"name": "main"}]}}'
+                return {"cmd": cmd, "returncode": 0, "stdout": stdout, "stderr": ""}
+            if cmd[1] == "logs":
+                return {
+                    "cmd": cmd,
+                    "returncode": 1,
+                    "stdout": "",
+                    "stderr": "forbidden",
+                }
+            return {"cmd": cmd, "returncode": 0, "stdout": "", "stderr": ""}
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            argv = [str(SCRIPT), "--namespace", "demo", "--outdir", tempdir]
+            with (
+                patch.object(sys, "argv", argv),
+                patch.object(bundle, "run", side_effect=fake_run),
+                redirect_stdout(StringIO()),
+                redirect_stderr(StringIO()),
+            ):
+                result = bundle.main()
+            summary = json.loads((Path(tempdir) / "summary.json").read_text())
+
+        self.assertEqual(result, 1)
+        self.assertFalse(summary["complete"])
+        self.assertEqual(summary["failed_commands"], ["logs_container_worker-0_main"])
+        self.assertEqual(
+            summary["optional_failed_commands"],
+            ["logs_previous_container_worker-0_main"],
+        )
+
+    def test_documented_output_dir_alias_is_accepted(self) -> None:
+        def fake_run(cmd: list[str], timeout: int) -> dict[str, object]:
+            del timeout
+            return {
+                "cmd": cmd,
+                "returncode": 0,
+                "stdout": '{"items": []}' if cmd[-2:] == ["-o", "json"] else "",
+                "stderr": "",
+            }
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            argv = [str(SCRIPT), "--namespace", "demo", "--output-dir", tempdir]
+            with (
+                patch.object(sys, "argv", argv),
+                patch.object(bundle, "run", side_effect=fake_run),
+                redirect_stdout(StringIO()),
+                redirect_stderr(StringIO()),
+            ):
+                result = bundle.main()
+
+        self.assertEqual(result, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/troubleshoot-dynamo/tests/test_collect_dynamo_debug_bundle.py
+++ b/.agents/skills/troubleshoot-dynamo/tests/test_collect_dynamo_debug_bundle.py
@@ -22,6 +22,7 @@ SPEC.loader.exec_module(bundle)
 
 class DebugBundleTest(unittest.TestCase):
     def test_redact_distinguishes_credentials_from_token_telemetry(self) -> None:
+        """Redact credential fields without hiding token-count telemetry."""
         source = (
             '{"api_key":"json-secret","access_token":"access-secret",'
             '"author":"alice","tokenizer":"Qwen","prompt_tokens":128,'
@@ -41,6 +42,7 @@ class DebugBundleTest(unittest.TestCase):
         self.assertEqual(output.count("<redacted>"), 3)
 
     def test_redact_decodes_json_keys_and_preserves_escaped_values(self) -> None:
+        """Decode escaped JSON keys while preserving non-secret escaped values."""
         source = r'{"api\u005fkey":"secr\"et","author":"ali\"ce"}'
 
         output = bundle.redact(source)
@@ -51,11 +53,30 @@ class DebugBundleTest(unittest.TestCase):
         )
 
     def test_redact_handles_long_unterminated_json_string(self) -> None:
+        """Handle adversarial unterminated JSON strings without backtracking."""
         source = '{"api_key":"' + (r"\!" * 50_000)
 
         self.assertEqual(bundle.redact(source), source)
 
+    def test_write_result_redacts_complete_bearer_credential(self) -> None:
+        """Remove a full opaque bearer credential from persisted command output."""
+        credential = "opaque+/token=="
+        result = {
+            "cmd": ["kubectl", "logs", "worker-0"],
+            "returncode": 0,
+            "stdout": f"Authorization: Bearer {credential}\n",
+            "stderr": "",
+        }
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            bundle.write_result(Path(tempdir), "logs", result)
+            output = (Path(tempdir) / "logs.txt").read_text()
+
+        self.assertNotIn(credential, output)
+        self.assertIn("<redacted>", output)
+
     def test_pod_discovery_files_do_not_persist_pod_specs(self) -> None:
+        """Omit full pod specifications from pod-discovery result files."""
         result = {
             "cmd": ["kubectl", "get", "pod", "worker-0", "-o", "json"],
             "returncode": 0,
@@ -70,15 +91,18 @@ class DebugBundleTest(unittest.TestCase):
         self.assertIn("pod JSON used only for local discovery", output)
 
     def test_deployment_and_explicit_selectors_are_combined(self) -> None:
+        """Combine deployment and caller selectors for pod discovery."""
         self.assertEqual(
             bundle.deployment_pod_selector("qwen", "app=worker"),
             "nvidia.com/dynamo-graph-deployment-name=qwen,app=worker",
         )
 
     def test_named_deployment_scopes_pods_and_failed_reads_return_nonzero(self) -> None:
+        """Scope pod reads and fail the bundle when a required read fails."""
         calls: list[list[str]] = []
 
         def fake_run(cmd: list[str], timeout: int) -> dict[str, object]:
+            """Record calls and fail only the required events query."""
             del timeout
             calls.append(cmd)
             failed = cmd[1:3] == ["get", "events"]
@@ -123,7 +147,10 @@ class DebugBundleTest(unittest.TestCase):
         )
 
     def test_complete_top_level_collection_returns_zero(self) -> None:
+        """Return zero when every required top-level collection succeeds."""
+
         def fake_run(cmd: list[str], timeout: int) -> dict[str, object]:
+            """Return successful empty inventory responses."""
             del timeout
             return {
                 "cmd": cmd,
@@ -148,7 +175,10 @@ class DebugBundleTest(unittest.TestCase):
         self.assertEqual(summary["failed_commands"], [])
 
     def test_current_log_rbac_failure_makes_bundle_incomplete(self) -> None:
+        """Treat denied current logs as required and previous logs as optional."""
+
         def fake_run(cmd: list[str], timeout: int) -> dict[str, object]:
+            """Expose one pod and deny both current and previous logs."""
             del timeout
             if cmd[1:3] == ["get", "pods"] and cmd[-2:] == ["-o", "json"]:
                 stdout = '{"items": [{"metadata": {"name": "worker-0"}}]}'
@@ -185,7 +215,10 @@ class DebugBundleTest(unittest.TestCase):
         )
 
     def test_documented_output_dir_alias_is_accepted(self) -> None:
+        """Accept the documented output-directory alias."""
+
         def fake_run(cmd: list[str], timeout: int) -> dict[str, object]:
+            """Return successful empty inventory responses."""
             del timeout
             return {
                 "cmd": cmd,
@@ -205,6 +238,24 @@ class DebugBundleTest(unittest.TestCase):
                 result = bundle.main()
 
         self.assertEqual(result, 0)
+
+    def test_nonempty_output_directory_is_rejected(self) -> None:
+        """Reject stale artifacts before running any collection command."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            stale_file = Path(tempdir) / "logs_from_another_scope.txt"
+            stale_file.write_text("stale")
+            argv = [str(SCRIPT), "--namespace", "demo", "--outdir", tempdir]
+            with (
+                patch.object(sys, "argv", argv),
+                patch.object(bundle, "run") as fake_run,
+                redirect_stdout(StringIO()),
+                redirect_stderr(StringIO()),
+                self.assertRaises(SystemExit) as raised,
+            ):
+                bundle.main()
+
+        self.assertEqual(raised.exception.code, 2)
+        fake_run.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/.agents/skills/troubleshoot-dynamo/tests/test_collect_dynamo_debug_bundle.py
+++ b/.agents/skills/troubleshoot-dynamo/tests/test_collect_dynamo_debug_bundle.py
@@ -52,6 +52,16 @@ class DebugBundleTest(unittest.TestCase):
             r'{"api\u005fkey":"<redacted>","author":"ali\"ce"}',
         )
 
+    def test_redact_recognizes_compact_key_names(self) -> None:
+        """Cover compact credential names without broad substring matching."""
+        source = "APIKEY=compact-api-secret\nACCESSKEY: compact-access-secret\n"
+
+        output = bundle.redact(source)
+
+        self.assertNotIn("compact-api-secret", output)
+        self.assertNotIn("compact-access-secret", output)
+        self.assertEqual(output.count("<redacted>"), 2)
+
     def test_redact_handles_long_unterminated_json_string(self) -> None:
         """Handle adversarial unterminated JSON strings without backtracking."""
         source = '{"api_key":"' + (r"\!" * 50_000)

--- a/.agents/skills/troubleshoot-dynamo/tests/test_collect_dynamo_debug_bundle.py
+++ b/.agents/skills/troubleshoot-dynamo/tests/test_collect_dynamo_debug_bundle.py
@@ -40,6 +40,21 @@ class DebugBundleTest(unittest.TestCase):
         self.assertIn('"monkey":"banana"', output)
         self.assertEqual(output.count("<redacted>"), 3)
 
+    def test_redact_decodes_json_keys_and_preserves_escaped_values(self) -> None:
+        source = r'{"api\u005fkey":"secr\"et","author":"ali\"ce"}'
+
+        output = bundle.redact(source)
+
+        self.assertEqual(
+            output,
+            r'{"api\u005fkey":"<redacted>","author":"ali\"ce"}',
+        )
+
+    def test_redact_handles_long_unterminated_json_string(self) -> None:
+        source = '{"api_key":"' + (r"\!" * 50_000)
+
+        self.assertEqual(bundle.redact(source), source)
+
     def test_pod_discovery_files_do_not_persist_pod_specs(self) -> None:
         result = {
             "cmd": ["kubectl", "get", "pod", "worker-0", "-o", "json"],


### PR DESCRIPTION
## Summary

Make the `troubleshoot-dynamo` debug bundle honor its documented deployment scope, report incomplete evidence collection, and persist only current, redacted evidence.

## Overview

The current `--deployment-name` option only adds a DynamoGraphDeployment description; pod discovery still selects every pod in the namespace and collects every container's logs. The script also exits 0 when top-level reads, pod discovery, descriptions, or current logs fail, so an incomplete bundle can look successful.

This change aligns the collector, skill contract, and regression coverage.

## Details

- Scope pod listings, descriptions, and logs to the named DGD through the operator's `nvidia.com/dynamo-graph-deployment-name` label.
- Combine an explicit `--selector` with the DGD label for narrower pod collection while keeping Services, Jobs, PVCs, and other namespace summaries namespace-wide.
- Record required and optional detail commands in `summary.json`, return nonzero for required collection failures, and treat missing `--previous` logs as optional.
- Preserve successfully collected evidence when part of the bundle is incomplete.
- Keep full pod JSON in memory for discovery instead of persisting pod specs to the bundle.
- Improve best-effort redaction for JSON and plain-text credential fields without hiding ordinary tokenizer and token-count diagnostics.
- Replace the JSON credential regex with a bounded scanner that handles escaped keys and values without exponential backtracking.
- Redact complete opaque bearer credentials before generic key/value handling.
- Reject nonempty user-provided output directories so stale files from another scope cannot remain in a new bundle.
- Accept both `--outdir` and the previously documented `--output-dir` spelling.
- Align the skill prerequisites, limitations, and troubleshooting table with the script's actual RBAC, scope, redaction, exit-status, output-directory, and provider-neutral model Secret behavior.
- Make the linked failure decision tree provider-neutral and derive model-access Secret/key names from the job without fetching Secret data.
- Add focused regression tests for scoping, incomplete collection, `pods/log` denial, optional previous logs, output-directory compatibility, pod-spec omission, credential redaction (including compact `APIKEY`/`ACCESSKEY` names), escaped JSON strings, and adversarial unterminated input.
- Document the non-obvious contracts and safety constraints in touched functions and test helpers.

## Validation

- `python3 -m unittest discover -s .agents/skills/troubleshoot-dynamo/tests -v` — 12 tests pass.
- `python3 -m py_compile` passes for the collector and its tests.
- `uvx pre-commit run --files .agents/skills/troubleshoot-dynamo/SKILL.md .agents/skills/troubleshoot-dynamo/references/failure-decision-tree.md .agents/skills/troubleshoot-dynamo/scripts/collect_dynamo_debug_bundle.py .agents/skills/troubleshoot-dynamo/tests/test_collect_dynamo_debug_bundle.py` passes.
- Skill Creator `quick_validate.py` reports `Skill is valid!`.
- `uv run --no-project --with pyyaml python scripts/validate_skills.py .` reports `validated 26 skills: OK`.
- `git diff --check` passes.
- AST inspection reports docstrings on 28 of 29 functions in the changed Python files (96.6%); the one undocumented function is a three-line nested replacement callback whose former restatement docstring was removed during review.
- Independent pre-submission review found four issues across completeness accounting, RBAC, secret handling, and over-broad redaction; all were fixed before the PR was opened.
- CodeQL alerts 733 and 734 were addressed by removing the flagged JSON regex and adding escaped/unterminated JSON regression cases; exact-head CodeQL revalidation is pending.
- CodeRabbit's bearer-redaction and provider-specific Secret findings were fixed, along with its stale-output-directory risk and docstring-coverage warning; exact-head re-review is pending.
- Dynamo review-agent feedback on compact credential keys and redundant docstrings was addressed; exact-head re-review is pending.
- No Kubernetes resource was read or changed for this patch; behavior was exercised with mocked command results.

## Where should the reviewer start?

Start with `redact_json_string_values()`, `deployment_pod_selector()`, and the required/optional command accounting in `.agents/skills/troubleshoot-dynamo/scripts/collect_dynamo_debug_bundle.py`, then review `.agents/skills/troubleshoot-dynamo/tests/test_collect_dynamo_debug_bundle.py`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamo debug bundle collection now supports deployment-aware pod selection and optional selectors.
  * Added broader read-only diagnostics for pod logs, services, nodes, and storage classes.
  * Added collection completeness reporting with clear required and optional failure status.
  * Added the `--output-dir` command-line option.

* **Security**
  * Sensitive credentials are redacted more comprehensively, while telemetry values are preserved.
  * Pod specifications and Kubernetes Secrets are excluded from collected bundle files.

* **Documentation**
  * Updated Dynamo troubleshooting guidance with RBAC requirements, log-scoping details, and expected partial-collection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
