### PR TITLE
fix(profiler): skip failed prefill benchmark measurements

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_aiperf.py
+++ b/components/src/dynamo/profiler/tests/unit/test_aiperf.py
@@ -12,6 +12,7 @@ from dynamo.profiler.utils.aiperf import (
     _get_common_aiperf_cmd,
     benchmark_decode,
     benchmark_prefill,
+    get_prefill_ttft,
 )
 
 pytestmark = [
@@ -56,6 +57,22 @@ def test_benchmark_prefill_logs_stdout_and_stderr(caplog):
     assert result is None
     assert "stdout: request rejected" in caplog.text
     assert "stderr: profile failed" in caplog.text
+
+
+@pytest.mark.parametrize("attention_dp_size", [1, 2])
+def test_get_prefill_ttft_returns_none_when_benchmark_fails(attention_dp_size):
+    process = _failed_process("request rejected", "profile failed")
+
+    with patch("dynamo.profiler.utils.aiperf.subprocess.Popen", return_value=process):
+        result = get_prefill_ttft(
+            100,
+            "artifacts",
+            "test-model",
+            "test-tokenizer",
+            attention_dp_size=attention_dp_size,
+        )
+
+    assert result is None
 
 
 def test_benchmark_decode_logs_stdout_and_stderr(caplog):

--- a/components/src/dynamo/profiler/utils/aiperf.py
+++ b/components/src/dynamo/profiler/utils/aiperf.py
@@ -242,7 +242,8 @@ def get_prefill_ttft(
             request_count=total_concurrency,
             warmup_request_count=AIPERF_WARMUP_REQUEST_PER_DP_RANK * attention_dp_size,
         )
-        assert aiperf_result is not None
+        if aiperf_result is None:
+            return None
         try:
             max_ttft = float(aiperf_result["time_to_first_token"]["max"])
             # subtract the decoding time in-between prefill runs
@@ -266,7 +267,8 @@ def get_prefill_ttft(
         tokenizer,
         base_url=base_url,
     )
-    assert aiperf_result is not None
+    if aiperf_result is None:
+        return None
     try:
         return float(aiperf_result["time_to_first_token"]["avg"])
     except (KeyError, TypeError, ValueError):


### PR DESCRIPTION
## Summary

A failed AIPerf prefill benchmark returns `None`, but `get_prefill_ttft()` asserts on it and aborts the profiling sweep. Return `None` for both the regular and attention-DP paths so the existing prefill sweep can skip failed measurements, matching the helper contract and decode profiling behavior.

## Validation

- Reproduced before the fix: both new parameterized cases fail with `AssertionError` after a simulated nonzero AIPerf process exit.
- `python -m pytest components/src/dynamo/profiler/tests/unit/test_aiperf.py -q`: 6 passed after the fix.
- `pre-commit run --files` for the two changed files: passed.
- Real AIPerf 0.10.0 process against a local HTTP 503 service (no `Popen` mock): the original code raises `AssertionError` for `attention_dp_size=1` and `2`; the fix returns `None` for both. Each run made actual HTTP requests and AIPerf exited with code 1.
- Real GPU success-path check through `get_prefill_ttft()`: both original and fixed helpers successfully parsed AIPerf exports and returned positive TTFT (51.657 ms / 45.864 ms). Qwen3-0.6B BF16, vLLM 0.28.0, RTX 5060 Ti 16GB, TP=1, eager/Triton attention; ISL=64, OSL=5, three warmups and one measured request. This checks successful return behavior, not a performance improvement.
- The attention-DP=2 check exercises the helper's failure branch; no multi-GPU deployment was tested.

## Related Issues

- [x] Confirmed — no related issue. Found while auditing the current main branch.
