### PR TITLE
feat(kvbm): support rcommu-owned G2 shared memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,6 +2775,7 @@ dependencies = [
  "dynamo-truthy",
  "libc",
  "libloading 0.8.9",
+ "memmap2",
  "nix 0.30.1",
  "nixl-sys",
  "offset-allocator",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -2206,6 +2206,7 @@ dependencies = [
  "dynamo-truthy",
  "libc",
  "libloading 0.8.9",
+ "memmap2",
  "nix 0.30.1",
  "nixl-sys",
  "offset-allocator",

--- a/lib/bindings/kvbm/README.md
+++ b/lib/bindings/kvbm/README.md
@@ -79,6 +79,11 @@ Note that the default pip wheel built is not compatible with CUDA 13 at the mome
 | Variable | Description | Default |
 |-----------|--------------|----------|
 | `DYN_KVBM_CPU_CACHE_GB` | CPU pinned memory cache size (GB) | required |
+| `DYN_KVBM_G2_BACKING` | G2 allocation owner: `cuda` or `rcommu` | `cuda` |
+| `DYN_KVBM_RCOMMU_ENDPOINT` | rcommu owner Unix socket; required when the G2 backing is `rcommu` | none |
+| `DYN_KVBM_RCOMMU_REGION_KEY` | Exclusive region key; supports `{device_id}`, `{rank}`, and `{pid}` placeholders | none |
+| `DYN_KVBM_RCOMMU_NUMA_NODE` | Optional NUMA node on which the owner binds and prefaults the region | none |
+| `DYN_KVBM_RCOMMU_ATTACH_TIMEOUT_MS` | Timeout for each owner lifecycle request | `30000` |
 | `DYN_KVBM_DISK_CACHE_GB` | SSD Disk/Storage system cache size (GB) | optional |
 | `DYN_KVBM_DISK_CACHE_DIR` | Disk cache directory | `/tmp/` |
 | `DYN_KVBM_DISK_ZEROFILL_FALLBACK` | Enable zero-fill when `fallocate()` unsupported (e.g., Lustre) | `false` |
@@ -107,6 +112,29 @@ export DYN_KVBM_DISK_ZEROFILL_FALLBACK=true  # Enables zero-fill fallback when f
 - With `ZEROFILL_FALLBACK=true`: KVBM writes zeros using page-aligned buffers compatible with O_DIRECT requirements
 
 **Troubleshooting:** If you encounter "write all error" or EINVAL (errno 22), try disabling O_DIRECT: `export DYN_KVBM_DISK_DISABLE_O_DIRECT=true`
+
+#### rcommu-owned G2 shared memory
+
+An rcommu owner can create and retain the physical G2 region instead of letting each KVBM worker
+call `cuMemHostAlloc`. KVBM still owns all slots, keys, pins, transfers, and eviction decisions.
+The owner and worker exchange lifecycle metadata over a local Unix socket; KV payload never travels
+through that socket.
+
+Start the matching `rcommu-kvbm-shm-owner`, then configure each worker with a unique key:
+
+```bash
+export DYN_KVBM_CPU_CACHE_GB=100
+export DYN_KVBM_G2_BACKING=rcommu
+export DYN_KVBM_RCOMMU_ENDPOINT=/run/rcommu/kvbm-owner.sock
+export DYN_KVBM_RCOMMU_REGION_KEY='my-deployment/instance-0/rank-{rank}/g2'
+export DYN_KVBM_RCOMMU_NUMA_NODE=0
+```
+
+Only `FullyContiguous` host layouts are supported. Explicitly selecting `rcommu` is fail-closed:
+owner, mmap, header, CUDA registration, NIXL registration, or activation failures stop worker
+initialization and never allocate a second CUDA-owned G2 cache. While active, the worker checks the
+lease and owner epoch; loss or restart marks G2 unhealthy, rejects new host transfers, and cancels
+the worker.
 
 ### vLLM
 

--- a/lib/bindings/kvbm/src/block_manager/distributed/worker.rs
+++ b/lib/bindings/kvbm/src/block_manager/distributed/worker.rs
@@ -8,7 +8,7 @@ use utils::{get_leader_zmq_ack_url, get_leader_zmq_pub_url};
 
 use llm_rs::block_manager::distributed::{
     BlockTransferHandler as RustBlockTransferHandler, KvbmWorker as KvbmWorkerImpl,
-    KvbmWorkerConfig, NcclConfig,
+    HostMemoryBacking, KvbmWorkerConfig, NcclConfig, RcommuShmConfig,
 };
 #[cfg(feature = "nccl")]
 use llm_rs::block_manager::distributed::{NcclBootstrap, NcclCommOwned};
@@ -253,6 +253,10 @@ impl KvbmWorker {
         let nccl_config = build_nccl_config(rank, world_size, nccl_comm_ptr).map_err(to_pyerr)?;
         // When NCCL is disabled, pass None for rank/world_size so the worker is consistently in sharded mode.
         let worker_rank = if nccl_config.is_enabled() { rank } else { None };
+        let host_memory_backing = RcommuShmConfig::from_env()
+            .map_err(to_pyerr)?
+            .map(HostMemoryBacking::Rcommu)
+            .unwrap_or_default();
 
         let config = KvbmWorkerConfig::builder()
             .cancel_token(get_current_cancel_token())
@@ -271,6 +275,7 @@ impl KvbmWorker {
                     .map(|py_layout| py_layout.into())
                     .unwrap_or(LayoutType::FullyContiguous),
             )
+            .host_memory_backing(host_memory_backing)
             .disk_layout_type(
                 disk_layout_type
                     .map(|py_layout| py_layout.into())

--- a/lib/llm/src/block_manager/distributed.rs
+++ b/lib/llm/src/block_manager/distributed.rs
@@ -8,11 +8,13 @@ mod zmq;
 mod leader;
 #[cfg(feature = "nccl")]
 mod nccl_bootstrap;
+mod shared_memory;
 mod worker;
 
 pub use leader::{KvbmLeader, KvbmLeaderConfig, KvbmLeaderNumBlocksConfig};
 #[cfg(feature = "nccl")]
 pub use nccl_bootstrap::{NcclBootstrap, NcclCommOwned};
+pub use shared_memory::{HostMemoryBacking, RcommuShmConfig};
 pub use transfer::{BlockTransferHandler, NcclConfig};
 pub use utils::{
     BlockTransferPool, BlockTransferRequest, ConnectorRequestLeader, ConnectorTransferType,

--- a/lib/llm/src/block_manager/distributed/shared_memory.rs
+++ b/lib/llm/src/block_manager/distributed/shared_memory.rs
@@ -1,0 +1,1020 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    fs::OpenOptions,
+    io::{Read, Write},
+    os::unix::{
+        fs::{FileExt, MetadataExt, OpenOptionsExt},
+        net::UnixStream as StdUnixStream,
+    },
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering, fence},
+    },
+    time::Duration,
+};
+
+use dynamo_memory::{ExternalFileMappingDescriptor, ExternalPinnedStorage};
+use dynamo_runtime::config::environment_names::kvbm::shared_memory::{
+    DYN_KVBM_G2_BACKING, DYN_KVBM_RCOMMU_ATTACH_TIMEOUT_MS, DYN_KVBM_RCOMMU_ENDPOINT,
+    DYN_KVBM_RCOMMU_NUMA_NODE, DYN_KVBM_RCOMMU_REGION_KEY,
+};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::UnixStream,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::block_manager::storage::PinnedStorage;
+
+const PROTOCOL_VERSION: u16 = 1;
+const HEADER_LEN: usize = 4096;
+const MAX_CONTROL_FRAME_LEN: usize = 1024 * 1024;
+const HEADER_MAGIC: &[u8; 8] = b"RCKVSHM1";
+const STATE_OFFSET: usize = 12;
+const OWNER_DOMAIN_OFFSET: usize = 16;
+const OWNER_EPOCH_OFFSET: usize = 24;
+const REGION_ID_OFFSET: usize = 32;
+const REGION_GENERATION_OFFSET: usize = 48;
+const DATA_OFFSET_OFFSET: usize = 56;
+const DATA_LEN_OFFSET: usize = 64;
+const DATA_ALIGNMENT_OFFSET: usize = 72;
+const LAYOUT_FINGERPRINT_OFFSET: usize = 88;
+const HEADER_DIGEST_OFFSET: usize = 120;
+
+#[derive(Clone, Debug, Default)]
+pub enum HostMemoryBacking {
+    #[default]
+    CudaAllocated,
+    Rcommu(RcommuShmConfig),
+}
+
+#[derive(Clone, Debug)]
+pub struct RcommuShmConfig {
+    pub endpoint: PathBuf,
+    pub region_key: String,
+    pub numa_node: Option<u32>,
+    pub attach_timeout: Duration,
+    pub worker_epoch: u64,
+}
+
+impl RcommuShmConfig {
+    pub fn from_env() -> anyhow::Result<Option<Self>> {
+        let Some(backing) = std::env::var_os(DYN_KVBM_G2_BACKING) else {
+            return Ok(None);
+        };
+        let backing = backing.to_string_lossy();
+        match backing.as_ref() {
+            "cuda" => return Ok(None),
+            "rcommu" => {}
+            other => {
+                anyhow::bail!("{DYN_KVBM_G2_BACKING} must be 'cuda' or 'rcommu', got {other:?}")
+            }
+        }
+        let endpoint = required_env(DYN_KVBM_RCOMMU_ENDPOINT)?;
+        let region_key = required_env(DYN_KVBM_RCOMMU_REGION_KEY)?;
+        let numa_node = optional_parse_env(DYN_KVBM_RCOMMU_NUMA_NODE)?;
+        let timeout_ms = optional_parse_env(DYN_KVBM_RCOMMU_ATTACH_TIMEOUT_MS)?.unwrap_or(30_000);
+        if timeout_ms == 0 {
+            anyhow::bail!("{DYN_KVBM_RCOMMU_ATTACH_TIMEOUT_MS} must be positive");
+        }
+        Ok(Some(Self {
+            endpoint: PathBuf::from(endpoint),
+            region_key,
+            numa_node,
+            attach_timeout: Duration::from_millis(timeout_ms),
+            worker_epoch: random_nonzero(),
+        }))
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.endpoint.as_os_str().is_empty() {
+            anyhow::bail!("rcommu owner endpoint must not be empty");
+        }
+        if self.region_key.is_empty() || self.region_key.len() > 512 {
+            anyhow::bail!("rcommu region key must contain between 1 and 512 bytes");
+        }
+        if self.attach_timeout.is_zero() {
+            anyhow::bail!("rcommu attach timeout must be positive");
+        }
+        if self.worker_epoch == 0 {
+            anyhow::bail!("rcommu worker epoch must be non-zero");
+        }
+        Ok(())
+    }
+
+    pub fn for_worker(&self, device_id: usize, rank: Option<i32>) -> Self {
+        let rank = rank
+            .map(|rank| rank.to_string())
+            .unwrap_or_else(|| device_id.to_string());
+        let region_key = self
+            .region_key
+            .replace("{device_id}", &device_id.to_string())
+            .replace("{rank}", &rank)
+            .replace("{pid}", &std::process::id().to_string());
+        Self {
+            region_key,
+            ..self.clone()
+        }
+    }
+}
+
+fn required_env(name: &str) -> anyhow::Result<String> {
+    let value = std::env::var(name).map_err(|_| anyhow::anyhow!("{name} is required"))?;
+    if value.is_empty() {
+        anyhow::bail!("{name} must not be empty");
+    }
+    Ok(value)
+}
+
+fn optional_parse_env<T: std::str::FromStr>(name: &str) -> anyhow::Result<Option<T>>
+where
+    T::Err: std::fmt::Display,
+{
+    std::env::var(name)
+        .ok()
+        .map(|value| {
+            value
+                .parse()
+                .map_err(|error| anyhow::anyhow!("invalid {name}={value:?}: {error}"))
+        })
+        .transpose()
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct OwnerIdentity {
+    domain_fingerprint: u64,
+    owner_epoch: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct RegionIdentity {
+    region_id: [u8; 16],
+    region_generation: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct ClientIdentity {
+    worker_id: String,
+    worker_epoch: u64,
+    pid: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RegionAccess {
+    ExclusiveReadWrite,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct SharedRegionSpec {
+    region_key: String,
+    data_len: u64,
+    data_alignment: u64,
+    numa_node: Option<u32>,
+    layout_fingerprint: [u8; 32],
+    access: RegionAccess,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct FileIdentity {
+    device: u64,
+    inode: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct SharedRegionDescriptor {
+    protocol_version: u16,
+    owner: OwnerIdentity,
+    region: RegionIdentity,
+    path: PathBuf,
+    file_identity: FileIdentity,
+    header_len: u64,
+    data_offset: u64,
+    data_len: u64,
+    data_alignment: u64,
+    layout_fingerprint: [u8; 32],
+    header_digest: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct AttachmentLease {
+    attachment_id: [u8; 16],
+    attachment_generation: u64,
+    owner: OwnerIdentity,
+    region: RegionIdentity,
+    client: ClientIdentity,
+    capability: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct OpenRegionReply {
+    descriptor: SharedRegionDescriptor,
+    lease: AttachmentLease,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct ClientAttachObservation {
+    observed_owner_epoch: u64,
+    observed_region_generation: u64,
+    observed_file_identity: FileIdentity,
+    observed_header_digest: [u8; 32],
+    mapped_data_len: u64,
+    layout_fingerprint: [u8; 32],
+    cuda_device: u32,
+    cuda_registration_ok: bool,
+    nixl_registration_ok: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum AttachmentStatus {
+    Opening,
+    Active,
+    Aborted,
+    Closed,
+    Quarantined,
+    Stale,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct AttachmentState {
+    attachment_id: [u8; 16],
+    region: RegionIdentity,
+    status: AttachmentStatus,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "operation", rename_all = "snake_case")]
+enum RegionOperation {
+    Open {
+        client: ClientIdentity,
+        spec: SharedRegionSpec,
+    },
+    Activate {
+        lease: AttachmentLease,
+        observation: ClientAttachObservation,
+    },
+    Abort {
+        lease: AttachmentLease,
+    },
+    Detach {
+        lease: AttachmentLease,
+    },
+    GetStatus {
+        lease: AttachmentLease,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct RegionRequest {
+    protocol_version: u16,
+    request_id: String,
+    operation: RegionOperation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "reply", rename_all = "snake_case")]
+enum RegionReply {
+    Open(Box<OpenRegionReply>),
+    Attachment(AttachmentState),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RegionErrorCode {
+    InvalidRequest,
+    ProtocolMismatch,
+    SpecConflict,
+    AttachmentBusy,
+    OwnerBusy,
+    AttachmentNotFound,
+    InvalidAttachmentState,
+    Unauthorized,
+    StaleOwner,
+    StaleRegion,
+    OperationConflict,
+    CapacityExceeded,
+    Io,
+    Internal,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct RegionError {
+    code: RegionErrorCode,
+    message: String,
+}
+
+impl std::fmt::Display for RegionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{:?}: {}", self.code, self.message)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct RegionResponse {
+    protocol_version: u16,
+    request_id: String,
+    result: Result<RegionReply, RegionError>,
+}
+
+#[derive(Clone, Debug)]
+struct OwnerClient {
+    endpoint: PathBuf,
+    timeout: Duration,
+}
+
+impl OwnerClient {
+    fn new(config: &RcommuShmConfig) -> Self {
+        Self {
+            endpoint: config.endpoint.clone(),
+            timeout: config.attach_timeout,
+        }
+    }
+
+    async fn call(&self, request: &RegionRequest) -> anyhow::Result<RegionReply> {
+        let mut last_error = None;
+        for _ in 0..2 {
+            match tokio::time::timeout(self.timeout, call_once(&self.endpoint, request)).await {
+                Ok(Ok(reply)) => return Ok(reply),
+                Ok(Err(error)) => last_error = Some(error),
+                Err(error) => last_error = Some(error.into()),
+            }
+        }
+        Err(anyhow::anyhow!(
+            "rcommu owner request {} failed twice with {:?} per-attempt timeout: {:#}",
+            request.request_id,
+            self.timeout,
+            last_error.expect("two attempts set an error")
+        ))
+    }
+
+    fn call_blocking(&self, request: &RegionRequest) -> anyhow::Result<RegionReply> {
+        let mut last_error = None;
+        for _ in 0..2 {
+            match self.call_blocking_once(request) {
+                Ok(reply) => return Ok(reply),
+                Err(error) => last_error = Some(error),
+            }
+        }
+        Err(anyhow::anyhow!(
+            "rcommu owner request {} failed twice: {:#}",
+            request.request_id,
+            last_error.expect("two attempts set an error")
+        ))
+    }
+
+    fn call_blocking_once(&self, request: &RegionRequest) -> anyhow::Result<RegionReply> {
+        let mut stream = StdUnixStream::connect(&self.endpoint)?;
+        stream.set_read_timeout(Some(self.timeout))?;
+        stream.set_write_timeout(Some(self.timeout))?;
+        let payload = serde_json::to_vec(request)?;
+        if payload.is_empty() || payload.len() > MAX_CONTROL_FRAME_LEN {
+            anyhow::bail!("rcommu owner request frame has invalid length");
+        }
+        stream.write_all(&(payload.len() as u32).to_be_bytes())?;
+        stream.write_all(&payload)?;
+        stream.flush()?;
+        let mut length = [0_u8; 4];
+        stream.read_exact(&mut length)?;
+        let length = u32::from_be_bytes(length) as usize;
+        if length == 0 || length > MAX_CONTROL_FRAME_LEN {
+            anyhow::bail!("rcommu owner response frame has invalid length {length}");
+        }
+        let mut response = vec![0_u8; length];
+        stream.read_exact(&mut response)?;
+        decode_response(request, serde_json::from_slice(&response)?)
+    }
+}
+
+async fn call_once(endpoint: &Path, request: &RegionRequest) -> anyhow::Result<RegionReply> {
+    let mut stream = UnixStream::connect(endpoint).await?;
+    write_frame(&mut stream, request).await?;
+    let response: RegionResponse = read_frame(&mut stream).await?;
+    decode_response(request, response)
+}
+
+fn decode_response(
+    request: &RegionRequest,
+    response: RegionResponse,
+) -> anyhow::Result<RegionReply> {
+    if response.protocol_version != PROTOCOL_VERSION {
+        anyhow::bail!(
+            "rcommu owner returned protocol version {}, expected {PROTOCOL_VERSION}",
+            response.protocol_version
+        );
+    }
+    if response.request_id != request.request_id {
+        anyhow::bail!("rcommu owner response request_id mismatch");
+    }
+    response
+        .result
+        .map_err(|error| anyhow::anyhow!("rcommu owner rejected request: {error}"))
+}
+
+async fn write_frame<T: Serialize>(stream: &mut UnixStream, value: &T) -> anyhow::Result<()> {
+    let payload = serde_json::to_vec(value)?;
+    if payload.is_empty() || payload.len() > MAX_CONTROL_FRAME_LEN {
+        anyhow::bail!("rcommu owner request frame has invalid length");
+    }
+    stream.write_u32(payload.len() as u32).await?;
+    stream.write_all(&payload).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+async fn read_frame<T: DeserializeOwned>(stream: &mut UnixStream) -> anyhow::Result<T> {
+    let length = stream.read_u32().await? as usize;
+    if length == 0 || length > MAX_CONTROL_FRAME_LEN {
+        anyhow::bail!("rcommu owner response frame has invalid length {length}");
+    }
+    let mut payload = vec![0_u8; length];
+    stream.read_exact(&mut payload).await?;
+    Ok(serde_json::from_slice(&payload)?)
+}
+
+pub(super) struct OpeningAttachment {
+    client: OwnerClient,
+    descriptor: SharedRegionDescriptor,
+    lease: AttachmentLease,
+    armed: bool,
+}
+
+impl OpeningAttachment {
+    pub(super) async fn open(
+        config: &RcommuShmConfig,
+        worker_id: String,
+        data_len: u64,
+        layout_fingerprint: [u8; 32],
+        cuda_device: u32,
+    ) -> anyhow::Result<(PinnedStorage, Self)> {
+        let client = OwnerClient::new(config);
+        let request = RegionRequest {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: request_id(),
+            operation: RegionOperation::Open {
+                client: ClientIdentity {
+                    worker_id,
+                    worker_epoch: config.worker_epoch,
+                    pid: std::process::id(),
+                },
+                spec: SharedRegionSpec {
+                    region_key: config.region_key.clone(),
+                    data_len,
+                    data_alignment: 4096,
+                    numa_node: config.numa_node,
+                    layout_fingerprint,
+                    access: RegionAccess::ExclusiveReadWrite,
+                },
+            },
+        };
+        let open = match client.call(&request).await? {
+            RegionReply::Open(open) => *open,
+            _ => anyhow::bail!("rcommu owner returned a non-open reply for open request"),
+        };
+        if let Err(error) = validate_header(&open.descriptor) {
+            abort_best_effort(&client, &open.lease).await;
+            return Err(error.context("validate rcommu shared-memory header"));
+        }
+        let mapping = ExternalFileMappingDescriptor {
+            path: open.descriptor.path.clone(),
+            device: open.descriptor.file_identity.device,
+            inode: open.descriptor.file_identity.inode,
+            offset: open.descriptor.data_offset,
+            len: open.descriptor.data_len,
+            alignment: open.descriptor.data_alignment,
+        };
+        let storage = match ExternalPinnedStorage::new(mapping, cuda_device) {
+            Ok(storage) => PinnedStorage::from_external(storage),
+            Err(error) => {
+                abort_best_effort(&client, &open.lease).await;
+                return Err(error.into());
+            }
+        };
+        Ok((
+            storage,
+            Self {
+                client,
+                descriptor: open.descriptor,
+                lease: open.lease,
+                armed: true,
+            },
+        ))
+    }
+
+    pub(super) async fn activate(
+        &mut self,
+        cuda_device: u32,
+        failure_token: CancellationToken,
+    ) -> anyhow::Result<Arc<ActiveAttachmentSession>> {
+        let request = RegionRequest {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: request_id(),
+            operation: RegionOperation::Activate {
+                lease: self.lease.clone(),
+                observation: ClientAttachObservation {
+                    observed_owner_epoch: self.descriptor.owner.owner_epoch,
+                    observed_region_generation: self.descriptor.region.region_generation,
+                    observed_file_identity: self.descriptor.file_identity,
+                    observed_header_digest: self.descriptor.header_digest,
+                    mapped_data_len: self.descriptor.data_len,
+                    layout_fingerprint: self.descriptor.layout_fingerprint,
+                    cuda_device,
+                    cuda_registration_ok: true,
+                    nixl_registration_ok: true,
+                },
+            },
+        };
+        match self.client.call(&request).await {
+            Ok(RegionReply::Attachment(state)) if state.status == AttachmentStatus::Active => {
+                self.armed = false;
+                Ok(ActiveAttachmentSession::new(
+                    self.client.clone(),
+                    self.lease.clone(),
+                    failure_token,
+                ))
+            }
+            Ok(_) => anyhow::bail!("rcommu owner did not activate the attachment"),
+            Err(error) => {
+                // The activate request is idempotent, but two timeouts can still leave its
+                // result ambiguous. Query the lease before deciding whether to abort.
+                let status = status_best_effort(&self.client, &self.lease).await;
+                if status == Some(AttachmentStatus::Active) {
+                    self.armed = false;
+                    return Ok(ActiveAttachmentSession::new(
+                        self.client.clone(),
+                        self.lease.clone(),
+                        failure_token,
+                    ));
+                }
+                Err(error)
+            }
+        }
+    }
+
+    pub(super) async fn abort(mut self) {
+        if self.armed {
+            abort_best_effort(&self.client, &self.lease).await;
+            self.armed = false;
+        }
+    }
+}
+
+impl Drop for OpeningAttachment {
+    fn drop(&mut self) {
+        if self.armed {
+            spawn_terminal_request(
+                self.client.clone(),
+                RegionOperation::Abort {
+                    lease: self.lease.clone(),
+                },
+            );
+        }
+    }
+}
+
+pub(super) struct ActiveAttachmentSession {
+    client: OwnerClient,
+    lease: AttachmentLease,
+    closed: AtomicBool,
+    healthy: Arc<AtomicBool>,
+    health_cancellation: CancellationToken,
+    health_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl std::fmt::Debug for ActiveAttachmentSession {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ActiveAttachmentSession")
+            .field("attachment_id", &self.lease.attachment_id)
+            .field("closed", &self.closed.load(Ordering::Acquire))
+            .finish()
+    }
+}
+
+impl ActiveAttachmentSession {
+    fn new(
+        client: OwnerClient,
+        lease: AttachmentLease,
+        failure_token: CancellationToken,
+    ) -> Arc<Self> {
+        let health_cancellation = CancellationToken::new();
+        let healthy = Arc::new(AtomicBool::new(true));
+        let health_task = tokio::spawn(monitor_owner_health(
+            client.clone(),
+            lease.clone(),
+            health_cancellation.clone(),
+            failure_token,
+            Arc::clone(&healthy),
+        ));
+        Arc::new(Self {
+            client,
+            lease,
+            closed: AtomicBool::new(false),
+            healthy,
+            health_cancellation,
+            health_task: Some(health_task),
+        })
+    }
+
+    pub(super) fn is_healthy(&self) -> bool {
+        self.healthy.load(Ordering::Acquire)
+    }
+}
+
+impl Drop for ActiveAttachmentSession {
+    fn drop(&mut self) {
+        self.health_cancellation.cancel();
+        if let Some(task) = self.health_task.take() {
+            task.abort();
+        }
+        if !self.closed.swap(true, Ordering::AcqRel) {
+            spawn_terminal_request(
+                self.client.clone(),
+                RegionOperation::Detach {
+                    lease: self.lease.clone(),
+                },
+            );
+        }
+    }
+}
+
+async fn monitor_owner_health(
+    client: OwnerClient,
+    lease: AttachmentLease,
+    cancellation: CancellationToken,
+    failure_token: CancellationToken,
+    healthy: Arc<AtomicBool>,
+) {
+    let mut interval = tokio::time::interval(Duration::from_secs(1));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            _ = cancellation.cancelled() => return,
+            _ = interval.tick() => {
+                let status = tokio::select! {
+                    _ = cancellation.cancelled() => return,
+                    status = status_best_effort(&client, &lease) => status,
+                };
+                if status != Some(AttachmentStatus::Active) {
+                    healthy.store(false, Ordering::Release);
+                    tracing::error!(
+                        ?status,
+                        "rcommu shared-memory owner or active attachment became unavailable; cancelling KVBM worker"
+                    );
+                    failure_token.cancel();
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn spawn_terminal_request(client: OwnerClient, operation: RegionOperation) {
+    let request = RegionRequest {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: request_id(),
+        operation,
+    };
+    let _ = std::thread::Builder::new()
+        .name("kvbm-rcommu-detach".into())
+        .spawn(move || {
+            if let Err(error) = client.call_blocking(&request) {
+                tracing::error!(%error, "failed to close rcommu shared-memory attachment");
+            }
+        });
+}
+
+async fn abort_best_effort(client: &OwnerClient, lease: &AttachmentLease) {
+    let request = RegionRequest {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: request_id(),
+        operation: RegionOperation::Abort {
+            lease: lease.clone(),
+        },
+    };
+    if let Err(error) = client.call(&request).await {
+        tracing::error!(%error, "failed to abort rcommu shared-memory attachment");
+    }
+}
+
+async fn status_best_effort(
+    client: &OwnerClient,
+    lease: &AttachmentLease,
+) -> Option<AttachmentStatus> {
+    let request = RegionRequest {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: request_id(),
+        operation: RegionOperation::GetStatus {
+            lease: lease.clone(),
+        },
+    };
+    match client.call(&request).await {
+        Ok(RegionReply::Attachment(state)) => Some(state.status),
+        _ => None,
+    }
+}
+
+fn validate_header(descriptor: &SharedRegionDescriptor) -> anyhow::Result<()> {
+    if descriptor.protocol_version != PROTOCOL_VERSION
+        || descriptor.header_len != HEADER_LEN as u64
+        || descriptor.data_offset < HEADER_LEN as u64
+    {
+        anyhow::bail!("rcommu shared-memory descriptor version or offsets are unsupported");
+    }
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if page_size <= 0 || !descriptor.data_offset.is_multiple_of(page_size as u64) {
+        anyhow::bail!("rcommu shared-memory data offset is not page aligned");
+    }
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(&descriptor.path)?;
+    let metadata = file.metadata()?;
+    if metadata.dev() != descriptor.file_identity.device
+        || metadata.ino() != descriptor.file_identity.inode
+    {
+        anyhow::bail!("rcommu shared-memory file identity changed before attach");
+    }
+    let required_len = descriptor
+        .data_offset
+        .checked_add(descriptor.data_len)
+        .ok_or_else(|| anyhow::anyhow!("rcommu shared-memory data range overflows"))?;
+    if metadata.len() < required_len {
+        anyhow::bail!("rcommu shared-memory file is shorter than its descriptor");
+    }
+    let mut header = [0_u8; HEADER_LEN];
+    file.read_exact_at(&mut header, 0)?;
+    if &header[..8] != HEADER_MAGIC
+        || get_u16(&header, 8) != PROTOCOL_VERSION
+        || get_u16(&header, 10) as usize != HEADER_LEN
+    {
+        anyhow::bail!("rcommu shared-memory header magic or version mismatch");
+    }
+    if get_u32(&header, STATE_OFFSET) != 1 {
+        anyhow::bail!("rcommu shared-memory region is not ready");
+    }
+    fence(Ordering::Acquire);
+    let mut expected_digest = [0_u8; 32];
+    expected_digest.copy_from_slice(&header[HEADER_DIGEST_OFFSET..HEADER_DIGEST_OFFSET + 32]);
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&header[..STATE_OFFSET]);
+    hasher.update(&header[STATE_OFFSET + 4..HEADER_DIGEST_OFFSET]);
+    let computed_digest = *hasher.finalize().as_bytes();
+    if !constant_time_eq(&expected_digest, &computed_digest)
+        || !constant_time_eq(&expected_digest, &descriptor.header_digest)
+    {
+        anyhow::bail!("rcommu shared-memory header digest mismatch");
+    }
+
+    let mut region_id = [0_u8; 16];
+    region_id.copy_from_slice(&header[REGION_ID_OFFSET..REGION_ID_OFFSET + 16]);
+    let mut layout_fingerprint = [0_u8; 32];
+    layout_fingerprint
+        .copy_from_slice(&header[LAYOUT_FINGERPRINT_OFFSET..LAYOUT_FINGERPRINT_OFFSET + 32]);
+    let observed_owner = OwnerIdentity {
+        domain_fingerprint: get_u64(&header, OWNER_DOMAIN_OFFSET),
+        owner_epoch: get_u64(&header, OWNER_EPOCH_OFFSET),
+    };
+    let observed_region = RegionIdentity {
+        region_id,
+        region_generation: get_u64(&header, REGION_GENERATION_OFFSET),
+    };
+    if observed_owner != descriptor.owner {
+        anyhow::bail!("rcommu shared-memory owner epoch is stale");
+    }
+    if observed_region != descriptor.region {
+        anyhow::bail!("rcommu shared-memory region generation is stale");
+    }
+    if get_u64(&header, DATA_OFFSET_OFFSET) != descriptor.data_offset
+        || get_u64(&header, DATA_LEN_OFFSET) != descriptor.data_len
+        || get_u64(&header, DATA_ALIGNMENT_OFFSET) != descriptor.data_alignment
+        || layout_fingerprint != descriptor.layout_fingerprint
+    {
+        anyhow::bail!("rcommu shared-memory header does not match its descriptor");
+    }
+    Ok(())
+}
+
+fn get_u16(bytes: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes(bytes[offset..offset + 2].try_into().expect("fixed header"))
+}
+
+fn get_u32(bytes: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes(bytes[offset..offset + 4].try_into().expect("fixed header"))
+}
+
+fn get_u64(bytes: &[u8], offset: usize) -> u64 {
+    u64::from_le_bytes(bytes[offset..offset + 8].try_into().expect("fixed header"))
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right)
+            .fold(0_u8, |difference, (left, right)| {
+                difference | (left ^ right)
+            })
+            == 0
+}
+
+fn request_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+fn random_nonzero() -> u64 {
+    loop {
+        let value = rand::random();
+        if value != 0 {
+            return value;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::{FileExt, MetadataExt};
+
+    use super::*;
+
+    #[test]
+    fn owner_wire_request_uses_versioned_tagged_contract() {
+        let request = RegionRequest {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: "request-1".into(),
+            operation: RegionOperation::Open {
+                client: ClientIdentity {
+                    worker_id: "worker-0".into(),
+                    worker_epoch: 9,
+                    pid: 10,
+                },
+                spec: SharedRegionSpec {
+                    region_key: "deployment/instance/rank-0/g2".into(),
+                    data_len: 4096,
+                    data_alignment: 4096,
+                    numa_node: None,
+                    layout_fingerprint: [7; 32],
+                    access: RegionAccess::ExclusiveReadWrite,
+                },
+            },
+        };
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["protocol_version"], PROTOCOL_VERSION);
+        assert_eq!(value["request_id"], "request-1");
+        assert_eq!(value["operation"]["operation"], "open");
+        assert_eq!(value["operation"]["spec"]["access"], "exclusive_read_write");
+    }
+
+    #[test]
+    fn region_key_placeholders_are_resolved_per_worker() {
+        let config = RcommuShmConfig {
+            endpoint: "/tmp/owner.sock".into(),
+            region_key: "deployment/device-{device_id}/rank-{rank}/pid-{pid}".into(),
+            numa_node: None,
+            attach_timeout: Duration::from_secs(1),
+            worker_epoch: 1,
+        };
+        let resolved = config.for_worker(3, Some(7));
+        assert_eq!(
+            resolved.region_key,
+            format!("deployment/device-3/rank-7/pid-{}", std::process::id())
+        );
+    }
+
+    #[test]
+    fn validates_owner_header_identity_digest_and_bounds() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        file.as_file().set_len(8192).unwrap();
+        let metadata = file.as_file().metadata().unwrap();
+        let owner = OwnerIdentity {
+            domain_fingerprint: 11,
+            owner_epoch: 12,
+        };
+        let region = RegionIdentity {
+            region_id: [13; 16],
+            region_generation: 14,
+        };
+        let layout_fingerprint = [15; 32];
+        let mut header = [0_u8; HEADER_LEN];
+        header[..8].copy_from_slice(HEADER_MAGIC);
+        header[8..10].copy_from_slice(&PROTOCOL_VERSION.to_le_bytes());
+        header[10..12].copy_from_slice(&(HEADER_LEN as u16).to_le_bytes());
+        header[STATE_OFFSET..STATE_OFFSET + 4].copy_from_slice(&1_u32.to_le_bytes());
+        header[OWNER_DOMAIN_OFFSET..OWNER_DOMAIN_OFFSET + 8]
+            .copy_from_slice(&owner.domain_fingerprint.to_le_bytes());
+        header[OWNER_EPOCH_OFFSET..OWNER_EPOCH_OFFSET + 8]
+            .copy_from_slice(&owner.owner_epoch.to_le_bytes());
+        header[REGION_ID_OFFSET..REGION_ID_OFFSET + 16].copy_from_slice(&region.region_id);
+        header[REGION_GENERATION_OFFSET..REGION_GENERATION_OFFSET + 8]
+            .copy_from_slice(&region.region_generation.to_le_bytes());
+        header[DATA_OFFSET_OFFSET..DATA_OFFSET_OFFSET + 8]
+            .copy_from_slice(&(HEADER_LEN as u64).to_le_bytes());
+        header[DATA_LEN_OFFSET..DATA_LEN_OFFSET + 8].copy_from_slice(&4096_u64.to_le_bytes());
+        header[DATA_ALIGNMENT_OFFSET..DATA_ALIGNMENT_OFFSET + 8]
+            .copy_from_slice(&4096_u64.to_le_bytes());
+        header[LAYOUT_FINGERPRINT_OFFSET..LAYOUT_FINGERPRINT_OFFSET + 32]
+            .copy_from_slice(&layout_fingerprint);
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&header[..STATE_OFFSET]);
+        hasher.update(&header[STATE_OFFSET + 4..HEADER_DIGEST_OFFSET]);
+        let digest = *hasher.finalize().as_bytes();
+        header[HEADER_DIGEST_OFFSET..HEADER_DIGEST_OFFSET + 32].copy_from_slice(&digest);
+        file.as_file().write_all_at(&header, 0).unwrap();
+
+        let descriptor = SharedRegionDescriptor {
+            protocol_version: PROTOCOL_VERSION,
+            owner,
+            region,
+            path: file.path().to_path_buf(),
+            file_identity: FileIdentity {
+                device: metadata.dev(),
+                inode: metadata.ino(),
+            },
+            header_len: HEADER_LEN as u64,
+            data_offset: HEADER_LEN as u64,
+            data_len: 4096,
+            data_alignment: 4096,
+            layout_fingerprint,
+            header_digest: digest,
+        };
+        validate_header(&descriptor).unwrap();
+
+        let mut forged = descriptor;
+        forged.header_digest[0] ^= 1;
+        assert!(validate_header(&forged).is_err());
+    }
+
+    #[tokio::test]
+    async fn unhealthy_owner_status_cancels_worker() {
+        let temporary = tempfile::TempDir::new().unwrap();
+        let endpoint = temporary.path().join("owner.sock");
+        let listener = tokio::net::UnixListener::bind(&endpoint).unwrap();
+        let lease = AttachmentLease {
+            attachment_id: [1; 16],
+            attachment_generation: 2,
+            owner: OwnerIdentity {
+                domain_fingerprint: 3,
+                owner_epoch: 4,
+            },
+            region: RegionIdentity {
+                region_id: [5; 16],
+                region_generation: 6,
+            },
+            client: ClientIdentity {
+                worker_id: "worker".into(),
+                worker_epoch: 7,
+                pid: std::process::id(),
+            },
+            capability: [8; 32],
+        };
+        let expected_lease = lease.clone();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let request: RegionRequest = read_frame(&mut stream).await.unwrap();
+            assert!(matches!(
+                request.operation,
+                RegionOperation::GetStatus { .. }
+            ));
+            write_frame(
+                &mut stream,
+                &RegionResponse {
+                    protocol_version: PROTOCOL_VERSION,
+                    request_id: request.request_id,
+                    result: Ok(RegionReply::Attachment(AttachmentState {
+                        attachment_id: expected_lease.attachment_id,
+                        region: expected_lease.region,
+                        status: AttachmentStatus::Closed,
+                    })),
+                },
+            )
+            .await
+            .unwrap();
+        });
+        let client = OwnerClient {
+            endpoint,
+            timeout: Duration::from_millis(100),
+        };
+        let health_cancellation = CancellationToken::new();
+        let failure = CancellationToken::new();
+        let healthy = Arc::new(AtomicBool::new(true));
+        let monitor = tokio::spawn(monitor_owner_health(
+            client,
+            lease,
+            health_cancellation.clone(),
+            failure.clone(),
+            Arc::clone(&healthy),
+        ));
+        tokio::time::timeout(Duration::from_secs(2), failure.cancelled())
+            .await
+            .expect("health monitor should cancel the worker");
+        assert!(!healthy.load(Ordering::Acquire));
+        health_cancellation.cancel();
+        monitor.await.unwrap();
+        server.await.unwrap();
+    }
+}

--- a/lib/llm/src/block_manager/distributed/transfer.rs
+++ b/lib/llm/src/block_manager/distributed/transfer.rs
@@ -238,6 +238,9 @@ impl ConnectorTransferBatcher {
 pub struct BlockTransferHandler {
     device: Option<LocalBlockDataList<DeviceStorage>>,
     host: Option<LocalBlockDataList<PinnedStorage>>,
+    // Declared after `host` so the mapping and its NIXL/CUDA registrations are
+    // released before the owner receives detach on final handler drop.
+    host_attachment: Option<Arc<super::shared_memory::ActiveAttachmentSession>>,
     disk: Option<LocalBlockDataList<DiskStorage>>,
     context: Arc<TransferContext>,
     scheduler_client: Option<TransferSchedulerClient>,
@@ -258,6 +261,26 @@ impl BlockTransferHandler {
         scheduler_client: Option<TransferSchedulerClient>,
         nccl_config: NcclConfig,
     ) -> Result<Self> {
+        Self::new_with_host_attachment(
+            device_blocks,
+            host_blocks,
+            None,
+            disk_blocks,
+            context,
+            scheduler_client,
+            nccl_config,
+        )
+    }
+
+    pub(super) fn new_with_host_attachment(
+        device_blocks: Option<Vec<LocalBlock<DeviceStorage, BasicMetadata>>>,
+        host_blocks: Option<Vec<LocalBlock<PinnedStorage, BasicMetadata>>>,
+        host_attachment: Option<Arc<super::shared_memory::ActiveAttachmentSession>>,
+        disk_blocks: Option<Vec<LocalBlock<DiskStorage, BasicMetadata>>>,
+        context: Arc<TransferContext>,
+        scheduler_client: Option<TransferSchedulerClient>,
+        nccl_config: NcclConfig,
+    ) -> Result<Self> {
         let transfer_mode = if nccl_config.is_enabled() {
             TransferMode::Replicated
         } else {
@@ -267,6 +290,7 @@ impl BlockTransferHandler {
         Ok(Self {
             device: Self::get_local_data(device_blocks),
             host: Self::get_local_data(host_blocks),
+            host_attachment,
             disk: Self::get_local_data(disk_blocks),
             context,
             scheduler_client,
@@ -349,11 +373,29 @@ impl BlockTransferHandler {
 
     /// Execute transfer with batching to prevent resource exhaustion
     pub async fn execute_transfer(&self, request: BlockTransferRequest) -> Result<()> {
+        let uses_host = request.from_pool() == &Host || request.to_pool() == &Host;
+        if uses_host
+            && self
+                .host_attachment
+                .as_ref()
+                .is_some_and(|attachment| !attachment.is_healthy())
+        {
+            return Err(anyhow::anyhow!("rcommu G2 attachment is no longer healthy"));
+        }
         self.batcher.execute_batched_transfer(self, request).await
     }
 
     /// Execute transfer directly without batching (used by the batcher)
     pub async fn execute_transfer_direct(&self, request: BlockTransferRequest) -> Result<()> {
+        let uses_host = request.from_pool() == &Host || request.to_pool() == &Host;
+        if uses_host
+            && self
+                .host_attachment
+                .as_ref()
+                .is_some_and(|attachment| !attachment.is_healthy())
+        {
+            return Err(anyhow::anyhow!("rcommu G2 attachment is no longer healthy"));
+        }
         match self.transfer_mode {
             TransferMode::Sharded => self.execute_transfer_spmd_sharded(request).await,
             #[cfg(feature = "nccl")]

--- a/lib/llm/src/block_manager/distributed/worker.rs
+++ b/lib/llm/src/block_manager/distributed/worker.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::shared_memory::OpeningAttachment;
 use super::*;
 
 use super::zmq::*;
@@ -9,7 +10,7 @@ use transfer::*;
 use utils::*;
 
 use crate::block_manager::{
-    BasicMetadata, BlockMetadata, LayoutConfigBuilder, NixlLayout, Storage,
+    BasicMetadata, BlockMetadata, LayoutConfig, LayoutConfigBuilder, NixlLayout, Storage,
     block::{
         Block, layout_to_blocks, locality,
         transfer::{PoolConfig, TransferContext},
@@ -178,21 +179,84 @@ async fn perform_allocation_and_build_handler(
     )?);
 
     // host (G2) - only allocated if should_allocate_offload
-    let host_blocks = if should_allocate_offload && leader_meta.num_host_blocks > 0 {
-        let host_allocator = Arc::new(PinnedAllocator::default());
-        let host_layout = layout_builder
-            .num_blocks(leader_meta.num_host_blocks)
-            .build()?
-            .allocate_layout(worker_config.host_layout_type, host_allocator)?;
-        Some(KvbmWorker::make_layout::<_, BasicMetadata>(
-            host_layout,
-            transfer_context.nixl_agent().as_ref(),
-            1,
-            worker_id,
-        )?)
-    } else {
-        None
-    };
+    let (host_blocks, host_attachment) =
+        if should_allocate_offload && leader_meta.num_host_blocks > 0 {
+            let host_config = layout_builder
+                .num_blocks(leader_meta.num_host_blocks)
+                .build()?;
+            match &worker_config.host_memory_backing {
+                HostMemoryBacking::CudaAllocated => {
+                    let host_allocator = Arc::new(PinnedAllocator::new(device_id)?);
+                    let host_layout = host_config
+                        .allocate_layout(worker_config.host_layout_type, host_allocator)?;
+                    let blocks = KvbmWorker::make_layout::<_, BasicMetadata>(
+                        host_layout,
+                        transfer_context.nixl_agent().as_ref(),
+                        1,
+                        worker_id,
+                    )?;
+                    (Some(blocks), None)
+                }
+                HostMemoryBacking::Rcommu(config) => {
+                    if worker_config.host_layout_type != LayoutType::FullyContiguous {
+                        anyhow::bail!("rcommu G2 backing requires a FullyContiguous host layout");
+                    }
+                    let data_len = fully_contiguous_allocation_size(&host_config)?;
+                    let fingerprint = g2_layout_fingerprint(&host_config);
+                    let config = config.for_worker(device_id, worker_config.rank);
+                    let attachment_worker_id = format!(
+                        "kvbm-device-{device_id}-rank-{}",
+                        worker_config
+                            .rank
+                            .map(|rank| rank.to_string())
+                            .unwrap_or_else(|| "sharded".into())
+                    );
+                    let (storage, mut opening) = OpeningAttachment::open(
+                        &config,
+                        attachment_worker_id,
+                        data_len,
+                        fingerprint,
+                        device_id as u32,
+                    )
+                    .await?;
+                    let host_layout = match host_config
+                        .create_layout(worker_config.host_layout_type, vec![storage])
+                    {
+                        Ok(layout) => layout,
+                        Err(error) => {
+                            opening.abort().await;
+                            return Err(error.into());
+                        }
+                    };
+                    let blocks = match KvbmWorker::make_layout::<_, BasicMetadata>(
+                        host_layout,
+                        transfer_context.nixl_agent().as_ref(),
+                        1,
+                        worker_id,
+                    ) {
+                        Ok(blocks) => blocks,
+                        Err(error) => {
+                            opening.abort().await;
+                            return Err(error);
+                        }
+                    };
+                    let attachment = match opening
+                        .activate(device_id as u32, worker_config.cancel_token.clone())
+                        .await
+                    {
+                        Ok(attachment) => attachment,
+                        Err(error) => {
+                            drop(blocks);
+                            opening.abort().await;
+                            return Err(error);
+                        }
+                    };
+                    (Some(blocks), Some(attachment))
+                }
+            }
+        } else {
+            (None, None)
+        };
     // disk (G3) - only allocated if should_allocate_offload
     let disk_blocks = if should_allocate_offload && leader_meta.num_disk_blocks > 0 {
         let disk_allocator = Arc::new(DiskAllocator::from_env()?);
@@ -210,9 +274,10 @@ async fn perform_allocation_and_build_handler(
         None
     };
 
-    let handler = BlockTransferHandler::new(
+    let handler = BlockTransferHandler::new_with_host_attachment(
         device_blocks,
         host_blocks,
+        host_attachment,
         disk_blocks,
         transfer_context,
         scheduler_client,
@@ -406,6 +471,43 @@ impl Handler for BlockTransferDispatch {
     }
 }
 
+fn g2_layout_fingerprint(config: &LayoutConfig) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"dynamo-kvbm-g2-fully-contiguous-v1");
+    for value in [
+        config.num_blocks,
+        config.num_layers,
+        config.outer_dim,
+        config.page_size,
+        config.inner_dim,
+        config.alignment,
+        config.dtype_width_bytes,
+    ] {
+        hasher.update(&(value as u64).to_le_bytes());
+    }
+    *hasher.finalize().as_bytes()
+}
+
+fn fully_contiguous_allocation_size(config: &LayoutConfig) -> anyhow::Result<u64> {
+    let natural_block_stride = config
+        .num_layers
+        .checked_mul(config.outer_dim)
+        .and_then(|value| value.checked_mul(config.page_size))
+        .and_then(|value| value.checked_mul(config.inner_dim))
+        .and_then(|value| value.checked_mul(config.dtype_width_bytes))
+        .ok_or_else(|| anyhow::anyhow!("G2 block stride overflows usize"))?;
+    let block_stride = natural_block_stride
+        .checked_add(config.alignment - 1)
+        .map(|value| value & !(config.alignment - 1))
+        .ok_or_else(|| anyhow::anyhow!("aligned G2 block stride overflows usize"))?;
+    let data_bytes = (config.num_blocks - 1)
+        .checked_mul(block_stride)
+        .and_then(|value| value.checked_add(natural_block_stride))
+        .and_then(|value| value.checked_add(config.alignment - 1))
+        .ok_or_else(|| anyhow::anyhow!("G2 shared-memory size overflows usize"))?;
+    Ok(u64::try_from(data_bytes)?)
+}
+
 fn validate_page_size(value: usize) -> Result<(), validator::ValidationError> {
     if !value.is_power_of_two() {
         return Err(validator::ValidationError::new(
@@ -440,6 +542,9 @@ pub struct KvbmWorkerConfig {
 
     #[builder(default = "LayoutType::FullyContiguous")]
     host_layout_type: LayoutType,
+
+    #[builder(default)]
+    host_memory_backing: HostMemoryBacking,
 
     #[builder(default = "LayoutType::FullyContiguous")]
     disk_layout_type: LayoutType,
@@ -501,6 +606,13 @@ impl KvbmWorkerConfig {
                 );
             }
             _ => {}
+        }
+
+        if let HostMemoryBacking::Rcommu(config) = &self.host_memory_backing {
+            config.validate()?;
+            if self.host_layout_type != LayoutType::FullyContiguous {
+                anyhow::bail!("rcommu G2 backing requires a FullyContiguous host layout");
+            }
         }
 
         Ok(())
@@ -601,8 +713,12 @@ impl KvbmWorker {
             }
         };
 
-        let bytes_per_block =
-            num_layers * outer_dim * config.page_size * inner_dim * config.dtype_width_bytes;
+        let bytes_per_block = num_layers
+            .checked_mul(outer_dim)
+            .and_then(|value| value.checked_mul(config.page_size))
+            .and_then(|value| value.checked_mul(inner_dim))
+            .and_then(|value| value.checked_mul(config.dtype_width_bytes))
+            .ok_or_else(|| anyhow::anyhow!("KV bytes per block overflows usize"))?;
 
         let mut layout_builder_instance = LayoutConfigBuilder::default();
         let layout_builder = layout_builder_instance
@@ -892,6 +1008,39 @@ mod tests {
             .num_device_blocks(1)
             .build()
             .expect("base config should build")
+    }
+
+    #[test]
+    fn fully_contiguous_external_allocation_matches_layout_rules() {
+        let config = LayoutConfig::builder()
+            .num_blocks(3)
+            .num_layers(2)
+            .outer_dim(2)
+            .page_size(16)
+            .inner_dim(64)
+            .dtype_width_bytes(2)
+            .alignment(4096)
+            .build()
+            .unwrap();
+        // Natural block size is 8192, with two extra blocks and at most 4095 bytes
+        // of initial alignment padding accepted by FullyContiguous::new.
+        assert_eq!(fully_contiguous_allocation_size(&config).unwrap(), 28_671);
+    }
+
+    #[test]
+    fn rcommu_backing_rejects_layer_separate_layout() {
+        let mut config = base_config();
+        config.host_memory_backing = HostMemoryBacking::Rcommu(RcommuShmConfig {
+            endpoint: "/tmp/rcommu-owner.sock".into(),
+            region_key: "deployment/instance/rank-0/g2".into(),
+            numa_node: None,
+            attach_timeout: std::time::Duration::from_secs(1),
+            worker_epoch: 1,
+        });
+        config.host_layout_type = LayoutType::LayerSeparate {
+            outer_contiguous: false,
+        };
+        assert!(config.validate().is_err());
     }
 
     // --- outer_dim ---

--- a/lib/llm/src/block_manager/storage/cuda.rs
+++ b/lib/llm/src/block_manager/storage/cuda.rs
@@ -158,11 +158,20 @@ impl Cuda {
     }
 }
 
-/// Pinned host memory storage using CUDA page-locked memory.
-/// Wraps [`dynamo_memory::PinnedStorage`] and adds registration handle support.
+#[derive(Debug)]
+enum PinnedBacking {
+    CudaAllocated(dynamo_memory::PinnedStorage),
+    External(dynamo_memory::ExternalPinnedStorage),
+}
+
+/// Pinned host memory storage with either CUDA-allocated or externally mapped backing.
+///
+/// Both variants use the same KVBM storage and NIXL registration interface. Their
+/// destruction remains distinct: CUDA allocations call `cuMemFreeHost`, while
+/// external mappings call `cuMemHostUnregister` and then unmap the owner-provided file.
 #[derive(Debug)]
 pub struct PinnedStorage {
-    inner: dynamo_memory::PinnedStorage,
+    inner: PinnedBacking,
     handles: RegistrationHandles,
 }
 
@@ -182,7 +191,7 @@ impl PinnedStorage {
         let inner =
             dynamo_memory::PinnedStorage::new_for_device(size, Some(ctx.cu_device() as u32))?;
         Ok(Self {
-            inner,
+            inner: PinnedBacking::CudaAllocated(inner),
             handles: RegistrationHandles::new(),
         })
     }
@@ -206,9 +215,17 @@ impl PinnedStorage {
         }
         let inner = dynamo_memory::PinnedStorage::new_for_device(size, device_id)?;
         Ok(Self {
-            inner,
+            inner: PinnedBacking::CudaAllocated(inner),
             handles: RegistrationHandles::new(),
         })
+    }
+
+    /// Wrap an owner-provided mapping that has already been registered with CUDA.
+    pub fn from_external(inner: dynamo_memory::ExternalPinnedStorage) -> Self {
+        Self {
+            inner: PinnedBacking::External(inner),
+            handles: RegistrationHandles::new(),
+        }
     }
 }
 
@@ -225,25 +242,40 @@ impl Storage for PinnedStorage {
     }
 
     fn addr(&self) -> u64 {
-        self.inner.addr() as u64
+        match &self.inner {
+            PinnedBacking::CudaAllocated(inner) => inner.addr() as u64,
+            PinnedBacking::External(inner) => inner.addr() as u64,
+        }
     }
 
     fn size(&self) -> usize {
-        self.inner.size()
+        match &self.inner {
+            PinnedBacking::CudaAllocated(inner) => inner.size(),
+            PinnedBacking::External(inner) => inner.size(),
+        }
     }
 
     unsafe fn as_ptr(&self) -> *const u8 {
-        unsafe { self.inner.as_ptr() }
+        match &self.inner {
+            PinnedBacking::CudaAllocated(inner) => unsafe { inner.as_ptr() },
+            PinnedBacking::External(inner) => inner.as_ptr(),
+        }
     }
 
     unsafe fn as_mut_ptr(&mut self) -> *mut u8 {
-        unsafe { self.inner.as_mut_ptr() }
+        match &mut self.inner {
+            PinnedBacking::CudaAllocated(inner) => unsafe { inner.as_mut_ptr() },
+            PinnedBacking::External(inner) => unsafe { inner.as_mut_ptr() },
+        }
     }
 }
 
 impl CudaContextProivder for PinnedStorage {
     fn cuda_context(&self) -> &Arc<CudaContext> {
-        self.inner.ctx()
+        match &self.inner {
+            PinnedBacking::CudaAllocated(inner) => inner.ctx(),
+            PinnedBacking::External(inner) => inner.ctx(),
+        }
     }
 }
 
@@ -267,13 +299,16 @@ impl RegisterableStorage for PinnedStorage {
 
 impl StorageMemset for PinnedStorage {
     fn memset(&mut self, value: u8, offset: usize, size: usize) -> Result<(), StorageError> {
-        if offset + size > self.inner.size() {
+        let end = offset.checked_add(size).ok_or_else(|| {
+            StorageError::OperationFailed("memset: offset + size overflow".into())
+        })?;
+        if end > self.size() {
             return Err(StorageError::OperationFailed(
                 "memset: offset + size > storage size".into(),
             ));
         }
         unsafe {
-            let ptr = self.inner.as_mut_ptr().add(offset);
+            let ptr = self.as_mut_ptr().add(offset);
             std::ptr::write_bytes(ptr, value, size);
         }
         Ok(())

--- a/lib/memory/Cargo.toml
+++ b/lib/memory/Cargo.toml
@@ -34,6 +34,7 @@ tracing = { workspace = true }
 
 libc = { version = "0.2" }
 libloading = "0.8"
+memmap2 = "0.9"
 nix = { version = "0.30", features = ["fs"] }
 offset-allocator = "0.2"
 

--- a/lib/memory/src/external_pinned.rs
+++ b/lib/memory/src/external_pinned.rs
@@ -1,0 +1,363 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! CUDA registration for externally owned, file-backed host memory.
+
+use std::{
+    any::Any,
+    fs::{File, OpenOptions},
+    os::unix::{fs::MetadataExt, fs::OpenOptionsExt},
+    path::PathBuf,
+    sync::Arc,
+};
+
+use cudarc::driver::{CudaContext, sys};
+use memmap2::{MmapMut, MmapOptions};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    MemoryDescriptor, Result, StorageError, StorageKind, actions,
+    nixl::{MemType, NixlCompatible, NixlDescriptor},
+};
+
+/// The file range and identity expected for an external shared-memory mapping.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExternalFileMappingDescriptor {
+    /// Owner-controlled backing path.
+    pub path: PathBuf,
+    /// Device ID from `stat(2)` when the owner created the file.
+    pub device: u64,
+    /// Inode from `stat(2)` when the owner created the file.
+    pub inode: u64,
+    /// Byte offset at which the opaque data area begins.
+    pub offset: u64,
+    /// Length of the opaque data area.
+    pub len: u64,
+    /// Required alignment of the mapped data address.
+    pub alignment: u64,
+}
+
+/// A checked writable `MAP_SHARED` file range.
+pub struct ExternalFileMapping {
+    descriptor: ExternalFileMappingDescriptor,
+    mmap: MmapMut,
+    _file: File,
+}
+
+impl std::fmt::Debug for ExternalFileMapping {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ExternalFileMapping")
+            .field("descriptor", &self.descriptor)
+            .field("addr", &(self.mmap.as_ptr() as usize))
+            .finish_non_exhaustive()
+    }
+}
+
+impl ExternalFileMapping {
+    /// Securely open and map the exact file range described by `descriptor`.
+    pub fn open(descriptor: ExternalFileMappingDescriptor) -> Result<Self> {
+        validate_descriptor(&descriptor)?;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+            .open(&descriptor.path)?;
+        let metadata = file.metadata()?;
+        if metadata.dev() != descriptor.device || metadata.ino() != descriptor.inode {
+            return Err(StorageError::OperationFailed(
+                "external mapping file identity does not match the owner descriptor".into(),
+            ));
+        }
+        let end = descriptor
+            .offset
+            .checked_add(descriptor.len)
+            .ok_or_else(|| {
+                StorageError::OperationFailed("external mapping range overflows".into())
+            })?;
+        if metadata.len() < end {
+            return Err(StorageError::OperationFailed(format!(
+                "external mapping ends at {end}, but the backing file is only {} bytes",
+                metadata.len()
+            )));
+        }
+        let len = usize::try_from(descriptor.len).map_err(|_| {
+            StorageError::OperationFailed("external mapping length does not fit usize".into())
+        })?;
+        let mmap = unsafe {
+            MmapOptions::new()
+                .offset(descriptor.offset)
+                .len(len)
+                .map_mut(&file)
+        }?;
+        if !(mmap.as_ptr() as usize).is_multiple_of(descriptor.alignment as usize) {
+            return Err(StorageError::OperationFailed(format!(
+                "external mapping address does not satisfy {}-byte alignment",
+                descriptor.alignment
+            )));
+        }
+        Ok(Self {
+            descriptor,
+            mmap,
+            _file: file,
+        })
+    }
+
+    /// Base host address of the mapped data range.
+    pub fn addr(&self) -> usize {
+        self.mmap.as_ptr() as usize
+    }
+
+    /// Length of the mapped data range.
+    pub fn len(&self) -> usize {
+        self.mmap.len()
+    }
+
+    /// Whether the mapped data range is empty.
+    pub fn is_empty(&self) -> bool {
+        self.mmap.is_empty()
+    }
+
+    /// Mapping descriptor validated by [`Self::open`].
+    pub fn descriptor(&self) -> &ExternalFileMappingDescriptor {
+        &self.descriptor
+    }
+
+    /// Immutable view of the mapped bytes.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.mmap
+    }
+
+    /// Mutable view of the mapped bytes.
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.mmap
+    }
+}
+
+/// An owner-provided shared-memory mapping registered as CUDA pinned host memory.
+///
+/// Unlike [`crate::PinnedStorage`], this type does not call `cuMemFreeHost`.
+/// Drop unregisters the host range from CUDA before the mapping and file are released.
+pub struct ExternalPinnedStorage {
+    mapping: Option<ExternalFileMapping>,
+    ctx: Arc<CudaContext>,
+    registered: bool,
+}
+
+unsafe impl Send for ExternalPinnedStorage {}
+unsafe impl Sync for ExternalPinnedStorage {}
+
+impl std::fmt::Debug for ExternalPinnedStorage {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ExternalPinnedStorage")
+            .field("mapping", &self.mapping)
+            .field("cuda_device", &self.ctx.cu_device())
+            .field("registered", &self.registered)
+            .finish()
+    }
+}
+
+impl ExternalPinnedStorage {
+    /// Map an owner-provided file range and register it in `device_id`'s CUDA context.
+    pub fn new(descriptor: ExternalFileMappingDescriptor, device_id: u32) -> Result<Self> {
+        let mapping = ExternalFileMapping::open(descriptor)?;
+        let ctx = crate::device::cuda_context(device_id)?;
+        ctx.bind_to_thread().map_err(StorageError::Cuda)?;
+        let result = unsafe {
+            sys::cuMemHostRegister_v2(
+                mapping.addr() as *mut std::ffi::c_void,
+                mapping.len(),
+                sys::CU_MEMHOSTREGISTER_DEVICEMAP | sys::CU_MEMHOSTREGISTER_PORTABLE,
+            )
+        };
+        result.result().map_err(StorageError::Cuda)?;
+        Ok(Self {
+            mapping: Some(mapping),
+            ctx,
+            registered: true,
+        })
+    }
+
+    /// Descriptor of the backing file range.
+    pub fn mapping_descriptor(&self) -> &ExternalFileMappingDescriptor {
+        self.mapping().descriptor()
+    }
+
+    /// CUDA context used to register this mapping.
+    pub fn ctx(&self) -> &Arc<CudaContext> {
+        &self.ctx
+    }
+
+    /// Raw host pointer. It remains valid until this storage is dropped.
+    pub fn as_ptr(&self) -> *const u8 {
+        self.mapping().addr() as *const u8
+    }
+
+    /// Raw mutable host pointer.
+    ///
+    /// # Safety
+    /// The caller must prevent concurrent aliases that access this memory.
+    pub unsafe fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.mapping().addr() as *mut u8
+    }
+
+    fn mapping(&self) -> &ExternalFileMapping {
+        self.mapping
+            .as_ref()
+            .expect("external mapping remains present until storage drop")
+    }
+}
+
+impl Drop for ExternalPinnedStorage {
+    fn drop(&mut self) {
+        if !self.registered {
+            return;
+        }
+        if let Err(error) = self.ctx.bind_to_thread() {
+            tracing::error!(%error, "failed to bind CUDA context before unregistering external host memory");
+        }
+        let address = self.mapping().addr();
+        let result = unsafe { sys::cuMemHostUnregister(address as *mut std::ffi::c_void) };
+        if let Err(error) = result.result() {
+            tracing::error!(%error, "failed to unregister external host memory from CUDA");
+            // Unmapping memory that CUDA still considers registered is unsafe. Leak this
+            // exceptional mapping (and its FD) instead of invalidating the CUDA registration.
+            if let Some(mapping) = self.mapping.take() {
+                std::mem::forget(mapping);
+            }
+        } else {
+            self.registered = false;
+        }
+    }
+}
+
+impl MemoryDescriptor for ExternalPinnedStorage {
+    fn addr(&self) -> usize {
+        self.mapping().addr()
+    }
+
+    fn size(&self) -> usize {
+        self.mapping().len()
+    }
+
+    fn storage_kind(&self) -> StorageKind {
+        StorageKind::Pinned
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn nixl_descriptor(&self) -> Option<NixlDescriptor> {
+        None
+    }
+}
+
+impl NixlCompatible for ExternalPinnedStorage {
+    fn nixl_params(&self) -> (*const u8, usize, MemType, u64) {
+        (self.as_ptr(), self.mapping().len(), MemType::Dram, 0)
+    }
+}
+
+impl actions::Memset for ExternalPinnedStorage {
+    fn memset(&mut self, value: u8, offset: usize, size: usize) -> Result<()> {
+        let end = offset
+            .checked_add(size)
+            .ok_or_else(|| StorageError::OperationFailed("memset range overflows".into()))?;
+        if end > self.mapping().len() {
+            return Err(StorageError::OperationFailed(
+                "memset range exceeds external storage".into(),
+            ));
+        }
+        self.mapping
+            .as_mut()
+            .expect("external mapping remains present until storage drop")
+            .as_mut_slice()[offset..end]
+            .fill(value);
+        Ok(())
+    }
+}
+
+fn validate_descriptor(descriptor: &ExternalFileMappingDescriptor) -> Result<()> {
+    if descriptor.len == 0 {
+        return Err(StorageError::OperationFailed(
+            "external mapping length must be positive".into(),
+        ));
+    }
+    if descriptor.alignment == 0 || !descriptor.alignment.is_power_of_two() {
+        return Err(StorageError::OperationFailed(
+            "external mapping alignment must be a non-zero power of two".into(),
+        ));
+    }
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if page_size <= 0 {
+        return Err(StorageError::Io(std::io::Error::last_os_error()));
+    }
+    let page_size = page_size as u64;
+    if !descriptor.offset.is_multiple_of(page_size) {
+        return Err(StorageError::OperationFailed(format!(
+            "external mapping offset must be aligned to the system page size ({page_size})"
+        )));
+    }
+    if descriptor.alignment > page_size || !page_size.is_multiple_of(descriptor.alignment) {
+        return Err(StorageError::OperationFailed(format!(
+            "external mapping alignment must not exceed the system page size ({page_size})"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::MetadataExt;
+
+    use super::*;
+
+    #[test]
+    fn checked_mapping_is_shared_and_rejects_identity_mismatch() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        file.as_file().set_len(8192).unwrap();
+        let metadata = file.as_file().metadata().unwrap();
+        let descriptor = ExternalFileMappingDescriptor {
+            path: file.path().to_path_buf(),
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            offset: 4096,
+            len: 4096,
+            alignment: 4096,
+        };
+        let mut first = ExternalFileMapping::open(descriptor.clone()).unwrap();
+        let second = ExternalFileMapping::open(descriptor.clone()).unwrap();
+        first.as_mut_slice()[9..13].copy_from_slice(b"kvbm");
+        assert_eq!(&second.as_slice()[9..13], b"kvbm");
+
+        let mut forged = descriptor;
+        forged.inode = forged.inode.wrapping_add(1);
+        assert!(ExternalFileMapping::open(forged).is_err());
+    }
+
+    #[test]
+    fn checked_mapping_rejects_overflow_and_unaligned_offsets() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        file.as_file().set_len(8192).unwrap();
+        let metadata = file.as_file().metadata().unwrap();
+        let base = ExternalFileMappingDescriptor {
+            path: file.path().to_path_buf(),
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            offset: 1,
+            len: 4096,
+            alignment: 4096,
+        };
+        assert!(ExternalFileMapping::open(base.clone()).is_err());
+        assert!(
+            ExternalFileMapping::open(ExternalFileMappingDescriptor {
+                offset: 4096,
+                len: u64::MAX,
+                ..base
+            })
+            .is_err()
+        );
+    }
+}

--- a/lib/memory/src/lib.rs
+++ b/lib/memory/src/lib.rs
@@ -29,6 +29,8 @@ pub mod prelude;
 mod device;
 mod disk;
 mod external;
+#[cfg(unix)]
+mod external_pinned;
 mod pinned;
 mod system;
 mod tensor;
@@ -40,6 +42,10 @@ pub use arena::{ArenaAllocator, ArenaBuffer, ArenaError};
 pub use device::DeviceStorage;
 pub use disk::DiskStorage;
 pub use external::ExternalDeviceMemory;
+#[cfg(unix)]
+pub use external_pinned::{
+    ExternalFileMapping, ExternalFileMappingDescriptor, ExternalPinnedStorage,
+};
 #[cfg(target_os = "linux")]
 pub use numa::{NumaNode, is_numa_disabled, is_numa_enabled};
 pub use offset::OffsetBuffer;

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -248,6 +248,24 @@ pub mod kvbm {
             "DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS";
     }
 
+    /// Owner-managed G2 shared-memory configuration.
+    pub mod shared_memory {
+        /// G2 backing implementation (`cuda` or `rcommu`).
+        pub const DYN_KVBM_G2_BACKING: &str = "DYN_KVBM_G2_BACKING";
+
+        /// Unix socket exposed by the rcommu shared-memory owner.
+        pub const DYN_KVBM_RCOMMU_ENDPOINT: &str = "DYN_KVBM_RCOMMU_ENDPOINT";
+
+        /// Exclusive owner region key for this worker and parallel rank.
+        pub const DYN_KVBM_RCOMMU_REGION_KEY: &str = "DYN_KVBM_RCOMMU_REGION_KEY";
+
+        /// Optional NUMA node on which the owner places the region.
+        pub const DYN_KVBM_RCOMMU_NUMA_NODE: &str = "DYN_KVBM_RCOMMU_NUMA_NODE";
+
+        /// Timeout in milliseconds for one owner lifecycle request.
+        pub const DYN_KVBM_RCOMMU_ATTACH_TIMEOUT_MS: &str = "DYN_KVBM_RCOMMU_ATTACH_TIMEOUT_MS";
+    }
+
     /// Disk cache configuration
     pub mod disk_cache {
         /// Disk cache size in GB
@@ -942,6 +960,11 @@ mod tests {
             kvbm::DYN_KVBM_DISABLE_DISK_OFFLOAD_FILTER,
             kvbm::cpu_cache::DYN_KVBM_CPU_CACHE_GB,
             kvbm::cpu_cache::DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS,
+            kvbm::shared_memory::DYN_KVBM_G2_BACKING,
+            kvbm::shared_memory::DYN_KVBM_RCOMMU_ENDPOINT,
+            kvbm::shared_memory::DYN_KVBM_RCOMMU_REGION_KEY,
+            kvbm::shared_memory::DYN_KVBM_RCOMMU_NUMA_NODE,
+            kvbm::shared_memory::DYN_KVBM_RCOMMU_ATTACH_TIMEOUT_MS,
             kvbm::disk_cache::DYN_KVBM_DISK_CACHE_GB,
             kvbm::disk_cache::DYN_KVBM_DISK_CACHE_OVERRIDE_NUM_BLOCKS,
             kvbm::leader::DYN_KVBM_LEADER_WORKER_INIT_TIMEOUT_SECS,


### PR DESCRIPTION
## Overview

Allow the current distributed KVBM worker to use an rcommu-owned file-backed shared-memory region as its G2 host cache. The existing CUDA-allocated backing remains the default.

Depends on ActivePeter/rcommu#1, which defines and serves the owner lifecycle contract.

## Summary

- Add checked ExternalFileMapping and ExternalPinnedStorage support to dynamo-memory, including device/inode/bounds/alignment validation and CUDA host registration.
- Add an explicit rcommu host-memory backing to the legacy distributed KVBM worker while preserving the existing PinnedStorage and transfer interfaces.
- Implement transactional open, map/register/build, activate, abort, status recovery, and detach behavior.
- Keep the attachment alive through all blocks and registrations; final teardown is NIXL unregister, CUDA unregister, munmap, then owner detach.
- Fail closed when rcommu is explicitly selected, require FullyContiguous G2 layout, monitor owner/lease health, and cancel the worker on loss.
- Document the environment configuration and per-worker region-key placeholders.

This PR only covers shared-memory G2 backing. It does not include the separate SGLang no-L2 work.

## Details

The owner control socket carries lifecycle metadata only; KV payload is accessed directly through MAP_SHARED memory. KVBM continues to own keys, slots, pins, transfers, and eviction decisions.

New configuration:

- DYN_KVBM_G2_BACKING=cuda or rcommu
- DYN_KVBM_RCOMMU_ENDPOINT
- DYN_KVBM_RCOMMU_REGION_KEY with device_id, rank, and pid placeholders
- DYN_KVBM_RCOMMU_NUMA_NODE
- DYN_KVBM_RCOMMU_ATTACH_TIMEOUT_MS

## Where should the reviewer start?

- lib/memory/src/external_pinned.rs for mapping and CUDA-registration lifetime
- lib/llm/src/block_manager/distributed/shared_memory.rs for the owner protocol and attachment state machine
- lib/llm/src/block_manager/distributed/worker.rs for G2 integration and rollback
- lib/llm/src/block_manager/distributed/transfer.rs for health gating and final drop ordering

## Related Issues

**This PR is NOT linked to an existing issue:**

- [x] Confirmed — searches for rcommu, KVBM shared memory, and external pinned memory found no matching issue.

This is intentionally a draft because repository policy classifies the host-memory ownership change as architectural and requires maintainer direction or a new DEP before merge.

## Validation

Run again after rebasing onto ai-dynamo/dynamo main at 9fab3f9ef5:

- cargo fmt --all -- --check
- dynamo-memory external mapping tests: 2 passed
- distributed shared-memory tests: 4 passed
- distributed worker tests: 13 passed
- runtime environment-name tests: 2 passed
- dynamo-memory clippy with warnings denied
- dynamo-llm all-targets clippy with warnings denied
- standalone KVBM Python binding locked cargo check
- Cross-repository smoke with ActivePeter/rcommu#1: owner open, real header/inode validation, MAP_SHARED write, and abort

No NVIDIA GPU is available in the development environment, so the CUDA D2H/H2D and NIXL round-trip must run in GPU CI.

The head commit dc84cb962c has a DCO sign-off but is not cryptographically verified. A maintainer may need to approve CI with /ok to test dc84cb9.
