### PR TITLE
perf(llm): only read the clock when a detokenize tracker is attached

### DIFF
--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -609,14 +609,13 @@ impl Decoder {
         self.generated_tokens += 1;
 
         // decode the token
-        let detokenize_start = Instant::now();
+        let detokenize_start = self.tracker.as_ref().map(|_| Instant::now());
         let token = {
             let _nvtx = dynamo_nvtx_range!("detokenize");
             self.decode_stream.step(token_id)?
         };
-        let detokenize_elapsed = detokenize_start.elapsed();
-        if let Some(tracker) = &self.tracker {
-            tracker.record_detokenize_latency(detokenize_elapsed);
+        if let (Some(start), Some(tracker)) = (detokenize_start, &self.tracker) {
+            tracker.record_detokenize_latency(start.elapsed());
         }
 
         // stop conditions to not apply until the minimum number of tokens have been generated


### PR DESCRIPTION
## Overview:

One removal of redundant work found during a hot-path review of `main`: `Decoder::step` timed every detokenization even when nothing consumed the measurement.

## Details:

`lib/llm/src/backend.rs` called `Instant::now()` and then `.elapsed()` on every generated token, but used the resulting duration only inside `if let Some(tracker) = &self.tracker`. The start timestamp is now taken only when a tracker is attached, so streams without one do no timing work. Behaviour with a tracker attached is unchanged, and there is no change to what gets recorded.

Scope note for anyone who reviewed the earlier revision: this PR previously also narrowed `subject_of` in `lib/runtime/src/pipeline/network/egress/addressed_router.rs` to deserialize only the field it reads. That commit has been dropped. The saving there was two small, short-lived allocations per dispatch — never benchmarked — and it carried a marginally more permissive parse plus a second decoupled definition of part of the wire format. On reflection that did not justify the review and maintenance cost, so the runtime file is untouched now. Thanks to the reviewers who caught the doc-comment inaccuracy on it.

Validation: `cargo check` and `cargo clippy` are clean for `dynamo-llm` (`--lib --no-default-features`, as the default features pull in the Linux-only `block-manager` and will not build on macOS), and `cargo fmt --all` is clean. Existing unit tests pass unchanged: 69 tests in `dynamo-llm` matching `backend`, including 8 in the `backend::` module itself. No new tests, as the change adds no new behaviour to cover.

## Where should the reviewer start?

`lib/llm/src/backend.rs`. The entire change is three lines in `Decoder::step`, and the only thing worth checking is that the conditional start timestamp still produces the same recorded latency when a tracker is present.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
