### PR TITLE
feat(router): order least-loaded routing by queued prompt tokens

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md
@@ -115,6 +115,8 @@ accepted, and ordinary physical classes are no longer direct header
 overrides. The sample is a Baseten-oriented continuing-session starting point,
 not a compatibility profile.
 
+For `--router-mode least-loaded`, set `DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE=1` to order workers by the total prompt tokens of their in-flight requests rather than by request count, using the request count only to break ties. See [Least-Loaded Routing](router-guide.md#least-loaded-routing).
+
 For `--router-mode device-aware-weighted`, set `DYN_ENCODER_CUDA_TO_CPU_RATIO` to the approximate throughput ratio of one non-CPU worker relative to one CPU worker. The default is `8`.
 
 ## Session Affinity

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-guide.md
@@ -110,9 +110,18 @@ The Dynamo router can be deployed in several configurations. The table below sho
 | **Random** | `random` | Selects a random worker for each request |
 | **Power of Two** | `power-of-two` | Samples two workers and routes to the one with fewer in-flight requests; in disaggregated prefill paths it falls back to synchronous prefill |
 | **KV** | `kv` | Evaluates KV cache overlap and decode load per worker; picks lowest cost |
-| **Least-Loaded** | `least-loaded` | Routes to the worker with fewest active connections; in disaggregated prefill paths it skips bootstrap optimization and falls back to synchronous prefill |
+| **Least-Loaded** | `least-loaded` | Routes to the worker with fewest active connections, or fewest queued prompt tokens under `DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE`; in disaggregated prefill paths it skips bootstrap optimization and falls back to synchronous prefill |
 | **Device-Aware Weighted** | `device-aware-weighted` | Partitions workers into CPU and non-CPU groups, applies capability-normalized ratio budgeting using `DYN_ENCODER_CUDA_TO_CPU_RATIO` to decide which group receives the request, then selects the least-loaded worker within that group |
 | **Direct** | `direct` | Reads the target `worker_id` from the request's routing hints; no selection logic |
+
+### Least-Loaded Routing
+
+`least-loaded` routes each request to the worker holding the fewest in-flight requests.
+
+Set `DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE=1` to order workers by queued prompt tokens instead. The router tracks the prompt length of every request it has scheduled and not yet completed, routes to the worker with the smallest total, and uses the in-flight request count only to break ties. This suits fleets with a wide spread of prompt lengths, where one long prompt costs far more than several short ones.
+
+> [!NOTE]
+> Token-aware ordering applies to hops that route tokenized requests: the frontend's preprocessed-request hop and the prefill hop. Hops that dispatch untokenized OpenAI requests, such as embeddings, have no prompt length to charge and keep request-count ordering. `power-of-two` and `device-aware-weighted` are unaffected by this variable.
 
 ### Device-Aware Weighted Routing
 

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -21,7 +21,9 @@ use crate::{
     model_card::ModelDeploymentCard,
     namespace::NamespaceFilter,
     preprocessor::{OpenAIPreprocessor, prompt::prompt_formatter_from_mdc},
-    protocols::common::llm_backend::{BackendOutput, LLMEngineOutput, PreprocessedRequest},
+    protocols::common::llm_backend::{
+        BackendOutput, LLMEngineOutput, PreprocessedRequest, preprocessed_prompt_load_weight,
+    },
     request_template::RequestTemplate,
     session_affinity::{
         AffinityCoordinator, SessionAffinityPushRouter, create_affinity_coordinator,
@@ -302,7 +304,8 @@ where
         embedding_cache_indexer,
         cache_key_extractor,
     )
-    .await?;
+    .await?
+    .with_load_weight(preprocessed_prompt_load_weight());
 
     // Eagerly register router request metrics so they appear as zeros even in
     // non-KV modes (Direct, Random, RoundRobin) where KvPushRouter is never created.

--- a/lib/llm/src/kv_router/prefill_router/activation.rs
+++ b/lib/llm/src/kv_router/prefill_router/activation.rs
@@ -30,7 +30,7 @@ use crate::{
     local_model::runtime_config::ModelRuntimeConfig,
     model_card::ModelDeploymentCard,
     protocols::common::{
-        llm_backend::{LLMEngineOutput, PreprocessedRequest},
+        llm_backend::{LLMEngineOutput, PreprocessedRequest, preprocessed_prompt_load_weight},
         timing::WORKER_TYPE_PREFILL,
     },
     session_affinity::create_affinity_coordinator,
@@ -402,7 +402,10 @@ where
                 prefill_router_mode,
                 None, // worker_monitor
             )
-            .await?;
+            .await?
+            // The prefill hop's cost is the prompt itself, so let least-loaded
+            // ordering weigh workers by the prompt tokens they already hold.
+            .with_load_weight(preprocessed_prompt_load_weight());
 
             (
                 InnerPrefillRouter::SimpleRouter(Arc::new(

--- a/lib/llm/src/protocols/common/llm_backend.rs
+++ b/lib/llm/src/protocols/common/llm_backend.rs
@@ -14,6 +14,17 @@ use dynamo_runtime::protocols::maybe_error::MaybeError;
 pub type TokenType = Option<String>;
 pub type LogProbs = Vec<f64>;
 
+/// Charge each request's prompt length against per-worker routing occupancy.
+///
+/// Hand this to [`PushRouter::with_load_weight`](dynamo_runtime::pipeline::PushRouter::with_load_weight)
+/// on any hop that dispatches [`PreprocessedRequest`]s, so occupancy-ordered
+/// routing can weigh workers by queued prompt tokens rather than request count
+/// alone. Inert unless token-aware ordering is enabled.
+pub fn preprocessed_prompt_load_weight()
+-> dynamo_runtime::pipeline::RequestLoadWeight<PreprocessedRequest> {
+    std::sync::Arc::new(|request: &PreprocessedRequest| request.prompt_token_count())
+}
+
 /// Per-position prompt logprob entry reported by an engine adapter.
 #[derive(Serialize, Deserialize, utoipa::ToSchema, Debug, Clone, PartialEq)]
 pub struct PromptLogprobEntry {

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -433,6 +433,14 @@ where
 }
 
 impl PreprocessedRequest {
+    /// Prompt length used as this request's routing load weight.
+    ///
+    /// Prefill cost scales with the prompt, so occupancy-ordered routing charges
+    /// this against the chosen worker for as long as the request is in flight.
+    pub fn prompt_token_count(&self) -> u64 {
+        self.token_ids.len() as u64
+    }
+
     pub fn has_annotation(&self, annotation: &str) -> bool {
         self.annotations.contains(&annotation.to_string())
     }

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -67,9 +67,9 @@ pub mod service;
 
 pub(crate) use client::EndpointDiscoverySource;
 pub(crate) use client::RoutingInstances;
-pub(crate) use client::RoutingOccupancyState;
 pub(crate) use client::get_or_create_routing_occupancy_state;
 pub use client::{Client, RoutingInstanceCounts};
+pub(crate) use client::{OccupancyLease, RoutingOccupancyState};
 pub use endpoint::{StartedEndpoint, build_transport_type};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -14,29 +14,129 @@ use dashmap::DashMap;
 use futures::StreamExt;
 
 use crate::component::{Endpoint, Instance};
+use crate::config::environment_names::router as env_router;
 use crate::config::environment_names::runtime as env_runtime;
 use crate::discovery::{DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId};
 use crate::routing_policy::{
-    AdmissionKind, CandidateView, RouteContext, RouteDecision, RoutePicker, RoutePolicy,
+    AdmissionKind, CandidateView, RouteContext, RouteDecision, RouteLoad, RoutePicker, RoutePolicy,
 };
 use crate::traits::DistributedRuntimeProvider;
 
+/// Whether least-loaded routing orders workers by queued prompt tokens.
+///
+/// Read once per process: the routing hot path must not touch the environment.
+static LEAST_LOADED_TOKEN_AWARE: LazyLock<bool> =
+    LazyLock::new(|| token_aware_least_loaded_from_env(|name| std::env::var(name).ok()));
+
+fn token_aware_least_loaded_from_env(mut lookup: impl FnMut(&str) -> Option<String>) -> bool {
+    let Some(raw) = lookup(env_router::DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE) else {
+        return false;
+    };
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "on" | "yes" => true,
+        "" | "0" | "false" | "off" | "no" => false,
+        other => {
+            tracing::warn!(
+                value = other,
+                env = env_router::DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE,
+                "Unrecognized boolean, keeping request-count least-loaded ordering"
+            );
+            false
+        }
+    }
+}
+
+/// The per-worker counters one admitted request is charged against.
+///
+/// Held for the lifetime of the request and released exactly once, either
+/// explicitly via [`Self::release`] or when the owning permit drops.
+#[derive(Clone, Debug)]
+pub(crate) struct OccupancyLease {
+    requests: Arc<AtomicU64>,
+    /// `None` unless token-aware ordering is on and the request carries a weight.
+    queued_tokens: Option<Arc<AtomicU64>>,
+    weight: u64,
+}
+
+impl OccupancyLease {
+    /// The prompt-token weight this lease charges, so a retarget can re-charge the same amount.
+    pub(crate) fn weight(&self) -> u64 {
+        self.weight
+    }
+
+    pub(crate) fn release(&self) {
+        subtract(&self.requests, 1);
+        if let Some(queued_tokens) = self.queued_tokens.as_ref() {
+            subtract(queued_tokens, self.weight);
+        }
+    }
+}
+
+fn subtract(counter: &AtomicU64, amount: u64) {
+    let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_sub(amount))
+    });
+}
+
 /// Shared occupancy state for routing modes that track per-worker in-flight requests.
-#[derive(Debug, Default)]
+///
+/// When `token_aware` is set, each admitted request also charges its prompt-token
+/// weight, and least-loaded selection orders by that total with the request count
+/// as the tie-break. Otherwise the token totals stay at zero and ordering is by
+/// request count alone.
+#[derive(Debug)]
 pub(crate) struct RoutingOccupancyState {
     counts: DashMap<u64, Arc<AtomicU64>>,
+    queued_tokens: DashMap<u64, Arc<AtomicU64>>,
+    token_aware: bool,
     exact_selection_lock: parking_lot::Mutex<()>,
 }
 
+impl Default for RoutingOccupancyState {
+    fn default() -> Self {
+        Self::new(*LEAST_LOADED_TOKEN_AWARE)
+    }
+}
+
 impl RoutingOccupancyState {
-    pub(crate) fn increment(&self, instance_id: u64) -> Arc<AtomicU64> {
-        let count = self
+    pub(crate) fn new(token_aware: bool) -> Self {
+        Self {
+            counts: DashMap::new(),
+            queued_tokens: DashMap::new(),
+            token_aware,
+            exact_selection_lock: parking_lot::Mutex::new(()),
+        }
+    }
+
+    /// Whether callers should compute a prompt-token weight for each request.
+    pub(crate) fn is_token_aware(&self) -> bool {
+        self.token_aware
+    }
+
+    /// Charge one request, plus `weight` prompt tokens when token-aware ordering is on.
+    pub(crate) fn increment(&self, instance_id: u64, weight: u64) -> OccupancyLease {
+        let requests = self
             .counts
             .entry(instance_id)
             .or_insert_with(|| Arc::new(AtomicU64::new(0)))
             .clone();
-        count.fetch_add(1, Ordering::Relaxed);
-        count
+        requests.fetch_add(1, Ordering::Relaxed);
+
+        let queued_tokens = (self.token_aware && weight > 0).then(|| {
+            let queued_tokens = self
+                .queued_tokens
+                .entry(instance_id)
+                .or_insert_with(|| Arc::new(AtomicU64::new(0)))
+                .clone();
+            queued_tokens.fetch_add(weight, Ordering::Relaxed);
+            queued_tokens
+        });
+
+        OccupancyLease {
+            requests,
+            queued_tokens,
+            weight,
+        }
     }
 
     pub(crate) async fn select_exact_min(&self, instance_ids: &[u64]) -> Option<u64> {
@@ -55,6 +155,7 @@ impl RoutingOccupancyState {
             &picker,
             CandidateView::Workers(instance_ids),
             RouteContext::default(),
+            0,
         )
         .map(|(decision, _)| decision.target.worker_id)
     }
@@ -81,34 +182,49 @@ impl RoutingOccupancyState {
         picker.peek(candidates, context, |id| self.load(id))
     }
 
+    /// Select a worker and, when the policy admits against occupancy, charge it.
+    ///
+    /// `weight` is the request's prompt-token count; it is ignored unless
+    /// token-aware ordering is on.
     pub(crate) fn select_and_admit(
         &self,
         picker: &RoutePicker,
         candidates: CandidateView<'_>,
         context: RouteContext,
-    ) -> Option<(RouteDecision, Option<Arc<AtomicU64>>)> {
+        weight: u64,
+    ) -> Option<(RouteDecision, Option<OccupancyLease>)> {
         let _guard = self.exact_selection_lock.lock();
         let decision = picker.select(candidates, context, |id| self.load(id))?;
-        let counter = match decision.admission {
+        let lease = match decision.admission {
             AdmissionKind::None => None,
-            AdmissionKind::Occupancy => Some(self.increment(decision.target.worker_id)),
+            AdmissionKind::Occupancy => Some(self.increment(decision.target.worker_id, weight)),
         };
-        Some((decision, counter))
+        Some((decision, lease))
     }
 
-    pub(crate) fn decrement_counter(counter: &AtomicU64) {
-        let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
-            Some(current.saturating_sub(1))
-        });
-    }
-
+    /// Drop one request-count charge without touching the token total.
+    ///
+    /// Requests release through their [`OccupancyLease`]; this exists for callers
+    /// holding only an instance id, and is therefore not weight-aware.
     pub(crate) fn decrement(&self, instance_id: u64) {
         if let Some(count) = self.counts.get(&instance_id) {
-            Self::decrement_counter(count.as_ref());
+            subtract(count.as_ref(), 1);
         }
     }
 
-    pub(crate) fn load(&self, instance_id: u64) -> u64 {
+    pub(crate) fn load(&self, instance_id: u64) -> RouteLoad {
+        RouteLoad {
+            queued_tokens: self
+                .queued_tokens
+                .get(&instance_id)
+                .map(|c| c.load(Ordering::Relaxed))
+                .unwrap_or(0),
+            requests: self.request_load(instance_id),
+        }
+    }
+
+    /// In-flight request count, for logging and tests that report a single number.
+    pub(crate) fn request_load(&self, instance_id: u64) -> u64 {
         self.counts
             .get(&instance_id)
             .map(|c| c.load(Ordering::Relaxed))
@@ -118,6 +234,7 @@ impl RoutingOccupancyState {
     pub(crate) fn retain(&self, instance_ids: &[u64]) {
         let live: HashSet<u64> = instance_ids.iter().copied().collect();
         self.counts.retain(|id, _| live.contains(id));
+        self.queued_tokens.retain(|id, _| live.contains(id));
     }
 }
 
@@ -1646,9 +1763,9 @@ mod tests {
             handle.await.unwrap();
         }
 
-        assert_eq!(state.load(100), 30);
-        assert_eq!(state.load(200), 30);
-        assert_eq!(state.load(300), 30);
+        assert_eq!(state.request_load(100), 30);
+        assert_eq!(state.request_load(200), 30);
+        assert_eq!(state.request_load(300), 30);
     }
 
     #[tokio::test]
@@ -1693,7 +1810,7 @@ mod tests {
             .select_exact_min_and_increment(&[10, 20, 30])
             .await
             .unwrap();
-        assert_eq!(state1.load(picked1), 1);
+        assert_eq!(state1.request_load(picked1), 1);
 
         let picked2 = state1
             .select_exact_min_and_increment(&[10, 20, 30])
@@ -1702,12 +1819,15 @@ mod tests {
         assert_ne!(picked1, picked2);
 
         // state2 should see the same counts (same underlying Arc)
-        assert_eq!(state2.load(10), state1.load(10));
-        assert_eq!(state2.load(20), state1.load(20));
-        assert_eq!(state2.load(30), state1.load(30));
+        assert_eq!(state2.request_load(10), state1.request_load(10));
+        assert_eq!(state2.request_load(20), state1.request_load(20));
+        assert_eq!(state2.request_load(30), state1.request_load(30));
 
         state2.decrement(picked1);
-        assert_eq!(state1.load(picked1), if picked1 == picked2 { 1 } else { 0 });
+        assert_eq!(
+            state1.request_load(picked1),
+            if picked1 == picked2 { 1 } else { 0 }
+        );
 
         rt.shutdown();
     }
@@ -1721,16 +1841,16 @@ mod tests {
         state.select_exact_min_and_increment(&[1, 2, 3]).await;
         state.select_exact_min_and_increment(&[1, 2, 3]).await;
         // Each instance should have 1 connection
-        assert_eq!(state.load(1), 1);
-        assert_eq!(state.load(2), 1);
-        assert_eq!(state.load(3), 1);
+        assert_eq!(state.request_load(1), 1);
+        assert_eq!(state.request_load(2), 1);
+        assert_eq!(state.request_load(3), 1);
 
         // Retain only instances 1 and 3 (instance 2 was removed)
         state.retain(&[1, 3]);
 
-        assert_eq!(state.load(1), 1);
-        assert_eq!(state.load(2), 0);
-        assert_eq!(state.load(3), 1);
+        assert_eq!(state.request_load(1), 1);
+        assert_eq!(state.request_load(2), 0);
+        assert_eq!(state.request_load(3), 1);
     }
 
     #[tokio::test]
@@ -1753,20 +1873,139 @@ mod tests {
 
         let worker_id = client.instance_ids_avail()[0];
         let state = get_or_create_routing_occupancy_state(&endpoint).await;
-        state.increment(worker_id);
-        assert_eq!(state.load(worker_id), 1);
+        state.increment(worker_id, 0);
+        assert_eq!(state.request_load(worker_id), 1);
 
         endpoint.unregister_endpoint_instance().await.unwrap();
 
         for _ in 0..10 {
-            if state.load(worker_id) == 0 {
+            if state.request_load(worker_id) == 0 {
                 break;
             }
             tokio::time::sleep(TEST_RECONCILE_INTERVAL).await;
         }
 
-        assert_eq!(state.load(worker_id), 0);
+        assert_eq!(state.request_load(worker_id), 0);
 
         rt.shutdown();
+    }
+
+    #[test]
+    fn token_aware_least_loaded_env_parses_booleans() {
+        for raw in ["1", "true", "TRUE", "on", " yes "] {
+            assert!(
+                token_aware_least_loaded_from_env(|_| Some(raw.to_string())),
+                "{raw} must enable token-aware ordering"
+            );
+        }
+        for raw in ["0", "false", "off", "no", "", "sometimes"] {
+            assert!(
+                !token_aware_least_loaded_from_env(|_| Some(raw.to_string())),
+                "{raw} must leave request-count ordering in place"
+            );
+        }
+        assert!(!token_aware_least_loaded_from_env(|_| None));
+    }
+
+    #[test]
+    fn token_aware_state_prefers_fewer_queued_prompt_tokens() {
+        let state = RoutingOccupancyState::new(true);
+        // Worker 1 holds one long prompt; worker 2 holds two short ones.
+        let long = state.increment(1, 4096);
+        state.increment(2, 16);
+        state.increment(2, 16);
+
+        assert_eq!(
+            state.load(1),
+            RouteLoad {
+                queued_tokens: 4096,
+                requests: 1
+            }
+        );
+        let picker = RoutePicker::new(RoutePolicy::LeastLoaded);
+        let (decision, lease) = state
+            .select_and_admit(
+                &picker,
+                CandidateView::Workers(&[1, 2]),
+                RouteContext::default(),
+                8,
+            )
+            .unwrap();
+        assert_eq!(
+            decision.target.worker_id, 2,
+            "the worker holding fewer prompt tokens wins despite more in-flight requests"
+        );
+        assert_eq!(state.load(2).queued_tokens, 40);
+
+        lease.unwrap().release();
+        assert_eq!(state.load(2).queued_tokens, 32);
+        long.release();
+        assert_eq!(
+            state.load(1),
+            RouteLoad::default(),
+            "releasing must return both counters to zero"
+        );
+    }
+
+    #[test]
+    fn token_aware_state_breaks_token_ties_on_request_count() {
+        let state = RoutingOccupancyState::new(true);
+        state.increment(1, 32);
+        state.increment(2, 16);
+        state.increment(2, 16);
+
+        let picker = RoutePicker::new(RoutePolicy::LeastLoaded);
+        let decision = state
+            .peek(
+                &picker,
+                CandidateView::Workers(&[1, 2]),
+                RouteContext::default(),
+            )
+            .unwrap();
+        assert_eq!(
+            decision.target.worker_id, 1,
+            "equal prompt tokens must fall back to the in-flight request count"
+        );
+    }
+
+    #[test]
+    fn request_count_state_ignores_prompt_weight() {
+        let state = RoutingOccupancyState::new(false);
+        state.increment(1, 4096);
+        state.increment(2, 16);
+        state.increment(2, 16);
+
+        assert_eq!(state.load(1), RouteLoad::requests(1));
+        assert_eq!(state.load(2), RouteLoad::requests(2));
+
+        let picker = RoutePicker::new(RoutePolicy::LeastLoaded);
+        let decision = state
+            .peek(
+                &picker,
+                CandidateView::Workers(&[1, 2]),
+                RouteContext::default(),
+            )
+            .unwrap();
+        assert_eq!(
+            decision.target.worker_id, 1,
+            "with weights off the long prompt must not count against worker 1"
+        );
+    }
+
+    #[test]
+    fn retain_drops_queued_tokens_for_departed_workers() {
+        let state = RoutingOccupancyState::new(true);
+        state.increment(1, 128);
+        state.increment(2, 128);
+
+        state.retain(&[2]);
+        assert_eq!(state.load(1), RouteLoad::default());
+        assert_eq!(
+            state.load(2),
+            RouteLoad {
+                queued_tokens: 128,
+                requests: 1
+            }
+        );
     }
 }

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -667,6 +667,11 @@ pub mod router {
 
     /// Stale active-request cleanup guard in seconds; this is not a request timeout.
     pub const DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS: &str = "DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS";
+
+    /// Order least-loaded routing by the queued prompt tokens of in-flight requests,
+    /// falling back to the in-flight request count only to break ties.
+    /// Set to "1", "true", "on", or "yes" to enable; unset keeps request-count ordering.
+    pub const DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE: &str = "DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE";
 }
 
 /// Request plane transport environment variables
@@ -964,6 +969,7 @@ mod tests {
             router::DYN_ROUTER_QUEUE_POLICY,
             router::DYN_ROUTER_POLICY_CONFIG,
             router::DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS,
+            router::DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE,
             request_plane::DYN_REQUEST_PLANE_CODEC,
             // TCP Response Stream
             tcp_response_stream::DYN_TCP_RESPONSE_STREAM_PORT,

--- a/lib/runtime/src/pipeline.rs
+++ b/lib/runtime/src/pipeline.rs
@@ -19,7 +19,8 @@ pub use network::egress::addressed_router::{
     AddressedPushRouter, AddressedRequest, StreamingDispatch,
 };
 pub use network::egress::push_router::{
-    MultimodalCacheIndex, MultimodalCacheKeyExtractor, PushRouter, RouterMode, WorkerLoadMonitor,
+    MultimodalCacheIndex, MultimodalCacheKeyExtractor, PushRouter, RequestLoadWeight, RouterMode,
+    WorkerLoadMonitor,
 };
 pub mod registry;
 

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -5,8 +5,8 @@ use super::{AsyncEngineContextProvider, ResponseStream};
 use crate::error::{BackendError, DynamoError, ErrorType, match_error_chain};
 use crate::{
     component::{
-        Client, DeviceType, Endpoint, Instance, RoutingInstances, RoutingOccupancyState,
-        get_or_create_routing_occupancy_state,
+        Client, DeviceType, Endpoint, Instance, OccupancyLease, RoutingInstances,
+        RoutingOccupancyState, get_or_create_routing_occupancy_state,
     },
     discovery::EndpointInstanceId,
     dynamo_nvtx_range,
@@ -18,8 +18,8 @@ use crate::{
     },
     protocols::{EndpointId, maybe_error::MaybeError},
     routing_policy::{
-        CandidateView, RouteCandidate, RouteContext, RouteDevice, RoutePicker, RoutePolicy,
-        RouteTarget,
+        CandidateView, RouteCandidate, RouteContext, RouteDevice, RouteLoad, RoutePicker,
+        RoutePolicy, RouteTarget,
     },
     traits::DistributedRuntimeProvider,
 };
@@ -69,30 +69,30 @@ fn response_inactivity_timeout() -> Option<std::time::Duration> {
 }
 
 /// RAII handle for one in-flight unit of work charged against
-/// [`RoutingOccupancyState`]. The counter is incremented at construction; the
-/// matching decrement is emitted on drop (or by [`Self::into_tracked_stream`]).
+/// [`RoutingOccupancyState`]. The lease is charged at construction; the matching
+/// release is emitted on drop (or by [`Self::into_tracked_stream`]).
 struct OccupancyPermit {
     state: Arc<RoutingOccupancyState>,
     instance_id: u64,
-    counter: Arc<AtomicU64>,
+    lease: OccupancyLease,
     armed: bool,
 }
 
 impl OccupancyPermit {
-    fn acquire(state: Arc<RoutingOccupancyState>, instance_id: u64) -> Self {
-        let counter = state.increment(instance_id);
-        Self::from_counter(state, instance_id, counter)
+    fn acquire(state: Arc<RoutingOccupancyState>, instance_id: u64, weight: u64) -> Self {
+        let lease = state.increment(instance_id, weight);
+        Self::from_lease(state, instance_id, lease)
     }
 
-    fn from_counter(
+    fn from_lease(
         state: Arc<RoutingOccupancyState>,
         instance_id: u64,
-        counter: Arc<AtomicU64>,
+        lease: OccupancyLease,
     ) -> Self {
         Self {
             state,
             instance_id,
-            counter,
+            lease,
             armed: true,
         }
     }
@@ -101,10 +101,10 @@ impl OccupancyPermit {
         if self.instance_id == instance_id {
             return;
         }
-        let counter = self.state.increment(instance_id);
-        RoutingOccupancyState::decrement_counter(self.counter.as_ref());
+        let lease = self.state.increment(instance_id, self.lease.weight());
+        self.lease.release();
         self.instance_id = instance_id;
-        self.counter = counter;
+        self.lease = lease;
     }
 
     fn into_tracked_stream<U: Data + MaybeError>(mut self, stream: ManyOut<U>) -> ManyOut<U> {
@@ -114,7 +114,7 @@ impl OccupancyPermit {
             Box::pin(OccupancyTrackedStream {
                 inner: stream,
                 instance_id: self.instance_id,
-                counter: self.counter.clone(),
+                lease: self.lease.clone(),
                 released: false,
             }),
             engine_ctx,
@@ -125,7 +125,7 @@ impl OccupancyPermit {
 impl Drop for OccupancyPermit {
     fn drop(&mut self) {
         if self.armed {
-            RoutingOccupancyState::decrement_counter(self.counter.as_ref());
+            self.lease.release();
         }
     }
 }
@@ -146,6 +146,12 @@ pub trait MultimodalCacheIndex: Send + Sync {
 }
 
 pub type MultimodalCacheKeyExtractor<T> = Arc<dyn Fn(&T) -> Vec<String> + Send + Sync>;
+
+/// Extracts the prompt-token weight a request should charge against per-worker occupancy.
+///
+/// Only consulted when token-aware least-loaded ordering is enabled; see
+/// [`DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE`](crate::config::environment_names::router::DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE).
+pub type RequestLoadWeight<T> = Arc<dyn Fn(&T) -> u64 + Send + Sync>;
 
 #[derive(Clone)]
 pub struct PushRouter<T, U>
@@ -197,6 +203,11 @@ where
 
     /// Optional typed request extractor for multimodal embedding cache keys.
     multimodal_cache_key_extractor: Option<MultimodalCacheKeyExtractor<T>>,
+
+    /// Optional typed request extractor for the prompt-token weight charged
+    /// against occupancy. Without it every request weighs zero and least-loaded
+    /// routing orders by in-flight request count alone.
+    load_weight: Option<RequestLoadWeight<T>>,
 
     /// An internal Rust type. This says that PushRouter is generic over the T and U types,
     /// which are the input and output types of it's `generate` function. It allows the
@@ -563,6 +574,7 @@ where
             occupancy_state,
             multimodal_cache_indexer: None,
             multimodal_cache_key_extractor: None,
+            load_weight: None,
             _phantom: PhantomData,
         })
     }
@@ -637,6 +649,7 @@ where
             occupancy_state,
             multimodal_cache_indexer,
             multimodal_cache_key_extractor,
+            load_weight: None,
             _phantom: PhantomData,
         };
 
@@ -685,8 +698,30 @@ where
             occupancy_state,
             multimodal_cache_indexer: None,
             multimodal_cache_key_extractor: None,
+            load_weight: None,
             _phantom: PhantomData,
         })
+    }
+
+    /// Charge each request's prompt-token weight against per-worker occupancy.
+    ///
+    /// Only takes effect when token-aware least-loaded ordering is enabled via
+    /// [`DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE`](crate::config::environment_names::router::DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE);
+    /// otherwise the extractor is never called.
+    pub fn with_load_weight(mut self, load_weight: RequestLoadWeight<T>) -> Self {
+        self.load_weight = Some(load_weight);
+        self
+    }
+
+    /// The prompt-token weight to charge for `request`, or 0 when weights are not tracked.
+    fn request_weight(&self, state: &RoutingOccupancyState, request: &T) -> u64 {
+        if !state.is_token_aware() {
+            return 0;
+        }
+        self.load_weight
+            .as_ref()
+            .map(|extract| extract(request))
+            .unwrap_or(0)
     }
 
     /// `ResourceExhausted` when workers are routable but all overloaded;
@@ -729,7 +764,7 @@ where
             .select(
                 CandidateView::Workers(candidates),
                 RouteContext::default(),
-                |_| 0,
+                |_| RouteLoad::default(),
             )
             .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?;
         Ok((decision.target.worker_id, candidates.len()))
@@ -808,19 +843,21 @@ where
         F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
     {
         let state = self.occupancy_state()?;
-        let (instance_id, counter, candidate_count) = {
+        let weight = self.request_weight(&state, request.content());
+        let (instance_id, lease, candidate_count) = {
             let routing_instances = self.client.routing_instances();
             let candidates = routing_instances.free_ids();
-            let (decision, counter) = state
+            let (decision, lease) = state
                 .select_and_admit(
                     self.picker()?,
                     CandidateView::Workers(candidates),
                     RouteContext::default(),
+                    weight,
                 )
                 .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?;
             (
                 decision.target.worker_id,
-                counter.expect("P2C selection always requests occupancy admission"),
+                lease.expect("P2C selection always requests occupancy admission"),
                 candidates.len(),
             )
         };
@@ -828,10 +865,10 @@ where
             router_mode = "power-of-two-choices",
             worker_id = instance_id,
             candidate_count,
-            load = state.load(instance_id),
+            load = state.request_load(instance_id),
             "Selected worker"
         );
-        let permit = OccupancyPermit::from_counter(state, instance_id, counter);
+        let permit = OccupancyPermit::from_lease(state, instance_id, lease);
         self.dispatch_selected(instance_id, request, Some(permit), prepare)
             .await
     }
@@ -1037,16 +1074,17 @@ where
 
         // Only full cache hits bypass weighted accounting; partial hits still follow the
         // device-aware ratio because some image encoding remains for this request.
-        let (decision, counter) = state
+        let (decision, lease) = state
             .select_and_admit(
                 self.picker()?,
                 CandidateView::DeviceAware(&selection.candidates),
                 selection.context,
+                self.request_weight(&state, request.content()),
             )
             .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?;
         let instance_id = decision.target.worker_id;
-        let permit = counter
-            .map(|counter| OccupancyPermit::from_counter(state.clone(), instance_id, counter));
+        let permit =
+            lease.map(|lease| OccupancyPermit::from_lease(state.clone(), instance_id, lease));
         let is_cpu = selection.candidates.iter().any(|candidate| {
             candidate.target.worker_id == instance_id && candidate.device == RouteDevice::Cpu
         });
@@ -1054,7 +1092,7 @@ where
             router_mode = "device-aware-weighted",
             worker_id = instance_id,
             candidate_count = selection.candidates.len(),
-            load = state.load(instance_id),
+            load = state.request_load(instance_id),
             endpoint = %endpoint_id,
             is_cpu,
             embedding_cache_hit = selection.embedding_cache_hit,
@@ -1150,24 +1188,27 @@ where
         let state = self.occupancy_state()?;
         let routing_instances = self.client.routing_instances();
         let instance_ids = routing_instances.free_ids();
-        let (decision, counter) = state
+        let (decision, lease) = state
             .select_and_admit(
                 self.picker()?,
                 CandidateView::Workers(instance_ids),
                 RouteContext::default(),
+                self.request_weight(&state, request.content()),
             )
             .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?;
         let instance_id = decision.target.worker_id;
-        let permit = OccupancyPermit::from_counter(
+        let permit = OccupancyPermit::from_lease(
             state.clone(),
             instance_id,
-            counter.expect("least-loaded selection always requests occupancy admission"),
+            lease.expect("least-loaded selection always requests occupancy admission"),
         );
+        let load = state.load(instance_id);
         tracing::info!(
             router_mode = "least-loaded",
             worker_id = instance_id,
             candidate_count = instance_ids.len(),
-            load = state.load(instance_id),
+            load = load.requests,
+            queued_tokens = load.queued_tokens,
             "Selected worker"
         );
 
@@ -1187,7 +1228,7 @@ where
                 .select(
                     CandidateView::Workers(routing_instances.free_ids()),
                     RouteContext::default(),
-                    |_| 0,
+                    |_| RouteLoad::default(),
                 )
                 .map(|decision| decision.target.worker_id),
             RouterMode::PowerOfTwoChoices
@@ -1224,7 +1265,7 @@ where
                 .peek(
                     CandidateView::Workers(instance_ids),
                     RouteContext::default(),
-                    |_| 0,
+                    |_| RouteLoad::default(),
                 )
                 .map(|decision| decision.target.worker_id),
             RouterMode::LeastLoaded | RouterMode::PowerOfTwoChoices => self
@@ -1290,7 +1331,7 @@ where
     pub fn occupancy_for_test(&self, worker_id: u64) -> u64 {
         self.occupancy_state
             .as_deref()
-            .map(|state| state.load(worker_id))
+            .map(|state| state.request_load(worker_id))
             .unwrap_or(0)
     }
 
@@ -1312,7 +1353,8 @@ where
                 | RouterMode::PowerOfTwoChoices
                 | RouterMode::DeviceAwareWeighted => {
                     let state = self.occupancy_state()?;
-                    Some(OccupancyPermit::acquire(state, instance_id))
+                    let weight = self.request_weight(&state, request);
+                    Some(OccupancyPermit::acquire(state, instance_id, weight))
                 }
                 RouterMode::RoundRobin
                 | RouterMode::Random
@@ -1333,12 +1375,14 @@ where
                     return Err(self.empty_free_pool_error(&routing_instances));
                 }
 
-                let (decision, counter) = match self.router_mode {
+                let weight = self.request_weight(&state, request);
+                let (decision, lease) = match self.router_mode {
                     RouterMode::LeastLoaded | RouterMode::PowerOfTwoChoices => state
                         .select_and_admit(
                             self.picker()?,
                             CandidateView::Workers(instance_ids),
                             RouteContext::default(),
+                            weight,
                         )
                         .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?,
                     RouterMode::DeviceAwareWeighted => {
@@ -1348,14 +1392,15 @@ where
                                 self.picker()?,
                                 CandidateView::DeviceAware(&selection.candidates),
                                 selection.context,
+                                weight,
                             )
                             .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?
                     }
                     _ => unreachable!(),
                 };
                 let instance_id = decision.target.worker_id;
-                let permit = counter
-                    .map(|counter| OccupancyPermit::from_counter(state, instance_id, counter));
+                let permit =
+                    lease.map(|lease| OccupancyPermit::from_lease(state, instance_id, lease));
                 Ok((instance_id, permit))
             }
             RouterMode::RoundRobin => self
@@ -1782,7 +1827,7 @@ where
 struct OccupancyTrackedStream<U: Data + MaybeError> {
     inner: ManyOut<U>,
     instance_id: u64,
-    counter: Arc<AtomicU64>,
+    lease: OccupancyLease,
     released: bool,
 }
 
@@ -1791,7 +1836,7 @@ impl<U: Data + MaybeError> OccupancyTrackedStream<U> {
         if self.released {
             return;
         }
-        RoutingOccupancyState::decrement_counter(self.counter.as_ref());
+        self.lease.release();
         self.released = true;
     }
 }
@@ -1902,9 +1947,9 @@ mod tests {
     fn p2c_selects_lower_load_worker() {
         let state = RoutingOccupancyState::default();
         for _ in 0..10 {
-            state.increment(1);
+            state.increment(1, 0);
         }
-        state.increment(2);
+        state.increment(2, 0);
 
         // With only two workers, p2c_select_from must pick both and choose id=2 (lower load).
         let result = p2c_select_from(&state, &[1, 2]);
@@ -1919,12 +1964,16 @@ mod tests {
 
         let candidates = CandidateView::Workers(&[10, 20, 30, 40]);
         random
-            .select(candidates, RouteContext::default(), |_| 0)
+            .select(candidates, RouteContext::default(), |_| {
+                RouteLoad::default()
+            })
             .expect("random selection must have a candidate");
         let selected = (0..2)
             .map(|_| {
                 round_robin
-                    .select(candidates, RouteContext::default(), |_| 0)
+                    .select(candidates, RouteContext::default(), |_| {
+                        RouteLoad::default()
+                    })
                     .expect("round-robin selection must have a candidate")
                     .target
                     .worker_id
@@ -1943,7 +1992,7 @@ mod tests {
     fn p2c_treats_missing_counts_as_zero() {
         let state = RoutingOccupancyState::default();
         for _ in 0..5 {
-            state.increment(1);
+            state.increment(1, 0);
         }
         // Worker 2 has no entry — should be treated as 0, so it wins.
         let result = p2c_select_from(&state, &[1, 2]);
@@ -1954,8 +2003,8 @@ mod tests {
     fn p2c_returns_valid_worker_on_tie() {
         let state = RoutingOccupancyState::default();
         for _ in 0..3 {
-            state.increment(1);
-            state.increment(2);
+            state.increment(1, 0);
+            state.increment(2, 0);
         }
 
         for _ in 0..100 {
@@ -1967,33 +2016,33 @@ mod tests {
     #[test]
     fn occupancy_permit_decrements_before_stream_creation() {
         let state = Arc::new(RoutingOccupancyState::default());
-        let counter = state.increment(42);
-        let permit = OccupancyPermit::from_counter(state.clone(), 42, counter);
-        assert_eq!(state.load(42), 1);
+        let lease = state.increment(42, 0);
+        let permit = OccupancyPermit::from_lease(state.clone(), 42, lease);
+        assert_eq!(state.request_load(42), 1);
         drop(permit);
-        assert_eq!(state.load(42), 0);
+        assert_eq!(state.request_load(42), 0);
     }
 
     #[test]
     fn occupancy_tracked_stream_decrements_on_drop() {
         let state = Arc::new(RoutingOccupancyState::default());
-        let counter = state.increment(7);
-        let permit = OccupancyPermit::from_counter(state.clone(), 7, counter);
+        let lease = state.increment(7, 0);
+        let permit = OccupancyPermit::from_lease(state.clone(), 7, lease);
         let ctx: Arc<dyn AsyncEngineContext> = Arc::new(Controller::default());
         let stream = permit.into_tracked_stream(ResponseStream::new(
             Box::pin(tokio_stream::iter(vec![TestResponse { error: None }])),
             ctx,
         ));
-        assert_eq!(state.load(7), 1);
+        assert_eq!(state.request_load(7), 1);
         drop(stream);
-        assert_eq!(state.load(7), 0);
+        assert_eq!(state.request_load(7), 0);
     }
 
     #[tokio::test]
     async fn occupancy_tracked_stream_decrements_on_completion() {
         let state = Arc::new(RoutingOccupancyState::default());
-        let counter = state.increment(7);
-        let permit = OccupancyPermit::from_counter(state.clone(), 7, counter);
+        let lease = state.increment(7, 0);
+        let permit = OccupancyPermit::from_lease(state.clone(), 7, lease);
         let ctx: Arc<dyn AsyncEngineContext> = Arc::new(Controller::default());
         let mut stream = permit.into_tracked_stream(ResponseStream::new(
             Box::pin(tokio_stream::iter(vec![TestResponse { error: None }])),
@@ -2001,18 +2050,22 @@ mod tests {
         ));
 
         assert!(stream.next().await.unwrap().err().is_none());
-        assert_eq!(state.load(7), 1);
+        assert_eq!(state.request_load(7), 1);
         assert!(stream.next().await.is_none());
-        assert_eq!(state.load(7), 0);
+        assert_eq!(state.request_load(7), 0);
         drop(stream);
-        assert_eq!(state.load(7), 0, "drop must not release twice after EOF");
+        assert_eq!(
+            state.request_load(7),
+            0,
+            "drop must not release twice after EOF"
+        );
     }
 
     #[tokio::test]
     async fn occupancy_tracked_stream_releases_before_yielding_error() {
         let state = Arc::new(RoutingOccupancyState::default());
-        let counter = state.increment(7);
-        let permit = OccupancyPermit::from_counter(state.clone(), 7, counter);
+        let lease = state.increment(7, 0);
+        let permit = OccupancyPermit::from_lease(state.clone(), 7, lease);
         let ctx: Arc<dyn AsyncEngineContext> = Arc::new(Controller::default());
         let error = DynamoError::builder()
             .error_type(ErrorType::WorkerOverloaded)
@@ -2028,7 +2081,7 @@ mod tests {
         let response = stream.next().await.expect("error response");
         assert!(response.err().is_some());
         assert_eq!(
-            state.load(7),
+            state.request_load(7),
             0,
             "occupancy must be released before retry observes the error"
         );
@@ -2037,21 +2090,21 @@ mod tests {
     #[test]
     fn old_reservation_cannot_decrement_readded_worker_counter() {
         let state = Arc::new(RoutingOccupancyState::default());
-        let old_counter = state.increment(7);
-        let old_permit = OccupancyPermit::from_counter(state.clone(), 7, old_counter);
+        let old_lease = state.increment(7, 0);
+        let old_permit = OccupancyPermit::from_lease(state.clone(), 7, old_lease);
 
         state.retain(&[]);
-        let new_counter = state.increment(7);
-        assert_eq!(state.load(7), 1);
+        let new_lease = state.increment(7, 0);
+        assert_eq!(state.request_load(7), 1);
 
         drop(old_permit);
         assert_eq!(
-            state.load(7),
+            state.request_load(7),
             1,
             "dropping an old incarnation must not touch the replacement counter"
         );
-        RoutingOccupancyState::decrement_counter(new_counter.as_ref());
-        assert_eq!(state.load(7), 0);
+        new_lease.release();
+        assert_eq!(state.request_load(7), 0);
     }
 
     /// A mid-generation stream end means the worker dropped the request, so it
@@ -2089,14 +2142,14 @@ mod tests {
         let mut permits = Vec::new();
         for _ in 0..5 {
             let selected = p2c_select_from(&state, &[1, 2]);
-            permits.push(OccupancyPermit::acquire(state.clone(), selected));
+            permits.push(OccupancyPermit::acquire(state.clone(), selected, 0));
         }
 
-        let total = state.load(1) + state.load(2);
+        let total = state.request_load(1) + state.request_load(2);
         assert_eq!(total, 5, "5 in-flight requests should be tracked");
 
         drop(permits);
-        let total = state.load(1) + state.load(2);
+        let total = state.request_load(1) + state.request_load(2);
         assert_eq!(total, 0, "All guards dropped, counts should be 0");
     }
 
@@ -2104,7 +2157,7 @@ mod tests {
     fn p2c_never_selects_dominated_worker() {
         let state = RoutingOccupancyState::default();
         for _ in 0..100 {
-            state.increment(3);
+            state.increment(3, 0);
         }
 
         let mut selected = [0u32; 3];
@@ -2127,29 +2180,30 @@ mod tests {
     #[tokio::test]
     async fn least_loaded_selects_exact_min_and_tracks_counts() {
         let state = Arc::new(RoutingOccupancyState::default());
-        state.increment(1);
-        state.increment(1);
-        state.increment(2);
+        state.increment(1, 0);
+        state.increment(1, 0);
+        state.increment(2, 0);
 
         let picker = RoutePicker::new(RoutePolicy::LeastLoaded);
-        let (decision, counter) = state
+        let (decision, lease) = state
             .select_and_admit(
                 &picker,
                 CandidateView::Workers(&[1, 2, 3]),
                 RouteContext::default(),
+                0,
             )
             .unwrap();
         let selected = decision.target.worker_id;
         assert_eq!(selected, 3);
 
-        let permit = OccupancyPermit::from_counter(
+        let permit = OccupancyPermit::from_lease(
             state.clone(),
             selected,
-            counter.expect("least-loaded selection must acquire a counter"),
+            lease.expect("least-loaded selection must acquire a lease"),
         );
-        assert_eq!(state.load(selected), 1);
+        assert_eq!(state.request_load(selected), 1);
         drop(permit);
-        assert_eq!(state.load(selected), 0);
+        assert_eq!(state.request_load(selected), 0);
     }
 
     #[tokio::test]
@@ -2311,6 +2365,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn load_weight_is_only_charged_when_the_state_tracks_tokens() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let ns = drt.namespace("test_load_weight".to_string()).unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+        let client = endpoint.client().await.unwrap();
+
+        endpoint.register_endpoint_instance().await.unwrap();
+        client.wait_for_instances().await.unwrap();
+
+        let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::LeastLoaded)
+            .await
+            .unwrap();
+        assert_eq!(
+            router.request_weight(&RoutingOccupancyState::new(true), &7u64),
+            0,
+            "a router without an extractor weighs every request at zero"
+        );
+
+        // The test request type is its own weight.
+        let router = router.with_load_weight(Arc::new(|request: &u64| *request));
+        assert_eq!(
+            router.request_weight(&RoutingOccupancyState::new(true), &7u64),
+            7
+        );
+        assert_eq!(
+            router.request_weight(&RoutingOccupancyState::new(false), &7u64),
+            0,
+            "the extractor must not run when the state does not track tokens"
+        );
+
+        rt.shutdown();
+    }
+
+    #[tokio::test]
     async fn exact_selection_releases_occupancy_when_preparation_fails() {
         let rt = Runtime::from_current().unwrap();
         let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
@@ -2337,7 +2429,7 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(
-            state.load(worker_id),
+            state.request_load(worker_id),
             0,
             "preparation failure must release the selected worker"
         );
@@ -2373,7 +2465,7 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(
-            state.load(worker_id),
+            state.request_load(worker_id),
             0,
             "validation failure must release the selected worker"
         );
@@ -2808,7 +2900,7 @@ mod tests {
             .await
             .unwrap();
         let state = router.occupancy_state.clone().unwrap();
-        state.increment(real_id);
+        state.increment(real_id, 0);
         let state_for_prepare = state.clone();
         let observed = Arc::new(AtomicU64::new(0));
         let observed_for_prepare = observed.clone();
@@ -2816,8 +2908,8 @@ mod tests {
         let _ = tokio::time::timeout(
             std::time::Duration::from_millis(100),
             router.select_and_dispatch(SingleIn::new(42), move |_, worker_id| {
-                assert_eq!(state_for_prepare.load(stale_id), 0);
-                assert_eq!(state_for_prepare.load(worker_id), 2);
+                assert_eq!(state_for_prepare.request_load(stale_id), 0);
+                assert_eq!(state_for_prepare.request_load(worker_id), 2);
                 observed_for_prepare.store(worker_id, Ordering::Relaxed);
                 Ok(())
             }),
@@ -2825,7 +2917,7 @@ mod tests {
         .await;
 
         assert_eq!(observed.load(Ordering::Relaxed), real_id);
-        assert_eq!(state.load(real_id), 1);
+        assert_eq!(state.request_load(real_id), 1);
         state.decrement(real_id);
         rt.shutdown();
     }

--- a/lib/runtime/src/routing_policy/mod.rs
+++ b/lib/runtime/src/routing_policy/mod.rs
@@ -8,5 +8,5 @@ pub(crate) use picker::RoutePicker;
 pub use types::RouteTarget;
 pub(crate) use types::{
     AdmissionKind, CandidateView, RouteCandidate, RouteContext, RouteDecision, RouteDevice,
-    RoutePolicy,
+    RouteLoad, RoutePolicy,
 };

--- a/lib/runtime/src/routing_policy/picker.rs
+++ b/lib/runtime/src/routing_policy/picker.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::{
     AdmissionKind, CandidateView, RouteCandidate, RouteContext, RouteDecision, RouteDevice,
-    RoutePolicy, RouteTarget,
+    RouteLoad, RoutePolicy, RouteTarget,
 };
 
 #[derive(Debug)]
@@ -31,7 +31,7 @@ impl RoutePicker {
         &self,
         candidates: CandidateView<'_>,
         context: RouteContext,
-        load: impl Fn(u64) -> u64,
+        load: impl Fn(u64) -> RouteLoad,
     ) -> Option<RouteDecision> {
         if self.policy == RoutePolicy::Random {
             return random_decision(candidates);
@@ -45,7 +45,7 @@ impl RoutePicker {
         &self,
         candidates: CandidateView<'_>,
         context: RouteContext,
-        load: impl Fn(u64) -> u64,
+        load: impl Fn(u64) -> RouteLoad,
     ) -> Option<RouteDecision> {
         if self.policy == RoutePolicy::Random {
             return random_decision(candidates);
@@ -59,7 +59,7 @@ impl RoutePicker {
         &self,
         candidates: CandidateView<'_>,
         context: RouteContext,
-        load: &impl Fn(u64) -> u64,
+        load: &impl Fn(u64) -> RouteLoad,
         commit: bool,
         samples: &mut impl SampleSource,
     ) -> Option<RouteDecision> {
@@ -95,7 +95,9 @@ impl RoutePicker {
                 let second = (first + second_offset) % candidates.len();
                 let first_target = candidates.target(first);
                 let second_target = candidates.target(second);
-                let target = if load(first_target.worker_id) <= load(second_target.worker_id) {
+                let target = if load(first_target.worker_id).requests
+                    <= load(second_target.worker_id).requests
+                {
                     first_target
                 } else {
                     second_target
@@ -154,49 +156,29 @@ fn random_decision(candidates: CandidateView<'_>) -> Option<RouteDecision> {
 #[inline(always)]
 fn lowest_load(
     candidates: CandidateView<'_>,
-    load: &impl Fn(u64) -> u64,
+    load: &impl Fn(u64) -> RouteLoad,
     samples: &mut impl SampleSource,
 ) -> Option<RouteTarget> {
-    match candidates {
-        CandidateView::Workers(workers) => {
-            let mut best = None;
-            let mut best_load = u64::MAX;
-            let mut ties = 0usize;
-            for &worker_id in workers {
-                let target_load = load(worker_id);
-                if target_load < best_load {
-                    best = Some(RouteTarget::worker(worker_id));
-                    best_load = target_load;
-                    ties = 1;
-                } else if target_load == best_load {
-                    ties += 1;
-                    if samples.index(ties) == 0 {
-                        best = Some(RouteTarget::worker(worker_id));
-                    }
+    let mut best: Option<(RouteTarget, RouteLoad)> = None;
+    let mut ties = 0usize;
+    for index in 0..candidates.len() {
+        let target = candidates.target(index);
+        let target_load = load(target.worker_id);
+        match best {
+            Some((_, best_load)) if target_load > best_load => {}
+            Some((_, best_load)) if target_load == best_load => {
+                ties += 1;
+                if samples.index(ties) == 0 {
+                    best = Some((target, target_load));
                 }
             }
-            best
-        }
-        CandidateView::DeviceAware(candidates) => {
-            let mut best = None;
-            let mut best_load = u64::MAX;
-            let mut ties = 0usize;
-            for candidate in candidates {
-                let target_load = load(candidate.target.worker_id);
-                if target_load < best_load {
-                    best = Some(candidate.target);
-                    best_load = target_load;
-                    ties = 1;
-                } else if target_load == best_load {
-                    ties += 1;
-                    if samples.index(ties) == 0 {
-                        best = Some(candidate.target);
-                    }
-                }
+            _ => {
+                best = Some((target, target_load));
+                ties = 1;
             }
-            best
         }
     }
+    best.map(|(target, _)| target)
 }
 
 #[derive(Default)]
@@ -230,7 +212,7 @@ impl DeviceGroup {
 fn device_aware(
     candidates: &[RouteCandidate],
     context: RouteContext,
-    load: &impl Fn(u64) -> u64,
+    load: &impl Fn(u64) -> RouteLoad,
     samples: &mut impl SampleSource,
 ) -> Option<RouteDecision> {
     let mut cpu = DeviceGroup {
@@ -247,7 +229,9 @@ fn device_aware(
     };
 
     for candidate in candidates {
-        let target_load = load(candidate.target.worker_id);
+        // Device-aware balancing budgets CPU work against accelerator work by
+        // request count, so it reads the request-count component only.
+        let target_load = load(candidate.target.worker_id).requests;
         match candidate.device {
             RouteDevice::Cpu => cpu.consider(candidate.target, target_load, samples),
             RouteDevice::Accelerator => {
@@ -323,7 +307,8 @@ mod tests {
         for _ in 0..16 {
             assert_eq!(
                 picker
-                    .peek(candidates, RouteContext::default(), |_| 0)
+                    .peek(candidates, RouteContext::default(), |_| RouteLoad::default(
+                    ))
                     .unwrap()
                     .target
                     .worker_id,
@@ -333,7 +318,9 @@ mod tests {
         let selected = (0..4)
             .map(|_| {
                 picker
-                    .select(candidates, RouteContext::default(), |_| 0)
+                    .select(candidates, RouteContext::default(), |_| {
+                        RouteLoad::default()
+                    })
                     .unwrap()
                     .target
                     .worker_id
@@ -351,7 +338,7 @@ mod tests {
             .choose_with_samples(
                 candidates,
                 RouteContext::default(),
-                &|_| 0,
+                &|_| RouteLoad::default(),
                 false,
                 &mut samples,
             )
@@ -372,7 +359,7 @@ mod tests {
                 RouteContext::default(),
                 &|worker| {
                     reads.set(reads.get() + 1);
-                    if worker == 20 { 5 } else { 1 }
+                    RouteLoad::requests(if worker == 20 { 5 } else { 1 })
                 },
                 true,
                 &mut samples,
@@ -392,13 +379,79 @@ mod tests {
             .choose_with_samples(
                 candidates,
                 RouteContext::default(),
-                &|_| 3,
+                &|_| RouteLoad::requests(3),
                 true,
                 &mut samples,
             )
             .unwrap();
         assert_eq!(decision.target.worker_id, 30);
         assert_eq!(samples.consumed, 2);
+    }
+
+    #[test]
+    fn least_loaded_orders_by_queued_tokens_then_request_count() {
+        let picker = RoutePicker::new(RoutePolicy::LeastLoaded);
+        let candidates = CandidateView::Workers(&[10, 20, 30]);
+        let mut samples = ScriptedSamples::new(vec![0, 0, 0]);
+        let decision = picker
+            .choose_with_samples(
+                candidates,
+                RouteContext::default(),
+                &|worker| match worker {
+                    // Fewest requests, but by far the most queued prompt tokens.
+                    10 => RouteLoad {
+                        queued_tokens: 4096,
+                        requests: 1,
+                    },
+                    20 => RouteLoad {
+                        queued_tokens: 64,
+                        requests: 3,
+                    },
+                    _ => RouteLoad {
+                        queued_tokens: 64,
+                        requests: 9,
+                    },
+                },
+                true,
+                &mut samples,
+            )
+            .unwrap();
+        assert_eq!(
+            decision.target.worker_id, 20,
+            "queued tokens decide, and the request count only breaks the 20/30 tie"
+        );
+    }
+
+    #[test]
+    fn p2c_ignores_queued_tokens() {
+        let picker = RoutePicker::new(RoutePolicy::PowerOfTwoChoices);
+        let candidates = CandidateView::Workers(&[10, 20]);
+        let mut samples = ScriptedSamples::new(vec![0, 0]);
+        let decision = picker
+            .choose_with_samples(
+                candidates,
+                RouteContext::default(),
+                &|worker| {
+                    if worker == 10 {
+                        RouteLoad {
+                            queued_tokens: 4096,
+                            requests: 1,
+                        }
+                    } else {
+                        RouteLoad {
+                            queued_tokens: 0,
+                            requests: 2,
+                        }
+                    }
+                },
+                true,
+                &mut samples,
+            )
+            .unwrap();
+        assert_eq!(
+            decision.target.worker_id, 10,
+            "power-of-two-choices stays ordered by in-flight request count"
+        );
     }
 
     #[test]
@@ -431,7 +484,7 @@ mod tests {
                 },
                 |worker| {
                     reads.set(reads.get() + 1);
-                    worker
+                    RouteLoad::requests(worker)
                 },
             )
             .unwrap();

--- a/lib/runtime/src/routing_policy/types.rs
+++ b/lib/runtime/src/routing_policy/types.rs
@@ -20,6 +20,30 @@ impl RouteTarget {
     }
 }
 
+/// Per-worker load used to order routing candidates.
+///
+/// Field order is the comparison order: derived `Ord` compares `queued_tokens`
+/// first and uses `requests` only to break ties. When token-aware occupancy is
+/// disabled `queued_tokens` is always zero, so the ordering degenerates to the
+/// in-flight request count.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct RouteLoad {
+    /// Prompt tokens of the requests currently charged to this worker.
+    pub(crate) queued_tokens: u64,
+    /// In-flight requests currently charged to this worker.
+    pub(crate) requests: u64,
+}
+
+impl RouteLoad {
+    /// A load carrying only a request count, as used by the request-count-ordered policies.
+    pub(crate) const fn requests(requests: u64) -> Self {
+        Self {
+            queued_tokens: 0,
+            requests,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum RoutePolicy {
     RoundRobin,

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -3939,3 +3939,144 @@ def _test_disagg_per_role_session_affinity(
             f"{set(prefill_ids)} (TTL advertised) while decode spread across "
             f"{set(decode_ids)} (no TTL)"
         )
+
+
+def _test_least_loaded_token_aware(
+    engine_workers,
+    request,
+    frontend_port: int,
+    *,
+    token_aware: bool,
+    store_backend: str = "file",
+    request_plane: str = "tcp",
+    block_size: int = 16,
+    long_prompt_words: int = 4000,
+    probe_count: int = 10,
+):
+    """Pin what `DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE` changes about least-loaded.
+
+    Holds one long-prompt and one short-prompt request open, one per worker, then
+    sends `probe_count` short probes one at a time. Both workers are tied at a
+    single in-flight request throughout, so:
+
+    * token-aware ordering must send every probe to the short-prompt worker, which
+      is the only one that is lighter by prompt tokens;
+    * request-count ordering sees a tie and breaks it randomly, so the long-prompt
+      worker must still receive probes.
+
+    Returns `(long_worker, short_worker, probes)` so callers can assert further.
+    """
+    url = f"http://localhost:{frontend_port}/v1/chat/completions"
+    model_name = engine_workers.model_name
+
+    def payload(word_count: int, max_tokens: int) -> dict[str, Any]:
+        # A fresh suffix per prompt keeps prefix caching from coupling the two
+        # workers; this scenario is about occupancy, not cache overlap.
+        content = " ".join([f"tok{uuid.uuid4().hex[:6]}"] * word_count)
+        return {
+            "model": model_name,
+            "messages": [{"role": "user", "content": content}],
+            "stream": True,
+            "max_tokens": max_tokens,
+            "nvext": {"extra_fields": ["worker_id"]},
+        }
+
+    def worker_of(chunks) -> Optional[int]:
+        worker = None
+        for chunk in chunks:
+            candidate = chunk.get("nvext", {}).get("worker_id")
+            if candidate:
+                worker = int(candidate["decode_worker_id"])
+        return worker
+
+    async def worker_of_open_stream(response: aiohttp.ClientResponse) -> int:
+        """Read only as far as the worker_id, leaving the request in flight."""
+        async for raw in response.content:
+            line = raw.decode("utf-8").strip()
+            if not line.startswith("data: ") or line == "data: [DONE]":
+                continue
+            worker = worker_of([json.loads(line[len("data: ") :])])
+            if worker is not None:
+                return worker
+        raise AssertionError("stream ended before reporting a worker_id")
+
+    async def run() -> tuple[int, int, list[int]]:
+        await wait_for_frontend_ready(
+            frontend_url=f"http://localhost:{frontend_port}",
+            expected_num_workers=engine_workers.num_workers,
+            timeout=120,
+            engine_workers=engine_workers,
+            store_backend=store_backend,
+            request_plane=request_plane,
+        )
+
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=300)
+        ) as session:
+            # A large max_tokens keeps these two requests in flight for the whole
+            # scenario, so their prompt weight stays charged to their workers.
+            long_ctx = session.post(url, json=payload(long_prompt_words, 4000))
+            long_response = await long_ctx.__aenter__()
+            try:
+                long_worker = await worker_of_open_stream(long_response)
+
+                short_ctx = session.post(url, json=payload(4, 4000))
+                short_response = await short_ctx.__aenter__()
+                try:
+                    short_worker = await worker_of_open_stream(short_response)
+                    assert short_worker != long_worker, (
+                        "the second request must land on the idle worker, but "
+                        f"both went to {long_worker}"
+                    )
+
+                    probes = []
+                    for _ in range(probe_count):
+                        async with session.post(
+                            url, json=payload(4, 1)
+                        ) as probe_response:
+                            body = await probe_response.text()
+                            assert probe_response.status == 200, body
+                        worker = worker_of(parse_sse_json_chunks(body))
+                        assert worker is not None, body
+                        probes.append(worker)
+
+                    logger.info(
+                        "token_aware=%s long_worker=%s short_worker=%s probes=%s",
+                        token_aware,
+                        long_worker,
+                        short_worker,
+                        probes,
+                    )
+                    return long_worker, short_worker, probes
+                finally:
+                    short_response.close()
+            finally:
+                long_response.close()
+
+    with FrontendRouterProcess(
+        request,
+        block_size=block_size,
+        frontend_port=frontend_port,
+        namespace=engine_workers.namespace,
+        store_backend=store_backend,
+        request_plane=request_plane,
+        router_mode="least-loaded",
+        min_initial_workers=engine_workers.num_workers,
+        extra_env={"DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE": "1" if token_aware else None},
+    ):
+        long_worker, short_worker, probes = asyncio.run(run())
+
+    assert probes, "no probes were sent"
+    if token_aware:
+        assert all(worker == short_worker for worker in probes), (
+            "token-aware ordering must send every probe to the worker holding "
+            f"fewer prompt tokens ({short_worker}); got {probes} with the long "
+            f"prompt on {long_worker}"
+        )
+    else:
+        assert long_worker in probes, (
+            "request-count ordering ties the workers at one request each, so the "
+            f"long-prompt worker {long_worker} must still receive probes; "
+            f"got {probes}"
+        )
+    return long_worker, short_worker, probes

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -27,6 +27,7 @@ from tests.router.common import (
     _test_disagg_per_role_session_affinity,
     _test_disagg_router_overload_529,
     _test_disagg_topology_required_prefill_pin_match_and_mismatch,
+    _test_least_loaded_token_aware,
     _test_python_router_bindings,
     _test_remote_indexer_decisions,
     _test_router_decisions_disagg_round_robin_prefill_dp_rank,
@@ -1815,3 +1816,46 @@ def test_update_model_taints_replaces_worker_routing_constraints(
             min_initial_workers=workers.num_workers,
         ):
             asyncio.run(run_test(workers))
+
+
+@pytest.mark.parametrize(
+    "token_aware",
+    [
+        pytest.param(True, id="token-aware"),
+        pytest.param(False, id="request-count"),
+    ],
+)
+@pytest.mark.timeout(120)
+def test_mocker_least_loaded_token_aware(
+    request,
+    predownload_tokenizers,
+    file_storage_backend,
+    token_aware,
+):
+    """`DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE` reorders least-loaded by prompt tokens.
+
+    The two parameterizations assert mutually exclusive outcomes from the same
+    scenario, so a pass on both is what shows the flag is doing the work.
+
+    Runs on file discovery plus the TCP request plane, so it deliberately does
+    not take `runtime_services_dynamic_ports`: no etcd or NATS is involved.
+    """
+    with MockerProcess(
+        request,
+        # Real-time simulation, unlike SPEEDUP_RATIO elsewhere in this file: the
+        # scenario needs its two setup requests to stay in flight while the
+        # probes are sent, and a 10x speedup retires them first.
+        mocker_args={"speedup_ratio": 1.0, "block_size": BLOCK_SIZE},
+        num_mockers=2,
+        store_backend="file",
+        request_plane="tcp",
+        model_name=MODEL_NAME,
+    ) as mockers:
+        (frontend_port,) = allocate_frontend_ports(request, 1)
+        _test_least_loaded_token_aware(
+            engine_workers=mockers,
+            request=request,
+            frontend_port=frontend_port,
+            token_aware=token_aware,
+            block_size=BLOCK_SIZE,
+        )


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR.** Targets `gluo/fixed-commit-prefill-card-router-mode`, not `main`, so the diff shows only this work. That base branch has no PR of its own yet; retarget this one to `main` once it lands.

## Summary

Least-loaded routing has only ever known *how many* requests a worker holds, never how large they are. A worker sitting on one 4k-token prompt therefore looks idler than one holding two 32-token prompts. Prefill cost tracks the prompt, not the request count, so that ordering inverts under a mixed-length workload.

This adds a second dimension to per-worker occupancy, gated behind `DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE`:

```bash
DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE=1 python -m dynamo.frontend --router-mode least-loaded
```

With it set, the router orders workers by the **total prompt tokens of their in-flight requests**, using the in-flight **request count only to break ties**. With it unset, behavior is unchanged.

### How it works

`RoutingOccupancyState` gains a `queued_tokens` map (one atomic per worker) parallel to the existing `counts`, and `increment` now returns an `OccupancyLease` carrying `Arc`s to *both* counter cells plus the weight it charged, so release is symmetric across all three paths — permit drop, response-stream completion, and `retarget` when transport fallback moves a request mid-flight.

Selection reads a `RouteLoad { queued_tokens, requests }` whose **field order is the comparison order**, so derived `Ord` gives tokens-then-count for free:

```rust
#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
pub(crate) struct RouteLoad {
    pub(crate) queued_tokens: u64,
    pub(crate) requests: u64,
}
```

`PushRouter::with_load_weight` injects the per-request weight (following the existing `MultimodalCacheKeyExtractor` pattern). The two hops that carry a tokenized request — the frontend's preprocessed-request router and the prefill hop — supply `PreprocessedRequest::prompt_token_count`.

### Behavior when the flag is off

`queued_tokens` stays 0 everywhere, so the `Ord` degenerates to exactly today's request-count ordering. The weight extractor is not even called. Power-of-two-choices and device-aware-weighted read only the request-count component, so **neither changes in either configuration**.

### Deliberate scope limits

- **Untokenized hops keep request-count ordering.** Embeddings, classify, pooling, and the chat/completions routers that tokenize in the backend have no prompt length available at routing time. They weigh 0 rather than being given an estimate. Documented in the router guide.
- **The weight is fixed at admission.** It is the prompt length; it does not grow with generated output and does not model KV footprint. This is prefill-shaped accounting, not a substitute for KV routing.
- **The flag is process-wide and cannot be overridden per hop.** See below.

## Validation

**Unit** — `cargo test -p dynamo-runtime --lib` 594 passed; `cargo test -p dynamo-llm --lib` 2086 passed. `cargo clippy --workspace --no-deps --all-targets -- -D warnings` clean; `cargo fmt` and `pre-commit` clean over the commit range.

New unit coverage: token ordering with request-count tie-break, weights-off degeneration, lease release returning both counters to zero, `retain` pruning token entries for departed workers, stale-lease isolation after a worker is re-added, env-var boolean parsing, P2C staying token-blind, and the extractor not running when the state is not token-aware.

**End-to-end** — a real `dynamo.frontend --router-mode least-loaded` against two real `dynamo.mocker` workers (file discovery + TCP request plane, so no etcd or NATS). The scenario holds a 4000-token prompt open on one worker and a 4-token prompt on the other, leaving both tied at exactly one in-flight request, then sends 10 short probes one at a time:

| Configuration | probes to short-prompt worker | to long-prompt worker |
|---|---|---|
| `DYN_ROUTER_LEAST_LOADED_TOKEN_AWARE=1` | **10** | 0 |
| unset | 4 | 6 |

The two parameterizations assert **mutually exclusive** outcomes, so a pass on both is what shows the flag is doing the work rather than the scenario passing for an unrelated reason. Stable across 4 runs.

Per `tests/router/CLAUDE.md`, the scenario lives in `tests/router/common.py` as `_test_least_loaded_token_aware` with a thin parameterized wrapper in `test_router_e2e_with_mockers.py`, and asserts through `nvext.worker_id` rather than log parsing.

**Not covered:** real engines (mockers only), the prefill hop specifically (the e2e exercises the frontend hop; both take the same weight from the same call), and fleet scale. The scenario is backend-agnostic, so pointing it at vLLM/SGLang is a thin wrapper away.

## Reviewer notes

**Why the diff spans 16 files.** The load metric was a scalar `u64` produced in `client.rs`, passed as `impl Fn(u64) -> u64` through `picker.rs`, and consumed at four selection sites in `push_router.rs`. Widening it to a pair is one type change whose fan-out is every producer, consumer, and test assertion. Roughly 250 production lines vs 310 test lines across those three files; the rest is a new type, an env constant, two re-export lines, four ~8-line wiring edits, and docs.

The smaller alternative — packing both values into one `u64` (`tokens << 20 | count`) and leaving every signature alone — would touch ~3 files. It was rejected because it corrupts ordering silently on overflow: a 1M-token prompt or >1M in-flight requests wraps into the neighbouring field and inverts the comparison with no error, which is precisely the failure mode this feature exists to prevent.

**Known tension worth a decision.** This branch is stacked on work whose purpose is making the prefill hop's routing configurable *per hop* from the prefill card. The flag added here is deliberately **not** per-hop: it is read once per process via `LazyLock`, and the only non-test construction path reaches it through `RoutingOccupancyState::default()`. `PrefillAdvertisement` carries nothing that can override it, so a prefill card can advertise *that* it wants `least-loaded` but not *how* least-loaded orders workers. You cannot run prefill token-aware and decode request-count.

An env var was chosen because the request allowed it, but making it card-overridable fits the existing seam: add the flag to `RouterConfig` so it rides the advertisement, then pass it into `get_or_create_routing_occupancy_state` (currently `&Endpoint` only) so per-endpoint state is built with the resolved per-hop value. `RoutingOccupancyState::new(bool)` already exists. The wrinkle is that state is shared per endpoint across routers, so two routers disagreeing about the same endpoint needs a defined winner — first-construction-wins, or reject the mismatch. Happy to do this if reviewers prefer it.


---

## Supplement: prior art in TensorRT-LLM ADP routing

Read from [`adp_router.py`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py) on `main`. Included as motivation: the ordering rule this PR adopts is already the production choice for attention-DP load balancing in TensorRT-LLM.

**The ordering key matches exactly.** `DefaultADPRouter` builds a min-heap of `HeapVal(num_tokens, num_requests, rank, ...)`. As a namedtuple that orders lexicographically — tokens primary, request count as tie-break — which is precisely this PR's `RouteLoad { queued_tokens, requests }` with derived `Ord`. Its own docstring:

> Balance remaining unscheduled requests across ranks using a min-heap keyed on `(num_active_tokens, num_active_requests)`, so ranks with fewer tokens get more requests.

Same metric, too: `sum(req.py_orig_prompt_len for req in active_requests)` is summed prompt length.

**What this PR deliberately does not reproduce:**

- **Longest-first batch packing.** TRT-LLM sorts a *batch* of pending requests by token count descending (`counted.sort(key=..., reverse=True)`) before heap-popping — LPT bin-packing, and the main source of its balance quality. A network router dispatching per request on arrival has no batch to sort. Greedy-on-arrival is strictly weaker on the same metric.
- **Per-rank capacity cap.** TRT-LLM drops a rank from the heap once `num_requests >= expected_num_active_requests` (fair-share soft cap, floored at the busiest rank, capped at `max_num_active_requests`). Least-loaded here keeps stacking onto the minimum. This is the cheapest gap to close — it is local to the picker and needs no batching.
- **Ground-truth state.** TRT-LLM recomputes rank state each iteration from live active requests and allgathers it. This PR maintains a router-side lease counter: a belief about the worker that can drift, and is blind to in-engine queueing, preemption, and chunked prefill.
- **DP-rank granularity.** ADP routing targets attention-DP ranks *inside* one engine. `RouteTarget` carries a `dp_rank`, but `CandidateView::Workers` constructs `RouteTarget::worker(id)` with `dp_rank: None`, so least-loaded addresses worker instances only.

**Two other things also called "ADP", and out of scope here:**

- `KVCacheAwareADPRouter` scores `(req_tokens - prefix_match) + weight * normalized_load` with a cache-discounted token count (`max(orig_prompt_len - cached_tokens, 0)`). This PR charges raw prompt length with no cache credit; cache-aware placement is the KV router's job.
- The [ADP Balance Strategy](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/blogs/tech_blog/blog10_ADP_Balance_Strategy.md) (`timeout_iters` / `batching_wait_iters`) deliberately *delays* scheduling to phase-align ranks — reported 33% throughput and balance ratio 54% → 88%, at a TTFT cost. That is iteration-level in-engine scheduling and is not reachable from a network router.

**Summary for reviewers:** this PR adopts the ADP ordering rule at worker granularity, not the ADP algorithm. The fair-share cap is the natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
