### PR TITLE
feat(sglang): add direct KVBM cache integration

### DIFF
--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -14,7 +14,15 @@ from pathlib import Path
 from typing import Any, Dict, Generator, Optional
 
 import yaml
+
+# Import the selected cache backend before any SGLang module resolves its registry.
+from dynamo.sglang.cache_plugin import load_sglang_cache_plugin
+
+# isort: split
+
 from sglang.srt.server_args import ServerArgs
+
+# isort: split
 
 from dynamo.common.config_dump import register_encoder
 from dynamo.common.configuration.groups import DynamoRuntimeConfig
@@ -355,6 +363,9 @@ async def parse_args(args: list[str]) -> Config:
     Raises:
         SystemExit: If arguments are invalid or incompatible.
     """
+    # Programmatic callers can pass argv unrelated to process-wide sys.argv.
+    load_sglang_cache_plugin(args)
+
     runtime_argspec = DynamoRuntimeArgGroup()
     dynamo_sglang_argspec = DynamoSGLangArgGroup()
 
@@ -416,6 +427,9 @@ async def parse_args(args: list[str]) -> Config:
         if "--config" in unknown:
             config_merger = ConfigArgumentMerger(parser=sglang_only_parser)
             unknown = config_merger.merge_config_with_args(unknown)
+
+        # A config file can select the backend even when the raw argv did not.
+        load_sglang_cache_plugin(unknown)
 
         unknown = _normalize_multimodal_disaggregation_args(unknown, dynamo_config)
         dynamo_config.validate_multimodal_topology()

--- a/components/src/dynamo/sglang/cache_plugin.py
+++ b/components/src/dynamo/sglang/cache_plugin.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Early loading for SGLang radix-cache backend plugins."""
+
+import importlib
+import sys
+from collections.abc import Sequence
+
+_RADIX_CACHE_PLUGINS = {
+    "dynamo_kvbm": "kvbm.sglang_integration",
+}
+
+
+def _radix_cache_backend(argv: Sequence[str]) -> str | None:
+    """Return the last explicitly selected radix-cache backend."""
+    flag = "--radix-cache-backend"
+    prefix = f"{flag}="
+    backend = None
+    for index, argument in enumerate(argv):
+        if argument.startswith(prefix):
+            backend = argument[len(prefix) :]
+        elif argument == flag and index + 1 < len(argv):
+            backend = argv[index + 1]
+    return backend
+
+
+def load_sglang_cache_plugin(argv: Sequence[str]) -> bool:
+    """Import the selected cache plugin before SGLang resolves ``ServerArgs``."""
+    module_name = _RADIX_CACHE_PLUGINS.get(_radix_cache_backend(argv))
+    if module_name is None:
+        return False
+    importlib.import_module(module_name)
+    return True
+
+
+# ``args`` imports this module immediately before ServerArgs. The normal CLI
+# therefore registers its selected backend as part of this module import.
+load_sglang_cache_plugin(sys.argv[1:])

--- a/components/src/dynamo/sglang/tests/test_cache_plugin.py
+++ b/components/src/dynamo/sglang/tests/test_cache_plugin.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for early SGLang cache-plugin registration."""
+
+import pytest
+
+# isort: split
+
+import dynamo.sglang.cache_plugin as cache_plugin
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.kvbm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--radix-cache-backend", "dynamo_kvbm"],
+        ["--radix-cache-backend=dynamo_kvbm"],
+        ["--radix-cache-backend", "unified", "--radix-cache-backend=dynamo_kvbm"],
+    ],
+)
+def test_kvbm_cache_plugin_is_loaded_for_explicit_backend(monkeypatch, argv):
+    imports = []
+    monkeypatch.setattr(cache_plugin.importlib, "import_module", imports.append)
+
+    assert cache_plugin.load_sglang_cache_plugin(argv) is True
+    assert imports == ["kvbm.sglang_integration"]
+
+
+def test_kvbm_cache_plugin_is_not_loaded_for_other_backends(monkeypatch):
+    imports = []
+    monkeypatch.setattr(cache_plugin.importlib, "import_module", imports.append)
+
+    assert cache_plugin.load_sglang_cache_plugin([]) is False
+    assert (
+        cache_plugin.load_sglang_cache_plugin(["--radix-cache-backend", "unified"])
+        is False
+    )
+    assert imports == []

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -237,6 +237,43 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86dde77d8a733a9dbaf865a9eb65c72e09c88f3d14d3dd0d2aecf511920ee4fe"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-util",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.8.6",
+ "regex",
+ "ring",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile",
+ "rustls-webpki 0.102.8",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
+]
+
+[[package]]
+name = "async-nats"
 version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad3cd6df81292728e2a8cb1f1dcb4d7e7a1ab59b80c14fbbcba2baf9d5cf86a"
@@ -252,9 +289,9 @@ dependencies = [
  "rand 0.10.1",
  "regex",
  "ring",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.4",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -656,7 +693,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.4",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2107,7 +2144,7 @@ dependencies = [
  "aligned-vec",
  "anyhow",
  "arc-swap",
- "async-nats",
+ "async-nats 0.49.1",
  "async-stream",
  "async-trait",
  "aws-config",
@@ -2151,7 +2188,7 @@ dependencies = [
  "json-five",
  "libc",
  "libloading 0.8.9",
- "lru",
+ "lru 0.16.4",
  "minijinja",
  "modelexpress-client",
  "modelexpress-common",
@@ -2341,7 +2378,7 @@ version = "1.5.0"
 dependencies = [
  "anyhow",
  "arc-swap",
- "async-nats",
+ "async-nats 0.49.1",
  "async-once-cell",
  "async-stream",
  "async-trait",
@@ -2368,7 +2405,7 @@ dependencies = [
  "libc",
  "local-ip-address",
  "log",
- "lru",
+ "lru 0.16.4",
  "mio 1.2.2",
  "notify",
  "nuid",
@@ -2831,6 +2868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
  "rustix 1.1.4",
+ "tokio",
  "windows-sys 0.59.0",
 ]
 
@@ -3352,6 +3390,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -3547,7 +3590,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.4",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -4259,6 +4302,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "kvbm-common"
+version = "1.5.0"
+dependencies = [
+ "dynamo-tokens",
+ "serde",
+]
+
+[[package]]
+name = "kvbm-kernels"
+version = "1.5.0"
+dependencies = [
+ "cudarc",
+]
+
+[[package]]
+name = "kvbm-logical"
+version = "1.5.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "bincode 2.0.1",
+ "bytes",
+ "derive_builder",
+ "dynamo-tokens",
+ "futures",
+ "indexmap 2.14.0",
+ "lru 0.16.4",
+ "parking_lot",
+ "prometheus",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "kvbm-physical"
+version = "1.5.0"
+dependencies = [
+ "aligned-vec",
+ "anyhow",
+ "bincode 2.0.1",
+ "blake3",
+ "cudarc",
+ "derive-getters",
+ "derive_builder",
+ "dynamo-memory",
+ "futures",
+ "kvbm-common",
+ "kvbm-kernels",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+ "validator",
+ "velo",
+]
+
+[[package]]
 name = "kvbm-py3"
 version = "1.5.0"
 dependencies = [
@@ -4267,7 +4375,11 @@ dependencies = [
  "derive-getters",
  "dlpark",
  "dynamo-llm",
+ "dynamo-memory",
  "dynamo-runtime",
+ "dynamo-tokens",
+ "kvbm-logical",
+ "kvbm-physical",
  "pyo3",
  "pyo3-async-runtimes",
  "serde",
@@ -4408,6 +4520,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -4845,6 +4966,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -5339,6 +5461,12 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -6611,7 +6739,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.4",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -6827,9 +6955,22 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -6838,10 +6979,10 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -6875,10 +7016,10 @@ dependencies = [
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.4",
  "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
+ "rustls-webpki 0.103.13",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -6889,6 +7030,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -7057,6 +7208,19 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.12.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
@@ -7129,6 +7293,16 @@ checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float 2.10.1",
  "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -7915,6 +8089,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -8098,7 +8273,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.4",
  "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
@@ -8659,6 +8834,72 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "velo"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7e92b2164d6df7b21f2b91eaae6a9b53eb313c8f6d305a642e75733c911f8d4"
+dependencies = [
+ "anyhow",
+ "async-nats 0.45.0",
+ "async-stream",
+ "axum",
+ "bs58",
+ "bytes",
+ "dashmap",
+ "derive-getters",
+ "derive_builder",
+ "flume",
+ "fs4",
+ "futures",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "lru 0.18.3",
+ "nix 0.31.3",
+ "parking_lot",
+ "prometheus",
+ "prost 0.13.5",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "socket2 0.6.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
+ "tower",
+ "tracing",
+ "uuid",
+ "velo-ext",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "velo-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bbf99f74c0202bd1bf6caaa8bb784f461b757df7beafe734273519caf65372e"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "flume",
+ "futures",
+ "rmp-serde",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "uuid",
+ "xxhash-rust",
+]
 
 [[package]]
 name = "version-compare"

--- a/lib/bindings/kvbm/Cargo.toml
+++ b/lib/bindings/kvbm/Cargo.toml
@@ -21,12 +21,24 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["block-manager"]
-block-manager = ["dynamo-llm/block-manager", "dep:dlpark", "dep:cudarc"]
+block-manager = [
+  "dynamo-llm/block-manager",
+  "dep:cudarc",
+  "dep:dlpark",
+  "dep:dynamo-memory",
+  "dep:dynamo-tokens",
+  "dep:kvbm-logical",
+  "dep:kvbm-physical",
+]
 nccl = ["block-manager", "dynamo-llm/nccl", "cudarc/nccl"]  # Enable NCCL collective operations for replicated mode
 
 [dependencies]
 dynamo-llm = { path = "../../llm" }
 dynamo-runtime = { path = "../../runtime" }
+dynamo-memory = { path = "../../memory", optional = true }
+dynamo-tokens = { path = "../../tokens", optional = true }
+kvbm-logical = { path = "../../kvbm-logical", optional = true }
+kvbm-physical = { path = "../../kvbm-physical", optional = true }
 
 anyhow = { version = "1" }
 derive-getters = "0.5"

--- a/lib/bindings/kvbm/python/kvbm/_core.pyi
+++ b/lib/bindings/kvbm/python/kvbm/_core.pyi
@@ -34,7 +34,6 @@ class NcclBootstrap:
             A new NcclBootstrap instance
         """
         ...
-
     def serialize(self) -> bytes:
         """
         Serialize the bootstrap data for distribution to other ranks.
@@ -45,7 +44,6 @@ class NcclBootstrap:
             The serialized bootstrap data (136 bytes)
         """
         ...
-
     @staticmethod
     def deserialize(data: bytes) -> "NcclBootstrap":
         """
@@ -62,7 +60,6 @@ class NcclBootstrap:
             A new NcclBootstrap instance
         """
         ...
-
     def init_communicator(self, rank: int) -> "NcclCommRef":
         """
         Initialize the NCCL communicator.
@@ -85,7 +82,6 @@ class NcclBootstrap:
             Owning reference; pass to KvbmWorker/PyTrtllmKvConnectorWorker
         """
         ...
-
     def world_size(self) -> int:
         """
         Get the world size for this bootstrap.
@@ -96,7 +92,6 @@ class NcclBootstrap:
             The world size
         """
         ...
-
 
 class NcclCommRef:
     """
@@ -111,7 +106,6 @@ class NcclCommRef:
         Raw ncclComm_t pointer as an integer (borrowed; do not destroy).
         """
         ...
-
 
 class KvbmWorker:
     """
@@ -175,12 +169,17 @@ class Layer:
 
     ...
 
-    def __dlpack__(self, stream: Optional[Any] = None, max_version: Optional[Any] = None, dl_device: Optional[Any] = None, copy: Optional[bool] = None) -> Any:
+    def __dlpack__(
+        self,
+        stream: Optional[Any] = None,
+        max_version: Optional[Any] = None,
+        dl_device: Optional[Any] = None,
+        copy: Optional[bool] = None,
+    ) -> Any:
         """
         Get a dlpack capsule of the layer
         """
         ...
-
     def __dlpack_device__(self) -> Any:
         """
         Get the dlpack device of the layer
@@ -199,38 +198,38 @@ class Block:
         Get the number of layers in the list
         """
         ...
-
     def __getitem__(self, index: int) -> Layer:
         """
         Get a layer by index
         """
         ...
-
-    def __iter__(self) -> 'Block':
+    def __iter__(self) -> "Block":
         """
         Get an iterator over the layers
         """
         ...
-
     def __next__(self) -> Block:
         """
         Get the next layer in the iterator
         """
         ...
-
     def to_list(self) -> List[Layer]:
         """
         Get a list of layers
         """
         ...
-
-    def __dlpack__(self, stream: Optional[Any] = None, max_version: Optional[Any] = None, dl_device: Optional[Any] = None, copy: Optional[bool] = None) -> Any:
+    def __dlpack__(
+        self,
+        stream: Optional[Any] = None,
+        max_version: Optional[Any] = None,
+        dl_device: Optional[Any] = None,
+        copy: Optional[bool] = None,
+    ) -> Any:
         """
         Get a dlpack capsule of the block
         Exception raised if the block is not contiguous
         """
         ...
-
     def __dlpack_device__(self) -> Any:
         """
         Get the dlpack device of the block
@@ -249,25 +248,21 @@ class BlockList:
         Get the number of blocks in the list
         """
         ...
-
     def __getitem__(self, index: int) -> Block:
         """
         Get a block by index
         """
         ...
-
-    def __iter__(self) -> 'BlockList':
+    def __iter__(self) -> "BlockList":
         """
         Get an iterator over the blocks
         """
         ...
-
     def __next__(self) -> Block:
         """
         Get the next block in the iterator
         """
         ...
-
     def to_list(self) -> List[Block]:
         """
         Get a list of blocks
@@ -288,7 +283,7 @@ class BlockManager:
         dtype: Optional[str] = None,
         host_num_blocks: Optional[int] = None,
         device_num_blocks: Optional[int] = None,
-        device_id: int = 0
+        device_id: int = 0,
     ) -> None:
         """
         Create a `BlockManager` object
@@ -313,7 +308,6 @@ class BlockManager:
             CUDA device ID, defaults to 0
         """
         ...
-
     def allocate_host_blocks_blocking(self, count: int) -> BlockList:
         """
         Allocate a list of host blocks (blocking call)
@@ -329,7 +323,6 @@ class BlockManager:
             List of allocated blocks
         """
         ...
-
     async def allocate_host_blocks(self, count: int) -> BlockList:
         """
         Allocate a list of host blocks
@@ -345,7 +338,6 @@ class BlockManager:
             List of allocated blocks
         """
         ...
-
     def allocate_device_blocks_blocking(self, count: int) -> BlockList:
         """
         Allocate a list of device blocks (blocking call)
@@ -361,7 +353,6 @@ class BlockManager:
             List of allocated blocks
         """
         ...
-
     async def allocate_device_blocks(self, count: int) -> BlockList:
         """
         Allocate a list of device blocks
@@ -383,9 +374,7 @@ class KvbmRequest:
     A request for KV cache
     """
 
-    def __init__(self, request_id: int, tokens: List[int], block_size: int) -> None:
-        ...
-
+    def __init__(self, request_id: int, tokens: List[int], block_size: int) -> None: ...
 
 class SchedulerOutput:
     """
@@ -396,9 +385,7 @@ class SchedulerOutput:
     cached_requests: List[Any]
     num_scheduled_tokens: dict
 
-    def __init__(self) -> None:
-        ...
-
+    def __init__(self) -> None: ...
 
 class PyTrtllmKvConnectorWorker:
     """
@@ -436,7 +423,6 @@ class PyTrtllmKvConnectorWorker:
             Required for MLA support optimization.
         """
         ...
-
     def register_kv_caches(
         self,
         num_device_blocks: int,
@@ -465,7 +451,6 @@ class PyTrtllmKvConnectorWorker:
             List of raw CUDA event handles
         """
         ...
-
     def bind_connector_meta(self, metadata: bytes) -> None:
         """
         Bind connector metadata from the leader.
@@ -476,13 +461,11 @@ class PyTrtllmKvConnectorWorker:
             Serialized connector metadata
         """
         ...
-
     def execute_offload_operations(self) -> None:
         """
         Execute pending offload operations.
         """
         ...
-
     def save_kv_layer(self, layer_idx: int) -> None:
         """
         Save a KV cache layer.
@@ -493,13 +476,11 @@ class PyTrtllmKvConnectorWorker:
             Index of the layer to save
         """
         ...
-
     def start_load_kv(self) -> None:
         """
         Start loading KV cache data.
         """
         ...
-
     def get_finished(
         self,
         finished_gen_req_ids: List[int],
@@ -521,7 +502,6 @@ class PyTrtllmKvConnectorWorker:
             A tuple of (finished_offloading, finished_onboarding) request ID lists
         """
         ...
-
     def submit_offload_on_event(self, event: int) -> None:
         """
         Submit offload operations to be executed when the given event completes.
@@ -532,7 +512,6 @@ class PyTrtllmKvConnectorWorker:
             Raw CUDA event handle
         """
         ...
-
 
 class PyTrtllmKvConnectorLeader:
     """
@@ -570,7 +549,6 @@ class PyTrtllmKvConnectorLeader:
             Output consolidator endpoint
         """
         ...
-
     def get_num_new_matched_tokens(
         self,
         request_id: str,
@@ -595,7 +573,6 @@ class PyTrtllmKvConnectorLeader:
             A tuple of (num_matched_tokens, is_complete)
         """
         ...
-
     def update_state_after_alloc(
         self,
         request_id: str,
@@ -615,7 +592,6 @@ class PyTrtllmKvConnectorLeader:
             Current context position
         """
         ...
-
     def build_connector_metadata(self, scheduler_output: SchedulerOutput) -> bytes:
         """
         Build connector metadata from scheduler output.
@@ -631,7 +607,6 @@ class PyTrtllmKvConnectorLeader:
             Serialized connector metadata
         """
         ...
-
     def request_finished(self, request_id: str, block_ids: List[int]) -> bool:
         """
         Mark a request as finished.
@@ -649,7 +624,6 @@ class PyTrtllmKvConnectorLeader:
             True if the request was successfully marked as finished
         """
         ...
-
     def has_slot(self, request_id: str) -> bool:
         """
         Check if a slot exists for the given request.
@@ -665,7 +639,6 @@ class PyTrtllmKvConnectorLeader:
             True if a slot exists
         """
         ...
-
     def create_slot(self, request: KvbmRequest, tokens: List[int]) -> None:
         """
         Create a slot for a request.
@@ -678,3 +651,73 @@ class PyTrtllmKvConnectorLeader:
             List of tokens for the request
         """
         ...
+
+class DynamoPlhKeyCodec:
+    def __init__(self, manager_namespace: bytes) -> None: ...
+    @property
+    def codec_id(self) -> str: ...
+    def extend_pages(
+        self,
+        parent_key: Optional[bytes],
+        page_tokens: List[int],
+        page_size: int,
+        cache_salt: Optional[str] = None,
+        extra_key: Optional[str] = None,
+    ) -> List[bytes]: ...
+
+class SglangLookupTicket:
+    @property
+    def ticket_id(self) -> int: ...
+    @property
+    def generation(self) -> int: ...
+    @property
+    def hit_pages(self) -> int: ...
+
+class SglangOperation:
+    @property
+    def operation_id(self) -> int: ...
+    @property
+    def generation(self) -> int: ...
+    @property
+    def kind(self) -> str: ...
+
+class SglangCompletion:
+    @property
+    def operation_id(self) -> int: ...
+    @property
+    def generation(self) -> int: ...
+    @property
+    def kind(self) -> str: ...
+    @property
+    def success(self) -> bool: ...
+    @property
+    def error(self) -> Optional[str]: ...
+
+class SglangLocalKvStore:
+    def __init__(
+        self,
+        page_size: int,
+        num_device_blocks: int,
+        tensors: List[Any],
+        host_ptr: int,
+        host_nbytes: int,
+        manager_namespace: bytes,
+        host_region_guard: Any,
+        device_id: int = 0,
+    ) -> None: ...
+    def lookup_prefix(self, encoded_keys: List[bytes]) -> SglangLookupTicket: ...
+    def cancel_lookup(self, ticket: SglangLookupTicket) -> None: ...
+    def enqueue_store(
+        self, encoded_keys: List[bytes], source_g1_blocks: List[int]
+    ) -> SglangOperation: ...
+    def enqueue_load(
+        self,
+        ticket: SglangLookupTicket,
+        encoded_keys: List[bytes],
+        target_g1_blocks: List[int],
+    ) -> SglangOperation: ...
+    def poll_completions(self) -> List[SglangCompletion]: ...
+    def drain(self, timeout_ms: int = 30_000) -> None: ...
+    def reset(self, timeout_ms: int = 30_000) -> None: ...
+    def close(self, timeout_ms: int = 30_000) -> None: ...
+    def pending_counts(self) -> tuple[int, int, int]: ...

--- a/lib/bindings/kvbm/python/kvbm/sglang_integration/__init__.py
+++ b/lib/bindings/kvbm/python/kvbm/sglang_integration/__init__.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Register Dynamo KVBM as an SGLang radix-cache backend."""
+
+from __future__ import annotations
+
+import importlib
+
+from sglang.srt.mem_cache.registry import (
+    TreeCacheBuildContext,
+    register_radix_cache_backend,
+)
+
+# isort: split
+
+from kvbm.sglang_integration.provider import (
+    HostMemoryProvider,
+    HostRegionRequest,
+    register_host_memory_provider,
+)
+
+
+def build_dynamo_kvbm_cache(ctx: TreeCacheBuildContext):
+    """Lazily load the native data plane after registering the backend name."""
+    factory = importlib.import_module("kvbm.sglang_integration.factory")
+    return factory.build_dynamo_kvbm_cache(ctx)
+
+
+register_radix_cache_backend("dynamo_kvbm", build_dynamo_kvbm_cache)
+
+__all__ = [
+    "HostMemoryProvider",
+    "HostRegionRequest",
+    "build_dynamo_kvbm_cache",
+    "register_host_memory_provider",
+]

--- a/lib/bindings/kvbm/python/kvbm/sglang_integration/factory.py
+++ b/lib/bindings/kvbm/python/kvbm/sglang_integration/factory.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Factory for SGLang's no-native-L2 Dynamo KVBM mode."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+
+from sglang.srt.mem_cache.hicache_storage import PoolName
+from sglang.srt.mem_cache.hybrid_cache.linker_pool_assembler import (
+    resolve_hybrid_device_pool_group,
+)
+from sglang.srt.mem_cache.registry import (
+    TreeCacheBuildContext,
+    create_unified_radix_cache_without_hicache,
+)
+from sglang.srt.mem_cache.unified_cache.component_type import ComponentType
+from sglang.srt.mem_cache.unified_cache.unified_tree_core import UnifiedTreeCore
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sglang.srt.runtime_context import get_disagg, get_memory
+
+# isort: split
+
+from kvbm._core import SglangLocalKvStore
+from kvbm.sglang_integration.linker import DynamoKvbmLinker
+from kvbm.sglang_integration.provider import HostRegionRequest, get_host_memory_provider
+
+
+def _manager_namespace(ctx: TreeCacheBuildContext, tensors: list) -> bytes:
+    deployment_namespace = os.environ.get("DYN_KVBM_MANAGER_NAMESPACE")
+    if not deployment_namespace:
+        raise ValueError(
+            "DYN_KVBM_MANAGER_NAMESPACE is required and must uniquely identify "
+            "the deployment/model revision."
+        )
+    digest = hashlib.sha256()
+    digest.update(b"dynamo-kvbm-manager-v1\0")
+    for text in (deployment_namespace, ctx.server_args.model_path):
+        encoded = text.encode()
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+    digest.update(ctx.params.page_size.to_bytes(8, "big"))
+    for rank in (
+        ctx.tp_rank,
+        -1 if ctx.dp_rank is None else ctx.dp_rank,
+        ctx.attn_dp_rank,
+        ctx.attn_cp_rank,
+        ctx.params.pp_rank,
+    ):
+        digest.update(rank.to_bytes(4, "big", signed=True))
+    for tensor in tensors:
+        for values in (tensor.shape, tensor.stride()):
+            digest.update(len(values).to_bytes(4, "big"))
+            for value in values:
+                digest.update(value.to_bytes(8, "big", signed=True))
+        dtype = str(tensor.dtype).encode()
+        digest.update(len(dtype).to_bytes(4, "big"))
+        digest.update(dtype)
+        digest.update(tensor.nbytes.to_bytes(8, "big"))
+    return digest.digest()
+
+
+def _validate_mode(ctx: TreeCacheBuildContext) -> None:
+    memory = get_memory()
+    conflicts = []
+    if ctx.enable_hierarchical_cache or memory.enable_hierarchical_cache:
+        conflicts.append("--enable-hierarchical-cache")
+    if memory.hicache_size > 0:
+        conflicts.append("--hicache-size")
+    if memory.hicache_ratio is not None:
+        conflicts.append("--hicache-ratio")
+    if memory.hicache_storage_backend is not None:
+        conflicts.append("--hicache-storage-backend")
+    if memory.enable_lmcache:
+        conflicts.append("--enable-lmcache")
+    if memory.enable_flexkv:
+        conflicts.append("--enable-flexkv")
+    if get_disagg().disaggregation_decode_retraction_backup == "host_pool":
+        conflicts.append("--disaggregation-decode-retraction-backup=host_pool")
+    if conflicts:
+        raise ValueError(
+            "dynamo_kvbm is mutually exclusive with native/external cache modes: "
+            + ", ".join(conflicts)
+        )
+    if ctx.disable_radix_cache:
+        raise ValueError("dynamo_kvbm requires SGLang's GPU radix cache.")
+    if ctx.is_hybrid_swa or ctx.is_hybrid_ssm or ctx.is_dsa:
+        raise ValueError("Dynamo KVBM V1 supports only homogeneous FULL attention.")
+    if ctx.params.pp_size != 1:
+        raise ValueError("Dynamo KVBM V1 requires PP=1.")
+    if ctx.params.is_eagle:
+        raise ValueError(
+            "Dynamo KVBM V1 does not support bigram/speculative tree keys."
+        )
+
+
+def _assert_no_native_l2(cache: UnifiedRadixCache) -> None:
+    if (
+        any(
+            value is not None
+            for value in (
+                cache.cache_controller,
+                cache.host_pool_group,
+                cache._storage_attachment,
+                cache.buffer_pipeline,
+            )
+        )
+        or cache.enable_storage
+    ):
+        raise RuntimeError("dynamo_kvbm unexpectedly initialized native HiCache state.")
+
+
+def build_dynamo_kvbm_cache(ctx: TreeCacheBuildContext) -> UnifiedRadixCache:
+    _validate_mode(ctx)
+    cache = create_unified_radix_cache_without_hicache(ctx)
+    if not isinstance(cache, UnifiedRadixCache):
+        raise TypeError("dynamo_kvbm requires UnifiedRadixCache.")
+    if not isinstance(cache.tree_core, UnifiedTreeCore):
+        raise TypeError("dynamo_kvbm V1 requires SGLang's Python unified tree core.")
+    if set(cache.tree_components) != {ComponentType.FULL}:
+        raise ValueError("dynamo_kvbm V1 requires exactly the FULL tree component.")
+
+    kvcache = ctx.params.token_to_kv_pool_allocator.get_kvcache()
+    pool_group = resolve_hybrid_device_pool_group(
+        kvcache=kvcache,
+        page_size=ctx.params.page_size,
+        params=ctx.params,
+        components={ComponentType.FULL},
+    )
+    if set(pool_group.entry_map) != {PoolName.KV}:
+        raise ValueError("dynamo_kvbm V1 requires exactly one physical KV pool.")
+    tensors = pool_group.entry_map[PoolName.KV].get_hybrid_pool_buffer()
+    if len(tensors) != 2 * pool_group.num_layers:
+        raise ValueError("dynamo_kvbm V1 requires one K/V tensor pair per layer.")
+    total_slots = kvcache.size + ctx.params.page_size
+    if total_slots % ctx.params.page_size:
+        raise ValueError("SGLang KV pool capacity is not page aligned.")
+    num_device_blocks = total_slots // ctx.params.page_size
+    if not tensors or any(tensor.nbytes != tensors[0].nbytes for tensor in tensors):
+        raise ValueError("dynamo_kvbm V1 requires homogeneous K/V tensor sizes.")
+    total_tensor_bytes = sum(tensor.nbytes for tensor in tensors)
+    if total_tensor_bytes % num_device_blocks:
+        raise ValueError("K/V tensor bytes are not divisible into whole device blocks.")
+    cuda_device = tensors[0].device.index
+    if cuda_device is None or any(
+        tensor.device.type != "cuda" or tensor.device.index != cuda_device
+        for tensor in tensors
+    ):
+        raise ValueError("dynamo_kvbm V1 requires one CUDA device for all KV tensors.")
+    bytes_per_block = total_tensor_bytes // num_device_blocks
+    manager_namespace = _manager_namespace(ctx, tensors)
+    requested_bytes = int(
+        os.environ.get("DYN_KVBM_G2_CAPACITY_BYTES", str(100 * 1024**3))
+    )
+    requested_bytes -= requested_bytes % bytes_per_block
+    if requested_bytes <= 0:
+        raise ValueError("DYN_KVBM_G2_CAPACITY_BYTES cannot hold one KV block.")
+
+    provider = get_host_memory_provider()
+    region = provider.attach(
+        HostRegionRequest(
+            requested_bytes=requested_bytes,
+            bytes_per_block=bytes_per_block,
+            alignment=512,
+            manager_namespace=manager_namespace,
+            tp_rank=ctx.tp_rank,
+            dp_rank=ctx.dp_rank,
+            attn_dp_rank=ctx.attn_dp_rank,
+            attn_cp_rank=ctx.attn_cp_rank,
+        ),
+        cuda_device,
+    )
+    try:
+        region_ptr = region.data_ptr()
+        region_nbytes = region.nbytes()
+        if (
+            region_ptr <= 0
+            or region_ptr % 512
+            or region_nbytes < bytes_per_block
+            or region_nbytes % bytes_per_block
+        ):
+            raise ValueError(
+                "The owner-backed KVBM region does not satisfy its "
+                "pointer/block geometry."
+            )
+    except Exception:
+        region.abort()
+        raise
+    core = None
+    try:
+        core = SglangLocalKvStore(
+            ctx.params.page_size,
+            num_device_blocks,
+            tensors,
+            region_ptr,
+            region_nbytes,
+            manager_namespace,
+            region,
+            cuda_device,
+        )
+        region.activate()
+    except Exception:
+        try:
+            if core is not None:
+                core.close()
+        finally:
+            region.abort()
+        raise
+
+    linker = None
+    try:
+        linker = DynamoKvbmLinker(
+            core=core,
+            manager_namespace=manager_namespace,
+            page_size=ctx.params.page_size,
+            num_device_blocks=num_device_blocks,
+            num_layers=pool_group.num_layers,
+            host_region=region,
+        )
+        cache.init_cache_linker(linker)
+        ctx.tp_worker.register_hicache_layer_transfer_counter(linker.layer_done_counter)
+        kvcache.register_layer_transfer_counter(linker.layer_done_counter)
+        _assert_no_native_l2(cache)
+    except Exception:
+        if linker is not None:
+            linker.close()
+        else:
+            core.close()
+            region.close()
+        raise
+    return cache

--- a/lib/bindings/kvbm/python/kvbm/sglang_integration/key_codec.py
+++ b/lib/bindings/kvbm/python/kvbm/sglang_integration/key_codec.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SGLang adapter for Dynamo's canonical PLH page-key codec."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sglang.srt.mem_cache.unified_cache.unified_cache_linker import LinkerKeyDomain
+
+# isort: split
+
+from kvbm._core import DynamoPlhKeyCodec as _NativeDynamoPlhKeyCodec
+
+
+class DynamoPlhKeyCodec:
+    codec_id = "dynamo-plh-v1"
+
+    def __init__(self, manager_namespace: bytes):
+        self._native = _NativeDynamoPlhKeyCodec(manager_namespace)
+
+    def extend_pages(
+        self,
+        *,
+        parent_key: bytes | None,
+        page_tokens: Sequence[int],
+        page_size: int,
+        key_domain: LinkerKeyDomain,
+    ) -> list[bytes]:
+        tokens = []
+        for token in page_tokens:
+            if not isinstance(token, int) or token < 0 or token > 0xFFFFFFFF:
+                raise ValueError(
+                    "dynamo-plh-v1 only accepts unsigned 32-bit token IDs."
+                )
+            tokens.append(token)
+        return list(
+            self._native.extend_pages(
+                parent_key,
+                tokens,
+                page_size,
+                key_domain.cache_salt,
+                key_domain.extra_key,
+            )
+        )

--- a/lib/bindings/kvbm/python/kvbm/sglang_integration/linker.py
+++ b/lib/bindings/kvbm/python/kvbm/sglang_integration/linker.py
@@ -1,0 +1,438 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct SGLang GPU-pool linker backed by the typed Rust KVBM core."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from dataclasses import dataclass, field
+
+import torch
+from sglang.srt.mem_cache.hicache_storage import PoolName, PoolTransfer
+from sglang.srt.mem_cache.unified_cache.unified_cache_linker import (
+    LinkerCancelOutcome,
+    UnifiedCacheLinker,
+)
+
+# isort: split
+
+from kvbm._core import SglangLocalKvStore, SglangLookupTicket
+from kvbm.sglang_integration.key_codec import DynamoPlhKeyCodec
+
+
+@dataclass
+class _CounterSlot:
+    done: threading.Event = field(default_factory=threading.Event)
+    error: BaseException | None = None
+
+
+class FullTransferLayerCounter:
+    """Conservative layer counter which gates every layer on full H2D."""
+
+    def __init__(self, num_layers: int):
+        if num_layers <= 0:
+            raise ValueError("A layer counter requires at least one model layer.")
+        self.num_layers = num_layers
+        self._slots: dict[int, _CounterSlot] = {}
+        self._producer = -1
+        self._consumer = -1
+        self._lock = threading.Lock()
+
+    def begin(self) -> int:
+        with self._lock:
+            self._producer += 1
+            self._slots[self._producer] = _CounterSlot()
+            return self._producer
+
+    def set_consumer(self, index: int) -> None:
+        with self._lock:
+            self._consumer = index
+
+    def complete(self, index: int) -> None:
+        with self._lock:
+            slot = self._slots[index]
+        slot.done.set()
+
+    def fail(self, index: int, error: BaseException) -> None:
+        with self._lock:
+            slot = self._slots[index]
+            slot.error = error
+        slot.done.set()
+
+    def wait_until(self, threshold: int) -> None:
+        if not 0 <= threshold < self.num_layers:
+            raise ValueError(f"Layer threshold {threshold} is out of range.")
+        with self._lock:
+            index = self._consumer
+            slot = self._slots.get(index)
+        if index < 0:
+            return
+        if slot is None:
+            raise RuntimeError(f"Unknown Dynamo KVBM counter slot {index}.")
+        slot.done.wait()
+        if slot.error is not None:
+            raise RuntimeError("Dynamo KVBM H2D transfer failed.") from slot.error
+        if threshold == self.num_layers - 1:
+            with self._lock:
+                self._slots.pop(index, None)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._slots.clear()
+            self._producer = -1
+            self._consumer = -1
+
+
+@dataclass
+class _QueuedLoad:
+    ticket: SglangLookupTicket
+    keys: list[bytes]
+    blocks: list[int]
+
+
+@dataclass
+class _LoadBatch:
+    rids: list[str]
+    pending_operations: set[int]
+    consumer_index: int
+    error: BaseException | None = None
+
+
+class DynamoKvbmLinker(UnifiedCacheLinker):
+    """Asynchronous request adapter around :class:`SglangLocalKvStore`."""
+
+    def __init__(
+        self,
+        core: SglangLocalKvStore,
+        manager_namespace: bytes,
+        page_size: int,
+        num_device_blocks: int,
+        num_layers: int,
+        host_region,
+    ):
+        self.core = core
+        self.key_codec = DynamoPlhKeyCodec(manager_namespace)
+        self.page_size = page_size
+        self.num_device_blocks = num_device_blocks
+        self.host_region = host_region
+        self.layer_done_counter = FullTransferLayerCounter(num_layers)
+        self._lookup_tickets: dict[str, SglangLookupTicket] = {}
+        self._queued_loads: dict[str, _QueuedLoad] = {}
+        self._submitted_loads: set[str] = set()
+        self._load_operations: dict[int, tuple[int, str, int]] = {}
+        self._load_batches: dict[int, _LoadBatch] = {}
+        self._completed_loads: queue.Queue[list[str]] = queue.Queue()
+        self._offload_operations: dict[int, tuple[int, int]] = {}
+        self._offload_ready: dict[int, bool] = {}
+        self._next_offload_sequence = 0
+        self._next_offload_completion = 0
+        self._completed_offloads: queue.Queue[bool] = queue.Queue()
+        self._fatal_error: BaseException | None = None
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._closed = False
+        self._pump = threading.Thread(
+            target=self._completion_pump,
+            name="dynamo-kvbm-completions",
+            daemon=True,
+        )
+        self._pump.start()
+
+    def _check_healthy(self) -> None:
+        if self._fatal_error is not None:
+            raise RuntimeError(
+                "Dynamo KVBM linker is unhealthy."
+            ) from self._fatal_error
+
+    def _keys(self, transfer: PoolTransfer) -> list[bytes]:
+        if transfer.name is not PoolName.KV:
+            raise ValueError("Dynamo KVBM V1 only supports the KV pool.")
+        if transfer.linker_keys is None or not transfer.linker_keys:
+            raise ValueError("Dynamo KVBM transfer is missing linker-owned page keys.")
+        if transfer.keys is None or len(transfer.linker_keys) != len(transfer.keys):
+            raise ValueError("Dynamo KVBM linker/SGLang key cardinality differs.")
+        return list(transfer.linker_keys)
+
+    def _blocks(self, transfer: PoolTransfer) -> list[int]:
+        indices = transfer.device_indices
+        if indices is None or indices.numel() == 0:
+            raise ValueError("Dynamo KVBM transfer has no device slots.")
+        slots = indices.detach().to(device="cpu", dtype=torch.int64).flatten()
+        if slots.numel() % self.page_size:
+            raise ValueError("Device slots do not contain complete KVBM pages.")
+        pages = slots.reshape(-1, self.page_size)
+        offsets = torch.arange(self.page_size, dtype=torch.int64)
+        starts = pages[:, 0]
+        if torch.any(starts.remainder(self.page_size)) or not torch.equal(
+            pages, starts[:, None] + offsets
+        ):
+            raise ValueError("Device slots must be aligned contiguous pages.")
+        blocks = starts.div(self.page_size, rounding_mode="floor")
+        if int(blocks.min()) < 0 or int(blocks.max()) >= self.num_device_blocks:
+            raise ValueError("Device page falls outside the registered G1 layout.")
+        if blocks.unique().numel() != blocks.numel():
+            raise ValueError("A KVBM transfer cannot reuse a device page.")
+        return blocks.tolist()
+
+    def lookup(self, rid: str, transfers: list[PoolTransfer]) -> list[int]:
+        with self._lock:
+            self._check_healthy()
+            if len(transfers) != 1:
+                raise ValueError("Dynamo KVBM V1 requires exactly one KV transfer.")
+            if (
+                rid in self._lookup_tickets
+                or rid in self._queued_loads
+                or rid in self._submitted_loads
+            ):
+                raise RuntimeError(f"Duplicate KVBM lookup for rid={rid!r}.")
+            ticket = self.core.lookup_prefix(self._keys(transfers[0]))
+            if ticket.hit_pages == 0:
+                self.core.cancel_lookup(ticket)
+                return []
+            self._lookup_tickets[rid] = ticket
+            return list(range(1, ticket.hit_pages + 1))
+
+    def load(self, rid: str, transfers: list[PoolTransfer]) -> bool:
+        with self._lock:
+            self._check_healthy()
+            if len(transfers) != 1:
+                raise ValueError(
+                    "Dynamo KVBM V1 requires exactly one KV load transfer."
+                )
+            transfer = transfers[0]
+            keys = self._keys(transfer)
+            blocks = self._blocks(transfer)
+            if len(keys) != len(blocks):
+                raise ValueError("KVBM load key/page cardinality differs.")
+            ticket = self._lookup_tickets.get(rid)
+            if ticket is None:
+                raise RuntimeError(f"KVBM load has no lookup ticket for rid={rid!r}.")
+            if len(keys) > ticket.hit_pages:
+                raise ValueError("KVBM load exceeds its lookup-ticket prefix.")
+            del self._lookup_tickets[rid]
+            self._queued_loads[rid] = _QueuedLoad(
+                ticket=ticket,
+                keys=keys,
+                blocks=blocks,
+            )
+            return True
+
+    def start_layer_wise_loading(self) -> int:
+        with self._lock:
+            self._check_healthy()
+            if not self._queued_loads:
+                return -1
+            queued = self._queued_loads
+            self._queued_loads = {}
+            consumer_index = self.layer_done_counter.begin()
+            batch = _LoadBatch(
+                rids=[], pending_operations=set(), consumer_index=consumer_index
+            )
+            self._load_batches[consumer_index] = batch
+            queued_items = list(queued.items())
+            try:
+                for _item_index, (rid, load) in enumerate(queued_items):
+                    operation = self.core.enqueue_load(
+                        load.ticket, load.keys, load.blocks
+                    )
+                    if operation.kind != "load":
+                        raise RuntimeError("KVBM returned a non-load operation handle.")
+                    batch.rids.append(rid)
+                    batch.pending_operations.add(operation.operation_id)
+                    self._load_operations[operation.operation_id] = (
+                        consumer_index,
+                        rid,
+                        operation.generation,
+                    )
+                    self._submitted_loads.add(rid)
+            except Exception as error:
+                try:
+                    self.core.cancel_lookup(load.ticket)
+                except KeyError:
+                    # enqueue_load consumed the ticket before its transfer failed.
+                    pass
+                for _, unsubmitted in queued_items[_item_index + 1 :]:
+                    self.core.cancel_lookup(unsubmitted.ticket)
+                self._fatal_error = error
+                batch.error = error
+                self.layer_done_counter.fail(consumer_index, error)
+                raise
+            return consumer_index
+
+    def cancel_queued_load(self, rid: str) -> bool:
+        with self._lock:
+            return self._cancel_queued_load(rid)
+
+    def _cancel_queued_load(self, rid: str) -> bool:
+        queued = self._queued_loads.get(rid)
+        if queued is None:
+            return False
+        self.core.cancel_lookup(queued.ticket)
+        del self._queued_loads[rid]
+        return True
+
+    def cancel_request(self, rid: str) -> LinkerCancelOutcome:
+        with self._lock:
+            ticket = self._lookup_tickets.get(rid)
+            if ticket is not None:
+                self.core.cancel_lookup(ticket)
+                del self._lookup_tickets[rid]
+                return LinkerCancelOutcome.LOOKUP_RELEASED
+            if self._cancel_queued_load(rid):
+                return LinkerCancelOutcome.QUEUED_LOAD_CANCELLED
+            if rid in self._submitted_loads:
+                return LinkerCancelOutcome.SUBMITTED_LOAD_RETAINED
+            return LinkerCancelOutcome.NOT_FOUND
+
+    def num_completed_loads(self) -> int:
+        self._check_healthy()
+        return self._completed_loads.qsize()
+
+    def pop_completed_load(self) -> list[str]:
+        with self._lock:
+            rids = self._completed_loads.get_nowait()
+            self._submitted_loads.difference_update(rids)
+            return rids
+
+    def offload(self, transfers: list[PoolTransfer]) -> bool:
+        with self._lock:
+            self._check_healthy()
+            if len(transfers) != 1:
+                raise ValueError(
+                    "Dynamo KVBM V1 requires exactly one KV store transfer."
+                )
+            transfer = transfers[0]
+            keys = self._keys(transfer)
+            blocks = self._blocks(transfer)
+            if len(keys) != len(blocks):
+                raise ValueError("KVBM store key/page cardinality differs.")
+            operation = self.core.enqueue_store(keys, blocks)
+            if operation.kind != "store":
+                raise RuntimeError("KVBM returned a non-store operation handle.")
+            sequence = self._next_offload_sequence
+            self._next_offload_sequence += 1
+            self._offload_operations[operation.operation_id] = (
+                sequence,
+                operation.generation,
+            )
+            return True
+
+    def num_completed_offloads(self) -> int:
+        self._check_healthy()
+        return self._completed_offloads.qsize()
+
+    def pop_completed_offload(self) -> bool:
+        return self._completed_offloads.get_nowait()
+
+    def has_pending_operations(self) -> bool:
+        with self._lock:
+            tickets, operations, completions = self.core.pending_counts()
+            return bool(
+                tickets
+                or operations
+                or completions
+                or self._lookup_tickets
+                or self._queued_loads
+                or self._submitted_loads
+                or self._offload_operations
+                or not self._completed_loads.empty()
+                or not self._completed_offloads.empty()
+            )
+
+    def _completion_pump(self) -> None:
+        while not self._stop.wait(0.001):
+            with self._lock:
+                try:
+                    completions = self.core.poll_completions()
+                except RuntimeError as error:
+                    if not self._stop.is_set():
+                        self._fatal_error = error
+                    return
+                for completion in completions:
+                    if completion.kind == "load":
+                        self._complete_load(completion)
+                    elif completion.kind == "store":
+                        self._complete_offload(completion)
+                    else:
+                        self._fatal_error = RuntimeError(
+                            f"Unknown KVBM completion kind {completion.kind!r}."
+                        )
+
+    def _complete_load(self, completion) -> None:
+        operation = self._load_operations.pop(completion.operation_id, None)
+        if operation is None:
+            self._fatal_error = RuntimeError("Unknown KVBM load completion.")
+            return
+        consumer_index, _, generation = operation
+        if completion.generation != generation:
+            self._fatal_error = RuntimeError("Stale KVBM load completion generation.")
+            return
+        batch = self._load_batches[consumer_index]
+        batch.pending_operations.remove(completion.operation_id)
+        if not completion.success:
+            error = RuntimeError(completion.error or "KVBM H2D failed")
+            self._fatal_error = error
+            if batch.error is None:
+                batch.error = error
+                self.layer_done_counter.fail(consumer_index, error)
+        if not batch.pending_operations:
+            if batch.error is None:
+                self.layer_done_counter.complete(consumer_index)
+                self._completed_loads.put(batch.rids)
+            del self._load_batches[consumer_index]
+
+    def _complete_offload(self, completion) -> None:
+        operation = self._offload_operations.pop(completion.operation_id, None)
+        if operation is None:
+            self._fatal_error = RuntimeError("Unknown KVBM store completion.")
+            return
+        sequence, generation = operation
+        if completion.generation != generation:
+            self._fatal_error = RuntimeError("Stale KVBM store completion generation.")
+            return
+        self._offload_ready[sequence] = completion.success
+        while self._next_offload_completion in self._offload_ready:
+            self._completed_offloads.put(
+                self._offload_ready.pop(self._next_offload_completion)
+            )
+            self._next_offload_completion += 1
+
+    def reset(self) -> None:
+        with self._lock:
+            for rid, ticket in list(self._lookup_tickets.items()):
+                self.core.cancel_lookup(ticket)
+                del self._lookup_tickets[rid]
+            for rid, load in list(self._queued_loads.items()):
+                self.core.cancel_lookup(load.ticket)
+                del self._queued_loads[rid]
+            self.core.reset()
+            self._submitted_loads.clear()
+            self._load_operations.clear()
+            self._load_batches.clear()
+            self._offload_operations.clear()
+            self._offload_ready.clear()
+            self._next_offload_sequence = 0
+            self._next_offload_completion = 0
+            self._drain_queue(self._completed_loads)
+            self._drain_queue(self._completed_offloads)
+            self._fatal_error = None
+            self.layer_done_counter.reset()
+
+    @staticmethod
+    def _drain_queue(target: queue.Queue) -> None:
+        while True:
+            try:
+                target.get_nowait()
+            except queue.Empty:
+                return
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._stop.set()
+        self._pump.join()
+        self.core.close()
+        self.host_region.close()
+        self._closed = True

--- a/lib/bindings/kvbm/python/kvbm/sglang_integration/provider.py
+++ b/lib/bindings/kvbm/python/kvbm/sglang_integration/provider.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-memory provider seam for the SGLang KVBM integration."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import threading
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class HostRegionRequest:
+    """Requested rcommu data-region geometry."""
+
+    requested_bytes: int
+    bytes_per_block: int
+    alignment: int
+    manager_namespace: bytes
+    tp_rank: int
+    dp_rank: int | None
+    attn_dp_rank: int
+    attn_cp_rank: int
+
+
+class AttachedHostRegion(Protocol):
+    """Provisional region returned by an owner-backed provider."""
+
+    def data_ptr(self) -> int:
+        ...
+
+    def nbytes(self) -> int:
+        ...
+
+    def activate(self) -> None:
+        ...
+
+    def abort(self) -> None:
+        ...
+
+    def close(self) -> None:
+        ...
+
+
+class HostMemoryProvider(Protocol):
+    def attach(
+        self, request: HostRegionRequest, cuda_device: int
+    ) -> AttachedHostRegion:
+        ...
+
+
+_provider: HostMemoryProvider | None = None
+_provider_lock = threading.Lock()
+
+
+def register_host_memory_provider(provider: HostMemoryProvider) -> None:
+    """Register the process-wide owner-backed host-memory provider."""
+    global _provider
+    with _provider_lock:
+        if _provider is not None and _provider is not provider:
+            raise RuntimeError(
+                "A different KVBM host-memory provider is already registered."
+            )
+        _provider = provider
+
+
+def get_host_memory_provider() -> HostMemoryProvider:
+    """Resolve a registered provider or load its zero-argument env factory."""
+    global _provider
+    with _provider_lock:
+        if _provider is not None:
+            return _provider
+
+    factory_path = os.environ.get("DYN_KVBM_HOST_MEMORY_PROVIDER")
+    if not factory_path or ":" not in factory_path:
+        raise RuntimeError(
+            "dynamo_kvbm requires an owner-backed host-memory provider. "
+            "Call register_host_memory_provider(...) or set "
+            "DYN_KVBM_HOST_MEMORY_PROVIDER=module:factory."
+        )
+    module_name, factory_name = factory_path.rsplit(":", 1)
+    module = importlib.import_module(module_name)
+    factory = getattr(module, factory_name)
+    provider = factory()
+
+    with _provider_lock:
+        if _provider is None:
+            _provider = provider
+        return _provider

--- a/lib/bindings/kvbm/python/tests/conftest.py
+++ b/lib/bindings/kvbm/python/tests/conftest.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for testing the optional SGLang integration in isolation."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1] / "kvbm" / "sglang_integration"
+
+
+@pytest.fixture
+def install_module(monkeypatch):
+    """Install an isolated module hierarchy for optional runtime dependencies."""
+
+    def install(name: str, **attributes) -> ModuleType:
+        parts = name.split(".")
+        for index in range(1, len(parts)):
+            package_name = ".".join(parts[:index])
+            if package_name not in sys.modules:
+                package = ModuleType(package_name)
+                package.__path__ = []
+                monkeypatch.setitem(sys.modules, package_name, package)
+        module = ModuleType(name)
+        for attribute, value in attributes.items():
+            setattr(module, attribute, value)
+        monkeypatch.setitem(sys.modules, name, module)
+        return module
+
+    return install
+
+
+@pytest.fixture
+def load_source(monkeypatch):
+    """Load one integration source file without importing package ``__init__``."""
+
+    def load(name: str, filename: str):
+        spec = importlib.util.spec_from_file_location(name, SOURCE_ROOT / filename)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"Cannot load integration source {filename!r}.")
+        module = importlib.util.module_from_spec(spec)
+        monkeypatch.setitem(sys.modules, name, module)
+        spec.loader.exec_module(module)
+        return module
+
+    return load

--- a/lib/bindings/kvbm/python/tests/test_sglang_factory.py
+++ b/lib/bindings/kvbm/python/tests/test_sglang_factory.py
@@ -1,0 +1,317 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""No-native-L2 and cleanup tests for the SGLang KVBM cache factory."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.kvbm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+@pytest.fixture
+def factory_contract(install_module, load_source):
+    class PoolName(Enum):
+        KV = "kv"
+
+    class ComponentType(Enum):
+        FULL = "full"
+
+    class UnifiedTreeCore:
+        pass
+
+    class UnifiedRadixCache:
+        def __init__(self):
+            self.tree_core = UnifiedTreeCore()
+            self.tree_components = [ComponentType.FULL]
+            self.cache_controller = None
+            self.host_pool_group = None
+            self._storage_attachment = None
+            self.buffer_pipeline = None
+            self.enable_storage = False
+            self.linker = None
+
+        def init_cache_linker(self, linker):
+            self.linker = linker
+
+    class Tensor:
+        def __init__(self, nbytes=64, device_index=3):
+            self.nbytes = nbytes
+            self.shape = (8, 4)
+            self.dtype = "torch.float16"
+            self.device = SimpleNamespace(type="cuda", index=device_index)
+
+        def stride(self):
+            return (4, 1)
+
+    class Region:
+        def __init__(self):
+            self.activated = False
+            self.aborted = False
+            self.closed = False
+            self.activation_error = None
+
+        def data_ptr(self):
+            return 512
+
+        def nbytes(self):
+            return 96
+
+        def activate(self):
+            if self.activation_error is not None:
+                raise self.activation_error
+            self.activated = True
+
+        def abort(self):
+            self.aborted = True
+
+        def close(self):
+            self.closed = True
+
+    @dataclass(frozen=True)
+    class HostRegionRequest:
+        requested_bytes: int
+        bytes_per_block: int
+        alignment: int
+        manager_namespace: bytes
+        tp_rank: int
+        dp_rank: int | None
+        attn_dp_rank: int
+        attn_cp_rank: int
+
+    memory = SimpleNamespace(
+        enable_hierarchical_cache=False,
+        hicache_size=0,
+        hicache_ratio=None,
+        hicache_storage_backend=None,
+        enable_lmcache=False,
+        enable_flexkv=False,
+    )
+    disagg = SimpleNamespace(disaggregation_decode_retraction_backup="none")
+    cache = UnifiedRadixCache()
+    tensors = [Tensor(), Tensor()]
+    pool_entry = SimpleNamespace(get_hybrid_pool_buffer=lambda: tensors)
+    pool_group = SimpleNamespace(
+        entry_map={PoolName.KV: pool_entry},
+        num_layers=1,
+    )
+    region = Region()
+    provider_calls = []
+    create_calls = []
+    core_instances = []
+    linker_instances = []
+
+    class Provider:
+        def attach(self, request, cuda_device):
+            provider_calls.append((request, cuda_device))
+            return region
+
+    provider = Provider()
+
+    class SglangLocalKvStore:
+        def __init__(self, *args):
+            self.args = args
+            self.closed = False
+            core_instances.append(self)
+
+        def close(self):
+            self.closed = True
+
+    class DynamoKvbmLinker:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.layer_done_counter = object()
+            self.closed = False
+            linker_instances.append(self)
+
+        def close(self):
+            self.closed = True
+            self.kwargs["core"].close()
+            self.kwargs["host_region"].close()
+
+    def create_unified_cache(ctx):
+        create_calls.append(ctx)
+        return cache
+
+    def resolve_pool_group(**kwargs):
+        return pool_group
+
+    install_module(
+        "sglang.srt.mem_cache.hicache_storage",
+        PoolName=PoolName,
+    )
+    install_module(
+        "sglang.srt.mem_cache.hybrid_cache.linker_pool_assembler",
+        resolve_hybrid_device_pool_group=resolve_pool_group,
+    )
+    install_module(
+        "sglang.srt.mem_cache.registry",
+        TreeCacheBuildContext=object,
+        create_unified_radix_cache_without_hicache=create_unified_cache,
+    )
+    install_module(
+        "sglang.srt.mem_cache.unified_cache.component_type",
+        ComponentType=ComponentType,
+    )
+    install_module(
+        "sglang.srt.mem_cache.unified_cache.unified_tree_core",
+        UnifiedTreeCore=UnifiedTreeCore,
+    )
+    install_module(
+        "sglang.srt.mem_cache.unified_radix_cache",
+        UnifiedRadixCache=UnifiedRadixCache,
+    )
+    install_module(
+        "sglang.srt.runtime_context",
+        get_disagg=lambda: disagg,
+        get_memory=lambda: memory,
+    )
+    install_module("kvbm._core", SglangLocalKvStore=SglangLocalKvStore)
+    install_module("kvbm.sglang_integration.linker", DynamoKvbmLinker=DynamoKvbmLinker)
+    install_module(
+        "kvbm.sglang_integration.provider",
+        HostRegionRequest=HostRegionRequest,
+        get_host_memory_provider=lambda: provider,
+    )
+    module = load_source("test_kvbm_sglang_factory", "factory.py")
+
+    kvcache = SimpleNamespace(size=6, registered_counters=[])
+    kvcache.register_layer_transfer_counter = kvcache.registered_counters.append
+    allocator = SimpleNamespace(get_kvcache=lambda: kvcache)
+    params = SimpleNamespace(
+        page_size=2,
+        pp_size=1,
+        pp_rank=0,
+        is_eagle=False,
+        token_to_kv_pool_allocator=allocator,
+    )
+    tp_worker = SimpleNamespace(registered_counters=[])
+    tp_worker.register_hicache_layer_transfer_counter = (
+        tp_worker.registered_counters.append
+    )
+    ctx = SimpleNamespace(
+        server_args=SimpleNamespace(model_path="model/revision"),
+        params=params,
+        tp_worker=tp_worker,
+        tp_rank=1,
+        dp_rank=2,
+        attn_dp_rank=3,
+        attn_cp_rank=4,
+        enable_hierarchical_cache=False,
+        disable_radix_cache=False,
+        is_hybrid_swa=False,
+        is_hybrid_ssm=False,
+        is_dsa=False,
+    )
+    return SimpleNamespace(
+        module=module,
+        ctx=ctx,
+        memory=memory,
+        cache=cache,
+        tensors=tensors,
+        region=region,
+        provider_calls=provider_calls,
+        create_calls=create_calls,
+        core_instances=core_instances,
+        linker_instances=linker_instances,
+        kvcache=kvcache,
+        tp_worker=tp_worker,
+    )
+
+
+def test_factory_builds_direct_cache_without_native_l2(monkeypatch, factory_contract):
+    contract = factory_contract
+    monkeypatch.setenv("DYN_KVBM_MANAGER_NAMESPACE", "deployment-a")
+    monkeypatch.setenv("DYN_KVBM_G2_CAPACITY_BYTES", "100")
+
+    cache = contract.module.build_dynamo_kvbm_cache(contract.ctx)
+
+    assert cache is contract.cache
+    assert contract.create_calls == [contract.ctx]
+    assert cache.cache_controller is None
+    assert cache.host_pool_group is None
+    assert cache._storage_attachment is None
+    assert cache.buffer_pipeline is None
+    assert cache.enable_storage is False
+    assert contract.region.activated is True
+    request, cuda_device = contract.provider_calls[0]
+    assert request.requested_bytes == 96
+    assert request.bytes_per_block == 32
+    assert request.alignment == 512
+    assert request.tp_rank == 1
+    assert request.dp_rank == 2
+    assert request.attn_dp_rank == 3
+    assert request.attn_cp_rank == 4
+    assert len(request.manager_namespace) == 32
+    assert cuda_device == 3
+    core = contract.core_instances[0]
+    assert core.args[:3] == (2, 4, contract.tensors)
+    assert core.args[3:5] == (512, 96)
+    linker = contract.linker_instances[0]
+    assert cache.linker is linker
+    assert contract.kvcache.registered_counters == [linker.layer_done_counter]
+    assert contract.tp_worker.registered_counters == [linker.layer_done_counter]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "option"),
+    [
+        ("enable_hierarchical_cache", True, "--enable-hierarchical-cache"),
+        ("hicache_size", 1, "--hicache-size"),
+        ("hicache_ratio", 1.0, "--hicache-ratio"),
+        ("hicache_storage_backend", "file", "--hicache-storage-backend"),
+        ("enable_lmcache", True, "--enable-lmcache"),
+        ("enable_flexkv", True, "--enable-flexkv"),
+    ],
+)
+def test_factory_rejects_conflicting_cache_modes_before_allocating(
+    factory_contract, field, value, option
+):
+    contract = factory_contract
+    setattr(contract.memory, field, value)
+
+    with pytest.raises(ValueError, match=option):
+        contract.module.build_dynamo_kvbm_cache(contract.ctx)
+
+    assert contract.create_calls == []
+    assert contract.provider_calls == []
+
+
+def test_factory_aborts_owner_region_if_activation_fails(monkeypatch, factory_contract):
+    contract = factory_contract
+    monkeypatch.setenv("DYN_KVBM_MANAGER_NAMESPACE", "deployment-a")
+    monkeypatch.setenv("DYN_KVBM_G2_CAPACITY_BYTES", "96")
+    contract.region.activation_error = RuntimeError("owner activation failed")
+
+    with pytest.raises(RuntimeError, match="owner activation failed"):
+        contract.module.build_dynamo_kvbm_cache(contract.ctx)
+
+    assert contract.core_instances[0].closed is True
+    assert contract.region.aborted is True
+    assert contract.region.closed is False
+
+
+def test_manager_namespace_is_deterministic_and_rank_isolated(
+    monkeypatch, factory_contract
+):
+    contract = factory_contract
+    monkeypatch.setenv("DYN_KVBM_MANAGER_NAMESPACE", "deployment-a")
+
+    first = contract.module._manager_namespace(contract.ctx, contract.tensors)
+    second = contract.module._manager_namespace(contract.ctx, contract.tensors)
+    contract.ctx.attn_cp_rank += 1
+    different_rank = contract.module._manager_namespace(contract.ctx, contract.tensors)
+
+    assert first == second
+    assert first != different_rank
+    assert len(first) == 32

--- a/lib/bindings/kvbm/python/tests/test_sglang_linker.py
+++ b/lib/bindings/kvbm/python/tests/test_sglang_linker.py
@@ -1,0 +1,369 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fake-core lifecycle tests for :class:`DynamoKvbmLinker`."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from enum import Enum
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.kvbm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+class _PoolName(Enum):
+    KV = "kv"
+
+
+class _CancelOutcome(Enum):
+    LOOKUP_RELEASED = "lookup_released"
+    QUEUED_LOAD_CANCELLED = "queued_load_cancelled"
+    SUBMITTED_LOAD_RETAINED = "submitted_load_retained"
+    NOT_FOUND = "not_found"
+
+
+@dataclass(frozen=True)
+class _Ticket:
+    ticket_id: int
+    generation: int
+    hit_pages: int
+
+
+@dataclass(frozen=True)
+class _Operation:
+    operation_id: int
+    generation: int
+    kind: str
+
+
+@dataclass(frozen=True)
+class _Completion:
+    operation_id: int
+    generation: int
+    kind: str
+    success: bool
+    error: str | None = None
+
+
+class _FakeCore:
+    def __init__(self, *, hit_pages: int = 2, events: list[str] | None = None):
+        self.hit_pages = hit_pages
+        self.events = [] if events is None else events
+        self.lookups = []
+        self.cancelled = []
+        self.load_calls = []
+        self.store_calls = []
+        self._tickets = set()
+        self._operations = {}
+        self._completions = []
+        self._next_ticket = 1
+        self._next_operation = 100
+        self._lock = threading.Lock()
+        self.completion_polled = threading.Event()
+        self.poll_error = None
+        self.reset_calls = 0
+        self.close_calls = 0
+
+    def lookup_prefix(self, keys):
+        with self._lock:
+            ticket = _Ticket(
+                ticket_id=self._next_ticket,
+                generation=0,
+                hit_pages=min(self.hit_pages, len(keys)),
+            )
+            self._next_ticket += 1
+            self._tickets.add(ticket.ticket_id)
+            self.lookups.append(list(keys))
+            return ticket
+
+    def cancel_lookup(self, ticket):
+        with self._lock:
+            if ticket.ticket_id not in self._tickets:
+                raise KeyError("lookup ticket already consumed")
+            self._tickets.remove(ticket.ticket_id)
+            self.cancelled.append(ticket.ticket_id)
+
+    def enqueue_load(self, ticket, keys, blocks):
+        with self._lock:
+            if ticket.ticket_id not in self._tickets:
+                raise KeyError("lookup ticket already consumed")
+            self._tickets.remove(ticket.ticket_id)
+            operation = self._new_operation("load")
+            self.load_calls.append((ticket, list(keys), list(blocks), operation))
+            return operation
+
+    def enqueue_store(self, keys, blocks):
+        with self._lock:
+            operation = self._new_operation("store")
+            self.store_calls.append((list(keys), list(blocks), operation))
+            return operation
+
+    def _new_operation(self, kind):
+        operation = _Operation(self._next_operation, 0, kind)
+        self._next_operation += 1
+        self._operations[operation.operation_id] = operation
+        return operation
+
+    def complete(self, operation, *, success=True, error=None):
+        with self._lock:
+            self._operations.pop(operation.operation_id)
+            self._completions.append(
+                _Completion(
+                    operation_id=operation.operation_id,
+                    generation=operation.generation,
+                    kind=operation.kind,
+                    success=success,
+                    error=error,
+                )
+            )
+
+    def poll_completions(self):
+        with self._lock:
+            if self.poll_error is not None:
+                raise self.poll_error
+            completions = self._completions
+            self._completions = []
+            if completions:
+                self.completion_polled.set()
+            return completions
+
+    def pending_counts(self):
+        with self._lock:
+            return len(self._tickets), len(self._operations), len(self._completions)
+
+    def reset(self):
+        with self._lock:
+            self.reset_calls += 1
+            self._tickets.clear()
+            self._operations.clear()
+            self._completions.clear()
+
+    def close(self):
+        self.events.append("core.close")
+        self.close_calls += 1
+
+
+class _HostRegion:
+    def __init__(self, events: list[str] | None = None):
+        self.events = [] if events is None else events
+        self.close_calls = 0
+
+    def close(self):
+        self.events.append("region.close")
+        self.close_calls += 1
+
+
+def _wait_for_completion_pump(linker, core):
+    assert core.completion_polled.wait(timeout=1.0)
+    # The pump holds this lock while polling and publishing the completion.
+    with linker._lock:
+        pass
+    core.completion_polled.clear()
+
+
+@pytest.fixture
+def linker_contract(install_module, load_source):
+    class UnifiedCacheLinker:
+        pass
+
+    class DynamoPlhKeyCodec:
+        def __init__(self, manager_namespace):
+            self.manager_namespace = manager_namespace
+
+    install_module(
+        "sglang.srt.mem_cache.hicache_storage",
+        PoolName=_PoolName,
+        PoolTransfer=object,
+    )
+    install_module(
+        "sglang.srt.mem_cache.unified_cache.unified_cache_linker",
+        LinkerCancelOutcome=_CancelOutcome,
+        UnifiedCacheLinker=UnifiedCacheLinker,
+    )
+    install_module(
+        "kvbm._core",
+        SglangLocalKvStore=object,
+        SglangLookupTicket=_Ticket,
+    )
+    install_module(
+        "kvbm.sglang_integration.key_codec",
+        DynamoPlhKeyCodec=DynamoPlhKeyCodec,
+    )
+    module = load_source("test_kvbm_sglang_linker", "linker.py")
+    return SimpleNamespace(module=module, pool_name=_PoolName, outcome=_CancelOutcome)
+
+
+def _transfer(pool_name, *, page_size=2, pages=(0, 1)):
+    slots = [
+        slot
+        for page in pages
+        for slot in range(page * page_size, (page + 1) * page_size)
+    ]
+    return SimpleNamespace(
+        name=pool_name.KV,
+        keys=[f"sha-{page}" for page in pages],
+        linker_keys=[f"key-{page}".encode() for page in pages],
+        device_indices=torch.tensor(slots, dtype=torch.int64),
+    )
+
+
+def _linker(contract, core, region=None):
+    return contract.module.DynamoKvbmLinker(
+        core=core,
+        manager_namespace=b"n" * 32,
+        page_size=2,
+        num_device_blocks=8,
+        num_layers=3,
+        host_region=_HostRegion() if region is None else region,
+    )
+
+
+def test_lookup_and_queued_cancel_release_ticket(linker_contract):
+    core = _FakeCore()
+    linker = _linker(linker_contract, core)
+    transfer = _transfer(linker_contract.pool_name)
+    try:
+        assert linker.lookup("request", [transfer]) == [1, 2]
+        assert linker.load("request", [transfer]) is True
+
+        assert (
+            linker.cancel_request("request")
+            is linker_contract.outcome.QUEUED_LOAD_CANCELLED
+        )
+        assert core.cancelled == [1]
+        assert linker.has_pending_operations() is False
+    finally:
+        linker.close()
+
+
+def test_load_cardinality_failure_leaves_lookup_ticket_cancellable(linker_contract):
+    core = _FakeCore(hit_pages=1)
+    linker = _linker(linker_contract, core)
+    lookup_transfer = _transfer(linker_contract.pool_name, pages=(0,))
+    load_transfer = _transfer(linker_contract.pool_name, pages=(0, 1))
+    load_transfer.keys = lookup_transfer.keys
+    load_transfer.linker_keys = lookup_transfer.linker_keys
+    try:
+        assert linker.lookup("request", [lookup_transfer]) == [1]
+        with pytest.raises(ValueError, match="load key/page cardinality"):
+            linker.load("request", [load_transfer])
+        assert (
+            linker.cancel_request("request") is linker_contract.outcome.LOOKUP_RELEASED
+        )
+    finally:
+        linker.close()
+
+
+def test_submitted_cancel_retains_guards_until_completion(linker_contract):
+    core = _FakeCore()
+    linker = _linker(linker_contract, core)
+    transfer = _transfer(linker_contract.pool_name)
+    try:
+        linker.lookup("request", [transfer])
+        linker.load("request", [transfer])
+        consumer_index = linker.start_layer_wise_loading()
+        linker.layer_done_counter.set_consumer(consumer_index)
+
+        assert (
+            linker.cancel_request("request")
+            is linker_contract.outcome.SUBMITTED_LOAD_RETAINED
+        )
+        operation = core.load_calls[0][3]
+        core.complete(operation)
+        _wait_for_completion_pump(linker, core)
+        assert linker.num_completed_loads() == 1
+
+        linker.layer_done_counter.wait_until(2)
+        assert linker.pop_completed_load() == ["request"]
+        assert linker.cancel_request("request") is linker_contract.outcome.NOT_FOUND
+        assert linker.has_pending_operations() is False
+    finally:
+        linker.close()
+
+
+def test_offload_completions_are_published_in_submission_order(linker_contract):
+    core = _FakeCore()
+    linker = _linker(linker_contract, core)
+    transfer = _transfer(linker_contract.pool_name)
+    try:
+        assert linker.offload([transfer]) is True
+        assert linker.offload([transfer]) is True
+        first = core.store_calls[0][2]
+        second = core.store_calls[1][2]
+
+        core.complete(second, success=False, error="D2H failed")
+        _wait_for_completion_pump(linker, core)
+        assert linker.num_completed_offloads() == 0
+
+        core.complete(first)
+        _wait_for_completion_pump(linker, core)
+        assert linker.num_completed_offloads() == 2
+        assert linker.pop_completed_offload() is True
+        assert linker.pop_completed_offload() is False
+        assert core.store_calls[0][:2] == ([b"key-0", b"key-1"], [0, 1])
+    finally:
+        linker.close()
+
+
+def test_reset_cancels_unsubmitted_tickets_before_resetting_core(linker_contract):
+    core = _FakeCore()
+    linker = _linker(linker_contract, core)
+    transfer = _transfer(linker_contract.pool_name)
+    try:
+        linker.lookup("lookup-only", [transfer])
+        linker.lookup("queued", [transfer])
+        linker.load("queued", [transfer])
+
+        linker.reset()
+
+        assert core.cancelled == [1, 2]
+        assert core.reset_calls == 1
+        assert linker.has_pending_operations() is False
+    finally:
+        linker.close()
+
+
+def test_close_releases_core_before_owner_region(linker_contract):
+    events = []
+    core = _FakeCore(events=events)
+    region = _HostRegion(events=events)
+    linker = _linker(linker_contract, core, region)
+
+    linker.close()
+    linker.close()
+
+    assert events == ["core.close", "region.close"]
+    assert core.close_calls == 1
+    assert region.close_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("slots", "message"),
+    [
+        ([1, 2], "aligned contiguous pages"),
+        ([0, 2], "aligned contiguous pages"),
+        ([16, 17], "outside the registered G1 layout"),
+        ([0, 1, 0, 1], "cannot reuse a device page"),
+    ],
+)
+def test_device_page_validation_fails_closed(linker_contract, slots, message):
+    core = _FakeCore()
+    linker = _linker(linker_contract, core)
+    transfer = _transfer(linker_contract.pool_name, pages=(0,))
+    transfer.device_indices = torch.tensor(slots, dtype=torch.int64)
+    try:
+        with pytest.raises(ValueError, match=message):
+            linker.offload([transfer])
+        assert core.store_calls == []
+    finally:
+        linker.close()

--- a/lib/bindings/kvbm/python/tests/test_sglang_provider.py
+++ b/lib/bindings/kvbm/python/tests/test_sglang_provider.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the owner-backed host-memory provider seam."""
+
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.kvbm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_registered_provider_is_idempotent_and_exclusive(load_source):
+    provider_module = load_source("test_kvbm_sglang_provider", "provider.py")
+    first = SimpleNamespace(name="first")
+    second = SimpleNamespace(name="second")
+
+    provider_module.register_host_memory_provider(first)
+    provider_module.register_host_memory_provider(first)
+
+    assert provider_module.get_host_memory_provider() is first
+    with pytest.raises(RuntimeError, match="different KVBM host-memory provider"):
+        provider_module.register_host_memory_provider(second)
+
+
+def test_provider_is_loaded_once_from_environment(
+    monkeypatch, install_module, load_source
+):
+    provider_module = load_source("test_kvbm_sglang_provider_env", "provider.py")
+    provider = SimpleNamespace(name="owner")
+    calls = []
+
+    def create_provider():
+        calls.append("create")
+        return provider
+
+    install_module("test_owner_provider", create_provider=create_provider)
+    monkeypatch.setenv(
+        "DYN_KVBM_HOST_MEMORY_PROVIDER", "test_owner_provider:create_provider"
+    )
+
+    assert provider_module.get_host_memory_provider() is provider
+    assert provider_module.get_host_memory_provider() is provider
+    assert calls == ["create"]
+
+
+@pytest.mark.parametrize("factory_path", [None, "module_without_separator"])
+def test_provider_configuration_is_required(monkeypatch, load_source, factory_path):
+    provider_module = load_source("test_kvbm_sglang_provider_missing", "provider.py")
+    if factory_path is None:
+        monkeypatch.delenv("DYN_KVBM_HOST_MEMORY_PROVIDER", raising=False)
+    else:
+        monkeypatch.setenv("DYN_KVBM_HOST_MEMORY_PROVIDER", factory_path)
+
+    with pytest.raises(RuntimeError, match="owner-backed host-memory provider"):
+        provider_module.get_host_memory_provider()

--- a/lib/bindings/kvbm/src/lib.rs
+++ b/lib/bindings/kvbm/src/lib.rs
@@ -16,6 +16,8 @@ use dynamo_runtime::{
 use dynamo_llm::{self as llm_rs};
 
 mod block_manager;
+#[cfg(feature = "block-manager")]
+mod sglang;
 
 /// A Python module implemented in Rust. The name of this function must match
 /// the `lib.name` setting in the `Cargo.toml`, else Python will not be able to
@@ -37,6 +39,8 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     #[cfg(feature = "block-manager")]
     block_manager::add_to_module(m)?;
+    #[cfg(feature = "block-manager")]
+    sglang::add_to_module(m)?;
 
     Ok(())
 }

--- a/lib/bindings/kvbm/src/sglang.rs
+++ b/lib/bindings/kvbm/src/sglang.rs
@@ -1,0 +1,993 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Typed local KVBM data plane used by SGLang's direct cache linker.
+
+use crate::{get_current_tokio_handle, to_pyerr};
+use anyhow::{Context, Result, anyhow, bail};
+use dynamo_memory::nixl::NixlDescriptor;
+use dynamo_memory::{ExternalPinnedStorage, MemoryDescriptor, StorageKind, TensorDescriptor};
+use dynamo_tokens::{
+    PositionalLineageHash, compute_block_hash_for_tokens, compute_salt_hash_from_bytes,
+};
+use kvbm_logical::blocks::BlockDuplicationPolicy;
+use kvbm_logical::{BlockManager, BlockRegistry, ImmutableBlock, MutableBlock};
+use kvbm_physical::TransferManager;
+use kvbm_physical::layout::{BlockDimension, LayoutConfig, PhysicalLayoutBuilder};
+use kvbm_physical::transfer::LayoutHandle;
+use kvbm_physical::transfer::TransferOptions;
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+use std::any::Any;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::{Duration, Instant};
+use uuid::Uuid;
+
+const CODEC_VERSION: u16 = 1;
+const COMPONENT_FULL_KV: u8 = 0;
+const KEY_LEN: usize = 2 + 32 + 16 + 1;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct KvbmPageKeyV1 {
+    manager_namespace: [u8; 32],
+    sequence_hash: PositionalLineageHash,
+}
+
+impl KvbmPageKeyV1 {
+    fn encode(&self) -> [u8; KEY_LEN] {
+        let mut encoded = [0u8; KEY_LEN];
+        encoded[..2].copy_from_slice(&CODEC_VERSION.to_be_bytes());
+        encoded[2..34].copy_from_slice(&self.manager_namespace);
+        encoded[34..50].copy_from_slice(&self.sequence_hash.to_be_bytes());
+        encoded[50] = COMPONENT_FULL_KV;
+        encoded
+    }
+
+    fn decode(encoded: &[u8], expected_namespace: &[u8; 32]) -> Result<Self> {
+        if encoded.len() != KEY_LEN {
+            bail!(
+                "dynamo-plh-v1 key has {} bytes; expected {KEY_LEN}",
+                encoded.len()
+            );
+        }
+        let version = u16::from_be_bytes(encoded[..2].try_into().unwrap());
+        if version != CODEC_VERSION {
+            bail!("unsupported KVBM page-key codec version {version}");
+        }
+        let namespace: [u8; 32] = encoded[2..34].try_into().unwrap();
+        if &namespace != expected_namespace {
+            bail!("KVBM page key belongs to a different manager namespace");
+        }
+        if encoded[50] != COMPONENT_FULL_KV {
+            bail!("KVBM V1 only supports the FullKv component");
+        }
+        let plh_bytes: [u8; 16] = encoded[34..50].try_into().unwrap();
+        let sequence_hash = PositionalLineageHash::from_be_bytes(plh_bytes);
+        let mode = sequence_hash.mode();
+        if mode > 2 {
+            bail!("dynamo-plh-v1 contains an invalid positional lineage hash");
+        }
+        let position = sequence_hash.position();
+        let canonical_mode = if position < (1 << 8) {
+            0
+        } else if position < (1 << 16) {
+            1
+        } else {
+            2
+        };
+        if mode != canonical_mode || (position == 0 && sequence_hash.parent_hash_fragment() != 0) {
+            bail!("dynamo-plh-v1 contains an invalid positional lineage hash");
+        }
+        Ok(Self {
+            manager_namespace: namespace,
+            sequence_hash,
+        })
+    }
+}
+
+fn domain_payload(cache_salt: Option<&str>, extra_key: Option<&str>) -> Vec<u8> {
+    fn append_field(output: &mut Vec<u8>, value: Option<&str>) {
+        match value {
+            None => output.push(0),
+            Some(value) => {
+                output.push(1);
+                output.extend_from_slice(&(value.len() as u64).to_be_bytes());
+                output.extend_from_slice(value.as_bytes());
+            }
+        }
+    }
+
+    let mut output = b"sglang-dynamo-plh-v1\0".to_vec();
+    append_field(&mut output, cache_salt);
+    append_field(&mut output, extra_key);
+    output
+}
+
+fn decode_key_sequence(encoded: &[Vec<u8>], namespace: &[u8; 32]) -> Result<Vec<KvbmPageKeyV1>> {
+    let keys: Vec<KvbmPageKeyV1> = encoded
+        .iter()
+        .map(|key| KvbmPageKeyV1::decode(key, namespace))
+        .collect::<Result<_>>()?;
+    for edge in keys.windows(2) {
+        let parent = &edge[0].sequence_hash;
+        let child = &edge[1].sequence_hash;
+        if child.position() != parent.position() + 1
+            || child.parent_hash_fragment()
+                != parent.parent_fragment_for_child_position(child.position())
+        {
+            bail!("dynamo-plh-v1 keys do not form one contiguous lineage");
+        }
+    }
+    Ok(keys)
+}
+
+fn validate_device_blocks(blocks: &[usize], num_device_blocks: usize) -> Result<()> {
+    if blocks.iter().any(|block| *block >= num_device_blocks) {
+        bail!("device block falls outside the registered G1 layout");
+    }
+    if blocks.iter().copied().collect::<HashSet<_>>().len() != blocks.len() {
+        bail!("a KVBM operation cannot reuse a G1 device block");
+    }
+    Ok(())
+}
+
+#[pyclass]
+struct DynamoPlhKeyCodec {
+    namespace: [u8; 32],
+}
+
+#[pymethods]
+impl DynamoPlhKeyCodec {
+    #[new]
+    fn new(manager_namespace: &[u8]) -> PyResult<Self> {
+        let namespace = manager_namespace.try_into().map_err(|_| {
+            pyo3::exceptions::PyValueError::new_err(
+                "manager_namespace must contain exactly 32 bytes",
+            )
+        })?;
+        Ok(Self { namespace })
+    }
+
+    #[getter]
+    fn codec_id(&self) -> &'static str {
+        "dynamo-plh-v1"
+    }
+
+    #[pyo3(signature = (parent_key, page_tokens, page_size, cache_salt=None, extra_key=None))]
+    fn extend_pages(
+        &self,
+        py: Python<'_>,
+        parent_key: Option<&[u8]>,
+        page_tokens: Vec<u32>,
+        page_size: usize,
+        cache_salt: Option<&str>,
+        extra_key: Option<&str>,
+    ) -> PyResult<Vec<Py<PyBytes>>> {
+        if page_size == 0 || page_tokens.is_empty() || !page_tokens.len().is_multiple_of(page_size)
+        {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "page_tokens must contain a whole, non-empty page sequence",
+            ));
+        }
+        let mut parent = parent_key
+            .map(|encoded| KvbmPageKeyV1::decode(encoded, &self.namespace))
+            .transpose()
+            .map_err(to_pyerr)?;
+        let page_count = page_tokens.len() / page_size;
+        let first_position = parent
+            .as_ref()
+            .map_or(0, |key| key.sequence_hash.position() + 1);
+        if first_position
+            .checked_add(page_count as u64)
+            .is_none_or(|end| end > (1 << 24))
+        {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "dynamo-plh-v1 page position exceeds its 24-bit limit",
+            ));
+        }
+        let salt_hash = compute_salt_hash_from_bytes(&domain_payload(cache_salt, extra_key));
+        let mut output = Vec::with_capacity(page_tokens.len() / page_size);
+        for tokens in page_tokens.chunks_exact(page_size) {
+            let block_hash = compute_block_hash_for_tokens(tokens, salt_hash);
+            let sequence_hash = match &parent {
+                Some(parent) => parent.sequence_hash.extend(block_hash),
+                None => PositionalLineageHash::root(block_hash),
+            };
+            let key = KvbmPageKeyV1 {
+                manager_namespace: self.namespace,
+                sequence_hash,
+            };
+            output.push(PyBytes::new(py, &key.encode()).unbind());
+            parent = Some(key);
+        }
+        Ok(output)
+    }
+}
+
+struct SglangTensor {
+    _owner: Py<PyAny>,
+    addr: usize,
+    size: usize,
+    shape: Vec<usize>,
+    stride: Vec<usize>,
+    element_size: usize,
+    device_id: u32,
+}
+
+impl SglangTensor {
+    fn from_python(py: Python<'_>, tensor: Py<PyAny>, device_id: u32) -> Result<Self> {
+        let bound = tensor.bind(py);
+        let device = bound.getattr("device")?;
+        let device_type: String = device.getattr("type")?.extract()?;
+        let actual_device: u32 = device
+            .getattr("index")?
+            .extract::<Option<u32>>()?
+            .unwrap_or(0);
+        if device_type != "cuda" || actual_device != device_id {
+            bail!(
+                "all SGLang KV tensors must be on cuda:{device_id}, got {device_type}:{actual_device}"
+            );
+        }
+        if !bound.call_method0("is_contiguous")?.extract::<bool>()? {
+            bail!("SGLang KV tensors must be contiguous");
+        }
+        Ok(Self {
+            addr: bound.call_method0("data_ptr")?.extract()?,
+            size: bound.getattr("nbytes")?.extract()?,
+            shape: bound.getattr("shape")?.extract()?,
+            stride: bound.call_method0("stride")?.extract()?,
+            element_size: bound.call_method0("element_size")?.extract()?,
+            device_id,
+            _owner: tensor,
+        })
+    }
+}
+
+impl fmt::Debug for SglangTensor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SglangTensor")
+            .field("addr", &format_args!("{:#x}", self.addr))
+            .field("size", &self.size)
+            .field("shape", &self.shape)
+            .field("stride", &self.stride)
+            .field("element_size", &self.element_size)
+            .field("device_id", &self.device_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MemoryDescriptor for SglangTensor {
+    fn addr(&self) -> usize {
+        self.addr
+    }
+    fn size(&self) -> usize {
+        self.size
+    }
+    fn storage_kind(&self) -> StorageKind {
+        StorageKind::Device(self.device_id)
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn nixl_descriptor(&self) -> Option<NixlDescriptor> {
+        None
+    }
+}
+
+impl TensorDescriptor for SglangTensor {
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+    fn stride(&self) -> &[usize] {
+        &self.stride
+    }
+    fn element_size(&self) -> usize {
+        self.element_size
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SglangG2;
+
+struct LookupTicketState {
+    keys: Vec<KvbmPageKeyV1>,
+    blocks: Vec<ImmutableBlock<SglangG2>>,
+}
+
+#[derive(Clone)]
+struct CompletionState {
+    operation_id: u128,
+    generation: u64,
+    kind: &'static str,
+    success: bool,
+    error: Option<String>,
+}
+
+struct PendingState {
+    count: Mutex<usize>,
+    changed: Condvar,
+}
+
+impl PendingState {
+    fn new() -> Self {
+        Self {
+            count: Mutex::new(0),
+            changed: Condvar::new(),
+        }
+    }
+
+    fn begin(&self) {
+        *self.count.lock().unwrap() += 1;
+    }
+
+    fn finish(&self) {
+        let mut count = self.count.lock().unwrap();
+        *count -= 1;
+        self.changed.notify_all();
+    }
+
+    fn wait(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        let mut count = self.count.lock().unwrap();
+        while *count != 0 {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                return false;
+            };
+            let (next, status) = self.changed.wait_timeout(count, remaining).unwrap();
+            count = next;
+            if status.timed_out() && *count != 0 {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn get(&self) -> usize {
+        *self.count.lock().unwrap()
+    }
+}
+
+struct StoreInner {
+    namespace: [u8; 32],
+    page_size: usize,
+    num_device_blocks: usize,
+    logical: Arc<BlockManager<SglangG2>>,
+    transfers: TransferManager,
+    g1: LayoutHandle,
+    g2: LayoutHandle,
+    generation: AtomicU64,
+    closing: AtomicBool,
+    tickets: Mutex<HashMap<u128, LookupTicketState>>,
+    completions: Mutex<VecDeque<CompletionState>>,
+    pending: PendingState,
+    // Keep the external mapping/attachment alive until the final layout or
+    // transfer task releases this shared state, including timeout paths.
+    _host_region_guard: Py<PyAny>,
+}
+
+impl StoreInner {
+    fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+
+    fn ensure_open(&self) -> Result<()> {
+        if self.closing.load(Ordering::Acquire) {
+            bail!("SGLang local KV store is closing");
+        }
+        Ok(())
+    }
+
+    fn decode_keys(&self, encoded: &[Vec<u8>]) -> Result<Vec<KvbmPageKeyV1>> {
+        decode_key_sequence(encoded, &self.namespace)
+    }
+
+    fn push_completion(&self, completion: CompletionState) {
+        self.completions.lock().unwrap().push_back(completion);
+    }
+}
+
+#[pyclass]
+#[derive(Clone)]
+struct SglangLookupTicket {
+    #[pyo3(get)]
+    ticket_id: u128,
+    #[pyo3(get)]
+    generation: u64,
+    #[pyo3(get)]
+    hit_pages: usize,
+}
+
+#[pyclass]
+#[derive(Clone)]
+struct SglangOperation {
+    #[pyo3(get)]
+    operation_id: u128,
+    #[pyo3(get)]
+    generation: u64,
+    #[pyo3(get)]
+    kind: &'static str,
+}
+
+#[pyclass]
+#[derive(Clone)]
+struct SglangCompletion {
+    #[pyo3(get)]
+    operation_id: u128,
+    #[pyo3(get)]
+    generation: u64,
+    #[pyo3(get)]
+    kind: &'static str,
+    #[pyo3(get)]
+    success: bool,
+    #[pyo3(get)]
+    error: Option<String>,
+}
+
+#[pyclass]
+struct SglangLocalKvStore {
+    inner: Option<Arc<StoreInner>>,
+}
+
+impl SglangLocalKvStore {
+    fn inner(&self) -> PyResult<Arc<StoreInner>> {
+        self.inner
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("KV store is closed"))
+    }
+
+    fn wait_for_drain(inner: &StoreInner, timeout_ms: u64) -> PyResult<()> {
+        if inner.pending.wait(Duration::from_millis(timeout_ms)) {
+            Ok(())
+        } else {
+            Err(pyo3::exceptions::PyTimeoutError::new_err(format!(
+                "timed out with {} KVBM operations still pending",
+                inner.pending.get()
+            )))
+        }
+    }
+}
+
+#[pymethods]
+impl SglangLocalKvStore {
+    #[new]
+    #[pyo3(signature = (page_size, num_device_blocks, tensors, host_ptr, host_nbytes, manager_namespace, host_region_guard, device_id=0))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        py: Python<'_>,
+        page_size: usize,
+        num_device_blocks: usize,
+        tensors: Vec<Py<PyAny>>,
+        host_ptr: usize,
+        host_nbytes: usize,
+        manager_namespace: &[u8],
+        host_region_guard: Py<PyAny>,
+        device_id: u32,
+    ) -> PyResult<Self> {
+        let namespace: [u8; 32] = manager_namespace
+            .try_into()
+            .map_err(|_| pyo3::exceptions::PyValueError::new_err("namespace must be 32 bytes"))?;
+        if page_size == 0 || !page_size.is_power_of_two() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "page_size must be a non-zero power of two",
+            ));
+        }
+        if num_device_blocks == 0 || tensors.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "device layout requires blocks and tensors",
+            ));
+        }
+        if !tensors.len().is_multiple_of(2) {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "device layout requires one K/V tensor pair per layer",
+            ));
+        }
+
+        let tensors = tensors
+            .into_iter()
+            .map(|tensor| SglangTensor::from_python(py, tensor, device_id))
+            .collect::<Result<Vec<_>>>()
+            .map_err(to_pyerr)?;
+        let element_size = tensors[0].element_size;
+        let tensor_bytes = tensors[0].size;
+        let tensor_shape = tensors[0].shape.as_slice();
+        let tensor_stride = tensors[0].stride.as_slice();
+        if tensors.iter().any(|tensor| {
+            tensor.size != tensor_bytes
+                || tensor.element_size != element_size
+                || tensor.shape.as_slice() != tensor_shape
+                || tensor.stride.as_slice() != tensor_stride
+        }) {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "KVBM V1 requires homogeneous K/V tensor geometry",
+            ));
+        }
+        let denominator = num_device_blocks
+            .checked_mul(page_size)
+            .and_then(|value| value.checked_mul(element_size))
+            .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("layout size overflow"))?;
+        if denominator == 0 || !tensor_bytes.is_multiple_of(denominator) {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "tensor bytes are not divisible by page geometry",
+            ));
+        }
+        let inner_dim = tensor_bytes / denominator;
+        let num_layers = tensors.len();
+        let config = LayoutConfig::builder()
+            .num_blocks(num_device_blocks)
+            .num_layers(num_layers)
+            .outer_dim(1usize)
+            .page_size(page_size)
+            .inner_dim(inner_dim)
+            .dtype_width_bytes(element_size)
+            .build()
+            .map_err(to_pyerr)?;
+        let bytes_per_block = config.bytes_per_block();
+        let host_blocks = host_nbytes / bytes_per_block;
+        if host_blocks == 0 || !host_nbytes.is_multiple_of(bytes_per_block) {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "host region has {host_nbytes} bytes; it must contain whole \
+                 {bytes_per_block}-byte KV blocks"
+            )));
+        }
+
+        let transfers = TransferManager::builder()
+            .cuda_device_id(device_id as usize)
+            .build()
+            .map_err(to_pyerr)?;
+        let tensor_regions: Vec<Arc<dyn TensorDescriptor>> = tensors
+            .into_iter()
+            .map(|tensor| Arc::new(tensor) as Arc<dyn TensorDescriptor>)
+            .collect();
+        let g1_layout = PhysicalLayoutBuilder::new(transfers.nixl_agent().clone())
+            .with_config(config.clone())
+            .layer_separate(BlockDimension::BlockIsFirstDim)
+            .with_external_device_regions(tensor_regions)
+            .and_then(|builder| builder.build())
+            .map_err(to_pyerr)?;
+
+        let host_config = LayoutConfig::builder()
+            .num_blocks(host_blocks)
+            .num_layers(num_layers)
+            .outer_dim(1usize)
+            .page_size(page_size)
+            .inner_dim(inner_dim)
+            .dtype_width_bytes(element_size)
+            .build()
+            .map_err(to_pyerr)?;
+        let host_storage =
+            unsafe { ExternalPinnedStorage::new(host_ptr as *mut u8, host_nbytes, device_id) }
+                .map_err(to_pyerr)?;
+        let g2_layout = PhysicalLayoutBuilder::new(transfers.nixl_agent().clone())
+            .with_config(host_config)
+            .fully_contiguous()
+            .with_memory_regions(vec![host_storage])
+            .and_then(|builder| builder.build())
+            .map_err(to_pyerr)?;
+        let g1 = transfers.register_layout(g1_layout).map_err(to_pyerr)?;
+        let g2 = transfers.register_layout(g2_layout).map_err(to_pyerr)?;
+
+        let logical = BlockManager::<SglangG2>::builder()
+            .block_count(host_blocks)
+            .block_size(page_size)
+            .registry(BlockRegistry::new())
+            .duplication_policy(BlockDuplicationPolicy::Reject)
+            .with_lru_backend()
+            .build()
+            .map_err(to_pyerr)?;
+        let inner = Arc::new(StoreInner {
+            namespace,
+            page_size,
+            num_device_blocks,
+            logical: Arc::new(logical),
+            transfers,
+            g1,
+            g2,
+            generation: AtomicU64::new(0),
+            closing: AtomicBool::new(false),
+            tickets: Mutex::new(HashMap::new()),
+            completions: Mutex::new(VecDeque::new()),
+            pending: PendingState::new(),
+            _host_region_guard: host_region_guard,
+        });
+        Ok(Self { inner: Some(inner) })
+    }
+
+    fn lookup_prefix(&self, encoded_keys: Vec<Vec<u8>>) -> PyResult<SglangLookupTicket> {
+        let inner = self.inner()?;
+        inner.ensure_open().map_err(to_pyerr)?;
+        let keys = inner.decode_keys(&encoded_keys).map_err(to_pyerr)?;
+        let hashes: Vec<_> = keys.iter().map(|key| key.sequence_hash).collect();
+        let blocks = inner.logical.match_blocks(&hashes);
+        let keys = keys.into_iter().take(blocks.len()).collect();
+        let ticket_id = Uuid::new_v4().as_u128();
+        let hit_pages = blocks.len();
+        inner
+            .tickets
+            .lock()
+            .unwrap()
+            .insert(ticket_id, LookupTicketState { keys, blocks });
+        Ok(SglangLookupTicket {
+            ticket_id,
+            generation: inner.generation(),
+            hit_pages,
+        })
+    }
+
+    fn cancel_lookup(&self, ticket: &SglangLookupTicket) -> PyResult<()> {
+        let inner = self.inner()?;
+        if ticket.generation != inner.generation() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "lookup ticket generation is stale",
+            ));
+        }
+        inner
+            .tickets
+            .lock()
+            .unwrap()
+            .remove(&ticket.ticket_id)
+            .ok_or_else(|| {
+                pyo3::exceptions::PyKeyError::new_err("lookup ticket already consumed")
+            })?;
+        Ok(())
+    }
+
+    fn enqueue_store(
+        &self,
+        encoded_keys: Vec<Vec<u8>>,
+        source_g1_blocks: Vec<usize>,
+    ) -> PyResult<SglangOperation> {
+        let inner = self.inner()?;
+        inner.ensure_open().map_err(to_pyerr)?;
+        let keys = inner.decode_keys(&encoded_keys).map_err(to_pyerr)?;
+        if keys.len() != source_g1_blocks.len() || keys.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "store keys and source blocks must have the same non-zero length",
+            ));
+        }
+        validate_device_blocks(&source_g1_blocks, inner.num_device_blocks)
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
+        let generation = inner.generation();
+        let operation_id = Uuid::new_v4().as_u128();
+        let hashes: Vec<_> = keys.iter().map(|key| key.sequence_hash).collect();
+        let existing = inner.logical.match_blocks_scattered(&hashes);
+        let mut seen = HashSet::new();
+        let mut missing = Vec::new();
+        for ((key, source), hit) in keys.into_iter().zip(source_g1_blocks).zip(existing) {
+            if hit.is_none() && seen.insert(key.sequence_hash) {
+                missing.push((key, source));
+            }
+        }
+        drop(seen);
+
+        let operation = SglangOperation {
+            operation_id,
+            generation,
+            kind: "store",
+        };
+        if missing.is_empty() {
+            inner.push_completion(CompletionState {
+                operation_id,
+                generation,
+                kind: "store",
+                success: true,
+                error: None,
+            });
+            return Ok(operation);
+        }
+
+        let Some(mutable) = inner.logical.allocate_blocks(missing.len()) else {
+            // Store admission is rank-local. Publish a normal failed completion
+            // instead of returning synchronously so SGLang can reduce success
+            // across every TP/CP rank without diverging pending queues.
+            inner.push_completion(CompletionState {
+                operation_id,
+                generation,
+                kind: "store",
+                success: false,
+                error: Some("KVBM G2 is full or all candidate blocks are pinned".into()),
+            });
+            return Ok(operation);
+        };
+        let source: Vec<_> = missing.iter().map(|(_, source)| *source).collect();
+        let destination: Vec<_> = mutable.iter().map(MutableBlock::block_id).collect();
+        let notification = inner
+            .transfers
+            .execute_transfer(
+                inner.g1,
+                &source,
+                inner.g2,
+                &destination,
+                TransferOptions::default(),
+            )
+            .map_err(to_pyerr)?;
+        let store_keys: Vec<_> = missing.into_iter().map(|(key, _)| key).collect();
+        inner.pending.begin();
+        let task_inner = inner.clone();
+        get_current_tokio_handle().spawn(async move {
+            let transfer_result = notification.await;
+            let result = match transfer_result {
+                Ok(()) => stage_and_register(&task_inner, mutable, store_keys),
+                Err(error) => Err(error.context("G1 to G2 transfer failed")),
+            };
+            task_inner.push_completion(CompletionState {
+                operation_id,
+                generation,
+                kind: "store",
+                success: result.is_ok(),
+                error: result.err().map(|error| format!("{error:#}")),
+            });
+            task_inner.pending.finish();
+        });
+        Ok(operation)
+    }
+
+    fn enqueue_load(
+        &self,
+        ticket: &SglangLookupTicket,
+        encoded_keys: Vec<Vec<u8>>,
+        target_g1_blocks: Vec<usize>,
+    ) -> PyResult<SglangOperation> {
+        let inner = self.inner()?;
+        inner.ensure_open().map_err(to_pyerr)?;
+        if ticket.generation != inner.generation() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "lookup ticket generation is stale",
+            ));
+        }
+        let requested = inner.decode_keys(&encoded_keys).map_err(to_pyerr)?;
+        if requested.len() != target_g1_blocks.len() || requested.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "load keys and target blocks must have the same non-zero length",
+            ));
+        }
+        validate_device_blocks(&target_g1_blocks, inner.num_device_blocks)
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
+        let mut state = inner
+            .tickets
+            .lock()
+            .unwrap()
+            .remove(&ticket.ticket_id)
+            .ok_or_else(|| {
+                pyo3::exceptions::PyKeyError::new_err("lookup ticket already consumed")
+            })?;
+        if requested.len() > state.keys.len()
+            || !state
+                .keys
+                .iter()
+                .zip(&requested)
+                .all(|(ticket_key, requested_key)| ticket_key == requested_key)
+        {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "load keys must be a prefix of their lookup ticket",
+            ));
+        }
+        state.keys.truncate(requested.len());
+        let tail_blocks = state.blocks.split_off(requested.len());
+        drop(tail_blocks);
+        let source: Vec<_> = state.blocks.iter().map(ImmutableBlock::block_id).collect();
+        let generation = inner.generation();
+        let operation_id = Uuid::new_v4().as_u128();
+        let notification = inner
+            .transfers
+            .execute_transfer(
+                inner.g2,
+                &source,
+                inner.g1,
+                &target_g1_blocks,
+                TransferOptions::default(),
+            )
+            .map_err(to_pyerr)?;
+        inner.pending.begin();
+        let task_inner = inner.clone();
+        get_current_tokio_handle().spawn(async move {
+            let result = notification.await.context("G2 to G1 transfer failed");
+            // Keep the immutable ticket blocks alive through the real completion.
+            drop(state);
+            task_inner.push_completion(CompletionState {
+                operation_id,
+                generation,
+                kind: "load",
+                success: result.is_ok(),
+                error: result.err().map(|error| format!("{error:#}")),
+            });
+            task_inner.pending.finish();
+        });
+        Ok(SglangOperation {
+            operation_id,
+            generation,
+            kind: "load",
+        })
+    }
+
+    fn poll_completions(&self) -> PyResult<Vec<SglangCompletion>> {
+        let inner = self.inner()?;
+        let mut queue = inner.completions.lock().unwrap();
+        Ok(queue
+            .drain(..)
+            .map(|completion| SglangCompletion {
+                operation_id: completion.operation_id,
+                generation: completion.generation,
+                kind: completion.kind,
+                success: completion.success,
+                error: completion.error,
+            })
+            .collect())
+    }
+
+    #[pyo3(signature = (timeout_ms=30_000))]
+    fn drain(&self, timeout_ms: u64) -> PyResult<()> {
+        let inner = self.inner()?;
+        Self::wait_for_drain(&inner, timeout_ms)
+    }
+
+    #[pyo3(signature = (timeout_ms=30_000))]
+    fn reset(&self, timeout_ms: u64) -> PyResult<()> {
+        let inner = self.inner()?;
+        Self::wait_for_drain(&inner, timeout_ms)?;
+        inner.tickets.lock().unwrap().clear();
+        inner.completions.lock().unwrap().clear();
+        inner.logical.reset_inactive_pool().map_err(to_pyerr)?;
+        inner.generation.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+
+    #[pyo3(signature = (timeout_ms=30_000))]
+    fn close(&mut self, timeout_ms: u64) -> PyResult<()> {
+        let Some(inner) = self.inner.as_ref().cloned() else {
+            return Ok(());
+        };
+        inner.closing.store(true, Ordering::Release);
+        Self::wait_for_drain(&inner, timeout_ms)?;
+        inner.tickets.lock().unwrap().clear();
+        self.inner.take();
+        drop(inner);
+        Ok(())
+    }
+
+    fn pending_counts(&self) -> PyResult<(usize, usize, usize)> {
+        let inner = self.inner()?;
+        Ok((
+            inner.tickets.lock().unwrap().len(),
+            inner.pending.get(),
+            inner.completions.lock().unwrap().len(),
+        ))
+    }
+}
+
+impl Drop for SglangLocalKvStore {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.as_ref() {
+            inner.closing.store(true, Ordering::Release);
+            if !inner.pending.wait(Duration::from_secs(30)) {
+                tracing::error!(
+                    pending = inner.pending.get(),
+                    "dropping SGLang KVBM store with operations still pending"
+                );
+            }
+        }
+    }
+}
+
+fn stage_and_register(
+    inner: &StoreInner,
+    mutable: Vec<MutableBlock<SglangG2>>,
+    keys: Vec<KvbmPageKeyV1>,
+) -> Result<()> {
+    let complete = mutable
+        .into_iter()
+        .zip(keys)
+        .map(|(block, key)| {
+            block
+                .stage(key.sequence_hash, inner.page_size)
+                .map_err(|error| anyhow!(error.to_string()))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    drop(inner.logical.register_blocks(complete));
+    Ok(())
+}
+
+pub fn add_to_module(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<DynamoPlhKeyCodec>()?;
+    module.add_class::<SglangLookupTicket>()?;
+    module.add_class::<SglangOperation>()?;
+    module.add_class::<SglangCompletion>()?;
+    module.add_class::<SglangLocalKvStore>()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_wire_roundtrip_and_namespace_validation() {
+        let key = KvbmPageKeyV1 {
+            manager_namespace: [7; 32],
+            sequence_hash: PositionalLineageHash::root(42),
+        };
+        let encoded = key.encode();
+        assert_eq!(KvbmPageKeyV1::decode(&encoded, &[7; 32]).unwrap(), key);
+        assert!(KvbmPageKeyV1::decode(&encoded, &[8; 32]).is_err());
+
+        let mut noncanonical = encoded;
+        noncanonical[34] |= 0x40;
+        assert!(KvbmPageKeyV1::decode(&noncanonical, &[7; 32]).is_err());
+
+        let mut reserved_mode = encoded;
+        reserved_mode[34] |= 0xc0;
+        assert!(KvbmPageKeyV1::decode(&reserved_mode, &[7; 32]).is_err());
+    }
+
+    #[test]
+    fn domain_encoding_distinguishes_none_empty_and_fields() {
+        assert_ne!(domain_payload(None, None), domain_payload(Some(""), None));
+        assert_ne!(
+            domain_payload(Some("a"), Some("b")),
+            domain_payload(Some("b"), Some("a"))
+        );
+    }
+
+    #[test]
+    fn device_block_validation_rejects_aliases_and_out_of_bounds_ids() {
+        assert!(validate_device_blocks(&[0, 2], 3).is_ok());
+        assert!(validate_device_blocks(&[0, 0], 3).is_err());
+        assert!(validate_device_blocks(&[0, 3], 3).is_err());
+    }
+
+    #[test]
+    fn key_sequence_rejects_disconnected_pages() {
+        let namespace = [9; 32];
+        let first = KvbmPageKeyV1 {
+            manager_namespace: namespace,
+            sequence_hash: PositionalLineageHash::root(1),
+        };
+        let disconnected = KvbmPageKeyV1 {
+            manager_namespace: namespace,
+            sequence_hash: PositionalLineageHash::root(2),
+        };
+        assert!(
+            decode_key_sequence(
+                &[first.encode().to_vec(), disconnected.encode().to_vec()],
+                &namespace,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn key_codec_vector_covers_domain_and_parent_lineage() {
+        let namespace = [0x11; 32];
+        let salt =
+            compute_salt_hash_from_bytes(&domain_payload(Some("tenant-a"), Some("adapter-a")));
+        let first = KvbmPageKeyV1 {
+            manager_namespace: namespace,
+            sequence_hash: PositionalLineageHash::root(compute_block_hash_for_tokens(
+                &[1, 2],
+                salt,
+            )),
+        };
+        let second = KvbmPageKeyV1 {
+            manager_namespace: namespace,
+            sequence_hash: first
+                .sequence_hash
+                .extend(compute_block_hash_for_tokens(&[3, 4], salt)),
+        };
+        let encoded = [first, second].map(|key| {
+            key.encode()
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<String>()
+        });
+        assert_eq!(
+            encoded,
+            [
+                "00011111111111111111111111111111111111111111111111111111111111111111001488c9a84e2f52f40000000000000000",
+                "00011111111111111111111111111111111111111111111111111111111111111111004e67c2eab285ba9d6326a138bd4bd000",
+            ]
+        );
+    }
+}

--- a/lib/memory/src/external_pinned.rs
+++ b/lib/memory/src/external_pinned.rs
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! CUDA registration wrapper for externally owned host memory.
+
+use crate::nixl::{MemType, NixlCompatible, NixlDescriptor};
+use crate::{MemoryDescriptor, Result, StorageError, StorageKind};
+use cudarc::driver::CudaContext;
+use cudarc::driver::result::DriverError;
+use std::any::Any;
+use std::ffi::c_void;
+use std::fmt;
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+/// Externally allocated host memory registered with CUDA for DMA.
+///
+/// The underlying mapping remains owned by the caller. Dropping this value only
+/// unregisters the pages from CUDA; it never calls `cuMemFreeHost` or unmaps the
+/// address. The caller must keep the mapping alive until this wrapper is dropped.
+pub struct ExternalPinnedStorage {
+    ptr: NonNull<u8>,
+    len: usize,
+    ctx: Arc<CudaContext>,
+}
+
+// SAFETY: construction requires the caller to keep the external mapping alive;
+// CUDA registration makes the address stable for the wrapper's lifetime.
+unsafe impl Send for ExternalPinnedStorage {}
+unsafe impl Sync for ExternalPinnedStorage {}
+
+impl ExternalPinnedStorage {
+    /// Register an externally owned host region for CUDA DMA.
+    ///
+    /// # Safety
+    ///
+    /// `ptr..ptr+len` must be a live, writable host mapping which remains valid
+    /// until this value is dropped. No other owner may unregister the same range.
+    pub unsafe fn new(ptr: *mut u8, len: usize, device_id: u32) -> Result<Self> {
+        let ptr = NonNull::new(ptr).ok_or_else(|| {
+            StorageError::RegistrationFailed("external host pointer is null".into())
+        })?;
+        if len == 0 {
+            return Err(StorageError::RegistrationFailed(
+                "external host region is empty".into(),
+            ));
+        }
+        if len > isize::MAX as usize || (ptr.as_ptr() as usize).checked_add(len).is_none() {
+            return Err(StorageError::RegistrationFailed(
+                "external host region address range overflows".into(),
+            ));
+        }
+
+        let ctx = crate::device::cuda_context(device_id)?;
+        ctx.bind_to_thread().map_err(StorageError::Cuda)?;
+        let flags = cudarc::driver::sys::CU_MEMHOSTREGISTER_PORTABLE
+            | cudarc::driver::sys::CU_MEMHOSTREGISTER_DEVICEMAP;
+        unsafe {
+            cudarc::driver::sys::cuMemHostRegister_v2(ptr.as_ptr().cast::<c_void>(), len, flags)
+                .result()
+                .map_err(StorageError::Cuda)?;
+        }
+        Ok(Self { ptr, len, ctx })
+    }
+}
+
+impl Drop for ExternalPinnedStorage {
+    fn drop(&mut self) {
+        if let Err(error) = self.ctx.bind_to_thread() {
+            tracing::error!(?error, "failed to bind CUDA context before host unregister");
+            return;
+        }
+        let result: std::result::Result<(), DriverError> = unsafe {
+            cudarc::driver::sys::cuMemHostUnregister(self.ptr.as_ptr().cast::<c_void>()).result()
+        };
+        if let Err(error) = result {
+            tracing::error!(?error, "failed to unregister external pinned memory");
+        }
+    }
+}
+
+impl fmt::Debug for ExternalPinnedStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExternalPinnedStorage")
+            .field("ptr", &self.ptr)
+            .field("len", &self.len)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MemoryDescriptor for ExternalPinnedStorage {
+    fn addr(&self) -> usize {
+        self.ptr.as_ptr() as usize
+    }
+
+    fn size(&self) -> usize {
+        self.len
+    }
+
+    fn storage_kind(&self) -> StorageKind {
+        StorageKind::Pinned
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn nixl_descriptor(&self) -> Option<NixlDescriptor> {
+        None
+    }
+}
+
+impl NixlCompatible for ExternalPinnedStorage {
+    fn nixl_params(&self) -> (*const u8, usize, MemType, u64) {
+        (self.ptr.as_ptr(), self.len, MemType::Dram, 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_invalid_regions_before_opening_cuda() {
+        let null = unsafe { ExternalPinnedStorage::new(std::ptr::null_mut(), 1, 0) };
+        assert!(matches!(null, Err(StorageError::RegistrationFailed(_))));
+
+        let empty = unsafe { ExternalPinnedStorage::new(NonNull::dangling().as_ptr(), 0, 0) };
+        assert!(matches!(empty, Err(StorageError::RegistrationFailed(_))));
+    }
+}

--- a/lib/memory/src/lib.rs
+++ b/lib/memory/src/lib.rs
@@ -29,6 +29,7 @@ pub mod prelude;
 mod device;
 mod disk;
 mod external;
+mod external_pinned;
 mod pinned;
 mod system;
 mod tensor;
@@ -40,6 +41,7 @@ pub use arena::{ArenaAllocator, ArenaBuffer, ArenaError};
 pub use device::DeviceStorage;
 pub use disk::DiskStorage;
 pub use external::ExternalDeviceMemory;
+pub use external_pinned::ExternalPinnedStorage;
 #[cfg(target_os = "linux")]
 pub use numa::{NumaNode, is_numa_disabled, is_numa_enabled};
 pub use offset::OffsetBuffer;

--- a/lib/tokens/src/lib.rs
+++ b/lib/tokens/src/lib.rs
@@ -602,6 +602,19 @@ impl PositionalLineageHash {
         Self::new(block_hash, None, 0)
     }
 
+    /// Decode the canonical 16-byte big-endian wire representation.
+    ///
+    /// This is the inverse of [`Self::to_be_bytes`] and is intended for typed
+    /// protocol boundaries which must resume a lineage hash chain.
+    pub fn from_be_bytes(bytes: [u8; 16]) -> Self {
+        Self(u128::from_be_bytes(bytes))
+    }
+
+    /// Encode this hash in its canonical 16-byte big-endian wire form.
+    pub fn to_be_bytes(self) -> [u8; 16] {
+        self.0.to_be_bytes()
+    }
+
     /// Extends this lineage by one block, producing the child PLH.
     ///
     /// The chain recurrence is [`compute_next_sequence_hash`]. Salt does not seed the
@@ -3323,6 +3336,7 @@ mod tests {
             rmp_serde::from_slice(&bytes).expect("plh deserialize");
         assert_eq!(plh, decoded);
         assert_eq!(plh.as_u128(), decoded.as_u128());
+        assert_eq!(PositionalLineageHash::from_be_bytes(plh.to_be_bytes()), plh);
 
         // Vec roundtrip — exercises the codec inside a container.
         let vec = vec![psh, PositionalSequenceHash::default(), psh];


### PR DESCRIPTION
## Summary

- Add a typed Rust SGLang KVBM core with canonical `dynamo-plh-v1` keys, external SGLang G1 tensors, owner-backed pinned G2 memory, lookup tickets, FIFO store/load completions, generation checks, and drain/reset/close ordering.
- Add the Python `kvbm.sglang_integration` factory/linker/provider seam and load the selected cache plugin early from the Dynamo SGLang launcher.
- Enforce no-native-L2 mode, homogeneous Full-KV layout, PP=1, page/block bounds, and conflict checks for HiCache, LMCache, FlexKV, quantized pools, and post-capture VMM pools.
- Keep queued and submitted cancellation distinct so G1/G2/layout/attachment guards remain live until real transfer completion.

Companion SGLang change: https://github.com/sgl-project/sglang/pull/37592

This PR is intentionally a draft. The architecture requires a Dynamo Enhancement Proposal before merge, and the owner-backed rcommu `HostMemoryProvider` implementation from the prerequisite design has not been submitted yet. No DEP issue is created as part of this PR.

## Validation

- `cargo check --manifest-path lib/bindings/kvbm/Cargo.toml -j 2`
- `cargo test --manifest-path lib/bindings/kvbm/Cargo.toml sglang::tests -j 2` — 5 passed
- `cargo test -p dynamo-tokens positional_lineage -j 2` — 10 passed
- `cargo test -p dynamo-memory -j 2` — 148 passed, 2 doctests ignored
- `PYTHONPATH=lib/bindings/kvbm/python:components/src python -m pytest -q lib/bindings/kvbm/python/tests components/src/dynamo/sglang/tests/test_cache_plugin.py` — 27 passed
- `cargo clippy -p dynamo-memory -p dynamo-tokens --all-targets -- -D warnings`
- `cargo clippy --manifest-path lib/bindings/kvbm/Cargo.toml --all-targets -- -D warnings`
- Pre-commit hooks on every changed file

GPU/rcommu end-to-end restore validation remains pending the owner-provider dependency.

## Where should the reviewer start?

1. `lib/bindings/kvbm/src/sglang.rs` for typed handles, transfer lifetime, and block publication.
2. `lib/bindings/kvbm/python/kvbm/sglang_integration/linker.py` for cancellation and completion ordering.
3. `lib/bindings/kvbm/python/kvbm/sglang_integration/factory.py` for layout registration and no-L2 startup checks.

## Related Issues

- Relates to #1199
