### PR TITLE
fix(trtllm): stop gRPC serving failing to start in the TensorRT-LLM image

### DIFF
--- a/container/deps/requirements.trtllm.txt
+++ b/container/deps/requirements.trtllm.txt
@@ -48,6 +48,15 @@ pillow>=12.3.0
 # /opt/dynamo/venv copy; trtllm_runtime.Dockerfile raises the system one to the
 # same floor. Keep the two specifiers in step.
 PyNvVideoCodec>=2.2.0
+# Python stubs for TensorRT-LLM's native gRPC service (tensorrt_llm.grpc), which
+# the trtllm sidecar talks to. Stands in for the tensorrt_llm[grpc-smg] extra:
+# 1.3.0rc25 moved this package behind that extra, so the base image stopped
+# bundling it and `tensorrt_llm.commands.serve <model> --grpc` now fails its
+# find_spec("smg_grpc_proto") guard. Naming the one package the extra pulls in,
+# rather than requesting the extra, keeps a resolver from reinstalling the
+# multi-gigabyte tensorrt_llm wheel over the base image's own build. Floor
+# matches the protocol revision vendored under lib/sidecar/trtllm/proto/.
+smg-grpc-proto>=0.4.14
 soupsieve>=2.8.4  # JupyterLab stack; see note above jupyter-server
 tornado>=6.5.6  # JupyterLab stack; see note above jupyter-server
 # Required by ai_dynamo_runtime (companion to msgspec above).

--- a/container/deps/requirements.trtllm.txt
+++ b/container/deps/requirements.trtllm.txt
@@ -48,14 +48,8 @@ pillow>=12.3.0
 # /opt/dynamo/venv copy; trtllm_runtime.Dockerfile raises the system one to the
 # same floor. Keep the two specifiers in step.
 PyNvVideoCodec>=2.2.0
-# Python stubs for TensorRT-LLM's native gRPC service (tensorrt_llm.grpc), which
-# the trtllm sidecar talks to. Stands in for the tensorrt_llm[grpc-smg] extra:
-# 1.3.0rc25 moved this package behind that extra, so the base image stopped
-# bundling it and `tensorrt_llm.commands.serve <model> --grpc` now fails its
-# find_spec("smg_grpc_proto") guard. Naming the one package the extra pulls in,
-# rather than requesting the extra, keeps a resolver from reinstalling the
-# multi-gigabyte tensorrt_llm wheel over the base image's own build. Floor
-# matches the protocol revision vendored under lib/sidecar/trtllm/proto/.
+# gRPC stubs for the trtllm sidecar; the tensorrt_llm[grpc-smg] extra would
+# reinstall the tensorrt_llm wheel. Floor matches lib/sidecar/trtllm/proto/.
 smg-grpc-proto>=0.4.14
 soupsieve>=2.8.4  # JupyterLab stack; see note above jupyter-server
 tornado>=6.5.6  # JupyterLab stack; see note above jupyter-server

--- a/lib/sidecar/trtllm/README.md
+++ b/lib/sidecar/trtllm/README.md
@@ -34,10 +34,11 @@ carries no context-phase handoff.
 
 ## Run
 
-The engine image has to meet the requirements noted under
-[Deploy on Kubernetes](#deploy-on-kubernetes-quick-start) below: `--grpc` needs
-`smg-grpc-proto` installed and matched to the image's `protobuf` runtime. Start
-TensorRT-LLM with its native gRPC listener:
+`--grpc` needs `smg-grpc-proto>=0.4.14` installed in the engine image, and that
+package's generated stubs have to load against the image's own `protobuf`
+runtime. See [Deploy on Kubernetes](#deploy-on-kubernetes-quick-start) below for
+which TensorRT-LLM releases bundle the package and how the two versions
+interact. Start TensorRT-LLM with its native gRPC listener:
 
 ```bash
 python -m tensorrt_llm.commands.serve <model> --grpc --host 127.0.0.1 --port 50051

--- a/lib/sidecar/trtllm/README.md
+++ b/lib/sidecar/trtllm/README.md
@@ -40,12 +40,12 @@ The engine image has to meet the requirements noted under
 TensorRT-LLM with its native gRPC listener:
 
 ```bash
-python -m tensorrt_llm.commands.serve <model> --grpc --host 0.0.0.0 --port 50051
+python -m tensorrt_llm.commands.serve <model> --grpc --host 127.0.0.1 --port 50051
 ```
 
-This listener is unauthenticated and plaintext. Keep colocated deployments on
-loopback or a private interface. Remote access requires network controls or a
-secure proxy.
+This listener is unauthenticated and plaintext, so the command binds it to
+loopback, which is all a colocated sidecar needs. Widening the bind address is an
+explicit opt-in and requires network controls or a secure proxy in front of it.
 
 Start the Dynamo worker:
 

--- a/lib/sidecar/trtllm/README.md
+++ b/lib/sidecar/trtllm/README.md
@@ -34,7 +34,10 @@ carries no context-phase handoff.
 
 ## Run
 
-Start TensorRT-LLM with its native gRPC listener (TRT-LLM `1.3.0rc21`; rc22 has a broken `--grpc`):
+The engine image has to meet the requirements noted under
+[Deploy on Kubernetes](#deploy-on-kubernetes-quick-start) below: `--grpc` needs
+`smg-grpc-proto` installed and matched to the image's `protobuf` runtime. Start
+TensorRT-LLM with its native gRPC listener:
 
 ```bash
 python -m tensorrt_llm.commands.serve <model> --grpc --host 0.0.0.0 --port 50051
@@ -72,6 +75,17 @@ There is no published sidecar image yet (see [Packaging](#packaging)), so build
 and push the image from `lib/sidecar/Dockerfile`. It contains all three
 engine-specific sidecar executables; this manifest runs `dynamo-trtllm-sidecar`
 as the container command.
+
+> [!NOTE]
+> The engine image must carry `smg-grpc-proto`, the package the
+> `tensorrt_llm[grpc-smg]` extra installs. TensorRT-LLM `1.3.0rc25` moved it
+> behind that extra, and without it `serve --grpc` exits with a `ValueError`
+> naming the extra. Releases through `1.3.0rc24` — including the
+> `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc21` image this example runs —
+> bundle it already. The installed `smg-grpc-proto` must also match the image's
+> `protobuf` runtime, or loading `trtllm_service.proto` fails with a
+> gencode/runtime `VersionError`; that mismatch is what breaks `--grpc` on
+> `1.3.0rc22`.
 
 ### Prerequisites
 


### PR DESCRIPTION
## Overview:

TensorRT-LLM `1.3.0rc25` moved `smg-grpc-proto` behind a new `tensorrt_llm[grpc-smg]` extra, so the base image stopped bundling it. `container/context.yaml` pins `runtime_image_tag: 1.3.0rc25`, so inside the Dynamo TensorRT-LLM runtime image `python3 -m tensorrt_llm.commands.serve <model> --grpc` now stops at the engine's `find_spec("smg_grpc_proto")` guard and raises a `ValueError` naming the extra. The gRPC listener that the TensorRT-LLM sidecar connects to cannot start.

## Details:

`container/deps/requirements.trtllm.txt` gains one entry, `smg-grpc-proto>=0.4.14`. That file is installed into `/opt/dynamo/venv` with `uv pip install --no-deps`, so requesting the extra itself would reinstall the multi-gigabyte `tensorrt_llm` wheel over the base image's own build while still installing none of the extra's dependencies. Naming the single package the extra provides is the form that works on this install path. The floor is `0.4.14` because `lib/sidecar/trtllm/proto/README.md` records that as the revision of the vendored `trtllm_service.proto`, which keeps the Python stubs the engine imports and the contract the Rust sidecar compiles on one protocol revision.

`lib/sidecar/trtllm/README.md` records the requirement in a note before `### Prerequisites`, in the same place and form as the note in `lib/sidecar/sglang/README.md`, and warns that the installed `smg-grpc-proto` must also match the image's `protobuf` runtime. The `## Run` section names `smg-grpc-proto>=0.4.14` and that runtime constraint where the `--grpc` command is, and links to the Kubernetes section for which TensorRT-LLM releases bundle the package.

The quick-start command in that README binds the engine's gRPC listener to `127.0.0.1`, matching `lib/sidecar/trtllm/launch/agg.sh` and `lib/sidecar/trtllm/deploy/agg.yaml`. The listener is unauthenticated and plaintext and the sidecar reaches it on `127.0.0.1:50051`, so loopback is all a colocated deployment needs; a wider bind address is described as an explicit opt-in that requires network controls or a secure proxy.

## Where should the reviewer start?

`container/deps/requirements.trtllm.txt` — the single added entry and its comment.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated TensorRT-LLM setup instructions with the required gRPC integration and compatible protobuf versions.
  - Clarified listener binding options and documented unauthenticated plaintext exposure.
  - Added Kubernetes deployment guidance, supported TensorRT-LLM version requirements, and common setup errors.

- **Improvements**
  - Improved sidecar setup compatibility by enabling the required gRPC integration without reinstalling the TensorRT-LLM package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->