### PR TITLE
fix(runtime): update to Pydantic

### DIFF
--- a/container/deps/requirements.common.txt
+++ b/container/deps/requirements.common.txt
@@ -31,7 +31,7 @@ opentelemetry-sdk<=1.38.0
 pillow>=12.3.0
 prometheus_client==0.23.1
 protobuf>=5.29.5,<7.0.0
-pydantic>=2.11.4,<=2.13.4
+pydantic>=2.11.4,<=2.13.5
 pydantic-settings<2.13.0
 PyYAML==6.0.3
 tensorboardX==2.6.2.2

--- a/container/deps/requirements.common.txt
+++ b/container/deps/requirements.common.txt
@@ -31,7 +31,7 @@ opentelemetry-sdk<=1.38.0
 pillow>=12.3.0
 prometheus_client==0.23.1
 protobuf>=5.29.5,<7.0.0
-pydantic>=2.11.4,<2.13
+pydantic>=2.11.4,<=2.13.4
 pydantic-settings<2.13.0
 PyYAML==6.0.3
 tensorboardX==2.6.2.2

--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -42,7 +42,7 @@ openai==2.32.0  # for Fault Tolerance migration tests
 pandas-stubs>=1.3.0
 psutil<=7.0.0  # System package, may vary by platform (was >=5.0.0)
 # Required by pyproject.toml warning filters (pydantic.warnings.PydanticDeprecatedSince20)
-pydantic>=2.11.4,<=2.13.4
+pydantic>=2.11.4,<=2.13.5
 pyelftools==0.33
 pytest==9.0.3
 pytest-asyncio==1.3.0

--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -42,7 +42,7 @@ openai==2.32.0  # for Fault Tolerance migration tests
 pandas-stubs>=1.3.0
 psutil<=7.0.0  # System package, may vary by platform (was >=5.0.0)
 # Required by pyproject.toml warning filters (pydantic.warnings.PydanticDeprecatedSince20)
-pydantic>=2.11.4,<2.13
+pydantic>=2.11.4,<=2.13.4
 pyelftools==0.33
 pytest==9.0.3
 pytest-asyncio==1.3.0

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -26,7 +26,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "pydantic>=2.10.6,<=2.13.4",
+    "pydantic>=2.10.6,<=2.13.5",
     "uvloop>=0.21.0",
 ]
 classifiers = [

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -26,7 +26,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "pydantic>=2.10.6,<=2.13",
+    "pydantic>=2.10.6,<=2.13.4",
     "uvloop>=0.21.0",
 ]
 classifiers = [


### PR DESCRIPTION
## Summary

- Widen the Python runtime Pydantic cap from 2.13.0 to 2.13.4.
- Keep the lower bound and minor-version ceiling unchanged.
- Unblock downstream environments already resolved to Pydantic 2.13.4.

## Validation

- Installed ai-dynamo-runtime 1.4.2 with Pydantic 2.13.4 in an isolated environment and imported DistributedRuntime successfully.
- Parsed the updated requirement and verified that it accepts 2.13.4 and rejects 2.13.5.
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python runtime compatibility to allow Pydantic versions through 2.13.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->