### PR TITLE
fix(mocker): restore public module entry point

### DIFF
--- a/components/src/dynamo/mocker/README.md
+++ b/components/src/dynamo/mocker/README.md
@@ -5,8 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 # Mocker engine
 
-The public `python -m dynamo.mocker` CLI is removed while online simulation is unavailable. The
-engine and private worker launcher remain for Dynamo internals, tests, and managed templates.
+Run the mocker worker with `python -m dynamo.mocker`. The internal
+`python -m dynamo.mocker._worker` entry point remains available for managed templates.
 
 The user-facing availability notice lives at
 [Simulate a Kubernetes Deployment with Mocker](../../../../docs/fern/pages/kubernetes/operations/simulation-with-dynosim/mocker-live-simulation.mdx).

--- a/components/src/dynamo/mocker/__main__.py
+++ b/components/src/dynamo/mocker/__main__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/components/src/dynamo/mocker/tests/unit/test_public_cli.py
+++ b/components/src/dynamo/mocker/tests/unit/test_public_cli.py
@@ -13,6 +13,6 @@ pytestmark = [
 ]
 
 
-def test_public_mocker_module_cli_is_removed() -> None:
-    assert importlib.util.find_spec("dynamo.mocker.__main__") is None
+def test_mocker_module_entry_points_are_available() -> None:
+    assert importlib.util.find_spec("dynamo.mocker.__main__") is not None
     assert importlib.util.find_spec("dynamo.mocker._worker") is not None


### PR DESCRIPTION
## Overview:

Restore `python -m dynamo.mocker` as a supported compatibility entry point.

## Details:

- Add a small `dynamo.mocker.__main__` shim that calls the existing `main()` function.
- Keep `python -m dynamo.mocker._worker` available for managed templates.
- Update the mocker README and unit test to cover both module entry points.

This restores the public command that was removed in #13665. Existing deployments still use that command, including Router Zoo nightly deployments on Nscale.

## Where should the reviewer start?

`components/src/dynamo/mocker/__main__.py`

## Related Issues

**This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q -c /dev/null --rootdir=. -o cache_dir=.pytest_cache components/src/dynamo/mocker/tests/unit/test_public_cli.py` (`1 passed`)
- `python -m dynamo.mocker --help`
- Repository-pinned Ruff, Black, isort, Flake8, and codespell checks on the changed files
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public command-line entry point for launching the mocker with `python -m dynamo.mocker`.

- **Documentation**
  - Updated usage guidance to document the public mocker command while retaining the managed-template entry point.

- **Tests**
  - Added coverage confirming the public command-line entry point is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->