### PR TITLE
chore: update dynamo-protocols to 5.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,9 +2881,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2723c9ec1c3106cd044ca7f3ff7db71e0e347d1190aa2694a7cc7121376a2a"
+checksum = "dbaf3179de1accba21fcad16eb22b5e113722084265e0315e808e32150088ee7"
 dependencies = [
  "async-openai",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ dynamo-kv-hashing = { path = "lib/kv-hashing", version = "1.5.0" }
 dynamo-memory = { path = "lib/memory", version = "1.5.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.5.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.5.0" }
-dynamo-protocols = { version = "=5.4.0" }
+dynamo-protocols = { version = "=5.4.1" }
 dynamo-parsers = { version = "8.1.0" }
 
 # Published on crates.io. To see all available versions:

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2723c9ec1c3106cd044ca7f3ff7db71e0e347d1190aa2694a7cc7121376a2a"
+checksum = "dbaf3179de1accba21fcad16eb22b5e113722084265e0315e808e32150088ee7"
 dependencies = [
  "async-openai",
  "derive_builder",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2340,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2723c9ec1c3106cd044ca7f3ff7db71e0e347d1190aa2694a7cc7121376a2a"
+checksum = "dbaf3179de1accba21fcad16eb22b5e113722084265e0315e808e32150088ee7"
 dependencies = [
  "async-openai",
  "derive_builder",


### PR DESCRIPTION
## Overview:

Bumps the pinned `dynamo-protocols` dependency from 5.4.0 to 5.4.1, which picks up ai-dynamo/frontend-crates#202 (closes ai-dynamo/frontend-crates#157). That release aligns `/v1/chat/completions` response serialization with the OpenAI spec: optional fields are omitted when absent instead of being emitted as explicit `null`, and the required-and-nullable `refusal` field is always present.

Wire changes visible to clients after this bump:

| Field | Before | After |
| -- | -- | -- |
| top-level `usage` / `service_tier` / `system_fingerprint` (non-stream + stream) | `null` when absent | omitted |
| stream tool-call chunk `id` / `type` / `function.name` on continuation chunks | `null` | omitted |
| `message.reasoning_content` (Dynamo extension) | `null` when absent | omitted |
| `usage.prompt_tokens_details.audio_tokens` etc. | `null` when absent | omitted |
| `message.refusal` | omitted | always present (`null` when no refusal), matching OpenAI |
| `finish_reason`, non-stream `logprobs`, `message.content` | unchanged | unchanged (spec-required) |

Deserialization is unaffected in both directions: payloads with or without the keys decode identically, so mixed-version frontend/worker deployments are safe. Official OpenAI SDKs (pydantic/zod models) are unaffected; only raw dict indexing such as `chunk["usage"]` on intermediate stream chunks would observe the change — and that code already fails against api.openai.com, which never emits those keys.

## Details:

Root `Cargo.toml` moves the pin from `=5.4.0` to `=5.4.1`. That is the only pin site in the tree; `lib/llm/Cargo.toml` and `lib/backend-common/Cargo.toml` inherit it via `workspace = true`.

The three lockfiles are refreshed to match: `Cargo.lock`, `lib/bindings/kvbm/Cargo.lock`, and `lib/bindings/python/Cargo.lock` (the two bindings crates are separate workspaces with their own lockfiles). Each moves exactly one package, `dynamo-protocols 5.4.0 -> 5.4.1`; no other dependency changes.

No Dynamo source changes: 5.4.1 keeps every public type identity (`CompletionUsage` etc. remain upstream re-exports), so this is a pure pin bump.

## Where should the reviewer start?

`Cargo.toml` line 71. Everything else is lockfile churn from `cargo update -p dynamo-protocols --precise 5.4.1`.

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to ai-dynamo/frontend-crates#157
- Picks up ai-dynamo/frontend-crates#202


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Dynamo protocols package to version 5.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->