### PR TITLE
test(profiler): stage generated DGD deployment validation

### DIFF
--- a/components/src/dynamo/profiler/tests/sweeper/DESIGN.md
+++ b/components/src/dynamo/profiler/tests/sweeper/DESIGN.md
@@ -272,6 +272,17 @@ Exact Sweeper goldens require reproducible search inputs and search ordering. Un
 CI must distinguish deterministic renderer checks from end-to-end search evidence rather than make
 a stochastic search an exact-diff gate.
 
+## Live validation
+
+Live validation independently deploys each available DGD and, when eligible, the recipe source.
+Each deployment must become ready and serve a valid inference request. Failure of one variant does
+not erase evidence from another.
+
+The initial harness validates the provider-neutral DGD on a matching cluster. Provider-specific
+composition should reuse existing Recipe Components, for example AWS EFA or GKE RoCE. Hardware
+remains the profiler input; Kustomize supplies the concrete Kubernetes platform binding without a
+second provider schema in this suite.
+
 ## Non-goals
 
 The comparison does not require:

--- a/components/src/dynamo/profiler/tests/sweeper/README.md
+++ b/components/src/dynamo/profiler/tests/sweeper/README.md
@@ -13,7 +13,7 @@ the distinction between cases, hardware configurations, suites, goldens, and loc
 Sweeper inputs. Known render and deployment exceptions are recorded on the affected suite row with
 a reason and optional evidence links. A missing generated variant has no placeholder golden.
 
-The portable runner and comparison-corpus direction build on Ashna Mehrotra's work in
+The portable runner and live-validation direction build on Ashna Mehrotra's work in
 [PR #14031](https://github.com/ai-dynamo/dynamo/pull/14031).
 
 ## Generate one combination
@@ -59,3 +59,22 @@ kubectl apply -f \
 
 Composed inputs, the selected Candidate, caches, and error files are local ignored diagnostics.
 The suite intentionally defines no custom report format.
+
+## Validate generated DGDs on a cluster
+
+After generating the goldens, run the deployment test against the same suite:
+
+```bash
+pytest -q tests/deploy/test_sweeper_cases.py \
+  --sweeper-suite components/src/dynamo/profiler/tests/sweeper/testsuite-issue-8469.yaml \
+  --namespace <namespace>
+```
+
+The default variants are the v1beta1 profiler output, Sweeper-AIC output, and an eligible recipe.
+Select a different set with `--sweeper-variants`, for example
+`--sweeper-variants profiler-v1beta1,sweeper-aic,sweeper-direct,recipe`. The test rejects a suite
+entry when its hardware family or total GPU budget is unavailable on the cluster.
+
+To probe a recipe on hardware not yet listed in its `recipe.yaml`, add
+`--sweeper-discover-recipe-hardware`. After successful deployment and inference, the test writes
+the proposed requirement to the ignored adjacent `recipe.new.yaml`; it never edits `recipe.yaml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,9 @@ vllm_tests = "dynamo.vllm.tests.conftest"
 trtllm_tests = "dynamo.trtllm.tests.conftest"
 sglang_tests = "dynamo.sglang.tests.conftest"
 
+[project.scripts]
+dynamo-profiler-sweeper = "dynamo.profiler.sweeper.__main__:main"
+
 [project.entry-points."aisimulate.sweep_config_providers"]
 "dynamo.planner" = "dynamo.planner.simulation:create_provider"
 "dynamo.router" = "dynamo.router.simulation:create_provider"

--- a/tests/deploy/conftest.py
+++ b/tests/deploy/conftest.py
@@ -17,6 +17,8 @@ import pytest
 from tests.deploy.dgd_utils import DeploymentSpec, _get_workspace_dir
 from tests.deploy.dgdr_utils import DGDRTestConfig, ManagedDGDR
 
+DEFAULT_SWEEPER_VARIANTS = "profiler-v1beta1,sweeper-aic,recipe"
+
 
 # Shared CLI options (--image, --namespace, --skip-service-restart) are defined in tests/conftest.py.
 # Deploy-specific options are defined here.
@@ -109,6 +111,29 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--dgdr-hf-token-secret",
         default="",
         help="Secret containing the profiler's HF_TOKEN value.",
+    )
+    parser.addoption(
+        "--sweeper-suite",
+        type=Path,
+        default=None,
+        help="Sweeper comparison suite whose DGDs should be validated.",
+    )
+    parser.addoption(
+        "--sweeper-output-dir",
+        type=Path,
+        default=None,
+        help="Generated DGD root; defaults to the suite's checked-in generated directory.",
+    )
+    parser.addoption(
+        "--sweeper-variants",
+        default=DEFAULT_SWEEPER_VARIANTS,
+        help="Comma-separated generated or recipe DGD variants to validate.",
+    )
+    parser.addoption(
+        "--sweeper-discover-recipe-hardware",
+        action="store_true",
+        default=False,
+        help="Try recipes without a matching requirement and write successful additions to recipe.new.yaml.",
     )
 
 

--- a/tests/deploy/dgd_utils.py
+++ b/tests/deploy/dgd_utils.py
@@ -403,7 +403,23 @@ class ServiceSpec:
         for i, arg in enumerate(args):
             if arg in ["--model", "--model-path"]:
                 if i + 1 < len(args) and not args[i + 1].startswith("-"):
-                    return args[i + 1]
+                    value = args[i + 1]
+                    match = re.fullmatch(
+                        r"\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))",
+                        value,
+                    )
+                    if match is None:
+                        return value
+                    variable = match.group(1) or match.group(2)
+                    container = self._get_main_container_for_args()
+                    envs = list(container.get("env", [])) if container else []
+                    envs.extend(self.envs)
+                    for env in envs:
+                        if env.get("name") == variable and isinstance(
+                            env.get("value"), str
+                        ):
+                            return env["value"]
+                    return value
         return None
 
     @model.setter

--- a/tests/deploy/test_dgd_utils.py
+++ b/tests/deploy/test_dgd_utils.py
@@ -6,7 +6,12 @@
 import pytest
 import yaml
 
-from tests.deploy.dgd_utils import DeploymentSpec
+from tests.deploy.dgd_utils import (
+    SCHEMA_V1ALPHA1,
+    SCHEMA_V1BETA1,
+    DeploymentSpec,
+    ServiceSpec,
+)
 
 pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
 
@@ -28,3 +33,70 @@ def test_logging_config_reads_existing_v1beta1_env(tmp_path) -> None:
     deployment_spec = DeploymentSpec(str(manifest_path))
 
     assert deployment_spec.get_logging_config()["jsonl_enabled"] is True
+
+
+def test_model_resolves_shell_variable_from_v1alpha1_container_env() -> None:
+    service = ServiceSpec(
+        "Worker",
+        {
+            "extraPodSpec": {
+                "mainContainer": {
+                    "args": ["--model-path", "${MODEL_PATH}"],
+                    "env": [{"name": "MODEL_PATH", "value": "Qwen/Qwen3-32B-FP8"}],
+                }
+            }
+        },
+        schema=SCHEMA_V1ALPHA1,
+    )
+
+    assert service.model == "Qwen/Qwen3-32B-FP8"
+
+
+def test_model_resolves_shell_variable_from_v1beta1_container_env() -> None:
+    service = ServiceSpec(
+        "Worker",
+        {
+            "podTemplate": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "main",
+                            "args": ["--model", "$MODEL_ID"],
+                            "env": [
+                                {
+                                    "name": "MODEL_ID",
+                                    "value": "Qwen/Qwen3-32B-FP8",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        },
+        schema=SCHEMA_V1BETA1,
+    )
+
+    assert service.model == "Qwen/Qwen3-32B-FP8"
+
+
+def test_model_prefers_v1beta1_container_env_over_component_env() -> None:
+    service = ServiceSpec(
+        "Worker",
+        {
+            "envs": [{"name": "MODEL_ID", "value": "component-model"}],
+            "podTemplate": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "main",
+                            "args": ["--model", "$MODEL_ID"],
+                            "env": [{"name": "MODEL_ID", "value": "container-model"}],
+                        }
+                    ]
+                }
+            },
+        },
+        schema=SCHEMA_V1BETA1,
+    )
+
+    assert service.model == "container-model"

--- a/tests/deploy/test_sweeper_cases.py
+++ b/tests/deploy/test_sweeper_cases.py
@@ -1,0 +1,429 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live validation for comparison DGDs selected directly from a suite.
+
+The deployment preparation and cluster-inventory flow builds on Ashna Mehrotra's
+work in https://github.com/ai-dynamo/dynamo/pull/14031. This version deliberately
+does not use a custom report file as its discovery or result protocol.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from dynamo.profiler.tests.sweeper.run_cases import (
+    SuiteException,
+    default_suite_output_root,
+    load_case,
+    load_hardware,
+    load_recipe,
+    load_suite,
+    missing_case_inputs,
+    recipe_gpu_count,
+    write_discovered_recipe_requirement,
+)
+from tests.deploy.conftest import DEFAULT_SWEEPER_VARIANTS, DeploymentTarget
+from tests.deploy.dgd_utils import DeploymentSpec
+from tests.deploy.dgdr_utils import kubectl
+from tests.deploy.test_dgd import test_deployment as run_dgd_deployment_test
+
+pytestmark = [
+    pytest.mark.k8s,
+    pytest.mark.deploy,
+    pytest.mark.e2e,
+    pytest.mark.integration,
+    pytest.mark.nightly,
+    pytest.mark.gpu_0,
+    pytest.mark.timeout(3600),
+]
+
+_VARIANT_FILES = {
+    "profiler-v1beta1": "dgd-profiler-v1beta1.yaml",
+    "sweeper-aic": "dgd-sweeper-aic.yaml",
+    "sweeper-direct": "dgd-sweeper-direct.yaml",
+}
+_VARIANTS = {*_VARIANT_FILES, "recipe"}
+
+
+@dataclass(frozen=True)
+class SweeperDeploymentTarget:
+    """One generated or recipe DGD selected for live validation."""
+
+    case_name: str
+    hardware_name: str
+    variant: str
+    backend: str
+    deployment_mode: str
+    yaml_path: Path
+    gpu_count: int
+    gpu_sku: str
+    expected_failure: SuiteException | None = None
+
+    @property
+    def test_id(self) -> str:
+        return f"{self.hardware_name}-{self.case_name}-{self.variant}"
+
+
+def _selected_variants(value: str) -> list[str]:
+    variants = [item.strip() for item in value.split(",") if item.strip()]
+    unknown = sorted(set(variants) - _VARIANTS)
+    if unknown:
+        raise pytest.UsageError(
+            f"unknown --sweeper-variants value(s): {', '.join(unknown)}"
+        )
+    if not variants:
+        raise pytest.UsageError("--sweeper-variants must select at least one variant")
+    return variants
+
+
+def _discover_targets(
+    suite_path: Path,
+    output_root: Path,
+    variants: list[str],
+    discover_recipe_hardware: bool,
+) -> list[SweeperDeploymentTarget]:
+    targets = []
+    hardware_cache = {}
+    for entry in load_suite(suite_path):
+        if entry.status is not None and entry.status.status == "skipped":
+            continue
+        case = None
+        if not missing_case_inputs(entry.case):
+            if entry.hardware not in hardware_cache:
+                hardware_cache[entry.hardware] = load_hardware(entry.hardware)
+            case = load_case(
+                entry.case,
+                hardware_cache[entry.hardware],
+                output_root=output_root,
+            )
+        recipe = load_recipe(entry.case)
+        for variant in variants:
+            deploy_exception = entry.exception_for("deploy", variant)
+            if deploy_exception is not None and deploy_exception.status == "skipped":
+                continue
+            if variant == "recipe":
+                if recipe is None:
+                    continue
+                if not recipe.path.is_file():
+                    if deploy_exception is not None:
+                        continue
+                    raise pytest.UsageError(
+                        f"{entry.case}: recipe source is missing: {recipe.path}"
+                    )
+                requirement = recipe.requirements.get(entry.hardware)
+                if requirement is None and not discover_recipe_hardware:
+                    continue
+                yaml_path = recipe.path
+                recipe_gpus = (
+                    requirement.get("gpus") if isinstance(requirement, dict) else None
+                )
+                gpu_count = (
+                    recipe_gpus
+                    if isinstance(recipe_gpus, int)
+                    else recipe_gpu_count(recipe)
+                )
+                backend = _recipe_backend(recipe.source)
+                deployment_mode = _recipe_deployment_mode(recipe.source)
+            else:
+                if case is None:
+                    continue
+                yaml_path = case.generated_dir / _VARIANT_FILES[variant]
+                gpu_count = case.dgdr_input["hardware"]["totalGpus"]
+                backend = case.dgdr_input["backend"]
+                deployment_modes = case.sweeper_input["search_space"].get(
+                    "deployment_mode", ["agg"]
+                )
+                deployment_mode = (
+                    deployment_modes[0]
+                    if isinstance(deployment_modes, list) and deployment_modes
+                    else "agg"
+                )
+            if not yaml_path.is_file():
+                render_exception = entry.exception_for("render", variant)
+                if render_exception is None and variant.startswith("sweeper-"):
+                    render_exception = entry.exception_for("render", "sweeper")
+                if render_exception is not None:
+                    continue
+                raise pytest.UsageError(
+                    f"{entry.hardware}/{entry.case}: requested {variant} artifact is missing: "
+                    f"{yaml_path}"
+                )
+            targets.append(
+                SweeperDeploymentTarget(
+                    case_name=entry.case,
+                    hardware_name=entry.hardware,
+                    variant=variant,
+                    backend=backend,
+                    deployment_mode=deployment_mode,
+                    yaml_path=yaml_path,
+                    gpu_count=gpu_count,
+                    gpu_sku=entry.hardware,
+                    expected_failure=deploy_exception,
+                )
+            )
+    if not targets:
+        raise pytest.UsageError(f"{suite_path}: no eligible deployment targets")
+    return targets
+
+
+def _recipe_backend(source: str) -> str:
+    matches = [
+        name for name in ("vllm", "sglang", "trtllm") if name in Path(source).parts
+    ]
+    if len(matches) != 1:
+        raise pytest.UsageError(f"cannot determine recipe backend from {source!r}")
+    return matches[0]
+
+
+def _recipe_deployment_mode(source: str) -> str:
+    return (
+        "disagg"
+        if any(part.startswith("disagg") for part in Path(source).parts)
+        else "agg"
+    )
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    if "sweeper_deployment_target" not in metafunc.fixturenames:
+        return
+    suite_path = metafunc.config.getoption("--sweeper-suite", default=None)
+    if suite_path is None:
+        metafunc.parametrize(
+            "sweeper_deployment_target",
+            [
+                pytest.param(
+                    None, marks=pytest.mark.skip(reason="--sweeper-suite is required")
+                )
+            ],
+        )
+        return
+    output_root = metafunc.config.getoption(
+        "--sweeper-output-dir", default=None
+    ) or default_suite_output_root(suite_path)
+    targets = _discover_targets(
+        suite_path,
+        output_root,
+        _selected_variants(
+            metafunc.config.getoption(
+                "--sweeper-variants",
+                default=DEFAULT_SWEEPER_VARIANTS,
+            )
+        ),
+        metafunc.config.getoption("--sweeper-discover-recipe-hardware", default=False),
+    )
+    parameters = []
+    for target in targets:
+        marks = []
+        if (
+            target.expected_failure is not None
+            and target.expected_failure.status == "broken"
+        ):
+            marks.append(
+                pytest.mark.xfail(
+                    reason=target.expected_failure.describe(), strict=False
+                )
+            )
+        parameters.append(pytest.param(target, marks=marks, id=target.test_id))
+    metafunc.parametrize("sweeper_deployment_target", parameters)
+
+
+def _gpu_family(value: str) -> str:
+    normalized = value.lower().replace("-", "").replace("_", "").replace(" ", "")
+    for family in ("gb300", "gb200", "b300", "b200", "h200", "h100", "a100"):
+        if family in normalized:
+            return family
+    return normalized
+
+
+def _cluster_inventory() -> dict[str, Any]:
+    result = kubectl("get", "nodes", "-o", "json")
+    if result.returncode != 0:
+        return {"error": result.stderr.strip() or result.stdout.strip()}
+    payload = json.loads(result.stdout)
+    products: dict[str, dict[str, int]] = {}
+    for node in payload.get("items", []):
+        labels = node.get("metadata", {}).get("labels", {})
+        capacity = node.get("status", {}).get("capacity", {})
+        product = labels.get("nvidia.com/gpu.product") or labels.get(
+            "node.kubernetes.io/instance-type"
+        )
+        gpu_count = capacity.get("nvidia.com/gpu")
+        if not product or gpu_count is None:
+            continue
+        entry = products.setdefault(product, {"nodes": 0, "gpus": 0})
+        entry["nodes"] += 1
+        entry["gpus"] += int(gpu_count)
+    return {"gpuProducts": products}
+
+
+def _validate_cluster_hardware(
+    target: SweeperDeploymentTarget, inventory: dict[str, Any]
+) -> None:
+    products = inventory.get("gpuProducts")
+    if not isinstance(products, dict) or not products:
+        pytest.fail(f"could not detect cluster GPU inventory: {inventory}")
+    family = _gpu_family(target.gpu_sku)
+    compatible_gpus = sum(
+        details["gpus"]
+        for product, details in products.items()
+        if _gpu_family(product) == family
+    )
+    if compatible_gpus < target.gpu_count:
+        pytest.fail(
+            f"{target.test_id} requires {target.gpu_count} {target.gpu_sku} GPUs; "
+            f"detected {inventory}"
+        )
+
+
+def _replace_resource_names(value: Any, replacements: dict[str, str]) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _replace_resource_names(item, replacements)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_replace_resource_names(item, replacements) for item in value]
+    if isinstance(value, str):
+        return replacements.get(value, value)
+    return value
+
+
+def _write_recipe_discovery(target: SweeperDeploymentTarget) -> None:
+    recipe = load_recipe(target.case_name)
+    if recipe is None:
+        raise pytest.UsageError(
+            f"{target.case_name}: recipe.yaml disappeared during test"
+        )
+    write_discovered_recipe_requirement(
+        recipe,
+        target.hardware_name,
+        target.gpu_count,
+    )
+
+
+@pytest.fixture
+def prepared_deployment_path(
+    sweeper_deployment_target: SweeperDeploymentTarget | None,
+    namespace: str,
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+):
+    """Extract one DGD and apply uniquely named supporting resources."""
+    if sweeper_deployment_target is None:
+        yield None
+        return
+
+    documents = [
+        document
+        for document in yaml.safe_load_all(
+            sweeper_deployment_target.yaml_path.read_text()
+        )
+        if document
+    ]
+    dgds = [
+        document
+        for document in documents
+        if document.get("kind") == "DynamoGraphDeployment"
+    ]
+    if len(dgds) != 1:
+        pytest.fail(
+            f"{sweeper_deployment_target.yaml_path} must contain exactly one "
+            "DynamoGraphDeployment"
+        )
+    resources = [
+        document
+        for document in documents
+        if document.get("kind") != "DynamoGraphDeployment"
+    ]
+    digest = hashlib.sha1(
+        sweeper_deployment_target.test_id.encode(), usedforsecurity=False
+    ).hexdigest()[:8]
+    replacements = {}
+    for resource in resources:
+        metadata = resource.setdefault("metadata", {})
+        original_name = metadata["name"]
+        replacements[original_name] = f"{original_name[:54]}-{digest}"
+        metadata["name"] = replacements[original_name]
+        metadata["namespace"] = namespace
+    model_cache_pvc = request.config.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        replacements["model-cache"] = model_cache_pvc
+    resources = _replace_resource_names(resources, replacements)
+    dgd = _replace_resource_names(dgds[0], replacements)
+    prepared_path = tmp_path / sweeper_deployment_target.yaml_path.name
+    prepared_path.write_text(yaml.safe_dump(dgd, sort_keys=False))
+    if not resources or not namespace:
+        yield prepared_path
+        return
+    resource_yaml = yaml.safe_dump_all(resources, sort_keys=False)
+    applied = kubectl("apply", "-n", namespace, "-f", "-", input_=resource_yaml)
+    if applied.returncode != 0:
+        pytest.fail(
+            "failed to apply recipe resources: "
+            f"{applied.stderr.strip() or applied.stdout.strip()}"
+        )
+    try:
+        yield prepared_path
+    finally:
+        deleted = kubectl(
+            "delete",
+            "-n",
+            namespace,
+            "-f",
+            "-",
+            "--ignore-not-found",
+            input_=resource_yaml,
+        )
+        if deleted.returncode != 0:
+            pytest.fail(
+                "failed to delete recipe resources: "
+                f"{deleted.stderr.strip() or deleted.stdout.strip()}"
+            )
+
+
+async def test_sweeper_generated_dgd(
+    sweeper_deployment_target: SweeperDeploymentTarget | None,
+    image: str | None,
+    namespace: str,
+    skip_service_restart: bool,
+    request: pytest.FixtureRequest,
+    prepared_deployment_path: Path | None,
+) -> None:
+    """Deploy one selected DGD and validate readiness and inference."""
+    assert sweeper_deployment_target is not None
+    if not namespace:
+        pytest.skip("--namespace is required for live-cluster validation")
+    assert prepared_deployment_path is not None
+    _validate_cluster_hardware(sweeper_deployment_target, _cluster_inventory())
+    deployment_spec = DeploymentSpec(str(prepared_deployment_path))
+    deployment_spec.namespace = namespace
+    digest = hashlib.sha1(
+        sweeper_deployment_target.test_id.encode(), usedforsecurity=False
+    ).hexdigest()[:8]
+    deployment_spec.name = f"sweeper-{digest}"
+    if image:
+        deployment_spec.set_image(image)
+    model_cache_pvc = request.config.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        deployment_spec.mount_model_cache_pvc(
+            model_cache_pvc, request.config.getoption("--model-cache-mount")
+        )
+    target = DeploymentTarget(
+        yaml_path=sweeper_deployment_target.yaml_path,
+        framework=sweeper_deployment_target.backend,
+        profile=sweeper_deployment_target.deployment_mode,
+        source=f"sweeper:{sweeper_deployment_target.case_name}",
+    )
+    await run_dgd_deployment_test(
+        target, deployment_spec, namespace, skip_service_restart, request
+    )
+    if sweeper_deployment_target.variant == "recipe":
+        _write_recipe_discovery(sweeper_deployment_target)


### PR DESCRIPTION
## Summary

Stacked on #13765, this draft parks the installation and live-validation work that is intentionally outside the initial standalone Sweeper-to-DGD CLI scope.

- register the installed `dynamo-profiler-sweeper` console entrypoint;
- select generated v1beta1, Sweeper-AIC, Sweeper-direct, and Recipe DGDs from a comparison suite;
- validate hardware availability before deployment;
- reuse the existing DGD readiness and inference smoke test; and
- optionally propose discovered Recipe hardware requirements through `recipe.new.yaml`.

## Not ready yet

The live validator is not wired into a GitHub Actions workflow and has not been proven on its required hardware matrix. This PR remains a draft until we decide where it should run and validate at least one generated DGD end to end.

## Validation

- pre-commit hooks pass for all changed files

Depends on #13765.
