### PR TITLE
fix(test): treat `sh -lc` workers as shell-invoked, not argv (OPS-8533)

### DIFF
--- a/tests/deploy/dgd_utils.py
+++ b/tests/deploy/dgd_utils.py
@@ -299,6 +299,22 @@ class ServiceSpec:
         return self._spec["extraPodSpec"]["mainContainer"]
 
     @staticmethod
+    def _is_shell_command_flag(flag) -> bool:
+        """True for a short-option cluster that ends in ``c``, i.e. one that
+        makes a shell read its command from the next word.
+
+        Covers ``-c`` and the equally common ``-lc``/``-ec``; rejects long
+        options so ``--config`` is never mistaken for one.
+        """
+        return (
+            isinstance(flag, str)
+            and len(flag) >= 2
+            and flag.startswith("-")
+            and not flag.startswith("--")
+            and flag.endswith("c")
+        )
+
+    @staticmethod
     def _is_shell_style(container: dict) -> bool:
         """Detect ``command: [..., "-c"]`` + ``args: ["<shell-string>"]``.
 
@@ -308,9 +324,31 @@ class ServiceSpec:
         breaks the shell's contract — ``sh -c`` takes exactly one command
         string; everything after it becomes ``$0``/``$1``/…, so the rest of
         the flags would be silently dropped at runtime.
+
+        The trailing flag is not always exactly ``-c``. Across ``recipes/`` and
+        ``examples/`` this predicate now matches 184 shell-invoked containers;
+        matching only ``-c`` found 84. The other 100, spread over 51 manifests,
+        use ``-lc`` and were classified as argv-style, which failed silently in
+        *both* directions:
+
+        * reads — :meth:`_get_args` returned ``["<the entire command string>"]``,
+          so every scan for a flag by token equality found nothing. ``.model``
+          reported ``None`` for a worker that plainly declares ``--model``;
+        * writes — :meth:`_set_args` wrote argv tokens back as a list.
+          ``add_arg_to_service()`` therefore produced
+          ``args: ["<command string>", "--max-model-len", "1024"]``, and a shell
+          binds everything after its command string to ``$0``/``$1``, so the
+          flag never reached the worker. The ``.model`` setter failed the other
+          way: finding no ``--model`` token, it returned without writing at all.
+
+        Both directions are silent, so a test that reconfigures a ``-lc`` worker
+        and then asserts on it passes while measuring the unmodified
+        deployment.
         """
         cmd = container.get("command")
-        if not isinstance(cmd, list) or len(cmd) < 2 or cmd[-1] != "-c":
+        if not isinstance(cmd, list) or len(cmd) < 2:
+            return False
+        if not ServiceSpec._is_shell_command_flag(cmd[-1]):
             return False
         args = container.get("args", [])
         return (
@@ -342,10 +380,51 @@ class ServiceSpec:
             container["args"] = args
             return args
         if self._is_shell_style(container):
-            import shlex
-
-            return shlex.split(args[0]) if args[0].strip() else []
+            return self._split_shell_command(args[0])
         return args
+
+    @staticmethod
+    def _strip_shell_comments(command: str) -> str:
+        """Drop whole-line ``#`` comments from a shell command string.
+
+        ``shlex`` has no notion of comments, so an apostrophe inside one — as in
+        ``# Dynamo's forward-pass metrics adapter`` — opens a quote that never
+        closes and tokenisation dies with ``No closing quotation``. 17 containers
+        in the corpus carry comment lines and four of them died on exactly this.
+        bash ignores those lines entirely, so we do too.
+
+        Only lines whose first non-blank character is ``#`` are removed. A ``#``
+        appearing mid-line is left alone: it may be inside a quoted argument
+        (JSON values, URLs with fragments), where bash would not treat it as a
+        comment either.
+        """
+        kept = [
+            line for line in command.splitlines() if not line.lstrip().startswith("#")
+        ]
+        return "\n".join(kept)
+
+    @classmethod
+    def _split_shell_command(cls, command: str) -> list[str]:
+        """Tokenise a shell command string into argv-ish tokens.
+
+        Shell operators (``&&``, ``|``, ``;``, redirections) survive as their own
+        tokens so that :meth:`_set_args` can put them back unquoted.
+        """
+        if not command.strip():
+            return []
+        import shlex
+
+        return shlex.split(cls._strip_shell_comments(command))
+
+    # Shell control operators. ``shlex`` returns these as ordinary tokens, so
+    # without an explicit carve-out the quoter below would emit ``'&&'`` and turn
+    # ``ulimit -l unlimited && exec python3 …`` into a single ``ulimit`` call with
+    # a literal ``&&`` argument. 47 of the 184 shell-invoked containers under
+    # ``recipes/`` and ``examples/`` contain at least one of these; none of them
+    # ever quotes one, so emitting them bare is lossless for the whole corpus.
+    _SHELL_OPERATORS = frozenset(
+        {"&&", "||", "|", ";", "&", "<", ">", ">>", "<<", "2>&1", ">&2", "2>"}
+    )
 
     # Bare-safe characters for re-joining shell-style argv tokens. Includes ``$``
     # so that ``$MODEL_PATH``-style references survive the round-trip without
@@ -359,12 +438,20 @@ class ServiceSpec:
         ``$VAR`` expansion when the variable name uses safe characters.
 
         Tokens that are entirely composed of safe characters (alnum, ``-_./
-        :=,@%+`` and ``$``) are left bare; everything else is wrapped in
-        single quotes (with embedded single quotes escaped via the standard
-        ``'\\''`` trick) to preserve literal contents.
+        :=,@%+`` and ``$``) are left bare, as are shell control operators
+        (:data:`_SHELL_OPERATORS`); everything else is wrapped in single quotes
+        (with embedded single quotes escaped via the standard ``'\\''`` trick)
+        to preserve literal contents.
+
+        The operator carve-out means a token that was a *literal* ``&&`` in the
+        source is re-emitted as an operator. ``shlex`` discards the quoting that
+        would distinguish the two, so this cannot be decided at write time; the
+        corpus contains no such token.
         """
         if not tok:
             return "''"
+        if tok in cls._SHELL_OPERATORS:
+            return tok
         if cls._SHELL_BARE_SAFE.match(tok):
             return tok
         return "'" + tok.replace("'", "'\\''") + "'"

--- a/tests/deploy/test_dgd_utils.py
+++ b/tests/deploy/test_dgd_utils.py
@@ -72,3 +72,192 @@ async def test_in_flight_restart_preserves_bounded_previous_log(tmp_path) -> Non
         previous=True,
         tail_lines=50000,
     )
+
+
+def _shell_style_manifest(tmp_path, command, script, name="lc-test"):
+    """A v1beta1 DGD whose worker is launched through a shell."""
+    manifest = {
+        "apiVersion": "nvidia.com/v1beta1",
+        "kind": "DynamoGraphDeployment",
+        "metadata": {"name": name},
+        "spec": {
+            "components": [
+                {
+                    "name": "Worker",
+                    "podTemplate": {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "name": "main",
+                                    "command": command,
+                                    "args": [script],
+                                }
+                            ]
+                        }
+                    },
+                }
+            ]
+        },
+    }
+    path = tmp_path / f"{name}.yaml"
+    path.write_text(yaml.safe_dump(manifest))
+    return DeploymentSpec(str(path))
+
+
+def _worker_container(spec):
+    component = spec._deployment_spec["spec"]["components"][0]
+    return component["podTemplate"]["spec"]["containers"][0]
+
+
+@pytest.mark.parametrize(
+    "flag, expected",
+    [
+        ("-c", True),
+        ("-lc", True),
+        ("-ec", True),
+        ("-euxc", True),
+        ("--config", False),
+        ("-l", False),
+        ("-", False),
+    ],
+)
+def test_shell_command_flag_matches_clusters_ending_in_c(flag, expected) -> None:
+    """``-lc`` invokes a shell exactly as ``-c`` does; ``--config`` does not."""
+    from tests.deploy.dgd_utils import ServiceSpec
+
+    assert ServiceSpec._is_shell_command_flag(flag) is expected
+
+
+def test_login_shell_worker_reports_its_model(tmp_path) -> None:
+    """A ``-lc`` worker's ``--model`` is readable, not hidden in one string.
+
+    Treating ``sh -lc`` as argv-style left the whole command as a single token,
+    so scanning for ``--model`` by equality found nothing and ``.model``
+    reported ``None`` for a worker that plainly declares one.
+    """
+    spec = _shell_style_manifest(
+        tmp_path,
+        ["/bin/bash", "-lc"],
+        "python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --tp 1",
+    )
+
+    assert spec["Worker"].model == "Qwen/Qwen3-0.6B"
+
+
+def test_login_shell_worker_model_is_actually_rewritten(tmp_path) -> None:
+    """``set_model`` on a ``-lc`` worker changes what the pod will serve."""
+    spec = _shell_style_manifest(
+        tmp_path,
+        ["/bin/bash", "-lc"],
+        "python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --tp 1",
+    )
+
+    spec.set_model("meta-llama/Llama-3.1-8B")
+
+    assert spec["Worker"].model == "meta-llama/Llama-3.1-8B"
+    args = _worker_container(spec)["args"]
+    assert len(args) == 1, f"shell contract broken, args must stay one string: {args}"
+    assert "Qwen/Qwen3-0.6B" not in args[0]
+
+
+def test_added_flag_stays_inside_the_login_shell_command(tmp_path) -> None:
+    """An added flag must land in the command, not in the shell's ``$0``/``$1``.
+
+    Writing argv tokens back as extra list entries yields
+    ``args: ["<command>", "--max-model-len", "1024"]``; a shell binds those to
+    positional parameters and the worker never sees the flag.
+    """
+    spec = _shell_style_manifest(
+        tmp_path,
+        ["/bin/bash", "-lc"],
+        "python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B",
+    )
+
+    spec.add_arg_to_service("Worker", "--max-model-len", "1024")
+
+    args = _worker_container(spec)["args"]
+    assert len(args) == 1, f"flag escaped the shell command string: {args}"
+    assert "--max-model-len 1024" in args[0]
+
+
+@pytest.mark.parametrize("shell_flag", ["-c", "-lc"])
+def test_shell_operators_survive_a_rewrite_unquoted(tmp_path, shell_flag) -> None:
+    """``&&`` must stay an operator, not become a literal argument.
+
+    Re-joining tokens through a quoter that treats ``&&`` as an ordinary word
+    emits ``'&&'``, collapsing ``ulimit -l unlimited && exec python3 …`` into a
+    single ``ulimit`` call whose third argument is the string ``&&``. The pod
+    then never starts the worker at all. This affected ``-c`` containers
+    already; extending the predicate to ``-lc`` would have widened it.
+    """
+    spec = _shell_style_manifest(
+        tmp_path,
+        ["/bin/bash", shell_flag],
+        "ulimit -l unlimited && exec python3 -m dynamo.sglang "
+        "--model-path Qwen/Qwen3-0.6B",
+        name=f"ops{shell_flag.strip('-')}",
+    )
+
+    spec.set_model("deepseek-ai/DeepSeek-V3")
+
+    rewritten = _worker_container(spec)["args"][0]
+    # The rewrite must have happened -- otherwise this passes by doing nothing.
+    assert spec["Worker"].model == "deepseek-ai/DeepSeek-V3"
+    assert "Qwen/Qwen3-0.6B" not in rewritten
+    assert "'&&'" not in rewritten, rewritten
+    assert rewritten.startswith("ulimit -l unlimited && exec python3"), rewritten
+
+
+def test_comment_lines_do_not_break_tokenisation(tmp_path) -> None:
+    """An apostrophe inside a ``#`` comment must not read as an open quote.
+
+    ``shlex`` has no notion of comments, so ``# Dynamo's adapter`` opened a
+    quote that never closed and tokenisation raised ``No closing quotation``.
+    """
+    spec = _shell_style_manifest(
+        tmp_path,
+        ["/bin/bash", "-lc"],
+        "# Dynamo's metrics adapter is stale for this image\n"
+        "exec python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B",
+    )
+
+    assert spec["Worker"].model == "Qwen/Qwen3-0.6B"
+
+
+def test_argv_style_worker_is_untouched(tmp_path) -> None:
+    """Widening the shell predicate must not reclassify argv-style workers."""
+    manifest = {
+        "apiVersion": "nvidia.com/v1beta1",
+        "kind": "DynamoGraphDeployment",
+        "metadata": {"name": "argv-test"},
+        "spec": {
+            "components": [
+                {
+                    "name": "Worker",
+                    "podTemplate": {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "name": "main",
+                                    "command": ["python3", "-m", "dynamo.vllm"],
+                                    "args": ["--model", "Qwen/Qwen3-0.6B"],
+                                }
+                            ]
+                        }
+                    },
+                }
+            ]
+        },
+    }
+    path = tmp_path / "argv.yaml"
+    path.write_text(yaml.safe_dump(manifest))
+    spec = DeploymentSpec(str(path))
+
+    spec.add_arg_to_service("Worker", "--max-model-len", "1024")
+
+    assert _worker_container(spec)["args"] == [
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--max-model-len",
+        "1024",
+    ]


### PR DESCRIPTION
Linear: OPS-8533

## Summary

`ServiceSpec._is_shell_style` in `tests/deploy/dgd_utils.py` matched a container as
shell-invoked only when `command[-1] == "-c"`, so anything launched with `sh -lc` was
classified as argv-style.

Measured against every `DynamoGraphDeployment` under `recipes/` and `examples/`, using the
real class rather than a grep:

| | containers |
|---|---:|
| detected by the current predicate | 84 |
| actually shell-invoked | 184 |
| **missed** | **100**, across **51** manifest files |

All 100 use `-lc`.

### Both directions failed silently

- **read** — `_get_args()` returns the whole command as one token, so scanning for a flag by
  equality finds nothing. `ServiceSpec.model` returns `None` for a worker that plainly
  declares `--model`.
- **write** — `_set_args()` writes argv tokens back as list entries, so
  `add_arg_to_service()` produces `args: ["<command string>", "--max-model-len", "1024"]`.
  A shell binds everything after its command string to `$0`/`$1`, so the flag never reaches
  the worker.
- **write, second mode** — the `.model` setter, finding no `--model` token, returns without
  writing anything.

Nothing raises, so a test can reconfigure a `-lc` worker, assert on it, and pass while
measuring an unmodified deployment.

### Widening the predicate alone would have spread an existing bug

The read→write path is `shlex.split` → mutate tokens → `" ".join(quote(t))`, and that
round-trip does not preserve shell semantics:

- **47 of 184** containers contain a control operator. `shlex` returns `&&` as an ordinary
  token and the quoter emitted `'&&'`, collapsing
  `ulimit -l unlimited && exec python3 …` into a single `ulimit` call with a literal `&&`
  argument — the worker never starts. **This already affects the 84 `-c` containers on
  `main`**; it is not introduced here.
- **17 of 184** contain whole-line `#` comments. `shlex` has no comment concept, so the
  apostrophe in `# Dynamo's forward-pass metrics adapter` opens a quote that never closes and
  tokenising raised `ValueError: No closing quotation` on 4 recipes.

## Changes

1. Match any short-option cluster ending in `c` (`-c`, `-lc`, `-ec`), rejecting long options
   so `--config` is never mistaken for one.
2. Strip whole-line `#` comments before tokenising, as bash does. A mid-line `#` is left
   alone since it may sit inside a quoted JSON value.
3. Re-emit shell control operators bare rather than quoted.

Item 3 is sound only because **zero** of the 184 containers ever quotes an operator as a
literal argument. `shlex` destroys that distinction at read time, so it cannot be recovered
at write time — the docstring states this as a corpus-scoped guarantee rather than a general
one.

## Validation

- **16 unit tests** in `tests/deploy/test_dgd_utils.py`. **13 of them fail against `main`'s
  `dgd_utils.py`** and all 16 pass with this change, so they are regression tests rather than
  restatements. The operator case is parameterised over `-c` and `-lc` and asserts the model
  actually changed, so it cannot pass by doing nothing.
- Replayed over every DGD in `recipes/` and `examples/`: detection goes 84 → 184 with **no
  container lost**, and for all 184 the tokenise/re-join round-trip is token-identical, quotes
  no operator, and the reconstructed command **parses under `bash -n`**. Tokenise failures
  4 → 0.
- `pytest tests/deploy -m unit` → 37 passed. No callers of the changed internals exist outside
  `dgd_utils.py`.

## Known limitation, deliberately not fixed here

Reconstructing a command from tokens is lossy in general: it also flattens `\`-continued
multi-line scripts and drops the comments that explain each flag. The durable fix is to retain
the original command string and splice writes into it. That belongs with the test-framework
design work (DEP 17), and doing it inside `dgd_utils.py` now would pre-empt it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment manifest handling for shell commands using options such as `-c`, `-lc`, and `-ec`.
  * Correctly processes comments and shell operators when reading or updating commands.
  * Supports argument updates for additional shell-invoked containers while preserving single-string command arguments.
  * Maintains existing behavior for argv-style workers.

* **Tests**
  * Added coverage for shell command parsing, argument updates, comments, operators, and supported shell options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->