### PR TITLE
docs(operator): update API reference footer and regenerate Fern docs

### DIFF
--- a/deploy/operator/docs/footer.md
+++ b/deploy/operator/docs/footer.md
@@ -344,7 +344,6 @@ For users who want to understand the implementation details or contribute to the
 - **Checkpoint / Restore**:
   - [`internal/checkpoint/podspec.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/podspec.go) - Checkpoint env var injection and volume setup
   - [`internal/checkpoint/resolve.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resolve.go) - Checkpoint resolution logic
-  - [`internal/checkpoint/resource.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resource.go) - Checkpoint resource management
 - **Constants & Annotations**: [`internal/consts/consts.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/consts/consts.go) - Defines annotation keys and other constants
 
 ## Notes

--- a/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
+++ b/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
@@ -3865,7 +3865,6 @@ For users who want to understand the implementation details or contribute to the
 - **Checkpoint / Restore**:
   - [`internal/checkpoint/podspec.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/podspec.go) - Checkpoint env var injection and volume setup
   - [`internal/checkpoint/resolve.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resolve.go) - Checkpoint resolution logic
-  - [`internal/checkpoint/resource.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resource.go) - Checkpoint resource management
 - **Constants & Annotations**: [`internal/consts/consts.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/consts/consts.go) - Defines annotation keys and other constants
 
 ## Notes

--- a/docs/fern/pages/reference/kubernetes-api/full-api-reference.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/full-api-reference.mdx
@@ -5079,7 +5079,6 @@ For users who want to understand the implementation details or contribute to the
 - **Checkpoint / Restore**:
   - [`internal/checkpoint/podspec.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/podspec.go) - Checkpoint env var injection and volume setup
   - [`internal/checkpoint/resolve.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resolve.go) - Checkpoint resolution logic
-  - [`internal/checkpoint/resource.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resource.go) - Checkpoint resource management
 - **Constants & Annotations**: [`internal/consts/consts.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/consts/consts.go) - Defines annotation keys and other constants
 
 ### Notes


### PR DESCRIPTION
## Overview:

PR [14076 — feat(operator)!: migrate checkpoints to standalone Snapshot ](https://github.com/ai-dynamo/dynamo/pull/14076)deleted deploy/operator/internal/checkpoint/resource.go, leaving the footer link stale.

## Details:

- Remove the link from `deploy/operator/docs/footer.md`.
- Regenerate `api-reference-k8s.md` and `full-api-reference.mdx` to propagate the change.

## Where should the reviewer start?

Start with `deploy/operator/docs/footer.md`. The other two files contain the corresponding

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

Relates to #14076 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed internal implementation-reference links from operator default-values and checkpoint/restore API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->