### PR TITLE
perf(kv-router): multiplex direct ZMQ subscribers

### DIFF
--- a/lib/llm/src/direct_zmq_fan_in.rs
+++ b/lib/llm/src/direct_zmq_fan_in.rs
@@ -524,7 +524,6 @@ where
         if let Err(error) = handler(envelope) {
             tracing::warn!(%error, publisher_id, generation, "direct-ZMQ source handler rejected an envelope");
         }
-        tokio::task::consume_budget().await;
     }
 }
 
@@ -613,7 +612,7 @@ mod tests {
         collections::{HashMap, HashSet},
         sync::{
             Arc, Condvar, Mutex,
-            atomic::{AtomicBool, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
         },
     };
 
@@ -659,6 +658,58 @@ mod tests {
             SequenceCursor::new(ContinuityMode::Disabled, None).observe(9),
             None
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn ready_source_messages_are_not_double_charged_against_coop_budget() {
+        const MESSAGE_COUNT: usize = 1_025;
+
+        let (sender, mut receiver) = mpsc::channel(MESSAGE_COUNT);
+        for sequence in 0..MESSAGE_COUNT as u64 {
+            sender
+                .try_send(DirectZmqSubItem::Envelope(ValidatedEnvelope {
+                    publisher_id: 1,
+                    sequence,
+                    published_at: 0,
+                    payload: Default::default(),
+                }))
+                .unwrap();
+        }
+        drop(sender);
+
+        let seen = Arc::new(AtomicUsize::new(0));
+        let (first_seen_tx, mut first_seen_rx) = mpsc::unbounded_channel();
+        let probe_seen = seen.clone();
+        let probe = tokio::spawn(async move {
+            first_seen_rx.recv().await.unwrap();
+            probe_seen.load(Ordering::SeqCst)
+        });
+        let consumer_seen = seen.clone();
+        let handler = move |envelope: ValidatedEnvelope| {
+            let previous = consumer_seen.fetch_add(1, Ordering::SeqCst);
+            assert_eq!(envelope.sequence, previous as u64);
+            if previous == 0 {
+                first_seen_tx.send(()).unwrap();
+            }
+            Ok(())
+        };
+        let mut cursor = SequenceCursor::new(ContinuityMode::Disabled, None);
+
+        assert!(
+            consume_connection(
+                1,
+                1,
+                &mut receiver,
+                &CancellationToken::new(),
+                &mut cursor,
+                &handler,
+                &|_| {},
+                &CancellationToken::new(),
+            )
+            .await
+        );
+        assert_eq!(seen.load(Ordering::SeqCst), MESSAGE_COUNT);
+        assert!(probe.await.unwrap() > 64);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/lib/llm/src/direct_zmq_fan_in.rs
+++ b/lib/llm/src/direct_zmq_fan_in.rs
@@ -445,12 +445,12 @@ where
         .await
         {
             group_pool
-                .unregister(registration.group_id, publisher_id, generation)
+                .unregister(registration, publisher_id, generation)
                 .await;
             break;
         }
         group_pool
-            .unregister(registration.group_id, publisher_id, generation)
+            .unregister(registration, publisher_id, generation)
             .await;
         if !sleep_or_cancel(retry_delay, &cancel).await {
             break;

--- a/lib/llm/src/direct_zmq_fan_in.rs
+++ b/lib/llm/src/direct_zmq_fan_in.rs
@@ -432,7 +432,7 @@ where
         connected_once = true;
         retry_delay = INITIAL_BACKOFF;
 
-        if !consume_connection(
+        let keep_running = consume_connection(
             publisher_id,
             generation,
             &mut registration.receiver,
@@ -442,16 +442,13 @@ where
             &observer,
             &cancel,
         )
-        .await
-        {
-            group_pool
-                .unregister(registration, publisher_id, generation)
-                .await;
-            break;
-        }
+        .await;
         group_pool
             .unregister(registration, publisher_id, generation)
             .await;
+        if !keep_running {
+            break;
+        }
         if !sleep_or_cancel(retry_delay, &cancel).await {
             break;
         }

--- a/lib/llm/src/direct_zmq_fan_in.rs
+++ b/lib/llm/src/direct_zmq_fan_in.rs
@@ -11,11 +11,15 @@ use dynamo_runtime::{
         EventChannelInstanceId, EventChannelQuery, EventScope, EventTransport,
     },
     traits::DistributedRuntimeProvider,
-    transports::event_plane::{ValidatedEnvelope, ValidatedZmqSource, ValidatedZmqSourceError},
+    transports::event_plane::ValidatedEnvelope,
 };
 use futures::StreamExt;
-use tokio::task::JoinHandle;
+use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
+
+use crate::direct_zmq_sub_pool::{
+    DirectZmqSubPool, DirectZmqSubPoolEvent, endpoints_per_sub_from_env,
+};
 
 const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
 const MAX_BACKOFF: Duration = Duration::from_secs(5);
@@ -119,6 +123,7 @@ where
     H: Fn(ValidatedEnvelope) -> Result<()> + Clone + Send + Sync + 'static,
     O: Fn(FanInObservation) + Clone + Send + Sync + 'static,
 {
+    let endpoints_per_sub = endpoints_per_sub_from_env()?;
     let query =
         DiscoveryQuery::EventChannels(EventChannelQuery::endpoint_topic(endpoint.id(), topic));
     let watch_cancel = cancellation_token.child_token();
@@ -127,12 +132,28 @@ where
         .discovery()
         .list_and_watch(query.clone(), Some(watch_cancel.clone()))
         .await?;
+    let pool_observer = observer.clone();
+    let group_pool = DirectZmqSubPool::new_with_rcvhwm(
+        topic,
+        endpoints_per_sub,
+        rcvhwm,
+        std::sync::Arc::new(move |event| match event {
+            DirectZmqSubPoolEvent::Lifecycle("envelope_decode_error") => {
+                observe(&pool_observer, 0, 0, FanInEvent::EnvelopeDecodeError)
+            }
+            DirectZmqSubPoolEvent::Lifecycle("identity_mismatch") => {
+                observe(&pool_observer, 0, 0, FanInEvent::IdentityMismatch)
+            }
+            _ => {}
+        }),
+        cancellation_token.child_token(),
+    )?;
 
     Ok(tokio::spawn(run_supervisor(
         endpoint,
         topic,
         query,
-        rcvhwm,
+        group_pool,
         excluded_publisher_id,
         continuity_mode,
         cancellation_token,
@@ -147,7 +168,7 @@ async fn run_supervisor<H, O>(
     endpoint: Endpoint,
     topic: &'static str,
     query: DiscoveryQuery,
-    rcvhwm: i32,
+    group_pool: DirectZmqSubPool,
     excluded_publisher_id: Option<u64>,
     continuity_mode: ContinuityMode,
     cancellation_token: CancellationToken,
@@ -253,8 +274,7 @@ async fn run_supervisor<H, O>(
                             endpoint,
                             generation,
                             high_watermark,
-                            topic,
-                            rcvhwm,
+                            group_pool.clone(),
                             continuity_mode,
                             handler.clone(),
                             observer.clone(),
@@ -296,6 +316,7 @@ async fn run_supervisor<H, O>(
         }
         retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
     }
+    group_pool.shutdown().await;
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -304,8 +325,7 @@ fn spawn_source<H, O>(
     endpoint: String,
     generation: u64,
     high_watermark: Option<u64>,
-    topic: &'static str,
-    rcvhwm: i32,
+    group_pool: DirectZmqSubPool,
     continuity_mode: ContinuityMode,
     handler: H,
     observer: O,
@@ -329,8 +349,7 @@ where
             task_endpoint,
             generation,
             high_watermark,
-            topic,
-            rcvhwm,
+            group_pool,
             continuity_mode,
             handler,
             observer,
@@ -353,8 +372,7 @@ async fn run_source<H, O>(
     endpoint: String,
     generation: u64,
     high_watermark: Option<u64>,
-    topic: &'static str,
-    rcvhwm: i32,
+    group_pool: DirectZmqSubPool,
     continuity_mode: ContinuityMode,
     handler: H,
     observer: O,
@@ -369,14 +387,14 @@ where
     let mut connected_once = false;
 
     loop {
-        let source = tokio::select! {
+        let registration = tokio::select! {
             _ = cancel.cancelled() => break,
-            source = ValidatedZmqSource::connect(&endpoint, topic, publisher_id, rcvhwm) => source,
+            registration = group_pool.register(publisher_id, &endpoint, generation) => registration,
         };
-        let mut source = match source {
-            Ok(source) => source,
+        let mut registration = match registration {
+            Ok(registration) => registration,
             Err(error) => {
-                tracing::warn!(%error, publisher_id, generation, %endpoint, topic, "failed to connect direct-ZMQ source");
+                tracing::warn!(%error, publisher_id, generation, %endpoint, "failed to register direct-ZMQ source");
                 observe(&observer, publisher_id, generation, FanInEvent::Reconnect);
                 if !sleep_or_cancel(retry_delay, &cancel).await {
                     break;
@@ -394,7 +412,8 @@ where
         if !consume_connection(
             publisher_id,
             generation,
-            &mut source,
+            &mut registration.receiver,
+            &registration.disconnected,
             &mut cursor,
             &handler,
             &observer,
@@ -402,8 +421,14 @@ where
         )
         .await
         {
+            group_pool
+                .unregister(registration.group_id, publisher_id, generation)
+                .await;
             break;
         }
+        group_pool
+            .unregister(registration.group_id, publisher_id, generation)
+            .await;
         if !sleep_or_cancel(retry_delay, &cancel).await {
             break;
         }
@@ -413,10 +438,12 @@ where
     cursor.high_watermark
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn consume_connection<H, O>(
     publisher_id: u64,
     generation: u64,
-    source: &mut ValidatedZmqSource,
+    receiver: &mut mpsc::Receiver<ValidatedEnvelope>,
+    disconnected: &CancellationToken,
     cursor: &mut SequenceCursor,
     handler: &H,
     observer: &O,
@@ -430,37 +457,11 @@ where
         let envelope = tokio::select! {
             biased;
             _ = cancel.cancelled() => return false,
-            envelope = source.next() => envelope,
+            _ = disconnected.cancelled() => return true,
+            envelope = receiver.recv() => envelope,
         };
         let Some(envelope) = envelope else {
             return true;
-        };
-        let envelope = match envelope {
-            Ok(envelope) => envelope,
-            Err(ValidatedZmqSourceError::Receive(error)) => {
-                tracing::warn!(%error, publisher_id, generation, "direct-ZMQ source receive failed");
-                return true;
-            }
-            Err(ValidatedZmqSourceError::EnvelopeDecode(error)) => {
-                tracing::warn!(%error, publisher_id, generation, "dropping malformed direct-ZMQ envelope");
-                observe(
-                    observer,
-                    publisher_id,
-                    generation,
-                    FanInEvent::EnvelopeDecodeError,
-                );
-                continue;
-            }
-            Err(error @ ValidatedZmqSourceError::IdentityMismatch { .. }) => {
-                tracing::warn!(%error, publisher_id, generation, "dropping misattributed direct-ZMQ envelope");
-                observe(
-                    observer,
-                    publisher_id,
-                    generation,
-                    FanInEvent::IdentityMismatch,
-                );
-                continue;
-            }
         };
 
         match cursor.observe(envelope.sequence) {

--- a/lib/llm/src/direct_zmq_fan_in.rs
+++ b/lib/llm/src/direct_zmq_fan_in.rs
@@ -443,9 +443,7 @@ where
             &cancel,
         )
         .await;
-        group_pool
-            .unregister(registration, publisher_id, generation)
-            .await;
+        registration.close().await;
         if !keep_running {
             break;
         }

--- a/lib/llm/src/direct_zmq_fan_in.rs
+++ b/lib/llm/src/direct_zmq_fan_in.rs
@@ -5,11 +5,12 @@ use std::{collections::HashMap, time::Duration};
 
 use anyhow::Result;
 use dynamo_runtime::{
-    component::Endpoint,
+    component::{Component, Endpoint},
     discovery::{
         DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, DiscoveryQuery,
         EventChannelInstanceId, EventChannelQuery, EventScope, EventTransport,
     },
+    protocols::EndpointId,
     traits::DistributedRuntimeProvider,
     transports::event_plane::ValidatedEnvelope,
 };
@@ -17,9 +18,7 @@ use futures::StreamExt;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 
-use crate::direct_zmq_sub_pool::{
-    DirectZmqSubPool, DirectZmqSubPoolEvent, endpoints_per_sub_from_env,
-};
+use crate::direct_zmq_sub_pool::{DirectZmqSubItem, DirectZmqSubPool, endpoints_per_sub_from_env};
 
 const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
 const MAX_BACKOFF: Duration = Duration::from_secs(5);
@@ -123,34 +122,57 @@ where
     H: Fn(ValidatedEnvelope) -> Result<()> + Clone + Send + Sync + 'static,
     O: Fn(FanInObservation) + Clone + Send + Sync + 'static,
 {
+    start_direct_zmq_fan_in_for_endpoint_id(
+        endpoint.component().clone(),
+        endpoint.id(),
+        topic,
+        rcvhwm,
+        excluded_publisher_id,
+        continuity_mode,
+        cancellation_token,
+        handler,
+        observer,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn start_direct_zmq_fan_in_for_endpoint_id<H, O>(
+    component: Component,
+    endpoint_id: EndpointId,
+    topic: &'static str,
+    rcvhwm: i32,
+    excluded_publisher_id: Option<u64>,
+    continuity_mode: ContinuityMode,
+    cancellation_token: CancellationToken,
+    handler: H,
+    observer: O,
+) -> Result<JoinHandle<()>>
+where
+    H: Fn(ValidatedEnvelope) -> Result<()> + Clone + Send + Sync + 'static,
+    O: Fn(FanInObservation) + Clone + Send + Sync + 'static,
+{
     let endpoints_per_sub = endpoints_per_sub_from_env()?;
-    let query =
-        DiscoveryQuery::EventChannels(EventChannelQuery::endpoint_topic(endpoint.id(), topic));
+    let query = DiscoveryQuery::EventChannels(EventChannelQuery::endpoint_topic(
+        endpoint_id.clone(),
+        topic,
+    ));
     let watch_cancel = cancellation_token.child_token();
-    let initial_watch = endpoint
+    let initial_watch = component
         .drt()
         .discovery()
         .list_and_watch(query.clone(), Some(watch_cancel.clone()))
         .await?;
-    let pool_observer = observer.clone();
-    let group_pool = DirectZmqSubPool::new_with_rcvhwm(
+    let group_pool = DirectZmqSubPool::new(
         topic,
         endpoints_per_sub,
         rcvhwm,
-        std::sync::Arc::new(move |event| match event {
-            DirectZmqSubPoolEvent::Lifecycle("envelope_decode_error") => {
-                observe(&pool_observer, 0, 0, FanInEvent::EnvelopeDecodeError)
-            }
-            DirectZmqSubPoolEvent::Lifecycle("identity_mismatch") => {
-                observe(&pool_observer, 0, 0, FanInEvent::IdentityMismatch)
-            }
-            _ => {}
-        }),
         cancellation_token.child_token(),
     )?;
 
     Ok(tokio::spawn(run_supervisor(
-        endpoint,
+        component,
+        endpoint_id,
         topic,
         query,
         group_pool,
@@ -165,7 +187,8 @@ where
 
 #[allow(clippy::too_many_arguments)]
 async fn run_supervisor<H, O>(
-    endpoint: Endpoint,
+    component: Component,
+    endpoint_id: EndpointId,
     topic: &'static str,
     query: DiscoveryQuery,
     group_pool: DirectZmqSubPool,
@@ -183,9 +206,9 @@ async fn run_supervisor<H, O>(
     O: Fn(FanInObservation) + Clone + Send + Sync + 'static,
 {
     let expected_scope = EventScope::Endpoint {
-        endpoint: endpoint.id(),
+        endpoint: endpoint_id,
     };
-    let discovery = endpoint.drt().discovery();
+    let discovery = component.drt().discovery();
     let mut resume_cursors = HashMap::<u64, u64>::new();
     let mut next_generation = 1_u64;
     let mut retry_delay = INITIAL_BACKOFF;
@@ -442,7 +465,7 @@ where
 async fn consume_connection<H, O>(
     publisher_id: u64,
     generation: u64,
-    receiver: &mut mpsc::Receiver<ValidatedEnvelope>,
+    receiver: &mut mpsc::Receiver<DirectZmqSubItem>,
     disconnected: &CancellationToken,
     cursor: &mut SequenceCursor,
     handler: &H,
@@ -454,14 +477,36 @@ where
     O: Fn(FanInObservation) + Send + Sync,
 {
     loop {
-        let envelope = tokio::select! {
+        let item = tokio::select! {
             biased;
             _ = cancel.cancelled() => return false,
             _ = disconnected.cancelled() => return true,
-            envelope = receiver.recv() => envelope,
+            item = receiver.recv() => item,
         };
-        let Some(envelope) = envelope else {
+        let Some(item) = item else {
             return true;
+        };
+
+        let envelope = match item {
+            DirectZmqSubItem::Envelope(envelope) => envelope,
+            DirectZmqSubItem::EnvelopeDecodeError => {
+                observe(
+                    observer,
+                    publisher_id,
+                    generation,
+                    FanInEvent::EnvelopeDecodeError,
+                );
+                continue;
+            }
+            DirectZmqSubItem::IdentityMismatch => {
+                observe(
+                    observer,
+                    publisher_id,
+                    generation,
+                    FanInEvent::IdentityMismatch,
+                );
+                continue;
+            }
         };
 
         match cursor.observe(envelope.sequence) {

--- a/lib/llm/src/direct_zmq_fan_in.rs
+++ b/lib/llm/src/direct_zmq_fan_in.rs
@@ -12,13 +12,15 @@ use dynamo_runtime::{
     },
     protocols::EndpointId,
     traits::DistributedRuntimeProvider,
-    transports::event_plane::ValidatedEnvelope,
+    transports::event_plane::{ValidatedEnvelope, ValidatedZmqSource, ValidatedZmqSourceError},
 };
 use futures::StreamExt;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 
-use crate::direct_zmq_sub_pool::{DirectZmqSubItem, DirectZmqSubPool, endpoints_per_sub_from_env};
+use crate::direct_zmq_sub_pool::{
+    DirectZmqSubConnection, DirectZmqSubItem, DirectZmqSubPool, endpoints_per_sub_from_env,
+};
 
 const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
 const MAX_BACKOFF: Duration = Duration::from_secs(5);
@@ -34,6 +36,8 @@ pub(crate) enum ContinuityMode {
 pub(crate) enum FanInEvent {
     SourceStarted,
     SourceStopped,
+    Disconnected,
+    DiscoveryReset,
     Reconnect,
     Replacement,
     EnvelopeDecodeError,
@@ -328,6 +332,16 @@ async fn run_supervisor<H, O>(
         }
 
         watch_cancel.cancel();
+        if restart_watch {
+            for source in sources.values() {
+                observe(
+                    &observer,
+                    source.publisher_id,
+                    source.generation,
+                    FanInEvent::DiscoveryReset,
+                );
+            }
+        }
         for (publisher_id, high_watermark) in stop_sources(sources, &observer).await {
             resume_cursors.insert(publisher_id, high_watermark);
         }
@@ -410,14 +424,14 @@ where
     let mut connected_once = false;
 
     loop {
-        let registration = tokio::select! {
+        let connection = tokio::select! {
             _ = cancel.cancelled() => break,
-            registration = group_pool.register(publisher_id, &endpoint, generation) => registration,
+            connection = group_pool.connect(publisher_id, &endpoint, generation) => connection,
         };
-        let mut registration = match registration {
-            Ok(registration) => registration,
+        let mut connection = match connection {
+            Ok(connection) => connection,
             Err(error) => {
-                tracing::warn!(%error, publisher_id, generation, %endpoint, "failed to register direct-ZMQ source");
+                tracing::warn!(%error, publisher_id, generation, %endpoint, "failed to connect direct-ZMQ source");
                 observe(&observer, publisher_id, generation, FanInEvent::Reconnect);
                 if !sleep_or_cancel(retry_delay, &cancel).await {
                     break;
@@ -432,18 +446,42 @@ where
         connected_once = true;
         retry_delay = INITIAL_BACKOFF;
 
-        let keep_running = consume_connection(
-            publisher_id,
-            generation,
-            &mut registration.receiver,
-            &registration.disconnected,
-            &mut cursor,
-            &handler,
-            &observer,
-            &cancel,
-        )
-        .await;
-        registration.close().await;
+        let keep_running = match &mut connection {
+            DirectZmqSubConnection::Dedicated(source) => {
+                consume_dedicated_connection(
+                    publisher_id,
+                    generation,
+                    source,
+                    &mut cursor,
+                    &handler,
+                    &observer,
+                    &cancel,
+                )
+                .await
+            }
+            DirectZmqSubConnection::Grouped(registration) => {
+                consume_grouped_connection(
+                    publisher_id,
+                    generation,
+                    &mut registration.receiver,
+                    &registration.disconnected,
+                    &mut cursor,
+                    &handler,
+                    &observer,
+                    &cancel,
+                )
+                .await
+            }
+        };
+        if keep_running {
+            observe(
+                &observer,
+                publisher_id,
+                generation,
+                FanInEvent::Disconnected,
+            );
+        }
+        connection.close().await;
         if !keep_running {
             break;
         }
@@ -457,7 +495,7 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn consume_connection<H, O>(
+async fn consume_grouped_connection<H, O>(
     publisher_id: u64,
     generation: u64,
     receiver: &mut mpsc::Receiver<DirectZmqSubItem>,
@@ -519,6 +557,75 @@ where
         if let Err(error) = handler(envelope) {
             tracing::warn!(%error, publisher_id, generation, "direct-ZMQ source handler rejected an envelope");
         }
+    }
+}
+
+async fn consume_dedicated_connection<H, O>(
+    publisher_id: u64,
+    generation: u64,
+    source: &mut ValidatedZmqSource,
+    cursor: &mut SequenceCursor,
+    handler: &H,
+    observer: &O,
+    cancel: &CancellationToken,
+) -> bool
+where
+    H: Fn(ValidatedEnvelope) -> Result<()> + Send + Sync,
+    O: Fn(FanInObservation) + Send + Sync,
+{
+    loop {
+        let envelope = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return false,
+            envelope = source.next() => envelope,
+        };
+        let Some(envelope) = envelope else {
+            return true;
+        };
+        let envelope = match envelope {
+            Ok(envelope) => envelope,
+            Err(ValidatedZmqSourceError::Receive(error)) => {
+                tracing::warn!(%error, publisher_id, generation, "direct-ZMQ source receive failed");
+                return true;
+            }
+            Err(ValidatedZmqSourceError::EnvelopeDecode(error)) => {
+                tracing::warn!(%error, publisher_id, generation, "dropping malformed direct-ZMQ envelope");
+                observe(
+                    observer,
+                    publisher_id,
+                    generation,
+                    FanInEvent::EnvelopeDecodeError,
+                );
+                continue;
+            }
+            Err(error @ ValidatedZmqSourceError::IdentityMismatch { .. }) => {
+                tracing::warn!(%error, publisher_id, generation, "dropping misattributed direct-ZMQ envelope");
+                observe(
+                    observer,
+                    publisher_id,
+                    generation,
+                    FanInEvent::IdentityMismatch,
+                );
+                continue;
+            }
+        };
+
+        match cursor.observe(envelope.sequence) {
+            None | Some(Continuity::InOrder) => {}
+            Some(Continuity::Gap(missing)) => observe(
+                observer,
+                publisher_id,
+                generation,
+                FanInEvent::SequenceGap { missing },
+            ),
+            Some(Continuity::OutOfOrder) => {
+                observe(observer, publisher_id, generation, FanInEvent::OutOfOrder)
+            }
+        }
+        if let Err(error) = handler(envelope) {
+            tracing::warn!(%error, publisher_id, generation, "direct-ZMQ source handler rejected an envelope");
+        }
+        tokio::task::consume_budget().await;
     }
 }
 
@@ -691,7 +798,7 @@ mod tests {
         let mut cursor = SequenceCursor::new(ContinuityMode::Disabled, None);
 
         assert!(
-            consume_connection(
+            consume_grouped_connection(
                 1,
                 1,
                 &mut receiver,

--- a/lib/llm/src/direct_zmq_sub_pool.rs
+++ b/lib/llm/src/direct_zmq_sub_pool.rs
@@ -14,18 +14,18 @@ use anyhow::Result;
 use dynamo_runtime::transports::event_plane::{
     Codec, DynamicZmqSubSocket, ValidatedEnvelope, ZmqWireMessage,
 };
+use parking_lot::Mutex;
 use tokio::{
-    sync::{Mutex, mpsc, oneshot},
+    sync::{mpsc, oneshot},
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
 
 const GROUP_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
-const GROUP_COMMAND_CAPACITY: usize = 128;
-const PUBLISHER_LANE_CAPACITY: usize = 64;
 
 pub(crate) const ENDPOINTS_PER_SUB_ENV: &str = "DYN_ROUTER_KV_ZMQ_ENDPOINTS_PER_SUB";
 pub(crate) const DEFAULT_ENDPOINTS_PER_SUB: usize = 64;
+pub(crate) const KV_ZMQ_RCVHWM: i32 = 100_000;
 
 pub(crate) fn endpoints_per_sub_from_env() -> Result<usize> {
     endpoints_per_sub_from_lookup(|key| std::env::var_os(key))
@@ -50,20 +50,17 @@ fn parse_endpoints_per_sub(raw: &OsStr) -> Result<usize> {
     Ok(value)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum DirectZmqSubPoolEvent {
-    SocketGroups(i64),
-    ConnectedEndpoints(i64),
-    Lifecycle(&'static str),
+#[derive(Debug)]
+pub(crate) enum DirectZmqSubItem {
+    Envelope(ValidatedEnvelope),
+    EnvelopeDecodeError,
+    IdentityMismatch,
 }
-
-pub(crate) type DirectZmqSubPoolObserver =
-    Arc<dyn Fn(DirectZmqSubPoolEvent) + Send + Sync + 'static>;
 
 struct GroupRoute {
     endpoint: String,
     generation: u64,
-    sender: mpsc::Sender<ValidatedEnvelope>,
+    sender: mpsc::Sender<DirectZmqSubItem>,
     disconnected: CancellationToken,
 }
 
@@ -82,25 +79,26 @@ enum GroupCommand {
     Remove {
         publisher_id: u64,
         generation: u64,
-        completed: oneshot::Sender<Result<()>>,
+        completed: Option<oneshot::Sender<Result<()>>>,
+    },
+    #[cfg(test)]
+    Pause {
+        started: oneshot::Sender<()>,
+        release: oneshot::Receiver<()>,
     },
 }
 
 struct SocketGroup {
-    members: HashMap<u64, GroupMember>,
-    command_tx: mpsc::Sender<GroupCommand>,
+    assignments: HashMap<u64, u64>,
+    command_tx: mpsc::UnboundedSender<GroupCommand>,
     cancel: CancellationToken,
     handle: JoinHandle<()>,
-}
-
-struct GroupMember {
-    generation: u64,
-    connected: bool,
 }
 
 struct PoolInner {
     groups: HashMap<u64, SocketGroup>,
     next_group_id: u64,
+    closed: bool,
 }
 
 #[derive(Clone)]
@@ -108,61 +106,67 @@ pub(crate) struct DirectZmqSubPool {
     inner: Arc<Mutex<PoolInner>>,
     topic: Arc<str>,
     endpoints_per_sub: usize,
-    rcvhwm: Option<i32>,
-    observer: DirectZmqSubPoolObserver,
+    rcvhwm: i32,
     cancellation_token: CancellationToken,
 }
 
 pub(crate) struct DirectZmqSubRegistration {
     pub(crate) group_id: u64,
-    pub(crate) receiver: mpsc::Receiver<ValidatedEnvelope>,
+    pub(crate) receiver: mpsc::Receiver<DirectZmqSubItem>,
     pub(crate) disconnected: CancellationToken,
+}
+
+struct PendingRegistration {
+    pool: DirectZmqSubPool,
+    group_id: u64,
+    publisher_id: u64,
+    generation: u64,
+    armed: bool,
+}
+
+impl PendingRegistration {
+    fn new(pool: DirectZmqSubPool, group_id: u64, publisher_id: u64, generation: u64) -> Self {
+        Self {
+            pool,
+            group_id,
+            publisher_id,
+            generation,
+            armed: true,
+        }
+    }
+
+    fn complete(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PendingRegistration {
+    fn drop(&mut self) {
+        if self.armed {
+            self.pool
+                .remove_registration(self.group_id, self.publisher_id, self.generation, None);
+        }
+    }
 }
 
 impl DirectZmqSubPool {
     pub(crate) fn new(
         topic: impl Into<Arc<str>>,
         endpoints_per_sub: usize,
-        observer: DirectZmqSubPoolObserver,
-        cancellation_token: CancellationToken,
-    ) -> Result<Self> {
-        Self::new_inner(topic, endpoints_per_sub, None, observer, cancellation_token)
-    }
-
-    pub(crate) fn new_with_rcvhwm(
-        topic: impl Into<Arc<str>>,
-        endpoints_per_sub: usize,
         rcvhwm: i32,
-        observer: DirectZmqSubPoolObserver,
-        cancellation_token: CancellationToken,
-    ) -> Result<Self> {
-        anyhow::ensure!(rcvhwm > 0, "ZMQ receive HWM must be greater than zero");
-        Self::new_inner(
-            topic,
-            endpoints_per_sub,
-            Some(rcvhwm),
-            observer,
-            cancellation_token,
-        )
-    }
-
-    fn new_inner(
-        topic: impl Into<Arc<str>>,
-        endpoints_per_sub: usize,
-        rcvhwm: Option<i32>,
-        observer: DirectZmqSubPoolObserver,
         cancellation_token: CancellationToken,
     ) -> Result<Self> {
         anyhow::ensure!(endpoints_per_sub > 0, "endpoints per SUB must be positive");
+        anyhow::ensure!(rcvhwm > 0, "ZMQ receive HWM must be greater than zero");
         Ok(Self {
             inner: Arc::new(Mutex::new(PoolInner {
                 groups: HashMap::new(),
                 next_group_id: 1,
+                closed: false,
             })),
             topic: topic.into(),
             endpoints_per_sub,
             rcvhwm,
-            observer,
             cancellation_token,
         })
     }
@@ -173,137 +177,143 @@ impl DirectZmqSubPool {
         endpoint: &str,
         generation: u64,
     ) -> Result<DirectZmqSubRegistration> {
-        let (sender, receiver) = mpsc::channel(PUBLISHER_LANE_CAPACITY);
+        enum RegistrationStart {
+            Pending {
+                group_id: u64,
+                receiver: mpsc::Receiver<DirectZmqSubItem>,
+                disconnected: CancellationToken,
+                completion: oneshot::Receiver<Result<()>>,
+                guard: PendingRegistration,
+            },
+            Ready(DirectZmqSubRegistration),
+        }
+
+        let (sender, receiver) = mpsc::channel(self.rcvhwm as usize);
         let disconnected = CancellationToken::new();
-        let mut inner = self.inner.lock().await;
-        self.reap_failed_groups(&mut inner);
-        anyhow::ensure!(
-            inner
-                .groups
-                .values()
-                .all(|group| !group.members.contains_key(&publisher_id)),
-            "publisher {publisher_id} is already registered"
-        );
-
-        let group_id = inner
-            .groups
-            .iter()
-            .filter(|(_, group)| {
-                group.members.len() < self.endpoints_per_sub
-                    && !group.command_tx.is_closed()
-                    && !group.handle.is_finished()
-            })
-            .min_by_key(|(group_id, group)| (group.members.len(), **group_id))
-            .map(|(group_id, _)| *group_id);
-
-        if let Some(group_id) = group_id {
-            let group = inner
-                .groups
-                .get_mut(&group_id)
-                .expect("selected socket group must exist");
-            group.members.insert(
-                publisher_id,
-                GroupMember {
-                    generation,
-                    connected: false,
-                },
-            );
-            let command_tx = group.command_tx.clone();
-            drop(inner);
-            let (completed, completion) = oneshot::channel();
-            let result = async {
-                command_tx
-                    .send(GroupCommand::Add {
-                        publisher_id,
-                        route: GroupRoute {
-                            endpoint: endpoint.to_string(),
-                            generation,
-                            sender,
-                            disconnected: disconnected.clone(),
-                        },
-                        completed,
-                    })
-                    .await
-                    .map_err(|_| anyhow::anyhow!("direct-ZMQ socket group stopped"))?;
-                completion
-                    .await
-                    .map_err(|_| anyhow::anyhow!("direct-ZMQ socket group stopped"))?
-            }
-            .await;
-            if let Err(error) = result {
-                self.rollback_registration(group_id, publisher_id, generation)
-                    .await;
-                return Err(error);
-            }
-            let marked_connected = {
-                let mut inner = self.inner.lock().await;
-                self.reap_failed_groups(&mut inner);
+        let start = {
+            let mut inner = self.inner.lock();
+            Self::reap_failed_groups(&mut inner);
+            anyhow::ensure!(!inner.closed, "direct-ZMQ socket pool is closed");
+            anyhow::ensure!(
                 inner
                     .groups
+                    .values()
+                    .all(|group| !group.assignments.contains_key(&publisher_id)),
+                "publisher {publisher_id} is already registered"
+            );
+
+            let group_id = inner
+                .groups
+                .iter()
+                .filter(|(_, group)| {
+                    group.assignments.len() < self.endpoints_per_sub
+                        && !group.command_tx.is_closed()
+                        && !group.handle.is_finished()
+                })
+                .min_by_key(|(group_id, group)| (group.assignments.len(), **group_id))
+                .map(|(group_id, _)| *group_id);
+
+            if let Some(group_id) = group_id {
+                let group = inner
+                    .groups
                     .get_mut(&group_id)
-                    .and_then(|group| group.members.get_mut(&publisher_id))
-                    .filter(|member| member.generation == generation)
-                    .is_some_and(|member| {
-                        member.connected = true;
-                        true
-                    })
-            };
-            anyhow::ensure!(marked_connected, "direct-ZMQ socket group stopped");
-            self.observe(DirectZmqSubPoolEvent::ConnectedEndpoints(1));
-            return Ok(DirectZmqSubRegistration {
+                    .expect("selected socket group must exist");
+                group.assignments.insert(publisher_id, generation);
+                let (completed, completion) = oneshot::channel();
+                let command = GroupCommand::Add {
+                    publisher_id,
+                    route: GroupRoute {
+                        endpoint: endpoint.to_string(),
+                        generation,
+                        sender,
+                        disconnected: disconnected.clone(),
+                    },
+                    completed,
+                };
+                if group.command_tx.send(command).is_err() {
+                    group.assignments.remove(&publisher_id);
+                    anyhow::bail!("direct-ZMQ socket group stopped");
+                }
+                RegistrationStart::Pending {
+                    group_id,
+                    receiver,
+                    disconnected,
+                    completion,
+                    guard: PendingRegistration::new(
+                        self.clone(),
+                        group_id,
+                        publisher_id,
+                        generation,
+                    ),
+                }
+            } else {
+                // libzmq connects asynchronously. Keep group creation serialized so
+                // concurrent registrations cannot create excess transient sockets.
+                let socket =
+                    DynamicZmqSubSocket::connect_with_rcvhwm(endpoint, &self.topic, self.rcvhwm)?;
+                let group_id = inner.next_group_id;
+                inner.next_group_id = inner.next_group_id.wrapping_add(1);
+                let (command_tx, command_rx) = mpsc::unbounded_channel();
+                let cancel = self.cancellation_token.child_token();
+                let routes = HashMap::from([(
+                    publisher_id,
+                    GroupRoute {
+                        endpoint: endpoint.to_string(),
+                        generation,
+                        sender,
+                        disconnected: disconnected.clone(),
+                    },
+                )]);
+                let handle = tokio::spawn(run_socket_group(
+                    group_id,
+                    self.topic.clone(),
+                    socket,
+                    routes,
+                    command_rx,
+                    cancel.clone(),
+                ));
+                inner.groups.insert(
+                    group_id,
+                    SocketGroup {
+                        assignments: HashMap::from([(publisher_id, generation)]),
+                        command_tx,
+                        cancel,
+                        handle,
+                    },
+                );
+                RegistrationStart::Ready(DirectZmqSubRegistration {
+                    group_id,
+                    receiver,
+                    disconnected,
+                })
+            }
+        };
+
+        let (group_id, receiver, disconnected, completion, guard) = match start {
+            RegistrationStart::Pending {
                 group_id,
                 receiver,
                 disconnected,
-            });
-        }
-
-        let socket = match self.rcvhwm {
-            Some(rcvhwm) => {
-                DynamicZmqSubSocket::connect_with_rcvhwm(endpoint, &self.topic, rcvhwm)?
-            }
-            None => DynamicZmqSubSocket::connect(endpoint, &self.topic)?,
+                completion,
+                guard,
+            } => (group_id, receiver, disconnected, completion, guard),
+            RegistrationStart::Ready(registration) => return Ok(registration),
         };
-        let group_id = inner.next_group_id;
-        inner.next_group_id = inner.next_group_id.wrapping_add(1);
-        let (command_tx, command_rx) = mpsc::channel(GROUP_COMMAND_CAPACITY);
-        let cancel = self.cancellation_token.child_token();
-        let mut routes = HashMap::new();
-        routes.insert(
-            publisher_id,
-            GroupRoute {
-                endpoint: endpoint.to_string(),
-                generation,
-                sender,
-                disconnected: disconnected.clone(),
-            },
-        );
-        let handle = tokio::spawn(run_socket_group(
-            group_id,
-            self.topic.clone(),
-            socket,
-            routes,
-            command_rx,
-            self.observer.clone(),
-            cancel.clone(),
-        ));
-        inner.groups.insert(
-            group_id,
-            SocketGroup {
-                members: HashMap::from([(
-                    publisher_id,
-                    GroupMember {
-                        generation,
-                        connected: true,
-                    },
-                )]),
-                command_tx,
-                cancel,
-                handle,
-            },
-        );
-        self.observe(DirectZmqSubPoolEvent::SocketGroups(1));
-        self.observe(DirectZmqSubPoolEvent::ConnectedEndpoints(1));
-        self.observe(DirectZmqSubPoolEvent::Lifecycle("group_started"));
+
+        completion
+            .await
+            .map_err(|_| anyhow::anyhow!("direct-ZMQ socket group stopped"))??;
+        let valid = {
+            let mut inner = self.inner.lock();
+            Self::reap_failed_groups(&mut inner);
+            !inner.closed
+                && inner
+                    .groups
+                    .get(&group_id)
+                    .is_some_and(|group| group.assignments.get(&publisher_id) == Some(&generation))
+        };
+        anyhow::ensure!(valid, "direct-ZMQ socket group stopped");
+        guard.complete();
         Ok(DirectZmqSubRegistration {
             group_id,
             receiver,
@@ -312,126 +322,74 @@ impl DirectZmqSubPool {
     }
 
     pub(crate) async fn unregister(&self, group_id: u64, publisher_id: u64, generation: u64) {
-        let mut group_to_stop = None;
-        let command_tx = {
-            let mut inner = self.inner.lock().await;
-            self.reap_failed_groups(&mut inner);
-            let Some(group) = inner.groups.get_mut(&group_id) else {
-                return;
-            };
-            let Some(member) = group.members.get(&publisher_id) else {
-                return;
-            };
-            if member.generation != generation {
-                return;
-            }
-            let connected = member.connected;
-            group.members.remove(&publisher_id);
-            if connected {
-                self.observe(DirectZmqSubPoolEvent::ConnectedEndpoints(-1));
-            }
-            if group.members.is_empty() {
-                group_to_stop = inner.groups.remove(&group_id);
-                self.observe(DirectZmqSubPoolEvent::SocketGroups(-1));
-                None
-            } else {
-                Some(group.command_tx.clone())
-            }
+        let (completed, group_to_stop) = {
+            let (completed_tx, completed_rx) = oneshot::channel();
+            let group =
+                self.remove_registration(group_id, publisher_id, generation, Some(completed_tx));
+            (completed_rx, group)
         };
-        if let Some(command_tx) = command_tx {
-            let (completed, completion) = oneshot::channel();
-            let removed = command_tx
-                .send(GroupCommand::Remove {
-                    publisher_id,
-                    generation,
-                    completed,
-                })
-                .await
-                .is_ok()
-                && completion.await.is_ok_and(|result| result.is_ok());
-            if !removed {
-                self.observe(DirectZmqSubPoolEvent::Lifecycle("group_command_error"));
-            }
-        }
+
         if let Some(group) = group_to_stop {
-            stop_group(group, &self.observer).await;
+            stop_group(group).await;
+        } else {
+            let _ = completed.await;
         }
     }
 
-    async fn rollback_registration(&self, group_id: u64, publisher_id: u64, generation: u64) {
-        let mut group_to_stop = None;
-        let command_tx = {
-            let mut inner = self.inner.lock().await;
-            self.reap_failed_groups(&mut inner);
-            let Some(group) = inner.groups.get_mut(&group_id) else {
-                return;
-            };
-            let Some(member) = group.members.get(&publisher_id) else {
-                return;
-            };
-            if member.generation != generation {
-                return;
-            }
-            group.members.remove(&publisher_id);
-            if group.members.is_empty() {
-                group_to_stop = inner.groups.remove(&group_id);
-                self.observe(DirectZmqSubPoolEvent::SocketGroups(-1));
-                None
-            } else {
-                Some(group.command_tx.clone())
-            }
-        };
-        if let Some(command_tx) = command_tx {
-            let (completed, completion) = oneshot::channel();
-            let _ = command_tx
-                .send(GroupCommand::Remove {
-                    publisher_id,
-                    generation,
-                    completed,
-                })
-                .await;
-            let _ = completion.await;
+    fn remove_registration(
+        &self,
+        group_id: u64,
+        publisher_id: u64,
+        generation: u64,
+        completed: Option<oneshot::Sender<Result<()>>>,
+    ) -> Option<SocketGroup> {
+        let mut inner = self.inner.lock();
+        Self::reap_failed_groups(&mut inner);
+        let group = inner.groups.get_mut(&group_id)?;
+        if group.assignments.get(&publisher_id) != Some(&generation) {
+            return None;
         }
-        if let Some(group) = group_to_stop {
-            stop_group(group, &self.observer).await;
+        group.assignments.remove(&publisher_id);
+        if group.assignments.is_empty() {
+            let group = inner
+                .groups
+                .remove(&group_id)
+                .expect("empty socket group must exist");
+            group.cancel.cancel();
+            return Some(group);
         }
+
+        let _ = group.command_tx.send(GroupCommand::Remove {
+            publisher_id,
+            generation,
+            completed,
+        });
+        None
     }
 
     pub(crate) async fn shutdown(&self) {
         let groups = {
-            let mut inner = self.inner.lock().await;
+            let mut inner = self.inner.lock();
+            inner.closed = true;
             let groups = inner
                 .groups
                 .drain()
                 .map(|(_, group)| group)
                 .collect::<Vec<_>>();
             for group in &groups {
-                self.observe(DirectZmqSubPoolEvent::SocketGroups(-1));
-                self.observe(DirectZmqSubPoolEvent::ConnectedEndpoints(
-                    -(group
-                        .members
-                        .values()
-                        .filter(|member| member.connected)
-                        .count() as i64),
-                ));
                 group.cancel.cancel();
             }
             groups
         };
-        futures::future::join_all(
-            groups
-                .into_iter()
-                .map(|group| stop_group(group, &self.observer)),
-        )
-        .await;
+        futures::future::join_all(groups.into_iter().map(stop_group)).await;
     }
 
     #[cfg(test)]
-    pub(crate) async fn group_count(&self) -> usize {
-        self.inner.lock().await.groups.len()
+    pub(crate) fn group_count(&self) -> usize {
+        self.inner.lock().groups.len()
     }
 
-    fn reap_failed_groups(&self, inner: &mut PoolInner) {
+    fn reap_failed_groups(inner: &mut PoolInner) {
         let failed = inner
             .groups
             .iter()
@@ -441,22 +399,9 @@ impl DirectZmqSubPool {
             .collect::<Vec<_>>();
         for group_id in failed {
             if let Some(group) = inner.groups.remove(&group_id) {
-                self.observe(DirectZmqSubPoolEvent::SocketGroups(-1));
-                self.observe(DirectZmqSubPoolEvent::ConnectedEndpoints(
-                    -(group
-                        .members
-                        .values()
-                        .filter(|member| member.connected)
-                        .count() as i64),
-                ));
-                self.observe(DirectZmqSubPoolEvent::Lifecycle("group_reaped"));
                 group.cancel.cancel();
             }
         }
-    }
-
-    fn observe(&self, event: DirectZmqSubPoolEvent) {
-        (self.observer)(event);
     }
 }
 
@@ -466,8 +411,7 @@ async fn run_socket_group(
     topic: Arc<str>,
     mut socket: DynamicZmqSubSocket,
     mut routes: HashMap<u64, GroupRoute>,
-    mut command_rx: mpsc::Receiver<GroupCommand>,
-    observer: DirectZmqSubPoolObserver,
+    mut command_rx: mpsc::UnboundedReceiver<GroupCommand>,
     cancellation_token: CancellationToken,
 ) {
     let codec = Codec::default();
@@ -500,24 +444,34 @@ async fn run_socket_group(
                             }
                             _ => Ok(()),
                         };
-                        let _ = completed.send(result);
+                        if let Some(completed) = completed {
+                            let _ = completed.send(result);
+                        }
+                    }
+                    #[cfg(test)]
+                    GroupCommand::Pause { started, release } => {
+                        let _ = started.send(());
+                        tokio::select! {
+                            _ = cancellation_token.cancelled() => return,
+                            _ = release => {}
+                        }
                     }
                 }
             }
             message = socket.next() => {
                 let Some(message) = message else {
-                    observer(DirectZmqSubPoolEvent::Lifecycle("group_failure"));
+                    tracing::warn!(group_id, topic = %topic, "Direct-ZMQ socket group stopped");
                     return;
                 };
                 let message = match message {
                     Ok(message) => message,
                     Err(error) => {
                         tracing::warn!(%error, group_id, topic = %topic, "Direct-ZMQ socket group receive failed");
-                        observer(DirectZmqSubPoolEvent::Lifecycle("group_failure"));
                         return;
                     }
                 };
-                dispatch_group_message(group_id, &topic, message, &codec, &mut routes, &observer);
+                dispatch_group_message(group_id, &topic, message, &codec, &routes);
+                tokio::task::consume_budget().await;
             }
         }
     }
@@ -528,56 +482,73 @@ fn dispatch_group_message(
     topic: &str,
     message: ZmqWireMessage,
     codec: &Codec,
-    routes: &mut HashMap<u64, GroupRoute>,
-    observer: &DirectZmqSubPoolObserver,
+    routes: &HashMap<u64, GroupRoute>,
 ) {
-    let envelope = match codec.decode_envelope(&message.payload) {
-        Ok(envelope) => envelope,
-        Err(error) => {
-            tracing::warn!(%error, group_id, topic, publisher_id = message.publisher_id, "Failed to decode direct-ZMQ envelope");
-            observer(DirectZmqSubPoolEvent::Lifecycle("envelope_decode_error"));
-            return;
-        }
-    };
-    if envelope.publisher_id != message.publisher_id
-        || envelope.sequence != message.sequence
-        || envelope.topic != topic
-    {
+    let Some(route) = routes.get(&message.publisher_id) else {
         tracing::warn!(
             group_id,
             topic,
-            frame_publisher_id = message.publisher_id,
-            frame_sequence = message.sequence,
-            envelope_publisher_id = envelope.publisher_id,
-            envelope_sequence = envelope.sequence,
-            envelope_topic = %envelope.topic,
-            "Dropping direct-ZMQ envelope with inconsistent attribution"
+            publisher_id = message.publisher_id,
+            "Dropping direct-ZMQ envelope from an unknown publisher"
         );
-        observer(DirectZmqSubPoolEvent::Lifecycle("identity_mismatch"));
-        return;
-    }
-    let Some(route) = routes.get(&message.publisher_id) else {
-        observer(DirectZmqSubPoolEvent::Lifecycle("unknown_publisher"));
         return;
     };
-    let envelope = ValidatedEnvelope {
-        publisher_id: envelope.publisher_id,
-        sequence: envelope.sequence,
-        published_at: envelope.published_at,
-        payload: envelope.payload,
+    let item = match codec.decode_envelope(&message.payload) {
+        Ok(envelope)
+            if envelope.publisher_id == message.publisher_id
+                && envelope.sequence == message.sequence
+                && envelope.topic == topic =>
+        {
+            DirectZmqSubItem::Envelope(ValidatedEnvelope {
+                publisher_id: envelope.publisher_id,
+                sequence: envelope.sequence,
+                published_at: envelope.published_at,
+                payload: envelope.payload,
+            })
+        }
+        Ok(envelope) => {
+            tracing::warn!(
+                group_id,
+                topic,
+                frame_publisher_id = message.publisher_id,
+                frame_sequence = message.sequence,
+                envelope_publisher_id = envelope.publisher_id,
+                envelope_sequence = envelope.sequence,
+                envelope_topic = %envelope.topic,
+                "Dropping direct-ZMQ envelope with inconsistent attribution"
+            );
+            DirectZmqSubItem::IdentityMismatch
+        }
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                group_id,
+                topic,
+                publisher_id = message.publisher_id,
+                "Failed to decode direct-ZMQ envelope"
+            );
+            DirectZmqSubItem::EnvelopeDecodeError
+        }
     };
-    match route.sender.try_send(envelope) {
+
+    match route.sender.try_send(item) {
         Ok(()) => {}
-        Err(mpsc::error::TrySendError::Full(_)) => {
-            observer(DirectZmqSubPoolEvent::Lifecycle("lane_full"));
-        }
-        Err(mpsc::error::TrySendError::Closed(_)) => {
-            observer(DirectZmqSubPoolEvent::Lifecycle("lane_closed"));
-        }
+        Err(mpsc::error::TrySendError::Full(_)) => tracing::warn!(
+            group_id,
+            topic,
+            publisher_id = message.publisher_id,
+            "Direct-ZMQ publisher lane is full; dropping newest envelope"
+        ),
+        Err(mpsc::error::TrySendError::Closed(_)) => tracing::warn!(
+            group_id,
+            topic,
+            publisher_id = message.publisher_id,
+            "Direct-ZMQ publisher lane is closed; dropping envelope"
+        ),
     }
 }
 
-async fn stop_group(mut group: SocketGroup, observer: &DirectZmqSubPoolObserver) {
+async fn stop_group(mut group: SocketGroup) {
     group.cancel.cancel();
     match tokio::time::timeout(GROUP_JOIN_TIMEOUT, &mut group.handle).await {
         Ok(Ok(())) => {}
@@ -586,10 +557,9 @@ async fn stop_group(mut group: SocketGroup, observer: &DirectZmqSubPoolObserver)
         Err(_) => {
             group.handle.abort();
             let _ = group.handle.await;
-            observer(DirectZmqSubPoolEvent::Lifecycle("group_forced_abort"));
+            tracing::warn!("Direct-ZMQ socket group was aborted during shutdown");
         }
     }
-    observer(DirectZmqSubPoolEvent::Lifecycle("group_stopped"));
 }
 
 #[cfg(test)]
@@ -607,8 +577,8 @@ mod tests {
         }
     }
 
-    fn observer() -> DirectZmqSubPoolObserver {
-        Arc::new(|_| {})
+    fn pool(topic: &str, endpoints_per_sub: usize, rcvhwm: i32) -> DirectZmqSubPool {
+        DirectZmqSubPool::new(topic, endpoints_per_sub, rcvhwm, CancellationToken::new()).unwrap()
     }
 
     fn wire_message(topic: &str, publisher_id: u64, sequence: u64) -> ZmqWireMessage {
@@ -619,6 +589,13 @@ mod tests {
             publisher_id,
             sequence,
             payload,
+        }
+    }
+
+    fn sequence(item: DirectZmqSubItem) -> u64 {
+        match item {
+            DirectZmqSubItem::Envelope(envelope) => envelope.sequence,
+            other => panic!("expected envelope, got {other:?}"),
         }
     }
 
@@ -643,8 +620,7 @@ mod tests {
 
     #[tokio::test]
     async fn creates_three_groups_for_129_publishers() {
-        let pool =
-            DirectZmqSubPool::new("kv-events", 64, observer(), CancellationToken::new()).unwrap();
+        let pool = pool("kv-events", 64, 128);
         let registrations = futures::future::join_all((1..=129).map(|publisher_id| {
             let pool = pool.clone();
             async move {
@@ -659,14 +635,18 @@ mod tests {
         let mut sizes = pool
             .inner
             .lock()
-            .await
             .groups
             .values()
-            .map(|group| group.members.len())
+            .map(|group| group.assignments.len())
             .collect::<Vec<_>>();
         sizes.sort_unstable();
         assert_eq!(sizes, vec![1, 64, 64]);
-        assert_eq!(pool.group_count().await, 3);
+        assert_eq!(pool.group_count(), 3);
+        assert!(
+            registrations
+                .iter()
+                .all(|registration| registration.receiver.max_capacity() == 128)
+        );
 
         drop(registrations);
         pool.shutdown().await;
@@ -676,15 +656,15 @@ mod tests {
     async fn full_publisher_lane_does_not_block_a_sibling() {
         let (full_tx, mut full_rx) = mpsc::channel(1);
         full_tx
-            .try_send(ValidatedEnvelope {
+            .try_send(DirectZmqSubItem::Envelope(ValidatedEnvelope {
                 publisher_id: 1,
                 sequence: 0,
                 published_at: 0,
                 payload: Bytes::new(),
-            })
+            }))
             .unwrap();
         let (sibling_tx, mut sibling_rx) = mpsc::channel(2);
-        let mut routes = HashMap::from([
+        let routes = HashMap::from([
             (
                 1,
                 GroupRoute {
@@ -705,42 +685,38 @@ mod tests {
             ),
         ]);
         let codec = Codec::default();
-        let observer = observer();
 
         dispatch_group_message(
             1,
             "kv_metrics",
             wire_message("kv_metrics", 1, 1),
             &codec,
-            &mut routes,
-            &observer,
+            &routes,
         );
         dispatch_group_message(
             1,
             "kv_metrics",
             wire_message("kv_metrics", 2, 1),
             &codec,
-            &mut routes,
-            &observer,
+            &routes,
         );
         dispatch_group_message(
             1,
             "kv_metrics",
             wire_message("kv_metrics", 2, 2),
             &codec,
-            &mut routes,
-            &observer,
+            &routes,
         );
 
-        assert_eq!(full_rx.recv().await.unwrap().sequence, 0);
-        assert_eq!(sibling_rx.recv().await.unwrap().sequence, 1);
-        assert_eq!(sibling_rx.recv().await.unwrap().sequence, 2);
+        assert_eq!(sequence(full_rx.recv().await.unwrap()), 0);
+        assert_eq!(sequence(sibling_rx.recv().await.unwrap()), 1);
+        assert_eq!(sequence(sibling_rx.recv().await.unwrap()), 2);
     }
 
     #[tokio::test]
-    async fn validates_topic_and_identity_before_dispatch() {
-        let (sender, mut receiver) = mpsc::channel(2);
-        let mut routes = HashMap::from([(
+    async fn publisher_lane_preserves_a_burst_above_the_old_limit() {
+        let (sender, mut receiver) = mpsc::channel(128);
+        let routes = HashMap::from([(
             1,
             GroupRoute {
                 endpoint: "tcp://127.0.0.1:1".to_string(),
@@ -750,50 +726,64 @@ mod tests {
             },
         )]);
         let codec = Codec::default();
-        let observer = observer();
+
+        for sequence in 1..=65 {
+            dispatch_group_message(
+                1,
+                "kv-events",
+                wire_message("kv-events", 1, sequence),
+                &codec,
+                &routes,
+            );
+        }
+        for expected in 1..=65 {
+            assert_eq!(sequence(receiver.recv().await.unwrap()), expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn reports_validation_errors_to_the_affected_publisher() {
+        let (sender, mut receiver) = mpsc::channel(3);
+        let routes = HashMap::from([(
+            1,
+            GroupRoute {
+                endpoint: "tcp://127.0.0.1:1".to_string(),
+                generation: 1,
+                sender,
+                disconnected: CancellationToken::new(),
+            },
+        )]);
+        let codec = Codec::default();
 
         dispatch_group_message(
             1,
             "kv_metrics",
             wire_message("kv-events", 1, 1),
             &codec,
-            &mut routes,
-            &observer,
-        );
-        let mut wrong_publisher = wire_message("kv_metrics", 1, 2);
-        wrong_publisher.publisher_id = 2;
-        dispatch_group_message(
-            1,
-            "kv_metrics",
-            wrong_publisher,
-            &codec,
-            &mut routes,
-            &observer,
+            &routes,
         );
         dispatch_group_message(
             1,
             "kv_metrics",
-            wire_message("kv_metrics", 1, 3),
+            wire_message("kv_metrics", 1, 2),
             &codec,
-            &mut routes,
-            &observer,
+            &routes,
         );
 
-        assert_eq!(receiver.recv().await.unwrap().sequence, 3);
         assert!(matches!(
-            receiver.try_recv(),
-            Err(mpsc::error::TryRecvError::Empty)
+            receiver.recv().await.unwrap(),
+            DirectZmqSubItem::IdentityMismatch
         ));
+        assert_eq!(sequence(receiver.recv().await.unwrap()), 2);
     }
 
     #[tokio::test]
     async fn failed_group_is_replaced_without_affecting_other_groups() {
-        let pool =
-            DirectZmqSubPool::new("kv_metrics", 1, observer(), CancellationToken::new()).unwrap();
+        let pool = pool("kv_metrics", 1, 128);
         let first = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
         let unaffected = pool.register(2, "tcp://127.0.0.1:31002", 2).await.unwrap();
         {
-            let inner = pool.inner.lock().await;
+            let inner = pool.inner.lock();
             inner.groups.get(&first.group_id).unwrap().handle.abort();
         }
         tokio::time::timeout(Duration::from_secs(1), first.disconnected.cancelled())
@@ -803,24 +793,138 @@ mod tests {
 
         let replacement = pool.register(3, "tcp://127.0.0.1:31003", 3).await.unwrap();
         assert_ne!(first.group_id, replacement.group_id);
-        let inner = pool.inner.lock().await;
-        assert!(!inner.groups.contains_key(&first.group_id));
-        assert!(inner.groups.contains_key(&unaffected.group_id));
-        assert!(inner.groups.contains_key(&replacement.group_id));
-        drop(inner);
+        {
+            let inner = pool.inner.lock();
+            assert!(!inner.groups.contains_key(&first.group_id));
+            assert!(inner.groups.contains_key(&unaffected.group_id));
+            assert!(inner.groups.contains_key(&replacement.group_id));
+        }
         pool.shutdown().await;
     }
 
     #[tokio::test]
-    async fn removing_last_publisher_stops_group() {
-        let pool =
-            DirectZmqSubPool::new("kv-events", 64, observer(), CancellationToken::new()).unwrap();
+    async fn removing_last_publisher_stops_group_and_shutdown_closes_pool() {
+        let pool = pool("kv-events", 64, 128);
         let registration = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
 
         pool.unregister(registration.group_id, 1, 1).await;
-
         assert!(registration.disconnected.is_cancelled());
-        assert_eq!(pool.group_count().await, 0);
+        assert_eq!(pool.group_count(), 0);
+
         pool.shutdown().await;
+        assert!(pool.register(2, "tcp://127.0.0.1:31002", 2).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn cancelled_registration_rolls_back_and_can_register_again() {
+        let pool = pool("kv-events", 64, 128);
+        let first = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        pool.inner
+            .lock()
+            .groups
+            .get(&first.group_id)
+            .unwrap()
+            .command_tx
+            .send(GroupCommand::Pause {
+                started: started_tx,
+                release: release_rx,
+            })
+            .unwrap();
+        started_rx.await.unwrap();
+
+        let pending_pool = pool.clone();
+        let pending =
+            tokio::spawn(async move { pending_pool.register(2, "tcp://127.0.0.1:31002", 1).await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if pool
+                    .inner
+                    .lock()
+                    .groups
+                    .get(&first.group_id)
+                    .unwrap()
+                    .assignments
+                    .contains_key(&2)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("registration should reserve a group slot");
+        pending.abort();
+        match pending.await {
+            Err(error) => assert!(error.is_cancelled()),
+            Ok(_) => panic!("registration task should be cancelled"),
+        }
+        assert!(
+            !pool
+                .inner
+                .lock()
+                .groups
+                .get(&first.group_id)
+                .unwrap()
+                .assignments
+                .contains_key(&2)
+        );
+
+        release_tx.send(()).unwrap();
+        let replacement = pool.register(2, "tcp://127.0.0.1:31002", 2).await.unwrap();
+        assert_eq!(replacement.group_id, first.group_id);
+        pool.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_rejects_an_inflight_registration() {
+        let pool = pool("kv-events", 64, 128);
+        let first = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
+        let (started_tx, started_rx) = oneshot::channel();
+        let (_release_tx, release_rx) = oneshot::channel();
+        pool.inner
+            .lock()
+            .groups
+            .get(&first.group_id)
+            .unwrap()
+            .command_tx
+            .send(GroupCommand::Pause {
+                started: started_tx,
+                release: release_rx,
+            })
+            .unwrap();
+        started_rx.await.unwrap();
+
+        let pending_pool = pool.clone();
+        let pending =
+            tokio::spawn(async move { pending_pool.register(2, "tcp://127.0.0.1:31002", 1).await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if pool
+                    .inner
+                    .lock()
+                    .groups
+                    .get(&first.group_id)
+                    .unwrap()
+                    .assignments
+                    .contains_key(&2)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("registration should reserve a group slot");
+
+        pool.shutdown().await;
+        match pending.await {
+            Ok(Err(_)) => {}
+            Ok(Ok(_)) => panic!("in-flight registration must fail during shutdown"),
+            Err(error) => panic!("registration task failed: {error}"),
+        }
+        assert_eq!(pool.group_count(), 0);
+        assert!(first.disconnected.is_cancelled());
     }
 }

--- a/lib/llm/src/direct_zmq_sub_pool.rs
+++ b/lib/llm/src/direct_zmq_sub_pool.rs
@@ -79,7 +79,6 @@ enum GroupCommand {
     Remove {
         publisher_id: u64,
         generation: u64,
-        completed: Option<oneshot::Sender<Result<()>>>,
     },
     #[cfg(test)]
     Pause {
@@ -117,8 +116,11 @@ pub(crate) struct DirectZmqSubPool {
 
 pub(crate) struct DirectZmqSubRegistration {
     pub(crate) group_id: u64,
+    // The receiver must close before the lease queues endpoint removal. This
+    // also wakes a socket group that is waiting for publisher-lane capacity.
     pub(crate) receiver: mpsc::Receiver<DirectZmqSubItem>,
     pub(crate) disconnected: CancellationToken,
+    lease: RegistrationLease,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -128,7 +130,7 @@ enum DispatchOutcome {
     GroupCancelled,
 }
 
-struct PendingRegistration {
+struct RegistrationLease {
     pool: DirectZmqSubPool,
     group_id: u64,
     publisher_id: u64,
@@ -136,7 +138,7 @@ struct PendingRegistration {
     armed: bool,
 }
 
-impl PendingRegistration {
+impl RegistrationLease {
     fn new(pool: DirectZmqSubPool, group_id: u64, publisher_id: u64, generation: u64) -> Self {
         Self {
             pool,
@@ -147,16 +149,21 @@ impl PendingRegistration {
         }
     }
 
-    fn complete(mut self) {
+    fn remove(mut self) -> Option<SocketGroup> {
         self.armed = false;
+        self.pool
+            .remove_registration(self.group_id, self.publisher_id, self.generation)
     }
 }
 
-impl Drop for PendingRegistration {
+impl Drop for RegistrationLease {
     fn drop(&mut self) {
-        if self.armed {
-            self.pool
-                .remove_registration(self.group_id, self.publisher_id, self.generation, None);
+        if self.armed
+            && let Some(group) =
+                self.pool
+                    .remove_registration(self.group_id, self.publisher_id, self.generation)
+        {
+            tokio::spawn(stop_group(group));
         }
     }
 }
@@ -191,11 +198,8 @@ impl DirectZmqSubPool {
     ) -> Result<DirectZmqSubRegistration> {
         enum RegistrationStart {
             Pending {
-                group_id: u64,
-                receiver: mpsc::Receiver<DirectZmqSubItem>,
-                disconnected: CancellationToken,
+                registration: DirectZmqSubRegistration,
                 completion: oneshot::Receiver<Result<()>>,
-                guard: PendingRegistration,
             },
             Ready(DirectZmqSubRegistration),
         }
@@ -247,16 +251,18 @@ impl DirectZmqSubPool {
                     anyhow::bail!("direct-ZMQ socket group stopped");
                 }
                 RegistrationStart::Pending {
-                    group_id,
-                    receiver,
-                    disconnected,
-                    completion,
-                    guard: PendingRegistration::new(
-                        self.clone(),
+                    registration: DirectZmqSubRegistration {
                         group_id,
-                        publisher_id,
-                        generation,
-                    ),
+                        receiver,
+                        disconnected,
+                        lease: RegistrationLease::new(
+                            self.clone(),
+                            group_id,
+                            publisher_id,
+                            generation,
+                        ),
+                    },
+                    completion,
                 }
             } else {
                 // libzmq connects asynchronously. Keep group creation serialized so
@@ -297,18 +303,16 @@ impl DirectZmqSubPool {
                     group_id,
                     receiver,
                     disconnected,
+                    lease: RegistrationLease::new(self.clone(), group_id, publisher_id, generation),
                 })
             }
         };
 
-        let (group_id, receiver, disconnected, completion, guard) = match start {
+        let (registration, completion) = match start {
             RegistrationStart::Pending {
-                group_id,
-                receiver,
-                disconnected,
+                registration,
                 completion,
-                guard,
-            } => (group_id, receiver, disconnected, completion, guard),
+            } => (registration, completion),
             RegistrationStart::Ready(registration) => return Ok(registration),
         };
 
@@ -321,16 +325,11 @@ impl DirectZmqSubPool {
             !inner.closed
                 && inner
                     .groups
-                    .get(&group_id)
+                    .get(&registration.group_id)
                     .is_some_and(|group| group.assignments.get(&publisher_id) == Some(&generation))
         };
         anyhow::ensure!(valid, "direct-ZMQ socket group stopped");
-        guard.complete();
-        Ok(DirectZmqSubRegistration {
-            group_id,
-            receiver,
-            disconnected,
-        })
+        Ok(registration)
     }
 
     pub(crate) async fn unregister(
@@ -340,25 +339,21 @@ impl DirectZmqSubPool {
         generation: u64,
     ) {
         let DirectZmqSubRegistration {
-            group_id,
             receiver,
             disconnected: _,
+            lease,
+            group_id: _,
         } = registration;
         // Wake a group task that may be waiting to send to this publisher before
         // queuing the ordered socket removal below.
         drop(receiver);
 
-        let (completed, group_to_stop) = {
-            let (completed_tx, completed_rx) = oneshot::channel();
-            let group =
-                self.remove_registration(group_id, publisher_id, generation, Some(completed_tx));
-            (completed_rx, group)
-        };
+        debug_assert_eq!(lease.publisher_id, publisher_id);
+        debug_assert_eq!(lease.generation, generation);
+        let group_to_stop = lease.remove();
 
         if let Some(group) = group_to_stop {
             stop_group(group).await;
-        } else {
-            let _ = completed.await;
         }
     }
 
@@ -367,7 +362,6 @@ impl DirectZmqSubPool {
         group_id: u64,
         publisher_id: u64,
         generation: u64,
-        completed: Option<oneshot::Sender<Result<()>>>,
     ) -> Option<SocketGroup> {
         let mut inner = self.inner.lock();
         Self::reap_failed_groups(&mut inner);
@@ -388,7 +382,6 @@ impl DirectZmqSubPool {
         let _ = group.command_tx.send(GroupCommand::Remove {
             publisher_id,
             generation,
-            completed,
         });
         None
     }
@@ -462,10 +455,16 @@ async fn run_socket_group(
                         };
                         let _ = completed.send(result);
                     }
-                    GroupCommand::Remove { publisher_id, generation, completed } => {
-                        let result = remove_route(&mut socket, &mut routes, publisher_id, generation);
-                        if let Some(completed) = completed {
-                            let _ = completed.send(result);
+                    GroupCommand::Remove { publisher_id, generation } => {
+                        if let Err(error) = remove_route(&mut socket, &mut routes, publisher_id, generation) {
+                            tracing::warn!(
+                                %error,
+                                group_id,
+                                topic = %topic,
+                                publisher_id,
+                                generation,
+                                "Failed to remove direct-ZMQ publisher endpoint"
+                            );
                         }
                     }
                     #[cfg(test)]
@@ -797,18 +796,59 @@ mod tests {
             blocked.try_recv(),
             Err(oneshot::error::TryRecvError::Empty)
         ));
+        let mut sibling_blocked =
+            dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 2, 0));
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            sibling_blocked.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
 
         assert_eq!(sequence(source.receiver.recv().await.unwrap()), 0);
         assert_eq!(blocked.await.unwrap(), DispatchOutcome::Delivered);
         assert_eq!(sequence(source.receiver.recv().await.unwrap()), 1);
+        assert_eq!(sibling_blocked.await.unwrap(), DispatchOutcome::Delivered);
+        assert_eq!(sequence(sibling.receiver.recv().await.unwrap()), 0);
+        pool.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn remove_then_add_stays_ordered_while_a_sibling_lane_is_blocked() {
+        let pool = pool("kv_metrics", 64, 1);
+        let mut blocked_source = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
+        let old = pool.register(2, "tcp://127.0.0.1:31002", 1).await.unwrap();
+        let group_id = blocked_source.group_id;
 
         assert_eq!(
-            dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 2, 0),)
+            dispatch_on_group(&pool, group_id, wire_message("kv_metrics", 1, 0))
                 .await
                 .unwrap(),
             DispatchOutcome::Delivered
         );
-        assert_eq!(sequence(sibling.receiver.recv().await.unwrap()), 0);
+        let blocked = dispatch_on_group(&pool, group_id, wire_message("kv_metrics", 1, 1));
+        tokio::task::yield_now().await;
+
+        drop(old);
+        let replacement_pool = pool.clone();
+        let replacement = tokio::spawn(async move {
+            replacement_pool
+                .register(2, "tcp://127.0.0.1:31002", 2)
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert!(!replacement.is_finished());
+
+        assert_eq!(sequence(blocked_source.receiver.recv().await.unwrap()), 0);
+        assert_eq!(blocked.await.unwrap(), DispatchOutcome::Delivered);
+        let mut replacement = replacement.await.unwrap().unwrap();
+        assert_eq!(replacement.group_id, group_id);
+        assert_eq!(
+            dispatch_on_group(&pool, group_id, wire_message("kv_metrics", 2, 0))
+                .await
+                .unwrap(),
+            DispatchOutcome::Delivered
+        );
+        assert_eq!(sequence(replacement.receiver.recv().await.unwrap()), 0);
         pool.shutdown().await;
     }
 
@@ -923,9 +963,12 @@ mod tests {
 
     #[tokio::test]
     async fn failed_group_is_replaced_without_affecting_other_groups() {
-        let pool = pool("kv_metrics", 1, 128);
+        let pool = pool("kv_metrics", 2, 128);
         let first = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
-        let unaffected = pool.register(2, "tcp://127.0.0.1:31002", 2).await.unwrap();
+        let second = pool.register(2, "tcp://127.0.0.1:31002", 1).await.unwrap();
+        let mut unaffected = pool.register(3, "tcp://127.0.0.1:31003", 1).await.unwrap();
+        assert_eq!(first.group_id, second.group_id);
+        assert_ne!(first.group_id, unaffected.group_id);
         {
             let inner = pool.inner.lock();
             inner.groups.get(&first.group_id).unwrap().handle.abort();
@@ -933,9 +976,19 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), first.disconnected.cancelled())
             .await
             .expect("failed group must disconnect its publishers");
+        tokio::time::timeout(Duration::from_secs(1), second.disconnected.cancelled())
+            .await
+            .expect("failed group must disconnect all its publishers");
         assert!(!unaffected.disconnected.is_cancelled());
+        assert_eq!(
+            dispatch_on_group(&pool, unaffected.group_id, wire_message("kv_metrics", 3, 0),)
+                .await
+                .unwrap(),
+            DispatchOutcome::Delivered
+        );
+        assert_eq!(sequence(unaffected.receiver.recv().await.unwrap()), 0);
 
-        let replacement = pool.register(3, "tcp://127.0.0.1:31003", 3).await.unwrap();
+        let replacement = pool.register(1, "tcp://127.0.0.1:31001", 2).await.unwrap();
         assert_ne!(first.group_id, replacement.group_id);
         {
             let inner = pool.inner.lock();
@@ -958,6 +1011,24 @@ mod tests {
 
         pool.shutdown().await;
         assert!(pool.register(2, "tcp://127.0.0.1:31002", 2).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn dropping_an_active_registration_removes_its_assignment() {
+        let pool = pool("kv-events", 64, 128);
+        let registration = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
+        let disconnected = registration.disconnected.clone();
+
+        drop(registration);
+
+        assert_eq!(pool.group_count(), 0);
+        tokio::time::timeout(Duration::from_secs(1), disconnected.cancelled())
+            .await
+            .expect("registration drop must stop its final socket group");
+        let replacement = pool.register(1, "tcp://127.0.0.1:31001", 2).await.unwrap();
+        assert_eq!(pool.group_count(), 1);
+        drop(replacement);
+        pool.shutdown().await;
     }
 
     #[tokio::test]

--- a/lib/llm/src/direct_zmq_sub_pool.rs
+++ b/lib/llm/src/direct_zmq_sub_pool.rs
@@ -1,0 +1,826 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared direct-ZMQ SUB socket grouping for high-fanout KV ingress.
+
+use std::{
+    collections::HashMap,
+    ffi::{OsStr, OsString},
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::Result;
+use dynamo_runtime::transports::event_plane::{
+    Codec, DynamicZmqSubSocket, ValidatedEnvelope, ZmqWireMessage,
+};
+use tokio::{
+    sync::{Mutex, mpsc, oneshot},
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+
+const GROUP_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
+const GROUP_COMMAND_CAPACITY: usize = 128;
+const PUBLISHER_LANE_CAPACITY: usize = 64;
+
+pub(crate) const ENDPOINTS_PER_SUB_ENV: &str = "DYN_ROUTER_KV_ZMQ_ENDPOINTS_PER_SUB";
+pub(crate) const DEFAULT_ENDPOINTS_PER_SUB: usize = 64;
+
+pub(crate) fn endpoints_per_sub_from_env() -> Result<usize> {
+    endpoints_per_sub_from_lookup(|key| std::env::var_os(key))
+}
+
+fn endpoints_per_sub_from_lookup(
+    mut lookup: impl FnMut(&str) -> Option<OsString>,
+) -> Result<usize> {
+    let Some(raw) = lookup(ENDPOINTS_PER_SUB_ENV) else {
+        return Ok(DEFAULT_ENDPOINTS_PER_SUB);
+    };
+    parse_endpoints_per_sub(&raw)
+}
+
+fn parse_endpoints_per_sub(raw: &OsStr) -> Result<usize> {
+    let value = raw
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("{ENDPOINTS_PER_SUB_ENV} must be valid UTF-8"))?
+        .parse::<usize>()
+        .map_err(|_| anyhow::anyhow!("{ENDPOINTS_PER_SUB_ENV} must be a positive integer"))?;
+    anyhow::ensure!(value > 0, "{ENDPOINTS_PER_SUB_ENV} must be positive");
+    Ok(value)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DirectZmqSubPoolEvent {
+    SocketGroups(i64),
+    ConnectedEndpoints(i64),
+    Lifecycle(&'static str),
+}
+
+pub(crate) type DirectZmqSubPoolObserver =
+    Arc<dyn Fn(DirectZmqSubPoolEvent) + Send + Sync + 'static>;
+
+struct GroupRoute {
+    endpoint: String,
+    generation: u64,
+    sender: mpsc::Sender<ValidatedEnvelope>,
+    disconnected: CancellationToken,
+}
+
+impl Drop for GroupRoute {
+    fn drop(&mut self) {
+        self.disconnected.cancel();
+    }
+}
+
+enum GroupCommand {
+    Add {
+        publisher_id: u64,
+        route: GroupRoute,
+        completed: oneshot::Sender<Result<()>>,
+    },
+    Remove {
+        publisher_id: u64,
+        generation: u64,
+        completed: oneshot::Sender<Result<()>>,
+    },
+}
+
+struct SocketGroup {
+    members: HashMap<u64, GroupMember>,
+    command_tx: mpsc::Sender<GroupCommand>,
+    cancel: CancellationToken,
+    handle: JoinHandle<()>,
+}
+
+struct GroupMember {
+    generation: u64,
+    connected: bool,
+}
+
+struct PoolInner {
+    groups: HashMap<u64, SocketGroup>,
+    next_group_id: u64,
+}
+
+#[derive(Clone)]
+pub(crate) struct DirectZmqSubPool {
+    inner: Arc<Mutex<PoolInner>>,
+    topic: Arc<str>,
+    endpoints_per_sub: usize,
+    rcvhwm: Option<i32>,
+    observer: DirectZmqSubPoolObserver,
+    cancellation_token: CancellationToken,
+}
+
+pub(crate) struct DirectZmqSubRegistration {
+    pub(crate) group_id: u64,
+    pub(crate) receiver: mpsc::Receiver<ValidatedEnvelope>,
+    pub(crate) disconnected: CancellationToken,
+}
+
+impl DirectZmqSubPool {
+    pub(crate) fn new(
+        topic: impl Into<Arc<str>>,
+        endpoints_per_sub: usize,
+        observer: DirectZmqSubPoolObserver,
+        cancellation_token: CancellationToken,
+    ) -> Result<Self> {
+        Self::new_inner(topic, endpoints_per_sub, None, observer, cancellation_token)
+    }
+
+    pub(crate) fn new_with_rcvhwm(
+        topic: impl Into<Arc<str>>,
+        endpoints_per_sub: usize,
+        rcvhwm: i32,
+        observer: DirectZmqSubPoolObserver,
+        cancellation_token: CancellationToken,
+    ) -> Result<Self> {
+        anyhow::ensure!(rcvhwm > 0, "ZMQ receive HWM must be greater than zero");
+        Self::new_inner(
+            topic,
+            endpoints_per_sub,
+            Some(rcvhwm),
+            observer,
+            cancellation_token,
+        )
+    }
+
+    fn new_inner(
+        topic: impl Into<Arc<str>>,
+        endpoints_per_sub: usize,
+        rcvhwm: Option<i32>,
+        observer: DirectZmqSubPoolObserver,
+        cancellation_token: CancellationToken,
+    ) -> Result<Self> {
+        anyhow::ensure!(endpoints_per_sub > 0, "endpoints per SUB must be positive");
+        Ok(Self {
+            inner: Arc::new(Mutex::new(PoolInner {
+                groups: HashMap::new(),
+                next_group_id: 1,
+            })),
+            topic: topic.into(),
+            endpoints_per_sub,
+            rcvhwm,
+            observer,
+            cancellation_token,
+        })
+    }
+
+    pub(crate) async fn register(
+        &self,
+        publisher_id: u64,
+        endpoint: &str,
+        generation: u64,
+    ) -> Result<DirectZmqSubRegistration> {
+        let (sender, receiver) = mpsc::channel(PUBLISHER_LANE_CAPACITY);
+        let disconnected = CancellationToken::new();
+        let mut inner = self.inner.lock().await;
+        self.reap_failed_groups(&mut inner);
+        anyhow::ensure!(
+            inner
+                .groups
+                .values()
+                .all(|group| !group.members.contains_key(&publisher_id)),
+            "publisher {publisher_id} is already registered"
+        );
+
+        let group_id = inner
+            .groups
+            .iter()
+            .filter(|(_, group)| {
+                group.members.len() < self.endpoints_per_sub
+                    && !group.command_tx.is_closed()
+                    && !group.handle.is_finished()
+            })
+            .min_by_key(|(group_id, group)| (group.members.len(), **group_id))
+            .map(|(group_id, _)| *group_id);
+
+        if let Some(group_id) = group_id {
+            let group = inner
+                .groups
+                .get_mut(&group_id)
+                .expect("selected socket group must exist");
+            group.members.insert(
+                publisher_id,
+                GroupMember {
+                    generation,
+                    connected: false,
+                },
+            );
+            let command_tx = group.command_tx.clone();
+            drop(inner);
+            let (completed, completion) = oneshot::channel();
+            let result = async {
+                command_tx
+                    .send(GroupCommand::Add {
+                        publisher_id,
+                        route: GroupRoute {
+                            endpoint: endpoint.to_string(),
+                            generation,
+                            sender,
+                            disconnected: disconnected.clone(),
+                        },
+                        completed,
+                    })
+                    .await
+                    .map_err(|_| anyhow::anyhow!("direct-ZMQ socket group stopped"))?;
+                completion
+                    .await
+                    .map_err(|_| anyhow::anyhow!("direct-ZMQ socket group stopped"))?
+            }
+            .await;
+            if let Err(error) = result {
+                self.rollback_registration(group_id, publisher_id, generation)
+                    .await;
+                return Err(error);
+            }
+            let marked_connected = {
+                let mut inner = self.inner.lock().await;
+                self.reap_failed_groups(&mut inner);
+                inner
+                    .groups
+                    .get_mut(&group_id)
+                    .and_then(|group| group.members.get_mut(&publisher_id))
+                    .filter(|member| member.generation == generation)
+                    .is_some_and(|member| {
+                        member.connected = true;
+                        true
+                    })
+            };
+            anyhow::ensure!(marked_connected, "direct-ZMQ socket group stopped");
+            self.observe(DirectZmqSubPoolEvent::ConnectedEndpoints(1));
+            return Ok(DirectZmqSubRegistration {
+                group_id,
+                receiver,
+                disconnected,
+            });
+        }
+
+        let socket = match self.rcvhwm {
+            Some(rcvhwm) => {
+                DynamicZmqSubSocket::connect_with_rcvhwm(endpoint, &self.topic, rcvhwm)?
+            }
+            None => DynamicZmqSubSocket::connect(endpoint, &self.topic)?,
+        };
+        let group_id = inner.next_group_id;
+        inner.next_group_id = inner.next_group_id.wrapping_add(1);
+        let (command_tx, command_rx) = mpsc::channel(GROUP_COMMAND_CAPACITY);
+        let cancel = self.cancellation_token.child_token();
+        let mut routes = HashMap::new();
+        routes.insert(
+            publisher_id,
+            GroupRoute {
+                endpoint: endpoint.to_string(),
+                generation,
+                sender,
+                disconnected: disconnected.clone(),
+            },
+        );
+        let handle = tokio::spawn(run_socket_group(
+            group_id,
+            self.topic.clone(),
+            socket,
+            routes,
+            command_rx,
+            self.observer.clone(),
+            cancel.clone(),
+        ));
+        inner.groups.insert(
+            group_id,
+            SocketGroup {
+                members: HashMap::from([(
+                    publisher_id,
+                    GroupMember {
+                        generation,
+                        connected: true,
+                    },
+                )]),
+                command_tx,
+                cancel,
+                handle,
+            },
+        );
+        self.observe(DirectZmqSubPoolEvent::SocketGroups(1));
+        self.observe(DirectZmqSubPoolEvent::ConnectedEndpoints(1));
+        self.observe(DirectZmqSubPoolEvent::Lifecycle("group_started"));
+        Ok(DirectZmqSubRegistration {
+            group_id,
+            receiver,
+            disconnected,
+        })
+    }
+
+    pub(crate) async fn unregister(&self, group_id: u64, publisher_id: u64, generation: u64) {
+        let mut group_to_stop = None;
+        let command_tx = {
+            let mut inner = self.inner.lock().await;
+            self.reap_failed_groups(&mut inner);
+            let Some(group) = inner.groups.get_mut(&group_id) else {
+                return;
+            };
+            let Some(member) = group.members.get(&publisher_id) else {
+                return;
+            };
+            if member.generation != generation {
+                return;
+            }
+            let connected = member.connected;
+            group.members.remove(&publisher_id);
+            if connected {
+                self.observe(DirectZmqSubPoolEvent::ConnectedEndpoints(-1));
+            }
+            if group.members.is_empty() {
+                group_to_stop = inner.groups.remove(&group_id);
+                self.observe(DirectZmqSubPoolEvent::SocketGroups(-1));
+                None
+            } else {
+                Some(group.command_tx.clone())
+            }
+        };
+        if let Some(command_tx) = command_tx {
+            let (completed, completion) = oneshot::channel();
+            let removed = command_tx
+                .send(GroupCommand::Remove {
+                    publisher_id,
+                    generation,
+                    completed,
+                })
+                .await
+                .is_ok()
+                && completion.await.is_ok_and(|result| result.is_ok());
+            if !removed {
+                self.observe(DirectZmqSubPoolEvent::Lifecycle("group_command_error"));
+            }
+        }
+        if let Some(group) = group_to_stop {
+            stop_group(group, &self.observer).await;
+        }
+    }
+
+    async fn rollback_registration(&self, group_id: u64, publisher_id: u64, generation: u64) {
+        let mut group_to_stop = None;
+        let command_tx = {
+            let mut inner = self.inner.lock().await;
+            self.reap_failed_groups(&mut inner);
+            let Some(group) = inner.groups.get_mut(&group_id) else {
+                return;
+            };
+            let Some(member) = group.members.get(&publisher_id) else {
+                return;
+            };
+            if member.generation != generation {
+                return;
+            }
+            group.members.remove(&publisher_id);
+            if group.members.is_empty() {
+                group_to_stop = inner.groups.remove(&group_id);
+                self.observe(DirectZmqSubPoolEvent::SocketGroups(-1));
+                None
+            } else {
+                Some(group.command_tx.clone())
+            }
+        };
+        if let Some(command_tx) = command_tx {
+            let (completed, completion) = oneshot::channel();
+            let _ = command_tx
+                .send(GroupCommand::Remove {
+                    publisher_id,
+                    generation,
+                    completed,
+                })
+                .await;
+            let _ = completion.await;
+        }
+        if let Some(group) = group_to_stop {
+            stop_group(group, &self.observer).await;
+        }
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        let groups = {
+            let mut inner = self.inner.lock().await;
+            let groups = inner
+                .groups
+                .drain()
+                .map(|(_, group)| group)
+                .collect::<Vec<_>>();
+            for group in &groups {
+                self.observe(DirectZmqSubPoolEvent::SocketGroups(-1));
+                self.observe(DirectZmqSubPoolEvent::ConnectedEndpoints(
+                    -(group
+                        .members
+                        .values()
+                        .filter(|member| member.connected)
+                        .count() as i64),
+                ));
+                group.cancel.cancel();
+            }
+            groups
+        };
+        futures::future::join_all(
+            groups
+                .into_iter()
+                .map(|group| stop_group(group, &self.observer)),
+        )
+        .await;
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn group_count(&self) -> usize {
+        self.inner.lock().await.groups.len()
+    }
+
+    fn reap_failed_groups(&self, inner: &mut PoolInner) {
+        let failed = inner
+            .groups
+            .iter()
+            .filter_map(|(group_id, group)| {
+                (group.command_tx.is_closed() || group.handle.is_finished()).then_some(*group_id)
+            })
+            .collect::<Vec<_>>();
+        for group_id in failed {
+            if let Some(group) = inner.groups.remove(&group_id) {
+                self.observe(DirectZmqSubPoolEvent::SocketGroups(-1));
+                self.observe(DirectZmqSubPoolEvent::ConnectedEndpoints(
+                    -(group
+                        .members
+                        .values()
+                        .filter(|member| member.connected)
+                        .count() as i64),
+                ));
+                self.observe(DirectZmqSubPoolEvent::Lifecycle("group_reaped"));
+                group.cancel.cancel();
+            }
+        }
+    }
+
+    fn observe(&self, event: DirectZmqSubPoolEvent) {
+        (self.observer)(event);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_socket_group(
+    group_id: u64,
+    topic: Arc<str>,
+    mut socket: DynamicZmqSubSocket,
+    mut routes: HashMap<u64, GroupRoute>,
+    mut command_rx: mpsc::Receiver<GroupCommand>,
+    observer: DirectZmqSubPoolObserver,
+    cancellation_token: CancellationToken,
+) {
+    let codec = Codec::default();
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancellation_token.cancelled() => return,
+            command = command_rx.recv() => {
+                let Some(command) = command else {
+                    return;
+                };
+                match command {
+                    GroupCommand::Add { publisher_id, route, completed } => {
+                        let result = if routes.contains_key(&publisher_id) {
+                            Err(anyhow::anyhow!("publisher {publisher_id} is already registered"))
+                        } else if routes.values().any(|existing| existing.endpoint == route.endpoint) {
+                            Err(anyhow::anyhow!("endpoint {} is already registered", route.endpoint))
+                        } else {
+                            socket.add_endpoint(&route.endpoint).map(|()| {
+                                routes.insert(publisher_id, route);
+                            })
+                        };
+                        let _ = completed.send(result);
+                    }
+                    GroupCommand::Remove { publisher_id, generation, completed } => {
+                        let result = match routes.get(&publisher_id) {
+                            Some(route) if route.generation == generation => {
+                                let route = routes.remove(&publisher_id).expect("route was present");
+                                socket.remove_endpoint(&route.endpoint)
+                            }
+                            _ => Ok(()),
+                        };
+                        let _ = completed.send(result);
+                    }
+                }
+            }
+            message = socket.next() => {
+                let Some(message) = message else {
+                    observer(DirectZmqSubPoolEvent::Lifecycle("group_failure"));
+                    return;
+                };
+                let message = match message {
+                    Ok(message) => message,
+                    Err(error) => {
+                        tracing::warn!(%error, group_id, topic = %topic, "Direct-ZMQ socket group receive failed");
+                        observer(DirectZmqSubPoolEvent::Lifecycle("group_failure"));
+                        return;
+                    }
+                };
+                dispatch_group_message(group_id, &topic, message, &codec, &mut routes, &observer);
+            }
+        }
+    }
+}
+
+fn dispatch_group_message(
+    group_id: u64,
+    topic: &str,
+    message: ZmqWireMessage,
+    codec: &Codec,
+    routes: &mut HashMap<u64, GroupRoute>,
+    observer: &DirectZmqSubPoolObserver,
+) {
+    let envelope = match codec.decode_envelope(&message.payload) {
+        Ok(envelope) => envelope,
+        Err(error) => {
+            tracing::warn!(%error, group_id, topic, publisher_id = message.publisher_id, "Failed to decode direct-ZMQ envelope");
+            observer(DirectZmqSubPoolEvent::Lifecycle("envelope_decode_error"));
+            return;
+        }
+    };
+    if envelope.publisher_id != message.publisher_id
+        || envelope.sequence != message.sequence
+        || envelope.topic != topic
+    {
+        tracing::warn!(
+            group_id,
+            topic,
+            frame_publisher_id = message.publisher_id,
+            frame_sequence = message.sequence,
+            envelope_publisher_id = envelope.publisher_id,
+            envelope_sequence = envelope.sequence,
+            envelope_topic = %envelope.topic,
+            "Dropping direct-ZMQ envelope with inconsistent attribution"
+        );
+        observer(DirectZmqSubPoolEvent::Lifecycle("identity_mismatch"));
+        return;
+    }
+    let Some(route) = routes.get(&message.publisher_id) else {
+        observer(DirectZmqSubPoolEvent::Lifecycle("unknown_publisher"));
+        return;
+    };
+    let envelope = ValidatedEnvelope {
+        publisher_id: envelope.publisher_id,
+        sequence: envelope.sequence,
+        published_at: envelope.published_at,
+        payload: envelope.payload,
+    };
+    match route.sender.try_send(envelope) {
+        Ok(()) => {}
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            observer(DirectZmqSubPoolEvent::Lifecycle("lane_full"));
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            observer(DirectZmqSubPoolEvent::Lifecycle("lane_closed"));
+        }
+    }
+}
+
+async fn stop_group(mut group: SocketGroup, observer: &DirectZmqSubPoolObserver) {
+    group.cancel.cancel();
+    match tokio::time::timeout(GROUP_JOIN_TIMEOUT, &mut group.handle).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) if error.is_cancelled() => {}
+        Ok(Err(error)) => tracing::warn!(%error, "Direct-ZMQ socket group failed during shutdown"),
+        Err(_) => {
+            group.handle.abort();
+            let _ = group.handle.await;
+            observer(DirectZmqSubPoolEvent::Lifecycle("group_forced_abort"));
+        }
+    }
+    observer(DirectZmqSubPoolEvent::Lifecycle("group_stopped"));
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+
+    fn config_lookup(value: Option<&str>) -> impl FnMut(&str) -> Option<OsString> {
+        let value = value.map(OsString::from);
+        move |key| {
+            (key == ENDPOINTS_PER_SUB_ENV)
+                .then(|| value.clone())
+                .flatten()
+        }
+    }
+
+    fn observer() -> DirectZmqSubPoolObserver {
+        Arc::new(|_| {})
+    }
+
+    fn wire_message(topic: &str, publisher_id: u64, sequence: u64) -> ZmqWireMessage {
+        let payload = Codec::default()
+            .encode_envelope_parts(publisher_id, sequence, 1, topic, b"payload")
+            .unwrap();
+        ZmqWireMessage {
+            publisher_id,
+            sequence,
+            payload,
+        }
+    }
+
+    #[test]
+    fn parses_endpoints_per_sub_configuration() {
+        assert_eq!(
+            endpoints_per_sub_from_lookup(config_lookup(None)).unwrap(),
+            DEFAULT_ENDPOINTS_PER_SUB
+        );
+        assert_eq!(
+            endpoints_per_sub_from_lookup(config_lookup(Some("1"))).unwrap(),
+            1
+        );
+        assert_eq!(
+            endpoints_per_sub_from_lookup(config_lookup(Some("128"))).unwrap(),
+            128
+        );
+        for invalid in ["", "0", "-1", "not-a-number"] {
+            assert!(endpoints_per_sub_from_lookup(config_lookup(Some(invalid))).is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn creates_three_groups_for_129_publishers() {
+        let pool =
+            DirectZmqSubPool::new("kv-events", 64, observer(), CancellationToken::new()).unwrap();
+        let registrations = futures::future::join_all((1..=129).map(|publisher_id| {
+            let pool = pool.clone();
+            async move {
+                let endpoint = format!("tcp://127.0.0.1:{}", 30_000 + publisher_id);
+                pool.register(publisher_id, &endpoint, publisher_id)
+                    .await
+                    .unwrap()
+            }
+        }))
+        .await;
+
+        let mut sizes = pool
+            .inner
+            .lock()
+            .await
+            .groups
+            .values()
+            .map(|group| group.members.len())
+            .collect::<Vec<_>>();
+        sizes.sort_unstable();
+        assert_eq!(sizes, vec![1, 64, 64]);
+        assert_eq!(pool.group_count().await, 3);
+
+        drop(registrations);
+        pool.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn full_publisher_lane_does_not_block_a_sibling() {
+        let (full_tx, mut full_rx) = mpsc::channel(1);
+        full_tx
+            .try_send(ValidatedEnvelope {
+                publisher_id: 1,
+                sequence: 0,
+                published_at: 0,
+                payload: Bytes::new(),
+            })
+            .unwrap();
+        let (sibling_tx, mut sibling_rx) = mpsc::channel(2);
+        let mut routes = HashMap::from([
+            (
+                1,
+                GroupRoute {
+                    endpoint: "tcp://127.0.0.1:1".to_string(),
+                    generation: 1,
+                    sender: full_tx,
+                    disconnected: CancellationToken::new(),
+                },
+            ),
+            (
+                2,
+                GroupRoute {
+                    endpoint: "tcp://127.0.0.1:2".to_string(),
+                    generation: 1,
+                    sender: sibling_tx,
+                    disconnected: CancellationToken::new(),
+                },
+            ),
+        ]);
+        let codec = Codec::default();
+        let observer = observer();
+
+        dispatch_group_message(
+            1,
+            "kv_metrics",
+            wire_message("kv_metrics", 1, 1),
+            &codec,
+            &mut routes,
+            &observer,
+        );
+        dispatch_group_message(
+            1,
+            "kv_metrics",
+            wire_message("kv_metrics", 2, 1),
+            &codec,
+            &mut routes,
+            &observer,
+        );
+        dispatch_group_message(
+            1,
+            "kv_metrics",
+            wire_message("kv_metrics", 2, 2),
+            &codec,
+            &mut routes,
+            &observer,
+        );
+
+        assert_eq!(full_rx.recv().await.unwrap().sequence, 0);
+        assert_eq!(sibling_rx.recv().await.unwrap().sequence, 1);
+        assert_eq!(sibling_rx.recv().await.unwrap().sequence, 2);
+    }
+
+    #[tokio::test]
+    async fn validates_topic_and_identity_before_dispatch() {
+        let (sender, mut receiver) = mpsc::channel(2);
+        let mut routes = HashMap::from([(
+            1,
+            GroupRoute {
+                endpoint: "tcp://127.0.0.1:1".to_string(),
+                generation: 1,
+                sender,
+                disconnected: CancellationToken::new(),
+            },
+        )]);
+        let codec = Codec::default();
+        let observer = observer();
+
+        dispatch_group_message(
+            1,
+            "kv_metrics",
+            wire_message("kv-events", 1, 1),
+            &codec,
+            &mut routes,
+            &observer,
+        );
+        let mut wrong_publisher = wire_message("kv_metrics", 1, 2);
+        wrong_publisher.publisher_id = 2;
+        dispatch_group_message(
+            1,
+            "kv_metrics",
+            wrong_publisher,
+            &codec,
+            &mut routes,
+            &observer,
+        );
+        dispatch_group_message(
+            1,
+            "kv_metrics",
+            wire_message("kv_metrics", 1, 3),
+            &codec,
+            &mut routes,
+            &observer,
+        );
+
+        assert_eq!(receiver.recv().await.unwrap().sequence, 3);
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn failed_group_is_replaced_without_affecting_other_groups() {
+        let pool =
+            DirectZmqSubPool::new("kv_metrics", 1, observer(), CancellationToken::new()).unwrap();
+        let first = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
+        let unaffected = pool.register(2, "tcp://127.0.0.1:31002", 2).await.unwrap();
+        {
+            let inner = pool.inner.lock().await;
+            inner.groups.get(&first.group_id).unwrap().handle.abort();
+        }
+        tokio::time::timeout(Duration::from_secs(1), first.disconnected.cancelled())
+            .await
+            .expect("failed group must disconnect its publishers");
+        assert!(!unaffected.disconnected.is_cancelled());
+
+        let replacement = pool.register(3, "tcp://127.0.0.1:31003", 3).await.unwrap();
+        assert_ne!(first.group_id, replacement.group_id);
+        let inner = pool.inner.lock().await;
+        assert!(!inner.groups.contains_key(&first.group_id));
+        assert!(inner.groups.contains_key(&unaffected.group_id));
+        assert!(inner.groups.contains_key(&replacement.group_id));
+        drop(inner);
+        pool.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn removing_last_publisher_stops_group() {
+        let pool =
+            DirectZmqSubPool::new("kv-events", 64, observer(), CancellationToken::new()).unwrap();
+        let registration = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
+
+        pool.unregister(registration.group_id, 1, 1).await;
+
+        assert!(registration.disconnected.is_cancelled());
+        assert_eq!(pool.group_count().await, 0);
+        pool.shutdown().await;
+    }
+}

--- a/lib/llm/src/direct_zmq_sub_pool.rs
+++ b/lib/llm/src/direct_zmq_sub_pool.rs
@@ -23,7 +23,7 @@ use tokio_util::sync::CancellationToken;
 
 const GROUP_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
 
-pub(crate) const ENDPOINTS_PER_SUB_ENV: &str = "DYN_ROUTER_KV_ZMQ_ENDPOINTS_PER_SUB";
+pub(crate) const ENDPOINTS_PER_SUB_ENV: &str = "DYN_ROUTER_ZMQ_ENDPOINTS_PER_SUB";
 pub(crate) const DEFAULT_ENDPOINTS_PER_SUB: usize = 64;
 pub(crate) const KV_ZMQ_RCVHWM: i32 = 100_000;
 

--- a/lib/llm/src/direct_zmq_sub_pool.rs
+++ b/lib/llm/src/direct_zmq_sub_pool.rs
@@ -116,11 +116,12 @@ pub(crate) struct DirectZmqSubPool {
 
 pub(crate) struct DirectZmqSubRegistration {
     pub(crate) group_id: u64,
-    // The receiver must close before the lease queues endpoint removal. This
-    // also wakes a socket group that is waiting for publisher-lane capacity.
     pub(crate) receiver: mpsc::Receiver<DirectZmqSubItem>,
     pub(crate) disconnected: CancellationToken,
-    lease: RegistrationLease,
+    pool: DirectZmqSubPool,
+    publisher_id: u64,
+    generation: u64,
+    armed: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -130,39 +131,29 @@ enum DispatchOutcome {
     GroupCancelled,
 }
 
-struct RegistrationLease {
-    pool: DirectZmqSubPool,
-    group_id: u64,
-    publisher_id: u64,
-    generation: u64,
-    armed: bool,
-}
-
-impl RegistrationLease {
-    fn new(pool: DirectZmqSubPool, group_id: u64, publisher_id: u64, generation: u64) -> Self {
-        Self {
-            pool,
-            group_id,
-            publisher_id,
-            generation,
-            armed: true,
+impl DirectZmqSubRegistration {
+    fn release(&mut self) -> Option<SocketGroup> {
+        if !self.armed {
+            return None;
         }
-    }
-
-    fn remove(mut self) -> Option<SocketGroup> {
+        // Wake a group task that may be waiting for this publisher before
+        // queuing the ordered endpoint removal.
+        self.receiver.close();
         self.armed = false;
         self.pool
             .remove_registration(self.group_id, self.publisher_id, self.generation)
     }
+
+    pub(crate) async fn close(mut self) {
+        if let Some(group) = self.release() {
+            stop_group(group).await;
+        }
+    }
 }
 
-impl Drop for RegistrationLease {
+impl Drop for DirectZmqSubRegistration {
     fn drop(&mut self) {
-        if self.armed
-            && let Some(group) =
-                self.pool
-                    .remove_registration(self.group_id, self.publisher_id, self.generation)
-        {
+        if let Some(group) = self.release() {
             tokio::spawn(stop_group(group));
         }
     }
@@ -196,17 +187,9 @@ impl DirectZmqSubPool {
         endpoint: &str,
         generation: u64,
     ) -> Result<DirectZmqSubRegistration> {
-        enum RegistrationStart {
-            Pending {
-                registration: DirectZmqSubRegistration,
-                completion: oneshot::Receiver<Result<()>>,
-            },
-            Ready(DirectZmqSubRegistration),
-        }
-
         let (sender, receiver) = mpsc::channel(self.rcvhwm as usize);
         let disconnected = CancellationToken::new();
-        let start = {
+        let (group_id, completion) = {
             let mut inner = self.inner.lock();
             Self::reap_failed_groups(&mut inner);
             anyhow::ensure!(!inner.closed, "direct-ZMQ socket pool is closed");
@@ -250,20 +233,7 @@ impl DirectZmqSubPool {
                     group.assignments.remove(&publisher_id);
                     anyhow::bail!("direct-ZMQ socket group stopped");
                 }
-                RegistrationStart::Pending {
-                    registration: DirectZmqSubRegistration {
-                        group_id,
-                        receiver,
-                        disconnected,
-                        lease: RegistrationLease::new(
-                            self.clone(),
-                            group_id,
-                            publisher_id,
-                            generation,
-                        ),
-                    },
-                    completion,
-                }
+                (group_id, Some(completion))
             } else {
                 // libzmq connects asynchronously. Keep group creation serialized so
                 // concurrent registrations cannot create excess transient sockets.
@@ -299,23 +269,22 @@ impl DirectZmqSubPool {
                         handle,
                     },
                 );
-                RegistrationStart::Ready(DirectZmqSubRegistration {
-                    group_id,
-                    receiver,
-                    disconnected,
-                    lease: RegistrationLease::new(self.clone(), group_id, publisher_id, generation),
-                })
+                (group_id, None)
             }
         };
-
-        let (registration, completion) = match start {
-            RegistrationStart::Pending {
-                registration,
-                completion,
-            } => (registration, completion),
-            RegistrationStart::Ready(registration) => return Ok(registration),
+        let registration = DirectZmqSubRegistration {
+            pool: self.clone(),
+            group_id,
+            publisher_id,
+            generation,
+            receiver,
+            disconnected,
+            armed: true,
         };
 
+        let Some(completion) = completion else {
+            return Ok(registration);
+        };
         completion
             .await
             .map_err(|_| anyhow::anyhow!("direct-ZMQ socket group stopped"))??;
@@ -330,31 +299,6 @@ impl DirectZmqSubPool {
         };
         anyhow::ensure!(valid, "direct-ZMQ socket group stopped");
         Ok(registration)
-    }
-
-    pub(crate) async fn unregister(
-        &self,
-        registration: DirectZmqSubRegistration,
-        publisher_id: u64,
-        generation: u64,
-    ) {
-        let DirectZmqSubRegistration {
-            receiver,
-            disconnected: _,
-            lease,
-            group_id: _,
-        } = registration;
-        // Wake a group task that may be waiting to send to this publisher before
-        // queuing the ordered socket removal below.
-        drop(receiver);
-
-        debug_assert_eq!(lease.publisher_id, publisher_id);
-        debug_assert_eq!(lease.generation, generation);
-        let group_to_stop = lease.remove();
-
-        if let Some(group) = group_to_stop {
-            stop_group(group).await;
-        }
     }
 
     fn remove_registration(
@@ -688,6 +632,20 @@ mod tests {
         DirectZmqSubPool::new(topic, endpoints_per_sub, rcvhwm, CancellationToken::new()).unwrap()
     }
 
+    fn endpoint(publisher_id: u64) -> String {
+        format!("tcp://127.0.0.1:{}", 31_000 + publisher_id)
+    }
+
+    async fn register(
+        pool: &DirectZmqSubPool,
+        publisher_id: u64,
+        generation: u64,
+    ) -> DirectZmqSubRegistration {
+        pool.register(publisher_id, &endpoint(publisher_id), generation)
+            .await
+            .unwrap()
+    }
+
     fn wire_message(topic: &str, publisher_id: u64, sequence: u64) -> ZmqWireMessage {
         let payload = Codec::default()
             .encode_envelope_parts(publisher_id, sequence, 1, topic, b"payload")
@@ -706,12 +664,14 @@ mod tests {
         }
     }
 
-    fn dispatch_on_group(
+    fn dispatch(
         pool: &DirectZmqSubPool,
         group_id: u64,
-        message: ZmqWireMessage,
+        publisher_id: u64,
+        sequence: u64,
     ) -> oneshot::Receiver<DispatchOutcome> {
         let (completed, completion) = oneshot::channel();
+        let message = wire_message(&pool.topic, publisher_id, sequence);
         pool.inner
             .lock()
             .groups
@@ -723,20 +683,63 @@ mod tests {
         completion
     }
 
+    async fn delivered(pool: &DirectZmqSubPool, group_id: u64, publisher_id: u64, sequence: u64) {
+        assert_eq!(
+            dispatch(pool, group_id, publisher_id, sequence)
+                .await
+                .unwrap(),
+            DispatchOutcome::Delivered
+        );
+    }
+
+    async fn pause_group(pool: &DirectZmqSubPool, group_id: u64) -> oneshot::Sender<()> {
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        pool.inner
+            .lock()
+            .groups
+            .get(&group_id)
+            .unwrap()
+            .command_tx
+            .send(GroupCommand::Pause {
+                started: started_tx,
+                release: release_rx,
+            })
+            .unwrap();
+        started_rx.await.unwrap();
+        release_tx
+    }
+
+    async fn wait_for_assignment(pool: &DirectZmqSubPool, group_id: u64, publisher_id: u64) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !pool
+                .inner
+                .lock()
+                .groups
+                .get(&group_id)
+                .unwrap()
+                .assignments
+                .contains_key(&publisher_id)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("registration should reserve a group slot");
+    }
+
     #[test]
     fn parses_endpoints_per_sub_configuration() {
-        assert_eq!(
-            endpoints_per_sub_from_lookup(config_lookup(None)).unwrap(),
-            DEFAULT_ENDPOINTS_PER_SUB
-        );
-        assert_eq!(
-            endpoints_per_sub_from_lookup(config_lookup(Some("1"))).unwrap(),
-            1
-        );
-        assert_eq!(
-            endpoints_per_sub_from_lookup(config_lookup(Some("128"))).unwrap(),
-            128
-        );
+        for (value, expected) in [
+            (None, DEFAULT_ENDPOINTS_PER_SUB),
+            (Some("1"), 1),
+            (Some("128"), 128),
+        ] {
+            assert_eq!(
+                endpoints_per_sub_from_lookup(config_lookup(value)).unwrap(),
+                expected
+            );
+        }
         for invalid in ["", "0", "-1", "not-a-number"] {
             assert!(endpoints_per_sub_from_lookup(config_lookup(Some(invalid))).is_err());
         }
@@ -747,12 +750,7 @@ mod tests {
         let pool = pool("kv-events", 64, 128);
         let registrations = futures::future::join_all((1..=129).map(|publisher_id| {
             let pool = pool.clone();
-            async move {
-                let endpoint = format!("tcp://127.0.0.1:{}", 30_000 + publisher_id);
-                pool.register(publisher_id, &endpoint, publisher_id)
-                    .await
-                    .unwrap()
-            }
+            async move { register(&pool, publisher_id, publisher_id).await }
         }))
         .await;
 
@@ -779,25 +777,18 @@ mod tests {
     #[tokio::test]
     async fn full_lane_backpressures_and_preserves_order() {
         let pool = pool("kv_metrics", 64, 1);
-        let mut source = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
-        let mut sibling = pool.register(2, "tcp://127.0.0.1:31002", 1).await.unwrap();
+        let mut source = register(&pool, 1, 1).await;
+        let mut sibling = register(&pool, 2, 1).await;
         assert_eq!(source.group_id, sibling.group_id);
 
-        assert_eq!(
-            dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 1, 0),)
-                .await
-                .unwrap(),
-            DispatchOutcome::Delivered
-        );
-        let mut blocked =
-            dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 1, 1));
+        delivered(&pool, source.group_id, 1, 0).await;
+        let mut blocked = dispatch(&pool, source.group_id, 1, 1);
         tokio::task::yield_now().await;
         assert!(matches!(
             blocked.try_recv(),
             Err(oneshot::error::TryRecvError::Empty)
         ));
-        let mut sibling_blocked =
-            dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 2, 0));
+        let mut sibling_blocked = dispatch(&pool, source.group_id, 2, 0);
         tokio::task::yield_now().await;
         assert!(matches!(
             sibling_blocked.try_recv(),
@@ -815,61 +806,42 @@ mod tests {
     #[tokio::test]
     async fn remove_then_add_stays_ordered_while_a_sibling_lane_is_blocked() {
         let pool = pool("kv_metrics", 64, 1);
-        let mut blocked_source = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
-        let old = pool.register(2, "tcp://127.0.0.1:31002", 1).await.unwrap();
+        let mut blocked_source = register(&pool, 1, 1).await;
+        let old = register(&pool, 2, 1).await;
         let group_id = blocked_source.group_id;
 
-        assert_eq!(
-            dispatch_on_group(&pool, group_id, wire_message("kv_metrics", 1, 0))
-                .await
-                .unwrap(),
-            DispatchOutcome::Delivered
-        );
-        let blocked = dispatch_on_group(&pool, group_id, wire_message("kv_metrics", 1, 1));
+        delivered(&pool, group_id, 1, 0).await;
+        let blocked = dispatch(&pool, group_id, 1, 1);
         tokio::task::yield_now().await;
 
         drop(old);
         let replacement_pool = pool.clone();
-        let replacement = tokio::spawn(async move {
-            replacement_pool
-                .register(2, "tcp://127.0.0.1:31002", 2)
-                .await
-        });
+        let replacement = tokio::spawn(async move { register(&replacement_pool, 2, 2).await });
         tokio::task::yield_now().await;
         assert!(!replacement.is_finished());
 
         assert_eq!(sequence(blocked_source.receiver.recv().await.unwrap()), 0);
         assert_eq!(blocked.await.unwrap(), DispatchOutcome::Delivered);
-        let mut replacement = replacement.await.unwrap().unwrap();
+        let mut replacement = replacement.await.unwrap();
         assert_eq!(replacement.group_id, group_id);
-        assert_eq!(
-            dispatch_on_group(&pool, group_id, wire_message("kv_metrics", 2, 0))
-                .await
-                .unwrap(),
-            DispatchOutcome::Delivered
-        );
+        delivered(&pool, group_id, 2, 0).await;
         assert_eq!(sequence(replacement.receiver.recv().await.unwrap()), 0);
         pool.shutdown().await;
     }
 
     #[tokio::test]
-    async fn unregister_unblocks_a_full_lane_and_keeps_the_group_alive() {
+    async fn close_unblocks_a_full_lane_and_keeps_the_group_alive() {
         let pool = pool("kv_metrics", 64, 1);
-        let source = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
-        let mut sibling = pool.register(2, "tcp://127.0.0.1:31002", 1).await.unwrap();
+        let source = register(&pool, 1, 1).await;
+        let mut sibling = register(&pool, 2, 1).await;
         let disconnected = source.disconnected.clone();
         assert_eq!(source.group_id, sibling.group_id);
 
-        assert_eq!(
-            dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 1, 0),)
-                .await
-                .unwrap(),
-            DispatchOutcome::Delivered
-        );
-        let blocked = dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 1, 1));
+        delivered(&pool, source.group_id, 1, 0).await;
+        let blocked = dispatch(&pool, source.group_id, 1, 1);
         tokio::task::yield_now().await;
 
-        tokio::time::timeout(Duration::from_secs(1), pool.unregister(source, 1, 1))
+        tokio::time::timeout(Duration::from_secs(1), source.close())
             .await
             .expect("unregister must interrupt a blocked lane send");
         assert_eq!(
@@ -881,12 +853,7 @@ mod tests {
         );
         assert!(disconnected.is_cancelled());
 
-        assert_eq!(
-            dispatch_on_group(&pool, sibling.group_id, wire_message("kv_metrics", 2, 0),)
-                .await
-                .unwrap(),
-            DispatchOutcome::Delivered
-        );
+        delivered(&pool, sibling.group_id, 2, 0).await;
         assert_eq!(sequence(sibling.receiver.recv().await.unwrap()), 0);
         pool.shutdown().await;
     }
@@ -894,16 +861,11 @@ mod tests {
     #[tokio::test]
     async fn shutdown_interrupts_a_blocked_lane_send() {
         let pool = pool("kv_metrics", 64, 1);
-        let source = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
+        let source = register(&pool, 1, 1).await;
         let disconnected = source.disconnected.clone();
 
-        assert_eq!(
-            dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 1, 0),)
-                .await
-                .unwrap(),
-            DispatchOutcome::Delivered
-        );
-        let blocked = dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 1, 1));
+        delivered(&pool, source.group_id, 1, 0).await;
+        let blocked = dispatch(&pool, source.group_id, 1, 1);
         tokio::task::yield_now().await;
 
         tokio::time::timeout(Duration::from_secs(1), pool.shutdown())
@@ -964,9 +926,9 @@ mod tests {
     #[tokio::test]
     async fn failed_group_is_replaced_without_affecting_other_groups() {
         let pool = pool("kv_metrics", 2, 128);
-        let first = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
-        let second = pool.register(2, "tcp://127.0.0.1:31002", 1).await.unwrap();
-        let mut unaffected = pool.register(3, "tcp://127.0.0.1:31003", 1).await.unwrap();
+        let first = register(&pool, 1, 1).await;
+        let second = register(&pool, 2, 1).await;
+        let mut unaffected = register(&pool, 3, 1).await;
         assert_eq!(first.group_id, second.group_id);
         assert_ne!(first.group_id, unaffected.group_id);
         {
@@ -980,15 +942,10 @@ mod tests {
             .await
             .expect("failed group must disconnect all its publishers");
         assert!(!unaffected.disconnected.is_cancelled());
-        assert_eq!(
-            dispatch_on_group(&pool, unaffected.group_id, wire_message("kv_metrics", 3, 0),)
-                .await
-                .unwrap(),
-            DispatchOutcome::Delivered
-        );
+        delivered(&pool, unaffected.group_id, 3, 0).await;
         assert_eq!(sequence(unaffected.receiver.recv().await.unwrap()), 0);
 
-        let replacement = pool.register(1, "tcp://127.0.0.1:31001", 2).await.unwrap();
+        let replacement = register(&pool, 1, 2).await;
         assert_ne!(first.group_id, replacement.group_id);
         {
             let inner = pool.inner.lock();
@@ -1000,77 +957,39 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn removing_last_publisher_stops_group_and_shutdown_closes_pool() {
+    async fn registrations_clean_up_on_close_and_drop() {
         let pool = pool("kv-events", 64, 128);
-        let registration = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
+        let registration = register(&pool, 1, 1).await;
         let disconnected = registration.disconnected.clone();
 
-        pool.unregister(registration, 1, 1).await;
+        registration.close().await;
         assert!(disconnected.is_cancelled());
         assert_eq!(pool.group_count(), 0);
 
-        pool.shutdown().await;
-        assert!(pool.register(2, "tcp://127.0.0.1:31002", 2).await.is_err());
-    }
-
-    #[tokio::test]
-    async fn dropping_an_active_registration_removes_its_assignment() {
-        let pool = pool("kv-events", 64, 128);
-        let registration = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
+        let registration = register(&pool, 1, 2).await;
         let disconnected = registration.disconnected.clone();
-
         drop(registration);
-
         assert_eq!(pool.group_count(), 0);
         tokio::time::timeout(Duration::from_secs(1), disconnected.cancelled())
             .await
             .expect("registration drop must stop its final socket group");
-        let replacement = pool.register(1, "tcp://127.0.0.1:31001", 2).await.unwrap();
+
+        let replacement = register(&pool, 1, 3).await;
         assert_eq!(pool.group_count(), 1);
         drop(replacement);
         pool.shutdown().await;
+        assert!(pool.register(2, "tcp://127.0.0.1:31002", 1).await.is_err());
     }
 
     #[tokio::test]
     async fn cancelled_registration_rolls_back_and_can_register_again() {
         let pool = pool("kv-events", 64, 128);
-        let first = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
-        let (started_tx, started_rx) = oneshot::channel();
-        let (release_tx, release_rx) = oneshot::channel();
-        pool.inner
-            .lock()
-            .groups
-            .get(&first.group_id)
-            .unwrap()
-            .command_tx
-            .send(GroupCommand::Pause {
-                started: started_tx,
-                release: release_rx,
-            })
-            .unwrap();
-        started_rx.await.unwrap();
+        let first = register(&pool, 1, 1).await;
+        let release = pause_group(&pool, first.group_id).await;
 
         let pending_pool = pool.clone();
-        let pending =
-            tokio::spawn(async move { pending_pool.register(2, "tcp://127.0.0.1:31002", 1).await });
-        tokio::time::timeout(Duration::from_secs(1), async {
-            loop {
-                if pool
-                    .inner
-                    .lock()
-                    .groups
-                    .get(&first.group_id)
-                    .unwrap()
-                    .assignments
-                    .contains_key(&2)
-                {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("registration should reserve a group slot");
+        let pending = tokio::spawn(async move { register(&pending_pool, 2, 1).await });
+        wait_for_assignment(&pool, first.group_id, 2).await;
         pending.abort();
         match pending.await {
             Err(error) => assert!(error.is_cancelled()),
@@ -1087,8 +1006,8 @@ mod tests {
                 .contains_key(&2)
         );
 
-        release_tx.send(()).unwrap();
-        let replacement = pool.register(2, "tcp://127.0.0.1:31002", 2).await.unwrap();
+        release.send(()).unwrap();
+        let replacement = register(&pool, 2, 2).await;
         assert_eq!(replacement.group_id, first.group_id);
         pool.shutdown().await;
     }
@@ -1096,43 +1015,12 @@ mod tests {
     #[tokio::test]
     async fn shutdown_rejects_an_inflight_registration() {
         let pool = pool("kv-events", 64, 128);
-        let first = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
-        let (started_tx, started_rx) = oneshot::channel();
-        let (_release_tx, release_rx) = oneshot::channel();
-        pool.inner
-            .lock()
-            .groups
-            .get(&first.group_id)
-            .unwrap()
-            .command_tx
-            .send(GroupCommand::Pause {
-                started: started_tx,
-                release: release_rx,
-            })
-            .unwrap();
-        started_rx.await.unwrap();
+        let first = register(&pool, 1, 1).await;
+        let _release = pause_group(&pool, first.group_id).await;
 
         let pending_pool = pool.clone();
-        let pending =
-            tokio::spawn(async move { pending_pool.register(2, "tcp://127.0.0.1:31002", 1).await });
-        tokio::time::timeout(Duration::from_secs(1), async {
-            loop {
-                if pool
-                    .inner
-                    .lock()
-                    .groups
-                    .get(&first.group_id)
-                    .unwrap()
-                    .assignments
-                    .contains_key(&2)
-                {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("registration should reserve a group slot");
+        let pending = tokio::spawn(async move { pending_pool.register(2, &endpoint(2), 1).await });
+        wait_for_assignment(&pool, first.group_id, 2).await;
 
         pool.shutdown().await;
         match pending.await {

--- a/lib/llm/src/direct_zmq_sub_pool.rs
+++ b/lib/llm/src/direct_zmq_sub_pool.rs
@@ -86,6 +86,11 @@ enum GroupCommand {
         started: oneshot::Sender<()>,
         release: oneshot::Receiver<()>,
     },
+    #[cfg(test)]
+    Dispatch {
+        message: ZmqWireMessage,
+        completed: oneshot::Sender<DispatchOutcome>,
+    },
 }
 
 struct SocketGroup {
@@ -114,6 +119,13 @@ pub(crate) struct DirectZmqSubRegistration {
     pub(crate) group_id: u64,
     pub(crate) receiver: mpsc::Receiver<DirectZmqSubItem>,
     pub(crate) disconnected: CancellationToken,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DispatchOutcome {
+    Delivered,
+    RouteClosed { publisher_id: u64, generation: u64 },
+    GroupCancelled,
 }
 
 struct PendingRegistration {
@@ -321,7 +333,21 @@ impl DirectZmqSubPool {
         })
     }
 
-    pub(crate) async fn unregister(&self, group_id: u64, publisher_id: u64, generation: u64) {
+    pub(crate) async fn unregister(
+        &self,
+        registration: DirectZmqSubRegistration,
+        publisher_id: u64,
+        generation: u64,
+    ) {
+        let DirectZmqSubRegistration {
+            group_id,
+            receiver,
+            disconnected: _,
+        } = registration;
+        // Wake a group task that may be waiting to send to this publisher before
+        // queuing the ordered socket removal below.
+        drop(receiver);
+
         let (completed, group_to_stop) = {
             let (completed_tx, completed_rx) = oneshot::channel();
             let group =
@@ -437,13 +463,7 @@ async fn run_socket_group(
                         let _ = completed.send(result);
                     }
                     GroupCommand::Remove { publisher_id, generation, completed } => {
-                        let result = match routes.get(&publisher_id) {
-                            Some(route) if route.generation == generation => {
-                                let route = routes.remove(&publisher_id).expect("route was present");
-                                socket.remove_endpoint(&route.endpoint)
-                            }
-                            _ => Ok(()),
-                        };
+                        let result = remove_route(&mut socket, &mut routes, publisher_id, generation);
                         if let Some(completed) = completed {
                             let _ = completed.send(result);
                         }
@@ -454,6 +474,29 @@ async fn run_socket_group(
                         tokio::select! {
                             _ = cancellation_token.cancelled() => return,
                             _ = release => {}
+                        }
+                    }
+                    #[cfg(test)]
+                    GroupCommand::Dispatch { message, completed } => {
+                        let outcome = dispatch_group_message(
+                            group_id,
+                            &topic,
+                            message,
+                            &codec,
+                            &routes,
+                            &cancellation_token,
+                        )
+                        .await;
+                        let keep_running = handle_dispatch_outcome(
+                            outcome,
+                            group_id,
+                            &topic,
+                            &mut socket,
+                            &mut routes,
+                        );
+                        let _ = completed.send(outcome);
+                        if !keep_running {
+                            return;
                         }
                     }
                 }
@@ -470,20 +513,81 @@ async fn run_socket_group(
                         return;
                     }
                 };
-                dispatch_group_message(group_id, &topic, message, &codec, &routes);
+                let outcome = dispatch_group_message(
+                    group_id,
+                    &topic,
+                    message,
+                    &codec,
+                    &routes,
+                    &cancellation_token,
+                )
+                .await;
+                if !handle_dispatch_outcome(
+                    outcome,
+                    group_id,
+                    &topic,
+                    &mut socket,
+                    &mut routes,
+                ) {
+                    return;
+                }
                 tokio::task::consume_budget().await;
             }
         }
     }
 }
 
-fn dispatch_group_message(
+fn handle_dispatch_outcome(
+    outcome: DispatchOutcome,
+    group_id: u64,
+    topic: &str,
+    socket: &mut DynamicZmqSubSocket,
+    routes: &mut HashMap<u64, GroupRoute>,
+) -> bool {
+    let DispatchOutcome::RouteClosed {
+        publisher_id,
+        generation,
+    } = outcome
+    else {
+        return outcome == DispatchOutcome::Delivered;
+    };
+
+    if let Err(error) = remove_route(socket, routes, publisher_id, generation) {
+        tracing::warn!(
+            %error,
+            group_id,
+            topic,
+            publisher_id,
+            generation,
+            "Failed to disconnect closed direct-ZMQ publisher lane"
+        );
+    }
+    true
+}
+
+fn remove_route(
+    socket: &mut DynamicZmqSubSocket,
+    routes: &mut HashMap<u64, GroupRoute>,
+    publisher_id: u64,
+    generation: u64,
+) -> Result<()> {
+    match routes.get(&publisher_id) {
+        Some(route) if route.generation == generation => {
+            let route = routes.remove(&publisher_id).expect("route was present");
+            socket.remove_endpoint(&route.endpoint)
+        }
+        _ => Ok(()),
+    }
+}
+
+async fn dispatch_group_message(
     group_id: u64,
     topic: &str,
     message: ZmqWireMessage,
     codec: &Codec,
     routes: &HashMap<u64, GroupRoute>,
-) {
+    cancellation_token: &CancellationToken,
+) -> DispatchOutcome {
     let Some(route) = routes.get(&message.publisher_id) else {
         tracing::warn!(
             group_id,
@@ -491,7 +595,7 @@ fn dispatch_group_message(
             publisher_id = message.publisher_id,
             "Dropping direct-ZMQ envelope from an unknown publisher"
         );
-        return;
+        return DispatchOutcome::Delivered;
     };
     let item = match codec.decode_envelope(&message.payload) {
         Ok(envelope)
@@ -532,19 +636,25 @@ fn dispatch_group_message(
     };
 
     match route.sender.try_send(item) {
-        Ok(()) => {}
-        Err(mpsc::error::TrySendError::Full(_)) => tracing::warn!(
-            group_id,
-            topic,
-            publisher_id = message.publisher_id,
-            "Direct-ZMQ publisher lane is full; dropping newest envelope"
-        ),
-        Err(mpsc::error::TrySendError::Closed(_)) => tracing::warn!(
-            group_id,
-            topic,
-            publisher_id = message.publisher_id,
-            "Direct-ZMQ publisher lane is closed; dropping envelope"
-        ),
+        Ok(()) => DispatchOutcome::Delivered,
+        Err(mpsc::error::TrySendError::Full(item)) => {
+            let result = tokio::select! {
+                biased;
+                _ = cancellation_token.cancelled() => return DispatchOutcome::GroupCancelled,
+                result = route.sender.send(item) => result,
+            };
+            match result {
+                Ok(()) => DispatchOutcome::Delivered,
+                Err(_) => DispatchOutcome::RouteClosed {
+                    publisher_id: message.publisher_id,
+                    generation: route.generation,
+                },
+            }
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => DispatchOutcome::RouteClosed {
+            publisher_id: message.publisher_id,
+            generation: route.generation,
+        },
     }
 }
 
@@ -564,8 +674,6 @@ async fn stop_group(mut group: SocketGroup) {
 
 #[cfg(test)]
 mod tests {
-    use bytes::Bytes;
-
     use super::*;
 
     fn config_lookup(value: Option<&str>) -> impl FnMut(&str) -> Option<OsString> {
@@ -597,6 +705,23 @@ mod tests {
             DirectZmqSubItem::Envelope(envelope) => envelope.sequence,
             other => panic!("expected envelope, got {other:?}"),
         }
+    }
+
+    fn dispatch_on_group(
+        pool: &DirectZmqSubPool,
+        group_id: u64,
+        message: ZmqWireMessage,
+    ) -> oneshot::Receiver<DispatchOutcome> {
+        let (completed, completion) = oneshot::channel();
+        pool.inner
+            .lock()
+            .groups
+            .get(&group_id)
+            .expect("socket group must exist")
+            .command_tx
+            .send(GroupCommand::Dispatch { message, completed })
+            .expect("socket group must be running");
+        completion
     }
 
     #[test]
@@ -653,92 +778,101 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn full_publisher_lane_does_not_block_a_sibling() {
-        let (full_tx, mut full_rx) = mpsc::channel(1);
-        full_tx
-            .try_send(DirectZmqSubItem::Envelope(ValidatedEnvelope {
-                publisher_id: 1,
-                sequence: 0,
-                published_at: 0,
-                payload: Bytes::new(),
-            }))
-            .unwrap();
-        let (sibling_tx, mut sibling_rx) = mpsc::channel(2);
-        let routes = HashMap::from([
-            (
-                1,
-                GroupRoute {
-                    endpoint: "tcp://127.0.0.1:1".to_string(),
-                    generation: 1,
-                    sender: full_tx,
-                    disconnected: CancellationToken::new(),
-                },
-            ),
-            (
-                2,
-                GroupRoute {
-                    endpoint: "tcp://127.0.0.1:2".to_string(),
-                    generation: 1,
-                    sender: sibling_tx,
-                    disconnected: CancellationToken::new(),
-                },
-            ),
-        ]);
-        let codec = Codec::default();
+    async fn full_lane_backpressures_and_preserves_order() {
+        let pool = pool("kv_metrics", 64, 1);
+        let mut source = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
+        let mut sibling = pool.register(2, "tcp://127.0.0.1:31002", 1).await.unwrap();
+        assert_eq!(source.group_id, sibling.group_id);
 
-        dispatch_group_message(
-            1,
-            "kv_metrics",
-            wire_message("kv_metrics", 1, 1),
-            &codec,
-            &routes,
+        assert_eq!(
+            dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 1, 0),)
+                .await
+                .unwrap(),
+            DispatchOutcome::Delivered
         );
-        dispatch_group_message(
-            1,
-            "kv_metrics",
-            wire_message("kv_metrics", 2, 1),
-            &codec,
-            &routes,
-        );
-        dispatch_group_message(
-            1,
-            "kv_metrics",
-            wire_message("kv_metrics", 2, 2),
-            &codec,
-            &routes,
-        );
+        let mut blocked =
+            dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 1, 1));
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            blocked.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
 
-        assert_eq!(sequence(full_rx.recv().await.unwrap()), 0);
-        assert_eq!(sequence(sibling_rx.recv().await.unwrap()), 1);
-        assert_eq!(sequence(sibling_rx.recv().await.unwrap()), 2);
+        assert_eq!(sequence(source.receiver.recv().await.unwrap()), 0);
+        assert_eq!(blocked.await.unwrap(), DispatchOutcome::Delivered);
+        assert_eq!(sequence(source.receiver.recv().await.unwrap()), 1);
+
+        assert_eq!(
+            dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 2, 0),)
+                .await
+                .unwrap(),
+            DispatchOutcome::Delivered
+        );
+        assert_eq!(sequence(sibling.receiver.recv().await.unwrap()), 0);
+        pool.shutdown().await;
     }
 
     #[tokio::test]
-    async fn publisher_lane_preserves_a_burst_above_the_old_limit() {
-        let (sender, mut receiver) = mpsc::channel(128);
-        let routes = HashMap::from([(
-            1,
-            GroupRoute {
-                endpoint: "tcp://127.0.0.1:1".to_string(),
-                generation: 1,
-                sender,
-                disconnected: CancellationToken::new(),
-            },
-        )]);
-        let codec = Codec::default();
+    async fn unregister_unblocks_a_full_lane_and_keeps_the_group_alive() {
+        let pool = pool("kv_metrics", 64, 1);
+        let source = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
+        let mut sibling = pool.register(2, "tcp://127.0.0.1:31002", 1).await.unwrap();
+        let disconnected = source.disconnected.clone();
+        assert_eq!(source.group_id, sibling.group_id);
 
-        for sequence in 1..=65 {
-            dispatch_group_message(
-                1,
-                "kv-events",
-                wire_message("kv-events", 1, sequence),
-                &codec,
-                &routes,
-            );
-        }
-        for expected in 1..=65 {
-            assert_eq!(sequence(receiver.recv().await.unwrap()), expected);
-        }
+        assert_eq!(
+            dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 1, 0),)
+                .await
+                .unwrap(),
+            DispatchOutcome::Delivered
+        );
+        let blocked = dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 1, 1));
+        tokio::task::yield_now().await;
+
+        tokio::time::timeout(Duration::from_secs(1), pool.unregister(source, 1, 1))
+            .await
+            .expect("unregister must interrupt a blocked lane send");
+        assert_eq!(
+            blocked.await.unwrap(),
+            DispatchOutcome::RouteClosed {
+                publisher_id: 1,
+                generation: 1,
+            }
+        );
+        assert!(disconnected.is_cancelled());
+
+        assert_eq!(
+            dispatch_on_group(&pool, sibling.group_id, wire_message("kv_metrics", 2, 0),)
+                .await
+                .unwrap(),
+            DispatchOutcome::Delivered
+        );
+        assert_eq!(sequence(sibling.receiver.recv().await.unwrap()), 0);
+        pool.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_interrupts_a_blocked_lane_send() {
+        let pool = pool("kv_metrics", 64, 1);
+        let source = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
+        let disconnected = source.disconnected.clone();
+
+        assert_eq!(
+            dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 1, 0),)
+                .await
+                .unwrap(),
+            DispatchOutcome::Delivered
+        );
+        let blocked = dispatch_on_group(&pool, source.group_id, wire_message("kv_metrics", 1, 1));
+        tokio::task::yield_now().await;
+
+        tokio::time::timeout(Duration::from_secs(1), pool.shutdown())
+            .await
+            .expect("shutdown must interrupt a blocked lane send");
+        assert_eq!(blocked.await.unwrap(), DispatchOutcome::GroupCancelled);
+        assert!(disconnected.is_cancelled());
+        assert_eq!(pool.group_count(), 0);
+        assert!(pool.register(2, "tcp://127.0.0.1:31002", 1).await.is_err());
     }
 
     #[tokio::test]
@@ -755,19 +889,29 @@ mod tests {
         )]);
         let codec = Codec::default();
 
-        dispatch_group_message(
-            1,
-            "kv_metrics",
-            wire_message("kv-events", 1, 1),
-            &codec,
-            &routes,
+        assert_eq!(
+            dispatch_group_message(
+                1,
+                "kv_metrics",
+                wire_message("kv-events", 1, 1),
+                &codec,
+                &routes,
+                &CancellationToken::new(),
+            )
+            .await,
+            DispatchOutcome::Delivered
         );
-        dispatch_group_message(
-            1,
-            "kv_metrics",
-            wire_message("kv_metrics", 1, 2),
-            &codec,
-            &routes,
+        assert_eq!(
+            dispatch_group_message(
+                1,
+                "kv_metrics",
+                wire_message("kv_metrics", 1, 2),
+                &codec,
+                &routes,
+                &CancellationToken::new(),
+            )
+            .await,
+            DispatchOutcome::Delivered
         );
 
         assert!(matches!(
@@ -806,9 +950,10 @@ mod tests {
     async fn removing_last_publisher_stops_group_and_shutdown_closes_pool() {
         let pool = pool("kv-events", 64, 128);
         let registration = pool.register(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
+        let disconnected = registration.disconnected.clone();
 
-        pool.unregister(registration.group_id, 1, 1).await;
-        assert!(registration.disconnected.is_cancelled());
+        pool.unregister(registration, 1, 1).await;
+        assert!(disconnected.is_cancelled());
         assert_eq!(pool.group_count(), 0);
 
         pool.shutdown().await;

--- a/lib/llm/src/direct_zmq_sub_pool.rs
+++ b/lib/llm/src/direct_zmq_sub_pool.rs
@@ -12,7 +12,7 @@ use std::{
 
 use anyhow::Result;
 use dynamo_runtime::transports::event_plane::{
-    Codec, DynamicZmqSubSocket, ValidatedEnvelope, ZmqWireMessage,
+    Codec, DynamicZmqSubSocket, ValidatedEnvelope, ValidatedZmqSource, ZmqWireMessage,
 };
 use parking_lot::Mutex;
 use tokio::{
@@ -24,7 +24,7 @@ use tokio_util::sync::CancellationToken;
 const GROUP_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(crate) const ENDPOINTS_PER_SUB_ENV: &str = "DYN_ROUTER_ZMQ_ENDPOINTS_PER_SUB";
-pub(crate) const DEFAULT_ENDPOINTS_PER_SUB: usize = 64;
+pub(crate) const DEFAULT_ENDPOINTS_PER_SUB: usize = 1;
 pub(crate) const KV_ZMQ_RCVHWM: i32 = 100_000;
 
 pub(crate) fn endpoints_per_sub_from_env() -> Result<usize> {
@@ -124,6 +124,11 @@ pub(crate) struct DirectZmqSubRegistration {
     armed: bool,
 }
 
+pub(crate) enum DirectZmqSubConnection {
+    Dedicated(ValidatedZmqSource),
+    Grouped(DirectZmqSubRegistration),
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DispatchOutcome {
     Delivered,
@@ -147,6 +152,28 @@ impl DirectZmqSubRegistration {
     pub(crate) async fn close(mut self) {
         if let Some(group) = self.release() {
             stop_group(group).await;
+        }
+    }
+}
+
+impl DirectZmqSubConnection {
+    pub(crate) fn group_id(&self) -> Option<u64> {
+        match self {
+            Self::Dedicated(_) => None,
+            Self::Grouped(registration) => Some(registration.group_id),
+        }
+    }
+
+    pub(crate) fn disconnected(&self) -> Option<CancellationToken> {
+        match self {
+            Self::Dedicated(_) => None,
+            Self::Grouped(registration) => Some(registration.disconnected.clone()),
+        }
+    }
+
+    pub(crate) async fn close(self) {
+        if let Self::Grouped(registration) = self {
+            registration.close().await;
         }
     }
 }
@@ -181,7 +208,33 @@ impl DirectZmqSubPool {
         })
     }
 
-    pub(crate) async fn register(
+    pub(crate) async fn connect(
+        &self,
+        publisher_id: u64,
+        endpoint: &str,
+        generation: u64,
+    ) -> Result<DirectZmqSubConnection> {
+        if self.endpoints_per_sub == 1 {
+            anyhow::ensure!(
+                !self.inner.lock().closed,
+                "direct-ZMQ socket pool is closed"
+            );
+            let source =
+                ValidatedZmqSource::connect(endpoint, &self.topic, publisher_id, self.rcvhwm)
+                    .await?;
+            anyhow::ensure!(
+                !self.inner.lock().closed,
+                "direct-ZMQ socket pool is closed"
+            );
+            return Ok(DirectZmqSubConnection::Dedicated(source));
+        }
+
+        self.register_grouped(publisher_id, endpoint, generation)
+            .await
+            .map(DirectZmqSubConnection::Grouped)
+    }
+
+    async fn register_grouped(
         &self,
         publisher_id: u64,
         endpoint: &str,
@@ -641,7 +694,7 @@ mod tests {
         publisher_id: u64,
         generation: u64,
     ) -> DirectZmqSubRegistration {
-        pool.register(publisher_id, &endpoint(publisher_id), generation)
+        pool.register_grouped(publisher_id, &endpoint(publisher_id), generation)
             .await
             .unwrap()
     }
@@ -730,11 +783,8 @@ mod tests {
 
     #[test]
     fn parses_endpoints_per_sub_configuration() {
-        for (value, expected) in [
-            (None, DEFAULT_ENDPOINTS_PER_SUB),
-            (Some("1"), 1),
-            (Some("128"), 128),
-        ] {
+        assert_eq!(DEFAULT_ENDPOINTS_PER_SUB, 1);
+        for (value, expected) in [(None, 1), (Some("1"), 1), (Some("128"), 128)] {
             assert_eq!(
                 endpoints_per_sub_from_lookup(config_lookup(value)).unwrap(),
                 expected
@@ -743,6 +793,16 @@ mod tests {
         for invalid in ["", "0", "-1", "not-a-number"] {
             assert!(endpoints_per_sub_from_lookup(config_lookup(Some(invalid))).is_err());
         }
+    }
+
+    #[tokio::test]
+    async fn one_endpoint_uses_dedicated_source_without_a_group() {
+        let pool = pool("kv-events", 1, 128);
+        let connection = pool.connect(1, "tcp://127.0.0.1:31001", 1).await.unwrap();
+
+        assert!(matches!(connection, DirectZmqSubConnection::Dedicated(_)));
+        assert_eq!(pool.group_count(), 0);
+        connection.close().await;
     }
 
     #[tokio::test]
@@ -874,7 +934,11 @@ mod tests {
         assert_eq!(blocked.await.unwrap(), DispatchOutcome::GroupCancelled);
         assert!(disconnected.is_cancelled());
         assert_eq!(pool.group_count(), 0);
-        assert!(pool.register(2, "tcp://127.0.0.1:31002", 1).await.is_err());
+        assert!(
+            pool.register_grouped(2, "tcp://127.0.0.1:31002", 1)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -978,7 +1042,11 @@ mod tests {
         assert_eq!(pool.group_count(), 1);
         drop(replacement);
         pool.shutdown().await;
-        assert!(pool.register(2, "tcp://127.0.0.1:31002", 1).await.is_err());
+        assert!(
+            pool.register_grouped(2, "tcp://127.0.0.1:31002", 1)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -1019,7 +1087,8 @@ mod tests {
         let _release = pause_group(&pool, first.group_id).await;
 
         let pending_pool = pool.clone();
-        let pending = tokio::spawn(async move { pending_pool.register(2, &endpoint(2), 1).await });
+        let pending =
+            tokio::spawn(async move { pending_pool.register_grouped(2, &endpoint(2), 1).await });
         wait_for_assignment(&pool, first.group_id, 2).await;
 
         pool.shutdown().await;

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -753,8 +753,8 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                 }
             };
 
-        // Subscribe to KV metrics events using EventSubscriber (Msgpack payloads)
-        // This is optional - if NATS isn't available, we skip KV metrics but still do TTFT/ITL cleanup
+        // Subscribe to KV metrics over the configured event transport. This is
+        // optional; cleanup of TTFT and ITL metrics continues without it.
         let kv_metrics_rx = match KvMetricsSubscriber::for_endpoint(endpoint).await {
             Ok(sub) => Some(sub),
             Err(e) => {

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -16,12 +16,12 @@ use crate::http::service::metrics::{
     WORKER_LAST_INPUT_SEQUENCE_TOKENS_GAUGE, WORKER_LAST_INTER_TOKEN_LATENCY_GAUGE,
     WORKER_LAST_TIME_TO_FIRST_TOKEN_GAUGE,
 };
+use crate::kv_router::RouterLoadSource;
 use crate::kv_router::metrics::WORKER_LOAD_METRICS;
+use crate::kv_router::metrics_subscriber::KvMetricsSubscriber;
 use crate::kv_router::routing_load::SchedulerLoadReceiver;
-use crate::kv_router::{KV_METRICS_SUBJECT, RouterLoadSource};
 use dynamo_runtime::component::Client;
 use dynamo_runtime::pipeline::{WorkerLoadMonitor, async_trait};
-use dynamo_runtime::transports::event_plane::EventSubscriber;
 
 use super::runtime_config_watch;
 
@@ -755,9 +755,8 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
 
         // Subscribe to KV metrics events using EventSubscriber (Msgpack payloads)
         // This is optional - if NATS isn't available, we skip KV metrics but still do TTFT/ITL cleanup
-        let kv_metrics_rx = match EventSubscriber::for_endpoint(endpoint, KV_METRICS_SUBJECT).await
-        {
-            Ok(sub) => Some(sub.typed::<ActiveLoad>()),
+        let kv_metrics_rx = match KvMetricsSubscriber::for_endpoint(endpoint).await {
+            Ok(sub) => Some(sub),
             Err(e) => {
                 tracing::warn!(
                     "KvWorkerMonitor: KV metrics subscriber not available ({}), skipping load metrics.",
@@ -807,10 +806,7 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
             loop {
                 let kv_event_future = async {
                     if let Some(kv_metrics_rx) = &mut kv_metrics_rx {
-                        kv_metrics_rx
-                            .next()
-                            .await
-                            .map(|result| result.map(|(_envelope, active_load)| active_load))
+                        kv_metrics_rx.next().await
                     } else {
                         std::future::pending().await
                     }

--- a/lib/llm/src/kv_dc_relay/host.rs
+++ b/lib/llm/src/kv_dc_relay/host.rs
@@ -25,7 +25,6 @@ use std::sync::atomic::Ordering;
 
 use dynamo_kv_router::identity::PoolId;
 use dynamo_kv_router::indexer::cuckoo::{CkfConfig, CkfFailureAction};
-use dynamo_kv_router::protocols::ActiveLoad;
 use dynamo_kv_router::protocols::{DpRank, KvCacheEventError, WorkerId};
 use dynamo_runtime::component::Component;
 use dynamo_runtime::component::{Client, Instance};
@@ -60,15 +59,14 @@ use super::topology::{TopologyPublisher, TopologySnapshot};
 use crate::discovery::{
     KvSourceMembershipCoordinator, KvSourceMembershipView, KvSourceMembershipWatch,
 };
-use crate::kv_router::KV_METRICS_SUBJECT;
 #[cfg(feature = "ckf-diagnostics")]
 use crate::kv_router::indexer::WorkerQueryHealthSnapshot;
 use crate::kv_router::indexer::{
     DEFAULT_RECOVERY_ATTEMPT_TIMEOUT, RecoverySupervisor, TargetFaultDisposition,
     start_target_subscriber,
 };
+use crate::kv_router::metrics_subscriber::KvMetricsSubscriber;
 use crate::local_model::runtime_config::ModelRuntimeConfig;
-use dynamo_runtime::transports::event_plane::EventSubscriber;
 
 pub const DEFAULT_EXPECTED_UNIQUE_BLOCKS: usize = 1_048_576;
 const DEFAULT_RECOVERY_FETCH_CONCURRENCY: usize = 16;
@@ -2078,10 +2076,9 @@ async fn run_load_collector(
 ) {
     let mut retry = LoadRetryBackoff::default();
     loop {
-        let subscriber =
-            EventSubscriber::for_endpoint_id(component.drt(), &endpoint, KV_METRICS_SUBJECT).await;
+        let subscriber = KvMetricsSubscriber::for_endpoint_id(&component, &endpoint).await;
         let mut subscriber = match subscriber {
-            Ok(subscriber) => subscriber.typed::<ActiveLoad>(),
+            Ok(subscriber) => subscriber,
             Err(error) => {
                 let failure = retry.failed();
                 if failure.first {
@@ -2102,7 +2099,7 @@ async fn run_load_collector(
                 event = subscriber.next() => event,
             };
             match event {
-                Some(Ok((_envelope, load))) => {
+                Some(Ok(load)) => {
                     retry.succeeded();
                     if !pools.observe_load(pool_id, layout_generation, load) {
                         tracing::debug!(%endpoint, %pool_id, layout_generation, "Ignoring ActiveLoad outside the pool generation's expected ranks");

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -55,6 +55,7 @@ pub use dynamo_kv_router::selector;
 pub mod encoder_router;
 pub mod indexer;
 pub mod metrics;
+pub(crate) mod metrics_subscriber;
 pub mod prefill_router;
 pub mod publisher;
 mod request_lease;

--- a/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
@@ -719,7 +719,7 @@ async fn run_source(
         };
         if cancel.is_cancelled() {
             group_pool
-                .unregister(registration.group_id, publisher_id, task_generation)
+                .unregister(registration, publisher_id, task_generation)
                 .await;
             return;
         }
@@ -757,7 +757,7 @@ async fn run_source(
         };
         if !matches!(activation_outcome, ActivationOutcome::Activated) {
             group_pool
-                .unregister(registration.group_id, publisher_id, task_generation)
+                .unregister(registration, publisher_id, task_generation)
                 .await;
             if matches!(activation_outcome, ActivationOutcome::Cancelled) {
                 return;
@@ -786,7 +786,7 @@ async fn run_source(
             _ = consume_connection(publisher_id, &mut registration.receiver, &client, &metrics) => false,
         };
         group_pool
-            .unregister(registration.group_id, publisher_id, task_generation)
+            .unregister(registration, publisher_id, task_generation)
             .await;
         if cancelled {
             return;

--- a/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
@@ -17,7 +17,7 @@ use dynamo_runtime::{
     },
     protocols::EndpointId,
     traits::DistributedRuntimeProvider,
-    transports::event_plane::{Codec, EventScope, ValidatedZmqSource, ValidatedZmqSourceError},
+    transports::event_plane::{Codec, EventScope, ValidatedEnvelope},
 };
 use futures::StreamExt;
 use tokio::{
@@ -35,8 +35,11 @@ use super::{
     worker_query::WorkerQueryClient,
 };
 use crate::{
+    direct_zmq_sub_pool::{
+        DirectZmqSubPool, DirectZmqSubPoolEvent, ENDPOINTS_PER_SUB_ENV, endpoints_per_sub_from_env,
+    },
     discovery::{KvSourceId, KvSourceMembershipView, KvSourceMembershipWatch},
-    kv_router::metrics::{KvZmqIngressMetrics, RouterWorkerStatusMetrics},
+    kv_router::metrics::{KvZmqIngressMetrics, KvZmqIngressStream, RouterWorkerStatusMetrics},
 };
 
 const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
@@ -104,6 +107,21 @@ pub(super) async fn run_direct_zmq_supervisor(
 ) {
     let status_metrics = RouterWorkerStatusMetrics::from_component(&component);
     let ingress_metrics = KvZmqIngressMetrics::from_component(&component);
+    let endpoints_per_sub = match endpoints_per_sub_from_env() {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::error!(%error, "Invalid direct-ZMQ KV ingress configuration");
+            if let Some(ready) = startup_ready.take() {
+                let _ = ready.send(Err(error.to_string()));
+            }
+            return;
+        }
+    };
+    tracing::info!(
+        endpoints_per_sub,
+        env = ENDPOINTS_PER_SUB_ENV,
+        "Configured direct-ZMQ KV ingress SUB fan-in"
+    );
     let mut retry_delay = INITIAL_BACKOFF;
 
     loop {
@@ -190,6 +208,7 @@ pub(super) async fn run_direct_zmq_supervisor(
             &serving_endpoint,
             metric_scope,
             &cancellation_token,
+            endpoints_per_sub,
         )
         .await;
         scope_cancel.cancel();
@@ -238,11 +257,23 @@ async fn consume_scope(
     serving_endpoint: &EndpointId,
     metric_scope: MismatchMetricScope,
     cancellation_token: &CancellationToken,
+    endpoints_per_sub: usize,
 ) -> ScopeExit {
     let expected_scope = EventScope::Endpoint {
         endpoint: kv_state_endpoint.clone(),
     };
     let (signal_tx, mut signal_rx) = mpsc::channel(SIGNAL_CAPACITY);
+    let pool_metrics = ingress_metrics.clone();
+    let pool_observer = Arc::new(move |event: DirectZmqSubPoolEvent| {
+        pool_metrics.observe_pool(KvZmqIngressStream::Events, event);
+    });
+    let group_pool = DirectZmqSubPool::new(
+        KV_EVENT_SUBJECT,
+        endpoints_per_sub,
+        pool_observer,
+        cancellation_token.child_token(),
+    )
+    .expect("validated direct-ZMQ KV ingress configuration");
     let mut sources = HashMap::<u64, SourceTask>::new();
     let mut invalid_publishers = HashSet::new();
     let mut next_task_generation = 1_u64;
@@ -270,6 +301,7 @@ async fn consume_scope(
                     client,
                     view.clone(),
                     &mut sources,
+                    &group_pool,
                     ingress_metrics,
                     &signal_tx,
                     cancellation_token,
@@ -307,6 +339,7 @@ async fn consume_scope(
                             client,
                             view,
                             &mut sources,
+                            &group_pool,
                             ingress_metrics,
                             &signal_tx,
                             cancellation_token,
@@ -328,6 +361,7 @@ async fn consume_scope(
                             client,
                             view,
                             &mut sources,
+                            &group_pool,
                             ingress_metrics,
                             &signal_tx,
                             cancellation_token,
@@ -374,6 +408,7 @@ async fn consume_scope(
                                 client,
                                 view,
                                 &mut sources,
+                                &group_pool,
                                 ingress_metrics,
                                 &signal_tx,
                                 cancellation_token,
@@ -389,6 +424,7 @@ async fn consume_scope(
                             endpoint,
                             task_generation,
                             signal_tx.clone(),
+                            group_pool.clone(),
                             client.clone(),
                             ingress_metrics.clone(),
                             cancellation_token.child_token(),
@@ -409,6 +445,7 @@ async fn consume_scope(
                                 client,
                                 view,
                                 &mut sources,
+                                &group_pool,
                                 ingress_metrics,
                                 &signal_tx,
                                 cancellation_token,
@@ -432,6 +469,7 @@ async fn consume_scope(
     for (_, source) in &stopped_sources {
         source.cancel.cancel();
     }
+    group_pool.shutdown().await;
     let publisher_ids = stopped_sources
         .iter()
         .map(|(publisher_id, _)| *publisher_id)
@@ -451,10 +489,12 @@ async fn consume_scope(
     exit
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn reconcile_sources(
     client: &Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
     preliminary_view: KvSourceMembershipView,
     sources: &mut HashMap<u64, SourceTask>,
+    group_pool: &DirectZmqSubPool,
     metrics: &Arc<KvZmqIngressMetrics>,
     signal_tx: &mpsc::Sender<SourceSignal>,
     cancellation_token: &CancellationToken,
@@ -475,6 +515,7 @@ async fn reconcile_sources(
             publisher_id,
             client,
             sources,
+            group_pool,
             metrics,
             signal_tx,
             cancellation_token,
@@ -502,6 +543,7 @@ async fn reconcile_sources(
             publisher_id,
             client,
             sources,
+            group_pool,
             metrics,
             signal_tx,
             cancellation_token,
@@ -547,6 +589,7 @@ async fn restart_source(
     publisher_id: u64,
     client: &Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
     sources: &mut HashMap<u64, SourceTask>,
+    group_pool: &DirectZmqSubPool,
     metrics: &Arc<KvZmqIngressMetrics>,
     signal_tx: &mpsc::Sender<SourceSignal>,
     cancellation_token: &CancellationToken,
@@ -568,6 +611,7 @@ async fn restart_source(
             endpoint,
             task_generation,
             signal_tx.clone(),
+            group_pool.clone(),
             client.clone(),
             metrics.clone(),
             cancellation_token.child_token(),
@@ -601,11 +645,13 @@ fn bindings_for_publisher(ready: &HashSet<KvSourceId>, publisher_id: u64) -> Has
         .collect()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn spawn_source(
     publisher_id: u64,
     endpoint: String,
     task_generation: u64,
     signal_tx: mpsc::Sender<SourceSignal>,
+    group_pool: DirectZmqSubPool,
     client: Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
     metrics: Arc<KvZmqIngressMetrics>,
     cancel: CancellationToken,
@@ -618,6 +664,7 @@ fn spawn_source(
             task_endpoint,
             task_generation,
             signal_tx,
+            group_pool,
             client,
             metrics,
             task_cancel,
@@ -639,24 +686,23 @@ async fn run_source(
     endpoint: String,
     task_generation: u64,
     signal_tx: mpsc::Sender<SourceSignal>,
+    group_pool: DirectZmqSubPool,
     client: Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
     metrics: Arc<KvZmqIngressMetrics>,
     cancel: CancellationToken,
 ) {
     let mut retry_delay = INITIAL_BACKOFF;
     loop {
-        let stream = tokio::select! {
-            _ = cancel.cancelled() => return,
-            stream = ValidatedZmqSource::connect_default(
-                &endpoint,
-                KV_EVENT_SUBJECT,
-                publisher_id,
-            ) => stream,
-        };
-        let mut stream = match stream {
-            Ok(stream) => stream,
+        if cancel.is_cancelled() {
+            return;
+        }
+        let registration = group_pool
+            .register(publisher_id, &endpoint, task_generation)
+            .await;
+        let mut registration = match registration {
+            Ok(registration) => registration,
             Err(error) => {
-                tracing::warn!(%error, publisher_id, %endpoint, "Failed to connect direct-ZMQ KV source");
+                tracing::warn!(%error, publisher_id, %endpoint, "Failed to register direct-ZMQ KV source with a socket group");
                 if signal_tx
                     .send(SourceSignal::Disconnected {
                         publisher_id,
@@ -674,6 +720,12 @@ async fn run_source(
                 continue;
             }
         };
+        if cancel.is_cancelled() {
+            group_pool
+                .unregister(registration.group_id, publisher_id, task_generation)
+                .await;
+            return;
+        }
         retry_delay = INITIAL_BACKOFF;
 
         let (activate, activation) = oneshot::channel();
@@ -689,18 +741,58 @@ async fn run_source(
             return;
         }
 
-        let activated = tokio::select! {
-            _ = cancel.cancelled() => return,
-            activated = activation => activated.is_ok(),
-        };
-        if !activated {
-            return;
+        enum ActivationOutcome {
+            Activated,
+            Cancelled,
+            Disconnected,
         }
 
-        tokio::select! {
+        let activation_outcome = tokio::select! {
+            _ = cancel.cancelled() => ActivationOutcome::Cancelled,
+            activated = activation => {
+                if activated.is_ok() {
+                    ActivationOutcome::Activated
+                } else {
+                    ActivationOutcome::Cancelled
+                }
+            },
+            _ = registration.disconnected.cancelled() => ActivationOutcome::Disconnected,
+        };
+        if !matches!(activation_outcome, ActivationOutcome::Activated) {
+            group_pool
+                .unregister(registration.group_id, publisher_id, task_generation)
+                .await;
+            if matches!(activation_outcome, ActivationOutcome::Cancelled) {
+                return;
+            }
+            if signal_tx
+                .send(SourceSignal::Disconnected {
+                    publisher_id,
+                    task_generation,
+                })
+                .await
+                .is_err()
+            {
+                return;
+            }
+            if !sleep_or_cancel(retry_delay, &cancel).await {
+                return;
+            }
+            retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+            continue;
+        }
+
+        let cancelled = tokio::select! {
             biased;
-            _ = cancel.cancelled() => return,
-            _ = consume_connection(publisher_id, &mut stream, &client, &metrics) => {}
+            _ = cancel.cancelled() => true,
+            _ = registration.disconnected.cancelled() => false,
+            _ = consume_connection(publisher_id, &mut registration.receiver, &client, &metrics) => false,
+        };
+        group_pool
+            .unregister(registration.group_id, publisher_id, task_generation)
+            .await;
+        if cancelled {
+            return;
         }
         if signal_tx
             .send(SourceSignal::Disconnected {
@@ -721,33 +813,12 @@ async fn run_source(
 
 async fn consume_connection(
     publisher_id: u64,
-    stream: &mut ValidatedZmqSource,
+    receiver: &mut mpsc::Receiver<ValidatedEnvelope>,
     client: &Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
     metrics: &KvZmqIngressMetrics,
 ) {
     let codec = Codec::default();
-    loop {
-        let result = stream.next().await;
-        let Some(result) = result else {
-            return;
-        };
-        let envelope = match result {
-            Ok(envelope) => envelope,
-            Err(ValidatedZmqSourceError::Receive(error)) => {
-                tracing::warn!(%error, publisher_id, "Direct-ZMQ KV source stream failed");
-                return;
-            }
-            Err(ValidatedZmqSourceError::EnvelopeDecode(error)) => {
-                tracing::warn!(%error, publisher_id, "Failed to decode direct-ZMQ KV envelope");
-                metrics.increment_lifecycle("envelope_decode_error");
-                continue;
-            }
-            Err(error @ ValidatedZmqSourceError::IdentityMismatch { .. }) => {
-                tracing::warn!(%error, publisher_id, "Dropping direct-ZMQ KV envelope with inconsistent attribution");
-                metrics.increment_lifecycle("identity_mismatch");
-                continue;
-            }
-        };
+    while let Some(envelope) = receiver.recv().await {
         let events = match codec.decode_payload::<Vec<RouterEvent>>(&envelope.payload) {
             Ok(events) => events,
             Err(error) => {
@@ -757,7 +828,7 @@ async fn consume_connection(
             }
         };
         client.handle_live_batch(publisher_id, events).await;
-        metrics.increment_batch();
+        metrics.increment_batch(KvZmqIngressStream::Events);
     }
 }
 

--- a/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
@@ -17,7 +17,7 @@ use dynamo_runtime::{
     },
     protocols::EndpointId,
     traits::DistributedRuntimeProvider,
-    transports::event_plane::{Codec, EventScope, ValidatedEnvelope},
+    transports::event_plane::{Codec, EventScope},
 };
 use futures::StreamExt;
 use tokio::{
@@ -36,10 +36,11 @@ use super::{
 };
 use crate::{
     direct_zmq_sub_pool::{
-        DirectZmqSubPool, DirectZmqSubPoolEvent, ENDPOINTS_PER_SUB_ENV, endpoints_per_sub_from_env,
+        DirectZmqSubItem, DirectZmqSubPool, ENDPOINTS_PER_SUB_ENV, KV_ZMQ_RCVHWM,
+        endpoints_per_sub_from_env,
     },
     discovery::{KvSourceId, KvSourceMembershipView, KvSourceMembershipWatch},
-    kv_router::metrics::{KvZmqIngressMetrics, KvZmqIngressStream, RouterWorkerStatusMetrics},
+    kv_router::metrics::{KvZmqIngressMetrics, RouterWorkerStatusMetrics},
 };
 
 const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
@@ -263,14 +264,10 @@ async fn consume_scope(
         endpoint: kv_state_endpoint.clone(),
     };
     let (signal_tx, mut signal_rx) = mpsc::channel(SIGNAL_CAPACITY);
-    let pool_metrics = ingress_metrics.clone();
-    let pool_observer = Arc::new(move |event: DirectZmqSubPoolEvent| {
-        pool_metrics.observe_pool(KvZmqIngressStream::Events, event);
-    });
     let group_pool = DirectZmqSubPool::new(
         KV_EVENT_SUBJECT,
         endpoints_per_sub,
-        pool_observer,
+        KV_ZMQ_RCVHWM,
         cancellation_token.child_token(),
     )
     .expect("validated direct-ZMQ KV ingress configuration");
@@ -813,12 +810,23 @@ async fn run_source(
 
 async fn consume_connection(
     publisher_id: u64,
-    receiver: &mut mpsc::Receiver<ValidatedEnvelope>,
+    receiver: &mut mpsc::Receiver<DirectZmqSubItem>,
     client: &Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
     metrics: &KvZmqIngressMetrics,
 ) {
     let codec = Codec::default();
-    while let Some(envelope) = receiver.recv().await {
+    while let Some(item) = receiver.recv().await {
+        let envelope = match item {
+            DirectZmqSubItem::Envelope(envelope) => envelope,
+            DirectZmqSubItem::EnvelopeDecodeError => {
+                metrics.increment_lifecycle("envelope_decode_error");
+                continue;
+            }
+            DirectZmqSubItem::IdentityMismatch => {
+                metrics.increment_lifecycle("identity_mismatch");
+                continue;
+            }
+        };
         let events = match codec.decode_payload::<Vec<RouterEvent>>(&envelope.payload) {
             Ok(events) => events,
             Err(error) => {
@@ -828,7 +836,7 @@ async fn consume_connection(
             }
         };
         client.handle_live_batch(publisher_id, events).await;
-        metrics.increment_batch(KvZmqIngressStream::Events);
+        metrics.increment_batch();
     }
 }
 

--- a/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
@@ -719,9 +719,7 @@ async fn run_source(
             }
         };
         if cancel.is_cancelled() {
-            group_pool
-                .unregister(registration, publisher_id, task_generation)
-                .await;
+            registration.close().await;
             return;
         }
         retry_delay = INITIAL_BACKOFF;
@@ -759,9 +757,7 @@ async fn run_source(
             _ = registration.disconnected.cancelled() => ActivationOutcome::Disconnected,
         };
         if !matches!(activation_outcome, ActivationOutcome::Activated) {
-            group_pool
-                .unregister(registration, publisher_id, task_generation)
-                .await;
+            registration.close().await;
             if matches!(activation_outcome, ActivationOutcome::Cancelled) {
                 return;
             }
@@ -790,9 +786,7 @@ async fn run_source(
             _ = registration.disconnected.cancelled() => false,
             _ = consume_connection(publisher_id, &mut registration.receiver, &client, &metrics) => false,
         };
-        group_pool
-            .unregister(registration, publisher_id, task_generation)
-            .await;
+        registration.close().await;
         if cancelled {
             return;
         }

--- a/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
@@ -466,7 +466,6 @@ async fn consume_scope(
     for (_, source) in &stopped_sources {
         source.cancel.cancel();
     }
-    group_pool.shutdown().await;
     let publisher_ids = stopped_sources
         .iter()
         .map(|(publisher_id, _)| *publisher_id)
@@ -477,6 +476,7 @@ async fn consume_scope(
             .map(|(_, source)| stop_source(source, ingress_metrics)),
     )
     .await;
+    group_pool.shutdown().await;
     for publisher_id in publisher_ids {
         client.fence_transport(publisher_id).await;
     }
@@ -690,23 +690,24 @@ async fn run_source(
 ) {
     let mut retry_delay = INITIAL_BACKOFF;
     loop {
-        if cancel.is_cancelled() {
-            return;
-        }
-        let registration = group_pool
-            .register(publisher_id, &endpoint, task_generation)
-            .await;
+        let registration = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return,
+            registration = group_pool.register(publisher_id, &endpoint, task_generation) => registration,
+        };
         let mut registration = match registration {
             Ok(registration) => registration,
             Err(error) => {
                 tracing::warn!(%error, publisher_id, %endpoint, "Failed to register direct-ZMQ KV source with a socket group");
-                if signal_tx
-                    .send(SourceSignal::Disconnected {
+                if !send_source_signal(
+                    &signal_tx,
+                    SourceSignal::Disconnected {
                         publisher_id,
                         task_generation,
-                    })
-                    .await
-                    .is_err()
+                    },
+                    &cancel,
+                )
+                .await
                 {
                     return;
                 }
@@ -726,14 +727,16 @@ async fn run_source(
         retry_delay = INITIAL_BACKOFF;
 
         let (activate, activation) = oneshot::channel();
-        if signal_tx
-            .send(SourceSignal::Ready {
+        if !send_source_signal(
+            &signal_tx,
+            SourceSignal::Ready {
                 publisher_id,
                 task_generation,
                 activate,
-            })
-            .await
-            .is_err()
+            },
+            &cancel,
+        )
+        .await
         {
             return;
         }
@@ -762,13 +765,15 @@ async fn run_source(
             if matches!(activation_outcome, ActivationOutcome::Cancelled) {
                 return;
             }
-            if signal_tx
-                .send(SourceSignal::Disconnected {
+            if !send_source_signal(
+                &signal_tx,
+                SourceSignal::Disconnected {
                     publisher_id,
                     task_generation,
-                })
-                .await
-                .is_err()
+                },
+                &cancel,
+            )
+            .await
             {
                 return;
             }
@@ -791,13 +796,15 @@ async fn run_source(
         if cancelled {
             return;
         }
-        if signal_tx
-            .send(SourceSignal::Disconnected {
+        if !send_source_signal(
+            &signal_tx,
+            SourceSignal::Disconnected {
                 publisher_id,
                 task_generation,
-            })
-            .await
-            .is_err()
+            },
+            &cancel,
+        )
+        .await
         {
             return;
         }
@@ -805,6 +812,18 @@ async fn run_source(
             return;
         }
         retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+    }
+}
+
+async fn send_source_signal(
+    signal_tx: &mpsc::Sender<SourceSignal>,
+    signal: SourceSignal,
+    cancel: &CancellationToken,
+) -> bool {
+    tokio::select! {
+        biased;
+        _ = cancel.cancelled() => false,
+        result = signal_tx.send(signal) => result.is_ok(),
     }
 }
 
@@ -904,5 +923,40 @@ async fn sleep_or_cancel(delay: Duration, cancellation_token: &CancellationToken
     tokio::select! {
         _ = cancellation_token.cancelled() => false,
         _ = tokio::time::sleep(delay) => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn full_source_status_channel_does_not_delay_shutdown() {
+        let (signal_tx, _signal_rx) = mpsc::channel(1);
+        signal_tx
+            .send(SourceSignal::Disconnected {
+                publisher_id: 1,
+                task_generation: 1,
+            })
+            .await
+            .unwrap();
+
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let sent = tokio::time::timeout(
+            Duration::from_secs(1),
+            send_source_signal(
+                &signal_tx,
+                SourceSignal::Disconnected {
+                    publisher_id: 2,
+                    task_generation: 1,
+                },
+                &cancel,
+            ),
+        )
+        .await
+        .expect("cancelled status send must finish promptly");
+
+        assert!(!sent);
     }
 }

--- a/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
@@ -17,7 +17,7 @@ use dynamo_runtime::{
     },
     protocols::EndpointId,
     traits::DistributedRuntimeProvider,
-    transports::event_plane::{Codec, EventScope},
+    transports::event_plane::{Codec, EventScope, ValidatedZmqSource, ValidatedZmqSourceError},
 };
 use futures::StreamExt;
 use tokio::{
@@ -36,8 +36,8 @@ use super::{
 };
 use crate::{
     direct_zmq_sub_pool::{
-        DirectZmqSubItem, DirectZmqSubPool, ENDPOINTS_PER_SUB_ENV, KV_ZMQ_RCVHWM,
-        endpoints_per_sub_from_env,
+        DirectZmqSubConnection, DirectZmqSubItem, DirectZmqSubPool, ENDPOINTS_PER_SUB_ENV,
+        KV_ZMQ_RCVHWM, endpoints_per_sub_from_env,
     },
     discovery::{KvSourceId, KvSourceMembershipView, KvSourceMembershipWatch},
     kv_router::metrics::{KvZmqIngressMetrics, RouterWorkerStatusMetrics},
@@ -58,11 +58,13 @@ enum SourceSignal {
     Ready {
         publisher_id: u64,
         task_generation: u64,
+        group_id: Option<u64>,
         activate: oneshot::Sender<()>,
     },
     Disconnected {
         publisher_id: u64,
         task_generation: u64,
+        group_id: Option<u64>,
     },
 }
 
@@ -72,6 +74,7 @@ struct SourceTask {
     cancel: CancellationToken,
     handle: JoinHandle<()>,
     state: SourceState,
+    group_id: Option<u64>,
 }
 
 enum SourceState {
@@ -318,13 +321,14 @@ async fn consume_scope(
                     break;
                 };
                 match signal {
-                    SourceSignal::Ready { publisher_id, task_generation, activate } => {
+                    SourceSignal::Ready { publisher_id, task_generation, group_id, activate } => {
                         let Some(source) = sources.get_mut(&publisher_id) else {
                             continue;
                         };
                         if source.task_generation != task_generation {
                             continue;
                         }
+                        source.group_id = group_id;
                         transition_source_state(
                             source,
                             SourceState::Preconnected { activate },
@@ -343,16 +347,27 @@ async fn consume_scope(
                             &mut next_task_generation,
                         ).await;
                     }
-                    SourceSignal::Disconnected { publisher_id, task_generation } => {
-                        let Some(source) = sources.get_mut(&publisher_id) else {
-                            continue;
-                        };
-                        if source.task_generation != task_generation {
+                    SourceSignal::Disconnected { publisher_id, task_generation, group_id } => {
+                        let affected = affected_source_ids(
+                            &sources,
+                            publisher_id,
+                            task_generation,
+                            group_id,
+                        );
+                        if affected.is_empty() {
                             continue;
                         }
-                        transition_source_state(source, SourceState::Fenced, ingress_metrics);
-                        ingress_metrics.increment_lifecycle("reconnect");
-                        client.fence_transport(publisher_id).await;
+                        for publisher_id in &affected {
+                            let source = sources
+                                .get_mut(publisher_id)
+                                .expect("affected source must exist");
+                            source.group_id = None;
+                            transition_source_state(source, SourceState::Fenced, ingress_metrics);
+                            ingress_metrics.increment_lifecycle("reconnect");
+                        }
+                        for publisher_id in affected {
+                            client.fence_transport(publisher_id).await;
+                        }
                         let view = membership_watch.borrow().clone();
                         reconcile_sources(
                             client,
@@ -484,6 +499,29 @@ async fn consume_scope(
         .sync_membership_with_ready_sources(&HashSet::new())
         .await;
     exit
+}
+
+fn affected_source_ids(
+    sources: &HashMap<u64, SourceTask>,
+    publisher_id: u64,
+    task_generation: u64,
+    group_id: Option<u64>,
+) -> Vec<u64> {
+    let Some(source) = sources.get(&publisher_id) else {
+        return Vec::new();
+    };
+    if source.task_generation != task_generation || source.group_id != group_id {
+        return Vec::new();
+    }
+    match group_id {
+        Some(group_id) => sources
+            .iter()
+            .filter_map(|(publisher_id, source)| {
+                (source.group_id == Some(group_id)).then_some(*publisher_id)
+            })
+            .collect(),
+        None => vec![publisher_id],
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -674,6 +712,7 @@ fn spawn_source(
         cancel,
         handle,
         state: SourceState::Connecting,
+        group_id: None,
     }
 }
 
@@ -690,20 +729,21 @@ async fn run_source(
 ) {
     let mut retry_delay = INITIAL_BACKOFF;
     loop {
-        let registration = tokio::select! {
+        let connection = tokio::select! {
             biased;
             _ = cancel.cancelled() => return,
-            registration = group_pool.register(publisher_id, &endpoint, task_generation) => registration,
+            connection = group_pool.connect(publisher_id, &endpoint, task_generation) => connection,
         };
-        let mut registration = match registration {
-            Ok(registration) => registration,
+        let mut connection = match connection {
+            Ok(connection) => connection,
             Err(error) => {
-                tracing::warn!(%error, publisher_id, %endpoint, "Failed to register direct-ZMQ KV source with a socket group");
+                tracing::warn!(%error, publisher_id, %endpoint, "Failed to connect direct-ZMQ KV source");
                 if !send_source_signal(
                     &signal_tx,
                     SourceSignal::Disconnected {
                         publisher_id,
                         task_generation,
+                        group_id: None,
                     },
                     &cancel,
                 )
@@ -719,10 +759,12 @@ async fn run_source(
             }
         };
         if cancel.is_cancelled() {
-            registration.close().await;
+            connection.close().await;
             return;
         }
         retry_delay = INITIAL_BACKOFF;
+        let group_id = connection.group_id();
+        let disconnected = connection.disconnected();
 
         let (activate, activation) = oneshot::channel();
         if !send_source_signal(
@@ -730,6 +772,7 @@ async fn run_source(
             SourceSignal::Ready {
                 publisher_id,
                 task_generation,
+                group_id,
                 activate,
             },
             &cancel,
@@ -754,10 +797,10 @@ async fn run_source(
                     ActivationOutcome::Cancelled
                 }
             },
-            _ = registration.disconnected.cancelled() => ActivationOutcome::Disconnected,
+            _ = wait_for_disconnect(disconnected.clone()) => ActivationOutcome::Disconnected,
         };
         if !matches!(activation_outcome, ActivationOutcome::Activated) {
-            registration.close().await;
+            connection.close().await;
             if matches!(activation_outcome, ActivationOutcome::Cancelled) {
                 return;
             }
@@ -766,6 +809,7 @@ async fn run_source(
                 SourceSignal::Disconnected {
                     publisher_id,
                     task_generation,
+                    group_id,
                 },
                 &cancel,
             )
@@ -783,10 +827,10 @@ async fn run_source(
         let cancelled = tokio::select! {
             biased;
             _ = cancel.cancelled() => true,
-            _ = registration.disconnected.cancelled() => false,
-            _ = consume_connection(publisher_id, &mut registration.receiver, &client, &metrics) => false,
+            _ = wait_for_disconnect(disconnected) => false,
+            _ = consume_connection(publisher_id, &mut connection, &client, &metrics) => false,
         };
-        registration.close().await;
+        connection.close().await;
         if cancelled {
             return;
         }
@@ -795,6 +839,7 @@ async fn run_source(
             SourceSignal::Disconnected {
                 publisher_id,
                 task_generation,
+                group_id,
             },
             &cancel,
         )
@@ -806,6 +851,13 @@ async fn run_source(
             return;
         }
         retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+    }
+}
+
+async fn wait_for_disconnect(disconnected: Option<CancellationToken>) {
+    match disconnected {
+        Some(disconnected) => disconnected.cancelled().await,
+        None => std::future::pending().await,
     }
 }
 
@@ -823,6 +875,23 @@ async fn send_source_signal(
 
 async fn consume_connection(
     publisher_id: u64,
+    connection: &mut DirectZmqSubConnection,
+    client: &Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
+    metrics: &KvZmqIngressMetrics,
+) {
+    match connection {
+        DirectZmqSubConnection::Dedicated(source) => {
+            consume_dedicated_connection(publisher_id, source, client, metrics).await
+        }
+        DirectZmqSubConnection::Grouped(registration) => {
+            consume_grouped_connection(publisher_id, &mut registration.receiver, client, metrics)
+                .await
+        }
+    }
+}
+
+async fn consume_grouped_connection(
+    publisher_id: u64,
     receiver: &mut mpsc::Receiver<DirectZmqSubItem>,
     client: &Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
     metrics: &KvZmqIngressMetrics,
@@ -836,6 +905,47 @@ async fn consume_connection(
                 continue;
             }
             DirectZmqSubItem::IdentityMismatch => {
+                metrics.increment_lifecycle("identity_mismatch");
+                continue;
+            }
+        };
+        let events = match codec.decode_payload::<Vec<RouterEvent>>(&envelope.payload) {
+            Ok(events) => events,
+            Err(error) => {
+                tracing::warn!(%error, publisher_id, "Failed to decode direct-ZMQ KV payload");
+                metrics.increment_lifecycle("payload_decode_error");
+                continue;
+            }
+        };
+        client.handle_live_batch(publisher_id, events).await;
+        metrics.increment_batch();
+    }
+}
+
+async fn consume_dedicated_connection(
+    publisher_id: u64,
+    source: &mut ValidatedZmqSource,
+    client: &Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
+    metrics: &KvZmqIngressMetrics,
+) {
+    let codec = Codec::default();
+    loop {
+        let Some(result) = source.next().await else {
+            return;
+        };
+        let envelope = match result {
+            Ok(envelope) => envelope,
+            Err(ValidatedZmqSourceError::Receive(error)) => {
+                tracing::warn!(%error, publisher_id, "Direct-ZMQ KV source stream failed");
+                return;
+            }
+            Err(ValidatedZmqSourceError::EnvelopeDecode(error)) => {
+                tracing::warn!(%error, publisher_id, "Failed to decode direct-ZMQ KV envelope");
+                metrics.increment_lifecycle("envelope_decode_error");
+                continue;
+            }
+            Err(error @ ValidatedZmqSourceError::IdentityMismatch { .. }) => {
+                tracing::warn!(%error, publisher_id, "Dropping direct-ZMQ KV envelope with inconsistent attribution");
                 metrics.increment_lifecycle("identity_mismatch");
                 continue;
             }
@@ -924,6 +1034,39 @@ async fn sleep_or_cancel(delay: Duration, cancellation_token: &CancellationToken
 mod tests {
     use super::*;
 
+    fn test_source(task_generation: u64, group_id: Option<u64>) -> SourceTask {
+        SourceTask {
+            endpoint: "tcp://127.0.0.1:1".to_string(),
+            task_generation,
+            cancel: CancellationToken::new(),
+            handle: tokio::spawn(std::future::pending()),
+            state: SourceState::Connecting,
+            group_id,
+        }
+    }
+
+    #[tokio::test]
+    async fn grouped_disconnect_selects_its_failure_domain_once() {
+        let mut sources = HashMap::from([
+            (1, test_source(10, Some(7))),
+            (2, test_source(20, Some(7))),
+            (3, test_source(30, Some(8))),
+        ]);
+
+        let affected = affected_source_ids(&sources, 1, 10, Some(7))
+            .into_iter()
+            .collect::<HashSet<_>>();
+        assert_eq!(affected, HashSet::from([1, 2]));
+        for publisher_id in affected {
+            sources.get_mut(&publisher_id).unwrap().group_id = None;
+        }
+        assert!(affected_source_ids(&sources, 2, 20, Some(7)).is_empty());
+
+        for source in sources.into_values() {
+            source.handle.abort();
+        }
+    }
+
     #[tokio::test]
     async fn full_source_status_channel_does_not_delay_shutdown() {
         let (signal_tx, _signal_rx) = mpsc::channel(1);
@@ -931,6 +1074,7 @@ mod tests {
             .send(SourceSignal::Disconnected {
                 publisher_id: 1,
                 task_generation: 1,
+                group_id: None,
             })
             .await
             .unwrap();
@@ -944,6 +1088,7 @@ mod tests {
                 SourceSignal::Disconnected {
                     publisher_id: 2,
                     task_generation: 1,
+                    group_id: None,
                 },
                 &cancel,
             ),

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -211,25 +211,8 @@ pub(crate) fn kv_publisher_metrics() -> Option<Arc<KvPublisherMetrics>> {
 
 pub(crate) struct KvZmqIngressMetrics {
     sources: IntGaugeVec,
-    socket_groups: IntGaugeVec,
-    connected_endpoints: IntGaugeVec,
-    batches_total: IntCounterVec,
+    batches_total: IntCounter,
     lifecycle_total: IntCounterVec,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum KvZmqIngressStream {
-    Events,
-    Metrics,
-}
-
-impl KvZmqIngressStream {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Events => "events",
-            Self::Metrics => "metrics",
-        }
-    }
 }
 
 static KV_ZMQ_INGRESS_METRICS: OnceLock<Arc<KvZmqIngressMetrics>> = OnceLock::new();
@@ -248,28 +231,12 @@ impl KvZmqIngressMetrics {
                     )
                     .expect("failed to create router_kv_zmq_ingress_sources gauge");
                 let batches_total = metrics
-                    .create_intcountervec(
+                    .create_intcounter(
                         "router_kv_zmq_ingress_batches_total",
                         "Total ZMQ KV ingress batches handed to WorkerQueryClient",
                         &[],
                     )
                     .expect("failed to create router_kv_zmq_ingress_batches_total counter");
-                let socket_groups = metrics
-                    .create_intgaugevec(
-                        "router_kv_zmq_ingress_socket_groups",
-                        "Number of direct-ZMQ KV ingress SUB socket groups by stream",
-                        &["stream"],
-                        &[],
-                    )
-                    .expect("failed to create router_kv_zmq_ingress_socket_groups gauge");
-                let connected_endpoints = metrics
-                    .create_intgaugevec(
-                        "router_kv_zmq_ingress_connected_endpoints",
-                        "Number of publisher endpoints connected to direct-ZMQ KV ingress SUB sockets by stream",
-                        &["stream"],
-                        &[],
-                    )
-                    .expect("failed to create router_kv_zmq_ingress_connected_endpoints gauge");
                 let lifecycle_total = metrics
                     .create_intcountervec(
                         "router_kv_zmq_ingress_lifecycle_total",
@@ -280,8 +247,6 @@ impl KvZmqIngressMetrics {
                     .expect("failed to create router_kv_zmq_ingress_lifecycle_total counter");
                 Arc::new(Self {
                     sources,
-                    socket_groups,
-                    connected_endpoints,
                     batches_total,
                     lifecycle_total,
                 })
@@ -297,46 +262,12 @@ impl KvZmqIngressMetrics {
         self.sources.with_label_values(&[state]).dec();
     }
 
-    pub(crate) fn increment_batch(&self, stream: KvZmqIngressStream) {
-        self.batches_total
-            .with_label_values(&[stream.label()])
-            .inc();
+    pub(crate) fn increment_batch(&self) {
+        self.batches_total.inc();
     }
 
     pub(crate) fn increment_lifecycle(&self, action: &'static str) {
-        self.increment_stream_lifecycle(KvZmqIngressStream::Events, action);
-    }
-
-    pub(crate) fn increment_stream_lifecycle(
-        &self,
-        stream: KvZmqIngressStream,
-        action: &'static str,
-    ) {
-        self.lifecycle_total
-            .with_label_values(&[stream.label(), action])
-            .inc();
-    }
-
-    pub(crate) fn observe_pool(
-        &self,
-        stream: KvZmqIngressStream,
-        event: crate::direct_zmq_sub_pool::DirectZmqSubPoolEvent,
-    ) {
-        use crate::direct_zmq_sub_pool::DirectZmqSubPoolEvent;
-
-        match event {
-            DirectZmqSubPoolEvent::SocketGroups(delta) => self
-                .socket_groups
-                .with_label_values(&[stream.label()])
-                .add(delta),
-            DirectZmqSubPoolEvent::ConnectedEndpoints(delta) => self
-                .connected_endpoints
-                .with_label_values(&[stream.label()])
-                .add(delta),
-            DirectZmqSubPoolEvent::Lifecycle(action) => {
-                self.increment_stream_lifecycle(stream, action)
-            }
-        }
+        self.lifecycle_total.with_label_values(&[action]).inc();
     }
 
     pub(crate) fn increment_lifecycle_by(&self, action: &'static str, value: u64) {

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -211,8 +211,25 @@ pub(crate) fn kv_publisher_metrics() -> Option<Arc<KvPublisherMetrics>> {
 
 pub(crate) struct KvZmqIngressMetrics {
     sources: IntGaugeVec,
-    batches_total: IntCounter,
+    socket_groups: IntGaugeVec,
+    connected_endpoints: IntGaugeVec,
+    batches_total: IntCounterVec,
     lifecycle_total: IntCounterVec,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KvZmqIngressStream {
+    Events,
+    Metrics,
+}
+
+impl KvZmqIngressStream {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Events => "events",
+            Self::Metrics => "metrics",
+        }
+    }
 }
 
 static KV_ZMQ_INGRESS_METRICS: OnceLock<Arc<KvZmqIngressMetrics>> = OnceLock::new();
@@ -231,12 +248,28 @@ impl KvZmqIngressMetrics {
                     )
                     .expect("failed to create router_kv_zmq_ingress_sources gauge");
                 let batches_total = metrics
-                    .create_intcounter(
+                    .create_intcountervec(
                         "router_kv_zmq_ingress_batches_total",
                         "Total ZMQ KV ingress batches handed to WorkerQueryClient",
                         &[],
                     )
                     .expect("failed to create router_kv_zmq_ingress_batches_total counter");
+                let socket_groups = metrics
+                    .create_intgaugevec(
+                        "router_kv_zmq_ingress_socket_groups",
+                        "Number of direct-ZMQ KV ingress SUB socket groups by stream",
+                        &["stream"],
+                        &[],
+                    )
+                    .expect("failed to create router_kv_zmq_ingress_socket_groups gauge");
+                let connected_endpoints = metrics
+                    .create_intgaugevec(
+                        "router_kv_zmq_ingress_connected_endpoints",
+                        "Number of publisher endpoints connected to direct-ZMQ KV ingress SUB sockets by stream",
+                        &["stream"],
+                        &[],
+                    )
+                    .expect("failed to create router_kv_zmq_ingress_connected_endpoints gauge");
                 let lifecycle_total = metrics
                     .create_intcountervec(
                         "router_kv_zmq_ingress_lifecycle_total",
@@ -247,6 +280,8 @@ impl KvZmqIngressMetrics {
                     .expect("failed to create router_kv_zmq_ingress_lifecycle_total counter");
                 Arc::new(Self {
                     sources,
+                    socket_groups,
+                    connected_endpoints,
                     batches_total,
                     lifecycle_total,
                 })
@@ -262,12 +297,46 @@ impl KvZmqIngressMetrics {
         self.sources.with_label_values(&[state]).dec();
     }
 
-    pub(crate) fn increment_batch(&self) {
-        self.batches_total.inc();
+    pub(crate) fn increment_batch(&self, stream: KvZmqIngressStream) {
+        self.batches_total
+            .with_label_values(&[stream.label()])
+            .inc();
     }
 
     pub(crate) fn increment_lifecycle(&self, action: &'static str) {
-        self.lifecycle_total.with_label_values(&[action]).inc();
+        self.increment_stream_lifecycle(KvZmqIngressStream::Events, action);
+    }
+
+    pub(crate) fn increment_stream_lifecycle(
+        &self,
+        stream: KvZmqIngressStream,
+        action: &'static str,
+    ) {
+        self.lifecycle_total
+            .with_label_values(&[stream.label(), action])
+            .inc();
+    }
+
+    pub(crate) fn observe_pool(
+        &self,
+        stream: KvZmqIngressStream,
+        event: crate::direct_zmq_sub_pool::DirectZmqSubPoolEvent,
+    ) {
+        use crate::direct_zmq_sub_pool::DirectZmqSubPoolEvent;
+
+        match event {
+            DirectZmqSubPoolEvent::SocketGroups(delta) => self
+                .socket_groups
+                .with_label_values(&[stream.label()])
+                .add(delta),
+            DirectZmqSubPoolEvent::ConnectedEndpoints(delta) => self
+                .connected_endpoints
+                .with_label_values(&[stream.label()])
+                .add(delta),
+            DirectZmqSubPoolEvent::Lifecycle(action) => {
+                self.increment_stream_lifecycle(stream, action)
+            }
+        }
     }
 
     pub(crate) fn increment_lifecycle_by(&self, action: &'static str, value: u64) {

--- a/lib/llm/src/kv_router/metrics_subscriber.rs
+++ b/lib/llm/src/kv_router/metrics_subscriber.rs
@@ -1,0 +1,501 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transport-selecting subscription for worker KV load metrics.
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use anyhow::Result;
+use dynamo_kv_router::protocols::ActiveLoad;
+use dynamo_runtime::{
+    DistributedRuntime,
+    component::{Component, Endpoint},
+    config::environment_names::event_plane::DYN_ZMQ_EVENT_SUBSCRIBER_CHANNEL_CAPACITY,
+    discovery::{
+        DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, EventChannelInstanceId,
+        EventChannelQuery, EventScope, EventTransport,
+    },
+    protocols::EndpointId,
+    traits::DistributedRuntimeProvider,
+    transports::event_plane::{Codec, EventSubscriber, TypedEventSubscriber, uses_direct_zmq},
+};
+use futures::StreamExt;
+use tokio::{sync::mpsc, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+
+use super::{
+    KV_METRICS_SUBJECT,
+    metrics::{KvZmqIngressMetrics, KvZmqIngressStream},
+};
+use crate::direct_zmq_sub_pool::{
+    DirectZmqSubPool, DirectZmqSubPoolEvent, endpoints_per_sub_from_env,
+};
+
+const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
+const MAX_BACKOFF: Duration = Duration::from_secs(5);
+const SOURCE_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_OUTPUT_CAPACITY: usize = 100_000;
+
+fn output_capacity() -> usize {
+    std::env::var(DYN_ZMQ_EVENT_SUBSCRIBER_CHANNEL_CAPACITY)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|&value| value > 0)
+        .unwrap_or(DEFAULT_OUTPUT_CAPACITY)
+}
+
+pub(crate) struct KvMetricsSubscriber {
+    inner: KvMetricsSubscriberInner,
+}
+
+enum KvMetricsSubscriberInner {
+    Standard(TypedEventSubscriber<ActiveLoad>),
+    Direct(DirectKvMetricsSubscriber),
+}
+
+struct DirectKvMetricsSubscriber {
+    receiver: mpsc::Receiver<ActiveLoad>,
+    cancellation_token: CancellationToken,
+    _supervisor: JoinHandle<()>,
+}
+
+impl Drop for DirectKvMetricsSubscriber {
+    fn drop(&mut self) {
+        self.cancellation_token.cancel();
+    }
+}
+
+impl KvMetricsSubscriber {
+    pub(crate) async fn for_endpoint(endpoint: &Endpoint) -> Result<Self> {
+        Self::new(
+            endpoint.component(),
+            endpoint.drt(),
+            endpoint.id(),
+            Some(endpoint),
+        )
+        .await
+    }
+
+    pub(crate) async fn for_endpoint_id(
+        component: &Component,
+        endpoint: &EndpointId,
+    ) -> Result<Self> {
+        Self::new(component, component.drt(), endpoint.clone(), None).await
+    }
+
+    async fn new(
+        component: &Component,
+        drt: &DistributedRuntime,
+        endpoint_id: EndpointId,
+        endpoint: Option<&Endpoint>,
+    ) -> Result<Self> {
+        if uses_direct_zmq(drt.default_event_transport_kind()) {
+            return Ok(Self {
+                inner: KvMetricsSubscriberInner::Direct(
+                    DirectKvMetricsSubscriber::start(component, endpoint_id).await?,
+                ),
+            });
+        }
+
+        let subscriber = match endpoint {
+            Some(endpoint) => EventSubscriber::for_endpoint(endpoint, KV_METRICS_SUBJECT).await?,
+            None => EventSubscriber::for_endpoint_id(drt, &endpoint_id, KV_METRICS_SUBJECT).await?,
+        };
+        Ok(Self {
+            inner: KvMetricsSubscriberInner::Standard(subscriber.typed::<ActiveLoad>()),
+        })
+    }
+
+    pub(crate) async fn next(&mut self) -> Option<Result<ActiveLoad>> {
+        match &mut self.inner {
+            KvMetricsSubscriberInner::Standard(subscriber) => subscriber
+                .next()
+                .await
+                .map(|result| result.map(|(_envelope, load)| load)),
+            KvMetricsSubscriberInner::Direct(subscriber) => {
+                subscriber.receiver.recv().await.map(Ok)
+            }
+        }
+    }
+}
+
+impl DirectKvMetricsSubscriber {
+    async fn start(component: &Component, endpoint: EndpointId) -> Result<Self> {
+        let endpoints_per_sub = endpoints_per_sub_from_env()?;
+        let cancellation_token = component.drt().primary_token().child_token();
+        let query = dynamo_runtime::discovery::DiscoveryQuery::EventChannels(
+            EventChannelQuery::endpoint_topic(endpoint.clone(), KV_METRICS_SUBJECT),
+        );
+        let watch_cancel = cancellation_token.child_token();
+        let watch = component
+            .drt()
+            .discovery()
+            .list_and_watch(query, Some(watch_cancel.clone()))
+            .await?;
+        let metrics = KvZmqIngressMetrics::from_component(component);
+        let pool_metrics = metrics.clone();
+        let pool_observer = Arc::new(move |event: DirectZmqSubPoolEvent| {
+            pool_metrics.observe_pool(KvZmqIngressStream::Metrics, event);
+        });
+        let pool = DirectZmqSubPool::new(
+            KV_METRICS_SUBJECT,
+            endpoints_per_sub,
+            pool_observer,
+            cancellation_token.child_token(),
+        )?;
+        let (sender, receiver) = mpsc::channel(output_capacity());
+        let supervisor_cancel = cancellation_token.clone();
+        let supervisor = tokio::spawn(run_metrics_supervisor(
+            endpoint,
+            watch,
+            watch_cancel,
+            pool,
+            sender,
+            metrics,
+            supervisor_cancel,
+        ));
+
+        Ok(Self {
+            receiver,
+            cancellation_token,
+            _supervisor: supervisor,
+        })
+    }
+}
+
+struct MetricsSourceTask {
+    endpoint: String,
+    generation: u64,
+    cancel: CancellationToken,
+    handle: JoinHandle<()>,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_metrics_supervisor(
+    endpoint: EndpointId,
+    mut discovery_stream: dynamo_runtime::discovery::DiscoveryStream,
+    watch_cancel: CancellationToken,
+    pool: DirectZmqSubPool,
+    output: mpsc::Sender<ActiveLoad>,
+    metrics: Arc<KvZmqIngressMetrics>,
+    cancellation_token: CancellationToken,
+) {
+    let expected_scope = EventScope::Endpoint { endpoint };
+    let mut sources = HashMap::<u64, MetricsSourceTask>::new();
+    let mut next_generation = 1_u64;
+
+    loop {
+        let event = tokio::select! {
+            biased;
+            _ = cancellation_token.cancelled() => break,
+            event = discovery_stream.next() => event,
+        };
+        let Some(event) = event else {
+            tracing::warn!(
+                topic = KV_METRICS_SUBJECT,
+                "Direct-ZMQ KV metrics discovery stream ended"
+            );
+            break;
+        };
+
+        match event {
+            Ok(DiscoveryEvent::Added(DiscoveryInstance::EventChannel {
+                scope,
+                topic,
+                instance_id,
+                transport,
+            })) if scope == expected_scope && topic == KV_METRICS_SUBJECT => {
+                let EventTransport::Zmq { endpoint } = transport else {
+                    tracing::warn!(
+                        publisher_id = instance_id,
+                        "Ignoring non-ZMQ KV metrics publisher in direct mode"
+                    );
+                    continue;
+                };
+                if sources
+                    .get(&instance_id)
+                    .is_some_and(|source| source.endpoint == endpoint)
+                {
+                    continue;
+                }
+                if let Some(source) = sources.remove(&instance_id) {
+                    stop_metrics_source(source, &metrics).await;
+                    metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "replacement");
+                }
+                let generation = next_generation;
+                next_generation = next_generation.wrapping_add(1);
+                sources.insert(
+                    instance_id,
+                    spawn_metrics_source(
+                        instance_id,
+                        endpoint,
+                        generation,
+                        pool.clone(),
+                        output.clone(),
+                        metrics.clone(),
+                        cancellation_token.child_token(),
+                    ),
+                );
+                metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "started");
+            }
+            Ok(DiscoveryEvent::Removed(DiscoveryInstanceId::EventChannel(
+                EventChannelInstanceId {
+                    scope,
+                    topic,
+                    instance_id,
+                },
+            ))) if scope == expected_scope && topic == KV_METRICS_SUBJECT => {
+                if let Some(source) = sources.remove(&instance_id) {
+                    stop_metrics_source(source, &metrics).await;
+                    metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "removed");
+                }
+            }
+            Ok(DiscoveryEvent::Added(_))
+            | Ok(DiscoveryEvent::ModelTaintsUpdated(_))
+            | Ok(DiscoveryEvent::Removed(_)) => {}
+            Err(error) => {
+                tracing::warn!(%error, topic = KV_METRICS_SUBJECT, "Direct-ZMQ KV metrics discovery failed");
+                break;
+            }
+        }
+    }
+
+    watch_cancel.cancel();
+    let sources = sources.into_values().collect::<Vec<_>>();
+    for source in &sources {
+        source.cancel.cancel();
+    }
+    pool.shutdown().await;
+    futures::future::join_all(
+        sources
+            .into_iter()
+            .map(|source| stop_metrics_source(source, &metrics)),
+    )
+    .await;
+}
+
+fn spawn_metrics_source(
+    publisher_id: u64,
+    endpoint: String,
+    generation: u64,
+    pool: DirectZmqSubPool,
+    output: mpsc::Sender<ActiveLoad>,
+    metrics: Arc<KvZmqIngressMetrics>,
+    cancel: CancellationToken,
+) -> MetricsSourceTask {
+    let task_endpoint = endpoint.clone();
+    let task_cancel = cancel.clone();
+    let handle = tokio::spawn(async move {
+        run_metrics_source(
+            publisher_id,
+            task_endpoint,
+            generation,
+            pool,
+            output,
+            metrics,
+            task_cancel,
+        )
+        .await;
+    });
+    MetricsSourceTask {
+        endpoint,
+        generation,
+        cancel,
+        handle,
+    }
+}
+
+async fn run_metrics_source(
+    publisher_id: u64,
+    endpoint: String,
+    generation: u64,
+    pool: DirectZmqSubPool,
+    output: mpsc::Sender<ActiveLoad>,
+    metrics: Arc<KvZmqIngressMetrics>,
+    cancel: CancellationToken,
+) {
+    let codec = Codec::default();
+    let mut retry_delay = INITIAL_BACKOFF;
+    loop {
+        if cancel.is_cancelled() {
+            return;
+        }
+        let registration = pool.register(publisher_id, &endpoint, generation).await;
+        let mut registration = match registration {
+            Ok(registration) => registration,
+            Err(error) => {
+                tracing::warn!(%error, publisher_id, %endpoint, "Failed to register direct-ZMQ KV metrics source");
+                metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "reconnect");
+                if !sleep_or_cancel(retry_delay, &cancel).await {
+                    return;
+                }
+                retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+                continue;
+            }
+        };
+        if cancel.is_cancelled() {
+            pool.unregister(registration.group_id, publisher_id, generation)
+                .await;
+            return;
+        }
+        retry_delay = INITIAL_BACKOFF;
+
+        let disconnected = loop {
+            let envelope = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => break false,
+                _ = registration.disconnected.cancelled() => break true,
+                envelope = registration.receiver.recv() => envelope,
+            };
+            let Some(envelope) = envelope else {
+                break true;
+            };
+            let load = match codec.decode_payload::<ActiveLoad>(&envelope.payload) {
+                Ok(load) => load,
+                Err(error) => {
+                    tracing::warn!(%error, publisher_id, "Failed to decode direct-ZMQ KV metrics payload");
+                    metrics.increment_stream_lifecycle(
+                        KvZmqIngressStream::Metrics,
+                        "payload_decode_error",
+                    );
+                    continue;
+                }
+            };
+            match output.try_send(load) {
+                Ok(()) => metrics.increment_batch(KvZmqIngressStream::Metrics),
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "consumer_full")
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => break false,
+            }
+        };
+
+        pool.unregister(registration.group_id, publisher_id, generation)
+            .await;
+        if !disconnected || output.is_closed() {
+            return;
+        }
+        metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "reconnect");
+        if !sleep_or_cancel(retry_delay, &cancel).await {
+            return;
+        }
+        retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+    }
+}
+
+async fn stop_metrics_source(mut source: MetricsSourceTask, metrics: &KvZmqIngressMetrics) {
+    source.cancel.cancel();
+    match tokio::time::timeout(SOURCE_JOIN_TIMEOUT, &mut source.handle).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) if error.is_cancelled() => {}
+        Ok(Err(error)) => {
+            tracing::warn!(%error, generation = source.generation, "Direct-ZMQ KV metrics source failed during shutdown")
+        }
+        Err(_) => {
+            source.handle.abort();
+            let _ = source.handle.await;
+            metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "forced_abort");
+        }
+    }
+    metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "stopped");
+}
+
+async fn sleep_or_cancel(delay: Duration, cancellation_token: &CancellationToken) -> bool {
+    tokio::select! {
+        _ = cancellation_token.cancelled() => false,
+        _ = tokio::time::sleep(delay) => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use dynamo_runtime::{
+        DistributedRuntime, Runtime, discovery::EventTransportKind, distributed::DistributedConfig,
+        transports::event_plane::EventPublisher,
+    };
+
+    use super::*;
+    use crate::direct_zmq_sub_pool::ENDPOINTS_PER_SUB_ENV;
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn direct_metrics_fan_in_receives_several_publishers() {
+        temp_env::async_with_vars(
+            [
+                (
+                    dynamo_runtime::config::environment_names::zmq_broker::DYN_ZMQ_BROKER_URL,
+                    None::<&str>,
+                ),
+                (
+                    dynamo_runtime::config::environment_names::zmq_broker::DYN_ZMQ_BROKER_ENABLED,
+                    None::<&str>,
+                ),
+                (ENDPOINTS_PER_SUB_ENV, Some("64")),
+            ],
+            async {
+                let runtime = Runtime::from_current().expect("create runtime handle");
+                let distributed =
+                    DistributedRuntime::new(runtime, DistributedConfig::process_local())
+                        .await
+                        .expect("create distributed runtime");
+                let endpoint = distributed
+                    .namespace(format!("kv-metrics-fan-in-{}", uuid::Uuid::new_v4()))
+                    .expect("create namespace")
+                    .component("frontend")
+                    .expect("create component")
+                    .endpoint("generate");
+                let mut subscriber = KvMetricsSubscriber::for_endpoint(&endpoint)
+                    .await
+                    .expect("create direct metrics subscriber");
+                let publisher_a = EventPublisher::for_endpoint_with_transport(
+                    &endpoint,
+                    KV_METRICS_SUBJECT,
+                    EventTransportKind::Zmq,
+                )
+                .await
+                .expect("create publisher A");
+                let publisher_b = EventPublisher::for_endpoint_with_transport(
+                    &endpoint,
+                    KV_METRICS_SUBJECT,
+                    EventTransportKind::Zmq,
+                )
+                .await
+                .expect("create publisher B");
+
+                let mut observed = HashSet::new();
+                tokio::time::timeout(Duration::from_secs(5), async {
+                    while observed.len() != 2 {
+                        publisher_a
+                            .publish(&ActiveLoad {
+                                worker_id: 1,
+                                ..ActiveLoad::default()
+                            })
+                            .await
+                            .expect("publish A");
+                        publisher_b
+                            .publish(&ActiveLoad {
+                                worker_id: 2,
+                                ..ActiveLoad::default()
+                            })
+                            .await
+                            .expect("publish B");
+                        if let Ok(Some(Ok(load))) =
+                            tokio::time::timeout(Duration::from_millis(50), subscriber.next()).await
+                        {
+                            observed.insert(load.worker_id);
+                        }
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                    }
+                })
+                .await
+                .expect("receive metrics from both publishers");
+                assert_eq!(observed, HashSet::from([1, 2]));
+
+                distributed.shutdown();
+            },
+        )
+        .await;
+    }
+}

--- a/lib/llm/src/kv_router/metrics_subscriber.rs
+++ b/lib/llm/src/kv_router/metrics_subscriber.rs
@@ -13,7 +13,6 @@ use dynamo_kv_router::protocols::{ActiveLoad, WorkerWithDpRank};
 use dynamo_runtime::{
     DistributedRuntime,
     component::{Component, Endpoint},
-    config::environment_names::event_plane::DYN_ZMQ_EVENT_SUBSCRIBER_CHANNEL_CAPACITY,
     protocols::EndpointId,
     traits::DistributedRuntimeProvider,
     transports::event_plane::{Codec, EventSubscriber, TypedEventSubscriber, uses_direct_zmq},
@@ -28,16 +27,7 @@ use crate::{
     direct_zmq_sub_pool::KV_ZMQ_RCVHWM,
 };
 
-const DEFAULT_OUTPUT_CAPACITY: usize = 100_000;
-const CAPACITY_DROP_LEVEL: tracing::Level = tracing::Level::TRACE;
-
-fn output_capacity() -> usize {
-    std::env::var(DYN_ZMQ_EVENT_SUBSCRIBER_CHANNEL_CAPACITY)
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|&value| value > 0)
-        .unwrap_or(DEFAULT_OUTPUT_CAPACITY)
-}
+const MAX_PENDING_ACTIVE_LOADS: usize = 100_000;
 
 pub(crate) struct KvMetricsSubscriber {
     inner: KvMetricsSubscriberInner,
@@ -76,14 +66,21 @@ impl PendingActiveLoads {
     fn push(&mut self, load: ActiveLoad) -> PushOutcome {
         let worker = WorkerWithDpRank::new(load.worker_id, load.dp_rank);
         if let Some(pending) = self.values.get_mut(&worker) {
-            if load.active_decode_blocks.is_some() {
-                pending.active_decode_blocks = load.active_decode_blocks;
+            let ActiveLoad {
+                worker_id: _,
+                dp_rank: _,
+                active_decode_blocks,
+                active_prefill_tokens,
+                kv_used_blocks,
+            } = load;
+            if active_decode_blocks.is_some() {
+                pending.active_decode_blocks = active_decode_blocks;
             }
-            if load.active_prefill_tokens.is_some() {
-                pending.active_prefill_tokens = load.active_prefill_tokens;
+            if active_prefill_tokens.is_some() {
+                pending.active_prefill_tokens = active_prefill_tokens;
             }
-            if load.kv_used_blocks.is_some() {
-                pending.kv_used_blocks = load.kv_used_blocks;
+            if kv_used_blocks.is_some() {
+                pending.kv_used_blocks = kv_used_blocks;
             }
             return PushOutcome::Accepted { should_wake: false };
         }
@@ -131,8 +128,7 @@ impl ActiveLoadSender {
         match outcome {
             PushOutcome::Accepted { should_wake: false } => Ok(()),
             PushOutcome::Full => {
-                tracing::event!(
-                    CAPACITY_DROP_LEVEL,
+                tracing::trace!(
                     worker_id,
                     dp_rank,
                     "Direct-ZMQ KV metrics consumer is full; dropping newest update"
@@ -165,7 +161,11 @@ impl ActiveLoadReceiver {
     }
 }
 
-fn active_load_mailbox(capacity: usize) -> (ActiveLoadSender, ActiveLoadReceiver) {
+fn active_load_mailbox() -> (ActiveLoadSender, ActiveLoadReceiver) {
+    active_load_mailbox_with_capacity(MAX_PENDING_ACTIVE_LOADS)
+}
+
+fn active_load_mailbox_with_capacity(capacity: usize) -> (ActiveLoadSender, ActiveLoadReceiver) {
     let (wake_tx, wake_rx) = mpsc::channel(1);
     let pending = Arc::new(Mutex::new(PendingActiveLoads::new(capacity)));
     (
@@ -240,7 +240,7 @@ impl KvMetricsSubscriber {
 impl DirectKvMetricsSubscriber {
     async fn start(component: &Component, endpoint_id: EndpointId) -> Result<Self> {
         let cancellation_token = component.drt().primary_token().child_token();
-        let (sender, receiver) = active_load_mailbox(output_capacity());
+        let (sender, receiver) = active_load_mailbox();
         let handler_cancel = cancellation_token.clone();
         let codec = Codec::default();
         let handler =
@@ -301,9 +301,15 @@ mod tests {
         }
     }
 
+    #[test]
+    fn direct_metrics_mailbox_uses_fixed_distinct_key_limit() {
+        let (sender, _receiver) = active_load_mailbox();
+        assert_eq!(sender.pending.lock().capacity, MAX_PENDING_ACTIVE_LOADS);
+    }
+
     #[tokio::test]
     async fn direct_metrics_mailbox_merges_partial_updates_in_key_order() {
-        let (sender, mut receiver) = active_load_mailbox(4);
+        let (sender, mut receiver) = active_load_mailbox_with_capacity(4);
 
         sender.send(load(1, 0, Some(7), None, None)).unwrap();
         sender.send(load(2, 0, None, None, Some(9))).unwrap();
@@ -326,7 +332,7 @@ mod tests {
 
     #[tokio::test]
     async fn direct_metrics_mailbox_bounds_distinct_keys_and_drains_on_close() {
-        let (sender, mut receiver) = active_load_mailbox(1);
+        let (sender, mut receiver) = active_load_mailbox_with_capacity(1);
 
         sender.send(load(1, 0, Some(7), None, None)).unwrap();
         sender.send(load(1, 0, None, None, Some(8))).unwrap();
@@ -343,12 +349,11 @@ mod tests {
             Some(load(2, 0, None, None, Some(10)))
         );
         assert_eq!(receiver.recv().await, None);
-        assert_eq!(CAPACITY_DROP_LEVEL, tracing::Level::TRACE);
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn direct_metrics_mailbox_wakes_a_waiter_and_reports_receiver_close() {
-        let (sender, mut receiver) = active_load_mailbox(1);
+        let (sender, mut receiver) = active_load_mailbox_with_capacity(1);
         let waiter = tokio::spawn(async move {
             let load = receiver.recv().await;
             (load, receiver)

--- a/lib/llm/src/kv_router/metrics_subscriber.rs
+++ b/lib/llm/src/kv_router/metrics_subscriber.rs
@@ -11,14 +11,13 @@ use std::{
 use anyhow::Result;
 use dynamo_kv_router::protocols::{ActiveLoad, WorkerWithDpRank};
 use dynamo_runtime::{
-    DistributedRuntime,
     component::{Component, Endpoint},
     protocols::EndpointId,
     traits::DistributedRuntimeProvider,
     transports::event_plane::{Codec, EventSubscriber, TypedEventSubscriber, uses_direct_zmq},
 };
 use parking_lot::Mutex;
-use tokio::{sync::mpsc, task::JoinHandle};
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use super::KV_METRICS_SUBJECT;
@@ -41,7 +40,6 @@ enum KvMetricsSubscriberInner {
 struct DirectKvMetricsSubscriber {
     receiver: ActiveLoadReceiver,
     cancellation_token: CancellationToken,
-    _supervisor: JoinHandle<()>,
 }
 
 struct PendingActiveLoads {
@@ -185,28 +183,18 @@ impl Drop for DirectKvMetricsSubscriber {
 
 impl KvMetricsSubscriber {
     pub(crate) async fn for_endpoint(endpoint: &Endpoint) -> Result<Self> {
-        Self::new(
-            endpoint.component(),
-            endpoint.drt(),
-            endpoint.id(),
-            Some(endpoint),
-        )
-        .await
+        Self::new(endpoint.component(), endpoint.id()).await
     }
 
     pub(crate) async fn for_endpoint_id(
         component: &Component,
         endpoint: &EndpointId,
     ) -> Result<Self> {
-        Self::new(component, component.drt(), endpoint.clone(), None).await
+        Self::new(component, endpoint.clone()).await
     }
 
-    async fn new(
-        component: &Component,
-        drt: &DistributedRuntime,
-        endpoint_id: EndpointId,
-        endpoint: Option<&Endpoint>,
-    ) -> Result<Self> {
+    async fn new(component: &Component, endpoint_id: EndpointId) -> Result<Self> {
+        let drt = component.drt();
         if uses_direct_zmq(drt.default_event_transport_kind()) {
             return Ok(Self {
                 inner: KvMetricsSubscriberInner::Direct(
@@ -215,10 +203,8 @@ impl KvMetricsSubscriber {
             });
         }
 
-        let subscriber = match endpoint {
-            Some(endpoint) => EventSubscriber::for_endpoint(endpoint, KV_METRICS_SUBJECT).await?,
-            None => EventSubscriber::for_endpoint_id(drt, &endpoint_id, KV_METRICS_SUBJECT).await?,
-        };
+        let subscriber =
+            EventSubscriber::for_endpoint_id(drt, &endpoint_id, KV_METRICS_SUBJECT).await?;
         Ok(Self {
             inner: KvMetricsSubscriberInner::Standard(subscriber.typed::<ActiveLoad>()),
         })
@@ -264,11 +250,11 @@ impl DirectKvMetricsSubscriber {
             |_| {},
         )
         .await?;
+        drop(supervisor);
 
         Ok(Self {
             receiver,
             cancellation_token,
-            _supervisor: supervisor,
         })
     }
 }
@@ -301,12 +287,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn direct_metrics_mailbox_uses_fixed_distinct_key_limit() {
-        let (sender, _receiver) = active_load_mailbox();
-        assert_eq!(sender.pending.lock().capacity, MAX_PENDING_ACTIVE_LOADS);
-    }
-
     #[tokio::test]
     async fn direct_metrics_mailbox_merges_partial_updates_in_key_order() {
         let (sender, mut receiver) = active_load_mailbox_with_capacity(4);
@@ -332,6 +312,12 @@ mod tests {
 
     #[tokio::test]
     async fn direct_metrics_mailbox_bounds_distinct_keys_and_drains_on_close() {
+        let (default_sender, _receiver) = active_load_mailbox();
+        assert_eq!(
+            default_sender.pending.lock().capacity,
+            MAX_PENDING_ACTIVE_LOADS
+        );
+
         let (sender, mut receiver) = active_load_mailbox_with_capacity(1);
 
         sender.send(load(1, 0, Some(7), None, None)).unwrap();

--- a/lib/llm/src/kv_router/metrics_subscriber.rs
+++ b/lib/llm/src/kv_router/metrics_subscriber.rs
@@ -3,8 +3,13 @@
 
 //! Transport-selecting subscription for worker KV load metrics.
 
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
+
 use anyhow::Result;
-use dynamo_kv_router::protocols::ActiveLoad;
+use dynamo_kv_router::protocols::{ActiveLoad, WorkerWithDpRank};
 use dynamo_runtime::{
     DistributedRuntime,
     component::{Component, Endpoint},
@@ -13,6 +18,7 @@ use dynamo_runtime::{
     traits::DistributedRuntimeProvider,
     transports::event_plane::{Codec, EventSubscriber, TypedEventSubscriber, uses_direct_zmq},
 };
+use parking_lot::Mutex;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 
@@ -23,6 +29,7 @@ use crate::{
 };
 
 const DEFAULT_OUTPUT_CAPACITY: usize = 100_000;
+const CAPACITY_DROP_LEVEL: tracing::Level = tracing::Level::TRACE;
 
 fn output_capacity() -> usize {
     std::env::var(DYN_ZMQ_EVENT_SUBSCRIBER_CHANNEL_CAPACITY)
@@ -42,9 +49,132 @@ enum KvMetricsSubscriberInner {
 }
 
 struct DirectKvMetricsSubscriber {
-    receiver: mpsc::Receiver<ActiveLoad>,
+    receiver: ActiveLoadReceiver,
     cancellation_token: CancellationToken,
     _supervisor: JoinHandle<()>,
+}
+
+struct PendingActiveLoads {
+    capacity: usize,
+    order: VecDeque<WorkerWithDpRank>,
+    values: HashMap<WorkerWithDpRank, ActiveLoad>,
+}
+
+impl PendingActiveLoads {
+    fn new(capacity: usize) -> Self {
+        assert!(
+            capacity > 0,
+            "active-load mailbox capacity must be positive"
+        );
+        Self {
+            capacity,
+            order: VecDeque::new(),
+            values: HashMap::new(),
+        }
+    }
+
+    fn push(&mut self, load: ActiveLoad) -> PushOutcome {
+        let worker = WorkerWithDpRank::new(load.worker_id, load.dp_rank);
+        if let Some(pending) = self.values.get_mut(&worker) {
+            if load.active_decode_blocks.is_some() {
+                pending.active_decode_blocks = load.active_decode_blocks;
+            }
+            if load.active_prefill_tokens.is_some() {
+                pending.active_prefill_tokens = load.active_prefill_tokens;
+            }
+            if load.kv_used_blocks.is_some() {
+                pending.kv_used_blocks = load.kv_used_blocks;
+            }
+            return PushOutcome::Accepted { should_wake: false };
+        }
+        if self.values.len() >= self.capacity {
+            return PushOutcome::Full;
+        }
+
+        let should_wake = self.values.is_empty();
+        self.order.push_back(worker);
+        self.values.insert(worker, load);
+        PushOutcome::Accepted { should_wake }
+    }
+
+    fn pop(&mut self) -> Option<ActiveLoad> {
+        let worker = self.order.pop_front()?;
+        Some(
+            self.values
+                .remove(&worker)
+                .expect("active-load order and values must stay synchronized"),
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PushOutcome {
+    Accepted { should_wake: bool },
+    Full,
+}
+
+#[derive(Clone)]
+struct ActiveLoadSender {
+    wake_tx: mpsc::Sender<()>,
+    pending: Arc<Mutex<PendingActiveLoads>>,
+}
+
+impl ActiveLoadSender {
+    fn send(&self, load: ActiveLoad) -> Result<()> {
+        if self.wake_tx.is_closed() {
+            anyhow::bail!("direct-ZMQ KV metrics consumer closed");
+        }
+
+        let worker_id = load.worker_id;
+        let dp_rank = load.dp_rank;
+        let outcome = self.pending.lock().push(load);
+        match outcome {
+            PushOutcome::Accepted { should_wake: false } => Ok(()),
+            PushOutcome::Full => {
+                tracing::event!(
+                    CAPACITY_DROP_LEVEL,
+                    worker_id,
+                    dp_rank,
+                    "Direct-ZMQ KV metrics consumer is full; dropping newest update"
+                );
+                Ok(())
+            }
+            PushOutcome::Accepted { should_wake: true } => match self.wake_tx.try_send(()) {
+                Ok(()) | Err(mpsc::error::TrySendError::Full(())) => Ok(()),
+                Err(mpsc::error::TrySendError::Closed(())) => {
+                    anyhow::bail!("direct-ZMQ KV metrics consumer closed")
+                }
+            },
+        }
+    }
+}
+
+struct ActiveLoadReceiver {
+    wake_rx: mpsc::Receiver<()>,
+    pending: Arc<Mutex<PendingActiveLoads>>,
+}
+
+impl ActiveLoadReceiver {
+    async fn recv(&mut self) -> Option<ActiveLoad> {
+        loop {
+            if let Some(load) = self.pending.lock().pop() {
+                return Some(load);
+            }
+            self.wake_rx.recv().await?;
+        }
+    }
+}
+
+fn active_load_mailbox(capacity: usize) -> (ActiveLoadSender, ActiveLoadReceiver) {
+    let (wake_tx, wake_rx) = mpsc::channel(1);
+    let pending = Arc::new(Mutex::new(PendingActiveLoads::new(capacity)));
+    (
+        ActiveLoadSender {
+            wake_tx,
+            pending: pending.clone(),
+        },
+        ActiveLoadReceiver { wake_rx, pending },
+    )
 }
 
 impl Drop for DirectKvMetricsSubscriber {
@@ -110,26 +240,17 @@ impl KvMetricsSubscriber {
 impl DirectKvMetricsSubscriber {
     async fn start(component: &Component, endpoint_id: EndpointId) -> Result<Self> {
         let cancellation_token = component.drt().primary_token().child_token();
-        let (sender, receiver) = mpsc::channel(output_capacity());
+        let (sender, receiver) = active_load_mailbox(output_capacity());
         let handler_cancel = cancellation_token.clone();
         let codec = Codec::default();
         let handler =
             move |envelope: dynamo_runtime::transports::event_plane::ValidatedEnvelope| {
                 let load = codec.decode_payload::<ActiveLoad>(&envelope.payload)?;
-                match sender.try_send(load) {
-                    Ok(()) => Ok(()),
-                    Err(mpsc::error::TrySendError::Full(_)) => {
-                        tracing::warn!(
-                            publisher_id = envelope.publisher_id,
-                            "Direct-ZMQ KV metrics consumer is full; dropping newest update"
-                        );
-                        Ok(())
-                    }
-                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                        handler_cancel.cancel();
-                        anyhow::bail!("direct-ZMQ KV metrics consumer closed")
-                    }
+                if let Err(error) = sender.send(load) {
+                    handler_cancel.cancel();
+                    return Err(error);
                 }
+                Ok(())
             };
         let supervisor = start_direct_zmq_fan_in_for_endpoint_id(
             component.clone(),
@@ -163,6 +284,87 @@ mod tests {
 
     use super::*;
     use crate::direct_zmq_sub_pool::ENDPOINTS_PER_SUB_ENV;
+
+    fn load(
+        worker_id: u64,
+        dp_rank: u32,
+        active_decode_blocks: Option<u64>,
+        active_prefill_tokens: Option<u64>,
+        kv_used_blocks: Option<u64>,
+    ) -> ActiveLoad {
+        ActiveLoad {
+            worker_id,
+            dp_rank,
+            active_decode_blocks,
+            active_prefill_tokens,
+            kv_used_blocks,
+        }
+    }
+
+    #[tokio::test]
+    async fn direct_metrics_mailbox_merges_partial_updates_in_key_order() {
+        let (sender, mut receiver) = active_load_mailbox(4);
+
+        sender.send(load(1, 0, Some(7), None, None)).unwrap();
+        sender.send(load(2, 0, None, None, Some(9))).unwrap();
+        sender.send(load(1, 0, None, Some(11), None)).unwrap();
+        sender.send(load(1, 0, Some(0), None, Some(5))).unwrap();
+        sender.send(load(1, 1, None, None, Some(13))).unwrap();
+
+        assert_eq!(
+            receiver.recv().await,
+            Some(load(1, 0, Some(0), Some(11), Some(5)))
+        );
+        sender.send(load(1, 0, None, None, Some(6))).unwrap();
+        assert_eq!(receiver.recv().await, Some(load(2, 0, None, None, Some(9))));
+        assert_eq!(
+            receiver.recv().await,
+            Some(load(1, 1, None, None, Some(13)))
+        );
+        assert_eq!(receiver.recv().await, Some(load(1, 0, None, None, Some(6))));
+    }
+
+    #[tokio::test]
+    async fn direct_metrics_mailbox_bounds_distinct_keys_and_drains_on_close() {
+        let (sender, mut receiver) = active_load_mailbox(1);
+
+        sender.send(load(1, 0, Some(7), None, None)).unwrap();
+        sender.send(load(1, 0, None, None, Some(8))).unwrap();
+        sender.send(load(2, 0, None, None, Some(9))).unwrap();
+
+        assert_eq!(
+            receiver.recv().await,
+            Some(load(1, 0, Some(7), None, Some(8)))
+        );
+        sender.send(load(2, 0, None, None, Some(10))).unwrap();
+        drop(sender);
+        assert_eq!(
+            receiver.recv().await,
+            Some(load(2, 0, None, None, Some(10)))
+        );
+        assert_eq!(receiver.recv().await, None);
+        assert_eq!(CAPACITY_DROP_LEVEL, tracing::Level::TRACE);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn direct_metrics_mailbox_wakes_a_waiter_and_reports_receiver_close() {
+        let (sender, mut receiver) = active_load_mailbox(1);
+        let waiter = tokio::spawn(async move {
+            let load = receiver.recv().await;
+            (load, receiver)
+        });
+        tokio::task::yield_now().await;
+
+        sender.send(load(1, 0, None, None, Some(3))).unwrap();
+        let (received, receiver) = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("waiting receiver must wake")
+            .unwrap();
+        assert_eq!(received, Some(load(1, 0, None, None, Some(3))));
+
+        drop(receiver);
+        assert!(sender.send(load(1, 0, None, None, Some(4))).is_err());
+    }
 
     #[tokio::test]
     #[serial_test::serial]

--- a/lib/llm/src/kv_router/metrics_subscriber.rs
+++ b/lib/llm/src/kv_router/metrics_subscriber.rs
@@ -3,37 +3,25 @@
 
 //! Transport-selecting subscription for worker KV load metrics.
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
-
 use anyhow::Result;
 use dynamo_kv_router::protocols::ActiveLoad;
 use dynamo_runtime::{
     DistributedRuntime,
     component::{Component, Endpoint},
     config::environment_names::event_plane::DYN_ZMQ_EVENT_SUBSCRIBER_CHANNEL_CAPACITY,
-    discovery::{
-        DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, EventChannelInstanceId,
-        EventChannelQuery, EventScope, EventTransport,
-    },
     protocols::EndpointId,
     traits::DistributedRuntimeProvider,
     transports::event_plane::{Codec, EventSubscriber, TypedEventSubscriber, uses_direct_zmq},
 };
-use futures::StreamExt;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 
-use super::{
-    KV_METRICS_SUBJECT,
-    metrics::{KvZmqIngressMetrics, KvZmqIngressStream},
-};
-use crate::direct_zmq_sub_pool::{
-    DirectZmqSubPool, DirectZmqSubPoolEvent, endpoints_per_sub_from_env,
+use super::KV_METRICS_SUBJECT;
+use crate::{
+    direct_zmq_fan_in::{ContinuityMode, start_direct_zmq_fan_in_for_endpoint_id},
+    direct_zmq_sub_pool::KV_ZMQ_RCVHWM,
 };
 
-const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
-const MAX_BACKOFF: Duration = Duration::from_secs(5);
-const SOURCE_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_OUTPUT_CAPACITY: usize = 100_000;
 
 fn output_capacity() -> usize {
@@ -120,40 +108,41 @@ impl KvMetricsSubscriber {
 }
 
 impl DirectKvMetricsSubscriber {
-    async fn start(component: &Component, endpoint: EndpointId) -> Result<Self> {
-        let endpoints_per_sub = endpoints_per_sub_from_env()?;
+    async fn start(component: &Component, endpoint_id: EndpointId) -> Result<Self> {
         let cancellation_token = component.drt().primary_token().child_token();
-        let query = dynamo_runtime::discovery::DiscoveryQuery::EventChannels(
-            EventChannelQuery::endpoint_topic(endpoint.clone(), KV_METRICS_SUBJECT),
-        );
-        let watch_cancel = cancellation_token.child_token();
-        let watch = component
-            .drt()
-            .discovery()
-            .list_and_watch(query, Some(watch_cancel.clone()))
-            .await?;
-        let metrics = KvZmqIngressMetrics::from_component(component);
-        let pool_metrics = metrics.clone();
-        let pool_observer = Arc::new(move |event: DirectZmqSubPoolEvent| {
-            pool_metrics.observe_pool(KvZmqIngressStream::Metrics, event);
-        });
-        let pool = DirectZmqSubPool::new(
-            KV_METRICS_SUBJECT,
-            endpoints_per_sub,
-            pool_observer,
-            cancellation_token.child_token(),
-        )?;
         let (sender, receiver) = mpsc::channel(output_capacity());
-        let supervisor_cancel = cancellation_token.clone();
-        let supervisor = tokio::spawn(run_metrics_supervisor(
-            endpoint,
-            watch,
-            watch_cancel,
-            pool,
-            sender,
-            metrics,
-            supervisor_cancel,
-        ));
+        let handler_cancel = cancellation_token.clone();
+        let codec = Codec::default();
+        let handler =
+            move |envelope: dynamo_runtime::transports::event_plane::ValidatedEnvelope| {
+                let load = codec.decode_payload::<ActiveLoad>(&envelope.payload)?;
+                match sender.try_send(load) {
+                    Ok(()) => Ok(()),
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        tracing::warn!(
+                            publisher_id = envelope.publisher_id,
+                            "Direct-ZMQ KV metrics consumer is full; dropping newest update"
+                        );
+                        Ok(())
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                        handler_cancel.cancel();
+                        anyhow::bail!("direct-ZMQ KV metrics consumer closed")
+                    }
+                }
+            };
+        let supervisor = start_direct_zmq_fan_in_for_endpoint_id(
+            component.clone(),
+            endpoint_id,
+            KV_METRICS_SUBJECT,
+            KV_ZMQ_RCVHWM,
+            None,
+            ContinuityMode::Disabled,
+            cancellation_token.clone(),
+            handler,
+            |_| {},
+        )
+        .await?;
 
         Ok(Self {
             receiver,
@@ -163,253 +152,9 @@ impl DirectKvMetricsSubscriber {
     }
 }
 
-struct MetricsSourceTask {
-    endpoint: String,
-    generation: u64,
-    cancel: CancellationToken,
-    handle: JoinHandle<()>,
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn run_metrics_supervisor(
-    endpoint: EndpointId,
-    mut discovery_stream: dynamo_runtime::discovery::DiscoveryStream,
-    watch_cancel: CancellationToken,
-    pool: DirectZmqSubPool,
-    output: mpsc::Sender<ActiveLoad>,
-    metrics: Arc<KvZmqIngressMetrics>,
-    cancellation_token: CancellationToken,
-) {
-    let expected_scope = EventScope::Endpoint { endpoint };
-    let mut sources = HashMap::<u64, MetricsSourceTask>::new();
-    let mut next_generation = 1_u64;
-
-    loop {
-        let event = tokio::select! {
-            biased;
-            _ = cancellation_token.cancelled() => break,
-            event = discovery_stream.next() => event,
-        };
-        let Some(event) = event else {
-            tracing::warn!(
-                topic = KV_METRICS_SUBJECT,
-                "Direct-ZMQ KV metrics discovery stream ended"
-            );
-            break;
-        };
-
-        match event {
-            Ok(DiscoveryEvent::Added(DiscoveryInstance::EventChannel {
-                scope,
-                topic,
-                instance_id,
-                transport,
-            })) if scope == expected_scope && topic == KV_METRICS_SUBJECT => {
-                let EventTransport::Zmq { endpoint } = transport else {
-                    tracing::warn!(
-                        publisher_id = instance_id,
-                        "Ignoring non-ZMQ KV metrics publisher in direct mode"
-                    );
-                    continue;
-                };
-                if sources
-                    .get(&instance_id)
-                    .is_some_and(|source| source.endpoint == endpoint)
-                {
-                    continue;
-                }
-                if let Some(source) = sources.remove(&instance_id) {
-                    stop_metrics_source(source, &metrics).await;
-                    metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "replacement");
-                }
-                let generation = next_generation;
-                next_generation = next_generation.wrapping_add(1);
-                sources.insert(
-                    instance_id,
-                    spawn_metrics_source(
-                        instance_id,
-                        endpoint,
-                        generation,
-                        pool.clone(),
-                        output.clone(),
-                        metrics.clone(),
-                        cancellation_token.child_token(),
-                    ),
-                );
-                metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "started");
-            }
-            Ok(DiscoveryEvent::Removed(DiscoveryInstanceId::EventChannel(
-                EventChannelInstanceId {
-                    scope,
-                    topic,
-                    instance_id,
-                },
-            ))) if scope == expected_scope && topic == KV_METRICS_SUBJECT => {
-                if let Some(source) = sources.remove(&instance_id) {
-                    stop_metrics_source(source, &metrics).await;
-                    metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "removed");
-                }
-            }
-            Ok(DiscoveryEvent::Added(_))
-            | Ok(DiscoveryEvent::ModelTaintsUpdated(_))
-            | Ok(DiscoveryEvent::Removed(_)) => {}
-            Err(error) => {
-                tracing::warn!(%error, topic = KV_METRICS_SUBJECT, "Direct-ZMQ KV metrics discovery failed");
-                break;
-            }
-        }
-    }
-
-    watch_cancel.cancel();
-    let sources = sources.into_values().collect::<Vec<_>>();
-    for source in &sources {
-        source.cancel.cancel();
-    }
-    pool.shutdown().await;
-    futures::future::join_all(
-        sources
-            .into_iter()
-            .map(|source| stop_metrics_source(source, &metrics)),
-    )
-    .await;
-}
-
-fn spawn_metrics_source(
-    publisher_id: u64,
-    endpoint: String,
-    generation: u64,
-    pool: DirectZmqSubPool,
-    output: mpsc::Sender<ActiveLoad>,
-    metrics: Arc<KvZmqIngressMetrics>,
-    cancel: CancellationToken,
-) -> MetricsSourceTask {
-    let task_endpoint = endpoint.clone();
-    let task_cancel = cancel.clone();
-    let handle = tokio::spawn(async move {
-        run_metrics_source(
-            publisher_id,
-            task_endpoint,
-            generation,
-            pool,
-            output,
-            metrics,
-            task_cancel,
-        )
-        .await;
-    });
-    MetricsSourceTask {
-        endpoint,
-        generation,
-        cancel,
-        handle,
-    }
-}
-
-async fn run_metrics_source(
-    publisher_id: u64,
-    endpoint: String,
-    generation: u64,
-    pool: DirectZmqSubPool,
-    output: mpsc::Sender<ActiveLoad>,
-    metrics: Arc<KvZmqIngressMetrics>,
-    cancel: CancellationToken,
-) {
-    let codec = Codec::default();
-    let mut retry_delay = INITIAL_BACKOFF;
-    loop {
-        if cancel.is_cancelled() {
-            return;
-        }
-        let registration = pool.register(publisher_id, &endpoint, generation).await;
-        let mut registration = match registration {
-            Ok(registration) => registration,
-            Err(error) => {
-                tracing::warn!(%error, publisher_id, %endpoint, "Failed to register direct-ZMQ KV metrics source");
-                metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "reconnect");
-                if !sleep_or_cancel(retry_delay, &cancel).await {
-                    return;
-                }
-                retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
-                continue;
-            }
-        };
-        if cancel.is_cancelled() {
-            pool.unregister(registration.group_id, publisher_id, generation)
-                .await;
-            return;
-        }
-        retry_delay = INITIAL_BACKOFF;
-
-        let disconnected = loop {
-            let envelope = tokio::select! {
-                biased;
-                _ = cancel.cancelled() => break false,
-                _ = registration.disconnected.cancelled() => break true,
-                envelope = registration.receiver.recv() => envelope,
-            };
-            let Some(envelope) = envelope else {
-                break true;
-            };
-            let load = match codec.decode_payload::<ActiveLoad>(&envelope.payload) {
-                Ok(load) => load,
-                Err(error) => {
-                    tracing::warn!(%error, publisher_id, "Failed to decode direct-ZMQ KV metrics payload");
-                    metrics.increment_stream_lifecycle(
-                        KvZmqIngressStream::Metrics,
-                        "payload_decode_error",
-                    );
-                    continue;
-                }
-            };
-            match output.try_send(load) {
-                Ok(()) => metrics.increment_batch(KvZmqIngressStream::Metrics),
-                Err(mpsc::error::TrySendError::Full(_)) => {
-                    metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "consumer_full")
-                }
-                Err(mpsc::error::TrySendError::Closed(_)) => break false,
-            }
-        };
-
-        pool.unregister(registration.group_id, publisher_id, generation)
-            .await;
-        if !disconnected || output.is_closed() {
-            return;
-        }
-        metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "reconnect");
-        if !sleep_or_cancel(retry_delay, &cancel).await {
-            return;
-        }
-        retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
-    }
-}
-
-async fn stop_metrics_source(mut source: MetricsSourceTask, metrics: &KvZmqIngressMetrics) {
-    source.cancel.cancel();
-    match tokio::time::timeout(SOURCE_JOIN_TIMEOUT, &mut source.handle).await {
-        Ok(Ok(())) => {}
-        Ok(Err(error)) if error.is_cancelled() => {}
-        Ok(Err(error)) => {
-            tracing::warn!(%error, generation = source.generation, "Direct-ZMQ KV metrics source failed during shutdown")
-        }
-        Err(_) => {
-            source.handle.abort();
-            let _ = source.handle.await;
-            metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "forced_abort");
-        }
-    }
-    metrics.increment_stream_lifecycle(KvZmqIngressStream::Metrics, "stopped");
-}
-
-async fn sleep_or_cancel(delay: Duration, cancellation_token: &CancellationToken) -> bool {
-    tokio::select! {
-        _ = cancellation_token.cancelled() => false,
-        _ = tokio::time::sleep(delay) => true,
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::{collections::HashSet, time::Duration};
 
     use dynamo_runtime::{
         DistributedRuntime, Runtime, discovery::EventTransportKind, distributed::DistributedConfig,

--- a/lib/llm/src/kv_router/metrics_subscriber.rs
+++ b/lib/llm/src/kv_router/metrics_subscriber.rs
@@ -22,7 +22,9 @@ use tokio_util::sync::CancellationToken;
 
 use super::KV_METRICS_SUBJECT;
 use crate::{
-    direct_zmq_fan_in::{ContinuityMode, start_direct_zmq_fan_in_for_endpoint_id},
+    direct_zmq_fan_in::{
+        ContinuityMode, FanInEvent, FanInObservation, start_direct_zmq_fan_in_for_endpoint_id,
+    },
     direct_zmq_sub_pool::KV_ZMQ_RCVHWM,
 };
 
@@ -46,6 +48,31 @@ struct PendingActiveLoads {
     capacity: usize,
     order: VecDeque<WorkerWithDpRank>,
     values: HashMap<WorkerWithDpRank, ActiveLoad>,
+    fault: Option<DirectKvMetricsFault>,
+}
+
+#[derive(Clone, Copy, Debug, thiserror::Error, PartialEq, Eq)]
+enum DirectKvMetricsFault {
+    #[error("direct-ZMQ KV metrics payload decode failed")]
+    PayloadDecode,
+    #[error("direct-ZMQ KV metrics envelope decode failed")]
+    EnvelopeDecode,
+    #[error("direct-ZMQ KV metrics publisher identity mismatch")]
+    IdentityMismatch,
+    #[error("direct-ZMQ KV metrics transport disconnected")]
+    Disconnected,
+    #[error("direct-ZMQ KV metrics discovery watch reset")]
+    DiscoveryReset,
+}
+
+fn fault_for_event(event: FanInEvent) -> Option<DirectKvMetricsFault> {
+    match event {
+        FanInEvent::EnvelopeDecodeError => Some(DirectKvMetricsFault::EnvelopeDecode),
+        FanInEvent::IdentityMismatch => Some(DirectKvMetricsFault::IdentityMismatch),
+        FanInEvent::Disconnected => Some(DirectKvMetricsFault::Disconnected),
+        FanInEvent::DiscoveryReset => Some(DirectKvMetricsFault::DiscoveryReset),
+        _ => None,
+    }
 }
 
 impl PendingActiveLoads {
@@ -58,6 +85,7 @@ impl PendingActiveLoads {
             capacity,
             order: VecDeque::new(),
             values: HashMap::new(),
+            fault: None,
         }
     }
 
@@ -86,19 +114,26 @@ impl PendingActiveLoads {
             return PushOutcome::Full;
         }
 
-        let should_wake = self.values.is_empty();
+        let should_wake = self.values.is_empty() && self.fault.is_none();
         self.order.push_back(worker);
         self.values.insert(worker, load);
         PushOutcome::Accepted { should_wake }
     }
 
-    fn pop(&mut self) -> Option<ActiveLoad> {
+    fn push_fault(&mut self, fault: DirectKvMetricsFault) {
+        self.order.clear();
+        self.values.clear();
+        self.fault = Some(fault);
+    }
+
+    fn pop(&mut self) -> Option<Result<ActiveLoad>> {
+        if let Some(fault) = self.fault.take() {
+            return Some(Err(fault.into()));
+        }
         let worker = self.order.pop_front()?;
-        Some(
-            self.values
-                .remove(&worker)
-                .expect("active-load order and values must stay synchronized"),
-        )
+        Some(Ok(self.values.remove(&worker).expect(
+            "active-load order and values must stay synchronized",
+        )))
     }
 }
 
@@ -141,6 +176,19 @@ impl ActiveLoadSender {
             },
         }
     }
+
+    fn send_fault(&self, fault: DirectKvMetricsFault) -> Result<()> {
+        if self.wake_tx.is_closed() {
+            anyhow::bail!("direct-ZMQ KV metrics consumer closed");
+        }
+        self.pending.lock().push_fault(fault);
+        match self.wake_tx.try_send(()) {
+            Ok(()) | Err(mpsc::error::TrySendError::Full(())) => Ok(()),
+            Err(mpsc::error::TrySendError::Closed(())) => {
+                anyhow::bail!("direct-ZMQ KV metrics consumer closed")
+            }
+        }
+    }
 }
 
 struct ActiveLoadReceiver {
@@ -149,7 +197,7 @@ struct ActiveLoadReceiver {
 }
 
 impl ActiveLoadReceiver {
-    async fn recv(&mut self) -> Option<ActiveLoad> {
+    async fn recv(&mut self) -> Option<Result<ActiveLoad>> {
         loop {
             if let Some(load) = self.pending.lock().pop() {
                 return Some(load);
@@ -216,9 +264,7 @@ impl KvMetricsSubscriber {
                 .next()
                 .await
                 .map(|result| result.map(|(_envelope, load)| load)),
-            KvMetricsSubscriberInner::Direct(subscriber) => {
-                subscriber.receiver.recv().await.map(Ok)
-            }
+            KvMetricsSubscriberInner::Direct(subscriber) => subscriber.receiver.recv().await,
         }
     }
 }
@@ -229,15 +275,27 @@ impl DirectKvMetricsSubscriber {
         let (sender, receiver) = active_load_mailbox();
         let handler_cancel = cancellation_token.clone();
         let codec = Codec::default();
+        let handler_sender = sender.clone();
         let handler =
             move |envelope: dynamo_runtime::transports::event_plane::ValidatedEnvelope| {
-                let load = codec.decode_payload::<ActiveLoad>(&envelope.payload)?;
-                if let Err(error) = sender.send(load) {
+                let load = match codec.decode_payload::<ActiveLoad>(&envelope.payload) {
+                    Ok(load) => load,
+                    Err(error) => {
+                        let _ = handler_sender.send_fault(DirectKvMetricsFault::PayloadDecode);
+                        return Err(error);
+                    }
+                };
+                if let Err(error) = handler_sender.send(load) {
                     handler_cancel.cancel();
                     return Err(error);
                 }
                 Ok(())
             };
+        let observer = move |observation: FanInObservation| {
+            if let Some(fault) = fault_for_event(observation.event) {
+                let _ = sender.send_fault(fault);
+            }
+        };
         let supervisor = start_direct_zmq_fan_in_for_endpoint_id(
             component.clone(),
             endpoint_id,
@@ -247,7 +305,7 @@ impl DirectKvMetricsSubscriber {
             ContinuityMode::Disabled,
             cancellation_token.clone(),
             handler,
-            |_| {},
+            observer,
         )
         .await?;
         drop(supervisor);
@@ -298,16 +356,22 @@ mod tests {
         sender.send(load(1, 1, None, None, Some(13))).unwrap();
 
         assert_eq!(
-            receiver.recv().await,
-            Some(load(1, 0, Some(0), Some(11), Some(5)))
+            receiver.recv().await.unwrap().unwrap(),
+            load(1, 0, Some(0), Some(11), Some(5))
         );
         sender.send(load(1, 0, None, None, Some(6))).unwrap();
-        assert_eq!(receiver.recv().await, Some(load(2, 0, None, None, Some(9))));
         assert_eq!(
-            receiver.recv().await,
-            Some(load(1, 1, None, None, Some(13)))
+            receiver.recv().await.unwrap().unwrap(),
+            load(2, 0, None, None, Some(9))
         );
-        assert_eq!(receiver.recv().await, Some(load(1, 0, None, None, Some(6))));
+        assert_eq!(
+            receiver.recv().await.unwrap().unwrap(),
+            load(1, 1, None, None, Some(13))
+        );
+        assert_eq!(
+            receiver.recv().await.unwrap().unwrap(),
+            load(1, 0, None, None, Some(6))
+        );
     }
 
     #[tokio::test]
@@ -325,16 +389,16 @@ mod tests {
         sender.send(load(2, 0, None, None, Some(9))).unwrap();
 
         assert_eq!(
-            receiver.recv().await,
-            Some(load(1, 0, Some(7), None, Some(8)))
+            receiver.recv().await.unwrap().unwrap(),
+            load(1, 0, Some(7), None, Some(8))
         );
         sender.send(load(2, 0, None, None, Some(10))).unwrap();
         drop(sender);
         assert_eq!(
-            receiver.recv().await,
-            Some(load(2, 0, None, None, Some(10)))
+            receiver.recv().await.unwrap().unwrap(),
+            load(2, 0, None, None, Some(10))
         );
-        assert_eq!(receiver.recv().await, None);
+        assert!(receiver.recv().await.is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -351,10 +415,42 @@ mod tests {
             .await
             .expect("waiting receiver must wake")
             .unwrap();
-        assert_eq!(received, Some(load(1, 0, None, None, Some(3))));
+        assert_eq!(received.unwrap().unwrap(), load(1, 0, None, None, Some(3)));
 
         drop(receiver);
         assert!(sender.send(load(1, 0, None, None, Some(4))).is_err());
+    }
+
+    #[tokio::test]
+    async fn direct_metrics_fault_discards_stale_loads_before_later_updates() {
+        let (sender, mut receiver) = active_load_mailbox_with_capacity(4);
+
+        sender.send(load(1, 0, None, None, Some(3))).unwrap();
+        sender
+            .send_fault(DirectKvMetricsFault::Disconnected)
+            .unwrap();
+        sender.send(load(2, 0, None, None, Some(4))).unwrap();
+
+        let error = receiver.recv().await.unwrap().unwrap_err();
+        assert!(error.to_string().contains("transport disconnected"));
+        assert_eq!(
+            receiver.recv().await.unwrap().unwrap(),
+            load(2, 0, None, None, Some(4))
+        );
+
+        assert_eq!(
+            fault_for_event(FanInEvent::EnvelopeDecodeError),
+            Some(DirectKvMetricsFault::EnvelopeDecode)
+        );
+        assert_eq!(
+            fault_for_event(FanInEvent::IdentityMismatch),
+            Some(DirectKvMetricsFault::IdentityMismatch)
+        );
+        assert_eq!(
+            fault_for_event(FanInEvent::DiscoveryReset),
+            Some(DirectKvMetricsFault::DiscoveryReset)
+        );
+        assert_eq!(fault_for_event(FanInEvent::SourceStarted), None);
     }
 
     #[tokio::test]

--- a/lib/llm/src/kv_router/sequence/direct_zmq.rs
+++ b/lib/llm/src/kv_router/sequence/direct_zmq.rs
@@ -118,6 +118,7 @@ pub(super) async fn start<P: SequencePublisher + 'static>(
         move |observation: crate::direct_zmq_fan_in::FanInObservation| match observation.event {
             FanInEvent::SourceStarted => metrics.source_started(),
             FanInEvent::SourceStopped => metrics.source_stopped(),
+            FanInEvent::Disconnected | FanInEvent::DiscoveryReset => {}
             FanInEvent::Reconnect => metrics.record_reconnect(),
             FanInEvent::Replacement => metrics.record_replacement(),
             FanInEvent::EnvelopeDecodeError => metrics.record_envelope_decode_error(),

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod backend;
 pub mod common;
 mod direct_zmq_fan_in;
+mod direct_zmq_sub_pool;
 pub mod discovery;
 pub mod endpoint_type;
 pub mod engines;

--- a/lib/runtime/src/transports/event_plane/mod.rs
+++ b/lib/runtime/src/transports/event_plane/mod.rs
@@ -17,8 +17,8 @@ pub use frame::{FRAME_HEADER_SIZE, FRAME_VERSION, Frame, FrameError, FrameHeader
 pub use traits::{EventEnvelope, EventStream, TypedEventStream};
 pub use transport::{EventTransportRx, EventTransportTx, WireStream};
 pub use zmq_transport::{
-    ValidatedEnvelope, ValidatedZmqSource, ValidatedZmqSourceError, ZmqPubTransport,
-    ZmqSubTransport,
+    DynamicZmqSubSocket, ValidatedEnvelope, ValidatedZmqSource, ValidatedZmqSourceError,
+    ZmqPubTransport, ZmqSubTransport, ZmqWireMessage,
 };
 
 // Re-export transport kind from discovery for convenience

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -19,7 +19,10 @@ use async_stream::stream;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
-use std::sync::{Arc, OnceLock};
+use std::{
+    collections::HashSet,
+    sync::{Arc, OnceLock},
+};
 use thiserror::Error;
 use tmq::{
     AsZmqSocket, Context, Message, Multipart, SocketBuilder,
@@ -284,6 +287,80 @@ pub struct ZmqWireMessage {
 
 pub type ZmqWireStream =
     std::pin::Pin<Box<dyn futures::Stream<Item = Result<ZmqWireMessage>> + Send>>;
+
+/// One dynamically managed ZMQ SUB socket connected to several publishers.
+///
+/// The caller must keep this value in one task. ZMQ SUB sockets are not thread-safe.
+pub struct DynamicZmqSubSocket {
+    socket: Subscribe,
+    expected_topic: Vec<u8>,
+    endpoints: HashSet<String>,
+}
+
+impl DynamicZmqSubSocket {
+    /// Connect a new SUB socket to its first publisher endpoint.
+    pub fn connect(endpoint: &str, topic: &str) -> Result<Self> {
+        Self::connect_with_rcvhwm(endpoint, topic, ZMQ_RCVHWM)
+    }
+
+    /// Connect a new SUB socket with an explicit receive high-water mark.
+    pub fn connect_with_rcvhwm(endpoint: &str, topic: &str, rcvhwm: i32) -> Result<Self> {
+        let socket = ZmqSubTransport::connect_socket_with_rcvhwm(endpoint, topic, rcvhwm)?;
+        tracing::info!(endpoint, topic, rcvhwm, "Dynamic ZMQ SUB socket connected");
+        Ok(Self {
+            socket,
+            expected_topic: topic.as_bytes().to_vec(),
+            endpoints: HashSet::from([endpoint.to_string()]),
+        })
+    }
+
+    /// Connect this SUB socket to one more publisher endpoint.
+    pub fn add_endpoint(&mut self, endpoint: &str) -> Result<()> {
+        if self.endpoints.contains(endpoint) {
+            return Ok(());
+        }
+        self.socket.get_socket().connect(endpoint)?;
+        self.endpoints.insert(endpoint.to_string());
+        Ok(())
+    }
+
+    /// Stop receiving from one publisher endpoint.
+    pub fn remove_endpoint(&mut self, endpoint: &str) -> Result<()> {
+        if !self.endpoints.contains(endpoint) {
+            return Ok(());
+        }
+        self.socket.get_socket().disconnect(endpoint)?;
+        self.endpoints.remove(endpoint);
+        Ok(())
+    }
+
+    /// Receive and decode the next multipart message.
+    pub async fn next(&mut self) -> Option<Result<ZmqWireMessage>> {
+        loop {
+            let frames = match self.socket.next().await? {
+                Ok(frames) => frames,
+                Err(error) => return Some(Err(error.into())),
+            };
+            match decode_multipart(frames, &self.expected_topic) {
+                Ok(message) => {
+                    return Some(Ok(ZmqWireMessage {
+                        publisher_id: message.publisher_id,
+                        sequence: message.sequence,
+                        payload: message.payload,
+                    }));
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "Dropping malformed dynamic ZMQ message");
+                }
+            }
+        }
+    }
+
+    /// Number of publisher endpoints connected to this SUB socket.
+    pub fn endpoint_count(&self) -> usize {
+        self.endpoints.len()
+    }
+}
 
 /// One event envelope whose ZMQ frames and envelope attribution agree.
 #[derive(Debug)]
@@ -957,6 +1034,71 @@ mod tests {
             codec.decode_envelope(&wire.payload).unwrap().payload,
             sentinel.payload
         );
+    }
+
+    #[tokio::test]
+    async fn dynamic_sub_socket_adds_and_removes_publishers() {
+        let process = std::process::id();
+        let endpoint_a = format!("inproc://dynamo-zmq-dynamic-a-{process}");
+        let endpoint_b = format!("inproc://dynamo-zmq-dynamic-b-{process}");
+        let topic = "dynamic-subscriber";
+        let (publisher_a, _) = ZmqPubTransport::bind(&endpoint_a, topic).await.unwrap();
+        let (publisher_b, _) = ZmqPubTransport::bind(&endpoint_b, topic).await.unwrap();
+        let mut subscriber = DynamicZmqSubSocket::connect(&endpoint_a, topic).unwrap();
+        subscriber.add_endpoint(&endpoint_b).unwrap();
+        assert_eq!(subscriber.endpoint_count(), 2);
+
+        let codec = MsgpackCodec;
+        let envelope_a = EventEnvelope {
+            publisher_id: 101,
+            sequence: 1,
+            published_at: 1,
+            topic: topic.to_string(),
+            payload: Bytes::from_static(b"a"),
+        };
+        let envelope_b = EventEnvelope {
+            publisher_id: 202,
+            sequence: 1,
+            published_at: 1,
+            topic: topic.to_string(),
+            payload: Bytes::from_static(b"b"),
+        };
+        let encoded_a = codec.encode_envelope(&envelope_a).unwrap();
+        let encoded_b = codec.encode_envelope(&envelope_b).unwrap();
+
+        let seen = timeout(Duration::from_secs(2), async {
+            let mut seen = HashSet::new();
+            while seen.len() < 2 {
+                publisher_a.publish(topic, encoded_a.clone()).await.unwrap();
+                publisher_b.publish(topic, encoded_b.clone()).await.unwrap();
+                if let Ok(Some(Ok(message))) =
+                    timeout(Duration::from_millis(25), subscriber.next()).await
+                {
+                    seen.insert(message.publisher_id);
+                }
+            }
+            seen
+        })
+        .await
+        .expect("dynamic SUB socket should receive from both publishers");
+        assert_eq!(seen, HashSet::from([101, 202]));
+
+        subscriber.remove_endpoint(&endpoint_a).unwrap();
+        assert_eq!(subscriber.endpoint_count(), 1);
+        let message = timeout(Duration::from_secs(2), async {
+            loop {
+                publisher_b.publish(topic, encoded_b.clone()).await.unwrap();
+                if let Ok(Some(Ok(message))) =
+                    timeout(Duration::from_millis(25), subscriber.next()).await
+                    && message.publisher_id == 202
+                {
+                    break message;
+                }
+            }
+        })
+        .await
+        .expect("remaining publisher should continue after endpoint removal");
+        assert_eq!(message.publisher_id, 202);
     }
 
     #[tokio::test]

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -19,10 +19,7 @@ use async_stream::stream;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
-use std::{
-    collections::HashSet,
-    sync::{Arc, OnceLock},
-};
+use std::sync::{Arc, OnceLock};
 use thiserror::Error;
 use tmq::{
     AsZmqSocket, Context, Message, Multipart, SocketBuilder,
@@ -294,15 +291,9 @@ pub type ZmqWireStream =
 pub struct DynamicZmqSubSocket {
     socket: Subscribe,
     expected_topic: Vec<u8>,
-    endpoints: HashSet<String>,
 }
 
 impl DynamicZmqSubSocket {
-    /// Connect a new SUB socket to its first publisher endpoint.
-    pub fn connect(endpoint: &str, topic: &str) -> Result<Self> {
-        Self::connect_with_rcvhwm(endpoint, topic, ZMQ_RCVHWM)
-    }
-
     /// Connect a new SUB socket with an explicit receive high-water mark.
     pub fn connect_with_rcvhwm(endpoint: &str, topic: &str, rcvhwm: i32) -> Result<Self> {
         let socket = ZmqSubTransport::connect_socket_with_rcvhwm(endpoint, topic, rcvhwm)?;
@@ -310,27 +301,18 @@ impl DynamicZmqSubSocket {
         Ok(Self {
             socket,
             expected_topic: topic.as_bytes().to_vec(),
-            endpoints: HashSet::from([endpoint.to_string()]),
         })
     }
 
     /// Connect this SUB socket to one more publisher endpoint.
     pub fn add_endpoint(&mut self, endpoint: &str) -> Result<()> {
-        if self.endpoints.contains(endpoint) {
-            return Ok(());
-        }
         self.socket.get_socket().connect(endpoint)?;
-        self.endpoints.insert(endpoint.to_string());
         Ok(())
     }
 
     /// Stop receiving from one publisher endpoint.
     pub fn remove_endpoint(&mut self, endpoint: &str) -> Result<()> {
-        if !self.endpoints.contains(endpoint) {
-            return Ok(());
-        }
         self.socket.get_socket().disconnect(endpoint)?;
-        self.endpoints.remove(endpoint);
         Ok(())
     }
 
@@ -342,23 +324,12 @@ impl DynamicZmqSubSocket {
                 Err(error) => return Some(Err(error.into())),
             };
             match decode_multipart(frames, &self.expected_topic) {
-                Ok(message) => {
-                    return Some(Ok(ZmqWireMessage {
-                        publisher_id: message.publisher_id,
-                        sequence: message.sequence,
-                        payload: message.payload,
-                    }));
-                }
+                Ok(message) => return Some(Ok(message)),
                 Err(error) => {
                     tracing::warn!(%error, "Dropping malformed dynamic ZMQ message");
                 }
             }
         }
-    }
-
-    /// Number of publisher endpoints connected to this SUB socket.
-    pub fn endpoint_count(&self) -> usize {
-        self.endpoints.len()
     }
 }
 
@@ -566,11 +537,7 @@ impl ZmqSubTransport {
                 };
 
                 match decode_multipart(frames, &expected_topic) {
-                    Ok(message) => yield Ok(ZmqWireMessage {
-                        publisher_id: message.publisher_id,
-                        sequence: message.sequence,
-                        payload: message.payload,
-                    }),
+                    Ok(message) => yield Ok(message),
                     Err(error) => {
                         tracing::warn!(%error, "Dropping malformed ZMQ message");
                     }
@@ -663,13 +630,7 @@ impl ZmqSubTransport {
     }
 }
 
-struct DecodedZmqMessage {
-    publisher_id: u64,
-    sequence: u64,
-    payload: Bytes,
-}
-
-fn decode_multipart(mut frames: Multipart, expected_topic: &[u8]) -> Result<DecodedZmqMessage> {
+fn decode_multipart(mut frames: Multipart, expected_topic: &[u8]) -> Result<ZmqWireMessage> {
     if frames.len() != 4 {
         anyhow::bail!("unexpected ZMQ multipart frame count: {}", frames.len());
     }
@@ -702,7 +663,7 @@ fn decode_multipart(mut frames: Multipart, expected_topic: &[u8]) -> Result<Deco
     let frame_bytes = Bytes::from_owner(ZmqMessageOwner(frame_message));
     let frame = Frame::decode(frame_bytes)?;
 
-    Ok(DecodedZmqMessage {
+    Ok(ZmqWireMessage {
         publisher_id,
         sequence,
         payload: frame.payload,
@@ -746,6 +707,7 @@ impl EventTransportRx for ZmqSubTransport {
 mod tests {
     use super::*;
     use crate::transports::event_plane::{EventEnvelope, MsgpackCodec};
+    use std::collections::HashSet;
     use tokio::time::{Duration, timeout};
 
     #[test]
@@ -801,6 +763,44 @@ mod tests {
             .send(Multipart::from(frames))
             .await
             .unwrap();
+    }
+
+    fn encoded_event(topic: &str, publisher_id: u64, sequence: u64) -> Bytes {
+        MsgpackCodec
+            .encode_envelope(&EventEnvelope {
+                publisher_id,
+                sequence,
+                published_at: sequence,
+                topic: topic.to_string(),
+                payload: Bytes::from_static(b"payload"),
+            })
+            .unwrap()
+    }
+
+    async fn receive_publishers(
+        subscriber: &mut DynamicZmqSubSocket,
+        topic: &str,
+        sequence: u64,
+        expected: usize,
+        publications: &[(&ZmqPubTransport, &Bytes)],
+    ) -> HashSet<u64> {
+        timeout(Duration::from_secs(2), async {
+            let mut seen = HashSet::new();
+            while seen.len() < expected {
+                for (publisher, payload) in publications {
+                    publisher.publish(topic, (*payload).clone()).await.unwrap();
+                }
+                if let Ok(Some(Ok(message))) =
+                    timeout(Duration::from_millis(25), subscriber.next()).await
+                    && message.sequence == sequence
+                {
+                    seen.insert(message.publisher_id);
+                }
+            }
+            seen
+        })
+        .await
+        .expect("dynamic subscriber should receive expected publishers")
     }
 
     #[test]
@@ -1044,101 +1044,54 @@ mod tests {
         let topic = "dynamic-subscriber";
         let (publisher_a, _) = ZmqPubTransport::bind(&endpoint_a, topic).await.unwrap();
         let (publisher_b, _) = ZmqPubTransport::bind(&endpoint_b, topic).await.unwrap();
-        let mut subscriber = DynamicZmqSubSocket::connect(&endpoint_a, topic).unwrap();
+        let mut subscriber =
+            DynamicZmqSubSocket::connect_with_rcvhwm(&endpoint_a, topic, ZMQ_RCVHWM).unwrap();
         subscriber.add_endpoint(&endpoint_b).unwrap();
-        assert_eq!(subscriber.endpoint_count(), 2);
 
-        let codec = MsgpackCodec;
-        let envelope_a = EventEnvelope {
-            publisher_id: 101,
-            sequence: 1,
-            published_at: 1,
-            topic: topic.to_string(),
-            payload: Bytes::from_static(b"a"),
-        };
-        let envelope_b = EventEnvelope {
-            publisher_id: 202,
-            sequence: 1,
-            published_at: 1,
-            topic: topic.to_string(),
-            payload: Bytes::from_static(b"b"),
-        };
-        let encoded_a = codec.encode_envelope(&envelope_a).unwrap();
-        let encoded_b = codec.encode_envelope(&envelope_b).unwrap();
-
-        let seen = timeout(Duration::from_secs(2), async {
-            let mut seen = HashSet::new();
-            while seen.len() < 2 {
-                publisher_a.publish(topic, encoded_a.clone()).await.unwrap();
-                publisher_b.publish(topic, encoded_b.clone()).await.unwrap();
-                if let Ok(Some(Ok(message))) =
-                    timeout(Duration::from_millis(25), subscriber.next()).await
-                {
-                    seen.insert(message.publisher_id);
-                }
-            }
-            seen
-        })
-        .await
-        .expect("dynamic SUB socket should receive from both publishers");
+        let encoded_a = encoded_event(topic, 101, 1);
+        let encoded_b = encoded_event(topic, 202, 1);
+        let seen = receive_publishers(
+            &mut subscriber,
+            topic,
+            1,
+            2,
+            &[(&publisher_a, &encoded_a), (&publisher_b, &encoded_b)],
+        )
+        .await;
         assert_eq!(seen, HashSet::from([101, 202]));
 
         subscriber.remove_endpoint(&endpoint_a).unwrap();
-        assert_eq!(subscriber.endpoint_count(), 1);
         tokio::time::sleep(Duration::from_millis(50)).await;
-        let envelope_a_after_removal = EventEnvelope {
-            sequence: 2,
-            ..envelope_a
-        };
-        let envelope_b_after_removal = EventEnvelope {
-            sequence: 2,
-            ..envelope_b
-        };
-        let encoded_a_after_removal = codec.encode_envelope(&envelope_a_after_removal).unwrap();
-        let encoded_b_after_removal = codec.encode_envelope(&envelope_b_after_removal).unwrap();
-        timeout(Duration::from_secs(2), async {
+        let encoded_a_after_removal = encoded_event(topic, 101, 2);
+        let encoded_b_after_removal = encoded_event(topic, 202, 2);
+        let publications = [
+            (&publisher_a, &encoded_a_after_removal),
+            (&publisher_b, &encoded_b_after_removal),
+        ];
+        assert_eq!(
+            receive_publishers(&mut subscriber, topic, 2, 1, &publications).await,
+            HashSet::from([202])
+        );
+
+        let removed_delivery = timeout(Duration::from_millis(250), async {
             loop {
                 publisher_a
                     .publish(topic, encoded_a_after_removal.clone())
                     .await
                     .unwrap();
-                publisher_b
-                    .publish(topic, encoded_b_after_removal.clone())
-                    .await
-                    .unwrap();
-                if let Ok(Some(Ok(message))) =
-                    timeout(Duration::from_millis(25), subscriber.next()).await
+                if let Some(Ok(message)) = subscriber.next().await
+                    && message.publisher_id == 101
                     && message.sequence == 2
                 {
-                    assert_ne!(
-                        message.publisher_id, 101,
-                        "removed publisher must not deliver new messages"
-                    );
-                    if message.publisher_id == 202 {
-                        break;
-                    }
+                    return;
                 }
             }
         })
-        .await
-        .expect("remaining publisher should continue after endpoint removal");
-
-        let deadline = tokio::time::Instant::now() + Duration::from_millis(250);
-        while tokio::time::Instant::now() < deadline {
-            publisher_a
-                .publish(topic, encoded_a_after_removal.clone())
-                .await
-                .unwrap();
-            if let Ok(Some(Ok(message))) =
-                timeout(Duration::from_millis(10), subscriber.next()).await
-                && message.sequence == 2
-            {
-                assert_ne!(
-                    message.publisher_id, 101,
-                    "removed publisher must remain disconnected"
-                );
-            }
-        }
+        .await;
+        assert!(
+            removed_delivery.is_err(),
+            "removed publisher delivered data"
+        );
     }
 
     #[tokio::test]

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -1085,20 +1085,60 @@ mod tests {
 
         subscriber.remove_endpoint(&endpoint_a).unwrap();
         assert_eq!(subscriber.endpoint_count(), 1);
-        let message = timeout(Duration::from_secs(2), async {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let envelope_a_after_removal = EventEnvelope {
+            sequence: 2,
+            ..envelope_a
+        };
+        let envelope_b_after_removal = EventEnvelope {
+            sequence: 2,
+            ..envelope_b
+        };
+        let encoded_a_after_removal = codec.encode_envelope(&envelope_a_after_removal).unwrap();
+        let encoded_b_after_removal = codec.encode_envelope(&envelope_b_after_removal).unwrap();
+        timeout(Duration::from_secs(2), async {
             loop {
-                publisher_b.publish(topic, encoded_b.clone()).await.unwrap();
+                publisher_a
+                    .publish(topic, encoded_a_after_removal.clone())
+                    .await
+                    .unwrap();
+                publisher_b
+                    .publish(topic, encoded_b_after_removal.clone())
+                    .await
+                    .unwrap();
                 if let Ok(Some(Ok(message))) =
                     timeout(Duration::from_millis(25), subscriber.next()).await
-                    && message.publisher_id == 202
+                    && message.sequence == 2
                 {
-                    break message;
+                    assert_ne!(
+                        message.publisher_id, 101,
+                        "removed publisher must not deliver new messages"
+                    );
+                    if message.publisher_id == 202 {
+                        break;
+                    }
                 }
             }
         })
         .await
         .expect("remaining publisher should continue after endpoint removal");
-        assert_eq!(message.publisher_id, 202);
+
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(250);
+        while tokio::time::Instant::now() < deadline {
+            publisher_a
+                .publish(topic, encoded_a_after_removal.clone())
+                .await
+                .unwrap();
+            if let Ok(Some(Ok(message))) =
+                timeout(Duration::from_millis(10), subscriber.next()).await
+                && message.sequence == 2
+            {
+                assert_ne!(
+                    message.publisher_id, 101,
+                    "removed publisher must remain disconnected"
+                );
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Keep one direct-ZMQ SUB socket per publisher as the default.
- Use the existing direct receive loop at the default, without a socket-group task or intermediate message queue.
- Allow explicit fan-in with `DYN_ROUTER_ZMQ_ENDPOINTS_PER_SUB`; values above `1` share a SUB socket across that many publishers, and `0` is rejected.
- Apply optional fan-in to KV events, KV metrics, active-sequence sync, and session-affinity sync.
- Preserve per-publisher order, bounded backpressure, recovery, and wire formats.
- Coalesce pending KV load metrics by `(worker_id, dp_rank)` while preserving partial-field updates.

At `64`, 2,048 workers use about 32 SUB sockets per direct-router stream on each frontend. TCP connections and file descriptors still grow linearly with worker count. Each shared socket is one backpressure and failure domain; other groups continue if one group stalls or reconnects.

Relates to #14166.

## Validation

Local validation passed:

- focused direct-ZMQ, KV recovery, KV metrics, active-sequence, and session-affinity tests
- `cargo check -p dynamo-runtime -p dynamo-llm`
- Clippy for both packages with warnings denied
- formatting and `git diff --check`

Tyche compared latest main `6a347c13082d` with this branch. Both arms used the same benchmark-only ZMQ context-capacity overlay, 2,048 workers, speedup 10, Python AIPerf at concurrency 6,144, two NUMA-local frontends, direct ZMQ, KV routing, and replica sync. The endpoint-per-SUB variable was unset, so the candidate used its default value of `1`.

| Metric | Main + overlay | PR default `1` | Change |
|---|---:|---:|---:|
| Throughput | 2,562.34 req/s | 2,549.24 req/s | -0.51% |
| Frontend CPU/request | 35.18 ms | 36.04 ms | +2.45% |
| TTFT p50 | 1,369.67 ms | 1,152.24 ms | -15.88% |
| TTFT p95 | 2,399.75 ms | 2,959.99 ms | +23.35% |
| TTFT p99 | 5,285.87 ms | 5,240.46 ms | -0.86% |

Both arms registered all 2,048 workers and reached 2,048 active KV-event sources on each frontend. Both had zero request errors, cancellations, direct-ZMQ lane-full events, active-sequence gaps, and KV-event warnings. Candidate KV-event application rates were within 3.1% of control on both frontends. The single-run TTFT p95 movement remains a caveat; throughput, CPU/request, p50, and p99 met the accepted validation criteria.
