### PR TITLE
perf(bindings): memoize ingress terminal-frame bytes per codec

### DIFF
--- a/lib/bindings/python/rust/python_payload.rs
+++ b/lib/bindings/python/rust/python_payload.rs
@@ -217,12 +217,7 @@ pub(crate) fn write_annotated_response<T: Serialize, W: std::io::Write>(
     Ok(is_error)
 }
 
-/// The end-of-stream marker: no data, `complete_final: true`.
-///
-/// The wrapper is a constant, so its bytes are fixed for the process — encoded
-/// once per codec rather than once per request. Both ingress encoders emit the
-/// identical frame, so the shape is defined here and nowhere else, exactly as
-/// [`write_annotated_response`] owns the non-terminal shape.
+/// Memoized separately per codec, since encoding is codec-specific.
 fn terminal_frame_bytes(codec: RequestPlanePayloadCodec) -> Result<Bytes, PipelineError> {
     static JSON: OnceLock<Bytes> = OnceLock::new();
     static MSGPACK: OnceLock<Bytes> = OnceLock::new();
@@ -379,8 +374,6 @@ mod tests {
         Annotated, NetworkStreamWrapper, RequestPlanePayloadCodec, encode_annotated_response,
         terminal_frame_bytes,
     };
-
-    // ── terminal_frame_bytes memoization ─────────────────────────────────────
 
     /// Each codec's terminal frame must decode back to `data: None,
     /// complete_final: true` — the contract both egress paths rely on to

--- a/lib/bindings/python/rust/python_payload.rs
+++ b/lib/bindings/python/rust/python_payload.rs
@@ -399,9 +399,10 @@ mod tests {
         }
     }
 
-    /// Two calls for the same codec must return the same bytes. This is the
-    /// assertion that actually pins the memoization: a bug that re-encoded on
-    /// every call would still pass the decode test above.
+    /// Two calls for the same codec must return the same cached `Bytes`
+    /// storage, not just equal contents. `assert_eq!` alone would still pass
+    /// if a bug re-encoded a byte-identical buffer on every call; comparing
+    /// `as_ptr()` is what actually pins the memoization.
     #[test]
     fn terminal_frame_bytes_is_memoized_per_codec() {
         for codec in [
@@ -410,7 +411,14 @@ mod tests {
         ] {
             let first = terminal_frame_bytes(codec).unwrap();
             let second = terminal_frame_bytes(codec).unwrap();
+            assert!(!first.is_empty(), "codec={}", codec.name());
             assert_eq!(first, second, "codec={}", codec.name());
+            assert_eq!(
+                first.as_ptr(),
+                second.as_ptr(),
+                "codec={} must reuse the cached Bytes storage",
+                codec.name()
+            );
         }
     }
 

--- a/lib/bindings/python/rust/python_payload.rs
+++ b/lib/bindings/python/rust/python_payload.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::OnceLock;
+
 use bytes::Bytes;
 use dynamo_runtime::pipeline::PipelineError;
 use dynamo_runtime::pipeline::network::{
@@ -117,18 +119,8 @@ impl IngressResponseEncoder<PythonResponseItem> for PythonIngressPayloadAdapter 
         complete_final: bool,
     ) -> Result<EncodedResponseFrame, PipelineError> {
         if complete_final {
-            let wrapper = NetworkStreamWrapper::<Annotated<()>> {
-                data: None,
-                complete_final: true,
-            };
-            let bytes = payload_codec.encode(&wrapper).map_err(|error| {
-                PipelineError::SerializationError(format!(
-                    "Failed serializing {} request-plane final response: {error}",
-                    payload_codec.name()
-                ))
-            })?;
             return Ok(EncodedResponseFrame {
-                bytes: bytes.into(),
+                bytes: terminal_frame_bytes(payload_codec)?,
                 is_error: false,
                 stop_stream: false,
             });
@@ -169,18 +161,8 @@ impl IngressResponseEncoder<crate::push_egress::PushFrame> for PythonIngressPayl
         complete_final: bool,
     ) -> Result<EncodedResponseFrame, PipelineError> {
         if complete_final {
-            let wrapper = NetworkStreamWrapper::<Annotated<()>> {
-                data: None,
-                complete_final: true,
-            };
-            let bytes = payload_codec.encode(&wrapper).map_err(|error| {
-                PipelineError::SerializationError(format!(
-                    "Failed serializing {} push-egress final response: {error}",
-                    payload_codec.name()
-                ))
-            })?;
             return Ok(EncodedResponseFrame {
-                bytes: bytes.into(),
+                bytes: terminal_frame_bytes(payload_codec)?,
                 is_error: false,
                 stop_stream: false,
             });
@@ -233,6 +215,40 @@ pub(crate) fn write_annotated_response<T: Serialize, W: std::io::Write>(
     };
     codec.encode_into(&wrapper, writer)?;
     Ok(is_error)
+}
+
+/// The end-of-stream marker: no data, `complete_final: true`.
+///
+/// The wrapper is a constant, so its bytes are fixed for the process — encoded
+/// once per codec rather than once per request. Both ingress encoders emit the
+/// identical frame, so the shape is defined here and nowhere else, exactly as
+/// [`write_annotated_response`] owns the non-terminal shape.
+fn terminal_frame_bytes(codec: RequestPlanePayloadCodec) -> Result<Bytes, PipelineError> {
+    static JSON: OnceLock<Bytes> = OnceLock::new();
+    static MSGPACK: OnceLock<Bytes> = OnceLock::new();
+
+    let cell = match codec {
+        RequestPlanePayloadCodec::Json => &JSON,
+        RequestPlanePayloadCodec::Msgpack => &MSGPACK,
+    };
+    if let Some(bytes) = cell.get() {
+        return Ok(bytes.clone());
+    }
+
+    let wrapper = NetworkStreamWrapper::<Annotated<()>> {
+        data: None,
+        complete_final: true,
+    };
+    let bytes: Bytes = codec
+        .encode(&wrapper)
+        .map_err(|error| {
+            PipelineError::SerializationError(format!(
+                "Failed serializing {} request-plane final response: {error}",
+                codec.name()
+            ))
+        })?
+        .into();
+    Ok(cell.get_or_init(|| bytes).clone())
 }
 
 fn encode_python_response(
@@ -361,7 +377,42 @@ mod tests {
 
     use super::{
         Annotated, NetworkStreamWrapper, RequestPlanePayloadCodec, encode_annotated_response,
+        terminal_frame_bytes,
     };
+
+    // ── terminal_frame_bytes memoization ─────────────────────────────────────
+
+    /// Each codec's terminal frame must decode back to `data: None,
+    /// complete_final: true` — the contract both egress paths rely on to
+    /// signal end-of-stream.
+    #[test]
+    fn terminal_frame_bytes_decodes_to_complete_final() {
+        for codec in [
+            RequestPlanePayloadCodec::Json,
+            RequestPlanePayloadCodec::Msgpack,
+        ] {
+            let bytes = terminal_frame_bytes(codec).unwrap();
+            let wrapper: NetworkStreamWrapper<Annotated<serde_json::Value>> =
+                codec.decode(&bytes).unwrap();
+            assert!(wrapper.complete_final, "codec={}", codec.name());
+            assert!(wrapper.data.is_none(), "codec={}", codec.name());
+        }
+    }
+
+    /// Two calls for the same codec must return the same bytes. This is the
+    /// assertion that actually pins the memoization: a bug that re-encoded on
+    /// every call would still pass the decode test above.
+    #[test]
+    fn terminal_frame_bytes_is_memoized_per_codec() {
+        for codec in [
+            RequestPlanePayloadCodec::Json,
+            RequestPlanePayloadCodec::Msgpack,
+        ] {
+            let first = terminal_frame_bytes(codec).unwrap();
+            let second = terminal_frame_bytes(codec).unwrap();
+            assert_eq!(first, second, "codec={}", codec.name());
+        }
+    }
 
     // ── encode_annotated_response contract ───────────────────────────────────
     //


### PR DESCRIPTION
#### Overview:

Both ingress response encoders (pull path and push-egress path) build and serialize the same end-of-stream `NetworkStreamWrapper { data: None, complete_final: true }` on every request, even though the encoded bytes are fixed for the process per codec. This avoids the redundant serde pass and allocation on every terminal frame.

#### Details:

- Added `terminal_frame_bytes(codec)` in `lib/bindings/python/rust/python_payload.rs`, caching the encoded terminal frame in a per-codec `OnceLock<Bytes>` (JSON and Msgpack), using a `get()`-then-`get_or_init()` shape to keep first-call serialization failures propagating as real errors rather than panicking.
- Both `IngressResponseEncoder::encode_response` terminal-frame branches (`PythonResponseItem` pull path and `push_egress::PushFrame` push path) now call `terminal_frame_bytes(payload_codec)?` instead of building and encoding the wrapper inline.
- `Bytes::clone` is a refcount bump, so handing the cached buffer to every request is free.
- Added unit tests pinning the decode contract (`complete_final: true`, `data: None` for both codecs) and the memoization itself (two calls return equal bytes).

Linear: DIS-2826

#### Where should the reviewer start?

`lib/bindings/python/rust/python_payload.rs` — the new `terminal_frame_bytes` helper and its two call sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved efficiency when processing terminal responses across supported data formats.
  * Reduced repeated response encoding during pull and push operations.

* **Reliability**
  * Added validation to ensure terminal responses are consistently decoded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->