### PR TITLE
fix(router): forward AIPerf trace hints

### DIFF
--- a/benchmarks/router/README.md
+++ b/benchmarks/router/README.md
@@ -283,7 +283,7 @@ python real_data_benchmark.py --input-dataset trace.jsonl --prefix-root-multipli
 1. The trace is synthesized (same parameters as `real_data_benchmark.py`) and split into low / medium / high tiers according to `--priority-distribution`.
 2. Each tier is sent to aiperf as a concurrent stream. In the priority-tagged run, every trace row carries an OpenAI-compatible extension field:
    ```json
-   {"nvext": {"agent_hints": {"priority": <value>}}}
+   {"extra": {"nvext": {"agent_hints": {"priority": <value>}}}}
    ```
    The `priority` value raises the request's router queue priority -- a higher value shifts the request's effective arrival time earlier, giving it priority over lower-valued requests.
 3. The baseline and priority runs use the same aiperf seed and split so prompt content matches. The priority run offsets `hash_ids` to keep its KV cache cold relative to the baseline and prevent mocker KV cache cross-contamination.

--- a/benchmarks/router/common.py
+++ b/benchmarks/router/common.py
@@ -62,7 +62,7 @@ def add_common_args(parser):
     parser.add_argument(
         "--use-expected-osl",
         action="store_true",
-        help="Pass agent_hints.osl to nvext for router output block tracking",
+        help="Pass agent_hints.osl through extra.nvext for router output block tracking",
     )
 
 
@@ -210,12 +210,38 @@ def get_aiperf_cmd_for_trace(
     return cmd
 
 
+def set_trace_agent_hint(request, name, value):
+    """Set an agent hint in the trace envelope forwarded by AIPerf."""
+    extra = request.get("extra")
+    if not isinstance(extra, dict):
+        extra = {}
+        request["extra"] = extra
+
+    nvext = extra.get("nvext")
+    if not isinstance(nvext, dict):
+        nvext = {}
+        extra["nvext"] = nvext
+
+    agent_hints = nvext.get("agent_hints")
+    if not isinstance(agent_hints, dict):
+        agent_hints = {}
+        nvext["agent_hints"] = agent_hints
+
+    agent_hints[name] = value
+
+
+def add_expected_osl(request):
+    """Add the trace output length as the router's expected OSL hint."""
+    osl = request.get("output_length", request.get("output_tokens", 0))
+    set_trace_agent_hint(request, "osl", osl)
+
+
 def prepare_trace_dataset(args, output_dir, logger):
     """Prepare a trace dataset, optionally synthesizing or modifying it.
 
     Handles three paths:
     1. No synthesis needed: use the original dataset as-is
-    2. Expected OSL injection only: inject agent_hints.osl into nvext
+    2. Expected OSL injection only: inject agent_hints.osl into extra.nvext
     3. Full synthesis: generate synthetic data from the input dataset
 
     Returns:
@@ -247,7 +273,7 @@ def prepare_trace_dataset(args, output_dir, logger):
         return requests, trace_dataset_path
 
     if not needs_synthesis and args.use_expected_osl:
-        # Only inject agent_hints.osl into nvext, no other synthesis
+        # Only inject agent_hints.osl into extra.nvext, no other synthesis
         logger.info("Injecting agent_hints.osl into original trace dataset...")
 
         requests = []
@@ -256,10 +282,7 @@ def prepare_trace_dataset(args, output_dir, logger):
                 requests.append(json.loads(line.strip()))
 
         for request in requests:
-            osl = request.get("output_length", request.get("output_tokens", 0))
-            if "nvext" not in request:
-                request["nvext"] = {}
-            request["nvext"].setdefault("agent_hints", {})["osl"] = osl
+            add_expected_osl(request)
 
         trace_dataset_path = os.path.join(output_dir, "trace_with_expected_osl.jsonl")
         with open(trace_dataset_path, "w") as f:
@@ -324,11 +347,8 @@ def prepare_trace_dataset(args, output_dir, logger):
 
     if args.use_expected_osl:
         for request in requests:
-            osl = request.get("output_length", request.get("output_tokens", 0))
-            if "nvext" not in request:
-                request["nvext"] = {}
-            request["nvext"].setdefault("agent_hints", {})["osl"] = osl
-        logger.info("Injected agent_hints.osl into nvext for each request")
+            add_expected_osl(request)
+        logger.info("Injected agent_hints.osl into extra.nvext for each request")
 
     with open(trace_dataset_path, "w") as f:
         for request in requests:

--- a/benchmarks/router/real_data_priority_benchmark.py
+++ b/benchmarks/router/real_data_priority_benchmark.py
@@ -21,6 +21,7 @@ from common import (
     get_aiperf_cmd_for_trace,
     prepare_trace_dataset,
     resolve_tokenizer,
+    set_trace_agent_hint,
     setup_logger,
 )
 
@@ -73,22 +74,11 @@ def offset_hash_ids(tier_requests):
 
 
 def tag_requests_with_priority(requests, priority):
-    """Return request copies with nvext.agent_hints.priority merged in."""
+    """Return request copies with extra.nvext.agent_hints.priority merged in."""
     tagged_requests = []
     for request in requests:
         tagged_request = copy.deepcopy(request)
-
-        nvext = tagged_request.get("nvext")
-        if not isinstance(nvext, dict):
-            nvext = {}
-            tagged_request["nvext"] = nvext
-
-        agent_hints = nvext.get("agent_hints")
-        if not isinstance(agent_hints, dict):
-            agent_hints = {}
-            nvext["agent_hints"] = agent_hints
-
-        agent_hints["priority"] = priority
+        set_trace_agent_hint(tagged_request, "priority", priority)
         tagged_requests.append(tagged_request)
     return tagged_requests
 
@@ -107,7 +97,7 @@ def run_concurrent_streams(
     """Launch concurrent aiperf subprocesses for each tier.
 
     Args:
-        tag_priority: If True, inject nvext.agent_hints.priority per tier.
+        tag_priority: If True, inject extra.nvext.agent_hints.priority per tier.
     """
     processes = []
     log_files = []

--- a/benchmarks/router/tests/conftest.py
+++ b/benchmarks/router/tests/conftest.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from pathlib import Path
+
+_ROUTER_DIR = Path(__file__).resolve().parents[1]
+sys.path[:0] = [str(_ROUTER_DIR.parent), str(_ROUTER_DIR)]

--- a/benchmarks/router/tests/test_common.py
+++ b/benchmarks/router/tests/test_common.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from router.common import add_expected_osl
+from router.real_data_priority_benchmark import tag_requests_with_priority
+
+
+def test_expected_osl_uses_mooncake_output_length_and_preserves_hints():
+    """Prefer Mooncake output length without replacing existing request hints."""
+    request = {
+        "output_length": 32,
+        "output_tokens": 64,
+        "extra": {
+            "metadata": "preserved",
+            "nvext": {"agent_hints": {"priority": 7}},
+        },
+    }
+
+    add_expected_osl(request)
+
+    assert request["extra"] == {
+        "metadata": "preserved",
+        "nvext": {"agent_hints": {"priority": 7, "osl": 32}},
+    }
+    assert "nvext" not in request
+
+
+def test_expected_osl_supports_legacy_output_tokens():
+    """Use the legacy output token field when output length is absent."""
+    request = {"output_tokens": 48}
+
+    add_expected_osl(request)
+
+    assert request["extra"]["nvext"]["agent_hints"]["osl"] == 48
+
+
+def test_priority_tagging_does_not_mutate_source_request():
+    """Add priority to a deep copy while preserving the source request."""
+    request = {
+        "extra": {
+            "metadata": {"request_id": "request-1"},
+            "nvext": {"agent_hints": {"osl": 32}},
+        }
+    }
+
+    tagged_request = tag_requests_with_priority([request], priority=7)[0]
+
+    assert request["extra"]["nvext"]["agent_hints"] == {"osl": 32}
+    assert tagged_request["extra"] == {
+        "metadata": {"request_id": "request-1"},
+        "nvext": {"agent_hints": {"osl": 32, "priority": 7}},
+    }
+    assert tagged_request["extra"] is not request["extra"]


### PR DESCRIPTION
## Overview:

Router benchmark traces wrote request-specific `nvext` hints at the top level, but AIPerf's Mooncake loader forwards them only from the `extra` envelope. As a result, expected-output-length and priority hints could be silently dropped before reaching Dynamo. The expected OSL path also read `output_tokens`, while Mooncake traces use `output_length`, which produced an `osl` hint of `0`.

## Details:

- Add a shared helper that writes router hints to `extra.nvext.agent_hints`.
- Derive expected OSL from Mooncake's `output_length`, retaining `output_tokens` as a compatibility fallback.
- Use the same forwarded envelope for the real-data priority benchmark.
- Update the documented priority trace shape and add focused regression coverage.

## Where should the reviewer start?

Start with `benchmarks/router/common.py`, particularly `set_trace_agent_hint()` and `add_expected_osl()`. The priority benchmark then reuses the same helper in `benchmarks/router/real_data_priority_benchmark.py`.

## Related Issues

- Relates to #14254

## Validation

- `PYTHONPATH=benchmarks python -m pytest -q benchmarks/router/tests/test_common.py` (`2 passed`)
- Repository pre-commit hooks passed for all changed files.
- Wire-capture runs with AIPerf `0.10.0` and `0.12.0` both forwarded `nvext.agent_hints.osl: 8` in the actual HTTP request from a Mooncake trace containing `output_length: 8`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark request examples to place `nvext` metadata under the OpenAI-compatible `extra` field.
  * Updated priority benchmark documentation to reflect the new metadata location.

* **Bug Fixes**
  * Improved benchmark metadata handling for priority and expected output-length hints.
  * Preserved existing request metadata while supporting legacy output-token data.

* **Tests**
  * Added coverage for metadata preservation, output-length precedence, legacy compatibility, and nested hint handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->