### PR TITLE
docs(operator): drop the checkpoint link the Snapshot migration deleted (OPS-8536)

### DIFF
--- a/deploy/operator/docs/footer.md
+++ b/deploy/operator/docs/footer.md
@@ -344,7 +344,6 @@ For users who want to understand the implementation details or contribute to the
 - **Checkpoint / Restore**:
   - [`internal/checkpoint/podspec.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/podspec.go) - Checkpoint env var injection and volume setup
   - [`internal/checkpoint/resolve.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resolve.go) - Checkpoint resolution logic
-  - [`internal/checkpoint/resource.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resource.go) - Checkpoint resource management
 - **Constants & Annotations**: [`internal/consts/consts.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/consts/consts.go) - Defines annotation keys and other constants
 
 ## Notes

--- a/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
+++ b/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
@@ -3865,7 +3865,6 @@ For users who want to understand the implementation details or contribute to the
 - **Checkpoint / Restore**:
   - [`internal/checkpoint/podspec.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/podspec.go) - Checkpoint env var injection and volume setup
   - [`internal/checkpoint/resolve.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resolve.go) - Checkpoint resolution logic
-  - [`internal/checkpoint/resource.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resource.go) - Checkpoint resource management
 - **Constants & Annotations**: [`internal/consts/consts.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/consts/consts.go) - Defines annotation keys and other constants
 
 ## Notes

--- a/docs/fern/pages/reference/kubernetes-api/full-api-reference.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/full-api-reference.mdx
@@ -5079,7 +5079,6 @@ For users who want to understand the implementation details or contribute to the
 - **Checkpoint / Restore**:
   - [`internal/checkpoint/podspec.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/podspec.go) - Checkpoint env var injection and volume setup
   - [`internal/checkpoint/resolve.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resolve.go) - Checkpoint resolution logic
-  - [`internal/checkpoint/resource.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resource.go) - Checkpoint resource management
 - **Constants & Annotations**: [`internal/consts/consts.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/consts/consts.go) - Defines annotation keys and other constants
 
 ### Notes


### PR DESCRIPTION
Linear: OPS-8536

## Summary

`lychee` is failing on **every open PR** with six errors, all the same 404:

```
https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resource.go
```

`internal/checkpoint/` still exists; `resource.go` does not. It was deleted by `337eeca8db`,
*feat(operator)!: migrate checkpoints to standalone Snapshot* (#14076), which removed the file
and left the documentation entry behind. The other two entries in that section — `podspec.go`
and `resolve.go` — are still correct.

## Change

One line, removed from three places. It lives in `footer.md` and reaches two generated pages:

| file | role |
|---|---|
| `deploy/operator/docs/footer.md` | source |
| `…/additional-resources/api-reference-k8s.md` | `cat header.md api_reference.md footer.md` (operator `Makefile:727`) |
| `…/kubernetes-api/full-api-reference.mdx` | rendered from the above by `gen_kubernetes_api.py` |

## How the generated files were updated

Running the full concatenation needs `crd-ref-docs` and the Go toolchain, which is not what
this change exercises. So instead:

1. Verified `footer.md` is a **verbatim suffix** of `api-reference-k8s.md` — the Makefile
   target is a plain `cat`, so this holds by construction.
2. Applied the identical one-line deletion to both, and confirmed the suffix property still
   holds afterwards. The result is byte-identical to what regeneration produces for this
   change.
3. Regenerated `full-api-reference.mdx` properly with `gen_kubernetes_api.py`, which reported
   it **stale** beforehand and **unchanged** after.

## Validation

- `gen_kubernetes_api.py --check` passes.
- `docs_lint.py --scan docs`: 440 files scanned, **0 errors**.
- pre-commit clean on all three files.
- Audited every repo-file link in `footer.md`: **13 links, 0** now pointing at a file that does
  not exist. This was the migration's only casualty in this document.

## Not fixed here

`Analyze Codebase (python)` is also red on every open PR, for an unrelated reason:
`CodeQL analyses from advanced configurations cannot be processed when the default setup is
enabled`. The analysis succeeds and only the upload is rejected — a repository CodeQL
configuration conflict rather than a code finding, so it needs a settings change rather than a
commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed outdated implementation reference links for checkpoint resource management from the operator and Kubernetes API documentation.
  - Updated generated API reference pages to no longer link to internal checkpoint/restore implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->