### PR TITLE
fix(profiler): keep an automatic-backend run on the backend it actually selected

### DIFF
--- a/components/src/dynamo/profiler/profile_sla.py
+++ b/components/src/dynamo/profiler/profile_sla.py
@@ -175,10 +175,8 @@ async def _execute_strategy(
                 request_latency,
             )
         else:
-            # THOROUGH measures one backend rather than searching across them,
-            # and derives a container image from the backend name, which has to
-            # be concrete. _check_auto_backend_support admits "auto" whenever
-            # any concrete backend is supported, so resolve it here.
+            # THOROUGH measures one backend rather than searching across them, and
+            # derives a container image, so "auto" has to be concrete here.
             backend = resolve_auto_backend(backend, "the measured (THOROUGH) search")
             pick_result = await run_thorough(
                 dgdr,

--- a/components/src/dynamo/profiler/profile_sla.py
+++ b/components/src/dynamo/profiler/profile_sla.py
@@ -51,6 +51,7 @@ from dynamo.profiler.utils.dgdr_validate import (
     validate_dgdr_dynamo_features,
 )
 from dynamo.profiler.utils.profile_common import (
+    DEFAULT_BACKEND,
     ProfilerOperationalConfig,
     determine_picking_mode,
     get_profiling_job_tolerations,
@@ -68,14 +69,28 @@ logger = logging.getLogger(__name__)
 _CONCRETE_BACKENDS = ["trtllm", "sglang", "vllm"]
 
 
+def _supported_concrete_backend(model: str, system: str) -> str | None:
+    """A concrete backend AIC reports as supporting this model/system, or None.
+
+    ``DEFAULT_BACKEND`` is offered first so the ordinary case keeps the backend
+    it has always run; the others are only reached when the default cannot
+    serve the model on this hardware.
+    """
+    ordered = [DEFAULT_BACKEND] + [
+        b for b in _CONCRETE_BACKENDS if b != DEFAULT_BACKEND
+    ]
+    for candidate in ordered:
+        if check_model_hardware_support(model, system, candidate):
+            return candidate
+    return None
+
+
 def _check_auto_backend_support(model: str, system: str) -> bool:
     """
     Return True if *any* concrete backend is AIC-supported for this model/system.
     TODO: move this function to AIC and handle partially supported model x backend x hardware
     """
-    return any(
-        check_model_hardware_support(model, system, b) for b in _CONCRETE_BACKENDS
-    )
+    return _supported_concrete_backend(model, system) is not None
 
 
 def _check_dgdr_aic_support(
@@ -176,8 +191,14 @@ async def _execute_strategy(
             )
         else:
             # THOROUGH measures one backend rather than searching across them, and
-            # derives a container image, so "auto" has to be concrete here.
-            backend = resolve_auto_backend(backend, "the measured (THOROUGH) search")
+            # derives a container image, so "auto" has to be concrete here. Prefer
+            # a backend AIC reports as supporting this model on this hardware,
+            # rather than deploying the default one against a model it cannot run.
+            backend = resolve_auto_backend(
+                backend,
+                "the measured (THOROUGH) search",
+                supported=_supported_concrete_backend(resolve_model_path(dgdr), system),
+            )
             pick_result = await run_thorough(
                 dgdr,
                 ops,
@@ -193,6 +214,11 @@ async def _execute_strategy(
                 request_latency,
                 deployment_clients,
             )
+            # THOROUGH reports no backend of its own, so publish the one it was
+            # measured with. The caller reads the deployment's backend out of
+            # this result, and would otherwise carry "auto" into the image and
+            # the command line.
+            pick_result.setdefault("resolved_backend", backend)
 
         ops.current_phase = ProfilingPhase.SelectingConfig
         write_profiler_status(

--- a/components/src/dynamo/profiler/profile_sla.py
+++ b/components/src/dynamo/profiler/profile_sla.py
@@ -56,6 +56,7 @@ from dynamo.profiler.utils.profile_common import (
     get_profiling_job_tolerations,
     needs_profile_data,
     picked_config_from_row,
+    resolve_auto_backend,
     resolve_model_path,
     warn_and_update_sla,
     warn_gpu_shortage,
@@ -174,6 +175,11 @@ async def _execute_strategy(
                 request_latency,
             )
         else:
+            # THOROUGH measures one backend rather than searching across them,
+            # and derives a container image from the backend name, which has to
+            # be concrete. _check_auto_backend_support admits "auto" whenever
+            # any concrete backend is supported, so resolve it here.
+            backend = resolve_auto_backend(backend, "the measured (THOROUGH) search")
             pick_result = await run_thorough(
                 dgdr,
                 ops,

--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -45,10 +45,8 @@ def _build_k8s_overrides(
 ) -> dict:
     """Extract K8s overrides (image, PVC) from a DGDR spec."""
     backend_image = derive_backend_image(dgdr.image, backend)
-    # derive_backend_image substitutes only the image-name component, keeping
-    # the registry, tag and digest. A difference therefore means the generated
-    # deployment pulls a sibling repository the request never named, which
-    # fails at pull time if that repository is absent from the registry.
+    # derive_backend_image keeps the registry, tag and digest, so a difference
+    # means a sibling repository that may be absent from the registry.
     if backend_image != dgdr.image:
         logger.warning(
             "Backend '%s' needs image '%s', so the generated deployment does "
@@ -150,9 +148,8 @@ def _generate_dgd_from_pick(
         )
         return None
 
-    # One backend for the whole generated deployment. The container image and
-    # the generated command line are both selected from this local, so they
-    # cannot name different backends.
+    # One backend for the whole generated deployment: the image and the
+    # command line are both selected from this local.
     backend = tc.primary_backend_name
     if row_backend is not None and row_backend != backend:
         logger.error(
@@ -410,10 +407,8 @@ def _run_default_sim(
                 "overriding to '%s' to support mocker/throughput-scaling.",
                 disagg_key,
             )
-            # Under backend="auto" each bucket is merged across backends, so the
-            # aggregated and disaggregated buckets can be won by different
-            # backends. The override then also changes the backend of the
-            # generated deployment away from the one the run summary reported.
+            # Each bucket is merged across backends under backend="auto", so the
+            # override can change the deployment's backend, not just its mode.
             summarized_backend = _winning_backend(best_configs.get(chosen))
             override_backend = _winning_backend(best_configs.get(disagg_key))
             if (
@@ -445,8 +440,7 @@ def _run_default_sim(
     # When backend="auto" AIC expands to per-backend task configs; the winning
     # row carries the concrete backend name so downstream consumers (e.g.
     # run_interpolation) can use it without re-encountering "auto". Resolved
-    # before generation so the generated deployment and the returned backend
-    # are read from the same row.
+    # before generation so both are read from the same row.
     resolved_backend = backend
     if backend == "auto":
         row_backend = _winning_backend(best_config_df)

--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -86,6 +86,29 @@ def _winning_backend(best_config_df: pd.DataFrame | None) -> str | None:
     return str(best_config_df.iloc[0]["backend"])
 
 
+def _generated_backend(
+    best_config_df: pd.DataFrame | None,
+    chosen_exp: str,
+    task_configs: dict[str, Task],
+) -> str | None:
+    """The backend the generated deployment runs.
+
+    ``_generate_dgd_from_pick`` takes both the runtime image and the command
+    line from the resolved task config, so that task's backend is the one the
+    deployment actually runs. Reading it through the same lookup covers the
+    merged rows that carry ``_task_key`` but no ``backend`` column, where the
+    row label alone resolves nothing. Falls back to the row label when no task
+    resolves, which is also the case in which nothing is generated.
+    """
+    if best_config_df is None or best_config_df.empty:
+        return None
+    row_backend = _winning_backend(best_config_df)
+    tc = _resolve_task_config(
+        best_config_df.iloc[0], chosen_exp, task_configs, row_backend
+    )
+    return tc.primary_backend_name if tc is not None else row_backend
+
+
 def _resolve_task_config(
     row: pd.Series,
     chosen_exp: str,
@@ -437,15 +460,15 @@ def _run_default_sim(
         chosen, {"ttft": 0.0, "tpot": 0.0, "request_latency": 0.0}
     )
 
-    # When backend="auto" AIC expands to per-backend task configs; the winning
-    # row carries the concrete backend name so downstream consumers (e.g.
-    # run_interpolation) can use it without re-encountering "auto". Resolved
-    # before generation so both are read from the same row.
+    # When backend="auto" AIC expands to per-backend task configs; downstream
+    # consumers (e.g. run_interpolation) need the concrete backend name so they
+    # do not re-encounter "auto". Read through the same task-config lookup the
+    # generator uses, so the reported backend is the generated deployment's.
     resolved_backend = backend
     if backend == "auto":
-        row_backend = _winning_backend(best_config_df)
-        if row_backend is not None:
-            resolved_backend = row_backend
+        generated = _generated_backend(best_config_df, chosen, task_configs)
+        if generated is not None:
+            resolved_backend = generated
 
     dgd_config = _generate_dgd_from_pick(
         dgdr, best_config_df, chosen, task_configs, picking_mode

--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -91,14 +91,8 @@ def _generated_backend(
     chosen_exp: str,
     task_configs: dict[str, Task],
 ) -> str | None:
-    """The backend the generated deployment runs.
-
-    ``_generate_dgd_from_pick`` takes both the runtime image and the command
-    line from the resolved task config, so that task's backend is the one the
-    deployment actually runs. Reading it through the same lookup covers the
-    merged rows that carry ``_task_key`` but no ``backend`` column, where the
-    row label alone resolves nothing. Falls back to the row label when no task
-    resolves, which is also the case in which nothing is generated.
+    """The backend the generated deployment runs, read through the same task
+    lookup ``_generate_dgd_from_pick`` derives its image and command line from.
     """
     if best_config_df is None or best_config_df.empty:
         return None

--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -29,6 +29,7 @@ from dynamo.profiler.utils.config import clamp_total_gpus_to_budget
 from dynamo.profiler.utils.dgdr_v1beta1_types import DynamoGraphDeploymentRequestSpec
 from dynamo.profiler.utils.model_cache_paths import model_cache_path_in_pvc
 from dynamo.profiler.utils.profile_common import (
+    DEFAULT_BACKEND,
     derive_backend_image,
     needs_mocker_aic_perf_model,
     needs_profile_data,
@@ -43,8 +44,22 @@ def _build_k8s_overrides(
     backend: str,
 ) -> dict:
     """Extract K8s overrides (image, PVC) from a DGDR spec."""
+    backend_image = derive_backend_image(dgdr.image, backend)
+    # derive_backend_image substitutes only the image-name component, keeping
+    # the registry, tag and digest. A difference therefore means the generated
+    # deployment pulls a sibling repository the request never named, which
+    # fails at pull time if that repository is absent from the registry.
+    if backend_image != dgdr.image:
+        logger.warning(
+            "Backend '%s' needs image '%s', so the generated deployment does "
+            "not use the requested image '%s'. Ensure the derived image exists "
+            "in the registry, or request a concrete backend.",
+            backend,
+            backend_image,
+            dgdr.image,
+        )
     overrides: dict = {
-        "k8s_image": derive_backend_image(dgdr.image, backend),
+        "k8s_image": backend_image,
     }
     if dgdr.modelCache:
         if dgdr.modelCache.pvcName:
@@ -59,6 +74,57 @@ def _build_k8s_overrides(
     return overrides
 
 
+def _winning_backend(best_config_df: pd.DataFrame | None) -> str | None:
+    """The concrete backend of a result bucket's rank-1 row.
+
+    AIC labels every row of a merged bucket with the backend of the task that
+    produced it. Returns ``None`` for an empty or unlabelled bucket, which is
+    what a single-backend search produces.
+    """
+    if best_config_df is None or best_config_df.empty:
+        return None
+    if "backend" not in best_config_df.columns:
+        return None
+    return str(best_config_df.iloc[0]["backend"])
+
+
+def _resolve_task_config(
+    row: pd.Series,
+    chosen_exp: str,
+    task_configs: dict[str, Task],
+    row_backend: str | None,
+) -> Task | None:
+    """Find the task config that produced the winning row.
+
+    Under ``backend='auto'`` AIC runs one task per backend, keyed e.g.
+    ``agg_vllm``, then merges their results into the bare mode buckets ``agg``
+    and ``disagg``. ``chosen_exp`` is therefore a merged bucket name that is
+    absent from ``task_configs``, and the originating key has to be recovered.
+    Three sources are tried, most authoritative first:
+
+    1. ``_task_key``, which AIC publishes on every merged row.
+    2. ``chosen_exp`` itself, which is the key when one concrete backend was
+       requested and no merge happened.
+    3. ``f"{chosen_exp}_{row_backend}"``, reconstructing AIC's key scheme for
+       dependency versions that do not publish ``_task_key``.
+
+    Returns:
+        The task config, or ``None`` if no source resolves one.
+    """
+    if "_task_key" in row.index and pd.notna(row["_task_key"]):
+        tc = task_configs.get(str(row["_task_key"]))
+        if tc is not None:
+            return tc
+
+    tc = task_configs.get(chosen_exp)
+    if tc is not None:
+        return tc
+
+    if row_backend is not None:
+        return task_configs.get(f"{chosen_exp}_{row_backend}")
+    return None
+
+
 def _generate_dgd_from_pick(
     dgdr: DynamoGraphDeploymentRequestSpec,
     best_config_df: pd.DataFrame,
@@ -71,16 +137,32 @@ def _generate_dgd_from_pick(
         return None
 
     row = best_config_df.iloc[0]
+    row_backend = str(row["backend"]) if "backend" in row.index else None
 
-    tc = task_configs.get(chosen_exp)
-    # TODO: temporary workaround — when backend="auto", AIC's
-    # merge_experiment_results_by_mode collapses e.g. "agg_vllm" into "agg",
-    # but task_configs retains the original keys. Reconstruct the key from
-    # the winning row's backend column. Proper fix: AIC should return the
-    # original task config key alongside the merged chosen experiment name.
-    if tc is None and "backend" in row.index:
-        tc = task_configs.get(f"{chosen_exp}_{row['backend']}")
+    tc = _resolve_task_config(row, chosen_exp, task_configs, row_backend)
     if tc is None:
+        logger.error(
+            "No task config resolves the picked result: experiment='%s', "
+            "winning backend=%s, available keys=%s. No deployment generated.",
+            chosen_exp,
+            row_backend,
+            sorted(task_configs),
+        )
+        return None
+
+    # One backend for the whole generated deployment. The container image and
+    # the generated command line are both selected from this local, so they
+    # cannot name different backends.
+    backend = tc.primary_backend_name
+    if row_backend is not None and row_backend != backend:
+        logger.error(
+            "Winning configuration reports backend '%s' but the resolved task "
+            "config '%s' is for backend '%s'. Refusing to generate a "
+            "deployment that would mix the two.",
+            row_backend,
+            chosen_exp,
+            backend,
+        )
         return None
 
     original_total_gpus = tc.total_gpus
@@ -110,7 +192,14 @@ def _generate_dgd_from_pick(
                 )
             tc.total_gpus = clamped_total_gpus
 
-        k8s_overrides = _build_k8s_overrides(dgdr, tc.primary_backend_name)
+        k8s_overrides = _build_k8s_overrides(dgdr, backend)
+        logger.info(
+            "Generating deployment for experiment='%s' with backend='%s' and "
+            "image='%s'.",
+            chosen_exp,
+            backend,
+            k8s_overrides["k8s_image"],
+        )
         cfg = task_config_to_generator_config(
             task_config=tc,
             result_df=row,
@@ -126,7 +215,7 @@ def _generate_dgd_from_pick(
 
     artifacts = generate_backend_artifacts(
         params=cfg,
-        backend=tc.primary_backend_name,
+        backend=backend,
         backend_version=tc.primary_backend_version,
         use_dynamo_generator=True,
     )
@@ -137,7 +226,7 @@ def _generate_dgd_from_pick(
 
 
 # Fallback backend when AIC simulation is unavailable and no concrete backend is specified.
-_DEFAULT_NAIVE_BACKEND = "vllm"
+_DEFAULT_NAIVE_BACKEND = DEFAULT_BACKEND
 
 
 def _run_naive_fallback(
@@ -321,6 +410,25 @@ def _run_default_sim(
                 "overriding to '%s' to support mocker/throughput-scaling.",
                 disagg_key,
             )
+            # Under backend="auto" each bucket is merged across backends, so the
+            # aggregated and disaggregated buckets can be won by different
+            # backends. The override then also changes the backend of the
+            # generated deployment away from the one the run summary reported.
+            summarized_backend = _winning_backend(best_configs.get(chosen))
+            override_backend = _winning_backend(best_configs.get(disagg_key))
+            if (
+                summarized_backend is not None
+                and override_backend is not None
+                and summarized_backend != override_backend
+            ):
+                logger.warning(
+                    "The override also changes the backend: the summarized "
+                    "winner used '%s' but the generated deployment uses '%s', "
+                    "so it runs the '%s' runtime image and command line.",
+                    summarized_backend,
+                    override_backend,
+                    override_backend,
+                )
             chosen = disagg_key
         else:
             logger.warning(
@@ -334,20 +442,20 @@ def _run_default_sim(
         chosen, {"ttft": 0.0, "tpot": 0.0, "request_latency": 0.0}
     )
 
+    # When backend="auto" AIC expands to per-backend task configs; the winning
+    # row carries the concrete backend name so downstream consumers (e.g.
+    # run_interpolation) can use it without re-encountering "auto". Resolved
+    # before generation so the generated deployment and the returned backend
+    # are read from the same row.
+    resolved_backend = backend
+    if backend == "auto":
+        row_backend = _winning_backend(best_config_df)
+        if row_backend is not None:
+            resolved_backend = row_backend
+
     dgd_config = _generate_dgd_from_pick(
         dgdr, best_config_df, chosen, task_configs, picking_mode
     )
-
-    # When backend="auto" AIC expands to per-backend task configs; the winning
-    # row carries the concrete backend name so downstream consumers (e.g.
-    # run_interpolation) can use it without re-encountering "auto".
-    resolved_backend = backend
-    if (
-        backend == "auto"
-        and not best_config_df.empty
-        and "backend" in best_config_df.columns
-    ):
-        resolved_backend = best_config_df.iloc[0]["backend"]
 
     return {
         "best_config_df": best_config_df,

--- a/components/src/dynamo/profiler/tests/unit/test_backend_image_coverage.py
+++ b/components/src/dynamo/profiler/tests/unit/test_backend_image_coverage.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Every declared backend value must yield a runtime container image.
+
+`BackendType` is the public enumeration a DynamoGraphDeploymentRequest sets
+its `backend:` field to. `derive_backend_image` maps a concrete backend to its
+published runtime image name and raises for anything else, so the automatic
+value has to be resolved to a concrete backend before an image is derived.
+Every search path must therefore be able to resolve it.
+
+This module imports only `dynamo.profiler.utils.profile_common` and the DGDR
+types, so it does not depend on the AIC simulation package that
+`dynamo.profiler.rapid` pulls in. It covers the backend enumeration rather
+than image substitution mechanics, which `test_planner_image_selection.py`
+already covers.
+"""
+
+import pytest
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+try:
+    from dynamo.profiler.utils.dgdr_v1beta1_types import BackendType
+    from dynamo.profiler.utils.profile_common import (
+        BACKEND_IMAGE_NAMES,
+        derive_backend_image,
+        resolve_auto_backend,
+    )
+except ImportError as e:  # pragma: no cover - environment guard
+    pytest.skip(f"Skip (missing dependency): {e}", allow_module_level=True)
+
+
+_REQUEST_IMAGE = "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.3"
+_CALLER = "this test"
+
+
+def _image_name(image_ref: str) -> str:
+    """The repository name of an image reference, without registry or tag."""
+    return image_ref.rsplit("/", 1)[-1].split(":")[0]
+
+
+def test_every_declared_backend_yields_a_runtime_image():
+    """No value of `BackendType` may reach `derive_backend_image` unresolved."""
+    published = set(BACKEND_IMAGE_NAMES.values())
+
+    derived = {
+        backend: derive_backend_image(
+            _REQUEST_IMAGE, resolve_auto_backend(backend.value, _CALLER)
+        )
+        for backend in BackendType
+    }
+
+    assert set(derived) == set(BackendType)
+    for backend, image in derived.items():
+        assert _image_name(image) in published, f"{backend.value} -> {image}"
+
+
+def test_auto_resolves_to_a_concrete_backend():
+    resolved = resolve_auto_backend(BackendType.Auto.value, _CALLER)
+
+    assert resolved != BackendType.Auto.value
+    assert resolved in BACKEND_IMAGE_NAMES
+
+
+def test_a_requested_backend_is_never_overridden():
+    """Resolution applies to the automatic value only; an explicit request
+    must reach the search path unchanged."""
+    for backend in (BackendType.Sglang, BackendType.Trtllm, BackendType.Vllm):
+        assert resolve_auto_backend(backend.value, _CALLER) == backend.value

--- a/components/src/dynamo/profiler/tests/unit/test_backend_image_coverage.py
+++ b/components/src/dynamo/profiler/tests/unit/test_backend_image_coverage.py
@@ -41,7 +41,6 @@ _CALLER = "this test"
 
 
 def _image_name(image_ref: str) -> str:
-    """The repository name of an image reference, without registry or tag."""
     return image_ref.rsplit("/", 1)[-1].split(":")[0]
 
 

--- a/components/src/dynamo/profiler/tests/unit/test_backend_image_coverage.py
+++ b/components/src/dynamo/profiler/tests/unit/test_backend_image_coverage.py
@@ -61,13 +61,6 @@ def test_every_declared_backend_yields_a_runtime_image():
         assert _image_name(image) in published, f"{backend.value} -> {image}"
 
 
-def test_auto_resolves_to_a_concrete_backend():
-    resolved = resolve_auto_backend(BackendType.Auto.value, _CALLER)
-
-    assert resolved != BackendType.Auto.value
-    assert resolved in BACKEND_IMAGE_NAMES
-
-
 def test_a_requested_backend_is_never_overridden():
     """Resolution applies to the automatic value only; an explicit request
     must reach the search path unchanged."""

--- a/components/src/dynamo/profiler/tests/unit/test_backend_image_coverage.py
+++ b/components/src/dynamo/profiler/tests/unit/test_backend_image_coverage.py
@@ -8,12 +8,6 @@ its `backend:` field to. `derive_backend_image` maps a concrete backend to its
 published runtime image name and raises for anything else, so the automatic
 value has to be resolved to a concrete backend before an image is derived.
 Every search path must therefore be able to resolve it.
-
-This module imports only `dynamo.profiler.utils.profile_common` and the DGDR
-types, so it does not depend on the AIC simulation package that
-`dynamo.profiler.rapid` pulls in. It covers the backend enumeration rather
-than image substitution mechanics, which `test_planner_image_selection.py`
-already covers.
 """
 
 import pytest

--- a/components/src/dynamo/profiler/tests/unit/test_rapid_backend_consistency.py
+++ b/components/src/dynamo/profiler/tests/unit/test_rapid_backend_consistency.py
@@ -46,9 +46,8 @@ _REGISTRY = "nvcr.io/nvidia/ai-dynamo"
 _REQUEST_IMAGE = f"{_REGISTRY}/dynamo-planner:1.2.3"
 _RAPID_LOGGER = "dynamo.profiler.rapid"
 
-# A non-empty artifact so a generated deployment is distinguishable from a
-# refused one: _generate_dgd_from_pick returns None for both an empty artifact
-# and a refusal.
+# A non-empty artifact: _generate_dgd_from_pick returns None for both an empty
+# artifact and a refusal.
 _ARTIFACT_YAML = "kind: DynamoGraphDeployment\nmetadata:\n  name: generated\n"
 
 

--- a/components/src/dynamo/profiler/tests/unit/test_rapid_backend_consistency.py
+++ b/components/src/dynamo/profiler/tests/unit/test_rapid_backend_consistency.py
@@ -225,8 +225,6 @@ class TestMergedAutoBackendPath:
 
         assert seen["k8s_image"] == f"{_REGISTRY}/sglang-runtime:1.2.3"
         assert seen["generator_backend"] == "sglang"
-        # The row carries no `backend` column, so the label alone reports
-        # nothing and the run would otherwise still be described as "auto".
         assert _generated_backend(row, "agg", task_configs) == "sglang"
 
 

--- a/components/src/dynamo/profiler/tests/unit/test_rapid_backend_consistency.py
+++ b/components/src/dynamo/profiler/tests/unit/test_rapid_backend_consistency.py
@@ -9,9 +9,6 @@ selects which command and argument generator `generate_backend_artifacts`
 runs. Both must name the backend that the winning configuration row reports,
 otherwise the deployment pulls one runtime image and runs another runtime's
 command line.
-
-These tests patch AIC's two generator entry points and assert on what AIC
-would have been handed, in the style of `test_rapid_planner_replicas.py`.
 """
 
 import logging
@@ -30,7 +27,7 @@ pytestmark = [
 try:
     from aiconfigurator.sdk.task_v2 import Task
 
-    from dynamo.profiler.rapid import _generate_dgd_from_pick
+    from dynamo.profiler.rapid import _generate_dgd_from_pick, _generated_backend
     from dynamo.profiler.utils.dgdr_v1beta1_types import (
         DynamoGraphDeploymentRequestSpec,
         HardwareSpec,
@@ -66,7 +63,7 @@ def _make_dgdr(
 
 def _make_task(backend: str, serving_mode: str = "agg") -> Task:
     """A real AIC Task for one backend, matching `_make_dgdr()`."""
-    shared = dict(total_gpus=8, isl=4000, osl=1000, ttft=2000.0, tpot=50.0)
+    shared = {"total_gpus": 8, "isl": 4000, "osl": 1000, "ttft": 2000.0, "tpot": 50.0}
     if serving_mode == "agg":
         return Task(
             serving_mode="agg",
@@ -222,11 +219,15 @@ class TestMergedAutoBackendPath:
         `backend` column to rebuild that key from."""
         dgdr = _make_dgdr()
         task_configs = {"agg_sglang": _make_task("sglang")}
+        row = _make_row(_task_key="agg_sglang")
 
-        seen = _drive(dgdr, _make_row(_task_key="agg_sglang"), "agg", task_configs)
+        seen = _drive(dgdr, row, "agg", task_configs)
 
         assert seen["k8s_image"] == f"{_REGISTRY}/sglang-runtime:1.2.3"
         assert seen["generator_backend"] == "sglang"
+        # The row carries no `backend` column, so the label alone reports
+        # nothing and the run would otherwise still be described as "auto".
+        assert _generated_backend(row, "agg", task_configs) == "sglang"
 
 
 class TestConcreteBackendPath:

--- a/components/src/dynamo/profiler/tests/unit/test_rapid_backend_consistency.py
+++ b/components/src/dynamo/profiler/tests/unit/test_rapid_backend_consistency.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests pinning backend consistency in `_generate_dgd_from_pick`.
+
+A generated deployment names a backend twice: once as the container image
+derived in `_build_k8s_overrides`, and once as the ``backend`` argument that
+selects which command and argument generator `generate_backend_artifacts`
+runs. Both must name the backend that the winning configuration row reports,
+otherwise the deployment pulls one runtime image and runs another runtime's
+command line.
+
+These tests patch AIC's two generator entry points and assert on what AIC
+would have been handed, in the style of `test_rapid_planner_replicas.py`.
+"""
+
+import logging
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+try:
+    from aiconfigurator.sdk.task_v2 import Task
+
+    from dynamo.profiler.rapid import _generate_dgd_from_pick
+    from dynamo.profiler.utils.dgdr_v1beta1_types import (
+        DynamoGraphDeploymentRequestSpec,
+        HardwareSpec,
+        SLASpec,
+        WorkloadSpec,
+    )
+except ImportError as e:  # pragma: no cover - environment guard
+    pytest.skip(f"Skip (missing dependency): {e}", allow_module_level=True)
+
+
+_MODEL = "Qwen/Qwen3-32B"
+_REGISTRY = "nvcr.io/nvidia/ai-dynamo"
+_REQUEST_IMAGE = f"{_REGISTRY}/dynamo-planner:1.2.3"
+_RAPID_LOGGER = "dynamo.profiler.rapid"
+
+# A non-empty artifact so a generated deployment is distinguishable from a
+# refused one: _generate_dgd_from_pick returns None for both an empty artifact
+# and a refusal.
+_ARTIFACT_YAML = "kind: DynamoGraphDeployment\nmetadata:\n  name: generated\n"
+
+
+def _make_dgdr(
+    image: str = _REQUEST_IMAGE, backend: str = "auto"
+) -> DynamoGraphDeploymentRequestSpec:
+    return DynamoGraphDeploymentRequestSpec(
+        model=_MODEL,
+        backend=backend,
+        image=image,
+        hardware=HardwareSpec(gpuSku="h200_sxm", totalGpus=8, numGpusPerNode=8),
+        workload=WorkloadSpec(isl=4000, osl=1000),
+        sla=SLASpec(ttft=2000.0, itl=50.0),
+    )
+
+
+def _make_task(backend: str, serving_mode: str = "agg") -> Task:
+    """A real AIC Task for one backend, matching `_make_dgdr()`."""
+    shared = dict(total_gpus=8, isl=4000, osl=1000, ttft=2000.0, tpot=50.0)
+    if serving_mode == "agg":
+        return Task(
+            serving_mode="agg",
+            model_path=_MODEL,
+            system_name="h200_sxm",
+            backend_name=backend,
+            **shared,
+        )
+    return Task(
+        serving_mode="disagg",
+        prefill_model_path=_MODEL,
+        decode_model_path=_MODEL,
+        prefill_system_name="h200_sxm",
+        decode_system_name="h200_sxm",
+        prefill_backend_name=backend,
+        decode_backend_name=backend,
+        **shared,
+    )
+
+
+def _make_row(**columns) -> pd.DataFrame:
+    """A rank-1 picker row. `backend` and `_task_key` are the columns AIC adds
+    when it merges per-backend experiments into one bucket."""
+    row: dict = {"tp": 1}
+    row.update(columns)
+    return pd.DataFrame([row])
+
+
+def _drive(dgdr, best_config_df, chosen_exp, task_configs) -> dict:
+    """Run `_generate_dgd_from_pick` with AIC's generator entry points patched
+    and report the image and the backend each one was handed."""
+    seen: dict = {"k8s_image": None, "generator_backend": None, "generator_calls": 0}
+
+    def fake_bridge(task_config, result_df, generator_overrides=None, **_kw):
+        overrides = generator_overrides or {}
+        seen["k8s_image"] = overrides.get("K8sConfig", {}).get("k8s_image")
+        return {}
+
+    def fake_artifacts(params, backend, **_kw):
+        seen["generator_backend"] = backend
+        seen["generator_calls"] += 1
+        return {"k8s_deploy.yaml": _ARTIFACT_YAML}
+
+    with (
+        patch(
+            "dynamo.profiler.rapid.task_config_to_generator_config",
+            side_effect=fake_bridge,
+        ),
+        patch(
+            "dynamo.profiler.rapid.generate_backend_artifacts",
+            side_effect=fake_artifacts,
+        ),
+    ):
+        seen["dgd_config"] = _generate_dgd_from_pick(
+            dgdr, best_config_df, chosen_exp, task_configs
+        )
+    return seen
+
+
+def _messages(caplog, level: int) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.levelno == level]
+
+
+class TestWinningBackendIsHonoured:
+    """The emitted backend equals the winning row's backend, or nothing is
+    emitted."""
+
+    def test_task_disagreeing_with_winning_row_emits_nothing(self, caplog):
+        """A TensorRT-LLM task under the plain `agg` key while the winning row
+        says SGLang must not produce a deployment: it would be a TensorRT-LLM
+        image running TensorRT-LLM arguments while the run summary named
+        SGLang.
+        """
+        dgdr = _make_dgdr()
+        task_configs = {"agg": _make_task("trtllm")}
+
+        with caplog.at_level(logging.ERROR, logger=_RAPID_LOGGER):
+            seen = _drive(dgdr, _make_row(backend="sglang"), "agg", task_configs)
+
+        assert seen["dgd_config"] is None
+        assert seen["generator_calls"] == 0
+        errors = _messages(caplog, logging.ERROR)
+        assert any("sglang" in m and "trtllm" in m for m in errors), errors
+
+    def test_unresolvable_task_is_reported(self, caplog):
+        """No task for the chosen experiment must be an error naming the
+        experiment and the keys that were available, not a silent `None`."""
+        dgdr = _make_dgdr()
+        task_configs = {"disagg_vllm": _make_task("vllm", "disagg")}
+
+        with caplog.at_level(logging.ERROR, logger=_RAPID_LOGGER):
+            seen = _drive(dgdr, _make_row(backend="sglang"), "agg", task_configs)
+
+        assert seen["dgd_config"] is None
+        assert seen["generator_calls"] == 0
+        errors = _messages(caplog, logging.ERROR)
+        assert any("agg" in m and "disagg_vllm" in m for m in errors), errors
+
+
+class TestSiblingImageIsAnnounced:
+    """The derived image can name a repository the operator never supplied."""
+
+    def test_warns_when_derived_repository_differs_from_the_request(self, caplog):
+        """The request supplies the SGLang runtime image but the winning
+        backend is TensorRT-LLM, so the deployment depends on a sibling image
+        that may not exist in the operator's registry."""
+        dgdr = _make_dgdr(image="myregistry.io/sglang-runtime:1.2.3")
+        task_configs = {"agg": _make_task("trtllm")}
+
+        with caplog.at_level(logging.WARNING, logger=_RAPID_LOGGER):
+            seen = _drive(dgdr, _make_row(), "agg", task_configs)
+
+        assert seen["k8s_image"] == "myregistry.io/tensorrtllm-runtime:1.2.3"
+        warnings = _messages(caplog, logging.WARNING)
+        assert any(
+            "sglang-runtime" in m and "tensorrtllm-runtime" in m for m in warnings
+        ), warnings
+
+    def test_no_warning_when_the_request_already_names_that_repository(self, caplog):
+        dgdr = _make_dgdr(image="myregistry.io/sglang-runtime:1.2.3")
+        task_configs = {"agg": _make_task("sglang")}
+
+        with caplog.at_level(logging.WARNING, logger=_RAPID_LOGGER):
+            seen = _drive(dgdr, _make_row(), "agg", task_configs)
+
+        assert seen["k8s_image"] == "myregistry.io/sglang-runtime:1.2.3"
+        assert _messages(caplog, logging.WARNING) == []
+
+
+class TestMergedAutoBackendPath:
+    """Control: with per-backend task keys the image and the generator already
+    agree, and must keep agreeing."""
+
+    def test_image_and_generator_both_follow_the_winning_backend(self):
+        dgdr = _make_dgdr()
+        task_configs = {
+            "agg_trtllm": _make_task("trtllm"),
+            "agg_sglang": _make_task("sglang"),
+        }
+
+        seen = _drive(dgdr, _make_row(backend="sglang"), "agg", task_configs)
+
+        assert seen["k8s_image"] == f"{_REGISTRY}/sglang-runtime:1.2.3"
+        assert seen["generator_backend"] == "sglang"
+        assert seen["dgd_config"] == {
+            "kind": "DynamoGraphDeployment",
+            "metadata": {"name": "generated"},
+        }
+
+    def test_published_task_key_resolves_the_task(self):
+        """AIC publishes each merged row's originating per-backend key as
+        `_task_key`, which resolves the task even when the row carries no
+        `backend` column to rebuild that key from."""
+        dgdr = _make_dgdr()
+        task_configs = {"agg_sglang": _make_task("sglang")}
+
+        seen = _drive(dgdr, _make_row(_task_key="agg_sglang"), "agg", task_configs)
+
+        assert seen["k8s_image"] == f"{_REGISTRY}/sglang-runtime:1.2.3"
+        assert seen["generator_backend"] == "sglang"
+
+
+class TestConcreteBackendPath:
+    """Control: a request naming one backend keeps that backend end to end."""
+
+    def test_plain_key_without_a_backend_column(self):
+        dgdr = _make_dgdr(backend="sglang")
+        task_configs = {"disagg": _make_task("sglang", "disagg")}
+
+        seen = _drive(dgdr, _make_row(), "disagg", task_configs)
+
+        assert seen["k8s_image"] == f"{_REGISTRY}/sglang-runtime:1.2.3"
+        assert seen["generator_backend"] == "sglang"

--- a/components/src/dynamo/profiler/utils/profile_common.py
+++ b/components/src/dynamo/profiler/utils/profile_common.py
@@ -50,6 +50,12 @@ BACKEND_IMAGE_NAMES: dict[str, str] = {
 
 PLANNER_IMAGE_NAME = "dynamo-planner"
 
+# Backend used when a request asks for automatic backend selection but the code
+# path taken cannot search across backends. Every path that derives a container
+# image or renders a command line needs one concrete backend name, so "auto"
+# has to become a real backend somewhere; this is the single value it becomes.
+DEFAULT_BACKEND = "vllm"
+
 
 def _replace_image_name(image_ref: str, new_name: str) -> str:
     """Replace the image name component in a Docker image reference.
@@ -109,6 +115,37 @@ def derive_backend_image(profiler_image: str, backend: str) -> str:
         )
 
     return _replace_image_name(profiler_image, backend_image_name)
+
+
+def resolve_auto_backend(backend: str, search_path: str) -> str:
+    """Resolve ``backend='auto'`` to a concrete backend for one search path.
+
+    ``auto`` asks the profiler to pick a backend by searching across all of
+    them. Only the RAPID simulation search can do that; every other path needs
+    a concrete backend to derive a container image and render a command line
+    from. Those paths call this helper, which logs which backend they settled
+    on and why the request was not honoured as written.
+
+    Concrete backends are returned unchanged, so this is safe to apply
+    unconditionally.
+
+    Args:
+        backend: The requested backend, possibly ``'auto'``.
+        search_path: Human-readable name of the calling path, used in the
+            warning so an operator can see which one did not search.
+
+    Returns:
+        A concrete backend name.
+    """
+    if backend != "auto":
+        return backend
+    logger.warning(
+        "backend='auto' was requested but %s does not search across backends; "
+        "using '%s'. Request a concrete backend to control which one runs.",
+        search_path,
+        DEFAULT_BACKEND,
+    )
+    return DEFAULT_BACKEND
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/profiler/utils/profile_common.py
+++ b/components/src/dynamo/profiler/utils/profile_common.py
@@ -115,35 +115,36 @@ def derive_backend_image(profiler_image: str, backend: str) -> str:
     return _replace_image_name(profiler_image, backend_image_name)
 
 
-def resolve_auto_backend(backend: str, search_path: str) -> str:
+def resolve_auto_backend(
+    backend: str, search_path: str, supported: str | None = None
+) -> str:
     """Resolve ``backend='auto'`` to a concrete backend for one search path.
 
-    ``auto`` asks the profiler to pick a backend by searching across all of
-    them. Only the RAPID simulation search can do that; every other path needs
-    a concrete backend to derive a container image and render a command line
-    from. Those paths call this helper, which logs which backend they settled
-    on and why the request was not honoured as written.
-
-    Concrete backends are returned unchanged, so this is safe to apply
-    unconditionally.
+    Only the RAPID simulation search can pick a backend by searching across
+    them; every other path needs a concrete one to derive a container image and
+    render a command line from. Explicit backends pass through unchanged.
 
     Args:
         backend: The requested backend, possibly ``'auto'``.
-        search_path: Human-readable name of the calling path, used in the
+        search_path: Human-readable name of the calling path, named in the
             warning so an operator can see which one did not search.
+        supported: A backend the caller has established can serve this model on
+            this hardware. Used in place of ``DEFAULT_BACKEND`` when supplied,
+            so a model the default cannot serve does not get it anyway.
 
     Returns:
         A concrete backend name.
     """
     if backend != "auto":
         return backend
+    chosen = supported or DEFAULT_BACKEND
     logger.warning(
         "backend='auto' was requested but %s does not search across backends; "
         "using '%s'. Request a concrete backend to control which one runs.",
         search_path,
-        DEFAULT_BACKEND,
+        chosen,
     )
-    return DEFAULT_BACKEND
+    return chosen
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/profiler/utils/profile_common.py
+++ b/components/src/dynamo/profiler/utils/profile_common.py
@@ -50,10 +50,8 @@ BACKEND_IMAGE_NAMES: dict[str, str] = {
 
 PLANNER_IMAGE_NAME = "dynamo-planner"
 
-# Backend used when a request asks for automatic backend selection but the code
-# path taken cannot search across backends. Every path that derives a container
-# image or renders a command line needs one concrete backend name, so "auto"
-# has to become a real backend somewhere; this is the single value it becomes.
+# Concrete backend for paths that cannot search across backends: every path that
+# derives an image or renders a command line needs one real backend name.
 DEFAULT_BACKEND = "vllm"
 
 


### PR DESCRIPTION
## Overview:

When the profiler runs with `backend: auto`, the backend the deployment ends up running
could differ from the one the run reported, and in one case was never resolved at all.
A deployment then pulls one runtime image and runs another runtime's command line, or
carries the literal string `auto` into an image reference. The derived image is a sibling
repository that may be absent from the operator's registry, so the container crash-loops
on pull.

Three paths were involved. `dynamo.profiler.rapid` can override an aggregated winner with
the best disaggregated result to support mocker or throughput scaling; result buckets are
merged across backends independently, so that override can also change the backend. The
same module reported the run's backend from the winning row's `backend` column, which
merged rows carrying only `_task_key` do not have. And the measured (THOROUGH) search in
`profile_sla` resolved `auto` for its own use without publishing the result, so the caller
read `auto` back out of the pick and carried it downstream.

## Details:

`_generate_dgd_from_pick` binds one `backend` local from the resolved task config and
passes it to both the image derivation and the command generator, so a single deployment
cannot name two backends. `_resolve_task_config` recovers the originating task key from
the merged row's `_task_key` column, keeping the previous reconstruction from
`chosen_exp` and the row's backend as a fallback; a row whose backend disagrees with its
task config is refused with an error naming both. The chosen experiment, backend, and
derived image are logged, and `_run_default_sim` warns when the override changes the
backend.

`_generated_backend` reports the run's backend through that same task-config lookup, so
the name published to downstream consumers such as `run_interpolation` is the generated
deployment's own backend rather than a row label that merged rows may not carry.

`resolve_auto_backend` in `profile_common` resolves `auto` to a concrete backend on paths
that cannot search across them, warning which path did not search. It takes an optional
`supported` backend, and `profile_sla` supplies one that `check_model_hardware_support`
confirms can serve this model on this hardware, falling back to the new `DEFAULT_BACKEND`
constant. The measured search publishes the backend it was measured with as
`resolved_backend` in its pick result.

## Where should the reviewer start?

`components/src/dynamo/profiler/rapid.py` — `_resolve_task_config`, `_generated_backend`,
and the single `backend` local in `_generate_dgd_from_pick`. Then `resolve_auto_backend`
in `components/src/dynamo/profiler/utils/profile_common.py` and its caller in
`components/src/dynamo/profiler/profile_sla.py`.

## Validation

CPU-only; no GPU path is exercised.

```
pre-commit run --files components/src/dynamo/profiler/profile_sla.py \
  components/src/dynamo/profiler/rapid.py \
  components/src/dynamo/profiler/utils/profile_common.py \
  components/src/dynamo/profiler/tests/unit/test_backend_image_coverage.py \
  components/src/dynamo/profiler/tests/unit/test_rapid_backend_consistency.py
```

All hooks pass.

```
python -m pytest components/src/dynamo/profiler/tests/unit -m 'unit and not gpu' -q \
  --ignore=components/src/dynamo/profiler/tests/unit/test_replay_aic_parity.py
```

367 passed. `test_replay_aic_parity.py` is excluded because it needs the Python bindings
built with the `aic-forward-pass` feature, which this environment does not have; it is
unaffected by these files. Two new test files cover the mismatch refusal, the unresolvable-pick error,
the sibling-image warning, resolution of a `_task_key`-only row, and `BackendType` image
coverage including `Auto`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Automatic backend selection now resolves to a specific supported backend before profiling and benchmarking.
  * Profiling results consistently use the selected backend for runtime images, commands, and generated artifacts.
  * Backend image selection is more reliable across thorough and rapid profiling modes.
  * A standardized default backend is used when automatic selection cannot search across backends.

* **Tests**
  * Added coverage for backend resolution, runtime image availability, and backend consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->