### PR TITLE
feat(planner): add leased batch runtime

### DIFF
--- a/components/src/dynamo/planner/core/planner_factory.py
+++ b/components/src/dynamo/planner/core/planner_factory.py
@@ -11,6 +11,7 @@ from dynamo.planner.connectors.global_planner import GlobalPlannerConnector
 from dynamo.planner.connectors.kubernetes import KubernetesConnector
 from dynamo.planner.connectors.virtual import VirtualConnector
 from dynamo.planner.environment.base import PlannerEnvironmentImpl
+from dynamo.planner.environment.batch_runtime import NativeBatchSchedulingProvider
 from dynamo.planner.environment.interface import PlannerEnvironment
 from dynamo.planner.environment.metrics_provider.prometheus_traffic_provider import (
     PrometheusTrafficProvider,
@@ -99,6 +100,11 @@ def construct_environment(
         controller=connector,
         require_prefill=require_prefill,
         require_decode=require_decode,
+        batch_provider=(
+            NativeBatchSchedulingProvider(config.batch_scheduling)
+            if config.batch_scheduling.enabled
+            else None
+        ),
     )
 
     namespace_binding: Optional[RuntimeNamespaceBinding] = None

--- a/components/src/dynamo/planner/environment/base.py
+++ b/components/src/dynamo/planner/environment/base.py
@@ -12,8 +12,14 @@ from dynamo.planner.config.defaults import SubComponentType, TargetReplica
 from dynamo.planner.config.planner_config import PlannerConfig
 from dynamo.planner.connectors.base import PlannerConnector, is_power_aware_connector
 from dynamo.planner.core.budget import minimum_power_footprint_fits
-from dynamo.planner.core.types import FpmObservations, TrafficObservation
+from dynamo.planner.core.types import (
+    BatchDrainLimitDecision,
+    BatchSchedulingObservation,
+    FpmObservations,
+    TrafficObservation,
+)
 from dynamo.planner.environment.interface import (
+    BatchSchedulingProvider,
     PlannerEnvironment,
     RuntimeNamespaceSource,
 )
@@ -67,6 +73,25 @@ class NoopFpmMetricsProvider:
         return None
 
 
+class NoopBatchSchedulingProvider:
+    """Disabled-state provider that rejects accidental batch actuation."""
+
+    async def initialize(self) -> None:
+        return None
+
+    async def collect(self) -> BatchSchedulingObservation:
+        raise RuntimeError("batch scheduling is not configured")
+
+    async def apply_drain_limits(
+        self, decisions: list[BatchDrainLimitDecision]
+    ) -> None:
+        if decisions:
+            raise RuntimeError("batch drain actuation is not configured")
+
+    async def shutdown(self) -> None:
+        return None
+
+
 class PlannerEnvironmentImpl(PlannerEnvironment):
     """Default environment facade consumed by planner core."""
 
@@ -79,6 +104,7 @@ class PlannerEnvironmentImpl(PlannerEnvironment):
         require_decode: bool,
         traffic_provider: Optional[TrafficMetricsProvider] = None,
         fpm_provider: Optional[FpmMetricsProvider] = None,
+        batch_provider: Optional[BatchSchedulingProvider] = None,
         runtime_namespace_source: Optional[RuntimeNamespaceSource] = None,
     ) -> None:
         self.config = config
@@ -87,6 +113,7 @@ class PlannerEnvironmentImpl(PlannerEnvironment):
         self.controller = controller
         self.traffic_provider = traffic_provider or NoopTrafficMetricsProvider()
         self.fpm_provider = fpm_provider or NoopFpmMetricsProvider()
+        self.batch_provider = batch_provider or NoopBatchSchedulingProvider()
         self.runtime_namespace_source = runtime_namespace_source
         self._state = DeploymentState()
         self._metrics_state = Metrics()
@@ -127,6 +154,7 @@ class PlannerEnvironmentImpl(PlannerEnvironment):
         # of the shared-GET path above.
         await self.fpm_provider.async_init(self._runtime_namespace_or_none())
         await self._refresh_deployment_state()
+        await self.batch_provider.initialize()
 
     async def refresh(self) -> DeploymentState:
         namespace_changed = False
@@ -165,13 +193,24 @@ class PlannerEnvironmentImpl(PlannerEnvironment):
     def collect_fpm(self) -> FpmObservations:
         return self.fpm_provider.collect_fpm()
 
+    async def collect_batch_scheduling(self) -> BatchSchedulingObservation:
+        return await self.batch_provider.collect()
+
     async def apply_scaling(
         self, targets: list[TargetReplica], blocking: bool = False
     ) -> None:
         await self.controller.set_component_replicas(targets, blocking=blocking)
 
+    async def apply_batch_drain_limits(
+        self, decisions: list[BatchDrainLimitDecision]
+    ) -> None:
+        await self.batch_provider.apply_drain_limits(decisions)
+
     async def shutdown(self) -> None:
-        await self.fpm_provider.shutdown()
+        try:
+            await self.batch_provider.shutdown()
+        finally:
+            await self.fpm_provider.shutdown()
 
     async def _refresh_deployment_state(
         self, deployment: Optional[dict] = None

--- a/components/src/dynamo/planner/environment/batch.py
+++ b/components/src/dynamo/planner/environment/batch.py
@@ -11,6 +11,7 @@ HTTP, OpenMetrics, Prometheus, and Redis clients.
 from __future__ import annotations
 
 import asyncio
+import importlib
 import inspect
 import logging
 import math
@@ -23,6 +24,7 @@ from urllib.parse import quote
 import aiohttp
 from dynamo.planner.core.types import (
     BatchDispatcherFeedback,
+    BatchDrainLimitDecision,
     BatchJobDemand,
     BatchSchedulingObservation,
     PoolTrafficDemand,
@@ -34,13 +36,18 @@ __all__ = [
     "BatchJobSource",
     "BatchResolver",
     "BatchSchedulingCollector",
+    "DISPATCH_RATE_LIMIT_API_VERSION",
     "DispatcherFeedbackSource",
+    "DrainLimitActuator",
     "LlmdAsyncPrometheusSource",
     "LlmdAsyncOpenMetricsSource",
     "OpenMetricsOnlineTrafficSource",
     "OnlineTrafficSource",
     "PrometheusQueryClient",
+    "RedisLeasedDrainLimitActuator",
 ]
+
+DISPATCH_RATE_LIMIT_API_VERSION = "llm-d.ai/v1alpha1"
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +66,7 @@ _KNOWN_BATCH_STATUSES = frozenset(
 _TERMINAL_BATCH_STATUSES = frozenset({"completed", "failed", "expired", "cancelled"})
 _PLANNER_REQUEST_COUNT_METADATA_KEY = "planner_request_count"
 _MAX_SIGNED_INT64 = (1 << 63) - 1
+_MAX_UNIX_MILLIS = (1 << 63) - 1
 _NANOSECONDS_PER_SECOND = 1_000_000_000
 _GO_DURATION_COMPONENT = re.compile(
     r"(?P<value>(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+))" r"(?P<unit>ns|us|µs|μs|ms|s|m|h)"
@@ -99,10 +107,39 @@ class DispatcherFeedbackSource(Protocol):
     ) -> list[BatchDispatcherFeedback]: ...
 
 
+class DrainLimitActuator(Protocol):
+    """Apply one leased batch-admission decision."""
+
+    async def apply_drain_limit(self, decision: BatchDrainLimitDecision) -> None: ...
+
+
 class PrometheusQueryClient(Protocol):
     """Subset of a Prometheus client used by the dispatcher source."""
 
     def custom_query(self, query: str) -> object: ...
+
+
+class _AsyncRedisPipeline(Protocol):
+    def hset(self, key: str, *, mapping: Mapping[str, str]) -> _AsyncRedisPipeline: ...
+
+    def pexpireat(self, key: str, when: int) -> _AsyncRedisPipeline: ...
+
+    async def execute(self) -> Sequence[object]: ...
+
+    async def __aenter__(self) -> _AsyncRedisPipeline: ...
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        traceback: Optional[object],
+    ) -> Optional[bool]: ...
+
+
+class _AsyncRedisClient(Protocol):
+    def pipeline(self, *, transaction: bool = True) -> _AsyncRedisPipeline: ...
+
+    async def aclose(self) -> None: ...
 
 
 BatchResolver = Callable[[Mapping[str, Any]], str]
@@ -757,6 +794,89 @@ class LlmdAsyncPrometheusSource:
         return _parse_prometheus_scalar(payload, query=query)
 
 
+class RedisLeasedDrainLimitActuator:
+    """Atomically publish llm-d Async leased drain limits to Redis."""
+
+    def __init__(
+        self,
+        *,
+        client: _AsyncRedisClient,
+        control_key_resolver: Callable[[str], str],
+        clock: Callable[[], float] = time.time,
+        owns_client: bool = False,
+    ) -> None:
+        self._client = client
+        self._control_key_resolver = control_key_resolver
+        self._clock = clock
+        self._owns_client = owns_client
+
+    @classmethod
+    def from_url(
+        cls,
+        redis_url: str,
+        *,
+        control_key_resolver: Callable[[str], str],
+        clock: Callable[[], float] = time.time,
+        **redis_options: object,
+    ) -> RedisLeasedDrainLimitActuator:
+        """Create an actuator while keeping ``redis`` an optional dependency."""
+
+        if not isinstance(redis_url, str) or not redis_url:
+            raise ValueError("redis_url must be non-empty")
+        redis_asyncio = importlib.import_module("redis.asyncio")
+        client = redis_asyncio.from_url(redis_url, **redis_options)
+        return cls(
+            client=client,
+            control_key_resolver=control_key_resolver,
+            clock=clock,
+            owns_client=True,
+        )
+
+    async def apply_drain_limit(self, decision: BatchDrainLimitDecision) -> None:
+        now_s = _require_finite_non_negative("current time", self._clock())
+        _validate_drain_decision(decision, now_s=now_s)
+
+        valid_until_unix_ms = math.floor(decision.valid_until_s * 1000.0)
+        now_unix_ms = math.floor(now_s * 1000.0)
+        if valid_until_unix_ms <= now_unix_ms:
+            raise ValueError(
+                "drain-limit lease must expire after the current millisecond"
+            )
+        if valid_until_unix_ms > _MAX_UNIX_MILLIS:
+            raise ValueError(
+                "drain-limit lease exceeds the Redis/llm-d timestamp range"
+            )
+
+        control_key = self._control_key_resolver(decision.pool_id)
+        if not isinstance(control_key, str) or not control_key:
+            raise ValueError("control_key_resolver must return a non-empty string")
+
+        fields = {
+            "api_version": DISPATCH_RATE_LIMIT_API_VERSION,
+            "pool_id": decision.pool_id,
+            "max_admission_rps": format(decision.max_admission_rps, ".17g"),
+            "valid_until_unix_ms": str(valid_until_unix_ms),
+            "decision_id": decision.decision_id,
+        }
+        async with self._client.pipeline(transaction=True) as pipeline:
+            pipeline.hset(control_key, mapping=fields)
+            pipeline.pexpireat(control_key, valid_until_unix_ms)
+            results = await pipeline.execute()
+
+        if len(results) != 2:
+            raise RuntimeError(
+                f"Redis transaction returned {len(results)} results; expected 2"
+            )
+        if not results[1]:
+            raise RuntimeError("Redis did not apply the drain-limit key expiry")
+
+    async def aclose(self) -> None:
+        """Close the Redis client only when it was created by ``from_url``."""
+
+        if self._owns_client:
+            await self._client.aclose()
+
+
 OpenMetricsSamples = dict[str, list[tuple[Mapping[str, str], float]]]
 
 
@@ -1177,3 +1297,22 @@ def _validate_dispatcher_feedback(
         if item.pool_id in seen_pools:
             raise ValueError(f"duplicate dispatcher pool {item.pool_id!r}")
         seen_pools.add(item.pool_id)
+
+
+def _validate_drain_decision(
+    decision: BatchDrainLimitDecision, *, now_s: float
+) -> None:
+    if not isinstance(decision, BatchDrainLimitDecision):
+        raise TypeError("decision must be a BatchDrainLimitDecision")
+    if not isinstance(decision.pool_id, str) or not decision.pool_id:
+        raise ValueError("drain-limit pool_id must be non-empty")
+    if not isinstance(decision.decision_id, str) or not decision.decision_id:
+        raise ValueError("drain-limit decision_id must be non-empty")
+    _require_finite_non_negative(
+        "drain-limit max_admission_rps", decision.max_admission_rps
+    )
+    valid_until_s = _require_finite_non_negative(
+        "drain-limit valid_until_s", decision.valid_until_s
+    )
+    if valid_until_s <= now_s:
+        raise ValueError("drain-limit lease has expired")

--- a/components/src/dynamo/planner/environment/batch_runtime.py
+++ b/components/src/dynamo/planner/environment/batch_runtime.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lifecycle owner for native single-pool batch scheduling I/O."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING, Optional
+
+import aiohttp
+from dynamo.planner.core.types import (
+    BatchDrainLimitDecision,
+    BatchSchedulingObservation,
+)
+from dynamo.planner.environment.batch import (
+    BatchGatewayJobSource,
+    BatchSchedulingCollector,
+    LlmdAsyncOpenMetricsSource,
+    OpenMetricsOnlineTrafficSource,
+    RedisLeasedDrainLimitActuator,
+)
+
+if TYPE_CHECKING:
+    from dynamo.planner.config.planner_config import BatchSchedulingConfig
+
+logger = logging.getLogger(__name__)
+
+
+class NativeBatchSchedulingProvider:
+    """Own HTTP/Redis clients for the native Planner batch tick path.
+
+    Construction is side-effect free so ``construct_environment`` remains a
+    synchronous dependency-composition root. Network clients are created in
+    ``initialize`` and released idempotently in ``shutdown``. A best-effort
+    zero-rate lease on shutdown prevents planned termination from leaving a
+    positive admission decision alive until TTL expiry.
+    """
+
+    def __init__(self, config: BatchSchedulingConfig) -> None:
+        if not config.enabled:
+            raise ValueError("NativeBatchSchedulingProvider requires enabled config")
+        self._config = config
+        self._gateway_session: Optional[aiohttp.ClientSession] = None
+        self._metrics_session: Optional[aiohttp.ClientSession] = None
+        self._collector: Optional[BatchSchedulingCollector] = None
+        self._actuator: Optional[RedisLeasedDrainLimitActuator] = None
+        self._initialized = False
+        self._shutdown = False
+
+    async def initialize(self) -> None:
+        if self._initialized:
+            return
+        if self._shutdown:
+            raise RuntimeError("batch scheduling provider was already shut down")
+
+        cfg = self._config
+        assert cfg.gateway is not None
+        assert cfg.metrics is not None
+        assert cfg.redis is not None
+        assert cfg.pool is not None
+
+        try:
+            self._gateway_session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=cfg.gateway.request_timeout_seconds)
+            )
+            self._metrics_session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=cfg.metrics.request_timeout_seconds)
+            )
+            jobs = BatchGatewayJobSource(
+                base_url=cfg.gateway.base_url,
+                session=self._gateway_session,
+                pool_resolver=lambda _job: cfg.pool.pool_id,
+                work_class_resolver=lambda _job: cfg.pool.work_class,
+                headers={"X-MaaS-Username": cfg.gateway.tenant},
+                page_size=cfg.gateway.page_size,
+                max_pages=cfg.gateway.max_pages,
+            )
+            online = OpenMetricsOnlineTrafficSource(
+                pool_id=cfg.pool.pool_id,
+                metrics_url=cfg.metrics.frontend_metrics_url,
+                session=self._metrics_session,
+                match_labels=cfg.metrics.online_match_labels,
+            )
+            feedback = LlmdAsyncOpenMetricsSource(
+                pools=[cfg.pool.pool_id],
+                metrics_url=cfg.metrics.dispatcher_metrics_url,
+                session=self._metrics_session,
+            )
+            self._collector = BatchSchedulingCollector(
+                batch_jobs=jobs,
+                online_traffic=online,
+                dispatcher_feedback=feedback,
+            )
+
+            redis_url = cfg.redis.url
+            get_secret_value = getattr(redis_url, "get_secret_value", None)
+            if callable(get_secret_value):
+                redis_url = get_secret_value()
+            self._actuator = RedisLeasedDrainLimitActuator.from_url(
+                str(redis_url),
+                control_key_resolver=self._control_key_for_pool,
+                decode_responses=True,
+                socket_connect_timeout=cfg.redis.connect_timeout_seconds,
+                socket_timeout=cfg.redis.socket_timeout_seconds,
+            )
+            self._initialized = True
+        except BaseException:
+            await self._close_resources(publish_pause=False)
+            raise
+
+    async def collect(self) -> BatchSchedulingObservation:
+        if not self._initialized or self._collector is None:
+            raise RuntimeError("batch scheduling provider is not initialized")
+        return await self._collector.collect()
+
+    async def apply_drain_limits(
+        self, decisions: list[BatchDrainLimitDecision]
+    ) -> None:
+        if not self._initialized or self._actuator is None:
+            raise RuntimeError("batch scheduling provider is not initialized")
+        if len(decisions) != 1:
+            raise ValueError(
+                "single-pool batch scheduling requires exactly one drain decision"
+            )
+        await self._actuator.apply_drain_limit(decisions[0])
+
+    async def shutdown(self) -> None:
+        if self._shutdown:
+            return
+        self._shutdown = True
+        await self._close_resources(publish_pause=self._initialized)
+
+    def _control_key_for_pool(self, pool_id: str) -> str:
+        pool = self._config.pool
+        redis = self._config.redis
+        assert pool is not None and redis is not None
+        if pool_id != pool.pool_id:
+            raise ValueError(
+                f"drain decision targeted unexpected pool {pool_id!r}; "
+                f"configured pool is {pool.pool_id!r}"
+            )
+        return redis.control_key
+
+    async def _close_resources(self, *, publish_pause: bool) -> None:
+        actuator = self._actuator
+        self._actuator = None
+        self._collector = None
+        self._initialized = False
+
+        cancellation: Optional[asyncio.CancelledError] = None
+        try:
+            if publish_pause and actuator is not None:
+                pool = self._config.pool
+                assert pool is not None
+                now_s = time.time()
+                pause = BatchDrainLimitDecision(
+                    pool_id=pool.pool_id,
+                    max_admission_rps=0.0,
+                    valid_until_s=now_s + pool.drain_lease_duration_seconds,
+                    decision_id=f"planner-shutdown-{time.time_ns()}",
+                )
+                await asyncio.wait_for(
+                    actuator.apply_drain_limit(pause),
+                    timeout=max(
+                        1.0,
+                        self._config.redis.connect_timeout_seconds
+                        + self._config.redis.socket_timeout_seconds,
+                    ),
+                )
+        except asyncio.CancelledError as exc:
+            cancellation = exc
+        except Exception:
+            if publish_pause:
+                logger.exception(
+                    "Failed to publish zero batch-drain lease during shutdown; "
+                    "the existing Redis lease will expire by TTL"
+                )
+        try:
+            if actuator is not None:
+                await actuator.aclose()
+        finally:
+            gateway_session = self._gateway_session
+            metrics_session = self._metrics_session
+            self._gateway_session = None
+            self._metrics_session = None
+            try:
+                if gateway_session is not None:
+                    await gateway_session.close()
+            finally:
+                if metrics_session is not None:
+                    await metrics_session.close()
+        if cancellation is not None:
+            raise cancellation
+
+
+__all__ = ["NativeBatchSchedulingProvider"]

--- a/components/src/dynamo/planner/environment/interface.py
+++ b/components/src/dynamo/planner/environment/interface.py
@@ -13,7 +13,12 @@ from __future__ import annotations
 from typing import Optional, Protocol
 
 from dynamo.planner.config.defaults import TargetReplica
-from dynamo.planner.core.types import FpmObservations, TrafficObservation
+from dynamo.planner.core.types import (
+    BatchDrainLimitDecision,
+    BatchSchedulingObservation,
+    FpmObservations,
+    TrafficObservation,
+)
 from dynamo.planner.environment.state import DeploymentState
 from dynamo.planner.monitoring.traffic_metrics import Metrics
 
@@ -29,6 +34,24 @@ class RuntimeNamespaceSource(Protocol):
 
     async def refresh_runtime_namespace(self) -> bool:
         """Return True when runtime-backed providers should rebind."""
+        pass
+
+
+class BatchSchedulingProvider(Protocol):
+    """Lifecycle-owned batch observation and actuation boundary."""
+
+    async def initialize(self) -> None:
+        pass
+
+    async def collect(self) -> BatchSchedulingObservation:
+        pass
+
+    async def apply_drain_limits(
+        self, decisions: list[BatchDrainLimitDecision]
+    ) -> None:
+        pass
+
+    async def shutdown(self) -> None:
         pass
 
 
@@ -62,8 +85,16 @@ class PlannerEnvironment(Protocol):
     def collect_fpm(self) -> FpmObservations:
         pass
 
+    async def collect_batch_scheduling(self) -> BatchSchedulingObservation:
+        pass
+
     async def apply_scaling(
         self, targets: list[TargetReplica], blocking: bool = False
+    ) -> None:
+        pass
+
+    async def apply_batch_drain_limits(
+        self, decisions: list[BatchDrainLimitDecision]
     ) -> None:
         pass
 

--- a/components/src/dynamo/planner/tests/unit/test_batch_environment.py
+++ b/components/src/dynamo/planner/tests/unit/test_batch_environment.py
@@ -11,15 +11,18 @@ from typing import Any, Optional
 import pytest
 from dynamo.planner.core.types import (
     BatchDispatcherFeedback,
+    BatchDrainLimitDecision,
     BatchJobDemand,
     PoolTrafficDemand,
 )
+from dynamo.planner.environment import batch as batch_environment
 from dynamo.planner.environment.batch import (
     BatchGatewayJobSource,
     BatchSchedulingCollector,
     LlmdAsyncOpenMetricsSource,
     LlmdAsyncPrometheusSource,
     OpenMetricsOnlineTrafficSource,
+    RedisLeasedDrainLimitActuator,
 )
 
 
@@ -1192,3 +1195,157 @@ async def test_llmd_async_prometheus_source_fails_on_missing_or_fractional_count
     )
     with pytest.raises(ValueError, match="queued_requests.*integer"):
         await fractional_source.collect_dispatcher_feedback(observed_at_s=1.0)
+
+
+class _FakeRedisPipeline:
+    def __init__(self, execute_results: Optional[list[object]] = None) -> None:
+        self.commands: list[tuple[object, ...]] = []
+        self.execute_results = execute_results or [5, True]
+        self.execute_count = 0
+
+    async def __aenter__(self) -> _FakeRedisPipeline:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        traceback: Optional[object],
+    ) -> None:
+        return None
+
+    def hset(self, key: str, *, mapping: Mapping[str, str]) -> _FakeRedisPipeline:
+        self.commands.append(("hset", key, dict(mapping)))
+        return self
+
+    def pexpireat(self, key: str, when: int) -> _FakeRedisPipeline:
+        self.commands.append(("pexpireat", key, when))
+        return self
+
+    async def execute(self) -> list[object]:
+        self.execute_count += 1
+        return self.execute_results
+
+
+class _FakeRedis:
+    def __init__(self, pipeline: Optional[_FakeRedisPipeline] = None) -> None:
+        self.fake_pipeline = pipeline or _FakeRedisPipeline()
+        self.transaction_values: list[bool] = []
+        self.closed = False
+
+    def pipeline(self, *, transaction: bool = True) -> _FakeRedisPipeline:
+        self.transaction_values.append(transaction)
+        return self.fake_pipeline
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_redis_actuator_atomically_sets_hash_and_absolute_expiry() -> None:
+    redis = _FakeRedis()
+    actuator = RedisLeasedDrainLimitActuator(
+        client=redis,
+        control_key_resolver=lambda pool_id: f"planner:drain:{pool_id}",
+        clock=lambda: 1_000.0,
+    )
+    decision = BatchDrainLimitDecision(
+        pool_id="pool-a",
+        max_admission_rps=0.0,
+        valid_until_s=1_030.1259,
+        decision_id="decision-7",
+    )
+
+    await actuator.apply_drain_limit(decision)
+
+    assert redis.transaction_values == [True]
+    assert redis.fake_pipeline.execute_count == 1
+    assert redis.fake_pipeline.commands == [
+        (
+            "hset",
+            "planner:drain:pool-a",
+            {
+                "api_version": "llm-d.ai/v1alpha1",
+                "pool_id": "pool-a",
+                "max_admission_rps": "0",
+                "valid_until_unix_ms": "1030125",
+                "decision_id": "decision-7",
+            },
+        ),
+        ("pexpireat", "planner:drain:pool-a", 1_030_125),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "field_name, invalid_value, error",
+    [
+        ("pool_id", "", "pool_id"),
+        ("max_admission_rps", math.nan, "max_admission_rps"),
+        ("valid_until_s", 999.0, "expired"),
+        ("decision_id", "", "decision_id"),
+    ],
+)
+async def test_redis_actuator_rejects_invalid_decisions_before_writing(
+    field_name: str, invalid_value: object, error: str
+) -> None:
+    decision = BatchDrainLimitDecision("pool-a", 1.0, 2_000.0, "decision")
+    setattr(decision, field_name, invalid_value)
+    redis = _FakeRedis()
+    actuator = RedisLeasedDrainLimitActuator(
+        client=redis,
+        control_key_resolver=lambda pool_id: pool_id,
+        clock=lambda: 1_000.0,
+    )
+
+    with pytest.raises(ValueError, match=error):
+        await actuator.apply_drain_limit(decision)
+
+    assert redis.transaction_values == []
+
+
+@pytest.mark.asyncio
+async def test_redis_actuator_fails_if_expiry_was_not_applied() -> None:
+    redis = _FakeRedis(_FakeRedisPipeline([5, False]))
+    actuator = RedisLeasedDrainLimitActuator(
+        client=redis,
+        control_key_resolver=lambda pool_id: pool_id,
+        clock=lambda: 1_000.0,
+    )
+
+    with pytest.raises(RuntimeError, match="did not apply"):
+        await actuator.apply_drain_limit(
+            BatchDrainLimitDecision("pool-a", 1.0, 2_000.0, "decision")
+        )
+
+
+@pytest.mark.asyncio
+async def test_redis_from_url_is_lazy_and_owns_created_client(monkeypatch) -> None:
+    redis = _FakeRedis()
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    class _FakeRedisModule:
+        @staticmethod
+        def from_url(redis_url: str, **options: object) -> _FakeRedis:
+            calls.append((redis_url, options))
+            return redis
+
+    monkeypatch.setattr(
+        batch_environment.importlib,
+        "import_module",
+        lambda module_name: (
+            _FakeRedisModule
+            if module_name == "redis.asyncio"
+            else pytest.fail(f"unexpected import: {module_name}")
+        ),
+    )
+    actuator = RedisLeasedDrainLimitActuator.from_url(
+        "redis://redis.example/0",
+        control_key_resolver=lambda pool_id: pool_id,
+        decode_responses=True,
+    )
+
+    await actuator.aclose()
+
+    assert calls == [("redis://redis.example/0", {"decode_responses": True})]
+    assert redis.closed is True

--- a/components/src/dynamo/planner/tests/unit/test_batch_runtime.py
+++ b/components/src/dynamo/planner/tests/unit/test_batch_runtime.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lifecycle tests for the native single-pool batch scheduling provider."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from dynamo.planner.config.planner_config import BatchSchedulingConfig
+from dynamo.planner.core.types import (
+    BatchDrainLimitDecision,
+    BatchSchedulingObservation,
+)
+from dynamo.planner.environment import batch_runtime
+from dynamo.planner.environment.batch_runtime import NativeBatchSchedulingProvider
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+def _config() -> BatchSchedulingConfig:
+    return BatchSchedulingConfig.model_validate(
+        {
+            "enabled": True,
+            "gateway": {
+                "base_url": "http://batch-gateway:8000/",
+                "tenant": "planner-poc",
+                "request_timeout_seconds": 7.0,
+                "page_size": 50,
+                "max_pages": 12,
+            },
+            "metrics": {
+                "frontend_metrics_url": "http://frontend:8000/metrics",
+                "dispatcher_metrics_url": "http://llm-d-async:9090/metrics",
+                "online_match_labels": {
+                    "request_type": "chat",
+                    "streaming": "true",
+                },
+                "request_timeout_seconds": 3.0,
+            },
+            "redis": {
+                "url": "redis://batch-gateway-valkey:6379/0",
+                "control_key": "llm-d-async:drain-limit:dynamo-batch",
+                "connect_timeout_seconds": 1.5,
+                "socket_timeout_seconds": 2.5,
+            },
+            "pool": {
+                "pool_id": "dynamo-batch",
+                "work_class": "gsm8k-128",
+                "safe_rps_per_ready_replica": 10.0,
+                "drain_lease_duration_seconds": 60.0,
+                "max_replicas": 8,
+            },
+        }
+    )
+
+
+def _session() -> MagicMock:
+    session = MagicMock()
+    session.close = AsyncMock()
+    return session
+
+
+def _actuator() -> MagicMock:
+    actuator = MagicMock()
+    actuator.apply_drain_limit = AsyncMock()
+    actuator.aclose = AsyncMock()
+    return actuator
+
+
+@dataclass
+class _InitializedProvider:
+    provider: NativeBatchSchedulingProvider
+    gateway_session: MagicMock
+    metrics_session: MagicMock
+    session_constructor: MagicMock
+    actuator: MagicMock
+    actuator_factory: MagicMock
+
+
+async def _initialize_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> _InitializedProvider:
+    gateway_session = _session()
+    metrics_session = _session()
+    session_constructor = MagicMock(side_effect=[gateway_session, metrics_session])
+    actuator = _actuator()
+    actuator_factory = MagicMock(return_value=actuator)
+    monkeypatch.setattr(
+        batch_runtime.aiohttp,
+        "ClientSession",
+        session_constructor,
+    )
+    monkeypatch.setattr(
+        batch_runtime.RedisLeasedDrainLimitActuator,
+        "from_url",
+        actuator_factory,
+    )
+
+    provider = NativeBatchSchedulingProvider(_config())
+    await provider.initialize()
+    return _InitializedProvider(
+        provider=provider,
+        gateway_session=gateway_session,
+        metrics_session=metrics_session,
+        session_constructor=session_constructor,
+        actuator=actuator,
+        actuator_factory=actuator_factory,
+    )
+
+
+@pytest.mark.asyncio
+async def test_construction_is_side_effect_free_and_uninitialized_calls_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_constructor = MagicMock()
+    actuator_factory = MagicMock()
+    monkeypatch.setattr(
+        batch_runtime.aiohttp,
+        "ClientSession",
+        session_constructor,
+    )
+    monkeypatch.setattr(
+        batch_runtime.RedisLeasedDrainLimitActuator,
+        "from_url",
+        actuator_factory,
+    )
+
+    provider = NativeBatchSchedulingProvider(_config())
+
+    session_constructor.assert_not_called()
+    actuator_factory.assert_not_called()
+    assert provider._gateway_session is None
+    assert provider._metrics_session is None
+    assert provider._collector is None
+    assert provider._actuator is None
+    with pytest.raises(RuntimeError, match="not initialized"):
+        await provider.collect()
+    with pytest.raises(RuntimeError, match="not initialized"):
+        await provider.apply_drain_limits([])
+
+
+def test_construction_rejects_disabled_config() -> None:
+    with pytest.raises(ValueError, match="requires enabled config"):
+        NativeBatchSchedulingProvider(BatchSchedulingConfig())
+
+
+@pytest.mark.asyncio
+async def test_initialize_composes_real_sources_and_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = await _initialize_provider(monkeypatch)
+    provider = runtime.provider
+    config = provider._config
+    assert config.gateway is not None
+    assert config.metrics is not None
+    assert config.redis is not None
+    assert config.pool is not None
+
+    await provider.initialize()
+
+    assert runtime.session_constructor.call_count == 2
+    gateway_timeout = runtime.session_constructor.call_args_list[0].kwargs["timeout"]
+    metrics_timeout = runtime.session_constructor.call_args_list[1].kwargs["timeout"]
+    assert gateway_timeout.total == config.gateway.request_timeout_seconds
+    assert metrics_timeout.total == config.metrics.request_timeout_seconds
+
+    collector = provider._collector
+    assert collector is not None
+    jobs = collector._batch_jobs
+    assert jobs._base_url == config.gateway.base_url.rstrip("/")
+    assert jobs._session is runtime.gateway_session
+    assert jobs._headers == {"X-MaaS-Username": config.gateway.tenant}
+    assert jobs._page_size == config.gateway.page_size
+    assert jobs._max_pages == config.gateway.max_pages
+    assert jobs._pool_resolver({}) == config.pool.pool_id
+    assert jobs._work_class_resolver({}) == config.pool.work_class
+
+    online = collector._online_traffic
+    assert online._pool_id == config.pool.pool_id
+    assert online._metrics_url == config.metrics.frontend_metrics_url
+    assert online._session is runtime.metrics_session
+    assert online._match_labels == config.metrics.online_match_labels
+
+    feedback = collector._dispatcher_feedback
+    assert feedback._pools == (config.pool.pool_id,)
+    assert feedback._metrics_url == config.metrics.dispatcher_metrics_url
+    assert feedback._session is runtime.metrics_session
+
+    runtime.actuator_factory.assert_called_once()
+    call = runtime.actuator_factory.call_args
+    assert call.args == (config.redis.url.get_secret_value(),)
+    assert call.kwargs["decode_responses"] is True
+    assert call.kwargs["socket_connect_timeout"] == config.redis.connect_timeout_seconds
+    assert call.kwargs["socket_timeout"] == config.redis.socket_timeout_seconds
+    assert provider._actuator is runtime.actuator
+
+
+@pytest.mark.asyncio
+async def test_collect_and_actuation_require_exactly_one_decision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = await _initialize_provider(monkeypatch)
+    observation = BatchSchedulingObservation()
+    collector = MagicMock()
+    collector.collect = AsyncMock(return_value=observation)
+    runtime.provider._collector = collector
+    decision = BatchDrainLimitDecision(
+        pool_id="dynamo-batch",
+        max_admission_rps=4.0,
+        valid_until_s=200.0,
+        decision_id="decision-1",
+    )
+
+    assert await runtime.provider.collect() is observation
+    await runtime.provider.apply_drain_limits([decision])
+
+    collector.collect.assert_awaited_once_with()
+    runtime.actuator.apply_drain_limit.assert_awaited_once_with(decision)
+    with pytest.raises(ValueError, match="exactly one"):
+        await runtime.provider.apply_drain_limits([])
+    with pytest.raises(ValueError, match="exactly one"):
+        await runtime.provider.apply_drain_limits([decision, decision])
+    runtime.actuator.apply_drain_limit.assert_awaited_once_with(decision)
+
+
+@pytest.mark.asyncio
+async def test_redis_control_key_resolver_rejects_wrong_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = await _initialize_provider(monkeypatch)
+    config = runtime.provider._config
+    assert config.redis is not None
+    resolver = runtime.actuator_factory.call_args.kwargs["control_key_resolver"]
+
+    assert resolver("dynamo-batch") == config.redis.control_key
+    with pytest.raises(ValueError, match="unexpected pool"):
+        resolver("another-pool")
+
+
+@pytest.mark.asyncio
+async def test_shutdown_publishes_zero_lease_closes_resources_and_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = await _initialize_provider(monkeypatch)
+    clock = MagicMock()
+    clock.time.return_value = 100.0
+    clock.time_ns.return_value = 123456789
+    monkeypatch.setattr(batch_runtime, "time", clock)
+
+    await runtime.provider.shutdown()
+    await runtime.provider.shutdown()
+
+    runtime.actuator.apply_drain_limit.assert_awaited_once()
+    pause = runtime.actuator.apply_drain_limit.await_args.args[0]
+    assert pause == BatchDrainLimitDecision(
+        pool_id="dynamo-batch",
+        max_admission_rps=0.0,
+        valid_until_s=160.0,
+        decision_id="planner-shutdown-123456789",
+    )
+    runtime.actuator.aclose.assert_awaited_once_with()
+    runtime.gateway_session.close.assert_awaited_once_with()
+    runtime.metrics_session.close.assert_awaited_once_with()
+    assert runtime.provider._collector is None
+    assert runtime.provider._actuator is None
+    assert runtime.provider._gateway_session is None
+    assert runtime.provider._metrics_session is None
+
+
+@pytest.mark.asyncio
+async def test_shutdown_pause_is_best_effort_but_resources_still_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = await _initialize_provider(monkeypatch)
+    runtime.actuator.apply_drain_limit.side_effect = RuntimeError("redis unavailable")
+
+    await runtime.provider.shutdown()
+
+    runtime.actuator.apply_drain_limit.assert_awaited_once()
+    runtime.actuator.aclose.assert_awaited_once_with()
+    runtime.gateway_session.close.assert_awaited_once_with()
+    runtime.metrics_session.close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_metrics_session_initialization_failure_closes_gateway_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway_session = _session()
+    session_constructor = MagicMock(
+        side_effect=[gateway_session, RuntimeError("metrics session failed")]
+    )
+    actuator_factory = MagicMock()
+    monkeypatch.setattr(
+        batch_runtime.aiohttp,
+        "ClientSession",
+        session_constructor,
+    )
+    monkeypatch.setattr(
+        batch_runtime.RedisLeasedDrainLimitActuator,
+        "from_url",
+        actuator_factory,
+    )
+    provider = NativeBatchSchedulingProvider(_config())
+
+    with pytest.raises(RuntimeError, match="metrics session failed"):
+        await provider.initialize()
+
+    gateway_session.close.assert_awaited_once_with()
+    actuator_factory.assert_not_called()
+    assert provider._gateway_session is None
+    assert provider._metrics_session is None
+    assert provider._collector is None
+    assert provider._actuator is None
+    assert provider._initialized is False
+
+
+@pytest.mark.asyncio
+async def test_redis_initialization_failure_closes_both_http_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway_session = _session()
+    metrics_session = _session()
+    session_constructor = MagicMock(side_effect=[gateway_session, metrics_session])
+    actuator_factory = MagicMock(side_effect=RuntimeError("redis init failed"))
+    monkeypatch.setattr(
+        batch_runtime.aiohttp,
+        "ClientSession",
+        session_constructor,
+    )
+    monkeypatch.setattr(
+        batch_runtime.RedisLeasedDrainLimitActuator,
+        "from_url",
+        actuator_factory,
+    )
+    provider = NativeBatchSchedulingProvider(_config())
+
+    with pytest.raises(RuntimeError, match="redis init failed"):
+        await provider.initialize()
+
+    gateway_session.close.assert_awaited_once_with()
+    metrics_session.close.assert_awaited_once_with()
+    assert provider._gateway_session is None
+    assert provider._metrics_session is None
+    assert provider._collector is None
+    assert provider._actuator is None
+    assert provider._initialized is False

--- a/components/src/dynamo/planner/tests/unit/test_environment.py
+++ b/components/src/dynamo/planner/tests/unit/test_environment.py
@@ -4,8 +4,11 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from dynamo.planner.config.planner_config import PlannerConfig
+from dynamo.planner.core.types import (
+    BatchDrainLimitDecision,
+    BatchSchedulingObservation,
+)
 from dynamo.planner.environment.base import PlannerEnvironmentImpl
 from dynamo.planner.errors import DeploymentValidationError
 from dynamo.planner.monitoring.worker_info import (
@@ -56,6 +59,15 @@ def _fpm_provider() -> MagicMock:
     return provider
 
 
+def _batch_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.initialize = AsyncMock()
+    provider.collect = AsyncMock(return_value=BatchSchedulingObservation())
+    provider.apply_drain_limits = AsyncMock()
+    provider.shutdown = AsyncMock()
+    return provider
+
+
 @pytest.mark.asyncio
 async def test_initialize_uses_backend_names_and_resolves_namespace_before_state():
     order = []
@@ -96,6 +108,41 @@ async def test_initialize_uses_backend_names_and_resolves_namespace_before_state
     assert order.index("ready") < order.index("namespace") < order.index("gpu")
     assert order.index("gpu") < order.index("fpm:base-ns-workerhash")
     fpm_provider.async_init.assert_awaited_once_with("base-ns-workerhash")
+
+
+@pytest.mark.asyncio
+async def test_batch_provider_lifecycle_collection_and_actuation_are_delegated():
+    controller = _controller()
+    fpm_provider = _fpm_provider()
+    batch_provider = _batch_provider()
+    environment = PlannerEnvironmentImpl(
+        config=_config(),
+        controller=controller,
+        require_prefill=True,
+        require_decode=True,
+        fpm_provider=fpm_provider,
+        batch_provider=batch_provider,
+    )
+
+    await environment.initialize()
+    observation = await environment.collect_batch_scheduling()
+    decisions = [
+        BatchDrainLimitDecision(
+            pool_id="pool",
+            max_admission_rps=0.0,
+            valid_until_s=100.0,
+            decision_id="decision",
+        )
+    ]
+    await environment.apply_batch_drain_limits(decisions)
+    await environment.shutdown()
+
+    assert observation == BatchSchedulingObservation()
+    batch_provider.initialize.assert_awaited_once_with()
+    batch_provider.collect.assert_awaited_once_with()
+    batch_provider.apply_drain_limits.assert_awaited_once_with(decisions)
+    batch_provider.shutdown.assert_awaited_once_with()
+    fpm_provider.shutdown.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -22,5 +22,6 @@ pmdarima==2.1.1
 prometheus-api-client==0.6.0
 prophet==1.2.1
 protobuf>=5.29.5,<7.0.0
+redis>=5.0,<7.0
 scikit-learn==1.7.2
 scipy>=1.14.0,<2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "transformers>=4.56.0",
     "kubernetes>=32.0.1,<33.0.0",
     "prometheus_client>=0.23.1,<1.0",
+    "redis>=5.0,<7.0",
     "msgspec>=0.19.0",
     "zstandard>=0.23.0,<1.0",
     "pyzmq>=26.0.0",


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This connects Planner's batch observation and drain-decision interfaces to lifecycle-owned HTTP and Redis clients. It gives the native environment a bounded, fail-closed actuation path while keeping construction side-effect free and disabled deployments unchanged.

CLOSES: LLM-187

### How This Was Implemented
- Add an atomic Redis actuator that writes the versioned llm-d Async lease hash and absolute expiry in one transaction.
- Compose Batch Gateway, frontend metrics, Async metrics, and Redis clients in an opt-in native provider.
- Initialize and close provider resources through the normal Planner environment lifecycle, including a best-effort zero-rate shutdown lease.
- Enforce the configured pool and control key and require exactly one single-pool drain decision per actuation.
- Add a rejecting no-op provider for disabled configurations and declare the Redis runtime dependency.

<details>
<summary>Walkthrough</summary>

- `environment/batch.py::RedisLeasedDrainLimitActuator` validates decisions and atomically applies hash fields plus `PEXPIREAT`.
- `environment/batch_runtime.py` owns client creation, collection, actuation, cleanup, and shutdown-pause behavior.
- `environment/interface.py` and `environment/base.py` expose batch collection and actuation through the existing environment boundary.
- `core/planner_factory.py` installs the native provider only when batch scheduling is enabled.
- `tests/unit/test_batch_environment.py`, `test_batch_runtime.py`, and `test_environment.py` cover transaction shape, ownership, initialization failures, cleanup, and disabled behavior.

</details>

### Validation
- Full stacked-head Planner sweep: 478 relevant tests passed, including Redis actuation, batch runtime, and environment lifecycle coverage.
- The deployed Planner image passed an in-image import and batch-policy smoke test before rollout.
<!-- codex-pr-description:end -->
