### PR TITLE
perf(runtime): avoid instance-table clone in per-request dispatch check

### DIFF
--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -519,8 +519,7 @@ impl Client {
     }
 
     /// Whether the live discovery source (not the asynchronously reconciled
-    /// routing snapshot) currently contains this instance. Zero-allocation
-    /// equivalent of `instance_ids().contains(&instance_id)`.
+    /// routing snapshot) currently contains this instance.
     pub fn is_instance_live(&self, instance_id: u64) -> bool {
         self.instance_source
             .borrow()

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -518,6 +518,16 @@ impl Client {
         self.instances().into_iter().map(|ep| ep.id()).collect()
     }
 
+    /// Whether the live discovery source (not the asynchronously reconciled
+    /// routing snapshot) currently contains this instance. Zero-allocation
+    /// equivalent of `instance_ids().contains(&instance_id)`.
+    pub fn is_instance_live(&self, instance_id: u64) -> bool {
+        self.instance_source
+            .borrow()
+            .iter()
+            .any(|instance| instance.id() == instance_id)
+    }
+
     /// Whether the latest discovery snapshot contains this instance, including inhibited workers.
     pub fn is_instance_discovered(&self, instance_id: u64) -> bool {
         self.routing_instances

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -883,7 +883,7 @@ where
     }
 
     fn ensure_discovered_for_dispatch(&self, instance_id: u64) -> anyhow::Result<()> {
-        if self.client.instance_ids().contains(&instance_id) {
+        if self.client.is_instance_discovered(instance_id) {
             return Ok(());
         }
         Err(DynamoError::builder()

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -883,7 +883,7 @@ where
     }
 
     fn ensure_discovered_for_dispatch(&self, instance_id: u64) -> anyhow::Result<()> {
-        if self.client.is_instance_discovered(instance_id) {
+        if self.client.is_instance_live(instance_id) {
             return Ok(());
         }
         Err(DynamoError::builder()


### PR DESCRIPTION
#### Overview:

`ensure_discovered_for_dispatch` on the push-router hot dispatch path allocates twice per request just to answer a membership question.

#### Details:

`ensure_discovered_for_dispatch` in `lib/runtime/src/pipeline/network/egress/push_router.rs` called `self.client.instance_ids().contains(&instance_id)`. `instance_ids()` clones the full `Vec<Instance>` and allocates a fresh `Vec<u64>` on every call, just to check membership.

`Client` already exposes `is_instance_discovered(&self, instance_id: u64) -> bool` (`lib/runtime/src/component/client.rs`), a zero-allocation binary search over the sorted discovered-ids snapshot that's kept in sync with the same discovery source via `reconcile_discovered`. It's already used for the identical check in `lib/llm/src/kv_router/routing_host.rs`.

This swaps the call site to use `is_instance_discovered`, removing two heap allocations per request on this path.

Linear: DYN-4231

#### Where should the reviewer start?

`lib/runtime/src/pipeline/network/egress/push_router.rs` — single-line change at `ensure_discovered_for_dispatch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dispatch routing by using the client’s discovery status when determining whether an instance is ready for dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->