### PR TITLE
fix(benchmarking): [cherry-pick 1.5.0] disable self benchmarking with dense model + attention dp on vLLM (#14292)

### DIFF
--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -700,6 +700,19 @@ def setup_vllm_engine(
 
     # Pass benchmark config to InstrumentedScheduler via additional_config.
     if hasattr(config, "_benchmark_additional_config"):
+        # Dense DP ranks are independent vLLM engines and cannot synchronize a
+        # multi-rank self-benchmark. Reject before AsyncLLM starts those engines.
+        if (
+            vllm_config.parallel_config.data_parallel_size > 1
+            and not vllm_config.model_config.is_moe
+        ):
+            raise ValueError(
+                "--benchmark-mode cannot be combined with --data-parallel-size "
+                f"{vllm_config.parallel_config.data_parallel_size} on a dense "
+                "(non-MoE) model. The attention-DP self-benchmark requires an MoE "
+                "model because vLLM runs dense data-parallel ranks as independent "
+                "engines. Use --data-parallel-size 1 or benchmark an MoE model."
+            )
         bench = config._benchmark_additional_config
         if fpm_worker_id and bench["output_path"] == "/tmp/benchmark_results.json":
             short_id = fpm_worker_id[-8:]

--- a/docs/fern/pages/reference/backends/vllm-configuration.mdx
+++ b/docs/fern/pages/reference/backends/vllm-configuration.mdx
@@ -306,6 +306,7 @@ With `--benchmark-mode` set and no points file, passing a legacy flag together w
 ## Validation rules
 
 - `--embedding-worker` is only valid with `--disaggregation-mode=agg` (or the default aggregated mode) and cannot be combined with `--enable-multimodal` or `--benchmark-mode`.
+- `--benchmark-mode` cannot be combined with `--data-parallel-size` greater than `1` unless the model is a mixture-of-experts (MoE) model. The attention-DP self-benchmark needs the data-parallel ranks to run as one coordinated group, which vLLM does only for MoE models; the worker rejects this combination at startup, before it loads the model.
 
 ## Related pages
 


### PR DESCRIPTION
Cherry-pick of #14292 to release/1.5.0. Fixes DYN-3750 / NVBug 6556503: on vLLM a dense model with attention data parallelism triggers the FPM self-benchmark, which kills rank 1. Original author: @karen-sy.

Signed-off cherry-pick with `-x --signoff -m 1`.