### PR TITLE
fix(frontend): reject a forced tool_choice with no tools

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -33,7 +33,7 @@ from vllm.tool_parsers.utils import get_json_schema_from_tools
 from vllm.utils.async_utils import make_async
 
 from dynamo.common.utils.guided_json import admits_only_empty_object
-from dynamo.llm.exceptions import InvalidArgument
+from dynamo.llm.exceptions import HttpError, InvalidArgument
 
 from .thinking import apply_default_thinking_mode_to_template_kwargs
 from .utils import legacy_guided_decoding
@@ -102,6 +102,24 @@ def _is_forced_tool_choice(tool_choice: Any) -> bool:
     return tool_choice == "required" or _is_named_tool_choice(tool_choice)
 
 
+def _forced_tool_choice_without_tools_error(tool_choice: Any) -> HttpError:
+    """Mirror the Rust frontend's wording so clients see one behaviour.
+
+    ``validate_tool_choice`` in protocols/openai/validate.rs emits exactly these
+    two messages for the same request.
+    """
+    if _is_named_tool_choice(tool_choice):
+        name = (
+            tool_choice.function.name
+            if isinstance(tool_choice, ChatCompletionNamedToolChoiceParam)
+            else tool_choice["function"]["name"]
+        )
+        return HttpError(
+            400, f'tool named "{name}" in tool_choice is not present in tools'
+        )
+    return HttpError(400, 'tool_choice is "required" but tools is empty')
+
+
 def _typed_tool_choice(tool_choice: Any) -> Any:
     """Normalize a raw named tool choice into the type vLLM's helpers expect.
 
@@ -164,13 +182,11 @@ def _should_build_tool_call_guidance(
     structural_tag_scope: str,
 ) -> bool:
     tool_choice = request.tool_choice or "auto"
-    # TODO: a forced tool_choice with no tools is unsatisfiable and should be a
-    # 400, not an unconstrained request. preprocessor/tool_choice.rs rejects it
-    # (ToolChoiceError::EmptyTools via get_json_schema_from_tools); here and in
-    # sglang_prepost.py it returns no constraint and the caller gets a plausible
-    # answer that can never contain the tool call they required. vLLM's own
-    # "when using tool_choice, tools must be set" validator does not run because
-    # the DYN_VLLM_SKIP_REQUEST_VALIDATION fast path uses model_construct.
+    # A forced tool_choice with no tools is rejected in preprocess_chat_request,
+    # so reaching here without tools means the choice was not forced and there is
+    # nothing to constrain.
+    # TODO: sglang_prepost.py still has no such rejection. #14179 is editing that
+    # file, so it is left for a follow-up.
     if not request.tools:
         return False
 
@@ -603,6 +619,17 @@ async def preprocess_chat_request(
     structural_tag_schema: str = "auto",
 ) -> PreprocessResult:
     validated_request = _validate_chat_completion_request(request)
+    # A forced tool_choice with no tools cannot be satisfied: the reply has to be
+    # a tool call and there is no tool to call. The Rust preprocessor rejects it
+    # (ToolChoiceError::EmptyTools); this path did not, because vLLM's own
+    # "when using tool_choice, tools must be set" validator is skipped on the
+    # DYN_VLLM_SKIP_REQUEST_VALIDATION fast path, which uses model_construct.
+    # Without this the caller gets a plausible answer that can never contain the
+    # tool call they required.
+    if not validated_request.tools and _is_forced_tool_choice(
+        validated_request.tool_choice
+    ):
+        raise _forced_tool_choice_without_tools_error(validated_request.tool_choice)
     assistant_guided_decoding = _build_assistant_guided_decoding(validated_request)
     client_structured_guidance = deepcopy(
         _guided_decoding_from_structured_outputs(

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -102,22 +102,48 @@ def _is_forced_tool_choice(tool_choice: Any) -> bool:
     return tool_choice == "required" or _is_named_tool_choice(tool_choice)
 
 
-def _forced_tool_choice_without_tools_error(tool_choice: Any) -> HttpError:
-    """Mirror the Rust frontend's wording so clients see one behaviour.
+def _named_tool_choice_name(tool_choice: Any) -> str:
+    """The requested tool name. Only call once _is_named_tool_choice has passed."""
+    if isinstance(tool_choice, ChatCompletionNamedToolChoiceParam):
+        return tool_choice.function.name
+    return tool_choice["function"]["name"]
 
-    ``validate_tool_choice`` in protocols/openai/validate.rs emits exactly these
-    two messages for the same request.
+
+def _tool_names(tools: Any) -> set[str]:
+    """Names of the supplied tools.
+
+    The fast path builds the request with ``model_construct``, so tools and
+    their function bodies can still be the client's raw dicts here.
     """
+    names: set[str] = set()
+    for tool in tools or ():
+        function = tool["function"] if isinstance(tool, dict) else tool.function
+        name = function["name"] if isinstance(function, dict) else function.name
+        if name:
+            names.add(name)
+    return names
+
+
+def _forced_tool_choice_error(request: Any) -> HttpError | None:
+    """The 400 a forced tool_choice deserves, or None if it can be satisfied.
+
+    Mirrors ``validate_tool_choice`` in protocols/openai/validate.rs, which
+    rejects both an empty tools list and a named choice naming a tool that is
+    not in a non-empty list, with exactly these two messages.
+    """
+    tool_choice = request.tool_choice
+    if not _is_forced_tool_choice(tool_choice):
+        return None
     if _is_named_tool_choice(tool_choice):
-        name = (
-            tool_choice.function.name
-            if isinstance(tool_choice, ChatCompletionNamedToolChoiceParam)
-            else tool_choice["function"]["name"]
-        )
-        return HttpError(
-            400, f'tool named "{name}" in tool_choice is not present in tools'
-        )
-    return HttpError(400, 'tool_choice is "required" but tools is empty')
+        name = _named_tool_choice_name(tool_choice)
+        if name not in _tool_names(request.tools):
+            return HttpError(
+                400, f'tool named "{name}" in tool_choice is not present in tools'
+            )
+        return None
+    if not request.tools:
+        return HttpError(400, 'tool_choice is "required" but tools is empty')
+    return None
 
 
 def _typed_tool_choice(tool_choice: Any) -> Any:
@@ -185,8 +211,6 @@ def _should_build_tool_call_guidance(
     # A forced tool_choice with no tools is rejected in preprocess_chat_request,
     # so reaching here without tools means the choice was not forced and there is
     # nothing to constrain.
-    # TODO: sglang_prepost.py still has no such rejection. #14179 is editing that
-    # file, so it is left for a follow-up.
     if not request.tools:
         return False
 
@@ -619,17 +643,13 @@ async def preprocess_chat_request(
     structural_tag_schema: str = "auto",
 ) -> PreprocessResult:
     validated_request = _validate_chat_completion_request(request)
-    # A forced tool_choice with no tools cannot be satisfied: the reply has to be
-    # a tool call and there is no tool to call. The Rust preprocessor rejects it
-    # (ToolChoiceError::EmptyTools); this path did not, because vLLM's own
-    # "when using tool_choice, tools must be set" validator is skipped on the
-    # DYN_VLLM_SKIP_REQUEST_VALIDATION fast path, which uses model_construct.
-    # Without this the caller gets a plausible answer that can never contain the
-    # tool call they required.
-    if not validated_request.tools and _is_forced_tool_choice(
-        validated_request.tool_choice
-    ):
-        raise _forced_tool_choice_without_tools_error(validated_request.tool_choice)
+    # A forced tool_choice the tools list cannot satisfy has no valid answer, and
+    # vLLM's own check for it is skipped on the DYN_VLLM_SKIP_REQUEST_VALIDATION
+    # fast path. Without this the caller gets a plausible reply that can never
+    # contain the tool call they required.
+    forced_tool_choice_error = _forced_tool_choice_error(validated_request)
+    if forced_tool_choice_error is not None:
+        raise forced_tool_choice_error
     assistant_guided_decoding = _build_assistant_guided_decoding(validated_request)
     client_structured_guidance = deepcopy(
         _guided_decoding_from_structured_outputs(


### PR DESCRIPTION
## Summary

A chat request with `tool_choice: "required"`, or a named `tool_choice`, and no `tools` cannot be satisfied. The reply has to be a tool call, and there is no tool to call. The vLLM chat processor answered it anyway, unconstrained, so the caller got a plausible assistant message that can never contain the tool call they asked for, with a 200.

The Rust frontend already rejects the same request. `validate_tool_choice` in `protocols/openai/validate.rs`:

```rust
Err(ToolChoiceError::EmptyTools) => {
    anyhow::bail!("tool_choice is \"required\" but tools is empty")
}
...
Err(ToolChoiceError::ToolNotFound(name)) => {
    anyhow::bail!("tool named \"{name}\" in tool_choice is not present in tools")
}
```

vLLM's own "when using tool_choice, tools must be set" validator does not cover it either, because the `DYN_VLLM_SKIP_REQUEST_VALIDATION` fast path builds the request with `model_construct` rather than `model_validate`.

So the same request is a 400 through the Rust frontend and a misleading 200 through `--dyn-chat-processor vllm`.

Rejected in `preprocess_chat_request`, reusing the two messages `validate.rs` already emits so the status and the wording match whichever frontend serves the request. The check runs off the existing `_is_forced_tool_choice` helper, which already handles both the typed `ChatCompletionNamedToolChoiceParam` and the raw client dict that the fast path leaves in place.

This was a `TODO` in `prepost.py` describing exactly this gap, including the pointer to the Rust rejection. I replaced it with a note that the gap remains in `sglang_prepost.py`.

### Scope

`sglang_prepost.py` has the same hole and its own copy of this logic. I deliberately did not touch it: #14179 is editing that file right now for a different forced-`tool_choice` bug, and a second change in the same place would just conflict. Happy to follow up once that lands.

## Validation

Static only, and I want to be clear about why rather than imply more.

`prepost.py` imports vLLM at module scope (`vllm.entrypoints.openai.chat_completion.protocol`, `vllm.tool_parsers`, and others), and vLLM is not installable in this environment. The repo's own tests for this module have the same dependency, so `test_vllm_processor_unit.py` cannot run here either. Stubbing vLLM's Pydantic request model would have made the run exercise my stubs rather than the real `ChatCompletionRequest`, which is worse than not running it, so I did not.

What I did check:

- `pre-commit run --files components/src/dynamo/frontend/prepost.py` passes every applicable hook: `black`, `isort`, `ruff`, `flake8`, `codespell`. `pytest-marker-report` fails identically on an untouched `README.md` here because vLLM and TensorRT-LLM are absent.
- The message strings are copied from `validate.rs` rather than reworded, so the two frontends cannot drift apart on this.
- No test added. I do not ship tests I have not executed, and the honest options here were an unrun test or none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests that force a tool choice when no tools are available are now rejected with a clear HTTP 400 error.
  * Error messages distinguish between a missing specifically named tool and a required tool choice with an empty tool list.
  * Invalid requests are consistently rejected before further processing, including requests that bypass standard validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->