### PR TITLE
perf(runtime): pre-size the ingress response encode buffer

### DIFF
--- a/lib/bindings/python/rust/push_egress.rs
+++ b/lib/bindings/python/rust/push_egress.rs
@@ -40,7 +40,8 @@ use dynamo_runtime::engine::AsyncEngineContext;
 use dynamo_runtime::error::DynamoError;
 use dynamo_runtime::logging::get_distributed_tracing_context;
 use dynamo_runtime::pipeline::network::{
-    EncodedResponseFrame, NetworkStreamWrapper, RequestPlanePayloadCodec,
+    EncodedResponseFrame, NetworkStreamWrapper, RESPONSE_ENCODE_CAPACITY_HINT,
+    RequestPlanePayloadCodec,
 };
 use dynamo_runtime::pipeline::{
     AsyncEngine, AsyncEngineContextProvider, ManyOut, PipelineError, ResponseStream, SingleIn,
@@ -110,9 +111,9 @@ impl EncodeBuffer {
     /// make the next one ask for less room than any frame could need.
     const MIN_RESERVE: usize = 64;
     /// Starting capacity for the private buffer a re-entrant `send` falls back
-    /// to. Matches what `encode_annotated_response` gives the pull path, so the
+    /// to. Shares the constant every other response encoder starts from, so the
     /// fallback does not grow from zero.
-    const SCRATCH_CAPACITY: usize = 128;
+    const SCRATCH_CAPACITY: usize = RESPONSE_ENCODE_CAPACITY_HINT;
 
     fn new() -> Self {
         Self {

--- a/lib/bindings/python/rust/python_payload.rs
+++ b/lib/bindings/python/rust/python_payload.rs
@@ -207,11 +207,8 @@ pub(crate) fn encode_annotated_response<T: Serialize>(
     codec: RequestPlanePayloadCodec,
     annotated: Annotated<T>,
 ) -> Result<(Vec<u8>, bool), anyhow::Error> {
-    // `with_capacity`, not `new`: this is still the pull path's encoder, and
-    // `serde_json::to_vec` — which it used before — starts pre-sized. Growing
-    // from zero here would regress JSON responses to pay the reallocations this
-    // change exists to remove. Shares its starting capacity with the Rust
-    // ingress encoder so both paths behave the same.
+    // `with_capacity`, not `new`: starting from zero would regress JSON
+    // responses to pay the reallocations this change exists to remove.
     let mut bytes = Vec::with_capacity(RESPONSE_ENCODE_CAPACITY_HINT);
     let is_error = write_annotated_response(codec, annotated, &mut bytes)?;
     Ok((bytes, is_error))

--- a/lib/bindings/python/rust/python_payload.rs
+++ b/lib/bindings/python/rust/python_payload.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use dynamo_runtime::pipeline::PipelineError;
 use dynamo_runtime::pipeline::network::{
     EncodedResponseFrame, IngressRequestDecoder, IngressResponseEncoder, NetworkStreamWrapper,
-    RequestPlanePayloadCodec,
+    RESPONSE_ENCODE_CAPACITY_HINT, RequestPlanePayloadCodec,
 };
 use dynamo_runtime::protocols::annotated::Annotated;
 use dynamo_runtime::protocols::maybe_error::MaybeError;
@@ -208,10 +208,11 @@ pub(crate) fn encode_annotated_response<T: Serialize>(
     annotated: Annotated<T>,
 ) -> Result<(Vec<u8>, bool), anyhow::Error> {
     // `with_capacity`, not `new`: this is still the pull path's encoder, and
-    // `serde_json::to_vec` — which it used before — starts at 128 bytes. Growing
+    // `serde_json::to_vec` — which it used before — starts pre-sized. Growing
     // from zero here would regress JSON responses to pay the reallocations this
-    // change exists to remove.
-    let mut bytes = Vec::with_capacity(128);
+    // change exists to remove. Shares its starting capacity with the Rust
+    // ingress encoder so both paths behave the same.
+    let mut bytes = Vec::with_capacity(RESPONSE_ENCODE_CAPACITY_HINT);
     let is_error = write_annotated_response(codec, annotated, &mut bytes)?;
     Ok((bytes, is_error))
 }

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -132,3 +132,7 @@ harness = false
 [[bench]]
 name = "tcp_codec_perf"
 harness = false
+
+[[bench]]
+name = "ingress_response_encode"
+harness = false

--- a/lib/runtime/benches/ingress_response_encode.rs
+++ b/lib/runtime/benches/ingress_response_encode.rs
@@ -3,31 +3,10 @@
 
 //! Per-frame cost of the ingress response encode.
 //!
-//! `Ingress::pump_response_stream` encodes one frame per item the engine yields,
-//! so for a streaming response this runs once per generated token. Each frame is
-//! encoded into its own buffer, which makes the buffer's starting capacity — not
-//! just the allocation count — the thing that decides how much work a frame
-//! costs.
-//!
-//! Three arms encode an identical frame and differ only in where the bytes land:
-//!
-//! - `encode` builds a `Vec` inside the codec. `serde_json::to_vec` pre-sizes
-//!   that `Vec`; `rmp_serde::to_vec_named` starts it at zero capacity, so the
-//!   two codecs are expected to diverge here and only here.
-//! - `encode_into_zero_capacity` writes into a caller-owned `Vec` that also
-//!   starts empty. It isolates the writer change from the sizing change, so a
-//!   difference between this arm and the next is attributable to capacity alone.
-//! - `encode_into_presized` is what the encoder does now: a caller-owned `Vec`
-//!   started at [`RESPONSE_ENCODE_CAPACITY_HINT`].
-//!
-//! Every arm allocates and frees within the timed region, so the numbers include
-//! the buffer's whole lifetime rather than just the serialization.
-//!
-//! The arms are asserted byte-identical before any of them is timed — a hot path
-//! that quietly emitted different bytes would surface only as a decode failure at
-//! the peer. That the real encoder agrees with the `encode_into_presized` arm is
-//! pinned separately by `serde_ingress_encoder_matches_encode_byte_for_byte` in
-//! `pipeline::network`.
+//! Three arms encode an identical frame and differ only in buffer capacity:
+//! `encode` (codec-internal `Vec`), `encode_into_zero_capacity` (caller `Vec`
+//! started empty), and `encode_into_presized` (caller `Vec` started at
+//! [`RESPONSE_ENCODE_CAPACITY_HINT`], what the encoder does now).
 //!
 //! Run with: cargo bench --bench ingress_response_encode
 

--- a/lib/runtime/benches/ingress_response_encode.rs
+++ b/lib/runtime/benches/ingress_response_encode.rs
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-frame cost of the ingress response encode.
+//!
+//! `Ingress::pump_response_stream` encodes one frame per item the engine yields,
+//! so for a streaming response this runs once per generated token. Each frame is
+//! encoded into its own buffer, which makes the buffer's starting capacity — not
+//! just the allocation count — the thing that decides how much work a frame
+//! costs.
+//!
+//! Three arms encode an identical frame and differ only in where the bytes land:
+//!
+//! - `encode` builds a `Vec` inside the codec. `serde_json::to_vec` pre-sizes
+//!   that `Vec`; `rmp_serde::to_vec_named` starts it at zero capacity, so the
+//!   two codecs are expected to diverge here and only here.
+//! - `encode_into_zero_capacity` writes into a caller-owned `Vec` that also
+//!   starts empty. It isolates the writer change from the sizing change, so a
+//!   difference between this arm and the next is attributable to capacity alone.
+//! - `encode_into_presized` is what the encoder does now: a caller-owned `Vec`
+//!   started at [`RESPONSE_ENCODE_CAPACITY_HINT`].
+//!
+//! Every arm allocates and frees within the timed region, so the numbers include
+//! the buffer's whole lifetime rather than just the serialization.
+//!
+//! The arms are asserted byte-identical before any of them is timed — a hot path
+//! that quietly emitted different bytes would surface only as a decode failure at
+//! the peer. That the real encoder agrees with the `encode_into_presized` arm is
+//! pinned separately by `serde_ingress_encoder_matches_encode_byte_for_byte` in
+//! `pipeline::network`.
+//!
+//! Run with: cargo bench --bench ingress_response_encode
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use dynamo_runtime::pipeline::network::{
+    NetworkStreamWrapper, RESPONSE_ENCODE_CAPACITY_HINT, RequestPlanePayloadCodec,
+};
+use dynamo_runtime::protocols::annotated::Annotated;
+use serde::Serialize;
+
+/// Stand-in for what a Rust-native engine streams during decode: some token ids
+/// and their position. A typed struct rather than a `serde_json::Value`, because
+/// the engines that reach `SerdeIngressPayloadAdapter` hand it typed responses —
+/// routing a `Value` through here would time serde's dynamic walk instead of the
+/// encode under test.
+#[derive(Serialize)]
+struct TokenFrame {
+    token_ids: Vec<u32>,
+    index: u64,
+}
+
+/// The exact envelope the response encoder builds, so the bench serializes the
+/// same shape the wire carries: the `Annotated` wrapper plus the stream marker.
+fn frame(tokens: usize) -> NetworkStreamWrapper<Annotated<TokenFrame>> {
+    NetworkStreamWrapper {
+        data: Some(Annotated::from_data(TokenFrame {
+            // Spread across the msgpack integer widths rather than clustering in
+            // the single-byte range, so a wider frame costs what a real one does.
+            token_ids: (0..tokens as u32).map(|i| 1_000 + i * 37).collect(),
+            index: 7,
+        })),
+        complete_final: false,
+    }
+}
+
+fn bench_ingress_response_encode(c: &mut Criterion) {
+    for codec in [
+        RequestPlanePayloadCodec::Msgpack,
+        RequestPlanePayloadCodec::Json,
+    ] {
+        let mut group = c.benchmark_group(format!("ingress_response_encode_{}", codec.name()));
+
+        // 1 token is steady-state decode; the wider frames are what speculative
+        // decode and MTP emit, and they show how the arms scale with frame size.
+        for tokens in [1usize, 4, 16] {
+            let frame = frame(tokens);
+
+            let expected = codec.encode(&frame).expect("reference encode");
+            let mut from_zero = Vec::new();
+            codec
+                .encode_into(&frame, &mut from_zero)
+                .expect("zero-capacity encode");
+            let mut presized = Vec::with_capacity(RESPONSE_ENCODE_CAPACITY_HINT);
+            codec
+                .encode_into(&frame, &mut presized)
+                .expect("presized encode");
+            assert_eq!(
+                expected,
+                from_zero,
+                "codec={} tokens={tokens}",
+                codec.name()
+            );
+            assert_eq!(expected, presized, "codec={} tokens={tokens}", codec.name());
+
+            group.throughput(Throughput::Bytes(expected.len() as u64));
+
+            group.bench_with_input(BenchmarkId::new("encode", tokens), &frame, |b, frame| {
+                b.iter(|| black_box(codec.encode(frame).expect("encode")));
+            });
+
+            group.bench_with_input(
+                BenchmarkId::new("encode_into_zero_capacity", tokens),
+                &frame,
+                |b, frame| {
+                    b.iter(|| {
+                        let mut bytes = Vec::new();
+                        codec.encode_into(frame, &mut bytes).expect("encode_into");
+                        black_box(bytes)
+                    });
+                },
+            );
+
+            group.bench_with_input(
+                BenchmarkId::new("encode_into_presized", tokens),
+                &frame,
+                |b, frame| {
+                    b.iter(|| {
+                        let mut bytes = Vec::with_capacity(RESPONSE_ENCODE_CAPACITY_HINT);
+                        codec.encode_into(frame, &mut bytes).expect("encode_into");
+                        black_box(bytes)
+                    });
+                },
+            );
+        }
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_ingress_response_encode);
+criterion_main!(benches);

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -130,6 +130,18 @@ impl RequestPlanePayloadCodec {
     }
 }
 
+/// Starting capacity for a buffer that one response frame is encoded into.
+///
+/// Where that buffer starts decides how many times it regrows before the frame
+/// fits, and a streaming response encodes a frame per generated token. The two
+/// codecs disagree on the default: `serde_json::to_vec` starts at 128 bytes,
+/// while `rmp_serde::to_vec_named` starts at zero — so msgpack, the default
+/// codec, pays that regrowth on every frame unless the caller sizes the buffer
+/// itself. Matching the JSON figure keeps both codecs starting from the same
+/// place. A frame larger than this still encodes correctly; it just grows as it
+/// would have anyway.
+pub const RESPONSE_ENCODE_CAPACITY_HINT: usize = 128;
+
 pub trait Codable: PipelineIO + Serialize + for<'de> Deserialize<'de> {}
 impl<T: PipelineIO + Serialize + for<'de> Deserialize<'de>> Codable for T {}
 
@@ -486,11 +498,13 @@ pub struct Egress<Req: PipelineIO, Resp: PipelineIO> {
 #[cfg(test)]
 mod tests {
     use super::{
-        DEFAULT_SEND_BUFFER_COUNT, NetworkStreamWrapper, RequestControlMessage,
-        RequestPlanePayloadCodec, RequestType, ResponseType, StreamOptions,
+        DEFAULT_SEND_BUFFER_COUNT, IngressResponseEncoder, NetworkStreamWrapper,
+        RequestControlMessage, RequestPlanePayloadCodec, RequestType, ResponseType,
+        SerdeIngressPayloadAdapter, StreamOptions,
     };
     use crate::engine::AsyncEngineContextProvider;
     use crate::pipeline::Context;
+    use crate::protocols::annotated::Annotated;
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -659,6 +673,58 @@ mod tests {
             assert_eq!(decoded, wrapper);
         }
     }
+
+    /// The ingress response encoder builds its frame with `encode_into` against a
+    /// pre-sized buffer rather than `encode`. Nothing local reads that frame back
+    /// — it is decoded by the peer — so a byte-level divergence would surface as
+    /// a decode failure at the caller, far from the change that caused it. Pin
+    /// the equivalence here instead, across both codecs and all three frame
+    /// shapes the encoder produces.
+    #[tokio::test]
+    async fn serde_ingress_encoder_matches_encode_byte_for_byte() {
+        let data = Annotated::from_data(serde_json::json!({
+            "token_ids": [128, 9001],
+            "index": 3,
+        }));
+        let error = Annotated::<serde_json::Value>::from_error("engine failed");
+
+        for codec in [
+            RequestPlanePayloadCodec::Json,
+            RequestPlanePayloadCodec::Msgpack,
+        ] {
+            for (case, response, complete_final, expect_error) in [
+                ("data frame", Some(data.clone()), false, false),
+                ("error frame", Some(error.clone()), false, true),
+                ("complete final", None, true, false),
+            ] {
+                let expected = codec
+                    .encode(&NetworkStreamWrapper {
+                        data: response.clone(),
+                        complete_final,
+                    })
+                    .expect("reference encode");
+
+                let frame = SerdeIngressPayloadAdapter
+                    .encode_response(codec, response, complete_final)
+                    .await
+                    .expect("adapter encode");
+
+                assert_eq!(
+                    frame.bytes.as_ref(),
+                    expected.as_slice(),
+                    "codec={} case={case}",
+                    codec.name()
+                );
+                assert_eq!(
+                    frame.is_error,
+                    expect_error,
+                    "codec={} case={case}",
+                    codec.name()
+                );
+                assert!(!frame.stop_stream, "codec={} case={case}", codec.name());
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -768,13 +834,17 @@ where
             data: response,
             complete_final,
         };
-        let encoded = payload_codec.encode(&wrapper).map_err(|err| {
-            PipelineError::SerializationError(format!(
-                "Failed serializing {} request-plane response: {}",
-                payload_codec.name(),
-                err
-            ))
-        });
+        let mut bytes = Vec::with_capacity(RESPONSE_ENCODE_CAPACITY_HINT);
+        let encoded = payload_codec
+            .encode_into(&wrapper, &mut bytes)
+            .map(|()| bytes)
+            .map_err(|err| {
+                PipelineError::SerializationError(format!(
+                    "Failed serializing {} request-plane response: {}",
+                    payload_codec.name(),
+                    err
+                ))
+            });
         std::future::ready(encoded.map(|bytes| EncodedResponseFrame {
             bytes: bytes.into(),
             is_error,

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -132,14 +132,8 @@ impl RequestPlanePayloadCodec {
 
 /// Starting capacity for a buffer that one response frame is encoded into.
 ///
-/// Where that buffer starts decides how many times it regrows before the frame
-/// fits, and a streaming response encodes a frame per generated token. The two
-/// codecs disagree on the default: `serde_json::to_vec` starts at 128 bytes,
-/// while `rmp_serde::to_vec_named` starts at zero — so msgpack, the default
-/// codec, pays that regrowth on every frame unless the caller sizes the buffer
-/// itself. Matching the JSON figure keeps both codecs starting from the same
-/// place. A frame larger than this still encodes correctly; it just grows as it
-/// would have anyway.
+/// Matches `serde_json::to_vec`'s own default so msgpack — which otherwise
+/// starts at zero — stops regrowing its buffer on every streamed frame.
 pub const RESPONSE_ENCODE_CAPACITY_HINT: usize = 128;
 
 pub trait Codable: PipelineIO + Serialize + for<'de> Deserialize<'de> {}
@@ -674,12 +668,7 @@ mod tests {
         }
     }
 
-    /// The ingress response encoder builds its frame with `encode_into` against a
-    /// pre-sized buffer rather than `encode`. Nothing local reads that frame back
-    /// — it is decoded by the peer — so a byte-level divergence would surface as
-    /// a decode failure at the caller, far from the change that caused it. Pin
-    /// the equivalence here instead, across both codecs and all three frame
-    /// shapes the encoder produces.
+    /// `encode_into` must stay byte-compatible with `encode` for both codecs.
     #[tokio::test]
     async fn serde_ingress_encoder_matches_encode_byte_for_byte() {
         let data = Annotated::from_data(serde_json::json!({


### PR DESCRIPTION
#### Overview:

`RequestPlanePayloadCodec::encode_into` landed in #13983 so a hot path could encode into a caller-owned buffer, and push egress was switched over to it. The Rust *ingress* response encoder beside it was missed and still calls the allocating `encode`. This points it at the same buffer and lifts the shared starting capacity into one constant.

#### Details:

`SerdeIngressPayloadAdapter::encode_response` emits one frame per generated token on the Rust-native worker paths (`lib/backend-common/src/worker.rs`, `lib/llm/src/entrypoint/input/endpoint.rs`). For msgpack — the default codec — `encode` hands `rmp_serde::to_vec_named` a `Vec` at zero capacity, so every frame is filled by a sequence of reallocate-and-copy steps.

- `lib/runtime/src/pipeline/network.rs` — `encode_response` now calls `encode_into` against a pre-sized buffer, and adds `RESPONSE_ENCODE_CAPACITY_HINT`.
- `lib/bindings/python/rust/python_payload.rs` — `encode_annotated_response` uses that constant in place of the bare `128` from #13983.
- `lib/bindings/python/rust/push_egress.rs` — so does `EncodeBuffer::SCRATCH_CAPACITY`, whose comment already claimed to match the pull path's capacity.

No wire-format change: `encode` and `encode_into` share the same serializer and differ only in the buffer they are handed.

#### Measured:

New bench `lib/runtime/benches/ingress_response_encode.rs`. Median ns per frame on macOS/arm64, so read the ratios rather than the absolute numbers:

| codec | tokens/frame | `encode` | this PR | change |
| -- | -- | -- | -- | -- |
| msgpack | 1 | 120.5 | 25.7 | −79% |
| msgpack | 4 | 127.5 | 30.6 | −76% |
| msgpack | 16 | 177.1 | 49.2 | −72% |
| json | 1 | 56.5 | 59.0 | +2.5 ns |
| json | 4 | 69.0 | 70.3 | +1.2 ns |
| json | 16 | 141.4 | 146.0 | +4.6 ns |

JSON gets marginally worse, and that is a real regression rather than measurement noise — the 95% confidence intervals do not overlap. It is worth taking: msgpack is the default, since `from_config_value` returns it for unset, empty, *and* invalid values, while JSON needs an explicit `DYN_REQUEST_PLANE_CODEC=json`. So this spends ~2.5 ns on an opt-in codec to save ~95 ns on the one that runs by default.

<details>
<summary>Why the win is the buffer's capacity and not the switch to a writer</summary>

Moving to `encode_into` changes two things at once — which function writes the bytes, and the buffer's starting capacity — so the bench has a third arm that writes into a *zero-capacity* `Vec`. That holds the writer fixed and varies only the capacity:

| codec | tokens | 1. `encode` | 2. `encode_into` zero-cap | 3. `encode_into` presized |
| -- | -- | -- | -- | -- |
| msgpack | 1 | 120.5 | 103.1 | **25.7** |
| msgpack | 4 | 127.5 | 105.9 | **30.6** |
| msgpack | 16 | 177.1 | 156.2 | **49.2** |
| json | 1 | 56.5 | 164.3 | **59.0** |
| json | 4 | 69.0 | 179.0 | **70.3** |
| json | 16 | 141.4 | 248.2 | **146.0** |

For msgpack, arm 1 → arm 2 barely moves while arm 2 → arm 3 drops ~4x, so the writer switch buys nothing and the capacity is the whole effect.

The JSON rows are the control. `serde_json::to_vec` already pre-sizes to 128, so arms 1 and 3 both start there, and arm 2 is what *removes* that pre-sizing — where it runs 2.9x slower than JSON's own baseline, reproducing exactly the pathology msgpack has. Had the gain come from `encode_into` being a faster writer, JSON's arm 2 would have been fast too. Instead the cost tracks capacity in both codecs and in both directions, which is also why the constant is 128: that is the size serde_json picked, so matching it makes the two codecs behave alike.

JSON's remaining ~2 ns is one extra generic layer — `encode_into` is generic over `W: io::Write` and delegates to `serde_json::to_writer`, where `encode` calls `to_vec`. I have not confirmed inlining is the mechanism. Branching per codec to avoid it would mean two buffer strategies to keep in sync, and would bake in an assumption about `to_vec`'s internal pre-sizing that is not part of its contract — if that changed on a dependency bump, the branch would silently become the wrong choice while the byte-equivalence tests stayed green.

Every arm allocates *and* frees inside the timed region, so these numbers cover the buffer's whole lifetime rather than just serialization.

</details>

#### Where should the reviewer start?

`lib/runtime/src/pipeline/network.rs` — the `encode_response` body and the new constant are the entire change; the other two files only swap a literal for it. `serde_ingress_encoder_matches_encode_byte_for_byte` in the same file's test module is what pins the no-wire-change claim, over data, error, and `complete_final` frames on both codecs.

#### Validation:

- `cargo test -p dynamo-runtime` passes, including the new byte-equivalence test.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean on `dynamo-runtime` and `dynamo-py3`; `pre-commit run` clean.
- Pre-existing flake, not from this change: `lib/runtime/tests/bidirectional_e2e.rs` fails roughly half the time on current `main` with `Disconnected: "Stream ended before generation completed"` — 5/10 runs with the stock encoder, 6/10 with this change.

#### Related Issues:

Tracked internally as DYN-4191.
