### PR TITLE
test(operator): stop pinning encoding/json's incidental struct name

### DIFF
--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
@@ -1926,7 +1926,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					`{"spec":{"template":{"topologyConstraint":{"pack":"rack"}}}}`,
 				)
 			}),
-			wantWebhookErrs: []string{`spec.providerOverride.value: Invalid value: null: does not match the registered PodCliqueSet schema: json: cannot unmarshal string into Go struct field TopologyConstraint.spec.template.topologyConstraint.pack of type v1alpha1.TopologyPackConstraint`},
+			wantWebhookErrs: []string{`spec.providerOverride.value: Invalid value: null: does not match the registered PodCliqueSet schema: json: cannot unmarshal string into Go struct field .spec.template.topologyConstraint.pack of type v1alpha1.TopologyPackConstraint`},
 		},
 		{
 			name: "typed and provider-native Grove topology cannot be combined",

--- a/deploy/operator/internal/webhook/validation/suite_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/suite_envtest_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -481,6 +482,17 @@ func expectedAdmissionErrors(t *testing.T, test admissionTestCase) []string {
 	return test.wantWebhookErrors
 }
 
+// goStructFieldType matches the leading Go type name encoding/json reports in
+// a nested UnmarshalTypeError, such as "PodCliqueSet" in "Go struct field
+// PodCliqueSet.spec.template.topologyConstraint.pack". That leading type is
+// the outermost struct passed to json.Unmarshal, not the struct that
+// declares the erroring field: it stays constant across every nesting depth,
+// so it carries no information a field-path assertion does not already
+// carry. Go 1.27 also changed which unqualified type name lands there for a
+// pointer-typed nested field, so pinning it ties this assertion to a Go
+// toolchain minor version the module does not otherwise require.
+var goStructFieldType = regexp.MustCompile(`Go struct field \S+?\.`)
+
 func assertAdmissionErrors(t *testing.T, err error, want []string, notWant string) {
 	t.Helper()
 	if len(want) == 0 {
@@ -513,6 +525,7 @@ func assertAdmissionErrors(t *testing.T, err error, want []string, notWant strin
 		}
 		message := strings.Replace(cause.Message, `Invalid value: "object": `, "Invalid value: ", 1)
 		message = strings.Replace(message, `Invalid value: "array": `, "Invalid value: ", 1)
+		message = goStructFieldType.ReplaceAllString(message, "Go struct field .")
 		got = append(got, fmt.Sprintf("%s: %s", cause.Field, message))
 	}
 	if !slices.Equal(got, want) {


### PR DESCRIPTION
## Overview:

Stop asserting an `encoding/json` implementation detail in a webhook
validation test, so `make envtest`/`make test` doesn't spuriously fail under
a Go 1.27 toolchain even though `go.mod` only requires `go 1.26.6`.

## Details:

`assertAdmissionErrors` in `suite_envtest_test.go` already normalizes two
incidental substrings (`Invalid value: "object": ` / `"array": `) before
comparing rendered error messages. This adds the same kind of normalization
for the leading Go struct type name `json.UnmarshalTypeError` prints ahead
of the field path (`Go struct field <Type>.spec...`) — that type is always
the outermost struct passed to `json.Unmarshal`, so it carries no
information the field path doesn't already carry, and which unqualified
type name Go picks there for a pointer-typed nested field changed between
1.26.x and 1.27.0.

**Validation — negative control, the test fails without the fix:**
Reverting only the two changed test files (production code untouched) and
re-running the one affected subtest under a Go 1.27.0 toolchain:

```
without the fix: 0 passed, 1 failed
with the fix:    1 passed, 0 failed
```

- Re-ran the full `internal/webhook/validation` package under both Go 1.26.6
  and Go 1.27.0 after the fix: both `ok`, no other test affected. No
  behavior change to `internal/provideroverride` — this is a test-only
  assertion fix.
- `go vet ./internal/webhook/validation/...` and `gofmt -l` clean.

## Where should the reviewer start?

`suite_envtest_test.go`'s `assertAdmissionErrors` (the new `goStructFieldType`
normalization) and the one updated expectation in
`dynamographdeployment_validation_envtest_test.go`.

## Related Issues

**🔗 This PR is linked to an issue:**
- Closes #14128


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation tests to match revised JSON unmarshalling error messages.
  * Improved admission error assertions to remain consistent across Go toolchains.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->