### PR TITLE
fix(planner): recognize internal mocker worker module

### DIFF
--- a/components/src/dynamo/planner/monitoring/dgd_services.py
+++ b/components/src/dynamo/planner/monitoring/dgd_services.py
@@ -137,7 +137,10 @@ class Service(BaseModel):
         container = get_main_container(self.service)
         command = break_arguments(container.get("command"))
         args = break_arguments(container.get("args"))
-        return "dynamo.mocker" in command + args
+        return any(
+            module in {"dynamo.mocker", "dynamo.mocker._worker"}
+            for module in command + args
+        )
 
     def get_model_name(self) -> Optional[str]:
         args = get_main_container(self.service).get("args", [])

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -1320,15 +1320,28 @@ def test_typed_worker_with_explicit_zero_shape_is_rejected(
         kubernetes_connector.get_gpu_shapes(require_prefill=False, require_decode=True)
 
 
+@pytest.mark.parametrize(
+    ("command", "args"),
+    [
+        (None, ["-m", "dynamo.mocker", "--model-name", "test-model"]),
+        (
+            ["python3", "-m", "dynamo.mocker._worker"],
+            ["--model-name", "test-model"],
+        ),
+    ],
+    ids=["public-module", "worker-module"],
+)
 def test_typed_mocker_worker_with_zero_physical_shape_uses_configured_fallback(
-    kubernetes_connector, mock_kube_api
+    kubernetes_connector, mock_kube_api, command, args
 ):
     component = _component(
         "decode-worker",
         "decode",
         replicas=1,
-        args=["-m", "dynamo.mocker", "--model-name", "test-model"],
+        args=args,
     )
+    if command is not None:
+        component["podTemplate"]["spec"]["containers"][0]["command"] = command
     deployment = _deployment(component)
     deployment["metadata"]["generation"] = 2
     deployment["status"] = {


### PR DESCRIPTION
## Overview

Fix the CPU DGDR lifecycle failure where Planner rejects a zero-GPU mocker worker and crashes before the deployment can become ready.

## Impact and urgency

This is a high-priority CI unblocker. It does not fail every CI job, but it reliably blocks PRs based on current `main` when they trigger the `operator` or `dgdr` paths: `DGDR Deploy Test / CPU / lifecycle` fails, then the required `deploy-status-check` fails as a consequence.

Among the 50 most recent completed PR workflow runs, **five PRs ran the affected DGDR lifecycle job from a head containing the #13871 merge commit, and all five failed with the same `GPUShapeUnavailableError` (5/5)**:

- #13512 — https://github.com/ai-dynamo/dynamo/actions/runs/33596529490/job/100142595116
- #12920 — https://github.com/ai-dynamo/dynamo/actions/runs/33587862112/job/100118922424
- #14076 — https://github.com/ai-dynamo/dynamo/actions/runs/33585638150/job/100111709798
- #14141 — https://github.com/ai-dynamo/dynamo/actions/runs/33583350607/job/100119916836
- #14105 — https://github.com/ai-dynamo/dynamo/actions/runs/33582194972/job/100102090883

This is deterministic for the affected path rather than an isolated infrastructure flake, and it is already blocking multiple unrelated PRs.

## CI failure evidence

The failure was observed on PR #13512:

- Workflow: https://github.com/ai-dynamo/dynamo/actions/runs/33596529490
- Failed job: https://github.com/ai-dynamo/dynamo/actions/runs/33596529490/job/100142595116
- Test: `tests/deploy/test_dgdr.py::test_dgdr_lifecycle_with_planner`

The preserved failure excerpt is:

```text
dynamo.planner.errors.GPUShapeUnavailableError:
GPU shape for component 'prefill' is unavailable:
operator published an authoritative zero-GPU shape

TimeoutError: Timed out after 600s waiting for DGDR ...
to reach Deployed; last phase=Deploying
```

## Details

The operator correctly publishes an authoritative zero-GPU shape for the CPU-only mocker workers. Planner permits that shape only when `Service.is_mocker()` recognizes the component. The check accepted `dynamo.mocker`, but the rendered DGDR launches the worker with `python3 -m dynamo.mocker._worker`, so Planner treated the mocker as a real GPU backend and exited.

This change recognizes both supported module spellings and extends the connector test with the rendered `dynamo.mocker._worker` command shape.

## Where should the reviewer start?

- `components/src/dynamo/planner/monitoring/dgd_services.py`
- `components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py`

## Validation

- `python -m pytest -q components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py` — 97 passed
- `pre-commit run --files components/src/dynamo/planner/monitoring/dgd_services.py components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py` — passed
- `git diff --check` — passed

## Related Issues

**🚫 This PR is NOT linked to an issue**:

- [x] Confirmed — no related issue
