### PR TITLE
fix(sglang): turn n>1 disagg request into sub-requests

### DIFF
--- a/components/src/dynamo/sglang/AGENTS.md
+++ b/components/src/dynamo/sglang/AGENTS.md
@@ -193,6 +193,15 @@ Prefill and decode workers coordinate via a bootstrap mechanism:
 Key functions: `BaseWorkerHandler._get_bootstrap_info()`,
 `BaseWorkerHandler._generate_bootstrap_room()`.
 
+**Parallel sampling (`n > 1`)**: SGLang cannot pair parallel samples across a PD
+handoff (#14098), so `parallel_sampling.py` fans an `n > 1` request out into `n`
+independent `n=1` sub-requests, one bootstrap room each (`bootstrap_info.bootstrap_rooms`,
+drawn by the frontend's prefill router), and `DecodeWorkerHandler._merge_choice_outputs()`
+merges the sub-streams by choice index and aborts the siblings if one fails. An older
+frontend sends one room and gets HTTP 400 for `n > 1`; an older *prefill* worker cannot be
+detected, so upgrade prefill workers first. The dedicated multimodal PD workers reject
+`n > 1`.
+
 ## Metrics & Publishing
 
 `publisher.py:DynamoSglangPublisher` manages:
@@ -383,6 +392,7 @@ sglang/
   register.py              # Model registration (LLM, image, video)
   publisher.py             # Metrics + KV event publishing
   protocol.py              # Request/response Pydantic models
+  parallel_sampling.py     # n>1 fan-out for disaggregated serving (#14098)
   health_check.py          # Health check payloads per worker type
   shutdown.py              # Graceful shutdown with deferred signal handling
   request_handlers/

--- a/components/src/dynamo/sglang/parallel_sampling.py
+++ b/components/src/dynamo/sglang/parallel_sampling.py
@@ -40,7 +40,6 @@ def requested_parallel_samples(sampling_params: Mapping[str, Any]) -> int:
 
 
 def single_sample_params(sampling_params: Mapping[str, Any]) -> dict[str, Any]:
-    """Copy of ``sampling_params`` for one fanned-out sub-request."""
     return {**sampling_params, "n": 1}
 
 
@@ -163,20 +162,21 @@ async def merge_choice_streams(
     before that stream's pump task is cancelled. Order matters: SGLang drops a
     cancelled request's state without telling its scheduler, so a later abort
     is a no-op and the sub-request would decode to ``max_tokens`` unconsumed.
-
-    The queue is unbounded; it holds at most one request's output.
     """
-    queue: asyncio.Queue[tuple[int, Any, BaseException | None]] = asyncio.Queue()
+    # Bounded so the consumer paces the pumps, as it paced the single stream.
+    queue: asyncio.Queue[tuple[int, Any, BaseException | None]] = asyncio.Queue(
+        maxsize=len(streams)
+    )
     finished: set[int] = set()
 
     async def pump(choice_index: int, stream: AsyncIterator[T]) -> None:
         try:
             async for item in stream:
-                queue.put_nowait((choice_index, item, None))
+                await queue.put((choice_index, item, None))
         except Exception as error:  # noqa: BLE001 - forwarded to the consumer
-            queue.put_nowait((choice_index, _STREAM_DONE, error))
+            await queue.put((choice_index, _STREAM_DONE, error))
             return
-        queue.put_nowait((choice_index, _STREAM_DONE, None))
+        await queue.put((choice_index, _STREAM_DONE, None))
 
     tasks = [
         asyncio.create_task(pump(choice_index, stream))

--- a/components/src/dynamo/sglang/parallel_sampling.py
+++ b/components/src/dynamo/sglang/parallel_sampling.py
@@ -3,21 +3,12 @@
 
 """Parallel sampling (``n > 1``) fan-out for SGLang disaggregated serving.
 
-SGLang cannot run parallel sampling across a prefill/decode handoff: its
-scheduler clones the first sub-request, bootstrap room included, for the
-prefix primer and every sample, so prefill registers one sender while decode
-waits for ``n`` receivers and the request hangs (ai-dynamo/dynamo#14098; the
-draft sgl-project/sglang#30723 would lift this on the SGLang side).
-
-Dynamo keeps SGLang blind to ``n`` in PD mode: the prefill and decode handlers
-run ``n`` independent ``n=1`` sub-requests, one bootstrap room each, and the
-decode handler merges the sub-streams back by choice index. The frontend's
-prefill router draws the rooms, so each keeps ``room % dp_size == dp_rank``
-(SGLang's decode receiver derives the prefill DP rank from the room), and
-carries them as ``bootstrap_info.bootstrap_rooms`` next to the single
-``bootstrap_room`` older peers read. A frontend that predates the field sends
-one room only; its ``n > 1`` requests are rejected with HTTP 400 instead of
-hanging.
+SGLang pairs one bootstrap room per request across a prefill/decode handoff, so
+parallel samples cannot share a request there. In PD mode Dynamo runs an
+``n > 1`` request as ``n`` independent ``n=1`` sub-requests, one room each
+(``bootstrap_info.bootstrap_rooms``, drawn by the prefill router), and merges
+the sub-streams back by choice index. A frontend that sends one room only gets
+HTTP 400 for ``n > 1``.
 """
 
 from __future__ import annotations

--- a/components/src/dynamo/sglang/parallel_sampling.py
+++ b/components/src/dynamo/sglang/parallel_sampling.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parallel sampling (``n > 1``) fan-out for SGLang disaggregated serving.
+
+SGLang cannot run parallel sampling across a prefill/decode handoff: its
+scheduler clones the first sub-request, bootstrap room included, for the
+prefix primer and every sample, so prefill registers one sender while decode
+waits for ``n`` receivers and the request hangs (ai-dynamo/dynamo#14098; the
+draft sgl-project/sglang#30723 would lift this on the SGLang side).
+
+Dynamo keeps SGLang blind to ``n`` in PD mode: the prefill and decode handlers
+run ``n`` independent ``n=1`` sub-requests, one bootstrap room each, and the
+decode handler merges the sub-streams back by choice index. The frontend's
+prefill router draws the rooms, so each keeps ``room % dp_size == dp_rank``
+(SGLang's decode receiver derives the prefill DP rank from the room), and
+carries them as ``bootstrap_info.bootstrap_rooms`` next to the single
+``bootstrap_room`` older peers read. A frontend that predates the field sends
+one room only; its ``n > 1`` requests are rejected with HTTP 400 instead of
+hanging.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from typing import Any, TypeVar
+
+from dynamo.llm import HttpError
+
+logger = logging.getLogger(__name__)
+
+BOOTSTRAP_ROOMS_KEY = "bootstrap_rooms"
+
+T = TypeVar("T")
+
+
+def requested_parallel_samples(sampling_params: Mapping[str, Any]) -> int:
+    """Samples an SGLang ``sampling_params`` dict asks for.
+
+    Anything that is not a positive integer is left for SGLang to validate and
+    counts as a single sample here.
+    """
+    n = sampling_params.get("n")
+    if isinstance(n, bool) or not isinstance(n, int):
+        return 1
+    return max(n, 1)
+
+
+def single_sample_params(sampling_params: Mapping[str, Any]) -> dict[str, Any]:
+    """Copy of ``sampling_params`` for one fanned-out sub-request."""
+    return {**sampling_params, "n": 1}
+
+
+def choice_request_ids(
+    request_id: str | None, fallback_id: str, num_choices: int
+) -> list[str | None]:
+    """SGLang ``rid`` per sub-request.
+
+    A single sample keeps the caller's id (``None`` lets SGLang assign one).
+    Fanned-out siblings need distinct ids that the decode worker also knows up
+    front so it can abort them, derived from ``request_id`` or ``fallback_id``.
+    """
+    if num_choices == 1:
+        return [request_id]
+    base = request_id or fallback_id
+    return [f"{base}-choice-{choice_index}" for choice_index in range(num_choices)]
+
+
+def _unsupported_parallel_sampling_error(num_choices: int, reason: str) -> HttpError:
+    return HttpError(
+        400,
+        f"SGLang disaggregated serving runs n={num_choices} as {num_choices} "
+        f"single-sample sub-requests and needs one bootstrap room per choice, "
+        f"but {reason}. Upgrade the Dynamo frontend so its prefill router "
+        "draws per-choice bootstrap rooms, or send n=1.",
+    )
+
+
+def _validated_rooms(rooms: Any, num_choices: int) -> list[int] | None:
+    if not isinstance(rooms, list) or len(rooms) != num_choices:
+        return None
+    if not all(isinstance(room, int) and not isinstance(room, bool) for room in rooms):
+        return None
+    if len(set(rooms)) != num_choices:
+        return None
+    return list(rooms)
+
+
+def resolve_decode_bootstrap_rooms(
+    bootstrap_info: Mapping[str, Any], num_choices: int
+) -> list[int]:
+    """Rooms the decode worker pairs on, one per choice.
+
+    Raises HTTP 400 for ``n > 1`` when the frontend-supplied ``bootstrap_info``
+    carries no usable per-choice rooms, which is what an older frontend sends.
+    """
+    if num_choices == 1:
+        return [bootstrap_info["bootstrap_room"]]
+    rooms = _validated_rooms(bootstrap_info.get(BOOTSTRAP_ROOMS_KEY), num_choices)
+    if rooms is None:
+        raise _unsupported_parallel_sampling_error(
+            num_choices, "the request carried no usable per-choice room list"
+        )
+    return rooms
+
+
+def resolve_prefill_bootstrap_rooms(
+    bootstrap_info: Mapping[str, Any] | None,
+    num_choices: int,
+    generate_room: Callable[[], int],
+) -> list[int]:
+    """Rooms the prefill worker registers, one per choice.
+
+    Router-drawn rooms win. Without any router room the worker draws its own
+    (the existing single-sample fallback), one distinct room per choice. A
+    single router room for ``n > 1`` means an older frontend: HTTP 400.
+    """
+    bootstrap_info = bootstrap_info or {}
+    router_room = bootstrap_info.get("bootstrap_room")
+    if num_choices == 1:
+        return [router_room if router_room is not None else generate_room()]
+
+    rooms = _validated_rooms(bootstrap_info.get(BOOTSTRAP_ROOMS_KEY), num_choices)
+    if rooms is not None:
+        return rooms
+    if router_room is not None:
+        raise _unsupported_parallel_sampling_error(
+            num_choices, "the frontend supplied a single bootstrap room"
+        )
+
+    rooms = []
+    while len(rooms) < num_choices:
+        room = generate_room()
+        if room not in rooms:
+            rooms.append(room)
+    return rooms
+
+
+def raise_if_disagg_parallel_sampling(sampling_params: Mapping[str, Any]) -> None:
+    """HTTP 400 for ``n > 1`` on a disaggregated path that does not fan out.
+
+    The dedicated multimodal prefill/decode workers still hand SGLang one room
+    for the whole request, so parallel sampling would hang there (#14098).
+    """
+    num_choices = requested_parallel_samples(sampling_params)
+    if num_choices > 1:
+        raise HttpError(
+            400,
+            f"n={num_choices} is not supported by SGLang multimodal "
+            "disaggregated serving; send n=1.",
+        )
+
+
+_STREAM_DONE = object()
+
+
+async def merge_choice_streams(
+    streams: Sequence[AsyncIterator[T]],
+    abort: Callable[[int], None] | None = None,
+) -> AsyncIterator[tuple[int, T]]:
+    """Interleave per-choice streams as they produce output.
+
+    Every stream is driven concurrently: SGLang submits a sub-request when its
+    generator is first iterated, and each decode sub-request must be in flight
+    for its prefill counterpart to pair with it. Yields ``(choice_index, item)``
+    pairs; a failure in one stream is re-raised and closing the merged stream
+    closes them all.
+
+    ``abort`` is called with the index of every stream that did not finish,
+    before that stream's pump task is cancelled. Order matters: SGLang drops a
+    cancelled request's state without telling its scheduler, so a later abort
+    is a no-op and the sub-request would decode to ``max_tokens`` unconsumed.
+
+    The queue is unbounded; it holds at most one request's output.
+    """
+    queue: asyncio.Queue[tuple[int, Any, BaseException | None]] = asyncio.Queue()
+    finished: set[int] = set()
+
+    async def pump(choice_index: int, stream: AsyncIterator[T]) -> None:
+        try:
+            async for item in stream:
+                queue.put_nowait((choice_index, item, None))
+        except Exception as error:  # noqa: BLE001 - forwarded to the consumer
+            queue.put_nowait((choice_index, _STREAM_DONE, error))
+            return
+        queue.put_nowait((choice_index, _STREAM_DONE, None))
+
+    tasks = [
+        asyncio.create_task(pump(choice_index, stream))
+        for choice_index, stream in enumerate(streams)
+    ]
+    try:
+        while len(finished) < len(tasks):
+            choice_index, item, error = await queue.get()
+            if item is _STREAM_DONE:
+                if error is not None:
+                    raise error
+                finished.add(choice_index)
+                continue
+            yield choice_index, item
+    finally:
+        if abort is not None:
+            for choice_index in range(len(tasks)):
+                if choice_index in finished:
+                    continue
+                try:
+                    abort(choice_index)
+                except Exception:  # noqa: BLE001 - best-effort sibling cleanup
+                    logger.warning(
+                        "Failed to abort fanned-out choice %d",
+                        choice_index,
+                        exc_info=True,
+                    )
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        for stream in streams:
+            aclose = getattr(stream, "aclose", None)
+            if aclose is None:
+                continue
+            try:
+                await aclose()
+            except Exception:  # noqa: BLE001 - best-effort sibling cleanup
+                logger.debug(
+                    "Failed to close a fanned-out choice stream", exc_info=True
+                )

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -591,8 +591,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     "bootstrap_info is required for disaggregated decode but was not provided"
                 )
 
-            # n > 1 runs as n single-sample sub-requests, one room each,
-            # merged back by choice index (see dynamo.sglang.parallel_sampling).
             num_choices = requested_parallel_samples(sampling_params)
             bootstrap_rooms = resolve_decode_bootstrap_rooms(
                 bootstrap_info, num_choices

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -34,6 +34,13 @@ from dynamo.sglang.engine_generate import (
     native_generate_payload,
     native_generate_stream,
 )
+from dynamo.sglang.parallel_sampling import (
+    choice_request_ids,
+    merge_choice_streams,
+    requested_parallel_samples,
+    resolve_decode_bootstrap_rooms,
+    single_sample_params,
+)
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
 from dynamo.sglang.request_handlers.llm.mm_disagg_utils import (
@@ -584,11 +591,18 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     "bootstrap_info is required for disaggregated decode but was not provided"
                 )
 
+            # n > 1 runs as n single-sample sub-requests, one room each,
+            # merged back by choice index (see dynamo.sglang.parallel_sampling).
+            num_choices = requested_parallel_samples(sampling_params)
+            bootstrap_rooms = resolve_decode_bootstrap_rooms(
+                bootstrap_info, num_choices
+            )
+
             logging.debug(
                 f"Using bootstrap_info: "
                 f"host={bootstrap_info['bootstrap_host']}, "
                 f"port={bootstrap_info['bootstrap_port']}, "
-                f"room={bootstrap_info['bootstrap_room']}"
+                f"rooms={bootstrap_rooms}"
             )
 
             trace_header = context.trace_headers() if self.enable_trace else None
@@ -600,42 +614,69 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             # Decode re-extracts the media so its token layout matches prefill's
             # and the transferred KV lines up.
             decode_mm_kwargs = build_disagg_mm_kwargs(request)
+            reasoning_kwargs = require_reasoning_kwargs(self.engine, request)
+            if num_choices > 1:
+                sampling_params = single_sample_params(sampling_params)
+            rids = choice_request_ids(trace_id, context.id(), num_choices)
 
-            decode = await self.engine.async_generate(
-                **input_param,
-                **decode_mm_kwargs,
-                sampling_params=sampling_params,
-                stream=True,
-                **require_reasoning_kwargs(self.engine, request),
-                **self._routed_experts_kwargs,
-                bootstrap_host=bootstrap_info["bootstrap_host"],
-                bootstrap_port=bootstrap_info["bootstrap_port"],
-                bootstrap_room=bootstrap_info["bootstrap_room"],
-                external_trace_header=trace_header,
-                rid=trace_id,
-                data_parallel_rank=dp_rank,
-                lora_path=lora_path,
-                **logprob_kwargs,
-                **priority_kwargs,
-            )
-            if not self.use_sglang_tokenizer:
-                async for out in self._process_token_stream(
-                    decode,
-                    context,
-                    return_tokens_as_token_ids,
-                    user_stop_token_ids=user_stop_token_ids,
-                    suppressed_stop_token_ids=suppressed_stop_token_ids,
-                    metadata_uploader=metadata_uploader,
-                ):
+            decode_streams = []
+            for bootstrap_room, rid in zip(bootstrap_rooms, rids):
+                decode_streams.append(
+                    await self.engine.async_generate(
+                        **input_param,
+                        **decode_mm_kwargs,
+                        sampling_params=sampling_params,
+                        stream=True,
+                        **reasoning_kwargs,
+                        **self._routed_experts_kwargs,
+                        bootstrap_host=bootstrap_info["bootstrap_host"],
+                        bootstrap_port=bootstrap_info["bootstrap_port"],
+                        bootstrap_room=bootstrap_room,
+                        external_trace_header=trace_header,
+                        rid=rid,
+                        data_parallel_rank=dp_rank,
+                        lora_path=lora_path,
+                        **logprob_kwargs,
+                        **priority_kwargs,
+                    )
+                )
+
+            # A single choice keeps the pre-fan-out stream shape: SGLang's own
+            # index and response id pass straight through.
+            response_id = None if num_choices == 1 else trace_id or context.id()
+            choice_streams: list[AsyncIterator[Dict[str, Any]]] = []
+            for index, decode in enumerate(decode_streams):
+                choice_index = index if num_choices > 1 else None
+                if not self.use_sglang_tokenizer:
+                    choice_streams.append(
+                        self._process_token_stream(
+                            decode,
+                            context,
+                            return_tokens_as_token_ids,
+                            user_stop_token_ids=user_stop_token_ids,
+                            suppressed_stop_token_ids=suppressed_stop_token_ids,
+                            metadata_uploader=metadata_uploader,
+                            choice_index=choice_index,
+                        )
+                    )
+                else:
+                    choice_streams.append(
+                        self._process_text_stream(
+                            decode,
+                            context,
+                            request=request,
+                            user_stop_token_ids=user_stop_token_ids,
+                            metadata_uploader=metadata_uploader,
+                            choice_index=choice_index,
+                            response_id=response_id,
+                        )
+                    )
+
+            if num_choices == 1:
+                async for out in choice_streams[0]:
                     yield out
             else:
-                async for out in self._process_text_stream(
-                    decode,
-                    context,
-                    request=request,
-                    user_stop_token_ids=user_stop_token_ids,
-                    metadata_uploader=metadata_uploader,
-                ):
+                async for out in self._merge_choice_outputs(choice_streams, rids):
                     yield out
         else:
             raise_if_unextracted_multimodal(request)
@@ -722,6 +763,40 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 ):
                     yield out
 
+    async def _merge_choice_outputs(
+        self,
+        choice_streams: List[AsyncIterator[Dict[str, Any]]],
+        rids: List[str | None],
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Interleave the per-choice sub-streams of a fanned-out n > 1 decode.
+
+        Each sub-stream stamps its own choice index; only usage is fixed up to
+        the request-wide running total the single-stream n > 1 path reports.
+        A sub-stream that fails takes its siblings down with it: they are
+        aborted in SGLang by rid, since the per-stream cancellation monitor
+        only fires on client cancellation.
+        """
+
+        def abort(choice_index: int) -> None:
+            tokenizer_manager = getattr(self.engine, "tokenizer_manager", None)
+            if tokenizer_manager is None:
+                return
+            tokenizer_manager.abort_request(rid=rids[choice_index], abort_all=False)
+
+        completion_tokens_per_choice: dict[int, int] = {}
+        async for choice_index, out in merge_choice_streams(choice_streams, abort):
+            completion_usage = out.get("completion_usage")
+            if completion_usage is not None:
+                completion_tokens_per_choice[choice_index] = completion_usage[
+                    "completion_tokens"
+                ]
+                request_completion_tokens = sum(completion_tokens_per_choice.values())
+                completion_usage["completion_tokens"] = request_completion_tokens
+                completion_usage["total_tokens"] = (
+                    completion_usage["prompt_tokens"] + request_completion_tokens
+                )
+            yield out
+
     async def _process_native_generate_stream(
         self,
         stream_source: AsyncIterator[Dict[str, Any]],
@@ -754,6 +829,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         user_stop_token_ids: set[int] | None = None,
         suppressed_stop_token_ids: set[int] | None = None,
         metadata_uploader: MetadataUploader | None = None,
+        choice_index: int | None = None,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Process token-based stream output.
 
@@ -763,6 +839,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         Args:
             stream_source: Async generator from engine.async_generate.
             context: Context object for cancellation handling.
+            choice_index: Choice this stream produces when it is one fanned-out
+                sub-request of a disaggregated n > 1 request. SGLang sees such a
+                sub-request as n=1 and reports every chunk as choice 0.
 
         Yields:
             Dict with token_ids and optional finish_reason.
@@ -790,7 +869,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 # The loop should exit by itself when context.is_stopped() returns True.
                 # SGLang omits index for non-n/legacy chunks; treat those as
                 # choice 0 while preserving explicit indices for n>1.
-                output_idx = res.get("index") or 0
+                if choice_index is not None:
+                    output_idx = choice_index
+                else:
+                    output_idx = res.get("index") or 0
 
                 out: dict[str, Any] = {"index": output_idx}
                 finish_reason = meta_info["finish_reason"]
@@ -946,12 +1028,20 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         request: Dict[str, Any] | None = None,
         user_stop_token_ids: set[int] | None = None,
         metadata_uploader: MetadataUploader | None = None,
+        choice_index: int | None = None,
+        response_id: str | None = None,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Process text-based stream output in OpenAI format.
 
         Args:
             stream_source: Async generator from engine.async_generate.
             context: Context object for cancellation handling.
+            choice_index: Choice this stream produces when it is one fanned-out
+                sub-request of a disaggregated n > 1 request; SGLang reports
+                such a sub-request as choice 0.
+            response_id: Response id to stamp on every chunk instead of the
+                sub-request's own SGLang id, so the sibling sub-streams of one
+                request share a single id.
 
         Yields:
             OpenAI-formatted chat completion chunk dicts.
@@ -982,7 +1072,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 # The loop should exit by itself when context.is_stopped() returns True.
 
                 # Same defaulting as token mode: non-n chunks are choice 0.
-                index = res.get("index") or 0
+                if choice_index is not None:
+                    index = choice_index
+                else:
+                    index = res.get("index") or 0
 
                 text = res.get("text", "")
 
@@ -1029,7 +1122,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 )
 
                 response = {
-                    "id": meta_info["id"],
+                    "id": response_id if response_id is not None else meta_info["id"],
                     "created": int(time.time()),
                     "choices": [choice_data],
                     "model": self.config.server_args.served_model_name,

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -17,6 +17,12 @@ from dynamo.sglang.engine_generate import (
     native_generate_payload,
     native_generate_stream,
 )
+from dynamo.sglang.parallel_sampling import (
+    BOOTSTRAP_ROOMS_KEY,
+    choice_request_ids,
+    requested_parallel_samples,
+    resolve_prefill_bootstrap_rooms,
+)
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
 from dynamo.sglang.request_handlers.llm.decode_handler import _sampling_option_params
@@ -106,7 +112,11 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 k: v for k, v in sampling_params.items() if v is not None
             }
         native_payload = native_generate_payload(inner_request)
+        # n > 1 runs as n single-sample sub-requests, one room each (see
+        # dynamo.sglang.parallel_sampling). Native Generate is always n == 1.
+        num_choices = 1
         if native_payload is None:
+            num_choices = requested_parallel_samples(sampling_params)
             sampling_params["n"] = 1
             sampling_params["max_new_tokens"] = 1
 
@@ -114,10 +124,11 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         # Otherwise use real bootstrap host/port from engine and generate room locally
         bootstrap_host = self.bootstrap_host
         bootstrap_port = self.bootstrap_port
-        bootstrap_room = None
 
         bootstrap_info_from_req = inner_request.get("bootstrap_info")
-        if isinstance(bootstrap_info_from_req, dict):
+        if not isinstance(bootstrap_info_from_req, dict):
+            bootstrap_info_from_req = None
+        if bootstrap_info_from_req is not None:
             # Allow overriding bootstrap_host for fake-transfer mode (health checks)
             if "bootstrap_host" in bootstrap_info_from_req:
                 bootstrap_host = bootstrap_info_from_req["bootstrap_host"]
@@ -129,19 +140,20 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 logging.debug(
                     f"Using request-provided bootstrap_port: {bootstrap_port}"
                 )
-            bootstrap_room = bootstrap_info_from_req.get("bootstrap_room")
-            if bootstrap_room is not None:
-                logging.debug(f"Using router-provided bootstrap_room: {bootstrap_room}")
 
-        if bootstrap_room is None:
-            bootstrap_room = self._generate_bootstrap_room()
-            logging.debug(f"Generated bootstrap_room locally: {bootstrap_room}")
+        # One room per choice: router-drawn when available, else drawn here.
+        bootstrap_rooms = resolve_prefill_bootstrap_rooms(
+            bootstrap_info_from_req, num_choices, self._generate_bootstrap_room
+        )
+        logging.debug(f"Using bootstrap rooms: {bootstrap_rooms}")
 
-        bootstrap_info = {
+        bootstrap_info: Dict[str, Any] = {
             "bootstrap_host": bootstrap_host,
             "bootstrap_port": bootstrap_port,
-            "bootstrap_room": bootstrap_room,
+            "bootstrap_room": bootstrap_rooms[0],
         }
+        if num_choices > 1:
+            bootstrap_info[BOOTSTRAP_ROOMS_KEY] = bootstrap_rooms
 
         input_param = self._get_input_param(inner_request)
 
@@ -166,6 +178,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             )
 
         priority_kwargs = self._priority_kwargs(priority)
+        results: list[AsyncIterator[Any]] = []
         if native_payload is not None:
             input_ids = input_param.get("input_ids")
             if not isinstance(input_ids, list):
@@ -178,32 +191,37 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 sampling_overrides={"n": 1, "max_new_tokens": 1},
                 bootstrap_host=bootstrap_host,
                 bootstrap_port=bootstrap_port,
-                bootstrap_room=bootstrap_room,
+                bootstrap_room=bootstrap_rooms[0],
                 external_trace_header=trace_header,
                 routed_dp_rank=dp_rank,
                 lora_path=lora_path,
             )
-            results = native_generate_stream(self.engine, native_request)
+            results.append(native_generate_stream(self.engine, native_request))
         else:
-            results = await self.engine.async_generate(
-                **input_param,
-                **mm_kwargs,
-                sampling_params=sampling_params,
-                stream=True,
-                **require_reasoning_kwargs(self.engine, inner_request),
-                bootstrap_host=bootstrap_host,
-                bootstrap_port=bootstrap_port,
-                bootstrap_room=bootstrap_room,
-                external_trace_header=trace_header,
-                rid=trace_id,
-                data_parallel_rank=dp_rank,
-                lora_path=lora_path,
-                **priority_kwargs,
-            )
+            reasoning_kwargs = require_reasoning_kwargs(self.engine, inner_request)
+            rids = choice_request_ids(trace_id, context.id(), num_choices)
+            for bootstrap_room, rid in zip(bootstrap_rooms, rids):
+                results.append(
+                    await self.engine.async_generate(
+                        **input_param,
+                        **mm_kwargs,
+                        sampling_params=sampling_params,
+                        stream=True,
+                        **reasoning_kwargs,
+                        bootstrap_host=bootstrap_host,
+                        bootstrap_port=bootstrap_port,
+                        bootstrap_room=bootstrap_room,
+                        external_trace_header=trace_header,
+                        rid=rid,
+                        data_parallel_rank=dp_rank,
+                        lora_path=lora_path,
+                        **priority_kwargs,
+                    )
+                )
         if inner_request.get(HEALTH_CHECK_KEY):
             # Canary: stream engine output so the Rust canary sees scheduler output.
             # No _cancellation_monitor — probe is bounded (max_tokens=1, FAKE_BOOTSTRAP_HOST).
-            async for res in results:
+            async for res in results[0]:
                 yield res
             return
 
@@ -216,11 +234,18 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             "disaggregated_params": bootstrap_info,
         }
 
-        task = asyncio.create_task(self._consume_results(results, context))
-        self._consume_tasks.add(task)
-        task.add_done_callback(self._consume_tasks.discard)
+        # Every sub-request must be iterated for SGLang to submit it, so each
+        # gets its own consumer; the handoff completes once all of them have.
+        # A failing consumer leaves its siblings running, bounded by
+        # max_new_tokens=1 and SGLang's bootstrap timeout.
+        tasks = []
+        for choice_results in results:
+            task = asyncio.create_task(self._consume_results(choice_results, context))
+            self._consume_tasks.add(task)
+            task.add_done_callback(self._consume_tasks.discard)
+            tasks.append(task)
 
-        await task
+        await asyncio.gather(*tasks)
 
     async def _consume_results(
         self, results: AsyncIterator[Any], context: Context

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -141,7 +141,6 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                     f"Using request-provided bootstrap_port: {bootstrap_port}"
                 )
 
-        # One room per choice: router-drawn when available, else drawn here.
         bootstrap_rooms = resolve_prefill_bootstrap_rooms(
             bootstrap_info_from_req, num_choices, self._generate_bootstrap_room
         )

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -15,7 +15,9 @@ from dynamo.common.constants import DisaggregationMode, EmbeddingTransferMode
 from dynamo.common.multimodal import EMBEDDING_RECEIVER_FACTORIES, TransferRequest
 from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.engine_response import normalize_finish_reason
+from dynamo.llm import HttpError
 from dynamo.sglang.args import Config
+from dynamo.sglang.parallel_sampling import raise_if_disagg_parallel_sampling
 from dynamo.sglang.protocol import (
     DisaggSglangMultimodalRequest,
     SglangMultimodalRequest,
@@ -516,6 +518,9 @@ class MultimodalWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, str]):
                 finally:
                     _nvtx.end_range(rng_agg)
 
+        except HttpError:
+            # Carries a client-facing status; let the request plane forward it.
+            raise
         except Exception as e:
             logger.error(f"Error in multimodal generation: {e}", exc_info=True)
             yield ErrorResponseBuilder.build_error_response(e)
@@ -535,6 +540,8 @@ class MultimodalWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, str]):
             raise ValueError("input_ids is required")
 
         sampling_params = SglangUtils.build_sampling_params(request)
+        # One room per request here, so n > 1 is not fanned out (#14098).
+        raise_if_disagg_parallel_sampling(sampling_params)
 
         # Request bootstrap info from prefill worker
         bootstrap_info = await self._get_bootstrap_from_prefill(
@@ -745,6 +752,7 @@ class MultimodalPrefillWorkerHandler(
         try:
             # Validate and parse request
             disagg_request = self._validate_and_parse_disagg_request(disagg_request)
+            raise_if_disagg_parallel_sampling(disagg_request.sampling_params)
 
             rid = context.trace_id or context.id()
             bootstrap_room = self._generate_bootstrap_room()

--- a/components/src/dynamo/sglang/tests/test_sglang_parallel_sampling.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_parallel_sampling.py
@@ -37,7 +37,9 @@ from dynamo.sglang.protocol import (
 )
 from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
 from dynamo.sglang.request_handlers.llm.prefill_handler import PrefillWorkerHandler
-from dynamo.sglang.request_handlers.multimodal.worker_handler import SglangUtils
+from dynamo.sglang.request_handlers.multimodal.worker_handler import (
+    MultimodalWorkerHandler,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -85,7 +87,6 @@ def test_choice_request_ids_keeps_sglang_ids_unique_per_choice():
 
 def test_decode_rooms_single_sample_uses_bootstrap_room():
     assert resolve_decode_bootstrap_rooms({"bootstrap_room": 7}, 1) == [7]
-    # Extra rooms are ignored for n == 1.
     assert resolve_decode_bootstrap_rooms(
         {"bootstrap_room": 7, BOOTSTRAP_ROOMS_KEY: [7, 9]}, 1
     ) == [7]
@@ -160,21 +161,20 @@ def test_raise_if_disagg_parallel_sampling_only_rejects_multiple_samples():
     assert "n=2" in excinfo.value.message
 
 
-def test_multimodal_disagg_sampling_params_reject_parallel_sampling():
-    def request(n: int | None) -> SglangMultimodalRequest:
-        return SglangMultimodalRequest(
-            request=PreprocessedRequest(
-                token_ids=[1, 2, 3],
-                stop_conditions=StopConditions(max_tokens=8),
-                sampling_options=SamplingOptions(n=n),
-            )
+@pytest.mark.asyncio
+async def test_multimodal_decode_rejects_parallel_sampling_before_dispatch():
+    handler = MultimodalWorkerHandler.__new__(MultimodalWorkerHandler)
+    handler.serving_mode = DisaggregationMode.DECODE
+    request = SglangMultimodalRequest(
+        request=PreprocessedRequest(
+            token_ids=[1, 2, 3],
+            stop_conditions=StopConditions(max_tokens=8),
+            sampling_options=SamplingOptions(n=2),
         )
-
-    raise_if_disagg_parallel_sampling(SglangUtils.build_sampling_params(request(None)))
-    raise_if_disagg_parallel_sampling(SglangUtils.build_sampling_params(request(1)))
+    )
 
     with pytest.raises(HttpError) as excinfo:
-        raise_if_disagg_parallel_sampling(SglangUtils.build_sampling_params(request(2)))
+        await _collect(handler.generate(request, _context()))
 
     assert excinfo.value.code == 400
 
@@ -270,7 +270,6 @@ async def test_merge_choice_streams_close_cancels_every_sibling():
     assert first[1] in (0, 1)
     await merged.aclose()
 
-    # Both sub-requests were submitted (iterated), aborted, and torn down.
     assert all(event.is_set() for event in started)
     assert sorted(aborted) == [0, 1]
     assert all(event.is_set() for event in closed)
@@ -546,7 +545,6 @@ async def test_decode_rejects_parallel_sampling_from_older_frontend():
         await _collect(handler.generate(_token_request(2, bootstrap_info), _context()))
 
     assert excinfo.value.code == 400
-    # Rejected before any engine work.
     assert engine.calls == []
 
 

--- a/components/src/dynamo/sglang/tests/test_sglang_parallel_sampling.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_parallel_sampling.py
@@ -58,10 +58,8 @@ BOOTSTRAP_PORT = 0  # never bound
 # ---------------------------------------------------------------------------
 
 
-def test_requested_parallel_samples_counts_only_positive_integers():
+def test_requested_parallel_samples_defaults_to_one():
     assert requested_parallel_samples({}) == 1
-    assert requested_parallel_samples({"n": 0}) == 1
-    assert requested_parallel_samples({"n": True}) == 1
     assert requested_parallel_samples({"n": 3}) == 3
 
 

--- a/components/src/dynamo/sglang/tests/test_sglang_parallel_sampling.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_parallel_sampling.py
@@ -1,0 +1,706 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``n > 1`` fan-out in SGLang disaggregated serving.
+
+Regression coverage for ai-dynamo/dynamo#14098: a disaggregated request with
+``n > 1`` must run as ``n`` single-sample sub-requests with one bootstrap room
+each instead of hanging after prefill.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from dynamo.common.constants import DisaggregationMode
+from dynamo.llm import HttpError
+from dynamo.sglang.parallel_sampling import (
+    BOOTSTRAP_ROOMS_KEY,
+    choice_request_ids,
+    merge_choice_streams,
+    raise_if_disagg_parallel_sampling,
+    requested_parallel_samples,
+    resolve_decode_bootstrap_rooms,
+    resolve_prefill_bootstrap_rooms,
+    single_sample_params,
+)
+from dynamo.sglang.protocol import (
+    PreprocessedRequest,
+    SamplingOptions,
+    SglangMultimodalRequest,
+    StopConditions,
+)
+from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
+from dynamo.sglang.request_handlers.llm.prefill_handler import PrefillWorkerHandler
+from dynamo.sglang.request_handlers.multimodal.worker_handler import SglangUtils
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.core,
+    pytest.mark.gpu_0,
+    pytest.mark.profiled_vram_gib(0),
+    pytest.mark.pre_merge,
+    pytest.mark.timeout(10),
+]
+
+BOOTSTRAP_HOST = "10.0.0.5"
+BOOTSTRAP_PORT = 0  # never bound
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_requested_parallel_samples_counts_only_positive_integers():
+    assert requested_parallel_samples({}) == 1
+    assert requested_parallel_samples({"n": 0}) == 1
+    assert requested_parallel_samples({"n": True}) == 1
+    assert requested_parallel_samples({"n": 3}) == 3
+
+
+def test_single_sample_params_copies_and_forces_one_sample():
+    sampling_params = {"n": 3, "temperature": 0.7}
+
+    single = single_sample_params(sampling_params)
+
+    assert single == {"n": 1, "temperature": 0.7}
+    assert sampling_params["n"] == 3
+
+
+def test_choice_request_ids_keeps_sglang_ids_unique_per_choice():
+    assert choice_request_ids(None, "ctx", 1) == [None]
+    assert choice_request_ids("trace", "ctx", 1) == ["trace"]
+    assert choice_request_ids("trace", "ctx", 2) == [
+        "trace-choice-0",
+        "trace-choice-1",
+    ]
+    # Siblings must be abortable by rid even when SGLang would assign one.
+    assert choice_request_ids(None, "ctx", 2) == ["ctx-choice-0", "ctx-choice-1"]
+
+
+def test_decode_rooms_single_sample_uses_bootstrap_room():
+    assert resolve_decode_bootstrap_rooms({"bootstrap_room": 7}, 1) == [7]
+    # Extra rooms are ignored for n == 1.
+    assert resolve_decode_bootstrap_rooms(
+        {"bootstrap_room": 7, BOOTSTRAP_ROOMS_KEY: [7, 9]}, 1
+    ) == [7]
+
+
+def test_decode_rooms_fan_out_uses_per_choice_rooms():
+    bootstrap_info = {"bootstrap_room": 8, BOOTSTRAP_ROOMS_KEY: [8, 16, 24]}
+
+    assert resolve_decode_bootstrap_rooms(bootstrap_info, 3) == [8, 16, 24]
+
+
+@pytest.mark.parametrize(
+    "bootstrap_info",
+    [
+        # Older frontend: a single room only.
+        {"bootstrap_room": 8},
+        # Wrong cardinality, not integers, not distinct.
+        {"bootstrap_room": 8, BOOTSTRAP_ROOMS_KEY: [8]},
+        {"bootstrap_room": 8, BOOTSTRAP_ROOMS_KEY: [8, "16"]},
+        {"bootstrap_room": 8, BOOTSTRAP_ROOMS_KEY: [8, 8]},
+    ],
+)
+def test_decode_rooms_fan_out_rejects_unusable_room_lists(bootstrap_info):
+    with pytest.raises(HttpError) as excinfo:
+        resolve_decode_bootstrap_rooms(bootstrap_info, 2)
+
+    assert excinfo.value.code == 400
+    assert "n=2" in excinfo.value.message
+    assert "Upgrade the Dynamo frontend" in excinfo.value.message
+
+
+def test_prefill_rooms_single_sample_prefers_router_room():
+    generate = iter([11, 12])
+
+    assert resolve_prefill_bootstrap_rooms({"bootstrap_room": 5}, 1, lambda: 0) == [5]
+    assert resolve_prefill_bootstrap_rooms(None, 1, lambda: next(generate)) == [11]
+    assert resolve_prefill_bootstrap_rooms({}, 1, lambda: next(generate)) == [12]
+
+
+def test_prefill_rooms_fan_out_uses_router_rooms():
+    bootstrap_info = {"bootstrap_room": 8, BOOTSTRAP_ROOMS_KEY: [8, 16]}
+
+    assert resolve_prefill_bootstrap_rooms(bootstrap_info, 2, lambda: 0) == [8, 16]
+
+
+def test_prefill_rooms_fan_out_rejects_single_router_room():
+    with pytest.raises(HttpError) as excinfo:
+        resolve_prefill_bootstrap_rooms({"bootstrap_room": 8}, 2, lambda: 0)
+
+    assert excinfo.value.code == 400
+    assert "single bootstrap room" in excinfo.value.message
+
+
+def test_prefill_rooms_fan_out_draws_distinct_local_rooms_without_router_room():
+    # The worker owns room generation when the frontend sent none; a repeated
+    # draw must not produce two choices on the same room.
+    draws = iter([7, 7, 9])
+
+    rooms = resolve_prefill_bootstrap_rooms(None, 2, lambda: next(draws))
+
+    assert rooms == [7, 9]
+
+
+def test_raise_if_disagg_parallel_sampling_only_rejects_multiple_samples():
+    raise_if_disagg_parallel_sampling({})
+    raise_if_disagg_parallel_sampling({"n": 1})
+
+    with pytest.raises(HttpError) as excinfo:
+        raise_if_disagg_parallel_sampling({"n": 2})
+
+    assert excinfo.value.code == 400
+    assert "n=2" in excinfo.value.message
+
+
+def test_multimodal_disagg_sampling_params_reject_parallel_sampling():
+    def request(n: int | None) -> SglangMultimodalRequest:
+        return SglangMultimodalRequest(
+            request=PreprocessedRequest(
+                token_ids=[1, 2, 3],
+                stop_conditions=StopConditions(max_tokens=8),
+                sampling_options=SamplingOptions(n=n),
+            )
+        )
+
+    raise_if_disagg_parallel_sampling(SglangUtils.build_sampling_params(request(None)))
+    raise_if_disagg_parallel_sampling(SglangUtils.build_sampling_params(request(1)))
+
+    with pytest.raises(HttpError) as excinfo:
+        raise_if_disagg_parallel_sampling(SglangUtils.build_sampling_params(request(2)))
+
+    assert excinfo.value.code == 400
+
+
+# ---------------------------------------------------------------------------
+# merge_choice_streams
+# ---------------------------------------------------------------------------
+
+
+async def _collect(stream):
+    return [item async for item in stream]
+
+
+@pytest.mark.asyncio
+async def test_merge_choice_streams_tags_items_with_their_choice_index():
+    async def choice(items, pauses):
+        for item in items:
+            for _ in range(pauses):
+                await asyncio.sleep(0)
+            yield item
+
+    aborted: list[int] = []
+    merged = await _collect(
+        merge_choice_streams(
+            [choice(["a0", "a1", "a2"], 3), choice(["b0", "b1"], 1)], aborted.append
+        )
+    )
+
+    assert aborted == []
+
+    assert sorted(merged) == [
+        (0, "a0"),
+        (0, "a1"),
+        (0, "a2"),
+        (1, "b0"),
+        (1, "b1"),
+    ]
+    # Per-choice order is preserved, and the faster stream is not held back
+    # behind the slower one.
+    assert [item for index, item in merged if index == 0] == ["a0", "a1", "a2"]
+    assert [item for index, item in merged if index == 1] == ["b0", "b1"]
+    assert merged.index((1, "b1")) < merged.index((0, "a2"))
+
+
+@pytest.mark.asyncio
+async def test_merge_choice_streams_propagates_failure_and_aborts_siblings():
+    aborted: list[int] = []
+    aborted_before_sibling_closed: bool | None = None
+
+    async def endless():
+        nonlocal aborted_before_sibling_closed
+        try:
+            while True:
+                await asyncio.sleep(0)
+                yield "tick"
+        finally:
+            aborted_before_sibling_closed = 0 in aborted
+
+    async def failing():
+        yield "first"
+        raise RuntimeError("choice 1 failed")
+
+    received = []
+    with pytest.raises(RuntimeError, match="choice 1 failed"):
+        async for item in merge_choice_streams([endless(), failing()], aborted.append):
+            received.append(item)
+
+    assert (1, "first") in received
+    # Every unfinished sub-request is aborted, the failed one included, and the
+    # abort lands before the sibling is torn down (SGLang forgets a cancelled
+    # request, so a later abort would be a no-op).
+    assert sorted(aborted) == [0, 1]
+    assert aborted_before_sibling_closed is True
+
+
+@pytest.mark.asyncio
+async def test_merge_choice_streams_close_cancels_every_sibling():
+    closed = [asyncio.Event(), asyncio.Event()]
+    started = [asyncio.Event(), asyncio.Event()]
+
+    async def choice(index):
+        started[index].set()
+        try:
+            while True:
+                await asyncio.sleep(0)
+                yield index
+        finally:
+            closed[index].set()
+
+    aborted: list[int] = []
+    merged = merge_choice_streams([choice(0), choice(1)], aborted.append)
+    first = await merged.__anext__()
+    assert first[1] in (0, 1)
+    await merged.aclose()
+
+    # Both sub-requests were submitted (iterated), aborted, and torn down.
+    assert all(event.is_set() for event in started)
+    assert sorted(aborted) == [0, 1]
+    assert all(event.is_set() for event in closed)
+
+
+# ---------------------------------------------------------------------------
+# Handler fan-out
+# ---------------------------------------------------------------------------
+
+
+class _FakeEngine:
+    """Records ``async_generate`` calls and replays canned output per room."""
+
+    def __init__(self, outputs_by_room: dict[int, list[Any]]):
+        self.outputs_by_room = outputs_by_room
+        self.calls: list[dict[str, Any]] = []
+        self.aborted: list[str] = []
+        self.tokenizer_manager = SimpleNamespace(
+            abort_request=lambda rid, abort_all=False: self.aborted.append(rid)
+        )
+
+    async def async_generate(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._replay(kwargs["bootstrap_room"])
+
+    async def _replay(self, room: int):
+        for output in self.outputs_by_room[room]:
+            await asyncio.sleep(0)
+            if isinstance(output, Exception):
+                raise output
+            yield dict(output, meta_info=dict(output["meta_info"]))
+
+
+def _context(trace_id: str | None = "trace"):
+    return SimpleNamespace(
+        id=lambda: "context-id",
+        trace_id=trace_id,
+        is_stopped=lambda: False,
+        notify_first_token=lambda: None,
+        trace_headers=lambda: None,
+    )
+
+
+@asynccontextmanager
+async def _no_cancellation_monitor(*_args, **_kwargs):
+    yield None
+
+
+def _new_disagg_decode_handler(engine, *, use_sglang_tokenizer: bool = False):
+    handler = DecodeWorkerHandler.__new__(DecodeWorkerHandler)
+    handler.engine = engine
+    handler.config = SimpleNamespace(
+        server_args=SimpleNamespace(served_model_name="test-model"),
+        dynamo_args=SimpleNamespace(enable_rl=False),
+    )
+    handler.serving_mode = DisaggregationMode.DECODE
+    handler.use_sglang_tokenizer = use_sglang_tokenizer
+    handler.enable_trace = False
+    handler.shutdown_event = None
+    handler._first_token_source = None
+    handler._routed_experts_kwargs = {}
+    handler._engine_supports_priority = False
+    handler.lora_id_for_name = {}
+    handler._cancellation_monitor = _no_cancellation_monitor
+    handler._get_input_param = lambda request: (
+        {"prompt": "hi"}
+        if use_sglang_tokenizer
+        else {"input_ids": request["token_ids"]}
+    )
+    return handler
+
+
+def _new_prefill_handler(engine, room_draws=None):
+    handler = PrefillWorkerHandler.__new__(PrefillWorkerHandler)
+    handler.engine = engine
+    handler.bootstrap_host = BOOTSTRAP_HOST
+    handler.bootstrap_port = BOOTSTRAP_PORT
+    handler.config = SimpleNamespace(
+        server_args=SimpleNamespace(served_model_name="test-model"),
+        dynamo_args=SimpleNamespace(enable_rl=False),
+    )
+    handler.serving_mode = DisaggregationMode.PREFILL
+    handler.use_sglang_tokenizer = False
+    handler.enable_trace = False
+    handler.shutdown_event = None
+    handler._engine_supports_priority = False
+    handler.lora_id_for_name = {}
+    handler._consume_tasks = set()
+    handler._cancellation_monitor = _no_cancellation_monitor
+    handler._get_input_param = lambda request: {"input_ids": request["token_ids"]}
+    if room_draws is not None:
+        draws = iter(room_draws)
+        handler._generate_bootstrap_room = lambda: next(draws)
+    return handler
+
+
+def _token_outputs(rid: str, tokens: list[int]) -> list[dict[str, Any]]:
+    outputs = []
+    for position, token in enumerate(tokens):
+        final = position == len(tokens) - 1
+        outputs.append(
+            {
+                "output_ids": [token],
+                "meta_info": {
+                    "id": rid,
+                    "finish_reason": {"type": "stop"} if final else None,
+                    **(
+                        {"prompt_tokens": 3, "completion_tokens": len(tokens)}
+                        if final
+                        else {}
+                    ),
+                },
+            }
+        )
+    return outputs
+
+
+def _text_outputs(rid: str, texts: list[str]) -> list[dict[str, Any]]:
+    outputs = []
+    for position, text in enumerate(texts):
+        final = position == len(texts) - 1
+        outputs.append(
+            {
+                "text": text,
+                "output_ids": [position],
+                "meta_info": {
+                    "id": rid,
+                    "finish_reason": {"type": "stop"} if final else None,
+                },
+            }
+        )
+    return outputs
+
+
+def _token_request(n: int | None, bootstrap_info: dict[str, Any]) -> dict[str, Any]:
+    sampling_options: dict[str, Any] = {"temperature": 0.5}
+    if n is not None:
+        sampling_options["n"] = n
+    return {
+        "token_ids": [1, 2, 3],
+        "sampling_options": sampling_options,
+        "stop_conditions": {"max_tokens": 8},
+        "output_options": {},
+        "routing": {"dp_rank": 2},
+        "bootstrap_info": bootstrap_info,
+    }
+
+
+def _fan_out_bootstrap_info(rooms: list[int]) -> dict[str, Any]:
+    return {
+        "bootstrap_host": BOOTSTRAP_HOST,
+        "bootstrap_port": BOOTSTRAP_PORT,
+        "bootstrap_room": rooms[0],
+        BOOTSTRAP_ROOMS_KEY: rooms,
+    }
+
+
+@pytest.mark.asyncio
+async def test_decode_fans_out_parallel_sampling_per_bootstrap_room():
+    engine = _FakeEngine(
+        {
+            100: _token_outputs("trace-choice-0", [11, 12, 13]),
+            200: _token_outputs("trace-choice-1", [21, 22]),
+        }
+    )
+    handler = _new_disagg_decode_handler(engine)
+
+    outputs = await _collect(
+        handler.generate(
+            _token_request(2, _fan_out_bootstrap_info([100, 200])), _context()
+        )
+    )
+
+    # One n=1 sub-request per room, each with its own SGLang request id.
+    assert [call["bootstrap_room"] for call in engine.calls] == [100, 200]
+    assert [call["rid"] for call in engine.calls] == [
+        "trace-choice-0",
+        "trace-choice-1",
+    ]
+    for call in engine.calls:
+        assert call["sampling_params"]["n"] == 1
+        assert call["sampling_params"]["temperature"] == 0.5
+        assert call["bootstrap_host"] == BOOTSTRAP_HOST
+        assert call["bootstrap_port"] == BOOTSTRAP_PORT
+        assert call["data_parallel_rank"] == 2
+        assert call["input_ids"] == [1, 2, 3]
+
+    # Sub-streams are merged back by choice index with per-choice order kept.
+    by_choice: dict[int, list[int]] = {}
+    for out in outputs:
+        by_choice.setdefault(out["index"], []).extend(out["token_ids"])
+    assert by_choice == {0: [11, 12, 13], 1: [21, 22]}
+
+    finishing = [out for out in outputs if out.get("finish_reason")]
+    assert {out["index"] for out in finishing} == {0, 1}
+    # Usage reports the running request-wide total, like the single-stream
+    # n > 1 path, so the last finishing chunk carries all completion tokens.
+    assert finishing[-1]["completion_usage"] == {
+        "prompt_tokens": 3,
+        "completion_tokens": 5,
+        "total_tokens": 8,
+    }
+    assert finishing[0]["completion_usage"]["completion_tokens"] in (2, 3)
+    assert engine.aborted == []
+
+
+@pytest.mark.asyncio
+async def test_decode_fan_out_aborts_siblings_when_one_choice_fails():
+    engine = _FakeEngine(
+        {
+            100: _token_outputs("trace-choice-0", list(range(100))),
+            200: [
+                _token_outputs("trace-choice-1", [21, 22])[0],
+                RuntimeError("choice 1 failed"),
+            ],
+        }
+    )
+    handler = _new_disagg_decode_handler(engine)
+
+    with pytest.raises(RuntimeError, match="choice 1 failed"):
+        await _collect(
+            handler.generate(
+                _token_request(2, _fan_out_bootstrap_info([100, 200])), _context()
+            )
+        )
+
+    # The surviving sub-request would otherwise decode to max_tokens with no
+    # consumer; both are aborted in SGLang by the rids the handler assigned.
+    assert sorted(engine.aborted) == ["trace-choice-0", "trace-choice-1"]
+
+
+@pytest.mark.asyncio
+async def test_decode_fan_out_merges_text_chunks_under_one_response_id():
+    engine = _FakeEngine(
+        {
+            100: _text_outputs("sglang-0", ["Hel", "Hello"]),
+            200: _text_outputs("sglang-1", ["Bye"]),
+        }
+    )
+    handler = _new_disagg_decode_handler(engine, use_sglang_tokenizer=True)
+    request = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "n": 2,
+        "max_tokens": 8,
+        "bootstrap_info": _fan_out_bootstrap_info([100, 200]),
+    }
+
+    outputs = await _collect(handler.generate(request, _context()))
+
+    assert [call["bootstrap_room"] for call in engine.calls] == [100, 200]
+    assert all(call["sampling_params"]["n"] == 1 for call in engine.calls)
+    assert {out["id"] for out in outputs} == {"trace"}
+    deltas: dict[int, str] = {}
+    for out in outputs:
+        (choice,) = out["choices"]
+        deltas[choice["index"]] = (
+            deltas.get(choice["index"], "") + choice["delta"]["content"]
+        )
+    assert deltas == {0: "Hello", 1: "Bye"}
+
+
+@pytest.mark.asyncio
+async def test_decode_rejects_parallel_sampling_from_older_frontend():
+    engine = _FakeEngine({})
+    handler = _new_disagg_decode_handler(engine)
+    bootstrap_info = {
+        "bootstrap_host": BOOTSTRAP_HOST,
+        "bootstrap_port": BOOTSTRAP_PORT,
+        "bootstrap_room": 100,
+    }
+
+    with pytest.raises(HttpError) as excinfo:
+        await _collect(handler.generate(_token_request(2, bootstrap_info), _context()))
+
+    assert excinfo.value.code == 400
+    # Rejected before any engine work.
+    assert engine.calls == []
+
+
+@pytest.mark.asyncio
+async def test_decode_single_sample_keeps_pre_fan_out_wire_shape():
+    engine = _FakeEngine({100: _token_outputs("trace", [11])})
+    handler = _new_disagg_decode_handler(engine)
+    bootstrap_info = {
+        "bootstrap_host": BOOTSTRAP_HOST,
+        "bootstrap_port": BOOTSTRAP_PORT,
+        "bootstrap_room": 100,
+    }
+
+    outputs = await _collect(
+        handler.generate(_token_request(None, bootstrap_info), _context())
+    )
+
+    (call,) = engine.calls
+    assert call["bootstrap_room"] == 100
+    assert call["rid"] == "trace"
+    assert "n" not in call["sampling_params"]
+    assert outputs == [
+        {
+            "index": 0,
+            "finish_reason": "stop",
+            "token_ids": [11],
+            "completion_usage": {
+                "prompt_tokens": 3,
+                "completion_tokens": 1,
+                "total_tokens": 4,
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_prefill_fans_out_parallel_sampling_with_router_rooms():
+    engine = _FakeEngine(
+        {
+            100: _token_outputs("trace-choice-0", [11]),
+            200: _token_outputs("trace-choice-1", [21]),
+        }
+    )
+    handler = _new_prefill_handler(engine)
+
+    outputs = await _collect(
+        handler.generate(
+            _token_request(2, _fan_out_bootstrap_info([100, 200])), _context()
+        )
+    )
+
+    assert outputs == [
+        {
+            "token_ids": [],
+            "text": None,
+            "finish_reason": None,
+            "disaggregated_params": _fan_out_bootstrap_info([100, 200]),
+        }
+    ]
+    assert [call["bootstrap_room"] for call in engine.calls] == [100, 200]
+    assert [call["rid"] for call in engine.calls] == [
+        "trace-choice-0",
+        "trace-choice-1",
+    ]
+    for call in engine.calls:
+        assert call["sampling_params"]["n"] == 1
+        assert call["sampling_params"]["max_new_tokens"] == 1
+        assert call["sampling_params"]["temperature"] == 0.5
+    # Every sub-request was consumed so its handoff completed.
+    assert handler._consume_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_prefill_rejects_parallel_sampling_from_older_frontend():
+    engine = _FakeEngine({})
+    handler = _new_prefill_handler(engine)
+    bootstrap_info = {
+        "bootstrap_host": BOOTSTRAP_HOST,
+        "bootstrap_port": BOOTSTRAP_PORT,
+        "bootstrap_room": 100,
+    }
+
+    with pytest.raises(HttpError) as excinfo:
+        await _collect(handler.generate(_token_request(2, bootstrap_info), _context()))
+
+    assert excinfo.value.code == 400
+    assert engine.calls == []
+
+
+@pytest.mark.asyncio
+async def test_prefill_draws_local_rooms_when_frontend_sent_none():
+    engine = _FakeEngine(
+        {
+            7: _token_outputs("trace-choice-0", [11]),
+            9: _token_outputs("trace-choice-1", [21]),
+        }
+    )
+    handler = _new_prefill_handler(engine, room_draws=[7, 7, 9])
+    request = _token_request(2, {})
+    del request["bootstrap_info"]
+
+    outputs = await _collect(handler.generate(request, _context()))
+
+    assert outputs[0]["disaggregated_params"] == {
+        "bootstrap_host": BOOTSTRAP_HOST,
+        "bootstrap_port": BOOTSTRAP_PORT,
+        "bootstrap_room": 7,
+        BOOTSTRAP_ROOMS_KEY: [7, 9],
+    }
+    assert [call["bootstrap_room"] for call in engine.calls] == [7, 9]
+
+
+@pytest.mark.asyncio
+async def test_prefill_single_sample_keeps_pre_fan_out_wire_shape():
+    engine = _FakeEngine({100: _token_outputs("trace", [11])})
+    handler = _new_prefill_handler(engine)
+    bootstrap_info = {
+        "bootstrap_host": BOOTSTRAP_HOST,
+        "bootstrap_port": BOOTSTRAP_PORT,
+        "bootstrap_room": 100,
+    }
+
+    outputs = await _collect(
+        handler.generate(_token_request(None, bootstrap_info), _context())
+    )
+
+    assert outputs[0]["disaggregated_params"] == bootstrap_info
+    assert BOOTSTRAP_ROOMS_KEY not in outputs[0]["disaggregated_params"]
+    (call,) = engine.calls
+    assert call["rid"] == "trace"
+    assert call["sampling_params"] == {"n": 1, "max_new_tokens": 1, "temperature": 0.5}
+
+
+@pytest.mark.asyncio
+async def test_prefill_wrapped_request_reads_parallel_sampling_from_sampling_params():
+    engine = _FakeEngine(
+        {
+            100: _token_outputs("trace-choice-0", [11]),
+            200: _token_outputs("trace-choice-1", [21]),
+        }
+    )
+    handler = _new_prefill_handler(engine)
+    request = {
+        "request": {
+            "token_ids": [1, 2, 3],
+            "bootstrap_info": _fan_out_bootstrap_info([100, 200]),
+        },
+        "sampling_params": {"n": 2, "max_new_tokens": 8},
+    }
+
+    outputs = await _collect(handler.generate(request, _context()))
+
+    assert outputs[0]["disaggregated_params"][BOOTSTRAP_ROOMS_KEY] == [100, 200]
+    assert [call["bootstrap_room"] for call in engine.calls] == [100, 200]
+    assert all(call["sampling_params"]["n"] == 1 for call in engine.calls)

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/disaggregation.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/disaggregation.md
@@ -82,6 +82,19 @@ sequenceDiagram
 7. **Decode phase**: Decode worker generates tokens using the transferred KV cache
 8. **Streaming**: Tokens are streamed back to the client as they're generated
 
+### Parallel Sampling (`n > 1`)
+
+SGLang cannot pair parallel samples across a prefill-decode handoff: its scheduler clones one bootstrap room for every sample, so prefill registers a single sender while decode waits for `n` receivers and the request never completes. Dynamo keeps SGLang blind to `n` in disaggregated mode instead:
+
+- The frontend's prefill router draws one bootstrap room per choice and carries them as `bootstrap_info.bootstrap_rooms`, alongside the single `bootstrap_room` that older workers read. Every router-drawn room keeps `room % dp_size == dp_rank`, which the SGLang decode receiver uses to derive the prefill DP rank.
+- The prefill and decode workers turn the request into `n` independent `n=1` sub-requests, one room each, and the decode worker merges the sub-streams back into one multi-choice response. If one sub-request fails, the decode worker aborts its siblings.
+- The single-choice wire format is unchanged. A frontend that predates per-choice rooms sends one room only, and the worker rejects its `n > 1` requests with HTTP 400 rather than hanging. The dedicated multimodal prefill and decode workers still reject `n > 1`.
+
+> [!IMPORTANT]
+> **Cost.** Each choice is a separate prefill sub-request and a separate KV transfer: an `n > 1` request prefills the prompt up to `n` times and holds `n` copies of the prompt KV on the decode worker, unlike aggregated SGLang, which shares one prefix primer across samples. The frontend caps `n` at 128. For long prompts, prefer `n=1` and fan out on the client.
+>
+> **Upgrade order.** Upgrade prefill workers before decode workers and frontends. An older prefill worker ignores `bootstrap_rooms` and registers one sender, so `n > 1` requests from a newer frontend wait for SGLang's bootstrap timeout instead of failing fast.
+
 ### Performance Characteristics
 
 - **RDMA transfer**: Zero-copy GPU-to-GPU transfer with minimal CPU involvement

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -116,8 +116,21 @@ fn extract_bootstrap_info(params: &serde_json::Value) -> Option<BootstrapInfo> {
         bootstrap_host,
         bootstrap_port,
         bootstrap_room,
+        bootstrap_rooms: extract_bootstrap_rooms(params),
         handoff_id: Some(Uuid::new_v4()),
     })
+}
+
+/// Per-choice rooms a prefill worker drew itself for an `n > 1` request.
+/// A malformed list is dropped; decode then rejects the request.
+fn extract_bootstrap_rooms(params: &serde_json::Value) -> Option<Vec<u64>> {
+    let rooms = params
+        .get("bootstrap_rooms")?
+        .as_array()?
+        .iter()
+        .map(serde_json::Value::as_u64)
+        .collect::<Option<Vec<u64>>>()?;
+    (rooms.len() > 1).then_some(rooms)
 }
 
 struct PreparedPrefill {
@@ -604,6 +617,9 @@ where
         let topology_constraints =
             self.preflight_kv_transfer_constraints(Some(endpoint_id), worker_id)?;
 
+        // An `n > 1` request fans out into `n` single-sample sub-requests on
+        // the worker; draw one room each so all keep `room % dp_size == dp_rank`.
+        let parallel_samples = parallel_sample_count(request);
         let bootstrap_info = self
             .model_manager
             .get_disaggregated_endpoint(endpoint_id, worker_id)
@@ -614,12 +630,15 @@ where
                 let dp_size = self
                     .model_manager
                     .get_data_parallel_size(endpoint_id, worker_id);
-                let random_room = rand::random_range(0..=i64::MAX.cast_unsigned());
-                let bootstrap_room = compute_bootstrap_room(dp_rank, dp_size, random_room);
+                let rooms = draw_bootstrap_rooms(dp_rank, dp_size, parallel_samples, || {
+                    rand::random_range(0..=i64::MAX.cast_unsigned())
+                });
+                let bootstrap_room = rooms[0];
                 Some(BootstrapInfo {
                     bootstrap_host: host,
                     bootstrap_port: port,
                     bootstrap_room,
+                    bootstrap_rooms: (rooms.len() > 1).then_some(rooms),
                     handoff_id: Some(Uuid::new_v4()),
                 })
             });
@@ -647,6 +666,33 @@ where
         self.model_manager
             .get_kv_transfer_routing_constraints(endpoint_id, worker_id)
     }
+}
+
+/// Number of independent samples the request asks for (`sampling_options.n`).
+fn parallel_sample_count(request: &PreprocessedRequest) -> usize {
+    request
+        .sampling_options
+        .n
+        .map_or(1, |n| usize::from(n.max(1)))
+}
+
+/// Draw `count >= 1` distinct bootstrap rooms that all satisfy
+/// `room % dp_size == dp_rank` (see [`compute_bootstrap_room`]).
+fn draw_bootstrap_rooms(
+    dp_rank: Option<u32>,
+    dp_size: Option<u32>,
+    count: usize,
+    mut random_room: impl FnMut() -> u64,
+) -> Vec<u64> {
+    let mut rooms = Vec::with_capacity(count);
+    while rooms.len() < count {
+        let room = compute_bootstrap_room(dp_rank, dp_size, random_room());
+        // Two choices of one request must never pair on the same room.
+        if !rooms.contains(&room) {
+            rooms.push(room);
+        }
+    }
+    rooms
 }
 
 fn compute_bootstrap_room(dp_rank: Option<u32>, dp_size: Option<u32>, random_room: u64) -> u64 {
@@ -910,6 +956,44 @@ mod tests {
         assert_eq!(room_a % 48, 7);
     }
 
+    #[test]
+    fn draw_bootstrap_rooms_yields_one_room_for_single_sample() {
+        let rooms = draw_bootstrap_rooms(Some(3), Some(8), 1, || 1_001);
+        assert_eq!(rooms.len(), 1);
+        assert_eq!(rooms[0] % 8, 3);
+    }
+
+    #[test]
+    fn draw_bootstrap_rooms_keeps_dp_invariant_and_distinct_rooms() {
+        // Repeated randomness must not yield duplicate rooms: the second
+        // draw repeats the first value and has to be skipped.
+        let raw = [500u64, 500, 501, 502];
+        let mut next = 0;
+        let rooms = draw_bootstrap_rooms(Some(5), Some(16), 3, || {
+            let value = raw[next];
+            next += 1;
+            value
+        });
+        assert_eq!(rooms.len(), 3);
+        assert_eq!(next, 4);
+        for room in &rooms {
+            assert_eq!(room % 16, 5);
+            assert!(*room <= MAX_ROOM);
+        }
+        let distinct: HashSet<u64> = rooms.iter().copied().collect();
+        assert_eq!(distinct.len(), 3);
+    }
+
+    #[test]
+    fn parallel_sample_count_reads_sampling_options() {
+        let mut request = request_with_constraints(None);
+        assert_eq!(parallel_sample_count(&request), 1);
+        request.sampling_options.n = Some(0);
+        assert_eq!(parallel_sample_count(&request), 1);
+        request.sampling_options.n = Some(4);
+        assert_eq!(parallel_sample_count(&request), 4);
+    }
+
     fn request_with_constraints(
         routing_constraints: Option<RoutingConstraints>,
     ) -> PreprocessedRequest {
@@ -1016,6 +1100,42 @@ mod tests {
         assert_eq!(info.bootstrap_host, "10.0.0.5");
         assert_eq!(info.bootstrap_port, 12345);
         assert_eq!(info.bootstrap_room, 987654321);
+        assert_eq!(info.bootstrap_rooms, None);
+    }
+
+    #[test]
+    fn extract_bootstrap_info_carries_worker_drawn_choice_rooms() {
+        let params = serde_json::json!({
+            "bootstrap_host": "10.0.0.5",
+            "bootstrap_port": 12345,
+            "bootstrap_room": 10,
+            "bootstrap_rooms": [10, 20, 30],
+        });
+        let info = extract_bootstrap_info(&params).expect("valid params should parse");
+        assert_eq!(info.bootstrap_room, 10);
+        assert_eq!(info.bootstrap_rooms, Some(vec![10, 20, 30]));
+    }
+
+    #[test]
+    fn extract_bootstrap_info_drops_malformed_choice_rooms() {
+        for rooms in [
+            serde_json::json!(null),
+            serde_json::json!("10,20"),
+            serde_json::json!([10, "20"]),
+            serde_json::json!([10, -20]),
+            // A single-entry list is not a fan-out.
+            serde_json::json!([10]),
+        ] {
+            let params = serde_json::json!({
+                "bootstrap_host": "10.0.0.5",
+                "bootstrap_port": 12345,
+                "bootstrap_room": 10,
+                "bootstrap_rooms": rooms,
+            });
+            let info = extract_bootstrap_info(&params).expect("room list is optional");
+            assert_eq!(info.bootstrap_room, 10);
+            assert_eq!(info.bootstrap_rooms, None, "rooms={rooms}");
+        }
     }
 
     #[test]

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -618,8 +618,6 @@ where
         let topology_constraints =
             self.preflight_kv_transfer_constraints(Some(endpoint_id), worker_id)?;
 
-        // An `n > 1` request fans out into `n` single-sample sub-requests on
-        // the worker; draw one room each so all keep `room % dp_size == dp_rank`.
         let parallel_samples = parallel_sample_count(request);
         let bootstrap_info = self
             .model_manager

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -669,7 +669,6 @@ where
     }
 }
 
-/// Number of independent samples the request asks for (`sampling_options.n`).
 fn parallel_sample_count(request: &PreprocessedRequest) -> usize {
     request
         .sampling_options

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -685,7 +685,6 @@ fn draw_bootstrap_rooms(
     let mut rooms = Vec::with_capacity(count);
     while rooms.len() < count {
         let room = compute_bootstrap_room(dp_rank, dp_size, random_room());
-        // Two choices of one request must never pair on the same room.
         if !rooms.contains(&room) {
             rooms.push(room);
         }
@@ -1115,7 +1114,6 @@ mod tests {
     #[test]
     fn extract_bootstrap_info_drops_malformed_choice_rooms() {
         for rooms in [
-            serde_json::json!(null),
             serde_json::json!("10,20"),
             serde_json::json!([10, "20"]),
             serde_json::json!([10, -20]),

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -116,21 +116,22 @@ fn extract_bootstrap_info(params: &serde_json::Value) -> Option<BootstrapInfo> {
         bootstrap_host,
         bootstrap_port,
         bootstrap_room,
-        bootstrap_rooms: extract_bootstrap_rooms(params),
+        bootstrap_rooms: extract_bootstrap_rooms(params, bootstrap_room),
         handoff_id: Some(Uuid::new_v4()),
     })
 }
 
 /// Per-choice rooms a prefill worker drew itself for an `n > 1` request.
-/// A malformed list is dropped; decode then rejects the request.
-fn extract_bootstrap_rooms(params: &serde_json::Value) -> Option<Vec<u64>> {
+/// A malformed list, or one not led by `bootstrap_room`, is dropped; decode
+/// then rejects the request.
+fn extract_bootstrap_rooms(params: &serde_json::Value, bootstrap_room: u64) -> Option<Vec<u64>> {
     let rooms = params
         .get("bootstrap_rooms")?
         .as_array()?
         .iter()
         .map(serde_json::Value::as_u64)
         .collect::<Option<Vec<u64>>>()?;
-    (rooms.len() > 1).then_some(rooms)
+    (rooms.len() > 1 && rooms[0] == bootstrap_room).then_some(rooms)
 }
 
 struct PreparedPrefill {
@@ -988,8 +989,6 @@ mod tests {
     fn parallel_sample_count_reads_sampling_options() {
         let mut request = request_with_constraints(None);
         assert_eq!(parallel_sample_count(&request), 1);
-        request.sampling_options.n = Some(0);
-        assert_eq!(parallel_sample_count(&request), 1);
         request.sampling_options.n = Some(4);
         assert_eq!(parallel_sample_count(&request), 4);
     }
@@ -1125,6 +1124,8 @@ mod tests {
             serde_json::json!([10, -20]),
             // A single-entry list is not a fan-out.
             serde_json::json!([10]),
+            // The first entry must be `bootstrap_room`.
+            serde_json::json!([20, 10, 30]),
         ] {
             let params = serde_json::json!({
                 "bootstrap_host": "10.0.0.5",

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -101,6 +101,12 @@ pub struct BootstrapInfo {
     /// Unique room ID for this request's KV transfer session
     pub bootstrap_room: u64,
 
+    /// One room per choice for an `n > 1` request the worker fans out into
+    /// single-sample sub-requests (SGLang PD). First entry is `bootstrap_room`;
+    /// absent for `n == 1`, so that wire format is unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bootstrap_rooms: Option<Vec<u64>>,
+
     /// Stable mocker lifecycle identity. Role, backend, and wire version are
     /// validated by the bootstrap registration and framing protocol.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -664,11 +670,14 @@ mod tests {
             bootstrap_host: "127.0.0.1".to_string(),
             bootstrap_port: 1234,
             bootstrap_room: 7,
+            bootstrap_rooms: None,
             handoff_id: Some(handoff_id),
         };
 
         let value = serde_json::to_value(&info).unwrap();
         assert_eq!(value["handoff_id"], handoff_id.to_string());
+        // `n == 1` requests keep the pre-fan-out wire format.
+        assert!(value.get("bootstrap_rooms").is_none());
         assert!(value.get("mocker_handoff_protocol_version").is_none());
         assert!(value.get("mocker_handoff_role").is_none());
         assert!(value.get("mocker_handoff_engine_type").is_none());
@@ -678,6 +687,32 @@ mod tests {
                 .handoff_id,
             Some(handoff_id)
         );
+    }
+
+    #[test]
+    fn bootstrap_info_round_trips_per_choice_rooms() {
+        let info = BootstrapInfo {
+            bootstrap_host: "127.0.0.1".to_string(),
+            bootstrap_port: 1234,
+            bootstrap_room: 8,
+            bootstrap_rooms: Some(vec![8, 16, 24]),
+            handoff_id: None,
+        };
+
+        let value = serde_json::to_value(&info).unwrap();
+        assert_eq!(value["bootstrap_room"], 8);
+        assert_eq!(value["bootstrap_rooms"], serde_json::json!([8, 16, 24]));
+        let decoded: BootstrapInfo = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded.bootstrap_rooms, Some(vec![8, 16, 24]));
+
+        // A worker or frontend that predates the field deserializes cleanly.
+        let legacy: BootstrapInfo = serde_json::from_value(serde_json::json!({
+            "bootstrap_host": "127.0.0.1",
+            "bootstrap_port": 1234,
+            "bootstrap_room": 8,
+        }))
+        .unwrap();
+        assert_eq!(legacy.bootstrap_rooms, None);
     }
 
     /// Covers the `is_probe` serde contract end-to-end: `rename = "_HEALTH_CHECK"`,

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -703,15 +703,6 @@ mod tests {
         assert_eq!(value["bootstrap_rooms"], serde_json::json!([8, 16, 24]));
         let decoded: BootstrapInfo = serde_json::from_value(value).unwrap();
         assert_eq!(decoded.bootstrap_rooms, Some(vec![8, 16, 24]));
-
-        // A worker or frontend that predates the field deserializes cleanly.
-        let legacy: BootstrapInfo = serde_json::from_value(serde_json::json!({
-            "bootstrap_host": "127.0.0.1",
-            "bootstrap_port": 1234,
-            "bootstrap_room": 8,
-        }))
-        .unwrap();
-        assert_eq!(legacy.bootstrap_rooms, None);
     }
 
     /// Covers the `is_probe` serde contract end-to-end: `rename = "_HEALTH_CHECK"`,

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -676,7 +676,6 @@ mod tests {
 
         let value = serde_json::to_value(&info).unwrap();
         assert_eq!(value["handoff_id"], handoff_id.to_string());
-        // `n == 1` requests keep the pre-fan-out wire format.
         assert!(value.get("bootstrap_rooms").is_none());
         assert!(value.get("mocker_handoff_protocol_version").is_none());
         assert!(value.get("mocker_handoff_role").is_none());

--- a/lib/sidecar/sglang/src/protocol.rs
+++ b/lib/sidecar/sglang/src/protocol.rs
@@ -609,6 +609,7 @@ mod tests {
             bootstrap_host: "prefill".to_string(),
             bootstrap_port: 5000,
             bootstrap_room: i64::MAX as u64,
+            bootstrap_rooms: None,
             handoff_id: None,
         });
         let mapped =
@@ -834,6 +835,7 @@ mod tests {
             bootstrap_host: "prefill".to_string(),
             bootstrap_port: 5000,
             bootstrap_room: i64::MAX as u64 + 1,
+            bootstrap_rooms: None,
             handoff_id: None,
         });
         assert!(


### PR DESCRIPTION
## Overview

Fan out SGLang disaggregated requests with `n > 1` into `n` single-sample sub-requests, one bootstrap room each, instead of letting them hang.

## Summary

* draw one bootstrap room per choice in the prefill router (`BootstrapInfo.bootstrap_rooms`, optional; `n=1` wire format unchanged)
* run `n` independent `n=1` sub-requests on the prefill and decode handlers, merged by choice index
* abort the sibling sub-requests in SGLang if one fails
* reject `n > 1` from an older frontend with HTTP 400; dedicated multimodal PD keeps the rejection
* document the cost and the upgrade order (prefill workers first)
* add unit coverage for room resolution, merge ordering, and sibling abort

## Details

Parallel sampling is not ready upstream ([sgl-project/sglang#30723](https://github.com/sgl-project/sglang/pull/30723)). On 0.5.18 the scheduler clones sub-object 0, room included, for the primer and every sample, so forwarding `n` or a room list lands on one room either way. The fan-out has to live in Dynamo.

Justification for this approach: with the 400 a client that wants `n` samples sends `n` requests. Decode work and KV transfers are the same either way. The difference is prefill: concurrent duplicates through the KV router land on different prefill workers about half the time with two of them, so each is prefilled from scratch. With the issue's numbers (207 ms prefill, `n=2`, two prefill workers) that is about 100 ms of prefill GPU time per request, so roughly 10 such requests per second consume one prefill GPU. The con is that it scales with prefill time. The assumption that fanned-out siblings share the prefix cache on the same worker is not measured yet; the docs state the cost as up to `n×` until it is.

## Where should the reviewer start?

`components/src/dynamo/sglang/parallel_sampling.py`, then `lib/llm/src/kv_router/prefill_router/mod.rs` (`draw_bootstrap_rooms`).

## Validation

* Rust: `cargo test -p dynamo-llm --no-default-features` for `prefill_router` and `preprocessor`, 49 passed; fmt, clippy `-D warnings`, pre-commit clean
* SGLang handler tests: new `test_sglang_parallel_sampling.py` (`pre_merge`, `sglang`, `gpu_0`); helper and merge tests run locally, handler tests need SGLang and run in CI
* real GPU A/B: not yet run; an end-to-end disaggregated `n=2` check on a PD deployment is still needed

## Related Issues

* Closes [[BUG]: SGLang disaggregated requests with n > 1 hang after prefill completes #14098](https://github.com/ai-dynamo/dynamo/issues/14098)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added parallel sampling for disaggregated SGLang requests, allowing multiple choices to be generated concurrently and returned as a merged response.
  - Added per-choice routing and bootstrap handling while preserving compatibility for single-sample requests.
  - Added failure handling that cancels sibling requests when one choice fails.

- **Bug Fixes**
  - Added clear HTTP 400 responses for unsupported legacy, malformed, and multimodal parallel-sampling requests.

- **Documentation**
  - Documented supported configurations, resource considerations, choice limits, and upgrade requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->