### PR TITLE
fix(operator): Ensure ray workers wait for leader

### DIFF
--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1482,7 +1482,7 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 										Name:  "wait-for-leader",
 										Image: "test-image:1.5.0",
 										Command: []string{"sh", "-c",
-											`export LEADER_HOST="${LWS_LEADER_ADDRESS}" LEADER_PORT="6379" && exec python3 /scripts/wait-for-leader.py`},
+											`export LEADER_HOST="${LWS_LEADER_ADDRESS}" LEADER_PORT="6379" && bash /scripts/wait-for-ray-leader.sh`},
 										VolumeMounts: []corev1.VolumeMount{
 											{
 												Name:      "wait-leader-script",

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1466,6 +1466,31 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 											},
 										},
 									},
+									{
+										Name: "wait-leader-script",
+										VolumeSource: corev1.VolumeSource{
+											ConfigMap: &corev1.ConfigMapVolumeSource{
+												LocalObjectReference: corev1.LocalObjectReference{
+													Name: "test-lws-deploy-wait-leader-script",
+												},
+											},
+										},
+									},
+								},
+								InitContainers: []corev1.Container{
+									{
+										Name:  "wait-for-leader",
+										Image: "test-image:1.5.0",
+										Command: []string{"sh", "-c",
+											`export LEADER_HOST="${LWS_LEADER_ADDRESS}" LEADER_PORT="6379" && exec python3 /scripts/wait-for-leader.py`},
+										VolumeMounts: []corev1.VolumeMount{
+											{
+												Name:      "wait-leader-script",
+												MountPath: "/scripts",
+												ReadOnly:  true,
+											},
+										},
+									},
 								},
 								RestartPolicy: corev1.RestartPolicyAlways,
 								Containers: []corev1.Container{

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -144,6 +144,7 @@ func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes
 const (
 	waitLeaderConfigMapSuffix = "wait-leader-script"
 	waitLeaderScriptKey       = "wait-for-leader.py"
+	waitRayLeaderScriptKey    = "wait-for-ray-leader.sh"
 	waitLeaderVolumeName      = "wait-leader-script"
 	waitLeaderMountPath       = "/scripts"
 )
@@ -222,6 +223,19 @@ while True:
     time.sleep(5)
 `
 
+// WaitRayLeaderScript is the Bash script that verifies Ray leader is started
+// It reads LEADER_HOST and LEADER_PORT from environment variables so the script content is generic.
+const WaitRayLeaderScript = `
+echo "Waiting for Ray leader to become available..."
+
+# Loop until a health check passes or a network connection succeeds
+until ray health-check --address "${LEADER_HOST}:${LEADER_PORT}" &>/dev/null; do
+	echo "Ray leader not healthy yet, retrying in 5 seconds"
+    sleep 5
+done
+echo "Ray leader is up"
+`
+
 // k8sVarPattern matches Kubernetes $(VAR) env-var expansion syntax.
 var k8sVarPattern = regexp.MustCompile(`\$\((\w+)\)`)
 
@@ -249,7 +263,8 @@ func GenerateWaitLeaderConfigMap(dgdName, namespace string) *corev1.ConfigMap {
 			},
 		},
 		Data: map[string]string{
-			waitLeaderScriptKey: WaitLeaderScript,
+			waitLeaderScriptKey:    WaitLeaderScript,
+			waitRayLeaderScriptKey: WaitRayLeaderScript,
 		},
 	}
 }
@@ -260,15 +275,25 @@ func (b *VLLMBackend) UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int32
 		return
 	}
 	initName := "wait-for-leader-mp"
-	leaderPort := commonconsts.VLLMMpMasterPort
-	// If the podSpec is detected as multi-node Ray, set different leader port and init container name
+	// Use sh -c so the shell expands variable references at runtime.
+	// Grove/LWS env vars are appended to init containers AFTER our env
+	// vars, so Kubernetes $(VAR) expansion (which is order-dependent)
+	// cannot resolve them. The shell sees all env vars regardless of
+	// definition order.
+	leaderHostname := multinodeDeployer.GetLeaderHostname(serviceName)
+	shellHostname := k8sToShellVarSyntax(leaderHostname)
+	command := []string{"sh", "-c", fmt.Sprintf(
+		`export LEADER_HOST="%s" LEADER_PORT="%s" && exec python3 %s/%s`,
+		shellHostname, commonconsts.VLLMMpMasterPort, waitLeaderMountPath, waitLeaderScriptKey)}
+	// If the podSpec is detected as multi-node Ray, set different init container name and init command
 	if b.shouldInjectVLLMRayWaitLeaderInit(podSpec, numberOfNodes, role) {
-		leaderPort = VLLMPort
 		initName = "wait-for-leader"
+		command = []string{"sh", "-c", fmt.Sprintf(
+			`export LEADER_HOST="%s" LEADER_PORT="%s" && bash %s/%s`,
+			shellHostname, VLLMPort, waitLeaderMountPath, waitRayLeaderScriptKey)}
 	}
 
 	mainContainer := &podSpec.Containers[0]
-	leaderHostname := multinodeDeployer.GetLeaderHostname(serviceName)
 	mainImage := mainContainer.Image
 	cmName := GetWaitLeaderConfigMapName(b.ParentGraphDeploymentName)
 
@@ -283,18 +308,10 @@ func (b *VLLMBackend) UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int32
 		},
 	})
 
-	// Use sh -c so the shell expands variable references at runtime.
-	// Grove/LWS env vars are appended to init containers AFTER our env
-	// vars, so Kubernetes $(VAR) expansion (which is order-dependent)
-	// cannot resolve them. The shell sees all env vars regardless of
-	// definition order.
-	shellHostname := k8sToShellVarSyntax(leaderHostname)
 	initContainer := corev1.Container{
-		Name:  initName,
-		Image: mainImage,
-		Command: []string{"sh", "-c", fmt.Sprintf(
-			`export LEADER_HOST="%s" LEADER_PORT="%s" && exec python3 %s/%s`,
-			shellHostname, leaderPort, waitLeaderMountPath, waitLeaderScriptKey)},
+		Name:    initName,
+		Image:   mainImage,
+		Command: command,
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      waitLeaderVolumeName,

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -255,8 +255,16 @@ func GenerateWaitLeaderConfigMap(dgdName, namespace string) *corev1.ConfigMap {
 }
 
 func (b *VLLMBackend) UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int32, role Role, _ *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer) {
-	if !b.shouldInjectVLLMMpWaitLeaderInit(podSpec, numberOfNodes, role) {
+	// Return early if the podSpec is not using multi-node MP or Ray
+	if !b.shouldInjectVLLMMpWaitLeaderInit(podSpec, numberOfNodes, role) && !b.shouldInjectVLLMRayWaitLeaderInit(podSpec, numberOfNodes, role) {
 		return
+	}
+	initName := "wait-for-leader-mp"
+	leaderPort := commonconsts.VLLMMpMasterPort
+	// If the podSpec is detected as multi-node Ray, set different leader port and init container name
+	if b.shouldInjectVLLMRayWaitLeaderInit(podSpec, numberOfNodes, role) {
+		leaderPort = VLLMPort
+		initName = "wait-for-leader"
 	}
 
 	mainContainer := &podSpec.Containers[0]
@@ -282,11 +290,11 @@ func (b *VLLMBackend) UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int32
 	// definition order.
 	shellHostname := k8sToShellVarSyntax(leaderHostname)
 	initContainer := corev1.Container{
-		Name:  "wait-for-leader-mp",
+		Name:  initName,
 		Image: mainImage,
 		Command: []string{"sh", "-c", fmt.Sprintf(
 			`export LEADER_HOST="%s" LEADER_PORT="%s" && exec python3 %s/%s`,
-			shellHostname, commonconsts.VLLMMpMasterPort, waitLeaderMountPath, waitLeaderScriptKey)},
+			shellHostname, leaderPort, waitLeaderMountPath, waitLeaderScriptKey)},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      waitLeaderVolumeName,
@@ -305,6 +313,15 @@ func (b *VLLMBackend) shouldInjectVLLMMpWaitLeaderInit(podSpec *corev1.PodSpec, 
 	}
 
 	return containerCommandLineHasArg(&podSpec.Containers[0], distributedExecutorFlag, "mp")
+}
+
+// Detect a multi-node Ray worker
+func (b *VLLMBackend) shouldInjectVLLMRayWaitLeaderInit(podSpec *corev1.PodSpec, numberOfNodes int32, role Role) bool {
+	if b.ParentGraphDeploymentName == "" || numberOfNodes <= 1 || role != RoleWorker || len(podSpec.Containers) == 0 {
+		return false
+	}
+
+	return containerCommandLineHasArg(&podSpec.Containers[0], "ray", "start")
 }
 
 // updateVLLMMultinodeArgs dispatches to the appropriate injection function based on

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -1006,6 +1006,7 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 		expectedLeaderPort  string
 		expectedInitImage   string
 		expectedLeaderHost  string
+		expectRayScript     bool
 	}{
 		{
 			name:                "mp worker with Grove deployer injects init container",
@@ -1097,7 +1098,7 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 			expectInitContainer: false,
 		},
 		{
-			name:              "non-mp worker command does not inject init container",
+			name:              "ray worker with Grove deployer injects init container with timeout",
 			numberOfNodes:     2,
 			role:              RoleWorker,
 			multinodeDeployer: &GroveMultinodeDeployer{},
@@ -1116,6 +1117,7 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 			expectedLeaderPort:  VLLMPort,
 			expectedInitImage:   "vllm:latest",
 			expectedLeaderHost:  "${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-test-service-ldr-0.${GROVE_HEADLESS_SERVICE}",
+			expectRayScript:     true,
 		},
 		{
 			name:          "single node does not inject init container",
@@ -1168,9 +1170,18 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 				g.Expect(injected.Name).To(gomega.Equal(tt.expectedInitName))
 				g.Expect(injected.Image).To(gomega.Equal(tt.expectedInitImage))
 
-				expectedCmd := fmt.Sprintf(
-					`export LEADER_HOST="%s" LEADER_PORT="%s" && exec python3 /scripts/wait-for-leader.py`,
-					tt.expectedLeaderHost, tt.expectedLeaderPort)
+				var expectedCmd string
+				if tt.expectRayScript {
+					// Ray workers use the bash script
+					expectedCmd = fmt.Sprintf(
+						`export LEADER_HOST="%s" LEADER_PORT="%s" && bash /scripts/wait-for-ray-leader.sh`,
+						tt.expectedLeaderHost, tt.expectedLeaderPort)
+				} else {
+					// MP workers use the Python script
+					expectedCmd = fmt.Sprintf(
+						`export LEADER_HOST="%s" LEADER_PORT="%s" && exec python3 /scripts/wait-for-leader.py`,
+						tt.expectedLeaderHost, tt.expectedLeaderPort)
+				}
 				g.Expect(injected.Command).To(gomega.Equal([]string{"sh", "-c", expectedCmd}))
 				g.Expect(injected.Env).To(gomega.BeEmpty())
 
@@ -1200,16 +1211,24 @@ func TestGenerateWaitLeaderConfigMap(t *testing.T) {
 	g.Expect(cm.Namespace).To(gomega.Equal("my-ns"))
 	g.Expect(cm.Labels).To(gomega.HaveKeyWithValue(commonconsts.KubeLabelDynamoGraphDeploymentName, "my-dgd"))
 	g.Expect(cm.Data).To(gomega.HaveKey("wait-for-leader.py"))
+	g.Expect(cm.Data).To(gomega.HaveKey("wait-for-ray-leader.sh"))
 
-	script := cm.Data["wait-for-leader.py"]
-	g.Expect(script).To(gomega.ContainSubstring(`os.environ["LEADER_HOST"]`))
-	g.Expect(script).To(gomega.ContainSubstring(`os.environ["LEADER_PORT"]`))
-	g.Expect(script).To(gomega.ContainSubstring("leader_pod_is_healthy"))
-	g.Expect(script).To(gomega.ContainSubstring("kubernetes.default.svc"))
-	g.Expect(script).To(gomega.ContainSubstring("fieldSelector=status.podIP="))
-	g.Expect(script).To(gomega.ContainSubstring("deletionTimestamp"))
-	g.Expect(script).To(gomega.ContainSubstring("socket.create_connection"))
-	g.Expect(script).To(gomega.ContainSubstring("time.sleep(5)"))
+	// Check Python script content
+	pythonScript := cm.Data["wait-for-leader.py"]
+	g.Expect(pythonScript).To(gomega.ContainSubstring(`os.environ["LEADER_HOST"]`))
+	g.Expect(pythonScript).To(gomega.ContainSubstring(`os.environ["LEADER_PORT"]`))
+	g.Expect(pythonScript).To(gomega.ContainSubstring("leader_pod_is_healthy"))
+	g.Expect(pythonScript).To(gomega.ContainSubstring("kubernetes.default.svc"))
+	g.Expect(pythonScript).To(gomega.ContainSubstring("fieldSelector=status.podIP="))
+	g.Expect(pythonScript).To(gomega.ContainSubstring("deletionTimestamp"))
+	g.Expect(pythonScript).To(gomega.ContainSubstring("socket.create_connection"))
+	g.Expect(pythonScript).To(gomega.ContainSubstring("time.sleep(5)"))
+
+	// Check Ray script content
+	rayScript := cm.Data["wait-for-ray-leader.sh"]
+	g.Expect(rayScript).To(gomega.ContainSubstring("Waiting for Ray leader to become available"))
+	g.Expect(rayScript).To(gomega.ContainSubstring("ray health-check --address \"${LEADER_HOST}:${LEADER_PORT}\""))
+	g.Expect(rayScript).To(gomega.ContainSubstring("sleep 5"))
 }
 
 func TestGetWaitLeaderConfigMapName(t *testing.T) {

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -1002,6 +1002,8 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 		multinodeDeployer   MultinodeDeployer
 		initialPodSpec      *corev1.PodSpec
 		expectInitContainer bool
+		expectedInitName    string
+		expectedLeaderPort  string
 		expectedInitImage   string
 		expectedLeaderHost  string
 	}{
@@ -1012,6 +1014,8 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 			multinodeDeployer:   &GroveMultinodeDeployer{},
 			initialPodSpec:      mpMultinodePodSpec("vllm:latest"),
 			expectInitContainer: true,
+			expectedInitName:    "wait-for-leader-mp",
+			expectedLeaderPort:  commonconsts.VLLMMpMasterPort,
 			expectedInitImage:   "vllm:latest",
 			expectedLeaderHost:  "${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-test-service-ldr-0.${GROVE_HEADLESS_SERVICE}",
 		},
@@ -1022,6 +1026,8 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 			multinodeDeployer:   &LWSMultinodeDeployer{},
 			initialPodSpec:      mpMultinodePodSpec("vllm:v2"),
 			expectInitContainer: true,
+			expectedInitName:    "wait-for-leader-mp",
+			expectedLeaderPort:  commonconsts.VLLMMpMasterPort,
 			expectedInitImage:   "vllm:v2",
 			expectedLeaderHost:  "${LWS_LEADER_ADDRESS}",
 		},
@@ -1040,6 +1046,8 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 				},
 			},
 			expectInitContainer: true,
+			expectedInitName:    "wait-for-leader-mp",
+			expectedLeaderPort:  commonconsts.VLLMMpMasterPort,
 			expectedInitImage:   "vllm:command",
 			expectedLeaderHost:  "${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-test-service-ldr-0.${GROVE_HEADLESS_SERVICE}",
 		},
@@ -1062,6 +1070,8 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 				},
 			},
 			expectInitContainer: true,
+			expectedInitName:    "wait-for-leader-mp",
+			expectedLeaderPort:  commonconsts.VLLMMpMasterPort,
 			expectedInitImage:   "vllm:shell-command",
 			expectedLeaderHost:  "${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-test-service-ldr-0.${GROVE_HEADLESS_SERVICE}",
 		},
@@ -1101,7 +1111,11 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 					},
 				},
 			},
-			expectInitContainer: false,
+			expectInitContainer: true,
+			expectedInitName:    "wait-for-leader",
+			expectedLeaderPort:  VLLMPort,
+			expectedInitImage:   "vllm:latest",
+			expectedLeaderHost:  "${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-test-service-ldr-0.${GROVE_HEADLESS_SERVICE}",
 		},
 		{
 			name:          "single node does not inject init container",
@@ -1131,6 +1145,8 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 				return podSpec
 			}(),
 			expectInitContainer: true,
+			expectedInitName:    "wait-for-leader-mp",
+			expectedLeaderPort:  commonconsts.VLLMMpMasterPort,
 			expectedInitImage:   "vllm:latest",
 			expectedLeaderHost:  "${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-test-service-ldr-0.${GROVE_HEADLESS_SERVICE}",
 		},
@@ -1149,12 +1165,12 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 				g.Expect(tt.initialPodSpec.Volumes).To(gomega.HaveLen(initialVolCount + 1))
 
 				injected := tt.initialPodSpec.InitContainers[len(tt.initialPodSpec.InitContainers)-1]
-				g.Expect(injected.Name).To(gomega.Equal("wait-for-leader-mp"))
+				g.Expect(injected.Name).To(gomega.Equal(tt.expectedInitName))
 				g.Expect(injected.Image).To(gomega.Equal(tt.expectedInitImage))
 
 				expectedCmd := fmt.Sprintf(
 					`export LEADER_HOST="%s" LEADER_PORT="%s" && exec python3 /scripts/wait-for-leader.py`,
-					tt.expectedLeaderHost, commonconsts.VLLMMpMasterPort)
+					tt.expectedLeaderHost, tt.expectedLeaderPort)
 				g.Expect(injected.Command).To(gomega.Equal([]string{"sh", "-c", expectedCmd}))
 				g.Expect(injected.Env).To(gomega.BeEmpty())
 

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -3965,6 +3965,31 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													},
 												},
 											},
+											{
+												Name: "wait-leader-script",
+												VolumeSource: corev1.VolumeSource{
+													ConfigMap: &corev1.ConfigMapVolumeSource{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "test-dynamo-graph-deployment-wait-leader-script",
+														},
+													},
+												},
+											},
+										},
+										InitContainers: []corev1.Container{
+											{
+												Name:  "wait-for-leader",
+												Image: "worker-image",
+												Command: []string{"sh", "-c",
+													`export LEADER_HOST="${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-worker-ldr-0.${GROVE_HEADLESS_SERVICE}" LEADER_PORT="6379" && exec python3 /scripts/wait-for-leader.py`},
+												VolumeMounts: []corev1.VolumeMount{
+													{
+														Name:      "wait-leader-script",
+														MountPath: "/scripts",
+														ReadOnly:  true,
+													},
+												},
+											},
 										},
 										RestartPolicy: corev1.RestartPolicyAlways,
 										Containers: []corev1.Container{

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -3981,7 +3981,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 												Name:  "wait-for-leader",
 												Image: "worker-image",
 												Command: []string{"sh", "-c",
-													`export LEADER_HOST="${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-worker-ldr-0.${GROVE_HEADLESS_SERVICE}" LEADER_PORT="6379" && exec python3 /scripts/wait-for-leader.py`},
+													`export LEADER_HOST="${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-worker-ldr-0.${GROVE_HEADLESS_SERVICE}" LEADER_PORT="6379" && bash /scripts/wait-for-ray-leader.sh`},
 												VolumeMounts: []corev1.VolumeMount{
 													{
 														Name:      "wait-leader-script",


### PR DESCRIPTION
## Overview:

Ray workers start without waiting for the vLLM port to start that the workers connect to

## Details:

Re-use the existing script to wait for the leader

## Where should the reviewer start?

vLLM backend logic in the operator that handled MP init now also handles Ray worker init

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #14108


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multinode vLLM startup reliability by ensuring worker processes wait for the leader to become available.
  - Added leader-wait support for both multiprocessing and Ray-based deployments.
  - Worker startup now uses the appropriate leader connection port for each deployment mode.
  - Standardized multinode worker initialization and script mounting across supported deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->