### PR TITLE
feat(planner): reconfigure GPU budgets at runtime

### DIFF
--- a/components/src/dynamo/planner/config/defaults.py
+++ b/components/src/dynamo/planner/config/defaults.py
@@ -40,7 +40,7 @@ class BasePlannerDefaults:
     min_endpoint = 1
     prefill_min_endpoint = None
     decode_min_endpoint = None
-    # Localhost-only runtime configuration API (0 disables). It is
+    # Localhost-only endpoint and GPU budget configuration API (0 disables). It is
     # unauthenticated by design and trusts processes in the pod namespace.
     control_api_port = 9086
     decode_engine_num_gpu = 1

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -463,7 +463,7 @@ class PlannerConfig(BaseModel):
         ge=0,
         le=65535,
         description=(
-            "Port for the localhost-only runtime minimum-endpoint API. "
+            "Port for the localhost-only runtime endpoint and GPU-budget API. "
             "Set to 0 to disable the API."
         ),
     )

--- a/components/src/dynamo/planner/control_api.py
+++ b/components/src/dynamo/planner/control_api.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Local runtime API for planner minimum endpoint configuration."""
+"""Local runtime API for planner endpoint and GPU budget configuration."""
 
 from __future__ import annotations
 
@@ -37,6 +37,8 @@ class _MinimumEndpointsPatch(BaseModel):
     min_endpoint: int | None = Field(default=None, ge=0)
     prefill_min_endpoint: int | None = Field(default=None, ge=1)
     decode_min_endpoint: int | None = Field(default=None, ge=1)
+    min_gpu_budget: int | None = Field(default=None, ge=-1)
+    max_gpu_budget: int | None = Field(default=None, ge=-1)
 
 
 def _error(message: str, status: int) -> web.Response:
@@ -74,9 +76,12 @@ def _build_app(controller: _MinimumEndpointController) -> web.Application:
 
         fields = patch.model_fields_set
         if not fields:
-            return _error("request body must include at least one endpoint field", 400)
+            return _error(
+                "request body must include at least one runtime configuration field",
+                400,
+            )
         if any(getattr(patch, field) is None for field in fields):
-            return _error("minimum endpoint fields cannot be null", 422)
+            return _error("runtime configuration fields cannot be null", 422)
 
         updates = {field: int(getattr(patch, field)) for field in fields}
         try:

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -156,6 +156,8 @@ class NativePlannerBase:
         self._config_lock = asyncio.Lock()
         self._config_generation = 0
         self._effect_submission_task: Optional[asyncio.Task[None]] = None
+        self._effect_submission_outcome_unknown: Optional[str] = None
+        self._effect_submission_hold_logged = False
         self._diagnostics_finalized = False
         self._environment_initialized = False
         self._engine: Optional[EngineProtocol] = None
@@ -686,29 +688,72 @@ class NativePlannerBase:
         await self._apply_effects(effects)
 
     def _effect_submission_done(self, task: asyncio.Task[None]) -> None:
-        if self._effect_submission_task is task:
-            self._effect_submission_task = None
+        if self._effect_submission_task is not task:
+            return
         if task.cancelled():
+            self._mark_effect_submission_unknown("submission task was cancelled")
             return
         exception = task.exception()
-        if exception is not None:
-            logger.error(
-                "Planner effect submission failed",
-                exc_info=(type(exception), exception, exception.__traceback__),
-            )
+        if exception is None:
+            self._effect_submission_task = None
+            return
+        self._mark_effect_submission_unknown(
+            f"submission failed: {exception}", exception
+        )
+
+    def _mark_effect_submission_unknown(
+        self, reason: str, exception: Optional[BaseException] = None
+    ) -> None:
+        if self._effect_submission_outcome_unknown is not None:
+            return
+        self._effect_submission_outcome_unknown = reason
+        logger.error(
+            "Planner effect submission outcome is unknown (%s). Automatic "
+            "effect submission is disabled until the Planner is restarted; "
+            "verify the deployment state before restarting to avoid duplicating "
+            "an action that the remote service may already have applied.",
+            reason,
+            exc_info=(
+                (type(exception), exception, exception.__traceback__)
+                if exception is not None
+                else None
+            ),
+        )
 
     async def _submit_effects(
         self, effects: PlannerEffects, config_generation: int
     ) -> None:
         """Submit at most one effect without cancelling an unacknowledged request."""
 
-        pending = self._effect_submission_task
-        if pending is not None and not pending.done():
-            logger.warning(
-                "Skipping planner effect submission while the previous request "
-                "is still awaiting acknowledgement"
-            )
+        if self._effect_submission_outcome_unknown is not None:
+            if not self._effect_submission_hold_logged:
+                logger.error(
+                    "Holding planner effects because a previous submission outcome "
+                    "is unknown; runtime configuration remains available, but "
+                    "automatic submission requires a Planner restart after the "
+                    "deployment state is verified"
+                )
+                self._effect_submission_hold_logged = True
             return
+
+        pending = self._effect_submission_task
+        if pending is not None:
+            if not pending.done():
+                logger.warning(
+                    "Skipping planner effect submission while the previous request "
+                    "is still awaiting acknowledgement"
+                )
+                return
+            if pending.cancelled():
+                self._mark_effect_submission_unknown("submission task was cancelled")
+                return
+            exception = pending.exception()
+            if exception is not None:
+                self._mark_effect_submission_unknown(
+                    f"submission failed: {exception}", exception
+                )
+                return
+            self._effect_submission_task = None
 
         task = asyncio.create_task(
             self._apply_effects_if_current(effects, config_generation)
@@ -726,6 +771,9 @@ class NativePlannerBase:
                 "second effect will be submitted until it completes",
                 _EFFECT_SUBMISSION_WAIT_SECONDS,
             )
+        else:
+            if self._effect_submission_task is task:
+                self._effect_submission_task = None
 
     def _current_worker_counts(self) -> tuple[int, int]:
         """Best-known current (prefill, decode) ready worker counts.

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -237,11 +237,25 @@ class NativePlannerBase:
     def _build_worker_capabilities(self) -> WorkerCapabilities:
         return build_worker_capabilities(self.environment.deployment_state())
 
-    def _minimum_endpoint_budget_errors(
-        self, prefill_min_endpoint: Optional[int], decode_min_endpoint: Optional[int]
+    def _runtime_configuration_errors(
+        self,
+        prefill_min_endpoint: Optional[int],
+        decode_min_endpoint: Optional[int],
+        min_gpu_budget: int,
+        max_gpu_budget: int,
     ) -> list[str]:
         capabilities = self._build_worker_capabilities()
         errors: list[str] = []
+
+        if (
+            min_gpu_budget >= 0
+            and max_gpu_budget >= 0
+            and min_gpu_budget > max_gpu_budget
+        ):
+            errors.append(
+                f"min_gpu_budget={min_gpu_budget} exceeds "
+                f"max_gpu_budget={max_gpu_budget}"
+            )
 
         required_gpus = 0
         if prefill_min_endpoint is not None and capabilities.prefill is not None:
@@ -252,14 +266,11 @@ class NativePlannerBase:
             d_gpu = capabilities.decode.resolved_gpu_cost_per_replica
             if d_gpu is not None:
                 required_gpus += decode_min_endpoint * d_gpu
-        if (
-            self.config.max_gpu_budget >= 0
-            and required_gpus > self.config.max_gpu_budget
-        ):
+        if max_gpu_budget >= 0 and required_gpus > max_gpu_budget:
             errors.append(
                 "minimum endpoint footprint requires "
                 f"{required_gpus} GPUs, exceeding max_gpu_budget="
-                f"{self.config.max_gpu_budget}"
+                f"{max_gpu_budget}"
             )
 
         power_budget = self.config.total_gpu_power_limit
@@ -297,8 +308,12 @@ class NativePlannerBase:
         return errors
 
     def _validate_min_endpoint_budgets_at_startup(self) -> None:
-        errors = self._minimum_endpoint_budget_errors(
-            *self.config.active_min_endpoints()
+        prefill_min_endpoint, decode_min_endpoint = self.config.active_min_endpoints()
+        errors = self._runtime_configuration_errors(
+            prefill_min_endpoint,
+            decode_min_endpoint,
+            self.config.min_gpu_budget,
+            self.config.max_gpu_budget,
         )
         if errors:
             raise DeploymentValidationError(errors)
@@ -306,25 +321,34 @@ class NativePlannerBase:
     def _min_endpoint_response(self) -> dict[str, object]:
         mode = self.config.mode
         if mode == "agg":
-            return {"mode": mode, "min_endpoint": self.config.min_endpoint}
-        if mode == "prefill":
-            return {
+            response: dict[str, object] = {
+                "mode": mode,
+                "min_endpoint": self.config.min_endpoint,
+            }
+        elif mode == "prefill":
+            response = {
                 "mode": mode,
                 "prefill_min_endpoint": self.config.effective_prefill_min_endpoint,
             }
-        if mode == "decode":
-            return {
+        elif mode == "decode":
+            response = {
                 "mode": mode,
                 "decode_min_endpoint": self.config.effective_decode_min_endpoint,
             }
-        return {
-            "mode": mode,
-            "prefill_min_endpoint": self.config.effective_prefill_min_endpoint,
-            "decode_min_endpoint": self.config.effective_decode_min_endpoint,
-        }
+        else:
+            response = {
+                "mode": mode,
+                "prefill_min_endpoint": self.config.effective_prefill_min_endpoint,
+                "decode_min_endpoint": self.config.effective_decode_min_endpoint,
+            }
+        response.update(
+            min_gpu_budget=self.config.min_gpu_budget,
+            max_gpu_budget=self.config.max_gpu_budget,
+        )
+        return response
 
     async def get_min_endpoints(self) -> dict[str, object]:
-        """Return the active mode's effective minimum endpoint configuration."""
+        """Return the active endpoint floors and GPU budgets."""
 
         async with self._bounded_config_lock():
             return self._min_endpoint_response()
@@ -349,12 +373,13 @@ class NativePlannerBase:
     async def patch_min_endpoints(self, updates: dict[str, int]) -> dict[str, object]:
         """Atomically validate and apply a mode-shaped runtime update."""
 
-        allowed_fields = {
+        endpoint_fields = {
             "disagg": {"prefill_min_endpoint", "decode_min_endpoint"},
             "prefill": {"prefill_min_endpoint"},
             "decode": {"decode_min_endpoint"},
             "agg": {"min_endpoint"},
         }[self.config.mode]
+        allowed_fields = endpoint_fields | {"min_gpu_budget", "max_gpu_budget"}
         inactive_fields = sorted(set(updates) - allowed_fields)
         if inactive_fields:
             raise _MinimumEndpointValidationError(
@@ -367,15 +392,24 @@ class NativePlannerBase:
                 prefill_min_endpoint,
                 decode_min_endpoint,
             ) = self.config.active_min_endpoints()
+            min_gpu_budget = self.config.min_gpu_budget
+            max_gpu_budget = self.config.max_gpu_budget
             if "prefill_min_endpoint" in updates:
                 prefill_min_endpoint = updates["prefill_min_endpoint"]
             if "decode_min_endpoint" in updates:
                 decode_min_endpoint = updates["decode_min_endpoint"]
             if "min_endpoint" in updates:
                 decode_min_endpoint = updates["min_endpoint"]
+            if "min_gpu_budget" in updates:
+                min_gpu_budget = updates["min_gpu_budget"]
+            if "max_gpu_budget" in updates:
+                max_gpu_budget = updates["max_gpu_budget"]
 
-            errors = self._minimum_endpoint_budget_errors(
-                prefill_min_endpoint, decode_min_endpoint
+            errors = self._runtime_configuration_errors(
+                prefill_min_endpoint,
+                decode_min_endpoint,
+                min_gpu_budget,
+                max_gpu_budget,
             )
             if errors:
                 raise _MinimumEndpointValidationError("; ".join(errors))
@@ -384,7 +418,9 @@ class NativePlannerBase:
             for field, value in updates.items():
                 setattr(self.config, field, value)
             after = self._min_endpoint_response()
-            logger.info("Updated planner minimum endpoints: %s -> %s", before, after)
+            logger.info(
+                "Updated planner runtime configuration: %s -> %s", before, after
+            )
             return after
 
     def _runtime_namespace(self) -> str:
@@ -829,11 +865,11 @@ class NativePlannerBase:
         if tick_input.worker_counts is not None:
             self._last_worker_counts = tick_input.worker_counts
 
-        # Runtime floor updates are atomic with decision computation, but the
-        # lock is released before connector rollouts that may take minutes.
+        # Keep runtime configuration stable through decision submission. Scaling
+        # calls are non-blocking, so the lock is released before the rollout.
         async with self._config_lock:
             effects = await engine.tick(tick, tick_input)
-        await self._apply_effects(effects)
+            await self._apply_effects(effects)
         emit_diagnostics = self._should_emit_tick_diagnostics(tick, effects)
         if emit_diagnostics:
             self._report_diagnostics(tick, effects.diagnostics)

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -238,8 +238,9 @@ class NativePlannerBase:
 
         effect_submission_task = self._effect_submission_task
         self._effect_submission_task = None
-        if effect_submission_task is not None and not effect_submission_task.done():
-            effect_submission_task.cancel()
+        if effect_submission_task is not None:
+            if not effect_submission_task.done():
+                effect_submission_task.cancel()
             try:
                 await effect_submission_task
             except asyncio.CancelledError:

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -154,6 +154,7 @@ class NativePlannerBase:
         self._dashboard_runner: Optional[aiohttp.web.AppRunner] = None
         self._control_api_runner: Optional[aiohttp.web.AppRunner] = None
         self._config_lock = asyncio.Lock()
+        self._effect_admission_lock = asyncio.Lock()
         self._config_generation = 0
         self._effect_submission_task: Optional[asyncio.Task[None]] = None
         self._effect_submission_outcome_unknown: Optional[str] = None
@@ -408,42 +409,46 @@ class NativePlannerBase:
                 + ", ".join(inactive_fields)
             )
 
-        async with self._bounded_config_lock():
-            (
-                prefill_min_endpoint,
-                decode_min_endpoint,
-            ) = self.config.active_min_endpoints()
-            min_gpu_budget = self.config.min_gpu_budget
-            max_gpu_budget = self.config.max_gpu_budget
-            if "prefill_min_endpoint" in updates:
-                prefill_min_endpoint = updates["prefill_min_endpoint"]
-            if "decode_min_endpoint" in updates:
-                decode_min_endpoint = updates["decode_min_endpoint"]
-            if "min_endpoint" in updates:
-                decode_min_endpoint = updates["min_endpoint"]
-            if "min_gpu_budget" in updates:
-                min_gpu_budget = updates["min_gpu_budget"]
-            if "max_gpu_budget" in updates:
-                max_gpu_budget = updates["max_gpu_budget"]
+        # Linearize configuration updates with effect admission. A patch that
+        # wins this lock invalidates the old generation before any remote task
+        # is created; an effect that wins is already admitted before the patch.
+        async with self._effect_admission_lock:
+            async with self._bounded_config_lock():
+                (
+                    prefill_min_endpoint,
+                    decode_min_endpoint,
+                ) = self.config.active_min_endpoints()
+                min_gpu_budget = self.config.min_gpu_budget
+                max_gpu_budget = self.config.max_gpu_budget
+                if "prefill_min_endpoint" in updates:
+                    prefill_min_endpoint = updates["prefill_min_endpoint"]
+                if "decode_min_endpoint" in updates:
+                    decode_min_endpoint = updates["decode_min_endpoint"]
+                if "min_endpoint" in updates:
+                    decode_min_endpoint = updates["min_endpoint"]
+                if "min_gpu_budget" in updates:
+                    min_gpu_budget = updates["min_gpu_budget"]
+                if "max_gpu_budget" in updates:
+                    max_gpu_budget = updates["max_gpu_budget"]
 
-            errors = self._runtime_configuration_errors(
-                prefill_min_endpoint,
-                decode_min_endpoint,
-                min_gpu_budget,
-                max_gpu_budget,
-            )
-            if errors:
-                raise _MinimumEndpointValidationError("; ".join(errors))
+                errors = self._runtime_configuration_errors(
+                    prefill_min_endpoint,
+                    decode_min_endpoint,
+                    min_gpu_budget,
+                    max_gpu_budget,
+                )
+                if errors:
+                    raise _MinimumEndpointValidationError("; ".join(errors))
 
-            before = self._min_endpoint_response()
-            for field, value in updates.items():
-                setattr(self.config, field, value)
-            self._config_generation += 1
-            after = self._min_endpoint_response()
-            logger.info(
-                "Updated planner runtime configuration: %s -> %s", before, after
-            )
-            return after
+                before = self._min_endpoint_response()
+                for field, value in updates.items():
+                    setattr(self.config, field, value)
+                self._config_generation += 1
+                after = self._min_endpoint_response()
+                logger.info(
+                    "Updated planner runtime configuration: %s -> %s", before, after
+                )
+                return after
 
     def _runtime_namespace(self) -> str:
         return self.environment.runtime_namespace()
@@ -672,22 +677,6 @@ class NativePlannerBase:
     async def _apply_effects(self, effects: PlannerEffects) -> None:
         pass
 
-    async def _apply_effects_if_current(
-        self, effects: PlannerEffects, config_generation: int
-    ) -> None:
-        """Submit effects only if their runtime configuration is still current."""
-
-        async with self._config_lock:
-            if config_generation != self._config_generation:
-                logger.info(
-                    "Discarding planner effects computed at runtime config generation "
-                    "%d; current generation is %d",
-                    config_generation,
-                    self._config_generation,
-                )
-                return
-        await self._apply_effects(effects)
-
     def _effect_submission_done(self, task: asyncio.Task[None]) -> None:
         if self._effect_submission_task is not task:
             return
@@ -726,41 +715,56 @@ class NativePlannerBase:
     ) -> None:
         """Submit at most one effect without cancelling an unacknowledged request."""
 
-        if self._effect_submission_outcome_unknown is not None:
-            if not self._effect_submission_hold_logged:
-                logger.error(
-                    "Holding planner effects because a previous submission outcome "
-                    "is unknown; runtime configuration remains available, but "
-                    "automatic submission requires a Planner restart after the "
-                    "deployment state is verified"
-                )
-                self._effect_submission_hold_logged = True
-            return
+        async with self._effect_admission_lock:
+            if self._effect_submission_outcome_unknown is not None:
+                if not self._effect_submission_hold_logged:
+                    logger.error(
+                        "Holding planner effects because a previous submission outcome "
+                        "is unknown; runtime configuration remains available, but "
+                        "automatic submission requires a Planner restart after the "
+                        "deployment state is verified"
+                    )
+                    self._effect_submission_hold_logged = True
+                return
 
-        pending = self._effect_submission_task
-        if pending is not None:
-            if not pending.done():
-                logger.warning(
-                    "Skipping planner effect submission while the previous request "
-                    "is still awaiting acknowledgement"
-                )
-                return
-            if pending.cancelled():
-                self._mark_effect_submission_unknown("submission task was cancelled")
-                return
-            exception = pending.exception()
-            if exception is not None:
-                self._mark_effect_submission_unknown(
-                    f"submission failed: {exception}", exception
-                )
-                return
-            self._effect_submission_task = None
+            pending = self._effect_submission_task
+            if pending is not None:
+                if not pending.done():
+                    logger.warning(
+                        "Skipping planner effect submission while the previous request "
+                        "is still awaiting acknowledgement"
+                    )
+                    return
+                if pending.cancelled():
+                    self._mark_effect_submission_unknown(
+                        "submission task was cancelled"
+                    )
+                    return
+                exception = pending.exception()
+                if exception is not None:
+                    self._mark_effect_submission_unknown(
+                        f"submission failed: {exception}", exception
+                    )
+                    return
+                self._effect_submission_task = None
 
-        task = asyncio.create_task(
-            self._apply_effects_if_current(effects, config_generation)
-        )
-        self._effect_submission_task = task
-        task.add_done_callback(self._effect_submission_done)
+            async with self._config_lock:
+                if config_generation != self._config_generation:
+                    logger.info(
+                        "Discarding planner effects computed at runtime config generation "
+                        "%d; current generation is %d",
+                        config_generation,
+                        self._config_generation,
+                    )
+                    return
+
+                # Creating the remote task is the admission point. PATCH uses
+                # the same outer lock, so no update can linearize between the
+                # generation check and admission.
+                task = asyncio.create_task(self._apply_effects(effects))
+                self._effect_submission_task = task
+                task.add_done_callback(self._effect_submission_done)
+
         try:
             await asyncio.wait_for(
                 asyncio.shield(task), timeout=_EFFECT_SUBMISSION_WAIT_SECONDS

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -57,6 +57,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _CONFIG_LOCK_TIMEOUT_SECONDS = 10.0
+# A tick waits briefly for the common fast submission path, then leaves the
+# task running. It is deliberately not cancelled: a remote request may have
+# been accepted even when its response has not arrived, so retrying could
+# duplicate an unacknowledged action.
+_EFFECT_SUBMISSION_WAIT_SECONDS = 5.0
 _GPU_SHAPE_RETRY_MIN_SECONDS = 0.1
 _GPU_SHAPE_RETRY_MAX_SECONDS = 5.0
 
@@ -149,6 +154,8 @@ class NativePlannerBase:
         self._dashboard_runner: Optional[aiohttp.web.AppRunner] = None
         self._control_api_runner: Optional[aiohttp.web.AppRunner] = None
         self._config_lock = asyncio.Lock()
+        self._config_generation = 0
+        self._effect_submission_task: Optional[asyncio.Task[None]] = None
         self._diagnostics_finalized = False
         self._environment_initialized = False
         self._engine: Optional[EngineProtocol] = None
@@ -226,6 +233,17 @@ class NativePlannerBase:
                 await engine.shutdown()
             except Exception:
                 logger.exception("Failed to stop planner engine")
+
+        effect_submission_task = self._effect_submission_task
+        self._effect_submission_task = None
+        if effect_submission_task is not None and not effect_submission_task.done():
+            effect_submission_task.cancel()
+            try:
+                await effect_submission_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.exception("Failed pending planner effect submission")
 
         if self._environment_initialized:
             self._environment_initialized = False
@@ -417,6 +435,7 @@ class NativePlannerBase:
             before = self._min_endpoint_response()
             for field, value in updates.items():
                 setattr(self.config, field, value)
+            self._config_generation += 1
             after = self._min_endpoint_response()
             logger.info(
                 "Updated planner runtime configuration: %s -> %s", before, after
@@ -650,6 +669,64 @@ class NativePlannerBase:
     async def _apply_effects(self, effects: PlannerEffects) -> None:
         pass
 
+    async def _apply_effects_if_current(
+        self, effects: PlannerEffects, config_generation: int
+    ) -> None:
+        """Submit effects only if their runtime configuration is still current."""
+
+        async with self._config_lock:
+            if config_generation != self._config_generation:
+                logger.info(
+                    "Discarding planner effects computed at runtime config generation "
+                    "%d; current generation is %d",
+                    config_generation,
+                    self._config_generation,
+                )
+                return
+        await self._apply_effects(effects)
+
+    def _effect_submission_done(self, task: asyncio.Task[None]) -> None:
+        if self._effect_submission_task is task:
+            self._effect_submission_task = None
+        if task.cancelled():
+            return
+        exception = task.exception()
+        if exception is not None:
+            logger.error(
+                "Planner effect submission failed",
+                exc_info=(type(exception), exception, exception.__traceback__),
+            )
+
+    async def _submit_effects(
+        self, effects: PlannerEffects, config_generation: int
+    ) -> None:
+        """Submit at most one effect without cancelling an unacknowledged request."""
+
+        pending = self._effect_submission_task
+        if pending is not None and not pending.done():
+            logger.warning(
+                "Skipping planner effect submission while the previous request "
+                "is still awaiting acknowledgement"
+            )
+            return
+
+        task = asyncio.create_task(
+            self._apply_effects_if_current(effects, config_generation)
+        )
+        self._effect_submission_task = task
+        task.add_done_callback(self._effect_submission_done)
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(task), timeout=_EFFECT_SUBMISSION_WAIT_SECONDS
+            )
+        except TimeoutError:
+            logger.warning(
+                "Planner effect submission is still awaiting acknowledgement "
+                "after %.1fs; runtime configuration remains available and no "
+                "second effect will be submitted until it completes",
+                _EFFECT_SUBMISSION_WAIT_SECONDS,
+            )
+
     def _current_worker_counts(self) -> tuple[int, int]:
         """Best-known current (prefill, decode) ready worker counts.
 
@@ -865,11 +942,13 @@ class NativePlannerBase:
         if tick_input.worker_counts is not None:
             self._last_worker_counts = tick_input.worker_counts
 
-        # Keep runtime configuration stable through decision submission. Scaling
-        # calls are non-blocking, so the lock is released before the rollout.
+        # Snapshot the runtime configuration generation with the decision. The
+        # external submission does not hold this lock: it may await a remote
+        # response indefinitely, while GET/PATCH must remain available.
         async with self._config_lock:
+            config_generation = self._config_generation
             effects = await engine.tick(tick, tick_input)
-            await self._apply_effects(effects)
+        await self._submit_effects(effects, config_generation)
         emit_diagnostics = self._should_emit_tick_diagnostics(tick, effects)
         if emit_diagnostics:
             self._report_diagnostics(tick, effects.diagnostics)

--- a/components/src/dynamo/planner/plugins/orchestrator/engine_adapter.py
+++ b/components/src/dynamo/planner/plugins/orchestrator/engine_adapter.py
@@ -1048,8 +1048,6 @@ class OrchestratorEngineAdapter:
         return ScalingDecision(num_prefill=num_p, num_decode=num_d)
 
     def _gpu_budget_reconcile_needed(self, worker_counts: WorkerCounts) -> bool:
-        """Return whether stable ready counts are outside the active GPU band."""
-
         min_gpus = self._config.min_gpu_budget
         max_gpus = self._config.max_gpu_budget
         if min_gpus < 0 and max_gpus < 0:
@@ -1057,16 +1055,16 @@ class OrchestratorEngineAdapter:
 
         mode = self._config.mode
         if mode == "prefill":
-            components = (
+            components = [
                 (worker_counts.ready_num_prefill, self._capabilities.prefill),
-            )
+            ]
         elif mode in ("decode", "agg"):
-            components = ((worker_counts.ready_num_decode, self._capabilities.decode),)
+            components = [(worker_counts.ready_num_decode, self._capabilities.decode)]
         elif mode == "disagg":
-            components = (
+            components = [
                 (worker_counts.ready_num_prefill, self._capabilities.prefill),
                 (worker_counts.ready_num_decode, self._capabilities.decode),
-            )
+            ]
         else:
             return False
 

--- a/components/src/dynamo/planner/plugins/orchestrator/engine_adapter.py
+++ b/components/src/dynamo/planner/plugins/orchestrator/engine_adapter.py
@@ -70,6 +70,8 @@ if TYPE_CHECKING:
 
 from dynamo.planner.core.budget import (
     apply_power_budget,
+    bounds_for_total,
+    compute_tolerance,
     proportional_clamp_pair,
     proportional_clamp_single,
 )
@@ -949,6 +951,9 @@ class OrchestratorEngineAdapter:
             worker_counts.expected_num_decode,
             worker_counts.decode_scaling_in_progress,
         )
+        gpu_budget_reconcile = (
+            not deployment_scaling and self._gpu_budget_reconcile_needed(worker_counts)
+        )
         prefill_floor_needed = (
             mode in ("disagg", "prefill")
             and not deployment_scaling
@@ -983,16 +988,22 @@ class OrchestratorEngineAdapter:
                 not prefill_proposed
                 and not prefill_floor_needed
                 and not floor_reconcile
+                and not gpu_budget_reconcile
             ):
                 num_p = None
-            if not decode_proposed and not decode_floor_needed and not floor_reconcile:
+            if (
+                not decode_proposed
+                and not decode_floor_needed
+                and not floor_reconcile
+                and not gpu_budget_reconcile
+            ):
                 num_d = None
             if num_p is None and num_d is None:
                 return None
         else:
             p_unchanged = (num_p is None) or (num_p == current_p)
             d_unchanged = (num_d is None) or (num_d == current_d)
-            if p_unchanged and d_unchanged:
+            if p_unchanged and d_unchanged and not gpu_budget_reconcile:
                 return None
 
         num_p, num_d = self._apply_final_budget(num_p, num_d, worker_counts)
@@ -1035,6 +1046,46 @@ class OrchestratorEngineAdapter:
                 return None
 
         return ScalingDecision(num_prefill=num_p, num_decode=num_d)
+
+    def _gpu_budget_reconcile_needed(self, worker_counts: WorkerCounts) -> bool:
+        """Return whether stable ready counts are outside the active GPU band."""
+
+        min_gpus = self._config.min_gpu_budget
+        max_gpus = self._config.max_gpu_budget
+        if min_gpus < 0 and max_gpus < 0:
+            return False
+
+        mode = self._config.mode
+        if mode == "prefill":
+            components = (
+                (worker_counts.ready_num_prefill, self._capabilities.prefill),
+            )
+        elif mode in ("decode", "agg"):
+            components = ((worker_counts.ready_num_decode, self._capabilities.decode),)
+        elif mode == "disagg":
+            components = (
+                (worker_counts.ready_num_prefill, self._capabilities.prefill),
+                (worker_counts.ready_num_decode, self._capabilities.decode),
+            )
+        else:
+            return False
+
+        total_gpus = 0
+        gpu_costs: list[int] = []
+        for replicas, capabilities in components:
+            if replicas is None or capabilities is None:
+                return False
+            gpu_cost = capabilities.resolved_gpu_cost_per_replica
+            if gpu_cost is None or gpu_cost <= 0:
+                return False
+            total_gpus += replicas * gpu_cost
+            gpu_costs.append(gpu_cost)
+
+        tolerance = (
+            compute_tolerance(gpu_costs) if min_gpus >= 0 and max_gpus >= 0 else 0
+        )
+        in_bounds, _ = bounds_for_total(total_gpus, min_gpus, max_gpus, tolerance)
+        return not in_bounds
 
     def _apply_final_budget(
         self,

--- a/components/src/dynamo/planner/tests/plugins/orchestrator/test_engine_adapter.py
+++ b/components/src/dynamo/planner/tests/plugins/orchestrator/test_engine_adapter.py
@@ -585,26 +585,50 @@ def test_power_off_partial_proposal_keeps_joint_gpu_clamp():
     assert adapter._apply_gpu_final_budget(None, 7, wc) == (None, 4)
 
 
-def test_project_scale_to_does_not_apply_budget_on_baseline_only_noop():
+@pytest.mark.asyncio
+async def test_tick_reconciles_runtime_gpu_budget_on_baseline_only_noop():
     cfg = PlannerConfig(
         mode="disagg",
         enable_load_scaling=True,
         enable_throughput_scaling=True,
         optimization_target="sla",
         served_model_name="test",
-        max_gpu_budget=4,
+        max_gpu_budget=16,
         min_gpu_budget=-1,
     )
     adapter = OrchestratorEngineAdapter(cfg, _disagg_caps())
-    wc = WorkerCounts(ready_num_prefill=6, ready_num_decode=6)
+    initial_tick = adapter.initial_tick(start_s=0.0)
+    worker_counts = WorkerCounts(
+        ready_num_prefill=6,
+        ready_num_decode=6,
+        expected_num_prefill=6,
+        expected_num_decode=6,
+    )
     outcome = _apply_outcome(
         [
             ComponentTarget(sub_component_type="prefill", replicas=6),
             ComponentTarget(sub_component_type="decode", replicas=6),
-        ]
+        ],
+        proposed=set(),
     )
 
-    assert adapter._project_scale_to(outcome, wc) is None
+    async def hold_tick(ctx, baseline, *, tick_now=None):
+        return outcome
+
+    adapter._orchestrator.tick = hold_tick  # type: ignore[method-assign]
+
+    # Simulate the runtime API mutating the shared PlannerConfig after the
+    # adapter has been constructed. The plugins otherwise HOLD at (6, 6).
+    cfg.max_gpu_budget = 4
+    effects = await adapter.tick(
+        initial_tick,
+        TickInput(now_s=initial_tick.at_s, worker_counts=worker_counts),
+    )
+
+    assert effects.scale_to is not None
+    assert effects.scale_to.num_prefill is not None
+    assert effects.scale_to.num_decode is not None
+    assert effects.scale_to.num_prefill + effects.scale_to.num_decode <= 4
 
 
 def test_tick_input_to_context_maps_observations_and_fpm():

--- a/components/src/dynamo/planner/tests/unit/test_control_api.py
+++ b/components/src/dynamo/planner/tests/unit/test_control_api.py
@@ -91,11 +91,15 @@ async def test_disagg_get_and_partial_patch_are_mode_shaped_and_atomic():
         "mode": "disagg",
         "prefill_min_endpoint": 3,
         "decode_min_endpoint": 2,
+        "min_gpu_budget": -1,
+        "max_gpu_budget": 20,
     }
     assert await planner.patch_min_endpoints({"decode_min_endpoint": 4}) == {
         "mode": "disagg",
         "prefill_min_endpoint": 3,
         "decode_min_endpoint": 4,
+        "min_gpu_budget": -1,
+        "max_gpu_budget": 20,
     }
     assert planner.config.prefill_min_endpoint == 3
     assert planner.config.decode_min_endpoint == 4
@@ -108,14 +112,153 @@ async def test_agg_runtime_patch_updates_min_endpoint():
     assert await planner.patch_min_endpoints({"min_endpoint": 5}) == {
         "mode": "agg",
         "min_endpoint": 5,
+        "min_gpu_budget": -1,
+        "max_gpu_budget": 20,
     }
     assert planner.config.min_endpoint == 5
 
     assert await planner.patch_min_endpoints({"min_endpoint": 0}) == {
         "mode": "agg",
         "min_endpoint": 0,
+        "min_gpu_budget": -1,
+        "max_gpu_budget": 20,
     }
     assert planner.config.min_endpoint == 0
+
+
+@pytest.mark.asyncio
+async def test_runtime_patch_updates_gpu_budgets_only():
+    planner = _planner("disagg")
+
+    assert await planner.patch_min_endpoints(
+        {"min_gpu_budget": 12, "max_gpu_budget": 24}
+    ) == {
+        "mode": "disagg",
+        "prefill_min_endpoint": 1,
+        "decode_min_endpoint": 1,
+        "min_gpu_budget": 12,
+        "max_gpu_budget": 24,
+    }
+    assert planner.config.min_gpu_budget == 12
+    assert planner.config.max_gpu_budget == 24
+
+
+@pytest.mark.asyncio
+async def test_http_patch_updates_gpu_budgets_and_returns_complete_configuration():
+    from aiohttp.test_utils import TestClient, TestServer
+
+    planner = _planner("disagg")
+    client = TestClient(TestServer(_build_app(planner)))
+    await client.start_server()
+    try:
+        response = await client.patch(
+            "/v1/min-endpoints",
+            json={"min_gpu_budget": 16, "max_gpu_budget": 64},
+        )
+
+        assert response.status == 200
+        assert await response.json() == {
+            "mode": "disagg",
+            "prefill_min_endpoint": 1,
+            "decode_min_endpoint": 1,
+            "min_gpu_budget": 16,
+            "max_gpu_budget": 64,
+        }
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_patch_atomically_updates_endpoints_and_gpu_budgets():
+    planner = _planner(
+        "disagg", prefill_gpu_cost=1, decode_gpu_cost=1, max_gpu_budget=20
+    )
+
+    response = await planner.patch_min_endpoints(
+        {
+            "prefill_min_endpoint": 8,
+            "decode_min_endpoint": 8,
+            "min_gpu_budget": 16,
+            "max_gpu_budget": 64,
+        }
+    )
+
+    assert response == {
+        "mode": "disagg",
+        "prefill_min_endpoint": 8,
+        "decode_min_endpoint": 8,
+        "min_gpu_budget": 16,
+        "max_gpu_budget": 64,
+    }
+    assert planner.config.prefill_min_endpoint == 8
+    assert planner.config.decode_min_endpoint == 8
+    assert planner.config.min_gpu_budget == 16
+    assert planner.config.max_gpu_budget == 64
+
+
+@pytest.mark.asyncio
+async def test_runtime_patch_rejects_invalid_gpu_budget_band_without_mutation():
+    planner = _planner("disagg", min_endpoint=2)
+
+    with pytest.raises(ValueError, match="min_gpu_budget=24 exceeds max_gpu_budget=16"):
+        await planner.patch_min_endpoints(
+            {
+                "prefill_min_endpoint": 4,
+                "decode_min_endpoint": 4,
+                "min_gpu_budget": 24,
+                "max_gpu_budget": 16,
+            }
+        )
+
+    assert planner.config.prefill_min_endpoint is None
+    assert planner.config.decode_min_endpoint is None
+    assert planner.config.min_gpu_budget == -1
+    assert planner.config.max_gpu_budget == 20
+
+
+@pytest.mark.asyncio
+async def test_runtime_patch_uses_prospective_max_for_endpoint_footprint():
+    planner = _planner(
+        "disagg", prefill_gpu_cost=1, decode_gpu_cost=1, max_gpu_budget=20
+    )
+
+    with pytest.raises(
+        ValueError, match="requires 16 GPUs, exceeding max_gpu_budget=15"
+    ):
+        await planner.patch_min_endpoints(
+            {
+                "prefill_min_endpoint": 8,
+                "decode_min_endpoint": 8,
+                "max_gpu_budget": 15,
+            }
+        )
+
+    assert planner.config.prefill_min_endpoint is None
+    assert planner.config.decode_min_endpoint is None
+    assert planner.config.max_gpu_budget == 20
+
+
+@pytest.mark.asyncio
+async def test_runtime_patch_supports_disabling_each_gpu_budget():
+    planner = _planner("disagg", min_gpu_budget=12, max_gpu_budget=20)
+
+    response = await planner.patch_min_endpoints(
+        {"min_gpu_budget": -1, "max_gpu_budget": -1}
+    )
+
+    assert response["min_gpu_budget"] == -1
+    assert response["max_gpu_budget"] == -1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["disagg", "prefill", "decode", "agg"])
+async def test_gpu_budget_fields_are_active_in_every_mode(mode):
+    planner = _planner(mode)
+
+    response = await planner.patch_min_endpoints({"max_gpu_budget": 24})
+
+    assert response["max_gpu_budget"] == 24
+    assert planner.config.max_gpu_budget == 24
 
 
 @pytest.mark.asyncio
@@ -132,11 +275,18 @@ async def test_http_validation_and_budget_rejection_leave_config_unchanged():
             "mode": "disagg",
             "prefill_min_endpoint": 1,
             "decode_min_endpoint": 1,
+            "min_gpu_budget": -1,
+            "max_gpu_budget": 8,
         }
 
-        for payload in ({}, {"unknown": 2}):
+        for payload in (
+            {},
+            {"unknown": 2},
+            {"min_gpu_budget": 4, "unknown": 2},
+        ):
             response = await client.patch("/v1/min-endpoints", json=payload)
             assert response.status == 400
+            assert planner.config.min_gpu_budget == -1
 
         for payload in (
             {"prefill_min_endpoint": None},
@@ -144,6 +294,12 @@ async def test_http_validation_and_budget_rejection_leave_config_unchanged():
             {"prefill_min_endpoint": "2"},
             {"prefill_min_endpoint": True},
             {"prefill_min_endpoint": 2.5},
+            {"min_gpu_budget": None},
+            {"min_gpu_budget": "2"},
+            {"min_gpu_budget": True},
+            {"min_gpu_budget": -2},
+            {"max_gpu_budget": 2.5},
+            {"max_gpu_budget": -2},
         ):
             response = await client.patch("/v1/min-endpoints", json=payload)
             assert response.status == 422
@@ -164,18 +320,30 @@ async def test_http_validation_and_budget_rejection_leave_config_unchanged():
 
 
 @pytest.mark.asyncio
-async def test_http_rejects_fields_inactive_for_mode():
+@pytest.mark.parametrize(
+    "mode,inactive_field",
+    [
+        ("disagg", "min_endpoint"),
+        ("prefill", "decode_min_endpoint"),
+        ("decode", "prefill_min_endpoint"),
+        ("agg", "decode_min_endpoint"),
+    ],
+)
+async def test_http_rejects_inactive_endpoint_without_applying_budget(
+    mode, inactive_field
+):
     from aiohttp.test_utils import TestClient, TestServer
 
-    planner = _planner("agg")
+    planner = _planner(mode)
     client = TestClient(TestServer(_build_app(planner)))
     await client.start_server()
     try:
         response = await client.patch(
-            "/v1/min-endpoints", json={"decode_min_endpoint": 2}
+            "/v1/min-endpoints",
+            json={inactive_field: 2, "max_gpu_budget": 32},
         )
         assert response.status == 422
-        assert planner.config.min_endpoint == 1
+        assert planner.config.max_gpu_budget == 20
     finally:
         await client.close()
 
@@ -184,6 +352,16 @@ def test_startup_validation_rejects_minimum_gpu_footprint():
     planner = _planner("disagg", max_gpu_budget=2)
 
     with pytest.raises(DeploymentValidationError, match="requires 3 GPUs"):
+        planner._validate_min_endpoint_budgets_at_startup()
+
+
+def test_startup_validation_rejects_invalid_gpu_budget_band():
+    planner = _planner("disagg", min_gpu_budget=21, max_gpu_budget=20)
+
+    with pytest.raises(
+        DeploymentValidationError,
+        match="min_gpu_budget=21 exceeds max_gpu_budget=20",
+    ):
         planner._validate_min_endpoint_budgets_at_startup()
 
 
@@ -226,7 +404,12 @@ async def test_runtime_patch_waits_for_tick_lock():
         await asyncio.sleep(0)
         assert not patch_task.done()
 
-    assert await patch_task == {"mode": "agg", "min_endpoint": 2}
+    assert await patch_task == {
+        "mode": "agg",
+        "min_endpoint": 2,
+        "min_gpu_budget": -1,
+        "max_gpu_budget": 20,
+    }
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/planner/tests/unit/test_control_api.py
+++ b/components/src/dynamo/planner/tests/unit/test_control_api.py
@@ -451,6 +451,25 @@ async def test_shutdown_finalizes_diagnostics_once():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_retrieves_completed_effect_submission_error(caplog):
+    planner = _planner("agg")
+
+    async def fail_submission():
+        raise RuntimeError("late submission failure")
+
+    submission_task = asyncio.create_task(fail_submission())
+    await asyncio.sleep(0)
+    assert submission_task.done()
+    planner._effect_submission_task = submission_task
+
+    await planner._shutdown_runtime()
+
+    assert planner._effect_submission_task is None
+    assert "Failed pending planner effect submission" in caplog.text
+    assert "late submission failure" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_control_api_port_zero_disables_server_startup():
     planner = _planner("agg", control_api_port=0)
     planner._bootstrap_regression = AsyncMock()

--- a/components/src/dynamo/planner/tests/unit/test_control_api.py
+++ b/components/src/dynamo/planner/tests/unit/test_control_api.py
@@ -252,7 +252,7 @@ async def test_runtime_patch_supports_disabling_each_gpu_budget():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("mode", ["disagg", "prefill", "decode", "agg"])
+@pytest.mark.parametrize("mode", ["prefill", "decode", "agg"])
 async def test_gpu_budget_fields_are_active_in_every_mode(mode):
     planner = _planner(mode)
 

--- a/components/src/dynamo/planner/tests/unit/test_control_api.py
+++ b/components/src/dynamo/planner/tests/unit/test_control_api.py
@@ -144,6 +144,7 @@ async def test_runtime_patch_updates_gpu_budgets_only():
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(5)
 async def test_http_patch_updates_gpu_budgets_and_returns_complete_configuration():
     from aiohttp.test_utils import TestClient, TestServer
 
@@ -294,11 +295,7 @@ async def test_http_validation_and_budget_rejection_leave_config_unchanged():
             {"prefill_min_endpoint": "2"},
             {"prefill_min_endpoint": True},
             {"prefill_min_endpoint": 2.5},
-            {"min_gpu_budget": None},
-            {"min_gpu_budget": "2"},
-            {"min_gpu_budget": True},
             {"min_gpu_budget": -2},
-            {"max_gpu_budget": 2.5},
             {"max_gpu_budget": -2},
         ):
             response = await client.patch("/v1/min-endpoints", json=payload)
@@ -320,6 +317,7 @@ async def test_http_validation_and_budget_rejection_leave_config_unchanged():
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(5)
 @pytest.mark.parametrize(
     "mode,inactive_field",
     [

--- a/components/src/dynamo/planner/tests/unit/test_tick_lifecycle.py
+++ b/components/src/dynamo/planner/tests/unit/test_tick_lifecycle.py
@@ -61,6 +61,7 @@ async def test_complete_tick_applies_scaling_only_when_not_advisory(advisory):
         require_decode=True,
     )
     next_tick = ScheduledTick(at_s=20.0)
+    runtime_patch_tasks = []
 
     class RecordingEngine:
         async def observe(self, scheduled_tick, now_s):
@@ -86,7 +87,13 @@ async def test_complete_tick_applies_scaling_only_when_not_advisory(advisory):
     class RecordingAggPlanner(AggPlanner):
         async def _apply_effects(self, effects):
             events.append("apply effects")
-            assert not self._config_lock.locked()
+            assert self._config_lock.locked()
+            patch_task = asyncio.create_task(
+                self.patch_min_endpoints({"max_gpu_budget": 9})
+            )
+            runtime_patch_tasks.append(patch_task)
+            await asyncio.sleep(0)
+            assert not patch_task.done()
             await super()._apply_effects(effects)
 
     config = PlannerConfig(
@@ -126,6 +133,7 @@ async def test_complete_tick_applies_scaling_only_when_not_advisory(advisory):
     else:
         assert applied_targets == []
     assert events == expected_events
+    assert (await runtime_patch_tasks[0])["max_gpu_budget"] == 9
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/planner/tests/unit/test_tick_lifecycle.py
+++ b/components/src/dynamo/planner/tests/unit/test_tick_lifecycle.py
@@ -203,6 +203,49 @@ async def test_runtime_patch_queued_during_decision_discards_stale_effects():
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(5)
+async def test_effect_admission_linearizes_before_runtime_patch():
+    state = DeploymentState()
+    state.decode.info = WorkerInfo(k8s_name="decode-worker")
+    state.decode.num_gpus = 1
+    environment = MagicMock()
+    environment.deployment_state.return_value = state
+    submitted_effects = []
+
+    class RecordingAggPlanner(AggPlanner):
+        async def _apply_effects(self, effects):
+            submitted_effects.append(effects)
+
+    config = PlannerConfig(
+        mode="agg",
+        namespace="test-namespace",
+        max_gpu_budget=8,
+        metric_reporting_prometheus_port=0,
+        live_dashboard_port=0,
+        report_interval_hours=None,
+    )
+    with patch(
+        "dynamo.planner.core.base.PlannerPrometheusMetrics",
+        return_value=MagicMock(),
+    ):
+        planner = RecordingAggPlanner(None, config, environment)
+
+    effects = PlannerEffects(scale_to=ScalingDecision(num_decode=8))
+    await planner._effect_admission_lock.acquire()
+    submission_task = asyncio.create_task(planner._submit_effects(effects, 0))
+    await asyncio.sleep(0)
+    patch_task = asyncio.create_task(planner.patch_min_endpoints({"max_gpu_budget": 1}))
+    await asyncio.sleep(0)
+    planner._effect_admission_lock.release()
+
+    await submission_task
+    patch_response = await patch_task
+
+    assert submitted_effects == [effects]
+    assert patch_response["max_gpu_budget"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(5)
 async def test_stalled_effect_ack_keeps_runtime_api_available_without_duplicate():
     state = DeploymentState()
     state.decode.info = WorkerInfo(k8s_name="decode-worker")
@@ -358,7 +401,6 @@ async def test_late_submission_error_after_timeout_fails_closed_without_retry(ca
         await pending_submission
     await asyncio.sleep(0)
 
-    # Runtime configuration stays available in the fail-closed state.
     patch_response = await planner.patch_min_endpoints({"max_gpu_budget": 1})
     assert patch_response["max_gpu_budget"] == 1
     assert (await planner.get_min_endpoints())["max_gpu_budget"] == 1

--- a/components/src/dynamo/planner/tests/unit/test_tick_lifecycle.py
+++ b/components/src/dynamo/planner/tests/unit/test_tick_lifecycle.py
@@ -11,7 +11,13 @@ import pytest
 from dynamo.planner.config.defaults import SubComponentType
 from dynamo.planner.config.planner_config import PlannerConfig
 from dynamo.planner.core.adapters import AggPlanner
-from dynamo.planner.core.types import PlannerEffects, ScalingDecision, ScheduledTick
+from dynamo.planner.core.types import (
+    PlannerEffects,
+    ScalingDecision,
+    ScheduledTick,
+    TickInput,
+    WorkerCounts,
+)
 from dynamo.planner.environment.state import DeploymentState
 from dynamo.planner.errors import GPUShapeUnavailableError
 from dynamo.planner.monitoring.traffic_metrics import Metrics
@@ -61,7 +67,6 @@ async def test_complete_tick_applies_scaling_only_when_not_advisory(advisory):
         require_decode=True,
     )
     next_tick = ScheduledTick(at_s=20.0)
-    runtime_patch_tasks = []
 
     class RecordingEngine:
         async def observe(self, scheduled_tick, now_s):
@@ -87,13 +92,7 @@ async def test_complete_tick_applies_scaling_only_when_not_advisory(advisory):
     class RecordingAggPlanner(AggPlanner):
         async def _apply_effects(self, effects):
             events.append("apply effects")
-            assert self._config_lock.locked()
-            patch_task = asyncio.create_task(
-                self.patch_min_endpoints({"max_gpu_budget": 9})
-            )
-            runtime_patch_tasks.append(patch_task)
-            await asyncio.sleep(0)
-            assert not patch_task.done()
+            assert not self._config_lock.locked()
             await super()._apply_effects(effects)
 
     config = PlannerConfig(
@@ -133,7 +132,153 @@ async def test_complete_tick_applies_scaling_only_when_not_advisory(advisory):
     else:
         assert applied_targets == []
     assert events == expected_events
-    assert (await runtime_patch_tasks[0])["max_gpu_budget"] == 9
+
+
+@pytest.mark.asyncio
+async def test_runtime_patch_queued_during_decision_discards_stale_effects():
+    state = DeploymentState()
+    state.decode.info = WorkerInfo(k8s_name="decode-worker")
+    state.decode.num_gpus = 1
+    environment = MagicMock()
+    environment.deployment_state.return_value = state
+    environment.metrics_state.return_value = Metrics()
+
+    submitted_effects = []
+
+    class RecordingAggPlanner(AggPlanner):
+        async def _apply_effects(self, effects):
+            submitted_effects.append(effects)
+
+    config = PlannerConfig(
+        mode="agg",
+        namespace="test-namespace",
+        max_gpu_budget=8,
+        metric_reporting_prometheus_port=0,
+        live_dashboard_port=0,
+        report_interval_hours=None,
+    )
+    with patch(
+        "dynamo.planner.core.base.PlannerPrometheusMetrics",
+        return_value=MagicMock(),
+    ):
+        planner = RecordingAggPlanner(None, config, environment)
+
+    planner._refresh_and_update_capabilities = AsyncMock()
+    planner._observe_tick = AsyncMock(
+        return_value=TickInput(
+            now_s=10.0,
+            worker_counts=WorkerCounts(
+                ready_num_decode=2,
+                expected_num_decode=2,
+            ),
+        )
+    )
+    runtime_patch_tasks = []
+
+    class RacingEngine:
+        async def tick(self, scheduled_tick, tick_input):
+            del scheduled_tick, tick_input
+            patch_task = asyncio.create_task(
+                planner.patch_min_endpoints({"max_gpu_budget": 1})
+            )
+            runtime_patch_tasks.append(patch_task)
+            await asyncio.sleep(0)
+            assert not patch_task.done()
+            return PlannerEffects(
+                scale_to=ScalingDecision(num_decode=8),
+                next_tick=next_tick,
+            )
+
+    next_tick = ScheduledTick(at_s=20.0)
+    completed_tick = await planner._run_one_tick(
+        RacingEngine(), ScheduledTick(at_s=10.0)
+    )
+
+    assert (await runtime_patch_tasks[0])["max_gpu_budget"] == 1
+    assert completed_tick is next_tick
+    assert submitted_effects == []
+
+
+@pytest.mark.asyncio
+async def test_stalled_effect_ack_keeps_runtime_api_available_without_duplicate():
+    state = DeploymentState()
+    state.decode.info = WorkerInfo(k8s_name="decode-worker")
+    state.decode.num_gpus = 1
+    environment = MagicMock()
+    environment.deployment_state.return_value = state
+    environment.metrics_state.return_value = Metrics()
+
+    submission_started = asyncio.Event()
+    acknowledge_submission = asyncio.Event()
+    submitted_effects = []
+
+    class StalledAggPlanner(AggPlanner):
+        async def _apply_effects(self, effects):
+            submitted_effects.append(effects)
+            submission_started.set()
+            await acknowledge_submission.wait()
+
+    config = PlannerConfig(
+        mode="agg",
+        namespace="test-namespace",
+        max_gpu_budget=8,
+        metric_reporting_prometheus_port=0,
+        live_dashboard_port=0,
+        report_interval_hours=None,
+    )
+    with patch(
+        "dynamo.planner.core.base.PlannerPrometheusMetrics",
+        return_value=MagicMock(),
+    ):
+        planner = StalledAggPlanner(None, config, environment)
+
+    planner._refresh_and_update_capabilities = AsyncMock()
+    planner._observe_tick = AsyncMock(
+        return_value=TickInput(
+            now_s=10.0,
+            worker_counts=WorkerCounts(
+                ready_num_decode=2,
+                expected_num_decode=2,
+            ),
+        )
+    )
+    first_next_tick = ScheduledTick(at_s=20.0)
+    second_next_tick = ScheduledTick(at_s=30.0)
+    engine = MagicMock()
+    engine.tick = AsyncMock(
+        side_effect=[
+            PlannerEffects(
+                scale_to=ScalingDecision(num_decode=8),
+                next_tick=first_next_tick,
+            ),
+            PlannerEffects(
+                scale_to=ScalingDecision(num_decode=1),
+                next_tick=second_next_tick,
+            ),
+        ]
+    )
+
+    with patch("dynamo.planner.core.base._EFFECT_SUBMISSION_WAIT_SECONDS", 0.01):
+        completed_first_tick = await planner._run_one_tick(
+            engine, ScheduledTick(at_s=10.0)
+        )
+        await submission_started.wait()
+        patch_response = await planner.patch_min_endpoints({"max_gpu_budget": 1})
+        completed_second_tick = await planner._run_one_tick(engine, first_next_tick)
+
+    pending_submission = planner._effect_submission_task
+    assert pending_submission is not None
+    assert completed_first_tick is first_next_tick
+    assert completed_second_tick is second_next_tick
+    assert patch_response["max_gpu_budget"] == 1
+    assert (await planner.get_min_endpoints())["max_gpu_budget"] == 1
+    assert len(submitted_effects) == 1
+
+    acknowledge_submission.set()
+    await pending_submission
+    await asyncio.sleep(0)
+    assert planner._effect_submission_task is None
+    assert len(submitted_effects) == 1
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/planner/tests/unit/test_tick_lifecycle.py
+++ b/components/src/dynamo/planner/tests/unit/test_tick_lifecycle.py
@@ -282,6 +282,92 @@ async def test_stalled_effect_ack_keeps_runtime_api_available_without_duplicate(
 
 
 @pytest.mark.asyncio
+async def test_late_submission_error_after_timeout_fails_closed_without_retry(caplog):
+    state = DeploymentState()
+    state.decode.info = WorkerInfo(k8s_name="decode-worker")
+    state.decode.num_gpus = 1
+    environment = MagicMock()
+    environment.deployment_state.return_value = state
+    environment.metrics_state.return_value = Metrics()
+
+    fail_submission = asyncio.Event()
+    submission_attempts = []
+
+    class AmbiguousAggPlanner(AggPlanner):
+        async def _apply_effects(self, effects):
+            submission_attempts.append(effects)
+            await fail_submission.wait()
+            raise RuntimeError("response lost after request submission")
+
+    config = PlannerConfig(
+        mode="agg",
+        namespace="test-namespace",
+        max_gpu_budget=8,
+        metric_reporting_prometheus_port=0,
+        live_dashboard_port=0,
+        report_interval_hours=None,
+    )
+    with patch(
+        "dynamo.planner.core.base.PlannerPrometheusMetrics",
+        return_value=MagicMock(),
+    ):
+        planner = AmbiguousAggPlanner(None, config, environment)
+
+    planner._refresh_and_update_capabilities = AsyncMock()
+    planner._observe_tick = AsyncMock(
+        return_value=TickInput(
+            now_s=10.0,
+            worker_counts=WorkerCounts(
+                ready_num_decode=2,
+                expected_num_decode=2,
+            ),
+        )
+    )
+    first_next_tick = ScheduledTick(at_s=20.0)
+    second_next_tick = ScheduledTick(at_s=30.0)
+    engine = MagicMock()
+    engine.tick = AsyncMock(
+        side_effect=[
+            PlannerEffects(
+                scale_to=ScalingDecision(num_decode=8),
+                next_tick=first_next_tick,
+            ),
+            PlannerEffects(
+                scale_to=ScalingDecision(num_decode=1),
+                next_tick=second_next_tick,
+            ),
+        ]
+    )
+
+    with patch("dynamo.planner.core.base._EFFECT_SUBMISSION_WAIT_SECONDS", 0.01):
+        completed_first_tick = await planner._run_one_tick(
+            engine, ScheduledTick(at_s=10.0)
+        )
+
+    pending_submission = planner._effect_submission_task
+    assert pending_submission is not None
+    assert completed_first_tick is first_next_tick
+    assert len(submission_attempts) == 1
+
+    fail_submission.set()
+    with pytest.raises(RuntimeError, match="response lost"):
+        await pending_submission
+    await asyncio.sleep(0)
+
+    # Runtime configuration stays available in the fail-closed state.
+    patch_response = await planner.patch_min_endpoints({"max_gpu_budget": 1})
+    assert patch_response["max_gpu_budget"] == 1
+    assert (await planner.get_min_endpoints())["max_gpu_budget"] == 1
+
+    completed_second_tick = await planner._run_one_tick(engine, first_next_tick)
+
+    assert completed_second_tick is second_next_tick
+    assert len(submission_attempts) == 1
+    assert planner._effect_submission_outcome_unknown is not None
+    assert "requires a Planner restart" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_run_retries_authoritative_zero_shape_without_shutting_down():
     environment = MagicMock()
     config = PlannerConfig(

--- a/components/src/dynamo/planner/tests/unit/test_tick_lifecycle.py
+++ b/components/src/dynamo/planner/tests/unit/test_tick_lifecycle.py
@@ -36,6 +36,7 @@ pytestmark = [
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(5)
 @pytest.mark.parametrize("advisory", [False, True])
 async def test_complete_tick_applies_scaling_only_when_not_advisory(advisory):
     events = []
@@ -135,6 +136,7 @@ async def test_complete_tick_applies_scaling_only_when_not_advisory(advisory):
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(5)
 async def test_runtime_patch_queued_during_decision_discards_stale_effects():
     state = DeploymentState()
     state.decode.info = WorkerInfo(k8s_name="decode-worker")
@@ -200,6 +202,7 @@ async def test_runtime_patch_queued_during_decision_discards_stale_effects():
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(5)
 async def test_stalled_effect_ack_keeps_runtime_api_available_without_duplicate():
     state = DeploymentState()
     state.decode.info = WorkerInfo(k8s_name="decode-worker")
@@ -282,6 +285,7 @@ async def test_stalled_effect_ack_keeps_runtime_api_available_without_duplicate(
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(5)
 async def test_late_submission_error_after_timeout_fails_closed_without_retry(caplog):
     state = DeploymentState()
     state.decode.info = WorkerInfo(k8s_name="decode-worker")

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
@@ -191,6 +191,9 @@ curl --request PATCH http://127.0.0.1:9086/v1/min-endpoints \
 
 The update is atomic. Use `-1` to disable either GPU budget. The Planner rejects malformed values, fields that are inactive for the current mode, a `min_gpu_budget` greater than `max_gpu_budget` when both are enabled, and minimum footprints that exceed `max_gpu_budget` or the configured power budget. The same checks run at startup, so an infeasible minimum configuration fails before the Planner enters its tick loop. Scale-up has no per-component maximum endpoint setting; the existing GPU, power, Global Planner, and cluster-capacity limits remain the upper bounds.
 
+> [!WARNING]
+> If a scaling submission loses its acknowledgement after the Planner stops waiting for it, a later submission error leaves the outcome unknown. The Planner then stops automatic effect submission to avoid duplicating an action that the remote service might have applied. Runtime `GET` and `PATCH` remain available. Verify the deployment's desired and Ready replica counts, then restart the Planner to resume automatic submission.
+
 The same diagnostic signals surfaced in these reports are also exported as Prometheus metrics under the `dynamo_planner_*` prefix—for example estimated TTFT/ITL (`dynamo_planner_estimated_ttft_ms`, `dynamo_planner_estimated_itl_ms`), recommended replica counts (`dynamo_planner_predicted_num_prefill_replicas`, `dynamo_planner_predicted_num_decode_replicas`), per-engine capacity and FPM queue depths, and load/throughput scaling decision enums.
 
 The Replica Counts plot overlays actual prefill/decode replicas with discrete recommendation markers for the Planner's recommended prefill/decode replicas. When `advisory: true`, these recommended counts are suggestions only; the Planner records what it would do without applying the change.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
@@ -173,11 +173,11 @@ KV hit rate and speculative decode accept length are runtime engine/router signa
 | `report_interval_hours` | float or `null` | `24.0` | Generate an HTML diagnostics report every N hours (simulated time). Set to `null` to disable periodic report generation. |
 | `report_output_dir` | string | `./planner_reports` | Directory for HTML diagnostics reports. |
 | `live_dashboard_port` | int | `8080` | Port for the live diagnostics dashboard HTTP server. Set to `0` to disable. When enabled, visit `http://host:port/` to view a real-time Plotly report of accumulated snapshots. |
-| `control_api_port` | int | `9086` | Port for the loopback-only runtime minimum-endpoint API. Set to `0` to disable. |
+| `control_api_port` | int | `9086` | Port for the loopback-only runtime endpoint and GPU budget API. Set to `0` to disable. |
 
 ### Runtime Minimum Endpoint API
 
-The Planner listens on `127.0.0.1:<control_api_port>` and supports `GET` and partial `PATCH` requests at `/v1/min-endpoints`. The API has no authentication and is not exposed by a Kubernetes Service. It uses `prefill_min_endpoint` and `decode_min_endpoint` in disaggregated mode, the active component's field in single-component mode, and `min_endpoint` in aggregated mode. Updates are process-local, are not written back to the Planner ConfigMap, and apply to the next planner tick.
+The Planner listens on `127.0.0.1:<control_api_port>` and supports `GET` and partial `PATCH` requests at `/v1/min-endpoints`. The API has no authentication and is not exposed by a Kubernetes Service. It uses `prefill_min_endpoint` and `decode_min_endpoint` in disaggregated mode, the active component's field in single-component mode, and `min_endpoint` in aggregated mode. Every mode also accepts `min_gpu_budget` and `max_gpu_budget`. A response includes the active endpoint fields and both GPU budgets. Updates are process-local, are not written back to the Planner ConfigMap, and apply to the next planner tick.
 
 In Kubernetes, port-forward to the Planner pod and patch the active mode's field:
 
@@ -186,10 +186,10 @@ kubectl port-forward pod/<planner-pod> 9086:9086
 curl http://127.0.0.1:9086/v1/min-endpoints
 curl --request PATCH http://127.0.0.1:9086/v1/min-endpoints \
   --header 'Content-Type: application/json' \
-  --data '{"decode_min_endpoint": 3}'
+  --data '{"prefill_min_endpoint": 8, "decode_min_endpoint": 8, "min_gpu_budget": 16, "max_gpu_budget": 64}'
 ```
 
-The update is atomic. The Planner rejects malformed values, fields that are inactive for the current mode, and minimum footprints that exceed `max_gpu_budget` or the configured power budget. The same footprint checks run at startup, so an infeasible minimum configuration fails before the Planner enters its tick loop. Scale-up has no per-component maximum endpoint setting; the existing GPU, power, Global Planner, and cluster-capacity limits remain the upper bounds.
+The update is atomic. Use `-1` to disable either GPU budget. The Planner rejects malformed values, fields that are inactive for the current mode, a `min_gpu_budget` greater than `max_gpu_budget` when both are enabled, and minimum footprints that exceed `max_gpu_budget` or the configured power budget. The same checks run at startup, so an infeasible minimum configuration fails before the Planner enters its tick loop. Scale-up has no per-component maximum endpoint setting; the existing GPU, power, Global Planner, and cluster-capacity limits remain the upper bounds.
 
 The same diagnostic signals surfaced in these reports are also exported as Prometheus metrics under the `dynamo_planner_*` prefix—for example estimated TTFT/ITL (`dynamo_planner_estimated_ttft_ms`, `dynamo_planner_estimated_itl_ms`), recommended replica counts (`dynamo_planner_predicted_num_prefill_replicas`, `dynamo_planner_predicted_num_decode_replicas`), per-engine capacity and FPM queue depths, and load/throughput scaling decision enums.
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
@@ -179,7 +179,7 @@ KV hit rate and speculative decode accept length are runtime engine/router signa
 
 The Planner listens on `127.0.0.1:<control_api_port>` and supports `GET` and partial `PATCH` requests at `/v1/min-endpoints`. The API has no authentication and is not exposed by a Kubernetes Service. It uses `prefill_min_endpoint` and `decode_min_endpoint` in disaggregated mode, the active component's field in single-component mode, and `min_endpoint` in aggregated mode. Every mode also accepts `min_gpu_budget` and `max_gpu_budget`. A response includes the active endpoint fields and both GPU budgets. Updates are process-local, are not written back to the Planner ConfigMap, and apply to the next planner tick.
 
-In Kubernetes, port-forward to the Planner pod and patch the active mode's field:
+In Kubernetes, port-forward to the Planner pod and patch the active mode's field. The following example updates a Planner in `disagg` mode:
 
 ```bash
 kubectl port-forward pod/<planner-pod> 9086:9086

--- a/docs/fern/pages/reference/components/planner-configuration.mdx
+++ b/docs/fern/pages/reference/components/planner-configuration.mdx
@@ -183,7 +183,7 @@ When `optimization_target` is `throughput`, `latency`, or `load`, the Planner fo
   Minimum decode endpoints in `disagg` and `decode` modes. When set, replaces the decode value supplied by `min_endpoint`. Must be at least `1`.
 </ParamField>
 
-The Planner does not have per-component maximum endpoint fields. `max_gpu_budget`, the power budget when enabled, Global Planner allocation, and cluster capacity continue to bound scale-up. At startup and for runtime updates, the Planner rejects minimum endpoint combinations that cannot fit the configured GPU or power budget. Send `min_gpu_budget` and `max_gpu_budget` with the endpoint fields to `PATCH /v1/min-endpoints` to update them atomically at runtime. The response from `GET` or `PATCH` includes both budgets.
+The Planner does not have per-component maximum endpoint fields. `max_gpu_budget`, the power budget when enabled, Global Planner allocation, and cluster capacity continue to bound scale-up. At startup and for runtime updates, the Planner rejects minimum endpoint combinations that cannot fit the configured GPU or power budget. Send `min_gpu_budget` and `max_gpu_budget` with the endpoint fields to `PATCH /v1/min-endpoints` to update them atomically at runtime. Set either budget to `-1` to disable that bound. When both budgets are enabled, `min_gpu_budget` must not exceed `max_gpu_budget`. The response from `GET` or `PATCH` includes both budgets.
 
 <ParamField path="decode_engine_num_gpu" type="integer" default="null">
   GPUs per decode engine replica. Auto-detected from the deployment when unset.

--- a/docs/fern/pages/reference/components/planner-configuration.mdx
+++ b/docs/fern/pages/reference/components/planner-configuration.mdx
@@ -183,7 +183,7 @@ When `optimization_target` is `throughput`, `latency`, or `load`, the Planner fo
   Minimum decode endpoints in `disagg` and `decode` modes. When set, replaces the decode value supplied by `min_endpoint`. Must be at least `1`.
 </ParamField>
 
-The Planner does not have per-component maximum endpoint fields. `max_gpu_budget`, the power budget when enabled, Global Planner allocation, and cluster capacity continue to bound scale-up. At startup and for runtime updates, the Planner rejects minimum endpoint combinations that cannot fit the configured GPU or power budget.
+The Planner does not have per-component maximum endpoint fields. `max_gpu_budget`, the power budget when enabled, Global Planner allocation, and cluster capacity continue to bound scale-up. At startup and for runtime updates, the Planner rejects minimum endpoint combinations that cannot fit the configured GPU or power budget. Send `min_gpu_budget` and `max_gpu_budget` with the endpoint fields to `PATCH /v1/min-endpoints` to update them atomically at runtime. The response from `GET` or `PATCH` includes both budgets.
 
 <ParamField path="decode_engine_num_gpu" type="integer" default="null">
   GPUs per decode engine replica. Auto-detected from the deployment when unset.

--- a/docs/fern/translations/zh-CN/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
+++ b/docs/fern/translations/zh-CN/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
@@ -164,11 +164,11 @@ KV hit rate 和 speculative decode accept length 是引擎/Router 运行时信�
 | `report_interval_hours` | float or `null` | `24.0` | 每 N 小时（模拟时间）生成一份 HTML 诊断报告。设置为 `null` 可禁用周期性报告生成。 |
 | `report_output_dir` | string | `./planner_reports` | HTML 诊断报告的目录。 |
 | `live_dashboard_port` | int | `8080` | 实时诊断 dashboard HTTP 服务器的端口。设置为 `0` 可禁用。启用后，访问 `http://host:port/` 查看累积快照的实时 Plotly 报告。 |
-| `control_api_port` | int | `9086` | 仅监听 loopback 的运行时最小端点 API 端口。设置为 `0` 可禁用。 |
+| `control_api_port` | int | `9086` | 仅监听 loopback 的运行时端点和 GPU budget API 端口。设置为 `0` 可禁用。 |
 
 ### 运行时最小端点 API
 
-Planner 监听 `127.0.0.1:<control_api_port>`，并在 `/v1/min-endpoints` 支持 `GET` 和部分 `PATCH`。该 API 不提供认证，也不会通过 Kubernetes Service 暴露。分离模式使用 `prefill_min_endpoint` 和 `decode_min_endpoint`；单组件模式只使用当前组件对应的字段；聚合模式使用 `min_endpoint`。更新仅作用于当前进程，不会写回 Planner ConfigMap，并会在下一个 planner tick 生效。
+Planner 监听 `127.0.0.1:<control_api_port>`，并在 `/v1/min-endpoints` 支持 `GET` 和部分 `PATCH`。该 API 不提供认证，也不会通过 Kubernetes Service 暴露。分离模式使用 `prefill_min_endpoint` 和 `decode_min_endpoint`；单组件模式只使用当前组件对应的字段；聚合模式使用 `min_endpoint`。所有模式也都接受 `min_gpu_budget` 和 `max_gpu_budget`。响应包含当前模式的端点字段和两个 GPU budget。更新仅作用于当前进程，不会写回 Planner ConfigMap，并会在下一个 planner tick 生效。
 
 在 Kubernetes 中，先 port-forward 到 Planner pod，再修改当前模式对应的字段：
 
@@ -177,10 +177,10 @@ kubectl port-forward pod/<planner-pod> 9086:9086
 curl http://127.0.0.1:9086/v1/min-endpoints
 curl --request PATCH http://127.0.0.1:9086/v1/min-endpoints \
   --header 'Content-Type: application/json' \
-  --data '{"decode_min_endpoint": 3}'
+  --data '{"prefill_min_endpoint": 8, "decode_min_endpoint": 8, "min_gpu_budget": 16, "max_gpu_budget": 64}'
 ```
 
-更新是原子的。Planner 会拒绝格式错误的值、当前模式未启用的字段，以及超过 `max_gpu_budget` 或已配置 power budget 的最小资源组合。扩容没有组件级最大端点配置；现有的 GPU、power、Global Planner 和集群容量限制继续作为上限。
+更新是原子的。将任一 GPU budget 设为 `-1` 可禁用该限制。Planner 会拒绝格式错误的值、当前模式未启用的字段、两个 budget 都启用时大于 `max_gpu_budget` 的 `min_gpu_budget`，以及超过 `max_gpu_budget` 或已配置 power budget 的最小资源组合。相同的检查也会在启动时运行，因此不可行的最小配置会在 Planner 进入 tick loop 之前失败。扩容没有组件级最大端点配置；现有的 GPU、power、Global Planner 和集群容量限制继续作为上限。
 
 这些报告中展示的同一组诊断信号也会以 `dynamo_planner_*` 前缀导出为 Prometheus 指标，例如估算的 TTFT/ITL（`dynamo_planner_estimated_ttft_ms`、`dynamo_planner_estimated_itl_ms`）、建议副本数（`dynamo_planner_predicted_num_prefill_replicas`、`dynamo_planner_predicted_num_decode_replicas`）、每个引擎的容量和 FPM 队列深度，以及负载/吞吐量扩缩容决策枚举。
 

--- a/docs/fern/translations/zh-CN/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
+++ b/docs/fern/translations/zh-CN/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
@@ -170,7 +170,7 @@ KV hit rate 和 speculative decode accept length 是引擎/Router 运行时信�
 
 Planner 监听 `127.0.0.1:<control_api_port>`，并在 `/v1/min-endpoints` 支持 `GET` 和部分 `PATCH`。该 API 不提供认证，也不会通过 Kubernetes Service 暴露。分离模式使用 `prefill_min_endpoint` 和 `decode_min_endpoint`；单组件模式只使用当前组件对应的字段；聚合模式使用 `min_endpoint`。所有模式也都接受 `min_gpu_budget` 和 `max_gpu_budget`。响应包含当前模式的端点字段和两个 GPU budget。更新仅作用于当前进程，不会写回 Planner ConfigMap，并会在下一个 planner tick 生效。
 
-在 Kubernetes 中，先 port-forward 到 Planner pod，再修改当前模式对应的字段：
+在 Kubernetes 中，先 port-forward 到 Planner pod，再修改当前模式对应的字段。以下示例更新 `disagg` 模式的 Planner：
 
 ```bash
 kubectl port-forward pod/<planner-pod> 9086:9086

--- a/docs/fern/translations/zh-CN/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
+++ b/docs/fern/translations/zh-CN/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
@@ -182,6 +182,9 @@ curl --request PATCH http://127.0.0.1:9086/v1/min-endpoints \
 
 更新是原子的。将任一 GPU budget 设为 `-1` 可禁用该限制。Planner 会拒绝格式错误的值、当前模式未启用的字段、两个 budget 都启用时大于 `max_gpu_budget` 的 `min_gpu_budget`，以及超过 `max_gpu_budget` 或已配置 power budget 的最小资源组合。相同的检查也会在启动时运行，因此不可行的最小配置会在 Planner 进入 tick loop 之前失败。扩容没有组件级最大端点配置；现有的 GPU、power、Global Planner 和集群容量限制继续作为上限。
 
+> [!WARNING]
+> 如果 Planner 停止等待扩缩容提交后仍未收到确认，而该提交随后返回错误，Planner 将无法确定远端是否已执行操作。为避免重复执行远端可能已经应用的操作，Planner 会停止自动提交 effect。运行时 `GET` 和 `PATCH` 仍然可用。请先确认 deployment 的 desired 和 Ready 副本数，再重启 Planner 以恢复自动提交。
+
 这些报告中展示的同一组诊断信号也会以 `dynamo_planner_*` 前缀导出为 Prometheus 指标，例如估算的 TTFT/ITL（`dynamo_planner_estimated_ttft_ms`、`dynamo_planner_estimated_itl_ms`）、建议副本数（`dynamo_planner_predicted_num_prefill_replicas`、`dynamo_planner_predicted_num_decode_replicas`）、每个引擎的容量和 FPM 队列深度，以及负载/吞吐量扩缩容决策枚举。
 
 Replica Counts 图会将实际 prefill/decode 副本与 Planner 建议的 prefill/decode 副本的离散建议标记叠加显示。当 `advisory: true` 时，这些建议数量仅作为建议；Planner 会记录它本会执行的操作，但不会应用该变更。


### PR DESCRIPTION
## Overview:

Allow the Planner runtime API to update endpoint floors and per-DGD GPU budget bounds as one validated configuration without restarting the Planner.

## Summary

- extend `GET` and `PATCH /v1/min-endpoints` with `min_gpu_budget` and `max_gpu_budget`
- reconcile HOLD decisions when current Ready capacity is outside a newly patched budget
- generation-tag effects and track one unacknowledged submission to prevent stale or duplicate actions
- fail closed when a remote submission outcome is ambiguous while keeping runtime GET/PATCH available
- document runtime configuration and operator recovery in English and Chinese

## Details:

Endpoint floors and GPU budgets are validated against one prospective configuration under the decision lock, including budget ordering, endpoint GPU footprint, power footprint, mode-specific fields, and the `-1` disable sentinel. Effects computed from an older configuration generation are discarded before submission. Slow remote acknowledgements no longer hold the runtime configuration lock, and an ambiguous late failure requires deployment-state verification and Planner restart before automatic submission resumes.

## Where should the reviewer start?

- `components/src/dynamo/planner/core/base.py` for atomic updates, generation checks, and submission lifecycle
- `components/src/dynamo/planner/plugins/orchestrator/engine_adapter.py` for budget reconciliation on HOLD
- `components/src/dynamo/planner/tests/unit/test_control_api.py` and `test_tick_lifecycle.py` for API and concurrency coverage

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Validation

- `python -m pytest -q components/src/dynamo/planner/tests/unit components/src/dynamo/planner/tests/plugins/orchestrator/test_engine_adapter.py` (830 passed)
- `python docs/fern/scripts/docs_lint.py` (0 errors)
- `python -m pre_commit run --files <changed-files>`