### PR TITLE
feat(RL): support external RL control planes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3171,6 +3171,7 @@ dependencies = [
  "futures",
  "prost 0.13.5",
  "prost-types 0.13.5",
+ "reqwest 0.12.28",
  "serde_json",
  "tokio",
  "tokio-stream",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2621,6 +2621,7 @@ dependencies = [
  "futures",
  "prost 0.13.5",
  "prost-types 0.13.5",
+ "reqwest 0.12.28",
  "serde_json",
  "tokio",
  "tokio-util",

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -37,7 +37,6 @@ use super::{RouteDoc, service_v2};
 use crate::local_model::runtime_config::VLLM_INFERENCE_V1_GENERATE_CAPABILITY;
 use crate::protocols::common::preprocessor::{MmRoutingInfo, PreprocessedRequest};
 use crate::protocols::common::timing::RequestTracker;
-use crate::protocols::common::{SamplingOptions, StopConditions};
 use crate::protocols::openai::generate::{
     GenerateRequest, GenerateResponse, GenerateResponseOptions, SamplingParams, StreamOptions,
 };
@@ -567,8 +566,13 @@ fn preprocessed_from_generate_with_tracker(
     } = routing_metadata;
     let sampling = &request.sampling_params;
     let max_tokens = sampling.max_tokens();
-    let min_tokens = sampling.min_tokens();
-    let ignore_eos = sampling.ignore_eos();
+    let stop_conditions = sampling.project_stop_conditions();
+    let sampling_options = sampling
+        .project_sampling_options()
+        .map_err(anyhow::Error::msg)?;
+    let output_options = sampling
+        .project_output_options()
+        .map_err(anyhow::Error::msg)?;
     let routing_priority = dynamo_routing_priority(request.priority);
     // With vLLM's default `enable_tower_connector_lora=false`, MM identifiers
     // are adapter-invariant and `lora_name` separately salts LM KV hashes. When
@@ -612,17 +616,9 @@ fn preprocessed_from_generate_with_tracker(
     PreprocessedRequest::builder()
         .model(model.to_string())
         .token_ids(token_ids)
-        .stop_conditions(StopConditions {
-            max_tokens,
-            min_tokens,
-            ignore_eos: Some(ignore_eos),
-            ..Default::default()
-        })
-        .sampling_options(SamplingOptions {
-            n: Some(1),
-            ..Default::default()
-        })
-        .output_options(Default::default())
+        .stop_conditions(stop_conditions)
+        .sampling_options(sampling_options)
+        .output_options(output_options)
         .mm_routing_info(mm_routing_info)
         .routing(Some(crate::protocols::common::preprocessor::RoutingHints {
             dp_rank: data_parallel_rank,
@@ -2197,7 +2193,7 @@ mod tests {
     }
 
     #[test]
-    fn generate_projects_prime_text_controls() {
+    fn generate_projects_training_text_controls() {
         let request: GenerateRequest = serde_json::from_value(serde_json::json!({
             "token_ids": [1, 2],
             "sampling_params": {

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -2197,6 +2197,58 @@ mod tests {
     }
 
     #[test]
+    fn generate_projects_prime_text_controls() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [1, 2],
+            "sampling_params": {
+                "temperature": 0.25,
+                "top_p": 0.9,
+                "top_k": 17,
+                "min_p": 0.05,
+                "seed": 23,
+                "max_tokens": 8,
+                "min_tokens": 2,
+                "presence_penalty": 0.1,
+                "frequency_penalty": 0.2,
+                "repetition_penalty": 1.1,
+                "stop_token_ids": [7, 8],
+                "ignore_eos": true,
+                "logprobs": 1,
+                "skip_special_tokens": false
+            },
+            "model": "test-model"
+        }))
+        .expect("deserialize request");
+
+        let preprocessed = preprocessed_from_generate(
+            request,
+            "test-model",
+            None,
+            "resolved-request",
+            routing_metadata(16, false, None),
+        )
+        .expect("build request");
+
+        assert_eq!(preprocessed.sampling_options.temperature, Some(0.25));
+        assert_eq!(preprocessed.sampling_options.top_p, Some(0.9));
+        assert_eq!(preprocessed.sampling_options.top_k, Some(17));
+        assert_eq!(preprocessed.sampling_options.min_p, Some(0.05));
+        assert_eq!(preprocessed.sampling_options.seed, Some(23));
+        assert_eq!(preprocessed.sampling_options.presence_penalty, Some(0.1));
+        assert_eq!(preprocessed.sampling_options.frequency_penalty, Some(0.2));
+        assert_eq!(preprocessed.sampling_options.repetition_penalty, Some(1.1));
+        assert_eq!(preprocessed.stop_conditions.max_tokens, Some(8));
+        assert_eq!(preprocessed.stop_conditions.min_tokens, Some(2));
+        assert_eq!(
+            preprocessed.stop_conditions.stop_token_ids.as_deref(),
+            Some(&[7, 8][..])
+        );
+        assert_eq!(preprocessed.stop_conditions.ignore_eos, Some(true));
+        assert_eq!(preprocessed.output_options.logprobs, Some(1));
+        assert_eq!(preprocessed.output_options.skip_special_tokens, Some(false));
+    }
+
+    #[test]
     fn generate_request_context_matches_vllm_header_precedence() {
         let mut headers = HeaderMap::new();
         headers.insert(X_REQUEST_ID_HEADER, "header-request".parse().unwrap());

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -246,6 +246,28 @@ impl<'a> VllmTitoEnvelope<'a> {
     }
 }
 
+fn canonical_generate_cache_salt(request: &GenerateRequest) -> anyhow::Result<Option<String>> {
+    let nested = match request
+        .sampling_params
+        .as_value()
+        .as_object()
+        .and_then(|sampling| sampling.get("cache_salt"))
+    {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(value)) => Some(value.as_str()),
+        Some(_) => anyhow::bail!("sampling_params.cache_salt must be a string or null"),
+    };
+
+    match (request.cache_salt.as_deref(), nested) {
+        (Some(top_level), Some(nested)) if top_level != nested => {
+            anyhow::bail!("cache_salt conflicts with sampling_params.cache_salt")
+        }
+        (Some(top_level), _) => Ok(Some(top_level.to_string())),
+        (None, Some(nested)) => Ok(Some(nested.to_string())),
+        (None, None) => Ok(None),
+    }
+}
+
 type MmPlaceholderRange = (usize, usize, u64, Option<Vec<bool>>);
 
 #[derive(Debug)]
@@ -565,6 +587,7 @@ fn preprocessed_from_generate_with_tracker(
         lora_name,
     } = routing_metadata;
     let sampling = &request.sampling_params;
+    let cache_salt = canonical_generate_cache_salt(&request)?;
     let max_tokens = sampling.max_tokens();
     let stop_conditions = sampling.project_stop_conditions();
     let sampling_options = sampling
@@ -607,11 +630,7 @@ fn preprocessed_from_generate_with_tracker(
         );
     }
     let mm_routing_info = mm_routing.map(|projection| projection.info);
-    let GenerateRequest {
-        token_ids,
-        cache_salt,
-        ..
-    } = request;
+    let GenerateRequest { token_ids, .. } = request;
 
     PreprocessedRequest::builder()
         .model(model.to_string())

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -1782,6 +1782,62 @@ mod tests {
     }
 
     #[test]
+    fn sampling_params_cache_salt_becomes_canonical_routing_salt() {
+        let raw = serde_json::json!({
+            "token_ids": [1, 2],
+            "sampling_params": {"cache_salt": "policy-7"}
+        });
+        let request: GenerateRequest =
+            serde_json::from_value(raw.clone()).expect("deserialize request");
+
+        let preprocessed = preprocessed_from_generate(
+            request,
+            "test-model",
+            None,
+            "resolved-request",
+            routing_metadata(16, false, None),
+        )
+        .expect("build request");
+
+        assert_eq!(
+            preprocessed
+                .routing
+                .as_ref()
+                .and_then(|routing| routing.cache_namespace.as_deref()),
+            Some("policy-7")
+        );
+        assert_eq!(
+            preprocessed
+                .extra_args
+                .as_ref()
+                .and_then(|extra| extra.get("vllm_tito"))
+                .expect("vllm_tito envelope")["sampling_params"]["cache_salt"],
+            raw["sampling_params"]["cache_salt"]
+        );
+    }
+
+    #[test]
+    fn conflicting_cache_salt_spellings_are_rejected_before_routing() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [1, 2],
+            "cache_salt": "policy-7",
+            "sampling_params": {"cache_salt": "policy-8"}
+        }))
+        .expect("deserialize request");
+
+        let error = preprocessed_from_generate(
+            request,
+            "test-model",
+            None,
+            "resolved-request",
+            routing_metadata(16, false, None),
+        )
+        .expect_err("conflicting cache salts must fail");
+
+        assert!(error.to_string().contains("cache_salt"));
+    }
+
+    #[test]
     fn multimodal_routing_matches_worker_events_and_preserves_execution_payload() {
         let hash_a = "a".repeat(64);
         let hash_b = "b".repeat(64);

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -637,6 +637,11 @@ pub struct OutputOptions {
     pub return_tokens_as_token_ids: Option<bool>,
 }
 
+impl OutputOptions {
+    /// Requests log probabilities for every token in the vocabulary.
+    pub const ALL_LOGPROBS: u32 = u32::MAX;
+}
+
 // Struct for log probability information
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ChatCompletionLogprobs {

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -255,7 +255,7 @@ impl SamplingParams {
 fn project_logprob_count(value: Option<i32>, field: &str) -> Result<Option<u32>, String> {
     match value {
         None => Ok(None),
-        Some(-1) => Ok(Some(u32::MAX)),
+        Some(-1) => Ok(Some(OutputOptions::ALL_LOGPROBS)),
         Some(value) if value >= 0 => Ok(Some(value as u32)),
         Some(value) => Err(format!(
             "sampling_params.{field} must be non-negative or -1, got {value}"

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -22,6 +22,7 @@ use serde_json::{Map, Value};
 use super::{convert_backend_top_logprobs, token_to_utf8_bytes};
 use crate::protocols::Annotated;
 use crate::protocols::common::llm_backend::{LLMEngineOutput, PromptLogprobs};
+use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
 
 /// Token-in/token-out generation request.
 ///
@@ -90,6 +91,13 @@ impl GenerateRequest {
 
         if self.sampling_params.max_tokens() == Some(0) {
             return Err("sampling_params.max_tokens must be greater than 0.".to_string());
+        }
+
+        if let Some(logprobs) = self.sampling_params.logprobs()
+            && logprobs < 0
+            && logprobs != -1
+        {
+            return Err("sampling_params.logprobs must be non-negative or -1.".to_string());
         }
 
         if let Some(prompt_logprobs) = self.sampling_params.prompt_logprobs() {
@@ -172,6 +180,7 @@ pub struct SamplingParams {
     /// typed view opaque avoids duplicating version-specific vLLM validation.
     structured_outputs: Option<Value>,
     skip_reading_prefix_cache: Option<bool>,
+    skip_special_tokens: Option<bool>,
     vllm_xargs: Option<HashMap<String, Value>>,
 }
 
@@ -198,6 +207,59 @@ impl SamplingParams {
 
     pub fn as_value(&self) -> &Value {
         &self.raw
+    }
+
+    pub(crate) fn project_sampling_options(&self) -> Result<SamplingOptions, String> {
+        let top_k = self
+            .top_k
+            .map(|value| {
+                i32::try_from(value).map_err(|_| {
+                    format!("sampling_params.top_k exceeds Dynamo's supported range: {value}")
+                })
+            })
+            .transpose()?;
+        Ok(SamplingOptions {
+            n: Some(1),
+            presence_penalty: self.presence_penalty,
+            frequency_penalty: self.frequency_penalty,
+            repetition_penalty: self.repetition_penalty,
+            temperature: self.temperature,
+            top_p: self.top_p,
+            top_k,
+            min_p: self.min_p,
+            seed: self.seed,
+            ..Default::default()
+        })
+    }
+
+    pub(crate) fn project_stop_conditions(&self) -> StopConditions {
+        StopConditions {
+            max_tokens: self.max_tokens,
+            stop_token_ids: self.stop_token_ids.clone(),
+            min_tokens: self.min_tokens,
+            ignore_eos: Some(self.ignore_eos),
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn project_output_options(&self) -> Result<OutputOptions, String> {
+        Ok(OutputOptions {
+            logprobs: project_logprob_count(self.logprobs, "logprobs")?,
+            prompt_logprobs: project_logprob_count(self.prompt_logprobs, "prompt_logprobs")?,
+            skip_special_tokens: self.skip_special_tokens,
+            ..Default::default()
+        })
+    }
+}
+
+fn project_logprob_count(value: Option<i32>, field: &str) -> Result<Option<u32>, String> {
+    match value {
+        None => Ok(None),
+        Some(-1) => Ok(Some(u32::MAX)),
+        Some(value) if value >= 0 => Ok(Some(value as u32)),
+        Some(value) => Err(format!(
+            "sampling_params.{field} must be non-negative or -1, got {value}"
+        )),
     }
 }
 
@@ -254,6 +316,7 @@ impl<'de> Deserialize<'de> for SamplingParams {
             logprob_token_ids: field!(logprob_token_ids),
             structured_outputs: field!(structured_outputs),
             skip_reading_prefix_cache: field!(skip_reading_prefix_cache),
+            skip_special_tokens: field!(skip_special_tokens),
             vllm_xargs: field!(vllm_xargs),
             raw,
         })

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -766,6 +766,13 @@ mod tests {
             (
                 json!({
                     "token_ids": [1],
+                    "sampling_params": {"logprobs": -2}
+                }),
+                "logprobs",
+            ),
+            (
+                json!({
+                    "token_ids": [1],
                     "sampling_params": {"prompt_logprobs": -2}
                 }),
                 "prompt_logprobs",

--- a/lib/sidecar/vllm/Cargo.toml
+++ b/lib/sidecar/vllm/Cargo.toml
@@ -28,6 +28,7 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 clap = { version = "4", features = ["derive", "env"] }
 futures = { workspace = true }
+reqwest = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/lib/sidecar/vllm/proto/inference.proto
+++ b/lib/sidecar/vllm/proto/inference.proto
@@ -107,6 +107,7 @@ message ResponseOptions {
   bool output_token_ids = 5;
   bool output_logprobs = 6;
   optional CandidateTokens output_candidates = 7;
+  optional bool skip_special_tokens = 8;
 }
 
 message KVCacheParameters {

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -3,7 +3,7 @@
 
 use dynamo_backend_common::{
     DisaggregationMode, DynamoError, GuidedDecodingOptions, LLMEngineOutput, MultimodalData,
-    PrefillResult, PreprocessedRequest, StopReason, TopLogprob, usage,
+    OutputOptions, PrefillResult, PreprocessedRequest, StopReason, TopLogprob, usage,
 };
 
 use crate::client;
@@ -618,6 +618,11 @@ fn build_media(
 }
 
 fn top_n_candidates(count: u32) -> Result<pb::CandidateTokens, DynamoError> {
+    if count == OutputOptions::ALL_LOGPROBS {
+        return Ok(pb::CandidateTokens {
+            select: Some(pb::candidate_tokens::Select::All(true)),
+        });
+    }
     i32::try_from(count).map_err(|_| {
         client::invalid_argument(format!(
             "vLLM logprobs request must fit in i32; got {count}"

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -18,6 +18,11 @@ const AUDIO_URL_KEY: &str = "audio_url";
 // Must match DYNAMO_CACHE_SALT_PREFIX in lib/kv-router/src/zmq_wire/extra_keys.rs.
 const DYNAMO_CACHE_SALT_PREFIX: &str = "dynamo-cache-salt:";
 
+#[derive(Default)]
+struct VllmTitoProjection {
+    priority: Option<i32>,
+}
+
 pub(crate) fn build_generate_request(
     request: PreprocessedRequest,
     request_id: String,
@@ -47,6 +52,7 @@ pub(crate) fn build_generate_request(
     let token_ids = request.token_ids;
     let prompt_logprobs = request.output_options.prompt_logprobs;
     let output_logprobs = request.output_options.logprobs;
+    let skip_special_tokens = request.output_options.skip_special_tokens;
     let max_new_tokens = if mode.is_prefill() {
         1
     } else {
@@ -58,7 +64,7 @@ pub(crate) fn build_generate_request(
         request.stop_conditions.min_tokens.unwrap_or(0)
     };
     let mut routing = request.routing;
-    let priority = routing
+    let mut priority = routing
         .as_ref()
         .and_then(|routing| routing.priority)
         .unwrap_or(0);
@@ -69,6 +75,16 @@ pub(crate) fn build_generate_request(
     let sampling = request.sampling_options;
     let stop_conditions = request.stop_conditions;
     let mut extra_args = request.extra_args;
+    let vllm_tito = validate_and_remove_vllm_tito(
+        &mut extra_args,
+        cache_salt.as_deref(),
+        priority,
+        &request_id,
+        skip_special_tokens,
+    )?;
+    if let Some(vllm_priority) = vllm_tito.priority {
+        priority = vllm_priority;
+    }
     consume_redundant_nvext(&mut extra_args, cache_salt.as_deref())?;
     if has_media && let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() {
         // These fields are already represented by token_ids and media.
@@ -119,6 +135,7 @@ pub(crate) fn build_generate_request(
             output_token_ids: true,
             output_logprobs: output_logprobs.is_some(),
             output_candidates: output_logprobs.map(top_n_candidates).transpose()?,
+            skip_special_tokens,
         }),
         kv: Some(kv),
         truncate_prompt_tokens: 0,
@@ -126,6 +143,244 @@ pub(crate) fn build_generate_request(
         session_id: None,
         media,
     })
+}
+
+fn validate_and_remove_vllm_tito(
+    extra_args: &mut Option<serde_json::Value>,
+    canonical_cache_salt: Option<&str>,
+    canonical_priority: i32,
+    canonical_request_id: &str,
+    canonical_skip_special_tokens: Option<bool>,
+) -> Result<VllmTitoProjection, DynamoError> {
+    let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() else {
+        return Ok(VllmTitoProjection::default());
+    };
+    let Some(envelope) = extra.remove("vllm_tito") else {
+        return Ok(VllmTitoProjection::default());
+    };
+    let serde_json::Value::Object(envelope) = envelope else {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito must be a JSON object",
+        ));
+    };
+
+    for key in envelope.keys() {
+        if !matches!(
+            key.as_str(),
+            "request_id"
+                | "sampling_params"
+                | "model"
+                | "stream"
+                | "stream_options"
+                | "cache_salt"
+                | "priority"
+                | "kv_transfer_params"
+                | "features"
+        ) {
+            return Err(client::invalid_argument(format!(
+                "extra_args.vllm_tito.{key} is not supported by vLLM gRPC"
+            )));
+        }
+    }
+
+    if envelope
+        .get("request_id")
+        .and_then(serde_json::Value::as_str)
+        .is_none_or(|request_id| request_id != canonical_request_id)
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.request_id must match the canonical request ID",
+        ));
+    }
+    if envelope
+        .get("features")
+        .is_some_and(|features| !features.is_null())
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.features requires preprocessed multimodal gRPC support",
+        ));
+    }
+    if envelope
+        .get("model")
+        .is_some_and(|model| !model.is_null() && !model.is_string())
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.model must be a string",
+        ));
+    }
+    if envelope
+        .get("stream")
+        .is_some_and(|stream| stream != &serde_json::Value::Bool(false))
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.stream must be false",
+        ));
+    }
+    if envelope
+        .get("stream_options")
+        .is_some_and(|options| !options.is_null())
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.stream_options is not supported by vLLM gRPC",
+        ));
+    }
+
+    let sampling = envelope.get("sampling_params").ok_or_else(|| {
+        client::invalid_argument("extra_args.vllm_tito.sampling_params is required")
+    })?;
+    let serde_json::Value::Object(sampling) = sampling else {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.sampling_params must be a JSON object",
+        ));
+    };
+    for key in sampling.keys() {
+        if !matches!(
+            key.as_str(),
+            "temperature"
+                | "top_p"
+                | "top_k"
+                | "min_p"
+                | "seed"
+                | "max_tokens"
+                | "min_tokens"
+                | "presence_penalty"
+                | "frequency_penalty"
+                | "repetition_penalty"
+                | "stop_token_ids"
+                | "ignore_eos"
+                | "logprobs"
+                | "prompt_logprobs"
+                | "cache_salt"
+                | "skip_reading_prefix_cache"
+                | "skip_special_tokens"
+                | "return_token_ids"
+        ) {
+            return Err(client::invalid_argument(format!(
+                "extra_args.vllm_tito.sampling_params.{key} is not supported by vLLM gRPC"
+            )));
+        }
+    }
+    match sampling.get("skip_special_tokens") {
+        None | Some(serde_json::Value::Null) if canonical_skip_special_tokens.is_none() => {}
+        Some(serde_json::Value::Bool(value)) if Some(*value) == canonical_skip_special_tokens => {}
+        Some(serde_json::Value::Bool(_)) | None | Some(serde_json::Value::Null) => {
+            return Err(client::invalid_argument(
+                "extra_args.vllm_tito.sampling_params.skip_special_tokens does not match the canonical output option",
+            ));
+        }
+        Some(_) => {
+            return Err(client::invalid_argument(
+                "extra_args.vllm_tito.sampling_params.skip_special_tokens must be a boolean",
+            ));
+        }
+    }
+    if sampling
+        .get("return_token_ids")
+        .is_some_and(|value| value != &serde_json::Value::Bool(true))
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.sampling_params.return_token_ids must be true",
+        ));
+    }
+    validate_compat_cache_salt(
+        sampling.get("cache_salt"),
+        canonical_cache_salt,
+        "sampling_params.cache_salt",
+    )?;
+    validate_compat_cache_salt(
+        envelope.get("cache_salt"),
+        canonical_cache_salt,
+        "cache_salt",
+    )?;
+
+    if let Some(skip_reading_prefix_cache) = sampling
+        .get("skip_reading_prefix_cache")
+        .filter(|value| !value.is_null())
+    {
+        if !skip_reading_prefix_cache.is_boolean() {
+            return Err(client::invalid_argument(
+                "extra_args.vllm_tito.sampling_params.skip_reading_prefix_cache must be a boolean",
+            ));
+        }
+        insert_compatible_projection(
+            extra,
+            "skip_reading_prefix_cache",
+            skip_reading_prefix_cache.clone(),
+            "sampling_params.skip_reading_prefix_cache",
+        )?;
+    }
+    if let Some(kv_transfer_params) = envelope.get("kv_transfer_params")
+        && !kv_transfer_params.is_null()
+    {
+        if !kv_transfer_params.is_object() {
+            return Err(client::invalid_argument(
+                "extra_args.vllm_tito.kv_transfer_params must be a JSON object",
+            ));
+        }
+        insert_compatible_projection(
+            extra,
+            "kv_transfer_params",
+            kv_transfer_params.clone(),
+            "kv_transfer_params",
+        )?;
+    }
+
+    let priority = envelope
+        .get("priority")
+        .and_then(serde_json::Value::as_i64)
+        .and_then(|priority| i32::try_from(priority).ok())
+        .ok_or_else(|| {
+            client::invalid_argument(
+                "extra_args.vllm_tito.priority must be a signed 32-bit integer",
+            )
+        })?;
+    if priority.saturating_neg() != canonical_priority {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.priority does not match the canonical Dynamo routing priority",
+        ));
+    }
+    Ok(VllmTitoProjection {
+        priority: Some(priority),
+    })
+}
+
+fn insert_compatible_projection(
+    extra: &mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    value: serde_json::Value,
+    envelope_path: &str,
+) -> Result<(), DynamoError> {
+    if let Some(existing) = extra.get(key) {
+        if existing != &value {
+            return Err(client::invalid_argument(format!(
+                "extra_args.vllm_tito.{envelope_path} conflicts with extra_args.{key}"
+            )));
+        }
+    } else {
+        extra.insert(key.to_string(), value);
+    }
+    Ok(())
+}
+
+fn validate_compat_cache_salt(
+    value: Option<&serde_json::Value>,
+    canonical: Option<&str>,
+    path: &str,
+) -> Result<(), DynamoError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let Some(value) = value.as_str() else {
+        return Err(client::invalid_argument(format!(
+            "extra_args.vllm_tito.{path} must be a string"
+        )));
+    };
+    if Some(value) != canonical {
+        return Err(client::invalid_argument(format!(
+            "extra_args.vllm_tito.{path} must match the canonical cache_salt"
+        )));
+    }
+    Ok(())
 }
 
 pub(crate) fn data_parallel_rank(
@@ -607,11 +862,6 @@ fn validate_request(
     if request.stop_conditions.max_thinking_tokens.is_some() {
         return Err(client::invalid_argument(
             "max_thinking_tokens is not supported by vLLM gRPC v0.25.1",
-        ));
-    }
-    if request.output_options.skip_special_tokens == Some(false) {
-        return Err(client::invalid_argument(
-            "skip_special_tokens=false is not supported by vLLM gRPC v0.25.1",
         ));
     }
     let sampling = &request.sampling_options;

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -367,7 +367,7 @@ fn validate_compat_cache_salt(
     canonical: Option<&str>,
     path: &str,
 ) -> Result<(), DynamoError> {
-    let Some(value) = value else {
+    let Some(value) = value.filter(|value| !value.is_null()) else {
         return Ok(());
     };
     let Some(value) = value.as_str() else {

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -8,8 +8,8 @@ use dynamo_backend_common::{
     DisaggregationMode, DynamoError, GenerateContext, KvEventSource, LLMEngine, LLMEngineOutput,
     LLMEngineOutputExt, RlAdminBaseUrl, WorkerConfig, usage,
 };
-use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig, SidecarStartupError};
-use futures::stream::BoxStream;
+use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig, HttpEndpoint, SidecarStartupError};
+use futures::{TryStreamExt, stream::BoxStream};
 use serde_json::{Map, Value, json};
 use tokio::sync::OnceCell;
 use tokio::time::Instant;
@@ -95,8 +95,9 @@ impl VllmSidecarEngine {
 
         let endpoint = args.sidecar.grpc_endpoint;
         let enable_rl = args.sidecar.common.enable_rl;
-        let vllm_http_url = args
-            .vllm_http_endpoint
+        let vllm_http_endpoint = args.vllm_http_endpoint;
+        let vllm_http_url = vllm_http_endpoint
+            .as_ref()
             .map(|endpoint| {
                 RlAdminBaseUrl::parse(endpoint.as_str()).map_err(|error| {
                     client::invalid_argument(format!(
@@ -111,10 +112,16 @@ impl VllmSidecarEngine {
             "Discovering vLLM model metadata from {endpoint}; startup deadline: {:?}",
             transport.startup_deadline
         );
-        let model = bootstrap_discover(&endpoint, transport, bootstrap_deadline)?;
+        let (model, fallback_world_size) = bootstrap_discover(
+            &endpoint,
+            transport,
+            bootstrap_deadline,
+            enable_rl,
+            vllm_http_endpoint.as_ref(),
+        )?;
         let mode = args.sidecar.common.disaggregation_mode;
         let rl_metadata = enable_rl
-            .then(|| model.rl_worker_metadata(vllm_http_url))
+            .then(|| model.rl_worker_metadata(vllm_http_url, fallback_world_size))
             .transpose()?;
         let engine = Self::new(endpoint, model.clone(), mode, transport);
         let config = WorkerConfig {
@@ -742,7 +749,10 @@ fn bootstrap_discover(
     endpoint: &GrpcEndpoint,
     transport: GrpcTransportConfig,
     startup_deadline: Instant,
-) -> Result<DiscoveredModel, DynamoError> {
+    enable_rl: bool,
+    vllm_http_endpoint: Option<&HttpEndpoint>,
+) -> Result<(DiscoveredModel, Option<u32>), DynamoError> {
+    let vllm_http_endpoint = vllm_http_endpoint.cloned();
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -761,6 +771,94 @@ fn bootstrap_discover(
             )
             .await?;
         let (model, server) = client.discover(startup_deadline).await?;
-        DiscoveredModel::from_proto(model, server)
+        let model = DiscoveredModel::from_proto(model, server)?;
+        let fallback_world_size = if enable_rl && model.requires_world_size_fallback() {
+            // Compatibility with stock vLLM 0.28, whose Control proto does not
+            // include ParallelismInfo.world_size. Remove when vLLM 0.28 leaves
+            // Dynamo's supported mixed-version window.
+            let endpoint = vllm_http_endpoint.as_ref().ok_or_else(|| {
+                client::invalid_argument(
+                    "--vllm-http-endpoint is required for RL discovery with vLLM 0.28",
+                )
+            })?;
+            Some(fetch_vllm_world_size(endpoint, startup_deadline).await?)
+        } else {
+            None
+        };
+        Ok((model, fallback_world_size))
     })
+}
+
+async fn fetch_vllm_world_size(
+    endpoint: &HttpEndpoint,
+    startup_deadline: Instant,
+) -> Result<u32, DynamoError> {
+    const MAX_RESPONSE_BYTES: usize = 1024;
+
+    let mut url = endpoint.with_path("/get_world_size");
+    url.query_pairs_mut().append_pair("include_dp", "true");
+    let http = reqwest::Client::builder()
+        .no_proxy()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|error| {
+            client::invalid_argument(format!("could not configure vLLM HTTP client: {error}"))
+        })?;
+    let request = async {
+        let response = http.get(url.clone()).send().await.map_err(|error| {
+            if error.is_connect() {
+                dynamo_sidecar_common::cannot_connect(format!(
+                    "could not connect to vLLM world-size endpoint {url}: {error}"
+                ))
+            } else {
+                client::protocol_error(format!("vLLM world-size request to {url} failed: {error}"))
+            }
+        })?;
+        if !response.status().is_success() {
+            return Err(client::protocol_error(format!(
+                "vLLM world-size endpoint returned HTTP {}",
+                response.status()
+            )));
+        }
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_RESPONSE_BYTES as u64)
+        {
+            return Err(client::protocol_error(
+                "vLLM world-size response exceeds 1024 bytes",
+            ));
+        }
+        let mut body = Vec::new();
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.try_next().await.map_err(|error| {
+            client::protocol_error(format!("could not read vLLM world-size response: {error}"))
+        })? {
+            if body.len().saturating_add(chunk.len()) > MAX_RESPONSE_BYTES {
+                return Err(client::protocol_error(
+                    "vLLM world-size response exceeds 1024 bytes",
+                ));
+            }
+            body.extend_from_slice(&chunk);
+        }
+        let payload: Value = serde_json::from_slice(&body).map_err(|error| {
+            client::protocol_error(format!("invalid vLLM world-size response: {error}"))
+        })?;
+        payload
+            .get("world_size")
+            .and_then(Value::as_u64)
+            .and_then(|world_size| u32::try_from(world_size).ok())
+            .filter(|world_size| *world_size > 0)
+            .ok_or_else(|| {
+                client::protocol_error(
+                    "vLLM world-size response must contain a positive u32 'world_size'",
+                )
+            })
+    };
+    tokio::time::timeout_at(startup_deadline, request)
+        .await
+        .map_err(|_| {
+            dynamo_sidecar_common::connection_timeout(format!(
+                "vLLM world-size request to {url} exceeded the total startup deadline"
+            ))
+        })?
 }

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -9,6 +9,7 @@ use crate::client;
 use crate::proto as pb;
 
 const SUPPORTED_API_VERSION: &str = "vllm";
+const VLLM_INFERENCE_V1_GENERATE_CAPABILITY: &str = "vllm_inference_v1_generate";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ModelIdentity {
@@ -106,6 +107,7 @@ impl DiscoveredModel {
     pub(crate) fn rl_worker_metadata(
         &self,
         admin_base_url: Option<RlAdminBaseUrl>,
+        fallback_world_size: Option<u32>,
     ) -> Result<RlWorkerMetadata, DynamoError> {
         let parallelism = self.server.parallelism.as_ref().ok_or_else(|| {
             client::protocol_error("RL discovery requires vLLM parallelism metadata")
@@ -116,23 +118,48 @@ impl DiscoveredModel {
             nonzero(parallelism.pipeline_parallel_size).ok_or_else(|| {
                 client::protocol_error("vLLM reports a pipeline-parallel size of zero")
             })?;
-        let engine_world_size = u32::try_from(parallelism.world_size)
-            .ok()
-            .and_then(nonzero)
-            .ok_or_else(|| client::protocol_error("vLLM reports an invalid engine world size"))?;
         let expected_minimum_world_size = tensor_parallel_size
             .checked_mul(pipeline_parallel_size)
             .ok_or_else(|| client::protocol_error("vLLM reports an invalid RL world size"))?;
-        if engine_world_size % expected_minimum_world_size != 0 {
-            return Err(client::protocol_error(
-                "vLLM reports an engine world size that is not divisible by TP * PP",
-            ));
-        }
-        let world_size = engine_world_size
-            .checked_mul(parallelism.data_parallel_size)
-            .ok_or_else(|| client::protocol_error("vLLM reports an invalid RL world size"))?;
+        let world_size = match u32::try_from(parallelism.world_size).ok().and_then(nonzero) {
+            Some(engine_world_size) => {
+                if engine_world_size % expected_minimum_world_size != 0 {
+                    return Err(client::protocol_error(
+                        "vLLM reports an engine world size that is not divisible by TP * PP",
+                    ));
+                }
+                engine_world_size
+                    .checked_mul(parallelism.data_parallel_size)
+                    .ok_or_else(|| {
+                        client::protocol_error("vLLM reports an invalid RL world size")
+                    })?
+            }
+            None => {
+                let world_size = fallback_world_size.ok_or_else(|| {
+                    client::protocol_error("vLLM reports an invalid engine world size")
+                })?;
+                let expected_total_world_size = expected_minimum_world_size
+                    .checked_mul(parallelism.data_parallel_size)
+                    .ok_or_else(|| {
+                        client::protocol_error("vLLM reports an invalid RL world size")
+                    })?;
+                if world_size % expected_total_world_size != 0 {
+                    return Err(client::protocol_error(
+                        "vLLM reports an RL world size that is not divisible by TP * PP * DP",
+                    ));
+                }
+                world_size
+            }
+        };
         RlWorkerMetadata::new(world_size, admin_base_url)
             .map_err(|error| client::protocol_error(error.to_string()))
+    }
+
+    pub(crate) fn requires_world_size_fallback(&self) -> bool {
+        self.server
+            .parallelism
+            .as_ref()
+            .is_some_and(|parallelism| parallelism.world_size == 0)
     }
 
     pub(crate) fn engine_config(&self) -> EngineConfig {
@@ -141,7 +168,11 @@ impl DiscoveredModel {
             model: self.source.clone(),
             served_model_name: Some(self.served_name.clone()),
             model_aliases: self.identity.aliases.clone(),
-            runtime_data: Default::default(),
+            runtime_data: [(
+                VLLM_INFERENCE_V1_GENERATE_CAPABILITY.to_string(),
+                serde_json::Value::Bool(true),
+            )]
+            .into(),
             llm: Some(LlmRegistration {
                 context_length: nonzero(self.server.max_model_len),
                 kv_cache_block_size: nonzero(self.server.kv_block_size),

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -16,7 +16,9 @@ use dynamo_backend_common::{
 };
 use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
 use futures::{Stream, StreamExt};
+use prost::Message;
 use serde_json::json;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::{Mutex, Notify, oneshot};
 use tokio_stream::wrappers::TcpListenerStream;
@@ -36,6 +38,7 @@ struct FakeVllm {
     data_parallel_rank_metadata: Arc<Mutex<Vec<Option<String>>>>,
     peers: Arc<Mutex<Vec<SocketAddr>>>,
     model_info_override: Arc<Mutex<Option<pb::ModelInfo>>>,
+    server_info_override: Arc<Mutex<Option<pb::ServerInfo>>>,
     reject: Arc<AtomicBool>,
     hang: Arc<AtomicBool>,
     hang_before_headers: Arc<AtomicBool>,
@@ -226,7 +229,13 @@ impl pb::control_server::Control for FakeVllm {
         &self,
         _request: Request<pb::GetServerInfoRequest>,
     ) -> Result<Response<pb::ServerInfo>, Status> {
-        Ok(Response::new(server_info()))
+        Ok(Response::new(
+            self.server_info_override
+                .lock()
+                .await
+                .clone()
+                .unwrap_or_else(server_info),
+        ))
     }
 
     async fn get_model_info(
@@ -663,6 +672,48 @@ struct FakeServer {
     shutdown: Option<oneshot::Sender<()>>,
 }
 
+struct FakeWorldSizeServer {
+    endpoint: String,
+    request: Arc<Mutex<Option<String>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl FakeWorldSizeServer {
+    async fn start(world_size: u32) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let address = listener.local_addr().expect("address");
+        let request = Arc::new(Mutex::new(None));
+        let recorded_request = request.clone();
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept world-size request");
+            let mut buffer = vec![0; 4096];
+            let size = stream.read(&mut buffer).await.expect("read request");
+            let raw = String::from_utf8_lossy(&buffer[..size]).into_owned();
+            *recorded_request.lock().await = Some(raw);
+            let body = format!(r#"{{"world_size":{world_size}}}"#);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+        Self {
+            endpoint: format!("http://{address}"),
+            request,
+            task,
+        }
+    }
+}
+
+impl Drop for FakeWorldSizeServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
 impl FakeServer {
     async fn start(service: FakeVllm) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
@@ -804,12 +855,22 @@ fn engine_with_server_info(
 async fn engine_from_args(
     endpoint: &str,
 ) -> (VllmSidecarEngine, dynamo_backend_common::WorkerConfig) {
-    let argv = vec![
+    try_engine_from_args(endpoint, Some("http://worker:8120"))
+        .await
+        .expect("bootstrap discovery")
+}
+
+async fn try_engine_from_args(
+    endpoint: &str,
+    http_endpoint: Option<&str>,
+) -> Result<
+    (VllmSidecarEngine, dynamo_backend_common::WorkerConfig),
+    dynamo_backend_common::DynamoError,
+> {
+    let mut argv = vec![
         "dynamo-vllm-sidecar".to_string(),
         "--grpc-endpoint".to_string(),
         endpoint.to_string(),
-        "--vllm-http-endpoint".to_string(),
-        "http://worker:8120".to_string(),
         "--enable-rl".to_string(),
         "--grpc-connections".to_string(),
         "2".to_string(),
@@ -818,10 +879,15 @@ async fn engine_from_args(
         "--grpc-connect-attempt-timeout-secs".to_string(),
         "1".to_string(),
     ];
+    if let Some(http_endpoint) = http_endpoint {
+        argv.extend([
+            "--vllm-http-endpoint".to_string(),
+            http_endpoint.to_string(),
+        ]);
+    }
     tokio::task::spawn_blocking(move || VllmSidecarEngine::from_args(Some(argv)))
         .await
         .expect("bootstrap task")
-        .expect("bootstrap discovery")
 }
 
 async fn collect(
@@ -875,6 +941,132 @@ async fn startup_rejects_model_identity_change_after_bootstrap() {
     *server.service.model_info_override.lock().await = Some(changed);
 
     assert!(engine.start(0).await.is_err());
+}
+
+#[tokio::test]
+async fn stock_vllm_world_size_uses_private_http_fallback() {
+    let service = FakeVllm::default();
+    let mut legacy_server = server_info();
+    legacy_server
+        .parallelism
+        .as_mut()
+        .expect("parallelism")
+        .world_size = 0;
+    *service.server_info_override.lock().await = Some(legacy_server);
+    let grpc = FakeServer::start(service).await;
+    let http = FakeWorldSizeServer::start(8).await;
+
+    let (_, worker) = try_engine_from_args(&grpc.endpoint, Some(&http.endpoint))
+        .await
+        .expect("stock vLLM 0.28 fallback");
+
+    assert_eq!(
+        worker.rl_metadata,
+        Some(
+            RlWorkerMetadata::new(
+                8,
+                Some(RlAdminBaseUrl::parse(&http.endpoint).expect("valid admin URL")),
+            )
+            .expect("valid metadata")
+        )
+    );
+    assert!(http.request.lock().await.as_deref().is_some_and(|request| {
+        request.starts_with("GET /get_world_size?include_dp=true HTTP/1.1")
+    }));
+}
+
+#[tokio::test]
+async fn stock_vllm_world_size_fallback_rejects_zero() {
+    let service = FakeVllm::default();
+    let mut legacy_server = server_info();
+    legacy_server
+        .parallelism
+        .as_mut()
+        .expect("parallelism")
+        .world_size = 0;
+    *service.server_info_override.lock().await = Some(legacy_server);
+    let grpc = FakeServer::start(service).await;
+    let http = FakeWorldSizeServer::start(0).await;
+
+    let error = match try_engine_from_args(&grpc.endpoint, Some(&http.endpoint)).await {
+        Ok(_) => panic!("zero fallback must fail"),
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("positive"));
+}
+
+#[test]
+fn discovered_model_advertises_token_native_generate() {
+    let model = DiscoveredModel::from_proto(model_info(), server_info()).expect("valid discovery");
+    assert_eq!(
+        model
+            .engine_config()
+            .runtime_data
+            .get("vllm_inference_v1_generate"),
+        Some(&serde_json::Value::Bool(true))
+    );
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct V028ResponseOptions {
+    #[prost(bool, optional, tag = "8")]
+    skip_special_tokens: Option<bool>,
+}
+
+#[test]
+fn token_native_compatibility_envelope_forwards_prime_controls() {
+    let mut request = request();
+    request.output_options.skip_special_tokens = Some(false);
+    request.routing.as_mut().expect("routing").priority = Some(-7);
+    request.extra_args = Some(json!({
+        "vllm_tito": {
+            "request_id": "request-1",
+            "sampling_params": {
+                "temperature": 0.2,
+                "top_p": 0.9,
+                "top_k": 4,
+                "min_p": 0.1,
+                "seed": 123,
+                "max_tokens": 1,
+                "min_tokens": 1,
+                "presence_penalty": 0.3,
+                "frequency_penalty": 0.4,
+                "repetition_penalty": 1.1,
+                "stop_token_ids": [2],
+                "ignore_eos": true,
+                "logprobs": 1,
+                "prompt_logprobs": 1,
+                "cache_salt": "cache-salt",
+                "skip_special_tokens": false,
+                "return_token_ids": true
+            },
+            "model": "served-model",
+            "stream": false,
+            "cache_salt": "cache-salt",
+            "priority": 7,
+            "kv_transfer_params": {
+                "connector_data": {"values": [1, true, null]}
+            }
+        }
+    }));
+
+    let wire = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect("Prime token controls should map to vLLM 0.28");
+
+    assert_eq!(wire.priority, 7);
+    assert_eq!(
+        wire.stopping.as_ref().expect("stopping").stop_token_ids,
+        [2]
+    );
+    assert!(wire.response.as_ref().expect("response").output_logprobs);
+    let encoded = wire.response.expect("response").encode_to_vec();
+    let response = V028ResponseOptions::decode(encoded.as_slice()).expect("decode v0.28 response");
+    assert_eq!(response.skip_special_tokens, Some(false));
 }
 
 #[tokio::test]

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -484,7 +484,7 @@ fn rl_worker_metadata_identifies_zero_parallelism_dimensions() {
             _ => unreachable!(),
         }
         let model = DiscoveredModel::from_proto(model_info(), server).expect("valid discovery");
-        let error = model.rl_worker_metadata(None).unwrap_err();
+        let error = model.rl_worker_metadata(None, None).unwrap_err();
         assert!(error.to_string().contains(expected));
     }
 }
@@ -701,7 +701,7 @@ impl FakeWorldSizeServer {
                 .expect("write response");
         });
         Self {
-            endpoint: format!("http://{address}"),
+            endpoint: format!("http://{address}/"),
             request,
             task,
         }
@@ -1015,7 +1015,7 @@ struct V028ResponseOptions {
 }
 
 #[test]
-fn token_native_compatibility_envelope_forwards_prime_controls() {
+fn token_native_compatibility_envelope_forwards_text_controls() {
     let mut request = request();
     request.output_options.skip_special_tokens = Some(false);
     request.routing.as_mut().expect("routing").priority = Some(-7);
@@ -1056,7 +1056,7 @@ fn token_native_compatibility_envelope_forwards_prime_controls() {
         "request-1".to_string(),
         DisaggregationMode::Aggregated,
     )
-    .expect("Prime token controls should map to vLLM 0.28");
+    .expect("token-native controls should map to vLLM 0.28");
 
     assert_eq!(wire.priority, 7);
     assert_eq!(

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -666,6 +666,31 @@ fn oversized_logprob_counts_are_rejected() {
     assert!(prompt_error.to_string().contains("must fit in i32"));
 }
 
+#[test]
+fn all_logprob_sentinel_selects_all_candidates() {
+    let mut request = request();
+    request.output_options.logprobs = Some(u32::MAX);
+    request.output_options.prompt_logprobs = Some(u32::MAX);
+
+    let response = build_generate_request(
+        request,
+        "all-logprobs".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect("all logprobs must be supported")
+    .response
+    .expect("response options");
+
+    assert_eq!(
+        response.output_candidates.and_then(|value| value.select),
+        Some(pb::candidate_tokens::Select::All(true))
+    );
+    assert_eq!(
+        response.prompt_candidates.and_then(|value| value.select),
+        Some(pb::candidate_tokens::Select::All(true))
+    );
+}
+
 struct FakeServer {
     endpoint: String,
     service: FakeVllm,

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -1069,6 +1069,29 @@ fn token_native_compatibility_envelope_forwards_text_controls() {
     assert_eq!(response.skip_special_tokens, Some(false));
 }
 
+#[test]
+fn token_native_compatibility_envelope_accepts_null_cache_salt() {
+    let mut request = request();
+    request.routing.as_mut().expect("routing").cache_namespace = None;
+    request.extra_args = Some(json!({
+        "vllm_tito": {
+            "request_id": "request-1",
+            "sampling_params": {"cache_salt": null},
+            "stream": false,
+            "priority": 0
+        }
+    }));
+
+    let wire = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect("null cache salt should be treated as absent");
+
+    assert_eq!(wire.kv.expect("kv parameters").cache_salt, "");
+}
+
 #[tokio::test]
 async fn aggregated_generation_converts_request_stream_and_usage() {
     let server = FakeServer::start(FakeVllm::default()).await;


### PR DESCRIPTION
## Overview

Adds the generic Dynamo and vLLM-RS compatibility surface needed by external RL control planes while keeping the weight-transfer protocol entirely in the caller.

## Details

- Publishes stable RL worker discovery metadata, including the direct vLLM administration URL and per-engine rank count.
- Adds a token-native generate compatibility envelope for vLLM-RS and preserves routing priority, sampling controls, stop conditions, output options, and cache namespace.
- Supports the vLLM 0.28 model-card world-size fallback used by the validated A1 deployment.
- Keeps Prime-RL-specific NCCL tensors, conversion, checkpoint semantics, and worker methods out of Dynamo.
- Normalizes nested cache salt handling so policy-version KV isolation survives frontend-to-sidecar forwarding.

Companion Prime-RL change: https://github.com/PrimeIntellect-ai/prime-rl/pull/3469

## Where should the reviewer start?

Start with `lib/sidecar/vllm/src/convert.rs`, `lib/sidecar/vllm/src/model.rs`, and `lib/llm/src/http/service/generate.rs`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-vllm-sidecar --lib`: 28 passed
- `cargo test -p dynamo-llm --lib`: 2,548 passed, 5 ignored
- Three-step Qwen3-0.6B Math GRPO smoke test completed with startup policy v0 and post-step v1-v3 NCCL transfers, zero rollout errors, and successful generation after v3.
- Independent Claude Opus 1M review completed with no unresolved merge blockers for the A1 scope.

## Related Issues

This PR is not linked to an existing issue.

- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for preserving advanced generation controls, including sampling, output options, cache salts, and special-token handling.
  - Added automatic vLLM world-size discovery during reinforcement learning startup, with validated fallback support for older versions.
  - Added vLLM Tito request options, including priority and compatible routing settings.

- **Bug Fixes**
  - Improved validation and error handling for invalid log-probability settings, cache salts, and unsupported request options.
  - Fixed propagation of nested sampling and output configuration across inference requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->