### PR TITLE
fix(operator): Avoid reconile errors when DGD is scaled

### DIFF
--- a/deploy/operator/internal/controller/dgd_workload_program_test.go
+++ b/deploy/operator/internal/controller/dgd_workload_program_test.go
@@ -172,10 +172,21 @@ func TestPersistWorkloadProgramResultEmitsEventsAfterStatusUpdate(t *testing.T) 
 						return tt.updateErr
 					},
 				}).
+				WithObjects(&nvidiacomv1beta1.DynamoGraphDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-dgd",
+						Namespace: "default",
+					},
+				}).
 				Build()
 			recorder := events.NewFakeRecorder(1)
-			reconciler := &DynamoGraphDeploymentReconciler{Client: kubeClient, Recorder: recorder}
-			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
+			reconciler := &DynamoGraphDeploymentReconciler{Client: kubeClient, DirectClient: kubeClient, Recorder: recorder}
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dgd",
+					Namespace: "default",
+				},
+			}
 			result := newWorkloadProgramResult(dgd)
 			result.Eventf(corev1.EventTypeNormal, "Transition", "transition persisted")
 
@@ -278,9 +289,13 @@ func TestComponentProgram_ReconcilePreservesResultOnError(t *testing.T) {
 				return reconcileErr
 			},
 		}).
+		WithObjects(&nvidiacomv1beta1.DynamoGraphDeployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "graph", Namespace: "default"},
+		}).
 		Build()
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:        kubeClient,
+		DirectClient:  kubeClient,
 		Config:        &configv1alpha1.OperatorConfiguration{},
 		RuntimeConfig: &commonController.RuntimeConfig{},
 	}
@@ -368,6 +383,7 @@ func TestGroveProgram_ReconcilePreservesResultOnError(t *testing.T) {
 		Build()
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:        kubeClient,
+		DirectClient:  kubeClient,
 		Recorder:      events.NewFakeRecorder(10),
 		Config:        &configv1alpha1.OperatorConfiguration{},
 		RuntimeConfig: &commonController.RuntimeConfig{Gate: features.Gates{Grove: true}},

--- a/deploy/operator/internal/controller/dgd_workload_provider_test.go
+++ b/deploy/operator/internal/controller/dgd_workload_provider_test.go
@@ -169,6 +169,7 @@ func TestEnsureWorkloadProvider(t *testing.T) {
 			require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(seed), live))
 			reconciler := &DynamoGraphDeploymentReconciler{
 				Client:        kubeClient,
+				DirectClient:  kubeClient,
 				RuntimeConfig: &commoncontroller.RuntimeConfig{Gate: tt.gate},
 			}
 
@@ -253,6 +254,7 @@ func TestEnsureWorkloadProviderRestoresObjectAfterPatchFailure(t *testing.T) {
 	require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(seed), live))
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:        kubeClient,
+		DirectClient:  kubeClient,
 		RuntimeConfig: &commoncontroller.RuntimeConfig{},
 	}
 
@@ -313,6 +315,7 @@ func TestDynamoGraphDeploymentReconcileReportsUnsupportedWorkloadProvider(t *tes
 			kubeClient := builder.Build()
 			reconciler := &DynamoGraphDeploymentReconciler{
 				Client:        kubeClient,
+				DirectClient:  kubeClient,
 				RuntimeConfig: &commoncontroller.RuntimeConfig{},
 			}
 

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -73,6 +73,7 @@ type rbacManager interface {
 // DynamoGraphDeploymentReconciler reconciles a DynamoGraphDeployment object
 type DynamoGraphDeploymentReconciler struct {
 	client.Client
+	DirectClient          client.Reader
 	Config                *configv1alpha1.OperatorConfiguration
 	RuntimeConfig         *commoncontroller.RuntimeConfig
 	RestConfig            *rest.Config
@@ -224,6 +225,11 @@ func (r *DynamoGraphDeploymentReconciler) persistWorkloadProgramResult(
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 	result workloadProgramResult,
 ) error {
+	namespacedName := types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}
+	// Re-fetch object to avoid "the object has been modified" errors
+	if err := r.DirectClient.Get(ctx, namespacedName, dgd); err != nil {
+		return fmt.Errorf("Failed to re-fetch DynamoGraphDeployment: %w", err)
+	}
 	dgd.Status = result.Status
 	if err := r.Status().Update(ctx, dgd); err != nil {
 		return fmt.Errorf("update DynamoGraphDeployment status: %w", err)

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -115,6 +115,7 @@ func TestDynamoGraphDeploymentReconcileLocksProviderBeforeRejectingStoredCheckpo
 		Build()
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:        kubeClient,
+		DirectClient:  kubeClient,
 		Recorder:      events.NewFakeRecorder(10),
 		Config:        &configv1alpha1.OperatorConfiguration{},
 		RuntimeConfig: &controller_common.RuntimeConfig{},
@@ -172,6 +173,7 @@ func TestDynamoGraphDeploymentReconcileFinalizesDeletingStoredCheckpointIncompat
 		Build()
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:        kubeClient,
+		DirectClient:  kubeClient,
 		Recorder:      events.NewFakeRecorder(10),
 		Config:        &configv1alpha1.OperatorConfiguration{},
 		RuntimeConfig: &controller_common.RuntimeConfig{},
@@ -209,6 +211,7 @@ func TestDynamoGraphDeploymentReconcileFinalizesWithoutSnapshotTypes(t *testing.
 		Build()
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:        kubeClient,
+		DirectClient:  kubeClient,
 		Recorder:      events.NewFakeRecorder(10),
 		Config:        &configv1alpha1.OperatorConfiguration{},
 		RuntimeConfig: &controller_common.RuntimeConfig{},
@@ -556,8 +559,9 @@ func TestDGDScalingAdaptersReconciler_Reconcile(t *testing.T) {
 			fakeClient := clientBuilder.Build()
 
 			r := &DynamoGraphDeploymentReconciler{
-				Client:   fakeClient,
-				Recorder: events.NewFakeRecorder(10),
+				Client:       fakeClient,
+				DirectClient: fakeClient,
+				Recorder:     events.NewFakeRecorder(10),
 			}
 
 			t.Log("Reconcile scaling adapters")
@@ -664,8 +668,9 @@ func TestDGDScalingAdaptersReconciler_EmitsDeleteEventOnlyAfterSuccessfulDelete(
 				Build()
 			recorder := events.NewFakeRecorder(10)
 			reconciler := &DynamoGraphDeploymentReconciler{
-				Client:   kubeClient,
-				Recorder: recorder,
+				Client:       kubeClient,
+				DirectClient: kubeClient,
+				Recorder:     recorder,
 			}
 
 			require.NoError(t, newDGDScalingAdaptersReconciler(reconciler.Client, reconciler.Recorder).Reconcile(context.Background(), dgd))
@@ -1046,6 +1051,7 @@ func TestGroveWorkloadsReconciler_Reconcile(t *testing.T) {
 			recorder := events.NewFakeRecorder(100)
 			reconciler := &DynamoGraphDeploymentReconciler{
 				Client:        fakeKubeClient,
+				DirectClient:  fakeKubeClient,
 				Recorder:      recorder,
 				Config:        &configv1alpha1.OperatorConfiguration{},
 				RuntimeConfig: &controller_common.RuntimeConfig{Gate: features.Gates{DRA: tt.draEnabled}},
@@ -1139,6 +1145,7 @@ func TestGroveWorkloadsReconciler_UsesPreservedAlphaServiceIngress(t *testing.T)
 
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:        fakeKubeClient,
+		DirectClient:  fakeKubeClient,
 		Recorder:      events.NewFakeRecorder(100),
 		Config:        &configv1alpha1.OperatorConfiguration{},
 		RuntimeConfig: &controller_common.RuntimeConfig{},
@@ -2377,9 +2384,10 @@ func TestDGDRestartReconciler_ComputeStatus(t *testing.T) {
 
 			recorder := events.NewFakeRecorder(100)
 			reconciler := &DynamoGraphDeploymentReconciler{
-				Client:   fakeKubeClient,
-				Recorder: recorder,
-				Config:   &configv1alpha1.OperatorConfiguration{},
+				Client:       fakeKubeClient,
+				DirectClient: fakeKubeClient,
+				Recorder:     recorder,
+				Config:       &configv1alpha1.OperatorConfiguration{},
 				RuntimeConfig: &controller_common.RuntimeConfig{
 					Gate: features.Gates{Grove: tt.groveEnabled},
 				},
@@ -3038,6 +3046,7 @@ func TestComponentWorkloadsReconciler_Reconcile(t *testing.T) {
 			recorder := events.NewFakeRecorder(100)
 			reconciler := &DynamoGraphDeploymentReconciler{
 				Client:        fakeKubeClient,
+				DirectClient:  fakeKubeClient,
 				Recorder:      recorder,
 				Config:        &configv1alpha1.OperatorConfiguration{},
 				RuntimeConfig: &controller_common.RuntimeConfig{},
@@ -3264,7 +3273,8 @@ func TestDGDGroveTopologyConditionReconciler_Reconcile(t *testing.T) {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
 			reconciler := &DynamoGraphDeploymentReconciler{
-				Client: fakeClient,
+				Client:       fakeClient,
+				DirectClient: fakeClient,
 				RuntimeConfig: &controller_common.RuntimeConfig{
 					Gate: features.Gates{Grove: tt.groveEnabled},
 				},
@@ -3484,8 +3494,10 @@ func TestGroveWatchSetup_MapPodCliqueScalingGroupToRequests(t *testing.T) {
 			if tt.existingPCS != nil {
 				builder = builder.WithObjects(tt.existingPCS)
 			}
+			kubeClient := builder.Build()
 			r := &DynamoGraphDeploymentReconciler{
-				Client: builder.Build(),
+				Client:       kubeClient,
+				DirectClient: kubeClient,
 			}
 			reqs := newGroveWatchSetup(r.Client).
 				mapPodCliqueScalingGroupToRequests(context.Background(), tt.obj)

--- a/deploy/operator/internal/controller/setup.go
+++ b/deploy/operator/internal/controller/setup.go
@@ -85,6 +85,7 @@ func SetupDynamoComponentDeployment(mgr ctrl.Manager, opts DynamoComponentDeploy
 func SetupDynamoGraphDeployment(mgr ctrl.Manager, opts DynamoGraphDeploymentSetupOptions) error {
 	if err := (&DynamoGraphDeploymentReconciler{
 		Client:                mgr.GetClient(),
+		DirectClient:          mgr.GetAPIReader(),
 		Recorder:              mgr.GetEventRecorder("dynamographdeployment"),
 		Config:                opts.Config,
 		RuntimeConfig:         opts.RuntimeConfig,


### PR DESCRIPTION
## Overview:

Re-fetch the DGD before updating status

## Details:

A fetch of the DGD should avoid "the object has been modified" errors when status is updated.

## Where should the reviewer start?

`deploy/operator/internal/controller/dynamographdeployment_controller.go`

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #14298



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment status updates by ensuring they use the latest available deployment information.
  * Deployment status updates now report an error when the current deployment information cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->