### PR TITLE
feat(frontend): consume Moonshot Kimi protocol fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,9 +2890,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2723c9ec1c3106cd044ca7f3ff7db71e0e347d1190aa2694a7cc7121376a2a"
+version = "5.4.1"
+source = "git+https://github.com/ai-dynamo/frontend-crates.git?branch=kimi-code-compat#4ac3253a2aa546bd86ca0ecf4b7cda30be58df7a"
 dependencies = [
  "async-openai",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ dynamo-kv-hashing = { path = "lib/kv-hashing", version = "1.5.0" }
 dynamo-memory = { path = "lib/memory", version = "1.5.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.5.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.5.0" }
-dynamo-protocols = { version = "=5.4.0" }
+dynamo-protocols = { version = "=5.4.1" }
 dynamo-parsers = { version = "8.1.0" }
 
 # Published on crates.io. To see all available versions:
@@ -214,3 +214,8 @@ lto = "thin"
 inherits = "release"
 debug = true
 strip = false
+
+# Temporary until dynamo-protocols with Moonshot Kimi fields is released
+# (ai-dynamo/frontend-crates#211). Remove and bump the pin instead.
+[patch.crates-io]
+dynamo-protocols = { git = "https://github.com/ai-dynamo/frontend-crates.git", branch = "kimi-code-compat" }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2824,6 +2824,7 @@ async fn chat_completions(
         inflight_guard.mark_error(extract_error_type_from_response(&err_response));
         return Err(err_response);
     }
+    request.normalize_partial_final_message();
 
     // Handle unsupported fields - if Some(resp) is returned by
     // validate_chat_completion_unsupported_fields,

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -38,6 +38,7 @@ fn push_system_message(content: String, messages: &mut Vec<ChatCompletionRequest
         ChatCompletionRequestSystemMessage {
             content: ChatCompletionRequestSystemMessageContent::Text(content),
             name: None,
+            tools: None,
         },
     ));
 }
@@ -100,6 +101,7 @@ impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
                             audio: None,
                             tool_calls: None,
                             function_call: None,
+                            partial: None,
                         },
                     ));
                 }
@@ -465,6 +467,7 @@ fn convert_assistant_blocks(
             tool_calls: tc,
             #[allow(deprecated)]
             function_call: None,
+            partial: None,
         },
     ));
 }

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -30,8 +30,9 @@ pub use delta::DeltaGenerator;
 use dynamo_parsers::tool_calling::{ToolCallResponse, ToolCallResponseChunk};
 use dynamo_protocols::types::{
     ChatChoiceStream, ChatCompletionMessageContent, ChatCompletionMessageToolCall,
-    ChatCompletionMessageToolCallChunk, ChatCompletionStreamResponseDelta, FinishReason,
-    FunctionCall, FunctionCallStream, FunctionType,
+    ChatCompletionMessageToolCallChunk, ChatCompletionRequestMessage,
+    ChatCompletionStreamResponseDelta, FinishReason, FunctionCall, FunctionCallStream,
+    FunctionType,
 };
 
 /// Map a parser-native [`ToolCallResponse`] onto the protocol/wire
@@ -237,6 +238,21 @@ impl NvCreateChatCompletionRequest {
         // re-interpreted with different precedence by the worker preprocessor).
         self.thinking = None;
         Ok(())
+    }
+
+    /// Moonshot partial mode: `partial: true` on a final assistant message asks
+    /// the model to continue that content. Express it as vLLM's
+    /// `continue_final_message` so one render path serves both dialects.
+    /// An explicit `add_generation_prompt: true` is left for validation to reject.
+    pub fn normalize_partial_final_message(&mut self) {
+        let Some(ChatCompletionRequestMessage::Assistant(last)) = self.inner.messages.last() else {
+            return;
+        };
+        if last.partial != Some(true) {
+            return;
+        }
+        self.common.continue_final_message = Some(true);
+        self.common.add_generation_prompt.get_or_insert(false);
     }
 }
 
@@ -1481,6 +1497,81 @@ mod tests {
 
         let args = request.chat_template_args.as_ref().unwrap();
         assert_eq!(args.get("preserve_thinking"), None);
+    }
+
+    #[test]
+    fn test_partial_final_assistant_message_becomes_continue_final_message() {
+        let mut request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "messages": [
+                {"role": "user", "content": "Return JSON"},
+                {"role": "assistant", "content": "{\"answer\":", "partial": true}
+            ]
+        }))
+        .unwrap();
+        request.normalize_partial_final_message();
+        assert_eq!(request.common.continue_final_message, Some(true));
+        assert_eq!(request.common.add_generation_prompt, Some(false));
+        ValidateRequest::validate(&request).unwrap();
+    }
+
+    #[test]
+    fn test_partial_only_applies_to_final_assistant_message() {
+        let mut request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "messages": [
+                {"role": "assistant", "content": "draft", "partial": true},
+                {"role": "user", "content": "Continue"}
+            ]
+        }))
+        .unwrap();
+        request.normalize_partial_final_message();
+        assert_eq!(request.common.continue_final_message, None);
+        assert_eq!(request.common.add_generation_prompt, None);
+    }
+
+    #[test]
+    fn test_partial_keeps_explicit_add_generation_prompt_for_validation() {
+        let mut request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "add_generation_prompt": true,
+            "messages": [{"role": "assistant", "content": "x", "partial": true}]
+        }))
+        .unwrap();
+        request.normalize_partial_final_message();
+        assert_eq!(request.common.add_generation_prompt, Some(true));
+        assert!(ValidateRequest::validate(&request).is_err());
+    }
+
+    #[test]
+    fn test_kimi_typed_fields_deserialize_without_unsupported_fields() {
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "prompt_cache_key": "sess_1",
+            "safety_identifier": "user_1",
+            "messages": [
+                {"role": "system", "tools": [{
+                    "type": "function",
+                    "function": {"name": "read_file", "parameters": {"type": "object"}}
+                }]},
+                {"role": "user", "content": "hi"}
+            ],
+            "tools": [{"type": "builtin_function", "function": {"name": "$web_search"}}]
+        }))
+        .unwrap();
+        assert_eq!(request.inner.prompt_cache_key.as_deref(), Some("sess_1"));
+        assert_eq!(request.inner.safety_identifier.as_deref(), Some("user_1"));
+        assert!(request.unsupported_fields.is_empty());
+        ValidateRequest::validate(&request).unwrap();
+
+        // The `$` prefix is only tolerated on builtin tools.
+        let plain: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "function", "function": {"name": "$web_search"}}]
+        }))
+        .unwrap();
+        assert!(ValidateRequest::validate(&plain).is_err());
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -483,6 +483,7 @@ impl PendingAssistant {
                 },
                 #[allow(deprecated)]
                 function_call: None,
+                partial: None,
             },
         ));
     }
@@ -510,6 +511,7 @@ fn convert_input_items_to_messages(
                                             text,
                                         ),
                                         name: None,
+                                        tools: None,
                                     },
                                 )
                             }
@@ -623,6 +625,7 @@ fn convert_input_items_to_messages(
                             ChatCompletionRequestSystemMessage {
                                 content: ChatCompletionRequestSystemMessageContent::Text(text),
                                 name: None,
+                                tools: None,
                             },
                         ));
                     }
@@ -799,6 +802,7 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
                 ChatCompletionRequestSystemMessage {
                     content: ChatCompletionRequestSystemMessageContent::Text(instructions.clone()),
                     name: None,
+                    tools: None,
                 },
             ));
         }
@@ -859,6 +863,7 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
                     ChatCompletionRequestMessage::System(ChatCompletionRequestSystemMessage {
                         content: ChatCompletionRequestSystemMessageContent::Text(combined),
                         name: None,
+                        tools: None,
                     }),
                 );
             }

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -109,10 +109,6 @@ pub const PASSTHROUGH_EXTRA_FIELDS: &[&str] = &[
     "allowed_token_ids",
     "bad_words_token_ids",
     "logprob_token_ids",
-    // OpenAI cache-affinity / abuse-tracking hints. Routing already keys on
-    // prompt prefix, so these are accepted and forwarded, not acted on.
-    "prompt_cache_key",
-    "safety_identifier",
 ];
 
 static IGNORE_OPENAI_FE_UNSUPPORTED_FIELDS: LazyLock<bool> =
@@ -170,13 +166,6 @@ fn validate_no_unsupported_fields_with_ignore(
     if let Some(value) = unsupported_fields.get("logprob_token_ids") {
         serde_json::from_value::<Vec<crate::types::TokenIdType>>(value.clone())
             .map_err(|_| anyhow::anyhow!("`logprob_token_ids` must be an array of token IDs"))?;
-    }
-    for key in ["prompt_cache_key", "safety_identifier"] {
-        if let Some(value) = unsupported_fields.get(key)
-            && !value.is_string()
-        {
-            anyhow::bail!("`{key}` must be a string");
-        }
     }
     Ok(())
 }
@@ -570,9 +559,16 @@ pub fn validate_tools(
         if tool.function.name.trim().is_empty() {
             anyhow::bail!("Function name at index {} cannot be empty", i);
         }
-        if !tool
-            .function
-            .name
+        // Moonshot builtin tools are `$`-prefixed (`$web_search`).
+        let name = match tool.r#type {
+            dynamo_protocols::types::ChatCompletionToolType::BuiltinFunction => tool
+                .function
+                .name
+                .strip_prefix('$')
+                .unwrap_or(&tool.function.name),
+            dynamo_protocols::types::ChatCompletionToolType::Function => &tool.function.name,
+        };
+        if !name
             .bytes()
             .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
         {
@@ -971,25 +967,6 @@ mod tests {
             let err = validate_no_unsupported_fields_with_ignore(&fields, false).unwrap_err();
             assert!(err.to_string().contains("must be an array of token IDs"));
         }
-    }
-
-    #[test]
-    fn validate_no_unsupported_fields_accepts_prompt_cache_key_and_safety_identifier() {
-        let fields = HashMap::from([
-            ("prompt_cache_key".to_string(), json!("sess_123")),
-            ("safety_identifier".to_string(), json!("user_abc")),
-        ]);
-        validate_no_unsupported_fields_with_ignore(&fields, false).unwrap();
-    }
-
-    #[test]
-    fn validate_no_unsupported_fields_rejects_non_string_prompt_cache_key() {
-        let fields = HashMap::from([("prompt_cache_key".to_string(), json!(42))]);
-        let err = validate_no_unsupported_fields_with_ignore(&fields, false).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("`prompt_cache_key` must be a string")
-        );
     }
 
     #[test]

--- a/lib/llm/tests/parallel_tool_call_integration.rs
+++ b/lib/llm/tests/parallel_tool_call_integration.rs
@@ -29,6 +29,7 @@ fn create_mock_chat_completion_request() -> NvCreateChatCompletionRequest {
                     "You MUST use two tools in parallel to resolve the user request: call get_current_weather for each city AND call is_holiday_today to check if today is a holiday. Do not answer without using both tools.".to_string()
                 ),
                 name: None,
+                tools: None,
             }
         ),
         dynamo_protocols::types::ChatCompletionRequestMessage::User(


### PR DESCRIPTION
## Summary

Follow-up to the Kimi Code frontend PR. Consumes the `dynamo-protocols` schema additions from ai-dynamo/frontend-crates#211 so the remaining Kimi Code CLI / Moonshot K3 request shapes work on `/v1/chat/completions`:

| Field | Before | After |
|---|---|---|
| `prompt_cache_key`, `safety_identifier` | passthrough extra fields | typed `Option<String>` on the request; passthrough entries removed |
| `{"role":"system","tools":[…]}` with no `content` (K3 dynamic tool loading) | deserialization error | accepted; `tools` flows to the chat template through the existing `serde_json::to_value(messages)` render path |
| `tools[].type: "builtin_function"` | rejected (only `function`) | accepted, rendered like a function; the client executes the resulting call |
| assistant `partial: true` on the final message | silently dropped | `normalize_partial_final_message` maps it to `continue_final_message = true` and defaults `add_generation_prompt = false`, reusing the existing continue-final-message render path; an explicit `add_generation_prompt: true` still fails validation |

Struct literals of `ChatCompletionRequestSystemMessage` / `ChatCompletionRequestAssistantMessage` gain `tools: None` / `partial: None`.

**Blocked on release:** `Cargo.toml` temporarily points `dynamo-protocols` at the `kimi-code-compat` branch via `[patch.crates-io]` and bumps the pin to `=5.4.1`. Once frontend-crates#211 is released, drop the patch section and pin the released version.

## Validation

- `cargo check -p dynamo-llm --no-default-features --all-targets` clean
- `cargo test -p dynamo-llm --no-default-features --lib -- partial kimi_typed thinking validate_no_unsupported_fields kimi_k3 continue_final` passes (new: 4 tests covering partial → continue_final_message and typed-field deserialization)
- Not yet exercised end-to-end against a live Kimi K3 deployment.
