### PR TITLE
feat(planner): collect batch scheduling observations

### DIFF
--- a/components/src/dynamo/planner/environment/batch.py
+++ b/components/src/dynamo/planner/environment/batch.py
@@ -1,0 +1,1179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""External observations and actuation for batch-aware planning.
+
+This module defines narrow source and actuator primitives. Native lifecycle
+ownership lives in ``batch_runtime`` so the policy core remains independent of
+HTTP, OpenMetrics, Prometheus, and Redis clients.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import math
+import re
+import time
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, Optional, Protocol, Union
+from urllib.parse import quote
+
+import aiohttp
+from dynamo.planner.core.types import (
+    BatchDispatcherFeedback,
+    BatchJobDemand,
+    BatchSchedulingObservation,
+    PoolTrafficDemand,
+)
+from prometheus_client.parser import text_string_to_metric_families
+
+__all__ = [
+    "BatchGatewayJobSource",
+    "BatchJobSource",
+    "BatchResolver",
+    "BatchSchedulingCollector",
+    "DispatcherFeedbackSource",
+    "LlmdAsyncPrometheusSource",
+    "LlmdAsyncOpenMetricsSource",
+    "OpenMetricsOnlineTrafficSource",
+    "OnlineTrafficSource",
+    "PrometheusQueryClient",
+]
+
+logger = logging.getLogger(__name__)
+
+_KNOWN_BATCH_STATUSES = frozenset(
+    {
+        "validating",
+        "failed",
+        "in_progress",
+        "finalizing",
+        "completed",
+        "expired",
+        "cancelling",
+        "cancelled",
+    }
+)
+_TERMINAL_BATCH_STATUSES = frozenset({"completed", "failed", "expired", "cancelled"})
+_PLANNER_REQUEST_COUNT_METADATA_KEY = "planner_request_count"
+_MAX_SIGNED_INT64 = (1 << 63) - 1
+_NANOSECONDS_PER_SECOND = 1_000_000_000
+_GO_DURATION_COMPONENT = re.compile(
+    r"(?P<value>(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+))" r"(?P<unit>ns|us|µs|μs|ms|s|m|h)"
+)
+_GO_DURATION_UNIT_NANOSECONDS = {
+    "ns": 1,
+    "us": 1_000,
+    "µs": 1_000,
+    "μs": 1_000,
+    "ms": 1_000_000,
+    "s": _NANOSECONDS_PER_SECOND,
+    "m": 60 * _NANOSECONDS_PER_SECOND,
+    "h": 60 * 60 * _NANOSECONDS_PER_SECOND,
+}
+
+
+class BatchJobSource(Protocol):
+    """Collect batch-job demand at a caller-supplied sample time."""
+
+    async def collect_batch_jobs(
+        self, *, observed_at_s: float
+    ) -> list[BatchJobDemand]: ...
+
+
+class OnlineTrafficSource(Protocol):
+    """Collect non-batch offered load at a caller-supplied sample time."""
+
+    async def collect_online_traffic(
+        self, *, observed_at_s: float
+    ) -> list[PoolTrafficDemand]: ...
+
+
+class DispatcherFeedbackSource(Protocol):
+    """Collect llm-d Async dispatcher feedback for configured pools."""
+
+    async def collect_dispatcher_feedback(
+        self, *, observed_at_s: float
+    ) -> list[BatchDispatcherFeedback]: ...
+
+
+class PrometheusQueryClient(Protocol):
+    """Subset of a Prometheus client used by the dispatcher source."""
+
+    def custom_query(self, query: str) -> object: ...
+
+
+BatchResolver = Callable[[Mapping[str, Any]], str]
+PrometheusQuery = Callable[[str], object]
+
+
+class OpenMetricsOnlineTrafficSource:
+    """Derive a strict online-request rate from a directly scraped counter.
+
+    The first successful scrape only establishes a counter baseline and raises
+    ``RuntimeError``.  This intentionally makes the first native Planner tick
+    publish a zero-rate safety lease instead of treating an unknown rate as
+    zero. Counter resets are handled the same way: the new value becomes the
+    next baseline, but the current observation fails closed.
+
+    ``match_labels`` is explicit because frontend metrics do not currently
+    carry a general online-vs-batch origin label.  A deployment can select a
+    dedicated request type (the POC uses streaming requests for online load)
+    without baking that convention into Planner policy.
+    """
+
+    def __init__(
+        self,
+        *,
+        pool_id: str,
+        metrics_url: str,
+        session: aiohttp.ClientSession,
+        match_labels: Mapping[str, str],
+        metric_name: str = "dynamo_frontend_requests_started_total",
+    ) -> None:
+        if not isinstance(pool_id, str) or not pool_id:
+            raise ValueError("pool_id must be non-empty")
+        if not isinstance(metrics_url, str) or not metrics_url:
+            raise ValueError("metrics_url must be non-empty")
+        if not isinstance(metric_name, str) or not metric_name:
+            raise ValueError("metric_name must be non-empty")
+        if any(
+            not isinstance(key, str)
+            or not key
+            or not isinstance(value, str)
+            or not value
+            for key, value in match_labels.items()
+        ):
+            raise ValueError("OpenMetrics match labels must be non-empty strings")
+
+        self._pool_id = pool_id
+        self._metrics_url = metrics_url
+        self._session = session
+        self._match_labels = dict(match_labels)
+        self._metric_name = metric_name
+        self._previous_counter: Optional[float] = None
+        self._previous_observed_at_s: Optional[float] = None
+
+    async def collect_online_traffic(
+        self, *, observed_at_s: float
+    ) -> list[PoolTrafficDemand]:
+        observed_at_s = _require_finite_non_negative("observed_at_s", observed_at_s)
+        payload = await _scrape_openmetrics(self._session, self._metrics_url)
+        counter = _sum_matching_metric(
+            payload,
+            metric_name=self._metric_name,
+            match_labels=self._match_labels,
+            allow_missing=True,
+        )
+
+        previous_counter = self._previous_counter
+        previous_observed_at_s = self._previous_observed_at_s
+        self._previous_counter = counter
+        self._previous_observed_at_s = observed_at_s
+
+        if previous_counter is None or previous_observed_at_s is None:
+            raise RuntimeError("online request-rate counter is warming up")
+        elapsed_s = observed_at_s - previous_observed_at_s
+        if elapsed_s <= 0:
+            raise RuntimeError("online request-rate sample time did not advance")
+        if counter < previous_counter:
+            raise RuntimeError("online request-rate counter reset")
+
+        return [
+            PoolTrafficDemand(
+                observed_at_s=observed_at_s,
+                pool_id=self._pool_id,
+                online_offered_rps=(counter - previous_counter) / elapsed_s,
+            )
+        ]
+
+
+class LlmdAsyncOpenMetricsSource:
+    """Read dispatcher state directly from llm-d Async's metrics endpoint.
+
+    This is the in-cluster counterpart to ``LlmdAsyncPrometheusSource`` for
+    environments where the central Prometheus API is not reachable from
+    workload namespaces. Availability is still strict: every configured pool
+    must expose a successful broker-backlog anchor with value exactly one.
+    """
+
+    def __init__(
+        self,
+        *,
+        pools: Sequence[str],
+        metrics_url: str,
+        session: aiohttp.ClientSession,
+    ) -> None:
+        if isinstance(pools, (str, bytes, bytearray)):
+            raise ValueError("pools must be a sequence of pool IDs, not a string")
+        pool_ids = tuple(pools)
+        if not pool_ids or any(
+            not isinstance(pool_id, str) or not pool_id for pool_id in pool_ids
+        ):
+            raise ValueError("pools must contain non-empty pool IDs")
+        if len(set(pool_ids)) != len(pool_ids):
+            raise ValueError("pool IDs must be unique")
+        if not isinstance(metrics_url, str) or not metrics_url:
+            raise ValueError("metrics_url must be non-empty")
+
+        self._pools = pool_ids
+        self._metrics_url = metrics_url
+        self._session = session
+        self._previous_dispatch_counters: dict[str, tuple[float, float]] = {}
+
+    async def collect_dispatcher_feedback(
+        self, *, observed_at_s: float
+    ) -> list[BatchDispatcherFeedback]:
+        observed_at_s = _require_finite_non_negative("observed_at_s", observed_at_s)
+        payload = await _scrape_openmetrics(self._session, self._metrics_url)
+        result = [
+            self._collect_pool(payload, pool_id, observed_at_s)
+            for pool_id in self._pools
+        ]
+        _validate_dispatcher_feedback(result)
+        return result
+
+    def _collect_pool(
+        self,
+        payload: str,
+        pool_id: str,
+        observed_at_s: float,
+    ) -> BatchDispatcherFeedback:
+        labels = {"pool_name": pool_id}
+        backlog = _sum_matching_metric(
+            payload,
+            metric_name="llm_d_async_async_broker_backlog",
+            match_labels=labels,
+            allow_missing=False,
+        )
+        availability_values = _matching_metric_values(
+            payload,
+            metric_name="llm_d_async_async_broker_backlog_source_available",
+            match_labels=labels,
+        )
+        if not availability_values or any(
+            value != 1.0 for value in availability_values
+        ):
+            raise ValueError(
+                f"broker backlog source availability for pool {pool_id!r} "
+                "must be exactly 1"
+            )
+        queue_depth = _sum_matching_metric(
+            payload,
+            metric_name="llm_d_async_async_queue_depth",
+            match_labels=labels,
+            allow_missing=True,
+        )
+        inflight = _sum_matching_metric(
+            payload,
+            metric_name="llm_d_async_async_inflight_requests",
+            match_labels=labels,
+            allow_missing=True,
+        )
+        dispatched = _sum_matching_metric(
+            payload,
+            metric_name="llm_d_async_async_dispatched_requests_total",
+            match_labels=labels,
+            allow_missing=True,
+        )
+
+        previous = self._previous_dispatch_counters.get(pool_id)
+        dispatch_rps = 0.0
+        if previous is not None:
+            previous_counter, previous_observed_at_s = previous
+            elapsed_s = observed_at_s - previous_observed_at_s
+            if elapsed_s > 0 and dispatched >= previous_counter:
+                dispatch_rps = (dispatched - previous_counter) / elapsed_s
+        self._previous_dispatch_counters[pool_id] = (dispatched, observed_at_s)
+
+        lease_valid_values = _matching_metric_values(
+            payload,
+            metric_name="llm_d_async_async_drain_limit_lease_valid",
+            match_labels=labels,
+        )
+        lease_valid = bool(lease_valid_values) and all(
+            value == 1.0 for value in lease_valid_values
+        )
+        cap_values = _matching_metric_values(
+            payload,
+            metric_name="llm_d_async_async_drain_limit_rps",
+            match_labels=labels,
+        )
+        expiry_values = _matching_metric_values(
+            payload,
+            metric_name="llm_d_async_async_drain_limit_valid_until_seconds",
+            match_labels=labels,
+        )
+        applied_cap: Optional[float] = None
+        if lease_valid and cap_values and expiry_values:
+            expiry_s = min(expiry_values)
+            if expiry_s > observed_at_s:
+                applied_cap = min(cap_values)
+
+        queued_requests = _require_integral_metric(
+            "queued_requests", backlog + queue_depth, pool_id
+        )
+        inflight_requests = _require_integral_metric(
+            "inflight_requests", inflight, pool_id
+        )
+        return BatchDispatcherFeedback(
+            observed_at_s=observed_at_s,
+            pool_id=pool_id,
+            observation_window_s=(
+                observed_at_s - previous[1]
+                if previous is not None and observed_at_s > previous[1]
+                else 1.0
+            ),
+            queued_requests=queued_requests,
+            inflight_requests=inflight_requests,
+            actual_dispatch_rps=dispatch_rps,
+            applied_max_admission_rps=applied_cap,
+        )
+
+
+class BatchSchedulingCollector:
+    """Collect independently implemented batch inputs into one observation."""
+
+    def __init__(
+        self,
+        *,
+        batch_jobs: BatchJobSource,
+        online_traffic: OnlineTrafficSource,
+        dispatcher_feedback: DispatcherFeedbackSource,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._batch_jobs = batch_jobs
+        self._online_traffic = online_traffic
+        self._dispatcher_feedback = dispatcher_feedback
+        self._clock = clock
+
+    async def collect(self) -> BatchSchedulingObservation:
+        """Sample all sources against one wall-clock timestamp.
+
+        Gateway job state is the durable demand authority, so its failure is
+        propagated. Traffic and dispatcher samples are independently optional:
+        omitting a failed sample preserves successfully observed jobs without
+        representing the missing value as zero. The policy treats a missing
+        traffic sample as a fail-closed admission pause.
+        """
+
+        observed_at_s = _require_finite_non_negative("observed_at_s", self._clock())
+        results = await asyncio.gather(
+            self._batch_jobs.collect_batch_jobs(observed_at_s=observed_at_s),
+            self._online_traffic.collect_online_traffic(observed_at_s=observed_at_s),
+            self._dispatcher_feedback.collect_dispatcher_feedback(
+                observed_at_s=observed_at_s
+            ),
+            return_exceptions=True,
+        )
+        # All sibling operations have settled before any propagation. This
+        # prevents an orphaned request from racing provider/session shutdown.
+        # Cancellation and process-control BaseExceptions are never degraded
+        # into a missing optional observation.
+        for result in results:
+            if isinstance(result, BaseException) and not isinstance(result, Exception):
+                raise result
+
+        jobs_result, traffic_result, feedback_result = results
+        if isinstance(jobs_result, BaseException):
+            raise jobs_result
+        jobs = jobs_result
+        _validate_job_demands(jobs)
+
+        traffic: Sequence[PoolTrafficDemand] = []
+        if isinstance(traffic_result, BaseException):
+            self._log_optional_source_failure("online traffic", traffic_result)
+        else:
+            try:
+                _validate_pool_traffic(traffic_result)
+            except Exception:
+                logger.exception(
+                    "Batch scheduling online traffic observation was invalid; "
+                    "continuing with the source missing"
+                )
+            else:
+                traffic = traffic_result
+
+        feedback: Sequence[BatchDispatcherFeedback] = []
+        if isinstance(feedback_result, BaseException):
+            self._log_optional_source_failure("dispatcher feedback", feedback_result)
+        else:
+            try:
+                _validate_dispatcher_feedback(feedback_result)
+            except Exception:
+                logger.exception(
+                    "Batch scheduling dispatcher feedback observation was invalid; "
+                    "continuing with the source missing"
+                )
+            else:
+                feedback = feedback_result
+
+        return BatchSchedulingObservation(
+            job_demands=list(jobs),
+            pool_traffic=list(traffic),
+            dispatcher_feedback=list(feedback),
+        )
+
+    @staticmethod
+    def _log_optional_source_failure(name: str, error: BaseException) -> None:
+        logger.warning(
+            "Batch scheduling %s observation failed; continuing with the "
+            "source missing",
+            name,
+            exc_info=(type(error), error, error.__traceback__),
+        )
+
+
+class BatchGatewayJobSource:
+    """Read batch jobs from the OpenAI-compatible Batch Gateway API.
+
+    The list endpoint contains database snapshots. For every job whose listed
+    status is nonterminal, this source retrieves ``/v1/batches/{id}`` so the
+    Gateway can merge its live Redis progress counters before Planner sees the
+    job.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        session: aiohttp.ClientSession,
+        pool_resolver: BatchResolver,
+        work_class_resolver: BatchResolver,
+        headers: Optional[Mapping[str, str]] = None,
+        page_size: int = 100,
+        max_pages: int = 10_000,
+    ) -> None:
+        if not isinstance(base_url, str):
+            raise ValueError("base_url must be a string")
+        normalized_url = base_url.rstrip("/")
+        if not normalized_url:
+            raise ValueError("base_url must be non-empty")
+        if (
+            isinstance(page_size, bool)
+            or not isinstance(page_size, int)
+            or not 1 <= page_size <= 100
+        ):
+            raise ValueError("page_size must be between 1 and 100")
+        if (
+            isinstance(max_pages, bool)
+            or not isinstance(max_pages, int)
+            or max_pages <= 0
+        ):
+            raise ValueError("max_pages must be positive")
+
+        self._base_url = normalized_url
+        self._session = session
+        self._pool_resolver = pool_resolver
+        self._work_class_resolver = work_class_resolver
+        self._headers = dict(headers or {})
+        self._page_size = page_size
+        self._max_pages = max_pages
+
+    async def collect_batch_jobs(self, *, observed_at_s: float) -> list[BatchJobDemand]:
+        observed_at_s = _require_finite_non_negative("observed_at_s", observed_at_s)
+        listed_jobs = await self._list_all_batches()
+        jobs: list[BatchJobDemand] = []
+        for listed_job in listed_jobs:
+            status = _batch_status(listed_job)
+            job = listed_job
+            if status not in _TERMINAL_BATCH_STATUSES:
+                job_id = _required_string(listed_job, "id")
+                job = await self._get_json(f"/v1/batches/{quote(job_id, safe='')}")
+                if not isinstance(job, Mapping):
+                    raise ValueError(
+                        f"batch {job_id!r} detail response must be an object"
+                    )
+                detailed_id = _required_string(job, "id")
+                if detailed_id != job_id:
+                    raise ValueError(
+                        f"batch detail ID {detailed_id!r} does not match {job_id!r}"
+                    )
+            jobs.append(self._to_job_demand(job, observed_at_s))
+
+        _validate_job_demands(jobs)
+        return jobs
+
+    async def _list_all_batches(self) -> list[Mapping[str, Any]]:
+        after = 0
+        listed_jobs: list[Mapping[str, Any]] = []
+        seen_ids: set[str] = set()
+
+        for _page_number in range(self._max_pages):
+            payload = await self._get_json(
+                "/v1/batches",
+                params={"limit": str(self._page_size), "after": str(after)},
+            )
+            if not isinstance(payload, Mapping):
+                raise ValueError("batch list response must be an object")
+            raw_jobs = payload.get("data")
+            has_more = payload.get("has_more")
+            if not isinstance(raw_jobs, list):
+                raise ValueError("batch list data must be a list")
+            if not isinstance(has_more, bool):
+                raise ValueError("batch list has_more must be a boolean")
+
+            for raw_job in raw_jobs:
+                if not isinstance(raw_job, Mapping):
+                    raise ValueError("each listed batch must be an object")
+                job_id = _required_string(raw_job, "id")
+                _batch_status(raw_job)
+                if job_id in seen_ids:
+                    raise ValueError(f"duplicate batch ID {job_id!r} across pages")
+                seen_ids.add(job_id)
+                listed_jobs.append(raw_job)
+
+            if not has_more:
+                return listed_jobs
+            if not raw_jobs:
+                raise ValueError("batch list returned has_more=true with an empty page")
+            after += len(raw_jobs)
+
+        raise ValueError(f"batch list exceeded max_pages={self._max_pages}")
+
+    async def _get_json(
+        self,
+        path: str,
+        *,
+        params: Optional[Mapping[str, str]] = None,
+    ) -> object:
+        async with self._session.get(
+            f"{self._base_url}{path}",
+            params=params,
+            headers=self._headers,
+        ) as response:
+            response.raise_for_status()
+            return await response.json()
+
+    def _to_job_demand(
+        self, job: Mapping[str, Any], observed_at_s: float
+    ) -> BatchJobDemand:
+        job_id = _required_string(job, "id")
+        status = _batch_status(job)
+        request_counts = job.get("request_counts")
+        if not isinstance(request_counts, Mapping):
+            raise ValueError(f"batch {job_id!r} request_counts must be an object")
+
+        deadline_at_s = _batch_deadline_at_s(job, context=job_id)
+        total_requests = _batch_total_requests(
+            job,
+            request_counts=request_counts,
+            status=status,
+            context=job_id,
+        )
+
+        pool_id = self._pool_resolver(job)
+        work_class = self._work_class_resolver(job)
+        if not isinstance(pool_id, str) or not pool_id:
+            raise ValueError(f"batch {job_id!r} resolved to an empty pool_id")
+        if not isinstance(work_class, str) or not work_class:
+            raise ValueError(f"batch {job_id!r} resolved to an empty work_class")
+
+        return BatchJobDemand(
+            observed_at_s=observed_at_s,
+            pool_id=pool_id,
+            job_id=job_id,
+            status=status,
+            total_requests=total_requests,
+            completed_requests=_required_non_negative_int(
+                request_counts, "completed", context=job_id
+            ),
+            failed_requests=_required_non_negative_int(
+                request_counts, "failed", context=job_id
+            ),
+            deadline_at_s=deadline_at_s,
+            work_class=work_class,
+        )
+
+
+class LlmdAsyncPrometheusSource:
+    """Collect pool-level llm-d Async feedback through Prometheus queries."""
+
+    def __init__(
+        self,
+        *,
+        pools: Sequence[str],
+        query: Union[PrometheusQuery, PrometheusQueryClient],
+        observation_window_s: int = 30,
+        max_sample_age_s: float = 60.0,
+    ) -> None:
+        if isinstance(pools, (str, bytes, bytearray)):
+            raise ValueError("pools must be a sequence of pool IDs, not a string")
+        pool_ids = tuple(pools)
+        if not pool_ids:
+            raise ValueError("at least one pool must be configured")
+        if any(not isinstance(pool_id, str) or not pool_id for pool_id in pool_ids):
+            raise ValueError("pool IDs must be non-empty strings")
+        if len(set(pool_ids)) != len(pool_ids):
+            raise ValueError("pool IDs must be unique")
+        if (
+            isinstance(observation_window_s, bool)
+            or not isinstance(observation_window_s, int)
+            or observation_window_s <= 0
+        ):
+            raise ValueError("observation_window_s must be a positive integer")
+        max_sample_age_s = _require_finite_non_negative(
+            "max_sample_age_s", max_sample_age_s
+        )
+
+        self._pools = pool_ids
+        self._observation_window_s = observation_window_s
+        self._max_sample_age_s = max_sample_age_s
+        if callable(query):
+            self._query = query
+        else:
+            self._query = query.custom_query
+
+    async def collect_dispatcher_feedback(
+        self, *, observed_at_s: float
+    ) -> list[BatchDispatcherFeedback]:
+        observed_at_s = _require_finite_non_negative("observed_at_s", observed_at_s)
+        feedback = await asyncio.gather(
+            *(self._collect_pool(pool_id, observed_at_s) for pool_id in self._pools)
+        )
+        result = list(feedback)
+        _validate_dispatcher_feedback(result)
+        return result
+
+    async def _collect_pool(
+        self, pool_id: str, observed_at_s: float
+    ) -> BatchDispatcherFeedback:
+        label = _escape_promql_label_value(pool_id)
+        selector = f'pool_name="{label}"'
+        window = f"{self._observation_window_s}s"
+
+        # Broker backlog is the pool-presence anchor and intentionally has no
+        # zero fallback. Availability is also mandatory; min() makes one failed
+        # queue/replica fail the entire pool sample. The other three activity
+        # series are absent before the first dequeue/dispatch, where zero is the
+        # only valid interpretation.
+        queued_query = (
+            "sum(max by (queue_id, queue_name, pool_name) "
+            f"(llm_d_async_async_broker_backlog{{{selector}}})) + "
+            f"(sum(llm_d_async_async_queue_depth{{{selector}}}) or vector(0))"
+        )
+        backlog_available_query = (
+            f"min(llm_d_async_async_broker_backlog_source_available{{{selector}}})"
+        )
+        # An instant-query result's sample timestamp is normally the PromQL
+        # evaluation time, even when the underlying series came from the
+        # lookback window. Put the oldest mandatory anchor's scrape age in the
+        # query value itself so a dead exporter cannot be replayed as fresh.
+        # Measuring age on the Prometheus server also avoids local/server clock
+        # skew; subtracting it from the collection timestamp is conservative.
+        sample_age_query = (
+            "time() - min(timestamp("
+            "llm_d_async_async_broker_backlog_source_available"
+            f"{{{selector}}}))"
+        )
+        inflight_query = (
+            f"(sum(llm_d_async_async_inflight_requests{{{selector}}}) or vector(0))"
+        )
+        rate_query = (
+            "(sum(rate(llm_d_async_async_dispatched_requests_total"
+            f"{{{selector}}}[{window}])) or vector(0))"
+        )
+        cap_query = f"min(llm_d_async_async_drain_limit_rps{{{selector}}})"
+        lease_query = f"min(llm_d_async_async_drain_limit_lease_valid{{{selector}}})"
+        # lease_valid is updated when the gate runs and can remain stale while
+        # an idle lease expires. Re-evaluate the published absolute expiry at
+        # Prometheus query time and require both signals below.
+        lease_unexpired_query = (
+            "min(llm_d_async_async_drain_limit_valid_until_seconds"
+            f"{{{selector}}}) > bool time()"
+        )
+
+        (
+            queued,
+            backlog_available,
+            sample_age,
+            inflight,
+            dispatch_rate,
+            cap,
+            lease_valid,
+            lease_unexpired,
+        ) = await asyncio.gather(
+            self._query_scalar(queued_query),
+            self._query_scalar(backlog_available_query),
+            self._query_scalar(sample_age_query),
+            self._query_scalar(inflight_query),
+            self._query_scalar(rate_query),
+            self._query_scalar(cap_query),
+            self._query_scalar(lease_query),
+            self._query_scalar(lease_unexpired_query),
+        )
+
+        queued_requests = _require_integral_metric("queued_requests", queued, pool_id)
+        if backlog_available != 1.0:
+            raise ValueError(
+                f"broker backlog source availability for pool {pool_id!r} "
+                "must be exactly 1"
+            )
+        sample_age = _require_finite_non_negative(
+            f"Prometheus sample age for pool {pool_id!r}", sample_age
+        )
+        if sample_age > self._max_sample_age_s:
+            raise ValueError(
+                f"Prometheus sample age for pool {pool_id!r} is {sample_age}s, "
+                f"exceeding the {self._max_sample_age_s}s maximum"
+            )
+        feedback_observed_at_s = max(0.0, observed_at_s - sample_age)
+        inflight_requests = _require_integral_metric(
+            "inflight_requests", inflight, pool_id
+        )
+        dispatch_rate = _require_finite_non_negative(
+            f"actual_dispatch_rps for pool {pool_id!r}", dispatch_rate
+        )
+        cap = _require_finite_non_negative(f"applied cap for pool {pool_id!r}", cap)
+        if lease_valid not in (0.0, 1.0):
+            raise ValueError(
+                f"lease validity for pool {pool_id!r} must be exactly 0 or 1"
+            )
+        if lease_unexpired not in (0.0, 1.0):
+            raise ValueError(
+                f"lease expiry state for pool {pool_id!r} must be exactly 0 or 1"
+            )
+        effective_lease_valid = lease_valid == 1.0 and lease_unexpired == 1.0
+
+        return BatchDispatcherFeedback(
+            observed_at_s=feedback_observed_at_s,
+            pool_id=pool_id,
+            observation_window_s=float(self._observation_window_s),
+            queued_requests=queued_requests,
+            inflight_requests=inflight_requests,
+            actual_dispatch_rps=dispatch_rate,
+            applied_max_admission_rps=cap if effective_lease_valid else None,
+        )
+
+    async def _query_scalar(self, query: str) -> float:
+        if inspect.iscoroutinefunction(self._query):
+            payload = await self._query(query)
+        else:
+            payload = await asyncio.to_thread(self._query, query)
+            if inspect.isawaitable(payload):
+                payload = await payload
+        return _parse_prometheus_scalar(payload, query=query)
+
+
+OpenMetricsSamples = dict[str, list[tuple[Mapping[str, str], float]]]
+
+
+async def _scrape_openmetrics(
+    session: aiohttp.ClientSession, metrics_url: str
+) -> OpenMetricsSamples:
+    """Fetch and parse one Prometheus/OpenMetrics exposition atomically."""
+
+    async with session.get(metrics_url) as response:
+        response.raise_for_status()
+        payload = await response.text()
+
+    samples: OpenMetricsSamples = {}
+    for family in text_string_to_metric_families(payload):
+        for sample in family.samples:
+            value = float(sample.value)
+            if not math.isfinite(value):
+                raise ValueError(f"OpenMetrics sample {sample.name!r} is not finite")
+            samples.setdefault(sample.name, []).append((dict(sample.labels), value))
+    return samples
+
+
+def _matching_metric_values(
+    samples: OpenMetricsSamples,
+    *,
+    metric_name: str,
+    match_labels: Mapping[str, str],
+) -> list[float]:
+    values = [
+        value
+        for labels, value in samples.get(metric_name, [])
+        if all(labels.get(key) == expected for key, expected in match_labels.items())
+    ]
+    if any(value < 0 for value in values):
+        raise ValueError(f"OpenMetrics sample {metric_name!r} must be non-negative")
+    return values
+
+
+def _sum_matching_metric(
+    samples: OpenMetricsSamples,
+    *,
+    metric_name: str,
+    match_labels: Mapping[str, str],
+    allow_missing: bool,
+) -> float:
+    values = _matching_metric_values(
+        samples,
+        metric_name=metric_name,
+        match_labels=match_labels,
+    )
+    if not values and not allow_missing:
+        raise ValueError(
+            f"required OpenMetrics sample {metric_name!r} was not present "
+            f"for labels {dict(match_labels)!r}"
+        )
+    return sum(values)
+
+
+def _batch_status(job: Mapping[str, Any]) -> str:
+    status = _required_string(job, "status")
+    if status not in _KNOWN_BATCH_STATUSES:
+        raise ValueError(f"batch {_job_context(job)!r} has unknown status {status!r}")
+    return status
+
+
+def _job_context(job: Mapping[str, Any]) -> str:
+    job_id = job.get("id")
+    return job_id if isinstance(job_id, str) and job_id else "<unknown>"
+
+
+def _required_string(payload: Mapping[str, Any], field_name: str) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value:
+        raise ValueError(
+            f"batch {_job_context(payload)!r} field {field_name!r} "
+            "must be a non-empty string"
+        )
+    return value
+
+
+def _required_non_negative_int(
+    payload: Mapping[str, Any], field_name: str, *, context: str
+) -> int:
+    value = payload.get(field_name)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(
+            f"batch {context!r} field {field_name!r} must be a non-negative integer"
+        )
+    return value
+
+
+def _batch_deadline_at_s(job: Mapping[str, Any], *, context: str) -> float:
+    """Resolve the best public deadline representation exposed by the Gateway."""
+
+    if job.get("expires_at") is not None:
+        expires_at_s = _required_non_negative_int64(job, "expires_at", context=context)
+        return _conservative_seconds_from_nanoseconds(
+            expires_at_s * _NANOSECONDS_PER_SECOND,
+            context=context,
+        )
+
+    created_at_s = _required_non_negative_int64(job, "created_at", context=context)
+    completion_window = job.get("completion_window")
+    if not isinstance(completion_window, str) or not completion_window:
+        raise ValueError(
+            f"batch {context!r} field 'completion_window' must be a non-empty string"
+        )
+
+    duration_ns = _parse_positive_go_duration_nanoseconds(
+        completion_window, context=context
+    )
+    deadline_ns = created_at_s * _NANOSECONDS_PER_SECOND + duration_ns
+    max_timestamp_ns = (
+        _MAX_SIGNED_INT64 * _NANOSECONDS_PER_SECOND + _NANOSECONDS_PER_SECOND - 1
+    )
+    if deadline_ns > max_timestamp_ns:
+        raise ValueError(
+            f"batch {context!r} derived deadline overflows int64 Unix time"
+        )
+    return _conservative_seconds_from_nanoseconds(deadline_ns, context=context)
+
+
+def _batch_total_requests(
+    job: Mapping[str, Any],
+    *,
+    request_counts: Mapping[str, Any],
+    status: str,
+    context: str,
+) -> int:
+    live_total = _required_non_negative_int(request_counts, "total", context=context)
+    if live_total > 0:
+        declared_total = _planner_request_count(job, context=context)
+        if declared_total is not None and declared_total != live_total:
+            raise ValueError(
+                f"batch {context!r} metadata."
+                f"{_PLANNER_REQUEST_COUNT_METADATA_KEY}={declared_total} does not "
+                f"match request_counts.total={live_total}"
+            )
+        return live_total
+
+    if status in _TERMINAL_BATCH_STATUSES:
+        return live_total
+
+    declared_total = _planner_request_count(job, context=context)
+    if declared_total is None:
+        raise ValueError(
+            f"active batch {context!r} has request_counts.total=0 and requires "
+            f"metadata.{_PLANNER_REQUEST_COUNT_METADATA_KEY}"
+        )
+    return declared_total
+
+
+def _planner_request_count(job: Mapping[str, Any], *, context: str) -> Optional[int]:
+    metadata = job.get("metadata")
+    if metadata is None:
+        return None
+    if not isinstance(metadata, Mapping):
+        raise ValueError(f"batch {context!r} metadata must be an object or null")
+    if _PLANNER_REQUEST_COUNT_METADATA_KEY not in metadata:
+        return None
+
+    raw_value = metadata[_PLANNER_REQUEST_COUNT_METADATA_KEY]
+    if (
+        not isinstance(raw_value, str)
+        or re.fullmatch(r"[1-9][0-9]*", raw_value) is None
+    ):
+        raise ValueError(
+            f"batch {context!r} metadata.{_PLANNER_REQUEST_COUNT_METADATA_KEY} "
+            "must be a canonical positive decimal string"
+        )
+    declared_total = int(raw_value)
+    if declared_total > _MAX_SIGNED_INT64:
+        raise ValueError(
+            f"batch {context!r} metadata.{_PLANNER_REQUEST_COUNT_METADATA_KEY} "
+            "exceeds signed int64"
+        )
+    return declared_total
+
+
+def _required_non_negative_int64(
+    payload: Mapping[str, Any], field_name: str, *, context: str
+) -> int:
+    value = _required_non_negative_int(payload, field_name, context=context)
+    if value > _MAX_SIGNED_INT64:
+        raise ValueError(f"batch {context!r} field {field_name!r} exceeds signed int64")
+    return value
+
+
+def _parse_positive_go_duration_nanoseconds(value: str, *, context: str) -> int:
+    """Parse the positive subset of Go's ``time.ParseDuration`` grammar."""
+
+    original_value = value
+    value = value.removeprefix("+")
+    if not value or value.startswith("-"):
+        raise ValueError(
+            f"batch {context!r} completion_window {original_value!r} "
+            "must be a positive Go duration"
+        )
+
+    total_ns = 0
+    offset = 0
+    while offset < len(value):
+        match = _GO_DURATION_COMPONENT.match(value, offset)
+        if match is None:
+            raise ValueError(
+                f"batch {context!r} completion_window {original_value!r} "
+                "must be a positive Go duration"
+            )
+
+        number = match.group("value")
+        unit_ns = _GO_DURATION_UNIT_NANOSECONDS[match.group("unit")]
+        whole_text, separator, fraction_text = number.partition(".")
+        whole = int(whole_text or "0")
+        component_ns = whole * unit_ns
+        if separator and fraction_text:
+            component_ns += int(fraction_text) * unit_ns // (10 ** len(fraction_text))
+
+        if component_ns > _MAX_SIGNED_INT64 - total_ns:
+            raise ValueError(
+                f"batch {context!r} completion_window {original_value!r} "
+                "overflows Go duration"
+            )
+        total_ns += component_ns
+        offset = match.end()
+
+    if total_ns <= 0:
+        raise ValueError(
+            f"batch {context!r} completion_window {original_value!r} "
+            "must resolve to a positive Go duration"
+        )
+    return total_ns
+
+
+def _conservative_seconds_from_nanoseconds(value_ns: int, *, context: str) -> float:
+    seconds = value_ns / _NANOSECONDS_PER_SECOND
+    if not math.isfinite(seconds):
+        raise ValueError(f"batch {context!r} deadline must be finite")
+
+    numerator, denominator = seconds.as_integer_ratio()
+    if numerator * _NANOSECONDS_PER_SECOND > value_ns * denominator:
+        seconds = math.nextafter(seconds, -math.inf)
+    if seconds < 0 or not math.isfinite(seconds):
+        raise ValueError(f"batch {context!r} deadline must be finite and non-negative")
+    return seconds
+
+
+def _escape_promql_label_value(value: str) -> str:
+    """Escape a value for a double-quoted PromQL label matcher."""
+
+    escaped: list[str] = []
+    for character in value:
+        if character == "\\":
+            escaped.append("\\\\")
+        elif character == '"':
+            escaped.append('\\"')
+        elif character == "\n":
+            escaped.append("\\n")
+        elif character == "\r":
+            escaped.append("\\r")
+        elif character == "\t":
+            escaped.append("\\t")
+        elif ord(character) < 0x20 or ord(character) == 0x7F:
+            escaped.append(f"\\x{ord(character):02x}")
+        else:
+            escaped.append(character)
+    return "".join(escaped)
+
+
+def _parse_prometheus_scalar(payload: object, *, query: str) -> float:
+    if isinstance(payload, Mapping) and "status" in payload:
+        if payload.get("status") != "success":
+            raise ValueError(f"Prometheus query failed: {query}")
+        data = payload.get("data")
+        if not isinstance(data, Mapping):
+            raise ValueError(f"Prometheus response data must be an object: {query}")
+        payload = data.get("result")
+
+    if isinstance(payload, bool):
+        raise ValueError(f"Prometheus returned a boolean instead of a scalar: {query}")
+    if isinstance(payload, (int, float)):
+        value = float(payload)
+    else:
+        if not isinstance(payload, Sequence) or isinstance(
+            payload, (str, bytes, bytearray)
+        ):
+            raise ValueError(f"Prometheus query result must be a vector: {query}")
+        if len(payload) != 1:
+            raise ValueError(
+                f"Prometheus query must return exactly one sample, got {len(payload)}: "
+                f"{query}"
+            )
+        sample = payload[0]
+        if not isinstance(sample, Mapping):
+            raise ValueError(f"Prometheus vector sample must be an object: {query}")
+        sample_value = sample.get("value")
+        if (
+            not isinstance(sample_value, Sequence)
+            or isinstance(sample_value, (str, bytes, bytearray))
+            or len(sample_value) != 2
+        ):
+            raise ValueError(f"Prometheus sample value is malformed: {query}")
+        raw_value = sample_value[1]
+        if isinstance(raw_value, bool) or not isinstance(raw_value, (str, int, float)):
+            raise ValueError(f"Prometheus sample scalar is malformed: {query}")
+        try:
+            value = float(raw_value)
+        except ValueError as exc:
+            raise ValueError(f"Prometheus sample is not numeric: {query}") from exc
+
+    if not math.isfinite(value):
+        raise ValueError(f"Prometheus sample must be finite: {query}")
+    return value
+
+
+def _require_finite_non_negative(name: str, value: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be numeric")
+    result = float(value)
+    if not math.isfinite(result) or result < 0:
+        raise ValueError(f"{name} must be finite and non-negative")
+    return result
+
+
+def _require_integral_metric(name: str, value: float, pool_id: str) -> int:
+    value = _require_finite_non_negative(f"{name} for pool {pool_id!r}", value)
+    if not value.is_integer():
+        raise ValueError(f"{name} for pool {pool_id!r} must be an integer")
+    return int(value)
+
+
+def _require_non_negative_int_value(name: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _validate_job_demands(jobs: Sequence[BatchJobDemand]) -> None:
+    seen_ids: set[str] = set()
+    for job in jobs:
+        if not isinstance(job, BatchJobDemand):
+            raise TypeError("batch job source returned a non-BatchJobDemand value")
+        _require_finite_non_negative("job observed_at_s", job.observed_at_s)
+        if any(
+            not isinstance(value, str) or not value
+            for value in (job.pool_id, job.job_id, job.work_class)
+        ):
+            raise ValueError("batch job identifiers and work_class must be non-empty")
+        if not isinstance(job.status, str) or job.status not in _KNOWN_BATCH_STATUSES:
+            raise ValueError(f"unknown batch job status {job.status!r}")
+        total_requests = _require_non_negative_int_value(
+            "batch total_requests", job.total_requests
+        )
+        completed_requests = _require_non_negative_int_value(
+            "batch completed_requests", job.completed_requests
+        )
+        failed_requests = _require_non_negative_int_value(
+            "batch failed_requests", job.failed_requests
+        )
+        if completed_requests + failed_requests > total_requests:
+            raise ValueError(
+                "batch completed_requests + failed_requests must not exceed "
+                "total_requests"
+            )
+        if job.deadline_at_s is not None:
+            _require_finite_non_negative("job deadline_at_s", job.deadline_at_s)
+        if job.job_id in seen_ids:
+            raise ValueError(f"duplicate batch job ID {job.job_id!r}")
+        seen_ids.add(job.job_id)
+
+
+def _validate_pool_traffic(traffic: Sequence[PoolTrafficDemand]) -> None:
+    seen_pools: set[str] = set()
+    for demand in traffic:
+        if not isinstance(demand, PoolTrafficDemand):
+            raise TypeError(
+                "online traffic source returned a non-PoolTrafficDemand value"
+            )
+        _require_finite_non_negative("traffic observed_at_s", demand.observed_at_s)
+        _require_finite_non_negative("online_offered_rps", demand.online_offered_rps)
+        if not isinstance(demand.pool_id, str) or not demand.pool_id:
+            raise ValueError("online traffic pool_id must be non-empty")
+        if demand.pool_id in seen_pools:
+            raise ValueError(f"duplicate online traffic pool {demand.pool_id!r}")
+        seen_pools.add(demand.pool_id)
+
+
+def _validate_dispatcher_feedback(
+    feedback: Sequence[BatchDispatcherFeedback],
+) -> None:
+    seen_pools: set[str] = set()
+    for item in feedback:
+        if not isinstance(item, BatchDispatcherFeedback):
+            raise TypeError(
+                "dispatcher source returned a non-BatchDispatcherFeedback value"
+            )
+        _require_finite_non_negative("dispatcher observed_at_s", item.observed_at_s)
+        window_s = _require_finite_non_negative(
+            "dispatcher observation_window_s", item.observation_window_s
+        )
+        if window_s <= 0:
+            raise ValueError("dispatcher observation_window_s must be positive")
+        _require_non_negative_int_value(
+            "dispatcher queued_requests", item.queued_requests
+        )
+        _require_non_negative_int_value(
+            "dispatcher inflight_requests", item.inflight_requests
+        )
+        _require_finite_non_negative(
+            "dispatcher actual_dispatch_rps", item.actual_dispatch_rps
+        )
+        if item.applied_max_admission_rps is not None:
+            _require_finite_non_negative(
+                "dispatcher applied_max_admission_rps",
+                item.applied_max_admission_rps,
+            )
+        if not isinstance(item.pool_id, str) or not item.pool_id:
+            raise ValueError("dispatcher pool_id must be non-empty")
+        if item.pool_id in seen_pools:
+            raise ValueError(f"duplicate dispatcher pool {item.pool_id!r}")
+        seen_pools.add(item.pool_id)

--- a/components/src/dynamo/planner/tests/unit/test_batch_environment.py
+++ b/components/src/dynamo/planner/tests/unit/test_batch_environment.py
@@ -1,0 +1,1194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import math
+from collections.abc import Mapping
+from typing import Any, Optional
+
+import pytest
+from dynamo.planner.core.types import (
+    BatchDispatcherFeedback,
+    BatchJobDemand,
+    PoolTrafficDemand,
+)
+from dynamo.planner.environment.batch import (
+    BatchGatewayJobSource,
+    BatchSchedulingCollector,
+    LlmdAsyncOpenMetricsSource,
+    LlmdAsyncPrometheusSource,
+    OpenMetricsOnlineTrafficSource,
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload: object) -> None:
+        self._payload = payload
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        traceback: Optional[object],
+    ) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def json(self) -> object:
+        return self._payload
+
+    async def text(self) -> str:
+        if not isinstance(self._payload, str):
+            raise TypeError("fake response payload is not text")
+        return self._payload
+
+
+class _FakeSession:
+    def __init__(
+        self, responses: Mapping[tuple[str, tuple[tuple[str, str], ...]], object]
+    ):
+        self._responses = dict(responses)
+        self.calls: list[
+            tuple[str, tuple[tuple[str, str], ...], Mapping[str, str]]
+        ] = []
+
+    def get(
+        self,
+        url: str,
+        *,
+        params: Optional[Mapping[str, str]],
+        headers: Mapping[str, str],
+    ) -> _FakeResponse:
+        normalized_params = tuple(sorted((params or {}).items()))
+        self.calls.append((url, normalized_params, dict(headers)))
+        key = (url, normalized_params)
+        if key not in self._responses:
+            raise AssertionError(f"unexpected HTTP request: {key!r}")
+        return _FakeResponse(self._responses[key])
+
+
+class _FakeOpenMetricsSession:
+    def __init__(self, payloads: list[str]) -> None:
+        self._payloads = list(payloads)
+        self.calls: list[str] = []
+
+    def get(self, url: str) -> _FakeResponse:
+        self.calls.append(url)
+        if not self._payloads:
+            raise AssertionError(f"unexpected HTTP request: {url!r}")
+        return _FakeResponse(self._payloads.pop(0))
+
+
+def _openmetrics(*samples: str) -> str:
+    return "\n".join(samples) + "\n"
+
+
+@pytest.mark.asyncio
+async def test_openmetrics_online_traffic_warms_up_then_reports_counter_rate() -> None:
+    metrics_url = "http://frontend.example/metrics"
+    session = _FakeOpenMetricsSession(
+        [
+            _openmetrics(
+                'dynamo_frontend_requests_started_total{request_type="chat",streaming="true"} 100',
+                'dynamo_frontend_requests_started_total{request_type="chat",streaming="false"} 900',
+            ),
+            _openmetrics(
+                'dynamo_frontend_requests_started_total{request_type="chat",streaming="true"} 130',
+                'dynamo_frontend_requests_started_total{request_type="chat",streaming="false"} 990',
+            ),
+        ]
+    )
+    source = OpenMetricsOnlineTrafficSource(
+        pool_id="pool-a",
+        metrics_url=metrics_url,
+        session=session,  # type: ignore[arg-type]
+        match_labels={"request_type": "chat", "streaming": "true"},
+    )
+
+    with pytest.raises(RuntimeError, match="warming up"):
+        await source.collect_online_traffic(observed_at_s=10.0)
+
+    traffic = await source.collect_online_traffic(observed_at_s=20.0)
+
+    assert traffic == [
+        PoolTrafficDemand(
+            observed_at_s=20.0,
+            pool_id="pool-a",
+            online_offered_rps=3.0,
+        )
+    ]
+    assert session.calls == [metrics_url, metrics_url]
+
+
+@pytest.mark.asyncio
+async def test_openmetrics_online_traffic_counter_reset_rewarms_baseline() -> None:
+    session = _FakeOpenMetricsSession(
+        [
+            _openmetrics("dynamo_frontend_requests_started_total 100"),
+            _openmetrics("dynamo_frontend_requests_started_total 5"),
+            _openmetrics("dynamo_frontend_requests_started_total 25"),
+        ]
+    )
+    source = OpenMetricsOnlineTrafficSource(
+        pool_id="pool-a",
+        metrics_url="http://frontend.example/metrics",
+        session=session,  # type: ignore[arg-type]
+        match_labels={},
+    )
+
+    with pytest.raises(RuntimeError, match="warming up"):
+        await source.collect_online_traffic(observed_at_s=10.0)
+    with pytest.raises(RuntimeError, match="counter reset"):
+        await source.collect_online_traffic(observed_at_s=20.0)
+
+    traffic = await source.collect_online_traffic(observed_at_s=25.0)
+
+    assert traffic[0].online_offered_rps == 4.0
+
+
+@pytest.mark.asyncio
+async def test_llmd_async_openmetrics_collects_queue_rate_and_valid_cap() -> None:
+    metrics_url = "http://llmd-async.example/metrics"
+    session = _FakeOpenMetricsSession(
+        [
+            _openmetrics(
+                'llm_d_async_async_broker_backlog{pool_name="pool-a"} 7',
+                'llm_d_async_async_broker_backlog_source_available{pool_name="pool-a"} 1',
+                'llm_d_async_async_queue_depth{pool_name="pool-a"} 3',
+                'llm_d_async_async_inflight_requests{pool_name="pool-a"} 2',
+                'llm_d_async_async_dispatched_requests_total{pool_name="pool-a"} 100',
+                'llm_d_async_async_drain_limit_lease_valid{pool_name="pool-a"} 1',
+                'llm_d_async_async_drain_limit_rps{pool_name="pool-a"} 4.5',
+                'llm_d_async_async_drain_limit_valid_until_seconds{pool_name="pool-a"} 200',
+            ),
+            _openmetrics(
+                'llm_d_async_async_broker_backlog{pool_name="pool-a"} 8',
+                'llm_d_async_async_broker_backlog_source_available{pool_name="pool-a"} 1',
+                'llm_d_async_async_queue_depth{pool_name="pool-a"} 3',
+                'llm_d_async_async_inflight_requests{pool_name="pool-a"} 4',
+                'llm_d_async_async_dispatched_requests_total{pool_name="pool-a"} 125',
+                'llm_d_async_async_drain_limit_lease_valid{pool_name="pool-a"} 1',
+                'llm_d_async_async_drain_limit_rps{pool_name="pool-a"} 6',
+                'llm_d_async_async_drain_limit_valid_until_seconds{pool_name="pool-a"} 200',
+            ),
+        ]
+    )
+    source = LlmdAsyncOpenMetricsSource(
+        pools=["pool-a"],
+        metrics_url=metrics_url,
+        session=session,  # type: ignore[arg-type]
+    )
+
+    initial = await source.collect_dispatcher_feedback(observed_at_s=100.0)
+    feedback = await source.collect_dispatcher_feedback(observed_at_s=110.0)
+
+    assert initial[0].actual_dispatch_rps == 0.0
+    assert initial[0].observation_window_s == 1.0
+    assert feedback == [
+        BatchDispatcherFeedback(
+            observed_at_s=110.0,
+            pool_id="pool-a",
+            observation_window_s=10.0,
+            queued_requests=11,
+            inflight_requests=4,
+            actual_dispatch_rps=2.5,
+            applied_max_admission_rps=6.0,
+        )
+    ]
+    assert session.calls == [metrics_url, metrics_url]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("lease_valid", "valid_until_s"),
+    [(0, 200), (1, 100)],
+)
+async def test_llmd_async_openmetrics_hides_invalid_or_expired_cap(
+    lease_valid: int,
+    valid_until_s: int,
+) -> None:
+    session = _FakeOpenMetricsSession(
+        [
+            _openmetrics(
+                'llm_d_async_async_broker_backlog{pool_name="pool-a"} 0',
+                'llm_d_async_async_broker_backlog_source_available{pool_name="pool-a"} 1',
+                f'llm_d_async_async_drain_limit_lease_valid{{pool_name="pool-a"}} {lease_valid}',
+                'llm_d_async_async_drain_limit_rps{pool_name="pool-a"} 9',
+                f'llm_d_async_async_drain_limit_valid_until_seconds{{pool_name="pool-a"}} {valid_until_s}',
+            )
+        ]
+    )
+    source = LlmdAsyncOpenMetricsSource(
+        pools=["pool-a"],
+        metrics_url="http://llmd-async.example/metrics",
+        session=session,  # type: ignore[arg-type]
+    )
+
+    feedback = await source.collect_dispatcher_feedback(observed_at_s=100.0)
+
+    assert feedback[0].applied_max_admission_rps is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        (
+            _openmetrics(
+                'llm_d_async_async_broker_backlog_source_available{pool_name="pool-a"} 1'
+            ),
+            "required OpenMetrics sample.*broker_backlog",
+        ),
+        (
+            _openmetrics(
+                'llm_d_async_async_broker_backlog{pool_name="pool-a"} 0',
+                'llm_d_async_async_broker_backlog_source_available{pool_name="pool-a"} 0',
+            ),
+            "availability.*exactly 1",
+        ),
+        (
+            _openmetrics('llm_d_async_async_broker_backlog{pool_name="pool-a"} 0'),
+            "availability.*exactly 1",
+        ),
+    ],
+)
+async def test_llmd_async_openmetrics_requires_available_broker_anchor(
+    payload: str,
+    error: str,
+) -> None:
+    source = LlmdAsyncOpenMetricsSource(
+        pools=["pool-a"],
+        metrics_url="http://llmd-async.example/metrics",
+        session=_FakeOpenMetricsSession([payload]),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ValueError, match=error):
+        await source.collect_dispatcher_feedback(observed_at_s=100.0)
+
+
+def _batch(
+    job_id: str,
+    status: str,
+    *,
+    total: int,
+    completed: int,
+    failed: int,
+    expires_at: object,
+    created_at: object = 1_000,
+    completion_window: object = "24h",
+    pool: str = "pool-a",
+    work_class: str = "chat-small",
+) -> dict[str, Any]:
+    return {
+        "id": job_id,
+        "status": status,
+        "expires_at": expires_at,
+        "created_at": created_at,
+        "completion_window": completion_window,
+        "metadata": {"pool": pool, "work_class": work_class},
+        "request_counts": {
+            "total": total,
+            "completed": completed,
+            "failed": failed,
+        },
+    }
+
+
+def _source_for_listed_batch(job: Mapping[str, Any]) -> BatchGatewayJobSource:
+    base_url = "http://batch.example"
+    responses: dict[tuple[str, tuple[tuple[str, str], ...]], object] = {
+        (
+            f"{base_url}/v1/batches",
+            (("after", "0"), ("limit", "100")),
+        ): {"data": [job], "has_more": False}
+    }
+    job_id = job.get("id")
+    if isinstance(job_id, str):
+        responses[(f"{base_url}/v1/batches/{job_id}", ())] = job
+    session = _FakeSession(responses)
+    return BatchGatewayJobSource(
+        base_url=base_url,
+        session=session,  # type: ignore[arg-type]
+        pool_resolver=lambda _job: "pool-a",
+        work_class_resolver=lambda _job: "chat",
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_gateway_paginates_and_refreshes_nonterminal_jobs() -> None:
+    base_url = "http://batch.example"
+    listed_active = _batch(
+        "batch/a b",
+        "in_progress",
+        total=10,
+        completed=1,
+        failed=0,
+        expires_at=2_000,
+    )
+    listed_terminal = _batch(
+        "batch-done",
+        "completed",
+        total=4,
+        completed=4,
+        failed=0,
+        expires_at=1_900,
+    )
+    listed_validating = _batch(
+        "batch-new",
+        "validating",
+        total=0,
+        completed=0,
+        failed=0,
+        expires_at=None,
+        pool="pool-b",
+        work_class="responses-large",
+    )
+    detailed_active = _batch(
+        "batch/a b",
+        "in_progress",
+        total=10,
+        completed=7,
+        failed=1,
+        expires_at=2_100,
+    )
+    detailed_validating = _batch(
+        "batch-new",
+        "in_progress",
+        total=8,
+        completed=2,
+        failed=0,
+        expires_at=2_200,
+        pool="pool-b",
+        work_class="responses-large",
+    )
+    responses = {
+        (
+            f"{base_url}/v1/batches",
+            (("after", "0"), ("limit", "2")),
+        ): {"data": [listed_active, listed_terminal], "has_more": True},
+        (
+            f"{base_url}/v1/batches",
+            (("after", "2"), ("limit", "2")),
+        ): {"data": [listed_validating], "has_more": False},
+        (f"{base_url}/v1/batches/batch%2Fa%20b", ()): detailed_active,
+        (f"{base_url}/v1/batches/batch-new", ()): detailed_validating,
+    }
+    session = _FakeSession(responses)
+    source = BatchGatewayJobSource(
+        base_url=f"{base_url}/",
+        session=session,  # type: ignore[arg-type]
+        pool_resolver=lambda job: job["metadata"]["pool"],
+        work_class_resolver=lambda job: job["metadata"]["work_class"],
+        headers={"Authorization": "Bearer test-only"},
+        page_size=2,
+    )
+
+    jobs = await source.collect_batch_jobs(observed_at_s=1_800.0)
+
+    assert [job.job_id for job in jobs] == [
+        "batch/a b",
+        "batch-done",
+        "batch-new",
+    ]
+    assert jobs[0].completed_requests == 7
+    assert jobs[0].failed_requests == 1
+    assert jobs[0].remaining_requests == 2
+    assert jobs[0].deadline_at_s == 2_100.0
+    assert jobs[1].completed_requests == 4
+    assert jobs[2].pool_id == "pool-b"
+    assert jobs[2].work_class == "responses-large"
+    assert jobs[2].total_requests == 8
+    requested_urls = [call[0] for call in session.calls]
+    assert requested_urls.count(f"{base_url}/v1/batches/batch-done") == 0
+    assert all(
+        headers == {"Authorization": "Bearer test-only"}
+        for _url, _params, headers in session.calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_gateway_rejects_nonprogressing_pagination() -> None:
+    base_url = "http://batch.example"
+    session = _FakeSession(
+        {
+            (
+                f"{base_url}/v1/batches",
+                (("after", "0"), ("limit", "100")),
+            ): {"data": [], "has_more": True}
+        }
+    )
+    source = BatchGatewayJobSource(
+        base_url=base_url,
+        session=session,  # type: ignore[arg-type]
+        pool_resolver=lambda _job: "pool-a",
+        work_class_resolver=lambda _job: "chat",
+    )
+
+    with pytest.raises(ValueError, match="has_more=true with an empty page"):
+        await source.collect_batch_jobs(observed_at_s=1.0)
+
+
+@pytest.mark.asyncio
+async def test_batch_gateway_rejects_unknown_status_before_using_stale_counts() -> None:
+    base_url = "http://batch.example"
+    unknown = _batch(
+        "batch-unknown",
+        "mystery",
+        total=10,
+        completed=0,
+        failed=0,
+        expires_at=None,
+    )
+    session = _FakeSession(
+        {
+            (
+                f"{base_url}/v1/batches",
+                (("after", "0"), ("limit", "100")),
+            ): {"data": [unknown], "has_more": False}
+        }
+    )
+    source = BatchGatewayJobSource(
+        base_url=base_url,
+        session=session,  # type: ignore[arg-type]
+        pool_resolver=lambda _job: "pool-a",
+        work_class_resolver=lambda _job: "chat",
+    )
+
+    with pytest.raises(ValueError, match="unknown status"):
+        await source.collect_batch_jobs(observed_at_s=1.0)
+
+
+@pytest.mark.asyncio
+async def test_batch_gateway_prefers_explicit_expiry_over_derivation_fields() -> None:
+    job = _batch(
+        "batch-explicit",
+        "completed",
+        total=1,
+        completed=1,
+        failed=0,
+        expires_at=2_000,
+        created_at=-1,
+        completion_window="not-a-duration",
+    )
+
+    jobs = await _source_for_listed_batch(job).collect_batch_jobs(observed_at_s=1.0)
+
+    assert jobs[0].deadline_at_s == 2_000.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "completion_window, duration_ns",
+    [
+        ("1h2m3s4ms5us6µs7ns", 3_723_004_011_007),
+        ("0.5h", 1_800_000_000_000),
+        ("+1.25ms", 1_250_000),
+        ("1μs", 1_000),
+        ("1.s", 1_000_000_000),
+        (".5s", 500_000_000),
+        ("1ns", 1),
+        ("2562047h47m16.854775807s", (1 << 63) - 1),
+    ],
+)
+async def test_batch_gateway_derives_expiry_from_go_duration(
+    completion_window: str, duration_ns: int
+) -> None:
+    created_at = 1
+    job = _batch(
+        "batch-derived",
+        "completed",
+        total=1,
+        completed=1,
+        failed=0,
+        expires_at=None,
+        created_at=created_at,
+        completion_window=completion_window,
+    )
+
+    jobs = await _source_for_listed_batch(job).collect_batch_jobs(observed_at_s=1.0)
+
+    expected_deadline_s = created_at + duration_ns / 1_000_000_000
+    assert jobs[0].deadline_at_s == pytest.approx(expected_deadline_s)
+    assert jobs[0].deadline_at_s <= expected_deadline_s
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "completion_window",
+    [
+        "",
+        "0",
+        "0s",
+        "0.1ns",
+        "-1s",
+        "1e3s",
+        "١s",
+        "1h 2m",
+        "24hours",
+        "2562047h47m16.854775808s",
+    ],
+)
+async def test_batch_gateway_rejects_invalid_or_nonpositive_completion_window(
+    completion_window: str,
+) -> None:
+    job = _batch(
+        "batch-invalid-window",
+        "completed",
+        total=1,
+        completed=1,
+        failed=0,
+        expires_at=None,
+        completion_window=completion_window,
+    )
+
+    with pytest.raises(ValueError, match="completion_window|Go duration"):
+        await _source_for_listed_batch(job).collect_batch_jobs(observed_at_s=1.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("created_at", [None, -1, True, "1000", 1 << 63])
+async def test_batch_gateway_rejects_invalid_created_at(created_at: object) -> None:
+    job = _batch(
+        "batch-invalid-created",
+        "completed",
+        total=1,
+        completed=1,
+        failed=0,
+        expires_at=None,
+        created_at=created_at,
+        completion_window="1h",
+    )
+
+    with pytest.raises(ValueError, match="created_at"):
+        await _source_for_listed_batch(job).collect_batch_jobs(observed_at_s=1.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("expires_at", [-1, True, "2000", 1 << 63])
+async def test_batch_gateway_rejects_invalid_explicit_expiry_without_fallback(
+    expires_at: object,
+) -> None:
+    job = _batch(
+        "batch-invalid-explicit",
+        "completed",
+        total=1,
+        completed=1,
+        failed=0,
+        expires_at=expires_at,
+        created_at=1_000,
+        completion_window="1h",
+    )
+
+    with pytest.raises(ValueError, match="expires_at"):
+        await _source_for_listed_batch(job).collect_batch_jobs(observed_at_s=1.0)
+
+
+@pytest.mark.asyncio
+async def test_batch_gateway_requires_completion_window_for_derived_expiry() -> None:
+    job = _batch(
+        "batch-missing-window",
+        "completed",
+        total=1,
+        completed=1,
+        failed=0,
+        expires_at=None,
+    )
+    del job["completion_window"]
+
+    with pytest.raises(ValueError, match="completion_window"):
+        await _source_for_listed_batch(job).collect_batch_jobs(observed_at_s=1.0)
+
+
+@pytest.mark.asyncio
+async def test_batch_gateway_rejects_derived_deadline_timestamp_overflow() -> None:
+    job = _batch(
+        "batch-overflow",
+        "completed",
+        total=1,
+        completed=1,
+        failed=0,
+        expires_at=None,
+        created_at=(1 << 63) - 1,
+        completion_window="1s",
+    )
+
+    with pytest.raises(ValueError, match="derived deadline overflows"):
+        await _source_for_listed_batch(job).collect_batch_jobs(observed_at_s=1.0)
+
+
+@pytest.mark.asyncio
+async def test_batch_gateway_uses_declared_count_while_active_total_is_zero() -> None:
+    job = _batch(
+        "batch-count-fallback",
+        "in_progress",
+        total=0,
+        completed=0,
+        failed=0,
+        expires_at=2_000,
+    )
+    job["metadata"]["planner_request_count"] = "37"
+
+    jobs = await _source_for_listed_batch(job).collect_batch_jobs(observed_at_s=1.0)
+
+    assert jobs[0].total_requests == 37
+    assert jobs[0].remaining_requests == 37
+
+
+@pytest.mark.asyncio
+async def test_batch_gateway_rejects_active_zero_total_without_declaration() -> None:
+    job = _batch(
+        "batch-count-missing",
+        "validating",
+        total=0,
+        completed=0,
+        failed=0,
+        expires_at=2_000,
+    )
+
+    with pytest.raises(ValueError, match="total=0.*planner_request_count"):
+        await _source_for_listed_batch(job).collect_batch_jobs(observed_at_s=1.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "declaration",
+    ["0", "-1", "+1", "01", " 1", "1.0", 1, True, None, str(1 << 63)],
+)
+async def test_batch_gateway_rejects_invalid_planner_request_count(
+    declaration: object,
+) -> None:
+    job = _batch(
+        "batch-count-invalid",
+        "in_progress",
+        total=0,
+        completed=0,
+        failed=0,
+        expires_at=2_000,
+    )
+    job["metadata"]["planner_request_count"] = declaration
+
+    with pytest.raises(ValueError, match="planner_request_count"):
+        await _source_for_listed_batch(job).collect_batch_jobs(observed_at_s=1.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["in_progress", "completed"])
+async def test_batch_gateway_rejects_declared_and_live_count_mismatch(
+    status: str,
+) -> None:
+    job = _batch(
+        "batch-count-mismatch",
+        status,
+        total=36,
+        completed=1,
+        failed=0,
+        expires_at=2_000,
+    )
+    job["metadata"]["planner_request_count"] = "37"
+
+    with pytest.raises(ValueError, match="does not match.*total=36"):
+        await _source_for_listed_batch(job).collect_batch_jobs(observed_at_s=1.0)
+
+
+@pytest.mark.asyncio
+async def test_batch_gateway_accepts_matching_declared_and_live_count() -> None:
+    job = _batch(
+        "batch-count-match",
+        "in_progress",
+        total=37,
+        completed=1,
+        failed=0,
+        expires_at=2_000,
+    )
+    job["metadata"]["planner_request_count"] = "37"
+
+    jobs = await _source_for_listed_batch(job).collect_batch_jobs(observed_at_s=1.0)
+
+    assert jobs[0].total_requests == 37
+    assert jobs[0].remaining_requests == 36
+
+
+class _JobSource:
+    def __init__(self, jobs: list[BatchJobDemand]) -> None:
+        self.jobs = jobs
+        self.observed_at_s: Optional[float] = None
+
+    async def collect_batch_jobs(self, *, observed_at_s: float) -> list[BatchJobDemand]:
+        self.observed_at_s = observed_at_s
+        return self.jobs
+
+
+class _TrafficSource:
+    def __init__(self, traffic: list[PoolTrafficDemand]) -> None:
+        self.traffic = traffic
+        self.observed_at_s: Optional[float] = None
+
+    async def collect_online_traffic(
+        self, *, observed_at_s: float
+    ) -> list[PoolTrafficDemand]:
+        self.observed_at_s = observed_at_s
+        return self.traffic
+
+
+class _FeedbackSource:
+    def __init__(self, feedback: list[BatchDispatcherFeedback]) -> None:
+        self.feedback = feedback
+        self.observed_at_s: Optional[float] = None
+
+    async def collect_dispatcher_feedback(
+        self, *, observed_at_s: float
+    ) -> list[BatchDispatcherFeedback]:
+        self.observed_at_s = observed_at_s
+        return self.feedback
+
+
+class _FailingSource:
+    def __init__(self, error: BaseException) -> None:
+        self.error = error
+
+    async def collect_batch_jobs(self, *, observed_at_s: float) -> list[BatchJobDemand]:
+        raise self.error
+
+    async def collect_online_traffic(
+        self, *, observed_at_s: float
+    ) -> list[PoolTrafficDemand]:
+        raise self.error
+
+    async def collect_dispatcher_feedback(
+        self, *, observed_at_s: float
+    ) -> list[BatchDispatcherFeedback]:
+        raise self.error
+
+
+def _valid_active_job(*, observed_at_s: float = 1.0) -> BatchJobDemand:
+    return BatchJobDemand(
+        observed_at_s=observed_at_s,
+        pool_id="pool-a",
+        job_id="job-a",
+        status="in_progress",
+        total_requests=10,
+        completed_requests=3,
+        failed_requests=1,
+        deadline_at_s=2_000.0,
+        work_class="chat",
+    )
+
+
+@pytest.mark.asyncio
+async def test_composite_collector_uses_one_sample_timestamp() -> None:
+    observed_at_s = 1_234.5
+    job_source = _JobSource(
+        [
+            BatchJobDemand(
+                observed_at_s=observed_at_s,
+                pool_id="pool-a",
+                job_id="job-a",
+                status="in_progress",
+                total_requests=10,
+                completed_requests=3,
+                failed_requests=1,
+                deadline_at_s=2_000.0,
+                work_class="chat",
+            )
+        ]
+    )
+    traffic_source = _TrafficSource(
+        [
+            PoolTrafficDemand(
+                observed_at_s=observed_at_s,
+                pool_id="pool-a",
+                online_offered_rps=5.0,
+            )
+        ]
+    )
+    feedback_source = _FeedbackSource(
+        [
+            BatchDispatcherFeedback(
+                observed_at_s=observed_at_s,
+                pool_id="pool-a",
+                observation_window_s=30.0,
+                queued_requests=6,
+                inflight_requests=2,
+                actual_dispatch_rps=1.5,
+                applied_max_admission_rps=2.0,
+            )
+        ]
+    )
+    collector = BatchSchedulingCollector(
+        batch_jobs=job_source,
+        online_traffic=traffic_source,
+        dispatcher_feedback=feedback_source,
+        clock=lambda: observed_at_s,
+    )
+
+    observation = await collector.collect()
+
+    assert job_source.observed_at_s == observed_at_s
+    assert traffic_source.observed_at_s == observed_at_s
+    assert feedback_source.observed_at_s == observed_at_s
+    assert observation.job_demands == job_source.jobs
+    assert observation.pool_traffic == traffic_source.traffic
+    assert observation.dispatcher_feedback == feedback_source.feedback
+
+
+@pytest.mark.asyncio
+async def test_composite_collector_omits_invalid_optional_traffic() -> None:
+    traffic = PoolTrafficDemand(
+        observed_at_s=1.0,
+        pool_id="pool-a",
+        online_offered_rps=1.0,
+    )
+    traffic.online_offered_rps = math.nan
+    job = _valid_active_job()
+    collector = BatchSchedulingCollector(
+        batch_jobs=_JobSource([job]),
+        online_traffic=_TrafficSource([traffic]),
+        dispatcher_feedback=_FeedbackSource([]),
+        clock=lambda: 1.0,
+    )
+
+    observation = await collector.collect()
+
+    assert observation.job_demands == [job]
+    assert observation.pool_traffic == []
+
+
+@pytest.mark.asyncio
+async def test_composite_collector_preserves_jobs_when_traffic_fails() -> None:
+    job = _valid_active_job()
+    feedback = BatchDispatcherFeedback(
+        observed_at_s=1.0,
+        pool_id="pool-a",
+        observation_window_s=10.0,
+        queued_requests=6,
+        inflight_requests=2,
+        actual_dispatch_rps=1.5,
+        applied_max_admission_rps=2.0,
+    )
+    collector = BatchSchedulingCollector(
+        batch_jobs=_JobSource([job]),
+        online_traffic=_FailingSource(RuntimeError("traffic unavailable")),
+        dispatcher_feedback=_FeedbackSource([feedback]),
+        clock=lambda: 1.0,
+    )
+
+    observation = await collector.collect()
+
+    assert observation.job_demands == [job]
+    assert observation.pool_traffic == []
+    assert observation.dispatcher_feedback == [feedback]
+
+
+@pytest.mark.asyncio
+async def test_composite_collector_preserves_jobs_and_traffic_when_feedback_fails() -> (
+    None
+):
+    job = _valid_active_job()
+    traffic = PoolTrafficDemand(
+        observed_at_s=1.0,
+        pool_id="pool-a",
+        online_offered_rps=0.0,
+    )
+    collector = BatchSchedulingCollector(
+        batch_jobs=_JobSource([job]),
+        online_traffic=_TrafficSource([traffic]),
+        dispatcher_feedback=_FailingSource(RuntimeError("feedback unavailable")),
+        clock=lambda: 1.0,
+    )
+
+    observation = await collector.collect()
+
+    assert observation.job_demands == [job]
+    assert observation.pool_traffic == [traffic]
+    assert observation.dispatcher_feedback == []
+
+
+@pytest.mark.asyncio
+async def test_composite_collector_propagates_gateway_failure() -> None:
+    collector = BatchSchedulingCollector(
+        batch_jobs=_FailingSource(RuntimeError("gateway unavailable")),
+        online_traffic=_TrafficSource([]),
+        dispatcher_feedback=_FeedbackSource([]),
+        clock=lambda: 1.0,
+    )
+
+    with pytest.raises(RuntimeError, match="gateway unavailable"):
+        await collector.collect()
+
+
+@pytest.mark.asyncio
+async def test_composite_collector_does_not_degrade_cancellation() -> None:
+    collector = BatchSchedulingCollector(
+        batch_jobs=_JobSource([]),
+        online_traffic=_FailingSource(asyncio.CancelledError()),
+        dispatcher_feedback=_FeedbackSource([]),
+        clock=lambda: 1.0,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await collector.collect()
+
+
+@pytest.mark.asyncio
+async def test_composite_collector_revalidates_mutated_contract_objects() -> None:
+    job = BatchJobDemand(
+        observed_at_s=1.0,
+        pool_id="pool-a",
+        job_id="job-a",
+        status="in_progress",
+        total_requests=10,
+        completed_requests=3,
+        failed_requests=1,
+        deadline_at_s=2_000.0,
+        work_class="chat",
+    )
+    job.completed_requests = 11
+    collector = BatchSchedulingCollector(
+        batch_jobs=_JobSource([job]),
+        online_traffic=_TrafficSource([]),
+        dispatcher_feedback=_FeedbackSource([]),
+        clock=lambda: 1.0,
+    )
+
+    with pytest.raises(ValueError, match="must not exceed"):
+        await collector.collect()
+
+
+def _prometheus_vector(value: object) -> list[dict[str, object]]:
+    return [{"metric": {}, "value": [1_234.0, value]}]
+
+
+@pytest.mark.asyncio
+async def test_llmd_async_prometheus_source_collects_and_escapes_pool() -> None:
+    pool_id = 'batch"\\\n\t'
+    queries: list[str] = []
+
+    async def query(promql: str) -> object:
+        queries.append(promql)
+        if "timestamp(" in promql:
+            return _prometheus_vector("2")
+        if "broker_backlog_source_available" in promql:
+            return _prometheus_vector("1")
+        if "broker_backlog" in promql:
+            return _prometheus_vector("11")
+        if "inflight_requests" in promql:
+            return _prometheus_vector("3")
+        if "dispatched_requests_total" in promql:
+            return _prometheus_vector("2.75")
+        if "drain_limit_rps" in promql:
+            return _prometheus_vector("4.5")
+        if "drain_limit_lease_valid" in promql:
+            return _prometheus_vector("1")
+        if "drain_limit_valid_until_seconds" in promql:
+            return _prometheus_vector("1")
+        raise AssertionError(f"unexpected query: {promql}")
+
+    source = LlmdAsyncPrometheusSource(
+        pools=[pool_id],
+        query=query,
+        observation_window_s=45,
+        max_sample_age_s=5,
+    )
+
+    feedback = await source.collect_dispatcher_feedback(observed_at_s=1_234.0)
+
+    assert feedback == [
+        BatchDispatcherFeedback(
+            observed_at_s=1_232.0,
+            pool_id=pool_id,
+            observation_window_s=45.0,
+            queued_requests=11,
+            inflight_requests=3,
+            actual_dispatch_rps=2.75,
+            applied_max_admission_rps=4.5,
+        )
+    ]
+    assert len(queries) == 8
+    escaped_selector = 'pool_name="batch\\"\\\\\\n\\t"'
+    assert all(escaped_selector in promql for promql in queries)
+    assert any("[45s]" in promql for promql in queries)
+    queued_query = next(
+        promql
+        for promql in queries
+        if "broker_backlog" in promql
+        and "broker_backlog_source_available" not in promql
+    )
+    assert "max by (queue_id, queue_name, pool_name)" in queued_query
+    assert "async_queue_depth" in queued_query
+    assert "async_broker_backlog" in queued_query.split("or vector(0)")[0]
+    assert "or vector(0)" in queued_query
+    availability_query = next(
+        promql
+        for promql in queries
+        if "broker_backlog_source_available" in promql and "timestamp(" not in promql
+    )
+    assert availability_query.startswith("min(")
+    assert "or vector(0)" not in availability_query
+    sample_age_query = next(promql for promql in queries if "timestamp(" in promql)
+    assert "time() - min(timestamp(" in sample_age_query
+    assert all(
+        "or vector(0)" in promql
+        for promql in queries
+        if "inflight_requests" in promql or "dispatched_requests_total" in promql
+    )
+    expiry_query = next(
+        promql for promql in queries if "drain_limit_valid_until_seconds" in promql
+    )
+    assert "> bool time()" in expiry_query
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "lease_valid, lease_unexpired",
+    [(0.0, 1.0), (1.0, 0.0)],
+)
+async def test_llmd_async_prometheus_source_maps_invalid_lease_to_unreported_cap(
+    lease_valid: float, lease_unexpired: float
+) -> None:
+    async def query(promql: str) -> object:
+        if "timestamp(" in promql:
+            return 0.25
+        if "broker_backlog_source_available" in promql:
+            return 1.0
+        if "broker_backlog" in promql:
+            return 0.0
+        if "inflight_requests" in promql:
+            return 0.0
+        if "dispatched_requests_total" in promql:
+            return 0.0
+        if "drain_limit_rps" in promql:
+            return 9.0
+        if "drain_limit_lease_valid" in promql:
+            return lease_valid
+        if "drain_limit_valid_until_seconds" in promql:
+            return lease_unexpired
+        raise AssertionError(f"unexpected query: {promql}")
+
+    source = LlmdAsyncPrometheusSource(pools=["pool-a"], query=query)
+
+    feedback = await source.collect_dispatcher_feedback(observed_at_s=1.0)
+
+    assert feedback[0].applied_max_admission_rps is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("availability", [0.0, []])
+async def test_llmd_async_prometheus_source_requires_backlog_availability(
+    availability: object,
+) -> None:
+    async def query(promql: str) -> object:
+        if "broker_backlog_source_available" in promql:
+            return availability
+        if "drain_limit_lease_valid" in promql:
+            return 1.0
+        if "drain_limit_valid_until_seconds" in promql:
+            return 1.0
+        return 0.0
+
+    source = LlmdAsyncPrometheusSource(pools=["pool-a"], query=query)
+
+    with pytest.raises(ValueError, match="availability|exactly one sample"):
+        await source.collect_dispatcher_feedback(observed_at_s=1.0)
+
+
+@pytest.mark.asyncio
+async def test_llmd_async_prometheus_source_accepts_sync_client_envelopes() -> None:
+    class _PrometheusClient:
+        def custom_query(self, promql: str) -> object:
+            if "timestamp(" in promql:
+                value = "0.25"
+            elif "drain_limit_lease_valid" in promql:
+                value = "1"
+            elif "drain_limit_valid_until_seconds" in promql:
+                value = "1"
+            elif "drain_limit_rps" in promql:
+                value = "2.5"
+            elif "broker_backlog_source_available" in promql:
+                value = "1"
+            elif "broker_backlog" in promql:
+                value = "7"
+            elif "inflight_requests" in promql:
+                value = "2"
+            elif "dispatched_requests_total" in promql:
+                value = "1.25"
+            else:
+                raise AssertionError(f"unexpected query: {promql}")
+            return {
+                "status": "success",
+                "data": {"result": _prometheus_vector(value)},
+            }
+
+    source = LlmdAsyncPrometheusSource(pools=["pool-a"], query=_PrometheusClient())
+
+    feedback = await source.collect_dispatcher_feedback(observed_at_s=1.0)
+
+    assert feedback[0].queued_requests == 7
+    assert feedback[0].inflight_requests == 2
+    assert feedback[0].actual_dispatch_rps == 1.25
+    assert feedback[0].applied_max_admission_rps == 2.5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sample_age", "error"),
+    [
+        (-0.1, "non-negative"),
+        (60.1, "exceeding"),
+        ([], "exactly one sample"),
+    ],
+)
+async def test_llmd_async_prometheus_source_rejects_untrustworthy_sample_age(
+    sample_age: object,
+    error: str,
+) -> None:
+    async def query(promql: str) -> object:
+        if "timestamp(" in promql:
+            return sample_age
+        if "broker_backlog_source_available" in promql:
+            return 1.0
+        if "drain_limit_lease_valid" in promql:
+            return 0.0
+        if "drain_limit_valid_until_seconds" in promql:
+            return 0.0
+        return 0.0
+
+    source = LlmdAsyncPrometheusSource(
+        pools=["pool-a"], query=query, max_sample_age_s=60.0
+    )
+
+    with pytest.raises(ValueError, match=error):
+        await source.collect_dispatcher_feedback(observed_at_s=1_234.0)
+
+
+@pytest.mark.asyncio
+async def test_llmd_async_prometheus_source_fails_on_missing_or_fractional_counts() -> (
+    None
+):
+    async def missing_query(_promql: str) -> object:
+        return []
+
+    missing_source = LlmdAsyncPrometheusSource(pools=["pool-a"], query=missing_query)
+    with pytest.raises(ValueError, match="exactly one sample"):
+        await missing_source.collect_dispatcher_feedback(observed_at_s=1.0)
+
+    async def fractional_query(promql: str) -> object:
+        if "broker_backlog_source_available" in promql:
+            return 1.0
+        if "broker_backlog" in promql:
+            return 1.5
+        if "drain_limit_lease_valid" in promql:
+            return 1.0
+        return 0.0
+
+    fractional_source = LlmdAsyncPrometheusSource(
+        pools=["pool-a"], query=fractional_query
+    )
+    with pytest.raises(ValueError, match="queued_requests.*integer"):
+        await fractional_source.collect_dispatcher_feedback(observed_at_s=1.0)


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This adds production-shaped sources for Batch Gateway demand, online traffic, and llm-d Async dispatcher feedback. It keeps durable job state authoritative while representing unavailable optional telemetry as missing data so policy can pause safely instead of inventing zeroes.

CLOSES: LLM-186

### How This Was Implemented
- Define narrow source protocols and a concurrent collector that samples all inputs against one timestamp.
- Page Batch Gateway jobs, refresh nonterminal job details, derive deadlines from explicit expiry or Go-style completion windows, and validate bootstrap request-count metadata.
- Derive online offered RPS from strict frontend OpenMetrics counter deltas with warm-up and reset handling.
- Read Async backlog, queue, in-flight, dispatch-rate, and leased-cap state from direct OpenMetrics or a Prometheus query API.
- Propagate durable Gateway failures while degrading invalid traffic or dispatcher samples to explicitly missing observations.

<details>
<summary>Walkthrough</summary>

- `environment/batch.py::BatchGatewayJobSource` normalizes durable job state and rejects ambiguous status, pagination, deadline, and count data.
- `OpenMetricsOnlineTrafficSource` computes online rate only from consecutive trustworthy counter samples.
- `LlmdAsyncOpenMetricsSource` and `LlmdAsyncPrometheusSource` validate queue cardinality, source availability, sample age, and lease validity.
- `BatchSchedulingCollector` waits for sibling collection tasks to settle, preserves jobs across optional-source failures, and never degrades cancellation.
- `tests/unit/test_batch_environment.py` covers source parsing, staleness, resets, pagination, metadata handoff, and partial-observation behavior.

</details>

### Validation
- Full stacked-head Planner sweep: 478 relevant tests passed, including the batch environment/source suite.
- Planner lint, formatting, and Python compilation passed.
<!-- codex-pr-description:end -->
