### PR TITLE
feat(frontend): support Kimi Code request fields on /v1/chat/completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,9 +2890,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2723c9ec1c3106cd044ca7f3ff7db71e0e347d1190aa2694a7cc7121376a2a"
+version = "5.4.1"
+source = "git+https://github.com/ai-dynamo/frontend-crates.git?branch=kimi-code-compat#4ac3253a2aa546bd86ca0ecf4b7cda30be58df7a"
 dependencies = [
  "async-openai",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ dynamo-kv-hashing = { path = "lib/kv-hashing", version = "1.5.0" }
 dynamo-memory = { path = "lib/memory", version = "1.5.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.5.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.5.0" }
-dynamo-protocols = { version = "=5.4.0" }
+dynamo-protocols = { version = "=5.4.1" }
 dynamo-parsers = { version = "8.1.0" }
 
 # Published on crates.io. To see all available versions:
@@ -214,3 +214,8 @@ lto = "thin"
 inherits = "release"
 debug = true
 strip = false
+
+# Temporary until dynamo-protocols with Moonshot Kimi fields is released
+# (ai-dynamo/frontend-crates#211). Remove and bump the pin instead.
+[patch.crates-io]
+dynamo-protocols = { git = "https://github.com/ai-dynamo/frontend-crates.git", branch = "kimi-code-compat" }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2824,6 +2824,7 @@ async fn chat_completions(
         inflight_guard.mark_error(extract_error_type_from_response(&err_response));
         return Err(err_response);
     }
+    request.normalize_partial_final_message();
 
     // Handle unsupported fields - if Some(resp) is returned by
     // validate_chat_completion_unsupported_fields,

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2219,6 +2219,36 @@ impl OpenAIPreprocessor {
         );
     }
 
+    /// The Kimi K3 template reads the grade as `thinking_effort` (`low|high|max`),
+    /// not the OpenAI `reasoning_effort` key the request normalizer writes.
+    fn normalize_kimi_k3_reasoning_effort(
+        request: &mut NvCreateChatCompletionRequest,
+        tool_call_parser: Option<&str>,
+    ) {
+        let uses_kimi_k3_parser =
+            tool_call_parser.is_some_and(|parser| matches!(parser, "kimi_k3" | "kimi-k3"));
+        if !uses_kimi_k3_parser {
+            return;
+        }
+        let Some(args) = request.chat_template_args.as_mut() else {
+            return;
+        };
+        if args.contains_key("thinking_effort") {
+            return;
+        }
+        let Some(effort) = args
+            .get("reasoning_effort")
+            .and_then(serde_json::Value::as_str)
+            .filter(|effort| matches!(*effort, "low" | "high" | "max"))
+        else {
+            return;
+        };
+        args.insert(
+            "thinking_effort".to_string(),
+            serde_json::Value::String(effort.to_string()),
+        );
+    }
+
     fn mistral_reasoning_enabled(
         chat_template_args: Option<&std::collections::HashMap<String, serde_json::Value>>,
     ) -> bool {
@@ -6963,6 +6993,7 @@ impl
             thinking_control_from_client,
         );
         Self::normalize_kimi_k3_named_tool_choice(&mut request, self.tool_call_parser.as_deref());
+        Self::normalize_kimi_k3_reasoning_effort(&mut request, self.tool_call_parser.as_deref());
 
         // create a response generator
         let response_generator = request.response_generator(context.id().to_string());
@@ -10276,6 +10307,66 @@ mod tests {
                 Some(args)
             ));
         }
+    }
+
+    #[test]
+    fn test_kimi_k3_reasoning_effort_maps_to_thinking_effort() {
+        for (body, expected) in [
+            (
+                serde_json::json!({"reasoning_effort": "high"}),
+                Some("high"),
+            ),
+            (
+                serde_json::json!({"thinking": {"type": "enabled", "effort": "max"}}),
+                Some("max"),
+            ),
+            (
+                serde_json::json!({
+                    "reasoning_effort": "low",
+                    "chat_template_args": {"thinking_effort": "max"}
+                }),
+                Some("max"),
+            ),
+            (serde_json::json!({"reasoning_effort": "medium"}), None),
+        ] {
+            let mut request_json = serde_json::json!({
+                "model": "moonshotai/Kimi-K3",
+                "messages": [{"role": "user", "content": "Hello"}]
+            });
+            request_json
+                .as_object_mut()
+                .unwrap()
+                .extend(body.as_object().unwrap().clone());
+            let mut request: NvCreateChatCompletionRequest =
+                serde_json::from_value(request_json).unwrap();
+            request.normalize_reasoning_template_args().unwrap();
+            OpenAIPreprocessor::normalize_kimi_k3_reasoning_effort(&mut request, Some("kimi_k3"));
+
+            let args = request.chat_template_args.as_ref().unwrap();
+            assert_eq!(
+                args.get("thinking_effort")
+                    .and_then(serde_json::Value::as_str),
+                expected,
+                "body {body}"
+            );
+        }
+
+        let mut request: NvCreateChatCompletionRequest =
+            serde_json::from_value(serde_json::json!({
+                "model": "test",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "reasoning_effort": "high"
+            }))
+            .unwrap();
+        request.normalize_reasoning_template_args().unwrap();
+        OpenAIPreprocessor::normalize_kimi_k3_reasoning_effort(&mut request, Some("hermes"));
+        assert!(
+            !request
+                .chat_template_args
+                .as_ref()
+                .unwrap()
+                .contains_key("thinking_effort")
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -38,6 +38,7 @@ fn push_system_message(content: String, messages: &mut Vec<ChatCompletionRequest
         ChatCompletionRequestSystemMessage {
             content: ChatCompletionRequestSystemMessageContent::Text(content),
             name: None,
+            tools: None,
         },
     ));
 }
@@ -100,6 +101,7 @@ impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
                             audio: None,
                             tool_calls: None,
                             function_call: None,
+                            partial: None,
                         },
                     ));
                 }
@@ -465,6 +467,7 @@ fn convert_assistant_blocks(
             tool_calls: tc,
             #[allow(deprecated)]
             function_call: None,
+            partial: None,
         },
     ));
 }

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -30,8 +30,9 @@ pub use delta::DeltaGenerator;
 use dynamo_parsers::tool_calling::{ToolCallResponse, ToolCallResponseChunk};
 use dynamo_protocols::types::{
     ChatChoiceStream, ChatCompletionMessageContent, ChatCompletionMessageToolCall,
-    ChatCompletionMessageToolCallChunk, ChatCompletionStreamResponseDelta, FinishReason,
-    FunctionCall, FunctionCallStream, FunctionType,
+    ChatCompletionMessageToolCallChunk, ChatCompletionRequestMessage,
+    ChatCompletionStreamResponseDelta, FinishReason, FunctionCall, FunctionCallStream,
+    FunctionType,
 };
 
 /// Map a parser-native [`ToolCallResponse`] onto the protocol/wire
@@ -139,12 +140,20 @@ impl NvCreateChatCompletionRequest {
             .map(openai_thinking_mode)
             .transpose()?
             .flatten();
+        let thinking_object = self.thinking.as_ref().and_then(|value| value.as_object());
         // vLLM's order: an explicit top-level grade wins, else the nested one.
+        // Kimi Code sends the grade as `thinking.effort` rather than `reasoning_effort`.
         let reasoning_effort = self
             .inner
             .reasoning_effort
             .as_ref()
             .and_then(|effort| serde_json::to_value(effort).ok())
+            .or_else(|| {
+                thinking_object
+                    .and_then(|object| object.get("effort"))
+                    .filter(|effort| effort.is_string())
+                    .cloned()
+            })
             .or_else(|| {
                 self.chat_template_args
                     .as_ref()
@@ -153,12 +162,22 @@ impl NvCreateChatCompletionRequest {
                     .filter(|effort| !effort.is_null())
                     .cloned()
             });
+        // Moonshot `thinking.keep: "all"` retains prior-turn reasoning in the
+        // prompt; the Kimi templates read it as `preserve_thinking`.
+        let preserve_thinking = thinking_object
+            .and_then(|object| object.get("keep"))
+            .filter(|keep| !keep.is_null())
+            .map(|keep| keep.as_str() == Some("all"));
 
         let has_template_control = self
             .chat_template_args
             .as_ref()
             .is_some_and(|args| THINKING_KEYS.iter().any(|key| args.contains_key(*key)));
-        if thinking_mode.is_none() && reasoning_effort.is_none() && !has_template_control {
+        if thinking_mode.is_none()
+            && reasoning_effort.is_none()
+            && preserve_thinking.is_none()
+            && !has_template_control
+        {
             return Ok(());
         }
 
@@ -207,12 +226,33 @@ impl NvCreateChatCompletionRequest {
         if let Some(effort) = reasoning_effort {
             args.insert("reasoning_effort".to_string(), effort);
         }
+        if let Some(preserve) = preserve_thinking {
+            args.insert(
+                "preserve_thinking".to_string(),
+                serde_json::Value::Bool(preserve),
+            );
+        }
 
         // The raw `thinking` payload has been folded into `chat_template_args`;
         // drop it so it isn't double-shipped downstream (and so it can't be
         // re-interpreted with different precedence by the worker preprocessor).
         self.thinking = None;
         Ok(())
+    }
+
+    /// Moonshot partial mode: `partial: true` on a final assistant message asks
+    /// the model to continue that content. Express it as vLLM's
+    /// `continue_final_message` so one render path serves both dialects.
+    /// An explicit `add_generation_prompt: true` is left for validation to reject.
+    pub fn normalize_partial_final_message(&mut self) {
+        let Some(ChatCompletionRequestMessage::Assistant(last)) = self.inner.messages.last() else {
+            return;
+        };
+        if last.partial != Some(true) {
+            return;
+        }
+        self.common.continue_final_message = Some(true);
+        self.common.add_generation_prompt.get_or_insert(false);
     }
 }
 
@@ -1410,6 +1450,128 @@ mod tests {
         assert_eq!(args.get("thinking_mode"), Some(&json!("adaptive")));
         assert_eq!(args.get("thinking"), None);
         assert!(request.thinking.is_none());
+    }
+
+    #[test]
+    fn test_nested_thinking_effort_and_keep_normalize_to_template_args() {
+        let mut request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "thinking": {"type": "enabled", "effort": "high", "keep": "all"}
+        }))
+        .unwrap();
+        request.normalize_reasoning_template_args().unwrap();
+
+        let args = request.chat_template_args.as_ref().unwrap();
+        assert_eq!(args.get("thinking"), Some(&json!(true)));
+        assert_eq!(args.get("reasoning_effort"), Some(&json!("high")));
+        assert_eq!(args.get("preserve_thinking"), Some(&json!(true)));
+        assert!(request.thinking.is_none());
+    }
+
+    #[test]
+    fn test_top_level_reasoning_effort_outranks_nested_thinking_effort() {
+        let mut request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "reasoning_effort": "low",
+            "thinking": {"type": "enabled", "effort": "max"}
+        }))
+        .unwrap();
+        request.normalize_reasoning_template_args().unwrap();
+
+        let args = request.chat_template_args.as_ref().unwrap();
+        assert_eq!(args.get("reasoning_effort"), Some(&json!("low")));
+        assert_eq!(args.get("preserve_thinking"), None);
+    }
+
+    #[test]
+    fn test_thinking_keep_null_is_not_preserve() {
+        let mut request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K2.6",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "thinking": {"type": "enabled", "keep": null}
+        }))
+        .unwrap();
+        request.normalize_reasoning_template_args().unwrap();
+
+        let args = request.chat_template_args.as_ref().unwrap();
+        assert_eq!(args.get("preserve_thinking"), None);
+    }
+
+    #[test]
+    fn test_partial_final_assistant_message_becomes_continue_final_message() {
+        let mut request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "messages": [
+                {"role": "user", "content": "Return JSON"},
+                {"role": "assistant", "content": "{\"answer\":", "partial": true}
+            ]
+        }))
+        .unwrap();
+        request.normalize_partial_final_message();
+        assert_eq!(request.common.continue_final_message, Some(true));
+        assert_eq!(request.common.add_generation_prompt, Some(false));
+        ValidateRequest::validate(&request).unwrap();
+    }
+
+    #[test]
+    fn test_partial_only_applies_to_final_assistant_message() {
+        let mut request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "messages": [
+                {"role": "assistant", "content": "draft", "partial": true},
+                {"role": "user", "content": "Continue"}
+            ]
+        }))
+        .unwrap();
+        request.normalize_partial_final_message();
+        assert_eq!(request.common.continue_final_message, None);
+        assert_eq!(request.common.add_generation_prompt, None);
+    }
+
+    #[test]
+    fn test_partial_keeps_explicit_add_generation_prompt_for_validation() {
+        let mut request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "add_generation_prompt": true,
+            "messages": [{"role": "assistant", "content": "x", "partial": true}]
+        }))
+        .unwrap();
+        request.normalize_partial_final_message();
+        assert_eq!(request.common.add_generation_prompt, Some(true));
+        assert!(ValidateRequest::validate(&request).is_err());
+    }
+
+    #[test]
+    fn test_kimi_typed_fields_deserialize_without_unsupported_fields() {
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "prompt_cache_key": "sess_1",
+            "safety_identifier": "user_1",
+            "messages": [
+                {"role": "system", "tools": [{
+                    "type": "function",
+                    "function": {"name": "read_file", "parameters": {"type": "object"}}
+                }]},
+                {"role": "user", "content": "hi"}
+            ],
+            "tools": [{"type": "builtin_function", "function": {"name": "$web_search"}}]
+        }))
+        .unwrap();
+        assert_eq!(request.inner.prompt_cache_key.as_deref(), Some("sess_1"));
+        assert_eq!(request.inner.safety_identifier.as_deref(), Some("user_1"));
+        assert!(request.unsupported_fields.is_empty());
+        ValidateRequest::validate(&request).unwrap();
+
+        // The `$` prefix is only tolerated on builtin tools.
+        let plain: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "function", "function": {"name": "$web_search"}}]
+        }))
+        .unwrap();
+        assert!(ValidateRequest::validate(&plain).is_err());
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -483,6 +483,7 @@ impl PendingAssistant {
                 },
                 #[allow(deprecated)]
                 function_call: None,
+                partial: None,
             },
         ));
     }
@@ -510,6 +511,7 @@ fn convert_input_items_to_messages(
                                             text,
                                         ),
                                         name: None,
+                                        tools: None,
                                     },
                                 )
                             }
@@ -623,6 +625,7 @@ fn convert_input_items_to_messages(
                             ChatCompletionRequestSystemMessage {
                                 content: ChatCompletionRequestSystemMessageContent::Text(text),
                                 name: None,
+                                tools: None,
                             },
                         ));
                     }
@@ -799,6 +802,7 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
                 ChatCompletionRequestSystemMessage {
                     content: ChatCompletionRequestSystemMessageContent::Text(instructions.clone()),
                     name: None,
+                    tools: None,
                 },
             ));
         }
@@ -859,6 +863,7 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
                     ChatCompletionRequestMessage::System(ChatCompletionRequestSystemMessage {
                         content: ChatCompletionRequestSystemMessageContent::Text(combined),
                         name: None,
+                        tools: None,
                     }),
                 );
             }

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -559,9 +559,16 @@ pub fn validate_tools(
         if tool.function.name.trim().is_empty() {
             anyhow::bail!("Function name at index {} cannot be empty", i);
         }
-        if !tool
-            .function
-            .name
+        // Moonshot builtin tools are `$`-prefixed (`$web_search`).
+        let name = match tool.r#type {
+            dynamo_protocols::types::ChatCompletionToolType::BuiltinFunction => tool
+                .function
+                .name
+                .strip_prefix('$')
+                .unwrap_or(&tool.function.name),
+            dynamo_protocols::types::ChatCompletionToolType::Function => &tool.function.name,
+        };
+        if !name
             .bytes()
             .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
         {

--- a/lib/llm/tests/parallel_tool_call_integration.rs
+++ b/lib/llm/tests/parallel_tool_call_integration.rs
@@ -29,6 +29,7 @@ fn create_mock_chat_completion_request() -> NvCreateChatCompletionRequest {
                     "You MUST use two tools in parallel to resolve the user request: call get_current_weather for each city AND call is_holiday_today to check if today is a holiday. Do not answer without using both tools.".to_string()
                 ),
                 name: None,
+                tools: None,
             }
         ),
         dynamo_protocols::types::ChatCompletionRequestMessage::User(


### PR DESCRIPTION
## Summary

Kimi Code CLI (Moonshot, `@moonshot-ai/kimi-code`) sends request shapes the frontend rejected or silently dropped on `/v1/chat/completions`. The schema additions live in `dynamo-protocols` (ai-dynamo/frontend-crates#211); this PR consumes them and adds the Dynamo-side normalization. No new CLI flags — every change is additive and only takes effect when the request carries the field.

| Field | Sent by Kimi Code | Before | After |
|---|---|---|---|
| `prompt_cache_key`, `safety_identifier` (OpenAI-standard) | every request | 400 `Unsupported parameter(s)` | typed request fields (frontend-crates#211); forwarded, not acted on — routing already keys on prompt prefix |
| `{"role":"system","tools":[…]}` with no `content` (K3 dynamic tool loading) | when dynamic tools on | deserialization error | accepted; `tools` reaches the chat template via the existing `serde_json::to_value(messages)` render path |
| `tools[].type: "builtin_function"` (`$web_search`) | not yet (documented) | rejected | accepted, rendered like a function; `$` prefix passes tool-name validation only for this type |
| assistant `partial: true` on the final message | not yet (documented) | silently dropped | `normalize_partial_final_message` → `continue_final_message = true`, `add_generation_prompt` defaults to `false`; an explicit `add_generation_prompt: true` still fails validation |
| `thinking.effort` (`low`/`high`/`max`) | yes | silently dropped — only `thinking.type` read | joins the `reasoning_effort` fallback chain (top-level `reasoning_effort` still wins) |
| `thinking.keep: "all"` | yes | silently dropped | → `chat_template_args.preserve_thinking = true` (the key the Kimi templates read) |
| `reasoning_effort` on K3 (Rust render path) | via the above | template reads `thinking_effort`, so effort never applied | mapped to `thinking_effort` when the `kimi_k3` tool parser is active (Rust counterpart of #13120) |

Struct literals of `ChatCompletionRequestSystemMessage` / `ChatCompletionRequestAssistantMessage` gain `tools: None` / `partial: None`.

**Blocked on release:** `Cargo.toml` temporarily points `dynamo-protocols` at the `kimi-code-compat` branch via `[patch.crates-io]` and bumps the pin to `=5.4.1`. Once frontend-crates#211 is released, drop the patch section and pin the released version.

Supersedes #14331 and #14332 (the latter carried an interim passthrough-list workaround in Dynamo; per team preference the protocol change goes in frontend-crates first).

## Validation

- `cargo check -p dynamo-llm --no-default-features --all-targets` clean
- `cargo test -p dynamo-llm --no-default-features --lib -- partial kimi_typed thinking validate_no_unsupported_fields kimi_k3 continue_final validate_tools` → 113 passed (10 new tests)
- `cargo clippy -p dynamo-llm --no-default-features --all-targets -- -D warnings` clean; `cargo fmt --check` clean
- Not yet exercised end-to-end against a live Kimi K3 deployment.
