### PR TITLE
fix: set OnRootMismatch FSGroup change policy default

### DIFF
--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1313,7 +1313,8 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 							Spec: corev1.PodSpec{
 								TerminationGracePeriodSeconds: ptr.To(int64(10)),
 								SecurityContext: &corev1.PodSecurityContext{
-									FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+									FSGroup:             ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+									FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 								},
 								Volumes: []corev1.Volume{
 									{
@@ -1454,7 +1455,8 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 							Spec: corev1.PodSpec{
 								TerminationGracePeriodSeconds: ptr.To(int64(10)),
 								SecurityContext: &corev1.PodSecurityContext{
-									FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+									FSGroup:             ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+									FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 								},
 								Volumes: []corev1.Volume{
 									{

--- a/deploy/operator/internal/controller/testdata/dcd/deployment/output.yaml
+++ b/deploy/operator/internal/controller/testdata/dcd/deployment/output.yaml
@@ -124,6 +124,7 @@ spec:
             schedulerName: default-scheduler
             securityContext:
                 fsGroup: 1000
+                fsGroupChangePolicy: OnRootMismatch
             serviceAccount: deployment-manifest-k8s-service-discovery
             serviceAccountName: deployment-manifest-k8s-service-discovery
             terminationGracePeriodSeconds: 60

--- a/deploy/operator/internal/controller/testdata/dcd/lws/output.yaml
+++ b/deploy/operator/internal/controller/testdata/dcd/lws/output.yaml
@@ -103,6 +103,7 @@ spec:
                 restartPolicy: Always
                 securityContext:
                     fsGroup: 1000
+                    fsGroupChangePolicy: OnRootMismatch
                 serviceAccountName: lws-manifest-k8s-service-discovery
                 terminationGracePeriodSeconds: 60
                 volumes:
@@ -186,6 +187,7 @@ spec:
                 restartPolicy: Always
                 securityContext:
                     fsGroup: 1000
+                    fsGroupChangePolicy: OnRootMismatch
                 serviceAccountName: lws-manifest-k8s-service-discovery
                 terminationGracePeriodSeconds: 60
                 volumes:

--- a/deploy/operator/internal/controller/testdata/dgd/components/output.yaml
+++ b/deploy/operator/internal/controller/testdata/dgd/components/output.yaml
@@ -172,6 +172,7 @@ spec:
             schedulerName: default-scheduler
             securityContext:
                 fsGroup: 1000
+                fsGroupChangePolicy: OnRootMismatch
             serviceAccount: component-manifests-k8s-service-discovery
             serviceAccountName: component-manifests-k8s-service-discovery
             terminationGracePeriodSeconds: 60
@@ -288,6 +289,7 @@ spec:
             schedulerName: default-scheduler
             securityContext:
                 fsGroup: 1000
+                fsGroupChangePolicy: OnRootMismatch
             serviceAccount: component-manifests-k8s-service-discovery
             serviceAccountName: component-manifests-k8s-service-discovery
             terminationGracePeriodSeconds: 60

--- a/deploy/operator/internal/controller/testdata/dgd/grove/output.yaml
+++ b/deploy/operator/internal/controller/testdata/dgd/grove/output.yaml
@@ -91,6 +91,7 @@ spec:
                     restartPolicy: Always
                     securityContext:
                         fsGroup: 1000
+                        fsGroupChangePolicy: OnRootMismatch
                     serviceAccountName: grove-manifest-k8s-service-discovery
                     terminationGracePeriodSeconds: 60
                     volumes:
@@ -204,6 +205,7 @@ spec:
                     restartPolicy: Always
                     securityContext:
                         fsGroup: 1000
+                        fsGroupChangePolicy: OnRootMismatch
                     serviceAccountName: grove-manifest-k8s-service-discovery
                     terminationGracePeriodSeconds: 60
                     volumes:
@@ -296,6 +298,7 @@ spec:
                     restartPolicy: Always
                     securityContext:
                         fsGroup: 1000
+                        fsGroupChangePolicy: OnRootMismatch
                     serviceAccountName: grove-manifest-k8s-service-discovery
                     terminationGracePeriodSeconds: 60
                     volumes:

--- a/deploy/operator/internal/controller/testdata/dgdr/deployment/output.yaml
+++ b/deploy/operator/internal/controller/testdata/dgdr/deployment/output.yaml
@@ -326,6 +326,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       serviceAccount: aic-deployment-dgd-k8s-service-discovery
       serviceAccountName: aic-deployment-dgd-k8s-service-discovery
       terminationGracePeriodSeconds: 60
@@ -442,6 +443,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       serviceAccount: aic-deployment-dgd-k8s-service-discovery
       serviceAccountName: aic-deployment-dgd-k8s-service-discovery
       terminationGracePeriodSeconds: 60
@@ -611,6 +613,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       serviceAccount: aic-deployment-dgd-k8s-service-discovery
       serviceAccountName: aic-deployment-dgd-k8s-service-discovery
       terminationGracePeriodSeconds: 60

--- a/deploy/operator/internal/controller/testdata/dgdr/grove/output.yaml
+++ b/deploy/operator/internal/controller/testdata/dgdr/grove/output.yaml
@@ -204,6 +204,7 @@ spec:
             restartPolicy: Always
             securityContext:
               fsGroup: 1000
+              fsGroupChangePolicy: OnRootMismatch
             serviceAccountName: aic-profiler-dgd-k8s-service-discovery
             terminationGracePeriodSeconds: 60
             volumes:
@@ -344,6 +345,7 @@ spec:
             restartPolicy: Always
             securityContext:
               fsGroup: 1000
+              fsGroupChangePolicy: OnRootMismatch
             serviceAccountName: aic-profiler-dgd-k8s-service-discovery
             terminationGracePeriodSeconds: 60
             volumes:
@@ -484,6 +486,7 @@ spec:
             restartPolicy: Always
             securityContext:
               fsGroup: 1000
+              fsGroupChangePolicy: OnRootMismatch
             serviceAccountName: aic-profiler-dgd-k8s-service-discovery
             terminationGracePeriodSeconds: 60
             volumes:

--- a/deploy/operator/internal/controller/testdata/dgdr/lws/output.yaml
+++ b/deploy/operator/internal/controller/testdata/dgdr/lws/output.yaml
@@ -277,6 +277,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       serviceAccount: aic-lws-dgd-k8s-service-discovery
       serviceAccountName: aic-lws-dgd-k8s-service-discovery
       terminationGracePeriodSeconds: 60
@@ -422,6 +423,7 @@ spec:
         restartPolicy: Always
         securityContext:
           fsGroup: 1000
+          fsGroupChangePolicy: OnRootMismatch
         serviceAccountName: aic-lws-dgd-k8s-service-discovery
         terminationGracePeriodSeconds: 60
         volumes:
@@ -558,6 +560,7 @@ spec:
         restartPolicy: Always
         securityContext:
           fsGroup: 1000
+          fsGroupChangePolicy: OnRootMismatch
         serviceAccountName: aic-lws-dgd-k8s-service-discovery
         terminationGracePeriodSeconds: 60
         volumes:
@@ -734,6 +737,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       serviceAccount: aic-lws-dgd-k8s-service-discovery
       serviceAccountName: aic-lws-dgd-k8s-service-discovery
       terminationGracePeriodSeconds: 60

--- a/deploy/operator/internal/controller/upgrade_test.go
+++ b/deploy/operator/internal/controller/upgrade_test.go
@@ -230,6 +230,7 @@ spec:
       serviceAccountName: qwen-decode-db6b6891-k8s-service-discovery
       securityContext:
         fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -425,6 +426,7 @@ spec:
         serviceAccountName: qwen-decode-db6b6891-k8s-service-discovery
         securityContext:
           fsGroup: 1000
+          fsGroupChangePolicy: OnRootMismatch
     workerTemplate:
       metadata:
         labels:
@@ -511,6 +513,7 @@ spec:
         serviceAccountName: qwen-decode-db6b6891-k8s-service-discovery
         securityContext:
           fsGroup: 1000
+          fsGroupChangePolicy: OnRootMismatch
     size: 2
   rolloutStrategy:
     type: ""
@@ -683,6 +686,7 @@ spec:
           terminationGracePeriodSeconds: 60
           securityContext:
             fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
         replicas: 1
         minAvailable: 1
     - name: vllmdecodeworker
@@ -784,6 +788,7 @@ spec:
           terminationGracePeriodSeconds: 60
           securityContext:
             fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
         replicas: 1
         minAvailable: 1
     cliqueStartupType: CliqueStartupTypeAnyOrder

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1684,8 +1684,9 @@ func applyCheckpointProbeCadence(
 	}
 }
 
-// applyDefaultSecurityContext sets secure defaults for pod security context.
-// Currently only sets fsGroup to solve volume permission issues.
+// applyDefaultSecurityContext sets volume-permission defaults for pod security context.
+// It sets fsGroup and avoids recursively changing ownership when the volume root
+// already has the expected ownership.
 // Does NOT set runAsUser/runAsGroup/runAsNonRoot to maintain backward compatibility
 // with images that may expect to run as root.
 // User-provided security context values (via extraPodSpec) will override these defaults.
@@ -1700,11 +1701,13 @@ func applyDefaultSecurityContext(podSpec *corev1.PodSpec) {
 		podSpec.SecurityContext = &corev1.PodSecurityContext{}
 	}
 
-	// Only set fsGroup by default
-	// This fixes volume permission issues without forcing a specific UID/GID
-	// which maintains compatibility with both root and non-root images
+	// These defaults fix volume permission issues without forcing a specific
+	// UID/GID, which maintains compatibility with both root and non-root images.
 	if podSpec.SecurityContext.FSGroup == nil {
 		podSpec.SecurityContext.FSGroup = ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup))
+	}
+	if podSpec.SecurityContext.FSGroupChangePolicy == nil {
+		podSpec.SecurityContext.FSGroupChangePolicy = ptr.To(corev1.FSGroupChangeOnRootMismatch)
 	}
 }
 

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -2117,7 +2117,8 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 										},
 										TerminationGracePeriodSeconds: ptr.To(int64(10)),
 										SecurityContext: &corev1.PodSecurityContext{
-											FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroup:             ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 										},
 										ImagePullSecrets: []corev1.LocalObjectReference{
 											{
@@ -2312,7 +2313,8 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 										ServiceAccountName:            commonconsts.PlannerServiceAccountName,
 										TerminationGracePeriodSeconds: ptr.To(int64(60)),
 										SecurityContext: &corev1.PodSecurityContext{
-											FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroup:             ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 										},
 										RestartPolicy: corev1.RestartPolicyAlways,
 
@@ -2731,7 +2733,8 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 										RestartPolicy:                 corev1.RestartPolicyAlways,
 										TerminationGracePeriodSeconds: ptr.To(int64(60)),
 										SecurityContext: &corev1.PodSecurityContext{
-											FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroup:             ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 										},
 										Volumes: []corev1.Volume{
 											{
@@ -2945,7 +2948,8 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 										RestartPolicy:                 corev1.RestartPolicyAlways,
 										TerminationGracePeriodSeconds: ptr.To(int64(60)),
 										SecurityContext: &corev1.PodSecurityContext{
-											FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroup:             ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 										},
 										Volumes: []corev1.Volume{
 											{
@@ -3131,7 +3135,8 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 										},
 										TerminationGracePeriodSeconds: ptr.To(int64(10)),
 										SecurityContext: &corev1.PodSecurityContext{
-											FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroup:             ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 										},
 										RestartPolicy: corev1.RestartPolicyAlways,
 										Containers: []corev1.Container{
@@ -3294,7 +3299,8 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 										TerminationGracePeriodSeconds: ptr.To(int64(60)),
 										ServiceAccountName:            commonconsts.PlannerServiceAccountName,
 										SecurityContext: &corev1.PodSecurityContext{
-											FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroup:             ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 										},
 										RestartPolicy: corev1.RestartPolicyAlways,
 										Volumes: []corev1.Volume{
@@ -3763,7 +3769,8 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 										},
 										TerminationGracePeriodSeconds: ptr.To(int64(60)),
 										SecurityContext: &corev1.PodSecurityContext{
-											FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroup:             ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 										},
 										RestartPolicy: corev1.RestartPolicyAlways,
 										Containers: []corev1.Container{
@@ -3953,7 +3960,8 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 									PodSpec: corev1.PodSpec{
 										TerminationGracePeriodSeconds: ptr.To(int64(60)),
 										SecurityContext: &corev1.PodSecurityContext{
-											FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroup:             ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 										},
 										Volumes: []corev1.Volume{
 											{
@@ -4140,7 +4148,8 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 										},
 										TerminationGracePeriodSeconds: ptr.To(int64(10)),
 										SecurityContext: &corev1.PodSecurityContext{
-											FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroup:             ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 										},
 										RestartPolicy: corev1.RestartPolicyAlways,
 										Containers: []corev1.Container{
@@ -4303,7 +4312,8 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 										TerminationGracePeriodSeconds: ptr.To(int64(60)),
 										ServiceAccountName:            commonconsts.PlannerServiceAccountName,
 										SecurityContext: &corev1.PodSecurityContext{
-											FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroup:             ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+											FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 										},
 										Volumes: []corev1.Volume{
 											{
@@ -6641,8 +6651,8 @@ func TestGenerateBasePodSpec_Worker(t *testing.T) {
 				RestartPolicy:                 corev1.RestartPolicyAlways,
 				TerminationGracePeriodSeconds: ptr.To(int64(60)),
 				SecurityContext: &corev1.PodSecurityContext{
-					// Only fsGroup is injected by default for volume permissions
-					FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+					FSGroup:             ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+					FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 				},
 				Volumes: []corev1.Volume{
 					{
@@ -7866,6 +7876,36 @@ func TestApplyCompilationCacheExistingMount(t *testing.T) {
 	}
 }
 
+func TestApplyDefaultSecurityContextPreservesFSGroupChangePolicy(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		SecurityContext: &corev1.PodSecurityContext{
+			FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeAlways),
+		},
+	}
+
+	applyDefaultSecurityContext(podSpec)
+
+	require.NotNil(t, podSpec.SecurityContext.FSGroup)
+	assert.Equal(t, int64(commonconsts.DefaultSecurityContextFSGroup), *podSpec.SecurityContext.FSGroup)
+	require.NotNil(t, podSpec.SecurityContext.FSGroupChangePolicy)
+	assert.Equal(t, corev1.FSGroupChangeAlways, *podSpec.SecurityContext.FSGroupChangePolicy)
+}
+
+func TestApplyDefaultSecurityContextAddsPolicyForExistingFSGroup(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		SecurityContext: &corev1.PodSecurityContext{
+			FSGroup: ptr.To(int64(2000)),
+		},
+	}
+
+	applyDefaultSecurityContext(podSpec)
+
+	require.NotNil(t, podSpec.SecurityContext.FSGroup)
+	assert.Equal(t, int64(2000), *podSpec.SecurityContext.FSGroup)
+	require.NotNil(t, podSpec.SecurityContext.FSGroupChangePolicy)
+	assert.Equal(t, corev1.FSGroupChangeOnRootMismatch, *podSpec.SecurityContext.FSGroupChangePolicy)
+}
+
 func TestGenerateBasePodSpec_SecurityContext(t *testing.T) {
 	secretsRetriever := &mockSecretsRetriever{}
 	controllerConfig := &configv1alpha1.OperatorConfiguration{}
@@ -7882,9 +7922,10 @@ func TestGenerateBasePodSpec_SecurityContext(t *testing.T) {
 				ComponentType: commonconsts.ComponentTypeFrontend,
 			},
 			expectedSecurityContext: &corev1.PodSecurityContext{
-				FSGroup: ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+				FSGroup:             ptr.To(int64(commonconsts.DefaultSecurityContextFSGroup)),
+				FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 			},
-			description: "Operator should only inject fsGroup for volume permissions, not UID/GID (backward compatible)",
+			description: "Operator should inject volume-permission defaults without setting UID/GID",
 		},
 		{
 			name: "full security context override - should use user values",
@@ -7893,19 +7934,21 @@ func TestGenerateBasePodSpec_SecurityContext(t *testing.T) {
 				ExtraPodSpec: &v1alpha1.ExtraPodSpec{
 					PodSpec: &corev1.PodSpec{
 						SecurityContext: &corev1.PodSecurityContext{
-							RunAsNonRoot: ptr.To(true),
-							RunAsUser:    ptr.To(int64(5000)),
-							RunAsGroup:   ptr.To(int64(5000)),
-							FSGroup:      ptr.To(int64(5000)),
+							RunAsNonRoot:        ptr.To(true),
+							RunAsUser:           ptr.To(int64(5000)),
+							RunAsGroup:          ptr.To(int64(5000)),
+							FSGroup:             ptr.To(int64(5000)),
+							FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeAlways),
 						},
 					},
 				},
 			},
 			expectedSecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: ptr.To(true),
-				RunAsUser:    ptr.To(int64(5000)),
-				RunAsGroup:   ptr.To(int64(5000)),
-				FSGroup:      ptr.To(int64(5000)),
+				RunAsNonRoot:        ptr.To(true),
+				RunAsUser:           ptr.To(int64(5000)),
+				RunAsGroup:          ptr.To(int64(5000)),
+				FSGroup:             ptr.To(int64(5000)),
+				FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeAlways),
 			},
 			description: "User-provided security context should completely override defaults",
 		},


### PR DESCRIPTION
## Overview:

Adding a default fsGroup means that if users aren't careful and mount large volumes, the subsequent chown can take a significant amount of time.

## Details:

This sets the [FSGroupChangePolicy](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods) to OnRootMismatch by default. This should satisfy both the security and performance concerns by default.

_TBD_ this will end up recreating all pods.  Should the default by applied to DGD creation through an admission webhook instead?

## Where should the reviewer start?

_N/A_

## Related Issues

_TODO_

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue
