### PR TITLE
feat(router): add opt-in decision traces

### DIFF
--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -1060,6 +1060,49 @@ pub struct WorkerSelectionResult {
     /// Selected worker's projected decode load after adding this request's
     /// prompt blocks, in scheduler-tracked block units.
     pub potential_decode_blocks: usize,
+
+    /// Opt-in, request-scoped explanation of the router choice. This is absent
+    /// unless `DYN_ROUTER_DECISION_TRACE_ENABLED=true`.
+    pub decision_trace: Option<RoutingDecisionTrace>,
+}
+
+/// A bounded explanation of one default KV-router selection.
+///
+/// This intentionally contains only numerical routing state — no prompt text,
+/// token IDs, cache keys, or user headers. It can therefore be attached to a
+/// request-end trace when explicitly enabled for a diagnostic deployment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingDecisionTrace {
+    pub worker_type: String,
+    pub block_size: u32,
+    pub selected_worker_id: WorkerId,
+    pub selected_dp_rank: DpRank,
+    pub overlap_score_credit: f64,
+    pub prefill_load_scale: f64,
+    pub host_cache_hit_weight: f64,
+    pub disk_cache_hit_weight: f64,
+    pub candidates: Vec<RoutingDecisionCandidate>,
+}
+
+/// The exact default-router inputs and cost for one eligible worker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingDecisionCandidate {
+    pub worker_id: WorkerId,
+    pub dp_rank: DpRank,
+    pub selected: bool,
+    pub total_cost_blocks: f64,
+    pub effective_overlap_blocks: f64,
+    pub device_overlap_blocks: f64,
+    pub host_overlap_blocks: f64,
+    pub disk_overlap_blocks: f64,
+    pub shared_beyond_device_blocks: u32,
+    pub raw_prefill_blocks: f64,
+    pub prefill_cost_blocks: f64,
+    pub decode_cost_blocks: f64,
+    pub active_request_cost_blocks: f64,
+    pub overlap_credit_blocks: f64,
+    pub overlap_credit_decay: f64,
+    pub preferred_taint_multiplier: Option<f64>,
 }
 
 /// Active load metrics for a worker, used for overload detection.

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -1090,6 +1090,7 @@ impl<
                 target_cached_prefix_blocks,
                 router_hint_candidates: request.router_hint_candidates.take(),
                 potential_decode_blocks: selected.selection.potential_decode_blocks,
+                decision_trace: selected.selection.decision_trace,
             },
         })
     }
@@ -1116,6 +1117,7 @@ impl<
             target_cached_prefix_blocks,
             router_hint_candidates: request.router_hint_candidates.take(),
             potential_decode_blocks: selected.selection.potential_decode_blocks,
+            decision_trace: selected.selection.decision_trace,
         };
         let non_max_overlap_selection = selected.non_max_overlap_selection;
 
@@ -1454,6 +1456,7 @@ mod tests {
                 cached_tokens: request.effective_cached_tokens_for(worker),
                 potential_decode_blocks: request
                     .potential_decode_blocks_after_admission(worker, block_size),
+                decision_trace: None,
             })
         }
     }

--- a/lib/kv-router/src/scheduling/selector/default.rs
+++ b/lib/kv-router/src/scheduling/selector/default.rs
@@ -14,7 +14,10 @@ use super::{
     WorkerInputView, WorkerInputs, WorkerPicker, WorkerSelectionContext, WorkerSelectionInput,
     WorkerSelector, select_worker_with_policy,
 };
-use crate::protocols::{WorkerConfigLike, WorkerId, WorkerSelectionResult, WorkerWithDpRank};
+use crate::protocols::{
+    RoutingDecisionCandidate, RoutingDecisionTrace, WorkerConfigLike, WorkerId,
+    WorkerSelectionResult, WorkerWithDpRank,
+};
 use crate::scheduling::config::KvRouterConfig;
 use crate::scheduling::filter::RoutingEligibility;
 use crate::scheduling::types::{KvSchedulerError, SchedulingRequest, WorkerSelectionPolicyError};
@@ -102,7 +105,7 @@ pub(super) struct DefaultWorkerScorer<C = KvRouterConfig> {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct DefaultScoringContext {
+pub(super) struct DefaultScoringContext {
     min_active_prefill_tokens: usize,
     has_tier_overlap_blocks: bool,
 }
@@ -254,7 +257,7 @@ impl DefaultScoringContext {
     }
 }
 
-fn default_row(
+pub(super) fn default_row(
     input: &MaterializedSelectionInput<'_>,
     context: DefaultScoringContext,
     worker: WorkerWithDpRank,
@@ -271,7 +274,7 @@ fn default_row(
 }
 
 impl<C: Borrow<KvRouterConfig>> DefaultWorkerScorer<C> {
-    fn worker_logit(
+    pub(super) fn worker_logit(
         &self,
         context: &WorkerSelectionContext<'_>,
         default_context: DefaultScoringContext,
@@ -389,7 +392,7 @@ impl<C: Borrow<KvRouterConfig>> DefaultWorkerScorer<C> {
     }
 
     #[inline]
-    fn worker_cost(
+    pub(super) fn worker_cost(
         &self,
         context: &WorkerSelectionContext<'_>,
         default_context: DefaultScoringContext,
@@ -403,6 +406,88 @@ impl<C: Borrow<KvRouterConfig>> DefaultWorkerScorer<C> {
             None => base_score,
         }
     }
+}
+
+/// Build the per-worker explanation only after a selection, and only when the
+/// caller explicitly enabled diagnostic tracing. The normal picker remains
+/// allocation-free beyond its existing scratch buffer.
+pub(super) fn decision_trace_for_selection<C: WorkerConfigLike>(
+    kv_router_config: &KvRouterConfig,
+    worker_type: &'static str,
+    input: &MaterializedSelectionInput<'_>,
+    workers: &HashMap<WorkerId, C>,
+    request: &SchedulingRequest,
+    eligibility: RoutingEligibility<'_>,
+    selected: WorkerWithDpRank,
+) -> Option<RoutingDecisionTrace> {
+    let default_context =
+        DefaultScoringContext::new(workers, request, eligibility, input.context.weights);
+    let scorer = DefaultWorkerScorer {
+        kv_router_config,
+        worker_type,
+    };
+    let weights = input.context.weights;
+    let mut candidates = Vec::new();
+    eligibility.for_each_eligible_worker_rank(workers, |worker, config| {
+        let preferred_taint_multiplier = request
+            .routing_constraints
+            .preferred_taint_multiplier(config.taints());
+        let row = default_row(input, default_context, worker, preferred_taint_multiplier);
+        let cache = row.cache;
+        let load = row.load;
+        let excess_active_prefill_blocks =
+            load.active_prefill_tokens
+                .saturating_sub(default_context.min_active_prefill_tokens) as f64
+                / input.context.block_size as f64;
+        let normalized_prefill_load =
+            excess_active_prefill_blocks / input.context.request_blocks as f64;
+        let overlap_credit_decay =
+            if input.context.track_prefill_tokens && weights.overlap_score_credit_decay > 0.0 {
+                1.0 / (1.0 + weights.overlap_score_credit_decay * normalized_prefill_load)
+            } else {
+                1.0
+            };
+        let device_overlap_blocks = default_context
+            .device_overlap(cache.effective_overlap_blocks, cache.device_overlap_blocks);
+        let overlap_credit_blocks =
+            weights.overlap_score_credit * overlap_credit_decay * device_overlap_blocks
+                + kv_router_config.host_cache_hit_weight * cache.host_overlap_blocks
+                + kv_router_config.disk_cache_hit_weight * cache.disk_overlap_blocks
+                + weights.shared_cache_multiplier * cache.shared_beyond_device_blocks as f64;
+        let prefill_cost_blocks =
+            weights.prefill_load_scale * (load.raw_prefill_blocks - overlap_credit_blocks).max(0.0);
+        let active_request_cost_blocks =
+            kv_router_config.decode_active_request_weight * load.active_requests as f64;
+        candidates.push(RoutingDecisionCandidate {
+            worker_id: worker.worker_id,
+            dp_rank: worker.dp_rank,
+            selected: worker == selected,
+            total_cost_blocks: scorer.worker_cost(&input.context, default_context, &row),
+            effective_overlap_blocks: cache.effective_overlap_blocks,
+            device_overlap_blocks,
+            host_overlap_blocks: cache.host_overlap_blocks,
+            disk_overlap_blocks: cache.disk_overlap_blocks,
+            shared_beyond_device_blocks: cache.shared_beyond_device_blocks,
+            raw_prefill_blocks: load.raw_prefill_blocks,
+            prefill_cost_blocks,
+            decode_cost_blocks: load.decode_cost_blocks,
+            active_request_cost_blocks,
+            overlap_credit_blocks,
+            overlap_credit_decay,
+            preferred_taint_multiplier,
+        });
+    });
+    (!candidates.is_empty()).then_some(RoutingDecisionTrace {
+        worker_type: worker_type.to_owned(),
+        block_size: input.context.block_size,
+        selected_worker_id: selected.worker_id,
+        selected_dp_rank: selected.dp_rank,
+        overlap_score_credit: weights.overlap_score_credit,
+        prefill_load_scale: weights.prefill_load_scale,
+        host_cache_hit_weight: kv_router_config.host_cache_hit_weight,
+        disk_cache_hit_weight: kv_router_config.disk_cache_hit_weight,
+        candidates,
+    })
 }
 
 impl DefaultWorkerPicker {

--- a/lib/kv-router/src/scheduling/selector/mod.rs
+++ b/lib/kv-router/src/scheduling/selector/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 mod default;
 mod policy;
@@ -15,7 +16,7 @@ pub use policy::{
     WorkerSelectionPolicy,
 };
 
-use default::{pick_default_worker, selection_weights};
+use default::{decision_trace_for_selection, pick_default_worker, selection_weights};
 use policy::{
     CustomWorkerSelectionState, WorkerSelectionPolicyStateRef, collect_custom_candidates,
 };
@@ -24,6 +25,23 @@ use super::config::KvRouterConfig;
 use super::filter::{RoutingEligibility, WorkerEligibilityError};
 use super::types::{KvSchedulerError, SchedulingRequest, WorkerSelectionPolicyError};
 use crate::protocols::{WorkerConfigLike, WorkerId, WorkerSelectionResult, WorkerWithDpRank};
+
+/// Disabled by default: collecting the candidate table is diagnostic-only and
+/// intentionally has zero extra work or trace volume in normal serving.
+static ROUTER_DECISION_TRACE_ENABLED: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("DYN_ROUTER_DECISION_TRACE_ENABLED")
+        .ok()
+        .is_some_and(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+});
+
+pub(crate) fn router_decision_trace_enabled() -> bool {
+    *ROUTER_DECISION_TRACE_ENABLED
+}
 
 /// Low-level selector used by routing hosts.
 ///
@@ -274,6 +292,7 @@ fn selection_result(
         cached_tokens: request.effective_cached_tokens_for(worker),
         potential_decode_blocks: request
             .potential_decode_blocks_after_admission(worker, block_size),
+        decision_trace: None,
     }
 }
 
@@ -437,7 +456,19 @@ fn select_worker_with_policy<C: WorkerConfigLike>(
         }
         return Err(KvSchedulerError::NoEndpoints);
     };
-    let result = selection_result(request, worker, block_size);
+    let mut result = selection_result(request, worker, block_size);
+    if router_decision_trace_enabled() && matches!(state, WorkerSelectionPolicyStateRef::Default(_))
+    {
+        result.decision_trace = decision_trace_for_selection(
+            kv_router_config,
+            worker_type,
+            &input,
+            workers,
+            request,
+            eligibility,
+            worker,
+        );
+    }
     log_selection(
         workers,
         request,

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -115,6 +115,8 @@ pub struct SchedulingResponse {
     pub target_cached_prefix_blocks: u32,
     pub router_hint_candidates: Option<RouterHintRootCandidates>,
     pub potential_decode_blocks: usize,
+    /// Populated only by opt-in default-router decision tracing.
+    pub decision_trace: Option<crate::protocols::RoutingDecisionTrace>,
 }
 
 /// A routing decision that selected less KV overlap than another eligible worker.

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -356,6 +356,7 @@ pub enum FindBestMatchOutcome {
         potential_decode_blocks: u64,
         routing_hashes: Option<RoutingDecisionHashes>,
         router_hint: Option<RouterHint>,
+        decision_trace: Option<dynamo_kv_router::protocols::RoutingDecisionTrace>,
     },
     QueueRejected {
         rejection: scheduling::QueueRejection,
@@ -375,6 +376,7 @@ pub enum FindBestMatchAdvisoryOutcome {
         potential_decode_blocks: u64,
         selected_worker_load: scheduling::AdvisoryWorkerLoad,
         routing_hashes: Option<RoutingDecisionHashes>,
+        decision_trace: Option<dynamo_kv_router::protocols::RoutingDecisionTrace>,
     },
     QueueRejected {
         rejection: scheduling::QueueRejection,
@@ -1543,6 +1545,7 @@ where
                     potential_decode_blocks: response.potential_decode_blocks as u64,
                     routing_hashes,
                     router_hint,
+                    decision_trace: response.decision_trace,
                 }),
             ),
             FindBestMatchAdmission::WithoutAdmission => Ok(
@@ -1555,6 +1558,7 @@ where
                     selected_worker_load: selected_worker_load
                         .expect("without-admission selection returns advisory load"),
                     routing_hashes,
+                    decision_trace: response.decision_trace,
                 }),
             ),
         }
@@ -2355,6 +2359,7 @@ mod tests {
                     .worker_load_for(self.selected_worker)
                     .potential_decode_blocks()
                     .saturating_add(request.isl_tokens.div_ceil(block_size as usize)),
+                decision_trace: None,
             })
         }
     }

--- a/lib/llm/src/kv_router/routing_host/builtin.rs
+++ b/lib/llm/src/kv_router/routing_host/builtin.rs
@@ -90,6 +90,7 @@ fn selection(worker_id: u64) -> WorkerSelectionResult {
         effective_overlap_blocks: 0.0,
         cached_tokens: 0,
         potential_decode_blocks: 0,
+        decision_trace: None,
     }
 }
 

--- a/lib/llm/src/kv_router/routing_host/kv.rs
+++ b/lib/llm/src/kv_router/routing_host/kv.rs
@@ -3,6 +3,44 @@
 
 use super::*;
 use crate::kv_router::{FindBestMatchAdmission, routing_host::kv_selection::SelectionOutcome};
+use crate::protocols::common::timing::{RoutingDecisionCandidate, RoutingDecisionTrace};
+
+fn request_trace_routing_decision(
+    trace: dynamo_kv_router::protocols::RoutingDecisionTrace,
+) -> RoutingDecisionTrace {
+    RoutingDecisionTrace {
+        worker_type: trace.worker_type,
+        block_size: trace.block_size,
+        selected_worker_id: trace.selected_worker_id,
+        selected_dp_rank: trace.selected_dp_rank,
+        overlap_score_credit: trace.overlap_score_credit,
+        prefill_load_scale: trace.prefill_load_scale,
+        host_cache_hit_weight: trace.host_cache_hit_weight,
+        disk_cache_hit_weight: trace.disk_cache_hit_weight,
+        candidates: trace
+            .candidates
+            .into_iter()
+            .map(|candidate| RoutingDecisionCandidate {
+                worker_id: candidate.worker_id,
+                dp_rank: candidate.dp_rank,
+                selected: candidate.selected,
+                total_cost_blocks: candidate.total_cost_blocks,
+                effective_overlap_blocks: candidate.effective_overlap_blocks,
+                device_overlap_blocks: candidate.device_overlap_blocks,
+                host_overlap_blocks: candidate.host_overlap_blocks,
+                disk_overlap_blocks: candidate.disk_overlap_blocks,
+                shared_beyond_device_blocks: candidate.shared_beyond_device_blocks,
+                raw_prefill_blocks: candidate.raw_prefill_blocks,
+                prefill_cost_blocks: candidate.prefill_cost_blocks,
+                decode_cost_blocks: candidate.decode_cost_blocks,
+                active_request_cost_blocks: candidate.active_request_cost_blocks,
+                overlap_credit_blocks: candidate.overlap_credit_blocks,
+                overlap_credit_decay: candidate.overlap_credit_decay,
+                preferred_taint_multiplier: candidate.preferred_taint_multiplier,
+            })
+            .collect(),
+    }
+}
 
 impl<Sel> RoutingHost<Sel>
 where
@@ -349,6 +387,9 @@ where
             }
 
             if let Some(ref tracker) = request.tracker {
+                if let Some(trace) = selection.decision_trace.take() {
+                    tracker.record_routing_decision_trace(request_trace_routing_decision(trace));
+                }
                 let isl_blocks = routing_parts.token_ids.len().div_ceil(block_size);
                 tracker.record_kv_hit(selection.effective_overlap_blocks, isl_blocks);
                 tracker.record_isl(routing_parts.token_ids.len(), Some(selection.cached_tokens));

--- a/lib/llm/src/kv_router/routing_host/kv_selection.rs
+++ b/lib/llm/src/kv_router/routing_host/kv_selection.rs
@@ -36,6 +36,7 @@ pub(super) struct WorkerSelection {
     pub(super) selected_worker_load: Option<AdvisoryWorkerLoad>,
     pub(super) routing_hashes: Option<RoutingDecisionHashes>,
     pub(super) router_hint: Option<RouterHint>,
+    pub(super) decision_trace: Option<dynamo_kv_router::protocols::RoutingDecisionTrace>,
 }
 
 pub(super) enum SelectionOutcome {
@@ -132,6 +133,7 @@ where
                     potential_decode_blocks,
                     routing_hashes,
                     router_hint,
+                    decision_trace,
                 } => Ok(SelectionOutcome::Routed(WorkerSelection {
                     worker,
                     overlap_amount: overlap_blocks,
@@ -141,6 +143,7 @@ where
                     selected_worker_load: None,
                     routing_hashes,
                     router_hint,
+                    decision_trace,
                 })),
                 FindBestMatchOutcome::QueueRejected { rejection } => {
                     Ok(SelectionOutcome::QueueRejected(rejection))
@@ -155,6 +158,7 @@ where
                     potential_decode_blocks,
                     selected_worker_load,
                     routing_hashes,
+                    decision_trace,
                 } => Ok(SelectionOutcome::Routed(WorkerSelection {
                     worker,
                     overlap_amount: overlap_blocks,
@@ -164,6 +168,7 @@ where
                     selected_worker_load: Some(selected_worker_load),
                     routing_hashes,
                     router_hint: None,
+                    decision_trace,
                 })),
                 crate::kv_router::FindBestMatchAdvisoryOutcome::QueueRejected { rejection } => {
                     Ok(SelectionOutcome::QueueRejected(rejection))

--- a/lib/llm/src/protocols/common/timing.rs
+++ b/lib/llm/src/protocols/common/timing.rs
@@ -29,6 +29,43 @@ pub const WORKER_TYPE_PREFILL: &str = "prefill";
 pub const WORKER_TYPE_DECODE: &str = "decode";
 const UNSET_DP_RANK_LABEL: &str = "none";
 
+/// One diagnostic-only router choice, retained only when the KV router's
+/// opt-in decision-trace flag is enabled.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingDecisionTrace {
+    pub worker_type: String,
+    pub block_size: u32,
+    pub selected_worker_id: u64,
+    pub selected_dp_rank: u32,
+    pub overlap_score_credit: f64,
+    pub prefill_load_scale: f64,
+    pub host_cache_hit_weight: f64,
+    pub disk_cache_hit_weight: f64,
+    pub candidates: Vec<RoutingDecisionCandidate>,
+}
+
+/// Numerical score inputs for one eligible worker. No user payload or cache
+/// key material is retained here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingDecisionCandidate {
+    pub worker_id: u64,
+    pub dp_rank: u32,
+    pub selected: bool,
+    pub total_cost_blocks: f64,
+    pub effective_overlap_blocks: f64,
+    pub device_overlap_blocks: f64,
+    pub host_overlap_blocks: f64,
+    pub disk_overlap_blocks: f64,
+    pub shared_beyond_device_blocks: u32,
+    pub raw_prefill_blocks: f64,
+    pub prefill_cost_blocks: f64,
+    pub decode_cost_blocks: f64,
+    pub active_request_cost_blocks: f64,
+    pub overlap_credit_blocks: f64,
+    pub overlap_credit_decay: f64,
+    pub preferred_taint_multiplier: Option<f64>,
+}
+
 /// Phase of the request in disaggregated serving.
 ///
 /// Used to determine which worker ID field to record when routing.
@@ -179,6 +216,9 @@ pub struct RequestTracker {
     /// re-tokenizing. Lives here rather than on `routing_data` because the preprocessor
     /// drains `routing_data` before the delta generator runs. First-write-wins.
     external_query_token_ids: OnceLock<Vec<u32>>,
+
+    /// Candidate scores selected by the frontend's KV router.
+    routing_decision_trace: OnceLock<RoutingDecisionTrace>,
 }
 
 /// Data a standalone router (running the `PushRouter` bindings in its own process)
@@ -238,6 +278,7 @@ impl RequestTracker {
             prefill_complete_time: OnceLock::new(),
             external_timing: OnceLock::new(),
             external_query_token_ids: OnceLock::new(),
+            routing_decision_trace: OnceLock::new(),
         }
     }
 
@@ -503,6 +544,17 @@ impl RequestTracker {
     /// Record router scheduler queue depth at routing time.
     pub fn record_router_queue_depth(&self, depth: usize) {
         let _ = self.router_queue_depth.set(depth);
+    }
+
+    /// Record the one prefill routing decision associated with this request.
+    /// First-write-wins keeps the trace bounded for disaggregated requests that
+    /// make more than one router hop.
+    pub fn record_routing_decision_trace(&self, trace: RoutingDecisionTrace) {
+        let _ = self.routing_decision_trace.set(trace);
+    }
+
+    pub fn routing_decision_trace(&self) -> Option<RoutingDecisionTrace> {
+        self.routing_decision_trace.get().cloned()
     }
 
     /// Get the router scheduler queue depth recorded at routing time.

--- a/lib/llm/src/request_trace/agent_context.rs
+++ b/lib/llm/src/request_trace/agent_context.rs
@@ -229,6 +229,7 @@ pub(crate) fn request_metrics(
         worker,
         replay: None,
         finish_reason_metadata: None,
+        routing_decision: tracker.and_then(RequestTracker::routing_decision_trace),
     }
 }
 

--- a/lib/llm/src/request_trace/record.rs
+++ b/lib/llm/src/request_trace/record.rs
@@ -89,6 +89,7 @@ pub(crate) fn emit_request_end(
         worker,
         replay: Some(replay),
         finish_reason_metadata: None,
+        routing_decision: tracker.routing_decision_trace(),
     };
     sanitize_request(&mut request);
 

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -335,6 +335,7 @@ mod tests {
                     input_sequence_hashes: vec![11, 22],
                 }),
                 finish_reason_metadata: None,
+                routing_decision: None,
             }),
             tool: None,
             payload: None,

--- a/lib/llm/src/request_trace/types.rs
+++ b/lib/llm/src/request_trace/types.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use crate::protocols::common::extensions::AgentContext;
+use crate::protocols::common::timing::RoutingDecisionTrace;
 use crate::protocols::openai::chat_completions::{
     NvCreateChatCompletionRequest, NvCreateChatCompletionResponse,
 };
@@ -116,6 +117,10 @@ pub struct RequestTraceMetrics {
     pub replay: Option<RequestReplayMetrics>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finish_reason_metadata: Option<FinishReasonMetadata>,
+    /// Opt-in full KV-router candidate table. Present only on diagnostic
+    /// deployments with `DYN_ROUTER_DECISION_TRACE_ENABLED=true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub routing_decision: Option<RoutingDecisionTrace>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -340,6 +345,7 @@ mod tests {
                     input_sequence_hashes: vec![11, 22],
                 }),
                 finish_reason_metadata: None,
+                routing_decision: None,
             }),
             tool: None,
             payload: None,
@@ -354,6 +360,77 @@ mod tests {
         assert!(value.get("payload").is_none());
         assert!(value["request"].get("model").is_none());
         assert!(value["request"].get("finish_reason_metadata").is_none());
+    }
+
+    #[test]
+    fn request_trace_serializes_opt_in_routing_decision() {
+        let record = RequestTraceRecord {
+            schema: RequestTraceSchema::V1,
+            event_type: RequestTraceEventType::RequestEnd,
+            event_time_unix_ms: 1_100,
+            event_source: None,
+            agent_context: None,
+            request: Some(RequestTraceMetrics {
+                request_id: "req-1".to_string(),
+                x_request_id: None,
+                model: None,
+                input_tokens: Some(256),
+                output_tokens: None,
+                cached_tokens: None,
+                request_received_ms: None,
+                prefill_wait_time_ms: None,
+                prefill_time_ms: None,
+                ttft_ms: None,
+                total_time_ms: None,
+                avg_itl_ms: None,
+                kv_hit_rate: None,
+                kv_transfer_estimated_latency_ms: None,
+                queue_depth: None,
+                worker: None,
+                replay: None,
+                finish_reason_metadata: None,
+                routing_decision: Some(RoutingDecisionTrace {
+                    worker_type: "aggregated".to_string(),
+                    block_size: 256,
+                    selected_worker_id: 42,
+                    selected_dp_rank: 0,
+                    overlap_score_credit: 1.0,
+                    prefill_load_scale: 3.0,
+                    host_cache_hit_weight: 0.5,
+                    disk_cache_hit_weight: 0.0,
+                    candidates: vec![crate::protocols::common::timing::RoutingDecisionCandidate {
+                        worker_id: 42,
+                        dp_rank: 0,
+                        selected: true,
+                        total_cost_blocks: 1.25,
+                        effective_overlap_blocks: 8.0,
+                        device_overlap_blocks: 4.0,
+                        host_overlap_blocks: 4.0,
+                        disk_overlap_blocks: 0.0,
+                        shared_beyond_device_blocks: 4,
+                        raw_prefill_blocks: 10.0,
+                        prefill_cost_blocks: 30.0,
+                        decode_cost_blocks: 2.0,
+                        active_request_cost_blocks: 1.0,
+                        overlap_credit_blocks: 8.0,
+                        overlap_credit_decay: 1.0,
+                        preferred_taint_multiplier: None,
+                    }],
+                }),
+            }),
+            tool: None,
+            payload: None,
+        };
+
+        let value = serde_json::to_value(record).unwrap();
+        assert_eq!(
+            value["request"]["routing_decision"]["selected_worker_id"],
+            42
+        );
+        assert_eq!(
+            value["request"]["routing_decision"]["candidates"][0]["effective_overlap_blocks"],
+            8.0
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `DYN_ROUTER_DECISION_TRACE_ENABLED`, disabled by default.
- When enabled, append one bounded candidate-score table to the correlated `request_end` trace: selected worker, per-candidate device/host/disk overlap, prefill/decode/active-load costs, credits and total cost.
- Keep normal serving unchanged when disabled.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p dynamo-llm`
- `cargo test -p dynamo-llm request_trace --lib`
- `cargo test -p dynamo-llm request_trace_serializes_opt_in_routing_decision --lib`

## Rollout
Diagnostic-only PPC shadow test with request tracing enabled; no production rollout.