### PR TITLE
fix(profiler): correct SGLang DP limits and vLLM decode mode

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -24,6 +24,9 @@ try:
     from dynamo.profiler.utils.config_modifiers.protocol import (  # noqa: F401
         BaseConfigModifier,
     )
+    from dynamo.profiler.utils.config_modifiers.sglang import (
+        _normalize_prefill_dp_limits,
+    )
     from dynamo.profiler.utils.defaults import (
         DYNAMO_RUN_DEFAULT_PORT,
         EngineType,
@@ -207,6 +210,34 @@ def test_convert_aggregate_template_preserves_single_worker(
     assert workers[0]["type"] == "decode"
 
 
+def test_convert_vllm_disagg_decode_removes_disaggregation_role() -> None:
+    """A standalone decode candidate must not retain a disaggregated role."""
+    modifier = CONFIG_MODIFIERS["vllm"]
+    config = modifier.load_default_config("disagg")
+    decode_args = _main_container(_component_by_type(config, "decode"))["args"]
+    decode_args.extend(
+        [
+            "--disaggregation-mode=decode",
+            "--disaggregation-mode",
+            "decode",
+            "--kv-transfer-config",
+            '{"kv_connector":"NixlConnector","kv_role":"kv_both"}',
+        ]
+    )
+
+    converted = modifier.convert_config(config, target=EngineType.DECODE)
+    workers = _worker_components(converted)
+    converted_args = _main_container(workers[0])["args"]
+
+    assert len(workers) == 1
+    assert workers[0]["type"] == "decode"
+    assert "--disaggregation-mode" not in converted_args
+    assert not any(arg.startswith("--disaggregation-mode=") for arg in converted_args)
+    assert converted_args[converted_args.index("--kv-transfer-config") + 1] == (
+        '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+    )
+
+
 def test_build_dgd_config_vllm_disagg_restores_runtime_args() -> None:
     """AIC tuning args must not remove Dynamo's vLLM disaggregation contract."""
     modifier = CONFIG_MODIFIERS["vllm"]
@@ -356,8 +387,52 @@ def test_build_dgd_config_sglang_prefill_mrr_one_sets_dp_safe_cuda_graph_bs() ->
 
     prefill_args = _main_container(_component_by_type(dgd_config, "prefill"))["args"]
 
+    assert prefill_args.count("--max-running-requests") == 1
+    assert prefill_args[prefill_args.index("--max-running-requests") + 1] == "2"
     assert prefill_args.count("--cuda-graph-bs") == 1
     assert prefill_args[prefill_args.index("--cuda-graph-bs") + 1] == "2"
+
+
+@pytest.mark.parametrize(
+    "prefill_args",
+    [
+        ["--enable-dp-attention", "--max-running-requests=2"],
+        ["--dp-size=4", "--max-running-requests=2"],
+        ["--dp-size=2", "--enable-dp-attention", "--max-running-requests=2"],
+    ],
+)
+def test_sglang_prefill_dp_limits_leave_safe_args_unchanged(
+    prefill_args: list[str],
+) -> None:
+    assert _normalize_prefill_dp_limits(prefill_args) == prefill_args
+
+
+@pytest.mark.parametrize(
+    ("prefill_args", "error"),
+    [
+        (
+            ["--enable-dp-attention", "--dp-size=invalid"],
+            "data parallel size must be an integer",
+        ),
+        (
+            ["--enable-dp-attention", "--dp-size=0"],
+            "data parallel size must be greater than zero",
+        ),
+        (
+            ["--enable-dp-attention", "--max-running-requests=invalid"],
+            "--max-running-requests must be an integer",
+        ),
+        (
+            ["--enable-dp-attention", "--max-running-requests=0"],
+            "--max-running-requests must be greater than zero",
+        ),
+    ],
+)
+def test_sglang_prefill_dp_limits_reject_invalid_explicit_values(
+    prefill_args: list[str], error: str
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        _normalize_prefill_dp_limits(prefill_args)
 
 
 def test_build_dgd_config_sglang_prefill_keeps_existing_cuda_graph_bs() -> None:
@@ -401,6 +476,7 @@ def test_sglang_set_prefill_config_uses_effective_mrr_override() -> None:
     _main_container(component)["args"] = [
         "--max-running-requests=512",
         "--dp=2",
+        "--enable-dp-attention",
     ]
 
     result = modifier.set_prefill_config(
@@ -410,7 +486,8 @@ def test_sglang_set_prefill_config_uses_effective_mrr_override() -> None:
     )
     args = _main_container(_component_by_type(result, "decode"))["args"]
 
-    assert args[args.index("--max-running-requests") + 1] == "1"
+    assert args.count("--max-running-requests") == 1
+    assert args[args.index("--max-running-requests") + 1] == "2"
     assert args.count("--cuda-graph-bs") == 1
     assert args[args.index("--cuda-graph-bs") + 1] == "2"
 

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -211,7 +211,6 @@ def test_convert_aggregate_template_preserves_single_worker(
 
 
 def test_convert_vllm_disagg_decode_removes_disaggregation_role() -> None:
-    """A standalone decode candidate must not retain a disaggregated role."""
     modifier = CONFIG_MODIFIERS["vllm"]
     config = modifier.load_default_config("disagg")
     decode_args = _main_container(_component_by_type(config, "decode"))["args"]
@@ -405,6 +404,21 @@ def test_sglang_prefill_dp_limits_leave_safe_args_unchanged(
     prefill_args: list[str],
 ) -> None:
     assert _normalize_prefill_dp_limits(prefill_args) == prefill_args
+
+
+def test_sglang_prefill_dp_limits_normalize_shell_joined_args() -> None:
+    args = [
+        "--dp 2",
+        "--enable-dp-attention",
+        "--max-running-requests 1",
+    ]
+
+    normalized = _normalize_prefill_dp_limits(args)
+
+    assert "--max-running-requests 1" not in normalized
+    assert normalized.count("--max-running-requests") == 1
+    assert normalized[normalized.index("--max-running-requests") + 1] == "2"
+    assert normalized[normalized.index("--cuda-graph-bs") + 1] == "2"
 
 
 @pytest.mark.parametrize(

--- a/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
@@ -148,7 +148,9 @@ def _normalize_prefill_dp_limits(args: list[str]) -> list[str]:
         max_running_requests_int,
         dp_size,
     )
-    return set_unique_argument_value(args, "--max-running-requests", str(dp_size))
+    return set_unique_argument_value(
+        parsed_args, "--max-running-requests", str(dp_size)
+    )
 
 
 class SGLangConfigModifier(BaseConfigModifier):

--- a/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
@@ -18,6 +18,7 @@ from dynamo.profiler.utils.config import (
     get_worker_component_from_config,
     remove_valued_arguments,
     set_argument_value,
+    set_unique_argument_value,
     setup_worker_component_resources,
     update_image,
     validate_and_get_worker_args,
@@ -88,6 +89,68 @@ def _ensure_safe_prefill_cuda_graph_bs(args: list[str]) -> list[str]:
     return args
 
 
+def _normalize_prefill_dp_limits(args: list[str]) -> list[str]:
+    """Keep SGLang's per-rank request limit positive under DP attention."""
+    args = _ensure_safe_prefill_cuda_graph_bs(args)
+    parsed_args = break_arguments(args)
+    if not _has_arg(parsed_args, "--enable-dp-attention"):
+        return args
+
+    dp_size_value = _arg_value_any(
+        parsed_args,
+        ("--data-parallel-size", "--dp-size", "--dp"),
+    )
+    if dp_size_value is None:
+        if any(
+            _has_arg(parsed_args, key)
+            for key in ("--data-parallel-size", "--dp-size", "--dp")
+        ):
+            raise ValueError("SGLang data parallel size must have an integer value")
+        dp_size = 1
+    else:
+        try:
+            dp_size = int(dp_size_value)
+        except ValueError as exc:
+            raise ValueError(
+                "SGLang data parallel size must be an integer, "
+                f"got {dp_size_value!r}"
+            ) from exc
+        if dp_size <= 0:
+            raise ValueError(
+                f"SGLang data parallel size must be greater than zero, got {dp_size}"
+            )
+
+    max_running_requests = _arg_value(parsed_args, "--max-running-requests")
+    if max_running_requests is None:
+        if _has_arg(parsed_args, "--max-running-requests"):
+            raise ValueError("SGLang --max-running-requests must have an integer value")
+        return args
+
+    try:
+        max_running_requests_int = int(max_running_requests)
+    except ValueError as exc:
+        raise ValueError(
+            "SGLang --max-running-requests must be an integer, "
+            f"got {max_running_requests!r}"
+        ) from exc
+    if max_running_requests_int <= 0:
+        raise ValueError(
+            "SGLang --max-running-requests must be greater than zero, "
+            f"got {max_running_requests_int}"
+        )
+
+    if max_running_requests_int >= dp_size:
+        return args
+
+    logger.warning(
+        "Clamping SGLang prefill --max-running-requests from %d to attention "
+        "DP size %d so every DP rank can admit a request.",
+        max_running_requests_int,
+        dp_size,
+    )
+    return set_unique_argument_value(args, "--max-running-requests", str(dp_size))
+
+
 class SGLangConfigModifier(BaseConfigModifier):
     BACKEND = "sglang"
 
@@ -112,7 +175,7 @@ class SGLangConfigModifier(BaseConfigModifier):
         decode_gpus: int,
         num_gpus_per_node: int | None = None,
     ) -> None:
-        prefill_cli_args = _ensure_safe_prefill_cuda_graph_bs(prefill_cli_args)
+        prefill_cli_args = _normalize_prefill_dp_limits(prefill_cli_args)
         super()._apply_disagg_workers(
             cfg,
             prefill_cli_args=prefill_cli_args,
@@ -447,7 +510,7 @@ class SGLangConfigModifier(BaseConfigModifier):
 
         # Set max concurrency to control effective batch size
         args = set_argument_value(args, "--max-running-requests", str(max_batch_size))
-        args = _ensure_safe_prefill_cuda_graph_bs(args)
+        args = _normalize_prefill_dp_limits(args)
 
         # Cap total tokens processed in a batch to avoid chunked prefill
         args = set_argument_value(args, "--chunked-prefill-size", str(max_num_tokens))

--- a/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
@@ -112,7 +112,6 @@ def _finalize_disagg_cli_args(args: list[str], role: SubComponentType) -> list[s
 
 
 def _remove_disaggregation_mode_args(args: list[str]) -> list[str]:
-    """Remove every spaced and equals-form disaggregation mode argument."""
     filtered_args: list[str] = []
     index = 0
     while index < len(args):

--- a/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
@@ -111,6 +111,23 @@ def _finalize_disagg_cli_args(args: list[str], role: SubComponentType) -> list[s
     return finalized
 
 
+def _remove_disaggregation_mode_args(args: list[str]) -> list[str]:
+    """Remove every spaced and equals-form disaggregation mode argument."""
+    filtered_args: list[str] = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--disaggregation-mode":
+            index += 2
+            continue
+        if arg.startswith("--disaggregation-mode="):
+            index += 1
+            continue
+        filtered_args.append(arg)
+        index += 1
+    return filtered_args
+
+
 class VllmV1ConfigModifier(BaseConfigModifier):
     BACKEND = "vllm"
     # vllm uses a different arg for model path
@@ -243,6 +260,9 @@ class VllmV1ConfigModifier(BaseConfigModifier):
             )
             args = validate_and_get_worker_args(worker_service, backend="vllm")
             args = break_arguments(args)
+
+            # The decode candidate is standalone after its prefill peer is removed.
+            args = _remove_disaggregation_mode_args(args)
 
             # enable prefix caching
             if "--enable-prefix-caching" not in args:


### PR DESCRIPTION
## Summary

- Clamp generated SGLang prefill `--max-running-requests` to the attention data-parallel size so every rank receives at least one request slot.
- Reject explicit invalid SGLang DP and request-limit values during profiler config generation.
- Strip spaced, equals-form, and duplicate vLLM `--disaggregation-mode` arguments when converting a decode worker into a standalone profiling candidate.
- Preserve unrelated vLLM KV-transfer configuration and add CPU-only regression coverage.

## Tracking

- [NVBug 6433916](https://nvbugs.nvidia.com/6433916)
- [Linear DYN-3446](https://linear.app/nvidia/issue/DYN-3446)
- [NVBug 6557469](https://nvbugs.nvidia.com/6557469)
- [Linear DYN-3752](https://linear.app/nvidia/issue/DYN-3752)

This change should be considered for backport to `release/1.5.0`.

## Validation

```bash
PYTHONPATH=components/src:lib/bindings/python/src \
  python -m pytest -q \
  components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
```

Result: `81 passed`.

```bash
pre-commit run --files \
  components/src/dynamo/profiler/utils/config_modifiers/sglang.py \
  components/src/dynamo/profiler/utils/config_modifiers/vllm.py \
  components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py

git diff --check
```

All applicable hooks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vLLM decode worker configuration by removing disaggregation mode settings while preserving KV-transfer options.
  - Normalized SGLang prefill data-parallel limits to reject invalid values and ensure request limits meet the configured data-parallel size.
  - Corrected effective maximum running request limits and enabled data-parallel attention in the relevant profiling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->