### PR TITLE
feat(llm): [cherry-pick 1.5.0] add extra_body passthrough to media requests (#13817)

### DIFF
--- a/components/src/dynamo/common/protocols/__init__.py
+++ b/components/src/dynamo/common/protocols/__init__.py
@@ -7,13 +7,91 @@ This module provides protocol types for various modalities:
 - video_protocol: NvCreateVideoRequest, NvVideosResponse for video generation
 """
 
+from typing import Any, Dict, Optional
+
 from dynamo.common.protocols.video_protocol import (
     NvCreateVideoRequest,
     NvVideosResponse,
     VideoData,
 )
 
+MEDIA_PASSTHROUGH_KEY = "media_passthrough"
+"""Key under a media request's ``extra_args`` where the frontend nests
+unknown top-level request fields (an OpenAI client's ``extra_body``)."""
+
+
+class MediaPassthroughRejected(ValueError):
+    """A request tried to pass a knob the deployment owns, not the caller."""
+
+
+# Keys a caller must never set through the passthrough bucket. These name a
+# thing to load or a safety/policy control, and the bucket is fully caller
+# controlled, so honoring them would let a request point the engine at code
+# to load or turn a guardrail off.
+_RESERVED_PASSTHROUGH_KEYS = frozenset(
+    {
+        "extra_args",
+        "guardrails",
+        "frame_interpolation_model_path",
+    }
+)
+
+# A knob whose name contains one of these is treated the same way: the first
+# group names a fetch or load location, the second a safety/policy switch.
+_UNSAFE_KEY_MARKERS = (
+    "path",
+    "checkpoint",
+    "ckpt",
+    "repo",
+    "hub",
+    "url",
+    "uri",
+    "local_dir",
+    "guardrail",
+    "safety",
+    "nsfw",
+    "moderation",
+)
+
+
+def _passthrough_key_rejected(key: str) -> bool:
+    if key in _RESERVED_PASSTHROUGH_KEYS or key.startswith("_"):
+        return True
+    lowered = key.lower()
+    return any(marker in lowered for marker in _UNSAFE_KEY_MARKERS)
+
+
+def sanitize_media_passthrough(
+    extra_args: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Return the passthrough knobs that are safe to hand a backend.
+
+    The frontend nests a request's unknown top-level fields (an OpenAI
+    client's ``extra_body``) under ``extra_args[MEDIA_PASSTHROUGH_KEY]``.
+    Those are untyped and fully caller controlled, so a knob that names a
+    model or checkpoint path, a fetch location, or a safety or policy
+    control is refused here rather than passed to the engine, where it could
+    reach a load path or a guardrail switch. Everything else is returned
+    unchanged for the caller to apply.
+
+    Raises MediaPassthroughRejected (a ValueError) when a rejected knob is
+    present, so request building fails before the engine runs.
+    """
+    knobs = (extra_args or {}).get(MEDIA_PASSTHROUGH_KEY) or {}
+    rejected = sorted(k for k in knobs if _passthrough_key_rejected(k))
+    if rejected:
+        raise MediaPassthroughRejected(
+            "these request fields cannot be set per request (a model or "
+            "checkpoint path, a fetch location, or a safety or policy "
+            "control is deployment configuration): " + ", ".join(rejected)
+        )
+    return dict(knobs)
+
+
 __all__ = [
+    "MEDIA_PASSTHROUGH_KEY",
+    "MediaPassthroughRejected",
+    "sanitize_media_passthrough",
     "NvCreateVideoRequest",
     "NvVideosResponse",
     "VideoData",

--- a/components/src/dynamo/common/protocols/audio_protocol.py
+++ b/components/src/dynamo/common/protocols/audio_protocol.py
@@ -12,7 +12,7 @@ code-generated from the Rust definitions; for now they are maintained
 manually and must be kept in sync.
 """
 
-from typing import Literal, Optional
+from typing import Any, Dict, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -33,6 +33,11 @@ class NvCreateAudioSpeechRequest(BaseModel):
 
     Follows vLLM-Omni's OpenAICreateSpeechRequest format.
     """
+
+    extra_args: Optional[Dict[str, Any]] = None
+    """Worker-boundary passthrough. The frontend nests unknown top-level
+    request fields (an OpenAI client's extra_body) under the
+    "media_passthrough" key."""
 
     # Standard OpenAI params
     input: str

--- a/components/src/dynamo/common/protocols/image_protocol.py
+++ b/components/src/dynamo/common/protocols/image_protocol.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel
 
@@ -37,6 +37,11 @@ class NvCreateImageRequest(BaseModel):
 
     Matches the flattened Rust NvCreateImageRequest in lib/llm/src/protocols/openai/images.rs
     """
+
+    extra_args: Optional[Dict[str, Any]] = None
+    """Worker-boundary passthrough. The frontend nests unknown top-level
+    request fields (an OpenAI client's extra_body) under the
+    "media_passthrough" key."""
 
     prompt: str
     """The text prompt for image generation."""

--- a/components/src/dynamo/common/protocols/video_protocol.py
+++ b/components/src/dynamo/common/protocols/video_protocol.py
@@ -8,7 +8,7 @@ to ensure compatibility with the Dynamo HTTP frontend.
 """
 # TODO: Replace these Pydantic models with Python bindings to the Rust protocol types once PyO3 bindings are available.
 
-from typing import Literal, Optional
+from typing import Any, Dict, Literal, Optional
 
 from pydantic import BaseModel
 
@@ -52,6 +52,11 @@ class NvCreateVideoRequest(BaseModel):
 
     Matches Rust NvCreateVideoRequest in lib/llm/src/protocols/openai/videos.rs.
     """
+
+    extra_args: Optional[Dict[str, Any]] = None
+    """Worker-boundary passthrough. The frontend nests unknown top-level
+    request fields (an OpenAI client's extra_body) under the
+    "media_passthrough" key."""
 
     # Required fields
     prompt: str

--- a/components/src/dynamo/common/tests/test_media_passthrough.py
+++ b/components/src/dynamo/common/tests/test_media_passthrough.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the media passthrough sanitizer.
+
+These run without any engine or model dependency: the point of the
+sanitizer is to refuse a dangerous request field before anything is loaded,
+so the test proves the rejection with no network and no model activity.
+"""
+
+import pytest
+
+from dynamo.common.protocols import (
+    MEDIA_PASSTHROUGH_KEY,
+    MediaPassthroughRejected,
+    sanitize_media_passthrough,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def _wrap(knobs):
+    return {MEDIA_PASSTHROUGH_KEY: knobs}
+
+
+def test_none_and_empty_are_empty():
+    assert sanitize_media_passthrough(None) == {}
+    assert sanitize_media_passthrough({}) == {}
+    assert sanitize_media_passthrough(_wrap({})) == {}
+
+
+def test_benign_knobs_pass_through():
+    knobs = {
+        "backend_custom_knob": 0.5,
+        "denoise_strength": 0.8,
+        "generate_sound": True,
+    }
+    assert sanitize_media_passthrough(_wrap(knobs)) == knobs
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "frame_interpolation_model_path",  # the reported RCE field
+        "guardrails",  # the reported guardrail bypass
+        "extra_args",  # the container itself
+        "vae_checkpoint",
+        "unet_ckpt",
+        "lora_repo",
+        "hf_hub_id",
+        "weights_url",
+        "source_uri",
+        "custom_local_dir",
+        "safety_checker",
+        "nsfw_filter",
+        "content_moderation",
+        "_private_attr",
+    ],
+)
+def test_reserved_and_shaped_keys_are_rejected(key):
+    with pytest.raises(MediaPassthroughRejected):
+        sanitize_media_passthrough(_wrap({key: "x", "harmless": 1}))
+
+
+def test_rejection_names_the_offending_key():
+    with pytest.raises(
+        MediaPassthroughRejected, match="frame_interpolation_model_path"
+    ):
+        sanitize_media_passthrough(
+            _wrap({"frame_interpolation_model_path": "attacker/repo"})
+        )
+
+
+def test_rejected_is_a_value_error():
+    # Request building catches ValueError and returns a client error, so the
+    # sanitizer's exception must be a ValueError subclass.
+    assert issubclass(MediaPassthroughRejected, ValueError)
+
+
+def test_original_bucket_is_not_mutated():
+    bucket = _wrap({"backend_custom_knob": 1})
+    sanitize_media_passthrough(bucket)["backend_custom_knob"] = 999
+    assert bucket[MEDIA_PASSTHROUGH_KEY]["backend_custom_knob"] == 1

--- a/components/src/dynamo/vllm/omni/audio_handler.py
+++ b/components/src/dynamo/vllm/omni/audio_handler.py
@@ -21,6 +21,7 @@ try:
 except ImportError:
     Qwen3TTSPromptEmbedsBuilder = None  # type: ignore[assignment, misc]
 
+from dynamo.common.protocols import sanitize_media_passthrough
 from dynamo.common.protocols.audio_protocol import NvCreateAudioSpeechRequest
 from dynamo.common.utils.output_modalities import RequestType
 
@@ -259,6 +260,12 @@ class AudioGenerationHandler:
 
         if task_type == "VoiceDesign":
             tts_params["non_streaming_mode"] = [True]
+
+        # Frontend-forwarded passthrough knobs join the engine params;
+        # fields the handler already set win. A knob naming a path or a
+        # policy control is refused here (see sanitize_media_passthrough).
+        for key, value in sanitize_media_passthrough(req.extra_args).items():
+            tts_params.setdefault(key, [value])
 
         estimated_len = self._estimate_tts_prompt_len(tts_params)
 

--- a/components/src/dynamo/vllm/omni/omni_handler.py
+++ b/components/src/dynamo/vllm/omni/omni_handler.py
@@ -26,6 +26,7 @@ from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
 
 from dynamo._core import Context
 from dynamo.common.multimodal import ImageLoader
+from dynamo.common.protocols import sanitize_media_passthrough
 from dynamo.common.protocols.audio_protocol import NvCreateAudioSpeechRequest
 from dynamo.common.protocols.image_protocol import ImageNvExt, NvCreateImageRequest
 from dynamo.common.protocols.video_protocol import NvCreateVideoRequest, VideoNvExt
@@ -63,6 +64,35 @@ from dynamo.vllm.omni.utils import (
 logger = logging.getLogger(__name__)
 
 DEFAULT_VIDEO_FPS = 16
+
+
+def _apply_media_passthrough(
+    sp: OmniDiffusionSamplingParams, extra_args: Optional[Dict[str, Any]]
+) -> None:
+    """Hand frontend-forwarded passthrough knobs to the engine.
+
+    The frontend nests a request's unknown top-level fields (an OpenAI
+    client's ``extra_body``) under ``extra_args["media_passthrough"]``.
+    ``sanitize_media_passthrough`` drops the request if any knob names a
+    path/checkpoint or a policy control, then the rest ride ``sp.extra_args``
+    to the engine. Nothing is set on the sampling params by attribute name:
+    a caller-controlled key must not choose which attribute it writes.
+    """
+    knobs = sanitize_media_passthrough(extra_args)
+    if not knobs:
+        return
+    existing = getattr(sp, "extra_args", None)
+    if isinstance(existing, dict):
+        existing.update(knobs)
+    else:
+        try:
+            sp.extra_args = knobs
+        except (AttributeError, TypeError):
+            logger.warning(
+                "Dropping media passthrough knobs %s: sampling params expose "
+                "no extra_args",
+                sorted(knobs),
+            )
 
 
 @dataclass
@@ -682,6 +712,7 @@ class OmniHandler(BaseOmniHandler):
         sp.seed = (
             nvext.seed if nvext.seed is not None else random.randint(0, 2**32 - 1)
         )
+        _apply_media_passthrough(sp, req.extra_args)
 
         sampling_params_list = self._build_sampling_params_list(sp)
         lora_request = self._resolve_and_apply_lora(req.model, sampling_params_list)
@@ -743,6 +774,7 @@ class OmniHandler(BaseOmniHandler):
         self._update_if_not_none(sp, "boundary_ratio", nvext.boundary_ratio)
         self._update_if_not_none(sp, "guidance_scale_2", nvext.guidance_scale_2)
         self._update_if_not_none(sp, "fps", fps)
+        _apply_media_passthrough(sp, req.extra_args)
 
         sampling_params_list = self._build_sampling_params_list(sp)
         lora_request = self._resolve_and_apply_lora(req.model, sampling_params_list)

--- a/components/src/dynamo/vllm/tests/omni/test_omni_handler.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_handler.py
@@ -263,6 +263,60 @@ class TestI2VEngineInputs:
         assert sp.guidance_scale_2 == 1.0
         assert sp.num_inference_steps == 40
 
+    async def test_media_passthrough_reaches_sampling_params(self):
+        """A top-level SDK extra_body field, nested by the frontend under
+        extra_args["media_passthrough"], rides sampling params extra_args to
+        the engine. Nothing is set on the sampling params by attribute name."""
+        handler = _make_handler()
+        req = NvCreateVideoRequest(
+            prompt="a cat by the sea",
+            model="test-model",
+            size="832x480",
+            extra_args={
+                "media_passthrough": {
+                    "backend_custom_knob": 0.5,
+                    "denoise_strength": 0.8,
+                }
+            },
+        )
+        result = await handler.build_engine_inputs(req, RequestType.VIDEO_GENERATION)
+        sp = result.sampling_params_list[0]
+        assert sp.extra_args["backend_custom_knob"] == 0.5
+        assert sp.extra_args["denoise_strength"] == 0.8
+
+    @pytest.mark.parametrize(
+        "bad_knob",
+        [
+            {"frame_interpolation_model_path": "attacker/repository"},
+            {"guardrails": False},
+            {"safety_checker": None},
+            {"vae_checkpoint_url": "http://evil/x.pkl"},
+        ],
+    )
+    async def test_media_passthrough_rejects_load_and_policy_knobs(self, bad_knob):
+        """A path/checkpoint field or a policy control is refused while the
+        request is being built, before any engine call, so it cannot reach a
+        model load or a guardrail switch."""
+        handler = _make_handler()
+        handler.engine_client.generate = MagicMock(
+            side_effect=AssertionError("engine must not run for a rejected request")
+        )
+        req = NvCreateVideoRequest(
+            prompt="a cat",
+            model="test-model",
+            size="832x480",
+            extra_args={"media_passthrough": bad_knob},
+        )
+        with pytest.raises(ValueError):
+            await handler.build_engine_inputs(req, RequestType.VIDEO_GENERATION)
+
+    def test_media_passthrough_absent_is_a_no_op(self):
+        req = NvCreateVideoRequest(prompt="a cat", model="test-model")
+        assert req.extra_args is None
+        handler = _make_handler()
+        inputs = handler._engine_inputs_from_video(req)
+        assert inputs.sampling_params_list is not None
+
     def test_i2v_protocol_roundtrip(self):
         """VideoNvExt and NvCreateVideoRequest serialize/deserialize I2V fields correctly."""
         req = NvCreateVideoRequest(

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -4283,13 +4283,14 @@ pub fn responses_router(
 async fn images(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(request): Json<NvCreateImageRequest>,
+    Json(mut request): Json<NvCreateImageRequest>,
 ) -> Result<Response, ErrorResponse> {
     // return a 503 if the service is not ready
     // (per-model readiness check is deferred until after we resolve the
     // ImageModel enum into a string; see below)
     check_ready(&state)?;
 
+    request.nest_passthrough();
     let request_id = get_or_create_request_id(&headers);
     let request = context_from_headers(request, request_id, &headers)?;
     let request_id = request.id().to_string();
@@ -4424,12 +4425,13 @@ pub fn images_router(
 async fn videos(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(request): Json<NvCreateVideoRequest>,
+    Json(mut request): Json<NvCreateVideoRequest>,
 ) -> Result<Response, ErrorResponse> {
     // return a 503 if the service or model is not ready
     check_ready(&state)?;
     check_model_serving_ready(&state, &request.model)?;
 
+    request.nest_passthrough();
     let request_id = get_or_create_request_id(&headers);
     let request = context_from_headers(request, request_id, &headers)?;
     let request_id = request.id().to_string();
@@ -4546,11 +4548,12 @@ async fn videos(
 async fn video_stream(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(request): Json<NvCreateVideoRequest>,
+    Json(mut request): Json<NvCreateVideoRequest>,
 ) -> Result<Response, ErrorResponse> {
     check_ready(&state)?;
     check_model_serving_ready(&state, &request.model)?;
 
+    request.nest_passthrough();
     let request_id = get_or_create_request_id(&headers);
     let request = context_from_headers(request, request_id, &headers)?;
     let model = request.model.clone();
@@ -4765,6 +4768,7 @@ async fn handler_audio_speech(
             .get_or_insert_default()
             .frontend_accepts_audio_chunks = Some(true);
     }
+    request.nest_passthrough();
     let request = context_from_headers(request, request_id, &headers)?;
 
     // model is optional in the request; fall back to a model that can actually

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -37,6 +37,28 @@ use validate::{
     TEMPERATURE_RANGE, validate_range, validate_top_p,
 };
 
+/// Key under `extra_args` where media handlers nest a request's captured
+/// top-level passthrough before dispatching it to a worker.
+pub const MEDIA_PASSTHROUGH_KEY: &str = "media_passthrough";
+
+/// Move a media request's captured top-level unknowns under an explicit
+/// `extra_args["media_passthrough"]` entry. Handlers call this before
+/// dispatch so the worker boundary carries one nested, namespaced field
+/// instead of loose top-level unknowns.
+pub(crate) fn nest_media_passthrough(
+    passthrough: &mut serde_json::Map<String, serde_json::Value>,
+    extra_args: &mut Option<serde_json::Map<String, serde_json::Value>>,
+) {
+    if passthrough.is_empty() {
+        return;
+    }
+    let nested = std::mem::take(passthrough);
+    extra_args.get_or_insert_with(serde_json::Map::new).insert(
+        MEDIA_PASSTHROUGH_KEY.to_string(),
+        serde_json::Value::Object(nested),
+    );
+}
+
 /// Side from which prompt tokens are truncated.
 #[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/lib/llm/src/protocols/openai/audios.rs
+++ b/lib/llm/src/protocols/openai/audios.rs
@@ -74,6 +74,29 @@ pub struct NvCreateAudioSpeechRequest {
     /// NVIDIA extensions (reserved for future use)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nvext: Option<NvExt>,
+
+    /// Worker-boundary contract, not a public field: the frontend moves
+    /// `passthrough` under `extra_args["media_passthrough"]` before
+    /// dispatch (see [`Self::nest_passthrough`]) so workers read one
+    /// explicit nested entry. A client-sent `extra_args` lands in
+    /// `passthrough` like any other unknown field.
+    #[serde(default, skip_deserializing, skip_serializing_if = "Option::is_none")]
+    pub extra_args: Option<serde_json::Map<String, serde_json::Value>>,
+
+    /// Unknown top-level fields are retained here and forwarded to the
+    /// backend without strict validation. This matches the OpenAI client's
+    /// extra_body option, which merges into the top level of the body.
+    /// Stable knobs can be promoted to typed fields over time.
+    #[serde(default, flatten)]
+    pub passthrough: serde_json::Map<String, serde_json::Value>,
+}
+
+impl NvCreateAudioSpeechRequest {
+    /// Nest captured top-level unknowns under `extra_args["media_passthrough"]`
+    /// for dispatch to a worker.
+    pub fn nest_passthrough(&mut self) {
+        super::nest_media_passthrough(&mut self.passthrough, &mut self.extra_args);
+    }
 }
 
 /// Audio data in response
@@ -246,9 +269,51 @@ mod tests {
             max_new_tokens: None,
             user: None,
             nvext: None,
+            extra_args: None,
+            passthrough: serde_json::Map::new(),
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("data_source"));
+    }
+
+    #[test]
+    fn audio_request_captures_unknown_top_level_fields() {
+        // The OpenAI client's extra_body option merges into the top level of
+        // the body, so that is where backend knobs arrive.
+        let json = r#"{"input":"hello","emotion":"calm","pitch":1.2}"#;
+        let req: NvCreateAudioSpeechRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.passthrough["emotion"], serde_json::json!("calm"));
+        assert_eq!(req.passthrough["pitch"], serde_json::json!(1.2));
+        assert!(!req.passthrough.contains_key("input"));
+
+        let out = serde_json::to_string(&req).unwrap();
+        let back: NvCreateAudioSpeechRequest = serde_json::from_str(&out).unwrap();
+        assert_eq!(back.passthrough, req.passthrough);
+        assert!(out.contains("\"emotion\":\"calm\""));
+    }
+
+    #[test]
+    fn audio_request_empty_passthrough_adds_nothing() {
+        let json = r#"{"input":"hello"}"#;
+        let req: NvCreateAudioSpeechRequest = serde_json::from_str(json).unwrap();
+        assert!(req.passthrough.is_empty());
+        let out: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&req).unwrap()).unwrap();
+        assert_eq!(out, serde_json::json!({"input":"hello"}));
+    }
+
+    #[test]
+    fn audio_request_nests_passthrough_for_workers() {
+        let json = r#"{"input":"hello","emotion":"calm"}"#;
+        let mut req: NvCreateAudioSpeechRequest = serde_json::from_str(json).unwrap();
+        req.nest_passthrough();
+        assert!(req.passthrough.is_empty());
+        let out = serde_json::to_value(&req).unwrap();
+        assert_eq!(
+            out["extra_args"]["media_passthrough"]["emotion"],
+            serde_json::json!("calm")
+        );
+        assert!(out.get("emotion").is_none());
     }
 
     // --- AudioData ---

--- a/lib/llm/src/protocols/openai/images.rs
+++ b/lib/llm/src/protocols/openai/images.rs
@@ -11,17 +11,115 @@ mod nvext;
 pub use nvext::{NvExt, NvExtProvider};
 
 /// Image generation request with NVIDIA extensions.
-#[derive(Serialize, Deserialize, Validate, Debug, Clone)]
+///
+/// Serde is hand-rolled: `inner` occupies the top level of the wire body,
+/// and a derived flattened map next to a flattened struct would capture the
+/// struct's keys too. The manual impls keep one external contract, typed
+/// fields at the top level plus unknown top-level fields retained in
+/// [`Self::passthrough`].
+#[derive(Validate, Debug, Clone)]
 pub struct NvCreateImageRequest {
-    #[serde(flatten)]
     pub inner: dynamo_protocols::types::CreateImageRequest,
 
     /// Optional image reference that guides generation (for I2I/TI2I).
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_reference: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub nvext: Option<NvExt>,
+
+    /// Worker-boundary contract, not a public field: the frontend moves
+    /// `passthrough` under `extra_args["media_passthrough"]` before
+    /// dispatch (see [`Self::nest_passthrough`]) so workers read one
+    /// explicit nested entry. A client-sent `extra_args` lands in
+    /// `passthrough` like any other unknown field.
+    pub extra_args: Option<serde_json::Map<String, serde_json::Value>>,
+
+    /// Unknown top-level fields are retained here and forwarded to the
+    /// backend without strict validation. This matches the OpenAI client's
+    /// extra_body option, which merges into the top level of the body.
+    /// Stable knobs can be promoted to typed fields over time.
+    pub passthrough: serde_json::Map<String, serde_json::Value>,
+}
+
+impl NvCreateImageRequest {
+    /// Nest captured top-level unknowns under `extra_args["media_passthrough"]`
+    /// for dispatch to a worker.
+    pub fn nest_passthrough(&mut self) {
+        super::nest_media_passthrough(&mut self.passthrough, &mut self.extra_args);
+    }
+}
+
+impl<'de> Deserialize<'de> for NvCreateImageRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut body = serde_json::Map::deserialize(deserializer)?;
+        let input_reference = match body.remove("input_reference") {
+            Some(value) => serde_json::from_value(value).map_err(serde::de::Error::custom)?,
+            None => None,
+        };
+        let nvext = match body.remove("nvext") {
+            Some(value) => serde_json::from_value(value).map_err(serde::de::Error::custom)?,
+            None => None,
+        };
+        let inner: dynamo_protocols::types::CreateImageRequest =
+            serde_json::from_value(serde_json::Value::Object(body.clone()))
+                .map_err(serde::de::Error::custom)?;
+        // Keys the typed request consumed stay out of the passthrough.
+        if let serde_json::Value::Object(consumed) =
+            serde_json::to_value(&inner).map_err(serde::de::Error::custom)?
+        {
+            for key in consumed.keys() {
+                body.remove(key);
+            }
+        }
+        Ok(Self {
+            inner,
+            input_reference,
+            nvext,
+            extra_args: None,
+            passthrough: body,
+        })
+    }
+}
+
+impl Serialize for NvCreateImageRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut body = match serde_json::to_value(&self.inner).map_err(serde::ser::Error::custom)? {
+            serde_json::Value::Object(map) => map,
+            _ => {
+                return Err(serde::ser::Error::custom(
+                    "image request must serialize to an object",
+                ));
+            }
+        };
+        // Typed fields win over passthrough entries of the same name.
+        for (key, value) in &self.passthrough {
+            body.entry(key.clone()).or_insert_with(|| value.clone());
+        }
+        if let Some(input_reference) = &self.input_reference {
+            body.insert(
+                "input_reference".to_string(),
+                serde_json::Value::String(input_reference.clone()),
+            );
+        }
+        if let Some(nvext) = &self.nvext {
+            body.insert(
+                "nvext".to_string(),
+                serde_json::to_value(nvext).map_err(serde::ser::Error::custom)?,
+            );
+        }
+        if let Some(extra_args) = &self.extra_args {
+            body.insert(
+                "extra_args".to_string(),
+                serde_json::Value::Object(extra_args.clone()),
+            );
+        }
+        body.serialize(serializer)
+    }
 }
 
 /// A response structure for image generation responses, embedding OpenAI's
@@ -83,5 +181,89 @@ impl AnnotationsProvider for NvCreateImageRequest {
             .and_then(|nvext| nvext.annotations.as_ref())
             .map(|annotations| annotations.contains(&annotation.to_string()))
             .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- NvCreateImageRequest ---
+
+    #[test]
+    fn image_request_captures_unknown_top_level_fields() {
+        // The OpenAI client's extra_body option merges into the top level of
+        // the body, so that is where backend knobs arrive.
+        let json = r#"{"prompt":"a cat","think_mode":true,"size_override":{"h":512,"w":768}}"#;
+        let req: NvCreateImageRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.inner.prompt, "a cat");
+        assert_eq!(req.passthrough["think_mode"], serde_json::json!(true));
+        assert_eq!(
+            req.passthrough["size_override"]["h"],
+            serde_json::json!(512)
+        );
+
+        let out = serde_json::to_string(&req).unwrap();
+        let back: NvCreateImageRequest = serde_json::from_str(&out).unwrap();
+        assert_eq!(back.inner.prompt, "a cat");
+        assert_eq!(back.passthrough, req.passthrough);
+    }
+
+    #[test]
+    fn image_request_typed_fields_stay_out_of_passthrough() {
+        let json = r#"{"prompt":"a cat","n":2,"input_reference":"ref.png","nvext":{"seed":7},"custom_knob":1}"#;
+        let req: NvCreateImageRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.inner.prompt, "a cat");
+        assert_eq!(req.input_reference.as_deref(), Some("ref.png"));
+        assert_eq!(req.nvext.as_ref().and_then(|n| n.seed), Some(7));
+        assert_eq!(req.passthrough["custom_knob"], serde_json::json!(1));
+        for consumed in ["prompt", "n", "input_reference", "nvext"] {
+            assert!(!req.passthrough.contains_key(consumed), "{consumed}");
+        }
+    }
+
+    #[test]
+    fn image_request_round_trips_all_field_kinds_at_top_level() {
+        let json =
+            r#"{"prompt":"a cat","input_reference":"ref.png","nvext":{"seed":7},"knob":"x"}"#;
+        let req: NvCreateImageRequest = serde_json::from_str(json).unwrap();
+        let out: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&req).unwrap()).unwrap();
+        assert_eq!(out["prompt"], serde_json::json!("a cat"));
+        assert_eq!(out["input_reference"], serde_json::json!("ref.png"));
+        assert_eq!(out["nvext"]["seed"], serde_json::json!(7));
+        assert_eq!(out["knob"], serde_json::json!("x"));
+        assert!(out.get("passthrough").is_none());
+        assert!(out.get("inner").is_none());
+    }
+
+    #[test]
+    fn image_request_empty_passthrough_stays_empty() {
+        let json = r#"{"prompt":"a cat"}"#;
+        let req: NvCreateImageRequest = serde_json::from_str(json).unwrap();
+        assert!(req.passthrough.is_empty());
+    }
+
+    #[test]
+    fn image_request_nests_passthrough_for_workers() {
+        let json = r#"{"prompt":"a cat","think_mode":true}"#;
+        let mut req: NvCreateImageRequest = serde_json::from_str(json).unwrap();
+        req.nest_passthrough();
+        assert!(req.passthrough.is_empty());
+        let out = serde_json::to_value(&req).unwrap();
+        assert_eq!(
+            out["extra_args"]["media_passthrough"]["think_mode"],
+            serde_json::json!(true)
+        );
+        assert!(out.get("think_mode").is_none());
+        assert_eq!(out["prompt"], serde_json::json!("a cat"));
+    }
+
+    #[test]
+    fn image_request_client_extra_args_is_not_the_worker_field() {
+        let json = r#"{"prompt":"a cat","extra_args":{"x":1}}"#;
+        let req: NvCreateImageRequest = serde_json::from_str(json).unwrap();
+        assert!(req.extra_args.is_none());
+        assert_eq!(req.passthrough["extra_args"]["x"], serde_json::json!(1));
     }
 }

--- a/lib/llm/src/protocols/openai/videos.rs
+++ b/lib/llm/src/protocols/openai/videos.rs
@@ -53,6 +53,29 @@ pub struct NvCreateVideoRequest {
     /// NVIDIA extensions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nvext: Option<NvExt>,
+
+    /// Worker-boundary contract, not a public field: the frontend moves
+    /// `passthrough` under `extra_args["media_passthrough"]` before
+    /// dispatch (see [`Self::nest_passthrough`]) so workers read one
+    /// explicit nested entry. A client-sent `extra_args` lands in
+    /// `passthrough` like any other unknown field.
+    #[serde(default, skip_deserializing, skip_serializing_if = "Option::is_none")]
+    pub extra_args: Option<serde_json::Map<String, serde_json::Value>>,
+
+    /// Unknown top-level fields are retained here and forwarded to the
+    /// backend without strict validation. This matches the OpenAI client's
+    /// extra_body option, which merges into the top level of the body.
+    /// Stable knobs can be promoted to typed fields over time.
+    #[serde(default, flatten)]
+    pub passthrough: serde_json::Map<String, serde_json::Value>,
+}
+
+impl NvCreateVideoRequest {
+    /// Nest captured top-level unknowns under `extra_args["media_passthrough"]`
+    /// for dispatch to a worker.
+    pub fn nest_passthrough(&mut self) {
+        super::nest_media_passthrough(&mut self.passthrough, &mut self.extra_args);
+    }
 }
 
 /// Video data in response
@@ -213,9 +236,77 @@ mod tests {
             output_format: None,
             stream: None,
             nvext: None,
+            extra_args: None,
+            passthrough: serde_json::Map::new(),
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("stream"));
+    }
+
+    #[test]
+    fn video_request_captures_unknown_top_level_fields() {
+        // The OpenAI client's extra_body option merges into the top level of
+        // the body, so that is where backend knobs arrive.
+        let json = r#"{"prompt":"cat","model":"cosmos","generate_sound":true,"strength":0.7}"#;
+        let req: NvCreateVideoRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.passthrough["generate_sound"], serde_json::json!(true));
+        assert_eq!(req.passthrough["strength"], serde_json::json!(0.7));
+
+        let out = serde_json::to_string(&req).unwrap();
+        let back: NvCreateVideoRequest = serde_json::from_str(&out).unwrap();
+        assert_eq!(back.passthrough, req.passthrough);
+        assert!(out.contains("\"generate_sound\":true"));
+    }
+
+    #[test]
+    fn video_request_typed_fields_stay_out_of_passthrough() {
+        let json = r#"{"prompt":"cat","model":"wan","stream":true,"custom_knob":1}"#;
+        let req: NvCreateVideoRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.stream, Some(true));
+        assert!(!req.passthrough.contains_key("prompt"));
+        assert!(!req.passthrough.contains_key("stream"));
+        assert_eq!(req.passthrough["custom_knob"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn video_request_empty_passthrough_adds_nothing() {
+        let json = r#"{"prompt":"cat","model":"wan"}"#;
+        let req: NvCreateVideoRequest = serde_json::from_str(json).unwrap();
+        assert!(req.passthrough.is_empty());
+        let out: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&req).unwrap()).unwrap();
+        assert_eq!(out, serde_json::json!({"prompt":"cat","model":"wan"}));
+    }
+
+    #[test]
+    fn video_request_nests_passthrough_for_workers() {
+        let json = r#"{"prompt":"cat","model":"cosmos","generate_sound":true}"#;
+        let mut req: NvCreateVideoRequest = serde_json::from_str(json).unwrap();
+        req.nest_passthrough();
+        assert!(req.passthrough.is_empty());
+        let out = serde_json::to_value(&req).unwrap();
+        assert_eq!(
+            out["extra_args"]["media_passthrough"]["generate_sound"],
+            serde_json::json!(true)
+        );
+        assert!(out.get("generate_sound").is_none());
+    }
+
+    #[test]
+    fn video_request_nest_without_unknowns_adds_nothing() {
+        let json = r#"{"prompt":"cat","model":"wan"}"#;
+        let mut req: NvCreateVideoRequest = serde_json::from_str(json).unwrap();
+        req.nest_passthrough();
+        let out = serde_json::to_value(&req).unwrap();
+        assert!(out.get("extra_args").is_none());
+    }
+
+    #[test]
+    fn video_request_client_extra_args_is_not_the_worker_field() {
+        let json = r#"{"prompt":"cat","model":"wan","extra_args":{"x":1}}"#;
+        let req: NvCreateVideoRequest = serde_json::from_str(json).unwrap();
+        assert!(req.extra_args.is_none());
+        assert_eq!(req.passthrough["extra_args"]["x"], serde_json::json!(1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Cherry-pick #13817 to `release/1.5.0`.
- Preserve backend-specific media request knobs under the namespaced worker `extra_args.media_passthrough` contract.
- Reject load-path and policy knobs before Omni dispatch.
- Feature backport; release approval is required.

Fixes DIS-2853

## Original PR
- Main PR: #13817
- Merge commit: `e50e16f8e97a8b200a580f33613359cd232e0b7a`

## Validation
- [x] `pre-commit run --from-ref origin/release/1.5.0 --to-ref HEAD`
- [x] `PYTHONPATH=components/src pytest -q components/src/dynamo/common/tests/test_media_passthrough.py components/src/dynamo/vllm/tests/omni/test_omni_handler.py -k media_passthrough` (19 passed; Omni module skipped because optional dependencies are unavailable locally)
- [x] `cargo test -p dynamo-llm --lib request_` (162 passed)