### PR TITLE
fix(trtllm-sidecar): [cherry-pick 1.5.0] install smg-grpc-proto before starting the gRPC engine

### DIFF
--- a/lib/sidecar/trtllm/README.md
+++ b/lib/sidecar/trtllm/README.md
@@ -34,9 +34,13 @@ carries no context-phase handoff.
 
 ## Run
 
-Start TensorRT-LLM with its native gRPC listener (TRT-LLM `1.3.0rc21`; rc22 has a broken `--grpc`):
+Start TensorRT-LLM with its native gRPC listener. Its protobuf bindings are an
+optional extra, so install them first. Install the package directly rather than
+via `tensorrt_llm[grpc-smg]`: the extra makes pip re-resolve TensorRT-LLM's whole
+dependency closure, which fails on an image whose site-packages is read-only.
 
 ```bash
+pip install "smg-grpc-proto>=0.4.2"
 python -m tensorrt_llm.commands.serve <model> --grpc --host 0.0.0.0 --port 50051
 ```
 

--- a/lib/sidecar/trtllm/deploy/agg.yaml
+++ b/lib/sidecar/trtllm/deploy/agg.yaml
@@ -42,11 +42,10 @@ spec:
     podTemplate:
       spec:
         # trtllm-engine as a native sidecar (initContainer + restartPolicy: Always):
-        # starts before `main`, stops after. --grpc needs rc21; rc22 crashes on
-        # startup (protobuf version mismatch).
+        # starts before `main`, stops after.
         initContainers:
         - name: trtllm-engine
-          image: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc21
+          image: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc25
           restartPolicy: Always
           # gRPC HealthCheck via exec (tcpSocket/grpc: dial the pod IP, not the
           # loopback engine). startupProbe gates `main`; readinessProbe drops dead workers.
@@ -77,10 +76,20 @@ spec:
             requests:
               # Increase for larger models.
               ephemeral-storage: 2Gi
+          # `--grpc` needs `smg-grpc-proto`, which TRT-LLM keeps behind the
+          # optional `grpc-smg` extra rather than shipping in the image.
+          # Constraint copied from that extra so we resolve what upstream
+          # resolves. Needs egress to PyPI; bake it into a derived image if the
+          # cluster has none.
           command:
-          - python3
-          - -m
-          - tensorrt_llm.commands.serve
+          - sh
+          - -c
+          - |
+            set -e
+            python3 -c "import smg_grpc_proto" 2>/dev/null \
+              || pip install --no-cache-dir "smg-grpc-proto>=0.4.2"
+            exec python3 -m tensorrt_llm.commands.serve "$@"
+          - trtllm-serve
           args:
           - Qwen/Qwen3-0.6B
           - --grpc

--- a/lib/sidecar/trtllm/launch/agg.sh
+++ b/lib/sidecar/trtllm/launch/agg.sh
@@ -65,6 +65,13 @@ TRTLLM_GRPC_PORT="${TRTLLM_GRPC_PORT:-50051}"
 TRTLLM_CONTEXT_LENGTH="${TRTLLM_CONTEXT_LENGTH:-4096}"
 CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
 
+# `--grpc` needs `smg-grpc-proto`, which TRT-LLM keeps behind its optional
+# `grpc-smg` extra. Constraint copied from that extra so we resolve what
+# upstream resolves.
+if ! "$TRTLLM_PYTHON" -c "import smg_grpc_proto" >/dev/null 2>&1; then
+    "$TRTLLM_PYTHON" -m pip install --no-cache-dir "smg-grpc-proto>=0.4.2"
+fi
+
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 GPU_MEM_ARGS=$(build_trtllm_override_args_with_mem)
 TRTLLM_GPU_MEM_ARGS=()


### PR DESCRIPTION
Backport of #14275 to `release/1.5.0`. Cherry-picked with `-x` from `522b050c86`;
applied cleanly.

## Summary

Fixes the QA-reported deployment failure: TensorRT-LLM keeps the SMG gRPC
protobuf bindings behind an optional `grpc-smg` extra, so `serve --grpc` aborts
on an engine image that does not ship `smg-grpc-proto`:

```
ValueError: gRPC serving with the SMG protocol requires the optional
'smg-grpc-proto' package. Install it with: pip install "tensorrt_llm[grpc-smg]"
```

With the engine down no worker registers, `/v1/models` stays empty, and the
deployment is torn down. gRPC is the only transport the TRT-LLM sidecar supports,
so for this deployment shape the dependency is not optional.

Both engine-launch paths — `launch/agg.sh` and the `trtllm-engine` container in
`deploy/agg.yaml` — now install the package before starting the engine, guarded by
an import check so it is a no-op where the package is already present.

Installed as the bare package rather than via `tensorrt_llm[grpc-smg]`: the extra
makes pip resolve TensorRT-LLM's entire dependency closure (transformers,
diffusers, jupyterlab, …) and fails on a release image with
`ERROR: Will not install to the user site because it will lack sys.path
precedence to jupyterlab`. The constraint `>=0.4.2` is copied verbatim from
upstream's own extra. The README states this so it is not "simplified" back.

## Validation

Validated on `main` in #14275 — see that PR for the full matrix. Summary:

- `launch/agg.sh` driven with stubs: guard runs before anything launches; no pip
  call when the package is present; exits 1 launching nothing when pip fails.
- `deploy/agg.yaml`'s wrapper executed verbatim in a real TensorRT-LLM release
  image: installs and forwards argv unchanged online; fails fast (`rc=1`, engine
  never starts) with no network. The latter is why the wrapper runs under `set -e`.
- Deployed to a live H100 cluster: engine installed the package and reached
  `[grpc] Initializing TensorRT-LLM SMG gRPC server...`, the graph came up `2/2`,
  and `/v1/chat/completions` returned a completion (18 prompt / 64 completion tokens).

On this branch: `bash -n` on the script, YAML parse of the manifest. The cherry-pick
was not re-deployed on `release/1.5.0`; the patched hunks are identical to `main`.

## Notes for reviewers

- The engine image pin in `deploy/agg.yaml` moves rc21 → rc25 as part of the
  cherry-pick, since rc21 bundles the package and would leave the new path dormant.
  Say the word if you would rather keep the pin untouched on a release branch — it
  is a one-line drop, at the cost of diverging from `main`.
- The fix installs from PyPI at launch, so an air-gapped cluster still cannot start
  the engine — it now fails at pip with `No matching distribution found for
  smg-grpc-proto>=0.4.2` instead of deep inside TensorRT-LLM. Worth confirming
  egress on the QA partition.
