### PR TITLE
fix(recipes): stop the qwen3-vl vLLM workers silently never starting (OPS-8534)

### DIFF
--- a/recipes/qwen3-vl-32b-fp8/vllm/agg/deploy.yaml
+++ b/recipes/qwen3-vl-32b-fp8/vllm/agg/deploy.yaml
@@ -68,7 +68,7 @@ spec:
             - /bin/sh
             - -c
           args:
-            - >-
+            - |-
               python3 -m dynamo.vllm \
               --model $MODEL_PATH \
               --served-model-name $SERVED_MODEL_NAME \

--- a/recipes/qwen3-vl-32b-fp8/vllm/hetero_hardware_disagg/deploy.yaml
+++ b/recipes/qwen3-vl-32b-fp8/vllm/hetero_hardware_disagg/deploy.yaml
@@ -92,7 +92,7 @@ spec:
             - /bin/sh
             - -c
           args:
-            - >-
+            - |-
               ulimit -l unlimited
               TRANSFER_LOCAL=0 \
               python -m dynamo.vllm \
@@ -167,7 +167,7 @@ spec:
             - /bin/sh
             - -c
           args:
-            - >-
+            - |-
               ulimit -l unlimited
               TRANSFER_LOCAL=0 CUDA_VISIBLE_DEVICES=0 \
               python -m dynamo.vllm \


### PR DESCRIPTION
Linear: OPS-8534

## Summary

Three worker containers across two `qwen3-vl-32b-fp8` vLLM recipes write their command in a
YAML **folded** scalar (`>-`) whose body uses shell line continuations. A folded scalar
collapses each newline into a space, so `\<newline>` becomes `\<space>` — an escaped space,
not a continuation. Bash joins the next word onto it:

```console
$ bash -c 'printf "[%s]\n" python3 -m dynamo.vllm \ --model $MODEL_PATH'
[python3]
[-m]
[dynamo.vllm]
[ --model]
```

`argparse` rejects that — `' --model'[0]` is a space rather than a prefix character, so it is
read as a positional:

```console
dynamo.vllm: error: unrecognized arguments:  --model Qwen/Q
```

### The disagg workers are worse: they exit 0 without ever starting Python

`EncodeWorker` and `VllmDecodeWorker` begin with
`ulimit -l unlimited TRANSFER_LOCAL=0 \ python -m dynamo.vllm …`. After folding, `ulimit`
receives ` python`, `-m`, `dynamo.vllm` and everything after as operands, ignores them, and
**exits 0**. The interpreter is never executed, the container command succeeds, and nothing
is logged to say why the worker is not there.

## Change

`>-` → `|-` on the three affected blocks. A literal scalar preserves newlines, so the
backslashes are line continuations again. Nothing else changes — 3 lines.

Six other recipes also use `>-`, and correctly: their bodies carry no trailing backslashes,
so folding to one line is the intent. All nine files using a folded scalar were audited;
exactly these three containers are affected.

## Validation

With a stub `python` on `PATH` that prints its argv, and `MODEL_PATH` / `SERVED_MODEL_NAME`
exported:

| component | before | after |
|---|---|---|
| `VllmWorker` | argv 17, **9 space-glued** | argv 17, **0 glued** |
| `EncodeWorker` | **argv 0 — never ran** | argv 19, 0 glued |
| `VllmDecodeWorker` | **argv 0 — never ran** | argv 21, 0 glued |

In each case `--model` now resolves to the expanded `$MODEL_PATH`, and all three pass
`bash -n`.

## How this was found

A corpus test in the shared test harness being built for DEP 17 reads the served model out of
every worker container in `recipes/` and `examples/` and reported `ABSENT` for exactly these
three. My first assumption was a tokeniser bug in the harness; bash confirmed the harness was
right and the manifests are wrong.

Worth a follow-up lint rule: a folded scalar whose body contains a trailing backslash is
almost always a mistake. Not included here to keep this reviewable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated deployment configuration formatting for worker command blocks.
  * Command content and runtime behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->