### PR TITLE
fix(sglang): stop every sidecar inference request failing with HTTP 500

### DIFF
--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -61,10 +61,17 @@ logger = logging.getLogger(__name__)
 try:
     from sglang.srt.utils.server_args_config_parser import ConfigArgumentMerger
 except ModuleNotFoundError as exc:
-    if exc.name != "sglang.srt.utils.server_args_config_parser":
+    if exc.name == "sglang.srt.utils.server_args_config_parser":
+        # Keep the CUDA 0.5.18 and XPU 0.5.11 pins working until both move here.
+        from sglang.srt.server_args_config_parser import ConfigArgumentMerger
+    elif exc.name == "sglang" or (exc.name or "").startswith("sglang."):
+        # SGLang is not installed at all. Every other SGLang import in this
+        # module already degrades to None, so match that instead of making the
+        # whole module unimportable: ensure_sglang_grpc_bridge_batch_size() has
+        # a SGLang-free code path that callers and tests exercise directly.
+        ConfigArgumentMerger = None  # type: ignore[assignment,misc]
+    else:
         raise
-    # Keep the CUDA 0.5.18 and XPU 0.5.11 pins working until both move here.
-    from sglang.srt.server_args_config_parser import ConfigArgumentMerger
 
 
 def get_sglang_model_config(server_args: Any) -> Any:
@@ -147,6 +154,90 @@ def ensure_sglang_tensor_image_size() -> None:
 
     resolve_image_token_counts._dynamo_tensor_image_size_support = True  # type: ignore[attr-defined]
     BaseMultimodalProcessor.resolve_image_token_counts = resolve_image_token_counts
+
+
+def _already_normalized() -> None:
+    """Stand in for a request's normalizer once the shim has already run it."""
+
+
+def _normalize_generate_request_once(obj: Any) -> None:
+    """Run SGLang's request normalization exactly once for this request object.
+
+    ``TokenizerManager.generate_request`` calls ``normalize_batch_and_arguments()``
+    unconditionally, and that call is not idempotent: for parallel sampling a
+    second pass re-derives the batch size from the already-expanded input list
+    and expands it again, turning ``n`` sequences into ``n * n``. Normalizing
+    early is therefore only safe if SGLang's own later call is neutralized.
+    """
+    if hasattr(obj, "batch_size"):
+        # Either SGLang normalized already or this release assigns batch_size
+        # itself. Nothing to do, and re-normalizing here would be the very
+        # double expansion described above.
+        return
+
+    normalize = getattr(obj, "normalize_batch_and_arguments", None)
+    if normalize is None:
+        return
+
+    try:
+        normalize()
+    except Exception:
+        # Leave the failure to SGLang. generate_request() normalizes again
+        # inside the generator body, where the bridge's own exception handler
+        # turns the error into a client-visible message. Do not neutralize.
+        logger.debug("Early SGLang request normalization failed", exc_info=True)
+        return
+
+    obj.normalize_batch_and_arguments = _already_normalized
+
+
+def ensure_sglang_grpc_bridge_batch_size(bridge_class: Any = None) -> None:
+    """Normalize gRPC generate requests before SGLang reads their batch size.
+
+    SGLang 0.5.17 and 0.5.18 read ``obj.batch_size`` in the streaming branch of
+    the native gRPC bridge's ``_run_generate``, one statement after calling
+    ``TokenizerManager.generate_request``. That call only builds an async
+    generator, so its body -- and with it the ``normalize_batch_and_arguments()``
+    call that assigns ``batch_size`` -- has not run yet. Every streaming request
+    over the native gRPC server therefore fails with ``'GenerateReqInput' object
+    has no attribute 'batch_size'``, which the sidecar surfaces as HTTP 500.
+    Normalizing first restores the ordering the upstream code assumes.
+
+    This only affects engines launched through ``dynamo.sglang.launch_server``.
+    A stock engine that does not need the shim must still start, so an absent
+    or already-fixed bridge is logged at debug level and left alone.
+
+    ``bridge_class`` patches an explicit class instead of importing SGLang's;
+    tests use it to exercise the wrapper without SGLang installed.
+
+    Remove this override once the minimum supported SGLang release normalizes
+    before reading ``batch_size`` -- that is, once both 0.5.17 and 0.5.18 fall
+    outside the support window.
+    """
+    if bridge_class is None:
+        try:
+            from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
+        except ImportError:
+            logger.debug(
+                "SGLang does not expose a native gRPC bridge; "
+                "skipping the batch_size normalization override"
+            )
+            return
+        bridge_class = RuntimeHandle
+
+    original = getattr(bridge_class, "_run_generate", None)
+    if original is None or getattr(
+        original, "_dynamo_grpc_bridge_batch_size_support", False
+    ):
+        return
+
+    @wraps(original)
+    async def _run_generate(self: Any, obj: Any, *args: Any, **kwargs: Any) -> Any:
+        _normalize_generate_request_once(obj)
+        return await original(self, obj, *args, **kwargs)
+
+    _run_generate._dynamo_grpc_bridge_batch_size_support = True  # type: ignore[attr-defined]
+    bridge_class._run_generate = _run_generate
 
 
 def override_server_args(server_args: Any, source: str, **fields: Any) -> None:
@@ -267,6 +358,7 @@ def require_reasoning_kwargs(engine: Any, request: Mapping[str, Any]) -> dict[st
 
 __all__ = [
     "ConfigArgumentMerger",
+    "ensure_sglang_grpc_bridge_batch_size",
     "ensure_sglang_tensor_image_size",
     "filter_supported_async_generate_kwargs",
     "get_sglang_model_config",

--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -179,12 +179,35 @@ def _normalize_generate_request_once(obj: Any) -> None:
     try:
         normalize()
     except Exception:
-        # Leave the failure to SGLang: generate_request() normalizes again in the
-        # generator body and surfaces the error there, so do not neutralize it.
+        # A rejected request keeps whatever the failed pass already changed:
+        # normalization assigns batch_size and expands parallel-sampling inputs
+        # before the validation that rejects it. Handing that partial state to
+        # the bridge would let SGLang normalize the same object again and
+        # re-derive the batch size from the expanded list -- the n * n expansion
+        # this shim exists to prevent -- so surface the error here instead.
         logger.debug("Early SGLang request normalization failed", exc_info=True)
-        return
+        raise
 
     obj.normalize_batch_and_arguments = _already_normalized
+
+
+_GRPC_BRIDGE_MODULE = "sglang.srt.entrypoints.grpc_bridge"
+
+
+def _is_absent_grpc_bridge(exc: ImportError) -> bool:
+    """Report whether an import failure means the native gRPC bridge is absent.
+
+    A release that does not ship the bridge, and one that renamed
+    ``RuntimeHandle``, both name the bridge module in ``exc.name``; an
+    environment without SGLang at all names one of its parent packages. Any
+    other name -- a dependency the bridge itself imports -- means the bridge is
+    present but failed to load, which is a broken install rather than a release
+    that does not need the override.
+    """
+    name = getattr(exc, "name", None)
+    if not name:
+        return False
+    return name == _GRPC_BRIDGE_MODULE or _GRPC_BRIDGE_MODULE.startswith(f"{name}.")
 
 
 def ensure_sglang_grpc_bridge_batch_size(bridge_class: Any = None) -> None:
@@ -201,7 +224,9 @@ def ensure_sglang_grpc_bridge_batch_size(bridge_class: Any = None) -> None:
 
     This only affects engines launched through ``dynamo.sglang.launch_server``.
     A stock engine that does not need the shim must still start, so an absent
-    or already-fixed bridge is logged at debug level and left alone.
+    or already-fixed bridge is logged at debug level and left alone. An SGLang
+    that is installed but fails to import raises: that is a broken environment,
+    not a release outside the support window.
 
     ``bridge_class`` patches an explicit class instead of importing SGLang's;
     tests use it to exercise the wrapper without SGLang installed.
@@ -213,7 +238,9 @@ def ensure_sglang_grpc_bridge_batch_size(bridge_class: Any = None) -> None:
     if bridge_class is None:
         try:
             from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
-        except ImportError:
+        except ImportError as exc:
+            if not _is_absent_grpc_bridge(exc):
+                raise
             logger.debug(
                 "SGLang does not expose a native gRPC bridge; "
                 "skipping the batch_size normalization override"

--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -65,10 +65,8 @@ except ModuleNotFoundError as exc:
         # Keep the CUDA 0.5.18 and XPU 0.5.11 pins working until both move here.
         from sglang.srt.server_args_config_parser import ConfigArgumentMerger
     elif exc.name == "sglang" or (exc.name or "").startswith("sglang."):
-        # SGLang is not installed at all. Every other SGLang import in this
-        # module already degrades to None, so match that instead of making the
-        # whole module unimportable: ensure_sglang_grpc_bridge_batch_size() has
-        # a SGLang-free code path that callers and tests exercise directly.
+        # SGLang absent entirely: degrade to None like every other SGLang import
+        # here, so this module's SGLang-free code paths stay importable.
         ConfigArgumentMerger = None  # type: ignore[assignment,misc]
     else:
         raise
@@ -170,9 +168,8 @@ def _normalize_generate_request_once(obj: Any) -> None:
     early is therefore only safe if SGLang's own later call is neutralized.
     """
     if hasattr(obj, "batch_size"):
-        # Either SGLang normalized already or this release assigns batch_size
-        # itself. Nothing to do, and re-normalizing here would be the very
-        # double expansion described above.
+        # Already normalized, or this release assigns batch_size itself.
+        # Re-normalizing here would cause the double expansion described above.
         return
 
     normalize = getattr(obj, "normalize_batch_and_arguments", None)
@@ -182,9 +179,8 @@ def _normalize_generate_request_once(obj: Any) -> None:
     try:
         normalize()
     except Exception:
-        # Leave the failure to SGLang. generate_request() normalizes again
-        # inside the generator body, where the bridge's own exception handler
-        # turns the error into a client-visible message. Do not neutralize.
+        # Leave the failure to SGLang: generate_request() normalizes again in the
+        # generator body and surfaces the error there, so do not neutralize it.
         logger.debug("Early SGLang request normalization failed", exc_info=True)
         return
 

--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -176,19 +176,29 @@ def _normalize_generate_request_once(obj: Any) -> None:
     if normalize is None:
         return
 
-    try:
-        normalize()
-    except Exception:
-        # A rejected request keeps whatever the failed pass already changed:
-        # normalization assigns batch_size and expands parallel-sampling inputs
-        # before the validation that rejects it. Handing that partial state to
-        # the bridge would let SGLang normalize the same object again and
-        # re-derive the batch size from the expanded list -- the n * n expansion
-        # this shim exists to prevent -- so surface the error here instead.
-        logger.debug("Early SGLang request normalization failed", exc_info=True)
-        raise
+    # A failed pass has already mutated the request, so let the error propagate
+    # rather than leave SGLang to normalize that partial state a second time.
+    normalize()
 
     obj.normalize_batch_and_arguments = _already_normalized
+
+
+def _report_rejected_request(
+    bridge: Any, exc: Exception, args: Any, kwargs: Any
+) -> bool:
+    """Answer a rejected request through the bridge's native error callback.
+
+    Reports ``False`` when the release exposes no way to do so, leaving the
+    caller to raise: worse for the client, which then waits out its deadline,
+    but the only remaining way to make the failure visible at all.
+    """
+    send_native_error = getattr(bridge, "_send_native_error", None)
+    chunk_callback = args[0] if args else kwargs.get("chunk_callback")
+    if send_native_error is None or chunk_callback is None:
+        return False
+
+    send_native_error(chunk_callback, str(exc))
+    return True
 
 
 _GRPC_BRIDGE_MODULE = "sglang.srt.entrypoints.grpc_bridge"
@@ -256,7 +266,22 @@ def ensure_sglang_grpc_bridge_batch_size(bridge_class: Any = None) -> None:
 
     @wraps(original)
     async def _run_generate(self: Any, obj: Any, *args: Any, **kwargs: Any) -> Any:
-        _normalize_generate_request_once(obj)
+        try:
+            _normalize_generate_request_once(obj)
+        except Exception as exc:
+            # A rejected request is normally answered from inside _run_generate's
+            # own handler. Normalizing early moves that failure outside it, and an
+            # exception escaping this coroutine would only reach the scheduler's
+            # logger -- leaving the client to wait out its deadline instead of
+            # receiving the error. Report it the same way, and do not run the
+            # request: the failed pass has already half-expanded it.
+            if not _report_rejected_request(self, exc, args, kwargs):
+                raise
+            logger.error(
+                "gRPC generate error for rid=%s: %s", getattr(obj, "rid", None), exc
+            )
+            return None
+
         return await original(self, obj, *args, **kwargs)
 
     _run_generate._dynamo_grpc_bridge_batch_size_support = True  # type: ignore[attr-defined]

--- a/components/src/dynamo/sglang/launch_server.py
+++ b/components/src/dynamo/sglang/launch_server.py
@@ -32,18 +32,16 @@ def main() -> None:
     try:
         ensure_sglang_grpc_bridge_batch_size()
     except Exception:
-        # Starting the engine matters more than the override. On a release that
-        # does not need it, or one that restructured the bridge, log and hand
-        # off anyway rather than failing a launch that would otherwise work.
+        # Starting the engine matters more than the override: a release that does
+        # not need it, or restructured the bridge, must still launch.
         logger.warning(
             "Could not install the SGLang gRPC bridge compatibility override; "
             "continuing to launch the engine",
             exc_info=True,
         )
 
-    # run_module rather than an import: sglang.launch_server does its work under
-    # `if __name__ == "__main__"`, so this reproduces `python -m sglang.launch_server`
-    # exactly, including its sys.argv handling.
+    # run_module, not import: sglang.launch_server does its work under
+    # `if __name__ == "__main__"`, so this reproduces `python -m` exactly.
     runpy.run_module("sglang.launch_server", run_name="__main__")
 
 

--- a/components/src/dynamo/sglang/launch_server.py
+++ b/components/src/dynamo/sglang/launch_server.py
@@ -19,26 +19,19 @@ image with no Dynamo Python available; that requires an SGLang release which
 fixes the ordering upstream.
 """
 
-import logging
 import runpy
 
 from dynamo.sglang._compat import ensure_sglang_grpc_bridge_batch_size
 
-logger = logging.getLogger(__name__)
-
 
 def main() -> None:
     """Install Dynamo's SGLang compat overrides, then run SGLang's launcher."""
-    try:
-        ensure_sglang_grpc_bridge_batch_size()
-    except Exception:
-        # Starting the engine matters more than the override: a release that does
-        # not need it, or restructured the bridge, must still launch.
-        logger.warning(
-            "Could not install the SGLang gRPC bridge compatibility override; "
-            "continuing to launch the engine",
-            exc_info=True,
-        )
+    # Deliberately unguarded. The override already returns quietly for a release
+    # that does not need it or that restructured the bridge, so anything raising
+    # here is a real failure -- and launching anyway would start an engine whose
+    # every streaming request fails with HTTP 500, the defect this module exists
+    # to avoid. Failing at startup reports that far better than a served 500.
+    ensure_sglang_grpc_bridge_batch_size()
 
     # run_module, not import: sglang.launch_server does its work under
     # `if __name__ == "__main__"`, so this reproduces `python -m` exactly.

--- a/components/src/dynamo/sglang/launch_server.py
+++ b/components/src/dynamo/sglang/launch_server.py
@@ -26,11 +26,8 @@ from dynamo.sglang._compat import ensure_sglang_grpc_bridge_batch_size
 
 def main() -> None:
     """Install Dynamo's SGLang compat overrides, then run SGLang's launcher."""
-    # Deliberately unguarded. The override already returns quietly for a release
-    # that does not need it or that restructured the bridge, so anything raising
-    # here is a real failure -- and launching anyway would start an engine whose
-    # every streaming request fails with HTTP 500, the defect this module exists
-    # to avoid. Failing at startup reports that far better than a served 500.
+    # Unguarded on purpose: a failure here must abort startup rather than launch
+    # an engine that serves the very defect the override exists to prevent.
     ensure_sglang_grpc_bridge_batch_size()
 
     # run_module, not import: sglang.launch_server does its work under

--- a/components/src/dynamo/sglang/launch_server.py
+++ b/components/src/dynamo/sglang/launch_server.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Drop-in replacement for ``sglang.launch_server`` with Dynamo's compat shims.
+
+The Dynamo SGLang sidecar drives SGLang's native gRPC server, which in SGLang
+0.5.17 and 0.5.18 fails every streaming request (see
+``_compat.ensure_sglang_grpc_bridge_batch_size``). The gRPC bridge runs in the
+same process as the engine, so the fix has to be installed there rather than in
+the sidecar. Launching the engine through this module installs the override and
+then hands off to SGLang unchanged.
+
+Every argument is passed through untouched::
+
+    python3 -m dynamo.sglang.launch_server --model-path <model> --grpc-port 30001
+
+Use plain ``sglang.launch_server`` when the engine runs from a stock SGLang
+image with no Dynamo Python available; that requires an SGLang release which
+fixes the ordering upstream.
+"""
+
+import logging
+import runpy
+
+from dynamo.sglang._compat import ensure_sglang_grpc_bridge_batch_size
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Install Dynamo's SGLang compat overrides, then run SGLang's launcher."""
+    try:
+        ensure_sglang_grpc_bridge_batch_size()
+    except Exception:
+        # Starting the engine matters more than the override. On a release that
+        # does not need it, or one that restructured the bridge, log and hand
+        # off anyway rather than failing a launch that would otherwise work.
+        logger.warning(
+            "Could not install the SGLang gRPC bridge compatibility override; "
+            "continuing to launch the engine",
+            exc_info=True,
+        )
+
+    # run_module rather than an import: sglang.launch_server does its work under
+    # `if __name__ == "__main__"`, so this reproduces `python -m sglang.launch_server`
+    # exactly, including its sys.argv handling.
+    runpy.run_module("sglang.launch_server", run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/components/src/dynamo/sglang/tests/test_grpc_bridge_batch_size.py
+++ b/components/src/dynamo/sglang/tests/test_grpc_bridge_batch_size.py
@@ -98,23 +98,20 @@ def _drive(handle, obj, stream=True):
     return chunks
 
 
-def test_unpatched_bridge_reproduces_the_defect():
-    """Without the shim, a streaming request dies on the missing attribute."""
-
-    class Bridge(FakeRuntimeHandle):
-        pass
-
-    with pytest.raises(AttributeError) as excinfo:
-        _drive(Bridge(), FakeGenerateReqInput("hello"))
-
-    assert "batch_size" in str(excinfo.value)
-
-
 def test_shim_lets_a_streaming_request_complete():
-    """With the shim installed, the request normalizes first and streams."""
+    """The unpatched bridge dies on the missing attribute; the shim fixes it.
+
+    Both halves run against one bridge so that each keeps the other honest. The
+    first fails if the fake stops reproducing the upstream ordering -- which
+    would otherwise leave every test in this module passing vacuously -- and the
+    second fails if the shim stops normalizing before the batch size is read.
+    """
 
     class Bridge(FakeRuntimeHandle):
         pass
+
+    with pytest.raises(AttributeError, match="batch_size"):
+        _drive(Bridge(), FakeGenerateReqInput("hello"))
 
     ensure_sglang_grpc_bridge_batch_size(Bridge)
 

--- a/components/src/dynamo/sglang/tests/test_grpc_bridge_batch_size.py
+++ b/components/src/dynamo/sglang/tests/test_grpc_bridge_batch_size.py
@@ -15,6 +15,7 @@ import asyncio
 import pytest
 
 from dynamo.sglang._compat import (
+    _is_absent_grpc_bridge,
     _normalize_generate_request_once,
     ensure_sglang_grpc_bridge_batch_size,
 )
@@ -175,12 +176,56 @@ def test_shim_leaves_an_already_normalized_request_alone():
     assert obj.text == ["hello", "hello"]
 
 
+def test_failed_normalization_never_reaches_the_bridge():
+    """A request SGLang rejects must fail before its partial state is reused.
+
+    Normalization assigns ``batch_size`` and expands parallel-sampling inputs
+    before the validation that rejects the request, so a failed pass still
+    mutates the object. Letting it through would leave SGLang to normalize that
+    already-expanded input a second time.
+    """
+
+    class RejectedGenerateReqInput(FakeGenerateReqInput):
+        def normalize_batch_and_arguments(self) -> None:
+            super().normalize_batch_and_arguments()
+            raise ValueError("the rids length mismatches the batch size")
+
+    class Bridge(FakeRuntimeHandle):
+        pass
+
+    ensure_sglang_grpc_bridge_batch_size(Bridge)
+
+    obj = RejectedGenerateReqInput("hello", n=2)
+    with pytest.raises(ValueError, match="rids length"):
+        _drive(Bridge(), obj)
+
+    assert obj.normalize_calls == 1, "SGLang re-normalized a half-expanded request"
+    assert obj.text == ["hello", "hello"]
+
+
+@pytest.mark.parametrize(
+    "missing, absent",
+    [
+        ("sglang", True),
+        ("sglang.srt.entrypoints", True),
+        ("sglang.srt.entrypoints.grpc_bridge", True),
+        ("grpc", False),
+        ("sglang.srt.entrypoints.grpc_bridge_helpers", False),
+        (None, False),
+    ],
+)
+def test_an_absent_bridge_is_distinguished_from_a_broken_install(missing, absent):
+    """Only the bridge's own absence is tolerable; a broken dependency is not."""
+    assert _is_absent_grpc_bridge(ImportError("boom", name=missing)) is absent
+
+
 def test_missing_sglang_bridge_is_not_an_error():
     """A stock engine without the native gRPC bridge must still start."""
     try:
         import sglang.srt.entrypoints.grpc_bridge  # noqa: F401
-    except Exception:
-        pass
+    except ImportError as exc:
+        if not _is_absent_grpc_bridge(exc):
+            raise
     else:
         # Skip rather than patch the real class process-wide for other tests.
         pytest.skip("SGLang's native gRPC bridge is importable here")

--- a/components/src/dynamo/sglang/tests/test_grpc_bridge_batch_size.py
+++ b/components/src/dynamo/sglang/tests/test_grpc_bridge_batch_size.py
@@ -75,8 +75,7 @@ class FakeRuntimeHandle:
         gen = self.generate_request(obj)
         if stream:
             # The defect: obj.batch_size is read before the generator body runs.
-            # Upstream wraps this in `except Exception` and forwards the message
-            # to the client, which is how it surfaces as an HTTP 500 body.
+            # Upstream forwards the resulting error to the client as HTTP 500.
             expected_choices = obj.batch_size * obj.parallel_sample_num
             completed = set()
             async for chunk in gen:

--- a/components/src/dynamo/sglang/tests/test_grpc_bridge_batch_size.py
+++ b/components/src/dynamo/sglang/tests/test_grpc_bridge_batch_size.py
@@ -176,19 +176,62 @@ def test_shim_leaves_an_already_normalized_request_alone():
     assert obj.text == ["hello", "hello"]
 
 
-def test_failed_normalization_never_reaches_the_bridge():
-    """A request SGLang rejects must fail before its partial state is reused.
+class RejectedGenerateReqInput(FakeGenerateReqInput):
+    """A request SGLang validates and rejects, after normalization mutated it."""
 
-    Normalization assigns ``batch_size`` and expands parallel-sampling inputs
-    before the validation that rejects the request, so a failed pass still
-    mutates the object. Letting it through would leave SGLang to normalize that
-    already-expanded input a second time.
+    def normalize_batch_and_arguments(self) -> None:
+        super().normalize_batch_and_arguments()
+        raise ValueError("the rids length mismatches the batch size")
+
+
+def test_a_rejected_request_is_reported_not_left_to_time_out():
+    """A rejected request must come back as an error rather than a hang.
+
+    The bridge normally answers one from inside ``_run_generate``'s own handler,
+    via ``_send_native_error``. Normalizing early moves the failure outside that
+    handler, where an escaping exception would only reach the scheduler's
+    logger and the client would wait out its deadline.
     """
 
-    class RejectedGenerateReqInput(FakeGenerateReqInput):
-        def normalize_batch_and_arguments(self) -> None:
-            super().normalize_batch_and_arguments()
-            raise ValueError("the rids length mismatches the batch size")
+    class Bridge(FakeRuntimeHandle):
+        def __init__(self) -> None:
+            self.reached_generate = 0
+
+        async def generate_request(self, obj):
+            self.reached_generate += 1
+            async for chunk in super().generate_request(obj):
+                yield chunk
+
+        def _send_native_error(self, chunk_callback, message: str) -> None:
+            # Upstream shape: an empty payload, marked finished, carrying the error.
+            chunk_callback({}, finished=True, error=message)
+
+    ensure_sglang_grpc_bridge_batch_size(Bridge)
+
+    bridge = Bridge()
+    obj = RejectedGenerateReqInput("hello", n=2)
+    sent: list[tuple] = []
+
+    asyncio.run(
+        bridge._run_generate(
+            obj, lambda payload, **kw: sent.append((payload, kw)), True
+        )
+    )
+
+    assert sent == [
+        ({}, {"finished": True, "error": "the rids length mismatches the batch size"})
+    ]
+    assert bridge.reached_generate == 0, "the rejected request still ran"
+    assert obj.normalize_calls == 1, "SGLang re-normalized a half-expanded request"
+    assert obj.text == ["hello", "hello"]
+
+
+def test_a_rejected_request_raises_when_there_is_no_error_callback():
+    """Without a native error callback, the failure must at least escape.
+
+    Staying silent would lose it entirely; raising leaves it for the scheduler
+    to log. Either way the half-expanded request never reaches the bridge.
+    """
 
     class Bridge(FakeRuntimeHandle):
         pass

--- a/components/src/dynamo/sglang/tests/test_grpc_bridge_batch_size.py
+++ b/components/src/dynamo/sglang/tests/test_grpc_bridge_batch_size.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the SGLang native gRPC bridge batch_size shim.
+
+SGLang 0.5.17 and 0.5.18 read ``obj.batch_size`` in the streaming branch of the
+native gRPC bridge's ``_run_generate``, one statement after building the
+``generate_request`` async generator -- and therefore before anything has run
+the normalization that assigns it. The fakes below reproduce that ordering, so
+these tests run without SGLang installed.
+"""
+
+import asyncio
+
+import pytest
+
+from dynamo.sglang._compat import (
+    _normalize_generate_request_once,
+    ensure_sglang_grpc_bridge_batch_size,
+)
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.core,
+]
+
+
+class FakeGenerateReqInput:
+    """Stand-in for SGLang's GenerateReqInput normalization behavior.
+
+    Mirrors the parts of ``normalize_batch_and_arguments()`` that matter here:
+    ``batch_size`` exists only after it runs, and running it twice re-expands
+    parallel-sampling inputs from an already-expanded list.
+    """
+
+    def __init__(self, text: str, n: int = 1) -> None:
+        self.rid = "test-request"
+        self.text: object = text
+        self.n = n
+        self.parallel_sample_num = 1
+        self.normalize_calls = 0
+        # batch_size is deliberately not set here: SGLang assigns it only in
+        # _determine_batch_size(), reached through the normalization below.
+
+    def normalize_batch_and_arguments(self) -> None:
+        self.normalize_calls += 1
+        if isinstance(self.text, str):
+            self.is_single = True
+            self.batch_size = 1
+        else:
+            self.is_single = False
+            self.batch_size = len(self.text)
+        self.parallel_sample_num = self.n
+        if self.parallel_sample_num > 1 and self.is_single:
+            self.is_single = False
+            self.text = [self.text]
+        if not self.is_single:
+            assert isinstance(self.text, list)
+            self.text = self.text * self.parallel_sample_num
+
+
+class FakeRuntimeHandle:
+    """Stand-in for the SGLang 0.5.18 grpc_bridge.RuntimeHandle call ordering."""
+
+    async def generate_request(self, obj):
+        # TokenizerManager.generate_request normalizes inside the generator
+        # body, so nothing here runs until the first anext() below.
+        obj.normalize_batch_and_arguments()
+        for index in range(obj.batch_size * obj.parallel_sample_num):
+            yield {"index": index, "text": "hi", "finish_reason": "stop"}
+
+    async def _run_generate(self, obj, chunk_callback, stream, request=None):
+        gen = self.generate_request(obj)
+        if stream:
+            # The defect: obj.batch_size is read before the generator body runs.
+            # Upstream wraps this in `except Exception` and forwards the message
+            # to the client, which is how it surfaces as an HTTP 500 body.
+            expected_choices = obj.batch_size * obj.parallel_sample_num
+            completed = set()
+            async for chunk in gen:
+                chunk_callback(chunk)
+                if chunk["finish_reason"] is not None:
+                    completed.add(chunk["index"])
+                if len(completed) >= expected_choices:
+                    return
+
+
+def _drive(handle, obj, stream=True):
+    """Run one request through the bridge and return the streamed chunks."""
+    chunks: list[dict] = []
+
+    async def run():
+        await handle._run_generate(obj, chunks.append, stream)
+
+    asyncio.run(run())
+    return chunks
+
+
+def test_unpatched_bridge_reproduces_the_defect():
+    """Without the shim, a streaming request dies on the missing attribute."""
+
+    class Bridge(FakeRuntimeHandle):
+        pass
+
+    with pytest.raises(AttributeError) as excinfo:
+        _drive(Bridge(), FakeGenerateReqInput("hello"))
+
+    assert "batch_size" in str(excinfo.value)
+
+
+def test_shim_lets_a_streaming_request_complete():
+    """With the shim installed, the request normalizes first and streams."""
+
+    class Bridge(FakeRuntimeHandle):
+        pass
+
+    ensure_sglang_grpc_bridge_batch_size(Bridge)
+
+    obj = FakeGenerateReqInput("hello")
+    chunks = _drive(Bridge(), obj)
+
+    assert [chunk["index"] for chunk in chunks] == [0]
+    assert obj.batch_size == 1
+
+
+def test_shim_does_not_double_expand_parallel_sampling():
+    """Normalization must happen exactly once, even though SGLang calls it too.
+
+    ``normalize_batch_and_arguments()`` is not idempotent: a second pass derives
+    the batch size from the already-expanded input list, so ``n`` sequences
+    would become ``n * n``. Normalizing early is only safe because the shim
+    neutralizes SGLang's own later call on that request object.
+    """
+
+    class Bridge(FakeRuntimeHandle):
+        pass
+
+    ensure_sglang_grpc_bridge_batch_size(Bridge)
+
+    obj = FakeGenerateReqInput("hello", n=3)
+    chunks = _drive(Bridge(), obj)
+
+    assert len(chunks) == 3, "parallel sampling produced the wrong choice count"
+    assert obj.text == ["hello", "hello", "hello"]
+    assert obj.normalize_calls == 1
+
+
+def test_shim_installation_is_idempotent():
+    """Installing twice must not stack wrappers or re-normalize."""
+
+    class Bridge(FakeRuntimeHandle):
+        pass
+
+    ensure_sglang_grpc_bridge_batch_size(Bridge)
+    wrapped = Bridge._run_generate
+    ensure_sglang_grpc_bridge_batch_size(Bridge)
+
+    assert Bridge._run_generate is wrapped
+
+    obj = FakeGenerateReqInput("hello", n=2)
+    assert len(_drive(Bridge(), obj)) == 2
+    assert obj.normalize_calls == 1
+
+
+def test_shim_leaves_an_already_normalized_request_alone():
+    """On a release that assigns batch_size first, the shim must do nothing."""
+    obj = FakeGenerateReqInput("hello", n=2)
+    obj.normalize_batch_and_arguments()
+    calls_before = obj.normalize_calls
+
+    _normalize_generate_request_once(obj)
+
+    assert obj.normalize_calls == calls_before
+    assert obj.text == ["hello", "hello"]
+
+
+def test_missing_sglang_bridge_is_not_an_error():
+    """A stock engine without the native gRPC bridge must still start."""
+    try:
+        import sglang.srt.entrypoints.grpc_bridge  # noqa: F401
+    except Exception:
+        pass
+    else:
+        # Skip rather than patch the real class process-wide for other tests.
+        pytest.skip("SGLang's native gRPC bridge is importable here")
+
+    ensure_sglang_grpc_bridge_batch_size()

--- a/lib/sidecar/sglang/README.md
+++ b/lib/sidecar/sglang/README.md
@@ -54,6 +54,12 @@ python3 -m sglang.launch_server \
     --sidecar dynamo.sglang.sidecar
 ```
 
+> [!NOTE]
+> On SGLang **v0.5.17** and **v0.5.18**, start the engine with
+> `python3 -m dynamo.sglang.launch_server` instead. It forwards every flag to
+> `sglang.launch_server` unchanged, after fixing a defect in those releases that
+> fails every streaming request over the native gRPC server.
+
 The entry point configures Dynamo logging when `main()` runs, then calls the
 private `dynamo._core.backend._run_sglang_sidecar(argv)` binding. The binding
 prepends the executable name expected by clap, releases the GIL, and runs the
@@ -78,6 +84,18 @@ command.
 > server (`--grpc-port`) landed there. The KV-routing examples require
 > **v0.5.18+** because the sidecar discovers their structured KV-event
 > descriptor through `GetServerInfo`. They use `lmsysorg/sglang:v0.5.18`.
+
+> [!WARNING]
+> Stock SGLang **v0.5.17** and **v0.5.18** have a defect in the native gRPC
+> server: it reads the request's batch size before SGLang normalizes the
+> request, so every streaming request fails with `'GenerateReqInput' object has
+> no attribute 'batch_size'` and the sidecar returns HTTP 500. The scripts under
+> `launch/` are unaffected — they start the engine with
+> `python3 -m dynamo.sglang.launch_server`, which installs a compatibility
+> override and then delegates to `sglang.launch_server` with every flag
+> unchanged. These manifests cannot do the same: their engine container is a
+> stock `lmsysorg/sglang` image with no Dynamo Python in it. Until the fix is
+> released upstream, run them against an engine image that carries it.
 
 ### Prerequisites
 

--- a/lib/sidecar/sglang/launch/agg.sh
+++ b/lib/sidecar/sglang/launch/agg.sh
@@ -35,7 +35,7 @@ while [[ $# -gt 0 ]]; do
             echo
             echo "Environment overrides:"
             echo "  MODEL                   Model to serve (default: Qwen/Qwen3-0.6B)"
-            echo "  SGLANG_PYTHON           Python with SGLang installed (default: python3)"
+            echo "  SGLANG_PYTHON           Python with SGLang and Dynamo installed (default: python3)"
             echo "  CUDA_VISIBLE_DEVICES    GPU assignment (default: 0)"
             echo "  DYN_HTTP_PORT           Dynamo frontend port (default: 8000)"
             echo "  DYN_SYSTEM_PORT         Dynamo sidecar system port (default: 8081)"
@@ -72,9 +72,11 @@ print_launch_banner "Launching SGLang Native-gRPC Sidecar (1 GPU)" "$MODEL" "$HT
 python3 -m dynamo.frontend &
 
 # --grpc-port enables the native Rust gRPC server alongside SGLang's HTTP API.
+# dynamo.sglang.launch_server passes every flag through to sglang.launch_server
+# after fixing that server's batch_size ordering defect on SGLang 0.5.17/0.5.18.
 # shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
 CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" \
-"$SGLANG_PYTHON" -m sglang.launch_server \
+"$SGLANG_PYTHON" -m dynamo.sglang.launch_server \
     --model-path "$MODEL" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_HTTP_PORT" \

--- a/lib/sidecar/sglang/launch/agg_kv_router.sh
+++ b/lib/sidecar/sglang/launch/agg_kv_router.sh
@@ -35,7 +35,7 @@ while [[ $# -gt 0 ]]; do
             echo
             echo "Environment overrides:"
             echo "  MODEL                         Model to serve (default: Qwen/Qwen3-0.6B)"
-            echo "  SGLANG_PYTHON                 Python with SGLang installed (default: python3)"
+            echo "  SGLANG_PYTHON                 Python with SGLang and Dynamo installed (default: python3)"
             echo "  SGLANG_WORKER1_GPU            First GPU assignment (default: 0)"
             echo "  SGLANG_WORKER2_GPU            Second GPU assignment (default: 1)"
             echo "  DYN_HTTP_PORT                 Dynamo frontend port (default: 8000)"
@@ -90,9 +90,11 @@ print_launch_banner "Launching SGLang Native-gRPC Sidecars with KV Routing (2 GP
 
 python3 -m dynamo.frontend --router-mode kv &
 
+# dynamo.sglang.launch_server passes every flag through to sglang.launch_server
+# after fixing that server's batch_size ordering defect on SGLang 0.5.17/0.5.18.
 # shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
 CUDA_VISIBLE_DEVICES="$SGLANG_WORKER1_GPU" \
-"$SGLANG_PYTHON" -m sglang.launch_server \
+"$SGLANG_PYTHON" -m dynamo.sglang.launch_server \
     --model-path "$MODEL" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_WORKER1_HTTP_PORT" \
@@ -107,7 +109,7 @@ CUDA_VISIBLE_DEVICES="$SGLANG_WORKER1_GPU" \
 
 # shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
 CUDA_VISIBLE_DEVICES="$SGLANG_WORKER2_GPU" \
-"$SGLANG_PYTHON" -m sglang.launch_server \
+"$SGLANG_PYTHON" -m dynamo.sglang.launch_server \
     --model-path "$MODEL" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_WORKER2_HTTP_PORT" \

--- a/lib/sidecar/sglang/launch/disagg.sh
+++ b/lib/sidecar/sglang/launch/disagg.sh
@@ -35,7 +35,7 @@ while [[ $# -gt 0 ]]; do
             echo
             echo "Environment overrides:"
             echo "  MODEL                                   Model to serve (default: Qwen/Qwen3-0.6B)"
-            echo "  SGLANG_PYTHON                           Python with SGLang installed (default: python3)"
+            echo "  SGLANG_PYTHON                           Python with SGLang and Dynamo installed (default: python3)"
             echo "  SGLANG_PREFILL_GPU                      Prefill GPU assignment (default: 0)"
             echo "  SGLANG_DECODE_GPU                       Decode GPU assignment (default: 1)"
             echo "  DYN_HTTP_PORT                           Dynamo frontend port (default: 8000)"
@@ -83,9 +83,11 @@ print_launch_banner "Launching SGLang Native-gRPC Sidecar (Disaggregated, 2 GPUs
 
 python3 -m dynamo.frontend &
 
+# dynamo.sglang.launch_server passes every flag through to sglang.launch_server
+# after fixing that server's batch_size ordering defect on SGLang 0.5.17/0.5.18.
 # shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
 CUDA_VISIBLE_DEVICES="$SGLANG_PREFILL_GPU" \
-"$SGLANG_PYTHON" -m sglang.launch_server \
+"$SGLANG_PYTHON" -m dynamo.sglang.launch_server \
     --model-path "$MODEL" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_PREFILL_HTTP_PORT" \
@@ -101,7 +103,7 @@ CUDA_VISIBLE_DEVICES="$SGLANG_PREFILL_GPU" \
 
 # shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
 CUDA_VISIBLE_DEVICES="$SGLANG_DECODE_GPU" \
-"$SGLANG_PYTHON" -m sglang.launch_server \
+"$SGLANG_PYTHON" -m dynamo.sglang.launch_server \
     --model-path "$MODEL" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_DECODE_HTTP_PORT" \

--- a/lib/sidecar/sglang/launch/disagg_kv_router.sh
+++ b/lib/sidecar/sglang/launch/disagg_kv_router.sh
@@ -35,7 +35,7 @@ while [[ $# -gt 0 ]]; do
             echo
             echo "Environment overrides:"
             echo "  MODEL                              Model to serve (default: Qwen/Qwen3-0.6B)"
-            echo "  SGLANG_PYTHON                      Python with SGLang installed (default: python3)"
+            echo "  SGLANG_PYTHON                      Python with SGLang and Dynamo installed (default: python3)"
             echo "  DYN_HTTP_PORT                      Dynamo frontend port (default: 8000)"
             echo "  DYN_SYSTEM_PORT1                   First prefill sidecar port (default: 8081)"
             echo "  DYN_SYSTEM_PORT2                   Second prefill sidecar port (default: 8082)"
@@ -117,9 +117,11 @@ print_launch_banner "Launching SGLang Native-gRPC Sidecars with Disaggregated KV
 python3 -m dynamo.frontend --router-mode kv &
 
 # Each prefill engine hosts its own KV-transfer bootstrap server, so these ports must be unique.
+# dynamo.sglang.launch_server passes every flag through to sglang.launch_server
+# after fixing that server's batch_size ordering defect on SGLang 0.5.17/0.5.18.
 # shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
 CUDA_VISIBLE_DEVICES="$SGLANG_PREFILL1_GPU" \
-"$SGLANG_PYTHON" -m sglang.launch_server \
+"$SGLANG_PYTHON" -m dynamo.sglang.launch_server \
     --model-path "$MODEL" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_PREFILL1_HTTP_PORT" \
@@ -137,7 +139,7 @@ CUDA_VISIBLE_DEVICES="$SGLANG_PREFILL1_GPU" \
 
 # shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
 CUDA_VISIBLE_DEVICES="$SGLANG_PREFILL2_GPU" \
-"$SGLANG_PYTHON" -m sglang.launch_server \
+"$SGLANG_PYTHON" -m dynamo.sglang.launch_server \
     --model-path "$MODEL" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_PREFILL2_HTTP_PORT" \
@@ -155,7 +157,7 @@ CUDA_VISIBLE_DEVICES="$SGLANG_PREFILL2_GPU" \
 
 # shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
 CUDA_VISIBLE_DEVICES="$SGLANG_DECODE1_GPU" \
-"$SGLANG_PYTHON" -m sglang.launch_server \
+"$SGLANG_PYTHON" -m dynamo.sglang.launch_server \
     --model-path "$MODEL" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_DECODE1_HTTP_PORT" \
@@ -172,7 +174,7 @@ CUDA_VISIBLE_DEVICES="$SGLANG_DECODE1_GPU" \
 
 # shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
 CUDA_VISIBLE_DEVICES="$SGLANG_DECODE2_GPU" \
-"$SGLANG_PYTHON" -m sglang.launch_server \
+"$SGLANG_PYTHON" -m dynamo.sglang.launch_server \
     --model-path "$MODEL" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_DECODE2_HTTP_PORT" \


### PR DESCRIPTION
## Overview:

Every request to an SGLang **sidecar** deployment returns HTTP 500 with `'GenerateReqInput' object has no attribute 'batch_size'`. The sidecar drives SGLang's native gRPC service, and in SGLang `0.5.17` and `0.5.18` the streaming branch of that service's `_run_generate` reads `obj.batch_size` one statement after calling `TokenizerManager.generate_request(obj)`. That call only *builds* an async generator, so the `normalize_batch_and_arguments()` call that assigns `batch_size` has not run yet. The read is absent in `v0.5.16`.

## Details:

`ensure_sglang_grpc_bridge_batch_size()` in `components/src/dynamo/sglang/_compat.py` wraps the bridge's `_run_generate` so the request is normalized before the batch size is read. `normalize_batch_and_arguments()` is not idempotent — a second pass re-expands parallel-sampling inputs — so the wrapper also neutralizes SGLang's own later call on that request object. Installing twice does not stack wrappers, and a release without the native gRPC bridge is left alone.

Normalization assigns `batch_size` and expands parallel-sampling inputs before the validation that rejects a malformed request, so a failed pass still mutates the request object, and that object must never reach the bridge — SGLang would re-derive the batch size from the already-expanded list and turn `n` sequences into `n * n`. The bridge itself answers a rejected request from inside `_run_generate`'s own exception handler, and normalizing early moves that failure outside it, where an escaping exception would reach only the scheduler's logger and the client would wait out its deadline. The wrapper therefore reports the error through the same `_send_native_error` callback the bridge uses, and falls back to raising on a release that exposes no such callback. The bridge import is narrowed the same way: an absent bridge and an absent SGLang are identified by the failing module name and tolerated, while a bridge that is present but fails to load propagates as the broken environment it is.

The bridge runs in the engine process, not the sidecar, so the override must be installed at engine startup. `components/src/dynamo/sglang/launch_server.py` is a thin drop-in for `sglang.launch_server`: it installs the override, then hands off with `runpy.run_module(...)` so every flag passes through unchanged. Installation is unguarded on purpose — the override already returns quietly for a release that does not need it, so a failure there would otherwise start an engine that serves HTTP 500 for every streaming request. The four scripts under `lib/sidecar/sglang/launch/` use this launcher. The manifests under `lib/sidecar/sglang/deploy/` cannot — their engine container is a stock `lmsysorg/sglang` image with no Dynamo Python — so `lib/sidecar/sglang/README.md` records that limitation.

## Where should the reviewer start?

`components/src/dynamo/sglang/_compat.py`, then `components/src/dynamo/sglang/tests/test_grpc_bridge_batch_size.py`, whose fakes reproduce the upstream call ordering and run without SGLang installed.

## Related Issues

Closes [DYN-4265](https://linear.app/nvidia/issue/DYN-4265/dynamorelease150sidecar-every-inference-request-to-the-sglang-sidecar)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed streaming failures affecting SGLang 0.5.17 and 0.5.18 by initializing request batch sizes correctly.
  - Prevented duplicate request expansion, reported rejected requests promptly, and handled unavailable native SGLang bridges safely.

- **New Features**
  - Added a Dynamo-compatible SGLang launcher that preserves command-line arguments.
  - Updated aggregate, routed, and disaggregated launch configurations to use the compatibility launcher.

- **Documentation**
  - Added guidance for supported SGLang versions and Kubernetes image requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->