### PR TITLE
fix(trtllm): [cherry-pick 1.5.0] stop leaking cancellation futures and shutdown tasks (#13901)

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -466,8 +466,9 @@ class HandlerBase(BaseGenerativeHandler):
 
         Raise EngineShutdown if shutdown event is triggered.
         """
+        cancellation_triggers: list[asyncio.Future[Any]] = []
         try:
-            cancellation_triggers: list[asyncio.Future[Any]] = [
+            cancellation_triggers = [
                 context.async_killed_or_stopped(),  # Request cancellation
             ]
             # Shutdown cancellation
@@ -500,6 +501,14 @@ class HandlerBase(BaseGenerativeHandler):
         except asyncio.CancelledError:
             # Task was cancelled, which is expected when generation completes normally
             pass
+        finally:
+            to_drain = []
+            for task in cancellation_triggers:
+                if not task.done():
+                    task.cancel()
+                    to_drain.append(task)
+            if to_drain:
+                await asyncio.gather(*to_drain, return_exceptions=True)
 
     @asynccontextmanager
     async def _cancellation_monitor(

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -473,6 +473,37 @@ class TestDeferredAbortGuard:
         generation_result.abort.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_cancellation_monitor_cleans_up_waiters_on_normal_completion(
+        self, monkeypatch
+    ):
+        handler = self._make_handler()
+        handler.shutdown_event = asyncio.Event()
+        generation_result = MagicMock()
+        context = MagicMock()
+        killed_future = asyncio.get_event_loop().create_future()
+        context.async_killed_or_stopped.return_value = killed_future
+        context.id.return_value = "test-waiter-cleanup"
+
+        original_create_task = asyncio.create_task
+        shutdown_tasks = []
+
+        def track_shutdown_task(coro):
+            task = original_create_task(coro)
+            shutdown_tasks.append(task)
+            return task
+
+        monkeypatch.setattr(asyncio, "create_task", track_shutdown_task)
+        monitor_task = original_create_task(
+            handler._handle_cancellation(generation_result, context)
+        )
+        await asyncio.sleep(0)
+        monitor_task.cancel()
+        await monitor_task
+
+        assert killed_future.cancelled()
+        assert shutdown_tasks[0].cancelled()
+
+    @pytest.mark.asyncio
     @pytest.mark.timeout(5)
     async def test_shutdown_calls_abort_directly(self):
         """Shutdown calls abort on whatever is passed (wrapper or real), immediately."""


### PR DESCRIPTION
Cherry-pick of #13901 to release/1.5.0. Clean pick of merge commit f7e6bb87de8045753d60dafc14383e1cd9b47ad3, no conflicts.

## Overview:

The TRT-LLM backend leaked cancellation futures and shutdown tasks; see #13901 for the fix and its tests.

## Details:

Approved for 1.5.0 on the release canvas (9/1, RC1 target). Original author weizhoublue; picked by the release TPM because a fork contributor cannot open a release-branch PR.