### PR TITLE
feat(request-trace): match header capture entries by prefix and add a denylist

### DIFF
--- a/docs/fern/pages/cli/operations/observability.mdx
+++ b/docs/fern/pages/cli/operations/observability.mdx
@@ -228,6 +228,17 @@ To capture selected request headers, provide a comma- or whitespace-separated al
 export DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST='x-request-id,x-tenant-id'
 ```
 
+An entry ending in `*` captures a whole header family, which is useful behind a gateway that
+injects a set of headers whose exact names vary by version:
+
+```bash
+export DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST='x-someplatform-*,x-request-id'
+export DYN_REQUEST_TRACE_HTTP_HEADER_DENY_LIST='x-someplatform-internal-token'
+```
+
+The denylist takes the same syntax and is applied after the capture list matches, so it can
+subtract one header from a family without giving up the prefix entry. It only ever subtracts.
+
 Header matching is case-insensitive. Dynamo does not redact captured values.
 
 ### Export Payloads over OTLP

--- a/docs/fern/pages/reference/observability/environment-variables.mdx
+++ b/docs/fern/pages/reference/observability/environment-variables.mdx
@@ -349,7 +349,11 @@ See [Forward Pass Metrics Trace Reference](forward-pass-metrics-traces.mdx) for 
 </ParamField>
 
 <ParamField path="DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST" type="string">
-  Comma- or whitespace-separated allowlist of HTTP header names captured on `request_payload` rows. Values are not redacted.
+  Comma- or whitespace-separated allowlist of HTTP header names captured on `request_payload` rows. An entry ending in `*` matches every header name with that prefix. Values are not redacted.
+</ParamField>
+
+<ParamField path="DYN_REQUEST_TRACE_HTTP_HEADER_DENY_LIST" type="string">
+  Comma- or whitespace-separated denylist applied after the capture list matches, using the same trailing-`*` syntax. It only subtracts; naming a header here never captures it.
 </ParamField>
 
 See [Request Trace Reference](request-traces.mdx) for compatibility aliases, sink behavior, and record semantics.

--- a/docs/fern/pages/reference/observability/request-traces.mdx
+++ b/docs/fern/pages/reference/observability/request-traces.mdx
@@ -27,7 +27,8 @@ one or more sinks. For the capture and replay workflow, see
 | `DYN_REQUEST_TRACE_FILE_ROLL_LINES` | unset | Positive integer records | Optional gzip roll threshold in records. |
 | `DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT` | unset | ZMQ bind address | Optional PULL endpoint for harness tool events. Configure it on only one process. |
 | `DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_TOPIC` | `agent-tool-events` | ZMQ topic | First-frame topic filter. |
-| `DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST` | unset | Header names | Comma- or whitespace-separated allowlist captured only on `request_payload` rows. Values are unredacted. |
+| `DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST` | unset | Header names or `prefix-*` | Comma- or whitespace-separated allowlist captured only on `request_payload` rows. Values are unredacted. |
+| `DYN_REQUEST_TRACE_HTTP_HEADER_DENY_LIST` | unset | Header names or `prefix-*` | Subtracted after the capture list matches. Never captures on its own. |
 
 Legacy `jsonl` and `jsonl_gz` sink values, `DYN_REQUEST_TRACE_OUTPUT_PATH`, and
 `DYN_REQUEST_TRACE_JSONL_*` remain migration aliases. `DYN_AUDIT_*` variables are migration shims,

--- a/lib/llm/src/request_trace/config.rs
+++ b/lib/llm/src/request_trace/config.rs
@@ -497,6 +497,7 @@ mod tests {
         env_request_trace::DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT,
         env_request_trace::DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_TOPIC,
         env_request_trace::DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST,
+        env_request_trace::DYN_REQUEST_TRACE_HTTP_HEADER_DENY_LIST,
         env_audit::DYN_AUDIT_SINKS,
         env_audit::DYN_AUDIT_FORCE_LOGGING,
         env_audit::DYN_AUDIT_CAPACITY,

--- a/lib/llm/src/request_trace/config.rs
+++ b/lib/llm/src/request_trace/config.rs
@@ -96,6 +96,7 @@ pub struct RequestTracePolicy {
     pub nats_subject: String,
     pub otel_max_payload_bytes: usize,
     pub http_header_capture_list: Vec<String>,
+    pub http_header_deny_list: Vec<String>,
     pub tool_events_zmq_endpoint: Option<String>,
     pub tool_events_zmq_topic: Option<String>,
     pub s3_bucket: Option<String>,
@@ -194,23 +195,14 @@ fn load_from_env() -> RequestTracePolicy {
     ])
     .filter(|value| *value > 0)
     .unwrap_or(DEFAULT_OTEL_MAX_PAYLOAD_BYTES);
-    let http_header_capture_list =
-        std::env::var(env_request_trace::DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST)
-            .ok()
-            .map(|raw| {
-                let mut names = Vec::new();
-                for name in raw
-                    .split(|c: char| c == ',' || c.is_whitespace())
-                    .map(str::to_ascii_lowercase)
-                    .filter(|name| !name.is_empty())
-                {
-                    if !names.contains(&name) {
-                        names.push(name);
-                    }
-                }
-                names
-            })
-            .unwrap_or_default();
+    let http_header_capture_list = parse_header_name_list(
+        env_request_trace::DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST,
+        StarSentinel::Deferred,
+    );
+    let http_header_deny_list = parse_header_name_list(
+        env_request_trace::DYN_REQUEST_TRACE_HTTP_HEADER_DENY_LIST,
+        StarSentinel::Allowed,
+    );
     let tool_events_zmq_endpoint =
         std::env::var(env_request_trace::DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT)
             .ok()
@@ -249,6 +241,7 @@ fn load_from_env() -> RequestTracePolicy {
         nats_subject,
         otel_max_payload_bytes,
         http_header_capture_list,
+        http_header_deny_list,
         tool_events_zmq_endpoint,
         tool_events_zmq_topic,
         s3_bucket,
@@ -257,6 +250,55 @@ fn load_from_env() -> RequestTracePolicy {
         s3_roll_uncompressed_bytes,
         s3_flush_interval_ms,
     }
+}
+
+/// Whether an all-`*` entry means anything for a given list.
+#[derive(Clone, Copy)]
+enum StarSentinel {
+    /// Capture list: "capture everything" is deferred until captured values are
+    /// redacted, so the entry is dropped.
+    Deferred,
+    /// Deny list: "deny everything" only ever subtracts, so it is safe to honour.
+    /// Dropping it would fail open on an explicit denial.
+    Allowed,
+}
+
+/// Parse a comma/whitespace-separated header-name list into lowercased, de-duplicated
+/// entries, preserving the order they were configured in. An entry ending in `*` is a
+/// prefix pattern; matching lives in `payload::capture_http_headers`.
+///
+/// A `*` anywhere other than the end is not pattern syntax, so it is reported instead of
+/// being left to match nothing silently.
+fn parse_header_name_list(env_name: &str, star_sentinel: StarSentinel) -> Vec<String> {
+    let Ok(raw) = std::env::var(env_name) else {
+        return Vec::new();
+    };
+    let mut names = Vec::new();
+    for name in raw
+        .split(|c: char| c == ',' || c.is_whitespace())
+        .map(str::to_ascii_lowercase)
+        .filter(|name| !name.is_empty())
+    {
+        let all_star = name.chars().all(|c| c == '*');
+        if all_star && matches!(star_sentinel, StarSentinel::Deferred) {
+            tracing::warn!(
+                %env_name,
+                "request trace: capture-all `*` is not supported yet; entry ignored"
+            );
+            continue;
+        }
+        if !all_star && name.trim_end_matches('*').contains('*') {
+            tracing::warn!(
+                %env_name,
+                %name,
+                "request trace: `*` is only a trailing prefix marker; entry matched literally"
+            );
+        }
+        if !names.contains(&name) {
+            names.push(name);
+        }
+    }
+    names
 }
 
 fn load_records(
@@ -564,6 +606,55 @@ mod tests {
             let policy = load_from_env();
             assert!(policy.http_header_capture_list.is_empty());
         });
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn http_header_deny_list_parses_like_the_capture_list_and_defaults_empty() {
+        with_request_trace_env(
+            &[
+                (env_request_trace::DYN_REQUEST_TRACE, "1"),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_HTTP_HEADER_DENY_LIST,
+                    " X-Someplatform-Internal-Token,, x-internal-*, * ",
+                ),
+            ],
+            || {
+                let policy = load_from_env();
+                assert_eq!(
+                    policy.http_header_deny_list,
+                    vec!["x-someplatform-internal-token", "x-internal-*", "*"],
+                    "the deny list keeps an all-`*` entry, which subtracts everything"
+                );
+            },
+        );
+
+        with_request_trace_env(&[(env_request_trace::DYN_REQUEST_TRACE, "1")], || {
+            let policy = load_from_env();
+            assert!(policy.http_header_deny_list.is_empty());
+        });
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn http_header_capture_list_keeps_prefix_entries_and_drops_a_bare_star() {
+        with_request_trace_env(
+            &[
+                (env_request_trace::DYN_REQUEST_TRACE, "1"),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST,
+                    "X-Someplatform-*, *, x-request-id",
+                ),
+            ],
+            || {
+                let policy = load_from_env();
+                assert_eq!(
+                    policy.http_header_capture_list,
+                    vec!["x-someplatform-*", "x-request-id"],
+                    "a trailing-`*` entry is kept as configured and a bare `*` is dropped"
+                );
+            },
+        );
     }
 
     #[test]

--- a/lib/llm/src/request_trace/payload.rs
+++ b/lib/llm/src/request_trace/payload.rs
@@ -25,31 +25,98 @@ pub(crate) fn http_header_capture_active() -> bool {
 
 /// Collect the allowlisted request headers (case-insensitive, comma-joined on
 /// repeats). `None` unless payload capture is active and the allowlist is non-empty.
+///
+/// A capture entry ending in `*` matches every header name carrying that prefix, so a
+/// gateway-injected family can be captured without enumerating it. Denylist entries take
+/// the same syntax and subtract from whatever the capture list matched.
 pub fn capture_http_headers(headers: &HeaderMap) -> Option<BTreeMap<String, String>> {
     if !http_header_capture_active() {
         return None;
     }
-    capture_http_headers_with_list(headers, &super::policy().http_header_capture_list)
+    let policy = super::policy();
+    capture_http_headers_with_lists(
+        headers,
+        &policy.http_header_capture_list,
+        &policy.http_header_deny_list,
+    )
 }
 
-fn capture_http_headers_with_list(
+/// True when `entry` ends in `*`, which is the one form that cannot be resolved by a
+/// direct name lookup.
+fn is_prefix_pattern(entry: &str) -> bool {
+    entry.len() > 1 && entry.ends_with('*')
+}
+
+/// Match one configured entry against a header name. Both sides are already lowercased.
+fn entry_matches(entry: &str, name: &str) -> bool {
+    match entry.strip_suffix('*') {
+        // A zero-length prefix never matches, so an all-`*` entry cannot turn into
+        // capture-all here. The deny list keeps such an entry and handles it in
+        // `denied`; the capture list drops it when the list is parsed.
+        Some(prefix) => !prefix.is_empty() && name.starts_with(prefix),
+        None => entry == name,
+    }
+}
+
+fn any_entry_matches(entries: &[String], name: &str) -> bool {
+    entries.iter().any(|entry| entry_matches(entry, name))
+}
+
+/// True when every character is `*`. Only the deny list keeps such an entry, where it
+/// means "deny everything"; the capture list drops it at config load.
+fn is_star_sentinel(entry: &str) -> bool {
+    !entry.is_empty() && entry.chars().all(|c| c == '*')
+}
+
+/// Deny entries match like capture entries, plus the all-`*` "deny everything" sentinel.
+fn denied(deny_list: &[String], name: &str) -> bool {
+    deny_list
+        .iter()
+        .any(|entry| is_star_sentinel(entry) || entry_matches(entry, name))
+}
+
+/// Comma-join the non-empty values recorded under `name`.
+fn joined_values(headers: &HeaderMap, name: &str) -> Option<String> {
+    let joined = headers
+        .get_all(name)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>()
+        .join(", ");
+    (!joined.is_empty()).then_some(joined)
+}
+
+fn capture_http_headers_with_lists(
     headers: &HeaderMap,
     capture_list: &[String],
+    deny_list: &[String],
 ) -> Option<BTreeMap<String, String>> {
     if capture_list.is_empty() {
         return None;
     }
     let mut out = BTreeMap::new();
-    for name in capture_list {
-        let joined = headers
-            .get_all(name.as_str())
-            .iter()
-            .filter_map(|value| value.to_str().ok())
-            .filter(|value| !value.is_empty())
-            .collect::<Vec<_>>()
-            .join(", ");
-        if !joined.is_empty() {
-            out.insert(name.clone(), joined);
+    if capture_list.iter().any(|entry| is_prefix_pattern(entry)) {
+        // A prefix entry has no single name to look up, so walk the request's headers
+        // once. Keys come off the request, because that is where the matched name lives.
+        for name in headers.keys() {
+            let name = name.as_str();
+            if !any_entry_matches(capture_list, name) || denied(deny_list, name) {
+                continue;
+            }
+            if let Some(joined) = joined_values(headers, name) {
+                out.insert(name.to_string(), joined);
+            }
+        }
+    } else {
+        // Every entry is a literal name, so keep the direct per-entry lookup.
+        for name in capture_list {
+            if denied(deny_list, name) {
+                continue;
+            }
+            if let Some(joined) = joined_values(headers, name.as_str()) {
+                out.insert(name.clone(), joined);
+            }
         }
     }
     (!out.is_empty()).then_some(out)
@@ -208,7 +275,7 @@ mod tests {
         headers.insert("NVCF-Function-Id", "fn-9".parse().unwrap());
         headers.insert("authorization", "Bearer secret".parse().unwrap());
 
-        let captured = capture_http_headers_with_list(&headers, &capture_list)
+        let captured = capture_http_headers_with_lists(&headers, &capture_list, &[])
             .expect("allowlisted headers are captured");
         assert_eq!(
             captured.get("x-request-id").map(String::as_str),
@@ -230,7 +297,7 @@ mod tests {
         headers.insert("x-request-id", "abc-123".parse().unwrap());
 
         assert!(
-            capture_http_headers_with_list(&headers, &[]).is_none(),
+            capture_http_headers_with_lists(&headers, &[], &[]).is_none(),
             "empty allowlist must capture nothing"
         );
     }
@@ -243,7 +310,7 @@ mod tests {
         headers.append("x-tag", "a".parse().unwrap());
         headers.append("x-tag", "b".parse().unwrap());
 
-        let captured = capture_http_headers_with_list(&headers, &capture_list)
+        let captured = capture_http_headers_with_lists(&headers, &capture_list, &[])
             .expect("repeated header is captured");
         assert_eq!(captured.get("x-tag").map(String::as_str), Some("a, b"));
     }
@@ -257,7 +324,7 @@ mod tests {
         headers.append("x-tag", "".parse().unwrap());
 
         assert!(
-            capture_http_headers_with_list(&headers, &capture_list).is_none(),
+            capture_http_headers_with_lists(&headers, &capture_list, &[]).is_none(),
             "repeated empty values must be omitted, not joined into \", \""
         );
     }
@@ -270,9 +337,177 @@ mod tests {
         headers.append("x-tag", "".parse().unwrap());
         headers.append("x-tag", "tenant-a".parse().unwrap());
 
-        let captured = capture_http_headers_with_list(&headers, &capture_list)
+        let captured = capture_http_headers_with_lists(&headers, &capture_list, &[])
             .expect("non-empty value is captured");
         assert_eq!(captured.get("x-tag").map(String::as_str), Some("tenant-a"));
+    }
+
+    #[test]
+    fn capture_http_headers_matches_a_prefix_family() {
+        let capture_list = vec!["x-someplatform-*".to_string(), "x-request-id".to_string()];
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-someplatform-tenant", "acme".parse().unwrap());
+        headers.insert("x-someplatform-region", "us-east".parse().unwrap());
+        headers.insert("x-request-id", "abc-123".parse().unwrap());
+        headers.insert("x-unrelated", "nope".parse().unwrap());
+
+        let captured = capture_http_headers_with_lists(&headers, &capture_list, &[])
+            .expect("prefix entry captures the family");
+        assert_eq!(
+            captured.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec![
+                "x-request-id",
+                "x-someplatform-region",
+                "x-someplatform-tenant"
+            ],
+            "a prefix entry captures every matching name and nothing else"
+        );
+        assert_eq!(
+            captured.get("x-someplatform-tenant").map(String::as_str),
+            Some("acme"),
+            "keys are the header names off the request, not the configured entry"
+        );
+    }
+
+    #[test]
+    fn capture_http_headers_denylist_subtracts_from_a_prefix_match() {
+        let capture_list = vec!["x-someplatform-*".to_string()];
+        let deny_list = vec!["x-someplatform-internal-token".to_string()];
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-someplatform-tenant", "acme".parse().unwrap());
+        headers.insert("x-someplatform-internal-token", "secret".parse().unwrap());
+
+        let captured = capture_http_headers_with_lists(&headers, &capture_list, &deny_list)
+            .expect("the rest of the family is still captured");
+        assert_eq!(
+            captured.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec!["x-someplatform-tenant"]
+        );
+        assert!(
+            !captured.contains_key("x-someplatform-internal-token"),
+            "a denied name must not reach the record"
+        );
+    }
+
+    #[test]
+    fn capture_http_headers_denylist_accepts_prefix_entries() {
+        let capture_list = vec!["x-someplatform-*".to_string()];
+        let deny_list = vec!["x-someplatform-internal-*".to_string()];
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-someplatform-tenant", "acme".parse().unwrap());
+        headers.insert("x-someplatform-internal-token", "secret".parse().unwrap());
+        headers.insert("x-someplatform-internal-trace", "secret".parse().unwrap());
+
+        let captured = capture_http_headers_with_lists(&headers, &capture_list, &deny_list)
+            .expect("the non-denied name is still captured");
+        assert_eq!(
+            captured.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec!["x-someplatform-tenant"]
+        );
+    }
+
+    #[test]
+    fn capture_http_headers_denylist_applies_to_literal_entries() {
+        let capture_list = vec!["x-request-id".to_string(), "x-tenant".to_string()];
+        let deny_list = vec!["x-tenant".to_string()];
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", "abc-123".parse().unwrap());
+        headers.insert("x-tenant", "acme".parse().unwrap());
+
+        let captured = capture_http_headers_with_lists(&headers, &capture_list, &deny_list)
+            .expect("the allowed literal is still captured");
+        assert_eq!(
+            captured.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec!["x-request-id"],
+            "the denylist subtracts on the literal path too, not just under a prefix"
+        );
+    }
+
+    #[test]
+    fn capture_http_headers_denylist_only_subtracts() {
+        let capture_list = vec!["x-request-id".to_string()];
+        let deny_list = vec!["x-tenant".to_string()];
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", "abc-123".parse().unwrap());
+        headers.insert("x-tenant", "acme".parse().unwrap());
+
+        let captured = capture_http_headers_with_lists(&headers, &capture_list, &deny_list)
+            .expect("capture list still applies");
+        assert_eq!(
+            captured.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec!["x-request-id"],
+            "naming an uncaptured header in the denylist changes nothing"
+        );
+    }
+
+    #[test]
+    fn capture_http_headers_bare_star_entry_captures_nothing() {
+        // The capture-all sentinel is deferred until captured values are redacted. If a
+        // bare `*` survives config parsing it must not silently become capture-all.
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer secret".parse().unwrap());
+        headers.insert("x-request-id", "abc-123".parse().unwrap());
+
+        for capture_list in [vec!["*".to_string()], vec!["**".to_string()]] {
+            assert!(
+                capture_http_headers_with_lists(&headers, &capture_list, &[]).is_none(),
+                "an all-`*` capture entry must not capture every header"
+            );
+        }
+    }
+
+    #[test]
+    fn capture_http_headers_deny_all_sentinel_subtracts_everything() {
+        // Deny-all only ever subtracts, so it is honoured rather than dropped. Failing
+        // open on an explicit denial would be the dangerous direction here.
+        let capture_list = vec!["x-someplatform-*".to_string(), "x-request-id".to_string()];
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-someplatform-tenant", "acme".parse().unwrap());
+        headers.insert("x-request-id", "abc-123".parse().unwrap());
+
+        for deny in [vec!["*".to_string()], vec!["**".to_string()]] {
+            assert!(
+                capture_http_headers_with_lists(&headers, &capture_list, &deny).is_none(),
+                "an all-`*` deny entry must subtract every captured header"
+            );
+        }
+    }
+
+    #[test]
+    fn capture_http_headers_interior_star_is_matched_literally() {
+        let capture_list = vec!["x-*-id".to_string()];
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", "abc-123".parse().unwrap());
+
+        assert!(
+            capture_http_headers_with_lists(&headers, &capture_list, &[]).is_none(),
+            "`*` is only a trailing prefix marker, so an interior one matches no real name"
+        );
+    }
+
+    #[test]
+    fn capture_http_headers_joins_repeats_matched_by_a_prefix() {
+        let capture_list = vec!["x-someplatform-*".to_string()];
+
+        let mut headers = HeaderMap::new();
+        headers.append("x-someplatform-tag", "tenant-a".parse().unwrap());
+        headers.append("x-someplatform-tag", "".parse().unwrap());
+        headers.append("x-someplatform-tag", "tenant-b".parse().unwrap());
+
+        let captured = capture_http_headers_with_lists(&headers, &capture_list, &[])
+            .expect("prefix match captures repeats");
+        assert_eq!(
+            captured.get("x-someplatform-tag").map(String::as_str),
+            Some("tenant-a, tenant-b"),
+            "repeats join and empty values drop, same as the literal path"
+        );
     }
 
     /// Test-only constructor. `create_handle` gates on env vars + a cached

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -629,10 +629,17 @@ pub mod llm {
             "DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_TOPIC";
 
         /// Comma/whitespace-separated allowlist of HTTP request header names to
-        /// record in request payload records. Unset/empty captures none. Values
+        /// record in request payload records. Unset/empty captures none. An entry
+        /// ending in `*` matches every header name with that prefix. Values
         /// are recorded unredacted; avoid credential-bearing headers.
         pub const DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST: &str =
             "DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST";
+
+        /// Comma/whitespace-separated denylist of HTTP request header names that
+        /// are never recorded, applied after the capture list matches. Accepts the
+        /// same trailing-`*` prefix entries. Unset/empty subtracts nothing.
+        pub const DYN_REQUEST_TRACE_HTTP_HEADER_DENY_LIST: &str =
+            "DYN_REQUEST_TRACE_HTTP_HEADER_DENY_LIST";
 
         /// S3 bucket for the S3 request-trace sink. Required when
         /// `DYN_REQUEST_TRACE_SINKS` includes `s3`.
@@ -1029,6 +1036,7 @@ mod tests {
             llm::request_trace::DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT,
             llm::request_trace::DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_TOPIC,
             llm::request_trace::DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST,
+            llm::request_trace::DYN_REQUEST_TRACE_HTTP_HEADER_DENY_LIST,
             llm::audit::DYN_AUDIT_OTEL_MAX_PAYLOAD_BYTES,
             // Model
             model::model_express::MODEL_EXPRESS_URL,


### PR DESCRIPTION
## Overview:

DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST only matches header names literally, so behind a
gateway you have to list every injected header by hand, and the list rots as soon as the
gateway renames anything. Nothing tells you either, the header just stops showing up.

Items 1 and 2 of #14220. Not item 3, the capture-all sentinel, that should wait for redaction
like the issue says.

## Details:

Capture entries can end in a star now to match a prefix, and there's a new
DYN_REQUEST_TRACE_HTTP_HEADER_DENY_LIST that subtracts after the capture list matches:

```
DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST=x-someplatform-*,x-request-id
DYN_REQUEST_TRACE_HTTP_HEADER_DENY_LIST=x-someplatform-internal-token
```

A lone star in the capture list is dropped at load with a warning, since capture-all should
wait for redaction. The deny list keeps it, because deny-all only subtracts.

Capture lists with no prefix entry keep the old per-entry get_all, so existing configs don't
change. Docs updated too.

Heads up that #14265 is changing the value side of the same function. This only touches name
matching, happy to rebase whichever lands first.

## Where should the reviewer start?

capture_http_headers_with_lists in lib/llm/src/request_trace/payload.rs, then
parse_header_name_list in config.rs for the star handling. Tests are at the bottom of
payload.rs.

## Related Issues

- Relates to #14220

## Validation

aarch64 Linux, pinned 1.96.1:

    cargo fmt --check                                                      clean
    cargo check -p dynamo-llm --lib --no-default-features                  clean
    cargo test -p dynamo-llm --lib request_trace --no-default-features     73 passed
    cargo clippy -p dynamo-llm --lib --no-default-features -- -D warnings  clean

11 new tests: the prefix match and its keys, the deny list on both the prefix and literal
paths, the star handling either way, repeats joining. Haven't run it against a real gateway.
