### PR TITLE
fix(frontend): stop an invalid route extension flag from failing only after the engine loads

### DIFF
--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -114,6 +114,14 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
             raise ValueError(
                 "--tls-cert-path and --tls-key-path must be provided together"
             )
+        if self.frontend_route_extensions and (
+            self.interactive or self.kserve_grpc_server
+        ):
+            mode_flag = "--interactive" if self.interactive else "--kserve-grpc-server"
+            raise ValueError(
+                "--frontend-route-extension is only supported by the HTTP frontend, "
+                f"so it cannot be combined with {mode_flag}"
+            )
         if self.migration_limit < 0 or self.migration_limit > _U32_MAX:
             raise ValueError(
                 f"--migration-limit must be between 0 and {_U32_MAX} (0=disabled)"

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -467,14 +467,6 @@ async def async_main():
 
     e = EntrypointArgs(EngineType.Dynamic, **kwargs)
     engine = await make_engine(runtime, e)
-    # Validate mode compatibility before loading extensions, so an incompatible
-    # mode fails fast without importing/executing third-party provider code.
-    if config.frontend_route_extensions and (
-        config.interactive or config.kserve_grpc_server
-    ):
-        raise ValueError(
-            "frontend route extensions are only supported by HTTP frontend mode"
-        )
     frontend_route_extensions = load_frontend_route_extensions(
         config.frontend_route_extensions
     )

--- a/tests/frontend/test_frontend_route_extension_mode.py
+++ b/tests/frontend/test_frontend_route_extension_mode.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the input-mode rule that guards frontend route extensions.
+
+Route extensions are mounted on the HTTP frontend only, so pairing
+``--frontend-route-extension`` with a non-HTTP input mode is a
+misconfiguration. ``FrontendConfig.validate()`` runs before the distributed
+runtime and the engine exist, so rejecting the pairing there is what makes the
+frontend fail at startup rather than after it has taken runtime resources.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from dynamo.frontend.frontend_args import FrontendArgGroup, FrontendConfig
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+]
+
+# Defaults are read from the environment when the parser is built, so anything
+# set in the ambient environment would otherwise decide the outcome here.
+_ENV_VARS_READ_BY_THESE_TESTS = (
+    "DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD",
+    "DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD",
+    "DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC",
+    "DYN_FRONTEND_ROUTE_EXTENSIONS",
+    "DYN_INTERACTIVE",
+    "DYN_KSERVE_GRPC_SERVER",
+)
+
+
+def _config_from(monkeypatch: pytest.MonkeyPatch, argv: list[str]) -> FrontendConfig:
+    for name in _ENV_VARS_READ_BY_THESE_TESTS:
+        monkeypatch.delenv(name, raising=False)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+    return FrontendConfig.from_cli_args(parser.parse_args(argv))
+
+
+def test_extension_http_only_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _config_from(
+        monkeypatch,
+        ["-i", "--frontend-route-extension", "some.module:provider"],
+    )
+
+    with pytest.raises(ValueError, match="--frontend-route-extension"):
+        config.validate()
+
+
+def test_extension_http_only_guard_rejects_grpc_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config_from(
+        monkeypatch,
+        [
+            "--kserve-grpc-server",
+            "--frontend-route-extension",
+            "some.module:provider",
+        ],
+    )
+
+    with pytest.raises(ValueError, match="--frontend-route-extension"):
+        config.validate()
+
+
+def test_extension_http_only_guard_allows_default_http_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config_from(
+        monkeypatch,
+        ["--frontend-route-extension", "some.module:provider"],
+    )
+
+    config.validate()
+
+
+def test_extension_http_only_guard_allows_interactive_without_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config_from(monkeypatch, ["-i"])
+
+    config.validate()


### PR DESCRIPTION
## Overview:

Route extensions are mounted by the HTTP frontend only, so passing
`--frontend-route-extension` together with `-i` / `--interactive` or
`--kserve-grpc-server` is a misconfiguration. The frontend already rejected that
pairing, but only inside `async_main`, after the distributed runtime had been
built and the engine created. An operator whose discovery plane was unreachable
therefore saw a transport failure rather than the real problem. The frontend now
refuses the pairing while it is still parsing arguments.

## Details:

The rule moves into `FrontendConfig.validate()` in
`components/src/dynamo/frontend/frontend_args.py`, next to the other cross-field
startup rules such as the `--tls-cert-path` / `--tls-key-path` pairing. The
condition is carried over unchanged, so both non-HTTP modes are still covered;
the error now names the flag as it is spelled on the command line and the mode
flag it conflicts with. `parse_args()` calls `validate()` before any runtime
object exists, so the now-redundant late check in
`components/src/dynamo/frontend/main.py` is deleted. The Rust guard in
`lib/llm/src/entrypoint/input.rs` is untouched and still covers callers that do
not enter through the Python frontend.

`tests/frontend/test_frontend_route_extension_mode.py` is new: it pins the
rejection for each non-HTTP mode and adds two negative controls, so an
over-broad rule would fail.

## Where should the reviewer start?

`components/src/dynamo/frontend/frontend_args.py` for the rule itself, then
`tests/frontend/test_frontend_route_extension_mode.py`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Validation

- `pre-commit run --files components/src/dynamo/frontend/frontend_args.py components/src/dynamo/frontend/main.py tests/frontend/test_frontend_route_extension_mode.py --hook-stage manual` — every hook with a file to check passed.
- `pytest tests/frontend/ -k "extension_http_only or route_construction" -m "unit and not gpu"` — `23 passed, 1 skipped, 98 deselected`. With the two production files reverted to their base content and the new tests kept, the same command reports `2 failed`, both with `DID NOT RAISE <class 'ValueError'>`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Route extensions are now restricted to HTTP frontend mode.
  - Interactive and KServe gRPC modes provide clearer validation when route extensions are specified.

- **Tests**
  - Added coverage for valid and invalid route-extension combinations across HTTP, interactive, and KServe gRPC modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->