### PR TITLE
fix(sglang): publish sidecar offloading capacity

### DIFF
--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -930,23 +930,17 @@ mod tests {
 
     use super::{
         DisaggregationMode, DiscoveredKvEventSource, Discovery, build_engine_config,
-        discover_kv_event_sources, resolve_bootstrap_host_with_local,
+        discover_kv_event_sources, hicache_native_offloading_capacity,
+        resolve_bootstrap_host_with_local,
     };
 
     fn discovery(server_info: serde_json::Value) -> Discovery {
-        discovery_with_model_info(server_info, json!({}))
-    }
-
-    fn discovery_with_model_info(
-        server_info: serde_json::Value,
-        model_info: serde_json::Value,
-    ) -> Discovery {
         Discovery {
             model_path: "model".to_string(),
             tokenizer_path: "tokenizer".to_string(),
             served_model_name: None,
             max_model_len: None,
-            model_info,
+            model_info: json!({}),
             server_info,
         }
     }
@@ -1057,30 +1051,7 @@ mod tests {
     }
 
     #[test]
-    fn publishes_ratio_based_hicache_capacity() {
-        let config = build_engine_config(
-            &discovery(json!({
-                "enable_hierarchical_cache": true,
-                "hicache_size": 0,
-                "hicache_ratio": 3.0,
-                "hicache_write_policy": "write_back",
-                "page_size": 16,
-                "max_total_num_tokens": 100,
-            })),
-            DisaggregationMode::Decode,
-            None,
-            None,
-        )
-        .unwrap();
-
-        assert_eq!(
-            config.runtime_data.get("native_offloading_capacity"),
-            Some(&json!({"total_tokens": 304}))
-        );
-    }
-
-    #[test]
-    fn hicache_capacity_accounts_for_write_policy() {
+    fn publishes_hicache_capacity() {
         let config = build_engine_config(
             &discovery(json!({
                 "enable_hierarchical_cache": true,
@@ -1103,116 +1074,37 @@ mod tests {
     }
 
     #[test]
-    fn authoritative_hicache_capacity_takes_precedence() {
-        let config = build_engine_config(
-            &discovery_with_model_info(
-                json!({
-                    "enable_hierarchical_cache": true,
-                    "hicache_host_total_tokens": 300,
-                    "hicache_size": 0,
-                    "hicache_ratio": 3.0,
-                    "hicache_write_policy": "write_back",
-                    "page_size": 16,
-                    "max_total_num_tokens": 100,
-                }),
-                json!({"architectures": ["DeepseekV4ForCausalLM"]}),
-            ),
-            DisaggregationMode::Decode,
-            None,
-            None,
-        )
-        .unwrap();
-
-        assert_eq!(
-            config.runtime_data.get("native_offloading_capacity"),
-            Some(&json!({"total_tokens": 300}))
-        );
-    }
-
-    #[test]
-    fn does_not_derive_ratio_based_capacity_for_deepseek_v4() {
+    fn deepseek_v4_capacity_requires_authoritative_total() {
+        let mut server_info = json!({
+            "enable_hierarchical_cache": true,
+            "hicache_size": 0,
+            "hicache_ratio": 2.0,
+            "hicache_write_policy": "write_back",
+            "page_size": 256,
+            "max_total_num_tokens": 8192,
+        });
         for architecture in [
             "DeepseekV4ForCausalLM",
             "DeepseekV4ForCausalLMNextN",
             "DeepseekV4ForCausalLMDSpark",
         ] {
-            let config = build_engine_config(
-                &discovery_with_model_info(
-                    json!({
-                        "enable_hierarchical_cache": true,
-                        "hicache_size": 0,
-                        "hicache_ratio": 2.0,
-                        "hicache_write_policy": "write_back",
-                        "page_size": 256,
-                        "max_total_num_tokens": 8192,
-                    }),
-                    json!({"architectures": [architecture]}),
+            assert_eq!(
+                hicache_native_offloading_capacity(
+                    &server_info,
+                    &json!({"architectures": [architecture]}),
                 ),
-                DisaggregationMode::Decode,
-                None,
-                None,
-            )
-            .unwrap();
-
-            assert!(
-                !config
-                    .runtime_data
-                    .contains_key("native_offloading_capacity")
+                None
             );
         }
-    }
 
-    #[test]
-    fn does_not_publish_unproven_hicache_capacity() {
-        for server_info in [
-            json!({
-                "enable_hierarchical_cache": false,
-                "hicache_size": 0,
-                "hicache_ratio": 3.0,
-                "hicache_write_policy": "write_back",
-                "page_size": 16,
-                "max_total_num_tokens": 100,
-            }),
-            json!({
-                "enable_hierarchical_cache": true,
-                "hicache_size": 4,
-                "hicache_ratio": 3.0,
-                "hicache_write_policy": "write_back",
-                "page_size": 16,
-                "max_total_num_tokens": 100,
-            }),
-            json!({
-                "enable_hierarchical_cache": true,
-                "hicache_size": 0,
-                "hicache_ratio": 3.0,
-                "hicache_write_policy": "write_through_selective",
-                "page_size": 16,
-                "max_total_num_tokens": 100,
-            }),
-            json!({
-                "enable_hierarchical_cache": true,
-                "hicache_size": 0,
-                "hicache_ratio": 3.0,
-                "hicache_write_policy": "write_back",
-                "page_size": 16,
-                "dcp_size": 2,
-                "max_total_num_tokens": 100,
-            }),
-        ] {
-            let config = build_engine_config(
-                &discovery(server_info),
-                DisaggregationMode::Decode,
-                None,
-                None,
-            )
-            .unwrap();
-
-            assert!(
-                !config
-                    .runtime_data
-                    .contains_key("native_offloading_capacity")
-            );
-        }
+        server_info["hicache_host_total_tokens"] = json!(16384);
+        assert_eq!(
+            hicache_native_offloading_capacity(
+                &server_info,
+                &json!({"architectures": ["DeepseekV4ForCausalLM"]}),
+            ),
+            Some(16384)
+        );
     }
 
     #[test]

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -769,7 +769,25 @@ fn kv_event_connect_host(
     Ok(bare_host.to_string())
 }
 
-fn hicache_native_offloading_capacity(server_info: &Value) -> Option<u64> {
+fn is_deepseek_v4_arch(model_info: &Value) -> bool {
+    model_info
+        .get("architectures")
+        .and_then(Value::as_array)
+        .is_some_and(|architectures| {
+            architectures.iter().any(|architecture| {
+                matches!(
+                    architecture.as_str(),
+                    Some(
+                        "DeepseekV4ForCausalLM"
+                            | "DeepseekV4ForCausalLMNextN"
+                            | "DeepseekV4ForCausalLMDSpark"
+                    )
+                )
+            })
+        })
+}
+
+fn hicache_native_offloading_capacity(server_info: &Value, model_info: &Value) -> Option<u64> {
     let device_tokens = server_info
         .get("max_total_num_tokens")?
         .as_u64()
@@ -782,10 +800,11 @@ fn hicache_native_offloading_capacity(server_info: &Value) -> Option<u64> {
     let host_tokens = match server_info.get("hicache_host_total_tokens") {
         Some(value) => value.as_u64().filter(|tokens| *tokens > 0)?,
         None => {
-            if server_info
-                .get("enable_hierarchical_cache")
-                .and_then(Value::as_bool)
-                != Some(true)
+            if is_deepseek_v4_arch(model_info)
+                || server_info
+                    .get("enable_hierarchical_cache")
+                    .and_then(Value::as_bool)
+                    != Some(true)
                 || server_info.get("hicache_size").and_then(Value::as_u64) != Some(0)
                 || client::json_u64(server_info, "dcp_size")
                     .unwrap_or(1)
@@ -876,7 +895,9 @@ fn build_engine_config(
         "grpc_service".to_string(),
         Value::String("sglang.runtime.v1.SglangService".to_string()),
     );
-    if let Some(total_tokens) = hicache_native_offloading_capacity(&discovery.server_info) {
+    if let Some(total_tokens) =
+        hicache_native_offloading_capacity(&discovery.server_info, &discovery.model_info)
+    {
         runtime_data.insert(
             "native_offloading_capacity".to_string(),
             serde_json::json!({"total_tokens": total_tokens}),
@@ -913,12 +934,19 @@ mod tests {
     };
 
     fn discovery(server_info: serde_json::Value) -> Discovery {
+        discovery_with_model_info(server_info, json!({}))
+    }
+
+    fn discovery_with_model_info(
+        server_info: serde_json::Value,
+        model_info: serde_json::Value,
+    ) -> Discovery {
         Discovery {
             model_path: "model".to_string(),
             tokenizer_path: "tokenizer".to_string(),
             served_model_name: None,
             max_model_len: None,
-            model_info: json!({}),
+            model_info,
             server_info,
         }
     }
@@ -1077,15 +1105,18 @@ mod tests {
     #[test]
     fn authoritative_hicache_capacity_takes_precedence() {
         let config = build_engine_config(
-            &discovery(json!({
-                "enable_hierarchical_cache": true,
-                "hicache_host_total_tokens": 300,
-                "hicache_size": 0,
-                "hicache_ratio": 3.0,
-                "hicache_write_policy": "write_back",
-                "page_size": 16,
-                "max_total_num_tokens": 100,
-            })),
+            &discovery_with_model_info(
+                json!({
+                    "enable_hierarchical_cache": true,
+                    "hicache_host_total_tokens": 300,
+                    "hicache_size": 0,
+                    "hicache_ratio": 3.0,
+                    "hicache_write_policy": "write_back",
+                    "page_size": 16,
+                    "max_total_num_tokens": 100,
+                }),
+                json!({"architectures": ["DeepseekV4ForCausalLM"]}),
+            ),
             DisaggregationMode::Decode,
             None,
             None,
@@ -1096,6 +1127,39 @@ mod tests {
             config.runtime_data.get("native_offloading_capacity"),
             Some(&json!({"total_tokens": 300}))
         );
+    }
+
+    #[test]
+    fn does_not_derive_ratio_based_capacity_for_deepseek_v4() {
+        for architecture in [
+            "DeepseekV4ForCausalLM",
+            "DeepseekV4ForCausalLMNextN",
+            "DeepseekV4ForCausalLMDSpark",
+        ] {
+            let config = build_engine_config(
+                &discovery_with_model_info(
+                    json!({
+                        "enable_hierarchical_cache": true,
+                        "hicache_size": 0,
+                        "hicache_ratio": 2.0,
+                        "hicache_write_policy": "write_back",
+                        "page_size": 256,
+                        "max_total_num_tokens": 8192,
+                    }),
+                    json!({"architectures": [architecture]}),
+                ),
+                DisaggregationMode::Decode,
+                None,
+                None,
+            )
+            .unwrap();
+
+            assert!(
+                !config
+                    .runtime_data
+                    .contains_key("native_offloading_capacity")
+            );
+        }
     }
 
     #[test]

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -800,11 +800,10 @@ fn hicache_native_offloading_capacity(server_info: &Value, model_info: &Value) -
     let host_tokens = match server_info.get("hicache_host_total_tokens") {
         Some(value) => value.as_u64().filter(|tokens| *tokens > 0)?,
         None => {
-            if is_deepseek_v4_arch(model_info)
-                || server_info
-                    .get("enable_hierarchical_cache")
-                    .and_then(Value::as_bool)
-                    != Some(true)
+            if server_info
+                .get("enable_hierarchical_cache")
+                .and_then(Value::as_bool)
+                != Some(true)
                 || server_info.get("hicache_size").and_then(Value::as_u64) != Some(0)
                 || client::json_u64(server_info, "dcp_size")
                     .unwrap_or(1)
@@ -819,16 +818,32 @@ fn hicache_native_offloading_capacity(server_info: &Value, model_info: &Value) -
                 .get("hicache_ratio")?
                 .as_f64()
                 .filter(|ratio| ratio.is_finite() && *ratio > 0.0)?;
-            let unaligned_tokens = device_tokens as f64 * ratio;
-            if !unaligned_tokens.is_finite() || unaligned_tokens >= u64::MAX as f64 {
-                return None;
+            if is_deepseek_v4_arch(model_info) {
+                // Compatibility with SGLang's current DSV4 host allocator. Prefer the
+                // authoritative field above once SGLang exposes realized capacity.
+                let device_pages = device_tokens
+                    .checked_add(page_size.checked_sub(1)?)?
+                    .checked_div(page_size)?;
+                let host_pages = device_pages as f64 * ratio;
+                if !host_pages.is_finite() || host_pages >= u64::MAX as f64 {
+                    return None;
+                }
+                (host_pages as u64).checked_mul(page_size)?
+            } else {
+                let unaligned_tokens = device_tokens as f64 * ratio;
+                if !unaligned_tokens.is_finite() || unaligned_tokens >= u64::MAX as f64 {
+                    return None;
+                }
+                (unaligned_tokens as u64)
+                    .checked_div(page_size)?
+                    .checked_add(1)?
+                    .checked_mul(page_size)?
             }
-            (unaligned_tokens as u64)
-                .checked_div(page_size)?
-                .checked_add(1)?
-                .checked_mul(page_size)?
         }
     };
+    if host_tokens == 0 {
+        return None;
+    }
 
     match policy {
         "write_back" => Some(host_tokens),
@@ -1074,7 +1089,7 @@ mod tests {
     }
 
     #[test]
-    fn deepseek_v4_capacity_requires_authoritative_total() {
+    fn supports_deepseek_v4_hicache_capacity() {
         let mut server_info = json!({
             "enable_hierarchical_cache": true,
             "hicache_size": 0,
@@ -1093,17 +1108,17 @@ mod tests {
                     &server_info,
                     &json!({"architectures": [architecture]}),
                 ),
-                None
+                Some(16384)
             );
         }
 
-        server_info["hicache_host_total_tokens"] = json!(16384);
+        server_info["hicache_host_total_tokens"] = json!(16640);
         assert_eq!(
             hicache_native_offloading_capacity(
                 &server_info,
                 &json!({"architectures": ["DeepseekV4ForCausalLM"]}),
             ),
-            Some(16384)
+            Some(16640)
         );
     }
 

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -769,6 +769,57 @@ fn kv_event_connect_host(
     Ok(bare_host.to_string())
 }
 
+fn hicache_native_offloading_capacity(server_info: &Value) -> Option<u64> {
+    let device_tokens = server_info
+        .get("max_total_num_tokens")?
+        .as_u64()
+        .filter(|tokens| *tokens > 0)?;
+    let policy = server_info.get("hicache_write_policy")?.as_str()?;
+    if !matches!(policy, "write_back" | "write_through") {
+        return None;
+    }
+
+    let host_tokens = match server_info.get("hicache_host_total_tokens") {
+        Some(value) => value.as_u64().filter(|tokens| *tokens > 0)?,
+        None => {
+            if server_info
+                .get("enable_hierarchical_cache")
+                .and_then(Value::as_bool)
+                != Some(true)
+                || server_info.get("hicache_size").and_then(Value::as_u64) != Some(0)
+                || client::json_u64(server_info, "dcp_size")
+                    .unwrap_or(1)
+                    .max(1)
+                    > 1
+            {
+                return None;
+            }
+
+            let page_size = client::json_u64(server_info, "page_size").filter(|size| *size > 0)?;
+            let ratio = server_info
+                .get("hicache_ratio")?
+                .as_f64()
+                .filter(|ratio| ratio.is_finite() && *ratio > 0.0)?;
+            let unaligned_tokens = device_tokens as f64 * ratio;
+            if !unaligned_tokens.is_finite() || unaligned_tokens >= u64::MAX as f64 {
+                return None;
+            }
+            (unaligned_tokens as u64)
+                .checked_div(page_size)?
+                .checked_add(1)?
+                .checked_mul(page_size)?
+        }
+    };
+
+    match policy {
+        "write_back" => Some(host_tokens),
+        "write_through" => host_tokens
+            .checked_sub(device_tokens)
+            .filter(|tokens| *tokens > 0),
+        _ => None,
+    }
+}
+
 fn build_engine_config(
     discovery: &Discovery,
     mode: DisaggregationMode,
@@ -825,6 +876,12 @@ fn build_engine_config(
         "grpc_service".to_string(),
         Value::String("sglang.runtime.v1.SglangService".to_string()),
     );
+    if let Some(total_tokens) = hicache_native_offloading_capacity(&discovery.server_info) {
+        runtime_data.insert(
+            "native_offloading_capacity".to_string(),
+            serde_json::json!({"total_tokens": total_tokens}),
+        );
+    }
 
     Ok(EngineConfig {
         model: discovery.model_path.clone(),
@@ -969,6 +1026,129 @@ mod tests {
 
         assert_eq!(registration.kv_cache_block_size, Some(512));
         assert_eq!(registration.total_kv_blocks, Some(16));
+    }
+
+    #[test]
+    fn publishes_ratio_based_hicache_capacity() {
+        let config = build_engine_config(
+            &discovery(json!({
+                "enable_hierarchical_cache": true,
+                "hicache_size": 0,
+                "hicache_ratio": 3.0,
+                "hicache_write_policy": "write_back",
+                "page_size": 16,
+                "max_total_num_tokens": 100,
+            })),
+            DisaggregationMode::Decode,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.runtime_data.get("native_offloading_capacity"),
+            Some(&json!({"total_tokens": 304}))
+        );
+    }
+
+    #[test]
+    fn hicache_capacity_accounts_for_write_policy() {
+        let config = build_engine_config(
+            &discovery(json!({
+                "enable_hierarchical_cache": true,
+                "hicache_size": 0,
+                "hicache_ratio": 3.0,
+                "hicache_write_policy": "write_through",
+                "page_size": 16,
+                "max_total_num_tokens": 100,
+            })),
+            DisaggregationMode::Decode,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.runtime_data.get("native_offloading_capacity"),
+            Some(&json!({"total_tokens": 204}))
+        );
+    }
+
+    #[test]
+    fn authoritative_hicache_capacity_takes_precedence() {
+        let config = build_engine_config(
+            &discovery(json!({
+                "enable_hierarchical_cache": true,
+                "hicache_host_total_tokens": 300,
+                "hicache_size": 0,
+                "hicache_ratio": 3.0,
+                "hicache_write_policy": "write_back",
+                "page_size": 16,
+                "max_total_num_tokens": 100,
+            })),
+            DisaggregationMode::Decode,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.runtime_data.get("native_offloading_capacity"),
+            Some(&json!({"total_tokens": 300}))
+        );
+    }
+
+    #[test]
+    fn does_not_publish_unproven_hicache_capacity() {
+        for server_info in [
+            json!({
+                "enable_hierarchical_cache": false,
+                "hicache_size": 0,
+                "hicache_ratio": 3.0,
+                "hicache_write_policy": "write_back",
+                "page_size": 16,
+                "max_total_num_tokens": 100,
+            }),
+            json!({
+                "enable_hierarchical_cache": true,
+                "hicache_size": 4,
+                "hicache_ratio": 3.0,
+                "hicache_write_policy": "write_back",
+                "page_size": 16,
+                "max_total_num_tokens": 100,
+            }),
+            json!({
+                "enable_hierarchical_cache": true,
+                "hicache_size": 0,
+                "hicache_ratio": 3.0,
+                "hicache_write_policy": "write_through_selective",
+                "page_size": 16,
+                "max_total_num_tokens": 100,
+            }),
+            json!({
+                "enable_hierarchical_cache": true,
+                "hicache_size": 0,
+                "hicache_ratio": 3.0,
+                "hicache_write_policy": "write_back",
+                "page_size": 16,
+                "dcp_size": 2,
+                "max_total_num_tokens": 100,
+            }),
+        ] {
+            let config = build_engine_config(
+                &discovery(server_info),
+                DisaggregationMode::Decode,
+                None,
+                None,
+            )
+            .unwrap();
+
+            assert!(
+                !config
+                    .runtime_data
+                    .contains_key("native_offloading_capacity")
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!-- codex-pr-description:start -->
The native SGLang sidecar now publishes backend-neutral HiCache offloading capacity in its model runtime data. This prevents capacity-aware routers from treating a HiCache-enabled worker as device-only.

Fixes #14312

### How This Was Implemented

- Prefer an authoritative `hicache_host_total_tokens` value when SGLang provides one.
- Otherwise derive ratio-based host tokens only when HiCache is enabled, the pool is ratio-sized, and DCP does not make the derivation ambiguous.
- Match SGLang's generic host-pool page rounding, with a temporary compatibility calculation for the current DeepSeek V4 allocator's distinct page rounding.
- Publish either the full `write_back` pool or the non-mirrored portion of a `write_through` pool.
- Omit the field for unsupported policies or malformed and unprovable capacities.

<details>
<summary>Walkthrough</summary>

#### Mental model

The sidecar already translates SGLang discovery data into the model deployment card's device KV fields. This change adds the missing translation for HiCache's unique host-tier capacity so existing backend-neutral consumers can include it without SGLang-specific logic.

```mermaid
flowchart LR
    M["SGLang GetModelInfo"] --> B["build_engine_config"]
    S["SGLang GetServerInfo"] --> B
    B --> R["runtime_data.native_offloading_capacity"]
    R --> C["Router capacity consumers"]
```

#### State and ordering

Capacity resolution uses strict precedence: an authoritative realized host-token count wins; otherwise the current DeepSeek V4 architectures use SGLang's DSV4 page calculation; other supported ratio-based configurations use the generic calculation; otherwise nothing is published. For a 100-token generic device pool, ratio 3.0, and page size 16, `write_through` publishes 204 unique host tokens. For a page-aligned 8,192-token DSV4 pool, ratio 2.0, and page size 256, the DSV4 calculation publishes the realized 16,384 host tokens under `write_back` rather than the generic calculation's 16,640.

#### Registration lifecycle

At sidecar startup, `build_engine_config` reads the server configuration and model architectures from discovery, computes the unique host capacity, and inserts `{"total_tokens": ...}` into `runtime_data`. Worker registration copies that payload into the model deployment card, where the existing local-model and KV-router readers consume it.

#### Boundaries and limitations

The change does not alter `total_kv_blocks`, block size, DP rank registration, or request routing. Ratio derivation remains fail-closed for fixed-size HiCache pools, selective write-through, DCP greater than one, invalid numeric values, and host pools that do not exceed the device mirror. The DSV4 architecture check is deliberately a temporary compatibility path; the long-term source is SGLang's constructed host pool through an authoritative server-info field.

</details>

### Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p dynamo-sglang-sidecar` (32 library tests plus executable and protobuf contract tests)
- `cargo clippy -p dynamo-sglang-sidecar --all-targets -- -D warnings`
- Live NVIDIA L4 smoke test with SGLang 0.5.18 and Qwen3-0.6B: 8,192 device KV tokens, HiCache ratio 2.0 with `write_through`, 16,400 allocated host tokens, 8,208 unique offloaded tokens published by the sidecar, and a successful chat completion while both processes were running.
<!-- codex-pr-description:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and reporting native offloading capacity for hierarchical caching.
  * Capacity is now calculated from available cache and device information, including write-back and write-through policies.
  * Reported capacity is available through runtime data when configuration is valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
