### PR TITLE
fix(pre-deployment): stop set -e from swallowing invalid architecture retry

### DIFF
--- a/deploy/pre-deployment/nixl/build_and_deploy.sh
+++ b/deploy/pre-deployment/nixl/build_and_deploy.sh
@@ -305,8 +305,7 @@ main() {
             continue
         fi
 
-        SELECTED_ARCH=$(validate_architecture "$arch_input")
-        if [ $? -eq 0 ]; then
+        if SELECTED_ARCH=$(validate_architecture "$arch_input"); then
             break
         else
             echo "Error: Invalid architecture. Please select 1, 2, x86_64, or aarch64"

--- a/deploy/pre-deployment/nixl/test_build_and_deploy_arch_retry.sh
+++ b/deploy/pre-deployment/nixl/test_build_and_deploy_arch_retry.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Regression test for the architecture-selection prompt in build_and_deploy.sh.
+#
+# An invalid answer must produce the script's own "Error: Invalid architecture"
+# message and let the user retry, per prompt_for_steps/validate_architecture's
+# documented contract. Under `set -euo pipefail`, a bare `VAR=$(fn)` assignment
+# whose command substitution returns non-zero terminates the shell immediately
+# -- before the `if [ $? -eq 0 ]` check that prints the retry message ever
+# runs -- so a single typo at that prompt silently kills the whole script.
+#
+# No test framework is used anywhere in this repo for shell scripts, so this
+# is a plain, self-contained bash script matching the style already used for
+# `tests/**/run_*_test.sh`.
+
+set -uo pipefail # not -e: we need to observe the target script's own exit code
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${SCRIPT_DIR}/build_and_deploy.sh"
+
+FAKEBIN="$(mktemp -d)"
+trap 'rm -rf "$FAKEBIN"' EXIT
+for tool in wget unzip kubectl docker; do
+  printf '#!/bin/bash\nexit 0\n' >"$FAKEBIN/$tool"
+  chmod +x "$FAKEBIN/$tool"
+done
+
+# A single invalid architecture answer at the first prompt.
+OUTPUT=$(printf 'not-a-real-arch\n' | PATH="$FAKEBIN:$PATH" timeout 10 bash "$TARGET" 2>&1)
+
+if grep -q 'Error: Invalid architecture' <<<"$OUTPUT"; then
+  echo "1 passed, 0 failed"
+  echo "PASS: invalid architecture input produced the documented retry error"
+  exit 0
+else
+  echo "0 passed, 1 failed"
+  echo "FAIL: invalid architecture input silently killed the script instead of"
+  echo "      printing 'Error: Invalid architecture...' and retrying. Observed output:"
+  echo "$OUTPUT"
+  exit 1
+fi


### PR DESCRIPTION
## Overview:

Stop `set -e` from swallowing the invalid-architecture retry in
`deploy/pre-deployment/nixl/build_and_deploy.sh`.

## Details:

The architecture prompt in `main()`'s selection loop assigned the
validator's result as a bare
`SELECTED_ARCH=$(validate_architecture "$arch_input")` statement and checked
`$?` on the next line. Under this script's own `set -euo pipefail`, a bare
assignment whose command substitution returns non-zero terminates the shell
immediately — before the `if [ $? -eq 0 ]` check that prints `Error: Invalid
architecture...` and loops back ever runs. Any typo at that prompt silently
killed the whole script instead of the documented retry.

Folds the assignment into the `if` condition itself
(`if SELECTED_ARCH=$(validate_architecture "$arch_input"); then`), matching
every other validation check already in this same file (`if !
command_exists wget`, `if ! check_docker_daemon`, etc.), which is exempt
from `-e` by definition. No other behavior changes.

**Validation — negative control, the test fails without the fix:**
Added `test_build_and_deploy_arch_retry.sh`, which drives the real script
end-to-end (stubbed `wget`/`unzip`/`kubectl`/`docker` on `PATH`, an invalid
architecture on stdin) and asserts the retry message is printed. Reverting
only `build_and_deploy.sh` (test file untouched) and re-running:

```
without the fix: 0 passed, 1 failed
with the fix:    1 passed, 0 failed
```

Also manually verified the happy path is unaffected: a valid architecture
(`x86_64`) still proceeds through the steps/registry/confirm prompts exactly
as before.

## Where should the reviewer start?

The one-line change in `main()`'s architecture-selection loop;
`test_build_and_deploy_arch_retry.sh` documents the exact failure mode it
fixes.

## Related Issues

**🔗 This PR is linked to an issue:**
- Closes #14132


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid architecture selections during deployment validation.
  * Ensures users receive a clear “Error: Invalid architecture” message instead of unexpected retry behavior.

* **Tests**
  * Added regression coverage to verify invalid architecture input is handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->