### PR TITLE
fix(operator): make Snapshot worker-hash validation source-driven

### DIFF
--- a/deploy/operator/internal/checkpoint/native.go
+++ b/deploy/operator/internal/checkpoint/native.go
@@ -62,8 +62,8 @@ func ManagedPodSnapshotUse(ownerUID types.UID) PodSnapshotUse {
 // but not-yet-ready snapshot is returned with Ready=false so callers can gate
 // workloads while retaining an admission-time reference to the same object.
 // A nil config means checkpointing is disabled. Reader must be non-nil when
-// checkpointing is enabled. A nil expectedWorkerHash means the target is not a
-// worker-class component; a non-nil value must contain its generation hash.
+// checkpointing is enabled. A non-empty snapshot worker hash requires the same
+// non-empty expectedWorkerHash; nil means the target has no worker generation.
 func ResolvePodSnapshotForService(
 	ctx context.Context,
 	reader client.Reader,
@@ -81,10 +81,6 @@ func ResolvePodSnapshotForService(
 	if config.CheckpointRef == nil || strings.TrimSpace(*config.CheckpointRef) == "" {
 		return nil, fmt.Errorf("checkpointRef is required for native PodSnapshot restore")
 	}
-	if expectedWorkerHash != nil && *expectedWorkerHash == "" {
-		return nil, fmt.Errorf("worker compatibility hash is required for native PodSnapshot restore")
-	}
-
 	// Read the referenced standalone Snapshot object directly.
 	snapshotName := strings.TrimSpace(*config.CheckpointRef)
 	snapshot := &snapshotv1alpha1.PodSnapshot{}
@@ -154,6 +150,10 @@ func ResolvePodSnapshotForService(
 		)
 	}
 	workerHash := annotations[consts.SnapshotWorkerHashAnnotation]
+	// Enforce source-declared worker compatibility against the target generation.
+	if workerHash != "" && (expectedWorkerHash == nil || *expectedWorkerHash == "") {
+		return nil, fmt.Errorf("worker compatibility hash is required for native PodSnapshot restore")
+	}
 	if expectedWorkerHash != nil && workerHash != *expectedWorkerHash {
 		return nil, fmt.Errorf(
 			"referenced PodSnapshot %s/%s worker hash %q does not match expected hash %q",

--- a/deploy/operator/internal/checkpoint/native_test.go
+++ b/deploy/operator/internal/checkpoint/native_test.go
@@ -136,6 +136,25 @@ func TestResolvePodSnapshotForService(t *testing.T) {
 		assert.Equal(t, snapshot.UID, info.NativeSnapshot.UID)
 	})
 
+	t.Run("rejects a worker snapshot when the target has no worker hash", func(t *testing.T) {
+		t.Log("Given a worker PodSnapshot and a target without worker generation metadata")
+		snapshot := nativeTestPodSnapshot()
+		reader := fake.NewClientBuilder().WithScheme(nativeTestScheme(t)).WithObjects(snapshot).Build()
+
+		t.Log("When the reference is resolved without a target worker hash")
+		_, err := ResolvePodSnapshotForService(
+			context.Background(),
+			reader,
+			snapshot.Namespace,
+			nativeTestCheckpointConfig(snapshot.Name),
+			nil,
+			ExplicitPodSnapshotUse(),
+		)
+
+		t.Log("Then the snapshot metadata requires worker compatibility validation")
+		require.ErrorContains(t, err, "worker compatibility hash is required")
+	})
+
 	t.Run("rejects a worker restore before its hash is available", func(t *testing.T) {
 		t.Log("Given a worker restore whose generation identity is not initialized")
 		snapshot := nativeTestPodSnapshot()

--- a/deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler.go
+++ b/deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 )
@@ -158,6 +157,7 @@ func (h *PodCheckpointRestoreMutator) buildPinnedPodSnapshotRestorePod(
 		Enabled:       true,
 		CheckpointRef: &snapshotName,
 	}
+	targetWorkerHash := pod.Labels[consts.KubeLabelDynamoWorkerHash]
 
 	// Admission bypasses the informer cache and repeats compatibility validation
 	// so a deleted and recreated PodSnapshot cannot satisfy old incarnation pins.
@@ -166,7 +166,7 @@ func (h *PodCheckpointRestoreMutator) buildPinnedPodSnapshotRestorePod(
 		h.apiReader,
 		podNamespace,
 		config,
-		expectedWorkerHashForPod(pod),
+		&targetWorkerHash,
 		checkpoint.ExplicitPodSnapshotUse(),
 	)
 	if err != nil {
@@ -234,12 +234,13 @@ func (h *PodCheckpointRestoreMutator) buildAutomaticSnapshotJobRestorePod(
 		Enabled:       true,
 		CheckpointRef: &snapshotName,
 	}
+	targetWorkerHash := pod.Labels[consts.KubeLabelDynamoWorkerHash]
 	info, err := checkpoint.ResolvePodSnapshotForService(
 		ctx,
 		h.apiReader,
 		podNamespace,
 		config,
-		expectedWorkerHashForPod(pod),
+		&targetWorkerHash,
 		checkpoint.ManagedPodSnapshotUse(ownerUID),
 	)
 	if apierrors.IsNotFound(err) {
@@ -267,14 +268,6 @@ func automaticCandidateUnavailable(
 		return nil, false, nil
 	}
 	return nil, false, fmt.Errorf("automatic restore candidate unavailable: %s", reason)
-}
-
-func expectedWorkerHashForPod(pod *corev1.Pod) *string {
-	if !dynamo.IsWorkerComponent(pod.Labels[consts.KubeLabelDynamoComponentType]) {
-		return nil
-	}
-	workerHash := pod.Labels[consts.KubeLabelDynamoWorkerHash]
-	return &workerHash
 }
 
 func (h *PodCheckpointRestoreMutator) shapeNativeRestorePod(

--- a/deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler_test.go
+++ b/deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler_test.go
@@ -130,6 +130,7 @@ func TestPodCheckpointRestoreMutatorNativeRestore(t *testing.T) {
 			{
 				name: "worker generation mismatch",
 				mutate: func(pod *corev1.Pod) {
+					pod.Labels[consts.KubeLabelDynamoComponentType] = consts.ComponentTypeFrontend
 					pod.Labels[consts.KubeLabelDynamoWorkerHash] = "worker-v2"
 				},
 				wantErr: "does not match expected hash",
@@ -246,6 +247,26 @@ func TestPodCheckpointRestoreMutatorAutomaticSnapshotJob(t *testing.T) {
 		assert.Equal(t, snapshot.Name, shaped.Annotations[podcontract.RestoreFromAnnotation])
 		assert.NotContains(t, shaped.Annotations, consts.RestoreCandidateSourceKindAnnotation)
 		assert.NotContains(t, shaped.Annotations, consts.SnapshotJobCandidateUIDAnnotation)
+	})
+
+	t.Run("completed worker capture rejects mismatched target worker generation", func(t *testing.T) {
+		t.Log("Given a completed worker SnapshotJob and a target claiming a non-worker component type")
+		snapshot := automaticRestoreTestSnapshot()
+		job := automaticRestoreTestJob(true)
+		job.Status.PodSnapshotName = snapshot.Name
+		job.Status.PodSnapshotUID = snapshot.UID
+		pod := automaticRestoreCandidatePod(job, nvidiacomv1alpha1.CheckpointStartupPolicyImmediate)
+		pod.Labels[consts.KubeLabelDynamoComponentType] = consts.ComponentTypeFrontend
+		pod.Labels[consts.KubeLabelDynamoWorkerHash] = "worker-v2"
+		mutator := automaticRestoreTestMutator(t, scheme, job, snapshot)
+
+		t.Log("When Pod admission resolves the worker snapshot from its server-side source")
+		resp := mutator.Handle(ctx, podCreateAdmissionRequest(t, pod))
+
+		t.Log("Then the target cannot suppress or bypass worker-hash validation")
+		assert.False(t, resp.Allowed)
+		require.NotNil(t, resp.Result)
+		assert.Contains(t, resp.Result.Message, "does not match expected hash")
 	})
 
 	t.Run("recreated SnapshotJob never restores through the stale candidate", func(t *testing.T) {

--- a/docs/fern/pages/reference/kubernetes-api/dynamo-component-deployment.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/dynamo-component-deployment.mdx
@@ -240,6 +240,10 @@ The upgrade does not delete the legacy `DynamoCheckpoint` CRD, instances, `PodSn
   <ParamField path="checkpointRef" type="string">
     References an existing `PodSnapshot` in the same namespace by `metadata.name`. When set, this component's `identity` is ignored and the referenced PodSnapshot is used directly. Standalone worker-class (`worker`, `prefill`, or `decode`) `DynamoComponentDeployment` resources cannot set this field; configure `checkpointRef` on the component in the owning `DynamoGraphDeployment`.
   </ParamField>
+
+  <Note>
+    Namespace isolation and Kubernetes RBAC control access to `PodSnapshot` resources. Dynamo compatibility annotations prevent restores into incompatible workloads; they are integrity metadata, not authorization credentials.
+  </Note>
   <ParamField path="targetContainerName" type="string" default="main">
     The workload container to snapshot and restore. Must match `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`, 1–63 characters.
   </ParamField>


### PR DESCRIPTION
## Overview:

Make Dynamo's worker compatibility check for PodSnapshot restores source-driven. A worker PodSnapshot now requires the target Pod to carry the same non-empty worker hash, even when the target claims a non-worker component type.

## Details:

- Require a target worker hash whenever the resolved PodSnapshot declares worker-generation metadata.
- Pass the target Pod's worker hash to the resolver independently of its self-declared component type.
- Preserve restores from genuine non-worker PodSnapshots that do not declare a worker hash.
- Cover missing and mismatched hashes through explicit and automatic SnapshotJob-backed admission paths.
- Clarify that namespace isolation and Kubernetes RBAC are the Snapshot access boundary; compatibility annotations provide integrity checks, not authorization.

### Validation

- Reproduced on current `main`: resolver, explicit admission, and automatic admission accepted worker snapshots after the target claimed `frontend` and omitted or mismatched its worker hash.
- `go test ./internal/checkpoint ./internal/webhook/mutation -count=1`
- `go test ./internal/checkpoint ./internal/webhook/mutation -run 'TestResolvePodSnapshotForService|TestPodCheckpointRestoreMutator' -count=10`
- `go test ./internal/controller -run 'Checkpoint|Snapshot' -count=1`
- `go test ./api/... -count=1`
- `go vet ./internal/checkpoint ./internal/webhook/mutation`
- Repository pre-commit hooks passed for all changed files.
- Docs lint, Fern configuration validation, and Fern broken-link validation passed.
- `go test ./internal/... -count=1` passed all packages except the unrelated `malformed_provider_override_field_is_invalid_without_echoing_its_value` assertion; the same failure reproduces on an untouched `origin/main` worktree.

The available AKS cluster does not yet have the standalone `SnapshotJob` API introduced by #14076, so live cluster admission was not exercised. The Pod-mutator tests cover request decoding, direct Snapshot API reads, compatibility validation, and the final admission response.

## Where should the reviewer start?

Start with `deploy/operator/internal/checkpoint/native.go`, where the resolved PodSnapshot now determines whether worker-hash validation is required. Then review `deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler.go`, which no longer gates the target hash on component type.

## Related Issues

**This PR is linked to an issue:**

- Closes #14287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PodSnapshot restore compatibility checks for worker workloads.
  - Restores now reject snapshots with worker metadata when the target’s worker compatibility hash is missing or does not match.
  - Non-worker restores continue to work without worker metadata.
  - Applied the same validation to both pinned snapshots and automatic restore workflows.

- **Documentation**
  - Clarified that PodSnapshot access is governed by namespace isolation and Kubernetes RBAC; compatibility annotations do not grant authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->