### PR TITLE
ci: force JavaScript actions to Node 24

### DIFF
--- a/.github/workflows/allure-report.yml
+++ b/.github/workflows/allure-report.yml
@@ -23,6 +23,9 @@ on:
         type: string
         default: 'dev'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   resolve-params:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-dep-upgrade-complete.yml
+++ b/.github/workflows/auto-dep-upgrade-complete.yml
@@ -14,6 +14,9 @@ permissions:
   pull-requests: write
   actions: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   finalize:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-dep-upgrade-trigger.yml
+++ b/.github/workflows/auto-dep-upgrade-trigger.yml
@@ -18,6 +18,9 @@ permissions:
   contents: write
   actions:  write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   upgrade:
     name: ${{ matrix.framework }}

--- a/.github/workflows/build-on-demand.yml
+++ b/.github/workflows/build-on-demand.yml
@@ -22,31 +22,12 @@ on:
         description: 'Build and push operator image, tagged with branch name'
         type: boolean
         default: false
-      test_node24_actions:
-        description: 'Verify Node 20 actions are forced onto Node 24'
-        type: boolean
-        default: false
 
 env:
   BUILDER_NAME: b-${{ github.run_id }}-${{ github.run_attempt }}
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-
-  node24-action-runtime-canary:
-    if: inputs.test_node24_actions
-    runs-on: prod-tester-amd-v2
-    container:
-      image: ubuntu:24.04
-    steps:
-      - name: Verify forced JavaScript action runtime
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
-        with:
-          script: |
-            core.info(`JavaScript action runtime: ${process.version}`)
-            if (!process.version.startsWith('v24.')) {
-              core.setFailed(`Expected Node 24, got ${process.version}`)
-            }
 
   init:
     runs-on: ubuntu-slim

--- a/.github/workflows/build-on-demand.yml
+++ b/.github/workflows/build-on-demand.yml
@@ -22,11 +22,31 @@ on:
         description: 'Build and push operator image, tagged with branch name'
         type: boolean
         default: false
+      test_node24_actions:
+        description: 'Verify Node 20 actions are forced onto Node 24'
+        type: boolean
+        default: false
 
 env:
   BUILDER_NAME: b-${{ github.run_id }}-${{ github.run_attempt }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+
+  node24-action-runtime-canary:
+    if: inputs.test_node24_actions
+    runs-on: prod-tester-amd-v2
+    container:
+      image: ubuntu:24.04
+    steps:
+      - name: Verify forced JavaScript action runtime
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
+        with:
+          script: |
+            core.info(`JavaScript action runtime: ${process.version}`)
+            if (!process.version.startsWith('v24.')) {
+              core.setFailed(`Expected Node 24, got ${process.version}`)
+            }
 
   init:
     runs-on: ubuntu-slim

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -19,6 +19,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   codeowners:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,9 @@ name: CodeQL
 on:
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   codeql:
     name: Analyze Codebase

--- a/.github/workflows/community-events-refresh.yml
+++ b/.github/workflows/community-events-refresh.yml
@@ -59,6 +59,9 @@ concurrency:
   group: community-events-refresh
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   refresh:
     name: Refresh community events

--- a/.github/workflows/compliance-base-drift.yml
+++ b/.github/workflows/compliance-base-drift.yml
@@ -42,6 +42,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   check-drift:
     runs-on: ubuntu-latest

--- a/.github/workflows/copyright-checks.yml
+++ b/.github/workflows/copyright-checks.yml
@@ -3,6 +3,9 @@ name: Copyright Checks
 on:
   pull_request
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   copyright-checks:
       runs-on: ubuntu-24.04

--- a/.github/workflows/dco_comment.yml
+++ b/.github/workflows/dco_comment.yml
@@ -8,6 +8,9 @@ permissions:
   issues: write
   checks: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   dco-comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   lychee:
     runs-on: ubuntu-latest

--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -72,6 +72,9 @@ on:
         required: false
 
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   image:
     uses: $/.github/workflows/shared-build-image.yml

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -69,6 +69,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   # Detect changed files for conditional job execution
   changed-files:

--- a/.github/workflows/generate-allure-report.yml
+++ b/.github/workflows/generate-allure-report.yml
@@ -26,6 +26,9 @@ permissions:
   contents: write
   actions: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   generate-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -19,6 +19,9 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -30,6 +30,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   # First-time bootstrap: Linear's `complete` targets an *existing* release, so
   # seed it first. Run this workflow manually once with command=sync and the

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -8,6 +8,9 @@ on:
       - synchronize
       - reopened
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   conventional-commits:
     name: Validate PR title and add label

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -34,6 +34,7 @@ permissions:
 
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   BUILDER_NAME: b-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -28,6 +28,9 @@ on:
       SLACK_NOTIFY_NIGHTLY_WEBHOOK_URL:
         required: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   notify-slack:
     name: Notify Slack

--- a/.github/workflows/nvskills-team-request.yml
+++ b/.github/workflows/nvskills-team-request.yml
@@ -16,6 +16,9 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   request:
     if: >

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -29,6 +29,9 @@ permissions:
   # workflow's token can't exceed the caller's, so this must be granted here.
   actions: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   # ============================================================================
   # DISPATCH CONFIG

--- a/.github/workflows/pr-xpu.yaml
+++ b/.github/workflows/pr-xpu.yaml
@@ -12,6 +12,9 @@ concurrency:
   group: pr-xpu-${{ github.ref_name }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
 
   # ============================================================================

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,6 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   BUILDER_NAME: b-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:

--- a/.github/workflows/pr_full_ci_reminder.yaml
+++ b/.github/workflows/pr_full_ci_reminder.yaml
@@ -17,6 +17,9 @@ name: PR Reminder Full CI Comment Bot
 on:
   pull_request_target:
     types: [opened]
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   pr_reminder:
     if: ${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -27,6 +27,9 @@ concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   changed-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,7 @@ permissions:
   contents: read
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
   ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
   AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}

--- a/.github/workflows/release_rc_announcement.yml
+++ b/.github/workflows/release_rc_announcement.yml
@@ -16,6 +16,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   announce-rc:
     name: Announce RC to Slack

--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -12,6 +12,9 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   team-request:
     uses: $/.github/workflows/nvskills-team-request.yml

--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -194,6 +194,9 @@ on:
         description: 'Baseline SBOM stem baked into the rendered Dockerfile (for the compliance-audit job)'
         value: ${{ jobs.build.outputs.baseline_sbom_file }}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/shared-build-sidecar.yml
+++ b/.github/workflows/shared-build-sidecar.yml
@@ -46,6 +46,9 @@ on:
         type: string
         default: ''
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     name: Build multi-arch cpu

--- a/.github/workflows/shared-compliance-audit.yml
+++ b/.github/workflows/shared-compliance-audit.yml
@@ -37,6 +37,9 @@ on:
         type: string
         default: ''
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   audit:
     name: Compliance audit

--- a/.github/workflows/shared-compliance.yml
+++ b/.github/workflows/shared-compliance.yml
@@ -43,6 +43,9 @@ on:
       AZURE_ACR_PASSWORD:
         required: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   compliance:
     strategy:

--- a/.github/workflows/shared-copy.yml
+++ b/.github/workflows/shared-copy.yml
@@ -48,6 +48,9 @@ on:
       AZURE_ACR_PASSWORD:
         required: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   copy-to-acr:
     permissions:

--- a/.github/workflows/shared-deploy-test.yml
+++ b/.github/workflows/shared-deploy-test.yml
@@ -31,6 +31,9 @@ on:
         type: string
         required: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   deploy-test:
     runs-on: prod-deploy-tester-v1

--- a/.github/workflows/shared-dgdr-deploy-test.yml
+++ b/.github/workflows/shared-dgdr-deploy-test.yml
@@ -32,6 +32,9 @@ on:
       DOCKERHUB_ACCESS_TOKEN:
         required: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   ensure-vcluster:
     name: Ensure vCluster

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -143,6 +143,9 @@ on:
       DD_API_KEY:
         required: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/stale_cleaner.yml
+++ b/.github/workflows/stale_cleaner.yml
@@ -21,6 +21,9 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_report.yaml
+++ b/.github/workflows/test_report.yaml
@@ -20,6 +20,9 @@ on:
     types:
       - completed
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test-results:
     name: Test Results

--- a/.github/workflows/trigger-ci-approval-flow.yml
+++ b/.github/workflows/trigger-ci-approval-flow.yml
@@ -63,6 +63,9 @@ permissions:
   issues: write
   pull-requests: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   ok-to-test:
     if: github.event.pull_request.head.repo.fork

--- a/.github/workflows/xpu-ci.yaml
+++ b/.github/workflows/xpu-ci.yaml
@@ -50,6 +50,7 @@ on:
         default: ''
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   FRAMEWORK: ${{ inputs.framework || 'vllm' }}
   TARGET: ${{ inputs.target || 'runtime' }}
   DEVICE: xpu


### PR DESCRIPTION
## Summary

- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` in all 40 existing Dynamo workflow definitions.
- Apply the setting directly in reusable workflows because workflow-level environment variables are not inherited across `workflow_call` boundaries.
- Force Node-20-declared JavaScript actions onto the Node 24 runtime already bundled with the current runners.

No synthetic canary job or test-only workflow remains in the proposed diff.

The runner's ARC Kubernetes hook still launches through `/home/runner/externals/node20/bin/node`; GitHub's force flag affects workflow JavaScript actions, not that infrastructure hook.

Tracks OPS-8394.

## Validation

- [Full existing PR pipeline](https://github.com/ai-dynamo/dynamo/actions/runs/33915028600)
  - Existing `tj-actions/changed-files` and `actions/upload-artifact` Node 20 actions were reported as forced onto Node 24.
  - Their jobs completed successfully.
- [Existing Build On Demand workflow](https://github.com/ai-dynamo/dynamo/actions/runs/33915033402) passed from the production-only revision on Actions Runner 2.336.0.
- Parsed all 40 workflow files as YAML.
- `python3 scripts/check_action_pins.py`
- `pre-commit run --files <all changed workflows>`
- `git diff --check`

Known unrelated CI failures:

- `dynamo-sidecar / Build multi-arch cpu`: its Docker build context omits `deploy/inference-gateway/sidecar/Cargo.toml`, which the root Cargo workspace references.
- `lychee`: existing repository links return 404, including `deploy/operator/internal/checkpoint/resource.go`; retry reproduced the failure.
