### PR TITLE
docs(simulation): backport unified AISimulate CLI docs to 1.5.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,7 @@ Sibling repositories this repo integrates with:
 |------|------|
 | [NIXL](https://github.com/ai-dynamo/nixl) | High-throughput inference data-transfer library (KV-cache transfer over RDMA/NVLink) that underpins disaggregated serving |
 | [AIPerf](https://github.com/ai-dynamo/aiperf) | Benchmarking and load-generation tool used by the benchmarking guides |
-| [AIConfigurator](https://github.com/ai-dynamo/aiconfigurator) | Simulates thousands of deployment configs to find an optimal serving config before spending GPU-hours |
+| [AISimulate](https://pypi.org/project/aisimulate/) | Predicts serving behavior and searches deployment configurations offline without requiring a GPU cluster |
 | [ModelExpress](https://github.com/ai-dynamo/modelexpress) | Streams model weights GPU-to-GPU via NIXL for fast replica cold-start |
 | [Grove](https://github.com/ai-dynamo/grove) | Kubernetes operator for topology-aware gang scheduling |
 

--- a/README.md
+++ b/README.md
@@ -103,12 +103,12 @@ Most inference engines optimize a single GPU or a single node. Dynamo is the **o
 | [**ModelExpress**](https://github.com/ai-dynamo/modelexpress) | Streams model weights GPU-to-GPU via NIXL/NVLink | 7x faster cold-start for new replicas |
 | [**Planner**](https://docs.nvidia.com/dynamo/components/planner/planner-guide) | SLA-driven autoscaler that profiles workloads and right-sizes pools | Meets latency targets at minimum total cost of ownership (TCO) |
 | [**Grove**](https://github.com/ai-dynamo/grove) | K8s operator for topology-aware gang scheduling (NVL72) | Places workloads optimally across racks, hosts, and NUMA nodes |
-| [**AIConfigurator**](https://github.com/ai-dynamo/aiconfigurator) | Simulates 10K+ deployment configs in seconds | Finds optimal serving config without burning GPU-hours |
+| [**AISimulate**](https://pypi.org/project/aisimulate/) | Predicts serving behavior and searches deployment configurations offline | Finds a strong serving configuration without bringing up a GPU cluster |
 | [**Fault Tolerance**](https://docs.nvidia.com/dynamo/user-guides/fault-tolerance/request-migration) | Canary health checks + in-flight request migration | Workers fail; user requests don't |
 
 ### New in 1.0
 
-- **Zero-config deploy ([DGDR](https://docs.nvidia.com/dynamo/kubernetes-deployment/deploy-models/dgdr-reference))** *(beta):* Specify model, HW, and SLA in one YAML — AIConfigurator auto-profiles the workload, Planner optimizes the topology, and Dynamo deploys
+- **Zero-config deploy ([DGDR](https://docs.nvidia.com/dynamo/kubernetes-deployment/deploy-models/dgdr-reference))** *(beta):* Specify model, HW, and SLA in one YAML — AISimulate performance models estimate candidate configurations, Planner optimizes the topology, and Dynamo deploys
 - **Agentic inference:** Per-request hints for priority, expected output length, and speculative prefill, plus session metadata for tracing and SGLang subagent KV isolation. [LangChain](https://docs.langchain.com/oss/python/integrations/chat/nvidia_ai_endpoints#use-with-nvidia-dynamo) + [NeMo Agent Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit) integrations
 - **Multimodal E/P/D:** Disaggregated encode/prefill/decode with embedding cache — 30% faster TTFT on image workloads
 - **Video generation:** Native [FastVideo](https://github.com/hao-ai-lab/FastVideo) + [SGLang Diffusion](https://lmsys.org/blog/2026-02-16-sglang-diffusion-advanced-optimizations/) support — real-time 1080p on single B200

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -95,12 +95,12 @@ limitations under the License.
 | [**ModelExpress**](https://github.com/ai-dynamo/modelexpress) | 通过 NIXL/NVLink 在 GPU 之间流式传输模型权重 | 新副本冷启动快 7x |
 | [**Planner**](docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md) | 由 SLA 驱动的自动扩缩容器，可分析工作负载并调整资源池规模 | 以最低总体拥有成本（TCO）满足延迟目标 |
 | [**Grove**](https://github.com/ai-dynamo/grove) | 面向拓扑感知 gang scheduling 的 K8s operator（NVL72） | 在机架、主机和 NUMA 节点之间优化放置工作负载 |
-| [**AIConfigurator**](https://github.com/ai-dynamo/aiconfigurator) | 在数秒内模拟 10K+ 部署配置 | 无需消耗 GPU 小时即可找到最优服务配置 |
+| [**AISimulate**](https://pypi.org/project/aisimulate/) | 离线预测服务行为并搜索部署配置 | 无需启动 GPU 集群即可找到高质量的服务配置 |
 | [**容错**](docs/fern/pages/kubernetes/fault-tolerance/request-migration.md) | 金丝雀健康检查 + 运行中请求迁移 | worker 可以失败，但用户请求不应失败 |
 
 ### 1.0 新功能
 
-- **零配置部署（[DGDR](https://docs.nvidia.com/dynamo/kubernetes-deployment/deploy-models/dgdr-reference)）** *(beta)：* 在一个 YAML 中指定模型、硬件和 SLA；AIConfigurator 自动分析工作负载，Planner 优化拓扑，然后由 Dynamo 完成部署
+- **零配置部署（[DGDR](https://docs.nvidia.com/dynamo/kubernetes-deployment/deploy-models/dgdr-reference)）** *(beta)：* 在一个 YAML 中指定模型、硬件和 SLA；AISimulate 性能模型估算候选配置，Planner 优化拓扑，然后由 Dynamo 完成部署
 - **Agentic inference：** 按请求提供延迟优先级、预期输出长度和缓存固定 TTL 等提示。集成 [LangChain](https://docs.langchain.com/oss/python/integrations/chat/nvidia_ai_endpoints#use-with-nvidia-dynamo) + [NeMo Agent Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit)
 - **多模态 E/P/D：** 带 embedding cache 的分离式 encode/prefill/decode；图像工作负载 TTFT 快 30%
 - **视频生成：** 原生支持 [FastVideo](https://github.com/hao-ai-lab/FastVideo) + [SGLang Diffusion](https://lmsys.org/blog/2026-02-16-sglang-diffusion-advanced-optimizations/)；单张 B200 上实现实时 1080p

--- a/benchmarks/mocker/README.md
+++ b/benchmarks/mocker/README.md
@@ -2,7 +2,7 @@
 
 These benchmarks demonstrate the benefit the AIC Rust core (aiconfigurator #1200)
 delivers to its consumer, the Dynamo mocker: they compare the mocker driving the
-Rust crate (`RustAicCallback`, wrapping `aiconfigurator_core::AicEngine`) against
+Rust crate (`RustAicCallback`, wrapping `aisimulate_core::AicEngine`) against
 the pre-#1200 pure-Python AIC. The headline numbers:
 
 - **~1.2x** faster offline replay (end-to-end). Offline replay is a

--- a/benchmarks/mocker/bench_aic_rust_callback.py
+++ b/benchmarks/mocker/bench_aic_rust_callback.py
@@ -14,7 +14,7 @@ removed fallback, use ``bench_aic_concurrency.py`` (it drives the Python
 
 Measures the end-to-end speedup of replacing the per-predict GIL + pyo3
 round-trip (``PyAicCallback``) with the pure-Rust ``RustAicCallback`` that wraps
-``aiconfigurator_core::AicEngine``.
+``aisimulate_core::AicEngine``.
 
 Both paths run the SAME Rust latency math (post aiconfigurator #1200, where the
 Python ``AicSession`` already dispatches to the compiled Rust engine). The only
@@ -44,9 +44,9 @@ Two things are reported per workload:
   2. SPEEDUP — median wall-clock ratio (python / rust) over ``--repeat`` runs.
 
 Run:  python benchmarks/mocker/bench_aic_rust_callback.py
-Requires: aiconfigurator-core installed with loadable systems/perf data for the
-model/system/backend tuple, and the bindings built with the ``aic-forward-pass``
-feature.
+Requires: AISimulate installed with loadable systems/perf data for the
+model/system/backend tuple (it provides the ``aiconfigurator_core`` compatibility
+namespace), and the bindings built with the ``aic-forward-pass`` feature.
 """
 
 import argparse

--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -215,7 +215,7 @@ redirects:
     destination: "/dynamo/dev/reference/api/python/nixl_connect#api-dynamo-nixl-connect-readableoperation"
   - source: "/dynamo/dev/reference/nixl-connect/writable-operation"
     destination: "/dynamo/dev/reference/api/python/nixl_connect#api-dynamo-nixl-connect-writableoperation"
-  # AI Simulate's experimental Spica package was renamed to Sweeper on dev only.
+  # AISimulate's experimental Spica package was renamed to Sweeper on dev only.
   - source: "/dynamo/dev/knowledge-base/modular-components/ai-simulate/spica"
     destination: "/dynamo/dev/knowledge-base/concepts/simulation/ai-simulate/sweeper/overview"
   - source: "/dynamo/dev/knowledge-base/modular-components/ai-simulate/spica/overview"

--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -343,7 +343,7 @@ navigation:
                   - page: Benchmark Planner Decisions
                     slug: planner-replay
                     path: pages/kubernetes/operations/simulation-with-dynosim/dynosim-planner-replay.mdx
-                  - section: AI Simulate (Experimental)
+                  - section: AISimulate (Experimental)
                     slug: ai-simulate
                     collapsed: true
                     contents:

--- a/docs/fern/pages/cli/disaggregated-serving/sizing-with-aiconfigurator.mdx
+++ b/docs/fern/pages/cli/disaggregated-serving/sizing-with-aiconfigurator.mdx
@@ -17,10 +17,11 @@ endpoint. The direct online Mocker CLI is temporarily unavailable. Use
 
 ## Prerequisites
 
-Install AIConfigurator in the environment where you run the sizing command:
+Use Python 3.11 through 3.13. Install AISimulate, which provides the retained `aiconfigurator`
+sizing command:
 
 ```bash
-pip install aiconfigurator
+python3 -m pip install "aisimulate==0.1.0.dev2"
 ```
 
 Collect:

--- a/docs/fern/pages/cli/operations/simulation-with-dynosim/overview.md
+++ b/docs/fern/pages/cli/operations/simulation-with-dynosim/overview.md
@@ -22,7 +22,7 @@ Use DynoSim when you want to answer questions such as:
 | DynoSim recommendation | `aisimulate recommend --stack dynamo` | Searches simulation trials across parallelism, worker split, router knobs, service-level objective (SLO) constraints, and GPU budget |
 | Direct online simulation CLI | Unavailable | Will return through the unified AISimulate CLI in a future release |
 | Mocker core | `lib/mocker` | Models engine scheduling, KV allocation, prefix caching, preemption, and timing |
-| AIC | AI Configurator SDK | Supplies calibrated timing and candidate-shape data for supported model/backend/GPU tuples |
+| AISimulate performance model | `timing.type: default` in the AISimulate YAML | Supplies calibrated timing and candidate-shape data for supported model/backend/GPU tuples |
 | Planner simulation | `planner` in the AISimulate YAML | Runs Planner decisions in the simulation loop to study scaling behavior and SLO compliance |
 
 ## How the tools differ
@@ -36,27 +36,32 @@ The tools overlap in workflow but perform different jobs:
 | DynoSim | Replays workloads and sweeps configurations using Mocker engine cores | Does not replace final validation on the target deployment |
 | AIPerf | Sends load to a live OpenAI-compatible endpoint and measures the result | Does not predict or simulate an undeployed configuration |
 
-DynoSim can use AIConfigurator predictions as the forward-pass timing model inside Mocker. In that
-combination, AIConfigurator estimates how long model work takes, while Mocker and DynoSim simulate
-how requests move through scheduling, KV-cache, routing, and Planner behavior.
+With `timing.type: default`, DynoSim uses the performance model shipped by AISimulate to estimate how
+long model work takes. Mocker and DynoSim simulate how requests move through scheduling, KV-cache,
+routing, and Planner behavior. Set `timing.type` to `fixed` or `polynomial` when calibrated timing is
+not required.
 
 ## Workflow
 
 ```mermaid
 flowchart LR
-    W["Workload trace or synthetic workload"] --> R["Single DynoSim run"]
-    R --> S["DynoSim sweep"]
+    W["Workload trace or synthetic workload"] --> R["aisimulate predict"]
+    R --> S["aisimulate recommend"]
     S --> C["Candidate configs"]
     C --> G["Real-GPU validation"]
 ```
 
-Start with a single DynoSim run to verify the workload shape and engine arguments. Use DynoSim
-sweeps to search the design space. Online Mocker deployments are temporarily unavailable. Validate
-the shortlist on real GPUs before production rollout.
+Start with `aisimulate predict --stack dynamo` to verify the workload shape and engine configuration.
+Use `aisimulate recommend --stack dynamo` to search the design space. Online Mocker deployments are
+temporarily unavailable. Validate the shortlist on real GPUs before production rollout.
 
-## Where AIC Fits
+## Where AISimulate Fits
 
-AIC provides performance models and candidate-shape information. DynoSim uses those models as one timing source inside the mocker engine and sweep optimizer. Mocker still owns the scheduler and KV-memory simulation: batching, prefix-cache hits, preemption, block allocation, and request lifecycle are simulated by Dynamo's mocker core, while AIC-backed timing predicts how long prefill and decode work should take for supported model/backend/GPU combinations.
+AISimulate provides performance models and candidate-shape information. DynoSim uses those models
+for default timing and parallelism recommendation. Mocker still owns the scheduler and KV-memory
+simulation: batching, prefix-cache hits, preemption, block allocation, and request lifecycle are
+simulated by Dynamo's Mocker core, while AISimulate-backed timing predicts how long prefill and
+decode work should take for supported model/backend/GPU combinations.
 
 ## Choosing an Entry Point
 

--- a/docs/fern/pages/cli/operations/simulation-with-dynosim/simulation-model.md
+++ b/docs/fern/pages/cli/operations/simulation-with-dynosim/simulation-model.md
@@ -41,87 +41,66 @@ events. The SGLang core uses its own token-pool and radix-cache implementation.
 ## Timing Sources
 
 Scheduler state determines the batch and cache-hit inputs to the timing source. Choose one timing
-source for prefill and decode work.
+source for each worker role with `engine.workers.<role>.timing.type`.
+
+The removed public Mocker CLI options for profile-derived interpolation and direct `--aic-*`
+configuration are not part of the unified CLI. Use only the timing types accepted by the
+AISimulate YAML schema.
+
+### AISimulate Performance Model
+
+`timing.type: default` uses the AISimulate performance model. AISimulate selects model data from
+`engine.model`, `engine.hardware`, `engine.backend`, the optional `engine.backend_version`, and the
+role's parallelism mapping. Unsupported combinations fail instead of silently using an
+uncalibrated timing model.
+
+KV-capacity selection is independent of the timing source. With `kv_cache.capacity.type: default`,
+AISimulate estimates capacity from the model, backend, hardware, parallelism, block size, and memory
+fraction. With `type: fixed`, set the concrete block count in `blocks`.
+
+### Fixed Timing
+
+Set `timing.type: fixed` and provide both `prefill_ms` and `decode_ms` to apply constant durations:
+
+```yaml
+timing: {type: fixed, prefill_ms: 2, decode_ms: 0.5}
+```
+
+Use fixed timing for functional tests or controlled comparisons. These values replace the
+AISimulate timing lookup but do not disable default KV-capacity estimation.
 
 ### Polynomial Baseline
 
-The default model is an uncalibrated synthetic baseline. Prefill latency follows a polynomial over
-the uncached tokens scheduled in the pass. Decode latency follows a polynomial over active KV-cache
-utilization. Use it for functional tests and relative experiments where hardware calibration is not
-required.
-
-### Profile-Derived Interpolation
-
-Set `--planner-profile-data` to either:
-
-- a profiler results directory, which Mocker converts to its interpolation input; or
-- a Mocker-format `.npz` file.
-
-The model linearly interpolates prefill latency over uncached batch tokens and bilinearly
-interpolates decode latency over the profiled decode dimensions. Values outside the measured grid
-are extrapolated, so inspect the profile coverage before relying on boundary results.
-
-### AIConfigurator
-
-Set `--aic-perf-model` to use
-[AIConfigurator](https://github.com/ai-dynamo/aiconfigurator) for forward-pass latency prediction.
-Select the model, system, backend, parallelism, and quantization identity with the `--aic-*` knobs.
-`--aic-backend` can differ from `--engine-type` when an experiment intentionally decouples simulated
-scheduler behavior from the timing backend.
-
-When block capacity is not overridden, the AIC-backed configuration estimates KV capacity from the
-backend-specific GPU-memory fraction. `--aic-nextn`, `--aic-nextn-accept-rates`, and
-`--aic-mtp-seed` add deterministic speculative-token burst sampling to the scheduler simulation.
-
-AIC predicts forward-pass duration and capacity inputs. Mocker still owns request admission,
-batching, prefix hits, memory pressure, token emission, and handoff state.
+Set `timing.type: polynomial` to use the uncalibrated synthetic baseline. Prefill latency follows a
+polynomial over the uncached tokens scheduled in the pass. Decode latency follows a polynomial over
+active KV-cache utilization.
 
 ## Prefill/Decode Handoff
 
-The retained internal disaggregated worker runtime has two handoff paths. The prefill worker's
-bootstrap configuration, rather than its engine type alone, selects the path.
+For `engine.mode: disaggregated`, define `engine.workers.prefill` and
+`engine.workers.decode`. Configure the modeled transfer under `engine.kv_transfer`:
 
-### Direct Completion Path
+```yaml
+kv_transfer:
+  bytes_per_token: auto
+  bandwidth_gb_per_second: 400
+  timing_mode: destination_missing
+```
 
-This is the default when the prefill worker omits `--bootstrap-ports`. The prefill worker completes
-the request, and the router consumes that result before dispatching decode. There is no handoff ID,
-source/destination rendezvous, destination reservation, or coordinated activation and release.
-
-The direct path still applies the simple full-prompt line-rate delay as part of prefill completion
-when transfer bandwidth and KV bytes per token are available. It does not use destination cache
-state, so `--kv-transfer-timing-mode destination_missing` does not apply.
-
-### Coordinated Bootstrap Path
-
-Set `--bootstrap-ports` on prefill workers to advertise a handoff endpoint. The router can then
-dispatch decode with a handoff ID and endpoint while prefill remains active. The two workers
-coordinate this lifecycle:
-
-1. The source finishes prefill and holds the terminal prefill result.
-2. The destination accepts the request and reserves capacity.
-3. The handoff applies the configured transfer delay.
-4. The destination activates the request.
-5. The source releases its hold.
-
-Cancellation and failure paths release the corresponding reservation or hold. vLLM uses
-source-first coordination; SGLang uses destination-first coordination. TensorRT-LLM handoff is not
-supported.
-
-Both paths use a per-request line-rate model:
+The offline simulation uses a per-request line-rate model:
 
 ```text
 transfer time = transferred KV bytes / kv_transfer_bandwidth
 transferred KV bytes = charged tokens * kv_bytes_per_token
 ```
 
-The direct path always charges the full logical prompt. In the coordinated path,
-`--kv-transfer-timing-mode full_prompt` does the same, while `destination_missing` charges only the
-prompt footprint missing at the destination and can produce zero delay on a full destination hit.
-Neither handoff path makes concurrent requests contend for a shared link.
+`timing_mode: full_prompt` charges the full logical prompt. `destination_missing` charges only the
+prompt footprint absent from the destination and can produce zero delay on a full destination hit.
+Concurrent requests do not contend for a shared link.
 
-Mocker derives `kv_bytes_per_token` from model metadata and `--kv-cache-dtype` when possible. Set
-`--kv-bytes-per-token` when the model configuration is unavailable or when the experiment requires
-an explicit value. Set `--kv-transfer-bandwidth 0` to disable P/D transfer delay.
+Set `bytes_per_token: auto` to derive the value from model metadata and parallelism, or provide a
+positive integer. Set a positive `bandwidth_gb_per_second` to apply the transfer delay. TensorRT-LLM
+does not support disaggregated simulation.
 
 ## Distributed Signals
 

--- a/docs/fern/pages/developer-guide/additional-resources/aiconfigurator-reference.md
+++ b/docs/fern/pages/developer-guide/additional-resources/aiconfigurator-reference.md
@@ -5,10 +5,13 @@ title: AIConfigurator Reference
 subtitle: Compare aggregated and disaggregated layouts before deployment
 ---
 
-This page is the full AIConfigurator reference: sizing
-[AIConfigurator](https://github.com/ai-dynamo/aiconfigurator/tree/main) for
-aggregated and disaggregated Dynamo deployments, generating deployment
-artifacts, and validating them. If you only need a parallelism layout for a DGD
+This page is the full reference for the `aiconfigurator` compatibility command shipped in the
+[AISimulate](https://pypi.org/project/aisimulate/) Python distribution: sizing aggregated and
+disaggregated Dynamo deployments, generating deployment artifacts, and validating them. Dynamo does
+not depend on the separate `aiconfigurator` or `aiconfigurator-core` distributions. The AISimulate
+wheel preserves the `aiconfigurator` and `aiconfigurator_core` import namespaces for compatibility.
+
+If you only need a parallelism layout for a DGD
 you are already authoring, use the shorter [Sizing with AIConfigurator](../../kubernetes/disaggregated-serving/sizing-with-aiconfigurator.mdx)
 tutorial. For the serving architecture and deployment-path overview, start with
 [Disaggregated Serving](../../kubernetes/disaggregated-serving/overview.md).
@@ -64,9 +67,11 @@ AIConfigurator evaluates two deployment architectures and recommends the best on
 
 ## Quick Start
 
+Use Python 3.11 through 3.13.
+
 ```bash
-# Install
-pip3 install aiconfigurator
+# Install the distribution that provides the compatibility command
+python3 -m pip install "aisimulate==0.1.0.dev2"
 
 # Optional: check whether the model/system/backend is covered
 aiconfigurator cli support \
@@ -533,18 +538,19 @@ Run `aiconfigurator cli default --generator-help` to see all available parameter
 
 ### Prefix Caching Considerations
 
-For workloads with repeated prefixes (e.g., system prompts):
+For workloads with repeated prefixes such as system prompts:
 
-- **Enable prefix caching** when you have high prefix hit rates
-- **Disable prefix caching** (`--no-enable-prefix-caching`) for diverse prompts
+- Leave `--prefix` at its default `0` when the workload has no reusable prefix.
+- Set `--prefix <tokens>` to model a fixed cached prefix, and configure the deployed backend to
+  match that assumption.
 
-AIConfigurator's default predictions assume no prefix caching. Enable it post-deployment if your workload benefits.
+AIConfigurator's default predictions assume no cached prefix.
 
 ## Supported Configurations
 
 ### Backends and Versions
 
-For a comprehensive breakdown of which model/system/backend/version combinations are supported in both aggregated and disaggregated modes, refer to the [**support matrix**](https://ai-dynamo.github.io/aiconfigurator/support-matrix/). The raw data is available as [per-system CSV files](https://github.com/ai-dynamo/aiconfigurator/tree/main/aic-core/src/aiconfigurator_core/systems/support_matrix), which are automatically generated and tested to ensure accuracy across all supported configurations.
+For a comprehensive breakdown of which model/system/backend/version combinations are supported in both aggregated and disaggregated modes, refer to the [**support matrix**](https://ai-dynamo.github.io/aiconfigurator/support-matrix/). The wheel packages its generated and tested per-system CSV data under `aiconfigurator_core/systems/support_matrix`.
 
 You can also check if a system / framework version is supported via the `aiconfigurator cli support` command. For example:
 ```bash
@@ -586,10 +592,6 @@ aiconfigurator cli default \
 ## Additional Options
 
 ```bash
-# Web interface for interactive exploration
-pip3 install aiconfigurator[webapp]
-aiconfigurator webapp  # Visit http://127.0.0.1:7860
-
 # Quick config generation (no parameter sweep)
 aiconfigurator cli generate \
   --model-path Qwen/Qwen3-32B-FP8 \
@@ -670,7 +672,7 @@ For balanced workloads (ISL/OSL ratio between 2:1 and 10:1), aggregated is often
 
 ## Learn More
 
-- [AIConfigurator CLI Guide](https://github.com/ai-dynamo/aiconfigurator/blob/main/docs/cli_user_guide.md)
-- [Dynamo Deployment Guide](https://github.com/ai-dynamo/aiconfigurator/blob/main/docs/dynamo_deployment_guide.md)
+- [AISimulate package](https://pypi.org/project/aisimulate/)
+- [AIConfigurator compatibility support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/)
 - [Dynamo Installation Guide](../../kubernetes/installation/install-dynamo.md)
 - [Benchmarking Guide](../../recipes/feature-benchmarks/benchmarking-guide.md)

--- a/docs/fern/pages/developer-guide/knowledge-base/concepts/simulation/dynosim-architecture.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/concepts/simulation/dynosim-architecture.md
@@ -6,8 +6,8 @@ subtitle: How the replay harness composes simulated engines, routing, and Planne
 ---
 
 DynoSim connects a workload driver to one or more Mocker engine cores and records request and token
-timing for analysis. It supports a direct offline path for fast simulation and an online path that
-uses live Dynamo workers and runtime services.
+timing for analysis. The unified `aisimulate predict` and `aisimulate recommend` commands run this
+simulation offline. The former public online replay and Mocker commands are unavailable.
 
 For task-oriented instructions, see [Run a DynoSim Simulation](../../../../cli/operations/simulation-with-dynosim/dynosim-replay.mdx),
 [Sweep DynoSim Configurations](../../../../cli/operations/simulation-with-dynosim/dynosim-sweeps.mdx), and
@@ -84,15 +84,15 @@ flowchart TD
 The engine core owns scheduling, KV allocation, prefix caching, preemption, and forward-pass timing.
 The multi-engine layer adds behavior that requires coordination across engine instances.
 
-## Offline and online execution
+## Execution model
 
 Offline execution drives Mocker engine cores directly. It uses a logical clock and does not require
 a frontend, worker registration, etcd, NATS, or HTTP traffic. This path is appropriate for fast,
 repeatable configuration comparisons and continuous-integration tests.
 
-Online execution launches mock workers through the live runtime path. It is useful when an
-experiment must include worker registration, request transport, event publication, or runtime
-coordination. The simulated engine remains the source of inference timing in both modes.
+The codebase retains an internal worker runtime and compatibility SDK paths, but they are not a
+supported online CLI workflow. Online simulation will return through the unified AISimulate CLI in
+a future release.
 
 ## Routing simulation
 
@@ -117,11 +117,8 @@ flowchart LR
     Q --> D["Deficit round-robin dispatch"]
 ```
 
-The replay CLI loads the startup-only policy YAML, selects an exact model profile when `--model-name`
-is set, and otherwise uses the root profile. A recognized family combines with the router-observed
-uncached Input Sequence Length (ISL) bucket. An exact explicit class bypasses bucketing. Ordinary
-physical-class names do not bypass classification; they fall back to the selected profile's default
-family.
+The trace loader preserves `policy_class` metadata for the replay runtime. The unified public YAML
+does not expose the former startup policy-file and `--model-name` CLI controls.
 
 ## Planner simulation adapter
 
@@ -149,14 +146,15 @@ part of the analysis.
 
 ## Timing models
 
-DynoSim can use polynomial, profile-derived, or AIConfigurator-backed forward-pass timing. The
-timing model predicts prefill and decode duration. The Mocker engine still owns batching, KV-cache
-state, prefix reuse, preemption, and request progression.
+DynoSim can use the default AIConfigurator-backed timing model or explicit fixed and polynomial
+timing from `engine.workers.<role>.timing`. The timing model predicts prefill and decode duration.
+The Mocker engine still owns batching, KV-cache state, prefix reuse, preemption, and request
+progression.
 
-AIConfigurator is used in two distinct places:
+AIConfigurator compatibility APIs from the `aisimulate` wheel are used in two distinct places:
 
-- engine-args fields configure the Mocker forward-pass timing model
-- top-level replay AIC flags configure router-side prompt-load estimation
+- `engine.workers.<role>.timing.type: default` configures the Mocker forward-pass timing model
+- `router.prefill_load_model.type: aic` configures router-side prompt-load estimation
 
 Keeping these paths separate makes it possible to test router estimates independently from engine
 timing.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/overview.md
@@ -39,6 +39,9 @@ path. They have no adapter migration.
 
 ## Install
 
+AISimulate requires Python 3.11 through 3.13. Dynamo itself still supports Python 3.10, but the
+`aisimulate` dependency and its CLI are not installed in a Python 3.10 environment.
+
 The `dynamo-planner` image installs the published `aisimulate==0.1.0.dev2` wheel from its local
 wheelhouse. Dynamo builds `aisimulate-core==0.1.0-dev.2` from crates.io instead of vendoring the
 AISimulate source tree.
@@ -47,7 +50,7 @@ For Dynamo source development, install the published AISimulate wheel, Dynamo, a
 dependencies from the Dynamo repository root:
 
 ```bash
-uv pip install "aisimulate==0.1.0.dev2"
-uv pip install --no-deps -e .
-uv pip install -r container/deps/requirements.planner.txt
+python3 -m pip install "aisimulate==0.1.0.dev2"
+python3 -m pip install --no-deps -e .
+python3 -m pip install -r container/deps/requirements.planner.txt
 ```

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/configuration.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/configuration.md
@@ -99,10 +99,10 @@ Providers](sweep-config-provider.md) for the complete ABI.
 The experimental `AISIMULATE_SWEEPER_VIZIER_ALGO` environment variable overrides the Vizier
 algorithm. For example, set it to `RANDOM_SEARCH` to bypass the default GP-bandit designer.
 `SPICA_VIZIER_ALGO` remains a deprecated fallback during migration; when both are set, the
-AI Simulate variable takes precedence.
+AISimulate variable takes precedence.
 
 ## Removed KVBM Fields
 
 Sweeper rejects the old KVBM block-count, transfer-bandwidth, offload-batch-size, and cache-hit
-fields. The AI Simulate engine and replay path do not support them, and they have no adapter
+fields. The AISimulate engine and replay path do not support them, and they have no adapter
 migration.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/dynamo-integration.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/dynamo-integration.md
@@ -1,41 +1,68 @@
 ---
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Dynamo Sweeper Integration
-subtitle: Install and compose Planner, Router, and Dynamo Replay with AI Simulate
+subtitle: Install and compose Planner, Router, and Dynamo Replay with AISimulate
 ---
 
 > [!WARNING]
-> **Experimental.** The AI Simulate and replay dependency split is still in progress.
+> **Experimental.** The AISimulate CLI, adapter ABI, and replay contracts may change without a
+> standard deprecation period.
 
-AI Simulate's Sweeper core does not depend on Dynamo. Dynamo owns its optional Planner and Router
+AISimulate's Sweeper core does not depend on Dynamo. Dynamo owns its optional Planner and Router
 sweep configuration providers and `DynamoReplayRunnerFactory`.
 
 ## Install
 
-The supported prebuilt environment is the `dynamo-planner` image. The image stages and installs the
-published `aisimulate==0.1.0.dev1` wheel alongside the Dynamo wheels. Dynamo's Rust workspace
-resolves `aisimulate-core==0.1.0-dev.1` from crates.io.
+AISimulate requires Python 3.11 through 3.13. The `ai-dynamo` package remains installable on Python
+3.10, but the AISimulate dependency and CLI are not installed there.
 
-For Dynamo source development, install the published AI Simulate wheel and build the matching
+The supported prebuilt environment is the `dynamo-planner` image. The image stages and installs the
+published `aisimulate==0.1.0.dev2` wheel alongside the Dynamo wheels. Dynamo's Rust workspace
+resolves `aisimulate-core==0.1.0-dev.2` from crates.io.
+
+For Dynamo source development, install the published AISimulate wheel and build the matching
 Dynamo bindings:
 
 ```bash
-python -m pip install pip "maturin[patchelf]"
+python3 -m pip install pip "maturin[patchelf]"
 cd lib/bindings/python
 maturin develop --uv --release --features aic-forward-pass
 cd ../../..
-python -m pip install --no-deps -e .
-python -m pip install "aisimulate==0.1.0.dev1"
-python -m pip install -r container/deps/requirements.planner.txt
+python3 -m pip install --no-deps -e .
+python3 -m pip install "aisimulate==0.1.0.dev2"
+python3 -m pip install -r container/deps/requirements.planner.txt
 ```
 
-The repository does not yet provide an `ai-dynamo[simulation]` extra. Add that extra only after the
-full AI Simulate and Replay refactor has a supported distribution path.
+On supported Python versions, `ai-dynamo` declares the exact AISimulate release as a base
+dependency. No `ai-dynamo[simulation]` extra is required.
 
-## Run a Dynamo Sweep
+## Run the Unified CLI
 
-Compose the runtime directly:
+Select the Dynamo stack explicitly to load the runner plus any configured Router and Planner
+adapters:
+
+```bash
+aisimulate predict --stack dynamo --config prediction.yaml
+aisimulate recommend --stack dynamo --config recommendation.yaml
+```
+
+The `--stack` option defaults to `engine`. Without `--stack dynamo`, top-level `router` and
+`planner` sections have no matching adapter and fail configuration resolution.
+
+The `ai-dynamo` distribution registers:
+
+| Entry-point group | Name | Purpose |
+|---|---|---|
+| `aisimulate.runner_factories` | `dynamo` | Execute a complete replay through Dynamo composition |
+| `aisimulate.config_adapters` | `dynamo.router` | Validate and materialize the public `router` section |
+| `aisimulate.config_adapters` | `dynamo.planner` | Validate and materialize the public `planner` section |
+| `aisimulate.sweep_config_providers` | `dynamo.router`, `dynamo.planner` | Preserve the legacy Sweeper Python API |
+
+## Use the Python SDK
+
+Call the retained Sweeper Python API only when an application needs the legacy `SmartSearchConfig`
+contract and explicit runner injection:
 
 ```python
 from aisimulate.sweeper import SmartSearchConfig, Sweeper
@@ -47,8 +74,7 @@ candidates = Sweeper(
 ).run(config)
 ```
 
-There is no `--enable-dynamo` flag. Selecting a Dynamo adapter in configuration and injecting the
-Dynamo runner are the explicit composition points.
+There is no compatibility CLI alias or `--enable-dynamo` flag.
 
 ## Dynamo Providers
 
@@ -59,23 +85,22 @@ The `ai-dynamo` distribution registers these entry points:
 | `dynamo.planner` | `DynamoPlannerSweepConfigProvider` | `dynamo.planner:scaling_policy@1` |
 | `dynamo.router` | `DynamoRouterSweepConfigProvider` | `dynamo.router:placement_policy@1` |
 
-Each adapter value is a search space, not one concrete Planner or Router config:
+The public recommendation YAML places the adapter-owned domains at the top level:
 
 ```yaml
-adapters:
-  dynamo.router:
-    search_space:
-      mode: [kv_router, round_robin]
-      overlap_score_credit: [0.0, 0.5, 1.0]
-  dynamo.planner:
-    search_space:
-      scaling_policy:
-        preset: [disabled, load_180_5]
-      fpm_sampling:
-        preset: [default]
-      load_sensitivity:
-        preset: [default]
+router:
+  policy: {choices: [round_robin, kv_router]}
+  prefill_load_model: {type: none}
+  overlap_score_credit: {choices: [0.0, 0.5, 1.0]}
+planner:
+  policy: enabled
+  scaling_policy: {preset: [disabled, load_180_5]}
+  fpm_sampling: {preset: [default]}
+  load_sensitivity: {preset: [default]}
+  load_predictor: {preset: [arima_raw]}
 ```
+
+The legacy `SmartSearchConfig.adapters` mapping remains available only through the Python SDK.
 
 > [!WARNING]
 > The legacy flat Planner preset lists remain accepted for backward compatibility but emit a
@@ -102,7 +127,7 @@ hook.
 ## Replay Composition
 
 `DynamoReplayRunnerFactory` converts each serializable `ReplaySpec` into an invocation of the
-shared AI Simulate Replayer. It resolves materialized Planner and Router hooks into Dynamo-owned
+shared AISimulate Replayer. It resolves materialized Planner and Router hooks into Dynamo-owned
 scaling and placement policies, while the Replayer continues to own traffic execution and report
 generation.
 
@@ -112,6 +137,7 @@ generation.
 | Synthetic traffic | Replayer with no scaling | Replayer with the selected Planner scaling policy |
 
 The runner passes trace, fixed, or KV-load-derived closed-loop concurrency through
-`ReplaySpec.concurrency`. It applies a goodput SLA only when `goal.sla` is configured; this SLA is
+`ReplaySpec.concurrency`. The public compiler maps `evaluation.sla` into `ReplaySpec.goal.sla`, and
+`DynamoReplayRunnerFactory` reads that lowered field as the replay goodput SLA. This SLA is
 independent of the Planner's scaling SLA. A `dynamo.router:placement_policy@1` hook selects the
 Dynamo placement policy. Without that hook, the Replayer uses its built-in round-robin policy.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/glm-5-fp8-pareto-sweep.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/glm-5-fp8-pareto-sweep.md
@@ -145,9 +145,9 @@ after round 53 consumed about 4 hours 39 minutes for 1.05% additional hypervolum
 ## Reproduction Status
 
 The packaged dependencies support this configuration's KV-capacity and candidate-concurrency
-calculations. These results are historical and cannot be reproduced from the current public
-artifacts because the published `aisimulate==0.1.0.dev1` wheel does not include the example runner
-or this experiment's configuration. Recreating the frontier also requires AI Configurator
+calculations. These results are historical and cannot be reproduced exactly. The experiment used
+`aisimulate==0.1.0.dev1`; that wheel did not include the example runner, and the experiment
+configuration was not published. Recreating the frontier also requires AI Configurator
 performance database coverage for B200/SGLang/GLM-5-FP8 and the Replay behavior from the original
 runtime snapshot.
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/overview.md
@@ -50,5 +50,5 @@ SDK configuration and an explicitly injected runtime.
 - The runner advertises supported `ReplaySpec` versions, backend/topology pairs, and runtime hooks
   before a study starts.
 - Every `Sweeper.run` call owns fresh optimizer studies, result caches, runners, and worker pools.
-- KVBM search fields are rejected. The AI Simulate engine and replay path do not support those
+- KVBM search fields are rejected. The AISimulate engine and replay path do not support those
   fields and provide no adapter migration for the old host or disk offload settings.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/planner-goodput-per-gpu-sweep.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/planner-goodput-per-gpu-sweep.md
@@ -155,9 +155,9 @@ spread within the `load_180_10` family is noise).
 
 ## Reproduction Status
 
-These results are historical and cannot be reproduced from the current public artifacts.
-The published `aisimulate==0.1.0.dev1` wheel does not include the example runner or the
-experiment configuration used for this sweep.
+These results are historical and cannot be reproduced exactly. The experiment used
+`aisimulate==0.1.0.dev1`; that wheel did not include the example runner, and the experiment
+configuration was not published.
 
 The original planner path required the `aic-forward-pass` binding; a per-throughput-interval
 load-predictor sub-sweep ran first (forecast-loss winner pinned per interval). Static and

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/quickstart.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/quickstart.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Sweeper Quickstart
 subtitle: Run a backend-neutral sweep with an injected replay runtime
@@ -9,10 +9,10 @@ subtitle: Run a backend-neutral sweep with an injected replay runtime
 > **Experimental.** Sweeper is intended for evaluation and feedback, not production capacity
 > planning.
 
-Install AI Simulate:
+Install AISimulate:
 
 ```bash
-python -m pip install "aisimulate==0.1.0.dev1"
+python3 -m pip install "aisimulate==0.1.0.dev2"
 ```
 
 Sweeper requires a `RunnerFactory` supplied by the application that owns replay execution:

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/router-end-to-end-latency-sweep.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/router-end-to-end-latency-sweep.md
@@ -139,9 +139,9 @@ Every distinct config the Vizier sweep evaluated (2k subset, c=32), best mean-e2
 
 ## Reproduction Status
 
-These results are historical and cannot be reproduced from the current public artifacts.
-The published `aisimulate==0.1.0.dev1` wheel does not include the example runner or the
-experiment configuration used for this sweep.
+These results are historical and cannot be reproduced exactly. The experiment used
+`aisimulate==0.1.0.dev1`; that wheel did not include the example runner, and the experiment
+configuration was not published.
 
 The original validation ran the winning router configuration against the full trace with
 `dynamo.replay.run_trace_replay`. It required the AI Configurator performance model and the

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/sweep-config-provider.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/sweep-config-provider.md
@@ -1,12 +1,12 @@
 ---
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Sweep Configuration Providers
 subtitle: Extend Sweeper without adding application dependencies to its core
 ---
 
 > [!WARNING]
-> **Experimental.** The provider ABI is versioned but may change before AI Simulate stabilizes.
+> **Experimental.** The provider ABI is versioned but may change before AISimulate stabilizes.
 
 A `SweepConfigProvider` lets an optional feature package contribute search dimensions without
 making `aisimulate` depend on that package.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/mocker/mocker-engine-architecture.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/mocker/mocker-engine-architecture.md
@@ -82,13 +82,18 @@ remain request-local until they cross a block boundary.
 
 ## Performance Model
 
-The mocker supports three timing prediction modes:
+The unified AISimulate configuration exposes three timing modes under
+`engine.workers.<role>.timing`:
 
-**Polynomial Model (Default):** Uses hardcoded polynomial formulas that approximate typical GPU behavior. Prefill time scales quadratically with token count, while decode time depends on the total active KV cache size.
+- **`default`** uses the AIConfigurator compatibility API shipped in the `aisimulate` wheel. It
+  derives the model, backend, hardware, and parallelism inputs from the `engine` configuration and
+  requires performance data for that tuple.
+- **`fixed`** uses the configured `prefill_ms` and `decode_ms` for deterministic tests.
+- **`polynomial`** uses hardcoded polynomial formulas. Prefill time scales quadratically with token
+  count, while decode time depends on the total active KV cache size.
 
-**Interpolated Model:** Loads actual profiling data from an NPZ file containing measured prefill and decode latencies. The mocker interpolates between data points to predict timing for any input size. This enables high-fidelity simulation matching a specific hardware configuration.
-
-**AIC Model (`--aic-perf-model`):** Uses the NVIDIA AI Configurator (AIC) SDK for latency prediction. AIC provides calibrated performance models for specific GPU/model/engine combinations, predicting prefill and decode latency as a function of batch size, sequence length, and prefix cache hits. The model path is automatically derived from `--model-path`, and the engine type from `--engine-type`. This mode is opt-in and requires both the `aiconfigurator` SDK and loadable systems/perf data for the requested tuple.
+The removed public Mocker CLI flags, including `--aic-perf-model`, are not inputs to
+`aisimulate predict` or `aisimulate recommend`.
 
 ## Bootstrap Rendezvous (Disaggregated Serving)
 
@@ -96,13 +101,18 @@ For disaggregated prefill/decode deployments, prefill and decode workers coordin
 
 ## KV Transfer Latency Simulation
 
-The mocker simulates KV cache transfer time between prefill and decode workers. Before the prefill worker emits its first (and only) token, it sleeps for a duration based on:
+The mocker simulates KV cache transfer time between prefill and decode workers. Configure it under
+`engine.kv_transfer` for a disaggregated prediction:
 
-- **kv_bytes_per_token** (auto-computed from model config): `num_layers * 2 * num_kv_heads * head_dim * dtype_bytes`. The `dtype_bytes` is determined by `--kv-cache-dtype`: when set to `auto` (default), it uses the model's `dtype` from config; when explicitly set (e.g., `fp8`), it uses the specified dtype instead. It can also be overridden directly with `--kv-bytes-per-token`.
-- **kv_transfer_bandwidth** (default: 64.0 GB/s, inter-node InfiniBand)
-- **Transfer time**: `num_input_tokens * kv_bytes_per_token / bandwidth`
+- `bytes_per_token: auto` derives the per-token footprint from the model and parallelism. Set a
+  positive integer to override it.
+- `bandwidth_gb_per_second` sets a positive transfer bandwidth. Omitting it disables modeled
+  transfer delay.
+- The public AISimulate `engine.kv_transfer.timing_mode` field defaults to `destination_missing`
+  and can be set to `full_prompt`.
 
-This delay is injected after the scheduler's prefill compute simulation completes, modeling the sequential flow: prefill computation → KV transfer → decode begins. Set `--kv-transfer-bandwidth 0` to disable.
+The delay is injected after simulated prefill compute completes, modeling the sequential flow:
+prefill computation, KV transfer, then decode.
 
 ## Integration with Dynamo
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
@@ -27,7 +27,7 @@ The planner offers four `optimization_target` settings that control how scaling 
 | **`throughput`** (default) | Maximizes throughput by scaling based on queue depth and KV cache utilization. Scales up when engines are saturated, scales down when utilization drops. | No | No |
 | **`latency`** | Minimizes latency by scaling aggressively to keep queues short. Scales up at lower utilization thresholds. | No | No |
 | **`load`** | Uses user-defined prefill queue token and decode KV cache utilization thresholds. | No | No |
-| **`sla`** | Targets specific TTFT/ITL SLA values through the Planner engine-query layer and the `aiconfigurator-core` wheel: native AIC estimates when available, online FPM tuning, and FPM regression fallback. | Yes (`ttft_ms`, `itl_ms`) | Recommended |
+| **`sla`** | Targets specific TTFT/ITL SLA values through the Planner engine-query layer and the AIConfigurator compatibility API in the `aisimulate` wheel: native AIC estimates when available, online FPM tuning, and FPM regression fallback. | Yes (`ttft_ms`, `itl_ms`) | Recommended |
 
 **We recommend starting with the default `throughput` target** because it requires no configuration. Switch to `latency` for latency-sensitive workloads, `load` for explicit prefill queue token and decode KV cache utilization thresholds, or `sla` for precise SLA targeting with native AIC or FPM-based performance modeling.
 
@@ -39,7 +39,7 @@ The planner offers four `optimization_target` settings that control how scaling 
 
 The Planner supports two scaling modes that can run independently or together:
 
-- **Throughput-based scaling (`sla` target only)**: Uses the Planner engine-query layer and traffic prediction to compute the replica count needed to meet TTFT and ITL targets. Forward-pass estimates come directly from the `aiconfigurator-core` wheel, with self-benchmark or profiler FPM bootstrap data and live FPM tuning. Adjusts on a longer interval (default 180s). The default `throughput` target instead uses load-based queue and KV-utilization thresholds.
+- **Throughput-based scaling (`sla` target only)**: Uses the Planner engine-query layer and traffic prediction to compute the replica count needed to meet TTFT and ITL targets. Forward-pass estimates come from the AIConfigurator compatibility API in the `aisimulate` wheel, with self-benchmark or profiler FPM bootstrap data and live FPM tuning. Adjusts on a longer interval (default 180s). The default `throughput` target instead uses load-based queue and KV-utilization thresholds.
 - **Load-based scaling**: Uses ForwardPassMetrics (FPM) from the Dynamo event plane and queries the same Planner engine-query layer for short-term TTFT/ITL estimates. No pre-deployment data or KV Router required. Adjusts on a short interval (default 5s) to respond quickly to bursts.
 
 When both modes are enabled, throughput-based scaling provides a capacity floor (long-term planning) while load-based scaling handles real-time adjustments above that floor.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-design.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-design.md
@@ -153,9 +153,9 @@ targets. The perf model is bootstrapped from the first available source:
 3. `profile_results_dir` NPZ/JSON fallback data
 4. live FPM regression warmup when no pre-deployment data is available
 
-The Planner calls `aiconfigurator_core.sdk.RustForwardPassPerfModel` directly
-for native AIC estimates, online correction, and regression fallback. A
-Planner-owned engine-query layer derives queue drain, TTFT, ITL, and capacity.
+The Planner calls `aiconfigurator_core.sdk.RustForwardPassPerfModel` through the compatibility
+namespace in the AISimulate wheel for native AIC estimates, online correction, and regression
+fallback. A Planner-owned engine-query layer derives queue drain, TTFT, ITL, and capacity.
 Runtime metadata such as KV hit rate and speculative accept length are applied
 as input features, not as persistent correction-factor flags.
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
@@ -18,7 +18,7 @@ The planner supports four optimization targets that determine how scaling decisi
 - **`throughput`** (default): Uses static thresholds on queue depth and KV cache utilization. No SLA targets or profiling needed. Works out of the box.
 - **`latency`**: Same approach as `throughput` but with more aggressive thresholds — scales up earlier and tolerates less queuing. Ideal for latency-sensitive workloads.
 - **`load`**: Uses user-defined prefill queue token thresholds and decode KV utilization thresholds for reactive load-based scaling.
-- **`sla`**: Uses the Planner engine-query layer with forward-pass estimates from the `aiconfigurator-core` Python wheel, plus online FPM tuning or FPM regression fallback, to target specific TTFT/ITL values. Supports both throughput-based (predictive) and load-based (reactive) scaling modes. For advanced users who need precise SLA control.
+- **`sla`**: Uses the Planner engine-query layer with forward-pass estimates from the AIConfigurator compatibility API in the `aisimulate` wheel, plus online FPM tuning or FPM regression fallback, to target specific TTFT/ITL values. Supports both throughput-based (predictive) and load-based (reactive) scaling modes. For advanced users who need precise SLA control.
 
 **When to use which:**
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
@@ -2,14 +2,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Profiler Guide
-subtitle: Runs the AI Configurator-driven profiling pipeline that turns a model, SLA targets, and backend into a ready-to-deploy DGD.
+subtitle: Runs the AIConfigurator-driven profiling pipeline that turns a model, SLA targets, and backend into a ready-to-deploy DGD.
 ---
 
 ## Overview
 
 The Dynamo Profiler analyzes model inference performance and generates optimized deployment configurations (DynamoGraphDeployments). Given a model, hardware, and SLA targets, it determines the best parallelization strategy, selects optimal prefill and decode engine configurations, and produces a ready-to-deploy DGD YAML.
 
-The profiler accepts a `DynamoGraphDeploymentRequestSpec` (DGDR) as input and uses [AI Configurator (AIC)](https://github.com/ai-dynamo/aiconfigurator) for performance simulation, candidate enumeration, and configuration picking. When the Planner is enabled, the profiler also emits the native AIC model identity passed directly to the `aiconfigurator-core` wheel and can generate optional engine interpolation curves used to bootstrap runtime autoscaling.
+The profiler accepts a `DynamoGraphDeploymentRequestSpec` (DGDR) as input and uses [AIConfigurator (AIC)](../../../additional-resources/aiconfigurator-reference.md) compatibility APIs from the `aisimulate` wheel for performance simulation, candidate enumeration, and configuration picking. When the Planner is enabled, the profiler also emits the native AIC model identity and can generate optional engine interpolation curves used to bootstrap runtime autoscaling.
 
 ## Workflow
 
@@ -128,7 +128,7 @@ Triggered when there is **no planner and no target load**. Maximizes throughput 
 
 ## Planner Integration
 
-When the Planner is enabled, the profiler emits the `aic_perf_model` identity used by the Planner's direct `aiconfigurator-core` integration whenever picked configs are available. The `pre_deployment_sweeping_mode` field controls optional bootstrap data:
+When the Planner is enabled, the profiler emits the `aic_perf_model` identity used by the Planner's AIConfigurator compatibility integration in the `aisimulate` wheel whenever picked configs are available. The `pre_deployment_sweeping_mode` field controls optional bootstrap data:
 
 ```yaml
 features:
@@ -353,7 +353,7 @@ spec:
   searchStrategy: thorough  # Deep exploration with real engine profiling
 ```
 
-### AI Configurator Simulation
+### AIConfigurator Simulation
 
 Uses performance simulation to rapidly estimate optimal configurations without running real deployments.
 
@@ -362,22 +362,22 @@ Uses performance simulation to rapidly estimate optimal configurations without r
 - **GPU Requirements**: None
 - **Backends**: All (vLLM, SGLang, TensorRT-LLM)
 
-AI Configurator is used by default with `searchStrategy: rapid`:
+AIConfigurator is used by default with `searchStrategy: rapid`:
 
 ```yaml
 spec:
-  searchStrategy: rapid  # Fast profiling with AI Configurator simulation (default)
+  searchStrategy: rapid  # Fast profiling with AIConfigurator simulation (default)
 ```
 
 > [!NOTE]
-> `aicBackendVersion` specifies the TensorRT-LLM version that AI Configurator simulates. See the [AI Configurator supported features](https://github.com/ai-dynamo/aiconfigurator#supported-features) for available versions.
+> `aicBackendVersion` specifies the TensorRT-LLM version that AIConfigurator simulates. See the [AIConfigurator compatibility support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/) for available versions.
 
 **Currently supports:**
 - **Backends**: vLLM, SGLang, TensorRT-LLM
 - **Systems**: H100 SXM, H200 SXM, B200 SXM, GB200 SXM, A100 SXM
 - **Models**: Wide range including GPT, Llama, Mixtral, DeepSeek, Qwen, and more
 
-See [AI Configurator documentation](https://github.com/ai-dynamo/aiconfigurator#supported-features) for the full list.
+See the [AIConfigurator compatibility support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/) for the full list.
 
 ### Automatic GPU Discovery
 

--- a/docs/fern/pages/kubernetes/disaggregated-serving/sizing-with-aiconfigurator.mdx
+++ b/docs/fern/pages/kubernetes/disaggregated-serving/sizing-with-aiconfigurator.mdx
@@ -23,11 +23,16 @@ forward-pass timing model.
 ## Prerequisites
 
 - A DGD in progress from [Deploy with DGD](../model-deployment/deploy-with-dgd.md), with the Frontend and worker defined and only parallelism left to set.
-- AIConfigurator installed: `pip3 install aiconfigurator`.
+- Python 3.11 through 3.13 with AISimulate installed. The AISimulate distribution provides the
+  retained `aiconfigurator` sizing command:
+
+  ```bash
+  python3 -m pip install "aisimulate==0.1.0.dev2"
+  ```
 - Your checkpoint's HuggingFace ID, GPU system (for example `h200_sxm`), backend (`vllm`, `sglang`, or `trtllm`), the total GPUs you can allocate, and your SLA: Time To First Token (TTFT), Time Per Output Token (TPOT), and typical input/output sequence lengths (ISL/OSL).
 
 <Info>
-AIConfigurator only models supported checkpoint + system + backend combinations. Confirm yours before sizing with `aiconfigurator cli support --model-path <model> --system <sku> --backend <backend>`. See the [support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/).
+AIConfigurator only models supported checkpoint + system + backend combinations. Confirm yours before sizing with `aiconfigurator cli support --model-path <model> --system <sku> --backend <backend>`. See the [AIConfigurator compatibility support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/).
 </Info>
 
 <Steps toc={true}>

--- a/docs/fern/pages/reference/components/dynosim-replay-cli-reference.mdx
+++ b/docs/fern/pages/reference/components/dynosim-replay-cli-reference.mdx
@@ -37,8 +37,9 @@ aisimulate predict --stack dynamo --config prediction.yaml
 </ParamField>
 
 <ParamField path="--set" type="PATH=YAML_VALUE" default="null">
-  Override an existing configuration path after loading the YAML file. Repeat the option for
-  multiple overrides. Values are parsed as YAML, and later assignments win.
+  Override a schema-valid configuration path after loading the YAML file. Repeat the option for
+  multiple overrides. Values are parsed as YAML, and later assignments win. Sequence indexes are
+  not supported.
 </ParamField>
 
 <ParamField path="--output-dir" type="path" default="./aisimulate-output">
@@ -125,38 +126,62 @@ evaluation:
 
 `traffic` contains `source`, `load`, and `stop` mappings.
 
+- Omitting the entire section creates 100 independent synthetic requests at concurrency 10, with
+  1,024 input tokens and 128 output tokens per request.
 - `source.type: synthetic` creates independent requests with `input_tokens` and `output_tokens`.
 - `source.type: synthetic-session` creates ordered multi-turn sessions.
 - `source.type: trace` reads one or more paths. Supported formats include `mooncake`,
   `mooncake-delta`, `agentic_mooncake`, `applied_compute_agentic`, and `dynamo`.
 - `load.type: concurrency` keeps a fixed number of requests or sessions active.
-- `load.type: constant_rate` uses `requests_per_second` or `sessions_per_second`.
+- `load.type: constant_rate` schedules evenly spaced arrivals from `requests_per_second` or
+  `sessions_per_second`.
+- `load.type: poisson` uses the matching rate with exponential inter-arrival times and an optional
+  `seed`, which defaults to 42.
 - `load.type: trace_timestamps` preserves trace timing and accepts a positive `speedup`.
 - `stop.requests` applies to independent requests. `stop.sessions` applies to session sources.
+- `stop.requests_per_load_unit` and `stop.sessions_per_load_unit` derive the count from the concrete
+  concurrency or arrival rate.
 - `stop.max_virtual_time_seconds` is a soft virtual-time cutoff. Requests admitted before the
   cutoff may finish afterward.
 
 For a Dynamo request trace, omit `traffic.source.block_size`; AISimulate derives it from the trace
-records and rejects mixed block sizes. For Mooncake-family traces, set the block size used to encode
-`hash_ids`.
+records and rejects mixed block sizes. Dynamo format accepts multiple trace shards. Other formats
+accept exactly one path, and their block size defaults to 512 when omitted.
+
+`mooncake-delta` and `agentic_mooncake` require aggregated engine mode.
+`agentic_mooncake` also requires `trace_timestamps` and rejects the virtual-time cutoff.
+`applied_compute_agentic` requires concurrency load.
+With the Dynamo stack, omit `planner` or set `planner.policy: disabled` for `mooncake-delta`,
+`agentic_mooncake`, and Dynamo traces that carry `agent_context` records.
 
 ## Engine and Adapter Rules
 
 - `engine.mode: aggregated` requires `engine.workers.aggregated`.
 - `engine.mode: disaggregated` requires `engine.workers.prefill`,
   `engine.workers.decode`, and `engine.kv_transfer`.
+- `aisimulate predict` and `aisimulate recommend` currently support TensorRT-LLM only in
+  aggregated mode. This is an offline simulation limitation; Dynamo runtime deployments support
+  TensorRT-LLM disaggregated serving.
 - Each `parallelism` mapping is concrete and contains `replicas`, `tensor`, `pipeline`,
   `attention_data`, `moe_tensor`, and `moe_expert`.
+- `engine.context_length` defaults to `max`, which AISimulate resolves from the model's Hugging Face
+  configuration. Default KV block sizes are 64 for vLLM, 1 for SGLang, and 32 for TensorRT-LLM.
+- Scheduler defaults are 8,192 batched tokens for every role and 256 sequences for aggregated and
+  decode workers. Prefill workers default to one sequence.
+- `timing.type: default` uses the AIConfigurator forward-pass model shipped in the `aisimulate`
+  wheel. `fixed` requires both `prefill_ms` and `decode_ms`; `polynomial` selects the built-in
+  polynomial model.
 - `router.policy: kv_router` requires more than one routable worker. Set
   `router.prefill_load_model.type` to `none` or `aic`.
 - `planner.policy` is `disabled` or `enabled`. When enabled, `planner.max_num_gpus` limits the
   Planner runtime budget; it is distinct from recommendation candidate constraints.
-- `evaluation.sla` accepts either or both `ttft_ms` and `itl_ms`. An omitted threshold does not
-  constrain that metric.
+- `evaluation.sla` accepts either `e2e_ms` alone or `ttft_ms` and `itl_ms` together. The two forms
+  are mutually exclusive.
 
 ## Overrides
 
-`--set` accepts dot-separated paths that already exist in the input schema:
+`--set` accepts dot-separated, schema-valid paths. The field does not need to be present in the
+input YAML:
 
 ```bash
 aisimulate predict \

--- a/docs/fern/pages/reference/components/dynosim-sweep-reference.mdx
+++ b/docs/fern/pages/reference/components/dynosim-sweep-reference.mdx
@@ -40,6 +40,9 @@ Recommendation accepts the prediction sections plus search controls:
 
 Unknown fields are rejected. Conditional validation runs after each candidate is materialized.
 
+When `traffic` is omitted, recommendation uses the same default as prediction: 100 independent
+synthetic requests at concurrency 10, with 1,024 input tokens and 128 output tokens per request.
+
 ## Domain Syntax
 
 ### Choices
@@ -81,6 +84,18 @@ enumeration and projection. A custom list treats each complete parallelism mappi
 choice. With `preset: false`, each parallelism knob becomes an independent dimension before
 feasibility filtering.
 
+## Traffic Domains
+
+Recommendation accepts `choices` or `range` on `traffic.load.concurrency`, request or session
+rate, `traffic.load.speedup` for trace timestamps, and `traffic.load.fraction` for
+KV-capacity-relative load. The
+`kv_capacity_fraction` load type is recommendation-only: it derives candidate concurrency from
+that candidate's estimated KV capacity. Fractions above 1 are valid and model oversubscribed load.
+
+For a swept load, use `stop.requests_per_load_unit` or `stop.sessions_per_load_unit` to scale the
+simulation length with each concrete candidate. Fixed `stop.requests` and `stop.sessions` keep the
+same simulation length across the load domain.
+
 ## Optimization
 
 `optimization.target` accepts:
@@ -94,13 +109,20 @@ feasibility filtering.
 | `goodput_per_gpu` | Highest goodput per simulated GPU |
 | `ttft` | Lowest Time to First Token (TTFT) |
 | `e2e_latency` | Lowest end-to-end latency |
-| `pareto` | Complete nondominated objective front |
+| `pareto` | Complete nondominated front over the public CLI's fixed pair: throughput per GPU and throughput per user |
 
 `goodput` and `goodput_per_gpu` require `evaluation.sla` with either `e2e_ms` or both `ttft_ms` and
 `itl_ms`.
 
+The public recommendation schema does not expose `pareto_objectives`. Custom objective lists remain
+available only through the legacy Sweeper Python SDK.
+
 `optimization.constraints.min_candidate_gpus` and `max_candidate_gpus` bound the simulated GPU
 footprint. When `engine.hardware: auto`, set one concrete `optimization.hardware` value.
+
+Recommendation searches aggregated and disaggregated modes by default, and vLLM and SGLang
+backends by default. TensorRT-LLM can be selected explicitly for aggregated mode. The default
+`engine.context_length: max` resolves from the model's Hugging Face configuration.
 
 ## Optimizer Controls
 

--- a/docs/fern/pages/reference/components/planner-configuration.mdx
+++ b/docs/fern/pages/reference/components/planner-configuration.mdx
@@ -118,7 +118,7 @@ When `optimization_target` is `throughput`, `latency`, or `load`, the Planner fo
 </ParamField>
 
 <ParamField path="aic_perf_model" type="AICPerfModelSpec" default="null">
-  Native AIConfigurator forward-pass model identity passed directly to the `aiconfigurator-core` wheel, enabling real-time AIC estimates with online correction. Unsupported native configs fall back to FPM regression. Does not trigger an AIC interpolation sweep.
+  Native AIConfigurator forward-pass model identity passed to the compatibility `aiconfigurator_core` namespace in the `aisimulate` wheel, enabling real-time AIC estimates with online correction. Unsupported native configs fall back to FPM regression. Does not trigger an AIC interpolation sweep.
 </ParamField>
 
 <Indent>

--- a/docs/fern/pages/reference/kubernetes-api/dynamo-graph-deployment-request.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/dynamo-graph-deployment-request.mdx
@@ -297,7 +297,7 @@ service.
 </ParamField>
 
 <ParamField path="aic_perf_model" type="AICPerfModelSpec" default="null">
-  Native AIConfigurator forward-pass model identity passed directly to the `aiconfigurator-core` wheel, enabling real-time AIC estimates with online correction. Unsupported native configs fall back to FPM regression. Does not trigger an AIC interpolation sweep.
+  Native AIConfigurator forward-pass model identity passed to the compatibility `aiconfigurator_core` namespace in the `aisimulate` wheel, enabling real-time AIC estimates with online correction. Unsupported native configs fall back to FPM regression. Does not trigger an AIC interpolation sweep.
 </ParamField>
 
 <Indent>

--- a/docs/fern/translations/zh-CN/pages/developer-guide/knowledge-base/modular-components/planner/planner-design.md
+++ b/docs/fern/translations/zh-CN/pages/developer-guide/knowledge-base/modular-components/planner/planner-design.md
@@ -93,7 +93,7 @@ Planner 会预测下一个 interval 的三个流量形状值：
 3. `profile_results_dir` 中的 NPZ/JSON fallback data
 4. 没有 pre-deployment data 时的 live FPM regression warmup
 
-Planner 直接调用 `aiconfigurator_core.sdk.RustForwardPassPerfModel`，获取原生 AIC 估算、在线校正和回归回退。Planner 自有的引擎查询层据此前向计算抽象推导 queue drain、TTFT、ITL 和 capacity。KV hit rate 和 speculative accept length 等 runtime metadata 会作为输入特征使用，而不是作为持久 correction-factor flags。
+Planner 直接调用 AISimulate wheel 中的 `aiconfigurator_core.sdk.RustForwardPassPerfModel`，获取原生 AIC 估算、在线校正和回归回退。Planner 自有的引擎查询层据此前向计算抽象推导 queue drain、TTFT、ITL 和 capacity。KV hit rate 和 speculative accept length 等 runtime metadata 会作为输入特征使用，而不是作为持久 correction-factor flags。
 
 ### Step 4: Proposal 和 Lower Bound
 

--- a/docs/fern/translations/zh-CN/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
+++ b/docs/fern/translations/zh-CN/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
@@ -15,7 +15,7 @@ planner 支持四个优化目标，这些目标决定扩缩容决策的方式：
 - **`throughput`**（默认）：基于队列深度和 KV cache 利用率使用静态阈值。不需要 SLA 目标或 profiling。开箱即用。
 - **`latency`**：与 `throughput` 采用相同方法，但使用更激进的阈值，即更早扩容并容忍更少排队。适合对延迟敏感的工作负载。
 - **`load`**：使用用户定义的 prefill 队列 token 阈值和 decode KV 利用率阈值，进行反应式的基于负载扩缩容。
-- **`sla`**：使用 Planner 自有的引擎查询层，并通过 `aiconfigurator-core` Python wheel 获取前向计算估算；同时支持在线 FPM 调优和 FPM 回归回退。支持基于吞吐量（预测式）和基于负载（反应式）的扩缩容模式。适合需要精确 SLA 控制的高级用户。
+- **`sla`**：使用 Planner 自有的引擎查询层，并通过 AISimulate Python wheel 提供的 `aiconfigurator_core` 兼容命名空间获取前向计算估算；同时支持在线 FPM 调优和 FPM 回归回退。支持基于吞吐量（预测式）和基于负载（反应式）的扩缩容模式。适合需要精确 SLA 控制的高级用户。
 
 **何时使用哪种模式：**
 
@@ -66,7 +66,7 @@ advisory 模式仅提供建议。Planner 会计算建议副本数、记录日志
 
 | 字段 | 类型 | 默认值 | 说明 |
 |-------|------|---------|-------------|
-| `optimization_target` | string | `throughput` | `throughput`：基于队列/利用率阈值扩缩容。`latency`：激进的低延迟阈值。`load`：用户定义的 prefill 队列和 decode KV 利用率阈值。`sla`：通过 Planner 自有的引擎查询层和 `aiconfigurator-core` wheel，以 ttft_ms/itl_ms 为目标扩缩容。 |
+| `optimization_target` | string | `throughput` | `throughput`：基于队列/利用率阈值扩缩容。`latency`：激进的低延迟阈值。`load`：用户定义的 prefill 队列和 decode KV 利用率阈值。`sla`：通过 Planner 自有的引擎查询层和 AISimulate wheel 中的 `aiconfigurator_core` 兼容命名空间，以 ttft_ms/itl_ms 为目标扩缩容。 |
 
 当 `optimization_target` 为 `throughput`、`latency` 或 `load` 时，会自动启用基于负载的扩缩容，并禁用基于吞吐量的扩缩容。`ttft_ms`/`itl_ms` 字段会被忽略。
 
@@ -85,7 +85,7 @@ advisory 模式仅提供建议。Planner 会计算建议副本数、记录日志
 |-------|------|---------|-------------|
 | `pre_deployment_sweeping_mode` | string | `rapid` | 如何生成可选的性能模型启动数据：`rapid`（AIC 仿真，约 30 秒）、`thorough`（真实 GPU，2-4 小时）或 `none`（跳过）。 |
 
-SLA 模式使用 Planner 自有的引擎查询层。如果配置了 `aic_perf_model`，Planner 会把原生 AIC 模型身份和引擎上限直接传给 `aiconfigurator_core.sdk.RustForwardPassPerfModel`；如果原生 AIC 不支持该模型，wheel 会自动回退到基于观测 FPM 的回归模型。如果没有配置 `aic_perf_model`，wheel 会从 FPM 回归模型启动，并在自基准测试或在线 FPM 观测足够后变为可用。
+SLA 模式使用 Planner 自有的引擎查询层。如果配置了 `aic_perf_model`，Planner 会把原生 AIC 模型身份和引擎上限直接传给 AISimulate wheel 中的 `aiconfigurator_core.sdk.RustForwardPassPerfModel`；如果原生 AIC 不支持该模型，该模型会自动回退到基于观测 FPM 的回归模型。如果没有配置 `aic_perf_model`，该模型会从 FPM 回归模型启动，并在自基准测试或在线 FPM 观测足够后变为可用。
 
 启动时，planner 总会先尝试从 `get_perf_metrics` Dynamo 端点获取自基准测试结果。如果不可用，则在配置存在时回退到 rapid 模式 AIC interpolation 数据或 `profile_results_dir` 中 profiler 生成的数据（npz 或 JSON）。这些数据都会转换为 ForwardPassMetrics，并用于调优或启动性能模型。当 `pre_deployment_sweeping_mode: none` 时，planner 仍然可以启动；吞吐量决策会在原生 AIC 可用或在线 FPM 足够之前报告 `model_not_ready`。
 

--- a/docs/fern/translations/zh-CN/pages/kubernetes/getting-started/introduction.mdx
+++ b/docs/fern/translations/zh-CN/pages/kubernetes/getting-started/introduction.mdx
@@ -17,7 +17,7 @@ Dynamo 是一个开源、高吞吐、低延迟的推理框架，专为在分布�
 - **在任意引擎之上的系统级优化** -- 推理引擎优化单 GPU 前向传递。Dynamo 增加分布式层：分离式服务、智能路由、跨内存层级的 KV 缓存管理，以及自动扩缩容。
 - **可组合的性能提升技术** -- 分离式服务、KV 缓存感知路由和 KV 缓存卸载等技术各自都能提升性能；组合使用时会带来叠加收益。
 - **引擎无关** -- 可与 vLLM、SGLang 和 TensorRT-LLM 配合使用。无需改变服务基础设施即可替换引擎。正在扩展对 Intel XPU 和 AMD 硬件的支持。
-- **面向大规模生产就绪** -- Dynamo 覆盖完整部署生命周期：自动配置（AIConfigurator）、运行时自动扩缩容（Planner）、拓扑感知的 gang scheduling（Grove）、容错和可观测性。
+- **面向大规模生产就绪** -- Dynamo 覆盖完整部署生命周期：离线预测与配置搜索（AISimulate）、运行时自动扩缩容（Planner）、拓扑感知的 gang scheduling（Grove）、容错和可观测性。
 - **模块化采用** -- 可以从一个组件开始（例如，仅在现有引擎之上使用 Router 实现 KV 感知路由）。按需采用更多组件。每个组件都可通过 pip 独立安装。
 
 ## 设计原则
@@ -56,7 +56,7 @@ Dynamo 生态系统包含以下额外的模块化组件，并会随着时间继�
 | **扩缩容 / 云** | Planner | 在给定 SLA 约束（TTFT 和 TPOT）下，实时自动调优 prefill 和 decode 的性能 |
 | | [Grove](https://github.com/ai-dynamo/grove) | 支持 Kubernetes 多节点分离式服务所需的 gang scheduling 和拓扑感知 |
 | | [Model Express](https://github.com/ai-dynamo/model-express) | 通过缓存模型权重并经由 NIXL 将其传输到其他 GPU，快速加载模型权重。未来也将用于容错 |
-| **性能** | [AIConfigurator](https://github.com/ai-dynamo/aiconfigurator) | 基于模型、ISL/OSL、HW 等估算聚合式与分离式服务的性能。以前称为 LLMPet |
+| **性能** | [AISimulate](https://pypi.org/project/aisimulate/) | 基于模型、ISL/OSL、硬件等信息离线预测聚合式与分离式服务的性能，并搜索部署配置。 |
 | | [AIPerf](https://github.com/ai-dynamo/aiperf) | 用 Python 编写、重新架构的 GenAI-Perf，具有最大可扩展性；支持分布式基准测试 |
 | | AITune | 给定模型或 pipeline，搜索最适合部署的后端（例如 TensorRT、Torch.compile 等）（即将推出） |
 | | Flex Tensor | 从主机内存向 GPU 流式传输权重，以便在内存容量有限的 GPU 上运行超大语言模型（即将推出） |
@@ -103,15 +103,15 @@ Dynamo 通过组合三项核心技术实现先进的 LLM 性能：分离式服�
 
 ## 从配置到生产级部署
 
-### 使用 AIConfigurator 在 30 秒内找到最佳配置
+### 使用 AISimulate 搜索部署配置
 
 手动为分离式服务寻找最佳并行度可能需要数天的穷举配置扫描，而这一挑战在大规模环境中只会更加严峻。
 
-Dynamo 的 [AIConfigurator](https://github.com/ai-dynamo/aiconfigurator/) 通过在 30 秒内识别性能最佳的配置来解决这一问题，并清晰预测相较于标准聚合式服务的性能提升。该逻辑原生集成到 Kubernetes Custom Resource Definition (CRD) 和 Dynamo Graph Deployment Request (DGDR) 中，使用户能够使用自动生成的优化配置进行部署。
+Dynamo 的 [AISimulate](https://pypi.org/project/aisimulate/) 可以离线预测聚合式与分离式服务的行为，并根据流量、延迟目标和 GPU 预算搜索候选部署配置。DGDR 使用同一性能建模能力生成 DynamoGraphDeployment（DGD）。
 
 ### 使用 Planner 根据 SLA 自动调整部署
 
-一旦通过 AIConfigurator 或 DGDR 找到离线配置，开发者就可以将所需模型部署到生产环境。然而，生产流量在线上可能变化很大，离线确定的静态配置将无法充分处理流量峰值。
+一旦通过 AISimulate 或 DGDR 找到离线配置，开发者就可以将所需模型部署到生产环境。然而，生产流量在线上可能变化很大，离线确定的静态配置将无法充分处理流量峰值。
 
 Dynamo 提供 [Planner](../../developer-guide/knowledge-base/modular-components/planner/planner-design.md) 来规避这个问题。开发者只需用 TTFT 和 Time Per Output Token (TPOT) 设置 SLA。Planner 会检查在线流量，并自动决定如何扩展 prefill 和 decode worker，从而在维持指定 SLA 的同时有效处理流量峰值。
 


### PR DESCRIPTION
## Summary

- cherry-pick the merged documentation refresh from #14130 onto `release/1.5.0`
- align the release documentation with the unified `aisimulate predict` and `aisimulate recommend` CLI included through #13665
- document AISimulate package ownership, the retained `aiconfigurator` compatibility command and namespaces, current offline simulation constraints, and Router/Planner YAML behavior
- update public links, English/Chinese ecosystem wording, and historical reproduction notes
- contain documentation and benchmark-docstring changes only; no runtime behavior changes

## Validation

- focused pre-commit hooks passed for all 34 changed files
- 7 AISimulate dependency and packaging contract tests passed
- internal Markdown scan checked 185 files and 973 links with 0 broken links
- benchmark Python compilation and `git diff --check` passed
- cherry-pick commit is GPG-signed and DCO-signed

## Cherry-pick Source

- Main PR: #14130
- Main merge commit: `08cca119ea33427696f17e3517018bae058b6035`
- Release commit: `e242cd451f`

## Related Issues

- [x] Confirmed — no related issue