### PR TITLE
feat(vllm): add sidecar KV-routing deploy examples

### DIFF
--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -219,7 +219,9 @@ curl -s localhost:8000/v1/chat/completions \
 
 The KV-routing manifests run multiple workers and configure each relevant vLLM
 engine to publish ZMQ KV-cache events on its pod IP. The sidecars advertise
-those event sources to the frontend for exact KV-aware routing.
+those event sources to the frontend for exact KV-aware routing. KV events
+contain token IDs and are unauthenticated, so restrict the routable ZMQ ports
+with NetworkPolicy.
 
 ```bash
 # Aggregated: two workers, two GPUs.

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -229,13 +229,22 @@ kubectl apply -f lib/sidecar/vllm/deploy/agg_kv_router.yaml -n <namespace>
 kubectl apply -f lib/sidecar/vllm/deploy/disagg_kv_router.yaml -n <namespace>
 ```
 
+After deploying one of the KV-routing manifests, port-forward its frontend:
+
+```bash
+# Aggregated.
+kubectl port-forward -n <namespace> svc/vllm-sidecar-agg-kv-router-frontend 8000:8000
+
+# Disaggregated.
+kubectl port-forward -n <namespace> svc/vllm-sidecar-disagg-kv-router-frontend 8000:8000
+```
+
 ### Disaggregated
 
 `deploy/disagg.yaml` runs prefill and decode as separate worker pods with NIXL
 KV transfer. It needs multiple GPUs and an RDMA fabric, and both worker pods
 must reach `2/2 Running`. `deploy/disagg_kv_router.yaml` uses two replicas per
-role and enables exact KV routing from the prefill event streams. Apply either
-manifest the same way and call its frontend as above.
+role and enables exact KV routing from the prefill event streams.
 
 ## Packaging
 

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -141,8 +141,11 @@ and fidelity limits.
 ## Deploy on Kubernetes (quick start)
 
 `deploy/agg.yaml` runs an aggregated deployment (a frontend plus one worker pod
-that colocates the sidecar with a vLLM engine). `deploy/disagg.yaml` runs
-disaggregated prefill/decode with NIXL KV transfer.
+that colocates the sidecar with a vLLM engine). `deploy/agg_kv_router.yaml`
+runs two aggregated workers behind Dynamo's KV-aware router.
+`deploy/disagg.yaml` runs disaggregated prefill/decode with NIXL KV transfer;
+`deploy/disagg_kv_router.yaml` expands it to two workers per role and publishes
+prefill KV-cache events for exact routing.
 
 There is no published sidecar image yet, so build and push the image from
 `lib/sidecar/Dockerfile`. It contains the vLLM, SGLang, and TensorRT-LLM
@@ -154,9 +157,10 @@ The sidecar waits for both the Control and Inference services through the standa
 ### Prerequisites
 
 - A Kubernetes cluster (**v1.29+**, or v1.28 with the `SidecarContainers` feature
-  gate) with the Dynamo operator and a GPU node (multiple GPUs plus an RDMA fabric
-  for `disagg.yaml`). The engine runs as a native sidecar (`initContainers` with
-  `restartPolicy: Always`), which requires that version.
+  gate) with the Dynamo operator and a GPU node (two GPUs for
+  `agg_kv_router.yaml`; two or four GPUs plus an RDMA fabric for `disagg.yaml` or
+  `disagg_kv_router.yaml`, respectively). The engine runs as a native sidecar
+  (`initContainers` with `restartPolicy: Always`), which requires that version.
 - `kubectl` set to that cluster, and a namespace to deploy into.
 - A Hugging Face token for the model.
 - A container registry you can push to and the cluster can pull from.
@@ -177,8 +181,8 @@ build. These manifests set the container `command` to
 
 ### 2. Point the manifest at your image
 
-In `deploy/agg.yaml` (and `deploy/disagg.yaml`), set the `main` worker image to
-the one you pushed. Add `imagePullSecrets` if your registry is private.
+In the selected manifest under `deploy/`, set the `main` worker image to the one
+you pushed. Add `imagePullSecrets` if your registry is private.
 
 ### 3. Create the Hugging Face token secret
 
@@ -211,11 +215,27 @@ curl -s localhost:8000/v1/chat/completions \
   -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello"}],"max_tokens":32}' | jq .
 ```
 
+### KV routing
+
+The KV-routing manifests run multiple workers and configure each relevant vLLM
+engine to publish ZMQ KV-cache events. The sidecars advertise those event
+sources to the frontend for exact KV-aware routing.
+
+```bash
+# Aggregated: two workers, two GPUs.
+kubectl apply -f lib/sidecar/vllm/deploy/agg_kv_router.yaml -n <namespace>
+
+# Disaggregated: two prefill + two decode workers, four GPUs and RDMA.
+kubectl apply -f lib/sidecar/vllm/deploy/disagg_kv_router.yaml -n <namespace>
+```
+
 ### Disaggregated
 
 `deploy/disagg.yaml` runs prefill and decode as separate worker pods with NIXL
 KV transfer. It needs multiple GPUs and an RDMA fabric, and both worker pods
-must reach `2/2 Running`. Apply it the same way and call the frontend as above.
+must reach `2/2 Running`. `deploy/disagg_kv_router.yaml` uses two replicas per
+role and enables exact KV routing from the prefill event streams. Apply either
+manifest the same way and call its frontend as above.
 
 ## Packaging
 

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -218,8 +218,8 @@ curl -s localhost:8000/v1/chat/completions \
 ### KV routing
 
 The KV-routing manifests run multiple workers and configure each relevant vLLM
-engine to publish ZMQ KV-cache events. The sidecars advertise those event
-sources to the frontend for exact KV-aware routing.
+engine to publish ZMQ KV-cache events on its pod IP. The sidecars advertise
+those event sources to the frontend for exact KV-aware routing.
 
 ```bash
 # Aggregated: two workers, two GPUs.

--- a/lib/sidecar/vllm/deploy/agg_kv_router.yaml
+++ b/lib/sidecar/vllm/deploy/agg_kv_router.yaml
@@ -11,7 +11,8 @@
 #
 # The unauthenticated gRPC listener stays on pod loopback. The ZMQ publisher
 # binds the pod IP injected by the downward API so the frontend can subscribe
-# to the endpoint advertised by vLLM's Control service.
+# to the endpoint advertised by vLLM's Control service. KV events contain token
+# IDs and are unauthenticated; restrict the ZMQ port with NetworkPolicy.
 #
 # There is no published sidecar image yet: build the image from
 # lib/sidecar/Dockerfile and set <your-registry> below (see README).

--- a/lib/sidecar/vllm/deploy/agg_kv_router.yaml
+++ b/lib/sidecar/vllm/deploy/agg_kv_router.yaml
@@ -9,9 +9,9 @@
 #   - vllm-engine: the stock vLLM image running vllm-rs. It holds one GPU and
 #     publishes KV-cache events over ZMQ for exact KV-aware routing.
 #
-# The gRPC listener is unauthenticated and plaintext, so vllm-rs binds it to pod
-# loopback. The ZMQ publisher binds all pod interfaces so the frontend can
-# subscribe to the pod IP advertised by vLLM's Control service.
+# The unauthenticated gRPC listener stays on pod loopback. The ZMQ publisher
+# binds the pod IP injected by the downward API so the frontend can subscribe
+# to the endpoint advertised by vLLM's Control service.
 #
 # There is no published sidecar image yet: build the image from
 # lib/sidecar/Dockerfile and set <your-registry> below (see README).
@@ -63,6 +63,11 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+          env:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           envFrom:
           - secretRef:
               name: hf-token-secret
@@ -73,7 +78,6 @@ spec:
               # Increase this value for larger models.
               ephemeral-storage: 2Gi
           # Arguments after `--` are forwarded to the managed vLLM engine.
-          # The sidecar converts tcp://*:20080 into a frontend-reachable pod IP.
           command:
           - /bin/sh
           - -c
@@ -81,7 +85,7 @@ spec:
             exec "$(python3 -c 'import os,vllm; print(os.path.join(os.path.dirname(vllm.__file__), "vllm-rs"))')"
             serve Qwen/Qwen3-0.6B --host 127.0.0.1 --grpc-port 50051 --
             --block-size 64
-            --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+            --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://${POD_IP}:20080\",\"enable_kv_cache_events\":true}"
         containers:
         # No published image yet; build lib/sidecar/Dockerfile and set the
         # registry below. Must be named "main" for operator injection.

--- a/lib/sidecar/vllm/deploy/agg_kv_router.yaml
+++ b/lib/sidecar/vllm/deploy/agg_kv_router.yaml
@@ -68,6 +68,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: PYTHONHASHSEED
+            value: "0"
           envFrom:
           - secretRef:
               name: hf-token-secret
@@ -87,8 +89,7 @@ spec:
             --block-size 64
             --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://${POD_IP}:20080\",\"enable_kv_cache_events\":true}"
         containers:
-        # No published image yet; build lib/sidecar/Dockerfile and set the
-        # registry below. Must be named "main" for operator injection.
+        # Must be named "main" for operator injection.
         - name: main
           image: <your-registry>/dynamo-sidecar:1.3.0
           command:

--- a/lib/sidecar/vllm/deploy/agg_kv_router.yaml
+++ b/lib/sidecar/vllm/deploy/agg_kv_router.yaml
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# EXPERIMENTAL. Aggregated vLLM sidecars behind Dynamo's KV-aware router.
+#
+# This deploys two worker pods. Each pod colocates:
+#   - main: the Dynamo worker (dynamo-vllm-sidecar), which discovers the engine's
+#     KV-event source over gRPC and registers it with Dynamo.
+#   - vllm-engine: the stock vLLM image running vllm-rs. It holds one GPU and
+#     publishes KV-cache events over ZMQ for exact KV-aware routing.
+#
+# The gRPC listener is unauthenticated and plaintext, so vllm-rs binds it to pod
+# loopback. The ZMQ publisher binds all pod interfaces so the frontend can
+# subscribe to the pod IP advertised by vLLM's Control service.
+#
+# There is no published sidecar image yet: build the image from
+# lib/sidecar/Dockerfile and set <your-registry> below (see README).
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-sidecar-agg-kv-router
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+  - name: VLLMWorker
+    type: worker
+    replicas: 2
+    podTemplate:
+      spec:
+        # vllm-engine as a native sidecar (initContainer, restartPolicy: Always):
+        # it starts before `main` and stops after it. Every replica can use the
+        # same ports because each engine runs in a separate pod network namespace.
+        initContainers:
+        - name: vllm-engine
+          image: vllm/vllm-openai:v0.28.0
+          restartPolicy: Always
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              # Increase this value for larger models.
+              ephemeral-storage: 2Gi
+          # Arguments after `--` are forwarded to the managed vLLM engine.
+          # The sidecar converts tcp://*:20080 into a frontend-reachable pod IP.
+          command:
+          - /bin/sh
+          - -c
+          - >-
+            exec "$(python3 -c 'import os,vllm; print(os.path.join(os.path.dirname(vllm.__file__), "vllm-rs"))')"
+            serve Qwen/Qwen3-0.6B --host 127.0.0.1 --grpc-port 50051 --
+            --block-size 64
+            --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+        containers:
+        # No published image yet; build lib/sidecar/Dockerfile and set the
+        # registry below. Must be named "main" for operator injection.
+        - name: main
+          image: <your-registry>/dynamo-sidecar:1.3.0
+          command:
+          - dynamo-vllm-sidecar
+          args:
+          - --grpc-endpoint
+          - 127.0.0.1:50051
+          envFrom:
+          - secretRef:
+              name: hf-token-secret

--- a/lib/sidecar/vllm/deploy/disagg_kv_router.yaml
+++ b/lib/sidecar/vllm/deploy/disagg_kv_router.yaml
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# EXPERIMENTAL. Disaggregated vLLM sidecars behind Dynamo's KV-aware router.
+#
+# This deploys two prefill and two decode worker pods. Each pod colocates the
+# Rust sidecar with a stock vLLM engine. Prefill engines publish KV-cache events
+# over ZMQ so the frontend can route requests to cached prefixes before handing
+# the resulting KV cache to a decode engine over NIXL/RDMA.
+#
+# kv_role is kv_producer on prefill and kv_consumer on decode (kv_both is
+# deprecated for NixlConnector). Decode engines use the same KV block size but
+# do not publish events, matching the local disaggregated KV-router launcher.
+#
+# PREREQUISITES / CAVEATS:
+#   - Needs a sidecar built from lib/sidecar/Dockerfile that carries the
+#     disaggregation fixes (component-by-role + NIXL port encoding).
+#   - RDMA/NIXL: the engine needs rdma/ib devices, IPC_LOCK/SYS_RESOURCE, pinned
+#     memory (ulimit -l unlimited), and UCX tuning; adjust for your fabric.
+#   - VLLM_NIXL_SIDE_CHANNEL_HOST must be a routable pod IP (set via downward API).
+#   - No published sidecar image yet; set <your-registry> below.
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-sidecar-disagg-kv-router
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+
+  - name: VLLMPrefillWorker
+    type: worker
+    replicas: 2
+    podTemplate:
+      spec:
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        initContainers:
+        - name: vllm-engine
+          image: vllm/vllm-openai:v0.28.0
+          restartPolicy: Always
+          securityContext:
+            runAsUser: 0
+            capabilities:
+              add: ["IPC_LOCK", "SYS_RESOURCE"]
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          env:
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: UCX_TLS
+            value: rc_x,rc,cuda_copy,cuda_ipc
+          - name: UCX_NET_DEVICES
+            value: mlx5_0:1
+          - name: UCX_IB_ADDR_TYPE
+            value: eth
+          - name: UCX_RNDV_SCHEME
+            value: get_zcopy
+          - name: UCX_RNDV_THRESH
+            value: "0"
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+            requests:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+              ephemeral-storage: 2Gi
+          volumeMounts:
+          - name: dshm
+            mountPath: /dev/shm
+          # The sidecar resolves the wildcard KV-event host to this pod's IP.
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            VLLM_RS="$(python3 -c 'import os,vllm; print(os.path.join(os.path.dirname(vllm.__file__), "vllm-rs"))')"
+            ulimit -l unlimited && exec "$VLLM_RS" serve Qwen/Qwen3-0.6B \
+              --host 127.0.0.1 --grpc-port 50051 -- \
+              --block-size 64 \
+              --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}' \
+              --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+        containers:
+        - name: main
+          image: <your-registry>/dynamo-sidecar:1.3.0
+          command:
+          - dynamo-vllm-sidecar
+          args:
+          - --grpc-endpoint
+          - 127.0.0.1:50051
+          - --disaggregation-mode
+          - prefill
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+
+  - name: VLLMDecodeWorker
+    type: worker
+    replicas: 2
+    podTemplate:
+      spec:
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        initContainers:
+        - name: vllm-engine
+          image: vllm/vllm-openai:v0.28.0
+          restartPolicy: Always
+          securityContext:
+            runAsUser: 0
+            capabilities:
+              add: ["IPC_LOCK", "SYS_RESOURCE"]
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          env:
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: UCX_TLS
+            value: rc_x,rc,cuda_copy,cuda_ipc
+          - name: UCX_NET_DEVICES
+            value: mlx5_0:1
+          - name: UCX_IB_ADDR_TYPE
+            value: eth
+          - name: UCX_RNDV_SCHEME
+            value: get_zcopy
+          - name: UCX_RNDV_THRESH
+            value: "0"
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+            requests:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+              ephemeral-storage: 2Gi
+          volumeMounts:
+          - name: dshm
+            mountPath: /dev/shm
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            VLLM_RS="$(python3 -c 'import os,vllm; print(os.path.join(os.path.dirname(vllm.__file__), "vllm-rs"))')"
+            ulimit -l unlimited && exec "$VLLM_RS" serve Qwen/Qwen3-0.6B \
+              --host 127.0.0.1 --grpc-port 50051 -- \
+              --block-size 64 \
+              --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
+        containers:
+        - name: main
+          image: <your-registry>/dynamo-sidecar:1.3.0
+          command:
+          - dynamo-vllm-sidecar
+          args:
+          - --grpc-endpoint
+          - 127.0.0.1:50051
+          - --disaggregation-mode
+          - decode
+          envFrom:
+          - secretRef:
+              name: hf-token-secret

--- a/lib/sidecar/vllm/deploy/disagg_kv_router.yaml
+++ b/lib/sidecar/vllm/deploy/disagg_kv_router.yaml
@@ -13,8 +13,8 @@
 # do not publish events, matching the local disaggregated KV-router launcher.
 #
 # PREREQUISITES / CAVEATS:
-#   - Needs a sidecar built from lib/sidecar/Dockerfile that carries the
-#     disaggregation fixes (component-by-role + NIXL port encoding).
+#   - Build the sidecar from the same Dynamo revision as this manifest; older
+#     builds can lack component-by-role routing and NIXL port encoding.
 #   - RDMA/NIXL: the engine needs rdma/ib devices, IPC_LOCK/SYS_RESOURCE, pinned
 #     memory (ulimit -l unlimited), and UCX tuning; adjust for your fabric.
 #   - VLLM_NIXL_SIDE_CHANNEL_HOST must be a routable pod IP (set via downward API).
@@ -79,6 +79,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: PYTHONHASHSEED
+            value: "0"
           - name: VLLM_NIXL_SIDE_CHANNEL_HOST
             valueFrom:
               fieldRef:

--- a/lib/sidecar/vllm/deploy/disagg_kv_router.yaml
+++ b/lib/sidecar/vllm/deploy/disagg_kv_router.yaml
@@ -18,6 +18,8 @@
 #   - RDMA/NIXL: the engine needs rdma/ib devices, IPC_LOCK/SYS_RESOURCE, pinned
 #     memory (ulimit -l unlimited), and UCX tuning; adjust for your fabric.
 #   - VLLM_NIXL_SIDE_CHANNEL_HOST must be a routable pod IP (set via downward API).
+#   - KV events contain token IDs and are unauthenticated; restrict the routable
+#     ZMQ port with NetworkPolicy.
 #   - No published sidecar image yet; set <your-registry> below.
 
 apiVersion: nvidia.com/v1beta1

--- a/lib/sidecar/vllm/deploy/disagg_kv_router.yaml
+++ b/lib/sidecar/vllm/deploy/disagg_kv_router.yaml
@@ -75,6 +75,10 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 3
           env:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           - name: VLLM_NIXL_SIDE_CHANNEL_HOST
             valueFrom:
               fieldRef:
@@ -103,7 +107,6 @@ spec:
           volumeMounts:
           - name: dshm
             mountPath: /dev/shm
-          # The sidecar resolves the wildcard KV-event host to this pod's IP.
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -112,7 +115,7 @@ spec:
               --host 127.0.0.1 --grpc-port 50051 -- \
               --block-size 64 \
               --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}' \
-              --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+              --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://${POD_IP}:20080\",\"enable_kv_cache_events\":true}"
         containers:
         - name: main
           image: <your-registry>/dynamo-sidecar:1.3.0


### PR DESCRIPTION
## Overview:

### Summary

Adds experimental aggregated and disaggregated vLLM sidecar DynamoGraphDeployment examples with exact KV-aware routing.

## Details:

- Adds `lib/sidecar/vllm/deploy/agg_kv_router.yaml` with two aggregated vLLM workers, deterministic KV block hashes, and pod-routable ZMQ KV events.
- Adds `lib/sidecar/vllm/deploy/disagg_kv_router.yaml` with two prefill and two decode workers, NIXL/RDMA transfer, deterministic hashes on event publishers, and KV events from prefill workers.
- Keeps the unauthenticated engine gRPC endpoint on pod loopback and documents NetworkPolicy protection for routable, unauthenticated KV-event ports.
- Updates `lib/sidecar/vllm/README.md` with prerequisites, deployment commands, and the exact frontend service names for both topologies.

## Where should the reviewer start?

1. `lib/sidecar/vllm/deploy/agg_kv_router.yaml`
2. `lib/sidecar/vllm/deploy/disagg_kv_router.yaml`
3. `lib/sidecar/vllm/README.md`

## Validation:

- `SKIP=pytest-marker-report pre-commit run --files lib/sidecar/vllm/deploy/agg_kv_router.yaml lib/sidecar/vllm/deploy/disagg_kv_router.yaml lib/sidecar/vllm/README.md`
- `pre-commit run check-yaml --files lib/sidecar/vllm/deploy/agg_kv_router.yaml lib/sidecar/vllm/deploy/disagg_kv_router.yaml`
- `git diff --check`
- A live deployment was not run because it requires a Kubernetes GPU cluster, RDMA for disaggregation, and a built sidecar image.
- The repository-wide `pytest-marker-report` hook is skipped because the unrelated `/tmp/pytest_port_allocations.lock` is not writable in this environment.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
