### PR TITLE
ci: scope the token for the PR title lint workflow (OPS-8530)

### DIFF
--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -8,6 +8,14 @@ on:
       - synchronize
       - reopened
 
+# The action adds a type label to the PR, and creates the repository label if
+# it does not exist yet, so it needs write on both issues and pull-requests.
+# Without this block the job inherits the repository default token.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   conventional-commits:
     name: Validate PR title and add label

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -10,9 +10,10 @@ on:
 
 # The action adds a type label to the PR, and creates the repository label if
 # it does not exist yet, so it needs write on both issues and pull-requests.
-# Without this block the job inherits the repository default token.
+# `contents` is deliberately left unset (none): there is no checkout step and
+# the action only calls the issues API, so nothing here reads repository
+# contents. Without this block the job inherits the repository default token.
 permissions:
-  contents: read
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
## Overview

`lint-pr-title.yaml` declares no `permissions:` block, so its job inherits the repository default token. It is the only `pull_request_target` workflow in the repo without one — `label-pr.yml`, `pr_full_ci_reminder.yaml` and `trigger-ci-approval-flow.yml` all scope theirs.

```yaml
permissions:
  issues: write
  pull-requests: write
```

## Why these three scopes

`ytanikin/pr-conventional-commits` is a Docker action whose `token` input defaults to `${{ github.token }}`. Its `githubapi.js` calls `octokit.rest.issues.addLabels` **and** `octokit.rest.issues.createLabel` — the latter creates the repository label when it does not already exist. That create path is repository-level, so `pull-requests: write` on its own is not enough; `issues: write` is required too. Scoping this to `pull-requests: write` alone would have broken a workflow that currently works.

`contents` is deliberately left unset, which means `none`. The job has no checkout step and the action only calls the issues API, so it never reads repository contents. That matches `pr_full_ci_reminder.yaml`, the other `pull_request_target` workflow here that runs without a checkout. (An earlier revision of this PR included `contents: read`; it was dropped in 7344d6f675 after review.)

## Validation

`pre-commit run --files .github/workflows/lint-pr-title.yaml` passes, including `check yaml` and the actions SHA-pinning hook.

**This change cannot be exercised before merge, and that is worth knowing up front.** `pull_request_target` always runs the workflow definition from the base branch, so the "Lint PR" check on *this* PR executes `main`'s copy, not the version in the diff. The first real exercise is the next PR-title event after merge.

If the scopes turn out to be short, the failure is loud and immediate rather than silent — the action's README documents it as `Error: Resource not accessible by integration` — and the fix is to widen this one block.

## Where should the reviewer start?

The whole diff is the eight added lines. The judgement call worth checking is `issues: write`, explained above.

## Related Issues

Internal tracking: OPS-8530

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request automation permissions so labels can be created and applied automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

