### PR TITLE
fix: escape backslashes in the events table script and tighten the snapshot shard file mode (OPS-8531)

### DIFF
--- a/.github/scripts/update-events.js
+++ b/.github/scripts/update-events.js
@@ -6,7 +6,7 @@ const ICS_URL = 'https://calendar.google.com/calendar/ical/c_c2448d2efb09eac2dde
 const ALLOWED_ONLINE_HOSTS = ['meet.google.com', 'zoom.us', 'teams.microsoft.com', 'webex.com'];
 
 function escapeMd(str) {
-  return str.replace(/\r?\n/g, ' ').replace(/[[\]|`*_~]/g, '\\$&');
+  return str.replace(/\r?\n/g, ' ').replace(/[\\[\]|`*_~]/g, '\\$&');
 }
 
 function safeUrl(url) {

--- a/lib/gpu_memory_service/snapshot/disk.py
+++ b/lib/gpu_memory_service/snapshot/disk.py
@@ -77,7 +77,7 @@ class DeviceToFileWriter:
             self._fd = os.open(
                 file_path,
                 os.O_CREAT | os.O_TRUNC | os.O_WRONLY,
-                0o666,
+                0o644,
             )
         except Exception:
             close_pinned_copy_slots(


### PR DESCRIPTION
## Overview

Two unrelated one-line correctness fixes, one commit each.

### 1. Escape backslashes in the community-events Markdown escaper (`b165549`)

`escapeMd` in `.github/scripts/update-events.js` escapes `[ ] | ` * _ ~` but not the backslash itself. A backslash in a calendar event title therefore passes through untouched, and the character after it ends up with only that stray backslash in front of it — which Markdown consumes as an escaped backslash, letting the next character re-open formatting in the generated README table.

Adding `\` to the character class fixes it:

```diff
-  return str.replace(/\r?\n/g, ' ').replace(/[[\]|`*_~]/g, '\\$&');
+  return str.replace(/\r?\n/g, ' ').replace(/[\\[\]|`*_~]/g, '\\$&');
```

### 2. Create snapshot shards without group or world write (`3687a1b`)

`DeviceToFileWriter` opens shard files with mode `0o666`, so their final permissions depend entirely on the umask the process happens to be running under. `0o644` keeps read access exactly as it was and only drops the group and other write bits, so no existing consumer can be affected.

It also lines the writer up with the rest of the package — `v1/server/rpc.py` sets an explicit mode for its socket rather than relying on the umask. `0o600` would be tighter still; I went with `0o644` because it cannot change behaviour for a reader running as a different user. No in-tree consumer was found either way, so if the owner knows these shards are single-user, `0o600` is the better end state and I'm happy to switch it.

## Validation

**Fix 1** — exercised in a real node 20 runtime against the before/after implementations:

| Input | Before | After |
|---|---|---|
| `back\slash` | `back\slash` (backslash lost) | `back\\slash` |
| `\*text*` | `\\*text\*` (asterisk can reopen) | `\\\*text\*` |
| `plain title`, `a\|b`, `[link]`, `` a`b`c ``, `x_y_z`, `~s~`, `multi\nline` | unchanged | unchanged |

Every input other than the two backslash cases is byte-identical to before.

**Fix 2** — `python3 -m pytest lib/gpu_memory_service/tests/test_v1_weight_artifact.py` passes (2 passed) in the CUDA 13 container. No test asserts the shard file mode; the only `st_mode` assertion in the package covers the RPC socket and is unrelated.

**Both** — `pre-commit run --files <changed>` passes (black, flake8, ruff, isort, codespell, actions-pinning and the rest).

## Where should the reviewer start?

Both diffs are one line each. `lib/gpu_memory_service/snapshot/disk.py` is the one worth a moment's thought — see the note above on `0o644` vs `0o600`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Internal tracking: OPS-8531

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Markdown handling by escaping backslashes correctly, preventing unintended formatting in generated event content.
  - Restricted permissions on generated GPU memory snapshot shard files to improve file security while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
