### PR TITLE
fix(sglang): keep the stop token in the token stream under --enable-rl

### DIFF
--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -986,6 +986,7 @@ class SglangStreamingPostProcessor:
         eos_token_ids: list[int] | None = None,
         prompt_token_ids: list[int] | None = None,
         stop_strings: set[str] | None = None,
+        stop_token_ids: set[int] | None = None,
     ) -> None:
         self.tokenizer = tokenizer
         self.tool_call_parser = tool_call_parser
@@ -1008,6 +1009,16 @@ class SglangStreamingPostProcessor:
             [] if self._is_json_array_parser and reasoning_parser is not None else None
         )
         self._eos_token_ids = set(eos_token_ids or [])
+        # Trailing stop markers are dropped here, before detokenization, because
+        # this is the layer that owns user-visible text. Two reasons the set is
+        # wider than ``_eos_token_ids``:
+        #
+        # * a worker launched with ``--enable-rl`` leaves the terminating token in
+        #   the stream on purpose, so this is the only place it gets removed;
+        # * ``_eos_token_ids`` comes from the tokenizer, while a model can declare
+        #   extra EOS ids in ``generation_config.json`` (GLM's ``<|user|>`` /
+        #   ``<|observation|>``). Those reach us only as request stop token ids.
+        self._trailing_stop_token_ids = self._eos_token_ids | set(stop_token_ids or [])
         self._stop_strings = stop_strings or set()
         self._pending_stop_text = ""
         self._locally_finished = False
@@ -1036,10 +1047,10 @@ class SglangStreamingPostProcessor:
         # Full text accumulator for robust finish-time re-parse.
         self._tool_text_parts: list[str] = []
 
-    def _strip_trailing_eos_token_ids(self, token_ids: list[int]) -> list[int]:
-        if not self._eos_token_ids:
+    def _strip_trailing_stop_token_ids(self, token_ids: list[int]) -> list[int]:
+        if not self._trailing_stop_token_ids:
             return token_ids
-        while token_ids and token_ids[-1] in self._eos_token_ids:
+        while token_ids and token_ids[-1] in self._trailing_stop_token_ids:
             token_ids.pop()
         return token_ids
 
@@ -1366,7 +1377,7 @@ class SglangStreamingPostProcessor:
         top_logprobs = engine_response.get("top_logprobs")
         if finish_reason is not None:
             raw_token_count = len(token_ids)
-            token_ids = self._strip_trailing_eos_token_ids(list(token_ids))
+            token_ids = self._strip_trailing_stop_token_ids(list(token_ids))
             retained_token_count = len(token_ids)
             if log_probs is not None and len(log_probs) == raw_token_count:
                 log_probs = log_probs[:retained_token_count]

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -146,6 +146,30 @@ def _request_stop_strings(request: dict[str, Any]) -> set[str]:
     return set()
 
 
+def _request_stop_token_ids(request: dict[str, Any]) -> set[int]:
+    """Stop token ids this request asks the engine to stop on.
+
+    Mirrors how :func:`_build_dynamo_preproc` fills
+    ``stop_conditions.stop_token_ids``, including the case where ``stop`` is an
+    all-integer array. The post-processor drops a trailing stop marker from these
+    before detokenizing, which is the only place it happens when the worker was
+    launched with ``--enable-rl`` and therefore keeps the marker in the token stream.
+    """
+    values: list[Any] = list(request.get("stop_token_ids") or [])
+    stop = request.get("stop")
+    if (
+        isinstance(stop, list)
+        and stop
+        and all(isinstance(item, int) and not isinstance(item, bool) for item in stop)
+    ):
+        values.extend(stop)
+    return {
+        token_id
+        for token_id in values
+        if isinstance(token_id, int) and not isinstance(token_id, bool)
+    }
+
+
 def _tokenizer_eos_token_ids(tokenizer: Any) -> list[int]:
     eos_token_ids = _normalize_eos_token_ids(getattr(tokenizer, "eos_token_ids", None))
     if eos_token_ids:
@@ -612,6 +636,7 @@ class SglangProcessor:
             eos_token_ids=self.eos_token_ids,
             prompt_token_ids=pre.prompt_token_ids,
             stop_strings=_request_stop_strings(request),
+            stop_token_ids=_request_stop_token_ids(request),
         )
 
         async for item in self._generate_and_stream(
@@ -672,6 +697,7 @@ class SglangProcessor:
             eos_token_ids=self.eos_token_ids,
             prompt_token_ids=preproc_result.prompt_token_ids,
             stop_strings=_request_stop_strings(request),
+            stop_token_ids=_request_stop_token_ids(request),
         )
 
         async for item in self._generate_and_stream(

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -57,6 +57,7 @@ from dynamo.frontend.sglang_processor import (
     _model_eos_token_ids,
     _normalize_eos_token_ids,
     _preprocess_worker,
+    _request_stop_token_ids,
     _runtime_config_parser_name,
     _tokenizer_eos_token_ids,
 )
@@ -561,6 +562,28 @@ class TestBuildDynamoPreproc:  # FRONTEND.7 — worker subprocess preproc constr
 
         assert result["stop_conditions"]["stop"] == []
         assert result["stop_conditions"]["stop_token_ids"] == [32, 34]
+
+    def test_request_stop_token_ids_mirrors_preproc_stop_token_ids(self):
+        """The post-processor's suppression set matches what the engine stops on.
+
+        ``_request_stop_token_ids`` feeds the post-processor, which drops a trailing
+        stop marker before detokenizing. It has to agree with the
+        ``stop_conditions.stop_token_ids`` sent to the worker, including the
+        integer-``stop`` spelling above.
+        """
+        for request in (
+            {"model": "test", "stop": [32, 34]},
+            {"model": "test", "stop_token_ids": [32, 34]},
+        ):
+            preproc = _build_dynamo_preproc(request, [1], "test", None)
+            assert _request_stop_token_ids(request) == set(
+                preproc["stop_conditions"]["stop_token_ids"]
+            )
+
+        # String stops are not token stops, and booleans are not token ids.
+        assert _request_stop_token_ids({"stop": " The"}) == set()
+        assert _request_stop_token_ids({"stop_token_ids": [True, 34]}) == {34}
+        assert _request_stop_token_ids({}) == set()
 
     def test_string_stops_remain_string_stops(self):
         """String stops are forwarded as string stops."""
@@ -3786,7 +3809,38 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
             eos_token_ids=[2, 3],
         )
 
-        assert post._strip_trailing_eos_token_ids([10, 3, 2]) == [10]
+        assert post._strip_trailing_stop_token_ids([10, 3, 2]) == [10]
+
+    def test_strips_trailing_request_stop_token_ids(self, tokenizer):
+        """A request stop token id is stripped even when it is not a tokenizer EOS.
+
+        Covers the two cases the EOS set alone misses: a model that declares extra
+        EOS ids in ``generation_config.json`` (they reach the frontend only as
+        request stop token ids), and a worker under ``--enable-rl`` that leaves the
+        terminating token in the stream on purpose.
+        """
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer,
+            tool_call_parser=None,
+            reasoning_parser=None,
+            eos_token_ids=[2],
+            stop_token_ids={576},
+        )
+
+        assert post._strip_trailing_stop_token_ids([10, 576]) == [10]
+        assert post._strip_trailing_stop_token_ids([10, 576, 2]) == [10]
+        # A stop id that is not at the tail is content, not a marker.
+        assert post._strip_trailing_stop_token_ids([576, 10]) == [576, 10]
+
+    def test_keeps_tail_when_no_stop_ids_configured(self, tokenizer):
+        """With neither EOS nor stop ids there is nothing to strip."""
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer,
+            tool_call_parser=None,
+            reasoning_parser=None,
+        )
+
+        assert post._strip_trailing_stop_token_ids([10, 2]) == [10, 2]
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -403,10 +403,43 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             return None
         return mm_hashes
 
+    def _rl_mode_enabled(self) -> bool:
+        """Whether this worker was launched with ``--enable-rl``.
+
+        RL clients consume the token stream itself rather than the detokenized
+        text, so a few response-shaping decisions differ between the two modes.
+        """
+        return bool(
+            getattr(getattr(self.config, "dynamo_args", None), "enable_rl", False)
+        )
+
+    def _suppressed_stop_token_ids_for(self, request: Dict[str, Any]) -> set[int]:
+        """Trailing stop token ids to drop from this worker's token stream.
+
+        Empty under ``--enable-rl``, so the token stream keeps the token that
+        terminated generation.
+
+        Tokens-in-Tokens-Out clients (``nvext.completion_token_ids``) treat the
+        returned ids as the exact sequence the engine sampled and feed it straight
+        back in as the next turn's prompt. Dropping the terminating token there
+        leaves an assistant turn that never closes, and no length check catches it
+        because the logprob array is trimmed by the same amount.
+
+        Nothing leaks into text as a result, because suppression already happens at
+        the presentation layer, which is where it belongs: the Rust ``Decoder``
+        returns no text for any hidden or user stop token id, and the SGLang frontend
+        post-processor strips trailing stop token ids before it detokenizes. Both are
+        unconditional, so this only decides *where* the marker is dropped, not
+        whether it reaches the user.
+        """
+        if self._rl_mode_enabled():
+            return set()
+        return _suppressed_stop_token_ids(request)
+
     def _metadata_uploader_from_request(
         self, request: Dict[str, Any]
     ) -> MetadataUploader | None:
-        if not getattr(getattr(self.config, "dynamo_args", None), "enable_rl", False):
+        if not self._rl_mode_enabled():
             return None
         return MetadataUploader.from_backend_request(request)
 
@@ -567,7 +600,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             output_options.get("return_tokens_as_token_ids")
         )
         user_stop_token_ids = _user_stop_token_ids(request)
-        suppressed_stop_token_ids = _suppressed_stop_token_ids(request)
+        suppressed_stop_token_ids = self._suppressed_stop_token_ids_for(request)
 
         lora_path = self._resolve_lora(request)
         if lora_path:

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -291,6 +291,83 @@ def _new_decode_handler(*, use_sglang_tokenizer: bool = False, enable_rl: bool =
     return handler
 
 
+_STOP_MARKER_REQUEST = {
+    "stop_conditions": {
+        "stop_token_ids": [576],
+        "stop_token_ids_hidden": [128001],
+    }
+}
+
+
+def test_suppressed_stop_token_ids_for_drops_markers_without_rl():
+    """Default serving keeps stop markers out of the token stream."""
+    handler = _new_decode_handler()
+
+    assert handler._suppressed_stop_token_ids_for(_STOP_MARKER_REQUEST) == {
+        576,
+        128001,
+    }
+
+
+def test_suppressed_stop_token_ids_for_preserves_markers_under_rl():
+    """``--enable-rl`` leaves the terminating token in the token stream.
+
+    Tokens-in-Tokens-Out clients re-feed the returned ids as the next prompt, so a
+    stripped terminator produces an assistant turn that never closes. Text stays
+    clean regardless: the Rust ``Decoder`` and the SGLang frontend post-processor
+    both suppress the marker at the presentation layer.
+    """
+    handler = _new_decode_handler(enable_rl=True)
+
+    assert handler._suppressed_stop_token_ids_for(_STOP_MARKER_REQUEST) == set()
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_keeps_stop_token_and_logprobs_under_rl():
+    """The RL token stream is byte-for-byte what the engine sampled.
+
+    Mirrors ``test_process_token_stream_trims_logprobs_for_suppressed_stop_token``
+    with the suppression set the RL path produces, so the two modes are pinned
+    against each other.
+    """
+    handler = _new_decode_handler(enable_rl=True)
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101, 128001],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop", "matched": 128001},
+                            "output_token_logprobs": [
+                                (-0.1, 101, "a"),
+                                (-0.2, 128001, "<|user|>"),
+                            ],
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            user_stop_token_ids={576},
+            suppressed_stop_token_ids=handler._suppressed_stop_token_ids_for(
+                _STOP_MARKER_REQUEST
+            ),
+        )
+    )
+
+    assert chunks == [
+        {
+            "index": 0,
+            "finish_reason": "stop",
+            "token_ids": [101, 128001],
+            "log_probs": [-0.1, -0.2],
+        }
+    ]
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "processor_name", ["_process_token_stream", "_process_text_stream"]


### PR DESCRIPTION
## Overview:

Since #12562 the SGLang worker removes the matched stop token id from the token
stream it emits, not only from the user-visible text. `nvext.completion_token_ids`
is populated from that stream, so the token that terminated generation — the model's
own EOS on a normal `finish_reason: "stop"` — went missing from the token array, and
`usage.completion_tokens` then reported one more token than the array contained.

This moves the suppression to the layer that owns user-visible text. #12562's fix
keeps working for OpenAI clients; token-space (Tokens-in-Tokens-Out) clients get a
faithful token stream back.

No wire-protocol change, no new response fields, and the default (non-`--enable-rl`)
path is byte-identical to today.
<img width="1894" height="794" alt="48e7bf489a0a806b9167b8a79931f793" src="https://github.com/user-attachments/assets/018a9313-4cb2-48c7-8ec7-af093daf8eee" />
After fixing this issue, the average output length decreased from 3k to 2.5k, and the Reward for Step 0 also returned to normal.
## Details:

**1. Worker — suppress only when the client reads text.**
`decode_handler.py` gains `_suppressed_stop_token_ids_for()`, which returns an empty
set under `--enable-rl`. The two existing helpers (`_remove_suppressed_stop_tokens`,
`_split_trailing_suppressed_stop_tokens`) already short-circuit on an empty set, so
`token_ids` and `log_probs` pass through untouched. `_rl_mode_enabled()` also replaces
the duplicated `getattr` chain in `_metadata_uploader_from_request()`.

Nothing leaks into text as a result, because both presentation layers already suppress
the marker on their own: the Rust `Decoder` (`lib/llm/src/backend.rs`) returns no text
for any hidden or user stop token id, and the SGLang frontend post-processor strips
trailing stop token ids before it detokenizes.

**2. Frontend — make that suppression self-sufficient, and widen it.**
`sglang_prepost.py`: `_strip_trailing_eos_token_ids` becomes
`_strip_trailing_stop_token_ids`, operating on the union of the model EOS ids and the
request's stop token ids. `sglang_processor.py` supplies the latter via a new
`_request_stop_token_ids()` that mirrors how `_build_dynamo_preproc()` fills
`stop_conditions.stop_token_ids` (including the all-integer `stop` array spelling).

This closes a second gap that is independent of `--enable-rl`: `_eos_token_ids` is
derived from the tokenizer, so a model that declares extra EOS ids in
`generation_config.json` — GLM's `<|user|>` / `<|observation|>`, which is the token in
the original #12562 report — was never in that set. The frontend also no longer depends
on the worker having stripped first.

### Validation

New tests (6):

- `test_suppressed_stop_token_ids_for_drops_markers_without_rl` /
  `..._preserves_markers_under_rl` — the gate itself, both modes
- `test_process_token_stream_keeps_stop_token_and_logprobs_under_rl` — end-to-end token
  stream; deliberately mirrors the existing
  `test_process_token_stream_trims_logprobs_for_suppressed_stop_token` so the two modes
  are pinned against each other
- `test_strips_trailing_request_stop_token_ids` — a non-tokenizer-EOS stop id is
  stripped; a stop id that is not at the tail is treated as content
- `test_keeps_tail_when_no_stop_ids_configured` — nothing configured, nothing stripped
- `test_request_stop_token_ids_mirrors_preproc_stop_token_ids` — the post-processor's
  set agrees with what the worker is told to stop on

`components/src/dynamo/sglang/tests/` + `components/src/dynamo/frontend/tests/test_sglang_processor_unit.py`
+ `test_sglang_processor_metrics_unit.py`: **680 passed, 1 skipped, 2 failed**. Both
failures are pre-existing local SGLang version skew in code this PR does not touch
(`GenerateReqInput` has no `session_id`; `ProfileReq.__init__()` missing `type`).

## Where should the reviewer start?

- `components/src/dynamo/sglang/request_handlers/llm/decode_handler.py` —
  `_suppressed_stop_token_ids_for()` is the only behavioral gate. Worth confirming that
  an empty set really is a no-op in both `_remove_suppressed_stop_tokens` and
  `_split_trailing_suppressed_stop_tokens`.
- `components/src/dynamo/frontend/sglang_processor.py` — `_request_stop_token_ids()`
  must stay in sync with `_build_dynamo_preproc()`; the test asserts that, but a second
  pair of eyes on the `stop`-as-integer-array case is welcome.
- `components/src/dynamo/frontend/sglang_prepost.py` — the widened set applies in both
  modes, so this is where a regression to the #12562 fix would show up.

## Related Issues

- Closes #14302

<!--
Internal notes — not part of the PR body. HTML comments render as nothing on GitHub,
so this block is safe to leave in when pasting, but deleting it is cleaner.

Before pushing (commit 7486a41d0 on branch `stop_token`, not yet pushed):

  1. No DCO sign-off, and the author is `root <>` with an empty email. CI's
     dco_check.py will fail and GitHub cannot attribute the commit. Fix with:

       git -c user.name="Your Name" -c user.email="you@example.com" \
           commit --amend --no-edit -s --reset-author

  2. Confirm issue #14302 is the right number (could not verify: GitHub API rate limit).

  3. Run `pre-commit run --all-files` in an environment that has ruff.

  4. Fork PRs need a maintainer to comment `/ok to test <sha>`. The automatic
     trusted-CI path additionally requires every commit to be GitHub-`Verified`
     (cryptographically signed); a DCO sign-off alone does not qualify.

PR title (reuse the commit subject, 70 chars):
  fix(sglang): keep the stop token in the token stream under --enable-rl
-->

Co-authored-by: @ShaneGZhu 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming responses to correctly remove trailing request-defined stop tokens before text generation completes.
  - Stop tokens supplied as IDs are now honored consistently across supported request formats.
  - Preserved non-terminal occurrences of stop tokens within generated content.

- **Generation Behavior**
  - Standard decoding continues to suppress terminating stop markers.
  - Reinforcement-learning decoding preserves terminating stop tokens and their associated log probabilities for downstream processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->