### PR TITLE
fix(router): bound request-path overload hints

### DIFF
--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -78,9 +78,9 @@ fn publish_overloaded_instances_if_needed(
     overloaded_tracker: &OverloadedWorkerTracker,
     overloaded_changed: bool,
 ) -> bool {
-    // NOTE: Recovery still relies on load producers publishing after meaningful capacity or
-    // lifecycle changes. This only prevents the next observation from being suppressed when
-    // request-path backpressure changed Client state outside this monitor's cached set.
+    // A fresh load observation clears request-path overload leases early.
+    // This prevents the monitor's unchanged-set suppression from retaining
+    // a request-path mark until its bounded lease expires.
     if !overloaded_changed && !overload_reconciliation_needed(client) {
         return false;
     }

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -823,6 +823,14 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                         let cfg = thresholds.get();
                         last_thresholds = cfg.clone();
                         let overloaded_workers = collect_overloaded_workers(&worker_load_states, &cfg);
+                        // Deliberately not `publish_overloaded_instances_if_needed`: unlike the
+                        // load branches below, this one carries no fresh load observation. It wakes
+                        // on endpoint membership and runtime-config changes, so the recompute above
+                        // reads whatever load state was last observed. Publishing on an unchanged
+                        // set here would retire request-path overload leases on no load evidence at
+                        // all — and because `runtime_config_watch` joins availability for the whole
+                        // endpoint, one unrelated worker appearing would clear another worker's
+                        // in-force lease. Leases are bounded, so they expire on their own instead.
                         if overloaded_tracker.replace(overloaded_workers) {
                             publish_overloaded_instances(&client, &overloaded_tracker.ids());
                         }

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, LazyLock, Mutex as StdMutex},
@@ -11,6 +10,7 @@ use std::{
 use anyhow::Result;
 use arc_swap::ArcSwap;
 use futures::StreamExt;
+use tokio::time::Instant;
 
 use crate::component::{Endpoint, Instance};
 use crate::config::environment_names::runtime as env_runtime;
@@ -20,6 +20,10 @@ use crate::traits::DistributedRuntimeProvider;
 
 /// Default interval for periodic reconciliation of instance_avail with instance_source
 const DEFAULT_INHIBITED_DURATION_SECS: u64 = 5;
+
+/// Request-path overload is a short-lived routing hint. A worker is probed
+/// again after this cooldown if no authoritative load update arrives first.
+const REQUEST_PATH_OVERLOAD_COOLDOWN: Duration = Duration::from_secs(1);
 
 /// Process-wide inhibited duration, resolved from the environment on first client construction.
 static INHIBITED_DURATION: LazyLock<Duration> =
@@ -114,6 +118,9 @@ pub struct RoutingInstanceCounts {
 pub(crate) struct RoutingInstances {
     discovered_ids: Vec<u64>,
     routable_ids: Vec<u64>,
+    monitor_overloaded_ids: HashSet<u64>,
+    request_overload_deadlines: HashMap<u64, Instant>,
+    next_request_overload_expiry: Option<Instant>,
     overloaded_ids: HashSet<u64>,
     free_ids: Vec<u64>,
     routable_id_set: Arc<HashSet<u64>>,
@@ -130,6 +137,7 @@ impl RoutingInstances {
             discovered_ids.clone(),
             discovered_ids,
             HashSet::new(),
+            HashMap::new(),
             availability_initialized,
         )
     }
@@ -137,18 +145,25 @@ impl RoutingInstances {
     fn from_parts(
         mut discovered_ids: Vec<u64>,
         mut routable_ids: Vec<u64>,
-        overloaded_ids: HashSet<u64>,
+        monitor_overloaded_ids: HashSet<u64>,
+        request_overload_deadlines: HashMap<u64, Instant>,
         availability_initialized: bool,
     ) -> Self {
         discovered_ids.sort_unstable();
         discovered_ids.dedup();
         routable_ids.sort_unstable();
         routable_ids.dedup();
+        let mut overloaded_ids = monitor_overloaded_ids.clone();
+        let next_request_overload_expiry = request_overload_deadlines.values().min().copied();
+        overloaded_ids.extend(request_overload_deadlines.keys().copied());
         let free_ids = Self::derive_free_ids(&routable_ids, &overloaded_ids);
         let routable_id_set = Arc::new(routable_ids.iter().copied().collect());
         Self {
             discovered_ids,
             routable_ids,
+            monitor_overloaded_ids,
+            request_overload_deadlines,
+            next_request_overload_expiry,
             overloaded_ids,
             free_ids,
             routable_id_set,
@@ -197,15 +212,19 @@ impl RoutingInstances {
     fn reconcile_discovered(&self, discovered_ids: Vec<u64>) -> Self {
         let old_discovered_ids = self.discovered_ids.iter().copied().collect::<HashSet<_>>();
         let new_discovered_ids = discovered_ids.iter().copied().collect::<HashSet<_>>();
-        let mut overloaded_ids = self.overloaded_ids.clone();
-        overloaded_ids
+        let mut monitor_overloaded_ids = self.monitor_overloaded_ids.clone();
+        monitor_overloaded_ids
             .retain(|id| !old_discovered_ids.contains(id) || new_discovered_ids.contains(id));
+        let mut request_overload_deadlines = self.request_overload_deadlines.clone();
+        request_overload_deadlines
+            .retain(|id, _| !old_discovered_ids.contains(id) || new_discovered_ids.contains(id));
 
         let availability_initialized = self.availability_initialized || !discovered_ids.is_empty();
         Self::from_parts(
             discovered_ids.clone(),
             discovered_ids,
-            overloaded_ids,
+            monitor_overloaded_ids,
+            request_overload_deadlines,
             availability_initialized,
         )
     }
@@ -221,7 +240,8 @@ impl RoutingInstances {
         Self::from_parts(
             self.discovered_ids.clone(),
             routable_ids,
-            self.overloaded_ids.clone(),
+            self.monitor_overloaded_ids.clone(),
+            self.request_overload_deadlines.clone(),
             self.availability_initialized,
         )
     }
@@ -233,7 +253,8 @@ impl RoutingInstances {
         Self::from_parts(
             self.discovered_ids.clone(),
             routable_ids,
-            self.overloaded_ids.clone(),
+            self.monitor_overloaded_ids.clone(),
+            self.request_overload_deadlines.clone(),
             self.availability_initialized,
         )
     }
@@ -243,31 +264,53 @@ impl RoutingInstances {
             self.discovered_ids.clone(),
             self.routable_ids.clone(),
             overloaded_ids,
+            HashMap::new(),
             self.availability_initialized,
         )
     }
 
     /// Add a single instance to the overloaded set (immediate
-    /// backpressure mark). Short-lived: the next metric-driven
-    /// `set_overloaded` recompute overwrites the whole set.
-    fn mark_overloaded(&self, instance_id: u64) -> Self {
-        let mut overloaded_ids = self.overloaded_ids.clone();
-        overloaded_ids.insert(instance_id);
+    /// backpressure mark). A monitor update clears all request-path
+    /// marks. Otherwise, each mark expires at its own deadline.
+    fn mark_overloaded_until(&self, instance_id: u64, deadline: Instant) -> Self {
+        let mut request_overload_deadlines = self.request_overload_deadlines.clone();
+        request_overload_deadlines.insert(instance_id, deadline);
         Self::from_parts(
             self.discovered_ids.clone(),
             self.routable_ids.clone(),
-            overloaded_ids,
+            self.monitor_overloaded_ids.clone(),
+            request_overload_deadlines,
+            self.availability_initialized,
+        )
+    }
+
+    fn has_expired_request_overload(&self, now: Instant) -> bool {
+        self.next_request_overload_expiry
+            .is_some_and(|deadline| deadline <= now)
+    }
+
+    fn clear_expired_request_overloads(&self, now: Instant) -> Self {
+        let mut request_overload_deadlines = self.request_overload_deadlines.clone();
+        request_overload_deadlines.retain(|_, deadline| *deadline > now);
+        Self::from_parts(
+            self.discovered_ids.clone(),
+            self.routable_ids.clone(),
+            self.monitor_overloaded_ids.clone(),
+            request_overload_deadlines,
             self.availability_initialized,
         )
     }
 
     fn clear_overloaded_for_removed(&self, removed_ids: &HashSet<u64>) -> Self {
-        let mut overloaded_ids = self.overloaded_ids.clone();
-        overloaded_ids.retain(|id| !removed_ids.contains(id));
+        let mut monitor_overloaded_ids = self.monitor_overloaded_ids.clone();
+        monitor_overloaded_ids.retain(|id| !removed_ids.contains(id));
+        let mut request_overload_deadlines = self.request_overload_deadlines.clone();
+        request_overload_deadlines.retain(|id, _| !removed_ids.contains(id));
         Self::from_parts(
             self.discovered_ids.clone(),
             self.routable_ids.clone(),
-            overloaded_ids,
+            monitor_overloaded_ids,
+            request_overload_deadlines,
             self.availability_initialized,
         )
     }
@@ -289,7 +332,6 @@ impl RoutingInstances {
 struct RoutingInstancesState {
     snapshot: ArcSwap<RoutingInstances>,
     update_lock: StdMutex<()>,
-    overload_reconciliation_needed: AtomicBool,
     instance_avail_tx: tokio::sync::watch::Sender<Vec<u64>>,
 }
 
@@ -302,7 +344,6 @@ impl RoutingInstancesState {
             Self {
                 snapshot: ArcSwap::from_pointee(snapshot),
                 update_lock: StdMutex::new(()),
-                overload_reconciliation_needed: AtomicBool::new(false),
                 instance_avail_tx,
             },
             instance_avail_rx,
@@ -310,7 +351,26 @@ impl RoutingInstancesState {
     }
 
     fn snapshot(&self) -> arc_swap::Guard<Arc<RoutingInstances>> {
+        let now = Instant::now();
+        let current = self.snapshot.load();
+        if !current.has_expired_request_overload(now) {
+            return current;
+        }
+        drop(current);
+
+        self.reconcile_expired_request_overloads(now);
         self.snapshot.load()
+    }
+
+    fn reconcile_expired_request_overloads(&self, now: Instant) {
+        let _guard = self.update_lock.lock().unwrap();
+        let current = self.snapshot.load();
+        if !current.has_expired_request_overload(now) {
+            return;
+        }
+
+        let next = Arc::new(current.clear_expired_request_overloads(now));
+        self.snapshot.store(next);
     }
 
     fn update(
@@ -364,29 +424,32 @@ impl RoutingInstancesState {
             .copied()
             .collect::<HashSet<_>>();
         let _guard = self.update_lock.lock().unwrap();
-        self.overload_reconciliation_needed
-            .store(false, Ordering::Release);
         let current = self.snapshot.load();
-        if current.overloaded_ids == overloaded_ids {
+        let next = Arc::new(current.set_overloaded(overloaded_ids));
+        let effective_changed = current.overloaded_ids != next.overloaded_ids;
+        let source_changed = current.monitor_overloaded_ids != next.monitor_overloaded_ids
+            || !current.request_overload_deadlines.is_empty();
+        if !source_changed {
             return false;
         }
 
-        let next = Arc::new(current.set_overloaded(overloaded_ids));
         self.snapshot.store(next);
-        true
+        effective_changed
     }
 
     fn mark_overloaded_immediate(&self, instance_id: u64) {
+        self.mark_overloaded_until(instance_id, Instant::now() + REQUEST_PATH_OVERLOAD_COOLDOWN);
+    }
+
+    fn mark_overloaded_until(&self, instance_id: u64, deadline: Instant) {
         let _guard = self.update_lock.lock().unwrap();
         let current = self.snapshot.load();
-        let next = Arc::new(current.mark_overloaded(instance_id));
+        let next = Arc::new(current.mark_overloaded_until(instance_id, deadline));
         self.snapshot.store(next);
-        self.overload_reconciliation_needed
-            .store(true, Ordering::Release);
     }
 
     fn overload_reconciliation_needed(&self) -> bool {
-        self.overload_reconciliation_needed.load(Ordering::Acquire)
+        !self.snapshot().request_overload_deadlines.is_empty()
     }
 
     fn clear_overloaded_for_removed(&self, removed_instance_ids: &[u64]) {
@@ -689,28 +752,28 @@ impl Client {
     }
 
     /// Replace the set of overloaded instances reported by the worker monitor.
-    /// Returns true when this changes the routing snapshot.
+    /// Returns true when this changes the effective overloaded set.
     pub fn set_overloaded_instances(&self, overloaded_instance_ids: &[u64]) -> bool {
         self.routing_instances
             .set_overloaded_instances(overloaded_instance_ids)
     }
 
-    /// Whether request-path backpressure changed overload state after the monitor's
-    /// most recent metric publication.
+    /// Whether an unexpired request-path overload lease remains after the
+    /// monitor's most recent metric publication.
     pub fn overload_reconciliation_needed(&self) -> bool {
         self.routing_instances.overload_reconciliation_needed()
     }
 
     /// Mark an instance overloaded immediately after a worker-scoped
     /// `WorkerOverloaded` response. This is backpressure, not a fault, so it
-    /// does not call `report_instance_down`. The next worker-monitor
-    /// reconciliation replaces this short-lived global routing hint.
+    /// does not call `report_instance_down`. A fresh worker-monitor publication
+    /// clears this hint early. Its bounded lease otherwise permits a recovery probe.
     pub fn mark_overloaded_immediate(&self, instance_id: u64) {
         self.routing_instances
             .mark_overloaded_immediate(instance_id);
         tracing::debug!(
             instance_id,
-            "marking instance overloaded (backpressure); next metric event will re-evaluate"
+            "marking instance overloaded with a bounded backpressure lease"
         );
     }
 
@@ -1167,6 +1230,69 @@ mod tests {
         assert_eq!(client.overloaded_instance_ids(), None);
         assert!(!client.set_overloaded_instances(&[]));
 
+        rt.shutdown();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn request_path_overload_expires_without_monitor_update() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let client = drt
+            .namespace("test_request_overload_expiry".to_string())
+            .unwrap()
+            .component("test_component".to_string())
+            .unwrap()
+            .endpoint("decode".to_string())
+            .client()
+            .await
+            .unwrap();
+
+        client.mark_overloaded_immediate(7);
+        assert_eq!(client.overloaded_instance_ids(), Some(HashSet::from([7])));
+
+        tokio::time::advance(REQUEST_PATH_OVERLOAD_COOLDOWN).await;
+
+        assert_eq!(client.overloaded_instance_ids(), None);
+        assert!(!client.overload_reconciliation_needed());
+        rt.shutdown();
+    }
+
+    #[tokio::test]
+    async fn request_path_expiry_preserves_monitor_overload() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let client = drt
+            .namespace("test_request_expiry_preserves_monitor".to_string())
+            .unwrap()
+            .component("test_component".to_string())
+            .unwrap()
+            .endpoint("decode".to_string())
+            .client()
+            .await
+            .unwrap();
+        let now = Instant::now();
+
+        assert!(client.set_overloaded_instances(&[11]));
+        client
+            .routing_instances
+            .mark_overloaded_until(7, now + Duration::from_secs(1));
+        client
+            .routing_instances
+            .mark_overloaded_until(8, now + Duration::from_secs(2));
+
+        client
+            .routing_instances
+            .reconcile_expired_request_overloads(now + Duration::from_millis(1500));
+
+        assert_eq!(
+            client.overloaded_instance_ids(),
+            Some(HashSet::from([8, 11]))
+        );
+        assert!(client.overload_reconciliation_needed());
         rt.shutdown();
     }
 

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -620,9 +620,9 @@ where
     /// Create a new PushRouter with an optional worker load monitor.
     ///
     /// The rejection path is gated by `fault_detection_enabled` (true here);
-    /// overload detection itself is driven by the monitor via `client.set_overloaded_instances(...)`.
-    /// If no thresholds are configured on the monitor (or no monitor is provided),
-    /// the routing snapshot reports at least one free instance and the gate never rejects.
+    /// durable overload detection is driven by the monitor through
+    /// `client.set_overloaded_instances(...)`. Worker responses can also create
+    /// bounded request-path overload leases.
     pub async fn from_client_with_monitor(
         client: Client,
         router_mode: RouterMode,
@@ -1941,11 +1941,11 @@ where
                         );
                         self.client.report_instance_down(instance_id);
                     } else if match_error_chain(err.as_ref(), &[ErrorType::WorkerOverloaded], &[]) {
-                        // Backpressure: worker said "my queue is full,
-                        // retry later". Mark overloaded so this FE skips it on
-                        // the next selection; the next ActiveLoad event from the
-                        // worker monitor overwrites the overloaded set from fresh
-                        // metrics. This is NOT report_instance_down (fault path).
+                        // Backpressure: the worker said "my queue is full,
+                        // retry later". A bounded lease prevents an immediate
+                        // retry loop. Fresh monitor data clears the lease early.
+                        // Lease expiry permits a recovery probe when load events
+                        // remain unchanged. This is not a fault quarantine.
                         tracing::debug!(
                             "Marking instance {instance_id} overloaded due to backpressure: {err}"
                         );


### PR DESCRIPTION
## Summary

- Worker capacity rejections can leave stale overload state after pressure ends. This causes continued HTTP 529 responses on an idle worker.

- This change gives request-path overload hints a one-second lease. Monitor-reported overload state remains independent.

## Validation

<img width="2343" height="269" alt="image" src="https://github.com/user-attachments/assets/1fb1ef44-4092-4ad5-86ee-0e879202d872" />


- I ran an identical container-level A/B test.
- Both arms received 128 concurrent requests.
- Both arms returned 3 HTTP 200 and 125 HTTP 529 responses.
- The control returned HTTP 529 for all 24 recovery probes.
- Engine usage and queue depth were already zero.
- The patched arm recovered after 1.038 seconds.
- Its next 19 recovery probes returned HTTP 200.
- All 16 runtime client tests passed.


### Longer test

| Runtime | Successful requests | HTTP 529 responses | Success rate | HTTP 529 rate | Recovery after drain |
|---|---:|---:|---:|---:|---:|
| Unpatched | 0 / 3,600 | 3,600 / 3,600 | 0.000% | 100.000% | No recovery within 900 seconds |
| Patched | 3,596 / 3,600 | 4 / 3,600 | 99.889% | 0.111% | 1.000 seconds |
  

- Measured: Arm A produced 900 times more HTTP 529 responses.
- Measured: Arm A never recovered during 15 minutes.
- Measured: Arm B recovered after 1.000 seconds.
- Measured: All containers remained ready with zero restarts.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing overload handling by separating monitor-reported overloads from temporary request-path overloads.
  * Request-path overloads now expire after a brief cooldown, while monitor-reported overloads remain active independently.
  * Existing instance overload state is preserved during discovery updates, while departed instances are removed.
  * Added coverage for overload expiry, monitor updates, and routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #14213