### PR TITLE
feat(sidecar): add KV-routing deploy examples

### DIFF
--- a/lib/sidecar/sglang/README.md
+++ b/lib/sidecar/sglang/README.md
@@ -62,8 +62,10 @@ same unified worker lifecycle as the standalone executable.
 ## Deploy on Kubernetes (quick start)
 
 `deploy/agg.yaml` runs an aggregated deployment (a frontend plus one worker pod
-that colocates the sidecar with an SGLang engine). `deploy/disagg.yaml` runs
-disaggregated prefill/decode with NIXL KV transfer.
+that colocates the sidecar with an SGLang engine). `deploy/agg_kv_router.yaml`
+runs two aggregated workers that publish ZMQ KV-cache events behind Dynamo's
+KV-aware router. `deploy/disagg.yaml` runs disaggregated prefill/decode with
+NIXL KV transfer.
 
 There is no published sidecar image yet, so build and push the image from
 `lib/sidecar/Dockerfile`. It contains all three engine-specific sidecar
@@ -78,9 +80,10 @@ command.
 ### Prerequisites
 
 - A Kubernetes cluster (**v1.29+**, or v1.28 with the `SidecarContainers` feature
-  gate) with the Dynamo operator and a GPU node (multiple GPUs plus an RDMA fabric
-  for `disagg.yaml`). The engine runs as a native sidecar (`initContainers` with
-  `restartPolicy: Always`), which requires that version.
+  gate) with the Dynamo operator and a GPU node (two GPUs for
+  `agg_kv_router.yaml`; multiple GPUs plus an RDMA fabric for `disagg.yaml`). The
+  engine runs as a native sidecar (`initContainers` with `restartPolicy:
+  Always`), which requires that version.
 - `kubectl` set to that cluster, and a namespace to deploy into.
 - A Hugging Face token for the model.
 - A container registry you can push to and the cluster can pull from.
@@ -101,8 +104,9 @@ build. These manifests set the container `command` to
 
 ### 2. Point the manifest at your image
 
-In `deploy/agg.yaml`, set the `main` worker image to the one you just pushed.
-If your registry is private, add `imagePullSecrets` to the worker pod spec.
+In `deploy/agg.yaml`, `deploy/agg_kv_router.yaml`, or `deploy/disagg.yaml`, set
+the `main` worker image to the one you just pushed. If your registry is private,
+add `imagePullSecrets` to the worker pod spec.
 
 ### 3. Create the Hugging Face token secret
 
@@ -133,6 +137,17 @@ curl -s localhost:8000/v1/models | jq .
 curl -s localhost:8000/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello"}],"max_tokens":32}' | jq .
+```
+
+### KV routing
+
+`deploy/agg_kv_router.yaml` runs two aggregated workers. Each SGLang engine
+publishes ZMQ KV-cache events, and its sidecar advertises the event source to
+the frontend for exact KV-aware routing.
+
+```bash
+kubectl apply -f lib/sidecar/sglang/deploy/agg_kv_router.yaml -n <namespace>
+kubectl port-forward -n <namespace> svc/sglang-sidecar-agg-kv-router-frontend 8000:8000
 ```
 
 ### Disaggregated

--- a/lib/sidecar/sglang/deploy/agg_kv_router.yaml
+++ b/lib/sidecar/sglang/deploy/agg_kv_router.yaml
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# EXPERIMENTAL. Aggregated SGLang sidecars behind Dynamo's KV-aware router.
+#
+# This deploys two worker pods. Each pod colocates:
+#   - main: the Dynamo worker (dynamo-sglang-sidecar), which discovers the
+#     engine's KV-event source over gRPC and registers it with Dynamo.
+#   - sglang-engine: the stock SGLang image. It holds one GPU and publishes
+#     KV-cache events over ZMQ for exact KV-aware routing.
+#
+# The gRPC listener is unauthenticated and plaintext, so SGLang binds it to pod
+# loopback. The ZMQ publisher binds all pod interfaces so the frontend can
+# subscribe to the pod IP advertised by SGLang's GetServerInfo RPC.
+#
+# There is no published sidecar image yet: build the image from
+# lib/sidecar/Dockerfile and set <your-registry> below (see README).
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-sidecar-agg-kv-router
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+  - name: SGLangWorker
+    type: worker
+    replicas: 2
+    podTemplate:
+      spec:
+        # sglang-engine as a native sidecar (initContainer, restartPolicy: Always):
+        # it starts before `main` and stops after it. Every replica can use the
+        # same ports because each engine runs in a separate pod network namespace.
+        initContainers:
+        - name: sglang-engine
+          image: lmsysorg/sglang:v0.5.17
+          restartPolicy: Always
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 5
+            timeoutSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              # Increase this value for larger models.
+              ephemeral-storage: 2Gi
+          command:
+          - python3
+          - -m
+          - sglang.launch_server
+          args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --host
+          - 127.0.0.1
+          - --port
+          - "30000"
+          - --grpc-port
+          - "30001"
+          - --incremental-streaming-output
+          - --page-size
+          - "16"
+          - --kv-events-config
+          - '{"publisher":"zmq","endpoint":"tcp://*:5557","topic":""}'
+        containers:
+        # No published image yet; build lib/sidecar/Dockerfile and set the
+        # registry below. Must be named "main" for operator injection.
+        - name: main
+          image: <your-registry>/dynamo-sidecar:1.3.0
+          command:
+          - dynamo-sglang-sidecar
+          args:
+          - --grpc-endpoint
+          - 127.0.0.1:30001
+          envFrom:
+          - secretRef:
+              name: hf-token-secret

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -141,8 +141,10 @@ and fidelity limits.
 ## Deploy on Kubernetes (quick start)
 
 `deploy/agg.yaml` runs an aggregated deployment (a frontend plus one worker pod
-that colocates the sidecar with a vLLM engine). `deploy/disagg.yaml` runs
-disaggregated prefill/decode with NIXL KV transfer.
+that colocates the sidecar with a vLLM engine). `deploy/agg_kv_router.yaml`
+runs two aggregated workers that publish ZMQ KV-cache events behind Dynamo's
+KV-aware router. `deploy/disagg.yaml` runs disaggregated prefill/decode with
+NIXL KV transfer.
 
 There is no published sidecar image yet, so build and push the image from
 `lib/sidecar/Dockerfile`. It contains the vLLM, SGLang, and TensorRT-LLM
@@ -154,9 +156,10 @@ The sidecar waits for both the Control and Inference services through the standa
 ### Prerequisites
 
 - A Kubernetes cluster (**v1.29+**, or v1.28 with the `SidecarContainers` feature
-  gate) with the Dynamo operator and a GPU node (multiple GPUs plus an RDMA fabric
-  for `disagg.yaml`). The engine runs as a native sidecar (`initContainers` with
-  `restartPolicy: Always`), which requires that version.
+  gate) with the Dynamo operator and a GPU node (two GPUs for
+  `agg_kv_router.yaml`; multiple GPUs plus an RDMA fabric for `disagg.yaml`). The
+  engine runs as a native sidecar (`initContainers` with `restartPolicy:
+  Always`), which requires that version.
 - `kubectl` set to that cluster, and a namespace to deploy into.
 - A Hugging Face token for the model.
 - A container registry you can push to and the cluster can pull from.
@@ -177,8 +180,9 @@ build. These manifests set the container `command` to
 
 ### 2. Point the manifest at your image
 
-In `deploy/agg.yaml` (and `deploy/disagg.yaml`), set the `main` worker image to
-the one you pushed. Add `imagePullSecrets` if your registry is private.
+In `deploy/agg.yaml`, `deploy/agg_kv_router.yaml`, or `deploy/disagg.yaml`, set
+the `main` worker image to the one you pushed. Add `imagePullSecrets` if your
+registry is private.
 
 ### 3. Create the Hugging Face token secret
 
@@ -209,6 +213,17 @@ curl -s localhost:8000/v1/models | jq .
 curl -s localhost:8000/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello"}],"max_tokens":32}' | jq .
+```
+
+### KV routing
+
+`deploy/agg_kv_router.yaml` runs two aggregated workers. Each vLLM engine
+publishes ZMQ KV-cache events, and its sidecar advertises the event source to
+the frontend for exact KV-aware routing.
+
+```bash
+kubectl apply -f lib/sidecar/vllm/deploy/agg_kv_router.yaml -n <namespace>
+kubectl port-forward -n <namespace> svc/vllm-sidecar-agg-kv-router-frontend 8000:8000
 ```
 
 ### Disaggregated

--- a/lib/sidecar/vllm/deploy/agg_kv_router.yaml
+++ b/lib/sidecar/vllm/deploy/agg_kv_router.yaml
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# EXPERIMENTAL. Aggregated vLLM sidecars behind Dynamo's KV-aware router.
+#
+# This deploys two worker pods. Each pod colocates:
+#   - main: the Dynamo worker (dynamo-vllm-sidecar), which discovers the engine's
+#     KV-event source over gRPC and registers it with Dynamo.
+#   - vllm-engine: the stock vLLM image running vllm-rs. It holds one GPU and
+#     publishes KV-cache events over ZMQ for exact KV-aware routing.
+#
+# The gRPC listener is unauthenticated and plaintext, so vllm-rs binds it to pod
+# loopback. The ZMQ publisher binds all pod interfaces so the frontend can
+# subscribe to the pod IP advertised by vLLM's Control service.
+#
+# There is no published sidecar image yet: build the image from
+# lib/sidecar/Dockerfile and set <your-registry> below (see README).
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-sidecar-agg-kv-router
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+  - name: VLLMWorker
+    type: worker
+    replicas: 2
+    podTemplate:
+      spec:
+        # vllm-engine as a native sidecar (initContainer, restartPolicy: Always):
+        # it starts before `main` and stops after it. Every replica can use the
+        # same ports because each engine runs in a separate pod network namespace.
+        initContainers:
+        - name: vllm-engine
+          image: vllm/vllm-openai:v0.28.0
+          restartPolicy: Always
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              # Increase this value for larger models.
+              ephemeral-storage: 2Gi
+          # Arguments after `--` are forwarded to the managed vLLM engine.
+          # The sidecar converts tcp://*:20080 into a frontend-reachable pod IP.
+          command:
+          - /bin/sh
+          - -c
+          - >-
+            exec "$(python3 -c 'import os,vllm; print(os.path.join(os.path.dirname(vllm.__file__), "vllm-rs"))')"
+            serve Qwen/Qwen3-0.6B --host 127.0.0.1 --grpc-port 50051 --
+            --block-size 64
+            --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+        containers:
+        # No published image yet; build lib/sidecar/Dockerfile and set the
+        # registry below. Must be named "main" for operator injection.
+        - name: main
+          image: <your-registry>/dynamo-sidecar:1.3.0
+          command:
+          - dynamo-vllm-sidecar
+          args:
+          - --grpc-endpoint
+          - 127.0.0.1:50051
+          envFrom:
+          - secretRef:
+              name: hf-token-secret


### PR DESCRIPTION
## Summary

- Add aggregated vLLM and SGLang sidecar DGD examples with two workers behind the KV-aware router.
- Configure backend-specific ZMQ KV-event publishing and KV block sizes so each sidecar can advertise exact KV state.
- Document prerequisites and deployment commands for both examples.

## Validation

- `SKIP=pytest-marker-report pre-commit run --files lib/sidecar/vllm/deploy/agg_kv_router.yaml lib/sidecar/sglang/deploy/agg_kv_router.yaml lib/sidecar/vllm/README.md lib/sidecar/sglang/README.md`
- `pre-commit run check-yaml --files lib/sidecar/vllm/deploy/agg_kv_router.yaml lib/sidecar/sglang/deploy/agg_kv_router.yaml`
- `git diff --check`

The full file-scoped pre-commit run passes all applicable checks except `pytest-marker-report`, which cannot collect the unrelated test suite because `/tmp/pytest_port_allocations.lock` is not writable in this environment. A live deployment was not run because it requires a Kubernetes GPU cluster and a published sidecar image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added experimental Kubernetes deployments for SGLang and vLLM with KV-cache-aware routing across two workers.
  - Added support for KV-cache event publishing and frontend routing for improved request placement.

- **Documentation**
  - Expanded Kubernetes quick-start guides with prerequisites, image configuration steps, deployment options, and commands for enabling KV-aware routing.
  - Clarified support for aggregated and disaggregated deployment patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->