### PR TITLE
fix(frontend): preserve forced SGLang tool guidance

### DIFF
--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -767,6 +767,7 @@ def preprocess_chat_request(
     # Reject a forced tool_choice that cannot be satisfied by the provided tools.
     # Otherwise the chat template and guided decoding cannot enforce the request.
     tool_choice = request.get("tool_choice", "auto")
+    forced_tool_choice = tool_choice == "required" or _is_named_tool_choice(tool_choice)
     if tool_choice == "required" and not sglang_tools:
         raise PreprocessError('tool_choice is "required" but tools is empty')
     if _is_named_tool_choice(tool_choice):
@@ -777,6 +778,17 @@ def preprocess_chat_request(
                 f"tool_choice names function {chosen_name!r}, but it is not "
                 f"present in tools (available: {sorted(available_names) or 'none'})"
             )
+
+    response_format = request.get("response_format")
+    if (
+        forced_tool_choice
+        and isinstance(response_format, dict)
+        and response_format.get("type") == "structural_tag"
+    ):
+        raise PreprocessError(
+            "tool_choice forces a tool call and cannot be combined with a "
+            "structural_tag response format"
+        )
 
     template_tools = _filter_template_tools(
         request,
@@ -837,7 +849,9 @@ def preprocess_chat_request(
         tool_call_parser_name=tool_call_parser_name,
         sglang_tools=sglang_tools,
     )
-    forced_tool_choice = tool_choice == "required" or _is_named_tool_choice(tool_choice)
+    # This path also never reads the legacy guided_json / guided_regex /
+    # guided_grammar / guided_choice fields at all, so those are dropped silently
+    # while both other paths honor them (and reject them against a forced choice).
     if (
         response_format_guided_decoding is not None
         and tool_call_guided_decoding is not None

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -837,22 +837,20 @@ def preprocess_chat_request(
         tool_call_parser_name=tool_call_parser_name,
         sglang_tools=sglang_tools,
     )
-    # TODO: response_format wins here even when tool_choice is "required" or names
-    # a function, so a request that demanded a tool call can come back with none
-    # -- the tool constraint is dropped and only logged. The other two paths do
-    # the opposite: preprocessor/tool_choice.rs clears the response_format JSON
-    # and keeps the tool constraint, and prepost.py does the same after narrowing
-    # its conflict check. response_format is scoped by the OpenAI spec to the
-    # message the model returns to the user, not to tool calls, so the tool
-    # constraint is the one that must survive.
-    #
+    forced_tool_choice = tool_choice == "required" or _is_named_tool_choice(tool_choice)
     if (
         response_format_guided_decoding is not None
         and tool_call_guided_decoding is not None
     ):
-        logger.warning(
-            "Tool-call guided decoding will be ignored because of response_format already exists."
-        )
+        if forced_tool_choice:
+            logger.warning(
+                "response_format guided decoding will be ignored because tool_choice is forced."
+            )
+        else:
+            logger.warning(
+                "Tool-call guided decoding will be ignored because response_format already exists."
+            )
+
     # A forced tool choice and a legacy guided_* constrain the same token stream,
     # so honoring the guided_* would drop the tool constraint while the forced-tool
     # parser stays selected. Reject that rather than drop one silently, matching
@@ -863,24 +861,23 @@ def preprocess_chat_request(
     # guided_regex; nothing is displaced, and named_zero_arg_tool below still
     # recognizes it. Rejecting an identical constraint would refuse a request the
     # two paths agree on.
-    tool_choice = request.get("tool_choice", "auto")
     if (
         legacy_guidance
         and tool_call_guided_decoding is not None
         and legacy_guidance != tool_call_guided_decoding
-        and (tool_choice == "required" or _is_named_tool_choice(tool_choice))
+        and forced_tool_choice
     ):
         raise InvalidArgument(
             "tool_choice forces a tool call and cannot be combined with an "
             "explicit guided_* constraint."
         )
 
-    # Explicit legacy constraints outrank automatic guidance, matching the vLLM
-    # processor. response_format is NOT covered by the check above -- see the TODO
-    # further up: it still wins over a forced tool choice here, unlike the other
-    # two paths.
     guided_decoding = (
-        legacy_guidance or response_format_guided_decoding or tool_call_guided_decoding
+        tool_call_guided_decoding
+        if forced_tool_choice
+        else legacy_guidance
+        or response_format_guided_decoding
+        or tool_call_guided_decoding
     )
 
     return SglangPreprocessResult(

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -764,11 +764,11 @@ def preprocess_chat_request(
     # Convert tools to SGLang format (done once, shared with parser creation)
     sglang_tools = convert_tools(request.get("tools"))
 
-    # Reject a named tool_choice whose function is missing from tools —
-    # otherwise the chat template would render with zero tools while
-    # guided decoding still constrains the output to that function's
-    # schema, producing confusing model behavior.
+    # Reject a forced tool_choice that cannot be satisfied by the provided tools.
+    # Otherwise the chat template and guided decoding cannot enforce the request.
     tool_choice = request.get("tool_choice", "auto")
+    if tool_choice == "required" and not sglang_tools:
+        raise PreprocessError('tool_choice is "required" but tools is empty')
     if _is_named_tool_choice(tool_choice):
         chosen_name = tool_choice["function"]["name"]
         available_names = {t.function.name for t in (sglang_tools or [])}

--- a/components/src/dynamo/frontend/tests/_tool_guidance_parity.py
+++ b/components/src/dynamo/frontend/tests/_tool_guidance_parity.py
@@ -45,17 +45,13 @@ TOOL_GUIDANCE_PARITY_CASES = (
         "assistant",
     ),
     # response_format is scoped to the message returned to the user, not to tool
-    # calls, so a forced choice keeps the tool constraint and drops it. SGLang
-    # instead lets response_format win and can return no tool call at all --
-    # see the TODO above `guided_decoding = response_format_guided_decoding or ...`
-    # in sglang_prepost.py.
+    # calls, so a forced choice keeps the tool constraint and drops it.
     ToolGuidanceParityCase(
         "forced-choice-with-response-format",
         "required",
         True,
         True,
         "tool",
-        known_divergent=(("sglang", "assistant"),),
     ),
     ToolGuidanceParityCase(
         "named-choice-with-response-format",
@@ -63,7 +59,6 @@ TOOL_GUIDANCE_PARITY_CASES = (
         True,
         True,
         "tool",
-        known_divergent=(("sglang", "assistant"),),
     ),
 )
 

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -2059,7 +2059,28 @@ class TestPreprocessChatRequest:  # FRONTEND.1 — chat-template input preproces
         assert len(with_tools.prompt_token_ids) > len(without_tools.prompt_token_ids)
         assert with_tools.tool_call_parser is not None
 
-    def test_response_format_takes_precedence_over_tool_guidance(
+    @pytest.mark.parametrize("tools", [None, []], ids=["missing", "empty"])
+    def test_required_tool_choice_rejects_missing_tools(self, tools):
+        request = {
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "response_format": {"type": "json_object"},
+            "tool_choice": "required",
+        }
+        if tools is not None:
+            request["tools"] = tools
+
+        with pytest.raises(
+            PreprocessError, match='tool_choice is "required" but tools is empty'
+        ):
+            preprocess_chat_request(
+                request,
+                tokenizer=None,
+                tool_call_parser_name="hermes",
+                reasoning_parser_name=None,
+            )
+
+    def test_forced_tool_guidance_takes_precedence_over_response_format(
         self, tokenizer, caplog
     ):
         result = preprocess_chat_request(
@@ -2086,13 +2107,14 @@ class TestPreprocessChatRequest:  # FRONTEND.1 — chat-template input preproces
             reasoning_parser_name=None,
         )
 
-        assert result.guided_decoding == {"json": {"type": "object"}}
+        assert result.guided_decoding is not None
+        assert result.guided_decoding["json"]["type"] == "array"
         assert (
-            "Tool-call guided decoding will be ignored because of response_format already exists."
+            "response_format guided decoding will be ignored because tool_choice is forced."
             in caplog.text
         )
 
-    def test_response_format_disables_named_zero_arg_tool_reconstruction(
+    def test_named_zero_arg_tool_guidance_takes_precedence_over_response_format(
         self, tokenizer
     ):
         result = preprocess_chat_request(
@@ -2123,8 +2145,8 @@ class TestPreprocessChatRequest:  # FRONTEND.1 — chat-template input preproces
             reasoning_parser_name=None,
         )
 
-        assert result.guided_decoding == {"json": {"type": "object"}}
-        assert result.named_zero_arg_tool is None
+        assert result.guided_decoding == {"regex": r"\{\}"}
+        assert result.named_zero_arg_tool == "get_server_time"
 
     def test_assistant_tool_calls_with_string_arguments(self, tokenizer):
         """Multi-turn with prior assistant tool_calls renders without raising.

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -2080,6 +2080,34 @@ class TestPreprocessChatRequest:  # FRONTEND.1 — chat-template input preproces
                 reasoning_parser_name=None,
             )
 
+    @pytest.mark.parametrize(
+        "tool_choice",
+        ["required", tool_choice_value("named")],
+        ids=["required", "named"],
+    )
+    def test_forced_tool_choice_rejects_structural_tag_response_format(
+        self, tool_choice
+    ):
+        with pytest.raises(
+            PreprocessError,
+            match="cannot be combined with a structural_tag response format",
+        ):
+            preprocess_chat_request(
+                {
+                    "model": MODEL,
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "tools": [parity_tool()],
+                    "tool_choice": tool_choice,
+                    "response_format": {
+                        "type": "structural_tag",
+                        "format": {"type": "any_text"},
+                    },
+                },
+                tokenizer=None,
+                tool_call_parser_name="hermes",
+                reasoning_parser_name=None,
+            )
+
     def test_forced_tool_guidance_takes_precedence_over_response_format(
         self, tokenizer, caplog
     ):


### PR DESCRIPTION
## Context

PR #12684 added tool-call guided decoding to the Python frontend and introduced a shared behavior matrix for the vLLM and SGLang paths.

The SGLang path still gives `response_format` precedence when a request also forces a tool call through either:

- `tool_choice="required"`
- a named `tool_choice`

As a result, the tool-call constraint is discarded. The model can return a regular assistant response that satisfies `response_format` without producing the tool call required by the request.

`response_format` applies to a regular assistant message, while a forced `tool_choice` requires the response to be a tool call. When both are present, the tool-call constraint should therefore take precedence. This also matches the Rust preprocessor and Python vLLM behavior.

## Summary

- prefer tool-call guided decoding for required and named tool choices
- preserve the existing `response_format` precedence for automatic tool choice
- reject required tool choices when `tools` is missing or empty
- update the focused SGLang preprocessing tests and remove the corresponding exceptions from the shared guidance parity matrix

Follow-up to #12684.

## Validation

- `pre-commit run --files components/src/dynamo/frontend/sglang_prepost.py components/src/dynamo/frontend/tests/_tool_guidance_parity.py components/src/dynamo/frontend/tests/test_sglang_processor_unit.py`
- `python3 -m compileall -q components/src/dynamo/frontend/sglang_prepost.py components/src/dynamo/frontend/tests/_tool_guidance_parity.py components/src/dynamo/frontend/tests/test_sglang_processor_unit.py`
- The targeted pytest was not run locally because the SGLang test dependency is not installed. The updated SGLang preprocessing and shared parity cases run in the SGLang CI environment.