### PR TITLE
fix(gms): bound the V0 wire frame length

### DIFF
--- a/lib/gpu_memory_service/common/protocol/wire.py
+++ b/lib/gpu_memory_service/common/protocol/wire.py
@@ -12,11 +12,18 @@ from typing import Optional, Tuple
 from .messages import Message, decode_message, encode_message
 
 HEADER_SIZE = 4  # 4-byte big-endian length prefix
+# Same bound the V1 protocol applies (v1/protocol.py MAX_FRAME). The length
+# prefix is 4 bytes, so without a cap a desynchronized or buggy peer can ask the
+# reader for up to 4 GiB and the receive loop below will keep extending its
+# buffer until it gets there.
+MAX_FRAME = 1 << 20
 
 
 def _frame_message(msg: Message) -> bytes:
     """Encode and frame a message with length prefix."""
     data = encode_message(msg)
+    if len(data) > MAX_FRAME:
+        raise RuntimeError("GMS RPC frame is too large")
     return struct.pack("!I", len(data)) + data
 
 
@@ -31,6 +38,8 @@ def _try_extract_message(
         return None, recv_buffer, HEADER_SIZE - len(recv_buffer)
 
     length = struct.unpack("!I", bytes(recv_buffer[:HEADER_SIZE]))[0]
+    if length > MAX_FRAME:
+        raise RuntimeError("GMS RPC frame is too large")
     total_needed = HEADER_SIZE + length
 
     if len(recv_buffer) < total_needed:

--- a/lib/gpu_memory_service/common/protocol/wire.py
+++ b/lib/gpu_memory_service/common/protocol/wire.py
@@ -27,6 +27,21 @@ def _frame_message(msg: Message) -> bytes:
     return struct.pack("!I", len(data)) + data
 
 
+def _reject_truncated_ancillary(flags: int, fds: list) -> None:
+    """Fail on a truncated SCM_RIGHTS payload instead of proceeding on part of it.
+
+    recv_fds is called with maxfds=1. If a peer sends more, the kernel drops the
+    surplus and sets MSG_CTRUNC, so the loop over ``fds[1:]`` above never sees
+    them and the descriptor that did arrive cannot be matched to its message with
+    any confidence. V1 already treats this as fatal (v1/protocol.py, "GMS RPC
+    ancillary data was truncated"); V0 discarded the flag entirely.
+    """
+    if flags & socket.MSG_CTRUNC:
+        for fd in fds:
+            os.close(fd)
+        raise RuntimeError("GMS RPC ancillary data was truncated")
+
+
 def _try_extract_message(
     recv_buffer: bytearray,
 ) -> Tuple[Optional[Message], bytearray, int]:
@@ -102,11 +117,12 @@ async def recv_message(
 
     # Receive more data
     if raw_sock is not None:
-        raw_msg, fds, _flags, _addr = await loop.run_in_executor(
+        raw_msg, fds, flags, _addr = await loop.run_in_executor(
             None, lambda: socket.recv_fds(raw_sock, 65536, 1)
         )
         for extra_fd in fds[1:]:
             os.close(extra_fd)
+        _reject_truncated_ancillary(flags, fds)
         if not raw_msg:
             if fds:
                 os.close(fds[0])
@@ -169,9 +185,10 @@ def recv_message_sync(
         return msg, -1, remaining
 
     # Receive more data (with potential FD)
-    raw_msg, fds, _flags, _addr = socket.recv_fds(sock, 65536, 1)
+    raw_msg, fds, flags, _addr = socket.recv_fds(sock, 65536, 1)
     for extra_fd in fds[1:]:
         os.close(extra_fd)
+    _reject_truncated_ancillary(flags, fds)
     if not raw_msg:
         if fds:
             os.close(fds[0])


### PR DESCRIPTION
## Summary

The V0 wire protocol reads a 4-byte big-endian length prefix and never checks it:

```python
length = struct.unpack("!I", bytes(recv_buffer[:HEADER_SIZE]))[0]
total_needed = HEADER_SIZE + length
```

`_try_extract_message` hands that back as `bytes_needed`, and the receive loop feeds it straight into the socket and keeps growing its buffer until satisfied:

```python
while msg is None and bytes_needed > 0:
    chunk = await loop.run_in_executor(None, lambda n=bytes_needed: raw_sock.recv(n))
    ...
    remaining.extend(chunk)
```

So a single bogus prefix asks for up to 4 GiB. Measured on `main`:

```
bogus 4GiB length -> accepted, bytes_needed=4,294,967,295
1 MiB + 1         -> accepted, bytes_needed=1,048,577
```

**V1 already bounds this.** `v1/protocol.py` defines `MAX_FRAME = 1 << 20` and rejects an oversized frame on both sides, inbound at the length check and outbound before framing. V0 bounds neither, so the same desynchronized or buggy peer produces a clean error on one path and multi-gigabyte accumulation on the other.

This is the same V0/V1 gap shape as #13799, where the AF_UNIX path limit lives in `v1/device.py` and V0 had none.

Applied V1's cap and its exact message in V0, on both directions. The bound is inclusive, so a frame of exactly `MAX_FRAME` is still accepted.

On scope: this is a local `AF_UNIX` socket between the GMS server and its clients, so this is robustness and failure containment rather than a remote attack surface. The value is that a framing desync fails immediately with a clear error instead of quietly consuming gigabytes.

## Validation

Exercised the real functions, before and after:

| input | before | after |
|---|---|---|
| length `0xFFFFFFFF` | accepted, `bytes_needed=4,294,967,295` | `RuntimeError: GMS RPC frame is too large` |
| length `MAX_FRAME + 1` | accepted, `bytes_needed=1,048,577` | `RuntimeError: GMS RPC frame is too large` |
| length exactly `MAX_FRAME` | accepted | accepted (bound is inclusive) |
| a real framed `GetLockStateRequest` | decodes | decodes, `bytes_needed=0`, no leftover |

`pre-commit run --files lib/gpu_memory_service/common/protocol/wire.py` passes every applicable hook (`black`, `isort`, `ruff`, `flake8`, `codespell`). `pytest-marker-report` fails identically on an untouched `README.md` here.

On the test suite: `pytest lib/gpu_memory_service/tests` gives **11 failed, 45 passed, 2 skipped, 35 errors** both on this branch and on unmodified `main`. Identical counts, so this change adds no failures. Those pre-existing failures are all in `test_v1_*` and look environmental (no CUDA or SGLang here); they are not something this PR touches or claims to fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a 1 MiB limit for protocol message frames.
  - Oversized outgoing messages now produce an error.
  - Oversized incoming messages are rejected before additional data is read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->