### PR TITLE
feat(router): add load-bounded cache affinity example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,9 +2451,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynamo-custom-policy-example-cache-affinity-budget"
+version = "1.5.0"
+dependencies = [
+ "dynamo-kv-router",
+ "serde",
+]
+
+[[package]]
 name = "dynamo-custom-policy-example-catalog"
 version = "1.5.0"
 dependencies = [
+ "dynamo-custom-policy-example-cache-affinity-budget",
  "dynamo-custom-policy-example-disagg-filter-score-pick",
  "dynamo-custom-policy-example-simple-filter-score-pick",
  "dynamo-custom-policy-example-simple-stacked-score-pick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "examples/router/custom-policy-example/disagg-filter-score-pick",
     "examples/router/custom-policy-example/epp",
     "examples/router/custom-policy-example/simple-stacked-score-pick",
+    "examples/router/custom-policy-example/cache-affinity-budget",
     "lib/memory",
     "lib/kvbm-common",
     "lib/kvbm-config",

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/custom-worker-selection.mdx
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/custom-worker-selection.mdx
@@ -26,6 +26,8 @@ flowchart LR
 
 For multiple compile-checked policies, see the [custom policy examples](https://github.com/ai-dynamo/dynamo/tree/main/examples/router/custom-policy-example). Repository contributors who use a coding agent must also provide the [worker-selection API rules](https://github.com/ai-dynamo/dynamo/blob/main/lib/kv-router/src/scheduling/CLAUDE.md).
 
+The `examples/router/custom-policy-example/cache-affinity-budget` example demonstrates lexicographic cache preference with a load-safety bound: it selects the worker with the most device-resident overlap only from candidates whose modeled load is within a configured block-cost delta of the least-loaded worker.
+
 ## Choose the Policy Stage
 
 | Stage | Input | Output | Use this stage for |

--- a/examples/router/custom-policy-example/README.md
+++ b/examples/router/custom-policy-example/README.md
@@ -27,6 +27,7 @@ Preferred routing taints are optional candidate metadata. A filter, scorer, or p
 | Crate | Use it for |
 |---|---|
 | [`soft-pin-repin`](soft-pin-repin/README.md) | Retain a soft session-affinity target until its active-request load exceeds a threshold, then repin |
+| [`cache-affinity-budget`](cache-affinity-budget/README.md) | Prefer the most cached worker only when its modeled load is within a configured cost budget |
 | `simple-filter-score-pick` | One filter, one scorer, and one picker show the complete policy flow |
 | `disagg-filter-score-pick` | Prefill and decode workers each need the complete policy flow |
 | `simple-stacked-score-pick` | Multiple scorer costs compose before one picker runs |
@@ -178,6 +179,10 @@ worker_selection:
       type: soft-pin-repin
       parameters:
         max_active_requests: 0
+    - name: cache-affinity-budget
+      type: cache-affinity-budget
+      parameters:
+        max_load_cost_delta_blocks: 64
 ```
 
 - `type` selects a registered provider.
@@ -203,6 +208,7 @@ cargo test \
   -p dynamo-custom-policy-example-simple-filter-score-pick \
   -p dynamo-custom-policy-example-disagg-filter-score-pick \
   -p dynamo-custom-policy-example-simple-stacked-score-pick \
+  -p dynamo-custom-policy-example-cache-affinity-budget \
   -p dynamo-custom-policy-example-catalog
 cargo build -p dynamo-custom-policy-example-epp
 ```

--- a/examples/router/custom-policy-example/cache-affinity-budget/Cargo.toml
+++ b/examples/router/custom-policy-example/cache-affinity-budget/Cargo.toml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "dynamo-custom-policy-example-cache-affinity-budget"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Load-bounded cache-affinity worker-selection policy example for Dynamo"
+
+[dependencies]
+dynamo-kv-router = { workspace = true, features = ["standalone-selection"] }
+serde = { workspace = true, features = ["derive"] }

--- a/examples/router/custom-policy-example/cache-affinity-budget/README.md
+++ b/examples/router/custom-policy-example/cache-affinity-budget/README.md
@@ -1,0 +1,36 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Cache Affinity Within a Load Budget
+
+This policy separates a hard cache preference from its load-safety bound. It first finds the least modeled active-load cost, keeps workers within `max_load_cost_delta_blocks` of that floor, and selects the remaining worker with the most device-resident prefix overlap.
+
+The active-load cost uses Dynamo's configured prefill-load scale and active-request weight:
+
+```text
+load_cost = prefill_load_scale * active_prefill_blocks
+          + decode_cost_blocks
+          + decode_active_request_weight * active_requests
+```
+
+This is lexicographic selection, not another cache coefficient. A sufficiently large budget makes cache overlap dominate load; a finite budget prevents a cache-hot worker from winning when its modeled backlog is too far above the load floor.
+
+```yaml
+worker_selection:
+  aggregated: cache-affinity-budget
+  instances:
+    - name: cache-affinity-budget
+      type: cache-affinity-budget
+      parameters:
+        max_load_cost_delta_blocks: 64
+```
+
+The unit is modeled KV blocks. Set the value from a matched workload experiment; it is not a latency duration. A value of `0` restricts selection to minimum-load workers and uses cache overlap only as a tie-breaker.
+
+## Test
+
+```bash
+cargo test -p dynamo-custom-policy-example-cache-affinity-budget
+```

--- a/examples/router/custom-policy-example/cache-affinity-budget/README.md
+++ b/examples/router/custom-policy-example/cache-affinity-budget/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # Cache Affinity Within a Load Budget
 
-This policy separates a hard cache preference from its load-safety bound. It first finds the least modeled active-load cost, keeps workers within `max_load_cost_delta_blocks` of that floor, and selects the remaining worker with the most device-resident prefix overlap.
+This policy separates a hard cache preference from its load-safety bound. It first finds the least modeled active-load cost, keeps workers within `max_load_cost_delta_blocks` of that floor, and selects the remaining worker with the most effective prefix overlap. Effective overlap is the same tier-weighted value used by Dynamo's cache-loss funnel, including device and configured lower-tier cache credit.
 
 The active-load cost uses Dynamo's configured prefill-load scale and active-request weight:
 

--- a/examples/router/custom-policy-example/cache-affinity-budget/src/lib.rs
+++ b/examples/router/custom-policy-example/cache-affinity-budget/src/lib.rs
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Load-bounded cache-affinity worker selection.
+
+mod picker;
+mod scorer;
+
+use std::sync::Arc;
+
+use dynamo_kv_router::services::selection::{
+    WorkerSelectionPolicyFactory, WorkerSelectionPolicyParameters,
+    WorkerSelectionPolicyProviderError, WorkerSelectionPolicyRegistry,
+    WorkerSelectionPolicyRegistryError,
+};
+use dynamo_kv_router::{KvRouterConfig, WorkerSelectionPolicy};
+use picker::CacheAffinityBudgetPicker;
+use scorer::ActiveLoadScorer;
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Parameters {
+    max_load_cost_delta_blocks: f64,
+}
+
+fn validate_cost_delta(value: f64) -> Result<(), WorkerSelectionPolicyProviderError> {
+    if value.is_finite() && value >= 0.0 {
+        return Ok(());
+    }
+    Err(WorkerSelectionPolicyProviderError::new(
+        "max_load_cost_delta_blocks must be a finite non-negative number",
+    ))
+}
+
+fn provider(
+    parameters: &WorkerSelectionPolicyParameters,
+) -> Result<WorkerSelectionPolicyFactory, WorkerSelectionPolicyProviderError> {
+    let parameters: Parameters = parameters.deserialize()?;
+    validate_cost_delta(parameters.max_load_cost_delta_blocks)?;
+    let max_load_cost_delta_blocks = parameters.max_load_cost_delta_blocks;
+
+    Ok(Arc::new(move |config, worker_type, _partition| {
+        create_policy(config, worker_type.as_str(), max_load_cost_delta_blocks)
+    }))
+}
+
+fn create_policy(
+    config: &KvRouterConfig,
+    worker_label: &'static str,
+    max_load_cost_delta_blocks: f64,
+) -> WorkerSelectionPolicy {
+    WorkerSelectionPolicy::new(
+        config.clone(),
+        worker_label,
+        vec![Box::new(ActiveLoadScorer {
+            prefill_load_scale: config.prefill_load_scale,
+            active_request_weight: config.decode_active_request_weight,
+        })],
+        Box::new(CacheAffinityBudgetPicker {
+            max_load_cost_delta_blocks,
+        }),
+    )
+}
+
+/// Register the `cache-affinity-budget` policy type.
+pub fn register(
+    registry: &mut WorkerSelectionPolicyRegistry,
+) -> Result<(), WorkerSelectionPolicyRegistryError> {
+    registry.register("cache-affinity-budget", Arc::new(provider))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use dynamo_kv_router::protocols::{RoutingConstraints, WorkerConfigLike, WorkerWithDpRank};
+    use dynamo_kv_router::scheduling::{OverlapSignals, ScheduleMode};
+    use dynamo_kv_router::{SchedulingRequest, WorkerSelectionInput, WorkerSelector};
+
+    use super::*;
+
+    struct TestWorker;
+
+    impl WorkerConfigLike for TestWorker {
+        fn data_parallel_start_rank(&self) -> u32 {
+            0
+        }
+        fn data_parallel_size(&self) -> u32 {
+            1
+        }
+        fn max_num_batched_tokens(&self) -> Option<u64> {
+            None
+        }
+        fn total_kv_blocks(&self) -> Option<u64> {
+            Some(4096)
+        }
+    }
+
+    fn request(warm_load_blocks: usize) -> SchedulingRequest {
+        let warm = WorkerWithDpRank::from_worker_id(0);
+        let cold = WorkerWithDpRank::from_worker_id(1);
+        let mut overlap = OverlapSignals::default();
+        overlap.tier_overlap_blocks.device.insert(warm, 80);
+        overlap.effective_overlap_blocks.insert(warm, 80.0);
+        let mut request = SchedulingRequest {
+            mode: ScheduleMode::QueryOnly { request_id: None },
+            token_seq: None,
+            isl_tokens: 1600,
+            lora_name: None,
+            expected_output_tokens: None,
+            affinity_target: None,
+            pinned_worker: None,
+            allowed_worker_ids: None,
+            routing_constraints: RoutingConstraints::default(),
+            router_config_override: None,
+            track_prefill_tokens: true,
+            priority_jump: 0.0,
+            strict_priority: 0,
+            policy_class: None,
+            session_context: None,
+            overlap,
+            router_hint_candidates: None,
+            retain_router_hint_chain: false,
+            shared_cache_hits: None,
+            worker_loads: Default::default(),
+            resp_tx: None,
+        };
+        request.worker_loads.insert(
+            warm,
+            dynamo_kv_router::sequences::WorkerLoadProjection {
+                active_decode_blocks: warm_load_blocks,
+                ..Default::default()
+            },
+        );
+        request.worker_loads.insert(cold, Default::default());
+        request
+    }
+
+    fn select(max_delta: f64, warm_load_blocks: usize) -> WorkerWithDpRank {
+        let policy = create_policy(&KvRouterConfig::default(), "test", max_delta);
+        let workers = HashMap::from([(0, TestWorker), (1, TestWorker)]);
+        let request = request(warm_load_blocks);
+        policy
+            .select_worker(WorkerSelectionInput::configured(
+                &workers,
+                &request,
+                request.eligibility(),
+                16,
+            ))
+            .unwrap()
+            .worker
+    }
+
+    #[test]
+    fn cache_wins_when_load_penalty_is_within_budget() {
+        assert_eq!(select(40.0, 40), WorkerWithDpRank::from_worker_id(0));
+    }
+
+    #[test]
+    fn load_wins_when_cache_worker_exceeds_budget() {
+        assert_eq!(select(39.0, 40), WorkerWithDpRank::from_worker_id(1));
+    }
+
+    #[test]
+    fn validates_cost_delta() {
+        assert!(validate_cost_delta(0.0).is_ok());
+        assert!(validate_cost_delta(64.0).is_ok());
+        assert!(validate_cost_delta(-1.0).is_err());
+        assert!(validate_cost_delta(f64::NAN).is_err());
+    }
+}

--- a/examples/router/custom-policy-example/cache-affinity-budget/src/lib.rs
+++ b/examples/router/custom-policy-example/cache-affinity-budget/src/lib.rs
@@ -194,6 +194,31 @@ mod tests {
     }
 
     #[test]
+    fn configured_active_request_weight_contributes_to_load_budget() {
+        let config = KvRouterConfig {
+            decode_active_request_weight: 32.0,
+            ..Default::default()
+        };
+        let policy = create_policy(&config, "test", 64.0);
+        let workers = HashMap::from([(0, TestWorker), (1, TestWorker)]);
+        let warm = WorkerWithDpRank::from_worker_id(0);
+        let mut request = request(0);
+        request.worker_loads.get_mut(&warm).unwrap().active_requests = 3;
+        assert_eq!(
+            policy
+                .select_worker(WorkerSelectionInput::configured(
+                    &workers,
+                    &request,
+                    request.eligibility(),
+                    16,
+                ))
+                .unwrap()
+                .worker,
+            WorkerWithDpRank::from_worker_id(1)
+        );
+    }
+
+    #[test]
     fn validates_cost_delta() {
         assert!(validate_cost_delta(0.0).is_ok());
         assert!(validate_cost_delta(64.0).is_ok());

--- a/examples/router/custom-policy-example/cache-affinity-budget/src/lib.rs
+++ b/examples/router/custom-policy-example/cache-affinity-budget/src/lib.rs
@@ -97,11 +97,24 @@ mod tests {
     }
 
     fn request(warm_load_blocks: usize) -> SchedulingRequest {
+        request_with_overlap(80, 80.0, warm_load_blocks)
+    }
+
+    fn request_with_overlap(
+        warm_device_blocks: usize,
+        warm_effective_blocks: f64,
+        warm_load_blocks: usize,
+    ) -> SchedulingRequest {
         let warm = WorkerWithDpRank::from_worker_id(0);
         let cold = WorkerWithDpRank::from_worker_id(1);
         let mut overlap = OverlapSignals::default();
-        overlap.tier_overlap_blocks.device.insert(warm, 80);
-        overlap.effective_overlap_blocks.insert(warm, 80.0);
+        overlap
+            .tier_overlap_blocks
+            .device
+            .insert(warm, warm_device_blocks);
+        overlap
+            .effective_overlap_blocks
+            .insert(warm, warm_effective_blocks);
         let mut request = SchedulingRequest {
             mode: ScheduleMode::QueryOnly { request_id: None },
             token_seq: None,
@@ -159,6 +172,25 @@ mod tests {
     #[test]
     fn load_wins_when_cache_worker_exceeds_budget() {
         assert_eq!(select(39.0, 40), WorkerWithDpRank::from_worker_id(1));
+    }
+
+    #[test]
+    fn lower_tier_cache_counts_within_load_budget() {
+        let policy = create_policy(&KvRouterConfig::default(), "test", 40.0);
+        let workers = HashMap::from([(0, TestWorker), (1, TestWorker)]);
+        let request = request_with_overlap(0, 80.0, 40);
+        assert_eq!(
+            policy
+                .select_worker(WorkerSelectionInput::configured(
+                    &workers,
+                    &request,
+                    request.eligibility(),
+                    16,
+                ))
+                .unwrap()
+                .worker,
+            WorkerWithDpRank::from_worker_id(0)
+        );
     }
 
     #[test]

--- a/examples/router/custom-policy-example/cache-affinity-budget/src/picker.rs
+++ b/examples/router/custom-policy-example/cache-affinity-budget/src/picker.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Cache-first selection within a bounded active-load cost delta.
+//! Effective-cache-first selection within a bounded active-load cost delta.
 
 use dynamo_kv_router::{
     WorkerInputView, WorkerInputs, WorkerPicker, WorkerSelectionContext, WorkerSelectionPolicyError,
@@ -39,8 +39,8 @@ impl WorkerPicker for CacheAffinityBudgetPicker {
             })
             .max_by(|(_, (left, left_cache)), (_, (right, right_cache))| {
                 left_cache
-                    .device_overlap_blocks()
-                    .total_cmp(&right_cache.device_overlap_blocks())
+                    .effective_overlap_blocks()
+                    .total_cmp(&right_cache.effective_overlap_blocks())
                     .then_with(|| right.cost().total_cmp(&left.cost()))
                     .then_with(|| right.worker().cmp(&left.worker()))
             })

--- a/examples/router/custom-policy-example/cache-affinity-budget/src/picker.rs
+++ b/examples/router/custom-policy-example/cache-affinity-budget/src/picker.rs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cache-first selection within a bounded active-load cost delta.
+
+use dynamo_kv_router::{
+    WorkerInputView, WorkerInputs, WorkerPicker, WorkerSelectionContext, WorkerSelectionPolicyError,
+};
+
+pub(crate) struct CacheAffinityBudgetPicker {
+    pub(crate) max_load_cost_delta_blocks: f64,
+}
+
+impl WorkerPicker for CacheAffinityBudgetPicker {
+    fn required_worker_inputs(&self) -> WorkerInputs {
+        WorkerInputs::CACHE
+    }
+
+    fn pick(
+        &mut self,
+        _context: &WorkerSelectionContext<'_>,
+        input: WorkerInputView<'_>,
+    ) -> Result<usize, WorkerSelectionPolicyError> {
+        let candidates = input.candidates();
+        let cache = input
+            .cache()
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("cache input unavailable"))?;
+        let min_cost = candidates
+            .iter()
+            .map(|candidate| candidate.cost())
+            .min_by(f64::total_cmp)
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("no eligible worker"))?;
+        candidates
+            .iter()
+            .zip(cache)
+            .enumerate()
+            .filter(|(_, (candidate, _))| {
+                candidate.cost() - min_cost <= self.max_load_cost_delta_blocks
+            })
+            .max_by(|(_, (left, left_cache)), (_, (right, right_cache))| {
+                left_cache
+                    .device_overlap_blocks()
+                    .total_cmp(&right_cache.device_overlap_blocks())
+                    .then_with(|| right.cost().total_cmp(&left.cost()))
+                    .then_with(|| right.worker().cmp(&left.worker()))
+            })
+            .map(|(row, _)| row)
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("no worker within load budget"))
+    }
+}

--- a/examples/router/custom-policy-example/cache-affinity-budget/src/scorer.rs
+++ b/examples/router/custom-policy-example/cache-affinity-budget/src/scorer.rs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Modeled active-load cost for cache-affinity budgeting.
+
+use dynamo_kv_router::{
+    WorkerCandidate, WorkerInputs, WorkerScorer, WorkerSelectionContext, WorkerSelectionPolicyError,
+};
+
+pub(crate) struct ActiveLoadScorer {
+    pub(crate) prefill_load_scale: f64,
+    pub(crate) active_request_weight: f64,
+}
+
+impl WorkerScorer for ActiveLoadScorer {
+    fn required_worker_inputs(&self) -> WorkerInputs {
+        WorkerInputs::LOAD
+    }
+
+    fn score(
+        &mut self,
+        context: &WorkerSelectionContext<'_>,
+        candidate: &WorkerCandidate,
+    ) -> Result<f64, WorkerSelectionPolicyError> {
+        let load = candidate
+            .load()
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("load input unavailable"))?;
+        let active_prefill_blocks =
+            load.active_prefill_tokens() as f64 / context.block_size() as f64;
+        Ok(self.prefill_load_scale * active_prefill_blocks
+            + load.decode_cost_blocks()
+            + self.active_request_weight * load.active_requests() as f64)
+    }
+}

--- a/examples/router/custom-policy-example/catalog/Cargo.toml
+++ b/examples/router/custom-policy-example/catalog/Cargo.toml
@@ -16,4 +16,5 @@ soft-pin-repin-policy = { package = "dynamo-custom-policy-example-soft-pin-repin
 simple-filter-score-pick-policy = { package = "dynamo-custom-policy-example-simple-filter-score-pick", path = "../simple-filter-score-pick" }
 disagg-filter-score-pick-policy = { package = "dynamo-custom-policy-example-disagg-filter-score-pick", path = "../disagg-filter-score-pick" }
 simple-stacked-score-pick-policy = { package = "dynamo-custom-policy-example-simple-stacked-score-pick", path = "../simple-stacked-score-pick" }
+cache-affinity-budget-policy = { package = "dynamo-custom-policy-example-cache-affinity-budget", path = "../cache-affinity-budget" }
 dynamo-kv-router = { workspace = true, features = ["standalone-selection"] }

--- a/examples/router/custom-policy-example/catalog/src/lib.rs
+++ b/examples/router/custom-policy-example/catalog/src/lib.rs
@@ -14,7 +14,8 @@ pub fn register(
     soft_pin_repin_policy::register(registry)?;
     simple_filter_score_pick_policy::register(registry)?;
     disagg_filter_score_pick_policy::register(registry)?;
-    simple_stacked_score_pick_policy::register(registry)
+    simple_stacked_score_pick_policy::register(registry)?;
+    cache_affinity_budget_policy::register(registry)
 }
 
 #[cfg(test)]
@@ -41,6 +42,10 @@ mod tests {
         assert!(matches!(
             simple_stacked_score_pick_policy::register(&mut registry),
             Err(WorkerSelectionPolicyRegistryError::Duplicate { name }) if name == "simple-stacked-score-pick"
+        ));
+        assert!(matches!(
+            cache_affinity_budget_policy::register(&mut registry),
+            Err(WorkerSelectionPolicyRegistryError::Duplicate { name }) if name == "cache-affinity-budget"
         ));
     }
 }

--- a/lib/kv-router/src/scheduling/selector/policy.rs
+++ b/lib/kv-router/src/scheduling/selector/policy.rs
@@ -284,6 +284,11 @@ impl ScoredWorkerCandidate {
 }
 
 impl WorkerCacheInput {
+    /// Return tier-weighted prefix overlap in KV blocks.
+    pub fn effective_overlap_blocks(&self) -> f64 {
+        self.effective_overlap_blocks
+    }
+
     /// Return device-resident prefix overlap in KV blocks.
     pub fn device_overlap_blocks(&self) -> f64 {
         self.device_overlap_blocks


### PR DESCRIPTION
## Summary

- add an opt-in custom worker-selection policy that gives effective cache overlap lexicographic priority within a configurable modeled-load budget
- rank the same tier-weighted overlap used by Dynamo's cache-loss funnel, including configured lower-tier cache credit
- keep the policy default-off and isolated to the existing custom-policy extension surface
- document the block-cost semantics and register the example in the standalone catalog

The budget is deliberately not presented as a production recommendation; it must be selected from a matched workload experiment.

## Validation

- `cargo test -p dynamo-custom-policy-example-cache-affinity-budget` (5 passed, including configured active-request load)
- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-custom-policy-example-cache-affinity-budget --all-targets` (passes; existing unrelated dead-code warning remains in `lib/kv-router/src/services/indexer/registry.rs`)
- the complete example/catalog suite, docs lint, and EPP build passed on the initial revision; CI reruns the full repository checks on this revision
