### PR TITLE
docs(planner): add mode selection guidance

### DIFF
--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -484,6 +484,8 @@ navigation:
                 contents:
                   - page: Overview
                     path: pages/developer-guide/knowledge-base/modular-components/planner/overview.md
+                  - page: Choose a Planner Mode
+                    path: pages/developer-guide/knowledge-base/modular-components/planner/choose-planner-mode.md
                   - page: Planner Guide
                     path: pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
                   - page: Global Planner Guide

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/choose-planner-mode.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/choose-planner-mode.md
@@ -1,0 +1,113 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Choose a Planner Mode
+subtitle: Select a deployment topology, optimization target, scaling method, and runtime environment for the Dynamo Planner.
+---
+
+The Planner has several settings that describe different decisions. Choose them in this order so that topology, scaling policy, and runtime behavior stay aligned.
+
+| Decision | Configuration | Question |
+|----------|---------------|----------|
+| Deployment topology | `mode` | Which worker roles does this Planner scale? |
+| Optimization target | `optimization_target` | What outcome should trigger scaling? |
+| Scaling method | `enable_throughput_scaling`, `enable_load_scaling` | How should the Planner calculate replica recommendations for an `sla` target? |
+| Runtime environment | `environment` | Should the Planner apply changes locally, delegate them, or simulate them? |
+
+## Recommended Starting Points
+
+| Requirement | Optimization Target | Scaling Method |
+|-------------|---------------------|----------------|
+| No specific latency SLA | `throughput` by default; `latency` when shorter queues matter more than GPU efficiency | Load-based, enabled automatically |
+| Specific TTFT and ITL SLA | `sla` | Enable throughput-based and load-based scaling together |
+
+Use `load` instead of `throughput` or `latency` only when you want to supply the prefill queue-token and decode KV-utilization thresholds yourself.
+
+## Choose the Deployment Topology
+
+Set `mode` to match the worker topology that the Planner controls.
+
+| `mode` | Worker Topology | Use When |
+|--------|-----------------|----------|
+| `disagg` (default) | Separate prefill and decode workers | The deployment uses disaggregated serving and each worker role must scale independently. |
+| `agg` | One worker performs prefill and decode | The deployment uses aggregated serving and needs one replica count. |
+| `prefill` | Prefill workers only | The Planner controls a prefill-only pool, typically in a multi-DGD deployment. |
+| `decode` | Decode workers only | The Planner controls a decode-only pool, typically in a multi-DGD deployment. |
+
+For a single DGD, use `disagg` or `agg` to match the deployment. Use `prefill` and `decode` for independently managed pools. To coordinate multiple DGDs or expose multiple pools through one endpoint, see the [Global Planner Guide](global-planner-guide.md).
+
+## Choose the Optimization Target
+
+Choose the target based on whether you have specific Time To First Token (TTFT) and Inter-Token Latency (ITL) requirements.
+
+| `optimization_target` | Use When | Scaling Behavior |
+|-----------------------|----------|------------------|
+| `throughput` (default) | You do not have a specific latency SLA and want the default balance of throughput and GPU use. | Uses built-in queue-depth and KV-utilization thresholds. |
+| `latency` | You do not have a specific latency SLA but prefer shorter queues and earlier scale-up. | Uses more aggressive built-in thresholds. |
+| `load` | You know the engine saturation points and want to configure thresholds directly. | Uses your prefill queue-token and decode KV-utilization thresholds. |
+| `sla` | You must target specific TTFT and ITL values. | Uses performance-model estimates and lets you select the scaling methods. |
+
+The `throughput`, `latency`, and `load` targets always use load-based scaling. They disable throughput-based scaling and ignore `enable_throughput_scaling` and `enable_load_scaling`.
+
+## Choose Scaling Methods for an SLA
+
+The `sla` target is the only target that lets you select scaling methods. Enable at least one.
+
+| Scaling Method | Use When | Default |
+|----------------|----------|:-------:|
+| Throughput-based | Traffic is predictable enough for forecasting and you want a stable capacity floor. | On |
+| Load-based | Traffic is bursty or difficult to predict and needs faster reactive adjustments. | Off |
+| Both | You want prediction-based baseline capacity and burst response. | Recommended |
+
+For most SLA-driven production deployments, enable both methods:
+
+```yaml
+features:
+  planner:
+    mode: disagg
+    backend: vllm
+    optimization_target: sla
+    enable_throughput_scaling: true
+    enable_load_scaling: true
+    ttft_ms: 500.0
+    itl_ms: 50.0
+```
+
+Keep `throughput_adjustment_interval_seconds` longer than `load_adjustment_interval_seconds` when both methods are enabled. The throughput-based method sets the capacity floor, then the load-based method adjusts above it.
+
+## Choose the Runtime Environment
+
+| `environment` | Behavior | Use When |
+|---------------|----------|----------|
+| `kubernetes` (default) | Applies replica changes to the local DynamoGraphDeployment (DGD). | One Planner controls one DGD on Kubernetes. |
+| `global-planner` | Sends scale requests to a GlobalPlanner. | Multiple DGDs need centralized policy, authorization, or a shared GPU budget. |
+| `virtual` | Applies changes through the VirtualConnector. | You are simulating, replaying, or integrating a non-Kubernetes scaling environment. |
+
+Set `global_planner_namespace` when `environment` is `global-planner`. See the [Global Planner Guide](global-planner-guide.md) for the control DGD, pool-local Planner, and routing requirements.
+
+## Check Dependencies
+
+| Choice | Required | Optional or Recommended |
+|--------|----------|-------------------------|
+| Any load-based scaling | A supported backend that emits ForwardPassMetrics (FPM) through the Dynamo event plane | KV-aware routing is optional. |
+| `throughput` or `latency` target | FPM from the backend | No SLA values, Prometheus traffic queries, or profiling data are required. |
+| `load` target | FPM plus the queue-token or KV-utilization thresholds for the active worker roles | No profiling data is required. |
+| `sla` target | TTFT and ITL values, Prometheus, and a supported performance-model path | Native AIConfigurator estimates or bootstrap profiling data reduce warmup time; live FPM can warm the regression fallback. |
+| `global-planner` environment | Dynamo Kubernetes Platform, GlobalPlanner, pool-local routers, and Prometheus scraping router metrics | Profile each intended pool before composing a multi-pool deployment. |
+
+The KV router is not required for load-based scaling. The Planner receives engine load through FPM regardless of the routing strategy. For backend-specific FPM requirements, see [Current Limitations](overview.md#current-limitations). For profiler bootstrap options, see the [Profiler Guide](../profiler/profiler-guide.md).
+
+## Validate Before Applying Changes
+
+Set `advisory: true` to calculate, log, and export recommendations without changing replica counts. Use advisory mode when introducing an SLA, changing targets, or validating a new workload.
+
+```yaml
+features:
+  planner:
+    optimization_target: sla
+    enable_throughput_scaling: true
+    enable_load_scaling: true
+    advisory: true
+```
+
+Set replica floors and `max_gpu_budget` before disabling advisory mode. See [Tune the Planner](../../../../kubernetes/auto-deployment/dynamo-planner.mdx) for the deployment workflow and the [Planner Configuration reference](../../../../reference/components/planner-configuration.mdx) for every field and validation rule.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
@@ -93,18 +93,24 @@ For `throughput`, `latency`, and `load`, the Planner enables load-based scaling,
 
 > **Need multi-DGD coordination?** See the [Global Planner Guide](global-planner-guide.md) for shared-policy coordination across multiple DGDs and single-endpoint multi-pool deployments.
 
-## When to Use Each Scaling Method
+## Choose a Target Without a Specific SLA
 
-- **Throughput-based scaling** should be enabled for the `sla` target when you want stable, prediction-based capacity planning. Native AIC or bootstrap FPMs make it ready sooner; otherwise it warms from live FPMs.
-- **Load-based scaling** should be enabled when traffic is bursty or hard to predict. It reacts quickly to real-time load changes without requiring pre-deployment data.
-- **Both methods together**: For the best of both worlds, enable both. Throughput-based scaling provides a lower bound (long-term capacity), while load-based scaling handles bursts above that floor. When both are enabled, use a longer `throughput_adjustment_interval_seconds` than `load_adjustment_interval_seconds`.
+Choose the default `throughput` target for a balance of throughput and GPU use, or choose `latency` to scale up earlier and keep queues shorter. Both targets use load-based scaling automatically, with no SLA values or profiling data required.
+
+For topology, target, runtime environment, and dependency decisions, see [Choose a Planner Mode](choose-planner-mode.md).
+
+## Choose a Target With a Specific SLA
+
+Choose the `sla` target and enable throughput-based and load-based scaling together. Throughput-based scaling provides a stable capacity floor, while load-based scaling responds to bursts above that floor. Native AIC or bootstrap FPMs make the performance model ready sooner; otherwise it warms from live FPMs.
+
+For the complete decision path and a recommended SLA configuration, see [Choose a Planner Mode](choose-planner-mode.md).
 
 ## Quick Start
 
 ### Prerequisites
 
 - Dynamo platform installed on Kubernetes ([Installation Guide](../../../../kubernetes/installation/install-dynamo.md))
-- kube-prometheus-stack installed ([Metrics Setup](../../../../kubernetes/operations/observability.mdx))
+- For the `sla` target, kube-prometheus-stack installed ([Metrics Setup](../../../../kubernetes/operations/observability.mdx))
 
 ### Default Target (zero config)
 
@@ -169,6 +175,7 @@ Load-based scaling has the following known limitations. Throughput-based scaling
 
 | Document | Description |
 |----------|-------------|
+| [Choose a Planner Mode](choose-planner-mode.md) | Topology, target, scaling method, environment, and dependency decisions |
 | [Planner Guide](planner-guide.md) | Deployment, configuration, integration |
 | [Planner Design](planner-design.md) | Architecture and algorithm internals |
 | [Planner Examples](planner-examples.md) | Planner-specific configuration examples |

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
@@ -18,9 +18,20 @@ LLM inference breaks these assumptions:
 
 The Dynamo **Planner** is an autoscaler purpose-built for these constraints. It understands engine profiling data, tracks per-worker GPU utilization, predicts traffic patterns, and makes scaling decisions that directly target TTFT and ITL SLAs — not proxy metrics.
 
-## Getting Started: Optimization Targets
+## Optimization Targets and Scaling Methods
 
-The planner offers four `optimization_target` settings that control how scaling decisions are made:
+Planner configuration has two separate layers:
+
+| Concept | Configuration | Purpose |
+|---------|---------------|---------|
+| **Optimization target** | `optimization_target` | Defines the objective and policy the Planner uses to decide when capacity should change. |
+| **Scaling method** | `enable_throughput_scaling`, `enable_load_scaling` | Defines the mechanism that turns traffic or engine signals into replica recommendations. These fields are selectable only with the `sla` target. |
+
+An optimization target is not a scaling method. In particular, the `throughput` optimization target uses load-based scaling with built-in thresholds; it does not enable the throughput-based scaling method.
+
+### Optimization Targets
+
+The Planner offers four optimization targets:
 
 | Target | Description | Requires SLA? | Requires Profiling? |
 |--------|-------------|:-------------:|:-------------------:|
@@ -29,20 +40,31 @@ The planner offers four `optimization_target` settings that control how scaling 
 | **`load`** | Uses user-defined prefill queue token and decode KV cache utilization thresholds. | No | No |
 | **`sla`** | Targets specific TTFT/ITL SLA values through the Planner engine-query layer and the AIConfigurator compatibility API in the `aisimulate` wheel: native AIC estimates when available, online FPM tuning, and FPM regression fallback. | Yes (`ttft_ms`, `itl_ms`) | Recommended |
 
+### Scaling Methods
+
+The Planner implements two scaling methods:
+
+- **Throughput-based scaling (`sla` target only)**: Uses the Planner engine-query layer and traffic prediction to compute the replica count needed to meet TTFT and ITL targets. Forward-pass estimates come from the AIConfigurator compatibility API in the `aisimulate` wheel, with self-benchmark or profiler FPM bootstrap data and live FPM tuning. Adjusts on a longer interval (default 180s). The default `throughput` target instead uses load-based queue and KV-utilization thresholds.
+- **Load-based scaling**: Uses ForwardPassMetrics (FPM) from the Dynamo event plane and queries the same Planner engine-query layer for short-term TTFT/ITL estimates. No pre-deployment data or KV Router required. Adjusts on a short interval (default 5s) to respond quickly to bursts.
+
+When both methods are enabled for the `sla` target, throughput-based scaling provides a capacity floor for long-term planning while load-based scaling handles real-time adjustments above that floor.
+
+### Target and Scaling Method Compatibility
+
+| Optimization Target | Throughput-Based | Load-Based | Behavior |
+|---------------------|:----------------:|:----------:|----------|
+| **`throughput`** (default) | — | ✅ Always enabled | Uses built-in queue-depth and KV-utilization thresholds. |
+| **`latency`** | — | ✅ Always enabled | Uses more aggressive built-in thresholds. |
+| **`load`** | — | ✅ Always enabled | Uses the queue-token and KV-utilization thresholds you configure. |
+| **`sla`** | ✅ Optional; enabled by default | ✅ Optional | Honors `enable_throughput_scaling` and `enable_load_scaling`; at least one must be enabled. |
+
+For `throughput`, `latency`, and `load`, the Planner enables load-based scaling, disables throughput-based scaling, and ignores both `enable_*_scaling` fields. The `sla` target is the only target that lets you select either scaling method or combine them.
+
 **We recommend starting with the default `throughput` target** because it requires no configuration. Switch to `latency` for latency-sensitive workloads, `load` for explicit prefill queue token and decode KV cache utilization thresholds, or `sla` for precise SLA targeting with native AIC or FPM-based performance modeling.
 
 > **New to the Planner?** Start with the [Planner Guide](planner-guide.md) for a complete workflow including profiling and deployment.
 
 > **Need multi-DGD coordination?** See the [Global Planner Guide](global-planner-guide.md) for shared-policy coordination across multiple DGDs and single-endpoint multi-pool deployments.
-
-## Scaling Modes
-
-The Planner supports two scaling modes that can run independently or together:
-
-- **Throughput-based scaling (`sla` target only)**: Uses the Planner engine-query layer and traffic prediction to compute the replica count needed to meet TTFT and ITL targets. Forward-pass estimates come from the AIConfigurator compatibility API in the `aisimulate` wheel, with self-benchmark or profiler FPM bootstrap data and live FPM tuning. Adjusts on a longer interval (default 180s). The default `throughput` target instead uses load-based queue and KV-utilization thresholds.
-- **Load-based scaling**: Uses ForwardPassMetrics (FPM) from the Dynamo event plane and queries the same Planner engine-query layer for short-term TTFT/ITL estimates. No pre-deployment data or KV Router required. Adjusts on a short interval (default 5s) to respond quickly to bursts.
-
-When both modes are enabled, throughput-based scaling provides a capacity floor (long-term planning) while load-based scaling handles real-time adjustments above that floor.
 
 ## Feature Matrix
 
@@ -69,13 +91,13 @@ When both modes are enabled, throughput-based scaling provides a capacity floor 
 
 **Legend:** ✅ Supported; — Not applicable.
 
-Router mode does not constrain either scaling mode. Load-based scaling consumes FPM directly from the engines through the Dynamo event plane, so it does not require the KV router. When runtime metrics are available, both scaling modes account for KV cache reuse through KV hit rate and speculative decoding through accepted tokens per forward pass. The Planner uses these signals for capacity estimates; it does not enable the engine features.
+Router mode does not constrain either scaling method. Load-based scaling consumes FPM directly from the engines through the Dynamo event plane, so it does not require the KV router. When runtime metrics are available, both scaling methods account for KV cache reuse through KV hit rate and speculative decoding through accepted tokens per forward pass. The Planner uses these signals for capacity estimates; it does not enable the engine features.
 
-## When to Use Which Mode
+## When to Use Each Scaling Method
 
-- **Throughput-based scaling** should be enabled for SLA mode when you want stable, prediction-based capacity planning. Native AIC or bootstrap FPMs make it ready sooner; otherwise it warms from live FPMs.
+- **Throughput-based scaling** should be enabled for the `sla` target when you want stable, prediction-based capacity planning. Native AIC or bootstrap FPMs make it ready sooner; otherwise it warms from live FPMs.
 - **Load-based scaling** should be enabled when traffic is bursty or hard to predict. It reacts quickly to real-time load changes without requiring pre-deployment data.
-- **Both modes together**: For the best of both worlds, enable both. Throughput-based scaling provides a lower bound (long-term capacity), while load-based scaling handles bursts above that floor. When both are enabled, use a longer `throughput_adjustment_interval_seconds` than `load_adjustment_interval_seconds`.
+- **Both methods together**: For the best of both worlds, enable both. Throughput-based scaling provides a lower bound (long-term capacity), while load-based scaling handles bursts above that floor. When both are enabled, use a longer `throughput_adjustment_interval_seconds` than `load_adjustment_interval_seconds`.
 
 ## Quick Start
 
@@ -84,7 +106,7 @@ Router mode does not constrain either scaling mode. Load-based scaling consumes 
 - Dynamo platform installed on Kubernetes ([Installation Guide](../../../../kubernetes/installation/install-dynamo.md))
 - kube-prometheus-stack installed ([Metrics Setup](../../../../kubernetes/operations/observability.mdx))
 
-### Default Mode (zero config)
+### Default Target (zero config)
 
 The planner works out of the box with no configuration needed. By default, `optimization_target` is set to `throughput`, which uses static thresholds on queue depth and KV cache utilization — no SLAs or profiling required:
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
@@ -18,6 +18,33 @@ LLM inference breaks these assumptions:
 
 The Dynamo **Planner** is an autoscaler purpose-built for these constraints. It understands engine profiling data, tracks per-worker GPU utilization, predicts traffic patterns, and makes scaling decisions that directly target TTFT and ITL SLAs — not proxy metrics.
 
+## Feature Matrix
+
+| Feature | Throughput-Based | Load-Based |
+|---------|:----------------:|:-------------------------:|
+| **Deployment** | | |
+| Disaggregated | ✅ | ✅ |
+| Aggregated | ✅ | ✅ |
+| **LLM Framework** | | |
+| SGLang | ✅ | ✅ |
+| TensorRT-LLM | ✅ | ✅ |
+| vLLM | ✅ | ✅ |
+| **Requires Pre-deployment Data** | No; recommended for faster warmup when native AIC is unavailable | No |
+| **Load Predictors** | ARIMA, Prophet, Kalman, Constant | — |
+| **Router** | | |
+| Standard routing (round-robin, random, etc.) | ✅ | ✅ |
+| KV-aware routing | ✅ | ✅ |
+| **Inference Optimizations** | | |
+| KV cache reuse | ✅ | ✅ |
+| Speculative decoding | ✅ | ✅ |
+| **Connectors** | | |
+| KubernetesConnector | ✅ | ✅ |
+| VirtualConnector | ✅ | ✅ |
+
+**Legend:** ✅ Supported; — Not applicable.
+
+Router mode does not constrain either scaling method. Load-based scaling consumes FPM directly from the engines through the Dynamo event plane, so it does not require the KV router. When runtime metrics are available, both scaling methods account for KV cache reuse through KV hit rate and speculative decoding through accepted tokens per forward pass. The Planner uses these signals for capacity estimates; it does not enable the engine features.
+
 ## Optimization Targets and Scaling Methods
 
 Planner configuration has two separate layers:
@@ -65,33 +92,6 @@ For `throughput`, `latency`, and `load`, the Planner enables load-based scaling,
 > **New to the Planner?** Start with the [Planner Guide](planner-guide.md) for a complete workflow including profiling and deployment.
 
 > **Need multi-DGD coordination?** See the [Global Planner Guide](global-planner-guide.md) for shared-policy coordination across multiple DGDs and single-endpoint multi-pool deployments.
-
-## Feature Matrix
-
-| Feature | Throughput-Based | Load-Based |
-|---------|:----------------:|:-------------------------:|
-| **Deployment** | | |
-| Disaggregated | ✅ | ✅ |
-| Aggregated | ✅ | ✅ |
-| **LLM Framework** | | |
-| SGLang | ✅ | ✅ |
-| TensorRT-LLM | ✅ | ✅ |
-| vLLM | ✅ | ✅ |
-| **Requires Pre-deployment Data** | No; recommended for faster warmup when native AIC is unavailable | No |
-| **Load Predictors** | ARIMA, Prophet, Kalman, Constant | — |
-| **Router** | | |
-| Standard routing (round-robin, random, etc.) | ✅ | ✅ |
-| KV-aware routing | ✅ | ✅ |
-| **Inference Optimizations** | | |
-| KV cache reuse | ✅ | ✅ |
-| Speculative decoding | ✅ | ✅ |
-| **Connectors** | | |
-| KubernetesConnector | ✅ | ✅ |
-| VirtualConnector | ✅ | ✅ |
-
-**Legend:** ✅ Supported; — Not applicable.
-
-Router mode does not constrain either scaling method. Load-based scaling consumes FPM directly from the engines through the Dynamo event plane, so it does not require the KV router. When runtime metrics are available, both scaling methods account for KV cache reuse through KV hit rate and speculative decoding through accepted tokens per forward pass. The Planner uses these signals for capacity estimates; it does not enable the engine features.
 
 ## When to Use Each Scaling Method
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
@@ -93,17 +93,12 @@ For `throughput`, `latency`, and `load`, the Planner enables load-based scaling,
 
 > **Need multi-DGD coordination?** See the [Global Planner Guide](global-planner-guide.md) for shared-policy coordination across multiple DGDs and single-endpoint multi-pool deployments.
 
-## Choose a Target Without a Specific SLA
+## Choose an Optimization Target
 
-Choose the default `throughput` target for a balance of throughput and GPU use, or choose `latency` to scale up earlier and keep queues shorter. Both targets use load-based scaling automatically, with no SLA values or profiling data required.
+- **Without a specific SLA:** Choose the default `throughput` target for a balance of throughput and GPU use, or choose `latency` to scale up earlier and keep queues shorter. Both targets use load-based scaling automatically, with no SLA values or profiling data required.
+- **With a specific SLA:** Choose the `sla` target and enable throughput-based and load-based scaling together. Throughput-based scaling provides a stable capacity floor, while load-based scaling responds to bursts above that floor. Native AIC or bootstrap FPMs make the performance model ready sooner; otherwise it warms from live FPMs.
 
-For topology, target, runtime environment, and dependency decisions, see [Choose a Planner Mode](choose-planner-mode.md).
-
-## Choose a Target With a Specific SLA
-
-Choose the `sla` target and enable throughput-based and load-based scaling together. Throughput-based scaling provides a stable capacity floor, while load-based scaling responds to bursts above that floor. Native AIC or bootstrap FPMs make the performance model ready sooner; otherwise it warms from live FPMs.
-
-For the complete decision path and a recommended SLA configuration, see [Choose a Planner Mode](choose-planner-mode.md).
+For topology, target, runtime environment, dependencies, and a recommended SLA configuration, see [Choose a Planner Mode](choose-planner-mode.md).
 
 ## Quick Start
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
@@ -49,20 +49,27 @@ When both modes are enabled, throughput-based scaling provides a capacity floor 
 | Feature | Throughput-Based | Load-Based |
 |---------|:----------------:|:-------------------------:|
 | **Deployment** | | |
-| Disaggregated | Supported | Supported |
-| Aggregated | Supported | Supported |
+| Disaggregated | ✅ | ✅ |
+| Aggregated | ✅ | ✅ |
 | **LLM Framework** | | |
-| SGLang | Supported | Supported |
-| TensorRT-LLM | Supported | Supported |
-| vLLM | Supported | Supported |
+| SGLang | ✅ | ✅ |
+| TensorRT-LLM | ✅ | ✅ |
+| vLLM | ✅ | ✅ |
 | **Requires Pre-deployment Data** | No; recommended for faster warmup when native AIC is unavailable | No |
-| **Load Predictors** | ARIMA, Prophet, Kalman, Constant | N/A |
+| **Load Predictors** | ARIMA, Prophet, Kalman, Constant | — |
 | **Router** | | |
-| Any (round-robin, random, etc.) | Supported | Not supported |
-| KV Router | Supported | Supported |
+| Standard routing (round-robin, random, etc.) | ✅ | ✅ |
+| KV-aware routing | ✅ | ✅ |
+| **Inference Optimizations** | | |
+| KV cache reuse | ✅ | ✅ |
+| Speculative decoding | ✅ | ✅ |
 | **Connectors** | | |
-| KubernetesConnector | Supported | Supported |
-| VirtualConnector | Supported | Supported |
+| KubernetesConnector | ✅ | ✅ |
+| VirtualConnector | ✅ | ✅ |
+
+**Legend:** ✅ Supported; — Not applicable.
+
+Router mode does not constrain either scaling mode. Load-based scaling consumes FPM directly from the engines through the Dynamo event plane, so it does not require the KV router. When runtime metrics are available, both scaling modes account for KV cache reuse through KV hit rate and speculative decoding through accepted tokens per forward pass. The Planner uses these signals for capacity estimates; it does not enable the engine features.
 
 ## When to Use Which Mode
 


### PR DESCRIPTION
## Summary

- add a **Choose a Planner Mode** guide covering deployment topology, optimization targets, SLA scaling methods, runtime environments, dependencies, and advisory validation
- split the Planner overview guidance into paths for users with and without specific TTFT/ITL SLAs
- define optimization targets separately from scaling methods and document their valid combinations
- replace repeated `Supported` labels with a compact support legend and check marks
- correct the stale router restriction for load-based scaling, which now consumes engine FPM through the Dynamo event plane
- document KV cache reuse and speculative decoding support in both scaling methods
- clarify that Planner accounts for KV hit rate and speculative accept length but does not enable those engine features

## Validation

- `python3 docs/fern/scripts/docs_lint.py docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/choose-planner-mode.md`
- `python3 docs/fern/scripts/check_asset_paths.py`
- `python -m pytest -q components/src/dynamo/planner/tests/unit/test_engine_query.py::test_decode_capacity_applies_accept_length components/src/dynamo/planner/tests/unit/test_engine_query.py::test_prefill_capacity_kv_hit_rate_discounts_compute components/src/dynamo/planner/tests/plugins/orchestrator/test_engine_adapter.py::test_load_only_sla_uses_kv_hit_rate_traffic_scrape`
- Fern draft preview generation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Planner mode selection guide covering supported modes, deployment options, scaling behavior, runtime environments, validation, and configuration examples.
  - Expanded the Planner overview with a feature matrix and clearer guidance on optimization targets, scaling methods, prerequisites, and quick-start configurations.
  - Added navigation links to the new Planner mode guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->