### PR TITLE
fix(vllm): start the omni stage router on a host with no accelerator

### DIFF
--- a/components/src/dynamo/vllm/omni/args.py
+++ b/components/src/dynamo/vllm/omni/args.py
@@ -481,10 +481,19 @@ def _wants_stage_router(argv: list[str]) -> bool:
     which keeps the full engine parser even when ``--omni-router`` is also
     present: that combination is rejected by :meth:`OmniConfig.validate`, and
     the stage worker's argument handling must not change on the way there.
+
+    Both scans stop at the first bare ``--``. Argparse treats that token as the
+    end-of-options delimiter and everything after it as positional, so
+    ``--omni-router -- --stage-id 0`` leaves ``stage_id`` unset. A scan that read
+    all of ``argv`` would still see the token and send the router to the engine
+    parser it cannot build on a host with no accelerator.
     """
-    if any(token == "--stage-id" or token.startswith("--stage-id=") for token in argv):
+    options = argv[: argv.index("--")] if "--" in argv else argv
+    if any(
+        token == "--stage-id" or token.startswith("--stage-id=") for token in options
+    ):
         return False
-    for token in reversed(argv):
+    for token in reversed(options):
         if token == "--omni-router":
             return True
         if token == "--no-omni-router":

--- a/components/src/dynamo/vllm/omni/args.py
+++ b/components/src/dynamo/vllm/omni/args.py
@@ -7,6 +7,8 @@ import argparse
 import dataclasses
 import logging
 import os
+import sys
+from types import SimpleNamespace
 from typing import Optional
 
 import huggingface_hub
@@ -23,7 +25,11 @@ from dynamo.common.configuration.groups.runtime_args import (
     DynamoRuntimeArgGroup,
     DynamoRuntimeConfig,
 )
-from dynamo.common.configuration.utils import add_argument, add_negatable_bool_argument
+from dynamo.common.configuration.utils import (
+    add_argument,
+    add_negatable_bool_argument,
+    env_or_default,
+)
 from dynamo.common.constants import DisaggregationMode
 
 logger = logging.getLogger(__name__)
@@ -451,6 +457,63 @@ class OmniConfig(DynamoRuntimeConfig):
             )
 
 
+def _wants_stage_router(argv: list[str]) -> bool:
+    """Decide whether this process is the stage router, before any parser exists.
+
+    ``OmniEngineArgs.add_cli_args`` instantiates every vLLM config dataclass to
+    compute its argparse defaults, and ``DeviceConfig.__post_init__`` raises
+    ``RuntimeError: Failed to infer device type`` when vLLM recognizes no
+    accelerator. That fires while *building* the parser, so the stage router --
+    which dispatches to stage workers over the Dynamo runtime and never
+    constructs an engine -- has to know its own role before the parser it would
+    otherwise crash on is built. Hence the raw ``argv`` scan.
+
+    Precedence follows the ``--omni-router`` flag registered in
+    :class:`OmniArgGroup`: it is an ``argparse.BooleanOptionalAction`` whose
+    default comes from ``DYN_OMNI_ROUTER``, so the last of ``--omni-router`` /
+    ``--no-omni-router`` on the command line wins and the environment applies
+    only when neither is present. The environment is read through the same
+    ``env_or_default`` call the flag itself uses, so a deployment that selects
+    the router purely through ``DYN_OMNI_ROUTER`` -- with no token on the
+    command line at all -- resolves identically in both places.
+
+    ``--stage-id`` on the command line means an engine-building stage worker,
+    which keeps the full engine parser even when ``--omni-router`` is also
+    present: that combination is rejected by :meth:`OmniConfig.validate`, and
+    the stage worker's argument handling must not change on the way there.
+    """
+    if any(token == "--stage-id" or token.startswith("--stage-id=") for token in argv):
+        return False
+    for token in reversed(argv):
+        if token == "--omni-router":
+            return True
+        if token == "--no-omni-router":
+            return False
+    return bool(env_or_default("DYN_OMNI_ROUTER", False))
+
+
+def _add_stage_router_engine_args(parser: argparse.ArgumentParser) -> None:
+    """Register the only engine options the stage router itself reads.
+
+    Each one mirrors the corresponding action from
+    ``OmniEngineArgs.add_cli_args`` -- same flag, same ``nargs``, same default
+    -- so router argv that parsed before parses the same way now. Nothing here
+    instantiates a vLLM config dataclass, so device detection is never reached.
+    """
+    parser.add_argument("--model", type=str, default=OmniEngineArgs.model)
+    parser.add_argument(
+        "--served-model-name",
+        type=str,
+        nargs="+",
+        default=None,
+        dest="served_model_name",
+    )
+    parser.add_argument(
+        "--trust-remote-code", action=argparse.BooleanOptionalAction, default=False
+    )
+    parser.add_argument("--revision", type=str, default=None)
+
+
 def parse_omni_args() -> OmniConfig:
     """Parse command-line arguments for the vLLM-Omni backend."""
     dynamo_runtime_argspec = DynamoRuntimeArgGroup()
@@ -468,8 +531,12 @@ def parse_omni_args() -> OmniConfig:
     vg = parser.add_argument_group(
         "vLLM-Omni Engine Options. Please refer to vLLM-Omni documentation for more details."
     )
+    stage_router = _wants_stage_router(sys.argv[1:])
     vllm_parser = FlexibleArgumentParser(add_help=False)
-    OmniEngineArgs.add_cli_args(vllm_parser)
+    if stage_router:
+        _add_stage_router_engine_args(vllm_parser)
+    else:
+        OmniEngineArgs.add_cli_args(vllm_parser)
 
     for action in vllm_parser._actions:
         if not action.option_strings:
@@ -482,7 +549,22 @@ def parse_omni_args() -> OmniConfig:
     if config.endpoint is None:
         config.endpoint = "generate"
 
-    vllm_args = vllm_parser.parse_args(unknown)
+    if stage_router:
+        # The launch scripts forward their EXTRA_ARGS passthrough to every omni
+        # process, router included, so engine flags meant for the stage workers
+        # land here. The reduced parser does not know them and must not abort on
+        # them, but a mistyped flag still has to be visible.
+        vllm_args, ignored = vllm_parser.parse_known_args(unknown)
+        if ignored:
+            logger.warning(
+                "Stage router ignoring unrecognized engine options: %s. "
+                "The router never builds an engine; only --model, "
+                "--served-model-name, --trust-remote-code and --revision "
+                "are honored on this path.",
+                " ".join(ignored),
+            )
+    else:
+        vllm_args = vllm_parser.parse_args(unknown)
     config.model = vllm_args.model
 
     # Resolve repo id to local snapshot path under HF_HUB_OFFLINE so
@@ -510,7 +592,24 @@ def parse_omni_args() -> OmniConfig:
                 config.model,
             )
 
-    engine_args = OmniEngineArgs.from_cli_args(vllm_args)
+    if stage_router:
+        # OmniConfig.engine_args has no class-level default, so from_cli_args
+        # never materializes it; leaving it unset makes main.worker() fail on
+        # config.engine_args before it ever reaches the router dispatch.
+        # OmniHandler already stands a SimpleNamespace in for engine_args on a
+        # path that has no vLLM engine args to hand, so the shape is one
+        # downstream consumers already see.
+        engine_args = SimpleNamespace(
+            # The parsed value, not the snapshot path config.model may have been
+            # rewritten to above -- the non-router path leaves engine_args.model
+            # as the repo id too (see the note in dynamo/vllm/main.py).
+            model=vllm_args.model,
+            served_model_name=vllm_args.served_model_name,
+            trust_remote_code=vllm_args.trust_remote_code,
+            revision=vllm_args.revision,
+        )
+    else:
+        engine_args = OmniEngineArgs.from_cli_args(vllm_args)
 
     if getattr(engine_args, "served_model_name", None) is not None:
         served = engine_args.served_model_name

--- a/components/src/dynamo/vllm/omni/args.py
+++ b/components/src/dynamo/vllm/omni/args.py
@@ -550,10 +550,8 @@ def parse_omni_args() -> OmniConfig:
         config.endpoint = "generate"
 
     if stage_router:
-        # The launch scripts forward their EXTRA_ARGS passthrough to every omni
-        # process, router included, so engine flags meant for the stage workers
-        # land here. The reduced parser does not know them and must not abort on
-        # them, but a mistyped flag still has to be visible.
+        # Launch scripts forward EXTRA_ARGS to every omni process, so stage-worker
+        # engine flags reach the router; tolerate them, but keep a typo visible.
         vllm_args, ignored = vllm_parser.parse_known_args(unknown)
         if ignored:
             logger.warning(
@@ -593,16 +591,11 @@ def parse_omni_args() -> OmniConfig:
             )
 
     if stage_router:
-        # OmniConfig.engine_args has no class-level default, so from_cli_args
-        # never materializes it; leaving it unset makes main.worker() fail on
-        # config.engine_args before it ever reaches the router dispatch.
-        # OmniHandler already stands a SimpleNamespace in for engine_args on a
-        # path that has no vLLM engine args to hand, so the shape is one
-        # downstream consumers already see.
+        # OmniConfig.engine_args has no class-level default, so leaving it unset
+        # makes main.worker() fail before it reaches the router dispatch.
         engine_args = SimpleNamespace(
-            # The parsed value, not the snapshot path config.model may have been
-            # rewritten to above -- the non-router path leaves engine_args.model
-            # as the repo id too (see the note in dynamo/vllm/main.py).
+            # The parsed repo id, not the snapshot path config.model may have
+            # been rewritten to above; the non-router path leaves this the same.
             model=vllm_args.model,
             served_model_name=vllm_args.served_model_name,
             trust_remote_code=vllm_args.trust_remote_code,

--- a/components/src/dynamo/vllm/omni/args.py
+++ b/components/src/dynamo/vllm/omni/args.py
@@ -7,6 +7,7 @@ import argparse
 import dataclasses
 import logging
 import os
+import re
 import sys
 from types import SimpleNamespace
 from typing import Optional
@@ -501,6 +502,32 @@ def _wants_stage_router(argv: list[str]) -> bool:
     return bool(env_or_default("DYN_OMNI_ROUTER", False))
 
 
+# Everything from the leading "--" up to the first "." -- the option name, but
+# not the key of a dotted value such as --json-arg.key_1.
+_OPTION_NAME = re.compile(r"(?<=^--)[^.]*")
+
+
+def _normalize_engine_option_names(argv: list[str]) -> list[str]:
+    """Rewrite ``--served_model_name`` to ``--served-model-name``, as vLLM does.
+
+    ``FlexibleArgumentParser`` accepts either spelling, but only through
+    ``parse_args``, which rewrites underscores to dashes in the option name
+    before parsing. ``parse_known_args`` -- which the stage router calls so that
+    a stage worker's engine flags stay non-fatal -- does not. Without this, the
+    underscore spelling would bind on the stage-worker path and be reported as
+    unrecognized on the router path, silently dropping the requested value.
+    """
+    normalized = []
+    for token in argv:
+        if not token.startswith("--"):
+            normalized.append(token)
+            continue
+        name, sep, value = token.partition("=")
+        name = _OPTION_NAME.sub(lambda match: match.group(0).replace("_", "-"), name)
+        normalized.append(f"{name}{sep}{value}" if sep else name)
+    return normalized
+
+
 def _add_stage_router_engine_args(parser: argparse.ArgumentParser) -> None:
     """Register the only engine options the stage router itself reads.
 
@@ -561,7 +588,9 @@ def parse_omni_args() -> OmniConfig:
     if stage_router:
         # Launch scripts forward EXTRA_ARGS to every omni process, so stage-worker
         # engine flags reach the router; tolerate them, but keep a typo visible.
-        vllm_args, ignored = vllm_parser.parse_known_args(unknown)
+        vllm_args, ignored = vllm_parser.parse_known_args(
+            _normalize_engine_option_names(unknown)
+        )
         if ignored:
             logger.warning(
                 "Stage router ignoring unrecognized engine options: %s. "
@@ -609,6 +638,11 @@ def parse_omni_args() -> OmniConfig:
             served_model_name=vllm_args.served_model_name,
             trust_remote_code=vllm_args.trust_remote_code,
             revision=vllm_args.revision,
+            # init_omni_stage_router() -> setup_metrics_collection() reads this
+            # straight off engine_args; the engine default keeps the router's
+            # metrics registration identical to the full OmniEngineArgs it used
+            # to build.
+            disable_log_stats=OmniEngineArgs.disable_log_stats,
         )
     else:
         engine_args = OmniEngineArgs.from_cli_args(vllm_args)

--- a/components/src/dynamo/vllm/omni/args.py
+++ b/components/src/dynamo/vllm/omni/args.py
@@ -459,35 +459,10 @@ class OmniConfig(DynamoRuntimeConfig):
 
 
 def _wants_stage_router(argv: list[str]) -> bool:
-    """Decide whether this process is the stage router, before any parser exists.
+    """Detect router mode before vLLM parser construction infers a device.
 
-    ``OmniEngineArgs.add_cli_args`` instantiates every vLLM config dataclass to
-    compute its argparse defaults, and ``DeviceConfig.__post_init__`` raises
-    ``RuntimeError: Failed to infer device type`` when vLLM recognizes no
-    accelerator. That fires while *building* the parser, so the stage router --
-    which dispatches to stage workers over the Dynamo runtime and never
-    constructs an engine -- has to know its own role before the parser it would
-    otherwise crash on is built. Hence the raw ``argv`` scan.
-
-    Precedence follows the ``--omni-router`` flag registered in
-    :class:`OmniArgGroup`: it is an ``argparse.BooleanOptionalAction`` whose
-    default comes from ``DYN_OMNI_ROUTER``, so the last of ``--omni-router`` /
-    ``--no-omni-router`` on the command line wins and the environment applies
-    only when neither is present. The environment is read through the same
-    ``env_or_default`` call the flag itself uses, so a deployment that selects
-    the router purely through ``DYN_OMNI_ROUTER`` -- with no token on the
-    command line at all -- resolves identically in both places.
-
-    ``--stage-id`` on the command line means an engine-building stage worker,
-    which keeps the full engine parser even when ``--omni-router`` is also
-    present: that combination is rejected by :meth:`OmniConfig.validate`, and
-    the stage worker's argument handling must not change on the way there.
-
-    Both scans stop at the first bare ``--``. Argparse treats that token as the
-    end-of-options delimiter and everything after it as positional, so
-    ``--omni-router -- --stage-id 0`` leaves ``stage_id`` unset. A scan that read
-    all of ``argv`` would still see the token and send the router to the engine
-    parser it cannot build on a host with no accelerator.
+    Match argparse precedence through the first ``--``; an explicit stage ID
+    keeps the full engine path.
     """
     options = argv[: argv.index("--")] if "--" in argv else argv
     if any(
@@ -548,6 +523,11 @@ def _add_stage_router_engine_args(parser: argparse.ArgumentParser) -> None:
         "--trust-remote-code", action=argparse.BooleanOptionalAction, default=False
     )
     parser.add_argument("--revision", type=str, default=None)
+    parser.add_argument(
+        "--disable-log-stats",
+        action="store_true",
+        default=OmniEngineArgs.disable_log_stats,
+    )
 
 
 def parse_omni_args() -> OmniConfig:
@@ -586,18 +566,16 @@ def parse_omni_args() -> OmniConfig:
         config.endpoint = "generate"
 
     if stage_router:
-        # Launch scripts forward EXTRA_ARGS to every omni process, so stage-worker
-        # engine flags reach the router; tolerate them, but keep a typo visible.
+        if "--config" in unknown:
+            unknown = vllm_parser._pull_args_from_config(unknown)
         vllm_args, ignored = vllm_parser.parse_known_args(
             _normalize_engine_option_names(unknown)
         )
         if ignored:
             logger.warning(
-                "Stage router ignoring unrecognized engine options: %s. "
-                "The router never builds an engine; only --model, "
-                "--served-model-name, --trust-remote-code and --revision "
-                "are honored on this path.",
-                " ".join(ignored),
+                "Stage router ignored %d unrecognized engine argument tokens; "
+                "the router does not build an engine.",
+                len(ignored),
             )
     else:
         vllm_args = vllm_parser.parse_args(unknown)
@@ -638,11 +616,7 @@ def parse_omni_args() -> OmniConfig:
             served_model_name=vllm_args.served_model_name,
             trust_remote_code=vllm_args.trust_remote_code,
             revision=vllm_args.revision,
-            # init_omni_stage_router() -> setup_metrics_collection() reads this
-            # straight off engine_args; the engine default keeps the router's
-            # metrics registration identical to the full OmniEngineArgs it used
-            # to build.
-            disable_log_stats=OmniEngineArgs.disable_log_stats,
+            disable_log_stats=vllm_args.disable_log_stats,
         )
     else:
         engine_args = OmniEngineArgs.from_cli_args(vllm_args)

--- a/components/src/dynamo/vllm/tests/omni/test_omni_args.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_args.py
@@ -281,6 +281,35 @@ def test_stage_worker_still_requires_an_accelerator(monkeypatch, tmp_path):
         parse_omni_args()
 
 
+def test_stage_router_ignores_stage_id_after_end_of_options(monkeypatch, tmp_path):
+    # Argparse never reads --stage-id past a bare --, so neither may the role
+    # pre-scan: treating it as a stage worker would build the engine parser
+    # this host cannot resolve a device for.
+    monkeypatch.setattr(
+        sys, "argv", _router_argv(tmp_path, "--omni-router", "--", "--stage-id", "0")
+    )
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    assert config.omni_router is True
+    assert config.stage_id is None
+    assert config.model == "test-model"
+
+
+def test_stage_router_ignores_negated_flag_after_end_of_options(monkeypatch, tmp_path):
+    # Same delimiter rule for the precedence scan: --no-omni-router past -- is a
+    # positional, so the environment still selects the router.
+    monkeypatch.setenv("DYN_OMNI_ROUTER", "true")
+    monkeypatch.setattr(sys, "argv", _router_argv(tmp_path, "--", "--no-omni-router"))
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    assert config.omni_router is True
+    assert config.model == "test-model"
+
+
 def test_parse_rejects_stage_id_combined_with_omni_router(monkeypatch, tmp_path):
     # The role pre-scan must not swallow the existing mutual-exclusion check.
     # No _no_accelerator here: --stage-id keeps this argv on the full parser.

--- a/components/src/dynamo/vllm/tests/omni/test_omni_args.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_args.py
@@ -5,6 +5,7 @@
 
 import contextlib
 import dataclasses
+import logging
 import sys
 from types import SimpleNamespace
 
@@ -321,6 +322,50 @@ def test_stage_id_keeps_the_full_parser_alongside_omni_router(monkeypatch, tmp_p
 
     with _no_accelerator(), pytest.raises(RuntimeError, match="Failed to infer device"):
         parse_omni_args()
+
+
+def test_stage_router_accepts_underscore_option_names(monkeypatch, tmp_path):
+    # FlexibleArgumentParser accepts either spelling, but the rewrite lives in
+    # parse_args and the router path calls parse_known_args. Unnormalized, this
+    # name is merely warned about and the served name is lost.
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        _router_argv(tmp_path, "--omni-router", "--served_model_name", "public-alias"),
+    )
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    assert config.served_model_name == "public-alias"
+    assert config.engine_args.served_model_name == ["public-alias"]
+
+
+def test_stage_router_engine_args_satisfy_metrics_setup(monkeypatch, tmp_path):
+    # init_omni_stage_router() hands this config to the shared
+    # setup_metrics_collection(), which reads fields directly off engine_args --
+    # so the router's reduced namespace has to carry them or the router dies
+    # right after the parse this change exists to make work.
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setattr(sys, "argv", _router_argv(tmp_path, "--omni-router"))
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    registered: list[dict] = []
+    monkeypatch.setattr(
+        vllm_main,
+        "register_engine_metrics_callback",
+        lambda **kwargs: registered.append(kwargs),
+    )
+    monkeypatch.delenv("PROMETHEUS_MULTIPROC_DIR", raising=False)
+
+    vllm_main.setup_metrics_collection(
+        config, SimpleNamespace(), logging.getLogger(__name__)
+    )
+
+    assert registered, "router metrics registration must still happen"
 
 
 # --- vllm_omni API compatibility guards ---

--- a/components/src/dynamo/vllm/tests/omni/test_omni_args.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_args.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for OmniConfig validation."""
+"""Unit tests for OmniConfig validation and omni argument parsing."""
 
+import contextlib
 import dataclasses
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -13,6 +15,7 @@ try:
         OmniConfig,
         OmniDiffusionKwargs,
         OmniParallelKwargs,
+        parse_omni_args,
     )
 except ImportError:
     pytest.skip("vLLM omni dependencies not available", allow_module_level=True)
@@ -167,6 +170,128 @@ def test_omni_router_with_stage_configs_path_valid(tmp_path):
         omni_router=True, stage_configs_path=str(tmp_path / "stages.yaml")
     )
     config.validate()
+
+
+# --- parse_omni_args() on a host with no accelerator ---
+
+_PLATFORM_UNSET = object()
+
+
+@contextlib.contextmanager
+def _no_accelerator():
+    """Pin the platform a host with no accelerator resolves to.
+
+    Every builtin plugin declines there and vLLM falls back to
+    ``UnspecifiedPlatform``, whose ``device_type`` is the empty string -- the
+    state ``DeviceConfig.__post_init__`` raises on. Restores exactly the way
+    ``vllm_cpu_platform_when_no_accelerator`` does: *delete* the module-dict
+    entry when there was none, so the PEP 562 lazy ``__getattr__`` in
+    ``vllm.platforms`` is re-armed for later tests on this worker.
+    """
+    import vllm.platforms as vllm_platforms
+    from vllm.platforms.interface import UnspecifiedPlatform
+
+    previous = vllm_platforms.__dict__.get("current_platform", _PLATFORM_UNSET)
+    vllm_platforms.current_platform = UnspecifiedPlatform()
+    try:
+        yield
+    finally:
+        if previous is _PLATFORM_UNSET:
+            del vllm_platforms.current_platform
+        else:
+            vllm_platforms.current_platform = previous
+
+
+def _router_argv(tmp_path, *extra):
+    return [
+        "dynamo.vllm.omni",
+        "--stage-configs-path",
+        str(tmp_path / "stages.yaml"),
+        "--model",
+        "test-model",
+        *extra,
+    ]
+
+
+def test_stage_router_parses_without_an_accelerator(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", _router_argv(tmp_path, "--omni-router"))
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    assert config.omni_router is True
+    assert config.model == "test-model"
+    assert config.engine_args.model == "test-model"
+    assert config.engine_args.trust_remote_code is False
+
+
+def test_stage_router_selected_by_environment_parses_without_an_accelerator(
+    monkeypatch, tmp_path
+):
+    # The containerized deployment shape: the role comes from DYN_OMNI_ROUTER
+    # with no --omni-router token on the command line at all.
+    monkeypatch.setenv("DYN_OMNI_ROUTER", "true")
+    monkeypatch.setattr(sys, "argv", _router_argv(tmp_path))
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    assert config.omni_router is True
+    assert config.model == "test-model"
+
+
+def test_stage_router_ignores_engine_option_passthrough(monkeypatch, tmp_path):
+    # The launch scripts forward their EXTRA_ARGS to every omni process, so
+    # engine-only flags reach the router and must not abort it.
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        _router_argv(
+            tmp_path,
+            "--omni-router",
+            "--gpu-memory-utilization",
+            "0.9",
+            "--enable-lora",
+        ),
+    )
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    assert config.omni_router is True
+    assert config.model == "test-model"
+
+
+def test_stage_router_honors_negated_flag_over_environment(monkeypatch, tmp_path):
+    # --no-omni-router must win over a truthy DYN_OMNI_ROUTER, the way argparse
+    # itself resolves a flag against its env-derived default. Losing that would
+    # route an engine-building worker onto the reduced parser.
+    monkeypatch.setenv("DYN_OMNI_ROUTER", "true")
+    monkeypatch.setattr(sys, "argv", _router_argv(tmp_path, "--no-omni-router"))
+
+    with _no_accelerator(), pytest.raises(RuntimeError, match="Failed to infer device"):
+        parse_omni_args()
+
+
+def test_stage_worker_still_requires_an_accelerator(monkeypatch, tmp_path):
+    # Negative control: --stage-id builds an engine, so it must keep failing
+    # loudly here rather than being swept up by the router's reduced parser.
+    monkeypatch.setattr(sys, "argv", _router_argv(tmp_path, "--stage-id", "0"))
+
+    with _no_accelerator(), pytest.raises(RuntimeError, match="Failed to infer device"):
+        parse_omni_args()
+
+
+def test_parse_rejects_stage_id_combined_with_omni_router(monkeypatch, tmp_path):
+    # The role pre-scan must not swallow the existing mutual-exclusion check.
+    # Runs under the module fixture's resolvable platform, not _no_accelerator,
+    # because --stage-id keeps this argv on the full engine parser.
+    monkeypatch.setattr(
+        sys, "argv", _router_argv(tmp_path, "--stage-id", "0", "--omni-router")
+    )
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        parse_omni_args()
 
 
 # --- vllm_omni API compatibility guards ---

--- a/components/src/dynamo/vllm/tests/omni/test_omni_args.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_args.py
@@ -263,9 +263,8 @@ def test_stage_router_ignores_engine_option_passthrough(monkeypatch, tmp_path):
 
 
 def test_stage_router_honors_negated_flag_over_environment(monkeypatch, tmp_path):
-    # --no-omni-router must win over a truthy DYN_OMNI_ROUTER, the way argparse
-    # itself resolves a flag against its env-derived default. Losing that would
-    # route an engine-building worker onto the reduced parser.
+    # --no-omni-router must win over a truthy DYN_OMNI_ROUTER; losing that
+    # would route an engine-building worker onto the reduced parser.
     monkeypatch.setenv("DYN_OMNI_ROUTER", "true")
     monkeypatch.setattr(sys, "argv", _router_argv(tmp_path, "--no-omni-router"))
 
@@ -284,8 +283,7 @@ def test_stage_worker_still_requires_an_accelerator(monkeypatch, tmp_path):
 
 def test_parse_rejects_stage_id_combined_with_omni_router(monkeypatch, tmp_path):
     # The role pre-scan must not swallow the existing mutual-exclusion check.
-    # Runs under the module fixture's resolvable platform, not _no_accelerator,
-    # because --stage-id keeps this argv on the full engine parser.
+    # No _no_accelerator here: --stage-id keeps this argv on the full parser.
     monkeypatch.setattr(
         sys, "argv", _router_argv(tmp_path, "--stage-id", "0", "--omni-router")
     )

--- a/components/src/dynamo/vllm/tests/omni/test_omni_args.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_args.py
@@ -228,8 +228,7 @@ def test_stage_router_parses_without_an_accelerator(monkeypatch, tmp_path):
 def test_stage_router_selected_by_environment_parses_without_an_accelerator(
     monkeypatch, tmp_path
 ):
-    # The containerized deployment shape: the role comes from DYN_OMNI_ROUTER
-    # with no --omni-router token on the command line at all.
+    # This is how the containerized deployment selects the router.
     monkeypatch.setenv("DYN_OMNI_ROUTER", "true")
     monkeypatch.setattr(sys, "argv", _router_argv(tmp_path))
 
@@ -310,14 +309,17 @@ def test_stage_router_ignores_negated_flag_after_end_of_options(monkeypatch, tmp
     assert config.model == "test-model"
 
 
-def test_parse_rejects_stage_id_combined_with_omni_router(monkeypatch, tmp_path):
-    # The role pre-scan must not swallow the existing mutual-exclusion check.
-    # No _no_accelerator here: --stage-id keeps this argv on the full parser.
+def test_stage_id_keeps_the_full_parser_alongside_omni_router(monkeypatch, tmp_path):
+    # --stage-id outranks --omni-router in the pre-scan, so this argv must still
+    # build the engine parser. The device error is what observes that choice:
+    # the reduced router parser resolves no device, so it would run on to the
+    # mutual-exclusion ValueError instead -- a result this argv also produces
+    # when the pre-scan is wrong, which is why it is asserted elsewhere.
     monkeypatch.setattr(
         sys, "argv", _router_argv(tmp_path, "--stage-id", "0", "--omni-router")
     )
 
-    with pytest.raises(ValueError, match="mutually exclusive"):
+    with _no_accelerator(), pytest.raises(RuntimeError, match="Failed to infer device"):
         parse_omni_args()
 
 

--- a/components/src/dynamo/vllm/tests/omni/test_omni_args.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_args.py
@@ -12,6 +12,10 @@ from types import SimpleNamespace
 import pytest
 
 try:
+    import vllm.platforms as vllm_platforms
+    from vllm.platforms.interface import UnspecifiedPlatform
+
+    from dynamo.vllm import main as vllm_main
     from dynamo.vllm.omni.args import (
         OmniConfig,
         OmniDiffusionKwargs,
@@ -189,9 +193,6 @@ def _no_accelerator():
     entry when there was none, so the PEP 562 lazy ``__getattr__`` in
     ``vllm.platforms`` is re-armed for later tests on this worker.
     """
-    import vllm.platforms as vllm_platforms
-    from vllm.platforms.interface import UnspecifiedPlatform
-
     previous = vllm_platforms.__dict__.get("current_platform", _PLATFORM_UNSET)
     vllm_platforms.current_platform = UnspecifiedPlatform()
     try:
@@ -229,7 +230,6 @@ def test_stage_router_parses_without_an_accelerator(monkeypatch, tmp_path):
 def test_stage_router_selected_by_environment_parses_without_an_accelerator(
     monkeypatch, tmp_path
 ):
-    # This is how the containerized deployment selects the router.
     monkeypatch.setenv("DYN_OMNI_ROUTER", "true")
     monkeypatch.setattr(sys, "argv", _router_argv(tmp_path))
 
@@ -240,18 +240,18 @@ def test_stage_router_selected_by_environment_parses_without_an_accelerator(
     assert config.model == "test-model"
 
 
-def test_stage_router_ignores_engine_option_passthrough(monkeypatch, tmp_path):
-    # The launch scripts forward their EXTRA_ARGS to every omni process, so
-    # engine-only flags reach the router and must not abort it.
+def test_stage_router_ignores_engine_options_without_logging_values(
+    monkeypatch, tmp_path, caplog
+):
+    secret = "secret-token-value"
     monkeypatch.setattr(
         sys,
         "argv",
         _router_argv(
             tmp_path,
             "--omni-router",
-            "--gpu-memory-utilization",
-            "0.9",
-            "--enable-lora",
+            "--hf-token",
+            secret,
         ),
     )
 
@@ -260,6 +260,8 @@ def test_stage_router_ignores_engine_option_passthrough(monkeypatch, tmp_path):
 
     assert config.omni_router is True
     assert config.model == "test-model"
+    assert "Stage router ignored 2 unrecognized engine argument tokens" in caplog.text
+    assert secret not in caplog.text
 
 
 def test_stage_router_honors_negated_flag_over_environment(monkeypatch, tmp_path):
@@ -282,9 +284,6 @@ def test_stage_worker_still_requires_an_accelerator(monkeypatch, tmp_path):
 
 
 def test_stage_router_ignores_stage_id_after_end_of_options(monkeypatch, tmp_path):
-    # Argparse never reads --stage-id past a bare --, so neither may the role
-    # pre-scan: treating it as a stage worker would build the engine parser
-    # this host cannot resolve a device for.
     monkeypatch.setattr(
         sys, "argv", _router_argv(tmp_path, "--omni-router", "--", "--stage-id", "0")
     )
@@ -298,8 +297,6 @@ def test_stage_router_ignores_stage_id_after_end_of_options(monkeypatch, tmp_pat
 
 
 def test_stage_router_ignores_negated_flag_after_end_of_options(monkeypatch, tmp_path):
-    # Same delimiter rule for the precedence scan: --no-omni-router past -- is a
-    # positional, so the environment still selects the router.
     monkeypatch.setenv("DYN_OMNI_ROUTER", "true")
     monkeypatch.setattr(sys, "argv", _router_argv(tmp_path, "--", "--no-omni-router"))
 
@@ -325,9 +322,6 @@ def test_stage_id_keeps_the_full_parser_alongside_omni_router(monkeypatch, tmp_p
 
 
 def test_stage_router_accepts_underscore_option_names(monkeypatch, tmp_path):
-    # FlexibleArgumentParser accepts either spelling, but the rewrite lives in
-    # parse_args and the router path calls parse_known_args. Unnormalized, this
-    # name is merely warned about and the served name is lost.
     monkeypatch.setattr(
         sys,
         "argv",
@@ -341,14 +335,43 @@ def test_stage_router_accepts_underscore_option_names(monkeypatch, tmp_path):
     assert config.engine_args.served_model_name == ["public-alias"]
 
 
-def test_stage_router_engine_args_satisfy_metrics_setup(monkeypatch, tmp_path):
-    # init_omni_stage_router() hands this config to the shared
-    # setup_metrics_collection(), which reads fields directly off engine_args --
-    # so the router's reduced namespace has to carry them or the router dies
-    # right after the parse this change exists to make work.
-    from dynamo.vllm import main as vllm_main
+def test_stage_router_loads_engine_options_from_config(monkeypatch, tmp_path):
+    config_path = tmp_path / "router.yaml"
+    config_path.write_text(
+        "model: config-model\n"
+        "served-model-name: [public-alias]\n"
+        "trust-remote-code: true\n"
+        "revision: test-revision\n"
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "dynamo.vllm.omni",
+            "--stage-configs-path",
+            str(tmp_path / "stages.yaml"),
+            "--omni-router",
+            "--config",
+            str(config_path),
+        ],
+    )
 
-    monkeypatch.setattr(sys, "argv", _router_argv(tmp_path, "--omni-router"))
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    assert config.model == "config-model"
+    assert config.served_model_name == "public-alias"
+    assert config.engine_args.served_model_name == ["public-alias"]
+    assert config.engine_args.trust_remote_code is True
+    assert config.engine_args.revision == "test-revision"
+
+
+def test_stage_router_honors_disable_log_stats(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        _router_argv(tmp_path, "--omni-router", "--disable-log-stats"),
+    )
 
     with _no_accelerator():
         config = parse_omni_args()
@@ -365,7 +388,8 @@ def test_stage_router_engine_args_satisfy_metrics_setup(monkeypatch, tmp_path):
         config, SimpleNamespace(), logging.getLogger(__name__)
     )
 
-    assert registered, "router metrics registration must still happen"
+    assert config.engine_args.disable_log_stats is True
+    assert not registered
 
 
 # --- vllm_omni API compatibility guards ---

--- a/components/src/dynamo/vllm/tests/omni/test_omni_args.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_args.py
@@ -13,12 +13,15 @@ import pytest
 
 try:
     import vllm.platforms as vllm_platforms
+    from vllm.engine.arg_utils import _compute_kwargs
     from vllm.platforms.interface import UnspecifiedPlatform
 
     from dynamo.vllm import main as vllm_main
     from dynamo.vllm.omni.args import (
+        FlexibleArgumentParser,
         OmniConfig,
         OmniDiffusionKwargs,
+        OmniEngineArgs,
         OmniParallelKwargs,
         parse_omni_args,
     )
@@ -194,10 +197,13 @@ def _no_accelerator():
     ``vllm.platforms`` is re-armed for later tests on this worker.
     """
     previous = vllm_platforms.__dict__.get("current_platform", _PLATFORM_UNSET)
+    # Cached parser defaults include DeviceConfig from the previous platform.
+    _compute_kwargs.cache_clear()
     vllm_platforms.current_platform = UnspecifiedPlatform()
     try:
         yield
     finally:
+        _compute_kwargs.cache_clear()
         if previous is _PLATFORM_UNSET:
             del vllm_platforms.current_platform
         else:
@@ -274,7 +280,11 @@ def test_stage_router_honors_negated_flag_over_environment(monkeypatch, tmp_path
         parse_omni_args()
 
 
-def test_stage_worker_still_requires_an_accelerator(monkeypatch, tmp_path):
+@pytest.mark.parametrize("warm_cache", [False, True])
+def test_stage_worker_still_requires_an_accelerator(monkeypatch, tmp_path, warm_cache):
+    _compute_kwargs.cache_clear()
+    if warm_cache:
+        OmniEngineArgs.add_cli_args(FlexibleArgumentParser(add_help=False))
     # Negative control: --stage-id builds an engine, so it must keep failing
     # loudly here rather than being swept up by the router's reduced parser.
     monkeypatch.setattr(sys, "argv", _router_argv(tmp_path, "--stage-id", "0"))


### PR DESCRIPTION
## Overview:

`python -m dynamo.vllm.omni --omni-router ...` could not start in a container
with no accelerator: it exited during argument parsing with `RuntimeError:
Failed to infer device type`. The stage router only dispatches to stage workers
over the Dynamo runtime and never builds a vLLM engine, so requiring a visible
device to parse its own command line was the defect.

## Details:

`parse_omni_args()` called `OmniEngineArgs.add_cli_args()` for every omni role.
That helper instantiates every vLLM config dataclass to compute its argparse
defaults, and `DeviceConfig.__post_init__` resolves the current platform while
doing so. The crash therefore happens while *building* the parser, so no
command-line value such as `--device cpu` avoids it.

`_wants_stage_router()` now decides the role from raw `sys.argv` before any
parser exists, matching how the `--omni-router` flag itself resolves: the last
of `--omni-router` / `--no-omni-router` wins, `DYN_OMNI_ROUTER` applies when
neither appears, and an explicit `--stage-id` keeps the full engine parser. Both
scans stop at the first bare `--`, because argparse treats everything past that
delimiter as positional and would not read those flags either. On the router
path `_add_stage_router_engine_args()` registers only the four options the
router reads — `--model`, `--served-model-name`, `--trust-remote-code`,
`--revision` — none of which builds a vLLM config object. Engine flags that the
launch scripts forward are logged and ignored instead of fatal, after underscore
spellings such as `--served_model_name` are normalized, because
`FlexibleArgumentParser` rewrites those in `parse_args` but not in the
`parse_known_args` this path needs. `config.engine_args` then carries those four
values plus `disable_log_stats`, which the shared `setup_metrics_collection()`
reads directly, so `main.worker()` reaches the router dispatch and the router
starts.

## Where should the reviewer start?

`components/src/dynamo/vllm/omni/args.py`: `_wants_stage_router()` for the role
precedence, then the two `stage_router` branches in `parse_omni_args()`.

## Validation

Ten new unit tests drive `parse_omni_args()` under a pinned no-accelerator
platform, with negative controls for the stage-worker path and for argv that
places `--stage-id` or `--no-omni-router` after the `--` delimiter. One of them
feeds the resulting config to `setup_metrics_collection()`, the first thing the
router dispatch calls.

```bash
CUDA_VISIBLE_DEVICES="" python -m pytest \
  components/src/dynamo/vllm/tests/omni/test_omni_args.py -m "unit and not gpu"
```

Passes with 37 tests. `pre-commit run --files
components/src/dynamo/vllm/omni/args.py
components/src/dynamo/vllm/tests/omni/test_omni_args.py`
also passes.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting stage-router mode through command-line options or the `DYN_OMNI_ROUTER` environment setting.
  * Router mode now accepts forwarded engine options while warning about unrecognized settings.
  * Router configurations can run without initializing accelerator devices.

* **Bug Fixes**
  * Improved precedence handling for router flags and stage identifiers.
  * Preserved strict option validation and accelerator requirements in non-router modes.

* **Tests**
  * Expanded coverage for router selection, option passthrough, platform handling, and configuration compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->