### PR TITLE
fix(trtllm-sidecar): install smg-grpc-proto before starting the gRPC engine

### DIFF
--- a/lib/sidecar/trtllm/README.md
+++ b/lib/sidecar/trtllm/README.md
@@ -32,9 +32,13 @@ carries no context-phase handoff.
 
 ## Run
 
-Start TensorRT-LLM with its native gRPC listener (TRT-LLM `1.3.0rc21`; rc22 has a broken `--grpc`):
+Start TensorRT-LLM with its native gRPC listener. Its protobuf bindings are an
+optional extra, so install them first. Install the package directly rather than
+via `tensorrt_llm[grpc-smg]`: the extra makes pip re-resolve TensorRT-LLM's whole
+dependency closure, which fails on an image whose site-packages is read-only.
 
 ```bash
+pip install "smg-grpc-proto>=0.4.2"
 python -m tensorrt_llm.commands.serve <model> --grpc --host 0.0.0.0 --port 50051
 ```
 

--- a/lib/sidecar/trtllm/deploy/agg.yaml
+++ b/lib/sidecar/trtllm/deploy/agg.yaml
@@ -42,11 +42,10 @@ spec:
     podTemplate:
       spec:
         # trtllm-engine as a native sidecar (initContainer + restartPolicy: Always):
-        # starts before `main`, stops after. --grpc needs rc21; rc22 crashes on
-        # startup (protobuf version mismatch).
+        # starts before `main`, stops after.
         initContainers:
         - name: trtllm-engine
-          image: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc21
+          image: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc25
           restartPolicy: Always
           # gRPC HealthCheck via exec (tcpSocket/grpc: dial the pod IP, not the
           # loopback engine). startupProbe gates `main`; readinessProbe drops dead workers.
@@ -77,10 +76,20 @@ spec:
             requests:
               # Increase for larger models.
               ephemeral-storage: 2Gi
+          # `--grpc` needs `smg-grpc-proto`, which TRT-LLM keeps behind the
+          # optional `grpc-smg` extra rather than shipping in the image.
+          # Constraint copied from that extra so we resolve what upstream
+          # resolves. Needs egress to PyPI; bake it into a derived image if the
+          # cluster has none.
           command:
-          - python3
-          - -m
-          - tensorrt_llm.commands.serve
+          - sh
+          - -c
+          - |
+            set -e
+            python3 -c "import smg_grpc_proto" 2>/dev/null \
+              || pip install --no-cache-dir "smg-grpc-proto>=0.4.2"
+            exec python3 -m tensorrt_llm.commands.serve "$@"
+          - trtllm-serve
           args:
           - Qwen/Qwen3-0.6B
           - --grpc

--- a/lib/sidecar/trtllm/launch/agg.sh
+++ b/lib/sidecar/trtllm/launch/agg.sh
@@ -65,6 +65,13 @@ TRTLLM_GRPC_PORT="${TRTLLM_GRPC_PORT:-50051}"
 TRTLLM_CONTEXT_LENGTH="${TRTLLM_CONTEXT_LENGTH:-4096}"
 CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
 
+# `--grpc` needs `smg-grpc-proto`, which TRT-LLM keeps behind its optional
+# `grpc-smg` extra. Constraint copied from that extra so we resolve what
+# upstream resolves.
+if ! "$TRTLLM_PYTHON" -c "import smg_grpc_proto" >/dev/null 2>&1; then
+    "$TRTLLM_PYTHON" -m pip install --no-cache-dir "smg-grpc-proto>=0.4.2"
+fi
+
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 GPU_MEM_ARGS=$(build_trtllm_override_args_with_mem)
 TRTLLM_GPU_MEM_ARGS=()


### PR DESCRIPTION
## Summary

TensorRT-LLM keeps the SMG gRPC protobuf bindings behind an optional extra rather
than shipping them in the release image:

```
Provides-Extra: grpc-smg
Requires-Dist: smg-grpc-proto>=0.4.2; extra == "grpc-smg"
```

The adapter code is present (`tensorrt_llm/grpc/smg/`), but `smg_grpc_proto` is
not, so `python -m tensorrt_llm.commands.serve --grpc` aborts before the listener
starts. Both paths that launch the engine for the sidecar — `launch/agg.sh` and
the `trtllm-engine` container in `deploy/agg.yaml` — now install the package first.

Three notes on the implementation:

- **Guarded by an import check**, so this is a no-op wherever the package is
  already present and nothing is fetched unnecessarily.
- **`smg-grpc-proto>=0.4.2`, unpinned**, copied verbatim from upstream's own
  `grpc-smg` extra so we resolve what upstream resolves. The vendored proto in
  `proto/` is byte-identical between its recorded 0.4.14 (checksum still matching)
  and current 0.4.16, so floating carries no wire-contract drift today.
- **The bare package, not `tensorrt_llm[grpc-smg]`.** The extra makes pip resolve
  TensorRT-LLM's entire dependency closure (transformers, diffusers, jupyterlab,
  jupyter_server, …), which fails on the release image:
  `ERROR: Will not install to the user site because it will lack sys.path
  precedence to jupyterlab in /opt/dynamo/venv/...`. The bare package installs one
  wheel plus `grpcio` and succeeds. The README says this explicitly so nobody
  "simplifies" it back to the extra.

The manifest wrapper runs under `set -e`. Without it a failed install still
`exec`'d the engine, which died on the same missing import minutes later — after
pip's retry backoff had already eaten into the startupProbe budget.

`deploy/agg.yaml`'s engine image moves rc21 → rc25, the release where the bindings
became optional, so the manifest exercises the path it now depends on.

## Validation

**Static.** `bash -n` on the script; YAML parse of the manifest;
`kubectl apply --dry-run=server` against a live cluster with the operator installed
(ConfigMap and `DynamoGraphDeployment` both validate).

**`launch/agg.sh`**, driven end to end with `python3`/`dynamo-trtllm-sidecar`
stubbed on PATH, asserting call order:

| Case | Result |
|---|---|
| package absent, pip succeeds | guard runs first, then frontend → engine → sidecar start |
| package present | no pip invocation |
| package absent, pip fails | exits 1, nothing launched |

**`deploy/agg.yaml`'s wrapper**, `command`/`args` extracted verbatim and executed in
a real `tensorrt-llm/release:1.3.0rc25` image with `serve` stubbed:

- online — installs 0.4.16 and forwards argv unchanged
  (`Qwen/Qwen3-0.6B --grpc --host 127.0.0.1 --port 50051 --extra_llm_api_options /config/config.yaml`)
- `--network none` — fails fast, `rc=1`, engine never starts. This is the case that
  motivated `set -e`; before it, the same run returned `rc=0` and started the engine.

**On a live H100 cluster.** The manifest was deployed (with only the `main` image,
`imagePullSecrets` and the DGD name changed for the test environment). The engine
container ran the committed wrapper and reached the gRPC listener:

```
Collecting smg-grpc-proto>=0.4.2
Downloading smg_grpc_proto-0.4.16-py3-none-any.whl (97 kB)
Successfully installed grpcio-1.83.1 smg-grpc-proto-0.4.16
[TRT-LLM] [I] [grpc] Initializing TensorRT-LLM SMG gRPC server...
[TRT-LLM] [I] [llmapi] Downloading model Qwen/Qwen3-0.6B from HuggingFace
```

On rc25 without this change that process aborts before the SMG line. A separate
in-cluster pod confirmed PyPI egress independently.

The full graph then came up (`2/2 Running`) and served a request end to end through
the frontend:

```
$ curl .../v1/chat/completions -d '{"model":"Qwen/Qwen3-0.6B","messages":[...],"max_tokens":64}'
{
  "choices": [{"index": 0, "message": {"role": "assistant", "content": "..."},
               "finish_reason": "length"}],
  "model": "Qwen/Qwen3-0.6B",
  "usage": {"prompt_tokens": 18, "completion_tokens": 64, "total_tokens": 82}
}
```

### Not verified

- Only the aggregated single-GPU path was exercised (`deploy/agg.yaml`,
  `launch/agg.sh`); there is no other trtllm sidecar launch path today.
- Installing the package replaces the image's `grpcio` (1.80.0 → 1.83.1; a
  user-site shadow where site-packages is read-only, an actual uninstall/reinstall
  where it is writable). Upstream's own `grpc-smg` extra pulls the same floor, so
  this is inherent to enabling the feature — baking the dependency into a derived
  image avoids the runtime mutation.
- The manifest's `ephemeral-storage: 2Gi` request is far below what the engine image
  needs; scheduling it onto an undersized node evicted the pod and filled that
  node's disk. Pre-existing, not introduced here, but worth a follow-up.
