### PR TITLE
fix(llm): allow guided_whitespace_pattern alongside a guided constraint

### DIFF
--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -549,7 +549,6 @@ impl GuidedDecodingOptions {
             self.regex.is_some(),
             self.choice.as_ref().is_some_and(|v| !v.is_empty()),
             self.grammar.is_some(),
-            self.whitespace_pattern.is_some(),
             self.structural_tag.is_some(),
         ]
         .iter()
@@ -1085,6 +1084,39 @@ mod tests {
         // All fields None (should be ok, but not useful)
         let opts = GuidedDecodingOptions::validated(None, None, None, None, None, None, None);
         assert!(opts.is_ok());
+    }
+
+    #[test]
+    fn whitespace_pattern_is_a_modifier_not_a_constraint() {
+        // guided_whitespace_pattern tunes how a json constraint is rendered, so it
+        // must combine with one, the same way guided_decoding_backend does.
+        let opts = GuidedDecodingOptions::validated(
+            Some(serde_json::json!({"type": "object"})),
+            None,
+            None,
+            None,
+            None,
+            Some(" ".to_string()),
+            None,
+        );
+        assert!(
+            opts.is_ok(),
+            "guided_json + whitespace_pattern was rejected"
+        );
+
+        // Two real constraints must still be rejected.
+        assert!(
+            GuidedDecodingOptions::validated(
+                Some(serde_json::json!({"type": "object"})),
+                Some(r"\d+".to_string()),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`guided_whitespace_pattern` tunes how a guided-json constraint is rendered, so it is a
modifier rather than a constraint of its own. It was being counted in
`GuidedDecodingOptions::validate`'s mutual-exclusion check, so a request setting
`guided_json` together with `guided_whitespace_pattern` gets rejected.

Three things say the count is the part that is wrong, not the intent:

- The check's own error message never lists it. It reads "Only one of json, regex, choice,
  grammar, or structural_tag can be set" — those are the five real constraints.
- `guided_decoding_backend`, the other modifier, is correctly left out of the count.
- History: #3231 added `whitespace_pattern` to the count and did not touch the message.
  When #9577 later added `structural_tag`, it updated *both*. The message is meant to
  enumerate exactly what is counted, and this is the one entry that never made it in.

It is reachable from the request path on both endpoints:
`extract_sampling_options` reads `guided_whitespace_pattern`, hands it to
`GuidedDecodingOptions::from_optional`, which calls `validated` and then `validate`. Since
#13790 the resulting error is returned to the caller as a 400 whose message does not name
the field that caused it, which is the confusing part.

This drops `whitespace_pattern` from the count so the check agrees with its own message.
Two real constraints together are still rejected; the added test covers both directions.

## Validation

Local, on macOS, with `--no-default-features` per AGENTS.md.

- `cargo test -p dynamo-llm --no-default-features --lib` — 2233 passed, 1 failed. The one
  failure is `http::service::service_v2::tests::test_oversized_body_returns_json_413`,
  which fails identically on clean `upstream/main` (verified by stashing this change and
  rerunning it), so it is pre-existing and unrelated.
- The added test was confirmed red before the fix: `guided_json + whitespace_pattern was
  rejected`, then green after.
- `cargo fmt --all -- --check` clean; `cargo clippy -p dynamo-llm --no-default-features
  --lib` produces no lints on this code.

No GPU, NIXL, or live engine involved — this is request-validation logic only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Whitespace pattern settings can now be used alongside JSON, regex, choice, grammar, and structural-tag constraints.
  * Conflicting combinations of multiple active guided-decoding constraints continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->