### PR TITLE
docs(security): name /clear_kv_blocks and /v1/loras in the deployment guide

### DIFF
--- a/docs/fern/pages/developer-guide/security/secure-deployment-guidelines.md
+++ b/docs/fern/pages/developer-guide/security/secure-deployment-guidelines.md
@@ -197,7 +197,7 @@ reachable.
   workers. This drops `request.nvext` at handler entry and ignores the
   routing-override headers.
 - **Admin API.** The frontend's HTTP admin API (for example,
-  `GET`/`POST /busy_threshold`) is enabled by default. If the deployer does not need to
+  `GET`/`POST /busy_threshold` and `POST /clear_kv_blocks`) is enabled by default. If the deployer does not need to
   change runtime tunables through it, set `DYN_DISABLE_FRONTEND_ADMIN_API=1`.
   Inference, metrics, models, health, and liveness routes are unaffected.
 - **Metrics endpoint.** The `/metrics` endpoint is intended for scraping by
@@ -207,9 +207,10 @@ reachable.
 ### Internal control and diagnostic interfaces
 
 Dynamo's internal control and diagnostic interfaces — for example the worker
-system server (`/engine/*` on `DYN_SYSTEM_PORT`), the planner live dashboard and
-plugin registration, and the standalone KV router services (indexer, selection,
-and slot tracker) — are designed to be used within the trusted network boundary.
+system server (`/engine/*`, and `/v1/loras` adapter load/unload when LoRA is
+enabled, on `DYN_SYSTEM_PORT`), the planner live dashboard and plugin
+registration, and the standalone KV router services (indexer, selection, and slot
+tracker) — are designed to be used within the trusted network boundary.
 While some provide their own authentication, many do not, and several bind on all
 interfaces.
 


### PR DESCRIPTION
## Summary

Small non-blocking follow-up to the merged Secure Deployment Guidelines (#13505). Two worker/admin control routes were not named in the guide; a PSIRT trust-boundary review of the unauthenticated-surface bugs surfaced the gap.

- **`/clear_kv_blocks`** — added next to `/busy_threshold` in the frontend Admin API bullet (both covered by `DYN_DISABLE_FRONTEND_ADMIN_API`).
- **`/v1/loras`** — LoRA adapter load/unload (RCE-class, gated by `DYN_LORA_ENABLED`) named alongside `/engine/*` in the internal control and diagnostic interfaces section.

Documentation only — no code change. Principle-based framing unchanged; these are the exact endpoints the existing guidance already governs.

## Validation

- `docs_lint`, `fern check`, and broken-links pass locally (relative links unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated secure deployment guidelines with details about the frontend admin API’s key-value block clearing endpoint.
  * Documented worker system server endpoints for loading and unloading LoRA adapters when LoRA is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->