### PR TITLE
test(router): wait for worker before stream error test

### DIFF
--- a/lib/bindings/python/tests/test_kv_router_stream_errors.py
+++ b/lib/bindings/python/tests/test_kv_router_stream_errors.py
@@ -67,8 +67,11 @@ async def error_router_endpoint(temp_file_store):
 @pytest.mark.timeout(30)
 @pytest.mark.parametrize("response_buffer_size", [0, 100])
 async def test_kv_router_propagates_stream_errors(
-    error_router_endpoint, response_buffer_size
+    error_router_endpoint, response_buffer_size, monkeypatch
 ):
+    # Wait for the router's worker watcher to observe the registered endpoint before
+    # issuing the request. The fixture's endpoint client has a separate watcher.
+    monkeypatch.setenv("DYN_ROUTER_MIN_INITIAL_WORKERS", "1")
     router = KvRouter(
         error_router_endpoint,
         4,


### PR DESCRIPTION
## Summary

- require one initial worker while constructing the KV router in the stream-error integration test
- use pytest's `monkeypatch` fixture so `DYN_ROUTER_MIN_INITIAL_WORKERS` is restored after each parametrized case
- remove the race between endpoint-client discovery readiness and the KV router's independent worker watcher

## Original CI failure evidence

This fixes a failure observed on [PR #13742](https://github.com/ai-dynamo/dynamo/pull/13742) at commit `09f1b8a3eeb98a309b21893e57414bb1d5283abb`.

- Workflow: [PR run 33583408848](https://github.com/ai-dynamo/dynamo/actions/runs/33583408848)
- Job: [dynamo-runtime / test / sequential cuda13.0, arm64](https://github.com/ai-dynamo/dynamo/actions/runs/33583408848/job/100104497727)
- Failing test: `lib/bindings/python/tests/test_kv_router_stream_errors.py::test_kv_router_propagates_stream_errors[100]`
- Job result: `1 failed, 3081 passed, 21 skipped, 1942 deselected`

The relevant failure was:

```text
FAILED lib/bindings/python/tests/test_kv_router_stream_errors.py::test_kv_router_propagates_stream_errors[100]
Exception: no endpoints available to route work
```

The fixture waits for an endpoint client to observe the registered worker, but `KvRouter` initializes a separate worker watcher. With the default minimum initial worker count of zero, router construction can return before that watcher has received its initial worker snapshot. The immediate `generate()` call can then observe an empty routing set.

## Why this fixes it

The test sets `DYN_ROUTER_MIN_INITIAL_WORKERS=1` before constructing `KvRouter`. The router's existing startup gate waits until its own watcher contains the registered worker, so the request tests stream-error propagation rather than discovery timing. `monkeypatch` scopes and restores the environment change for test isolation.

## Validation

- `git diff --check`
- `uvx ruff format --check lib/bindings/python/tests/test_kv_router_stream_errors.py`
- `python3 -m py_compile lib/bindings/python/tests/test_kv_router_stream_errors.py`
- Commit verified locally with the registered SSH signing key and verified by GitHub

The targeted pytest was not runnable on the host because it does not have pytest or a built Dynamo Python environment. Full CI should exercise both parametrized cases in the repository image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved coverage and reliability for KV-router stream error propagation across different response buffer sizes.
  - Test setup now consistently exercises scenarios with a minimal initial worker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->