### PR TITLE
ci: give five workflows an explicit default token scope (OPS-8532)

### DIFF
--- a/.github/workflows/build-on-demand.yml
+++ b/.github/workflows/build-on-demand.yml
@@ -26,6 +26,17 @@ on:
 env:
   BUILDER_NAME: b-${{ github.run_id }}-${{ github.run_attempt }}
 
+# Scope the token for every job that does not set its own `permissions`.
+# `actions: read` is needed as well as `contents: read`: most of the unscoped
+# jobs here call reusable workflows, and a caller's block is the ceiling for
+# the workflow it calls -- shared-build-image.yml and shared-build-sidecar.yml
+# both declare `actions: read` internally, which a `contents: read` ceiling
+# would strip. Jobs that set their own block are unaffected; a job-level
+# `permissions` replaces this one outright.
+permissions:
+  actions: read
+  contents: read
+
 jobs:
 
   init:

--- a/.github/workflows/pr-xpu.yaml
+++ b/.github/workflows/pr-xpu.yaml
@@ -12,6 +12,17 @@ concurrency:
   group: pr-xpu-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Scope the token for every job that does not set its own `permissions`.
+# `actions: read` is needed as well as `contents: read`: most of the unscoped
+# jobs here call reusable workflows, and a caller's block is the ceiling for
+# the workflow it calls -- shared-build-image.yml and shared-build-sidecar.yml
+# both declare `actions: read` internally, which a `contents: read` ceiling
+# would strip. Jobs that set their own block are unaffected; a job-level
+# `permissions` replaces this one outright.
+permissions:
+  actions: read
+  contents: read
+
 jobs:
 
   # ============================================================================

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,6 +16,17 @@ concurrency:
 env:
   BUILDER_NAME: b-${{ github.run_id }}-${{ github.run_attempt }}
 
+# Scope the token for every job that does not set its own `permissions`.
+# `actions: read` is needed as well as `contents: read`: most of the unscoped
+# jobs here call reusable workflows, and a caller's block is the ceiling for
+# the workflow it calls -- shared-build-image.yml and shared-build-sidecar.yml
+# both declare `actions: read` internally, which a `contents: read` ceiling
+# would strip. Jobs that set their own block are unaffected; a job-level
+# `permissions` replaces this one outright.
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   # ============================================================================
   # SETUP & DETECTION JOBS

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -27,6 +27,17 @@ concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Scope the token for every job that does not set its own `permissions`.
+# `actions: read` is needed as well as `contents: read`: most of the unscoped
+# jobs here call reusable workflows, and a caller's block is the ceiling for
+# the workflow it calls -- shared-build-image.yml and shared-build-sidecar.yml
+# both declare `actions: read` internally, which a `contents: read` ceiling
+# would strip. Jobs that set their own block are unaffected; a job-level
+# `permissions` replaces this one outright.
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   changed-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/xpu-ci.yaml
+++ b/.github/workflows/xpu-ci.yaml
@@ -56,6 +56,17 @@ env:
   PLATFORM: linux/amd64
   SOURCE_REF: ${{ inputs.source_ref || github.sha }}
 
+# Scope the token for every job that does not set its own `permissions`.
+# `actions: read` is needed as well as `contents: read`: most of the unscoped
+# jobs here call reusable workflows, and a caller's block is the ceiling for
+# the workflow it calls -- shared-build-image.yml and shared-build-sidecar.yml
+# both declare `actions: read` internally, which a `contents: read` ceiling
+# would strip. Jobs that set their own block are unaffected; a job-level
+# `permissions` replaces this one outright.
+permissions:
+  actions: read
+  contents: read
+
 jobs:
 
   # ============================================================================


### PR DESCRIPTION
> **Draft on purpose.** This narrows the token for 62 CI jobs. Please confirm the repository's Workflow permissions default before merging — see "Before merging" below.

## Overview

`pr.yaml`, `pre-merge.yml`, `build-on-demand.yml`, `xpu-ci.yaml` and `pr-xpu.yaml` declare no workflow-level `permissions`, so every job in them that does not set its own block inherits the repository default token. That is **62 jobs** across the five files — 43 in `pr.yaml`, 9 in `build-on-demand.yml`, 4 each in the two xpu workflows, 2 in `pre-merge.yml`.

Each file gets:

```yaml
permissions:
  actions: read
  contents: read
```

## Why `actions: read` and not `contents: read` alone

`contents: read` on its own would break CI. **28 of `pr.yaml`'s 43 unscoped jobs are reusable-workflow calls**, and a caller's `permissions` block is the *ceiling* for the workflow it calls, not a floor. `shared-build-image.yml` and `shared-build-sidecar.yml` each declare `actions: read` internally, so a `contents: read` ceiling would strip it out from under them.

The same pair is what the nine already-scoped call jobs in `pr.yaml` declare, so this matches the file's own established pattern rather than inventing one.

Jobs that already set their own `permissions` are untouched: a job-level block *replaces* the workflow-level one rather than merging with it. That includes the one `pr.yaml` job that needs `contents: write`.

## Before merging

Check **Settings → Actions → General → Workflow permissions**.

Evidence suggests it is currently set to *Read and write*: `lint-pr-title.yaml` has no `permissions` block, and its `ytanikin/pr-conventional-commits` step calls `octokit.rest.issues.createLabel` / `addLabels` — yet recent runs succeed and PRs are getting `feat`/`fix`/`chore` labels. That only works with a writable default token. If so, this PR is a genuine narrowing for all 62 jobs. If the default is already read-only, the change is documentation of intent and costs nothing.

## Residual risk, stated plainly

I verified the two shared workflows that declare permissions internally. `shared-compliance-audit.yml` and `shared-compliance.yml` declare **none**, so they inherit whatever the caller allows. I did not prove they need nothing beyond `actions: read` + `contents: read` — they authenticate to ACR/ECR via repository secrets rather than the GitHub token, which is why I expect this to be fine, but it is an expectation, not a verified fact.

Failures here are loud rather than silent (`Error: Resource not accessible by integration`), and the fix is to widen the one block that is short. Merging when a full CI run can be watched is the sensible play.

## Validation

`pre-commit run --files <the five workflows>` passes, including `check yaml` and the actions SHA-pinning hook. The change is additive; no existing key is modified.

## Where should the reviewer start?

Any one of the five diffs — they are identical 11-line insertions. The judgement call is `actions: read`, explained above.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Internal tracking: OPS-8532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

