### PR TITLE
fix(planner): guard load scaling at GPU floor

### DIFF
--- a/components/src/dynamo/planner/core/budget.py
+++ b/components/src/dynamo/planner/core/budget.py
@@ -175,6 +175,138 @@ def proportional_clamp_pair(
     return new_p, new_d
 
 
+def guard_disagg_load_budget(
+    current_p: int,
+    current_d: int,
+    proposed_p: int,
+    proposed_d: int,
+    p_gpu: int,
+    d_gpu: int,
+    min_gpus: int,
+    max_gpus: int,
+    prefill_min_endpoint: int,
+    decode_min_endpoint: int,
+) -> tuple[int, int, Optional[str]]:
+    """Apply GPU budgets to a disaggregated *load-scaling* proposal safely.
+
+    ``min_gpu_budget`` is a scale-down guard, not an independent source of
+    scale-up intent. Once the current allocation has reached that floor, a
+    down/down or down/hold proposal is held instead of being proportionally
+    grown into a direction-reversing action. At a full (maximum-budget)
+    allocation, a scale-up is admitted only as an explicit opposing rebalance:
+    one pool must propose up while the other proposes down, and the proposed
+    pair itself must fit the budget band.
+
+    If the observed allocation is already outside the budget band, recovery is
+    kept explicit: the current allocation, rather than the load proposal, is
+    reconciled back toward the band and ``"gpu_budget_reconcile"`` is returned.
+    A negative minimum preserves the legacy clamp behavior, including for
+    max-only configurations.
+
+    The returned optional reason is suitable for load-decision diagnostics.
+    """
+    if min_gpus < 0 or p_gpu <= 0 or d_gpu <= 0:
+        new_p, new_d = proportional_clamp_pair(
+            proposed_p,
+            proposed_d,
+            p_gpu,
+            d_gpu,
+            min_gpus,
+            max_gpus,
+            prefill_min_endpoint,
+            decode_min_endpoint,
+        )
+        return new_p, new_d, None
+
+    tolerance = compute_tolerance([p_gpu, d_gpu]) if max_gpus >= 0 else 0
+    current_total = current_p * p_gpu + current_d * d_gpu
+    current_in_band, _ = bounds_for_total(current_total, min_gpus, max_gpus, tolerance)
+
+    # Budget recovery is not an ordinary load decision. Reconcile from the
+    # observed allocation so a stale down proposal cannot dictate which pool
+    # receives recovery capacity (or turn the recovery into churn).
+    if not current_in_band:
+        new_p, new_d = proportional_clamp_pair(
+            current_p,
+            current_d,
+            p_gpu,
+            d_gpu,
+            min_gpus,
+            max_gpus,
+            prefill_min_endpoint,
+            decode_min_endpoint,
+        )
+        return new_p, new_d, "gpu_budget_reconcile"
+
+    p_down = proposed_p < current_p
+    p_up = proposed_p > current_p
+    d_down = proposed_d < current_d
+    d_up = proposed_d > current_d
+    any_down = p_down or d_down
+    any_up = p_up or d_up
+    opposing_rebalance = (p_down and d_up) or (p_up and d_down)
+
+    # The nominal floor is the configured safety intent. Tolerance only makes
+    # integer GPU-width targets feasible; it must not permit repeated
+    # scale-down-only actions once the allocation has reached the floor.
+    if current_total <= min_gpus and any_down and not any_up:
+        return current_p, current_d, "gpu_budget_guard_hold"
+
+    # At the floor, an opposing proposal is one indivisible rebalance. If its
+    # weighted pair does not fit, fail closed rather than letting the generic
+    # clamp suppress the scale-up leg while retaining the donor removal.
+    if current_total <= min_gpus and opposing_rebalance:
+        proposed_total = proposed_p * p_gpu + proposed_d * d_gpu
+        proposed_in_band, _ = bounds_for_total(
+            proposed_total, min_gpus, max_gpus, tolerance
+        )
+        if not proposed_in_band:
+            return current_p, current_d, "gpu_budget_guard_hold"
+        return proposed_p, proposed_d, None
+
+    # At the hard ceiling there is no unallocated capacity for a scale-up.
+    # Refuse to invent a donor from a pool whose load signal said hold/up.
+    # For an explicit opposing proposal, require the pair itself to fit so the
+    # clamp cannot suppress one leg and execute only the other.
+    if max_gpus >= 0 and current_total >= max_gpus and any_up:
+        proposed_total = proposed_p * p_gpu + proposed_d * d_gpu
+        proposed_in_band, _ = bounds_for_total(
+            proposed_total, min_gpus, max_gpus, tolerance
+        )
+        if not opposing_rebalance or not proposed_in_band:
+            return current_p, current_d, "gpu_budget_guard_hold"
+        return proposed_p, proposed_d, None
+
+    new_p, new_d = proportional_clamp_pair(
+        proposed_p,
+        proposed_d,
+        p_gpu,
+        d_gpu,
+        min_gpus,
+        max_gpus,
+        prefill_min_endpoint,
+        decode_min_endpoint,
+    )
+
+    # Constraints may suppress a requested movement, but must not reverse or
+    # amplify it. An explicit recovery path above handles out-of-band current
+    # allocations; ordinary in-band load decisions fail closed to HOLD.
+    def _within_requested_direction(current: int, proposed: int, final: int) -> bool:
+        return min(current, proposed) <= final <= max(current, proposed)
+
+    if not _within_requested_direction(current_p, proposed_p, new_p) or not (
+        _within_requested_direction(current_d, proposed_d, new_d)
+    ):
+        return current_p, current_d, "gpu_budget_guard_hold"
+
+    new_total = new_p * p_gpu + new_d * d_gpu
+    new_in_band, _ = bounds_for_total(new_total, min_gpus, max_gpus, tolerance)
+    if not new_in_band:
+        return current_p, current_d, "gpu_budget_guard_hold"
+
+    return new_p, new_d, None
+
+
 def proportional_clamp_single(
     desired: int,
     engine_gpu: int,

--- a/components/src/dynamo/planner/core/load_scaling.py
+++ b/components/src/dynamo/planner/core/load_scaling.py
@@ -201,7 +201,9 @@ class LoadScalingMixin:
 
         final_p = max(final_p, resolve_min_endpoint(self._config, "prefill"))
         final_d = max(final_d, resolve_min_endpoint(self._config, "decode"))
-        final_p, final_d = self._apply_global_budget(final_p, final_d)
+        final_p, final_d, budget_reason = self._apply_disagg_load_budget(
+            final_p, final_d
+        )
 
         # Per-component reasons
         def _reason(final: int, original: int, post_floor: int, current: int) -> str:
@@ -235,6 +237,8 @@ class LoadScalingMixin:
             (self._diag_load_reason_prefill, self._diag_load_reason_decode),
             key=lambda r: _PRIORITY.get(r or "", 0),
         )
+        if budget_reason is not None:
+            self._diag_load_reason = budget_reason
 
         if final_p == self._num_p_workers and final_d == self._num_d_workers:
             logger.info("Load-based scaling: no scaling needed")
@@ -248,10 +252,11 @@ class LoadScalingMixin:
                 self._diag_load_reason_decode = d_reason
             # Aggregate reason: surface the most informative of the two
             # so the non-per-component Enum/HTML view also reflects it.
-            for candidate in (p_reason, d_reason):
-                if candidate is not None and candidate != "no_change":
-                    self._diag_load_reason = candidate
-                    break
+            if budget_reason is None:
+                for candidate in (p_reason, d_reason):
+                    if candidate is not None and candidate != "no_change":
+                        self._diag_load_reason = candidate
+                        break
             return None
 
         logger.info(

--- a/components/src/dynamo/planner/core/state_machine.py
+++ b/components/src/dynamo/planner/core/state_machine.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Literal, Optional
 
 from dynamo.planner.config.planner_config import PlannerConfig, resolve_min_endpoint
 from dynamo.planner.core.budget import (
+    guard_disagg_load_budget,
     proportional_clamp_pair,
     proportional_clamp_single,
 )
@@ -386,6 +387,20 @@ class PlannerScalingState(LoadScalingMixin, ThroughputScalingMixin):
     # Budget
     # ------------------------------------------------------------------
 
+    def _resolve_disagg_gpu_costs(self) -> tuple[Optional[int], Optional[int]]:
+        """Resolve per-replica GPU costs for prefill and decode."""
+        p_gpu = (
+            self._capabilities.prefill.resolved_gpu_cost_per_replica
+            if self._capabilities.prefill is not None
+            else None
+        )
+        d_gpu = (
+            self._capabilities.decode.resolved_gpu_cost_per_replica
+            if self._capabilities.decode is not None
+            else None
+        )
+        return p_gpu, d_gpu
+
     def _min_endpoint_for(self, component: Literal["prefill", "decode"]) -> int:
         """Return the effective floor for a planner component."""
 
@@ -410,16 +425,7 @@ class PlannerScalingState(LoadScalingMixin, ThroughputScalingMixin):
         ``(num_p, num_d)``. Delegates to ``budget.proportional_clamp_pair``
         for the actual math; this method only resolves the per-replica GPU
         costs from capabilities."""
-        p_gpu = (
-            self._capabilities.prefill.resolved_gpu_cost_per_replica
-            if self._capabilities.prefill is not None
-            else None
-        )
-        d_gpu = (
-            self._capabilities.decode.resolved_gpu_cost_per_replica
-            if self._capabilities.decode is not None
-            else None
-        )
+        p_gpu, d_gpu = self._resolve_disagg_gpu_costs()
         if p_gpu is None or d_gpu is None:
             return num_p, num_d
 
@@ -443,6 +449,49 @@ class PlannerScalingState(LoadScalingMixin, ThroughputScalingMixin):
                 f"({new_p}P + {new_d}D = {new_total})"
             )
         return new_p, new_d
+
+    def _apply_disagg_load_budget(
+        self, num_p: int, num_d: int
+    ) -> tuple[int, int, Optional[str]]:
+        """Apply the direction-preserving budget policy for load scaling."""
+        p_gpu, d_gpu = self._resolve_disagg_gpu_costs()
+        if p_gpu is None or d_gpu is None:
+            return num_p, num_d, None
+
+        new_p, new_d, reason = guard_disagg_load_budget(
+            self._num_p_workers,
+            self._num_d_workers,
+            num_p,
+            num_d,
+            p_gpu,
+            d_gpu,
+            self._config.min_gpu_budget,
+            self._config.max_gpu_budget,
+            self._min_endpoint_for("prefill"),
+            self._min_endpoint_for("decode"),
+        )
+        if reason is not None or (new_p, new_d) != (num_p, num_d):
+            old_total = self._num_p_workers * p_gpu + self._num_d_workers * d_gpu
+            proposed_total = num_p * p_gpu + num_d * d_gpu
+            new_total = new_p * p_gpu + new_d * d_gpu
+            logger.warning(
+                "GPU budget load policy %s: current=(%sP + %sD = %s), "
+                "proposed=(%sP + %sD = %s), final=(%sP + %sD = %s), "
+                "band=[min=%s, max=%s]",
+                reason or "gpu_budget_clamped",
+                self._num_p_workers,
+                self._num_d_workers,
+                old_total,
+                num_p,
+                num_d,
+                proposed_total,
+                new_p,
+                new_d,
+                new_total,
+                self._config.min_gpu_budget,
+                self._config.max_gpu_budget,
+            )
+        return new_p, new_d, reason
 
     def _budget_clamp(self, desired: int, gpu_cost: int, min_endpoint: int) -> int:
         """Apply the GPU budget band to a single component's desired replica

--- a/components/src/dynamo/planner/monitoring/planner_metrics.py
+++ b/components/src/dynamo/planner/monitoring/planner_metrics.py
@@ -26,6 +26,8 @@ LOAD_DECISION_STATES = [
     "reconcile_clamped_to_ceiling",
     "held_over",
     "rejected_by_plugin",
+    "gpu_budget_guard_hold",
+    "gpu_budget_reconcile",
 ]
 
 THROUGHPUT_DECISION_STATES = [

--- a/components/src/dynamo/planner/tests/monitoring/test_decision_state_enums.py
+++ b/components/src/dynamo/planner/tests/monitoring/test_decision_state_enums.py
@@ -53,13 +53,15 @@ _V1_THROUGHPUT_STATES = [
     "scale",
 ]
 
-# Plugin-era additions — appended in this order.
-_PLUGIN_LOAD_ADDITIONS = [
+# Post-v1 additions — appended in this order.
+_LOAD_ADDITIONS = [
     "override_by_user_plugin",
     "reconcile_clamped_to_floor",
     "reconcile_clamped_to_ceiling",
     "held_over",
     "rejected_by_plugin",
+    "gpu_budget_guard_hold",
+    "gpu_budget_reconcile",
 ]
 
 _PLUGIN_THROUGHPUT_ADDITIONS = [
@@ -82,7 +84,7 @@ def test_v1_throughput_states_preserved_in_original_order():
 
 
 def test_load_additions_appended_in_order():
-    assert LOAD_DECISION_STATES[len(_V1_LOAD_STATES) :] == _PLUGIN_LOAD_ADDITIONS
+    assert LOAD_DECISION_STATES[len(_V1_LOAD_STATES) :] == _LOAD_ADDITIONS
 
 
 def test_throughput_additions_appended_in_order():
@@ -92,7 +94,7 @@ def test_throughput_additions_appended_in_order():
     )
 
 
-@pytest.mark.parametrize("state", _PLUGIN_LOAD_ADDITIONS)
+@pytest.mark.parametrize("state", _LOAD_ADDITIONS)
 def test_new_load_state_is_settable_on_enum(state):
     """Construct an Enum with our extended states list and verify the
     new state can be set without raising. Uses an isolated registry so

--- a/components/src/dynamo/planner/tests/unit/test_budget.py
+++ b/components/src/dynamo/planner/tests/unit/test_budget.py
@@ -11,6 +11,7 @@ import pytest
 from dynamo.planner.core.budget import (
     bounds_for_total,
     compute_tolerance,
+    guard_disagg_load_budget,
     proportional_clamp_pair,
     proportional_clamp_single,
 )
@@ -215,6 +216,173 @@ def test_clamp_pair_infeasible_band_falls_back_to_inputs():
     # Floor push would land far above the strict ceiling (4), so we keep
     # inputs and let the caller surface the config error.
     assert (new_p, new_d) == (2, 2)
+
+
+# ---------------------------------------------------------------------------- #
+# disaggregated load-budget safety guard                                       #
+# ---------------------------------------------------------------------------- #
+
+
+def _guard(
+    current: tuple[int, int],
+    proposed: tuple[int, int],
+    *,
+    p_gpu: int = 1,
+    d_gpu: int = 1,
+    min_gpus: int = 64,
+    max_gpus: int = 64,
+    prefill_min_endpoint: int = 1,
+    decode_min_endpoint: int = 1,
+) -> tuple[int, int, str | None]:
+    return guard_disagg_load_budget(
+        current[0],
+        current[1],
+        proposed[0],
+        proposed[1],
+        p_gpu,
+        d_gpu,
+        min_gpus,
+        max_gpus,
+        prefill_min_endpoint,
+        decode_min_endpoint,
+    )
+
+
+@pytest.mark.parametrize(
+    ("current", "proposed"),
+    [
+        ((28, 36), (27, 36)),
+        ((27, 36), (26, 35)),
+    ],
+)
+def test_load_budget_holds_scale_down_without_scale_up_at_floor(current, proposed):
+    assert _guard(current, proposed) == (
+        current[0],
+        current[1],
+        "gpu_budget_guard_hold",
+    )
+
+
+def test_load_budget_allows_explicit_opposing_swap_at_fixed_budget():
+    assert _guard((27, 37), (26, 38)) == (26, 38, None)
+
+
+def test_load_budget_allows_reverse_explicit_opposing_swap_at_fixed_budget():
+    assert _guard((27, 37), (28, 36)) == (28, 36, None)
+
+
+@pytest.mark.parametrize("proposed", [(28, 37), (29, 37)])
+def test_load_budget_does_not_invent_donor_at_full_budget(proposed):
+    # hold/up and up/up do not establish that either pool is safe to donate.
+    assert _guard((28, 36), proposed) == (
+        28,
+        36,
+        "gpu_budget_guard_hold",
+    )
+
+
+def test_load_budget_rejects_opposing_swap_that_does_not_fit():
+    # Removing one 1-GPU prefill cannot fund one 2-GPU decode.
+    assert _guard(
+        (2, 1),
+        (1, 2),
+        p_gpu=1,
+        d_gpu=2,
+        min_gpus=4,
+        max_gpus=4,
+    ) == (2, 1, "gpu_budget_guard_hold")
+
+
+def test_load_budget_does_not_execute_only_donor_leg_of_weighted_swap():
+    # The generic clamp turns the 7-GPU proposal into (1P, 1D) = 4 GPUs,
+    # suppressing decode-up but retaining prefill-down because tolerance makes
+    # 4 valid for a min=5 floor. At the floor, the swap must be atomic.
+    assert _guard(
+        (2, 1),
+        (1, 2),
+        p_gpu=1,
+        d_gpu=3,
+        min_gpus=5,
+        max_gpus=6,
+    ) == (2, 1, "gpu_budget_guard_hold")
+
+
+def test_load_budget_allows_scale_down_above_floor():
+    assert _guard((35, 35), (34, 35), max_gpus=80) == (34, 35, None)
+
+
+def test_load_budget_disabled_minimum_preserves_legacy_clamp():
+    expected = proportional_clamp_pair(3, 2, 1, 1, -1, 4, 1, 1)
+    actual_p, actual_d, reason = _guard(
+        (3, 1),
+        (3, 2),
+        min_gpus=-1,
+        max_gpus=4,
+    )
+    assert (actual_p, actual_d) == expected
+    assert reason is None
+
+
+def test_load_budget_weighted_tolerance_does_not_enable_donor_only_churn():
+    # min=max=5 is unreachable with 2-GPU replicas. The existing tolerance
+    # accepts total=4, but the nominal floor still guards donor-only removal.
+    assert _guard(
+        (1, 1),
+        (0, 1),
+        p_gpu=2,
+        d_gpu=2,
+        min_gpus=5,
+        max_gpus=5,
+        prefill_min_endpoint=0,
+    ) == (1, 1, "gpu_budget_guard_hold")
+
+
+def test_load_budget_weighted_tolerance_allows_feasible_opposing_swap():
+    assert _guard(
+        (1, 1),
+        (0, 2),
+        p_gpu=2,
+        d_gpu=2,
+        min_gpus=5,
+        max_gpus=5,
+        prefill_min_endpoint=0,
+    ) == (0, 2, None)
+
+
+def test_load_budget_clamp_never_inverts_hold_into_scale_up():
+    # The proportional floor clamp would turn (1P, 3D) into (2P, 4D),
+    # inventing a decode scale-up from a hold signal. Fail closed instead.
+    assert _guard(
+        (4, 3),
+        (1, 3),
+        min_gpus=6,
+        max_gpus=10,
+    ) == (4, 3, "gpu_budget_guard_hold")
+
+
+def test_load_budget_holds_when_integer_width_clamp_cannot_reach_band():
+    # Current total 5 is valid in the tolerance-relaxed [5, 7] band. The
+    # proportional primitive cannot lift the proposed total 4 without
+    # overshooting the hard max, so it returns the proposal unchanged. The
+    # load guard must not dispatch that out-of-band result.
+    assert _guard(
+        (1, 2),
+        (2, 1),
+        p_gpu=1,
+        d_gpu=2,
+        min_gpus=7,
+        max_gpus=7,
+    ) == (1, 2, "gpu_budget_guard_hold")
+
+
+def test_load_budget_below_floor_uses_explicit_reconcile_from_current():
+    assert _guard(
+        (1, 1),
+        (0, 1),
+        min_gpus=4,
+        max_gpus=6,
+        prefill_min_endpoint=1,
+    ) == (2, 2, "gpu_budget_reconcile")
 
 
 # ---------------------------------------------------------------------------- #

--- a/components/src/dynamo/planner/tests/unit/test_load_budget_guard.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_budget_guard.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for disaggregated load scaling at a GPU budget floor."""
+
+from types import MethodType
+from typing import Optional
+
+import pytest
+
+from dynamo.planner.config.planner_config import PlannerConfig
+from dynamo.planner.core.state_machine import PlannerScalingState
+from dynamo.planner.core.types import (
+    EngineCapabilities,
+    FpmObservations,
+    WorkerCapabilities,
+    WorkerCounts,
+)
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+def _state(
+    current_p: int,
+    current_d: int,
+    *,
+    min_gpus: int = 64,
+    max_gpus: int = 64,
+    p_gpu: int = 1,
+    d_gpu: int = 1,
+) -> PlannerScalingState:
+    config = PlannerConfig.model_construct(
+        mode="disagg",
+        optimization_target="throughput",
+        enable_load_scaling=True,
+        enable_throughput_scaling=False,
+        min_gpu_budget=min_gpus,
+        max_gpu_budget=max_gpus,
+        min_endpoint=1,
+        prefill_min_endpoint=None,
+        decode_min_endpoint=None,
+    )
+    state = PlannerScalingState(
+        config,
+        WorkerCapabilities(
+            prefill=EngineCapabilities(gpu_cost_per_replica=p_gpu),
+            decode=EngineCapabilities(gpu_cost_per_replica=d_gpu),
+        ),
+    )
+    state.observe_worker_counts(
+        WorkerCounts(
+            ready_num_prefill=current_p,
+            ready_num_decode=current_d,
+            expected_num_prefill=current_p,
+            expected_num_decode=current_d,
+        )
+    )
+    return state
+
+
+def _decision(
+    state: PlannerScalingState,
+    proposed_p: Optional[int],
+    proposed_d: Optional[int],
+):
+    state.begin_tick()
+
+    def _prefill(_self, _stats, _workers):
+        return proposed_p
+
+    def _decode(_self, _stats, _workers):
+        return proposed_d
+
+    state._prefill_easy_decision = MethodType(_prefill, state)
+    state._decode_easy_decision = MethodType(_decode, state)
+    observations = FpmObservations(
+        prefill={(f"p-{index}", 0): object() for index in range(state._num_p_workers)},
+        decode={(f"d-{index}", 0): object() for index in range(state._num_d_workers)},
+    )
+    return state.advance_load(observations)
+
+
+def test_fixed_budget_scale_down_hold_returns_hold():
+    state = _state(28, 36)
+
+    assert _decision(state, 27, None) is None
+    diagnostics = state.diagnostics()
+    assert diagnostics.load_decision_reason == "gpu_budget_guard_hold"
+
+
+def test_fixed_budget_both_down_cannot_become_scale_up():
+    state = _state(27, 36)
+
+    assert _decision(state, 26, 35) is None
+    diagnostics = state.diagnostics()
+    assert diagnostics.load_decision_reason == "gpu_budget_guard_hold"
+
+
+def test_fixed_budget_rebalance_waits_for_decode_scale_up_intent():
+    state = _state(27, 37)
+
+    assert _decision(state, 26, None) is None
+    assert state.diagnostics().load_decision_reason == "gpu_budget_guard_hold"
+
+    decision = _decision(state, 26, 38)
+    assert decision is not None
+    assert (decision.num_prefill, decision.num_decode) == (26, 38)
+
+
+def test_load_loop_does_not_invent_donor_for_scale_up_at_full_budget():
+    state = _state(28, 36)
+
+    assert _decision(state, None, 37) is None
+    assert state.diagnostics().load_decision_reason == "gpu_budget_guard_hold"
+
+
+def test_load_loop_still_scales_down_above_floor():
+    state = _state(35, 35, max_gpus=80)
+
+    decision = _decision(state, 34, None)
+    assert decision is not None
+    assert (decision.num_prefill, decision.num_decode) == (34, 35)


### PR DESCRIPTION
## Overview:

Prevent disaggregated load scaling at a configured GPU floor from turning scale-down proposals into scale-up churn or unpaired donor removal.

## Details:

- Treat `min_gpu_budget` as a scale-down guard: down/down and down/hold decisions at the floor now HOLD.
- At a full fixed budget, require one role to explicitly scale down before admitting the other role's scale-up.
- Require weighted role swaps at the floor to fit the budget band as one complete proposal, including unequal GPU-per-replica widths and tolerance.
- Keep out-of-band recovery on an explicit reconcile-from-current path and preserve max-only behavior when the minimum is disabled.
- Expose `gpu_budget_guard_hold` and `gpu_budget_reconcile` load-decision diagnostics.

## Where should the reviewer start?

Start with `guard_disagg_load_budget` in `components/src/dynamo/planner/core/budget.py`, then its load-loop integration in `components/src/dynamo/planner/core/load_scaling.py`. Regression coverage is in `components/src/dynamo/planner/tests/unit/test_load_budget_guard.py` and `test_budget.py`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Validation

- `PYTHONPATH=components/src /home/hongkuanz/Projects/dynamo/.venv/bin/python -m pytest -q components/src/dynamo/planner/tests/unit components/src/dynamo/planner/tests/core components/src/dynamo/planner/tests/monitoring` (835 passed, 1 skipped)
- focused budget/load-guard/decision-enum tests (75 passed)
- `MYPYPATH=components/src:lib/bindings/python/src mypy --explicit-package-bases components/src/dynamo/planner`
- changed-file `pre-commit run --files ...`
- `git diff --check`
- independent agent review (clean after implementation and bot-fix passes)