### PR TITLE
feat(batch): deploy the Planner scheduling POC

### DIFF
--- a/examples/deployments/llm-d-batch-gateway/batch-gateway-values.yaml
+++ b/examples/deployments/llm-d-batch-gateway/batch-gateway-values.yaml
@@ -15,6 +15,14 @@
 
 global:
   secretName: batch-gateway-secrets
+  # The API server and processor share the filesystem-backed batch store.
+  # Match the chart images' non-root group so both pods can write the same PVC.
+  podSecurityContext:
+    fsGroup: 65532
+    fsGroupChangePolicy: OnRootMismatch
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   dbClient:
     type: redis
   fileClient:

--- a/examples/deployments/llm-d-batch-gateway/dynamo.yaml
+++ b/examples/deployments/llm-d-batch-gateway/dynamo.yaml
@@ -22,6 +22,7 @@ spec:
     - name: Frontend
       type: frontend
       replicas: 1
+      minAvailable: 1
       podTemplate:
         spec:
           containers:
@@ -36,15 +37,30 @@ spec:
                 - round-robin
                 - --http-port
                 - "8000"
+              env:
+                - name: HF_HOME
+                  value: /model-store/huggingface
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              volumeMounts:
+                - name: model-cache
+                  mountPath: /model-store
               workingDir: /workspace
               resources:
                 requests:
                   cpu: "1"
                 limits:
                   cpu: "2"
+          volumes:
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
     - name: VllmDecodeWorker
       type: worker
       replicas: 1
+      minAvailable: 1
+      scalingAdapter: {}
       podTemplate:
         spec:
           containers:
@@ -66,13 +82,13 @@ spec:
                 - --no-enable-log-requests
               env:
                 - name: HF_HOME
-                  value: /opt/models
+                  value: /model-store/huggingface
               envFrom:
                 - secretRef:
                     name: hf-token-secret
               volumeMounts:
                 - name: model-cache
-                  mountPath: /opt/models
+                  mountPath: /model-store
               workingDir: /workspace/examples/backends/vllm
               resources:
                 requests:

--- a/examples/deployments/llm-d-batch-gateway/llm-d-async-planner-values.yaml
+++ b/examples/deployments/llm-d-batch-gateway/llm-d-async-planner-values.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Overlay for the Planner-controlled batch-drain POC. Apply this after
+# llm-d-async-values.yaml. The deployment command must provide ap.image.repository
+# and ap.image.tag for an image containing the companion Redis leased-rate gate.
+ap:
+  imagePullPolicy: Always
+
+  # The controller queries a Prometheus server, not this pod's raw /metrics
+  # endpoint. The target cluster selects PodMonitors across namespaces.
+  podMonitor:
+    enabled: true
+    interval: 5s
+
+  # A named pool gives the observation and effect contracts one stable key.
+  workerPools:
+    - id: dynamo-batch
+      workers: 8
+      # Admission control belongs at the worker-pool boundary. Queue gates do
+      # not wait on ActionWait, so placing this under queuesConfig would not
+      # enforce the leased drain rate.
+      gate_type: wait-on-refuse
+      gate_params:
+        gate:
+          gate_type: redis-leased-rate
+          gate_params:
+            address: batch-gateway-valkey:6379
+            control_key: llm-d-async:drain-limit:dynamo-batch
+            # Keep the permitted burst small while allowing sub-1 RPS limits.
+            burst_seconds: "0.25"
+
+  redis:
+    # queuesConfig replaces the single-queue fields from the base values. The
+    # empty global gate is required because the chart rejects both forms at once.
+    gateType: ""
+    gateParams: {}
+    queuesConfig:
+      - id: dynamo-batch
+        queue_name: llm-d-async:requests:dynamo-batch
+        # Do not set result_queue_name here. Batch Gateway supplies the
+        # destination in each request's routing metadata.
+        worker_pool_id: dynamo-batch
+        request_path_url: /v1/chat/completions
+        igw_base_url: http://qwen3-0-6b-batch-frontend:8000

--- a/examples/deployments/llm-d-batch-gateway/planner-scheduling/README.md
+++ b/examples/deployments/llm-d-batch-gateway/planner-scheduling/README.md
@@ -1,0 +1,299 @@
+# Planner as a Batch Scheduler
+
+## Planner Batch Scheduling POC
+
+Batch Gateway remains the durable owner of jobs and results, llm-d Async remains
+the request dispatcher, and Planner does not dispatch individual requests. Every
+due native Planner tick observes durable job state plus optional
+serving/dispatcher feedback and controls two generic outputs:
+
+- a batch replica floor merged into Planner's normal final scaling decision;
+- a renewable maximum batch-admission lease enforced by llm-d Async.
+
+```mermaid
+flowchart LR
+    gateway["Batch Gateway jobs"] --> planner["Native Planner tick"]
+    telemetry["Optional traffic and Async feedback"] --> planner
+    planner -->|"replica floor"| dgdsa["Owned worker DGDSA"]
+    planner -->|"leased RPS cap"| redis["Redis control key"]
+    redis --> async["llm-d Async dispatcher"]
+    async --> frontend["Dynamo frontend"]
+    frontend --> worker["Dynamo worker"]
+```
+
+The POC focuses on plumbing, fail-closed control, autonomous worker recovery,
+and batch-only execution. Due-date optimization, concurrent online SLA
+protection, fairness among jobs/tenants, and post-batch scale-down remain future
+policy work.
+
+## Deploy the Planner POC
+
+First deploy the stock Batch Gateway example through the Async dispatch step in
+the [parent README](../README.md). The stock `dynamo.yaml` remains independently
+deployable and does not create a Planner pod.
+
+The stock Async deployment uses a constant-open queue gate. Before starting
+Planner, replace it with an Async image containing the companion LLM-180 Redis
+leased-rate gate and apply the Planner worker-pool overlay. The v0.9.0 chart
+accepts image repository and tag separately, so `ASYNC_IMAGE` must be a complete
+tagged image reference (digests and untagged references are rejected here).
+
+From `examples/deployments/llm-d-batch-gateway`, set the namespace and image,
+split the image according to the chart schema, and render the exact Helm inputs:
+
+```bash
+export NAMESPACE=your-namespace
+export ASYNC_IMAGE=your-registry.example/llm-d-async:llm-180
+
+: "${NAMESPACE:?set NAMESPACE to the deployed example namespace}"
+: "${ASYNC_IMAGE:?set ASYNC_IMAGE to the companion LLM-180 image}"
+
+case "${ASYNC_IMAGE}" in
+  *@*)
+    echo "ASYNC_IMAGE must use a tag; the chart renders repository:tag" >&2
+    exit 1
+    ;;
+esac
+ASYNC_IMAGE_REPOSITORY="${ASYNC_IMAGE%:*}"
+ASYNC_IMAGE_TAG="${ASYNC_IMAGE##*:}"
+if [[ "${ASYNC_IMAGE_REPOSITORY}" == "${ASYNC_IMAGE}" ||
+      -z "${ASYNC_IMAGE_REPOSITORY}" ||
+      -z "${ASYNC_IMAGE_TAG}" ||
+      "${ASYNC_IMAGE_TAG}" == */* ]]; then
+  echo "ASYNC_IMAGE must be a complete repository:tag reference" >&2
+  exit 1
+fi
+
+ASYNC_HELM_ARGS=(
+  --version v0.9.0
+  --namespace "${NAMESPACE}"
+  --values llm-d-async-values.yaml
+  --values llm-d-async-planner-values.yaml
+  --set-string "ap.image.repository=${ASYNC_IMAGE_REPOSITORY}"
+  --set-string "ap.image.tag=${ASYNC_IMAGE_TAG}"
+)
+
+if ! ASYNC_RENDERED="$(helm template async-dispatch \
+  oci://ghcr.io/llm-d/charts/llm-d-async \
+  "${ASYNC_HELM_ARGS[@]}")"; then
+  echo "failed to render the llm-d Async Planner deployment" >&2
+  exit 1
+fi
+
+if ! grep -Fq -- \
+  '--pool-config-file=/etc/llm-d-async/config/worker-pools.json' \
+  <<<"${ASYNC_RENDERED}"; then
+  echo "rendered Async deployment does not consume worker-pools.json" >&2
+  exit 1
+fi
+if ! grep -Fq -- 'worker_pool_id\":\"dynamo-batch' \
+  <<<"${ASYNC_RENDERED}"; then
+  echo "rendered Async queue does not route to dynamo-batch" >&2
+  exit 1
+fi
+if ! grep -Fq -- 'redis-leased-rate' <<<"${ASYNC_RENDERED}"; then
+  echo "rendered Async worker pool does not use redis-leased-rate" >&2
+  exit 1
+fi
+if ! grep -Fq -- "image: \"${ASYNC_IMAGE}\"" <<<"${ASYNC_RENDERED}"; then
+  echo "rendered Async deployment does not use ASYNC_IMAGE" >&2
+  exit 1
+fi
+```
+
+Only after all three render checks pass, upgrade the existing Async release and
+verify the live image, pool-config argument, and mounted gate configuration:
+
+```bash
+if ! helm upgrade --install async-dispatch \
+  oci://ghcr.io/llm-d/charts/llm-d-async \
+  "${ASYNC_HELM_ARGS[@]}"; then
+  echo "failed to deploy the llm-d Async Planner overlay" >&2
+  exit 1
+fi
+
+if ! kubectl rollout status --namespace "${NAMESPACE}" \
+  deployment/async-dispatch-llm-d-async \
+  --timeout=180s; then
+  echo "llm-d Async Planner rollout did not become ready" >&2
+  exit 1
+fi
+
+DEPLOYED_ASYNC_IMAGE="$(kubectl get deployment \
+  --namespace "${NAMESPACE}" \
+  async-dispatch-llm-d-async \
+  -o jsonpath='{.spec.template.spec.containers[0].image}')"
+if [[ "${DEPLOYED_ASYNC_IMAGE}" != "${ASYNC_IMAGE}" ]]; then
+  echo "live llm-d Async image does not match ASYNC_IMAGE" >&2
+  exit 1
+fi
+
+if ! kubectl get deployment \
+  --namespace "${NAMESPACE}" \
+  async-dispatch-llm-d-async \
+  -o jsonpath='{.spec.template.spec.containers[0].args}' \
+  | grep -Fq -- \
+    '--pool-config-file=/etc/llm-d-async/config/worker-pools.json'; then
+  echo "live llm-d Async deployment does not consume worker-pools.json" >&2
+  exit 1
+fi
+if ! kubectl get deployment \
+  --namespace "${NAMESPACE}" \
+  async-dispatch-llm-d-async \
+  -o jsonpath='{.spec.template.spec.containers[0].args}' \
+  | grep -Fq -- 'worker_pool_id":"dynamo-batch'; then
+  echo "live llm-d Async queue does not route to dynamo-batch" >&2
+  exit 1
+fi
+
+if ! kubectl get configmap \
+  --namespace "${NAMESPACE}" \
+  async-dispatch-llm-d-async-config \
+  -o jsonpath='{.data.worker-pools\.json}' \
+  | grep -Fq -- 'redis-leased-rate'; then
+  echo "live llm-d Async worker pool does not use redis-leased-rate" >&2
+  exit 1
+fi
+```
+
+The POC overlay is an `envsubst` template because the Planner's service-account
+subject, runtime namespace, and parent-DGD namespace must match the caller's
+Kubernetes namespace. It also requires a Planner image built from this branch;
+the template deliberately has no fallback image.
+
+Set the remaining required image and render the template into `kubectl`:
+
+```bash
+export PLANNER_IMAGE=your-registry.example/dynamo:planner-batch-poc
+
+: "${PLANNER_IMAGE:?set PLANNER_IMAGE to an image built from this branch}"
+
+if ! envsubst '${NAMESPACE} ${PLANNER_IMAGE}' \
+  < planner-scheduling/planner-poc.yaml \
+  | kubectl apply --namespace "${NAMESPACE}" -f -; then
+  echo "failed to apply the Planner POC resources" >&2
+  exit 1
+fi
+```
+
+The overlay uses same-namespace service names for Batch Gateway, the Dynamo
+frontend, llm-d Async metrics, and Valkey. The stock backend and POC overlay
+both expect the documented `model-cache` PVC and `hf-token-secret` in
+`NAMESPACE`.
+
+Wait for the Planner and confirm that the rendered image and namespaces are the
+ones you intended:
+
+```bash
+if ! kubectl wait --namespace "${NAMESPACE}" \
+  --for=condition=Ready \
+  dynamographdeployment/qwen3-0-6b-batch-planner \
+  --timeout=300s; then
+  echo "Planner POC deployment did not become ready" >&2
+  exit 1
+fi
+
+DEPLOYED_PLANNER_IMAGE="$(kubectl get dynamographdeployment \
+  --namespace "${NAMESPACE}" \
+  qwen3-0-6b-batch-planner \
+  -o jsonpath='{.spec.components[0].podTemplate.spec.containers[0].image}')"
+if [[ "${DEPLOYED_PLANNER_IMAGE}" != "${PLANNER_IMAGE}" ]]; then
+  echo "live Planner image does not match PLANNER_IMAGE" >&2
+  exit 1
+fi
+
+DEPLOYED_ROLE_NAMESPACE="$(kubectl get rolebinding \
+  --namespace "${NAMESPACE}" \
+  qwen3-0-6b-batch-planner-scaling-adapter \
+  -o jsonpath='{.subjects[0].namespace}')"
+if [[ "${DEPLOYED_ROLE_NAMESPACE}" != "${NAMESPACE}" ]]; then
+  echo "Planner RoleBinding subject is in the wrong namespace" >&2
+  exit 1
+fi
+
+if ! kubectl get configmap \
+  --namespace "${NAMESPACE}" \
+  qwen3-0-6b-batch-planner-config \
+  -o jsonpath='{.data.planner\.yaml}' \
+  | grep -Fq -- "namespace: ${NAMESPACE}-qwen3-0-6b-batch"; then
+  echo "live Planner config targets the wrong runtime namespace" >&2
+  exit 1
+fi
+```
+
+## Optional POC Cleanup
+
+Remove the Planner-only resources, then restore the stock Async image and
+constant gate without changing the rest of the Batch Gateway example:
+
+```bash
+envsubst '${NAMESPACE} ${PLANNER_IMAGE}' \
+  < planner-scheduling/planner-poc.yaml \
+  | kubectl delete --ignore-not-found -f -
+
+helm upgrade --install async-dispatch \
+  oci://ghcr.io/llm-d/charts/llm-d-async \
+  --version v0.9.0 \
+  --namespace "${NAMESPACE}" \
+  --reset-values \
+  --values llm-d-async-values.yaml
+```
+
+## Original design sketch
+
+We will use Planner as a Batch Scheduler.
+
+It will observe state like it does today, but may decide to dispatch a batch job instead of
+make a scaling decision.
+
+I.e. Planner can make predictions as to when is a good time to schedule a batch job vs autoscale.
+For example, we may not have to autoscale if we are below our utilization (meeting SLA) but have enough batch work queued that we can
+get done so that we do not have to pay the coldstart cost.
+
+steady state -> some percentage below max utilization if know we have enough long term batch work.  steadily work through batch jobs. chunk up large batch jobs so that they are evenly distributed.
+    short term traffic spike -> take a break from scheduling more batch work.
+    short term traffic dip -> dispatch more batch work.
+    long term traffic dip -> scale down
+    long term traffic spike -> scale up
+    giant batch job addition -> scale up
+    small batch job addition -> scale down.
+
+the calculus will look something like this.
+Client schedules batch job with 20,000 requests and a DUE date of 1 hour from now.
+Currently we are using 90% of capacity of the pool since the full pool can process 100 rps.
+Meaning we can fit an actual 10 rps without violating SLAs.
+So we start with a steady schedule of throwing 10rps.
+Then we get to the point where we have a traffic spike, we need to stop the batch jobs.
+The spike hit was 10% so we were able to survive it without autoscaling, but maybe lasted 50 mins.
+So now we still have 10,0000 requests left but only 10 mins left.  so we need to scale up so we can handle 20rps extra.
+And so we do that.  And everything meets SLA.  batch jobs and live traffic.
+
+Obviously we can flesh out how that works but this is the basic idea.
+Some big questions:
+
+Should Planner basically just use the state of the batch jobs to determine whether it makes scaling decisions or not
+and let router just handle scheduling of the batch job based on its SLA?
+
+Planner knows what its planning for the size of the pool.
+Case for Planner owning dispatching?
+     it knows how much batch work a router should be taking and prioritizing.
+     if router always prioritized by due date, then even when under utilized new requests will always cut in front of batch jobs.
+Case for no?
+    Router can just handle above as its own cost function.
+    Planner just observes the actual batch job drain rate and scales based on that?
+Case for a mix:
+    1) to not overwhelm router anyway Planner will chunk.
+    2) Planner will tune Router with an expected batch drain rate.
+    3) Planner will change that drain rate as necessary
+    4) Based on Routing decisions there may be a different effective batch drain rate.
+
+Can we implement this with a customer Router policy class for batch tho?
+
+POC Work:
+1) Enable batch policy class / queue
+2) If deficit round robin balancing exists today, we can use that?
+3) For POC it might be easiest to just have Planner dispatch batch requests at a steady state: i.e. rate limited 10 RPS.
+4) On LLM-D Gateway we would need to assess work - how to do partial batch job selection?
+5) We will need plumbing of batch state to Planner
+6) we will need to work on adding this to the Planner pipeline / brain.
+7) We will need to add a testing setup and see how this works.

--- a/examples/deployments/llm-d-batch-gateway/planner-scheduling/experiment/README.md
+++ b/examples/deployments/llm-d-batch-gateway/planner-scheduling/experiment/README.md
@@ -1,0 +1,58 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Batch Gateway Planner POC Experiment
+
+## Goal
+
+Measure the stock Batch Gateway path, then prove that Planner can ingest job and
+dispatcher state and safely control llm-d Async batch admission with renewable,
+fail-closed leases.
+
+## Hypothesis
+
+The native Planner tick can preserve durable Batch Gateway demand when optional
+serving telemetry is unavailable, recover the owned worker from zero replicas,
+and safely control llm-d Async admission with renewable fail-closed leases. The
+same evidence harness can preserve enough request, progress, Kubernetes,
+metric, and log state to distinguish Planner actions from experiment setup and
+support later online-traffic comparisons.
+
+## Success Criteria
+
+- Every run has a unique UTC identifier and an immutable directory under
+  `results/raw/`.
+- The submitted JSONL contains a deterministic GSM8K slice with one model,
+  temperature, and output-token limit.
+- Progress observations preserve total, completed, and failed counts until a
+  terminal state.
+- Optional online traffic records per-request HTTP status, Time To First Token
+  (TTFT), and end-to-end latency.
+- The run captures the effective pod images, referenced ConfigMaps, selected
+  pod logs, Kubernetes client/server versions, and any configured metric
+  endpoints.
+- The command exits nonzero when preflight, workload execution, online load, or
+  required result retrieval fails.
+- A native scale-from-zero treatment begins with the authoritative DGDSA at
+  zero, observes Planner alone change it to one, keeps admission closed through
+  readiness, drains every request, and returns the lease to zero.
+- Native evidence records continuous DGDSA, worker readiness, Planner decision,
+  Redis lease, and Async counter transitions and is checked by a machine
+  verifier.
+- Credential values are neither read from the Hugging Face environment nor
+  written to artifacts.
+
+## Scope and Environment
+
+The experiment targets a caller-selected namespace, model `Qwen/Qwen3-0.6B`,
+and the existing Batch Gateway, Valkey, llm-d Async, and Dynamo deployment. The
+workload harness itself never mutates Kubernetes resources. In native mode, the
+deployed Planner is the only experiment control plane: it publishes leased
+Redis decisions and scales the exact owned worker DGDSA through its normal tick.
+
+The default dataset is the converted GSM8K test split at
+`../../../../../../datasets/gsm8k/batch-gateway/gsm8k-main-test.jsonl`.
+The source file remains read-only; each run writes its exact normalized slice
+into that run's raw artifact directory.

--- a/examples/deployments/llm-d-batch-gateway/planner-scheduling/experiment/tests/conftest.py
+++ b/examples/deployments/llm-d-batch-gateway/planner-scheduling/experiment/tests/conftest.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+WORKLOADS_DIR = Path(__file__).resolve().parents[1] / "workloads"
+sys.path.insert(0, str(WORKLOADS_DIR))

--- a/examples/deployments/llm-d-batch-gateway/planner-scheduling/experiment/tests/test_batch_planner_control_loop.py
+++ b/examples/deployments/llm-d-batch-gateway/planner-scheduling/experiment/tests/test_batch_planner_control_loop.py
@@ -1,0 +1,574 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import batch_planner_control_loop as control_loop
+import pytest
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.unit,
+    pytest.mark.timeout(30),
+]
+
+
+@dataclasses.dataclass
+class FakeObservation:
+    job_demands: list[dict[str, Any]]
+    pool_traffic: list[dict[str, Any]]
+    dispatcher_feedback: list[dict[str, Any]]
+
+
+@dataclasses.dataclass
+class FakeDrainLimit:
+    pool_id: str
+    max_admission_rps: float
+    valid_until_s: float
+    decision_id: str
+
+
+@dataclasses.dataclass
+class FakeDiagnostics:
+    safety_paused: bool = False
+    required_batch_rps: float = 3.0
+    minimum_deadline_slack_s: float = 10.0
+
+
+@dataclasses.dataclass
+class FakePlan:
+    replica_floor: int
+    drain_limit: FakeDrainLimit
+    diagnostics: FakeDiagnostics
+
+
+@dataclasses.dataclass
+class FakeTick:
+    now_s: float
+    ready_replicas: int
+    batch: FakeObservation
+
+
+class SequenceCollector:
+    def __init__(self, values: list[FakeObservation | BaseException]) -> None:
+        self._values = list(values)
+        self.calls = 0
+
+    async def collect(self) -> FakeObservation:
+        value = self._values[self.calls]
+        self.calls += 1
+        if isinstance(value, BaseException):
+            raise value
+        return value
+
+
+class FakeActuator:
+    def __init__(self, fail_on_call: int | None = None) -> None:
+        self.decisions: list[FakeDrainLimit] = []
+        self.fail_on_call = fail_on_call
+
+    async def apply_drain_limit(self, decision: FakeDrainLimit) -> None:
+        self.decisions.append(decision)
+        if self.fail_on_call == len(self.decisions):
+            raise RuntimeError("Redis write failed")
+
+
+class SequenceClock:
+    def __init__(self, values: list[float]) -> None:
+        self._values = list(values)
+
+    def __call__(self) -> float:
+        if not self._values:
+            raise AssertionError("clock called more times than expected")
+        return self._values.pop(0)
+
+
+def observation() -> FakeObservation:
+    return FakeObservation(
+        job_demands=[
+            {
+                "job_id": "batch-1",
+                "remaining_requests": 100,
+                "deadline_at_s": 200.0,
+            }
+        ],
+        pool_traffic=[{"pool_id": "pool-a", "online_offered_rps": 7.0}],
+        dispatcher_feedback=[{"pool_id": "pool-a", "queued_requests": 100}],
+    )
+
+
+def settings(
+    *, apply: bool = False, iterations: int = 1
+) -> control_loop.ControlLoopSettings:
+    return control_loop.ControlLoopSettings(
+        run_id="20260828T130000Z-planner-loop-abcdef",
+        pool_id="pool-a",
+        work_class="gsm8k-128",
+        safe_rps_per_ready_replica=10.0,
+        ready_replicas=2,
+        online_offered_rps=7.0,
+        iterations=iterations,
+        interval_seconds=5.0,
+        drain_lease_duration_s=20.0,
+        apply_drain_limit=apply,
+    )
+
+
+def tick_builder(
+    now_s: float,
+    ready_replicas: int,
+    batch: FakeObservation,
+) -> FakeTick:
+    return FakeTick(now_s, ready_replicas, batch)
+
+
+def policy(
+    tick: FakeTick,
+    _config: object,
+    *,
+    decision_id: str,
+) -> FakePlan:
+    return FakePlan(
+        replica_floor=tick.ready_replicas,
+        drain_limit=FakeDrainLimit(
+            pool_id="pool-a",
+            max_admission_rps=13.0,
+            valid_until_s=tick.now_s + 20.0,
+            decision_id=decision_id,
+        ),
+        diagnostics=FakeDiagnostics(),
+    )
+
+
+def pause_builder(
+    pool_id: str,
+    rate: float,
+    valid_until_s: float,
+    decision_id: str,
+) -> FakeDrainLimit:
+    return FakeDrainLimit(pool_id, rate, valid_until_s, decision_id)
+
+
+def read_records(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def test_dry_run_records_two_decisions_without_actuation(tmp_path: Path) -> None:
+    output = tmp_path / "decisions.jsonl"
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    with control_loop.JsonlDecisionRecorder(output) as recorder:
+        asyncio.run(
+            control_loop.run_control_loop(
+                settings=settings(iterations=2),
+                collector=SequenceCollector([observation(), observation()]),
+                policy_config=object(),
+                policy=policy,
+                tick_input_builder=tick_builder,
+                pause_decision_builder=pause_builder,
+                recorder=recorder,
+                clock=SequenceClock([100.0, 105.0]),
+                sleeper=fake_sleep,
+            )
+        )
+
+    records = read_records(output)
+    assert len(records) == 2
+    assert [record["status"] for record in records] == ["planned", "planned"]
+    assert [record["mode"] for record in records] == ["dry_run", "dry_run"]
+    assert all(not record["actuation"]["drain_limit_applied"] for record in records)
+    assert all(not record["actuation"]["replica_scaling_applied"] for record in records)
+    assert records[0]["observation"]["job_demands"][0]["job_id"] == "batch-1"
+    assert records[0]["decision"]["drain_limit"]["max_admission_rps"] == 13.0
+    assert records[0]["diagnostics"]["required_batch_rps"] == 3.0
+    assert sleeps == [5.0]
+
+
+def test_apply_mode_renews_unique_leased_decisions(tmp_path: Path) -> None:
+    output = tmp_path / "decisions.jsonl"
+    actuator = FakeActuator()
+
+    async def fake_sleep(_delay: float) -> None:
+        return None
+
+    with control_loop.JsonlDecisionRecorder(output) as recorder:
+        asyncio.run(
+            control_loop.run_control_loop(
+                settings=settings(apply=True, iterations=2),
+                collector=SequenceCollector([observation(), observation()]),
+                policy_config=object(),
+                policy=policy,
+                tick_input_builder=tick_builder,
+                pause_decision_builder=pause_builder,
+                recorder=recorder,
+                actuator=actuator,
+                clock=SequenceClock([100.0, 105.0]),
+                sleeper=fake_sleep,
+            )
+        )
+
+    assert len(actuator.decisions) == 2
+    assert [decision.valid_until_s for decision in actuator.decisions] == [120.0, 125.0]
+    assert len({decision.decision_id for decision in actuator.decisions}) == 2
+    records = read_records(output)
+    assert [record["status"] for record in records] == ["applied", "applied"]
+    assert all(record["actuation"]["drain_limit_applied"] for record in records)
+
+
+def test_apply_collection_failure_writes_best_effort_pause(tmp_path: Path) -> None:
+    output = tmp_path / "decisions.jsonl"
+    actuator = FakeActuator()
+
+    with (
+        control_loop.JsonlDecisionRecorder(output) as recorder,
+        pytest.raises(control_loop.ControlLoopFailure, match="collection failed"),
+    ):
+        asyncio.run(
+            control_loop.run_control_loop(
+                settings=settings(apply=True),
+                collector=SequenceCollector([RuntimeError("gateway unavailable")]),
+                policy_config=object(),
+                policy=policy,
+                tick_input_builder=tick_builder,
+                pause_decision_builder=pause_builder,
+                recorder=recorder,
+                actuator=actuator,
+                clock=SequenceClock([100.0, 101.0]),
+            )
+        )
+
+    assert len(actuator.decisions) == 1
+    pause = actuator.decisions[0]
+    assert pause.max_admission_rps == 0.0
+    assert pause.valid_until_s == 121.0
+    assert pause.decision_id.endswith("-fail-closed")
+    record = read_records(output)[0]
+    assert record["error"]["phase"] == "collection"
+    assert record["fail_closed_pause"]["attempted"] is True
+    assert record["fail_closed_pause"]["applied"] is True
+
+
+def test_failed_best_effort_pause_preserves_original_failure(tmp_path: Path) -> None:
+    output = tmp_path / "decisions.jsonl"
+    actuator = FakeActuator(fail_on_call=1)
+
+    with (
+        control_loop.JsonlDecisionRecorder(output) as recorder,
+        pytest.raises(control_loop.ControlLoopFailure, match="collection failed"),
+    ):
+        asyncio.run(
+            control_loop.run_control_loop(
+                settings=settings(apply=True),
+                collector=SequenceCollector([RuntimeError("gateway unavailable")]),
+                policy_config=object(),
+                policy=policy,
+                tick_input_builder=tick_builder,
+                pause_decision_builder=pause_builder,
+                recorder=recorder,
+                actuator=actuator,
+                clock=SequenceClock([100.0, 101.0]),
+            )
+        )
+
+    record = read_records(output)[0]
+    assert record["error"]["phase"] == "collection"
+    assert record["fail_closed_pause"]["attempted"] is True
+    assert record["fail_closed_pause"]["applied"] is False
+    assert record["fail_closed_pause"]["error"]["type"] == "RuntimeError"
+
+
+def test_dry_run_collection_failure_never_calls_actuator(tmp_path: Path) -> None:
+    output = tmp_path / "decisions.jsonl"
+    actuator = FakeActuator()
+
+    with (
+        control_loop.JsonlDecisionRecorder(output) as recorder,
+        pytest.raises(control_loop.ControlLoopFailure),
+    ):
+        asyncio.run(
+            control_loop.run_control_loop(
+                settings=settings(),
+                collector=SequenceCollector([RuntimeError("gateway unavailable")]),
+                policy_config=object(),
+                policy=policy,
+                tick_input_builder=tick_builder,
+                pause_decision_builder=pause_builder,
+                recorder=recorder,
+                actuator=actuator,
+                clock=SequenceClock([100.0]),
+            )
+        )
+
+    assert actuator.decisions == []
+    assert read_records(output)[0]["fail_closed_pause"] is None
+
+
+def test_apply_policy_failure_writes_pause_with_observation(tmp_path: Path) -> None:
+    output = tmp_path / "decisions.jsonl"
+    actuator = FakeActuator()
+
+    def failing_policy(
+        _tick: FakeTick,
+        _config: object,
+        *,
+        decision_id: str,
+    ) -> FakePlan:
+        del decision_id
+        raise ValueError("policy input rejected")
+
+    with (
+        control_loop.JsonlDecisionRecorder(output) as recorder,
+        pytest.raises(control_loop.ControlLoopFailure, match="policy failed"),
+    ):
+        asyncio.run(
+            control_loop.run_control_loop(
+                settings=settings(apply=True),
+                collector=SequenceCollector([observation()]),
+                policy_config=object(),
+                policy=failing_policy,
+                tick_input_builder=tick_builder,
+                pause_decision_builder=pause_builder,
+                recorder=recorder,
+                actuator=actuator,
+                clock=SequenceClock([100.0, 101.0, 102.0]),
+            )
+        )
+
+    assert len(actuator.decisions) == 1
+    assert actuator.decisions[0].max_admission_rps == 0.0
+    record = read_records(output)[0]
+    assert record["observation"]["job_demands"][0]["job_id"] == "batch-1"
+    assert record["decision"] is None
+    assert record["error"]["phase"] == "policy"
+
+
+def test_actuation_failure_does_not_issue_a_second_mutation(tmp_path: Path) -> None:
+    output = tmp_path / "decisions.jsonl"
+    actuator = FakeActuator(fail_on_call=1)
+
+    with (
+        control_loop.JsonlDecisionRecorder(output) as recorder,
+        pytest.raises(control_loop.ControlLoopFailure, match="actuation failed"),
+    ):
+        asyncio.run(
+            control_loop.run_control_loop(
+                settings=settings(apply=True),
+                collector=SequenceCollector([observation()]),
+                policy_config=object(),
+                policy=policy,
+                tick_input_builder=tick_builder,
+                pause_decision_builder=pause_builder,
+                recorder=recorder,
+                actuator=actuator,
+                clock=SequenceClock([100.0, 101.0]),
+            )
+        )
+
+    assert len(actuator.decisions) == 1
+    record = read_records(output)[0]
+    assert record["error"]["phase"] == "actuation"
+    assert record["fail_closed_pause"] is None
+    assert record["decision"]["drain_limit"]["max_admission_rps"] == 13.0
+
+
+def test_invalid_policy_decision_fails_closed_before_applying_it(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "decisions.jsonl"
+    actuator = FakeActuator()
+
+    def mismatched_policy(
+        tick: FakeTick,
+        _config: object,
+        *,
+        decision_id: str,
+    ) -> FakePlan:
+        return FakePlan(
+            replica_floor=1,
+            drain_limit=FakeDrainLimit(
+                pool_id="another-pool",
+                max_admission_rps=1.0,
+                valid_until_s=tick.now_s + 20.0,
+                decision_id=decision_id,
+            ),
+            diagnostics=FakeDiagnostics(),
+        )
+
+    with (
+        control_loop.JsonlDecisionRecorder(output) as recorder,
+        pytest.raises(control_loop.ControlLoopFailure, match="wrong pool"),
+    ):
+        asyncio.run(
+            control_loop.run_control_loop(
+                settings=settings(apply=True),
+                collector=SequenceCollector([observation()]),
+                policy_config=object(),
+                policy=mismatched_policy,
+                tick_input_builder=tick_builder,
+                pause_decision_builder=pause_builder,
+                recorder=recorder,
+                actuator=actuator,
+                clock=SequenceClock([100.0, 101.0, 102.0]),
+            )
+        )
+
+    assert len(actuator.decisions) == 1
+    assert actuator.decisions[0].pool_id == "pool-a"
+    assert actuator.decisions[0].max_admission_rps == 0.0
+
+
+def test_records_are_strict_json_and_redact_credential_shapes(tmp_path: Path) -> None:
+    output = tmp_path / "decisions.jsonl"
+    secret = "top" + "secret"
+    hf_value = "hf_" + ("x" * 24)
+    with control_loop.JsonlDecisionRecorder(output) as recorder:
+        recorder.append(
+            {
+                "error": (
+                    f"redis://user:{secret}@host/0 Bearer {secret} HF_TOKEN={hf_value}"
+                ),
+                "positive": math.inf,
+                "negative": -math.inf,
+            }
+        )
+
+    raw = output.read_text()
+    assert secret not in raw
+    assert hf_value not in raw
+    record = json.loads(raw)
+    assert record["positive"] == "Infinity"
+    assert record["negative"] == "-Infinity"
+
+
+def required_cli() -> list[str]:
+    return [
+        "--pool",
+        "pool-a",
+        "--work-class",
+        "gsm8k-128",
+        "--safe-rps-per-ready-replica",
+        "10",
+        "--ready-replicas",
+        "2",
+        "--online-offered-rps",
+        "7",
+    ]
+
+
+def test_cli_defaults_to_dry_run_and_bounds_max_replicas() -> None:
+    args = control_loop.parse_args(required_cli())
+
+    control_loop.validate_args(args)
+
+    assert args.apply_drain_limit is False
+    assert args.iterations == 1
+    assert args.max_replicas == 2
+    assert args.redis_url is None
+    assert args.tenant == "planner-poc-baseline"
+
+
+def test_cli_accepts_bounded_interval_flag() -> None:
+    args = control_loop.parse_args([*required_cli(), "--interval", "4"])
+
+    control_loop.validate_args(args)
+
+    assert args.interval_seconds == 4.0
+
+
+def test_apply_mode_requires_explicit_redis_target() -> None:
+    args = control_loop.parse_args([*required_cli(), "--apply-drain-limit"])
+
+    with pytest.raises(
+        control_loop.ControlLoopConfigurationError,
+        match="requires --redis-url and --redis-control-key",
+    ):
+        control_loop.validate_args(args)
+
+
+def test_redis_options_are_rejected_without_apply_flag() -> None:
+    args = control_loop.parse_args(
+        [*required_cli(), "--redis-url", "redis://127.0.0.1:6379/0"]
+    )
+
+    with pytest.raises(
+        control_loop.ControlLoopConfigurationError,
+        match="explicit --apply-drain-limit",
+    ):
+        control_loop.validate_args(args)
+
+
+def test_credential_bearing_http_url_is_rejected() -> None:
+    args = control_loop.parse_args(
+        [
+            *required_cli(),
+            "--batch-base-url",
+            "https://user:password@example.test",
+        ]
+    )
+
+    with pytest.raises(
+        control_loop.ControlLoopConfigurationError,
+        match="must not contain credentials",
+    ):
+        control_loop.validate_args(args)
+
+
+def test_output_is_exclusive(tmp_path: Path) -> None:
+    output = tmp_path / "decisions.jsonl"
+    with control_loop.JsonlDecisionRecorder(output):
+        pass
+
+    with pytest.raises(FileExistsError):
+        control_loop.JsonlDecisionRecorder(output)
+
+
+def test_main_records_startup_error_and_returns_nonzero(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output = tmp_path / "decisions.jsonl"
+    secret = "do-not-" + "record"
+
+    async def failing_live_runner(
+        _args: Any,
+        _settings: control_loop.ControlLoopSettings,
+        _recorder: control_loop.JsonlDecisionRecorder,
+    ) -> None:
+        raise RuntimeError(f"redis://user:{secret}@host/0")
+
+    exit_code = control_loop.main(
+        [*required_cli(), "--output", str(output)],
+        live_runner=failing_live_runner,
+    )
+
+    assert exit_code == 1
+    record = read_records(output)[0]
+    assert record["status"] == "error"
+    assert record["error"]["phase"] == "startup"
+    assert secret not in output.read_text()
+    assert secret not in capsys.readouterr().err
+
+
+def test_settings_reject_lease_that_cannot_outlive_interval() -> None:
+    unsafe = dataclasses.replace(
+        settings(),
+        interval_seconds=20.0,
+        drain_lease_duration_s=20.0,
+    )
+
+    with pytest.raises(
+        control_loop.ControlLoopConfigurationError,
+        match="greater than the loop interval",
+    ):
+        control_loop.validate_settings(unsafe)

--- a/examples/deployments/llm-d-batch-gateway/planner-scheduling/experiment/workloads/README.md
+++ b/examples/deployments/llm-d-batch-gateway/planner-scheduling/experiment/workloads/README.md
@@ -1,0 +1,465 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Experiment Workloads
+
+## Standalone Planner Control Loop
+
+`batch_planner_control_loop.py` is the single-pool Planner POC runner. It wires
+the public `BatchGatewayJobSource`, `LlmdAsyncPrometheusSource`,
+`BatchSchedulingCollector`, `plan_batch_schedule`, and
+`RedisLeasedDrainLimitActuator` APIs without joining the normal Planner
+lifecycle.
+
+The default is a read-only dry run. It reads Batch Gateway and Prometheus,
+evaluates the policy for a bounded number of iterations, and writes one strict
+JSON object per decision. It never changes Redis unless
+`--apply-drain-limit` is present. Replica floors are recorded as advisory;
+this runner never scales replicas.
+
+Run from the experiment root after the Batch Gateway and Prometheus endpoints
+are reachable:
+
+```bash
+../../../../../.venv/bin/python workloads/batch_planner_control_loop.py \
+  --pool dynamo-batch \
+  --work-class gsm8k-max-output-128 \
+  --tenant planner-poc-baseline \
+  --prometheus-url http://127.0.0.1:19090 \
+  --prometheus-observation-window-seconds 90 \
+  --safe-rps-per-ready-replica 10 \
+  --ready-replicas 1 \
+  --online-offered-rps 0 \
+  --iterations 6 \
+  --interval 10 \
+  --drain-lease-seconds 30
+```
+
+`--pool` and `--work-class` are applied to jobs collected from this
+single-pool POC. `--safe-rps-per-ready-replica`, `--ready-replicas`, and
+`--online-offered-rps` are explicit static assumptions, not discovered
+measurements. If `--max-replicas` is omitted, it defaults to the supplied ready
+replica count.
+
+Batch Gateway listing is scoped by `X-MaaS-Username`, so this POC defaults to
+the same `planner-poc-baseline` tenant used by the baseline submission harness.
+The Redis drain cap, however, applies to the whole worker pool. A cap derived
+from one tenant's visible jobs would be unsafe if other tenants share that pool.
+Mixed-tenant pools are therefore out of scope; use one dedicated tenant and
+worker pool for this POC.
+
+`--prometheus-url` must target a real Prometheus HTTP API that serves
+`/api/v1/query`, such as a local port-forward from `19090` to the cluster's
+Prometheus service. Do not point it at llm-d Async's raw container
+`:9090/metrics` listener; that endpoint exposes text metrics but cannot execute
+the instant PromQL queries used by `LlmdAsyncPrometheusSource`.
+The dispatch-rate range must span at least two Prometheus scrapes. The POC
+defaults to 90 seconds so it remains meaningful with a 30-second scrape; if a
+PodMonitor is enabled, prefer a 5-10 second scrape interval.
+
+By default, decisions go to a unique
+`results/raw/<UTC-run-id>/control-loop-decisions.jsonl` path. Each line contains
+the collected observation, drain and advisory replica decision, diagnostics,
+actuation status, and any sanitized error. Endpoint URLs, Redis keys, and
+credentials are not recorded. Existing output paths are never overwritten.
+
+### Apply the Leased Drain Limit
+
+Apply mode needs the optional `redis` Python package, which is not part of the
+current Dynamo environment. Layer it onto the project environment for the
+invocation:
+
+```bash
+uv pip install --python ../../../../../.venv/bin/python 'redis>=5,<7'
+
+../../../../../.venv/bin/python \
+  workloads/batch_planner_control_loop.py \
+  --pool dynamo-batch \
+  --work-class gsm8k-max-output-128 \
+  --tenant planner-poc-baseline \
+  --prometheus-url http://127.0.0.1:19090 \
+  --prometheus-observation-window-seconds 90 \
+  --safe-rps-per-ready-replica 10 \
+  --ready-replicas 1 \
+  --online-offered-rps 0 \
+  --iterations 6 \
+  --interval 10 \
+  --drain-lease-seconds 30 \
+  --apply-drain-limit \
+  --redis-url redis://127.0.0.1:6379/0 \
+  --redis-control-key 'llm-d-async:drain-limit:dynamo-batch'
+```
+
+The controlled overlay uses worker pool `dynamo-batch` and control key
+`llm-d-async:drain-limit:dynamo-batch`. The key is deliberately required; the
+runner does not guess it. Verify that both values still match the deployed
+dispatcher configuration before apply mode. Use a credentialless local Redis
+port forward where possible. The runner does not print or record the Redis URL,
+but command-line credentials can still be visible in shell history and process
+listings.
+
+The controlled Helm overlay installs the `redis-leased-rate` gate on
+`ap.workerPools[0]`. This is a worker-pool admission boundary: it limits batch
+requests entering `dynamo-batch`. It is intentionally not a `queuesConfig`
+queue gate, where an `ActionWait` result can fall through to later dispatch
+stages. The pool ID in Prometheus, the policy input, and the Redis key must all
+name this same worker pool.
+
+Every successful apply iteration publishes a fresh decision ID and absolute
+lease expiry. The interval must be shorter than the lease duration. A
+post-start collection or policy failure causes one best-effort zero-RPS pause
+lease in apply mode, records whether that pause succeeded, and exits nonzero.
+Dry-run failures never invoke the actuator. An actuation failure is recorded
+and exits nonzero without attempting a second mutation; any prior lease is
+allowed to expire into llm-d Async's fail-closed behavior.
+
+Prometheus must expose all metrics required by
+`LlmdAsyncPrometheusSource`, including backlog-source availability and both raw
+and wall-clock lease-validity signals. Missing or ambiguous series abort the
+observation instead of being treated as zero.
+
+The source also evaluates `time() - min(timestamp(...))` for the mandatory
+backlog-availability series. This puts scrape age in the PromQL value instead of
+trusting an instant query's evaluation timestamp. A missing, future, or older
+than `--max-observation-age-seconds` anchor aborts collection; apply mode then
+publishes its existing best-effort zero-RPS pause. The backlog gauge itself is
+updated on Async's configured broker-poll cadence, so that cadence remains a
+separate, bounded source of observation lag.
+
+Before any live dry run, verify that Prometheus is scraping the controlled
+llm-d Async pods and that its HTTP API returns the required series. The target
+cluster's PodMonitor CRD and cross-namespace Prometheus selectors were verified,
+so the controlled overlay enables a 5-second PodMonitor. A rendered resource is
+not sufficient evidence: confirm the live target is healthy before applying a
+drain decision.
+
+### Canonical Controlled Run
+
+The successful 2026-08-28 treatment used a dedicated test cluster. Set the
+context for your deployment and run these forwards in separate terminals:
+
+```bash
+export KUBE_CONTEXT=your-kube-context
+
+kubectl --context "${KUBE_CONTEXT}" port-forward -n default \
+  service/qwen3-0-6b-batch-frontend 18000:8000
+kubectl --context "${KUBE_CONTEXT}" port-forward -n default \
+  service/batch-gateway-apiserver 18001:8000
+kubectl --context "${KUBE_CONTEXT}" port-forward -n monitoring \
+  service/kube-prometheus-stack-prometheus 19090:9090
+kubectl --context "${KUBE_CONTEXT}" port-forward -n default \
+  service/batch-gateway-valkey 16379:6379
+```
+
+From the Dynamo repository root, the bounded apply controller was:
+
+```bash
+.venv/bin/python -u \
+  examples/deployments/llm-d-batch-gateway/planner-scheduling/experiment/workloads/batch_planner_control_loop.py \
+  --pool dynamo-batch \
+  --work-class gsm8k-qwen3 \
+  --tenant planner-poc-baseline \
+  --batch-base-url http://127.0.0.1:18001 \
+  --prometheus-url http://127.0.0.1:19090 \
+  --prometheus-observation-window-seconds 90 \
+  --safe-rps-per-ready-replica 15 \
+  --ready-replicas 1 \
+  --online-offered-rps 0 \
+  --iterations 40 \
+  --interval 2 \
+  --drain-lease-seconds 10 \
+  --max-observation-age-seconds 15 \
+  --min-replicas 0 \
+  --max-replicas 1 \
+  --max-batch-admission-rps 5 \
+  --apply-drain-limit \
+  --redis-url redis://127.0.0.1:16379/0 \
+  --redis-control-key llm-d-async:drain-limit:dynamo-batch
+```
+
+Controller run `20260828T183813Z-planner-loop-15424f` was paired with this
+command from the experiment root:
+
+```bash
+./workloads/run_baseline.sh \
+  --run-kind planner-controlled \
+  --paired-controller-run-id 20260828T183813Z-planner-loop-15424f \
+  --context "${KUBE_CONTEXT}" \
+  --namespace default \
+  --tenant planner-poc-baseline \
+  --batch-base-url http://127.0.0.1:18001 \
+  --batch-size 100 \
+  --max-tokens 128 \
+  --poll-interval-seconds 2 \
+  --timeout-seconds 600 \
+  --expected-gate-type redis-leased-rate
+```
+
+For a new treatment, replace the paired controller ID with the new ID printed
+by the controller. The controller must already be running before submission.
+
+Inspect decisions with:
+
+```bash
+jq -c '{iteration,status,decision,diagnostics,error,fail_closed_pause}' \
+  results/raw/<run-id>/control-loop-decisions.jsonl
+```
+
+## Native Planner-Controlled Run
+
+Use `--run-kind planner-native` when the normal Planner tick owns observation,
+policy, leased drain actuation, and replica effects. This mode does not accept a
+paired standalone controller ID. It records `control_plane.mode=native-planner`
+and uses `planner-native` in both the run ID and submitted request IDs, so the
+treatment cannot be mistaken for either the stock baseline or the standalone
+controller experiment.
+
+A live native run also has a stricter evidence contract. Before submission, the
+harness requires a Running pod matching the native Planner regex and captures
+the explicitly named ConfigMap mounted by that pod. At the end, logs captured
+since the run began must contain at least two `Batch scheduling decision:`
+records. This proves recurring native ticks made batch decisions during the
+workload; merely having a Planner pod in the namespace is insufficient.
+
+With the POC deployment, run from the experiment root while the Batch API port
+forward is active:
+
+```bash
+./workloads/run_baseline.sh \
+  --run-kind planner-native \
+  --native-planner-configmap qwen3-0-6b-batch-planner-config \
+  --native-planner-pod-name-regex 'qwen3-0-6b-batch-planner.*planner' \
+  --context "${KUBE_CONTEXT}" \
+  --namespace default \
+  --tenant planner-poc-baseline \
+  --batch-base-url http://127.0.0.1:18001 \
+  --batch-size 100 \
+  --max-tokens 128 \
+  --poll-interval-seconds 2 \
+  --timeout-seconds 600
+```
+
+For `planner-native`, the default expected gate type is `redis-leased-rate`,
+the default decision log expression is `Batch scheduling decision:`, and the
+minimum match count is two. Native runs require that gate type and do not allow
+`--skip-gate-verification`. Use `--native-planner-decision-log-regex` or
+`--native-planner-min-decision-logs` only when the deployed logging contract or
+tick cadence intentionally differs. The generic `--pod-name-regex` must still
+select the Planner pod; its default already includes this POC's DGD name.
+
+## Evidence-Preserving Batch Baseline
+
+Run this harness against the existing Batch Gateway, llm-d Async, and Dynamo
+deployment. It never applies or changes Kubernetes resources. The live path
+requires read access to the selected namespace plus existing local port forwards for
+the Batch API and, when online load is enabled, the Dynamo frontend.
+
+## What the Harness Records
+
+Each invocation creates `results/raw/<UTC-run-id>/` before it does any work. A
+run contains:
+
+- exact normalized GSM8K Batch JSONL and its source/output checksums;
+- file upload, Batch creation, progress, terminal state, and retrieved result
+  files;
+- optional per-online-request HTTP status, Time To First Token (TTFT), latency,
+  and token usage;
+- selected pod specifications, image digests, referenced ConfigMaps, events,
+  current and previous logs, Kubernetes versions, and pod-proxy metric snapshots;
+- optional periodic snapshots from explicit unauthenticated metric URLs;
+- sanitized stdout, stderr, every captured command's stdout/stderr, and each exit
+  code.
+
+Native Planner runs additionally store the expected and observed Planner pods,
+mounted/captured ConfigMap, Planner image digest records, per-log command exit
+codes, and in-run decision-log match count under
+`kubernetes.{start,end}.native_planner` in `metadata.json`.
+
+The pod selector defaults to names containing `batch-gateway`,
+`async-dispatch`, or `qwen3-0-6b-batch`. Override `--pod-name-regex` if the
+deployed names differ.
+
+## Canonical Autonomous Zero-Worker Run
+
+Canonical run `20260828T213549Z-planner-native-1e3ff8` used one explicit
+pre-run setup mutation to establish the worker DGDSA at zero:
+
+```bash
+kubectl patch dgdsa \
+  qwen3-0-6b-batch-vllmdecodeworker \
+  --namespace default \
+  --subresource scale \
+  --type merge \
+  --patch '{"spec":{"replicas":0}}'
+```
+
+That patch completed at 21:28:07Z, more than seven minutes before the evidence
+window. Before T0, verify DGDSA spec/status are both zero, no worker pod exists,
+the Planner is Ready, the Redis lease is zero, and the Gateway tenant has no
+active job. Start read-only DGDSA watch, Planner log-follow, and periodic
+DGD/worker/Redis observers before submission. Do not run `kubectl patch`,
+`apply`, `delete`, or `scale` between T0 and T1. The canonical raw evidence
+directory includes the exact three observer scripts used.
+
+With Batch Gateway on local port 18001 and Async metrics on 19092, the workload
+command was:
+
+```bash
+./workloads/run_baseline.sh \
+  --run-kind planner-native \
+  --native-planner-configmap qwen3-0-6b-batch-planner-config \
+  --native-planner-pod-name-regex 'qwen3-0-6b-batch-planner.*planner' \
+  --native-planner-min-decision-logs 3 \
+  --context "${KUBE_CONTEXT}" \
+  --namespace default \
+  --tenant planner-poc-baseline \
+  --batch-base-url http://127.0.0.1:18001 \
+  --batch-size 100 \
+  --max-tokens 128 \
+  --poll-interval-seconds 2 \
+  --timeout-seconds 900 \
+  --expected-gate-type redis-leased-rate \
+  --metrics-url async=http://127.0.0.1:19092/metrics \
+  --metrics-interval-seconds 2
+```
+
+After terminal completion, retain observers for at least two more Planner
+ticks, capture final DGD/DGDSA/Redis/Async state, and stop only the exact
+observer PIDs. Verify the resulting evidence directory:
+
+```bash
+python3 workloads/verify_native_planner_e2e.py \
+  --run-dir results/raw/20260828T213549Z-planner-native-1e3ff8 \
+  --evidence-dir \
+    results/raw/20260828T213549Z-planner-native-1e3ff8/autonomous-scale-evidence
+```
+
+The verifier checks 15 invariants: terminal 100/100/0 and output validity,
+DGDSA zero-to-one watch evidence, Planner scaling logs, policy ordering,
+closed admission through worker readiness, dispatch only after a positive
+lease, exact Async counter deltas, empty terminal queues, and a fresh
+authoritative terminal zero lease. It deliberately does not claim worker
+scale-down; the final worker replica remains one while the floor and cap return
+to zero.
+
+## Run a Local Preflight
+
+Validate the scripts and deterministic workload without contacting Kubernetes or
+an API:
+
+```bash
+./workloads/run_baseline.sh \
+  --preflight-only \
+  --skip-cluster-preflight \
+  --skip-api-preflight
+```
+
+This creates a raw preflight run but no external traffic.
+
+## Run a Read-Only Live Preflight
+
+Start the existing Batch API port forward in another terminal:
+
+```bash
+kubectl port-forward -n default service/batch-gateway-apiserver 8001:8000
+```
+
+Then verify namespace access, selected pods, effective gate configuration, and
+the Batch API without creating a job:
+
+```bash
+./workloads/run_baseline.sh --preflight-only
+```
+
+The default requires evidence of `gate_type=constant`. Use
+`--expected-gate-type` to name another already deployed fast gate. Do not bypass
+gate verification unless you preserve and review the effective config manually.
+
+## Run the Batch-Only Baseline
+
+Keep the Batch API port forward running, then submit the default deterministic
+100-request slice:
+
+```bash
+./workloads/run_baseline.sh \
+  --batch-size 100 \
+  --max-tokens 128 \
+  --timeout-seconds 1800
+```
+
+The harness uses the existing gate and deployment without Planner actions.
+
+## Add Concurrent Online Load
+
+Forward the existing Dynamo frontend in another terminal:
+
+```bash
+kubectl port-forward -n default service/qwen3-0-6b-batch-frontend 8000:8000
+```
+
+Run fixed streaming online requests at two requests per second for two minutes:
+
+```bash
+./workloads/run_baseline.sh \
+  --batch-size 100 \
+  --online-rate 2 \
+  --online-duration-seconds 120 \
+  --online-max-inflight 32
+```
+
+Online requests use streaming so TTFT and end-to-end latency remain separate.
+The scheduler is open loop. A request that cannot acquire an in-flight slot is
+recorded as `max_inflight` instead of silently changing the offered rate.
+
+## Add Periodic Metric Snapshots
+
+Forward an existing metric endpoint and pass an unauthenticated URL:
+
+```bash
+./workloads/run_baseline.sh \
+  --metrics-url async=http://127.0.0.1:9092/metrics \
+  --metrics-interval-seconds 15
+```
+
+Metric URLs must not contain credentials or query parameters. Independently, the
+harness attempts read-only Kubernetes pod-proxy snapshots for selected container
+ports named `metrics` and common metric ports.
+
+## Compile a Run
+
+Use the run ID printed by the harness:
+
+```bash
+python3 workloads/compile_run.py \
+  --run-id 20260828T120000Z-baseline-a1b2c3
+```
+
+The compiler writes a new `results/compiled/<run-id>-summary/` directory. It
+checks monotonic progress and duplicate online request indexes, writes CSV
+projections, calculates nearest-rank latency percentiles, and records checksums
+for every source artifact it used.
+
+## Workload Contract
+
+The immutable source defaults to the user's converted GSM8K main/test JSONL.
+Each run selects records in source order and rewrites only:
+
+- `custom_id`, to the existing stable baseline identifier for stock/standalone
+  runs or a distinct `planner-native` identifier for native control;
+- `model`;
+- `max_tokens`;
+- `temperature`;
+- `stream=false`.
+
+The message content is preserved, so GSM8K prompt lengths still vary. “Fixed
+shape” here means an identical deterministic record slice and request
+configuration across comparable runs, not identical token counts.
+
+## Credential Handling
+
+The harness does not enumerate the process environment, query Kubernetes Secret
+objects, or read Hugging Face credentials. It uses a fixed non-credential
+authorization placeholder accepted by this validation deployment. Captured text
+is sanitized for credential-shaped values before it is written.

--- a/examples/deployments/llm-d-batch-gateway/planner-scheduling/experiment/workloads/batch_planner_control_loop.py
+++ b/examples/deployments/llm-d-batch-gateway/planner-scheduling/experiment/workloads/batch_planner_control_loop.py
@@ -1,0 +1,964 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run the standalone, single-pool Batch Planner POC control loop."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import datetime as dt
+import importlib
+import json
+import math
+import re
+import secrets
+import sys
+import time
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from pathlib import Path
+from types import ModuleType, TracebackType
+from typing import Any, Protocol, Self
+from urllib.parse import urlsplit
+
+EXPERIMENT_ROOT = Path(__file__).resolve().parents[1]
+DYNAMO_REPO_ROOT = Path(__file__).resolve().parents[6]
+DYNAMO_COMPONENTS_SRC = DYNAMO_REPO_ROOT / "components" / "src"
+if DYNAMO_COMPONENTS_SRC.is_dir():
+    # Keep this standalone POC runnable from a source checkout without an
+    # editable ai-dynamo install. Dependencies still come from the caller's
+    # selected Python environment.
+    sys.path.insert(0, str(DYNAMO_COMPONENTS_SRC))
+HF_CREDENTIAL_RE = re.compile(r"\bhf_[A-Za-z0-9][A-Za-z0-9_%.-]{15,}")
+HF_ASSIGNMENT_RE = re.compile(
+    r"(?im)(\b(?:HF_TOKEN|HUGGING_FACE_HUB_TOKEN)\b\s*[:=]\s*)[^\s,}\]]+"
+)
+BEARER_RE = re.compile(r"(?i)(\bBearer\s+)[^\s\"']+")
+URL_USERINFO_RE = re.compile(r"(?i)([a-z][a-z0-9+.-]*://)[^/\s@]+@")
+
+
+class ControlLoopConfigurationError(ValueError):
+    """The requested loop configuration is unsafe or incomplete."""
+
+
+class ControlLoopFailure(RuntimeError):
+    """One control-loop phase failed after the loop started."""
+
+    def __init__(self, phase: str, cause: BaseException) -> None:
+        self.phase = phase
+        self.cause = cause
+        super().__init__(f"{phase} failed: {sanitize_text(str(cause))}")
+
+
+def prepare_source_checkout_planner_imports() -> None:
+    """Load only Planner's source-only packages when no wheel is required.
+
+    ``dynamo.planner.__init__`` imports runtime connectors backed by the native
+    ``dynamo._core`` extension. This standalone POC only needs the pure-Python
+    policy and environment packages, so a source checkout can expose those
+    subpackages without building the unrelated runtime extension.
+    """
+
+    planner_root = DYNAMO_COMPONENTS_SRC / "dynamo" / "planner"
+    if not planner_root.is_dir() or "dynamo.planner" in sys.modules:
+        return
+
+    dynamo_package = importlib.import_module("dynamo")
+    planner_package = ModuleType("dynamo.planner")
+    planner_package.__file__ = str(planner_root / "__init__.py")
+    planner_package.__package__ = "dynamo.planner"
+    planner_package.__path__ = [str(planner_root)]
+    sys.modules["dynamo.planner"] = planner_package
+    dynamo_package.planner = planner_package
+
+    # ``core.__init__`` also exports the native-runtime-backed state machine.
+    # Mount the core directory as a package so this POC can import only its
+    # pure policy and contract modules.
+    core_package = ModuleType("dynamo.planner.core")
+    core_package.__file__ = str(planner_root / "core" / "__init__.py")
+    core_package.__package__ = "dynamo.planner.core"
+    core_package.__path__ = [str(planner_root / "core")]
+    sys.modules["dynamo.planner.core"] = core_package
+    planner_package.core = core_package
+
+
+class SchedulingCollector(Protocol):
+    async def collect(self) -> Any: ...
+
+
+class DrainLimitActuator(Protocol):
+    async def apply_drain_limit(self, decision: Any) -> None: ...
+
+
+class SchedulingPolicy(Protocol):
+    def __call__(
+        self,
+        tick_input: Any,
+        config: Any,
+        *,
+        decision_id: str,
+    ) -> Any: ...
+
+
+TickInputBuilder = Callable[[float, int, Any], Any]
+PauseDecisionBuilder = Callable[[str, float, float, str], Any]
+
+
+@dataclasses.dataclass(frozen=True)
+class ControlLoopSettings:
+    """Safe, non-secret inputs shared by the live runner and tests."""
+
+    run_id: str
+    pool_id: str
+    work_class: str
+    safe_rps_per_ready_replica: float
+    ready_replicas: int
+    online_offered_rps: float
+    iterations: int
+    interval_seconds: float
+    drain_lease_duration_s: float
+    apply_drain_limit: bool = False
+    cold_start_margin_s: float = 0.0
+    finalization_margin_s: float = 0.0
+    max_observation_age_s: float = 60.0
+    min_replicas: int = 0
+    max_replicas: int | None = None
+    max_batch_admission_rps: float | None = None
+    tenant: str = "planner-poc-baseline"
+
+    def public_record(self) -> dict[str, Any]:
+        return {
+            "pool_id": self.pool_id,
+            "work_class": self.work_class,
+            "safe_rps_per_ready_replica": self.safe_rps_per_ready_replica,
+            "ready_replicas": self.ready_replicas,
+            "online_offered_rps": self.online_offered_rps,
+            "iterations": self.iterations,
+            "interval_seconds": self.interval_seconds,
+            "drain_lease_duration_s": self.drain_lease_duration_s,
+            "cold_start_margin_s": self.cold_start_margin_s,
+            "finalization_margin_s": self.finalization_margin_s,
+            "max_observation_age_s": self.max_observation_age_s,
+            "min_replicas": self.min_replicas,
+            "max_replicas": self.max_replicas,
+            "max_batch_admission_rps": self.max_batch_admission_rps,
+            "tenant": self.tenant,
+        }
+
+
+class JsonlDecisionRecorder:
+    """Write strict, sanitized JSON Lines without overwriting prior evidence."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = self.path.open("x", encoding="utf-8", buffering=1)
+
+    def append(self, record: Mapping[str, Any]) -> None:
+        payload = to_json_value(record)
+        self._handle.write(
+            json.dumps(
+                payload,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            )
+            + "\n"
+        )
+        self._handle.flush()
+
+    def close(self) -> None:
+        self._handle.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        self.close()
+
+
+class StaticOnlineTrafficSource:
+    """Expose a caller-configured offered rate through the public source protocol."""
+
+    def __init__(
+        self,
+        *,
+        pool_id: str,
+        online_offered_rps: float,
+        demand_factory: Callable[..., Any],
+    ) -> None:
+        self._pool_id = pool_id
+        self._online_offered_rps = online_offered_rps
+        self._demand_factory = demand_factory
+
+    async def collect_online_traffic(self, *, observed_at_s: float) -> list[Any]:
+        return [
+            self._demand_factory(
+                observed_at_s=observed_at_s,
+                pool_id=self._pool_id,
+                online_offered_rps=self._online_offered_rps,
+            )
+        ]
+
+
+class PrometheusHttpQuery:
+    """Call Prometheus instant-query API with an existing aiohttp session."""
+
+    def __init__(self, session: Any, base_url: str) -> None:
+        self._session = session
+        self._endpoint = f"{base_url.rstrip('/')}/api/v1/query"
+
+    async def __call__(self, query: str) -> object:
+        async with self._session.get(
+            self._endpoint,
+            params={"query": query},
+        ) as response:
+            response.raise_for_status()
+            return await response.json()
+
+
+def sanitize_text(value: str) -> str:
+    """Remove common credential shapes from errors before output or recording."""
+
+    result = URL_USERINFO_RE.sub(r"\1<redacted>@", value)
+    result = HF_ASSIGNMENT_RE.sub(r"\1<redacted>", result)
+    result = HF_CREDENTIAL_RE.sub("<redacted-hugging-face-credential>", result)
+    return BEARER_RE.sub(r"\1<redacted>", result)
+
+
+def to_json_value(value: Any) -> Any:
+    """Convert dataclasses and non-finite floats into strict JSON values."""
+
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return to_json_value(dataclasses.asdict(value))
+    if isinstance(value, Mapping):
+        return {str(key): to_json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [to_json_value(item) for item in value]
+    if isinstance(value, str):
+        return sanitize_text(value)
+    if isinstance(value, float) and not math.isfinite(value):
+        if math.isnan(value):
+            return "NaN"
+        return "Infinity" if value > 0 else "-Infinity"
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return sanitize_text(str(value))
+
+
+def utc_timestamp(value_s: float) -> str:
+    """Format a wall-clock timestamp as RFC 3339 UTC."""
+
+    return (
+        dt.datetime.fromtimestamp(value_s, tz=dt.timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def make_run_id(now_s: float | None = None, suffix: str | None = None) -> str:
+    """Create a collision-resistant UTC control-loop run identifier."""
+
+    observed_s = time.time() if now_s is None else now_s
+    timestamp = dt.datetime.fromtimestamp(observed_s, tz=dt.timezone.utc)
+    random_suffix = suffix or secrets.token_hex(3)
+    return (
+        f"{timestamp.strftime('%Y%m%dT%H%M%SZ')}-planner-loop-{random_suffix.lower()}"
+    )
+
+
+def validate_settings(settings: ControlLoopSettings) -> None:
+    """Reject configurations that cannot renew a valid lease safely."""
+
+    if not settings.run_id:
+        raise ControlLoopConfigurationError("run_id must not be empty")
+    if not settings.pool_id or not settings.work_class or not settings.tenant:
+        raise ControlLoopConfigurationError(
+            "pool_id, work_class, and tenant must not be empty"
+        )
+    if settings.iterations <= 0:
+        raise ControlLoopConfigurationError("iterations must be positive")
+    if not math.isfinite(settings.interval_seconds) or settings.interval_seconds <= 0:
+        raise ControlLoopConfigurationError(
+            "interval_seconds must be positive and finite"
+        )
+    if (
+        not math.isfinite(settings.drain_lease_duration_s)
+        or settings.drain_lease_duration_s <= settings.interval_seconds
+    ):
+        raise ControlLoopConfigurationError(
+            "drain lease duration must be finite and greater than the loop interval"
+        )
+    if settings.ready_replicas < 0:
+        raise ControlLoopConfigurationError("ready_replicas must be non-negative")
+    if settings.min_replicas < 0:
+        raise ControlLoopConfigurationError("min_replicas must be non-negative")
+    if (
+        settings.max_replicas is not None
+        and settings.max_replicas < settings.min_replicas
+    ):
+        raise ControlLoopConfigurationError(
+            "max_replicas must be greater than or equal to min_replicas"
+        )
+    for name, value, allow_zero in (
+        (
+            "safe_rps_per_ready_replica",
+            settings.safe_rps_per_ready_replica,
+            False,
+        ),
+        ("online_offered_rps", settings.online_offered_rps, True),
+        ("cold_start_margin_s", settings.cold_start_margin_s, True),
+        ("finalization_margin_s", settings.finalization_margin_s, True),
+        ("max_observation_age_s", settings.max_observation_age_s, True),
+    ):
+        if not math.isfinite(value) or value < 0 or (not allow_zero and value == 0):
+            qualifier = "non-negative" if allow_zero else "positive"
+            raise ControlLoopConfigurationError(
+                f"{name} must be {qualifier} and finite"
+            )
+    if settings.max_batch_admission_rps is not None and (
+        not math.isfinite(settings.max_batch_admission_rps)
+        or settings.max_batch_admission_rps < 0
+    ):
+        raise ControlLoopConfigurationError(
+            "max_batch_admission_rps must be non-negative and finite"
+        )
+
+
+def validate_plan(
+    plan: Any,
+    settings: ControlLoopSettings,
+    tick_now_s: float,
+    decision_id: str,
+) -> None:
+    """Validate the policy boundary before a Redis mutation is possible."""
+
+    replica_floor = getattr(plan, "replica_floor", None)
+    if (
+        isinstance(replica_floor, bool)
+        or not isinstance(replica_floor, int)
+        or replica_floor < 0
+    ):
+        raise ValueError("policy returned an invalid replica_floor")
+    decision = getattr(plan, "drain_limit", None)
+    if decision is None:
+        raise ValueError("policy returned no drain_limit")
+    if getattr(decision, "pool_id", None) != settings.pool_id:
+        raise ValueError("policy drain_limit targets the wrong pool")
+    rate = getattr(decision, "max_admission_rps", None)
+    if (
+        isinstance(rate, bool)
+        or not isinstance(rate, (int, float))
+        or not math.isfinite(rate)
+        or rate < 0
+    ):
+        raise ValueError("policy returned an invalid drain rate")
+    valid_until_s = getattr(decision, "valid_until_s", None)
+    if (
+        isinstance(valid_until_s, bool)
+        or not isinstance(valid_until_s, (int, float))
+        or not math.isfinite(valid_until_s)
+        or valid_until_s <= tick_now_s
+    ):
+        raise ValueError("policy returned an expired or invalid drain lease")
+    if getattr(decision, "decision_id", None) != decision_id:
+        raise ValueError("policy returned a mismatched decision_id")
+
+
+def decision_record(
+    *,
+    settings: ControlLoopSettings,
+    iteration: int,
+    recorded_at_s: float,
+    status: str,
+    observation: Any,
+    plan: Any,
+    drain_limit_applied: bool,
+    error: Mapping[str, Any] | None = None,
+    fail_closed_pause: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one stable audit record without endpoint or credential fields."""
+
+    decision = None
+    diagnostics = None
+    if plan is not None:
+        decision = {
+            "replica_floor_advisory": plan.replica_floor,
+            "replica_scaling_applied": False,
+            "drain_limit": plan.drain_limit,
+        }
+        diagnostics = plan.diagnostics
+    return {
+        "schema_version": "1.0",
+        "run_id": settings.run_id,
+        "iteration": iteration,
+        "recorded_at": utc_timestamp(recorded_at_s),
+        "mode": "apply" if settings.apply_drain_limit else "dry_run",
+        "status": status,
+        "inputs": settings.public_record(),
+        "observation": observation,
+        "decision": decision,
+        "diagnostics": diagnostics,
+        "actuation": {
+            "drain_limit_applied": drain_limit_applied,
+            "replica_scaling_applied": False,
+        },
+        "error": error,
+        "fail_closed_pause": fail_closed_pause,
+    }
+
+
+async def _best_effort_fail_closed_pause(
+    *,
+    settings: ControlLoopSettings,
+    phase: str,
+    decision_id: str,
+    actuator: DrainLimitActuator | None,
+    pause_decision_builder: PauseDecisionBuilder,
+    clock: Callable[[], float],
+) -> dict[str, Any] | None:
+    if (
+        not settings.apply_drain_limit
+        or actuator is None
+        or phase not in {"collection", "policy"}
+    ):
+        return None
+
+    result: dict[str, Any] = {
+        "attempted": True,
+        "applied": False,
+        "decision": None,
+        "error": None,
+    }
+    try:
+        now_s = clock()
+        pause = pause_decision_builder(
+            settings.pool_id,
+            0.0,
+            now_s + settings.drain_lease_duration_s,
+            f"{decision_id}-fail-closed",
+        )
+        result["decision"] = pause
+        await actuator.apply_drain_limit(pause)
+        result["applied"] = True
+    except Exception as error:  # noqa: BLE001 - best-effort failure is evidence
+        result["error"] = {
+            "type": type(error).__name__,
+            "message": sanitize_text(str(error)),
+        }
+    return result
+
+
+async def run_control_loop(
+    *,
+    settings: ControlLoopSettings,
+    collector: SchedulingCollector,
+    policy_config: Any,
+    policy: SchedulingPolicy,
+    tick_input_builder: TickInputBuilder,
+    pause_decision_builder: PauseDecisionBuilder,
+    recorder: JsonlDecisionRecorder,
+    actuator: DrainLimitActuator | None = None,
+    clock: Callable[[], float] = time.time,
+    sleeper: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    status_sink: Callable[[str], None] | None = None,
+) -> None:
+    """Collect, decide, optionally renew the leased drain cap, and record."""
+
+    validate_settings(settings)
+    if settings.apply_drain_limit and actuator is None:
+        raise ControlLoopConfigurationError(
+            "apply mode requires a drain-limit actuator"
+        )
+
+    for iteration in range(1, settings.iterations + 1):
+        if iteration > 1:
+            try:
+                await sleeper(settings.interval_seconds)
+            except Exception as error:
+                failed_at_s = clock()
+                recorder.append(
+                    decision_record(
+                        settings=settings,
+                        iteration=iteration,
+                        recorded_at_s=failed_at_s,
+                        status="error",
+                        observation=None,
+                        plan=None,
+                        drain_limit_applied=False,
+                        error={
+                            "phase": "interval",
+                            "type": type(error).__name__,
+                            "message": sanitize_text(str(error)),
+                        },
+                    )
+                )
+                raise ControlLoopFailure("interval", error) from error
+
+        decision_id = f"{settings.run_id}-{iteration:06d}"
+        phase = "collection"
+        observation = None
+        plan = None
+        tick_now_s: float | None = None
+        drain_limit_applied = False
+        try:
+            observation = await collector.collect()
+            phase = "policy"
+            tick_now_s = clock()
+            tick_input = tick_input_builder(
+                tick_now_s,
+                settings.ready_replicas,
+                observation,
+            )
+            plan = policy(
+                tick_input,
+                policy_config,
+                decision_id=decision_id,
+            )
+            validate_plan(plan, settings, tick_now_s, decision_id)
+            phase = "actuation"
+            if settings.apply_drain_limit:
+                assert actuator is not None
+                await actuator.apply_drain_limit(plan.drain_limit)
+                drain_limit_applied = True
+        except Exception as error:
+            failure_at_s = clock()
+            pause_result = await _best_effort_fail_closed_pause(
+                settings=settings,
+                phase=phase,
+                decision_id=decision_id,
+                actuator=actuator,
+                pause_decision_builder=pause_decision_builder,
+                clock=clock,
+            )
+            recorder.append(
+                decision_record(
+                    settings=settings,
+                    iteration=iteration,
+                    recorded_at_s=failure_at_s,
+                    status="error",
+                    observation=observation,
+                    plan=plan,
+                    drain_limit_applied=drain_limit_applied,
+                    error={
+                        "phase": phase,
+                        "type": type(error).__name__,
+                        "message": sanitize_text(str(error)),
+                    },
+                    fail_closed_pause=pause_result,
+                )
+            )
+            raise ControlLoopFailure(phase, error) from error
+
+        assert tick_now_s is not None
+        status = "applied" if settings.apply_drain_limit else "planned"
+        recorder.append(
+            decision_record(
+                settings=settings,
+                iteration=iteration,
+                recorded_at_s=tick_now_s,
+                status=status,
+                observation=observation,
+                plan=plan,
+                drain_limit_applied=drain_limit_applied,
+            )
+        )
+        if status_sink is not None:
+            status_sink(
+                f"iteration {iteration}/{settings.iterations}: {status}; "
+                f"drain_limit_rps={plan.drain_limit.max_admission_rps:.6g}; "
+                f"lease_until={plan.drain_limit.valid_until_s:.3f}; "
+                f"replica_floor_advisory={plan.replica_floor}"
+            )
+
+
+def _validate_http_base_url(name: str, value: str) -> None:
+    try:
+        parsed = urlsplit(value)
+        _port = parsed.port
+    except ValueError as error:
+        raise ControlLoopConfigurationError(f"{name} is invalid: {error}") from error
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ControlLoopConfigurationError(f"{name} must be an HTTP(S) URL")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ControlLoopConfigurationError(
+            f"{name} must not contain credentials, a query, or a fragment"
+        )
+
+
+def positive_int(value: str) -> int:
+    result = int(value)
+    if result <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return result
+
+
+def non_negative_int(value: str) -> int:
+    result = int(value)
+    if result < 0:
+        raise argparse.ArgumentTypeError("must be non-negative")
+    return result
+
+
+def positive_float(value: str) -> float:
+    result = float(value)
+    if not math.isfinite(result) or result <= 0:
+        raise argparse.ArgumentTypeError("must be positive and finite")
+    return result
+
+
+def non_negative_float(value: str) -> float:
+    result = float(value)
+    if not math.isfinite(result) or result < 0:
+        raise argparse.ArgumentTypeError("must be non-negative and finite")
+    return result
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pool", required=True)
+    parser.add_argument("--work-class", required=True)
+    parser.add_argument(
+        "--safe-rps-per-ready-replica",
+        required=True,
+        type=positive_float,
+    )
+    parser.add_argument("--ready-replicas", required=True, type=non_negative_int)
+    parser.add_argument(
+        "--online-offered-rps",
+        required=True,
+        type=non_negative_float,
+    )
+    parser.add_argument("--batch-base-url", default="http://127.0.0.1:8001")
+    parser.add_argument("--prometheus-url", default="http://127.0.0.1:9090")
+    parser.add_argument("--tenant", default="planner-poc-baseline")
+    parser.add_argument("--iterations", type=positive_int, default=1)
+    parser.add_argument(
+        "--interval",
+        "--interval-seconds",
+        dest="interval_seconds",
+        type=positive_float,
+        default=10.0,
+    )
+    parser.add_argument("--drain-lease-seconds", type=positive_float, default=30.0)
+    parser.add_argument(
+        "--max-observation-age-seconds",
+        type=non_negative_float,
+        default=60.0,
+    )
+    parser.add_argument(
+        "--cold-start-margin-seconds",
+        type=non_negative_float,
+        default=0.0,
+    )
+    parser.add_argument(
+        "--finalization-margin-seconds",
+        type=non_negative_float,
+        default=0.0,
+    )
+    parser.add_argument("--min-replicas", type=non_negative_int, default=0)
+    parser.add_argument("--max-replicas", type=non_negative_int)
+    parser.add_argument(
+        "--max-batch-admission-rps",
+        type=non_negative_float,
+    )
+    parser.add_argument(
+        "--prometheus-observation-window-seconds",
+        type=positive_int,
+        default=90,
+    )
+    parser.add_argument("--http-timeout-seconds", type=positive_float, default=10.0)
+    parser.add_argument("--batch-page-size", type=positive_int, default=100)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Decision JSONL path; defaults to a unique raw experiment run",
+    )
+    parser.add_argument(
+        "--apply-drain-limit",
+        action="store_true",
+        help="Apply and renew the leased Redis drain limit; default is dry-run",
+    )
+    parser.add_argument("--redis-url")
+    parser.add_argument(
+        "--redis-control-key",
+        help="Exact single-pool llm-d Async control key; required in apply mode",
+    )
+    return parser
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    return build_parser().parse_args(argv)
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    _validate_http_base_url("--batch-base-url", args.batch_base_url)
+    _validate_http_base_url("--prometheus-url", args.prometheus_url)
+    if args.interval_seconds >= args.drain_lease_seconds:
+        raise ControlLoopConfigurationError(
+            "--interval must be less than --drain-lease-seconds"
+        )
+    if args.batch_page_size > 100:
+        raise ControlLoopConfigurationError("--batch-page-size cannot exceed 100")
+    max_replicas = (
+        args.ready_replicas if args.max_replicas is None else args.max_replicas
+    )
+    if max_replicas < args.min_replicas:
+        raise ControlLoopConfigurationError(
+            "--max-replicas must be greater than or equal to --min-replicas"
+        )
+    args.max_replicas = max_replicas
+    if args.apply_drain_limit and (not args.redis_url or not args.redis_control_key):
+        raise ControlLoopConfigurationError(
+            "--apply-drain-limit requires --redis-url and --redis-control-key"
+        )
+    if not args.apply_drain_limit and (args.redis_url or args.redis_control_key):
+        raise ControlLoopConfigurationError(
+            "Redis options require the explicit --apply-drain-limit flag"
+        )
+
+
+def _control_key_for_pool(
+    requested_pool: str,
+    configured_pool: str,
+    control_key: str,
+) -> str:
+    if requested_pool != configured_pool:
+        raise ValueError(
+            f"actuator requested pool {requested_pool!r}, expected {configured_pool!r}"
+        )
+    return control_key
+
+
+async def run_live(
+    args: argparse.Namespace,
+    settings: ControlLoopSettings,
+    recorder: JsonlDecisionRecorder,
+) -> None:
+    """Wire the stable Planner public APIs to the standalone loop."""
+
+    try:
+        prepare_source_checkout_planner_imports()
+        import aiohttp
+        from dynamo.planner.core.batch_policy import (
+            BatchSchedulingPolicyConfig,
+            plan_batch_schedule,
+        )
+        from dynamo.planner.core.types import (
+            BatchDrainLimitDecision,
+            PoolTrafficDemand,
+            TickInput,
+            WorkerCounts,
+        )
+        from dynamo.planner.environment.batch import (
+            BatchGatewayJobSource,
+            BatchSchedulingCollector,
+            LlmdAsyncPrometheusSource,
+            RedisLeasedDrainLimitActuator,
+        )
+    except ImportError as error:
+        raise RuntimeError(
+            "the control loop requires the Dynamo Planner package and aiohttp"
+        ) from error
+
+    timeout = aiohttp.ClientTimeout(total=args.http_timeout_seconds)
+    actuator = None
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        jobs = BatchGatewayJobSource(
+            base_url=args.batch_base_url,
+            session=session,
+            pool_resolver=lambda _job: args.pool,
+            work_class_resolver=lambda _job: args.work_class,
+            headers={"X-MaaS-Username": args.tenant},
+            page_size=args.batch_page_size,
+        )
+        online = StaticOnlineTrafficSource(
+            pool_id=args.pool,
+            online_offered_rps=args.online_offered_rps,
+            demand_factory=PoolTrafficDemand,
+        )
+        feedback = LlmdAsyncPrometheusSource(
+            pools=[args.pool],
+            query=PrometheusHttpQuery(session, args.prometheus_url),
+            observation_window_s=args.prometheus_observation_window_seconds,
+            max_sample_age_s=args.max_observation_age_seconds,
+        )
+        collector = BatchSchedulingCollector(
+            batch_jobs=jobs,
+            online_traffic=online,
+            dispatcher_feedback=feedback,
+        )
+        policy_config = BatchSchedulingPolicyConfig(
+            pool_id=args.pool,
+            work_class=args.work_class,
+            safe_rps_per_ready_replica=args.safe_rps_per_ready_replica,
+            cold_start_margin_s=args.cold_start_margin_seconds,
+            finalization_margin_s=args.finalization_margin_seconds,
+            max_observation_age_s=args.max_observation_age_seconds,
+            drain_lease_duration_s=args.drain_lease_seconds,
+            min_replicas=args.min_replicas,
+            max_replicas=args.max_replicas,
+            max_batch_admission_rps=args.max_batch_admission_rps,
+        )
+        if args.apply_drain_limit:
+            assert args.redis_url is not None
+            assert args.redis_control_key is not None
+            actuator = RedisLeasedDrainLimitActuator.from_url(
+                args.redis_url,
+                control_key_resolver=lambda pool_id: _control_key_for_pool(
+                    pool_id,
+                    args.pool,
+                    args.redis_control_key,
+                ),
+                decode_responses=True,
+            )
+
+        try:
+            await run_control_loop(
+                settings=settings,
+                collector=collector,
+                policy_config=policy_config,
+                policy=plan_batch_schedule,
+                tick_input_builder=lambda now_s, ready, observation: TickInput(
+                    now_s=now_s,
+                    worker_counts=WorkerCounts(ready_num_decode=ready),
+                    batch=observation,
+                ),
+                pause_decision_builder=lambda pool_id, rate, valid_until_s, decision_id: (
+                    BatchDrainLimitDecision(
+                        pool_id=pool_id,
+                        max_admission_rps=rate,
+                        valid_until_s=valid_until_s,
+                        decision_id=decision_id,
+                    )
+                ),
+                recorder=recorder,
+                actuator=actuator,
+                status_sink=print,
+            )
+        finally:
+            if actuator is not None:
+                await actuator.aclose()
+
+
+def _startup_error_record(
+    settings: ControlLoopSettings,
+    error: BaseException,
+) -> dict[str, Any]:
+    recorded_at_s = time.time()
+    return {
+        "schema_version": "1.0",
+        "run_id": settings.run_id,
+        "iteration": 0,
+        "recorded_at": utc_timestamp(recorded_at_s),
+        "mode": "apply" if settings.apply_drain_limit else "dry_run",
+        "status": "error",
+        "inputs": settings.public_record(),
+        "observation": None,
+        "decision": None,
+        "diagnostics": None,
+        "actuation": {
+            "drain_limit_applied": False,
+            "replica_scaling_applied": False,
+        },
+        "error": {
+            "phase": "startup",
+            "type": type(error).__name__,
+            "message": sanitize_text(str(error)),
+        },
+        "fail_closed_pause": None,
+    }
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    live_runner: Callable[
+        [argparse.Namespace, ControlLoopSettings, JsonlDecisionRecorder],
+        Awaitable[None],
+    ] = run_live,
+) -> int:
+    args = parse_args(argv)
+    try:
+        validate_args(args)
+    except ControlLoopConfigurationError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    run_id = make_run_id()
+    output = (
+        args.output.expanduser().resolve()
+        if args.output is not None
+        else EXPERIMENT_ROOT
+        / "results"
+        / "raw"
+        / run_id
+        / "control-loop-decisions.jsonl"
+    )
+    settings = ControlLoopSettings(
+        run_id=run_id,
+        pool_id=args.pool,
+        work_class=args.work_class,
+        safe_rps_per_ready_replica=args.safe_rps_per_ready_replica,
+        ready_replicas=args.ready_replicas,
+        online_offered_rps=args.online_offered_rps,
+        iterations=args.iterations,
+        interval_seconds=args.interval_seconds,
+        drain_lease_duration_s=args.drain_lease_seconds,
+        apply_drain_limit=args.apply_drain_limit,
+        cold_start_margin_s=args.cold_start_margin_seconds,
+        finalization_margin_s=args.finalization_margin_seconds,
+        max_observation_age_s=args.max_observation_age_seconds,
+        min_replicas=args.min_replicas,
+        max_replicas=args.max_replicas,
+        max_batch_admission_rps=args.max_batch_admission_rps,
+        tenant=args.tenant,
+    )
+
+    try:
+        with JsonlDecisionRecorder(output) as recorder:
+            print(f"run ID: {run_id}")
+            print(f"mode: {'apply' if args.apply_drain_limit else 'dry-run'}")
+            print(f"decision records: {output}")
+            try:
+                asyncio.run(live_runner(args, settings, recorder))
+            except ControlLoopFailure as error:
+                print(f"error: {error}", file=sys.stderr)
+                return 1
+            except KeyboardInterrupt:
+                print("control loop interrupted", file=sys.stderr)
+                return 130
+            except Exception as error:  # noqa: BLE001 - startup needs evidence
+                recorder.append(_startup_error_record(settings, error))
+                print(
+                    f"error: {type(error).__name__}: {sanitize_text(str(error))}",
+                    file=sys.stderr,
+                )
+                return 1
+    except OSError as error:
+        print(f"error: cannot create decision output: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/deployments/llm-d-batch-gateway/planner-scheduling/experiment/workloads/verify_native_planner_e2e.py
+++ b/examples/deployments/llm-d-batch-gateway/planner-scheduling/experiment/workloads/verify_native_planner_e2e.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Verify a native Planner autonomous scale-from-zero batch run."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+DISPATCHED = "llm_d_async_async_dispatched_requests_total"
+SUCCESSFUL = "llm_d_async_async_successful_requests_total"
+BACKLOG = "llm_d_async_async_broker_backlog"
+INFLIGHT = "llm_d_async_async_inflight_requests"
+QUEUE_DEPTH = "llm_d_async_async_queue_depth"
+DRAIN_GAUGE = "llm_d_async_async_drain_limit_rps"
+
+
+def _read_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    with path.open(encoding="utf-8") as stream:
+        return [json.loads(line) for line in stream if line.strip()]
+
+
+def _lease_cap(state: dict[str, Any]) -> float:
+    fields = next(csv.reader([state["lease_csv"]]))
+    if len(fields) != 5:
+        raise ValueError(f"expected five lease fields, got {fields!r}")
+    return float(fields[2])
+
+
+def _metric_value(payload: str, name: str) -> float:
+    for line in payload.splitlines():
+        if not line.startswith(name):
+            continue
+        if "{" in line and 'pool_name="dynamo-batch"' not in line:
+            continue
+        return float(line.rsplit(maxsplit=1)[1])
+    raise ValueError(f"metric {name!r} not found")
+
+
+def _parse_rfc3339(value: str) -> datetime:
+    match = re.match(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z$", value)
+    if match is None:
+        raise ValueError(f"invalid RFC3339 timestamp: {value!r}")
+    fraction = (match.group(2) or "")[:6].ljust(6, "0")
+    return datetime.fromisoformat(f"{match.group(1)}.{fraction}+00:00")
+
+
+def _normalize_observer_time(value: str) -> str:
+    # BSD date preserves GNU's unsupported %3N token literally. The raw stream
+    # remains untouched; derived output safely falls back to second precision.
+    return re.sub(r"\.3NZ$", "Z", value)
+
+
+def _first_log_time(log: str, needle: str) -> datetime:
+    for line in log.splitlines():
+        if needle not in line:
+            continue
+        return _parse_rfc3339(line.split(maxsplit=1)[0])
+    raise ValueError(f"Planner log entry not found: {needle!r}")
+
+
+def _first_metric_increase(
+    run_dir: Path, baseline: float
+) -> tuple[str | None, float | None]:
+    for prom_path in sorted((run_dir / "metrics" / "async").glob("*.prom")):
+        value = _metric_value(prom_path.read_text(encoding="utf-8"), DISPATCHED)
+        if value <= baseline:
+            continue
+        metadata_path = prom_path.with_suffix(".json")
+        observed_at = _read_json(metadata_path)["observed_at"]
+        return observed_at, value
+    return None, None
+
+
+def _first_index(items: list[Any], predicate: Any) -> int:
+    return next(index for index, item in enumerate(items) if predicate(item))
+
+
+def verify(run_dir: Path, evidence_dir: Path) -> dict[str, Any]:
+    states = _read_jsonl(evidence_dir / "state.jsonl")
+    caps = [_lease_cap(state) for state in states]
+    scale_index = _first_index(states, lambda state: state["adapter_spec"] == 1)
+    ready_index = _first_index(states, lambda state: state["ready_worker_pods"] >= 1)
+    positive_index = _first_index(caps, lambda cap: cap > 0)
+    terminal_zero_index = next(
+        index for index in range(positive_index + 1, len(caps)) if caps[index] == 0
+    )
+
+    terminal = _read_json(run_dir / "terminal-batch.json")
+    validation = _read_json(run_dir / "result-validation.json")
+    adapter_before = _read_json(evidence_dir / "dgdsa.before.json")
+    adapter_after = _read_json(evidence_dir / "dgdsa.after.json")
+    watch_events = _read_jsonl(evidence_dir / "dgdsa.watch.jsonstream")
+    planner_log = (evidence_dir / "planner.log").read_text(encoding="utf-8")
+
+    redis_after = (
+        (evidence_dir / "redis.after.txt").read_text(encoding="utf-8").splitlines()
+    )
+    redis_pttl_ms = int(
+        (evidence_dir / "redis.after.pttl-ms.txt").read_text(encoding="utf-8").strip()
+    )
+
+    metrics_before = (evidence_dir / "async-metrics.before.txt").read_text(
+        encoding="utf-8"
+    )
+    metrics_after = (evidence_dir / "async-metrics.after.txt").read_text(
+        encoding="utf-8"
+    )
+    dispatched_before = _metric_value(metrics_before, DISPATCHED)
+    dispatched_after = _metric_value(metrics_after, DISPATCHED)
+    successful_before = _metric_value(metrics_before, SUCCESSFUL)
+    successful_after = _metric_value(metrics_after, SUCCESSFUL)
+    first_increase_at, first_increase_value = _first_metric_increase(
+        run_dir, dispatched_before
+    )
+    positive_log_at = _first_log_time(planner_log, "max_admission_rps=5.0")
+
+    log_needles = [
+        "replica_floor=1 max_admission_rps=0.0",
+        "Updating decode component VllmDecodeWorker from 0 to desired replica count 1",
+        "Scaled DGDSA qwen3-0-6b-batch-vllmdecodeworker to 1 replicas",
+        "replica_floor=1 max_admission_rps=5.0",
+        "replica_floor=0 max_admission_rps=0.0",
+    ]
+    log_positions: list[int] = []
+    log_cursor = 0
+    for needle in log_needles:
+        position = planner_log.find(needle, log_cursor)
+        log_positions.append(position)
+        if position >= 0:
+            log_cursor = position + len(needle)
+
+    assertions = {
+        "harness_exit_zero": (run_dir / "exit_code.txt").read_text().strip() == "0",
+        "gateway_terminal_100_100_0": terminal.get("status") == "completed"
+        and terminal.get("request_counts")
+        == {"completed": 100, "failed": 0, "total": 100},
+        "downloaded_results_valid": validation.get("valid") is True
+        and validation.get("downloaded_output_lines") == 100
+        and validation.get("unique_custom_ids") == 100,
+        "adapter_started_at_zero": adapter_before["spec"]["replicas"] == 0
+        and adapter_before["status"]["replicas"] == 0
+        and states[0]["adapter_spec"] == 0,
+        "adapter_finished_at_one": adapter_after["spec"]["replicas"] == 1
+        and adapter_after["status"]["replicas"] == 1
+        and states[-1]["adapter_spec"] == 1,
+        "watch_observed_zero_to_one": watch_events[0]["object"]["spec"]["replicas"] == 0
+        and any(event["object"]["spec"]["replicas"] == 1 for event in watch_events),
+        "planner_logged_authoritative_scale": all(
+            position >= 0 for position in log_positions[:3]
+        ),
+        "planner_policy_log_order": all(position >= 0 for position in log_positions),
+        "scale_preceded_worker_readiness": scale_index < ready_index,
+        "lease_remained_closed_until_ready": positive_index > ready_index
+        and all(
+            cap <= 0
+            or (
+                states[index]["ready_worker_pods"] >= 1
+                and states[index]["worker_ready_replicas"] >= 1
+                and states[index]["dgd_ready"] == "True"
+            )
+            for index, cap in enumerate(caps)
+        ),
+        "dispatch_started_after_positive_lease": first_increase_at is not None
+        and _parse_rfc3339(first_increase_at) >= positive_log_at,
+        "terminal_zero_observed_after_positive": terminal_zero_index > positive_index
+        and caps[-1] == 0,
+        "authoritative_terminal_lease_zero_and_fresh": len(redis_after) >= 5
+        and redis_after[0] == "llm-d.ai/v1alpha1"
+        and redis_after[1] == "dynamo-batch"
+        and float(redis_after[2]) == 0
+        and 0 < redis_pttl_ms <= 60_000,
+        "exactly_100_dispatches_and_successes": dispatched_after - dispatched_before
+        == 100
+        and successful_after - successful_before == 100,
+        "async_terminal_queues_empty": _metric_value(metrics_after, BACKLOG) == 0
+        and _metric_value(metrics_after, INFLIGHT) == 0
+        and _metric_value(metrics_after, QUEUE_DEPTH) == 0,
+    }
+
+    return {
+        "schema_version": 1,
+        "all_passed": all(assertions.values()),
+        "assertions": assertions,
+        "timeline": {
+            "observer_first": _normalize_observer_time(states[0]["observed_at"]),
+            "adapter_one": _normalize_observer_time(states[scale_index]["observed_at"]),
+            "worker_ready": _normalize_observer_time(
+                states[ready_index]["observed_at"]
+            ),
+            "positive_lease": _normalize_observer_time(
+                states[positive_index]["observed_at"]
+            ),
+            "first_dispatch_counter_increase": first_increase_at,
+            "terminal_zero_lease": _normalize_observer_time(
+                states[terminal_zero_index]["observed_at"]
+            ),
+            "observer_last": _normalize_observer_time(states[-1]["observed_at"]),
+        },
+        "observed": {
+            "batch_id": terminal["id"],
+            "state_samples": len(states),
+            "adapter_generation": {
+                "before": adapter_before["metadata"]["generation"],
+                "after": adapter_after["metadata"]["generation"],
+            },
+            "adapter_resource_version": {
+                "before": adapter_before["metadata"]["resourceVersion"],
+                "after": adapter_after["metadata"]["resourceVersion"],
+            },
+            "dispatch_counter": {
+                "before": dispatched_before,
+                "after": dispatched_after,
+                "first_increase_value": first_increase_value,
+            },
+            "successful_counter": {
+                "before": successful_before,
+                "after": successful_after,
+            },
+            "redis_terminal_cap_rps": float(redis_after[2]),
+            "redis_terminal_pttl_ms": redis_pttl_ms,
+            "async_idle_last_evaluated_drain_gauge_rps": _metric_value(
+                metrics_after, DRAIN_GAUGE
+            ),
+        },
+        "notes": [
+            "The Redis lease is authoritative; Async's drain gauge reports the last gate evaluation and can remain at 5 while the queue is idle.",
+            "A batch floor is a lower bound, so the worker may remain at one replica after the batch completes even though the floor and drain cap return to zero.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-dir", type=Path, required=True)
+    parser.add_argument("--evidence-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    result = verify(args.run_dir.resolve(), args.evidence_dir.resolve())
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["all_passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/deployments/llm-d-batch-gateway/planner-scheduling/planner-poc.yaml
+++ b/examples/deployments/llm-d-batch-gateway/planner-scheduling/planner-poc.yaml
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Template variables are intentionally required. Render this file with the
+# documented envsubst command; do not apply it directly.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: qwen3-0-6b-batch-planner-scaling-adapter
+  namespace: ${NAMESPACE}
+rules:
+  - apiGroups:
+      - nvidia.com
+    resources:
+      - dynamographdeploymentscalingadapters
+    resourceNames:
+      - qwen3-0-6b-batch-vllmdecodeworker
+    verbs:
+      - get
+  - apiGroups:
+      - nvidia.com
+    resources:
+      - dynamographdeploymentscalingadapters/scale
+    resourceNames:
+      - qwen3-0-6b-batch-vllmdecodeworker
+    verbs:
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: qwen3-0-6b-batch-planner-scaling-adapter
+  namespace: ${NAMESPACE}
+subjects:
+  - kind: ServiceAccount
+    name: planner-serviceaccount
+    namespace: ${NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: qwen3-0-6b-batch-planner-scaling-adapter
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: qwen3-0-6b-batch-planner-config
+  namespace: ${NAMESPACE}
+data:
+  planner.yaml: |
+    environment: kubernetes
+    namespace: ${NAMESPACE}-qwen3-0-6b-batch
+    backend: vllm
+    mode: agg
+    model_name: Qwen/Qwen3-0.6B
+    optimization_target: throughput
+    pre_deployment_sweeping_mode: none
+    enable_throughput_scaling: false
+    enable_load_scaling: true
+    load_adjustment_interval_seconds: 5
+    throughput_adjustment_interval_seconds: 60
+    min_endpoint: 0
+    max_gpu_budget: 1
+    metric_reporting_prometheus_port: 0
+    live_dashboard_port: 0
+    report_interval_hours: null
+    scheduling:
+      scale_interval_seconds: 5
+      tick_max_duration_seconds: 20
+    batch_scheduling:
+      enabled: true
+      gateway:
+        base_url: http://batch-gateway-apiserver:8000
+        tenant: planner-poc-baseline
+        request_timeout_seconds: 5
+        page_size: 100
+        max_pages: 100
+      metrics:
+        frontend_metrics_url: http://qwen3-0-6b-batch-frontend:8000/metrics
+        dispatcher_metrics_url: http://async-dispatch-llm-d-async-metrics:9090/metrics
+        online_match_labels:
+          endpoint: chat_completions
+          model: Qwen/Qwen3-0.6B
+          request_type: stream
+        request_timeout_seconds: 5
+      redis:
+        control_key: llm-d-async:drain-limit:dynamo-batch
+        connect_timeout_seconds: 2
+        socket_timeout_seconds: 2
+      pool:
+        pool_id: dynamo-batch
+        work_class: gsm8k-qwen3-0.6b-chat-v1
+        safe_rps_per_ready_replica: 15
+        cold_start_margin_seconds: 30
+        finalization_margin_seconds: 5
+        max_observation_age_seconds: 15
+        drain_lease_duration_seconds: 60
+        min_replicas: 0
+        max_replicas: 1
+        scale_from_zero_replicas: 1
+        max_batch_admission_rps: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: async-dispatch-llm-d-async-metrics
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/instance: async-dispatch
+    app.kubernetes.io/name: llm-d-async
+spec:
+  selector:
+    app.kubernetes.io/instance: async-dispatch
+    app.kubernetes.io/name: llm-d-async
+  ports:
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: metrics
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: qwen3-0-6b-batch-planner
+  namespace: ${NAMESPACE}
+spec:
+  components:
+    - name: Planner
+      type: planner
+      replicas: 1
+      podTemplate:
+        spec:
+          terminationGracePeriodSeconds: 30
+          containers:
+            - name: main
+              image: ${PLANNER_IMAGE}
+              imagePullPolicy: Always
+              command:
+                - python3
+                - -m
+                - dynamo.planner
+              args:
+                - --config
+                - /etc/dynamo/planner/planner.yaml
+              env:
+                - name: DYN_NAMESPACE
+                  value: ${NAMESPACE}-qwen3-0-6b-batch
+                - name: DYN_PARENT_DGD_K8S_NAME
+                  value: qwen3-0-6b-batch
+                - name: DYN_PARENT_DGD_K8S_NAMESPACE
+                  value: ${NAMESPACE}
+                - name: DYN_PLANNER_BATCH_REDIS_URL
+                  value: redis://batch-gateway-valkey:6379/0
+              volumeMounts:
+                - name: planner-config
+                  mountPath: /etc/dynamo/planner
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: "1"
+                  memory: 1Gi
+                limits:
+                  cpu: "2"
+                  memory: 2Gi
+          volumes:
+            - name: planner-config
+              configMap:
+                name: qwen3-0-6b-batch-planner-config


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This adds the deployment plumbing and bounded control tooling for a single-pool Planner-controlled llm-d Batch Gateway POC. It provides a reproducible path from Gateway job observation through leased Async admission control and owned worker scaling, with explicit safety checks at every boundary.

CLOSES: LLM-190

### How This Was Implemented
- Add an llm-d Async v0.9 overlay that routes `dynamo-batch` through the companion Redis leased-rate worker-pool gate.
- Add a namespace-rendered Planner DGD, configuration, metrics service, and least-privilege DGDSA RBAC.
- Make the frontend and worker share the model cache, opt the worker into DGDSA ownership, and set Batch Gateway storage security context for the shared PVC.
- Add a bounded standalone control-loop runner with dry-run default, explicit apply gating, immutable decision logs, and fail-closed pause behavior.
- Add deployment, experiment, workload, cleanup, and verification instructions plus a machine verifier for native scale-from-zero runs.

<details>
<summary>Walkthrough</summary>

- `llm-d-async-planner-values.yaml` configures the worker pool, Redis control key, queue routing, frontend target, and five-second metrics scrape.
- `planner-scheduling/planner-poc.yaml` renders six same-namespace resources for the native Planner deployment.
- `dynamo.yaml` adds DGDSA ownership and shared Hugging Face cache access to the serving graph.
- `batch-gateway-values.yaml` gives the API server and processor a compatible non-root shared-volume security context.
- `workloads/batch_planner_control_loop.py` exercises the public collector, policy, and actuator interfaces outside native lifecycle for controlled baselines.
- `workloads/verify_native_planner_e2e.py` checks ordering, cardinality, DGDSA recovery, lease state, and Async counter deltas from preserved artifacts.

</details>

### Validation
- Combined standalone control-loop and baseline experiment suites passed all 37 hermetic tests.
- Helm lint/render passed, the six-resource Planner deployment passed Kubernetes server-side dry-run, and the deployed image passed an import/policy smoke test.
- Live validation completed 100/100 requests with zero failures under the controlled gate; the native run separately passed all 15 scale-from-zero assertions.
<!-- codex-pr-description:end -->
