### PR TITLE
test(fault_tolerance): share a SIGTERM-only graceful shutdown context

### DIFF
--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -3,14 +3,10 @@
 
 import logging
 import os
-import signal
 import threading
 import time
-from collections.abc import Iterator
-from contextlib import contextmanager
 from pathlib import Path
 
-import psutil
 import pytest
 import requests
 
@@ -24,9 +20,9 @@ from tests.utils.prometheus import sum_metric_samples
 # Customized utils for migration tests
 from .utils import (
     DynamoFrontendProcess,
+    graceful_worker_shutdown,
     managed_processes_concurrently,
     run_migration_test,
-    wait_for_endpoint_instance_reduction,
     wait_for_endpoint_instances,
 )
 
@@ -43,52 +39,6 @@ KV_TRANSFER_PROMPT_REPETITIONS = 128
 SGLANG_MIGRATION_FRONTEND_STARTUP_TIMEOUT_S = 60
 # Last-resort ceiling; individual operations have their own bounded waits.
 SGLANG_MIGRATION_TEST_TIMEOUT_S = 780
-
-
-@contextmanager
-def _sglang_graceful_shutdown(
-    frontend: DynamoFrontendProcess,
-    worker: ManagedProcess,
-) -> Iterator[None]:
-    """Keep the failed worker alive until the request outcome is observable."""
-    endpoint = ("backend", "generate")
-    response = requests.get(
-        f"http://localhost:{frontend.frontend_port}/health",
-        timeout=1,
-    )
-    response.raise_for_status()
-    previous_count = sum(
-        1
-        for instance in response.json().get("instances", [])
-        if (instance.get("component"), instance.get("endpoint")) == endpoint
-    )
-
-    pid = worker.get_pid()
-    parent = psutil.Process(pid)
-    process_groups = {os.getpgid(pid)}
-    try:
-        for child in parent.children(recursive=True):
-            try:
-                process_groups.add(os.getpgid(child.pid))
-            except (ProcessLookupError, OSError):
-                pass
-    except (psutil.AccessDenied, psutil.NoSuchProcess):
-        pass
-
-    try:
-        parent.terminate()
-        wait_for_endpoint_instance_reduction(
-            frontend.frontend_port,
-            endpoint,
-            previous_count,
-        )
-        yield
-    finally:
-        for process_group in process_groups:
-            try:
-                os.killpg(process_group, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
 
 
 def get_sglang_kv_transfer_metrics(worker_system_port: int) -> tuple[float, float]:
@@ -557,7 +507,7 @@ def test_request_migration_sglang_aggregated(
                 stream=stream,
                 max_tokens=AGGREGATED_MAX_TOKENS,
                 expected_ongoing_request_count=1,
-                graceful_shutdown=lambda worker: _sglang_graceful_shutdown(
+                graceful_shutdown=lambda worker: graceful_worker_shutdown(
                     frontend, worker
                 ),
                 verify_replacement_worker=True,
@@ -670,7 +620,7 @@ def test_request_migration_sglang_kv_transfer(
                 use_long_prompt=True,
                 long_prompt_repetitions=KV_TRANSFER_PROMPT_REPETITIONS,
                 expected_ongoing_request_count=1,
-                graceful_shutdown=lambda worker: _sglang_graceful_shutdown(
+                graceful_shutdown=lambda worker: graceful_worker_shutdown(
                     frontend, worker
                 ),
                 verify_replacement_worker=True,
@@ -770,7 +720,7 @@ def test_request_migration_sglang_decode(
                 max_tokens=DECODE_MAX_TOKENS,
                 wait_for_new_response_before_stop=True,
                 expected_ongoing_request_count=1,
-                graceful_shutdown=lambda worker: _sglang_graceful_shutdown(
+                graceful_shutdown=lambda worker: graceful_worker_shutdown(
                     frontend, worker
                 ),
                 verify_replacement_worker=True,

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -21,7 +21,7 @@ from tests.utils.payloads import check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port
 
 # Customized utils for migration tests
-from .utils import DynamoFrontendProcess, run_migration_test
+from .utils import DynamoFrontendProcess, graceful_worker_shutdown, run_migration_test
 
 logger = logging.getLogger(__name__)
 
@@ -250,6 +250,10 @@ def test_request_migration_trtllm_aggregated(
                     immediate_kill=immediate_kill,
                     use_chat_completion=(request_api == "chat"),
                     stream=stream,
+                    expect_drain=not immediate_kill,
+                    graceful_shutdown=lambda worker: graceful_worker_shutdown(
+                        frontend, worker
+                    ),
                 )
 
 
@@ -327,6 +331,10 @@ def test_request_migration_trtllm_prefill(
                         use_chat_completion=(request_api == "chat"),
                         stream=stream,
                         use_long_prompt=True,
+                        expect_drain=not immediate_kill,
+                        graceful_shutdown=lambda worker: graceful_worker_shutdown(
+                            frontend, worker, endpoint=("prefill", "generate")
+                        ),
                     )
 
 
@@ -402,6 +410,10 @@ def test_request_migration_trtllm_kv_transfer(
                         use_chat_completion=(request_api == "chat"),
                         stream=stream,
                         use_long_prompt=True,
+                        expect_drain=not immediate_kill,
+                        graceful_shutdown=lambda worker: graceful_worker_shutdown(
+                            frontend, worker
+                        ),
                     )
 
 
@@ -480,4 +492,8 @@ def test_request_migration_trtllm_decode(
                         use_chat_completion=(request_api == "chat"),
                         stream=stream,
                         wait_for_new_response_before_stop=True,
+                        expect_drain=not immediate_kill,
+                        graceful_shutdown=lambda worker: graceful_worker_shutdown(
+                            frontend, worker
+                        ),
                     )

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -331,10 +331,6 @@ def test_request_migration_trtllm_prefill(
                         use_chat_completion=(request_api == "chat"),
                         stream=stream,
                         use_long_prompt=True,
-                        expect_drain=not immediate_kill,
-                        graceful_shutdown=lambda worker: graceful_worker_shutdown(
-                            frontend, worker, endpoint=("prefill", "generate")
-                        ),
                     )
 
 
@@ -410,10 +406,6 @@ def test_request_migration_trtllm_kv_transfer(
                         use_chat_completion=(request_api == "chat"),
                         stream=stream,
                         use_long_prompt=True,
-                        expect_drain=not immediate_kill,
-                        graceful_shutdown=lambda worker: graceful_worker_shutdown(
-                            frontend, worker
-                        ),
                     )
 
 

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -250,7 +250,6 @@ def test_request_migration_trtllm_aggregated(
                     immediate_kill=immediate_kill,
                     use_chat_completion=(request_api == "chat"),
                     stream=stream,
-                    expect_drain=not immediate_kill,
                     graceful_shutdown=lambda worker: graceful_worker_shutdown(
                         frontend, worker
                     ),
@@ -484,7 +483,6 @@ def test_request_migration_trtllm_decode(
                         use_chat_completion=(request_api == "chat"),
                         stream=stream,
                         wait_for_new_response_before_stop=True,
-                        expect_drain=not immediate_kill,
                         graceful_shutdown=lambda worker: graceful_worker_shutdown(
                             frontend, worker
                         ),

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -24,6 +24,7 @@ from tests.utils.port_utils import allocate_port, deallocate_ports
 # Customized utils for migration tests
 from .utils import (
     DynamoFrontendProcess,
+    graceful_worker_shutdown,
     managed_processes_concurrently,
     run_migration_test,
     wait_for_endpoint_instances,
@@ -459,7 +460,11 @@ def test_request_migration_vllm_aggregated(
                 use_chat_completion=(request_api == "chat"),
                 stream=stream,
                 max_tokens=AGGREGATED_MAX_TOKENS,
-                expected_ongoing_request_count=1,
+                expected_ongoing_request_count=1 if immediate_kill else None,
+                expect_drain=not immediate_kill,
+                graceful_shutdown=lambda worker: graceful_worker_shutdown(
+                    frontend, worker
+                ),
             )
 
 
@@ -548,7 +553,11 @@ def test_request_migration_vllm_kv_transfer(
                 max_tokens=KV_TRANSFER_MAX_TOKENS,
                 use_long_prompt=True,
                 long_prompt_repetitions=KV_TRANSFER_PROMPT_REPETITIONS,
-                expected_ongoing_request_count=1,
+                expected_ongoing_request_count=1 if immediate_kill else None,
+                expect_drain=not immediate_kill,
+                graceful_shutdown=lambda worker: graceful_worker_shutdown(
+                    frontend, worker
+                ),
             )
 
 
@@ -633,5 +642,9 @@ def test_request_migration_vllm_decode(
                 stream=True,
                 max_tokens=DECODE_MAX_TOKENS,
                 wait_for_new_response_before_stop=True,
-                expected_ongoing_request_count=1,
+                expected_ongoing_request_count=1 if immediate_kill else None,
+                expect_drain=not immediate_kill,
+                graceful_shutdown=lambda worker: graceful_worker_shutdown(
+                    frontend, worker
+                ),
             )

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -460,8 +460,7 @@ def test_request_migration_vllm_aggregated(
                 use_chat_completion=(request_api == "chat"),
                 stream=stream,
                 max_tokens=AGGREGATED_MAX_TOKENS,
-                expected_ongoing_request_count=1 if immediate_kill else None,
-                expect_drain=not immediate_kill,
+                expected_ongoing_request_count=1,
                 graceful_shutdown=lambda worker: graceful_worker_shutdown(
                     frontend, worker
                 ),
@@ -553,8 +552,7 @@ def test_request_migration_vllm_kv_transfer(
                 max_tokens=KV_TRANSFER_MAX_TOKENS,
                 use_long_prompt=True,
                 long_prompt_repetitions=KV_TRANSFER_PROMPT_REPETITIONS,
-                expected_ongoing_request_count=1 if immediate_kill else None,
-                expect_drain=not immediate_kill,
+                expected_ongoing_request_count=1,
                 graceful_shutdown=lambda worker: graceful_worker_shutdown(
                     frontend, worker
                 ),
@@ -642,8 +640,7 @@ def test_request_migration_vllm_decode(
                 stream=True,
                 max_tokens=DECODE_MAX_TOKENS,
                 wait_for_new_response_before_stop=True,
-                expected_ongoing_request_count=1 if immediate_kill else None,
-                expect_drain=not immediate_kill,
+                expected_ongoing_request_count=1,
                 graceful_shutdown=lambda worker: graceful_worker_shutdown(
                     frontend, worker
                 ),

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -25,6 +25,10 @@ from tests.utils.prometheus import sum_metric_samples
 
 logger = logging.getLogger(__name__)
 
+# The (component, endpoint) pair a decode or aggregated worker registers with
+# the frontend.
+BACKEND_ENDPOINT = ("backend", "generate")
+
 
 @contextmanager
 def managed_processes_concurrently(
@@ -470,7 +474,6 @@ def wait_for_endpoint_instance_reduction(
 def graceful_worker_shutdown(
     frontend: DynamoFrontendProcess,
     worker: ManagedProcess,
-    endpoint: tuple[str, str] = ("backend", "generate"),
 ) -> Iterator[None]:
     """Send SIGTERM only, and keep the worker alive until the outcome is known.
 
@@ -484,8 +487,6 @@ def graceful_worker_shutdown(
     Args:
         frontend: Frontend whose `/health` view reports endpoint instances
         worker: Worker to shut down
-        endpoint: The (component, endpoint) pair this worker registers.
-            Prefill workers register ("prefill", "generate").
     """
     response = requests.get(
         f"http://localhost:{frontend.frontend_port}/health",
@@ -495,7 +496,7 @@ def graceful_worker_shutdown(
     previous_count = sum(
         1
         for instance in response.json().get("instances", [])
-        if (instance.get("component"), instance.get("endpoint")) == endpoint
+        if (instance.get("component"), instance.get("endpoint")) == BACKEND_ENDPOINT
     )
 
     pid = worker.get_pid()
@@ -505,16 +506,16 @@ def graceful_worker_shutdown(
         for child in parent.children(recursive=True):
             try:
                 process_groups.add(os.getpgid(child.pid))
-            except (ProcessLookupError, OSError):
+            except ProcessLookupError:
                 pass
-    except (psutil.AccessDenied, psutil.NoSuchProcess):
+    except psutil.NoSuchProcess:
         pass
 
     try:
         parent.terminate()
         wait_for_endpoint_instance_reduction(
             frontend.frontend_port,
-            endpoint,
+            BACKEND_ENDPOINT,
             previous_count,
         )
         yield
@@ -814,13 +815,8 @@ def run_migration_test(
             opt into strict metric validation. When omitted, preserve the
             shared helper's historical backend-agnostic lower-bound behavior.
         expect_drain: Assert the graceful-shutdown contract instead of the
-            migration contract: a SIGTERM'd worker finishes the requests it has
-            already admitted, so the request must succeed and both migration
-            counters must be exactly zero. The max_seq_len_exceeded counter is
-            not a migration outcome and keeps its usual expectation -- see
-            Step 6. Requires immediate_kill=False and a graceful_shutdown
-            context, and is mutually exclusive with
-            expected_ongoing_request_count.
+            migration contract: a SIGTERM'd worker finishes the request it has
+            already admitted, so the request succeeds and nothing migrates.
         graceful_shutdown: Optional backend-specific context that initiates
             graceful shutdown before response validation and performs final
             cleanup after the request outcome is known.

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -815,9 +815,11 @@ def run_migration_test(
             shared helper's historical backend-agnostic lower-bound behavior.
         expect_drain: Assert the graceful-shutdown contract instead of the
             migration contract: a SIGTERM'd worker finishes the requests it has
-            already admitted, so the request must succeed and every migration
-            counter must be exactly zero. Requires immediate_kill=False and a
-            graceful_shutdown context, and is mutually exclusive with
+            already admitted, so the request must succeed and both migration
+            counters must be exactly zero. The max_seq_len_exceeded counter is
+            not a migration outcome and keeps its usual expectation -- see
+            Step 6. Requires immediate_kill=False and a graceful_shutdown
+            context, and is mutually exclusive with
             expected_ongoing_request_count.
         graceful_shutdown: Optional backend-specific context that initiates
             graceful shutdown before response validation and performs final
@@ -845,7 +847,7 @@ def run_migration_test(
             )
         if expected_ongoing_request_count is not None:
             raise ValueError(
-                "expect_drain already pins every migration counter to zero; "
+                "expect_drain already pins both migration counters to zero; "
                 "pass expected_ongoing_request_count only without it"
             )
 
@@ -940,15 +942,27 @@ def run_migration_test(
     # log strings. `ongoing_request` counts an error from an established
     # stream, including an attempt that cannot retry because migration_limit is
     # zero. It is the structured equivalent of the old "Stream disconnected,
-    # recreating stream" log assertion. `max_seq_len_exceeded` records hitting
-    # the migration seq-len cap. A drain migrates nothing at all, so every
-    # counter must be exactly zero -- lower-bound checks would pass vacuously.
+    # recreating stream" log assertion.
+    #
+    # `max_seq_len_exceeded` is deliberately NOT part of the drain contract. It
+    # is not a migration outcome: RetryManager increments it from ordinary token
+    # accounting in `exceed_max_seq_len` (lib/llm/src/migration.rs), which runs
+    # once at request build time against the prompt and then per response chunk
+    # from `track_response`. No fault, stream break, or migration is involved,
+    # and the counter fires at most once because it zeroes `retries_left`. So a
+    # request that drains perfectly with migration_max_seq_len=1 still records
+    # exactly one seq-cap event, and both arms share the same expectation.
+    expected_max_seq_len_exceeded_count = 1 if migration_max_seq_len == 1 else 0
+
     if expect_drain:
+        # A drain migrates nothing, so both migration counters must be exactly
+        # zero -- under the default lower-bound mode a zero expectation asserts
+        # nothing at all, hence exact_counts=True.
         verify_migration_metrics(
             frontend.frontend_port,
             expected_ongoing_request_count=0,
             expected_new_request_count=0,
-            expected_max_seq_len_exceeded_count=0,
+            expected_max_seq_len_exceeded_count=expected_max_seq_len_exceeded_count,
             exact_counts=True,
         )
         return
@@ -960,6 +974,6 @@ def run_migration_test(
     verify_migration_metrics(
         frontend.frontend_port,
         expected_ongoing_request_count=expected_ongoing_request_count,
-        expected_max_seq_len_exceeded_count=1 if migration_max_seq_len == 1 else 0,
+        expected_max_seq_len_exceeded_count=expected_max_seq_len_exceeded_count,
         exact_counts=exact_metric_counts,
     )

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -910,10 +910,8 @@ def run_migration_test(
             shutdown_context = graceful_shutdown(worker)
 
     # Step 5: Validate the request outcome via its response (the user-facing
-    # contract). A drained worker must complete the request it already admitted,
-    # whatever the migration settings are. Otherwise migration is expected to
-    # succeed only when it is enabled and the request does not exceed the
-    # migration seq-len cap; otherwise the in-flight request must fail.
+    # contract). A drained worker completes its admitted request; otherwise
+    # migration succeeds only when enabled and under the seq-len cap, else fails.
     with shutdown_context:
         if expect_drain:
             validate_response(request_thread, response_list)
@@ -942,22 +940,13 @@ def run_migration_test(
     # log strings. `ongoing_request` counts an error from an established
     # stream, including an attempt that cannot retry because migration_limit is
     # zero. It is the structured equivalent of the old "Stream disconnected,
-    # recreating stream" log assertion.
-    #
-    # `max_seq_len_exceeded` is deliberately NOT part of the drain contract. It
-    # is not a migration outcome: RetryManager increments it from ordinary token
-    # accounting in `exceed_max_seq_len` (lib/llm/src/migration.rs), which runs
-    # once at request build time against the prompt and then per response chunk
-    # from `track_response`. No fault, stream break, or migration is involved,
-    # and the counter fires at most once because it zeroes `retries_left`. So a
-    # request that drains perfectly with migration_max_seq_len=1 still records
-    # exactly one seq-cap event, and both arms share the same expectation.
+    # recreating stream" log assertion. `max_seq_len_exceeded` records the
+    # seq-len cap from token accounting, not migration, so both arms share it.
     expected_max_seq_len_exceeded_count = 1 if migration_max_seq_len == 1 else 0
 
     if expect_drain:
-        # A drain migrates nothing, so both migration counters must be exactly
-        # zero -- under the default lower-bound mode a zero expectation asserts
-        # nothing at all, hence exact_counts=True.
+        # A drain migrates nothing. Under the default lower-bound mode a zero
+        # expectation asserts nothing, hence exact_counts=True.
         verify_migration_metrics(
             frontend.frontend_port,
             expected_ongoing_request_count=0,

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -2,13 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
 import re
+import signal
 import threading
 import time
 from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import AbstractContextManager, ExitStack, contextmanager, nullcontext
 
+import psutil
 import pytest
 import requests
 from openai import APIError, OpenAI
@@ -463,6 +466,66 @@ def wait_for_endpoint_instance_reduction(
     )
 
 
+@contextmanager
+def graceful_worker_shutdown(
+    frontend: DynamoFrontendProcess,
+    worker: ManagedProcess,
+    endpoint: tuple[str, str] = ("backend", "generate"),
+) -> Iterator[None]:
+    """Send SIGTERM only, and keep the worker alive until the outcome is known.
+
+    `terminate_process_tree` escalates to SIGKILL a fixed number of seconds
+    after SIGTERM, so a worker that is still draining a generation is killed
+    mid-stream and the request migrates instead. This context sends SIGTERM,
+    waits for the worker to leave frontend discovery, yields while the request
+    outcome is observed, and only then force-kills the worker's process groups.
+    Teardown still cannot leak engine processes that pin the GPU.
+
+    Args:
+        frontend: Frontend whose `/health` view reports endpoint instances
+        worker: Worker to shut down
+        endpoint: The (component, endpoint) pair this worker registers.
+            Prefill workers register ("prefill", "generate").
+    """
+    response = requests.get(
+        f"http://localhost:{frontend.frontend_port}/health",
+        timeout=1,
+    )
+    response.raise_for_status()
+    previous_count = sum(
+        1
+        for instance in response.json().get("instances", [])
+        if (instance.get("component"), instance.get("endpoint")) == endpoint
+    )
+
+    pid = worker.get_pid()
+    parent = psutil.Process(pid)
+    process_groups = {os.getpgid(pid)}
+    try:
+        for child in parent.children(recursive=True):
+            try:
+                process_groups.add(os.getpgid(child.pid))
+            except (ProcessLookupError, OSError):
+                pass
+    except (psutil.AccessDenied, psutil.NoSuchProcess):
+        pass
+
+    try:
+        parent.terminate()
+        wait_for_endpoint_instance_reduction(
+            frontend.frontend_port,
+            endpoint,
+            previous_count,
+        )
+        yield
+    finally:
+        for process_group in process_groups:
+            try:
+                os.killpg(process_group, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
 def wait_for_response(
     response_list: list[tuple[str | None | Exception, float]],
     num_responses: int = 5,
@@ -723,6 +786,7 @@ def run_migration_test(
     long_prompt_repetitions: int = 8_000,
     wait_for_new_response_before_stop: bool = False,
     expected_ongoing_request_count: int | None = None,
+    expect_drain: bool = False,
     graceful_shutdown: Callable[[ManagedProcess], AbstractContextManager[None]]
     | None = None,
     verify_replacement_worker: bool = False,
@@ -749,6 +813,12 @@ def run_migration_test(
         expected_ongoing_request_count: Exact expected count for callers that
             opt into strict metric validation. When omitted, preserve the
             shared helper's historical backend-agnostic lower-bound behavior.
+        expect_drain: Assert the graceful-shutdown contract instead of the
+            migration contract: a SIGTERM'd worker finishes the requests it has
+            already admitted, so the request must succeed and every migration
+            counter must be exactly zero. Requires immediate_kill=False and a
+            graceful_shutdown context, and is mutually exclusive with
+            expected_ongoing_request_count.
         graceful_shutdown: Optional backend-specific context that initiates
             graceful shutdown before response validation and performs final
             cleanup after the request outcome is known.
@@ -762,6 +832,23 @@ def run_migration_test(
             max_tokens budget so state-based fault synchronization cannot race
             an early EOS.
     """
+    if expect_drain:
+        if immediate_kill:
+            raise ValueError(
+                "expect_drain asserts the graceful-shutdown drain contract and "
+                "is incompatible with immediate_kill=True"
+            )
+        if graceful_shutdown is None:
+            raise ValueError(
+                "expect_drain requires a graceful_shutdown context; the default "
+                "shutdown path escalates to SIGKILL and cuts the drain short"
+            )
+        if expected_ongoing_request_count is not None:
+            raise ValueError(
+                "expect_drain already pins every migration counter to zero; "
+                "pass expected_ongoing_request_count only without it"
+            )
+
     # Step 1: Send the request
     if use_chat_completion:
         request_thread, response_list = start_chat_completion_request(
@@ -821,11 +908,14 @@ def run_migration_test(
             shutdown_context = graceful_shutdown(worker)
 
     # Step 5: Validate the request outcome via its response (the user-facing
-    # contract). Migration is expected to succeed only when it is enabled and the
-    # request does not exceed the migration seq-len cap; otherwise the in-flight
-    # request must fail.
+    # contract). A drained worker must complete the request it already admitted,
+    # whatever the migration settings are. Otherwise migration is expected to
+    # succeed only when it is enabled and the request does not exceed the
+    # migration seq-len cap; otherwise the in-flight request must fail.
     with shutdown_context:
-        if migration_limit > 0 and migration_max_seq_len != 1:
+        if expect_drain:
+            validate_response(request_thread, response_list)
+        elif migration_limit > 0 and migration_max_seq_len != 1:
             if verify_replacement_worker:
                 wait_for_worker_request_id(
                     replacement_worker,
@@ -851,7 +941,18 @@ def run_migration_test(
     # stream, including an attempt that cannot retry because migration_limit is
     # zero. It is the structured equivalent of the old "Stream disconnected,
     # recreating stream" log assertion. `max_seq_len_exceeded` records hitting
-    # the migration seq-len cap.
+    # the migration seq-len cap. A drain migrates nothing at all, so every
+    # counter must be exactly zero -- lower-bound checks would pass vacuously.
+    if expect_drain:
+        verify_migration_metrics(
+            frontend.frontend_port,
+            expected_ongoing_request_count=0,
+            expected_new_request_count=0,
+            expected_max_seq_len_exceeded_count=0,
+            exact_counts=True,
+        )
+        return
+
     exact_metric_counts = expected_ongoing_request_count is not None
     if expected_ongoing_request_count is None:
         expected_ongoing_request_count = 1 if migration_limit > 0 else 0

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -478,11 +478,17 @@ def graceful_worker_shutdown(
     """Send SIGTERM only, and keep the worker alive until the outcome is known.
 
     `terminate_process_tree` escalates to SIGKILL a fixed number of seconds
-    after SIGTERM, so a worker that is still draining a generation is killed
-    mid-stream and the request migrates instead. This context sends SIGTERM,
-    waits for the worker to leave frontend discovery, yields while the request
-    outcome is observed, and only then force-kills the worker's process groups.
-    Teardown still cannot leak engine processes that pin the GPU.
+    after SIGTERM, which severs the worker's streams before its own shutdown
+    path can report anything. A migration observed that way shows only that the
+    frontend reacts to a dead connection, not that the backend interrupted the
+    request at grace expiry and reported a migratable error. Sending SIGTERM
+    alone leaves the backend's shutdown event, abort monitor and error
+    propagation as the only thing that can produce the migration.
+
+    This context sends SIGTERM, waits for the worker to leave frontend
+    discovery, yields while the request outcome is observed, and only then
+    force-kills the worker's process groups, so teardown still cannot leak
+    engine processes that pin the GPU.
 
     Args:
         frontend: Frontend whose `/health` view reports endpoint instances
@@ -787,7 +793,6 @@ def run_migration_test(
     long_prompt_repetitions: int = 8_000,
     wait_for_new_response_before_stop: bool = False,
     expected_ongoing_request_count: int | None = None,
-    expect_drain: bool = False,
     graceful_shutdown: Callable[[ManagedProcess], AbstractContextManager[None]]
     | None = None,
     verify_replacement_worker: bool = False,
@@ -814,9 +819,6 @@ def run_migration_test(
         expected_ongoing_request_count: Exact expected count for callers that
             opt into strict metric validation. When omitted, preserve the
             shared helper's historical backend-agnostic lower-bound behavior.
-        expect_drain: Assert the graceful-shutdown contract instead of the
-            migration contract: a SIGTERM'd worker finishes the request it has
-            already admitted, so the request succeeds and nothing migrates.
         graceful_shutdown: Optional backend-specific context that initiates
             graceful shutdown before response validation and performs final
             cleanup after the request outcome is known.
@@ -830,23 +832,6 @@ def run_migration_test(
             max_tokens budget so state-based fault synchronization cannot race
             an early EOS.
     """
-    if expect_drain:
-        if immediate_kill:
-            raise ValueError(
-                "expect_drain asserts the graceful-shutdown drain contract and "
-                "is incompatible with immediate_kill=True"
-            )
-        if graceful_shutdown is None:
-            raise ValueError(
-                "expect_drain requires a graceful_shutdown context; the default "
-                "shutdown path escalates to SIGKILL and cuts the drain short"
-            )
-        if expected_ongoing_request_count is not None:
-            raise ValueError(
-                "expect_drain already pins both migration counters to zero; "
-                "pass expected_ongoing_request_count only without it"
-            )
-
     # Step 1: Send the request
     if use_chat_completion:
         request_thread, response_list = start_chat_completion_request(
@@ -906,12 +891,11 @@ def run_migration_test(
             shutdown_context = graceful_shutdown(worker)
 
     # Step 5: Validate the request outcome via its response (the user-facing
-    # contract). A drained worker completes its admitted request; otherwise
-    # migration succeeds only when enabled and under the seq-len cap, else fails.
+    # contract). Migration is expected to succeed only when it is enabled and the
+    # request does not exceed the migration seq-len cap; otherwise the in-flight
+    # request must fail.
     with shutdown_context:
-        if expect_drain:
-            validate_response(request_thread, response_list)
-        elif migration_limit > 0 and migration_max_seq_len != 1:
+        if migration_limit > 0 and migration_max_seq_len != 1:
             if verify_replacement_worker:
                 wait_for_worker_request_id(
                     replacement_worker,
@@ -936,22 +920,8 @@ def run_migration_test(
     # log strings. `ongoing_request` counts an error from an established
     # stream, including an attempt that cannot retry because migration_limit is
     # zero. It is the structured equivalent of the old "Stream disconnected,
-    # recreating stream" log assertion. `max_seq_len_exceeded` records the
-    # seq-len cap from token accounting, not migration, so both arms share it.
-    expected_max_seq_len_exceeded_count = 1 if migration_max_seq_len == 1 else 0
-
-    if expect_drain:
-        # A drain migrates nothing. Under the default lower-bound mode a zero
-        # expectation asserts nothing, hence exact_counts=True.
-        verify_migration_metrics(
-            frontend.frontend_port,
-            expected_ongoing_request_count=0,
-            expected_new_request_count=0,
-            expected_max_seq_len_exceeded_count=expected_max_seq_len_exceeded_count,
-            exact_counts=True,
-        )
-        return
-
+    # recreating stream" log assertion. `max_seq_len_exceeded` records hitting
+    # the migration seq-len cap.
     exact_metric_counts = expected_ongoing_request_count is not None
     if expected_ongoing_request_count is None:
         expected_ongoing_request_count = 1 if migration_limit > 0 else 0
@@ -959,6 +929,6 @@ def run_migration_test(
     verify_migration_metrics(
         frontend.frontend_port,
         expected_ongoing_request_count=expected_ongoing_request_count,
-        expected_max_seq_len_exceeded_count=expected_max_seq_len_exceeded_count,
+        expected_max_seq_len_exceeded_count=1 if migration_max_seq_len == 1 else 0,
         exact_counts=exact_metric_counts,
     )


### PR DESCRIPTION
## Overview:

The request-migration fault-tolerance tests run each case twice: an abrupt worker kill (`worker_failure`) and a graceful shutdown (`graceful_shutdown`). Both arms assert that the in-flight request migrates to the surviving worker. On the graceful arm that assertion was not testing what it looked like it was testing. With no caller-supplied shutdown context, `run_migration_test` tore the worker down with `terminate_process_tree(..., timeout=2)`, which escalates to `SIGKILL` two seconds after `SIGTERM` — far shorter than a generation. The severed connection produced the migration by itself, so the row stayed green whether or not the backend's own shutdown path ever reported anything.

## Details:

`tests/fault_tolerance/migration/utils.py` gains a shared `graceful_worker_shutdown` context. It sends `SIGTERM`, waits for the worker to leave frontend discovery, yields while the request outcome is observed, and force-kills the worker's process groups only afterwards, so teardown still cannot leak engine processes that pin GPU memory. Its escalation deadline is the request outcome rather than a constant, so no value has to be guessed to exceed the slowest generation on a loaded nightly runner. Process-group capture suppresses only `ProcessLookupError` and `psutil.NoSuchProcess`, so an inspection failure surfaces rather than silently dropping a live child group before `SIGKILL`.

Without the harness `SIGKILL`, the only thing that can still migrate the request is the backend's own shutdown path. `graceful_shutdown_with_discovery` sets the shared `shutdown_event` once the grace period and the pre-shutdown callback are done; each handler's per-request abort monitor is waiting on that event, aborts the request through the engine client and raises `EngineShutdown`; and that reaches the frontend as `ErrorType::Backend(BackendError::EngineShutdown)`, which `lib/llm/src/migration.rs` lists as migratable. The graceful rows keep their migration expectation, and now fail if any link in that chain breaks instead of passing on a dead socket.

`graceful_worker_shutdown` is the only copy of that context for all three backend suites. `tests/fault_tolerance/migration/test_sglang.py` imports it at its three `graceful_shutdown=` call sites in place of a private duplicate. `tests/fault_tolerance/migration/test_vllm.py` adopts it at all three of its call sites and pins `expected_ongoing_request_count=1`, which asks `verify_migration_metrics` for an exact count rather than the backend-agnostic lower bound. `tests/fault_tolerance/migration/test_trtllm.py` adopts it in the aggregated and decode tests; its prefill and KV-transfer tests carry an unconditional `@pytest.mark.skip`, so they are left alone rather than given a context no CI stage can exercise. The `worker_failure` arm is unchanged everywhere.

## Where should the reviewer start?

`graceful_worker_shutdown` in `tests/fault_tolerance/migration/utils.py`, then the `graceful_shutdown=` call sites that now use it. The judgement worth making is whether the request outcome is the right escalation deadline for a nightly runner, given that a worker which never reports and never drains would hold the row open until the suite's own `@pytest.mark.timeout`.

## Validation

Test-only. No production code changes, and no test function or parametrized argument is added or removed, so the collected node ids are unchanged.

```
python -m pytest --collect-only -q tests/fault_tolerance/migration/
pre-commit run --files tests/fault_tolerance/migration/utils.py \
    tests/fault_tolerance/migration/test_trtllm.py \
    tests/fault_tolerance/migration/test_vllm.py \
    tests/fault_tolerance/migration/test_sglang.py
```

Collection reports `412 tests collected in 0.54s` with `PYTHONPATH` pointing at `lib/bindings/python/src` and `components/src`, which supplies the pure-Python `dynamo.prometheus_names` that `tests/utils/payloads.py` imports. Every applicable `pre-commit` hook reports `Passed`, including `isort`, `black`, `flake8`, `ruff` and `codespell`.

The shutdown chain the graceful rows depend on was exercised directly, without a GPU, against the real `components/src/dynamo/common/utils/graceful_shutdown.py` and the real `BaseWorkerHandler._abort_monitor` from `components/src/dynamo/vllm/handlers.py`, with only the compiled `dynamo._core` extension and the engine client stubbed. `graceful_shutdown_with_discovery` reached `shutdown_event.set()` `0.000s` after entry with `DYN_GRACEFUL_SHUTDOWN_GRACE_PERIOD_SECS=0`, and did so before the cleanup callback rather than after it, so engine teardown does not delay the notification. Setting that event drove the real abort monitor to call `engine_client.abort("req-1")` and raise `EngineShutdown: Engine was shut down during generation.` out of the body the context manager wraps.

The graceful-shutdown rows themselves were not run. They carry the `fault_tolerance` and `nightly` markers and need two live backend workers plus a frontend. On the machine used here the GPU driver reports CUDA 12.8 while the installed PyTorch 2.11.0 and vLLM 0.26.0 are built for CUDA 13.0, so `torch.cuda.init()` raises `The NVIDIA driver on your system is too old (found version 12080)` and no vLLM worker starts. A nightly GPU run is what confirms these rows end to end.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized graceful worker shutdown handling across fault-tolerance migration scenarios.
  * Expanded validation for backend endpoint deregistration and request handling during worker termination.
  * Applied shared shutdown behavior to aggregated, KV-transfer, and decode migration workflows across supported backends.
  * Improved handling of workers that exit during migration, including graceful termination followed by forced cleanup when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->