### PR TITLE
fix(docs-ci): probe the benchmarks section landing in the published-styles check

### DIFF
--- a/docs/fern/scripts/check_published_styles.py
+++ b/docs/fern/scripts/check_published_styles.py
@@ -69,13 +69,10 @@ CHECKS: list[tuple[str, str, str]] = [
     ("community", ".dynamo-community-page", "LandingStyles"),
     ("digest", ".dynamo-blog-art__grid", "BlogStyles"),
     ("reference/compatibility", ".dynref-panel", "ReferenceStyles"),
-    # URL from the nav's explicit slugs (section `benchmarks`, page
-    # `llama-3-70b-topology`), not the page's file path.
-    (
-        "recipes/benchmarks/llama-3-70b-topology",
-        ".dynamo-benchmark-grid",
-        "RecipeStyles",
-    ),
+    # Probe the Feature Benchmarks section landing, not a recipe detail page:
+    # detail pages retire with their recipes. Path is the nav slug from
+    # index.yml (`slug: benchmarks`), not the page's file path.
+    ("recipes/benchmarks", ".dynamo-benchmark-grid", "RecipeStyles"),
 ]
 
 # Minified CSS keeps only mandatory whitespace, so match `.foo{` and `.foo,`


### PR DESCRIPTION
## Overview:

The `Verify published pages carry their component CSS` step in **Fern Docs** has been failing on
`main` since 2026-08-26. It probes a Feature Benchmarks page that no longer exists, so the job
fails every time the publish path actually runs. This repoints the probe at the section landing,
which does not retire when an individual recipe does.

## Details:

`check_published_styles.py` probed `recipes/benchmarks/llama-3-70b-topology`. #13663
(*chore(recipes): remove DeepSeek-V3.2 FP4 and Llama-3-70B recipes*, merged 2026-08-26T18:30:23Z)
removed `docs/fern/pages/recipes/feature-benchmarks/_catalog/benchmarks/llama-3-70b-topology.yaml`,
and no redirect was added, so the URL now 404s permanently.

Failing step output (run 33579735939, `50c6fea10`):

```
ok    https://docs.nvidia.com/dynamo/dev/reference/compatibility  .dynref-panel (9 rules, ReferenceStyles)
could not fetch https://docs.nvidia.com/dynamo/dev/recipes/benchmarks/llama-3-70b-topology: HTTP Error 404: Not Found
```

The replacement is the **Feature Benchmarks section landing**, `recipes/benchmarks` — the
`slug: benchmarks` entry at `docs/fern/index.yml:852-854`. Its page,
`pages/recipes/feature-benchmarks/browse-all-benchmarks.mdx`, imports and renders `<RecipeStyles />`
(lines 9 and 11), so the entry still exercises the component it names. The live landing carries
**6** `.dynamo-benchmark-grid` rules — the same count as the surviving benchmark pages.

Unlike a model page, the section slug survives the retirement of any individual recipe, which is
exactly the failure that occurred here. This entry has now broken twice: once on slug shape
(fixed in #13476) and once on page deletion. Probing the landing removes the second failure mode
without adding machinery.

## Where should the reviewer start?

`docs/fern/scripts/check_published_styles.py`, the final `CHECKS` entry (lines 72-77). It is a
one-tuple change.

The publish step is gated on `is_main == 'true'` in `fern-docs.yml`, so this check cannot run on a
PR. Correctness is reproducible locally in under two minutes:

```
$ python3 docs/fern/scripts/check_published_styles.py --test
7/7 passed

$ python3 docs/fern/scripts/check_published_styles.py --retries 1 --delay 1
ok    https://docs.nvidia.com/dynamo/dev/recipes/benchmarks  .dynamo-benchmark-grid (6 rules, RecipeStyles)
all 6 published style checks passed
```

On `main` as it stands today, that second command exits 1 with the 404 above.

### Deliberately not included

- **`probe()` retry behaviour.** A 404 currently retries 5 times at 30s intervals (~124s of runner
  time) and reports `could not fetch` rather than distinguishing "this page no longer exists", and
  `SystemExit` aborts the remaining checks so one 404 masks later breakage. Real, but a separate
  concern — happy to open a follow-up.
- **Deriving probe URLs from `index.yml`.** Would prevent this class of drift entirely, but it is a
  design change rather than a repair. Raising it as an option, not proposing it here.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the published-style check to reference the Feature Benchmarks landing page instead of the retired model topology detail page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->