### PR TITLE
refactor(errors): unify semantic failure handling

### DIFF
--- a/lib/backend-common/src/adapter.rs
+++ b/lib/backend-common/src/adapter.rs
@@ -865,7 +865,7 @@ mod tests {
         let input = Context::new(make_request(vec![1]));
         let err = adapter.generate(input).await.unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("BackendInvalidArgument"), "got: {msg}");
+        assert!(msg.contains("InvalidRequest"), "got: {msg}");
         assert!(msg.contains("bad param"), "got: {msg}");
     }
 

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -97,6 +97,8 @@ class frontend_service:
     REQUESTS_TOTAL = "requests_total"
     # Total number of LLM requests accepted by the frontend handler
     REQUESTS_STARTED_TOTAL = "requests_started_total"
+    # Total number of terminal semantic request failures.
+    FAILURES_TOTAL = "failures_total"
     # Number of requests waiting in HTTP queue before receiving the first response (gauge)
     QUEUED_REQUESTS = "queued_requests"
     # Number of inflight/concurrent requests going to the engine (vLLM, SGLang, ...)

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -1234,9 +1234,9 @@ fn anthropic_semantic_error(error: &dynamo_runtime::error::DynamoError) -> Optio
 
     super::metrics::record_failure(error);
     if matches!(error.class(), dynamo_runtime::error::ErrorClass::Internal) {
-        tracing::error!(class = %error.class(), reason = %error.reason(), "Semantic request failure");
+        tracing::error!(class = %error.class(), reason = %error.reason(), diagnostic = ?error.diagnostic().map(dynamo_runtime::error::Diagnostic::as_str), "Semantic request failure");
     } else {
-        tracing::debug!(class = %error.class(), reason = %error.reason(), "Semantic request failure");
+        tracing::debug!(class = %error.class(), reason = %error.reason(), diagnostic = ?error.diagnostic().map(dynamo_runtime::error::Diagnostic::as_str), "Semantic request failure");
     }
     Some(anthropic_error_unrecorded(
         status,

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -24,6 +24,7 @@ use axum::{
     },
     routing::{get, post},
 };
+use dynamo_runtime::error::ErrorClass;
 use dynamo_runtime::pipeline::{AsyncEngineContextProvider, Context};
 use futures::StreamExt;
 use tracing::Instrument;
@@ -31,7 +32,8 @@ use tracing::Instrument;
 use super::{
     RouteDoc, apply_request_tool_call_parsing_options,
     disconnect::{
-        ConnectionHandle, create_connection_monitor, monitor_for_disconnects_with_activity,
+        ConnectionHandle, StreamErrorSignal, create_connection_monitor,
+        monitor_for_disconnects_with_activity_and_error_signal,
     },
     metrics::{
         CancellationLabels, Endpoint, ErrorType, InflightGuard,
@@ -61,7 +63,10 @@ use crate::request_template::{RequestTemplate, resolve_request_model};
 use crate::types::Annotated;
 
 // Re-use helpers from the openai module (sibling under service/)
-use super::error::{SanitizedError, invalid_argument};
+use super::error::{
+    ClientErrorAction, SanitizedError, find_canonical_error_in_chain, http_action_for_error,
+    invalid_argument,
+};
 use super::metadata::{attach_x_request_id, extract_metadata_from_http};
 use super::openai::{get_body_limit, get_or_create_request_id, warn_nvext_disabled};
 
@@ -127,6 +132,7 @@ async fn anthropic_error_middleware(request: Request<Body>, next: Next) -> Respo
             .unwrap_or_default();
         let error_message = String::from_utf8_lossy(&body_bytes).to_string();
         return anthropic_error(
+            ErrorClass::InvalidRequest,
             StatusCode::BAD_REQUEST,
             "invalid_request_error",
             &error_message,
@@ -278,6 +284,7 @@ async fn handler_anthropic_messages(
     if let Err(error) = validate_anthropic_messages(&request.messages) {
         inflight_guard.mark_error(error.metric_error_type());
         return Err(anthropic_error(
+            ErrorClass::InvalidRequest,
             error.status(),
             error.anthropic_error_type(),
             error.message(),
@@ -286,6 +293,7 @@ async fn handler_anthropic_messages(
     if let Err(error) = validate_anthropic_tools(request.tools.as_deref()) {
         inflight_guard.mark_error(error.metric_error_type());
         return Err(anthropic_error(
+            ErrorClass::InvalidRequest,
             error.status(),
             error.anthropic_error_type(),
             error.message(),
@@ -294,6 +302,7 @@ async fn handler_anthropic_messages(
     if request.max_tokens == 0 {
         inflight_guard.mark_error(ErrorType::Validation);
         return Err(anthropic_error(
+            ErrorClass::InvalidRequest,
             StatusCode::BAD_REQUEST,
             "invalid_request_error",
             "max_tokens: must be greater than 0",
@@ -302,6 +311,7 @@ async fn handler_anthropic_messages(
     if let Err(error) = gate_anthropic_nvext(&mut request, &headers, state.nvext_enabled()) {
         inflight_guard.mark_error(ErrorType::Validation);
         return Err(anthropic_error(
+            ErrorClass::InvalidRequest,
             StatusCode::BAD_REQUEST,
             "invalid_request_error",
             &error.to_string(),
@@ -317,6 +327,7 @@ async fn handler_anthropic_messages(
     let metadata = extract_metadata_from_http(&headers).map_err(|err| {
         inflight_guard.mark_error(ErrorType::Validation);
         anthropic_error(
+            ErrorClass::PayloadTooLarge,
             StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
             "invalid_request_error",
             &err.to_string(),
@@ -423,6 +434,7 @@ async fn anthropic_messages(
             crate::discovery::ModelManagerError::ModelUnavailable(_) => {
                 inflight_guard.mark_error(ErrorType::Unavailable);
                 anthropic_error(
+                    ErrorClass::Unavailable,
                     StatusCode::SERVICE_UNAVAILABLE,
                     "overloaded_error",
                     &super::openai::model_not_ready_message(&model),
@@ -431,6 +443,7 @@ async fn anthropic_messages(
             _ => {
                 inflight_guard.mark_error(ErrorType::NotFound);
                 anthropic_error(
+                    ErrorClass::NotFound,
                     StatusCode::NOT_FOUND,
                     "not_found_error",
                     &format!("Model '{}' not found", model),
@@ -466,6 +479,7 @@ async fn anthropic_messages(
             "Failed to convert AnthropicCreateMessageRequest to UnifiedRequest",
         );
         anthropic_error(
+            ErrorClass::InvalidRequest,
             StatusCode::BAD_REQUEST,
             "invalid_request_error",
             &format!("Failed to convert request: {}", e),
@@ -482,6 +496,7 @@ async fn anthropic_messages(
         inflight_guard.mark_error(ErrorType::Validation);
         let error = invalid_argument(error.to_string());
         return Err(anthropic_error(
+            ErrorClass::InvalidRequest,
             StatusCode::BAD_REQUEST,
             "invalid_request_error",
             error.message(),
@@ -531,6 +546,7 @@ async fn anthropic_messages(
         .map_err(|e| {
             inflight_guard.mark_error(ErrorType::Validation);
             anthropic_error(
+                ErrorClass::InvalidRequest,
                 StatusCode::BAD_REQUEST,
                 "invalid_request_error",
                 &format!("Invalid tool_choice: {}", e.message()),
@@ -560,6 +576,12 @@ async fn anthropic_messages(
     tracing::trace!("Issuing generate call for Anthropic messages");
 
     let engine_stream = engine.generate(request).await.map_err(|e| {
+        if let Some(error) = find_canonical_error_in_chain(e.as_ref())
+            && let Some(response) = anthropic_semantic_error(error)
+        {
+            inflight_guard.mark_error(super::openai::metric_error_type_for_class(error.class()));
+            return response;
+        }
         if super::metrics::request_was_rejected(e.as_ref()) {
             state
                 .metrics_clone()
@@ -577,13 +599,11 @@ async fn anthropic_messages(
                 format!("{e:#}"),
             );
         }
-        if let Some(dynamo_err) = find_invalid_argument_in_chain(e.as_ref()) {
+        if let Some(dynamo_err) = find_invalid_argument_in_chain(e.as_ref())
+            && let Some(response) = anthropic_semantic_error(dynamo_err)
+        {
             inflight_guard.mark_error(super::metrics::ErrorType::Validation);
-            return anthropic_error(
-                StatusCode::BAD_REQUEST,
-                "invalid_request_error",
-                dynamo_err.message(),
-            );
+            return response;
         }
         // Check for cancelled request (client disconnected before response was sent)
         if super::metrics::request_was_cancelled(e.as_ref()) {
@@ -639,6 +659,8 @@ async fn anthropic_messages(
         let cancel_ctx = ctx.clone();
 
         let (activity_tx, activity_rx) = tokio::sync::mpsc::unbounded_channel();
+        let error_signal = StreamErrorSignal::default();
+        let producer_error_signal = error_signal.clone();
         let full_stream = async_stream::stream! {
             let mut events = Vec::with_capacity(4);
             converter.append_start_events(&mut events);
@@ -647,6 +669,7 @@ async fn anthropic_messages(
             }
 
             let mut saw_error = false;
+            let mut stream_error_body = None;
             let mut cancelled = false;
 
             // Keep a single cancellation future alive across chunks — recreating
@@ -670,9 +693,24 @@ async fn anthropic_messages(
                             &mut http_queue_guard,
                         );
 
+                        let semantic_error = !saw_error
+                            && super::openai::set_stream_semantic_error(
+                                &annotated_chunk,
+                                &producer_error_signal,
+                            );
+                        if semantic_error {
+                            saw_error = true;
+                            stream_error_body = annotated_chunk
+                                .error
+                                .as_ref()
+                                .map(anthropic_stream_error_body);
+                        }
                         let Some(stream_resp) = annotated_chunk.data else {
                             if annotated_chunk.event.as_deref() == Some("error") {
                                 saw_error = true;
+                                if !semantic_error {
+                                    producer_error_signal.set(ErrorType::Internal);
+                                }
                             }
                             continue;
                         };
@@ -694,7 +732,12 @@ async fn anthropic_messages(
             }
 
             if saw_error {
-                converter.append_error_events(&mut events);
+                if let Some(error) = stream_error_body {
+                    converter.append_error_events_with_body(&mut events, error);
+                } else {
+                    converter.append_error_events(&mut events);
+                }
+                producer_error_signal.mark_terminal_event_emitted();
             } else {
                 converter.append_end_events(&mut events);
             }
@@ -712,12 +755,13 @@ async fn anthropic_messages(
         };
 
         let keep_alive = state.sse_keep_alive_for_response(stream_can_defer_all_output);
-        let stream = monitor_for_disconnects_with_activity(
+        let stream = monitor_for_disconnects_with_activity_and_error_signal(
             full_stream,
             ctx,
             inflight_guard,
             stream_handle,
             activity_rx,
+            error_signal,
         );
 
         let mut sse_stream = Sse::new(stream);
@@ -749,6 +793,7 @@ async fn anthropic_messages(
                     None => {
                         tracing::error!(%status, "Anthropic backend error event");
                         anthropic_error(
+                            ErrorClass::InvalidRequest,
                             status,
                             "invalid_request_error",
                             status.canonical_reason().unwrap_or("Client error"),
@@ -800,6 +845,7 @@ async fn handler_count_tokens(
 ) -> Result<Response, Response> {
     if let Err(error) = validate_anthropic_messages(&request.messages) {
         return Err(anthropic_error(
+            ErrorClass::InvalidRequest,
             error.status(),
             error.anthropic_error_type(),
             error.message(),
@@ -1110,6 +1156,13 @@ fn anthropic_sanitized_error_with_details(
     details: impl std::fmt::Display,
 ) -> Response {
     let status = err.status();
+    let class = match err {
+        SanitizedError::Cancelled => ErrorClass::Cancelled,
+        SanitizedError::Overloaded => ErrorClass::CapacityExhausted,
+        SanitizedError::Unavailable => ErrorClass::Unavailable,
+        SanitizedError::Internal | SanitizedError::PreserveServerError(_) => ErrorClass::Internal,
+    };
+    super::openai::record_local_failure(class);
     if err.log_as_error() {
         tracing::error!(status = %status, "Anthropic {err}: {details}");
     } else {
@@ -1153,19 +1206,73 @@ fn find_invalid_argument_in_chain<'a>(
     None
 }
 
+fn anthropic_stream_error_body(error: &dynamo_runtime::error::DynamoError) -> AnthropicErrorBody {
+    let (status, message) = match http_action_for_error(error) {
+        ClientErrorAction::Respond {
+            status,
+            public_message,
+        } => (status, public_message),
+        ClientErrorAction::NoDelivery => (
+            StatusCode::from_u16(499).expect("499 is a valid extension status"),
+            "Request cancelled",
+        ),
+    };
+    AnthropicErrorBody {
+        error_type: anthropic_error_type_for_status(status, "api_error").to_string(),
+        message: message.to_string(),
+    }
+}
+
+fn anthropic_semantic_error(error: &dynamo_runtime::error::DynamoError) -> Option<Response> {
+    let ClientErrorAction::Respond {
+        status,
+        public_message,
+    } = http_action_for_error(error)
+    else {
+        return None;
+    };
+
+    super::metrics::record_failure(error);
+    if matches!(error.class(), dynamo_runtime::error::ErrorClass::Internal) {
+        tracing::error!(class = %error.class(), reason = %error.reason(), "Semantic request failure");
+    } else {
+        tracing::debug!(class = %error.class(), reason = %error.reason(), "Semantic request failure");
+    }
+    Some(anthropic_error_unrecorded(
+        status,
+        "api_error",
+        public_message,
+    ))
+}
+
 /// Build an Anthropic-formatted error response.
 /// Maps HTTP status codes to Anthropic error types following the Anthropic API spec.
-fn anthropic_error(status: StatusCode, error_type: &str, message: &str) -> Response {
-    let mapped_type = match status.as_u16() {
+fn anthropic_error(
+    class: ErrorClass,
+    status: StatusCode,
+    error_type: &str,
+    message: &str,
+) -> Response {
+    super::openai::record_local_failure(class);
+    anthropic_error_unrecorded(status, error_type, message)
+}
+
+fn anthropic_error_type_for_status<'a>(status: StatusCode, fallback: &'a str) -> &'a str {
+    match status.as_u16() {
         400 => "invalid_request_error",
         401 => "authentication_error",
         403 => "permission_error",
         404 => "not_found_error",
         429 => "rate_limit_error",
+        499 => "request_cancelled",
         503 | 529 => "overloaded_error",
-        // Use the caller-provided type for other codes (e.g. 500 → "api_error")
-        _ => error_type,
-    };
+        _ if status.is_client_error() => "invalid_request_error",
+        _ => fallback,
+    }
+}
+
+fn anthropic_error_unrecorded(status: StatusCode, error_type: &str, message: &str) -> Response {
+    let mapped_type = anthropic_error_type_for_status(status, error_type);
 
     (
         status,
@@ -1184,6 +1291,7 @@ fn anthropic_error(status: StatusCode, error_type: &str, message: &str) -> Respo
 /// Anthropic clients expect the nested `{"type": "error", "error": {...}}`
 pub(crate) fn unmatched_route_response(method: &Method, uri: &Uri) -> Response {
     anthropic_error(
+        ErrorClass::NotFound,
         StatusCode::NOT_FOUND,
         "not_found_error",
         &format!("Route not found: {} {}", method, uri.path()),
@@ -1332,6 +1440,84 @@ mod tests {
                 .as_deref(),
             Some("tenant-body")
         );
+    }
+
+    #[tokio::test]
+    async fn anthropic_semantic_error_hides_private_diagnostic() {
+        use dynamo_runtime::error::{DynamoError, ErrorType};
+
+        let error = DynamoError::builder()
+            .error_type(ErrorType::InvalidArgument)
+            .diagnostic("PRIVATE_DIAGNOSTIC_SENTINEL")
+            .build();
+        let response = anthropic_semantic_error(&error).expect("invalid request response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), get_body_limit())
+            .await
+            .unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body.contains("Invalid request"));
+        assert!(!body.contains("PRIVATE_DIAGNOSTIC_SENTINEL"));
+    }
+
+    #[tokio::test]
+    async fn anthropic_semantic_client_statuses_use_invalid_request_type() {
+        for (class, reason, status) in [
+            (
+                dynamo_runtime::error::ErrorClass::Conflict,
+                "request.conflict",
+                StatusCode::CONFLICT,
+            ),
+            (
+                dynamo_runtime::error::ErrorClass::PayloadTooLarge,
+                "request.payload_too_large",
+                StatusCode::PAYLOAD_TOO_LARGE,
+            ),
+            (
+                dynamo_runtime::error::ErrorClass::UnsupportedMedia,
+                "request.unsupported_media",
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            ),
+        ] {
+            let error = dynamo_runtime::error::DynamoError::builder()
+                .class(class)
+                .reason(dynamo_runtime::error::ErrorReason::new(reason).unwrap())
+                .build();
+            let response = anthropic_semantic_error(&error).expect("client response");
+            assert_eq!(response.status(), status);
+            let body = axum::body::to_bytes(response.into_body(), get_body_limit())
+                .await
+                .unwrap();
+            let body: AnthropicErrorResponse = serde_json::from_slice(&body).unwrap();
+            assert_eq!(body.error.error_type, "invalid_request_error");
+        }
+    }
+
+    #[test]
+    fn anthropic_stream_error_uses_semantic_identity_without_diagnostic() {
+        let error = dynamo_runtime::error::DynamoError::builder()
+            .class(ErrorClass::InvalidRequest)
+            .diagnostic("PRIVATE_STREAM_DIAGNOSTIC")
+            .build();
+
+        let body = anthropic_stream_error_body(&error);
+
+        assert_eq!(body.error_type, "invalid_request_error");
+        assert_eq!(body.message, "Invalid request");
+        assert!(!body.message.contains("PRIVATE_STREAM_DIAGNOSTIC"));
+    }
+
+    #[test]
+    fn anthropic_stream_cancellation_has_request_cancelled_body() {
+        let error = dynamo_runtime::error::DynamoError::builder()
+            .class(ErrorClass::Cancelled)
+            .build();
+
+        let body = anthropic_stream_error_body(&error);
+
+        assert_eq!(body.error_type, "request_cancelled");
+        assert_eq!(body.message, "Request cancelled");
     }
 
     #[test]

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -1462,36 +1462,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn anthropic_semantic_client_statuses_use_invalid_request_type() {
-        for (class, reason, status) in [
-            (
-                dynamo_runtime::error::ErrorClass::Conflict,
-                "request.conflict",
-                StatusCode::CONFLICT,
-            ),
-            (
-                dynamo_runtime::error::ErrorClass::PayloadTooLarge,
-                "request.payload_too_large",
-                StatusCode::PAYLOAD_TOO_LARGE,
-            ),
-            (
-                dynamo_runtime::error::ErrorClass::UnsupportedMedia,
-                "request.unsupported_media",
-                StatusCode::UNSUPPORTED_MEDIA_TYPE,
-            ),
-        ] {
-            let error = dynamo_runtime::error::DynamoError::builder()
-                .class(class)
-                .reason(dynamo_runtime::error::ErrorReason::new(reason).unwrap())
-                .build();
-            let response = anthropic_semantic_error(&error).expect("client response");
-            assert_eq!(response.status(), status);
-            let body = axum::body::to_bytes(response.into_body(), get_body_limit())
-                .await
-                .unwrap();
-            let body: AnthropicErrorResponse = serde_json::from_slice(&body).unwrap();
-            assert_eq!(body.error.error_type, "invalid_request_error");
-        }
+    async fn anthropic_semantic_conflict_uses_invalid_request_type() {
+        let error = dynamo_runtime::error::DynamoError::builder()
+            .class(dynamo_runtime::error::ErrorClass::Conflict)
+            .reason(dynamo_runtime::error::ErrorReason::new("request.conflict").unwrap())
+            .build();
+        let response = anthropic_semantic_error(&error).expect("client response");
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = axum::body::to_bytes(response.into_body(), get_body_limit())
+            .await
+            .unwrap();
+        let body: AnthropicErrorResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body.error.error_type, "invalid_request_error");
     }
 
     #[test]

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -1257,7 +1257,7 @@ fn anthropic_error(
     anthropic_error_unrecorded(status, error_type, message)
 }
 
-fn anthropic_error_type_for_status<'a>(status: StatusCode, fallback: &'a str) -> &'a str {
+fn anthropic_error_type_for_status(status: StatusCode, fallback: &str) -> &str {
     match status.as_u16() {
         400 => "invalid_request_error",
         401 => "authentication_error",

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -28,7 +28,7 @@
 //! done by sending a [`axum::response::sse::Event`] with the event type "error" and the data "`[DONE]`".
 //!
 
-use axum::response::sse::Event;
+use axum::{http::StatusCode, response::sse::Event};
 use dynamo_runtime::engine::AsyncEngineContext;
 use futures::{Stream, StreamExt};
 use std::ops::{Deref, DerefMut};
@@ -39,8 +39,9 @@ use std::sync::{
 use std::time::Duration;
 use tokio::sync::mpsc;
 
-use crate::http::service::error::SanitizedError;
+use crate::http::service::error::{ClientErrorAction, SanitizedError, http_action_for_class};
 use crate::http::service::metrics::{CancellationLabels, ErrorType, InflightGuard, Metrics};
+use dynamo_runtime::error::DynamoError;
 
 use dynamo_runtime::config::environment_names::llm::DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS as BACKEND_STREAM_TIMEOUT_ENV;
 
@@ -77,9 +78,14 @@ pub struct ConnectionHandle {
 /// protocol event immediately before yielding it. The disconnect monitor reads
 /// only when the source stream ends or its guards are dropped, avoiding
 /// synchronization on successful per-token events.
+struct StreamFailure {
+    error_type: ErrorType,
+    semantic_error: Option<DynamoError>,
+}
+
 #[derive(Default)]
 struct StreamErrorState {
-    error_type: OnceLock<ErrorType>,
+    failure: OnceLock<StreamFailure>,
     terminal_event_emitted: AtomicBool,
 }
 
@@ -88,11 +94,21 @@ pub(super) struct StreamErrorSignal(Arc<StreamErrorState>);
 
 impl StreamErrorSignal {
     pub(super) fn set(&self, error_type: ErrorType) {
-        let _ = self.0.error_type.set(error_type);
+        let _ = self.0.failure.set(StreamFailure {
+            error_type,
+            semantic_error: None,
+        });
+    }
+
+    pub(super) fn set_semantic(&self, error_type: ErrorType, error: &DynamoError) {
+        let _ = self.0.failure.set(StreamFailure {
+            error_type,
+            semantic_error: Some(error.clone()),
+        });
     }
 
     fn get(&self) -> Option<&ErrorType> {
-        self.0.error_type.get()
+        self.0.failure.get().map(|failure| &failure.error_type)
     }
 
     pub(super) fn mark_terminal_event_emitted(&self) {
@@ -101,6 +117,22 @@ impl StreamErrorSignal {
 
     fn terminal_event_emitted(&self) -> bool {
         self.0.terminal_event_emitted.load(Ordering::Acquire)
+    }
+
+    fn semantic_error(&self) -> Option<&DynamoError> {
+        self.0
+            .failure
+            .get()
+            .and_then(|failure| failure.semantic_error.as_ref())
+    }
+
+    fn record_delivered_semantic_failure(&self) {
+        if self.terminal_event_emitted()
+            && let Some(error) = self.semantic_error()
+            && !matches!(error.class(), dynamo_runtime::error::ErrorClass::Cancelled)
+        {
+            crate::http::service::metrics::record_failure(error);
+        }
     }
 }
 
@@ -141,10 +173,15 @@ impl DerefMut for SignaledInflightGuard {
 
 impl Drop for SignaledInflightGuard {
     fn drop(&mut self) {
-        if self.guard.error_type() == &ErrorType::Cancelled
-            && let Some(error_type) = self.signaled_error_type()
+        if let Some(error_signal) = &self.error_signal
+            && error_signal.terminal_event_emitted()
         {
-            self.guard.mark_error(error_type);
+            error_signal.record_delivered_semantic_failure();
+            if self.guard.error_type() == &ErrorType::Cancelled
+                && let Some(error_type) = self.signaled_error_type()
+            {
+                self.guard.mark_error(error_type);
+            }
         }
     }
 }
@@ -319,6 +356,46 @@ fn openai_stream_error(_error: &(dyn std::error::Error + 'static)) -> (ErrorType
     (ErrorType::Internal, body)
 }
 
+fn openai_semantic_stream_error(class: dynamo_runtime::error::ErrorClass) -> (ErrorType, String) {
+    let (status, message) = match http_action_for_class(class) {
+        ClientErrorAction::Respond {
+            status,
+            public_message,
+        } => (status, public_message),
+        ClientErrorAction::NoDelivery => (
+            StatusCode::from_u16(499).expect("499 is a valid extension status"),
+            "Request cancelled",
+        ),
+    };
+    let error_type = match status {
+        StatusCode::BAD_REQUEST
+        | StatusCode::CONFLICT
+        | StatusCode::PAYLOAD_TOO_LARGE
+        | StatusCode::UNSUPPORTED_MEDIA_TYPE => "invalid_request_error",
+        StatusCode::UNAUTHORIZED => "authentication_error",
+        StatusCode::FORBIDDEN => "permission_error",
+        StatusCode::NOT_FOUND => "not_found_error",
+        StatusCode::TOO_MANY_REQUESTS => "rate_limit_error",
+        StatusCode::SERVICE_UNAVAILABLE => "service_unavailable",
+        StatusCode::GATEWAY_TIMEOUT => "timeout_error",
+        StatusCode::NOT_IMPLEMENTED => "not_implemented_error",
+        _ if status.as_u16() == 499 => "request_cancelled",
+        _ => "internal_server_error",
+    };
+    let body = serde_json::json!({
+        "error": {
+            "message": message,
+            "type": error_type,
+            "code": status.as_u16(),
+        }
+    })
+    .to_string();
+    (
+        crate::http::service::openai::metric_error_type_for_class(class),
+        body,
+    )
+}
+
 /// This method will consume a stream of SSE events and monitor for disconnects or context cancellation.
 ///
 /// Uses `tokio::select!` to choose between receiving events from the source stream or detecting when
@@ -406,6 +483,28 @@ pub fn monitor_for_disconnects_with_activity(
     )
 }
 
+pub(super) fn monitor_for_disconnects_with_activity_and_error_signal(
+    stream: impl Stream<Item = Result<Event, axum::Error>>,
+    context: Arc<dyn AsyncEngineContext>,
+    inflight_guard: InflightGuard,
+    stream_handle: ConnectionHandle,
+    activity_rx: mpsc::UnboundedReceiver<()>,
+    error_signal: StreamErrorSignal,
+) -> impl Stream<Item = Result<Event, axum::Error>> {
+    monitor_for_disconnects_with_timeout_error_and_keep_alive(
+        stream,
+        context,
+        inflight_guard,
+        stream_handle,
+        backend_stream_timeout(),
+        openai_stream_error,
+        StreamMonitorOptions {
+            activity_rx: Some(activity_rx),
+            error_signal: Some(error_signal),
+        },
+    )
+}
+
 #[cfg(test)]
 fn monitor_for_disconnects_with_timeout(
     stream: impl Stream<Item = Result<Event, axum::Error>>,
@@ -472,14 +571,37 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
                             yield event;
                         }
                         Some(Err(err)) => {
-                            let (error_type, error_body) = error_formatter(&err);
-                            inflight_guard.mark_error(error_type);
+                            let semantic_identity = inflight_guard
+                                .error_signal
+                                .as_ref()
+                                .and_then(StreamErrorSignal::semantic_error)
+                                .map(|error| (error.class(), error.reason().clone()));
+                            let (fallback_error_type, fallback_error_body) =
+                                error_formatter(&err);
+                            let (error_type, error_body) = match semantic_identity.as_ref() {
+                                Some((class, _)) => openai_semantic_stream_error(*class),
+                                None => (fallback_error_type, fallback_error_body),
+                            };
+                            inflight_guard.mark_error(error_type.clone());
                             // We're terminating the stream intentionally here with a
                             // structured error + [DONE]; disarm so the stream handle
                             // doesn't later record this as ClosedUnexpectedly (which
                             // would mis-attribute the fault as a client disconnect).
                             stream_handle.disarm();
-                            tracing::error!("Streaming error: {err}");
+                            if let Some(error_signal) = &inflight_guard.error_signal {
+                                error_signal.mark_terminal_event_emitted();
+                                if let Some(error) = error_signal.semantic_error() {
+                                    tracing::debug!(
+                                        class = %error.class(),
+                                        reason = %error.reason(),
+                                        "Semantic streaming failure"
+                                    );
+                                } else {
+                                    tracing::error!(%error_type, "Streaming failure");
+                                }
+                            } else {
+                                tracing::error!(%error_type, "Streaming failure");
+                            }
                             yield Event::default().data(error_body);
                             yield Event::default().data("[DONE]");
                             // Break to prevent any subsequent mark_ok() from overwriting the error
@@ -784,6 +906,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn signaled_semantic_err_is_classified_when_terminal_frame_is_emitted() {
+        let model = "delivered-semantic-error";
+        let metrics = Arc::new(Metrics::new());
+        let guard = metrics.clone().create_inflight_guard(
+            model,
+            Endpoint::ChatCompletions,
+            true,
+            "req-delivered-semantic-error",
+        );
+        let context: Arc<dyn AsyncEngineContext> = Arc::new(MockContext::with_kill_tracking());
+        let (stream_tx, _stream_rx) = tokio::sync::oneshot::channel();
+        let stream_handle = ConnectionHandle::create_disabled(stream_tx);
+        let error_signal = StreamErrorSignal::default();
+        let producer_error_signal = error_signal.clone();
+        let stream = futures::stream::once(async move {
+            let error = DynamoError::builder()
+                .class(dynamo_runtime::error::ErrorClass::InvalidRequest)
+                .reason(
+                    dynamo_runtime::error::ErrorReason::new("request.invalid_argument").unwrap(),
+                )
+                .diagnostic("PRIVATE_STREAM_DIAGNOSTIC")
+                .build();
+            producer_error_signal.set_semantic(ErrorType::Validation, &error);
+            Err::<Event, _>(axum::Error::new("semantic stream error"))
+        });
+        let monitored = monitor_for_disconnects_with_timeout_error_and_keep_alive(
+            stream,
+            context,
+            guard,
+            stream_handle,
+            None,
+            openai_stream_error,
+            StreamMonitorOptions {
+                error_signal: Some(error_signal),
+                ..Default::default()
+            },
+        );
+        let body = collect_sse_body(monitored).await;
+
+        assert!(body.contains("Invalid request"));
+        assert!(body.contains("\"code\":400"));
+        assert!(body.contains("invalid_request_error"));
+        assert!(!body.contains("PRIVATE_STREAM_DIAGNOSTIC"));
+        assert_eq!(
+            metrics.get_request_counter(
+                model,
+                &Endpoint::ChatCompletions,
+                &RequestType::Stream,
+                &Status::Error,
+                &ErrorType::Validation,
+            ),
+            1
+        );
+        assert_eq!(
+            metrics.get_request_counter(
+                model,
+                &Endpoint::ChatCompletions,
+                &RequestType::Stream,
+                &Status::Error,
+                &ErrorType::Internal,
+            ),
+            0
+        );
+    }
+
+    #[tokio::test]
     async fn signaled_error_before_terminal_event_keeps_disconnect_handle_armed() {
         let error_signal = StreamErrorSignal::default();
         error_signal.set(ErrorType::Internal);
@@ -797,6 +985,44 @@ mod tests {
             rx.await.expect("stream handle did not report its status"),
             ConnectionStatus::ClosedUnexpectedly
         ));
+    }
+
+    #[test]
+    fn undelivered_signaled_error_preserves_cancellation_classification() {
+        let model = "undelivered-terminal-error";
+        let metrics = Arc::new(Metrics::new());
+        let mut guard = metrics.clone().create_inflight_guard(
+            model,
+            Endpoint::Responses,
+            true,
+            "req-undelivered-terminal-error",
+        );
+        guard.mark_error(ErrorType::Cancelled);
+        let error_signal = StreamErrorSignal::default();
+        error_signal.set(ErrorType::Internal);
+
+        drop(SignaledInflightGuard::new(guard, Some(error_signal)));
+
+        assert_eq!(
+            metrics.get_request_counter(
+                model,
+                &Endpoint::Responses,
+                &RequestType::Stream,
+                &Status::Error,
+                &ErrorType::Cancelled,
+            ),
+            1
+        );
+        assert_eq!(
+            metrics.get_request_counter(
+                model,
+                &Endpoint::Responses,
+                &RequestType::Stream,
+                &Status::Error,
+                &ErrorType::Internal,
+            ),
+            0
+        );
     }
 
     fn generate_cancellation_labels() -> CancellationLabels {

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -349,7 +349,7 @@ fn openai_stream_error(_error: &(dyn std::error::Error + 'static)) -> (ErrorType
         "error": {
             "message": error.to_string(),
             "type": error.openai_type_slug(),
-            "code": error.status().as_u16(),
+            "code": error.status().as_u16().to_string(),
         }
     })
     .to_string();
@@ -386,7 +386,7 @@ fn openai_semantic_stream_error(class: dynamo_runtime::error::ErrorClass) -> (Er
         "error": {
             "message": message,
             "type": error_type,
-            "code": status.as_u16(),
+            "code": status.as_u16().to_string(),
         }
     })
     .to_string();
@@ -594,6 +594,7 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
                                     tracing::debug!(
                                         class = %error.class(),
                                         reason = %error.reason(),
+                                        diagnostic = ?error.diagnostic().map(dynamo_runtime::error::Diagnostic::as_str),
                                         "Semantic streaming failure"
                                     );
                                 } else {
@@ -946,7 +947,7 @@ mod tests {
         let body = collect_sse_body(monitored).await;
 
         assert!(body.contains("Invalid request"));
-        assert!(body.contains("\"code\":400"));
+        assert!(body.contains("\"code\":\"400\""));
         assert!(body.contains("invalid_request_error"));
         assert!(!body.contains("PRIVATE_STREAM_DIAGNOSTIC"));
         assert_eq!(
@@ -1329,9 +1330,10 @@ mod tests {
             Some(expected.openai_type_slug()),
             "[{case}] structured error `type` mismatch. Body:\n{text}"
         );
+        let expected_code = expected.status().as_u16().to_string();
         assert_eq!(
-            error.get("code").and_then(|v| v.as_i64()),
-            Some(i64::from(expected.status().as_u16())),
+            error.get("code").and_then(|v| v.as_str()),
+            Some(expected_code.as_str()),
             "[{case}] structured error `code` mismatch. Body:\n{text}"
         );
         assert!(

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -50,19 +50,15 @@ pub(crate) enum ClientErrorAction {
 
 /// Total class-to-HTTP policy. Backends never select these status codes.
 pub(crate) fn http_action_for_class(class: dynamo_runtime::error::ErrorClass) -> ClientErrorAction {
-    use dynamo_runtime::error::{BackendError, ErrorClass};
+    use dynamo_runtime::error::ErrorClass;
 
     let response = |status, public_message| ClientErrorAction::Respond {
         status,
         public_message,
     };
 
-    match class {
-        ErrorClass::InvalidArgument
-        | ErrorClass::InvalidRequest
-        | ErrorClass::Backend(BackendError::InvalidArgument) => {
-            response(StatusCode::BAD_REQUEST, "Invalid request")
-        }
+    match class.normalized() {
+        ErrorClass::InvalidRequest => response(StatusCode::BAD_REQUEST, "Invalid request"),
         ErrorClass::Unauthenticated => {
             response(StatusCode::UNAUTHORIZED, "Authentication required")
         }
@@ -76,39 +72,25 @@ pub(crate) fn http_action_for_class(class: dynamo_runtime::error::ErrorClass) ->
             response(StatusCode::UNSUPPORTED_MEDIA_TYPE, "Unsupported media type")
         }
         ErrorClass::RateLimited => response(StatusCode::TOO_MANY_REQUESTS, "Rate limit exceeded"),
-        ErrorClass::ResourceExhausted
-        | ErrorClass::WorkerOverloaded
-        | ErrorClass::CapacityExhausted => response(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "Service temporarily unavailable",
-        ),
-        ErrorClass::CannotConnect
-        | ErrorClass::Disconnected
-        | ErrorClass::Unavailable
-        | ErrorClass::Backend(BackendError::CannotConnect)
-        | ErrorClass::Backend(BackendError::Disconnected)
-        | ErrorClass::Backend(BackendError::EngineShutdown)
-        | ErrorClass::Backend(BackendError::StreamIncomplete) => response(
+        ErrorClass::CapacityExhausted => {
+            response(overload_status_code(), "Service temporarily unavailable")
+        }
+        ErrorClass::Unavailable => response(
             StatusCode::SERVICE_UNAVAILABLE,
             "Service temporarily unavailable",
         ),
         ErrorClass::BackendProtocol => response(StatusCode::BAD_GATEWAY, "Bad gateway"),
-        ErrorClass::ConnectionTimeout
-        | ErrorClass::ResponseTimeout
-        | ErrorClass::DeadlineExceeded
-        | ErrorClass::Backend(BackendError::ConnectionTimeout)
-        | ErrorClass::Backend(BackendError::ResponseTimeout) => {
+        ErrorClass::DeadlineExceeded => {
             response(StatusCode::GATEWAY_TIMEOUT, "Request deadline exceeded")
         }
         ErrorClass::NotImplemented => {
             response(StatusCode::NOT_IMPLEMENTED, "Operation not implemented")
         }
-        ErrorClass::Cancelled | ErrorClass::Backend(BackendError::Cancelled) => {
-            ClientErrorAction::NoDelivery
-        }
-        ErrorClass::Unknown | ErrorClass::Internal | ErrorClass::Backend(BackendError::Unknown) => {
+        ErrorClass::Cancelled => ClientErrorAction::NoDelivery,
+        ErrorClass::Internal => {
             response(StatusCode::INTERNAL_SERVER_ERROR, "Internal server error")
         }
+        _ => unreachable!("normalized error class must be canonical"),
     }
 }
 
@@ -508,10 +490,7 @@ mod tests {
                 Some(StatusCode::UNSUPPORTED_MEDIA_TYPE),
             ),
             (ErrorClass::RateLimited, Some(StatusCode::TOO_MANY_REQUESTS)),
-            (
-                ErrorClass::CapacityExhausted,
-                Some(StatusCode::SERVICE_UNAVAILABLE),
-            ),
+            (ErrorClass::CapacityExhausted, Some(overload_status_code())),
             (ErrorClass::BackendProtocol, Some(StatusCode::BAD_GATEWAY)),
             (
                 ErrorClass::Unavailable,
@@ -549,10 +528,7 @@ mod tests {
 
         for (class, expected) in [
             (ErrorClass::InvalidArgument, StatusCode::BAD_REQUEST),
-            (
-                ErrorClass::WorkerOverloaded,
-                StatusCode::SERVICE_UNAVAILABLE,
-            ),
+            (ErrorClass::WorkerOverloaded, overload_status_code()),
             (ErrorClass::Unknown, StatusCode::INTERNAL_SERVER_ERROR),
         ] {
             assert!(matches!(

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -38,6 +38,109 @@ pub struct HttpError {
     pub message: String,
 }
 
+/// Frontend-owned HTTP disposition derived only from semantic error class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClientErrorAction {
+    NoDelivery,
+    Respond {
+        status: StatusCode,
+        public_message: &'static str,
+    },
+}
+
+/// Total class-to-HTTP policy. Backends never select these status codes.
+pub(crate) fn http_action_for_class(class: dynamo_runtime::error::ErrorClass) -> ClientErrorAction {
+    use dynamo_runtime::error::{BackendError, ErrorClass};
+
+    let response = |status, public_message| ClientErrorAction::Respond {
+        status,
+        public_message,
+    };
+
+    match class {
+        ErrorClass::InvalidArgument
+        | ErrorClass::InvalidRequest
+        | ErrorClass::Backend(BackendError::InvalidArgument) => {
+            response(StatusCode::BAD_REQUEST, "Invalid request")
+        }
+        ErrorClass::Unauthenticated => {
+            response(StatusCode::UNAUTHORIZED, "Authentication required")
+        }
+        ErrorClass::PermissionDenied => response(StatusCode::FORBIDDEN, "Permission denied"),
+        ErrorClass::NotFound => response(StatusCode::NOT_FOUND, "Resource not found"),
+        ErrorClass::Conflict => response(StatusCode::CONFLICT, "Request conflict"),
+        ErrorClass::PayloadTooLarge => {
+            response(StatusCode::PAYLOAD_TOO_LARGE, "Request payload too large")
+        }
+        ErrorClass::UnsupportedMedia => {
+            response(StatusCode::UNSUPPORTED_MEDIA_TYPE, "Unsupported media type")
+        }
+        ErrorClass::RateLimited => response(StatusCode::TOO_MANY_REQUESTS, "Rate limit exceeded"),
+        ErrorClass::ResourceExhausted
+        | ErrorClass::WorkerOverloaded
+        | ErrorClass::CapacityExhausted => response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Service temporarily unavailable",
+        ),
+        ErrorClass::CannotConnect
+        | ErrorClass::Disconnected
+        | ErrorClass::Unavailable
+        | ErrorClass::Backend(BackendError::CannotConnect)
+        | ErrorClass::Backend(BackendError::Disconnected)
+        | ErrorClass::Backend(BackendError::EngineShutdown)
+        | ErrorClass::Backend(BackendError::StreamIncomplete) => response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Service temporarily unavailable",
+        ),
+        ErrorClass::BackendProtocol => response(StatusCode::BAD_GATEWAY, "Bad gateway"),
+        ErrorClass::ConnectionTimeout
+        | ErrorClass::ResponseTimeout
+        | ErrorClass::DeadlineExceeded
+        | ErrorClass::Backend(BackendError::ConnectionTimeout)
+        | ErrorClass::Backend(BackendError::ResponseTimeout) => {
+            response(StatusCode::GATEWAY_TIMEOUT, "Request deadline exceeded")
+        }
+        ErrorClass::NotImplemented => {
+            response(StatusCode::NOT_IMPLEMENTED, "Operation not implemented")
+        }
+        ErrorClass::Cancelled | ErrorClass::Backend(BackendError::Cancelled) => {
+            ClientErrorAction::NoDelivery
+        }
+        ErrorClass::Unknown | ErrorClass::Internal | ErrorClass::Backend(BackendError::Unknown) => {
+            response(StatusCode::INTERNAL_SERVER_ERROR, "Internal server error")
+        }
+    }
+}
+
+pub(crate) fn http_action_for_error(error: &DynamoError) -> ClientErrorAction {
+    http_action_for_class(error.class())
+}
+
+/// Return the first DynamoError only when it already uses the canonical class
+/// vocabulary. Legacy variants continue through compatibility handling.
+pub(crate) fn find_canonical_error_in_chain<'a>(
+    err: &'a (dyn std::error::Error + 'static),
+) -> Option<&'a DynamoError> {
+    use dynamo_runtime::error::ErrorClass;
+
+    let mut current = Some(err);
+    let mut fallback = None;
+    while let Some(error) = current {
+        if let Some(dynamo_error) = error.downcast_ref::<DynamoError>() {
+            let raw_class = dynamo_error.error_type();
+            if raw_class == raw_class.normalized() && raw_class != ErrorClass::Cancelled {
+                if dynamo_error.reason().as_str() == "runtime.unclassified" {
+                    fallback.get_or_insert(dynamo_error);
+                } else {
+                    return Some(dynamo_error);
+                }
+            }
+        }
+        current = error.source();
+    }
+    fallback
+}
+
 /// Construct a typed invalid-argument error for validation performed at an
 /// HTTP protocol adapter boundary.
 pub(crate) fn invalid_argument(message: impl Into<String>) -> DynamoError {
@@ -352,5 +455,110 @@ mod tests {
             BackendStatusAction::triage(StatusCode::from_u16(399).unwrap()),
             BackendStatusAction::Sanitize(SanitizedError::Internal)
         );
+    }
+
+    #[test]
+    fn canonical_lookup_skips_legacy_wrapper() {
+        use dynamo_runtime::error::{ErrorClass, ErrorReason};
+
+        let inner = DynamoError::builder()
+            .class(ErrorClass::InvalidRequest)
+            .reason(ErrorReason::new("request.invalid").unwrap())
+            .build();
+        let outer = DynamoError::builder()
+            .error_type(DynamoErrorType::Unknown)
+            .cause(inner)
+            .build();
+
+        assert_eq!(
+            find_canonical_error_in_chain(&outer).map(DynamoError::class),
+            Some(ErrorClass::InvalidRequest)
+        );
+    }
+
+    #[test]
+    fn canonical_lookup_retains_unclassified_as_fallback() {
+        let error = DynamoError::builder()
+            .class(dynamo_runtime::error::ErrorClass::Internal)
+            .reason(dynamo_runtime::error::ErrorReason::new("runtime.unclassified").unwrap())
+            .build();
+
+        assert_eq!(
+            find_canonical_error_in_chain(&error).map(|error| error.reason().as_str()),
+            Some("runtime.unclassified")
+        );
+    }
+
+    #[test]
+    fn semantic_classes_have_total_http_policy() {
+        use dynamo_runtime::error::ErrorClass;
+
+        let cases = [
+            (ErrorClass::InvalidRequest, Some(StatusCode::BAD_REQUEST)),
+            (ErrorClass::Unauthenticated, Some(StatusCode::UNAUTHORIZED)),
+            (ErrorClass::PermissionDenied, Some(StatusCode::FORBIDDEN)),
+            (ErrorClass::NotFound, Some(StatusCode::NOT_FOUND)),
+            (ErrorClass::Conflict, Some(StatusCode::CONFLICT)),
+            (
+                ErrorClass::PayloadTooLarge,
+                Some(StatusCode::PAYLOAD_TOO_LARGE),
+            ),
+            (
+                ErrorClass::UnsupportedMedia,
+                Some(StatusCode::UNSUPPORTED_MEDIA_TYPE),
+            ),
+            (ErrorClass::RateLimited, Some(StatusCode::TOO_MANY_REQUESTS)),
+            (
+                ErrorClass::CapacityExhausted,
+                Some(StatusCode::SERVICE_UNAVAILABLE),
+            ),
+            (ErrorClass::BackendProtocol, Some(StatusCode::BAD_GATEWAY)),
+            (
+                ErrorClass::Unavailable,
+                Some(StatusCode::SERVICE_UNAVAILABLE),
+            ),
+            (
+                ErrorClass::DeadlineExceeded,
+                Some(StatusCode::GATEWAY_TIMEOUT),
+            ),
+            (
+                ErrorClass::NotImplemented,
+                Some(StatusCode::NOT_IMPLEMENTED),
+            ),
+            (
+                ErrorClass::Internal,
+                Some(StatusCode::INTERNAL_SERVER_ERROR),
+            ),
+            (ErrorClass::Cancelled, None),
+        ];
+
+        for (class, expected_status) in cases {
+            match (http_action_for_class(class), expected_status) {
+                (ClientErrorAction::Respond { status, .. }, Some(expected)) => {
+                    assert_eq!(status, expected, "{class}");
+                }
+                (ClientErrorAction::NoDelivery, None) => {}
+                (actual, expected) => panic!("{class}: got {actual:?}, expected {expected:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn legacy_classes_normalize_before_http_policy() {
+        use dynamo_runtime::error::ErrorClass;
+
+        for (class, expected) in [
+            (ErrorClass::InvalidArgument, StatusCode::BAD_REQUEST),
+            (
+                ErrorClass::WorkerOverloaded,
+                StatusCode::SERVICE_UNAVAILABLE,
+            ),
+            (ErrorClass::Unknown, StatusCode::INTERNAL_SERVER_ERROR),
+        ] {
+            assert!(matches!(
+                http_action_for_class(class),
+                ClientErrorAction::Respond { status, .. } if status == expected
+            ));
+        }
     }
 }

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -40,7 +40,11 @@ use dynamo_runtime::error::{DynamoError, ErrorType as DynamoErrorType};
 fn new_failure_counter() -> IntCounterVec {
     IntCounterVec::new(
         Opts::new(
-            "dynam_failures_total",
+            format!(
+                "{}_{}",
+                name_prefix::FRONTEND,
+                frontend_service::FAILURES_TOTAL
+            ),
             "Total number of terminal semantic request failures",
         ),
         &["class", "reason"],
@@ -48,6 +52,7 @@ fn new_failure_counter() -> IntCounterVec {
     .expect("the fixed failure metric name and labels are valid")
 }
 
+/// Process-wide because protocol error renderers can run without a request-scoped `Metrics`.
 pub(crate) static DYNAM_FAILURES_TOTAL: LazyLock<IntCounterVec> =
     LazyLock::new(new_failure_counter);
 
@@ -4010,8 +4015,8 @@ mod tests {
         let family = registry
             .gather()
             .into_iter()
-            .find(|family| family.name() == "dynam_failures_total")
-            .expect("dynam_failures_total metric");
+            .find(|family| family.name() == "dynamo_frontend_failures_total")
+            .expect("dynamo_frontend_failures_total metric");
         let metric = family
             .get_metric()
             .iter()

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -35,7 +35,31 @@ use crate::protocols::{
 use crate::reasoning_field::{ReasoningField, RoutedReasoning};
 use dynamo_runtime::metrics::prometheus_names::clamp_u64_to_i64;
 
-use dynamo_runtime::error::ErrorType as DynamoErrorType;
+use dynamo_runtime::error::{DynamoError, ErrorType as DynamoErrorType};
+
+fn new_failure_counter() -> IntCounterVec {
+    IntCounterVec::new(
+        Opts::new(
+            "dynam_failures_total",
+            "Total number of terminal semantic request failures",
+        ),
+        &["class", "reason"],
+    )
+    .expect("the fixed failure metric name and labels are valid")
+}
+
+pub(crate) static DYNAM_FAILURES_TOTAL: LazyLock<IntCounterVec> =
+    LazyLock::new(new_failure_counter);
+
+fn record_failure_into(counter: &IntCounterVec, error: &DynamoError) {
+    counter
+        .with_label_values(&[error.class().as_str(), error.reason().as_str()])
+        .inc();
+}
+
+pub(crate) fn record_failure(error: &DynamoError) {
+    record_failure_into(&DYNAM_FAILURES_TOTAL, error);
+}
 
 /// Check whether an error chain indicates the request was rejected.
 pub fn request_was_rejected(err: &(dyn std::error::Error + 'static)) -> bool {
@@ -58,7 +82,10 @@ pub fn request_was_unavailable(err: &(dyn std::error::Error + 'static)) -> bool 
 
 /// Check whether an error chain indicates the request was cancelled.
 pub fn request_was_cancelled(err: &(dyn std::error::Error + 'static)) -> bool {
-    const CANCELLATION: &[DynamoErrorType] = &[DynamoErrorType::Cancelled];
+    const CANCELLATION: &[DynamoErrorType] = &[
+        DynamoErrorType::Cancelled,
+        DynamoErrorType::Backend(dynamo_runtime::error::BackendError::Cancelled),
+    ];
     const NON_CANCELLATION: &[DynamoErrorType] = &[];
     dynamo_runtime::error::match_error_chain(err, CANCELLATION, NON_CANCELLATION)
 }
@@ -1295,6 +1322,7 @@ impl Metrics {
         registry.register(Box::new(self.embedding_latency.clone()))?;
         registry.register(Box::new(self.images_per_request.clone()))?;
         registry.register(Box::new(self.videos_per_request.clone()))?;
+        registry.register(Box::new(DYNAM_FAILURES_TOTAL.clone()))?;
         registry.register(Box::new(self.audio_per_request.clone()))?;
         registry.register(Box::new(self.image_tokens_per_request.clone()))?;
 
@@ -2229,19 +2257,14 @@ fn annotated_to_sse_event<T: Serialize>(
 
     if let Some(ref msg) = annotated.event {
         if msg == "error" {
-            let error_message = if let Some(ref dynamo_err) = annotated.error
-                && !dynamo_err.message().is_empty()
-            {
-                dynamo_err.message().to_string()
-            } else if let Some(ref comments) = annotated.comment {
-                let joined = comments.join(" -- ");
-                if joined.trim().is_empty() {
-                    "unspecified error".to_string()
-                } else {
-                    joined
-                }
+            let error_message = if let Some(ref dynamo_err) = annotated.error {
+                format!(
+                    "semantic stream error: class={} reason={}",
+                    dynamo_err.class(),
+                    dynamo_err.reason()
+                )
             } else {
-                "unspecified error".to_string()
+                "backend stream error".to_string()
             };
             return Err(axum::Error::new(error_message));
         }
@@ -3971,6 +3994,47 @@ mod tests {
     }
 
     #[test]
+    fn semantic_failure_metric_has_only_class_and_reason_labels() {
+        use dynamo_runtime::error::{DynamoError, ErrorClass, ErrorReason};
+
+        let registry = prometheus::Registry::new();
+        let counter = new_failure_counter();
+        registry.register(Box::new(counter.clone())).unwrap();
+        let error = DynamoError::builder()
+            .class(ErrorClass::InvalidRequest)
+            .reason(ErrorReason::new("request.invalid").unwrap())
+            .build();
+
+        record_failure_into(&counter, &error);
+
+        let family = registry
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "dynam_failures_total")
+            .expect("dynam_failures_total metric");
+        let metric = family
+            .get_metric()
+            .iter()
+            .find(|metric| {
+                metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "reason" && label.value() == "request.invalid")
+            })
+            .expect("request.invalid sample");
+        let labels: Vec<_> = metric
+            .get_label()
+            .iter()
+            .map(|label| (label.name(), label.value()))
+            .collect();
+        assert_eq!(
+            labels,
+            vec![("class", "InvalidRequest"), ("reason", "request.invalid")]
+        );
+        assert_eq!(metric.get_counter().value(), 1.0);
+    }
+
+    #[test]
     fn test_multiple_requests_different_error_types() {
         let metrics = Arc::new(Metrics::new());
         let registry = prometheus::Registry::new();
@@ -4165,36 +4229,41 @@ mod tests {
     }
 
     #[test]
-    fn test_error_event_uses_dynamo_error_message() {
+    fn test_error_event_uses_semantic_identity_without_diagnostic() {
         use dynamo_runtime::error::DynamoError;
         let result = run_event_converter(error_annotated(
             Some(DynamoError::msg("image load failed: 403 Forbidden")),
             None,
         ));
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("403 Forbidden"));
+        let message = result.unwrap_err().to_string();
+        assert!(message.contains("class=Internal"));
+        assert!(message.contains("reason=runtime.internal"));
+        assert!(!message.contains("403 Forbidden"));
     }
 
     #[test]
-    fn test_error_event_falls_back_to_comment() {
+    fn test_error_event_does_not_expose_comment() {
         let result =
             run_event_converter(error_annotated(None, Some(vec!["connection lost".into()])));
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("connection lost"));
+        let message = result.unwrap_err().to_string();
+        assert_eq!(message, "backend stream error");
+        assert!(!message.contains("connection lost"));
     }
 
     #[test]
-    fn test_error_event_unspecified_when_no_message() {
+    fn test_error_event_without_identity_is_generic() {
         let result = run_event_converter(error_annotated(None, None));
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "unspecified error");
+        assert_eq!(result.unwrap_err().to_string(), "backend stream error");
     }
 
     #[test]
-    fn test_error_event_empty_comment_falls_through() {
+    fn test_error_event_empty_comment_is_generic() {
         let result = run_event_converter(error_annotated(None, Some(vec!["".into()])));
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "unspecified error");
+        assert_eq!(result.unwrap_err().to_string(), "backend stream error");
     }
 
     #[test]

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -4265,13 +4265,6 @@ mod tests {
     }
 
     #[test]
-    fn test_error_event_empty_comment_is_generic() {
-        let result = run_event_converter(error_annotated(None, Some(vec!["".into()])));
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "backend stream error");
-    }
-
-    #[test]
     fn test_event_converter_serializes_chat_stream_response_as_json_data() {
         let event = run_chat_stream_event_converter(make_chat_stream_annotated("hello"))
             .unwrap()

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -261,42 +261,24 @@ fn sanitized_error_class(error: SanitizedError) -> ErrorClass {
 }
 
 pub(super) fn metric_error_type_for_class(class: dynamo_runtime::error::ErrorClass) -> ErrorType {
-    use dynamo_runtime::error::{BackendError, ErrorClass};
+    use dynamo_runtime::error::ErrorClass;
 
-    match class {
-        ErrorClass::InvalidArgument
-        | ErrorClass::InvalidRequest
+    match class.normalized() {
+        ErrorClass::InvalidRequest
         | ErrorClass::Unauthenticated
         | ErrorClass::PermissionDenied
         | ErrorClass::Conflict
         | ErrorClass::PayloadTooLarge
-        | ErrorClass::UnsupportedMedia
-        | ErrorClass::Backend(BackendError::InvalidArgument) => ErrorType::Validation,
+        | ErrorClass::UnsupportedMedia => ErrorType::Validation,
         ErrorClass::NotFound => ErrorType::NotFound,
-        ErrorClass::RateLimited
-        | ErrorClass::ResourceExhausted
-        | ErrorClass::WorkerOverloaded
-        | ErrorClass::CapacityExhausted => ErrorType::Overload,
-        ErrorClass::CannotConnect
-        | ErrorClass::Disconnected
-        | ErrorClass::Unavailable
-        | ErrorClass::Backend(BackendError::CannotConnect)
-        | ErrorClass::Backend(BackendError::Disconnected)
-        | ErrorClass::Backend(BackendError::EngineShutdown)
-        | ErrorClass::Backend(BackendError::StreamIncomplete) => ErrorType::Unavailable,
-        ErrorClass::Cancelled | ErrorClass::Backend(BackendError::Cancelled) => {
-            ErrorType::Cancelled
-        }
+        ErrorClass::RateLimited | ErrorClass::CapacityExhausted => ErrorType::Overload,
+        ErrorClass::Unavailable => ErrorType::Unavailable,
+        ErrorClass::Cancelled => ErrorType::Cancelled,
         ErrorClass::NotImplemented => ErrorType::NotImplemented,
-        ErrorClass::Unknown
-        | ErrorClass::BackendProtocol
-        | ErrorClass::ConnectionTimeout
-        | ErrorClass::ResponseTimeout
-        | ErrorClass::DeadlineExceeded
-        | ErrorClass::Internal
-        | ErrorClass::Backend(BackendError::Unknown)
-        | ErrorClass::Backend(BackendError::ConnectionTimeout)
-        | ErrorClass::Backend(BackendError::ResponseTimeout) => ErrorType::Internal,
+        ErrorClass::BackendProtocol | ErrorClass::DeadlineExceeded | ErrorClass::Internal => {
+            ErrorType::Internal
+        }
+        _ => unreachable!("normalized error class must be canonical"),
     }
 }
 
@@ -595,7 +577,7 @@ impl ErrorMessage {
     pub fn unsupported_content_error<T: Display>(msg: T) -> ErrorResponse {
         tracing::debug!("Unsupported Content error: {msg}");
         let code = StatusCode::BAD_REQUEST;
-        record_local_failure(ErrorClass::NotImplemented);
+        record_local_failure(ErrorClass::InvalidRequest);
         let error_type = bad_request_error_type();
         (
             code,
@@ -604,7 +586,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-                metric_error_type: Some(ErrorType::NotImplemented),
+                metric_error_type: Some(ErrorType::Validation),
             }),
         )
     }
@@ -653,12 +635,14 @@ impl ErrorMessage {
             tracing::error!(
                 class = %error.class(),
                 reason = %error.reason(),
+                diagnostic = ?error.diagnostic().map(dynamo_runtime::error::Diagnostic::as_str),
                 "Semantic request failure"
             );
         } else {
             tracing::debug!(
                 class = %error.class(),
                 reason = %error.reason(),
+                diagnostic = ?error.diagnostic().map(dynamo_runtime::error::Diagnostic::as_str),
                 "Semantic request failure"
             );
         }
@@ -667,10 +651,7 @@ impl ErrorMessage {
             status,
             Json(ErrorMessage {
                 message: public_message.to_string(),
-                error_type: status
-                    .canonical_reason()
-                    .unwrap_or("UnknownError")
-                    .to_string(),
+                error_type: map_error_code_to_error_type(status),
                 code: status.as_u16(),
                 details: error
                     .public_details()
@@ -698,6 +679,13 @@ impl ErrorMessage {
                     details: serde_json::to_value(rejection).ok().map(Box::new),
                     metric_error_type: None,
                 }),
+            );
+        }
+
+        if super::metrics::request_was_cancelled(err.as_ref()) {
+            return ErrorMessage::sanitized_with_details(
+                SanitizedError::Cancelled,
+                format!("{err:#}"),
             );
         }
 
@@ -730,14 +718,6 @@ impl ErrorMessage {
             && let Some(response) = Self::from_semantic_error(dynamo_err)
         {
             return response;
-        }
-
-        // Check for Cancelled anywhere in the error chain → HTTP 499 (Client Closed Request)
-        if super::metrics::request_was_cancelled(err.as_ref()) {
-            return ErrorMessage::sanitized_with_details(
-                SanitizedError::Cancelled,
-                format!("{err:#}"),
-            );
         }
 
         if let Some(error) = canonical_error
@@ -808,7 +788,30 @@ impl ErrorMessage {
                 .unwrap_or("Client error")
                 .to_string();
         }
-        Self::from_http_error(ErrorClass::Internal, err)
+        Self::from_http_error(backend_http_error_class(status), err)
+    }
+}
+
+fn backend_http_error_class(status: StatusCode) -> ErrorClass {
+    if status == overload_status_code() {
+        return ErrorClass::CapacityExhausted;
+    }
+
+    match status {
+        status if status.as_u16() == 499 => ErrorClass::Cancelled,
+        StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY => ErrorClass::InvalidRequest,
+        StatusCode::UNAUTHORIZED => ErrorClass::Unauthenticated,
+        StatusCode::FORBIDDEN => ErrorClass::PermissionDenied,
+        StatusCode::NOT_FOUND => ErrorClass::NotFound,
+        StatusCode::CONFLICT => ErrorClass::Conflict,
+        StatusCode::PAYLOAD_TOO_LARGE => ErrorClass::PayloadTooLarge,
+        StatusCode::UNSUPPORTED_MEDIA_TYPE => ErrorClass::UnsupportedMedia,
+        StatusCode::TOO_MANY_REQUESTS => ErrorClass::RateLimited,
+        StatusCode::SERVICE_UNAVAILABLE => ErrorClass::Unavailable,
+        StatusCode::GATEWAY_TIMEOUT => ErrorClass::DeadlineExceeded,
+        StatusCode::NOT_IMPLEMENTED => ErrorClass::NotImplemented,
+        status if status.is_client_error() => ErrorClass::InvalidRequest,
+        _ => ErrorClass::Internal,
     }
 }
 
@@ -2751,7 +2754,8 @@ fn backend_error_response(backend_error: BackendErrorInfo, record_failure: bool)
     } = backend_error;
     let mut render_record_failure = record_failure;
     if let Some(error) = &semantic {
-        let is_canonical = error.error_type() == error.class();
+        let is_classified = error.reason().as_str() != "runtime.unclassified";
+        let is_canonical = is_classified && error.error_type() == error.class();
         if (is_canonical
             || matches!(
                 error.class(),
@@ -2769,7 +2773,7 @@ fn backend_error_response(backend_error: BackendErrorInfo, record_failure: bool)
                 false,
             );
         }
-        if record_failure {
+        if record_failure && is_classified {
             super::metrics::record_failure(error);
             render_record_failure = false;
         }
@@ -2787,7 +2791,7 @@ fn backend_error_response(backend_error: BackendErrorInfo, record_failure: bool)
         }
         BackendStatusAction::ForwardClientError => {
             if render_record_failure {
-                record_local_failure(ErrorClass::Internal);
+                record_local_failure(backend_http_error_class(status));
             }
             (
                 status,
@@ -6017,6 +6021,45 @@ mod tests {
     }
 
     #[test]
+    fn unclassified_backend_error_uses_its_trusted_http_status() {
+        let backend_payload = std::io::Error::other("backend payload");
+        let response = backend_error_response(
+            BackendErrorInfo {
+                message: "unsupported image format".to_string(),
+                status: StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                semantic: Some(dynamo_runtime::error::DynamoError::from(
+                    &backend_payload as &(dyn std::error::Error + 'static),
+                )),
+                sanitized: None,
+            },
+            true,
+        );
+
+        assert_eq!(response.0, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        assert_eq!(response.1.message, "Unsupported Media Type");
+    }
+
+    #[test]
+    fn classified_internal_error_ignores_backend_http_status() {
+        let response = backend_error_response(
+            BackendErrorInfo {
+                message: "backend unavailable".to_string(),
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                semantic: Some(
+                    dynamo_runtime::error::DynamoError::builder()
+                        .class(dynamo_runtime::error::ErrorClass::Internal)
+                        .build(),
+                ),
+                sanitized: None,
+            },
+            true,
+        );
+
+        assert_eq!(response.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.1.message, "Internal server error");
+    }
+
+    #[test]
     fn test_from_http_error_sanitizes_499_message() {
         // Backend may construct HttpError { code: 499, message: "..." }; that
         // message can carry context IDs / queue paths and must not leak.
@@ -6477,6 +6520,39 @@ mod tests {
     }
 
     #[test]
+    fn frontend_invalid_argument_does_not_expose_diagnostic_details() {
+        const DIAGNOSTIC: &str = "request.messages must not be empty at /srv/frontend.rs:42";
+        let response =
+            ErrorMessage::from_anyhow(invalid_argument(DIAGNOSTIC).into(), BACKUP_ERROR_MESSAGE);
+
+        assert_eq!(response.0, StatusCode::BAD_REQUEST);
+        assert_eq!(response.1.message, "Invalid request");
+        assert!(response.1.details.is_none());
+        let body = serde_json::to_string(&response.1.0).expect("error response serializes");
+        assert!(!body.contains(DIAGNOSTIC));
+    }
+
+    #[test]
+    fn backend_http_status_derives_the_recorded_semantic_class() {
+        assert_eq!(
+            backend_http_error_class(StatusCode::BAD_REQUEST),
+            ErrorClass::InvalidRequest
+        );
+        assert_eq!(
+            backend_http_error_class(StatusCode::TOO_MANY_REQUESTS),
+            ErrorClass::RateLimited
+        );
+        assert_eq!(
+            backend_http_error_class(overload_status_code()),
+            ErrorClass::CapacityExhausted
+        );
+        assert_eq!(
+            backend_http_error_class(StatusCode::SERVICE_UNAVAILABLE),
+            ErrorClass::Unavailable
+        );
+    }
+
+    #[test]
     fn test_backend_invalid_argument_surfaces_as_400() {
         // `Backend(InvalidArgument)` is what `py_err_to_dynamo` produces
         // for Python `ValueError` / `TypeError` raised inside an engine's
@@ -6495,6 +6571,17 @@ mod tests {
         assert_eq!(response.1.code, StatusCode::BAD_REQUEST.as_u16());
         assert_eq!(response.1.message, "Invalid request");
     }
+    #[test]
+    fn canonical_capacity_uses_the_configured_overload_status() {
+        let error = dynamo_runtime::error::DynamoError::builder()
+            .class(ErrorClass::CapacityExhausted)
+            .build();
+        let response = ErrorMessage::from_anyhow(error.into(), BACKUP_ERROR_MESSAGE);
+
+        assert_eq!(response.0, overload_status_code());
+        assert_eq!(response.1.code, overload_status_code().as_u16());
+    }
+
     #[test]
     fn canonical_errors_use_shared_status_and_hide_diagnostics() {
         use dynamo_runtime::error::{DynamoError, ErrorClass};
@@ -6520,7 +6607,7 @@ mod tests {
             ),
             (
                 ErrorClass::CapacityExhausted,
-                StatusCode::SERVICE_UNAVAILABLE,
+                overload_status_code(),
                 "Service temporarily unavailable",
                 ErrorType::Overload,
             ),
@@ -6558,7 +6645,11 @@ mod tests {
             assert_eq!(response.1.message, expected_message, "{class}");
             assert_eq!(
                 response.1.error_type,
-                expected_status.canonical_reason().unwrap(),
+                if class == ErrorClass::CapacityExhausted {
+                    "Overloaded"
+                } else {
+                    expected_status.canonical_reason().unwrap()
+                },
                 "{class}"
             );
             assert_eq!(
@@ -8091,7 +8182,7 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_content_responses_conversion_errors_are_not_implemented() {
+    fn unsupported_content_responses_conversion_errors_are_validation_errors() {
         let response = responses_conversion_error_response(
             ResponsesConversionError::UnsupportedContent("feature not available".to_string())
                 .into(),
@@ -8101,7 +8192,7 @@ mod tests {
         assert_eq!(response.1.error_type, "Bad Request");
         assert_eq!(
             extract_error_type_from_response(&response),
-            ErrorType::NotImplemented
+            ErrorType::Validation
         );
     }
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -24,6 +24,7 @@ use axum::{
 use base64::Engine as _;
 use bytes::Bytes;
 use dynamo_runtime::config::{env_is_truthy, environment_names::llm as env_llm};
+use dynamo_runtime::error::ErrorClass;
 use dynamo_runtime::{
     pipeline::{AsyncEngineContextProvider, Context},
     protocols::annotated::AnnotationsProvider,
@@ -36,7 +37,8 @@ use super::{
     RouteDoc, apply_request_tool_call_parsing_options,
     disconnect::{
         ConnectionHandle, StreamErrorSignal, create_connection_monitor, monitor_for_disconnects,
-        monitor_for_disconnects_with_activity, monitor_for_disconnects_with_error_signal,
+        monitor_for_disconnects_with_activity_and_error_signal,
+        monitor_for_disconnects_with_error_signal,
     },
     error::{HttpError, invalid_argument},
     metadata::{attach_x_request_id, extract_metadata_from_http},
@@ -110,7 +112,10 @@ const BATCH_OUTPUT_RETRIEVAL_NOT_IMPLEMENTED: &str =
 static FORCE_INCLUDE_USAGE: LazyLock<bool> =
     LazyLock::new(|| env_is_truthy(env_llm::DYN_ENABLE_FORCE_INCLUDE_USAGE));
 
-use super::error::{BackendStatusAction, SanitizedError, overload_status_code};
+use super::error::{
+    BackendStatusAction, ClientErrorAction, SanitizedError, find_canonical_error_in_chain,
+    http_action_for_error, overload_status_code,
+};
 
 pub(super) fn rl_router(
     drt: Arc<dynamo_runtime::DistributedRuntime>,
@@ -237,6 +242,64 @@ fn classify_error_for_metrics(code: StatusCode, message: &str) -> ErrorType {
     }
 }
 
+pub(super) fn record_local_failure(class: ErrorClass) {
+    use dynamo_runtime::error::DynamoError;
+
+    if class == ErrorClass::Cancelled {
+        return;
+    }
+    super::metrics::record_failure(&DynamoError::builder().class(class).build());
+}
+
+fn sanitized_error_class(error: SanitizedError) -> ErrorClass {
+    match error {
+        SanitizedError::Cancelled => ErrorClass::Cancelled,
+        SanitizedError::Overloaded => ErrorClass::CapacityExhausted,
+        SanitizedError::Unavailable => ErrorClass::Unavailable,
+        SanitizedError::Internal | SanitizedError::PreserveServerError(_) => ErrorClass::Internal,
+    }
+}
+
+pub(super) fn metric_error_type_for_class(class: dynamo_runtime::error::ErrorClass) -> ErrorType {
+    use dynamo_runtime::error::{BackendError, ErrorClass};
+
+    match class {
+        ErrorClass::InvalidArgument
+        | ErrorClass::InvalidRequest
+        | ErrorClass::Unauthenticated
+        | ErrorClass::PermissionDenied
+        | ErrorClass::Conflict
+        | ErrorClass::PayloadTooLarge
+        | ErrorClass::UnsupportedMedia
+        | ErrorClass::Backend(BackendError::InvalidArgument) => ErrorType::Validation,
+        ErrorClass::NotFound => ErrorType::NotFound,
+        ErrorClass::RateLimited
+        | ErrorClass::ResourceExhausted
+        | ErrorClass::WorkerOverloaded
+        | ErrorClass::CapacityExhausted => ErrorType::Overload,
+        ErrorClass::CannotConnect
+        | ErrorClass::Disconnected
+        | ErrorClass::Unavailable
+        | ErrorClass::Backend(BackendError::CannotConnect)
+        | ErrorClass::Backend(BackendError::Disconnected)
+        | ErrorClass::Backend(BackendError::EngineShutdown)
+        | ErrorClass::Backend(BackendError::StreamIncomplete) => ErrorType::Unavailable,
+        ErrorClass::Cancelled | ErrorClass::Backend(BackendError::Cancelled) => {
+            ErrorType::Cancelled
+        }
+        ErrorClass::NotImplemented => ErrorType::NotImplemented,
+        ErrorClass::Unknown
+        | ErrorClass::BackendProtocol
+        | ErrorClass::ConnectionTimeout
+        | ErrorClass::ResponseTimeout
+        | ErrorClass::DeadlineExceeded
+        | ErrorClass::Internal
+        | ErrorClass::Backend(BackendError::Unknown)
+        | ErrorClass::Backend(BackendError::ConnectionTimeout)
+        | ErrorClass::Backend(BackendError::ResponseTimeout) => ErrorType::Internal,
+    }
+}
+
 /// Extract ErrorType from ErrorResponse for metrics
 fn extract_error_type_from_response(response: &ErrorResponse) -> ErrorType {
     response
@@ -312,6 +375,7 @@ impl ErrorMessage {
     /// Not Found Error
     pub fn model_not_found() -> ErrorResponse {
         let code = StatusCode::NOT_FOUND;
+        record_local_failure(ErrorClass::NotFound);
         let error_type = map_error_code_to_error_type(code);
         (
             code,
@@ -352,6 +416,7 @@ impl ErrorMessage {
     /// shedding.
     pub fn _service_unavailable() -> ErrorResponse {
         let code = StatusCode::SERVICE_UNAVAILABLE;
+        record_local_failure(ErrorClass::Unavailable);
         (
             code,
             Json(ErrorMessage {
@@ -372,6 +437,7 @@ impl ErrorMessage {
     /// `metric_error_type` are set directly rather than derived from `code`.
     pub fn service_unavailable_with_body(message: String) -> ErrorResponse {
         let code = StatusCode::SERVICE_UNAVAILABLE;
+        record_local_failure(ErrorClass::Unavailable);
         (
             code,
             Json(ErrorMessage {
@@ -395,6 +461,7 @@ impl ErrorMessage {
     pub fn internal_server_error(msg: &str) -> ErrorResponse {
         tracing::error!("Internal server error: {msg}");
         let code = StatusCode::INTERNAL_SERVER_ERROR;
+        record_local_failure(ErrorClass::Internal);
         (
             code,
             Json(ErrorMessage {
@@ -421,6 +488,7 @@ impl ErrorMessage {
     ) -> ErrorResponse {
         tracing::error!("Internal server error: {public_msg}: {details}");
         let code = StatusCode::INTERNAL_SERVER_ERROR;
+        record_local_failure(ErrorClass::Internal);
         (
             code,
             Json(ErrorMessage {
@@ -442,7 +510,18 @@ impl ErrorMessage {
         err: SanitizedError,
         details: impl std::fmt::Display,
     ) -> ErrorResponse {
+        Self::sanitized_with_details_recording(err, details, true)
+    }
+
+    fn sanitized_with_details_recording(
+        err: SanitizedError,
+        details: impl std::fmt::Display,
+        record_failure: bool,
+    ) -> ErrorResponse {
         let status = err.status();
+        if record_failure {
+            record_local_failure(sanitized_error_class(err));
+        }
         if err.log_as_error() {
             tracing::error!(status = %status, "{err}: {details}");
         } else {
@@ -477,10 +556,12 @@ impl ErrorMessage {
     fn coerced_backend_error(
         asserted: StatusCode,
         details: impl std::fmt::Display,
+        record_failure: bool,
     ) -> ErrorResponse {
-        let (status, mut body) = ErrorMessage::sanitized_with_details(
+        let (status, mut body) = ErrorMessage::sanitized_with_details_recording(
             SanitizedError::Internal,
             format!("backend asserted status {}: {details}", asserted.as_u16()),
+            record_failure,
         );
         body.0.details = Some(Box::new(
             serde_json::json!({ "backend_status": asserted.as_u16() }),
@@ -494,6 +575,7 @@ impl ErrorMessage {
     pub fn not_implemented_error<T: Display>(msg: T) -> ErrorResponse {
         tracing::error!("Not Implemented error: {msg}");
         let code = StatusCode::NOT_IMPLEMENTED;
+        record_local_failure(ErrorClass::NotImplemented);
         let error_type = map_error_code_to_error_type(code);
         (
             code,
@@ -513,6 +595,7 @@ impl ErrorMessage {
     pub fn unsupported_content_error<T: Display>(msg: T) -> ErrorResponse {
         tracing::debug!("Unsupported Content error: {msg}");
         let code = StatusCode::BAD_REQUEST;
+        record_local_failure(ErrorClass::NotImplemented);
         let error_type = bad_request_error_type();
         (
             code,
@@ -528,6 +611,7 @@ impl ErrorMessage {
 
     pub fn request_headers_too_large(msg: &str) -> ErrorResponse {
         let code = StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE;
+        record_local_failure(ErrorClass::PayloadTooLarge);
         let error_type = map_error_code_to_error_type(code);
         (
             code,
@@ -541,6 +625,62 @@ impl ErrorMessage {
         )
     }
 
+    fn from_semantic_error(error: &dynamo_runtime::error::DynamoError) -> Option<ErrorResponse> {
+        Self::from_semantic_error_with_recording(error, true)
+    }
+
+    fn from_semantic_error_with_recording(
+        error: &dynamo_runtime::error::DynamoError,
+        record_failure: bool,
+    ) -> Option<ErrorResponse> {
+        let ClientErrorAction::Respond {
+            status,
+            public_message,
+        } = http_action_for_error(error)
+        else {
+            return None;
+        };
+
+        if record_failure {
+            super::metrics::record_failure(error);
+        }
+
+        if matches!(
+            error.class(),
+            dynamo_runtime::error::ErrorClass::Internal
+                | dynamo_runtime::error::ErrorClass::BackendProtocol
+        ) {
+            tracing::error!(
+                class = %error.class(),
+                reason = %error.reason(),
+                "Semantic request failure"
+            );
+        } else {
+            tracing::debug!(
+                class = %error.class(),
+                reason = %error.reason(),
+                "Semantic request failure"
+            );
+        }
+
+        Some((
+            status,
+            Json(ErrorMessage {
+                message: public_message.to_string(),
+                error_type: status
+                    .canonical_reason()
+                    .unwrap_or("UnknownError")
+                    .to_string(),
+                code: status.as_u16(),
+                details: error
+                    .public_details()
+                    .and_then(|details| serde_json::to_value(details).ok())
+                    .map(Box::new),
+                metric_error_type: Some(metric_error_type_for_class(error.class())),
+            }),
+        ))
+    }
+
     /// The OAI endpoints call an [`dynamo.runtime::engine::AsyncEngine`] which are specialized to return
     /// an [`anyhow::Error`]. This method will convert the [`anyhow::Error`] into an [`HttpError`].
     /// If successful, it will return the [`HttpError`] as an [`ErrorMessage::internal_server_error`]
@@ -548,6 +688,7 @@ impl ErrorMessage {
     pub fn from_anyhow(err: anyhow::Error, alt_msg: &str) -> ErrorResponse {
         if let Some(rejection) = find_queue_rejection_in_chain(err.as_ref()) {
             let code = overload_status_code();
+            record_local_failure(ErrorClass::CapacityExhausted);
             return (
                 code,
                 Json(ErrorMessage {
@@ -558,6 +699,14 @@ impl ErrorMessage {
                     metric_error_type: None,
                 }),
             );
+        }
+
+        let canonical_error = find_canonical_error_in_chain(err.as_ref());
+        if let Some(error) = canonical_error
+            && error.reason().as_str() != "runtime.unclassified"
+            && let Some(response) = Self::from_semantic_error(error)
+        {
+            return response;
         }
 
         // Check for ResourceExhausted anywhere in the error chain → HTTP 529
@@ -577,17 +726,10 @@ impl ErrorMessage {
         }
 
         // InvalidArgument (top-level OR Backend) → 400.
-        if let Some(dynamo_err) = find_invalid_argument_in_chain(err.as_ref()) {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorMessage {
-                    message: dynamo_err.message().to_string(),
-                    error_type: map_error_code_to_error_type(StatusCode::BAD_REQUEST),
-                    code: StatusCode::BAD_REQUEST.as_u16(),
-                    details: None,
-                    metric_error_type: Some(ErrorType::Validation),
-                }),
-            );
+        if let Some(dynamo_err) = find_invalid_argument_in_chain(err.as_ref())
+            && let Some(response) = Self::from_semantic_error(dynamo_err)
+        {
+            return response;
         }
 
         // Check for Cancelled anywhere in the error chain → HTTP 499 (Client Closed Request)
@@ -598,34 +740,45 @@ impl ErrorMessage {
             );
         }
 
+        if let Some(error) = canonical_error
+            && let Some(response) = Self::from_semantic_error(error)
+        {
+            return response;
+        }
+
         // Then check for HttpError
         match err.downcast::<HttpError>() {
-            Ok(http_error) => ErrorMessage::from_http_error(http_error),
+            Ok(http_error) => ErrorMessage::from_backend_http_error(http_error),
             Err(err) => {
                 ErrorMessage::internal_server_error_with_details(alt_msg, format!("{err:#}"))
             }
         }
     }
 
-    /// Convert a backend-supplied [`HttpError`] into a client response.
+    /// Convert a locally constructed [`HttpError`] into a client response.
     ///
     /// Parse first, so a code outside the HTTP status space cannot reach the
     /// response, then let [`BackendStatusAction::triage`] decide. A 5xx keeps
     /// its own status only when it is 503 or the configured overload code,
     /// which is what makes a deliberate load shed distinguishable from an
     /// internal error. The body text is sanitized either way.
-    pub fn from_http_error(err: HttpError) -> ErrorResponse {
+    pub fn from_http_error(class: ErrorClass, err: HttpError) -> ErrorResponse {
         let Ok(status) = StatusCode::from_u16(err.code) else {
-            return ErrorMessage::sanitized_with_details(SanitizedError::Internal, err.message);
+            record_local_failure(ErrorClass::Internal);
+            return ErrorMessage::sanitized_with_details_recording(
+                SanitizedError::Internal,
+                err.message,
+                false,
+            );
         };
+        record_local_failure(class);
         match BackendStatusAction::triage(status) {
             BackendStatusAction::Sanitize(variant) => {
-                ErrorMessage::sanitized_with_details(variant, err.message)
+                ErrorMessage::sanitized_with_details_recording(variant, err.message, false)
             }
             BackendStatusAction::CoerceToInternal(asserted) => {
-                ErrorMessage::coerced_backend_error(asserted, err.message)
+                ErrorMessage::coerced_backend_error(asserted, err.message, false)
             }
-            // 4xx (non-499): forward the backend's own message.
             BackendStatusAction::ForwardClientError => (
                 status,
                 Json(ErrorMessage {
@@ -637,6 +790,25 @@ impl ErrorMessage {
                 }),
             ),
         }
+    }
+
+    /// Convert an untrusted backend [`HttpError`] into a client response.
+    ///
+    /// The status remains useful protocol information, but backend message text
+    /// is diagnostic-only and must not become public merely because it used a
+    /// 4xx status.
+    fn from_backend_http_error(mut err: HttpError) -> ErrorResponse {
+        let Ok(status) = StatusCode::from_u16(err.code) else {
+            return ErrorMessage::sanitized_with_details(SanitizedError::Internal, err.message);
+        };
+        if status.is_client_error() && status.as_u16() != 499 && status != overload_status_code() {
+            tracing::debug!(status = %status, "Backend client error: {}", err.message);
+            err.message = status
+                .canonical_reason()
+                .unwrap_or("Client error")
+                .to_string();
+        }
+        Self::from_http_error(ErrorClass::Internal, err)
     }
 }
 
@@ -661,6 +833,7 @@ pub async fn smart_json_error_middleware(request: Request<Body>, next: Next) -> 
     let response = next.run(request).await;
 
     if response.status() == StatusCode::UNPROCESSABLE_ENTITY {
+        record_local_failure(ErrorClass::InvalidRequest);
         let (_parts, body) = response.into_parts();
         let body_bytes = axum::body::to_bytes(body, get_body_limit())
             .await
@@ -1004,6 +1177,8 @@ async fn completions_single(
     if streaming {
         // For streaming, we'll drop the http_queue_guard on the first token
         let mut http_queue_guard = Some(http_queue_guard);
+        let error_signal = StreamErrorSignal::default();
+        let producer_error_signal = error_signal.clone();
         let stream = stream
             .filter(|r| {
                 // Drop empty chunks from multi-byte token assembly
@@ -1014,19 +1189,30 @@ async fn completions_single(
                 )
             })
             .map(move |response| {
+                let semantic_error = set_stream_semantic_error(&response, &producer_error_signal);
                 // Calls observe_response() on each token
-                process_response_using_event_converter_and_observe_metrics(
+                let result = process_response_using_event_converter_and_observe_metrics(
                     EventConverter::from(response),
                     &mut response_collector,
                     &mut http_queue_guard,
-                )
+                );
+                if semantic_error && matches!(result, Ok(Some(_))) {
+                    producer_error_signal.mark_terminal_event_emitted();
+                }
+                result
             })
             .filter_map(|result| {
                 use futures::future;
                 // Transpose Result<Option<T>> -> Option<Result<T>>
                 future::ready(result.transpose())
             });
-        let stream = monitor_for_disconnects(stream, ctx, inflight_guard, stream_handle);
+        let stream = monitor_for_disconnects_with_error_signal(
+            stream,
+            ctx,
+            inflight_guard,
+            stream_handle,
+            error_signal,
+        );
 
         let mut sse_stream = Sse::new(stream);
 
@@ -1333,6 +1519,8 @@ async fn completions_batch(
     if streaming {
         // For streaming, we'll drop the http_queue_guard on the first token
         let mut http_queue_guard = Some(http_queue_guard);
+        let error_signal = StreamErrorSignal::default();
+        let producer_error_signal = error_signal.clone();
         let stream = merged_stream
             .filter(|r| {
                 // Drop empty chunks from multi-byte token assembly
@@ -1343,19 +1531,30 @@ async fn completions_batch(
                 )
             })
             .map(move |response| {
+                let semantic_error = set_stream_semantic_error(&response, &producer_error_signal);
                 // Calls observe_response() on each token
-                process_response_using_event_converter_and_observe_metrics(
+                let result = process_response_using_event_converter_and_observe_metrics(
                     EventConverter::from(response),
                     &mut response_collector,
                     &mut http_queue_guard,
-                )
+                );
+                if semantic_error && matches!(result, Ok(Some(_))) {
+                    producer_error_signal.mark_terminal_event_emitted();
+                }
+                result
             })
             .filter_map(|result| {
                 use futures::future;
                 // Transpose Result<Option<T>> -> Option<Result<T>>
                 future::ready(result.transpose())
             });
-        let stream = monitor_for_disconnects(stream, ctx, inflight_guard, stream_handle);
+        let stream = monitor_for_disconnects_with_error_signal(
+            stream,
+            ctx,
+            inflight_guard,
+            stream_handle,
+            error_signal,
+        );
 
         let mut sse_stream = Sse::new(stream);
 
@@ -1675,16 +1874,12 @@ async fn classify(
 }
 
 fn pooling_or_classify_bad_request(message: String) -> ErrorResponse {
-    let code = StatusCode::BAD_REQUEST;
-    (
-        code,
-        Json(ErrorMessage {
+    ErrorMessage::from_http_error(
+        ErrorClass::InvalidRequest,
+        HttpError {
+            code: StatusCode::BAD_REQUEST.as_u16(),
             message,
-            error_type: map_error_code_to_error_type(code),
-            code: code.as_u16(),
-            details: None,
-            metric_error_type: None,
-        }),
+        },
     )
 }
 
@@ -2113,16 +2308,12 @@ where
 }
 
 fn json_deserialize_error(error: serde_json::Error) -> ErrorResponse {
-    let code = StatusCode::BAD_REQUEST;
-    (
-        code,
-        Json(ErrorMessage {
+    ErrorMessage::from_http_error(
+        ErrorClass::InvalidRequest,
+        HttpError {
+            code: StatusCode::BAD_REQUEST.as_u16(),
             message: format!("Failed to deserialize the JSON body into the target type: {error}"),
-            error_type: map_error_code_to_error_type(code),
-            code: code.as_u16(),
-            details: None,
-            metric_error_type: None,
-        }),
+        },
     )
 }
 
@@ -2142,51 +2333,39 @@ fn ensure_json_content_type(headers: &HeaderMap) -> Result<(), ErrorResponse> {
 }
 
 fn unsupported_media_type_error() -> ErrorResponse {
-    let code = StatusCode::UNSUPPORTED_MEDIA_TYPE;
-    (
-        code,
-        Json(ErrorMessage {
+    ErrorMessage::from_http_error(
+        ErrorClass::UnsupportedMedia,
+        HttpError {
+            code: StatusCode::UNSUPPORTED_MEDIA_TYPE.as_u16(),
             message: "Expected request with Content-Type application/json".to_string(),
-            error_type: map_error_code_to_error_type(code),
-            code: code.as_u16(),
-            details: None,
-            metric_error_type: None,
-        }),
+        },
     )
 }
 
 /// Returns the standard error response for a request body that exceeds the
 /// configured size limit.
 fn payload_too_large_error() -> ErrorResponse {
-    let code = StatusCode::PAYLOAD_TOO_LARGE;
-    (
-        code,
-        Json(ErrorMessage {
+    ErrorMessage::from_http_error(
+        ErrorClass::PayloadTooLarge,
+        HttpError {
+            code: StatusCode::PAYLOAD_TOO_LARGE.as_u16(),
             message: format!(
                 "Request body exceeds the limit of {} MB set by {}",
                 get_body_limit() / (1024 * 1024),
                 env_llm::DYN_HTTP_BODY_LIMIT_MB
             ),
-            error_type: map_error_code_to_error_type(code),
-            code: code.as_u16(),
-            details: None,
-            metric_error_type: None,
-        }),
+        },
     )
 }
 
 /// Returns the standard error response when the request body cannot be read.
 fn failed_to_read_request_body_error() -> ErrorResponse {
-    let code = StatusCode::BAD_REQUEST;
-    (
-        code,
-        Json(ErrorMessage {
+    ErrorMessage::from_http_error(
+        ErrorClass::InvalidRequest,
+        HttpError {
+            code: StatusCode::BAD_REQUEST.as_u16(),
             message: "Failed to read request body".to_string(),
-            error_type: map_error_code_to_error_type(code),
-            code: code.as_u16(),
-            details: None,
-            metric_error_type: None,
-        }),
+        },
     )
 }
 
@@ -2259,10 +2438,29 @@ fn escape_json_string_control_chars(body: &[u8]) -> Option<Vec<u8>> {
     changed.then_some(out)
 }
 
+/// Capture the first typed terminal stream error without recording it yet.
+/// The disconnect monitor records it only after the protocol terminal event is delivered.
+pub(super) fn set_stream_semantic_error<T>(
+    event: &Annotated<T>,
+    error_signal: &StreamErrorSignal,
+) -> bool {
+    let Some(error) = event
+        .error
+        .as_ref()
+        .filter(|_| event.event.as_deref() == Some("error"))
+    else {
+        return false;
+    };
+    let error_type = metric_error_type_for_class(error.class());
+    error_signal.set_semantic(error_type, error);
+    true
+}
+
 /// A backend error extracted from an event, ready for `backend_error_response`.
 struct BackendErrorInfo {
     message: String,
     status: StatusCode,
+    semantic: Option<dynamo_runtime::error::DynamoError>,
     /// Classification already established from the error chain, when the
     /// status alone is not enough to recover it. `None` means "derive it from
     /// `status`" — the ordinary case for a status the worker supplied.
@@ -2275,8 +2473,14 @@ impl BackendErrorInfo {
         Self {
             message,
             status,
+            semantic: None,
             sanitized: None,
         }
+    }
+
+    fn with_semantic(mut self, error: Option<&dynamo_runtime::error::DynamoError>) -> Self {
+        self.semantic = error.cloned();
+        self
     }
 }
 
@@ -2296,6 +2500,8 @@ fn extract_backend_error_if_present<T: serde::Serialize>(
         && event_type == "error"
     {
         use dynamo_runtime::error::{BackendError, ErrorType};
+
+        let semantic = event.error.as_ref();
 
         // Classify only this event's error, not its causes. An inner invalid
         // argument must not override an outer unavailable or internal error.
@@ -2365,29 +2571,34 @@ fn extract_backend_error_if_present<T: serde::Serialize>(
             return Some(BackendErrorInfo {
                 message,
                 status: code,
+                semantic: semantic.cloned(),
                 sanitized: overloaded.then_some(SanitizedError::Overloaded),
             });
         }
 
-        if let Some(invalid_argument) = invalid_argument {
-            return Some(BackendErrorInfo::from_status(
-                invalid_argument.message().to_string(),
-                StatusCode::BAD_REQUEST,
-            ));
+        if invalid_argument.is_some() {
+            return Some(
+                BackendErrorInfo::from_status(
+                    "Invalid request".to_string(),
+                    StatusCode::BAD_REQUEST,
+                )
+                .with_semantic(semantic),
+            );
         }
 
         if overloaded {
             return Some(BackendErrorInfo {
                 message: error_str,
                 status: overload_status_code(),
+                semantic: semantic.cloned(),
                 sanitized: Some(SanitizedError::Overloaded),
             });
         }
 
-        return Some(BackendErrorInfo::from_status(
-            error_str,
-            StatusCode::INTERNAL_SERVER_ERROR,
-        ));
+        return Some(
+            BackendErrorInfo::from_status(error_str, StatusCode::INTERNAL_SERVER_ERROR)
+                .with_semantic(semantic),
+        );
     }
 
     // Check if the data payload itself contains an error structure with code >= 400
@@ -2504,7 +2715,7 @@ where
         }
 
         if let Some(backend_error) = extract_backend_error_if_present(&event) {
-            return Err(backend_error_response(backend_error));
+            return Err(backend_error_response(backend_error, true));
         }
 
         // First non-annotation, non-error event — hand back for downstream
@@ -2531,34 +2742,67 @@ where
 /// from the status: the status alone cannot distinguish a capacity rejection
 /// from an outage once `DYN_HTTP_OVERLOAD_STATUS_CODE` is set outside the 5xx
 /// range.
-fn backend_error_response(backend_error: BackendErrorInfo) -> ErrorResponse {
+fn backend_error_response(backend_error: BackendErrorInfo, record_failure: bool) -> ErrorResponse {
     let BackendErrorInfo {
         message,
         status,
+        semantic,
         sanitized,
     } = backend_error;
+    let mut render_record_failure = record_failure;
+    if let Some(error) = &semantic {
+        let is_canonical = error.error_type() == error.class();
+        if (is_canonical
+            || matches!(
+                error.class(),
+                dynamo_runtime::error::ErrorClass::InvalidRequest
+            ))
+            && let Some(response) =
+                ErrorMessage::from_semantic_error_with_recording(error, record_failure)
+        {
+            return response;
+        }
+        if matches!(http_action_for_error(error), ClientErrorAction::NoDelivery) {
+            return ErrorMessage::sanitized_with_details_recording(
+                SanitizedError::Cancelled,
+                message,
+                false,
+            );
+        }
+        if record_failure {
+            super::metrics::record_failure(error);
+            render_record_failure = false;
+        }
+    }
     let action = match sanitized {
         Some(variant) => BackendStatusAction::Sanitize(variant),
         None => BackendStatusAction::triage(status),
     };
     match action {
         BackendStatusAction::Sanitize(variant) => {
-            ErrorMessage::sanitized_with_details(variant, message)
+            ErrorMessage::sanitized_with_details_recording(variant, message, render_record_failure)
         }
         BackendStatusAction::CoerceToInternal(asserted) => {
-            ErrorMessage::coerced_backend_error(asserted, message)
+            ErrorMessage::coerced_backend_error(asserted, message, render_record_failure)
         }
-        // 4xx (non-499): protocol contract — forward backend message as-is.
-        BackendStatusAction::ForwardClientError => (
-            status,
-            Json(ErrorMessage {
-                message,
-                error_type: map_error_code_to_error_type(status),
-                code: status.as_u16(),
-                details: None,
-                metric_error_type: None,
-            }),
-        ),
+        BackendStatusAction::ForwardClientError => {
+            if render_record_failure {
+                record_local_failure(ErrorClass::Internal);
+            }
+            (
+                status,
+                Json(ErrorMessage {
+                    message: status
+                        .canonical_reason()
+                        .unwrap_or("Client error")
+                        .to_string(),
+                    error_type: map_error_code_to_error_type(status),
+                    code: status.as_u16(),
+                    details: None,
+                    metric_error_type: None,
+                }),
+            )
+        }
     }
 }
 
@@ -2984,12 +3228,16 @@ async fn chat_completions(
         //   - `event: tool_call_dispatch`  — complete tool call detected early (tool dispatch)
         //   - `event: reasoning_dispatch`  — complete reasoning block (emitted once)
         let (activity_tx, activity_rx) = tokio::sync::mpsc::unbounded_channel();
+        let error_signal = StreamErrorSignal::default();
+        let producer_error_signal = error_signal.clone();
         let stream = async_stream::stream! {
             let mut stream = Box::pin(stream);
             let mut events: Vec<Result<Event, axum::Error>> = Vec::with_capacity(4);
 
             while let Some(mut response) = stream.next().await {
                 events.clear();
+                let semantic_error =
+                    set_stream_semantic_error(&response, &producer_error_signal);
 
                 // When parallel_tool_calls is false, surface only the first tool call
                 // Keep index 0 and drop any higher indexes
@@ -3051,6 +3299,10 @@ async fn chat_completions(
                     reasoning_field,
                 );
 
+                if semantic_error && matches!(&sse_result, Ok(Some(_))) {
+                    producer_error_signal.mark_terminal_event_emitted();
+                }
+
                 // Side-channel events come first, then the regular data event.
                 match sse_result {
                     Ok(Some(ev)) => events.push(Ok(ev)),
@@ -3065,12 +3317,13 @@ async fn chat_completions(
             }
         };
         let keep_alive = state.sse_keep_alive_for_response(stream_can_defer_all_output);
-        let stream = monitor_for_disconnects_with_activity(
+        let stream = monitor_for_disconnects_with_activity_and_error_signal(
             stream,
             ctx,
             inflight_guard,
             stream_handle,
             activity_rx,
+            error_signal,
         );
 
         let mut sse_stream = Sse::new(stream);
@@ -3159,10 +3412,13 @@ fn normalize_chat_reasoning_template_args(
     request: &mut NvCreateChatCompletionRequest,
 ) -> Result<(), ErrorResponse> {
     request.normalize_reasoning_template_args().map_err(|e| {
-        ErrorMessage::from_http_error(HttpError {
-            code: 400,
-            message: VALIDATION_PREFIX.to_string() + &e.to_string(),
-        })
+        ErrorMessage::from_http_error(
+            ErrorClass::InvalidRequest,
+            HttpError {
+                code: 400,
+                message: VALIDATION_PREFIX.to_string() + &e.to_string(),
+            },
+        )
     })
 }
 
@@ -3184,11 +3440,14 @@ pub fn validate_chat_completion_required_fields(
     let inner = &request.inner;
 
     if inner.messages.is_empty() {
-        return Err(ErrorMessage::from_http_error(HttpError {
-            code: 400,
-            message: VALIDATION_PREFIX.to_string()
-                + "The 'messages' field cannot be empty. At least one message is required.",
-        }));
+        return Err(ErrorMessage::from_http_error(
+            ErrorClass::InvalidRequest,
+            HttpError {
+                code: 400,
+                message: VALIDATION_PREFIX.to_string()
+                    + "The 'messages' field cannot be empty. At least one message is required.",
+            },
+        ));
     }
 
     Ok(())
@@ -3201,11 +3460,14 @@ pub fn validate_chat_completion_stream_options(
     let inner = &request.inner;
     let streaming = inner.stream.unwrap_or(false);
     if !streaming && inner.stream_options.is_some() {
-        return Err(ErrorMessage::from_http_error(HttpError {
-            code: 400,
-            message: VALIDATION_PREFIX.to_string()
-                + "The 'stream_options' field is only allowed when 'stream' is set to true.",
-        }));
+        return Err(ErrorMessage::from_http_error(
+            ErrorClass::InvalidRequest,
+            HttpError {
+                code: 400,
+                message: VALIDATION_PREFIX.to_string()
+                    + "The 'stream_options' field is only allowed when 'stream' is set to true.",
+            },
+        ));
     }
     Ok(())
 }
@@ -3218,10 +3480,13 @@ pub fn validate_chat_completion_fields_generic(
     request: &NvCreateChatCompletionRequest,
 ) -> Result<(), ErrorResponse> {
     request.validate().map_err(|e| {
-        ErrorMessage::from_http_error(HttpError {
-            code: 400,
-            message: VALIDATION_PREFIX.to_string() + &e.to_string(),
-        })
+        ErrorMessage::from_http_error(
+            ErrorClass::InvalidRequest,
+            HttpError {
+                code: 400,
+                message: VALIDATION_PREFIX.to_string() + &e.to_string(),
+            },
+        )
     })
 }
 
@@ -3232,11 +3497,14 @@ pub fn validate_completion_stream_options(
     let inner = &request.inner;
     let streaming = inner.stream.unwrap_or(false);
     if !streaming && inner.stream_options.is_some() {
-        return Err(ErrorMessage::from_http_error(HttpError {
-            code: 400,
-            message: VALIDATION_PREFIX.to_string()
-                + "The 'stream_options' field is only allowed when 'stream' is set to true.",
-        }));
+        return Err(ErrorMessage::from_http_error(
+            ErrorClass::InvalidRequest,
+            HttpError {
+                code: 400,
+                message: VALIDATION_PREFIX.to_string()
+                    + "The 'stream_options' field is only allowed when 'stream' is set to true.",
+            },
+        ));
     }
     Ok(())
 }
@@ -3249,10 +3517,13 @@ pub fn validate_completion_fields_generic(
     request: &NvCreateCompletionRequest,
 ) -> Result<(), ErrorResponse> {
     request.validate().map_err(|e| {
-        ErrorMessage::from_http_error(HttpError {
-            code: 400,
-            message: VALIDATION_PREFIX.to_string() + &e.to_string(),
-        })
+        ErrorMessage::from_http_error(
+            ErrorClass::InvalidRequest,
+            HttpError {
+                code: 400,
+                message: VALIDATION_PREFIX.to_string() + &e.to_string(),
+            },
+        )
     })
 }
 
@@ -3629,13 +3900,21 @@ async fn responses(
                 if let Some(backend_error_info) =
                     extract_backend_error_if_present(&annotated_chunk)
                 {
-                    let error_response = backend_error_response(backend_error_info);
-                    producer_error_signal
-                        .set(extract_error_type_from_response(&error_response));
-                    backend_error.get_or_insert_with(|| ErrorObject {
-                        code: responses_error_code(error_response.0).to_string(),
-                        message: error_response.1.message.clone(),
-                    });
+                    if backend_error.is_none() {
+                        let semantic = set_stream_semantic_error(
+                            &annotated_chunk,
+                            &producer_error_signal,
+                        );
+                        let error_response = backend_error_response(backend_error_info, false);
+                        if !semantic {
+                            producer_error_signal
+                                .set(extract_error_type_from_response(&error_response));
+                        }
+                        backend_error = Some(ErrorObject {
+                            code: responses_error_code(error_response.0).to_string(),
+                            message: error_response.1.message.clone(),
+                        });
+                    }
                     continue;
                 }
 
@@ -3806,10 +4085,13 @@ pub fn validate_responses_fields(request: &NvCreateResponse) -> Result<(), Error
     use crate::protocols::openai::validate;
 
     let map_err = |e: anyhow::Error| {
-        ErrorMessage::from_http_error(HttpError {
-            code: 400,
-            message: VALIDATION_PREFIX.to_string() + &e.to_string(),
-        })
+        ErrorMessage::from_http_error(
+            ErrorClass::InvalidRequest,
+            HttpError {
+                code: 400,
+                message: VALIDATION_PREFIX.to_string() + &e.to_string(),
+            },
+        )
     };
 
     validate::validate_temperature(request.inner.temperature).map_err(&map_err)?;
@@ -3838,6 +4120,7 @@ pub(crate) fn check_ready(state: &Arc<service_v2::State>) -> Result<(), ErrorRes
 /// unmatched route.
 pub(crate) fn unmatched_route_response(method: &Method, uri: &Uri) -> ErrorResponse {
     let code = StatusCode::NOT_FOUND;
+    record_local_failure(ErrorClass::NotFound);
     (
         code,
         Json(ErrorMessage {
@@ -4405,16 +4688,12 @@ async fn images_edits(
     let body = read_json_request_body(&headers, body).await?;
     let request: NvCreateImageRequest = parse_json_request("image edits", &body)?;
     if request.input_reference.is_none() {
-        let code = StatusCode::BAD_REQUEST;
-        return Err((
-            code,
-            Json(ErrorMessage {
+        return Err(ErrorMessage::from_http_error(
+            ErrorClass::InvalidRequest,
+            HttpError {
+                code: StatusCode::BAD_REQUEST.as_u16(),
                 message: "input_reference is required for /v1/images/edits".to_string(),
-                error_type: map_error_code_to_error_type(code),
-                code: code.as_u16(),
-                details: None,
-                metric_error_type: None,
-            }),
+            },
         ));
     }
     images_with_request(state.0, headers, request).await
@@ -5662,7 +5941,8 @@ mod tests {
         let err = http_error_from_engine(400).unwrap_err();
         let response = ErrorMessage::from_anyhow(err, BACKUP_ERROR_MESSAGE);
         assert_eq!(response.0, StatusCode::BAD_REQUEST);
-        assert_eq!(response.1.message, "custom error message");
+        assert_eq!(response.1.message, "Bad Request");
+        assert!(!response.1.message.contains("custom error message"));
     }
 
     #[test]
@@ -5682,10 +5962,7 @@ mod tests {
         let response = ErrorMessage::from_anyhow(error, BACKUP_ERROR_MESSAGE);
 
         assert_eq!(response.0, StatusCode::BAD_REQUEST);
-        assert_eq!(
-            response.1.message,
-            "Only one guided-decoding constraint can be set; received: json, regex"
-        );
+        assert_eq!(response.1.message, "Invalid request");
     }
 
     #[test]
@@ -5747,7 +6024,7 @@ mod tests {
             code: 499,
             message: "session abc-123 cancelled at /srv/queue.py:42".to_string(),
         };
-        let response = ErrorMessage::from_http_error(err);
+        let response = ErrorMessage::from_http_error(ErrorClass::Internal, err);
         assert_eq!(response.0.as_u16(), 499);
         assert_eq!(response.1.code, 499);
         assert_eq!(response.1.message, "Request cancelled");
@@ -5763,7 +6040,7 @@ mod tests {
             code: 529,
             message: "site overloaded at /srv/pool.py:12".to_string(),
         };
-        let response = ErrorMessage::from_http_error(err);
+        let response = ErrorMessage::from_http_error(ErrorClass::Internal, err);
         assert_eq!(response.0.as_u16(), 529);
         assert_eq!(response.1.code, 529);
         assert_eq!(response.1.error_type, "Overloaded");
@@ -5781,10 +6058,13 @@ mod tests {
     fn test_from_http_error_529_classifies_as_overload_for_metrics() {
         // Observability half of the same bug: the metric recorded Internal
         // while the status was squashed, hiding load shedding.
-        let response = ErrorMessage::from_http_error(HttpError {
-            code: 529,
-            message: "site overloaded".to_string(),
-        });
+        let response = ErrorMessage::from_http_error(
+            ErrorClass::InvalidRequest,
+            HttpError {
+                code: 529,
+                message: "site overloaded".to_string(),
+            },
+        );
         assert_eq!(
             extract_error_type_from_response(&response),
             ErrorType::Overload
@@ -5798,7 +6078,7 @@ mod tests {
             code: 1000,
             message: "bogus status from /srv/backend.py:7".to_string(),
         };
-        let response = ErrorMessage::from_http_error(err);
+        let response = ErrorMessage::from_http_error(ErrorClass::Internal, err);
         assert_eq!(response.0, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(response.1.code, 500);
         assert_eq!(response.1.message, "Internal server error");
@@ -5816,10 +6096,13 @@ mod tests {
         // `details`. 507 is a WebDAV code no Dynamo component emits; 501 is
         // what the previous blanket pass-through forwarded verbatim.
         for code in [501u16, 502, 504, 507] {
-            let response = ErrorMessage::from_http_error(HttpError {
-                code,
-                message: format!("engine failure {code} at /srv/pool.py:12"),
-            });
+            let response = ErrorMessage::from_http_error(
+                ErrorClass::InvalidRequest,
+                HttpError {
+                    code,
+                    message: format!("engine failure {code} at /srv/pool.py:12"),
+                },
+            );
             assert_eq!(
                 response.0,
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -5849,10 +6132,13 @@ mod tests {
     fn test_from_http_error_preserves_retryable_5xx_without_tunnel() {
         // These two survive on the status line, so nothing lands in `details`.
         for status in [StatusCode::SERVICE_UNAVAILABLE, overload_status_code()] {
-            let response = ErrorMessage::from_http_error(HttpError {
-                code: status.as_u16(),
-                message: "shedding load at /srv/pool.py:12".to_string(),
-            });
+            let response = ErrorMessage::from_http_error(
+                ErrorClass::InvalidRequest,
+                HttpError {
+                    code: status.as_u16(),
+                    message: "shedding load at /srv/pool.py:12".to_string(),
+                },
+            );
             assert_eq!(response.0, status);
             assert_eq!(response.1.code, status.as_u16());
             assert_eq!(response.1.message, "Internal server error");
@@ -5868,14 +6154,37 @@ mod tests {
     fn test_from_http_error_forwards_4xx_verbatim() {
         // The 5xx allowlist leaves 4xx alone: the backend's own description is
         // what the caller needs (e.g. the in-tree 415 from image loading).
-        let response = ErrorMessage::from_http_error(HttpError {
-            code: 415,
-            message: "Unsupported Media Type: image/tiff".to_string(),
-        });
+        let response = ErrorMessage::from_http_error(
+            ErrorClass::InvalidRequest,
+            HttpError {
+                code: 415,
+                message: "Unsupported Media Type: image/tiff".to_string(),
+            },
+        );
         assert_eq!(response.0, StatusCode::UNSUPPORTED_MEDIA_TYPE);
         assert_eq!(response.1.code, 415);
         assert_eq!(response.1.message, "Unsupported Media Type: image/tiff");
         assert_eq!(tunnelled_backend_status(&response), None);
+    }
+
+    #[test]
+    fn backend_http_error_hides_untrusted_client_error_message() {
+        let response = ErrorMessage::from_anyhow(
+            anyhow::Error::new(HttpError {
+                code: 400,
+                message: "PRIVATE_BACKEND_HTTP_ERROR_SENTINEL=/srv/worker.py".to_string(),
+            }),
+            BACKUP_ERROR_MESSAGE,
+        );
+
+        assert_eq!(response.0, StatusCode::BAD_REQUEST);
+        assert_eq!(response.1.message, "Bad Request");
+        assert!(
+            !response
+                .1
+                .message
+                .contains("PRIVATE_BACKEND_HTTP_ERROR_SENTINEL")
+        );
     }
 
     #[test]
@@ -5995,16 +6304,61 @@ mod tests {
         // coerce-to-500 path, dropping the configured status. The carried
         // category avoids both, so the worker path renders exactly like the
         // admission path at every configured value.
-        let response = backend_error_response(BackendErrorInfo {
-            message: "Worker local total request limit reached (32/32)".to_string(),
-            status: StatusCode::TOO_MANY_REQUESTS,
-            sanitized: Some(SanitizedError::Overloaded),
-        });
+        let response = backend_error_response(
+            BackendErrorInfo {
+                message: "Worker local total request limit reached (32/32)".to_string(),
+                status: StatusCode::TOO_MANY_REQUESTS,
+                semantic: None,
+                sanitized: Some(SanitizedError::Overloaded),
+            },
+            true,
+        );
 
         assert_eq!(response.0, overload_status_code());
         assert_eq!(response.1.code, overload_status_code().as_u16());
         assert_eq!(response.1.message, SanitizedError::Overloaded.to_string());
         assert!(!response.1.message.contains("32/32"));
+    }
+
+    #[test]
+    fn canonical_backend_cancellation_is_not_coerced_to_internal() {
+        let cancelled = dynamo_runtime::error::DynamoError::builder()
+            .class(dynamo_runtime::error::ErrorClass::Cancelled)
+            .reason(dynamo_runtime::error::ErrorReason::new("request.cancelled").unwrap())
+            .build();
+        let response = backend_error_response(
+            BackendErrorInfo {
+                message: "backend stopped".to_string(),
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                semantic: Some(cancelled),
+                sanitized: None,
+            },
+            true,
+        );
+
+        assert_eq!(response.0.as_u16(), 499);
+        assert_eq!(response.1.message, "Request cancelled");
+    }
+
+    #[test]
+    fn legacy_backend_cancellation_is_not_coerced_to_internal() {
+        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
+
+        let cancelled = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::Cancelled))
+            .build();
+        let response = backend_error_response(
+            BackendErrorInfo {
+                message: "backend stopped".to_string(),
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                semantic: Some(cancelled),
+                sanitized: None,
+            },
+            true,
+        );
+
+        assert_eq!(response.0.as_u16(), 499);
+        assert_eq!(response.1.message, "Request cancelled");
     }
 
     #[test]
@@ -6117,7 +6471,7 @@ mod tests {
 
         assert_eq!(response.0, StatusCode::BAD_REQUEST);
         assert_eq!(response.1.code, StatusCode::BAD_REQUEST.as_u16());
-        assert!(response.1.message.contains("Request payload is too large"));
+        assert_eq!(response.1.message, "Invalid request");
         assert!(!response.1.message.contains("NATS"));
         assert!(!response.1.message.contains("payload_bytes"));
     }
@@ -6139,7 +6493,82 @@ mod tests {
 
         assert_eq!(response.0, StatusCode::BAD_REQUEST);
         assert_eq!(response.1.code, StatusCode::BAD_REQUEST.as_u16());
-        assert!(response.1.message.contains("does not currently support"));
+        assert_eq!(response.1.message, "Invalid request");
+    }
+    #[test]
+    fn canonical_errors_use_shared_status_and_hide_diagnostics() {
+        use dynamo_runtime::error::{DynamoError, ErrorClass};
+
+        let cases = [
+            (
+                ErrorClass::InvalidRequest,
+                StatusCode::BAD_REQUEST,
+                "Invalid request",
+                ErrorType::Validation,
+            ),
+            (
+                ErrorClass::PermissionDenied,
+                StatusCode::FORBIDDEN,
+                "Permission denied",
+                ErrorType::Validation,
+            ),
+            (
+                ErrorClass::RateLimited,
+                StatusCode::TOO_MANY_REQUESTS,
+                "Rate limit exceeded",
+                ErrorType::Overload,
+            ),
+            (
+                ErrorClass::CapacityExhausted,
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Service temporarily unavailable",
+                ErrorType::Overload,
+            ),
+            (
+                ErrorClass::BackendProtocol,
+                StatusCode::BAD_GATEWAY,
+                "Bad gateway",
+                ErrorType::Internal,
+            ),
+            (
+                ErrorClass::DeadlineExceeded,
+                StatusCode::GATEWAY_TIMEOUT,
+                "Request deadline exceeded",
+                ErrorType::Internal,
+            ),
+            (
+                ErrorClass::Internal,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error",
+                ErrorType::Internal,
+            ),
+        ];
+
+        for (class, expected_status, expected_message, expected_metric) in cases {
+            let err: anyhow::Error = DynamoError::builder()
+                .class(class)
+                .diagnostic("PRIVATE_DIAGNOSTIC_SENTINEL")
+                .build()
+                .into();
+
+            let response = ErrorMessage::from_anyhow(err, BACKUP_ERROR_MESSAGE);
+
+            assert_eq!(response.0, expected_status, "{class}");
+            assert_eq!(response.1.code, expected_status.as_u16(), "{class}");
+            assert_eq!(response.1.message, expected_message, "{class}");
+            assert_eq!(
+                response.1.error_type,
+                expected_status.canonical_reason().unwrap(),
+                "{class}"
+            );
+            assert_eq!(
+                response.1.metric_error_type,
+                Some(expected_metric),
+                "{class}"
+            );
+            let body = serde_json::to_string(&response.1.0).unwrap();
+            assert!(!body.contains("PRIVATE_DIAGNOSTIC_SENTINEL"));
+        }
     }
 
     #[test]
@@ -7008,7 +7437,7 @@ mod tests {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
             assert_eq!(error_response.1.error_type, "Bad Request");
-            assert_eq!(error_response.1.message, "unsupported JSON schema keyword");
+            assert_eq!(error_response.1.message, "Invalid request");
         }
     }
 
@@ -7039,12 +7468,7 @@ mod tests {
         assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
         assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
         assert_eq!(error_response.1.error_type, "Bad Request");
-        assert!(
-            error_response
-                .1
-                .message
-                .contains("does not currently support logprobs >= 1")
-        );
+        assert_eq!(error_response.1.message, "Invalid request");
     }
 
     #[tokio::test]
@@ -7085,7 +7509,7 @@ mod tests {
         assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
         assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
         assert_eq!(error_response.1.error_type, "Bad Request");
-        assert_eq!(error_response.1.message, "invalid second prompt");
+        assert_eq!(error_response.1.message, "Invalid request");
     }
 
     #[tokio::test]
@@ -7342,7 +7766,7 @@ mod tests {
         if let Err(error_response) = result {
             assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
             assert_eq!(error_response.1.code, 400);
-            assert_eq!(error_response.1.message, "bad input from client");
+            assert_eq!(error_response.1.message, "Bad Request");
         }
     }
 
@@ -7536,10 +7960,13 @@ mod tests {
 
     #[test]
     fn test_extract_error_type_from_response_validation() {
-        let response = ErrorMessage::from_http_error(HttpError {
-            code: 400,
-            message: "Validation: bad input".to_string(),
-        });
+        let response = ErrorMessage::from_http_error(
+            ErrorClass::InvalidRequest,
+            HttpError {
+                code: 400,
+                message: "Validation: bad input".to_string(),
+            },
+        );
         assert_eq!(
             extract_error_type_from_response(&response),
             ErrorType::Validation

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -6572,17 +6572,6 @@ mod tests {
         assert_eq!(response.1.message, "Invalid request");
     }
     #[test]
-    fn canonical_capacity_uses_the_configured_overload_status() {
-        let error = dynamo_runtime::error::DynamoError::builder()
-            .class(ErrorClass::CapacityExhausted)
-            .build();
-        let response = ErrorMessage::from_anyhow(error.into(), BACKUP_ERROR_MESSAGE);
-
-        assert_eq!(response.0, overload_status_code());
-        assert_eq!(response.1.code, overload_status_code().as_u16());
-    }
-
-    #[test]
     fn canonical_errors_use_shared_status_and_hide_diagnostics() {
         use dynamo_runtime::error::{DynamoError, ErrorClass};
 

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -25,14 +25,12 @@ use crate::{
 };
 
 use dynamo_runtime::engine::Data;
-use dynamo_runtime::error::{self, BackendError, DynamoError, ErrorType};
+use dynamo_runtime::error::{self, DynamoError, ErrorType};
 use dynamo_runtime::metrics::prometheus_names::frontend_service;
 use dynamo_runtime::pipeline::{
     AsyncEngineContext, AsyncEngineContextProvider, Context, ManyOut, Operator, PipelineOperator,
     ResponseStream, ServerStreamingEngine, SingleIn, async_trait, attach_first_response_guard,
-    network::egress::route_span::{
-        RouteTraceContext, attach_route_trace_context, error_type_from_chain, error_type_name,
-    },
+    network::egress::route_span::{RouteTraceContext, attach_route_trace_context, error_type_name},
 };
 use dynamo_runtime::protocols::annotated::Annotated;
 
@@ -63,25 +61,40 @@ impl HasTokenIds for LLMEngineOutput {
     }
 }
 
+/// Return the semantic cause when an error chain is safe to migrate.
+fn migratable_error_in_chain<'a>(err: &'a (dyn StdError + 'static)) -> Option<&'a DynamoError> {
+    let mut migratable = None;
+    let mut current = Some(err);
+    while let Some(source) = current {
+        if let Some(error) = source.downcast_ref::<DynamoError>() {
+            match error.reason().as_str() {
+                "request.cancelled"
+                | "backend.cancelled"
+                | "capacity.exhausted"
+                | "capacity.pool_exhausted" => return None,
+                "transport.cannot_connect"
+                | "transport.disconnected"
+                | "transport.connection_timeout"
+                | "backend.cannot_connect"
+                | "backend.disconnected"
+                | "backend.connection_timeout"
+                | "backend.response_timeout"
+                | "backend.engine_shutdown"
+                | "backend.stream_incomplete"
+                | "capacity.worker_overloaded" => {
+                    migratable.get_or_insert(error);
+                }
+                _ => {}
+            }
+        }
+        current = source.source();
+    }
+    migratable
+}
+
 /// Check if an error chain indicates the request should be migrated.
 fn is_migratable(err: &(dyn StdError + 'static)) -> bool {
-    const MIGRATABLE: &[ErrorType] = &[
-        ErrorType::CannotConnect,
-        ErrorType::Disconnected,
-        ErrorType::ConnectionTimeout,
-        // a stalled/frozen worker's stream-inactivity timeout surfaces
-        // as ResponseTimeout (push_router fault detection quarantines the worker
-        // via the same signal); migrate instead of hanging to the stream timeout.
-        ErrorType::ResponseTimeout,
-        ErrorType::Backend(BackendError::EngineShutdown),
-        // A truncated stream from a departed worker is recoverable by failover.
-        ErrorType::Backend(BackendError::StreamIncomplete),
-        // One overloaded worker: another may have room. Pool-wide exhaustion is
-        // ResourceExhausted below and stays non-migratable.
-        ErrorType::WorkerOverloaded,
-    ];
-    const NON_MIGRATABLE: &[ErrorType] = &[ErrorType::Cancelled, ErrorType::ResourceExhausted];
-    error::match_error_chain(err, MIGRATABLE, NON_MIGRATABLE)
+    migratable_error_in_chain(err).is_some()
 }
 
 /// Whether a worker-scoped failure can be retried without violating an explicit route.
@@ -384,17 +397,22 @@ where
                 if let Some(err) = response.error.as_ref()
                     && is_migratable_for_request(&self.request, err)
                 {
+                    let migration_error = migratable_error_in_chain(err)
+                        .expect("migration eligibility requires a semantic cause");
                     if self.retries_left == 0 {
                         let route_trace = self.active_route_trace.clone();
                         self.record_migration_exhausted(MigrationCause {
-                            reason: err.error_type(),
+                            reason: migration_error.error_type(),
                             from_worker_id: route_trace
                                 .as_deref()
                                 .and_then(RouteTraceContext::selected_worker_id),
                             attempt: self.failed_attempt(route_trace.as_deref()),
                         });
                     } else {
-                        self.queue_migration(err.error_type(), self.active_route_trace.clone());
+                        self.queue_migration(
+                            migration_error.error_type(),
+                            self.active_route_trace.clone(),
+                        );
                     }
                     tracing::warn!(error = %err, "Stream disconnected, recreating stream");
                     self.metrics.inc_migration_ongoing_request(&self.model_name);
@@ -519,7 +537,9 @@ where
                     return Ok(());
                 }
                 Err(err) if is_migratable_for_request(&self.request, err.as_ref()) => {
-                    let reason = error_type_from_chain(err.as_ref());
+                    let reason = migratable_error_in_chain(err.as_ref())
+                        .expect("migration eligibility requires a semantic cause")
+                        .error_type();
                     if migration_event.is_none() {
                         migration_event = Some(MigrationEvent::new(
                             frontend_service::migration_type::NEW_REQUEST,
@@ -691,7 +711,7 @@ mod tests {
         GuidedDecodingOptions, OutputOptions, SamplingOptions, StopConditions,
         preprocessor::RoutingHints, timing::RequestTracker,
     };
-    use dynamo_runtime::error::{DynamoError, ErrorType};
+    use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
     use dynamo_runtime::pipeline::AsyncEngine;
     use dynamo_runtime::pipeline::context::Controller;
     use dynamo_runtime::protocols::maybe_error::MaybeError;
@@ -1248,24 +1268,73 @@ mod tests {
     /// request that had a healthy worker available, or bounces a pool-wide
     /// rejection around until retries run out.
     #[test]
-    fn worker_overload_migrates_but_pool_exhaustion_does_not() {
-        let worker_busy = DynamoError::builder()
-            .error_type(ErrorType::WorkerOverloaded)
-            .message("Selected worker is overloaded, please retry later")
+    fn semantic_reasons_preserve_worker_scoped_migration() {
+        use dynamo_runtime::error::{ErrorClass, ErrorReason};
+
+        let cases = [
+            (
+                ErrorClass::CapacityExhausted,
+                "capacity.worker_overloaded",
+                true,
+            ),
+            (
+                ErrorClass::CapacityExhausted,
+                "capacity.pool_exhausted",
+                false,
+            ),
+            (ErrorClass::Unavailable, "transport.disconnected", true),
+            (ErrorClass::Unavailable, "backend.unavailable", false),
+        ];
+
+        for (class, reason, expected) in cases {
+            let error = DynamoError::builder()
+                .class(class)
+                .reason(ErrorReason::new(reason).unwrap())
+                .diagnostic("worker failure")
+                .build();
+            assert_eq!(is_migratable(&error), expected, "reason: {reason}");
+        }
+    }
+
+    #[test]
+    fn migration_uses_inner_semantic_cause_and_preserves_exclusions() {
+        use dynamo_runtime::error::{ErrorClass, ErrorReason};
+
+        let disconnected = DynamoError::builder()
+            .class(ErrorClass::Unavailable)
+            .reason(ErrorReason::new("transport.disconnected").unwrap())
             .build();
-        assert!(
-            is_migratable(&worker_busy),
-            "one overloaded worker must fail over to another"
+        let wrapped = DynamoError::builder()
+            .error_type(ErrorType::Unknown)
+            .cause(disconnected)
+            .build();
+        assert_eq!(
+            migratable_error_in_chain(&wrapped).map(DynamoError::error_type),
+            Some(ErrorClass::Unavailable)
         );
 
-        let pool_exhausted = DynamoError::builder()
-            .error_type(ErrorType::ResourceExhausted)
-            .message("All workers are busy, please retry later")
+        let cancelled = DynamoError::builder()
+            .class(ErrorClass::Cancelled)
+            .reason(ErrorReason::new("request.cancelled").unwrap())
             .build();
-        assert!(
-            !is_migratable(&pool_exhausted),
-            "pool-wide exhaustion must not migrate; no worker has room"
-        );
+        let conflicted = DynamoError::builder()
+            .class(ErrorClass::Unavailable)
+            .reason(ErrorReason::new("transport.disconnected").unwrap())
+            .cause(cancelled)
+            .build();
+        assert!(!is_migratable(&conflicted));
+
+        let exhausted = DynamoError::builder()
+            .class(ErrorClass::CapacityExhausted)
+            .reason(ErrorReason::new("capacity.exhausted").unwrap())
+            .cause(
+                DynamoError::builder()
+                    .class(ErrorClass::Unavailable)
+                    .reason(ErrorReason::new("transport.disconnected").unwrap())
+                    .build(),
+            )
+            .build();
+        assert!(!is_migratable(&exhausted));
     }
 
     /// Tests the normal case where the RetryManager successfully processes all responses

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -397,8 +397,10 @@ where
                 if let Some(err) = response.error.as_ref()
                     && is_migratable_for_request(&self.request, err)
                 {
-                    let migration_error = migratable_error_in_chain(err)
-                        .expect("migration eligibility requires a semantic cause");
+                    let Some(migration_error) = migratable_error_in_chain(err) else {
+                        tracing::warn!(error = %err, "Migration eligibility had no semantic error");
+                        continue;
+                    };
                     if self.retries_left == 0 {
                         let route_trace = self.active_route_trace.clone();
                         self.record_migration_exhausted(MigrationCause {
@@ -537,9 +539,11 @@ where
                     return Ok(());
                 }
                 Err(err) if is_migratable_for_request(&self.request, err.as_ref()) => {
-                    let reason = migratable_error_in_chain(err.as_ref())
-                        .expect("migration eligibility requires a semantic cause")
-                        .error_type();
+                    let Some(migration_error) = migratable_error_in_chain(err.as_ref()) else {
+                        tracing::warn!(error = %err, "Migration eligibility had no semantic error");
+                        return Err(err);
+                    };
+                    let reason = migration_error.error_type();
                     if migration_event.is_none() {
                         migration_event = Some(MigrationEvent::new(
                             frontend_service::migration_type::NEW_REQUEST,

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -61,30 +61,16 @@ impl HasTokenIds for LLMEngineOutput {
     }
 }
 
-/// Return the semantic cause when an error chain is safe to migrate.
 fn migratable_error_in_chain<'a>(err: &'a (dyn StdError + 'static)) -> Option<&'a DynamoError> {
     let mut migratable = None;
     let mut current = Some(err);
     while let Some(source) = current {
         if let Some(error) = source.downcast_ref::<DynamoError>() {
-            match error.reason().as_str() {
-                "request.cancelled"
-                | "backend.cancelled"
-                | "capacity.exhausted"
-                | "capacity.pool_exhausted" => return None,
-                "transport.cannot_connect"
-                | "transport.disconnected"
-                | "transport.connection_timeout"
-                | "backend.cannot_connect"
-                | "backend.disconnected"
-                | "backend.connection_timeout"
-                | "backend.response_timeout"
-                | "backend.engine_shutdown"
-                | "backend.stream_incomplete"
-                | "capacity.worker_overloaded" => {
-                    migratable.get_or_insert(error);
-                }
-                _ => {}
+            if error.reason().blocks_migration() {
+                return None;
+            }
+            if error.reason().is_migration_eligible() {
+                migratable.get_or_insert(error);
             }
         }
         current = source.source();

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -626,12 +626,22 @@ impl AnthropicStreamConverter {
 
     /// Append error events when the stream ends due to a backend error.
     pub fn append_error_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
-        let error_event = AnthropicStreamEvent::Error {
-            error: AnthropicErrorBody {
+        self.append_error_events_with_body(
+            events,
+            AnthropicErrorBody {
                 error_type: "api_error".to_string(),
                 message: "An internal error occurred during generation.".to_string(),
             },
-        };
+        );
+    }
+
+    /// Append a terminal error event whose body was selected by the HTTP protocol boundary.
+    pub fn append_error_events_with_body(
+        &mut self,
+        events: &mut Vec<Result<Event, anyhow::Error>>,
+        error: AnthropicErrorBody,
+    ) {
+        let error_event = AnthropicStreamEvent::Error { error };
         events.push(make_sse_event("error", &error_event));
     }
 }

--- a/lib/runtime/src/error.rs
+++ b/lib/runtime/src/error.rs
@@ -37,8 +37,6 @@ use std::sync::{Arc, LazyLock};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ErrorClass {
-    /// Uncategorized or unknown error.
-    Unknown,
     /// The request contains invalid input (e.g., prompt exceeds context length).
     InvalidArgument,
     /// Failed to establish a connection to a remote worker.
@@ -88,6 +86,9 @@ pub enum ErrorClass {
     NotImplemented,
     /// An internal defect or unclassified failure occurred.
     Internal,
+    /// Uncategorized or unknown error.
+    #[serde(other)]
+    Unknown,
 }
 
 impl fmt::Display for ErrorClass {
@@ -568,7 +569,10 @@ impl<'de> Deserialize<'de> for DynamoError {
         }
 
         let representation = Representation::deserialize(deserializer)?;
-        let raw_class = representation.class;
+        let raw_class = match representation.class {
+            ErrorClass::Unknown => ErrorClass::Internal,
+            class => class,
+        };
         let reason = match representation.reason {
             Some(reason) => ErrorReason::new(reason).ok(),
             None => Some(ErrorReason::for_class(raw_class)),
@@ -688,10 +692,25 @@ impl<'a> From<&'a (dyn std::error::Error + 'static)> for DynamoError {
         }
 
         let diagnostic = Diagnostic::new(err.to_string());
-        let diagnostic = match err.source() {
-            Some(source) => diagnostic.with_source(DynamoError::from(source)),
-            None => diagnostic,
+        let Some(source) = err.source() else {
+            return Self {
+                class: ErrorClass::Internal,
+                reason: ErrorReason::from_static("runtime.unclassified"),
+                diagnostic: Some(diagnostic),
+                public: None,
+            };
         };
+
+        let source = DynamoError::from(source);
+        let diagnostic = diagnostic.with_source(source.clone());
+        if source.has_valid_identity() && source.class() != ErrorClass::Internal {
+            return Self {
+                class: source.error_type(),
+                reason: source.reason().clone(),
+                diagnostic: Some(diagnostic),
+                public: source.public_details().cloned(),
+            };
+        }
 
         Self {
             class: ErrorClass::Internal,
@@ -1118,6 +1137,65 @@ mod tests {
             Some("bad request")
         );
         assert!(err.public_details().is_none());
+    }
+
+    #[test]
+    fn backend_class_roundtrips_as_its_canonical_class() {
+        let error = DynamoError::builder()
+            .error_type(ErrorClass::Backend(BackendError::InvalidArgument))
+            .build();
+
+        let serialized = serde_json::to_string(&error).unwrap();
+        assert!(serialized.contains("\"class\":\"InvalidRequest\""));
+
+        let decoded: DynamoError = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(decoded.error_type(), ErrorClass::InvalidRequest);
+        assert_eq!(decoded.class(), ErrorClass::InvalidRequest);
+        assert_eq!(decoded.reason().as_str(), "backend.invalid_argument");
+    }
+
+    #[test]
+    fn unknown_class_fails_closed_during_deserialization() {
+        let json = r#"{"class":"FutureErrorClass","reason":"runtime.internal"}"#;
+        let error: DynamoError = serde_json::from_str(json).unwrap();
+
+        assert_eq!(error.error_type(), ErrorClass::Internal);
+        assert_eq!(error.class(), ErrorClass::Internal);
+        assert_eq!(error.reason().as_str(), "runtime.internal");
+    }
+
+    #[test]
+    fn wrapping_preserves_the_semantic_head_across_the_wire() {
+        #[derive(Debug)]
+        struct Wrapper(DynamoError);
+
+        impl fmt::Display for Wrapper {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("transport wrapper")
+            }
+        }
+
+        impl std::error::Error for Wrapper {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        let wrapped = Wrapper(
+            DynamoError::builder()
+                .class(ErrorClass::Unavailable)
+                .reason(ErrorReason::new("transport.disconnected").unwrap())
+                .build(),
+        );
+        let error = DynamoError::from(&wrapped as &(dyn std::error::Error + 'static));
+
+        assert_eq!(error.class(), ErrorClass::Unavailable);
+        assert_eq!(error.reason().as_str(), "transport.disconnected");
+        let value = serde_json::to_value(&error).unwrap();
+        assert!(value.get("caused_by").is_none());
+        let decoded: DynamoError = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded.class(), ErrorClass::Unavailable);
+        assert_eq!(decoded.reason().as_str(), "transport.disconnected");
     }
 
     #[test]

--- a/lib/runtime/src/error.rs
+++ b/lib/runtime/src/error.rs
@@ -3,10 +3,7 @@
 
 //! Dynamo Error System
 //!
-//! This module provides a standardized error type for Dynamo with support for:
-//! - Categorized error types via [`ErrorType`] enum
-//! - Error chaining via the standard [`std::error::Error::source()`] method
-//! - Serialization for network transmission via serde
+//! This module provides a standardized, serializable error type for Dynamo.
 //!
 //! # DynamoError
 //!
@@ -14,17 +11,15 @@
 //! directly or converted from any [`std::error::Error`]:
 //!
 //! ```rust,ignore
-//! use dynamo_runtime::error::{DynamoError, ErrorType};
+//! use dynamo_runtime::error::{DynamoError, ErrorClass};
 //!
 //! // Simple error
 //! let err = DynamoError::msg("something failed");
 //!
-//! // Typed error with cause
-//! let cause = std::io::Error::other("io error");
+//! // Typed error with a private diagnostic
 //! let err = DynamoError::builder()
-//!     .error_type(ErrorType::Unknown)
-//!     .message("operation failed")
-//!     .cause(cause)
+//!     .class(ErrorClass::Internal)
+//!     .diagnostic("operation failed")
 //!     .build();
 //!
 //! // Convert from any std::error::Error
@@ -34,13 +29,14 @@
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::sync::{Arc, LazyLock};
 
 // ============================================================================
-// ErrorType Enum
+// ErrorClass Enum
 // ============================================================================
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ErrorType {
+pub enum ErrorClass {
     /// Uncategorized or unknown error.
     Unknown,
     /// The request contains invalid input (e.g., prompt exceeds context length).
@@ -66,25 +62,144 @@ pub enum ErrorType {
     Unavailable,
     /// Error originating from a backend engine.
     Backend(BackendError),
+    /// The client request is malformed or fails request-level validation.
+    InvalidRequest,
+    /// Authentication credentials are missing or invalid.
+    Unauthenticated,
+    /// The authenticated caller is not permitted to perform the operation.
+    PermissionDenied,
+    /// The requested resource does not exist.
+    NotFound,
+    /// The request conflicts with current resource state.
+    Conflict,
+    /// The request body exceeds a configured size limit.
+    PayloadTooLarge,
+    /// The request uses an unsupported media type.
+    UnsupportedMedia,
+    /// The caller exceeded an admission or request-rate limit.
+    RateLimited,
+    /// The eligible worker pool has no capacity.
+    CapacityExhausted,
+    /// A backend response violates the expected protocol.
+    BackendProtocol,
+    /// The operation exceeded its deadline.
+    DeadlineExceeded,
+    /// The requested operation is not implemented.
+    NotImplemented,
+    /// An internal defect or unclassified failure occurred.
+    Internal,
 }
 
-impl fmt::Display for ErrorType {
+impl fmt::Display for ErrorClass {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ErrorType::Unknown => write!(f, "Unknown"),
-            ErrorType::InvalidArgument => write!(f, "InvalidArgument"),
-            ErrorType::CannotConnect => write!(f, "CannotConnect"),
-            ErrorType::Disconnected => write!(f, "Disconnected"),
-            ErrorType::ConnectionTimeout => write!(f, "ConnectionTimeout"),
-            ErrorType::ResponseTimeout => write!(f, "ResponseTimeout"),
-            ErrorType::Cancelled => write!(f, "Cancelled"),
-            ErrorType::ResourceExhausted => write!(f, "ResourceExhausted"),
-            ErrorType::WorkerOverloaded => write!(f, "WorkerOverloaded"),
-            ErrorType::Unavailable => write!(f, "Unavailable"),
-            ErrorType::Backend(sub) => write!(f, "Backend{sub}"),
+            ErrorClass::Unknown => write!(f, "Unknown"),
+            ErrorClass::InvalidArgument => write!(f, "InvalidArgument"),
+            ErrorClass::CannotConnect => write!(f, "CannotConnect"),
+            ErrorClass::Disconnected => write!(f, "Disconnected"),
+            ErrorClass::ConnectionTimeout => write!(f, "ConnectionTimeout"),
+            ErrorClass::ResponseTimeout => write!(f, "ResponseTimeout"),
+            ErrorClass::Cancelled => write!(f, "Cancelled"),
+            ErrorClass::ResourceExhausted => write!(f, "ResourceExhausted"),
+            ErrorClass::WorkerOverloaded => write!(f, "WorkerOverloaded"),
+            ErrorClass::Unavailable => write!(f, "Unavailable"),
+            ErrorClass::Backend(sub) => write!(f, "Backend{sub}"),
+            ErrorClass::InvalidRequest => write!(f, "InvalidRequest"),
+            ErrorClass::Unauthenticated => write!(f, "Unauthenticated"),
+            ErrorClass::PermissionDenied => write!(f, "PermissionDenied"),
+            ErrorClass::NotFound => write!(f, "NotFound"),
+            ErrorClass::Conflict => write!(f, "Conflict"),
+            ErrorClass::PayloadTooLarge => write!(f, "PayloadTooLarge"),
+            ErrorClass::UnsupportedMedia => write!(f, "UnsupportedMedia"),
+            ErrorClass::RateLimited => write!(f, "RateLimited"),
+            ErrorClass::CapacityExhausted => write!(f, "CapacityExhausted"),
+            ErrorClass::BackendProtocol => write!(f, "BackendProtocol"),
+            ErrorClass::DeadlineExceeded => write!(f, "DeadlineExceeded"),
+            ErrorClass::NotImplemented => write!(f, "NotImplemented"),
+            ErrorClass::Internal => write!(f, "Internal"),
         }
     }
 }
+
+impl ErrorClass {
+    /// Return the canonical semantic class for a legacy or backend-specific variant.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "Unknown",
+            Self::InvalidArgument => "InvalidArgument",
+            Self::CannotConnect => "CannotConnect",
+            Self::Disconnected => "Disconnected",
+            Self::ConnectionTimeout => "ConnectionTimeout",
+            Self::ResponseTimeout => "ResponseTimeout",
+            Self::Cancelled => "Cancelled",
+            Self::ResourceExhausted => "ResourceExhausted",
+            Self::WorkerOverloaded => "WorkerOverloaded",
+            Self::Unavailable => "Unavailable",
+            Self::Backend(BackendError::Unknown) => "BackendUnknown",
+            Self::Backend(BackendError::InvalidArgument) => "BackendInvalidArgument",
+            Self::Backend(BackendError::CannotConnect) => "BackendCannotConnect",
+            Self::Backend(BackendError::Disconnected) => "BackendDisconnected",
+            Self::Backend(BackendError::ConnectionTimeout) => "BackendConnectionTimeout",
+            Self::Backend(BackendError::ResponseTimeout) => "BackendResponseTimeout",
+            Self::Backend(BackendError::Cancelled) => "BackendCancelled",
+            Self::Backend(BackendError::EngineShutdown) => "BackendEngineShutdown",
+            Self::Backend(BackendError::StreamIncomplete) => "BackendStreamIncomplete",
+            Self::InvalidRequest => "InvalidRequest",
+            Self::Unauthenticated => "Unauthenticated",
+            Self::PermissionDenied => "PermissionDenied",
+            Self::NotFound => "NotFound",
+            Self::Conflict => "Conflict",
+            Self::PayloadTooLarge => "PayloadTooLarge",
+            Self::UnsupportedMedia => "UnsupportedMedia",
+            Self::RateLimited => "RateLimited",
+            Self::CapacityExhausted => "CapacityExhausted",
+            Self::BackendProtocol => "BackendProtocol",
+            Self::DeadlineExceeded => "DeadlineExceeded",
+            Self::NotImplemented => "NotImplemented",
+            Self::Internal => "Internal",
+        }
+    }
+
+    pub fn normalized(self) -> Self {
+        match self {
+            Self::Unknown => Self::Internal,
+            Self::InvalidArgument => Self::InvalidRequest,
+            Self::CannotConnect | Self::Disconnected => Self::Unavailable,
+            Self::ConnectionTimeout | Self::ResponseTimeout => Self::DeadlineExceeded,
+            Self::ResourceExhausted | Self::WorkerOverloaded => Self::CapacityExhausted,
+            Self::Backend(error) => match error {
+                BackendError::Unknown => Self::Internal,
+                BackendError::InvalidArgument => Self::InvalidRequest,
+                BackendError::CannotConnect
+                | BackendError::Disconnected
+                | BackendError::EngineShutdown
+                | BackendError::StreamIncomplete => Self::Unavailable,
+                BackendError::ConnectionTimeout | BackendError::ResponseTimeout => {
+                    Self::DeadlineExceeded
+                }
+                BackendError::Cancelled => Self::Cancelled,
+            },
+            canonical @ (Self::Cancelled
+            | Self::Unavailable
+            | Self::InvalidRequest
+            | Self::Unauthenticated
+            | Self::PermissionDenied
+            | Self::NotFound
+            | Self::Conflict
+            | Self::PayloadTooLarge
+            | Self::UnsupportedMedia
+            | Self::RateLimited
+            | Self::CapacityExhausted
+            | Self::BackendProtocol
+            | Self::DeadlineExceeded
+            | Self::NotImplemented
+            | Self::Internal) => canonical,
+        }
+    }
+}
+
+/// Backward-compatible name retained while callers migrate to ErrorClass.
+pub type ErrorType = ErrorClass;
 
 /// Categorizes errors into a fixed set of standard types.
 ///
@@ -129,33 +244,356 @@ impl fmt::Display for BackendError {
     }
 }
 
+/// Stable, bounded catalog key for a specific failure cause.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ErrorReason(String);
+
+impl ErrorReason {
+    pub const MAX_BYTES: usize = 128;
+
+    pub fn new(value: impl Into<String>) -> Result<Self, InvalidErrorReason> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(InvalidErrorReason::Empty);
+        }
+        if value.len() > Self::MAX_BYTES {
+            return Err(InvalidErrorReason::TooLong);
+        }
+        if !value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"._-".contains(&byte)
+        }) {
+            return Err(InvalidErrorReason::InvalidCharacter);
+        }
+        if Self::catalog_class(&value).is_none() {
+            return Err(InvalidErrorReason::UnknownCatalogKey);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn catalog_class(value: &str) -> Option<ErrorClass> {
+        match value {
+            "runtime.unclassified" | "runtime.invalid_error" | "runtime.internal" => {
+                Some(ErrorClass::Internal)
+            }
+            "request.invalid_argument" | "backend.invalid_argument" | "request.invalid" => {
+                Some(ErrorClass::InvalidRequest)
+            }
+            "transport.cannot_connect"
+            | "transport.disconnected"
+            | "backend.unavailable"
+            | "backend.cannot_connect"
+            | "backend.disconnected"
+            | "backend.engine_shutdown"
+            | "backend.stream_incomplete" => Some(ErrorClass::Unavailable),
+            "transport.connection_timeout"
+            | "backend.response_timeout"
+            | "backend.connection_timeout"
+            | "request.deadline_exceeded" => Some(ErrorClass::DeadlineExceeded),
+            "request.cancelled" | "backend.cancelled" => Some(ErrorClass::Cancelled),
+            "capacity.pool_exhausted" | "capacity.worker_overloaded" | "capacity.exhausted" => {
+                Some(ErrorClass::CapacityExhausted)
+            }
+            "backend.unknown" => Some(ErrorClass::Internal),
+            "backend.protocol" => Some(ErrorClass::BackendProtocol),
+            "request.unauthenticated" => Some(ErrorClass::Unauthenticated),
+            "request.permission_denied" => Some(ErrorClass::PermissionDenied),
+            "request.not_found" => Some(ErrorClass::NotFound),
+            "request.conflict" => Some(ErrorClass::Conflict),
+            "request.payload_too_large" => Some(ErrorClass::PayloadTooLarge),
+            "request.unsupported_media" => Some(ErrorClass::UnsupportedMedia),
+            "request.rate_limited" => Some(ErrorClass::RateLimited),
+            "runtime.not_implemented" => Some(ErrorClass::NotImplemented),
+            _ => None,
+        }
+    }
+
+    fn from_static(value: &'static str) -> Self {
+        debug_assert!(!value.is_empty() && value.len() <= Self::MAX_BYTES);
+        debug_assert!(value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"._-".contains(&byte)
+        }));
+        debug_assert!(Self::catalog_class(value).is_some());
+        Self(value.to_owned())
+    }
+
+    fn for_class(class: ErrorClass) -> Self {
+        let value = match class {
+            ErrorClass::Unknown => "runtime.unclassified",
+            ErrorClass::InvalidArgument => "request.invalid_argument",
+            ErrorClass::CannotConnect => "transport.cannot_connect",
+            ErrorClass::Disconnected => "transport.disconnected",
+            ErrorClass::ConnectionTimeout => "transport.connection_timeout",
+            ErrorClass::ResponseTimeout => "backend.response_timeout",
+            ErrorClass::Cancelled => "request.cancelled",
+            ErrorClass::ResourceExhausted => "capacity.pool_exhausted",
+            ErrorClass::WorkerOverloaded => "capacity.worker_overloaded",
+            ErrorClass::Unavailable => "backend.unavailable",
+            ErrorClass::Backend(error) => match error {
+                BackendError::Unknown => "backend.unknown",
+                BackendError::InvalidArgument => "backend.invalid_argument",
+                BackendError::CannotConnect => "backend.cannot_connect",
+                BackendError::Disconnected => "backend.disconnected",
+                BackendError::ConnectionTimeout => "backend.connection_timeout",
+                BackendError::ResponseTimeout => "backend.response_timeout",
+                BackendError::Cancelled => "backend.cancelled",
+                BackendError::EngineShutdown => "backend.engine_shutdown",
+                BackendError::StreamIncomplete => "backend.stream_incomplete",
+            },
+            ErrorClass::InvalidRequest => "request.invalid",
+            ErrorClass::Unauthenticated => "request.unauthenticated",
+            ErrorClass::PermissionDenied => "request.permission_denied",
+            ErrorClass::NotFound => "request.not_found",
+            ErrorClass::Conflict => "request.conflict",
+            ErrorClass::PayloadTooLarge => "request.payload_too_large",
+            ErrorClass::UnsupportedMedia => "request.unsupported_media",
+            ErrorClass::RateLimited => "request.rate_limited",
+            ErrorClass::CapacityExhausted => "capacity.exhausted",
+            ErrorClass::BackendProtocol => "backend.protocol",
+            ErrorClass::DeadlineExceeded => "request.deadline_exceeded",
+            ErrorClass::NotImplemented => "runtime.not_implemented",
+            ErrorClass::Internal => "runtime.internal",
+        };
+        Self::from_static(value)
+    }
+}
+
+static INVALID_ERROR_REASON: LazyLock<ErrorReason> =
+    LazyLock::new(|| ErrorReason::from_static("runtime.invalid_error"));
+
+impl fmt::Display for ErrorReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Serialize for ErrorReason {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for ErrorReason {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvalidErrorReason {
+    Empty,
+    TooLong,
+    InvalidCharacter,
+    UnknownCatalogKey,
+}
+
+impl fmt::Display for InvalidErrorReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("error reason cannot be empty"),
+            Self::TooLong => write!(f, "error reason exceeds {} bytes", ErrorReason::MAX_BYTES),
+            Self::InvalidCharacter => f.write_str(
+                "error reason may contain only lowercase ASCII, digits, '.', '_', or '-'",
+            ),
+            Self::UnknownCatalogKey => f.write_str("error reason is not registered in the catalog"),
+        }
+    }
+}
+
+impl std::error::Error for InvalidErrorReason {}
+
+/// Closed set of structured, client-safe details.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PublicDetails {
+    SizeLimit {
+        limit: u64,
+        actual: Option<u64>,
+    },
+    ContextLength {
+        limit: u64,
+        actual: Option<u64>,
+    },
+    RateLimit {
+        limit: Option<u64>,
+        remaining: Option<u64>,
+    },
+}
+
+/// Bounded operator-only diagnostic text.
+#[derive(Debug, Clone, Default)]
+pub struct Diagnostic {
+    message: String,
+    source: Option<Arc<dyn std::error::Error + Send + Sync>>,
+}
+
+impl Diagnostic {
+    pub const MAX_BYTES: usize = 4096;
+    pub const TRUNCATION_SUFFIX: &'static str = "...[truncated]";
+
+    pub fn new(value: impl Into<String>) -> Self {
+        let mut message = value.into();
+        if message.len() > Self::MAX_BYTES {
+            let mut end = Self::MAX_BYTES - Self::TRUNCATION_SUFFIX.len();
+            while !message.is_char_boundary(end) {
+                end -= 1;
+            }
+            message.truncate(end);
+            message.push_str(Self::TRUNCATION_SUFFIX);
+        }
+        Self {
+            message,
+            source: None,
+        }
+    }
+
+    fn with_source(mut self, source: impl std::error::Error + Send + Sync + 'static) -> Self {
+        self.source = Some(Arc::new(source));
+        self
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.message
+    }
+
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_deref()
+            .map(|source| source as &(dyn std::error::Error + 'static))
+    }
+}
+
+impl PartialEq for Diagnostic {
+    fn eq(&self, other: &Self) -> bool {
+        self.message == other.message
+    }
+}
+
+impl Eq for Diagnostic {}
+
+impl Serialize for Diagnostic {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.message)
+    }
+}
+
+impl<'de> Deserialize<'de> for Diagnostic {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self::new(String::deserialize(deserializer)?))
+    }
+}
+
 // ============================================================================
 // DynamoError - The Standardized Error Type
 // ============================================================================
 
 /// The standardized error type for Dynamo.
 ///
-/// `DynamoError` is a serializable, chainable error that:
-/// - Carries an [`ErrorType`] for categorization
-/// - Supports error chaining via [`std::error::Error::source()`]
+/// `DynamoError` is a serializable semantic error that:
+/// - Carries an [`ErrorClass`] for categorization
 /// - Is serializable for network transmission via `Annotated`
 /// - Can be created from any [`std::error::Error`]
 ///
 /// # Display
 ///
-/// `Display` shows only the current error (standard Rust convention).
-/// Use `source()` to walk the cause chain:
+/// `Display` shows the private diagnostic when present and otherwise the reason.
 ///
 /// ```rust,ignore
 /// let err = DynamoError::msg("outer");
-/// println!("{}", err); // "Unknown: outer"
+/// println!("{}", err); // "Internal: outer"
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct DynamoError {
-    error_type: ErrorType,
-    message: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    caused_by: Option<Box<DynamoError>>,
+    pub class: ErrorClass,
+    pub reason: ErrorReason,
+    pub diagnostic: Option<Diagnostic>,
+    pub public: Option<PublicDetails>,
+}
+
+impl Serialize for DynamoError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        let public = self.public_details();
+        let mut state = serializer.serialize_struct(
+            "DynamoError",
+            2 + usize::from(self.diagnostic.is_some()) + usize::from(public.is_some()),
+        )?;
+        state.serialize_field("class", &self.class())?;
+        state.serialize_field("reason", self.reason())?;
+        if let Some(diagnostic) = &self.diagnostic {
+            state.serialize_field("diagnostic", diagnostic)?;
+        }
+        if let Some(public) = public {
+            state.serialize_field("public", public)?;
+        }
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for DynamoError {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Representation {
+            #[serde(alias = "error_type")]
+            class: ErrorClass,
+            #[serde(default)]
+            reason: Option<String>,
+            #[serde(default, alias = "message")]
+            diagnostic: Option<Diagnostic>,
+            #[serde(default, rename = "public", alias = "public_details")]
+            public: Option<PublicDetails>,
+        }
+
+        let representation = Representation::deserialize(deserializer)?;
+        let raw_class = representation.class;
+        let reason = match representation.reason {
+            Some(reason) => ErrorReason::new(reason).ok(),
+            None => Some(ErrorReason::for_class(raw_class)),
+        };
+        let valid_reason = reason
+            .as_ref()
+            .and_then(|reason| ErrorReason::catalog_class(reason.as_str()))
+            .is_some_and(|class| class == raw_class.normalized());
+
+        let (class, reason, public) = match reason {
+            Some(reason) if valid_reason => (raw_class, reason, representation.public),
+            _ => (
+                ErrorClass::Internal,
+                ErrorReason::from_static("runtime.invalid_error"),
+                None,
+            ),
+        };
+
+        Ok(Self {
+            class,
+            reason,
+            diagnostic: representation.diagnostic,
+            public,
+        })
+    }
 }
 
 impl DynamoError {
@@ -164,59 +602,107 @@ impl DynamoError {
         DynamoErrorBuilder::default()
     }
 
-    /// Shorthand to create an `Unknown` error with just a message and no cause.
+    /// Shorthand to create an internal error with a private diagnostic.
     pub fn msg(message: impl Into<String>) -> Self {
-        Self::builder().message(message).build()
+        Self::builder().diagnostic(message).build()
     }
 
-    /// Returns the error type.
+    /// Returns the validated legacy error type without normalization.
+    ///
+    /// Invalid public-field combinations fail closed so legacy policy callers
+    /// cannot bypass the canonical identity check.
     pub fn error_type(&self) -> ErrorType {
-        self.error_type
+        if self.has_valid_identity() {
+            self.class
+        } else {
+            ErrorClass::Internal
+        }
     }
 
-    /// Returns the error message.
+    fn has_valid_identity(&self) -> bool {
+        ErrorReason::catalog_class(self.reason.as_str())
+            .is_some_and(|class| class == self.class.normalized())
+    }
+
+    /// Returns the canonical semantic error class.
+    pub fn class(&self) -> ErrorClass {
+        if self.has_valid_identity() {
+            self.class.normalized()
+        } else {
+            ErrorClass::Internal
+        }
+    }
+
+    /// Returns the stable reason key.
+    pub fn reason(&self) -> &ErrorReason {
+        if self.has_valid_identity() {
+            &self.reason
+        } else {
+            &INVALID_ERROR_REASON
+        }
+    }
+
+    /// Returns the optional private diagnostic.
+    pub fn diagnostic(&self) -> Option<&Diagnostic> {
+        self.diagnostic.as_ref()
+    }
+
+    /// Returns structured client-safe details.
+    pub fn public_details(&self) -> Option<&PublicDetails> {
+        self.has_valid_identity()
+            .then_some(self.public.as_ref())
+            .flatten()
+    }
+
+    /// Returns the legacy error message view.
     pub fn message(&self) -> &str {
-        &self.message
+        self.diagnostic
+            .as_ref()
+            .map(Diagnostic::as_str)
+            .unwrap_or_default()
     }
 }
 
 impl fmt::Display for DynamoError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {}", self.error_type, self.message)
+        match self.diagnostic() {
+            Some(diagnostic) if !diagnostic.as_str().is_empty() => {
+                write!(f, "{}: {}", self.class(), diagnostic.as_str())
+            }
+            _ => write!(f, "{}: {}", self.class(), self.reason()),
+        }
     }
 }
 
 impl std::error::Error for DynamoError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.caused_by
-            .as_deref()
-            .map(|e| e as &(dyn std::error::Error + 'static))
+        self.diagnostic.as_ref().and_then(Diagnostic::source)
     }
 }
 
 /// Convert from a reference to any `std::error::Error`.
-///
-/// If the error is already a `DynamoError`, it is cloned. Otherwise, it is
-/// wrapped as `ErrorType::Unknown` with the display string as the message.
-/// The source chain is recursively converted, preserving `DynamoError` instances.
 impl<'a> From<&'a (dyn std::error::Error + 'static)> for DynamoError {
     fn from(err: &'a (dyn std::error::Error + 'static)) -> Self {
         if let Some(dynamo_err) = err.downcast_ref::<DynamoError>() {
             return dynamo_err.clone();
         }
 
+        let diagnostic = Diagnostic::new(err.to_string());
+        let diagnostic = match err.source() {
+            Some(source) => diagnostic.with_source(DynamoError::from(source)),
+            None => diagnostic,
+        };
+
         Self {
-            error_type: ErrorType::Unknown,
-            message: err.to_string(),
-            caused_by: err.source().map(|s| Box::new(DynamoError::from(s))),
+            class: ErrorClass::Internal,
+            reason: ErrorReason::from_static("runtime.unclassified"),
+            diagnostic: Some(diagnostic),
+            public: None,
         }
     }
 }
 
 /// Convert from an owned boxed `std::error::Error`.
-///
-/// If the error is already a `DynamoError`, ownership is taken without cloning.
-/// Otherwise, falls back to the reference-based conversion.
 impl From<Box<dyn std::error::Error + 'static>> for DynamoError {
     fn from(err: Box<dyn std::error::Error + 'static>) -> Self {
         match err.downcast::<DynamoError>() {
@@ -235,50 +721,89 @@ impl From<Box<dyn std::error::Error + 'static>> for DynamoError {
 /// # Example
 /// ```rust,ignore
 /// let err = DynamoError::builder()
-///     .error_type(ErrorType::Disconnected)
+///     .error_type(ErrorClass::Disconnected)
 ///     .message("worker lost")
 ///     .cause(some_io_error)
 ///     .build();
 /// ```
 #[derive(Default)]
 pub struct DynamoErrorBuilder {
-    error_type: Option<ErrorType>,
-    message: Option<String>,
-    caused_by: Option<Box<DynamoError>>,
+    class: Option<ErrorClass>,
+    reason: Option<ErrorReason>,
+    diagnostic: Option<Diagnostic>,
+    public: Option<PublicDetails>,
 }
 
 impl DynamoErrorBuilder {
-    /// Set the error type.
+    /// Set the legacy or canonical error class.
     pub fn error_type(mut self, error_type: ErrorType) -> Self {
-        self.error_type = Some(error_type);
+        self.class = Some(error_type);
         self
     }
 
-    /// Set the error message.
-    pub fn message(mut self, message: impl Into<String>) -> Self {
-        self.message = Some(message.into());
+    /// Set the canonical error class.
+    pub fn class(self, class: ErrorClass) -> Self {
+        self.error_type(class)
+    }
+
+    /// Set the stable reason key.
+    pub fn reason(mut self, reason: ErrorReason) -> Self {
+        self.reason = Some(reason);
         self
     }
 
-    /// Set the cause from any `std::error::Error`.
-    ///
-    /// If the cause is already a `DynamoError`, it is preserved as-is.
-    /// Otherwise, it is converted to a `DynamoError` with `ErrorType::Unknown`.
+    /// Set the private bounded diagnostic.
+    pub fn diagnostic(mut self, diagnostic: impl Into<String>) -> Self {
+        self.diagnostic = Some(Diagnostic::new(diagnostic));
+        self
+    }
+
+    /// Set the legacy error message view.
+    pub fn message(self, message: impl Into<String>) -> Self {
+        self.diagnostic(message)
+    }
+
+    /// Set structured client-safe details.
+    pub fn public_details(mut self, public: PublicDetails) -> Self {
+        self.public = Some(public);
+        self
+    }
+
+    /// Preserve compatibility with existing builders while keeping native causes out of the semantic payload.
     pub fn cause(mut self, cause: impl std::error::Error + 'static) -> Self {
-        self.caused_by = Some(Box::new(DynamoError::from(
-            &cause as &(dyn std::error::Error + 'static),
-        )));
+        let message = cause.to_string();
+        let source = DynamoError::from(&cause as &(dyn std::error::Error + 'static));
+        let diagnostic = self
+            .diagnostic
+            .take()
+            .unwrap_or_else(|| Diagnostic::new(message));
+        self.diagnostic = Some(diagnostic.with_source(source));
         self
     }
 
-    /// Build the `DynamoError`.
-    ///
-    /// Defaults: `error_type` → `Unknown`, `message` → `""`, `cause` → `None`.
+    /// Build the `DynamoError` and fail closed on a class/reason mismatch.
     pub fn build(self) -> DynamoError {
-        DynamoError {
-            error_type: self.error_type.unwrap_or(ErrorType::Unknown),
-            message: self.message.unwrap_or_default(),
-            caused_by: self.caused_by,
+        let raw_class = self.class.unwrap_or(ErrorClass::Internal);
+        let reason = self
+            .reason
+            .unwrap_or_else(|| ErrorReason::for_class(raw_class));
+        let valid_reason = ErrorReason::catalog_class(reason.as_str())
+            .is_some_and(|class| class == raw_class.normalized());
+
+        if valid_reason {
+            DynamoError {
+                class: raw_class,
+                reason,
+                diagnostic: self.diagnostic,
+                public: self.public,
+            }
+        } else {
+            DynamoError {
+                class: ErrorClass::Internal,
+                reason: ErrorReason::from_static("runtime.invalid_error"),
+                diagnostic: self.diagnostic,
+                public: None,
+            }
         }
     }
 }
@@ -296,8 +821,8 @@ impl DynamoErrorBuilder {
 /// in `match_set`. Errors that are not `DynamoError` are skipped.
 pub fn match_error_chain(
     err: &(dyn std::error::Error + 'static),
-    match_set: &[ErrorType],
-    exclude_set: &[ErrorType],
+    match_set: &[ErrorClass],
+    exclude_set: &[ErrorClass],
 ) -> bool {
     let mut found = false;
     let mut current: Option<&(dyn std::error::Error + 'static)> = Some(err);
@@ -344,83 +869,56 @@ mod tests {
     #[test]
     fn test_msg_constructor() {
         let err = DynamoError::msg("something failed");
-        assert_eq!(err.error_type(), ErrorType::Unknown);
+        assert_eq!(err.error_type(), ErrorClass::Internal);
+        assert_eq!(err.reason().as_str(), "runtime.internal");
         assert_eq!(err.message(), "something failed");
         assert!(err.source().is_none());
     }
 
     #[test]
-    fn test_new_constructor_with_cause() {
-        let cause = std::io::Error::other("io error");
+    fn cause_is_local_and_does_not_expand_the_semantic_payload() {
         let err = DynamoError::builder()
-            .error_type(ErrorType::Unknown)
-            .message("operation failed")
-            .cause(cause)
+            .class(ErrorClass::Internal)
+            .reason(ErrorReason::new("runtime.internal").unwrap())
+            .diagnostic("operation failed")
+            .cause(std::io::Error::other("io error"))
             .build();
 
-        assert_eq!(err.error_type(), ErrorType::Unknown);
         assert_eq!(err.message(), "operation failed");
-        assert!(err.source().is_some());
+        assert_eq!(err.source().unwrap().to_string(), "Internal: io error");
+        let value = serde_json::to_value(&err).unwrap();
+        assert_eq!(value.as_object().unwrap().len(), 3);
+
+        let roundtrip: DynamoError = serde_json::from_value(value).unwrap();
+        assert!(roundtrip.source().is_none());
     }
 
     #[test]
-    fn test_display_shows_only_current_error() {
-        let cause = std::io::Error::other("io error");
-        let err = DynamoError::builder()
-            .error_type(ErrorType::Unknown)
-            .message("operation failed")
-            .cause(cause)
+    fn display_uses_diagnostic_or_reason() {
+        let with_diagnostic = DynamoError::builder()
+            .class(ErrorClass::Internal)
+            .reason(ErrorReason::new("runtime.internal").unwrap())
+            .diagnostic("operation failed")
+            .build();
+        let without_diagnostic = DynamoError::builder()
+            .class(ErrorClass::Internal)
+            .reason(ErrorReason::new("runtime.internal").unwrap())
             .build();
 
-        // Display should only show the current error, not the chain
-        assert_eq!(err.to_string(), "Unknown: operation failed");
+        assert_eq!(with_diagnostic.to_string(), "Internal: operation failed");
+        assert_eq!(without_diagnostic.to_string(), "Internal: runtime.internal");
     }
 
     #[test]
-    fn test_source_chain() {
-        let cause = std::io::Error::other("io error");
-        let err = DynamoError::builder()
-            .error_type(ErrorType::Unknown)
-            .message("operation failed")
-            .cause(cause)
-            .build();
-
-        // source() should return the cause
-        let source = err.source().unwrap();
-        assert!(source.to_string().contains("io error"));
-    }
-
-    #[test]
-    fn test_from_boxed_std_error() {
-        let std_err = std::io::Error::other("io error");
-        let boxed: Box<dyn std::error::Error> = Box::new(std_err);
-        let dynamo_err = DynamoError::from(boxed);
-
-        assert_eq!(dynamo_err.error_type(), ErrorType::Unknown);
-        assert_eq!(dynamo_err.message(), "io error");
-    }
-
-    #[test]
-    fn test_from_boxed_takes_ownership_of_dynamo_error() {
-        let inner = DynamoError::msg("original");
-        let boxed: Box<dyn std::error::Error> = Box::new(inner);
-        let dynamo_err = DynamoError::from(boxed);
-
-        // Should take ownership, not clone or wrap
-        assert_eq!(dynamo_err.error_type(), ErrorType::Unknown);
-        assert_eq!(dynamo_err.message(), "original");
-    }
-
-    #[test]
-    fn test_from_boxed_with_source_chain() {
+    fn conversion_preserves_nested_semantic_source_locally() {
         #[derive(Debug)]
         struct OuterError {
-            source: std::io::Error,
+            source: DynamoError,
         }
 
         impl fmt::Display for OuterError {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "outer error occurred")
+                f.write_str("outer failure")
             }
         }
 
@@ -430,94 +928,266 @@ mod tests {
             }
         }
 
-        let inner = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
-        let outer = OuterError { source: inner };
-        let boxed: Box<dyn std::error::Error> = Box::new(outer);
-        let dynamo_err = DynamoError::from(boxed);
+        let outer = OuterError {
+            source: DynamoError::builder()
+                .error_type(ErrorType::InvalidArgument)
+                .diagnostic("invalid input")
+                .build(),
+        };
+        let converted = DynamoError::from(&outer as &(dyn std::error::Error + 'static));
 
-        assert_eq!(dynamo_err.message(), "outer error occurred");
-        assert!(dynamo_err.source().is_some());
-
-        let cause = dynamo_err.source().unwrap();
-        assert!(cause.to_string().contains("file not found"));
+        assert!(match_error_chain(
+            &converted,
+            &[ErrorType::InvalidArgument],
+            &[]
+        ));
+        let value = serde_json::to_value(converted).unwrap();
+        assert!(value.get("caused_by").is_none());
     }
 
     #[test]
-    fn test_serialization_roundtrip() {
-        let cause = DynamoError::msg("inner cause");
+    fn test_from_boxed_std_error() {
+        let std_err = std::io::Error::other("io error");
+        let boxed: Box<dyn std::error::Error> = Box::new(std_err);
+        let dynamo_err = DynamoError::from(boxed);
+
+        assert_eq!(dynamo_err.class(), ErrorClass::Internal);
+        assert_eq!(dynamo_err.reason().as_str(), "runtime.unclassified");
+        assert_eq!(dynamo_err.message(), "io error");
+    }
+
+    #[test]
+    fn test_from_boxed_takes_ownership_of_dynamo_error() {
+        let inner = DynamoError::msg("original");
+        let boxed: Box<dyn std::error::Error> = Box::new(inner);
+        let dynamo_err = DynamoError::from(boxed);
+
+        assert_eq!(dynamo_err.class(), ErrorClass::Internal);
+        assert_eq!(dynamo_err.message(), "original");
+    }
+
+    #[test]
+    fn semantic_metadata_roundtrips() {
         let err = DynamoError::builder()
-            .error_type(ErrorType::Unknown)
-            .message("outer error")
-            .cause(cause)
+            .class(ErrorClass::RateLimited)
+            .reason(ErrorReason::new("request.rate_limited").unwrap())
+            .diagnostic("request rate exceeded")
+            .public_details(PublicDetails::RateLimit {
+                limit: Some(100),
+                remaining: Some(0),
+            })
             .build();
 
         let json = serde_json::to_string(&err).unwrap();
         let deserialized: DynamoError = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(deserialized.error_type(), ErrorType::Unknown);
-        assert_eq!(deserialized.message(), "outer error");
-        assert!(deserialized.source().is_some());
+        assert_eq!(deserialized.class(), ErrorClass::RateLimited);
+        assert_eq!(deserialized.reason().as_str(), "request.rate_limited");
+        assert_eq!(
+            deserialized.diagnostic().map(Diagnostic::as_str),
+            Some("request rate exceeded")
+        );
+        assert_eq!(
+            deserialized.public_details(),
+            Some(&PublicDetails::RateLimit {
+                limit: Some(100),
+                remaining: Some(0),
+            })
+        );
+    }
 
-        let cause = deserialized
-            .source()
-            .unwrap()
-            .downcast_ref::<DynamoError>()
-            .unwrap();
-        assert_eq!(cause.message(), "inner cause");
+    #[test]
+    fn semantic_schema_serializes_only_four_fields() {
+        let err = DynamoError::builder()
+            .class(ErrorClass::RateLimited)
+            .reason(ErrorReason::new("request.rate_limited").unwrap())
+            .diagnostic("request rate exceeded")
+            .public_details(PublicDetails::RateLimit {
+                limit: Some(100),
+                remaining: Some(0),
+            })
+            .build();
+
+        let value = serde_json::to_value(err).unwrap();
+        let object = value.as_object().unwrap();
+
+        assert_eq!(object.len(), 4);
+        assert_eq!(value["class"], "RateLimited");
+        assert_eq!(value["reason"], "request.rate_limited");
+        assert_eq!(value["diagnostic"], "request rate exceeded");
+        assert!(value.get("public").is_some());
+    }
+
+    #[test]
+    fn optional_semantic_fields_are_omitted() {
+        let err = DynamoError::builder()
+            .class(ErrorClass::InvalidRequest)
+            .reason(ErrorReason::new("request.invalid").unwrap())
+            .build();
+
+        let value = serde_json::to_value(err).unwrap();
+        let object = value.as_object().unwrap();
+
+        assert_eq!(object.len(), 2);
+        assert_eq!(value["class"], "InvalidRequest");
+        assert_eq!(value["reason"], "request.invalid");
+        assert!(value.get("diagnostic").is_none());
+        assert!(value.get("public").is_none());
+    }
+
+    #[test]
+    fn unknown_catalog_reason_fails_closed() {
+        let json = r#"{
+            "class": "InvalidRequest",
+            "reason": "request.user_supplied_metric_label",
+            "diagnostic": "private details"
+        }"#;
+        let err: DynamoError = serde_json::from_str(json).unwrap();
+
+        assert_eq!(err.class(), ErrorClass::Internal);
+        assert_eq!(err.reason().as_str(), "runtime.invalid_error");
+        assert_eq!(
+            err.diagnostic().map(Diagnostic::as_str),
+            Some("private details")
+        );
+    }
+
+    #[test]
+    fn public_fields_fail_closed_at_consumer_boundaries() {
+        let err = DynamoError {
+            class: ErrorClass::InvalidRequest,
+            reason: ErrorReason::new("request.rate_limited").unwrap(),
+            diagnostic: Some(Diagnostic::new("private details")),
+            public: Some(PublicDetails::RateLimit {
+                limit: Some(10),
+                remaining: Some(0),
+            }),
+        };
+
+        assert_eq!(err.class(), ErrorClass::Internal);
+        assert_eq!(err.error_type(), ErrorClass::Internal);
+        assert_eq!(err.reason().as_str(), "runtime.invalid_error");
+        assert!(err.public_details().is_none());
+        assert_eq!(err.to_string(), "Internal: private details");
+        assert_eq!(
+            serde_json::to_value(err).unwrap(),
+            serde_json::json!({
+                "class": "Internal",
+                "reason": "runtime.invalid_error",
+                "diagnostic": "private details"
+            })
+        );
+    }
+
+    #[test]
+    fn diagnostic_is_bounded_at_utf8_boundary() {
+        let diagnostic = Diagnostic::new("x".repeat(Diagnostic::MAX_BYTES - 1) + "é");
+
+        assert!(diagnostic.as_str().len() <= Diagnostic::MAX_BYTES);
+        assert!(
+            diagnostic
+                .as_str()
+                .is_char_boundary(diagnostic.as_str().len())
+        );
+        assert!(diagnostic.as_str().ends_with(Diagnostic::TRUNCATION_SUFFIX));
+    }
+
+    #[test]
+    fn legacy_builder_derives_semantic_defaults() {
+        let legacy_type: ErrorType = ErrorType::InvalidArgument;
+        let err = DynamoError::builder()
+            .error_type(legacy_type)
+            .message("bad request")
+            .build();
+
+        assert_eq!(err.error_type(), ErrorType::InvalidArgument);
+        assert_eq!(err.class(), ErrorClass::InvalidRequest);
+        assert_eq!(err.reason().as_str(), "request.invalid_argument");
+        assert_eq!(err.message(), "bad request");
+    }
+
+    #[test]
+    fn legacy_json_derives_semantic_defaults() {
+        let json = r#"{"error_type":"InvalidArgument","message":"bad request"}"#;
+        let err: DynamoError = serde_json::from_str(json).unwrap();
+
+        assert_eq!(err.class(), ErrorClass::InvalidRequest);
+        assert_eq!(err.reason().as_str(), "request.invalid_argument");
+        assert_eq!(
+            err.diagnostic().map(Diagnostic::as_str),
+            Some("bad request")
+        );
+        assert!(err.public_details().is_none());
+    }
+
+    #[test]
+    fn malformed_semantic_reason_fails_closed() {
+        let json = r#"{
+            "class": "InvalidRequest",
+            "reason": "INVALID REASON",
+            "diagnostic": "private details",
+            "public": {"type": "rate_limit", "limit": 10, "remaining": 0}
+        }"#;
+        let err: DynamoError = serde_json::from_str(json).unwrap();
+
+        assert_eq!(err.error_type(), ErrorClass::Internal);
+        assert_eq!(err.class(), ErrorClass::Internal);
+        assert_eq!(err.reason().as_str(), "runtime.invalid_error");
+        assert!(err.public_details().is_none());
     }
 
     #[test]
     fn test_error_type_display() {
-        assert_eq!(ErrorType::Unknown.to_string(), "Unknown");
-        assert_eq!(ErrorType::InvalidArgument.to_string(), "InvalidArgument");
-        assert_eq!(ErrorType::CannotConnect.to_string(), "CannotConnect");
-        assert_eq!(ErrorType::Disconnected.to_string(), "Disconnected");
+        assert_eq!(ErrorClass::Unknown.to_string(), "Unknown");
+        assert_eq!(ErrorClass::InvalidArgument.to_string(), "InvalidArgument");
+        assert_eq!(ErrorClass::CannotConnect.to_string(), "CannotConnect");
+        assert_eq!(ErrorClass::Disconnected.to_string(), "Disconnected");
         assert_eq!(
-            ErrorType::ConnectionTimeout.to_string(),
+            ErrorClass::ConnectionTimeout.to_string(),
             "ConnectionTimeout"
         );
-        assert_eq!(ErrorType::ResponseTimeout.to_string(), "ResponseTimeout");
-        assert_eq!(ErrorType::Cancelled.to_string(), "Cancelled");
+        assert_eq!(ErrorClass::ResponseTimeout.to_string(), "ResponseTimeout");
+        assert_eq!(ErrorClass::Cancelled.to_string(), "Cancelled");
         assert_eq!(
-            ErrorType::ResourceExhausted.to_string(),
+            ErrorClass::ResourceExhausted.to_string(),
             "ResourceExhausted"
         );
-        assert_eq!(ErrorType::WorkerOverloaded.to_string(), "WorkerOverloaded");
-        assert_eq!(ErrorType::Unavailable.to_string(), "Unavailable");
+        assert_eq!(ErrorClass::WorkerOverloaded.to_string(), "WorkerOverloaded");
+        assert_eq!(ErrorClass::Unavailable.to_string(), "Unavailable");
         assert_eq!(
-            ErrorType::Backend(BackendError::Unknown).to_string(),
+            ErrorClass::Backend(BackendError::Unknown).to_string(),
             "BackendUnknown"
         );
         assert_eq!(
-            ErrorType::Backend(BackendError::InvalidArgument).to_string(),
+            ErrorClass::Backend(BackendError::InvalidArgument).to_string(),
             "BackendInvalidArgument"
         );
         assert_eq!(
-            ErrorType::Backend(BackendError::CannotConnect).to_string(),
+            ErrorClass::Backend(BackendError::CannotConnect).to_string(),
             "BackendCannotConnect"
         );
         assert_eq!(
-            ErrorType::Backend(BackendError::Disconnected).to_string(),
+            ErrorClass::Backend(BackendError::Disconnected).to_string(),
             "BackendDisconnected"
         );
         assert_eq!(
-            ErrorType::Backend(BackendError::ConnectionTimeout).to_string(),
+            ErrorClass::Backend(BackendError::ConnectionTimeout).to_string(),
             "BackendConnectionTimeout"
         );
         assert_eq!(
-            ErrorType::Backend(BackendError::Cancelled).to_string(),
+            ErrorClass::Backend(BackendError::Cancelled).to_string(),
             "BackendCancelled"
         );
         assert_eq!(
-            ErrorType::Backend(BackendError::EngineShutdown).to_string(),
+            ErrorClass::Backend(BackendError::EngineShutdown).to_string(),
             "BackendEngineShutdown"
         );
         assert_eq!(
-            ErrorType::Backend(BackendError::StreamIncomplete).to_string(),
+            ErrorClass::Backend(BackendError::StreamIncomplete).to_string(),
             "BackendStreamIncomplete"
         );
         assert_eq!(
-            ErrorType::Backend(BackendError::ResponseTimeout).to_string(),
+            ErrorClass::Backend(BackendError::ResponseTimeout).to_string(),
             "BackendResponseTimeout"
         );
     }

--- a/lib/runtime/src/error.rs
+++ b/lib/runtime/src/error.rs
@@ -31,10 +31,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::sync::{Arc, LazyLock};
 
-// ============================================================================
-// ErrorClass Enum
-// ============================================================================
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ErrorClass {
     /// The request contains invalid input (e.g., prompt exceeds context length).
@@ -273,6 +269,34 @@ impl ErrorReason {
 
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    /// Returns whether this reason makes the enclosing request ineligible for migration.
+    pub fn blocks_migration(&self) -> bool {
+        matches!(
+            self.as_str(),
+            "request.cancelled"
+                | "backend.cancelled"
+                | "capacity.exhausted"
+                | "capacity.pool_exhausted"
+        )
+    }
+
+    /// Returns whether this reason permits retrying the request on another worker.
+    pub fn is_migration_eligible(&self) -> bool {
+        matches!(
+            self.as_str(),
+            "transport.cannot_connect"
+                | "transport.disconnected"
+                | "transport.connection_timeout"
+                | "backend.cannot_connect"
+                | "backend.disconnected"
+                | "backend.connection_timeout"
+                | "backend.response_timeout"
+                | "backend.engine_shutdown"
+                | "backend.stream_incomplete"
+                | "capacity.worker_overloaded"
+        )
     }
 
     fn catalog_class(value: &str) -> Option<ErrorClass> {
@@ -1109,6 +1133,20 @@ mod tests {
                 .is_char_boundary(diagnostic.as_str().len())
         );
         assert!(diagnostic.as_str().ends_with(Diagnostic::TRUNCATION_SUFFIX));
+    }
+
+    #[test]
+    fn migration_reason_helpers_preserve_the_reason_policy() {
+        let retryable = ErrorReason::new("backend.disconnected").unwrap();
+        let blocked = ErrorReason::new("capacity.exhausted").unwrap();
+        let unrelated = ErrorReason::new("request.invalid").unwrap();
+
+        assert!(retryable.is_migration_eligible());
+        assert!(!retryable.blocks_migration());
+        assert!(blocked.blocks_migration());
+        assert!(!blocked.is_migration_eligible());
+        assert!(!unrelated.blocks_migration());
+        assert!(!unrelated.is_migration_eligible());
     }
 
     #[test]

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -180,6 +180,9 @@ pub mod frontend_service {
     /// Total number of LLM requests accepted by the frontend handler
     pub const REQUESTS_STARTED_TOTAL: &str = "requests_started_total";
 
+    /// Total number of terminal semantic request failures.
+    pub const FAILURES_TOTAL: &str = "failures_total";
+
     /// Number of requests waiting in HTTP queue before receiving the first response (gauge)
     pub const QUEUED_REQUESTS: &str = "queued_requests";
 

--- a/lib/runtime/src/pipeline/network/egress/route_span.rs
+++ b/lib/runtime/src/pipeline/network/egress/route_span.rs
@@ -172,18 +172,20 @@ where
 
 pub fn error_type_from_chain(err: &(dyn StdError + 'static)) -> ErrorType {
     let mut current = Some(err);
-    let mut first = None;
+    let mut fallback = None;
     while let Some(error) = current {
         if let Some(dynamo_error) = error.downcast_ref::<DynamoError>() {
             let error_type = dynamo_error.error_type();
-            first.get_or_insert(error_type);
-            if error_type != ErrorType::Unknown {
+            fallback.get_or_insert(error_type);
+            if error_type != ErrorType::Unknown
+                && dynamo_error.reason().as_str() != "runtime.unclassified"
+            {
                 return error_type;
             }
         }
         current = error.source();
     }
-    first.unwrap_or(ErrorType::Unknown)
+    fallback.unwrap_or(ErrorType::Unknown)
 }
 
 pub fn error_type_name(error_type: ErrorType) -> &'static str {
@@ -207,6 +209,19 @@ pub fn error_type_name(error_type: ErrorType) -> &'static str {
         ErrorType::Backend(BackendError::Cancelled) => "backend_cancelled",
         ErrorType::Backend(BackendError::EngineShutdown) => "engine_shutdown",
         ErrorType::Backend(BackendError::StreamIncomplete) => "stream_incomplete",
+        ErrorType::InvalidRequest => "invalid_request",
+        ErrorType::Unauthenticated => "unauthenticated",
+        ErrorType::PermissionDenied => "permission_denied",
+        ErrorType::NotFound => "not_found",
+        ErrorType::Conflict => "conflict",
+        ErrorType::PayloadTooLarge => "payload_too_large",
+        ErrorType::UnsupportedMedia => "unsupported_media",
+        ErrorType::RateLimited => "rate_limited",
+        ErrorType::CapacityExhausted => "capacity_exhausted",
+        ErrorType::BackendProtocol => "backend_protocol",
+        ErrorType::DeadlineExceeded => "deadline_exceeded",
+        ErrorType::NotImplemented => "not_implemented",
+        ErrorType::Internal => "internal",
     }
 }
 
@@ -237,6 +252,17 @@ fn error_outcome(error_type: ErrorType) -> &'static str {
         ErrorType::Unavailable => "unavailable",
         ErrorType::Cancelled | ErrorType::Backend(BackendError::Cancelled) => "cancelled",
         ErrorType::Unknown | ErrorType::Backend(BackendError::Unknown) => "error",
+        ErrorType::InvalidRequest
+        | ErrorType::Unauthenticated
+        | ErrorType::PermissionDenied
+        | ErrorType::NotFound
+        | ErrorType::Conflict
+        | ErrorType::PayloadTooLarge
+        | ErrorType::UnsupportedMedia
+        | ErrorType::RateLimited
+        | ErrorType::CapacityExhausted => "rejected",
+        ErrorType::DeadlineExceeded => "timeout",
+        ErrorType::BackendProtocol | ErrorType::NotImplemented | ErrorType::Internal => "error",
     }
 }
 


### PR DESCRIPTION
## Summary

- Establishes DynamoError as the shared semantic error envelope: normalized class and reason, an optional bounded operator diagnostic, and optional allowlisted structured public details.
- Centralizes semantic class-to-HTTP rendering for OpenAI and Anthropic adapters so classified errors retain their intended client status; unknown wire classes fail closed to Internal.
- Classifies legacy unstructured backend HTTP errors from trusted status codes, while preserving canonical semantic errors as the authority.
- Uses the configured overload status for capacity exhaustion and records semantic failures as dynamo_frontend_failures_total{class,reason}.
- Preserves the semantic source head across wrappers without serializing error causes; removes migration-path panics and makes stream error codes protocol-correct strings.
- Keeps diagnostics out of public validation responses and adds regressions for diagnostic non-exposure and classified-internal HTTP 500 behavior.

## Rollout

The compact error writer requires a reader-first compatible rollout. Deploy readers that understand the new fields before enabling new writers, or use an approved atomic/versioned upgrade.

## Validation

- cargo fmt --all
- cargo test -q -p dynamo-llm --lib --no-default-features: 2443 passed, 3 ignored
- Focused regressions for diagnostic non-exposure, backend HTTP triage, semantic HTTP authority, unknown-class fail-closed deserialization, and semantic-head preservation
- git diff --check

Relates to #14354.