### PR TITLE
fix(mocker): keep live passes on modeled deadlines

### DIFF
--- a/lib/mocker/src/generalized_live.rs
+++ b/lib/mocker/src/generalized_live.rs
@@ -4,11 +4,14 @@
 //! Tokio/wall-clock driver for one logical generalized mock engine.
 //!
 //! The AISimulate engine remains runtime-neutral: it eagerly computes a pass
-//! and returns an absolute modeled completion time. This module owns the live
-//! concerns around that contract: bounded control lanes, wall-clock sleeps,
-//! mid-pass cancellation, attention-DP barrier release, and ordered effect
-//! delivery. Dynamo-specific transport and metric publication stay outside the
-//! driver and consume [`GroupedLiveEvent`] values.
+//! and returns an absolute modeled completion time. While work remains ready,
+//! this driver carries that modeled completion forward as the next pass start
+//! deadline. It uses wall time for sleeps and when work resumes after idle.
+//!
+//! This module also owns bounded control lanes, mid-pass cancellation,
+//! attention-DP barrier release, and ordered effect delivery. Dynamo-specific
+//! transport and metric publication stay outside the driver and consume
+//! [`GroupedLiveEvent`] values.
 
 use std::collections::VecDeque;
 use std::fmt;
@@ -37,9 +40,9 @@ use crate::common::utils::sleep_until_precise;
 /// Engine type driven by the native live runtime.
 pub type GroupedEngine = GeneralizedMockerEngine<SchedulerRank>;
 
-const DEFAULT_ABSOLUTE_PASS_MAX_CATCH_UP: Duration = Duration::from_millis(5);
+const ABSOLUTE_PASS_MAX_CATCH_UP: Duration = Duration::from_millis(5);
 
-/// Bounded-channel sizing for one grouped live engine.
+/// Bounded-channel configuration for one grouped live engine.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GroupedLiveDriverConfig {
     /// Capacity shared independently by the ordinary-command and cancellation
@@ -47,10 +50,6 @@ pub struct GroupedLiveDriverConfig {
     pub control_capacity: usize,
     /// Capacity of the ordered neutral-effect lane.
     pub event_capacity: usize,
-    /// Use each modeled pass end as the next pass start deadline, but do not
-    /// start more than this duration behind wall time. This defaults to 5 ms.
-    /// `None` explicitly selects the historical wall-clock-per-pass behavior.
-    pub absolute_pass_max_catch_up: Option<Duration>,
 }
 
 impl Default for GroupedLiveDriverConfig {
@@ -58,7 +57,6 @@ impl Default for GroupedLiveDriverConfig {
         Self {
             control_capacity: 64,
             event_capacity: 64,
-            absolute_pass_max_catch_up: Some(DEFAULT_ABSOLUTE_PASS_MAX_CATCH_UP),
         }
     }
 }
@@ -70,9 +68,6 @@ impl GroupedLiveDriverConfig {
         }
         if self.event_capacity == 0 {
             bail!("grouped live event capacity must be positive");
-        }
-        if self.absolute_pass_max_catch_up == Some(Duration::ZERO) {
-            bail!("grouped live absolute-pass catch-up must be positive");
         }
         Ok(self)
     }
@@ -303,7 +298,6 @@ pub fn spawn_grouped_live_engine(
             cancel_token: actor_cancel_token,
             clock_origin,
             deferred_commands: VecDeque::new(),
-            absolute_pass_max_catch_up: config.absolute_pass_max_catch_up,
             engine_time_ms: 0.0,
             next_pass_deadline_ms: None,
         }
@@ -332,26 +326,33 @@ struct GroupedLiveActor {
     cancel_token: CancellationToken,
     clock_origin: Instant,
     deferred_commands: VecDeque<ControlEnvelope>,
-    absolute_pass_max_catch_up: Option<Duration>,
     engine_time_ms: f64,
     next_pass_deadline_ms: Option<f64>,
 }
 
-fn select_pass_start(
-    wall_ms: f64,
-    engine_time_ms: f64,
-    next_deadline_ms: Option<f64>,
-    max_catch_up: Option<Duration>,
-) -> f64 {
-    let Some(max_catch_up) = max_catch_up else {
-        return wall_ms.max(engine_time_ms);
-    };
+fn select_pass_start(wall_ms: f64, engine_time_ms: f64, next_deadline_ms: Option<f64>) -> f64 {
     let Some(deadline_ms) = next_deadline_ms else {
         return wall_ms.max(engine_time_ms);
     };
 
-    let catch_up_floor_ms = (wall_ms - max_catch_up.as_secs_f64() * 1_000.0).max(0.0);
+    let catch_up_floor_ms = (wall_ms - ABSOLUTE_PASS_MAX_CATCH_UP.as_secs_f64() * 1_000.0).max(0.0);
     deadline_ms.max(catch_up_floor_ms).max(engine_time_ms)
+}
+
+fn select_internal_work_time(
+    wall_ms: f64,
+    engine_time_ms: f64,
+    deadline_ms: f64,
+    active_pass_sequence: bool,
+) -> Option<f64> {
+    if deadline_ms > wall_ms.max(engine_time_ms) {
+        return None;
+    }
+    if active_pass_sequence {
+        Some(engine_time_ms.max(deadline_ms))
+    } else {
+        Some(engine_time_ms.max(wall_ms))
+    }
 }
 
 #[derive(Debug)]
@@ -400,9 +401,8 @@ impl GroupedLiveActor {
                 self.elapsed_ms(),
                 self.engine_time_ms,
                 self.next_pass_deadline_ms,
-                self.absolute_pass_max_catch_up,
             );
-            self.engine_time_ms = started_at_ms;
+            self.advance_engine_time(started_at_ms);
             let Some(started) = self.engine.execute_pass(started_at_ms)? else {
                 self.next_pass_deadline_ms = None;
                 continue;
@@ -416,12 +416,7 @@ impl GroupedLiveActor {
             if !self.wait_for_pass_boundary(end_ms).await? {
                 return Ok(());
             }
-            let completion_candidate_ms = if self.absolute_pass_max_catch_up.is_some() {
-                end_ms
-            } else {
-                self.elapsed_ms().max(end_ms)
-            };
-            let completed_at_ms = self.advance_engine_time(completion_candidate_ms);
+            let completed_at_ms = self.advance_engine_time(end_ms);
             let completed = self.engine.complete_pass(pass_id, completed_at_ms)?;
             let (boundary_tx, boundary_rx) = mpsc::channel(1);
             self.publish(GroupedLiveEvent::PassCompleted {
@@ -452,6 +447,15 @@ impl GroupedLiveActor {
     fn advance_engine_time(&mut self, candidate_ms: f64) -> f64 {
         self.engine_time_ms = self.engine_time_ms.max(candidate_ms);
         self.engine_time_ms
+    }
+
+    fn command_time_ms(&mut self) -> f64 {
+        let candidate_ms = if self.next_pass_deadline_ms.is_some() {
+            self.engine_time_ms
+        } else {
+            self.elapsed_ms()
+        };
+        self.advance_engine_time(candidate_ms)
     }
 
     async fn publish(&self, event: GroupedLiveEvent) -> Result<()> {
@@ -485,8 +489,7 @@ impl GroupedLiveActor {
             };
             match request {
                 BoundaryRequest::Apply { command, reply } => {
-                    let wall_ms = self.elapsed_ms();
-                    let now_ms = self.advance_engine_time(wall_ms);
+                    let now_ms = self.command_time_ms();
                     let result = self.engine.apply_command_effects(command, now_ms);
                     let _ = reply.send(result);
                 }
@@ -502,8 +505,7 @@ impl GroupedLiveActor {
         let command_id = envelope.command_id;
         let is_request_cancellation =
             matches!(&envelope.command.command, Command::CancelRequest { .. });
-        let wall_ms = self.elapsed_ms();
-        let now_ms = self.advance_engine_time(wall_ms);
+        let now_ms = self.command_time_ms();
         let result = self.engine.apply_command_effects(envelope.command, now_ms);
         match result {
             Ok(effects) => {
@@ -613,8 +615,7 @@ impl GroupedLiveActor {
         let command_id = envelope.command_id;
         let is_request_cancellation =
             matches!(&envelope.command.command, Command::CancelRequest { .. });
-        let wall_ms = self.elapsed_ms();
-        let now_ms = self.advance_engine_time(wall_ms);
+        let now_ms = self.command_time_ms();
         let result = self.engine.apply_command_effects(envelope.command, now_ms);
         match result {
             Ok(effects) => {
@@ -659,15 +660,18 @@ impl GroupedLiveActor {
     }
 
     async fn process_due_internal_work(&mut self) -> Result<()> {
-        let now_ms = self.engine_time_ms.max(self.elapsed_ms());
-        if !self
-            .engine
-            .next_internal_deadline_ms()
-            .is_some_and(|deadline| deadline <= now_ms)
-        {
+        let Some(deadline_ms) = self.engine.next_internal_deadline_ms() else {
             return Ok(());
-        }
-        let now_ms = self.advance_engine_time(now_ms);
+        };
+        let Some(candidate_ms) = select_internal_work_time(
+            self.elapsed_ms(),
+            self.engine_time_ms,
+            deadline_ms,
+            self.next_pass_deadline_ms.is_some(),
+        ) else {
+            return Ok(());
+        };
+        let now_ms = self.advance_engine_time(candidate_ms);
         self.engine.process_internal_work(now_ms)?;
         Ok(())
     }
@@ -732,19 +736,11 @@ mod tests {
     }
 
     fn runtime_with_config(dp_size: u32, config: EngineConfig) -> GroupedLiveRuntime {
-        runtime_with_driver_config(dp_size, config, GroupedLiveDriverConfig::default())
-    }
-
-    fn runtime_with_driver_config(
-        dp_size: u32,
-        config: EngineConfig,
-        driver_config: GroupedLiveDriverConfig,
-    ) -> GroupedLiveRuntime {
         let engine = EngineFactory::new(config)
             .unwrap()
             .build(EngineIdentity::new(7), NonZeroU32::new(dp_size).unwrap())
             .unwrap();
-        spawn_grouped_live_engine(engine, driver_config, None).unwrap()
+        spawn_grouped_live_engine(engine, GroupedLiveDriverConfig::default(), None).unwrap()
     }
 
     struct PromptLengthTiming;
@@ -789,8 +785,8 @@ mod tests {
         events.recv().await.expect("live actor must remain active")
     }
 
-    fn ten_ms_runtime(max_catch_up: Option<Duration>) -> GroupedLiveRuntime {
-        runtime_with_driver_config(
+    fn ten_ms_runtime() -> GroupedLiveRuntime {
+        runtime_with_config(
             1,
             EngineConfig {
                 num_gpu_blocks: 128,
@@ -802,10 +798,6 @@ mod tests {
                     decode_ms: 10.0,
                 },
                 ..EngineConfig::default()
-            },
-            GroupedLiveDriverConfig {
-                absolute_pass_max_catch_up: max_catch_up,
-                ..GroupedLiveDriverConfig::default()
             },
         )
     }
@@ -841,24 +833,34 @@ mod tests {
 
     #[test]
     fn absolute_pass_start_is_bounded_and_monotonic() {
-        let cap = Some(Duration::from_millis(5));
+        assert_eq!(ABSOLUTE_PASS_MAX_CATCH_UP, Duration::from_millis(5));
+        assert_eq!(select_pass_start(12.0, 0.0, Some(10.0)), 10.0);
+        assert_eq!(select_pass_start(30.0, 0.0, Some(10.0)), 25.0);
+        assert_eq!(select_pass_start(30.0, 28.0, Some(10.0)), 28.0);
+        assert_eq!(select_pass_start(100.0, 28.0, None), 100.0);
+        assert_eq!(select_pass_start(9.0, 0.0, Some(10.0)), 10.0);
+    }
 
+    #[test]
+    fn internal_work_uses_the_active_modeled_timeline() {
         assert_eq!(
-            GroupedLiveDriverConfig::default().absolute_pass_max_catch_up,
-            cap
+            select_internal_work_time(30.0, 10.0, 12.0, true),
+            Some(12.0)
         );
-        assert_eq!(select_pass_start(12.0, 0.0, Some(10.0), cap), 10.0);
-        assert_eq!(select_pass_start(30.0, 0.0, Some(10.0), cap), 25.0);
-        assert_eq!(select_pass_start(30.0, 28.0, Some(10.0), cap), 28.0);
-        assert_eq!(select_pass_start(100.0, 28.0, None, cap), 100.0);
-        assert_eq!(select_pass_start(9.0, 0.0, Some(10.0), cap), 10.0);
-        assert_eq!(select_pass_start(30.0, 0.0, Some(10.0), None), 30.0);
+        assert_eq!(
+            select_internal_work_time(30.0, 15.0, 12.0, true),
+            Some(15.0)
+        );
+        assert_eq!(
+            select_internal_work_time(30.0, 10.0, 12.0, false),
+            Some(30.0)
+        );
+        assert_eq!(select_internal_work_time(11.0, 10.0, 12.0, true), None);
     }
 
     #[tokio::test(start_paused = true)]
     async fn default_deadline_removes_finish_delay_without_skipping_finish() {
-        let mut runtime =
-            ten_ms_runtime(GroupedLiveDriverConfig::default().absolute_pass_max_catch_up);
+        let mut runtime = ten_ms_runtime();
         let (first_end_ms, boundary) = first_completion_after_ten_ms(&mut runtime, 201, 3).await;
 
         tokio::time::advance(Duration::from_millis(2)).await;
@@ -879,9 +881,8 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn boundary_command_time_floors_a_carried_deadline() {
-        let mut runtime =
-            ten_ms_runtime(GroupedLiveDriverConfig::default().absolute_pass_max_catch_up);
+    async fn boundary_command_keeps_a_carried_deadline() {
+        let mut runtime = ten_ms_runtime();
         let (first_end_ms, boundary) = first_completion_after_ten_ms(&mut runtime, 202, 3).await;
 
         tokio::time::advance(Duration::from_millis(2)).await;
@@ -896,7 +897,36 @@ mod tests {
         let GroupedLiveEvent::PassStarted(second) = next_event(&mut runtime.events).await else {
             panic!("expected second pass start");
         };
-        assert_eq!(second.started_at_ms, first_end_ms + 2.0);
+        assert_eq!(second.started_at_ms, first_end_ms);
+
+        runtime.handle.shutdown();
+        runtime.actor.await.unwrap().unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn queued_control_keeps_a_carried_deadline() {
+        let mut runtime = ten_ms_runtime();
+        let (first_end_ms, boundary) = first_completion_after_ten_ms(&mut runtime, 204, 3).await;
+
+        tokio::time::advance(Duration::from_millis(2)).await;
+        let queued = runtime
+            .handle
+            .enqueue_command(SchedulerCommand::new(
+                0,
+                Command::Submit(request(205, 4, 1)),
+            ))
+            .await
+            .unwrap();
+        boundary.finish().await.unwrap();
+        assert!(matches!(
+            next_event(&mut runtime.events).await,
+            GroupedLiveEvent::CommandApplied { .. }
+        ));
+        queued.response.await.unwrap().unwrap();
+        let GroupedLiveEvent::PassStarted(second) = next_event(&mut runtime.events).await else {
+            panic!("expected second pass start");
+        };
+        assert_eq!(second.started_at_ms, first_end_ms);
 
         runtime.handle.shutdown();
         runtime.actor.await.unwrap().unwrap();
@@ -904,9 +934,8 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn default_catch_up_is_bounded_after_a_long_finish_delay() {
-        let mut runtime =
-            ten_ms_runtime(GroupedLiveDriverConfig::default().absolute_pass_max_catch_up);
-        let (first_end_ms, boundary) = first_completion_after_ten_ms(&mut runtime, 204, 3).await;
+        let mut runtime = ten_ms_runtime();
+        let (first_end_ms, boundary) = first_completion_after_ten_ms(&mut runtime, 206, 3).await;
 
         tokio::time::advance(Duration::from_millis(20)).await;
         boundary.finish().await.unwrap();
@@ -921,26 +950,9 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn explicit_legacy_schedule_keeps_finish_delay_in_the_next_pass_start() {
-        let mut runtime = ten_ms_runtime(None);
-        let (first_end_ms, boundary) = first_completion_after_ten_ms(&mut runtime, 205, 3).await;
-
-        tokio::time::advance(Duration::from_millis(2)).await;
-        boundary.finish().await.unwrap();
-        let GroupedLiveEvent::PassStarted(second) = next_event(&mut runtime.events).await else {
-            panic!("expected second pass start");
-        };
-        assert_eq!(second.started_at_ms, first_end_ms + 2.0);
-
-        runtime.handle.shutdown();
-        runtime.actor.await.unwrap().unwrap();
-    }
-
-    #[tokio::test(start_paused = true)]
     async fn default_deadline_restarts_from_wall_time_after_idle() {
-        let mut runtime =
-            ten_ms_runtime(GroupedLiveDriverConfig::default().absolute_pass_max_catch_up);
-        let (first_end_ms, boundary) = first_completion_after_ten_ms(&mut runtime, 206, 1).await;
+        let mut runtime = ten_ms_runtime();
+        let (first_end_ms, boundary) = first_completion_after_ten_ms(&mut runtime, 207, 1).await;
         boundary.finish().await.unwrap();
         tokio::task::yield_now().await;
 
@@ -949,7 +961,7 @@ mod tests {
             .handle
             .apply_command(SchedulerCommand::new(
                 0,
-                Command::Submit(request(207, 4, 1)),
+                Command::Submit(request(208, 4, 1)),
             ))
             .await
             .unwrap();
@@ -1000,7 +1012,6 @@ mod tests {
             cancel_token,
             clock_origin: Instant::now(),
             deferred_commands: VecDeque::new(),
-            absolute_pass_max_catch_up: None,
             engine_time_ms: 0.0,
             next_pass_deadline_ms: None,
         }
@@ -1269,7 +1280,6 @@ mod tests {
             cancel_token: CancellationToken::new(),
             clock_origin: Instant::now() - Duration::from_millis(200),
             deferred_commands: VecDeque::new(),
-            absolute_pass_max_catch_up: None,
             engine_time_ms: 0.0,
             next_pass_deadline_ms: None,
         };

--- a/lib/mocker/src/generalized_live.rs
+++ b/lib/mocker/src/generalized_live.rs
@@ -418,6 +418,7 @@ impl GroupedLiveActor {
             }
             let completed_at_ms = self.advance_engine_time(end_ms);
             let completed = self.engine.complete_pass(pass_id, completed_at_ms)?;
+            self.clear_pass_deadline_if_not_ready();
             let (boundary_tx, boundary_rx) = mpsc::channel(1);
             self.publish(GroupedLiveEvent::PassCompleted {
                 completed,
@@ -458,6 +459,12 @@ impl GroupedLiveActor {
         self.advance_engine_time(candidate_ms)
     }
 
+    fn clear_pass_deadline_if_not_ready(&mut self) {
+        if !self.engine.is_ready() {
+            self.next_pass_deadline_ms = None;
+        }
+    }
+
     async fn publish(&self, event: GroupedLiveEvent) -> Result<()> {
         tokio::select! {
             biased;
@@ -491,6 +498,7 @@ impl GroupedLiveActor {
                 BoundaryRequest::Apply { command, reply } => {
                     let now_ms = self.command_time_ms();
                     let result = self.engine.apply_command_effects(command, now_ms);
+                    self.clear_pass_deadline_if_not_ready();
                     let _ = reply.send(result);
                 }
                 BoundaryRequest::Finish { reply } => {
@@ -507,6 +515,7 @@ impl GroupedLiveActor {
             matches!(&envelope.command.command, Command::CancelRequest { .. });
         let now_ms = self.command_time_ms();
         let result = self.engine.apply_command_effects(envelope.command, now_ms);
+        self.clear_pass_deadline_if_not_ready();
         match result {
             Ok(effects) => {
                 let event = GroupedLiveEvent::CommandApplied {
@@ -927,6 +936,35 @@ mod tests {
             panic!("expected second pass start");
         };
         assert_eq!(second.started_at_ms, first_end_ms);
+
+        runtime.handle.shutdown();
+        runtime.actor.await.unwrap().unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn queued_control_after_a_drained_boundary_starts_from_wall_time() {
+        let mut runtime = ten_ms_runtime();
+        let (first_end_ms, boundary) = first_completion_after_ten_ms(&mut runtime, 210, 1).await;
+
+        tokio::time::advance(Duration::from_millis(20)).await;
+        let queued = runtime
+            .handle
+            .enqueue_command(SchedulerCommand::new(
+                0,
+                Command::Submit(request(211, 4, 1)),
+            ))
+            .await
+            .unwrap();
+        boundary.finish().await.unwrap();
+        assert!(matches!(
+            next_event(&mut runtime.events).await,
+            GroupedLiveEvent::CommandApplied { .. }
+        ));
+        queued.response.await.unwrap().unwrap();
+        let GroupedLiveEvent::PassStarted(second) = next_event(&mut runtime.events).await else {
+            panic!("expected second pass start");
+        };
+        assert_eq!(second.started_at_ms, first_end_ms + 20.0);
 
         runtime.handle.shutdown();
         runtime.actor.await.unwrap().unwrap();

--- a/lib/mocker/src/generalized_live.rs
+++ b/lib/mocker/src/generalized_live.rs
@@ -37,6 +37,8 @@ use crate::common::utils::sleep_until_precise;
 /// Engine type driven by the native live runtime.
 pub type GroupedEngine = GeneralizedMockerEngine<SchedulerRank>;
 
+const DEFAULT_ABSOLUTE_PASS_MAX_CATCH_UP: Duration = Duration::from_millis(5);
+
 /// Bounded-channel sizing for one grouped live engine.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GroupedLiveDriverConfig {
@@ -45,6 +47,10 @@ pub struct GroupedLiveDriverConfig {
     pub control_capacity: usize,
     /// Capacity of the ordered neutral-effect lane.
     pub event_capacity: usize,
+    /// Use each modeled pass end as the next pass start deadline, but do not
+    /// start more than this duration behind wall time. This defaults to 5 ms.
+    /// `None` explicitly selects the historical wall-clock-per-pass behavior.
+    pub absolute_pass_max_catch_up: Option<Duration>,
 }
 
 impl Default for GroupedLiveDriverConfig {
@@ -52,6 +58,7 @@ impl Default for GroupedLiveDriverConfig {
         Self {
             control_capacity: 64,
             event_capacity: 64,
+            absolute_pass_max_catch_up: Some(DEFAULT_ABSOLUTE_PASS_MAX_CATCH_UP),
         }
     }
 }
@@ -63,6 +70,9 @@ impl GroupedLiveDriverConfig {
         }
         if self.event_capacity == 0 {
             bail!("grouped live event capacity must be positive");
+        }
+        if self.absolute_pass_max_catch_up == Some(Duration::ZERO) {
+            bail!("grouped live absolute-pass catch-up must be positive");
         }
         Ok(self)
     }
@@ -293,6 +303,9 @@ pub fn spawn_grouped_live_engine(
             cancel_token: actor_cancel_token,
             clock_origin,
             deferred_commands: VecDeque::new(),
+            absolute_pass_max_catch_up: config.absolute_pass_max_catch_up,
+            engine_time_ms: 0.0,
+            next_pass_deadline_ms: None,
         }
         .run()
         .await
@@ -319,6 +332,26 @@ struct GroupedLiveActor {
     cancel_token: CancellationToken,
     clock_origin: Instant,
     deferred_commands: VecDeque<ControlEnvelope>,
+    absolute_pass_max_catch_up: Option<Duration>,
+    engine_time_ms: f64,
+    next_pass_deadline_ms: Option<f64>,
+}
+
+fn select_pass_start(
+    wall_ms: f64,
+    engine_time_ms: f64,
+    next_deadline_ms: Option<f64>,
+    max_catch_up: Option<Duration>,
+) -> f64 {
+    let Some(max_catch_up) = max_catch_up else {
+        return wall_ms.max(engine_time_ms);
+    };
+    let Some(deadline_ms) = next_deadline_ms else {
+        return wall_ms.max(engine_time_ms);
+    };
+
+    let catch_up_floor_ms = (wall_ms - max_catch_up.as_secs_f64() * 1_000.0).max(0.0);
+    deadline_ms.max(catch_up_floor_ms).max(engine_time_ms)
 }
 
 #[derive(Debug)]
@@ -348,6 +381,7 @@ impl GroupedLiveActor {
 
             self.process_due_internal_work().await?;
             if !self.engine.is_ready() {
+                self.next_pass_deadline_ms = None;
                 if !self.wait_for_idle_work().await? {
                     return Ok(());
                 }
@@ -358,22 +392,36 @@ impl GroupedLiveActor {
             // so a continuously refilled control lane cannot starve a pass.
             self.apply_idle_control_snapshot().await?;
             if !self.engine.is_ready() {
+                self.next_pass_deadline_ms = None;
                 continue;
             }
 
-            let started_at_ms = self.elapsed_ms();
+            let started_at_ms = select_pass_start(
+                self.elapsed_ms(),
+                self.engine_time_ms,
+                self.next_pass_deadline_ms,
+                self.absolute_pass_max_catch_up,
+            );
+            self.engine_time_ms = started_at_ms;
             let Some(started) = self.engine.execute_pass(started_at_ms)? else {
+                self.next_pass_deadline_ms = None;
                 continue;
             };
             let pass_id = started.pass_id;
             let end_ms = started.end_ms;
+            self.next_pass_deadline_ms = Some(end_ms);
             let zero_duration = end_ms <= started_at_ms;
             self.publish(GroupedLiveEvent::PassStarted(started)).await?;
 
             if !self.wait_for_pass_boundary(end_ms).await? {
                 return Ok(());
             }
-            let completed_at_ms = self.elapsed_ms().max(end_ms);
+            let completion_candidate_ms = if self.absolute_pass_max_catch_up.is_some() {
+                end_ms
+            } else {
+                self.elapsed_ms().max(end_ms)
+            };
+            let completed_at_ms = self.advance_engine_time(completion_candidate_ms);
             let completed = self.engine.complete_pass(pass_id, completed_at_ms)?;
             let (boundary_tx, boundary_rx) = mpsc::channel(1);
             self.publish(GroupedLiveEvent::PassCompleted {
@@ -399,6 +447,11 @@ impl GroupedLiveActor {
 
     fn elapsed_ms(&self) -> f64 {
         self.clock_origin.elapsed().as_secs_f64() * 1_000.0
+    }
+
+    fn advance_engine_time(&mut self, candidate_ms: f64) -> f64 {
+        self.engine_time_ms = self.engine_time_ms.max(candidate_ms);
+        self.engine_time_ms
     }
 
     async fn publish(&self, event: GroupedLiveEvent) -> Result<()> {
@@ -432,9 +485,9 @@ impl GroupedLiveActor {
             };
             match request {
                 BoundaryRequest::Apply { command, reply } => {
-                    let result = self
-                        .engine
-                        .apply_command_effects(command, self.elapsed_ms());
+                    let wall_ms = self.elapsed_ms();
+                    let now_ms = self.advance_engine_time(wall_ms);
+                    let result = self.engine.apply_command_effects(command, now_ms);
                     let _ = reply.send(result);
                 }
                 BoundaryRequest::Finish { reply } => {
@@ -449,7 +502,8 @@ impl GroupedLiveActor {
         let command_id = envelope.command_id;
         let is_request_cancellation =
             matches!(&envelope.command.command, Command::CancelRequest { .. });
-        let now_ms = self.elapsed_ms();
+        let wall_ms = self.elapsed_ms();
+        let now_ms = self.advance_engine_time(wall_ms);
         let result = self.engine.apply_command_effects(envelope.command, now_ms);
         match result {
             Ok(effects) => {
@@ -559,7 +613,8 @@ impl GroupedLiveActor {
         let command_id = envelope.command_id;
         let is_request_cancellation =
             matches!(&envelope.command.command, Command::CancelRequest { .. });
-        let now_ms = self.elapsed_ms();
+        let wall_ms = self.elapsed_ms();
+        let now_ms = self.advance_engine_time(wall_ms);
         let result = self.engine.apply_command_effects(envelope.command, now_ms);
         match result {
             Ok(effects) => {
@@ -604,7 +659,7 @@ impl GroupedLiveActor {
     }
 
     async fn process_due_internal_work(&mut self) -> Result<()> {
-        let now_ms = self.elapsed_ms();
+        let now_ms = self.engine_time_ms.max(self.elapsed_ms());
         if !self
             .engine
             .next_internal_deadline_ms()
@@ -612,6 +667,7 @@ impl GroupedLiveActor {
         {
             return Ok(());
         }
+        let now_ms = self.advance_engine_time(now_ms);
         self.engine.process_internal_work(now_ms)?;
         Ok(())
     }
@@ -676,11 +732,19 @@ mod tests {
     }
 
     fn runtime_with_config(dp_size: u32, config: EngineConfig) -> GroupedLiveRuntime {
+        runtime_with_driver_config(dp_size, config, GroupedLiveDriverConfig::default())
+    }
+
+    fn runtime_with_driver_config(
+        dp_size: u32,
+        config: EngineConfig,
+        driver_config: GroupedLiveDriverConfig,
+    ) -> GroupedLiveRuntime {
         let engine = EngineFactory::new(config)
             .unwrap()
             .build(EngineIdentity::new(7), NonZeroU32::new(dp_size).unwrap())
             .unwrap();
-        spawn_grouped_live_engine(engine, GroupedLiveDriverConfig::default(), None).unwrap()
+        spawn_grouped_live_engine(engine, driver_config, None).unwrap()
     }
 
     struct PromptLengthTiming;
@@ -725,6 +789,183 @@ mod tests {
         events.recv().await.expect("live actor must remain active")
     }
 
+    fn ten_ms_runtime(max_catch_up: Option<Duration>) -> GroupedLiveRuntime {
+        runtime_with_driver_config(
+            1,
+            EngineConfig {
+                num_gpu_blocks: 128,
+                block_size: 4,
+                max_num_seqs: 8,
+                max_num_batched_tokens: 256,
+                timing_model: TimingModelConfig::Fixed {
+                    prefill_ms: 10.0,
+                    decode_ms: 10.0,
+                },
+                ..EngineConfig::default()
+            },
+            GroupedLiveDriverConfig {
+                absolute_pass_max_catch_up: max_catch_up,
+                ..GroupedLiveDriverConfig::default()
+            },
+        )
+    }
+
+    async fn first_completion_after_ten_ms(
+        runtime: &mut GroupedLiveRuntime,
+        request_id: u128,
+        output_len: usize,
+    ) -> (f64, GroupedPassBoundary) {
+        runtime
+            .handle
+            .apply_command(SchedulerCommand::new(
+                0,
+                Command::Submit(request(request_id, 4, output_len)),
+            ))
+            .await
+            .unwrap();
+        assert!(matches!(
+            next_event(&mut runtime.events).await,
+            GroupedLiveEvent::CommandApplied { .. }
+        ));
+        let GroupedLiveEvent::PassStarted(first) = next_event(&mut runtime.events).await else {
+            panic!("expected first pass start");
+        };
+        tokio::time::advance(Duration::from_millis(10)).await;
+        let GroupedLiveEvent::PassCompleted { boundary, .. } =
+            next_event(&mut runtime.events).await
+        else {
+            panic!("expected first pass completion");
+        };
+        (first.end_ms, boundary)
+    }
+
+    #[test]
+    fn absolute_pass_start_is_bounded_and_monotonic() {
+        let cap = Some(Duration::from_millis(5));
+
+        assert_eq!(
+            GroupedLiveDriverConfig::default().absolute_pass_max_catch_up,
+            cap
+        );
+        assert_eq!(select_pass_start(12.0, 0.0, Some(10.0), cap), 10.0);
+        assert_eq!(select_pass_start(30.0, 0.0, Some(10.0), cap), 25.0);
+        assert_eq!(select_pass_start(30.0, 28.0, Some(10.0), cap), 28.0);
+        assert_eq!(select_pass_start(100.0, 28.0, None, cap), 100.0);
+        assert_eq!(select_pass_start(9.0, 0.0, Some(10.0), cap), 10.0);
+        assert_eq!(select_pass_start(30.0, 0.0, Some(10.0), None), 30.0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn default_deadline_removes_finish_delay_without_skipping_finish() {
+        let mut runtime =
+            ten_ms_runtime(GroupedLiveDriverConfig::default().absolute_pass_max_catch_up);
+        let (first_end_ms, boundary) = first_completion_after_ten_ms(&mut runtime, 201, 3).await;
+
+        tokio::time::advance(Duration::from_millis(2)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            runtime.events.try_recv().is_err(),
+            "the actor must not start another pass before Finish"
+        );
+        boundary.finish().await.unwrap();
+        let GroupedLiveEvent::PassStarted(second) = next_event(&mut runtime.events).await else {
+            panic!("expected second pass start");
+        };
+        assert_eq!(second.started_at_ms, first_end_ms);
+        assert_eq!(second.end_ms, first_end_ms + 10.0);
+
+        runtime.handle.shutdown();
+        runtime.actor.await.unwrap().unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn boundary_command_time_floors_a_carried_deadline() {
+        let mut runtime =
+            ten_ms_runtime(GroupedLiveDriverConfig::default().absolute_pass_max_catch_up);
+        let (first_end_ms, boundary) = first_completion_after_ten_ms(&mut runtime, 202, 3).await;
+
+        tokio::time::advance(Duration::from_millis(2)).await;
+        boundary
+            .apply_command(SchedulerCommand::new(
+                0,
+                Command::Submit(request(203, 4, 1)),
+            ))
+            .await
+            .unwrap();
+        boundary.finish().await.unwrap();
+        let GroupedLiveEvent::PassStarted(second) = next_event(&mut runtime.events).await else {
+            panic!("expected second pass start");
+        };
+        assert_eq!(second.started_at_ms, first_end_ms + 2.0);
+
+        runtime.handle.shutdown();
+        runtime.actor.await.unwrap().unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn default_catch_up_is_bounded_after_a_long_finish_delay() {
+        let mut runtime =
+            ten_ms_runtime(GroupedLiveDriverConfig::default().absolute_pass_max_catch_up);
+        let (first_end_ms, boundary) = first_completion_after_ten_ms(&mut runtime, 204, 3).await;
+
+        tokio::time::advance(Duration::from_millis(20)).await;
+        boundary.finish().await.unwrap();
+        let GroupedLiveEvent::PassStarted(second) = next_event(&mut runtime.events).await else {
+            panic!("expected second pass start");
+        };
+        assert_eq!(second.started_at_ms, first_end_ms + 15.0);
+        assert_eq!(second.end_ms, second.started_at_ms + 10.0);
+
+        runtime.handle.shutdown();
+        runtime.actor.await.unwrap().unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn explicit_legacy_schedule_keeps_finish_delay_in_the_next_pass_start() {
+        let mut runtime = ten_ms_runtime(None);
+        let (first_end_ms, boundary) = first_completion_after_ten_ms(&mut runtime, 205, 3).await;
+
+        tokio::time::advance(Duration::from_millis(2)).await;
+        boundary.finish().await.unwrap();
+        let GroupedLiveEvent::PassStarted(second) = next_event(&mut runtime.events).await else {
+            panic!("expected second pass start");
+        };
+        assert_eq!(second.started_at_ms, first_end_ms + 2.0);
+
+        runtime.handle.shutdown();
+        runtime.actor.await.unwrap().unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn default_deadline_restarts_from_wall_time_after_idle() {
+        let mut runtime =
+            ten_ms_runtime(GroupedLiveDriverConfig::default().absolute_pass_max_catch_up);
+        let (first_end_ms, boundary) = first_completion_after_ten_ms(&mut runtime, 206, 1).await;
+        boundary.finish().await.unwrap();
+        tokio::task::yield_now().await;
+
+        tokio::time::advance(Duration::from_millis(100)).await;
+        runtime
+            .handle
+            .apply_command(SchedulerCommand::new(
+                0,
+                Command::Submit(request(207, 4, 1)),
+            ))
+            .await
+            .unwrap();
+        assert!(matches!(
+            next_event(&mut runtime.events).await,
+            GroupedLiveEvent::CommandApplied { .. }
+        ));
+        let GroupedLiveEvent::PassStarted(second) = next_event(&mut runtime.events).await else {
+            panic!("expected second pass start");
+        };
+        assert_eq!(second.started_at_ms, first_end_ms + 100.0);
+
+        runtime.handle.shutdown();
+        runtime.actor.await.unwrap().unwrap();
+    }
+
     fn ready_actor(
         event_tx: mpsc::Sender<GroupedLiveEvent>,
         cancel_token: CancellationToken,
@@ -759,6 +1000,9 @@ mod tests {
             cancel_token,
             clock_origin: Instant::now(),
             deferred_commands: VecDeque::new(),
+            absolute_pass_max_catch_up: None,
+            engine_time_ms: 0.0,
+            next_pass_deadline_ms: None,
         }
     }
 
@@ -1025,6 +1269,9 @@ mod tests {
             cancel_token: CancellationToken::new(),
             clock_origin: Instant::now() - Duration::from_millis(200),
             deferred_commands: VecDeque::new(),
+            absolute_pass_max_catch_up: None,
+            engine_time_ms: 0.0,
+            next_pass_deadline_ms: None,
         };
         assert!(actor.wait_for_pass_boundary(started.end_ms).await.unwrap());
         response

--- a/lib/mocker/src/grouped_scheduler.rs
+++ b/lib/mocker/src/grouped_scheduler.rs
@@ -49,6 +49,37 @@ use crate::scheduler::{
     handoff_channel_capacity,
 };
 
+const ABSOLUTE_PASS_MAX_CATCH_UP_ENV: &str = "DYN_MOCKER_ABSOLUTE_PASS_MAX_CATCH_UP_MS";
+
+fn parse_absolute_pass_max_catch_up(value: &str) -> Result<std::time::Duration> {
+    let milliseconds = value.parse::<f64>().with_context(|| {
+        format!("{ABSOLUTE_PASS_MAX_CATCH_UP_ENV} must be a number of milliseconds")
+    })?;
+    ensure!(
+        milliseconds.is_finite() && milliseconds > 0.0,
+        "{ABSOLUTE_PASS_MAX_CATCH_UP_ENV} must be finite and positive, got {value}"
+    );
+    let duration = std::time::Duration::try_from_secs_f64(milliseconds / 1_000.0)
+        .with_context(|| format!("{ABSOLUTE_PASS_MAX_CATCH_UP_ENV} is out of range: {value}"))?;
+    ensure!(
+        !duration.is_zero(),
+        "{ABSOLUTE_PASS_MAX_CATCH_UP_ENV} is below the supported duration precision: {value}"
+    );
+    Ok(duration)
+}
+
+fn absolute_pass_max_catch_up_from_env() -> Result<Option<std::time::Duration>> {
+    match std::env::var(ABSOLUTE_PASS_MAX_CATCH_UP_ENV) {
+        Ok(value) => parse_absolute_pass_max_catch_up(&value).map(Some),
+        Err(std::env::VarError::NotPresent) => {
+            Ok(GroupedLiveDriverConfig::default().absolute_pass_max_catch_up)
+        }
+        Err(std::env::VarError::NotUnicode(_)) => {
+            bail!("{ABSOLUTE_PASS_MAX_CATCH_UP_ENV} must be valid UTF-8")
+        }
+    }
+}
+
 /// Per-rank Dynamo sinks consumed by [`create_grouped_scheduler`].
 #[derive(Clone, Default)]
 pub struct GroupedSchedulerRankSinks {
@@ -277,6 +308,7 @@ fn create_grouped_scheduler_from_components(
         .checked_mul(dp_size.get() as usize)
         .context("grouped scheduler control capacity overflow")?;
     let event_capacity = control_capacity.max(dp_size.get() as usize * 4).max(64);
+    let absolute_pass_max_catch_up = absolute_pass_max_catch_up_from_env()?;
     let factory = engine_factory(components.rank, components.timing)?;
     // Existing live schedulers seed every process-local worker from DP rank.
     // A logical worker therefore retains worker_id=0 at this compatibility
@@ -299,6 +331,7 @@ fn create_grouped_scheduler_from_components(
         GroupedLiveDriverConfig {
             control_capacity,
             event_capacity,
+            absolute_pass_max_catch_up,
         },
         Some(cancel_token.clone()),
     )?;
@@ -788,6 +821,25 @@ fn fail_pending_command(
         let _ = reply.send(Err(error));
     } else {
         tracing::warn!(command_id, error = ?error, "grouped live request failed");
+    }
+}
+
+#[cfg(test)]
+mod absolute_pass_config_tests {
+    use super::*;
+
+    #[test]
+    fn absolute_pass_catch_up_requires_a_finite_positive_value() {
+        assert_eq!(
+            parse_absolute_pass_max_catch_up("5").unwrap(),
+            std::time::Duration::from_millis(5)
+        );
+        for invalid in ["0", "-1", "NaN", "inf", "1e-300", "not-a-number"] {
+            assert!(
+                parse_absolute_pass_max_catch_up(invalid).is_err(),
+                "{invalid}"
+            );
+        }
     }
 }
 

--- a/lib/mocker/src/grouped_scheduler.rs
+++ b/lib/mocker/src/grouped_scheduler.rs
@@ -49,37 +49,6 @@ use crate::scheduler::{
     handoff_channel_capacity,
 };
 
-const ABSOLUTE_PASS_MAX_CATCH_UP_ENV: &str = "DYN_MOCKER_ABSOLUTE_PASS_MAX_CATCH_UP_MS";
-
-fn parse_absolute_pass_max_catch_up(value: &str) -> Result<std::time::Duration> {
-    let milliseconds = value.parse::<f64>().with_context(|| {
-        format!("{ABSOLUTE_PASS_MAX_CATCH_UP_ENV} must be a number of milliseconds")
-    })?;
-    ensure!(
-        milliseconds.is_finite() && milliseconds > 0.0,
-        "{ABSOLUTE_PASS_MAX_CATCH_UP_ENV} must be finite and positive, got {value}"
-    );
-    let duration = std::time::Duration::try_from_secs_f64(milliseconds / 1_000.0)
-        .with_context(|| format!("{ABSOLUTE_PASS_MAX_CATCH_UP_ENV} is out of range: {value}"))?;
-    ensure!(
-        !duration.is_zero(),
-        "{ABSOLUTE_PASS_MAX_CATCH_UP_ENV} is below the supported duration precision: {value}"
-    );
-    Ok(duration)
-}
-
-fn absolute_pass_max_catch_up_from_env() -> Result<Option<std::time::Duration>> {
-    match std::env::var(ABSOLUTE_PASS_MAX_CATCH_UP_ENV) {
-        Ok(value) => parse_absolute_pass_max_catch_up(&value).map(Some),
-        Err(std::env::VarError::NotPresent) => {
-            Ok(GroupedLiveDriverConfig::default().absolute_pass_max_catch_up)
-        }
-        Err(std::env::VarError::NotUnicode(_)) => {
-            bail!("{ABSOLUTE_PASS_MAX_CATCH_UP_ENV} must be valid UTF-8")
-        }
-    }
-}
-
 /// Per-rank Dynamo sinks consumed by [`create_grouped_scheduler`].
 #[derive(Clone, Default)]
 pub struct GroupedSchedulerRankSinks {
@@ -308,7 +277,6 @@ fn create_grouped_scheduler_from_components(
         .checked_mul(dp_size.get() as usize)
         .context("grouped scheduler control capacity overflow")?;
     let event_capacity = control_capacity.max(dp_size.get() as usize * 4).max(64);
-    let absolute_pass_max_catch_up = absolute_pass_max_catch_up_from_env()?;
     let factory = engine_factory(components.rank, components.timing)?;
     // Existing live schedulers seed every process-local worker from DP rank.
     // A logical worker therefore retains worker_id=0 at this compatibility
@@ -331,7 +299,6 @@ fn create_grouped_scheduler_from_components(
         GroupedLiveDriverConfig {
             control_capacity,
             event_capacity,
-            absolute_pass_max_catch_up,
         },
         Some(cancel_token.clone()),
     )?;
@@ -821,25 +788,6 @@ fn fail_pending_command(
         let _ = reply.send(Err(error));
     } else {
         tracing::warn!(command_id, error = ?error, "grouped live request failed");
-    }
-}
-
-#[cfg(test)]
-mod absolute_pass_config_tests {
-    use super::*;
-
-    #[test]
-    fn absolute_pass_catch_up_requires_a_finite_positive_value() {
-        assert_eq!(
-            parse_absolute_pass_max_catch_up("5").unwrap(),
-            std::time::Duration::from_millis(5)
-        );
-        for invalid in ["0", "-1", "NaN", "inf", "1e-300", "not-a-number"] {
-            assert!(
-                parse_absolute_pass_max_catch_up(invalid).is_err(),
-                "{invalid}"
-            );
-        }
     }
 }
 


### PR DESCRIPTION
## Overview

The live mocker starts each forward pass from wall time after the prior pass completes its mandatory `Finish` handoff. This adds the output and `Finish` boundary delay to every modeled pass. That delay changes with placement, so the same timing model can produce different inter-token latency (ITL).

This PR makes the modeled-deadline schedule the default. It uses the prior modeled pass end as the next pass start deadline and limits catch-up to 5 ms with one internal constant.

## Details

### Root cause

A matched Y-X-X-Y placement test reproduced the ITL direction after the run order changed:

| Paired delta, Y minus X | Pair 1 | Pair 2 |
|---|---:|---:|
| Mean ITL | +0.163321 ms | +0.129939 ms |
| Completion boundary per pass | +0.168010 ms | +0.132797 ms |
| `Finish` actor wake per pass | +0.156542 ms | +0.120714 ms |
| Tokio OS worker thread CPU | +0.155988 ms | +0.130994 ms |
| Wall time minus thread CPU | -0.000580 ms | -0.008181 ms |

The placement-sensitive part was local active CPU time on the Tokio OS worker thread between the `Finish` send and the actor poll. The probe measures the full OS thread. It does not assign the CPU time to one Tokio task. Direct frontend-to-worker packet transit is outside this interval.

The code defect is independent of which local task used that time. The live loop used wall time after `Finish` as the next modeled pass start. It therefore added the full boundary delay to the next forward-pass sleep.

### Fix

The live driver now:

- Carries the prior modeled pass end as the next pass start deadline.
- Sleeps to the absolute modeled deadline.
- Still requires `Finish` before another pass can start.
- Applies commands on modeled engine time while a pass sequence remains active, so command handling cannot erase the carried deadline.
- Processes due internal work at its modeled deadline while a pass sequence remains active.
- Clears the carried deadline before publishing a completion that leaves the engine not ready, and after an out-of-pass command makes it not ready.
- Resets the carried deadline and returns to wall time when the engine becomes idle.
- Limits how far logical time can stay behind wall time to a fixed 5 ms.

The pass start is `max(prior modeled end, wall time - 5 ms, modeled engine time)`. The fixed catch-up limit is internal to the live driver. This PR adds no CLI flag, environment variable, or public timing option.

The catch-up limit bounds time debt. It does not directly limit the number of immediately due passes when the limit is longer than one modeled pass.

### Benchmark results

I tested the scheduler algorithm with a matched C-D-D-C sequence:

- C: previous wall-time schedule.
- D: modeled-deadline schedule with a 5 ms catch-up limit.
- Benchmark: `inferencex-fixed-1k1k-pooled-seamless-ramp10s@1`.
- AIPerf revision: `04802735fecc2acea650e38cd7da29e1295ecc8b`.
- Benchmarked Dynamo SHA: `ff28cbb7244aee2a3a2c13658634f75fef560cd9`.
- Router Zoo build: `0242ac01-706d-472f-b1f4-adf01821c22a`.
- Run IDs: `5ba0d421-5c84-4ff8-af11-d6399e7fb3a4`, `65b068bf-77f8-404e-a41f-822fcb948e30`, `2f2fda8c-ddc4-45b2-ae3e-b077799f9edf`, and `c5d1c0f1-32b7-4437-b122-437ad70b92d8`.
- Load: closed-loop concurrency 512, with 5,120 measured 1,024-input/1,024-output requests per run.
- Placement: one fixed frontend node and four mockers on one fixed worker node.
- Validity: all runs used pooled connections and had zero request errors, zero output-length mismatches, zero pod restarts, saved results, and saved telemetry.

The diagnostic runs explicitly selected 5 ms. This is the same policy and fixed bound used by this PR.

The paired comparisons are D2-C1 and D3-C4:

| Metric | Control mean | Deadline mean | D2-C1 | D3-C4 | Mean delta |
|---|---:|---:|---:|---:|---:|
| Mean ITL | 8.3343 ms | 5.9323 ms | -2.5368 ms | -2.2671 ms | -2.4020 ms |
| p50 ITL | 8.5075 ms | 6.0488 ms | -2.5804 ms | -2.3371 ms | -2.4587 ms |
| p95 ITL | 8.6806 ms | 6.2352 ms | -2.5719 ms | -2.3189 ms | -2.4454 ms |
| Mean TTFT | 38.8433 ms | 49.4227 ms | +12.0799 ms | +9.0790 ms | +10.5795 ms |
| p50 TTFT | 37.8049 ms | 46.9472 ms | +10.4235 ms | +7.8611 ms | +9.1423 ms |
| p95 TTFT | 51.2251 ms | 74.2528 ms | +26.5013 ms | +19.5541 ms | +23.0277 ms |
| Request throughput | 54.0638 req/s | 75.5165 req/s | +22.4685 req/s | +20.4368 req/s | +21.4527 req/s |
| Input throughput | 55,361.3 tok/s | 77,328.9 tok/s | +23,007.8 tok/s | +20,927.3 tok/s | +21,967.5 tok/s |
| Effective prefill concurrency | 2.0997 | 3.7331 | +1.8013 | +1.4655 | +1.6334 |
| Mean request latency | 8,778.5 ms | 6,269.7 ms | -2,648.3 ms | -2,369.3 ms | -2,508.8 ms |

The new schedule reduced mean ITL by 28.8% and p95 ITL by 28.2%. The reverse control returned close to the first control, which excludes a simple monotonic time drift.

The captured pass timing also predicts the ITL change. Control modeled time plus non-modeled time was 8.2586 ms/pass. Deadline modeled time plus non-modeled time minus catch-up was 5.8889 ms/pass. The predicted change was -2.3696 ms/pass; the measured mean ITL change was -2.4020 ms.

The TTFT values are not an equal-load comparison. This was a closed-loop concurrency-512 test. Faster completions caused AIPerf to send replacement requests sooner. Request and input throughput increased by 39.7%, and effective prefill concurrency increased by 77.8%. This proves that the operating point changed. It does not prove that the deadline algorithm directly made prefill slower. A fixed-rate test is required to compare TTFT at the same offered load.

### Catch-up safety

The diagnostic benchmark build reported:

- 110,592 passes with modeled-deadline scheduling.
- 110,584 passes that carried a prior deadline.
- 2.3264 ms mean deadline lag.
- 2.0845 ms mean applied catch-up.
- 5.0000 ms maximum applied catch-up.
- 586 already-due passes, or 0.5299%.
- 130 catch-up-clamped passes, or 0.1175%.
- 24.3418 ms maximum raw deadline lag.

All control-arm deadline counters stayed at zero. The 5 ms limit held in both treatment runs.

The benchmark SHA includes four diagnostic-only ancestor commits. This PR ports the same scheduling algorithm, uses its tested 5 ms setting as a fixed default, and keeps the CPU probes and diagnostic timing logs out of this PR.

### Validation on this PR head

- `cargo test -p dynamo-mocker --lib` — 205 passed.
- `cargo clippy -p dynamo-mocker -p dynamo-llm --all-targets -- -D warnings` — passed.
- `cargo check -p dynamo-llm` — passed.
- `cargo fmt --all -- --check` — passed.

The focused tests cover the fixed 5 ms policy, delayed-`Finish` catch-up, mandatory `Finish` ordering, boundary and queued commands, a new request queued behind a drained completion boundary, due internal work, idle reset, bounded catch-up after a long delay, and zero-duration shutdown.

## Where should the reviewer start?

- `lib/mocker/src/generalized_live.rs`: pass deadline selection, modeled command and internal-work time, and focused tests.

## Related Issues

**This PR is NOT linked to an issue**:

- [x] Confirmed — no related issue
