### PR TITLE
ci(test): collapse container-job steps into fewer hook round trips

### DIFF
--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -1,5 +1,12 @@
 name: 'Pytest'
 description: 'Run pytest on pre-built container images'
+# This action runs as ONE shell step on purpose. The test jobs execute as
+# GitHub `container:` jobs on ARC Kubernetes runners, where every step is a
+# separate exec into the job pod costing 20-40 s of fixed overhead regardless
+# of what it does. The former nine-step layout (env init, MinIO wait, GPU
+# check, pytest, result processing, three uploads) spent ~4 min per invocation
+# on that overhead alone. Artifact uploads moved to shared-test.yml so they
+# happen once per job rather than once per stage.
 inputs:
   pytest_marks:
     description: 'Pytest marks'
@@ -13,7 +20,7 @@ inputs:
     required: false
     default: 'unknown'
   framework:
-    description: 'Test framework label used in metrics env and artifact names (e.g. vllm, sglang, trtllm)'
+    description: 'Test framework label used in metrics env (e.g. vllm, sglang, trtllm)'
     required: false
     default: 'unknown'
   test_type:
@@ -70,35 +77,60 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Initialize test type env var
+    - name: Run pytest
       shell: bash
+      # Inputs are passed through env rather than interpolated into the script
+      # body (see zizmor "template-injection").
+      env:
+        PYTEST_MARKS: ${{ inputs.pytest_marks }}
+        CONTAINER_WORKSPACE: ${{ inputs.container_workspace }}
+        TEST_SUITE_NAME: ${{ inputs.test_suite_name }}
+        TEST_TYPE: ${{ inputs.test_type }}
+        PLATFORM_ARCH: ${{ inputs.platform_arch }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        ENABLE_COVERAGE: ${{ inputs.enable_coverage }}
+        PARALLEL_MODE: ${{ inputs.parallel_mode }}
+        MAX_VRAM_GIB: ${{ inputs.max_vram_gib }}
+        NVME_DIR: ${{ inputs.nvme_dir }}
+        REQUESTED_HF_HOME: ${{ inputs.hf_home }}
+        GPU_TESTS: ${{ inputs.gpu_tests }}
+        RUN_ID: ${{ github.run_id }}
+        # The Datadog GitHub action used to export this; the ddtrace GitHub
+        # provider reads it to link test sessions to the job.
+        JOB_CHECK_RUN_ID: ${{ job.check_run_id }}
+        CONTAINER_ID: test_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.job }}
+        PYTEST_XML_FILE: pytest_test_report.xml
+        HF_TOKEN: ${{ inputs.hf_token }}
+        DYNAMO_TEST_PLATFORM: ${{ inputs.platform_arch }}
+        DYNAMO_TEST_TYPE: ${{ inputs.test_type }}
+        DYNAMO_TEST_WORKFLOW: ${{ github.workflow }}
+        DYNAMO_TEST_FRAMEWORK: ${{ inputs.framework }}
+        HF_XET_HIGH_PERFORMANCE: 1
+        PYTEST_DD_FLAKY_RETRY_ENABLED: ${{ inputs.dd_flaky_retry_enabled }}
       run: |
-        STR_TEST_TYPE=$(echo '${{ inputs.test_type }}' | tr ', ' '_')
-        echo "STR_TEST_TYPE=${STR_TEST_TYPE}" >> $GITHUB_ENV
-    - name: verify minio
-      if: inputs.gpu_tests == 'true' # only gpu tests require minio
-      shell: bash
-      run: |
-        # Wait for MinIO to be ready
-        echo "⏳ Waiting for MinIO to be ready..."
-        MAX_ATTEMPTS=30
-        ATTEMPT=0
-        while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-          if curl -sf http://localhost:9000/minio/health/live > /dev/null 2>&1; then
-            echo "✅ MinIO is ready (attempt $((ATTEMPT + 1)))"
-            break
-          fi
-          ATTEMPT=$((ATTEMPT + 1))
-          if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
-            echo "❌ MinIO failed to start within ${MAX_ATTEMPTS}s"
-            exit 1
-          fi
-          sleep 1
-        done
-    - name: Verify GPU visibility
-      if: inputs.gpu_tests == 'true'
-      shell: python
-      run: |
+        # Sanitize test_type for filenames: remove commas and spaces.
+        STR_TEST_TYPE=$(echo "${TEST_TYPE}" | tr ', ' '_')
+
+        if [[ "${GPU_TESTS}" == "true" ]]; then
+          # Only GPU tests require MinIO (LoRA tests). Wait for the job service.
+          echo "⏳ Waiting for MinIO to be ready..."
+          MAX_ATTEMPTS=30
+          ATTEMPT=0
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            if curl -sf http://localhost:9000/minio/health/live > /dev/null 2>&1; then
+              echo "✅ MinIO is ready (attempt $((ATTEMPT + 1)))"
+              break
+            fi
+            ATTEMPT=$((ATTEMPT + 1))
+            if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
+              echo "❌ MinIO failed to start within ${MAX_ATTEMPTS}s"
+              exit 1
+            fi
+            sleep 1
+          done
+
+          # Verify GPU visibility before spending time on collection.
+          python - <<'PY'
         import sys
         import torch
         available = torch.cuda.is_available()
@@ -110,31 +142,18 @@ runs:
         print(f"GPU Name: {name}")
         if not available:
             sys.exit("GPU tests requested but torch.cuda.is_available() is False")
+        PY
+        fi
 
-    # TRT-LLM starts MPI ranks and several runtime processes per test.
-    # Higher slot counts can starve startup even when VRAM fits.
-    # xdist resolves `-n auto` from this variable before tests/conftest.py
-    # saves the result as the GPU scheduler slot count.
-    - name: Limit TRT-LLM GPU parallelism
-      if: inputs.max_vram_gib != '' && startsWith(inputs.test_suite_name, 'trtllm')
-      shell: bash
-      run: |
-        echo "PYTEST_XDIST_AUTO_NUM_WORKERS=2" >> "$GITHUB_ENV"
-        echo "📊 TRT-LLM GPU parallelism: capping at 2 concurrent tests"
+        # TRT-LLM starts MPI ranks and several runtime processes per test.
+        # Higher slot counts can starve startup even when VRAM fits.
+        # xdist resolves `-n auto` from this variable before tests/conftest.py
+        # saves the result as the GPU scheduler slot count.
+        if [[ -n "${MAX_VRAM_GIB}" && "${TEST_SUITE_NAME}" == trtllm* ]]; then
+          export PYTEST_XDIST_AUTO_NUM_WORKERS=2
+          echo "📊 TRT-LLM GPU parallelism: capping at 2 concurrent tests"
+        fi
 
-    - name: Run pytest
-      shell: bash
-      env:
-        CONTAINER_ID: test_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.job }}
-        PYTEST_XML_FILE: pytest_test_report.xml
-        HF_TOKEN: ${{ inputs.hf_token }}
-        DYNAMO_TEST_PLATFORM: ${{ inputs.platform_arch }}
-        DYNAMO_TEST_TYPE: ${{ inputs.test_type }}
-        DYNAMO_TEST_WORKFLOW: ${{ github.workflow }}
-        DYNAMO_TEST_FRAMEWORK: ${{ inputs.framework }}
-        HF_XET_HIGH_PERFORMANCE: 1
-        PYTEST_DD_FLAKY_RETRY_ENABLED: ${{ inputs.dd_flaky_retry_enabled }}
-      run: |
         # Run pytest with detailed output and JUnit XML
         set +e  # Don't exit on test failures
 
@@ -144,23 +163,22 @@ runs:
         echo "Datadog flaky retries enabled: ${DD_CIVISIBILITY_FLAKY_RETRY_ENABLED:-unset}"
 
         # Get absolute path for test-results directory and ensure it has proper permissions.
-        # Artifacts go to the GitHub Actions checkout so upload-artifact can find them.
+        # Artifacts go to the GitHub Actions checkout so the per-job upload in
+        # shared-test.yml can find them.
         TEST_RESULTS_DIR="${GITHUB_WORKSPACE}/test-results"
         mkdir -p "${TEST_RESULTS_DIR}"
         chmod 777 "${TEST_RESULTS_DIR}"
         echo "📁 Test results will be saved to: ${TEST_RESULTS_DIR}"
 
-
-        # NVMe guard: GPU runners mount ${{ inputs.nvme_dir }}" (nvme-scratch emptyDir, NVMe-backed via
-        # instanceStorePolicy: RAID0). CPU/ARM runners have no ${{ inputs.nvme_dir }} mount.
-        if [[ -d "${{ inputs.nvme_dir }}" ]]; then
-          WORK_DIR="${{ inputs.nvme_dir }}"
+        # NVMe guard: GPU runners mount ${NVME_DIR} (nvme-scratch emptyDir, NVMe-backed via
+        # instanceStorePolicy: RAID0). CPU/ARM runners have no ${NVME_DIR} mount.
+        if [[ -d "${NVME_DIR}" ]]; then
+          WORK_DIR="${NVME_DIR}"
           echo "✅ NVMe scratch available"
         else
           WORK_DIR="/tmp"
         fi
 
-        REQUESTED_HF_HOME="${{ inputs.hf_home }}"
         FALLBACK_HF_HOME="${WORK_DIR}/.cache/huggingface"
         # Prefer the requested cache path when it is usable in this job container.
         if
@@ -188,23 +206,20 @@ runs:
         mkdir -p "${XDG_CACHE_HOME}"
         echo "XDG_CACHE_HOME=${XDG_CACHE_HOME}" >> $GITHUB_ENV
 
-
-        CONTAINER_WORKSPACE="${{ inputs.container_workspace }}"
         if [[ ! -d "${CONTAINER_WORKSPACE}" ]]; then
           echo "❌ container_workspace '${CONTAINER_WORKSPACE}' not found inside container"
           exit 1
         fi
         echo "📦 Running pytest from container workspace: ${CONTAINER_WORKSPACE}"
 
-        # Determine docker runtime flags and pytest command based on dry_run mode
-        if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+        # Determine pytest command based on dry_run mode
+        if [[ "${DRY_RUN}" == "true" ]]; then
           echo "🔍 Running pytest in dry-run mode (collect-only, no GPU required)"
-          GPU_FLAGS=""
-          PYTEST_CMD="python -m pytest -v --collect-only -m \"${{ inputs.pytest_marks }}\""
+          PYTEST_CMD="python -m pytest -v --collect-only -m \"${PYTEST_MARKS}\""
         else
           echo "🚀 Running pytest in normal mode"
           # Determine parallelization based on parallel_mode input
-          case "${{ inputs.parallel_mode }}" in
+          case "${PARALLEL_MODE}" in
             "auto")
               PARALLEL_OPTS="-n auto"
               echo "📊 Parallelization: auto (use all available cores)"
@@ -214,8 +229,8 @@ runs:
               echo "📊 Parallelization: disabled (sequential execution) for GPU runs"
               ;;
             *)
-              PARALLEL_OPTS="-n ${{ inputs.parallel_mode }}"
-              echo "📊 Parallelization: ${{ inputs.parallel_mode }} workers"
+              PARALLEL_OPTS="-n ${PARALLEL_MODE}"
+              echo "📊 Parallelization: ${PARALLEL_MODE} workers"
               ;;
           esac
 
@@ -225,10 +240,10 @@ runs:
           # consumes both, disables xdist, and runs tests as VRAM-aware
           # subprocesses. --dist=loadscope is omitted because xdist is bypassed.
           VRAM_OPTS=""
-          if [[ -n "${{ inputs.max_vram_gib }}" ]]; then
-            VRAM_OPTS="--max-vram-gib=${{ inputs.max_vram_gib }}"
+          if [[ -n "${MAX_VRAM_GIB}" ]]; then
+            VRAM_OPTS="--max-vram-gib=${MAX_VRAM_GIB}"
             DIST_OPTS=""
-            echo "🧮 GPU-parallel mode: --max-vram-gib=${{ inputs.max_vram_gib }} (xdist replaced by VRAM-aware orchestrator)"
+            echo "🧮 GPU-parallel mode: --max-vram-gib=${MAX_VRAM_GIB} (xdist replaced by VRAM-aware orchestrator)"
           else
             # --dist=loadscope groups tests by module/class to prevent race conditions in stateful tests
             DIST_OPTS="--dist=loadscope"
@@ -236,14 +251,17 @@ runs:
 
           # Add coverage flags if enabled
           COVERAGE_FLAGS=""
-          if [[ "${{ inputs.enable_coverage }}" == "true" ]]; then
+          if [[ "${ENABLE_COVERAGE}" == "true" ]]; then
             echo "📊 Coverage collection enabled"
             COVERAGE_FLAGS="--cov=components/src/dynamo --cov=lib/bindings/python/src/dynamo --cov-report="
-            export COVERAGE_FILE="${TEST_RESULTS_DIR}/.coverage"
+            # Suffix the data file per stage: the job uploads test-results/ once
+            # at the end, so stages must not overwrite each other. The nightly
+            # merge globs `.coverage*` and combines whatever it finds.
+            export COVERAGE_FILE="${TEST_RESULTS_DIR}/.coverage.${STR_TEST_TYPE}"
             export PYTHONPATH="${CONTAINER_WORKSPACE}/components/src:${CONTAINER_WORKSPACE}/lib/bindings/python/src${PYTHONPATH:+:${PYTHONPATH}}"
           fi
 
-          PYTEST_CMD="python -m pytest ${PARALLEL_OPTS} ${VRAM_OPTS} ${DIST_OPTS} --continue-on-collection-errors -v --tb=short --basetemp=${WORK_DIR}/pytest_temp -o cache_dir=${WORK_DIR}/.pytest_cache --junitxml=${TEST_RESULTS_DIR}/${{ env.PYTEST_XML_FILE }} --alluredir=${TEST_RESULTS_DIR}/allure-results --durations=10 ${COVERAGE_FLAGS} -m \"${{ inputs.pytest_marks }}\""
+          PYTEST_CMD="python -m pytest ${PARALLEL_OPTS} ${VRAM_OPTS} ${DIST_OPTS} --continue-on-collection-errors -v --tb=short --basetemp=${WORK_DIR}/pytest_temp -o cache_dir=${WORK_DIR}/.pytest_cache --junitxml=${TEST_RESULTS_DIR}/${PYTEST_XML_FILE} --alluredir=${TEST_RESULTS_DIR}/allure-results --durations=10 ${COVERAGE_FLAGS} -m \"${PYTEST_MARKS}\""
         fi
 
         echo "▶️ Executing (cwd=${CONTAINER_WORKSPACE}): ${PYTEST_CMD}"
@@ -253,78 +271,23 @@ runs:
         bash -c "${PYTEST_CMD}"
 
         TEST_EXIT_CODE=$?
-        echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV
         echo "🧪 Tests completed with exit code: ${TEST_EXIT_CODE}"
 
-        # Verify test results were written (only in normal mode)
-        if [[ "${{ inputs.dry_run }}" != "true" ]]; then
-          if [[ -f "${TEST_RESULTS_DIR}/${{ env.PYTEST_XML_FILE }}" ]]; then
-            echo "✅ Test results file found: ${TEST_RESULTS_DIR}/${{ env.PYTEST_XML_FILE }}"
-          else
-            echo "⚠️  Test results file not found: ${TEST_RESULTS_DIR}/${{ env.PYTEST_XML_FILE }}"
-          fi
-        fi
-
-        # Always continue to results processing
-        exit 0
-
-    - name: Process Test Results
-      shell: bash
-      run: |
-
-        # Sanitize test_type for filenames (always set this for artifact upload)
-        # Remove commas and spaces from test_type for use in filenames
-        STR_TEST_TYPE=$(echo "${{ inputs.test_type }}" | tr ', ' '_')
-        echo "STR_TEST_TYPE=${STR_TEST_TYPE}" >> $GITHUB_ENV
-
-        # Check for JUnit XML file and determine test status
-        JUNIT_FILE="test-results/pytest_test_report.xml"
-
+        # Process test results. The JUnit file gets a unique per-stage name so
+        # several stages can share one test-results/ directory and one upload.
+        JUNIT_FILE="${TEST_RESULTS_DIR}/${PYTEST_XML_FILE}"
         if [[ -f "$JUNIT_FILE" ]]; then
           echo "✅ JUnit XML generated successfully"
-          # Extract basic test counts for status determination
           TOTAL_TESTS=$(grep -o 'tests="[0-9]*"' "$JUNIT_FILE" | grep -o '[0-9]*' | head -1 || echo "0")
           FAILED_TESTS=$(grep -o 'failures="[0-9]*"' "$JUNIT_FILE" | grep -o '[0-9]*' | head -1 || echo "0")
           ERROR_TESTS=$(grep -o 'errors="[0-9]*"' "$JUNIT_FILE" | grep -o '[0-9]*' | head -1 || echo "0")
           echo "📊 ${TOTAL_TESTS} tests completed (${FAILED_TESTS} failed, ${ERROR_TESTS} errors)"
 
-          # Rename XML file to unique name
-          JUNIT_NAME="pytest_test_report_${{ inputs.test_suite_name }}_${STR_TEST_TYPE}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml"
-          mv "$JUNIT_FILE" "test-results/$JUNIT_NAME"
-          echo "📝 Renamed XML file to: $JUNIT_NAME"
-        else
+          JUNIT_NAME="pytest_test_report_${TEST_SUITE_NAME}_${STR_TEST_TYPE}_${PLATFORM_ARCH}_${RUN_ID}_${JOB_CHECK_RUN_ID}.xml"
+          mv "$JUNIT_FILE" "${TEST_RESULTS_DIR}/${JUNIT_NAME}"
+          echo "📝 Renamed XML file to: ${JUNIT_NAME}"
+        elif [[ "${DRY_RUN}" != "true" ]]; then
           echo "⚠️  JUnit XML file not found - test results may not be available for upload"
-          TOTAL_TESTS=0
-          FAILED_TESTS=1  # Treat missing XML as failure
-          ERROR_TESTS=0
         fi
 
         exit ${TEST_EXIT_CODE}
-
-
-
-    - name: Upload Test Results
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-      if: always()  # Always upload test results, even if tests failed
-      with:
-        name: test-results-${{ inputs.test_suite_name }}-${{ env.STR_TEST_TYPE }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
-        path: test-results/pytest_test_report_${{ inputs.test_suite_name }}_${{ env.STR_TEST_TYPE }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml
-        retention-days: 7
-
-    - name: Upload Coverage Data
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-      if: always() && inputs.enable_coverage == 'true'
-      with:
-        name: coverage-python-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
-        path: test-results/
-        include-hidden-files: true
-        retention-days: 7
-
-    - name: Upload Allure Results
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-      if: always()
-      with:
-        name: allure-results-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
-        path: test-results/allure-results/
-        retention-days: 7
-        if-no-files-found: ignore

--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -1,12 +1,8 @@
 name: 'Pytest'
 description: 'Run pytest on pre-built container images'
-# This action runs as ONE shell step on purpose. The test jobs execute as
-# GitHub `container:` jobs on ARC Kubernetes runners, where every step is a
-# separate exec into the job pod costing 20-40 s of fixed overhead regardless
-# of what it does. The former nine-step layout (env init, MinIO wait, GPU
-# check, pytest, result processing, three uploads) spent ~4 min per invocation
-# on that overhead alone. Artifact uploads moved to shared-test.yml so they
-# happen once per job rather than once per stage.
+# Keep this a single shell step: each step in a `container:` job is a separate
+# exec into the job pod with significant fixed overhead. Artifact uploads live
+# in shared-test.yml so they happen once per job.
 inputs:
   pytest_marks:
     description: 'Pytest marks'
@@ -95,8 +91,7 @@ runs:
         REQUESTED_HF_HOME: ${{ inputs.hf_home }}
         GPU_TESTS: ${{ inputs.gpu_tests }}
         RUN_ID: ${{ github.run_id }}
-        # The Datadog GitHub action used to export this; the ddtrace GitHub
-        # provider reads it to link test sessions to the job.
+        # Required by the ddtrace GitHub provider to link test sessions to the job.
         JOB_CHECK_RUN_ID: ${{ job.check_run_id }}
         CONTAINER_ID: test_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.job }}
         PYTEST_XML_FILE: pytest_test_report.xml

--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -1,8 +1,9 @@
 name: 'Pytest'
 description: 'Run pytest on pre-built container images'
-# Keep this a single shell step: each step in a `container:` job is a separate
-# exec into the job pod with significant fixed overhead. Artifact uploads live
-# in shared-test.yml so they happen once per job.
+# Keep the test run a single shell step: each step in a `container:` job is a
+# separate exec into the job pod with significant fixed overhead. The JUnit
+# upload lives in shared-test.yml so it happens once per job; Allure and
+# coverage are uploaded per stage below for the external CI-metrics pipeline.
 inputs:
   pytest_marks:
     description: 'Pytest marks'
@@ -103,8 +104,10 @@ runs:
         HF_XET_HIGH_PERFORMANCE: 1
         PYTEST_DD_FLAKY_RETRY_ENABLED: ${{ inputs.dd_flaky_retry_enabled }}
       run: |
-        # Sanitize test_type for filenames: remove commas and spaces.
+        # Sanitize test_type for filenames: remove commas and spaces. Exported
+        # for the per-stage upload steps' artifact names.
         STR_TEST_TYPE=$(echo "${TEST_TYPE}" | tr ', ' '_')
+        echo "STR_TEST_TYPE=${STR_TEST_TYPE}" >> $GITHUB_ENV
 
         if [[ "${GPU_TESTS}" == "true" ]]; then
           # Only GPU tests require MinIO (LoRA tests). Wait for the job service.
@@ -289,3 +292,26 @@ runs:
         fi
 
         exit ${TEST_EXIT_CODE}
+
+    # Allure results and coverage data are uploaded per stage, under the same
+    # artifact names as before the step collapse, because an external CI-metrics
+    # pipeline consumes them by name. `always()` because the step above exits
+    # with the pytest status. The JUnit upload happens once per job in
+    # shared-test.yml.
+    - name: Upload Coverage Data
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      if: always() && inputs.enable_coverage == 'true'
+      with:
+        name: coverage-python-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
+        path: test-results/
+        include-hidden-files: true
+        retention-days: 7
+
+    - name: Upload Allure Results
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      if: always()
+      with:
+        name: allure-results-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
+        path: test-results/allure-results/
+        retention-days: 7
+        if-no-files-found: ignore

--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -267,6 +267,9 @@ runs:
 
         TEST_EXIT_CODE=$?
         echo "🧪 Tests completed with exit code: ${TEST_EXIT_CODE}"
+        # Back to fail-fast: a failure while processing results must fail the
+        # step instead of being masked by the pytest status returned below.
+        set -e
 
         # Process test results. The JUnit file gets a unique per-stage name so
         # several stages can share one test-results/ directory and one upload.

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -172,11 +172,9 @@ jobs:
         # coverage.py collects nothing ("No data was collected" warnings) and TIA
         # gets no signal. Disable ITR (skips the settings API, coverage, skipping).
         DD_CIVISIBILITY_ITR_ENABLED: 'false'
-        # Datadog Test Optimization is configured here rather than through
-        # datadog/test-visibility-github-action: that action is six steps, and
-        # every step in a `container:` job on the ARC runners costs 20-40 s of
-        # exec overhead. ddtrace itself is pinned in requirements.test.txt. These
-        # are the variables the action exported (see its job log).
+        # Datadog Test Optimization is configured through ddtrace environment
+        # variables (ddtrace is pinned in requirements.test.txt) to avoid extra
+        # container-job hook steps.
         DD_API_KEY: ${{ secrets.DD_API_KEY }}
         DD_SITE: datadoghq.com
         DD_CIVISIBILITY_ENABLED: 'true'
@@ -290,12 +288,8 @@ jobs:
           parallel_mode: 'none'
           enable_coverage: ${{ inputs.enable_coverage }}
           gpu_tests: 'true'
-      # Artifacts are uploaded once per job, not once per stage: every stage
-      # writes uniquely named files into the shared test-results/ directory, and
-      # each upload step is another ~30 s container-hook round trip. Names keep
-      # the test-results-* / allure-results-* / coverage-python-* prefixes that
-      # test_report.yaml, generate-allure-report.yml, and the nightly coverage
-      # merge match on.
+      # Artifact names must keep the test-results-* / allure-results-* /
+      # coverage-python-* prefixes consumed by the report and coverage workflows.
       - name: Upload Test Results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -172,6 +172,17 @@ jobs:
         # coverage.py collects nothing ("No data was collected" warnings) and TIA
         # gets no signal. Disable ITR (skips the settings API, coverage, skipping).
         DD_CIVISIBILITY_ITR_ENABLED: 'false'
+        # Datadog Test Optimization is configured here rather than through
+        # datadog/test-visibility-github-action: that action is six steps, and
+        # every step in a `container:` job on the ARC runners costs 20-40 s of
+        # exec overhead. ddtrace itself is pinned in requirements.test.txt. These
+        # are the variables the action exported (see its job log).
+        DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        DD_SITE: datadoghq.com
+        DD_CIVISIBILITY_ENABLED: 'true'
+        DD_CIVISIBILITY_AGENTLESS_ENABLED: 'true'
+        DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER: github
+        PYTEST_ADDOPTS: --ddtrace
     permissions:
       contents: read
     services:
@@ -195,14 +206,6 @@ jobs:
           KVBM_MLA_BACKEND: ${{ inputs.kvbm_mla_backend }}
         run: |
           echo "KVBM_MLA_BACKEND=${KVBM_MLA_BACKEND}" >> "$GITHUB_ENV"
-      # Experimental: trialing Datadog Test Visibility. Remove if not kept.
-      - name: Configure Datadog Test Visibility
-        continue-on-error: true
-        uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b  # v2.10.0
-        with:
-          languages: python
-          api_key: ${{ secrets.DD_API_KEY }}
-          site: datadoghq.com
       - name: Run Sanity Check on Runtime Image
         if: ${{ inputs.run_sanity_check }}
         shell: bash
@@ -287,3 +290,33 @@ jobs:
           parallel_mode: 'none'
           enable_coverage: ${{ inputs.enable_coverage }}
           gpu_tests: 'true'
+      # Artifacts are uploaded once per job, not once per stage: every stage
+      # writes uniquely named files into the shared test-results/ directory, and
+      # each upload step is another ~30 s container-hook round trip. Names keep
+      # the test-results-* / allure-results-* / coverage-python-* prefixes that
+      # test_report.yaml, generate-allure-report.yml, and the nightly coverage
+      # merge match on.
+      - name: Upload Test Results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        with:
+          name: test-results-${{ inputs.test_suite_name }}-${{ matrix.platform }}-${{ github.run_id }}-${{ job.check_run_id }}
+          path: test-results/pytest_test_report_*.xml
+          retention-days: 7
+          if-no-files-found: warn
+      - name: Upload Allure Results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        with:
+          name: allure-results-${{ inputs.test_suite_name }}-${{ matrix.platform }}-${{ github.run_id }}-${{ job.check_run_id }}
+          path: test-results/allure-results/
+          retention-days: 7
+          if-no-files-found: ignore
+      - name: Upload Coverage Data
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' && inputs.enable_coverage == 'true' }}
+        with:
+          name: coverage-python-${{ inputs.test_suite_name }}-${{ matrix.platform }}-${{ github.run_id }}-${{ job.check_run_id }}
+          path: test-results/
+          include-hidden-files: true
+          retention-days: 7

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -288,8 +288,9 @@ jobs:
           parallel_mode: 'none'
           enable_coverage: ${{ inputs.enable_coverage }}
           gpu_tests: 'true'
-      # Artifact names must keep the test-results-* / allure-results-* /
-      # coverage-python-* prefixes consumed by the report and coverage workflows.
+      # One JUnit upload per job (one XML per stage inside). The name must keep
+      # the test-results-* prefix consumed by the report workflows. Allure and
+      # coverage are uploaded per stage by the pytest-local action.
       - name: Upload Test Results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
@@ -298,19 +299,3 @@ jobs:
           path: test-results/pytest_test_report_*.xml
           retention-days: 7
           if-no-files-found: warn
-      - name: Upload Allure Results
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
-        with:
-          name: allure-results-${{ inputs.test_suite_name }}-${{ matrix.platform }}-${{ github.run_id }}-${{ job.check_run_id }}
-          path: test-results/allure-results/
-          retention-days: 7
-          if-no-files-found: ignore
-      - name: Upload Coverage Data
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        if: ${{ !cancelled() && steps.checkout.outcome == 'success' && inputs.enable_coverage == 'true' }}
-        with:
-          name: coverage-python-${{ inputs.test_suite_name }}-${{ matrix.platform }}-${{ github.run_id }}-${{ job.check_run_id }}
-          path: test-results/
-          include-hidden-files: true
-          retention-days: 7

--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -17,9 +17,7 @@ chardet<6
 coverage[toml]==7.13.1
 # For IFEval dataset loading in kvbm tests
 datasets==4.4.1
-# Datadog Test Optimization pytest plugin (--ddtrace). Baked into the test
-# image instead of installed by datadog/test-visibility-github-action at job
-# start: each of that action's six steps cost ~30 s of container-hook overhead.
+# Datadog Test Optimization pytest plugin (--ddtrace)
 ddtrace==4.14.0
 filelock==3.25.1
 # For faster model downloads. Must stay a floor, not an exact pin: huggingface_hub

--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -17,6 +17,10 @@ chardet<6
 coverage[toml]==7.13.1
 # For IFEval dataset loading in kvbm tests
 datasets==4.4.1
+# Datadog Test Optimization pytest plugin (--ddtrace). Baked into the test
+# image instead of installed by datadog/test-visibility-github-action at job
+# start: each of that action's six steps cost ~30 s of container-hook overhead.
+ddtrace==4.14.0
 filelock==3.25.1
 # For faster model downloads. Must stay a floor, not an exact pin: huggingface_hub
 # raises its hf-xet requirement over time (>=1.4.3 at hub 1.18, >=1.5.1 at 1.19,


### PR DESCRIPTION
## Overview:

### Summary

The framework test jobs run as `container:` jobs on the ARC Kubernetes runners, where every step is a separate exec into the job pod costing 20 to 40 s of fixed overhead regardless of what it does (median 32 s measured in the vLLM test job of run 33915559672). That job had 33 steps, 28 of which did under a second of real work, about 14 minutes per job, and these jobs are the PR workflow's critical path (TensorRT-LLM Test p50 65 min, vLLM Test p50 60 min over 35 recent runs).

This PR removes most of those steps without changing what is tested:

- `.github/actions/pytest-local/action.yml`: one shell step per invocation. The MinIO wait, GPU visibility check, TensorRT-LLM slot cap, pytest run, and result processing run in the same shell. Coverage data files get a per-stage suffix (`.coverage.<stage>`) so stages sharing one `test-results/` directory do not overwrite each other. The action keeps its per-stage Allure and coverage uploads, under their pre-existing names (`allure-results-<framework>-<test_type>-<arch>-<run>-<job>`, `coverage-python-...`), because an external CI-metrics (Grafana) pipeline consumes them by name; only the JUnit upload moved out.
- `.github/workflows/shared-test.yml`: upload the JUnit results once per job after the last stage (one XML per stage inside), keeping the `test-results-*` prefix that `test_report.yaml` matches on. The six-step `datadog/test-visibility-github-action` is replaced by the environment variables it exported, set on the job container.
- `container/deps/requirements.test.txt`: pin `ddtrace==4.14.0`, the version the action installed at job start, so it ships in the test image.

### Measured results (run 33925050338, attempt 1, vs the 35-run baseline p50)

Measured before the per-stage Allure and coverage uploads were restored in review; each restored step is one more hook round trip (27 to 41 s on the GPU pool), so expect the GPU test jobs about 2.3 min slower than this table.

| Job | baseline p50 | this PR | hook round trips |
|---|---|---|---|
| trtllm-runtime / Test cuda13.1, amd64 | 64.8 min | **46.9** | 30 -> 10 |
| vllm-runtime / Test cuda13.0, amd64 | 60.4 | **39.2** | 33 -> 11 |
| sglang-runtime / Test cuda13.0, amd64 | 42.6 | **32.1** | |
| trtllm-runtime / 2-GPU Test | 39.7 | 35.6 | |
| vllm-runtime / 2-GPU Test | 31.0 | 27.6 | |
| sglang-runtime / 2-GPU Test | 19.5 | 17.5 | |
| trtllm-runtime / Test, arm64 | 5.7 | 2.0 | |
| vllm-runtime / Test, arm64 | 6.5 | 5.2 | 20 -> 9 |
| dynamo-runtime / test / gpu | 12.8 | 12.4 (same-job: 14.4 -> 12.4) | 12 -> 6 |
| dynamo-runtime / test / sequential amd64 / arm64 | 35.8 / 44.8 | 35.8 / 44.2 | CPU pool, hook is cheap there |

Run wall clock: **62.2 min**, ending on TensorRT-LLM Test at minute 62.0. Baseline runs that include the TensorRT-LLM job ended at minute 76.9 (p50) to 86.2 (p90).

Attribution: pytest wall times are unchanged to within seconds (vLLM GPU-parallel 28:14 -> 28:16, TensorRT-LLM GPU-parallel 16:44 -> 16:29, dynamo sequential 33:00 -> 33:39), so the savings are the removed wrapper steps. On vLLM, ~15 of the 24 minutes are the collapse and ~8 are an image pull that happened to hit a warm node (10.4 -> 2.2 min); on TensorRT-LLM the pull was at its usual 23 min and ~19 of the 21 minutes are the collapse. The old TensorRT-LLM sequential GPU stage spent 8.3 min wrapping 29 s of tests; it now takes 1.3. The per-step overhead is specific to the GPU runner pool (`prod-tester-amd-gpu-v2`); on the CPU and arm64 pools the hook costs 2 to 8 s, so those jobs changed little.

### Datadog: previously-missing coverage, and a first-run retry storm

The `datadog/test-visibility-github-action` step ran with `continue-on-error: true` and had been **silently failing on every dynamo-runtime and planner test job**: those images have no `curl` or `wget`, and the action's install script exits with `Error: Neither wget nor curl is installed.` before installing ddtrace. Only the vLLM, SGLang, and TensorRT-LLM suites were ever reporting to Datadog. With `ddtrace` now baked into the test image, the dynamo-runtime CPU/GPU jobs and the planner jobs report for the first time (decision: keep Early Flake Detection on everywhere).

First-run consequence: Datadog Early Flake Detection retries tests it has never seen up to 10 times, and it had never seen any test in those suites. In attempt 1: planner amd64 pytest 264 s -> 514 s (1,770 tests, 9,766 EFD re-runs); dynamo-runtime parallel amd64 673 s -> 1,503 s (3,970 re-runs); dynamo-runtime parallel arm64 hit its 30-minute step timeout mid-retry and failed. The two sequential jobs (3,433 tests) ran with the plugin active but were not retried and finished at baseline speed (+2%). Known tests are stored per test service, so once a suite has one clean session its tests stop being "new": attempt 2 re-ran only the failed arm64 parallel job and it passed in 18.7 min (baseline 18.1) with zero retries. Any suite reporting to Datadog for the first time should expect the same one-time ~2x pytest time and be checked against its step timeout.

## Details:

Inputs are passed to the shell step through `env:` rather than interpolated into the script body. The pytest body is otherwise unchanged from the previous "Run pytest" step. `PYTEST_XDIST_AUTO_NUM_WORKERS=2` for TensorRT-LLM is now exported inside the step rather than via `GITHUB_ENV`; only the GPU-parallel stage read it. `JOB_CHECK_RUN_ID`, which the Datadog action exported, is set on the step because the `job` context is not available in job-level `env`.

### Validation

Local:
- Both YAML files parse; `bash -n` accepts the extracted `run:` script and resolves the Python heredoc.
- Old and new pytest shell bodies diff to only the intended lines after mapping `${{ inputs.* }}` to env vars.
- No other workflow reads the `STR_TEST_TYPE` or `TEST_EXIT_CODE` values the old action exported to `GITHUB_ENV`; no reference to the removed action remains.
- `pre-commit` passes on the changed files (action pins, requirements sorter, marker report).

CI (run 33925050338):
- [x] Framework `Test ... amd64` jobs dropped 10 to 21 minutes against baseline (table above); hook round trips 33 -> 11 (vLLM), 30 -> 10 (TensorRT-LLM).
- [x] pytest logs show the `service: ai-dynamo (env: ci)` header and the `Datadog Test Reports` footer link with env-only configuration.
- [x] Each test job produces one `test-results-*` artifact (one XML per stage) and one `allure-results-*` artifact.
- [x] Attempt 2: the arm64 parallel job re-ran in 18.7 min (baseline 18.1) with zero EFD retries and the run finished green, confirming the storm is a one-time first-contact cost.
- [x] Run 34260047032 attempt 2 on `da7cdba` (review fixes; attempt 1 was cut short by a cluster-wide runner exec drop at 18:29 UTC and rerun in full): green across the matrix, 57.9 min wall. Per-stage artifacts as before the PR: vLLM Test 4 `allure-results-unknown-<test_type>-amd64-<run>-<job>` (cpu, cpu_e2e, gpu_parallel, gpu), TensorRT-LLM and SGLang 3 each (their CPU e2e stage is skipped), one `test-results-*` per job, no coverage artifacts (coverage is off in PR CI). Durations vs the table: TensorRT-LLM Test 42.5 min (46.9), SGLang Test 22.1 (32.1, warm image pull), vLLM Test 49.6 (39.2: +6 min cold image pull, +3.8 min of hook round trips including the restored uploads); 2-GPU jobs 27.3 / 34.2 / 16.7 (27.6 / 35.6 / 17.5); dynamo-runtime sequential 35.6 / 45.1 (35.8 / 44.2). The `allure-report` job is skipped by its workflow condition on PR runs.
- [ ] Nightly coverage merge picks up `.coverage.<stage>` files from the per-stage `coverage-python-*` artifacts (nightly run after merge).

## Where should the reviewer start?

`.github/workflows/shared-test.yml` (the Datadog env block and the JUnit upload step), then the single `run:` block and the two per-stage upload steps in `.github/actions/pytest-local/action.yml`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution with configurable parallelism, dry-run collection, VRAM-aware orchestration, and stage-specific coverage reporting.
  * Preserved test exit codes and improved handling of test results and reports.
  * Added Datadog test tracing and visibility integration for pytest runs.
  * Test, Allure, and optional coverage artifacts are now uploaded once per job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

