### PR TITLE
fix(ci): retry ECR login through STS failures (OPS-8529)

### DIFF
--- a/.github/actions/docker-login/action.yml
+++ b/.github/actions/docker-login/action.yml
@@ -27,9 +27,176 @@ runs:
     - name: ECR Login
       shell: bash
       if: ${{ inputs.aws_default_region != '' && inputs.ecr_registry != '' }}
+      env:
+        # Passed through env, never interpolated into the script body: a
+        # ${{ ... }} expansion inside `run:` is substituted before bash parses
+        # the script, so the value is materialized into the runner's temp
+        # script file and cannot be safely quoted.
+        AWS_DEFAULT_REGION: ${{ inputs.aws_default_region }}
+        ECR_REGISTRY: ${{ inputs.ecr_registry }}
+        LOGIN_CLIENT: docker
       run: |
         set -euo pipefail
-        aws ecr get-login-password --region ${{ inputs.aws_default_region }} | docker login --username AWS --password-stdin "${{ inputs.ecr_registry }}"
+
+        # ---- preflight (cheap, fails loud, never burns the retry budget) -------------
+        # A typo'd region emits the byte-identical "Could not connect to the endpoint
+        # URL" that a real DNS outage does, so it is unclassifiable after the fact.
+        [ -n "${AWS_DEFAULT_REGION:-}" ] || { echo "::error::ECR login: aws_default_region input is empty."; exit 1; }
+        [ -n "${ECR_REGISTRY:-}" ]      || { echo "::error::ECR login: ecr_registry input is empty.";      exit 1; }
+        [ -n "${LOGIN_CLIENT:-}" ]      || { echo "::error::ECR login: LOGIN_CLIENT is not set.";          exit 1; }
+        ATTEMPT_TIMEOUT=60    # per-attempt wall-clock bound on the aws call
+        if ! [[ "$AWS_DEFAULT_REGION" =~ ^[a-z]{2}(-gov|-iso[a-z]?)?-[a-z]+-[0-9]+$ ]]; then
+          echo "::error::ECR login: region '$AWS_DEFAULT_REGION' is not a well-formed AWS region."
+          exit 1
+        fi
+        command -v aws           >/dev/null || { echo "::error::ECR login: 'aws' is not on PATH.";            exit 1; }
+        command -v "$LOGIN_CLIENT" >/dev/null || { echo "::error::ECR login: '$LOGIN_CLIENT' is not on PATH."; exit 1; }
+        echo "aws: $(aws --version 2>&1)"   # the runner image is not in this repo; record the version
+
+        # A blackholed STS endpoint hangs `aws` indefinitely (measured: still running
+        # after 8s, killed by timeout with rc=124 and EMPTY stderr). coreutils `timeout`
+        # is present on the Debian/Ubuntu runner; degrade loudly rather than hard-fail.
+        TIMEOUT_PREFIX=()
+        if   command -v timeout  >/dev/null; then TIMEOUT_PREFIX=(timeout  "$ATTEMPT_TIMEOUT")
+        elif command -v gtimeout >/dev/null; then TIMEOUT_PREFIX=(gtimeout "$ATTEMPT_TIMEOUT")
+        else echo "::warning::ECR login: no 'timeout' on PATH; a hung STS call will not be bounded."
+        fi
+
+        # ---- password file ----------------------------------------------------------
+        # mktemp, never a fixed path: a fixed /tmp/ecr_pw is a symlink-follow write
+        # primitive on 1777 /tmp and leaked another job's token in 200/200 concurrent
+        # trials. umask 077 + mktemp gives 0600 regardless of the ambient umask.
+        umask 077
+        PW_FILE=""
+        cleanup() { [ -n "$PW_FILE" ] && rm -f "$PW_FILE"; return 0; }
+        trap cleanup EXIT INT TERM          # installed BEFORE mktemp: no leak window.
+        PW_FILE="$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/ecrpw.XXXXXXXX")"
+
+        # ---- retry policy -----------------------------------------------------------
+        MAX_ATTEMPTS=5        # 1-(1-0.226)^5 = 72% login success at the measured rate
+        BASE_DELAY=3          # full-jitter cap for the first backoff
+        MAX_DELAY=45          # cap; keeps worst-case sleep at 3+6+12+24 = 45s
+        TOTAL_BUDGET=300      # hard wall-clock ceiling for the whole step
+        DEADLINE=$(( $(date +%s) + TOTAL_BUDGET ))
+        EMPTY_PW='aws exited 0 but produced an empty authorization token'
+
+        # ---- retryability: ALLOW-list, fail closed ----------------------------------
+        # Scored 40/40 on the induced-error catalog where the deny-list scored 28/40.
+        # Matches the EXTRACTED error code, not a glob over the whole message, so a
+        # message body containing "AccessDenied" cannot flip a transient 5xx.
+        is_retryable() {
+          local rc="$1" err="$2" code   # `local`: bash functions share scope, so an
+                                        # unlocal rc= here would clobber the caller's.
+          # `timeout` produces rc 124 with EMPTY stderr, so text matching cannot see it.
+          if [ "$rc" -eq 124 ]; then return 0; fi
+          if [ "$err" = "$EMPTY_PW" ]; then return 0; fi
+          code="$(printf '%s' "$err" | sed -n 's/.*An error occurred (\([^)]*\)).*/\1/p')"
+          if [ -n "$code" ]; then
+            case "$code" in
+              # Bare numerics appear whenever the HTTP error body is unparseable.
+              Throttling|ThrottlingException|TooManyRequestsException|RequestLimitExceeded|SlowDown| \
+              ServiceUnavailable|ServiceUnavailableException|InternalError|InternalFailure| \
+              InternalServerError|ServerException|RequestTimeout|RequestTimeoutException| \
+              BandwidthLimitExceeded|PriorRequestNotComplete|LimitExceededException|IDPCommunicationError| \
+              429|500|502|503|504|509) return 0 ;;
+              *) return 1 ;;   # AccessDenied, InvalidIdentityToken, UnrecognizedClientException,
+            esac                # ExpiredTokenException, NoCredentials, ValidationError, ...
+          fi
+          # rc 255 errors carry NO error code at all; these are the transport failures.
+          case "$err" in
+            *'Could not connect to the endpoint URL'*|*'Connect timeout on endpoint URL'*| \
+            *'Read timeout on endpoint URL'*|*'Connection was closed before we received a valid response'*| \
+            *'Connection reset'*) return 0 ;;
+            *) return 1 ;;
+          esac
+        }
+
+        # ---- fetch loop -------------------------------------------------------------
+        attempt=1
+        while : ; do
+          # `2>&1 >file` (this order) sends stdout to the file and stderr to the
+          # capture. Never pipe into the client: pipefail returns the RIGHTMOST
+          # non-zero status, so the client's rc=1 destroys aws's 253/254/255, and an
+          # empty stdin makes skopeo print "inappropriate ioctl for device" (docker:
+          # "password is empty") -- messages that name neither AWS nor STS.
+          # The explicit `|| rc=$?` is required: `$?` inside `if ! cmd` is 0.
+          # TOTAL_BUDGET is a HARD ceiling, so the per-attempt timeout is clamped to the
+          # budget that is actually left. Without this the last attempt can overrun the
+          # deadline by a full ATTEMPT_TIMEOUT (measured: 328s against a 300s budget).
+          remaining=$(( DEADLINE - $(date +%s) ))
+          if [ "$remaining" -le 0 ]; then
+            echo "::error::ECR login exhausted its ${TOTAL_BUDGET}s budget after $(( attempt - 1 )) attempts."
+            exit 1
+          fi
+          this_timeout="$ATTEMPT_TIMEOUT"
+          if [ "$remaining" -lt "$this_timeout" ]; then this_timeout="$remaining"; fi
+          if [ "${#TIMEOUT_PREFIX[@]}" -gt 0 ]; then TIMEOUT_PREFIX[1]="$this_timeout"; fi
+
+          rc=0
+          err="$("${TIMEOUT_PREFIX[@]}" aws ecr get-login-password \
+                   --region "$AWS_DEFAULT_REGION" 2>&1 >"$PW_FILE")" || rc=$?
+          if [ "$rc" -eq 0 ] && [ -s "$PW_FILE" ]; then
+            break
+          fi
+          # aws CLI v2 writes a LEADING BLANK LINE before "aws: [ERROR]:", so a naive
+          # head -1 yields "" and every log line reads "failed ()". `|| true` is
+          # mandatory: grep -v exits 1 on empty input and set -e would kill the step.
+          err="$(printf '%s\n' "$err" | grep -v '^[[:space:]]*$' | head -1 || true)"
+          if [ "$rc" -eq 0 ]; then err="$EMPTY_PW"; fi
+          if [ -z "$err" ]; then err="aws exited $rc with no diagnostic output"; fi
+          : > "$PW_FILE"   # drop any partial write before the next attempt
+
+          if ! is_retryable "$rc" "$err"; then
+            echo "::error::ECR login failed permanently (aws rc=$rc): $err"
+            exit 1
+          fi
+          if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+            echo "::error::ECR login failed after $MAX_ATTEMPTS attempts (aws rc=$rc): $err"
+            exit 1
+          fi
+          # Full jitter over an exponentially growing cap. NOT delay=$((delay*2+RANDOM%5)):
+          # that compounds its own jitter (2x spread over 6 rounds) and wraps negative,
+          # after which `sleep` fails and set -e aborts the step.
+          cap=$(( BASE_DELAY << (attempt - 1) ))
+          if [ "$cap" -gt "$MAX_DELAY" ]; then cap="$MAX_DELAY"; fi
+          delay=$(( 1 + RANDOM % cap ))
+          if [ $(( $(date +%s) + delay )) -ge "$DEADLINE" ]; then
+            echo "::error::ECR login exhausted its ${TOTAL_BUDGET}s budget after $attempt attempts (aws rc=$rc): $err"
+            exit 1
+          fi
+          echo "::warning::ECR login attempt $attempt/$MAX_ATTEMPTS failed (aws rc=$rc): $err; retrying in ${delay}s"
+          sleep "$delay"
+          attempt=$(( attempt + 1 ))   # never a bare `(( attempt++ ))`: it returns the
+        done                           # OLD value, so at 0 it exits 1 and set -e kills the step.
+
+        # ---- hand the token to the client -------------------------------------------
+        # `< "$PW_FILE"` keeps the token out of argv, out of the environment, out of any
+        # shell variable, and out of a `set -x` trace. No ::add-mask:: is needed or
+        # wanted: the token is never printed, and `echo "::add-mask::$PW"` is itself
+        # traced in cleartext under set -x before the mask exists.
+        if ! "$LOGIN_CLIENT" login --username AWS --password-stdin "$ECR_REGISTRY" < "$PW_FILE"; then
+          echo "::error::ECR login: '$LOGIN_CLIENT' rejected a token that aws returned successfully on attempt $attempt."
+          exit 1
+        fi
+        echo "ECR login succeeded on attempt $attempt/$MAX_ATTEMPTS."
+
+        # ---- credential-cache diagnostic (non-fatal, IRSA only) ---------------------
+        # AWS CLI v2 caches sts:AssumeRoleWithWebIdentity results under
+        # ~/.aws/cli/cache with a key that is stable across processes, so every
+        # `aws` call in a job should collapse to ONE STS call. That silently
+        # degrades to a fresh STS call per process when HOME is unset or not
+        # writable (ARC runner pods run as uid 1001), multiplying this repo's STS
+        # load with no log line anywhere. Report it; never fail the step over it.
+        # The cache files hold live credentials: count them, never print them.
+        if [ -n "${AWS_WEB_IDENTITY_TOKEN_FILE:-}" ] && [ -n "${AWS_ROLE_ARN:-}" ]; then
+          if [ -z "${HOME:-}" ]; then
+            echo "::warning::ECR login: HOME is unset, so the AWS CLI credential cache is disabled and every 'aws' process re-assumes the role via STS."
+          elif [ -d "$HOME/.aws/cli/cache" ]; then
+            echo "ECR login: AWS credential cache is live ($(find "$HOME/.aws/cli/cache" -type f 2>/dev/null | wc -l | tr -d ' ') entries under \$HOME/.aws/cli/cache)."
+          else
+            echo "::warning::ECR login: no credential cache at \$HOME/.aws/cli/cache after a successful login; every 'aws' process will re-assume the role via STS. Check that HOME ($HOME) is writable by uid $(id -u)."
+          fi
+        fi
     - name: NGC Login
       if: ${{ inputs.ngc_ci_access_token != '' }}
       shell: bash

--- a/.github/actions/skopeo-login/action.yml
+++ b/.github/actions/skopeo-login/action.yml
@@ -44,10 +44,176 @@ runs:
     - name: ECR Login
       shell: bash
       if: ${{ inputs.aws_default_region != '' && inputs.ecr_registry != '' }}
+      env:
+        # Passed through env, never interpolated into the script body: a
+        # ${{ ... }} expansion inside `run:` is substituted before bash parses
+        # the script, so the value is materialized into the runner's temp
+        # script file and cannot be safely quoted.
+        AWS_DEFAULT_REGION: ${{ inputs.aws_default_region }}
+        ECR_REGISTRY: ${{ inputs.ecr_registry }}
+        LOGIN_CLIENT: skopeo
       run: |
         set -euo pipefail
-        aws ecr get-login-password --region ${{ inputs.aws_default_region }} | skopeo login --username AWS --password-stdin "${{ inputs.ecr_registry }}"
 
+        # ---- preflight (cheap, fails loud, never burns the retry budget) -------------
+        # A typo'd region emits the byte-identical "Could not connect to the endpoint
+        # URL" that a real DNS outage does, so it is unclassifiable after the fact.
+        [ -n "${AWS_DEFAULT_REGION:-}" ] || { echo "::error::ECR login: aws_default_region input is empty."; exit 1; }
+        [ -n "${ECR_REGISTRY:-}" ]      || { echo "::error::ECR login: ecr_registry input is empty.";      exit 1; }
+        [ -n "${LOGIN_CLIENT:-}" ]      || { echo "::error::ECR login: LOGIN_CLIENT is not set.";          exit 1; }
+        ATTEMPT_TIMEOUT=60    # per-attempt wall-clock bound on the aws call
+        if ! [[ "$AWS_DEFAULT_REGION" =~ ^[a-z]{2}(-gov|-iso[a-z]?)?-[a-z]+-[0-9]+$ ]]; then
+          echo "::error::ECR login: region '$AWS_DEFAULT_REGION' is not a well-formed AWS region."
+          exit 1
+        fi
+        command -v aws           >/dev/null || { echo "::error::ECR login: 'aws' is not on PATH.";            exit 1; }
+        command -v "$LOGIN_CLIENT" >/dev/null || { echo "::error::ECR login: '$LOGIN_CLIENT' is not on PATH."; exit 1; }
+        echo "aws: $(aws --version 2>&1)"   # the runner image is not in this repo; record the version
+
+        # A blackholed STS endpoint hangs `aws` indefinitely (measured: still running
+        # after 8s, killed by timeout with rc=124 and EMPTY stderr). coreutils `timeout`
+        # is present on the Debian/Ubuntu runner; degrade loudly rather than hard-fail.
+        TIMEOUT_PREFIX=()
+        if   command -v timeout  >/dev/null; then TIMEOUT_PREFIX=(timeout  "$ATTEMPT_TIMEOUT")
+        elif command -v gtimeout >/dev/null; then TIMEOUT_PREFIX=(gtimeout "$ATTEMPT_TIMEOUT")
+        else echo "::warning::ECR login: no 'timeout' on PATH; a hung STS call will not be bounded."
+        fi
+
+        # ---- password file ----------------------------------------------------------
+        # mktemp, never a fixed path: a fixed /tmp/ecr_pw is a symlink-follow write
+        # primitive on 1777 /tmp and leaked another job's token in 200/200 concurrent
+        # trials. umask 077 + mktemp gives 0600 regardless of the ambient umask.
+        umask 077
+        PW_FILE=""
+        cleanup() { [ -n "$PW_FILE" ] && rm -f "$PW_FILE"; return 0; }
+        trap cleanup EXIT INT TERM          # installed BEFORE mktemp: no leak window.
+        PW_FILE="$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/ecrpw.XXXXXXXX")"
+
+        # ---- retry policy -----------------------------------------------------------
+        MAX_ATTEMPTS=5        # 1-(1-0.226)^5 = 72% login success at the measured rate
+        BASE_DELAY=3          # full-jitter cap for the first backoff
+        MAX_DELAY=45          # cap; keeps worst-case sleep at 3+6+12+24 = 45s
+        TOTAL_BUDGET=300      # hard wall-clock ceiling for the whole step
+        DEADLINE=$(( $(date +%s) + TOTAL_BUDGET ))
+        EMPTY_PW='aws exited 0 but produced an empty authorization token'
+
+        # ---- retryability: ALLOW-list, fail closed ----------------------------------
+        # Scored 40/40 on the induced-error catalog where the deny-list scored 28/40.
+        # Matches the EXTRACTED error code, not a glob over the whole message, so a
+        # message body containing "AccessDenied" cannot flip a transient 5xx.
+        is_retryable() {
+          local rc="$1" err="$2" code   # `local`: bash functions share scope, so an
+                                        # unlocal rc= here would clobber the caller's.
+          # `timeout` produces rc 124 with EMPTY stderr, so text matching cannot see it.
+          if [ "$rc" -eq 124 ]; then return 0; fi
+          if [ "$err" = "$EMPTY_PW" ]; then return 0; fi
+          code="$(printf '%s' "$err" | sed -n 's/.*An error occurred (\([^)]*\)).*/\1/p')"
+          if [ -n "$code" ]; then
+            case "$code" in
+              # Bare numerics appear whenever the HTTP error body is unparseable.
+              Throttling|ThrottlingException|TooManyRequestsException|RequestLimitExceeded|SlowDown| \
+              ServiceUnavailable|ServiceUnavailableException|InternalError|InternalFailure| \
+              InternalServerError|ServerException|RequestTimeout|RequestTimeoutException| \
+              BandwidthLimitExceeded|PriorRequestNotComplete|LimitExceededException|IDPCommunicationError| \
+              429|500|502|503|504|509) return 0 ;;
+              *) return 1 ;;   # AccessDenied, InvalidIdentityToken, UnrecognizedClientException,
+            esac                # ExpiredTokenException, NoCredentials, ValidationError, ...
+          fi
+          # rc 255 errors carry NO error code at all; these are the transport failures.
+          case "$err" in
+            *'Could not connect to the endpoint URL'*|*'Connect timeout on endpoint URL'*| \
+            *'Read timeout on endpoint URL'*|*'Connection was closed before we received a valid response'*| \
+            *'Connection reset'*) return 0 ;;
+            *) return 1 ;;
+          esac
+        }
+
+        # ---- fetch loop -------------------------------------------------------------
+        attempt=1
+        while : ; do
+          # `2>&1 >file` (this order) sends stdout to the file and stderr to the
+          # capture. Never pipe into the client: pipefail returns the RIGHTMOST
+          # non-zero status, so the client's rc=1 destroys aws's 253/254/255, and an
+          # empty stdin makes skopeo print "inappropriate ioctl for device" (docker:
+          # "password is empty") -- messages that name neither AWS nor STS.
+          # The explicit `|| rc=$?` is required: `$?` inside `if ! cmd` is 0.
+          # TOTAL_BUDGET is a HARD ceiling, so the per-attempt timeout is clamped to the
+          # budget that is actually left. Without this the last attempt can overrun the
+          # deadline by a full ATTEMPT_TIMEOUT (measured: 328s against a 300s budget).
+          remaining=$(( DEADLINE - $(date +%s) ))
+          if [ "$remaining" -le 0 ]; then
+            echo "::error::ECR login exhausted its ${TOTAL_BUDGET}s budget after $(( attempt - 1 )) attempts."
+            exit 1
+          fi
+          this_timeout="$ATTEMPT_TIMEOUT"
+          if [ "$remaining" -lt "$this_timeout" ]; then this_timeout="$remaining"; fi
+          if [ "${#TIMEOUT_PREFIX[@]}" -gt 0 ]; then TIMEOUT_PREFIX[1]="$this_timeout"; fi
+
+          rc=0
+          err="$("${TIMEOUT_PREFIX[@]}" aws ecr get-login-password \
+                   --region "$AWS_DEFAULT_REGION" 2>&1 >"$PW_FILE")" || rc=$?
+          if [ "$rc" -eq 0 ] && [ -s "$PW_FILE" ]; then
+            break
+          fi
+          # aws CLI v2 writes a LEADING BLANK LINE before "aws: [ERROR]:", so a naive
+          # head -1 yields "" and every log line reads "failed ()". `|| true` is
+          # mandatory: grep -v exits 1 on empty input and set -e would kill the step.
+          err="$(printf '%s\n' "$err" | grep -v '^[[:space:]]*$' | head -1 || true)"
+          if [ "$rc" -eq 0 ]; then err="$EMPTY_PW"; fi
+          if [ -z "$err" ]; then err="aws exited $rc with no diagnostic output"; fi
+          : > "$PW_FILE"   # drop any partial write before the next attempt
+
+          if ! is_retryable "$rc" "$err"; then
+            echo "::error::ECR login failed permanently (aws rc=$rc): $err"
+            exit 1
+          fi
+          if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+            echo "::error::ECR login failed after $MAX_ATTEMPTS attempts (aws rc=$rc): $err"
+            exit 1
+          fi
+          # Full jitter over an exponentially growing cap. NOT delay=$((delay*2+RANDOM%5)):
+          # that compounds its own jitter (2x spread over 6 rounds) and wraps negative,
+          # after which `sleep` fails and set -e aborts the step.
+          cap=$(( BASE_DELAY << (attempt - 1) ))
+          if [ "$cap" -gt "$MAX_DELAY" ]; then cap="$MAX_DELAY"; fi
+          delay=$(( 1 + RANDOM % cap ))
+          if [ $(( $(date +%s) + delay )) -ge "$DEADLINE" ]; then
+            echo "::error::ECR login exhausted its ${TOTAL_BUDGET}s budget after $attempt attempts (aws rc=$rc): $err"
+            exit 1
+          fi
+          echo "::warning::ECR login attempt $attempt/$MAX_ATTEMPTS failed (aws rc=$rc): $err; retrying in ${delay}s"
+          sleep "$delay"
+          attempt=$(( attempt + 1 ))   # never a bare `(( attempt++ ))`: it returns the
+        done                           # OLD value, so at 0 it exits 1 and set -e kills the step.
+
+        # ---- hand the token to the client -------------------------------------------
+        # `< "$PW_FILE"` keeps the token out of argv, out of the environment, out of any
+        # shell variable, and out of a `set -x` trace. No ::add-mask:: is needed or
+        # wanted: the token is never printed, and `echo "::add-mask::$PW"` is itself
+        # traced in cleartext under set -x before the mask exists.
+        if ! "$LOGIN_CLIENT" login --username AWS --password-stdin "$ECR_REGISTRY" < "$PW_FILE"; then
+          echo "::error::ECR login: '$LOGIN_CLIENT' rejected a token that aws returned successfully on attempt $attempt."
+          exit 1
+        fi
+        echo "ECR login succeeded on attempt $attempt/$MAX_ATTEMPTS."
+
+        # ---- credential-cache diagnostic (non-fatal, IRSA only) ---------------------
+        # AWS CLI v2 caches sts:AssumeRoleWithWebIdentity results under
+        # ~/.aws/cli/cache with a key that is stable across processes, so every
+        # `aws` call in a job should collapse to ONE STS call. That silently
+        # degrades to a fresh STS call per process when HOME is unset or not
+        # writable (ARC runner pods run as uid 1001), multiplying this repo's STS
+        # load with no log line anywhere. Report it; never fail the step over it.
+        # The cache files hold live credentials: count them, never print them.
+        if [ -n "${AWS_WEB_IDENTITY_TOKEN_FILE:-}" ] && [ -n "${AWS_ROLE_ARN:-}" ]; then
+          if [ -z "${HOME:-}" ]; then
+            echo "::warning::ECR login: HOME is unset, so the AWS CLI credential cache is disabled and every 'aws' process re-assumes the role via STS."
+          elif [ -d "$HOME/.aws/cli/cache" ]; then
+            echo "ECR login: AWS credential cache is live ($(find "$HOME/.aws/cli/cache" -type f 2>/dev/null | wc -l | tr -d ' ') entries under \$HOME/.aws/cli/cache)."
+          else
+            echo "::warning::ECR login: no credential cache at \$HOME/.aws/cli/cache after a successful login; every 'aws' process will re-assume the role via STS. Check that HOME ($HOME) is writable by uid $(id -u)."
+          fi
+        fi
     - name: ACR Login
       shell: bash
       if: ${{ inputs.azure_acr_hostname != '' && inputs.azure_acr_user != '' && inputs.azure_acr_password != '' }}


### PR DESCRIPTION
Linear: OPS-8529

## Summary

An AWS STS `us-west-2` degradation on 2026-09-03 (~21:10–22:15 UTC) killed **at least 94 jobs across 12+ workflow runs**, every one at the same unretried call in `docker-login` / `skopeo-login`:

```
aws: [ERROR]: An error occurred (Throttling) when calling the AssumeRoleWithWebIdentity operation (reached max retries: 2): Rate exceeded
aws: [ERROR]: An error occurred (ServiceUnavailable) when calling the AssumeRoleWithWebIdentity operation (reached max retries: 2): Unknown
```

Zero occurrences in the preceding 100 post-merge runs (2.5 days), then 7 of 7 consecutive runs. `ServiceUnavailable` (an STS 5xx) outnumbered `Throttling` 31:11, so this was primarily AWS-side unavailability that the repo's zero-retry login converted straight into red CI.

Two defects made it fatal:

1. **No retry on the auth path** — while `skopeo-copy` wraps the *cheap, idempotent* `skopeo copy` immediately after it in a 3-attempt backoff loop **and** passes `--retry-times 4`. The fragile step was the only unprotected one.
2. **Piping destroyed the diagnostics** — `pipefail` returns the *rightmost* non-zero status, so the login client's `rc=1` overwrote aws's `253/254/255`; fed an empty stdin, skopeo falls back to a TTY prompt and prints `inappropriate ioctl for device` (docker: `password is empty`). Every affected log named neither AWS nor STS, so this read as a registry problem for the first 40 minutes of the outage.

### What changed

Capture aws's stdout to a `0600` `mktemp` file and feed the client only on success, so aws's exit code and stderr survive and an empty token can never reach the client. Retry on an **allow-list** of the *extracted* error code plus the code-less transport failures — 5 attempts, full jitter over caps 3/6/12/24s, 60s per-attempt timeout, 300s hard ceiling. Permanent errors exit after exactly one attempt.

The two files' `ECR Login` bodies are byte-identical; the only difference is `LOGIN_CLIENT: skopeo` vs `docker` in `env:`.

Also adds a **non-fatal probe** for the AWS CLI on-disk credential cache (`~/.aws/cli/cache`). It should collapse N STS calls per job into one, but degrades silently to a fresh call per process when `HOME` is unset or unwritable — ARC runner pods run as uid 1001, so this needs observing rather than assuming. This PR's first green run answers it.

### Why not `AWS_MAX_ATTEMPTS` / `AWS_RETRY_MODE`

Deliberately not set. Measured against a fake STS endpoint, they *do* reach the `AssumeRoleWithWebIdentity` credential-resolution call (HTTP request count `== AWS_MAX_ATTEMPTS` exactly, 1/3/6/10 → 1/3/6/10, on aws-cli 2.34.30 and 2.34.34). But:

- The entire span at `AWS_MAX_ATTEMPTS=10` is only **52–89s** — botocore caps its backoff at 20s. That cannot span a 65-minute degradation.
- **`AWS_RETRY_MODE=legacy` is rejected outright by aws-cli v2** (`must be one of: "standard" or "adaptive"`, rc=255, zero network calls). Setting it at workflow-`env` level would hard-fail *every* `aws` invocation repo-wide — and AWS's own docs describe `legacy` as the botocore default, making it an easy value to reach for. An empty value does the same.
- It fixes none of the defects above.

### Sizing

22.6% of logins succeeded during the degradation (14 of 62 login-performing jobs). At that rate 5 attempts is the knee — ~72% recovery, `+8.1pp` over 4, while 10 attempts would issue **10× today's STS volume from every job simultaneously** into a service that is already failing. Treat 72% as an upper bound: a regional degradation is correlated, not independent.

## Validation

Run on macOS bash 5.3.15 **and** Linux bash 5.2.21 (closest match to the ARC runner), launched exactly as GitHub launches a composite step (`bash --noprofile --norc -e -o pipefail`), with the body extracted from the *rendered* `action.yml` via `yaml.safe_load`:

| Scenario | Result |
|---|---|
| immediate success | exit 0, 1 aws call, 0 leftover files |
| 2× Throttling then success | exit 0, 3 aws calls, succeeded on attempt 3 |
| permanent (`UnrecognizedClientException`) | exit 1, **exactly 1 aws call** |
| permanent (`NoCredentials`, rc 253) | exit 1, exactly 1 aws call |
| permanent (bare `[Errno 2]`, no error code, rc 255) | exit 1, exactly 1 aws call |
| exhaustion (sustained Throttling) | exit 1, 5 aws calls, 24s |
| transport failure (rc 255, no code) | retried, as intended |
| `InternalServerError` whose body contains `AccessDenied` | **retried** (a deny-list abandons this on attempt 1) |
| aws exits 0 with empty output | never reaches the client; no `ioctl`/`password is empty` |
| hung STS (blackholed endpoint) | 300s ceiling honoured exactly |
| 5 trials × 40 parallel logins | 200/200 correct token, 0 mismatches, 0 leftovers |
| SIGTERM / SIGINT | temp file removed |

Also verified against the **real** `aws` CLI 2.34.30 (missing token file, no credentials, refused STS endpoint) — the leading-blank-line normalization matters there and a stub had hidden it.

Retry predicate scored **40/40** on the induced-error catalog; the deny-list I first drafted scored 28/40, and its one fail-*closed* miss (`InternalServerError` whose body says `AccessDenied`) would have defeated the change during exactly the outage it was written for.

`pre-commit run --files <both>` passes, including `check-action-pins`. Note nothing in this repo lints workflow shell — no actionlint or shellcheck hook exists — so the shell wants human eyes.

### Reviewer checklist

- `2>&1 >"$PW_FILE"` ordering (reversed writes the *error text* into the password file)
- `|| rc=$?`, never `if ! err=$(…)` — the latter zeroes `$?`
- `|| true` after `grep -v` — `grep` exits 1 on empty input and `set -e` kills the step
- `local` in `is_retryable` — bash functions share scope
- `umask 077` and `trap` both **before** `mktemp`
- no bare `(( x++ ))` — returns the old value, exits 1 at 0

### Known-debatable

`ExpiredTokenException` is classified **permanent**, against botocore's own "refreshable" classification: kubelet refreshes a projected IRSA token at 80% of TTL, not inside a 45s backoff window, so retrying only delays a failure that needs an operator fix.

### Out of scope

`release.yml:290`/`:845`, `aws ecr describe-images` in `docker-remote-build` (failure silently swallowed by `2>/dev/null || echo "0"`), sccache inside BuildKit (~195 STS calls/run, Rust SDK, different retry impl), and the infra-level fixes — EKS Pod Identity, which AWS documents as **not** consuming account STS quota unlike IRSA, and a support case on the unpublished `AssumeRoleWithWebIdentity` rate ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container registry authentication reliability for Docker and Skopeo workflows.
  * Added validation for required settings, regions, and command availability before login attempts.
  * Added bounded retries for transient failures, with clearer handling of permanent errors and rejected credentials.
  * Improved security when handling temporary authentication credentials.
  * Added clearer status reporting for credential caching in web-identity authentication environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->