### PR TITLE
test(runtime): isolate hello world client output

### DIFF
--- a/lib/bindings/python/tests/test_example_hello_world.py
+++ b/lib/bindings/python/tests/test_example_hello_world.py
@@ -53,22 +53,24 @@ async def server_process(example_dir):
 
 async def run_client(example_dir):
     """Run the client for a specified duration and capture its output"""
-    client_proc = subprocess.Popen(
+    with subprocess.Popen(
         ["python3", "-u", "client.py"],
         cwd=example_dir,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
-    )
+    ) as client_proc:
+        # Let it run for 5 seconds
+        await asyncio.sleep(5)
 
-    # Let it run for 5 seconds
-    await asyncio.sleep(5)
-
-    # Terminate the client
-    client_proc.terminate()
-    stdout, stderr = client_proc.communicate(timeout=1)
-
-    return stdout, stderr
+        # Terminate the client
+        client_proc.terminate()
+        try:
+            return client_proc.communicate(timeout=1)
+        except subprocess.TimeoutExpired:
+            client_proc.kill()
+            client_proc.communicate()
+            raise
 
 
 @pytest.mark.asyncio

--- a/lib/bindings/python/tests/test_example_hello_world.py
+++ b/lib/bindings/python/tests/test_example_hello_world.py
@@ -15,6 +15,7 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
     pytest.mark.integration,
+    pytest.mark.timeout(30),
 ]
 
 
@@ -56,7 +57,7 @@ async def run_client(example_dir):
         ["python3", "-u", "client.py"],
         cwd=example_dir,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
         text=True,
     )
 
@@ -65,16 +66,16 @@ async def run_client(example_dir):
 
     # Terminate the client
     client_proc.terminate()
-    stdout, _ = client_proc.communicate(timeout=1)
+    stdout, stderr = client_proc.communicate(timeout=1)
 
-    return stdout
+    return stdout, stderr
 
 
 @pytest.mark.asyncio
 async def test_hello_world(example_dir, server_process):
     """Test that hello_world starts and its client produces the expected output sequence"""
     # Run the client for 5 seconds
-    client_output = await run_client(example_dir)
+    client_output, client_logs = await run_client(example_dir)
 
     # Split output into lines and strip whitespace, filter out empty lines
     lines = [line.strip() for line in client_output.split("\n") if line.strip()]
@@ -85,5 +86,7 @@ async def test_hello_world(example_dir, server_process):
     expected_lines = ["Hello world!", "Hello sun!", "Hello moon!", "Hello star!"]
     for expected_line in expected_lines:
         assert expected_line in lines, (
-            f"Expected line '{expected_line}' not found in output.\n" f"Lines: {lines}"
+            f"Expected line '{expected_line}' not found in output.\n"
+            f"Lines: {lines}\n"
+            f"Client logs: {client_logs}"
         )


### PR DESCRIPTION
## Overview:

Prevent the hello-world integration test from failing when Rust tracing output is written at the same time as the client's final protocol line.

The original failure occurred on [PR #13742](https://github.com/ai-dynamo/dynamo/pull/13742) at commit `09f1b8a3eeb98a309b21893e57414bb1d5283abb`.

## Details:

- capture the hello-world client's stdout and stderr separately
- assert protocol output using stdout only
- retain stderr in assertion diagnostics
- bound the test with a 30-second pytest timeout
- manage the client subprocess with a context manager
- if graceful termination exceeds one second, kill the client, drain both pipes, and re-raise `subprocess.TimeoutExpired`

### Original CI failure evidence

- Workflow: [PR run 33583408848](https://github.com/ai-dynamo/dynamo/actions/runs/33583408848)
- Job: [dynamo-runtime / test / sequential cuda13.0, amd64](https://github.com/ai-dynamo/dynamo/actions/runs/33583408848/job/100104497678)
- Failing test: `lib/bindings/python/tests/test_example_hello_world.py::test_hello_world`
- Result: `1 failed, 3081 passed, 21 skipped, 1942 deselected`

The expected application output was present, but a tracing record from stderr was appended to the same captured line:

```text
AssertionError: Expected line 'Hello star!' not found in output.
...
'Hello star!\x1b[2m2026-09-02T02:46:32.435568Z\x1b[0m ... route request completed ...'
```

The test previously used `stderr=subprocess.STDOUT` and required `"Hello star!"` to equal an entire split line. Concurrent stdout and stderr writes could therefore create a combined line even though the response was correct.

## Where should the reviewer start?

`lib/bindings/python/tests/test_example_hello_world.py`, especially `run_client()` and the output assertions in `test_hello_world()`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Validation

- `git diff --check`
- `uvx ruff format --check lib/bindings/python/tests/test_example_hello_world.py`
- `python3 -m py_compile lib/bindings/python/tests/test_example_hello_world.py`
- all commits verified locally with the registered SSH signing key and verified by GitHub

The targeted pytest is not runnable on this host because it does not have pytest or a built Dynamo Python environment. Full CI exercises the integration test in the repository image.
