### PR TITLE
docs: make platform uninstall guidance safe

### DIFF
--- a/docs/fern/pages/kubernetes/installation/install-dynamo.md
+++ b/docs/fern/pages/kubernetes/installation/install-dynamo.md
@@ -381,18 +381,66 @@ Add to the helm install command:
 --set "etcd.image.repository=bitnamilegacy/etcd" --set "etcd.global.security.allowInsecureImages=true"
 ```
 
-**Clean uninstall?**
+**Uninstall the platform chart?**
+
+In the default cluster-wide installation, the operator image applies Dynamo CRDs outside Helm's
+normal resource ownership, so `helm uninstall` leaves them in the cluster. Keep the CRDs by
+default. The chart also contains the cluster-wide operator and shared services, so do not use this
+procedure for namespace cleanup.
+
+Before uninstalling the chart, inventory the CRDs stamped by Dynamo's `crd-apply` process and their
+scope:
 
 ```bash
-# Uninstall the platform
-helm uninstall dynamo-platform --namespace $NAMESPACE
-
-# List Dynamo CRDs
-kubectl get crd | grep "dynamo.*nvidia.com"
-
-# Delete each CRD
-kubectl delete crd <crd-name>
+kubectl get crd -o json | jq -r '
+  .items[]
+  | select(.metadata.annotations["dynamo.nvidia.com/operator-version"] != null)
+  | [.metadata.name, .spec.scope]
+  | @tsv'
 ```
+
+Back up every listed custom resource before decommissioning. Use the CRD name from the first column
+and choose the command that matches its scope. The output can contain sensitive workload
+configuration, so store it accordingly.
+
+```bash
+# Example for a Namespaced row; set this to each CRD name from the inventory
+CRD_NAME=dynamographdeployments.nvidia.com
+kubectl get "$CRD_NAME" --all-namespaces -o yaml > "${CRD_NAME}.backup.yaml"
+```
+
+For a `Cluster`-scoped row, set `CRD_NAME` to that row's CRD name and omit
+`--all-namespaces`:
+
+```bash
+kubectl get "$CRD_NAME" -o yaml > "${CRD_NAME}.backup.yaml"
+```
+
+If the workloads are also being decommissioned, first delete any DGDRs so they cannot create or
+update deployments. Deleting a DGDR does not delete the DGD it generated, so explicitly delete
+every DGD and any other top-level Dynamo custom resources being decommissioned through the normal
+Kubernetes API while the operator is still running. Verify that their child workloads are gone
+before uninstalling the platform. If workloads must remain running, do not uninstall this chart
+until a supported replacement control plane has assumed their reconciliation and dependencies.
+
+```bash
+helm uninstall dynamo-platform --namespace $NAMESPACE
+```
+
+For a namespace-restricted development or test installation, do not treat the shared CRDs as owned
+by that release: `dynamo-operator.upgradeCRD=false` makes the cluster-wide operator responsible for
+them. Remove or hand off only the target namespace's workloads, verify reconciliation has moved to a
+supported operator if they remain, and then uninstall the namespace-restricted release. Do not
+delete the shared CRDs.
+
+> [!WARNING]
+> Do not delete Dynamo CRDs as routine release or namespace cleanup. CRDs are cluster-scoped, and
+> [deleting a CRD deletes every custom object stored in it across all
+> namespaces](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#delete-a-customresourcedefinition).
+> Recreating the CRD starts with no stored custom objects. For a full cluster-wide Dynamo
+> decommission, complete the inventory, backup, and workload cleanup above. Treat CRD deletion as a
+> separate destructive cluster-administrator action.
+
 ## Reference
 
 - [Helm Chart Configuration](https://github.com/ai-dynamo/dynamo/tree/main/deploy/helm/charts/platform/README.md)

--- a/docs/fern/pages/kubernetes/installation/install-dynamo.md
+++ b/docs/fern/pages/kubernetes/installation/install-dynamo.md
@@ -401,27 +401,34 @@ kubectl get crd -o json | jq -r '
 
 Back up every listed custom resource before decommissioning. Use the CRD name from the first column
 and choose the command that matches its scope. The output can contain sensitive workload
-configuration, so store it accordingly.
+configuration, so create the backups with owner-only permissions.
 
 ```bash
 # Example for a Namespaced row; set this to each CRD name from the inventory
+BACKUP_DIR=dynamo-cr-backup
+umask 077
+mkdir -p "$BACKUP_DIR"
+chmod 700 "$BACKUP_DIR"
 CRD_NAME=dynamographdeployments.nvidia.com
-kubectl get "$CRD_NAME" --all-namespaces -o yaml > "${CRD_NAME}.backup.yaml"
+kubectl get "$CRD_NAME" --all-namespaces -o yaml \
+  > "$BACKUP_DIR/${CRD_NAME}.backup.yaml"
 ```
 
 For a `Cluster`-scoped row, set `CRD_NAME` to that row's CRD name and omit
 `--all-namespaces`:
 
 ```bash
-kubectl get "$CRD_NAME" -o yaml > "${CRD_NAME}.backup.yaml"
+kubectl get "$CRD_NAME" -o yaml > "$BACKUP_DIR/${CRD_NAME}.backup.yaml"
 ```
 
 If the workloads are also being decommissioned, first delete any DGDRs so they cannot create or
-update deployments. Deleting a DGDR does not delete the DGD it generated, so explicitly delete
-every DGD and any other top-level Dynamo custom resources being decommissioned through the normal
-Kubernetes API while the operator is still running. Verify that their child workloads are gone
-before uninstalling the platform. If workloads must remain running, do not uninstall this chart
-until a supported replacement control plane has assumed their reconciliation and dependencies.
+update deployments. The standard controller leaves each generated DGD in place, but temporary
+profiling workflows can owner-reference the DGD to its DGDR and allow Kubernetes to garbage-collect
+it. After deleting the DGDRs, list and explicitly delete every remaining DGD and any other top-level
+Dynamo custom resources being decommissioned through the normal Kubernetes API while the operator
+is still running. Verify that their child workloads are gone before uninstalling the platform. If
+workloads must remain running, do not uninstall this chart until a supported replacement control
+plane has assumed their reconciliation and dependencies.
 
 ```bash
 helm uninstall dynamo-platform --namespace $NAMESPACE
@@ -429,9 +436,12 @@ helm uninstall dynamo-platform --namespace $NAMESPACE
 
 For a namespace-restricted development or test installation, do not treat the shared CRDs as owned
 by that release: `dynamo-operator.upgradeCRD=false` makes the cluster-wide operator responsible for
-them. Remove or hand off only the target namespace's workloads, verify reconciliation has moved to a
-supported operator if they remain, and then uninstall the namespace-restricted release. Do not
-delete the shared CRDs.
+them. Before uninstalling, delete every DGDR, DGD, and other Dynamo custom resource in the target
+namespace, or complete a supported handoff for all of them. Uninstalling the release removes or
+stops renewing its namespace-scope Lease; after that Lease is deleted or expires, the cluster-wide
+operator resumes reconciliation for retained custom resources and may recreate workloads. Verify
+that reconciliation has moved to the replacement operator if resources remain. Do not delete the
+shared CRDs.
 
 > [!WARNING]
 > Do not delete Dynamo CRDs as routine release or namespace cleanup. CRDs are cluster-scoped, and


### PR DESCRIPTION
## Overview

The Kubernetes installation guide's clean-uninstall example told users to delete every Dynamo CRD after uninstalling the platform chart. Kubernetes CRD deletion also deletes every stored custom resource of that kind across all namespaces, so that copy-paste path could destroy unrelated Dynamo deployments on a shared cluster.

This change replaces that recipe with a release-aware decommission procedure and makes CRD deletion an explicitly separate, destructive cluster-administrator action.

## Details

- Keeps Dynamo CRDs by default after uninstalling the platform chart.
- Requires inventory and sensitive YAML backups of the custom resources served by CRDs stamped by Dynamo's `crd-apply` process before a cluster-wide decommission.
- Preserves the operator until DGDRs, their separately persisted DGDs, other top-level custom resources, and child workloads are removed and verified.
- Distinguishes the default cluster-wide installation from namespace-restricted development/test releases, which do not own the shared CRDs.
- Links to Kubernetes' CRD-deletion semantics and removes the routine `kubectl delete crd` command.

## Where should the reviewer start?

Review the `Uninstall the platform chart?` troubleshooting section in `docs/fern/pages/kubernetes/installation/install-dynamo.md`. In particular, verify the ordering of backup, workload cleanup, chart uninstall, and the CRD-deletion warning.

## Validation

- `uvx pre-commit run --files docs/fern/pages/kubernetes/installation/install-dynamo.md`
- `uv run --isolated --no-project --python 3.13 --with griffe==2.1.0 python docs/fern/scripts/gen_python_api.py`
- `uv run --isolated --no-project --python 3.13 --with griffe==2.1.0 python docs/fern/scripts/gen_rust_api.py`
- `npx --yes fern-api check` (0 errors; 2 existing warnings)
- `npx --yes fern-api docs broken-links` (the new Kubernetes link passes; the command reports 10 pre-existing errors in `tls.md` and the Qwen recipe page)
- `git diff --check -- docs/fern/pages/kubernetes/installation/install-dynamo.md`
- Three independent review passes; all findings resolved before submission.

## Related Issues

**🚫 This PR is NOT linked to an issue**:

- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Kubernetes troubleshooting guidance with safer uninstall procedures.
  - Added instructions for identifying and backing up managed resources.
  - Clarified cleanup ordering and separate steps for cluster-wide versus namespace-restricted installations.
  - Added a warning that deleting custom resource definitions also deletes stored custom resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->