### PR TITLE
fix(operator): set parent references on resource updates

### DIFF
--- a/deploy/operator/internal/controller_common/resource.go
+++ b/deploy/operator/internal/controller_common/resource.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -30,7 +31,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -38,6 +39,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -93,7 +95,7 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 	}
 
 	err = r.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: resourceNamespace}, oldResource)
-	oldResourceIsNotFound := errors.IsNotFound(err)
+	oldResourceIsNotFound := apierrors.IsNotFound(err)
 	if err != nil && !oldResourceIsNotFound {
 		r.GetRecorder().Eventf(resource, nil, corev1.EventTypeWarning, fmt.Sprintf("Get%s", resourceType), "Get", "Failed to get %s %s: %s", resourceType, resourceNamespace, err)
 		logs.Error(err, "Failed to get resource.")
@@ -133,6 +135,8 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 // object previously observed by its caller. Unlike SyncResource, it does not
 // read from the API server. Create and update conflicts must be retried from a
 // fresh observation so render-time decisions remain tied to the written object.
+// The parent controls new or unowned resources; an existing foreign controller
+// is preserved while desired content continues to synchronize.
 func SyncObservedResource[T client.Object](
 	ctx context.Context,
 	r Reconciler,
@@ -187,12 +191,42 @@ func SyncObservedResource[T client.Object](
 		recordResourceEvent(r, desired, corev1.EventTypeWarning, fmt.Sprintf("CalculatePatch%s", resourceType), "Update", "Failed to calculate patch for %s %s: %s", resourceType, resourceNamespace, err)
 		return false, desired, fmt.Errorf("failed to check if spec has changed: %w", err)
 	}
-	if !changeResult.NeedsUpdate {
-		logs.Info(fmt.Sprintf("%s spec is the same. Skipping update.", resourceType))
+
+	synced, ok := observed.DeepCopyObject().(T)
+	if !ok {
+		var zero T
+		return false, zero, fmt.Errorf("deep copy observed %s as %T", resourceType, observed)
+	}
+	controllerReferenceChanged := false
+	if parentResource != nil {
+		observedOwnerReferences := observed.GetOwnerReferences()
+
+		if err := ctrl.SetControllerReference(parentResource, synced, r.Scheme()); err != nil {
+			var alreadyOwnedError *controllerutil.AlreadyOwnedError
+			if errors.As(err, &alreadyOwnedError) {
+				logs.V(1).Info(
+					"Preserving controller reference owned by another resource",
+					"controllerKind", alreadyOwnedError.Owner.Kind,
+					"controllerName", alreadyOwnedError.Owner.Name,
+					"controllerUID", alreadyOwnedError.Owner.UID,
+				)
+			} else {
+				logs.Error(err, "Failed to set controller reference.")
+				recordResourceEvent(r, observed, corev1.EventTypeWarning, "SetControllerReference", "Update", "Failed to set controller reference for %s %s: %s", resourceType, resourceNamespace, err)
+				var zero T
+				return false, zero, err
+			}
+		}
+
+		controllerReferenceChanged = !equality.Semantic.DeepEqual(observedOwnerReferences, synced.GetOwnerReferences())
+	}
+
+	if !changeResult.NeedsUpdate && !controllerReferenceChanged {
+		logs.Info(fmt.Sprintf("%s spec and controller reference are unchanged. Skipping update.", resourceType))
 		recordResourceEvent(r, observed, corev1.EventTypeNormal, fmt.Sprintf("Update%s", resourceType), "Update", "Skipping update %s %s", resourceType, resourceNamespace)
 		return false, observed, nil
 	}
-	if changeResult.NewHash == nil {
+	if changeResult.NeedsUpdate && changeResult.NewHash == nil {
 		var zero T
 		return false, zero, fmt.Errorf("%s update has no desired spec hash", resourceType)
 	}
@@ -203,11 +237,6 @@ func SyncObservedResource[T client.Object](
 			"lastAppliedGeneration", getAnnotation(observed, NvidiaAnnotationGenerationKey))
 	}
 
-	synced, ok := observed.DeepCopyObject().(T)
-	if !ok {
-		var zero T
-		return false, zero, fmt.Errorf("deep copy observed %s as %T", resourceType, observed)
-	}
 	if changeResult.SpecNeedsUpdate {
 		diff, diffErr := generateSpecDiff(observed, desired)
 		if diffErr != nil {
@@ -222,11 +251,13 @@ func SyncObservedResource[T client.Object](
 			var zero T
 			return false, zero, err
 		}
-	} else {
+	} else if changeResult.NeedsUpdate {
 		logs.Info(fmt.Sprintf("%s spec is equivalent. Updating bookkeeping annotations only.", resourceType))
 	}
 
-	updateAnnotations(synced, *changeResult.NewHash, changeResult.NewGeneration)
+	if changeResult.NeedsUpdate {
+		updateAnnotations(synced, *changeResult.NewHash, changeResult.NewGeneration)
+	}
 	if err := r.Update(ctx, synced); err != nil {
 		logs.Error(err, fmt.Sprintf("Failed to update %s.", resourceType))
 		recordResourceEvent(r, observed, corev1.EventTypeWarning, fmt.Sprintf("Update%s", resourceType), "Update", "Failed to update %s %s: %s", resourceType, resourceNamespace, err)

--- a/deploy/operator/internal/controller_common/resource_test.go
+++ b/deploy/operator/internal/controller_common/resource_test.go
@@ -25,10 +25,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 
 	"github.com/bsm/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -1010,4 +1012,133 @@ func TestSyncObservedResourceUsesProvidedObservation(t *testing.T) {
 	g.Expect(getCalls).To(gomega.Equal(1), "sync must use the caller's exact observation")
 	g.Expect(observed.Data["value"]).To(gomega.Equal("before"), "sync must not mutate the caller's observation")
 	g.Expect(synced.Data["value"]).To(gomega.Equal("after"))
+}
+
+func TestSyncObservedResourceUpdatesControllerReference(t *testing.T) {
+	tests := []struct {
+		name          string
+		oldParentName string
+		oldParentUID  types.UID
+		currentData   string
+		desiredData   string
+		wantModified  bool
+		preserveOwner bool
+	}{
+		{
+			name:         "sets missing controller reference with spec update",
+			currentData:  "before",
+			desiredData:  "after",
+			wantModified: true,
+		},
+		{
+			name:         "sets missing controller reference without spec update",
+			currentData:  "same",
+			desiredData:  "same",
+			wantModified: true,
+		},
+		{
+			name:          "repairs stale controller reference without spec update",
+			oldParentName: "parent",
+			oldParentUID:  types.UID("old-parent"),
+			currentData:   "same",
+			desiredData:   "same",
+			wantModified:  true,
+		},
+		{
+			name:          "skips update for current controller reference and spec",
+			oldParentName: "parent",
+			oldParentUID:  types.UID("current-parent"),
+			currentData:   "same",
+			desiredData:   "same",
+			wantModified:  false,
+		},
+		{
+			name:          "preserves another controller without spec update",
+			oldParentName: "other-parent",
+			oldParentUID:  types.UID("other-parent"),
+			currentData:   "same",
+			desiredData:   "same",
+			preserveOwner: true,
+		},
+		{
+			name:          "preserves another controller with spec update",
+			oldParentName: "other-parent",
+			oldParentUID:  types.UID("other-parent"),
+			currentData:   "before",
+			desiredData:   "after",
+			wantModified:  true,
+			preserveOwner: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			scheme := runtime.NewScheme()
+			g.Expect(corev1.AddToScheme(scheme)).To(gomega.Succeed())
+
+			parent := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "parent",
+					Namespace: "default",
+					UID:       types.UID("current-parent"),
+				},
+			}
+			existing := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "child",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Data: map[string]string{"value": tt.currentData},
+			}
+			hash, err := GetSpecHash(existing)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			updateAnnotations(existing, hash, existing.Generation)
+
+			if tt.oldParentName != "" {
+				oldParent := parent.DeepCopy()
+				oldParent.Name = tt.oldParentName
+				oldParent.UID = tt.oldParentUID
+				g.Expect(ctrl.SetControllerReference(oldParent, existing, scheme)).To(gomega.Succeed())
+			}
+
+			kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+			reconciler := observedResourceTestReconciler{
+				Client:   kubeClient,
+				recorder: events.NewFakeRecorder(10),
+			}
+			observed := &corev1.ConfigMap{}
+			g.Expect(kubeClient.Get(t.Context(), client.ObjectKeyFromObject(existing), observed)).To(gomega.Succeed())
+			observedOwnerReferences := append([]metav1.OwnerReference(nil), observed.OwnerReferences...)
+			desired := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: existing.Name, Namespace: existing.Namespace},
+				Data:       map[string]string{"value": tt.desiredData},
+			}
+
+			t.Log("Synchronize the desired child against the exact observation")
+			modified, synced, err := SyncObservedResource(t.Context(), reconciler, parent, observed, desired)
+
+			t.Log("Verify the child content and controller reference converge")
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(modified).To(gomega.Equal(tt.wantModified))
+			g.Expect(observed.OwnerReferences).To(gomega.Equal(observedOwnerReferences), "sync must not mutate the caller's observation")
+			g.Expect(synced.Data["value"]).To(gomega.Equal(tt.desiredData))
+
+			got := &corev1.ConfigMap{}
+			g.Expect(kubeClient.Get(t.Context(), client.ObjectKeyFromObject(existing), got)).To(gomega.Succeed())
+			g.Expect(got.Data["value"]).To(gomega.Equal(tt.desiredData))
+			controllerReference := metav1.GetControllerOf(got)
+			g.Expect(controllerReference).NotTo(gomega.BeNil())
+			g.Expect(controllerReference.APIVersion).To(gomega.Equal("v1"))
+			g.Expect(controllerReference.Kind).To(gomega.Equal("ConfigMap"))
+			if tt.preserveOwner {
+				g.Expect(controllerReference.Name).To(gomega.Equal(tt.oldParentName))
+				g.Expect(controllerReference.UID).To(gomega.Equal(tt.oldParentUID))
+			} else {
+				g.Expect(controllerReference.Name).To(gomega.Equal(parent.Name))
+				g.Expect(controllerReference.UID).To(gomega.Equal(parent.UID))
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Overview:

Running:
```
kubectl apply -f dgd.yaml
kubectl delete --cascade=orphan -f dgd.yaml
kubectl apply -f dgd.yaml
kubectl delete -f dgd.yaml
```
Does not retake ownership of the controlled resources and so they are left orphaned after the second deletion.

## Details:

_N/A_

## Where should the reviewer start?

_N/A_

## Related Issues

_TODO_

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue
