### PR TITLE
feat(mm-routing): [cherry-pick 1.5.0] add Qwen video-aware KV routing

### DIFF
--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -133,7 +133,7 @@ jobs:
           mkdir -p "${CARGO_TARGET_DIR}"
           echo "CARGO_TARGET_DIR=${CARGO_TARGET_DIR}" >> "$GITHUB_ENV"
 
-      - name: Run Rust checks (block-manager + media-ffmpeg + integration tests)
+      - name: Run Rust checks (block-manager + media-ffmpeg + MM routing + integration tests)
         # Run from the checked-out source (owned by the runner uid) rather than
         # /workspace (baked as dynamo:0 mode 0775). The ARC pod runs as uid 1001
         # with non-zero gid, so it falls into "other" perms on the baked tree and
@@ -148,7 +148,7 @@ jobs:
           eval $(/workspace/container/use-sccache.sh setup-env)
           rustup component add rustfmt clippy
           cargo fmt -- --check
-          cargo clippy --features block-manager,media-ffmpeg,testing-nixl,integration --no-deps --all-targets -- -D warnings
+          cargo clippy --features block-manager,media-ffmpeg,mm-routing,testing-nixl,integration --no-deps --all-targets -- -D warnings
           # dynamo_llm lib unit tests mutate process env via `temp_env`
           # (std::env::set_var/remove_var); in a multi-threaded libtest binary that
           # write reallocates `environ` while another test thread (a parallel test's
@@ -162,7 +162,7 @@ jobs:
           # criterion. (Verified on the GPU tester: whole command runs green with
           # benches; lib suite 7s -> 35s single-threaded, other targets sub-second; and
           # under 12x contention 3/3 parallel shards segfault vs 0/3 single-threaded.)
-          RUST_TEST_THREADS=1 cargo test --locked --all-targets --features=block-manager,media-ffmpeg,testing-nixl,integration -- --nocapture
+          RUST_TEST_THREADS=1 cargo test --locked --all-targets --features=block-manager,media-ffmpeg,mm-routing,testing-nixl,integration -- --nocapture
           cargo clippy -p kvbm-physical --no-deps --all-targets -- -D warnings
           cargo test --locked -p kvbm-physical --features testing-kvbm -- --nocapture --test-threads=4
           /workspace/container/use-sccache.sh show-stats "Rust Checks"

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -78,6 +78,9 @@ from .kv_connector_protocols import (
 )
 from .multimodal_utils.cache_config import configure_multimodal_embedding_cache
 from .multimodal_utils.media_config import create_frontend_media_config
+from .multimodal_utils.models.qwen_video_routing import (
+    publish_vllm_qwen_video_processor_contract,
+)
 from .publisher import DYNAMO_COMPONENT_REGISTRY, StatLoggerFactory
 from .snapshot import prepare_snapshot_engine
 from .state_agent import (
@@ -427,6 +430,15 @@ def _resolve_image_token_id(config: Config, vllm_config: VllmConfig) -> Optional
     return resolve_routing_image_token_id(config.model, model_dir)
 
 
+def _resolve_video_token_id(vllm_config: VllmConfig) -> Optional[int]:
+    hf_config = vllm_config.model_config.hf_config
+    for field in ("video_token_id", "video_token_index"):
+        token_id = getattr(hf_config, field, None)
+        if token_id is not None:
+            return int(token_id)
+    return None
+
+
 def setup_kv_event_publisher(
     config: Config,
     generate_endpoint: Endpoint,
@@ -466,12 +478,12 @@ def setup_kv_event_publisher(
     dp_start, dp_size = get_dp_range_for_worker(vllm_config)
     kv_publishers = []
     kv_event_block_size = get_configured_kv_event_block_size(vllm_config)
-    # The image-placeholder token id the frontend substitutes pad_value over.
-    # Passed to the KV publisher so the router-side normalizer rewrites those
-    # runs in vLLM BlockStored events to the same canonical pad_value scheme.
-    # None (no mm-routing, model not in registry, text-only) leaves events
-    # unchanged — consistent with the frontend also skipping MM routing.
+    # Placeholder token ids the frontend substitutes pad_value over. Pass them
+    # to the KV publisher so the router-side normalizer rewrites image and
+    # video runs in vLLM BlockStored events to the same canonical scheme.
+    # Missing ids leave their modality unchanged.
     image_token_id = _resolve_image_token_id(config, vllm_config)
+    video_token_id = _resolve_video_token_id(vllm_config)
 
     for dp_rank in range(dp_start, dp_start + dp_size):
         if consolidator_enabled:
@@ -499,6 +511,7 @@ def setup_kv_event_publisher(
             dp_rank=dp_rank,
             image_token_id=image_token_id,
             kv_state_endpoint=config.kv_state_endpoint,
+            video_token_id=video_token_id,
         )
         kv_publishers.append(kv_publisher)
 
@@ -809,6 +822,7 @@ async def register_vllm_model(
     """
     runtime_config = ModelRuntimeConfig()
     publish_vllm_structural_tag_reasoning_policy(runtime_config, vllm_config)
+    publish_vllm_qwen_video_processor_contract(runtime_config, vllm_config)
     dp_range = get_dp_range_for_worker(vllm_config)
     state_agent_enabled = state_agent_settings(config) is not None
     apply_data_parallel_runtime_config(runtime_config, dp_range)

--- a/components/src/dynamo/vllm/multimodal_utils/models/qwen_video_routing.py
+++ b/components/src/dynamo/vllm/multimodal_utils/models/qwen_video_routing.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve the Qwen video processor contract used by vLLM workers."""
+
+import json
+import logging
+from collections.abc import Callable
+from typing import Any, Optional
+
+import transformers
+from vllm.config import VllmConfig
+
+from dynamo.llm import ModelRuntimeConfig
+
+qwen3_smart_resize: Optional[Callable[..., Any]]
+try:
+    from transformers.models.qwen3_vl.video_processing_qwen3_vl import (
+        smart_resize as _qwen3_smart_resize,
+    )
+except ImportError:
+    qwen3_smart_resize = None
+else:
+    qwen3_smart_resize = _qwen3_smart_resize
+
+logger = logging.getLogger(__name__)
+
+VLLM_QWEN_VIDEO_PROCESSOR_CONTRACT_RUNTIME_KEY = "vllm_qwen_video_processor_contract"
+QWEN_VIDEO_TARGET_BARE = "bare_video_token"
+QWEN_VIDEO_TARGET_WRAPPED = "vision_wrapped_video_token"
+QWEN_VIDEO_RESIZE_LEGACY_CEIL = "legacy_ceil"
+QWEN_VIDEO_RESIZE_ROUND_TIES_EVEN = "round_ties_even"
+QWEN_VIDEO_MODEL_TYPES = {"qwen3_vl", "qwen3_vl_moe", "qwen3_5", "qwen3_5_moe"}
+QWEN_VIDEO_ARCHITECTURES = {
+    "Qwen3VLForConditionalGeneration",
+    "Qwen3VLMoeForConditionalGeneration",
+    "Qwen3_5ForConditionalGeneration",
+    "Qwen3_5MoeForConditionalGeneration",
+}
+
+
+def _resolve_qwen_video_resize_mode() -> Optional[str]:
+    """Identify the installed Qwen video processor's temporal resize rule."""
+    if qwen3_smart_resize is None:
+        logger.warning(
+            "Exact video-aware KV routing disabled because the installed "
+            "Transformers package has no Qwen3 video processor"
+        )
+        return None
+    try:
+        result = qwen3_smart_resize(
+            num_frames=5,
+            height=1120,
+            width=3760,
+            temporal_factor=2,
+            factor=32,
+            min_pixels=4096,
+            max_pixels=25165824,
+        )
+    except (TypeError, ValueError) as error:
+        logger.warning(
+            "Exact video-aware KV routing disabled because the installed Qwen "
+            "smart_resize API is unsupported: %s",
+            error,
+        )
+        return None
+    if result == (1216, 4096):
+        return QWEN_VIDEO_RESIZE_LEGACY_CEIL
+    if result == (1120, 3776):
+        return QWEN_VIDEO_RESIZE_ROUND_TIES_EVEN
+    logger.warning(
+        "Exact video-aware KV routing disabled because the installed Qwen "
+        "smart_resize behavior is unsupported: %s",
+        result,
+    )
+    return None
+
+
+def _resolve_qwen_video_processor_contract(
+    vllm_config: VllmConfig,
+) -> Optional[dict[str, str]]:
+    """Match the prompt expansion selected by vLLM's Qwen3 processor."""
+    hf_config = vllm_config.model_config.hf_config
+    if getattr(hf_config, "model_type", None) not in QWEN_VIDEO_MODEL_TYPES:
+        return None
+    architectures = getattr(hf_config, "architectures", None) or []
+    if not QWEN_VIDEO_ARCHITECTURES.intersection(architectures):
+        return None
+    multimodal_config = vllm_config.model_config.multimodal_config
+    if multimodal_config is None:
+        return None
+    if multimodal_config.mm_processor_kwargs:
+        logger.warning(
+            "Exact video-aware KV routing disabled because engine-level "
+            "mm_processor_kwargs can change the Qwen video token layout"
+        )
+        return None
+
+    # Some supported vLLM images predate this optional capability query.
+    get_video_pruning_spec = getattr(multimodal_config, "get_video_pruning_spec", None)
+    if not callable(get_video_pruning_spec):
+        logger.warning(
+            "Exact video-aware KV routing disabled because the installed vLLM "
+            "cannot report video pruning configuration"
+        )
+        return None
+    if get_video_pruning_spec() is not None:
+        logger.warning(
+            "Exact video-aware KV routing disabled because video pruning "
+            "changes the Qwen video token layout"
+        )
+        return None
+
+    qwen_processor = getattr(transformers, "Qwen3VLProcessor", None)
+    if qwen_processor is None:
+        logger.warning(
+            "Exact video-aware KV routing disabled because the installed "
+            "Transformers package has no Qwen3 processor"
+        )
+        return None
+    mixin_impl = getattr(transformers.ProcessorMixin, "replace_video_token", None)
+    processor_impl = getattr(qwen_processor, "replace_video_token", None)
+    placeholder_target = QWEN_VIDEO_TARGET_WRAPPED
+    if processor_impl is not None and processor_impl is not mixin_impl:
+        placeholder_target = QWEN_VIDEO_TARGET_BARE
+    resize_mode = _resolve_qwen_video_resize_mode()
+    if resize_mode is None:
+        return None
+    return {
+        "placeholder_target": placeholder_target,
+        "resize_mode": resize_mode,
+    }
+
+
+def publish_vllm_qwen_video_processor_contract(
+    runtime_config: ModelRuntimeConfig, vllm_config: VllmConfig
+) -> None:
+    """Publish exact Qwen video preprocessing behavior for the frontend."""
+    contract = _resolve_qwen_video_processor_contract(vllm_config)
+    if contract is not None:
+        runtime_config.set_engine_specific(
+            VLLM_QWEN_VIDEO_PROCESSOR_CONTRACT_RUNTIME_KEY,
+            json.dumps(contract),
+        )

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_qwen_video_routing.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_qwen_video_routing.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the vLLM Qwen video routing contract."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from dynamo.vllm.multimodal_utils.models import qwen_video_routing
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.multimodal,
+    pytest.mark.timeout(180),
+]
+
+
+def _qwen_vllm_config(multimodal_config):
+    return SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                model_type="qwen3_5",
+                architectures=["Qwen3_5ForConditionalGeneration"],
+            ),
+            multimodal_config=multimodal_config,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides_video_replacement", "expected"),
+    [
+        (True, "bare_video_token"),
+        (False, "vision_wrapped_video_token"),
+    ],
+)
+def test_publishes_actual_qwen_video_placeholder_target(
+    monkeypatch, overrides_video_replacement, expected
+):
+    class ProcessorMixin:
+        def replace_video_token(self):
+            pass
+
+    if overrides_video_replacement:
+
+        class Qwen3VLProcessor(ProcessorMixin):
+            def replace_video_token(self):
+                pass
+
+    else:
+
+        class Qwen3VLProcessor(ProcessorMixin):
+            pass
+
+    monkeypatch.setattr(
+        qwen_video_routing.transformers, "ProcessorMixin", ProcessorMixin
+    )
+    monkeypatch.setattr(
+        qwen_video_routing.transformers,
+        "Qwen3VLProcessor",
+        Qwen3VLProcessor,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        qwen_video_routing,
+        "_resolve_qwen_video_resize_mode",
+        lambda: qwen_video_routing.QWEN_VIDEO_RESIZE_LEGACY_CEIL,
+    )
+    runtime_config = SimpleNamespace(set_engine_specific=Mock())
+    vllm_config = _qwen_vllm_config(
+        SimpleNamespace(
+            mm_processor_kwargs=None,
+            get_video_pruning_spec=lambda: None,
+        )
+    )
+
+    qwen_video_routing.publish_vllm_qwen_video_processor_contract(
+        runtime_config, vllm_config
+    )
+
+    runtime_config.set_engine_specific.assert_called_once_with(
+        qwen_video_routing.VLLM_QWEN_VIDEO_PROCESSOR_CONTRACT_RUNTIME_KEY,
+        json.dumps(
+            {
+                "placeholder_target": expected,
+                "resize_mode": qwen_video_routing.QWEN_VIDEO_RESIZE_LEGACY_CEIL,
+            }
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "hf_config",
+    [
+        SimpleNamespace(model_type="llama"),
+        SimpleNamespace(model_type="qwen3_5", architectures=["Qwen3_5ForCausalLM"]),
+    ],
+)
+def test_skips_video_placeholder_target_for_non_video_models(hf_config):
+    runtime_config = SimpleNamespace(set_engine_specific=Mock())
+    vllm_config = SimpleNamespace(model_config=SimpleNamespace(hf_config=hf_config))
+
+    qwen_video_routing.publish_vllm_qwen_video_processor_contract(
+        runtime_config, vllm_config
+    )
+
+    runtime_config.set_engine_specific.assert_not_called()
+
+
+def test_skips_video_placeholder_target_for_engine_processor_overrides():
+    runtime_config = SimpleNamespace(set_engine_specific=Mock())
+    vllm_config = _qwen_vllm_config(
+        SimpleNamespace(
+            mm_processor_kwargs={"max_pixels": 4096},
+            get_video_pruning_spec=lambda: None,
+        )
+    )
+
+    qwen_video_routing.publish_vllm_qwen_video_processor_contract(
+        runtime_config, vllm_config
+    )
+
+    runtime_config.set_engine_specific.assert_not_called()
+
+
+def test_skips_video_placeholder_target_for_video_pruning():
+    runtime_config = SimpleNamespace(set_engine_specific=Mock())
+    vllm_config = _qwen_vllm_config(
+        SimpleNamespace(
+            mm_processor_kwargs=None,
+            get_video_pruning_spec=lambda: ("evs", 0.5),
+        )
+    )
+
+    qwen_video_routing.publish_vllm_qwen_video_processor_contract(
+        runtime_config, vllm_config
+    )
+
+    runtime_config.set_engine_specific.assert_not_called()
+
+
+def test_skips_video_contract_when_pruning_api_is_unavailable():
+    runtime_config = SimpleNamespace(set_engine_specific=Mock())
+    vllm_config = _qwen_vllm_config(SimpleNamespace(mm_processor_kwargs=None))
+
+    qwen_video_routing.publish_vllm_qwen_video_processor_contract(
+        runtime_config, vllm_config
+    )
+
+    runtime_config.set_engine_specific.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("resize_result", "expected"),
+    [
+        ((1216, 4096), "legacy_ceil"),
+        ((1120, 3776), "round_ties_even"),
+        ((999, 999), None),
+    ],
+)
+def test_resolve_qwen_video_resize_mode(monkeypatch, resize_result, expected):
+    resize = Mock(return_value=resize_result)
+    monkeypatch.setattr(qwen_video_routing, "qwen3_smart_resize", resize)
+
+    assert qwen_video_routing._resolve_qwen_video_resize_mode() == expected
+    resize.assert_called_once_with(
+        num_frames=5,
+        height=1120,
+        width=3760,
+        temporal_factor=2,
+        factor=32,
+        min_pixels=4096,
+        max_pixels=25165824,
+    )
+
+
+def test_resolve_qwen_video_resize_mode_without_qwen_processor(monkeypatch):
+    monkeypatch.setattr(qwen_video_routing, "qwen3_smart_resize", None)
+
+    assert qwen_video_routing._resolve_qwen_video_resize_mode() is None
+
+
+def test_skips_video_contract_without_qwen_processor(monkeypatch):
+    monkeypatch.setattr(
+        qwen_video_routing.transformers,
+        "Qwen3VLProcessor",
+        None,
+        raising=False,
+    )
+    runtime_config = SimpleNamespace(set_engine_specific=Mock())
+    vllm_config = _qwen_vllm_config(
+        SimpleNamespace(
+            mm_processor_kwargs=None,
+            get_video_pruning_spec=lambda: None,
+        )
+    )
+
+    qwen_video_routing.publish_vllm_qwen_video_processor_contract(
+        runtime_config, vllm_config
+    )
+
+    runtime_config.set_engine_specific.assert_not_called()

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -486,6 +486,54 @@ def test_vllm_publishes_structural_tag_reasoning_policy(
     )
 
 
+@pytest.mark.parametrize(
+    ("hf_config", "expected"),
+    [
+        (SimpleNamespace(video_token_id=101, video_token_index=202), 101),
+        (SimpleNamespace(video_token_index=202), 202),
+        (SimpleNamespace(), None),
+    ],
+)
+def test_resolve_video_token_id(hf_config, expected):
+    vllm_config = SimpleNamespace(model_config=SimpleNamespace(hf_config=hf_config))
+
+    assert _load_vllm_main()._resolve_video_token_id(vllm_config) == expected
+
+
+def test_kv_event_publisher_receives_video_token_id(monkeypatch):
+    vllm_main = _load_vllm_main()
+    publisher = Mock()
+    monkeypatch.setattr(vllm_main, "KvEventPublisher", publisher)
+    monkeypatch.setattr(vllm_main, "get_dp_range_for_worker", lambda _: (0, 1))
+    monkeypatch.setattr(vllm_main, "get_configured_kv_event_block_size", lambda _: 16)
+    monkeypatch.setattr(vllm_main, "_resolve_image_token_id", lambda *_: 100)
+    monkeypatch.setattr(vllm_main, "_resolve_video_token_id", lambda _: 200)
+    monkeypatch.setattr(
+        vllm_main.ZmqEventPublisher,
+        "offset_endpoint_port",
+        lambda endpoint, data_parallel_rank: endpoint,
+    )
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(
+            enable_prefix_caching=True,
+            kv_events_config=SimpleNamespace(
+                enable_kv_cache_events=True,
+                endpoint="tcp://*:5557",
+            ),
+        ),
+        enable_local_indexer=True,
+        kv_state_endpoint=None,
+    )
+
+    publishers = vllm_main.setup_kv_event_publisher(
+        config, SimpleNamespace(), SimpleNamespace()
+    )
+
+    assert publishers is not None and len(publishers) == 1
+    assert publisher.call_args.kwargs["image_token_id"] == 100
+    assert publisher.call_args.kwargs["video_token_id"] == 200
+
+
 @pytest.mark.parametrize("load_format", ["modelexpress", "mx"])
 def test_should_not_prefetch_model_for_modelexpress_load_formats(load_format):
     from dynamo.vllm.main import (

--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -183,7 +183,7 @@ Kubernetes: `>=1.30.0-0`
 | dynamo-operator.controllerManager.leaderElection.id | string | `""` | Leader election ID for cluster-wide coordination. WARNING: All cluster-wide operators must use the SAME ID to prevent split-brain. Different IDs would allow multiple leaders simultaneously. |
 | dynamo-operator.controllerManager.leaderElection.namespace | string | `""` | Namespace for leader election leases (only used in cluster-wide mode). If empty, defaults to kube-system for cluster-wide coordination. All cluster-wide operators should use the SAME namespace for proper leader election. |
 | dynamo-operator.controllerManager.manager.image.repository | string | `"nvcr.io/nvidia/ai-dynamo/kubernetes-operator"` | Official NVIDIA Dynamo operator image repository |
-| dynamo-operator.controllerManager.manager.image.tag | string | `""` | Image tag (leave empty to use chart default) |
+| dynamo-operator.controllerManager.manager.image.tag | string | `"1.5.0"` | Image tag (leave empty to use chart default) |
 | dynamo-operator.controllerManager.manager.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy - when to pull the image |
 | dynamo-operator.controllerManager.manager.args[0] | string | `"--health-probe-bind-address=:8081"` | Health probe endpoint for Kubernetes health checks |
 | dynamo-operator.controllerManager.manager.args[1] | string | `"--metrics-bind-address=127.0.0.1:8080"` | Metrics endpoint for Prometheus scraping (localhost only for security) |

--- a/lib/kv-router/src/zmq_wire/convert.rs
+++ b/lib/kv-router/src/zmq_wire/convert.rs
@@ -193,7 +193,7 @@ fn mm_token_kind(
 /// timestamp-separated runs, so consecutive video runs belong to one object.
 /// Only an exact ordered run/object mapping is normalized. Boundary or mixed
 /// blocks that cannot be mapped exactly preserve vLLM's native MM hash path.
-fn substitute_pad_values(
+pub fn normalize_mm_placeholder_runs(
     token_ids: &[u32],
     image_token_id: Option<u32>,
     video_token_id: Option<u32>,
@@ -346,7 +346,7 @@ fn create_stored_block_from_parts_with_video_context(
     let normalized_tokens = match mm_extra_info.as_ref() {
         Some(info) if requires_exact_mm_mapping && !info.mm_objects.is_empty() => {
             let mm_hashes: Vec<u64> = info.mm_objects.iter().map(|o| o.mm_hash).collect();
-            substitute_pad_values(token_ids, image_token_id, video_token_id, &mm_hashes)
+            normalize_mm_placeholder_runs(token_ids, image_token_id, video_token_id, &mm_hashes)
                 .map(|(tokens, _)| tokens)
         }
         Some(info)
@@ -778,7 +778,7 @@ mod normalize_tests {
             image_token_id,
         ];
 
-        let normalized = substitute_pad_values(
+        let normalized = normalize_mm_placeholder_runs(
             &tokens,
             Some(image_token_id),
             Some(video_token_id),
@@ -802,7 +802,9 @@ mod normalize_tests {
         let video_token_id = 151656u32;
         let tokens = [video_token_id, 7, video_token_id];
 
-        assert!(substitute_pad_values(&tokens, None, Some(video_token_id), &[41, 42]).is_none());
+        assert!(
+            normalize_mm_placeholder_runs(&tokens, None, Some(video_token_id), &[41, 42]).is_none()
+        );
     }
 
     #[test]
@@ -811,7 +813,7 @@ mod normalize_tests {
         let video_token_id = 151656u32;
 
         assert!(
-            substitute_pad_values(
+            normalize_mm_placeholder_runs(
                 &[image_token_id, 7, image_token_id],
                 Some(image_token_id),
                 Some(video_token_id),
@@ -820,7 +822,7 @@ mod normalize_tests {
             .is_none()
         );
         assert!(
-            substitute_pad_values(
+            normalize_mm_placeholder_runs(
                 &[image_token_id, image_token_id],
                 Some(image_token_id),
                 Some(video_token_id),
@@ -842,7 +844,7 @@ mod normalize_tests {
         let mm_objects: Vec<u64> = (0..28).collect();
 
         assert!(
-            substitute_pad_values(
+            normalize_mm_placeholder_runs(
                 &tokens,
                 Some(image_token_id),
                 Some(video_token_id),

--- a/lib/kv-router/src/zmq_wire/mod.rs
+++ b/lib/kv-router/src/zmq_wire/mod.rs
@@ -25,7 +25,7 @@ mod types;
 
 pub use convert::{
     StoredBlockOptions, convert_event, create_stored_block_from_parts, create_stored_blocks,
-    normalize_mm_token_runs,
+    normalize_mm_placeholder_runs, normalize_mm_token_runs,
 };
 pub use extra_keys::{
     extra_keys_to_block_mm_infos, extra_keys_to_cache_namespace, mark_mm_hash_for_extra_key,

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -91,6 +91,13 @@ pub const ENV_TOKENIZER_FALLBACK: &str = "DYN_TOKENIZER_FALLBACK";
 /// surfaces without implementing vLLM's Generate contract.
 pub const VLLM_INFERENCE_V1_GENERATE_CAPABILITY: &str = "vllm_inference_v1_generate";
 
+/// Worker-reported Qwen3 video prompt-expansion contract used by vLLM.
+///
+/// Absence disables exact video routing so a newer frontend remains safe with
+/// older workers that predate this runtime contract.
+pub const VLLM_QWEN_VIDEO_PROCESSOR_CONTRACT_RUNTIME_KEY: &str =
+    "vllm_qwen_video_processor_contract";
+
 /// Worker-reported vLLM setting that makes multimodal cache identities depend
 /// on the active LoRA adapter. Missing and explicit `false` are equivalent.
 pub const VLLM_ENABLE_TOWER_CONNECTOR_LORA_RUNTIME_KEY: &str = "vllm_enable_tower_connector_lora";

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -14,6 +14,8 @@
 #[cfg(feature = "mm-routing")]
 pub mod lightseek_mm;
 pub mod media;
+#[cfg(all(feature = "mm-routing", any(feature = "media-ffmpeg", test)))]
+mod mm_routing;
 pub mod prompt;
 pub mod speculative_prefill;
 pub(crate) mod structural_tag;
@@ -52,6 +54,8 @@ use std::{
 };
 use tracing;
 
+#[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+use crate::local_model::runtime_config::VLLM_QWEN_VIDEO_PROCESSOR_CONTRACT_RUNTIME_KEY;
 use crate::local_model::runtime_config::{TOKEN_BUDGET_RUNTIME_KEY, TokenBudget};
 #[cfg(feature = "mm-routing")]
 use crate::model_card::ModelInfoType;
@@ -744,6 +748,73 @@ pub struct MmImageEntry {
     pub height: u32,
 }
 
+/// One replacement tracked in both the worker-visible and canonical routing
+/// token spaces. vLLM includes MM metadata on every block intersecting a
+/// feature span, including timestamp/delimiter-only boundary blocks. Those
+/// blocks need the worker token form plus `block_mm_infos`; blocks with an
+/// exact placeholder/object mapping use the canonical pad-value form.
+#[cfg(feature = "mm-routing")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TrackedMmRoutingReplacement {
+    mm_hash: u64,
+    target_tokens: Vec<TokenIdType>,
+    worker_tokens: Vec<TokenIdType>,
+    routing_tokens: Vec<TokenIdType>,
+}
+
+/// Modality-aware routing payload accumulated in original message order.
+#[cfg_attr(
+    not(feature = "mm-routing"),
+    allow(
+        dead_code,
+        reason = "the default build keeps the shared media-gathering return type but emits no routing entries"
+    )
+)]
+#[derive(Debug, Clone)]
+enum MmRoutingEntry {
+    Image {
+        mm_hash: u64,
+        width: u32,
+        height: u32,
+    },
+    #[cfg_attr(
+        not(feature = "media-ffmpeg"),
+        allow(dead_code, reason = "video entries require the FFmpeg media decoder")
+    )]
+    Video {
+        mm_hash: u64,
+        placeholder_token_id: TokenIdType,
+        target_tokens: Vec<TokenIdType>,
+        replacement_tokens: Vec<TokenIdType>,
+    },
+}
+
+#[cfg(feature = "mm-routing")]
+impl MmRoutingEntry {
+    fn mm_hash(&self) -> u64 {
+        match self {
+            Self::Image { mm_hash, .. } | Self::Video { mm_hash, .. } => *mm_hash,
+        }
+    }
+}
+
+#[cfg(feature = "mm-routing")]
+fn exact_mm_routing_entries_are_unambiguous(entries: &[MmRoutingEntry]) -> bool {
+    !entries.windows(2).any(|pair| {
+        matches!(
+            pair,
+            [MmRoutingEntry::Video { .. }, MmRoutingEntry::Video { .. }]
+        )
+    })
+}
+
+#[cfg(feature = "mm-routing")]
+fn routing_bos_to_prepend(
+    configured_bos: Option<TokenIdType>,
+    has_image_entry: bool,
+) -> Option<TokenIdType> {
+    has_image_entry.then_some(configured_bos).flatten()
+}
 #[cfg(feature = "mm-routing")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RoutingImagePromptLayout {
@@ -832,6 +903,25 @@ fn append_mm_routing_replacement(
 ) -> Result<()> {
     let fill_token = dynamo_kv_router::protocols::pad_value_for_mm_hash(image.mm_hash);
 
+    append_mm_routing_replacement_with_fill(
+        expanded,
+        tokenizer,
+        layout,
+        image,
+        num_image_tokens,
+        fill_token,
+    )
+}
+
+#[cfg(feature = "mm-routing")]
+fn append_mm_routing_replacement_with_fill(
+    expanded: &mut Vec<TokenIdType>,
+    tokenizer: &dyn Tokenizer,
+    layout: RoutingImagePromptLayout,
+    image: MmImageEntry,
+    num_image_tokens: usize,
+    fill_token: TokenIdType,
+) -> Result<()> {
     match layout {
         RoutingImagePromptLayout::RepeatedPad => {
             expanded.extend(std::iter::repeat_n(fill_token, num_image_tokens));
@@ -852,6 +942,149 @@ fn append_mm_routing_replacement(
     Ok(())
 }
 
+/// Build the request-side hash representation that mirrors vLLM's event
+/// normalizer block by block.
+///
+/// Most blocks use canonical pad-value tokens. If a feature-span boundary
+/// does not contain an exact ordered placeholder/object mapping, vLLM keeps
+/// the worker tokens and hashes the block's MM metadata instead. Reproducing
+/// that fallback here keeps both sides identical without discarding the media
+/// identity carried by an ambiguous boundary block.
+#[cfg(feature = "mm-routing")]
+fn apply_tracked_mm_replacements(
+    routing_prepend_bos: Option<TokenIdType>,
+    replacements: &[TrackedMmRoutingReplacement],
+    token_ids: &[TokenIdType],
+    block_size: usize,
+    image_token_id: Option<TokenIdType>,
+    video_token_id: Option<TokenIdType>,
+) -> Result<(
+    Vec<TokenIdType>,
+    usize,
+    Vec<Option<dynamo_kv_router::protocols::BlockExtraInfo>>,
+)> {
+    use dynamo_kv_router::protocols::{BlockExtraInfo, BlockMmObjectInfo};
+    use dynamo_kv_router::zmq_wire::normalize_mm_placeholder_runs;
+
+    anyhow::ensure!(block_size > 0, "MM routing block size must be positive");
+    anyhow::ensure!(
+        replacements.iter().all(|replacement| {
+            !replacement.target_tokens.is_empty()
+                && replacement.worker_tokens.len() == replacement.routing_tokens.len()
+        }),
+        "tracked MM routing replacements must have a non-empty target and equal token lengths"
+    );
+
+    let replacement_tokens = replacements.iter().try_fold(0usize, |total, replacement| {
+        total
+            .checked_add(replacement.routing_tokens.len())
+            .context("MM routing replacement capacity overflow")
+    })?;
+    let capacity = token_ids
+        .len()
+        .checked_add(replacement_tokens)
+        .and_then(|value| value.checked_add(routing_prepend_bos.is_some() as usize))
+        .context("MM routing token capacity overflow")?;
+    let mut worker_tokens = Vec::with_capacity(capacity);
+    let mut routing_tokens = Vec::with_capacity(capacity);
+    if let Some(bos) = routing_prepend_bos {
+        worker_tokens.push(bos);
+        routing_tokens.push(bos);
+    }
+
+    // Placeholder targets are model/modality contracts, so many media objects
+    // normally share the same target. Deduplicate them once to keep the prompt
+    // scan proportional to the number of modalities rather than media objects.
+    let mut distinct_targets: Vec<&[TokenIdType]> = Vec::new();
+    for replacement in replacements {
+        let target = replacement.target_tokens.as_slice();
+        if !distinct_targets.contains(&target) {
+            distinct_targets.push(target);
+        }
+    }
+    let target_matches_at = |target: &[TokenIdType], token_index: usize| {
+        token_ids.get(token_index..token_index.saturating_add(target.len())) == Some(target)
+    };
+
+    let mut spans = Vec::with_capacity(replacements.len());
+    let mut replacement_index = 0usize;
+    let mut token_index = 0usize;
+    while token_index < token_ids.len() {
+        if let Some(replacement) = replacements.get(replacement_index)
+            && target_matches_at(&replacement.target_tokens, token_index)
+        {
+            let start = worker_tokens.len();
+            worker_tokens.extend_from_slice(&replacement.worker_tokens);
+            routing_tokens.extend_from_slice(&replacement.routing_tokens);
+            spans.push((start, worker_tokens.len(), replacement.mm_hash));
+            token_index += replacement.target_tokens.len();
+            replacement_index += 1;
+            continue;
+        }
+
+        anyhow::ensure!(
+            !distinct_targets
+                .iter()
+                .any(|target| target_matches_at(target, token_index)),
+            "multimodal placeholders do not match request order"
+        );
+        worker_tokens.push(token_ids[token_index]);
+        routing_tokens.push(token_ids[token_index]);
+        token_index += 1;
+    }
+
+    anyhow::ensure!(
+        replacement_index == replacements.len(),
+        "tokenized prompt is missing multimodal placeholders"
+    );
+    let expanded_prompt_len = routing_tokens.len();
+    let padded_len = expanded_prompt_len.div_ceil(block_size) * block_size;
+    worker_tokens.resize(padded_len, 0);
+    routing_tokens.resize(padded_len, 0);
+
+    let mut block_mm_infos = vec![None; padded_len / block_size];
+    for (block_index, block_start) in (0..padded_len).step_by(block_size).enumerate() {
+        let block_end = block_start + block_size;
+        let mm_hashes: Vec<u64> = spans
+            .iter()
+            .filter(|(start, end, _)| *start < block_end && *end > block_start)
+            .map(|(_, _, mm_hash)| *mm_hash)
+            .collect();
+        if mm_hashes.is_empty() {
+            continue;
+        }
+
+        let worker_block = &worker_tokens[block_start..block_end];
+        let routing_block = &mut routing_tokens[block_start..block_end];
+        match normalize_mm_placeholder_runs(
+            worker_block,
+            image_token_id,
+            video_token_id,
+            &mm_hashes,
+        ) {
+            Some((normalized, _)) => {
+                anyhow::ensure!(
+                    normalized == routing_block,
+                    "frontend MM replacement differs from KV-event normalization"
+                );
+            }
+            None => {
+                routing_block.copy_from_slice(worker_block);
+                block_mm_infos[block_index] = Some(BlockExtraInfo {
+                    mm_objects: mm_hashes
+                        .into_iter()
+                        .map(|mm_hash| BlockMmObjectInfo {
+                            mm_hash,
+                            offsets: Vec::new(),
+                        })
+                        .collect(),
+                });
+            }
+        }
+    }
+
+    Ok((routing_tokens, expanded_prompt_len, block_mm_infos))
+}
 /// Construct the unpadded routing sequence and return its exact logical
 /// length. Errors are routing-only: callers must discard the partial vector
 /// and fall back without failing the inference request.
@@ -966,7 +1199,7 @@ fn checked_add_image_tokens(total: Option<usize>, next: usize) -> Option<usize> 
 }
 
 #[cfg(feature = "mm-routing")]
-fn has_image_token_processor_override(value: Option<&serde_json::Value>) -> bool {
+fn has_mm_processor_override(value: Option<&serde_json::Value>) -> bool {
     value.is_some_and(|value| match value {
         serde_json::Value::Null => false,
         serde_json::Value::Object(map) => !map.is_empty(),
@@ -987,6 +1220,24 @@ fn exact_mm_routing_preconditions_met(
     // prompt expansion. Until the frontend reproduces those transformations,
     // exact routing must fail closed so router and worker cache keys agree.
     !has_user_uuid && !has_processor_override && resolved_image_count == total_image_count
+}
+
+#[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+fn should_hash_decoded_video(
+    exact_mm_routing_eligible: bool,
+    has_user_uuid: bool,
+    has_processor_override: bool,
+    has_video_routing_processor: bool,
+) -> bool {
+    exact_mm_routing_eligible
+        && !has_user_uuid
+        && !has_processor_override
+        && has_video_routing_processor
+}
+
+#[cfg(feature = "mm-routing")]
+fn exact_mm_routing_supports_modality(modality: &str, frontend_decoding: bool) -> bool {
+    modality == "image_url" || (modality == "video_url" && frontend_decoding)
 }
 
 #[cfg(feature = "mm-routing")]
@@ -1317,6 +1568,10 @@ pub struct OpenAIPreprocessor {
     /// unreadable.
     #[cfg(feature = "mm-routing")]
     image_token_counter: Option<lightseek_mm::LightseekMmCounter>,
+    /// Lightweight model-visible video expansion. Unlike the image counter,
+    /// this does not resize or normalize pixels in the frontend.
+    #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+    video_routing_processor: Option<mm_routing::VideoRoutingProcessor>,
     /// Image-placeholder token id the routing-side sequence fills per image.
     /// Resolved from `config.json`'s `image_token_id` field when present,
     /// otherwise falls back to the `ModelProcessorSpec` registry value. This
@@ -1340,8 +1595,9 @@ pub struct OpenAIPreprocessor {
     /// BOS token id to prepend to the routing-side sequence so per-block
     /// hashes match the backend's HF processor output on models with
     /// `add_bos_token: true` (LLaVA-1.5 and other `LlamaTokenizer`
-    /// families). `None` when the model doesn't need it or `bos_token`
-    /// doesn't round-trip to a single id.
+    /// families). Applied only to requests containing images; video-only
+    /// routing starts from the frontend-tokenized prompt. `None` when the
+    /// model doesn't need it or `bos_token` doesn't round-trip to one id.
     #[cfg(feature = "mm-routing")]
     routing_prepend_bos: Option<crate::protocols::TokenIdType>,
 }
@@ -2051,15 +2307,14 @@ impl OpenAIPreprocessor {
             );
         }
         #[cfg(feature = "mm-routing")]
-        let image_token_inputs: Option<(String, String, std::path::PathBuf)> = {
+        let image_token_inputs: Option<(String, String, std::path::PathBuf)> =
             model_dir_for_routing.as_ref().map(|p| {
                 (
                     mdc.source_path().to_string(),
                     model_info.model_type(),
                     p.clone(),
                 )
-            })
-        };
+            });
 
         let media_loader = match mdc.media_decoder {
             Some(media_decoder) => Some(MediaLoader::new(media_decoder, mdc.media_fetcher)?),
@@ -2072,7 +2327,7 @@ impl OpenAIPreprocessor {
             routing_image_token_id,
             routing_image_prompt_layout,
             bos_token_string,
-        ) = match image_token_inputs {
+        ) = match image_token_inputs.as_ref() {
             Some((model_id, model_type, model_dir)) => {
                 // Resolve counter + image-token id independently so the
                 // summary log can name which piece is missing.
@@ -2080,9 +2335,9 @@ impl OpenAIPreprocessor {
                     Option<lightseek_mm::LightseekMmCounter>,
                     Option<String>,
                 ) = match lightseek_mm::LightseekMmCounter::try_new(
-                    &model_id,
-                    Some(&model_type),
-                    &model_dir,
+                    model_id,
+                    Some(model_type),
+                    model_dir,
                 ) {
                     Ok(c) => (Some(c), None),
                     Err(e) => (None, Some(e.to_string())),
@@ -2093,11 +2348,8 @@ impl OpenAIPreprocessor {
                     // One-shot config/tokenizer_config read for all
                     // routing-side token info. Parsing lives next to the
                     // spec resolution in the MM-routing module.
-                    let routing_tokens = lightseek_mm::resolve_routing_tokens(
-                        &model_id,
-                        &model_dir,
-                        counter.as_ref(),
-                    );
+                    let routing_tokens =
+                        lightseek_mm::resolve_routing_tokens(model_id, model_dir, counter.as_ref());
                     let prompt_layout =
                             routing_tokens.image_prompt_kind.and_then(|kind| {
                                 match resolve_routing_image_prompt_layout(tokenizer.as_ref(), kind) {
@@ -2174,6 +2426,63 @@ impl OpenAIPreprocessor {
             }
         };
 
+        #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+        let video_routing_processor = {
+            let processor_contract = match runtime_config
+                .get_engine_specific::<mm_routing::QwenVideoProcessorContract>(
+                    VLLM_QWEN_VIDEO_PROCESSOR_CONTRACT_RUNTIME_KEY,
+                ) {
+                Ok(target) => target,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "mm_routing",
+                        %error,
+                        key = VLLM_QWEN_VIDEO_PROCESSOR_CONTRACT_RUNTIME_KEY,
+                        "invalid Qwen video processor runtime metadata; exact video routing disabled"
+                    );
+                    None
+                }
+            };
+            if fastokens_active {
+                None
+            } else {
+                match (image_token_inputs.as_ref(), processor_contract) {
+                    (Some((model_id, model_type, model_dir)), Some(processor_contract)) => {
+                        match mm_routing::VideoRoutingProcessor::try_new(
+                            model_id,
+                            model_type,
+                            model_dir,
+                            tokenizer.clone(),
+                            processor_contract,
+                        ) {
+                            Ok(processor) => processor,
+                            Err(error) => {
+                                tracing::warn!(
+                                    target: "mm_routing",
+                                    model = %model_id,
+                                    %error,
+                                    "exact video-aware KV routing disabled for this model"
+                                );
+                                None
+                            }
+                        }
+                    }
+                    _ => None,
+                }
+            }
+        };
+        #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+        if video_routing_processor.is_some()
+            && let Some((model_id, model_type, _)) = image_token_inputs.as_ref()
+        {
+            tracing::info!(
+                target: "mm_routing",
+                model = %model_id,
+                model_type = %model_type,
+                "exact video-aware KV routing enabled"
+            );
+        }
+
         #[cfg(feature = "mm-routing")]
         let routing_image_dimension_policy = routing_image_dimension_policy(
             &runtime_config,
@@ -2184,8 +2493,8 @@ impl OpenAIPreprocessor {
         // Force the dim-fetch HTTP client to build at startup for any
         // MM-countable or routable preprocessor, so TLS / env-var / reqwest-init
         // failures fail the deployment instead of crashing the first
-        // MM request 20 minutes in. Text-only preprocessors skip the
-        // force (both MM-routing hooks resolved to `None`) — no point
+        // image request 20 minutes in. Other preprocessors skip the
+        // force when both image-routing hooks resolve to `None` — no point
         // building a client they'll never use.
         #[cfg(feature = "mm-routing")]
         if image_token_counter.is_some() || routing_image_token_id.is_some() {
@@ -2249,6 +2558,8 @@ impl OpenAIPreprocessor {
             context_length,
             #[cfg(feature = "mm-routing")]
             image_token_counter,
+            #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+            video_routing_processor,
             #[cfg(feature = "mm-routing")]
             routing_image_token_id,
             #[cfg(feature = "mm-routing")]
@@ -2357,7 +2668,7 @@ impl OpenAIPreprocessor {
         };
         TOKENIZE_SECONDS.observe(tokenize_start.elapsed().as_secs_f64());
 
-        let (_mm_image_entries, image_tokens) = self
+        let (_mm_routing_entries, image_tokens) = self
             .gather_multi_modal_data_with_image_tokens(
                 request,
                 &mut builder,
@@ -2836,7 +3147,21 @@ impl OpenAIPreprocessor {
                 token_ids,
             )
             .await?;
-        Ok(entries)
+        Ok(entries
+            .into_iter()
+            .filter_map(|entry| match entry {
+                MmRoutingEntry::Image {
+                    mm_hash,
+                    width,
+                    height,
+                } => Some(MmImageEntry {
+                    mm_hash,
+                    width,
+                    height,
+                }),
+                MmRoutingEntry::Video { .. } => None,
+            })
+            .collect())
     }
 
     async fn gather_multi_modal_data_with_image_tokens<
@@ -2847,7 +3172,7 @@ impl OpenAIPreprocessor {
         builder: &mut PreprocessedRequestBuilder,
         formatted_prompt: Option<&str>,
         token_ids: &[crate::protocols::TokenIdType],
-    ) -> Result<(Vec<MmImageEntry>, Option<usize>)> {
+    ) -> Result<(Vec<MmRoutingEntry>, Option<usize>)> {
         // `token_ids` is only consumed by exact MM-routing construction below.
         #[cfg(not(feature = "mm-routing"))]
         let _ = token_ids;
@@ -2858,19 +3183,21 @@ impl OpenAIPreprocessor {
         // Decoded results are written back into these reserved modality slots so
         // URL-backed and UUID-only inputs retain request order.
         let mut fetch_tasks: Vec<MediaFetchTask<'_>> = Vec::new();
-        // Per-image (mm_hash, width, height) for the MM-routing path.
-        // Accumulated in message order so we don't walk messages twice.
-        // Cleared and returned to the caller; empty for non-image / text-only requests.
         #[cfg(feature = "mm-routing")]
-        let mut mm_image_entries: Vec<MmImageEntry> = Vec::new();
+        let mut mm_routing_entries: Vec<MmRoutingEntry> = Vec::new();
         // Private per-request total for frontend metrics. `None` means the SMG
         // counter is unavailable or checked addition overflowed.
         #[cfg(feature = "mm-routing")]
         let mut image_tokens = self.image_token_counter.as_ref().map(|_| 0usize);
+        // A raw/passthrough video or unsupported decoded-video processor makes
+        // the model-visible token sequence unknowable. In that case the whole
+        // request falls back rather than publishing a partial routing view.
+        #[cfg(feature = "mm-routing")]
+        let mut exact_mm_routing_eligible = true;
         // Total `image_url` content parts in the request. Bumped at every
         // image part regardless of which fetch path handles it. Used at
-        // `mm_hashes` forwarding time: if `mm_image_entries.len()` is
-        // smaller, we omit `mm_hashes` for the whole request rather than
+        // hash forwarding time: if fewer image entries were resolved, we omit
+        // exact routing hashes for the whole request rather than
         // ship a partial / misaligned UUID list to vLLM.
         //
         // The mismatch is only reachable on the URL-passthrough path when
@@ -2909,6 +3236,10 @@ impl OpenAIPreprocessor {
                 #[cfg(feature = "mm-routing")]
                 if type_str == "image_url" {
                     total_image_count += 1;
+                }
+                #[cfg(feature = "mm-routing")]
+                if !exact_mm_routing_supports_modality(type_str, has_media_loader) {
+                    exact_mm_routing_eligible = false;
                 }
 
                 if uuid.as_deref().is_some_and(str::is_empty) {
@@ -2956,6 +3287,18 @@ impl OpenAIPreprocessor {
             }
         }
 
+        #[cfg(feature = "mm-routing")]
+        let has_processor_override = has_mm_processor_override(request.mm_processor_kwargs());
+        #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+        let hash_decoded_video = should_hash_decoded_video(
+            exact_mm_routing_eligible,
+            has_user_uuid,
+            has_processor_override,
+            self.video_routing_processor.is_some(),
+        );
+        #[cfg(not(all(feature = "mm-routing", feature = "media-ffmpeg")))]
+        let hash_decoded_video = false;
+
         // Execute all fetch tasks
         if !fetch_tasks.is_empty() {
             let loader = self.media_loader.as_ref().unwrap();
@@ -2968,9 +3311,10 @@ impl OpenAIPreprocessor {
                 .transpose()
                 .map_err(|e| invalid_argument_error(format!("invalid media_io_kwargs: {e}")))?;
             let results = futures::future::join_all(fetch_tasks.iter().map(|task| {
-                loader.fetch_and_decode_media_part(
+                loader.fetch_and_decode_media_part_with_video_hash(
                     task.content_part.as_ref(),
                     media_io_kwargs.as_ref(),
+                    hash_decoded_video,
                 )
             }))
             .await;
@@ -2979,8 +3323,6 @@ impl OpenAIPreprocessor {
                 // if one item fails, errors the whole request, other items will be cleaned up by Drop
                 let rdma_descriptor = result?;
 
-                // Decoded RDMA descriptor carries shape `[H, W, C]`.
-                // Image-only; MM-routing doesn't cover audio/video.
                 #[cfg(feature = "mm-routing")]
                 if task.modality == "image_url" {
                     let shape = &rdma_descriptor.tensor_info.shape;
@@ -3020,11 +3362,67 @@ impl OpenAIPreprocessor {
                             );
                             image_tokens = checked_add_image_tokens(image_tokens, n);
                         }
-                        mm_image_entries.push(MmImageEntry {
+                        mm_routing_entries.push(MmRoutingEntry::Image {
                             mm_hash,
                             width: w,
                             height: h,
                         });
+                    }
+                } else if task.modality == "video_url" {
+                    #[cfg(feature = "media-ffmpeg")]
+                    {
+                        let video_entry = (|| -> Result<MmRoutingEntry> {
+                            let processor =
+                                self.video_routing_processor.as_ref().ok_or_else(|| {
+                                    anyhow::anyhow!("model has no exact video routing processor")
+                                })?;
+                            anyhow::ensure!(
+                                !has_processor_override,
+                                "request mm_processor_kwargs can change the video token layout"
+                            );
+                            let (frame_count, width, height) =
+                                rdma_descriptor.video_dimensions()?;
+                            let metadata = rdma_descriptor.video_metadata()?;
+                            let mm_hash = rdma_descriptor.video_content_hash()?;
+                            let routing =
+                                processor.build_replacement(&mm_routing::VideoRoutingInput {
+                                    frame_count,
+                                    width,
+                                    height,
+                                    source_fps: metadata.source_fps,
+                                    sampled_timestamps: &metadata.sampled_timestamps,
+                                })?;
+                            tracing::debug!(
+                                target: "mm_routing",
+                                n_frames = frame_count,
+                                width,
+                                height,
+                                replacement_tokens = routing.replacement_tokens.len(),
+                                mm_hash,
+                                "video routing metadata resolved"
+                            );
+                            Ok(MmRoutingEntry::Video {
+                                mm_hash,
+                                placeholder_token_id: routing.placeholder_token_id,
+                                target_tokens: routing.target_tokens,
+                                replacement_tokens: routing.replacement_tokens,
+                            })
+                        })();
+                        match video_entry {
+                            Ok(entry) => mm_routing_entries.push(entry),
+                            Err(error) => {
+                                exact_mm_routing_eligible = false;
+                                tracing::debug!(
+                                    target: "mm_routing",
+                                    %error,
+                                    "mm-routing: decoded video is not eligible for exact routing; falling back to text-prefix routing"
+                                );
+                            }
+                        }
+                    }
+                    #[cfg(not(feature = "media-ffmpeg"))]
+                    {
+                        exact_mm_routing_eligible = false;
                     }
                 }
 
@@ -3065,7 +3463,7 @@ impl OpenAIPreprocessor {
                             );
                             image_tokens = checked_add_image_tokens(image_tokens, n);
                         }
-                        mm_image_entries.push(MmImageEntry {
+                        mm_routing_entries.push(MmRoutingEntry::Image {
                             mm_hash,
                             width: w,
                             height: h,
@@ -3097,10 +3495,6 @@ impl OpenAIPreprocessor {
             }
         }
 
-        #[cfg(feature = "mm-routing")]
-        let has_processor_override =
-            has_image_token_processor_override(request.mm_processor_kwargs());
-
         if !media_map.is_empty() {
             builder.multi_modal_data(Some(media_map));
             if has_user_uuid {
@@ -3112,7 +3506,7 @@ impl OpenAIPreprocessor {
             // instead of routing and publishing under different cache keys.
             #[cfg(feature = "mm-routing")]
             if has_user_uuid {
-                mm_image_entries.clear();
+                mm_routing_entries.clear();
             }
 
             // Preserve original messages and formatted prompt in extra_args for multimodal
@@ -3152,43 +3546,70 @@ impl OpenAIPreprocessor {
                 extra_args_obj.extend(backend_extra_args);
             }
 
-            // Build and install routing info + worker hashes atomically. If
-            // dimensions are incomplete, processor kwargs can change feature
-            // hashing/prompt expansion, a placeholder precondition misses, or
-            // K3 dimension text cannot be encoded, neither side receives
-            // image-aware keys and the request cleanly uses text-prefix routing.
-            // Hashes use the canonical 16-char u64 form; SGLang reads it directly
-            // and vLLM pads it to its 64-char BlockStored form.
+            // Build and install routing info + worker hashes atomically. If any
+            // mixed-media precondition misses, neither side receives exact keys
+            // and the request cleanly uses text-prefix routing.
             #[cfg(feature = "mm-routing")]
-            let mm_routing_info = if exact_mm_routing_preconditions_met(
-                has_user_uuid,
-                mm_image_entries.len(),
-                total_image_count,
-                has_processor_override,
-            ) {
-                self.build_mm_exact_routing_info(&mm_image_entries, token_ids)
+            let resolved_image_count = mm_routing_entries
+                .iter()
+                .filter(|entry| matches!(entry, MmRoutingEntry::Image { .. }))
+                .count();
+            #[cfg(feature = "mm-routing")]
+            let mm_routing_info = if exact_mm_routing_eligible
+                && exact_mm_routing_preconditions_met(
+                    has_user_uuid,
+                    resolved_image_count,
+                    total_image_count,
+                    has_processor_override,
+                ) {
+                self.build_mm_exact_routing_info(&mm_routing_entries, token_ids)
             } else {
                 None
             };
             #[cfg(feature = "mm-routing")]
             if let Some(mm_routing_info) = mm_routing_info {
-                let hexes: Vec<serde_json::Value> = mm_image_entries
+                let hex = |entry: &MmRoutingEntry| {
+                    serde_json::Value::String(format!("{:016x}", entry.mm_hash()))
+                };
+                if mm_routing_entries
                     .iter()
-                    .map(|e| serde_json::Value::String(format!("{:016x}", e.mm_hash)))
-                    .collect();
-                extra_args["mm_hashes"] = serde_json::Value::Array(hexes);
+                    .all(|entry| matches!(entry, MmRoutingEntry::Image { .. }))
+                {
+                    // Preserve the legacy image-only worker protocol.
+                    extra_args["mm_hashes"] =
+                        serde_json::Value::Array(mm_routing_entries.iter().map(hex).collect());
+                } else {
+                    let mut grouped = serde_json::Map::new();
+                    let image_hashes: Vec<_> = mm_routing_entries
+                        .iter()
+                        .filter(|entry| matches!(entry, MmRoutingEntry::Image { .. }))
+                        .map(hex)
+                        .collect();
+                    let video_hashes: Vec<_> = mm_routing_entries
+                        .iter()
+                        .filter(|entry| matches!(entry, MmRoutingEntry::Video { .. }))
+                        .map(hex)
+                        .collect();
+                    if !image_hashes.is_empty() {
+                        grouped.insert("image".to_string(), serde_json::Value::Array(image_hashes));
+                    }
+                    if !video_hashes.is_empty() {
+                        grouped.insert("video".to_string(), serde_json::Value::Array(video_hashes));
+                    }
+                    extra_args["mm_hashes_by_modality"] = serde_json::Value::Object(grouped);
+                }
                 builder.mm_routing_info(Some(mm_routing_info));
             } else if has_processor_override && total_image_count > 0 {
                 tracing::debug!(
                     target: "mm_routing",
                     "mm-routing: exact MM routing disabled because mm_processor_kwargs is non-empty"
                 );
-            } else if !mm_image_entries.is_empty() && self.routing_image_token_id.is_some() {
+            } else if !mm_routing_entries.is_empty() {
                 tracing::warn!(
                     target: "mm_routing",
-                    resolved = mm_image_entries.len(),
-                    expected = total_image_count,
-                    "mm-routing: exact MM routing info not built (dim resolution or placeholder-count mismatch); skipping mm_hashes forwarding"
+                    resolved = mm_routing_entries.len(),
+                    expected_images = total_image_count,
+                    "mm-routing: exact MM routing info not built (media resolution or placeholder-order mismatch); skipping mm_hashes forwarding"
                 );
             }
 
@@ -3198,33 +3619,38 @@ impl OpenAIPreprocessor {
         #[cfg(feature = "mm-routing")]
         let image_tokens = aggregate_image_tokens(
             image_tokens,
-            mm_image_entries.len(),
+            mm_routing_entries
+                .iter()
+                .filter(|entry| matches!(entry, MmRoutingEntry::Image { .. }))
+                .count(),
             total_image_count,
             has_processor_override,
         );
         #[cfg(feature = "mm-routing")]
-        return Ok((mm_image_entries, image_tokens));
+        return Ok((mm_routing_entries, image_tokens));
         #[cfg(not(feature = "mm-routing"))]
         Ok((Vec::new(), None))
     }
 
-    /// Build `MmRoutingInfo` for exact MM-aware KV routing. The worker-bound
-    /// `token_ids` are unchanged — only the routing-side view is expanded.
-    /// Supports single-special-token placeholder families (Qwen-VL, LLaVA,
-    /// Kimi-K2.x) and Kimi-K3's dimension-bearing media wrapper.
-    /// Returns `Ok(())` with no work performed on any precondition miss or
-    /// routing-only tokenizer failure (caller falls back to text-prefix
-    /// routing). Request preprocessing must use the atomic installation in
-    /// `gather_multi_modal_data_with_image_tokens` so worker `mm_hashes` are
-    /// forwarded if and only if this routing info was built.
+    /// Build image-only exact routing info without changing the worker-bound
+    /// token IDs. Kept as the public compatibility surface; request
+    /// preprocessing uses the mixed-media builder internally.
     #[cfg(feature = "mm-routing")]
     pub fn gather_mm_exact_routing_info(
         &self,
         builder: &mut PreprocessedRequestBuilder,
-        mm_image_entries: &[MmImageEntry],
+        image_entries: &[MmImageEntry],
         token_ids: &[crate::protocols::TokenIdType],
     ) -> Result<()> {
-        if let Some(info) = self.build_mm_exact_routing_info(mm_image_entries, token_ids) {
+        let entries: Vec<_> = image_entries
+            .iter()
+            .map(|entry| MmRoutingEntry::Image {
+                mm_hash: entry.mm_hash,
+                width: entry.width,
+                height: entry.height,
+            })
+            .collect();
+        if let Some(info) = self.build_mm_exact_routing_info(&entries, token_ids) {
             builder.mm_routing_info(Some(info));
         }
         Ok(())
@@ -3233,35 +3659,46 @@ impl OpenAIPreprocessor {
     #[cfg(feature = "mm-routing")]
     fn build_mm_exact_routing_info(
         &self,
-        mm_image_entries: &[MmImageEntry],
+        entries: &[MmRoutingEntry],
         token_ids: &[crate::protocols::TokenIdType],
     ) -> Option<crate::protocols::common::preprocessor::MmRoutingInfo> {
         use crate::protocols::common::preprocessor::MmRoutingInfo;
 
-        if mm_image_entries.is_empty() {
+        if entries.is_empty() {
             return None;
         }
-        let Some(find_token_id) = self.routing_image_token_id else {
+        if !exact_mm_routing_entries_are_unambiguous(entries) {
             tracing::debug!(
                 target: "mm_routing",
-                "routing_image_token_id unresolved; skipping MM routing info"
+                "consecutive video objects cannot be mapped exactly in vLLM KV events; skipping MM routing info"
             );
             return None;
-        };
-        let Some(prompt_layout) = self.routing_image_prompt_layout else {
-            tracing::debug!(
-                target: "mm_routing",
-                "routing_image_prompt_layout unresolved; skipping MM routing info"
-            );
-            return None;
-        };
-        let Some(counter) = self.image_token_counter.as_ref() else {
+        }
+        let image_token_id = self.routing_image_token_id;
+        let image_counter_required = entries
+            .iter()
+            .any(|entry| matches!(entry, MmRoutingEntry::Image { .. }));
+        if image_counter_required && self.image_token_counter.is_none() {
             tracing::debug!(
                 target: "mm_routing",
                 "image_token_counter unavailable; skipping MM routing info"
             );
             return None;
-        };
+        }
+        if image_counter_required && image_token_id.is_none() {
+            tracing::debug!(
+                target: "mm_routing",
+                "routing_image_token_id unresolved; skipping MM routing info"
+            );
+            return None;
+        }
+        if image_counter_required && self.routing_image_prompt_layout.is_none() {
+            tracing::debug!(
+                target: "mm_routing",
+                "routing_image_prompt_layout unresolved; skipping MM routing info"
+            );
+            return None;
+        }
         let block_size = self.kv_cache_block_size;
         if block_size == 0 {
             tracing::debug!(
@@ -3270,50 +3707,180 @@ impl OpenAIPreprocessor {
             );
             return None;
         }
-
-        // Single-special-token placeholders (Qwen-VL `<|image_pad|>`, LLaVA
-        // `<image>`) emit exactly one `find_token_id` per image in the
-        // tokenized prompt. Any other shape (e.g. numbered-text placeholders
-        // that BPE-shatter) can't be aligned to images here, so we skip MM
-        // routing and let the caller fall back to text-prefix routing.
-        let placeholder_count = token_ids.iter().filter(|&&t| t == find_token_id).count();
-        if placeholder_count != mm_image_entries.len() {
-            tracing::warn!(
-                target: "mm_routing",
-                placeholder_count,
-                image_count = mm_image_entries.len(),
-                routing_image_token_id = find_token_id,
-                "placeholder token count in tokenized prompt does not match image count; \
-                 skipping MM routing info (text-prefix routing only)"
-            );
-            return None;
-        }
-        let normalized_token_ids = token_ids;
-
-        // Compute per-image N via the registry + run the expansion.
-        let n_tokens: Vec<usize> = mm_image_entries
+        let (mut expanded, expanded_prompt_len, block_mm_infos) = if entries
             .iter()
-            .map(|e| counter.count_tokens(e.width, e.height))
-            .collect();
-        // Canonical pad_value fill at image positions for ALL backends. sglang
-        // consumes pad_value natively; vLLM events are normalized to pad_value
-        // in the kv-router (see `create_stored_blocks`), so the frontend stays
-        // backend-agnostic. pad_value formula pinned by
-        // `pad_value_matches_sglang_protocol` in dynamo_kv_router.
-        //
-        // Prepend the routing-side BOS for `add_bos_token: true` models
-        // (LlamaTokenizer family, e.g. LLaVA-1.5) so per-block hashes match
-        // the backend's HF processor output.
-        let (mut expanded, expanded_prompt_len) = try_expand_mm_routing_tokens(
-            self.tokenizer.as_ref(),
-            prompt_layout,
-            self.routing_prepend_bos,
-            find_token_id,
-            mm_image_entries,
-            &n_tokens,
-            normalized_token_ids,
-            counter.model_id(),
-        )?;
+            .all(|entry| matches!(entry, MmRoutingEntry::Image { .. }))
+        {
+            let counter = self
+                .image_token_counter
+                .as_ref()
+                .expect("image counter requirement checked above");
+            let images: Vec<MmImageEntry> = entries
+                .iter()
+                .map(|entry| match entry {
+                    MmRoutingEntry::Image {
+                        mm_hash,
+                        width,
+                        height,
+                    } => MmImageEntry {
+                        mm_hash: *mm_hash,
+                        width: *width,
+                        height: *height,
+                    },
+                    MmRoutingEntry::Video { .. } => unreachable!("all entries checked as images"),
+                })
+                .collect();
+            let image_token_id = image_token_id.expect("image token requirement checked above");
+            let placeholder_count = token_ids
+                .iter()
+                .filter(|&&token_id| token_id == image_token_id)
+                .count();
+            if placeholder_count != images.len() {
+                tracing::warn!(
+                    target: "mm_routing",
+                    placeholder_count,
+                    image_count = images.len(),
+                    routing_image_token_id = image_token_id,
+                    "placeholder token count in tokenized prompt does not match image count; \
+                     skipping MM routing info (text-prefix routing only)"
+                );
+                return None;
+            }
+            let n_tokens: Vec<usize> = images
+                .iter()
+                .map(|image| counter.count_tokens(image.width, image.height))
+                .collect();
+            let (expanded, expanded_prompt_len) = try_expand_mm_routing_tokens(
+                self.tokenizer.as_ref(),
+                self.routing_image_prompt_layout
+                    .expect("image prompt layout requirement checked above"),
+                self.routing_prepend_bos,
+                image_token_id,
+                &images,
+                &n_tokens,
+                token_ids,
+                counter.model_id(),
+            )?;
+            (expanded, expanded_prompt_len, Vec::new())
+        } else {
+            let mut replacements = Vec::with_capacity(entries.len());
+            let video_token_id = entries.iter().find_map(|entry| match entry {
+                MmRoutingEntry::Video {
+                    placeholder_token_id,
+                    ..
+                } => Some(*placeholder_token_id),
+                MmRoutingEntry::Image { .. } => None,
+            });
+            for entry in entries {
+                let replacement = match entry {
+                    MmRoutingEntry::Image {
+                        mm_hash,
+                        width,
+                        height,
+                    } => {
+                        let counter = self
+                            .image_token_counter
+                            .as_ref()
+                            .expect("image counter requirement checked above");
+                        let token_count = counter.count_tokens(*width, *height);
+                        let mut routing_tokens = Vec::with_capacity(token_count);
+                        let mut worker_tokens = Vec::with_capacity(token_count);
+                        let image = MmImageEntry {
+                            mm_hash: *mm_hash,
+                            width: *width,
+                            height: *height,
+                        };
+                        let layout = self
+                            .routing_image_prompt_layout
+                            .expect("image prompt layout requirement checked above");
+                        let image_token_id =
+                            image_token_id.expect("image token requirement checked above");
+                        let result = append_mm_routing_replacement(
+                            &mut routing_tokens,
+                            self.tokenizer.as_ref(),
+                            layout,
+                            image,
+                            token_count,
+                        )
+                        .and_then(|()| {
+                            append_mm_routing_replacement_with_fill(
+                                &mut worker_tokens,
+                                self.tokenizer.as_ref(),
+                                layout,
+                                image,
+                                token_count,
+                                image_token_id,
+                            )
+                        });
+                        if let Err(error) = result {
+                            tracing::warn!(
+                                target: "mm_routing",
+                                model = counter.model_id(),
+                                %error,
+                                "routing-only image prompt expansion failed; skipping MM routing info"
+                            );
+                            return None;
+                        }
+                        TrackedMmRoutingReplacement {
+                            mm_hash: *mm_hash,
+                            target_tokens: vec![image_token_id],
+                            worker_tokens,
+                            routing_tokens,
+                        }
+                    }
+                    MmRoutingEntry::Video {
+                        mm_hash,
+                        placeholder_token_id,
+                        target_tokens,
+                        replacement_tokens,
+                    } => {
+                        let fill_token =
+                            dynamo_kv_router::protocols::pad_value_for_mm_hash(*mm_hash);
+                        TrackedMmRoutingReplacement {
+                            mm_hash: *mm_hash,
+                            target_tokens: target_tokens.clone(),
+                            worker_tokens: replacement_tokens.clone(),
+                            routing_tokens: replacement_tokens
+                                .iter()
+                                .map(|replacement_id| {
+                                    if *replacement_id == *placeholder_token_id {
+                                        fill_token
+                                    } else {
+                                        *replacement_id
+                                    }
+                                })
+                                .collect(),
+                        }
+                    }
+                };
+                replacements.push(replacement);
+            }
+
+            // Configured BOS is image-specific; video-only routing starts from
+            // the frontend-tokenized prompt.
+            let routing_bos =
+                routing_bos_to_prepend(self.routing_prepend_bos, image_counter_required);
+            match apply_tracked_mm_replacements(
+                routing_bos,
+                &replacements,
+                token_ids,
+                block_size,
+                image_token_id,
+                video_token_id,
+            ) {
+                Ok(expanded) => expanded,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "mm_routing",
+                        media_count = entries.len(),
+                        %error,
+                        "placeholder token sequence does not match multimodal content order; \
+                         skipping MM routing info (text-prefix routing only)"
+                    );
+                    return None;
+                }
+            }
+        };
 
         // Pad to a whole multiple of kv_cache_block_size. The router's
         // compute_block_hash_for_seq only hashes whole blocks, so the partial
@@ -3326,13 +3893,11 @@ impl OpenAIPreprocessor {
             expanded.resize(total_tokens, 0);
         }
 
-        // pad_value already encodes mm_hash in the routing tokens the router
-        // hashes, so block_mm_infos is always empty (the canonical scheme for
-        // both backends). The mm identity rides in the token stream, not a
-        // side channel.
+        // Exact blocks carry MM identity in pad-value tokens. Ambiguous
+        // feature-span boundaries carry the same block metadata vLLM hashes.
         tracing::debug!(
             target: "mm_routing",
-            n_images = mm_image_entries.len(),
+            n_media = entries.len(),
             block_size,
             total_tokens,
             "MmRoutingInfo built (exact, pad_value)"
@@ -3340,7 +3905,7 @@ impl OpenAIPreprocessor {
 
         Some(MmRoutingInfo {
             routing_token_ids: expanded,
-            block_mm_infos: Vec::new(),
+            block_mm_infos,
             expanded_prompt_len,
         })
     }
@@ -7655,18 +8220,106 @@ mod tests {
 
     #[cfg(feature = "mm-routing")]
     #[test]
-    fn image_token_processor_override_is_conservative() {
-        assert!(!has_image_token_processor_override(None));
-        assert!(!has_image_token_processor_override(Some(
-            &serde_json::Value::Null
-        )));
-        assert!(!has_image_token_processor_override(Some(
-            &serde_json::json!({})
-        )));
-        assert!(has_image_token_processor_override(Some(
-            &serde_json::json!([])
-        )));
-        assert!(has_image_token_processor_override(Some(
+    fn image_expansion_applies_placeholders_in_request_order() {
+        let tokenizer = RoutingTestTokenizer {
+            atomic_controls: true,
+            fail_plain_text: false,
+        };
+        let images = [
+            MmImageEntry {
+                mm_hash: 0x1234,
+                width: 320,
+                height: 240,
+            },
+            MmImageEntry {
+                mm_hash: 0x5678,
+                width: 640,
+                height: 480,
+            },
+        ];
+        let first_fill = dynamo_kv_router::protocols::pad_value_for_mm_hash(images[0].mm_hash);
+        let second_fill = dynamo_kv_router::protocols::pad_value_for_mm_hash(images[1].mm_hash);
+
+        let (expanded, prompt_len) = expand_mm_routing_tokens(
+            &tokenizer,
+            RoutingImagePromptLayout::RepeatedPad,
+            Some(1),
+            10,
+            &images,
+            &[2, 3],
+            &[7, 10, 8, 10, 9],
+        )
+        .unwrap();
+
+        assert_eq!(
+            expanded,
+            [
+                1,
+                7,
+                first_fill,
+                first_fill,
+                8,
+                second_fill,
+                second_fill,
+                second_fill,
+                9,
+            ]
+        );
+        assert_eq!(prompt_len, expanded.len());
+    }
+
+    #[cfg(feature = "mm-routing")]
+    #[test]
+    fn exact_routing_rejects_image_placeholder_count_mismatch() {
+        let model_dir = tempfile::tempdir().unwrap();
+        std::fs::write(model_dir.path().join("preprocessor_config.json"), "{}").unwrap();
+        let counter = lightseek_mm::LightseekMmCounter::try_new(
+            "Qwen/Qwen3-VL-2B-Instruct",
+            Some("qwen3_vl"),
+            model_dir.path(),
+        )
+        .unwrap();
+        let mdc = ModelDeploymentCard::load_from_disk(
+            "tests/data/sample-models/mock-llama-3.1-8b-instruct",
+            None,
+        )
+        .unwrap();
+        let mut preprocessor = match Arc::try_unwrap(OpenAIPreprocessor::new(mdc).unwrap()) {
+            Ok(preprocessor) => preprocessor,
+            Err(_) => panic!("test preprocessor unexpectedly shared"),
+        };
+        preprocessor.image_token_counter = Some(counter);
+        preprocessor.routing_image_token_id = Some(10);
+        preprocessor.routing_image_prompt_layout = Some(RoutingImagePromptLayout::RepeatedPad);
+        preprocessor.kv_cache_block_size = 16;
+        let image = [MmRoutingEntry::Image {
+            mm_hash: 0x1234,
+            width: 320,
+            height: 240,
+        }];
+
+        assert!(
+            preprocessor
+                .build_mm_exact_routing_info(&image, &[7, 8])
+                .is_none(),
+            "missing placeholder must fail closed at the production boundary"
+        );
+        assert!(
+            preprocessor
+                .build_mm_exact_routing_info(&image, &[7, 10, 10, 8])
+                .is_none(),
+            "extra placeholder must fail closed at the production boundary"
+        );
+    }
+
+    #[cfg(feature = "mm-routing")]
+    #[test]
+    fn mm_processor_override_is_conservative() {
+        assert!(!has_mm_processor_override(None));
+        assert!(!has_mm_processor_override(Some(&serde_json::Value::Null)));
+        assert!(!has_mm_processor_override(Some(&serde_json::json!({}))));
+        assert!(has_mm_processor_override(Some(&serde_json::json!([]))));
+        assert!(has_mm_processor_override(Some(
             &serde_json::json!({"min_pixels": 64})
         )));
     }
@@ -7678,6 +8331,16 @@ mod tests {
         assert!(!exact_mm_routing_preconditions_met(false, 1, 1, true));
         assert!(!exact_mm_routing_preconditions_met(true, 1, 1, false));
         assert!(!exact_mm_routing_preconditions_met(false, 0, 1, false));
+    }
+
+    #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+    #[test]
+    fn decoded_video_hash_requires_exact_routing_eligibility() {
+        assert!(should_hash_decoded_video(true, false, false, true));
+        assert!(!should_hash_decoded_video(false, false, false, true));
+        assert!(!should_hash_decoded_video(true, true, false, true));
+        assert!(!should_hash_decoded_video(true, false, true, true));
+        assert!(!should_hash_decoded_video(true, false, false, false));
     }
 
     #[test]
@@ -8538,6 +9201,15 @@ mod tests {
             &request(serde_json::json!("required"), None),
             Some("gpt_oss")
         ));
+    }
+
+    #[cfg(feature = "mm-routing")]
+    #[test]
+    fn exact_mm_routing_rejects_backend_owned_modalities() {
+        assert!(exact_mm_routing_supports_modality("image_url", false));
+        assert!(exact_mm_routing_supports_modality("video_url", true));
+        assert!(!exact_mm_routing_supports_modality("video_url", false));
+        assert!(!exact_mm_routing_supports_modality("audio_url", true));
     }
 
     /// Verifies SGLang's effective reasoning mode for each parser family.
@@ -10581,5 +11253,217 @@ mod tests {
             s3a, s3b,
             "s3:// query params identify objects and must not collide"
         );
+    }
+
+    #[cfg(feature = "mm-routing")]
+    #[test]
+    fn tracked_video_boundary_uses_native_metadata_only_when_needed() {
+        use dynamo_kv_router::protocols::pad_value_for_mm_hash;
+
+        let video_token_id = 100;
+        let mm_hash = 41;
+        let video_pad = pad_value_for_mm_hash(mm_hash);
+        let replacement = TrackedMmRoutingReplacement {
+            mm_hash,
+            target_tokens: vec![9],
+            worker_tokens: vec![3, 4, 5, 6, video_token_id, video_token_id],
+            routing_tokens: vec![3, 4, 5, 6, video_pad, video_pad],
+        };
+
+        let (tokens, prompt_len, infos) = apply_tracked_mm_replacements(
+            None,
+            &[replacement],
+            &[1, 9, 2],
+            4,
+            Some(99),
+            Some(video_token_id),
+        )
+        .unwrap();
+
+        assert_eq!(prompt_len, 8);
+        assert_eq!(&tokens[..4], &[1, 3, 4, 5]);
+        assert_eq!(&tokens[4..], &[6, video_pad, video_pad, 2]);
+        assert_eq!(infos[0].as_ref().unwrap().mm_objects[0].mm_hash, mm_hash);
+        assert!(infos[1].is_none());
+    }
+
+    #[cfg(feature = "mm-routing")]
+    #[test]
+    fn tracked_mixed_boundary_preserves_worker_hash_fallback() {
+        use dynamo_kv_router::protocols::pad_value_for_mm_hash;
+
+        let image_token_id = 99;
+        let video_token_id = 100;
+        let image_hash = 41;
+        let video_hash = 42;
+        let replacements = [
+            TrackedMmRoutingReplacement {
+                mm_hash: image_hash,
+                target_tokens: vec![image_token_id],
+                worker_tokens: vec![image_token_id, image_token_id, 7],
+                routing_tokens: vec![
+                    pad_value_for_mm_hash(image_hash),
+                    pad_value_for_mm_hash(image_hash),
+                    7,
+                ],
+            },
+            TrackedMmRoutingReplacement {
+                mm_hash: video_hash,
+                target_tokens: vec![video_token_id],
+                worker_tokens: vec![8, video_token_id, video_token_id, 9],
+                routing_tokens: vec![
+                    8,
+                    pad_value_for_mm_hash(video_hash),
+                    pad_value_for_mm_hash(video_hash),
+                    9,
+                ],
+            },
+        ];
+
+        let (tokens, prompt_len, infos) = apply_tracked_mm_replacements(
+            None,
+            &replacements,
+            &[image_token_id, video_token_id],
+            4,
+            Some(image_token_id),
+            Some(video_token_id),
+        )
+        .unwrap();
+
+        assert_eq!(prompt_len, 7);
+        assert_eq!(&tokens[..4], &[image_token_id, image_token_id, 7, 8]);
+        assert_eq!(
+            &tokens[4..],
+            &[
+                pad_value_for_mm_hash(video_hash),
+                pad_value_for_mm_hash(video_hash),
+                9,
+                0
+            ]
+        );
+        assert_eq!(
+            infos[0]
+                .as_ref()
+                .unwrap()
+                .mm_objects
+                .iter()
+                .map(|object| object.mm_hash)
+                .collect::<Vec<_>>(),
+            [image_hash, video_hash]
+        );
+        assert!(infos[1].is_none());
+    }
+
+    #[cfg(feature = "mm-routing")]
+    #[test]
+    fn tracked_replacements_preserve_image_video_image_order() {
+        use dynamo_kv_router::protocols::pad_value_for_mm_hash;
+
+        let image_token_id = 99;
+        let video_token_id = 100;
+        let replacement = |mm_hash, target_token| TrackedMmRoutingReplacement {
+            mm_hash,
+            target_tokens: vec![target_token],
+            worker_tokens: vec![target_token, target_token],
+            routing_tokens: vec![
+                pad_value_for_mm_hash(mm_hash),
+                pad_value_for_mm_hash(mm_hash),
+            ],
+        };
+        let replacements = [
+            replacement(41, image_token_id),
+            replacement(42, video_token_id),
+            replacement(43, image_token_id),
+        ];
+
+        let (tokens, prompt_len, infos) = apply_tracked_mm_replacements(
+            None,
+            &replacements,
+            &[1, image_token_id, 2, video_token_id, 3, image_token_id, 4],
+            16,
+            Some(image_token_id),
+            Some(video_token_id),
+        )
+        .unwrap();
+
+        assert_eq!(prompt_len, 10);
+        assert_eq!(
+            &tokens[..prompt_len],
+            &[
+                1,
+                pad_value_for_mm_hash(41),
+                pad_value_for_mm_hash(41),
+                2,
+                pad_value_for_mm_hash(42),
+                pad_value_for_mm_hash(42),
+                3,
+                pad_value_for_mm_hash(43),
+                pad_value_for_mm_hash(43),
+                4,
+            ]
+        );
+        assert!(infos[0].is_none());
+    }
+
+    #[cfg(feature = "mm-routing")]
+    #[test]
+    fn tracked_replacements_reject_misordered_missing_and_extra_targets() {
+        let replacement = |mm_hash, target| TrackedMmRoutingReplacement {
+            mm_hash,
+            target_tokens: vec![target],
+            worker_tokens: vec![target],
+            routing_tokens: vec![target],
+        };
+        let replacements = [replacement(41, 10), replacement(42, 20)];
+
+        for token_ids in [&[20, 10][..], &[10][..], &[10, 20, 20][..]] {
+            assert!(
+                apply_tracked_mm_replacements(
+                    None,
+                    &replacements,
+                    token_ids,
+                    4,
+                    Some(10),
+                    Some(20),
+                )
+                .is_err(),
+                "invalid target sequence {token_ids:?} must fail closed"
+            );
+        }
+    }
+
+    #[cfg(feature = "mm-routing")]
+    #[test]
+    fn routing_bos_preserves_image_behavior_and_skips_video_only_requests() {
+        assert_eq!(routing_bos_to_prepend(Some(1), true), Some(1));
+        assert_eq!(routing_bos_to_prepend(None, true), None);
+        assert_eq!(routing_bos_to_prepend(Some(1), false), None);
+    }
+
+    #[cfg(feature = "mm-routing")]
+    #[test]
+    fn consecutive_video_entries_are_not_exactly_routable() {
+        let video = |mm_hash| MmRoutingEntry::Video {
+            mm_hash,
+            placeholder_token_id: 3,
+            target_tokens: vec![3],
+            replacement_tokens: vec![3],
+        };
+        let image = MmRoutingEntry::Image {
+            mm_hash: 2,
+            width: 1,
+            height: 1,
+        };
+
+        assert!(exact_mm_routing_entries_are_unambiguous(&[video(1)]));
+        assert!(!exact_mm_routing_entries_are_unambiguous(&[
+            video(1),
+            video(2)
+        ]));
+        assert!(exact_mm_routing_entries_are_unambiguous(&[
+            video(1),
+            image,
+            video(2)
+        ]));
     }
 }

--- a/lib/llm/src/preprocessor/media/decoders.rs
+++ b/lib/llm/src/preprocessor/media/decoders.rs
@@ -24,12 +24,20 @@ pub trait Decoder: Clone + Send + 'static {
     fn with_runtime(&self, runtime: Option<&Self>) -> Self;
 
     async fn decode_async(&self, data: EncodedMediaData) -> Result<DecodedMediaData> {
+        self.decode_async_with_video_hash(data, false).await
+    }
+
+    async fn decode_async_with_video_hash(
+        &self,
+        data: EncodedMediaData,
+        hash_video: bool,
+    ) -> Result<DecodedMediaData> {
         // light clone (only config params)
         let decoder = self.clone();
         // compute heavy -> rayon
         let result = tokio_rayon::spawn(move || {
             let mut decoded = decoder.decode(data)?;
-            decoded.compute_content_hash();
+            decoded.compute_content_hash(hash_video);
             Ok::<_, anyhow::Error>(decoded)
         })
         .await?;

--- a/lib/llm/src/preprocessor/media/loader.rs
+++ b/lib/llm/src/preprocessor/media/loader.rs
@@ -517,6 +517,16 @@ impl MediaLoader {
         oai_content_part: &ChatCompletionRequestUserMessageContentPart,
         media_io_kwargs: Option<&MediaDecoder>,
     ) -> Result<RdmaMediaDataDescriptor> {
+        self.fetch_and_decode_media_part_with_video_hash(oai_content_part, media_io_kwargs, false)
+            .await
+    }
+
+    pub(crate) async fn fetch_and_decode_media_part_with_video_hash(
+        &self,
+        oai_content_part: &ChatCompletionRequestUserMessageContentPart,
+        media_io_kwargs: Option<&MediaDecoder>,
+        _hash_video: bool,
+    ) -> Result<RdmaMediaDataDescriptor> {
         // Image-only fast path: cache lookup keyed by URL/datauri string.
         // Video/audio aren't cached yet (their lifetime/content semantics
         // are different — easy to add later if profiling justifies it).
@@ -591,7 +601,9 @@ impl MediaLoader {
                     // Use runtime decoder if provided, with MDC limits enforced
                     let decoder =
                         mdc_decoder.with_runtime(media_io_kwargs.and_then(|k| k.video.as_ref()));
-                    decoder.decode_async(data).await?
+                    decoder
+                        .decode_async_with_video_hash(data, _hash_video)
+                        .await?
                 }
             }
             ChatCompletionRequestUserMessageContentPart::AudioUrl(_) => {

--- a/lib/llm/src/preprocessor/media/rdma.rs
+++ b/lib/llm/src/preprocessor/media/rdma.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+use anyhow::Context;
 use anyhow::Result;
 use base64::{Engine as _, engine::general_purpose};
 use dynamo_memory::SystemStorage;
@@ -46,9 +48,9 @@ pub struct RdmaMediaDataDescriptor {
     #[serde(flatten)]
     pub(crate) tensor_info: MediaTensorInfo,
 
-    /// Canonical xxh3-64 key for `(shape, dtype, decoded image byte payload)`.
-    /// Serialized once so routing and backend embedding caches consume the
-    /// exact same hash without reimplementing the payload contract.
+    /// Canonical xxh3-64 key for decoded media. Image identity covers shape,
+    /// dtype, and RGB bytes; video identity additionally covers decoded
+    /// metadata that affects the model-visible token sequence.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) content_hash: Option<String>,
 
@@ -59,6 +61,16 @@ pub struct RdmaMediaDataDescriptor {
 }
 
 impl RdmaMediaDataDescriptor {
+    #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+    fn local_payload(&self) -> Option<&[u8]> {
+        use dynamo_memory::actions::Slice;
+        let registered = self.source_storage.as_ref()?;
+        let storage = registered.storage();
+        // SAFETY: the descriptor keeps the registered SystemStorage alive and
+        // request construction does not mutate it while this borrow exists.
+        unsafe { storage.as_slice().ok() }
+    }
+
     /// Canonical cache/routing key serialized on the descriptor.
     pub(crate) fn content_hash_key(&self) -> Option<&str> {
         self.content_hash.as_deref()
@@ -70,6 +82,113 @@ impl RdmaMediaDataDescriptor {
         self.content_hash_key()
             .and_then(|key| u64::from_str_radix(key, 16).ok())
     }
+
+    /// Canonical identity for one frontend-decoded video:
+    /// `(modality, shape, dtype, decoded metadata, sampled RGB bytes)`.
+    /// Metadata is serialized from the typed object sent to the worker, so new
+    /// model-visible fields automatically participate in the identity.
+    #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+    pub(crate) fn video_content_hash(&self) -> Result<u64> {
+        self.video_metadata()?;
+        self.content_hash()
+            .context("decoded video content hash is missing")
+    }
+
+    #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+    pub(crate) fn video_metadata(&self) -> Result<&super::decoders::VideoMetadata> {
+        match self.tensor_info.metadata.as_ref() {
+            Some(DecodedMediaMetadata::Video(metadata)) => Ok(metadata),
+            Some(_) => anyhow::bail!("decoded media metadata is not video metadata"),
+            None => anyhow::bail!("decoded video metadata is missing"),
+        }
+    }
+
+    /// Validate the contiguous `[T, H, W, 3]` payload and return its video
+    /// dimensions without copying or preprocessing pixels.
+    #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+    pub(crate) fn video_dimensions(&self) -> Result<(usize, u32, u32)> {
+        let bytes = self
+            .local_payload()
+            .ok_or_else(|| anyhow::anyhow!("decoded video has no local payload"))?;
+        video_dimensions_from_parts(&self.tensor_info, bytes)
+    }
+}
+
+#[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+fn hash_video_content(tensor_info: &MediaTensorInfo, bytes: &[u8]) -> Result<u64> {
+    use xxhash_rust::xxh3::Xxh3;
+
+    anyhow::ensure!(!bytes.is_empty(), "decoded video payload is empty");
+    let metadata = tensor_info
+        .metadata
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("decoded video metadata is missing"))?;
+    let DecodedMediaMetadata::Video(metadata) = metadata else {
+        anyhow::bail!("decoded media metadata is not video metadata");
+    };
+    let metadata_bytes = serde_json::to_vec(metadata)
+        .map_err(|error| anyhow::anyhow!("failed to serialize video metadata: {error}"))?;
+
+    let mut hasher = Xxh3::new();
+    update_len_prefixed(&mut hasher, b"video");
+    hasher.update(&(tensor_info.shape.len() as u64).to_le_bytes());
+    for &dim in &tensor_info.shape {
+        hasher.update(&(dim as u64).to_le_bytes());
+    }
+    let dtype_byte = match tensor_info.dtype {
+        DataType::UINT8 => 0,
+    };
+    hasher.update(&[dtype_byte]);
+    update_len_prefixed(&mut hasher, &metadata_bytes);
+    update_len_prefixed(&mut hasher, bytes);
+    Ok(hasher.digest())
+}
+
+#[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+fn video_dimensions_from_parts(
+    tensor_info: &MediaTensorInfo,
+    bytes: &[u8],
+) -> Result<(usize, u32, u32)> {
+    let [frames, height, width, channels] = tensor_info.shape.as_slice() else {
+        anyhow::bail!(
+            "decoded video shape must be [T, H, W, C], got {:?}",
+            tensor_info.shape
+        );
+    };
+    anyhow::ensure!(*frames > 0, "decoded video has no frames");
+    anyhow::ensure!(
+        *height > 0 && *width > 0,
+        "decoded video dimensions are zero"
+    );
+    anyhow::ensure!(*channels == 3, "decoded video must contain RGB frames");
+    anyhow::ensure!(
+        tensor_info.dtype == DataType::UINT8,
+        "decoded video dtype must be uint8"
+    );
+
+    let frame_len = height
+        .checked_mul(*width)
+        .and_then(|value| value.checked_mul(*channels))
+        .ok_or_else(|| anyhow::anyhow!("decoded video frame size overflow"))?;
+    let expected_len = frames
+        .checked_mul(frame_len)
+        .ok_or_else(|| anyhow::anyhow!("decoded video payload size overflow"))?;
+    anyhow::ensure!(
+        bytes.len() == expected_len,
+        "decoded video payload has {} bytes, expected {}",
+        bytes.len(),
+        expected_len
+    );
+    let width = u32::try_from(*width).context("decoded video width exceeds u32")?;
+    let height = u32::try_from(*height).context("decoded video height exceeds u32")?;
+
+    Ok((*frames, width, height))
+}
+
+#[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+fn update_len_prefixed(hasher: &mut xxhash_rust::xxh3::Xxh3, bytes: &[u8]) {
+    hasher.update(&(bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
 }
 
 fn canonical_content_hash(shape: &[usize], dtype: DataType, bytes: &[u8]) -> u64 {
@@ -91,34 +210,50 @@ fn canonical_content_hash(shape: &[usize], dtype: DataType, bytes: &[u8]) -> u64
     hasher.digest()
 }
 
-fn content_hash_for_storage(tensor_info: &MediaTensorInfo, storage: &SystemStorage) -> Option<u64> {
+fn content_hash_for_storage(
+    tensor_info: &MediaTensorInfo,
+    storage: &SystemStorage,
+    _hash_video: bool,
+) -> Option<u64> {
     use dynamo_memory::{MemoryDescriptor, actions::Slice};
 
-    // The current consumers cache and route images only. Avoid an otherwise
-    // unused full-buffer pass over decoded videos.
-    if !matches!(
-        tensor_info.metadata.as_ref(),
-        Some(DecodedMediaMetadata::Image(_))
-    ) || storage.size() == 0
-    {
+    if storage.size() == 0 {
         return None;
     }
 
     // SAFETY: storage owns this stable buffer and is only read while the
     // descriptor is being built, before NIXL can access it concurrently.
     let bytes = unsafe { storage.as_slice().ok()? };
-    Some(canonical_content_hash(
-        &tensor_info.shape,
-        tensor_info.dtype,
-        bytes,
-    ))
+    match tensor_info.metadata.as_ref() {
+        Some(DecodedMediaMetadata::Image(_)) => Some(canonical_content_hash(
+            &tensor_info.shape,
+            tensor_info.dtype,
+            bytes,
+        )),
+        #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+        Some(DecodedMediaMetadata::Video(_)) if _hash_video => {
+            match hash_video_content(tensor_info, bytes) {
+                Ok(hash) => Some(hash),
+                Err(error) => {
+                    tracing::debug!(%error, "Skipping exact routing hash for decoded video");
+                    None
+                }
+            }
+        }
+        #[cfg(all(feature = "mm-routing", feature = "media-ffmpeg"))]
+        Some(DecodedMediaMetadata::Video(_)) => None,
+        #[cfg(all(not(feature = "mm-routing"), feature = "media-ffmpeg"))]
+        Some(DecodedMediaMetadata::Video(_)) => None,
+        None => None,
+    }
 }
 
 impl DecodedMediaData {
-    /// Precompute the canonical image hash while still running on the decode
-    /// thread. Videos and empty buffers intentionally remain unkeyed.
-    pub(crate) fn compute_content_hash(&mut self) {
-        self.content_hash = content_hash_for_storage(&self.tensor_info, &self.data);
+    /// Precompute the canonical media hash while still running on the decode
+    /// thread. Images are always hashed; videos are hashed only when the
+    /// request is eligible for exact MM routing.
+    pub(crate) fn compute_content_hash(&mut self, hash_video: bool) {
+        self.content_hash = content_hash_for_storage(&self.tensor_info, &self.data, hash_video);
     }
 
     pub fn into_rdma_descriptor(self, nixl_agent: &NixlAgent) -> Result<RdmaMediaDataDescriptor> {
@@ -205,5 +340,89 @@ mod tests {
 
         assert_eq!(hash, 0x7a9b_bcb1_1a89_8630);
         assert_eq!(format!("{hash:016x}"), "7a9bbcb11a898630");
+    }
+}
+#[cfg(all(test, feature = "mm-routing", feature = "media-ffmpeg"))]
+mod video_tests {
+    use super::*;
+    use crate::preprocessor::media::decoders::VideoMetadata;
+
+    fn video_info(sampled_timestamps: Vec<f64>) -> MediaTensorInfo {
+        MediaTensorInfo {
+            shape: vec![2, 1, 2, 3],
+            dtype: DataType::UINT8,
+            metadata: Some(DecodedMediaMetadata::Video(VideoMetadata {
+                source_fps: 24.0,
+                source_duration: 10.0,
+                sampled_timestamps,
+            })),
+        }
+    }
+
+    #[test]
+    fn video_hash_covers_metadata_shape_and_rgb_bytes() {
+        let bytes = [0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+        let info = video_info(vec![0.0, 5.0]);
+        let expected = hash_video_content(&info, &bytes).unwrap();
+
+        assert_eq!(hash_video_content(&info, &bytes).unwrap(), expected);
+
+        let changed_metadata = video_info(vec![0.0, 5.1]);
+        assert_ne!(
+            hash_video_content(&changed_metadata, &bytes).unwrap(),
+            expected
+        );
+
+        let mut changed_shape = info.clone();
+        changed_shape.shape = vec![1, 2, 2, 3];
+        assert_ne!(
+            hash_video_content(&changed_shape, &bytes).unwrap(),
+            expected
+        );
+
+        let mut changed_bytes = bytes;
+        changed_bytes[0] = 42;
+        assert_ne!(hash_video_content(&info, &changed_bytes).unwrap(), expected);
+    }
+
+    #[test]
+    fn video_hash_is_precomputed_from_decoded_storage() {
+        let bytes = [0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+        let info = video_info(vec![0.0, 5.0]);
+        let mut storage = SystemStorage::new(bytes.len()).unwrap();
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), storage.as_mut_ptr(), bytes.len());
+        }
+
+        assert_eq!(
+            content_hash_for_storage(&info, &storage, true),
+            Some(hash_video_content(&info, &bytes).unwrap())
+        );
+    }
+
+    #[test]
+    fn video_hash_is_skipped_when_exact_routing_is_ineligible() {
+        let bytes = [0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+        let info = video_info(vec![0.0, 5.0]);
+        let mut storage = SystemStorage::new(bytes.len()).unwrap();
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), storage.as_mut_ptr(), bytes.len());
+        }
+
+        assert_eq!(content_hash_for_storage(&info, &storage, false), None);
+    }
+
+    #[test]
+    fn video_dimensions_validate_rgb_payload_layout() {
+        let bytes = [0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+        let info = video_info(vec![0.0, 5.0]);
+        let dimensions = video_dimensions_from_parts(&info, &bytes).unwrap();
+
+        assert_eq!(dimensions, (2, 2, 1));
+
+        let mut rgba = info.clone();
+        rgba.shape[3] = 4;
+        assert!(video_dimensions_from_parts(&rgba, &bytes).is_err());
+        assert!(video_dimensions_from_parts(&info, &bytes[..11]).is_err());
     }
 }

--- a/lib/llm/src/preprocessor/mm_routing/config.rs
+++ b/lib/llm/src/preprocessor/mm_routing/config.rs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use crate::protocols::TokenIdType;
+
+pub(super) fn read_model_config(
+    model_id: &str,
+    expected_model_type: &str,
+    expected_architecture: &str,
+    family: &str,
+    model_dir: &Path,
+) -> Result<Value> {
+    let config = read_json(model_dir, "config.json")?;
+    let actual_model_type = config
+        .get("model_type")
+        .and_then(Value::as_str)
+        .with_context(|| format!("mm-routing: {family} model_type is missing from config.json"))?;
+    anyhow::ensure!(
+        actual_model_type == expected_model_type,
+        "mm-routing: model_type mismatch for {model_id}: deployment reports {expected_model_type:?}, config.json reports {actual_model_type:?}"
+    );
+
+    let architectures = config
+        .get("architectures")
+        .and_then(Value::as_array)
+        .with_context(|| {
+            format!("mm-routing: {family} architectures are missing from config.json")
+        })?;
+    anyhow::ensure!(
+        architectures
+            .iter()
+            .any(|architecture| architecture.as_str() == Some(expected_architecture)),
+        "mm-routing: {family} model_type {actual_model_type:?} requires architecture {expected_architecture:?}"
+    );
+    Ok(config)
+}
+
+pub(super) fn read_json(model_dir: &Path, filename: &str) -> Result<Value> {
+    let path = model_dir.join(filename);
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("mm-routing: failed to read {}", path.display()))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("mm-routing: failed to parse {}", path.display()))
+}
+
+pub(super) fn required_usize(value: &Value, field: &str, family: &str) -> Result<usize> {
+    value
+        .get(field)
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .with_context(|| format!("mm-routing: missing or invalid {family} field {field:?}"))
+}
+
+pub(super) fn required_token_id(value: &Value, field: &str, family: &str) -> Result<TokenIdType> {
+    value
+        .get(field)
+        .and_then(Value::as_u64)
+        .and_then(|value| TokenIdType::try_from(value).ok())
+        .with_context(|| format!("mm-routing: missing or invalid {family} token id {field:?}"))
+}

--- a/lib/llm/src/preprocessor/mm_routing/mod.rs
+++ b/lib/llm/src/preprocessor/mm_routing/mod.rs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lightweight model-visible video token expansion for MM-aware routing.
+
+// The facade is instantiated only when FFmpeg-backed frontend video decoding
+// is enabled. Its model-specific unit tests remain available without FFmpeg.
+#![cfg_attr(not(feature = "media-ffmpeg"), allow(dead_code))]
+
+mod config;
+mod qwen3;
+
+use std::{path::Path, sync::Arc};
+
+use anyhow::Result;
+use serde::Deserialize;
+
+use crate::{protocols::TokenIdType, tokenizers::traits::Tokenizer};
+
+/// Which token sequence the running vLLM Qwen3 processor replaces for video.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum QwenVideoPlaceholderTarget {
+    BareVideoToken,
+    VisionWrappedVideoToken,
+}
+
+/// Temporal rounding used by the running Transformers video processor.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum QwenVideoResizeMode {
+    LegacyCeil,
+    RoundTiesEven,
+}
+
+/// Worker-reported Qwen video prompt-expansion behavior.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+pub(crate) struct QwenVideoProcessorContract {
+    pub placeholder_target: QwenVideoPlaceholderTarget,
+    pub resize_mode: QwenVideoResizeMode,
+}
+
+/// Geometry and temporal metadata visible to a model's video processor.
+pub(crate) struct VideoRoutingInput<'a> {
+    pub frame_count: usize,
+    pub width: u32,
+    pub height: u32,
+    pub source_fps: f64,
+    pub sampled_timestamps: &'a [f64],
+}
+
+pub(crate) struct VideoRoutingReplacement {
+    pub placeholder_token_id: TokenIdType,
+    /// Exact chat-template token sequence replaced by the model processor.
+    pub target_tokens: Vec<TokenIdType>,
+    pub replacement_tokens: Vec<TokenIdType>,
+}
+
+enum SupportedVideoModel {
+    Qwen3(qwen3::Qwen3VideoRoutingSpec),
+}
+
+pub(crate) struct VideoRoutingProcessor {
+    model: SupportedVideoModel,
+}
+
+impl VideoRoutingProcessor {
+    pub(crate) fn try_new(
+        model_id: &str,
+        model_type: &str,
+        model_dir: &Path,
+        tokenizer: Arc<dyn Tokenizer>,
+        qwen_video_contract: QwenVideoProcessorContract,
+    ) -> Result<Option<Self>> {
+        let model = if qwen3::supports_model_type(model_type) {
+            SupportedVideoModel::Qwen3(qwen3::Qwen3VideoRoutingSpec::from_model_dir(
+                model_id,
+                model_type,
+                model_dir,
+                tokenizer,
+                qwen_video_contract,
+            )?)
+        } else {
+            return Ok(None);
+        };
+
+        Ok(Some(Self { model }))
+    }
+
+    pub(crate) fn build_replacement(
+        &self,
+        input: &VideoRoutingInput<'_>,
+    ) -> Result<VideoRoutingReplacement> {
+        match &self.model {
+            SupportedVideoModel::Qwen3(spec) => spec.build_replacement(input),
+        }
+    }
+}

--- a/lib/llm/src/preprocessor/mm_routing/qwen3.rs
+++ b/lib/llm/src/preprocessor/mm_routing/qwen3.rs
@@ -1,0 +1,862 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{path::Path, sync::Arc};
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use super::{
+    QwenVideoPlaceholderTarget, QwenVideoProcessorContract, QwenVideoResizeMode, VideoRoutingInput,
+    VideoRoutingReplacement,
+    config::{read_json, read_model_config, required_token_id, required_usize},
+};
+use crate::{protocols::TokenIdType, tokenizers::traits::Tokenizer};
+
+const SUPPORTED_MODEL_TYPES: &[&str] = &["qwen3_vl", "qwen3_vl_moe", "qwen3_5", "qwen3_5_moe"];
+
+fn expected_architecture(model_type: &str) -> Option<&'static str> {
+    match model_type {
+        "qwen3_vl" => Some("Qwen3VLForConditionalGeneration"),
+        "qwen3_vl_moe" => Some("Qwen3VLMoeForConditionalGeneration"),
+        "qwen3_5" => Some("Qwen3_5ForConditionalGeneration"),
+        "qwen3_5_moe" => Some("Qwen3_5MoeForConditionalGeneration"),
+        _ => None,
+    }
+}
+
+pub(super) fn supports_model_type(model_type: &str) -> bool {
+    SUPPORTED_MODEL_TYPES.contains(&model_type)
+}
+
+pub(super) struct Qwen3VideoRoutingSpec {
+    patch_size: usize,
+    spatial_merge_size: usize,
+    temporal_patch_size: usize,
+    video_min_pixels: usize,
+    video_max_pixels: usize,
+    video_token_id: TokenIdType,
+    vision_start_token_id: TokenIdType,
+    vision_end_token_id: TokenIdType,
+    placeholder_target: QwenVideoPlaceholderTarget,
+    resize_mode: QwenVideoResizeMode,
+    tokenizer: Arc<dyn Tokenizer>,
+}
+
+impl Qwen3VideoRoutingSpec {
+    pub(super) fn from_model_dir(
+        model_id: &str,
+        expected_model_type: &str,
+        model_dir: &Path,
+        tokenizer: Arc<dyn Tokenizer>,
+        processor_contract: QwenVideoProcessorContract,
+    ) -> Result<Self> {
+        let expected_architecture = expected_architecture(expected_model_type)
+            .context("mm-routing: Qwen video model_type has no registered architecture")?;
+        let model_config = read_model_config(
+            model_id,
+            expected_model_type,
+            expected_architecture,
+            "Qwen",
+            model_dir,
+        )?;
+
+        let vision_config = model_config
+            .get("vision_config")
+            .context("mm-routing: Qwen vision_config is missing")?;
+        let patch_size = required_usize(vision_config, "patch_size", "Qwen")?;
+        let spatial_merge_size = required_usize(vision_config, "spatial_merge_size", "Qwen")?;
+        let temporal_patch_size = required_usize(vision_config, "temporal_patch_size", "Qwen")?;
+        anyhow::ensure!(
+            patch_size > 0 && spatial_merge_size > 0 && temporal_patch_size > 0,
+            "mm-routing: Qwen video patch and merge sizes must be positive"
+        );
+
+        let video_config = read_json(model_dir, "video_preprocessor_config.json")?;
+        anyhow::ensure!(
+            video_config
+                .get("video_processor_type")
+                .and_then(Value::as_str)
+                == Some("Qwen3VLVideoProcessor"),
+            "mm-routing: unsupported Qwen video_processor_type"
+        );
+        anyhow::ensure!(
+            video_config
+                .get("do_resize")
+                .and_then(Value::as_bool)
+                .unwrap_or(true),
+            "mm-routing: Qwen video routing does not support do_resize=false"
+        );
+        if let Some(cap_pixels_per_frame) = video_config
+            .get("cap_pixels_per_frame")
+            .filter(|value| !value.is_null())
+        {
+            let cap_pixels_per_frame = cap_pixels_per_frame
+                .as_bool()
+                .context("mm-routing: Qwen cap_pixels_per_frame must be boolean")?;
+            anyhow::ensure!(
+                !cap_pixels_per_frame,
+                "mm-routing: Qwen video routing does not support cap_pixels_per_frame=true"
+            );
+        }
+        ensure_matching_value(&video_config, "patch_size", patch_size)?;
+        ensure_matching_value(&video_config, "temporal_patch_size", temporal_patch_size)?;
+        ensure_matching_value(&video_config, "merge_size", spatial_merge_size)?;
+
+        let size = video_config
+            .get("size")
+            .context("mm-routing: Qwen video processor size is missing")?;
+        let video_min_pixels = required_usize(size, "shortest_edge", "Qwen")?;
+        let video_max_pixels = required_usize(size, "longest_edge", "Qwen")?;
+        anyhow::ensure!(
+            video_min_pixels > 0 && video_max_pixels >= video_min_pixels,
+            "mm-routing: invalid Qwen video pixel bounds"
+        );
+
+        Ok(Self {
+            patch_size,
+            spatial_merge_size,
+            temporal_patch_size,
+            video_min_pixels,
+            video_max_pixels,
+            video_token_id: required_token_id(&model_config, "video_token_id", "Qwen")?,
+            vision_start_token_id: required_token_id(
+                &model_config,
+                "vision_start_token_id",
+                "Qwen",
+            )?,
+            vision_end_token_id: required_token_id(&model_config, "vision_end_token_id", "Qwen")?,
+            placeholder_target: processor_contract.placeholder_target,
+            resize_mode: processor_contract.resize_mode,
+            tokenizer,
+        })
+    }
+
+    pub(super) fn build_replacement(
+        &self,
+        input: &VideoRoutingInput<'_>,
+    ) -> Result<VideoRoutingReplacement> {
+        self.validate_input(input)?;
+        let (grid_t, grid_h, grid_w) = self.video_grid(input)?;
+        let merge_area = self
+            .spatial_merge_size
+            .checked_mul(self.spatial_merge_size)
+            .context("mm-routing: Qwen spatial merge area overflow")?;
+        let spatial_patches = grid_h
+            .checked_mul(grid_w)
+            .context("mm-routing: Qwen video spatial grid overflow")?;
+        anyhow::ensure!(
+            spatial_patches.is_multiple_of(merge_area),
+            "mm-routing: Qwen video grid is not divisible by the spatial merge area"
+        );
+        let tokens_per_grid = spatial_patches / merge_area;
+        let base_video_tokens = grid_t
+            .checked_mul(tokens_per_grid)
+            .context("mm-routing: Qwen video token count overflow")?;
+
+        let grid_timestamps = self.grid_timestamps(input, grid_t)?;
+        let mut replacement_tokens = Vec::with_capacity(
+            base_video_tokens
+                .checked_add(grid_t.saturating_mul(8))
+                .context("mm-routing: Qwen video replacement capacity overflow")?,
+        );
+        for timestamp in grid_timestamps {
+            let timestamp_text = format!("<{timestamp:.1} seconds>");
+            let timestamp_tokens = self.tokenizer.encode(&timestamp_text).with_context(|| {
+                format!("mm-routing: failed to tokenize Qwen video timestamp {timestamp_text:?}")
+            })?;
+            replacement_tokens.extend_from_slice(timestamp_tokens.token_ids());
+            replacement_tokens.push(self.vision_start_token_id);
+            replacement_tokens.extend(std::iter::repeat_n(self.video_token_id, tokens_per_grid));
+            replacement_tokens.push(self.vision_end_token_id);
+        }
+
+        let target_tokens = match self.placeholder_target {
+            QwenVideoPlaceholderTarget::BareVideoToken => vec![self.video_token_id],
+            QwenVideoPlaceholderTarget::VisionWrappedVideoToken => vec![
+                self.vision_start_token_id,
+                self.video_token_id,
+                self.vision_end_token_id,
+            ],
+        };
+
+        Ok(VideoRoutingReplacement {
+            placeholder_token_id: self.video_token_id,
+            target_tokens,
+            replacement_tokens,
+        })
+    }
+
+    fn validate_input(&self, input: &VideoRoutingInput<'_>) -> Result<()> {
+        anyhow::ensure!(
+            input.frame_count > 0,
+            "mm-routing: Qwen video requires at least one sampled frame"
+        );
+        anyhow::ensure!(
+            input.sampled_timestamps.len() == input.frame_count,
+            "mm-routing: sampled timestamp count {} does not match frame count {}",
+            input.sampled_timestamps.len(),
+            input.frame_count
+        );
+        anyhow::ensure!(
+            input.source_fps.is_finite() && input.source_fps > 0.0,
+            "mm-routing: Qwen video source fps must be finite and positive"
+        );
+        anyhow::ensure!(
+            input
+                .sampled_timestamps
+                .iter()
+                .all(|timestamp| timestamp.is_finite() && *timestamp >= 0.0),
+            "mm-routing: Qwen sampled timestamps must be finite and non-negative"
+        );
+        anyhow::ensure!(
+            input
+                .sampled_timestamps
+                .windows(2)
+                .all(|pair| pair[0] <= pair[1]),
+            "mm-routing: Qwen sampled timestamps must be non-decreasing"
+        );
+        Ok(())
+    }
+
+    fn video_grid(&self, input: &VideoRoutingInput<'_>) -> Result<(usize, usize, usize)> {
+        let (resized_height, resized_width) = self.smart_resize(
+            input.frame_count,
+            usize::try_from(input.height).context("mm-routing: video height exceeds usize")?,
+            usize::try_from(input.width).context("mm-routing: video width exceeds usize")?,
+        )?;
+        let padded_frames = self.padded_frame_count(input.frame_count)?;
+        Ok((
+            padded_frames / self.temporal_patch_size,
+            resized_height / self.patch_size,
+            resized_width / self.patch_size,
+        ))
+    }
+
+    fn padded_frame_count(&self, frame_count: usize) -> Result<usize> {
+        let temporal_groups = frame_count
+            .checked_add(self.temporal_patch_size - 1)
+            .context("mm-routing: Qwen temporal padding overflow")?
+            / self.temporal_patch_size;
+        temporal_groups
+            .checked_mul(self.temporal_patch_size)
+            .context("mm-routing: Qwen temporal padding overflow")
+    }
+
+    /// Match Transformers' Qwen3VLVideoProcessor.smart_resize.
+    fn smart_resize(
+        &self,
+        num_frames: usize,
+        height: usize,
+        width: usize,
+    ) -> Result<(usize, usize)> {
+        let factor = self
+            .patch_size
+            .checked_mul(self.spatial_merge_size)
+            .context("mm-routing: Qwen resize factor overflow")?;
+        let (height, width) = match self.resize_mode {
+            QwenVideoResizeMode::LegacyCeil => {
+                anyhow::ensure!(
+                    height >= factor && width >= factor,
+                    "mm-routing: Qwen video dimensions {width}x{height} are smaller than resize factor {factor}"
+                );
+                (height, width)
+            }
+            QwenVideoResizeMode::RoundTiesEven => {
+                anyhow::ensure!(
+                    num_frames >= self.temporal_patch_size,
+                    "mm-routing: Qwen video frame count {num_frames} is smaller than temporal patch size {}",
+                    self.temporal_patch_size
+                );
+                if height < factor || width < factor {
+                    let scale = (factor as f64 / height as f64).max(factor as f64 / width as f64);
+                    (
+                        (height as f64 * scale) as usize,
+                        (width as f64 * scale) as usize,
+                    )
+                } else {
+                    (height, width)
+                }
+            }
+        };
+        let aspect_ratio = height.max(width) as f64 / height.min(width) as f64;
+        anyhow::ensure!(
+            aspect_ratio <= 200.0,
+            "mm-routing: Qwen video aspect ratio exceeds 200:1"
+        );
+
+        let mut resized_height =
+            (height as f64 / factor as f64).round_ties_even() as usize * factor;
+        let mut resized_width = (width as f64 / factor as f64).round_ties_even() as usize * factor;
+        let resize_frames = match self.resize_mode {
+            QwenVideoResizeMode::LegacyCeil => self.padded_frame_count(num_frames)?,
+            // Resize rounds to the nearest temporal group; patchification pads upward.
+            QwenVideoResizeMode::RoundTiesEven => {
+                ((num_frames as f64 / self.temporal_patch_size as f64).round_ties_even() as usize)
+                    .checked_mul(self.temporal_patch_size)
+                    .context("mm-routing: Qwen resize frame count overflow")?
+            }
+        };
+
+        let resized_volume = resize_frames as f64 * resized_height as f64 * resized_width as f64;
+        let source_volume = num_frames as f64 * height as f64 * width as f64;
+        if resized_volume > self.video_max_pixels as f64 {
+            let beta = (source_volume / self.video_max_pixels as f64).sqrt();
+            resized_height =
+                ((height as f64 / beta / factor as f64).floor() as usize * factor).max(factor);
+            resized_width =
+                ((width as f64 / beta / factor as f64).floor() as usize * factor).max(factor);
+        } else if resized_volume < self.video_min_pixels as f64 {
+            let beta = (self.video_min_pixels as f64 / source_volume).sqrt();
+            resized_height = (height as f64 * beta / factor as f64).ceil() as usize * factor;
+            resized_width = (width as f64 * beta / factor as f64).ceil() as usize * factor;
+        }
+
+        Ok((resized_height, resized_width))
+    }
+
+    fn grid_timestamps(&self, input: &VideoRoutingInput<'_>, grid_t: usize) -> Result<Vec<f64>> {
+        let mut frame_timestamps = Vec::with_capacity(
+            grid_t
+                .checked_mul(self.temporal_patch_size)
+                .context("mm-routing: Qwen timestamp padding overflow")?,
+        );
+        for timestamp in input.sampled_timestamps {
+            let frame_index = (timestamp * input.source_fps).round_ties_even();
+            anyhow::ensure!(
+                frame_index.is_finite() && frame_index <= u64::MAX as f64,
+                "mm-routing: Qwen sampled frame index is out of range"
+            );
+            frame_timestamps.push(frame_index / input.source_fps);
+        }
+        let last = *frame_timestamps
+            .last()
+            .context("mm-routing: Qwen sampled timestamps are empty")?;
+        frame_timestamps.resize(grid_t * self.temporal_patch_size, last);
+
+        Ok(frame_timestamps
+            .chunks_exact(self.temporal_patch_size)
+            .map(|timestamps| (timestamps[0] + timestamps[self.temporal_patch_size - 1]) / 2.0)
+            .collect())
+    }
+}
+
+fn ensure_matching_value(config: &Value, field: &str, expected: usize) -> Result<()> {
+    let actual = required_usize(config, field, "Qwen")?;
+    anyhow::ensure!(
+        actual == expected,
+        "mm-routing: Qwen {field} differs between config.json ({expected}) and video_preprocessor_config.json ({actual})"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tokenizers::{Encoding, traits::DecodeResult};
+
+    use super::*;
+
+    struct TimestampTokenizer;
+
+    impl crate::tokenizers::traits::Encoder for TimestampTokenizer {
+        fn encode(&self, input: &str) -> anyhow::Result<Encoding> {
+            let ids = match input {
+                "<0.5 seconds>" => vec![10, 11, 12, 13],
+                "<1.0 seconds>" => vec![30, 31, 32, 33],
+                "<2.5 seconds>" => vec![20, 21, 22, 23],
+                _ => anyhow::bail!("unexpected timestamp {input:?}"),
+            };
+            Ok(Encoding::Sp(ids))
+        }
+
+        fn encode_batch(&self, inputs: &[&str]) -> anyhow::Result<Vec<Encoding>> {
+            inputs.iter().map(|input| self.encode(input)).collect()
+        }
+    }
+
+    impl crate::tokenizers::traits::Decoder for TimestampTokenizer {
+        fn decode(
+            &self,
+            _token_ids: &[TokenIdType],
+            _skip_special_tokens: bool,
+        ) -> anyhow::Result<DecodeResult> {
+            Ok(DecodeResult::Complete(String::new()))
+        }
+    }
+
+    impl Tokenizer for TimestampTokenizer {}
+
+    fn spec() -> Qwen3VideoRoutingSpec {
+        Qwen3VideoRoutingSpec {
+            patch_size: 8,
+            spatial_merge_size: 1,
+            temporal_patch_size: 2,
+            video_min_pixels: 1,
+            video_max_pixels: 4096 * 4,
+            video_token_id: 151656,
+            vision_start_token_id: 151652,
+            vision_end_token_id: 151653,
+            placeholder_target: QwenVideoPlaceholderTarget::VisionWrappedVideoToken,
+            resize_mode: QwenVideoResizeMode::LegacyCeil,
+            tokenizer: Arc::new(TimestampTokenizer),
+        }
+    }
+
+    fn production_geometry_spec(resize_mode: QwenVideoResizeMode) -> Qwen3VideoRoutingSpec {
+        Qwen3VideoRoutingSpec {
+            patch_size: 16,
+            spatial_merge_size: 2,
+            temporal_patch_size: 2,
+            video_min_pixels: 4096,
+            video_max_pixels: 25_165_824,
+            video_token_id: 151656,
+            vision_start_token_id: 151652,
+            vision_end_token_id: 151653,
+            placeholder_target: QwenVideoPlaceholderTarget::VisionWrappedVideoToken,
+            resize_mode,
+            tokenizer: Arc::new(TimestampTokenizer),
+        }
+    }
+
+    #[test]
+    fn builds_timestamped_qwen_replacement_without_preprocessing_pixels() {
+        let timestamps = [0.0, 1.0, 2.0, 3.0];
+        let input = VideoRoutingInput {
+            frame_count: 4,
+            width: 32,
+            height: 32,
+            source_fps: 1.0,
+            sampled_timestamps: &timestamps,
+        };
+
+        let replacement = spec().build_replacement(&input).unwrap();
+
+        assert_eq!(replacement.placeholder_token_id, 151656);
+        assert_eq!(replacement.target_tokens, [151652, 151656, 151653]);
+        assert_eq!(replacement.replacement_tokens.len(), 44);
+        assert_eq!(
+            &replacement.replacement_tokens[..6],
+            &[10, 11, 12, 13, 151652, 151656]
+        );
+        assert_eq!(replacement.replacement_tokens[20], 151656);
+        assert_eq!(replacement.replacement_tokens[21], 151653);
+        assert_eq!(
+            &replacement.replacement_tokens[22..28],
+            &[20, 21, 22, 23, 151652, 151656]
+        );
+        assert_eq!(replacement.replacement_tokens[42], 151656);
+        assert_eq!(replacement.replacement_tokens[43], 151653);
+    }
+
+    #[test]
+    fn selects_worker_advertised_video_placeholder_target() {
+        let timestamps = [0.0, 1.0];
+        let input = VideoRoutingInput {
+            frame_count: 2,
+            width: 32,
+            height: 32,
+            source_fps: 1.0,
+            sampled_timestamps: &timestamps,
+        };
+
+        let mut video_token_spec = spec();
+        video_token_spec.placeholder_target = QwenVideoPlaceholderTarget::BareVideoToken;
+        assert_eq!(
+            video_token_spec
+                .build_replacement(&input)
+                .unwrap()
+                .target_tokens,
+            [151656]
+        );
+
+        let wrapped_spec = spec();
+        assert_eq!(
+            wrapped_spec
+                .build_replacement(&input)
+                .unwrap()
+                .target_tokens,
+            [151652, 151656, 151653]
+        );
+    }
+
+    struct CheckpointTimestampTokenizer {
+        seconds_token_id: TokenIdType,
+    }
+
+    impl crate::tokenizers::traits::Encoder for CheckpointTimestampTokenizer {
+        fn encode(&self, input: &str) -> anyhow::Result<Encoding> {
+            anyhow::ensure!(input == "<0.5 seconds>", "unexpected timestamp {input:?}");
+            Ok(Encoding::Sp(vec![
+                27,
+                15,
+                13,
+                20,
+                self.seconds_token_id,
+                29,
+            ]))
+        }
+
+        fn encode_batch(&self, inputs: &[&str]) -> anyhow::Result<Vec<Encoding>> {
+            inputs.iter().map(|input| self.encode(input)).collect()
+        }
+    }
+
+    impl crate::tokenizers::traits::Decoder for CheckpointTimestampTokenizer {
+        fn decode(
+            &self,
+            _token_ids: &[TokenIdType],
+            _skip_special_tokens: bool,
+        ) -> anyhow::Result<DecodeResult> {
+            Ok(DecodeResult::Complete(String::new()))
+        }
+    }
+
+    impl Tokenizer for CheckpointTimestampTokenizer {}
+
+    #[test]
+    fn replacement_tokens_match_qwen3_checkpoint_tokenizer_golden() {
+        let timestamps = [0.0, 1.0];
+        let input = VideoRoutingInput {
+            frame_count: 2,
+            width: 32,
+            height: 32,
+            source_fps: 1.0,
+            sampled_timestamps: &timestamps,
+        };
+        let spec = Qwen3VideoRoutingSpec {
+            patch_size: 16,
+            spatial_merge_size: 2,
+            temporal_patch_size: 2,
+            video_min_pixels: 4096,
+            video_max_pixels: 25_165_824,
+            video_token_id: 151656,
+            vision_start_token_id: 151652,
+            vision_end_token_id: 151653,
+            placeholder_target: QwenVideoPlaceholderTarget::BareVideoToken,
+            resize_mode: QwenVideoResizeMode::LegacyCeil,
+            tokenizer: Arc::new(CheckpointTimestampTokenizer {
+                seconds_token_id: 6486,
+            }),
+        };
+
+        assert_eq!(
+            spec.build_replacement(&input).unwrap().replacement_tokens,
+            vec![
+                27, 15, 13, 20, 6486, 29, 151652, 151656, 151656, 151656, 151656, 151653,
+            ]
+        );
+    }
+
+    #[test]
+    fn timestamp_frame_indices_use_ties_to_even_like_worker() {
+        let timestamps = [1.25, 1.25];
+        let input = VideoRoutingInput {
+            frame_count: 2,
+            width: 32,
+            height: 32,
+            source_fps: 2.0,
+            sampled_timestamps: &timestamps,
+        };
+
+        assert_eq!(spec().grid_timestamps(&input, 1).unwrap(), vec![1.0]);
+
+        let replacement = spec().build_replacement(&input).unwrap();
+        assert_eq!(&replacement.replacement_tokens[..4], &[30, 31, 32, 33]);
+    }
+
+    #[test]
+    fn temporal_padding_repeats_the_last_sampled_frame() {
+        struct PaddingTokenizer;
+        impl crate::tokenizers::traits::Encoder for PaddingTokenizer {
+            fn encode(&self, input: &str) -> anyhow::Result<Encoding> {
+                let id = match input {
+                    "<0.5 seconds>" => 1,
+                    "<2.5 seconds>" => 2,
+                    "<4.0 seconds>" => 3,
+                    _ => anyhow::bail!("unexpected timestamp {input:?}"),
+                };
+                Ok(Encoding::Sp(vec![id]))
+            }
+            fn encode_batch(&self, inputs: &[&str]) -> anyhow::Result<Vec<Encoding>> {
+                inputs.iter().map(|input| self.encode(input)).collect()
+            }
+        }
+        impl crate::tokenizers::traits::Decoder for PaddingTokenizer {
+            fn decode(
+                &self,
+                _token_ids: &[TokenIdType],
+                _skip_special_tokens: bool,
+            ) -> anyhow::Result<DecodeResult> {
+                Ok(DecodeResult::Complete(String::new()))
+            }
+        }
+        impl Tokenizer for PaddingTokenizer {}
+
+        let mut spec = spec();
+        spec.tokenizer = Arc::new(PaddingTokenizer);
+        let timestamps = [0.0, 1.0, 2.0, 3.0, 4.0];
+        let input = VideoRoutingInput {
+            frame_count: 5,
+            width: 32,
+            height: 32,
+            source_fps: 1.0,
+            sampled_timestamps: &timestamps,
+        };
+
+        let replacement = spec.build_replacement(&input).unwrap();
+        let timestamp_positions: Vec<_> = replacement
+            .replacement_tokens
+            .iter()
+            .copied()
+            .filter(|token| (1..=3).contains(token))
+            .collect();
+        assert_eq!(timestamp_positions, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn rejects_non_monotonic_timestamps() {
+        let timestamps = [0.0, 2.0, 1.0, 3.0];
+        let input = VideoRoutingInput {
+            frame_count: 4,
+            width: 32,
+            height: 32,
+            source_fps: 1.0,
+            sampled_timestamps: &timestamps,
+        };
+        assert!(spec().build_replacement(&input).is_err());
+    }
+
+    #[test]
+    fn video_grid_matches_transformers_golden_cases() {
+        let cases = [
+            // frames, width, height, expected [T, H, W]
+            (4, 426, 240, (2, 16, 26)),
+            (30, 1280, 720, (15, 42, 76)),
+            (5, 641, 359, (3, 22, 40)),
+            (2, 32, 32, (1, 4, 4)),
+            (31, 1920, 1080, (16, 42, 74)),
+            (32, 1920, 1080, (16, 40, 72)),
+            (3, 224, 224, (2, 14, 14)),
+        ];
+        for resize_mode in [
+            QwenVideoResizeMode::LegacyCeil,
+            QwenVideoResizeMode::RoundTiesEven,
+        ] {
+            let spec = production_geometry_spec(resize_mode);
+            for (frame_count, width, height, expected) in cases {
+                let timestamps = vec![0.0; frame_count];
+                let input = VideoRoutingInput {
+                    frame_count,
+                    width,
+                    height,
+                    source_fps: 24.0,
+                    sampled_timestamps: &timestamps,
+                };
+                assert_eq!(
+                    spec.video_grid(&input).unwrap(),
+                    expected,
+                    "geometry mismatch for {frame_count} frames at {width}x{height}"
+                );
+            }
+        }
+
+        let timestamps = vec![0.0; 5];
+        let odd_frame_input = VideoRoutingInput {
+            frame_count: 5,
+            width: 3760,
+            height: 1120,
+            source_fps: 24.0,
+            sampled_timestamps: &timestamps,
+        };
+        assert_eq!(
+            production_geometry_spec(QwenVideoResizeMode::LegacyCeil)
+                .video_grid(&odd_frame_input)
+                .unwrap(),
+            (3, 76, 256)
+        );
+        assert_eq!(
+            production_geometry_spec(QwenVideoResizeMode::RoundTiesEven)
+                .video_grid(&odd_frame_input)
+                .unwrap(),
+            (3, 70, 236)
+        );
+    }
+
+    #[test]
+    fn handles_single_frame_by_advertised_resize_contract() {
+        let timestamps = [0.0];
+        let input = VideoRoutingInput {
+            frame_count: 1,
+            width: 224,
+            height: 224,
+            source_fps: 24.0,
+            sampled_timestamps: &timestamps,
+        };
+
+        assert!(
+            production_geometry_spec(QwenVideoResizeMode::RoundTiesEven)
+                .video_grid(&input)
+                .is_err()
+        );
+        assert_eq!(
+            production_geometry_spec(QwenVideoResizeMode::LegacyCeil)
+                .video_grid(&input)
+                .unwrap(),
+            (1, 14, 14)
+        );
+    }
+
+    #[test]
+    fn parses_qwen35_video_routing_config() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            r#"{
+                "model_type": "qwen3_5",
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "video_token_id": 248057,
+                "vision_start_token_id": 248053,
+                "vision_end_token_id": 248054,
+                "vision_config": {
+                    "patch_size": 16,
+                    "spatial_merge_size": 2,
+                    "temporal_patch_size": 2
+                }
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("video_preprocessor_config.json"),
+            r#"{
+                "video_processor_type": "Qwen3VLVideoProcessor",
+                "patch_size": 16,
+                "merge_size": 2,
+                "temporal_patch_size": 2,
+                "size": {"shortest_edge": 4096, "longest_edge": 25165824}
+            }"#,
+        )
+        .unwrap();
+
+        let parsed = Qwen3VideoRoutingSpec::from_model_dir(
+            "Qwen/Qwen3.5-4B",
+            "qwen3_5",
+            dir.path(),
+            Arc::new(TimestampTokenizer),
+            QwenVideoProcessorContract {
+                placeholder_target: QwenVideoPlaceholderTarget::BareVideoToken,
+                resize_mode: QwenVideoResizeMode::LegacyCeil,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(parsed.video_token_id, 248057);
+        assert_eq!(parsed.vision_start_token_id, 248053);
+        assert_eq!(parsed.vision_end_token_id, 248054);
+        assert_eq!(parsed.video_min_pixels, 4096);
+        assert_eq!(parsed.video_max_pixels, 25_165_824);
+    }
+
+    #[test]
+    fn rejects_video_processor_geometry_that_differs_from_model_config() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            r#"{
+                "model_type": "qwen3_vl",
+                "architectures": ["Qwen3VLForConditionalGeneration"],
+                "video_token_id": 151656,
+                "vision_start_token_id": 151652,
+                "vision_end_token_id": 151653,
+                "vision_config": {
+                    "patch_size": 16,
+                    "spatial_merge_size": 2,
+                    "temporal_patch_size": 2
+                }
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("video_preprocessor_config.json"),
+            r#"{
+                "video_processor_type": "Qwen3VLVideoProcessor",
+                "patch_size": 14,
+                "merge_size": 2,
+                "temporal_patch_size": 2,
+                "size": {"shortest_edge": 4096, "longest_edge": 25165824}
+            }"#,
+        )
+        .unwrap();
+
+        assert!(
+            Qwen3VideoRoutingSpec::from_model_dir(
+                "Qwen/Qwen3-VL-2B-Instruct",
+                "qwen3_vl",
+                dir.path(),
+                Arc::new(TimestampTokenizer),
+                QwenVideoProcessorContract {
+                    placeholder_target: QwenVideoPlaceholderTarget::BareVideoToken,
+                    resize_mode: QwenVideoResizeMode::LegacyCeil,
+                },
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_per_frame_pixel_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            r#"{
+                "model_type": "qwen3_vl",
+                "architectures": ["Qwen3VLForConditionalGeneration"],
+                "video_token_id": 151656,
+                "vision_start_token_id": 151652,
+                "vision_end_token_id": 151653,
+                "vision_config": {
+                    "patch_size": 16,
+                    "spatial_merge_size": 2,
+                    "temporal_patch_size": 2
+                }
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("video_preprocessor_config.json"),
+            r#"{
+                "video_processor_type": "Qwen3VLVideoProcessor",
+                "patch_size": 16,
+                "merge_size": 2,
+                "temporal_patch_size": 2,
+                "cap_pixels_per_frame": true,
+                "max_video_tokens": 768,
+                "size": {"shortest_edge": 4096, "longest_edge": 25165824}
+            }"#,
+        )
+        .unwrap();
+
+        let error = Qwen3VideoRoutingSpec::from_model_dir(
+            "Qwen/Qwen3-VL-2B-Instruct",
+            "qwen3_vl",
+            dir.path(),
+            Arc::new(TimestampTokenizer),
+            QwenVideoProcessorContract {
+                placeholder_target: QwenVideoPlaceholderTarget::BareVideoToken,
+                resize_mode: QwenVideoResizeMode::LegacyCeil,
+            },
+        )
+        .err()
+        .expect("per-frame pixel cap must disable exact video routing");
+
+        assert!(error.to_string().contains("cap_pixels_per_frame=true"));
+    }
+
+    #[test]
+    fn supports_only_explicit_qwen3_video_model_types() {
+        for model_type in ["qwen3_vl", "qwen3_vl_moe", "qwen3_5", "qwen3_5_moe"] {
+            assert!(supports_model_type(model_type));
+        }
+        assert!(!supports_model_type("qwen2_5_vl"));
+        assert!(!supports_model_type("my_qwen3_vl_finetune"));
+    }
+}

--- a/tests/mm_router/test_router_rust_mm_frontend_decode_e2e.py
+++ b/tests/mm_router/test_router_rust_mm_frontend_decode_e2e.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""End-to-end test for MM-aware KV routing with frontend image decoding.
+"""End-to-end tests for MM-aware KV routing with frontend media decoding.
 
 Architecture:
   Frontend (Rust preprocessor + KV router + MediaLoader)
@@ -21,6 +21,9 @@ Without content hashing (e.g. if the code regressed to URL hashing in the
 decoded branch), the second request would miss and overlap would be
 text-prefix only.
 
+The video case applies the same contract to sampled RGB frames plus the
+model-visible temporal metadata and verifies grouped video hashes reach vLLM.
+
 Kept in a separate module from test_router_rust_mm_router_e2e.py so its
 module-scoped fixture (different worker, different DYN_NAMESPACE) does
 not collide with the URL-passthrough fixture's registry entries.
@@ -34,6 +37,7 @@ import threading
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from io import BytesIO
+from pathlib import Path
 from typing import Any, Generator
 
 import pytest
@@ -50,13 +54,13 @@ from tests.utils.router_logs import (
 )
 
 VLLM_MM_MODEL = os.getenv("DYN_TEST_VLLM_MM_MODEL", "Qwen/Qwen3-VL-2B-Instruct")
+VIDEO_NUM_FRAMES = int(os.getenv("DYN_TEST_MM_VIDEO_NUM_FRAMES", "4"))
 BLOCK_SIZE = 16
 # Distinct namespace from test_router_rust_mm_router_e2e.py so the two
 # modules' workers/frontends don't register against each other.
 NAMESPACE = "router-rust-mm-fed"
 
 pytestmark = [
-    pytest.mark.post_merge,
     pytest.mark.e2e,
     pytest.mark.vllm,
     pytest.mark.multimodal,
@@ -137,7 +141,10 @@ class VLLMWorkerFrontendDecodeProcess(ManagedProcess):
                     f'"enable_kv_cache_events": true}}'
                 ),
             ],
-            env=_make_process_env(DYN_SYSTEM_PORT=str(system_port)),
+            env=_make_process_env(
+                DYN_SYSTEM_PORT=str(system_port),
+                DYN_MM_VIDEO_NUM_FRAMES=str(VIDEO_NUM_FRAMES),
+            ),
             health_check_urls=[
                 (f"http://localhost:{system_port}/health", _check_ready)
             ],
@@ -222,6 +229,22 @@ def _build_payload(image_uris: list[str]) -> dict[str, Any]:
     }
 
 
+def _build_video_payload(video_uri: str) -> dict[str, Any]:
+    return {
+        "model": VLLM_MM_MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this video."},
+                    {"type": "video_url", "video_url": {"url": video_uri}},
+                ],
+            }
+        ],
+        "max_tokens": 4,
+    }
+
+
 def _send(
     frontend_port: int,
     router_proc: ManagedProcess,
@@ -258,6 +281,7 @@ def _make_image_handler(image_map: dict[str, bytes]) -> type:
             if data is None:
                 self.send_error(404)
                 return
+            content_type = "video/mp4" if path.endswith(".mp4") else "image/png"
             range_hdr = self.headers.get("Range", "")
             if range_hdr.startswith("bytes="):
                 spec = range_hdr[len("bytes=") :]
@@ -275,14 +299,14 @@ def _make_image_handler(image_map: dict[str, bytes]) -> type:
                     return
                 chunk = data[lo : hi + 1]
                 self.send_response(206)
-                self.send_header("Content-Type", "image/png")
+                self.send_header("Content-Type", content_type)
                 self.send_header("Content-Length", str(len(chunk)))
                 self.send_header("Content-Range", f"bytes {lo}-{hi}/{len(data)}")
                 self.end_headers()
                 self.wfile.write(chunk)
             else:
                 self.send_response(200)
-                self.send_header("Content-Type", "image/png")
+                self.send_header("Content-Type", content_type)
                 self.send_header("Content-Length", str(len(data)))
                 self.end_headers()
                 self.wfile.write(data)
@@ -319,6 +343,33 @@ def http_image_server_with_alias() -> Generator[dict[str, str], None, None]:
         thread.join(timeout=5)
 
 
+@pytest.fixture(scope="module")
+def http_video_server_with_alias() -> Generator[dict[str, str], None, None]:
+    (port,) = allocate_ports(count=1, start_port=18700)
+    media_dir = Path(__file__).resolve().parents[2] / "lib/llm/tests/data/media"
+    video_bytes = (media_dir / "240p_100.mp4").read_bytes()
+    secondary_video_bytes = (media_dir / "triangle_240p_10.mp4").read_bytes()
+    media_map = {
+        "/video_A.mp4": video_bytes,
+        "/video_A_alias.mp4": video_bytes,
+        "/video_B.mp4": secondary_video_bytes,
+    }
+    server = HTTPServer(("127.0.0.1", port), _make_image_handler(media_map))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield {
+            "primary": f"http://127.0.0.1:{port}/video_A.mp4",
+            "alias": f"http://127.0.0.1:{port}/video_A_alias.mp4",
+            "secondary": f"http://127.0.0.1:{port}/video_B.mp4",
+        }
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.post_merge
 @pytest.mark.timeout(300)
 def test_frontend_decode_content_hash_collides_across_urls(
     start_frontend_decode_services,
@@ -344,10 +395,9 @@ def test_frontend_decode_content_hash_collides_across_urls(
         frontend_port, router_proc, _build_payload([alias_url]), "fed_alias"
     )
 
-    assert total_1 > 1 and total_2 > 1, (
-        f"expected non-trivial total blocks for MM request, got "
-        f"{total_1}, {total_2}"
-    )
+    assert (
+        total_1 > 1 and total_2 > 1
+    ), f"expected non-trivial total blocks for MM request, got {total_1}, {total_2}"
     assert overlap_2 > overlap_1 + 1, (
         f"frontend-decode mm_hash must be content-addressed: distinct URLs "
         f"serving the same image bytes should collide on the routing key. "
@@ -367,6 +417,7 @@ def test_frontend_decode_content_hash_collides_across_urls(
     )
 
 
+@pytest.mark.post_merge
 @pytest.mark.timeout(300)
 def test_frontend_decode_logs_decoded_bytes_source(
     start_frontend_decode_services,
@@ -394,3 +445,56 @@ def test_frontend_decode_logs_decoded_bytes_source(
         "`url_fallback` branch (descriptor lost source_storage) or the "
         "URL-passthrough branch (media_loader was None)."
     )
+
+
+@pytest.mark.pre_merge
+@pytest.mark.timeout(1800)
+def test_frontend_decoded_video_routes_by_sampled_content(
+    start_frontend_decode_services,
+    predownload_models,
+    http_video_server_with_alias,
+):
+    """Cover video identity reuse and separation under one model startup.
+
+    CI runs each selected test in its own pytest process, so keeping both video
+    scenarios here avoids paying the vLLM startup cost twice in pre-merge.
+    """
+    frontend_port, router_proc = start_frontend_decode_services
+    overlap_a1, total_a1, _ = _send(
+        frontend_port,
+        router_proc,
+        _build_video_payload(http_video_server_with_alias["primary"]),
+        "fed_video_a_primary",
+    )
+    overlap_a2, total_a2, data_a2 = _send(
+        frontend_port,
+        router_proc,
+        _build_video_payload(http_video_server_with_alias["alias"]),
+        "fed_video_a_alias",
+    )
+
+    assert total_a1 > 1 and total_a2 > 1
+    assert overlap_a2 > overlap_a1, (
+        "frontend-decoded aliases of the same video should share the sampled "
+        f"video routing key, got {overlap_a1}/{total_a1} then "
+        f"{overlap_a2}/{total_a2}"
+    )
+    cached_a2 = (data_a2.get("usage", {}).get("prompt_tokens_details") or {}).get(
+        "cached_tokens"
+    )
+    prompt_tokens_a2 = data_a2.get("usage", {}).get("prompt_tokens", 0)
+    assert cached_a2 is not None and cached_a2 > prompt_tokens_a2 // 2
+
+    overlap_b1, total_b1, _ = _send(
+        frontend_port,
+        router_proc,
+        _build_video_payload(http_video_server_with_alias["secondary"]),
+        "fed_video_b_primary",
+    )
+
+    assert total_b1 > 1
+    assert overlap_b1 < overlap_a2, (
+        "a distinct decoded video must not reuse video A's full routing prefix, "
+        f"got A warm={overlap_a2}/{total_a2}, B cold={overlap_b1}/{total_b1}"
+    )
+    assert "video routing metadata resolved" in router_proc.read_logs()


### PR DESCRIPTION
## Summary

- Backports #14094 to release/1.5.0.
- PR #13910 (commit 59b62c752) is already present on the release branch, so this completes both required video-routing changes.
- Does not include the separate #14214 optimization.

## Validation

- Verified the backport patch ID exactly matches merged commit 5b12de397.
- `cargo fmt --all -- --check`
- `cargo test -p dynamo-llm --features mm-routing mm_routing::qwen3 -- --nocapture` (12 passed)