### PR TITLE
fix(ci): pass framework metadata through shared tests

### DIFF
--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -214,6 +214,7 @@ jobs:
           container_workspace: ${{ inputs.container_workspace }}
           pytest_marks: ${{ inputs.cpu_only_test_markers }}
           test_suite_name: ${{ inputs.test_suite_name }}
+          framework: ${{ inputs.test_suite_name }}
           test_type: "pre_merge_cpu"
           platform_arch: ${{ matrix.platform }}
           hf_token: ${{ secrets.HF_TOKEN }}
@@ -228,6 +229,7 @@ jobs:
           container_workspace: ${{ inputs.container_workspace }}
           pytest_marks: ${{ inputs.gpu_test_markers }}
           test_suite_name: ${{ inputs.test_suite_name }}
+          framework: ${{ inputs.test_suite_name }}
           test_type: "pre_merge_gpu_parallel"
           platform_arch: ${{ matrix.platform }}
           hf_token: ${{ secrets.HF_TOKEN }}
@@ -250,6 +252,7 @@ jobs:
           # When the parallel stage runs, exclude profiled tests here so they don't run twice.
           pytest_marks: ${{ inputs.run_gpu_parallel_tests && format('({0}) and not profiled_vram_gib', inputs.gpu_test_markers) || inputs.gpu_test_markers }}
           test_suite_name: ${{ inputs.test_suite_name }}
+          framework: ${{ inputs.test_suite_name }}
           test_type: "pre_merge_gpu"
           platform_arch: ${{ matrix.platform }}
           hf_token: ${{ secrets.HF_TOKEN }}


### PR DESCRIPTION
## Overview

Pass the reusable workflow's test-suite name through as the framework metadata for each local pytest invocation. This prevents test metadata, coverage artifacts, and Allure artifacts from using `unknown`.

## Details

- Set `framework` for the CPU-only test step.
- Set `framework` for both the parallel and sequential GPU test steps.
- Reuse `inputs.test_suite_name`, which is the backend identifier supplied by current callers.

## Where should the reviewer start?

Review the three `pytest-local` call sites in `.github/workflows/shared-test.yml`.

## Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/shared-test.yml`
- `pre-commit run check-yaml --files .github/workflows/shared-test.yml`
- `pre-commit run trailing-whitespace --files .github/workflows/shared-test.yml`
- `pre-commit run mixed-line-ending --files .github/workflows/shared-test.yml`
- Parsed the workflow and asserted that all three `pytest-local` calls pass `framework: ${{ inputs.test_suite_name }}`.
- `git diff --check`

## Known limitations

The end-to-end artifact names require a workflow run in project CI; local validation covers workflow syntax and all three call sites.

## Related Issues

- Closes #14267
