### PR TITLE
fix(replay): reject a planner profile .npz that does not exist

### DIFF
--- a/components/src/dynamo/replay/config.py
+++ b/components/src/dynamo/replay/config.py
@@ -36,7 +36,11 @@ def resolve_planner_profile_data(
 ) -> PlannerProfileDataResult:
     if planner_profile_data is None:
         return SimpleNamespace(npz_path=None)
-    if planner_profile_data.suffix == ".npz":
+    # Only short-circuit a file that is actually there. The suffix alone used to
+    # be enough, which skipped the mocker resolver -- the one thing that checks
+    # the path exists -- so a mistyped .npz was accepted here and rejected by
+    # the same input under dynamo.mocker.
+    if planner_profile_data.suffix == ".npz" and planner_profile_data.is_file():
         return SimpleNamespace(npz_path=planner_profile_data)
     return _resolve_mocker_planner_profile_data(planner_profile_data)
 

--- a/components/src/dynamo/replay/config.py
+++ b/components/src/dynamo/replay/config.py
@@ -36,10 +36,8 @@ def resolve_planner_profile_data(
 ) -> PlannerProfileDataResult:
     if planner_profile_data is None:
         return SimpleNamespace(npz_path=None)
-    # Only short-circuit a file that is actually there. The suffix alone used to
-    # be enough, which skipped the mocker resolver -- the one thing that checks
-    # the path exists -- so a mistyped .npz was accepted here and rejected by
-    # the same input under dynamo.mocker.
+    # Only short-circuit a file that is actually there: the mocker resolver is
+    # the one step that checks the path exists.
     if planner_profile_data.suffix == ".npz" and planner_profile_data.is_file():
         return SimpleNamespace(npz_path=planner_profile_data)
     return _resolve_mocker_planner_profile_data(planner_profile_data)

--- a/components/src/dynamo/replay/tests/test_config.py
+++ b/components/src/dynamo/replay/tests/test_config.py
@@ -1,0 +1,37 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from dynamo.replay.config import resolve_planner_profile_data
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+]
+
+
+def test_an_existing_npz_is_used_directly(tmp_path: Path) -> None:
+    npz = tmp_path / "profile.npz"
+    npz.write_bytes(b"not really an npz, only its presence matters here")
+
+    assert resolve_planner_profile_data(npz).npz_path == npz
+
+
+def test_a_missing_npz_is_rejected_rather_than_accepted_on_its_suffix(
+    tmp_path: Path,
+) -> None:
+    """The mocker resolver is the only step that checks the path exists.
+
+    Short-circuiting on the suffix skipped it, so a mistyped .npz was accepted
+    here and rejected by the same input under dynamo.mocker.
+    """
+    with pytest.raises(FileNotFoundError):
+        resolve_planner_profile_data(tmp_path / "typo.npz")
+
+
+def test_no_planner_profile_data_stays_none() -> None:
+    assert resolve_planner_profile_data(None).npz_path is None


### PR DESCRIPTION
## Summary

`resolve_planner_profile_data` in `dynamo/replay/config.py` short-circuits on the file suffix:

```python
if planner_profile_data.suffix == ".npz":
    return SimpleNamespace(npz_path=planner_profile_data)
return _resolve_mocker_planner_profile_data(planner_profile_data)
```

The path is never opened, so a `.npz` that does not exist is accepted and carried forward as profile data.

What makes it worth fixing rather than tolerating is that the branch it skips is the one that validates. `dynamo.mocker`'s resolver starts with `is_mocker_format_npz`, whose first line is `path.is_file()`, and a path matching nothing raises `FileNotFoundError` naming the formats it accepts. So the identical mistyped path is rejected under `dynamo.mocker` and accepted under `dynamo.replay`.

Fixed by short-circuiting only when the file is actually there. A missing `.npz` now falls through to the mocker resolver and picks up its existing diagnostic, rather than inventing a second error message for the same condition.

This supersedes #13863, which I opened against `dynamo/replay/main.py`. #13665 removed that file when it landed the unified AISimulate CLI, and moved this function to `config.py` with the short-circuit intact, so the defect survived the rewrite in a new location. I am closing #13863 in favour of this.

## Validation

Exercised the real function, before and after, in a temp directory:

| input | before | after |
|---|---|---|
| `nope.npz` (does not exist) | accepted, `npz_path=/tmp/.../nope.npz` | `FileNotFoundError: Path '...' is neither a mocker-format NPZ file nor a valid profiler results directory` |
| a real mocker-format `.npz` | `npz_path=real.npz` | `npz_path=real.npz` |

So the missing-file case flips and the existing-file case is untouched.

One caveat I want to be straight about. The prebuilt `dynamo._core.abi3.so` in this checkout predates `main`'s `LoadThresholdConfig`, and rebuilding it here fails (the machine runs out of disk, and `rustc` is then OOM-killed on `dynamo-llm`). To import `dynamo.replay.config` at all I stubbed that one missing symbol onto `dynamo._core` before importing. Nothing under test touches it, and the function exercised is the real one from this branch, but I could not run the `replay` pytest suite end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of planner profile paths.
  * Invalid or nonexistent `.npz` paths are now checked instead of being accepted automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->