### PR TITLE
feat(recipes): add Nemotron 3.5 Lightning RTX PRO 6000 aggregate DSpark recipe

### DIFF
--- a/recipes/nemotron-3.5-lightning/perf/README.md
+++ b/recipes/nemotron-3.5-lightning/perf/README.md
@@ -66,3 +66,17 @@ The following table contains BF16 rows for B200 and GB200 recipes.
 | BF16 | `trtllm/agg-b200-mtp-bf16/deploy.yaml` | TensorRT-LLM | agg | B200 | Single worker | MTP | 3 | 2.874 | 18 | 3541 | 3411 | 130 | 244.95 | 3295.50 | 183.08 |
 | BF16 | `trtllm/agg-gb200-bf16/deploy.yaml` | TensorRT-LLM | agg | GB200 | Single worker | None | 0 | 0.0 | 18 | 3541 | 3411 | 130 | 216.77 | 1985.84 | 110.32 |
 | BF16 | `trtllm/agg-gb200-mtp-bf16/deploy.yaml` | TensorRT-LLM | agg | GB200 | Single worker | MTP | 3 | 2.874 | 18 | 3541 | 3411 | 130 | 231.34 | 3556.40 | 197.58 |
+
+### RTX PRO 6000
+
+| Precision | Recipe | FW | Mode | GPU | Routing | Spec method | Spec tok | Synthetic AL | Concurrency | Requests | Valid requests | Errors | TTFT p50 (ms) | Output tok/s/GPU | Tok/s/user |
+|----------|--------|----|------|-----|---------|-------------|----------|--------------|-------------|----------|----------------|--------|---------------|------------------|------------|
+| NVFP4 | `vllm/agg-rtxpro6000-dspark/deploy.yaml` | vLLM | agg | RTX PRO 6000 | Single worker | DSpark | 7 | n/m | 20 | 3541 | 3526 | 15 | 542.50 | 776.03 | 53.42 |
+
+`Synthetic AL` is `n/m` (not measured): the value in the manifest is inherited from the H100
+recipe and was not re-derived on sm_120. This row shows 15 errors rather than 130 because the
+deployment resolves `max_seq_len` to 1048576, so the long trace requests that exceed a
+262144-token context on the other SKUs completed here.
+
+RTX PRO 6000 is single-node only (PCIe, no NVLink) and uses NVFP4 rather than the BF16 weights
+used on B200 and GB200; BF16 measured 3.3x slower on sm_120.

--- a/recipes/nemotron-3.5-lightning/vllm/README.md
+++ b/recipes/nemotron-3.5-lightning/vllm/README.md
@@ -7,7 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 
 Dynamo vLLM recipes for Nemotron 3.5 Lightning. H100 and H200 use
 `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4`, while B200 and GB200 use
-`nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16`. Aggregate and
+`nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16`. RTX PRO 6000 (sm_120) uses NVFP4:
+BF16 measured 3.3x slower there, the opposite of the B200 result, because decode is
+memory-bandwidth-bound and RTX PRO 6000 uses GDDR7 rather than HBM. Aggregate and
 disaggregated configurations are available as explained below.
 
 ## Configurations
@@ -18,6 +20,7 @@ disaggregated configurations are available as explained below.
 | H200 | `agg-h200-{mtp,dflash,dspark}` | `disagg-h200-{dflash,dspark}` | UCX over IB/RDMA |
 | B200 | `agg-b200-{mtp,dspark}-bf16` | `disagg-b200-dspark-bf16` | UCX over IB/RDMA |
 | GB200 | `agg-gb200-{mtp,dspark}-bf16` | `disagg-gb200-{dflash,dspark}-bf16` | UCX/NIXL, cluster-specific fabric resources |
+| RTX PRO 6000 | `agg-rtxpro6000-dspark` | -- | Single-node only (PCIe, no NVLink) |
 
 B200 and GB200 directories use BF16 weights and include a `-bf16` suffix, for
 example `agg-b200-dspark-bf16` and `disagg-gb200-dspark-bf16`.

--- a/recipes/nemotron-3.5-lightning/vllm/agg-rtxpro6000-dspark/deploy.yaml
+++ b/recipes/nemotron-3.5-lightning/vllm/agg-rtxpro6000-dspark/deploy.yaml
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated vLLM deployment for Nemotron 3.5 Lightning NVFP4 on 1x RTX PRO 6000 Blackwell with DSpark speculative decoding.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vllm-agg-rtxpro6000-dspark-config
+data:
+  speculative-config: |-
+    {
+      "method": "dspark",
+      "model": "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark",
+      "num_speculative_tokens": 7,
+      "attention_backend": "TRITON_ATTN"
+    }
+  speculative-config-synthetic: |-
+    {
+      "method": "dspark",
+      "model": "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark",
+      "num_speculative_tokens": 7,
+      "rejection_sample_method": "synthetic",
+      "synthetic_acceptance_length": 3.69,
+      "attention_backend": "TRITON_ATTN"
+    }
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-agg-rtxpro6000-dspark
+  labels:
+    app.kubernetes.io/name: vllm-agg-rtxpro6000-dspark
+    app.kubernetes.io/part-of: dynamo
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          imagePullSecrets:
+            - name: your-image-pull-secret
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-nemotron-3.5-lightning-dev.1
+              imagePullPolicy: IfNotPresent
+              command:
+                - python3
+              args:
+                - -m
+                - dynamo.frontend
+                - --trust-remote-code
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: DYN_HTTP_BODY_LIMIT_MB
+                  value: "200"
+                - name: HF_HOME
+                  value: /model-cache
+                - name: HF_HUB_OFFLINE
+                  value: "1"
+                - name: HF_MODULES_CACHE
+                  value: /tmp/hf_modules
+              resources: {}
+              startupProbe:
+                httpGet:
+                  path: /health
+                  port: 8000
+                periodSeconds: 10
+                timeoutSeconds: 60
+                failureThreshold: 60
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /model-cache
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+
+    - name: agg
+      type: worker
+      replicas: 1
+      sharedMemorySize: 40Gi
+      podTemplate:
+        spec:
+          imagePullSecrets:
+            - name: your-image-pull-secret
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: dshm
+              emptyDir:
+                medium: Memory
+                sizeLimit: 40Gi
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-nemotron-3.5-lightning-dev.1
+              imagePullPolicy: IfNotPresent
+              workingDir: /workspace/
+              command:
+                - python3
+                - -m
+                - dynamo.vllm
+              args:
+                - --model
+                - nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4
+                - --served-model-name
+                - nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4
+                - --trust-remote-code
+                - --tensor-parallel-size
+                - "1"
+                - --max-num-seqs
+                - "512"
+                - --max-num-batched-tokens
+                - "32768"
+                - --enable-prefix-caching
+                - --async-scheduling
+                - --mamba-backend
+                - flashinfer
+                - --mamba-ssm-cache-dtype
+                - float16
+                - --mamba-cache-mode
+                - align
+                - --enable-mamba-cache-stochastic-rounding
+                - --mamba-cache-philox-rounds
+                - "5"
+                - --dyn-tool-call-parser
+                - nemotron_nano
+                - --dyn-reasoning-parser
+                - nemotron_nano
+                - --reasoning-parser
+                - nemotron_v3
+                - --speculative-config=$(SPECULATIVE_CONFIG)
+                - --disaggregation-mode
+                - agg
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: HF_HUB_OFFLINE
+                  value: "1"
+                - name: HF_MODULES_CACHE
+                  value: /tmp/hf_modules
+                - name: TRITON_CACHE_DIR
+                  value: /tmp/.triton-cache
+                - name: VLLM_CONFIG_ROOT
+                  value: /tmp/vllm-config
+                - name: VLLM_CACHE_ROOT
+                  value: /tmp/vllm-cache
+                - name: SPECULATIVE_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: vllm-agg-rtxpro6000-dspark-config
+                      key: speculative-config # speculative-config-synthetic for benchmarking
+                - name: NCCL_IB_DISABLE
+                  value: "1"
+                - name: PYTHONHASHSEED
+                  value: "0"
+              resources:
+                requests:
+                  memory: 128Gi
+                  nvidia.com/gpu: "1"
+                limits:
+                  nvidia.com/gpu: "1"
+              securityContext:
+                runAsUser: 0
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_RESOURCE
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 30
+                timeoutSeconds: 20
+                failureThreshold: 120
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /model-cache
+                - name: dshm
+                  mountPath: /dev/shm


### PR DESCRIPTION
## Overview

Adds `agg-rtxpro6000-dspark` — the first RTX PRO 6000 Blackwell (sm_120) variant in the
Nemotron 3.5 Lightning family. Existing variants cover H100, H200, B200, and GB200 only.

Derived from `agg-h100-dspark`. Six lines changed: node selector, DGD name, label, ConfigMap
name and reference, header comment. **No engine flags touched.**

```
NEW  recipes/nemotron-3.5-lightning/vllm/agg-rtxpro6000-dspark/deploy.yaml
MOD  recipes/nemotron-3.5-lightning/vllm/README.md    (+5)
MOD  recipes/nemotron-3.5-lightning/perf/README.md   (+14)
```

## Results

Benchmarked on the family's shared trace
(`64k_400_90kv_agent_new_noschedule_short_15perc.jsonl`) at concurrency 20 with 3,541
requests — the same shape as the published H100 DSpark row.

| Recipe | Conc | Valid | Err | Output tok/s/GPU | User tok/s p50 | TTFT p50 |
|---|---|---|---|---|---|---|
| `agg-h100-dspark` | 20 | 3,411 | 130 | 1,878 | 93.9 | 239 ms |
| `agg-b200-dspark-bf16` | 24 | 3,411 | 130 | 2,471 | 103.0 | 207 ms |
| **`agg-rtxpro6000-dspark`** | **20** | **3,526** | **15** | **776** | **53.4** | **543 ms** |

~41% of H100 throughput, consistent with the GDDR7-vs-HBM3 bandwidth ratio for a
decode-bound workload.

Two notes on comparability, both also in `perf/README.md`:

- **15 errors rather than 130.** This deployment resolves `max_seq_len` to 1048576, so the
  long trace requests that exceed a 262144-token context on the other SKUs completed here.
- **`Synthetic AL` is `n/m`.** The manifest inherits 3.69 from the H100 recipe; I did not
  re-derive it on sm_120. Affects synthetic benchmarking runs only, not serving.

## Why NVFP4 rather than BF16

B200 and GB200 moved to BF16 in #13370. That result does not transfer to sm_120. Measured on
identical hardware, same trace, cold cache, only the checkpoint differing:

| | NVFP4 | BF16 |
|---|---|---|
| Output tok/s | **252** | 76 |
| User tok/s p50 | **85** | 24 |
| ITL p50 | **11.8 ms** | 41.2 ms |
| TTFT p50 | 11,227 ms | 11,547 ms |

TTFT is unchanged — prefill is compute-bound and precision-insensitive. Inter-token latency
is 3.5× worse under BF16 because decode is memory-bandwidth-bound and BF16 weights are 4×
larger. RTX PRO 6000 uses GDDR7 rather than HBM, so weight size dominates decode in a way it
does not on B200.

DSpark was also measured against DFlash on the same hardware: 1.86× throughput, better on
every metric.

## Best-practices compliance

Checked against `nim-turbo-recipe-best-practices` (MR !7).

**Passes:** v1beta1, no internal cluster references, no taints/tolerations, no hardcoded
namespace, 2-space indentation, user/group 0, `IPC_LOCK` capabilities, frontend 1 replica,
`imagePullPolicy: IfNotPresent`, same image across frontend and workers, commented
synthetic-AL block present.

**Deviations, all inherited from `agg-h100-dspark` and identical across the family:** node
affinity for GPU type, explicit probes, `imagePullSecrets`, unpinned image digest, frontend
mounting `model-cache`, no `DYN_ROUTER_MODE`, `sharedMemorySize: 40Gi` vs 64Gi, no
ephemeral-disk or CPU requests, and the family's `vllm-agg-<sku>-<specdec>` naming.

I matched the siblings rather than diverge from them; happy to conform whenever the family
does.

One note for whoever owns the standard, not a blocker here: rule 4 (no GPU-type node affinity
in the base recipe) is currently the only thing distinguishing SKU variants in this family —
`agg-h100-dspark` and `agg-h200-dspark` differ by six lines, of which one is the node label.
Worth a decision at some point for SKU-differentiated families.

**Not included:** `perf/perf.yaml` (no sibling in this family ships one) and Fern docs (happy
to write one, would need the pattern).

## Testing

Deployed and benchmarked on AWS `g7e.8xlarge` (1× RTX PRO 6000 Blackwell, 96 GB, 32 vCPU,
256 GiB), single-node Kubernetes, Dynamo Platform 1.3.0. Smoke-tested via
`/v1/chat/completions`, then the full shared-trace run above. Raw aiperf exports available.
