### PR TITLE
chore(deps): bump axios in the community events generator [DYN-4274]

### DIFF
--- a/.github/scripts/events/package-lock.json
+++ b/.github/scripts/events/package-lock.json
@@ -7,9 +7,20 @@
     "": {
       "name": "docs-events",
       "version": "1.0.0",
-      "license": "ISC",
       "dependencies": {
         "node-ical": "0.20.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/asynckit": {
@@ -19,14 +30,15 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -52,6 +64,23 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/delayed-stream": {
@@ -255,6 +284,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -306,6 +348,12 @@
         "node": "*"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/node-ical": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.20.0.tgz",
@@ -319,10 +367,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/rrule": {
       "version": "2.8.1",

--- a/.github/scripts/events/package.json
+++ b/.github/scripts/events/package.json
@@ -6,5 +6,8 @@
   "dependencies": {
     "node-ical": "0.20.0"
   },
+  "overrides": {
+    "axios": ">=1.18.1 <2.0.0"
+  },
   "private": true
 }


### PR DESCRIPTION
## Summary

`.github/scripts/events/` pins `axios@1.7.7` transitively. This refreshes it to `1.20.0`
so the directory's dependency tree comes back clean under `npm audit`.

It cannot be done by editing the lockfile alone. `node-ical@0.20.0` declares axios as an
*exact* pin rather than a range:

```json
"dependencies": { "axios": "1.7.7", ... }
```

so npm has no freedom to resolve anything newer, and a hand-edited version string fails
`npm ci` with `EINTEGRITY`. The fix is an npm `overrides` entry in `package.json`, after
which the lockfile was regenerated by npm rather than hand-edited:

```json
"overrides": {
  "axios": ">=1.18.1 <2.0.0"
}
```

The range is bounded on both ends so a future regeneration can neither drop back to an
older release nor float into axios 2.x.

**Scope of the lockfile diff:** axios `1.7.7 -> 1.20.0`, `proxy-from-env` `1.1.0 -> 2.1.0`,
plus four transitives axios 1.20 introduces (`agent-base`, `debug`, `https-proxy-agent`,
`ms`). Nothing else moves; `node-ical` itself stays at `0.20.0`.

**One diff line worth explaining:** the root `"license": "ISC"` entry disappears from the
lockfile. `package.json` here has no `license` field, so the lockfile was already drifted
from it — that line is npm normalising on regeneration, not an edit of mine.

This directory is build-time only: it exists solely for
`.github/workflows/community-events-refresh.yml`, which regenerates the docs calendar
component and the README events table on a six-hourly cron. Nothing here ships in a wheel,
container, or operator image.

**Not included:** `npm audit` also flags `uuid <11.1.1` (moderate), likewise from
`node-ical@0.20.0`. Clearing it means moving to `node-ical@0.27.1` — which happens to drop
axios as a dependency entirely — but that raises the floor to `engines: node>=22` and needs
its own compatibility review of both generator scripts, so it is left for a separate change.

## Validation

Run in `node:22` containers on two architectures, matching the workflow's
`actions/setup-node` v22 on `ubuntu-latest`. Commands are the ones CI actually runs.

| Check | linux/amd64 (native) | darwin/arm64 |
|---|---|---|
| `npm ci --prefix .github/scripts/events` | pass | pass |
| `npm ls axios` | `axios@1.20.0 overridden` | `axios@1.20.0 overridden` |
| `node .github/scripts/generate-events.js` | `1 upcoming, 5 past` (exit 0) | `1 upcoming, 5 past` (exit 0) |
| `node .github/scripts/update-events.js` | `3 events (2 past, 1 upcoming)` (exit 0) | `3 events (2 past, 1 upcoming)` (exit 0) |
| `npm audit` — axios findings | 0 | 0 |

Both generators were run against the live calendar, not stubbed. That matters here because
`ical.async.fromURL()` is the only axios surface `node-ical` touches (it calls
`axios.get(url, options)`), so a successful run exercises the upgraded code path end to end
rather than just proving the resolver picked a new version.

**Output equivalence:** the regenerated `events.generated.ts` and `README.md` are
byte-identical to the committed files except for `GENERATED_ON` rolling to the run date —
identical on both architectures. So the upgrade changes no calendar output.

**Reproducibility:** deleting the lockfile and regenerating from scratch yields a
byte-identical file to the incremental regeneration. The tree contains no `os`/`cpu`/`libc`
gated packages, so it is platform-independent.

`pre-commit run --all-files` passes.

## Related

Internal tracking ticket: DYN-4274.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Constrained the Axios dependency to compatible 1.x versions for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->