### PR TITLE
refactor(bindings): use ReceiverStream in push egress response channel

### DIFF
--- a/lib/bindings/python/rust/push_egress.rs
+++ b/lib/bindings/python/rust/push_egress.rs
@@ -32,7 +32,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
-use tokio_stream::{Stream, StreamExt};
+use tokio_stream::{Stream, StreamExt, wrappers::ReceiverStream};
 
 use tokio::sync::mpsc;
 
@@ -594,9 +594,7 @@ pub(crate) fn response_channel(
 
     // The consumer side is pure Rust: no Python work, no GIL, no encoding, just
     // the wait for whatever the handler pushes next.
-    let stream = futures::stream::unfold(rx, |mut rx| async move {
-        rx.recv().await.map(|item| (item, rx))
-    });
+    let stream = ReceiverStream::new(rx);
 
     (sender, stream)
 }


### PR DESCRIPTION
#### Overview:

`response_channel` in `push_egress.rs` built the consumer side of the push channel by folding the mpsc receiver into a stream by hand. `tokio_stream::wrappers::ReceiverStream` is exactly that adapter, and this file already imports `tokio_stream`.

Two lines change. **No behavior change, no dependency change, no API change.**

#### Details:

The consumer side was written as:

```rust
let stream = futures::stream::unfold(rx, |mut rx| async move {
    rx.recv().await.map(|item| (item, rx))
});
```

What makes this redundancy rather than a style preference is that the crate providing the ready-made adapter was *already imported in this file* — `push_egress.rs:35` is `use tokio_stream::{Stream, StreamExt};` — while that `unfold` was the **only** reference to `futures` anywhere in `push_egress.rs`. The one call site reached into a second crate for something the first crate already provides.

The wrapper form is also already the house style immediately around this code path:

- `engine.rs:16` imports `use tokio_stream::{Stream, StreamExt, wrappers::ReceiverStream};` and uses it at `engine.rs:551`. The new import line here is now identical to that one.
- `push_handler.rs:554` — the consumer of this very stream — already constructs `ReceiverStream::new(frame_rx)`.

**Why the swap is safe.** `response_channel` returns `impl Stream<Item = PushFrame> + Send + 'static`, so callers are promised only those three bounds. `ReceiverStream<PushFrame>` satisfies all three, and is additionally `Unpin`, which the `unfold` stream is not — so this can only relax constraints downstream, never tighten them.

Drop semantics are identical: dropping the stream drops the receiver, which is what signals senders that the consumer is gone, and that is what `ResponseSink::send` relies on at `push_egress.rs:425` to observe `TrySendError::Closed`.

The comment above the binding is kept deliberately. It explains why no GIL is involved, which remains true and is not obvious from the one-line replacement.

**`futures` is not removed from the crate.** It is still used in `engine.rs:120`, `lib.rs:10`, `llm/fpm.rs:18`, `backend.rs:38`, and `llm/kv/demand_driven.rs:5`, so `Cargo.toml` is untouched. This removes the last use inside `push_egress.rs` only.

#### Where should the reviewer start?

`lib/bindings/python/rust/push_egress.rs` is the only file touched, and the whole diff is 2 insertions / 4 deletions:

1. **Line 35** — `wrappers::ReceiverStream` added to the existing `tokio_stream` import.
2. **Line 597** — the three-line `unfold` becomes `let stream = ReceiverStream::new(rx);`.

#### Validation

- ✅ `cargo check` on `lib/bindings/python` passes clean, no warnings.
- ✅ `cargo fmt --check` clean on the changed file.
- No new test: this is a like-for-like adapter substitution with no observable behavior change, covered by the existing `push_egress` suite.

#### Related Issues

**🔗 This PR is linked to an issue:**

- Relates to #13983

Tracked internally as DYN-4230.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined asynchronous receiver-backed stream handling.
  * Preserved existing streaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->