### PR TITLE
chore(deps): bump velo to 0.12.0 and drop unused kvbm dev-dependencies (OPS-7544)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5333,9 +5333,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "rmp-serde",
- "rstest 0.26.1",
  "serde",
- "tempfile",
  "tmq",
  "tokio",
  "tokio-stream",
@@ -5413,8 +5411,6 @@ dependencies = [
  "parking_lot",
  "prometheus",
  "proptest",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
  "rmp-serde",
  "rstest 0.26.1",
  "serde",
@@ -5424,7 +5420,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-mutex",
- "tracing-subscriber",
  "xxhash-rust",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,43 +256,6 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86dde77d8a733a9dbaf865a9eb65c72e09c88f3d14d3dd0d2aecf511920ee4fe"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-util",
- "memchr",
- "nkeys",
- "nuid",
- "once_cell",
- "pin-project",
- "portable-atomic",
- "rand 0.8.6",
- "regex",
- "ring",
- "rustls-native-certs 0.7.3",
- "rustls-pemfile",
- "rustls-webpki 0.102.8",
- "serde",
- "serde_json",
- "serde_nanos",
- "serde_repr",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tokio-rustls 0.26.4",
- "tokio-stream",
- "tokio-util",
- "tokio-websockets",
- "tracing",
- "tryhard",
- "url",
-]
-
-[[package]]
-name = "async-nats"
 version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad3cd6df81292728e2a8cb1f1dcb4d7e7a1ab59b80c14fbbcba2baf9d5cf86a"
@@ -308,7 +271,7 @@ dependencies = [
  "rand 0.10.1",
  "regex",
  "ring",
- "rustls-native-certs 0.8.4",
+ "rustls-native-certs",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "serde",
@@ -788,7 +751,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.40",
- "rustls-native-certs 0.8.4",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -2668,7 +2631,7 @@ dependencies = [
  "approx",
  "arc-swap",
  "assert_matches",
- "async-nats 0.49.1",
+ "async-nats",
  "async-stream",
  "async-trait",
  "aws-config",
@@ -2944,7 +2907,7 @@ version = "1.5.0"
 dependencies = [
  "anyhow",
  "arc-swap",
- "async-nats 0.49.1",
+ "async-nats",
  "async-once-cell",
  "async-stream",
  "async-trait",
@@ -4556,7 +4519,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls 0.23.40",
- "rustls-native-certs 0.8.4",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -5387,7 +5350,7 @@ name = "kvbm-engine"
 version = "1.5.0"
 dependencies = [
  "anyhow",
- "async-nats 0.49.1",
+ "async-nats",
  "aws-config",
  "aws-sdk-s3",
  "bytes",
@@ -6733,12 +6696,6 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -8105,7 +8062,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.40",
- "rustls-native-certs 0.8.4",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -8464,27 +8421,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -8518,10 +8462,10 @@ dependencies = [
  "log",
  "once_cell",
  "rustls 0.23.40",
- "rustls-native-certs 0.8.4",
+ "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -8540,16 +8484,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "rustls-pki-types",
  "untrusted",
 ]
 
@@ -8752,19 +8686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]
@@ -10246,7 +10167,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "rustls-native-certs 0.8.4",
+ "rustls-native-certs",
  "socket2 0.6.4",
  "sync_wrapper 1.0.2",
  "tokio",
@@ -10903,12 +10824,12 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velo"
-version = "0.4.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e92b2164d6df7b21f2b91eaae6a9b53eb313c8f6d305a642e75733c911f8d4"
+checksum = "eceeba617fb6d080b9c91973e188e64592cca714f37bf091e74c5393436de54d"
 dependencies = [
  "anyhow",
- "async-nats 0.45.0",
+ "async-nats",
  "async-stream",
  "axum 0.8.4",
  "bs58",
@@ -10948,9 +10869,9 @@ dependencies = [
 
 [[package]]
 name = "velo-ext"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bbf99f74c0202bd1bf6caaa8bb784f461b757df7beafe734273519caf65372e"
+checksum = "57410d88c22c8e737d060a8b0a922ffba586e940be28996f187802e955dcfcb1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ kvbm-logical = { path = "lib/kvbm-logical", version = "1.5.0" }
 kvbm-physical = { path = "lib/kvbm-physical", version = "1.5.0" }
 
 # velo
-velo = { version = "0.4.1" }
+velo = { version = "0.12.0" }
 
 # External dependencies
 anyhow = { version = "1" }

--- a/lib/kvbm-consolidator/Cargo.toml
+++ b/lib/kvbm-consolidator/Cargo.toml
@@ -33,8 +33,6 @@ insta = { version = "1", features = ["yaml", "redactions"] }
 portpicker = "0.1"
 pretty_assertions = "1.4"
 proptest = "1.5"
-rstest = "0.26"
-tempfile = "3"
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber = { workspace = true }
 tracing-test = "0.2"

--- a/lib/kvbm-logical/Cargo.toml
+++ b/lib/kvbm-logical/Cargo.toml
@@ -37,8 +37,6 @@ testing = []
 [dev-dependencies]
 criterion = "0.5"
 proptest = "1.5.0"
-rand = { workspace = true }
-rand_chacha = "0.9"
 rstest = "0.26"
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
@@ -47,7 +45,6 @@ tokio = { workspace = true, features = ["full"] }
 # only under `#[cfg(test)]` because the per-acquire global-DAG cost is
 # unacceptable on production hot paths.
 tracing-mutex = { version = "0.3", features = ["parking_lot"] }
-tracing-subscriber = { workspace = true }
 
 # Criterion benchmark for the match_blocks / acquire hot path. Needs the
 # `testing` feature for src/testing/ helpers (create_test_manager, etc.).


### PR DESCRIPTION
## Summary

Two dependency-hygiene changes, one commit each. Linear: OPS-7544.

### 1. velo 0.4.1 → 0.12.0 (`dbc4b8d`)

velo 0.12.0 requires `async-nats ^0.49.1`, where 0.4.1 required `^0.45.0`. The workspace already
depends on `async-nats 0.49.1` directly, so the two copies collapse into one and `Cargo.lock` loses
five duplicate packages:

| Dropped from `Cargo.lock` | Reached through |
|---|---|
| `async-nats 0.45.0` | velo 0.4.1 |
| `rustls-webpki 0.102.8` | async-nats 0.45.0 |
| `rustls-native-certs 0.7.3` | async-nats 0.45.0 |
| `openssl-probe 0.1.6` | rustls-native-certs 0.7.3 |
| `security-framework 2.11.1` | rustls-native-certs 0.7.3 |

That was the last `rustls-webpki 0.102.x` anywhere in the repo — the three sibling lockfiles
(`lib/bindings/python`, `lib/bindings/kvbm`, `lib/runtime/examples`) already resolve only `0.103.13`.
The unrelated `rustls-webpki 0.101.7` stays; it is reached through `rustls 0.21.12` →
`aws-smithy-http-client`, a chain this PR does not touch.

No source changes are needed. Of the eight public items velo removed between 0.4.1 and 0.12.0
(`fire`, `register_outcome_async`, `VELO_STREAM_KEY`, `backpressure_count`,
`record_send_backpressure_on`, `unbind`, `with_concurrency_limit`, `VeloFrameTransport`), none is
referenced in this repo, and every velo item the kvbm crates use is still exported. The feature set
is unchanged apart from a new opt-in `ucx` feature, which stays off.

### 2. Unused kvbm dev-dependencies (`099e6ac`)

`kvbm-logical` declared `rand`, `rand_chacha` and `tracing-subscriber`; `kvbm-consolidator` declared
`rstest` and `tempfile`. None of the five is referenced by any `.rs` file in its crate — `src/`,
`tests/` and `benches/` included. `cargo machete` in the default mode CI runs does not report them;
`cargo machete --with-metadata` does. Both modes are clean after the removal.

Two things that look unused but are left in place on purpose:

- `mio` in `lib/runtime` — an exact `=1.2.2` workspace pin sitting alongside `hyper =1.7.0` and
  `hyper-util =0.1.17`, with its own `cargo-machete` ignore. It is a transitive-version floor forced
  through a direct dependency, not dead weight.
- `prost` in `lib/sidecar/vllm` and `lib/sidecar/trtllm` — referenced only from protobuf code
  generated into `OUT_DIR`, as their manifest comments state.

## Validation

velo does not build on macOS — `socket2::SockRef::set_tcp_user_timeout` is Linux/Android/Fuchsia
only and `tcp_transport.rs` calls it unguarded. This is pre-existing: 0.4.1 fails identically. So
everything below ran on Linux x86_64 in a `dynamo-runtime-test` container (cargo 1.96.1 matching
`rust-toolchain.toml`, CUDA 13, NCCL, NIXL, protoc) against this exact tree. Every cargo command
used `--locked`, so the committed `Cargo.lock` is what was resolved.

| Command | Result |
|---|---|
| `cargo check --locked --workspace --all-targets` | pass, 1m18s |
| `cargo clippy --locked --no-deps --all-targets -- -D warnings` | pass |
| `cargo test --locked -p kvbm-config -p kvbm-physical -p kvbm-engine -p kvbm-logical -p kvbm-consolidator` | 763 passed, 0 failed |
| `cargo check --locked --all-features --all-targets` (the three velo consumers) | pass |
| `cargo machete` in all four CI workspace dirs | clean |
| `pre-commit run --files <changed>` | pass |

Not covered: kvbm-engine's multi-GPU distributed tests — the validation box has a single GPU. That
is a runtime gap, not a compile gap; those targets all type-check under `--all-features
--all-targets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the workspace’s Velo dependency from version 0.4.1 to 0.12.0.
  - Removed unused development dependencies from the consolidation and logical components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->