### PR TITLE
fix(sglang): Sglang compatbility fixes for get_model_config / use_mla_backend

### DIFF
--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -38,6 +38,24 @@ except ImportError:
     # SGLang #36255 exposes ServerArgs._resolved() instead.
     sglang_resolved_view = None
 
+try:
+    from sglang.srt.arg_groups.overrides import (
+        model_config_of as sglang_model_config_of,
+    )
+except ImportError:
+    # Fallback for sglang <= 0.5.18, which exposes ServerArgs.get_model_config().
+    # Remove when min supported version has the accessor move (sgl #36972).
+    sglang_model_config_of = None
+
+try:
+    from sglang.srt.arg_groups.overrides import (
+        use_mla_backend as sglang_use_mla_backend,
+    )
+except ImportError:
+    # Fallback for sglang <= 0.5.18, which exposes ServerArgs.use_mla_backend().
+    # Remove when min supported version has the accessor move (sgl #36972).
+    sglang_use_mla_backend = None
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -47,6 +65,36 @@ except ModuleNotFoundError as exc:
         raise
     # Keep the CUDA 0.5.18 and XPU 0.5.11 pins working until both move here.
     from sglang.srt.server_args_config_parser import ConfigArgumentMerger
+
+
+def get_sglang_model_config(server_args: Any) -> Any:
+    """Return the resolved model config across SGLang ServerArgs APIs.
+
+    SGLang #36972 moved ``ServerArgs.get_model_config()`` to the module-level
+    ``model_config_of()``. Remove the legacy branch when the minimum supported
+    SGLang release contains that move.
+    """
+    legacy_getter = getattr(server_args, "get_model_config", None)
+    if legacy_getter is not None:
+        return legacy_getter()
+    if sglang_model_config_of is None:
+        raise AttributeError("SGLang does not expose a model config accessor")
+    return sglang_model_config_of(server_args)
+
+
+def sglang_uses_mla_backend(server_args: Any) -> bool:
+    """Return whether this configuration selects SGLang's MLA attention backend.
+
+    SGLang #36972 moved ``ServerArgs.use_mla_backend()`` to the module-level
+    ``use_mla_backend()``. Remove the legacy branch when the minimum supported
+    SGLang release contains that move.
+    """
+    legacy_getter = getattr(server_args, "use_mla_backend", None)
+    if legacy_getter is not None:
+        return bool(legacy_getter())
+    if sglang_use_mla_backend is None:
+        raise AttributeError("SGLang does not expose an MLA backend accessor")
+    return bool(sglang_use_mla_backend(server_args))
 
 
 @lru_cache(maxsize=1)
@@ -221,7 +269,9 @@ __all__ = [
     "ConfigArgumentMerger",
     "ensure_sglang_tensor_image_size",
     "filter_supported_async_generate_kwargs",
+    "get_sglang_model_config",
     "override_server_args",
     "require_reasoning_kwargs",
     "resolved_server_args",
+    "sglang_uses_mla_backend",
 ]

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -36,6 +36,7 @@ from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.sglang._compat import (
     ConfigArgumentMerger,
     ensure_sglang_tensor_image_size,
+    get_sglang_model_config,
     resolved_server_args,
 )
 from dynamo.sglang.backend_args import DynamoSGLangArgGroup, DynamoSGLangConfig
@@ -624,7 +625,7 @@ async def parse_args(args: list[str]) -> Config:
         # Dynamo expects disjoint output_ids; ServerArgs is read-only after resolution.
         parsed_args.incremental_streaming_output = True
         server_args = ServerArgs.from_cli_args(parsed_args)
-        if server_args.get_model_config().is_multimodal:
+        if get_sglang_model_config(server_args).is_multimodal:
             ensure_sglang_tensor_image_size()
 
     if getattr(server_args, "schedule_low_priority_values_first", False):

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -30,6 +30,7 @@ from dynamo.llm import (
     WorkerType,
     register_model,
 )
+from dynamo.sglang._compat import sglang_uses_mla_backend
 from dynamo.sglang._disagg import SGLANG_WORKER_GROUP_ID_KEY, get_sglang_worker_group_id
 from dynamo.sglang.args import DynamoConfig, use_modelexpress_remote_instance
 from dynamo.sglang.capacity import (
@@ -291,7 +292,7 @@ def _get_mooncake_runtime_data(server_args: ServerArgs) -> Optional[dict[str, An
     pp_size = int(getattr(server_args, "pp_size", 1) or 1)
 
     try:
-        is_mla_model = bool(server_args.use_mla_backend())
+        is_mla_model = sglang_uses_mla_backend(server_args)
     except Exception as e:
         logging.warning(f"Failed to determine whether model uses MLA backend: {e}")
         is_mla_model = False

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -23,9 +23,11 @@ from dynamo.common.snapshot.constants import SNAPSHOT_CONTROL_DIR_ENV
 from dynamo.sglang._compat import (
     ensure_sglang_tensor_image_size,
     filter_supported_async_generate_kwargs,
+    get_sglang_model_config,
     override_server_args,
     require_reasoning_kwargs,
     resolved_server_args,
+    sglang_uses_mla_backend,
 )
 from dynamo.sglang.args import (
     _diffusion_generator_kwargs,
@@ -168,6 +170,52 @@ def test_resolved_server_args_uses_declarative_view(monkeypatch):
 
     assert resolved_server_args(raw_server_args) is resolved_server_args_view
     assert raw_server_args.page_size is None
+
+
+def test_compat_uses_current_sglang_model_config_accessor(monkeypatch):
+    expected = SimpleNamespace(is_multimodal=True)
+    server_args = SimpleNamespace()
+    monkeypatch.setattr(
+        sglang_compat,
+        "sglang_model_config_of",
+        lambda value: expected if value is server_args else None,
+    )
+
+    assert get_sglang_model_config(server_args) is expected
+
+
+def test_compat_uses_legacy_sglang_model_config_accessor(monkeypatch):
+    expected = SimpleNamespace(is_multimodal=False)
+    server_args = SimpleNamespace(get_model_config=lambda: expected)
+    monkeypatch.setattr(
+        sglang_compat,
+        "sglang_model_config_of",
+        lambda _: pytest.fail("current accessor should not run for legacy ServerArgs"),
+    )
+
+    assert get_sglang_model_config(server_args) is expected
+
+
+def test_compat_uses_current_sglang_mla_accessor(monkeypatch):
+    server_args = SimpleNamespace()
+    monkeypatch.setattr(
+        sglang_compat,
+        "sglang_use_mla_backend",
+        lambda value: value is server_args,
+    )
+
+    assert sglang_uses_mla_backend(server_args) is True
+
+
+def test_compat_uses_legacy_sglang_mla_accessor(monkeypatch):
+    server_args = SimpleNamespace(use_mla_backend=lambda: True)
+    monkeypatch.setattr(
+        sglang_compat,
+        "sglang_use_mla_backend",
+        lambda _: pytest.fail("current accessor should not run for legacy ServerArgs"),
+    )
+
+    assert sglang_uses_mla_backend(server_args) is True
 
 
 def test_config_uses_resolved_server_args_after_runtime_init():


### PR DESCRIPTION
## Overview:

https://github.com/sgl-project/sglang/pull/36972 made the following changes which broke Dynamo usage:
* `server_args.get_model_config()` is now `overrides.model_config_of()`
* `server_args.use_mla_backend()` is now `overrides.use_mla_backend()`

## Details:

Add compatiblity shims for both methods.

Example error when using ToT dynamo with ToT sglang without this fix:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/sglang/lib/python3.12/site-packages/dynamo/sglang/__main__.py", line 18, in <module>
    main()
  File "/opt/sglang/lib/python3.12/site-packages/dynamo/sglang/main.py", line 164, in main
    uvloop.run(worker())
  File "/opt/sglang/lib/python3.12/site-packages/uvloop/__init__.py", line 96, in run
    return __asyncio.run(
           ^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/opt/sglang/lib/python3.12/site-packages/uvloop/__init__.py", line 48, in wrapper
    return await main
           ^^^^^^^^^^
  File "/opt/sglang/lib/python3.12/site-packages/dynamo/sglang/main.py", line 44, in worker
    config = await parse_args(argv)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/sglang/lib/python3.12/site-packages/dynamo/sglang/args.py", line 627, in parse_args
    if server_args.get_model_config().is_multimodal:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ServerArgs' object has no attribute 'get_model_config'
```

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility across supported SGLang versions when retrieving model configuration and detecting MLA backend usage.
  - Preserved support for both current APIs and legacy server argument accessors.
- **Tests**
  - Added coverage verifying compatibility behavior and accessor preference across SGLang versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->