### PR TITLE
refactor(llm): drop two validators nothing calls

### DIFF
--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -262,19 +262,6 @@ pub fn validate_top_k(top_k: Option<i32>) -> Result<(), anyhow::Error> {
     }
 }
 
-/// Validates mutual exclusion of temperature and top_p
-pub fn validate_temperature_top_p_exclusion(
-    temperature: Option<f32>,
-    top_p: Option<f32>,
-) -> Result<(), anyhow::Error> {
-    match (temperature, top_p) {
-        (Some(t), Some(p)) if t != 1.0 && p != 1.0 => {
-            anyhow::bail!("Only one of temperature or top_p should be set (not both)");
-        }
-        _ => Ok(()),
-    }
-}
-
 /// Validates frequency penalty parameter
 pub fn validate_frequency_penalty(frequency_penalty: Option<f32>) -> Result<(), anyhow::Error> {
     if let Some(penalty) = frequency_penalty
@@ -732,15 +719,6 @@ fn validate_prompt_embeds_format(embeds: &str) -> Result<(), anyhow::Error> {
         );
     }
 
-    Ok(())
-}
-
-/// Validates prompt_embeds field (public wrapper for standalone validation)
-/// Format: PyTorch tensor serialized with torch.save() and base64-encoded
-pub fn validate_prompt_embeds(prompt_embeds: Option<&str>) -> Result<(), anyhow::Error> {
-    if let Some(embeds) = prompt_embeds {
-        validate_prompt_embeds_format(embeds)?;
-    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Two functions in `protocols/openai/validate.rs` have no call site anywhere in the tree and no test.

### `validate_temperature_top_p_exclusion`

```rust
(Some(t), Some(p)) if t != 1.0 && p != 1.0 => {
    anyhow::bail!("Only one of temperature or top_p should be set (not both)");
}
```

This is the one worth removing rather than leaving. Connecting it would be a regression, not a fix: the OpenAI API permits setting both `temperature` and `top_p`. Its documentation only *recommends* altering one or the other, and vLLM accepts both, so enforcing this would start rejecting requests that clients legitimately send today. Nothing else in the tree enforces or warns about the pair, so this is the only place that treats it as an error.

It sits in a file whose other validators are all wired into the request path, which is exactly the shape that invites someone to "finish the job" during a cleanup. I have made that mistake elsewhere in this repo, so removing the invitation seems better than leaving it.

### `validate_prompt_embeds`

A public wrapper around `validate_prompt_embeds_format` with no caller. The embeds path is already validated: `validate_prompt_or_embeds` calls the format helper directly.

```rust
if let Some(embeds) = prompt_embeds {
    validate_prompt_embeds_format(embeds)?;   // <- the real path
} else if let Some(p) = prompt {
    validate_prompt(p)?;
}
```

So this only duplicated the entry point. `validate_prompt_embeds_format` stays and keeps doing the base64, minimum-size and maximum-size checks. No validation is lost.

## Validation

- `cargo check -p dynamo-llm --no-default-features --lib` clean, `cargo clippy -p dynamo-llm --no-default-features --lib` clean, `cargo fmt --all --check` clean.
- Confirmed both are unreferenced before removing: a repo-wide search for each name returns only the definition. `validate_prompt` by contrast *is* called (from `validate_prompt_or_embeds`), so it stays.
- Confirmed neither has a test, so nothing in the suite encodes the removed behaviour.
- Deletions only, 22 lines, one file.

I could not run the `dynamo-llm` test binary here: linking it is OOM-killed on this machine. Since the change is deletions of unreferenced code and the crate builds and lints clean, I do not think execution adds much, but flagging it rather than leaving it implied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed two publicly exposed validation interfaces for temperature/top-p settings and prompt embeddings.
  * Prompt-embedding format validation remains available through the internal validation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->