### PR TITLE
fix(mocker): restore public live worker CLI

### DIFF
--- a/benchmarks/frontend/dgd/templates/mocker.yaml
+++ b/benchmarks/frontend/dgd/templates/mocker.yaml
@@ -64,7 +64,7 @@ ${WORKER_IMAGE_PULL_SECRETS_BLOCK}
             - -c
           args:
             - |
-              python3 -m dynamo.mocker._worker \
+              python3 -m dynamo.mocker \
                 --model-path "${MODEL_PATH}" \
                 --model-name "${MODEL_NAME}" \
                 --num-workers ${NUM_WORKERS} \

--- a/benchmarks/frontend/scripts/run_perf.sh
+++ b/benchmarks/frontend/scripts/run_perf.sh
@@ -409,7 +409,7 @@ for MN in "${MODEL_NAMES[@]}"; do
         fi
 
         MN_SAFE="${MN//\//_}"
-        HF_HUB_OFFLINE=1 DYN_SYSTEM_PORT=$WORKER_PORT DYN_EVENT_PLANE="$EVENT_PLANE" python -m dynamo.mocker._worker "${MOCKER_ARGS[@]}" \
+        HF_HUB_OFFLINE=1 DYN_SYSTEM_PORT=$WORKER_PORT DYN_EVENT_PLANE="$EVENT_PLANE" python -m dynamo.mocker "${MOCKER_ARGS[@]}" \
             > "$OUTPUT_DIR/logs/mocker_${MN_SAFE}_${i}.log" 2>&1 &
         ALL_PIDS+=($!)
         echo "  Worker $WORKER_IDX ($MN #$i): PID ${ALL_PIDS[-1]}, port $WORKER_PORT"

--- a/benchmarks/router/README.md
+++ b/benchmarks/router/README.md
@@ -104,10 +104,6 @@ We also support running lightweight mock engines that simulate vLLM behavior wit
 
 #### Disaggregated Serving with Mockers (No GPU Required)
 
-> [!WARNING]
-> The public online Mocker CLI is temporarily unavailable. The direct commands below do not run in
-> this release and are retained only to document the workflow that will return in a future release.
-
 You can test disaggregated serving entirely with mockers by launching separate prefill and decode mocker groups that share a namespace. This is useful for validating routing logic, metrics, and the prefill-decode handoff without any GPUs.
 
 ```bash
@@ -115,13 +111,13 @@ NAMESPACE="test-disagg"
 MODEL="Qwen/Qwen3-0.6B"
 
 # Terminal 1: Decode mockers (2 workers)
-python -m dynamo.mocker --model-path "$MODEL" \
+python3 -m dynamo.mocker --model-path "$MODEL" \
     --endpoint "dyn://${NAMESPACE}.backend.generate" \
     --disaggregation-mode decode --num-workers 2 \
     --speedup-ratio 10 --block-size 16
 
 # Terminal 2: Prefill mockers (2 workers)
-python -m dynamo.mocker --model-path "$MODEL" \
+python3 -m dynamo.mocker --model-path "$MODEL" \
     --endpoint "dyn://${NAMESPACE}.prefill.generate" \
     --disaggregation-mode prefill --num-workers 2 \
     --speedup-ratio 10 --block-size 16

--- a/benchmarks/router/run_engines.sh
+++ b/benchmarks/router/run_engines.sh
@@ -202,7 +202,7 @@ if [ "$USE_MOCKERS" = true ]; then
     fi
     MOCKER_ARGS+=("${EXTRA_ARGS[@]}")
 
-    python -m dynamo.mocker._worker "${MOCKER_ARGS[@]}" &
+    python -m dynamo.mocker "${MOCKER_ARGS[@]}" &
     PIDS+=($!)
     echo "Started mocker with $NUM_WORKERS workers (PID: $!)"
 else

--- a/components/src/dynamo/mocker/README.md
+++ b/components/src/dynamo/mocker/README.md
@@ -5,10 +5,11 @@ SPDX-License-Identifier: Apache-2.0
 
 # Mocker engine
 
-The public `python -m dynamo.mocker` CLI is removed while online simulation is unavailable. The
-engine and private worker launcher remain for Dynamo internals, tests, and managed templates.
+Run `python3 -m dynamo.mocker` to launch live Mocker workers that register with the Dynamo runtime.
+The command does not generate traffic or run virtual-clock replay. Use `aisimulate predict` or
+`aisimulate recommend` for offline simulation.
 
-The user-facing availability notice lives at
+The user-facing live deployment guide lives at
 [Simulate a Kubernetes Deployment with Mocker](../../../../docs/fern/pages/kubernetes/operations/simulation-with-dynosim/mocker-live-simulation.mdx).
 
 Useful adjacent references:

--- a/components/src/dynamo/mocker/__main__.py
+++ b/components/src/dynamo/mocker/__main__.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""CLI entry point for live Mocker workers."""
-
 from .main import main
 
 if __name__ == "__main__":

--- a/components/src/dynamo/mocker/__main__.py
+++ b/components/src/dynamo/mocker/__main__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI entry point for live Mocker workers."""
+
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/components/src/dynamo/mocker/_worker.py
+++ b/components/src/dynamo/mocker/_worker.py
@@ -1,9 +1,0 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
-"""Private process entry point for Dynamo integration tests and managed templates."""
-
-from .main import main
-
-if __name__ == "__main__":
-    main()

--- a/components/src/dynamo/mocker/main.py
+++ b/components/src/dynamo/mocker/main.py
@@ -1,7 +1,7 @@
 #  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Live Mocker worker launcher. Offline virtual-clock replay lives in AISimulate.
+# Offline virtual-clock replay lives in AISimulate.
 
 import argparse
 import asyncio

--- a/components/src/dynamo/mocker/main.py
+++ b/components/src/dynamo/mocker/main.py
@@ -1,8 +1,7 @@
 #  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Internal worker launcher. The public `python -m dynamo.mocker` CLI is removed while online
-# simulation is unavailable.
+# Live Mocker worker launcher. Offline virtual-clock replay lives in AISimulate.
 
 import argparse
 import asyncio

--- a/components/src/dynamo/mocker/tests/unit/test_public_cli.py
+++ b/components/src/dynamo/mocker/tests/unit/test_public_cli.py
@@ -13,6 +13,6 @@ pytestmark = [
 ]
 
 
-def test_public_mocker_module_cli_is_removed() -> None:
-    assert importlib.util.find_spec("dynamo.mocker.__main__") is None
-    assert importlib.util.find_spec("dynamo.mocker._worker") is not None
+def test_public_mocker_module_cli_is_available() -> None:
+    assert importlib.util.find_spec("dynamo.mocker.__main__") is not None
+    assert importlib.util.find_spec("dynamo.mocker._worker") is None

--- a/components/src/dynamo/mocker/tests/unit/test_public_cli.py
+++ b/components/src/dynamo/mocker/tests/unit/test_public_cli.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import importlib.util
 import subprocess
 import sys
 
@@ -13,10 +12,6 @@ pytestmark = [
     pytest.mark.pre_merge,
     pytest.mark.unit,
 ]
-
-
-def test_public_mocker_module_cli_is_available() -> None:
-    assert importlib.util.find_spec("dynamo.mocker.__main__") is not None
 
 
 @pytest.mark.parametrize("option", ["--help", "--version"])

--- a/components/src/dynamo/mocker/tests/unit/test_public_cli.py
+++ b/components/src/dynamo/mocker/tests/unit/test_public_cli.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib.util
+import subprocess
+import sys
 
 import pytest
 
@@ -15,4 +17,16 @@ pytestmark = [
 
 def test_public_mocker_module_cli_is_available() -> None:
     assert importlib.util.find_spec("dynamo.mocker.__main__") is not None
-    assert importlib.util.find_spec("dynamo.mocker._worker") is None
+
+
+@pytest.mark.parametrize("option", ["--help", "--version"])
+def test_public_mocker_module_cli_executes(option: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "dynamo.mocker", option],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout

--- a/components/src/dynamo/mocker/tests/unit/test_public_cli.py
+++ b/components/src/dynamo/mocker/tests/unit/test_public_cli.py
@@ -14,10 +14,9 @@ pytestmark = [
 ]
 
 
-@pytest.mark.parametrize("option", ["--help", "--version"])
-def test_public_mocker_module_cli_executes(option: str) -> None:
+def test_public_mocker_module_cli_executes() -> None:
     result = subprocess.run(
-        [sys.executable, "-m", "dynamo.mocker", option],
+        [sys.executable, "-m", "dynamo.mocker", "--help"],
         check=False,
         capture_output=True,
         text=True,

--- a/components/src/dynamo/planner/monitoring/dgd_services.py
+++ b/components/src/dynamo/planner/monitoring/dgd_services.py
@@ -137,10 +137,7 @@ class Service(BaseModel):
         container = get_main_container(self.service)
         command = break_arguments(container.get("command"))
         args = break_arguments(container.get("args"))
-        return any(
-            module in {"dynamo.mocker", "dynamo.mocker._worker"}
-            for module in command + args
-        )
+        return "dynamo.mocker" in command + args
 
     def get_model_name(self) -> Optional[str]:
         args = get_main_container(self.service).get("args", [])

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -1320,15 +1320,25 @@ def test_typed_worker_with_explicit_zero_shape_is_rejected(
         kubernetes_connector.get_gpu_shapes(require_prefill=False, require_decode=True)
 
 
+@pytest.mark.parametrize(
+    ("command", "args"),
+    [
+        (None, ["-m", "dynamo.mocker", "--model-name", "test-model"]),
+        (["python3", "-m", "dynamo.mocker"], ["--model-name", "test-model"]),
+    ],
+    ids=["module-in-args", "module-in-command"],
+)
 def test_typed_mocker_worker_with_zero_physical_shape_uses_configured_fallback(
-    kubernetes_connector, mock_kube_api
+    kubernetes_connector, mock_kube_api, command, args
 ):
     component = _component(
         "decode-worker",
         "decode",
         replicas=1,
-        args=["-m", "dynamo.mocker", "--model-name", "test-model"],
+        args=args,
     )
+    if command is not None:
+        component["podTemplate"]["spec"]["containers"][0]["command"] = command
     deployment = _deployment(component)
     deployment["metadata"]["generation"] = 2
     deployment["status"] = {

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -1320,28 +1320,15 @@ def test_typed_worker_with_explicit_zero_shape_is_rejected(
         kubernetes_connector.get_gpu_shapes(require_prefill=False, require_decode=True)
 
 
-@pytest.mark.parametrize(
-    ("command", "args"),
-    [
-        (None, ["-m", "dynamo.mocker", "--model-name", "test-model"]),
-        (
-            ["python3", "-m", "dynamo.mocker._worker"],
-            ["--model-name", "test-model"],
-        ),
-    ],
-    ids=["public-module", "worker-module"],
-)
 def test_typed_mocker_worker_with_zero_physical_shape_uses_configured_fallback(
-    kubernetes_connector, mock_kube_api, command, args
+    kubernetes_connector, mock_kube_api
 ):
     component = _component(
         "decode-worker",
         "decode",
         replicas=1,
-        args=args,
+        args=["-m", "dynamo.mocker", "--model-name", "test-model"],
     )
-    if command is not None:
-        component["podTemplate"]["spec"]["containers"][0]["command"] = command
     deployment = _deployment(component)
     deployment["metadata"]["generation"] = 2
     deployment["status"] = {

--- a/components/src/dynamo/profiler/templates/dgd/mocker/disagg.yaml
+++ b/components/src/dynamo/profiler/templates/dgd/mocker/disagg.yaml
@@ -3,7 +3,7 @@
 
 # NOTE: There is no dedicated `mocker-runtime` image. The published
 # `dynamo-planner` image includes the ai-dynamo wheel, ai-dynamo-runtime, and
-# Planner/profiler dependencies needed by the internal Mocker worker launcher.
+# Planner/profiler dependencies needed by the Mocker worker launcher.
 # Replace `my-tag` below with the Dynamo release tag you deploy.
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
@@ -40,7 +40,7 @@ spec:
           command:
           - python3
           - -m
-          - dynamo.mocker._worker
+          - dynamo.mocker
           envFrom:
           - secretRef:
               name: hf-token-secret
@@ -65,7 +65,7 @@ spec:
           command:
           - python3
           - -m
-          - dynamo.mocker._worker
+          - dynamo.mocker
           envFrom:
           - secretRef:
               name: hf-token-secret

--- a/components/src/dynamo/profiler/tests/unit/test_dgd_materialization.py
+++ b/components/src/dynamo/profiler/tests/unit/test_dgd_materialization.py
@@ -188,12 +188,6 @@ def test_mocker_detection_matches_discrete_command_tokens(command, args) -> None
     assert dgd_materialization._invokes_mocker(command, args)
 
 
-@pytest.mark.parametrize(
-    "args",
-    [
-        ["-m", "dynamo.worker", "--model", "org/dynamo.mocker-model"],
-        ["-m", "dynamo.worker", "--endpoint", "dyn://dynamo.mocker.generate"],
-    ],
-)
-def test_mocker_detection_rejects_substring_matches(args) -> None:
+def test_mocker_detection_rejects_substring_matches() -> None:
+    args = ["-m", "dynamo.worker", "--model", "org/dynamo.mocker-model"]
     assert not dgd_materialization._invokes_mocker(["python3"], args)

--- a/components/src/dynamo/profiler/tests/unit/test_dgd_materialization.py
+++ b/components/src/dynamo/profiler/tests/unit/test_dgd_materialization.py
@@ -175,3 +175,25 @@ def test_materialize_dgd_rejects_non_object_dgd() -> None:
             [{"kind": "ConfigMap"}, "not-an-object"],
             purpose=DGDMaterializationPurpose.FINAL_OUTPUT,
         )
+
+
+@pytest.mark.parametrize(
+    ("command", "args"),
+    [
+        (["python3", "-m", "dynamo.mocker"], []),
+        (["sh", "-c"], ["python3 -m dynamo.mocker --model-path test/model"]),
+    ],
+)
+def test_mocker_detection_matches_discrete_command_tokens(command, args) -> None:
+    assert dgd_materialization._invokes_mocker(command, args)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["-m", "dynamo.worker", "--model", "org/dynamo.mocker-model"],
+        ["-m", "dynamo.worker", "--endpoint", "dyn://dynamo.mocker.generate"],
+    ],
+)
+def test_mocker_detection_rejects_substring_matches(args) -> None:
+    assert not dgd_materialization._invokes_mocker(["python3"], args)

--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -187,7 +187,7 @@ def get_main_container_dict(component: dict[str, Any]) -> dict[str, Any] | None:
     )
 
 
-def break_arguments(args: list[str] | None) -> list[str]:
+def break_arguments(args: list[str] | str | None) -> list[str]:
     ans: list[str] = []
     if args is None:
         return ans

--- a/components/src/dynamo/profiler/utils/dgd_materialization.py
+++ b/components/src/dynamo/profiler/utils/dgd_materialization.py
@@ -146,7 +146,6 @@ _WORKER_COMPONENT_TYPES = frozenset({"worker", "prefill", "decode"})
 def _invokes_mocker(
     command: list[str] | str | None, args: list[str] | str | None
 ) -> bool:
-    """Return whether a container command invokes the public Mocker module."""
     return "dynamo.mocker" in break_arguments(command) + break_arguments(args)
 
 

--- a/components/src/dynamo/profiler/utils/dgd_materialization.py
+++ b/components/src/dynamo/profiler/utils/dgd_materialization.py
@@ -168,7 +168,7 @@ def _all_workers_already_have_trust_flag(config: dict) -> bool:
 
         # Skip mocker workers — they never carry the flag.
         all_tokens = " ".join(str(t) for t in (list(cmd) + list(args)))
-        if "dynamo.mocker._worker" in all_tokens:
+        if "dynamo.mocker" in all_tokens:
             continue
 
         is_shell_c = (
@@ -199,7 +199,7 @@ def _inject_trust_remote_code_flag(config: dict) -> None:
     rather than as a second list element (which would become ``$0`` and break
     the worker).
 
-    Internal Mocker workers are skipped because their
+    Mocker workers are skipped because their
     argparse does not accept ``--trust-remote-code``.
     """
     components = config.get("spec", {}).get("components", [])
@@ -218,7 +218,7 @@ def _inject_trust_remote_code_flag(config: dict) -> None:
 
         # Skip mocker workers — their argparse does not accept the flag.
         all_tokens = " ".join(str(t) for t in (list(cmd) + list(args)))
-        if "dynamo.mocker._worker" in all_tokens:
+        if "dynamo.mocker" in all_tokens:
             continue
 
         # Detect shell form: command=["sh","-c"] with a single-string args.

--- a/components/src/dynamo/profiler/utils/dgd_materialization.py
+++ b/components/src/dynamo/profiler/utils/dgd_materialization.py
@@ -10,7 +10,7 @@ import logging
 from enum import Enum
 from typing import Any
 
-from dynamo.profiler.utils.config import get_main_container_dict
+from dynamo.profiler.utils.config import break_arguments, get_main_container_dict
 from dynamo.profiler.utils.config_modifiers import CONFIG_MODIFIERS
 from dynamo.profiler.utils.dgd_override import apply_dgd_overrides
 from dynamo.profiler.utils.model_info import (
@@ -143,6 +143,13 @@ _TRUST_REMOTE_CODE_FLAG = "--trust-remote-code"
 _WORKER_COMPONENT_TYPES = frozenset({"worker", "prefill", "decode"})
 
 
+def _invokes_mocker(
+    command: list[str] | str | None, args: list[str] | str | None
+) -> bool:
+    """Return whether a container command invokes the public Mocker module."""
+    return "dynamo.mocker" in break_arguments(command) + break_arguments(args)
+
+
 def _all_workers_already_have_trust_flag(config: dict) -> bool:
     """Return True when every worker component carries --trust-remote-code.
 
@@ -167,8 +174,7 @@ def _all_workers_already_have_trust_flag(config: dict) -> bool:
         cmd = main_container.get("command") or []
 
         # Skip mocker workers — they never carry the flag.
-        all_tokens = " ".join(str(t) for t in (list(cmd) + list(args)))
-        if "dynamo.mocker" in all_tokens:
+        if _invokes_mocker(cmd, args):
             continue
 
         is_shell_c = (
@@ -217,8 +223,7 @@ def _inject_trust_remote_code_flag(config: dict) -> None:
         cmd = main_container.get("command") or []
 
         # Skip mocker workers — their argparse does not accept the flag.
-        all_tokens = " ".join(str(t) for t in (list(cmd) + list(args)))
-        if "dynamo.mocker" in all_tokens:
+        if _invokes_mocker(cmd, args):
             continue
 
         # Detect shell form: command=["sh","-c"] with a single-string args.

--- a/container/launch_message/frontend.txt
+++ b/container/launch_message/frontend.txt
@@ -50,9 +50,11 @@ Benefits:
 
 Quick Start:
 
-Online Mocker simulation is temporarily unavailable. Use
-aisimulate predict --stack dynamo for offline simulation. Online simulation will return through
-the unified AISimulate CLI in a future release.
+Start a live Mocker worker with:
+> python3 -m dynamo.mocker --model-path Qwen/Qwen3-0.6B
+
+Use aisimulate predict --stack dynamo for offline virtual-clock simulation. The former public
+Replay online CLI is temporarily unavailable; the live Mocker worker CLI remains available.
 
 Start frontend server:
 > python -m dynamo.frontend --http-port 8000

--- a/container/launch_message/frontend.txt
+++ b/container/launch_message/frontend.txt
@@ -50,11 +50,10 @@ Benefits:
 
 Quick Start:
 
-Start a live Mocker worker with:
-> python3 -m dynamo.mocker --model-path Qwen/Qwen3-0.6B
-
 Use aisimulate predict --stack dynamo for offline virtual-clock simulation. The former public
-Replay online CLI is temporarily unavailable; the live Mocker worker CLI remains available.
+Replay online CLI is temporarily unavailable. Live Mocker workers remain available from a full
+Dynamo installation or the planner image; this frontend-only image does not include their
+dependencies.
 
 Start frontend server:
 > python -m dynamo.frontend --http-port 8000

--- a/deploy/operator/internal/controller/testdata/dgdr/deployment/output.yaml
+++ b/deploy/operator/internal/controller/testdata/dgdr/deployment/output.yaml
@@ -55,7 +55,7 @@ spec:
               command:
                 - python3
                 - -m
-                - dynamo.mocker._worker
+                - dynamo.mocker
               envFrom:
                 - secretRef:
                     name: hf-token-secret
@@ -98,7 +98,7 @@ spec:
               command:
                 - python3
                 - -m
-                - dynamo.mocker._worker
+                - dynamo.mocker
               envFrom:
                 - secretRef:
                     name: hf-token-secret
@@ -155,7 +155,7 @@ spec:
           command:
             - python3
             - -m
-            - dynamo.mocker._worker
+            - dynamo.mocker
           envFrom:
             - secretRef:
                 name: hf-token-secret
@@ -229,7 +229,7 @@ spec:
           command:
             - python3
             - -m
-            - dynamo.mocker._worker
+            - dynamo.mocker
           env:
             - name: DYN_COMPONENT
               value: decode
@@ -514,7 +514,7 @@ spec:
           command:
             - python3
             - -m
-            - dynamo.mocker._worker
+            - dynamo.mocker
           env:
             - name: DYN_COMPONENT
               value: prefill
@@ -692,7 +692,7 @@ spec:
           command:
             - python3
             - -m
-            - dynamo.mocker._worker
+            - dynamo.mocker
           envFrom:
             - secretRef:
                 name: hf-token-secret

--- a/deploy/operator/internal/controller/testdata/dgdr/grove/output.yaml
+++ b/deploy/operator/internal/controller/testdata/dgdr/grove/output.yaml
@@ -57,7 +57,7 @@ spec:
               command:
                 - python3
                 - -m
-                - dynamo.mocker._worker
+                - dynamo.mocker
               envFrom:
                 - secretRef:
                     name: hf-token-secret
@@ -101,7 +101,7 @@ spec:
               command:
                 - python3
                 - -m
-                - dynamo.mocker._worker
+                - dynamo.mocker
               envFrom:
                 - secretRef:
                     name: hf-token-secret
@@ -261,7 +261,7 @@ spec:
                 command:
                   - python3
                   - -m
-                  - dynamo.mocker._worker
+                  - dynamo.mocker
                 env:
                   - name: DYN_COMPONENT
                     value: decode
@@ -401,7 +401,7 @@ spec:
                 command:
                   - python3
                   - -m
-                  - dynamo.mocker._worker
+                  - dynamo.mocker
                 env:
                   - name: DYN_COMPONENT
                     value: prefill

--- a/deploy/operator/internal/controller/testdata/dgdr/lws/output.yaml
+++ b/deploy/operator/internal/controller/testdata/dgdr/lws/output.yaml
@@ -57,7 +57,7 @@ spec:
               command:
                 - python3
                 - -m
-                - dynamo.mocker._worker
+                - dynamo.mocker
               envFrom:
                 - secretRef:
                     name: hf-token-secret
@@ -100,7 +100,7 @@ spec:
               command:
                 - python3
                 - -m
-                - dynamo.mocker._worker
+                - dynamo.mocker
               envFrom:
                 - secretRef:
                     name: hf-token-secret
@@ -159,7 +159,7 @@ spec:
           command:
             - python3
             - -m
-            - dynamo.mocker._worker
+            - dynamo.mocker
           envFrom:
             - secretRef:
                 name: hf-token-secret
@@ -339,7 +339,7 @@ spec:
             command:
               - python3
               - -m
-              - dynamo.mocker._worker
+              - dynamo.mocker
             env:
               - name: DYN_COMPONENT
                 value: decode
@@ -475,7 +475,7 @@ spec:
             command:
               - python3
               - -m
-              - dynamo.mocker._worker
+              - dynamo.mocker
             env:
               - name: DYN_COMPONENT
                 value: decode
@@ -637,7 +637,7 @@ spec:
           command:
             - python3
             - -m
-            - dynamo.mocker._worker
+            - dynamo.mocker
           env:
             - name: DYN_COMPONENT
               value: prefill
@@ -815,7 +815,7 @@ spec:
           command:
             - python3
             - -m
-            - dynamo.mocker._worker
+            - dynamo.mocker
           envFrom:
             - secretRef:
                 name: hf-token-secret

--- a/docs/fern/pages/cli/disaggregated-serving/sizing-with-aiconfigurator.mdx
+++ b/docs/fern/pages/cli/disaggregated-serving/sizing-with-aiconfigurator.mdx
@@ -11,8 +11,9 @@ parallelism (PP), and the number of worker replicas to validate.
 
 AIConfigurator is an analytical performance model and configuration optimizer. It does not start a
 Dynamo frontend, simulate request-by-request scheduler or KV-cache behavior, or benchmark a live
-endpoint. The direct online Mocker CLI is temporarily unavailable. Use
-[DynoSim Replay](../operations/simulation-with-dynosim/dynosim-replay.mdx) for request-level offline simulation and
+endpoint. Use [Mocker Live Simulation](../operations/simulation-with-dynosim/mocker-live-simulation.mdx)
+to exercise a live frontend and simulated workers, [DynoSim Replay](../operations/simulation-with-dynosim/dynosim-replay.mdx)
+for request-level offline simulation, and
 [Benchmarking with AIPerf](../operations/benchmarking-with-aiperf.mdx) for measurements against the running local endpoint.
 
 ## Prerequisites

--- a/docs/fern/pages/cli/operations/simulation-with-dynosim/dynosim-replay.mdx
+++ b/docs/fern/pages/cli/operations/simulation-with-dynosim/dynosim-replay.mdx
@@ -9,9 +9,9 @@ A DynoSim prediction evaluates one workload against one simulated Dynamo configu
 drives the simulated engine cores directly without starting a frontend, registering workers, or
 sending HTTP requests. It runs on CPUs and writes an AIPerf-style summary and JSON report.
 
-Online simulation with live Mocker workers is temporarily unavailable; see
-[Simulate a Local Deployment with Mocker](mocker-live-simulation.mdx) for its status. For the
-configuration and output contract, see the
+For live simulation with registered Mocker workers, see
+[Simulate a Local Deployment with Mocker](mocker-live-simulation.mdx). The former Replay online mode
+remains unavailable. For the configuration and output contract, see the
 [DynoSim Replay CLI Reference](../../../reference/components/dynosim-replay-cli-reference.mdx). For
 the internal execution model, see
 [DynoSim Architecture](../../../developer-guide/knowledge-base/concepts/simulation/dynosim-architecture.md).

--- a/docs/fern/pages/cli/operations/simulation-with-dynosim/dynosim-replay.mdx
+++ b/docs/fern/pages/cli/operations/simulation-with-dynosim/dynosim-replay.mdx
@@ -10,8 +10,9 @@ drives the simulated engine cores directly without starting a frontend, register
 sending HTTP requests. It runs on CPUs and writes an AIPerf-style summary and JSON report.
 
 For live simulation with registered Mocker workers, see
-[Simulate a Local Deployment with Mocker](mocker-live-simulation.mdx). The former Replay online mode
-remains unavailable. For the configuration and output contract, see the
+[Simulate a Local Deployment with Mocker](mocker-live-simulation.mdx). The former public Replay
+online CLI remains unavailable, although the Python replay SDK retains online mode. For the
+configuration and output contract, see the
 [DynoSim Replay CLI Reference](../../../reference/components/dynosim-replay-cli-reference.mdx). For
 the internal execution model, see
 [DynoSim Architecture](../../../developer-guide/knowledge-base/concepts/simulation/dynosim-architecture.md).

--- a/docs/fern/pages/cli/operations/simulation-with-dynosim/mocker-live-simulation.mdx
+++ b/docs/fern/pages/cli/operations/simulation-with-dynosim/mocker-live-simulation.mdx
@@ -2,15 +2,125 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Simulate a Local Deployment with Mocker
-subtitle: Online local simulation is temporarily unavailable
+subtitle: Run a GPU-free frontend and simulated worker from the command line
 ---
 
-<Warning>
-Online simulation with Mocker is temporarily unavailable. The public `python -m dynamo.mocker` CLI
-has been removed. This workflow will return through the unified AISimulate CLI in a future release.
-</Warning>
+Mocker is a simulated Dynamo backend. Use it locally to test frontend discovery, routing, KV events,
+and worker behavior without loading a model or using GPUs. This is a **live simulation**: you start a
+frontend and workers, then send HTTP requests through the Dynamo runtime.
 
-The Mocker engine remains part of Dynamo and powers offline prediction through
-`aisimulate predict --stack dynamo`. Use
-[Run a DynoSim Simulation](dynosim-replay.mdx) to evaluate a synthetic workload or saved trace
-without starting a frontend or live worker processes.
+For a faster **offline replay** that drives simulated engines directly without a frontend, worker
+registration, or runtime services, see [Run a DynoSim Simulation](dynosim-replay.mdx).
+
+This tutorial uses file-based discovery so that the frontend and worker can run without etcd or
+NATS. For Kubernetes, see
+[Simulate a Kubernetes Deployment](../../../kubernetes/operations/simulation-with-dynosim/mocker-live-simulation.mdx).
+For commonly used flags, see the
+[Mocker CLI Reference](../../../reference/components/mocker-cli-reference.mdx).
+
+## Prerequisites
+
+Install Dynamo by following [Install Dynamo](../../installation/install-dynamo.mdx). Verify that
+the local environment can import the frontend and Mocker modules:
+
+```bash
+python3 -m dynamo.frontend --help >/dev/null
+python3 -m dynamo.mocker --help >/dev/null
+```
+
+<Steps toc={true}>
+<Step title="Start the frontend" id="start-the-frontend">
+In the first terminal, start the OpenAI-compatible frontend:
+
+```bash
+python3 -m dynamo.frontend --http-port 8000 --discovery-backend file
+```
+
+File-based discovery keeps this tutorial on one machine and selects the local event path.
+
+</Step>
+<Step title="Start a Mocker worker" id="start-a-mocker-worker">
+In a second terminal, start one simulated worker with the same discovery backend:
+
+```bash
+python3 -m dynamo.mocker \
+  --model-path Qwen/Qwen3-0.6B \
+  --discovery-backend file
+```
+
+Wait for the worker to register with the frontend.
+
+</Step>
+<Step title="Send a request" id="send-a-request">
+In a third terminal, send a request to the frontend:
+
+```bash
+curl localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 32
+  }'
+```
+
+A successful response confirms that local discovery and request routing are working.
+
+</Step>
+<Step title="Run multiple simulated workers" id="run-multiple-simulated-workers">
+Stop the Mocker process and restart it with four workers:
+
+```bash
+python3 -m dynamo.mocker \
+  --model-path Qwen/Qwen3-0.6B \
+  --discovery-backend file \
+  --num-workers 4
+```
+
+Send several requests and compare the frontend and worker logs. For local scale tests, prefer
+`--num-workers` over launching many separate Mocker processes because the workers share one runtime
+and thread pool.
+
+</Step>
+<Step title="Simulate disaggregated serving" id="simulate-disaggregated-serving">
+Stop the aggregated Mocker process. Start a prefill worker:
+
+```bash
+python3 -m dynamo.mocker \
+  --model-path Qwen/Qwen3-0.6B \
+  --discovery-backend file \
+  --disaggregation-mode prefill \
+  --bootstrap-ports 50100
+```
+
+In another terminal, start a decode worker:
+
+```bash
+python3 -m dynamo.mocker \
+  --model-path Qwen/Qwen3-0.6B \
+  --discovery-backend file \
+  --disaggregation-mode decode
+```
+
+Send another request and inspect both worker logs to confirm that the request moved through prefill
+and decode.
+
+</Step>
+<Step title="Tune the simulation" id="tune-the-simulation">
+Restart the worker with settings that match the experiment you want to run. For example:
+
+```bash
+python3 -m dynamo.mocker \
+  --model-path Qwen/Qwen3-0.6B \
+  --discovery-backend file \
+  --num-gpu-blocks-override 8192 \
+  --block-size 64 \
+  --max-num-seqs 256 \
+  --speedup-ratio 10.0
+```
+
+Use the [Mocker CLI Reference](../../../reference/components/mocker-cli-reference.mdx) for scheduling,
+KV-cache, timing, AIC, and transport settings. Use [Run a DynoSim Simulation](dynosim-replay.mdx) when you want
+to replay a complete trace without managing live frontend and worker processes.
+</Step>
+</Steps>

--- a/docs/fern/pages/cli/operations/simulation-with-dynosim/overview.md
+++ b/docs/fern/pages/cli/operations/simulation-with-dynosim/overview.md
@@ -21,7 +21,7 @@ Use DynoSim when you want to answer questions such as:
 | DynoSim prediction | `aisimulate predict --stack dynamo` | Runs one workload against one simulated Dynamo configuration and emits metrics plus a report |
 | DynoSim recommendation | `aisimulate recommend --stack dynamo` | Searches simulation trials across parallelism, worker split, router knobs, service-level objective (SLO) constraints, and GPU budget |
 | Live Mocker workers | `python3 -m dynamo.mocker` | Registers simulated workers with the live Dynamo runtime; does not generate replay traffic |
-| Replay online mode | Unavailable | Will return through the unified AISimulate CLI in a future release |
+| Public Replay online CLI | Unavailable | Will return through the unified AISimulate CLI in a future release; the Python replay SDK retains online mode |
 | Mocker core | `lib/mocker` | Models engine scheduling, KV allocation, prefix caching, preemption, and timing |
 | AISimulate performance model | `timing.type: default` in the AISimulate YAML | Supplies calibrated timing and candidate-shape data for supported model/backend/GPU tuples |
 | Planner simulation | `planner` in the AISimulate YAML | Runs Planner decisions in the simulation loop to study scaling behavior and SLO compliance |

--- a/docs/fern/pages/cli/operations/simulation-with-dynosim/overview.md
+++ b/docs/fern/pages/cli/operations/simulation-with-dynosim/overview.md
@@ -20,7 +20,8 @@ Use DynoSim when you want to answer questions such as:
 |---|---|---|
 | DynoSim prediction | `aisimulate predict --stack dynamo` | Runs one workload against one simulated Dynamo configuration and emits metrics plus a report |
 | DynoSim recommendation | `aisimulate recommend --stack dynamo` | Searches simulation trials across parallelism, worker split, router knobs, service-level objective (SLO) constraints, and GPU budget |
-| Direct online simulation CLI | Unavailable | Will return through the unified AISimulate CLI in a future release |
+| Live Mocker workers | `python3 -m dynamo.mocker` | Registers simulated workers with the live Dynamo runtime; does not generate replay traffic |
+| Replay online mode | Unavailable | Will return through the unified AISimulate CLI in a future release |
 | Mocker core | `lib/mocker` | Models engine scheduling, KV allocation, prefix caching, preemption, and timing |
 | AISimulate performance model | `timing.type: default` in the AISimulate YAML | Supplies calibrated timing and candidate-shape data for supported model/backend/GPU tuples |
 | Planner simulation | `planner` in the AISimulate YAML | Runs Planner decisions in the simulation loop to study scaling behavior and SLO compliance |
@@ -52,8 +53,9 @@ flowchart LR
 ```
 
 Start with `aisimulate predict --stack dynamo` to verify the workload shape and engine configuration.
-Use `aisimulate recommend --stack dynamo` to search the design space. Online Mocker deployments are
-temporarily unavailable. Validate the shortlist on real GPUs before production rollout.
+Use `aisimulate recommend --stack dynamo` to search the design space. Launch live Mocker workers
+when an integration test needs the real Dynamo runtime. Validate the shortlist on real GPUs before
+production rollout.
 
 ## Where AISimulate Fits
 
@@ -69,8 +71,8 @@ decode work should take for supported model/backend/GPU combinations.
 |---|---|
 | Run one trace or synthetic workload through one config | [Run a DynoSim Simulation](dynosim-replay.mdx) |
 | Sweep topology and router choices under SLA/GPU constraints | [Sweep DynoSim Configurations](dynosim-sweeps.mdx) |
-| Check the status of Kubernetes online simulation | [Simulate a Kubernetes Deployment](../../../kubernetes/operations/simulation-with-dynosim/mocker-live-simulation.mdx) |
-| Check the status of local online simulation | [Simulate a Local Deployment](mocker-live-simulation.mdx) |
+| Run live Mocker workers on Kubernetes | [Simulate a Kubernetes Deployment](../../../kubernetes/operations/simulation-with-dynosim/mocker-live-simulation.mdx) |
+| Run live Mocker workers locally | [Simulate a Local Deployment](mocker-live-simulation.mdx) |
 | Study Planner scaling decisions against a trace | [Benchmark Planner Decisions](../../../kubernetes/operations/simulation-with-dynosim/dynosim-planner-replay.mdx) |
 | Generate a deployable Kubernetes config from model/SLA intent | [Auto Deployment](../../../kubernetes/auto-deployment/overview.mdx) |
 

--- a/docs/fern/pages/cli/operations/simulation-with-dynosim/simulation-model.md
+++ b/docs/fern/pages/cli/operations/simulation-with-dynosim/simulation-model.md
@@ -10,7 +10,8 @@ engine-specific scheduler and KV-cache state. Offline prediction and live Mocker
 same core through virtual-time and wall-clock execution, respectively.
 
 Run `python3 -m dynamo.mocker` to launch live workers. This worker launcher is separate from the
-former Replay online mode, which remains unavailable in the unified AISimulate CLI.
+former public Replay online CLI, which remains unavailable in the unified AISimulate CLI. The
+Python replay SDK retains online mode for programmatic callers.
 
 ## Engine Behavior
 
@@ -41,9 +42,9 @@ events. The SGLang core uses its own token-pool and radix-cache implementation.
 Scheduler state determines the batch and cache-hit inputs to the timing source. Choose one timing
 source for each worker role with `engine.workers.<role>.timing.type`.
 
-The removed public Mocker CLI options for profile-derived interpolation and direct `--aic-*`
-configuration are not part of the unified CLI. Use only the timing types accepted by the
-AISimulate YAML schema.
+The live Mocker CLI options for profile-derived interpolation and direct `--aic-*` configuration
+are separate from the unified CLI. In AISimulate configurations, use only the timing types accepted
+by the AISimulate YAML schema.
 
 ### AISimulate Performance Model
 
@@ -127,5 +128,5 @@ Interpret simulation results within these boundaries:
 - Mocker simulates text-token processing; it does not model multimodal encoder or cross-attention
   compute.
 
-Use offline prediction for broad algorithm and configuration exploration. Validate the distributed
-path with focused GPU benchmarks until online simulation returns.
+Use offline prediction for broad algorithm and configuration exploration. Use live Mocker workers
+to exercise the distributed path, and validate performance conclusions with focused GPU benchmarks.

--- a/docs/fern/pages/cli/operations/simulation-with-dynosim/simulation-model.md
+++ b/docs/fern/pages/cli/operations/simulation-with-dynosim/simulation-model.md
@@ -6,13 +6,11 @@ subtitle: Engine behavior, timing sources, KV movement, and fidelity boundaries
 ---
 
 DynoSim builds a distributed serving simulation from Mocker engine cores. Each core owns
-engine-specific scheduler and KV-cache state. Offline prediction and the retained internal worker
-runtime drive the same core through virtual-time and wall-clock execution, respectively.
+engine-specific scheduler and KV-cache state. Offline prediction and live Mocker workers drive the
+same core through virtual-time and wall-clock execution, respectively.
 
-> [!WARNING]
-> The public online Mocker CLI is temporarily unavailable. The internal online behavior described
-> here remains an implementation detail and will return through the unified AISimulate CLI in a
-> future release.
+Run `python3 -m dynamo.mocker` to launch live workers. This worker launcher is separate from the
+former Replay online mode, which remains unavailable in the unified AISimulate CLI.
 
 ## Engine Behavior
 

--- a/docs/fern/pages/developer-guide/knowledge-base/concepts/simulation/dynosim-architecture.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/concepts/simulation/dynosim-architecture.md
@@ -7,8 +7,9 @@ subtitle: How the replay harness composes simulated engines, routing, and Planne
 
 DynoSim connects a workload driver to one or more Mocker engine cores and records request and token
 timing for analysis. The unified `aisimulate predict` and `aisimulate recommend` commands run this
-simulation offline. The former Replay online mode is unavailable. The separate `python3 -m
-dynamo.mocker` command launches live Mocker workers without replay orchestration.
+simulation offline. The former public Replay online CLI is unavailable, although the Python replay
+SDK retains online mode. The separate `python3 -m dynamo.mocker` command launches live Mocker
+workers without replay orchestration.
 
 For task-oriented instructions, see [Run a DynoSim Simulation](../../../../cli/operations/simulation-with-dynosim/dynosim-replay.mdx),
 [Sweep DynoSim Configurations](../../../../cli/operations/simulation-with-dynosim/dynosim-sweeps.mdx), and
@@ -91,9 +92,9 @@ Offline execution drives Mocker engine cores directly. It uses a logical clock a
 a frontend, worker registration, etcd, NATS, or HTTP traffic. This path is appropriate for fast,
 repeatable configuration comparisons and continuous-integration tests.
 
-The codebase retains an internal worker runtime and compatibility SDK paths, but they are not a
-supported online CLI workflow. Online simulation will return through the unified AISimulate CLI in
-a future release.
+Run `python3 -m dynamo.mocker` for the supported live worker CLI. The Python replay SDK retains
+online mode for programmatic callers, but no public Replay CLI currently exposes online replay
+orchestration.
 
 ## Routing simulation
 

--- a/docs/fern/pages/developer-guide/knowledge-base/concepts/simulation/dynosim-architecture.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/concepts/simulation/dynosim-architecture.md
@@ -7,7 +7,8 @@ subtitle: How the replay harness composes simulated engines, routing, and Planne
 
 DynoSim connects a workload driver to one or more Mocker engine cores and records request and token
 timing for analysis. The unified `aisimulate predict` and `aisimulate recommend` commands run this
-simulation offline. The former public online replay and Mocker commands are unavailable.
+simulation offline. The former Replay online mode is unavailable. The separate `python3 -m
+dynamo.mocker` command launches live Mocker workers without replay orchestration.
 
 For task-oriented instructions, see [Run a DynoSim Simulation](../../../../cli/operations/simulation-with-dynosim/dynosim-replay.mdx),
 [Sweep DynoSim Configurations](../../../../cli/operations/simulation-with-dynosim/dynosim-sweeps.mdx), and

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/mocker/mocker-engine-architecture.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/mocker/mocker-engine-architecture.md
@@ -13,8 +13,8 @@ component-level design.
 
 For offline usage, see
 [Run a DynoSim Simulation](../../../../../cli/operations/simulation-with-dynosim/dynosim-replay.mdx).
-The [Mocker CLI Reference](../../../../../reference/components/mocker-cli-reference.mdx) tracks the
-temporarily unavailable online surface.
+For live workers, see the
+[Mocker CLI Reference](../../../../../reference/components/mocker-cli-reference.mdx).
 
 ## Generalized Engine
 
@@ -23,10 +23,9 @@ attention data-parallel (DP) barrier. A logical engine contains either one rank 
 sibling ranks. Grouped execution starts a pass only when every sibling rank is ready and completes
 at the latest rank completion time.
 
-Offline prediction and the retained internal worker runtime construct this same generalized engine.
-The AISimulate Replayer advances it with a virtual clock and deterministic event queue. The internal
-worker runtime advances it with Tokio and wall-clock timers, but it is not a public CLI while online
-simulation is unavailable.
+Offline prediction and live Mocker workers construct this same generalized engine. The AISimulate
+Replayer advances it with a virtual clock and deterministic event queue. Live workers advance it
+with Tokio and wall-clock timers and register with the Dynamo runtime.
 
 ## Scheduler
 
@@ -151,7 +150,7 @@ The following features are not yet supported by the mocker:
 
 | Document | Description |
 |----------|-------------|
-| [Simulate a Kubernetes Deployment](../../../../../kubernetes/operations/simulation-with-dynosim/mocker-live-simulation.mdx) | Check online Kubernetes simulation availability |
-| [Simulate a Local Deployment](../../../../../cli/operations/simulation-with-dynosim/mocker-live-simulation.mdx) | Check online local simulation availability |
-| [Mocker CLI Reference](../../../../../reference/components/mocker-cli-reference.mdx) | Check the removed public CLI status |
+| [Simulate a Kubernetes Deployment](../../../../../kubernetes/operations/simulation-with-dynosim/mocker-live-simulation.mdx) | Deploy live Mocker workers on Kubernetes |
+| [Simulate a Local Deployment](../../../../../cli/operations/simulation-with-dynosim/mocker-live-simulation.mdx) | Run live Mocker workers from the command line |
+| [Mocker CLI Reference](../../../../../reference/components/mocker-cli-reference.mdx) | Configure and launch live Mocker workers |
 | [Run a DynoSim Simulation](../../../../../cli/operations/simulation-with-dynosim/dynosim-replay.mdx) | Predict one workload against a simulated configuration with `aisimulate predict --stack dynamo` |

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/mocker/mocker-engine-architecture.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/mocker/mocker-engine-architecture.md
@@ -91,8 +91,8 @@ The unified AISimulate configuration exposes three timing modes under
 - **`polynomial`** uses hardcoded polynomial formulas. Prefill time scales quadratically with token
   count, while decode time depends on the total active KV cache size.
 
-The removed public Mocker CLI flags, including `--aic-perf-model`, are not inputs to
-`aisimulate predict` or `aisimulate recommend`.
+The live Mocker CLI flags, including `--aic-perf-model`, are separate from the inputs to
+`aisimulate predict` and `aisimulate recommend`.
 
 ## Bootstrap Rendezvous (Disaggregated Serving)
 

--- a/docs/fern/pages/kubernetes/auto-deployment/dynamo-profiler.md
+++ b/docs/fern/pages/kubernetes/auto-deployment/dynamo-profiler.md
@@ -173,7 +173,7 @@ spec:
       enabled: true
 ```
 
-Mocker is a testing and experimentation path, not a serving deployment. It is independent of `searchStrategy` — enabling it does not change or override rapid versus thorough, and the profiler still runs the search strategy you set. The one interaction is with the Planner: when you enable mocker **alongside the Planner**, the Planner's pre-deployment sweeping cannot be `none`, because the mocker needs the simulated performance data that sweeping produces. Without a Planner, mocker carries no such requirement. The public direct Mocker CLI is removed, but Profiler-managed Mocker deployments continue to use the retained internal worker runtime.
+Mocker is a testing and experimentation path, not a serving deployment. It is independent of `searchStrategy` — enabling it does not change or override rapid versus thorough, and the profiler still runs the search strategy you set. The one interaction is with the Planner: when you enable mocker **alongside the Planner**, the Planner's pre-deployment sweeping cannot be `none`, because the mocker needs the simulated performance data that sweeping produces. Without a Planner, mocker carries no such requirement. Profiler-managed deployments and the public `python3 -m dynamo.mocker` command use the same live Mocker worker runtime.
 
 ## Accessing profiling artifacts
 

--- a/docs/fern/pages/kubernetes/getting-started/introduction.mdx
+++ b/docs/fern/pages/kubernetes/getting-started/introduction.mdx
@@ -169,7 +169,7 @@ This page covers the **Kubernetes** path. To run Dynamo directly on a workstatio
         Learn the simulation workflow and components.
       </Card>
       <Card title="Simulate a Kubernetes Deployment" icon="regular server" href="../operations/simulation-with-dynosim/mocker-live-simulation.mdx">
-        Check the status of temporarily unavailable online simulation.
+        Deploy live Mocker workers without GPUs.
       </Card>
     </CardGroup>
   </Accordion>

--- a/docs/fern/pages/kubernetes/operations/simulation-with-dynosim/mocker-live-simulation.mdx
+++ b/docs/fern/pages/kubernetes/operations/simulation-with-dynosim/mocker-live-simulation.mdx
@@ -112,8 +112,6 @@ args:
 - Qwen/Qwen3-0.6B
 - --disaggregation-mode
 - prefill
-- --bootstrap-ports
-- "50100"
 ```
 
 The decode worker uses:
@@ -130,7 +128,7 @@ Apply the manifest, repeat the port-forward and request steps, and inspect the w
 
 ```bash
 kubectl logs -n "$NAMESPACE" \
-  --selector=nvidia.com/dynamo-graph-deployment=mocker-disagg \
+  --selector=nvidia.com/dynamo-graph-deployment-name=mocker-disagg \
   --all-containers --prefix
 ```
 

--- a/docs/fern/pages/kubernetes/operations/simulation-with-dynosim/mocker-live-simulation.mdx
+++ b/docs/fern/pages/kubernetes/operations/simulation-with-dynosim/mocker-live-simulation.mdx
@@ -2,15 +2,153 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Simulate a Kubernetes Deployment with Mocker
-subtitle: Online Kubernetes simulation is temporarily unavailable
+subtitle: Exercise the Dynamo frontend, router, and worker lifecycle without GPUs
 ---
 
-<Warning>
-Online simulation with Mocker is temporarily unavailable. The public `python -m dynamo.mocker` CLI
-has been removed. This workflow will return through the unified AISimulate CLI in a future release.
-</Warning>
+Mocker is a simulated Dynamo backend. It registers workers, publishes KV events, and returns mock
+responses while exercising the same frontend and routing path as a model-serving deployment.
 
-Use [Run a DynoSim Simulation](../../../cli/operations/simulation-with-dynosim/dynosim-replay.mdx)
-for offline prediction. It evaluates Router and Planner behavior without deploying live Mocker
-workers. Validate selected configurations on a real deployment with
-[Benchmarking with AIPerf](../benchmarking-with-aiperf.mdx).
+Use this tutorial to deploy Mocker with a `DynamoGraphDeployment` (DGD). For local development, see
+[Simulate a Local Deployment](../../../cli/operations/simulation-with-dynosim/mocker-live-simulation.mdx). For configuration details, see the
+[Mocker CLI Reference](../../../reference/components/mocker-cli-reference.mdx). For implementation details,
+see [Mocker Engine Architecture](../../../developer-guide/knowledge-base/modular-components/backends/mocker/mocker-engine-architecture.md).
+
+## Prerequisites
+
+Before you begin:
+
+- Install the Dynamo Kubernetes Platform.
+- Set `NAMESPACE` to the namespace where you deploy Dynamo resources.
+- Set `PLANNER_IMAGE` to a released or locally built `dynamo-planner` image.
+- Configure cluster access with `kubectl`.
+
+Mocker runs in the planner image and does not request GPU resources.
+
+<Steps toc={true}>
+<Step title="Deploy an aggregated simulation" id="deploy-an-aggregated-simulation">
+Create `mocker-agg.yaml`:
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: mocker-agg
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: ${PLANNER_IMAGE}
+  - name: decode
+    type: decode
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: ${PLANNER_IMAGE}
+          workingDir: /workspace
+          command:
+          - python3
+          - -m
+          - dynamo.mocker
+          args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --speedup-ratio
+          - "1.0"
+```
+
+Replace `${PLANNER_IMAGE}` with the image URI, and then apply the DGD:
+
+```bash
+kubectl apply -n "$NAMESPACE" -f mocker-agg.yaml
+kubectl wait -n "$NAMESPACE" \
+  --for=condition=Ready pod \
+  --selector=nvidia.com/dynamo-graph-deployment-name=mocker-agg \
+  --timeout=300s
+```
+
+The checked-in
+[aggregated Mocker example](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/mocker/deploy/agg.yaml)
+contains the complete deployment manifest.
+
+</Step>
+<Step title="Send a request" id="send-a-request">
+Forward the frontend service to port 8000:
+
+```bash
+kubectl port-forward -n "$NAMESPACE" svc/mocker-agg-frontend 8000:8000
+```
+
+In another terminal, send an OpenAI-compatible request:
+
+```bash
+curl localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 32
+  }'
+```
+
+A successful response confirms that the frontend discovered the Mocker worker and routed the
+request through the deployment.
+
+</Step>
+<Step title="Simulate disaggregated serving" id="simulate-disaggregated-serving">
+Start from the checked-in
+[disaggregated Mocker example](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/mocker/deploy/disagg.yaml).
+It defines separate prefill and decode components. The prefill worker uses:
+
+```yaml
+args:
+- --model-path
+- Qwen/Qwen3-0.6B
+- --disaggregation-mode
+- prefill
+- --bootstrap-ports
+- "50100"
+```
+
+The decode worker uses:
+
+```yaml
+args:
+- --model-path
+- Qwen/Qwen3-0.6B
+- --disaggregation-mode
+- decode
+```
+
+Apply the manifest, repeat the port-forward and request steps, and inspect the worker logs:
+
+```bash
+kubectl logs -n "$NAMESPACE" \
+  --selector=nvidia.com/dynamo-graph-deployment=mocker-disagg \
+  --all-containers --prefix
+```
+
+Use the logs to confirm that both worker stages registered and that requests moved from prefill to
+decode.
+
+</Step>
+<Step title="Try another simulation" id="try-another-simulation">
+Change one setting at a time and repeat the request:
+
+- Increase `replicas` to exercise routing across more workers.
+- Add Mocker scheduling or KV-cache flags from the
+  [Mocker CLI Reference](../../../reference/components/mocker-cli-reference.mdx).
+- Enable the Planner to test scaling behavior with simulated workers.
+- Compare the simulation with a real-GPU deployment by using
+  [Benchmarking with AIPerf](../benchmarking-with-aiperf.mdx).
+
+DynoSim helps test control-plane behavior and shortlist configurations. Validate performance
+conclusions on the target GPU hardware before production use.
+</Step>
+</Steps>

--- a/docs/fern/pages/recipes/feature-benchmarks/benchmarking-guide.md
+++ b/docs/fern/pages/recipes/feature-benchmarks/benchmarking-guide.md
@@ -84,11 +84,11 @@ For full documentation, see the [AIPerf docs](https://github.com/ai-dynamo/aiper
 
 ---
 
-# Client-Side Benchmarking (Local)
+## Client-Side Benchmarking (Local)
 
 Client-side benchmarking runs on your local machine and connects to Kubernetes deployments via port-forwarding.
 
-## Prerequisites
+### Prerequisites
 
 1. **Dynamo container environment** - You must be running inside a Dynamo container with AIPerf pre-installed, or install it locally:
    ```bash
@@ -100,9 +100,9 @@ Client-side benchmarking runs on your local machine and connects to Kubernetes d
    - External services (vLLM, llm-d, AIBrix, etc.)
    - Any HTTP endpoint serving OpenAI-compatible models
 
-## User Workflow
+### User Workflow
 
-### Step 1: Set Up Cluster and Deploy
+#### Step 1: Set Up Cluster and Deploy
 
 Set up your Kubernetes cluster with NVIDIA GPUs and install the Dynamo Kubernetes Platform following the [installation guide](../../kubernetes/installation/install-dynamo.md). Then deploy your `DynamoGraphDeployment`.
 
@@ -113,7 +113,7 @@ benchmark jobs that you can run or adapt. If no recipe matches, start from the
 [Model Deployment](../../kubernetes/model-deployment/introduction.mdx) or the backend
 examples in [examples/backends](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends).
 
-### Step 2: Port-Forward and Run a Single Benchmark
+#### Step 2: Port-Forward and Run a Single Benchmark
 
 > **Wait for model readiness.** Before benchmarking, ensure your deployment has fully loaded the model. Check pod logs or hit the health endpoint (`curl http://localhost:8000/health`) — it should return `200 OK` before you proceed.
 
@@ -155,7 +155,7 @@ This produces results in `artifacts/` and prints a summary table to the console:
 
 To stop the port-forward when done: `kill %1` (or `kill <PID>`).
 
-### Step 3: Concurrency Sweep for Pareto Analysis
+#### Step 3: Concurrency Sweep for Pareto Analysis
 
 To understand how your deployment behaves across load levels, run a concurrency sweep. Each concurrency level sends enough requests for stable measurements (`max(c*3, 10)`):
 
@@ -179,7 +179,7 @@ done
 
 **Note**: Adjust concurrency levels to match your deployment's capacity. Very high concurrency on a small deployment (e.g., c250 on a single GPU) will cause server errors. Start with lower values and increase until you find the saturation point.
 
-### Step 4: [If Comparative] Benchmark a Second Deployment
+#### Step 4: [If Comparative] Benchmark a Second Deployment
 
 Teardown deployment A and deploy deployment B with a different configuration. Kill the previous port-forward (`kill %1`), then repeat:
 
@@ -200,7 +200,7 @@ for c in 1 2 5 10 50 100; do
 done
 ```
 
-### Step 5: Generate Visualizations
+#### Step 5: Generate Visualizations
 
 ```bash
 # Compare all runs — auto-detects multi-run directories
@@ -224,7 +224,7 @@ Here is an example Pareto frontier from a concurrency sweep of Qwen3-0.6B on 8x 
 
 See the [AIPerf Visualization Guide](https://github.com/ai-dynamo/aiperf/blob/main/docs/tutorials/plot.md) for full details on plot customization, experiment classification, and themes.
 
-## Use Cases
+### Use Cases
 
 - **Compare DynamoGraphDeployments** (e.g., aggregated vs disaggregated configurations)
 - **Compare different backends** (e.g., SGLang vs TensorRT-LLM vs vLLM)
@@ -233,9 +233,9 @@ See the [AIPerf Visualization Guide](https://github.com/ai-dynamo/aiperf/blob/ma
 - **Compare different hardware configurations** (e.g., H100 vs A100 vs H200)
 - **Compare different parallelization strategies** (e.g., different GPU counts or memory configurations)
 
-## AIPerf Quick Reference
+### AIPerf Quick Reference
 
-### Commonly Used Options
+#### Commonly Used Options
 
 ```text
 aiperf profile [OPTIONS]
@@ -260,7 +260,7 @@ COMMON OPTIONS:
 
 For the complete CLI reference, see `aiperf profile --help` or the [CLI docs](https://github.com/ai-dynamo/aiperf/blob/main/docs/cli-options.md).
 
-### Output Sequence Length
+#### Output Sequence Length
 
 To enforce a specific output length, pass `ignore_eos` and `min_tokens` via `--extra-inputs`:
 
@@ -277,7 +277,7 @@ aiperf profile \
     --extra-inputs ignore_eos:true
 ```
 
-### Understanding Results
+#### Understanding Results
 
 Each `aiperf profile` run produces an artifact directory containing:
 - **`profile_export_aiperf.json`** — Structured metrics (latency, throughput, TTFT, ITL, etc.)
@@ -308,19 +308,19 @@ artifacts/
 
 ---
 
-# Server-Side Benchmarking (In-Cluster)
+## Server-Side Benchmarking (In-Cluster)
 
 Server-side benchmarking runs directly within the Kubernetes cluster, eliminating port-forwarding overhead and enabling high-load testing.
 
-## Prerequisites
+### Prerequisites
 
 1. **Kubernetes cluster** with NVIDIA GPUs and Dynamo namespace setup (see [Dynamo Kubernetes Platform docs](../../kubernetes/getting-started/quickstart.mdx))
 2. **Storage**: PersistentVolumeClaim configured with appropriate permissions (see [deploy/utils README](https://github.com/ai-dynamo/dynamo/blob/main/deploy/utils/README.md))
 3. **Docker image** containing AIPerf (Dynamo runtime images include it)
 
-## Quick Start
+### Quick Start
 
-### Step 1: Deploy Your DynamoGraphDeployment
+#### Step 1: Deploy Your DynamoGraphDeployment
 Deploy a `DynamoGraphDeployment` using a matching
 [Dynamo Recipe](https://github.com/ai-dynamo/dynamo/tree/main/recipes), the
 [Model Deployment](../../kubernetes/model-deployment/introduction.mdx), or the backend
@@ -329,7 +329,7 @@ Ensure it has a frontend service exposed and the model is fully loaded before
 running benchmarks — check pod logs or verify the health endpoint returns
 `200 OK`.
 
-### Step 2: Configure and Run Benchmark Job
+#### Step 2: Configure and Run Benchmark Job
 
 If your recipe includes a `perf.yaml`, start from that benchmark job because it
 already encodes the model, endpoint, workload shape, and result collection
@@ -354,7 +354,7 @@ kubectl apply -f benchmarks/incluster/benchmark_job.yaml -n $NAMESPACE
 kubectl logs -f job/dynamo-benchmark -n $NAMESPACE
 ```
 
-### Step 3: Retrieve Results
+#### Step 3: Retrieve Results
 ```bash
 # Create access pod (skip if already running)
 kubectl apply -f deploy/utils/manifests/pvc-access-pod.yaml -n $NAMESPACE
@@ -367,12 +367,12 @@ kubectl cp $NAMESPACE/pvc-access-pod:/data/results ./results
 kubectl delete pod pvc-access-pod -n $NAMESPACE
 ```
 
-### Step 4: Generate Plots
+#### Step 4: Generate Plots
 ```bash
 aiperf plot ./results
 ```
 
-## Cross-Namespace Service Access
+### Cross-Namespace Service Access
 
 When referencing services in other namespaces, use full Kubernetes DNS:
 
@@ -384,7 +384,7 @@ When referencing services in other namespaces, use full Kubernetes DNS:
 --url http://vllm-agg-frontend.production.svc.cluster.local:8000
 ```
 
-## Monitoring and Debugging
+### Monitoring and Debugging
 
 ```bash
 # Check job status
@@ -400,7 +400,7 @@ kubectl get pods -n $NAMESPACE -l job-name=dynamo-benchmark
 kubectl describe pod <pod-name> -n $NAMESPACE
 ```
 
-### Troubleshooting
+#### Troubleshooting
 
 1. **Service not found**: Ensure your DynamoGraphDeployment frontend service is running
 2. **PVC access**: Check that `dynamo-pvc` is properly configured and accessible
@@ -418,7 +418,7 @@ kubectl get endpoints <service-name> -n $NAMESPACE
 
 ---
 
-## Testing with DynoSim / Mocker
+### Testing with DynoSim / Mocker
 
 For development and testing purposes, Dynamo provides DynoSim and the [mocker backend](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/mocker) to simulate LLM inference without requiring actual GPU resources. This is useful for:
 
@@ -431,12 +431,13 @@ The Mocker engine models backend behavior without running inference. Use
 [DynoSim Runs](../../cli/operations/simulation-with-dynosim/dynosim-replay.mdx) for one offline
 workload/configuration trial and
 [DynoSim Sweeps](../../cli/operations/simulation-with-dynosim/dynosim-sweeps.mdx) to search candidate
-configurations. The direct online Mocker CLI is temporarily unavailable and will return in a future
-release.
+configurations. Use [Mocker Live Simulation](../../cli/operations/simulation-with-dynosim/mocker-live-simulation.mdx)
+to launch live simulated workers through the Dynamo runtime. The former Replay online mode remains
+unavailable.
 
 ---
 
-## Advanced AIPerf Features
+### Advanced AIPerf Features
 
 AIPerf has many capabilities beyond basic profiling. Here are some particularly useful for Dynamo benchmarking:
 

--- a/docs/fern/pages/recipes/feature-benchmarks/benchmarking-guide.md
+++ b/docs/fern/pages/recipes/feature-benchmarks/benchmarking-guide.md
@@ -432,8 +432,8 @@ The Mocker engine models backend behavior without running inference. Use
 workload/configuration trial and
 [DynoSim Sweeps](../../cli/operations/simulation-with-dynosim/dynosim-sweeps.mdx) to search candidate
 configurations. Use [Mocker Live Simulation](../../cli/operations/simulation-with-dynosim/mocker-live-simulation.mdx)
-to launch live simulated workers through the Dynamo runtime. The former Replay online mode remains
-unavailable.
+to launch live simulated workers through the Dynamo runtime. The former public Replay online CLI
+remains unavailable, although the Python replay SDK retains online mode.
 
 ---
 

--- a/docs/fern/pages/recipes/feature-benchmarks/mocker-trace-replay.md
+++ b/docs/fern/pages/recipes/feature-benchmarks/mocker-trace-replay.md
@@ -9,7 +9,8 @@ This page has moved to [Run a DynoSim Simulation](../../cli/operations/simulatio
 
 > [!NOTE]
 > The former `online` replay mode has no replacement in the unified AISimulate CLI yet. It will
-> return in a future release. The public `python -m dynamo.mocker` CLI has also been removed.
+> return in a future release. The separate `python3 -m dynamo.mocker` command remains available for
+> launching live Mocker workers; it does not replay a trace by itself.
 
 The old path remains so existing links, including the DynoSim blog post's
 related guide link, continue to resolve.

--- a/docs/fern/pages/reference/components/dynosim-replay-cli-reference.mdx
+++ b/docs/fern/pages/reference/components/dynosim-replay-cli-reference.mdx
@@ -15,9 +15,9 @@ search configuration domains, see
 [Sweep DynoSim Configurations](../../cli/operations/simulation-with-dynosim/dynosim-sweeps.mdx).
 
 <Warning>
-The former `online` replay mode and public `python -m dynamo.mocker` CLI have no replacement in the
-unified AISimulate CLI yet. `aisimulate predict` and `aisimulate recommend` are offline-only. Online
-simulation will return in a future release.
+The former Replay `online` mode has no replacement in the unified AISimulate CLI yet. `aisimulate
+predict` and `aisimulate recommend` are offline-only. The separate `python3 -m dynamo.mocker`
+command remains available for launching live workers but does not provide replay orchestration.
 </Warning>
 
 ## Command

--- a/docs/fern/pages/reference/components/mocker-cli-reference.mdx
+++ b/docs/fern/pages/reference/components/mocker-cli-reference.mdx
@@ -2,16 +2,330 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Mocker CLI Reference
-subtitle: Availability status for the removed online Mocker CLI
+subtitle: Command-line flags for live Mocker workers
 ---
 
-<Warning>
-The public `python -m dynamo.mocker` CLI has been removed while online simulation is unavailable. It
-will return through the unified AISimulate CLI in a future release.
-</Warning>
+`python3 -m dynamo.mocker` launches a simulated Dynamo worker that registers with the frontend,
+publishes KV events, and exercises the router and planner paths without a GPU. This page is the flag
+reference. For the deployment workflow and local/Kubernetes launch recipes, see
+[Simulate a Kubernetes Deployment](../../kubernetes/operations/simulation-with-dynosim/mocker-live-simulation.mdx) or
+[Simulate a Local Deployment](../../cli/operations/simulation-with-dynosim/mocker-live-simulation.mdx); for the engine internals these flags
+configure, see [Mocker Engine Architecture](../../developer-guide/knowledge-base/modular-components/backends/mocker/mocker-engine-architecture.md).
 
-The `dynamo.mocker` Python package and generalized Mocker engine remain available to Dynamo
-internals and SDK callers. For the engine architecture, see
-[Mocker Engine Architecture](../../developer-guide/knowledge-base/modular-components/backends/mocker/mocker-engine-architecture.md).
-For the supported offline command and YAML configuration, see
-[DynoSim Replay CLI Reference](dynosim-replay-cli-reference.mdx).
+Run `python3 -m dynamo.mocker --help` for the complete option list supported by the installed
+version.
+
+AISimulate reuses the same engine core for offline virtual-clock prediction and recommendation, but
+its public YAML is separate from these live-worker flags. See the
+[DynoSim Replay CLI Reference](dynosim-replay-cli-reference.mdx) for the offline contract. The former
+Replay online mode remains unavailable.
+
+## Core and model
+
+<ParamField path="--model-path" type="string" default="null">
+  Hugging Face model ID or local path for the tokenizer. Set this for normal frontend requests.
+</ParamField>
+
+<ParamField path="--model-name" type="string" default="derived from --model-path">
+  Model name used in API responses.
+</ParamField>
+
+<ParamField path="--endpoint" type="string" default="auto-derived">
+  Dynamo endpoint string. Defaults are namespace-dependent, and prefill workers use a different
+  default endpoint than aggregated or decode workers.
+</ParamField>
+
+<ParamField path="--engine-type" type="string" default="vllm">
+  Engine simulation type.
+
+  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>vllm</Badge> <Badge intent="note" minimal>sglang</Badge> <Badge intent="note" minimal>trtllm</Badge></span>
+</ParamField>
+
+<ParamField path="--extra-engine-args" type="path" default="null">
+  Path to a JSON file with mocker configuration. Overrides individual CLI arguments.
+</ParamField>
+
+## KV cache
+
+<ParamField path="--num-gpu-blocks-override" type="integer" default="auto">
+  Usable KV cache blocks per data-parallel rank. Non-AIC timing defaults to 16,384 blocks; AIC
+  timing estimates capacity when this option is omitted.
+</ParamField>
+
+<ParamField path="--block-size" type="integer" default="engine-specific">
+  Tokens per KV cache block. Defaults are 64 for vLLM, 1 for SGLang, and 32 for TensorRT-LLM.
+</ParamField>
+
+<ParamField path="--max-model-len" type="integer" default="null">
+  Maximum sequence length, including prompt and generated tokens. Omitting the option leaves the
+  simulated engine without a model-length limit.
+</ParamField>
+
+<ParamField path="--enable-prefix-caching" type="boolean" default="true">
+  Enable prefix caching. Pass `--no-enable-prefix-caching` to disable.
+</ParamField>
+
+<ParamField path="--kv-cache-dtype" type="string" default="auto">
+  KV cache dtype for the bytes-per-token computation.
+</ParamField>
+
+<ParamField path="--kv-bytes-per-token" type="integer" default="auto-computed">
+  KV cache bytes per token. Overrides the auto-computation.
+</ParamField>
+
+## Scheduling
+
+<ParamField path="--max-num-seqs" type="integer" default="256">
+  Maximum concurrent sequences.
+</ParamField>
+
+<ParamField path="--max-num-batched-tokens" type="integer" default="8192">
+  Maximum tokens per batch.
+</ParamField>
+
+<ParamField path="--enable-chunked-prefill" type="boolean" default="true">
+  Enable chunked prefill. Pass `--no-enable-chunked-prefill` to disable.
+</ParamField>
+
+<ParamField path="--preemption-mode" type="string" default="lifo">
+  Decode eviction policy under memory pressure. `lifo` is vLLM v1 style.
+
+  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>lifo</Badge> <Badge intent="note" minimal>fifo</Badge></span>
+</ParamField>
+
+## Timing
+
+<ParamField path="--speedup-ratio" type="float" default="1.0">
+  Timing speedup factor applied to simulated prefill and decode durations.
+</ParamField>
+
+<ParamField path="--decode-speedup-ratio" type="float" default="1.0">
+  Decode-only speedup multiplier, for example for Eagle speculation.
+</ParamField>
+
+<ParamField path="--startup-time" type="float" default="null">
+  Simulated startup delay, in seconds.
+</ParamField>
+
+## Data parallelism and workers
+
+<ParamField path="--data-parallel-size" type="integer" default="1">
+  Number of DP replicas.
+</ParamField>
+
+<ParamField path="--num-workers" type="integer" default="1">
+  Workers per process. Prefer this over launching many separate mocker processes: all workers share
+  one tokio runtime and thread pool.
+</ParamField>
+
+<ParamField path="--stagger-delay" type="float" default="-1 (auto)">
+  Delay between worker launches, in seconds. `0` disables; `-1` enables auto mode.
+</ParamField>
+
+## Performance modeling
+
+<ParamField path="--planner-profile-data" type="path" default="null">
+  Path to either a mocker-format `.npz` file or a profiler results directory.
+</ParamField>
+
+<ParamField path="--reasoning" type="JSON string" default="null">
+  JSON config for emitting reasoning token spans, with `start_thinking_token_id`,
+  `end_thinking_token_id`, and `thinking_ratio`.
+</ParamField>
+
+<ParamField path="--response-replay-trace-path" type="path" default="null">
+  Mooncake JSONL trace whose `output_token_ids` provide response replay annotations.
+</ParamField>
+
+## AIC performance model
+
+Opt-in flags for the AIConfigurator (AIC) latency model. Live Mocker workers do not use AIC by
+default.
+For the timing-model design, see [Mocker Engine Architecture](../../developer-guide/knowledge-base/modular-components/backends/mocker/mocker-engine-architecture.md#performance-model).
+
+<ParamField path="--aic-perf-model" type="boolean" default="false">
+  Use the AIC compatibility API in the AISimulate wheel for latency prediction instead of the
+  interpolated or polynomial models. Install `aisimulate` and use a supported
+  `system/backend/version` tuple.
+</ParamField>
+
+<ParamField path="--aic-system" type="string" default="null">
+  AIC system name, for example `h200_sxm`. Used with `--aic-perf-model`.
+</ParamField>
+
+<ParamField path="--aic-backend" type="string" default="--engine-type">
+  Backend used for AIC performance-data lookup. Set it only to model timing for a different backend
+  than the simulated scheduler.
+
+  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>vllm</Badge> <Badge intent="note" minimal>sglang</Badge> <Badge intent="note" minimal>trtllm</Badge></span>
+</ParamField>
+
+<ParamField path="--aic-backend-version" type="string" default="auto">
+  AIC backend engine version, for example `0.12.0` for vLLM. When unset, uses the default version for
+  the backend.
+</ParamField>
+
+<ParamField path="--aic-tp-size" type="integer" default="1">
+  Tensor-parallel size for AIC latency prediction. Affects only AIC performance-model lookups, not
+  mocker scheduling.
+</ParamField>
+
+<ParamField path="--aic-moe-tp-size" type="integer" default="null">
+  Mixture-of-Experts tensor-parallel size for AIC latency prediction. Required by some MoE models.
+</ParamField>
+
+<ParamField path="--aic-moe-ep-size" type="integer" default="null">
+  Mixture-of-Experts expert-parallel size for AIC latency prediction. Required by some MoE models.
+</ParamField>
+
+<ParamField path="--aic-attention-dp-size" type="integer" default="null">
+  Attention data-parallel size for AIC latency prediction. Required by some MoE models.
+</ParamField>
+
+<ParamField path="--gpu-memory-utilization" type="float" default="0.9">
+  vLLM GPU memory fraction used for AIC KV-capacity estimation.
+</ParamField>
+
+<ParamField path="--mem-fraction-static" type="float" default="0.88">
+  SGLang static memory fraction used for AIC KV-capacity estimation.
+</ParamField>
+
+<ParamField path="--free-gpu-memory-fraction" type="float" default="0.9">
+  TensorRT-LLM fraction of post-model-load free GPU memory used for AIC KV-capacity estimation.
+</ParamField>
+
+<ParamField path="--aic-nextn" type="integer" default="null">
+  Experimental Multi-Token Prediction (MTP) draft length, from 1 through 5.
+</ParamField>
+
+<ParamField path="--aic-nextn-accept-rates" type="string" default="null">
+  Experimental comma-separated conditional MTP acceptance rates.
+</ParamField>
+
+<ParamField path="--aic-mtp-seed" type="integer" default="42">
+  Base random seed for Mocker MTP burst sampling.
+</ParamField>
+
+## Disaggregation
+
+<ParamField path="--disaggregation-mode" type="string" default="agg">
+  Worker mode.
+
+  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>agg</Badge> <Badge intent="note" minimal>prefill</Badge> <Badge intent="note" minimal>decode</Badge></span>
+</ParamField>
+
+<ParamField path="--bootstrap-ports" type="string" default="null">
+  Comma-separated rendezvous base ports, one per worker in disaggregated mode.
+</ParamField>
+
+<ParamField path="--kv-transfer-bandwidth" type="float" default="64.0">
+  KV cache transfer bandwidth in GB/s. Set to `0` to disable.
+</ParamField>
+
+<ParamField path="--kv-transfer-timing-mode" type="string" default="full_prompt">
+  Prompt footprint charged to a coordinated prefill/decode transfer.
+
+  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>full_prompt</Badge> <Badge intent="note" minimal>destination_missing</Badge></span>
+</ParamField>
+
+## Event and request transport
+
+<ParamField path="--event-plane" type="string" default="auto">
+  Event transport. When the environment does not set a value, Mocker uses ZMQ with file or memory
+  discovery and NATS with etcd or Kubernetes discovery.
+
+  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>nats</Badge> <Badge intent="note" minimal>zmq</Badge></span>
+</ParamField>
+
+<ParamField path="--request-plane" type="string" default="env-driven (tcp)">
+  Request transport.
+
+  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>nats</Badge> <Badge intent="note" minimal>tcp</Badge></span>
+</ParamField>
+
+<ParamField path="--discovery-backend" type="string" default="env-driven (etcd)">
+  Discovery backend.
+
+  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>kubernetes</Badge> <Badge intent="note" minimal>etcd</Badge> <Badge intent="note" minimal>file</Badge> <Badge intent="note" minimal>mem</Badge></span>
+</ParamField>
+
+<ParamField path="--zmq-kv-events-ports" type="string" default="null">
+  Comma-separated ZMQ PUB base ports for KV event publishing, one per worker.
+</ParamField>
+
+<ParamField path="--zmq-replay-ports" type="string" default="null">
+  Comma-separated ZMQ ROUTER base ports for gap recovery, one per worker.
+</ParamField>
+
+## SGLang-specific
+
+Apply only when `--engine-type sglang`.
+
+<ParamField path="--sglang-schedule-policy" type="string" default="fifo / fcfs">
+  SGLang scheduling policy. `fifo`/`fcfs` is the default; `lpm` is longest prefix match.
+
+  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>fifo</Badge> <Badge intent="note" minimal>fcfs</Badge> <Badge intent="note" minimal>lpm</Badge></span>
+</ParamField>
+
+<ParamField path="--sglang-page-size" type="integer" default="1">
+  SGLang radix-cache page size in tokens. Also becomes the effective block size when
+  `--engine-type sglang` and `--block-size` is omitted.
+</ParamField>
+
+<ParamField path="--sglang-max-prefill-tokens" type="integer" default="16384">
+  SGLang max prefill-token budget per batch.
+</ParamField>
+
+<ParamField path="--sglang-chunked-prefill-size" type="integer" default="8192">
+  SGLang chunked-prefill chunk size.
+</ParamField>
+
+<ParamField path="--sglang-clip-max-new-tokens" type="integer" default="4096">
+  SGLang admission-budget cap for max new tokens.
+</ParamField>
+
+<ParamField path="--sglang-schedule-conservativeness" type="float" default="1.0">
+  SGLang schedule conservativeness factor.
+</ParamField>
+
+## TensorRT-LLM-specific
+
+Apply only when `--engine-type trtllm`.
+
+<ParamField path="--trtllm-capacity-scheduler-policy" type="string" default="guaranteed_no_evict">
+  TensorRT-LLM capacity scheduler policy. The Mocker currently supports only
+  `guaranteed_no_evict`.
+</ParamField>
+
+## Router advertisement
+
+Mocker accepts the same `--router-*` worker-advertisement options as the real backend launchers.
+Use them to override Router behavior for this worker set. See
+[Router Configuration and Tuning](../../developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md)
+for the shared fields.
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DYN_MOCKER_KV_CACHE_TRACE` | off | Set to `1` or `true` to log structured native KV-cache allocation and eviction traces. |
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Simulate a Kubernetes Deployment" icon="server" href="../../kubernetes/operations/simulation-with-dynosim/mocker-live-simulation.mdx">
+    Deploy and run the Mocker worker on Kubernetes.
+  </Card>
+  <Card title="Simulate a Local Deployment" icon="terminal" href="../../cli/operations/simulation-with-dynosim/mocker-live-simulation.mdx">
+    Run a frontend and Mocker worker from the command line.
+  </Card>
+  <Card title="Run a DynoSim Simulation" icon="play" href="../../cli/operations/simulation-with-dynosim/dynosim-replay.mdx">
+    Run one workload through an offline simulated configuration with `aisimulate predict --stack dynamo`.
+  </Card>
+  <Card title="Mocker Engine Architecture" icon="diagram-project" href="../../developer-guide/knowledge-base/modular-components/backends/mocker/mocker-engine-architecture.md">
+    Scheduler, KV block manager, eviction, and timing internals.
+  </Card>
+  <Card title="Planner Configuration" icon="sliders" href="planner-configuration.mdx">
+    The PlannerConfig field reference for the Dynamo Planner service.
+  </Card>
+</CardGroup>

--- a/docs/fern/pages/reference/components/mocker-cli-reference.mdx
+++ b/docs/fern/pages/reference/components/mocker-cli-reference.mdx
@@ -17,10 +17,15 @@ version.
 
 AISimulate reuses the same engine core for offline virtual-clock prediction and recommendation, but
 its public YAML is separate from these live-worker flags. See the
-[DynoSim Replay CLI Reference](dynosim-replay-cli-reference.mdx) for the offline contract. The former
-Replay online mode remains unavailable.
+[DynoSim Replay CLI Reference](dynosim-replay-cli-reference.mdx) for the offline contract. The
+former public Replay online CLI remains unavailable, although the Python replay SDK retains online
+mode.
 
 ## Core and model
+
+<ParamField path="--version" type="boolean" default="false">
+  Print the Dynamo Mocker version and exit.
+</ParamField>
 
 <ParamField path="--model-path" type="string" default="null">
   Hugging Face model ID or local path for the tokenizer. Set this for normal frontend requests.
@@ -149,8 +154,9 @@ For the timing-model design, see [Mocker Engine Architecture](../../developer-gu
   `system/backend/version` tuple.
 </ParamField>
 
-<ParamField path="--aic-system" type="string" default="null">
-  AIC system name, for example `h200_sxm`. Used with `--aic-perf-model`.
+<ParamField path="--aic-system" type="string" default="h200_sxm when AIC is enabled">
+  AIC system name used with `--aic-perf-model`. The raw CLI value is unset when omitted; runtime
+  resolution uses `h200_sxm` when AIC modeling is enabled.
 </ParamField>
 
 <ParamField path="--aic-backend" type="string" default="--engine-type">
@@ -212,6 +218,16 @@ For the timing-model design, see [Mocker Engine Architecture](../../developer-gu
   Worker mode.
 
   <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>agg</Badge> <Badge intent="note" minimal>prefill</Badge> <Badge intent="note" minimal>decode</Badge></span>
+</ParamField>
+
+<ParamField path="--is-prefill-worker" type="boolean" default="false">
+  Deprecated alias for `--disaggregation-mode=prefill`. Do not combine it with
+  `--disaggregation-mode` or `--is-decode-worker`.
+</ParamField>
+
+<ParamField path="--is-decode-worker" type="boolean" default="false">
+  Deprecated alias for `--disaggregation-mode=decode`. Do not combine it with
+  `--disaggregation-mode` or `--is-prefill-worker`.
 </ParamField>
 
 <ParamField path="--bootstrap-ports" type="string" default="null">
@@ -303,6 +319,13 @@ Mocker accepts the same `--router-*` worker-advertisement options as the real ba
 Use them to override Router behavior for this worker set. See
 [Router Configuration and Tuning](../../developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md)
 for the shared fields.
+
+<ParamField path="--router-mode" type="string" default="inherit frontend">
+  Advertise a Router configuration for this worker set. When omitted, the worker advertises no
+  Router configuration and inherits the Frontend configuration.
+
+  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>round-robin</Badge> <Badge intent="note" minimal>random</Badge> <Badge intent="note" minimal>power-of-two</Badge> <Badge intent="note" minimal>kv</Badge> <Badge intent="note" minimal>direct</Badge> <Badge intent="note" minimal>least-loaded</Badge> <Badge intent="note" minimal>device-aware-weighted</Badge></span>
+</ParamField>
 
 ## Environment variables
 

--- a/docs/fern/pages/use-cases/reinforcement-learning/operations-and-simulation.md
+++ b/docs/fern/pages/use-cases/reinforcement-learning/operations-and-simulation.md
@@ -116,15 +116,36 @@ A validated `request_end` trace preserves request schedule, input and output len
 | Live replay | Measure serving latency, throughput, cache behavior, and regressions on real workers | Synthetic requests do not rerun training, rewards, tools, or original model decisions. |
 | Offline DynoSim | Compare worker counts, routing, cache capacity, topology, and planner choices | Results are directional until calibrated against a matching live run. |
 
-Run DynoSim directly on the captured trace:
+Save an offline prediction config as `/tmp/rl-run/dynosim.yaml`. Set the `engine` identity to match
+the deployment that produced the trace, and list every trace shard explicitly under `paths`:
+
+```yaml
+traffic:
+  source:
+    type: trace
+    format: dynamo
+    paths:
+    - /tmp/rl-run/request-trace.000000.jsonl.gz
+  load: {type: trace_timestamps, speedup: 1.0}
+engine:
+  mode: aggregated
+  model: Qwen/Qwen3-0.6B
+  hardware: h200_sxm
+  backend: vllm
+  workers:
+    aggregated:
+      parallelism: {replicas: 4}
+router:
+  policy: kv_router
+```
+
+Run DynoSim on the captured trace:
 
 ```bash
-python -m dynamo.replay /tmp/rl-run/request-trace.*.jsonl.gz \
-  --trace-format dynamo \
-  --replay-mode offline \
-  --router-mode kv_router \
-  --num-workers 4 \
-  --report-json /tmp/rl-run/dynosim-report.json
+aisimulate predict \
+  --stack dynamo \
+  --config /tmp/rl-run/dynosim.yaml \
+  --output-dir /tmp/rl-run/dynosim-output
 ```
 
 Change one serving factor at a time. Use [DynoSim](../../cli/operations/simulation-with-dynosim/overview.md) for the complete workflow and [Agent Trace Replay](../agents/agent-simulation.mdx) for the live synthetic replay path.

--- a/docs/fern/pages/use-cases/reinforcement-learning/operations-and-simulation.md
+++ b/docs/fern/pages/use-cases/reinforcement-learning/operations-and-simulation.md
@@ -134,7 +134,7 @@ engine:
   backend: vllm
   workers:
     aggregated:
-      parallelism: {replicas: 4}
+      parallelism: {replicas: 4, tensor: 1, pipeline: 1, attention_data: 1, moe_tensor: 1, moe_expert: 1}
 router:
   policy: kv_router
 ```

--- a/examples/backends/mocker/deploy/agg.yaml
+++ b/examples/backends/mocker/deploy/agg.yaml
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Live Mocker deployment example for testing without GPUs.
-
 # NOTE: There is no dedicated `mocker-runtime` image. The published
 # `dynamo-planner` image includes the ai-dynamo wheel, ai-dynamo-runtime, and
 # Planner/profiler dependencies needed by the Mocker worker launcher.

--- a/examples/backends/mocker/deploy/agg.yaml
+++ b/examples/backends/mocker/deploy/agg.yaml
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Internal test fixture. The public online Mocker CLI is temporarily unavailable.
+# Live Mocker deployment example for testing without GPUs.
 
 # NOTE: There is no dedicated `mocker-runtime` image. The published
 # `dynamo-planner` image includes the ai-dynamo wheel, ai-dynamo-runtime, and
-# Planner/profiler dependencies needed by the internal Mocker worker launcher.
+# Planner/profiler dependencies needed by the Mocker worker launcher.
 # Replace `my-tag` below with the Dynamo release tag you deploy.
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
@@ -37,7 +37,7 @@ spec:
           command:
           - python3
           - -m
-          - dynamo.mocker._worker
+          - dynamo.mocker
           envFrom:
           - secretRef:
               name: hf-token-secret

--- a/examples/backends/mocker/deploy/disagg.yaml
+++ b/examples/backends/mocker/deploy/disagg.yaml
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Live Mocker deployment example for testing without GPUs.
-
 # NOTE: There is no dedicated `mocker-runtime` image. The published
 # `dynamo-planner` image includes the ai-dynamo wheel, ai-dynamo-runtime, and
 # Planner/profiler dependencies needed by the Mocker worker launcher.

--- a/examples/backends/mocker/deploy/disagg.yaml
+++ b/examples/backends/mocker/deploy/disagg.yaml
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Internal test fixture. The public online Mocker CLI is temporarily unavailable.
+# Live Mocker deployment example for testing without GPUs.
 
 # NOTE: There is no dedicated `mocker-runtime` image. The published
 # `dynamo-planner` image includes the ai-dynamo wheel, ai-dynamo-runtime, and
-# Planner/profiler dependencies needed by the internal Mocker worker launcher.
+# Planner/profiler dependencies needed by the Mocker worker launcher.
 # Replace `my-tag` below with the Dynamo release tag you deploy.
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
@@ -39,7 +39,7 @@ spec:
           command:
           - python3
           - -m
-          - dynamo.mocker._worker
+          - dynamo.mocker
           envFrom:
           - secretRef:
               name: hf-token-secret
@@ -66,7 +66,7 @@ spec:
           command:
           - python3
           - -m
-          - dynamo.mocker._worker
+          - dynamo.mocker
           envFrom:
           - secretRef:
               name: hf-token-secret

--- a/examples/global_planner/global-planner-mocker-test.yaml
+++ b/examples/global_planner/global-planner-mocker-test.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Internal test fixture. The public online Mocker CLI is temporarily unavailable.
+# Live Mocker deployment fixture for Global Planner testing without GPUs.
 #
 # Mocker-based GlobalPlanner test: 2 prefill pools + 2 decode pools.
 # Each pool SLA Planner reads router histogram metrics from cluster Prometheus
@@ -164,7 +164,7 @@ spec:
           command:
           - python3
           - -m
-          - dynamo.mocker._worker
+          - dynamo.mocker
           image: ${DYNAMO_IMAGE}
           name: main
           workingDir: /workspace
@@ -234,7 +234,7 @@ spec:
           command:
           - python3
           - -m
-          - dynamo.mocker._worker
+          - dynamo.mocker
           image: ${DYNAMO_IMAGE}
           name: main
           workingDir: /workspace
@@ -304,7 +304,7 @@ spec:
           command:
           - python3
           - -m
-          - dynamo.mocker._worker
+          - dynamo.mocker
           image: ${DYNAMO_IMAGE}
           name: main
           workingDir: /workspace
@@ -374,7 +374,7 @@ spec:
           command:
           - python3
           - -m
-          - dynamo.mocker._worker
+          - dynamo.mocker
           image: ${DYNAMO_IMAGE}
           name: main
           workingDir: /workspace

--- a/examples/global_planner/global-planner-mocker-test.yaml
+++ b/examples/global_planner/global-planner-mocker-test.yaml
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Live Mocker deployment fixture for Global Planner testing without GPUs.
-#
 # Mocker-based GlobalPlanner test: 2 prefill pools + 2 decode pools.
 # Each pool SLA Planner reads router histogram metrics from cluster Prometheus
 # and delegates scaling decisions to the GlobalPlanner (no-op mode).

--- a/examples/router/custom-policy-example/README.md
+++ b/examples/router/custom-policy-example/README.md
@@ -70,7 +70,7 @@ Each policy stage has one job:
 
 Each example keeps its implemented stages in these matching files. `lib.rs` parses parameters, composes the stages, and registers the policy. The stacked example keeps each scorer implementation in a separate file under [`scorer/`](simple-stacked-score-pick/src/scorer/).
 
-Read the [custom worker-selection guide](https://github.com/ai-dynamo/dynamo/blob/main/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx) for input groups, method contracts, and error handling.
+Read the [custom worker-selection guide](https://github.com/ai-dynamo/dynamo/blob/main/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/custom-worker-selection.mdx) for input groups, method contracts, and error handling.
 
 ## 3. Parse Parameters and Build the Factory
 
@@ -263,7 +263,7 @@ Follow the [standalone EPP guide](../../../docs/fern/pages/kubernetes/kv-aware-r
 - Prove that filter failures, all-filtered candidate sets, scorer failures, and invalid picker rows do not reserve a worker.
 - Benchmark stateful or input-heavy policies at the expected worker count.
 
-The [custom routing API reference](https://github.com/ai-dynamo/dynamo/blob/main/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx) lists the available context and worker signals.
+The [custom routing API reference](https://github.com/ai-dynamo/dynamo/blob/main/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/custom-worker-selection.mdx) lists the available context and worker signals.
 
 ## Try the Policies End to End With Mocker
 

--- a/examples/router/custom-policy-example/README.md
+++ b/examples/router/custom-policy-example/README.md
@@ -70,7 +70,7 @@ Each policy stage has one job:
 
 Each example keeps its implemented stages in these matching files. `lib.rs` parses parameters, composes the stages, and registers the policy. The stacked example keeps each scorer implementation in a separate file under [`scorer/`](simple-stacked-score-pick/src/scorer/).
 
-Read the [custom worker-selection guide](../../../docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx) for input groups, method contracts, and error handling.
+Read the [custom worker-selection guide](https://github.com/ai-dynamo/dynamo/blob/main/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx) for input groups, method contracts, and error handling.
 
 ## 3. Parse Parameters and Build the Factory
 
@@ -263,14 +263,9 @@ Follow the [standalone EPP guide](../../../docs/fern/pages/kubernetes/kv-aware-r
 - Prove that filter failures, all-filtered candidate sets, scorer failures, and invalid picker rows do not reserve a worker.
 - Benchmark stateful or input-heavy policies at the expected worker count.
 
-The [custom routing API reference](../../../docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx) lists the available context and worker signals.
+The [custom routing API reference](https://github.com/ai-dynamo/dynamo/blob/main/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.mdx) lists the available context and worker signals.
 
 ## Try the Policies End to End With Mocker
-
-> [!WARNING]
-> Online simulation with Mocker is temporarily unavailable. The `python -m dynamo.mocker` commands
-> in this section do not run in this release. This workflow will return through the unified
-> AISimulate surface in a future release.
 
 Use the embedded Python frontend for this local test. The standalone EPP uses Kubernetes `InferencePool` discovery. Complete [Run With the Python Frontend](#run-with-the-python-frontend) first so that the extension links this example catalog.
 
@@ -294,7 +289,7 @@ python -m dynamo.frontend \
 In the second terminal, start two aggregated Mocker workers:
 
 ```bash
-python -m dynamo.mocker \
+python3 -m dynamo.mocker \
   --model-path Qwen/Qwen3-0.6B \
   --discovery-backend file \
   --num-workers 2
@@ -346,7 +341,7 @@ The two flags override `worker_selection.prefill` and `worker_selection.decode`.
 In the second terminal, start two prefill Mocker workers:
 
 ```bash
-python -m dynamo.mocker \
+python3 -m dynamo.mocker \
   --model-path Qwen/Qwen3-0.6B \
   --discovery-backend file \
   --disaggregation-mode prefill \
@@ -359,7 +354,7 @@ python -m dynamo.mocker \
 In the third terminal, start two decode Mocker workers:
 
 ```bash
-python -m dynamo.mocker \
+python3 -m dynamo.mocker \
   --model-path Qwen/Qwen3-0.6B \
   --discovery-backend file \
   --disaggregation-mode decode \

--- a/tests/frontend/conftest.py
+++ b/tests/frontend/conftest.py
@@ -230,7 +230,7 @@ def start_services_with_grpc(
 class MockerWorkerProcess(ManagedProcess):
     """Shared mocker worker process for frontend tests.
 
-    Uses the internal Mocker worker launcher with configurable model and speedup ratio.
+    Uses the live Mocker worker launcher with configurable model and speedup ratio.
     Can be used by any frontend test that needs a fast mock backend.
     """
 
@@ -252,7 +252,7 @@ class MockerWorkerProcess(ManagedProcess):
         command = [
             "python3",
             "-m",
-            "dynamo.mocker._worker",
+            "dynamo.mocker",
             "--model-path",
             model,
             "--speedup-ratio",
@@ -286,7 +286,7 @@ class MockerWorkerProcess(ManagedProcess):
             display_output=True,
             terminate_all_matching_process_names=False,
             stragglers=["VLLM::EngineCore"],
-            straggler_commands=["-m dynamo.mocker._worker"],
+            straggler_commands=["-m dynamo.mocker"],
             log_dir=log_dir,
         )
 

--- a/tests/frontend/conftest.py
+++ b/tests/frontend/conftest.py
@@ -230,7 +230,6 @@ def start_services_with_grpc(
 class MockerWorkerProcess(ManagedProcess):
     """Shared mocker worker process for frontend tests.
 
-    Uses the live Mocker worker launcher with configurable model and speedup ratio.
     Can be used by any frontend test that needs a fast mock backend.
     """
 

--- a/tests/router/mocker_process.py
+++ b/tests/router/mocker_process.py
@@ -48,7 +48,7 @@ def _build_mocker_command(
     command = [
         sys.executable,
         "-m",
-        "dynamo.mocker._worker",
+        "dynamo.mocker",
         "--model-path",
         MODEL_NAME,
         "--endpoint",


### PR DESCRIPTION
## Summary

- restore `python3 -m dynamo.mocker` as the public launcher for live Mocker workers
- remove the temporary private `dynamo.mocker._worker` module and move all managed templates, tests, benchmarks, and Profiler detection back to `dynamo.mocker`
- revert #14175 because Planner no longer needs to recognize the private worker module
- restore the local and Kubernetes live-Mocker guides plus the Mocker CLI reference
- distinguish the live Mocker worker launcher from Replay online orchestration: Mocker remains available, while the former Replay online mode remains unavailable
- keep offline virtual-clock prediction and recommendation under `aisimulate predict` and `aisimulate recommend`

## Validation

- 138 focused Mocker, Planner connector, and Profiler materialization tests passed
- `python3 -m dynamo.mocker --help` and `--version` passed from the source tree
- built the `ai-dynamo` wheel and verified it contains `dynamo/mocker/__main__.py` and excludes `_worker.py`
- focused pre-commit hooks and shell syntax checks passed
- docs lint reports 0 errors for touched files
- Fern configuration and broken-link checks passed
- internal link scan checked 236 Markdown files with 0 broken links
- recipe and feature-benchmark catalog validation passed
- `git diff --check` passed

## Where should the reviewer start?

- `components/src/dynamo/mocker/__main__.py`
- `components/src/dynamo/mocker/tests/unit/test_public_cli.py`
- `components/src/dynamo/planner/monitoring/dgd_services.py`
- `docs/fern/pages/reference/components/mocker-cli-reference.mdx`
- `docs/fern/pages/cli/operations/simulation-with-dynosim/mocker-live-simulation.mdx`

## Related Issues

- Reverts #14175
- [x] Confirmed — no external issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public `python3 -m dynamo.mocker` command for launching live, GPU-free Mocker workers.
  - Added live Mocker simulation workflows for local and Kubernetes deployments, including disaggregated serving and request testing.
  - Added comprehensive CLI guidance and configuration references.

- **Documentation**
  - Clarified the distinction between live Mocker workers and offline DynoSim prediction and recommendation workflows.
  - Updated deployment examples, benchmarks, and tutorials to use the public Mocker command.
  - Documented that Replay online mode remains unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->