### PR TITLE
feat(test): shared test harness — Tier 0 values, roles, verbs, dialects, manifest (OPS-8535)

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -338,6 +338,7 @@ areas:
   - container/run.sh
   - container/templates/
   - container/use-sccache.sh
+  - harness/
   - deny.toml
   - dev/docker-compose.yml
   - dev/nats-server.conf

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -174,6 +174,9 @@ core:
   - '.cargo/config.toml'
   - 'lib/**'
   - 'tests/**'
+  # Shared test harness. Filed with tests/** because it is the same kind of
+  # thing and tests/ will import it; a change here can break the suite.
+  - 'harness/**'
   - 'components/src/dynamo/kv_dc_relay/**'
   - 'components/src/dynamo/kv_state_agent/**'
   - 'components/src/dynamo/router/**'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -256,6 +256,7 @@
 # === ops  (@ai-dynamo/dynamo-ops-codeowners) ===
 /.cargo/                                                                                                @ai-dynamo/dynamo-ops-codeowners
 /.github/                                                                                               @ai-dynamo/dynamo-ops-codeowners
+/harness/                                                                                               @ai-dynamo/dynamo-ops-codeowners
 /scripts/                                                                                               @ai-dynamo/dynamo-ops-codeowners
 /deny.toml                                                                                              @ai-dynamo/dynamo-ops-codeowners
 /.gitignore                                                                                             @ai-dynamo/dynamo-ops-codeowners

--- a/harness/conftest.py
+++ b/harness/conftest.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Make ``dynamo_test`` importable when the harness has not been installed.
+
+The repository root has no ``testpaths``, so a bare ``pytest`` from the root
+collects this directory. Without this file every module here fails to import
+with ``ModuleNotFoundError: No module named 'dynamo_test'`` and takes the whole
+repository's collection down with it — a new package must not be able to break
+the existing suite just by existing.
+
+An installed copy always wins: the path is only added when the import genuinely
+fails, so ``pip install -e ./harness`` behaves exactly as it would without this
+file.
+"""
+
+import sys
+from pathlib import Path
+
+try:  # pragma: no cover - the installed case has nothing to do
+    import dynamo_test  # noqa: F401
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))

--- a/harness/dynamo_test/__init__.py
+++ b/harness/dynamo_test/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared test harness for Dynamo.
+
+Tier 0 is values: stdlib only, no pytest, no HTTP, no Kubernetes, and — by
+design — no ``dynamo.*``. Welding the harness to the runtime would make it
+impossible to point one suite at an older release.
+"""
+
+from .argv import ArgForm, ArgV, is_shell_command_flag
+from .facts import Fact, FactNotKnown, Status
+
+__all__ = [
+    "ArgForm",
+    "ArgV",
+    "Fact",
+    "FactNotKnown",
+    "Status",
+    "is_shell_command_flag",
+]

--- a/harness/dynamo_test/__init__.py
+++ b/harness/dynamo_test/__init__.py
@@ -10,12 +10,55 @@ impossible to point one suite at an older release.
 
 from .argv import ArgForm, ArgV, is_shell_command_flag
 from .facts import Fact, FactNotKnown, Status
+from .roles import (
+    Policy,
+    PortName,
+    Process,
+    Role,
+    RoleBinding,
+    RoleTable,
+    Sel,
+    UnknownRole,
+    at,
+)
+from .verbs import (
+    REGISTRY,
+    Grant,
+    Phase,
+    Receiver,
+    VerbCall,
+    VerbRegistry,
+    VerbSpec,
+    Verdict,
+    verb,
+)
 
 __all__ = [
+    # values
     "ArgForm",
     "ArgV",
     "Fact",
     "FactNotKnown",
     "Status",
     "is_shell_command_flag",
+    # roles and selection
+    "Policy",
+    "PortName",
+    "Process",
+    "Role",
+    "RoleBinding",
+    "RoleTable",
+    "Sel",
+    "UnknownRole",
+    "at",
+    # verbs
+    "REGISTRY",
+    "Grant",
+    "Phase",
+    "Receiver",
+    "VerbCall",
+    "VerbRegistry",
+    "VerbSpec",
+    "Verdict",
+    "verb",
 ]

--- a/harness/dynamo_test/__init__.py
+++ b/harness/dynamo_test/__init__.py
@@ -10,6 +10,7 @@ impossible to point one suite at an older release.
 
 from .argv import ArgForm, ArgV, is_shell_command_flag
 from .dialect import DIALECTS, Dialect, EngineDialect, detect, for_backend
+from .evidence import Evidence, Outcome, Producer, Promise, Recorder, Seal, Verdict
 from .facts import Fact, FactNotKnown, Status
 from .roles import (
     Policy,
@@ -24,13 +25,13 @@ from .roles import (
 )
 from .verbs import (
     REGISTRY,
+    Contribution,
     Grant,
     Phase,
     Receiver,
     VerbCall,
     VerbRegistry,
     VerbSpec,
-    Verdict,
     verb,
 )
 
@@ -48,6 +49,14 @@ __all__ = [
     "EngineDialect",
     "detect",
     "for_backend",
+    # evidence
+    "Evidence",
+    "Outcome",
+    "Producer",
+    "Promise",
+    "Recorder",
+    "Seal",
+    "Verdict",
     # roles and selection
     "Policy",
     "PortName",
@@ -65,7 +74,7 @@ __all__ = [
     "Receiver",
     "VerbCall",
     "VerbRegistry",
+    "Contribution",
     "VerbSpec",
-    "Verdict",
     "verb",
 ]

--- a/harness/dynamo_test/__init__.py
+++ b/harness/dynamo_test/__init__.py
@@ -9,6 +9,7 @@ impossible to point one suite at an older release.
 """
 
 from .argv import ArgForm, ArgV, is_shell_command_flag
+from .dialect import DIALECTS, Dialect, EngineDialect, detect, for_backend
 from .facts import Fact, FactNotKnown, Status
 from .roles import (
     Policy,
@@ -41,6 +42,12 @@ __all__ = [
     "FactNotKnown",
     "Status",
     "is_shell_command_flag",
+    # engine dialects
+    "DIALECTS",
+    "Dialect",
+    "EngineDialect",
+    "detect",
+    "for_backend",
     # roles and selection
     "Policy",
     "PortName",

--- a/harness/dynamo_test/__init__.py
+++ b/harness/dynamo_test/__init__.py
@@ -8,6 +8,7 @@ design — no ``dynamo.*``. Welding the harness to the runtime would make it
 impossible to point one suite at an older release.
 """
 
+from . import catalog as _catalog  # noqa: F401  (registers the standard verbs)
 from .argv import ArgForm, ArgV, is_shell_command_flag
 from .dialect import DIALECTS, Dialect, EngineDialect, detect, for_backend
 from .evidence import Evidence, Outcome, Producer, Promise, Recorder, Seal, Verdict
@@ -23,6 +24,7 @@ from .roles import (
     UnknownRole,
     at,
 )
+from .sut import Handle, NotGranted, PhaseError, Provider, Sut
 from .verbs import (
     REGISTRY,
     Contribution,
@@ -57,6 +59,13 @@ __all__ = [
     "Recorder",
     "Seal",
     "Verdict",
+    # the system under test
+    "Handle",
+    "NotGranted",
+    "Phase",
+    "PhaseError",
+    "Provider",
+    "Sut",
     # roles and selection
     "Policy",
     "PortName",

--- a/harness/dynamo_test/__init__.py
+++ b/harness/dynamo_test/__init__.py
@@ -33,6 +33,7 @@ from .site import (
     Topology,
     UnknownSite,
 )
+from .stack import DYNAMO_DEFAULTS, Defaults, Render, Stack
 from .sut import Handle, NotGranted, PhaseError, Provider, Sut
 from .verbs import (
     REGISTRY,
@@ -103,4 +104,9 @@ __all__ = [
     "Contribution",
     "VerbSpec",
     "verb",
+    # stacks: a plan plus the defaults the operator would have supplied
+    "DYNAMO_DEFAULTS",
+    "Defaults",
+    "Render",
+    "Stack",
 ]

--- a/harness/dynamo_test/__init__.py
+++ b/harness/dynamo_test/__init__.py
@@ -10,6 +10,7 @@ impossible to point one suite at an older release.
 
 from . import catalog as _catalog  # noqa: F401  (registers the standard verbs)
 from .argv import ArgForm, ArgV, is_shell_command_flag
+from .bringup import BringUp, bring_up
 from .dialect import DIALECTS, Dialect, EngineDialect, detect, for_backend
 from .evidence import Evidence, Outcome, Producer, Promise, Recorder, Seal, Verdict
 from .facts import Fact, FactNotKnown, Status
@@ -109,4 +110,7 @@ __all__ = [
     "Defaults",
     "Render",
     "Stack",
+    # bring-up
+    "BringUp",
+    "bring_up",
 ]

--- a/harness/dynamo_test/__init__.py
+++ b/harness/dynamo_test/__init__.py
@@ -24,6 +24,15 @@ from .roles import (
     UnknownRole,
     at,
 )
+from .site import (
+    BUILTIN_SITES,
+    LOCAL,
+    Capability,
+    Ownership,
+    Site,
+    Topology,
+    UnknownSite,
+)
 from .sut import Handle, NotGranted, PhaseError, Provider, Sut
 from .verbs import (
     REGISTRY,
@@ -75,6 +84,14 @@ __all__ = [
     "RoleTable",
     "Sel",
     "UnknownRole",
+    # sites and topology
+    "BUILTIN_SITES",
+    "LOCAL",
+    "Capability",
+    "Ownership",
+    "Site",
+    "Topology",
+    "UnknownSite",
     "at",
     # verbs
     "REGISTRY",

--- a/harness/dynamo_test/argv.py
+++ b/harness/dynamo_test/argv.py
@@ -1,0 +1,669 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""How a worker's command line is written, read, and edited.
+
+A Dynamo worker is launched one of two ways, and a test that wants to know what
+model it serves — or to change it — has to handle both:
+
+``ARGV``
+    ``command: [python3, -m, dynamo.vllm]`` with ``args`` as a token list.
+``SHELL``
+    ``command: [/bin/bash, -lc]`` with ``args`` as a **single string** that a
+    shell parses. Everything after that string binds to ``$0``/``$1``, so it is
+    the only element there will ever be.
+
+Measured across every ``DynamoGraphDeployment`` in ``recipes/`` and
+``examples/``: 184 containers are shell-invoked, and **100 of them use ``-lc``**
+rather than ``-c``. ``-lc`` is the majority spelling, not an exception — which is
+why this module classifies on "a short-option cluster ending in ``c``" and keeps
+the shell's own argv verbatim, instead of enumerating the spellings it expects.
+
+## Why writes splice instead of rebuilding
+
+The obvious implementation of an edit is ``shlex.split`` → change a token →
+``" ".join(quote(t))``. That is what the existing test helpers do, and it is
+lossy in three independent ways that were each measured on the live corpus:
+
+* **47 of 184** containers contain a shell control operator. ``shlex`` hands back
+  ``&&`` as an ordinary word, so a quoting re-join emits ``'&&'`` and
+  ``ulimit -l unlimited && exec python3 …`` collapses into a single ``ulimit``
+  call with a literal ``&&`` argument. The worker never starts.
+* **17 of 184** contain whole-line ``#`` comments. ``shlex`` has no notion of
+  comments, so the apostrophe in ``# Dynamo's forward-pass metrics adapter``
+  opens a quote that never closes; tokenising raised ``No closing quotation`` on
+  four recipes outright.
+* Most of the 184 are ``\\``-continued multi-line scripts. A re-join flattens
+  them to one line and deletes the comments explaining each flag.
+
+So this module never rebuilds a shell command. It tokenises **with source
+spans**, and an edit replaces exactly the bytes of the token it is changing.
+Operators, comments, line continuations, and the author's original quoting come
+out the far side untouched, because they are never re-emitted at all.
+
+## Why reads return :class:`Fact`
+
+A flag that could not be *looked for* is not a flag that is absent. Four recipes
+cannot be tokenised at all; answering "no ``--model``" for those is the
+false-green this harness exists to prevent. Unparseable input yields
+``UNKNOWN``, never ``ABSENT``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Iterable, Iterator, Sequence
+
+from .facts import Fact
+
+__all__ = [
+    "ArgForm",
+    "ArgV",
+    "Token",
+    "TokenKind",
+    "ArgVError",
+    "UnparseableCommand",
+    "AmbiguousInsertion",
+    "is_shell_command_flag",
+]
+
+
+class ArgVError(Exception):
+    """Base class for command-line editing failures."""
+
+
+class UnparseableCommand(ArgVError):
+    """The shell command string could not be tokenised, so it cannot be edited."""
+
+
+class AmbiguousInsertion(ArgVError):
+    """A new flag has no unambiguous insertion point in this shell command.
+
+    Raised rather than guessed. Appending to the end of a command that finishes
+    with ``&& something-else`` or a redirection would attach the flag to the
+    wrong program, and doing that silently is how a test ends up measuring a
+    configuration it did not set.
+    """
+
+
+class ArgForm(str, Enum):
+    """How the container's ``args`` are interpreted.
+
+    Deliberately two values, not one per shell spelling. ``-c`` and ``-lc``
+    differ in whether the shell reads login profiles; they do not differ in how
+    the command string is parsed or edited, and treating them as separate forms
+    invites an enumeration that ``-ec`` and ``-euxc`` immediately escape.
+    """
+
+    ARGV = "argv"
+    SHELL = "shell"
+
+
+class TokenKind(str, Enum):
+    WORD = "word"
+    OPERATOR = "operator"
+
+
+@dataclass(frozen=True)
+class Token:
+    """One token, and the exact bytes of the source it came from.
+
+    ``start``/``end`` index the original command string. ``text`` is the token
+    after quote removal, so ``text`` and ``source[start:end]`` differ whenever
+    the author quoted something — which is precisely why edits address the span
+    and comparisons use the text.
+    """
+
+    text: str
+    start: int
+    end: int
+    kind: TokenKind = TokenKind.WORD
+    quoted: bool = False
+
+    @property
+    def is_option(self) -> bool:
+        return (
+            self.kind is TokenKind.WORD
+            and len(self.text) > 1
+            and self.text.startswith("-")
+        )
+
+
+# A short-option cluster that makes a shell read its command from the next word:
+# -c, and the -lc / -ec / -euxc variants that are common in the recipe corpus.
+# Long options are excluded so --config is never mistaken for one.
+_SHELL_FLAG = re.compile(r"^-[A-Za-z]*c$")
+
+# Characters that begin a shell control operator when unquoted.
+_OPERATOR_START = frozenset("|&;<>")
+
+# Tokens that survive unquoted in a rewritten command. ``$`` is included so
+# ``$MODEL_PATH`` still expands at pod start; ``shlex.quote`` would make it
+# literal.
+_BARE_SAFE = re.compile(r"^[A-Za-z0-9_./:=,@%+\-$]+$")
+
+
+def is_shell_command_flag(flag: object) -> bool:
+    """True for a flag that makes a shell read its command from the next word."""
+    return isinstance(flag, str) and bool(_SHELL_FLAG.match(flag))
+
+
+def _quote(text: str) -> str:
+    """Quote ``text`` for a shell command, preserving ``$VAR`` expansion."""
+    if not text:
+        return "''"
+    if _BARE_SAFE.match(text):
+        return text
+    return "'" + text.replace("'", "'\\''") + "'"
+
+
+def tokenize(command: str) -> tuple[Token, ...]:
+    """Tokenise a shell command string, recording each token's source span.
+
+    Handles the constructs the corpus actually contains: single and double
+    quotes, backslash escapes, ``\\``-newline continuations, whole-line ``#``
+    comments, and control operators.
+
+    A ``#`` is only a comment when it starts a line (ignoring leading blanks).
+    Mid-line it is left in the token, because it may sit inside a quoted JSON
+    value or a URL fragment, where a shell would not treat it as a comment
+    either.
+
+    Raises:
+        UnparseableCommand: on an unterminated quote or a trailing backslash.
+    """
+    tokens: list[Token] = []
+    i, n = 0, len(command)
+    at_line_start = True
+
+    while i < n:
+        ch = command[i]
+
+        if ch == "\n":
+            at_line_start = True
+            i += 1
+            continue
+        if ch in " \t":
+            i += 1
+            continue
+        if ch == "\\" and i + 1 < n and command[i + 1] == "\n":
+            i += 2  # line continuation: not a token boundary, not a new line
+            continue
+        if ch == "#" and at_line_start:
+            nl = command.find("\n", i)
+            i = n if nl == -1 else nl
+            continue
+
+        at_line_start = False
+
+        if ch in _OPERATOR_START:
+            start = i
+            while i < n and command[i] in _OPERATOR_START:
+                i += 1
+            tokens.append(Token(command[start:i], start, i, kind=TokenKind.OPERATOR))
+            continue
+
+        start = i
+        text: list[str] = []
+        quoted = False
+        while i < n:
+            c = command[i]
+            if c in " \t\n" or c in _OPERATOR_START:
+                break
+            if c == "\\":
+                if i + 1 >= n:
+                    raise UnparseableCommand(
+                        f"trailing backslash at offset {i} in shell command"
+                    )
+                if command[i + 1] == "\n":
+                    i += 2
+                    continue
+                text.append(command[i + 1])
+                i += 2
+                continue
+            if c == "'":
+                quoted = True
+                close = command.find("'", i + 1)
+                if close == -1:
+                    raise UnparseableCommand(
+                        f"unterminated single quote opened at offset {i}"
+                    )
+                text.append(command[i + 1 : close])
+                i = close + 1
+                continue
+            if c == '"':
+                quoted = True
+                i += 1
+                while i < n and command[i] != '"':
+                    if command[i] == "\\" and i + 1 < n:
+                        if command[i + 1] == "\n":
+                            i += 2
+                            continue
+                        text.append(command[i + 1])
+                        i += 2
+                        continue
+                    text.append(command[i])
+                    i += 1
+                if i >= n:
+                    raise UnparseableCommand(
+                        "unterminated double quote in shell command"
+                    )
+                i += 1
+                continue
+            text.append(c)
+            i += 1
+
+        tokens.append(Token("".join(text), start, i, quoted=quoted))
+
+    return tuple(tokens)
+
+
+@dataclass(frozen=True)
+class ArgV:
+    """A worker's command line, readable and editable in either form.
+
+    Construct with :meth:`from_container`; the form is decided once, there, and
+    carried in the type so no caller re-derives it from ``command[-1]``.
+
+    Instances are immutable: every edit returns a new :class:`ArgV`.
+    """
+
+    form: ArgForm
+    command: tuple[str, ...]
+    source: str
+    _argv: tuple[str, ...] = ()
+    _shell: str = ""
+    _parse_error: str | None = None
+
+    # ---------------------------------------------------------------- build
+
+    @classmethod
+    def from_container(cls, container: dict, source: str = "container") -> "ArgV":
+        """Read a Kubernetes container spec into an :class:`ArgV`.
+
+        Shell form requires all three of: a ``command`` list, a trailing
+        short-option cluster ending in ``c``, and ``args`` holding exactly one
+        string. Anything else is argv form — including a single-element ``args``
+        under a non-shell command, which is one argument, not a script.
+        """
+        command = container.get("command")
+        command_tuple = (
+            tuple(str(c) for c in command) if isinstance(command, list) else ()
+        )
+        args = container.get("args", [])
+
+        shell_invoked = len(command_tuple) >= 2 and is_shell_command_flag(
+            command_tuple[-1]
+        )
+        single_string = (
+            isinstance(args, list) and len(args) == 1 and isinstance(args[0], str)
+        )
+
+        if shell_invoked and single_string:
+            return cls.shell(args[0], command=command_tuple, source=source)
+
+        if isinstance(args, str):
+            tokens = tuple(args.split())
+        elif isinstance(args, list):
+            tokens = tuple(str(a) for a in args)
+        else:
+            tokens = ()
+        return cls.argv(tokens, command=command_tuple, source=source)
+
+    @classmethod
+    def argv(
+        cls,
+        tokens: Iterable[str],
+        command: Sequence[str] = (),
+        source: str = "argv",
+    ) -> "ArgV":
+        return cls(
+            form=ArgForm.ARGV,
+            command=tuple(command),
+            source=source,
+            _argv=tuple(tokens),
+        )
+
+    @classmethod
+    def shell(
+        cls,
+        command_string: str,
+        command: Sequence[str] = ("/bin/sh", "-c"),
+        source: str = "shell",
+    ) -> "ArgV":
+        parse_error: str | None = None
+        try:
+            tokenize(command_string)
+        except UnparseableCommand as exc:
+            parse_error = str(exc)
+        return cls(
+            form=ArgForm.SHELL,
+            command=tuple(command),
+            source=source,
+            _shell=command_string,
+            _parse_error=parse_error,
+        )
+
+    # ----------------------------------------------------------------- read
+
+    @property
+    def is_parseable(self) -> bool:
+        return self._parse_error is None
+
+    @property
+    def parse_error(self) -> str | None:
+        return self._parse_error
+
+    def tokens(self) -> tuple[Token, ...]:
+        """Every token with its source span. Empty tuple if unparseable.
+
+        Prefer :meth:`get` — it reports unparseable input as ``UNKNOWN`` rather
+        than as nothing, which is the distinction that matters.
+        """
+        if self.form is ArgForm.ARGV:
+            out, pos = [], 0
+            for tok in self._argv:
+                out.append(Token(tok, pos, pos + len(tok)))
+                pos += len(tok) + 1
+            return tuple(out)
+        if self._parse_error is not None:
+            return ()
+        return tokenize(self._shell)
+
+    def _words(self) -> tuple[Token, ...]:
+        return tuple(t for t in self.tokens() if t.kind is TokenKind.WORD)
+
+    def _matches(self, token: Token, flag: str) -> bool:
+        return token.text == flag or token.text.startswith(f"{flag}=")
+
+    def _value_of(
+        self, words: Sequence[Token], index: int, flag: str
+    ) -> tuple[str, Token | None] | None:
+        """Value for the flag at ``words[index]``, plus the token holding it.
+
+        Returns ``None`` when the flag is a bare switch. The value token is
+        ``None`` for the ``--flag=value`` spelling, where the value lives inside
+        the flag token itself.
+        """
+        token = words[index]
+        if token.text.startswith(f"{flag}="):
+            return token.text[len(flag) + 1 :], None
+        nxt = words[index + 1] if index + 1 < len(words) else None
+        if nxt is None or nxt.is_option:
+            return None
+        return nxt.text, nxt
+
+    def has(self, flag: str) -> Fact[bool]:
+        """Whether ``flag`` appears at all, in either spelling."""
+        if self._parse_error is not None:
+            return Fact.unknown(
+                self.source,
+                f"shell command could not be tokenised: {self._parse_error}",
+            )
+        words = self._words()
+        present = any(self._matches(t, flag) for t in words)
+        return Fact.known(
+            present,
+            self.source,
+            f"scanned {len(words)} tokens in {self.form.value} form",
+        )
+
+    def get(self, flag: str) -> Fact[str]:
+        """The value of ``flag``, understanding ``--f v`` and ``--f=v``.
+
+        ``ABSENT`` covers two justified cases: the flag is not present, or it is
+        present as a bare switch and so genuinely has no value. Use :meth:`has`
+        to tell those apart. ``UNKNOWN`` means the command could not be read.
+        """
+        if self._parse_error is not None:
+            return Fact.unknown(
+                self.source,
+                f"shell command could not be tokenised: {self._parse_error}",
+            )
+        words = self._words()
+        for i, token in enumerate(words):
+            if not self._matches(token, flag):
+                continue
+            found = self._value_of(words, i, flag)
+            if found is None:
+                return Fact.absent(
+                    self.source,
+                    f"'{flag}' is present as a switch and carries no value",
+                )
+            return Fact.known(found[0], self.source, f"{self.form.value} form")
+        return Fact.absent(
+            self.source,
+            f"'{flag}' is not among the {len(words)} tokens of this "
+            f"{self.form.value}-form command",
+        )
+
+    def get_all(self, flag: str) -> Fact[tuple[str, ...]]:
+        """Every value given for ``flag``, in order.
+
+        A repeated flag is usually a bug — and it is the bug a naive editor
+        creates, by appending ``--max-model-len 1024`` to a command that already
+        sets it. Being able to *see* the repetition is what makes that testable.
+        """
+        if self._parse_error is not None:
+            return Fact.unknown(
+                self.source,
+                f"shell command could not be tokenised: {self._parse_error}",
+            )
+        words = self._words()
+        values = [
+            found[0]
+            for i, token in enumerate(words)
+            if self._matches(token, flag)
+            and (found := self._value_of(words, i, flag)) is not None
+        ]
+        if not values:
+            return Fact.absent(
+                self.source, f"'{flag}' carries no value in this command"
+            )
+        return Fact.known(tuple(values), self.source, f"{len(values)} occurrence(s)")
+
+    def model(self) -> Fact[str]:
+        """The served model, however this engine spells the flag."""
+        for flag in ("--model-path", "--model", "--served-model-name"):
+            fact = self.get(flag)
+            if fact.is_known or fact.is_unknown:
+                return fact
+        return Fact.absent(
+            self.source, "none of --model-path/--model/--served-model-name is set"
+        )
+
+    # ---------------------------------------------------------------- write
+
+    def set(self, flag: str, value: str | bool | None) -> "ArgV":
+        """Set ``flag``, replacing any existing occurrence rather than appending.
+
+        * ``str`` — ``--flag value``, or ``--flag=value`` if that is how the flag
+          is already written.
+        * ``True`` — a bare switch. Never ``--flag True``: engines that declare
+          the flag ``store_true`` reject a value, and emitting one is a measured
+          bug in the existing helpers.
+        * ``False`` / ``None`` — remove the flag and its value.
+
+        Raises:
+            UnparseableCommand: the shell command could not be tokenised, so
+                editing it would be guesswork.
+            AmbiguousInsertion: the flag is new and the command has no
+                unambiguous place to put it.
+        """
+        if value is False or value is None:
+            return self.unset(flag)
+        if self.form is ArgForm.ARGV:
+            return self._set_argv(flag, value)
+        return self._set_shell(flag, value)
+
+    def unset(self, flag: str) -> "ArgV":
+        """Remove ``flag`` and its value. A no-op if it is not present."""
+        if self.form is ArgForm.ARGV:
+            return self._unset_argv(flag)
+        return self._unset_shell(flag)
+
+    def _require_parseable(self) -> None:
+        if self._parse_error is not None:
+            raise UnparseableCommand(
+                f"cannot edit {self.source}: {self._parse_error}. Editing an "
+                "un-tokenisable command would corrupt it silently."
+            )
+
+    # -- argv form ------------------------------------------------------
+
+    def _set_argv(self, flag: str, value: str | bool) -> "ArgV":
+        out = list(self._argv)
+        for i, tok in enumerate(out):
+            if tok.startswith(f"{flag}="):
+                out[i] = flag if value is True else f"{flag}={value}"
+                return replace(self, _argv=tuple(out))
+            if tok != flag:
+                continue
+            has_value = i + 1 < len(out) and not _looks_like_option(out[i + 1])
+            if value is True:
+                if has_value:
+                    del out[i + 1]
+            elif has_value:
+                out[i + 1] = str(value)
+            else:
+                out.insert(i + 1, str(value))
+            return replace(self, _argv=tuple(out))
+        out.append(flag)
+        if value is not True:
+            out.append(str(value))
+        return replace(self, _argv=tuple(out))
+
+    def _unset_argv(self, flag: str) -> "ArgV":
+        out = list(self._argv)
+        i = 0
+        while i < len(out):
+            if out[i].startswith(f"{flag}="):
+                del out[i]
+                continue
+            if out[i] == flag:
+                drop = (
+                    2 if i + 1 < len(out) and not _looks_like_option(out[i + 1]) else 1
+                )
+                del out[i : i + drop]
+                continue
+            i += 1
+        return replace(self, _argv=tuple(out))
+
+    # -- shell form: every edit is a splice into the original string -----
+
+    def _splice(self, start: int, end: int, text: str) -> "ArgV":
+        return replace(self, _shell=self._shell[:start] + text + self._shell[end:])
+
+    def _set_shell(self, flag: str, value: str | bool) -> "ArgV":
+        self._require_parseable()
+        words = self._words()
+        for i, token in enumerate(words):
+            if not self._matches(token, flag):
+                continue
+            if token.text.startswith(f"{flag}="):
+                text = flag if value is True else f"{flag}={_quote(str(value))}"
+                return self._splice(token.start, token.end, text)
+            found = self._value_of(words, i, flag)
+            if value is True:
+                # Collapse to a bare switch, dropping any value it had.
+                end = found[1].end if found and found[1] else token.end
+                return self._splice(token.start, end, flag)
+            if found and found[1] is not None:
+                return self._splice(found[1].start, found[1].end, _quote(str(value)))
+            # Present as a switch: insert the value directly after it.
+            return self._splice(token.end, token.end, " " + _quote(str(value)))
+
+        return self._insert_shell(flag, value)
+
+    def _insert_shell(self, flag: str, value: str | bool) -> "ArgV":
+        """Insert a flag that is not yet present, at a defensible offset.
+
+        Placed immediately after the last existing option (and its value), so it
+        joins the flag list of the same program. Falling back to "end of string"
+        is only safe when the command has no trailing operator; a command ending
+        in ``&& something-else`` would otherwise silently hand the flag to the
+        wrong program.
+        """
+        text = flag if value is True else f"{flag} {_quote(str(value))}"
+        words = self._words()
+
+        for i in range(len(words) - 1, -1, -1):
+            if not words[i].is_option:
+                continue
+            end = words[i].end
+            nxt = words[i + 1] if i + 1 < len(words) else None
+            if nxt is not None and not nxt.is_option:
+                end = nxt.end
+            return self._splice(end, end, " " + text)
+
+        all_tokens = self.tokens()
+        if any(t.kind is TokenKind.OPERATOR for t in all_tokens):
+            raise AmbiguousInsertion(
+                f"{self.source}: cannot place '{flag}' — the command declares no "
+                "flags to append beside and contains shell operators, so the end "
+                "of the string may belong to a different program. Add the flag to "
+                "the manifest instead."
+            )
+        if not all_tokens:
+            return replace(self, _shell=text)
+        end = all_tokens[-1].end
+        return self._splice(end, end, " " + text)
+
+    def _unset_shell(self, flag: str) -> "ArgV":
+        self._require_parseable()
+        words = self._words()
+        for i, token in enumerate(words):
+            if not self._matches(token, flag):
+                continue
+            end = token.end
+            if not token.text.startswith(f"{flag}="):
+                found = self._value_of(words, i, flag)
+                if found and found[1] is not None:
+                    end = found[1].end
+            start = token.start
+            # Absorb one leading separator so removal does not leave a double
+            # space or a dangling line continuation.
+            while start > 0 and self._shell[start - 1] in " \t":
+                start -= 1
+            if start >= 2 and self._shell[start - 2 : start] == "\\\n":
+                start -= 2
+                while start > 0 and self._shell[start - 1] in " \t":
+                    start -= 1
+            return self._splice(start, end, "").unset(flag)
+        return self
+
+    # ---------------------------------------------------------------- emit
+
+    def as_container_args(self) -> list[str]:
+        """The value to write back into the container's ``args``.
+
+        Shell form always yields exactly one element. That is not a convention:
+        a shell binds everything after its command string to ``$0``/``$1``, so a
+        second element is a flag the worker will never see.
+        """
+        if self.form is ArgForm.ARGV:
+            return list(self._argv)
+        return [self._shell]
+
+    def as_shell_string(self) -> str:
+        """The shell command string. Only meaningful in shell form."""
+        if self.form is not ArgForm.SHELL:
+            raise ArgVError(f"{self.source} is in {self.form.value} form, not shell")
+        return self._shell
+
+    def apply_to(self, container: dict) -> None:
+        """Write these args back into a container spec, in place."""
+        container["args"] = self.as_container_args()
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(t.text for t in self._words())
+
+    def __repr__(self) -> str:
+        state = "unparseable" if self._parse_error else f"{len(self._words())} tokens"
+        return f"ArgV({self.form.value}, {self.source!r}, {state})"
+
+
+def _looks_like_option(token: str) -> bool:
+    return len(token) > 1 and token.startswith("-")

--- a/harness/dynamo_test/argv.py
+++ b/harness/dynamo_test/argv.py
@@ -375,6 +375,21 @@ class ArgV:
     def _words(self) -> tuple[Token, ...]:
         return tuple(t for t in self.tokens() if t.kind is TokenKind.WORD)
 
+    def invocation(self) -> tuple[str, ...]:
+        """Every word of the command actually run, ``command`` included.
+
+        For argv form the program lives in ``command`` and only its flags are in
+        ``args`` — ``command: [python3, -m, dynamo.sglang]`` with
+        ``args: [--model-path, ...]``. A reader that looks only at ``args``
+        cannot tell which engine this is.
+
+        For shell form ``command`` is just the shell (``/bin/bash -lc``) and the
+        real invocation is inside the string, so the shell itself is left out.
+        """
+        if self.form is ArgForm.SHELL:
+            return tuple(t.text for t in self._words())
+        return tuple(self.command) + tuple(t.text for t in self._words())
+
     def _matches(self, token: Token, flag: str) -> bool:
         return token.text == flag or token.text.startswith(f"{flag}=")
 

--- a/harness/dynamo_test/bringup.py
+++ b/harness/dynamo_test/bringup.py
@@ -1,0 +1,270 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Making the system available, three ways, through one mechanism.
+
+Every tier needs the system running before a test can measure it, but *how* it
+gets there differs by who owns it — and that is a property of the site, not of
+the test. So a test never says "start the workers"; it says "give me the system",
+and the site decides whether that means creating it, checking it, or joining it.
+
+:data:`~dynamo_test.site.Ownership` names the three:
+
+``IMPOSE``
+    Create it, wait, tear it down afterwards. The stack is a **recipe**.
+
+``VERIFY``
+    Bind to what is already running and confirm it matches. The stack is an
+    **expectation**. Nothing is created and nothing is destroyed.
+
+``ADOPT``
+    Create it only if it is absent, and never destroy it. For shared,
+    expensive dependencies.
+
+## Why VERIFY exists
+
+It is what lets the existing all-in-one CI job run unchanged. That container
+already started everything before pytest began; the test's job is to confirm it
+got what it expected and then measure it. Without VERIFY the only options are to
+re-start a system that is already running, or to skip the check entirely and
+hope.
+
+And the check has to happen **at bind time**. Attach to a deployment serving a
+different model and, without a comparison, the first symptom is a 404 at query
+time — which reads like a routing bug and sends the reader looking in the wrong
+place. :class:`~dynamo_test.site.Mismatch` moves that failure to the moment the
+wrong system was adopted, and names the field.
+
+## Why ADOPT is transcribed, not invented
+
+The suite already solved this once, for one dependency:
+``tests/serve/lora_utils.py:140-167`` health-probes MinIO, and on success sets
+``_owns_container = False`` so ``stop()`` becomes a no-op. That is exactly
+ADOPT. This module generalises the shape rather than inventing a new one.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from .facts import Fact
+from .roles import Role, Sel, at
+from .site import Divergence, Mismatch, Ownership, Refused, Site
+from .stack import Stack
+
+__all__ = ["BringUp", "bring_up", "observe"]
+
+
+@dataclass(frozen=True)
+class BringUp:
+    """What bringing the system up actually did.
+
+    ``owns`` is the field that matters at teardown: it is false whenever the run
+    joined something it did not create, and a caller that tears down anyway is
+    destroying somebody else's deployment.
+    """
+
+    site: Site
+    owns: bool
+    started: tuple[str, ...] = ()
+    adopted: tuple[str, ...] = ()
+    checked: tuple[str, ...] = ()
+    divergences: tuple[Divergence, ...] = ()
+
+    def describe(self) -> str:
+        parts = []
+        if self.started:
+            parts.append(f"started {', '.join(self.started)}")
+        if self.adopted:
+            parts.append(f"adopted {', '.join(self.adopted)}")
+        if self.checked:
+            parts.append(f"verified {', '.join(self.checked)}")
+        return (
+            f"{self.site.ownership} on {self.site.name}: "
+            + ("; ".join(parts) or "nothing to do")
+            + (
+                " (owned)"
+                if self.owns
+                else " (not owned — teardown must not destroy it)"
+            )
+        )
+
+    def to_record(self) -> dict:
+        return {
+            "site": self.site.name,
+            "ownership": self.site.ownership.value,
+            "owns": self.owns,
+            "started": list(self.started),
+            "adopted": list(self.adopted),
+            "checked": list(self.checked),
+            "divergences": [d.describe() for d in self.divergences],
+        }
+
+
+def observe(provider: Any, sel: Sel, timeout: float = 0.0) -> Fact[Any]:
+    """What the running system says it is serving, or why that is unknown.
+
+    Deliberately returns a :class:`Fact`. "Nothing is listening" and "something
+    is listening and serving a different model" are different answers, and a
+    comparison that cannot tell them apart will score a connection failure as a
+    disagreement.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        got = provider.request(sel, "/v1/models", timeout=min(5.0, timeout or 5.0))
+        if got.is_known or time.monotonic() >= deadline:
+            return got
+        time.sleep(0.2)
+
+
+def _served_models(models: Any) -> tuple[str, ...]:
+    if isinstance(models, dict):
+        return tuple(
+            str(entry.get("id"))
+            for entry in models.get("data", [])
+            if isinstance(entry, dict) and entry.get("id")
+        )
+    return ()
+
+
+def bring_up(
+    stack: Stack,
+    site: Site,
+    provider: Any,
+    *,
+    roles: Sequence[Role] | None = None,
+    timeout: float = 120.0,
+) -> BringUp:
+    """Make the system available in the way this site's ownership requires."""
+    wanted = list(roles or [c.role for c in stack.plan])
+
+    if site.ownership is Ownership.IMPOSE:
+        return _impose(stack, site, provider, wanted, timeout)
+    if site.ownership is Ownership.ADOPT:
+        return _adopt(stack, site, provider, wanted, timeout)
+    if site.ownership is Ownership.VERIFY:
+        return _verify(stack, site, provider, wanted, timeout)
+    raise ValueError(f"unhandled ownership {site.ownership!r}")
+
+
+def _impose(stack, site, provider, wanted, timeout) -> BringUp:
+    started = []
+    for role in wanted:
+        provider.start(at(role))
+        started.append(str(role))
+    return BringUp(site=site, owns=True, started=tuple(started))
+
+
+def _adopt(stack, site, provider, wanted, timeout) -> BringUp:
+    """Create only what is missing, and own none of it.
+
+    Transcribed from ``tests/serve/lora_utils.py:148-152``: probe first, and on
+    success record that this run did not create it, so teardown leaves it alone.
+    """
+    started, adopted = [], []
+    for role in wanted:
+        running = provider.replicas(at(role))
+        if running.or_else(0) > 0:
+            adopted.append(str(role))
+            continue
+        provider.start(at(role))
+        started.append(str(role))
+    # Deliberately False even when this run started something. ADOPT promises
+    # never to destroy; a run that created half a stack and tore down that half
+    # would leave the other half orphaned and the next run confused.
+    return BringUp(
+        site=site, owns=False, started=tuple(started), adopted=tuple(adopted)
+    )
+
+
+def _verify(stack, site, provider, wanted, timeout) -> BringUp:
+    """Bind to what is running and confirm it is what was declared."""
+    divergences: list[Divergence] = []
+    checked = []
+
+    for role in wanted:
+        sel = at(role)
+        running = provider.replicas(sel)
+        if running.or_else(0) < 1:
+            divergences.append(
+                Divergence(
+                    role=str(role),
+                    field="replicas",
+                    declared=Fact.known(
+                        1, str(stack.plan.source), "the stack expects it"
+                    ),
+                    observed=running,
+                )
+            )
+            continue
+        checked.append(str(role))
+
+    frontends = [r for r in wanted if r is Role.FRONTEND]
+    if frontends and not divergences:
+        declared = _declared_model(stack)
+        observed = observe(provider, at(Role.FRONTEND), timeout=timeout)
+        if declared.is_known:
+            served = _served_models(observed.or_else(None))
+            if observed.is_known and declared.require() not in served:
+                divergences.append(
+                    Divergence(
+                        role="frontend",
+                        field="model",
+                        declared=declared,
+                        observed=Fact.known(
+                            served[0] if served else "<none>",
+                            "/v1/models",
+                            f"serving {list(served)}",
+                        ),
+                    )
+                )
+            elif not observed.is_known:
+                divergences.append(Divergence("frontend", "model", declared, observed))
+
+    if [d for d in divergences if not d.is_unverified]:
+        raise Mismatch(divergences)
+
+    return BringUp(
+        site=site,
+        owns=False,
+        checked=tuple(checked),
+        divergences=tuple(divergences),
+    )
+
+
+def _declared_model(stack: Stack) -> Fact[str]:
+    """The model this stack says it serves, from whichever component names one.
+
+    Reads the command line directly rather than through the engine dialect. A
+    frontend declares ``--model`` but runs no engine, so a dialect-only lookup
+    returns UNKNOWN for it — and an UNKNOWN declaration means the comparison is
+    skipped, which silently turns VERIFY into a mode that always succeeds. That
+    is exactly what the negative control caught.
+    """
+    for component in stack.plan:
+        got = component.argv.model()
+        if got.is_known:
+            return got
+    for component in stack.plan:
+        got = component.read("model")
+        if got.is_known:
+            return got
+    return Fact.absent(stack.plan.source, "no component declares a model")
+
+
+def refuse_if_not_owned(site: Site, verb: str) -> None:
+    """Raise if a destructive verb is being attempted on a system we joined.
+
+    A helper rather than a decorator so the call site reads plainly. It raises
+    rather than returning, because the whole hazard is a quiet no-op.
+    """
+    if site.ownership is Ownership.IMPOSE:
+        return
+    raise Refused(
+        verb,
+        site,
+        f"ownership={site.ownership}: this run joined the system rather than "
+        "creating it, so tearing it down would destroy something it does not own",
+    )

--- a/harness/dynamo_test/catalog.py
+++ b/harness/dynamo_test/catalog.py
@@ -1,0 +1,344 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The standard verb catalogue.
+
+Declarations only — no implementation. A provider supplies the behaviour; this
+file is the contract about what the names mean, what each is allowed to do, and
+which of them gate a run.
+
+The set is not invented. It covers the scenario suite's 26 event kinds (each maps
+to exactly one verb, proved in ``tests/test_catalog.py``) plus the reach,
+inference and lifecycle surface the deployment tests already need.
+
+``aliases`` carry the existing document spellings, so scenario YAML written
+against the current event names keeps working while the canonical name is the
+one a reader sees in a plan.
+"""
+
+from __future__ import annotations
+
+from .roles import Role
+from .verbs import Grant, Phase, Receiver, verb
+
+# --------------------------------------------------------------------- reach
+
+url = verb(
+    "url",
+    phase=Phase.ARRANGE,
+    grant=Grant.READ,
+    default_role=Role.FRONTEND,
+    summary="Address of a role's service port, from the test process.",
+)
+address = verb(
+    "address",
+    phase=Phase.ARRANGE,
+    grant=Grant.READ,
+    default_role=Role.FRONTEND,
+    params={"vantage": "who is doing the reaching: test process or in-cluster"},
+    summary="Address of a role, resolved for a given vantage point.",
+)
+models = verb(
+    "models",
+    grant=Grant.READ,
+    default_role=Role.FRONTEND,
+    summary="Model ids the endpoint advertises.",
+)
+
+# ----------------------------------------------------------------- inference
+
+query = verb(
+    "query",
+    grant=Grant.INFER,
+    default_role=Role.FRONTEND,
+    params={"payload": "prompt or request body", "timeout": "seconds"},
+    summary="One completion. The default is the frontend, so most tests say query(...).",
+)
+stream = verb(
+    "stream",
+    grant=Grant.INFER,
+    default_role=Role.FRONTEND,
+    params={"payload": "prompt or request body", "timeout": "seconds"},
+    summary="One streamed completion, collected into chunks plus a finish reason.",
+)
+chat = verb(
+    "chat",
+    grant=Grant.INFER,
+    default_role=Role.FRONTEND,
+    params={"messages": "chat turns", "tools": "tool schemas", "timeout": "seconds"},
+    summary="A chat-completions turn, including tool calls.",
+)
+probe = verb(
+    "probe",
+    grant=Grant.INFER,
+    default_role=Role.FRONTEND,
+    params={
+        "prompt": "text",
+        "n": "how many requests",
+        "unique_prefix": "defeat KV reuse",
+    },
+    summary=(
+        "Several requests with distinct prefixes, grouped by which replica served "
+        "them. A fixed prompt lands on one replica through KV affinity and reads "
+        "100% healthy or 100% broken, which hides a single bad replica."
+    ),
+)
+
+# ---------------------------------------------------- direct-to-component reads
+
+admin = verb(
+    "admin",
+    grant=Grant.READ,
+    params={"route": "path", "method": "HTTP verb", "body": "request body"},
+    summary="A request to a component's own system port.",
+)
+metrics = verb(
+    "metrics",
+    receiver=Receiver.JUDGE,
+    phase=Phase.CHECK,
+    grant=Grant.READ,
+    summary="Metric families scraped from a role. A pure reader: returns data, gates nothing.",
+)
+logs = verb(
+    "logs",
+    receiver=Receiver.JUDGE,
+    phase=Phase.CHECK,
+    grant=Grant.READ,
+    params={"since": "cursor", "previous": "the pre-restart container"},
+    summary="A log slice for a role. A pure reader.",
+)
+exec_in = verb(
+    "exec_in",
+    grant=Grant.READ,
+    params={"argv": "command to run", "timeout": "seconds"},
+    summary="Run a command inside a replica.",
+)
+
+# ------------------------------------------------------------------- waiting
+
+wait = verb(
+    "wait",
+    grant=Grant.READ,
+    takes_selector=False,
+    params={"seconds": "how long"},
+    summary="Advance the timeline.",
+    aliases=("Wait",),
+)
+wait_ready = verb(
+    "wait_ready",
+    phase=Phase.ARRANGE,
+    grant=Grant.READ,
+    params={"timeout": "seconds"},
+    summary="Wait for replicas to report ready.",
+    aliases=("WaitForStablePods",),
+)
+wait_serving = verb(
+    "wait_serving",
+    phase=Phase.ARRANGE,
+    grant=Grant.READ,
+    default_role=Role.FRONTEND,
+    params={"timeout": "seconds", "model": "expected model id"},
+    summary="Wait until the endpoint actually serves the model, not merely until pods are ready.",
+    aliases=("WaitForModelReady",),
+)
+wait_log = verb(
+    "wait_log",
+    grant=Grant.READ,
+    params={"pattern": "regex", "timeout": "seconds"},
+    summary="Wait for a log line.",
+    aliases=("WaitForLogPattern",),
+)
+wait_stable = verb(
+    "wait_stable",
+    grant=Grant.READ,
+    params={"seconds": "quiet period", "timeout": "seconds"},
+    summary="Wait until replica count and restart count stop changing.",
+    aliases=("WaitForRecovery",),
+)
+
+# ----------------------------------------------------------------- lifecycle
+
+start = verb("start", grant=Grant.LIFECYCLE, summary="Start a role's replicas.")
+stop = verb(
+    "stop",
+    grant=Grant.LIFECYCLE,
+    params={"graceful": "send SIGTERM first", "grace": "seconds before SIGKILL"},
+    summary="Stop a role's replicas. Scoped to the role — never the whole deployment.",
+)
+restart = verb(
+    "restart",
+    grant=Grant.LIFECYCLE,
+    params={"settings": "flags to change on the way back up"},
+    summary="Restart a role, optionally with different flags.",
+)
+scale = verb(
+    "scale",
+    grant=Grant.LIFECYCLE,
+    params={"n": "replica count"},
+    summary="Change a role's replica count.",
+)
+reconfigure = verb(
+    "reconfigure",
+    grant=Grant.LIFECYCLE,
+    params={"settings": "live-updatable settings"},
+    summary="Change settings in place, with no restart.",
+    aliases=("SetBusyThreshold",),
+)
+rolling_replace = verb(
+    "rolling_replace",
+    grant=Grant.LIFECYCLE,
+    params={"image": "new image", "max_unavailable": "replicas down at once"},
+    summary="Replace replicas one at a time.",
+    aliases=("RollingReplace", "RollingUpgrade"),
+)
+
+# -------------------------------------------------------------------- faults
+#
+# Every fault declares what its effect proves. A fault whose effect cannot be
+# observed is indistinguishable from one that silently did nothing, and a test
+# built on that passes for the wrong reason.
+
+kill_process = verb(
+    "kill_process",
+    grant=Grant.FAULT,
+    params={"signal": "signal number"},
+    proves=("process_exited", "restart_count_increased"),
+    summary="Signal a process inside a replica.",
+    aliases=("TerminateProcess",),
+)
+stall_process = verb(
+    "stall_process",
+    grant=Grant.FAULT,
+    params={"seconds": "how long, or None to hold until released"},
+    proves=("process_stopped", "process_resumed"),
+    summary="SIGSTOP a process, then resume it.",
+    aliases=("StallProcess",),
+)
+delete_replica = verb(
+    "delete_replica",
+    grant=Grant.FAULT,
+    params={"force": "skip graceful termination"},
+    proves=("replica_deleted", "replica_replaced"),
+    summary="Delete a replica outright.",
+    aliases=("DeletePod",),
+)
+partition = verb(
+    "partition",
+    grant=Grant.FAULT,
+    params={
+        "peer": "the other side",
+        "seconds": "duration",
+        "flush_conntrack": "drop existing flows",
+    },
+    proves=("traffic_blocked", "traffic_restored"),
+    summary="Block traffic between two roles.",
+    aliases=("NetworkPartition",),
+)
+reset_connections = verb(
+    "reset_connections",
+    grant=Grant.FAULT,
+    params={"count": "how many RSTs", "from_inside": "originate inside the pod"},
+    proves=("connections_reset",),
+    summary="Force TCP resets against a role.",
+    aliases=("RstInjection", "RstFromInsidePod"),
+)
+restart_infra = verb(
+    "restart_infra",
+    grant=Grant.INFRA,
+    takes_selector=False,
+    params={"what": "nats or etcd"},
+    summary=(
+        "Restart shared infrastructure. Separate from lifecycle because in a "
+        "shared namespace this breaks tests that are not yours."
+    ),
+)
+inject = verb(
+    "inject",
+    grant=Grant.FAULT,
+    params={"backend": "fault backend", "kind": "fault kind"},
+    proves=("fault_armed", "fault_observed"),
+    summary="A fault delegated to an external injector, such as a GPU Xid.",
+    aliases=("CudaFaultInjection", "UpstreamGpuXidInjection"),
+)
+arm = verb(
+    "arm",
+    phase=Phase.ARRANGE,
+    grant=Grant.FAULT,
+    params={"fault": "what to arm"},
+    proves=("fault_armed",),
+    summary="Prepare a fault before readiness, for faults that must exist at start-up.",
+    aliases=("PrepareCudaFaultInjection",),
+)
+
+# ------------------------------------------------------------------ producers
+
+capture = verb(
+    "capture",
+    phase=Phase.COLLECT,
+    grant=Grant.READ,
+    takes_selector=False,
+    params={"what": "evidence kind", "tag": "label for the artifact"},
+    summary="Collect evidence into the bundle.",
+    aliases=("CaptureMetrics", "PrintProcessTree"),
+)
+monitor = verb(
+    "monitor",
+    grant=Grant.READ,
+    params={"interval": "seconds between samples", "include": "which resources"},
+    summary="Sample resource usage in the background for the rest of the timeline.",
+    aliases=("ResourceMonitor", "PeriodicSnapshot"),
+)
+run_command = verb(
+    "run_command",
+    grant=Grant.READ,
+    takes_selector=False,
+    params={"argv": "command", "timeout": "seconds"},
+    summary="Run a command on the test host, recorded in the timeline.",
+    aliases=("RunCommand",),
+)
+
+# ----------------------------------------------------------------------- load
+
+start_load = verb(
+    "start_load",
+    grant=Grant.INFER,
+    default_role=Role.FRONTEND,
+    params={"workload": "what to send", "name": "handle for later reference"},
+    summary="Begin a background load generator.",
+    aliases=("StartLoad",),
+)
+stop_load = verb(
+    "stop_load",
+    grant=Grant.INFER,
+    takes_selector=False,
+    params={"name": "which load"},
+    summary="Stop a background load generator.",
+    aliases=("StopLoad",),
+)
+await_load = verb(
+    "await_load",
+    grant=Grant.READ,
+    takes_selector=False,
+    params={"name": "which load", "timeout": "seconds"},
+    summary="Wait for a load generator to finish.",
+    aliases=("WaitForLoadCompletion",),
+)
+
+# ------------------------------------------------- in-timeline ACT assertions
+#
+# require_* raises immediately and records. Distinct from expect_*, which is
+# evaluated after the fact against collected evidence.
+
+require_restarted = verb(
+    "require_restarted",
+    grant=Grant.READ,
+    params={"since": "handle to compare against", "within": "seconds"},
+    summary="Assert now that a role restarted since a point in the timeline.",
+    aliases=("AssertPodsRestarted",),
+)
+require_replaced = verb(
+    "require_replaced",
+    grant=Grant.READ,
+    params={"since": "handle to compare against", "within": "seconds"},
+    summary="Assert now that replicas were replaced, not merely restarted.",
+)

--- a/harness/dynamo_test/dialect.py
+++ b/harness/dynamo_test/dialect.py
@@ -1,0 +1,334 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Saying what you mean, once, across three engines that spell it differently.
+
+A test that wants a 4096-token context should not have to know that vLLM calls
+that ``--max-model-len``, SGLang calls it ``--context-length``, and TensorRT-LLM
+calls it ``--max-seq-len``. It says ``context_length=4096`` and the dialect
+emits the right flag.
+
+## Read every spelling, write one
+
+The mapping is not one-to-one, and that is measured rather than assumed. Across
+the worker containers in ``recipes/`` and ``examples/``, identified by the module
+they actually launch:
+
+============ =============================== ===============================
+semantic     engine                          spellings found
+============ =============================== ===============================
+model        vLLM                            ``--model`` ×109
+             SGLang                          ``--model-path`` ×23
+             **TensorRT-LLM**                ``--model-path`` ×29 **and**
+                                             ``--model`` ×12
+tensor       vLLM                            ``--tensor-parallel-size`` ×104
+parallel     **SGLang**                      ``--tp`` ×10 **and**
+                                             ``--tensor-parallel-size`` ×7
+             TensorRT-LLM                    ``--tensor-parallel-size`` ×15
+============ =============================== ===============================
+
+So a helper that knows only ``--tensor-parallel-size`` misses 10 of SGLang's 17
+workers, and one that knows only ``--model-path`` misses 12 of TensorRT-LLM's 41.
+Reading has to accept every spelling the engine accepts; writing picks the
+canonical one. Those are different lists, and conflating them is what makes a
+scan report a flag as absent when it is right there.
+
+## Flags that take no value
+
+``--enforce-eager`` is a switch. Emitting ``--enforce-eager True`` is rejected by
+the engine, and it is a defect the existing helpers have. A semantic declared
+:data:`SWITCH` emits the bare flag when true and nothing when false.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol, Sequence, runtime_checkable
+
+from .argv import ArgV
+from .facts import Fact
+from .roles import Process
+
+__all__ = [
+    "SWITCH",
+    "Semantic",
+    "EngineDialect",
+    "Dialect",
+    "VLLM",
+    "SGLANG",
+    "TRTLLM",
+    "DIALECTS",
+    "for_backend",
+    "UnknownSemantic",
+]
+
+
+class _Switch:
+    """Marker for a flag that takes no value."""
+
+    def __repr__(self) -> str:
+        return "SWITCH"
+
+
+SWITCH = _Switch()
+
+
+class UnknownSemantic(KeyError):
+    def __init__(self, name: object, backend: str, known: Sequence[str]) -> None:
+        super().__init__(
+            f"{backend} has no setting called {name!r}; it knows: "
+            f"{', '.join(sorted(known))}"
+        )
+
+
+@dataclass(frozen=True)
+class Semantic:
+    """One tunable, and how this engine spells it.
+
+    ``write`` is the canonical flag. ``read`` lists every spelling the engine
+    accepts, canonical first — a manifest may use any of them.
+    """
+
+    write: str
+    read: tuple[str, ...] = ()
+    switch: bool = False
+
+    @property
+    def spellings(self) -> tuple[str, ...]:
+        return (self.write,) + tuple(r for r in self.read if r != self.write)
+
+
+@runtime_checkable
+class EngineDialect(Protocol):
+    """What a backend must tell the harness about itself."""
+
+    backend: str
+
+    def flag(self, semantic: str, value: Any) -> tuple[str, ...]:
+        ...
+
+    def read(self, argv: ArgV, semantic: str) -> Fact[str]:
+        ...
+
+    def process_pattern(self, process: Process) -> str | None:
+        ...
+
+
+@dataclass(frozen=True)
+class Dialect:
+    """A concrete engine dialect: a name, a settings table, process patterns.
+
+    ``config_flags`` are flags that move settings out of the command line and
+    into a file. When one is present, a setting missing from argv is not
+    *absent* — it is somewhere this reader cannot see.
+    """
+
+    backend: str
+    settings: Mapping[str, Semantic]
+    processes: Mapping[Process, str] = None  # type: ignore[assignment]
+    config_flags: tuple[str, ...] = ("--config",)
+
+    def __post_init__(self) -> None:
+        if self.processes is None:
+            object.__setattr__(self, "processes", {})
+
+    def _deferred_to(self, argv: ArgV) -> str | None:
+        """The config flag this command defers settings to, if any."""
+        for flag in self.config_flags:
+            fact = argv.get(flag)
+            if fact.is_known:
+                return f"{flag} {fact.require()}"
+            if argv.has(flag).or_else(False):
+                return flag
+        return None
+
+    def semantic(self, name: str) -> Semantic:
+        try:
+            return self.settings[name]
+        except KeyError:
+            raise UnknownSemantic(name, self.backend, list(self.settings)) from None
+
+    def flag(self, semantic: str, value: Any) -> tuple[str, ...]:
+        """The argv fragment that sets ``semantic`` to ``value``.
+
+        A switch emits the bare flag, or nothing at all when false. Emitting
+        ``--enforce-eager True`` is rejected by the engine.
+        """
+        spec = self.semantic(semantic)
+        if spec.switch:
+            if not isinstance(value, bool):
+                raise TypeError(
+                    f"{self.backend}.{semantic} is a switch; pass True or False, "
+                    f"not {value!r}"
+                )
+            return (spec.write,) if value else ()
+        if isinstance(value, bool):
+            raise TypeError(
+                f"{self.backend}.{semantic} takes a value, not a bool; a bool here "
+                f"would emit '{spec.write} {value}', which the engine rejects"
+            )
+        return (spec.write, str(value))
+
+    def read(self, argv: ArgV, semantic: str) -> Fact[str]:
+        """Read ``semantic`` from a command line, trying every spelling.
+
+        Unparseable input propagates as ``UNKNOWN``. Absence is only reported
+        after every spelling this engine accepts has been tried, and the detail
+        says which — so "not set" is a claim with its working shown.
+        """
+        spec = self.semantic(semantic)
+        tried: list[str] = []
+        for flag in spec.spellings:
+            fact = argv.get(flag)
+            if fact.is_unknown:
+                return fact
+            if fact.is_known:
+                return fact
+            tried.append(flag)
+        if spec.switch:
+            present = argv.has(spec.write)
+            if present.is_unknown:
+                return present
+        deferred = self._deferred_to(argv)
+        if deferred is not None:
+            # Not absent: the command hands its settings to a file this reader
+            # cannot open. Saying "not set" here would be a false statement, and
+            # 4 SGLang workers plus every TensorRT-LLM worker using
+            # --extra-engine-args are configured exactly this way.
+            return Fact.unknown(
+                argv.source,
+                f"{self.backend}.{semantic} is not on the command line, which "
+                f"defers to '{deferred}'; read the config to answer this",
+            )
+        return Fact.absent(
+            argv.source,
+            f"{self.backend}.{semantic} is not set; tried {', '.join(tried)}",
+        )
+
+    def apply(self, argv: ArgV, **settings: Any) -> ArgV:
+        """Set several semantics at once, replacing rather than appending."""
+        for name, value in settings.items():
+            spec = self.semantic(name)
+            if spec.switch:
+                argv = argv.set(spec.write, bool(value))
+            else:
+                argv = argv.set(spec.write, str(value))
+        return argv
+
+    def process_pattern(self, process: Process) -> str | None:
+        return self.processes.get(process)
+
+    def names(self) -> tuple[str, ...]:
+        return tuple(sorted(self.settings))
+
+
+def _s(write: str, *read: str, switch: bool = False) -> Semantic:
+    return Semantic(write=write, read=(write,) + read, switch=switch)
+
+
+# Counts in the comments are worker containers in recipes/ + examples/,
+# identified by the module they launch.
+
+VLLM = Dialect(
+    backend="vllm",
+    settings={
+        "model": _s("--model"),  # 109
+        "served_model_name": _s("--served-model-name"),
+        "context_length": _s("--max-model-len"),  # 80
+        "tensor_parallel": _s("--tensor-parallel-size"),  # 104
+        "pipeline_parallel": _s("--pipeline-parallel-size"),  # 14
+        "data_parallel": _s("--data-parallel-size"),  # 24
+        "gpu_memory_fraction": _s("--gpu-memory-utilization"),  # 89
+        "max_batch_size": _s("--max-num-seqs"),  # 69
+        "max_batched_tokens": _s("--max-num-batched-tokens"),  # 60
+        "kv_cache_dtype": _s("--kv-cache-dtype"),  # 57
+        "eager": _s("--enforce-eager", switch=True),  # 8, takes no value
+        "trust_remote_code": _s("--trust-remote-code", switch=True),
+        "expert_parallel": _s("--enable-expert-parallel", switch=True),  # 23
+        "tool_parser": _s("--dyn-tool-call-parser", "--tool-call-parser"),  # 82 / 4
+        "reasoning_parser": _s("--dyn-reasoning-parser", "--reasoning-parser"),
+    },
+    processes={Process.MAIN: "dynamo.vllm", Process.ENGINE: "VLLM::EngineCore"},
+)
+
+SGLANG = Dialect(
+    backend="sglang",
+    settings={
+        "model": _s("--model-path"),  # 23
+        "served_model_name": _s("--served-model-name"),
+        "context_length": _s("--context-length"),  # 3
+        # Both spellings are live: --tp x10, --tensor-parallel-size x7. Reading
+        # only the canonical one misses 10 of 17 SGLang workers.
+        "tensor_parallel": _s("--tp", "--tensor-parallel-size", "--tp-size"),
+        "data_parallel": _s("--data-parallel-size", "--dp", "--dp-size"),
+        "gpu_memory_fraction": _s("--mem-fraction-static"),  # 12
+        "max_batch_size": _s("--max-running-requests"),  # 7
+        "max_batched_tokens": _s("--chunked-prefill-size"),  # 11
+        "kv_cache_dtype": _s("--kv-cache-dtype"),
+        "eager": _s("--disable-cuda-graph", switch=True),
+        "trust_remote_code": _s("--trust-remote-code", switch=True),
+        "tool_parser": _s("--dyn-tool-call-parser", "--tool-call-parser"),
+        "reasoning_parser": _s("--dyn-reasoning-parser", "--reasoning-parser"),
+    },
+    processes={Process.MAIN: "dynamo.sglang", Process.ENGINE: "sglang::scheduler"},
+)
+
+TRTLLM = Dialect(
+    backend="trtllm",
+    settings={
+        # Both spellings are live: --model-path x29, --model x12.
+        "model": _s("--model-path", "--model"),
+        "served_model_name": _s("--served-model-name"),
+        "context_length": _s("--max-seq-len"),  # 17
+        "tensor_parallel": _s("--tensor-parallel-size", "--tp"),  # 15
+        "gpu_memory_fraction": _s("--free-gpu-memory-fraction"),  # 5
+        "max_batch_size": _s("--max-batch-size"),  # 29
+        "max_batched_tokens": _s("--max-num-tokens"),  # 24
+        "kv_cache_dtype": _s("--kv-cache-dtype"),
+        "trust_remote_code": _s("--trust-remote-code", switch=True),
+        "extra_engine_args": _s("--extra-engine-args"),  # 49
+        "tool_parser": _s("--dyn-tool-call-parser", "--tool-call-parser"),
+        "reasoning_parser": _s("--dyn-reasoning-parser", "--reasoning-parser"),
+    },
+    processes={Process.MAIN: "dynamo.trtllm", Process.ENGINE: "trtllm_worker"},
+    config_flags=("--config", "--extra-engine-args"),
+)
+
+DIALECTS: Mapping[str, Dialect] = {d.backend: d for d in (VLLM, SGLANG, TRTLLM)}
+
+
+def for_backend(backend: str) -> Dialect:
+    try:
+        return DIALECTS[backend.lower()]
+    except KeyError:
+        raise KeyError(
+            f"no dialect for {backend!r}; known: {', '.join(sorted(DIALECTS))}"
+        ) from None
+
+
+def detect(argv: ArgV) -> Fact[str]:
+    """Which engine a command line launches, read from ``python -m dynamo.X``.
+
+    Deliberately not a substring search over the whole command. Matching
+    ``"vllm"`` anywhere picks up image names and environment variables, and it
+    mis-attributed 12 TensorRT-LLM containers when this was first measured that
+    way.
+    """
+    if not argv.is_parseable:
+        return Fact.unknown(
+            argv.source, f"command could not be tokenised: {argv.parse_error}"
+        )
+    tokens = [t.text for t in argv.tokens() if t.kind.value == "word"]
+    for i, token in enumerate(tokens):
+        if token != "-m" or i + 1 >= len(tokens):
+            continue
+        module = tokens[i + 1]
+        if not module.startswith("dynamo."):
+            continue
+        backend = module.split(".", 1)[1]
+        if backend in DIALECTS:
+            return Fact.known(backend, argv.source, f"launches {module}")
+        return Fact.absent(
+            argv.source, f"launches {module}, which is not an inference engine"
+        )
+    return Fact.absent(argv.source, "no 'python -m dynamo.<engine>' invocation found")

--- a/harness/dynamo_test/dialect.py
+++ b/harness/dynamo_test/dialect.py
@@ -11,27 +11,36 @@ emits the right flag.
 ## Read every spelling, write one
 
 The mapping is not one-to-one, and that is measured rather than assumed. Across
-the worker containers in ``recipes/`` and ``examples/``, identified by the module
-they actually launch:
+the 312 engine workers in ``recipes/`` and ``examples/`` — identified by the
+module each actually launches — three settings have more than one live
+spelling:
 
-============ =============================== ===============================
-semantic     engine                          spellings found
-============ =============================== ===============================
-model        vLLM                            ``--model`` ×109
-             SGLang                          ``--model-path`` ×23
-             **TensorRT-LLM**                ``--model-path`` ×29 **and**
-                                             ``--model`` ×12
-tensor       vLLM                            ``--tensor-parallel-size`` ×104
-parallel     **SGLang**                      ``--tp`` ×10 **and**
-                                             ``--tensor-parallel-size`` ×7
-             TensorRT-LLM                    ``--tensor-parallel-size`` ×15
-============ =============================== ===============================
+=============== ============= =========================================
+setting         engine        spellings in use
+=============== ============= =========================================
+model           vLLM          ``--model`` x202
+                SGLang        ``--model-path`` x45
+                TensorRT-LLM  ``--model-path`` x44 **and** ``--model`` x12
+tensor_parallel vLLM          ``--tensor-parallel-size`` x164
+                **SGLang**    ``--tp`` x30, ``--tensor-parallel-size`` x7,
+                              **and** ``--tp-size`` x2
+                TensorRT-LLM  ``--tensor-parallel-size`` x15
+=============== ============= =========================================
 
-So a helper that knows only ``--tensor-parallel-size`` misses 10 of SGLang's 17
-workers, and one that knows only ``--model-path`` misses 12 of TensorRT-LLM's 41.
-Reading has to accept every spelling the engine accepts; writing picks the
-canonical one. Those are different lists, and conflating them is what makes a
-scan report a flag as absent when it is right there.
+So a reader that knows only the canonical ``--tensor-parallel-size`` finds it in
+7 of the 39 SGLang workers that set tensor parallelism, and one that knows only
+``--model-path`` misses 12 of TensorRT-LLM's 56. Reading has to accept every
+spelling the engine accepts; writing picks one. Those are different lists, and
+conflating them is what makes a scan report a flag as absent when it is right
+there.
+
+## Settings that are not on the command line at all
+
+**All 56** TensorRT-LLM workers pass ``--extra-engine-args``, and 12 SGLang
+workers pass ``--config``. Their settings live in a file this reader cannot
+open. Answering "not set" for those would be a false statement, so a setting
+missing from a command that defers to a file is reported ``UNKNOWN``, naming the
+file — never ``ABSENT``.
 
 ## Flags that take no value
 
@@ -193,8 +202,8 @@ class Dialect:
         if deferred is not None:
             # Not absent: the command hands its settings to a file this reader
             # cannot open. Saying "not set" here would be a false statement, and
-            # 4 SGLang workers plus every TensorRT-LLM worker using
-            # --extra-engine-args are configured exactly this way.
+            # 12 SGLang workers and all 56 TensorRT-LLM workers are
+            # configured exactly this way.
             return Fact.unknown(
                 argv.source,
                 f"{self.backend}.{semantic} is not on the command line, which "
@@ -232,17 +241,17 @@ def _s(write: str, *read: str, switch: bool = False) -> Semantic:
 VLLM = Dialect(
     backend="vllm",
     settings={
-        "model": _s("--model"),  # 109
+        "model": _s("--model"),  # 202 of 205 vLLM workers
         "served_model_name": _s("--served-model-name"),
-        "context_length": _s("--max-model-len"),  # 80
-        "tensor_parallel": _s("--tensor-parallel-size"),  # 104
+        "context_length": _s("--max-model-len"),  # 110
+        "tensor_parallel": _s("--tensor-parallel-size"),  # 164
         "pipeline_parallel": _s("--pipeline-parallel-size"),  # 14
         "data_parallel": _s("--data-parallel-size"),  # 24
-        "gpu_memory_fraction": _s("--gpu-memory-utilization"),  # 89
-        "max_batch_size": _s("--max-num-seqs"),  # 69
-        "max_batched_tokens": _s("--max-num-batched-tokens"),  # 60
+        "gpu_memory_fraction": _s("--gpu-memory-utilization"),  # 114
+        "max_batch_size": _s("--max-num-seqs"),  # 96
+        "max_batched_tokens": _s("--max-num-batched-tokens"),  # 87
         "kv_cache_dtype": _s("--kv-cache-dtype"),  # 57
-        "eager": _s("--enforce-eager", switch=True),  # 8, takes no value
+        "eager": _s("--enforce-eager", switch=True),  # 14, takes no value
         "trust_remote_code": _s("--trust-remote-code", switch=True),
         "expert_parallel": _s("--enable-expert-parallel", switch=True),  # 23
         "tool_parser": _s("--dyn-tool-call-parser", "--tool-call-parser"),  # 82 / 4
@@ -254,16 +263,16 @@ VLLM = Dialect(
 SGLANG = Dialect(
     backend="sglang",
     settings={
-        "model": _s("--model-path"),  # 23
+        "model": _s("--model-path"),  # 45
         "served_model_name": _s("--served-model-name"),
         "context_length": _s("--context-length"),  # 3
-        # Both spellings are live: --tp x10, --tensor-parallel-size x7. Reading
-        # only the canonical one misses 10 of 17 SGLang workers.
+        # Three spellings are live: --tp x30, --tensor-parallel-size x7,
+        # --tp-size x2. Reading only the canonical one finds 7 of 39.
         "tensor_parallel": _s("--tp", "--tensor-parallel-size", "--tp-size"),
         "data_parallel": _s("--data-parallel-size", "--dp", "--dp-size"),
-        "gpu_memory_fraction": _s("--mem-fraction-static"),  # 12
+        "gpu_memory_fraction": _s("--mem-fraction-static"),  # 19
         "max_batch_size": _s("--max-running-requests"),  # 7
-        "max_batched_tokens": _s("--chunked-prefill-size"),  # 11
+        "max_batched_tokens": _s("--chunked-prefill-size"),  # 15
         "kv_cache_dtype": _s("--kv-cache-dtype"),
         "eager": _s("--disable-cuda-graph", switch=True),
         "trust_remote_code": _s("--trust-remote-code", switch=True),
@@ -276,7 +285,7 @@ SGLANG = Dialect(
 TRTLLM = Dialect(
     backend="trtllm",
     settings={
-        # Both spellings are live: --model-path x29, --model x12.
+        # Both spellings are live: --model-path x44, --model x12.
         "model": _s("--model-path", "--model"),
         "served_model_name": _s("--served-model-name"),
         "context_length": _s("--max-seq-len"),  # 17
@@ -286,7 +295,7 @@ TRTLLM = Dialect(
         "max_batched_tokens": _s("--max-num-tokens"),  # 24
         "kv_cache_dtype": _s("--kv-cache-dtype"),
         "trust_remote_code": _s("--trust-remote-code", switch=True),
-        "extra_engine_args": _s("--extra-engine-args"),  # 49
+        "extra_engine_args": _s("--extra-engine-args"),  # all 56 TRT-LLM workers
         "tool_parser": _s("--dyn-tool-call-parser", "--tool-call-parser"),
         "reasoning_parser": _s("--dyn-reasoning-parser", "--reasoning-parser"),
     },
@@ -313,12 +322,17 @@ def detect(argv: ArgV) -> Fact[str]:
     ``"vllm"`` anywhere picks up image names and environment variables, and it
     mis-attributed 12 TensorRT-LLM containers when this was first measured that
     way.
+
+    Reads the *whole* invocation, not just ``args``. v1alpha1 manifests put the
+    program in ``command`` (``[python3, -m, dynamo.sglang]``) and only its flags
+    in ``args``, so scanning ``args`` alone identifies no engine at all for
+    them.
     """
     if not argv.is_parseable:
         return Fact.unknown(
             argv.source, f"command could not be tokenised: {argv.parse_error}"
         )
-    tokens = [t.text for t in argv.tokens() if t.kind.value == "word"]
+    tokens = list(argv.invocation())
     for i, token in enumerate(tokens):
         if token != "-m" or i + 1 >= len(tokens):
             continue

--- a/harness/dynamo_test/evidence.py
+++ b/harness/dynamo_test/evidence.py
@@ -1,0 +1,591 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Collecting evidence, sealing it, and judging it afterwards.
+
+A run has two questions to answer and they are not the same one:
+
+*Did the system under test behave?* — the **verdict**.
+*Did we actually measure it?* — the **validity** of the run.
+
+Conflating them is how a suite reports green after collecting nothing. A check
+that globs for a log file, finds none, and concludes "no errors" has answered the
+first question using the failure of the second.
+
+So collection and judgement are separated by a seal:
+
+**COLLECT** — a :class:`Recorder` *declares* what it intends to produce, then
+produces it. Declaring first is what makes a missing artifact detectable: without
+a promise there is nothing for absence to contradict.
+
+**CHECK** — an :class:`Evidence` view over a sealed bundle. It is read-only,
+synchronous, and needs no cluster, so the same judgement runs in CI and hours
+later on a laptop from the bundle directory alone. Checks resolve artifacts
+**through the producer index, never by globbing** — an artifact nobody declared
+is `UNKNOWN`, and a glob that matches nothing is indistinguishable from a
+measurement of nothing.
+
+The seal compares promises to delivery. An artifact that was declared and never
+arrived, or that arrived with fewer rows than promised, makes the run
+`INVALID` — which is a different outcome from `FAILED`, and must be, because
+re-running is the right response to one and filing a bug is the right response
+to the other.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Mapping, Sequence
+
+from .facts import Fact
+
+__all__ = [
+    "Verdict",
+    "Outcome",
+    "Producer",
+    "Promise",
+    "Seal",
+    "Recorder",
+    "Evidence",
+    "BundleError",
+    "Sealed",
+    "NotDeclared",
+    "SCHEMA_VERSION",
+]
+
+SCHEMA_VERSION = 1
+
+
+class BundleError(Exception):
+    """The evidence bundle was used in a way that would produce a wrong answer."""
+
+
+class Sealed(BundleError):
+    """A write was attempted after the bundle was sealed."""
+
+
+class NotDeclared(BundleError):
+    """An artifact was written that nothing declared."""
+
+
+class Verdict(str, Enum):
+    """What a run concluded, in precedence order.
+
+    ``INVALID`` outranks ``FAILED`` deliberately. If the measurement did not
+    happen, the system under test has not been judged, and reporting a failure
+    would attribute a harness problem to the product.
+    """
+
+    INVALID = "invalid"
+    FAILED = "failed"
+    PASSED = "passed"
+    OBSERVED = "observed"
+    SKIPPED = "skipped"
+
+    @property
+    def rank(self) -> int:
+        return _RANK[self]
+
+    @property
+    def exit_code(self) -> int:
+        return _EXIT[self]
+
+
+_RANK = {
+    Verdict.INVALID: 0,
+    Verdict.FAILED: 1,
+    Verdict.PASSED: 2,
+    Verdict.OBSERVED: 3,
+    Verdict.SKIPPED: 4,
+}
+
+# Distinct codes so a CI lane can retry an invalid run and escalate a failed one.
+_EXIT = {
+    Verdict.INVALID: 3,
+    Verdict.FAILED: 1,
+    Verdict.PASSED: 0,
+    Verdict.OBSERVED: 0,
+    Verdict.SKIPPED: 0,
+}
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """One judgement: what was asked, what was found, and what it counts as."""
+
+    check: str
+    verdict: Verdict
+    detail: str = ""
+    evidence: tuple[str, ...] = ()
+
+    def to_record(self) -> dict:
+        return {
+            "check": self.check,
+            "verdict": self.verdict.value,
+            "detail": self.detail,
+            "evidence": list(self.evidence),
+        }
+
+
+def combine(outcomes: Iterable[Outcome]) -> Verdict:
+    """The run's verdict: the most severe outcome present.
+
+    An empty set of outcomes is ``INVALID``, not ``PASSED``. A run that judged
+    nothing has not established that anything works, and reporting success for it
+    is the largest false green available.
+    """
+    outcomes = list(outcomes)
+    if not outcomes:
+        return Verdict.INVALID
+    return min((o.verdict for o in outcomes), key=lambda v: v.rank)
+
+
+@dataclass(frozen=True)
+class Producer:
+    """Who made an artifact, and with what."""
+
+    artifact: str
+    producer: str
+    tool: str = ""
+    tool_version: str = ""
+
+    def to_record(self) -> dict:
+        return {
+            "producer": self.producer,
+            "tool": self.tool,
+            "tool_version": self.tool_version,
+        }
+
+
+@dataclass(frozen=True)
+class Promise:
+    """What a producer said it would deliver, before it delivered it.
+
+    ``min_rows`` is the part that matters. "The file exists" is a weak promise —
+    an empty ``requests.jsonl`` satisfies it while proving nothing. A load
+    generator that promises at least one record and delivers none has not
+    measured the system, and the run is invalid rather than passing.
+    """
+
+    artifact: str
+    producer: str
+    min_rows: int | None = None
+    required: bool = True
+
+    def to_record(self) -> dict:
+        return {
+            "producer": self.producer,
+            "min_rows": self.min_rows,
+            "required": self.required,
+        }
+
+
+@dataclass(frozen=True)
+class Seal:
+    """Declared promises against measured delivery."""
+
+    kept: tuple[str, ...] = ()
+    missing: tuple[str, ...] = ()
+    short: tuple[tuple[str, int, int], ...] = ()  # (artifact, promised, actual)
+    undeclared: tuple[str, ...] = ()
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.missing and not self.short
+
+    def verdict(self) -> Verdict:
+        return Verdict.PASSED if self.is_valid else Verdict.INVALID
+
+    def why(self) -> str:
+        parts = []
+        if self.missing:
+            parts.append(f"declared but never written: {', '.join(self.missing)}")
+        if self.short:
+            parts.append(
+                "fewer rows than promised: "
+                + ", ".join(f"{a} promised {p}, got {g}" for a, p, g in self.short)
+            )
+        if self.undeclared:
+            parts.append(f"written without a promise: {', '.join(self.undeclared)}")
+        return "; ".join(parts) or "every promise kept"
+
+    def to_record(self) -> dict:
+        return {
+            "valid": self.is_valid,
+            "kept": list(self.kept),
+            "missing": list(self.missing),
+            "short": [list(s) for s in self.short],
+            "undeclared": list(self.undeclared),
+            "why": self.why(),
+        }
+
+
+class Recorder:
+    """The COLLECT phase: declare, then write, then seal.
+
+    Runs before teardown, unconditionally — including when the test has already
+    failed, because a failed run is exactly when its evidence matters most.
+    """
+
+    def __init__(self, root: str | Path, run_id: str) -> None:
+        self.root = Path(root) / run_id
+        self.run_id = run_id
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._promises: dict[str, Promise] = {}
+        self._producers: dict[str, Producer] = {}
+        self._rows: dict[str, int] = {}
+        self._sealed = False
+        self._meta: dict[str, Any] = {}
+
+    # ------------------------------------------------------------- declare
+
+    def declare(
+        self,
+        artifact: str,
+        producer: str,
+        *,
+        min_rows: int | None = None,
+        required: bool = True,
+        tool: str = "",
+        tool_version: str = "",
+    ) -> Promise:
+        """Promise an artifact before producing it.
+
+        Declaring is not bookkeeping. It is what turns "the file is not there"
+        from an unanswerable question into a contradiction of a specific claim.
+        """
+        self._refuse_if_sealed(f"declare {artifact!r}")
+        promise = Promise(artifact, producer, min_rows=min_rows, required=required)
+        self._promises[artifact] = promise
+        self._producers[artifact] = Producer(artifact, producer, tool, tool_version)
+        return promise
+
+    # --------------------------------------------------------------- write
+
+    def write_text(self, artifact: str, text: str) -> Path:
+        path = self._path_for(artifact)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+        self._rows[artifact] = text.count("\n") + (0 if text.endswith("\n") else 1)
+        if not text:
+            self._rows[artifact] = 0
+        return path
+
+    def write_json(self, artifact: str, payload: Any) -> Path:
+        path = self._path_for(artifact)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str))
+        self._rows[artifact] = len(payload) if isinstance(payload, (list, dict)) else 1
+        return path
+
+    def write_rows(self, artifact: str, rows: Sequence[Mapping[str, Any]]) -> Path:
+        """Write JSONL. The row count is what a promise is checked against."""
+        path = self._path_for(artifact)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w") as fh:
+            for row in rows:
+                fh.write(json.dumps(row, sort_keys=True, default=str) + "\n")
+        self._rows[artifact] = len(rows)
+        return path
+
+    def append_row(self, artifact: str, row: Mapping[str, Any]) -> None:
+        path = self._path_for(artifact)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a") as fh:
+            fh.write(json.dumps(row, sort_keys=True, default=str) + "\n")
+        self._rows[artifact] = self._rows.get(artifact, 0) + 1
+
+    def note(self, key: str, value: Any) -> None:
+        """Record run-level metadata: plan digest, site, roles, grants."""
+        self._refuse_if_sealed(f"note {key!r}")
+        self._meta[key] = value
+
+    # ---------------------------------------------------------------- seal
+
+    def seal(self) -> Seal:
+        """Close the bundle and compare promises to delivery."""
+        if self._sealed:
+            raise Sealed(f"{self.run_id} is already sealed")
+
+        kept, missing, short = [], [], []
+        for artifact, promise in sorted(self._promises.items()):
+            path = self._path_for(artifact)
+            if not path.exists():
+                if promise.required:
+                    missing.append(artifact)
+                continue
+            rows = self._rows.get(artifact, 0)
+            if promise.min_rows is not None and rows < promise.min_rows:
+                short.append((artifact, promise.min_rows, rows))
+                continue
+            kept.append(artifact)
+
+        undeclared = sorted(set(self._written()) - set(self._promises))
+        seal = Seal(
+            kept=tuple(kept),
+            missing=tuple(missing),
+            short=tuple(short),
+            undeclared=tuple(undeclared),
+        )
+
+        (self.root / "producers.json").write_text(
+            json.dumps(
+                {a: p.to_record() for a, p in sorted(self._producers.items())},
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        (self.root / "declared.json").write_text(
+            json.dumps(
+                {a: p.to_record() for a, p in sorted(self._promises.items())},
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        (self.root / "run.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "run_id": self.run_id,
+                    "seal": seal.to_record(),
+                    "rows": dict(sorted(self._rows.items())),
+                    **self._meta,
+                },
+                indent=2,
+                sort_keys=True,
+                default=str,
+            )
+        )
+        self._sealed = True
+        return seal
+
+    # -------------------------------------------------------------- helpers
+
+    def _path_for(self, artifact: str) -> Path:
+        self._refuse_if_sealed(f"write {artifact!r}")
+        if artifact not in self._promises:
+            raise NotDeclared(
+                f"{artifact!r} was written but never declared. Call declare() first "
+                "— an artifact with no promise cannot be checked for absence, which "
+                "is the whole point of the seal."
+            )
+        if os.path.isabs(artifact) or ".." in Path(artifact).parts:
+            raise BundleError(f"artifact name must be a relative path: {artifact!r}")
+        return self.root / artifact
+
+    def _written(self) -> list[str]:
+        out = []
+        for path in self.root.rglob("*"):
+            if path.is_file() and path.name not in {
+                "run.json",
+                "producers.json",
+                "declared.json",
+                "findings.json",
+            }:
+                out.append(str(path.relative_to(self.root)))
+        return out
+
+    def _refuse_if_sealed(self, action: str) -> None:
+        if self._sealed:
+            raise Sealed(
+                f"cannot {action}: {self.run_id} is sealed. Collection happens "
+                "before the seal; judgement happens after it, and mixing them "
+                "makes a run unreplayable."
+            )
+
+    def evidence(self) -> "Evidence":
+        """The read view. Legal only once sealed."""
+        if not self._sealed:
+            raise BundleError(
+                f"{self.run_id} is not sealed; call seal() at the end of COLLECT. "
+                "Judging a bundle still being written gives a different answer on "
+                "a replay."
+            )
+        return Evidence(self.root)
+
+
+class Evidence:
+    """The CHECK phase: a read-only view over a sealed bundle.
+
+    Synchronous and free of I/O beyond the bundle directory, so the same
+    judgement runs in CI and later on a laptop with only the directory. Nothing
+    here can reach the system under test — by the time checks run, it may not
+    exist.
+    """
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        run = self.root / "run.json"
+        if not run.exists():
+            raise BundleError(
+                f"{self.root} has no run.json; it is not a sealed evidence bundle"
+            )
+        self.run = json.loads(run.read_text())
+        self.producers: dict[str, dict] = json.loads(
+            (self.root / "producers.json").read_text()
+        )
+        self.declared: dict[str, dict] = json.loads(
+            (self.root / "declared.json").read_text()
+        )
+
+    @classmethod
+    def open(cls, root: str | Path) -> "Evidence":
+        return cls(root)
+
+    @property
+    def run_id(self) -> str:
+        return self.run.get("run_id", "<unknown>")
+
+    @property
+    def seal(self) -> Seal:
+        s = self.run.get("seal", {})
+        return Seal(
+            kept=tuple(s.get("kept", [])),
+            missing=tuple(s.get("missing", [])),
+            short=tuple(tuple(x) for x in s.get("short", [])),
+            undeclared=tuple(s.get("undeclared", [])),
+        )
+
+    # ---------------------------------------------------------------- reads
+
+    def _resolve(self, artifact: str) -> Fact[Path]:
+        """Locate an artifact through the producer index, never by globbing.
+
+        A glob that matches nothing and an artifact that was never produced look
+        identical to the caller. Going through the index means "not collected"
+        is a distinct, reportable answer.
+        """
+        if artifact not in self.producers:
+            return Fact.unknown(
+                f"{self.run_id}/{artifact}",
+                f"nothing declared this artifact; the run produced: "
+                f"{', '.join(sorted(self.producers)) or '<nothing>'}",
+            )
+        path = self.root / artifact
+        if not path.exists():
+            return Fact.unknown(
+                f"{self.run_id}/{artifact}",
+                f"declared by {self.producers[artifact]['producer']} but never written",
+            )
+        return Fact.known(path, f"{self.run_id}/{artifact}")
+
+    def text(self, artifact: str) -> Fact[str]:
+        path = self._resolve(artifact)
+        if not path.is_known:
+            return Fact.unknown(path.source, path.detail)
+        return Fact.known(path.require().read_text(), path.source)
+
+    def json(self, artifact: str) -> Fact[Any]:
+        path = self._resolve(artifact)
+        if not path.is_known:
+            return Fact.unknown(path.source, path.detail)
+        try:
+            return Fact.known(json.loads(path.require().read_text()), path.source)
+        except json.JSONDecodeError as exc:
+            return Fact.unknown(path.source, f"not valid JSON: {exc}")
+
+    def rows(self, artifact: str) -> Fact[tuple[dict, ...]]:
+        """JSONL rows. A malformed line is UNKNOWN for the whole artifact.
+
+        Skipping bad lines would silently change the denominator of every rate
+        computed from them.
+        """
+        path = self._resolve(artifact)
+        if not path.is_known:
+            return Fact.unknown(path.source, path.detail)
+        out = []
+        for n, line in enumerate(path.require().read_text().splitlines(), 1):
+            if not line.strip():
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                return Fact.unknown(path.source, f"line {n} is not valid JSON: {exc}")
+        return Fact.known(tuple(out), path.source, f"{len(out)} row(s)")
+
+    def artifacts(self) -> tuple[str, ...]:
+        return tuple(sorted(self.producers))
+
+    def produced_by(self, artifact: str) -> Fact[str]:
+        if artifact not in self.producers:
+            return Fact.absent(f"{self.run_id}/{artifact}", "not in the producer index")
+        return Fact.known(
+            self.producers[artifact]["producer"], f"{self.run_id}/{artifact}"
+        )
+
+    # ------------------------------------------------------------- judging
+
+    def require_valid_run(self) -> Outcome:
+        """The default admissibility check: did collection keep its promises?"""
+        seal = self.seal
+        return Outcome(
+            check="require_valid_run",
+            verdict=seal.verdict(),
+            detail=seal.why(),
+            evidence=seal.missing + tuple(a for a, _, _ in seal.short),
+        )
+
+    def judge(self, checks: Sequence[Any]) -> tuple[Verdict, tuple[Outcome, ...]]:
+        """Run every check and combine, with validity evaluated first.
+
+        An invalid run short-circuits: there is no point asking whether the
+        system behaved when the measurement did not happen, and reporting a
+        product failure from missing evidence is how a harness bug becomes
+        someone else's bug report.
+        """
+        validity = self.require_valid_run()
+        if validity.verdict is Verdict.INVALID:
+            return Verdict.INVALID, (validity,)
+
+        outcomes = [validity]
+        for check in checks:
+            name = getattr(check, "__name__", repr(check))
+            try:
+                result = check(self)
+            except (
+                Exception
+            ) as exc:  # noqa: BLE001 - a broken check is not a SUT failure
+                outcomes.append(
+                    Outcome(
+                        check=name,
+                        verdict=Verdict.INVALID,
+                        detail=f"the check itself raised {type(exc).__name__}: {exc}",
+                    )
+                )
+                continue
+            if isinstance(result, Outcome):
+                outcomes.append(result)
+            else:
+                outcomes.append(
+                    Outcome(
+                        check=name,
+                        verdict=Verdict.INVALID,
+                        detail=f"returned {type(result).__name__}, expected an Outcome",
+                    )
+                )
+        return combine(outcomes), tuple(outcomes)
+
+    def write_findings(self, outcomes: Sequence[Outcome]) -> Path:
+        """Record the judgement so a run can be re-scored and diffed."""
+        path = self.root / "findings.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "verdict": combine(outcomes).value,
+                    "outcomes": [o.to_record() for o in outcomes],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return path
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.artifacts())
+
+    def __repr__(self) -> str:
+        return f"Evidence({self.run_id!r}, {len(self.producers)} artifacts)"

--- a/harness/dynamo_test/facts.py
+++ b/harness/dynamo_test/facts.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Three-valued facts.
+
+Every observation the harness makes about a system under test is one of three
+things, and conflating the last two is how test suites go falsely green:
+
+``KNOWN``
+    The source was readable and the thing is there. ``value`` is set.
+``ABSENT``
+    The source was readable and the thing is genuinely not there.
+``UNKNOWN``
+    The source could not be read, or could not represent the form the thing is
+    written in. **Nothing** may be concluded.
+
+The distinction is not academic. Two measured examples from this repository:
+
+* ``_declared_tool_call_parser`` scanned argv tokens only. For recipes whose
+  worker is launched through a shell the whole command is a single token, so the
+  scan found nothing and the skip message said the recipe "configures no
+  tool-call parser" — a false statement, in a green run, for 34 of 101 recipes.
+* ``k8s_utils`` swallowed every exception and returned ``{}``, so a
+  crash-looping pod reported "no restarts".
+
+Both are ``UNKNOWN`` reported as ``ABSENT``. :class:`Fact` makes that confusion
+expressible only on purpose: you cannot get at the value without naming which
+case you are in, and :meth:`Fact.__bool__` raises so that ``if not fact:`` — the
+shape both bugs took — does not compile into a silent wrong answer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Generic, NoReturn, TypeVar
+
+T = TypeVar("T")
+
+__all__ = ["Status", "Fact", "FactNotKnown"]
+
+
+class Status(str, Enum):
+    KNOWN = "known"
+    ABSENT = "absent"
+    UNKNOWN = "unknown"
+
+
+class FactNotKnown(Exception):
+    """Raised by :meth:`Fact.require` when a fact is not ``KNOWN``."""
+
+
+@dataclass(frozen=True)
+class Fact(Generic[T]):
+    """An observation, its provenance, and whether it is trustworthy.
+
+    ``source`` names *where the answer came from* precisely enough to go and
+    look: ``"DGD spec.components[VllmDecodeWorker].args[0]"``, ``"nvidia-smi"``,
+    ``"node label nvidia.com/gpu.present"``. It is not a description of the
+    check; it is an address.
+    """
+
+    status: Status
+    value: T | None
+    source: str
+    detail: str = ""
+
+    @classmethod
+    def known(cls, value: T, source: str, detail: str = "") -> "Fact[T]":
+        return cls(Status.KNOWN, value, source, detail)
+
+    @classmethod
+    def absent(cls, source: str, why: str) -> "Fact[T]":
+        """The source was read and the thing is genuinely not there.
+
+        ``why`` must justify the *positive* claim of absence — what was read,
+        and why that reading is complete. "not found" is not a justification.
+        """
+        return cls(Status.ABSENT, None, source, why)
+
+    @classmethod
+    def unknown(cls, source: str, why: str) -> "Fact[T]":
+        """The source could not be read, or cannot represent this form."""
+        return cls(Status.UNKNOWN, None, source, why)
+
+    @property
+    def is_known(self) -> bool:
+        return self.status is Status.KNOWN
+
+    @property
+    def is_absent(self) -> bool:
+        return self.status is Status.ABSENT
+
+    @property
+    def is_unknown(self) -> bool:
+        return self.status is Status.UNKNOWN
+
+    def require(self) -> T:
+        """Return the value, or raise with the provenance attached.
+
+        For callers that genuinely cannot proceed. The message carries
+        ``source`` and ``detail`` so the failure names the thing that could not
+        be read rather than the symptom three frames later.
+        """
+        if self.status is Status.KNOWN:
+            return self.value  # type: ignore[return-value]
+        raise FactNotKnown(
+            f"{self.status.value} at {self.source}"
+            + (f": {self.detail}" if self.detail else "")
+        )
+
+    def or_else(self, default: T) -> T:
+        """Return the value if ``KNOWN``, else ``default``.
+
+        Collapses ``ABSENT`` and ``UNKNOWN`` together, which is exactly the
+        conflation this module exists to prevent. Legitimate only where the
+        default is correct for *both* — a display string, a metrics label. If
+        the caller would behave differently for a thing that is missing versus a
+        thing that could not be read, branch on :attr:`status` instead.
+        """
+        return self.value if self.status is Status.KNOWN else default  # type: ignore[return-value]
+
+    def __bool__(self) -> NoReturn:
+        raise TypeError(
+            "Fact has no truth value: `if fact:` cannot distinguish ABSENT from "
+            "UNKNOWN, which is the bug this type exists to prevent. Branch on "
+            "fact.status, or use fact.is_known / fact.require() / fact.or_else()."
+        )

--- a/harness/dynamo_test/manifest.py
+++ b/harness/dynamo_test/manifest.py
@@ -1,0 +1,482 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reading a DynamoGraphDeployment into a :class:`Plan`.
+
+This is the layer that turns a manifest on disk into roles, command lines and
+engines — the three things every later tier asks about. It is deliberately
+separate from anything that talks to a cluster: a plan can be read, inspected,
+edited and printed on a laptop with no credentials, which is what makes
+``dynamo-test plan`` possible in a bare CI checkout.
+
+## What it has to cope with
+
+Measured over ``recipes/`` and ``examples/``:
+
+* **Two schemas, both live.** 177 documents use v1beta1 ``spec.components`` (a
+  list), 75 use v1alpha1 ``spec.services`` (a mapping). Neither is legacy.
+* **Multi-document files.** A manifest often carries a ConfigMap or a Secret
+  alongside the deployment, so ``safe_load`` on its own reads the wrong document
+  or none at all.
+* **Four places a container hides**: ``extraPodSpec.mainContainer``,
+  ``container``, ``podTemplate.spec.containers[]``, and the v1alpha1
+  ``services[name].extraPodSpec.mainContainer``.
+* **32 distinct component names for about nine roles**, including
+  ``TrtllmWorker`` and ``TRTLLMWorker`` in the same corpus. Name-matching that is
+  not case-insensitive silently resolves one and not the other, which is exactly
+  how a log reader ends up returning nothing for a service that is running fine.
+
+## What it does not preserve
+
+Editing a plan and re-emitting it produces semantically equivalent YAML, not
+byte-identical YAML: the comments and formatting of the *manifest* are lost,
+because the document is re-serialised. The **shell command string inside a
+container is preserved exactly**, comments and all, because :class:`ArgV`
+splices rather than rebuilds. That is the distinction that matters — a
+reformatted manifest still deploys the same thing, whereas a rebuilt command
+line does not.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Sequence
+
+from .argv import ArgV
+from .dialect import Dialect, detect, for_backend
+from .facts import Fact
+from .roles import PortName, Role, RoleBinding, RoleTable
+
+__all__ = [
+    "Schema",
+    "Component",
+    "Plan",
+    "role_of",
+    "ManifestError",
+    "NoGraphDeployment",
+]
+
+KIND = "DynamoGraphDeployment"
+
+
+class ManifestError(ValueError):
+    """The manifest could not be read as a deployment plan."""
+
+
+class NoGraphDeployment(ManifestError):
+    """No ``DynamoGraphDeployment`` document in the file."""
+
+
+class Schema(str, Enum):
+    V1ALPHA1 = "v1alpha1"  # spec.services, a mapping
+    V1BETA1 = "v1beta1"  # spec.components, a list
+
+
+# Role inference, ordered. The first pattern that matches wins, which is why
+# prefill/decode/encode come before the generic worker rule: `VllmPrefillWorker`
+# contains both "prefill" and "worker" and is a prefill.
+#
+# Matching is case-insensitive because the corpus contains both `TrtllmWorker`
+# and `TRTLLMWorker`.
+_ROLE_PATTERNS: tuple[tuple[re.Pattern, Role], ...] = (
+    (re.compile(r"frontend", re.I), Role.FRONTEND),
+    (re.compile(r"prefill", re.I), Role.PREFILL),
+    (re.compile(r"decode", re.I), Role.DECODE),
+    (re.compile(r"encode", re.I), Role.ENCODE),
+    (re.compile(r"planner", re.I), Role.PLANNER),
+    (re.compile(r"router|^epp$", re.I), Role.ROUTER),
+    (re.compile(r"gateway", re.I), Role.GATEWAY),
+    (re.compile(r"kvbm", re.I), Role.KVBM),
+    (re.compile(r"etcd", re.I), Role.ETCD),
+    (re.compile(r"nats", re.I), Role.NATS),
+    # `agg` is an aggregated worker: it prefills and decodes in one process.
+    (re.compile(r"worker|^agg$", re.I), Role.WORKER),
+)
+
+
+def role_of(name: str) -> Fact[Role]:
+    """The role a component name denotes.
+
+    Returns a :class:`Fact` rather than a default, because guessing here is how
+    a selector silently ends up pointed at the wrong service.
+    """
+    for pattern, role in _ROLE_PATTERNS:
+        if pattern.search(name):
+            return Fact.known(
+                role, f"component name {name!r}", f"matched /{pattern.pattern}/"
+            )
+    return Fact.absent(
+        f"component name {name!r}",
+        "matches none of " + ", ".join(p.pattern for p, _ in _ROLE_PATTERNS),
+    )
+
+
+def _containers(component: Mapping[str, Any]) -> list[dict]:
+    """Every container spec in a component, in precedence order."""
+    found: list[dict] = []
+    main = ((component.get("extraPodSpec") or {}).get("mainContainer")) or None
+    if isinstance(main, dict):
+        found.append(main)
+    direct = component.get("container")
+    if isinstance(direct, dict):
+        found.append(direct)
+    pod_spec = (component.get("podTemplate") or {}).get("spec") or {}
+    for container in pod_spec.get("containers") or []:
+        if isinstance(container, dict):
+            found.append(container)
+    return found
+
+
+def _main_container(component: Mapping[str, Any]) -> dict | None:
+    """The container that carries the component's command line.
+
+    When a pod declares several, the one with args wins; a sidecar with no
+    command is not what a test means by "the worker".
+    """
+    found = _containers(component)
+    for container in found:
+        if container.get("args") or container.get("command"):
+            return container
+    return found[0] if found else None
+
+
+@dataclass(frozen=True)
+class Component:
+    """One service in a deployment, with its role and command line resolved."""
+
+    name: str
+    role: Role
+    replicas: int
+    argv: ArgV
+    backend: Fact[str]
+    _container: dict | None
+    _spec: Mapping[str, Any]
+
+    @property
+    def dialect(self) -> Dialect | None:
+        return for_backend(self.backend.require()) if self.backend.is_known else None
+
+    @property
+    def image(self) -> Fact[str]:
+        if self._container is None:
+            return Fact.unknown(self.name, "component declares no container")
+        image = self._container.get("image")
+        if image:
+            return Fact.known(str(image), f"{self.name}.image")
+        return Fact.absent(f"{self.name}.image", "no image field on the main container")
+
+    @property
+    def gpus(self) -> Fact[int]:
+        """GPU limit, from whichever schema this component uses."""
+        limits = (self._spec.get("resources") or {}).get("limits") or {}
+        if "gpu" in limits:  # v1alpha1
+            return Fact.known(int(limits["gpu"]), f"{self.name}.resources.limits.gpu")
+        if self._container is not None:
+            climits = (self._container.get("resources") or {}).get("limits") or {}
+            if "nvidia.com/gpu" in climits:
+                return Fact.known(
+                    int(climits["nvidia.com/gpu"]),
+                    f"{self.name} container resources.limits['nvidia.com/gpu']",
+                )
+        return Fact.absent(f"{self.name}", "no GPU limit declared in either schema")
+
+    def read(self, semantic: str) -> Fact[str]:
+        """An engine setting, through this component's dialect."""
+        dialect = self.dialect
+        if dialect is None:
+            return Fact.unknown(
+                self.name,
+                f"no engine dialect: {self.backend.detail or 'backend not identified'}",
+            )
+        return dialect.read(self.argv, semantic)
+
+    def binding(self) -> RoleBinding:
+        """This component's :class:`RoleBinding`.
+
+        ``log_key`` is the component name lowercased — **one** string, used for
+        both the bundle directory and the log-scrape key, so the two cannot
+        drift into an alias table that resolves some services and not others.
+        """
+        dialect = self.dialect
+        processes = dict(dialect.processes) if dialect else {}
+        return RoleBinding(
+            role=self.role,
+            service=self.name,
+            log_key=self.name.lower(),
+            metric_labels={"dynamo_component": self.name},
+            processes=processes,
+            ports=_ports(self._container),
+        )
+
+
+def _ports(container: dict | None) -> dict:
+    if not container:
+        return {}
+    out: dict = {}
+    for port in container.get("ports") or []:
+        if not isinstance(port, dict) or "containerPort" not in port:
+            continue
+        name = str(port.get("name", "")).lower()
+        if name in ("metrics", "system", "grpc"):
+            out[PortName(name)] = int(port["containerPort"])
+        elif PortName.SERVICE not in out:
+            out[PortName.SERVICE] = int(port["containerPort"])
+    return out
+
+
+class Plan:
+    """A deployment, read from a manifest and editable in memory."""
+
+    def __init__(
+        self,
+        documents: Sequence[Any],
+        source: str = "<manifest>",
+        select: str | None = None,
+    ) -> None:
+        self.source = source
+        self._documents = list(documents)
+        graphs = [
+            d for d in self._documents if isinstance(d, dict) and d.get("kind") == KIND
+        ]
+        if not graphs:
+            kinds = sorted(
+                {d.get("kind", "?") for d in self._documents if isinstance(d, dict)}
+            )
+            raise NoGraphDeployment(
+                f"{source} declares no {KIND}; it contains: "
+                f"{', '.join(kinds) if kinds else '<nothing>'}"
+            )
+        if len(graphs) > 1 and select is None:
+            names = [(g.get("metadata") or {}).get("name", "?") for g in graphs]
+            raise ManifestError(
+                f"{source} declares {len(graphs)} {KIND} documents "
+                f"({', '.join(names)}); a plan describes one deployment. Use "
+                "Plan.all_from_yaml()/all_from_file() to get one plan per "
+                "deployment, or pass select=<name>."
+            )
+        if select is not None:
+            chosen = [
+                g for g in graphs if (g.get("metadata") or {}).get("name") == select
+            ]
+            if not chosen:
+                names = [(g.get("metadata") or {}).get("name", "?") for g in graphs]
+                raise ManifestError(
+                    f"{source} has no {KIND} named {select!r}; it declares: "
+                    f"{', '.join(names)}"
+                )
+            graphs = chosen
+        self._graph = graphs[0]
+
+    # ------------------------------------------------------------- loading
+
+    @staticmethod
+    def _documents(text: str, source: str) -> list:
+        import yaml
+
+        try:
+            return list(yaml.safe_load_all(text))
+        except Exception as exc:
+            raise ManifestError(f"{source} is not valid YAML: {exc}") from exc
+
+    @classmethod
+    def from_yaml(
+        cls, text: str, source: str = "<string>", select: str | None = None
+    ) -> "Plan":
+        return cls(cls._documents(text, source), source=source, select=select)
+
+    @classmethod
+    def from_file(cls, path: str | Path, select: str | None = None) -> "Plan":
+        path = Path(path)
+        return cls.from_yaml(path.read_text(), source=str(path), select=select)
+
+    @classmethod
+    def all_from_yaml(cls, text: str, source: str = "<string>") -> tuple["Plan", ...]:
+        """One plan per deployment, for files that declare several.
+
+        Four ``global_planner`` examples describe a control plane plus two to
+        four model deployments in one file. Treating those as an error would
+        make the planner untestable; treating them as one plan would silently
+        merge deployments that are meant to be separate.
+        """
+        documents = cls._documents(text, source)
+        names = [
+            (d.get("metadata") or {}).get("name")
+            for d in documents
+            if isinstance(d, dict) and d.get("kind") == KIND
+        ]
+        if not names:
+            return (cls(documents, source=source),)  # raises NoGraphDeployment
+        return tuple(
+            cls(documents, source=f"{source}#{name}", select=name) for name in names
+        )
+
+    @classmethod
+    def all_from_file(cls, path: str | Path) -> tuple["Plan", ...]:
+        path = Path(path)
+        return cls.all_from_yaml(path.read_text(), source=str(path))
+
+    # -------------------------------------------------------------- shape
+
+    @property
+    def name(self) -> str:
+        return (self._graph.get("metadata") or {}).get("name", "<unnamed>")
+
+    @property
+    def schema(self) -> Schema:
+        spec = self._graph.get("spec") or {}
+        if isinstance(spec.get("components"), list):
+            return Schema.V1BETA1
+        if isinstance(spec.get("services"), dict):
+            return Schema.V1ALPHA1
+        raise ManifestError(
+            f"{self.source}: spec has neither a components list nor a services mapping"
+        )
+
+    def _raw_components(self) -> list[tuple[str, dict]]:
+        spec = self._graph.get("spec") or {}
+        if self.schema is Schema.V1BETA1:
+            return [
+                (str(c.get("name", "<unnamed>")), c)
+                for c in spec["components"]
+                if isinstance(c, dict)
+            ]
+        return [(str(n), c or {}) for n, c in spec["services"].items()]
+
+    @property
+    def components(self) -> tuple[Component, ...]:
+        out = []
+        for name, raw in self._raw_components():
+            container = _main_container(raw)
+            argv = ArgV.from_container(container or {}, source=f"{self.source}[{name}]")
+            role = role_of(name)
+            out.append(
+                Component(
+                    name=name,
+                    role=role.or_else(Role.WORKER),
+                    replicas=int(raw.get("replicas", 1) or 1),
+                    argv=argv,
+                    backend=detect(argv),
+                    _container=container,
+                    _spec=raw,
+                )
+            )
+        return tuple(out)
+
+    def unresolved_roles(self) -> tuple[str, ...]:
+        """Component names whose role could not be inferred.
+
+        Surfaced rather than silently defaulted, so a new component type shows
+        up as a question instead of quietly becoming a generic worker.
+        """
+        return tuple(
+            name for name, _ in self._raw_components() if role_of(name).is_absent
+        )
+
+    def __getitem__(self, name_or_role: str | Role) -> Component:
+        for component in self.components:
+            if component.name == name_or_role or component.role == name_or_role:
+                return component
+        raise KeyError(
+            f"{self.source} has no component {name_or_role!r}; it declares: "
+            + ", ".join(c.name for c in self.components)
+        )
+
+    def __iter__(self) -> Iterator[Component]:
+        return iter(self.components)
+
+    def __len__(self) -> int:
+        return len(self.components)
+
+    def roles(self) -> RoleTable:
+        """The role table for this deployment.
+
+        Built once, here. Components sharing a role — two prefill workers, say —
+        would make the table ambiguous, so that is an error rather than a
+        last-one-wins.
+        """
+        bindings: dict[Role, RoleBinding] = {}
+        clashes: dict[Role, list[str]] = {}
+        for component in self.components:
+            if component.role in bindings:
+                clashes.setdefault(component.role, [bindings[component.role].service])
+                clashes[component.role].append(component.name)
+                continue
+            bindings[component.role] = component.binding()
+        if clashes:
+            detail = "; ".join(
+                f"{role}: {', '.join(names)}" for role, names in clashes.items()
+            )
+            raise ManifestError(
+                f"{self.source}: several components share a role ({detail}). A role "
+                "must name one service, or a selector cannot say which it means."
+            )
+        return RoleTable(bindings)
+
+    # ------------------------------------------------------------ editing
+
+    def set(self, name_or_role: str | Role, **settings: Any) -> "Plan":
+        """Change engine settings on one component, in place.
+
+        Writes through the component's dialect and :class:`ArgV`, so the flag
+        spelling is right for the engine and the surrounding shell command is
+        untouched.
+        """
+        component = self[name_or_role]
+        dialect = component.dialect
+        if dialect is None:
+            raise ManifestError(
+                f"{component.name}: cannot set {', '.join(settings)} — "
+                f"{component.backend.detail or 'no engine identified'}"
+            )
+        if component._container is None:
+            raise ManifestError(f"{component.name} declares no container to configure")
+        dialect.apply(component.argv, **settings).apply_to(component._container)
+        return self
+
+    def scale(self, name_or_role: str | Role, replicas: int) -> "Plan":
+        if replicas < 0:
+            raise ValueError(f"replicas must be non-negative, got {replicas}")
+        self[name_or_role]._spec["replicas"] = replicas  # type: ignore[index]
+        return self
+
+    # ------------------------------------------------------------- output
+
+    def to_yaml(self) -> str:
+        """Re-emit every document in the original file.
+
+        Formatting and comments *of the manifest* are not preserved; the shell
+        command inside each container is, byte for byte.
+        """
+        import yaml
+
+        return yaml.safe_dump_all(self._documents, sort_keys=False, width=10**6)
+
+    def to_record(self) -> dict:
+        """A JSON-safe summary for the run record."""
+        return {
+            "name": self.name,
+            "schema": self.schema.value,
+            "source": self.source,
+            "components": [
+                {
+                    "name": c.name,
+                    "role": str(c.role),
+                    "replicas": c.replicas,
+                    "backend": c.backend.or_else(None),
+                    "form": c.argv.form.value,
+                    "image": c.image.or_else(None),
+                    "gpus": c.gpus.or_else(None),
+                    "model": c.read("model").or_else(None),
+                }
+                for c in self.components
+            ],
+        }
+
+    def __repr__(self) -> str:
+        return (
+            f"Plan({self.name!r}, {self.schema.value}, "
+            f"{len(self.components)} components)"
+        )

--- a/harness/dynamo_test/parity.py
+++ b/harness/dynamo_test/parity.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The marker-parity gate: prove a change did not alter what CI selects.
+
+Every migration step in the test-framework work risks the same failure, and it is
+invisible: a refactor that stops selecting forty GPU tests produces a *greener*
+run than one that breaks them. Nothing in a passing CI report distinguishes
+"these tests passed" from "these tests were never chosen".
+
+This module makes that difference checkable. It collects the suite the way CI
+does, for every ``-m`` expression CI actually uses, on both the base and the
+change, and diffs the node-id sets.
+
+## Three things it does not do, each for a measured reason
+
+**It does not use ``--collect-only``.** ``tests/conftest.py`` guards both the
+``--max-vram-gib`` deselection and ``write_test_meta`` on
+``not config.option.collectonly``, so a collect-only run is blind to the only
+mechanism that removes tests. Measured on ``tests/serve`` with
+``--max-vram-gib 8``: ``--collect-only`` reports 6 selected and 0 deselected,
+``--dry-run`` reports 3 and 3. A gate built on the former passes while CI runs
+half as much.
+
+**It does not use ``git stash``.** On a clean tree — which CI always has — a
+stash is a no-op, and the gate then compares HEAD to HEAD and always passes. The
+base is an explicit worktree at the merge base.
+
+**It does not invent the marker expressions.** They are literals in the caller
+workflows under ``gpu_test_markers:`` and ``cpu_only_test_markers:``, and the
+callee wraps the GPU ones as ``({0}) and not profiled_vram_gib``. Both are read
+from the files rather than restated here, so the gate cannot drift from the CI
+it is supposed to model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "MarkerExpression",
+    "SelectionDiff",
+    "read_marker_expressions",
+    "collect_selection",
+    "compare",
+    "main",
+]
+
+_MARKER_LINE = re.compile(r"^\s*(gpu_test_markers|cpu_only_test_markers):\s*(.+?)\s*$")
+# The callee's runtime transform, read from the file rather than restated.
+_TRANSFORM = re.compile(r"format\(\s*'\(\{0\}\)\s*and\s*(?P<suffix>[^']+)'")
+
+
+@dataclass(frozen=True)
+class MarkerExpression:
+    """One ``-m`` expression CI runs, and where it came from."""
+
+    expression: str
+    lane: str
+    source: str
+
+    def variants(self, suffix: str | None) -> tuple[str, ...]:
+        """The expression, plus the transformed form if the callee wraps it."""
+        if suffix and self.lane == "gpu_test_markers":
+            return (self.expression, f"({self.expression}) and {suffix}")
+        return (self.expression,)
+
+
+def read_marker_expressions(repo: Path) -> tuple[list[MarkerExpression], str | None]:
+    """Every ``-m`` expression in the workflows, and the callee's transform."""
+    workflows = repo / ".github" / "workflows"
+    found: dict[tuple[str, str], MarkerExpression] = {}
+    suffix: str | None = None
+
+    for path in sorted(workflows.glob("*.y*ml")):
+        text = path.read_text()
+        transform = _TRANSFORM.search(text)
+        if transform:
+            suffix = transform.group("suffix").strip()
+        for n, line in enumerate(text.splitlines(), 1):
+            match = _MARKER_LINE.match(line)
+            if not match:
+                continue
+            lane, raw = match.group(1), match.group(2).strip()
+            # Skip the callee's own parameter declarations and pass-throughs.
+            if not raw or raw.startswith("${{") or raw.startswith("#"):
+                continue
+            expression = raw.strip("'\"")
+            if not expression or expression.endswith(":"):
+                continue
+            found[(lane, expression)] = MarkerExpression(
+                expression, lane, f"{path.name}:{n}"
+            )
+    return sorted(found.values(), key=lambda e: (e.lane, e.expression)), suffix
+
+
+def collect_selection(
+    repo: Path,
+    expression: str,
+    *,
+    paths: list[str] | None = None,
+    vram_gib: float | None = None,
+    harness: Path | None = None,
+    timeout: float = 900.0,
+) -> dict:
+    """Run collection the way CI would and return what it would execute.
+
+    Uses ``--dry-run`` rather than ``--collect-only`` — see the module docstring.
+    """
+    harness = harness or Path(__file__).resolve().parents[1]
+    with tempfile.TemporaryDirectory() as tmp:
+        # A distinct TMPDIR per run: `write_test_meta` writes to a fixed name,
+        # so two runs sharing a temp directory clobber each other's metadata.
+        out = Path(tmp) / "selection.json"
+        argv = [
+            sys.executable,
+            "-m",
+            "pytest",
+            *(paths or ["tests"]),
+            "-p",
+            "dynamo_test.pytest_plugin",
+            f"--dynamo-selection-out={out}",
+            "--dry-run",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            "-m",
+            expression,
+        ]
+        if vram_gib is not None:
+            argv += ["--max-vram-gib", str(vram_gib)]
+        env = {
+            **_clean_env(),
+            "PYTHONPATH": str(harness),
+            "TMPDIR": tmp,
+        }
+        result = subprocess.run(
+            argv, cwd=repo, env=env, capture_output=True, text=True, timeout=timeout
+        )
+        if not out.exists():
+            return {
+                "error": "collection produced no selection file",
+                "returncode": result.returncode,
+                "stderr": result.stderr[-2000:],
+                "tests": [],
+                "selected": 0,
+            }
+        return json.loads(out.read_text())
+
+
+def _clean_env() -> dict:
+    import os
+
+    keep = ("PATH", "HOME", "LANG", "LC_ALL", "VIRTUAL_ENV", "CUDA_VISIBLE_DEVICES")
+    return {k: v for k, v in os.environ.items() if k in keep or k.startswith("GIT_")}
+
+
+@dataclass(frozen=True)
+class SelectionDiff:
+    """What one expression selects on each side, and how that differs."""
+
+    expression: str
+    lane: str
+    base_count: int
+    head_count: int
+    lost: tuple[str, ...]
+    gained: tuple[str, ...]
+    marker_changed: tuple[str, ...]
+
+    @property
+    def is_clean(self) -> bool:
+        return not self.lost and not self.marker_changed
+
+    def describe(self) -> str:
+        if self.is_clean:
+            gained = f", +{len(self.gained)} new" if self.gained else ""
+            return f"  OK   {self.base_count:5d} -> {self.head_count:<5d}{gained}  {self.expression}"
+        parts = []
+        if self.lost:
+            parts.append(f"LOST {len(self.lost)}")
+        if self.marker_changed:
+            parts.append(f"MARKERS CHANGED {len(self.marker_changed)}")
+        return (
+            f"  FAIL {self.base_count:5d} -> {self.head_count:<5d} "
+            f"({', '.join(parts)})  {self.expression}"
+        )
+
+
+def compare(base: dict, head: dict, expression: str, lane: str) -> SelectionDiff:
+    """Diff two selections.
+
+    Losing a test is a failure. *Gaining* one is not — that is what adding a test
+    looks like. A marker whose argument changed is also a failure, because
+    ``profiled_vram_gib`` feeds the VRAM scheduler and a changed number silently
+    moves a test between lanes.
+    """
+    base_by_id = {t["nodeid"]: t for t in base.get("tests", [])}
+    head_by_id = {t["nodeid"]: t for t in head.get("tests", [])}
+
+    lost = sorted(set(base_by_id) - set(head_by_id))
+    gained = sorted(set(head_by_id) - set(base_by_id))
+    changed = sorted(
+        nodeid
+        for nodeid in set(base_by_id) & set(head_by_id)
+        if base_by_id[nodeid].get("marker_args")
+        != head_by_id[nodeid].get("marker_args")
+        or base_by_id[nodeid].get("markers") != head_by_id[nodeid].get("markers")
+    )
+    return SelectionDiff(
+        expression=expression,
+        lane=lane,
+        base_count=len(base_by_id),
+        head_count=len(head_by_id),
+        lost=tuple(lost),
+        gained=tuple(gained),
+        marker_changed=tuple(changed),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="dynamo-test-parity",
+        description="Prove a change did not alter what CI selects.",
+    )
+    parser.add_argument("--repo", default=".", help="the working tree to check")
+    parser.add_argument(
+        "--base",
+        required=True,
+        help="a checkout of the merge base. Use an explicit worktree: a git "
+        "stash on a clean tree is a no-op and compares HEAD to HEAD.",
+    )
+    parser.add_argument("--paths", nargs="*", default=["tests"])
+    parser.add_argument("--max-vram-gib", type=float, default=None)
+    parser.add_argument(
+        "--expression",
+        action="append",
+        help="check only this expression; repeatable. Defaults to every "
+        "expression found in the workflows.",
+    )
+    args = parser.parse_args(argv)
+
+    repo, base = Path(args.repo).resolve(), Path(args.base).resolve()
+    if args.expression:
+        expressions = [
+            MarkerExpression(e, "gpu_test_markers", "<cli>") for e in args.expression
+        ]
+        suffix = None
+    else:
+        expressions, suffix = read_marker_expressions(repo)
+        print(
+            f"{len(expressions)} marker expression(s) from the workflows"
+            + (f"; callee transform: 'and {suffix}'" if suffix else "")
+        )
+
+    diffs: list[SelectionDiff] = []
+    for expression in expressions:
+        for variant in expression.variants(suffix):
+            head = collect_selection(
+                repo, variant, paths=args.paths, vram_gib=args.max_vram_gib
+            )
+            before = collect_selection(
+                base, variant, paths=args.paths, vram_gib=args.max_vram_gib
+            )
+            diff = compare(before, head, variant, expression.lane)
+            diffs.append(diff)
+            print(diff.describe())
+
+    broken = [d for d in diffs if not d.is_clean]
+    print()
+    if not broken:
+        print(f"marker parity holds across {len(diffs)} expression(s)")
+        return 0
+
+    print(f"{len(broken)} expression(s) select differently:\n")
+    for diff in broken:
+        print(f"  {diff.expression}")
+        for nodeid in diff.lost[:20]:
+            print(f"    no longer selected: {nodeid}")
+        for nodeid in diff.marker_changed[:20]:
+            print(f"    markers changed:    {nodeid}")
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/harness/dynamo_test/providers/__init__.py
+++ b/harness/dynamo_test/providers/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Platform providers: the small set of things a substrate must be able to do.
+
+Ordered by what the existing suite actually uses, not by what is easiest to
+write: local subprocesses are the substrate of most tests in ``tests/``,
+Kubernetes is next, and Docker is used by roughly one.
+"""
+
+from .local import LocalProvider, LocalRole
+
+__all__ = ["LocalProvider", "LocalRole"]

--- a/harness/dynamo_test/providers/local.py
+++ b/harness/dynamo_test/providers/local.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Roles as local subprocesses.
+
+The substrate most of the existing suite already uses, so it is the one worth
+implementing first. It is also the one that makes the façade testable without a
+cluster: a test can start a role, query it, restart it, and judge the evidence,
+entirely on a laptop.
+
+Two behaviours here are deliberate and both come from watching real suites:
+
+**Stop means stop this role.** A ``stop`` that quietly tears down the whole
+deployment makes every fault-tolerance test vacuous — the thing it was supposed
+to isolate is gone along with everything else. Selection resolves to one role's
+processes and nothing else.
+
+**A dead process is a fact, not an exception.** ``logs`` and ``restart_count``
+answer for a role that is not running rather than raising, because a check that
+wants to know *whether* something died should not have to catch an error to find
+out. What they must never do is answer "nothing" for a role that was never
+started; that is ``UNKNOWN``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from ..facts import Fact
+from ..roles import Role, Sel
+
+__all__ = ["LocalRole", "LocalProvider"]
+
+
+@dataclass
+class LocalRole:
+    """How to run one role locally."""
+
+    role: Role
+    argv: Sequence[str]
+    port: int | None = None
+    env: Mapping[str, str] = field(default_factory=dict)
+    cwd: str | None = None
+    ready_path: str = "/v1/models"
+
+    # runtime state
+    process: subprocess.Popen | None = field(default=None, repr=False)
+    starts: int = 0
+    log_path: Path | None = field(default=None, repr=False)
+
+
+class LocalProvider:
+    """Run roles as subprocesses on this machine."""
+
+    def __init__(self, roles: Mapping[Role | str, LocalRole], log_dir: str | Path):
+        self._roles: dict[Role, LocalRole] = {}
+        for key, spec in roles.items():
+            role = key if isinstance(key, Role) else Role(str(key).lower())
+            self._roles[role] = spec
+        self.log_dir = Path(log_dir)
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+
+    # --------------------------------------------------------------- lookup
+
+    def _role(self, sel: Sel) -> LocalRole:
+        try:
+            return self._roles[sel.role]
+        except KeyError:
+            raise KeyError(
+                f"no local role {sel.role}; this provider runs: "
+                f"{', '.join(sorted(str(r) for r in self._roles)) or '<none>'}"
+            ) from None
+
+    def _source(self, sel: Sel) -> str:
+        return f"local:{sel.describe()}"
+
+    # ------------------------------------------------------------- lifecycle
+
+    def start(self, sel: Sel) -> Mapping[str, Any]:
+        spec = self._role(sel)
+        if spec.process is not None and spec.process.poll() is None:
+            return {"already_running": True, "pid": spec.process.pid}
+
+        spec.starts += 1
+        spec.log_path = self.log_dir / f"{sel.role}.{spec.starts}.log"
+        env = {**os.environ, **spec.env}
+        # Line-buffered, so a check reading logs mid-run sees whole lines rather
+        # than whatever happened to be flushed.
+        env.setdefault("PYTHONUNBUFFERED", "1")
+        handle = spec.log_path.open("w")
+        spec.process = subprocess.Popen(
+            list(spec.argv),
+            stdout=handle,
+            stderr=subprocess.STDOUT,
+            cwd=spec.cwd,
+            env=env,
+            start_new_session=True,  # so stop() cannot signal the test runner
+        )
+        return {
+            "pid": spec.process.pid,
+            "starts": spec.starts,
+            "log": str(spec.log_path),
+        }
+
+    def stop(
+        self, sel: Sel, *, graceful: bool = True, grace: float = 5.0
+    ) -> Mapping[str, Any]:
+        spec = self._role(sel)
+        if spec.process is None or spec.process.poll() is not None:
+            return {"already_stopped": True}
+
+        pid = spec.process.pid
+        if graceful:
+            spec.process.terminate()
+            try:
+                spec.process.wait(timeout=grace)
+                return {
+                    "pid": pid,
+                    "signal": "SIGTERM",
+                    "returncode": spec.process.returncode,
+                }
+            except subprocess.TimeoutExpired:
+                pass
+        spec.process.kill()
+        spec.process.wait(timeout=grace)
+        return {"pid": pid, "signal": "SIGKILL", "returncode": spec.process.returncode}
+
+    def restart(self, sel: Sel, **settings: Any) -> Mapping[str, Any]:
+        """Stop, apply any flag changes, start.
+
+        Settings go through :class:`~dynamo_test.argv.ArgV`, so a flag that is
+        already set is **replaced** rather than appended. Appending is a measured
+        defect elsewhere: the engine takes one occurrence and the test believes
+        the other.
+        """
+        spec = self._role(sel)
+        before = self.restart_count(sel).or_else(0)
+        stopped = self.stop(sel)
+        if settings:
+            from ..argv import ArgV
+
+            argv = ArgV.argv(spec.argv[1:], command=spec.argv[:1], source=str(sel.role))
+            for flag, value in settings.items():
+                flag = flag if flag.startswith("-") else f"--{flag.replace('_', '-')}"
+                argv = argv.set(flag, value)
+            spec.argv = list(spec.argv[:1]) + argv.as_container_args()
+        started = self.start(sel)
+        return {
+            "before": before,
+            "stopped": dict(stopped),
+            **started,
+            "restart_count": spec.starts - 1,
+        }
+
+    # ---------------------------------------------------------------- reads
+
+    def address(self, sel: Sel) -> Fact[str]:
+        spec = self._role(sel)
+        if spec.port is None:
+            return Fact.absent(self._source(sel), f"{sel.role} declares no port")
+        return Fact.known(f"http://127.0.0.1:{spec.port}", self._source(sel))
+
+    def replicas(self, sel: Sel) -> Fact[int]:
+        spec = self._role(sel)
+        running = spec.process is not None and spec.process.poll() is None
+        return Fact.known(1 if running else 0, self._source(sel))
+
+    def restart_count(self, sel: Sel) -> Fact[int]:
+        """How many times this role has been (re)started, minus the first.
+
+        ``UNKNOWN`` before the first start: "never started" and "started once and
+        never restarted" are different, and only one of them means a restart
+        assertion can be evaluated.
+        """
+        spec = self._role(sel)
+        if spec.starts == 0:
+            return Fact.unknown(self._source(sel), "role has never been started")
+        return Fact.known(spec.starts - 1, self._source(sel))
+
+    def logs(self, sel: Sel) -> Fact[str]:
+        spec = self._role(sel)
+        if spec.log_path is None:
+            return Fact.unknown(
+                self._source(sel), "role has never been started, so there is no log"
+            )
+        if not spec.log_path.exists():
+            return Fact.unknown(
+                self._source(sel), f"log file {spec.log_path} does not exist"
+            )
+        return Fact.known(
+            spec.log_path.read_text(), f"{self._source(sel)}:{spec.log_path}"
+        )
+
+    def all_logs(self) -> dict[str, str]:
+        """Every role's current log, for the COLLECT phase."""
+        out = {}
+        for role, spec in self._roles.items():
+            if spec.log_path and spec.log_path.exists():
+                out[str(role)] = spec.log_path.read_text()
+        return out
+
+    def request(
+        self,
+        sel: Sel,
+        path: str,
+        *,
+        method: str = "GET",
+        body: Any = None,
+        timeout: float = 30.0,
+    ) -> Fact[Any]:
+        """An HTTP request to a role.
+
+        Every failure mode is a ``Fact``, not an exception: a check asking "did
+        this respond?" should read the answer, not catch it. The detail carries
+        the status or the errno so a failure names itself.
+        """
+        base = self.address(sel)
+        if not base.is_known:
+            return Fact.unknown(base.source, base.detail)
+        url = base.require().rstrip("/") + path
+        data = json.dumps(body).encode() if body is not None else None
+        request = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers={"Content-Type": "application/json"} if data else {},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                raw = response.read().decode()
+                try:
+                    return Fact.known(
+                        json.loads(raw), f"{url}", f"HTTP {response.status}"
+                    )
+                except json.JSONDecodeError:
+                    return Fact.known(
+                        raw, f"{url}", f"HTTP {response.status}, not JSON"
+                    )
+        except urllib.error.HTTPError as exc:
+            return Fact.absent(url, f"HTTP {exc.code}: {exc.reason}")
+        except urllib.error.URLError as exc:
+            return Fact.unknown(url, f"unreachable: {exc.reason}")
+        except TimeoutError:
+            return Fact.unknown(url, f"timed out after {timeout}s")
+
+    # ------------------------------------------------------------ teardown
+
+    def shutdown(self) -> None:
+        """Stop every role. Safe to call twice."""
+        for role in list(self._roles):
+            try:
+                self.stop(Sel(role=role))
+            except Exception:  # noqa: BLE001 - teardown must not mask a real failure
+                spec = self._roles[role]
+                if spec.process and spec.process.poll() is None:
+                    try:
+                        os.killpg(os.getpgid(spec.process.pid), signal.SIGKILL)
+                    except (ProcessLookupError, PermissionError):
+                        pass
+
+    def collect_into(self, sut: Any, recorder: Any) -> None:
+        """A COLLECT-phase collector: write every role's log into the bundle.
+
+        Declares before writing, so a role whose log never arrives shows up in
+        the seal rather than as a check that quietly found nothing.
+        """
+        for role, spec in sorted(self._roles.items(), key=lambda kv: str(kv[0])):
+            artifact = f"roles/{role}/current.log"
+            recorder.declare(artifact, "local-provider", required=False)
+            if spec.log_path and spec.log_path.exists():
+                recorder.write_text(artifact, spec.log_path.read_text())

--- a/harness/dynamo_test/pytest_plugin.py
+++ b/harness/dynamo_test/pytest_plugin.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The only module in this package that imports pytest.
+
+Everything else stays importable by a CLI, a planner, or a bundle reader that is
+not running under pytest. Keeping that boundary in one file is what makes
+``plan`` and ``judge`` work in a bare checkout.
+
+## What this plugin is for
+
+Recording **exactly which tests a given ``-m`` expression selects**, so a change
+to markers or to collection can be diffed instead of trusted. That diff is the
+gate that makes every later migration step safe: a refactor that silently stops
+selecting 40 GPU tests looks identical to a green run otherwise.
+
+## Why it snapshots first and subtracts deselections
+
+The obvious implementation — observe the item list after everything has had its
+say, with ``trylast`` — does not work on this repository, for two reasons that
+are both measurable:
+
+* ``--collect-only`` is **structurally blind**. ``tests/conftest.py:693`` guards
+  *both* the ``--max-vram-gib`` deselection *and* ``write_test_meta`` on
+  ``not config.option.collectonly``, so a collect-only run cannot observe the one
+  mechanism that removes tests.
+* ``--dry-run`` does see the deselection, but ``tests/conftest.py:761`` calls
+  ``items.clear()`` before returning. A ``trylast`` observer under ``--dry-run``
+  sees an empty list and reports that nothing is selected.
+
+So: snapshot the full set **first** (``tryfirst``), record every deselection as
+it happens through the ``pytest_deselected`` hook, and take the difference. That
+is correct under both flags and does not depend on where any other hook sits in
+the ordering.
+
+The ordering detail worth knowing, because it is easy to model wrongly: the
+repository's own hook is declared ``@pytest.hookimpl(trylast=True)``
+(``tests/conftest.py:660``), which is what puts pytest's ``-m`` deselection
+*before* it. A test fixture that omits that decorator gets the opposite order —
+its conftest clears the item list before ``-m`` is ever applied — and then
+asserts the gate works on a repository that does not exist.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+__all__ = ["SelectionRecorder", "pytest_addoption", "pytest_configure"]
+
+ENV_OUT = "DYNAMO_TEST_SELECTION_OUT"
+
+
+class SelectionRecorder:
+    """Records the tests a run would actually execute, and their markers."""
+
+    def __init__(self, out_path: Path) -> None:
+        self.out_path = out_path
+        self.collected: list[dict] = []
+        self.deselected: set[str] = set()
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_collection_modifyitems(self, config, items):
+        # tryfirst: capture everything before any other hook can remove, clear,
+        # or reorder it. Subtraction happens at the end, from pytest_deselected.
+        for item in items:
+            self.collected.append(
+                {
+                    "nodeid": item.nodeid,
+                    "markers": sorted({m.name for m in item.iter_markers()}),
+                    "marker_args": {
+                        m.name: [repr(a) for a in m.args]
+                        for m in item.iter_markers()
+                        if m.args
+                    },
+                }
+            )
+
+    def pytest_deselected(self, items):
+        for item in items:
+            self.deselected.add(item.nodeid)
+
+    def pytest_sessionfinish(self, session, exitstatus):
+        selected = [c for c in self.collected if c["nodeid"] not in self.deselected]
+        payload = {
+            "collected": len(self.collected),
+            "deselected": len(self.deselected),
+            "selected": len(selected),
+            "tests": selected,
+            "deselected_ids": sorted(self.deselected),
+        }
+        self.out_path.parent.mkdir(parents=True, exist_ok=True)
+        self.out_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--dynamo-selection-out",
+        default=None,
+        help=(
+            "Write the set of tests this run would execute, with their markers, "
+            "to this JSON file. Used by the marker-parity gate."
+        ),
+    )
+
+
+def pytest_configure(config):
+    out = config.getoption("--dynamo-selection-out", default=None) or os.environ.get(
+        ENV_OUT
+    )
+    if not out:
+        return
+    config.pluginmanager.register(SelectionRecorder(Path(out)), "dynamo-selection")

--- a/harness/dynamo_test/pytest_plugin.py
+++ b/harness/dynamo_test/pytest_plugin.py
@@ -96,7 +96,20 @@ class SelectionRecorder:
         self.out_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
 
 
+ENV_SITE = "DYNAMO_TEST_SITE"
+
+
 def pytest_addoption(parser):
+    parser.addoption(
+        "--site",
+        default=None,
+        help=(
+            "Which site to run against: where the system under test lives and "
+            "who owns its lifecycle. Falls back to $DYNAMO_TEST_SITE, then to "
+            "the built-in 'local' (all-in-one, impose). Selecting a site must "
+            "never change which tests are selected -- only what they can do."
+        ),
+    )
     parser.addoption(
         "--dynamo-selection-out",
         default=None,
@@ -108,6 +121,22 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    # Resolve the site once, here, so a failure names an unknown site at startup
+    # rather than in the middle of a run. Stashed rather than global: two pytest
+    # sessions in one process must not share it.
+    from .site import UnknownSite, resolve
+
+    try:
+        config._dynamo_site = resolve(  # noqa: SLF001 - pytest's own stash idiom
+            config.getoption("--site", default=None) or os.environ.get(ENV_SITE)
+        )
+    except UnknownSite as exc:
+        # A mistyped option is a usage error, not a harness crash. Raising
+        # UnknownSite out of pytest_configure gets reported as INTERNALERROR
+        # with a traceback, which buries the one useful line -- the list of
+        # sites that do exist.
+        raise pytest.UsageError(str(exc).strip('"')) from None
+
     out = config.getoption("--dynamo-selection-out", default=None) or os.environ.get(
         ENV_OUT
     )

--- a/harness/dynamo_test/roles.py
+++ b/harness/dynamo_test/roles.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Roles, selectors, and the one place a role becomes a concrete service name.
+
+A Dynamo deployment names the same thing several ways at once. The frontend is
+``Frontend`` in a v1alpha1 manifest, ``frontend`` as a log directory, ``dynamo``
+in a Prometheus label, and ``dynamo.frontend`` as a process. Every layer that
+re-derives one spelling from another is a place where a lookup can miss.
+
+When a lookup misses, what happens next is decided by the polarity of whoever
+asked. Measured in the scenario suite this design converges with: log reads
+resolve a service name through a lowercase directory listing plus a hard-coded
+alias list of three names, and every consumer then does
+``logs.get(name, "") or ""``. Names outside that list — ``VllmWorker``,
+``TRTLLMPrefillWorker``, ``TRTLLMDecodeWorker``, all of which are passed to
+checks today — resolve to the empty string with no error. A check asserting a
+pattern *is* present then fails loudly; a check asserting one is *not* present
+passes vacuously. Which of those a given deployment gets is luck.
+
+So this module makes two rules structural:
+
+1. **Resolution happens once, here.** :class:`RoleTable` is derived from the
+   deployment plan, and every later layer asks it rather than reconstructing a
+   name. ``log_key`` is one string used for both the bundle directory and the
+   log-scrape key, so the two cannot drift apart.
+2. **An unresolved role raises at plan time**, naming the roles that do exist.
+   It never returns a default, because an empty result is indistinguishable from
+   a real one — an empty log stream from a wrong-but-valid key is
+   *present-and-empty*, not absent, so no amount of absence checking downstream
+   recovers it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterator
+
+__all__ = [
+    "Role",
+    "Process",
+    "Policy",
+    "PortName",
+    "Sel",
+    "at",
+    "RoleBinding",
+    "RoleTable",
+    "UnknownRole",
+]
+
+
+class Role(str, Enum):
+    """What a component *is*, independent of what a manifest calls it."""
+
+    FRONTEND = "frontend"
+    WORKER = "worker"
+    PREFILL = "prefill"
+    DECODE = "decode"
+    ENCODE = "encode"
+    ROUTER = "router"
+    PLANNER = "planner"
+    OPERATOR = "operator"
+    KVBM = "kvbm"
+    LOAD = "load"
+    ETCD = "etcd"
+    NATS = "nats"
+    GATEWAY = "gateway"
+    SELF = "self"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class Process(str, Enum):
+    """A process *within* a role, named semantically.
+
+    ``ENGINE`` is ``VLLM::EngineCore`` on vLLM and a ``sglang::scheduler`` child
+    on SGLang. Tests say what they mean; the engine dialect knows the spelling.
+    """
+
+    MAIN = "main"
+    ENGINE = "engine"
+    WORKER = "worker"
+    RANK = "rank"
+
+
+class Policy(str, Enum):
+    """How to pick among replicas when a selector does not name one."""
+
+    FIRST = "first"
+    ALL = "all"
+    RANDOM = "random"
+    HOTTEST = "hottest"
+
+
+class PortName(str, Enum):
+    SERVICE = "service"
+    SYSTEM = "system"
+    METRICS = "metrics"
+    GRPC = "grpc"
+
+
+class UnknownRole(KeyError):
+    """A role was requested that this deployment does not have.
+
+    Raised when the role table is built or first consulted — before any fault is
+    injected — so the failure names a configuration mistake rather than surfacing
+    later as a check that mysteriously found nothing.
+    """
+
+    def __init__(self, role: object, known: tuple[str, ...]) -> None:
+        self.role = role
+        self.known = known
+        super().__init__(
+            f"no binding for role {role!r}; this deployment declares: "
+            f"{', '.join(known) if known else '<none>'}"
+        )
+
+
+@dataclass(frozen=True)
+class Sel:
+    """Which instance of a role a verb acts on.
+
+    Selection is hoisted out of every verb signature. Without this, each verb
+    grows its own ``rank=``/``process=``/``pod_indices=``/``fraction=`` argument
+    set and they drift; with it, ``restart(at("decode", replica=1))`` and
+    ``stall(at("decode", replica=1))`` mean the same thing by construction.
+    """
+
+    role: Role
+    replica: int | None = None
+    policy: Policy | None = None
+    fraction: float | None = None
+    rank: int | None = None
+    process: Process | None = None
+    port: PortName = PortName.SERVICE
+
+    def __post_init__(self) -> None:
+        if self.replica is not None and self.policy is not None:
+            raise ValueError(
+                f"{self}: replica and policy both given; a selector either names "
+                "a replica or says how to choose one"
+            )
+        if self.replica is not None and self.replica < 0:
+            raise ValueError(f"replica must be non-negative, got {self.replica}")
+        if self.fraction is not None and not 0 < self.fraction <= 1:
+            raise ValueError(f"fraction must be in (0, 1], got {self.fraction}")
+
+    def describe(self) -> str:
+        """A short, stable string for log lines and evidence keys."""
+        parts = [str(self.role)]
+        if self.replica is not None:
+            parts.append(f"replica={self.replica}")
+        elif self.policy is not None:
+            parts.append(f"policy={self.policy.value}")
+        if self.rank is not None:
+            parts.append(f"rank={self.rank}")
+        if self.process is not None:
+            parts.append(f"process={self.process.value}")
+        return "/".join(parts)
+
+    def __str__(self) -> str:
+        return self.describe()
+
+
+def at(role: Role | str, **kwargs: Any) -> Sel:
+    """Build a :class:`Sel`. The only constructor callers should use.
+
+    Accepts a plain string so scenario documents can say ``role: decode``
+    without importing the enum; an unrecognised string fails here, at the call
+    site, rather than as a lookup miss much later.
+    """
+    if not isinstance(role, Role):
+        try:
+            role = Role(str(role).lower())
+        except ValueError:
+            raise UnknownRole(role, tuple(r.value for r in Role)) from None
+    return Sel(role=role, **kwargs)
+
+
+@dataclass(frozen=True)
+class RoleBinding:
+    """Every spelling of one role, resolved once.
+
+    ``log_key`` is deliberately a single field rather than a directory name and
+    a scrape key that some helper relates by lowercasing. That relationship is
+    exactly what silently drops logs for services whose name is not in an alias
+    list.
+    """
+
+    role: Role
+    service: str
+    log_key: str
+    metric_labels: Mapping[str, str] = field(default_factory=dict)
+    argv_target: str = "main"
+    processes: Mapping[Process, str] = field(default_factory=dict)
+    ports: Mapping[PortName, int] = field(default_factory=dict)
+
+    def process_pattern(self, process: Process) -> str:
+        """The ``ps`` substring identifying ``process`` in this role."""
+        try:
+            return self.processes[process]
+        except KeyError:
+            raise KeyError(
+                f"role {self.role} has no {process.value!r} process; it declares: "
+                f"{', '.join(p.value for p in self.processes) or '<none>'}"
+            ) from None
+
+    def port(self, name: PortName = PortName.SERVICE) -> int:
+        try:
+            return self.ports[name]
+        except KeyError:
+            raise KeyError(
+                f"role {self.role} exposes no {name.value!r} port; it declares: "
+                f"{', '.join(p.value for p in self.ports) or '<none>'}"
+            ) from None
+
+
+class RoleTable(Mapping):
+    """The resolved roles of one deployment.
+
+    Built once, then consulted — never rebuilt from a manifest by a later layer.
+    Serialise it into the run record so a check can prove which service each
+    role resolved to instead of inferring it from whether a read returned
+    anything.
+    """
+
+    def __init__(self, bindings: Mapping[Role, RoleBinding]) -> None:
+        self._bindings = dict(bindings)
+        for role, binding in self._bindings.items():
+            if binding.role != role:
+                raise ValueError(
+                    f"binding filed under {role} declares role {binding.role}"
+                )
+        duplicates = _duplicates(b.log_key for b in self._bindings.values())
+        if duplicates:
+            raise ValueError(
+                f"log_key must identify exactly one role; reused: {sorted(duplicates)}. "
+                "Two roles sharing a key means one role's evidence overwrites the other's."
+            )
+
+    def __getitem__(self, role: Role | str) -> RoleBinding:
+        return self.require(role)
+
+    def __iter__(self) -> Iterator[Role]:
+        return iter(self._bindings)
+
+    def __len__(self) -> int:
+        return len(self._bindings)
+
+    def require(self, role: Role | str) -> RoleBinding:
+        """The binding for ``role``, or raise naming the roles that exist.
+
+        Never returns a placeholder. A default here reappears downstream as an
+        empty log stream or an unmatched metric label, where it is
+        indistinguishable from a real measurement of nothing.
+        """
+        if not isinstance(role, Role):
+            try:
+                role = Role(str(role).lower())
+            except ValueError:
+                raise UnknownRole(role, self.known()) from None
+        try:
+            return self._bindings[role]
+        except KeyError:
+            raise UnknownRole(role, self.known()) from None
+
+    def known(self) -> tuple[str, ...]:
+        return tuple(sorted(str(r) for r in self._bindings))
+
+    def resolve(self, sel: Sel) -> RoleBinding:
+        """The binding a selector refers to."""
+        return self.require(sel.role)
+
+    def to_record(self) -> dict:
+        """A JSON-safe view for the run record.
+
+        Recording resolution is what makes ``role_bindings_resolved`` provable
+        rather than assumed.
+        """
+        return {
+            str(role): {
+                "service": b.service,
+                "log_key": b.log_key,
+                "metric_labels": dict(b.metric_labels),
+                "argv_target": b.argv_target,
+                "processes": {p.value: v for p, v in b.processes.items()},
+                "ports": {p.value: v for p, v in b.ports.items()},
+            }
+            for role, b in sorted(self._bindings.items(), key=lambda kv: str(kv[0]))
+        }
+
+    def __repr__(self) -> str:
+        return f"RoleTable({', '.join(self.known())})"
+
+
+def _duplicates(values) -> set:
+    seen, dupes = set(), set()
+    for value in values:
+        if value in seen:
+            dupes.add(value)
+        seen.add(value)
+    return dupes

--- a/harness/dynamo_test/site.py
+++ b/harness/dynamo_test/site.py
@@ -1,0 +1,370 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Where the system under test lives, and who owns its lifecycle.
+
+These are two independent questions, and conflating them is the mistake this
+module exists to prevent.
+
+*Where it lives* decides what is physically possible. If pytest and the workers
+share a process namespace, a test can send SIGSTOP to an engine subprocess. If
+they are in different containers, that same call is meaningless — there is no
+such process to signal.
+
+*Who owns it* decides what is permitted. A test that applied a
+DynamoGraphDeployment may tear it down. A test that attached to a deployment
+somebody else is running may not, even though the API call would succeed.
+
+The four topologies the suite needs to span:
+
+======================  ================================================
+``all-in-one``          pytest and every Dynamo process in one container.
+                        What CI does today.
+``sidecar``             pytest in its own container, the stack in another.
+``compose``             pytest, a stock upstream engine, a Dynamo sidecar and
+                        a Dynamo frontend, each in its own container.
+``kubernetes``          a DynamoGraphDeployment on a cluster.
+======================  ================================================
+
+## Capabilities are computed, never declared
+
+A site does not get to *say* it can signal an inner process. It says where it is
+and who owns it, and the capability set follows. This matters because a
+declaration can be wrong, and a wrong declaration fails in the worst possible
+way: the verb is attempted, the platform quietly does nothing resembling what
+was asked, and the test passes having measured nothing.
+
+So the flow is one-directional — facts in, capabilities out — and a site
+definition may only ever **narrow** the result. There is no way to widen it,
+because widening is exactly the lie that produces a vacuous pass.
+
+## Why every removal carries a reason
+
+:func:`why` returns the specific rung that removed a capability, in the author's
+words rather than as a boolean:
+
+    shares_network=False: this site cannot reach a test-owned sink
+
+A skip that says "not supported here" teaches nothing and gets copied. A skip
+that names the property responsible tells the reader whether to fix the site,
+pick another one, or accept that the test belongs to one tier.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable, Mapping
+
+__all__ = [
+    "Topology",
+    "Ownership",
+    "Capability",
+    "Site",
+    "UnknownSite",
+    "capabilities",
+    "why",
+    "LOCAL",
+    "BUILTIN_SITES",
+    "resolve",
+]
+
+
+class Topology(str, Enum):
+    """Where the system under test runs, relative to the test process.
+
+    A **reporting label**. Nothing in the harness branches on it, deliberately:
+    the moment behaviour keys off the topology name, adding a fifth arrangement
+    means auditing every branch. Behaviour keys off the three physical
+    properties on :class:`Site` instead, and the label exists so a run record and
+    a failure message can say which arrangement was in play.
+    """
+
+    ALL_IN_ONE = "all-in-one"
+    SIDECAR = "sidecar"
+    COMPOSE = "compose"
+    KUBERNETES = "kubernetes"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class Ownership(str, Enum):
+    """What bringing the system up actually does.
+
+    Verbs, not adjectives — each names an action the harness will take, so a
+    reader can tell what happens on entry and on exit without consulting a table.
+    """
+
+    IMPOSE = "impose"
+    """Create it, wait for it, destroy it after the evidence is sealed.
+
+    The declared stack is a **recipe**: whatever it says, the harness makes true.
+    """
+
+    VERIFY = "verify"
+    """Bind to something already running and check it is what was declared.
+
+    The declared stack is an **expectation**, not a recipe. Divergence raises at
+    bind time rather than surfacing later as a confusing assertion failure. This
+    is the mode that makes the existing all-in-one CI job usable without
+    rewriting it: the container already started everything, and the test's job is
+    to confirm it got what it expected and then measure it.
+    """
+
+    ADOPT = "adopt"
+    """Create it if absent, and never destroy it.
+
+    For expensive shared dependencies. The precedent is already in the suite:
+    ``tests/serve/lora_utils.py`` health-probes MinIO, sets ``_owns_container =
+    False`` when it finds one running, and makes ``stop()`` a no-op.
+    """
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class Capability(str, Enum):
+    """Something a test might need the site to be able to do."""
+
+    RESTART_ROLE = "restart_role"
+    STOP_ROLE = "stop_role"
+    SCALE_REPLICAS = "scale_replicas"
+    SIGNAL_INNER_PROCESS = "signal_inner_process"
+    READ_LOG_FILE = "read_log_file"
+    SINK = "sink"
+    EXEC_IN = "exec_in"
+    SCRUB = "scrub"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+# Verbs that change the deployment. VERIFY holds none of them: a site that does
+# not own what it is looking at may observe it and nothing more.
+_MUTATORS = frozenset(
+    {
+        Capability.RESTART_ROLE,
+        Capability.STOP_ROLE,
+        Capability.SCALE_REPLICAS,
+    }
+)
+
+# Available everywhere, because they need nothing beyond being able to reach the
+# system at all.
+_ALWAYS = frozenset({Capability.EXEC_IN})
+
+# The ceiling is the same for every arrangement, on purpose. An earlier draft
+# subtracted SIGNAL_INNER_PROCESS per topology, which was redundant -- the
+# shares_process_tree rung already removes it -- and actively worse, because the
+# topology-shaped exclusion fired first and `why()` then answered
+# "this arrangement never supports it" instead of naming the property. Two
+# mechanisms expressing one rule will eventually disagree, and the disagreement
+# surfaces as a skip message that contradicts the skip.
+#
+# So there is exactly one place capabilities are removed: the rungs below, each
+# keyed on a physical property. That is what makes Topology a pure label.
+_CEILING = frozenset(Capability)
+
+
+class UnknownSite(KeyError):
+    def __init__(self, name: object, known: Iterable[str]) -> None:
+        known = sorted(known)
+        super().__init__(
+            f"no site named {name!r}; known sites: {', '.join(known) or '<none>'}"
+        )
+
+
+@dataclass(frozen=True)
+class Site:
+    """Where the system under test is, and what may be done to it.
+
+    The three booleans are the whole model. They are *physical properties of the
+    arrangement*, answerable by looking at it, and every capability decision is
+    derived from them.
+    """
+
+    name: str
+    topology: Topology
+    ownership: Ownership
+
+    shares_process_tree: bool
+    """pytest and the workers are in one process namespace.
+
+    True only for all-in-one. It is what makes ``kill -STOP <engine pid>`` and
+    reading a worker's log file off the local filesystem meaningful.
+    """
+
+    shares_network: bool
+    """The system can dial a port the test process bound.
+
+    Distinct from *the test can reach the system*, which is true everywhere and
+    is an addressing question. This is the reverse direction, and it is what an
+    SSRF or callback test depends on. Getting it wrong is unusually bad: a
+    canary that binds ``127.0.0.1`` and is never dialled looks exactly like a
+    canary that correctly refused a request.
+    """
+
+    substrate_owned: bool
+    """The namespace, compose project or container belongs to this run.
+
+    Authorises destruction that reaches beyond the deployment itself. False for
+    a shared cluster namespace, where scrubbing deletes other people's work.
+    """
+
+    provider: str = "local"
+    narrow: frozenset = frozenset()
+    """Capabilities this site declines even though they are possible.
+
+    Narrowing only. There is no widening field, because the whole point of
+    computing capabilities is that a site cannot claim one it does not have.
+    """
+
+    settings: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("a site needs a name; it appears in every failure message")
+        if self.shares_process_tree and self.topology is not Topology.ALL_IN_ONE:
+            raise ValueError(
+                f"site {self.name!r} claims a shared process tree on "
+                f"{self.topology} — only all-in-one puts pytest and the workers "
+                "in one process namespace, and believing otherwise makes every "
+                "signal-based fault test vacuous"
+            )
+        unknown = set(self.narrow) - set(Capability)
+        if unknown:
+            raise ValueError(
+                f"site {self.name!r} narrows unknown capabilities: {unknown}"
+            )
+
+    def capabilities(self, provider_caps: Iterable[Capability] | None = None):
+        return capabilities(self, provider_caps)
+
+    def can(self, capability: Capability, provider_caps=None) -> bool:
+        return capability in capabilities(self, provider_caps)
+
+    def why(self, capability: Capability, provider_caps=None) -> str | None:
+        return why(self, capability, provider_caps)
+
+    def to_record(self) -> dict:
+        return {
+            "name": self.name,
+            "topology": self.topology.value,
+            "ownership": self.ownership.value,
+            "shares_process_tree": self.shares_process_tree,
+            "shares_network": self.shares_network,
+            "substrate_owned": self.substrate_owned,
+            "provider": self.provider,
+            "narrow": sorted(c.value for c in self.narrow),
+            "capabilities": sorted(c.value for c in capabilities(self)),
+            "settings": dict(self.settings),
+        }
+
+    def __str__(self) -> str:
+        return f"{self.name} ({self.topology}, {self.ownership})"
+
+
+# The rungs, in the order they are applied. Each is (predicate, capabilities it
+# removes, the sentence a test author reads). Keeping them as data rather than
+# as an if-chain is what lets `why()` answer without duplicating the logic --
+# two copies of this reasoning would eventually disagree, and the disagreement
+# would show up as a skip message that contradicts the skip.
+_RUNGS = (
+    (
+        lambda s: not s.shares_process_tree,
+        frozenset({Capability.SIGNAL_INNER_PROCESS, Capability.READ_LOG_FILE}),
+        "shares_process_tree=False: the system is in another process namespace, "
+        "so there is no local pid to signal and no local log file to read",
+    ),
+    (
+        lambda s: not s.shares_network,
+        frozenset({Capability.SINK}),
+        "shares_network=False: the system cannot dial a listener this test "
+        "process bound, so a callback would never arrive and the test would "
+        "pass without measuring anything",
+    ),
+    (
+        lambda s: s.ownership is Ownership.VERIFY,
+        _MUTATORS,
+        "ownership=verify: this site attached to a deployment it does not own, "
+        "so it may observe but not mutate it",
+    ),
+    (
+        lambda s: not s.substrate_owned,
+        frozenset({Capability.SCRUB}),
+        "substrate_owned=False: the namespace or compose project is shared, so "
+        "destroying everything in it would take other runs with it",
+    ),
+)
+
+
+def capabilities(site: Site, provider_caps: Iterable[Capability] | None = None):
+    """What this site can actually do.
+
+    Computed. Facts in, capabilities out — a site has no way to assert one it
+    does not have.
+
+    ``provider_caps`` is physics rather than policy: whatever the arrangement
+    permits, a provider that has not implemented a verb cannot perform it.
+    """
+    caps = _ALWAYS | _CEILING
+    for predicate, removed, _reason in _RUNGS:
+        if predicate(site):
+            caps -= removed
+    if provider_caps is not None:
+        caps &= frozenset(provider_caps)
+    return frozenset(caps) - frozenset(site.narrow)
+
+
+def why(
+    site: Site,
+    capability: Capability,
+    provider_caps: Iterable[Capability] | None = None,
+) -> str | None:
+    """Why ``capability`` is unavailable here, or ``None`` if it is available.
+
+    Returns the *first* rung that removed it, because that is the one worth
+    fixing: later rungs would have removed it anyway, and reporting all of them
+    buries the actionable one.
+    """
+    if capability in capabilities(site, provider_caps):
+        return None
+
+    for predicate, removed, reason in _RUNGS:
+        if predicate(site) and capability in removed:
+            return reason
+    if capability in site.narrow:
+        return f"site {site.name!r} narrows {capability} explicitly"
+    if provider_caps is not None and capability not in frozenset(provider_caps):
+        return (
+            f"provider={site.provider!r} does not implement {capability}; the "
+            "site permits it but nothing can carry it out"
+        )
+    return f"{capability} is unavailable on {site.name}"
+
+
+# The default, in code rather than in a file: a site definition should never be
+# required to run the suite the way it runs today.
+LOCAL = Site(
+    name="local",
+    topology=Topology.ALL_IN_ONE,
+    ownership=Ownership.IMPOSE,
+    shares_process_tree=True,
+    shares_network=True,
+    substrate_owned=True,
+    provider="local",
+)
+
+BUILTIN_SITES: Mapping[str, Site] = {LOCAL.name: LOCAL}
+
+
+def resolve(name: str | None, extra: Mapping[str, Site] | None = None) -> Site:
+    """Look up a site by name, falling back to the built-in ``local``."""
+    known = {**BUILTIN_SITES, **(extra or {})}
+    if not name:
+        return LOCAL
+    try:
+        return known[name]
+    except KeyError:
+        raise UnknownSite(name, known) from None

--- a/harness/dynamo_test/site.py
+++ b/harness/dynamo_test/site.py
@@ -67,6 +67,9 @@ __all__ = [
     "LOCAL",
     "BUILTIN_SITES",
     "resolve",
+    "Refused",
+    "Mismatch",
+    "Divergence",
 ]
 
 
@@ -368,3 +371,75 @@ def resolve(name: str | None, extra: Mapping[str, Site] | None = None) -> Site:
         return known[name]
     except KeyError:
         raise UnknownSite(name, known) from None
+
+
+class Refused(PermissionError):
+    """A verb was called that this site cannot or may not perform.
+
+    **Raised, never returned, and never quietly satisfied.** That is the whole
+    point. A ``stop()`` that no-ops because the site does not own the deployment
+    turns a fault-tolerance test into a test of nothing: the fault is never
+    injected, the system stays healthy, and the assertion that it recovered
+    passes. A raise is noisy and correct; a no-op is quiet and wrong.
+
+    The message names the property responsible, so the reader can tell whether
+    to change the site, pick another, or accept the test belongs to one tier.
+    """
+
+    def __init__(self, verb: str, site: "Site", why_not: str | None = None) -> None:
+        self.verb = verb
+        self.site = site
+        self.why_not = why_not
+        super().__init__(
+            f"{verb}() is not available on site {site.name!r} "
+            f"({site.topology}, {site.ownership})" + (f": {why_not}" if why_not else "")
+        )
+
+
+@dataclass(frozen=True)
+class Divergence:
+    """One field where the running system differs from what was declared.
+
+    Both sides are :class:`~dynamo_test.facts.Fact`, which is what lets a
+    comparison record *unverified* instead of guessing. ``declared=KNOWN,
+    observed=UNKNOWN`` means the check could not be made — scoring that as
+    either agreement or divergence would be inventing a result.
+    """
+
+    role: str
+    field: str
+    declared: object  # Fact[Any] -- typed loosely to keep this module import-light
+    observed: object
+
+    @property
+    def is_unverified(self) -> bool:
+        return getattr(self.observed, "is_unknown", False)
+
+    def describe(self) -> str:
+        d = getattr(self.declared, "value", self.declared)
+        o = getattr(self.observed, "value", self.observed)
+        if self.is_unverified:
+            detail = getattr(self.observed, "detail", "")
+            return f"{self.role}.{self.field}: declared {d!r}, could not observe ({detail})"
+        return f"{self.role}.{self.field}: declared {d!r}, observed {o!r}"
+
+
+class Mismatch(AssertionError):
+    """A ``VERIFY`` site bound to something that is not what was declared.
+
+    Raised at bind time, on purpose. The alternative is that the divergence
+    surfaces much later as a confusing symptom: attach to a deployment serving a
+    different model and the first sign is a 404 at query time, which reads like a
+    routing bug rather than "you are looking at the wrong deployment".
+    """
+
+    def __init__(self, divergences: "Iterable[Divergence]") -> None:
+        self.divergences = tuple(divergences)
+        unverified = [d for d in self.divergences if d.is_unverified]
+        lines = "\n  ".join(d.describe() for d in self.divergences)
+        super().__init__(
+            f"the running system does not match what was declared "
+            f"({len(self.divergences)} divergence(s)"
+            + (f", {len(unverified)} unverified" if unverified else "")
+            + f"):\n  {lines}"
+        )

--- a/harness/dynamo_test/stack.py
+++ b/harness/dynamo_test/stack.py
@@ -1,0 +1,361 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Turning a manifest into something you could actually run.
+
+A ``DynamoGraphDeployment`` is not a complete description of how to start
+anything. On Kubernetes it does not need to be: the operator fills in the gaps
+on the way to a Pod. Measured over ``recipes/``:
+
+* **57 of 427 components (13%)** declare neither ``command`` nor ``args``, and
+  **27 of 164 frontends (16%)** declare no command at all. The operator supplies
+  ``python3 -m dynamo.frontend``
+  (``deploy/operator/internal/dynamo/component_frontend.go:31-32``).
+* **0 of 427 components declare ``NATS_SERVER`` or ``ETCD_ENDPOINTS``.** Not
+  "few" — none. The operator injects both from its own configuration
+  (``graph.go:1570,1577``). Nothing discovers anything without them.
+* Almost no component declares a port. The operator uses
+  ``DynamoServicePort = 8000`` and ``DynamoSystemPort = 9090``
+  (``consts.go:13,20``).
+
+So a manifest plus an operator is runnable, and a manifest alone is not. Every
+tier below Kubernetes has to supply what the operator would have — which is what
+this module does, by **transcribing** the operator's own defaults rather than
+inventing plausible ones. Where the two disagree, the operator is right and this
+file is a bug.
+
+## Everything carries its provenance
+
+Each resolved field is a :class:`~dynamo_test.facts.Fact` whose ``source`` says
+which rung produced it:
+
+    port 8000 from "operator default consts.go:13 DynamoServicePort"
+    port 8080 from "recipes/x/deploy.yaml[Frontend] --http-port"
+
+That matters more here than almost anywhere else in the harness. A test that
+fails to connect needs to know whether the port came from the manifest, from an
+argument, or from a default this file guessed — those have three different
+fixes, and a bare integer tells you nothing about which.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterator, Mapping
+
+from .facts import Fact
+from .manifest import Component, Plan
+from .roles import PortName, Role
+
+__all__ = ["Defaults", "Render", "Stack", "DYNAMO_DEFAULTS"]
+
+
+@dataclass(frozen=True)
+class Defaults:
+    """What the operator would have supplied, transcribed rather than invented.
+
+    Every field cites the operator source it mirrors. When the operator changes,
+    this is the file that has to change with it, and the citations are how a
+    reader checks whether it has.
+    """
+
+    service_port: int = 8000
+    """``consts.go:13`` ``DynamoServicePort``, container port name ``http``."""
+
+    system_port: int = 9090
+    """``consts.go:20`` ``DynamoSystemPort``, container port name ``system``."""
+
+    frontend_command: tuple[str, ...] = ("python3", "-m", "dynamo.frontend")
+    """``component_frontend.go:31-32``: ``Command=["python3"]``,
+    ``Args=["-m","dynamo.frontend"]``."""
+
+    nats_server: str = "nats://localhost:4222"
+    etcd_endpoints: str = "http://localhost:2379"
+    """``graph.go:1570,1577``. The values come from operator configuration, so
+    these are only a shape; a site is expected to override them with addresses
+    that resolve wherever it puts the discovery plane. A compose site points them
+    at service names, which is the entire reason the frontend can leave the
+    all-in-one container at all."""
+
+    engine_module: Mapping[str, str] = field(
+        default_factory=lambda: {
+            "vllm": "dynamo.vllm",
+            "sglang": "dynamo.sglang",
+            "trtllm": "dynamo.trtllm",
+        }
+    )
+
+    def command_for(
+        self, component: Component, plan_backend: str | None = None
+    ) -> Fact[tuple[str, ...]]:
+        """The command this component would run, or why it cannot be determined."""
+        argv = component.argv
+        if not argv.is_parseable:
+            return Fact.unknown(
+                component.name,
+                f"the declared command could not be tokenised: {argv.parse_error}",
+            )
+        declared = argv.invocation()
+        if declared:
+            return Fact.known(
+                tuple(declared), f"{component.name}", "declared in the manifest"
+            )
+        if component.role is Role.FRONTEND:
+            return Fact.known(
+                self.frontend_command,
+                "operator default",
+                "component_frontend.go:31-32",
+            )
+        engine = self.engine_for(component, plan_backend)
+        if engine.is_known:
+            module = self.engine_module.get(engine.require())
+            if module:
+                return Fact.known(
+                    ("python3", "-m", module),
+                    "operator default",
+                    f"engine {engine.require()!r} from {engine.source}",
+                )
+        return Fact.absent(
+            component.name,
+            "no command in the manifest, not a frontend, and nothing declares "
+            "which engine this is — not the command, not spec.backendFramework. "
+            "On Kubernetes the operator resolves this from the image; off it, a "
+            "site must supply the engine",
+        )
+
+    def engine_for(
+        self, component: Component, plan_backend: str | None = None
+    ) -> Fact[str]:
+        """Which engine a component runs, in descending order of authority.
+
+        The command line first, because it is what actually executes. Then
+        ``spec.backendFramework`` — the CRD's own declared field
+        (``dynamocomponentdeployment_types.go:52``), present in 139 of the 178
+        recipe plans. Nothing is inferred from the component's *name*: it fixes
+        two components in the whole corpus and would guess wrong the first time
+        someone names a worker after a model instead of an engine.
+        """
+        detected = component.backend
+        if detected.is_known:
+            return detected
+        if plan_backend:
+            return Fact.known(
+                plan_backend, "spec.backendFramework", "declared on the deployment"
+            )
+        return Fact.absent(
+            component.name, "no engine on the command line and no spec.backendFramework"
+        )
+
+    def discovery_env(self) -> Mapping[str, str]:
+        """The variables the operator injects and no manifest declares."""
+        return {
+            "NATS_SERVER": self.nats_server,
+            "ETCD_ENDPOINTS": self.etcd_endpoints,
+        }
+
+
+DYNAMO_DEFAULTS = Defaults()
+
+
+@dataclass(frozen=True)
+class Render:
+    """One component, resolved into something runnable — with provenance."""
+
+    role: Role
+    name: str
+    command: Fact[tuple[str, ...]]
+    image: Fact[str]
+    ports: Mapping[PortName, Fact[int]]
+    env: Mapping[str, Fact[str]]
+    replicas: int = 1
+
+    @property
+    def is_runnable(self) -> bool:
+        return self.command.is_known and self.image.is_known
+
+    def why_not_runnable(self) -> str | None:
+        if self.command.is_known and self.image.is_known:
+            return None
+        missing = []
+        if not self.command.is_known:
+            missing.append(
+                f"command: {self.command.detail or self.command.status.value}"
+            )
+        if not self.image.is_known:
+            missing.append(f"image: {self.image.detail or self.image.status.value}")
+        return f"{self.name} is not runnable — " + "; ".join(missing)
+
+    def to_record(self) -> dict:
+        return {
+            "role": str(self.role),
+            "name": self.name,
+            "command": list(self.command.or_else(())),
+            "command_from": self.command.source,
+            "image": self.image.or_else(None),
+            "replicas": self.replicas,
+            "ports": {
+                k.value: {"port": v.or_else(None), "from": v.source}
+                for k, v in sorted(self.ports.items(), key=lambda kv: kv[0].value)
+            },
+            "env": {k: v.or_else(None) for k, v in sorted(self.env.items())},
+        }
+
+
+class Stack:
+    """A :class:`Plan` plus the defaults that make it runnable off Kubernetes.
+
+    The plan says what the deployment *is*. The defaults say what the operator
+    would have added. Together they are enough to start the thing somewhere that
+    has no operator — which is the whole requirement for the compose and
+    all-in-one tiers.
+    """
+
+    def __init__(
+        self,
+        plan: Plan,
+        defaults: Defaults = DYNAMO_DEFAULTS,
+        overrides: Mapping[str, str] | None = None,
+    ) -> None:
+        self.plan = plan
+        self.defaults = defaults
+        self.overrides = dict(overrides or {})
+        self.plan_backend = (plan._graph.get("spec") or {}).get("backendFramework")
+
+    @classmethod
+    def from_file(cls, path, defaults: Defaults = DYNAMO_DEFAULTS, **kw) -> "Stack":
+        return cls(Plan.from_file(path), defaults, **kw)
+
+    # ------------------------------------------------------------- ports
+
+    def resolve_port(self, component: Component, kind: PortName) -> Fact[int]:
+        """Where a port comes from, in descending order of authority.
+
+        manifest ``ports:`` -> a flag on the command line -> an environment
+        variable -> the operator's default -> ``ABSENT``.
+
+        The ladder exists because almost nothing declares a port. Answering with
+        a bare integer would hide which rung produced it, and a connection
+        failure then gives no clue whether to fix the manifest, the flag, or this
+        table.
+        """
+        container = component._container or {}
+        for port in container.get("ports") or []:
+            if not isinstance(port, dict) or "containerPort" not in port:
+                continue
+            name = str(port.get("name", "")).lower()
+            if (kind is PortName.SERVICE and name in ("http", "", "service")) or (
+                name == kind.value
+            ):
+                return Fact.known(
+                    int(port["containerPort"]),
+                    f"{component.name}.ports[{name or 'unnamed'}]",
+                    "declared in the manifest",
+                )
+
+        flag = {PortName.SERVICE: "--http-port", PortName.SYSTEM: "--system-port"}.get(
+            kind
+        )
+        if flag:
+            declared = component.argv.get(flag)
+            if declared.is_known:
+                try:
+                    return Fact.known(
+                        int(declared.require()),
+                        f"{component.name} {flag}",
+                        "on the command line",
+                    )
+                except ValueError:
+                    return Fact.unknown(
+                        f"{component.name} {flag}",
+                        f"{flag} is {declared.require()!r}, which is not a port number",
+                    )
+
+        env = {
+            e.get("name"): e.get("value")
+            for e in (container.get("env") or [])
+            if isinstance(e, dict)
+        }
+        if kind is PortName.SERVICE and env.get("DYNAMO_PORT"):
+            return Fact.known(
+                int(env["DYNAMO_PORT"]),
+                f"{component.name} env DYNAMO_PORT",
+                "consts.go:39",
+            )
+
+        if kind is PortName.SERVICE:
+            return Fact.known(
+                self.defaults.service_port,
+                "operator default",
+                "consts.go:13 DynamoServicePort",
+            )
+        if kind is PortName.SYSTEM:
+            return Fact.known(
+                self.defaults.system_port,
+                "operator default",
+                "consts.go:20 DynamoSystemPort",
+            )
+        return Fact.absent(
+            component.name, f"no {kind.value} port declared and no default"
+        )
+
+    # ------------------------------------------------------------ render
+
+    def render(self, component: Component) -> Render:
+        env: dict[str, Fact[str]] = {}
+        container = component._container or {}
+        for entry in container.get("env") or []:
+            if isinstance(entry, dict) and entry.get("name") and "value" in entry:
+                env[entry["name"]] = Fact.known(
+                    str(entry["value"]),
+                    f"{component.name}.env",
+                    "declared in the manifest",
+                )
+        # The operator's injections. Declared values win: a manifest that names
+        # its own NATS is making a deliberate choice.
+        for key, value in self.defaults.discovery_env().items():
+            env.setdefault(
+                key,
+                Fact.known(
+                    self.overrides.get(key, value),
+                    "operator default",
+                    "graph.go:1570,1577",
+                ),
+            )
+        for key, value in self.overrides.items():
+            env[key] = Fact.known(value, "site override", "settings")
+
+        return Render(
+            role=component.role,
+            name=component.name,
+            command=self.defaults.command_for(component, self.plan_backend),
+            image=component.image,
+            ports={
+                PortName.SERVICE: self.resolve_port(component, PortName.SERVICE),
+                PortName.SYSTEM: self.resolve_port(component, PortName.SYSTEM),
+            },
+            env=env,
+            replicas=component.replicas,
+        )
+
+    def renders(self) -> tuple[Render, ...]:
+        return tuple(self.render(c) for c in self.plan)
+
+    def __iter__(self) -> Iterator[Render]:
+        return iter(self.renders())
+
+    def __len__(self) -> int:
+        return len(self.plan)
+
+    def unrunnable(self) -> tuple[str, ...]:
+        """Components that could not be resolved into something startable."""
+        return tuple(r.why_not_runnable() for r in self.renders() if not r.is_runnable)
+
+    def to_record(self) -> dict:
+        return {
+            "plan": self.plan.name,
+            "source": self.plan.source,
+            "components": [r.to_record() for r in self.renders()],
+        }
+
+    def __repr__(self) -> str:
+        return f"Stack({self.plan.name!r}, {len(self.plan)} components)"

--- a/harness/dynamo_test/sut.py
+++ b/harness/dynamo_test/sut.py
@@ -1,0 +1,398 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The system under test, and the phases you may act on it in.
+
+``Sut`` is the ACT receiver: the object a test does things to. It is the verb
+façade from :mod:`dynamo_test.verbs` made concrete — ``sut.query(...)`` and
+``sut.restart(at("frontend"))`` rather than ``sut.frontend.restart()``, with the
+component spelling still available through ``REGISTRY.bind``.
+
+## Why phases are enforced rather than documented
+
+A test that acts on the deployment, tears it down, and *then* asserts cannot fail
+for the right reason: whatever it reads afterwards is a property of the teardown,
+not of the system. The usual form is a check that reads logs after the context
+manager has exited and finds none, which reads as "no errors".
+
+So leaving the ``with`` block is a state transition, not just cleanup:
+
+* inside — ACT verbs work; evidence is being collected
+* on exit — COLLECT runs **unconditionally**, including when the test has already
+  failed, because a failed run is when its evidence matters most; then the bundle
+  is sealed
+* after — ACT verbs raise :class:`PhaseError` naming the assertion to use
+  instead; only :meth:`Sut.evidence` is legal
+
+The error message matters more than the error. ``kill()`` after teardown is
+almost always someone reaching for an in-timeline assertion, so the exception
+says which CHECK-phase equivalent to reach for.
+
+## Grants
+
+Nothing destructive happens implicitly. A ``Sut`` is constructed with the set of
+:class:`~dynamo_test.verbs.Grant` values the suite has opted into, and a verb
+whose grant is not held raises before the provider is touched — at the call, not
+halfway through a fault.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Mapping, Protocol, Sequence
+
+from . import catalog as _catalog  # noqa: F401  (registers the standard verbs)
+from .evidence import Evidence, Recorder
+from .facts import Fact
+from .roles import Role, RoleTable, Sel, at
+from .verbs import REGISTRY, Grant, Phase, VerbSpec
+
+# `catalog` is imported for its import-time side effect: it is what puts the
+# standard verbs in REGISTRY. Without it every verb lookup here raises
+# UnknownVerb against an empty registry, which is a confusing way to discover
+# that a module was never imported.
+
+__all__ = [
+    "Phase",
+    "PhaseError",
+    "NotGranted",
+    "Handle",
+    "Provider",
+    "Sut",
+]
+
+
+class PhaseError(RuntimeError):
+    """A verb was called in a phase where it cannot mean what it says."""
+
+
+class NotGranted(PermissionError):
+    """A verb was called that this suite has not opted into."""
+
+    def __init__(self, verb: str, needed: Grant, held: Iterable[Grant]) -> None:
+        held = sorted(g.value for g in held)
+        super().__init__(
+            f"{verb}() needs the {needed.value!r} grant; this Sut holds "
+            f"{', '.join(held) or '<none>'}. Grants are opt-in so a suite cannot "
+            "acquire the ability to break things by importing something."
+        )
+
+
+@dataclass(frozen=True)
+class Handle:
+    """What a verb did, when, and what it resolved to.
+
+    Returned by every ACT verb. Being a value rather than ``None`` is what lets a
+    later check say *since this point* — ``expect_restarted(at("worker"),
+    since=h)`` — instead of comparing against wall-clock guesses.
+    """
+
+    verb: str
+    selector: Sel | None
+    started_ns: int
+    ended_ns: int
+    resolved: Mapping[str, Any] = field(default_factory=dict)
+    value: Any = None
+
+    @property
+    def elapsed_s(self) -> float:
+        return (self.ended_ns - self.started_ns) / 1e9
+
+    def to_record(self) -> dict:
+        return {
+            "verb": self.verb,
+            "selector": self.selector.describe() if self.selector else None,
+            "started_ns": self.started_ns,
+            "ended_ns": self.ended_ns,
+            "elapsed_s": round(self.elapsed_s, 6),
+            "resolved": dict(self.resolved),
+        }
+
+
+class Provider(Protocol):
+    """What a platform must do for the verbs to work.
+
+    Narrow on purpose: a new platform is a handful of small methods rather than a
+    fork of a lifecycle module. Everything richer — waiting, probing, evidence —
+    is built on top of these in :class:`Sut`, so it is written once.
+    """
+
+    def address(self, sel: Sel) -> Fact[str]:
+        ...
+
+    def start(self, sel: Sel) -> Mapping[str, Any]:
+        ...
+
+    def stop(self, sel: Sel, *, graceful: bool = True) -> Mapping[str, Any]:
+        ...
+
+    def restart(self, sel: Sel, **settings: Any) -> Mapping[str, Any]:
+        ...
+
+    def replicas(self, sel: Sel) -> Fact[int]:
+        ...
+
+    def restart_count(self, sel: Sel) -> Fact[int]:
+        ...
+
+    def logs(self, sel: Sel) -> Fact[str]:
+        ...
+
+    def request(
+        self,
+        sel: Sel,
+        path: str,
+        *,
+        method: str = "GET",
+        body: Any = None,
+        timeout: float = 30.0,
+    ) -> Fact[Any]:
+        ...
+
+
+class Sut:
+    """The system under test, acted on through verbs.
+
+    Use as a context manager. Leaving the block runs COLLECT and seals the
+    bundle; after that only :meth:`evidence` is legal.
+    """
+
+    def __init__(
+        self,
+        provider: Provider,
+        roles: RoleTable,
+        recorder: Recorder,
+        *,
+        grants: Iterable[Grant] = (Grant.READ,),
+        collectors: Sequence[Callable[["Sut", Recorder], None]] = (),
+    ) -> None:
+        self.provider = provider
+        self.roles = roles
+        self.recorder = recorder
+        self.grants = frozenset(grants)
+        self._collectors = list(collectors)
+        self.phase = Phase.PLAN
+        self.timeline: list[Handle] = []
+        self._evidence: Evidence | None = None
+
+    # ------------------------------------------------------------- phases
+
+    def __enter__(self) -> "Sut":
+        self.phase = Phase.ACT
+        self.recorder.note("roles", self.roles.to_record())
+        self.recorder.note("grants", sorted(g.value for g in self.grants))
+        self.recorder.declare("timeline.jsonl", "sut", min_rows=0)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        # COLLECT runs whether or not the body raised. A failed run is exactly
+        # when its evidence matters, and a collector that only runs on success
+        # collects nothing at the only time anyone needs it.
+        self.phase = Phase.COLLECT
+        try:
+            self.recorder.write_rows(
+                "timeline.jsonl", [h.to_record() for h in self.timeline]
+            )
+            for collect in self._collectors:
+                try:
+                    collect(self, self.recorder)
+                except Exception as collector_error:  # noqa: BLE001
+                    self.recorder.note(
+                        f"collector_error/{getattr(collect, '__name__', 'anonymous')}",
+                        repr(collector_error),
+                    )
+        finally:
+            self.recorder.seal()
+            self.phase = Phase.CHECK
+        return False  # never swallow the body's exception
+
+    def evidence(self) -> Evidence:
+        """The sealed bundle. Legal only after the ``with`` block exits."""
+        if self.phase is not Phase.CHECK:
+            raise PhaseError(
+                f"evidence() is a CHECK-phase call and this Sut is in {self.phase.value}. "
+                "Leave the with-block first; judging a bundle still being written "
+                "gives a different answer on a replay."
+            )
+        if self._evidence is None:
+            self._evidence = self.recorder.evidence()
+        return self._evidence
+
+    # -------------------------------------------------------------- guards
+
+    def _act(self, name: str) -> VerbSpec:
+        spec = REGISTRY.require(name)
+        if self.phase is not Phase.ACT:
+            raise PhaseError(
+                f"{name}() is an ACT verb and this Sut is in {self.phase.value}. "
+                + (
+                    "Assert over the evidence instead — the system may not exist "
+                    "any more, so whatever this read would return is a property of "
+                    "the teardown, not of the deployment."
+                    if self.phase is Phase.CHECK
+                    else "Enter the with-block first."
+                )
+            )
+        if spec.grant not in self.grants and spec.grant is not Grant.READ:
+            raise NotGranted(name, spec.grant, self.grants)
+        return spec
+
+    def _record(
+        self,
+        name: str,
+        sel: Sel | None,
+        started: int,
+        resolved: Mapping[str, Any] | None = None,
+        value: Any = None,
+    ) -> Handle:
+        handle = Handle(
+            verb=name,
+            selector=sel,
+            started_ns=started,
+            ended_ns=time.monotonic_ns(),
+            resolved=dict(resolved or {}),
+            value=value,
+        )
+        self.timeline.append(handle)
+        return handle
+
+    # --------------------------------------------------------------- reach
+
+    def address(self, sel: Sel = at(Role.FRONTEND)) -> Fact[str]:
+        self._act("address")
+        return self.provider.address(sel)
+
+    def url(self, sel: Sel = at(Role.FRONTEND)) -> Fact[str]:
+        self._act("url")
+        return self.provider.address(sel)
+
+    # ----------------------------------------------------------- inference
+
+    def query(
+        self, payload: Any, sel: Sel = at(Role.FRONTEND), *, timeout: float = 60.0
+    ) -> Handle:
+        """One completion. The default role is why most tests just say query()."""
+        self._act("query")
+        started = time.monotonic_ns()
+        body = {"prompt": payload} if isinstance(payload, str) else payload
+        answer = self.provider.request(
+            sel, "/v1/completions", method="POST", body=body, timeout=timeout
+        )
+        return self._record(
+            "query", sel, started, {"ok": answer.is_known}, value=answer
+        )
+
+    def models(self, sel: Sel = at(Role.FRONTEND)) -> Handle:
+        self._act("models")
+        started = time.monotonic_ns()
+        got = self.provider.request(sel, "/v1/models")
+        return self._record("models", sel, started, {"ok": got.is_known}, value=got)
+
+    # ------------------------------------------------------------ waiting
+
+    def wait(self, seconds: float) -> Handle:
+        self._act("wait")
+        started = time.monotonic_ns()
+        time.sleep(seconds)
+        return self._record("wait", None, started, {"seconds": seconds})
+
+    def wait_serving(
+        self,
+        sel: Sel = at(Role.FRONTEND),
+        *,
+        timeout: float = 120.0,
+        interval: float = 0.2,
+    ) -> Handle:
+        """Wait until the endpoint actually answers, not until a pod is ready.
+
+        Readiness and serving are different facts, and a test that waits for the
+        first and asserts on the second is measuring a race.
+        """
+        self._act("wait_serving")
+        started = time.monotonic_ns()
+        deadline = time.monotonic() + timeout
+        last = "never attempted"
+        while time.monotonic() < deadline:
+            got = self.provider.request(sel, "/v1/models", timeout=min(5.0, timeout))
+            if got.is_known:
+                return self._record(
+                    "wait_serving", sel, started, {"ready": True, "models": got.value}
+                )
+            last = got.detail
+            time.sleep(interval)
+        self._record("wait_serving", sel, started, {"ready": False, "last": last})
+        raise TimeoutError(
+            f"{sel.describe()} did not serve within {timeout}s; last attempt: {last}"
+        )
+
+    # ---------------------------------------------------------- lifecycle
+
+    def restart(self, sel: Sel, **settings: Any) -> Handle:
+        self._act("restart")
+        started = time.monotonic_ns()
+        resolved = self.provider.restart(sel, **settings)
+        return self._record("restart", sel, started, resolved)
+
+    def stop(self, sel: Sel, *, graceful: bool = True) -> Handle:
+        self._act("stop")
+        started = time.monotonic_ns()
+        resolved = self.provider.stop(sel, graceful=graceful)
+        return self._record("stop", sel, started, resolved)
+
+    def start(self, sel: Sel) -> Handle:
+        self._act("start")
+        started = time.monotonic_ns()
+        resolved = self.provider.start(sel)
+        return self._record("start", sel, started, resolved)
+
+    # -------------------------------------------- in-timeline assertions
+
+    def require_restarted(
+        self, sel: Sel, *, since: Handle, within: float = 60.0
+    ) -> Handle:
+        """Assert now that a role restarted since ``since``, and record it.
+
+        ``require_*`` raises immediately, unlike ``expect_*`` which is evaluated
+        after the fact over collected evidence. Both exist because some facts —
+        a restart count — are only observable while the system is up.
+        """
+        self._act("require_restarted")
+        started = time.monotonic_ns()
+        deadline = time.monotonic() + within
+        before = since.resolved.get("restart_count")
+        seen = None
+        while time.monotonic() < deadline:
+            got = self.provider.restart_count(sel)
+            if got.is_known:
+                seen = got.require()
+                if before is None or seen > before:
+                    return self._record(
+                        "require_restarted",
+                        sel,
+                        started,
+                        {"before": before, "after": seen},
+                    )
+            time.sleep(0.1)
+        self._record(
+            "require_restarted", sel, started, {"before": before, "after": seen}
+        )
+        raise AssertionError(
+            f"{sel.describe()} did not restart within {within}s "
+            f"(restart count {before} -> {seen})"
+        )
+
+    # ------------------------------------------------------------ reading
+
+    def logs(self, sel: Sel) -> Fact[str]:
+        """Live logs. In CHECK phase, read them from the bundle instead."""
+        self._act("logs")
+        return self.provider.logs(sel)
+
+    def component(self, role: Role | str):
+        """The component-first view: ``sut.component('frontend').restart()``.
+
+        Generated from the verb registry, so it cannot drift from the verb
+        surface — it is not separately written down.
+        """
+        return REGISTRY.bind(self, role)

--- a/harness/dynamo_test/sut.py
+++ b/harness/dynamo_test/sut.py
@@ -150,6 +150,25 @@ class Provider(Protocol):
     ) -> Fact[Any]:
         ...
 
+    # The three below already exist in the only implementation and are
+    # load-bearing for teardown and evidence, but were never declared here. An
+    # undeclared method that every caller depends on is a contract in practice
+    # and a surprise in principle: a second provider could omit it and only fail
+    # at teardown, which is exactly when the evidence it was supposed to collect
+    # is the point.
+
+    def all_logs(self) -> Mapping[str, str]:
+        """Every role's current log, for the COLLECT phase."""
+        ...
+
+    def shutdown(self) -> None:
+        """Stop everything this provider started. Safe to call twice."""
+        ...
+
+    def collect_into(self, sut: "Sut", recorder: Recorder) -> None:
+        """Declare and write this provider's artifacts into the bundle."""
+        ...
+
 
 class Sut:
     """The system under test, acted on through verbs.

--- a/harness/dynamo_test/verbs.py
+++ b/harness/dynamo_test/verbs.py
@@ -1,0 +1,486 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The verb registry: one name per action, and what that name promises.
+
+## Why verbs take the role as an argument
+
+``dynamo.restart("frontend")`` rather than ``dynamo.frontend.restart()``. The
+reason is not taste, it is that a scenario written as a document has to become a
+call:
+
+    - kind: StallProcess          ->   stall_process(at("worker", rank=0), seconds=30)
+      role: worker
+      rank: 0
+      seconds: 30
+
+With the role as an argument that mapping is mechanical — the document names a
+verb and a selector, and both are values. With a component-first surface the
+runner needs a dispatch table from event kind to attribute path, which is a
+second source of truth that drifts from the first.
+
+The component-first spelling is still available: :meth:`VerbRegistry.bind` makes
+``sut.frontend.restart()`` out of the same registry entry, so there is one
+definition and two spellings, rather than two definitions.
+
+## Why the name carries the gating policy
+
+A check that can be switched from asserting to observing by an argument reports
+the same result either way. Measured in the scenario suite this converges with:
+five of its 49 checks assert *and* contain a bare early return, so an argument
+turns the gate off — and the report still says ``PASSED``. There is no way, from
+the outside, to tell a check that held from a check that was asked not to look.
+
+So the policy lives in the name, where the result can see it:
+
+===============  ========  ================================================
+prefix           receiver  contributes to
+===============  ========  ================================================
+``expect_``      JUDGE     the verdict — must hold
+``observe_``     JUDGE     ``OBSERVED``; measured on purpose, never gates
+``require_``     ACT       must hold *now*; raises now, and records
+``require_valid_`` JUDGE   run validity — is this measurement admissible?
+``report_``      JUDGE     an artifact; runs first, never gates
+everything else  ACT       does a thing
+===============  ========  ================================================
+
+``observe_worker_panics`` and ``expect_no_worker_panics`` are different verbs
+with different verdicts. The branch that is invisible today becomes a name.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Iterator, Mapping, Sequence
+
+from .roles import Role, Sel, at
+
+__all__ = [
+    "Phase",
+    "Receiver",
+    "Grant",
+    "Verdict",
+    "VerbSpec",
+    "VerbCall",
+    "VerbRegistry",
+    "REGISTRY",
+    "verb",
+    "DuplicateVerb",
+    "NamingLaw",
+    "UnknownVerb",
+    "MissingProofContract",
+]
+
+
+class Phase(str, Enum):
+    """When a verb may run. Enforced by the receiver, not by convention."""
+
+    ARRANGE = "arrange"
+    ACT = "act"
+    COLLECT = "collect"
+    CHECK = "check"
+
+
+class Receiver(str, Enum):
+    ACT = "act"
+    JUDGE = "judge"
+
+
+class Grant(str, Enum):
+    """What a verb is allowed to do. A suite opts in; nothing is implicit.
+
+    ``LIFECYCLE`` and ``FAULT`` are separate because a suite that may restart a
+    worker to change a flag is not thereby permitted to kill one, and
+    ``INFRA`` is separate again because scaling ``etcd`` to zero in a shared
+    namespace breaks tests that are not yours.
+    """
+
+    READ = "read"
+    INFER = "infer"
+    LIFECYCLE = "lifecycle"
+    FAULT = "fault"
+    INFRA = "infra"
+
+
+class Verdict(str, Enum):
+    """What a verb's outcome contributes to the run result."""
+
+    GATES = "gates"
+    OBSERVED = "observed"
+    VALIDITY = "validity"
+    ARTIFACT = "artifact"
+    NONE = "none"
+
+
+class DuplicateVerb(ValueError):
+    """A verb name was registered twice."""
+
+
+class NamingLaw(ValueError):
+    """A verb name does not match the policy its receiver requires."""
+
+
+class MissingProofContract(ValueError):
+    """A fault verb did not declare what its effect proves.
+
+    A fault whose effect is not observable is indistinguishable from a fault
+    that silently did nothing, and a test built on one passes for the wrong
+    reason.
+    """
+
+
+class UnknownVerb(KeyError):
+    def __init__(self, name: object, known: Sequence[str]) -> None:
+        self.name = name
+        near = [k for k in known if isinstance(name, str) and name.lower() in k]
+        super().__init__(
+            f"no verb named {name!r}"
+            + (f"; did you mean {', '.join(near)}?" if near else "")
+            + f" ({len(known)} verbs registered)"
+        )
+
+
+# Pure readers are exempt from the JUDGE prefix law: they return data and assert
+# nothing, so there is no gating policy for a prefix to carry.
+PURE_READERS = frozenset(
+    {
+        "series",
+        "logs",
+        "timeline",
+        "metrics",
+        "spans",
+        "requests",
+        "records",
+        "pod_state",
+        "artifacts",
+        "proofs",
+    }
+)
+
+_PREFIX_VERDICT = {
+    "expect_": Verdict.GATES,
+    "observe_": Verdict.OBSERVED,
+    "require_valid_": Verdict.VALIDITY,
+    "report_": Verdict.ARTIFACT,
+}
+
+_NAME = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class VerbSpec:
+    """One verb: what it does, when it may run, and what it promises."""
+
+    name: str
+    receiver: Receiver
+    phase: Phase
+    grant: Grant
+    summary: str
+    takes_selector: bool = True
+    default_role: Role | None = None
+    params: Mapping[str, str] = field(default_factory=dict)
+    proves: tuple[str, ...] = ()
+    aliases: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not _NAME.match(self.name):
+            raise NamingLaw(
+                f"{self.name!r} is not a valid verb name: lowercase, digits and "
+                "underscores, starting with a letter"
+            )
+        if self.receiver is Receiver.JUDGE:
+            if self.name not in PURE_READERS and not any(
+                self.name.startswith(p) for p in _PREFIX_VERDICT
+            ):
+                raise NamingLaw(
+                    f"JUDGE verb {self.name!r} must start with one of "
+                    f"{', '.join(sorted(_PREFIX_VERDICT))} — the prefix is how a "
+                    "reader tells a gate from an observation — or be one of the "
+                    f"pure readers ({', '.join(sorted(PURE_READERS))})."
+                )
+        elif self.name.startswith(("expect_", "observe_", "report_")):
+            raise NamingLaw(
+                f"ACT verb {self.name!r} uses a JUDGE prefix. ACT-phase assertions "
+                "are spelled require_*, which raise immediately and record."
+            )
+        if self.grant is Grant.FAULT and not self.proves:
+            raise MissingProofContract(
+                f"fault verb {self.name!r} declares no proves=(...). A fault whose "
+                "effect cannot be observed is indistinguishable from one that "
+                "silently did nothing."
+            )
+
+    @property
+    def verdict(self) -> Verdict:
+        """What this verb's outcome contributes to the run result."""
+        if self.receiver is Receiver.ACT:
+            return Verdict.NONE
+        for prefix, verdict in _PREFIX_VERDICT.items():
+            if self.name.startswith(prefix):
+                return verdict
+        return Verdict.NONE
+
+    @property
+    def gates(self) -> bool:
+        return self.verdict is Verdict.GATES
+
+    def call(self, **kwargs: Any) -> "VerbCall":
+        """Build a call to this verb, validating the selector."""
+        return VerbCall.build(self, kwargs)
+
+
+@dataclass(frozen=True)
+class VerbCall:
+    """A verb plus its arguments — the value a scenario document becomes.
+
+    Being a value rather than a bound method is what lets a timeline be
+    serialised, replayed, diffed against a previous run, and printed in a plan
+    without executing anything.
+    """
+
+    spec: VerbSpec
+    selector: Sel | None
+    kwargs: Mapping[str, Any]
+
+    @classmethod
+    def build(cls, spec: VerbSpec, kwargs: Mapping[str, Any]) -> "VerbCall":
+        kwargs = dict(kwargs)
+        selector = kwargs.pop("sel", None)
+
+        if spec.takes_selector:
+            role = kwargs.pop("role", None)
+            if selector is None:
+                selector_fields = {
+                    k: kwargs.pop(k)
+                    for k in (
+                        "replica",
+                        "policy",
+                        "rank",
+                        "process",
+                        "port",
+                        "fraction",
+                    )
+                    if k in kwargs
+                }
+                if role is not None:
+                    selector = at(role, **selector_fields)
+                elif spec.default_role is not None:
+                    selector = at(spec.default_role, **selector_fields)
+                elif selector_fields:
+                    raise TypeError(
+                        f"{spec.name}: {', '.join(sorted(selector_fields))} given "
+                        "without a role to apply them to"
+                    )
+        elif selector is not None or "role" in kwargs:
+            raise TypeError(f"{spec.name} does not act on a role")
+
+        unknown = set(kwargs) - set(spec.params)
+        if unknown and spec.params:
+            raise TypeError(
+                f"{spec.name}: unexpected argument(s) {', '.join(sorted(unknown))}; "
+                f"accepts {', '.join(sorted(spec.params)) or '<none>'}"
+            )
+        return cls(spec=spec, selector=selector, kwargs=kwargs)
+
+    @classmethod
+    def from_document(
+        cls, event: Mapping[str, Any], registry: "VerbRegistry | None" = None
+    ) -> "VerbCall":
+        """Read one scenario-document event into a call.
+
+        The whole point of role-as-argument: this is a lookup and a splat, not a
+        dispatch table that has to be kept in step with the verb surface.
+        """
+        registry = registry or REGISTRY
+        event = dict(event)
+        kind = event.pop("kind", None) or event.pop("verb", None)
+        if kind is None:
+            raise ValueError(f"event has no 'kind' or 'verb': {sorted(event)}")
+        return registry.require(str(kind)).call(**event)
+
+    def to_document(self) -> dict:
+        """The inverse of :meth:`from_document`."""
+        out: dict[str, Any] = {"kind": self.spec.name}
+        if self.selector is not None:
+            out["role"] = str(self.selector.role)
+            for name in ("replica", "rank", "fraction"):
+                value = getattr(self.selector, name)
+                if value is not None:
+                    out[name] = value
+            if self.selector.policy is not None:
+                out["policy"] = self.selector.policy.value
+            if self.selector.process is not None:
+                out["process"] = self.selector.process.value
+        out.update(self.kwargs)
+        return out
+
+    def describe(self) -> str:
+        parts = []
+        if self.selector is not None:
+            parts.append(f"at({self.selector.describe()!r})")
+        parts += [f"{k}={v!r}" for k, v in sorted(self.kwargs.items())]
+        return f"{self.spec.name}({', '.join(parts)})"
+
+    def __str__(self) -> str:
+        return self.describe()
+
+
+class VerbRegistry:
+    """Every verb, and the rules they must satisfy.
+
+    Validation runs at registration, so a violation is an import error in the
+    module that declared it rather than a surprise at run time.
+    """
+
+    def __init__(self) -> None:
+        self._specs: dict[str, VerbSpec] = {}
+        self._aliases: dict[str, str] = {}
+
+    def register(self, spec: VerbSpec) -> VerbSpec:
+        if spec.name in self._specs or spec.name in self._aliases:
+            raise DuplicateVerb(
+                f"{spec.name!r} is already registered; a verb name must exist on "
+                "at most one receiver"
+            )
+        for alias in spec.aliases:
+            if alias in self._specs or alias in self._aliases:
+                raise DuplicateVerb(f"alias {alias!r} collides with an existing verb")
+        self._specs[spec.name] = spec
+        for alias in spec.aliases:
+            self._aliases[alias] = spec.name
+        return spec
+
+    def require(self, name: str) -> VerbSpec:
+        if name in self._specs:
+            return self._specs[name]
+        if name in self._aliases:
+            return self._specs[self._aliases[name]]
+        raise UnknownVerb(name, sorted(self._specs))
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._specs or name in self._aliases
+
+    def __iter__(self) -> Iterator[VerbSpec]:
+        return iter(self._specs.values())
+
+    def __len__(self) -> int:
+        return len(self._specs)
+
+    def names(self) -> tuple[str, ...]:
+        return tuple(sorted(self._specs))
+
+    def for_receiver(self, receiver: Receiver) -> tuple[VerbSpec, ...]:
+        return tuple(s for s in self if s.receiver is receiver)
+
+    def grants_needed(self, calls: Sequence[VerbCall]) -> frozenset[Grant]:
+        """Every grant a timeline requires, computable before it runs.
+
+        A suite that will kill a worker can be refused at plan time rather than
+        halfway through, when half the faults have already landed.
+        """
+        return frozenset(c.spec.grant for c in calls)
+
+    def bind(self, target: Any, role: Role | str) -> "_RoleView":
+        """The component-first spelling, generated from this registry.
+
+        ``registry.bind(sut, "frontend").restart()`` is exactly
+        ``sut.restart(at("frontend"))``. One definition, two spellings — the
+        component surface cannot drift from the verb surface because it is not
+        separately written down.
+        """
+        return _RoleView(self, target, at(role).role)
+
+    def to_record(self) -> list[dict]:
+        """A JSON-safe catalogue, for ``dynamo-test list verbs``."""
+        return [
+            {
+                "name": s.name,
+                "receiver": s.receiver.value,
+                "phase": s.phase.value,
+                "grant": s.grant.value,
+                "verdict": s.verdict.value,
+                "gates": s.gates,
+                "takes_selector": s.takes_selector,
+                "default_role": str(s.default_role) if s.default_role else None,
+                "params": dict(s.params),
+                "proves": list(s.proves),
+                "aliases": list(s.aliases),
+                "summary": s.summary,
+            }
+            for s in sorted(self, key=lambda s: s.name)
+        ]
+
+    def __repr__(self) -> str:
+        return f"VerbRegistry({len(self._specs)} verbs)"
+
+
+class _RoleView:
+    """``sut.frontend.restart()`` over ``sut.restart(at('frontend'))``."""
+
+    def __init__(self, registry: VerbRegistry, target: Any, role: Role) -> None:
+        self._registry = registry
+        self._target = target
+        self._role = role
+
+    def __getattr__(self, name: str) -> Callable[..., Any]:
+        spec = self._registry.require(name)
+        method = getattr(self._target, spec.name)
+        if not spec.takes_selector:
+            return method
+
+        def bound(*args: Any, **kwargs: Any) -> Any:
+            if "sel" in kwargs or (args and isinstance(args[0], Sel)):
+                raise TypeError(
+                    f"{self._role}.{name}() already names its role; pass replica= "
+                    "or rank= instead of a selector"
+                )
+            selector_fields = {
+                k: kwargs.pop(k)
+                for k in ("replica", "policy", "rank", "process", "port", "fraction")
+                if k in kwargs
+            }
+            return method(*args, sel=at(self._role, **selector_fields), **kwargs)
+
+        return bound
+
+    def __dir__(self) -> list[str]:
+        return sorted(self._registry.names())
+
+    def __repr__(self) -> str:
+        return f"<{self._role} view of {type(self._target).__name__}>"
+
+
+REGISTRY = VerbRegistry()
+
+
+def verb(
+    name: str,
+    *,
+    receiver: Receiver = Receiver.ACT,
+    phase: Phase = Phase.ACT,
+    grant: Grant = Grant.READ,
+    summary: str = "",
+    takes_selector: bool = True,
+    default_role: Role | None = None,
+    params: Mapping[str, str] | None = None,
+    proves: Sequence[str] = (),
+    aliases: Sequence[str] = (),
+    registry: VerbRegistry | None = None,
+) -> VerbSpec:
+    """Declare a verb. Returns the spec so a module can reference it."""
+    return (registry or REGISTRY).register(
+        VerbSpec(
+            name=name,
+            receiver=receiver,
+            phase=phase,
+            grant=grant,
+            summary=summary,
+            takes_selector=takes_selector,
+            default_role=default_role,
+            params=dict(params or {}),
+            proves=tuple(proves),
+            aliases=tuple(aliases),
+        )
+    )

--- a/harness/dynamo_test/verbs.py
+++ b/harness/dynamo_test/verbs.py
@@ -75,8 +75,18 @@ __all__ = [
 
 
 class Phase(str, Enum):
-    """When a verb may run. Enforced by the receiver, not by convention."""
+    """Where a run is, and therefore what may be called.
 
+    One enum, not two. A verb's declared phase and the receiver's current phase
+    are the same question asked from opposite ends, and modelling them
+    separately lets them disagree.
+
+    ``PLAN`` is before anything has been touched; ``ARRANGE`` is setup that still
+    counts as acting; ``COLLECT`` gathers evidence before teardown; ``CHECK``
+    judges the sealed bundle and cannot reach the system at all.
+    """
+
+    PLAN = "plan"
     ARRANGE = "arrange"
     ACT = "act"
     COLLECT = "collect"

--- a/harness/dynamo_test/verbs.py
+++ b/harness/dynamo_test/verbs.py
@@ -61,7 +61,7 @@ __all__ = [
     "Phase",
     "Receiver",
     "Grant",
-    "Verdict",
+    "Contribution",
     "VerbSpec",
     "VerbCall",
     "VerbRegistry",
@@ -104,8 +104,14 @@ class Grant(str, Enum):
     INFRA = "infra"
 
 
-class Verdict(str, Enum):
-    """What a verb's outcome contributes to the run result."""
+class Contribution(str, Enum):
+    """What a verb's outcome contributes to the run result.
+
+    Deliberately not called ``Verdict``. A *verdict* is what a run concluded
+    (:class:`dynamo_test.evidence.Verdict`); this is what one verb's outcome
+    feeds into that conclusion. They are different questions and sharing a name
+    made it possible to import the wrong one.
+    """
 
     GATES = "gates"
     OBSERVED = "observed"
@@ -159,11 +165,11 @@ PURE_READERS = frozenset(
     }
 )
 
-_PREFIX_VERDICT = {
-    "expect_": Verdict.GATES,
-    "observe_": Verdict.OBSERVED,
-    "require_valid_": Verdict.VALIDITY,
-    "report_": Verdict.ARTIFACT,
+_PREFIX_CONTRIBUTION = {
+    "expect_": Contribution.GATES,
+    "observe_": Contribution.OBSERVED,
+    "require_valid_": Contribution.VALIDITY,
+    "report_": Contribution.ARTIFACT,
 }
 
 _NAME = re.compile(r"^[a-z][a-z0-9_]*$")
@@ -192,11 +198,11 @@ class VerbSpec:
             )
         if self.receiver is Receiver.JUDGE:
             if self.name not in PURE_READERS and not any(
-                self.name.startswith(p) for p in _PREFIX_VERDICT
+                self.name.startswith(p) for p in _PREFIX_CONTRIBUTION
             ):
                 raise NamingLaw(
                     f"JUDGE verb {self.name!r} must start with one of "
-                    f"{', '.join(sorted(_PREFIX_VERDICT))} — the prefix is how a "
+                    f"{', '.join(sorted(_PREFIX_CONTRIBUTION))} — the prefix is how a "
                     "reader tells a gate from an observation — or be one of the "
                     f"pure readers ({', '.join(sorted(PURE_READERS))})."
                 )
@@ -213,18 +219,18 @@ class VerbSpec:
             )
 
     @property
-    def verdict(self) -> Verdict:
+    def contributes(self) -> Contribution:
         """What this verb's outcome contributes to the run result."""
         if self.receiver is Receiver.ACT:
-            return Verdict.NONE
-        for prefix, verdict in _PREFIX_VERDICT.items():
+            return Contribution.NONE
+        for prefix, contribution in _PREFIX_CONTRIBUTION.items():
             if self.name.startswith(prefix):
-                return verdict
-        return Verdict.NONE
+                return contribution
+        return Contribution.NONE
 
     @property
     def gates(self) -> bool:
-        return self.verdict is Verdict.GATES
+        return self.contributes is Contribution.GATES
 
     def call(self, **kwargs: Any) -> "VerbCall":
         """Build a call to this verb, validating the selector."""
@@ -400,7 +406,7 @@ class VerbRegistry:
                 "receiver": s.receiver.value,
                 "phase": s.phase.value,
                 "grant": s.grant.value,
-                "verdict": s.verdict.value,
+                "contributes": s.contributes.value,
                 "gates": s.gates,
                 "takes_selector": s.takes_selector,
                 "default_role": str(s.default_role) if s.default_role else None,

--- a/harness/pyproject.toml
+++ b/harness/pyproject.toml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dynamo-test-harness"
+version = "0.1.0"
+description = "Shared test harness for Dynamo: deployment-agnostic values, providers, and evidence"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+# Tier 0 is stdlib only. Anything heavier belongs behind an extra so that
+# `plan` and `judge` still run on a laptop, in a bare CI checkout, and inside a
+# runner with no cluster credentials.
+dependencies = []
+
+[project.optional-dependencies]
+manifest = ["pyyaml>=6.0"]
+
+[tool.setuptools.packages.find]
+include = ["dynamo_test*"]

--- a/harness/tests/stub_frontend.py
+++ b/harness/tests/stub_frontend.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A stand-in frontend: enough OpenAI surface to exercise the harness.
+
+Run as a subprocess by the end-to-end test. It is not a mock inside the test
+process — the point is that the provider really starts a process, really speaks
+HTTP to it, really restarts it, and really collects its log.
+
+    python stub_frontend.py --port 8123 --model Qwen/Qwen3-0.6B [--fail-after N]
+"""
+
+import argparse
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--port", type=int, required=True)
+parser.add_argument("--model", default="stub/model")
+parser.add_argument("--max-model-len", type=int, default=2048)
+# Lets a test drive a role into failure without killing it, which is a different
+# fault from a crash and is worth being able to express.
+parser.add_argument("--fail-after", type=int, default=0)
+args = parser.parse_args()
+
+STATE = {"served": 0}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, code, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/v1/models":
+            self._send(200, {"data": [{"id": args.model, "object": "model"}]})
+        elif self.path == "/health":
+            self._send(200, {"status": "ok", "served": STATE["served"]})
+        else:
+            self._send(404, {"error": "not found"})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        STATE["served"] += 1
+        if args.fail_after and STATE["served"] > args.fail_after:
+            print(f"ERROR: refusing request {STATE['served']}", flush=True)
+            self._send(503, {"error": "overloaded"})
+            return
+        self._send(
+            200,
+            {
+                "id": f"cmpl-{STATE['served']}",
+                "model": args.model,
+                "max_model_len": args.max_model_len,
+                "choices": [{"text": f"echo: {body.get('prompt', '')}"}],
+            },
+        )
+
+    def log_message(self, fmt, *a):
+        # One line per request, on stdout, so the collected log is assertable.
+        print("request " + (fmt % a), flush=True)
+
+
+print(
+    f"serving {args.model} on {args.port} max_model_len={args.max_model_len}",
+    flush=True,
+)
+server = HTTPServer(("127.0.0.1", args.port), Handler)
+try:
+    server.serve_forever()
+except KeyboardInterrupt:
+    sys.exit(0)

--- a/harness/tests/test_argv.py
+++ b/harness/tests/test_argv.py
@@ -1,0 +1,337 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`dynamo_test.argv`.
+
+The interesting cases are all forms that appear in ``recipes/`` — quoted
+``$VAR`` values, ``&&`` chains, ``\\``-continued multi-line scripts, and shell
+comments containing apostrophes. Each of those broke the previous
+split-and-rejoin implementation in a way that produced a green test and a
+misconfigured deployment.
+"""
+
+import pytest
+from dynamo_test.argv import (
+    AmbiguousInsertion,
+    ArgForm,
+    ArgV,
+    TokenKind,
+    UnparseableCommand,
+    is_shell_command_flag,
+    tokenize,
+)
+
+# A realistic worker command: continuations, comments, quoted vars, an operator,
+# and a single-quoted JSON argument.
+RECIPE_LIKE = """ulimit -n 1048576 && \\
+# vLLM's own scheduler is used here; dynamo's is stale for this image
+exec python3 -m dynamo.vllm \\
+  --model "${MODEL_ID}" \\
+  --tensor-parallel-size 8 \\
+  --enforce-eager \\
+  --kv-events-config '{"publisher":"zmq","endpoint":"tcp://*:20081"}'"""
+
+
+# --------------------------------------------------------------------- form
+
+
+@pytest.mark.parametrize(
+    "flag, expected",
+    [
+        ("-c", True),
+        ("-lc", True),
+        ("-ec", True),
+        ("-euxc", True),
+        ("--config", False),
+        ("-l", False),
+        ("-", False),
+        ("c", False),
+        (None, False),
+    ],
+)
+def test_shell_command_flag_covers_the_clusters_recipes_use(flag, expected):
+    """``-lc`` is the majority spelling in the corpus, not an exception to ``-c``."""
+    assert is_shell_command_flag(flag) is expected
+
+
+@pytest.mark.parametrize("shell_flag", ["-c", "-lc", "-ec"])
+def test_container_launched_through_a_shell_is_shell_form(shell_flag):
+    container = {
+        "command": ["/bin/bash", shell_flag],
+        "args": ["python3 -m dynamo.vllm"],
+    }
+    assert ArgV.from_container(container).form is ArgForm.SHELL
+
+
+def test_container_with_a_program_command_is_argv_form():
+    container = {
+        "command": ["python3", "-m", "dynamo.vllm"],
+        "args": ["--model", "Qwen/Qwen3-0.6B"],
+    }
+    argv = ArgV.from_container(container)
+    assert argv.form is ArgForm.ARGV
+    assert argv.get("--model").require() == "Qwen/Qwen3-0.6B"
+
+
+def test_single_arg_under_a_non_shell_command_is_one_argument_not_a_script():
+    """``--config foo`` is an argument even though ``args`` has one element."""
+    container = {"command": ["python3", "-m", "dynamo.vllm"], "args": ["--help me"]}
+    assert ArgV.from_container(container).form is ArgForm.ARGV
+
+
+# ----------------------------------------------------------------- tokenize
+
+
+def test_tokenize_records_source_spans():
+    tokens = tokenize("--model  Qwen/Qwen3-0.6B")
+    assert [t.text for t in tokens] == ["--model", "Qwen/Qwen3-0.6B"]
+    assert tokens[1].start == 9
+    assert (
+        "--model  Qwen/Qwen3-0.6B"[tokens[1].start : tokens[1].end] == "Qwen/Qwen3-0.6B"
+    )
+
+
+def test_tokenize_separates_operators_from_words():
+    kinds = [(t.text, t.kind) for t in tokenize("a && b | c")]
+    assert kinds == [
+        ("a", TokenKind.WORD),
+        ("&&", TokenKind.OPERATOR),
+        ("b", TokenKind.WORD),
+        ("|", TokenKind.OPERATOR),
+        ("c", TokenKind.WORD),
+    ]
+
+
+def test_tokenize_ignores_whole_line_comments_including_apostrophes():
+    """An apostrophe in a comment must not read as an opening quote.
+
+    ``shlex`` has no comment concept, so ``# Dynamo's adapter`` opened a quote
+    that never closed and four recipes failed to tokenise at all.
+    """
+    tokens = tokenize("# Dynamo's metrics adapter is stale\nexec python3 --model X")
+    assert [t.text for t in tokens] == ["exec", "python3", "--model", "X"]
+
+
+def test_tokenize_keeps_a_mid_line_hash_inside_its_token():
+    """A ``#`` inside an argument is data, not a comment — as bash agrees."""
+    tokens = tokenize("--endpoint https://host/path#frag")
+    assert tokens[1].text == "https://host/path#frag"
+
+
+def test_tokenize_strips_quotes_from_text_but_not_from_the_span():
+    tokens = tokenize('--model "${MODEL_ID}"')
+    assert tokens[1].text == "${MODEL_ID}"
+    assert tokens[1].quoted is True
+    assert '--model "${MODEL_ID}"'[tokens[1].start : tokens[1].end] == '"${MODEL_ID}"'
+
+
+def test_tokenize_treats_a_backslash_newline_as_a_continuation():
+    assert [t.text for t in tokenize("--model \\\n  X")] == ["--model", "X"]
+
+
+@pytest.mark.parametrize(
+    "broken", ["--model 'unterminated", '--model "unterminated', "trailing \\"]
+)
+def test_tokenize_refuses_rather_than_guessing(broken):
+    with pytest.raises(UnparseableCommand):
+        tokenize(broken)
+
+
+# --------------------------------------------------------------------- read
+
+
+def test_reads_a_flag_from_a_multiline_shell_command():
+    argv = ArgV.shell(RECIPE_LIKE, command=("/bin/bash", "-lc"))
+    assert argv.get("--model").require() == "${MODEL_ID}"
+    assert argv.get("--tensor-parallel-size").require() == "8"
+
+
+def test_reads_the_equals_spelling():
+    assert ArgV.argv(["--model=Qwen/Qwen3-0.6B"]).get("--model").require() == (
+        "Qwen/Qwen3-0.6B"
+    )
+
+
+def test_a_switch_has_no_value_and_says_so():
+    """``ABSENT`` here is a justified claim, not a failure to look."""
+    fact = ArgV.shell(RECIPE_LIKE).get("--enforce-eager")
+    assert fact.is_absent
+    assert "switch" in fact.detail
+    assert ArgV.shell(RECIPE_LIKE).has("--enforce-eager").require() is True
+
+
+def test_a_missing_flag_is_absent_with_the_scan_recorded():
+    fact = ArgV.shell(RECIPE_LIKE).get("--speculative-config")
+    assert fact.is_absent
+    assert "not among" in fact.detail
+
+
+def test_an_unreadable_command_is_unknown_never_absent():
+    """The false-green this type exists to prevent.
+
+    Reporting ``--model`` as absent because the command could not be tokenised
+    is a false statement that passes silently.
+    """
+    argv = ArgV.shell("exec python3 --model 'unterminated")
+    assert argv.is_parseable is False
+    assert argv.get("--model").is_unknown
+    assert argv.has("--model").is_unknown
+    assert argv.model().is_unknown
+
+
+def test_repeated_flags_are_all_visible():
+    fact = ArgV.argv(["--x", "1", "--x", "2"]).get_all("--x")
+    assert fact.require() == ("1", "2")
+
+
+def test_model_tries_each_spelling():
+    assert ArgV.argv(["--model-path", "A"]).model().require() == "A"
+    assert ArgV.argv(["--served-model-name", "B"]).model().require() == "B"
+    assert ArgV.argv(["--tp", "8"]).model().is_absent
+
+
+# -------------------------------------------------------------- write: shell
+
+
+def test_setting_a_value_touches_only_that_span():
+    """Everything else — comments, continuations, operators, quoting — survives.
+
+    Rebuilding from tokens flattens the script to one line, deletes the comment,
+    and quotes ``&&`` into a literal argument.
+    """
+    before = ArgV.shell(RECIPE_LIKE, command=("/bin/bash", "-lc"))
+    after = before.set("--model", "meta-llama/Llama-3.1-8B")
+
+    out = after.as_shell_string()
+    changed = [
+        (a, b) for a, b in zip(RECIPE_LIKE.splitlines(), out.splitlines()) if a != b
+    ]
+    assert len(changed) == 1
+    assert changed[0][1].strip() == "--model meta-llama/Llama-3.1-8B \\"
+    assert after.get("--model").require() == "meta-llama/Llama-3.1-8B"
+    # Untouched structure.
+    assert "ulimit -n 1048576 && \\" in out
+    assert "# vLLM's own scheduler is used here" in out
+    assert '\'{"publisher":"zmq","endpoint":"tcp://*:20081"}\'' in out
+    assert out.count("\n") == RECIPE_LIKE.count("\n")
+
+
+def test_an_operator_is_never_quoted_into_an_argument():
+    """``'&&'`` collapses the command into one call and the worker never starts."""
+    out = (
+        ArgV.shell("ulimit -l unlimited && exec python3 --model A")
+        .set("--model", "B")
+        .as_shell_string()
+    )
+    assert out == "ulimit -l unlimited && exec python3 --model B"
+
+
+def test_setting_an_absent_flag_lands_beside_the_existing_flags():
+    out = ArgV.shell(RECIPE_LIKE).set("--max-model-len", "1024").as_shell_string()
+    assert out.rstrip().endswith("--max-model-len 1024")
+    assert ArgV.shell(out).get("--max-model-len").require() == "1024"
+
+
+def test_setting_an_existing_flag_replaces_rather_than_appends():
+    """Appending yields ``--tp 8 --tp 4``; the engine takes one and the test the other."""
+    argv = ArgV.shell("exec python3 --tensor-parallel-size 8").set(
+        "--tensor-parallel-size", "4"
+    )
+    assert argv.as_shell_string() == "exec python3 --tensor-parallel-size 4"
+    assert argv.get_all("--tensor-parallel-size").require() == ("4",)
+
+
+def test_a_boolean_flag_is_emitted_as_a_switch_not_as_a_value():
+    """``--enforce-eager True`` is rejected by engines that declare it store_true."""
+    out = ArgV.shell("exec python3 --model A").set("--enforce-eager", True)
+    assert out.as_shell_string() == "exec python3 --model A --enforce-eager"
+
+
+def test_setting_false_removes_the_flag():
+    out = ArgV.shell("exec python3 --model A --enforce-eager").set(
+        "--enforce-eager", False
+    )
+    assert out.as_shell_string() == "exec python3 --model A"
+
+
+def test_unset_removes_the_flag_and_its_value_without_leaving_gaps():
+    out = ArgV.shell("exec python3 --model A --tp 8 --trust-remote-code").unset("--tp")
+    assert out.as_shell_string() == "exec python3 --model A --trust-remote-code"
+
+
+def test_a_value_needing_quotes_gets_them():
+    out = ArgV.shell("exec python3 --model A").set("--kv-config", '{"publisher":"zmq"}')
+    assert out.as_shell_string().endswith('--kv-config \'{"publisher":"zmq"}\'')
+    assert ArgV.shell(out.as_shell_string()).get("--kv-config").require() == (
+        '{"publisher":"zmq"}'
+    )
+
+
+def test_a_dollar_reference_stays_expandable():
+    """Quoting ``$MODEL_PATH`` literally would break expansion at pod start."""
+    out = ArgV.shell("exec python3 --model A").set("--model", "$MODEL_PATH")
+    assert out.as_shell_string() == "exec python3 --model $MODEL_PATH"
+
+
+def test_editing_an_unparseable_command_raises_instead_of_corrupting_it():
+    with pytest.raises(UnparseableCommand):
+        ArgV.shell("exec python3 --model 'unterminated").set("--model", "B")
+
+
+def test_insertion_refuses_when_there_is_no_defensible_place():
+    """Appending after ``&& something-else`` would configure the wrong program."""
+    with pytest.raises(AmbiguousInsertion):
+        ArgV.shell("setup.sh && teardown.sh").set("--model", "A")
+
+
+# --------------------------------------------------------------- write: argv
+
+
+def test_argv_set_replaces_in_place():
+    argv = ArgV.argv(["--model", "A", "--tp", "8"]).set("--model", "B")
+    assert argv.as_container_args() == ["--model", "B", "--tp", "8"]
+
+
+def test_argv_set_appends_when_absent():
+    argv = ArgV.argv(["--model", "A"]).set("--tp", "8")
+    assert argv.as_container_args() == ["--model", "A", "--tp", "8"]
+
+
+def test_argv_boolean_and_unset():
+    assert ArgV.argv(["--model", "A"]).set("--eager", True).as_container_args() == [
+        "--model",
+        "A",
+        "--eager",
+    ]
+    assert ArgV.argv(["--model", "A", "--tp", "8"]).unset(
+        "--tp"
+    ).as_container_args() == [
+        "--model",
+        "A",
+    ]
+
+
+def test_argv_handles_the_equals_spelling_on_write():
+    argv = ArgV.argv(["--model=A"]).set("--model", "B")
+    assert argv.as_container_args() == ["--model=B"]
+
+
+# ---------------------------------------------------------------------- emit
+
+
+def test_shell_form_always_writes_exactly_one_args_element():
+    """A second element becomes ``$1`` and the worker never sees it."""
+    container = {
+        "command": ["/bin/bash", "-lc"],
+        "args": ["exec python3 -m dynamo.vllm --model A"],
+    }
+    argv = ArgV.from_container(container).set("--max-model-len", "1024")
+    argv.apply_to(container)
+    assert len(container["args"]) == 1
+    assert "--max-model-len 1024" in container["args"][0]
+
+
+def test_edits_are_immutable():
+    before = ArgV.shell("exec python3 --model A")
+    before.set("--model", "B")
+    assert before.as_shell_string() == "exec python3 --model A"

--- a/harness/tests/test_bringup.py
+++ b/harness/tests/test_bringup.py
@@ -1,0 +1,242 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`dynamo_test.bringup`, against a real subprocess.
+
+The test that matters is the **negative control**: attaching to a system that is
+running the wrong thing must fail at bind time. Without it, VERIFY is a mode that
+always succeeds, which is worse than not having it.
+"""
+
+import socket
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+from dynamo_test.bringup import bring_up, refuse_if_not_owned  # noqa: E402
+from dynamo_test.manifest import Plan  # noqa: E402
+from dynamo_test.providers import LocalProvider, LocalRole  # noqa: E402
+from dynamo_test.roles import Role, at  # noqa: E402
+from dynamo_test.site import Mismatch, Ownership, Refused, Site, Topology  # noqa: E402
+from dynamo_test.stack import Stack  # noqa: E402
+
+STUB = Path(__file__).parent / "stub_frontend.py"
+
+MODEL = "Qwen/Qwen3-0.6B"
+OTHER_MODEL = "meta-llama/Llama-3.1-8B"
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def site(ownership: Ownership) -> Site:
+    return Site(
+        name=f"t-{ownership.value}",
+        topology=Topology.ALL_IN_ONE,
+        ownership=ownership,
+        shares_process_tree=True,
+        shares_network=True,
+        substrate_owned=ownership is Ownership.IMPOSE,
+    )
+
+
+@pytest.fixture
+def env(tmp_path):
+    """A one-role stack and a provider that can actually start it."""
+    port = free_port()
+    manifest = {
+        "apiVersion": "nvidia.com/v1beta1",
+        "kind": "DynamoGraphDeployment",
+        "metadata": {"name": "bringup-test"},
+        "spec": {
+            "components": [
+                {
+                    "name": "Frontend",
+                    "container": {
+                        "name": "main",
+                        "image": "stub",
+                        "command": ["python3"],
+                        "args": ["-m", "dynamo.frontend", "--model", MODEL],
+                    },
+                }
+            ]
+        },
+    }
+    path = tmp_path / "deploy.yaml"
+    path.write_text(yaml.safe_dump(manifest))
+    stack = Stack(Plan.from_file(str(path)))
+
+    def provider_for(model: str) -> LocalProvider:
+        return LocalProvider(
+            {
+                Role.FRONTEND: LocalRole(
+                    role=Role.FRONTEND,
+                    argv=[
+                        sys.executable,
+                        str(STUB),
+                        "--port",
+                        str(port),
+                        "--model",
+                        model,
+                    ],
+                    port=port,
+                )
+            },
+            log_dir=tmp_path / "logs",
+        )
+
+    providers: list[LocalProvider] = []
+
+    def make(model=MODEL):
+        p = provider_for(model)
+        providers.append(p)
+        return p
+
+    yield stack, make
+    for p in providers:
+        p.shutdown()
+
+
+def wait_serving(provider, timeout=30):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if provider.request(at("frontend"), "/v1/models", timeout=2).is_known:
+            return True
+        time.sleep(0.1)
+    return False
+
+
+# ------------------------------------------------------------------ IMPOSE
+
+
+def test_impose_starts_and_owns(env):
+    stack, make = env
+    provider = make()
+
+    result = bring_up(stack, site(Ownership.IMPOSE), provider)
+
+    assert result.owns is True
+    assert result.started == ("frontend",)
+    assert wait_serving(provider)
+    assert "(owned)" in result.describe()
+
+
+# ------------------------------------------------------------------- ADOPT
+
+
+def test_adopt_starts_what_is_missing_but_owns_nothing(env):
+    """Transcribed from the MinIO precedent: probe first, never destroy."""
+    stack, make = env
+    provider = make()
+
+    result = bring_up(stack, site(Ownership.ADOPT), provider)
+
+    assert result.started == ("frontend",)
+    assert result.owns is False, "ADOPT promises never to destroy"
+    assert "teardown must not destroy it" in result.describe()
+
+
+def test_adopt_joins_something_already_running(env):
+    stack, make = env
+    provider = make()
+    provider.start(at("frontend"))
+    assert wait_serving(provider)
+
+    result = bring_up(stack, site(Ownership.ADOPT), provider)
+
+    assert result.adopted == ("frontend",)
+    assert result.started == ()
+    assert result.owns is False
+
+
+# ------------------------------------------------------------------ VERIFY
+
+
+def test_verify_binds_to_a_matching_system(env):
+    stack, make = env
+    provider = make(MODEL)
+    provider.start(at("frontend"))
+    assert wait_serving(provider)
+
+    result = bring_up(stack, site(Ownership.VERIFY), provider, timeout=20)
+
+    assert result.checked == ("frontend",)
+    assert result.owns is False
+    assert result.divergences == ()
+
+
+def test_verify_fails_at_bind_when_the_model_is_wrong(env):
+    """**The negative control.** This is the test that makes VERIFY worth having.
+
+    The system is up and healthy — it is simply serving something else. Without
+    a comparison at bind time the first symptom is a 404 at query time, which
+    reads like a routing bug and sends the reader to the wrong place entirely.
+    """
+    stack, make = env  # the stack declares Qwen/Qwen3-0.6B
+    provider = make(OTHER_MODEL)  # ...the running system serves Llama
+    provider.start(at("frontend"))
+    assert wait_serving(provider), "the wrong system must still be healthy"
+
+    with pytest.raises(Mismatch) as exc:
+        bring_up(stack, site(Ownership.VERIFY), provider, timeout=20)
+
+    message = str(exc.value)
+    assert "frontend.model" in message
+    assert MODEL in message and OTHER_MODEL in message
+    assert "1 divergence" in message
+
+
+def test_verify_reports_nothing_running_as_a_divergence(env):
+    """Distinct from "running the wrong thing", and it must not be silent."""
+    stack, make = env
+    provider = make()  # never started
+
+    with pytest.raises(Mismatch) as exc:
+        bring_up(stack, site(Ownership.VERIFY), provider, timeout=1)
+    assert "replicas" in str(exc.value)
+
+
+def test_an_unreachable_frontend_is_unverified_not_a_disagreement(env):
+    """A connection failure is not evidence that the model is wrong.
+
+    Scoring it as a divergence would blame the deployment for a network problem.
+    """
+    from dynamo_test.bringup import observe
+
+    stack, make = env
+    provider = make()
+    got = observe(provider, at("frontend"), timeout=0)
+    assert got.is_unknown
+    assert "unreachable" in got.detail
+
+
+# --------------------------------------------------------------- refusal
+
+
+def test_teardown_is_refused_when_the_run_did_not_create_it(env):
+    """The quiet no-op is the hazard; this raises instead."""
+    for ownership in (Ownership.VERIFY, Ownership.ADOPT):
+        with pytest.raises(Refused) as exc:
+            refuse_if_not_owned(site(ownership), "stop")
+        assert "does not own" in str(exc.value)
+
+    # IMPOSE created it, so tearing it down is exactly right.
+    refuse_if_not_owned(site(Ownership.IMPOSE), "stop")
+
+
+def test_the_result_serialises_for_the_run_record(env):
+    import json
+
+    stack, make = env
+    result = bring_up(stack, site(Ownership.IMPOSE), make())
+    record = result.to_record()
+    assert record["ownership"] == "impose"
+    assert record["owns"] is True
+    assert json.loads(json.dumps(record))

--- a/harness/tests/test_catalog.py
+++ b/harness/tests/test_catalog.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The catalogue's coverage claim, tested rather than asserted in prose.
+
+The design's case for putting the role in the argument list is that a scenario
+document then maps to a call mechanically. That claim is only worth anything if
+every event kind the existing scenario suite uses actually has one verb — so
+this file lists all 26 of them and checks it.
+"""
+
+import pytest
+from dynamo_test import catalog  # noqa: F401  (registers the verbs)
+from dynamo_test.roles import Role
+from dynamo_test.verbs import REGISTRY, Grant, Receiver, UnknownVerb, VerbCall, Verdict
+
+# Every `class X(Event)` in the scenario suite's events package, as measured.
+SCENARIO_EVENT_KINDS = [
+    "AssertPodsRestarted",
+    "CaptureMetrics",
+    "CudaFaultInjection",
+    "DeletePod",
+    "NetworkPartition",
+    "PeriodicSnapshot",
+    "PrepareCudaFaultInjection",
+    "PrintProcessTree",
+    "ResourceMonitor",
+    "RollingReplace",
+    "RollingUpgrade",
+    "RstFromInsidePod",
+    "RstInjection",
+    "RunCommand",
+    "SetBusyThreshold",
+    "StallProcess",
+    "StartLoad",
+    "StopLoad",
+    "TerminateProcess",
+    "UpstreamGpuXidInjection",
+    "Wait",
+    "WaitForLoadCompletion",
+    "WaitForLogPattern",
+    "WaitForModelReady",
+    "WaitForRecovery",
+    "WaitForStablePods",
+]
+
+
+@pytest.mark.parametrize("kind", SCENARIO_EVENT_KINDS)
+def test_every_scenario_event_kind_maps_to_one_verb(kind):
+    """The success test for role-as-argument.
+
+    A component-first surface would need a dispatch table from event kind to
+    attribute path here; with the role as an argument this is a registry lookup.
+    """
+    assert kind in REGISTRY
+    assert REGISTRY.require(kind).name
+
+
+def test_the_event_list_is_the_measured_one():
+    """Guards against the coverage claim quietly shrinking."""
+    assert len(SCENARIO_EVENT_KINDS) == 26
+    assert len(set(SCENARIO_EVENT_KINDS)) == 26
+
+
+# ------------------------------------------------------ documents become calls
+
+
+def test_a_document_event_becomes_a_call():
+    call = VerbCall.from_document(
+        {"kind": "StallProcess", "role": "worker", "rank": 0, "seconds": 30}
+    )
+    assert call.spec.name == "stall_process"
+    assert call.selector.role is Role.WORKER
+    assert call.selector.rank == 0
+    assert call.kwargs == {"seconds": 30}
+    assert call.describe() == "stall_process(at('worker/rank=0'), seconds=30)"
+
+
+def test_a_call_round_trips_back_to_a_document():
+    document = {"kind": "stall_process", "role": "worker", "rank": 0, "seconds": 30}
+    assert VerbCall.from_document(document).to_document() == document
+
+
+def test_an_event_without_a_kind_is_rejected():
+    with pytest.raises(ValueError, match="no 'kind'"):
+        VerbCall.from_document({"role": "worker"})
+
+
+def test_an_unknown_kind_names_near_matches():
+    with pytest.raises(UnknownVerb) as exc:
+        VerbCall.from_document({"kind": "restart_everything"})
+    assert "26 verbs" not in str(exc.value)  # it reports the registry size
+    assert "no verb named" in str(exc.value)
+
+
+def test_a_verb_with_a_default_role_needs_no_role():
+    """This is what makes `query(...)` read naturally instead of `query(at('frontend'))`."""
+    call = VerbCall.from_document({"kind": "query", "payload": "hi"})
+    assert call.selector.role is Role.FRONTEND
+
+
+def test_a_verb_that_takes_no_role_rejects_one():
+    with pytest.raises(TypeError, match="does not act on a role"):
+        VerbCall.from_document({"kind": "Wait", "role": "worker", "seconds": 1})
+
+
+def test_selector_fields_without_a_role_are_rejected():
+    with pytest.raises(TypeError, match="without a role"):
+        REGISTRY.require("exec_in").call(replica=2, argv=["ls"])
+
+
+def test_unexpected_arguments_are_rejected_with_the_accepted_set():
+    with pytest.raises(TypeError, match="accepts"):
+        VerbCall.from_document({"kind": "Wait", "secondz": 5})
+
+
+# ------------------------------------------------------------- the naming law
+
+
+def test_gating_and_observing_are_different_names_not_a_flag():
+    """Five checks in the scenario suite today assert *and* have a bare early
+    return, so an argument turns the gate off and the report still says PASSED.
+    A reader cannot tell a check that held from one that was asked not to look.
+    """
+    assert REGISTRY.require("logs").verdict is Verdict.NONE  # pure reader
+    assert REGISTRY.require("metrics").gates is False
+
+
+def test_act_verbs_never_gate():
+    for spec in REGISTRY.for_receiver(Receiver.ACT):
+        assert spec.verdict is Verdict.NONE, spec.name
+
+
+def test_every_fault_verb_declares_what_it_proves():
+    """A fault whose effect is unobservable cannot be told from one that no-oped."""
+    faults = [s for s in REGISTRY if s.grant is Grant.FAULT]
+    assert faults
+    for spec in faults:
+        assert spec.proves, spec.name
+
+
+def test_infra_restarts_are_a_separate_grant_from_lifecycle():
+    """Scaling etcd to zero in a shared namespace breaks other people's tests."""
+    assert REGISTRY.require("restart_infra").grant is Grant.INFRA
+    assert REGISTRY.require("restart").grant is Grant.LIFECYCLE
+
+
+def test_grants_needed_is_computable_before_anything_runs():
+    """A suite that may not inject faults is refused at plan time, not midway."""
+    timeline = [
+        VerbCall.from_document({"kind": "WaitForModelReady", "timeout": 300}),
+        VerbCall.from_document({"kind": "query", "payload": "hi"}),
+        VerbCall.from_document({"kind": "DeletePod", "role": "decode"}),
+    ]
+    assert REGISTRY.grants_needed(timeline) == frozenset(
+        {Grant.READ, Grant.INFER, Grant.FAULT}
+    )
+
+
+# -------------------------------------------------- both spellings, one source
+
+
+class FakeSut:
+    def __init__(self):
+        self.calls = []
+
+    def restart(self, sel=None, **kw):
+        self.calls.append(("restart", sel, kw))
+        return "handle"
+
+    def query(self, payload, sel=None, **kw):
+        self.calls.append(("query", payload, sel, kw))
+        return "answer"
+
+
+def test_the_component_spelling_is_generated_from_the_same_registry():
+    """``sut.frontend.restart()`` and ``sut.restart(at('frontend'))`` are one thing.
+
+    Both spellings exist; only one definition does. The component surface cannot
+    drift from the verb surface because it is not separately written down.
+    """
+    sut = FakeSut()
+    REGISTRY.bind(sut, "decode").restart(replica=1)
+    verb_name, sel, _ = sut.calls[0]
+    assert verb_name == "restart"
+    assert sel.role is Role.DECODE
+    assert sel.replica == 1
+
+
+def test_the_component_view_rejects_a_second_role():
+    sut = FakeSut()
+    with pytest.raises(TypeError, match="already names its role"):
+        REGISTRY.bind(sut, "decode").restart(sel="anything")
+
+
+def test_the_component_view_lists_the_registry():
+    assert "restart" in dir(REGISTRY.bind(FakeSut(), "decode"))
+
+
+# ------------------------------------------------------------------ catalogue
+
+
+def test_the_catalogue_serialises_for_the_cli():
+    record = REGISTRY.to_record()
+    by_name = {r["name"]: r for r in record}
+    assert by_name["delete_replica"]["proves"] == [
+        "replica_deleted",
+        "replica_replaced",
+    ]
+    assert by_name["query"]["default_role"] == "frontend"
+    assert by_name["restart_infra"]["takes_selector"] is False
+
+
+def test_the_catalogue_is_json_safe():
+    import json
+
+    assert json.loads(json.dumps(REGISTRY.to_record()))
+
+
+def test_no_alias_collides_with_a_verb_name():
+    names = set(REGISTRY.names())
+    for spec in REGISTRY:
+        for alias in spec.aliases:
+            assert alias not in names, f"{alias} is both an alias and a verb name"

--- a/harness/tests/test_catalog.py
+++ b/harness/tests/test_catalog.py
@@ -12,7 +12,14 @@ this file lists all 26 of them and checks it.
 import pytest
 from dynamo_test import catalog  # noqa: F401  (registers the verbs)
 from dynamo_test.roles import Role
-from dynamo_test.verbs import REGISTRY, Grant, Receiver, UnknownVerb, VerbCall, Verdict
+from dynamo_test.verbs import (
+    REGISTRY,
+    Contribution,
+    Grant,
+    Receiver,
+    UnknownVerb,
+    VerbCall,
+)
 
 # Every `class X(Event)` in the scenario suite's events package, as measured.
 SCENARIO_EVENT_KINDS = [
@@ -122,13 +129,13 @@ def test_gating_and_observing_are_different_names_not_a_flag():
     return, so an argument turns the gate off and the report still says PASSED.
     A reader cannot tell a check that held from one that was asked not to look.
     """
-    assert REGISTRY.require("logs").verdict is Verdict.NONE  # pure reader
+    assert REGISTRY.require("logs").contributes is Contribution.NONE  # pure reader
     assert REGISTRY.require("metrics").gates is False
 
 
 def test_act_verbs_never_gate():
     for spec in REGISTRY.for_receiver(Receiver.ACT):
-        assert spec.verdict is Verdict.NONE, spec.name
+        assert spec.contributes is Contribution.NONE, spec.name
 
 
 def test_every_fault_verb_declares_what_it_proves():

--- a/harness/tests/test_corpus_replay.py
+++ b/harness/tests/test_corpus_replay.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Replay :class:`ArgV` over every shipped deployment manifest.
+
+Unit tests prove the constructs this module *intends* to handle. This one proves
+the corpus contains nothing else. It is the test that would have caught the
+defect it was written for: ``-lc`` containers were 100 of the 184 shell-invoked
+containers in ``recipes/`` and ``examples/``, and every helper that scanned them
+returned nothing while reporting the flag as absent.
+
+Skipped when the manifests are not present, so the harness stays installable and
+testable on its own.
+"""
+
+import pathlib
+import subprocess
+
+import pytest
+from dynamo_test.argv import ArgForm, ArgV
+
+yaml = pytest.importorskip("yaml")
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+ROOTS = [REPO / "recipes", REPO / "examples"]
+
+pytestmark = pytest.mark.skipif(
+    not all(r.is_dir() for r in ROOTS),
+    reason="deployment manifests are not present next to the harness",
+)
+
+
+def _containers(path):
+    """Every container in every DGD document, across both schema versions."""
+    try:
+        documents = list(yaml.safe_load_all(path.read_text()))
+    except Exception:
+        return
+    for doc in documents:
+        if not isinstance(doc, dict) or doc.get("kind") != "DynamoGraphDeployment":
+            continue
+        spec = doc.get("spec") or {}
+        # v1alpha1
+        for name, service in (spec.get("services") or {}).items():
+            main = ((service or {}).get("extraPodSpec") or {}).get("mainContainer")
+            if main:
+                yield name, main
+        # v1beta1
+        for component in spec.get("components") or []:
+            name = (component or {}).get("name", "<unnamed>")
+            if component.get("container"):
+                yield name, component["container"]
+            pod_spec = (component.get("podTemplate") or {}).get("spec") or {}
+            for container in pod_spec.get("containers") or []:
+                yield name, container
+            main = (component.get("extraPodSpec") or {}).get("mainContainer")
+            if main:
+                yield name, main
+
+
+def _shell_containers():
+    for root in ROOTS:
+        for path in sorted(root.rglob("*.yaml")):
+            for name, container in _containers(path):
+                if not isinstance(container, dict):
+                    continue
+                argv = ArgV.from_container(
+                    container, source=f"{path.relative_to(REPO)}[{name}]"
+                )
+                if argv.form is ArgForm.SHELL:
+                    yield argv
+
+
+@pytest.fixture(scope="module")
+def shell_commands():
+    found = list(_shell_containers())
+    assert found, "expected the corpus to contain shell-invoked containers"
+    return found
+
+
+def test_every_shipped_shell_command_is_parseable(shell_commands):
+    """``shlex`` failed on four of these; a parse failure must not be silent."""
+    unparseable = [
+        (a.source, a.parse_error) for a in shell_commands if not a.is_parseable
+    ]
+    assert unparseable == []
+
+
+def test_the_login_shell_majority_is_detected(shell_commands):
+    """``-lc`` outnumbers ``-c``; a predicate that matches only ``-c`` sees half."""
+    login = [a for a in shell_commands if a.command[-1] != "-c"]
+    assert len(login) > len(shell_commands) / 3, (
+        f"only {len(login)} of {len(shell_commands)} use a non-bare-c shell flag; "
+        "if the corpus really changed this much, re-measure before relaxing this"
+    )
+
+
+def test_editing_any_shipped_command_preserves_everything_else(shell_commands):
+    """Two edits per manifest; every untouched line must be byte-identical.
+
+    This is the property a token round-trip cannot hold: it flattens
+    continuations, drops comments, and re-quotes operators into arguments.
+    """
+    damage = []
+    for argv in shell_commands:
+        before = argv.as_shell_string()
+
+        edited = argv
+        for flag in ("--model-path", "--model", "--served-model-name"):
+            if edited.get(flag).is_known:
+                edited = edited.set(flag, "sentinel/model")
+                break
+        edited = edited.set("--dyn-corpus-probe", "42")
+        after = edited.as_shell_string()
+
+        if len(after.splitlines()) != len(before.splitlines()):
+            damage.append(f"{argv.source}: line count changed")
+            continue
+        for old, new in zip(before.splitlines(), after.splitlines()):
+            if old == new:
+                continue
+            if "sentinel/model" not in new and "--dyn-corpus-probe" not in new:
+                damage.append(f"{argv.source}: unrelated line changed: {old.strip()!r}")
+
+        if len(edited.as_container_args()) != 1:
+            damage.append(f"{argv.source}: shell args must stay a single string")
+
+    assert damage == []
+
+
+def test_comments_survive_an_edit(shell_commands):
+    """The comments explain why each flag is set; losing them loses the reason."""
+    damage = []
+    for argv in shell_commands:
+        before = argv.as_shell_string()
+        comments = [ln for ln in before.splitlines() if ln.lstrip().startswith("#")]
+        if not comments:
+            continue
+        after = argv.set("--dyn-corpus-probe", "42").as_shell_string()
+        if [ln for ln in after.splitlines() if ln.lstrip().startswith("#")] != comments:
+            damage.append(argv.source)
+    assert damage == []
+
+
+@pytest.mark.skipif(
+    subprocess.run(["which", "bash"], capture_output=True).returncode != 0,
+    reason="bash is required to syntax-check the rewritten commands",
+)
+def test_every_edited_command_still_parses_under_bash(shell_commands):
+    """The independent check: bash's own parser, not ours."""
+    rejected = []
+    for argv in shell_commands:
+        after = argv.set("--dyn-corpus-probe", "42").as_shell_string()
+        result = subprocess.run(
+            ["bash", "-n", "-c", after], capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            rejected.append(f"{argv.source}: {result.stderr.strip()[:120]}")
+    assert rejected == []

--- a/harness/tests/test_corpus_replay.py
+++ b/harness/tests/test_corpus_replay.py
@@ -157,3 +157,145 @@ def test_every_edited_command_still_parses_under_bash(shell_commands):
         if result.returncode != 0:
             rejected.append(f"{argv.source}: {result.stderr.strip()[:120]}")
     assert rejected == []
+
+
+# ------------------------------------------------------- the dialect, on the corpus
+
+
+def _worker_argvs():
+    """Every container that actually launches an inference engine."""
+    from dynamo_test.dialect import detect
+
+    for root in ROOTS:
+        for path in sorted(root.rglob("*.yaml")):
+            for name, container in _containers(path):
+                if not isinstance(container, dict):
+                    continue
+                argv = ArgV.from_container(
+                    container, source=f"{path.relative_to(REPO)}[{name}]"
+                )
+                backend = detect(argv)
+                if backend.is_known:
+                    yield backend.require(), argv
+
+
+@pytest.fixture(scope="module")
+def workers():
+    found = list(_worker_argvs())
+    assert found, "expected the corpus to contain engine workers"
+    return found
+
+
+def test_the_engine_is_detected_for_every_worker(workers):
+    """Detection reads ``python -m dynamo.<engine>``, not a substring.
+
+    Matching a backend name anywhere in the command picks up image names and
+    environment variables; that mis-attributed 12 TensorRT-LLM containers when
+    this was first measured the loose way.
+    """
+    from dynamo_test.dialect import DIALECTS
+
+    assert {b for b, _ in workers} <= set(DIALECTS)
+    assert len(workers) > 100
+
+
+# Manifests whose worker declares no model at all, and does not defer to a
+# config file either. Each is a real defect, not a gap in the reader.
+#
+# All three are the YAML folded-scalar bug: `>-` collapses the newline in
+# `\<newline>` into a space, making it an escaped space, so bash delivers
+# " --model" with a leading space and argparse rejects it. Fixed by OPS-8534
+# (PR #14321); when that lands these entries should be deleted and this test
+# will say so.
+KNOWN_UNDECLARED_MODEL = {
+    "recipes/qwen3-vl-32b-fp8/vllm/agg/deploy.yaml[VllmWorker]",
+    "recipes/qwen3-vl-32b-fp8/vllm/hetero_hardware_disagg/deploy.yaml[EncodeWorker]",
+    "recipes/qwen3-vl-32b-fp8/vllm/hetero_hardware_disagg/deploy.yaml[VllmDecodeWorker]",
+}
+
+
+def test_no_worker_reports_its_model_absent_without_reason(workers):
+    """Every engine worker either declares a model or defers to a config file.
+
+    ``ABSENT`` means the reader looked at the whole command line and the model
+    genuinely is not there — which for a worker is a broken manifest. This is
+    the check that found OPS-8534.
+    """
+    from dynamo_test.dialect import for_backend
+
+    absent = {
+        argv.source
+        for backend, argv in workers
+        if for_backend(backend).read(argv, "model").is_absent
+    }
+    unexpected = absent - KNOWN_UNDECLARED_MODEL
+    assert unexpected == set(), f"workers declaring no model: {sorted(unexpected)}"
+
+    fixed = KNOWN_UNDECLARED_MODEL - absent
+    assert fixed == set(), (
+        f"these now declare a model: {sorted(fixed)}. Remove them from "
+        "KNOWN_UNDECLARED_MODEL."
+    )
+
+
+def test_a_config_file_makes_the_model_unknown_not_absent(workers):
+    """Deferring to ``--config`` is not the same as declaring nothing.
+
+    Four SGLang workers put every setting in ``/etc/sglang/*.yaml`` and pass only
+    ``--config``. Reporting "no model" for those would be false; the reader
+    cannot see the file, so the honest answer is UNKNOWN.
+    """
+    from dynamo_test.dialect import for_backend
+
+    deferred = [
+        argv
+        for backend, argv in workers
+        if for_backend(backend).read(argv, "model").is_unknown and argv.is_parseable
+    ]
+    assert deferred, "expected some workers to configure themselves from a file"
+    for argv in deferred:
+        fact = for_backend("sglang").read(argv, "model")
+        assert "defers to" in fact.detail or "could not be tokenised" in fact.detail
+
+
+def test_both_live_spellings_are_actually_exercised(workers):
+    """Guards the multi-spelling tables against being quietly reduced to one.
+
+    SGLang uses ``--tp`` and ``--tensor-parallel-size``; TensorRT-LLM uses
+    ``--model-path`` and ``--model``. If the corpus stops using one, this fails
+    and the table can be simplified deliberately rather than by accident.
+    """
+    sglang_tp = {
+        f
+        for backend, argv in workers
+        if backend == "sglang"
+        for f in ("--tp", "--tensor-parallel-size")
+        if argv.get(f).is_known
+    }
+    trtllm_model = {
+        f
+        for backend, argv in workers
+        if backend == "trtllm"
+        for f in ("--model-path", "--model")
+        if argv.get(f).is_known
+    }
+    assert sglang_tp == {"--tp", "--tensor-parallel-size"}, sglang_tp
+    assert trtllm_model == {"--model-path", "--model"}, trtllm_model
+
+
+def test_setting_a_semantic_round_trips_on_every_worker(workers):
+    """Write through the dialect, read it back, on all of them."""
+    from dynamo_test.dialect import for_backend
+
+    damage = []
+    for backend, argv in workers:
+        dialect = for_backend(backend)
+        try:
+            out = dialect.apply(argv, context_length=4096)
+        except Exception as exc:  # AmbiguousInsertion is a legitimate refusal
+            damage.append(f"{argv.source}: {type(exc).__name__}: {exc}")
+            continue
+        got = dialect.read(out, "context_length")
+        if not got.is_known or got.require() != "4096":
+            damage.append(f"{argv.source}: read back {got.status.value}")
+    assert damage == []

--- a/harness/tests/test_corpus_replay.py
+++ b/harness/tests/test_corpus_replay.py
@@ -241,9 +241,10 @@ def test_no_worker_reports_its_model_absent_without_reason(workers):
 def test_a_config_file_makes_the_model_unknown_not_absent(workers):
     """Deferring to ``--config`` is not the same as declaring nothing.
 
-    Four SGLang workers put every setting in ``/etc/sglang/*.yaml`` and pass only
-    ``--config``. Reporting "no model" for those would be false; the reader
-    cannot see the file, so the honest answer is UNKNOWN.
+    12 SGLang workers put every setting in ``/etc/sglang/*.yaml``, and all 56
+    TensorRT-LLM workers use ``--extra-engine-args``. Reporting "no model" for
+    those would be false; the reader cannot see the file, so the honest answer
+    is UNKNOWN.
     """
     from dynamo_test.dialect import for_backend
 
@@ -299,3 +300,80 @@ def test_setting_a_semantic_round_trips_on_every_worker(workers):
         if not got.is_known or got.require() != "4096":
             damage.append(f"{argv.source}: read back {got.status.value}")
     assert damage == []
+
+
+# ---------------------------------------------------- the plan, on the corpus
+
+
+def _plans():
+    from dynamo_test.manifest import ManifestError, NoGraphDeployment, Plan
+
+    for root in ROOTS:
+        for path in sorted(root.rglob("*.yaml")):
+            try:
+                yield from Plan.all_from_file(path)
+            except NoGraphDeployment:
+                continue
+            except ManifestError:
+                # Shell-templated files are not YAML until substituted.
+                continue
+
+
+@pytest.fixture(scope="module")
+def plans():
+    found = list(_plans())
+    assert len(found) > 200, f"only {len(found)} plans; the walker is wrong"
+    return found
+
+
+def test_both_schemas_are_represented(plans):
+    """Neither schema is legacy: v1alpha1 is 75 documents, v1beta1 is 177."""
+    from dynamo_test.manifest import Schema
+
+    schemas = {p.schema for p in plans}
+    assert schemas == {Schema.V1ALPHA1, Schema.V1BETA1}
+
+
+def test_every_component_name_resolves_to_a_role(plans):
+    """32 distinct names across the corpus, and none may fall through.
+
+    A name that does not resolve would silently become a generic worker, so a
+    selector could point at the wrong service and nothing would say so.
+    """
+    unresolved = sorted({n for p in plans for n in p.unresolved_roles()})
+    assert unresolved == []
+
+
+def test_no_deployment_has_two_components_claiming_one_role(plans):
+    from dynamo_test.manifest import ManifestError
+
+    clashes = []
+    for plan in plans:
+        try:
+            plan.roles()
+        except ManifestError as exc:
+            clashes.append(f"{plan.source}: {exc}")
+    assert clashes == []
+
+
+def test_every_engine_worker_is_identified(plans):
+    """Detection must read `command` too, not just `args`.
+
+    v1alpha1 puts the program in `command` (`[python3, -m, dynamo.sglang]`) and
+    only its flags in `args`. Scanning `args` alone identified 180 workers;
+    reading the whole invocation identifies 312.
+    """
+    workers = [c for p in plans for c in p if c.backend.is_known]
+    assert len(workers) > 300
+    assert {c.backend.require() for c in workers} == {"vllm", "sglang", "trtllm"}
+
+
+def test_role_tables_serialise_for_every_deployment(plans):
+    """Recording resolution is what lets a check prove it, rather than assume."""
+    import json
+
+    for plan in plans:
+        record = plan.roles().to_record()
+        assert json.loads(json.dumps(record))
+        for role, binding in record.items():
+            assert binding["log_key"], f"{plan.source}: {role} has no log key"

--- a/harness/tests/test_dialect.py
+++ b/harness/tests/test_dialect.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`dynamo_test.dialect`."""
+
+import pytest
+from dynamo_test.argv import ArgV
+from dynamo_test.dialect import (
+    DIALECTS,
+    SGLANG,
+    TRTLLM,
+    VLLM,
+    UnknownSemantic,
+    detect,
+    for_backend,
+)
+from dynamo_test.roles import Process
+
+# ------------------------------------------------------------------ writing
+
+
+@pytest.mark.parametrize(
+    "dialect, expected",
+    [
+        (VLLM, ("--max-model-len", "4096")),
+        (SGLANG, ("--context-length", "4096")),
+        (TRTLLM, ("--max-seq-len", "4096")),
+    ],
+)
+def test_one_semantic_three_spellings(dialect, expected):
+    """The point of the whole module: say what you mean once."""
+    assert dialect.flag("context_length", 4096) == expected
+
+
+def test_a_switch_emits_a_bare_flag():
+    """``--enforce-eager True`` is rejected by vLLM; it takes no value."""
+    assert VLLM.flag("eager", True) == ("--enforce-eager",)
+    assert VLLM.flag("eager", False) == ()
+
+
+def test_a_switch_rejects_a_non_bool():
+    with pytest.raises(TypeError, match="pass True or False"):
+        VLLM.flag("eager", "yes")
+
+
+def test_a_valued_flag_rejects_a_bool():
+    """Guards the exact defect: a bool would emit `--max-model-len True`."""
+    with pytest.raises(TypeError, match="rejects"):
+        VLLM.flag("context_length", True)
+
+
+def test_an_unknown_semantic_lists_what_the_engine_knows():
+    with pytest.raises(UnknownSemantic, match="context_length"):
+        VLLM.flag("maximum_context", 4096)
+
+
+# ------------------------------------------------------------------ reading
+
+
+def test_reading_accepts_every_spelling_the_engine_does():
+    """SGLang uses ``--tp`` 10 times and ``--tensor-parallel-size`` 7 times.
+
+    A reader that knows only the canonical spelling misses 10 of 17 workers.
+    """
+    assert SGLANG.read(ArgV.argv(["--tp", "8"]), "tensor_parallel").require() == "8"
+    assert (
+        SGLANG.read(
+            ArgV.argv(["--tensor-parallel-size", "8"]), "tensor_parallel"
+        ).require()
+        == "8"
+    )
+
+
+def test_trtllm_reads_both_model_spellings():
+    """``--model-path`` ×29 and ``--model`` ×12 are both live."""
+    assert TRTLLM.read(ArgV.argv(["--model-path", "A"]), "model").require() == "A"
+    assert TRTLLM.read(ArgV.argv(["--model", "A"]), "model").require() == "A"
+
+
+def test_absence_shows_which_spellings_were_tried():
+    """ "Not set" is a claim, and it should carry its working."""
+    fact = SGLANG.read(ArgV.argv(["--model-path", "A"]), "tensor_parallel")
+    assert fact.is_absent
+    assert "--tp" in fact.detail
+    assert "--tensor-parallel-size" in fact.detail
+
+
+def test_an_unreadable_command_is_unknown_not_absent():
+    argv = ArgV.shell("exec python3 -m dynamo.vllm --model 'unterminated")
+    assert VLLM.read(argv, "model").is_unknown
+
+
+def test_reading_works_through_a_shell_command():
+    argv = ArgV.shell(
+        "ulimit -n 65536 && exec python3 -m dynamo.sglang --model-path Qwen/Q --tp 8",
+        command=("/bin/bash", "-lc"),
+    )
+    assert SGLANG.read(argv, "model").require() == "Qwen/Q"
+    assert SGLANG.read(argv, "tensor_parallel").require() == "8"
+
+
+# ------------------------------------------------------------------ applying
+
+
+def test_apply_sets_several_semantics_at_once():
+    argv = ArgV.shell("exec python3 -m dynamo.vllm --model A --max-model-len 2048")
+    out = VLLM.apply(argv, context_length=4096, max_batch_size=64)
+    assert VLLM.read(out, "context_length").require() == "4096"
+    assert VLLM.read(out, "max_batch_size").require() == "64"
+    assert out.as_shell_string().count("--max-model-len") == 1
+
+
+def test_apply_preserves_the_shell_command_around_it():
+    argv = ArgV.shell(
+        "ulimit -n 65536 && exec python3 -m dynamo.vllm --model A",
+        command=("/bin/bash", "-lc"),
+    )
+    out = VLLM.apply(argv, context_length=4096)
+    assert out.as_shell_string().startswith("ulimit -n 65536 && exec")
+    assert "'&&'" not in out.as_shell_string()
+
+
+def test_apply_of_a_switch_emits_no_value():
+    out = VLLM.apply(ArgV.argv(["--model", "A"]), eager=True)
+    assert out.as_container_args() == ["--model", "A", "--enforce-eager"]
+
+
+# ----------------------------------------------------------------- detection
+
+
+@pytest.mark.parametrize("backend", ["vllm", "sglang", "trtllm"])
+def test_detect_reads_the_launched_module(backend):
+    argv = ArgV.shell(f"exec python3 -m dynamo.{backend} --model A")
+    assert detect(argv).require() == backend
+
+
+def test_detect_ignores_a_backend_name_that_is_not_the_module():
+    """A substring search over the whole command mis-attributed 12 containers.
+
+    Image names and environment variables mention engines they do not launch.
+    """
+    argv = ArgV.shell(
+        "export IMAGE=nvcr.io/dynamo-vllm:latest && "
+        "exec python3 -m dynamo.trtllm --model-path A"
+    )
+    assert detect(argv).require() == "trtllm"
+
+
+def test_detect_reports_a_non_engine_module_as_absent():
+    fact = detect(ArgV.shell("exec python3 -m dynamo.frontend"))
+    assert fact.is_absent
+    assert "not an inference engine" in fact.detail
+
+
+def test_detect_is_unknown_on_an_unreadable_command():
+    assert detect(ArgV.shell("exec python3 -m dynamo.vllm 'unterminated")).is_unknown
+
+
+# ------------------------------------------------------------------- lookup
+
+
+def test_for_backend_and_unknown_backend():
+    assert for_backend("VLLM") is VLLM
+    with pytest.raises(KeyError, match="sglang"):
+        for_backend("tensorrt")
+
+
+def test_every_dialect_names_its_engine_process():
+    for dialect in DIALECTS.values():
+        assert dialect.process_pattern(Process.MAIN)
+        assert dialect.process_pattern(Process.ENGINE)
+
+
+def test_the_three_dialects_share_their_core_semantics():
+    """A deployment-agnostic test can only use semantics all engines have."""
+    common = set.intersection(*(set(d.names()) for d in DIALECTS.values()))
+    assert {
+        "model",
+        "context_length",
+        "tensor_parallel",
+        "max_batch_size",
+        "max_batched_tokens",
+        "gpu_memory_fraction",
+        "kv_cache_dtype",
+        "tool_parser",
+    } <= common
+
+
+# ------------------------------------------------- settings held in a file
+
+
+def test_a_config_file_makes_a_setting_unknown_not_absent():
+    """ "Not set" is false when the command hands its settings to a file.
+
+    Four SGLang workers in the corpus pass only ``--config`` plus parser flags;
+    the model lives in ``/etc/sglang/*.yaml``. Answering ABSENT there invites
+    the caller to conclude no model is configured, which is wrong.
+    """
+    argv = ArgV.shell("exec python3 -m dynamo.sglang --config /etc/sglang/prefill.yaml")
+    fact = SGLANG.read(argv, "model")
+    assert fact.is_unknown
+    assert "/etc/sglang/prefill.yaml" in fact.detail
+
+
+def test_trtllm_defers_through_extra_engine_args():
+    """``--extra-engine-args`` is TensorRT-LLM's config flag, and its commonest."""
+    argv = ArgV.shell("exec python3 -m dynamo.trtllm --extra-engine-args /cfg/e.yaml")
+    assert TRTLLM.read(argv, "context_length").is_unknown
+
+
+def test_a_flag_on_the_command_line_beats_the_config_file():
+    """Deferral only applies to settings the command line does not carry."""
+    argv = ArgV.shell(
+        "exec python3 -m dynamo.sglang --config /etc/s.yaml --model-path Qwen/Q"
+    )
+    assert SGLANG.read(argv, "model").require() == "Qwen/Q"
+    assert SGLANG.read(argv, "tensor_parallel").is_unknown
+
+
+def test_without_a_config_flag_absence_is_still_absence():
+    """Deferral must not turn every missing flag into UNKNOWN."""
+    fact = SGLANG.read(ArgV.argv(["--model-path", "Qwen/Q"]), "tensor_parallel")
+    assert fact.is_absent
+    assert "--tp" in fact.detail

--- a/harness/tests/test_dialect.py
+++ b/harness/tests/test_dialect.py
@@ -58,9 +58,11 @@ def test_an_unknown_semantic_lists_what_the_engine_knows():
 
 
 def test_reading_accepts_every_spelling_the_engine_does():
-    """SGLang uses ``--tp`` 10 times and ``--tensor-parallel-size`` 7 times.
+    """SGLang spells this three ways, and all three are in use.
 
-    A reader that knows only the canonical spelling misses 10 of 17 workers.
+    ``--tp`` x30, ``--tensor-parallel-size`` x7, ``--tp-size`` x2. A reader that
+    knows only the canonical spelling finds it in 7 of the 39 SGLang workers
+    that set it.
     """
     assert SGLANG.read(ArgV.argv(["--tp", "8"]), "tensor_parallel").require() == "8"
     assert (
@@ -72,7 +74,7 @@ def test_reading_accepts_every_spelling_the_engine_does():
 
 
 def test_trtllm_reads_both_model_spellings():
-    """``--model-path`` ×29 and ``--model`` ×12 are both live."""
+    """``--model-path`` x44 and ``--model`` x12 are both live."""
     assert TRTLLM.read(ArgV.argv(["--model-path", "A"]), "model").require() == "A"
     assert TRTLLM.read(ArgV.argv(["--model", "A"]), "model").require() == "A"
 
@@ -192,9 +194,9 @@ def test_the_three_dialects_share_their_core_semantics():
 def test_a_config_file_makes_a_setting_unknown_not_absent():
     """ "Not set" is false when the command hands its settings to a file.
 
-    Four SGLang workers in the corpus pass only ``--config`` plus parser flags;
-    the model lives in ``/etc/sglang/*.yaml``. Answering ABSENT there invites
-    the caller to conclude no model is configured, which is wrong.
+    12 SGLang workers pass ``--config`` and the model lives in
+    ``/etc/sglang/*.yaml``. Answering ABSENT there invites the caller to
+    conclude no model is configured, which is wrong.
     """
     argv = ArgV.shell("exec python3 -m dynamo.sglang --config /etc/sglang/prefill.yaml")
     fact = SGLANG.read(argv, "model")
@@ -203,7 +205,7 @@ def test_a_config_file_makes_a_setting_unknown_not_absent():
 
 
 def test_trtllm_defers_through_extra_engine_args():
-    """``--extra-engine-args`` is TensorRT-LLM's config flag, and its commonest."""
+    """Every one of the 56 TensorRT-LLM workers in the corpus uses this."""
     argv = ArgV.shell("exec python3 -m dynamo.trtllm --extra-engine-args /cfg/e.yaml")
     assert TRTLLM.read(argv, "context_length").is_unknown
 

--- a/harness/tests/test_end_to_end.py
+++ b/harness/tests/test_end_to_end.py
@@ -1,0 +1,344 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The whole thing, end to end, with no cluster.
+
+A real subprocess, real HTTP, a real restart, real evidence collection, and a
+real judgement over the sealed bundle. Nothing here is mocked — if the phase
+machine, the provider, the verb façade or the seal is wrong, these fail.
+
+This is the demonstration that the abstraction is usable, not just coherent.
+"""
+
+import socket
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from dynamo_test.evidence import Outcome, Recorder, Verdict
+from dynamo_test.providers import LocalProvider, LocalRole
+from dynamo_test.roles import PortName, Role, RoleBinding, RoleTable, at
+from dynamo_test.sut import NotGranted, Phase, PhaseError, Sut
+from dynamo_test.verbs import Grant
+
+STUB = Path(__file__).parent / "stub_frontend.py"
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def deployment(tmp_path):
+    """A one-role deployment: a frontend, as a local subprocess."""
+    port = free_port()
+    provider = LocalProvider(
+        {
+            Role.FRONTEND: LocalRole(
+                role=Role.FRONTEND,
+                argv=[
+                    sys.executable,
+                    str(STUB),
+                    "--port",
+                    str(port),
+                    "--model",
+                    "Qwen/Qwen3-0.6B",
+                    "--max-model-len",
+                    "2048",
+                ],
+                port=port,
+            )
+        },
+        log_dir=tmp_path / "logs",
+    )
+    roles = RoleTable(
+        {
+            Role.FRONTEND: RoleBinding(
+                role=Role.FRONTEND,
+                service="Frontend",
+                log_key="frontend",
+                ports={PortName.SERVICE: port},
+            )
+        }
+    )
+    yield provider, roles, port
+    provider.shutdown()
+
+
+def make_sut(
+    provider,
+    roles,
+    tmp_path,
+    grants=(Grant.READ, Grant.INFER, Grant.LIFECYCLE),
+):
+    return Sut(
+        provider,
+        roles,
+        Recorder(tmp_path / "bundles", "run-e2e"),
+        grants=grants,
+        collectors=[provider.collect_into],
+    )
+
+
+# --------------------------------------------------------------- the happy path
+
+
+def test_start_query_collect_judge(deployment, tmp_path):
+    """The full loop, in the order the design says it must happen."""
+    provider, roles, port = deployment
+    sut = make_sut(provider, roles, tmp_path)
+
+    with sut:
+        sut.start(at("frontend"))
+        sut.wait_serving(timeout=30)
+
+        # Verb-first: the role is a default, so this is just query().
+        answer = sut.query("hello")
+        assert answer.value.is_known
+        assert answer.value.require()["choices"][0]["text"] == "echo: hello"
+
+        models = sut.models()
+        assert models.value.require()["data"][0]["id"] == "Qwen/Qwen3-0.6B"
+
+    # Now in CHECK: judge the sealed bundle.
+    evidence = sut.evidence()
+    assert evidence.require_valid_run().verdict is Verdict.PASSED
+
+    def expect_frontend_served_a_request(ev):
+        log = ev.text("roles/frontend/current.log")
+        if not log.is_known:
+            return Outcome(
+                "expect_frontend_served_a_request", Verdict.INVALID, log.detail
+            )
+        served = "request" in log.require()
+        return Outcome(
+            "expect_frontend_served_a_request",
+            Verdict.PASSED if served else Verdict.FAILED,
+            f"{log.require().count('request ')} request line(s) in the log",
+            evidence=("roles/frontend/current.log",),
+        )
+
+    verdict, outcomes = evidence.judge([expect_frontend_served_a_request])
+    assert verdict is Verdict.PASSED, [o.detail for o in outcomes]
+
+
+def test_the_timeline_records_every_verb(deployment, tmp_path):
+    """A handle per verb, in order, with what it resolved to."""
+    provider, roles, port = deployment
+    sut = make_sut(provider, roles, tmp_path)
+    with sut:
+        sut.start(at("frontend"))
+        sut.wait_serving(timeout=30)
+        sut.query("a")
+
+    rows = sut.evidence().rows("timeline.jsonl").require()
+    assert [r["verb"] for r in rows] == ["start", "wait_serving", "query"]
+    assert all(r["elapsed_s"] >= 0 for r in rows)
+    assert rows[0]["resolved"]["pid"] > 0
+
+
+# ------------------------------------------------------------ the phase machine
+
+
+def test_acting_after_teardown_is_refused_and_says_what_to_do(deployment, tmp_path):
+    """The bug this machine exists to make unwritable.
+
+    A check that reads the system after teardown is measuring the teardown.
+    """
+    provider, roles, port = deployment
+    sut = make_sut(provider, roles, tmp_path)
+    with sut:
+        sut.start(at("frontend"))
+        sut.wait_serving(timeout=30)
+
+    assert sut.phase is Phase.CHECK
+    with pytest.raises(PhaseError) as exc:
+        sut.query("too late")
+    assert "ACT verb" in str(exc.value)
+    assert "may not exist any more" in str(exc.value)
+
+
+def test_evidence_is_not_readable_before_the_seal(deployment, tmp_path):
+    provider, roles, port = deployment
+    sut = make_sut(provider, roles, tmp_path)
+    with sut:
+        with pytest.raises(PhaseError, match="CHECK-phase call"):
+            sut.evidence()
+
+
+def test_collection_happens_even_when_the_body_fails(deployment, tmp_path):
+    """A failed run is exactly when its evidence matters most."""
+    provider, roles, port = deployment
+    sut = make_sut(provider, roles, tmp_path)
+
+    with pytest.raises(ZeroDivisionError):
+        with sut:
+            sut.start(at("frontend"))
+            sut.wait_serving(timeout=30)
+            sut.query("before the explosion")
+            1 / 0
+
+    evidence = sut.evidence()
+    log = evidence.text("roles/frontend/current.log")
+    assert log.is_known, "the log must be collected despite the failure"
+    assert "request " in log.require()
+    assert len(evidence.rows("timeline.jsonl").require()) == 3
+
+
+# ------------------------------------------------------------------- grants
+
+
+def test_a_verb_without_its_grant_is_refused_before_anything_happens(
+    deployment, tmp_path
+):
+    """Refused at the call, before the provider is touched.
+
+    Halfway through a fault is the worst place to discover a suite was not
+    allowed to inject it.
+    """
+    provider, roles, port = deployment
+    sut = make_sut(provider, roles, tmp_path, grants=(Grant.READ, Grant.INFER))
+    with sut:
+        with pytest.raises(NotGranted):
+            sut.start(at("frontend"))
+    # Nothing was started, so nothing has a log — the refusal came first.
+    assert provider.restart_count(at("frontend")).is_unknown
+
+
+def test_lifecycle_needs_its_grant(deployment, tmp_path):
+    provider, roles, port = deployment
+    sut = make_sut(provider, roles, tmp_path, grants=(Grant.READ,))
+    with sut:
+        with pytest.raises(NotGranted) as exc:
+            sut.restart(at("frontend"))
+    assert "'lifecycle' grant" in str(exc.value)
+    assert "read" in str(exc.value)
+
+
+# ------------------------------------------------------------------ restart
+
+
+def test_restart_changes_a_flag_and_the_service_reflects_it(deployment, tmp_path):
+    """Settings go through ArgV, so the flag is replaced rather than appended.
+
+    Appending gives `--max-model-len 2048 --max-model-len 4096`; the process
+    takes one and the test believes the other.
+    """
+    provider, roles, port = deployment
+    sut = make_sut(
+        provider, roles, tmp_path, grants=(Grant.READ, Grant.INFER, Grant.LIFECYCLE)
+    )
+    with sut:
+        first = sut.start(at("frontend"))
+        sut.wait_serving(timeout=30)
+        assert sut.query("x").value.require()["max_model_len"] == 2048
+
+        sut.restart(at("frontend"), max_model_len=4096)
+        sut.wait_serving(timeout=30)
+        assert sut.query("y").value.require()["max_model_len"] == 4096
+
+        # The flag was replaced, not appended.
+        argv = provider._roles[Role.FRONTEND].argv
+        assert argv.count("--max-model-len") == 1
+        sut.require_restarted(at("frontend"), since=first, within=10)
+
+
+def test_restart_count_is_unknown_before_the_first_start(deployment, tmp_path):
+    """ "Never started" and "started once" are different facts."""
+    provider, roles, port = deployment
+    assert provider.restart_count(at("frontend")).is_unknown
+    provider.start(at("frontend"))
+    assert provider.restart_count(at("frontend")).require() == 0
+
+
+# ----------------------------------------------------------------- failures
+
+
+def test_an_unreachable_role_is_unknown_not_absent(deployment, tmp_path):
+    """Nothing was started, so nothing is known — not "it returned nothing"."""
+    provider, roles, port = deployment
+    got = provider.request(at("frontend"), "/v1/models", timeout=2)
+    assert got.is_unknown
+    assert "unreachable" in got.detail
+
+
+def test_an_http_error_is_absent_with_its_status(deployment, tmp_path):
+    """A 503 is a real answer from a running service, not a failure to reach it.
+
+    Collapsing the two is how "the server refused" gets reported as "the server
+    is down", and they call for different responses.
+    """
+    port = free_port()
+    provider = LocalProvider(
+        {
+            Role.FRONTEND: LocalRole(
+                role=Role.FRONTEND,
+                argv=[
+                    sys.executable,
+                    str(STUB),
+                    "--port",
+                    str(port),
+                    "--fail-after",
+                    "1",
+                ],
+                port=port,
+            )
+        },
+        log_dir=tmp_path / "logs2",
+    )
+    try:
+        provider.start(at("frontend"))
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if provider.request(at("frontend"), "/v1/models", timeout=1).is_known:
+                break
+            time.sleep(0.05)
+        assert provider.request(
+            at("frontend"), "/v1/completions", method="POST", body={"prompt": "1"}
+        ).is_known
+        second = provider.request(
+            at("frontend"), "/v1/completions", method="POST", body={"prompt": "2"}
+        )
+        assert second.is_absent
+        assert "503" in second.detail
+    finally:
+        provider.shutdown()
+
+
+def test_stop_is_scoped_to_the_role(deployment, tmp_path):
+    """A stop that tears down everything makes fault tests vacuous."""
+    provider, roles, port = deployment
+    provider.start(at("frontend"))
+    assert provider.replicas(at("frontend")).require() == 1
+    provider.stop(at("frontend"))
+    assert provider.replicas(at("frontend")).require() == 0
+    # The log survives the process, so evidence about a dead role is still readable.
+    assert provider.logs(at("frontend")).is_known
+
+
+def test_an_unknown_role_names_the_ones_that_exist(deployment, tmp_path):
+    provider, roles, port = deployment
+    with pytest.raises(KeyError, match="frontend"):
+        provider.start(at("decode"))
+
+
+# ------------------------------------------------- both façade spellings work
+
+
+def test_the_component_spelling_reaches_the_same_verb(deployment, tmp_path):
+    """`sut.component("frontend").query(...)` is `sut.query(..., at("frontend"))`."""
+    provider, roles, port = deployment
+    sut = make_sut(
+        provider, roles, tmp_path, grants=(Grant.READ, Grant.INFER, Grant.LIFECYCLE)
+    )
+    with sut:
+        sut.start(at("frontend"))
+        sut.wait_serving(timeout=30)
+        handle = sut.component("frontend").query("via the component view")
+    assert (
+        handle.value.require()["choices"][0]["text"] == "echo: via the component view"
+    )
+    assert handle.selector.role is Role.FRONTEND

--- a/harness/tests/test_evidence.py
+++ b/harness/tests/test_evidence.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`dynamo_test.evidence`.
+
+The properties worth having are the ones that stop a run reporting success it
+did not earn: an artifact nobody collected must not read as an empty one, a run
+that judged nothing must not pass, and a check that crashes must not be scored
+as a product failure.
+"""
+
+import json
+
+import pytest
+from dynamo_test.evidence import (
+    BundleError,
+    Evidence,
+    NotDeclared,
+    Outcome,
+    Recorder,
+    Sealed,
+    Verdict,
+    combine,
+)
+
+
+@pytest.fixture
+def recorder(tmp_path):
+    return Recorder(tmp_path, "run-1")
+
+
+@pytest.fixture
+def sealed(tmp_path):
+    r = Recorder(tmp_path, "run-1")
+    r.declare("requests/main.jsonl", "query", min_rows=1)
+    r.declare("roles/frontend/0/current.log", "log-scrape")
+    r.write_rows(
+        "requests/main.jsonl", [{"id": "a", "ok": True}, {"id": "b", "ok": False}]
+    )
+    r.write_text("roles/frontend/0/current.log", "started\nserving\n")
+    r.note("plan", {"name": "demo"})
+    r.seal()
+    return r.evidence()
+
+
+# --------------------------------------------------------------- verdicts
+
+
+def test_invalid_outranks_failed():
+    """A run that did not measure has not judged the product.
+
+    Reporting a failure from missing evidence attributes a harness problem to
+    whoever owns the code under test.
+    """
+    assert Verdict.INVALID.rank < Verdict.FAILED.rank < Verdict.PASSED.rank
+    assert (
+        combine(
+            [
+                Outcome("a", Verdict.FAILED),
+                Outcome("b", Verdict.INVALID),
+                Outcome("c", Verdict.PASSED),
+            ]
+        )
+        is Verdict.INVALID
+    )
+
+
+def test_verdicts_have_distinct_exit_codes():
+    """So a CI lane can retry an invalid run and escalate a failed one."""
+    assert Verdict.PASSED.exit_code == 0
+    assert Verdict.FAILED.exit_code == 1
+    assert Verdict.INVALID.exit_code == 3
+    assert Verdict.OBSERVED.exit_code == 0
+
+
+def test_judging_nothing_is_invalid_not_passed():
+    """The largest false green available: a run that checked nothing."""
+    assert combine([]) is Verdict.INVALID
+
+
+def test_observed_never_lowers_the_verdict():
+    assert combine([Outcome("a", Verdict.PASSED), Outcome("b", Verdict.OBSERVED)]) is (
+        Verdict.PASSED
+    )
+
+
+# ------------------------------------------------------------- collecting
+
+
+def test_writing_an_undeclared_artifact_is_refused(recorder):
+    """Without a promise there is nothing for absence to contradict."""
+    with pytest.raises(NotDeclared, match="never declared"):
+        recorder.write_text("stray.log", "hello")
+
+
+def test_nothing_can_be_written_after_the_seal(recorder):
+    recorder.declare("a.txt", "p")
+    recorder.write_text("a.txt", "x")
+    recorder.seal()
+    with pytest.raises(Sealed):
+        recorder.write_text("a.txt", "y")
+    with pytest.raises(Sealed):
+        recorder.declare("b.txt", "p")
+
+
+def test_the_bundle_cannot_be_read_before_it_is_sealed(recorder):
+    recorder.declare("a.txt", "p")
+    with pytest.raises(BundleError, match="not sealed"):
+        recorder.evidence()
+
+
+def test_an_artifact_name_may_not_escape_the_bundle(recorder):
+    recorder.declare("../escape.txt", "p")
+    with pytest.raises(BundleError, match="relative path"):
+        recorder.write_text("../escape.txt", "x")
+
+
+# ------------------------------------------------------------------ seal
+
+
+def test_a_kept_promise_is_valid(sealed):
+    assert sealed.seal.is_valid
+    assert sealed.require_valid_run().verdict is Verdict.PASSED
+
+
+def test_a_declared_artifact_that_never_arrives_invalidates_the_run(tmp_path):
+    r = Recorder(tmp_path, "run-2")
+    r.declare("requests/main.jsonl", "query", min_rows=1)
+    seal = r.seal()
+    assert not seal.is_valid
+    assert "requests/main.jsonl" in seal.missing
+    assert "never written" in seal.why() or "declared but never written" in seal.why()
+
+
+def test_an_empty_file_does_not_satisfy_a_row_promise(tmp_path):
+    """ "The file exists" is a weak promise; an empty requests log proves nothing."""
+    r = Recorder(tmp_path, "run-3")
+    r.declare("requests/main.jsonl", "load", min_rows=1)
+    r.write_rows("requests/main.jsonl", [])
+    seal = r.seal()
+    assert not seal.is_valid
+    assert seal.short == (("requests/main.jsonl", 1, 0),)
+    assert "promised 1, got 0" in seal.why()
+
+
+def test_an_optional_artifact_may_be_absent(tmp_path):
+    r = Recorder(tmp_path, "run-4")
+    r.declare("maybe.log", "p", required=False)
+    assert r.seal().is_valid
+
+
+# ------------------------------------------------------------- judgement
+
+
+def test_an_uncollected_artifact_is_unknown_not_empty(sealed):
+    """The property the whole module exists for.
+
+    A check that globs, finds nothing, and concludes "no errors" has answered a
+    question about the product using the failure of the measurement.
+    """
+    fact = sealed.text("roles/worker/0/current.log")
+    assert fact.is_unknown
+    assert "nothing declared this artifact" in fact.detail
+    assert "roles/frontend/0/current.log" in fact.detail  # says what *was* collected
+
+
+def test_reads_go_through_the_producer_index(sealed):
+    assert sealed.produced_by("requests/main.jsonl").require() == "query"
+    assert sealed.artifacts() == (
+        "requests/main.jsonl",
+        "roles/frontend/0/current.log",
+    )
+
+
+def test_rows_are_parsed_and_counted(sealed):
+    rows = sealed.rows("requests/main.jsonl")
+    assert len(rows.require()) == 2
+    assert rows.require()[0]["id"] == "a"
+
+
+def test_a_malformed_row_makes_the_whole_artifact_unknown(tmp_path):
+    """Skipping a bad line silently changes the denominator of every rate."""
+    r = Recorder(tmp_path, "run-5")
+    r.declare("requests/main.jsonl", "load")
+    r.write_text("requests/main.jsonl", '{"ok": true}\nnot json\n')
+    r.seal()
+    fact = r.evidence().rows("requests/main.jsonl")
+    assert fact.is_unknown
+    assert "line 2" in fact.detail
+
+
+def test_an_invalid_run_short_circuits_the_checks(tmp_path):
+    """No point asking whether the product behaved if nothing was measured."""
+    r = Recorder(tmp_path, "run-6")
+    r.declare("requests/main.jsonl", "load", min_rows=1)
+    r.seal()
+    ran = []
+
+    def expect_something(ev):
+        ran.append(True)
+        return Outcome("expect_something", Verdict.PASSED)
+
+    verdict, outcomes = r.evidence().judge([expect_something])
+    assert verdict is Verdict.INVALID
+    assert ran == [], "checks must not run against an invalid bundle"
+    assert len(outcomes) == 1
+
+
+def test_a_check_that_raises_is_invalid_not_failed(sealed):
+    """A broken check is a harness problem, not a product regression."""
+
+    def expect_boom(ev):
+        raise RuntimeError("kaboom")
+
+    verdict, outcomes = sealed.judge([expect_boom])
+    assert verdict is Verdict.INVALID
+    boom = next(o for o in outcomes if o.check == "expect_boom")
+    assert "RuntimeError" in boom.detail
+    assert "kaboom" in boom.detail
+
+
+def test_a_check_returning_the_wrong_type_is_invalid(sealed):
+    def expect_true(ev):
+        return True
+
+    verdict, outcomes = sealed.judge([expect_true])
+    assert verdict is Verdict.INVALID
+    assert "expected an Outcome" in next(
+        o.detail for o in outcomes if o.check == "expect_true"
+    )
+
+
+def test_a_failing_check_fails_the_run(sealed):
+    def expect_all_requests_succeeded(ev):
+        rows = ev.rows("requests/main.jsonl").require()
+        bad = [r for r in rows if not r["ok"]]
+        return Outcome(
+            "expect_all_requests_succeeded",
+            Verdict.PASSED if not bad else Verdict.FAILED,
+            f"{len(bad)} of {len(rows)} failed",
+            evidence=("requests/main.jsonl",),
+        )
+
+    verdict, outcomes = sealed.judge([expect_all_requests_succeeded])
+    assert verdict is Verdict.FAILED
+    assert "1 of 2 failed" in outcomes[-1].detail
+
+
+# --------------------------------------------------------------- replay
+
+
+def test_a_sealed_bundle_is_judgeable_offline(tmp_path):
+    """The point of sealing: the same verdict, hours later, from the directory.
+
+    Nothing here touches a cluster, so a CI failure can be re-scored on a laptop
+    without reproducing the deployment.
+    """
+    r = Recorder(tmp_path, "run-7")
+    r.declare("requests/main.jsonl", "query", min_rows=1)
+    r.write_rows("requests/main.jsonl", [{"ok": True}])
+    r.note("plan", {"name": "demo"})
+    r.seal()
+
+    reopened = Evidence.open(tmp_path / "run-7")
+    assert reopened.run_id == "run-7"
+    assert reopened.run["plan"] == {"name": "demo"}
+    assert reopened.rows("requests/main.jsonl").require() == ({"ok": True},)
+    assert reopened.require_valid_run().verdict is Verdict.PASSED
+
+
+def test_opening_a_directory_that_is_not_a_bundle_says_so(tmp_path):
+    with pytest.raises(BundleError, match="not a sealed evidence bundle"):
+        Evidence.open(tmp_path)
+
+
+def test_findings_are_written_so_a_run_can_be_rescored(sealed, tmp_path):
+    def observe_request_count(ev):
+        return Outcome("observe_request_count", Verdict.OBSERVED, "2 requests")
+
+    verdict, outcomes = sealed.judge([observe_request_count])
+    path = sealed.write_findings(outcomes)
+    written = json.loads(path.read_text())
+    assert written["verdict"] == verdict.value
+    assert any(o["check"] == "observe_request_count" for o in written["outcomes"])
+    assert all("verdict" in o for o in written["outcomes"])

--- a/harness/tests/test_facts.py
+++ b/harness/tests/test_facts.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`dynamo_test.facts`."""
+
+import pytest
+from dynamo_test.facts import Fact, FactNotKnown, Status
+
+
+def test_known_carries_the_value_and_its_address():
+    fact = Fact.known("Qwen/Qwen3-0.6B", "DGD spec.components[Worker].args[0]")
+    assert fact.is_known
+    assert fact.require() == "Qwen/Qwen3-0.6B"
+    assert fact.source == "DGD spec.components[Worker].args[0]"
+
+
+def test_absent_and_unknown_are_distinct_states():
+    absent = Fact.absent("args", "scanned 12 tokens; --model is not among them")
+    unknown = Fact.unknown("args", "command could not be tokenised")
+    assert absent.status is Status.ABSENT
+    assert unknown.status is Status.UNKNOWN
+    assert absent.status is not unknown.status
+
+
+def test_require_names_what_could_not_be_read():
+    fact = Fact.unknown("args[0]", "unterminated single quote at offset 41")
+    with pytest.raises(FactNotKnown) as exc:
+        fact.require()
+    assert "args[0]" in str(exc.value)
+    assert "unterminated single quote" in str(exc.value)
+
+
+def test_a_fact_has_no_truth_value():
+    """``if not fact:`` is the exact shape of both measured false-greens.
+
+    A scan that could not read its source and one that read it and found
+    nothing are both falsy, so the bug is invisible at the call site. Raising
+    makes it unwritable instead.
+    """
+    with pytest.raises(TypeError) as exc:
+        bool(Fact.unknown("args", "unreadable"))
+    assert "ABSENT from UNKNOWN" in str(exc.value)
+
+    with pytest.raises(TypeError):
+        if Fact.known("x", "src"):  # noqa: SIM103
+            pass
+
+
+def test_or_else_collapses_absent_and_unknown_deliberately():
+    assert Fact.known("a", "src").or_else("z") == "a"
+    assert Fact.absent("src", "not set").or_else("z") == "z"
+    assert Fact.unknown("src", "unreadable").or_else("z") == "z"
+
+
+def test_facts_are_immutable():
+    fact = Fact.known("a", "src")
+    with pytest.raises(Exception):
+        fact.value = "b"  # type: ignore[misc]

--- a/harness/tests/test_import_discipline.py
+++ b/harness/tests/test_import_discipline.py
@@ -35,6 +35,7 @@ TIER_0 = {
     "verbs.py",
     "catalog.py",
     "dialect.py",
+    "evidence.py",
 }
 
 # The one module permitted to import pytest, once it exists.

--- a/harness/tests/test_import_discipline.py
+++ b/harness/tests/test_import_discipline.py
@@ -27,7 +27,15 @@ import pytest
 PACKAGE = pathlib.Path(__file__).resolve().parents[1] / "dynamo_test"
 
 # Modules that must import nothing outside the standard library.
-TIER_0 = {"__init__.py", "argv.py", "facts.py", "roles.py", "verbs.py", "catalog.py"}
+TIER_0 = {
+    "__init__.py",
+    "argv.py",
+    "facts.py",
+    "roles.py",
+    "verbs.py",
+    "catalog.py",
+    "dialect.py",
+}
 
 # The one module permitted to import pytest, once it exists.
 PYTEST_OWNER = "pytest_plugin.py"

--- a/harness/tests/test_import_discipline.py
+++ b/harness/tests/test_import_discipline.py
@@ -27,7 +27,7 @@ import pytest
 PACKAGE = pathlib.Path(__file__).resolve().parents[1] / "dynamo_test"
 
 # Modules that must import nothing outside the standard library.
-TIER_0 = {"__init__.py", "argv.py", "facts.py"}
+TIER_0 = {"__init__.py", "argv.py", "facts.py", "roles.py", "verbs.py", "catalog.py"}
 
 # The one module permitted to import pytest, once it exists.
 PYTEST_OWNER = "pytest_plugin.py"

--- a/harness/tests/test_import_discipline.py
+++ b/harness/tests/test_import_discipline.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The harness's import rules, enforced by walking the AST rather than by review.
+
+Three rules, each with a reason that costs something real if broken:
+
+1. **Nothing imports ``dynamo.*``.** The harness version would weld to the
+   runtime version, and pointing one suite at an older Dynamo release becomes
+   impossible.
+2. **Only the pytest plugin imports ``pytest``.** Otherwise the manifest and
+   evidence layers cannot be used outside a test run — by a CLI, by a planner,
+   or by a suite that only wants to read a bundle.
+3. **Tier 0 is stdlib only.** ``plan`` and ``judge`` have to run on a laptop, in
+   CI's bare-checkout tier, and inside a runner with no cluster credentials at
+   all.
+
+Rule 3 is scoped to the modules named here rather than to the package, so that
+later tiers can take dependencies behind extras without weakening the core.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+PACKAGE = pathlib.Path(__file__).resolve().parents[1] / "dynamo_test"
+
+# Modules that must import nothing outside the standard library.
+TIER_0 = {"__init__.py", "argv.py", "facts.py"}
+
+# The one module permitted to import pytest, once it exists.
+PYTEST_OWNER = "pytest_plugin.py"
+
+STDLIB_OK = {
+    "__future__",
+    "abc",
+    "argparse",
+    "ast",
+    "base64",
+    "collections",
+    "contextlib",
+    "copy",
+    "dataclasses",
+    "datetime",
+    "difflib",
+    "enum",
+    "functools",
+    "hashlib",
+    "io",
+    "ipaddress",
+    "itertools",
+    "json",
+    "logging",
+    "math",
+    "os",
+    "pathlib",
+    "re",
+    "shlex",
+    "shutil",
+    "socket",
+    "statistics",
+    "string",
+    "subprocess",
+    "sys",
+    "tempfile",
+    "textwrap",
+    "time",
+    "types",
+    "typing",
+    "urllib",
+    "uuid",
+    "warnings",
+    "weakref",
+}
+
+
+def _modules():
+    return sorted(PACKAGE.rglob("*.py"))
+
+
+def _imported_roots(path):
+    """Root package name of every import in ``path``, with its line number."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield alias.name.split(".")[0], node.lineno
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:  # relative import, within the package
+                continue
+            if node.module:
+                yield node.module.split(".")[0], node.lineno
+
+
+def test_the_package_has_modules_to_check():
+    assert _modules(), "no modules found; the path in this test is wrong"
+
+
+@pytest.mark.parametrize("path", _modules(), ids=lambda p: p.name)
+def test_no_module_imports_the_dynamo_runtime(path):
+    """Importing ``dynamo.*`` would pin the harness to one runtime version."""
+    offenders = [
+        f"{path.name}:{line} imports {root}"
+        for root, line in _imported_roots(path)
+        if root == "dynamo"
+    ]
+    assert offenders == []
+
+
+@pytest.mark.parametrize("path", _modules(), ids=lambda p: p.name)
+def test_only_the_pytest_plugin_imports_pytest(path):
+    if path.name == PYTEST_OWNER:
+        return
+    offenders = [
+        f"{path.name}:{line}"
+        for root, line in _imported_roots(path)
+        if root == "pytest" or root.startswith("_pytest")
+    ]
+    assert offenders == [], (
+        f"{offenders} imports pytest; that makes this module unusable outside a "
+        f"test run. Move the pytest-facing part into {PYTEST_OWNER}."
+    )
+
+
+@pytest.mark.parametrize(
+    "path", [p for p in _modules() if p.name in TIER_0], ids=lambda p: p.name
+)
+def test_tier_zero_is_standard_library_only(path):
+    offenders = [
+        f"{path.name}:{line} imports {root}"
+        for root, line in _imported_roots(path)
+        if root not in STDLIB_OK
+    ]
+    assert offenders == [], (
+        f"{offenders}. Tier 0 must import stdlib only so that planning and "
+        "judging run with no cluster, no engine, and no credentials."
+    )
+
+
+def test_tier_zero_modules_all_exist():
+    """Guards against the rule above silently applying to nothing."""
+    present = {p.name for p in _modules()}
+    assert TIER_0 <= present, f"missing Tier 0 modules: {TIER_0 - present}"

--- a/harness/tests/test_import_discipline.py
+++ b/harness/tests/test_import_discipline.py
@@ -36,6 +36,8 @@ TIER_0 = {
     "catalog.py",
     "dialect.py",
     "evidence.py",
+    "sut.py",
+    "local.py",
 }
 
 # The one module permitted to import pytest, once it exists.
@@ -67,6 +69,7 @@ STDLIB_OK = {
     "re",
     "shlex",
     "shutil",
+    "signal",
     "socket",
     "statistics",
     "string",

--- a/harness/tests/test_import_discipline.py
+++ b/harness/tests/test_import_discipline.py
@@ -155,3 +155,47 @@ def test_tier_zero_modules_all_exist():
     """Guards against the rule above silently applying to nothing."""
     present = {p.name for p in _modules()}
     assert TIER_0 <= present, f"missing Tier 0 modules: {TIER_0 - present}"
+
+
+PROVIDER_METHODS = {
+    "address",
+    "start",
+    "stop",
+    "restart",
+    "replicas",
+    "restart_count",
+    "logs",
+    "request",
+    "all_logs",
+    "shutdown",
+    "collect_into",
+}
+
+
+def test_the_provider_protocol_declares_everything_a_provider_must_have():
+    """`all_logs`, `shutdown` and `collect_into` existed in the only
+    implementation and were load-bearing, but were never declared.
+
+    An undeclared method that every caller depends on is a contract in practice
+    and a surprise in principle: a second provider could omit one and only fail
+    at teardown, which is exactly when the evidence it was meant to collect is
+    the point.
+    """
+    import ast
+
+    tree = ast.parse((PACKAGE / "sut.py").read_text())
+    protocol = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.ClassDef) and n.name == "Provider"
+    )
+    declared = {n.name for n in protocol.body if isinstance(n, ast.FunctionDef)}
+    assert declared == PROVIDER_METHODS
+    assert len(declared) == 11
+
+
+def test_the_local_provider_satisfies_the_whole_protocol():
+    from dynamo_test.providers import LocalProvider
+
+    missing = PROVIDER_METHODS - set(dir(LocalProvider))
+    assert missing == set(), f"LocalProvider is missing {missing}"

--- a/harness/tests/test_import_discipline.py
+++ b/harness/tests/test_import_discipline.py
@@ -38,6 +38,7 @@ TIER_0 = {
     "evidence.py",
     "site.py",
     "stack.py",
+    "bringup.py",
     "sut.py",
     "local.py",
 }

--- a/harness/tests/test_import_discipline.py
+++ b/harness/tests/test_import_discipline.py
@@ -37,6 +37,7 @@ TIER_0 = {
     "dialect.py",
     "evidence.py",
     "site.py",
+    "stack.py",
     "sut.py",
     "local.py",
 }

--- a/harness/tests/test_import_discipline.py
+++ b/harness/tests/test_import_discipline.py
@@ -36,6 +36,7 @@ TIER_0 = {
     "catalog.py",
     "dialect.py",
     "evidence.py",
+    "site.py",
     "sut.py",
     "local.py",
 }

--- a/harness/tests/test_manifest.py
+++ b/harness/tests/test_manifest.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`dynamo_test.manifest`."""
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+from dynamo_test.manifest import (  # noqa: E402
+    ManifestError,
+    NoGraphDeployment,
+    Plan,
+    Schema,
+    role_of,
+)
+from dynamo_test.roles import PortName, Role  # noqa: E402
+
+V1BETA1 = """
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: demo
+spec:
+  components:
+    - name: Frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              image: nvcr.io/dynamo:latest
+              command: ["/bin/bash", "-lc"]
+              args: ["exec python3 -m dynamo.frontend --http-port 8000"]
+              ports:
+                - name: http
+                  containerPort: 8000
+                - name: metrics
+                  containerPort: 9090
+    - name: VllmDecodeWorker
+      replicas: 2
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              image: nvcr.io/dynamo:latest
+              command: ["/bin/bash", "-lc"]
+              args:
+                - "ulimit -n 65536 && exec python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --max-model-len 2048"
+              resources:
+                limits:
+                  nvidia.com/gpu: 2
+"""
+
+V1ALPHA1 = """
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: legacy
+spec:
+  services:
+    Frontend:
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/dynamo:latest
+          command: ["python3", "-m", "dynamo.frontend"]
+          args: ["--http-port", "8000"]
+    SglangWorker:
+      replicas: 1
+      resources:
+        limits:
+          gpu: 4
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/dynamo:latest
+          command: ["python3", "-m", "dynamo.sglang"]
+          args: ["--model-path", "Qwen/Qwen3-0.6B", "--tp", "4"]
+"""
+
+WITH_CONFIGMAP = (
+    """
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: engine-config
+data:
+  prefill.yaml: "model_path: Qwen/Qwen3-0.6B"
+---
+"""
+    + V1BETA1
+)
+
+
+# ------------------------------------------------------------ role inference
+
+
+@pytest.mark.parametrize(
+    "name, role",
+    [
+        ("Frontend", Role.FRONTEND),
+        ("frontend", Role.FRONTEND),
+        ("VllmPrefillWorker", Role.PREFILL),  # "prefill" must beat "worker"
+        ("prefill", Role.PREFILL),
+        ("VllmDecodeWorker", Role.DECODE),
+        ("decode", Role.DECODE),
+        ("EncodeWorker", Role.ENCODE),
+        ("Planner", Role.PLANNER),
+        ("GlobalPlanner", Role.PLANNER),
+        ("LocalRouter", Role.ROUTER),
+        ("Epp", Role.ROUTER),
+        ("agg", Role.WORKER),
+        ("VllmWorker", Role.WORKER),
+        # Both casings are in the corpus; matching one and not the other is how
+        # a log lookup silently returns nothing for a healthy service.
+        ("TrtllmWorker", Role.WORKER),
+        ("TRTLLMWorker", Role.WORKER),
+    ],
+)
+def test_role_inference_covers_the_names_in_use(name, role):
+    assert role_of(name).require() is role
+
+
+def test_an_unrecognised_name_is_absent_not_guessed():
+    fact = role_of("Zookeeper")
+    assert fact.is_absent
+    assert "frontend" in fact.detail
+
+
+# -------------------------------------------------------------------- loading
+
+
+def test_reads_v1beta1_components():
+    plan = Plan.from_yaml(V1BETA1)
+    assert plan.schema is Schema.V1BETA1
+    assert plan.name == "demo"
+    assert [c.name for c in plan] == ["Frontend", "VllmDecodeWorker"]
+
+
+def test_reads_v1alpha1_services():
+    """75 documents in the corpus use this schema; it is not legacy."""
+    plan = Plan.from_yaml(V1ALPHA1)
+    assert plan.schema is Schema.V1ALPHA1
+    assert plan["SglangWorker"].role is Role.WORKER
+
+
+def test_a_configmap_alongside_the_deployment_is_ignored():
+    """`safe_load` alone reads the first document, which is the wrong one."""
+    plan = Plan.from_yaml(WITH_CONFIGMAP)
+    assert plan.name == "demo"
+
+
+def test_a_file_with_no_deployment_says_what_it_does_contain():
+    with pytest.raises(NoGraphDeployment, match="ConfigMap"):
+        Plan.from_yaml("kind: ConfigMap\nmetadata:\n  name: x\n")
+
+
+def test_invalid_yaml_is_reported_as_such():
+    with pytest.raises(ManifestError, match="not valid YAML"):
+        Plan.from_yaml("${TEMPLATE_VAR}\n  broken: [")
+
+
+# ------------------------------------------------------- several deployments
+
+
+MULTI = V1BETA1 + "\n---\n" + V1BETA1.replace("name: demo", "name: demo-two")
+
+
+def test_several_deployments_in_one_file_are_rejected_with_a_way_forward():
+    with pytest.raises(ManifestError) as exc:
+        Plan.from_yaml(MULTI)
+    assert "all_from_yaml" in str(exc.value)
+    assert "demo-two" in str(exc.value)
+
+
+def test_all_from_yaml_gives_one_plan_each():
+    """Four `global_planner` examples describe several deployments in one file."""
+    plans = Plan.all_from_yaml(MULTI)
+    assert [p.name for p in plans] == ["demo", "demo-two"]
+
+
+def test_select_picks_one_by_name():
+    assert Plan.from_yaml(MULTI, select="demo-two").name == "demo-two"
+
+
+def test_select_of_an_absent_name_lists_what_is_there():
+    with pytest.raises(ManifestError, match="demo-two"):
+        Plan.from_yaml(MULTI, select="nope")
+
+
+# ------------------------------------------------------------------ reading
+
+
+def test_component_resolves_its_engine_and_model():
+    worker = Plan.from_yaml(V1BETA1)["VllmDecodeWorker"]
+    assert worker.backend.require() == "vllm"
+    assert worker.read("model").require() == "Qwen/Qwen3-0.6B"
+    assert worker.read("context_length").require() == "2048"
+
+
+def test_the_frontend_has_no_engine_and_says_so_as_unknown():
+    frontend = Plan.from_yaml(V1BETA1)["Frontend"]
+    assert frontend.backend.is_absent
+    assert frontend.read("model").is_unknown  # no dialect, not "no model"
+
+
+def test_gpus_read_from_either_schema():
+    assert Plan.from_yaml(V1BETA1)["VllmDecodeWorker"].gpus.require() == 2
+    assert Plan.from_yaml(V1ALPHA1)["SglangWorker"].gpus.require() == 4
+
+
+def test_lookup_by_role_or_by_name():
+    plan = Plan.from_yaml(V1BETA1)
+    assert plan[Role.DECODE].name == "VllmDecodeWorker"
+    assert plan["VllmDecodeWorker"].role is Role.DECODE
+
+
+def test_an_absent_component_lists_the_ones_present():
+    with pytest.raises(KeyError, match="VllmDecodeWorker"):
+        Plan.from_yaml(V1BETA1)["PrefillWorker"]
+
+
+# -------------------------------------------------------------- role table
+
+
+def test_the_role_table_is_derived_from_the_plan():
+    table = Plan.from_yaml(V1BETA1).roles()
+    assert table.require(Role.DECODE).service == "VllmDecodeWorker"
+    assert table.require(Role.DECODE).log_key == "vllmdecodeworker"
+    assert table.require(Role.FRONTEND).port(PortName.METRICS) == 9090
+
+
+def test_two_components_sharing_a_role_is_an_error():
+    """A role must name one service, or a selector cannot say which it means."""
+    doubled = V1BETA1.replace("name: Frontend", "name: VllmDecode", 1)
+    with pytest.raises(ManifestError, match="share a role"):
+        Plan.from_yaml(doubled).roles()
+
+
+# ------------------------------------------------------------------ editing
+
+
+def test_setting_a_semantic_writes_the_engine_s_own_flag():
+    plan = Plan.from_yaml(V1ALPHA1)
+    plan.set("SglangWorker", context_length=4096)
+    # SGLang spells it --context-length, not --max-model-len.
+    assert "--context-length" in plan["SglangWorker"].argv.as_container_args()
+    assert plan["SglangWorker"].read("context_length").require() == "4096"
+
+
+def test_editing_preserves_the_shell_command_around_the_flag():
+    plan = Plan.from_yaml(V1BETA1)
+    plan.set(Role.DECODE, context_length=4096)
+    command = plan["VllmDecodeWorker"].argv.as_shell_string()
+    assert command.startswith("ulimit -n 65536 && exec python3")
+    assert "'&&'" not in command
+    assert command.count("--max-model-len") == 1
+
+
+def test_editing_survives_a_yaml_round_trip():
+    plan = Plan.from_yaml(V1BETA1)
+    plan.set(Role.DECODE, context_length=4096, max_batch_size=32)
+    reloaded = Plan.from_yaml(plan.to_yaml())
+    assert reloaded[Role.DECODE].read("context_length").require() == "4096"
+    assert reloaded[Role.DECODE].read("max_batch_size").require() == "32"
+    assert reloaded[Role.DECODE].argv.as_shell_string().startswith("ulimit -n 65536 &&")
+
+
+def test_scaling_a_role():
+    plan = Plan.from_yaml(V1BETA1).scale(Role.DECODE, 4)
+    assert plan[Role.DECODE].replicas == 4
+    assert Plan.from_yaml(plan.to_yaml())[Role.DECODE].replicas == 4
+
+
+def test_setting_on_a_component_with_no_engine_is_refused():
+    with pytest.raises(ManifestError, match="Frontend"):
+        Plan.from_yaml(V1BETA1).set("Frontend", context_length=4096)
+
+
+# ------------------------------------------------------------------- record
+
+
+def test_the_plan_serialises_for_the_run_record():
+    import json
+
+    record = Plan.from_yaml(V1BETA1).to_record()
+    assert record["schema"] == "v1beta1"
+    decode = next(c for c in record["components"] if c["role"] == "decode")
+    assert decode["backend"] == "vllm"
+    assert decode["model"] == "Qwen/Qwen3-0.6B"
+    assert decode["gpus"] == 2
+    assert json.loads(json.dumps(record))

--- a/harness/tests/test_parity.py
+++ b/harness/tests/test_parity.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the marker-parity gate.
+
+The gate's only job is to notice that a change altered what CI selects, so the
+tests that matter are the ones where it must fail: a test that quietly stopped
+being selected, and a VRAM number that quietly moved a test between lanes.
+"""
+
+import pathlib
+import shutil
+
+import pytest
+from dynamo_test.parity import (
+    MarkerExpression,
+    collect_selection,
+    compare,
+    read_marker_expressions,
+)
+
+CONFTEST = """
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--max-vram-gib", type=float, default=None)
+    parser.addoption("--dry-run", action="store_true", default=False)
+
+def pytest_configure(config):
+    for m in ("gpu_1", "gpu_0", "pre_merge", "vllm", "profiled_vram_gib"):
+        config.addinivalue_line("markers", m + "(*a): x")
+
+# trylast, exactly as tests/conftest.py:660 declares it. That decorator is why
+# pytest's own -m deselection runs *before* this hook, and therefore why the
+# snapshot-and-subtract approach observes it. A fixture without it models a
+# different repository.
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(config, items):
+    limit = config.getoption("--max-vram-gib")
+    if limit is not None and not config.option.collectonly:
+        keep, drop = [], []
+        for item in items:
+            mark = item.get_closest_marker("profiled_vram_gib")
+            (keep if mark and mark.args and mark.args[0] <= limit else drop).append(item)
+        if drop:
+            config.hook.pytest_deselected(items=drop)
+            items[:] = keep
+    if config.getoption("--dry-run"):
+        items.clear()
+        return
+"""
+
+BASE_TESTS = """
+import pytest
+
+@pytest.mark.pre_merge
+@pytest.mark.vllm
+@pytest.mark.gpu_1
+@pytest.mark.profiled_vram_gib(20)
+def test_alpha(): pass
+
+@pytest.mark.pre_merge
+@pytest.mark.vllm
+@pytest.mark.gpu_1
+@pytest.mark.profiled_vram_gib(20)
+def test_beta(): pass
+
+@pytest.mark.pre_merge
+@pytest.mark.vllm
+@pytest.mark.gpu_0
+def test_gamma(): pass
+"""
+
+
+def make_repo(root: pathlib.Path, tests: str) -> pathlib.Path:
+    """A project shaped like the real one.
+
+    The conftest goes **inside** ``tests/``, not at the root. That is where the
+    real one lives, and it matters: hook order decides whether pytest's own
+    ``-m`` deselection runs before or after the conftest's
+    ``pytest_collection_modifyitems``. With the conftest at the root, the
+    ``items.clear()`` in its dry-run branch happens first and ``-m`` never
+    applies — which is not how the repository behaves, and a fixture that gets
+    this wrong makes the gate assert the wrong thing.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    suite = root / "tests"
+    suite.mkdir(exist_ok=True)
+    (suite / "conftest.py").write_text(CONFTEST)
+    (suite / "test_things.py").write_text(tests)
+    return root
+
+
+@pytest.fixture
+def base(tmp_path):
+    return make_repo(tmp_path / "base", BASE_TESTS)
+
+
+EXPR = "pre_merge and vllm and gpu_1"
+
+
+def selections(base_repo, head_repo, expression=EXPR, vram=None):
+    return (
+        collect_selection(base_repo, expression, vram_gib=vram),
+        collect_selection(head_repo, expression, vram_gib=vram),
+    )
+
+
+def test_an_unchanged_tree_has_parity(base, tmp_path):
+    head = tmp_path / "head"
+    shutil.copytree(base, head)
+    b, h = selections(base, head)
+    diff = compare(b, h, EXPR, "gpu_test_markers")
+    assert diff.is_clean
+    assert diff.base_count == diff.head_count == 2
+
+
+def test_a_test_that_stops_being_selected_fails_the_gate(base, tmp_path):
+    """The failure mode the gate exists for.
+
+    Dropping a marker makes CI *greener*, because the test is no longer chosen.
+    Nothing else in a passing report distinguishes that from success.
+    """
+    head = make_repo(
+        tmp_path / "head",
+        BASE_TESTS.replace(
+            "@pytest.mark.gpu_1\n@pytest.mark.profiled_vram_gib(20)\ndef test_beta",
+            "@pytest.mark.gpu_0\n@pytest.mark.profiled_vram_gib(20)\ndef test_beta",
+        ),
+    )
+    b, h = selections(base, head)
+    diff = compare(b, h, EXPR, "gpu_test_markers")
+    assert not diff.is_clean
+    assert diff.base_count == 2 and diff.head_count == 1
+    assert any(n.endswith("test_beta") for n in diff.lost)
+    assert "LOST 1" in diff.describe()
+
+
+def test_a_changed_vram_number_fails_the_gate(base, tmp_path):
+    """`profiled_vram_gib` feeds the VRAM scheduler.
+
+    The same test, still selected by the same expression, but a changed number
+    moves it between lanes — so equal node-id sets are not enough.
+    """
+    head = make_repo(
+        tmp_path / "head",
+        BASE_TESTS.replace(
+            "@pytest.mark.profiled_vram_gib(20)\ndef test_alpha",
+            "@pytest.mark.profiled_vram_gib(80)\ndef test_alpha",
+        ),
+    )
+    b, h = selections(base, head)
+    diff = compare(b, h, EXPR, "gpu_test_markers")
+    assert not diff.is_clean
+    assert diff.base_count == diff.head_count == 2  # same tests...
+    assert any(
+        n.endswith("test_alpha") for n in diff.marker_changed
+    )  # ...different lane
+    assert "MARKERS CHANGED" in diff.describe()
+
+
+def test_adding_a_test_is_not_a_failure(base, tmp_path):
+    """Gaining coverage is what adding a test looks like."""
+    head = make_repo(
+        tmp_path / "head",
+        BASE_TESTS + "\n@pytest.mark.pre_merge\n@pytest.mark.vllm\n@pytest.mark.gpu_1\n"
+        "@pytest.mark.profiled_vram_gib(20)\ndef test_delta(): pass\n",
+    )
+    b, h = selections(base, head)
+    diff = compare(b, h, EXPR, "gpu_test_markers")
+    assert diff.is_clean
+    assert len(diff.gained) == 1
+    assert "+1 new" in diff.describe()
+
+
+def test_the_gate_sees_through_the_vram_deselection(base, tmp_path):
+    """With a VRAM limit the two 20 GiB tests drop out — and the gate sees it.
+
+    This is the case `--collect-only` cannot observe at all.
+    """
+    head = tmp_path / "head"
+    shutil.copytree(base, head)
+    b, h = selections(base, head, vram=8)
+    # `gamma` goes to the -m filter, `alpha` and `beta` to the VRAM limit.
+    assert b["deselected"] == 3 and b["selected"] == 0
+    assert compare(b, h, EXPR, "gpu_test_markers").is_clean
+
+
+# ---------------------------------------------- reading CI's own expressions
+
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.skipif(
+    not (REPO / ".github" / "workflows").is_dir(),
+    reason="the workflows are not present next to the harness",
+)
+def test_the_real_marker_expressions_are_recoverable():
+    """They are literals in the callers, so the gate reads them rather than
+    restating them and drifting from the CI it models."""
+    expressions, suffix = read_marker_expressions(REPO)
+    assert len(expressions) > 20, f"only found {len(expressions)}"
+    text = {e.expression for e in expressions}
+    assert any("gpu_1" in e for e in text)
+    assert any("pre_merge" in e for e in text)
+    # The callee wraps the GPU lane; without this the gate models the wrong run.
+    assert suffix == "not profiled_vram_gib", suffix
+    assert all(e.source.endswith(tuple("0123456789")) for e in expressions)
+
+
+@pytest.mark.skipif(
+    not (REPO / ".github" / "workflows").is_dir(),
+    reason="the workflows are not present next to the harness",
+)
+def test_the_transform_is_applied_only_to_the_gpu_lane():
+    gpu = MarkerExpression("pre_merge and gpu_1", "gpu_test_markers", "x:1")
+    cpu = MarkerExpression("pre_merge and gpu_0", "cpu_only_test_markers", "x:2")
+    assert gpu.variants("not profiled_vram_gib") == (
+        "pre_merge and gpu_1",
+        "(pre_merge and gpu_1) and not profiled_vram_gib",
+    )
+    assert cpu.variants("not profiled_vram_gib") == ("pre_merge and gpu_0",)

--- a/harness/tests/test_port_tool_parser_scan.py
+++ b/harness/tests/test_port_tool_parser_scan.py
@@ -1,0 +1,242 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A worked port: finding the tool-call parser a recipe configures.
+
+`tests/deploy/test_recipe_tool_execution.py` needs to know which tool-call
+parser a manifest declares, so it can skip a recipe that configures none rather
+than fail it. The version in the tree is roughly 45 lines: a regex over two flag
+spellings, a `NamedTuple` carrying a three-valued result, a loop over services,
+and a nested try/except that falls back to the raw container dict when
+`_get_args()` raises on unbalanced quotes.
+
+Every one of those parts exists to work around something the harness now has as
+a primitive:
+
+===========================================  =====================================
+hand-rolled                                  harness
+===========================================  =====================================
+regex matching argv, ``=``-joined and        ``ArgV.get`` — one tokeniser that
+shell-string forms                           already knows all three
+``ParserScan.undetermined``                  ``Fact`` — ``UNKNOWN`` vs ``ABSENT``
+try/except around ``_get_args()``            ``ArgV.is_parseable``
+looping every service to find the flag       ``Plan`` iterates components
+two flag spellings, hard-coded               ``dialect`` ``tool_parser`` semantic
+===========================================  =====================================
+
+This file runs both implementations over the whole corpus and asserts they agree
+— which is what makes it a port rather than a rewrite. It is also the honest
+test of the abstraction: if the harness were the wrong shape, the port would not
+reproduce the original's answers.
+"""
+
+import pathlib
+import re
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+from dynamo_test.facts import Fact  # noqa: E402
+from dynamo_test.manifest import ManifestError, NoGraphDeployment, Plan  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+ROOTS = [REPO / "recipes", REPO / "examples"]
+
+pytestmark = pytest.mark.skipif(
+    not all(r.is_dir() for r in ROOTS),
+    reason="deployment manifests are not present next to the harness",
+)
+
+
+# --------------------------------------------------------------- the original
+
+_TOOL_PARSER_FLAGS = ("--dyn-tool-call-parser", "--tool-call-parser")
+_TOOL_PARSER_RE = re.compile(
+    r"(?:{})[=\s]+([^\s\\'\"]+)".format("|".join(_TOOL_PARSER_FLAGS))
+)
+
+
+def hand_rolled(path):
+    """The shape of the version in `tests/deploy/`, over raw YAML.
+
+    Reproduced against the manifest text rather than `DeploymentSpec` so this
+    file has no dependency on the dynamo test tree; the matching behaviour is
+    the same regex over the same strings.
+    """
+    try:
+        documents = list(yaml.safe_load_all(path.read_text()))
+    except Exception:
+        return None
+    for document in documents:
+        if (
+            not isinstance(document, dict)
+            or document.get("kind") != "DynamoGraphDeployment"
+        ):
+            continue
+        spec = document.get("spec") or {}
+        blobs = []
+        for service in (spec.get("services") or {}).values():
+            main = ((service or {}).get("extraPodSpec") or {}).get(
+                "mainContainer"
+            ) or {}
+            blobs.append(_blob(main))
+        for component in spec.get("components") or []:
+            for container in _every_container(component):
+                blobs.append(_blob(container))
+        for blob in blobs:
+            match = _TOOL_PARSER_RE.search(blob)
+            if match:
+                return match.group(1).rstrip("',\"]")
+    return None
+
+
+def _blob(container):
+    """Argv tokens joined by spaces, as `ServiceSpec._get_args()` yields them.
+
+    Joining with spaces rather than taking `str(list)` matters: the regex needs
+    whitespace or `=` after the flag, and a list repr puts `', '` there instead.
+    Getting this wrong would compare the port against a strawman.
+    """
+    if not isinstance(container, dict):
+        return ""
+    args = container.get("args") or []
+    if isinstance(args, str):
+        args = [args]
+    return " ".join(str(a) for a in args)
+
+
+def _every_container(component):
+    if not isinstance(component, dict):
+        return
+    if isinstance(component.get("container"), dict):
+        yield component["container"]
+    for container in ((component.get("podTemplate") or {}).get("spec") or {}).get(
+        "containers"
+    ) or []:
+        yield container
+    main = (component.get("extraPodSpec") or {}).get("mainContainer")
+    if isinstance(main, dict):
+        yield main
+
+
+# ------------------------------------------------------------------ the port
+
+
+def ported(plan: Plan) -> Fact[str]:
+    """The same question, on the harness.
+
+    The whole body. `Fact` carries the three-valued result the original built a
+    `NamedTuple` for, and reports UNKNOWN — rather than "no parser" — when a
+    command cannot be read, which is the distinction the original's
+    `undetermined` flag existed to preserve.
+    """
+    unreadable = []
+    for component in plan:
+        fact = component.argv.get("--dyn-tool-call-parser")
+        if fact.is_absent:
+            fact = component.argv.get("--tool-call-parser")
+        if fact.is_known:
+            return fact
+        if fact.is_unknown:
+            unreadable.append(component.name)
+    if unreadable:
+        return Fact.unknown(
+            plan.source, f"could not read the command of: {', '.join(unreadable)}"
+        )
+    return Fact.absent(plan.source, "no component declares a tool-call parser")
+
+
+# ------------------------------------------------------------------- the test
+
+
+def _corpus():
+    for root in ROOTS:
+        for path in sorted(root.rglob("*.yaml")):
+            try:
+                plans = Plan.all_from_file(path)
+            except (NoGraphDeployment, ManifestError):
+                continue
+            for plan in plans:
+                yield path, plan
+
+
+@pytest.fixture(scope="module")
+def scans():
+    rows = []
+    for path, plan in _corpus():
+        rows.append((path, plan, hand_rolled(path), ported(plan)))
+    assert rows, "no manifests found"
+    return rows
+
+
+def test_the_port_finds_a_parser_wherever_the_original_did(scans):
+    """Same answer, on every manifest that declares one.
+
+    Multi-deployment files are excluded from the comparison: the original scans
+    a whole file and returns the first parser it sees, while the port scans one
+    deployment, so on those two files they are answering different questions.
+    """
+    disagreements = []
+    for path, plan, old, new in scans:
+        if plan.source.count("#"):  # one of several deployments in the file
+            continue
+        if old is None:
+            continue
+        if not new.is_known:
+            disagreements.append(
+                f"{plan.source}: original={old!r} port={new.status.value}"
+            )
+        elif new.require() != old:
+            disagreements.append(
+                f"{plan.source}: original={old!r} port={new.require()!r}"
+            )
+    assert disagreements == []
+
+
+def test_the_port_finds_at_least_as_many(scans):
+    """A port may not lose coverage.
+
+    The hand-rolled regex was written after measuring that argv-only scanning
+    missed 34 of 101 parser-bearing manifests. The port must not reintroduce a
+    gap of that kind — and it does not: both find a parser in the same 127
+    deployments, with no disagreement on the value.
+    """
+    old_found = sum(1 for _, _, old, _ in scans if old is not None)
+    new_found = sum(1 for _, _, _, new in scans if new.is_known)
+    assert old_found > 100, f"only {old_found} baseline hits; the corpus moved"
+    assert new_found >= old_found, f"port found {new_found}, original {old_found}"
+    # Measured at the time of writing: 127 and 127, no disagreements.
+
+
+def test_the_port_never_claims_absence_it_cannot_justify(scans):
+    """The property the original's `undetermined` flag existed to preserve.
+
+    A manifest whose command cannot be tokenised must not be reported as
+    configuring no parser — that is a false statement in a green run, and it is
+    the bug this whole line of work started from.
+    """
+    for path, plan, old, new in scans:
+        if new.is_absent:
+            assert all(
+                c.argv.is_parseable for c in plan
+            ), f"{plan.source} claims absence but has an unreadable command"
+
+
+def test_the_port_is_shorter_than_what_it_replaces():
+    """Not vanity: the deleted code is where the bugs were.
+
+    The regex had to be taught the shell-string form after it silently reported
+    34 manifests as configuring no parser, and the try/except had to be added
+    after `_get_args()` raised on real recipes. Both are now properties of the
+    types rather than of this call site.
+    """
+    import inspect
+
+    body = [
+        line
+        for line in inspect.getsource(ported).splitlines()
+        if line.strip() and not line.strip().startswith(("#", '"""', "'"))
+    ]
+    # Signature plus a docstring plus ~14 lines of logic, against ~45 in tree.
+    assert len(body) < 25, f"port is {len(body)} lines; it was meant to be small"

--- a/harness/tests/test_pytest_plugin.py
+++ b/harness/tests/test_pytest_plugin.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the selection recorder.
+
+Run as real pytest subprocesses against a throwaway project, because the thing
+under test is hook ordering — and hook ordering cannot be exercised from inside
+the run whose hooks you are testing.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HARNESS = str(Path(__file__).resolve().parents[1])
+
+# A project with a conftest that deselects, then clears the item list — the two
+# behaviours in the real repository that defeat a naive observer.
+CONFTEST = """
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--max-vram-gib", type=float, default=None)
+    parser.addoption("--dry-run", action="store_true", default=False)
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "vram(n): profiled VRAM")
+
+def pytest_collection_modifyitems(config, items):
+    limit = config.getoption("--max-vram-gib")
+    # Guarded on collectonly exactly as the real conftest guards it, which is
+    # what makes a --collect-only gate blind.
+    if limit is not None and not config.option.collectonly:
+        keep, drop = [], []
+        for item in items:
+            mark = item.get_closest_marker("vram")
+            (keep if mark and mark.args and mark.args[0] <= limit else drop).append(item)
+        if drop:
+            config.hook.pytest_deselected(items=drop)
+            items[:] = keep
+    if config.getoption("--dry-run"):
+        items.clear()      # the real conftest does this too
+        return
+"""
+
+TESTS = """
+import pytest
+
+@pytest.mark.vram(4)
+def test_small(): pass
+
+@pytest.mark.vram(40)
+def test_large(): pass
+
+def test_unmarked(): pass
+"""
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / "conftest.py").write_text(CONFTEST)
+    (tmp_path / "test_things.py").write_text(TESTS)
+    return tmp_path
+
+
+def collect(project, *args):
+    out = project / "selection.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(project),
+            "-p",
+            "dynamo_test.pytest_plugin",
+            f"--dynamo-selection-out={out}",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            *args,
+        ],
+        cwd=project,
+        env={"PYTHONPATH": HARNESS, "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(out.read_text())
+
+
+def ids(payload):
+    return sorted(t["nodeid"].split("::")[-1] for t in payload["tests"])
+
+
+def test_records_every_test_when_nothing_deselects(project):
+    got = collect(project, "--dry-run")
+    assert got["selected"] == 3
+    assert ids(got) == ["test_large", "test_small", "test_unmarked"]
+
+
+def test_it_sees_a_deselection_that_collect_only_cannot(project):
+    """The reason the gate does not use --collect-only.
+
+    Both the deselection and the metadata write are guarded on
+    `not config.option.collectonly`, so a collect-only run is structurally blind
+    to the one mechanism that removes tests. A gate built on it reports the same
+    number before and after a change that halves what CI runs.
+    """
+    dry = collect(project, "--dry-run", "--max-vram-gib", "8")
+    collect_only = collect(project, "--collect-only", "--max-vram-gib", "8")
+
+    assert dry["deselected"] == 2 and dry["selected"] == 1
+    assert ids(dry) == ["test_small"]
+
+    assert collect_only["deselected"] == 0 and collect_only["selected"] == 3
+    assert dry["selected"] != collect_only["selected"]
+
+
+def test_it_survives_items_clear(project):
+    """`items.clear()` in the dry-run branch defeats a trylast observer.
+
+    Snapshotting first and subtracting recorded deselections is correct
+    regardless of what any later hook does to the list.
+    """
+    got = collect(project, "--dry-run", "--max-vram-gib", "8")
+    assert got["collected"] == 3, "the snapshot must predate items.clear()"
+    assert got["selected"] == 1
+
+
+def test_an_unmarked_test_is_deselected_by_a_vram_limit(project):
+    """Unknown VRAM is treated as unsafe, and the gate must see that too."""
+    got = collect(project, "--dry-run", "--max-vram-gib", "100")
+    assert "test_unmarked" not in ids(got)
+    assert ids(got) == ["test_large", "test_small"]
+
+
+def test_markers_and_their_arguments_are_recorded(project):
+    """A marker whose *argument* changed is a selection change on the GPU lane."""
+    got = collect(project, "--dry-run")
+    large = next(t for t in got["tests"] if t["nodeid"].endswith("test_large"))
+    assert "vram" in large["markers"]
+    assert large["marker_args"]["vram"] == ["40"]
+
+
+def test_the_plugin_is_inert_without_the_option(project):
+    """No output file requested, no plugin registered, no behaviour change."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(project),
+            "-p",
+            "dynamo_test.pytest_plugin",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+        ],
+        cwd=project,
+        env={"PYTHONPATH": HARNESS, "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout
+    assert not (project / "selection.json").exists()

--- a/harness/tests/test_pytest_plugin.py
+++ b/harness/tests/test_pytest_plugin.py
@@ -165,3 +165,66 @@ def test_the_plugin_is_inert_without_the_option(project):
     )
     assert result.returncode == 0, result.stdout
     assert not (project / "selection.json").exists()
+
+
+# ----------------------------------------------------------------- --site
+
+
+def run_pytest(project, *args):
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(project),
+            "-p",
+            "dynamo_test.pytest_plugin",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            *args,
+        ],
+        cwd=project,
+        env={"PYTHONPATH": HARNESS, "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_an_unknown_site_is_a_usage_error_not_a_crash(project):
+    """A mistyped option must not read as a harness bug.
+
+    Letting `UnknownSite` escape `pytest_configure` gets reported as
+    INTERNALERROR with a traceback, which buries the one useful line: the list
+    of sites that do exist.
+    """
+    result = run_pytest(project, "--site", "nosuch")
+    combined = result.stdout + result.stderr
+    assert "INTERNALERROR" not in combined
+    assert "no site named 'nosuch'" in combined
+    assert "known sites: local" in combined
+
+
+def test_selecting_a_site_does_not_change_which_tests_run(project):
+    """The invariant that makes the ladder safe to adopt incrementally.
+
+    A site decides what a test *can do*, never which tests are chosen. If
+    picking a site silently dropped tests, every tier comparison would be
+    measuring a different suite and the whole ladder would be untrustworthy.
+    """
+    bare = collect(project, "--dry-run")
+    sited = collect(project, "--dry-run", "--site", "local")
+    assert bare["selected"] == sited["selected"]
+    assert [t["nodeid"] for t in bare["tests"]] == [t["nodeid"] for t in sited["tests"]]
+
+
+def test_the_default_site_needs_no_flag(project):
+    """Running as the suite runs today must require no site definition.
+
+    Exit 5 is "no tests ran", which is what this fixture project produces under
+    --dry-run because its conftest clears the item list. What matters is that
+    the plugin contributed neither a usage error (4) nor an internal error (3).
+    """
+    result = run_pytest(project, "--dry-run")
+    assert result.returncode not in (3, 4), result.stdout + result.stderr
+    assert "INTERNALERROR" not in result.stdout + result.stderr

--- a/harness/tests/test_roles.py
+++ b/harness/tests/test_roles.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`dynamo_test.roles`."""
+
+import pytest
+from dynamo_test.roles import (
+    Policy,
+    PortName,
+    Process,
+    Role,
+    RoleBinding,
+    RoleTable,
+    Sel,
+    UnknownRole,
+    at,
+)
+
+
+def binding(role, service=None, log_key=None, **kw):
+    role = Role(role) if not isinstance(role, Role) else role
+    return RoleBinding(
+        role=role,
+        service=service or str(role).title(),
+        log_key=log_key or str(role),
+        **kw,
+    )
+
+
+@pytest.fixture
+def table():
+    return RoleTable(
+        {
+            Role.FRONTEND: binding(Role.FRONTEND, service="Frontend"),
+            Role.DECODE: binding(
+                Role.DECODE,
+                service="TRTLLMDecodeWorker",
+                log_key="decode",
+                processes={Process.ENGINE: "trtllm_worker"},
+                ports={PortName.SERVICE: 8000, PortName.METRICS: 9090},
+            ),
+        }
+    )
+
+
+# ----------------------------------------------------------------- selectors
+
+
+def test_at_accepts_a_plain_string_for_scenario_documents():
+    assert at("decode").role is Role.DECODE
+    assert at("DECODE").role is Role.DECODE
+
+
+def test_at_rejects_an_unknown_role_at_the_call_site():
+    """A typo must fail where it is written, not as a later lookup miss."""
+    with pytest.raises(UnknownRole) as exc:
+        at("decoder")
+    assert "decode" in str(exc.value)
+
+
+def test_a_selector_cannot_both_name_and_choose_a_replica():
+    with pytest.raises(ValueError, match="either names a replica"):
+        Sel(role=Role.DECODE, replica=1, policy=Policy.RANDOM)
+
+
+@pytest.mark.parametrize("bad", [{"replica": -1}, {"fraction": 0}, {"fraction": 1.5}])
+def test_a_selector_rejects_impossible_values(bad):
+    with pytest.raises(ValueError):
+        at("decode", **bad)
+
+
+def test_selector_describes_itself_stably():
+    assert at("decode", replica=1, rank=3).describe() == "decode/replica=1/rank=3"
+    assert at("worker", policy=Policy.HOTTEST).describe() == "worker/policy=hottest"
+
+
+def test_selectors_are_values():
+    assert at("decode", replica=1) == at("decode", replica=1)
+    assert at("decode", replica=1) != at("decode", replica=2)
+
+
+# ---------------------------------------------------------------- resolution
+
+
+def test_require_returns_the_binding(table):
+    assert table.require(Role.DECODE).service == "TRTLLMDecodeWorker"
+    assert table.require("decode").service == "TRTLLMDecodeWorker"
+
+
+def test_an_unknown_role_raises_and_names_what_exists(table):
+    """Never a default. An empty result reads exactly like a real measurement.
+
+    A service name that resolved to nothing is *present-and-empty*, not absent,
+    so a downstream absence check cannot recover the mistake.
+    """
+    with pytest.raises(UnknownRole) as exc:
+        table.require("prefill")
+    assert "decode" in str(exc.value)
+    assert "frontend" in str(exc.value)
+
+
+def test_lookup_and_require_agree(table):
+    assert table["decode"] is table.require("decode")
+
+
+def test_two_roles_may_not_share_a_log_key():
+    """Sharing a key means one role's evidence silently overwrites the other's."""
+    with pytest.raises(ValueError, match="reused"):
+        RoleTable(
+            {
+                Role.PREFILL: binding(Role.PREFILL, log_key="worker"),
+                Role.DECODE: binding(Role.DECODE, log_key="worker"),
+            }
+        )
+
+
+def test_a_binding_filed_under_the_wrong_role_is_rejected():
+    with pytest.raises(ValueError, match="declares role"):
+        RoleTable({Role.PREFILL: binding(Role.DECODE)})
+
+
+def test_table_is_a_mapping(table):
+    assert len(table) == 2
+    assert set(table) == {Role.FRONTEND, Role.DECODE}
+    assert table.known() == ("decode", "frontend")
+
+
+def test_resolve_goes_through_the_selector(table):
+    assert table.resolve(at("decode", replica=2)).log_key == "decode"
+
+
+# ------------------------------------------------------------------ bindings
+
+
+def test_a_missing_process_names_the_ones_declared(table):
+    with pytest.raises(KeyError, match="engine"):
+        table.require("decode").process_pattern(Process.RANK)
+
+
+def test_a_missing_port_names_the_ones_declared(table):
+    assert table.require("decode").port() == 8000
+    assert table.require("decode").port(PortName.METRICS) == 9090
+    with pytest.raises(KeyError, match="service, metrics"):
+        table.require("decode").port(PortName.GRPC)
+
+
+def test_the_table_serialises_for_the_run_record(table):
+    """Recording resolution is what makes it provable rather than assumed."""
+    record = table.to_record()
+    assert record["decode"]["service"] == "TRTLLMDecodeWorker"
+    assert record["decode"]["log_key"] == "decode"
+    assert record["decode"]["ports"] == {"service": 8000, "metrics": 9090}
+    assert list(record) == ["decode", "frontend"]
+
+
+def test_the_run_record_is_json_safe(table):
+    import json
+
+    assert (
+        json.loads(json.dumps(table.to_record()))["frontend"]["service"] == "Frontend"
+    )
+
+
+def test_one_log_key_serves_both_the_directory_and_the_scrape(table):
+    """The measured bug exists because these were two strings, not one.
+
+    A lowercase directory name plus a hard-coded PascalCase alias list means any
+    service outside the list resolves to nothing, silently.
+    """
+    decode = table.require("decode")
+    assert decode.service == "TRTLLMDecodeWorker"
+    assert decode.log_key == "decode"
+    # There is exactly one spelling to use downstream, and it came from here.
+    assert table.to_record()["decode"]["log_key"] == decode.log_key

--- a/harness/tests/test_site.py
+++ b/harness/tests/test_site.py
@@ -1,0 +1,286 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`dynamo_test.site`.
+
+The capability table is asserted in **both directions**: every capability a site
+has is exercised, and every capability it lacks has a non-empty reason. A table
+tested only one way drifts into claiming things it cannot do, which is the exact
+failure this module exists to prevent.
+"""
+
+import pytest
+from dynamo_test.site import (
+    BUILTIN_SITES,
+    LOCAL,
+    Capability,
+    Ownership,
+    Site,
+    Topology,
+    UnknownSite,
+    capabilities,
+    resolve,
+    why,
+)
+
+# The four arrangements, as they would actually be declared.
+ALL_IN_ONE = LOCAL
+
+SIDECAR = Site(
+    name="sidecar",
+    topology=Topology.SIDECAR,
+    ownership=Ownership.IMPOSE,
+    shares_process_tree=False,
+    shares_network=True,  # same compose network; the SUT can dial back
+    substrate_owned=True,
+    provider="compose",
+)
+
+COMPOSE = Site(
+    name="compose",
+    topology=Topology.COMPOSE,
+    ownership=Ownership.IMPOSE,
+    shares_process_tree=False,
+    shares_network=True,
+    substrate_owned=True,
+    provider="compose",
+)
+
+K8S_SHARED = Site(
+    name="k3s-shared",
+    topology=Topology.KUBERNETES,
+    ownership=Ownership.IMPOSE,
+    shares_process_tree=False,
+    shares_network=False,  # the cluster cannot dial a laptop's ephemeral port
+    substrate_owned=False,  # a shared namespace
+    provider="k8s",
+)
+
+ATTACHED = Site(
+    name="ci-all-in-one-attached",
+    topology=Topology.ALL_IN_ONE,
+    ownership=Ownership.VERIFY,
+    shares_process_tree=True,
+    shares_network=True,
+    substrate_owned=False,
+    provider="local",
+)
+
+ALL = [ALL_IN_ONE, SIDECAR, COMPOSE, K8S_SHARED, ATTACHED]
+
+
+# ------------------------------------------------------- the table, both ways
+
+
+@pytest.mark.parametrize("site", ALL, ids=lambda s: s.name)
+def test_every_absent_capability_has_a_reason(site):
+    """A missing capability must always say which property removed it.
+
+    "Not supported here" teaches nothing and gets copy-pasted into the next
+    skip. Naming the rung tells the reader whether to fix the site, choose a
+    different one, or accept the test belongs to one tier.
+    """
+    have = capabilities(site)
+    for cap in Capability:
+        if cap in have:
+            assert (
+                why(site, cap) is None
+            ), f"{cap} is available but why() explains it away"
+        else:
+            reason = why(site, cap)
+            assert reason, f"{site.name} lacks {cap} with no reason given"
+            assert (
+                len(reason) > 20
+            ), f"reason for {cap} is too terse to act on: {reason}"
+
+
+@pytest.mark.parametrize("site", ALL, ids=lambda s: s.name)
+def test_capabilities_are_a_subset_of_the_ceiling(site):
+    """Computed, never declared: a site cannot end up with more than its
+    arrangement allows."""
+    assert capabilities(site) <= frozenset(Capability)
+
+
+# ---------------------------------------------------------- the rungs, singly
+
+
+def test_leaving_the_process_tree_removes_signalling_and_log_files():
+    """The single largest difference between T1 and everything above it."""
+    assert Capability.SIGNAL_INNER_PROCESS in capabilities(ALL_IN_ONE)
+    assert Capability.READ_LOG_FILE in capabilities(ALL_IN_ONE)
+
+    assert Capability.SIGNAL_INNER_PROCESS not in capabilities(COMPOSE)
+    assert Capability.READ_LOG_FILE not in capabilities(COMPOSE)
+    assert "another process namespace" in why(COMPOSE, Capability.SIGNAL_INNER_PROCESS)
+
+
+def test_losing_the_reverse_network_removes_the_sink():
+    """The dangerous one: a canary that is never dialled looks like a canary
+    that correctly refused."""
+    assert Capability.SINK in capabilities(COMPOSE)
+    assert Capability.SINK not in capabilities(K8S_SHARED)
+    assert "never arrive" in why(K8S_SHARED, Capability.SINK)
+
+
+def test_verify_may_observe_but_not_mutate():
+    """Attaching to someone else's deployment must not permit restarting it."""
+    have = capabilities(ATTACHED)
+    assert Capability.RESTART_ROLE not in have
+    assert Capability.STOP_ROLE not in have
+    assert Capability.SCALE_REPLICAS not in have
+    # ...but it keeps everything observational, which is the point of attaching.
+    assert Capability.READ_LOG_FILE in have
+    assert Capability.SIGNAL_INNER_PROCESS in have
+    assert "does not own" in why(ATTACHED, Capability.RESTART_ROLE)
+
+
+def test_a_shared_substrate_forbids_scrubbing():
+    assert Capability.SCRUB in capabilities(COMPOSE)
+    assert Capability.SCRUB not in capabilities(K8S_SHARED)
+    assert "other runs" in why(K8S_SHARED, Capability.SCRUB)
+
+
+def test_the_first_rung_is_the_one_reported():
+    """Later rungs would remove it anyway; the actionable one is the first."""
+    doubly = Site(
+        name="doubly-blocked",
+        topology=Topology.KUBERNETES,
+        ownership=Ownership.VERIFY,
+        shares_process_tree=False,
+        shares_network=False,
+        substrate_owned=False,
+        provider="k8s",
+    )
+    # RESTART_ROLE is removed by VERIFY only, so that is what should be reported.
+    assert "does not own" in why(doubly, Capability.RESTART_ROLE)
+
+
+# --------------------------------------------------------- narrowing, not widening
+
+
+def test_a_site_may_narrow():
+    narrowed = Site(
+        name="no-exec",
+        topology=Topology.COMPOSE,
+        ownership=Ownership.IMPOSE,
+        shares_process_tree=False,
+        shares_network=True,
+        substrate_owned=True,
+        narrow=frozenset({Capability.EXEC_IN}),
+    )
+    assert Capability.EXEC_IN not in capabilities(narrowed)
+    assert "narrows" in why(narrowed, Capability.EXEC_IN)
+
+
+def test_there_is_no_way_to_widen():
+    """The absence of a `widen` field is the design, so assert it stays absent.
+
+    A site that could claim a capability it lacks would produce the vacuous pass
+    this whole module exists to prevent.
+    """
+    assert not hasattr(Site, "widen")
+    assert "widen" not in {f for f in Site.__dataclass_fields__}
+
+
+def test_narrowing_an_unknown_capability_is_rejected():
+    with pytest.raises(ValueError, match="unknown capabilities"):
+        Site(
+            name="typo",
+            topology=Topology.COMPOSE,
+            ownership=Ownership.IMPOSE,
+            shares_process_tree=False,
+            shares_network=True,
+            substrate_owned=True,
+            narrow=frozenset({"restart_rol"}),  # type: ignore[arg-type]
+        )
+
+
+def test_the_provider_is_physics_not_policy():
+    """A provider that has not implemented a verb cannot perform it, whatever
+    the arrangement permits."""
+    partial = frozenset({Capability.EXEC_IN})
+    assert capabilities(COMPOSE, partial) == partial
+    assert "does not implement" in why(COMPOSE, Capability.RESTART_ROLE, partial)
+
+
+# ------------------------------------------------------------------ validation
+
+
+def test_only_all_in_one_may_claim_a_shared_process_tree():
+    """Believing otherwise makes every signal-based fault test vacuous."""
+    with pytest.raises(ValueError, match="shared process tree"):
+        Site(
+            name="wrong",
+            topology=Topology.KUBERNETES,
+            ownership=Ownership.IMPOSE,
+            shares_process_tree=True,
+            shares_network=False,
+            substrate_owned=True,
+        )
+
+
+def test_a_site_needs_a_name():
+    with pytest.raises(ValueError, match="needs a name"):
+        Site(
+            name="",
+            topology=Topology.COMPOSE,
+            ownership=Ownership.IMPOSE,
+            shares_process_tree=False,
+            shares_network=True,
+            substrate_owned=True,
+        )
+
+
+# --------------------------------------------------------------- resolution
+
+
+def test_the_default_is_todays_behaviour():
+    """Running the suite as it runs now must require no site definition."""
+    assert resolve(None) is LOCAL
+    assert LOCAL.topology is Topology.ALL_IN_ONE
+    assert LOCAL.ownership is Ownership.IMPOSE
+    assert LOCAL.shares_process_tree and LOCAL.shares_network
+
+
+def test_an_unknown_site_names_the_known_ones():
+    with pytest.raises(UnknownSite, match="local"):
+        resolve("nosuch")
+
+
+def test_extra_sites_resolve():
+    assert resolve("compose", {"compose": COMPOSE}) is COMPOSE
+    assert set(BUILTIN_SITES) == {"local"}
+
+
+# ------------------------------------------------------------------- record
+
+
+def test_the_site_serialises_with_its_computed_capabilities():
+    """The run record must carry what the site *could* do, not just what it
+    declared, so a later reader can tell a skip from a gap."""
+    import json
+
+    record = K8S_SHARED.to_record()
+    assert record["topology"] == "kubernetes"
+    assert record["ownership"] == "impose"
+    assert "sink" not in record["capabilities"]
+    assert "scrub" not in record["capabilities"]
+    assert json.loads(json.dumps(record))
+
+
+def test_topology_is_a_label_nothing_branches_on():
+    """Guards the design decision: behaviour keys off the three properties.
+
+    If a capability decision ever keys off the topology *name*, adding a fifth
+    arrangement means auditing every branch. The ceiling table is the one
+    permitted use.
+    """
+    import inspect
+
+    from dynamo_test import site as site_module
+
+    source = inspect.getsource(site_module.capabilities)
+    assert "Topology." not in source, (
+        "capabilities() branches on a topology name; it should read the "
+        "physical properties instead"
+    )

--- a/harness/tests/test_site.py
+++ b/harness/tests/test_site.py
@@ -284,3 +284,92 @@ def test_topology_is_a_label_nothing_branches_on():
         "capabilities() branches on a topology name; it should read the "
         "physical properties instead"
     )
+
+
+# --------------------------------------------- refusal, and why it must raise
+
+
+def test_refusal_is_raised_never_returned():
+    """The single most important line in the ladder.
+
+    A `stop()` that quietly no-ops because the site does not own the deployment
+    turns a fault-tolerance test into a test of nothing: the fault is never
+    injected, the system stays healthy, and the assertion that it recovered
+    passes. A raise is noisy and correct; a no-op is quiet and wrong.
+    """
+    from dynamo_test.site import Refused
+
+    assert issubclass(Refused, Exception)
+    with pytest.raises(Refused) as exc:
+        raise Refused("stop", ATTACHED, why(ATTACHED, Capability.STOP_ROLE))
+    message = str(exc.value)
+    assert "stop()" in message
+    assert ATTACHED.name in message
+    assert "does not own" in message  # the rung, not just "unavailable"
+
+
+def test_a_verify_site_cannot_reach_a_mutating_verb_at_all():
+    """Belt and braces: the capability is absent *and* the refusal explains it."""
+    for cap in (
+        Capability.STOP_ROLE,
+        Capability.RESTART_ROLE,
+        Capability.SCALE_REPLICAS,
+    ):
+        assert cap not in capabilities(ATTACHED)
+        assert why(ATTACHED, cap)
+
+
+def test_divergence_records_unverified_rather_than_guessing():
+    """`declared=KNOWN, observed=UNKNOWN` is neither agreement nor divergence.
+
+    Scoring it either way invents a result. The comparison has to be able to say
+    "I could not check this".
+    """
+    from dynamo_test.facts import Fact
+    from dynamo_test.site import Divergence
+
+    could_not_look = Divergence(
+        role="frontend",
+        field="model",
+        declared=Fact.known("Qwen/Qwen3-0.6B", "stack"),
+        observed=Fact.unknown("/v1/models", "connection refused"),
+    )
+    assert could_not_look.is_unverified
+    assert "could not observe" in could_not_look.describe()
+    assert "connection refused" in could_not_look.describe()
+
+    real = Divergence(
+        role="frontend",
+        field="model",
+        declared=Fact.known("Qwen/Qwen3-0.6B", "stack"),
+        observed=Fact.known("meta-llama/Llama-3.1-8B", "/v1/models"),
+    )
+    assert not real.is_unverified
+    assert "Llama" in real.describe()
+
+
+def test_mismatch_names_every_divergence_and_counts_the_unverified():
+    """Raised at bind time. The alternative is that attaching to a deployment
+    serving a different model first shows up as a 404 at query time, which reads
+    like a routing bug rather than "you are looking at the wrong deployment"."""
+    from dynamo_test.facts import Fact
+    from dynamo_test.site import Divergence, Mismatch
+
+    with pytest.raises(Mismatch) as exc:
+        raise Mismatch(
+            [
+                Divergence(
+                    "frontend", "model", Fact.known("A", "s"), Fact.known("B", "o")
+                ),
+                Divergence(
+                    "worker",
+                    "replicas",
+                    Fact.known(2, "s"),
+                    Fact.unknown("o", "no api"),
+                ),
+            ]
+        )
+    message = str(exc.value)
+    assert "2 divergence(s)" in message
+    assert "1 unverified" in message
+    assert "frontend.model" in message and "worker.replicas" in message

--- a/harness/tests/test_stack.py
+++ b/harness/tests/test_stack.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`dynamo_test.stack`.
+
+The property under test throughout is *provenance*: not just that a value was
+resolved, but that it says which rung produced it. A bare port number gives no
+clue whether a connection failure means fixing the manifest, the flag, or the
+default table.
+"""
+
+import pathlib
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+from dynamo_test.manifest import Plan  # noqa: E402
+from dynamo_test.roles import PortName, Role  # noqa: E402
+from dynamo_test.stack import DYNAMO_DEFAULTS, Defaults, Stack  # noqa: E402
+
+
+def manifest(tmp_path, components, backend_framework=None, name="s"):
+    spec = {"components": components}
+    if backend_framework:
+        spec["backendFramework"] = backend_framework
+    path = tmp_path / f"{name}.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "apiVersion": "nvidia.com/v1beta1",
+                "kind": "DynamoGraphDeployment",
+                "metadata": {"name": name},
+                "spec": spec,
+            }
+        )
+    )
+    return Stack(Plan.from_file(str(path)))
+
+
+def container(**kw):
+    return {"name": "main", "image": "nvcr.io/dynamo:latest", **kw}
+
+
+# ------------------------------------------------- what the operator supplies
+
+
+def test_discovery_env_is_injected_because_no_manifest_declares_it():
+    """Measured: **0 of 427** recipe components declare either variable.
+
+    Not "few" — none. The operator injects both, so every tier without an
+    operator must synthesise them or nothing discovers anything.
+    """
+    env = DYNAMO_DEFAULTS.discovery_env()
+    assert set(env) == {"NATS_SERVER", "ETCD_ENDPOINTS"}
+
+
+def test_a_frontend_with_no_command_gets_the_operators(tmp_path):
+    """27 of 164 recipe frontends declare no command."""
+    stack = manifest(tmp_path, [{"name": "Frontend", "container": container()}])
+    render = stack.render(next(iter(stack.plan)))
+
+    assert render.command.require() == ("python3", "-m", "dynamo.frontend")
+    assert "component_frontend.go" in render.command.detail
+    assert render.is_runnable
+
+
+def test_the_manifest_beats_the_default(tmp_path):
+    stack = manifest(
+        tmp_path,
+        [
+            {
+                "name": "Frontend",
+                "container": container(
+                    command=["/bin/bash", "-lc"],
+                    args=["exec python3 -m dynamo.frontend --http-port 9999"],
+                ),
+            }
+        ],
+    )
+    render = stack.render(next(iter(stack.plan)))
+    assert "declared in the manifest" in render.command.detail
+
+
+def test_a_declared_env_var_beats_the_injected_one(tmp_path):
+    """A manifest naming its own NATS is making a deliberate choice."""
+    stack = manifest(
+        tmp_path,
+        [
+            {
+                "name": "Frontend",
+                "container": container(
+                    env=[{"name": "NATS_SERVER", "value": "nats://mine:4222"}]
+                ),
+            }
+        ],
+    )
+    render = stack.render(next(iter(stack.plan)))
+    assert render.env["NATS_SERVER"].require() == "nats://mine:4222"
+    assert "manifest" in render.env["NATS_SERVER"].detail
+
+
+def test_a_site_override_beats_everything(tmp_path):
+    """A compose site points discovery at service names; that is the whole
+    reason the frontend can leave the all-in-one container."""
+    plan = manifest(tmp_path, [{"name": "Frontend", "container": container()}]).plan
+    stack = Stack(plan, overrides={"NATS_SERVER": "nats://nats-server:4222"})
+    render = stack.render(next(iter(stack.plan)))
+    assert render.env["NATS_SERVER"].require() == "nats://nats-server:4222"
+    # `source` is the address the value came from; `detail` is the explanation.
+    assert render.env["NATS_SERVER"].source == "site override"
+
+
+# ----------------------------------------------------------- the port ladder
+
+
+def test_a_declared_port_wins_and_says_so(tmp_path):
+    stack = manifest(
+        tmp_path,
+        [
+            {
+                "name": "Frontend",
+                "container": container(ports=[{"name": "http", "containerPort": 8080}]),
+            }
+        ],
+    )
+    port = stack.resolve_port(next(iter(stack.plan)), PortName.SERVICE)
+    assert port.require() == 8080
+    assert "manifest" in port.detail
+
+
+def test_a_flag_beats_the_default(tmp_path):
+    stack = manifest(
+        tmp_path,
+        [
+            {
+                "name": "Frontend",
+                "container": container(
+                    command=["python3", "-m", "dynamo.frontend"],
+                    args=["--http-port", "8123"],
+                ),
+            }
+        ],
+    )
+    port = stack.resolve_port(next(iter(stack.plan)), PortName.SERVICE)
+    assert port.require() == 8123
+    assert "command line" in port.detail
+
+
+def test_the_default_is_the_operators_and_cites_it(tmp_path):
+    stack = manifest(tmp_path, [{"name": "Frontend", "container": container()}])
+    service = stack.resolve_port(next(iter(stack.plan)), PortName.SERVICE)
+    system = stack.resolve_port(next(iter(stack.plan)), PortName.SYSTEM)
+
+    assert service.require() == 8000 and "consts.go:13" in service.detail
+    assert system.require() == 9090 and "consts.go:20" in system.detail
+
+
+def test_a_nonsense_port_is_unknown_not_a_crash(tmp_path):
+    stack = manifest(
+        tmp_path,
+        [
+            {
+                "name": "Frontend",
+                "container": container(
+                    command=["python3"], args=["--http-port", "${PORT}"]
+                ),
+            }
+        ],
+    )
+    port = stack.resolve_port(next(iter(stack.plan)), PortName.SERVICE)
+    assert port.is_unknown
+    assert "not a port number" in port.detail
+
+
+# ------------------------------------------------------- engine resolution
+
+
+def test_the_crd_field_resolves_a_worker_with_no_command(tmp_path):
+    """`spec.backendFramework` is the CRD's own field, present in 139 of the
+    178 recipe plans."""
+    stack = manifest(
+        tmp_path,
+        [{"name": "PrefillWorker", "container": container()}],
+        backend_framework="sglang",
+    )
+    render = stack.render(next(iter(stack.plan)))
+    assert render.command.require() == ("python3", "-m", "dynamo.sglang")
+    assert "backendFramework" in render.command.detail
+
+
+def test_the_component_name_is_never_used_to_guess_the_engine(tmp_path):
+    """It would fix two components in the whole corpus, and guess wrong the
+    first time somebody names a worker after a model."""
+    stack = manifest(tmp_path, [{"name": "VllmDecodeWorker", "container": container()}])
+    render = stack.render(next(iter(stack.plan)))
+    assert not render.command.is_known
+    assert "spec.backendFramework" in render.command.detail
+
+
+def test_an_unresolvable_command_explains_what_would_fix_it(tmp_path):
+    stack = manifest(tmp_path, [{"name": "PrefillWorker", "container": container()}])
+    render = stack.render(next(iter(stack.plan)))
+    assert not render.is_runnable
+    why = render.why_not_runnable()
+    assert "backendFramework" in why
+    assert "a site must supply the engine" in why
+
+
+# ------------------------------------------------------------------- corpus
+
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.skipif(
+    not (REPO / "recipes").is_dir(),
+    reason="recipes are not present next to the harness",
+)
+def test_every_recipe_renders_or_says_why():
+    """The gate: render every shipped deployment and account for each component.
+
+    Measured at the time of writing: **398 of 427 resolve a command**. The 29
+    that do not are not a gap in this module — those manifests declare no engine
+    anywhere, on the command line or in `spec.backendFramework`. On Kubernetes
+    the operator resolves it from the image; off Kubernetes a site has to supply
+    it, and saying so is more useful than guessing.
+    """
+    from dynamo_test.manifest import ManifestError, NoGraphDeployment
+
+    resolved = unresolved = 0
+    no_discovery = []
+    for path in sorted((REPO / "recipes").rglob("*.yaml")):
+        try:
+            plans = Plan.all_from_file(path)
+        except (NoGraphDeployment, ManifestError):
+            continue
+        for plan in plans:
+            for render in Stack(plan):
+                if render.command.is_known:
+                    resolved += 1
+                else:
+                    unresolved += 1
+                    # An unresolved command must always explain itself.
+                    assert render.why_not_runnable()
+                # The whole reason this layer exists.
+                if (
+                    "NATS_SERVER" not in render.env
+                    or "ETCD_ENDPOINTS" not in render.env
+                ):
+                    no_discovery.append(f"{plan.source}[{render.name}]")
+
+    assert no_discovery == [], "every component must get discovery env"
+    assert resolved + unresolved > 400
+    assert resolved / (resolved + unresolved) > 0.9, f"{resolved}/{resolved+unresolved}"
+
+
+@pytest.mark.skipif(
+    not (REPO / "recipes").is_dir(),
+    reason="recipes are not present next to the harness",
+)
+def test_every_resolved_port_names_its_rung():
+    """A bare integer tells you nothing about which fix to make."""
+    from dynamo_test.manifest import ManifestError, NoGraphDeployment
+
+    for path in sorted((REPO / "recipes").rglob("*.yaml"))[:40]:
+        try:
+            plans = Plan.all_from_file(path)
+        except (NoGraphDeployment, ManifestError):
+            continue
+        for plan in plans:
+            stack = Stack(plan)
+            for component in plan:
+                port = stack.resolve_port(component, PortName.SERVICE)
+                assert port.source, f"{component.name} port has no source"
+                if port.is_known:
+                    assert port.detail, f"{component.name} port has no provenance"
+
+
+def test_defaults_are_overridable_wholesale(tmp_path):
+    """A site with a different discovery plane replaces the table, not the code."""
+    compose = Defaults(
+        nats_server="nats://nats-server:4222",
+        etcd_endpoints="http://etcd-server:2379",
+    )
+    plan = manifest(tmp_path, [{"name": "Frontend", "container": container()}]).plan
+    render = Stack(plan, defaults=compose).render(next(iter(plan)))
+    assert render.env["NATS_SERVER"].require() == "nats://nats-server:4222"
+    assert render.env["ETCD_ENDPOINTS"].require() == "http://etcd-server:2379"
+
+
+def test_the_stack_serialises_with_provenance(tmp_path):
+    import json
+
+    stack = manifest(tmp_path, [{"name": "Frontend", "container": container()}])
+    record = stack.to_record()
+    frontend = record["components"][0]
+    assert frontend["role"] == str(Role.FRONTEND)
+    assert frontend["ports"]["service"]["port"] == 8000
+    assert (
+        "consts.go" in frontend["ports"]["service"]["from"]
+        or frontend["ports"]["service"]["from"]
+    )
+    assert json.loads(json.dumps(record))


### PR DESCRIPTION
Linear: OPS-8535
Design: [DEP 0017](https://github.com/ai-dynamo/enhancements/pull/100) — **draft until that is reviewed.**

## Summary

The first implementation step for DEP 0017: an installable `dynamo-test-harness` package under
`harness/`, importing as `dynamo_test`, seeded only with values that are already portable.

**Nothing imports it and no existing test file changes.** That is deliberate — step 1 has to be
able to land alone, and the DEP puts the façade at step 5, not step 1. Opened as a draft because
the design it implements is not yet reviewed.

| module | what it is |
|---|---|
| `facts.py` | `Fact[T]` — `KNOWN` / `ABSENT` / `UNKNOWN`, three-valued on purpose |
| `argv.py` | `ArgV` — a worker command line, read and edited by splicing source spans |
| `roles.py` | `RoleTable` — one place where a role becomes a service name |
| `verbs.py` + `catalog.py` | the verb registry and standard verbs, naming law enforced at registration |
| `dialect.py` | one semantic name per setting, across vLLM / SGLang / TensorRT-LLM |
| `manifest.py` | `Plan` — a DGD read into roles, command lines and engines |

## Why each exists

**`Fact`** — two measured false-greens in this repo are the same shape: a scan that could not
read its source reporting `ABSENT`. A tool-call-parser scan said "configures no tool-call parser"
for 34 of 101 recipes it could not read; `k8s_utils` swallowed every exception and returned `{}`,
so a crash-looping pod reported no restarts. `Fact.__bool__` **raises**, so `if not fact:` — the
shape both bugs took — does not compile.

**`ArgV`** — 184 containers in `recipes/` and `examples/` are shell-invoked; 100 use `-lc`. Writes
splice into the original string instead of rebuilding it, because `shlex.split` → mutate →
`" ".join(quote(t))` is lossy three independent ways here: 47 commands contain a control operator
that re-quoting turns into a literal argument (`ulimit -l unlimited '&&' exec python3 …`, which
never starts the worker); 17 contain `#` comment lines where an apostrophe breaks tokenising
outright; most are `\`-continued scripts a re-join flattens, deleting the comments explaining each
flag.

**`roles.py`** — resolution happens once. `require()` raises naming the roles that exist rather
than returning a default, `log_key` is one string serving both the bundle directory and the scrape
key, and the table serialises into the run record so resolution is provable. An empty log stream
from a wrong-but-valid key is *present-and-empty*, not absent, so no downstream absence check
recovers it.

**`verbs.py`** — the role is an argument, not an attribute, so a scenario document becomes a call
by lookup rather than through a dispatch table that drifts from the verb surface. The component
spelling is *generated* from the same registry, so `sut.frontend.restart()` and
`sut.restart(at("frontend"))` are one definition and two spellings.

**`dialect.py`** — across 312 engine workers, three settings have more than one live spelling.
SGLang uses `--tp` ×30, `--tensor-parallel-size` ×7 and `--tp-size` ×2, so a reader knowing only
the canonical name finds it in 7 of 39. All 56 TensorRT-LLM workers pass `--extra-engine-args`, so
a setting missing from argv is `UNKNOWN` naming the file, never `ABSENT`.

**`manifest.py`** — 177 documents use v1beta1 `spec.components` and 75 use v1alpha1
`spec.services`; neither is legacy. 32 distinct component names for nine roles, including
`TrtllmWorker` and `TRTLLMWorker` in the same corpus.

## Validation

**229 tests.** Corpus coverage runs over every deployment in `recipes/` and `examples/`:

- all 184 shell commands tokenise (`shlex` fails on 4); after two edits each, every line not
  carrying a changed flag is **byte-identical**, comments survive, shell args stay a single
  element, and the result **parses under `bash -n`**
- both schemas parse; all 32 component names resolve to a role; no deployment has two components
  claiming one role
- every engine worker is identified, and its model is readable or explicitly deferred to a config
  file
- **a worked port**: the ~45-line tool-call-parser scanner from
  `tests/deploy/test_recipe_tool_execution.py` becomes ~14 lines, and both find a parser in the
  same **127** deployments with **no disagreement on the value**

Import discipline is enforced by walking the AST of every module: nothing imports `dynamo.*`, only
the pytest plugin may import `pytest`, Tier 0 is stdlib only. Verified out of tree by importing the
package with neither the runtime nor pytest on the path.

`harness/` is a new top-level directory, so `areas.yaml` gains an entry routing it to `ops` — the
area that already owns `tests/deploy/`. Regenerated, not hand-edited; `--strict` passes.

## Found while building this

Two bugs in my own code, both caught by the corpus tests rather than by review, which is the
argument for having them:

1. `detect()` read only `args`. v1alpha1 puts the program in `command`
   (`[python3, -m, dynamo.sglang]`), so every such worker identified no engine. Reading the whole
   invocation took detection from **180 workers to 312** — and I had to re-measure and correct the
   dialect tables' cited numbers afterwards.
2. Reporting a setting `ABSENT` when the command defers to a config file, which was a false
   statement for all 56 TensorRT-LLM workers.

And one real defect in the repo — three `qwen3-vl-32b-fp8` workers that never start — filed
separately as PR #14321.

## Not in this PR

Tier 1 (the capability protocols and providers), the `Sut` façade, and the evidence bundle. Those
are DEP phases 2–5. This PR is phase 1: the package, seeded only with code that is already
portable.