### PR TITLE
fix(operator): wait for Ray head before joining workers

### DIFF
--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -419,9 +419,17 @@ func injectRayDistributedLaunchFlags(container *corev1.Container, role Role, ser
 		vllmMultinodeFlags := fmt.Sprintf("%s ray", distributedExecutorFlag)
 		container.Args = []string{fmt.Sprintf("ray start --head --port=%s && %s %s %s", VLLMPort, fullCommand, originalArgs, vllmMultinodeFlags)}
 	case RoleWorker:
-		// Worker nodes only run Ray agent - vLLM on leader will spawn Ray actors on workers
-		leaderHostname := multinodeDeployer.GetLeaderHostname(serviceName)
-		container.Args = []string{fmt.Sprintf("ray start --address=%s:%s --block", leaderHostname, VLLMPort)}
+		// Wait for the Ray head's GCS port before joining. Waiting for vLLM
+		// readiness would deadlock TP/PP startup, which needs the workers.
+		leaderHostname := k8sToShellVarSyntax(multinodeDeployer.GetLeaderHostname(serviceName))
+		container.Args = []string{fmt.Sprintf(
+			`export LEADER_HOST="%s"; `+
+				`i=0; until python3 -c "import os, socket; s=socket.create_connection((os.environ['LEADER_HOST'], %s), timeout=2); s.close()" 2>/dev/null; `+
+				`do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not become reachable after 150 attempts" >&2; exit 1; }; `+
+				`echo "Waiting for Ray head at $LEADER_HOST:%s..."; sleep 2; done && `+
+				`ray start --address="$LEADER_HOST:%s" --block`,
+			leaderHostname, VLLMPort, VLLMPort, VLLMPort,
+		)}
 	}
 	container.Command = []string{"/bin/sh", "-c"} // ensure cmd is a shell
 }

--- a/deploy/operator/internal/dynamo/backend_vllm_ray_startup_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_ray_startup_test.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dynamo
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestRayWorkerWaitsForHead(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		deployer  MultinodeDeployer
+		env       []string
+		hostname  string
+		failures  string
+		attempts  string
+		wantError bool
+	}{
+		{"LWS delayed head", &LWSMultinodeDeployer{}, []string{"LWS_LEADER_ADDRESS=head.test"}, "head.test", "2", "3", false},
+		{"Grove ready head", &GroveMultinodeDeployer{}, []string{"GROVE_PCSG_NAME=group", "GROVE_PCSG_INDEX=0", "GROVE_HEADLESS_SERVICE=headless"}, "group-0-test-service-ldr-0.headless", "0", "1", false},
+		{"head never starts", &LWSMultinodeDeployer{}, []string{"LWS_LEADER_ADDRESS=head.test"}, "head.test", "150", "150", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Render the production worker command with provider environment references")
+			container := &corev1.Container{}
+			injectRayDistributedLaunchFlags(container, RoleWorker, "test-service", tt.deployer)
+
+			t.Log("Control readiness failures and record whether Ray is launched")
+			dir := t.TempDir()
+			scripts := map[string]string{
+				"python3": `#!/bin/sh
+[ "$LEADER_HOST" = "$EXPECTED_HOST" ] || exit 2
+n=0
+[ ! -f "$TEST_DIR/attempts" ] || read -r n < "$TEST_DIR/attempts"
+n=$((n+1))
+printf '%s' "$n" > "$TEST_DIR/attempts"
+[ "$n" -gt "$FAILURES" ]
+`,
+				"sleep": "#!/bin/sh\nexit 0\n",
+				"ray":   "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$TEST_DIR/ray-args\"\n",
+			}
+			for name, script := range scripts {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(script), 0o700))
+			}
+
+			t.Log("Expand Kubernetes environment references before executing the shell")
+			for _, env := range tt.env {
+				name, value, _ := strings.Cut(env, "=")
+				container.Args[0] = strings.ReplaceAll(container.Args[0], "$("+name+")", value)
+			}
+
+			t.Log("Execute the real shell command and check retry and join behavior")
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, container.Command[0], append(container.Command[1:], container.Args...)...)
+			cmd.Env = append(os.Environ(), "PATH="+dir+":"+os.Getenv("PATH"), "TEST_DIR="+dir, "EXPECTED_HOST="+tt.hostname, "FAILURES="+tt.failures)
+			cmd.Env = append(cmd.Env, tt.env...)
+			output, err := cmd.CombinedOutput()
+			require.NoError(t, ctx.Err(), string(output))
+			if tt.wantError {
+				require.Error(t, err, string(output))
+				require.Contains(t, string(output), "Ray head did not become reachable after 150 attempts")
+				_, statErr := os.Stat(filepath.Join(dir, "ray-args"))
+				require.ErrorIs(t, statErr, os.ErrNotExist)
+			} else {
+				require.NoError(t, err, string(output))
+				args, readErr := os.ReadFile(filepath.Join(dir, "ray-args"))
+				require.NoError(t, readErr)
+				require.Equal(t, "start\n--address="+tt.hostname+":"+VLLMPort+"\n--block\n", string(args))
+			}
+			attempts, err := os.ReadFile(filepath.Join(dir, "attempts"))
+			require.NoError(t, err)
+			require.Equal(t, tt.attempts, string(attempts))
+		})
+	}
+}

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -126,7 +126,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			multinodeDeployer:   &GroveMultinodeDeployer{},
 			initialContainer:    &corev1.Container{Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm", "--model", "test", tensorParallelSizeFlag, "8"}},
 			containerGPUs:       4,
-			expectedArgs:        []string{"ray start --address=$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE):6379 --block"},
+			expectedArgs:        []string{`export LEADER_HOST="${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-test-service-ldr-0.${GROVE_HEADLESS_SERVICE}"; i=0; until python3 -c "import os, socket; s=socket.create_connection((os.environ['LEADER_HOST'], 6379), timeout=2); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not become reachable after 150 attempts" >&2; exit 1; }; echo "Waiting for Ray head at $LEADER_HOST:6379..."; sleep 2; done && ray start --address="$LEADER_HOST:6379" --block`},
 			expectProbesRemoved: true,
 		},
 		{
@@ -137,7 +137,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			multinodeDeployer:   &LWSMultinodeDeployer{},
 			initialContainer:    &corev1.Container{Args: []string{"python3", "-m", "dynamo.vllm", tensorParallelSizeFlag, "8"}},
 			containerGPUs:       4,
-			expectedArgs:        []string{"ray start --address=$(LWS_LEADER_ADDRESS):6379 --block"},
+			expectedArgs:        []string{`export LEADER_HOST="${LWS_LEADER_ADDRESS}"; i=0; until python3 -c "import os, socket; s=socket.create_connection((os.environ['LEADER_HOST'], 6379), timeout=2); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not become reachable after 150 attempts" >&2; exit 1; }; echo "Waiting for Ray head at $LEADER_HOST:6379..."; sleep 2; done && ray start --address="$LEADER_HOST:6379" --block`},
 			expectProbesRemoved: true,
 		},
 		{
@@ -806,7 +806,7 @@ func TestUpdateVLLMMultinodeArgs(t *testing.T) {
 			initialContainer:  &corev1.Container{Args: []string{"python3", "-m", "dynamo.vllm", tensorParallelSizeFlag, "16"}},
 			gpuCount:          8,
 			annotations:       nil,
-			expectedArgs:      []string{"ray start --address=$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE):6379 --block"},
+			expectedArgs:      []string{`export LEADER_HOST="${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-test-service-ldr-0.${GROVE_HEADLESS_SERVICE}"; i=0; until python3 -c "import os, socket; s=socket.create_connection((os.environ['LEADER_HOST'], 6379), timeout=2); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not become reachable after 150 attempts" >&2; exit 1; }; echo "Waiting for Ray head at $LEADER_HOST:6379..."; sleep 2; done && ray start --address="$LEADER_HOST:6379" --block`},
 		},
 		{
 			name:              "worker with data parallel launch Grove",
@@ -833,7 +833,7 @@ func TestUpdateVLLMMultinodeArgs(t *testing.T) {
 			initialContainer:  &corev1.Container{Args: []string{"python3", "-m", "dynamo.vllm", tensorParallelSizeFlag, "16"}},
 			gpuCount:          8,
 			annotations:       nil,
-			expectedArgs:      []string{"ray start --address=$(LWS_LEADER_ADDRESS):6379 --block"},
+			expectedArgs:      []string{`export LEADER_HOST="${LWS_LEADER_ADDRESS}"; i=0; until python3 -c "import os, socket; s=socket.create_connection((os.environ['LEADER_HOST'], 6379), timeout=2); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not become reachable after 150 attempts" >&2; exit 1; }; echo "Waiting for Ray head at $LEADER_HOST:6379..."; sleep 2; done && ray start --address="$LEADER_HOST:6379" --block`},
 		},
 		{
 			name:              "main role does not modify args",

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -3976,7 +3976,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													"-c",
 												},
 												Args: []string{
-													"ray start --address=$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-worker-ldr-0.$(GROVE_HEADLESS_SERVICE):6379 --block",
+													`export LEADER_HOST="${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-worker-ldr-0.${GROVE_HEADLESS_SERVICE}"; i=0; until python3 -c "import os, socket; s=socket.create_connection((os.environ['LEADER_HOST'], 6379), timeout=2); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not become reachable after 150 attempts" >&2; exit 1; }; echo "Waiting for Ray head at $LEADER_HOST:6379..."; sleep 2; done && ray start --address="$LEADER_HOST:6379" --block`,
 												},
 												Ports: []corev1.ContainerPort{
 													{
@@ -5052,7 +5052,7 @@ func TestGeneratePodSpecForComponent_VLLM(t *testing.T) {
 			role:              RoleWorker,
 			numberOfNodes:     3,
 			expectError:       false,
-			expectContains:    []string{"ray start --address=$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-worker-ldr-0.$(GROVE_HEADLESS_SERVICE):6379 --block"},
+			expectContains:    []string{`export LEADER_HOST="${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-worker-ldr-0.${GROVE_HEADLESS_SERVICE}"; i=0; until python3 -c "import os, socket; s=socket.create_connection((os.environ['LEADER_HOST'], 6379), timeout=2); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not become reachable after 150 attempts" >&2; exit 1; }; echo "Waiting for Ray head at $LEADER_HOST:6379..."; sleep 2; done && ray start --address="$LEADER_HOST:6379" --block`},
 			expectNotContains: []string{"python3 -m dynamo.vllm"},
 		},
 		{


### PR DESCRIPTION
## Overview

Multi-node vLLM Ray workers can attempt to join before the head is listening. Wait for the head's GCS port before running `ray start`, with 150 attempts and a clear failure if the head remains unreachable. Waiting on the GCS port avoids the TP/PP startup deadlock that waiting for model readiness would cause.

Expand Grove and LWS leader host variables in the shell. Add behavioral tests for a delayed head, an immediately available head, and exhausted retries; update launch and graph-rendering expectations.

## Details

- Convert Kubernetes-style leader host references to shell syntax so Grove and LWS variables expand when the worker command executes.
- Poll the Ray head's GCS port before starting the worker agent.
- Bound the wait at 150 attempts and return a clear startup error when the head remains unavailable.
- Preserve the existing leader launch behavior and the worker's blocking Ray process.
- Cover delayed startup, immediate availability, retry exhaustion, Grove rendering, and LWS rendering.

## Where should the reviewer start?

Start in `deploy/operator/internal/dynamo/backend_vllm.go`, specifically `injectRayDistributedLaunchFlags`, which contains the worker startup gate. Then review `deploy/operator/internal/dynamo/backend_vllm_ray_startup_test.go` for the behavioral coverage and the updated rendering expectations in `backend_vllm_test.go` and `graph_test.go`.

## Validation

- `go test ./internal/dynamo -count=1`
- `go test -race ./internal/dynamo -count=1`
- Kubernetes validation across two Spark nodes with three workers started before the Ray head. All workers waited, joined without restarts after the head started, and completed tasks pinned to each of the four Ray nodes.

The cluster validation used isolated CPU-only pods. It did not run model inference or replace the deployed operator.

## Related Issues

- Closes #14108 
