### PR TITLE
fix(multimodal): return 4xx client errors for unfetchable image URLs

### DIFF
--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -16,7 +16,13 @@ from PIL import Image
 from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.runtime import run_async
 
-from ..http import HttpError, HttpStatusError, HttpTimeoutError, fetch_bytes
+from ..http import (
+    HttpConnectionError,
+    HttpError,
+    HttpStatusError,
+    HttpTimeoutError,
+    fetch_bytes,
+)
 from ..http.url_validator import (
     UrlValidationError,
     UrlValidationPolicy,
@@ -141,7 +147,21 @@ class ImageLoader:
                 f"{type(e).__name__} loading image: '{image_url}' "
                 f"(timeout={self._http_timeout}s)"
             )
-            raise ValueError(f"Timeout loading image: '{image_url}'") from e
+            raise HttpStatusError(
+                408,
+                f"Timeout loading image: '{image_url}' "
+                f"(timeout={self._http_timeout}s)",
+                image_url,
+            ) from e
+        except HttpConnectionError as e:
+            # Treat a user-supplied unreachable URL as a client error (400)
+            # rather than an internal server fault.
+            logger.error("%s loading image: '%s': %s", type(e).__name__, image_url, e)
+            raise HttpStatusError(
+                400,
+                f"Connection error loading image: '{image_url}': {e}",
+                image_url,
+            ) from e
         except HttpError as e:
             logger.error(f"{type(e).__name__} loading image: '{image_url}': {e}")
             raise
@@ -285,8 +305,10 @@ class ImageLoader:
 
         Raises:
             HttpStatusError: If any image fails with an HTTP status error
-                (e.g. 415 Unsupported Media Type); the status is preserved so the
-                frontend returns the correct client-error code instead of 500.
+                (e.g. 415 Unsupported Media Type), or with a transport error
+                (timeout mapped to 408, connection error mapped to 400); the
+                status is preserved so the frontend returns the correct
+                client-error code instead of 500.
             UrlValidationError: If a media URL is rejected by the SSRF policy;
                 preserved as a ValueError so the frontend returns a 4xx, not 500.
             Exception: If any image fails to load for any other reason

--- a/components/src/dynamo/common/tests/multimodal/test_image_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_image_loader.py
@@ -24,7 +24,7 @@ import numpy as np
 import pytest
 from PIL import Image
 
-from dynamo.common.http import HttpStatusError, HttpTimeoutError
+from dynamo.common.http import HttpConnectionError, HttpStatusError, HttpTimeoutError
 from dynamo.common.http.url_validator import UrlValidationError, UrlValidationPolicy
 from dynamo.common.multimodal.image_loader import URL_VARIANT_KEY, ImageLoader
 
@@ -153,7 +153,7 @@ async def test_retry_after_failure(loader: ImageLoader) -> None:
     ok_fetch = _mock_fetch_bytes()
 
     with patch(_FETCH_BYTES_PATH, fail_fetch):
-        with pytest.raises(ValueError, match="Timeout"):
+        with pytest.raises(HttpStatusError, match="Timeout"):
             await loader.load_image("https://example.com/img.png")
 
     # _inflight should be cleared after failure
@@ -195,12 +195,30 @@ async def test_data_url_non_image_rejected(loader: ImageLoader) -> None:
 # --- HTTP error contract ---
 
 
-async def test_http_timeout_raises_valueerror(loader: ImageLoader) -> None:
-    """HTTP timeout should be normalized to ValueError."""
+async def test_http_timeout_raises_408(loader: ImageLoader) -> None:
+    """A timeout on a user-supplied URL is a client error, so the
+    frontend must surface 408 instead of an opaque 500."""
     mock_fetch = _mock_fetch_bytes(side_effect=HttpTimeoutError("timed out"))
     with patch(_FETCH_BYTES_PATH, mock_fetch):
-        with pytest.raises(ValueError, match="Timeout loading image"):
+        with pytest.raises(HttpStatusError) as exc_info:
             await loader.load_image("https://example.com/img.png")
+        assert exc_info.value.status == 408
+        assert "Timeout loading image" in exc_info.value.message
+        assert "https://example.com/img.png" in exc_info.value.url
+
+
+async def test_http_connection_error_raises_400(loader: ImageLoader) -> None:
+    """An unreachable user-supplied URL is a client error, so the
+    frontend must surface 400 instead of an opaque 500."""
+    mock_fetch = _mock_fetch_bytes(
+        side_effect=HttpConnectionError("connection refused")
+    )
+    with patch(_FETCH_BYTES_PATH, mock_fetch):
+        with pytest.raises(HttpStatusError) as exc_info:
+            await loader.load_image("https://example.com/img.png")
+        assert exc_info.value.status == 400
+        assert "Connection error loading image" in exc_info.value.message
+        assert "https://example.com/img.png" in exc_info.value.url
 
 
 async def test_http_status_error_propagated(loader: ImageLoader) -> None:


### PR DESCRIPTION
## Overview:

Fetching a user-supplied `image_url` that times out or fails to connect was reported as an opaque HTTP 500. This change converts those transport failures into `HttpStatusError(408)` and `HttpStatusError(400)` so the frontend returns a 4xx client error carrying the URL and failure reason.


## Details:

- `image_loader.py`:
  - `HttpTimeoutError` is mapped to `HttpStatusError(408, ...)`.
  - `HttpConnectionError` is mapped to `HttpStatusError(400, ...)`.

- `test_image_loader.py`:
  - Updated `test_http_timeout_raises_valueerror` → `test_http_timeout_raises_408`.
  - Added `test_http_connection_error_raises_400`.

## Where should the reviewer start?

`components/srcynamo/common/multimodal/image_loader.py` — _fetch_and_process exception handling.
`components/src/dynamo/common/tests/multimodal/test_image_loader.py` — new error contract tests.


## Validation
Unit tests:

`pytest components/src/dynamo/common/tests/multimodal/test_image_loader.py -v`
Result: 26 passed.

Manual deployment check:

Request with a hanging image URL returned HTTP 400 with:

`{"message":"Timeout loading image: 'http://10.233.74.169:9999/x.jpg' (timeout=30.0s)","code":408}`

Previously this returned HTTP 500 Failed to generate completions.

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #14243 

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image-loading error handling for network timeouts and connection failures.
  * Timeouts now return a clear 408 error, while connection failures return a 400 error.
  * Error responses include the relevant message and request URL.
* **Documentation**
  * Updated batch image-loading documentation to describe how transport errors are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->