### PR TITLE
fix(planner): [cherry-pick 1.5.0] recognize internal mocker worker module (#14175)

### DIFF
--- a/components/src/dynamo/planner/monitoring/dgd_services.py
+++ b/components/src/dynamo/planner/monitoring/dgd_services.py
@@ -137,7 +137,10 @@ class Service(BaseModel):
         container = get_main_container(self.service)
         command = break_arguments(container.get("command"))
         args = break_arguments(container.get("args"))
-        return "dynamo.mocker" in command + args
+        return any(
+            module in {"dynamo.mocker", "dynamo.mocker._worker"}
+            for module in command + args
+        )
 
     def get_model_name(self) -> Optional[str]:
         args = get_main_container(self.service).get("args", [])

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -1320,15 +1320,28 @@ def test_typed_worker_with_explicit_zero_shape_is_rejected(
         kubernetes_connector.get_gpu_shapes(require_prefill=False, require_decode=True)
 
 
+@pytest.mark.parametrize(
+    ("command", "args"),
+    [
+        (None, ["-m", "dynamo.mocker", "--model-name", "test-model"]),
+        (
+            ["python3", "-m", "dynamo.mocker._worker"],
+            ["--model-name", "test-model"],
+        ),
+    ],
+    ids=["public-module", "worker-module"],
+)
 def test_typed_mocker_worker_with_zero_physical_shape_uses_configured_fallback(
-    kubernetes_connector, mock_kube_api
+    kubernetes_connector, mock_kube_api, command, args
 ):
     component = _component(
         "decode-worker",
         "decode",
         replicas=1,
-        args=["-m", "dynamo.mocker", "--model-name", "test-model"],
+        args=args,
     )
+    if command is not None:
+        component["podTemplate"]["spec"]["containers"][0]["command"] = command
     deployment = _deployment(component)
     deployment["metadata"]["generation"] = 2
     deployment["status"] = {


### PR DESCRIPTION
Cherry-pick of #14175 into `release/1.5.0`.

Clean pick, no conflicts. Source commit recorded via `git cherry-pick -x`.

Main PR: https://github.com/ai-dynamo/dynamo/pull/14175