### PR TITLE
feat(frontend): accept Kimi Code request fields on /v1/chat/completions

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2219,6 +2219,36 @@ impl OpenAIPreprocessor {
         );
     }
 
+    /// The Kimi K3 template reads the grade as `thinking_effort` (`low|high|max`),
+    /// not the OpenAI `reasoning_effort` key the request normalizer writes.
+    fn normalize_kimi_k3_reasoning_effort(
+        request: &mut NvCreateChatCompletionRequest,
+        tool_call_parser: Option<&str>,
+    ) {
+        let uses_kimi_k3_parser =
+            tool_call_parser.is_some_and(|parser| matches!(parser, "kimi_k3" | "kimi-k3"));
+        if !uses_kimi_k3_parser {
+            return;
+        }
+        let Some(args) = request.chat_template_args.as_mut() else {
+            return;
+        };
+        if args.contains_key("thinking_effort") {
+            return;
+        }
+        let Some(effort) = args
+            .get("reasoning_effort")
+            .and_then(serde_json::Value::as_str)
+            .filter(|effort| matches!(*effort, "low" | "high" | "max"))
+        else {
+            return;
+        };
+        args.insert(
+            "thinking_effort".to_string(),
+            serde_json::Value::String(effort.to_string()),
+        );
+    }
+
     fn mistral_reasoning_enabled(
         chat_template_args: Option<&std::collections::HashMap<String, serde_json::Value>>,
     ) -> bool {
@@ -6963,6 +6993,7 @@ impl
             thinking_control_from_client,
         );
         Self::normalize_kimi_k3_named_tool_choice(&mut request, self.tool_call_parser.as_deref());
+        Self::normalize_kimi_k3_reasoning_effort(&mut request, self.tool_call_parser.as_deref());
 
         // create a response generator
         let response_generator = request.response_generator(context.id().to_string());
@@ -10276,6 +10307,66 @@ mod tests {
                 Some(args)
             ));
         }
+    }
+
+    #[test]
+    fn test_kimi_k3_reasoning_effort_maps_to_thinking_effort() {
+        for (body, expected) in [
+            (
+                serde_json::json!({"reasoning_effort": "high"}),
+                Some("high"),
+            ),
+            (
+                serde_json::json!({"thinking": {"type": "enabled", "effort": "max"}}),
+                Some("max"),
+            ),
+            (
+                serde_json::json!({
+                    "reasoning_effort": "low",
+                    "chat_template_args": {"thinking_effort": "max"}
+                }),
+                Some("max"),
+            ),
+            (serde_json::json!({"reasoning_effort": "medium"}), None),
+        ] {
+            let mut request_json = serde_json::json!({
+                "model": "moonshotai/Kimi-K3",
+                "messages": [{"role": "user", "content": "Hello"}]
+            });
+            request_json
+                .as_object_mut()
+                .unwrap()
+                .extend(body.as_object().unwrap().clone());
+            let mut request: NvCreateChatCompletionRequest =
+                serde_json::from_value(request_json).unwrap();
+            request.normalize_reasoning_template_args().unwrap();
+            OpenAIPreprocessor::normalize_kimi_k3_reasoning_effort(&mut request, Some("kimi_k3"));
+
+            let args = request.chat_template_args.as_ref().unwrap();
+            assert_eq!(
+                args.get("thinking_effort")
+                    .and_then(serde_json::Value::as_str),
+                expected,
+                "body {body}"
+            );
+        }
+
+        let mut request: NvCreateChatCompletionRequest =
+            serde_json::from_value(serde_json::json!({
+                "model": "test",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "reasoning_effort": "high"
+            }))
+            .unwrap();
+        request.normalize_reasoning_template_args().unwrap();
+        OpenAIPreprocessor::normalize_kimi_k3_reasoning_effort(&mut request, Some("hermes"));
+        assert!(
+            !request
+                .chat_template_args
+                .as_ref()
+                .unwrap()
+                .contains_key("thinking_effort")
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -139,12 +139,20 @@ impl NvCreateChatCompletionRequest {
             .map(openai_thinking_mode)
             .transpose()?
             .flatten();
+        let thinking_object = self.thinking.as_ref().and_then(|value| value.as_object());
         // vLLM's order: an explicit top-level grade wins, else the nested one.
+        // Kimi Code sends the grade as `thinking.effort` rather than `reasoning_effort`.
         let reasoning_effort = self
             .inner
             .reasoning_effort
             .as_ref()
             .and_then(|effort| serde_json::to_value(effort).ok())
+            .or_else(|| {
+                thinking_object
+                    .and_then(|object| object.get("effort"))
+                    .filter(|effort| effort.is_string())
+                    .cloned()
+            })
             .or_else(|| {
                 self.chat_template_args
                     .as_ref()
@@ -153,12 +161,22 @@ impl NvCreateChatCompletionRequest {
                     .filter(|effort| !effort.is_null())
                     .cloned()
             });
+        // Moonshot `thinking.keep: "all"` retains prior-turn reasoning in the
+        // prompt; the Kimi templates read it as `preserve_thinking`.
+        let preserve_thinking = thinking_object
+            .and_then(|object| object.get("keep"))
+            .filter(|keep| !keep.is_null())
+            .map(|keep| keep.as_str() == Some("all"));
 
         let has_template_control = self
             .chat_template_args
             .as_ref()
             .is_some_and(|args| THINKING_KEYS.iter().any(|key| args.contains_key(*key)));
-        if thinking_mode.is_none() && reasoning_effort.is_none() && !has_template_control {
+        if thinking_mode.is_none()
+            && reasoning_effort.is_none()
+            && preserve_thinking.is_none()
+            && !has_template_control
+        {
             return Ok(());
         }
 
@@ -206,6 +224,12 @@ impl NvCreateChatCompletionRequest {
         }
         if let Some(effort) = reasoning_effort {
             args.insert("reasoning_effort".to_string(), effort);
+        }
+        if let Some(preserve) = preserve_thinking {
+            args.insert(
+                "preserve_thinking".to_string(),
+                serde_json::Value::Bool(preserve),
+            );
         }
 
         // The raw `thinking` payload has been folded into `chat_template_args`;
@@ -1410,6 +1434,53 @@ mod tests {
         assert_eq!(args.get("thinking_mode"), Some(&json!("adaptive")));
         assert_eq!(args.get("thinking"), None);
         assert!(request.thinking.is_none());
+    }
+
+    #[test]
+    fn test_nested_thinking_effort_and_keep_normalize_to_template_args() {
+        let mut request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "thinking": {"type": "enabled", "effort": "high", "keep": "all"}
+        }))
+        .unwrap();
+        request.normalize_reasoning_template_args().unwrap();
+
+        let args = request.chat_template_args.as_ref().unwrap();
+        assert_eq!(args.get("thinking"), Some(&json!(true)));
+        assert_eq!(args.get("reasoning_effort"), Some(&json!("high")));
+        assert_eq!(args.get("preserve_thinking"), Some(&json!(true)));
+        assert!(request.thinking.is_none());
+    }
+
+    #[test]
+    fn test_top_level_reasoning_effort_outranks_nested_thinking_effort() {
+        let mut request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "reasoning_effort": "low",
+            "thinking": {"type": "enabled", "effort": "max"}
+        }))
+        .unwrap();
+        request.normalize_reasoning_template_args().unwrap();
+
+        let args = request.chat_template_args.as_ref().unwrap();
+        assert_eq!(args.get("reasoning_effort"), Some(&json!("low")));
+        assert_eq!(args.get("preserve_thinking"), None);
+    }
+
+    #[test]
+    fn test_thinking_keep_null_is_not_preserve() {
+        let mut request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K2.6",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "thinking": {"type": "enabled", "keep": null}
+        }))
+        .unwrap();
+        request.normalize_reasoning_template_args().unwrap();
+
+        let args = request.chat_template_args.as_ref().unwrap();
+        assert_eq!(args.get("preserve_thinking"), None);
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -109,6 +109,10 @@ pub const PASSTHROUGH_EXTRA_FIELDS: &[&str] = &[
     "allowed_token_ids",
     "bad_words_token_ids",
     "logprob_token_ids",
+    // OpenAI cache-affinity / abuse-tracking hints. Routing already keys on
+    // prompt prefix, so these are accepted and forwarded, not acted on.
+    "prompt_cache_key",
+    "safety_identifier",
 ];
 
 static IGNORE_OPENAI_FE_UNSUPPORTED_FIELDS: LazyLock<bool> =
@@ -166,6 +170,13 @@ fn validate_no_unsupported_fields_with_ignore(
     if let Some(value) = unsupported_fields.get("logprob_token_ids") {
         serde_json::from_value::<Vec<crate::types::TokenIdType>>(value.clone())
             .map_err(|_| anyhow::anyhow!("`logprob_token_ids` must be an array of token IDs"))?;
+    }
+    for key in ["prompt_cache_key", "safety_identifier"] {
+        if let Some(value) = unsupported_fields.get(key)
+            && !value.is_string()
+        {
+            anyhow::bail!("`{key}` must be a string");
+        }
     }
     Ok(())
 }
@@ -960,6 +971,25 @@ mod tests {
             let err = validate_no_unsupported_fields_with_ignore(&fields, false).unwrap_err();
             assert!(err.to_string().contains("must be an array of token IDs"));
         }
+    }
+
+    #[test]
+    fn validate_no_unsupported_fields_accepts_prompt_cache_key_and_safety_identifier() {
+        let fields = HashMap::from([
+            ("prompt_cache_key".to_string(), json!("sess_123")),
+            ("safety_identifier".to_string(), json!("user_abc")),
+        ]);
+        validate_no_unsupported_fields_with_ignore(&fields, false).unwrap();
+    }
+
+    #[test]
+    fn validate_no_unsupported_fields_rejects_non_string_prompt_cache_key() {
+        let fields = HashMap::from([("prompt_cache_key".to_string(), json!(42))]);
+        let err = validate_no_unsupported_fields_with_ignore(&fields, false).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("`prompt_cache_key` must be a string")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Kimi Code CLI (Moonshot, `@moonshot-ai/kimi-code`) sends two things the frontend mishandled on `/v1/chat/completions`:

| Field | Sent by Kimi Code | Before | After |
|---|---|---|---|
| `prompt_cache_key` (OpenAI-standard, = session id, every request) | yes | 400 `Unsupported parameter(s)` | accepted as passthrough (string-validated), alongside `safety_identifier` |
| `thinking.effort` (`low`/`high`/`max`) | yes | silently dropped — only `thinking.type` was read | joins the `reasoning_effort` fallback chain (top-level `reasoning_effort` still wins) |
| `thinking.keep: "all"` | yes | silently dropped | → `chat_template_args.preserve_thinking = true` (the key the Kimi templates read) |
| `reasoning_effort` on K3 | via the above | template reads `thinking_effort`, so effort never applied on the Rust render path | mapped to `thinking_effort` when the `kimi_k3` tool parser is active (Rust counterpart of #13120) |

Routing already keys on prompt prefix, so `prompt_cache_key` is forwarded, not acted on. No new CLI flags: every change is additive and only takes effect when the request carries the field.

Remaining Kimi Code gaps (content-less system message carrying `tools`, `builtin_function`, `partial`) are schema changes in `dynamo-protocols` — see the ai-dynamo/frontend-crates PR "feat(protocols): add Moonshot Kimi chat request fields"; a follow-up here will consume them once released.

## Validation

- `cargo test -p dynamo-llm --no-default-features --lib -- thinking reasoning_effort validate_no_unsupported_fields kimi_k3` → 73 passed (incl. 6 new tests)
- `cargo clippy -p dynamo-llm --no-default-features --lib --tests -- -D warnings` clean; `cargo fmt --check` clean
- Not yet exercised end-to-end against a live Kimi K3 deployment.
