### PR TITLE
feat(recipes): cherry-pick Inkling GB300 agentic recipes and runtime image (#13798, #14235)

### DIFF
--- a/docs/fern/pages/recipes/_catalog/recipes/inkling.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/inkling.yaml
@@ -20,6 +20,61 @@ artifacts:
     release_tag: v1.4.0-inkling-dev.1
     release_state: prerelease
 targets:
+- id: agg-gb300-agentic
+  recommended: true
+  hardware:
+    gpu: GB300
+    count: 8
+  runtime:
+    framework: vLLM
+  topology: aggregated
+  techniques:
+  - tp4
+  - mtp-spec-dec
+  - kv-aware-routing
+  - prefix-caching
+  - 1m-context
+  workload:
+    type: agentic-trace-replay
+    traffic: Mooncake agentic trace, 64K median ISL / 400 median OSL, 90% KV cache hit, concurrency 20
+    sla: user_tps P50 >= 50 and TTFT P50 <= 5000 ms
+  deploy:
+    asset: recipes/inkling/vllm/agg-gb300-agentic/deploy.yaml
+  benchmark:
+    tool: aiperf
+    asset: recipes/inkling/perf/perf.yaml
+  expected_performance:
+    available: true
+    summary: 192.41 tok/s/GPU, 84.87 user tok/s P50 at concurrency 20 over 2 TP4 replicas (3,541-request agentic trace)
+- id: disagg-gb300-agentic
+  recommended: false
+  hardware:
+    gpu: GB300
+    count: 8
+  runtime:
+    framework: vLLM
+  topology: disaggregated
+  techniques:
+  - 1p1d
+  - tp4-per-role
+  - mtp-spec-dec
+  - kv-aware-routing
+  - prefix-caching
+  - 1m-context
+  - pd-kv-transfer
+  - mnnvl-compute-domain
+  workload:
+    type: agentic-trace-replay
+    traffic: Mooncake agentic trace, 64K median ISL / 400 median OSL, 90% KV cache hit, concurrency 16
+    sla: user_tps P50 >= 50 and TTFT P50 <= 5000 ms
+  deploy:
+    asset: recipes/inkling/vllm/disagg-gb300-agentic/deploy-generic.yaml
+  benchmark:
+    tool: aiperf
+    asset: recipes/inkling/perf/perf.yaml
+  expected_performance:
+    available: true
+    summary: 144.01 tok/s/GPU, 77.94 user tok/s P50, TTFT P50 1305 ms at concurrency 16 over 4P + 4D (3,541-request agentic trace), measured on the aws-roce fabric variant
 - id: agg-b200
   recommended: true
   hardware:
@@ -44,10 +99,11 @@ targets:
 related_benchmarks: []
 maintainer: null
 gaps:
-- no perf.yaml / benchmark reproduction path in source (day-0 deploy only)
-- no expected-performance numbers published
 - no related Feature Benchmark page exists for this model
-- runtime is a Day-0 dev image (sglang-runtime:1.4.0-inkling-dev.1, custom SGLang build) pending upstream merge
-- AAC/.m4a audio decode absent from the runtime image (royalty-bearing codec removal); noted on page
-- provider logo sourced from thinkingmachines.ai site icon; formal brand-asset provenance pass pending (same debt as the other provider logos)
+- SGLang runtime is a Day-0 dev image (sglang-runtime:1.4.0-inkling-dev.1, custom SGLang
+  build) pending upstream merge; no expected-performance numbers published for it
+- AAC/.m4a audio decode absent from the SGLang runtime image (royalty-bearing codec
+  removal); noted on page
+- provider logo sourced from thinkingmachines.ai site icon; formal brand-asset provenance
+  pass pending (same debt as the other provider logos)
 - maintainer unknown

--- a/docs/fern/pages/recipes/_catalog/recipes/inkling.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/inkling.yaml
@@ -13,12 +13,16 @@ status: experimental
 artifacts:
   recipe_specific_images:
   - nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0-inkling-dev.1
+  - nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-inkling-dev.1
   recipe_specific_image_periods:
   - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0-inkling-dev.1
     source_revision: 73aa2073d12c8cbd5c955f618aed251be920b8cd
     source_kind: github-release
     release_tag: v1.4.0-inkling-dev.1
     release_state: prerelease
+  - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-inkling-dev.1
+    source_revision: 5e75161371dbca94ad878b7fee2904c0715d308b
+    source_kind: deploy-asset
 targets:
 - id: agg-gb300-agentic
   recommended: true

--- a/docs/fern/pages/recipes/model-recipes/inkling-nvfp4.mdx
+++ b/docs/fern/pages/recipes/model-recipes/inkling-nvfp4.mdx
@@ -2,31 +2,83 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Inkling NVFP4"
-subtitle: "Day-0 SGLang recipe for Thinking Machines' Inkling on 8x B200."
+subtitle: "Serve Thinking Machines' Inkling on GB300 with vLLM for long-context agentic workloads, or on B200 with SGLang for multimodal input."
 ---
 
 import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-Day-0 aggregated SGLang deployment for `thinkingmachines/Inkling-NVFP4` — the NVFP4-quantized checkpoint of Thinking Machines Lab's first open-weights model, a Mixture-of-Experts that reasons natively over text, image, and audio input with controllable reasoning effort. One TP8 worker on 8x B200 with EAGLE speculative decoding, FA4 attention, and the Inkling reasoning and tool-call parsers wired end to end.
+Deployments for `thinkingmachines/Inkling-NVFP4` — the NVFP4-quantized checkpoint of Thinking Machines Lab's first open-weights model, a Mixture-of-Experts that reasons natively with controllable reasoning effort. Two stacks, aimed at different jobs. **GB300 with vLLM** targets an agentic workload (64K median ISL, 400 median OSL, 90% KV cache hit) at 1M context with MTP speculative decoding and KV-aware routing, aggregated or disaggregated. **B200 with SGLang** is the day-0 profile and the only one that serves image and audio input. Pick your target; every command on this page updates to match.
 
-<div className="dynamo-target-picker static">
-<p className="dynamo-target-picker-title">Deployment target</p>
-<div className="dynamo-target-picker-summary">
+<div className="dynamo-target-picker">
+<p className="dynamo-target-picker-title">Choose your deployment target</p>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">GPU</span>
+<input type="radio" id="recipe-sku-gb300" name="recipe-sku" value="gb300" defaultChecked />
+<label htmlFor="recipe-sku-gb300">GB300 · vLLM</label>
+<input type="radio" id="recipe-sku-b200" name="recipe-sku" value="b200" />
+<label htmlFor="recipe-sku-b200">B200 · SGLang</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Topology</span>
+<input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" defaultChecked />
+<label htmlFor="recipe-variant-agg">Aggregated <span className="dynamo-target-picker-hint">Recommended</span></label>
+<input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" />
+<label htmlFor="recipe-variant-disagg">Disaggregated</label>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="gb300" data-variant="agg">
 <span><b>Checkpoint</b> thinkingmachines/Inkling-NVFP4 (~592 GB)</span>
-<span><b>Precision</b> NVFP4 (modelopt_fp4)</span>
+<span><b>Precision</b> NVFP4 (`modelopt_fp4`)</span>
+<span><b>GPUs</b> 4x GB300 per replica, `replicas: 2` (8x)</span>
+<span><b>Parallelism</b> TP4</span>
+<span><b>Context</b> 1,048,576</span>
+<span><b>Spec decode</b> MTP, 8 draft tokens</span>
+<span><b>Routing</b> KV-aware</span>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="gb300" data-variant="disagg">
+<span><b>Checkpoint</b> thinkingmachines/Inkling-NVFP4 (~592 GB)</span>
+<span><b>Precision</b> NVFP4 (`modelopt_fp4`)</span>
+<span><b>GPUs</b> 4x GB300 prefill + 4x GB300 decode</span>
+<span><b>Parallelism</b> TP4 per worker</span>
+<span><b>Context</b> 1,048,576</span>
+<span><b>Spec decode</b> MTP, 8 draft tokens</span>
+<span><b>Routing</b> KV-aware, NIXL over MNNVL or RDMA</span>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="agg">
+<span><b>Checkpoint</b> thinkingmachines/Inkling-NVFP4 (~592 GB)</span>
+<span><b>Precision</b> NVFP4 (`modelopt_fp4`)</span>
 <span><b>GPUs</b> 8x B200, one TP8 worker</span>
-<span><b>Techniques</b> Aggregated serving, EAGLE speculative decoding, FA4 attention, Mamba radix cache</span>
+<span><b>Techniques</b> EAGLE speculative decoding, FA4 attention, Mamba radix cache</span>
 <span><b>Modalities</b> Text + image + audio input, text output</span>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="b200" data-variant="disagg">
+<span><b>Not available</b> The SGLang B200 profile is aggregated only. Select GB300 for a disaggregated deployment.</span>
 </div>
 </div>
 
 ## Prerequisites
 
+<div data-sku="gb300">
+
+- A Kubernetes cluster with the Dynamo platform installed and **8x GB300** available — see the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
+- A Hugging Face token (the model is public, but a token avoids rate limits).
+
+</div>
+
+<div data-sku="b200">
+
 - A Kubernetes cluster with the Dynamo platform installed and **8x B200** available on one node — see the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - An image pull secret with access to the runtime image registry.
 - A Hugging Face token (the model is public, but a token avoids rate limits).
+
+</div>
+
+<div data-sku="gb300" data-variant="disagg">
+
+- The NVIDIA DRA driver installed cluster-wide, so the recipe's `ComputeDomain` can allocate an MNNVL channel to each worker. Both variants use Dynamic Resource Allocation; the `aws-roce` variant also declares a `resource.k8s.io/v1` `ResourceClaimTemplate` and so needs Kubernetes 1.34 or later.
+
+</div>
 
 Create the namespace and secrets:
 
@@ -34,16 +86,22 @@ Create the namespace and secrets:
 export NAMESPACE=your-namespace
 kubectl create namespace ${NAMESPACE}
 
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="your-token" \
+  -n ${NAMESPACE}
+```
+
+<div data-sku="b200">
+
+```bash
 kubectl create secret docker-registry nvcr-imagepullsecret \
   --docker-server=nvcr.io \
   --docker-username='$oauthtoken' \
   --docker-password="your-ngc-api-key" \
   -n ${NAMESPACE}
-
-kubectl create secret generic hf-token-secret \
-  --from-literal=HF_TOKEN="your-token" \
-  -n ${NAMESPACE}
 ```
+
+</div>
 
 <Warning>
 Update `storageClassName` in `model-cache/model-cache.yaml` to match your cluster (`kubectl get storageclass`) before applying. The checkpoint is ~592 GB — the download job can take a while. On clusters that already provide a shared RWX PVC, skip the cache step and replace the `model-cache` claim name in the manifests with the shared PVC name.
@@ -62,17 +120,70 @@ kubectl wait --for=condition=Complete job/inkling-model-download -n ${NAMESPACE}
 
 Then deploy:
 
+<div data-sku="gb300" data-variant="agg">
+
+```bash
+kubectl apply -f recipes/inkling/vllm/agg-gb300-agentic/deploy.yaml -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="gb300" data-variant="disagg">
+
+The disaggregated profile ships as Kustomize variants, because the fabric that carries KV from prefill to decode is a cluster property. The `generic` variant moves KV over MNNVL `cuda_ipc` inside the ComputeDomain and carries the NIXL control plane over TCP. The `aws-roce` variant adds a RoCE device claim on clusters that expose one through Dynamic Resource Allocation:
+
+```bash
+kubectl apply -f recipes/inkling/vllm/disagg-gb300-agentic/deploy-generic.yaml -n ${NAMESPACE}
+```
+
+```bash
+# On EKS, where the roce.networking.k8s.aws device class is available:
+kubectl apply -f recipes/inkling/vllm/disagg-gb300-agentic/deploy-aws-roce.yaml -n ${NAMESPACE}
+```
+
+To compose a different fabric, apply the checked-in overlay and add your own Component rather than editing the rendered manifest:
+
+```bash
+kubectl apply -k recipes/inkling/vllm/disagg-gb300-agentic/kustomize/overlays/generic -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="b200" data-variant="agg">
+
 ```bash
 kubectl apply -f recipes/inkling/sglang/agg-b200/deploy.yaml -n ${NAMESPACE}
 ```
 
+</div>
+
 ## Smoke Test
 
-Inkling accepts text, image, and audio input in a single OpenAI-compatible API. First, forward the frontend port:
+Forward the frontend port:
+
+<div data-sku="gb300" data-variant="agg">
+
+```bash
+kubectl port-forward svc/inkling-vllm-gb300-agg-agentic-frontend 8000:8000 -n ${NAMESPACE} &
+```
+
+</div>
+
+<div data-sku="gb300" data-variant="disagg">
+
+```bash
+kubectl port-forward svc/inkling-vllm-gb300-disagg-agentic-frontend 8000:8000 -n ${NAMESPACE} &
+```
+
+</div>
+
+<div data-sku="b200" data-variant="agg">
 
 ```bash
 kubectl port-forward svc/tml-inkling-sglang-agg-frontend 8000:8000 -n ${NAMESPACE} &
 ```
+
+</div>
 
 ### Text
 
@@ -82,9 +193,28 @@ curl -s http://localhost:8000/v1/chat/completions \
   -d '{
     "model": "thinkingmachines/Inkling-NVFP4",
     "messages": [{"role": "user", "content": "Hello, who are you?"}],
-    "max_tokens": 64
+    "max_tokens": 1500
   }'
 ```
+
+Inkling reasons before answering, so a small `max_tokens` is spent entirely on reasoning and returns empty `content` with `finish_reason: "length"`. The answer may also land in `reasoning_content` rather than `content`.
+
+### Reasoning effort
+
+Inkling's controllable thinking is exposed per request: pass `reasoning_effort` as a named level (`none` / `minimal` / `low` / `medium` / `high` / `max`) or a float in `[0.0, 0.99]`; omitted requests default to `0.9` (high). These are the values in this checkpoint's chat template — `xhigh` from the launch blog is not in its map and is rejected:
+
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "thinkingmachines/Inkling-NVFP4",
+    "messages": [{"role": "user", "content": "What is 17 times 24?"}],
+    "chat_template_kwargs": {"reasoning_effort": "low"},
+    "max_tokens": 128
+  }'
+```
+
+<div data-sku="b200">
 
 ### Image
 
@@ -128,22 +258,42 @@ curl -s http://localhost:8000/v1/chat/completions \
 
 For air-gapped clusters, send local files as `data:` URIs instead. Encode to a single line first (`base64` wraps output by default, which breaks the JSON payload): `AUDIO_B64=$(base64 < sample.wav | tr -d '\n')`, then `{"type": "audio_url", "audio_url": {"url": "data:audio/wav;base64,'"${AUDIO_B64}"'"}}`. Multiple media parts can ride in one message as the context budget allows.
 
-### Reasoning effort
+</div>
 
-Inkling's controllable thinking is exposed per request: pass `reasoning_effort` as a named level (`none` / `minimal` / `low` / `medium` / `high` / `max`) or a float in `[0.0, 0.99]`; omitted requests default to `0.9` (high). These are the values in this checkpoint's chat template — `xhigh` from the launch blog is not in its map and is rejected:
+<div data-sku="gb300">
 
-```bash
-curl -s http://localhost:8000/v1/chat/completions \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "thinkingmachines/Inkling-NVFP4",
-    "messages": [{"role": "user", "content": "What is 17 times 24?"}],
-    "chat_template_kwargs": {"reasoning_effort": "low"},
-    "max_tokens": 128
-  }'
-```
+## Performance
+
+Measured with the [AIPerf](https://github.com/ai-dynamo/aiperf) trace-replay Job in [`recipes/inkling/perf`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/inkling/perf/README.md), replaying a 3,541-request agentic trace against the SLO pair `user_tps p50 >= 50` and `TTFT p50 <= 5000 ms`. Both topologies clear both gates.
+
+| Topology | GPUs | Concurrency | tok/s/GPU | user_tps p50 | TTFT p50 |
+| --- | --- | --- | --- | --- | --- |
+| Aggregated | 8 (2x TP4) | 20 | 192.41 | 84.87 | 361 ms |
+| Disaggregated | 8 (4P + 4D) | 16 | 144.01 | 77.94 | 1305 ms |
+
+Measured on the `aws-roce` fabric variant.
+
+<Note>
+Aggregated outperformed every disaggregated split tested on this workload. Prefill is only about 5% of the GPU-time budget here, so dedicating half the fleet to it costs more per-GPU throughput than the prefill/decode separation returns. Choose the disaggregated profile when you need to scale prefill and decode independently, not for throughput on this trace.
+</Note>
+
+</div>
 
 ## Notes
+
+<div data-sku="gb300">
+
+- Image and audio input are not supported: the Dynamo vLLM runtime has no multimodal support for this model yet, so these profiles are text-only. Use the B200 SGLang profile for image and audio. Do not set `--enable-multimodal` to work around it — the flag only lifts the request rejection, so media is still never encoded and requests return HTTP 200 with an answer invented from the text prompt alone.
+- Some OpenAI API fields are rejected rather than silently ignored, each with a message naming the reason. `min_p` and `logit_bias` return 400 — unsupported with speculative decoding, and these profiles run MTP 8; remove `--speculative-config` to use them. `logprobs` and `top_logprobs` return 400, not implemented on the Dynamo vLLM chat processor. The Responses API is stateless: `previous_response_id` returns 501, `GET /v1/responses/{id}` returns 404, and `store: true` is echoed back but not persisted.
+- Inkling reasons before answering, so a low `max_tokens` can be spent entirely on reasoning, returning empty `content` with `finish_reason: "length"`. Allow roughly 1500, and read the answer from `content`, `reasoning_content`, or `reasoning`.
+- `--kv-cache-memory-bytes` is required. Sizing the KV cache from `--gpu-memory-utilization` alone leaves too little headroom at 1M context and OOMs during CUDA graph capture. The value is measured for 288 GB GB300; re-measure it if you change the context length or GPU.
+- `--max-model-len 1048576` keeps the model's full 1M context available. Lowering it frees KV headroom if you do not need it.
+- Reasoning and tool calling use the model's dedicated parsers, wired in both the frontend and the worker (`--reasoning-parser inkling --tool-call-parser inkling`).
+- MTP speculative decoding runs at 8 draft tokens on both topologies. Remove `--speculative-config` to run without it.
+
+</div>
+
+<div data-sku="b200">
 
 - This is a Day-0 recipe on a dedicated dev runtime image (`sglang-runtime:1.4.0-inkling-dev.1`, a custom SGLang build carrying the Inkling model support); it is functional but not yet promoted to a release runtime image, and no benchmark results are published yet.
 - Audio input: the model card specifies WAV sampled at 16 kHz, ideally under 20 minutes. The runtime image ships without royalty-bearing media codecs — AAC/`.m4a` decode is not included; other common formats (WAV, FLAC, OGG/Opus, MP3) decode via `libsndfile`. Image input is unaffected.
@@ -153,9 +303,14 @@ curl -s http://localhost:8000/v1/chat/completions \
 - The manifest sets `DYN_FORWARDPASS_METRIC_PORT` to an empty value — a deliberate workaround that keeps forward-pass metrics off, because this rc image crashes on EAGLE batches when they are enabled. Keep it (and don't set that variable) until a fixed image ships.
 - The worker enables the Mamba radix cache (`extra_buffer` strategy) and FlashInfer TRT-LLM GEMM/MoE backends; these flags are part of the validated configuration — change them only deliberately.
 
+</div>
+
 ## Source
 
 - Source README: [recipes/inkling/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/inkling/README.md)
+- vLLM aggregated GB300: [deploy.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/inkling/vllm/agg-gb300-agentic/deploy.yaml)
+- vLLM disaggregated GB300: [deploy-generic.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/inkling/vllm/disagg-gb300-agentic/deploy-generic.yaml) and [deploy-aws-roce.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/inkling/vllm/disagg-gb300-agentic/deploy-aws-roce.yaml)
 - SGLang aggregated B200: [deploy.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/inkling/sglang/agg-b200/deploy.yaml)
+- Benchmark: [recipes/inkling/perf](https://github.com/ai-dynamo/dynamo/blob/main/recipes/inkling/perf/README.md)
 - Setup assets: [model-cache.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/inkling/model-cache/model-cache.yaml) and [model-download.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/inkling/model-cache/model-download.yaml)
 - Model announcement: [Inkling — Thinking Machines Lab](https://thinkingmachines.ai/news/introducing-inkling/)

--- a/docs/fern/pages/recipes/model-recipes/overview.mdx
+++ b/docs/fern/pages/recipes/model-recipes/overview.mdx
@@ -37,11 +37,11 @@ Start with the model, runtime, and hardware you need to run. Model cards are sor
   <div className="dynamo-recipe-browser-header">
     <div>
       <p className="dynamo-recipe-eyebrow">Recipe catalog</p>
-      <h3>16 model families</h3>
+      <h3>17 model families</h3>
       <p>Filter by provider, runtime, and hardware. Each card notes its serving technique and workload shape.</p>
     </div>
     <div className="dynamo-catalog-facts">
-      <strong>84</strong>
+      <strong>97</strong>
       <span>Deployable configurations</span>
       <button className="dynamo-filter-reset" type="reset">Reset filters</button>
     </div>
@@ -69,6 +69,15 @@ Start with the model, runtime, and hardware you need to run. Model cards are sor
 </div>
 
 <div className="dynamo-model-grid" data-recipe-card-grid>
+  <div className="dynamo-model-card" data-recipe-card data-provider="zai" data-runtime="vllm" data-hardware="gb200 h200" data-technique="aggregated disaggregated kv-routing spec-decoding" data-workload="agentic-coding long-context-reuse">
+    <div className="dynamo-model-card-top">
+      <img className="dynamo-model-logo" src="../../../assets/img/recipes/providers/zai-org.svg" alt="" />
+      <div><h3>GLM-5.3-Flash</h3><p>Z.AI</p></div>
+    </div>
+    <p className="dynamo-model-summary">vLLM recipes for agentic traffic on GB200 or H200, aggregated or 1P1D disaggregated with KV-aware routing, NIXL KV transfer, and H200 MTP7.</p>
+    <div className="dynamo-model-tags"><span>vLLM</span><span>4x/8x GB200 · 8x/16x H200</span><span>Agentic · up to 1M context</span></div>
+  <a className="dynamo-card-link" href="glm-5-3-flash.mdx" aria-label="Open the GLM-5.3-Flash recipe">Open recipe</a>
+  </div>
   <div className="dynamo-model-card" data-recipe-card data-provider="moonshot" data-runtime="vllm" data-hardware="gb200 gb300" data-technique="aggregated disaggregated kv-routing" data-workload="agentic-coding">
     <div className="dynamo-model-card-top">
       <img className="dynamo-model-logo" src="../../../assets/img/recipes/providers/moonshotai.webp" alt="" />
@@ -78,22 +87,31 @@ Start with the model, runtime, and hardware you need to run. Model cards are sor
     <div className="dynamo-model-tags"><span>vLLM</span><span>GB200 · GB300</span><span>Day-0</span></div>
   <a className="dynamo-card-link" href="kimi-k3.mdx" aria-label="Open the Kimi-K3 recipe">Open recipe</a>
   </div>
+  <div className="dynamo-model-card" data-recipe-card data-provider="qwen" data-runtime="vllm sglang" data-hardware="gb200 gb300" data-technique="aggregated disaggregated kv-routing spec-decoding" data-workload="agentic-coding long-context-reuse">
+    <div className="dynamo-model-card-top">
+      <img className="dynamo-model-logo" src="../../../assets/img/recipes/providers/qwen.webp" alt="" />
+      <div><h3>Qwen3.8-2.4T-A95B</h3><p>Qwen</p></div>
+    </div>
+    <p className="dynamo-model-summary">vLLM and SGLang recipes for chat and agentic traffic on GB300 or GB200, aggregated or disaggregated, with KV-aware routing, MTP speculation, and FP8 weights/KV over MNNVL.</p>
+    <div className="dynamo-model-tags"><span>vLLM + SGLang</span><span>16x GB300 · 16x GB200</span><span>Chat + agentic · 262K context</span></div>
+  <a className="dynamo-card-link" href="qwen-3-8-2-4t-a95b-fp8.mdx" aria-label="Open the Qwen3.8-2.4T-A95B recipe">Open recipe</a>
+  </div>
   <div className="dynamo-model-card" data-recipe-card data-provider="zai" data-runtime="sglang" data-hardware="b200 h200" data-technique="aggregated disaggregated kv-routing spec-decoding" data-workload="agentic-coding long-context-reuse">
     <div className="dynamo-model-card-top">
       <img className="dynamo-model-logo" src="../../../assets/img/recipes/providers/zai-org.svg" alt="" />
-      <div><h3>GLM-5.2</h3><p>Z.AI / NVIDIA</p></div>
+      <div><h3>GLM-5.3/5.2</h3><p>Z.AI / NVIDIA</p></div>
     </div>
     <p className="dynamo-model-summary">SGLang recipes for long-context agentic traffic on B200 (NVFP4) or H200 (FP8), aggregated or disaggregated, with KV-aware routing, EAGLE MTP speculation, and HiCache CPU offload.</p>
     <div className="dynamo-model-tags"><span>SGLang</span><span>4x/12x B200 · 8x/16x H200</span><span>Agentic · up to 500K context</span></div>
-  <a className="dynamo-card-link" href="glm-5-2.mdx" aria-label="Open the GLM-5.2 recipe">Open recipe</a>
+  <a className="dynamo-card-link" href="glm-5-2.mdx" aria-label="Open the GLM-5.3/5.2 recipe">Open recipe</a>
   </div>
-  <div className="dynamo-model-card" data-recipe-card data-provider="thinkingmachines" data-runtime="sglang" data-hardware="b200" data-technique="aggregated spec-decoding" data-workload="multimodal-reuse">
+  <div className="dynamo-model-card" data-recipe-card data-provider="thinkingmachines" data-runtime="sglang vllm" data-hardware="b200 gb300" data-technique="aggregated disaggregated kv-routing spec-decoding" data-workload="agentic-coding long-context-reuse multimodal-reuse">
     <div className="dynamo-model-card-top">
       <img className="dynamo-model-logo" src="../../../assets/img/recipes/providers/thinkingmachines.png" alt="" />
       <div><h3>Inkling NVFP4</h3><p>Thinking Machines</p></div>
     </div>
-    <p className="dynamo-model-summary">Day-0 aggregated SGLang recipe for Thinking Machines' first open-weights model — multimodal MoE with controllable reasoning effort, TP8 with EAGLE speculation.</p>
-    <div className="dynamo-model-tags"><span>SGLang</span><span>8x B200</span><span>Text + image + audio</span><span>Day-0</span></div>
+    <p className="dynamo-model-summary">Thinking Machines' first open-weights model — a multimodal MoE with controllable reasoning effort. vLLM GB300 targets serve agentic traffic at 1M context with MTP speculation and KV-aware routing, aggregated or disaggregated; the Day-0 SGLang B200 target adds image and audio input.</p>
+    <div className="dynamo-model-tags"><span>vLLM · SGLang</span><span>8x GB300 / 8x B200</span><span>Agentic · 1M context</span><span>Text + image + audio</span></div>
   <a className="dynamo-card-link" href="inkling-nvfp4.mdx" aria-label="Open the Inkling NVFP4 recipe">Open recipe</a>
   </div>
   <div className="dynamo-model-card" data-recipe-card data-provider="moonshot" data-runtime="vllm" data-hardware="b200 h200" data-technique="aggregated kv-routing spec-decoding" data-workload="agentic-coding long-context-reuse">

--- a/recipes/AGENTS.md
+++ b/recipes/AGENTS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 
@@ -9,18 +9,32 @@ SPDX-License-Identifier: Apache-2.0
   `deploy-<name>.yaml`; an `overlays/generic/` variant renders when it exists.
   Shared Components selected by multiple recipes live under
   `recipes/kustomize/components/`; that directory has no base or overlays and
-  never renders by itself. Prefer resource-shaped Kustomize merge patches over
-  JSON patches where possible. Bases that patch Dynamo CRDs include the central
+  never renders by itself. The copy-and-fill beta cluster scaffold lives under
+  `recipes/templates/kustomize/`; it uses guarded JSON 6902 patches against
+  canonical `nvidia.com/v1beta1` component positions, requires standalone
+  Kustomize v5.8.1, and does not include the central OpenAPI Component. Keep
+  filled site values outside the repository. Portable templates omit
+  credential Secret references and probe structs. They use the canonical
+  `shared-model-cache` bundle, exec-form runtime commands, and
+  `imagePullPolicy: IfNotPresent`. Every beta component sets both offline
+  environment variables; beta Frontends do not mount the cache, and beta
+  backend workers run as UID/GID 0 with `IPC_LOCK`, `SYS_PTRACE`, and
+  `SYS_RESOURCE`. The scaffold's optional `probes` Component owns complete
+  worker startup-probe overrides. Place it after registry credentials and
+  before scheduling. In the legacy alpha matrix path, prefer
+  resource-shaped Kustomize merge patches where possible. Legacy bases
+  that use strategic merge against Dynamo CRDs include the central
   `recipes/kustomize/components/dynamo-openapi/` Component; its schema is
   generated from every operator CRD. The central
   `recipes/kustomize/components/disagg-workers/` Components require one DGD per
   base with backend-neutral `PrefillWorker` and `DecodeWorker` service keys.
   A recipe matrix at `.kustomize-matrix.yaml` has an explicit `source`, a
-  `nameTemplate`, and a `matrix` mapping whose values contain a `name` and a
-  `components` list. The matrix, recipe-local base and Components, and shared
-  Components are source. A dimension value may also select `templates` and set
-  `values`. Each template selection has a source relative to the matrix and a
-  generated `path` under the overlay's `components/` directory. Generated paths
+  `nameTemplate`, and a `matrix` mapping whose values contain a `name` and may
+  provide `components`, `templates`, `values`, and `sortOptions`. The matrix,
+  recipe-local base and Components, and shared Components are source.
+  `sortOptions` orders the resources in that value's generated overlay. Each
+  template selection has a source relative to the matrix and a generated `path`
+  under the overlay's `components/` directory. Generated paths
   selected by one variant must be unique and non-overlapping. Shared
   template sources live in `recipes/kustomize/templates/`. A selected template
   directory extends the direct `*.yaml` and `*.yaml.j2` files in its parent

--- a/recipes/CONTRIBUTING.md
+++ b/recipes/CONTRIBUTING.md
@@ -143,6 +143,28 @@ matrix:
         EFAS_PER_GPU: 4
 ```
 
+A matrix value may also set `sortOptions`. Kustomize reads sort options from the
+kustomization it builds, so a base cannot set them. Only the generated overlay
+can. Set the key on the variant that needs an order, not on the matrix, so the
+other variants keep the default `order: fifo`. Use it when apply order matters,
+for example to emit a `ResourceClaimTemplate` before the resource that claims it:
+
+```yaml
+matrix:
+  variant:
+    - name: aws-roce
+      sortOptions:
+        order: legacy
+        legacySortOptions:
+          orderFirst: [ResourceClaimTemplate, ComputeDomain]
+          orderLast: []
+```
+
+> [!NOTE]
+> An explicit `orderFirst` replaces Kustomize's default legacy list. Kinds that
+> you do not name then sort by `ResId`, so `Namespace` loses its usual first
+> slot. Name every kind whose order matters.
+
 A template selection names a source directory relative to the matrix and an
 output `path` relative to the generated overlay. The output path must be under
 `components/`; `path: components/efa` produces a normal local Component at

--- a/recipes/inkling/README.md
+++ b/recipes/inkling/README.md
@@ -25,16 +25,41 @@ Dynamo + SGLang deployment profile:
 | **Mamba radix cache**    | extra_buffer strategy                 |
 | **Speculative decoding** | EAGLE multi-layer (8 steps, topk 1, 9 draft tokens, rejection sampling) |
 
+Dynamo + vLLM deployment profiles, tuned for an agentic workload (64K median
+ISL, 400 median OSL, 90% KV cache hit):
+
+|                          | GB300 aggregated                | GB300 disaggregated             |
+|--------------------------|---------------------------------|---------------------------------|
+| **GPU**                  | 8x GB300 (2 replicas x TP4)     | 8x GB300 (1 prefill + 1 decode, TP4 each) |
+| **Mode**                 | aggregated                      | disaggregated prefill/decode    |
+| **Framework**            | vLLM                            | vLLM                            |
+| **Precision**            | NVFP4 (ModelOpt), BF16 KV       | NVFP4 (ModelOpt), BF16 KV       |
+| **Parallelism**          | TP4                             | TP4 per worker                  |
+| **MoE runner backend**   | auto: FLASHINFER_TRTLLM (routed) + FlashInfer CUTLASS (shared) | auto: FLASHINFER_TRTLLM (routed) + FlashInfer CUTLASS (shared) |
+| **AllReduce backend**    | vLLM default                    | FlashInfer (MNNVL)              |
+| **Context length**       | 1,048,576                       | 1,048,576                       |
+| **Speculative decoding** | MTP, 8 draft tokens             | MTP, 8 draft tokens             |
+| **Routing**              | KV-aware                        | KV-aware                        |
+| **KV transfer**          | n/a                             | NIXL over MNNVL, or RDMA where available |
+
+Inkling excludes the shared experts from NVFP4 quantization, so the two expert
+groups resolve their backend on their own. `--moe-backend` is global. Pinning it
+would also override the choice for the shared experts, which no published number
+covers.
+
 ## Supported features
 
-- Modalities: Text, image, and audio input
-- Reasoning (`inkling` reasoning parser)
-- Tool calling (`inkling` tool-call parser)
+- Reasoning (`inkling` reasoning parser) — all profiles
+- Tool calling (`inkling` tool-call parser) — all profiles
+- Modalities: text, image, and audio input — **SGLang B200 only**. The Dynamo
+  vLLM runtime does not support multimodal input yet, so the vLLM GB300
+  profiles are text-only.
 
 ## Prerequisites
 
 1. **Dynamo Platform installed** — see [Kubernetes Deployment Guide](../../docs/fern/pages/kubernetes/getting-started/quickstart.mdx).
-2. **Image pull secret** with access to `nvcr.io/nvstaging/nim` (staging registry):
+2. **Image pull secret** — SGLang B200 profile only, for access to
+   `nvcr.io/nvstaging/nim` (staging registry):
    ```bash
    export NAMESPACE=your-namespace
    kubectl create secret docker-registry nvcr-imagepullsecret \
@@ -62,7 +87,7 @@ kubectl create namespace ${NAMESPACE}
 ### 2. Create Storage
 
 > [!NOTE]
-> Edit `model-cache/model-cache.yaml` first and update `storageClassName` to match your cluster (`kubectl get storageclass`). On clusters that already provide a shared RWX PVC (e.g. `shared-model-cache` on the Dynamo dev clusters), skip this step and replace the `model-cache` claim name in three places: `model-cache/model-download.yaml` (`.spec.template.spec.volumes[0].persistentVolumeClaim.claimName`) and `sglang/agg-b200/deploy.yaml` (both the Frontend and decode component volumes).
+> Edit `model-cache/model-cache.yaml` first and update `storageClassName` to match your cluster (`kubectl get storageclass`). On clusters that already provide a shared RWX PVC (e.g. `shared-model-cache` on the Dynamo dev clusters), skip this step and replace the `model-cache` claim name in `model-cache/model-download.yaml` (`.spec.template.spec.volumes[0].persistentVolumeClaim.claimName`) and in every `persistentVolumeClaim.claimName` of the profile you deploy. For the Kustomize-based disaggregated profile, change it in `vllm/disagg-gb300-agentic/kustomize/base/deploy.yaml` and re-render, rather than editing `deploy-*.yaml`.
 
 ```bash
 kubectl apply -f model-cache/model-cache.yaml -n ${NAMESPACE}
@@ -79,15 +104,50 @@ kubectl wait --for=condition=Complete job/inkling-model-download -n ${NAMESPACE}
 
 ### 4. Deploy the DynamoGraphDeployment
 
+Pick one profile, then apply it:
+
+| Profile | `DEPLOY` |
+| --- | --- |
+| SGLang, aggregated, B200 | `sglang/agg-b200/deploy.yaml` |
+| vLLM, aggregated, GB300 | `vllm/agg-gb300-agentic/deploy.yaml` |
+| vLLM, disaggregated, GB300 | `vllm/disagg-gb300-agentic/deploy-generic.yaml` |
+| vLLM, disaggregated, GB300, RoCE via DRA | `vllm/disagg-gb300-agentic/deploy-aws-roce.yaml` |
+
 ```bash
-kubectl apply -f sglang/agg-b200/deploy.yaml -n ${NAMESPACE}
+export DEPLOY=vllm/agg-gb300-agentic/deploy.yaml
+kubectl apply -f ${DEPLOY} -n ${NAMESPACE}
 ```
+
+Both disaggregated profiles use Dynamic Resource Allocation, so they need the
+NVIDIA DRA driver (for `ComputeDomain`) installed cluster-wide and a cluster that
+serves the DRA APIs. `deploy-aws-roce.yaml` additionally declares a
+`resource.k8s.io/v1` `ResourceClaimTemplate`, which requires **Kubernetes 1.34 or
+later**, and a cluster exposing the `roce.networking.k8s.aws` device class;
+`deploy-generic.yaml` moves KV over MNNVL `cuda_ipc` instead. To compose a
+different fabric, apply the overlay instead:
+`kubectl apply -k vllm/disagg-gb300-agentic/kustomize/overlays/generic`.
+
+To benchmark a deployment, see [`perf/README.md`](perf/README.md).
 
 ### 5. Smoke Test
 
+Forward the frontend of the profile you deployed — the Service is the DGD name
+with a `-frontend` suffix:
+
 ```bash
-kubectl port-forward svc/tml-inkling-sglang-agg-frontend 8000:8000 -n ${NAMESPACE} &
+export FRONTEND=inkling-vllm-gb300-agg-agentic-frontend
+kubectl port-forward svc/${FRONTEND} 8000:8000 -n ${NAMESPACE} &
 ```
+
+| Profile | Service |
+| --- | --- |
+| SGLang, aggregated, B200 | `tml-inkling-sglang-agg-frontend` |
+| vLLM, aggregated, GB300 | `inkling-vllm-gb300-agg-agentic-frontend` |
+| vLLM, disaggregated, GB300 | `inkling-vllm-gb300-disagg-agentic-frontend` |
+
+Every profile serves the model as `thinkingmachines/Inkling-NVFP4`, so the
+requests below are identical across them. Image and audio need the SGLang B200
+profile.
 
 #### Text
 
@@ -97,9 +157,18 @@ curl -s http://localhost:8000/v1/chat/completions \
   -d '{
     "model": "thinkingmachines/Inkling-NVFP4",
     "messages": [{"role": "user", "content": "Hello, who are you?"}],
-    "max_tokens": 128
+    "max_tokens": 1500
   }'
 ```
+
+Inkling reasons before answering, so a small `max_tokens` is spent entirely on reasoning and
+returns empty `content` with `finish_reason: "length"`. The answer may also land in
+`reasoning_content` rather than `content`.
+
+> [!NOTE]
+> The image and audio tests below need the **SGLang B200** profile. On vLLM GB300 they are rejected
+> with `Received multimodal data but multimodal processing is not enabled` — that is expected; see
+> [Known Issues](#known-issues).
 
 #### Image
 
@@ -223,9 +292,17 @@ To tear down the deployment and free cluster resources:
 ```bash
 # Stop the port-forward if it is still running
 pkill -f "kubectl port-forward svc/tml-inkling-sglang-agg-frontend" 2>/dev/null || true
+pkill -f "kubectl port-forward svc/inkling-vllm-gb300-agg-agentic-frontend" 2>/dev/null || true
+pkill -f "kubectl port-forward svc/inkling-vllm-gb300-disagg-agentic-frontend" 2>/dev/null || true
 
-# Delete the deployment (stops all pods)
+# Delete the deployment (stops all pods) -- whichever profile you deployed
 kubectl delete dynamographdeployment tml-inkling-sglang-agg -n ${NAMESPACE} 2>/dev/null || true
+kubectl delete dynamographdeployment inkling-vllm-gb300-agg-agentic -n ${NAMESPACE} 2>/dev/null || true
+kubectl delete dynamographdeployment inkling-vllm-gb300-disagg-agentic -n ${NAMESPACE} 2>/dev/null || true
+
+# Disaggregated only: the ComputeDomain and the RoCE claim template outlive the DGD
+kubectl delete computedomain inkling-vllm-gb300-disagg-agentic-compute-domain -n ${NAMESPACE} 2>/dev/null || true
+kubectl delete resourceclaimtemplate inkling-vllm-gb300-disagg-agentic-roce -n ${NAMESPACE} 2>/dev/null || true
 
 # Delete the model-download job (idempotent — already finished or not yet run)
 kubectl delete job inkling-model-download -n ${NAMESPACE} 2>/dev/null || true
@@ -245,8 +322,58 @@ For a one-shot cleanup run see [`cleanup.sh`](cleanup.sh).
 
 ## Known Issues
 
-1. `deploy.yaml` overrides `DYN_FORWARDPASS_METRIC_PORT` to an empty value. This override is
-   required for MTP/EAGLE speculative decoding with SGLang because the forward-pass metrics reporter
-   (auto-enabled by the operator-injected port) crashes the scheduler on speculative batches
-   (`batch.seq_lens_cpu` is `None`). Only per-forward-pass telemetry is lost. Remove the override
-   once the container image carries a fix.
+### vLLM GB300 profiles
+
+**Disable reasoning with `reasoning_effort: "none"`, not with a zero thinking budget.**
+`nvext.max_thinking_tokens: 0` returns HTTP 200 but no usable answer: the model emits empty
+thinking blocks until it hits `max_tokens` (`finish_reason: "length"`). Inkling's end-of-thinking
+token also ends the message, so a zero budget closes the message on the first token and the cycle
+repeats. `chat_template_kwargs: {"thinking": false}` is not a substitute either — the model still
+reasons, and the reasoning text lands in `content`.
+
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "thinkingmachines/Inkling-NVFP4",
+    "messages": [{"role": "user", "content": "What is 2+2?"}],
+    "reasoning_effort": "none",
+    "max_tokens": 128
+  }'
+```
+
+**Keep both structured-output flags on the worker.** `tool_choice: "required"` and named
+`tool_choice` are enforced through a structural-tag grammar that needs both flags the manifests
+already set:
+
+```
+--dyn-enable-structural-tag
+--structured-outputs-config '{"enable_in_reasoning": true}'
+```
+
+Drop the second and the grammar is silently inert on a reasoning model — HTTP 200, no error, and
+the requested tool is not enforced. Both belong on the worker; the frontend does not accept
+`--dyn-enable-structural-tag`.
+
+**Image and audio input are not supported.** The Dynamo vLLM runtime has no multimodal support for
+this model yet, so the vLLM GB300 profiles are text-only; use the SGLang B200 profile for image and
+audio. Do not set `--enable-multimodal` to work around it — the flag only lifts the request
+rejection, so media is still never encoded and requests return HTTP 200 with an answer invented from
+the text prompt alone.
+
+**Some OpenAI API fields are rejected rather than silently ignored**, each with a message naming
+the reason:
+
+| Request field | Status | Reason |
+| --- | --- | --- |
+| `min_p`, `logit_bias` | 400 | Unsupported with speculative decoding, and these profiles run MTP 8. Remove `--speculative-config` to use them, at a throughput cost. |
+| `logprobs`, `top_logprobs` | 400 | Not implemented on the Dynamo vLLM chat processor. |
+| `previous_response_id` (501), `GET /v1/responses/{id}` (404) | — | The Responses API is stateless here. `store: true` is echoed back but nothing is persisted, so reuse the response from the original `POST`. |
+
+### SGLang B200 profile
+
+`deploy.yaml` overrides `DYN_FORWARDPASS_METRIC_PORT` to an empty value. This override is
+required for MTP/EAGLE speculative decoding with SGLang because the forward-pass metrics reporter
+(auto-enabled by the operator-injected port) crashes the scheduler on speculative batches
+(`batch.seq_lens_cpu` is `None`). Only per-forward-pass telemetry is lost. Remove the override
+once the container image carries a fix.

--- a/recipes/inkling/cleanup.sh
+++ b/recipes/inkling/cleanup.sh
@@ -36,13 +36,30 @@ done
 
 echo "==> Namespace: ${NAMESPACE}"
 
-# Stop any local port-forward for the frontend service
-echo "==> Stopping port-forward (if running)..."
-pkill -f "kubectl port-forward svc/tml-inkling-sglang-agg-frontend" 2>/dev/null || true
+DGDS=(
+  tml-inkling-sglang-agg
+  inkling-vllm-gb300-agg-agentic
+  inkling-vllm-gb300-disagg-agentic
+)
 
-# Delete the DynamoGraphDeployment (cascades to pods and services)
-echo "==> Deleting DynamoGraphDeployment tml-inkling-sglang-agg..."
-kubectl delete dynamographdeployment tml-inkling-sglang-agg \
+# Stop any local port-forward for the frontend services
+echo "==> Stopping port-forwards (if running)..."
+for dgd in "${DGDS[@]}"; do
+  pkill -f "kubectl port-forward svc/${dgd}-frontend" 2>/dev/null || true
+done
+
+# Delete the DynamoGraphDeployments (cascades to pods and services)
+for dgd in "${DGDS[@]}"; do
+  echo "==> Deleting DynamoGraphDeployment ${dgd}..."
+  kubectl delete dynamographdeployment "${dgd}" \
+    -n "${NAMESPACE}" --ignore-not-found=true
+done
+
+# Delete the DRA resources of the disaggregated profile. They outlive the DGD.
+echo "==> Deleting ComputeDomain and ResourceClaimTemplate..."
+kubectl delete computedomain inkling-vllm-gb300-disagg-agentic-compute-domain \
+  -n "${NAMESPACE}" --ignore-not-found=true
+kubectl delete resourceclaimtemplate inkling-vllm-gb300-disagg-agentic-roce \
   -n "${NAMESPACE}" --ignore-not-found=true
 
 # Delete the model-download job

--- a/recipes/inkling/perf/README.md
+++ b/recipes/inkling/perf/README.md
@@ -1,0 +1,176 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Inkling-NVFP4 Benchmark Recipe
+
+A single [AIPerf](https://github.com/ai-dynamo/aiperf) trace-replay Job —
+[`perf.yaml`](perf.yaml) — covers both Inkling vLLM GB300 DGDs. The benchmark is
+identical across variants; `ENDPOINT` and `CONCURRENCY` select the target, and
+the `podAffinity` selector needs the same target when both DGDs are deployed.
+
+The Job waits for the target model on the DGD frontend, runs a short warmup,
+replays the configured trace at one `CONCURRENCY` value, and writes raw
+artifacts to the shared `model-cache` PVC. The benchmark pod is co-located with
+a DGD frontend through `podAffinity`.
+
+## Targeting a variant
+
+Edit the `env` block in [`perf.yaml`](perf.yaml):
+
+| Variant target | `ENDPOINT` | `CONCURRENCY` |
+| --- | --- | --- |
+| GB300 aggregated agentic | `inkling-vllm-gb300-agg-agentic-frontend:8000` | `20` |
+| GB300 disaggregated agentic | `inkling-vllm-gb300-disagg-agentic-frontend:8000` | `16` |
+
+If both DGDs are deployed in the same namespace, also trim the
+`nvidia.com/dynamo-graph-deployment-name` values under `affinity.podAffinity` to
+the target alone. The selector accepts either frontend, so the Job can otherwise
+land beside the one it is not measuring and add a network hop.
+
+If you run more than one benchmark in the same namespace, also update
+`metadata.name` and `labels.app` so Jobs and artifact directories stay
+distinct.
+
+## Dataset
+
+The benchmark replays a
+[Mooncake-format](https://github.com/kvcache-ai/Mooncake) trace through
+`--custom-dataset-type mooncake_trace`. Each JSONL line describes one request
+with `input_length`, `output_length`, `hash_ids`, and `timestamp`.
+
+Use the 3,541-request agentic trace in [`traces`](traces) (Git LFS) — 64K median
+ISL, 400 median OSL, 90% KV cache hit. AIPerf builds its replay schedule from a
+`timestamp` field; the shipped rows have none, and without it AIPerf replays a
+small default instead of the file, so add one:
+
+```bash
+git lfs install
+git lfs pull --include "recipes/*/perf/traces/*"
+python3 -c "
+import json
+src='traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl'
+for line in open(src):
+    print(json.dumps({'timestamp': 0, **json.loads(line)}))
+" > mooncake_agentic.jsonl
+```
+
+Confirm a run replayed the whole file: `Request Count` in `profile_export_aiperf.csv`
+should account for every line, successes and errors together.
+
+## Workflow
+
+```bash
+export NAMESPACE=your-namespace
+```
+
+### 1. Deploy the DGD
+
+See the deployment instructions in the [recipe README](../README.md).
+
+### 2. Stage the trace and the artifact directory on the PVC
+
+Copy `mooncake_agentic.jsonl` through a helper pod that mounts `model-cache`:
+
+```bash
+kubectl run pvc-helper -n ${NAMESPACE} \
+  --image=busybox:1.36 --restart=Never \
+  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"model-cache","mountPath":"/model-cache"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"model-cache"}}]}}' \
+  --command -- sleep 3600
+
+kubectl exec -n ${NAMESPACE} pvc-helper -- mkdir -p /model-cache/traces
+kubectl cp mooncake_agentic.jsonl ${NAMESPACE}/pvc-helper:/model-cache/traces/
+
+# Artifact root. The Job creates a per-run subdirectory here as UID 1000, so it
+# needs write access -- creating the directory alone is not enough.
+kubectl exec -n ${NAMESPACE} pvc-helper -- mkdir -p /model-cache/perf
+kubectl exec -n ${NAMESPACE} pvc-helper -- chown 1000:1000 /model-cache/perf
+```
+
+Keep `pvc-helper` for fetching artifacts, or delete it after staging.
+
+UID 1000 is the `aiperf:0.11.0` runtime user. If your storage backend ignores
+POSIX ownership, make the directory writable by that user another way; the Job
+exits at `mkdir` with `Permission denied` if it cannot write there.
+
+### 3. Run the benchmark
+
+```bash
+kubectl apply -f perf.yaml -n ${NAMESPACE}
+kubectl logs -n ${NAMESPACE} -l job-name=inkling-bench -f
+kubectl wait --for=condition=Complete job/inkling-bench \
+  -n ${NAMESPACE} --timeout=10800s
+```
+
+The Job uses `nvcr.io/nvidia/ai-dynamo/aiperf:0.11.0` directly and does not
+install or patch AIPerf at runtime.
+
+### 4. Fetch artifacts
+
+```bash
+kubectl cp \
+  ${NAMESPACE}/pvc-helper:/model-cache/perf/<epoch>_inkling-bench \
+  ./results
+```
+
+### 5. Cleanup
+
+```bash
+kubectl delete job inkling-bench -n ${NAMESPACE}
+kubectl delete pod pvc-helper -n ${NAMESPACE}
+```
+
+## Running a concurrency sweep
+
+`perf.yaml` runs one `CONCURRENCY` value. Clear vLLM KV state and Dynamo
+frontend/router state between independent runs by restarting the DGD pods:
+
+```bash
+kubectl delete job inkling-bench -n ${NAMESPACE} --ignore-not-found
+
+DGD=inkling-vllm-gb300-agg-agentic # or inkling-vllm-gb300-disagg-agentic
+kubectl delete pods -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD}
+kubectl wait --for=condition=Ready pod -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD} \
+  --timeout=7200s
+
+# Update CONCURRENCY in perf.yaml before each run.
+kubectl apply -f perf.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/inkling-bench \
+  -n ${NAMESPACE} --timeout=10800s
+```
+
+Do not compare partial runs. A completed run must account for successful,
+errored, and unfinished requests before reporting aggregate throughput.
+
+## Reference results
+
+Measured against the SLO pair `user_tps p50 >= 50` and `TTFT p50 <= 5000 ms`.
+Both variants clear both gates.
+
+| Variant | GPUs | Concurrency | tok/s/GPU | user_tps p50 | TTFT p50 |
+| --- | --- | --- | --- | --- | --- |
+| Aggregated | 8 (2x TP4) | 20 | 192.41 | 84.87 | 361 ms |
+| Disaggregated | 8 (4P + 4D) | 16 | 144.01 | 77.94 | 1305 ms |
+
+Measured on the `aws-roce` fabric variant.
+
+> [!NOTE]
+> Aggregated beat every disaggregated split tested on this workload: prefill is
+> only about 5% of the GPU-time budget, so dedicating half the fleet to it costs
+> more per-GPU throughput than the prefill/decode separation returns.
+
+## Artifacts
+
+Results are written to:
+
+```text
+/model-cache/perf/<epoch>_<job-name>/
+  warmup/
+  Inkling-NVFP4_trace_c<concurrency>_<timestamp>/
+    profile_export_aiperf.json
+    inputs.json
+    ...
+```

--- a/recipes/inkling/perf/perf.yaml
+++ b/recipes/inkling/perf/perf.yaml
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# AIPerf trace-replay benchmark for the Inkling-NVFP4 vLLM GB300 DGDs.
+#
+# One Job covers the aggregated and disaggregated variants. Edit ENDPOINT and
+# CONCURRENCY below to select a target. Restart the DGD pods between independent
+# concurrency points so vLLM KV state and Dynamo routing state are reset.
+#
+# Prerequisites:
+# - Target DGD is Ready (see ../README.md)
+# - model-cache PVC contains TRACE_FILE and the checkpoint
+#
+# Results: /model-cache/perf/<epoch>_<job-name>/
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: inkling-bench
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 21600
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: inkling-bench
+    spec:
+      # Co-locate the benchmark pod with a DGD frontend. Keep only the target
+      # DGD in values when both variants are deployed in the same namespace.
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: nvidia.com/dynamo-component-type
+                operator: In
+                values:
+                - frontend
+              - key: nvidia.com/dynamo-graph-deployment-name
+                operator: In
+                values:
+                # Must match ENDPOINT below. Two entries let the Job sit
+                # beside the frontend it does not measure.
+                - inkling-vllm-gb300-agg-agentic
+            topologyKey: kubernetes.io/hostname
+      # tolerations: # Uncomment and populate for tainted frontend nodes.
+      containers:
+      - name: perf
+        image: nvcr.io/nvidia/ai-dynamo/aiperf:0.11.0
+        imagePullPolicy: IfNotPresent
+        workingDir: /app
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          ulimit -n 600000
+          export COLUMNS=200
+          EPOCH=$(/busybox/date +%s)
+
+          wait_for_model_ready() {
+            python3 - <<'PY'
+          import json
+          import os
+          import time
+          import urllib.request
+
+          endpoint = os.environ["ENDPOINT"]
+          model = os.environ["TARGET_MODEL"]
+          max_attempts = int(os.environ.get("WAIT_FOR_MODEL_MAX_ATTEMPTS", "2160"))
+          url = f"http://{endpoint}/v1/models"
+
+          print(f"Waiting for model '{model}' at {url} (max {max_attempts} attempts) ...")
+          for attempt in range(1, max_attempts + 1):
+              try:
+                  with urllib.request.urlopen(url, timeout=5) as response:
+                      payload = json.load(response)
+                  if any(item.get("id") == model for item in payload.get("data", [])):
+                      print(json.dumps(payload, indent=2))
+                      raise SystemExit(0)
+              except Exception:
+                  pass
+
+              if attempt == max_attempts:
+                  break
+              timestamp = time.strftime("%H:%M:%S")
+              print(f"[{timestamp}] not ready (attempt {attempt}/{max_attempts}), sleeping 5s")
+              time.sleep(5)
+
+          raise SystemExit(
+              f"model '{model}' did not become ready after {max_attempts} attempts"
+          )
+          PY
+          }
+
+          if [ ! -f "$TRACE_FILE" ]; then
+            echo "ERROR: trace file not found at ${TRACE_FILE}"
+            echo "Copy it onto the PVC via a helper pod, e.g.:"
+            echo " kubectl cp <local_trace.jsonl> <ns>/<helper-pod>:${TRACE_FILE}"
+            exit 1
+          fi
+
+          wait_for_model_ready
+          ROOT_DIR="${ROOT_ARTIFACT_DIR}/${EPOCH}_${JOB_NAME}"
+          /busybox/mkdir -p "$ROOT_DIR"
+          echo "=============================================="
+          echo "Trace Replay Benchmark (aiperf)"
+          echo "=============================================="
+          echo "Endpoint:     http://${ENDPOINT}"
+          echo "Model:        ${TARGET_MODEL}"
+          echo "Trace file:   ${TRACE_FILE}"
+          echo "Concurrency:  ${CONCURRENCY}"
+          echo "Artifact root:${ROOT_DIR}"
+          echo "=============================================="
+
+          # Warmup
+          WARMUP_DIR="${ROOT_DIR}/warmup"
+          /busybox/mkdir -p "$WARMUP_DIR"
+          aiperf profile \
+            -m "$TARGET_MODEL" \
+            --tokenizer "$TOKENIZER_PATH" \
+            --tokenizer-trust-remote-code \
+            --url "http://$ENDPOINT" \
+            --streaming \
+            --ui simple \
+            --isl 8000 \
+            --osl 400 \
+            --concurrency 1 \
+            --request-count 5 \
+            --artifact-dir "$WARMUP_DIR"
+          echo "Warmup complete"
+
+          MODEL_BASE="${TARGET_MODEL##*/}"
+          TS=$(/busybox/date +'%Y%m%d_%H%M%S')
+          RUN_DIR="${ROOT_DIR}/${MODEL_BASE}_trace_c${CONCURRENCY}_${TS}"
+          /busybox/mkdir -p "$RUN_DIR"
+          aiperf profile \
+            -m "$TARGET_MODEL" \
+            --tokenizer "$TOKENIZER_PATH" \
+            --tokenizer-trust-remote-code \
+            --input-file "$TRACE_FILE" \
+            --custom-dataset-type mooncake_trace \
+            --synthesis-max-isl 500000 \
+            --synthesis-max-osl 12000 \
+            --num-requests $(/busybox/wc -l < "${TRACE_FILE}") \
+            --dataset-sampling-strategy sequential \
+            --url "http://$ENDPOINT" \
+            --streaming \
+            --use-server-token-count \
+            --extra-inputs ignore_eos:true \
+            --concurrency "$CONCURRENCY" \
+            --random-seed 42 \
+            --ui simple \
+            --artifact-dir "$RUN_DIR" \
+            --request-timeout-seconds 3900 \
+            --workers-max "$CONCURRENCY" \
+            --export-http-trace
+          echo "Concurrency ${CONCURRENCY} complete; artifacts in ${RUN_DIR}"
+          /busybox/ls -la "$RUN_DIR" || true
+          echo ""
+          echo "Done. Root: ${ROOT_DIR}"
+        env:
+        # --- Edit these two to select a target. See ./README.md. ---
+        - name: ENDPOINT
+          value: inkling-vllm-gb300-agg-agentic-frontend:8000
+        - name: CONCURRENCY
+          value: "20"
+        # --- The remainder is shared across both variants. ---
+        # 2160 x 5s = 3h, matching the worker startupProbe budget.
+        - name: WAIT_FOR_MODEL_MAX_ATTEMPTS
+          value: "2160"
+        - name: TRACE_FILE
+          value: /model-cache/traces/mooncake_agentic.jsonl
+        - name: TARGET_MODEL
+          value: thinkingmachines/Inkling-NVFP4
+        # Local path, not a Hub id: the download job stages the checkpoint with
+        # `--local-dir`, so the Hub cache layout HF_HOME expects is not present.
+        - name: TOKENIZER_PATH
+          value: /model-cache/thinkingmachines/Inkling-NVFP4
+        - name: AIPERF_HTTP_CONNECTION_LIMIT
+          value: "200"
+        - name: AIPERF_HTTP_SO_RCVTIMEO
+          value: "120"
+        - name: AIPERF_SERVICE_PROFILE_CONFIGURE_TIMEOUT
+          value: "3600"
+        - name: AIPERF_DATASET_CONFIGURATION_TIMEOUT
+          value: "3600"
+        - name: JOB_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['job-name']
+        - name: ROOT_ARTIFACT_DIR
+          value: /model-cache/perf
+        - name: HF_HOME
+          value: /model-cache
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        resources:
+          requests:
+            cpu: "4"
+            memory: 8Gi
+          limits:
+            cpu: "16"
+            memory: 64Gi
+        volumeMounts:
+        - name: model-cache
+          mountPath: /model-cache
+      restartPolicy: Never
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache

--- a/recipes/inkling/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
+++ b/recipes/inkling/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
@@ -1,0 +1,1 @@
+../../../kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl

--- a/recipes/inkling/vllm/agg-gb300-agentic/deploy.yaml
+++ b/recipes/inkling/vllm/agg-gb300-agentic/deploy.yaml
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Inkling-NVFP4 on vLLM, aggregated serving on GB300, tuned for an agentic
+# workload (64K median ISL / 400 median OSL, 90% KV cache hit) with KV-aware
+# routing.
+#
+# Shape: 2 worker replicas x TP4 = 8x GB300. Every replica runs prefill and
+# decode; the frontend routes on KV cache locality using the events each worker
+# publishes.
+#
+# Weights come from the `model-cache` PVC — see recipes/inkling/model-cache/.
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: inkling-vllm-gb300-agg-agentic
+  labels:
+    app.kubernetes.io/name: inkling-vllm-gb300-agg-agentic
+    app.kubernetes.io/part-of: dynamo
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      replicas: 1
+      type: frontend
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-inkling-dev.1
+              imagePullPolicy: Always
+              command: [python3, -m, dynamo.frontend]
+              args:
+                - --router-mode
+                - kv
+                - --router-kv-events
+                - --http-port
+                - "8000"
+                - --model-path
+                - /model-cache/thinkingmachines/Inkling-NVFP4
+                - --dyn-chat-processor
+                - vllm
+                - --reasoning-parser
+                - inkling
+                - --tool-call-parser
+                - inkling
+                - --enable-auto-tool-choice
+                - --trust-remote-code
+              env:
+                - {name: DYN_ROUTER_MODE, value: kv}
+                - {name: HF_HUB_OFFLINE, value: "1"}
+                - {name: TRANSFORMERS_OFFLINE, value: "1"}
+              ports: [{name: http, containerPort: 8000, protocol: TCP}]
+              readinessProbe:
+                httpGet: {path: /v1/models, port: http}
+                periodSeconds: 10
+                timeoutSeconds: 5
+                failureThreshold: 3
+              resources:
+                requests: {cpu: "4", memory: 8Gi}
+                limits: {cpu: "4", memory: 8Gi}
+              volumeMounts:
+                - {name: model-cache, mountPath: /model-cache}
+          volumes:
+            - {name: model-cache, persistentVolumeClaim: {claimName: model-cache}}
+    - name: VllmWorker
+      replicas: 2
+      type: worker
+      # tmpfs at /dev/shm for the vLLM multiprocess executor's TP4 IPC buffers.
+      # The operator default (8Gi) is too small for this context length.
+      sharedMemorySize: 64Gi
+      podTemplate:
+        spec:
+          hostIPC: true
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-GB300
+          # Some clusters taint their GPU nodes. This toleration is inert
+          # where they do not.
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-inkling-dev.1
+              imagePullPolicy: Always
+              command: [python3, -m, dynamo.vllm]
+              args:
+                - --model
+                - /model-cache/thinkingmachines/Inkling-NVFP4
+                - --served-model-name
+                - thinkingmachines/Inkling-NVFP4
+                - --trust-remote-code
+                - --tokenizer-mode
+                - inkling
+                - --dyn-reasoning-parser
+                - inkling
+                - --dyn-tool-call-parser
+                - inkling
+                - --reasoning-parser
+                - inkling
+                - --dyn-enable-structural-tag
+                - --structured-outputs-config
+                - '{"enable_in_reasoning": true}'
+                - --tensor-parallel-size
+                - "4"
+                # 1M context is a model capability this recipe keeps available.
+                - --max-model-len
+                - "1048576"
+                - --speculative-config
+                - '{"method":"mtp","num_speculative_tokens":8}'
+                - --gpu-memory-utilization
+                - "0.92"
+                # Required. Sizing KV from the utilization fraction alone leaves
+                # too little headroom and OOMs during CUDA graph capture at this
+                # context length. ~102 GiB, measured on 288 GB GB300.
+                - --kv-cache-memory-bytes
+                - "109521666048"
+                - --enable-prefix-caching
+                - --kernel-config.enable_flashinfer_autotune=False
+                # KV events feed the frontend's KV-aware router.
+                - --kv-events-config
+                - '{"enable_kv_cache_events": true}'
+                - --disaggregation-mode
+                - agg
+              env:
+                - {name: HF_HOME, value: /model-cache}
+                - {name: HF_HUB_OFFLINE, value: "1"}
+                - {name: TRANSFORMERS_OFFLINE, value: "1"}
+                - {name: VLLM_USE_V2_MODEL_RUNNER, value: "1"}
+                - {name: FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED, value: "1"}
+                # Retain only the latest completed prompt boundary. Env-only in
+                # vLLM; there is no equivalent CLI flag.
+                - {name: VLLM_PREFIX_CACHE_RETENTION_INTERVAL, value: "0"}
+                # A 1M-token forward pass can exceed the default worker timeout.
+                - {name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800"}
+              ports: [{name: system, containerPort: 9090, protocol: TCP}]
+              startupProbe:
+                httpGet: {path: /live, port: system}
+                periodSeconds: 10
+                timeoutSeconds: 5
+                failureThreshold: 1080
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                capabilities: {add: [IPC_LOCK, SYS_RESOURCE]}
+              resources:
+                requests: {nvidia.com/gpu: "4"}
+                limits: {nvidia.com/gpu: "4"}
+              volumeMounts:
+                - {name: model-cache, mountPath: /model-cache}
+          volumes:
+            - {name: model-cache, persistentVolumeClaim: {claimName: model-cache}}

--- a/recipes/inkling/vllm/disagg-gb300-agentic/.kustomize-matrix.yaml
+++ b/recipes/inkling/vllm/disagg-gb300-agentic/.kustomize-matrix.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+source: kustomize/base
+nameTemplate: "${variant}"
+matrix:
+  variant:
+    - name: generic
+      components: []
+    - name: aws-roce
+      components:
+        - kustomize/components/aws-roce-dra
+      # Put the ResourceClaimTemplate before the DGD that claims it. The default
+      # fifo order emits the Component's claim template last, so `kubectl apply`
+      # reports a transient resource-claim-template-not-found event.
+      sortOptions:
+        order: legacy
+        legacySortOptions:
+          orderFirst: [ResourceClaimTemplate, ComputeDomain]
+          orderLast: []

--- a/recipes/inkling/vllm/disagg-gb300-agentic/deploy-aws-roce.yaml
+++ b/recipes/inkling/vllm/disagg-gb300-agentic/deploy-aws-roce.yaml
@@ -1,0 +1,435 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Generated file. For repository contributors, do not edit this checked-in copy.
+# Regenerate every public overlay and rendered manifest of this matrix (from the repository root):
+#   scripts/kustomize-matrix.py unfold recipes/inkling/vllm/disagg-gb300-agentic/.kustomize-matrix.yaml
+#   scripts/kustomize-matrix.py render recipes/inkling/vllm/disagg-gb300-agentic/.kustomize-matrix.yaml
+# Inspect only this Kustomize overlay (from the repository root):
+#   kustomize build recipes/inkling/vllm/disagg-gb300-agentic/kustomize/overlays/aws-roce
+# You may edit a copy before applying it.
+
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: inkling-vllm-gb300-disagg-agentic-roce
+spec:
+  spec:
+    devices:
+      requests:
+      - exactly:
+          allocationMode: ExactCount
+          count: 1
+          deviceClassName: roce.networking.k8s.aws
+        name: roce
+---
+#
+# Inkling-NVFP4 on vLLM, disaggregated prefill/decode on GB300, tuned for an
+# agentic workload (64K median ISL / 400 median OSL, 90% KV cache hit) with
+# KV-aware routing.
+#
+# Shape: 1 prefill x TP4 + 1 decode x TP4 = 8x GB300.
+#
+# Fabric: this base is fabric-neutral. NIXL moves KV over MNNVL `cuda_ipc`
+# within the ComputeDomain, and UCX carries its active-message control plane
+# over TCP. Clusters that expose RDMA NICs to pods select a fabric Component —
+# see recipes/inkling/vllm/disagg-gb300-agentic/kustomize/components/ and
+# the recipe's `.kustomize-matrix.yaml`.
+#
+# Weights come from the `model-cache` PVC — see recipes/inkling/model-cache/.
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: inkling-vllm-gb300-disagg-agentic-compute-domain
+spec:
+  channel:
+    allocationMode: Single
+    resourceClaimTemplate:
+      name: inkling-vllm-gb300-disagg-agentic-compute-domain-channel
+  numNodes: 0
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  labels:
+    app.kubernetes.io/name: inkling-vllm-gb300-disagg-agentic
+    app.kubernetes.io/part-of: dynamo
+  name: inkling-vllm-gb300-disagg-agentic
+spec:
+  backendFramework: vllm
+  components:
+  - name: VllmPrefillWorker
+    podTemplate:
+      metadata:
+        annotations:
+          nvidia.com/vllm-distributed-executor-backend: mp
+      spec:
+        containers:
+        - args:
+          - |
+            set -euo pipefail
+            # Fabric discovery. When the cluster allocates this pod an RDMA
+            # HCA with a pod network interface, point UCX at it. With no HCA
+            # the transports in UCX_TLS carry NIXL instead: MNNVL cuda_ipc
+            # for bulk KV, TCP for the active-message control plane. Never
+            # hardcode UCX_NET_DEVICES -- the device name is host-specific.
+            hca=""
+            for hca_path in /sys/class/infiniband/*; do
+              [ -d "${hca_path}/device/net" ] || continue
+              for net_path in "${hca_path}"/device/net/*; do
+                [ -e "${net_path}" ] || continue
+                hca="${hca_path##*/}"; break 2
+              done
+            done
+            if [ -n "${hca}" ]; then
+              export UCX_NET_DEVICES="${hca}:1"
+              echo "RDMA_HCA_SELECTED=${hca} UCX_TLS=${UCX_TLS:-default}"
+            else
+              echo "RDMA_HCA_SELECTED=none UCX_TLS=${UCX_TLS:-default}"
+              # A fabric variant whose UCX_TLS has no TCP fallback cannot
+              # carry NIXL without an HCA. Stop now. Otherwise the pod
+              # runs and the startupProbe fails 3h later.
+              if [ "${DYN_REQUIRE_RDMA_HCA:-0}" = "1" ]; then
+                echo "FATAL: no RDMA HCA, and UCX_TLS has no TCP fallback" >&2
+                exit 1
+              fi
+            fi
+            exec python3 -m dynamo.vllm \
+              --model /model-cache/thinkingmachines/Inkling-NVFP4 \
+              --served-model-name thinkingmachines/Inkling-NVFP4 \
+              --trust-remote-code \
+              --tokenizer-mode inkling \
+              --dyn-reasoning-parser inkling \
+              --dyn-tool-call-parser inkling \
+              --reasoning-parser inkling \
+              --dyn-enable-structural-tag \
+              --structured-outputs-config \
+              '{"enable_in_reasoning": true}' \
+              --tensor-parallel-size 4 \
+              --max-model-len 1048576 \
+              --speculative-config '{"method":"mtp","num_speculative_tokens":8}' \
+              --gpu-memory-utilization 0.92 \
+              --kv-cache-memory-bytes 109521666048 \
+              --enable-prefix-caching \
+              --kernel-config.enable_flashinfer_autotune=False \
+              --kv-events-config '{"enable_kv_cache_events": true}' \
+              --disaggregation-mode prefill \
+              --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_connector_extra_config":{"num_threads":8}}'
+          command:
+          - /bin/bash
+          - -lc
+          env:
+          - name: UCX_TLS
+            value: rc_x,rc,cuda_copy,cuda_ipc
+          - name: UCX_IB_ADDR_TYPE
+            value: eth
+          - name: DYN_REQUIRE_RDMA_HCA
+            value: "1"
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          - name: TRANSFORMERS_OFFLINE
+            value: "1"
+          - name: VLLM_USE_V2_MODEL_RUNNER
+            value: "1"
+          - name: FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED
+            value: "1"
+          - name: VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+            value: "0"
+          - name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS
+            value: "1800"
+          - name: NCCL_SOCKET_IFNAME
+            value: eth0
+          - name: GLOO_SOCKET_IFNAME
+            value: eth0
+          - name: NCCL_MNNVL_ENABLE
+            value: "1"
+          - name: NCCL_NVLS_ENABLE
+            value: "1"
+          - name: NCCL_P2P_LEVEL
+            value: NVL
+          - name: NCCL_CUMEM_ENABLE
+            value: "1"
+          - name: VLLM_USE_NCCL_SYMM_MEM
+            value: "0"
+          - name: UCX_CUDA_IPC_ENABLE_MNNVL
+            value: "y"
+          - name: MC_FORCE_MNNVL
+            value: "1"
+          - name: UCX_MEMTYPE_CACHE
+            value: "n"
+          - name: VLLM_ALLREDUCE_USE_FLASHINFER
+            value: "1"
+          - name: VLLM_FLASHINFER_ALLREDUCE_BACKEND
+            value: mnnvl
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-inkling-dev.1
+          imagePullPolicy: Always
+          name: main
+          ports:
+          - containerPort: 9090
+            name: system
+            protocol: TCP
+          resources:
+            claims:
+            - name: compute-domain-channel
+            - name: roce
+            limits:
+              nvidia.com/gpu: "4"
+            requests:
+              nvidia.com/gpu: "4"
+          securityContext:
+            capabilities:
+              add:
+              - IPC_LOCK
+              - SYS_RESOURCE
+            runAsGroup: 0
+            runAsUser: 0
+          startupProbe:
+            failureThreshold: 1080
+            httpGet:
+              path: /live
+              port: system
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+        hostIPC: true
+        nodeSelector:
+          nvidia.com/gpu.product: NVIDIA-GB300
+        resourceClaims:
+        - name: roce
+          resourceClaimTemplateName: inkling-vllm-gb300-disagg-agentic-roce
+        - name: compute-domain-channel
+          resourceClaimTemplateName: inkling-vllm-gb300-disagg-agentic-compute-domain-channel
+        tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Equal
+          value: "true"
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+    replicas: 1
+    sharedMemorySize: 64Gi
+    type: prefill
+  - name: VllmDecodeWorker
+    podTemplate:
+      metadata:
+        annotations:
+          nvidia.com/vllm-distributed-executor-backend: mp
+      spec:
+        containers:
+        - args:
+          - |
+            set -euo pipefail
+            # See VllmPrefillWorker for the fabric-discovery rationale.
+            hca=""
+            for hca_path in /sys/class/infiniband/*; do
+              [ -d "${hca_path}/device/net" ] || continue
+              for net_path in "${hca_path}"/device/net/*; do
+                [ -e "${net_path}" ] || continue
+                hca="${hca_path##*/}"; break 2
+              done
+            done
+            if [ -n "${hca}" ]; then
+              export UCX_NET_DEVICES="${hca}:1"
+              echo "RDMA_HCA_SELECTED=${hca} UCX_TLS=${UCX_TLS:-default}"
+            else
+              echo "RDMA_HCA_SELECTED=none UCX_TLS=${UCX_TLS:-default}"
+              # A fabric variant whose UCX_TLS has no TCP fallback cannot
+              # carry NIXL without an HCA. Stop now. Otherwise the pod
+              # runs and the startupProbe fails 3h later.
+              if [ "${DYN_REQUIRE_RDMA_HCA:-0}" = "1" ]; then
+                echo "FATAL: no RDMA HCA, and UCX_TLS has no TCP fallback" >&2
+                exit 1
+              fi
+            fi
+            exec python3 -m dynamo.vllm \
+              --model /model-cache/thinkingmachines/Inkling-NVFP4 \
+              --served-model-name thinkingmachines/Inkling-NVFP4 \
+              --trust-remote-code \
+              --tokenizer-mode inkling \
+              --dyn-reasoning-parser inkling \
+              --dyn-tool-call-parser inkling \
+              --reasoning-parser inkling \
+              --dyn-enable-structural-tag \
+              --structured-outputs-config \
+              '{"enable_in_reasoning": true}' \
+              --tensor-parallel-size 4 \
+              --max-model-len 1048576 \
+              --speculative-config '{"method":"mtp","num_speculative_tokens":8}' \
+              --gpu-memory-utilization 0.92 \
+              --kv-cache-memory-bytes 109521666048 \
+              --enable-prefix-caching \
+              --kernel-config.enable_flashinfer_autotune=False \
+              --kv-events-config '{"enable_kv_cache_events": true}' \
+              --disaggregation-mode decode \
+              --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_connector_extra_config":{"num_threads":8}}'
+          command:
+          - /bin/bash
+          - -lc
+          env:
+          - name: UCX_TLS
+            value: rc_x,rc,cuda_copy,cuda_ipc
+          - name: UCX_IB_ADDR_TYPE
+            value: eth
+          - name: DYN_REQUIRE_RDMA_HCA
+            value: "1"
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          - name: TRANSFORMERS_OFFLINE
+            value: "1"
+          - name: VLLM_USE_V2_MODEL_RUNNER
+            value: "1"
+          - name: FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED
+            value: "1"
+          - name: VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+            value: "0"
+          - name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS
+            value: "1800"
+          - name: NCCL_SOCKET_IFNAME
+            value: eth0
+          - name: GLOO_SOCKET_IFNAME
+            value: eth0
+          - name: NCCL_MNNVL_ENABLE
+            value: "1"
+          - name: NCCL_NVLS_ENABLE
+            value: "1"
+          - name: NCCL_P2P_LEVEL
+            value: NVL
+          - name: NCCL_CUMEM_ENABLE
+            value: "1"
+          - name: VLLM_USE_NCCL_SYMM_MEM
+            value: "0"
+          - name: UCX_CUDA_IPC_ENABLE_MNNVL
+            value: "y"
+          - name: MC_FORCE_MNNVL
+            value: "1"
+          - name: UCX_MEMTYPE_CACHE
+            value: "n"
+          - name: VLLM_ALLREDUCE_USE_FLASHINFER
+            value: "1"
+          - name: VLLM_FLASHINFER_ALLREDUCE_BACKEND
+            value: mnnvl
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-inkling-dev.1
+          imagePullPolicy: Always
+          name: main
+          ports:
+          - containerPort: 9090
+            name: system
+            protocol: TCP
+          resources:
+            claims:
+            - name: compute-domain-channel
+            - name: roce
+            limits:
+              nvidia.com/gpu: "4"
+            requests:
+              nvidia.com/gpu: "4"
+          securityContext:
+            capabilities:
+              add:
+              - IPC_LOCK
+              - SYS_RESOURCE
+            runAsGroup: 0
+            runAsUser: 0
+          startupProbe:
+            failureThreshold: 1080
+            httpGet:
+              path: /live
+              port: system
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+        hostIPC: true
+        nodeSelector:
+          nvidia.com/gpu.product: NVIDIA-GB300
+        resourceClaims:
+        - name: roce
+          resourceClaimTemplateName: inkling-vllm-gb300-disagg-agentic-roce
+        - name: compute-domain-channel
+          resourceClaimTemplateName: inkling-vllm-gb300-disagg-agentic-compute-domain-channel
+        # Some clusters taint their GPU nodes. This toleration is inert
+        # where they do not.
+        tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Equal
+          value: "true"
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+    replicas: 1
+    # tmpfs at /dev/shm for the vLLM multiprocess executor's TP4 IPC buffers.
+    # The operator default (8Gi) is too small for this context length.
+    sharedMemorySize: 64Gi
+    type: decode
+  - name: Frontend
+    podTemplate:
+      spec:
+        containers:
+        - args:
+          - --router-mode
+          - kv
+          - --router-kv-events
+          - --http-port
+          - "8000"
+          - --model-path
+          - /model-cache/thinkingmachines/Inkling-NVFP4
+          - --dyn-chat-processor
+          - vllm
+          - --reasoning-parser
+          - inkling
+          - --tool-call-parser
+          - inkling
+          - --enable-auto-tool-choice
+          - --trust-remote-code
+          command:
+          - python3
+          - -m
+          - dynamo.frontend
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          - name: TRANSFORMERS_OFFLINE
+            value: "1"
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-inkling-dev.1
+          imagePullPolicy: Always
+          name: main
+          ports:
+          - containerPort: 8000
+            name: http
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /v1/models
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: "4"
+              memory: 8Gi
+            requests:
+              cpu: "4"
+              memory: 8Gi
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+    replicas: 1
+    type: frontend

--- a/recipes/inkling/vllm/disagg-gb300-agentic/deploy-generic.yaml
+++ b/recipes/inkling/vllm/disagg-gb300-agentic/deploy-generic.yaml
@@ -1,0 +1,409 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Generated file. For repository contributors, do not edit this checked-in copy.
+# Regenerate every public overlay and rendered manifest of this matrix (from the repository root):
+#   scripts/kustomize-matrix.py unfold recipes/inkling/vllm/disagg-gb300-agentic/.kustomize-matrix.yaml
+#   scripts/kustomize-matrix.py render recipes/inkling/vllm/disagg-gb300-agentic/.kustomize-matrix.yaml
+# Inspect only this Kustomize overlay (from the repository root):
+#   kustomize build recipes/inkling/vllm/disagg-gb300-agentic/kustomize/overlays/generic
+# You may edit a copy before applying it.
+
+#
+# Inkling-NVFP4 on vLLM, disaggregated prefill/decode on GB300, tuned for an
+# agentic workload (64K median ISL / 400 median OSL, 90% KV cache hit) with
+# KV-aware routing.
+#
+# Shape: 1 prefill x TP4 + 1 decode x TP4 = 8x GB300.
+#
+# Fabric: this base is fabric-neutral. NIXL moves KV over MNNVL `cuda_ipc`
+# within the ComputeDomain, and UCX carries its active-message control plane
+# over TCP. Clusters that expose RDMA NICs to pods select a fabric Component —
+# see recipes/inkling/vllm/disagg-gb300-agentic/kustomize/components/ and
+# the recipe's `.kustomize-matrix.yaml`.
+#
+# Weights come from the `model-cache` PVC — see recipes/inkling/model-cache/.
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: inkling-vllm-gb300-disagg-agentic-compute-domain
+spec:
+  channel:
+    allocationMode: Single
+    resourceClaimTemplate:
+      name: inkling-vllm-gb300-disagg-agentic-compute-domain-channel
+  numNodes: 0
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  labels:
+    app.kubernetes.io/name: inkling-vllm-gb300-disagg-agentic
+    app.kubernetes.io/part-of: dynamo
+  name: inkling-vllm-gb300-disagg-agentic
+spec:
+  backendFramework: vllm
+  components:
+  - name: Frontend
+    podTemplate:
+      spec:
+        containers:
+        - args:
+          - --router-mode
+          - kv
+          - --router-kv-events
+          - --http-port
+          - "8000"
+          - --model-path
+          - /model-cache/thinkingmachines/Inkling-NVFP4
+          - --dyn-chat-processor
+          - vllm
+          - --reasoning-parser
+          - inkling
+          - --tool-call-parser
+          - inkling
+          - --enable-auto-tool-choice
+          - --trust-remote-code
+          command:
+          - python3
+          - -m
+          - dynamo.frontend
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          - name: TRANSFORMERS_OFFLINE
+            value: "1"
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-inkling-dev.1
+          imagePullPolicy: Always
+          name: main
+          ports:
+          - containerPort: 8000
+            name: http
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /v1/models
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: "4"
+              memory: 8Gi
+            requests:
+              cpu: "4"
+              memory: 8Gi
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+    replicas: 1
+    type: frontend
+  - name: VllmPrefillWorker
+    podTemplate:
+      metadata:
+        annotations:
+          nvidia.com/vllm-distributed-executor-backend: mp
+      spec:
+        containers:
+        - args:
+          - |
+            set -euo pipefail
+            # Fabric discovery. When the cluster allocates this pod an RDMA
+            # HCA with a pod network interface, point UCX at it. With no HCA
+            # the transports in UCX_TLS carry NIXL instead: MNNVL cuda_ipc
+            # for bulk KV, TCP for the active-message control plane. Never
+            # hardcode UCX_NET_DEVICES -- the device name is host-specific.
+            hca=""
+            for hca_path in /sys/class/infiniband/*; do
+              [ -d "${hca_path}/device/net" ] || continue
+              for net_path in "${hca_path}"/device/net/*; do
+                [ -e "${net_path}" ] || continue
+                hca="${hca_path##*/}"; break 2
+              done
+            done
+            if [ -n "${hca}" ]; then
+              export UCX_NET_DEVICES="${hca}:1"
+              echo "RDMA_HCA_SELECTED=${hca} UCX_TLS=${UCX_TLS:-default}"
+            else
+              echo "RDMA_HCA_SELECTED=none UCX_TLS=${UCX_TLS:-default}"
+              # A fabric variant whose UCX_TLS has no TCP fallback cannot
+              # carry NIXL without an HCA. Stop now. Otherwise the pod
+              # runs and the startupProbe fails 3h later.
+              if [ "${DYN_REQUIRE_RDMA_HCA:-0}" = "1" ]; then
+                echo "FATAL: no RDMA HCA, and UCX_TLS has no TCP fallback" >&2
+                exit 1
+              fi
+            fi
+            exec python3 -m dynamo.vllm \
+              --model /model-cache/thinkingmachines/Inkling-NVFP4 \
+              --served-model-name thinkingmachines/Inkling-NVFP4 \
+              --trust-remote-code \
+              --tokenizer-mode inkling \
+              --dyn-reasoning-parser inkling \
+              --dyn-tool-call-parser inkling \
+              --reasoning-parser inkling \
+              --dyn-enable-structural-tag \
+              --structured-outputs-config \
+              '{"enable_in_reasoning": true}' \
+              --tensor-parallel-size 4 \
+              --max-model-len 1048576 \
+              --speculative-config '{"method":"mtp","num_speculative_tokens":8}' \
+              --gpu-memory-utilization 0.92 \
+              --kv-cache-memory-bytes 109521666048 \
+              --enable-prefix-caching \
+              --kernel-config.enable_flashinfer_autotune=False \
+              --kv-events-config '{"enable_kv_cache_events": true}' \
+              --disaggregation-mode prefill \
+              --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_connector_extra_config":{"num_threads":8}}'
+          command:
+          - /bin/bash
+          - -lc
+          env:
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          - name: TRANSFORMERS_OFFLINE
+            value: "1"
+          - name: VLLM_USE_V2_MODEL_RUNNER
+            value: "1"
+          - name: FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED
+            value: "1"
+          - name: VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+            value: "0"
+          - name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS
+            value: "1800"
+          - name: NCCL_SOCKET_IFNAME
+            value: eth0
+          - name: GLOO_SOCKET_IFNAME
+            value: eth0
+          - name: NCCL_MNNVL_ENABLE
+            value: "1"
+          - name: NCCL_NVLS_ENABLE
+            value: "1"
+          - name: NCCL_P2P_LEVEL
+            value: NVL
+          - name: NCCL_CUMEM_ENABLE
+            value: "1"
+          - name: VLLM_USE_NCCL_SYMM_MEM
+            value: "0"
+          - name: UCX_CUDA_IPC_ENABLE_MNNVL
+            value: "y"
+          - name: MC_FORCE_MNNVL
+            value: "1"
+          - name: UCX_MEMTYPE_CACHE
+            value: "n"
+          - name: UCX_TLS
+            value: cuda_copy,cuda_ipc,tcp
+          - name: VLLM_ALLREDUCE_USE_FLASHINFER
+            value: "1"
+          - name: VLLM_FLASHINFER_ALLREDUCE_BACKEND
+            value: mnnvl
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-inkling-dev.1
+          imagePullPolicy: Always
+          name: main
+          ports:
+          - containerPort: 9090
+            name: system
+            protocol: TCP
+          resources:
+            claims:
+            - name: compute-domain-channel
+            limits:
+              nvidia.com/gpu: "4"
+            requests:
+              nvidia.com/gpu: "4"
+          securityContext:
+            capabilities:
+              add:
+              - IPC_LOCK
+              - SYS_RESOURCE
+            runAsGroup: 0
+            runAsUser: 0
+          startupProbe:
+            failureThreshold: 1080
+            httpGet:
+              path: /live
+              port: system
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+        hostIPC: true
+        nodeSelector:
+          nvidia.com/gpu.product: NVIDIA-GB300
+        resourceClaims:
+        - name: compute-domain-channel
+          resourceClaimTemplateName: inkling-vllm-gb300-disagg-agentic-compute-domain-channel
+        # Some clusters taint their GPU nodes. This toleration is inert
+        # where they do not.
+        tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Equal
+          value: "true"
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+    replicas: 1
+    # tmpfs at /dev/shm for the vLLM multiprocess executor's TP4 IPC buffers.
+    # The operator default (8Gi) is too small for this context length.
+    sharedMemorySize: 64Gi
+    type: prefill
+  - name: VllmDecodeWorker
+    podTemplate:
+      metadata:
+        annotations:
+          nvidia.com/vllm-distributed-executor-backend: mp
+      spec:
+        containers:
+        - args:
+          - |
+            set -euo pipefail
+            # See VllmPrefillWorker for the fabric-discovery rationale.
+            hca=""
+            for hca_path in /sys/class/infiniband/*; do
+              [ -d "${hca_path}/device/net" ] || continue
+              for net_path in "${hca_path}"/device/net/*; do
+                [ -e "${net_path}" ] || continue
+                hca="${hca_path##*/}"; break 2
+              done
+            done
+            if [ -n "${hca}" ]; then
+              export UCX_NET_DEVICES="${hca}:1"
+              echo "RDMA_HCA_SELECTED=${hca} UCX_TLS=${UCX_TLS:-default}"
+            else
+              echo "RDMA_HCA_SELECTED=none UCX_TLS=${UCX_TLS:-default}"
+              # A fabric variant whose UCX_TLS has no TCP fallback cannot
+              # carry NIXL without an HCA. Stop now. Otherwise the pod
+              # runs and the startupProbe fails 3h later.
+              if [ "${DYN_REQUIRE_RDMA_HCA:-0}" = "1" ]; then
+                echo "FATAL: no RDMA HCA, and UCX_TLS has no TCP fallback" >&2
+                exit 1
+              fi
+            fi
+            exec python3 -m dynamo.vllm \
+              --model /model-cache/thinkingmachines/Inkling-NVFP4 \
+              --served-model-name thinkingmachines/Inkling-NVFP4 \
+              --trust-remote-code \
+              --tokenizer-mode inkling \
+              --dyn-reasoning-parser inkling \
+              --dyn-tool-call-parser inkling \
+              --reasoning-parser inkling \
+              --dyn-enable-structural-tag \
+              --structured-outputs-config \
+              '{"enable_in_reasoning": true}' \
+              --tensor-parallel-size 4 \
+              --max-model-len 1048576 \
+              --speculative-config '{"method":"mtp","num_speculative_tokens":8}' \
+              --gpu-memory-utilization 0.92 \
+              --kv-cache-memory-bytes 109521666048 \
+              --enable-prefix-caching \
+              --kernel-config.enable_flashinfer_autotune=False \
+              --kv-events-config '{"enable_kv_cache_events": true}' \
+              --disaggregation-mode decode \
+              --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_connector_extra_config":{"num_threads":8}}'
+          command:
+          - /bin/bash
+          - -lc
+          env:
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_HUB_OFFLINE
+            value: "1"
+          - name: TRANSFORMERS_OFFLINE
+            value: "1"
+          - name: VLLM_USE_V2_MODEL_RUNNER
+            value: "1"
+          - name: FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED
+            value: "1"
+          - name: VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+            value: "0"
+          - name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS
+            value: "1800"
+          - name: NCCL_SOCKET_IFNAME
+            value: eth0
+          - name: GLOO_SOCKET_IFNAME
+            value: eth0
+          - name: NCCL_MNNVL_ENABLE
+            value: "1"
+          - name: NCCL_NVLS_ENABLE
+            value: "1"
+          - name: NCCL_P2P_LEVEL
+            value: NVL
+          - name: NCCL_CUMEM_ENABLE
+            value: "1"
+          - name: VLLM_USE_NCCL_SYMM_MEM
+            value: "0"
+          - name: UCX_CUDA_IPC_ENABLE_MNNVL
+            value: "y"
+          - name: MC_FORCE_MNNVL
+            value: "1"
+          - name: UCX_MEMTYPE_CACHE
+            value: "n"
+          - name: UCX_TLS
+            value: cuda_copy,cuda_ipc,tcp
+          - name: VLLM_ALLREDUCE_USE_FLASHINFER
+            value: "1"
+          - name: VLLM_FLASHINFER_ALLREDUCE_BACKEND
+            value: mnnvl
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-inkling-dev.1
+          imagePullPolicy: Always
+          name: main
+          ports:
+          - containerPort: 9090
+            name: system
+            protocol: TCP
+          resources:
+            claims:
+            - name: compute-domain-channel
+            limits:
+              nvidia.com/gpu: "4"
+            requests:
+              nvidia.com/gpu: "4"
+          securityContext:
+            capabilities:
+              add:
+              - IPC_LOCK
+              - SYS_RESOURCE
+            runAsGroup: 0
+            runAsUser: 0
+          startupProbe:
+            failureThreshold: 1080
+            httpGet:
+              path: /live
+              port: system
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+          - mountPath: /model-cache
+            name: model-cache
+        hostIPC: true
+        nodeSelector:
+          nvidia.com/gpu.product: NVIDIA-GB300
+        resourceClaims:
+        - name: compute-domain-channel
+          resourceClaimTemplateName: inkling-vllm-gb300-disagg-agentic-compute-domain-channel
+        # Some clusters taint their GPU nodes. This toleration is inert
+        # where they do not.
+        tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Equal
+          value: "true"
+        volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+    replicas: 1
+    sharedMemorySize: 64Gi
+    type: decode

--- a/recipes/inkling/vllm/disagg-gb300-agentic/kustomize/base/deploy.yaml
+++ b/recipes/inkling/vllm/disagg-gb300-agentic/kustomize/base/deploy.yaml
@@ -1,0 +1,291 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Inkling-NVFP4 on vLLM, disaggregated prefill/decode on GB300, tuned for an
+# agentic workload (64K median ISL / 400 median OSL, 90% KV cache hit) with
+# KV-aware routing.
+#
+# Shape: 1 prefill x TP4 + 1 decode x TP4 = 8x GB300.
+#
+# Fabric: this base is fabric-neutral. NIXL moves KV over MNNVL `cuda_ipc`
+# within the ComputeDomain, and UCX carries its active-message control plane
+# over TCP. Clusters that expose RDMA NICs to pods select a fabric Component —
+# see recipes/inkling/vllm/disagg-gb300-agentic/kustomize/components/ and
+# the recipe's `.kustomize-matrix.yaml`.
+#
+# Weights come from the `model-cache` PVC — see recipes/inkling/model-cache/.
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: inkling-vllm-gb300-disagg-agentic-compute-domain
+spec:
+  numNodes: 0
+  channel:
+    allocationMode: Single
+    resourceClaimTemplate:
+      name: inkling-vllm-gb300-disagg-agentic-compute-domain-channel
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: inkling-vllm-gb300-disagg-agentic
+  labels:
+    app.kubernetes.io/name: inkling-vllm-gb300-disagg-agentic
+    app.kubernetes.io/part-of: dynamo
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      replicas: 1
+      type: frontend
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-inkling-dev.1
+              imagePullPolicy: Always
+              command: [python3, -m, dynamo.frontend]
+              args:
+                - --router-mode
+                - kv
+                - --router-kv-events
+                - --http-port
+                - "8000"
+                - --model-path
+                - /model-cache/thinkingmachines/Inkling-NVFP4
+                - --dyn-chat-processor
+                - vllm
+                - --reasoning-parser
+                - inkling
+                - --tool-call-parser
+                - inkling
+                - --enable-auto-tool-choice
+                - --trust-remote-code
+              env:
+                - {name: DYN_ROUTER_MODE, value: kv}
+                - {name: HF_HUB_OFFLINE, value: "1"}
+                - {name: TRANSFORMERS_OFFLINE, value: "1"}
+              ports: [{name: http, containerPort: 8000, protocol: TCP}]
+              readinessProbe:
+                httpGet: {path: /v1/models, port: http}
+                periodSeconds: 10
+                timeoutSeconds: 5
+                failureThreshold: 3
+              resources:
+                requests: {cpu: "4", memory: 8Gi}
+                limits: {cpu: "4", memory: 8Gi}
+              volumeMounts:
+                - {name: model-cache, mountPath: /model-cache}
+          volumes:
+            - {name: model-cache, persistentVolumeClaim: {claimName: model-cache}}
+
+    - name: VllmPrefillWorker
+      replicas: 1
+      type: prefill
+      # tmpfs at /dev/shm for the vLLM multiprocess executor's TP4 IPC buffers.
+      # The operator default (8Gi) is too small for this context length.
+      sharedMemorySize: 64Gi
+      podTemplate:
+        metadata:
+          annotations: {nvidia.com/vllm-distributed-executor-backend: mp}
+        spec:
+          hostIPC: true
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-GB300
+          # Some clusters taint their GPU nodes. This toleration is inert
+          # where they do not.
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          resourceClaims:
+            - name: compute-domain-channel
+              resourceClaimTemplateName: inkling-vllm-gb300-disagg-agentic-compute-domain-channel
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-inkling-dev.1
+              imagePullPolicy: Always
+              command: [/bin/bash, -lc]
+              args:
+                - |
+                  set -euo pipefail
+                  # Fabric discovery. When the cluster allocates this pod an RDMA
+                  # HCA with a pod network interface, point UCX at it. With no HCA
+                  # the transports in UCX_TLS carry NIXL instead: MNNVL cuda_ipc
+                  # for bulk KV, TCP for the active-message control plane. Never
+                  # hardcode UCX_NET_DEVICES -- the device name is host-specific.
+                  hca=""
+                  for hca_path in /sys/class/infiniband/*; do
+                    [ -d "${hca_path}/device/net" ] || continue
+                    for net_path in "${hca_path}"/device/net/*; do
+                      [ -e "${net_path}" ] || continue
+                      hca="${hca_path##*/}"; break 2
+                    done
+                  done
+                  if [ -n "${hca}" ]; then
+                    export UCX_NET_DEVICES="${hca}:1"
+                    echo "RDMA_HCA_SELECTED=${hca} UCX_TLS=${UCX_TLS:-default}"
+                  else
+                    echo "RDMA_HCA_SELECTED=none UCX_TLS=${UCX_TLS:-default}"
+                    # A fabric variant whose UCX_TLS has no TCP fallback cannot
+                    # carry NIXL without an HCA. Stop now. Otherwise the pod
+                    # runs and the startupProbe fails 3h later.
+                    if [ "${DYN_REQUIRE_RDMA_HCA:-0}" = "1" ]; then
+                      echo "FATAL: no RDMA HCA, and UCX_TLS has no TCP fallback" >&2
+                      exit 1
+                    fi
+                  fi
+                  exec python3 -m dynamo.vllm \
+                    --model /model-cache/thinkingmachines/Inkling-NVFP4 \
+                    --served-model-name thinkingmachines/Inkling-NVFP4 \
+                    --trust-remote-code \
+                    --tokenizer-mode inkling \
+                    --dyn-reasoning-parser inkling \
+                    --dyn-tool-call-parser inkling \
+                    --reasoning-parser inkling \
+                    --dyn-enable-structural-tag \
+                    --structured-outputs-config \
+                    '{"enable_in_reasoning": true}' \
+                    --tensor-parallel-size 4 \
+                    --max-model-len 1048576 \
+                    --speculative-config '{"method":"mtp","num_speculative_tokens":8}' \
+                    --gpu-memory-utilization 0.92 \
+                    --kv-cache-memory-bytes 109521666048 \
+                    --enable-prefix-caching \
+                    --kernel-config.enable_flashinfer_autotune=False \
+                    --kv-events-config '{"enable_kv_cache_events": true}' \
+                    --disaggregation-mode prefill \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_connector_extra_config":{"num_threads":8}}'
+              env: &workerEnv
+                - {name: HF_HOME, value: /model-cache}
+                - {name: HF_HUB_OFFLINE, value: "1"}
+                - {name: TRANSFORMERS_OFFLINE, value: "1"}
+                - {name: VLLM_USE_V2_MODEL_RUNNER, value: "1"}
+                - {name: FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED, value: "1"}
+                # Retain only the latest completed prompt boundary. Env-only in
+                # vLLM; there is no equivalent CLI flag.
+                - {name: VLLM_PREFIX_CACHE_RETENTION_INTERVAL, value: "0"}
+                # A 1M-token forward pass can exceed the default worker timeout.
+                - {name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800"}
+                # Pin the control-plane interface. Left unset, NCCL and Gloo pick
+                # an interface from the host, which silently varies per node.
+                - {name: NCCL_SOCKET_IFNAME, value: eth0}
+                - {name: GLOO_SOCKET_IFNAME, value: eth0}
+                # MNNVL fabric for TP collectives and for NIXL's cuda_ipc path.
+                - {name: NCCL_MNNVL_ENABLE, value: "1"}
+                - {name: NCCL_NVLS_ENABLE, value: "1"}
+                - {name: NCCL_P2P_LEVEL, value: NVL}
+                - {name: NCCL_CUMEM_ENABLE, value: "1"}
+                - {name: VLLM_USE_NCCL_SYMM_MEM, value: "0"}
+                - {name: UCX_CUDA_IPC_ENABLE_MNNVL, value: "y"}
+                - {name: MC_FORCE_MNNVL, value: "1"}
+                # UCX's memory-type cache misattributes MNNVL-mapped buffers.
+                - {name: UCX_MEMTYPE_CACHE, value: "n"}
+                # cuda_ipc and cuda_copy are memory-type transports and cannot
+                # carry NIXL's UCX active-message control plane; tcp can. A
+                # fabric Component replaces this with its RDMA transports.
+                - {name: UCX_TLS, value: "cuda_copy,cuda_ipc,tcp"}
+                - {name: VLLM_ALLREDUCE_USE_FLASHINFER, value: "1"}
+                - {name: VLLM_FLASHINFER_ALLREDUCE_BACKEND, value: mnnvl}
+              ports: [{name: system, containerPort: 9090, protocol: TCP}]
+              startupProbe: &workerStartupProbe
+                httpGet: {path: /live, port: system}
+                periodSeconds: 10
+                timeoutSeconds: 5
+                failureThreshold: 1080
+              securityContext: &workerSecurityContext
+                runAsUser: 0
+                runAsGroup: 0
+                capabilities: {add: [IPC_LOCK, SYS_RESOURCE]}
+              resources:
+                requests: {nvidia.com/gpu: "4"}
+                limits: {nvidia.com/gpu: "4"}
+                claims: [{name: compute-domain-channel}]
+              volumeMounts: &workerVolumeMounts
+                - {name: model-cache, mountPath: /model-cache}
+          volumes: &workerVolumes
+            - {name: model-cache, persistentVolumeClaim: {claimName: model-cache}}
+
+    - name: VllmDecodeWorker
+      replicas: 1
+      type: decode
+      sharedMemorySize: 64Gi
+      podTemplate:
+        metadata:
+          annotations: {nvidia.com/vllm-distributed-executor-backend: mp}
+        spec:
+          hostIPC: true
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-GB300
+          # Some clusters taint their GPU nodes. This toleration is inert
+          # where they do not.
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          resourceClaims:
+            - name: compute-domain-channel
+              resourceClaimTemplateName: inkling-vllm-gb300-disagg-agentic-compute-domain-channel
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-inkling-dev.1
+              imagePullPolicy: Always
+              command: [/bin/bash, -lc]
+              args:
+                - |
+                  set -euo pipefail
+                  # See VllmPrefillWorker for the fabric-discovery rationale.
+                  hca=""
+                  for hca_path in /sys/class/infiniband/*; do
+                    [ -d "${hca_path}/device/net" ] || continue
+                    for net_path in "${hca_path}"/device/net/*; do
+                      [ -e "${net_path}" ] || continue
+                      hca="${hca_path##*/}"; break 2
+                    done
+                  done
+                  if [ -n "${hca}" ]; then
+                    export UCX_NET_DEVICES="${hca}:1"
+                    echo "RDMA_HCA_SELECTED=${hca} UCX_TLS=${UCX_TLS:-default}"
+                  else
+                    echo "RDMA_HCA_SELECTED=none UCX_TLS=${UCX_TLS:-default}"
+                    # A fabric variant whose UCX_TLS has no TCP fallback cannot
+                    # carry NIXL without an HCA. Stop now. Otherwise the pod
+                    # runs and the startupProbe fails 3h later.
+                    if [ "${DYN_REQUIRE_RDMA_HCA:-0}" = "1" ]; then
+                      echo "FATAL: no RDMA HCA, and UCX_TLS has no TCP fallback" >&2
+                      exit 1
+                    fi
+                  fi
+                  exec python3 -m dynamo.vllm \
+                    --model /model-cache/thinkingmachines/Inkling-NVFP4 \
+                    --served-model-name thinkingmachines/Inkling-NVFP4 \
+                    --trust-remote-code \
+                    --tokenizer-mode inkling \
+                    --dyn-reasoning-parser inkling \
+                    --dyn-tool-call-parser inkling \
+                    --reasoning-parser inkling \
+                    --dyn-enable-structural-tag \
+                    --structured-outputs-config \
+                    '{"enable_in_reasoning": true}' \
+                    --tensor-parallel-size 4 \
+                    --max-model-len 1048576 \
+                    --speculative-config '{"method":"mtp","num_speculative_tokens":8}' \
+                    --gpu-memory-utilization 0.92 \
+                    --kv-cache-memory-bytes 109521666048 \
+                    --enable-prefix-caching \
+                    --kernel-config.enable_flashinfer_autotune=False \
+                    --kv-events-config '{"enable_kv_cache_events": true}' \
+                    --disaggregation-mode decode \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_connector_extra_config":{"num_threads":8}}'
+              env: *workerEnv
+              ports: [{name: system, containerPort: 9090, protocol: TCP}]
+              startupProbe: *workerStartupProbe
+              securityContext: *workerSecurityContext
+              resources:
+                requests: {nvidia.com/gpu: "4"}
+                limits: {nvidia.com/gpu: "4"}
+                claims: [{name: compute-domain-channel}]
+              volumeMounts: *workerVolumeMounts
+          volumes: *workerVolumes

--- a/recipes/inkling/vllm/disagg-gb300-agentic/kustomize/base/kustomization.yaml
+++ b/recipes/inkling/vllm/disagg-gb300-agentic/kustomize/base/kustomization.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+sortOptions:
+  order: fifo
+components:
+  - ../../../../../kustomize/components/dynamo-openapi
+resources:
+  - deploy.yaml

--- a/recipes/inkling/vllm/disagg-gb300-agentic/kustomize/components/aws-roce-dra/kustomization.yaml
+++ b/recipes/inkling/vllm/disagg-gb300-agentic/kustomize/components/aws-roce-dra/kustomization.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# RoCE over Dynamic Resource Allocation, as exposed by EKS through the
+# `roce.networking.k8s.aws` device class. Each worker claims one RoCE device;
+# the base image's fabric-discovery prologue then finds the allocated HCA and
+# points UCX at it.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - resourceclaimtemplate.yaml
+patches:
+  - target:
+      group: nvidia.com
+      version: v1beta1
+      kind: DynamoGraphDeployment
+    path: patch-dgd.yaml

--- a/recipes/inkling/vllm/disagg-gb300-agentic/kustomize/components/aws-roce-dra/patch-dgd.yaml
+++ b/recipes/inkling/vllm/disagg-gb300-agentic/kustomize/components/aws-roce-dra/patch-dgd.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: inkling-vllm-gb300-disagg-agentic
+spec:
+  components:
+    - name: VllmPrefillWorker
+      podTemplate:
+        spec:
+          resourceClaims: &roceClaims
+            - name: roce
+              resourceClaimTemplateName: inkling-vllm-gb300-disagg-agentic-roce
+          containers:
+            - name: main
+              env: &roceEnv
+                # RDMA transports replace the base's TCP control plane: rc_x/rc
+                # are active-message capable, so NIXL runs entirely over RoCE
+                # while cuda_ipc still serves peers reachable over MNNVL.
+                - {name: UCX_TLS, value: "rc_x,rc,cuda_copy,cuda_ipc"}
+                # RoCE, not InfiniBand: address the HCA by its Ethernet GID.
+                - {name: UCX_IB_ADDR_TYPE, value: eth}
+                # The transports above need an HCA. The DRA claim can be met by
+                # char devices alone, with no netdev in the pod, so the worker
+                # must stop when discovery finds none.
+                - {name: DYN_REQUIRE_RDMA_HCA, value: "1"}
+              resources:
+                claims: &roceResourceClaims
+                  - name: compute-domain-channel
+                  - name: roce
+    - name: VllmDecodeWorker
+      podTemplate:
+        spec:
+          resourceClaims: *roceClaims
+          containers:
+            - name: main
+              env: *roceEnv
+              resources:
+                claims: *roceResourceClaims

--- a/recipes/inkling/vllm/disagg-gb300-agentic/kustomize/components/aws-roce-dra/resourceclaimtemplate.yaml
+++ b/recipes/inkling/vllm/disagg-gb300-agentic/kustomize/components/aws-roce-dra/resourceclaimtemplate.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: inkling-vllm-gb300-disagg-agentic-roce
+spec:
+  spec:
+    devices:
+      requests:
+        - name: roce
+          exactly:
+            allocationMode: ExactCount
+            count: 1
+            deviceClassName: roce.networking.k8s.aws

--- a/recipes/inkling/vllm/disagg-gb300-agentic/kustomize/overlays/aws-roce/kustomization.yaml
+++ b/recipes/inkling/vllm/disagg-gb300-agentic/kustomize/overlays/aws-roce/kustomization.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Generated file. For repository contributors, do not edit this checked-in copy.
+# Regenerate this matrix's public overlays and template Components from the repository root:
+# Regenerate: scripts/kustomize-matrix.py unfold recipes/inkling/vllm/disagg-gb300-agentic/.kustomize-matrix.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+sortOptions:
+  order: legacy
+  legacySortOptions:
+    orderFirst: ["ResourceClaimTemplate", "ComputeDomain"]
+    orderLast: []
+resources:
+  - "../../base"
+components:
+  - "../../components/aws-roce-dra"

--- a/recipes/inkling/vllm/disagg-gb300-agentic/kustomize/overlays/generic/kustomization.yaml
+++ b/recipes/inkling/vllm/disagg-gb300-agentic/kustomize/overlays/generic/kustomization.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Generated file. For repository contributors, do not edit this checked-in copy.
+# Regenerate this matrix's public overlays and template Components from the repository root:
+# Regenerate: scripts/kustomize-matrix.py unfold recipes/inkling/vllm/disagg-gb300-agentic/.kustomize-matrix.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+sortOptions:
+  order: fifo
+resources:
+  - "../../base"

--- a/scripts/kustomize-matrix.py
+++ b/scripts/kustomize-matrix.py
@@ -76,6 +76,10 @@ class MatrixValue:
     components: tuple[Path, ...]
     templates: tuple[TemplateSelection, ...]
     values: dict[str, Any]
+    sort_options: str | None = None
+
+
+DEFAULT_SORT_OPTIONS = "sortOptions:\n  order: fifo"
 
 
 @dataclass(frozen=True)
@@ -84,6 +88,11 @@ class MatrixVariant:
     components: tuple[Path, ...]
     templates: tuple[TemplateSelection, ...]
     values: dict[str, Any]
+    # Rendered `sortOptions:` block for this variant's generated overlay.
+    # Kustomize reads sortOptions from the kustomization it builds, so a base
+    # cannot set them -- only the generated overlay can. Per variant, not per
+    # matrix: only the variant that needs an order pays for one.
+    sort_options: str = DEFAULT_SORT_OPTIONS
 
 
 @dataclass(frozen=True)
@@ -277,6 +286,7 @@ def load_matrix(path: str) -> MatrixConfig:
                 "components",
                 "templates",
                 "values",
+                "sortOptions",
             }
             if unknown_value_keys:
                 raise ValueError(
@@ -307,6 +317,11 @@ def load_matrix(path: str) -> MatrixConfig:
                     ),
                     values=load_variant_values(
                         raw_value.get("values"), f"{context}.values"
+                    ),
+                    sort_options=(
+                        parse_sort_options(raw_value["sortOptions"])
+                        if "sortOptions" in raw_value
+                        else None
                     ),
                 )
             )
@@ -385,12 +400,25 @@ def expand_matrix(config: MatrixConfig) -> list[MatrixVariant]:
                         f"variant {name!r} defines value {key!r} more than once"
                     )
                 variant_values[key] = template_value
+        selected_sort_options = [
+            value.sort_options for value in values if value.sort_options is not None
+        ]
+        if len(set(selected_sort_options)) > 1:
+            raise ValueError(
+                f"variant {name!r} selects conflicting sortOptions from more than "
+                f"one dimension"
+            )
         variants.append(
             MatrixVariant(
                 name=name,
                 components=components,
                 templates=templates,
                 values=variant_values,
+                sort_options=(
+                    selected_sort_options[0]
+                    if selected_sort_options
+                    else DEFAULT_SORT_OPTIONS
+                ),
             )
         )
 
@@ -735,6 +763,59 @@ def generated_template_content(
     )
 
 
+def parse_sort_options(raw: Any) -> str:
+    """Render an optional matrix `sortOptions` mapping into a kustomization block.
+
+    Omitted (the normal case) keeps the repository-wide `order: fifo`, so matrices
+    that do not declare it render byte-identically.
+    """
+    if raw is None:
+        return DEFAULT_SORT_OPTIONS
+    if not isinstance(raw, dict) or not raw:
+        raise ValueError("sortOptions must be a non-empty mapping")
+    unknown = set(raw) - {"order", "legacySortOptions"}
+    if unknown:
+        raise ValueError(f"unsupported sortOptions key: {min(unknown)}")
+    order = require_string(raw.get("order"), "sortOptions.order")
+    if order not in {"fifo", "legacy"}:
+        raise ValueError(f"sortOptions.order must be fifo or legacy, got {order!r}")
+
+    lines = ["sortOptions:", f"  order: {order}"]
+    legacy = raw.get("legacySortOptions")
+    if legacy is not None:
+        if order != "legacy":
+            raise ValueError("sortOptions.legacySortOptions requires order: legacy")
+        if not isinstance(legacy, dict):
+            raise ValueError("sortOptions.legacySortOptions must be a mapping")
+        unknown_legacy = set(legacy) - {"orderFirst", "orderLast"}
+        if unknown_legacy:
+            raise ValueError(
+                f"unsupported legacySortOptions key: {min(unknown_legacy)}"
+            )
+        legacy_lines: list[str] = []
+        for key in ("orderFirst", "orderLast"):
+            kinds = legacy.get(key)
+            if kinds is None:
+                continue
+            if not isinstance(kinds, list) or not all(
+                isinstance(kind, str) for kind in kinds
+            ):
+                raise ValueError(f"legacySortOptions.{key} must be a list of kinds")
+            legacy_lines.append(f"    {key}: {json.dumps(kinds)}")
+        # Emitting the key with no children renders `legacySortOptions:`, which
+        # parses back as null rather than an empty mapping, and Kustomize then
+        # applies its own hardcoded legacy ordering. Reject instead: omitting the
+        # key entirely is the way to ask for the default ordering.
+        if not legacy_lines:
+            raise ValueError(
+                "sortOptions.legacySortOptions must set orderFirst or orderLast; "
+                "omit the key to keep Kustomize's default legacy ordering"
+            )
+        lines.append("  legacySortOptions:")
+        lines.extend(legacy_lines)
+    return "\n".join(lines)
+
+
 def unfolded_kustomization(
     config: MatrixConfig, variant: MatrixVariant, template_components: tuple[Path, ...]
 ) -> str:
@@ -748,8 +829,7 @@ def unfolded_kustomization(
         "",
         "apiVersion: kustomize.config.k8s.io/v1beta1",
         "kind: Kustomization",
-        "sortOptions:",
-        "  order: fifo",
+        *variant.sort_options.split("\n"),
         "resources:",
         f"  - {json.dumps(relative_path(config.source, overlay_dir))}",
     ]

--- a/tests/test_kustomize_matrix.py
+++ b/tests/test_kustomize_matrix.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import importlib.util
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -826,3 +827,154 @@ def test_help():
 
     assert result.returncode == 0
     assert "{unfold,render,check,compose}" in result.stdout
+
+
+def test_sort_options_default_and_opt_in():
+    """A matrix without `sortOptions` keeps fifo; only an opt-in matrix differs."""
+    module = load_matrix_module()
+
+    # Omitted -> byte-identical to the repository-wide default, so existing
+    # matrices regenerate unchanged.
+    assert module.parse_sort_options(None) == "sortOptions:\n  order: fifo"
+
+    # Opt-in renders a legacy block with explicit kind ordering. Kustomize applies
+    # sortOptions from the kustomization being built, so this only works when the
+    # generated overlay carries it -- a base cannot set it.
+    rendered = module.parse_sort_options(
+        {
+            "order": "legacy",
+            "legacySortOptions": {
+                "orderFirst": ["ResourceClaimTemplate", "ComputeDomain"],
+                "orderLast": [],
+            },
+        }
+    )
+    assert rendered == (
+        "sortOptions:\n"
+        "  order: legacy\n"
+        "  legacySortOptions:\n"
+        '    orderFirst: ["ResourceClaimTemplate", "ComputeDomain"]\n'
+        "    orderLast: []"
+    )
+
+
+@pytest.mark.parametrize(
+    "raw, message",
+    [
+        ({}, "non-empty mapping"),
+        ({"order": "alphabetical"}, "must be fifo or legacy"),
+        ({"order": "fifo", "legacySortOptions": {}}, "requires order: legacy"),
+        ({"order": "legacy", "nope": 1}, "unsupported sortOptions key"),
+        (
+            {"order": "legacy", "legacySortOptions": {"orderFirst": "Secret"}},
+            "must be a list of kinds",
+        ),
+        # An empty (or all-null) mapping would render `legacySortOptions:` with no
+        # children, which parses back as null -- not an empty mapping -- and lets
+        # Kustomize fall back to its own hardcoded legacy ordering.
+        (
+            {"order": "legacy", "legacySortOptions": {}},
+            "must set orderFirst or orderLast",
+        ),
+        (
+            {"order": "legacy", "legacySortOptions": {"orderFirst": None}},
+            "must set orderFirst or orderLast",
+        ),
+    ],
+)
+def test_sort_options_rejects_invalid_input(raw, message):
+    module = load_matrix_module()
+    with pytest.raises(ValueError, match=message):
+        module.parse_sort_options(raw)
+
+
+def _kustomize_build_argv():
+    """Real Kustomize, so the test asserts what users get, not what we emit."""
+    for argv in (["kustomize", "build"], ["kubectl", "kustomize"]):
+        if shutil.which(argv[0]):
+            return argv
+    return None
+
+
+@pytest.mark.parametrize(
+    "variant_sort_options, expected_order",
+    [
+        # fifo keeps authored order, so the claim template lands last.
+        ("", ["ComputeDomain", "DynamoGraphDeployment", "ResourceClaimTemplate"]),
+        # The opt-in puts the claim template before the DGD that claims it.
+        (
+            "      sortOptions:\n"
+            "        order: legacy\n"
+            "        legacySortOptions:\n"
+            "          orderFirst: [ResourceClaimTemplate, ComputeDomain]\n"
+            "          orderLast: []\n",
+            ["ResourceClaimTemplate", "ComputeDomain", "DynamoGraphDeployment"],
+        ),
+    ],
+    ids=["default-fifo", "opt-in-legacy"],
+)
+def test_sort_options_control_rendered_resource_order(
+    tmp_path, variant_sort_options, expected_order
+):
+    """Render with real Kustomize and assert the order the user receives.
+
+    The unit tests cover the emitted YAML. Only a real build proves the property
+    the feature exists for: the claim template comes before the DGD.
+    """
+    argv = _kustomize_build_argv()
+    if argv is None:
+        pytest.skip("no kustomize or kubectl on PATH")
+
+    recipe = tmp_path / "recipe"
+    base = recipe / "kustomize/base"
+    write_kustomization(base, "resources:\n  - deploy.yaml\n")
+    (base / "deploy.yaml").write_text(
+        "apiVersion: resource.nvidia.com/v1beta1\n"
+        "kind: ComputeDomain\n"
+        "metadata:\n  name: cd\n"
+        "---\n"
+        "apiVersion: nvidia.com/v1beta1\n"
+        "kind: DynamoGraphDeployment\n"
+        "metadata:\n  name: dgd\n",
+        encoding="utf-8",
+    )
+    component = recipe / "kustomize/components/claim"
+    component.mkdir(parents=True)
+    (component / "kustomization.yaml").write_text(
+        "apiVersion: kustomize.config.k8s.io/v1alpha1\n"
+        "kind: Component\n"
+        "resources:\n  - rct.yaml\n",
+        encoding="utf-8",
+    )
+    (component / "rct.yaml").write_text(
+        "apiVersion: resource.k8s.io/v1\n"
+        "kind: ResourceClaimTemplate\n"
+        "metadata:\n  name: rct\n",
+        encoding="utf-8",
+    )
+
+    matrix = recipe / ".kustomize-matrix.yaml"
+    matrix.write_text(
+        "source: kustomize/base\n"
+        'nameTemplate: "${variant}"\n'
+        "matrix:\n"
+        "  variant:\n"
+        "    - name: claimed\n"
+        "      components:\n"
+        "        - kustomize/components/claim\n" + variant_sort_options,
+        encoding="utf-8",
+    )
+
+    module = load_matrix_module()
+    module.unfold_matrix(module.load_matrix(str(matrix)), check=False, clean=False)
+
+    overlay = recipe / "kustomize/overlays/claimed"
+    result = subprocess.run(
+        [*argv, str(overlay)], capture_output=True, text=True, check=True
+    )
+    order = [
+        line.split(":", 1)[1].strip()
+        for line in result.stdout.splitlines()
+        if line.startswith("kind:")
+    ]
+    assert order == expected_order


### PR DESCRIPTION
## Summary

Cherry-picks merged #13798 (`5e75161371dbca94ad878b7fee2904c0715d308b`) and #14235 (`83c520aafd5d459a92ca0c1252cdc1a143ad5fcb`) onto `release/1.5.0-inkling-dev.1`.

- Adds Inkling-NVFP4 vLLM GB300 agentic aggregated and disaggregated recipes, perf assets, kustomize-matrix `sortOptions` support, and related docs
- Declares `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.5.0-inkling-dev.1` in the Inkling recipe catalog
- Uses signed-off cherry-pick commits

## Verification

- [x] Cherry-picked merge commits with `git cherry-pick --signoff`
- [x] Resolved narrow conflicts in `overview.mdx` and `AGENTS.md` using the source merge commit versions
- [x] `git diff --check` passes
- [x] Recipe, script, test, and catalog paths match the source merge commits; `recipes/CONTRIBUTING.md` retains release-branch doc structure with the PR `sortOptions` addition applied