### PR TITLE
feat(router): trace sampled routing decisions

### DIFF
--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -1079,6 +1079,70 @@ pub struct WorkerSelectionResult {
     /// Selected worker's projected decode load after adding this request's
     /// prompt blocks, in scheduler-tracked block units.
     pub potential_decode_blocks: usize,
+
+    /// Opt-in, request-scoped explanation of the router choice. This is absent
+    /// unless `DYN_ROUTER_DECISION_TRACE_ENABLED=true`.
+    pub decision_trace: Option<RoutingDecisionTrace>,
+}
+
+/// A bounded explanation of one default KV-router selection.
+///
+/// This intentionally contains only numerical routing state — no prompt text,
+/// token IDs, cache keys, or user headers. It can therefore be attached to a
+/// request-end trace when explicitly enabled for a diagnostic deployment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingDecisionTrace {
+    pub schema: String,
+    pub worker_type: String,
+    pub policy: String,
+    pub selection_reason: String,
+    pub candidate_scope: String,
+    pub block_size: u32,
+    pub request_blocks: u64,
+    pub track_prefill_tokens: bool,
+    pub selected_worker_id: WorkerId,
+    pub selected_dp_rank: DpRank,
+    pub max_overlap_worker_id: WorkerId,
+    pub max_overlap_dp_rank: DpRank,
+    pub avoidable_prefill_token_equivalents: f64,
+    pub overlap_score_credit: f64,
+    pub overlap_score_credit_decay: f64,
+    pub prefill_load_scale: f64,
+    pub host_cache_hit_weight: f64,
+    pub disk_cache_hit_weight: f64,
+    pub shared_cache_multiplier: f64,
+    pub decode_active_request_weight: f64,
+    pub router_temperature: f64,
+    pub candidates: Vec<RoutingDecisionCandidate>,
+}
+
+/// The exact default-router inputs and cost for one eligible worker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingDecisionCandidate {
+    pub worker_id: WorkerId,
+    pub dp_rank: DpRank,
+    pub eligible: bool,
+    pub selected: bool,
+    pub max_overlap: bool,
+    pub total_cost_blocks: f64,
+    pub effective_overlap_blocks: f64,
+    pub device_overlap_blocks: f64,
+    pub host_overlap_blocks: f64,
+    pub disk_overlap_blocks: f64,
+    pub shared_beyond_device_blocks: u32,
+    pub raw_prefill_blocks: f64,
+    pub active_prefill_tokens: usize,
+    pub prefill_cost_blocks: f64,
+    pub decode_cost_blocks: f64,
+    pub active_requests: usize,
+    pub active_request_cost_blocks: f64,
+    pub overlap_credit_blocks: f64,
+    pub overlap_credit_decay: f64,
+    pub effective_overlap_score_credit: f64,
+    pub adjusted_prefill_blocks: f64,
+    pub base_score_blocks: f64,
+    pub preferred_taint_multiplier: Option<f64>,
+    pub decode_overlap_formula: bool,
 }
 
 /// Active load metrics for a worker, used for overload detection.

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -1081,7 +1081,8 @@ pub struct WorkerSelectionResult {
     pub potential_decode_blocks: usize,
 
     /// Opt-in, request-scoped explanation of the router choice. This is absent
-    /// unless `DYN_ROUTER_DECISION_TRACE_ENABLED=true`.
+    /// unless `DYN_ROUTER_DECISION_TRACE_ENABLED=true`; an unset sampling rate
+    /// then defaults to 1.0, while an explicit 0.0 disables sampling.
     pub decision_trace: Option<RoutingDecisionTrace>,
 }
 

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -1470,6 +1470,7 @@ impl<
                 target_cached_prefix_blocks,
                 router_hint_candidates: request.router_hint_candidates.take(),
                 potential_decode_blocks: selected.selection.potential_decode_blocks,
+                decision_trace: selected.selection.decision_trace,
             },
         })
     }
@@ -1502,6 +1503,7 @@ impl<
             target_cached_prefix_blocks,
             router_hint_candidates: request.router_hint_candidates.take(),
             potential_decode_blocks: selected.selection.potential_decode_blocks,
+            decision_trace: selected.selection.decision_trace,
         };
         let non_max_overlap_selection = selected.non_max_overlap_selection;
 
@@ -1880,6 +1882,7 @@ mod tests {
                 cached_tokens: request.effective_cached_tokens_for(worker),
                 potential_decode_blocks: request
                     .potential_decode_blocks_after_admission(worker, block_size),
+                decision_trace: None,
             })
         }
     }

--- a/lib/kv-router/src/scheduling/selector/default.rs
+++ b/lib/kv-router/src/scheduling/selector/default.rs
@@ -14,7 +14,10 @@ use super::{
     WorkerInputView, WorkerInputs, WorkerPicker, WorkerSelectionContext, WorkerSelectionInput,
     WorkerSelector, select_worker_with_policy,
 };
-use crate::protocols::{WorkerConfigLike, WorkerId, WorkerSelectionResult, WorkerWithDpRank};
+use crate::protocols::{
+    RoutingDecisionCandidate, RoutingDecisionTrace, WorkerConfigLike, WorkerId,
+    WorkerSelectionResult, WorkerWithDpRank,
+};
 use crate::scheduling::config::KvRouterConfig;
 use crate::scheduling::filter::RoutingEligibility;
 use crate::scheduling::types::{KvSchedulerError, SchedulingRequest, WorkerSelectionPolicyError};
@@ -102,7 +105,7 @@ pub(super) struct DefaultWorkerScorer<C = KvRouterConfig> {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct DefaultScoringContext {
+pub(super) struct DefaultScoringContext {
     min_active_prefill_tokens: usize,
     has_tier_overlap_blocks: bool,
 }
@@ -254,7 +257,7 @@ impl DefaultScoringContext {
     }
 }
 
-fn default_row(
+pub(super) fn default_row(
     input: &MaterializedSelectionInput<'_>,
     context: DefaultScoringContext,
     worker: WorkerWithDpRank,
@@ -271,7 +274,7 @@ fn default_row(
 }
 
 impl<C: Borrow<KvRouterConfig>> DefaultWorkerScorer<C> {
-    fn worker_logit(
+    pub(super) fn worker_logit(
         &self,
         context: &WorkerSelectionContext<'_>,
         default_context: DefaultScoringContext,
@@ -389,7 +392,7 @@ impl<C: Borrow<KvRouterConfig>> DefaultWorkerScorer<C> {
     }
 
     #[inline]
-    fn worker_cost(
+    pub(super) fn worker_cost(
         &self,
         context: &WorkerSelectionContext<'_>,
         default_context: DefaultScoringContext,
@@ -403,6 +406,158 @@ impl<C: Borrow<KvRouterConfig>> DefaultWorkerScorer<C> {
             None => base_score,
         }
     }
+}
+
+fn sampled_request(request_id: &str, sample_rate: f64) -> bool {
+    if sample_rate <= 0.0 {
+        return false;
+    }
+    if sample_rate >= 1.0 {
+        return true;
+    }
+    let sample = xxhash_rust::xxh3::xxh3_64(request_id.as_bytes()) as f64 / u64::MAX as f64;
+    sample < sample_rate
+}
+
+/// Build the per-worker explanation only after a selection, and only when the
+/// caller explicitly enabled diagnostic tracing. The normal picker remains
+/// allocation-free beyond its existing scratch buffer.
+pub(super) fn decision_trace_for_selection<C: WorkerConfigLike>(
+    kv_router_config: &KvRouterConfig,
+    worker_type: &'static str,
+    input: &MaterializedSelectionInput<'_>,
+    workers: &HashMap<WorkerId, C>,
+    request: &SchedulingRequest,
+    eligibility: RoutingEligibility<'_>,
+    selected: WorkerWithDpRank,
+    sample_rate: f64,
+) -> Option<RoutingDecisionTrace> {
+    let request_id = request.mode.request_id()?;
+    if !sampled_request(request_id, sample_rate) || eligibility.pinned_worker().is_some() {
+        return None;
+    }
+    let default_context =
+        DefaultScoringContext::new(workers, request, eligibility, input.context.weights);
+    let weights = input.context.weights;
+    let mut candidates = Vec::new();
+    eligibility.for_each_eligible_worker_rank(workers, |worker, config| {
+        let preferred_taint_multiplier = request
+            .routing_constraints
+            .preferred_taint_multiplier(config.taints());
+        let row = default_row(input, default_context, worker, preferred_taint_multiplier);
+        let cache = row.cache;
+        let load = row.load;
+        let excess_active_prefill_blocks =
+            load.active_prefill_tokens
+                .saturating_sub(default_context.min_active_prefill_tokens) as f64
+                / input.context.block_size as f64;
+        let normalized_prefill_load =
+            excess_active_prefill_blocks / input.context.request_blocks as f64;
+        let overlap_credit_decay =
+            if input.context.track_prefill_tokens && weights.overlap_score_credit_decay > 0.0 {
+                1.0 / (1.0 + weights.overlap_score_credit_decay * normalized_prefill_load)
+            } else {
+                1.0
+            };
+        let device_overlap_blocks = default_context
+            .device_overlap(cache.effective_overlap_blocks, cache.device_overlap_blocks);
+        let effective_overlap_score_credit = weights.overlap_score_credit * overlap_credit_decay;
+        let overlap_credit_blocks = effective_overlap_score_credit * device_overlap_blocks
+            + kv_router_config.host_cache_hit_weight * cache.host_overlap_blocks
+            + kv_router_config.disk_cache_hit_weight * cache.disk_overlap_blocks
+            + weights.shared_cache_multiplier * cache.shared_beyond_device_blocks as f64;
+        let adjusted_prefill_blocks = (load.raw_prefill_blocks - overlap_credit_blocks).max(0.0);
+        let prefill_cost_blocks = weights.prefill_load_scale * adjusted_prefill_blocks;
+        let active_request_cost_blocks =
+            kv_router_config.decode_active_request_weight * load.active_requests as f64;
+        let decode_overlap_formula = worker_type == "decode"
+            && !input.context.track_prefill_tokens
+            && weights.overlap_score_credit > 0.0;
+        let base_score_blocks = if decode_overlap_formula {
+            (load.decode_cost_blocks - overlap_credit_blocks).max(0.0) + active_request_cost_blocks
+        } else {
+            prefill_cost_blocks + load.decode_cost_blocks + active_request_cost_blocks
+        };
+        let total_cost_blocks = preferred_taint_multiplier
+            .map_or(base_score_blocks, |multiplier| {
+                base_score_blocks * multiplier
+            });
+        candidates.push(RoutingDecisionCandidate {
+            worker_id: worker.worker_id,
+            dp_rank: worker.dp_rank,
+            eligible: true,
+            selected: worker == selected,
+            max_overlap: false,
+            total_cost_blocks,
+            effective_overlap_blocks: cache.effective_overlap_blocks,
+            device_overlap_blocks,
+            host_overlap_blocks: cache.host_overlap_blocks,
+            disk_overlap_blocks: cache.disk_overlap_blocks,
+            shared_beyond_device_blocks: cache.shared_beyond_device_blocks,
+            raw_prefill_blocks: load.raw_prefill_blocks,
+            active_prefill_tokens: load.active_prefill_tokens,
+            prefill_cost_blocks,
+            decode_cost_blocks: load.decode_cost_blocks,
+            active_requests: load.active_requests,
+            active_request_cost_blocks,
+            overlap_credit_blocks,
+            overlap_credit_decay,
+            effective_overlap_score_credit,
+            adjusted_prefill_blocks,
+            base_score_blocks,
+            preferred_taint_multiplier,
+            decode_overlap_formula,
+        });
+    });
+    candidates.sort_unstable_by_key(|candidate| (candidate.worker_id, candidate.dp_rank));
+    let max_overlap = candidates.iter().max_by(|left, right| {
+        left.effective_overlap_blocks
+            .total_cmp(&right.effective_overlap_blocks)
+    })?;
+    let selected_overlap = candidates
+        .iter()
+        .find(|candidate| candidate.selected)
+        .map(|candidate| candidate.effective_overlap_blocks)?;
+    let max_overlap_worker_id = max_overlap.worker_id;
+    let max_overlap_dp_rank = max_overlap.dp_rank;
+    let max_overlap_blocks = max_overlap.effective_overlap_blocks;
+    for candidate in &mut candidates {
+        candidate.max_overlap = candidate.worker_id == max_overlap_worker_id
+            && candidate.dp_rank == max_overlap_dp_rank;
+    }
+    let temperature = input
+        .context
+        .router_temperature_override
+        .unwrap_or(kv_router_config.router_temperature);
+    Some(RoutingDecisionTrace {
+        schema: "dynamo.router.decision.v1".to_string(),
+        worker_type: worker_type.to_owned(),
+        policy: "default".to_string(),
+        selection_reason: if temperature == 0.0 {
+            "minimum_cost".to_string()
+        } else {
+            "temperature_sample".to_string()
+        },
+        candidate_scope: "eligible_workers_only".to_string(),
+        block_size: input.context.block_size,
+        request_blocks: input.context.request_blocks,
+        track_prefill_tokens: input.context.track_prefill_tokens,
+        selected_worker_id: selected.worker_id,
+        selected_dp_rank: selected.dp_rank,
+        max_overlap_worker_id,
+        max_overlap_dp_rank,
+        avoidable_prefill_token_equivalents: (max_overlap_blocks - selected_overlap)
+            * input.context.block_size as f64,
+        overlap_score_credit: weights.overlap_score_credit,
+        overlap_score_credit_decay: weights.overlap_score_credit_decay,
+        prefill_load_scale: weights.prefill_load_scale,
+        host_cache_hit_weight: kv_router_config.host_cache_hit_weight,
+        disk_cache_hit_weight: kv_router_config.disk_cache_hit_weight,
+        shared_cache_multiplier: weights.shared_cache_multiplier,
+        decode_active_request_weight: kv_router_config.decode_active_request_weight,
+        router_temperature: temperature,
+        candidates,
+    })
 }
 
 impl DefaultWorkerPicker {

--- a/lib/kv-router/src/scheduling/selector/default.rs
+++ b/lib/kv-router/src/scheduling/selector/default.rs
@@ -422,6 +422,7 @@ fn sampled_request(request_id: &str, sample_rate: f64) -> bool {
 /// Build the per-worker explanation only after a selection, and only when the
 /// caller explicitly enabled diagnostic tracing. The normal picker remains
 /// allocation-free beyond its existing scratch buffer.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn decision_trace_for_selection<C: WorkerConfigLike>(
     kv_router_config: &KvRouterConfig,
     worker_type: &'static str,

--- a/lib/kv-router/src/scheduling/selector/default.rs
+++ b/lib/kv-router/src/scheduling/selector/default.rs
@@ -1858,6 +1858,99 @@ mod tests {
     }
 
     #[test]
+    fn decision_trace_scores_match_default_selection() {
+        let block_size = 16;
+        let warm_worker = WorkerWithDpRank::from_worker_id(0);
+        let cold_worker = WorkerWithDpRank::from_worker_id(1);
+        let workers = HashMap::from([
+            (warm_worker.worker_id, TaintedWorkerConfig::default()),
+            (cold_worker.worker_id, TaintedWorkerConfig::default()),
+        ]);
+        let mut request = base_request(128);
+        request
+            .overlap
+            .tier_overlap_blocks
+            .device
+            .insert(warm_worker, 4);
+        request
+            .overlap
+            .effective_overlap_blocks
+            .insert(warm_worker, 4.0);
+        request.worker_loads.insert(
+            warm_worker,
+            crate::sequences::WorkerLoadProjection {
+                active_decode_blocks: 10,
+                ..Default::default()
+            },
+        );
+        request.worker_loads.insert(
+            cold_worker,
+            crate::sequences::WorkerLoadProjection {
+                active_decode_blocks: 1,
+                ..Default::default()
+            },
+        );
+        let selector = DefaultWorkerSelector::new(
+            Some(KvRouterConfig {
+                overlap_score_credit: 1.0,
+                router_temperature: 0.0,
+                ..Default::default()
+            }),
+            "test",
+        );
+        let weights = selection_weights(&selector.kv_router_config, &request);
+        let input = MaterializedSelectionInput::new(&request, block_size, weights);
+        let selected = selector
+            .select_worker(WorkerSelectionInput::configured(
+                &workers,
+                &request,
+                request.eligibility(),
+                block_size,
+            ))
+            .unwrap();
+        let trace = decision_trace_for_selection(
+            &selector.kv_router_config,
+            selector.worker_type,
+            &input,
+            &workers,
+            &request,
+            request.eligibility(),
+            selected.worker,
+            1.0,
+        )
+        .expect("full sampling should retain a default-policy trace");
+
+        assert_eq!(selected.worker, cold_worker);
+        assert_eq!(trace.selected_worker_id, cold_worker.worker_id);
+        assert_eq!(trace.max_overlap_worker_id, warm_worker.worker_id);
+        assert_eq!(trace.avoidable_prefill_token_equivalents, 64.0);
+
+        let default_context =
+            DefaultScoringContext::new(&workers, &request, request.eligibility(), weights);
+        let scorer =
+            DefaultWorkerScorer::new(selector.kv_router_config.clone(), selector.worker_type);
+        for candidate in &trace.candidates {
+            let worker = WorkerWithDpRank {
+                worker_id: candidate.worker_id,
+                dp_rank: candidate.dp_rank,
+            };
+            let expected = scorer.worker_logit(
+                &input.context,
+                default_context,
+                &default_row(&input, default_context, worker, None),
+                "test",
+            );
+            assert!(
+                (candidate.total_cost_blocks - expected).abs() < f64::EPSILON,
+                "worker {} trace score {} differs from selection score {}",
+                candidate.worker_id,
+                candidate.total_cost_blocks,
+                expected,
+            );
+        }
+    }
+
+    #[test]
     fn test_worker_logit_clamps_non_decode_overlap_credit() {
         let worker = WorkerWithDpRank::from_worker_id(0);
         let mut request = base_request(64);

--- a/lib/kv-router/src/scheduling/selector/mod.rs
+++ b/lib/kv-router/src/scheduling/selector/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 mod default;
 mod policy;
@@ -15,7 +16,7 @@ pub use policy::{
     WorkerSelectionPolicy,
 };
 
-use default::{pick_default_worker, selection_weights};
+use default::{decision_trace_for_selection, pick_default_worker, selection_weights};
 use policy::{
     CustomWorkerSelectionState, WorkerSelectionPolicyStateRef, collect_custom_candidates,
 };
@@ -24,6 +25,43 @@ use super::config::KvRouterConfig;
 use super::filter::{RoutingEligibility, WorkerEligibilityError};
 use super::types::{KvSchedulerError, SchedulingRequest, WorkerSelectionPolicyError};
 use crate::protocols::{WorkerConfigLike, WorkerId, WorkerSelectionResult, WorkerWithDpRank};
+
+/// Disabled by default: collecting the candidate table is diagnostic-only and
+/// intentionally has zero extra work or trace volume in normal serving.
+static ROUTER_DECISION_TRACE_ENABLED: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("DYN_ROUTER_DECISION_TRACE_ENABLED")
+        .ok()
+        .is_some_and(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+});
+
+pub(crate) fn router_decision_trace_enabled() -> bool {
+    *ROUTER_DECISION_TRACE_ENABLED
+}
+
+pub(crate) fn router_decision_trace_sample_rate() -> f64 {
+    static SAMPLE_RATE: LazyLock<f64> = LazyLock::new(|| {
+        let Some(value) = std::env::var_os("DYN_ROUTER_DECISION_TRACE_SAMPLE_RATE") else {
+            return 0.0;
+        };
+        let value = value.to_string_lossy();
+        match value.parse::<f64>() {
+            Ok(rate) if rate.is_finite() && (0.0..=1.0).contains(&rate) => rate,
+            _ => {
+                tracing::warn!(
+                    value = %value,
+                    "Ignoring invalid DYN_ROUTER_DECISION_TRACE_SAMPLE_RATE; expected 0 through 1"
+                );
+                0.0
+            }
+        }
+    });
+    *SAMPLE_RATE
+}
 
 /// Low-level selector used by routing hosts.
 ///
@@ -282,6 +320,7 @@ fn selection_result(
         cached_tokens: request.effective_cached_tokens_for(worker),
         potential_decode_blocks: request
             .potential_decode_blocks_after_admission(worker, block_size),
+        decision_trace: None,
     }
 }
 
@@ -445,7 +484,20 @@ fn select_worker_with_policy<C: WorkerConfigLike>(
         }
         return Err(KvSchedulerError::NoEndpoints);
     };
-    let result = selection_result(request, worker, block_size);
+    let mut result = selection_result(request, worker, block_size);
+    if router_decision_trace_enabled() && matches!(state, WorkerSelectionPolicyStateRef::Default(_))
+    {
+        result.decision_trace = decision_trace_for_selection(
+            kv_router_config,
+            worker_type,
+            &input,
+            workers,
+            request,
+            eligibility,
+            worker,
+            router_decision_trace_sample_rate(),
+        );
+    }
     log_selection(
         workers,
         request,

--- a/lib/kv-router/src/scheduling/selector/mod.rs
+++ b/lib/kv-router/src/scheduling/selector/mod.rs
@@ -4,6 +4,8 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
+use dynamo_truthy::env_is_truthy;
+
 mod default;
 mod policy;
 
@@ -28,16 +30,8 @@ use crate::protocols::{WorkerConfigLike, WorkerId, WorkerSelectionResult, Worker
 
 /// Disabled by default: collecting the candidate table is diagnostic-only and
 /// intentionally has zero extra work or trace volume in normal serving.
-static ROUTER_DECISION_TRACE_ENABLED: LazyLock<bool> = LazyLock::new(|| {
-    std::env::var("DYN_ROUTER_DECISION_TRACE_ENABLED")
-        .ok()
-        .is_some_and(|value| {
-            matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-        })
-});
+static ROUTER_DECISION_TRACE_ENABLED: LazyLock<bool> =
+    LazyLock::new(|| env_is_truthy("DYN_ROUTER_DECISION_TRACE_ENABLED"));
 
 pub(crate) fn router_decision_trace_enabled() -> bool {
     *ROUTER_DECISION_TRACE_ENABLED

--- a/lib/kv-router/src/scheduling/selector/mod.rs
+++ b/lib/kv-router/src/scheduling/selector/mod.rs
@@ -40,7 +40,7 @@ pub(crate) fn router_decision_trace_enabled() -> bool {
 pub(crate) fn router_decision_trace_sample_rate() -> f64 {
     static SAMPLE_RATE: LazyLock<f64> = LazyLock::new(|| {
         let Some(value) = std::env::var_os("DYN_ROUTER_DECISION_TRACE_SAMPLE_RATE") else {
-            return 0.0;
+            return 1.0;
         };
         let value = value.to_string_lossy();
         match value.parse::<f64>() {

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -138,6 +138,8 @@ pub struct SchedulingResponse {
     pub target_cached_prefix_blocks: u32,
     pub router_hint_candidates: Option<RouterHintRootCandidates>,
     pub potential_decode_blocks: usize,
+    /// Populated only by opt-in default-router decision tracing.
+    pub decision_trace: Option<crate::protocols::RoutingDecisionTrace>,
 }
 
 /// Internal result that pairs a public scheduling response with its attempt identity.

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -353,6 +353,7 @@ pub enum FindBestMatchOutcome {
         potential_decode_blocks: u64,
         routing_hashes: Option<RoutingDecisionHashes>,
         router_hint: Option<RouterHint>,
+        decision_trace: Option<dynamo_kv_router::protocols::RoutingDecisionTrace>,
     },
     QueueRejected {
         rejection: scheduling::QueueRejection,
@@ -372,6 +373,7 @@ pub enum FindBestMatchAdvisoryOutcome {
         potential_decode_blocks: u64,
         selected_worker_load: scheduling::AdvisoryWorkerLoad,
         routing_hashes: Option<RoutingDecisionHashes>,
+        decision_trace: Option<dynamo_kv_router::protocols::RoutingDecisionTrace>,
     },
     QueueRejected {
         rejection: scheduling::QueueRejection,
@@ -1713,6 +1715,7 @@ where
                         potential_decode_blocks: response.potential_decode_blocks as u64,
                         routing_hashes,
                         router_hint,
+                        decision_trace: response.decision_trace,
                     },
                     attempt,
                 }),
@@ -1727,6 +1730,7 @@ where
                     selected_worker_load: selected_worker_load
                         .expect("without-admission selection returns advisory load"),
                     routing_hashes,
+                    decision_trace: response.decision_trace,
                 }),
             ),
         }
@@ -2569,6 +2573,7 @@ mod tests {
                     .worker_load_for(self.selected_worker)
                     .potential_decode_blocks()
                     .saturating_add(request.isl_tokens.div_ceil(block_size as usize)),
+                decision_trace: None,
             })
         }
     }

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -353,7 +353,7 @@ pub enum FindBestMatchOutcome {
         potential_decode_blocks: u64,
         routing_hashes: Option<RoutingDecisionHashes>,
         router_hint: Option<RouterHint>,
-        decision_trace: Option<dynamo_kv_router::protocols::RoutingDecisionTrace>,
+        decision_trace: Option<Box<dynamo_kv_router::protocols::RoutingDecisionTrace>>,
     },
     QueueRejected {
         rejection: scheduling::QueueRejection,
@@ -373,7 +373,7 @@ pub enum FindBestMatchAdvisoryOutcome {
         potential_decode_blocks: u64,
         selected_worker_load: scheduling::AdvisoryWorkerLoad,
         routing_hashes: Option<RoutingDecisionHashes>,
-        decision_trace: Option<dynamo_kv_router::protocols::RoutingDecisionTrace>,
+        decision_trace: Option<Box<dynamo_kv_router::protocols::RoutingDecisionTrace>>,
     },
     QueueRejected {
         rejection: scheduling::QueueRejection,
@@ -1715,7 +1715,7 @@ where
                         potential_decode_blocks: response.potential_decode_blocks as u64,
                         routing_hashes,
                         router_hint,
-                        decision_trace: response.decision_trace,
+                        decision_trace: response.decision_trace.map(Box::new),
                     },
                     attempt,
                 }),
@@ -1730,7 +1730,7 @@ where
                     selected_worker_load: selected_worker_load
                         .expect("without-admission selection returns advisory load"),
                     routing_hashes,
-                    decision_trace: response.decision_trace,
+                    decision_trace: response.decision_trace.map(Box::new),
                 }),
             ),
         }

--- a/lib/llm/src/kv_router/routing_host/builtin.rs
+++ b/lib/llm/src/kv_router/routing_host/builtin.rs
@@ -90,6 +90,7 @@ fn selection(worker_id: u64) -> WorkerSelectionResult {
         effective_overlap_blocks: 0.0,
         cached_tokens: 0,
         potential_decode_blocks: 0,
+        decision_trace: None,
     }
 }
 

--- a/lib/llm/src/kv_router/routing_host/kv.rs
+++ b/lib/llm/src/kv_router/routing_host/kv.rs
@@ -3,6 +3,65 @@
 
 use super::*;
 use crate::kv_router::{FindBestMatchAdmission, routing_host::kv_selection::SelectionOutcome};
+use crate::protocols::common::timing::{RoutingDecisionCandidate, RoutingDecisionTrace};
+
+fn request_trace_routing_decision(
+    trace: dynamo_kv_router::protocols::RoutingDecisionTrace,
+) -> RoutingDecisionTrace {
+    RoutingDecisionTrace {
+        schema: trace.schema,
+        worker_type: trace.worker_type,
+        policy: trace.policy,
+        selection_reason: trace.selection_reason,
+        candidate_scope: trace.candidate_scope,
+        block_size: trace.block_size,
+        request_blocks: trace.request_blocks,
+        track_prefill_tokens: trace.track_prefill_tokens,
+        selected_worker_id: trace.selected_worker_id,
+        selected_dp_rank: trace.selected_dp_rank,
+        max_overlap_worker_id: trace.max_overlap_worker_id,
+        max_overlap_dp_rank: trace.max_overlap_dp_rank,
+        avoidable_prefill_token_equivalents: trace.avoidable_prefill_token_equivalents,
+        overlap_score_credit: trace.overlap_score_credit,
+        overlap_score_credit_decay: trace.overlap_score_credit_decay,
+        prefill_load_scale: trace.prefill_load_scale,
+        host_cache_hit_weight: trace.host_cache_hit_weight,
+        disk_cache_hit_weight: trace.disk_cache_hit_weight,
+        shared_cache_multiplier: trace.shared_cache_multiplier,
+        decode_active_request_weight: trace.decode_active_request_weight,
+        router_temperature: trace.router_temperature,
+        candidates: trace
+            .candidates
+            .into_iter()
+            .map(|candidate| RoutingDecisionCandidate {
+                worker_id: candidate.worker_id,
+                dp_rank: candidate.dp_rank,
+                eligible: candidate.eligible,
+                selected: candidate.selected,
+                max_overlap: candidate.max_overlap,
+                total_cost_blocks: candidate.total_cost_blocks,
+                effective_overlap_blocks: candidate.effective_overlap_blocks,
+                device_overlap_blocks: candidate.device_overlap_blocks,
+                host_overlap_blocks: candidate.host_overlap_blocks,
+                disk_overlap_blocks: candidate.disk_overlap_blocks,
+                shared_beyond_device_blocks: candidate.shared_beyond_device_blocks,
+                raw_prefill_blocks: candidate.raw_prefill_blocks,
+                active_prefill_tokens: candidate.active_prefill_tokens,
+                prefill_cost_blocks: candidate.prefill_cost_blocks,
+                decode_cost_blocks: candidate.decode_cost_blocks,
+                active_requests: candidate.active_requests,
+                active_request_cost_blocks: candidate.active_request_cost_blocks,
+                overlap_credit_blocks: candidate.overlap_credit_blocks,
+                overlap_credit_decay: candidate.overlap_credit_decay,
+                effective_overlap_score_credit: candidate.effective_overlap_score_credit,
+                adjusted_prefill_blocks: candidate.adjusted_prefill_blocks,
+                base_score_blocks: candidate.base_score_blocks,
+                preferred_taint_multiplier: candidate.preferred_taint_multiplier,
+                decode_overlap_formula: candidate.decode_overlap_formula,
+            })
+            .collect(),
+    }
+}
 
 impl<Sel> RoutingHost<Sel>
 where
@@ -360,6 +419,9 @@ where
             }
 
             if let Some(ref tracker) = request.tracker {
+                if let Some(trace) = selection.decision_trace.take() {
+                    tracker.record_routing_decision_trace(request_trace_routing_decision(trace));
+                }
                 let isl_blocks = routing_parts.token_ids.len().div_ceil(block_size);
                 tracker.record_kv_hit(selection.effective_overlap_blocks, isl_blocks);
                 tracker.record_isl(routing_parts.token_ids.len(), Some(selection.cached_tokens));

--- a/lib/llm/src/kv_router/routing_host/kv.rs
+++ b/lib/llm/src/kv_router/routing_host/kv.rs
@@ -420,7 +420,7 @@ where
 
             if let Some(ref tracker) = request.tracker {
                 if let Some(trace) = selection.decision_trace.take() {
-                    tracker.record_routing_decision_trace(request_trace_routing_decision(trace));
+                    tracker.record_routing_decision_trace(request_trace_routing_decision(*trace));
                 }
                 let isl_blocks = routing_parts.token_ids.len().div_ceil(block_size);
                 tracker.record_kv_hit(selection.effective_overlap_blocks, isl_blocks);

--- a/lib/llm/src/kv_router/routing_host/kv_selection.rs
+++ b/lib/llm/src/kv_router/routing_host/kv_selection.rs
@@ -39,6 +39,7 @@ pub(super) struct WorkerSelection {
     pub(super) selected_worker_load: Option<AdvisoryWorkerLoad>,
     pub(super) routing_hashes: Option<RoutingDecisionHashes>,
     pub(super) router_hint: Option<RouterHint>,
+    pub(super) decision_trace: Option<dynamo_kv_router::protocols::RoutingDecisionTrace>,
 }
 
 pub(super) enum SelectionOutcome {
@@ -138,6 +139,7 @@ where
                     potential_decode_blocks,
                     routing_hashes,
                     router_hint,
+                    decision_trace,
                 } => Ok(SelectionOutcome::Routed(WorkerSelection {
                     worker,
                     attempt: admitted.attempt,
@@ -148,6 +150,7 @@ where
                     selected_worker_load: None,
                     routing_hashes,
                     router_hint,
+                    decision_trace,
                 })),
                 FindBestMatchOutcome::QueueRejected { rejection } => {
                     Ok(SelectionOutcome::QueueRejected(rejection))
@@ -162,6 +165,7 @@ where
                     potential_decode_blocks,
                     selected_worker_load,
                     routing_hashes,
+                    decision_trace,
                 } => Ok(SelectionOutcome::Routed(WorkerSelection {
                     worker,
                     attempt: AdmissionAttempt::Untracked,
@@ -172,6 +176,7 @@ where
                     selected_worker_load: Some(selected_worker_load),
                     routing_hashes,
                     router_hint: None,
+                    decision_trace,
                 })),
                 crate::kv_router::FindBestMatchAdvisoryOutcome::QueueRejected { rejection } => {
                     Ok(SelectionOutcome::QueueRejected(rejection))

--- a/lib/llm/src/kv_router/routing_host/kv_selection.rs
+++ b/lib/llm/src/kv_router/routing_host/kv_selection.rs
@@ -39,7 +39,7 @@ pub(super) struct WorkerSelection {
     pub(super) selected_worker_load: Option<AdvisoryWorkerLoad>,
     pub(super) routing_hashes: Option<RoutingDecisionHashes>,
     pub(super) router_hint: Option<RouterHint>,
-    pub(super) decision_trace: Option<dynamo_kv_router::protocols::RoutingDecisionTrace>,
+    pub(super) decision_trace: Option<Box<dynamo_kv_router::protocols::RoutingDecisionTrace>>,
 }
 
 pub(super) enum SelectionOutcome {

--- a/lib/llm/src/protocols/common/timing.rs
+++ b/lib/llm/src/protocols/common/timing.rs
@@ -29,6 +29,64 @@ pub const WORKER_TYPE_PREFILL: &str = "prefill";
 pub const WORKER_TYPE_DECODE: &str = "decode";
 const UNSET_DP_RANK_LABEL: &str = "none";
 
+/// One diagnostic-only router choice, retained only when the KV router's
+/// opt-in decision-trace flag is enabled.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingDecisionTrace {
+    pub schema: String,
+    pub worker_type: String,
+    pub policy: String,
+    pub selection_reason: String,
+    pub candidate_scope: String,
+    pub block_size: u32,
+    pub request_blocks: u64,
+    pub track_prefill_tokens: bool,
+    pub selected_worker_id: u64,
+    pub selected_dp_rank: u32,
+    pub max_overlap_worker_id: u64,
+    pub max_overlap_dp_rank: u32,
+    pub avoidable_prefill_token_equivalents: f64,
+    pub overlap_score_credit: f64,
+    pub overlap_score_credit_decay: f64,
+    pub prefill_load_scale: f64,
+    pub host_cache_hit_weight: f64,
+    pub disk_cache_hit_weight: f64,
+    pub shared_cache_multiplier: f64,
+    pub decode_active_request_weight: f64,
+    pub router_temperature: f64,
+    pub candidates: Vec<RoutingDecisionCandidate>,
+}
+
+/// Numerical score inputs for one eligible worker. No user payload or cache
+/// key material is retained here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingDecisionCandidate {
+    pub worker_id: u64,
+    pub dp_rank: u32,
+    pub eligible: bool,
+    pub selected: bool,
+    pub max_overlap: bool,
+    pub total_cost_blocks: f64,
+    pub effective_overlap_blocks: f64,
+    pub device_overlap_blocks: f64,
+    pub host_overlap_blocks: f64,
+    pub disk_overlap_blocks: f64,
+    pub shared_beyond_device_blocks: u32,
+    pub raw_prefill_blocks: f64,
+    pub active_prefill_tokens: usize,
+    pub prefill_cost_blocks: f64,
+    pub decode_cost_blocks: f64,
+    pub active_requests: usize,
+    pub active_request_cost_blocks: f64,
+    pub overlap_credit_blocks: f64,
+    pub overlap_credit_decay: f64,
+    pub effective_overlap_score_credit: f64,
+    pub adjusted_prefill_blocks: f64,
+    pub base_score_blocks: f64,
+    pub preferred_taint_multiplier: Option<f64>,
+    pub decode_overlap_formula: bool,
+}
+
 /// Phase of the request in disaggregated serving.
 ///
 /// Used to determine which worker ID field to record when routing.
@@ -184,6 +242,9 @@ pub struct RequestTracker {
     /// `nvext.extra_fields=["prompt_token_ids"]` response request.
     /// First-write-wins because one response generator owns one prompt.
     prompt_token_ids: OnceLock<Vec<u32>>,
+
+    /// Candidate scores selected by the frontend's KV router.
+    routing_decision_trace: OnceLock<RoutingDecisionTrace>,
 }
 
 /// Data a standalone router (running the `PushRouter` bindings in its own process)
@@ -244,6 +305,7 @@ impl RequestTracker {
             external_timing: OnceLock::new(),
             external_query_token_ids: OnceLock::new(),
             prompt_token_ids: OnceLock::new(),
+            routing_decision_trace: OnceLock::new(),
         }
     }
 
@@ -509,6 +571,17 @@ impl RequestTracker {
     /// Record router scheduler queue depth at routing time.
     pub fn record_router_queue_depth(&self, depth: usize) {
         let _ = self.router_queue_depth.set(depth);
+    }
+
+    /// Record the one prefill routing decision associated with this request.
+    /// First-write-wins keeps the trace bounded for disaggregated requests that
+    /// make more than one router hop.
+    pub fn record_routing_decision_trace(&self, trace: RoutingDecisionTrace) {
+        let _ = self.routing_decision_trace.set(trace);
+    }
+
+    pub fn routing_decision_trace(&self) -> Option<RoutingDecisionTrace> {
+        self.routing_decision_trace.get().cloned()
     }
 
     /// Get the router scheduler queue depth recorded at routing time.

--- a/lib/llm/src/request_trace/agent_context.rs
+++ b/lib/llm/src/request_trace/agent_context.rs
@@ -229,6 +229,7 @@ pub(crate) fn request_metrics(
         worker,
         replay: None,
         finish_reason_metadata: None,
+        routing_decision: tracker.and_then(RequestTracker::routing_decision_trace),
     }
 }
 

--- a/lib/llm/src/request_trace/record.rs
+++ b/lib/llm/src/request_trace/record.rs
@@ -89,6 +89,7 @@ pub(crate) fn emit_request_end(
         worker,
         replay: Some(replay),
         finish_reason_metadata: None,
+        routing_decision: tracker.routing_decision_trace(),
     };
     sanitize_request(&mut request);
 

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -335,6 +335,7 @@ mod tests {
                     input_sequence_hashes: vec![11, 22],
                 }),
                 finish_reason_metadata: None,
+                routing_decision: None,
             }),
             tool: None,
             payload: None,

--- a/lib/llm/src/request_trace/types.rs
+++ b/lib/llm/src/request_trace/types.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use crate::protocols::common::extensions::AgentContext;
+use crate::protocols::common::timing::RoutingDecisionTrace;
 use crate::protocols::openai::chat_completions::{
     NvCreateChatCompletionRequest, NvCreateChatCompletionResponse,
 };
@@ -116,6 +117,10 @@ pub struct RequestTraceMetrics {
     pub replay: Option<RequestReplayMetrics>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finish_reason_metadata: Option<FinishReasonMetadata>,
+    /// Opt-in full KV-router candidate table. Present only on diagnostic
+    /// deployments with `DYN_ROUTER_DECISION_TRACE_ENABLED=true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub routing_decision: Option<RoutingDecisionTrace>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -340,6 +345,7 @@ mod tests {
                     input_sequence_hashes: vec![11, 22],
                 }),
                 finish_reason_metadata: None,
+                routing_decision: None,
             }),
             tool: None,
             payload: None,
@@ -354,6 +360,102 @@ mod tests {
         assert!(value.get("payload").is_none());
         assert!(value["request"].get("model").is_none());
         assert!(value["request"].get("finish_reason_metadata").is_none());
+    }
+
+    #[test]
+    fn request_trace_serializes_opt_in_routing_decision() {
+        let record = RequestTraceRecord {
+            schema: RequestTraceSchema::V1,
+            event_type: RequestTraceEventType::RequestEnd,
+            event_time_unix_ms: 1_100,
+            event_source: None,
+            agent_context: None,
+            request: Some(RequestTraceMetrics {
+                request_id: "req-1".to_string(),
+                x_request_id: None,
+                model: None,
+                input_tokens: Some(256),
+                output_tokens: None,
+                cached_tokens: None,
+                request_received_ms: None,
+                prefill_wait_time_ms: None,
+                prefill_time_ms: None,
+                ttft_ms: None,
+                total_time_ms: None,
+                avg_itl_ms: None,
+                kv_hit_rate: None,
+                kv_transfer_estimated_latency_ms: None,
+                queue_depth: None,
+                worker: None,
+                replay: None,
+                finish_reason_metadata: None,
+                routing_decision: Some(RoutingDecisionTrace {
+                    schema: "dynamo.router.decision.v1".to_string(),
+                    worker_type: "aggregated".to_string(),
+                    policy: "default".to_string(),
+                    selection_reason: "minimum_cost".to_string(),
+                    candidate_scope: "eligible_workers_only".to_string(),
+                    block_size: 256,
+                    request_blocks: 1,
+                    track_prefill_tokens: true,
+                    selected_worker_id: 42,
+                    selected_dp_rank: 0,
+                    max_overlap_worker_id: 42,
+                    max_overlap_dp_rank: 0,
+                    avoidable_prefill_token_equivalents: 0.0,
+                    overlap_score_credit: 1.0,
+                    overlap_score_credit_decay: 1.0,
+                    prefill_load_scale: 3.0,
+                    host_cache_hit_weight: 0.5,
+                    disk_cache_hit_weight: 0.0,
+                    shared_cache_multiplier: 0.0,
+                    decode_active_request_weight: 0.0,
+                    router_temperature: 0.0,
+                    candidates: vec![crate::protocols::common::timing::RoutingDecisionCandidate {
+                        worker_id: 42,
+                        dp_rank: 0,
+                        eligible: true,
+                        selected: true,
+                        max_overlap: true,
+                        total_cost_blocks: 1.25,
+                        effective_overlap_blocks: 8.0,
+                        device_overlap_blocks: 4.0,
+                        host_overlap_blocks: 4.0,
+                        disk_overlap_blocks: 0.0,
+                        shared_beyond_device_blocks: 4,
+                        raw_prefill_blocks: 10.0,
+                        active_prefill_tokens: 512,
+                        prefill_cost_blocks: 30.0,
+                        decode_cost_blocks: 2.0,
+                        active_requests: 1,
+                        active_request_cost_blocks: 1.0,
+                        overlap_credit_blocks: 8.0,
+                        overlap_credit_decay: 1.0,
+                        effective_overlap_score_credit: 1.0,
+                        adjusted_prefill_blocks: 2.0,
+                        base_score_blocks: 3.0,
+                        preferred_taint_multiplier: None,
+                        decode_overlap_formula: false,
+                    }],
+                }),
+            }),
+            tool: None,
+            payload: None,
+        };
+
+        let value = serde_json::to_value(record).unwrap();
+        assert_eq!(
+            value["request"]["routing_decision"]["selected_worker_id"],
+            42
+        );
+        assert_eq!(
+            value["request"]["routing_decision"]["candidates"][0]["effective_overlap_blocks"],
+            8.0
+        );
+        assert_eq!(
+            value["request"]["routing_decision"]["avoidable_prefill_token_equivalents"],
+            0.0
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What this adds

This PR adds opt-in, sampled routing-decision metadata to the existing `request_end` trace record. It makes an F2→F3 loss explainable: for every sampled eligible routing decision, it records each candidate worker's identity, prefix overlap and GPU/external cache evidence, queue/running inputs, score components and final score, plus the selected worker, the best-prefix worker, and avoidable prompt tokens.

It is disabled by default. Sampling is configurable through `DYN_ROUTER_DECISION_TRACE_ENABLED` and `DYN_ROUTER_DECISION_TRACE_SAMPLE_RATE`; no prompt content, headers, session identifiers, or cache keys are recorded.

## Controlled/local metadata example

```json
{
  "request_end": {
    "request": {
      "routing_decision": {
        "selected_worker": "worker-b",
        "best_prefix_worker": "worker-a",
        "avoidable_prefill_tokens": 192,
        "eligible_workers": [
          {"worker_id": "worker-a", "prefix_overlap_tokens": 384, "gpu_overlap_tokens": 256, "external_overlap_tokens": 128, "running_requests": 8, "queue_depth": 1, "final_score": 1.25},
          {"worker_id": "worker-b", "prefix_overlap_tokens": 192, "gpu_overlap_tokens": 192, "external_overlap_tokens": 0, "running_requests": 4, "queue_depth": 0, "final_score": 0.93}
        ]
      }
    }
  }
}
```

This is a controlled, local example only; it contains no prompt, header, cache-key, or session data.

## Safety and scope

- Routing-decision trace metadata only—no F0–F5 cache-loss funnel counters.
- Default-off and sampled before serializing the bounded metadata.
- The selected worker and all eligible candidates are correlated through the existing request trace, rather than a detached log stream.

## Tests

- `cargo test -p dynamo-kv-router --lib` (937 passed)
- `cargo test -p dynamo-llm request_trace_serializes_opt_in_routing_decision --lib` (1 passed)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional routing decision diagnostics to request traces and metrics.
  * Diagnostics can show routing policy, selected workers, candidate eligibility, cache overlap, load, cost, and taint details.
  * Supports configurable enablement and sampling for diagnostic deployments.
  * Captures traces for both admitted and advisory routing decisions.

* **Compatibility**
  * Diagnostic data is omitted when unavailable or disabled, preserving existing request trace output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Measured overhead at 1,024 eligible workers (current head `38b68256ec`)

Measured locally in release mode with the `dynamo-kv-router` criterion benchmark. The 1,024 candidates are all eligible workers for one routing decision.

| Case | Median CPU time per routing decision | Change vs. tracing off |
|---|---:|---:|
| Tracing disabled | **71.6 µs** | — |
| Construct sampled trace record | **199.5 µs** | **+128 µs (+179%)** |
| Construct and JSON-serialize record | **1.10 ms** | **+1.03 ms** |

A full 1,024-candidate record is **650,510 bytes**. At 1,000 sampled decisions/s, 100% sampling would emit roughly **650 MB/s** before transport overhead. This PR therefore keeps tracing default-off and sampling-configurable; a low sampling rate is required for large worker pools.
