### PR TITLE
docs(benchmarks): correct multi-turn trace semantics

### DIFF
--- a/benchmarks/router/README.md
+++ b/benchmarks/router/README.md
@@ -369,31 +369,34 @@ python agent_benchmark.py --input-dataset trace.jsonl --concurrency 10 --delay 1
 
 Both `real_data_benchmark.py` and `agent_benchmark.py` accept trace datasets in JSONL format (one JSON object per line). The format is compatible with [Mooncake trace format](https://github.com/kvcache-ai/Mooncake).
 
+For `agent_benchmark.py`, each row contains only the new input for that turn. AIPerf builds the request by appending the row to earlier turns and live assistant responses from the same `session_id`. Supplying a cumulative context on every row duplicates the earlier conversation and overstates the prompt work.
+
 #### Fields
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `input_length` | int | Number of input tokens for this request |
+| `input_length` | int | Number of new input tokens in this turn. For `agent_benchmark.py`, exclude earlier turns and assistant responses. |
 | `output_length` | int | Number of output tokens to generate |
 | `session_id` | string | Groups turns into multi-turn conversations. Requests with the same `session_id` are processed sequentially. |
-| `hash_ids` | list[int] | List of hash IDs representing prefix blocks for KV cache routing. Shared hash IDs indicate shared prefixes. |
+| `hash_ids` | list[int] | Hash IDs representing blocks in this row's input. For later turns in `agent_benchmark.py`, do not repeat blocks already supplied by earlier turns. |
 | `delay` | int | Delay in milliseconds to wait before sending this turn (applied after the previous turn in the same session completes). Not applied to first turns. |
 
 #### Example Trace File
 
 ```jsonl
-{"session_id": "conv_0", "input_length": 9176, "output_length": 152, "hash_ids": [0, 1, 2, 3, 4, 5]}
-{"session_id": "conv_0", "input_length": 9368, "output_length": 104, "hash_ids": [0, 1, 2, 3, 4, 5, 6, 7], "delay": 500}
-{"session_id": "conv_0", "input_length": 9516, "output_length": 164, "hash_ids": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], "delay": 500}
-{"session_id": "conv_1", "input_length": 9445, "output_length": 143, "hash_ids": [0, 1, 2, 10, 11, 12, 13]}
-{"session_id": "conv_1", "input_length": 9628, "output_length": 123, "hash_ids": [0, 1, 2, 10, 11, 12, 13, 14, 15], "delay": 500}
+{"session_id": "conv_0", "input_length": 1024, "output_length": 152, "hash_ids": [0, 1]}
+{"session_id": "conv_0", "input_length": 192, "output_length": 104, "hash_ids": [2], "delay": 500}
+{"session_id": "conv_0", "input_length": 148, "output_length": 164, "hash_ids": [3], "delay": 500}
+{"session_id": "conv_1", "input_length": 1024, "output_length": 143, "hash_ids": [0, 1]}
+{"session_id": "conv_1", "input_length": 183, "output_length": 123, "hash_ids": [4], "delay": 500}
 ```
 
 In this example:
 - `conv_0` and `conv_1` are two separate conversations that can run concurrently
 - Within each conversation, turns are processed sequentially
 - Subsequent turns have a 500ms delay after the previous turn completes
-- `hash_ids` show prefix sharing: both conversations share prefix blocks `[0, 1, 2]`
+- The first turns share prefix blocks `[0, 1]`; later turns add only their new input blocks
+- AIPerf adds each live assistant response to its session before sending the next turn
 
 ## Benchmarking Results
 

--- a/benchmarks/router/agent_benchmark.py
+++ b/benchmarks/router/agent_benchmark.py
@@ -11,11 +11,15 @@ in parallel while maintaining sequential ordering within each session.
 Expected input JSON format (JSONL - one JSON object per line):
 {
     "session_id": "conv_0",           # Groups turns into conversations (required for multi-turn)
-    "input_length": 9176,             # Number of input tokens (required)
+    "input_length": 9176,             # New input tokens for this turn (required)
     "output_length": 152,             # Number of output tokens (required)
-    "hash_ids": [0, 1, 2, ...],       # List of hash IDs for prefix caching (optional)
+    "hash_ids": [0, 1, 2, ...],       # Hash IDs for blocks in this turn's input (optional)
     "delay": 500                      # Delay in ms before this turn (optional, applied after previous turn completes)
 }
+
+AIPerf accumulates earlier turns and live assistant responses for entries that
+share a session_id. Do not include that existing context again in input_length
+or hash_ids on later turns.
 """
 
 import argparse


### PR DESCRIPTION
## Overview:

Clarify that `agent_benchmark.py` expects incremental input for each turn. AIPerf already accumulates earlier turns and live assistant responses for a shared `session_id`, so cumulative rows duplicate conversation history and overstate prompt work.

## Details:

- Define `input_length` as the new input tokens for the current turn.
- Define `hash_ids` as blocks belonging to the current row rather than previously supplied turns.
- Replace the cumulative-looking example with an incremental, Mooncake-compatible trace.
- Keep the change documentation-only; no serving or benchmark runtime behavior changes.

### Validation

- `uvx pre-commit run --files benchmarks/router/README.md benchmarks/router/agent_benchmark.py`
- `python3 -m py_compile benchmarks/router/agent_benchmark.py`
- Corrected example passed `aiperf validate mooncake-trace` with the repository-pinned AIPerf 0.10.
- Reproduced request accumulation with AIPerf 0.10 and 0.12 by capturing the outgoing HTTP payloads.
- Validated twice on AKS with Dynamo Platform 1.4.2, Qwen3.5-4B, and two vLLM workers on separate A100 nodes. Cumulative rows processed 5,246 and 5,314 prompt tokens; equivalent incremental rows processed 3,153 in both runs, avoiding 66-69% unintended prompt work.

## Where should the reviewer start?

`benchmarks/router/README.md` contains the clarified contract and corrected example. `benchmarks/router/agent_benchmark.py` mirrors the same contract in its module documentation.

## Related Issues

- Relates to #14254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the JSONL trace format for multi-turn benchmark inputs.
  - Documented that each turn contains only newly added input, while prior context and assistant responses are assembled automatically.
  - Updated field descriptions and examples to explain incremental input lengths, shared prefixes, new hash blocks, and appended responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
