### PR TITLE
docs(vllm): [cherry-pick 1.5.0] remove stale version references (#14139)

### DIFF
--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -31,7 +31,7 @@ It is a standalone Rust executable and is also compiled into
 - Capability-gated RL pause/resume, sleep/wake, weight-transfer, and weight-version controls through native gRPC
 - Image, video, and audio URL and data-URI inputs; cache UUIDs remain image-only
 
-Audio and video inputs currently require the `connorcarpenter15/vllm:feat/grpc-audio-video-combined` review branch at commit [`236caaec7221842c307e87e05ea3356539be6b20`](https://github.com/connorcarpenter15/vllm/commit/236caaec7221842c307e87e05ea3356539be6b20), tracked by [connorcarpenter15/vllm#32](https://github.com/connorcarpenter15/vllm/pull/32). The fork's current `main` and stock vLLM releases do not contain this support while that PR remains open.
+Audio and video gRPC inputs are not available in vLLM `0.28.0`. They require a later vLLM release.
 
 The protocol does not support LoRA, encode workers, beam search, `n > 1`, or Dynamo tool-call and reasoning parsers. The sidecar does not support `input_audio`, `file://` media, `use_audio_in_video` or other `mm_processor_kwargs`, preprocessed multimodal features, decoded RDMA media, UUID-only media, audio/video cache UUIDs, or EPD. Direct vLLM gRPC callers can send raw media bytes, but Dynamo's current `MultimodalData` representation cannot. Parser defaults returned by Control are intentionally not advertised to the Dynamo frontend because the current inference protocol does not preserve all parser-related request semantics.
 

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -401,7 +401,7 @@ fn structured_output(
     };
     if guided.backend.is_some() || guided.whitespace_pattern.is_some() {
         return Err(client::invalid_argument(
-            "guided decoding backend and whitespace_pattern are not supported by vLLM gRPC v0.25.1",
+            "guided decoding backend and whitespace_pattern are not supported by vLLM gRPC",
         ));
     }
 
@@ -455,7 +455,7 @@ fn build_kv_parameters(
                 "bypass_prefix_cache" | "skip_reading_prefix_cache" | "kv_transfer_params"
             ) {
                 return Err(client::invalid_argument(format!(
-                    "extra_args.{key} is not supported by vLLM gRPC v0.25.1"
+                    "extra_args.{key} is not supported by vLLM gRPC"
                 )));
             }
         }
@@ -566,7 +566,7 @@ fn validate_request(
     }
     if request.prompt_embeds.is_some() {
         return Err(client::invalid_argument(
-            "prompt embeddings are not supported by vLLM gRPC v0.25.1",
+            "prompt embeddings are not supported by vLLM gRPC",
         ));
     }
     if request.mm_processor_kwargs.is_some() || request.encoder_result.is_some() {
@@ -586,7 +586,7 @@ fn validate_request(
         .is_some_and(|name| !name.is_empty())
     {
         return Err(client::invalid_argument(
-            "LoRA request selection is not supported by vLLM gRPC v0.25.1",
+            "LoRA request selection is not supported by vLLM gRPC",
         ));
     }
     if request.bootstrap_info.is_some() {
@@ -601,17 +601,17 @@ fn validate_request(
         .is_some_and(|ids| !ids.is_empty())
     {
         return Err(client::invalid_argument(
-            "visible stop token IDs are not supported by vLLM gRPC v0.25.1",
+            "visible stop token IDs are not supported by vLLM gRPC",
         ));
     }
     if request.stop_conditions.max_thinking_tokens.is_some() {
         return Err(client::invalid_argument(
-            "max_thinking_tokens is not supported by vLLM gRPC v0.25.1",
+            "max_thinking_tokens is not supported by vLLM gRPC",
         ));
     }
     if request.output_options.skip_special_tokens == Some(false) {
         return Err(client::invalid_argument(
-            "skip_special_tokens=false is not supported by vLLM gRPC v0.25.1",
+            "skip_special_tokens=false is not supported by vLLM gRPC",
         ));
     }
     let sampling = &request.sampling_options;


### PR DESCRIPTION
Cherry-pick of #14139 into `release/1.5.0`.

Clean pick, no conflicts. Source commit recorded via `git cherry-pick -x`.

Main PR: https://github.com/ai-dynamo/dynamo/pull/14139