### PR TITLE
perf(mocker): estimate KV bytes from config.json without importing transformers

### DIFF
--- a/components/src/dynamo/mocker/main.py
+++ b/components/src/dynamo/mocker/main.py
@@ -42,22 +42,31 @@ async def graceful_shutdown(runtimes: list):
     logger.info("DistributedRuntime shutdown complete")
 
 
-async def prefetch_model(model_path: str) -> None:
-    """Pre-fetch model from HuggingFace to avoid rate limiting with many workers."""
+async def prefetch_model(model_path: str) -> str:
+    """Resolve ``model_path`` to a local directory, fetching config/tokenizer if needed.
+
+    ``fetch_model`` returns the cached snapshot directory without contacting the
+    hub when config.json and the tokenizer files are already present, and downloads
+    only those files otherwise. Resolving once here means neither the workers nor
+    the KV-bytes estimate below resolve a hub ID over the network. Returns the
+    original path on failure so callers degrade to their previous behavior.
+    """
 
     if Path(model_path).exists():
         logger.info(f"Using local model path: {model_path}")
-        return
+        return model_path
 
     logger.info(f"Pre-fetching model from HuggingFace: {model_path}")
     try:
         local_path = await fetch_model(model_path, ignore_weights=True)
         logger.info(f"Model cached at: {local_path}")
+        return str(local_path)
     except Exception as e:
         logger.warning(
             f"Failed to pre-fetch model: {e}. "
             "Workers will attempt individual downloads (may cause rate limiting)."
         )
+        return model_path
 
 
 async def worker():
@@ -72,9 +81,12 @@ async def worker():
     args.planner_profile_data = profile_data_result.npz_path
 
     try:
-        # Pre-fetch model once to avoid HuggingFace rate limiting when launching many workers
-        if args.num_workers > 1 and args.model_path:
-            await prefetch_model(args.model_path)
+        # Resolve the model to a local directory once, up front. Besides avoiding
+        # HuggingFace rate limiting with many workers, this keeps the KV-bytes
+        # estimate below from resolving a hub ID over the network on every start.
+        local_model_path = None
+        if args.model_path:
+            local_model_path = await prefetch_model(args.model_path)
 
         engine_args = load_mocker_engine_args(args)
         logger.info(
@@ -86,7 +98,7 @@ async def worker():
         # Auto-compute kv_bytes_per_token from model config if not explicitly set
         if args.kv_bytes_per_token is None and args.model_path:
             args.kv_bytes_per_token = compute_kv_bytes_per_token(
-                args.model_path, args.kv_cache_dtype
+                local_model_path or args.model_path, args.kv_cache_dtype
             )
         engine_args = apply_worker_engine_args_overrides(
             engine_args, kv_bytes_per_token=args.kv_bytes_per_token

--- a/components/src/dynamo/mocker/main.py
+++ b/components/src/dynamo/mocker/main.py
@@ -81,11 +81,12 @@ async def worker():
     args.planner_profile_data = profile_data_result.npz_path
 
     try:
-        # Resolve the model to a local directory once, up front. Besides avoiding
-        # HuggingFace rate limiting with many workers, this keeps the KV-bytes
-        # estimate below from resolving a hub ID over the network on every start.
+        # Only when something needs the local files: many workers (rate limiting)
+        # or the KV-bytes estimate below (reads config.json).
         local_model_path = None
-        if args.model_path:
+        if args.model_path and (
+            args.num_workers > 1 or args.kv_bytes_per_token is None
+        ):
             local_model_path = await prefetch_model(args.model_path)
 
         engine_args = load_mocker_engine_args(args)

--- a/components/src/dynamo/mocker/main.py
+++ b/components/src/dynamo/mocker/main.py
@@ -62,9 +62,14 @@ async def prefetch_model(model_path: str) -> str:
         logger.info(f"Model cached at: {local_path}")
         return str(local_path)
     except Exception as e:
+        # The binding raises the base ``Exception`` for every Rust-side failure
+        # (``to_pyerr``), so there is nothing narrower to catch. Falling back is
+        # deliberate: the workers, and the transformers branch of the KV-bytes
+        # estimate, still resolve the hub ID themselves.
         logger.warning(
-            f"Failed to pre-fetch model: {e}. "
-            "Workers will attempt individual downloads (may cause rate limiting)."
+            "Failed to pre-fetch model: %s. "
+            "Workers will attempt individual downloads (may cause rate limiting).",
+            e,
         )
         return model_path
 

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -5,6 +5,7 @@ import argparse
 import importlib
 import importlib.util
 import json
+import sys
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
 from types import SimpleNamespace
@@ -508,13 +509,43 @@ def test_compute_kv_bytes_uses_transformers_text_config(monkeypatch):
         dtype="bfloat16",
     )
     config = SimpleNamespace(get_text_config=lambda: text_config)
-    monkeypatch.setattr(
-        kv_cache.AutoConfig,
-        "from_pretrained",
-        lambda *args, **kwargs: config,
-    )
+    monkeypatch.setattr(kv_cache, "_load_config", lambda model_path: config)
 
     assert kv_cache.compute_kv_bytes_per_token("model") == 256
+
+
+def test_load_config_stays_offline_for_local_directories(monkeypatch, tmp_path):
+    """A cached snapshot directory must never trigger a hub round trip.
+
+    The mocker resolves hub IDs to the local cache before estimating KV bytes;
+    ``local_files_only`` is what turns that into a no-network load. A bare hub
+    ID keeps resolving through the hub as before.
+    """
+    from dynamo.mocker.utils import kv_cache
+
+    calls: list[tuple[str, dict]] = []
+
+    class FakeAutoConfig:
+        @staticmethod
+        def from_pretrained(model_path, **kwargs):
+            calls.append((model_path, kwargs))
+            return SimpleNamespace()
+
+    monkeypatch.setitem(
+        sys.modules, "transformers", SimpleNamespace(AutoConfig=FakeAutoConfig)
+    )
+
+    kv_cache._load_config(str(tmp_path))
+    kv_cache._load_config("org/model")
+
+    assert calls[0] == (
+        str(tmp_path),
+        {"trust_remote_code": False, "local_files_only": True},
+    )
+    assert calls[1] == (
+        "org/model",
+        {"trust_remote_code": False, "local_files_only": False},
+    )
 
 
 def test_build_mocker_engine_args_estimates_aic_blocks(monkeypatch):

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -497,8 +497,56 @@ def test_get_kv_cache_dtype_bytes_supports_int8():
     assert get_kv_cache_dtype_bytes(cfg, "auto") == 2  # model default dtype
 
 
-def test_compute_kv_bytes_uses_transformers_text_config(monkeypatch):
-    """Use the language-model config when Transformers exposes a multimodal wrapper."""
+def test_compute_kv_bytes_reads_local_config_json_without_transformers(
+    monkeypatch, tmp_path
+):
+    """A local model directory must be sized from config.json alone.
+
+    Importing transformers and instantiating its config classes (which import
+    torch) cost ~12 s per mocker start; the local path must not touch them.
+    """
+    from dynamo.mocker.utils import kv_cache
+
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "num_hidden_layers": 2,
+                "num_key_value_heads": 4,
+                "num_attention_heads": 8,
+                "hidden_size": 64,
+                "torch_dtype": "bfloat16",
+            }
+        )
+    )
+    monkeypatch.setitem(sys.modules, "transformers", None)  # import would fail
+
+    assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) == 256
+
+
+def test_compute_kv_bytes_unwraps_multimodal_text_config_json(tmp_path):
+    from dynamo.mocker.utils import kv_cache
+
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "some_vlm",
+                "vision_config": {"hidden_size": 1},
+                "text_config": {
+                    "num_hidden_layers": 2,
+                    "num_key_value_heads": 4,
+                    "num_attention_heads": 8,
+                    "hidden_size": 64,
+                    "dtype": "bfloat16",
+                },
+            }
+        )
+    )
+
+    assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) == 256
+
+
+def test_compute_kv_bytes_uses_transformers_text_config_for_hub_ids(monkeypatch):
+    """A bare hub ID still resolves through transformers, unwrapping wrappers."""
     from dynamo.mocker.utils import kv_cache
 
     text_config = SimpleNamespace(
@@ -509,43 +557,18 @@ def test_compute_kv_bytes_uses_transformers_text_config(monkeypatch):
         dtype="bfloat16",
     )
     config = SimpleNamespace(get_text_config=lambda: text_config)
-    monkeypatch.setattr(kv_cache, "_load_config", lambda model_path: config)
-
-    assert kv_cache.compute_kv_bytes_per_token("model") == 256
-
-
-def test_load_config_stays_offline_for_local_directories(monkeypatch, tmp_path):
-    """A cached snapshot directory must never trigger a hub round trip.
-
-    The mocker resolves hub IDs to the local cache before estimating KV bytes;
-    ``local_files_only`` is what turns that into a no-network load. A bare hub
-    ID keeps resolving through the hub as before.
-    """
-    from dynamo.mocker.utils import kv_cache
-
-    calls: list[tuple[str, dict]] = []
 
     class FakeAutoConfig:
         @staticmethod
         def from_pretrained(model_path, **kwargs):
-            calls.append((model_path, kwargs))
-            return SimpleNamespace()
+            assert model_path == "org/model"
+            return config
 
     monkeypatch.setitem(
         sys.modules, "transformers", SimpleNamespace(AutoConfig=FakeAutoConfig)
     )
 
-    kv_cache._load_config(str(tmp_path))
-    kv_cache._load_config("org/model")
-
-    assert calls[0] == (
-        str(tmp_path),
-        {"trust_remote_code": False, "local_files_only": True},
-    )
-    assert calls[1] == (
-        "org/model",
-        {"trust_remote_code": False, "local_files_only": False},
-    )
+    assert kv_cache.compute_kv_bytes_per_token("org/model") == 256
 
 
 def test_build_mocker_engine_args_estimates_aic_blocks(monkeypatch):

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -512,7 +512,7 @@ def test_compute_kv_bytes_reads_local_config_json_without_transformers(
             }
         )
     )
-    monkeypatch.setitem(sys.modules, "transformers", None)  # import would fail
+    monkeypatch.setitem(sys.modules, "transformers", None)
 
     assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) == 256
 
@@ -590,7 +590,7 @@ def test_compute_kv_bytes_unwraps_nested_thinker_text_config(monkeypatch, tmp_pa
             }
         )
     )
-    monkeypatch.setitem(sys.modules, "transformers", None)  # import would fail
+    monkeypatch.setitem(sys.modules, "transformers", None)
 
     assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) == 256
 

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -500,11 +500,6 @@ def test_get_kv_cache_dtype_bytes_supports_int8():
 def test_compute_kv_bytes_reads_local_config_json_without_transformers(
     monkeypatch, tmp_path
 ):
-    """A local model directory must be sized from config.json alone.
-
-    Importing transformers and instantiating its config classes (which import
-    torch) cost ~12 s per mocker start; the local path must not touch them.
-    """
     from dynamo.mocker.utils import kv_cache
 
     (tmp_path / "config.json").write_text(

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -16,6 +16,7 @@ import pytest
 from dynamo.llm import EngineType, EntrypointArgs
 from dynamo.mocker import MockEngineArgs
 from dynamo.mocker.args import parse_args
+from dynamo.mocker.utils import kv_cache
 
 MODULE_PATH = Path(__file__).resolve().parents[2] / "config.py"
 SPEC = importlib.util.spec_from_file_location("dynamo_mocker_config", MODULE_PATH)
@@ -500,8 +501,6 @@ def test_get_kv_cache_dtype_bytes_supports_int8():
 def test_compute_kv_bytes_reads_local_config_json_without_transformers(
     monkeypatch, tmp_path
 ):
-    from dynamo.mocker.utils import kv_cache
-
     (tmp_path / "config.json").write_text(
         json.dumps(
             {
@@ -519,8 +518,6 @@ def test_compute_kv_bytes_reads_local_config_json_without_transformers(
 
 
 def test_compute_kv_bytes_unwraps_multimodal_text_config_json(tmp_path):
-    from dynamo.mocker.utils import kv_cache
-
     (tmp_path / "config.json").write_text(
         json.dumps(
             {
@@ -542,8 +539,6 @@ def test_compute_kv_bytes_unwraps_multimodal_text_config_json(tmp_path):
 
 def test_compute_kv_bytes_uses_transformers_text_config_for_hub_ids(monkeypatch):
     """A bare hub ID still resolves through transformers, unwrapping wrappers."""
-    from dynamo.mocker.utils import kv_cache
-
     text_config = SimpleNamespace(
         num_hidden_layers=2,
         num_key_value_heads=4,
@@ -564,6 +559,96 @@ def test_compute_kv_bytes_uses_transformers_text_config_for_hub_ids(monkeypatch)
     )
 
     assert kv_cache.compute_kv_bytes_per_token("org/model") == 256
+
+
+_KV_TEXT_CONFIG = {
+    "num_hidden_layers": 2,
+    "num_key_value_heads": 4,
+    "num_attention_heads": 8,
+    "hidden_size": 64,
+    "torch_dtype": "bfloat16",
+}
+
+
+def _fake_transformers(from_pretrained):
+    return SimpleNamespace(AutoConfig=SimpleNamespace(from_pretrained=from_pretrained))
+
+
+def test_compute_kv_bytes_unwraps_nested_thinker_text_config(monkeypatch, tmp_path):
+    # Qwen2.5-Omni keeps the serving LLM under thinker_config.text_config.
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen2_5_omni",
+                "thinker_config": {
+                    "model_type": "qwen2_5_omni_thinker",
+                    "audio_config": {"d_model": 1},
+                    "vision_config": {"hidden_size": 1},
+                    "text_config": _KV_TEXT_CONFIG,
+                },
+                "talker_config": {"hidden_size": 1, "num_hidden_layers": 1},
+            }
+        )
+    )
+    monkeypatch.setitem(sys.modules, "transformers", None)  # import would fail
+
+    assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) == 256
+
+
+def test_compute_kv_bytes_falls_back_to_transformers_for_gpt2_style_config(
+    monkeypatch, tmp_path
+):
+    # GPT-2 stores n_layer/n_head/n_embd; only transformers' attribute_map maps
+    # them, so the raw config.json must not be trusted for this layout.
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "gpt2", "n_layer": 2, "n_head": 8, "n_embd": 64})
+    )
+    seen = []
+
+    def from_pretrained(model_path, **kwargs):
+        seen.append(model_path)
+        return SimpleNamespace(
+            num_hidden_layers=2, num_attention_heads=8, hidden_size=64
+        )
+
+    monkeypatch.setitem(
+        sys.modules, "transformers", _fake_transformers(from_pretrained)
+    )
+
+    # No num_key_value_heads: defaults to num_attention_heads; no dtype: float16.
+    assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) == 2 * 2 * 8 * 8 * 2
+    assert seen == [str(tmp_path)]
+
+
+def test_compute_kv_bytes_returns_none_for_unreadable_or_incomplete_config(
+    monkeypatch, tmp_path
+):
+    def from_pretrained(model_path, **kwargs):
+        return SimpleNamespace(model_type="unknown")  # no size fields
+
+    monkeypatch.setitem(
+        sys.modules, "transformers", _fake_transformers(from_pretrained)
+    )
+
+    assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) is None  # no config
+
+    (tmp_path / "config.json").write_text("{not json")
+    assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) is None
+
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "unknown"}))
+    assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) is None
+
+
+def test_compute_kv_bytes_propagates_unexpected_errors(monkeypatch):
+    def from_pretrained(model_path, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setitem(
+        sys.modules, "transformers", _fake_transformers(from_pretrained)
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        kv_cache.compute_kv_bytes_per_token("org/model")
 
 
 def test_build_mocker_engine_args_estimates_aic_blocks(monkeypatch):

--- a/components/src/dynamo/mocker/utils/kv_cache.py
+++ b/components/src/dynamo/mocker/utils/kv_cache.py
@@ -1,6 +1,7 @@
 #  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 import os
 from typing import Any
@@ -50,26 +51,60 @@ def get_kv_cache_dtype_bytes(config: Any, kv_cache_dtype: str = "auto") -> int:
     Follows vLLM's --kv-cache-dtype convention.
     """
     if kv_cache_dtype == "auto":
-        dtype = _normalize_dtype_str(getattr(config, "dtype", "float16"))
+        dtype = _normalize_dtype_str(
+            _config_get(config, "dtype", "torch_dtype") or "float16"
+        )
         return TORCH_DTYPE_BYTES.get(dtype, 2)
     return TORCH_DTYPE_BYTES.get(kv_cache_dtype, 2)
 
 
-def _load_config(model_path: str) -> Any:
-    """Load the Hugging Face config for ``model_path``.
+def _config_get(config: Any, *names: str) -> Any:
+    """Return the first non-None value among ``names`` from a dict or config object."""
+    for name in names:
+        value = (
+            config.get(name)
+            if isinstance(config, dict)
+            else getattr(config, name, None)
+        )
+        if value is not None:
+            return value
+    return None
 
-    ``transformers`` is imported here rather than at module import so the mocker
-    only pays for it when the KV-bytes estimate is actually needed. A local
-    directory is loaded with ``local_files_only=True`` so a cached model never
-    triggers a hub round trip; a bare hub ID still resolves through the hub.
+
+# Keys under which multimodal wrappers nest their language-model config. Mirrors
+# what transformers' ``get_text_config`` unwraps for the raw config.json path.
+_TEXT_CONFIG_KEYS = ("text_config", "llm_config", "language_config", "decoder")
+
+
+def _text_config(config: dict[str, Any]) -> dict[str, Any]:
+    if "num_hidden_layers" in config and "hidden_size" in config:
+        return config
+    for key in _TEXT_CONFIG_KEYS:
+        sub = config.get(key)
+        if isinstance(sub, dict) and "num_hidden_layers" in sub:
+            return sub
+    return config
+
+
+def _load_config(model_path: str) -> Any:
+    """Return the model's text config for ``model_path`` as a dict or config object.
+
+    A local directory is read straight from its config.json. Importing
+    ``transformers`` costs several seconds and instantiating its config classes
+    imports ``torch``; together that was ~12 s of every mocker start, so the
+    common path (the mocker resolves hub IDs to the local cache first) must not
+    touch either. A bare hub ID still goes through transformers as before.
     """
+    if os.path.isdir(model_path):
+        with open(os.path.join(model_path, "config.json")) as f:
+            return _text_config(json.load(f))
+
     from transformers import AutoConfig
 
-    return AutoConfig.from_pretrained(
-        model_path,
-        trust_remote_code=False,
-        local_files_only=os.path.isdir(model_path),
-    )
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=False)
+    if hasattr(config, "get_text_config"):
+        config = config.get_text_config()
+    return config
 
 
 def compute_kv_bytes_per_token(
@@ -91,15 +126,12 @@ def compute_kv_bytes_per_token(
     """
     try:
         config = _load_config(model_path)
-        if hasattr(config, "get_text_config"):
-            config = config.get_text_config()
-        num_layers = config.num_hidden_layers
-        num_kv_heads = getattr(config, "num_key_value_heads", None)
+        num_layers = _config_get(config, "num_hidden_layers")
+        num_attention_heads = _config_get(config, "num_attention_heads")
+        num_kv_heads = _config_get(config, "num_key_value_heads", "num_kv_heads")
         if num_kv_heads is None:
-            num_kv_heads = getattr(config, "num_kv_heads", None)
-        if num_kv_heads is None:
-            num_kv_heads = config.num_attention_heads
-        head_dim = config.hidden_size // config.num_attention_heads
+            num_kv_heads = num_attention_heads
+        head_dim = _config_get(config, "hidden_size") // num_attention_heads
         dtype_bytes = get_kv_cache_dtype_bytes(config, kv_cache_dtype)
         kv_bytes = num_layers * 2 * num_kv_heads * head_dim * dtype_bytes
         logger.debug(

--- a/components/src/dynamo/mocker/utils/kv_cache.py
+++ b/components/src/dynamo/mocker/utils/kv_cache.py
@@ -2,9 +2,8 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
 from typing import Any
-
-from transformers import AutoConfig
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +55,23 @@ def get_kv_cache_dtype_bytes(config: Any, kv_cache_dtype: str = "auto") -> int:
     return TORCH_DTYPE_BYTES.get(kv_cache_dtype, 2)
 
 
+def _load_config(model_path: str) -> Any:
+    """Load the Hugging Face config for ``model_path``.
+
+    ``transformers`` is imported here rather than at module import so the mocker
+    only pays for it when the KV-bytes estimate is actually needed. A local
+    directory is loaded with ``local_files_only=True`` so a cached model never
+    triggers a hub round trip; a bare hub ID still resolves through the hub.
+    """
+    from transformers import AutoConfig
+
+    return AutoConfig.from_pretrained(
+        model_path,
+        trust_remote_code=False,
+        local_files_only=os.path.isdir(model_path),
+    )
+
+
 def compute_kv_bytes_per_token(
     model_path: str, kv_cache_dtype: str = "auto"
 ) -> int | None:
@@ -74,7 +90,7 @@ def compute_kv_bytes_per_token(
         KV bytes per token, or None if model config cannot be parsed.
     """
     try:
-        config = AutoConfig.from_pretrained(model_path, trust_remote_code=False)
+        config = _load_config(model_path)
         if hasattr(config, "get_text_config"):
             config = config.get_text_config()
         num_layers = config.num_hidden_layers

--- a/components/src/dynamo/mocker/utils/kv_cache.py
+++ b/components/src/dynamo/mocker/utils/kv_cache.py
@@ -71,32 +71,56 @@ def _config_get(config: Any, *names: str) -> Any:
     return None
 
 
-# Keys under which multimodal wrappers nest their language-model config. Mirrors
-# what transformers' ``get_text_config`` unwraps for the raw config.json path.
-_TEXT_CONFIG_KEYS = ("text_config", "llm_config", "language_config", "decoder")
+# Wrapper keys under which multimodal and multi-module configs nest the language
+# model's config, e.g. ``text_config`` (most VLMs) or ``thinker_config.text_config``
+# (Qwen2.5-Omni). Transformers' ``get_text_config`` picks the sub-config the same
+# way plus per-model overrides; a layout not found here falls back to transformers.
+_TEXT_CONFIG_KEYS = (
+    "text_config",
+    "llm_config",
+    "language_config",
+    "decoder",
+    "thinker_config",
+)
+# A raw config.json is used only when these appear verbatim. Legacy aliases such
+# as GPT-2's ``n_layer``/``n_embd`` are left to transformers' ``attribute_map``.
+_REQUIRED_KEYS = ("num_hidden_layers", "num_attention_heads", "hidden_size")
 
 
-def _text_config(config: dict[str, Any]) -> dict[str, Any]:
-    if "num_hidden_layers" in config and "hidden_size" in config:
+def _find_text_config(config: dict[str, Any], depth: int = 3) -> dict[str, Any] | None:
+    """Return the first dict carrying the required sizes, searching known wrappers."""
+    if all(isinstance(config.get(key), int) for key in _REQUIRED_KEYS):
         return config
+    if depth == 0:
+        return None
     for key in _TEXT_CONFIG_KEYS:
         sub = config.get(key)
-        if isinstance(sub, dict) and "num_hidden_layers" in sub:
-            return sub
-    return config
+        if isinstance(sub, dict):
+            found = _find_text_config(sub, depth - 1)
+            if found is not None:
+                return found
+    return None
 
 
 def _load_config(model_path: str) -> Any:
     """Return the model's text config for ``model_path`` as a dict or config object.
 
-    A local directory is read straight from its config.json so this path imports
-    neither ``transformers`` nor ``torch``. A bare hub ID still goes through
-    transformers as before.
+    A local directory whose config.json has the canonical layout is read directly,
+    so that path imports neither ``transformers`` nor ``torch``. Any other layout,
+    and a bare hub ID, go through transformers as before.
     """
     if os.path.isdir(model_path):
         with open(os.path.join(model_path, "config.json")) as f:
-            return _text_config(json.load(f))
+            text_config = _find_text_config(json.load(f))
+        if text_config is not None:
+            return text_config
+        logger.info(
+            "config.json layout not recognized, resolving %s through transformers",
+            model_path,
+        )
 
+    # Imported here on purpose: transformers pulls in torch, which dominates
+    # mocker startup, and the common path above does not need it.
     from transformers import AutoConfig
 
     config = AutoConfig.from_pretrained(model_path, trust_remote_code=False)
@@ -124,24 +148,38 @@ def compute_kv_bytes_per_token(
     """
     try:
         config = _load_config(model_path)
-        num_layers = _config_get(config, "num_hidden_layers")
-        num_attention_heads = _config_get(config, "num_attention_heads")
-        num_kv_heads = _config_get(config, "num_key_value_heads", "num_kv_heads")
-        if num_kv_heads is None:
-            num_kv_heads = num_attention_heads
-        head_dim = _config_get(config, "hidden_size") // num_attention_heads
-        dtype_bytes = get_kv_cache_dtype_bytes(config, kv_cache_dtype)
-        kv_bytes = num_layers * 2 * num_kv_heads * head_dim * dtype_bytes
-        logger.debug(
-            "Auto-computed kv_bytes_per_token=%s "
-            "(%s layers, %s kv_heads, %s head_dim, %s dtype_bytes)",
-            kv_bytes,
-            num_layers,
-            num_kv_heads,
-            head_dim,
-            dtype_bytes,
-        )
-        return kv_bytes
-    except Exception as e:
+    except (OSError, ValueError, KeyError) as e:
+        # No or unreadable config.json, invalid JSON, or a model type that
+        # transformers does not recognize. Anything else is a bug: let it raise.
         logger.warning("Could not compute kv_bytes_per_token from model config: %s", e)
         return None
+
+    num_layers = _config_get(config, "num_hidden_layers")
+    num_attention_heads = _config_get(config, "num_attention_heads")
+    hidden_size = _config_get(config, "hidden_size")
+    sizes = (num_layers, num_attention_heads, hidden_size)
+    if not all(isinstance(v, int) for v in sizes) or num_attention_heads == 0:
+        logger.warning(
+            "Could not compute kv_bytes_per_token: model config for %s lacks "
+            "layer, head, or hidden sizes (%s)",
+            model_path,
+            sizes,
+        )
+        return None
+
+    num_kv_heads = _config_get(config, "num_key_value_heads", "num_kv_heads")
+    if num_kv_heads is None:
+        num_kv_heads = num_attention_heads
+    head_dim = hidden_size // num_attention_heads
+    dtype_bytes = get_kv_cache_dtype_bytes(config, kv_cache_dtype)
+    kv_bytes = num_layers * 2 * num_kv_heads * head_dim * dtype_bytes
+    logger.debug(
+        "Auto-computed kv_bytes_per_token=%s "
+        "(%s layers, %s kv_heads, %s head_dim, %s dtype_bytes)",
+        kv_bytes,
+        num_layers,
+        num_kv_heads,
+        head_dim,
+        dtype_bytes,
+    )
+    return kv_bytes

--- a/components/src/dynamo/mocker/utils/kv_cache.py
+++ b/components/src/dynamo/mocker/utils/kv_cache.py
@@ -89,11 +89,9 @@ def _text_config(config: dict[str, Any]) -> dict[str, Any]:
 def _load_config(model_path: str) -> Any:
     """Return the model's text config for ``model_path`` as a dict or config object.
 
-    A local directory is read straight from its config.json. Importing
-    ``transformers`` costs several seconds and instantiating its config classes
-    imports ``torch``; together that was ~12 s of every mocker start, so the
-    common path (the mocker resolves hub IDs to the local cache first) must not
-    touch either. A bare hub ID still goes through transformers as before.
+    A local directory is read straight from its config.json so this path imports
+    neither ``transformers`` nor ``torch``. A bare hub ID still goes through
+    transformers as before.
     """
     if os.path.isdir(model_path):
         with open(os.path.join(model_path, "config.json")) as f:

--- a/tests/router/helper.py
+++ b/tests/router/helper.py
@@ -392,9 +392,12 @@ async def poll_for_worker_instances(
     instance_ids: list[int] = []
     start_time = asyncio.get_running_loop().time()
 
+    last_logged = None
     while len(instance_ids) < expected_num_workers:
         instance_ids = client.instance_ids()
-        logger.info(f"Found {len(instance_ids)} instance(s): {instance_ids}")
+        if len(instance_ids) != last_logged:
+            logger.info(f"Found {len(instance_ids)} instance(s): {instance_ids}")
+            last_logged = len(instance_ids)
 
         if len(instance_ids) >= expected_num_workers:
             break
@@ -404,7 +407,10 @@ async def poll_for_worker_instances(
                 f"Timeout waiting for workers. Found {len(instance_ids)} instance(s), expected {expected_num_workers}"
             )
 
-        await asyncio.sleep(1.0)
+        # Registration takes a few seconds; a coarse poll adds up to a full
+        # interval of dead time to every mocker launch. Log only on change so
+        # the finer poll does not flood the test log.
+        await asyncio.sleep(0.25)
 
     return instance_ids
 

--- a/tests/router/helper.py
+++ b/tests/router/helper.py
@@ -396,7 +396,7 @@ async def poll_for_worker_instances(
     while len(instance_ids) < expected_num_workers:
         instance_ids = client.instance_ids()
         if len(instance_ids) != last_logged:
-            logger.info(f"Found {len(instance_ids)} instance(s): {instance_ids}")
+            logger.info("Found %d instance(s): %s", len(instance_ids), instance_ids)
             last_logged = len(instance_ids)
 
         if len(instance_ids) >= expected_num_workers:


### PR DESCRIPTION
## Overview:

### Summary

A mocker process took ~13 s from launch to endpoint registration, ~12 s of it importing `transformers` and `torch` to read a few sizes out of the model's `config.json`. This PR takes that off the common path.

- `components/src/dynamo/mocker/utils/kv_cache.py`: for a local model directory, read `config.json` directly when it has the canonical layout (`num_hidden_layers` / `num_attention_heads` / `hidden_size`, at the top level or under a known wrapper such as `text_config` or `thinker_config.text_config`). Any other layout, and any hub ID, still resolves through `transformers.AutoConfig` exactly as before, so the estimate cannot differ from transformers for a layout it did not recognize. `transformers` is imported lazily. Only expected failures (missing or unreadable `config.json`, invalid JSON, unknown model type) return `None`; anything else propagates.
- `components/src/dynamo/mocker/main.py`: resolve the model to the local HF cache with `fetch_model(ignore_weights=True)` when multiple workers or the KV-bytes estimate need it, and pass that directory to the estimate.
- `tests/router/helper.py`: poll worker registration every 0.25 s instead of 1 s.

Measured in CI (run 34009265647):

| | before | after |
|---|---|---|
| mocker launch to endpoint registration | 12.5 s | 0.8 s |
| `test_router_e2e_with_mockers.py`, mean per test (56 tests) | 27 s | 10.5 s |
| dynamo-runtime sequential CPU job, amd64 | 35.8 min | 18.8 min |
| dynamo-runtime sequential CPU job, arm64 | 44.8 min | 22.0 min |

Every other suite and deployment that launches mockers gets the same faster start.

## Details:

### Validation

- Unit tests in `components/src/dynamo/mocker/tests/unit/test_config.py`: flat `config.json` with `transformers` unimportable; nested `text_config` and `thinker_config.text_config` (Qwen2.5-Omni); hub-ID path and GPT-2-layout fallback through a fake `transformers`, asserting the fallback receives the local directory; `None` for missing, invalid, or incomplete configs; unexpected errors propagate.
- CI: run 34160691007 on the final head (`507f245`) is green across the full matrix (74 min wall). It reproduces the numbers above: mocker launch-to-registration 0.8 s, mocker e2e mean 10.5 s (9.8 min for 56 tests), sequential CPU job 18.9 min amd64 / 21.4 min arm64, all 42 `test_config.py` tests passing. Run 34009265647 (`f16c7d3`) first produced them; run 33992673290 (first commit) was full-matrix green.
- `pre-commit` passes.

## Where should the reviewer start?

`_load_config` and `_find_text_config` in `components/src/dynamo/mocker/utils/kv_cache.py`, then `prefetch_model` in `components/src/dynamo/mocker/main.py`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
