### PR TITLE
test(sglang): serialize bounded multi-worker startup

### DIFF
--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -2732,6 +2732,7 @@ def _test_router_decisions(
     router_predicted_ttl_secs: Optional[float] = None,
     router_approximate_cache_policy: str = "ttl",
     initial_wait: float = 0.25,
+    router_init_timeout: int = 120,
 ):
     """Validate cross-worker routing decisions based on longest prefix match.
 
@@ -2797,6 +2798,7 @@ def _test_router_decisions(
             ),
             num_workers=expected_num_instances,
             engine_workers=engine_workers,
+            timeout=router_init_timeout,
         )
 
         # Wait for workers to be ready and get their instance IDs

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -2758,6 +2758,7 @@ def _test_router_decisions(
             approximate routing with the configured retention policy (--no-kv-events mode).
         router_aic_config: Optional AIC router perf-model config for direct KvRouter tests.
         router_approximate_cache_policy: Retention policy for the local approximate indexer.
+        router_init_timeout: Maximum time for the router to discover its initial workers.
 
     Raises:
         AssertionError: If routing decisions don't match expected prefix logic

--- a/tests/router/e2e_harness.py
+++ b/tests/router/e2e_harness.py
@@ -52,9 +52,27 @@ def build_test_payload(model_name: str) -> dict[str, Any]:
 class ManagedEngineProcessMixin:
     process_name = "worker"
     cleanup_name = "worker resources"
+    # Backends that provide a real readiness check can opt in to finishing one
+    # worker's initialization before launching the next worker.
+    serialize_startup_with_readiness = False
     init_delay_seconds = 5
     init_delay_reason = "initialize before starting next worker"
     cleanup_delay_seconds = 2
+
+    def _wait_for_worker_readiness(self, process, worker_index):
+        logger.info(
+            "[%s] Checking readiness for worker %d...",
+            self.__class__.__name__,
+            worker_index,
+        )
+        elapsed = process._check_ports(process.timeout)
+        elapsed += process._check_urls(process.timeout - elapsed)
+        process._check_funcs(process.timeout - elapsed)
+        logger.info(
+            "[%s] Worker %d readiness checks passed",
+            self.__class__.__name__,
+            worker_index,
+        )
 
     def __enter__(self):
         logger.info(
@@ -93,7 +111,18 @@ class ManagedEngineProcessMixin:
                 )
                 time.sleep(process.delayed_start)
 
-                if i < len(self.worker_processes) - 1:
+                if self.serialize_startup_with_readiness:
+                    if not (
+                        process.health_check_ports
+                        or process.health_check_urls
+                        or process.health_check_funcs
+                    ):
+                        raise ValueError(
+                            "Serialized worker startup requires at least one "
+                            "readiness check"
+                        )
+                    self._wait_for_worker_readiness(process, i)
+                elif i < len(self.worker_processes) - 1:
                     logger.info(
                         "[%s] Waiting %ss for worker %d to %s...",
                         self.__class__.__name__,
@@ -108,7 +137,7 @@ class ManagedEngineProcessMixin:
                     "[%s] Failed to start worker %d", self.__class__.__name__, i
                 )
                 try:
-                    process.__exit__(None, None, None)
+                    self.__exit__(None, None, None)
                 except Exception as cleanup_err:
                     logger.warning(
                         "[%s] Error during cleanup: %s",
@@ -122,30 +151,26 @@ class ManagedEngineProcessMixin:
             self.__class__.__name__,
             len(self.worker_processes),
         )
-        logger.info(
-            "[%s] Waiting for health checks to complete...", self.__class__.__name__
-        )
 
-        for i, process in enumerate(self.worker_processes):
+        if not self.serialize_startup_with_readiness:
             logger.info(
-                "[%s] Checking health for worker %d...", self.__class__.__name__, i
+                "[%s] Waiting for health checks to complete...",
+                self.__class__.__name__,
             )
-            try:
-                elapsed = process._check_ports(process.timeout)
-                process._check_urls(process.timeout - elapsed)
-                process._check_funcs(process.timeout - elapsed)
-                logger.info(
-                    "[%s] Worker %d health checks passed", self.__class__.__name__, i
-                )
-            except Exception:
-                logger.error(
-                    "[%s] Worker %d health check failed", self.__class__.__name__, i
-                )
-                self.__exit__(None, None, None)
-                raise
+            for i, process in enumerate(self.worker_processes):
+                try:
+                    self._wait_for_worker_readiness(process, i)
+                except Exception:
+                    logger.error(
+                        "[%s] Worker %d health check failed",
+                        self.__class__.__name__,
+                        i,
+                    )
+                    self.__exit__(None, None, None)
+                    raise
 
         logger.info(
-            "[%s] All workers started successfully and passed health checks!",
+            "[%s] All workers started successfully and passed readiness checks!",
             self.__class__.__name__,
         )
         return self

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -21,7 +21,7 @@ from tests.router.e2e_harness import (
 from tests.router.helper import generate_random_suffix
 from tests.utils.constants import DynamoPortRange
 from tests.utils.gpu_args import build_gpu_mem_args
-from tests.utils.managed_process import ManagedProcess
+from tests.utils.managed_process import ManagedProcess, check_health_ready
 from tests.utils.port_utils import (
     allocate_contiguous_ports,
     allocate_port,
@@ -67,6 +67,8 @@ class SGLangProcess(ManagedEngineProcessMixin):
     - KV cache event publishing (ZMQ → NATS bridge)
     - Integration with dynamo.frontend router
     """
+
+    serialize_startup_with_readiness = True
 
     def __init__(
         self,
@@ -251,10 +253,15 @@ class SGLangProcess(ManagedEngineProcessMixin):
             process = ManagedProcess(
                 command=command,
                 env=env,
-                timeout=120,  # Allow time for model loading
+                timeout=180,  # Bound serialized model loading and registration
                 display_output=True,
                 health_check_ports=[],
-                health_check_urls=[],
+                health_check_urls=[
+                    (
+                        f"http://localhost:{system_port}/health",
+                        check_health_ready,
+                    )
+                ],
                 log_dir=request.node.name,
                 terminate_all_matching_process_names=False,
             )
@@ -310,7 +317,7 @@ def test_sglang_kv_router_basic(
 @pytest.mark.gpu_1
 @pytest.mark.profiled_vram_gib(12.0)
 @pytest.mark.requested_sglang_kv_tokens(2048)
-@pytest.mark.timeout(300)
+@pytest.mark.timeout(600)  # Covers two bounded 180s startups plus router validation
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 def test_router_decisions_sglang_multiple_workers(
     request,

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -331,6 +331,7 @@ def test_router_decisions_sglang_multiple_workers(
         num_workers=2,
         single_gpu=True,
         test_dp_rank=False,
+        test_kwargs={"router_init_timeout": 180},
     )
 
 


### PR DESCRIPTION
## What

- Start SGLang workers serially for router tests: launch worker 0, wait for its Dynamo `/health` endpoint to report `ready`, then launch worker 1.
- Bound each worker's readiness wait at 180 seconds.
- Keep the multi-worker test's router-discovery timeout at 180 seconds after both workers are ready.
- Raise the outer pytest timeout to 600 seconds so the bounded worker/readiness failures surface instead of being preempted by the old 300-second cap.

The shared defaults and startup behavior for other backends are unchanged.

## Why

`test_router_decisions_sglang_multiple_workers[tcp]` verifies prefix-based routing across two SGLang workers. The two observed failures occurred during setup, before the routing assertions ran: both workers began loading the model concurrently, but initialization did not complete before the existing 120-second router-registration deadline.

The fixed five-second launch stagger did not prevent overlapping model initialization. Readiness-gated startup removes that contention within this test, gives each worker a finite initialization window, and makes a timeout identify the worker that failed to become ready. The longer router timeout remains a backstop for service discovery after both workers are ready.

Failed jobs:

- https://github.com/ai-dynamo/dynamo/actions/runs/32825570611/job/97735504846
- https://github.com/ai-dynamo/dynamo/actions/runs/33168580073/job/98931884853

## Verification

- A focused harness simulation verified the required order: `start worker 0 -> worker 0 ready -> start worker 1 -> worker 1 ready`.
- The simulation verified that a readiness timeout prevents the next worker from launching and cleans up all started workers.
- Direct checks verified that the readiness predicate accepts Dynamo's `ready` response and rejects `notready`.
- Python AST syntax validation passed for all three modified files.
- `git diff --check` passed.

These checks validate the new orchestration, timeout propagation, and failure cleanup. Full end-to-end validation still requires the SGLang GPU CI environment; the local checkout does not have the built Dynamo bindings or GPU dev image.
