### PR TITLE
feat(sglang): add sidecar KV-routing deploy examples

### DIFF
--- a/lib/sidecar/sglang/README.md
+++ b/lib/sidecar/sglang/README.md
@@ -62,8 +62,11 @@ same unified worker lifecycle as the standalone executable.
 ## Deploy on Kubernetes (quick start)
 
 `deploy/agg.yaml` runs an aggregated deployment (a frontend plus one worker pod
-that colocates the sidecar with an SGLang engine). `deploy/disagg.yaml` runs
-disaggregated prefill/decode with NIXL KV transfer.
+that colocates the sidecar with an SGLang engine). `deploy/agg_kv_router.yaml`
+runs two aggregated workers behind Dynamo's KV-aware router.
+`deploy/disagg.yaml` runs disaggregated prefill/decode with NIXL KV transfer;
+`deploy/disagg_kv_router.yaml` expands it to two workers per role and publishes
+KV-cache events for exact routing.
 
 There is no published sidecar image yet, so build and push the image from
 `lib/sidecar/Dockerfile`. It contains all three engine-specific sidecar
@@ -78,9 +81,10 @@ command.
 ### Prerequisites
 
 - A Kubernetes cluster (**v1.29+**, or v1.28 with the `SidecarContainers` feature
-  gate) with the Dynamo operator and a GPU node (multiple GPUs plus an RDMA fabric
-  for `disagg.yaml`). The engine runs as a native sidecar (`initContainers` with
-  `restartPolicy: Always`), which requires that version.
+  gate) with the Dynamo operator and a GPU node (two GPUs for
+  `agg_kv_router.yaml`; two or four GPUs plus an RDMA fabric for `disagg.yaml` or
+  `disagg_kv_router.yaml`, respectively). The engine runs as a native sidecar
+  (`initContainers` with `restartPolicy: Always`), which requires that version.
 - `kubectl` set to that cluster, and a namespace to deploy into.
 - A Hugging Face token for the model.
 - A container registry you can push to and the cluster can pull from.
@@ -101,8 +105,9 @@ build. These manifests set the container `command` to
 
 ### 2. Point the manifest at your image
 
-In `deploy/agg.yaml`, set the `main` worker image to the one you just pushed.
-If your registry is private, add `imagePullSecrets` to the worker pod spec.
+In the selected manifest under `deploy/`, set the `main` worker image to the one
+you just pushed. If your registry is private, add `imagePullSecrets` to the
+worker pod spec.
 
 ### 3. Create the Hugging Face token secret
 
@@ -135,8 +140,24 @@ curl -s localhost:8000/v1/chat/completions \
   -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello"}],"max_tokens":32}' | jq .
 ```
 
+### KV routing
+
+The KV-routing manifests run multiple workers and configure each SGLang engine
+to publish ZMQ KV-cache events on its pod IP. The sidecars advertise those
+event sources to the frontend for exact KV-aware routing.
+
+```bash
+# Aggregated: two workers, two GPUs.
+kubectl apply -f lib/sidecar/sglang/deploy/agg_kv_router.yaml -n <namespace>
+
+# Disaggregated: two prefill + two decode workers, four GPUs and RDMA.
+kubectl apply -f lib/sidecar/sglang/deploy/disagg_kv_router.yaml -n <namespace>
+```
+
 ### Disaggregated
 
 `deploy/disagg.yaml` runs prefill and decode as separate worker pods that hand
 off KV cache over a bootstrap server + NIXL. It needs multiple GPUs and an RDMA
 fabric, and both worker pods must reach `2/2 Running`.
+`deploy/disagg_kv_router.yaml` uses two replicas per role and enables exact KV
+routing from all four event streams.

--- a/lib/sidecar/sglang/README.md
+++ b/lib/sidecar/sglang/README.md
@@ -75,8 +75,9 @@ command.
 
 > [!NOTE]
 > The engine image must be a stock SGLang **v0.5.16+** build: the native gRPC
-> server (`--grpc-port`) landed there. The deployment examples use
-> `lmsysorg/sglang:v0.5.17`, matching Dynamo main's SGLang pin.
+> server (`--grpc-port`) landed there. The KV-routing examples require
+> **v0.5.18+** because the sidecar discovers their structured KV-event
+> descriptor through `GetServerInfo`. They use `lmsysorg/sglang:v0.5.18`.
 
 ### Prerequisites
 
@@ -143,8 +144,10 @@ curl -s localhost:8000/v1/chat/completions \
 ### KV routing
 
 The KV-routing manifests run multiple workers and configure each SGLang engine
-to publish ZMQ KV-cache events on its pod IP. The sidecars advertise those
-event sources to the frontend for exact KV-aware routing.
+to publish ZMQ KV-cache events on all pod interfaces. Each sidecar connects to
+the engine over its pod IP and advertises that routable address to the frontend
+for exact KV-aware routing. Restrict the unauthenticated gRPC and ZMQ ports with
+NetworkPolicy.
 
 ```bash
 # Aggregated: two workers, two GPUs.
@@ -152,6 +155,16 @@ kubectl apply -f lib/sidecar/sglang/deploy/agg_kv_router.yaml -n <namespace>
 
 # Disaggregated: two prefill + two decode workers, four GPUs and RDMA.
 kubectl apply -f lib/sidecar/sglang/deploy/disagg_kv_router.yaml -n <namespace>
+```
+
+After deploying one of the KV-routing manifests, port-forward its frontend:
+
+```bash
+# Aggregated.
+kubectl port-forward -n <namespace> svc/sglang-sidecar-agg-kv-router-frontend 8000:8000
+
+# Disaggregated.
+kubectl port-forward -n <namespace> svc/sglang-sidecar-disagg-kv-router-frontend 8000:8000
 ```
 
 ### Disaggregated

--- a/lib/sidecar/sglang/deploy/agg_kv_router.yaml
+++ b/lib/sidecar/sglang/deploy/agg_kv_router.yaml
@@ -9,9 +9,9 @@
 #   - sglang-engine: the stock SGLang image. It holds one GPU and publishes
 #     KV-cache events over ZMQ for exact KV-aware routing.
 #
-# The unauthenticated gRPC listener stays on pod loopback. The ZMQ publisher
-# binds the pod IP injected by the downward API so the frontend can subscribe
-# to the endpoint advertised by SGLang's GetServerInfo RPC.
+# SGLang binds its unauthenticated gRPC and ZMQ listeners on the pod network.
+# The sidecar connects over the downward-API pod IP so it can replace the ZMQ
+# wildcard with that routable address. Restrict both ports with NetworkPolicy.
 #
 # There is no published sidecar image yet: build the image from
 # lib/sidecar/Dockerfile and set <your-registry> below (see README).
@@ -42,7 +42,7 @@ spec:
         # separate pod network namespace.
         initContainers:
         - name: sglang-engine
-          image: lmsysorg/sglang:v0.5.17
+          image: lmsysorg/sglang:v0.5.18
           restartPolicy: Always
           startupProbe:
             exec:
@@ -62,11 +62,6 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 3
-          env:
-          - name: POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
           envFrom:
           - secretRef:
               name: hf-token-secret
@@ -83,7 +78,7 @@ spec:
           - --model-path
           - Qwen/Qwen3-0.6B
           - --host
-          - 127.0.0.1
+          - 0.0.0.0
           - --port
           - "30000"
           - --grpc-port
@@ -92,7 +87,7 @@ spec:
           - --page-size
           - "16"
           - --kv-events-config
-          - '{"publisher":"zmq","endpoint":"tcp://$(POD_IP):5557","topic":""}'
+          - '{"publisher":"zmq","endpoint":"tcp://*:5557","topic":""}'
         containers:
         - name: main
           image: <your-registry>/dynamo-sidecar:1.3.0
@@ -100,7 +95,12 @@ spec:
           - dynamo-sglang-sidecar
           args:
           - --grpc-endpoint
-          - 127.0.0.1:30001
+          - $(POD_IP):30001
+          env:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           envFrom:
           - secretRef:
               name: hf-token-secret

--- a/lib/sidecar/sglang/deploy/agg_kv_router.yaml
+++ b/lib/sidecar/sglang/deploy/agg_kv_router.yaml
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# EXPERIMENTAL. Aggregated SGLang sidecars behind Dynamo's KV-aware router.
+#
+# This deploys two worker pods. Each pod colocates:
+#   - main: the Dynamo worker (dynamo-sglang-sidecar), which discovers the
+#     engine's KV-event source over gRPC and registers it with Dynamo.
+#   - sglang-engine: the stock SGLang image. It holds one GPU and publishes
+#     KV-cache events over ZMQ for exact KV-aware routing.
+#
+# The unauthenticated gRPC listener stays on pod loopback. The ZMQ publisher
+# binds the pod IP injected by the downward API so the frontend can subscribe
+# to the endpoint advertised by SGLang's GetServerInfo RPC.
+#
+# There is no published sidecar image yet: build the image from
+# lib/sidecar/Dockerfile and set <your-registry> below (see README).
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-sidecar-agg-kv-router
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+  - name: SGLangWorker
+    type: worker
+    replicas: 2
+    podTemplate:
+      spec:
+        # Every replica can use the same ports because each engine runs in a
+        # separate pod network namespace.
+        initContainers:
+        - name: sglang-engine
+          image: lmsysorg/sglang:v0.5.17
+          restartPolicy: Always
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 5
+            timeoutSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          env:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              ephemeral-storage: 2Gi
+          command:
+          - python3
+          - -m
+          - sglang.launch_server
+          args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --host
+          - 127.0.0.1
+          - --port
+          - "30000"
+          - --grpc-port
+          - "30001"
+          - --incremental-streaming-output
+          - --page-size
+          - "16"
+          - --kv-events-config
+          - '{"publisher":"zmq","endpoint":"tcp://$(POD_IP):5557","topic":""}'
+        containers:
+        - name: main
+          image: <your-registry>/dynamo-sidecar:1.3.0
+          command:
+          - dynamo-sglang-sidecar
+          args:
+          - --grpc-endpoint
+          - 127.0.0.1:30001
+          envFrom:
+          - secretRef:
+              name: hf-token-secret

--- a/lib/sidecar/sglang/deploy/disagg_kv_router.yaml
+++ b/lib/sidecar/sglang/deploy/disagg_kv_router.yaml
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# EXPERIMENTAL. Disaggregated SGLang sidecars behind Dynamo's KV-aware router.
+#
+# This deploys two prefill and two decode worker pods. Each pod colocates the
+# Rust sidecar with a stock SGLang engine. All engines publish KV-cache events
+# over ZMQ, matching the local SGLang disaggregated KV-router launcher. KV cache
+# moves from prefill to decode over NIXL/RDMA.
+#
+# SGLang binds 0.0.0.0 so its bootstrap server is reachable across pods. The
+# native gRPC service is therefore also exposed on the pod network; restrict it
+# with NetworkPolicy. ZMQ publishers bind the downward-API pod IP so the
+# frontend can reach the event endpoints advertised by GetServerInfo.
+#
+# PREREQUISITES / CAVEATS:
+#   - RDMA/NIXL: engines need rdma/ib devices, IPC_LOCK, and shared memory; tune
+#     UCX for your fabric.
+#   - Model, served model name, page size, and TP must match across both roles.
+#   - No published sidecar image yet; build lib/sidecar/Dockerfile and set
+#     <your-registry> below.
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-sidecar-disagg-kv-router
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+
+  - name: SGLangPrefillWorker
+    type: worker
+    replicas: 2
+    podTemplate:
+      spec:
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        initContainers:
+        - name: sglang-engine
+          image: lmsysorg/sglang:v0.5.17
+          restartPolicy: Always
+          securityContext:
+            capabilities:
+              add: ["IPC_LOCK"]
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 5
+            timeoutSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          env:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+            requests:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+              ephemeral-storage: 2Gi
+          volumeMounts:
+          - name: dshm
+            mountPath: /dev/shm
+          command:
+          - python3
+          - -m
+          - sglang.launch_server
+          args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --host
+          - 0.0.0.0
+          - --port
+          - "30000"
+          - --grpc-port
+          - "30001"
+          - --incremental-streaming-output
+          - --disaggregation-mode
+          - prefill
+          - --disaggregation-bootstrap-port
+          - "8998"
+          - --disaggregation-transfer-backend
+          - nixl
+          - --page-size
+          - "64"
+          - --kv-events-config
+          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://$(POD_IP):5557"}'
+        containers:
+        - name: main
+          image: <your-registry>/dynamo-sidecar:1.3.0
+          command:
+          - dynamo-sglang-sidecar
+          args:
+          - --grpc-endpoint
+          - 127.0.0.1:30001
+          env:
+          - name: SGLANG_DISAGGREGATION_BOOTSTRAP_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+
+  - name: SGLangDecodeWorker
+    type: worker
+    replicas: 2
+    podTemplate:
+      spec:
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        initContainers:
+        - name: sglang-engine
+          image: lmsysorg/sglang:v0.5.17
+          restartPolicy: Always
+          securityContext:
+            capabilities:
+              add: ["IPC_LOCK"]
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 5
+            timeoutSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          env:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+            requests:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+              ephemeral-storage: 2Gi
+          volumeMounts:
+          - name: dshm
+            mountPath: /dev/shm
+          command:
+          - python3
+          - -m
+          - sglang.launch_server
+          args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --host
+          - 0.0.0.0
+          - --port
+          - "30000"
+          - --grpc-port
+          - "30001"
+          - --incremental-streaming-output
+          - --disaggregation-mode
+          - decode
+          - --disaggregation-bootstrap-port
+          - "8998"
+          - --disaggregation-transfer-backend
+          - nixl
+          - --page-size
+          - "64"
+          - --kv-events-config
+          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://$(POD_IP):5557"}'
+        containers:
+        - name: main
+          image: <your-registry>/dynamo-sidecar:1.3.0
+          command:
+          - dynamo-sglang-sidecar
+          args:
+          - --grpc-endpoint
+          - 127.0.0.1:30001
+          envFrom:
+          - secretRef:
+              name: hf-token-secret

--- a/lib/sidecar/sglang/deploy/disagg_kv_router.yaml
+++ b/lib/sidecar/sglang/deploy/disagg_kv_router.yaml
@@ -10,8 +10,8 @@
 #
 # SGLang binds 0.0.0.0 so its bootstrap server is reachable across pods. The
 # native gRPC service is therefore also exposed on the pod network; restrict it
-# with NetworkPolicy. ZMQ publishers bind the downward-API pod IP so the
-# frontend can reach the event endpoints advertised by GetServerInfo.
+# with NetworkPolicy. ZMQ publishers bind all pod interfaces, and each sidecar
+# connects over its pod IP so GetServerInfo's wildcard becomes routable.
 #
 # PREREQUISITES / CAVEATS:
 #   - RDMA/NIXL: engines need rdma/ib devices, IPC_LOCK, and shared memory; tune
@@ -50,7 +50,7 @@ spec:
             sizeLimit: 10Gi
         initContainers:
         - name: sglang-engine
-          image: lmsysorg/sglang:v0.5.17
+          image: lmsysorg/sglang:v0.5.18
           restartPolicy: Always
           securityContext:
             capabilities:
@@ -73,11 +73,6 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 3
-          env:
-          - name: POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
           envFrom:
           - secretRef:
               name: hf-token-secret
@@ -115,7 +110,7 @@ spec:
           - --page-size
           - "64"
           - --kv-events-config
-          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://$(POD_IP):5557"}'
+          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'
         containers:
         - name: main
           image: <your-registry>/dynamo-sidecar:1.3.0
@@ -123,8 +118,12 @@ spec:
           - dynamo-sglang-sidecar
           args:
           - --grpc-endpoint
-          - 127.0.0.1:30001
+          - $(POD_IP):30001
           env:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           - name: SGLANG_DISAGGREGATION_BOOTSTRAP_HOST
             valueFrom:
               fieldRef:
@@ -145,7 +144,7 @@ spec:
             sizeLimit: 10Gi
         initContainers:
         - name: sglang-engine
-          image: lmsysorg/sglang:v0.5.17
+          image: lmsysorg/sglang:v0.5.18
           restartPolicy: Always
           securityContext:
             capabilities:
@@ -168,11 +167,6 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 3
-          env:
-          - name: POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
           envFrom:
           - secretRef:
               name: hf-token-secret
@@ -210,7 +204,7 @@ spec:
           - --page-size
           - "64"
           - --kv-events-config
-          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://$(POD_IP):5557"}'
+          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'
         containers:
         - name: main
           image: <your-registry>/dynamo-sidecar:1.3.0
@@ -218,7 +212,12 @@ spec:
           - dynamo-sglang-sidecar
           args:
           - --grpc-endpoint
-          - 127.0.0.1:30001
+          - $(POD_IP):30001
+          env:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           envFrom:
           - secretRef:
               name: hf-token-secret


### PR DESCRIPTION
## Overview:

### Summary

Adds experimental aggregated and disaggregated SGLang sidecar DynamoGraphDeployment examples with exact KV-aware routing.

## Details:

- Adds `lib/sidecar/sglang/deploy/agg_kv_router.yaml` with two aggregated SGLang workers behind the KV-aware frontend.
- Adds `lib/sidecar/sglang/deploy/disagg_kv_router.yaml` with two prefill and two decode workers, NIXL/RDMA transfer, and KV events from all four engines.
- Uses SGLang v0.5.18, the first pinned version whose native gRPC `GetServerInfo` reports the structured KV-event descriptor required by the sidecar.
- Uses wildcard ZMQ bind endpoints and pod-IP gRPC authorities so the sidecars advertise routable event sources, with NetworkPolicy guidance for the exposed unauthenticated listeners.
- Updates `lib/sidecar/sglang/README.md` with version requirements, prerequisites, deployment commands, and exact frontend service names.

## Where should the reviewer start?

1. `lib/sidecar/sglang/deploy/agg_kv_router.yaml`
2. `lib/sidecar/sglang/deploy/disagg_kv_router.yaml`
3. `lib/sidecar/sglang/README.md`

## Validation:

- `SKIP=pytest-marker-report pre-commit run --files lib/sidecar/sglang/deploy/agg_kv_router.yaml lib/sidecar/sglang/deploy/disagg_kv_router.yaml lib/sidecar/sglang/README.md`
- `pre-commit run check-yaml --files lib/sidecar/sglang/deploy/agg_kv_router.yaml lib/sidecar/sglang/deploy/disagg_kv_router.yaml`
- `git diff --check`
- A live deployment was not run because it requires a Kubernetes GPU cluster, RDMA for disaggregation, and a built sidecar image.
- The repository-wide `pytest-marker-report` hook is skipped because the unrelated `/tmp/pytest_port_allocations.lock` is not writable in this environment.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
