### PR TITLE
docs(operator): drop the link to the deleted checkpoint resource.go

### DIFF
--- a/deploy/operator/docs/footer.md
+++ b/deploy/operator/docs/footer.md
@@ -344,7 +344,6 @@ For users who want to understand the implementation details or contribute to the
 - **Checkpoint / Restore**:
   - [`internal/checkpoint/podspec.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/podspec.go) - Checkpoint env var injection and volume setup
   - [`internal/checkpoint/resolve.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resolve.go) - Checkpoint resolution logic
-  - [`internal/checkpoint/resource.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resource.go) - Checkpoint resource management
 - **Constants & Annotations**: [`internal/consts/consts.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/consts/consts.go) - Defines annotation keys and other constants
 
 ## Notes

--- a/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
+++ b/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
@@ -3865,7 +3865,6 @@ For users who want to understand the implementation details or contribute to the
 - **Checkpoint / Restore**:
   - [`internal/checkpoint/podspec.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/podspec.go) - Checkpoint env var injection and volume setup
   - [`internal/checkpoint/resolve.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resolve.go) - Checkpoint resolution logic
-  - [`internal/checkpoint/resource.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resource.go) - Checkpoint resource management
 - **Constants & Annotations**: [`internal/consts/consts.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/consts/consts.go) - Defines annotation keys and other constants
 
 ## Notes

--- a/docs/fern/pages/reference/kubernetes-api/full-api-reference.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/full-api-reference.mdx
@@ -5079,7 +5079,6 @@ For users who want to understand the implementation details or contribute to the
 - **Checkpoint / Restore**:
   - [`internal/checkpoint/podspec.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/podspec.go) - Checkpoint env var injection and volume setup
   - [`internal/checkpoint/resolve.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resolve.go) - Checkpoint resolution logic
-  - [`internal/checkpoint/resource.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/checkpoint/resource.go) - Checkpoint resource management
 - **Constants & Annotations**: [`internal/consts/consts.go`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/consts/consts.go) - Defines annotation keys and other constants
 
 ### Notes


### PR DESCRIPTION
## Summary

`deploy/operator/internal/checkpoint/resource.go` was deleted by #14076 (`337eeca8db`,
"migrate checkpoints to standalone Snapshot"), but the operator docs footer still links to
it, so the link 404s.

`lychee` reports it six times because the footer is concatenated into two generated pages
and the run's own `out.md` picks it up again. It is currently the only failing link in the
job, and it fails on any PR that runs the check, including ones that touch no docs at all.

The link lives in `deploy/operator/docs/footer.md`, which is the hand-written source. The
two pages that carry it are generated and marked "do not edit", so this removes the entry
from the source and regenerates:

- `cd deploy/operator && make generate-api-docs` rebuilds
  `docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md`
- `python3 docs/fern/scripts/gen_kubernetes_api.py` rebuilds
  `docs/fern/pages/reference/kubernetes-api/full-api-reference.mdx`

Both generators produced exactly the one-line removal and no other drift, so the committed
artifacts were already current.

I did not substitute a replacement link. #14076 redistributed that file's work inside the
`checkpoint` package rather than renaming it, so which of the new files (if any) belongs in
that list is the author's call, and guessing would be worse than a shorter list. The
sibling entries `podspec.go` and `resolve.go` still resolve and are untouched.

## Validation

- Audited every `blob/main/...` link in `footer.md` against `upstream/main` with
  `git cat-file -e`. `resource.go` was the only one missing; the rest all resolve.
- `python3 docs/fern/scripts/gen_kubernetes_api.py --check` exits 0 after the change, so
  the generated output matches its source.
- `pre-commit run --files <the three files>` is clean.
- `grep -rn "checkpoint/resource.go"` across `*.md`, `*.mdx` and `*.yaml` returns nothing.

I have not run `lychee` locally, so the proof that the job goes green is CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed outdated internal implementation references from operator default-values and checkpoint/restore documentation.
  - Removed the corresponding generated documentation link from the Kubernetes API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->