### PR TITLE
feat(router): count blocks rejected by missing parent

### DIFF
--- a/lib/kv-router/src/indexer/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree.rs
@@ -567,22 +567,30 @@ impl SyncIndexer for ConcurrentRadixTree {
             match task {
                 WorkerTask::Event(event) => {
                     let kind = EventKind::of(&event.event.data);
+                    let stored_block_count = EventKind::stored_block_count(&event.event.data);
                     let result = self.apply_event(&mut lookup, event, counters.as_ref());
                     if result.is_err() {
                         tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
                     }
                     if let Some(ref c) = counters {
+                        if let Some(block_count) = stored_block_count {
+                            c.inc_stored_parent_not_found_blocks(block_count, &result);
+                        }
                         c.inc(kind, result);
                     }
                 }
                 WorkerTask::EventWithAck { event, resp } => {
                     let kind = EventKind::of(&event.event.data);
+                    let stored_block_count = EventKind::stored_block_count(&event.event.data);
                     let result = self.apply_event(&mut lookup, event, counters.as_ref());
                     let applied = result.is_ok();
                     if result.is_err() {
                         tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
                     }
                     if let Some(ref c) = counters {
+                        if let Some(block_count) = stored_block_count {
+                            c.inc_stored_parent_not_found_blocks(block_count, &result);
+                        }
                         c.inc(kind, result);
                     }
                     let _ = resp.send(applied);
@@ -600,12 +608,16 @@ impl SyncIndexer for ConcurrentRadixTree {
                     correlation_id,
                 } => {
                     let kind = EventKind::of(&event.event.data);
+                    let stored_block_count = EventKind::stored_block_count(&event.event.data);
                     let result = self.apply_event(&mut lookup, event, counters.as_ref());
                     observation.record(correlation_id, result.is_ok());
                     if result.is_err() {
                         tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
                     }
                     if let Some(ref c) = counters {
+                        if let Some(block_count) = stored_block_count {
+                            c.inc_stored_parent_not_found_blocks(block_count, &result);
+                        }
                         c.inc(kind, result);
                     }
                 }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/sync_impl.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/sync_impl.rs
@@ -27,22 +27,30 @@ impl SyncIndexer for ConcurrentRadixTreeCompressed {
             match task {
                 WorkerTask::Event(event) => {
                     let kind = EventKind::of(&event.event.data);
+                    let stored_block_count = EventKind::stored_block_count(&event.event.data);
                     let result = self.apply_event(&mut lookup, event, counters.as_ref());
                     if result.is_err() {
                         tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
                     }
                     if let Some(ref c) = counters {
+                        if let Some(block_count) = stored_block_count {
+                            c.inc_stored_parent_not_found_blocks(block_count, &result);
+                        }
                         c.inc(kind, result);
                     }
                 }
                 WorkerTask::EventWithAck { event, resp } => {
                     let kind = EventKind::of(&event.event.data);
+                    let stored_block_count = EventKind::stored_block_count(&event.event.data);
                     let result = self.apply_event(&mut lookup, event, counters.as_ref());
                     let applied = result.is_ok();
                     if result.is_err() {
                         tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
                     }
                     if let Some(ref c) = counters {
+                        if let Some(block_count) = stored_block_count {
+                            c.inc_stored_parent_not_found_blocks(block_count, &result);
+                        }
                         c.inc(kind, result);
                     }
                     let _ = resp.send(applied);
@@ -63,8 +71,14 @@ impl SyncIndexer for ConcurrentRadixTreeCompressed {
                         } = output;
                         for event in events {
                             let kind = EventKind::of(&event.event.data);
+                            let stored_block_count =
+                                EventKind::stored_block_count(&event.event.data);
                             let applied = self.apply_event(&mut lookup, event, counters.as_ref());
                             if let Some(ref counters) = counters {
+                                if let Some(block_count) = stored_block_count {
+                                    counters
+                                        .inc_stored_parent_not_found_blocks(block_count, &applied);
+                                }
                                 counters.inc(kind, applied);
                             }
                             if applied.is_err() {
@@ -96,12 +110,16 @@ impl SyncIndexer for ConcurrentRadixTreeCompressed {
                     correlation_id,
                 } => {
                     let kind = EventKind::of(&event.event.data);
+                    let stored_block_count = EventKind::stored_block_count(&event.event.data);
                     let result = self.apply_event(&mut lookup, event, counters.as_ref());
                     observation.record(correlation_id, result.is_ok());
                     if result.is_err() {
                         tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
                     }
                     if let Some(ref c) = counters {
+                        if let Some(block_count) = stored_block_count {
+                            c.inc_stored_parent_not_found_blocks(block_count, &result);
+                        }
                         c.inc(kind, result);
                     }
                 }

--- a/lib/kv-router/src/indexer/kv_indexer.rs
+++ b/lib/kv-router/src/indexer/kv_indexer.rs
@@ -28,6 +28,7 @@ fn apply_event_with_counters(
     counters: &PreBoundEventCounters,
 ) -> bool {
     let kind = EventKind::of(&event.event.data);
+    let stored_block_count = EventKind::stored_block_count(&event.event.data);
     let event_id = event.event.event_id;
     let worker_id = event.worker_id;
     let result = trie.apply_event_with_counters(event, Some(counters));
@@ -37,6 +38,9 @@ fn apply_event_with_counters(
         tracing::trace!(
             "Applied KV event to global radix tree: event_type={kind}, event_id={event_id}, worker_id={worker_id}, success={result_is_ok}, global_radix_tree_size={tree_size}"
         );
+    }
+    if let Some(block_count) = stored_block_count {
+        counters.inc_stored_parent_not_found_blocks(block_count, &result);
     }
     counters.inc(kind, result);
     result_is_ok

--- a/lib/kv-router/src/indexer/lower_tier.rs
+++ b/lib/kv-router/src/indexer/lower_tier.rs
@@ -1033,22 +1033,30 @@ impl SyncIndexer for LowerTierIndexer {
             match task {
                 WorkerTask::Event(event) => {
                     let kind = EventKind::of(&event.event.data);
+                    let stored_block_count = EventKind::stored_block_count(&event.event.data);
                     let result = self.apply_event(&mut worker_blocks, event);
                     if let Err(ref error) = result {
                         tracing::warn!(%error, "Failed to apply lower-tier event");
                     }
                     if let Some(ref c) = counters {
+                        if let Some(block_count) = stored_block_count {
+                            c.inc_stored_parent_not_found_blocks(block_count, &result);
+                        }
                         c.inc(kind, result);
                     }
                 }
                 WorkerTask::EventWithAck { event, resp } => {
                     let kind = EventKind::of(&event.event.data);
+                    let stored_block_count = EventKind::stored_block_count(&event.event.data);
                     let result = self.apply_event(&mut worker_blocks, event);
                     let applied = result.is_ok();
                     if let Err(ref error) = result {
                         tracing::warn!(%error, "Failed to apply lower-tier event");
                     }
                     if let Some(ref c) = counters {
+                        if let Some(block_count) = stored_block_count {
+                            c.inc_stored_parent_not_found_blocks(block_count, &result);
+                        }
                         c.inc(kind, result);
                     }
                     let _ = resp.send(applied);
@@ -1066,12 +1074,16 @@ impl SyncIndexer for LowerTierIndexer {
                     correlation_id,
                 } => {
                     let kind = EventKind::of(&event.event.data);
+                    let stored_block_count = EventKind::stored_block_count(&event.event.data);
                     let result = self.apply_event(&mut worker_blocks, event);
                     observation.record(correlation_id, result.is_ok());
                     if let Err(ref error) = result {
                         tracing::warn!(%error, "Failed to apply lower-tier event");
                     }
                     if let Some(ref c) = counters {
+                        if let Some(block_count) = stored_block_count {
+                            c.inc_stored_parent_not_found_blocks(block_count, &result);
+                        }
                         c.inc(kind, result);
                     }
                 }

--- a/lib/kv-router/src/indexer/metrics.rs
+++ b/lib/kv-router/src/indexer/metrics.rs
@@ -29,7 +29,7 @@ static IGNORED_RESIDENCY_EVENT_COUNT: AtomicU64 = AtomicU64::new(0);
 /// `event_type` label — replacing the former `get_event_type()` helper.
 #[derive(Debug, Clone, Copy)]
 pub enum EventKind {
-    Stored { block_count: u64 },
+    Stored,
     Removed,
     Cleared,
 }
@@ -37,17 +37,22 @@ pub enum EventKind {
 impl EventKind {
     pub fn of(data: &KvCacheEventData) -> Self {
         match data {
-            KvCacheEventData::Stored(store) => Self::Stored {
-                block_count: store.blocks.len() as u64,
-            },
+            KvCacheEventData::Stored(_) => Self::Stored,
             KvCacheEventData::Removed(_) => Self::Removed,
             KvCacheEventData::Cleared => Self::Cleared,
         }
     }
 
+    pub(crate) fn stored_block_count(data: &KvCacheEventData) -> Option<u64> {
+        match data {
+            KvCacheEventData::Stored(store) => Some(store.blocks.len() as u64),
+            _ => None,
+        }
+    }
+
     pub fn label(self) -> &'static str {
         match self {
-            Self::Stored { .. } => METRIC_EVENT_STORED,
+            Self::Stored => METRIC_EVENT_STORED,
             Self::Removed => METRIC_EVENT_REMOVED,
             Self::Cleared => METRIC_EVENT_CLEARED,
         }
@@ -556,23 +561,30 @@ impl PreBoundEventCounters {
         #[cfg(feature = "metrics")]
         {
             let counters = match kind {
-                EventKind::Stored { .. } => &self.inner.stored,
+                EventKind::Stored => &self.inner.stored,
                 EventKind::Removed => &self.inner.removed,
                 EventKind::Cleared => &self.inner.cleared,
             };
             counters.for_result(result).inc();
-            if let (
-                EventKind::Stored { block_count },
-                Err(KvCacheEventError::ParentBlockNotFound),
-            ) = (kind, result)
-            {
-                self.inner
-                    .rejected_parent_not_found_blocks
-                    .inc_by(block_count);
-            }
         }
         #[cfg(not(feature = "metrics"))]
         let _ = (self, kind, result);
+    }
+
+    /// Record rejected stored blocks without changing the public [`EventKind`] shape.
+    pub(crate) fn inc_stored_parent_not_found_blocks(
+        &self,
+        block_count: u64,
+        result: &Result<(), KvCacheEventError>,
+    ) {
+        #[cfg(feature = "metrics")]
+        if matches!(result, Err(KvCacheEventError::ParentBlockNotFound)) {
+            self.inner
+                .rejected_parent_not_found_blocks
+                .inc_by(block_count);
+        }
+        #[cfg(not(feature = "metrics"))]
+        let _ = (self, block_count, result);
     }
 
     pub fn inc_warning(&self, kind: EventWarningKind) {

--- a/lib/kv-router/src/indexer/metrics.rs
+++ b/lib/kv-router/src/indexer/metrics.rs
@@ -29,7 +29,7 @@ static IGNORED_RESIDENCY_EVENT_COUNT: AtomicU64 = AtomicU64::new(0);
 /// `event_type` label — replacing the former `get_event_type()` helper.
 #[derive(Debug, Clone, Copy)]
 pub enum EventKind {
-    Stored,
+    Stored { block_count: u64 },
     Removed,
     Cleared,
 }
@@ -37,7 +37,9 @@ pub enum EventKind {
 impl EventKind {
     pub fn of(data: &KvCacheEventData) -> Self {
         match data {
-            KvCacheEventData::Stored(_) => Self::Stored,
+            KvCacheEventData::Stored(store) => Self::Stored {
+                block_count: store.blocks.len() as u64,
+            },
             KvCacheEventData::Removed(_) => Self::Removed,
             KvCacheEventData::Cleared => Self::Cleared,
         }
@@ -45,7 +47,7 @@ impl EventKind {
 
     pub fn label(self) -> &'static str {
         match self {
-            Self::Stored => METRIC_EVENT_STORED,
+            Self::Stored { .. } => METRIC_EVENT_STORED,
             Self::Removed => METRIC_EVENT_REMOVED,
             Self::Cleared => METRIC_EVENT_CLEARED,
         }
@@ -178,6 +180,9 @@ pub struct KvIndexerMetrics {
     /// Counters for CKF mutation outcomes that are finer-grained than event status.
     #[cfg(feature = "metrics")]
     pub ckf_mutation: IntCounterVec,
+    /// Counter of blocks rejected because their parent was absent from the index.
+    #[cfg(feature = "metrics")]
+    pub kv_cache_rejected_blocks: IntCounterVec,
 }
 
 /// Metric status labels.
@@ -229,6 +234,16 @@ const CKF_MUTATION_NAME: &str = "dynamo_kvrouter_ckf_mutation_total";
 const CKF_MUTATION_HELP: &str = "Total number of CKF block-level mutation outcomes";
 #[cfg(feature = "metrics")]
 const CKF_MUTATION_LABELS: &[&str] = &["outcome"];
+#[cfg(all(feature = "metrics", feature = "runtime-protocols"))]
+const KV_CACHE_REJECTED_BLOCKS_SUFFIX: &str = "kv_cache_rejected_blocks_total";
+#[cfg(feature = "metrics")]
+const KV_CACHE_REJECTED_BLOCKS_NAME: &str = "dynamo_kvrouter_kv_cache_rejected_blocks_total";
+#[cfg(feature = "metrics")]
+const KV_CACHE_REJECTED_BLOCKS_HELP: &str = "Total KV cache blocks rejected by the router indexer";
+#[cfg(feature = "metrics")]
+const KV_CACHE_REJECTED_BLOCKS_LABELS: &[&str] = &["reason"];
+#[cfg(feature = "metrics")]
+pub const METRIC_REJECTED_BLOCKS_PARENT_NOT_FOUND: &str = "parent_block_not_found";
 
 #[cfg(all(feature = "metrics", feature = "runtime-protocols"))]
 static KV_INDEXER_METRICS: OnceLock<Arc<KvIndexerMetrics>> = OnceLock::new();
@@ -239,11 +254,13 @@ impl KvIndexerMetrics {
         kv_cache_events_applied: IntCounterVec,
         kv_cache_event_warnings: IntCounterVec,
         ckf_mutation: IntCounterVec,
+        kv_cache_rejected_blocks: IntCounterVec,
     ) -> Self {
         Self {
             kv_cache_events_applied,
             kv_cache_event_warnings,
             ckf_mutation,
+            kv_cache_rejected_blocks,
         }
     }
 
@@ -262,6 +279,10 @@ impl KvIndexerMetrics {
                 Opts::new(CKF_MUTATION_NAME, CKF_MUTATION_HELP),
                 CKF_MUTATION_LABELS,
             )?,
+            IntCounterVec::new(
+                Opts::new(KV_CACHE_REJECTED_BLOCKS_NAME, KV_CACHE_REJECTED_BLOCKS_HELP),
+                KV_CACHE_REJECTED_BLOCKS_LABELS,
+            )?,
         ))
     }
 
@@ -272,6 +293,7 @@ impl KvIndexerMetrics {
         registry.register(Box::new(metrics.kv_cache_events_applied.clone()))?;
         registry.register(Box::new(metrics.kv_cache_event_warnings.clone()))?;
         registry.register(Box::new(metrics.ckf_mutation.clone()))?;
+        registry.register(Box::new(metrics.kv_cache_rejected_blocks.clone()))?;
         Ok(metrics)
     }
 
@@ -302,17 +324,28 @@ impl KvIndexerMetrics {
                             CKF_MUTATION_LABELS,
                             &[],
                         ),
+                        component.metrics().create_intcountervec(
+                            KV_CACHE_REJECTED_BLOCKS_SUFFIX,
+                            KV_CACHE_REJECTED_BLOCKS_HELP,
+                            KV_CACHE_REJECTED_BLOCKS_LABELS,
+                            &[],
+                        ),
                     ) {
                         (
                             Ok(kv_cache_events_applied),
                             Ok(kv_cache_event_warnings),
                             Ok(ckf_mutation),
+                            Ok(kv_cache_rejected_blocks),
                         ) => Arc::new(Self::new(
                             kv_cache_events_applied,
                             kv_cache_event_warnings,
                             ckf_mutation,
+                            kv_cache_rejected_blocks,
                         )),
-                        (Err(e), _, _) | (_, Err(e), _) | (_, _, Err(e)) => {
+                        (Err(e), _, _, _)
+                        | (_, Err(e), _, _)
+                        | (_, _, Err(e), _)
+                        | (_, _, _, Err(e)) => {
                             tracing::warn!("Failed to create kv indexer metrics from component: {}. Using unregistered metrics as fallback.", e);
                             Arc::new(Self::new_unregistered())
                         }
@@ -418,6 +451,7 @@ struct PreBoundMetricCounters {
     cleared: ResultCounters,
     duplicate_store_warning: IntCounter,
     ckf_mutation: CkfMutationCounters,
+    rejected_parent_not_found_blocks: IntCounter,
 }
 
 #[cfg(feature = "metrics")]
@@ -500,6 +534,9 @@ impl PreBoundEventCounters {
                             .ckf_mutation
                             .with_label_values(&[METRIC_CKF_MUTATION_CAPACITY_EXHAUSTED]),
                     },
+                    rejected_parent_not_found_blocks: metrics
+                        .kv_cache_rejected_blocks
+                        .with_label_values(&[METRIC_REJECTED_BLOCKS_PARENT_NOT_FOUND]),
                 },
             }
         }
@@ -519,11 +556,20 @@ impl PreBoundEventCounters {
         #[cfg(feature = "metrics")]
         {
             let counters = match kind {
-                EventKind::Stored => &self.inner.stored,
+                EventKind::Stored { .. } => &self.inner.stored,
                 EventKind::Removed => &self.inner.removed,
                 EventKind::Cleared => &self.inner.cleared,
             };
             counters.for_result(result).inc();
+            if let (
+                EventKind::Stored { block_count },
+                Err(KvCacheEventError::ParentBlockNotFound),
+            ) = (kind, result)
+            {
+                self.inner
+                    .rejected_parent_not_found_blocks
+                    .inc_by(block_count);
+            }
         }
         #[cfg(not(feature = "metrics"))]
         let _ = (self, kind, result);

--- a/lib/kv-router/src/indexer/positional.rs
+++ b/lib/kv-router/src/indexer/positional.rs
@@ -221,22 +221,30 @@ impl SyncIndexer for PositionalIndexer {
             match task {
                 WorkerTask::Event(event) => {
                     let kind = EventKind::of(&event.event.data);
+                    let stored_block_count = EventKind::stored_block_count(&event.event.data);
                     let result = self.apply_event(&mut worker_blocks, event, counters.as_ref());
                     if result.is_err() {
                         tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
                     }
                     if let Some(ref c) = counters {
+                        if let Some(block_count) = stored_block_count {
+                            c.inc_stored_parent_not_found_blocks(block_count, &result);
+                        }
                         c.inc(kind, result);
                     }
                 }
                 WorkerTask::EventWithAck { event, resp } => {
                     let kind = EventKind::of(&event.event.data);
+                    let stored_block_count = EventKind::stored_block_count(&event.event.data);
                     let result = self.apply_event(&mut worker_blocks, event, counters.as_ref());
                     let applied = result.is_ok();
                     if result.is_err() {
                         tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
                     }
                     if let Some(ref c) = counters {
+                        if let Some(block_count) = stored_block_count {
+                            c.inc_stored_parent_not_found_blocks(block_count, &result);
+                        }
                         c.inc(kind, result);
                     }
                     let _ = resp.send(applied);
@@ -254,12 +262,16 @@ impl SyncIndexer for PositionalIndexer {
                     correlation_id,
                 } => {
                     let kind = EventKind::of(&event.event.data);
+                    let stored_block_count = EventKind::stored_block_count(&event.event.data);
                     let result = self.apply_event(&mut worker_blocks, event, counters.as_ref());
                     observation.record(correlation_id, result.is_ok());
                     if result.is_err() {
                         tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
                     }
                     if let Some(ref c) = counters {
+                        if let Some(block_count) = stored_block_count {
+                            c.inc_stored_parent_not_found_blocks(block_count, &result);
+                        }
                         c.inc(kind, result);
                     }
                 }

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -392,6 +392,15 @@ fn warning_metric_value(metrics: &KvIndexerMetrics, warning_kind: &'static str) 
 }
 
 #[cfg(feature = "metrics")]
+fn rejected_parent_block_count(metrics: &KvIndexerMetrics) -> u64 {
+    metrics
+        .kv_cache_rejected_blocks
+        .get_metric_with_label_values(&[METRIC_REJECTED_BLOCKS_PARENT_NOT_FOUND])
+        .unwrap()
+        .get()
+}
+
+#[cfg(feature = "metrics")]
 fn assert_no_event_errors(metrics: &KvIndexerMetrics) {
     let invalid_count = [
         (METRIC_EVENT_STORED, METRIC_STATUS_PARENT_NOT_FOUND),
@@ -480,6 +489,33 @@ mod interface_tests {
         .await;
         assert_no_event_errors(metrics.as_ref());
         assert_no_event_warnings(metrics.as_ref());
+    }
+
+    #[cfg(feature = "metrics")]
+    #[tokio::test]
+    #[apply(indexer_template)]
+    async fn orphaned_multi_block_store_counts_all_rejected_blocks(variant: &str) {
+        let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
+        let (index, metrics) = make_indexer_with_metrics(variant, metrics);
+
+        index.apply_event(make_store_event(1, &[7, 8])).await;
+        flush_and_settle(index.as_ref()).await;
+        assert_eq!(rejected_parent_block_count(metrics.as_ref()), 0);
+
+        index
+            .apply_event(make_store_event_with_parent(0, &[1, 2, 3], &[4, 5, 6]))
+            .await;
+        flush_and_settle(index.as_ref()).await;
+
+        assert_eq!(
+            event_metric_value(
+                metrics.as_ref(),
+                METRIC_EVENT_STORED,
+                METRIC_STATUS_PARENT_NOT_FOUND,
+            ),
+            1
+        );
+        assert_eq!(rejected_parent_block_count(metrics.as_ref()), 3);
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -493,10 +493,9 @@ mod interface_tests {
 
     #[cfg(feature = "metrics")]
     #[tokio::test]
-    #[apply(indexer_template)]
-    async fn orphaned_multi_block_store_counts_all_rejected_blocks(variant: &str) {
+    async fn orphaned_multi_block_store_counts_all_rejected_blocks() {
         let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
-        let (index, metrics) = make_indexer_with_metrics(variant, metrics);
+        let (index, metrics) = make_indexer_with_metrics("single", metrics);
 
         index.apply_event(make_store_event(1, &[7, 8])).await;
         flush_and_settle(index.as_ref()).await;


### PR DESCRIPTION
Summary
- add a bounded-cardinality counter for cache blocks rejected when a stored event has no parent
- retain the existing event counter and cover a three-block orphan batch across all indexer variants

Validation
- cargo check -p dynamo-kv-router --features 'metrics runtime-protocols'
- cargo test -p dynamo-kv-router --features metrics orphaned_multi_block_store_counts_all_rejected_blocks --lib
- cargo fmt --all --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metrics for tracking blocks rejected because their parent block is missing.
  * Rejected-block metrics now record the number of affected blocks in each stored event.

* **Tests**
  * Added coverage confirming that orphaned stores correctly record missing-parent events and rejected block counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->