### PR TITLE
fix(sglang): stop GPU Memory Service workers crashing at startup on SGLang 0.5.18

### DIFF
--- a/components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
+import sys
 from contextlib import contextmanager
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -12,6 +13,7 @@ import pytest
 pytest.importorskip("gpu_memory_service", reason="gpu_memory_service is required")
 torch = pytest.importorskip("torch", reason="torch is required")
 
+import gpu_memory_service.integrations.sglang as gms_sglang  # noqa: E402
 import gpu_memory_service.integrations.sglang.memory_saver as gms_memory_saver  # noqa: E402
 from gpu_memory_service.common.locks import (  # noqa: E402
     GrantedLockType,
@@ -29,6 +31,65 @@ pytestmark = [
     pytest.mark.sglang,
     pytest.mark.core,
 ]
+
+
+@pytest.fixture
+def fake_gms_model_loader(monkeypatch):
+    model_loader = ModuleType("gpu_memory_service.integrations.sglang.model_loader")
+    model_loader.GMSModelLoader = object
+    monkeypatch.setitem(
+        sys.modules,
+        "gpu_memory_service.integrations.sglang.model_loader",
+        model_loader,
+    )
+    monkeypatch.setattr(gms_sglang, "_gms_initialized", False)
+    monkeypatch.setattr(gms_sglang, "_gms_lock_mode", None)
+    monkeypatch.setattr(gms_sglang, "_gms_ro_connect_timeout_ms", None)
+
+
+def test_setup_gms_declares_memory_saver(monkeypatch, fake_gms_model_loader):
+    class ReadOnlyServerArgs:
+        def __setattr__(self, name, value):
+            raise AssertionError(f"unexpected direct assignment: {name}={value!r}")
+
+    server_args = ReadOnlyServerArgs()
+    declare_late_resolution = Mock()
+    monkeypatch.setattr(gms_sglang, "declare_late_resolution", declare_late_resolution)
+
+    loader = gms_sglang.setup_gms(server_args)
+
+    declare_late_resolution.assert_called_once_with(
+        server_args,
+        "dynamo.gms",
+        enable_memory_saver=True,
+    )
+    assert loader is object
+    assert gms_sglang.is_gms_active()
+
+
+def test_setup_gms_uses_override_when_declaration_is_unavailable(
+    monkeypatch,
+    fake_gms_model_loader,
+):
+    override = Mock()
+    server_args = SimpleNamespace(override=override)
+    monkeypatch.setattr(gms_sglang, "declare_late_resolution", None)
+
+    gms_sglang.setup_gms(server_args)
+
+    override.assert_called_once_with("dynamo.gms", enable_memory_saver=True)
+
+
+def test_setup_gms_assigns_memory_saver_for_legacy_args(
+    monkeypatch,
+    fake_gms_model_loader,
+):
+    server_args = SimpleNamespace(enable_memory_saver=False)
+    monkeypatch.setattr(gms_sglang, "declare_late_resolution", None)
+
+    gms_sglang.setup_gms(server_args)
+
+    assert server_args.enable_memory_saver is True
 
 
 class _FakeManager:

--- a/lib/gpu_memory_service/integrations/sglang/__init__.py
+++ b/lib/gpu_memory_service/integrations/sglang/__init__.py
@@ -1,20 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""GPU Memory Service integration for SGLang.
-
-Usage:
-    from gpu_memory_service.integrations.sglang import setup_gms
-
-    if server_args.load_format == "gms":
-        load_format = setup_gms(server_args)
-        server_args.override("dynamo.gms", load_format=load_format)
-"""
+"""GPU Memory Service integration for SGLang."""
 
 from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Type
+
+try:
+    from sglang.srt.arg_groups.overrides import declare_late_resolution
+except ImportError:
+    declare_late_resolution = None
 
 if TYPE_CHECKING:
     from gpu_memory_service.integrations.sglang.model_loader import GMSModelLoader
@@ -58,13 +55,19 @@ def setup_gms(server_args) -> Type["GMSModelLoader"]:
             "Cannot use --enable-draft-weights-cpu-backup with --load-format gms."
         )
 
-    override = getattr(server_args, "override", None)
-    if callable(override):
-        override("dynamo.gms", enable_memory_saver=True)
+    if declare_late_resolution is not None:
+        declare_late_resolution(server_args, "dynamo.gms", enable_memory_saver=True)
     else:
-        # The separately pinned XPU image still uses SGLang 0.5.11, which
-        # predates ServerArgs.override. Remove after that pin reaches 0.5.16+.
-        server_args.enable_memory_saver = True
+        # Fallback for SGLang 0.5.17. Remove when the minimum supported version
+        # is 0.5.18+.
+        override = getattr(server_args, "override", None)
+        if callable(override):
+            override("dynamo.gms", enable_memory_saver=True)
+        else:
+            # The separately pinned XPU image still uses SGLang 0.5.11, which
+            # predates ServerArgs.override. Remove after that pin reaches 0.5.16+.
+            server_args.enable_memory_saver = True
+
     # Resolve lock mode and RO reconnect timeout from model_loader_extra_config
     # before patches fire.
     global _gms_lock_mode


### PR DESCRIPTION
## Overview:

Fix SGLang GMS v0 startup after SGLang has resolved `ServerArgs` and made direct field assignment read-only.

The failure was exposed while validating the live GMS pause/resume paths for #13951: the worker exited while enabling memory saver, before loading through GMS or reaching a pause call.

This PR now carries the cleaned and validated implementation previously developed in #14466, while preserving `glamr-agent` as the PR and commit author.

## Details:

- enable SGLang memory saver through the public `declare_late_resolution` API
- retain the SGLang 0.5.17 `ServerArgs.override` fallback and legacy SGLang 0.5.11/XPU direct-assignment fallback
- preserve the public `setup_gms()` contract that automatically enables memory saver
- add focused regression coverage for all three supported configuration paths
- remove the stale usage example that called `ServerArgs.override` on pinned SGLang 0.5.18

## Where should the reviewer start?

1. `lib/gpu_memory_service/integrations/sglang/__init__.py` — the public-first compatibility ladder in `setup_gms()`
2. `components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py` — the three focused regression cases

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to #13951
- Supersedes #14466

## Validation

### Automated

- `python -m pytest -v components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py` — 15 passed
- `python -m pytest -v -k setup_gms components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py` — 3 passed
- `python -m pytest -v lib/gpu_memory_service/tests/test_sglang_patches.py` — 2 passed
- `python -m pytest -q lib/gpu_memory_service/tests` — 99 passed, 1 skipped
- pre-commit, Black, Ruff lint/format, mypy, py_compile, and `git diff --check` — passed

### Live B200 GMS

Ran the nightly-only tests on one NVIDIA B200 using the exact fix image at immutable digest `sha256:3133de622b8ca3f87962299589eaf5f4daa9df13b7c950b9390cc8dcca3defcb`:

- `test_gms_basic_pause_resume_sglang` — passed in 64.71s
- `test_gms_shadow_engine_failover_sglang` — passed in 111.60s

The logs confirm initial and post-resume inference, real weights/KV allocator transitions, read-only weight reconnection, fresh read-write KV allocation, and blocked shadow takeover.

Also validated the clean synthetic merge of this fix plus #13951 head `1cc92d7e3` on the same B200:

- 10 native-route/handler tests passed
- basic GMS pause/resume passed in 68.04s
- GMS shadow failover passed in 113.95s
- the worker stayed out of discovery through pause, release, and memory resume, then re-registered only after `continue_generation`
