### PR TITLE
fix(deploy): bump KAI Scheduler to v0.17.0

### DIFF
--- a/deploy/helm/charts/platform/Chart.yaml
+++ b/deploy/helm/charts/platform/Chart.yaml
@@ -37,7 +37,7 @@ dependencies:
     repository: "https://charts.bitnami.com/bitnami"
     condition: global.etcd.install
   - name: kai-scheduler
-    version: v0.13.4
+    version: v0.17.0
     repository: oci://ghcr.io/kai-scheduler/kai-scheduler
     condition: global.kai-scheduler.install
   - name: grove-charts

--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -151,7 +151,7 @@ Kubernetes: `>=1.30.0-0`
 | https://nats-io.github.io/k8s/helm/charts/ | nats | 1.3.2 |
 | oci://ghcr.io/ai-dynamo/grove | grove(grove-charts) | v0.1.0-alpha.12-rc1 |
 | oci://ghcr.io/ai-dynamo/snapshot | snapshot | 0.1.0-rc.1 |
-| oci://ghcr.io/kai-scheduler/kai-scheduler | kai-scheduler | v0.13.4 |
+| oci://ghcr.io/kai-scheduler/kai-scheduler | kai-scheduler | v0.17.0 |
 
 ## Values
 


### PR DESCRIPTION
## Summary

- bump the bundled KAI Scheduler chart from v0.13.4 to v0.17.0
- restore the KAI binder RBAC required for granular DRA ResourceClaim authorization on Kubernetes 1.36+
- regenerate the platform chart dependency documentation

Upstream fix: https://github.com/kai-scheduler/KAI-Scheduler/pull/1372
Linear: https://linear.app/nvidia/issue/DEP-481/update-kai-scheduler

## Validation

- `helm dependency update deploy/helm/charts/platform`
- `make -C deploy/helm/charts/platform lint test` (42 tests passed)
- `helm template dynamo-platform deploy/helm/charts/platform --set global.kai-scheduler.install=true`
- verified that the rendered `kai-binder` ClusterRole grants `patch` and `update` on `resourceclaims/binding`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kai Scheduler deployment chart to version `v0.17.0`.
  * Updated deployment documentation to reflect the new chart version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->