### PR TITLE
fix(profiler): strip stripped-by-design args in both CLI spellings

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -237,6 +237,49 @@ def test_convert_vllm_disagg_decode_removes_disaggregation_role() -> None:
     )
 
 
+def _use_equals_spelling(args: list[str], flag: str) -> None:
+    """Rewrite ``--flag value`` in place as the equivalent ``--flag=value``."""
+    index = args.index(flag)
+    args[index : index + 2] = [f"{flag}={args[index + 1]}"]
+
+
+def test_convert_vllm_prefill_to_aggregated_drops_equals_spelled_role() -> None:
+    """An aggregated candidate must not keep the prefill role it was converted from."""
+    modifier = CONFIG_MODIFIERS["vllm"]
+    config = modifier.load_default_config("disagg")
+    prefill_args = _main_container(_component_by_type(config, "prefill"))["args"]
+    _use_equals_spelling(prefill_args, "--disaggregation-mode")
+
+    converted = modifier.convert_config(config, target=EngineType.PREFILL)
+    converted_args = _main_container(_worker_components(converted)[0])["args"]
+
+    assert not any("--disaggregation-mode" in arg for arg in converted_args)
+
+
+@pytest.mark.parametrize(
+    ("target", "source_type"),
+    [(EngineType.PREFILL, "prefill"), (EngineType.DECODE, "decode")],
+)
+def test_convert_sglang_drops_equals_spelled_disaggregation_args(
+    target: EngineType, source_type: str
+) -> None:
+    """SGLang candidates must not inherit disaggregation wiring in either spelling."""
+    modifier = CONFIG_MODIFIERS["sglang"]
+    config = modifier.load_default_config("disagg")
+    source_args = _main_container(_component_by_type(config, source_type))["args"]
+    for flag in (
+        "--disaggregation-mode",
+        "--disaggregation-transfer-backend",
+        "--disaggregation-bootstrap-port",
+    ):
+        _use_equals_spelling(source_args, flag)
+
+    converted = modifier.convert_config(config, target=target)
+    converted_args = _main_container(_worker_components(converted)[0])["args"]
+
+    assert not any("--disaggregation" in arg for arg in converted_args)
+
+
 def test_build_dgd_config_vllm_disagg_restores_runtime_args() -> None:
     """AIC tuning args must not remove Dynamo's vLLM disaggregation contract."""
     modifier = CONFIG_MODIFIERS["vllm"]

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -260,6 +260,25 @@ def test_convert_vllm_prefill_to_aggregated_drops_equals_spelled_role() -> None:
     ("target", "source_type"),
     [(EngineType.PREFILL, "prefill"), (EngineType.DECODE, "decode")],
 )
+def test_convert_trtllm_drops_equals_spelled_disaggregation_args(
+    target: EngineType, source_type: str
+) -> None:
+    """TensorRT-LLM candidates must not inherit disaggregation wiring either."""
+    modifier = CONFIG_MODIFIERS["trtllm"]
+    config = modifier.load_default_config("disagg")
+    source_args = _main_container(_component_by_type(config, source_type))["args"]
+    _use_equals_spelling(source_args, "--disaggregation-mode")
+
+    converted = modifier.convert_config(config, target=target)
+    converted_args = _main_container(_worker_components(converted)[0])["args"]
+
+    assert not any("--disaggregation" in arg for arg in converted_args)
+
+
+@pytest.mark.parametrize(
+    ("target", "source_type"),
+    [(EngineType.PREFILL, "prefill"), (EngineType.DECODE, "decode")],
+)
 def test_convert_sglang_drops_equals_spelled_disaggregation_args(
     target: EngineType, source_type: str
 ) -> None:

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -256,6 +256,37 @@ def test_convert_vllm_prefill_to_aggregated_drops_equals_spelled_role() -> None:
     assert not any("--disaggregation-mode" in arg for arg in converted_args)
 
 
+def test_sglang_tp_sweep_drops_equals_spelled_parallelism_args() -> None:
+    """A TP sweep point must not inherit the user's DP/EP settings.
+
+    set_config_tp_size strips --dp/--ep so the point is pure tensor parallel, and
+    nothing later re-sets them, so a surviving copy silently changes what was
+    measured while GPU resources are still sized for tp_size alone.
+    """
+    from dynamo.planner.config.defaults import SubComponentType
+
+    modifier = CONFIG_MODIFIERS["sglang"]
+    config = modifier.load_default_config("agg")
+    worker = next(
+        component
+        for component in config["spec"]["components"]
+        if component.get("type") == "worker"
+    )
+    _main_container(worker)["args"].extend(["--dp-size=4", "--ep-size=8"])
+
+    converted = modifier.set_config_tp_size(
+        config, 2, component_type=SubComponentType.DECODE
+    )
+    converted_worker = next(
+        component
+        for component in converted["spec"]["components"]
+        if component.get("type") == "worker"
+    )
+    converted_args = _main_container(converted_worker)["args"]
+
+    assert not any("--dp" in arg or "--ep" in arg for arg in converted_args)
+
+
 @pytest.mark.parametrize(
     ("target", "source_type"),
     [(EngineType.PREFILL, "prefill"), (EngineType.DECODE, "decode")],

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -238,13 +238,11 @@ def test_convert_vllm_disagg_decode_removes_disaggregation_role() -> None:
 
 
 def _use_equals_spelling(args: list[str], flag: str) -> None:
-    """Rewrite ``--flag value`` in place as the equivalent ``--flag=value``."""
     index = args.index(flag)
     args[index : index + 2] = [f"{flag}={args[index + 1]}"]
 
 
 def test_convert_vllm_prefill_to_aggregated_drops_equals_spelled_role() -> None:
-    """An aggregated candidate must not keep the prefill role it was converted from."""
     modifier = CONFIG_MODIFIERS["vllm"]
     config = modifier.load_default_config("disagg")
     prefill_args = _main_container(_component_by_type(config, "prefill"))["args"]
@@ -294,7 +292,6 @@ def test_sglang_tp_sweep_drops_equals_spelled_parallelism_args() -> None:
 def test_convert_trtllm_drops_equals_spelled_disaggregation_args(
     target: EngineType, source_type: str
 ) -> None:
-    """TensorRT-LLM candidates must not inherit disaggregation wiring either."""
     modifier = CONFIG_MODIFIERS["trtllm"]
     config = modifier.load_default_config("disagg")
     source_args = _main_container(_component_by_type(config, source_type))["args"]
@@ -313,7 +310,6 @@ def test_convert_trtllm_drops_equals_spelled_disaggregation_args(
 def test_convert_sglang_drops_equals_spelled_disaggregation_args(
     target: EngineType, source_type: str
 ) -> None:
-    """SGLang candidates must not inherit disaggregation wiring in either spelling."""
     modifier = CONFIG_MODIFIERS["sglang"]
     config = modifier.load_default_config("disagg")
     source_args = _main_container(_component_by_type(config, source_type))["args"]

--- a/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
@@ -16,6 +16,7 @@ from dynamo.profiler.utils.config import (
     get_component_name_by_type,
     get_main_container,
     get_worker_component_from_config,
+    remove_all_argument_occurrences,
     remove_valued_arguments,
     set_argument_value,
     set_unique_argument_value,
@@ -238,9 +239,13 @@ class SGLangConfigModifier(BaseConfigModifier):
             args = break_arguments(args)
 
             # remove disagg flags
-            args = remove_valued_arguments(args, "--disaggregation-mode")
-            args = remove_valued_arguments(args, "--disaggregation-transfer-backend")
-            args = remove_valued_arguments(args, "--disaggregation-bootstrap-port")
+            args = remove_all_argument_occurrences(args, "--disaggregation-mode")
+            args = remove_all_argument_occurrences(
+                args, "--disaggregation-transfer-backend"
+            )
+            args = remove_all_argument_occurrences(
+                args, "--disaggregation-bootstrap-port"
+            )
 
             # disable prefix caching
             if "--disable-radix-cache" not in args:
@@ -276,9 +281,13 @@ class SGLangConfigModifier(BaseConfigModifier):
             args = break_arguments(args)
 
             # remove disagg flags
-            args = remove_valued_arguments(args, "--disaggregation-mode")
-            args = remove_valued_arguments(args, "--disaggregation-transfer-backend")
-            args = remove_valued_arguments(args, "--disaggregation-bootstrap-port")
+            args = remove_all_argument_occurrences(args, "--disaggregation-mode")
+            args = remove_all_argument_occurrences(
+                args, "--disaggregation-transfer-backend"
+            )
+            args = remove_all_argument_occurrences(
+                args, "--disaggregation-bootstrap-port"
+            )
 
             # enable prefix caching
             if "--disable-radix-cache" in args:

--- a/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
@@ -17,7 +17,6 @@ from dynamo.profiler.utils.config import (
     get_main_container,
     get_worker_component_from_config,
     remove_all_argument_occurrences,
-    remove_valued_arguments,
     set_argument_value,
     set_unique_argument_value,
     setup_worker_component_resources,
@@ -339,18 +338,18 @@ class SGLangConfigModifier(BaseConfigModifier):
 
         # Set --tp argument
         args = set_argument_value(args, "--tp", str(tp_size))
-        args = remove_valued_arguments(args, "--tp-size")
-        args = remove_valued_arguments(args, "--tensor-parallel-size")
+        args = remove_all_argument_occurrences(args, "--tp-size")
+        args = remove_all_argument_occurrences(args, "--tensor-parallel-size")
 
         # Remove --ep if present
-        args = remove_valued_arguments(args, "--ep")
-        args = remove_valued_arguments(args, "--ep-size")
-        args = remove_valued_arguments(args, "--expert-parallel-size")
+        args = remove_all_argument_occurrences(args, "--ep")
+        args = remove_all_argument_occurrences(args, "--ep-size")
+        args = remove_all_argument_occurrences(args, "--expert-parallel-size")
 
         # remove --dp if present
-        args = remove_valued_arguments(args, "--dp")
-        args = remove_valued_arguments(args, "--dp-size")
-        args = remove_valued_arguments(args, "--data-parallel-size")
+        args = remove_all_argument_occurrences(args, "--dp")
+        args = remove_all_argument_occurrences(args, "--dp-size")
+        args = remove_all_argument_occurrences(args, "--data-parallel-size")
 
         get_main_container(worker_service).args = args
         return cfg.model_dump()
@@ -376,18 +375,18 @@ class SGLangConfigModifier(BaseConfigModifier):
 
         # 1. Set --tp=tep_size, if not present add it
         args = set_argument_value(args, "--tp", str(tep_size))
-        args = remove_valued_arguments(args, "--tp-size")
-        args = remove_valued_arguments(args, "--tensor-parallel-size")
+        args = remove_all_argument_occurrences(args, "--tp-size")
+        args = remove_all_argument_occurrences(args, "--tensor-parallel-size")
 
         # 2. Set --ep=tep_size, if not present add it
         args = set_argument_value(args, "--ep", str(tep_size))
-        args = remove_valued_arguments(args, "--ep-size")
-        args = remove_valued_arguments(args, "--expert-parallel-size")
+        args = remove_all_argument_occurrences(args, "--ep-size")
+        args = remove_all_argument_occurrences(args, "--expert-parallel-size")
 
         # 3. Remove --dp if present
-        args = remove_valued_arguments(args, "--dp")
-        args = remove_valued_arguments(args, "--dp-size")
-        args = remove_valued_arguments(args, "--data-parallel-size")
+        args = remove_all_argument_occurrences(args, "--dp")
+        args = remove_all_argument_occurrences(args, "--dp-size")
+        args = remove_all_argument_occurrences(args, "--data-parallel-size")
 
         # 4. Remove --enable-dp-attention if present
         if "--enable-dp-attention" in args:
@@ -417,13 +416,13 @@ class SGLangConfigModifier(BaseConfigModifier):
 
         # 1. Set --tp=dep_size
         args = set_argument_value(args, "--tp", str(dep_size))
-        args = remove_valued_arguments(args, "--tp-size")
-        args = remove_valued_arguments(args, "--tensor-parallel-size")
+        args = remove_all_argument_occurrences(args, "--tp-size")
+        args = remove_all_argument_occurrences(args, "--tensor-parallel-size")
 
         # 2. Set --dp=dep_size (data parallelism across experts)
         args = set_argument_value(args, "--dp", str(dep_size))
-        args = remove_valued_arguments(args, "--dp-size")
-        args = remove_valued_arguments(args, "--data-parallel-size")
+        args = remove_all_argument_occurrences(args, "--dp-size")
+        args = remove_all_argument_occurrences(args, "--data-parallel-size")
 
         # 3. Enable --enable-dp-attention
         if "--enable-dp-attention" not in args:
@@ -431,8 +430,8 @@ class SGLangConfigModifier(BaseConfigModifier):
 
         # 4. Set --ep=dep_size (expert parallelism size)
         args = set_argument_value(args, "--ep", str(dep_size))
-        args = remove_valued_arguments(args, "--ep-size")
-        args = remove_valued_arguments(args, "--expert-parallel-size")
+        args = remove_all_argument_occurrences(args, "--ep-size")
+        args = remove_all_argument_occurrences(args, "--expert-parallel-size")
 
         get_main_container(worker_service).args = args
         return cfg.model_dump()

--- a/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
@@ -18,7 +18,7 @@ from dynamo.profiler.utils.config import (
     get_main_container,
     get_worker_component_from_config,
     parse_override_engine_args,
-    remove_valued_arguments,
+    remove_all_argument_occurrences,
     setup_worker_component_resources,
     update_image,
     validate_and_get_worker_args,
@@ -325,8 +325,8 @@ class TrtllmConfigModifier(BaseConfigModifier):
             args = break_arguments(args)
 
             # Remove disaggregation args
-            args = remove_valued_arguments(args, "--disaggregation-mode")
-            args = remove_valued_arguments(args, "--disaggregation-strategy")
+            args = remove_all_argument_occurrences(args, "--disaggregation-mode")
+            args = remove_all_argument_occurrences(args, "--disaggregation-strategy")
 
             args = _merge_overrides_into_args(
                 args,
@@ -368,8 +368,8 @@ class TrtllmConfigModifier(BaseConfigModifier):
             args = break_arguments(args)
 
             # Remove disaggregation args
-            args = remove_valued_arguments(args, "--disaggregation-mode")
-            args = remove_valued_arguments(args, "--disaggregation-strategy")
+            args = remove_all_argument_occurrences(args, "--disaggregation-mode")
+            args = remove_all_argument_occurrences(args, "--disaggregation-strategy")
 
             args = _merge_overrides_into_args(
                 args,

--- a/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
@@ -18,6 +18,7 @@ from dynamo.profiler.utils.config import (
     get_component_name_by_type,
     get_main_container,
     get_worker_component_from_config,
+    remove_all_argument_occurrences,
     remove_valued_arguments,
     set_argument_value,
     set_unique_argument_value,
@@ -109,22 +110,6 @@ def _finalize_disagg_cli_args(args: list[str], role: SubComponentType) -> list[s
             DEFAULT_VLLM_KV_TRANSFER_CONFIG,
         )
     return finalized
-
-
-def _remove_disaggregation_mode_args(args: list[str]) -> list[str]:
-    filtered_args: list[str] = []
-    index = 0
-    while index < len(args):
-        arg = args[index]
-        if arg == "--disaggregation-mode":
-            index += 2
-            continue
-        if arg.startswith("--disaggregation-mode="):
-            index += 1
-            continue
-        filtered_args.append(arg)
-        index += 1
-    return filtered_args
 
 
 class VllmV1ConfigModifier(BaseConfigModifier):
@@ -222,7 +207,7 @@ class VllmV1ConfigModifier(BaseConfigModifier):
             args = break_arguments(args)
 
             # Remove role selection when converting the prefill worker to aggregated.
-            args = remove_valued_arguments(args, "--disaggregation-mode")
+            args = remove_all_argument_occurrences(args, "--disaggregation-mode")
             # AIC may still emit this removed vLLM role flag.
             if "--is-prefill-worker" in args:
                 args.remove("--is-prefill-worker")
@@ -263,7 +248,7 @@ class VllmV1ConfigModifier(BaseConfigModifier):
             args = break_arguments(args)
 
             # The decode candidate is standalone after its prefill peer is removed.
-            args = _remove_disaggregation_mode_args(args)
+            args = remove_all_argument_occurrences(args, "--disaggregation-mode")
 
             # enable prefix caching
             if "--enable-prefix-caching" not in args:

--- a/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
@@ -19,7 +19,6 @@ from dynamo.profiler.utils.config import (
     get_main_container,
     get_worker_component_from_config,
     remove_all_argument_occurrences,
-    remove_valued_arguments,
     set_argument_value,
     set_unique_argument_value,
     setup_worker_component_resources,
@@ -421,7 +420,7 @@ class VllmV1ConfigModifier(BaseConfigModifier):
         args = break_arguments(args)
 
         # Remove --tp alias if present, use --tensor-parallel-size as canonical form
-        args = remove_valued_arguments(args, "--tp")
+        args = remove_all_argument_occurrences(args, "--tp")
         args = set_argument_value(args, "--tensor-parallel-size", str(tp_size))
 
         get_main_container(worker_service).args = args
@@ -457,13 +456,13 @@ class VllmV1ConfigModifier(BaseConfigModifier):
         args = break_arguments(args)
 
         # Remove aliases, use canonical forms
-        args = remove_valued_arguments(args, "--tp")
+        args = remove_all_argument_occurrences(args, "--tp")
         args = set_argument_value(args, "--tensor-parallel-size", str(tep_size))
-        args = remove_valued_arguments(args, "--dp")
+        args = remove_all_argument_occurrences(args, "--dp")
         args = set_argument_value(args, "--data-parallel-size", "1")
 
         # Remove hybrid load balancing flags - not compatible with DP=1
-        args = remove_valued_arguments(args, "--data-parallel-size-local")
+        args = remove_all_argument_occurrences(args, "--data-parallel-size-local")
         if "--data-parallel-hybrid-lb" in args:
             args.remove("--data-parallel-hybrid-lb")
 
@@ -503,9 +502,9 @@ class VllmV1ConfigModifier(BaseConfigModifier):
         args = break_arguments(args)
 
         # Remove aliases, use canonical forms
-        args = remove_valued_arguments(args, "--tp")
+        args = remove_all_argument_occurrences(args, "--tp")
         args = set_argument_value(args, "--tensor-parallel-size", "1")
-        args = remove_valued_arguments(args, "--dp")
+        args = remove_all_argument_occurrences(args, "--dp")
         args = set_argument_value(args, "--data-parallel-size", str(dep_size))
 
         # Handle hybrid load balancing for multinode DEP
@@ -517,7 +516,7 @@ class VllmV1ConfigModifier(BaseConfigModifier):
             )
         else:
             # Remove hybrid-lb flags if not needed or not multinode
-            args = remove_valued_arguments(args, "--data-parallel-size-local")
+            args = remove_all_argument_occurrences(args, "--data-parallel-size-local")
             if "--data-parallel-hybrid-lb" in args:
                 args.remove("--data-parallel-hybrid-lb")
 


### PR DESCRIPTION
## Summary

The profiler shapes a benchmark point by deleting arguments from the user's worker
command: disaggregation wiring when a role is collapsed, and parallelism flags when a
sweep sets its own. Both used `remove_valued_arguments`, which matches only the
`--flag value` spelling and only the first occurrence. Anything written as `--flag=value`
survives into the generated point.

**Disaggregation.** The candidate is profiled as aggregated while the engine still starts
in a disaggregated role; for SGLang it also keeps `--disaggregation-bootstrap-port`,
pointing at a peer that was just deleted from the config. With each backend's stock
`disagg` config rewritten to the equals spelling:

| backend | target | flags surviving into the candidate |
|---|---|---|
| vLLM | `PREFILL` | `--disaggregation-mode=prefill` |
| SGLang | `PREFILL` / `DECODE` | `--disaggregation-mode`, `--disaggregation-transfer-backend`, `--disaggregation-bootstrap-port` |
| TensorRT-LLM | `PREFILL` / `DECODE` | `--disaggregation-mode=<role>` |

**Parallelism.** `set_config_tp_size` and its siblings strip the `--tp`/`--dp`/`--ep`
aliases so the point runs the parallelism the sweep asked for. `--tp` is re-set afterwards
and wins, so it is self-correcting. `--dp` and `--ep` are not: they are removed with no
replacement, so a worker written as `--dp-size=4 --ep-size=8` keeps both through a TP
sweep. The point then runs with data and expert parallelism still on while
`setup_worker_component_resources` has sized GPUs for `tp_size` alone, and the resulting
numbers are recorded against a TP-only configuration.

`config.py` already exports `remove_all_argument_occurrences`, which handles both
spellings and leaves no occurrence behind; its docstring describes this exact hazard, and
`config.py` and `protocol.py` already use it. This routes every deliberate removal in the
three modifiers through it. It ends up being the only remover these modules use, so the
`remove_valued_arguments` import goes with it.

vLLM's decode path was already correct, but it got there in #14351 via
`_remove_disaggregation_mode_args`, a private copy of that shared helper. That copy is
dropped.

## Validation

Local, on macOS. No GPU, cluster, or live engine was involved, so this is config-shaping
only; the engines were never launched.

- `pytest components/src/dynamo/profiler/tests/unit/` — 378 passed. Baseline on clean
  `main` is 372 passed with the same 13 `test_replay_aic_parity.py` failures, which are
  pre-existing and unrelated (verified by running the suite on `upstream/main` before this
  change and getting identical counts). Converting all 28 removal sites introduced no
  regressions.
- Each added test was confirmed to fail with the source reverted and the tests kept, then
  pass with the fix.
- `black` at the pinned `23.1.0` — clean. `pre-commit` on the touched files — clean.

One caveat on how I ran the tests: this file skips unless the `dynamo.llm` bindings
import, and they do not build in my environment (`ImportError: cannot import name
'LoadThresholdConfig' from 'dynamo._core'`). I injected that one missing symbol into
`dynamo._core` before importing so the skip guard passes. Nothing on these code paths
touches it, but CI is the real check here.
