### PR TITLE
perf(mocker): reuse precise timerfds

### DIFF
--- a/lib/mocker/src/common/utils.rs
+++ b/lib/mocker/src/common/utils.rs
@@ -3,6 +3,9 @@
 
 use std::time::{Duration, Instant};
 
+#[cfg(target_os = "linux")]
+use std::sync::Once;
+
 use aisimulate_core::engine::{WorkerType as EngineWorkerType, prefill_handoff_delay_ms};
 
 use crate::common::handoff::HandoffTransferTiming;
@@ -80,32 +83,162 @@ pub async fn sleep_precise(duration: Duration) {
     sleep_until_precise(Instant::now() + duration).await;
 }
 
+#[cfg(target_os = "linux")]
+enum PreciseTimerState {
+    Uninitialized,
+    Ready(tokio_timerfd::Delay),
+    // A timerfd error permanently selects Tokio for this timer instance.
+    Disabled,
+}
+
+#[cfg(target_os = "linux")]
+static TIMERFD_FALLBACK_WARNING: Once = Once::new();
+
+#[cfg(all(test, target_os = "linux"))]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TimerTestMode {
+    Tokio,
+    TimerFd,
+    FailCreation,
+}
+
+pub(crate) struct ReusablePreciseTimer {
+    #[cfg(target_os = "linux")]
+    state: PreciseTimerState,
+    #[cfg(all(test, target_os = "linux"))]
+    test_mode: TimerTestMode,
+    #[cfg(all(test, target_os = "linux"))]
+    timerfd_create_attempts: usize,
+}
+
+impl Default for ReusablePreciseTimer {
+    fn default() -> Self {
+        Self {
+            #[cfg(target_os = "linux")]
+            state: PreciseTimerState::Uninitialized,
+            #[cfg(all(test, target_os = "linux"))]
+            test_mode: TimerTestMode::Tokio,
+            #[cfg(all(test, target_os = "linux"))]
+            timerfd_create_attempts: 0,
+        }
+    }
+}
+
+impl ReusablePreciseTimer {
+    pub(crate) async fn sleep_until(&mut self, deadline: Instant) {
+        #[cfg(all(test, target_os = "linux"))]
+        if self.test_mode == TimerTestMode::Tokio {
+            sleep_until_tokio(deadline).await;
+            return;
+        }
+
+        if deadline <= Instant::now() {
+            tokio::task::yield_now().await;
+            return;
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            match self.arm_timerfd(deadline) {
+                Ok(true) => {}
+                Ok(false) => {
+                    sleep_until_tokio(deadline).await;
+                    return;
+                }
+                Err(error) => {
+                    self.disable_timerfd(&error);
+                    sleep_until_tokio(deadline).await;
+                    return;
+                }
+            }
+
+            let result = match &mut self.state {
+                PreciseTimerState::Ready(delay) => Some(delay.await),
+                PreciseTimerState::Uninitialized | PreciseTimerState::Disabled => None,
+            };
+            match result {
+                Some(Ok(())) => {}
+                Some(Err(error)) => {
+                    self.disable_timerfd(&error);
+                    sleep_until_tokio(deadline).await;
+                }
+                None => sleep_until_tokio(deadline).await,
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        sleep_until_tokio(deadline).await;
+    }
+
+    #[cfg(target_os = "linux")]
+    fn arm_timerfd(&mut self, deadline: Instant) -> std::io::Result<bool> {
+        match &mut self.state {
+            PreciseTimerState::Uninitialized => {
+                #[cfg(test)]
+                {
+                    self.timerfd_create_attempts += 1;
+                    if self.test_mode == TimerTestMode::FailCreation {
+                        return Err(std::io::Error::other("injected timerfd creation failure"));
+                    }
+                }
+                self.state = PreciseTimerState::Ready(tokio_timerfd::Delay::new(deadline)?);
+                Ok(true)
+            }
+            PreciseTimerState::Ready(delay) => {
+                delay.reset(deadline);
+                Ok(true)
+            }
+            PreciseTimerState::Disabled => Ok(false),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn disable_timerfd(&mut self, error: &std::io::Error) {
+        self.state = PreciseTimerState::Disabled;
+        TIMERFD_FALLBACK_WARNING.call_once(|| {
+            tracing::warn!(
+                error = %error,
+                "precise timerfd failed; using Tokio for this timer"
+            );
+        });
+    }
+
+    #[cfg(all(test, target_os = "linux"))]
+    pub(crate) fn with_timerfd_for_test() -> Self {
+        Self {
+            test_mode: TimerTestMode::TimerFd,
+            ..Self::default()
+        }
+    }
+
+    #[cfg(all(test, target_os = "linux"))]
+    fn with_timerfd_creation_failure() -> Self {
+        Self {
+            test_mode: TimerTestMode::FailCreation,
+            ..Self::default()
+        }
+    }
+
+    #[cfg(all(test, target_os = "linux"))]
+    pub(crate) fn timerfd_create_attempts(&self) -> usize {
+        self.timerfd_create_attempts
+    }
+}
+
+async fn sleep_until_tokio(deadline: Instant) {
+    if deadline <= Instant::now() {
+        tokio::task::yield_now().await;
+    } else {
+        tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
+    }
+}
+
 /// Sleep until the specified deadline using timerfd on Linux for precision.
 ///
 /// Unlike `sleep_precise`, this accounts for time already elapsed since the
 /// deadline's reference point, making it suitable for simulation loops where
 /// computation time should be subtracted from the sleep.
 pub async fn sleep_until_precise(deadline: Instant) {
-    // Scheduler work may consume the modeled delay, especially at high speedup ratios. Avoid
-    // allocating and registering a timerfd when there is no remaining time to sleep. Preserve
-    // the scheduler loop's cooperative yield so other tasks on the runtime can make progress.
-    if deadline <= Instant::now() {
-        tokio::task::yield_now().await;
-        return;
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        if let Ok(delay) = tokio_timerfd::Delay::new(deadline) {
-            let _ = delay.await;
-        } else {
-            tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
-        }
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
-    }
+    ReusablePreciseTimer::default().sleep_until(deadline).await;
 }
 
 #[cfg(test)]
@@ -122,6 +255,70 @@ mod tests {
 
         assert!(matches!(first_poll, Poll::Pending));
         sleep.await;
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test(flavor = "current_thread")]
+    async fn reusable_precise_timer_reuses_its_timerfd() {
+        let mut timer = ReusablePreciseTimer::with_timerfd_for_test();
+
+        for _ in 0..2 {
+            let started = Instant::now();
+            let deadline = started + Duration::from_millis(5);
+            tokio::time::timeout(Duration::from_secs(1), timer.sleep_until(deadline))
+                .await
+                .expect("reusable precise timer did not complete");
+            assert!(started.elapsed() >= Duration::from_millis(1));
+        }
+
+        assert_eq!(timer.timerfd_create_attempts(), 1);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test(flavor = "current_thread")]
+    async fn reusable_precise_timer_rearms_after_cancelled_wait_expires() {
+        let mut timer = ReusablePreciseTimer::with_timerfd_for_test();
+        let cancelled_deadline = Instant::now() + Duration::from_millis(50);
+        {
+            let wait = timer.sleep_until(cancelled_deadline);
+            tokio::pin!(wait);
+            tokio::select! {
+                biased;
+                _ = tokio::time::sleep(Duration::from_millis(2)) => {}
+                _ = &mut wait => panic!("the cancelled wait completed early"),
+            }
+        }
+
+        tokio::time::sleep_until(tokio::time::Instant::from_std(
+            cancelled_deadline + Duration::from_millis(5),
+        ))
+        .await;
+
+        let rearmed_at = Instant::now();
+        let rearmed_deadline = rearmed_at + Duration::from_millis(30);
+        tokio::time::timeout(Duration::from_secs(1), timer.sleep_until(rearmed_deadline))
+            .await
+            .expect("rearmed precise timer did not complete");
+
+        assert!(
+            rearmed_at.elapsed() >= Duration::from_millis(20),
+            "the old unread expiration completed the rearmed wait early"
+        );
+        assert_eq!(timer.timerfd_create_attempts(), 1);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test(flavor = "current_thread")]
+    async fn reusable_precise_timer_latches_creation_failure() {
+        let mut timer = ReusablePreciseTimer::with_timerfd_creation_failure();
+
+        for _ in 0..2 {
+            let started = Instant::now();
+            timer.sleep_until(started + Duration::from_millis(2)).await;
+            assert!(started.elapsed() >= Duration::from_millis(1));
+        }
+
+        assert_eq!(timer.timerfd_create_attempts(), 1);
     }
 
     #[test]

--- a/lib/mocker/src/generalized_live.rs
+++ b/lib/mocker/src/generalized_live.rs
@@ -34,6 +34,8 @@ use tokio_util::sync::CancellationToken;
 #[cfg(test)]
 use uuid::Uuid;
 
+use crate::common::utils::ReusablePreciseTimer;
+
 /// Engine type driven by the native live runtime.
 pub type GroupedEngine = GeneralizedMockerEngine<SchedulerRank>;
 
@@ -704,65 +706,8 @@ fn command_can_apply_during_pass(command: &Command) -> bool {
     )
 }
 
-#[derive(Default)]
-struct ReusablePreciseTimer {
-    #[cfg(target_os = "linux")]
-    delay: Option<tokio_timerfd::Delay>,
-    #[cfg(all(test, target_os = "linux"))]
-    timerfd_creations: usize,
-}
-
-impl ReusablePreciseTimer {
-    async fn sleep_until(&mut self, deadline: std::time::Instant) {
-        if deadline <= std::time::Instant::now() {
-            tokio::task::yield_now().await;
-            return;
-        }
-
-        #[cfg(target_os = "linux")]
-        {
-            if let Some(delay) = self.delay.as_mut() {
-                delay.reset(deadline);
-            } else {
-                match tokio_timerfd::Delay::new(deadline) {
-                    Ok(delay) => {
-                        self.delay = Some(delay);
-                        #[cfg(test)]
-                        {
-                            self.timerfd_creations += 1;
-                        }
-                    }
-                    Err(_) => {
-                        tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
-                        return;
-                    }
-                }
-            }
-
-            let result = self
-                .delay
-                .as_mut()
-                .expect("timerfd delay must exist after initialization")
-                .await;
-            if result.is_err() {
-                self.delay = None;
-                tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
-            }
-        }
-        #[cfg(not(target_os = "linux"))]
-        {
-            tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
-        }
-    }
-
-    #[cfg(all(test, target_os = "linux"))]
-    fn timerfd_creations(&self) -> usize {
-        self.timerfd_creations
-    }
-}
-
 async fn sleep_until_ms(
-    _timer: &mut ReusablePreciseTimer,
+    timer: &mut ReusablePreciseTimer,
     origin: Instant,
     deadline_ms: Option<f64>,
 ) {
@@ -771,10 +716,7 @@ async fn sleep_until_ms(
         return;
     };
     let deadline = origin + Duration::from_secs_f64(deadline_ms.max(0.0) / 1_000.0);
-    #[cfg(test)]
-    tokio::time::sleep_until(deadline).await;
-    #[cfg(not(test))]
-    _timer.sleep_until(deadline.into_std()).await;
+    timer.sleep_until(deadline.into_std()).await;
 }
 
 #[cfg(test)]
@@ -789,54 +731,6 @@ mod tests {
     };
 
     use super::*;
-
-    #[cfg(target_os = "linux")]
-    #[tokio::test(flavor = "current_thread")]
-    async fn reusable_precise_timer_reuses_its_timerfd() {
-        let mut timer = ReusablePreciseTimer::default();
-
-        for _ in 0..2 {
-            let deadline = std::time::Instant::now() + Duration::from_millis(2);
-            tokio::time::timeout(Duration::from_secs(1), timer.sleep_until(deadline))
-                .await
-                .expect("reusable precise timer did not complete");
-        }
-
-        assert_eq!(timer.timerfd_creations(), 1);
-    }
-
-    #[cfg(target_os = "linux")]
-    #[tokio::test(flavor = "current_thread")]
-    async fn reusable_precise_timer_rearms_after_cancelled_wait_expires() {
-        let mut timer = ReusablePreciseTimer::default();
-        let cancelled_deadline = std::time::Instant::now() + Duration::from_millis(50);
-        {
-            let wait = timer.sleep_until(cancelled_deadline);
-            tokio::pin!(wait);
-            tokio::select! {
-                biased;
-                _ = tokio::time::sleep(Duration::from_millis(2)) => {}
-                _ = &mut wait => panic!("the cancelled wait completed early"),
-            }
-        }
-
-        tokio::time::sleep_until(tokio::time::Instant::from_std(
-            cancelled_deadline + Duration::from_millis(5),
-        ))
-        .await;
-
-        let rearmed_at = std::time::Instant::now();
-        let rearmed_deadline = rearmed_at + Duration::from_millis(30);
-        tokio::time::timeout(Duration::from_secs(1), timer.sleep_until(rearmed_deadline))
-            .await
-            .expect("rearmed precise timer did not complete");
-
-        assert!(
-            rearmed_at.elapsed() >= Duration::from_millis(20),
-            "the old unread expiration completed the rearmed wait early"
-        );
-        assert_eq!(timer.timerfd_creations(), 1);
-    }
 
     fn request(id: u128, prompt_len: usize, output_len: usize) -> Request {
         Request {
@@ -1381,6 +1275,61 @@ mod tests {
 
         handle.shutdown();
         actor.await.unwrap().unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test(flavor = "current_thread")]
+    async fn pass_boundary_uses_reusable_timerfd() {
+        let mut engine = EngineFactory::new(EngineConfig {
+            num_gpu_blocks: 128,
+            block_size: 4,
+            max_num_seqs: 8,
+            max_num_batched_tokens: 256,
+            timing_model: TimingModelConfig::Fixed {
+                prefill_ms: 5.0,
+                decode_ms: 0.0,
+            },
+            ..EngineConfig::default()
+        })
+        .unwrap()
+        .build(EngineIdentity::new(7), NonZeroU32::new(1).unwrap())
+        .unwrap();
+        engine
+            .apply_command_effects(
+                SchedulerCommand::new(0, Command::Submit(request(12, 4, 2))),
+                0.0,
+            )
+            .unwrap();
+        let started = engine.execute_pass(0.0).unwrap().unwrap();
+
+        let (_command_tx, command_rx) = mpsc::channel(1);
+        let (_cancellation_tx, cancellation_rx) = mpsc::channel(1);
+        let (event_tx, _events) = mpsc::channel(1);
+        let mut actor = GroupedLiveActor {
+            engine,
+            command_rx,
+            cancellation_rx,
+            event_tx,
+            cancel_token: CancellationToken::new(),
+            clock_origin: Instant::now(),
+            deferred_commands: VecDeque::new(),
+            engine_time_ms: 0.0,
+            next_pass_deadline_ms: Some(started.end_ms),
+        };
+        let mut pass_timer = ReusablePreciseTimer::with_timerfd_for_test();
+        let mut internal_timer = ReusablePreciseTimer::default();
+        let waited_at = std::time::Instant::now();
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            actor.wait_for_pass_boundary(started.end_ms, &mut pass_timer, &mut internal_timer),
+        )
+        .await
+        .expect("pass boundary did not complete")
+        .unwrap();
+
+        assert!(waited_at.elapsed() >= Duration::from_millis(1));
+        assert_eq!(pass_timer.timerfd_create_attempts(), 1);
     }
 
     #[tokio::test(start_paused = true)]

--- a/lib/mocker/src/generalized_live.rs
+++ b/lib/mocker/src/generalized_live.rs
@@ -34,9 +34,6 @@ use tokio_util::sync::CancellationToken;
 #[cfg(test)]
 use uuid::Uuid;
 
-#[cfg(not(test))]
-use crate::common::utils::sleep_until_precise;
-
 /// Engine type driven by the native live runtime.
 pub type GroupedEngine = GeneralizedMockerEngine<SchedulerRank>;
 
@@ -375,6 +372,8 @@ impl GroupedLiveActor {
     }
 
     async fn run_until_stopped(&mut self) -> Result<()> {
+        let mut pass_timer = ReusablePreciseTimer::default();
+        let mut internal_timer = ReusablePreciseTimer::default();
         loop {
             if self.cancel_token.is_cancelled() {
                 return Ok(());
@@ -383,7 +382,7 @@ impl GroupedLiveActor {
             self.process_due_internal_work().await?;
             if !self.engine.is_ready() {
                 self.next_pass_deadline_ms = None;
-                if !self.wait_for_idle_work().await? {
+                if !self.wait_for_idle_work(&mut internal_timer).await? {
                     return Ok(());
                 }
                 continue;
@@ -413,7 +412,10 @@ impl GroupedLiveActor {
             let zero_duration = end_ms <= started_at_ms;
             self.publish(GroupedLiveEvent::PassStarted(started)).await?;
 
-            if !self.wait_for_pass_boundary(end_ms).await? {
+            if !self
+                .wait_for_pass_boundary(end_ms, &mut pass_timer, &mut internal_timer)
+                .await?
+            {
                 return Ok(());
             }
             let completed_at_ms = self.advance_engine_time(end_ms);
@@ -538,9 +540,12 @@ impl GroupedLiveActor {
         }
     }
 
-    async fn wait_for_idle_work(&mut self) -> Result<bool> {
+    async fn wait_for_idle_work(
+        &mut self,
+        internal_timer: &mut ReusablePreciseTimer,
+    ) -> Result<bool> {
         let deadline_ms = self.engine.next_internal_deadline_ms();
-        let deadline = sleep_until_ms(self.clock_origin, deadline_ms);
+        let deadline = sleep_until_ms(internal_timer, self.clock_origin, deadline_ms);
         tokio::pin!(deadline);
         tokio::select! {
             biased;
@@ -584,13 +589,19 @@ impl GroupedLiveActor {
         Ok(())
     }
 
-    async fn wait_for_pass_boundary(&mut self, end_ms: f64) -> Result<bool> {
-        let pass_deadline = sleep_until_ms(self.clock_origin, Some(end_ms));
+    async fn wait_for_pass_boundary(
+        &mut self,
+        end_ms: f64,
+        pass_timer: &mut ReusablePreciseTimer,
+        internal_timer: &mut ReusablePreciseTimer,
+    ) -> Result<bool> {
+        let pass_deadline = sleep_until_ms(pass_timer, self.clock_origin, Some(end_ms));
         tokio::pin!(pass_deadline);
         let mut accept_commands = true;
         loop {
             let internal_deadline_ms = self.engine.next_internal_deadline_ms();
-            let internal_deadline = sleep_until_ms(self.clock_origin, internal_deadline_ms);
+            let internal_deadline =
+                sleep_until_ms(internal_timer, self.clock_origin, internal_deadline_ms);
             tokio::pin!(internal_deadline);
             tokio::select! {
                 biased;
@@ -693,7 +704,68 @@ fn command_can_apply_during_pass(command: &Command) -> bool {
     )
 }
 
-async fn sleep_until_ms(origin: Instant, deadline_ms: Option<f64>) {
+#[derive(Default)]
+struct ReusablePreciseTimer {
+    #[cfg(target_os = "linux")]
+    delay: Option<tokio_timerfd::Delay>,
+    #[cfg(all(test, target_os = "linux"))]
+    timerfd_creations: usize,
+}
+
+impl ReusablePreciseTimer {
+    async fn sleep_until(&mut self, deadline: std::time::Instant) {
+        if deadline <= std::time::Instant::now() {
+            tokio::task::yield_now().await;
+            return;
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            if let Some(delay) = self.delay.as_mut() {
+                delay.reset(deadline);
+            } else {
+                match tokio_timerfd::Delay::new(deadline) {
+                    Ok(delay) => {
+                        self.delay = Some(delay);
+                        #[cfg(test)]
+                        {
+                            self.timerfd_creations += 1;
+                        }
+                    }
+                    Err(_) => {
+                        tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
+                        return;
+                    }
+                }
+            }
+
+            let result = self
+                .delay
+                .as_mut()
+                .expect("timerfd delay must exist after initialization")
+                .await;
+            if result.is_err() {
+                self.delay = None;
+                tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
+        }
+    }
+
+    #[cfg(all(test, target_os = "linux"))]
+    fn timerfd_creations(&self) -> usize {
+        self.timerfd_creations
+    }
+}
+
+async fn sleep_until_ms(
+    _timer: &mut ReusablePreciseTimer,
+    origin: Instant,
+    deadline_ms: Option<f64>,
+) {
     let Some(deadline_ms) = deadline_ms else {
         std::future::pending::<()>().await;
         return;
@@ -702,7 +774,7 @@ async fn sleep_until_ms(origin: Instant, deadline_ms: Option<f64>) {
     #[cfg(test)]
     tokio::time::sleep_until(deadline).await;
     #[cfg(not(test))]
-    sleep_until_precise(deadline.into_std()).await;
+    _timer.sleep_until(deadline.into_std()).await;
 }
 
 #[cfg(test)]
@@ -717,6 +789,54 @@ mod tests {
     };
 
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test(flavor = "current_thread")]
+    async fn reusable_precise_timer_reuses_its_timerfd() {
+        let mut timer = ReusablePreciseTimer::default();
+
+        for _ in 0..2 {
+            let deadline = std::time::Instant::now() + Duration::from_millis(2);
+            tokio::time::timeout(Duration::from_secs(1), timer.sleep_until(deadline))
+                .await
+                .expect("reusable precise timer did not complete");
+        }
+
+        assert_eq!(timer.timerfd_creations(), 1);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test(flavor = "current_thread")]
+    async fn reusable_precise_timer_rearms_after_cancelled_wait_expires() {
+        let mut timer = ReusablePreciseTimer::default();
+        let cancelled_deadline = std::time::Instant::now() + Duration::from_millis(50);
+        {
+            let wait = timer.sleep_until(cancelled_deadline);
+            tokio::pin!(wait);
+            tokio::select! {
+                biased;
+                _ = tokio::time::sleep(Duration::from_millis(2)) => {}
+                _ = &mut wait => panic!("the cancelled wait completed early"),
+            }
+        }
+
+        tokio::time::sleep_until(tokio::time::Instant::from_std(
+            cancelled_deadline + Duration::from_millis(5),
+        ))
+        .await;
+
+        let rearmed_at = std::time::Instant::now();
+        let rearmed_deadline = rearmed_at + Duration::from_millis(30);
+        tokio::time::timeout(Duration::from_secs(1), timer.sleep_until(rearmed_deadline))
+            .await
+            .expect("rearmed precise timer did not complete");
+
+        assert!(
+            rearmed_at.elapsed() >= Duration::from_millis(20),
+            "the old unread expiration completed the rearmed wait early"
+        );
+        assert_eq!(timer.timerfd_creations(), 1);
+    }
 
     fn request(id: u128, prompt_len: usize, output_len: usize) -> Request {
         Request {
@@ -1321,7 +1441,14 @@ mod tests {
             engine_time_ms: 0.0,
             next_pass_deadline_ms: None,
         };
-        assert!(actor.wait_for_pass_boundary(started.end_ms).await.unwrap());
+        let mut pass_timer = ReusablePreciseTimer::default();
+        let mut internal_timer = ReusablePreciseTimer::default();
+        assert!(
+            actor
+                .wait_for_pass_boundary(started.end_ms, &mut pass_timer, &mut internal_timer,)
+                .await
+                .unwrap()
+        );
         response
             .try_recv()
             .expect("queued cancellation must be applied before the overdue boundary")


### PR DESCRIPTION
## Summary

Reuse Linux timerfds in the grouped live mocker instead of creating and
destroying a timerfd for almost every modeled wait.

This reduces mocker kernel overhead without changing modeled deadlines,
cancellation priority, catch-up behavior, output timing, or public interfaces.

## Details

- Add two actor-local reusable timers: one for pass boundaries and one for
  internal work.
- Create each timerfd lazily on its first positive wait and use `Delay::reset()`
  for later deadlines.
- Keep the pass timer armed while control or internal-work branches run.
- Keep the existing cooperative yield for expired deadlines.
- On timerfd creation or I/O failure, warn once per process and permanently use
  Tokio timing for that timer instance.
- Share the timer implementation with the existing one-shot precise-sleep
  helpers. Non-Linux behavior remains unchanged.

Each actor can lazily create at most two timerfds because pass and internal-work
deadlines can be active together. The benchmark observed one timerfd per active
worker.

## Performance

Hecate SPX, one five-node allocation with full teardown between arms. The test
used 2,048 mock workers across three nodes, speedup ratio 10, AgentX-336,
AIPerf concurrency 6,144, KV routing, replica sync, TCP/Ethernet, and a
120-second measurement.

| Metric | Exact base | Reusable timerfd | Change |
|---|---:|---:|---:|
| Sent throughput | 1,914.2 req/s | 2,470.6 req/s | +29.1% |
| Mocker occupied cores | 294.9 | 59.4 | -79.9% |
| Mocker system CPU/request | 140.78 ms | 9.76 ms | -93.1% |
| Mocker total CPU/request | 154.04 ms | 24.04 ms | -84.4% |
| Mocker total CPU/output token | 0.2380 ms | 0.03431 ms | -85.6% |

Timer-associated `queued_spin_lock_slowpath` stacks fell from 28.894% of
historical exact-base kernel samples to at most 0.0393% in the candidate, a
99.86% reduction. Candidate samples contained no grouped-actor
`Delay::new`, `timerfd_create`, VFS inode creation, epoll lifecycle, or
close/dput lifecycle stacks. Timerfd counts stayed fixed at one per active
worker during load and returned to zero after teardown.

The profile lost zero samples and had at most 1.24% unresolved frames. The
profiled candidate reproduced the clean result at 2,488.3 requests/s and
23.66 ms mocker CPU/request.

Raw user CPU/request increased by 7.7%, while output tokens/request increased
by 8.2%. User CPU/output token decreased by 0.5%.

The candidate AIPerf export covered 82.3% of completed requests, versus 100%
for the control. The CPU comparison is matched, but latency percentiles from
this run are characterization only. Both arms contained the existing HTTP 500
request-timeout class; this change added no new error class.

The Hecate build tested the equivalent patch at
`ffbe0d6990f0aefc671312551b160d1ec462c8f1`, based on
`749b57222a1a227d2d8e72b8f53d781f9ae20783`. This PR rebases that isolated
change onto `2c92a88896e5d979418ce0853b17a4234ecedc58`.

## Where should the reviewer start?

Start with `ReusablePreciseTimer` in `lib/mocker/src/common/utils.rs`, then see
the two timer slots in `GroupedLiveActor::run_until_stopped()`.

## Validation

- `cargo test -p dynamo-mocker --lib` (209 passed)
- `cargo check -p dynamo-mocker --all-targets`
- `cargo clippy -p dynamo-mocker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Hecate user/kernel profile of both mocker NUMA domains

## Related Issues

**This PR is not linked to an issue:**

- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved timing precision and efficiency during live execution.
  * Reused timing resources to reduce overhead across repeated waits.
  * Improved responsiveness when handling interrupted or rearmed deadlines.

* **Reliability**
  * Added fallback timing behavior for environments where precise timers are unavailable.
  * Improved handling of expired deadlines so execution can continue promptly.
  * Added coverage for timer reuse and correct behavior after interrupted waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
