### PR TITLE
feat(planner): cap throughput scaling replica changes

### DIFF
--- a/components/src/dynamo/planner/config/defaults.py
+++ b/components/src/dynamo/planner/config/defaults.py
@@ -27,6 +27,7 @@ class BasePlannerDefaults:
     backend: Literal["vllm", "sglang", "trtllm", "mocker"] = "vllm"
     log_dir = None
     throughput_adjustment_interval_seconds = 180
+    max_throughput_scaling_replicas = 8
     max_gpu_budget = 8
     # GPU floor for the local planner (per-DGD scope). -1 disables.
     # When set alongside max_gpu_budget (with min == max), pins the total

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -414,6 +414,16 @@ class PlannerConfig(BaseModel):
             "throughput_adjustment_interval",
         ),
     )
+    max_throughput_scaling_replicas: int = Field(
+        default=SLAPlannerDefaults.max_throughput_scaling_replicas,
+        gt=0,
+        description=(
+            "Maximum replica-count change per component produced by one "
+            "throughput-scaling observation. The same limit applies to scale-up "
+            "and scale-down. Hard endpoint, GPU-budget, and power-budget recovery "
+            "may override this limit."
+        ),
+    )
     max_gpu_budget: int = SLAPlannerDefaults.max_gpu_budget
     min_gpu_budget: int = SLAPlannerDefaults.min_gpu_budget
     """Per-DGD GPU floor enforced by the local planner. -1 disables (default).

--- a/components/src/dynamo/planner/core/budget.py
+++ b/components/src/dynamo/planner/core/budget.py
@@ -5,9 +5,9 @@
 
 Two layers:
 
-* **Pure math** (``compute_tolerance``, ``bounds_for_total``,
-  ``proportional_clamp_pair``, ``proportional_clamp_single``, plus the
-  power-budget helpers below): no I/O, no state, no logging. Shared by
+* **Pure math** (``compute_tolerance``, ``bounds_for_total``, the directional
+  scaling guards, the proportional clamps, and the power-budget helpers
+  below): no I/O, no state, no logging. Shared by
   the builtin local planner state (where the budget is enforced
   intra-DGD by clamping the joint ``(num_prefill, num_decode)`` desired
   counts), the orchestrator engine adapter's final budget clamp, and the
@@ -175,7 +175,199 @@ def proportional_clamp_pair(
     return new_p, new_d
 
 
-def guard_disagg_load_budget(
+def fit_directional_budget_pair(
+    current_p: int,
+    current_d: int,
+    proposed_p: int,
+    proposed_d: int,
+    p_gpu: int,
+    d_gpu: int,
+    min_gpus: int,
+    max_gpus: int,
+    prefill_min_endpoint: int,
+    decode_min_endpoint: int,
+) -> tuple[int, int]:
+    """Fit a bounded proposal to the GPU band without changing its directions.
+
+    Every returned component lies between its current and proposed counts. For
+    an opposing rebalance, both legs move or neither moves so a GPU-width
+    mismatch can never leave only the donor removal. Callers bound throughput
+    deltas before invoking this helper, keeping the candidate set small.
+    """
+    if p_gpu <= 0 or d_gpu <= 0:
+        return proposed_p, proposed_d
+
+    tolerance = (
+        compute_tolerance([p_gpu, d_gpu]) if min_gpus >= 0 and max_gpus >= 0 else 0
+    )
+    p_down = proposed_p < current_p
+    p_up = proposed_p > current_p
+    d_down = proposed_d < current_d
+    d_up = proposed_d > current_d
+    opposing_rebalance = (p_down and d_up) or (p_up and d_down)
+    requested_p = abs(proposed_p - current_p)
+    requested_d = abs(proposed_d - current_d)
+
+    def _ceil_div(numerator: int, denominator: int) -> int:
+        return -((-numerator) // denominator)
+
+    p_low = max(min(current_p, proposed_p), prefill_min_endpoint)
+    p_high = max(current_p, proposed_p)
+    d_low = max(min(current_d, proposed_d), decode_min_endpoint)
+    d_high = max(current_d, proposed_d)
+
+    # Counts outside these bounds cannot possibly satisfy the band, so do not
+    # let an extreme configured cap or stale cached floor expand the scan past
+    # the actual resource envelope.
+    if max_gpus >= 0:
+        p_high = min(p_high, (max_gpus - d_low * d_gpu) // p_gpu)
+        d_high = min(d_high, (max_gpus - p_low * p_gpu) // d_gpu)
+    if min_gpus >= 0:
+        lower_budget = min_gpus - tolerance
+        p_low = max(p_low, _ceil_div(lower_budget - d_high * d_gpu, p_gpu))
+        d_low = max(d_low, _ceil_div(lower_budget - p_high * p_gpu, d_gpu))
+    if p_low > p_high or d_low > d_high:
+        return current_p, current_d
+
+    proposed_in_band, _ = bounds_for_total(
+        proposed_p * p_gpu + proposed_d * d_gpu,
+        min_gpus,
+        max_gpus,
+        tolerance,
+    )
+    if (
+        proposed_p >= prefill_min_endpoint
+        and proposed_d >= decode_min_endpoint
+        and proposed_in_band
+    ):
+        return proposed_p, proposed_d
+
+    best: Optional[tuple[tuple[int, int, int, int, int], tuple[int, int]]] = None
+
+    def _consider(candidate_p: int, candidate_d: int) -> None:
+        nonlocal best
+        total = candidate_p * p_gpu + candidate_d * d_gpu
+        in_band, _ = bounds_for_total(total, min_gpus, max_gpus, tolerance)
+        if not in_band:
+            return
+        distance = abs(proposed_p - candidate_p) + abs(proposed_d - candidate_d)
+        progress_p = abs(candidate_p - current_p)
+        progress_d = abs(candidate_d - current_d)
+        proportional_skew = abs(progress_p * requested_d - progress_d * requested_p)
+        score = (
+            distance,
+            proportional_skew,
+            -(progress_p + progress_d),
+            candidate_p,
+            candidate_d,
+        )
+        if best is None or score < best[0]:
+            best = (score, (candidate_p, candidate_d))
+
+    effective_min: Optional[int] = min_gpus - tolerance if min_gpus >= 0 else None
+
+    # Enumerate only the shorter component range. For each value, the budget
+    # band defines one interval for the other component, whose closest point
+    # to the proposal is the only candidate that can minimize the primary
+    # distance score. This reduces the old Cartesian O(P*D) search to
+    # O(min(P,D)); the normal cap=8 path is at most nine iterations.
+    if p_high - p_low <= d_high - d_low:
+        for candidate_p in range(p_low, p_high + 1):
+            candidate_d_low, candidate_d_high = d_low, d_high
+            p_cost = candidate_p * p_gpu
+            if effective_min is not None:
+                candidate_d_low = max(
+                    candidate_d_low,
+                    _ceil_div(effective_min - p_cost, d_gpu),
+                )
+            if max_gpus >= 0:
+                candidate_d_high = min(
+                    candidate_d_high,
+                    (max_gpus - p_cost) // d_gpu,
+                )
+            if opposing_rebalance:
+                if candidate_p == current_p:
+                    if candidate_d_low <= current_d <= candidate_d_high:
+                        _consider(candidate_p, current_d)
+                    continue
+                if proposed_d > current_d:
+                    candidate_d_low = max(candidate_d_low, current_d + 1)
+                else:
+                    candidate_d_high = min(candidate_d_high, current_d - 1)
+            if candidate_d_low <= candidate_d_high:
+                candidate_d = min(
+                    max(proposed_d, candidate_d_low),
+                    candidate_d_high,
+                )
+                _consider(candidate_p, candidate_d)
+    else:
+        for candidate_d in range(d_low, d_high + 1):
+            candidate_p_low, candidate_p_high = p_low, p_high
+            d_cost = candidate_d * d_gpu
+            if effective_min is not None:
+                candidate_p_low = max(
+                    candidate_p_low,
+                    _ceil_div(effective_min - d_cost, p_gpu),
+                )
+            if max_gpus >= 0:
+                candidate_p_high = min(
+                    candidate_p_high,
+                    (max_gpus - d_cost) // p_gpu,
+                )
+            if opposing_rebalance:
+                if candidate_d == current_d:
+                    if candidate_p_low <= current_p <= candidate_p_high:
+                        _consider(current_p, candidate_d)
+                    continue
+                if proposed_p > current_p:
+                    candidate_p_low = max(candidate_p_low, current_p + 1)
+                else:
+                    candidate_p_high = min(candidate_p_high, current_p - 1)
+            if candidate_p_low <= candidate_p_high:
+                candidate_p = min(
+                    max(proposed_p, candidate_p_low),
+                    candidate_p_high,
+                )
+                _consider(candidate_p, candidate_d)
+
+    return (current_p, current_d) if best is None else best[1]
+
+
+def guard_single_scaling_budget(
+    current: int,
+    proposed: int,
+    gpu_cost: int,
+    min_gpus: int,
+    max_gpus: int,
+    min_endpoint: int,
+) -> tuple[int, Optional[str]]:
+    """Apply a GPU band to one bounded proposal without reversing direction."""
+    if gpu_cost <= 0:
+        return proposed, None
+
+    tolerance = gpu_cost if min_gpus >= 0 and max_gpus >= 0 else 0
+    current_total = current * gpu_cost
+    current_in_band, _ = bounds_for_total(current_total, min_gpus, max_gpus, tolerance)
+    if not current_in_band:
+        reconciled = proportional_clamp_single(
+            current, gpu_cost, min_gpus, max_gpus, min_endpoint
+        )
+        return reconciled, "gpu_budget_reconcile"
+
+    if min_gpus >= 0 and current_total <= min_gpus and proposed < current:
+        return current, "gpu_budget_guard_hold"
+    if max_gpus >= 0 and current_total >= max_gpus and proposed > current:
+        return current, "gpu_budget_guard_hold"
+
+    final = proportional_clamp_single(
+        proposed, gpu_cost, min_gpus, max_gpus, min_endpoint
+    )
+    if not min(current, proposed) <= final <= max(current, proposed):
+        return current, "gpu_budget_guard_hold"
+    return final, None
+
+
+def guard_disagg_scaling_budget(
     current_p: int,
     current_d: int,
     proposed_p: int,
@@ -187,7 +379,7 @@ def guard_disagg_load_budget(
     prefill_min_endpoint: int,
     decode_min_endpoint: int,
 ) -> tuple[int, int, Optional[str]]:
-    """Apply GPU budgets to a disaggregated *load-scaling* proposal safely.
+    """Apply GPU budgets to a bounded disaggregated scaling proposal safely.
 
     ``min_gpu_budget`` is a scale-down guard, not an independent source of
     scale-up intent. Once the current allocation has reached that floor, a
@@ -200,12 +392,12 @@ def guard_disagg_load_budget(
     If the observed allocation is already outside the budget band, recovery is
     kept explicit: the current allocation, rather than the load proposal, is
     reconciled back toward the band and ``"gpu_budget_reconcile"`` is returned.
-    A negative minimum preserves the legacy clamp behavior, including for
-    max-only configurations.
+    A negative minimum disables only the floor; the hard ceiling remains
+    direction-preserving and never invents a donor.
 
     The returned optional reason is suitable for load-decision diagnostics.
     """
-    if min_gpus < 0 or p_gpu <= 0 or d_gpu <= 0:
+    if p_gpu <= 0 or d_gpu <= 0:
         new_p, new_d = proportional_clamp_pair(
             proposed_p,
             proposed_d,
@@ -252,30 +444,48 @@ def guard_disagg_load_budget(
     if current_total <= min_gpus and any_down and not any_up:
         return current_p, current_d, "gpu_budget_guard_hold"
 
-    # At the floor, an opposing proposal is one indivisible rebalance. If its
-    # weighted pair does not fit, fail closed rather than letting the generic
-    # clamp suppress the scale-up leg while retaining the donor removal.
+    # At the floor, keep opposing movements atomic. Fit the largest useful
+    # direction-preserving sub-pair; if no receiver can move with its donor,
+    # fail closed instead of executing only the removal.
     if current_total <= min_gpus and opposing_rebalance:
-        proposed_total = proposed_p * p_gpu + proposed_d * d_gpu
-        proposed_in_band, _ = bounds_for_total(
-            proposed_total, min_gpus, max_gpus, tolerance
+        fitted_p, fitted_d = fit_directional_budget_pair(
+            current_p,
+            current_d,
+            proposed_p,
+            proposed_d,
+            p_gpu,
+            d_gpu,
+            min_gpus,
+            max_gpus,
+            prefill_min_endpoint,
+            decode_min_endpoint,
         )
-        if not proposed_in_band:
+        if (fitted_p, fitted_d) == (current_p, current_d):
             return current_p, current_d, "gpu_budget_guard_hold"
-        return proposed_p, proposed_d, None
+        return fitted_p, fitted_d, None
 
     # At the hard ceiling there is no unallocated capacity for a scale-up.
     # Refuse to invent a donor from a pool whose load signal said hold/up.
-    # For an explicit opposing proposal, require the pair itself to fit so the
-    # clamp cannot suppress one leg and execute only the other.
+    # For an explicit opposing proposal, fit both legs together so a clamp can
+    # never suppress the receiver and execute only the donor removal.
     if max_gpus >= 0 and current_total >= max_gpus and any_up:
-        proposed_total = proposed_p * p_gpu + proposed_d * d_gpu
-        proposed_in_band, _ = bounds_for_total(
-            proposed_total, min_gpus, max_gpus, tolerance
-        )
-        if not opposing_rebalance or not proposed_in_band:
+        if not opposing_rebalance:
             return current_p, current_d, "gpu_budget_guard_hold"
-        return proposed_p, proposed_d, None
+        fitted_p, fitted_d = fit_directional_budget_pair(
+            current_p,
+            current_d,
+            proposed_p,
+            proposed_d,
+            p_gpu,
+            d_gpu,
+            min_gpus,
+            max_gpus,
+            prefill_min_endpoint,
+            decode_min_endpoint,
+        )
+        if (fitted_p, fitted_d) == (current_p, current_d):
+            return current_p, current_d, "gpu_budget_guard_hold"
+        return fitted_p, fitted_d, None
 
     new_p, new_d = proportional_clamp_pair(
         proposed_p,
@@ -507,6 +717,36 @@ def apply_power_budget(
     if p_adjustable and d_adjustable:
         assert proposed_p is not None and proposed_d is not None
         assert p_watts is not None and d_watts is not None
+        current_p_count = 0 if current_p is None else current_p
+        current_d_count = 0 if current_d is None else current_d
+        if (
+            project_watts(
+                current_p_count,
+                current_d_count,
+                p_watts,
+                d_watts,
+            )
+            <= total_budget
+        ):
+            # An ordinary in-band proposal may use only the directions it
+            # requested. Proportional shrinking can otherwise invent a donor
+            # (and exceed a throughput delta cap) merely because another role
+            # asked to scale up. Explicit opposing swaps were staged above;
+            # out-of-band current allocations retain the recovery path below.
+            new_p, new_d = fit_directional_budget_pair(
+                current_p_count,
+                current_d_count,
+                proposed_p,
+                proposed_d,
+                p_watts,
+                d_watts,
+                -1,
+                total_budget,
+                prefill_min_endpoint,
+                decode_min_endpoint,
+            )
+            return new_p, new_d, "power_budget_clamped"
+
         new_p, new_d = _shrink_pair(
             proposed_p,
             proposed_d,

--- a/components/src/dynamo/planner/core/load_scaling.py
+++ b/components/src/dynamo/planner/core/load_scaling.py
@@ -101,7 +101,10 @@ class LoadScalingMixin:
             )
             desired = max(desired, bound)
 
-        desired = self._apply_single_budget(desired, component)
+        desired, budget_reason = self._apply_single_scaling_budget(
+            desired,
+            component,
+        )
 
         if desired < num_workers:
             if desired > original_desired:
@@ -112,6 +115,8 @@ class LoadScalingMixin:
             self._diag_load_reason = "scale_up"
         else:
             self._diag_load_reason = "no_change"
+        if budget_reason is not None:
+            self._diag_load_reason = budget_reason
 
         return (
             ScalingDecision(num_prefill=desired)
@@ -201,8 +206,13 @@ class LoadScalingMixin:
 
         final_p = max(final_p, resolve_min_endpoint(self._config, "prefill"))
         final_d = max(final_d, resolve_min_endpoint(self._config, "decode"))
-        final_p, final_d, budget_reason = self._apply_disagg_load_budget(
-            final_p, final_d
+        throughput_lifted_proposal = self._config.enable_throughput_scaling and (
+            post_floor_p > original_p or post_floor_d > original_d
+        )
+        if throughput_lifted_proposal:
+            final_p, final_d = self._fit_disagg_throughput_ceiling(final_p, final_d)
+        final_p, final_d, budget_reason = self._apply_disagg_scaling_budget(
+            final_p, final_d, source="load"
         )
 
         # Per-component reasons
@@ -294,7 +304,10 @@ class LoadScalingMixin:
             desired = max(desired, resolve_min_endpoint(self._config, "decode"))
             if self._config.enable_throughput_scaling:
                 desired = max(desired, self._throughput_lower_bound_d)
-            desired = self._apply_single_budget(desired, "decode")
+            desired, budget_reason = self._apply_single_scaling_budget(
+                desired,
+                "decode",
+            )
 
             if desired < num_workers:
                 if desired > original_desired:
@@ -305,6 +318,8 @@ class LoadScalingMixin:
                 self._diag_load_reason = "scale_up"
             else:
                 self._diag_load_reason = "no_change"
+            if budget_reason is not None:
+                self._diag_load_reason = budget_reason
 
             logger.info(f"Agg easy-mode scaling: {num_workers} -> {desired}")
             return ScalingDecision(num_decode=desired)
@@ -362,7 +377,10 @@ class LoadScalingMixin:
         desired = max(desired, resolve_min_endpoint(self._config, "decode"))
         if self._config.enable_throughput_scaling:
             desired = max(desired, self._throughput_lower_bound_d)
-        desired = self._apply_single_budget(desired, "decode")
+        desired, budget_reason = self._apply_single_scaling_budget(
+            desired,
+            "decode",
+        )
 
         # Preserve "load wanted to scale down but floor lifted it" as a
         # distinct diagnostic reason even when the net result is no change.
@@ -370,7 +388,9 @@ class LoadScalingMixin:
 
         if desired == num_workers:
             logger.info("Agg scaling: no scaling needed")
-            if any_refused and not floor_capped:
+            if budget_reason is not None:
+                self._diag_load_reason = budget_reason
+            elif any_refused and not floor_capped:
                 # A sub-decision actively vetoed scale-down on consolidation
                 # safety grounds; surface that distinct from "no_change".
                 self._diag_load_reason = "scale_down_refused_consolidation"
@@ -386,6 +406,8 @@ class LoadScalingMixin:
             )
         else:  # desired > num_workers (equality returned above)
             self._diag_load_reason = "scale_up"
+        if budget_reason is not None:
+            self._diag_load_reason = budget_reason
 
         logger.info(f"Agg load-based scaling: {num_workers} -> {desired}")
         return ScalingDecision(num_decode=desired)

--- a/components/src/dynamo/planner/core/state_machine.py
+++ b/components/src/dynamo/planner/core/state_machine.py
@@ -24,7 +24,9 @@ from typing import TYPE_CHECKING, Literal, Optional
 
 from dynamo.planner.config.planner_config import PlannerConfig, resolve_min_endpoint
 from dynamo.planner.core.budget import (
-    guard_disagg_load_budget,
+    fit_directional_budget_pair,
+    guard_disagg_scaling_budget,
+    guard_single_scaling_budget,
     proportional_clamp_pair,
     proportional_clamp_single,
 )
@@ -420,6 +422,47 @@ class PlannerScalingState(LoadScalingMixin, ThroughputScalingMixin):
         min_endpoint = self._min_endpoint_for(component)
         return self._budget_clamp(max(desired, min_endpoint), gpu, min_endpoint)
 
+    def _apply_single_scaling_budget(
+        self, desired: int, component: Literal["prefill", "decode"]
+    ) -> tuple[int, Optional[str]]:
+        """Apply the direction-preserving budget policy for builtin scaling."""
+        return self._guard_single_throughput_budget(
+            desired,
+            component,
+            min_gpus=self._config.min_gpu_budget,
+        )
+
+    def _fit_single_throughput_ceiling(
+        self, desired: int, component: Literal["prefill", "decode"]
+    ) -> tuple[int, Optional[str]]:
+        """Fit a throughput lower bound under the hard GPU ceiling only."""
+        return self._guard_single_throughput_budget(desired, component, min_gpus=-1)
+
+    def _guard_single_throughput_budget(
+        self,
+        desired: int,
+        component: Literal["prefill", "decode"],
+        *,
+        min_gpus: int,
+    ) -> tuple[int, Optional[str]]:
+        caps = (
+            self._capabilities.prefill
+            if component == "prefill"
+            else self._capabilities.decode
+        )
+        gpu = caps.resolved_gpu_cost_per_replica if caps is not None else None
+        if gpu is None:
+            return desired, None
+        current = self._num_p_workers if component == "prefill" else self._num_d_workers
+        return guard_single_scaling_budget(
+            current,
+            desired,
+            gpu,
+            min_gpus,
+            self._config.max_gpu_budget,
+            self._min_endpoint_for(component),
+        )
+
     def _apply_global_budget(self, num_p: int, num_d: int) -> tuple[int, int]:
         """Apply the GPU budget band (ceiling and optional floor) to
         ``(num_p, num_d)``. Delegates to ``budget.proportional_clamp_pair``
@@ -450,15 +493,94 @@ class PlannerScalingState(LoadScalingMixin, ThroughputScalingMixin):
             )
         return new_p, new_d
 
-    def _apply_disagg_load_budget(
-        self, num_p: int, num_d: int
+    def _fit_disagg_throughput_ceiling(self, num_p: int, num_d: int) -> tuple[int, int]:
+        """Fit a throughput-bounded pair under the hard GPU ceiling.
+
+        ``min_gpu_budget`` guards an actual scale-down; it is not demand and
+        must not inflate a persisted throughput lower bound.  The full budget
+        band is enforced later when the combined load/throughput action is
+        materialized.
+        """
+        p_gpu, d_gpu = self._resolve_disagg_gpu_costs()
+        if p_gpu is None or d_gpu is None:
+            return num_p, num_d
+
+        prefill_min = self._min_endpoint_for("prefill")
+        decode_min = self._min_endpoint_for("decode")
+        endpoint_recovery = (
+            self._num_p_workers < prefill_min or self._num_d_workers < decode_min
+        )
+        if endpoint_recovery:
+            # A runtime endpoint increase is explicit allocation policy and may
+            # select a donor to make its minimum footprint fit the hard ceiling.
+            new_p, new_d = proportional_clamp_pair(
+                max(num_p, prefill_min),
+                max(num_d, decode_min),
+                p_gpu,
+                d_gpu,
+                -1,
+                self._config.max_gpu_budget,
+                prefill_min,
+                decode_min,
+            )
+        else:
+            new_p, new_d = fit_directional_budget_pair(
+                self._num_p_workers,
+                self._num_d_workers,
+                num_p,
+                num_d,
+                p_gpu,
+                d_gpu,
+                -1,
+                self._config.max_gpu_budget,
+                prefill_min,
+                decode_min,
+            )
+        if (new_p, new_d) != (num_p, num_d):
+            logger.warning(
+                "GPU ceiling limited throughput target: current=(%sP, %sD), "
+                "proposed=(%sP, %sD), fitted=(%sP, %sD), max=%s",
+                self._num_p_workers,
+                self._num_d_workers,
+                num_p,
+                num_d,
+                new_p,
+                new_d,
+                self._config.max_gpu_budget,
+            )
+        return new_p, new_d
+
+    def _apply_disagg_scaling_budget(
+        self,
+        num_p: int,
+        num_d: int,
+        *,
+        source: Literal["load", "throughput"],
     ) -> tuple[int, int, Optional[str]]:
-        """Apply the direction-preserving budget policy for load scaling."""
+        """Apply the direction-preserving budget policy for builtin scaling."""
         p_gpu, d_gpu = self._resolve_disagg_gpu_costs()
         if p_gpu is None or d_gpu is None:
             return num_p, num_d, None
 
-        new_p, new_d, reason = guard_disagg_load_budget(
+        prefill_min = self._min_endpoint_for("prefill")
+        decode_min = self._min_endpoint_for("decode")
+        if self._num_p_workers < prefill_min or self._num_d_workers < decode_min:
+            # Endpoint floors are explicit runtime policy. Reconcile them even
+            # if doing so requires a donor that the ordinary scaling signal did
+            # not nominate; startup/runtime validation guarantees feasibility.
+            new_p, new_d = proportional_clamp_pair(
+                max(num_p, prefill_min),
+                max(num_d, decode_min),
+                p_gpu,
+                d_gpu,
+                self._config.min_gpu_budget,
+                self._config.max_gpu_budget,
+                prefill_min,
+                decode_min,
+            )
+            return new_p, new_d, "gpu_budget_reconcile"
+
+        new_p, new_d, reason = guard_disagg_scaling_budget(
             self._num_p_workers,
             self._num_d_workers,
             num_p,
@@ -467,17 +589,18 @@ class PlannerScalingState(LoadScalingMixin, ThroughputScalingMixin):
             d_gpu,
             self._config.min_gpu_budget,
             self._config.max_gpu_budget,
-            self._min_endpoint_for("prefill"),
-            self._min_endpoint_for("decode"),
+            prefill_min,
+            decode_min,
         )
         if reason is not None or (new_p, new_d) != (num_p, num_d):
             old_total = self._num_p_workers * p_gpu + self._num_d_workers * d_gpu
             proposed_total = num_p * p_gpu + num_d * d_gpu
             new_total = new_p * p_gpu + new_d * d_gpu
             logger.warning(
-                "GPU budget load policy %s: current=(%sP + %sD = %s), "
+                "GPU budget %s policy %s: current=(%sP + %sD = %s), "
                 "proposed=(%sP + %sD = %s), final=(%sP + %sD = %s), "
                 "band=[min=%s, max=%s]",
+                source,
                 reason or "gpu_budget_clamped",
                 self._num_p_workers,
                 self._num_d_workers,

--- a/components/src/dynamo/planner/core/throughput_scaling.py
+++ b/components/src/dynamo/planner/core/throughput_scaling.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Optional
+from typing import Literal, Optional
 
 from dynamo.planner.config.planner_config import resolve_min_endpoint
 from dynamo.planner.core.types import ScalingDecision
@@ -34,12 +34,30 @@ class ThroughputScalingMixin:
     _diag_throughput_reason_prefill: Optional[str]
     _diag_throughput_reason_decode: Optional[str]
 
+    def _cap_throughput_replicas(
+        self, desired: int, current: int, component: str
+    ) -> int:
+        """Bound one throughput observation's replica change for a component."""
+        limit = self._config.max_throughput_scaling_replicas
+        bounded = min(max(desired, max(0, current - limit)), current + limit)
+        if bounded != desired:
+            logger.warning(
+                "Throughput target capped for %s: raw=%s, current=%s, "
+                "max_delta=%s, bounded=%s",
+                component,
+                desired,
+                current,
+                limit,
+                bounded,
+            )
+        return bounded
+
     def _throughput_single(
         self,
         demand_rps: float,
         isl: float,
         osl: float,
-        component: str,
+        component: Literal["prefill", "decode"],
         kv_hit_rate: Optional[float] = None,
     ) -> Optional[ScalingDecision]:
         desired = (
@@ -49,6 +67,15 @@ class ThroughputScalingMixin:
         )
         if desired is None:
             return None
+        current = self._num_p_workers if component == "prefill" else self._num_d_workers
+        desired = self._cap_throughput_replicas(desired, current, component)
+        # Endpoint recovery is a hard invariant, not an ordinary throughput
+        # movement, so it may exceed the per-observation delta cap.
+        desired = max(desired, resolve_min_endpoint(self._config, component))
+        desired, _ceiling_reason = self._fit_single_throughput_ceiling(
+            desired,
+            component,
+        )
 
         if self._config.enable_load_scaling:
             if component == "prefill":
@@ -56,10 +83,22 @@ class ThroughputScalingMixin:
             else:
                 self._throughput_lower_bound_d = desired
             logger.info(f"Throughput lower bound set to {desired} for {component}")
-            self._diag_throughput_reason = "set_lower_bound"
+            self._diag_throughput_reason = (
+                "gpu_budget_guard_hold"
+                if _ceiling_reason == "gpu_budget_guard_hold"
+                else "set_lower_bound"
+            )
             return None
 
-        desired = self._apply_single_budget(desired, component)
+        desired, _budget_reason = self._apply_single_scaling_budget(
+            desired,
+            component,
+        )
+        if desired == current:
+            self._diag_throughput_reason = (
+                _budget_reason or _ceiling_reason or "no_change"
+            )
+            return None
         self._diag_throughput_reason = "scale"
         return (
             ScalingDecision(num_prefill=desired)
@@ -90,6 +129,19 @@ class ThroughputScalingMixin:
             )
             return None
 
+        num_p = self._cap_throughput_replicas(num_p, self._num_p_workers, "prefill")
+        num_d = self._cap_throughput_replicas(num_d, self._num_d_workers, "decode")
+        # A runtime endpoint increase must recover immediately even when the
+        # gap is larger than the throughput delta cap.
+        num_p = max(num_p, resolve_min_endpoint(self._config, "prefill"))
+        num_d = max(num_d, resolve_min_endpoint(self._config, "decode"))
+        bounded_p, bounded_d = num_p, num_d
+        num_p, num_d = self._fit_disagg_throughput_ceiling(num_p, num_d)
+        budget_held = (num_p, num_d) == (self._num_p_workers, self._num_d_workers) and (
+            bounded_p,
+            bounded_d,
+        ) != (self._num_p_workers, self._num_d_workers)
+
         reason = "set_lower_bound" if self._config.enable_load_scaling else "scale"
         self._diag_throughput_reason_prefill = reason
         self._diag_throughput_reason_decode = reason
@@ -98,10 +150,26 @@ class ThroughputScalingMixin:
             self._throughput_lower_bound_p = num_p
             self._throughput_lower_bound_d = num_d
             logger.info(f"Throughput lower bounds set: prefill={num_p}, decode={num_d}")
-            self._diag_throughput_reason = "set_lower_bound"
+            if budget_held:
+                self._diag_throughput_reason = "gpu_budget_guard_hold"
+                self._diag_throughput_reason_prefill = "gpu_budget_guard_hold"
+                self._diag_throughput_reason_decode = "gpu_budget_guard_hold"
+            else:
+                self._diag_throughput_reason = "set_lower_bound"
             return None
 
-        num_p, num_d = self._apply_global_budget(num_p, num_d)
+        num_p, num_d, budget_reason = self._apply_disagg_scaling_budget(
+            num_p, num_d, source="throughput"
+        )
+        if num_p == self._num_p_workers and num_d == self._num_d_workers:
+            hold_reason = budget_reason or (
+                "gpu_budget_guard_hold" if budget_held else "no_change"
+            )
+            self._diag_throughput_reason = hold_reason
+            self._diag_throughput_reason_prefill = hold_reason
+            self._diag_throughput_reason_decode = hold_reason
+            return None
+
         self._diag_throughput_reason = "scale"
         return ScalingDecision(num_prefill=num_p, num_decode=num_d)
 
@@ -155,14 +223,34 @@ class ThroughputScalingMixin:
         logger.info(
             f"Agg: {demand_rps:.2f} rps / {engine_rps:.2f} engine_rps = {desired} replicas"
         )
+        desired = self._cap_throughput_replicas(
+            desired, self._num_d_workers, "aggregated"
+        )
+        desired = max(desired, resolve_min_endpoint(self._config, "decode"))
+        desired, _ceiling_reason = self._fit_single_throughput_ceiling(
+            desired,
+            "decode",
+        )
 
         if self._config.enable_load_scaling:
             self._throughput_lower_bound_d = desired
             logger.info(f"Agg throughput lower bound set to {desired}")
-            self._diag_throughput_reason = "set_lower_bound"
+            self._diag_throughput_reason = (
+                "gpu_budget_guard_hold"
+                if _ceiling_reason == "gpu_budget_guard_hold"
+                else "set_lower_bound"
+            )
             return None
 
-        desired = self._apply_single_budget(desired, "decode")
+        desired, _budget_reason = self._apply_single_scaling_budget(
+            desired,
+            "decode",
+        )
+        if desired == self._num_d_workers:
+            self._diag_throughput_reason = (
+                _budget_reason or _ceiling_reason or "no_change"
+            )
+            return None
         self._diag_throughput_reason = "scale"
         return ScalingDecision(num_decode=desired)
 

--- a/components/src/dynamo/planner/core/throughput_scaling.py
+++ b/components/src/dynamo/planner/core/throughput_scaling.py
@@ -82,7 +82,11 @@ class ThroughputScalingMixin:
                 self._throughput_lower_bound_p = desired
             else:
                 self._throughput_lower_bound_d = desired
-            logger.info(f"Throughput lower bound set to {desired} for {component}")
+            logger.info(
+                "Throughput lower bound set to %s for %s",
+                desired,
+                component,
+            )
             self._diag_throughput_reason = (
                 "gpu_budget_guard_hold"
                 if _ceiling_reason == "gpu_budget_guard_hold"
@@ -234,7 +238,7 @@ class ThroughputScalingMixin:
 
         if self._config.enable_load_scaling:
             self._throughput_lower_bound_d = desired
-            logger.info(f"Agg throughput lower bound set to {desired}")
+            logger.info("Agg throughput lower bound set to %s", desired)
             self._diag_throughput_reason = (
                 "gpu_budget_guard_hold"
                 if _ceiling_reason == "gpu_budget_guard_hold"

--- a/components/src/dynamo/planner/monitoring/planner_metrics.py
+++ b/components/src/dynamo/planner/monitoring/planner_metrics.py
@@ -44,6 +44,8 @@ THROUGHPUT_DECISION_STATES = [
     "held_over",
     "circuit_open",
     "rejected_by_plugin",
+    "gpu_budget_guard_hold",
+    "no_change",
 ]
 
 

--- a/components/src/dynamo/planner/monitoring/planner_metrics.py
+++ b/components/src/dynamo/planner/monitoring/planner_metrics.py
@@ -46,6 +46,7 @@ THROUGHPUT_DECISION_STATES = [
     "rejected_by_plugin",
     "gpu_budget_guard_hold",
     "no_change",
+    "gpu_budget_reconcile",
 ]
 
 

--- a/components/src/dynamo/planner/simulation/config.py
+++ b/components/src/dynamo/planner/simulation/config.py
@@ -96,6 +96,7 @@ class PlannerPredictionConfig(BaseModel):
     enable_throughput_scaling: bool = True
     enable_load_scaling: bool = False
     throughput_adjustment_interval_seconds: PositiveInt = 180
+    max_throughput_scaling_replicas: PositiveInt = 8
     load_adjustment_interval_seconds: PositiveInt = 5
     max_num_fpm_samples: PositiveInt = 64
     fpm_sample_bucket_size: PositiveInt = 16
@@ -168,6 +169,7 @@ class PlannerRecommendationConfig(BaseModel):
     enable_load_scaling: bool | Choices[bool] | None = None
     throughput_adjustment_interval_seconds: IntDomain | None = None
     load_adjustment_interval_seconds: IntDomain | None = None
+    max_throughput_scaling_replicas: PositiveInt = 8
     max_num_fpm_samples: IntDomain | None = None
     fpm_sample_bucket_size: IntDomain | None = None
     load_scaling_down_sensitivity: NonNegativeIntDomain | None = None

--- a/components/src/dynamo/planner/simulation/provider.py
+++ b/components/src/dynamo/planner/simulation/provider.py
@@ -82,6 +82,7 @@ _PLANNER_PASSTHROUGH = (
     "enable_load_scaling",
     "throughput_adjustment_interval_seconds",
     "load_adjustment_interval_seconds",
+    "max_throughput_scaling_replicas",
     "max_num_fpm_samples",
     "fpm_sample_bucket_size",
     "load_scaling_down_sensitivity",
@@ -412,6 +413,7 @@ class PlannerSearchSpace(BaseModel):
     # ``None`` preserves the legacy provider behavior of inheriting the
     # candidate's GPU budget. The public schema always supplies its default 8.
     max_num_gpus: int | None = Field(default=None, ge=1)
+    max_throughput_scaling_replicas: int = Field(default=8, ge=1)
     public_schema: bool = False
     public_policy: list[str] | None = None
     planner_target: str | None = None
@@ -723,6 +725,7 @@ class DynamoPlannerSweepConfigProvider:
             "enable_load_scaling": public.enable_load_scaling,
             "throughput_adjustment_interval_seconds": public.throughput_adjustment_interval_seconds,
             "load_adjustment_interval_seconds": public.load_adjustment_interval_seconds,
+            "max_throughput_scaling_replicas": public.max_throughput_scaling_replicas,
             "max_num_gpus": public.max_num_gpus,
             "min_workers": public.min_workers,
         }
@@ -1021,6 +1024,9 @@ class DynamoPlannerSweepConfigProvider:
             return AdapterReplaySpec(
                 config=({"policy": "disabled"} if public_schema else candidate_config)
             )
+        candidate_config[
+            "max_throughput_scaling_replicas"
+        ] = space.max_throughput_scaling_replicas
 
         if scaling["enable_throughput_scaling"]:
             fpm_entry = selection["fpm_sampling"]

--- a/components/src/dynamo/planner/tests/monitoring/test_decision_state_enums.py
+++ b/components/src/dynamo/planner/tests/monitoring/test_decision_state_enums.py
@@ -71,6 +71,7 @@ _PLUGIN_THROUGHPUT_ADDITIONS = [
     "rejected_by_plugin",
     "gpu_budget_guard_hold",
     "no_change",
+    "gpu_budget_reconcile",
 ]
 
 

--- a/components/src/dynamo/planner/tests/monitoring/test_decision_state_enums.py
+++ b/components/src/dynamo/planner/tests/monitoring/test_decision_state_enums.py
@@ -69,6 +69,8 @@ _PLUGIN_THROUGHPUT_ADDITIONS = [
     "held_over",
     "circuit_open",
     "rejected_by_plugin",
+    "gpu_budget_guard_hold",
+    "no_change",
 ]
 
 

--- a/components/src/dynamo/planner/tests/unit/test_budget.py
+++ b/components/src/dynamo/planner/tests/unit/test_budget.py
@@ -11,7 +11,9 @@ import pytest
 from dynamo.planner.core.budget import (
     bounds_for_total,
     compute_tolerance,
-    guard_disagg_load_budget,
+    fit_directional_budget_pair,
+    guard_disagg_scaling_budget,
+    guard_single_scaling_budget,
     proportional_clamp_pair,
     proportional_clamp_single,
 )
@@ -219,6 +221,132 @@ def test_clamp_pair_infeasible_band_falls_back_to_inputs():
 
 
 # ---------------------------------------------------------------------------- #
+# single-component direction-preserving guard                                  #
+# ---------------------------------------------------------------------------- #
+
+
+def test_single_budget_holds_scale_down_at_nominal_floor():
+    assert guard_single_scaling_budget(64, 63, 1, 64, 64, 1) == (
+        64,
+        "gpu_budget_guard_hold",
+    )
+
+
+def test_single_budget_does_not_bounce_from_tolerance_edge_to_floor():
+    assert guard_single_scaling_budget(63, 62, 1, 64, 64, 1) == (
+        63,
+        "gpu_budget_guard_hold",
+    )
+
+
+def test_single_budget_recovery_can_override_throughput_delta():
+    assert guard_single_scaling_budget(70, 69, 1, -1, 64, 1) == (
+        64,
+        "gpu_budget_reconcile",
+    )
+
+
+# ---------------------------------------------------------------------------- #
+# bounded direction-preserving throughput fit                                  #
+# ---------------------------------------------------------------------------- #
+
+
+def _fit_throughput(
+    current: tuple[int, int],
+    proposed: tuple[int, int],
+    *,
+    p_gpu: int = 1,
+    d_gpu: int = 1,
+    min_gpus: int = 64,
+    max_gpus: int = 64,
+) -> tuple[int, int]:
+    return fit_directional_budget_pair(
+        current[0],
+        current[1],
+        proposed[0],
+        proposed[1],
+        p_gpu,
+        d_gpu,
+        min_gpus,
+        max_gpus,
+        1,
+        1,
+    )
+
+
+def test_throughput_fit_holds_when_both_roles_scale_up_at_ceiling():
+    assert _fit_throughput((24, 40), (32, 48)) == (24, 40)
+
+
+def test_throughput_fit_admits_only_funded_part_of_opposing_rebalance():
+    assert _fit_throughput((24, 40), (23, 48)) == (23, 41)
+
+
+def test_throughput_fit_preserves_weighted_opposing_atomicity():
+    assert _fit_throughput(
+        (16, 16),
+        (15, 24),
+        p_gpu=2,
+        d_gpu=1,
+        min_gpus=48,
+        max_gpus=48,
+    ) == (15, 18)
+
+
+def test_throughput_fit_shares_available_headroom_between_two_scale_ups():
+    assert _fit_throughput(
+        (24, 36),
+        (32, 44),
+        min_gpus=-1,
+        max_gpus=64,
+    ) == (26, 38)
+
+
+@pytest.mark.parametrize(("p_gpu", "d_gpu"), [(1, 1), (1, 2), (2, 3)])
+def test_throughput_fit_exhaustively_preserves_directions_and_budget(p_gpu, d_gpu):
+    for current_p in range(1, 5):
+        for current_d in range(1, 5):
+            budget = current_p * p_gpu + current_d * d_gpu
+            for proposed_p in range(max(0, current_p - 2), current_p + 3):
+                for proposed_d in range(max(0, current_d - 2), current_d + 3):
+                    final_p, final_d = fit_directional_budget_pair(
+                        current_p,
+                        current_d,
+                        proposed_p,
+                        proposed_d,
+                        p_gpu,
+                        d_gpu,
+                        budget,
+                        budget,
+                        0,
+                        0,
+                    )
+                    assert (
+                        min(current_p, proposed_p)
+                        <= final_p
+                        <= max(current_p, proposed_p)
+                    )
+                    assert (
+                        min(current_d, proposed_d)
+                        <= final_d
+                        <= max(current_d, proposed_d)
+                    )
+                    final_total = final_p * p_gpu + final_d * d_gpu
+                    assert bounds_for_total(
+                        final_total,
+                        budget,
+                        budget,
+                        max(p_gpu, d_gpu),
+                    )[0]
+
+                    opposing = (proposed_p < current_p and proposed_d > current_d) or (
+                        proposed_p > current_p and proposed_d < current_d
+                    )
+                    if opposing:
+                        assert (final_p == current_p) == (final_d == current_d)
+
+
+# ---------------------------------------------------------------------------- #
 # disaggregated load-budget safety guard                                       #
 # ---------------------------------------------------------------------------- #
 
@@ -234,7 +362,7 @@ def _guard(
     prefill_min_endpoint: int = 1,
     decode_min_endpoint: int = 1,
 ) -> tuple[int, int, str | None]:
-    return guard_disagg_load_budget(
+    return guard_disagg_scaling_budget(
         current[0],
         current[1],
         proposed[0],
@@ -311,16 +439,24 @@ def test_load_budget_allows_scale_down_above_floor():
     assert _guard((35, 35), (34, 35), max_gpus=80) == (34, 35, None)
 
 
-def test_load_budget_disabled_minimum_preserves_legacy_clamp():
-    expected = proportional_clamp_pair(3, 2, 1, 1, -1, 4, 1, 1)
+def test_load_budget_disabled_minimum_does_not_invent_ceiling_donor():
     actual_p, actual_d, reason = _guard(
         (3, 1),
         (3, 2),
         min_gpus=-1,
         max_gpus=4,
     )
-    assert (actual_p, actual_d) == expected
-    assert reason is None
+    assert (actual_p, actual_d) == (3, 1)
+    assert reason == "gpu_budget_guard_hold"
+
+
+def test_load_budget_max_only_both_up_does_not_invent_donor():
+    assert _guard(
+        (4, 1),
+        (5, 2),
+        min_gpus=-1,
+        max_gpus=5,
+    ) == (4, 1, "gpu_budget_guard_hold")
 
 
 def test_load_budget_weighted_tolerance_does_not_enable_donor_only_churn():

--- a/components/src/dynamo/planner/tests/unit/test_load_budget_guard.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_budget_guard.py
@@ -125,3 +125,31 @@ def test_load_loop_still_scales_down_above_floor():
     decision = _decision(state, 34, None)
     assert decision is not None
     assert (decision.num_prefill, decision.num_decode) == (34, 35)
+
+
+def test_single_load_loop_holds_scale_down_at_fixed_budget():
+    state = _state(1, 64)
+    state._config.mode = "decode"
+    state._config.enable_throughput_scaling = False
+
+    decision = _decision(state, None, 63)
+
+    assert decision is not None
+    assert decision.num_decode == 64
+    assert state.diagnostics().load_decision_reason == "gpu_budget_guard_hold"
+
+
+def test_agg_load_loop_holds_scale_down_at_fixed_budget():
+    state = _state(1, 64)
+    state._config.mode = "agg"
+    state._config.enable_throughput_scaling = False
+
+    def _agg(_self, _stats, _workers):
+        return 63
+
+    state._agg_easy_decision = MethodType(_agg, state)
+    decision = _decision(state, None, 63)
+
+    assert decision is not None
+    assert decision.num_decode == 64
+    assert state.diagnostics().load_decision_reason == "gpu_budget_guard_hold"

--- a/components/src/dynamo/planner/tests/unit/test_planner_config.py
+++ b/components/src/dynamo/planner/tests/unit/test_planner_config.py
@@ -46,6 +46,17 @@ def test_invalid_environment():
         )
 
 
+def test_max_throughput_scaling_replicas_defaults_to_eight():
+    config = PlannerConfig(namespace="test-ns")
+
+    assert config.max_throughput_scaling_replicas == 8
+
+
+def test_max_throughput_scaling_replicas_must_be_positive():
+    with pytest.raises(ValidationError):
+        PlannerConfig(namespace="test-ns", max_throughput_scaling_replicas=0)
+
+
 # ---------------------------------------------------------------------------
 # Power-awareness validator (DGD-owned caps; read-only)
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/planner/tests/unit/test_planner_sweep_config_provider.py
+++ b/components/src/dynamo/planner/tests/unit/test_planner_sweep_config_provider.py
@@ -418,6 +418,7 @@ def test_scaling_policy_materializes_legacy_planner_payload() -> None:
         "enable_load_scaling": False,
         "throughput_adjustment_interval_seconds": 180,
         "load_adjustment_interval_seconds": 5,
+        "max_throughput_scaling_replicas": 8,
         "max_num_fpm_samples": 128,
         "fpm_sample_bucket_size": 64,
         "load_predictor": "constant",
@@ -450,6 +451,7 @@ def test_custom_float_interval_resolves_predictor_and_preserves_selection() -> N
             "fpm_sampling": {"preset": ["default"]},
             "load_sensitivity": {"preset": ["default"]},
             "load_predictor": {"preset": ["constant_last"]},
+            "max_throughput_scaling_replicas": 3,
         },
         _sweep_context(),
     )
@@ -466,11 +468,13 @@ def test_custom_float_interval_resolves_predictor_and_preserves_selection() -> N
 
     assert replay_spec.config["scaling_policy"] == custom_policy
     assert replay_spec.config["throughput_adjustment_interval_seconds"] == 180
+    assert replay_spec.config["max_throughput_scaling_replicas"] == 3
     assert replay_spec.config["load_predictor"] == "constant"
     planner_config = replay_spec.runtime_hooks[0].config["planner_config"]
     assert isinstance(planner_config, dict)
     assert "scaling_policy" not in planner_config
     assert planner_config["load_predictor"] == "constant"
+    assert planner_config["max_throughput_scaling_replicas"] == 3
 
 
 def test_disaggregated_scaling_preserves_both_engine_gpu_counts() -> None:

--- a/components/src/dynamo/planner/tests/unit/test_power_budget.py
+++ b/components/src/dynamo/planner/tests/unit/test_power_budget.py
@@ -144,20 +144,21 @@ def test_apply_power_budget_rebalance_stages_scale_down_first():
     )
 
 
-def test_apply_power_budget_clamp_synthesized_rebalance_is_staged():
-    """Clamp can create an opposing rebalance even when the proposal was not one.
-
-    Current (4,1), proposal (5,5), 1000 W/replica, 5000 W budget: the
-    proportional clamp yields settled (2,3)=5000 W, but parallel actuation
-    peaks at (4,3)=7000 W. Stage by holding the decode scale-up at current
-    so this tick emits (2,1) under the ceiling instead of (2,3).
-    """
+def test_apply_power_budget_does_not_synthesize_rebalance():
+    """An in-band current allocation never donates to an up/up proposal."""
     assert apply_power_budget(5, 5, 4, 1, 1000, 1000, 5000, 1) == (
-        2,
+        4,
         1,
-        "power_rebalance_staged",
+        "power_budget_clamped",
     )
-    assert peak_parallel_watts(4, 1, 2, 1, 1000, 1000) <= 5000
+
+
+def test_apply_power_budget_preserves_capped_hold_direction():
+    assert apply_power_budget(9, 22, 1, 22, 4, 1, 26, 1) == (
+        1,
+        22,
+        "power_budget_clamped",
+    )
 
 
 def test_apply_power_budget_rebalance_staged_with_none_current_p():

--- a/components/src/dynamo/planner/tests/unit/test_throughput_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_throughput_scaling.py
@@ -1,12 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
+from typing import Optional
 
 import pytest
 
+from dynamo.planner.config.planner_config import PlannerConfig
+from dynamo.planner.core.state_machine import PlannerScalingState
 from dynamo.planner.core.throughput_scaling import ThroughputScalingMixin
-from dynamo.planner.core.types import EngineCapabilities, WorkerCapabilities
+from dynamo.planner.core.types import (
+    EngineCapabilities,
+    FpmObservations,
+    WorkerCapabilities,
+    WorkerCounts,
+)
 
 pytestmark = [
     pytest.mark.gpu_0,
@@ -28,6 +36,7 @@ class _ThroughputScalingHarness(ThroughputScalingMixin):
             min_endpoint=1,
             prefill_min_endpoint=None,
             decode_min_endpoint=None,
+            max_throughput_scaling_replicas=8,
         )
         self._prefill_regression = _PrefillRegression()
         self._diag_throughput_reason = None
@@ -57,6 +66,372 @@ def test_prefill_throughput_uses_component_minimum_override():
     )
 
     assert replicas == 3
+
+
+def _disagg_state(
+    current_p: int,
+    current_d: int,
+    raw_p: int,
+    raw_d: int,
+    *,
+    enable_load_scaling: bool,
+    cap: int = 8,
+    min_gpus: int = 64,
+    max_gpus: int = 64,
+    p_gpu: int = 1,
+    d_gpu: int = 1,
+    prefill_min_endpoint: Optional[int] = None,
+    decode_min_endpoint: Optional[int] = None,
+) -> PlannerScalingState:
+    config = PlannerConfig.model_construct(
+        mode="disagg",
+        optimization_target="throughput",
+        enable_load_scaling=enable_load_scaling,
+        enable_throughput_scaling=True,
+        max_throughput_scaling_replicas=cap,
+        min_gpu_budget=min_gpus,
+        max_gpu_budget=max_gpus,
+        min_endpoint=1,
+        prefill_min_endpoint=prefill_min_endpoint,
+        decode_min_endpoint=decode_min_endpoint,
+    )
+    state = PlannerScalingState(
+        config,
+        WorkerCapabilities(
+            prefill=EngineCapabilities(gpu_cost_per_replica=p_gpu),
+            decode=EngineCapabilities(gpu_cost_per_replica=d_gpu),
+        ),
+    )
+    state.observe_worker_counts(
+        WorkerCounts(
+            ready_num_prefill=current_p,
+            ready_num_decode=current_d,
+            expected_num_prefill=current_p,
+            expected_num_decode=current_d,
+        )
+    )
+
+    def _prefill(_self, _demand, _isl, _osl, _kv_hit_rate=None):
+        return raw_p
+
+    def _decode(_self, _demand, _isl, _osl):
+        return raw_d
+
+    state._compute_prefill_replicas = MethodType(_prefill, state)
+    state._compute_decode_replicas = MethodType(_decode, state)
+    return state
+
+
+def _load_decision(
+    state: PlannerScalingState,
+    proposed_p: Optional[int],
+    proposed_d: Optional[int],
+):
+    def _prefill(_self, _stats, _workers):
+        return proposed_p
+
+    def _decode(_self, _stats, _workers):
+        return proposed_d
+
+    state._prefill_easy_decision = MethodType(_prefill, state)
+    state._decode_easy_decision = MethodType(_decode, state)
+    observations = FpmObservations(
+        prefill={(f"p-{index}", 0): object() for index in range(state._num_p_workers)},
+        decode={(f"d-{index}", 0): object() for index in range(state._num_d_workers)},
+    )
+    return state.advance_load(observations)
+
+
+def test_disagg_throughput_caps_persisted_lower_bounds_once_per_observation():
+    state = _disagg_state(24, 40, 8, 180, enable_load_scaling=True)
+
+    assert state._throughput_disagg(1.0, 1.0, 1.0) is None
+    assert (state._throughput_lower_bound_p, state._throughput_lower_bound_d) == (
+        16,
+        48,
+    )
+
+    # The second builtin consumer evaluates the same throughput observation.
+    # Repeating it must not ratchet either bound by another eight replicas.
+    assert state._throughput_disagg(1.0, 1.0, 1.0) is None
+    assert (state._throughput_lower_bound_p, state._throughput_lower_bound_d) == (
+        16,
+        48,
+    )
+
+
+def test_disagg_throughput_uses_configured_replica_cap():
+    state = _disagg_state(
+        24,
+        40,
+        8,
+        180,
+        enable_load_scaling=True,
+        cap=3,
+    )
+
+    assert state._throughput_disagg(1.0, 1.0, 1.0) is None
+    assert (state._throughput_lower_bound_p, state._throughput_lower_bound_d) == (
+        21,
+        43,
+    )
+
+
+def test_disagg_throughput_holds_two_scale_ups_at_gpu_ceiling():
+    state = _disagg_state(24, 40, 32, 48, enable_load_scaling=False)
+
+    assert state._throughput_disagg(1.0, 1.0, 1.0) is None
+    assert state.diagnostics().throughput_decision_reason == "gpu_budget_guard_hold"
+
+
+def test_disagg_throughput_natural_noop_is_not_reported_as_budget_hold():
+    state = _disagg_state(24, 40, 24, 40, enable_load_scaling=False)
+
+    assert state._throughput_disagg(1.0, 1.0, 1.0) is None
+    assert state.diagnostics().throughput_decision_reason == "no_change"
+
+
+def test_mixed_scaling_does_not_persist_unfunded_scale_ups_at_gpu_ceiling():
+    state = _disagg_state(24, 40, 32, 48, enable_load_scaling=True)
+
+    assert state._throughput_disagg(1.0, 1.0, 1.0) is None
+    assert (state._throughput_lower_bound_p, state._throughput_lower_bound_d) == (
+        24,
+        40,
+    )
+    assert state.diagnostics().throughput_decision_reason == "gpu_budget_guard_hold"
+
+
+def test_single_mixed_scaling_reports_unfunded_scale_up_at_gpu_ceiling():
+    state = _disagg_state(1, 64, 1, 180, enable_load_scaling=True)
+
+    assert state._throughput_single(1.0, 1.0, 1.0, "decode") is None
+    assert state._throughput_lower_bound_d == 64
+    assert state.diagnostics().throughput_decision_reason == "gpu_budget_guard_hold"
+
+
+def test_disagg_throughput_holds_scale_down_without_scale_up_at_gpu_floor():
+    state = _disagg_state(28, 36, 27, 36, enable_load_scaling=False)
+
+    assert state._throughput_disagg(1.0, 1.0, 1.0) is None
+    assert state.diagnostics().throughput_decision_reason == "gpu_budget_guard_hold"
+
+
+def test_single_throughput_does_not_oscillate_at_tolerance_edge():
+    state = _disagg_state(1, 63, 1, 62, enable_load_scaling=False)
+
+    assert state._throughput_single(1.0, 1.0, 1.0, "decode") is None
+    assert state.diagnostics().throughput_decision_reason == "gpu_budget_guard_hold"
+
+
+def test_single_throughput_natural_noop_is_not_reported_as_budget_hold():
+    state = _disagg_state(1, 64, 1, 64, enable_load_scaling=False)
+
+    assert state._throughput_single(1.0, 1.0, 1.0, "decode") is None
+    assert state.diagnostics().throughput_decision_reason == "no_change"
+
+
+def test_single_throughput_floor_is_not_inflated_by_minimum_gpu_budget():
+    state = _disagg_state(1, 64, 1, 1, enable_load_scaling=True)
+
+    assert state._throughput_single(1.0, 1.0, 1.0, "decode") is None
+    assert state._throughput_lower_bound_d == 56
+
+
+def test_disagg_throughput_uses_only_available_headroom():
+    state = _disagg_state(
+        24,
+        36,
+        40,
+        36,
+        enable_load_scaling=False,
+        min_gpus=-1,
+    )
+
+    decision = state._throughput_disagg(1.0, 1.0, 1.0)
+
+    assert decision is not None
+    assert (decision.num_prefill, decision.num_decode) == (28, 36)
+
+
+def test_disagg_throughput_caps_scale_down_when_minimum_is_disabled():
+    state = _disagg_state(
+        20,
+        20,
+        1,
+        20,
+        enable_load_scaling=False,
+        min_gpus=-1,
+    )
+
+    decision = state._throughput_disagg(1.0, 1.0, 1.0)
+
+    assert decision is not None
+    assert (decision.num_prefill, decision.num_decode) == (12, 20)
+
+
+def test_endpoint_and_budget_recovery_take_precedence_over_throughput_cap():
+    state = _disagg_state(
+        21,
+        34,
+        30,
+        34,
+        enable_load_scaling=False,
+        prefill_min_endpoint=30,
+        decode_min_endpoint=34,
+    )
+
+    decision = state._throughput_disagg(1.0, 1.0, 1.0)
+
+    assert decision is not None
+    assert (decision.num_prefill, decision.num_decode) == (30, 34)
+
+
+def test_disagg_endpoint_recovery_overrides_cap_without_minimum_gpu_budget():
+    state = _disagg_state(
+        1,
+        1,
+        30,
+        1,
+        enable_load_scaling=False,
+        min_gpus=-1,
+        prefill_min_endpoint=30,
+        decode_min_endpoint=1,
+    )
+
+    decision = state._throughput_disagg(1.0, 1.0, 1.0)
+
+    assert decision is not None
+    assert (decision.num_prefill, decision.num_decode) == (30, 1)
+
+
+def test_endpoint_recovery_can_select_budget_donor():
+    state = _disagg_state(
+        24,
+        40,
+        8,
+        180,
+        enable_load_scaling=False,
+        prefill_min_endpoint=30,
+        decode_min_endpoint=8,
+    )
+
+    decision = state._throughput_disagg(1.0, 1.0, 1.0)
+
+    assert decision is not None
+    assert (decision.num_prefill, decision.num_decode) == (30, 34)
+
+
+def test_mixed_endpoint_recovery_can_select_budget_donor():
+    state = _disagg_state(
+        24,
+        40,
+        8,
+        180,
+        enable_load_scaling=True,
+        prefill_min_endpoint=30,
+        decode_min_endpoint=8,
+    )
+    assert state._throughput_disagg(1.0, 1.0, 1.0) is None
+    assert (state._throughput_lower_bound_p, state._throughput_lower_bound_d) == (
+        30,
+        34,
+    )
+
+    decision = _load_decision(state, 23, 39)
+
+    assert decision is not None
+    assert (decision.num_prefill, decision.num_decode) == (30, 34)
+    assert state.diagnostics().load_decision_reason == "gpu_budget_reconcile"
+
+
+def test_load_only_endpoint_recovery_can_select_budget_donor():
+    state = _disagg_state(
+        24,
+        40,
+        8,
+        180,
+        enable_load_scaling=True,
+        prefill_min_endpoint=30,
+        decode_min_endpoint=8,
+    )
+    state._config.enable_throughput_scaling = False
+
+    decision = _load_decision(state, 23, 39)
+
+    assert decision is not None
+    assert (decision.num_prefill, decision.num_decode) == (30, 34)
+    assert state.diagnostics().load_decision_reason == "gpu_budget_reconcile"
+
+
+def test_single_endpoint_recovery_overrides_cap_without_minimum_gpu_budget():
+    state = _disagg_state(
+        1,
+        1,
+        30,
+        1,
+        enable_load_scaling=False,
+        min_gpus=-1,
+        prefill_min_endpoint=30,
+    )
+
+    decision = state._throughput_single(1.0, 1.0, 1.0, "prefill")
+
+    assert decision is not None
+    assert decision.num_prefill == 30
+
+
+def test_agg_throughput_uses_replica_cap():
+    state = _disagg_state(
+        1,
+        10,
+        1,
+        1,
+        enable_load_scaling=False,
+        min_gpus=-1,
+        max_gpus=100,
+    )
+    state._capabilities = WorkerCapabilities(
+        decode=EngineCapabilities(
+            gpu_cost_per_replica=1,
+            max_num_batched_tokens=4096,
+        )
+    )
+    state._agg_regression = SimpleNamespace(
+        find_engine_capacity_rps=lambda **_kwargs: SimpleNamespace(
+            rps=1.0,
+            ttft_ms=1.0,
+            itl_ms=1.0,
+            eligible=True,
+        )
+    )
+
+    decision = state._throughput_agg(100.0, 1.0, 1.0)
+
+    assert decision is not None
+    assert decision.num_decode == 18
+
+
+def test_mixed_scaling_funds_only_atomic_part_of_large_throughput_floor():
+    state = _disagg_state(24, 40, 8, 180, enable_load_scaling=True)
+    assert state._throughput_disagg(1.0, 1.0, 1.0) is None
+
+    decision = _load_decision(state, 23, 39)
+
+    assert decision is not None
+    assert (decision.num_prefill, decision.num_decode) == (23, 41)
+
+
+def test_capped_throughput_floor_preserves_floor_guard_without_oscillation():
+    state = _disagg_state(27, 36, 8, 8, enable_load_scaling=True)
+    assert state._throughput_disagg(1.0, 1.0, 1.0) is None
+    assert (state._throughput_lower_bound_p, state._throughput_lower_bound_d) == (
+        19,
+        28,
+    )
+
+    assert _load_decision(state, 26, 35) is None
+    assert state.diagnostics().load_decision_reason == "gpu_budget_guard_hold"
 
 
 @pytest.mark.parametrize("gpu_cost_per_replica", [4, 5])

--- a/components/src/dynamo/planner/tests/unit/test_throughput_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_throughput_scaling.py
@@ -127,6 +127,8 @@ def _load_decision(
     proposed_p: Optional[int],
     proposed_d: Optional[int],
 ):
+    state.begin_tick()
+
     def _prefill(_self, _stats, _workers):
         return proposed_p
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
@@ -118,6 +118,7 @@ spec:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `throughput_adjustment_interval_seconds` | int | `180` | Seconds between throughput-based scaling decisions. |
+| `max_throughput_scaling_replicas` | int | `8` | Maximum replica-count change per component from one throughput observation. The capped target persists until the next throughput observation. GPU and power budgets may reduce it further; endpoint and out-of-band budget recovery take precedence. |
 | `throughput_metrics_source` | string | `frontend` | Prometheus traffic source for throughput scaling: `frontend` reads `dynamo_frontend_*` metrics from the public Frontend; `router` reads `dynamo_component_router_*` metrics from a LocalRouter. Use `router` for pool-local Planner in GlobalPlanner deployments. |
 | `min_endpoint` | int | `1` | Minimum endpoints for `agg` mode. In `disagg` mode, applies the same minimum to prefill and decode. In `prefill` or `decode` mode, supplies the active role when its role-specific field is `null`. May be `0` for scale-to-zero compatibility. |
 | `prefill_min_endpoint` | int or `null` | `null` | Minimum prefill endpoints for `disagg` and `prefill` modes. When set, replaces the prefill value from `min_endpoint`. Must be at least `1`. |

--- a/docs/fern/pages/reference/components/planner-configuration.mdx
+++ b/docs/fern/pages/reference/components/planner-configuration.mdx
@@ -199,6 +199,10 @@ The Planner does not have per-component maximum endpoint fields. `max_gpu_budget
   Seconds between throughput-based scaling decisions. Also accepts the alias `throughput_adjustment_interval`.
 </ParamField>
 
+<ParamField path="max_throughput_scaling_replicas" type="integer" default="8">
+  Maximum replica-count change per component from one throughput observation. The Planner caps and stores the throughput lower bound, so load-scaling ticks cannot repeatedly apply the same uncapped prediction. GPU and power budgets can reduce the change further. At the nominal minimum GPU budget, scale-down-only requests hold. At a full GPU budget, two scale-up requests hold; an opposing prefill/decode proposal applies only the largest atomic pair that fits the budget. Endpoint and out-of-band budget recovery take precedence over this limit. Must be greater than `0`.
+</ParamField>
+
 <ParamField path="throughput_metrics_source" type="string" default="frontend">
   Prometheus traffic source. `frontend` reads `dynamo_frontend_*` metrics from the public Frontend; `router` reads `dynamo_component_router_*` from a LocalRouter (use for a pool-local Planner in GlobalPlanner deployments).
 

--- a/docs/fern/pages/reference/kubernetes-api/dynamo-graph-deployment-request.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/dynamo-graph-deployment-request.mdx
@@ -376,6 +376,10 @@ service.
   Seconds between throughput-based scaling decisions. Also accepts the alias `throughput_adjustment_interval`.
 </ParamField>
 
+<ParamField path="max_throughput_scaling_replicas" type="integer" default="8">
+  Maximum replica-count change per component from one throughput observation. The Planner caps and stores the throughput lower bound, so load-scaling ticks cannot repeatedly apply the same uncapped prediction. GPU and power budgets can reduce the change further. At the nominal minimum GPU budget, scale-down-only requests hold. At a full GPU budget, two scale-up requests hold; an opposing prefill/decode proposal applies only the largest atomic pair that fits the budget. Endpoint and out-of-band budget recovery take precedence over this limit. Must be greater than `0`.
+</ParamField>
+
 <ParamField path="throughput_metrics_source" type="string" default="frontend">
   Prometheus traffic source. `frontend` reads `dynamo_frontend_*` metrics from the public Frontend; `router` reads `dynamo_component_router_*` from a LocalRouter (use for a pool-local Planner in GlobalPlanner deployments).
 

--- a/docs/fern/translations/zh-CN/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
+++ b/docs/fern/translations/zh-CN/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
@@ -109,6 +109,7 @@ spec:
 | 字段 | 类型 | 默认值 | 说明 |
 |-------|------|---------|-------------|
 | `throughput_adjustment_interval_seconds` | int | `180` | 基于吞吐量的扩缩容决策之间的秒数。 |
+| `max_throughput_scaling_replicas` | int | `8` | 单次吞吐量观测对每个组件产生的最大副本数变化。限幅后的目标会保留到下一次吞吐量观测。GPU 和 power budget 可以进一步缩小变化；端点下限和超出 budget band 后的恢复优先于该限制。 |
 | `throughput_metrics_source` | string | `frontend` | 用于吞吐量扩缩容的 Prometheus 流量来源：`frontend` 从公共 Frontend 读取 `dynamo_frontend_*` 指标；`router` 从 LocalRouter 读取 `dynamo_component_router_*` 指标。在 GlobalPlanner 部署中，为池本地 Planner 使用 `router`。 |
 | `min_endpoint` | int | `1` | `agg` 模式的最小端点数；在 `disagg` 模式中，将同一最小值同时应用于 prefill 和 decode；在 `prefill` 或 `decode` 单组件模式中，当对应角色专用字段为 `null` 时应用于当前角色。为兼容 scale-to-zero，可设置为 `0`。 |
 | `prefill_min_endpoint` | int 或 `null` | `null` | `disagg` 和 `prefill` 模式的最小 prefill 端点数。设置后会替换 `min_endpoint` 提供的 prefill 值。必须至少为 `1`。 |


### PR DESCRIPTION
## Summary

- add `max_throughput_scaling_replicas` with a default of 8 and apply it per component to throughput scale-up and scale-down targets
- fit capped targets against GPU and power ceilings without inventing donors, while preserving explicit endpoint and out-of-band budget recovery
- keep `min_gpu_budget` as an action-time scale-down guard instead of persisting it as artificial throughput demand
- extend the direction-preserving budget policy to single and aggregated load paths and add accurate hold/no-change diagnostics
- document the configuration in the Planner guides and API references, including the Amazon Ads fixed-budget interaction

## Related Issues

None.

## Where should the reviewer start?

- `components/src/dynamo/planner/core/throughput_scaling.py` for cap placement and lower-bound behavior
- `components/src/dynamo/planner/core/budget.py` for direction-preserving GPU and power fitting
- `components/src/dynamo/planner/tests/unit/test_throughput_scaling.py` for the Amazon Ads replay and boundary matrix

## Validation

- `PYTHONPATH="$PWD/components/src" /home/hongkuanz/Projects/dynamo/.venv/bin/python -m pytest -q components/src/dynamo/planner/tests` (`1339 passed, 2 skipped`)
- `MYPYPATH=components/src:lib/bindings/python/src /home/hongkuanz/Projects/dynamo/.venv/bin/mypy --explicit-package-bases components/src/dynamo/planner` (206 source files clean)
- changed-file `pre-commit run --files` (passed)
- `python3 docs/fern/scripts/docs_lint.py` (0 errors)
- directional fitter parity against exhaustive brute force (2,429,028 combinations)
- in-band power direction/budget matrix (672,084 combinations)
- agentic replay of the Amazon Ads scenario: `24P/40D`, raw `8P/180D` produces capped floor `16P/48D` and first materialized action `23P/41D`, rather than `8P/56D`

`fern check` was not available in the local Node 18 environment because the installed Fern CLI requires global Web Crypto support; the PR Fern checks pass.