### PR TITLE
docs: Follow up DOC fixes to go epp deprecation fixes [DYNO-102]

### DIFF
--- a/deploy/inference-gateway/ext-proc/DEVEL.md
+++ b/deploy/inference-gateway/ext-proc/DEVEL.md
@@ -135,7 +135,7 @@ The common local environment variables are:
 | `DYN_NAMESPACE` | unset | Exact Dynamo discovery namespace fallback. If unset, the binary uses `vllm-agg`. |
 | `DYN_COMPONENT_NAME` | `backend` | Dynamo component that exposes the `generate` endpoint. |
 | `DYN_ENFORCE_DISAGG` | `false` | Deprecated and ignored. Registered worker types determine routing topology and readiness. |
-| `DYN_KUBE_DISCOVERY_MODE` | `pod` | Kubernetes discovery identity mode. `container` (intra-pod GMS failover) is supported under the default `DYN_EPP_MODE=dynamo`, which resolves per-container worker identities from reflected Pods. `DYN_EPP_MODE=standalone` rejects it at startup: standalone selects workers from the Pod's aggregate `Ready` condition, which a pod holding an intentionally-standby engine container never satisfies. Deferred there, not permanent — see `TODO(epp-standalone-container-discovery)` in `src/epp_standalone_config.rs`. |
+| `DYN_KUBE_DISCOVERY_MODE` | `pod` | Kubernetes discovery identity mode. `container` (intra-pod GMS failover) is supported under the default `DYN_EPP_MODE=dynamo`, which resolves per-container worker identities from reflected Pods. `DYN_EPP_MODE=standalone` rejects it at startup: standalone selects workers from the Pod's aggregate `Ready` condition, which a pod holding an intentionally-standby engine container never satisfies. Standalone support is planned rather than ruled out, tracked by [DEP #11661](https://github.com/ai-dynamo/dynamo/issues/11661) (EPP Embedded SelectionService Interface). |
 | `RUST_LOG` | `info` | Tracing log filter. |
 
 ## Cleaning

--- a/deploy/inference-gateway/ext-proc/DEVEL.md
+++ b/deploy/inference-gateway/ext-proc/DEVEL.md
@@ -135,7 +135,7 @@ The common local environment variables are:
 | `DYN_NAMESPACE` | unset | Exact Dynamo discovery namespace fallback. If unset, the binary uses `vllm-agg`. |
 | `DYN_COMPONENT_NAME` | `backend` | Dynamo component that exposes the `generate` endpoint. |
 | `DYN_ENFORCE_DISAGG` | `false` | Deprecated and ignored. Registered worker types determine routing topology and readiness. |
-| `DYN_KUBE_DISCOVERY_MODE` | `pod` | Kubernetes discovery identity mode. The EPP currently rejects `container`. |
+| `DYN_KUBE_DISCOVERY_MODE` | `pod` | Kubernetes discovery identity mode. `container` (intra-pod GMS failover) is supported under the default `DYN_EPP_MODE=dynamo`, which resolves per-container worker identities from reflected Pods. `DYN_EPP_MODE=standalone` rejects it at startup: standalone selects workers from the Pod's aggregate `Ready` condition, which a pod holding an intentionally-standby engine container never satisfies. Deferred there, not permanent — see `TODO(epp-standalone-container-discovery)` in `src/epp_standalone_config.rs`. |
 | `RUST_LOG` | `info` | Tracing log filter. |
 
 ## Cleaning

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -231,8 +231,8 @@ impl EppStandaloneConfig {
 }
 
 /// Reject `DYN_KUBE_DISCOVERY_MODE=container` (e.g. intra-pod GMS failover)
-/// in standalone mode. Deferred, not a permanent restriction — see
-/// TODO(epp-standalone-container-discovery) below for what unblocks it.
+/// in standalone mode. Standalone support is planned rather than ruled out;
+/// see the note below for what it requires.
 ///
 /// Unlike `DYN_EPP_MODE=dynamo` (which already resolves per-container worker
 /// identities; see `hash_container_name` / `pod_worker_ids` in `epp.rs`),

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -245,11 +245,12 @@ impl EppStandaloneConfig {
 /// excluded from every worker index rather than just failing to fail over.
 /// Reject it at startup instead of shipping that silent malfunction.
 ///
-/// TODO(epp-standalone-container-discovery): replace `pod_discovery.rs`'s
-/// pod-aggregate `pod_is_ready()` gate with a per-named-container readiness
-/// check (mirroring dynamo mode's `pod_worker_ids`) so a `WorkerIndex` entry
-/// is keyed on an individual container's own `Ready` status, not the pod's.
-/// Once that lands, lift this rejection.
+/// Lifting this rejection is planned work, tracked by DEP #11661 (EPP Embedded
+/// SelectionService Interface): <https://github.com/ai-dynamo/dynamo/issues/11661>.
+/// It requires replacing `pod_discovery.rs`'s pod-aggregate `pod_is_ready()`
+/// gate with a per-named-container readiness check (mirroring dynamo mode's
+/// `pod_worker_ids`), so a `WorkerIndex` entry is keyed on an individual
+/// container's own `Ready` status rather than the pod's.
 fn reject_unsupported_container_discovery(get: &EnvGet) -> anyhow::Result<()> {
     match trimmed(get(DYN_KUBE_DISCOVERY_MODE)).as_deref() {
         Some("container") => anyhow::bail!(

--- a/deploy/operator/internal/dynamo/component_epp.go
+++ b/deploy/operator/internal/dynamo/component_epp.go
@@ -157,21 +157,30 @@ func (e *EPPDefaults) GetBaseContainer(context ComponentContext) (corev1.Contain
 		// unbounded toward node DiskPressure and fails outright under
 		// readOnlyRootFilesystem: true.
 		//
-		// Only the native EPP gets this mount. The legacy Go EPP downloads no
-		// model configs, and its HOME cannot be derived from the launch contract
-		// alone: eppConfig selects the contract but not the image, so a legacy
-		// component on the frontend image (HOME=/home/dynamo) would take the
-		// nonroot path and mount the cache somewhere nothing ever reads.
+		// Only the native EPP gets this mount. The legacy Go EPP does reach the
+		// same download_config -- it statically links libdynamo_llm_capi, whose
+		// create_routers -> init_preprocessor path calls it, and resolves the
+		// same $HOME-rooted cache (its image sets no ENV HOME, so the runtime
+		// derives HOME=/home/nonroot from /etc/passwd). But it runs once at
+		// startup over a fixed set of metadata files, so the cost of dropping
+		// the volume is a few MB on the writable layer and a re-fetch on
+		// restart. That is bounded, unlike the growth the native path guards
+		// against, and not worth a volume for a component being removed.
+		//
+		// Its HOME cannot be derived here in any case: eppConfig selects the
+		// contract but not the image, so keying a mount path off it would put
+		// the cache where nothing reads it for a legacy component running on
+		// the frontend image (HOME=/home/dynamo).
 		//
 		// Withholding it from the legacy path re-renders every existing legacy
 		// EPP Pod, so those components roll once on an operator upgrade even
 		// though their DGD did not change. That is a deliberate exception to the
 		// rule that an operator-only upgrade must not roll unchanged workloads
-		// (deploy/operator/internal/AGENTS.md): the volume being withdrawn was
-		// never read on this path, and the Go EPP it was shaped for is
-		// deprecated, with its source removed in this release. The enumerated
-		// legacy Pod contract that upgrade compatibility actually promises --
-		// CLI flags, config volume, Service selector -- is untouched.
+		// (deploy/operator/internal/AGENTS.md), taken on deprecation grounds:
+		// the Go EPP this was shaped for is deprecated, with its source removed
+		// in this release. The enumerated legacy Pod contract that upgrade
+		// compatibility actually promises -- CLI flags, config volume, Service
+		// selector -- is untouched.
 		//
 		// A HOME supplied through podTemplate still wins over the one set above
 		// (MergeEnvs gives user env precedence), which would re-break the
@@ -199,10 +208,11 @@ func (e *EPPDefaults) GetBasePodSpec(context ComponentContext) (corev1.PodSpec, 
 		podSpec.Volumes = append(podSpec.Volumes, volume)
 	} else {
 		// Backs the model-config cache mounted in GetBaseContainer. Native EPP
-		// only: the legacy Go EPP downloads no model configs, so the volume
-		// would be dead weight and its mount path unknowable from the contract.
-		// See GetBaseContainer for why withholding it from the legacy path is a
-		// deliberate exception to the no-roll-on-operator-upgrade rule.
+		// only: the legacy Go EPP's own config download is bounded and small
+		// enough not to warrant a volume, and its mount path is not derivable
+		// from the launch contract. See GetBaseContainer for both, and for why
+		// withholding it from the legacy path is a deliberate exception to the
+		// no-roll-on-operator-upgrade rule.
 		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 			Name: "hf-cache",
 			VolumeSource: corev1.VolumeSource{

--- a/deploy/operator/internal/dynamo/component_epp.go
+++ b/deploy/operator/internal/dynamo/component_epp.go
@@ -149,42 +149,22 @@ func (e *EPPDefaults) GetBaseContainer(context ComponentContext) (corev1.Contain
 			Value: nativeRustEPPHome,
 		})
 
-		// Mount the model-config cache the EPP writes while downloading model
-		// configs. The path must track the container's HOME: the Rust EPP
+		// Mount the model-config cache under the pinned HOME. The Rust EPP
 		// resolves its MDC cache root from $HOME (lib/llm/src/model_card.rs), so
-		// a mount that does not match is silently inert -- no error, but the
-		// blobs land on the container's ephemeral writable layer, which grows
-		// unbounded toward node DiskPressure and fails outright under
-		// readOnlyRootFilesystem: true.
+		// a mount that does not match is silently inert and the blobs grow on
+		// the container's writable layer instead.
 		//
-		// Only the native EPP gets this mount. The legacy Go EPP does reach the
-		// same download_config -- it statically links libdynamo_llm_capi, whose
-		// create_routers -> init_preprocessor path calls it, and resolves the
-		// same $HOME-rooted cache (its image sets no ENV HOME, so the runtime
-		// derives HOME=/home/nonroot from /etc/passwd). But it runs once at
-		// startup over a fixed set of metadata files, so the cost of dropping
-		// the volume is a few MB on the writable layer and a re-fetch on
-		// restart. That is bounded, unlike the growth the native path guards
-		// against, and not worth a volume for a component being removed.
+		// Native only. The legacy Go EPP reaches the same download_config
+		// through libdynamo_llm_capi, but once at startup over a fixed file set
+		// -- a few MB and a re-fetch on restart, for a component being removed.
+		// Its HOME is not derivable here either, since eppConfig selects the
+		// contract but not the image.
 		//
-		// Its HOME cannot be derived here in any case: eppConfig selects the
-		// contract but not the image, so keying a mount path off it would put
-		// the cache where nothing reads it for a legacy component running on
-		// the frontend image (HOME=/home/dynamo).
-		//
-		// Withholding it from the legacy path re-renders every existing legacy
-		// EPP Pod, so those components roll once on an operator upgrade even
-		// though their DGD did not change. That is a deliberate exception to the
-		// rule that an operator-only upgrade must not roll unchanged workloads
-		// (deploy/operator/internal/AGENTS.md), taken on deprecation grounds:
-		// the Go EPP this was shaped for is deprecated, with its source removed
-		// in this release. The enumerated legacy Pod contract that upgrade
-		// compatibility actually promises -- CLI flags, config volume, Service
-		// selector -- is untouched.
-		//
-		// A HOME supplied through podTemplate still wins over the one set above
-		// (MergeEnvs gives user env precedence), which would re-break the
-		// pairing; that is the caller's choice, the same as overriding args.
+		// Withholding it re-renders existing legacy EPP Pods, so they roll once
+		// on an operator upgrade. That is a deliberate exception to the no-roll
+		// rule in deploy/operator/internal/AGENTS.md, taken on deprecation
+		// grounds; the promised legacy contract (CLI flags, config volume,
+		// Service selector) is untouched.
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 			Name:      "hf-cache",
 			MountPath: nativeRustEPPHome + "/.cache",
@@ -207,12 +187,8 @@ func (e *EPPDefaults) GetBasePodSpec(context ComponentContext) (corev1.PodSpec, 
 		volume, _ := epp.GetConfigMapVolumeMount(context.ParentGraphDeploymentName, context.EPPConfig)
 		podSpec.Volumes = append(podSpec.Volumes, volume)
 	} else {
-		// Backs the model-config cache mounted in GetBaseContainer. Native EPP
-		// only: the legacy Go EPP's own config download is bounded and small
-		// enough not to warrant a volume, and its mount path is not derivable
-		// from the launch contract. See GetBaseContainer for both, and for why
-		// withholding it from the legacy path is a deliberate exception to the
-		// no-roll-on-operator-upgrade rule.
+		// Backs the model-config cache mounted in GetBaseContainer, which is
+		// native-only; see there for why the legacy path goes without.
 		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 			Name: "hf-cache",
 			VolumeSource: corev1.VolumeSource{

--- a/deploy/operator/internal/dynamo/component_epp.go
+++ b/deploy/operator/internal/dynamo/component_epp.go
@@ -142,8 +142,8 @@ func (e *EPPDefaults) GetBaseContainer(context ComponentContext) (corev1.Contain
 
 		// Pin HOME rather than inheriting whatever the image sets. The native
 		// Rust EPP's default image (frontend) uses /home/dynamo while the
-		// standalone dynamo-epp image runs as nonroot, so without this the
-		// mount below can only be right for one of them.
+		// dedicated dynamo-epp image runs as nonroot, so without this the mount
+		// below can only be right for one of them.
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  "HOME",
 			Value: nativeRustEPPHome,
@@ -154,14 +154,20 @@ func (e *EPPDefaults) GetBaseContainer(context ComponentContext) (corev1.Contain
 		// a mount that does not match is silently inert and the blobs grow on
 		// the container's writable layer instead.
 		//
-		// Native Rust EPP only. Four contract/image combinations reach this
-		// renderer, and the image's own HOME differs across them:
+		// Native Rust EPP only. Recipes render the native path on
+		// dynamo-frontend, but the image is the user's to set, and the images an
+		// EPP component can carry disagree on HOME:
 		//
 		//   contract  image                     image HOME      mounted
 		//   native    dynamo-frontend:1.5.0+    /home/dynamo    yes, HOME pinned
 		//   native    dynamo-epp:1.5.0          /home/nonroot   yes, HOME pinned
 		//   legacy    epp-image:1.4.x           /home/nonroot   no
 		//   legacy    dynamo-frontend:1.4.x     /home/dynamo    no
+		//
+		// A DYN_EPP_MODE=standalone EPP is absent from that list on both counts:
+		// it is applied as hand-written YAML rather than rendered here, and it
+		// needs no cache anyway, since runner.rs takes the
+		// EppRouter::from_selector branch and never reaches download_config.
 		//
 		// The two native images disagree just as the legacy pair does, but the
 		// operator sets HOME itself above, so both converge on /home/dynamo and

--- a/deploy/operator/internal/dynamo/component_epp.go
+++ b/deploy/operator/internal/dynamo/component_epp.go
@@ -141,9 +141,9 @@ func (e *EPPDefaults) GetBaseContainer(context ComponentContext) (corev1.Contain
 		container.Args = []string{}
 
 		// Pin HOME rather than inheriting whatever the image sets. The native
-		// EPP's default image (frontend) uses /home/dynamo while the standalone
-		// dynamo-epp image runs as nonroot, so without this the mount below can
-		// only be right for one of them.
+		// Rust EPP's default image (frontend) uses /home/dynamo while the
+		// standalone dynamo-epp image runs as nonroot, so without this the
+		// mount below can only be right for one of them.
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  "HOME",
 			Value: nativeRustEPPHome,
@@ -154,11 +154,29 @@ func (e *EPPDefaults) GetBaseContainer(context ComponentContext) (corev1.Contain
 		// a mount that does not match is silently inert and the blobs grow on
 		// the container's writable layer instead.
 		//
-		// Native only. The legacy Go EPP reaches the same download_config
-		// through libdynamo_llm_capi, but once at startup over a fixed file set
-		// -- a few MB and a re-fetch on restart, for a component being removed.
-		// Its HOME is not derivable here either, since eppConfig selects the
-		// contract but not the image.
+		// Native Rust EPP only. Four contract/image combinations reach this
+		// renderer, and the image's own HOME differs across them:
+		//
+		//   contract  image                     image HOME      mounted
+		//   native    dynamo-frontend:1.5.0+    /home/dynamo    yes, HOME pinned
+		//   native    dynamo-epp:1.5.0          /home/nonroot   yes, HOME pinned
+		//   legacy    epp-image:1.4.x           /home/nonroot   no
+		//   legacy    dynamo-frontend:1.4.x     /home/dynamo    no
+		//
+		// The two native images disagree just as the legacy pair does, but the
+		// operator sets HOME itself above, so both converge on /home/dynamo and
+		// one mount path is right for both. The legacy rows get no such pin, and
+		// nothing available here picks between them: eppConfig names the launch
+		// contract, not the image, and the resolved runtime version only bounds
+		// it to "below 1.5.0", which both legacy images satisfy. A mount at the
+		// wrong HOME is worse than none -- nothing errors, the blobs go to the
+		// writable layer anyway, and the volume merely looks correct.
+		//
+		// Going without costs little there in any case: the legacy Go EPP does
+		// download the same files, calling the same download_config through
+		// libdynamo_llm_capi, but only once at startup over a fixed file set --
+		// so the loss is a few MB and a re-fetch on restart, on a component
+		// being removed.
 		//
 		// Withholding it re-renders existing legacy EPP Pods, so they roll once
 		// on an operator upgrade. That is a deliberate exception to the no-roll
@@ -188,7 +206,7 @@ func (e *EPPDefaults) GetBasePodSpec(context ComponentContext) (corev1.PodSpec, 
 		podSpec.Volumes = append(podSpec.Volumes, volume)
 	} else {
 		// Backs the model-config cache mounted in GetBaseContainer, which is
-		// native-only; see there for why the legacy path goes without.
+		// native Rust EPP only; see there for why the legacy path goes without.
 		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 			Name: "hf-cache",
 			VolumeSource: corev1.VolumeSource{

--- a/docs/fern/pages/reference/kubernetes-api/dynamo-component-deployment.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/dynamo-component-deployment.mdx
@@ -121,6 +121,23 @@ These fields are shared between a standalone DCD and each entry of a DGD `spec.c
   </ParamField>
 </Indent>
 
+<ParamField path="eppConfig" type="EPPConfig" deprecated={true}>
+  Deprecated: omit `eppConfig` and use the native Rust EPP, which is configured through environment variables and takes no config file. Presence of this field selects the legacy Go EPP pod contract, so existing deployments keep running across an operator upgrade until you clear it.
+
+  Only valid when `type` is `epp`, and its use is decided by the component's resolved runtime version: required below 1.5.0 (legacy Go EPP image), forbidden at 1.5.0 and later (native Rust EPP image). Migrate by clearing `eppConfig` and moving to a 1.5.0+ image in the same update. Exactly one of `configMapRef` or `config` must be set. See the [Gateway API Routing Reference](../components/gateway-api-routing.mdx).
+</ParamField>
+
+<Indent>
+  <ParamField path="configMapRef" type="core/v1.ConfigMapKeySelector">
+    References a user-provided ConfigMap key containing EPP configuration. Mutually exclusive with `config`.
+
+    <a href="https://pkg.go.dev/k8s.io/api/core/v1#ConfigMapKeySelector" target="_blank">core/v1.ConfigMapKeySelector</a>
+  </ParamField>
+  <ParamField path="config" type="EndpointPickerConfig">
+    EPP `EndpointPickerConfig` supplied inline. The operator marshals it to YAML and creates the ConfigMap for you. Mutually exclusive with `configMapRef`.
+  </ParamField>
+</Indent>
+
 <ParamField path="topologyConstraint" type="TopologyConstraint">
   Component-level topology placement. See the [SpecTopologyConstraint API](full-api-reference.mdx#spectopologyconstraint).
 </ParamField>


### PR DESCRIPTION
## Overview:

fixes [DYNO-102](https://linear.app/nvidia/issue/DYNO-102/deprecate-go-epp)
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Kubernetes discovery behavior: `container` discovery is supported in default Dynamo mode but rejected at startup in standalone mode.
  - Documented worker-readiness implications and the related follow-up guidance.
  - Added reference documentation for the deprecated EPP configuration, including runtime-version rules, migration requirements, validation constraints, and supported configuration sources.
  - Documented mutually exclusive inline configuration and ConfigMap-based configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->