### PR TITLE
fix(skills): scope debug bundle pods by deployment

### DIFF
--- a/.agents/skills/troubleshoot-dynamo/SKILL.md
+++ b/.agents/skills/troubleshoot-dynamo/SKILL.md
@@ -50,6 +50,9 @@ python3 scripts/collect_dynamo_debug_bundle.py \
   --deployment-name <deployment-name>
 ```
 
+This scopes the pod inventory, descriptions, and logs to that deployment.
+Services, jobs, PVCs, events, and other summaries remain namespace-wide.
+
 Do not collect Kubernetes secrets. Do not print Hugging Face tokens.
 
 ### 2. Classify The Failure

--- a/.agents/skills/troubleshoot-dynamo/scripts/collect_dynamo_debug_bundle.py
+++ b/.agents/skills/troubleshoot-dynamo/scripts/collect_dynamo_debug_bundle.py
@@ -18,6 +18,7 @@ from typing import Any
 # Tunables and conventional return codes (kept here to avoid magic numbers).
 DEFAULT_KUBECTL_TIMEOUT_SEC = 30
 DEFAULT_LOG_TAIL_LINES = 200
+DGD_POD_LABEL = "nvidia.com/dynamo-graph-deployment-name"
 # POSIX-conventional return codes used when the wrapper itself fails before
 # kubectl can produce a real one.
 RETURNCODE_COMMAND_NOT_FOUND = 127  # `kubectl` not installed
@@ -113,6 +114,15 @@ def pod_names(namespace: str, selector: str | None, timeout: int) -> list[str]:
     ]
 
 
+def deployment_pod_selector(
+    deployment_name: str | None, selector: str | None
+) -> str | None:
+    if not deployment_name:
+        return selector
+    deployment_selector = f"{DGD_POD_LABEL}={deployment_name}"
+    return f"{deployment_selector},{selector}" if selector else deployment_selector
+
+
 def container_names(namespace: str, pod: str, timeout: int) -> list[tuple[str, str]]:
     body = kubectl_json(["get", "pod", pod, "-n", namespace], timeout)
     if not body:
@@ -155,6 +165,11 @@ def main() -> int:
         # guessable /tmp/dynamo-debug-<timestamp> path on a shared host.
         outdir = Path(tempfile.mkdtemp(prefix="dynamo-debug-")).resolve()
 
+    pod_selector = deployment_pod_selector(args.deployment_name, args.selector)
+    pod_command = ["kubectl", "get", "pods", "-n", args.namespace, "-o", "wide"]
+    if pod_selector:
+        pod_command.extend(["-l", pod_selector])
+
     commands: list[tuple[str, list[str]]] = [
         ("context", ["kubectl", "config", "current-context"]),
         ("nodes", ["kubectl", "get", "nodes", "-o", "wide"]),
@@ -172,7 +187,7 @@ def main() -> int:
                 "wide",
             ],
         ),
-        ("pods", ["kubectl", "get", "pods", "-n", args.namespace, "-o", "wide"]),
+        ("pods", pod_command),
         ("services", ["kubectl", "get", "svc", "-n", args.namespace, "-o", "wide"]),
         ("pvc", ["kubectl", "get", "pvc", "-n", args.namespace, "-o", "wide"]),
         ("jobs", ["kubectl", "get", "jobs", "-n", args.namespace, "-o", "wide"]),
@@ -215,7 +230,11 @@ def main() -> int:
             {"name": name, "cmd": cmd, "returncode": result["returncode"]}
         )
 
-    pods = pod_names(args.namespace, args.selector, args.timeout)
+    pods = pod_names(
+        args.namespace,
+        pod_selector,
+        args.timeout,
+    )
     summary["pods"] = pods
     for pod in pods:
         result = run(

--- a/.agents/skills/troubleshoot-dynamo/tests/test_collect_dynamo_debug_bundle.py
+++ b/.agents/skills/troubleshoot-dynamo/tests/test_collect_dynamo_debug_bundle.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT = Path(__file__).parents[1] / "scripts/collect_dynamo_debug_bundle.py"
+spec = importlib.util.spec_from_file_location("collect_dynamo_debug_bundle", SCRIPT)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"Unable to load {SCRIPT}")
+bundle = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bundle)
+
+
+class DeploymentPodSelectorTest(unittest.TestCase):
+    def test_selector_combinations(self):
+        cases = [
+            (None, None, None),
+            (None, "app=worker", "app=worker"),
+            ("qwen", None, "nvidia.com/dynamo-graph-deployment-name=qwen"),
+            (
+                "qwen",
+                "app=worker",
+                "nvidia.com/dynamo-graph-deployment-name=qwen,app=worker",
+            ),
+        ]
+
+        for deployment_name, selector, expected in cases:
+            with self.subTest(deployment_name=deployment_name, selector=selector):
+                self.assertEqual(
+                    bundle.deployment_pod_selector(deployment_name, selector), expected
+                )
+
+    def test_main_scopes_both_pod_queries(self):
+        calls = []
+
+        def fake_run(cmd, timeout):
+            del timeout
+            calls.append(cmd)
+            stdout = json.dumps({"items": []}) if cmd[-2:] == ["-o", "json"] else ""
+            return {"cmd": cmd, "returncode": 0, "stdout": stdout, "stderr": ""}
+
+        with tempfile.TemporaryDirectory() as outdir:
+            argv = [
+                str(SCRIPT),
+                "--namespace",
+                "demo",
+                "--deployment-name",
+                "qwen",
+                "--selector",
+                "app=worker",
+                "--outdir",
+                outdir,
+            ]
+            with (
+                patch.object(sys, "argv", argv),
+                patch.object(bundle, "run", side_effect=fake_run),
+                redirect_stdout(StringIO()),
+            ):
+                self.assertEqual(bundle.main(), 0)
+
+        selector = "nvidia.com/dynamo-graph-deployment-name=qwen,app=worker"
+        self.assertIn(
+            ["kubectl", "get", "pods", "-n", "demo", "-o", "wide", "-l", selector],
+            calls,
+        )
+        self.assertIn(
+            ["kubectl", "get", "pods", "-n", "demo", "-l", selector, "-o", "json"],
+            calls,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Scope debug-bundle pod collection to the requested `DynamoGraphDeployment`.

## Overview:

`--deployment-name` previously selected the deployment description without
limiting pod discovery. In a namespace with multiple deployments, the collector
could therefore describe and collect logs from unrelated pods.

## Details:

- Build a pod selector from the deployment's
  `nvidia.com/dynamo-graph-deployment-name` label.
- Combine that label with an explicit `--selector` when both are provided.
- Apply the selector to the human-readable pod inventory and the JSON discovery
  used for pod descriptions and logs.
- Clarify that services, jobs, PVCs, events, and other summaries remain
  namespace-wide.
- Add focused tests for selector combinations and both pod-query paths.

## Where should the reviewer start?

Start with `deployment_pod_selector()` and its use in `main()` in
`.agents/skills/troubleshoot-dynamo/scripts/collect_dynamo_debug_bundle.py`,
then review
`.agents/skills/troubleshoot-dynamo/tests/test_collect_dynamo_debug_bundle.py`.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -B -m unittest discover -s .agents/skills/troubleshoot-dynamo/tests -v` — 2 tests passed.
- Targeted pre-commit hooks passed for all three changed files.
- Skill Creator and repository skill validators passed.
- `git diff --check` passed.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Debug bundles can now target pods belonging to a specified DynamoGraphDeployment.
  - Optional pod selectors are combined with the deployment filter for more precise troubleshooting.
  - Pod descriptions and logs are limited to the selected deployment’s pods, while other namespace-wide diagnostics remain available.

- **Documentation**
  - Clarified which diagnostic data is deployment-scoped versus namespace-wide.

- **Tests**
  - Added coverage for selector combinations and consistent filtering across pod queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->