### PR TITLE
test(sglang): cover disaggregated n=2 HTTP error

### DIFF
--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -51,6 +51,7 @@ from tests.utils.payload_builder import (
 )
 from tests.utils.payloads import (
     ChatPayload,
+    HttpErrorPayload,
     ImageGenerationPayload,
     ResponsesPayload,
     ResponsesStreamPayload,
@@ -272,6 +273,17 @@ sglang_configs = {
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
+            HttpErrorPayload(
+                body={
+                    "messages": [{"role": "user", "content": "Name one color."}],
+                    "n": 2,
+                    "max_tokens": 1,
+                },
+                expected_response=["supports only n=1"],
+                expected_log=[],
+                endpoint="/v1/chat/completions",
+                timeout=10,
+            ),
             # Disagg workers expose fewer sglang:* metrics (~14 vs ~25 for aggregated)
             # because each only runs half the scheduler pipeline.
             metric_payload_default(

--- a/tests/utils/engine_process.py
+++ b/tests/utils/engine_process.py
@@ -128,12 +128,17 @@ class EngineProcess(ManagedProcess):
             EngineResponseError: If the response is invalid or missing expected content
         """
 
-        if response.status_code != 200:
+        if response.status_code != payload.expected_status_code:
             logger.error(
-                "Response returned non-200 status code: %d", response.status_code
+                "Response returned unexpected status code: got %d, expected %d",
+                response.status_code,
+                payload.expected_status_code,
             )
 
-            error_msg = f"Response returned non-200 status code: {response.status_code}"
+            error_msg = (
+                "Response returned unexpected status code: "
+                f"got {response.status_code}, expected {payload.expected_status_code}"
+            )
             try:
                 error_data = response.json()
                 if "error" in error_data:

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -44,6 +44,7 @@ class BasePayload:
     body: Dict[str, Any]
     expected_response: List[Any]  # Can be List[str] or List[List[str]] for alternatives
     expected_log: List[str]
+    expected_status_code: int = field(default=200, kw_only=True)
     # Number of times to send this exact request in sequence. Each call must
     # pass validation independently. Use >1 for cache/repeatability tests
     # (e.g., CachedTokensChatPayload asserts a cache hit on the 2nd+ call).
@@ -129,6 +130,16 @@ class BasePayload:
         content = self.response_handler(response)
         self.validate(response, content)
         return content
+
+
+@dataclass
+class HttpErrorPayload(BasePayload):
+    """Payload that validates an expected HTTP error response."""
+
+    expected_status_code: int = field(default=400, kw_only=True)
+
+    def response_handler(self, response: Any) -> str:
+        return response.text
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- add an HTTP 400 serve regression for SGLang disaggregated `n=2`
- allow serve payloads to declare expected non-200 status codes
- rely on #14112 for the production validation

## Validation

- targeted pre-commit checks passed
- 30 SGLang serve tests collected
- 16 related handler regressions passed

## Related Issues

- #14098
- #14112