### PR TITLE
[BUG]: autoscaling deprecation warning points to docs/kubernetes/autoscaling.md, which does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,4 +300,5 @@ To quickly setup both: `docker compose -f dev/docker-compose.yml up -d`
 [kvbm]: docs/components/kvbm/README.md
 [migration]: docs/fault-tolerance/request-migration.md
 [lora]: examples/backends/vllm/deploy/lora/README.md
+[autoscaling]: docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/autoscaling.md
 [tools]: docs/fern/pages/use-cases/tool-calling-and-reasoning/tool-call-parsing.mdx


### PR DESCRIPTION
Fixes #13317

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference link to the Kubernetes operator autoscaling documentation in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->