### PR TITLE
fix(operator): [cherry-pick 1.5.0] preserve sparse v1alpha1 container fields (#14338)

### DIFF
--- a/deploy/operator/api/v1alpha1/marshal.go
+++ b/deploy/operator/api/v1alpha1/marshal.go
@@ -1,0 +1,136 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1alpha1
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+type dynamoGraphDeploymentForMarshal DynamoGraphDeployment
+
+// MarshalJSON serializes a DGD and removes native-container zero-value fields
+// introduced by the typed v1beta1-to-v1alpha1 conversion path.
+// Normalization stays at the root so ExtraPodSpec's historical JSON, which
+// participates in the legacy v1alpha1 worker hash, remains unchanged.
+func (d DynamoGraphDeployment) MarshalJSON() ([]byte, error) {
+	raw, err := json.Marshal(dynamoGraphDeploymentForMarshal(d))
+	if err != nil {
+		return nil, err
+	}
+
+	return normalizeDynamoGraphDeploymentJSON(raw)
+}
+
+type dynamoComponentDeploymentForMarshal DynamoComponentDeployment
+
+// MarshalJSON serializes a DCD and removes native-container zero-value fields
+// introduced by the typed v1beta1-to-v1alpha1 conversion path.
+// See DynamoGraphDeployment.MarshalJSON for why normalization is root-scoped.
+func (d DynamoComponentDeployment) MarshalJSON() ([]byte, error) {
+	raw, err := json.Marshal(dynamoComponentDeploymentForMarshal(d))
+	if err != nil {
+		return nil, err
+	}
+
+	return normalizeDynamoComponentDeploymentJSON(raw)
+}
+
+func normalizeDynamoGraphDeploymentJSON(raw []byte) ([]byte, error) {
+	// Decode the DGD into a mutable root before normalizing its service containers.
+	root, err := decodeV1alpha1JSONObject(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	// Limit normalization to service specs so unrelated DGD fields retain their encoding.
+	if spec, ok := root["spec"].(map[string]any); ok {
+		if services, ok := spec["services"].(map[string]any); ok {
+			for _, service := range services {
+				if serviceSpec, ok := service.(map[string]any); ok {
+					normalizeV1alpha1ExtraPodSpecJSON(serviceSpec)
+				}
+			}
+		}
+	}
+
+	return json.Marshal(root)
+}
+
+func normalizeDynamoComponentDeploymentJSON(raw []byte) ([]byte, error) {
+	// Decode the DCD into a mutable root before normalizing its component container.
+	root, err := decodeV1alpha1JSONObject(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	// Limit normalization to the component spec so unrelated DCD fields retain their encoding.
+	if spec, ok := root["spec"].(map[string]any); ok {
+		normalizeV1alpha1ExtraPodSpecJSON(spec)
+	}
+
+	return json.Marshal(root)
+}
+
+func decodeV1alpha1JSONObject(raw []byte) (map[string]any, error) {
+	// Preserve JSON numbers while configuring the generic object decoder.
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+
+	// Decode the root object for targeted container normalization.
+	var root map[string]any
+	if err := decoder.Decode(&root); err != nil {
+		return nil, err
+	}
+	return root, nil
+}
+
+func normalizeV1alpha1ExtraPodSpecJSON(component map[string]any) {
+	extraPodSpec, ok := component["extraPodSpec"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	// MainContainer has no required name and conversion clears its synthetic one.
+	if mainContainer, ok := extraPodSpec["mainContainer"].(map[string]any); ok {
+		if name, ok := mainContainer["name"].(string); ok && name == "" {
+			delete(mainContainer, "name")
+		}
+		removeEmptyContainerResourcesJSON(mainContainer)
+	}
+
+	// Native container lists also materialize zero ResourceRequirements as {}.
+	for _, field := range []string{"containers", "initContainers", "ephemeralContainers"} {
+		containers, ok := extraPodSpec[field].([]any)
+		if !ok {
+			continue
+		}
+		for _, container := range containers {
+			if container, ok := container.(map[string]any); ok {
+				removeEmptyContainerResourcesJSON(container)
+			}
+		}
+	}
+}
+
+func removeEmptyContainerResourcesJSON(container map[string]any) {
+	resources, ok := container["resources"].(map[string]any)
+	if ok && len(resources) == 0 {
+		delete(container, "resources")
+	}
+}

--- a/deploy/operator/api/v1alpha1/marshal_test.go
+++ b/deploy/operator/api/v1alpha1/marshal_test.go
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+)
+
+func TestV1alpha1WireShapeSurvivesV1beta1StorageMigration(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawAlpha   string
+		alpha      conversion.Convertible
+		hub        conversion.Hub
+		storedHub  conversion.Hub
+		afterAlpha conversion.Convertible
+	}{
+		{
+			name:       "DynamoGraphDeployment",
+			rawAlpha:   `{"apiVersion":"nvidia.com/v1alpha1","kind":"DynamoGraphDeployment","metadata":{"name":"preupgrade-spec-probe","namespace":"dynamo-cloud"},"spec":{"services":{"Frontend":{"replicas":0,"componentType":"frontend","extraPodSpec":{"mainContainer":{"image":"busybox:1.36"}}}}}}`,
+			alpha:      &DynamoGraphDeployment{},
+			hub:        &v1beta1.DynamoGraphDeployment{},
+			storedHub:  &v1beta1.DynamoGraphDeployment{},
+			afterAlpha: &DynamoGraphDeployment{},
+		},
+		{
+			name:       "DynamoComponentDeployment",
+			rawAlpha:   `{"apiVersion":"nvidia.com/v1alpha1","kind":"DynamoComponentDeployment","metadata":{"name":"preupgrade-component","namespace":"dynamo-cloud"},"spec":{"componentType":"frontend","extraPodSpec":{"mainContainer":{"image":"busybox:1.36"}},"replicas":0}}`,
+			alpha:      &DynamoComponentDeployment{},
+			hub:        &v1beta1.DynamoComponentDeployment{},
+			storedHub:  &v1beta1.DynamoComponentDeployment{},
+			afterAlpha: &DynamoComponentDeployment{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Decode the sparse v1alpha1 object and retain its original wire-level spec")
+			var before map[string]any
+			if err := json.Unmarshal([]byte(tt.rawAlpha), &before); err != nil {
+				t.Fatalf("unmarshal raw v1alpha1 object: %v", err)
+			}
+			if err := json.Unmarshal([]byte(tt.rawAlpha), tt.alpha); err != nil {
+				t.Fatalf("unmarshal typed v1alpha1 object: %v", err)
+			}
+
+			t.Log("Convert the object to v1beta1 and round-trip it through storage JSON")
+			if err := tt.alpha.ConvertTo(tt.hub); err != nil {
+				t.Fatalf("ConvertTo() error = %v", err)
+			}
+			hubJSON, err := json.Marshal(tt.hub)
+			if err != nil {
+				t.Fatalf("marshal v1beta1 object: %v", err)
+			}
+			if err := json.Unmarshal(hubJSON, tt.storedHub); err != nil {
+				t.Fatalf("unmarshal stored v1beta1 object: %v", err)
+			}
+
+			t.Log("Convert the stored object back to the v1alpha1 API wire representation")
+			if err := tt.afterAlpha.ConvertFrom(tt.storedHub); err != nil {
+				t.Fatalf("ConvertFrom() error = %v", err)
+			}
+			afterJSON, err := json.Marshal(tt.afterAlpha)
+			if err != nil {
+				t.Fatalf("marshal converted v1alpha1 object: %v", err)
+			}
+			var after map[string]any
+			if err := json.Unmarshal(afterJSON, &after); err != nil {
+				t.Fatalf("unmarshal converted v1alpha1 object: %v", err)
+			}
+
+			t.Log("Verify storage migration preserves the original sparse spec shape")
+			if diff := cmp.Diff(before["spec"], after["spec"]); diff != "" {
+				t.Fatalf("v1alpha1 spec changed across v1beta1 storage migration (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDynamoGraphDeploymentMarshalNormalizesExtraPodSpecContainers(t *testing.T) {
+	t.Log("Build a DGD containing empty and non-empty native container resources")
+	dgd := DynamoGraphDeployment{
+		Spec: DynamoGraphDeploymentSpec{
+			Services: map[string]*DynamoComponentDeploymentSharedSpec{
+				"frontend": {
+					ExtraPodSpec: &ExtraPodSpec{
+						PodSpec: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "empty-sidecar"},
+								{Name: "resource-sidecar", Resources: corev1.ResourceRequirements{Claims: []corev1.ResourceClaim{{Name: "sidecar-gpu"}}}},
+							},
+							InitContainers: []corev1.Container{{Name: "init"}},
+							EphemeralContainers: []corev1.EphemeralContainer{{
+								EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "debug"},
+							}},
+						},
+						MainContainer: &corev1.Container{Image: "busybox"},
+					},
+				},
+			},
+		},
+	}
+
+	t.Log("Marshal through the public v1alpha1 root object")
+	raw, err := json.Marshal(dgd)
+	if err != nil {
+		t.Fatalf("marshal DGD: %v", err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		t.Fatalf("unmarshal DGD JSON: %v", err)
+	}
+	extraPodSpec := root["spec"].(map[string]any)["services"].(map[string]any)["frontend"].(map[string]any)["extraPodSpec"].(map[string]any)
+
+	t.Log("Verify the main container omits its empty synthetic fields")
+	mainContainer := extraPodSpec["mainContainer"].(map[string]any)
+	if _, ok := mainContainer["name"]; ok {
+		t.Fatalf("mainContainer.name was not omitted: %v", mainContainer)
+	}
+	if _, ok := mainContainer["resources"]; ok {
+		t.Fatalf("mainContainer.resources was not omitted: %v", mainContainer)
+	}
+
+	t.Log("Verify every PodSpec container list omits empty resources")
+	containers := extraPodSpec["containers"].([]any)
+	if _, ok := containers[0].(map[string]any)["resources"]; ok {
+		t.Fatalf("containers[0].resources was not omitted: %v", containers[0])
+	}
+	initContainers := extraPodSpec["initContainers"].([]any)
+	if _, ok := initContainers[0].(map[string]any)["resources"]; ok {
+		t.Fatalf("initContainers[0].resources was not omitted: %v", initContainers[0])
+	}
+	ephemeralContainers := extraPodSpec["ephemeralContainers"].([]any)
+	if _, ok := ephemeralContainers[0].(map[string]any)["resources"]; ok {
+		t.Fatalf("ephemeralContainers[0].resources was not omitted: %v", ephemeralContainers[0])
+	}
+
+	t.Log("Verify non-empty resources remain present")
+	resources, ok := containers[1].(map[string]any)["resources"].(map[string]any)
+	if !ok || len(resources) == 0 {
+		t.Fatalf("containers[1].resources = %v, want non-empty", containers[1])
+	}
+}

--- a/deploy/operator/api/v1beta1/marshal.go
+++ b/deploy/operator/api/v1beta1/marshal.go
@@ -95,6 +95,7 @@
 package v1beta1
 
 import (
+	"bytes"
 	"encoding/json"
 	"reflect"
 	"strings"
@@ -111,10 +112,15 @@ import (
 // embedded encoder, which would indicate a bug in the standard library
 // rather than user input.
 func normalizeV1Beta1JSON(raw []byte, rootType reflect.Type) ([]byte, error) {
+	// Decode numbers as json.Number so re-encoding preserves full int64 precision.
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
 	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
+	if err := decoder.Decode(&v); err != nil {
 		return nil, err
 	}
+
+	// Strip encoder artefacts while retaining the Kubernetes object envelope.
 	stripEmptyValueStructs(rootType, v)
 	ensureRuntimeObjectMetadata(rootType, v)
 	return json.Marshal(v)

--- a/deploy/operator/api/v1beta1/marshal_test.go
+++ b/deploy/operator/api/v1beta1/marshal_test.go
@@ -49,6 +49,22 @@ func TestNormalizeJSON_OuterFieldWinsEmbeddedCollision(t *testing.T) {
 	}
 }
 
+func TestNormalizeJSON_PreservesLargeInteger(t *testing.T) {
+	const raw = `{"spec":{"components":[{"podTemplate":{"spec":{"terminationGracePeriodSeconds":9007199254740993}}}]}}`
+
+	t.Log("Normalize a DGD containing an int64 value beyond exact float64 precision")
+	normalized, err := normalizeV1Beta1JSON([]byte(raw), reflect.TypeOf(DynamoGraphDeployment{}))
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+
+	t.Log("Verify normalization preserves the original integer token")
+	const want = `"terminationGracePeriodSeconds":9007199254740993`
+	if !bytes.Contains(normalized, []byte(want)) {
+		t.Fatalf("normalized JSON does not contain %s: %s", want, normalized)
+	}
+}
+
 func TestRootMarshal_PreservesEmptyMetadata(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Overview

Cherry-picks #14338 to `release/1.5.0` so v1alpha1 DynamoGraphDeployment and DynamoComponentDeployment objects retain their sparse container wire shape after v1beta1 storage migration.

## Summary

- omit conversion-generated empty `mainContainer.name` and container `resources` fields from v1alpha1 responses
- preserve non-empty resource requirements and full int64 precision during JSON normalization
- add raw storage-migration and large-integer regression coverage

## Details

Clean cherry-pick of `eac8c023` as `818d56087b` onto the latest `origin/release/1.5.0`.

## Where should the reviewer start?

Start with `deploy/operator/api/v1alpha1/marshal.go`, followed by the wire-shape regression in `deploy/operator/api/v1alpha1/marshal_test.go`.

## Related Issues

- Backport of #14338
- Relates to #14337
- Internal tracking: DYN-4293

## Validation

- `docker buildx build --platform linux/amd64 --target linter --progress=plain .`
- `go test ./api/v1alpha1 ./api/v1beta1 -count=1`
- `go test ./api/... -count=1`
- `go test ./api -run TestFuzzRoundTrip -roundtrip-fuzz-iters=3000 -count=1`
- `go test ./internal/dynamo -count=1`
- `git diff --check origin/release/1.5.0...HEAD`