### PR TITLE
fix(vllm): stop the attention-DP benchmark from killing a rank on dense models

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -171,10 +171,11 @@ def _is_moe_model(vllm_config: "VllmConfig") -> bool:
     vLLM itself branches on when it decides whether DP ranks form one
     coordinated group. ``ParallelConfig.is_moe_model`` is a copy of it and
     serves as the fallback for engine versions that do not expose the
-    ``ModelConfig`` property.
+    ``ModelConfig`` property, and for the configurations in which
+    ``VllmConfig.model_config`` is ``None``.
     """
-    model_config = getattr(vllm_config, "model_config", None)
-    is_moe = getattr(model_config, "is_moe", None)
+    model_config = vllm_config.model_config
+    is_moe = None if model_config is None else getattr(model_config, "is_moe", None)
     if is_moe is None:
         is_moe = getattr(vllm_config.parallel_config, "is_moe_model", False)
     return bool(is_moe)
@@ -202,8 +203,7 @@ def validate_benchmark_data_parallelism(
     if benchmark_mode is None:
         return
 
-    parallel_config = getattr(vllm_config, "parallel_config", None)
-    data_parallel_size = getattr(parallel_config, "data_parallel_size", 1) or 1
+    data_parallel_size = vllm_config.parallel_config.data_parallel_size or 1
     if data_parallel_size <= 1:
         return
 

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -164,6 +164,63 @@ class BenchmarkConfig:
     collect_imbalanced: bool = False
 
 
+def _is_moe_model(vllm_config: "VllmConfig") -> bool:
+    """Whether the engine resolved this model as a mixture-of-experts model.
+
+    Read from the resolved ``ModelConfig`` because that is the same property
+    vLLM itself branches on when it decides whether DP ranks form one
+    coordinated group. ``ParallelConfig.is_moe_model`` is a copy of it and
+    serves as the fallback for engine versions that do not expose the
+    ``ModelConfig`` property.
+    """
+    model_config = getattr(vllm_config, "model_config", None)
+    is_moe = getattr(model_config, "is_moe", None)
+    if is_moe is None:
+        is_moe = getattr(vllm_config.parallel_config, "is_moe_model", False)
+    return bool(is_moe)
+
+
+def validate_benchmark_data_parallelism(
+    vllm_config: "VllmConfig", benchmark_mode: BenchmarkMode | None
+) -> None:
+    """Reject the attention-DP self-benchmark on a dense (non-MoE) model.
+
+    vLLM keeps data-parallel ranks in one coordinated group only for MoE
+    models (``vllm/v1/engine/core.py``: ``if data_parallel and
+    vllm_config.model_config.is_moe``). Every dense DP child takes the other
+    branch, which rewrites ``data_parallel_size`` to ``1`` and leaves the true
+    rank in ``data_parallel_index``. The benchmark then builds no cross-rank
+    synchronizer, so rank 0 expects results from ``[0]`` while rank 1 reports
+    ``[1]`` and dies partway through the sweep with
+    "attention-DP benchmark result ranks do not match".
+
+    This must run in the parent process, against the requested
+    ``--data-parallel-size`` and before the engine is constructed: by the time
+    a dense DP child is alive the model is loaded and the size it would read
+    has already been rewritten to ``1``.
+    """
+    if benchmark_mode is None:
+        return
+
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    data_parallel_size = getattr(parallel_config, "data_parallel_size", 1) or 1
+    if data_parallel_size <= 1:
+        return
+
+    if _is_moe_model(vllm_config):
+        return
+
+    raise ValueError(
+        "--benchmark-mode cannot be combined with --data-parallel-size "
+        f"{data_parallel_size} on a dense (non-MoE) model. The attention-DP "
+        "self-benchmark requires an MoE model, because vLLM runs data-parallel "
+        "ranks as one coordinated group only for MoE models; on a dense model "
+        "each rank is an independent engine and the cross-rank benchmark "
+        "cannot complete. Either run the benchmark with "
+        "--data-parallel-size 1, or benchmark an MoE model."
+    )
+
+
 def _bench_point_is_imbalanced(candidate: PrefillPointCandidate) -> bool:
     """Whether this point spreads work unevenly across the batch.
 

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -186,19 +186,10 @@ def validate_benchmark_data_parallelism(
 ) -> None:
     """Reject the attention-DP self-benchmark on a dense (non-MoE) model.
 
-    vLLM keeps data-parallel ranks in one coordinated group only for MoE
-    models (``vllm/v1/engine/core.py``: ``if data_parallel and
-    vllm_config.model_config.is_moe``). Every dense DP child takes the other
-    branch, which rewrites ``data_parallel_size`` to ``1`` and leaves the true
-    rank in ``data_parallel_index``. The benchmark then builds no cross-rank
-    synchronizer, so rank 0 expects results from ``[0]`` while rank 1 reports
-    ``[1]`` and dies partway through the sweep with
-    "attention-DP benchmark result ranks do not match".
-
-    This must run in the parent process, against the requested
-    ``--data-parallel-size`` and before the engine is constructed: by the time
-    a dense DP child is alive the model is loaded and the size it would read
-    has already been rewritten to ``1``.
+    Call this in the parent process and before the engine is constructed. A
+    dense DP child is not part of a coordinated group and rewrites its local
+    ``data_parallel_size`` to ``1``, so by the time one is alive the requested
+    size is no longer readable and the model is already loaded.
     """
     if benchmark_mode is None:
         return

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -72,7 +72,11 @@ from .embedding_worker_processes import (
 from .engine_generate import publish_engine_generate_capability
 from .handlers import apply_data_parallel_runtime_config
 from .headless import run_dynamo_headless
-from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
+from .instrumented_scheduler import (
+    ENV_FPM_BENCHMARK_OUTPUT_PATH,
+    ENV_FPM_WORKER_ID,
+    validate_benchmark_data_parallelism,
+)
 from .kv_connector_protocols import (
     disable_hybrid_kv_cache_manager_for_incompatible_pd_connector,
 )
@@ -672,6 +676,11 @@ def setup_vllm_engine(
     usage_context = UsageContext.OPENAI_API_SERVER
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
     disable_hybrid_kv_cache_manager_for_incompatible_pd_connector(vllm_config)
+    # Must stay ahead of engine construction: this is the first point where
+    # ``model_config.is_moe`` is resolved and the last point before weights
+    # load, and it is the only process that still sees the requested
+    # --data-parallel-size (a dense DP child reads it back as 1).
+    validate_benchmark_data_parallelism(vllm_config, config.benchmark_mode)
     default_sampling_params = vllm_config.model_config.get_diff_sampling_param()
 
     # Set up consolidator endpoints if KVBM (DynamoConnector) is enabled

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -676,10 +676,8 @@ def setup_vllm_engine(
     usage_context = UsageContext.OPENAI_API_SERVER
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
     disable_hybrid_kv_cache_manager_for_incompatible_pd_connector(vllm_config)
-    # Must stay ahead of engine construction: this is the first point where
-    # ``model_config.is_moe`` is resolved and the last point before weights
-    # load, and it is the only process that still sees the requested
-    # --data-parallel-size (a dense DP child reads it back as 1).
+    # Must run before engine construction: weights load past this point, and a
+    # dense DP child reads --data-parallel-size back as 1.
     validate_benchmark_data_parallelism(vllm_config, config.benchmark_mode)
     default_sampling_params = vllm_config.model_config.get_diff_sampling_param()
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -1264,10 +1264,8 @@ class TestBenchmarkDataParallelismRejection:
         assert "--benchmark-mode" in message
         assert "--data-parallel-size" in message
         assert "MoE" in message
-        # The load-bearing assertion: the rejection has to land before
-        # AsyncLLM.from_vllm_config, which is where weights start loading.
-        # Rejecting after it would still raise ValueError and still leave a
-        # dead rank behind, so the message alone proves nothing.
+        # Load-bearing: a guard running after AsyncLLM.from_vllm_config would
+        # still raise, so the message alone proves nothing about ordering.
         assert engines_built == []
 
     def test_moe_dp_benchmark_still_builds_an_engine(self, monkeypatch):

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -624,6 +624,7 @@ def test_setup_vllm_engine_reuses_engine_config_model_config(monkeypatch):
     )
 
     config = SimpleNamespace(
+        benchmark_mode=None,
         component="backend",
         namespace="dynamo",
         engine_args=FakeEngineArgs(),
@@ -1142,6 +1143,168 @@ class TestBenchmarkConfig:
         )
 
         assert parse_args().benchmark_mode == "prefill"
+
+
+def _make_benchmark_vllm_config(*, is_moe: bool, data_parallel_size: int):
+    """A resolved-engine-config stand-in with only what setup_vllm_engine reads."""
+    return SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            data_parallel_size=data_parallel_size,
+            is_moe_model=is_moe,
+        ),
+        model_config=SimpleNamespace(
+            is_moe=is_moe,
+            get_diff_sampling_param=lambda: {},
+        ),
+        additional_config={},
+        cache_config=SimpleNamespace(block_size=None),
+        kv_transfer_config=None,
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+    )
+
+
+class _RecordingEngineArgs:
+    """AsyncEngineArgs stand-in that hands back a pre-built engine config."""
+
+    enable_lora = False
+    load_format = "auto"
+    enable_log_requests = False
+    disable_log_stats = True
+
+    def __init__(self, vllm_config):
+        self._vllm_config = vllm_config
+
+    def create_engine_config(self, usage_context=None):
+        return self._vllm_config
+
+
+class TestBenchmarkDataParallelismRejection:
+    """--benchmark-mode with --data-parallel-size > 1 is MoE-only.
+
+    Every case drives the real ``setup_vllm_engine`` with engine construction
+    replaced by a recorder, so the assertions are about whether an engine got
+    built -- which is what "rejected before model loading" means -- rather than
+    about the shape of the guard.
+    """
+
+    def _run_setup(
+        self,
+        monkeypatch,
+        engines_built,
+        *,
+        is_moe,
+        data_parallel_size,
+        benchmark_mode,
+    ):
+        """Call setup_vllm_engine, appending one entry per engine construction.
+
+        ``engines_built`` is supplied by the caller rather than returned so the
+        rejection test can still read it after setup_vllm_engine raises.
+        """
+        vllm_main = _load_vllm_main()
+        vllm_config = _make_benchmark_vllm_config(
+            is_moe=is_moe, data_parallel_size=data_parallel_size
+        )
+        config = SimpleNamespace(
+            engine_args=_RecordingEngineArgs(vllm_config),
+            served_model_name="test-model",
+            component="backend",
+            namespace="dynamo",
+            route_to_encoder=False,
+            multimodal_embedding_cache_capacity_gb=None,
+            benchmark_mode=benchmark_mode,
+            embedding_worker=False,
+            embedding_worker_processes=1,
+            gms_shadow_mode=False,
+        )
+        if benchmark_mode is not None:
+            config._benchmark_additional_config = {
+                "mode": benchmark_mode,
+                "output_path": "/tmp/benchmark_results.json",
+            }
+
+        class RecordingAsyncLLM:
+            @staticmethod
+            def from_vllm_config(**kwargs):
+                engines_built.append(kwargs)
+                return SimpleNamespace()
+
+        monkeypatch.setattr(vllm_main, "AsyncLLM", RecordingAsyncLLM)
+        monkeypatch.setattr(
+            vllm_main, "get_engine_cache_info", lambda _client: {"block_size": 16}
+        )
+        monkeypatch.setattr(
+            vllm_main,
+            "configure_multimodal_embedding_cache",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(vllm_main, "_uses_dynamo_connector", lambda _args: False)
+        monkeypatch.setattr(
+            vllm_main,
+            "LLMBackendMetrics",
+            lambda **kwargs: SimpleNamespace(set_model_load_time=lambda _t: None),
+        )
+
+        vllm_main.setup_vllm_engine(config)
+
+    def test_dense_dp_benchmark_is_rejected_before_any_engine_is_built(
+        self, monkeypatch
+    ):
+        engines_built: list[dict] = []
+        with pytest.raises(ValueError) as excinfo:
+            self._run_setup(
+                monkeypatch,
+                engines_built,
+                is_moe=False,
+                data_parallel_size=2,
+                benchmark_mode="agg",
+            )
+
+        message = str(excinfo.value)
+        assert "--benchmark-mode" in message
+        assert "--data-parallel-size" in message
+        assert "MoE" in message
+        # The load-bearing assertion: the rejection has to land before
+        # AsyncLLM.from_vllm_config, which is where weights start loading.
+        # Rejecting after it would still raise ValueError and still leave a
+        # dead rank behind, so the message alone proves nothing.
+        assert engines_built == []
+
+    def test_moe_dp_benchmark_still_builds_an_engine(self, monkeypatch):
+        engines_built: list[dict] = []
+        self._run_setup(
+            monkeypatch,
+            engines_built,
+            is_moe=True,
+            data_parallel_size=2,
+            benchmark_mode="agg",
+        )
+
+        assert len(engines_built) == 1
+
+    def test_dense_benchmark_without_dp_still_builds_an_engine(self, monkeypatch):
+        engines_built: list[dict] = []
+        self._run_setup(
+            monkeypatch,
+            engines_built,
+            is_moe=False,
+            data_parallel_size=1,
+            benchmark_mode="agg",
+        )
+
+        assert len(engines_built) == 1
+
+    def test_dense_dp_without_benchmark_mode_still_builds_an_engine(self, monkeypatch):
+        engines_built: list[dict] = []
+        self._run_setup(
+            monkeypatch,
+            engines_built,
+            is_moe=False,
+            data_parallel_size=2,
+            benchmark_mode=None,
+        )
+
+        assert len(engines_built) == 1
 
 
 class TestBenchmarkGrid:

--- a/docs/fern/pages/reference/backends/vllm-configuration.mdx
+++ b/docs/fern/pages/reference/backends/vllm-configuration.mdx
@@ -306,6 +306,7 @@ With `--benchmark-mode` set and no points file, passing a legacy flag together w
 ## Validation rules
 
 - `--embedding-worker` is only valid with `--disaggregation-mode=agg` (or the default aggregated mode) and cannot be combined with `--enable-multimodal` or `--benchmark-mode`.
+- `--benchmark-mode` cannot be combined with `--data-parallel-size` greater than `1` unless the model is a mixture-of-experts (MoE) model. The attention-DP self-benchmark needs the data-parallel ranks to run as one coordinated group, which vLLM does only for MoE models; the worker rejects this combination at startup, before it loads the model.
 
 ## Related pages
 


### PR DESCRIPTION
## Overview:

Starting the vLLM backend with `--benchmark-mode` and `--data-parallel-size` greater than `1` on a dense (non-MoE) model loads the model on every GPU, begins the prefill sweep, and then kills rank 1 with `attention-DP benchmark result ranks do not match: expected=[0] actual=[1]`. Dense-model attention-DP benchmarking is not a supported configuration, so the worker now refuses it at startup, before any weights load.

## Details:

vLLM runs data-parallel ranks as one coordinated group only for mixture-of-experts models: `run_engine_core` in `vllm/v1/engine/core.py` branches on `model_config.is_moe`. A dense model takes the other branch, which rewrites `data_parallel_size` to `1` and leaves the true rank in `data_parallel_index`. The benchmark therefore builds no cross-rank synchronizer, and rank 0 waits for results from `[0]` while rank 1 reports `[1]`.

`validate_benchmark_data_parallelism` in `components/src/dynamo/vllm/instrumented_scheduler.py` raises a `ValueError` naming both flags and the MoE requirement. `setup_vllm_engine` calls it once the engine config is resolved and before `AsyncLLM.from_vllm_config(...)` — the only window where `model_config.is_moe` is known and the requested `--data-parallel-size` is still visible, since a dense DP child reads it back as `1`. MoE data parallelism, `--data-parallel-size 1`, and dense data parallelism without the benchmark are all unchanged; one test covers each and asserts an engine is still built.

## Where should the reviewer start?

`components/src/dynamo/vllm/main.py` for the call site and why its position matters, then `validate_benchmark_data_parallelism` in `components/src/dynamo/vllm/instrumented_scheduler.py` and `TestBenchmarkDataParallelismRejection` in `components/src/dynamo/vllm/tests/test_vllm_unit.py`.

## Summary

Rejects `--benchmark-mode` combined with `--data-parallel-size` greater than `1` on dense models at startup, with a `ValueError`, instead of failing partway through the prefill sweep after a full model load. Adds four unit tests and one bullet to `docs/fern/pages/reference/backends/vllm-configuration.mdx`.

## Validation

`python -m pytest components/src/dynamo/vllm/tests/test_vllm_unit.py components/src/dynamo/vllm/tests/test_backend_args.py -m 'unit and not gpu'` passes, and the new rejection test fails with `DID NOT RAISE <class 'ValueError'>` when the two source files are reverted, so it is load-bearing. `pre-commit run --files <the four changed files>` passes. A live single-GPU worker start was attempted but could not run on the machine used: its NVIDIA driver supports CUDA `12.8`, while the installed `torch 2.11.0+cu130` and vLLM `0.26.0` require CUDA `13.0`, so the engine cannot initialize the device. Please confirm on suitable hardware that a dense `--data-parallel-size 2 --benchmark-mode agg` start exits with the new error before any weight load, and that the MoE equivalent still starts.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added startup validation for incompatible benchmark configurations.
  - Dense models using benchmark mode with data parallelism greater than one are now rejected before model loading, with a clear error message.
  - MoE models, single-rank configurations, and data-parallel configurations without benchmark mode continue to work.

- **Documentation**
  - Documented the benchmark and data-parallel compatibility rule for vLLM configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->