### PR TITLE
refactor(kv-router): remove redundant defensive paths

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md
@@ -49,10 +49,8 @@ operations as the standalone HTTP service.
 
 `SelectionCore::try_new_local` creates an intentionally unsynchronized core for
 tests and local-only use while reporting invalid tracking-hash configuration.
-`SelectionCore::new_local` remains available for compatibility and panics on
-invalid configuration. Production integrations should use
-`SelectionServiceBuilder` so startup recovery, readiness, and background-task
-lifecycle remain consistent with the standalone service.
+Production integrations should use `SelectionServiceBuilder` so startup recovery,
+readiness, and background-task lifecycle remain consistent with the standalone service.
 
 To inject native Rust scorers and a picker while retaining those service-owned capabilities, see [Write Custom Routing Strategies](custom-worker-selection.mdx).
 

--- a/lib/bench/kv_router/mooncake_shared.rs
+++ b/lib/bench/kv_router/mooncake_shared.rs
@@ -161,7 +161,7 @@ impl MooncakeIndexerConfig {
                         )
                     })
                     .collect();
-                Arc::new(BranchShardedIndexer::new_with_options(
+                Arc::new(BranchShardedIndexer::new(
                     shards,
                     self.prefix_depth,
                     block_size,

--- a/lib/kv-router/src/indexer/approximate_lru.rs
+++ b/lib/kv-router/src/indexer/approximate_lru.rs
@@ -457,7 +457,10 @@ impl RankLruState {
     }
 
     fn next_release_epoch(&mut self) -> u64 {
-        self.release_epoch = self.release_epoch.wrapping_add(1).max(1);
+        self.release_epoch = self
+            .release_epoch
+            .checked_add(1)
+            .expect("release epoch exhausted");
         self.release_epoch
     }
 
@@ -501,10 +504,13 @@ impl RankLruState {
                 let copy = self
                     .copies
                     .get_mut(&copy_id)
-                    .ok_or(KvRouterError::IndexerDroppedRequest)?;
+                    .expect("hash index references a missing block copy");
                 if copy.refs == 0 {
                     let key = Self::inactive_key(copy_id, copy);
-                    self.inactive.remove(&key);
+                    assert!(
+                        self.inactive.remove(&key),
+                        "inactive copy is missing from the eviction index"
+                    );
                 }
                 copy.refs += 1;
                 copy.sequence_position = position;
@@ -512,7 +518,10 @@ impl RankLruState {
             } else {
                 prefix_hit = false;
                 let copy_id = self.next_copy_id;
-                self.next_copy_id = self.next_copy_id.wrapping_add(1).max(1);
+                self.next_copy_id = self
+                    .next_copy_id
+                    .checked_add(1)
+                    .expect("block copy ID exhausted");
                 self.copies.insert(
                     copy_id,
                     BlockCopy {
@@ -546,7 +555,10 @@ impl RankLruState {
         let mut lease = self.leases.remove(&attempt_id)?;
         for (offset, block) in blocks.iter().enumerate() {
             let copy_id = self.next_copy_id;
-            self.next_copy_id = self.next_copy_id.wrapping_add(1).max(1);
+            self.next_copy_id = self
+                .next_copy_id
+                .checked_add(1)
+                .expect("block copy ID exhausted");
             self.copies.insert(
                 copy_id,
                 BlockCopy {
@@ -577,14 +589,16 @@ impl RankLruState {
             return Vec::new();
         };
         let release_epoch = self.next_release_epoch();
-        self.private_blocks = self.private_blocks.saturating_sub(lease.private_blocks);
+        self.private_blocks = self
+            .private_blocks
+            .checked_sub(lease.private_blocks)
+            .expect("lease private blocks exceed rank total");
         for copy_id in lease.copies {
-            let Some(copy) = self.copies.get_mut(&copy_id) else {
-                continue;
-            };
-            if copy.refs == 0 {
-                continue;
-            }
+            let copy = self
+                .copies
+                .get_mut(&copy_id)
+                .expect("lease references a missing block copy");
+            assert_ne!(copy.refs, 0, "lease references an inactive block copy");
             copy.refs -= 1;
             if copy.refs == 0 {
                 copy.release_epoch = release_epoch;
@@ -601,24 +615,31 @@ impl RankLruState {
             let Some(key) = self.inactive.pop_first() else {
                 break;
             };
-            let Some(copy) = self.copies.remove(&key.copy_id) else {
-                continue;
-            };
-            evicted_blocks = evicted_blocks.saturating_add(1);
-            debug_assert_eq!(copy.refs, 0);
-            let mut remove_hash = false;
-            if let Some(copies) = self.by_hash.get_mut(&copy.sequence_hash) {
-                if let Some(position) = copies.iter().position(|id| *id == key.copy_id) {
-                    copies.swap_remove(position);
-                }
-                remove_hash = copies.is_empty();
-            }
+            let copy = self
+                .copies
+                .remove(&key.copy_id)
+                .expect("eviction index references a missing block copy");
+            evicted_blocks += 1;
+            assert_eq!(copy.refs, 0, "eviction index references an active copy");
+            let copies = self
+                .by_hash
+                .get_mut(&copy.sequence_hash)
+                .expect("block copy is missing from the hash index");
+            let position = copies
+                .iter()
+                .position(|id| *id == key.copy_id)
+                .expect("block copy is missing from its hash-index entry");
+            copies.swap_remove(position);
+            let remove_hash = copies.is_empty();
             if remove_hash {
                 self.by_hash.remove(&copy.sequence_hash);
                 removed_hashes.push(copy.sequence_hash);
             }
         }
-        self.evicted_blocks = self.evicted_blocks.saturating_add(evicted_blocks);
+        self.evicted_blocks = self
+            .evicted_blocks
+            .checked_add(evicted_blocks)
+            .expect("rank eviction counter overflowed");
         removed_hashes
     }
 
@@ -783,7 +804,7 @@ impl ApproximateLruLane {
                             let before = state.evicted_blocks;
                             state.capacity = capacity;
                             let removed = state.reconcile();
-                            (removed, state.evicted_blocks.saturating_sub(before))
+                            (removed, state.evicted_blocks - before)
                         }
                         Some(WorkerRetentionState::TtlFallback { .. }) => (Vec::new(), 0),
                         None => {
@@ -871,7 +892,7 @@ impl ApproximateLruLane {
                 };
                 let before = state.evicted_blocks;
                 let removed = state.acquire(attempt_id, &blocks, private_blocks)?;
-                let evicted = state.evicted_blocks.saturating_sub(before);
+                let evicted = state.evicted_blocks - before;
                 self.record_evictions(evicted);
                 self.push_store_event(&mut events, worker, None, blocks);
                 self.push_remove_event(&mut events, worker, removed);
@@ -900,7 +921,7 @@ impl ApproximateLruLane {
                     if let Some(removed) =
                         state.materialize(attempt_id, &blocks, start_position, private_blocks)
                     {
-                        let evicted = state.evicted_blocks.saturating_sub(before);
+                        let evicted = state.evicted_blocks - before;
                         self.record_evictions(evicted);
                         self.push_store_event(&mut events, worker, parent_hash, blocks);
                         self.push_remove_event(&mut events, worker, removed);
@@ -922,7 +943,7 @@ impl ApproximateLruLane {
                 {
                     let before = state.evicted_blocks;
                     let removed = state.release(attempt_id);
-                    let evicted = state.evicted_blocks.saturating_sub(before);
+                    let evicted = state.evicted_blocks - before;
                     self.record_evictions(evicted);
                     self.push_remove_event(&mut events, worker, removed);
                 }

--- a/lib/kv-router/src/indexer/branch_sharded.rs
+++ b/lib/kv-router/src/indexer/branch_sharded.rs
@@ -30,10 +30,7 @@ use rustc_hash::{FxBuildHasher, FxHashSet};
 #[cfg(feature = "bench")]
 use super::ShardedIndexerMetrics;
 use super::shard_handle::AsyncShardHandle;
-use super::{
-    AnchorCapableSyncIndexer, AnchorRef, AnchorTask, KvIndexerInterface, KvRouterError,
-    ShardSizeSnapshot, ThreadPoolIndexer,
-};
+use super::{AnchorRef, AnchorTask, KvIndexerInterface, KvRouterError, ShardSizeSnapshot};
 use crate::protocols::*;
 
 type WorkerRoutingLookup = DashMap<ExternalSequenceBlockHash, BlockRoutingEntry, FxBuildHasher>;
@@ -92,12 +89,16 @@ struct BlockRoutingEntry {
     affects_router_node: bool,
 }
 
-struct StoreRouteDecision {
-    shard_idx: usize,
-    anchor: Option<AnchorRef>,
-    anchor_block_offset: usize,
-    rewrite_for_anchor: bool,
-    skip_backend: bool,
+enum StoreRouteDecision {
+    RouterOnly,
+    Direct {
+        shard_idx: usize,
+    },
+    Anchored {
+        shard_idx: usize,
+        anchor: AnchorRef,
+        block_offset: usize,
+    },
 }
 
 /// Branch-sharded wrapper over N `AsyncShardHandle` shard backends.
@@ -121,47 +122,6 @@ pub struct BranchShardedIndexer<S: AsyncShardHandle> {
     metrics: ShardedIndexerMetrics,
 }
 
-/// Compatibility alias for the previous implementation name.
-#[deprecated(note = "use BranchShardedIndexer<ThreadPoolIndexer<T>> instead")]
-pub type AnchorAwareBranchShardedIndexer<T> = BranchShardedIndexer<ThreadPoolIndexer<T>>;
-
-impl<T: AnchorCapableSyncIndexer> BranchShardedIndexer<ThreadPoolIndexer<T>> {
-    /// Source-compatibility constructor: accepts raw `T` backends and wraps
-    /// each in a [`ThreadPoolIndexer`] with 2 worker threads.
-    ///
-    /// This shim exists because the former `AnchorAwareBranchShardedIndexer`
-    /// accepted `Vec<T>` directly.  Prefer the primary
-    /// [`BranchShardedIndexer::new`] constructor with pre-built
-    /// [`ThreadPoolIndexer`] shards when you need control over thread-pool
-    /// size.
-    #[deprecated(
-        note = "build ThreadPoolIndexers explicitly (choosing num_threads) and call \
-                BranchShardedIndexer::new"
-    )]
-    pub fn new_from_backends(backends: Vec<T>, prefix_depth: usize, kv_block_size: u32) -> Self {
-        let shards = backends
-            .into_iter()
-            .map(|b| ThreadPoolIndexer::new(b, 2, kv_block_size))
-            .collect();
-        BranchShardedIndexer::new(shards, prefix_depth, kv_block_size)
-    }
-
-    /// Alias of [`Self::new_from_backends`] for drop-in replacement of the
-    /// former `new_with_options` call pattern.
-    #[deprecated(
-        note = "build ThreadPoolIndexers explicitly (choosing num_threads) and call \
-                BranchShardedIndexer::new_with_options"
-    )]
-    #[allow(deprecated)]
-    pub fn new_with_options_from_backends(
-        backends: Vec<T>,
-        prefix_depth: usize,
-        kv_block_size: u32,
-    ) -> Self {
-        Self::new_from_backends(backends, prefix_depth, kv_block_size)
-    }
-}
-
 impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
     /// Create a branch-sharded indexer from pre-built shard handles.
     pub fn new(shards: Vec<S>, prefix_depth: usize, kv_block_size: u32) -> Self {
@@ -180,11 +140,6 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
             #[cfg(feature = "bench")]
             metrics: ShardedIndexerMetrics::new(),
         }
-    }
-
-    /// Alias for [`BranchShardedIndexer::new`].
-    pub fn new_with_options(shards: Vec<S>, prefix_depth: usize, kv_block_size: u32) -> Self {
-        Self::new(shards, prefix_depth, kv_block_size)
     }
 
     fn static_divergent_shard(
@@ -206,16 +161,17 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
         if slot >= parent_shard { slot + 1 } else { slot }
     }
 
-    fn anchor_for_parent(&self, parent: &RoutingNode) -> Option<AnchorRef> {
-        if parent.depth == 0 {
-            return None;
-        }
-        let anchor_id = parent.external_hash?;
-        Some(AnchorRef {
+    fn anchor_for_parent(&self, parent: &RoutingNode) -> AnchorRef {
+        let anchor_id = parent
+            .external_hash
+            .expect("non-root routing node must have an external hash");
+        AnchorRef {
             anchor_id,
-            anchor_local_hash: parent.key.unwrap_or(LocalBlockHash(anchor_id.0)),
+            anchor_local_hash: parent
+                .key
+                .expect("non-root routing node must have a local hash"),
             anchor_depth: parent.depth,
-        })
+        }
     }
 
     fn get_or_create_child(
@@ -263,19 +219,18 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
         &self,
         worker: WorkerWithDpRank,
         store_data: &KvCacheStoreData,
-    ) -> StoreRouteDecision {
-        let mut start_depth = 0usize;
-        let mut node = self.root.clone();
-
-        let parent_entry = store_data.parent_hash.and_then(|parent_hash| {
-            self.worker_block_index
-                .get(&worker)
-                .and_then(|lookup| lookup.get(&parent_hash).map(|entry| entry.clone()))
-        });
-        if let Some(entry) = parent_entry {
-            node = entry.routing_node.clone();
-            start_depth = entry.sequence_depth;
-        }
+    ) -> Result<StoreRouteDecision, KvRouterError> {
+        let (mut node, start_depth) = match store_data.parent_hash {
+            Some(parent_hash) => {
+                let entry = self
+                    .worker_block_index
+                    .get(&worker)
+                    .and_then(|lookup| lookup.get(&parent_hash).map(|entry| entry.clone()))
+                    .ok_or(KvRouterError::BlockNotFound)?;
+                (entry.routing_node, entry.sequence_depth)
+            }
+            None => (self.root.clone(), 0),
+        };
 
         let lookup = self.worker_lookup(worker);
 
@@ -308,24 +263,21 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
             .min(store_data.blocks.len());
         let needs_boundary_anchor =
             start_depth <= self.max_routing_depth && router_owned_blocks < store_data.blocks.len();
-        let anchor = needs_boundary_anchor
-            .then(|| self.anchor_for_parent(&node))
-            .flatten();
-        let (anchor_block_offset, rewrite_for_anchor) = if anchor.is_some() {
-            (router_owned_blocks, true)
-        } else {
-            (0, false)
-        };
         let skip_backend =
             start_depth <= self.max_routing_depth && router_owned_blocks >= store_data.blocks.len();
 
-        StoreRouteDecision {
-            shard_idx,
-            anchor,
-            anchor_block_offset,
-            rewrite_for_anchor,
-            skip_backend,
+        if skip_backend {
+            return Ok(StoreRouteDecision::RouterOnly);
         }
+        if needs_boundary_anchor {
+            let anchor = self.anchor_for_parent(&node);
+            return Ok(StoreRouteDecision::Anchored {
+                shard_idx,
+                anchor,
+                block_offset: router_owned_blocks,
+            });
+        }
+        Ok(StoreRouteDecision::Direct { shard_idx })
     }
 
     fn add_active_scores(
@@ -391,14 +343,8 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
             .counters
             .find_match_dispatches
             .fetch_add(1, Ordering::Relaxed);
-        let Some(anchor) = self.anchor_for_parent(&node) else {
-            return Ok(scores);
-        };
-        let suffix: &[LocalBlockHash] = if anchor.anchor_depth <= sequence.len() {
-            &sequence[anchor.anchor_depth..]
-        } else {
-            &[]
-        };
+        let anchor = self.anchor_for_parent(&node);
+        let suffix = &sequence[anchor.anchor_depth..];
         let shard = Arc::clone(&self.shards[shard_idx]);
         let mut shard_scores = shard
             .as_ref()
@@ -414,7 +360,12 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
         Ok(scores)
     }
 
-    fn ensure_worker_anchor(&self, shard_idx: usize, worker: WorkerWithDpRank, anchor: AnchorRef) {
+    fn ensure_worker_anchor(
+        &self,
+        shard_idx: usize,
+        worker: WorkerWithDpRank,
+        anchor: AnchorRef,
+    ) -> bool {
         let anchor_key = (shard_idx, anchor.anchor_id.0);
 
         // Fast-path dedup: read lock only, no write.
@@ -428,7 +379,7 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
                 .counters
                 .anchor_reuses
                 .fetch_add(1, Ordering::Relaxed);
-            return;
+            return true;
         }
 
         let task = AnchorTask {
@@ -460,9 +411,11 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
                 }
                 #[cfg(not(feature = "bench"))]
                 let _ = newly_inserted;
+                true
             }
             Err(error) => {
                 tracing::warn!(?error, shard_idx, ?worker, "Failed to enqueue anchor");
+                false
             }
         }
     }
@@ -488,24 +441,21 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
     }
 
     fn rewritten_store_event(
-        &self,
         mut event: RouterEvent,
-        decision: &StoreRouteDecision,
-    ) -> Option<RouterEvent> {
-        let anchor = decision.anchor?;
+        anchor: AnchorRef,
+        block_offset: usize,
+    ) -> RouterEvent {
         let KvCacheEventData::Stored(store_data) = &mut event.event.data else {
-            return None;
+            unreachable!("only stored events are routed through the store path");
         };
-        if decision.anchor_block_offset > store_data.blocks.len() {
-            return None;
-        }
-        let blocks = store_data.blocks.split_off(decision.anchor_block_offset);
-        if blocks.is_empty() {
-            return None;
-        }
+        assert!(
+            block_offset < store_data.blocks.len(),
+            "anchored store must retain a non-empty backend suffix"
+        );
+        let blocks = store_data.blocks.split_off(block_offset);
         store_data.parent_hash = Some(anchor.anchor_id);
         store_data.blocks = blocks;
-        Some(event)
+        event
     }
 
     fn remove_worker_entries(&self, worker: WorkerWithDpRank) {
@@ -616,21 +566,37 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
             return;
         };
         let worker = WorkerWithDpRank::new(event.worker_id, event.event.dp_rank);
-        let decision = self.route_stored(worker, store_data);
-
-        if decision.skip_backend {
-            return;
-        }
-
-        if let (true, Some(anchor)) = (decision.rewrite_for_anchor, decision.anchor) {
-            self.ensure_worker_anchor(decision.shard_idx, worker, anchor);
-            if let Some(rewritten) = self.rewritten_store_event(event, &decision) {
-                self.shards[decision.shard_idx].apply_event(rewritten).await;
+        let decision = match self.route_stored(worker, store_data) {
+            Ok(decision) => decision,
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    worker_id = ?worker.worker_id,
+                    dp_rank = worker.dp_rank,
+                    event_id = event.event.event_id,
+                    parent_hash = ?store_data.parent_hash,
+                    "Failed to route stored event"
+                );
+                return;
             }
-            return;
-        }
+        };
 
-        self.shards[decision.shard_idx].apply_event(event).await;
+        match decision {
+            StoreRouteDecision::RouterOnly => {}
+            StoreRouteDecision::Direct { shard_idx } => {
+                self.shards[shard_idx].apply_event(event).await;
+            }
+            StoreRouteDecision::Anchored {
+                shard_idx,
+                anchor,
+                block_offset,
+            } => {
+                if self.ensure_worker_anchor(shard_idx, worker, anchor) {
+                    let rewritten = Self::rewritten_store_event(event, anchor, block_offset);
+                    self.shards[shard_idx].apply_event(rewritten).await;
+                }
+            }
+        }
     }
 
     async fn apply_removed(&self, event: RouterEvent) {
@@ -1000,7 +966,9 @@ mod tests {
     use std::sync::{Arc, Barrier};
 
     use super::*;
-    use crate::indexer::concurrent_radix_tree_compressed::ConcurrentRadixTreeCompressed;
+    use crate::indexer::{
+        ThreadPoolIndexer, concurrent_radix_tree_compressed::ConcurrentRadixTreeCompressed,
+    };
     use crate::test_utils::{remove_event, router_event, stored_blocks_with_sequence_hashes};
     use tokio::sync::Barrier as AsyncBarrier;
 
@@ -1340,9 +1308,7 @@ mod tests {
 
         let b = child(&child(&index.root, 1), 2);
         let e = child(&b, 5);
-        let anchor = index
-            .anchor_for_parent(&e)
-            .expect("expected boundary anchor");
+        let anchor = index.anchor_for_parent(&e);
         let shard_idx = e.shard();
 
         let full = local_hashes(&[1, 2, 5, 7]);

--- a/lib/kv-router/src/indexer/branch_sharded.rs
+++ b/lib/kv-router/src/indexer/branch_sharded.rs
@@ -30,7 +30,9 @@ use rustc_hash::{FxBuildHasher, FxHashSet};
 #[cfg(feature = "bench")]
 use super::ShardedIndexerMetrics;
 use super::shard_handle::AsyncShardHandle;
-use super::{AnchorRef, AnchorTask, KvIndexerInterface, KvRouterError, ShardSizeSnapshot};
+use super::{
+    AnchorRef, AnchorTask, KvIndexerInterface, KvRouterError, ShardSizeSnapshot, ThreadPoolIndexer,
+};
 use crate::protocols::*;
 
 type WorkerRoutingLookup = DashMap<ExternalSequenceBlockHash, BlockRoutingEntry, FxBuildHasher>;
@@ -121,6 +123,10 @@ pub struct BranchShardedIndexer<S: AsyncShardHandle> {
     #[cfg(feature = "bench")]
     metrics: ShardedIndexerMetrics,
 }
+
+/// Compatibility alias for the previous implementation name.
+#[deprecated(note = "use BranchShardedIndexer<ThreadPoolIndexer<T>> instead")]
+pub type AnchorAwareBranchShardedIndexer<T> = BranchShardedIndexer<ThreadPoolIndexer<T>>;
 
 impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
     /// Create a branch-sharded indexer from pre-built shard handles.

--- a/lib/kv-router/src/indexer/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree.rs
@@ -354,20 +354,7 @@ impl ConcurrentRadixTree {
 
                 // parent_guard is dropped at the end of this block
                 match parent_guard.children.get(&block_data.tokens_hash) {
-                    Some(existing) => {
-                        {
-                            let existing_guard = existing.read();
-                            if existing_guard.block_hash != Some(block_data.block_hash) {
-                                duplicate_store = false;
-                                tracing::warn!(
-                                    expected = ?block_data.block_hash,
-                                    actual = ?existing_guard.block_hash,
-                                    "block_hash mismatch: sequence hashes should be uniform across workers"
-                                );
-                            }
-                        }
-                        existing.clone()
-                    }
+                    Some(existing) => existing.clone(),
                     None => {
                         duplicate_store = false;
                         // Reuse from lookup or create new

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/children.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/children.rs
@@ -146,31 +146,29 @@ impl NodeChildren {
     }
 
     pub(super) fn insert(&self, key: LocalBlockHash, child: SharedNode) -> Option<SharedNode> {
-        loop {
-            let current = self.state.load_full();
-            if let ChildrenState::Sharded(children) = current.as_ref() {
-                return children.insert(key, child);
-            }
-
-            let mut entries = Self::clone_compact_entries(current.as_ref());
-            let previous = match entries.binary_search_by_key(&key, |entry| entry.hash) {
-                Ok(index) => Some(std::mem::replace(&mut entries[index].node, child.clone())),
-                Err(index) => {
-                    entries.insert(
-                        index,
-                        ChildEntry {
-                            hash: key,
-                            node: child.clone(),
-                        },
-                    );
-                    None
-                }
-            };
-
-            if self.compare_and_swap(&current, Self::state_from_entries(entries)) {
-                return previous;
-            }
+        let current = self.state.load_full();
+        if let ChildrenState::Sharded(children) = current.as_ref() {
+            return children.insert(key, child);
         }
+
+        let mut entries = Self::clone_compact_entries(current.as_ref());
+        let previous = match entries.binary_search_by_key(&key, |entry| entry.hash) {
+            Ok(index) => Some(std::mem::replace(&mut entries[index].node, child.clone())),
+            Err(index) => {
+                entries.insert(
+                    index,
+                    ChildEntry {
+                        hash: key,
+                        node: child,
+                    },
+                );
+                None
+            }
+        };
+
+        self.state
+            .store(Arc::new(Self::state_from_entries(entries)));
+        previous
     }
 
     pub(super) fn insert_if_absent(
@@ -220,70 +218,61 @@ impl NodeChildren {
     }
 
     pub(super) fn remove(&self, key: &LocalBlockHash) -> Option<SharedNode> {
-        loop {
-            let current = self.state.load_full();
-            let remove_index = match current.as_ref() {
-                ChildrenState::Empty => return None,
-                ChildrenState::Singleton(entry) => {
-                    if entry.hash != *key {
-                        return None;
-                    }
-                    0
+        let current = self.state.load_full();
+        let remove_index = match current.as_ref() {
+            ChildrenState::Empty => return None,
+            ChildrenState::Singleton(entry) => {
+                if entry.hash != *key {
+                    return None;
                 }
-                ChildrenState::Small(entries) => {
-                    let Ok(index) = entries.binary_search_by_key(key, |entry| entry.hash) else {
-                        return None;
-                    };
-                    index
-                }
-                ChildrenState::Sharded(children) => {
-                    return children.remove(key).map(|(_, child)| child);
-                }
-            };
-
-            let mut entries = Self::clone_compact_entries(current.as_ref());
-            let removed = entries.remove(remove_index);
-            if self.compare_and_swap(&current, Self::compact_state(entries)) {
-                return Some(removed.node);
+                0
             }
-        }
+            ChildrenState::Small(entries) => {
+                let Ok(index) = entries.binary_search_by_key(key, |entry| entry.hash) else {
+                    return None;
+                };
+                index
+            }
+            ChildrenState::Sharded(children) => {
+                return children.remove(key).map(|(_, child)| child);
+            }
+        };
+
+        let mut entries = Self::clone_compact_entries(current.as_ref());
+        let removed = entries.remove(remove_index);
+        self.state.store(Arc::new(Self::compact_state(entries)));
+        Some(removed.node)
     }
 
     pub(super) fn clear(&self) -> bool {
-        loop {
-            let current = self.state.load_full();
-            match current.as_ref() {
-                ChildrenState::Empty => return false,
-                ChildrenState::Sharded(children) => {
-                    let had_children = !children.is_empty();
-                    children.clear();
-                    return had_children;
-                }
-                ChildrenState::Singleton(_) | ChildrenState::Small(_) => {
-                    if self.compare_and_swap(&current, ChildrenState::Empty) {
-                        return true;
-                    }
-                }
+        let current = self.state.load_full();
+        match current.as_ref() {
+            ChildrenState::Empty => false,
+            ChildrenState::Sharded(children) => {
+                let had_children = !children.is_empty();
+                children.clear();
+                had_children
+            }
+            ChildrenState::Singleton(_) | ChildrenState::Small(_) => {
+                self.state.store(Arc::new(ChildrenState::Empty));
+                true
             }
         }
     }
 
     /// Transfers the current state while the owning node's exclusive shape gate is held.
     pub(super) fn transfer_for_split(&self) -> Self {
-        loop {
-            let current = self.state.load_full();
-            let replacement = match current.as_ref() {
-                ChildrenState::Sharded(_) => {
-                    ChildrenState::Sharded(ShardedChildren::with_hasher(FxBuildHasher))
-                }
-                ChildrenState::Empty | ChildrenState::Singleton(_) | ChildrenState::Small(_) => {
-                    ChildrenState::Empty
-                }
-            };
-            if self.compare_and_swap(&current, replacement) {
-                return Self::from_state(current);
+        let current = self.state.load_full();
+        let replacement = match current.as_ref() {
+            ChildrenState::Sharded(_) => {
+                ChildrenState::Sharded(ShardedChildren::with_hasher(FxBuildHasher))
             }
-        }
+            ChildrenState::Empty | ChildrenState::Singleton(_) | ChildrenState::Small(_) => {
+                ChildrenState::Empty
+            }
+        };
+        self.state.store(Arc::new(replacement));
+        Self::from_state(current)
     }
 
     fn clone_compact_entries(state: &ChildrenState) -> Vec<ChildEntry> {
@@ -309,24 +298,12 @@ impl NodeChildren {
 
     fn compact_state(mut entries: Vec<ChildEntry>) -> ChildrenState {
         debug_assert!(entries.windows(2).all(|pair| pair[0].hash < pair[1].hash));
-        if entries.is_empty() {
-            return ChildrenState::Empty;
+        debug_assert!(entries.len() <= SMALL_CHILD_LIMIT);
+        match entries.len() {
+            0 => ChildrenState::Empty,
+            1 => ChildrenState::Singleton(entries.remove(0)),
+            _ => ChildrenState::Small(entries.into_boxed_slice()),
         }
-        if entries.len() == 1 {
-            if let Some(entry) = entries.pop() {
-                return ChildrenState::Singleton(entry);
-            }
-            return ChildrenState::Empty;
-        }
-        if entries.len() <= SMALL_CHILD_LIMIT {
-            return ChildrenState::Small(entries.into_boxed_slice());
-        }
-
-        let sharded = ShardedChildren::with_hasher(FxBuildHasher);
-        for entry in entries {
-            sharded.insert(entry.hash, entry.node);
-        }
-        ChildrenState::Sharded(sharded)
     }
 
     fn compare_and_swap(&self, current: &Arc<ChildrenState>, next: ChildrenState) -> bool {

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
@@ -118,17 +118,14 @@ impl Node {
         }
     }
 
-    fn with_shape_plan<R>(
-        &self,
-        plan: impl FnOnce(&NodeState, &NodeChildren, u64) -> R,
-    ) -> Option<R> {
+    fn with_shape_plan<R>(&self, plan: impl FnOnce(&NodeState, &NodeChildren, u64) -> R) -> R {
         // NOTE(perf): Replacing these shape-gated reads with state-only snapshots
         // was neutral or regressive, and profiling did not identify the RwLock
         // as a hotspot. Re-profile before removing this shape read.
         let _gate = self.shape_gate.read();
         let shape_version = self.shape_version.load(Ordering::Acquire);
         let state = self.state.read();
-        Some(plan(&state, &self.children, shape_version))
+        plan(&state, &self.children, shape_version)
     }
 
     fn validate_shape_read<R>(&self, expected_version: u64, f: impl FnOnce() -> R) -> Option<R> {
@@ -396,7 +393,6 @@ impl Node {
                 action,
             })
         })
-        .flatten()
     }
 
     pub(super) fn apply_store_parent_edge_plan(
@@ -452,31 +448,21 @@ impl Node {
     }
 
     pub(super) fn scan_store_prefix(&self, blocks: &[KvCacheStoredBlockData]) -> ChildEdgeScan {
-        loop {
-            if let Some(scan) = self.with_shape_plan(|state, _children, shape_version| {
-                let mut match_len = 0;
-                let mut block_hash_mismatch = None;
-
-                for (edge_elem, block) in state.edge.iter().zip(blocks.iter()) {
-                    if edge_elem.0 != block.tokens_hash {
-                        break;
-                    }
-                    if edge_elem.1 != block.block_hash && block_hash_mismatch.is_none() {
-                        block_hash_mismatch = Some((block.block_hash, edge_elem.1));
-                    }
-                    match_len += 1;
+        self.with_shape_plan(|state, _children, shape_version| {
+            let mut match_len = 0;
+            for (edge_elem, block) in state.edge.iter().zip(blocks) {
+                if edge_elem.0 != block.tokens_hash {
+                    break;
                 }
-
-                ChildEdgeScan {
-                    shape_version,
-                    edge_len: state.edge.len(),
-                    match_len,
-                    block_hash_mismatch,
-                }
-            }) {
-                return scan;
+                match_len += 1;
             }
-        }
+
+            ChildEdgeScan {
+                shape_version,
+                edge_len: state.edge.len(),
+                match_len,
+            }
+        })
     }
 
     pub(super) fn cover_prefix_for_worker_with_version(
@@ -562,7 +548,6 @@ impl Node {
 
             ParentChildPlan::MissingChild { shape_version }
         })
-        .unwrap_or(ParentChildPlan::Stale)
     }
 
     pub(super) fn insert_child_if_still_missing(

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/store.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/store.rs
@@ -250,12 +250,6 @@ impl ConcurrentRadixTreeCompressed {
             .child_lookup_plan(cursor.last_ext_hash, first_local);
 
         let shape_version = match plan {
-            ParentChildPlan::Stale => {
-                return Ok(StoreInsertStep::RetryParent {
-                    parent: cursor.parent.clone(),
-                    parent_is_anchor: cursor.parent_is_anchor,
-                });
-            }
             ParentChildPlan::StaleParent { hash } => {
                 let Some(resolved) =
                     self.resolve_lookup(lookup, worker, hash, LookupRepairDirection::TowardTail)
@@ -423,15 +417,6 @@ impl ConcurrentRadixTreeCompressed {
                     ) else {
                         continue;
                     };
-                    if let Some((expected, actual)) = scan.block_hash_mismatch {
-                        duplicate_store = false;
-                        tracing::warn!(
-                            ?expected,
-                            ?actual,
-                            "block_hash mismatch: sequence hashes should be uniform across workers"
-                        );
-                    }
-
                     return ChildInsertStep::Done(Self::finish_with_lookup_update(
                         lookup,
                         worker,
@@ -454,14 +439,6 @@ impl ConcurrentRadixTreeCompressed {
                 ) else {
                     continue;
                 };
-                if let Some((expected, actual)) = scan.block_hash_mismatch {
-                    tracing::warn!(
-                        ?expected,
-                        ?actual,
-                        "block_hash mismatch: sequence hashes should be uniform across workers"
-                    );
-                }
-
                 return ChildInsertStep::Done(self.finish_after_split_lookup(
                     lookup,
                     worker,
@@ -482,14 +459,6 @@ impl ConcurrentRadixTreeCompressed {
             else {
                 continue;
             };
-            if let Some((expected, actual)) = scan.block_hash_mismatch {
-                duplicate_store = false;
-                tracing::warn!(
-                    ?expected,
-                    ?actual,
-                    "block_hash mismatch: sequence hashes should be uniform across workers"
-                );
-            }
             if promoted {
                 duplicate_store = false;
             }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/types.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/types.rs
@@ -172,11 +172,9 @@ pub(super) struct ChildEdgeScan {
     pub(super) shape_version: u64,
     pub(super) edge_len: usize,
     pub(super) match_len: usize,
-    pub(super) block_hash_mismatch: Option<(ExternalSequenceBlockHash, ExternalSequenceBlockHash)>,
 }
 
 pub(super) enum ParentChildPlan {
-    Stale,
     StaleParent { hash: ExternalSequenceBlockHash },
     InteriorParent { shape_version: u64 },
     Descend(SharedNode),

--- a/lib/kv-router/src/indexer/cuckoo/adapter.rs
+++ b/lib/kv-router/src/indexer/cuckoo/adapter.rs
@@ -12,6 +12,7 @@
 //! provides the full-state rebootstrap point for a lease.
 
 use std::sync::Arc;
+#[cfg(test)]
 use std::time::Duration;
 
 #[cfg(test)]
@@ -27,50 +28,12 @@ use super::publication::{
 };
 use super::{CkfBuildError, CkfConfig, DcCkfState};
 
-pub const DEFAULT_LOCAL_CKF_RECOVERY_ATTEMPTS: usize = 8;
-pub const DEFAULT_LOCAL_CKF_RECOVERY_BACKOFF: Duration = Duration::from_millis(200);
-
-/// Same-generation snapshot-recovery policy.
-///
-/// The adapter exposes the exponential schedule but deliberately does not sleep. A lifecycle
-/// coordinator can apply the returned delays without blocking the actor or an ingestion worker.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct LocalCkfRecoveryPolicy {
-    pub max_attempts: usize,
-    pub initial_backoff: Duration,
-}
-
-impl Default for LocalCkfRecoveryPolicy {
-    fn default() -> Self {
-        Self {
-            max_attempts: DEFAULT_LOCAL_CKF_RECOVERY_ATTEMPTS,
-            initial_backoff: DEFAULT_LOCAL_CKF_RECOVERY_BACKOFF,
-        }
-    }
-}
-
-impl LocalCkfRecoveryPolicy {
-    pub fn delay_after_failure(self, failed_attempt: usize) -> Option<Duration> {
-        if failed_attempt == 0 || failed_attempt >= self.max_attempts {
-            return None;
-        }
-        let exponent = u32::try_from(failed_attempt - 1).unwrap_or(u32::MAX);
-        Some(
-            self.initial_backoff
-                .checked_mul(2u32.checked_pow(exponent).unwrap_or(u32::MAX))
-                .unwrap_or(Duration::MAX),
-        )
-    }
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum LocalCkfAdapterBuildError {
     #[error(transparent)]
     Producer(#[from] CkfBuildError),
     #[error("producer identity format does not match the local CKF state")]
     ProducerFormatMismatch,
-    #[error("local CKF recovery max_attempts must be nonzero")]
-    ZeroRecoveryAttempts,
     #[error("initial lane assignment failed: {0}")]
     Assignment(#[source] GlobalCkfIngestionError),
     #[error("initial actor barrier snapshot failed: {0:?}")]
@@ -105,12 +68,6 @@ pub enum LocalCkfAdapterError {
     SnapshotIngestion(#[source] GlobalCkfIngestionError),
     #[error("snapshot installation returned {0:?}")]
     SnapshotInstallation(GlobalCkfIngestOutcome),
-    #[error("snapshot recovery failed after {attempts} attempts: {last}")]
-    RecoveryExhausted {
-        attempts: usize,
-        #[source]
-        last: Box<LocalCkfAdapterError>,
-    },
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -136,7 +93,6 @@ pub struct LocalCkfDrainReport {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LocalCkfRecoveryReport {
-    pub attempts: usize,
     pub lease: LaneLease,
     pub sequence: u64,
 }
@@ -177,7 +133,6 @@ pub struct LocalCkfAdapter {
     state: DcCkfState,
     publisher: DcCkfPublisher<IngestionDeltaSink>,
     ingestion: Arc<GlobalCkfIngestionPool>,
-    recovery: LocalCkfRecoveryPolicy,
     consumer_instance: super::global::ConsumerInstanceId,
     physical_lane: u8,
     next_assignment_epoch: u64,
@@ -194,11 +149,7 @@ impl LocalCkfAdapter {
         identity: ProducerIdentity,
         lease: LaneLease,
         ingestion: Arc<GlobalCkfIngestionPool>,
-        recovery: LocalCkfRecoveryPolicy,
     ) -> Result<Self, LocalCkfAdapterBuildError> {
-        if recovery.max_attempts == 0 {
-            return Err(LocalCkfAdapterBuildError::ZeroRecoveryAttempts);
-        }
         let mut state = DcCkfState::new(config)?;
         if state.format() != identity.format() {
             return Err(LocalCkfAdapterBuildError::ProducerFormatMismatch);
@@ -235,7 +186,6 @@ impl LocalCkfAdapter {
             state,
             publisher,
             ingestion,
-            recovery,
             consumer_instance: lease.consumer_instance(),
             physical_lane: lease.physical_lane(),
             next_assignment_epoch: lease.assignment_epoch(),
@@ -337,36 +287,10 @@ impl LocalCkfAdapter {
     }
 
     /// Replace the current lease and recover the same producer generation from a new barrier
-    /// snapshot. Retry delays are exposed by [`LocalCkfRecoveryPolicy`] and intentionally not
-    /// slept here so this method never blocks a shared runtime worker on backoff.
+    /// snapshot. Failure leaves actor admission closed for an external lifecycle coordinator to
+    /// retry or tear down.
     pub fn recover_snapshot(&mut self) -> Result<LocalCkfRecoveryReport, LocalCkfAdapterError> {
         self.admission_open = false;
-        let mut last = None;
-        for attempt in 1..=self.recovery.max_attempts {
-            match self.recover_snapshot_once() {
-                Ok((lease, sequence)) => {
-                    self.admission_open = true;
-                    return Ok(LocalCkfRecoveryReport {
-                        attempts: attempt,
-                        lease,
-                        sequence,
-                    });
-                }
-                Err(
-                    error @ LocalCkfAdapterError::Snapshot(
-                        PublisherSnapshotError::SequenceExhausted,
-                    ),
-                ) => return Err(error),
-                Err(error) => last = Some(error),
-            }
-        }
-        Err(LocalCkfAdapterError::RecoveryExhausted {
-            attempts: self.recovery.max_attempts,
-            last: Box::new(last.expect("nonzero recovery attempts always record an error")),
-        })
-    }
-
-    fn recover_snapshot_once(&mut self) -> Result<(LaneLease, u64), LocalCkfAdapterError> {
         let assignment_epoch = self
             .next_assignment_epoch
             .checked_add(1)
@@ -390,7 +314,8 @@ impl LocalCkfAdapter {
         if outcome != (GlobalCkfIngestOutcome::SnapshotInstalled { sequence }) {
             return Err(LocalCkfAdapterError::SnapshotInstallation(outcome));
         }
-        Ok((lease, sequence))
+        self.admission_open = true;
+        Ok(LocalCkfRecoveryReport { lease, sequence })
     }
 
     #[cfg(test)]
@@ -456,17 +381,7 @@ mod tests {
             )
             .unwrap(),
         );
-        LocalCkfAdapter::new(
-            config,
-            identity,
-            lease,
-            ingestion,
-            LocalCkfRecoveryPolicy {
-                max_attempts: 8,
-                initial_backoff: Duration::ZERO,
-            },
-        )
-        .unwrap()
+        LocalCkfAdapter::new(config, identity, lease, ingestion).unwrap()
     }
 
     fn stored(event_id: u64, hash: u64) -> RouterEvent {
@@ -532,11 +447,25 @@ mod tests {
         );
 
         let recovery = adapter.recover_snapshot().unwrap();
-        assert_eq!(recovery.attempts, 1);
         assert_eq!(recovery.sequence, 0);
         assert_eq!(recovery.lease.assignment_epoch(), 2);
         assert_ne!(adapter.indexer().ready_lanes(), 0);
         adapter.exact_consumer_drain().unwrap();
+    }
+
+    #[test]
+    fn failed_recovery_returns_the_concrete_error_and_keeps_admission_closed() {
+        let mut adapter = build_adapter(CkfConfig::new(128));
+        adapter.next_assignment_epoch = u64::MAX;
+
+        assert!(matches!(
+            adapter.recover_snapshot(),
+            Err(LocalCkfAdapterError::AssignmentEpochExhausted)
+        ));
+        assert!(matches!(
+            adapter.apply_event(stored(1, 41)),
+            Err(LocalCkfAdapterError::AdmissionClosed)
+        ));
     }
 
     #[test]
@@ -590,19 +519,5 @@ mod tests {
                 .is_none()
         );
         adapter.exact_consumer_drain().unwrap();
-    }
-
-    #[test]
-    fn recovery_policy_exposes_backoff_without_sleeping() {
-        let policy = LocalCkfRecoveryPolicy::default();
-        assert_eq!(
-            policy.delay_after_failure(1),
-            Some(Duration::from_millis(200))
-        );
-        assert_eq!(
-            policy.delay_after_failure(2),
-            Some(Duration::from_millis(400))
-        );
-        assert_eq!(policy.delay_after_failure(8), None);
     }
 }

--- a/lib/kv-router/src/indexer/cuckoo/dc.rs
+++ b/lib/kv-router/src/indexer/cuckoo/dc.rs
@@ -912,7 +912,7 @@ impl DcCkfState {
             .filter(|canonical| !self.is_resident(canonical))
             .count();
         let maximum_new_touches = admission_candidates
-            .checked_mul(self.config.max_kicks.saturating_add(1))
+            .checked_mul(self.config.max_kicks + 1)
             .and_then(|touches| touches.checked_add(reoffered_admissions))
             .ok_or(KvCacheEventError::AllocationFailed)?
             .min(self.format.bucket_count);
@@ -921,8 +921,10 @@ impl DcCkfState {
         if !scratch.new_mappings.is_empty() {
             if let Some(lineage) = self.source_lineage.get_mut(&worker) {
                 for &(external, canonical) in &scratch.new_mappings {
-                    let previous = lineage.insert(external, canonical);
-                    debug_assert!(previous.is_none());
+                    assert!(
+                        lineage.insert(external, canonical).is_none(),
+                        "prepared store replaced an existing source mapping"
+                    );
                 }
             } else {
                 let mut lineage = FxHashMap::default();
@@ -1013,7 +1015,7 @@ impl DcCkfState {
         let maximum_new_touches = replacement
             .canonical_candidates
             .len()
-            .checked_mul(self.config.max_kicks.saturating_add(1))
+            .checked_mul(self.config.max_kicks + 1)
             .ok_or(KvCacheEventError::AllocationFailed)?
             .min(self.format.bucket_count);
         self.reserve_publication_scratch(maximum_new_touches)?;
@@ -1051,14 +1053,13 @@ impl DcCkfState {
     /// Record a successful admission. The owner entry always exists here: every admission
     /// candidate comes from a mapping whose ownership was committed earlier in the same operation.
     fn mark_resident(&mut self, canonical: CanonicalSequenceBlockHash) {
-        match self.canonical_owners.get_mut(&canonical) {
-            Some(ownership) => {
-                debug_assert!(!ownership.resident);
-                ownership.resident = true;
-                self.resident_count += 1;
-            }
-            None => debug_assert!(false, "admitted a canonical hash with no owner"),
-        }
+        let ownership = self
+            .canonical_owners
+            .get_mut(&canonical)
+            .expect("admitted a canonical hash with no owner");
+        assert!(!ownership.resident, "canonical hash admitted twice");
+        ownership.resident = true;
+        self.resident_count += 1;
     }
 
     fn insert_canonical(
@@ -1119,6 +1120,7 @@ impl DcCkfState {
             .copied()
             .ok_or(KvCacheEventError::IndexerInvariantViolation)?;
         let current = ownership.owners;
+        assert_ne!(current, 0, "source mapping has no canonical owner");
         let remove_resident = current == 1 && ownership.resident;
         if remove_resident {
             self.reserve_publication_scratch(1)?;
@@ -1127,10 +1129,11 @@ impl DcCkfState {
             .source_lineage
             .remove(&worker)
             .ok_or(KvCacheEventError::IndexerInvariantViolation)?;
-        if lineage.get(&external) != Some(&canonical) {
-            self.source_lineage.insert(worker, lineage);
-            return Err(KvCacheEventError::IndexerInvariantViolation);
-        }
+        assert_eq!(
+            lineage.get(&external),
+            Some(&canonical),
+            "source mapping changed during actor-owned removal"
+        );
         if remove_resident {
             let dirty = &mut self.publication.dirty;
             let physical_touches = &mut self.telemetry.physical_touches;
@@ -1147,22 +1150,25 @@ impl DcCkfState {
         }
 
         if current == 1 {
-            if self.canonical_owners.remove(&canonical).is_none() {
-                self.source_lineage.insert(worker, lineage);
-                return Err(KvCacheEventError::IndexerInvariantViolation);
-            }
+            assert!(
+                self.canonical_owners.remove(&canonical).is_some(),
+                "source mapping references missing ownership"
+            );
             if remove_resident {
-                self.resident_count -= 1;
+                self.resident_count = self
+                    .resident_count
+                    .checked_sub(1)
+                    .expect("resident ownership is missing from the resident count");
             }
         } else {
-            let Some(ownership) = self.canonical_owners.get_mut(&canonical) else {
-                self.source_lineage.insert(worker, lineage);
-                return Err(KvCacheEventError::IndexerInvariantViolation);
-            };
+            let ownership = self
+                .canonical_owners
+                .get_mut(&canonical)
+                .expect("source mapping references missing ownership");
             ownership.owners = current - 1;
         }
         let removed = lineage.remove(&external);
-        debug_assert_eq!(removed, Some(canonical));
+        assert_eq!(removed, Some(canonical));
         if !lineage.is_empty() {
             self.source_lineage.insert(worker, lineage);
         }
@@ -1187,7 +1193,7 @@ impl DcCkfState {
             self.remove(worker, hash)?;
         }
         self.remove_scratch.clear();
-        self.source_lineage.remove(&worker);
+        assert!(self.source_lineage.remove(&worker).is_none());
         Ok(())
     }
 
@@ -1215,6 +1221,9 @@ impl DcCkfState {
             }
             images
         });
+        let net_reverted = distinct_touched
+            .checked_sub(emitted_images as u64)
+            .expect("emitted images exceed distinct touched buckets");
         self.publication.dirty.clear();
         self.telemetry.distinct_touched_buckets = self
             .telemetry
@@ -1227,7 +1236,7 @@ impl DcCkfState {
         self.telemetry.net_reverted_buckets = self
             .telemetry
             .net_reverted_buckets
-            .saturating_add(distinct_touched.saturating_sub(emitted_images as u64));
+            .saturating_add(net_reverted);
         self.publication.pending_events = 0;
         Some(DcCkfPublicationBatch { images: images? })
     }
@@ -1236,11 +1245,12 @@ impl DcCkfState {
         &mut self,
         maximum_new_touches: usize,
     ) -> Result<(), KvCacheEventError> {
-        let maximum_new_touches = maximum_new_touches.min(
-            self.format
-                .bucket_count
-                .saturating_sub(self.publication.dirty.buckets.len()),
-        );
+        let available_buckets = self
+            .format
+            .bucket_count
+            .checked_sub(self.publication.dirty.buckets.len())
+            .expect("dirty bucket set exceeds filter bucket count");
+        let maximum_new_touches = maximum_new_touches.min(available_buckets);
         self.publication.dirty.try_reserve(maximum_new_touches)
     }
 

--- a/lib/kv-router/src/indexer/radix_tree.rs
+++ b/lib/kv-router/src/indexer/radix_tree.rs
@@ -350,36 +350,18 @@ impl RadixTree {
                 break;
             };
 
-            let (edge_len, match_len, mismatch) = {
+            let (edge_len, match_len) = {
                 let child_ref = child.borrow();
                 let edge_len = child_ref.state.edge.len();
-                let mut mismatch = None;
                 let match_len = child_ref
                     .state
                     .edge
                     .iter()
                     .zip(remaining)
-                    .take_while(|((local_hash, existing_hash), block)| {
-                        if local_hash != &block.tokens_hash {
-                            return false;
-                        }
-                        if existing_hash != &block.block_hash && mismatch.is_none() {
-                            mismatch = Some((block.block_hash, *existing_hash));
-                        }
-                        true
-                    })
+                    .take_while(|((local_hash, _), block)| *local_hash == block.tokens_hash)
                     .count();
-                (edge_len, match_len, mismatch)
+                (edge_len, match_len)
             };
-
-            if let Some((expected, actual)) = mismatch {
-                duplicate_store = false;
-                tracing::warn!(
-                    ?expected,
-                    ?actual,
-                    "block_hash mismatch: sequence hashes should be uniform across workers"
-                );
-            }
 
             if match_len < edge_len {
                 if match_len == remaining.len() {

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -55,9 +55,11 @@ pub use config::{
     RouterQueuePolicy, SharedCacheType,
 };
 pub use identity::{DEFAULT_ROUTING_GROUP, DcId, RoutingPartitionId, RoutingPartitionRef};
+#[allow(deprecated)]
 pub use indexer::{
-    AnchorRef, AnchorTask, BranchShardedIndexer, LowerTierContinuation, LowerTierIndexer,
-    MaybeError, SharedKvCache, SyncIndexer, ThreadPoolIndexer,
+    AnchorAwareBranchShardedIndexer, AnchorRef, AnchorTask, BranchShardedIndexer,
+    LowerTierContinuation, LowerTierIndexer, MaybeError, SharedKvCache, SyncIndexer,
+    ThreadPoolIndexer,
 };
 pub use nested_map::PositionalIndexer;
 pub use protocols::{

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -55,11 +55,9 @@ pub use config::{
     RouterQueuePolicy, SharedCacheType,
 };
 pub use identity::{DEFAULT_ROUTING_GROUP, DcId, RoutingPartitionId, RoutingPartitionRef};
-#[allow(deprecated)]
 pub use indexer::{
-    AnchorAwareBranchShardedIndexer, AnchorRef, AnchorTask, BranchShardedIndexer,
-    LowerTierContinuation, LowerTierIndexer, MaybeError, SharedKvCache, SyncIndexer,
-    ThreadPoolIndexer,
+    AnchorRef, AnchorTask, BranchShardedIndexer, LowerTierContinuation, LowerTierIndexer,
+    MaybeError, SharedKvCache, SyncIndexer, ThreadPoolIndexer,
 };
 pub use nested_map::PositionalIndexer;
 pub use protocols::{

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -1098,7 +1098,6 @@ pub struct ActiveLoad {
     ///
     /// This is published by workers only and is the authoritative signal for
     /// backend KV occupancy used by overload detection.
-    #[serde(default)]
     pub kv_used_blocks: Option<u64>,
 }
 
@@ -1156,7 +1155,6 @@ pub struct ActiveSequenceEvent {
     /// Source DRT identity, used to suppress a publisher's own echo. Router events use the router
     /// ID; worker-origin completion marks use the worker ID.
     pub router_id: u64,
-    #[serde(default)]
     pub lora_name: Option<String>,
 }
 
@@ -1183,7 +1181,6 @@ pub enum ActiveSequenceEventData {
         #[serde(default = "default_track_prefill_tokens")]
         track_prefill_tokens: bool,
         expected_output_tokens: Option<u32>,
-        #[serde(default)]
         prefill_load_hint: Option<PrefillLoadHint>,
     },
     // NOTE: Output-block growth is intentionally not a replica-sync event. It can occur
@@ -1246,7 +1243,6 @@ pub struct KvCacheStoreData {
     /// The optional hash of the parent block.
     pub parent_hash: Option<ExternalSequenceBlockHash>,
     /// Absolute position of the first block in this batch for positional replay.
-    #[serde(default)]
     pub start_position: Option<u32>,
     /// A list of stored blocked data.
     pub blocks: Vec<KvCacheStoredBlockData>,
@@ -1367,7 +1363,6 @@ pub struct KvCacheStoredBlockData {
     /// Extra multimodal metadata for this block
     /// Note: Do NOT use skip_serializing_if with bincode - it breaks deserialization
     /// because bincode is positional and expects all fields to be present.
-    #[serde(default)]
     pub mm_extra_info: Option<BlockExtraInfo>,
 }
 

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -676,7 +676,6 @@ struct KvRouterConfigSerde {
     _legacy_router_reset_states: bool,
     router_ttl_secs: f64,
     router_queue_threshold: Option<f64>,
-    #[serde(default)]
     router_policy_config: Option<String>,
     router_event_threads: u32,
     skip_initial_worker_wait: bool,
@@ -690,9 +689,7 @@ struct KvRouterConfigSerde {
     conditional_disagg_policy: ConditionalDisaggPolicyKind,
     conditional_disagg_eff_isl_threshold: usize,
     conditional_disagg_eff_isl_ratio_threshold: f64,
-    #[serde(default)]
     conditional_disagg_prefill_busy_threshold: Option<f64>,
-    #[serde(default)]
     conditional_disagg_decode_busy_threshold: Option<f64>,
 }
 
@@ -832,7 +829,6 @@ pub struct KvRouterConfig {
     pub router_queue_threshold: Option<f64>,
 
     /// Optional startup-only YAML configuration for policy-class queues and custom worker selection.
-    #[serde(default)]
     pub router_policy_config: Option<String>,
 
     /// Optional prefill worker-selection instance override.
@@ -895,7 +891,6 @@ pub struct KvRouterConfig {
     /// populated by routing decisions; `find_matches` queries both the
     /// event-driven primary and local side indexer and returns the per-worker
     /// maximum overlap.
-    #[serde(default)]
     pub router_predicted_ttl_secs: Option<f64>,
 
     /// Enable conditional-disagg bypass. When true, the `PrefillRouter`

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -10,6 +10,7 @@ use tokio::sync::watch;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
+#[cfg(test)]
 use super::config::RouterQueuePolicy;
 use super::overlap::OverlapSignals;
 use super::overlap_refresh::{NoopOverlapScoresRefresh, OverlapScoresRefresh};
@@ -147,47 +148,8 @@ where
         WorkerConfigReconcileOutcome::Applied
     }
 
-    /// Construct a scheduler with dequeue-time overlap refresh.
     #[allow(clippy::too_many_arguments)]
-    pub fn new_with_overlap_refresh(
-        slots: Arc<ActiveSequencesMultiWorker<P>>,
-        workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
-        threshold_frac: Option<f64>,
-        block_size: u32,
-        selector: Sel,
-        queue_policy: RouterQueuePolicy,
-        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
-        overlap_scores_refresh: Option<Arc<RF>>,
-        overloaded_worker_provider: Option<OverloadedWorkerProvider>,
-        available_worker_provider: Option<WorkerAvailabilityProvider>,
-        recheck_interval: Duration,
-        track_prefill_tokens_default: bool,
-        cancellation_token: CancellationToken,
-        worker_type: &'static str,
-        monitor_worker_configs: bool,
-    ) -> Self {
-        let profile = PolicyProfile::synthetic(threshold_frac, queue_policy);
-        Self::new_with_policy_profile(
-            slots,
-            workers_with_configs,
-            profile,
-            block_size,
-            selector,
-            prefill_load_estimator,
-            overlap_scores_refresh,
-            overloaded_worker_provider,
-            available_worker_provider,
-            recheck_interval,
-            track_prefill_tokens_default,
-            cancellation_token,
-            worker_type,
-            monitor_worker_configs,
-        )
-        .expect("synthetic policy profile is valid")
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_with_policy_profile(
+    pub fn new(
         slots: Arc<ActiveSequencesMultiWorker<P>>,
         workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
         profile: PolicyProfile,
@@ -202,8 +164,8 @@ where
         cancellation_token: CancellationToken,
         worker_type: &'static str,
         monitor_worker_configs: bool,
-    ) -> Result<Self, KvSchedulerError> {
-        let queue = Arc::new(SchedulerQueue::new_with_policy_profile(
+    ) -> Self {
+        let queue = Arc::new(SchedulerQueue::new(
             Arc::clone(&slots),
             workers_with_configs.clone(),
             profile,
@@ -213,7 +175,7 @@ where
             overlap_scores_refresh,
             overloaded_worker_provider,
             available_worker_provider,
-        )?);
+        ));
 
         let (queue_updates, _) = watch::channel(());
 
@@ -304,13 +266,13 @@ where
             }
         });
 
-        Ok(Self {
+        Self {
             slots,
             queue,
             queue_updates,
             track_prefill_tokens_default,
             worker_type,
-        })
+        }
     }
 
     pub async fn schedule_request(
@@ -725,149 +687,6 @@ where
     }
 }
 
-impl<P, C, Sel> LocalScheduler<P, C, Sel, NoopOverlapScoresRefresh>
-where
-    P: SequencePublisher + 'static,
-    C: WorkerConfigLike + Clone + PartialEq + Send + Sync + 'static,
-    Sel: WorkerSelector<C> + Send + 'static,
-{
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_without_overlap_refresh_with_policy_profile(
-        slots: Arc<ActiveSequencesMultiWorker<P>>,
-        workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
-        profile: PolicyProfile,
-        block_size: u32,
-        selector: Sel,
-        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
-        overloaded_worker_provider: Option<OverloadedWorkerProvider>,
-        available_worker_provider: Option<WorkerAvailabilityProvider>,
-        recheck_interval: Duration,
-        track_prefill_tokens_default: bool,
-        cancellation_token: CancellationToken,
-        worker_type: &'static str,
-        monitor_worker_configs: bool,
-    ) -> Result<Self, KvSchedulerError> {
-        Self::new_with_policy_profile(
-            slots,
-            workers_with_configs,
-            profile,
-            block_size,
-            selector,
-            prefill_load_estimator,
-            None,
-            overloaded_worker_provider,
-            available_worker_provider,
-            recheck_interval,
-            track_prefill_tokens_default,
-            cancellation_token,
-            worker_type,
-            monitor_worker_configs,
-        )
-    }
-
-    /// Construct a scheduler without dequeue-time overlap refresh.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        slots: Arc<ActiveSequencesMultiWorker<P>>,
-        workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
-        threshold_frac: Option<f64>,
-        block_size: u32,
-        selector: Sel,
-        queue_policy: RouterQueuePolicy,
-        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
-        recheck_interval: Duration,
-        track_prefill_tokens_default: bool,
-        cancellation_token: CancellationToken,
-        worker_type: &'static str,
-        monitor_worker_configs: bool,
-    ) -> Self {
-        Self::new_with_overload_provider(
-            slots,
-            workers_with_configs,
-            threshold_frac,
-            block_size,
-            selector,
-            queue_policy,
-            prefill_load_estimator,
-            None,
-            recheck_interval,
-            track_prefill_tokens_default,
-            cancellation_token,
-            worker_type,
-            monitor_worker_configs,
-        )
-    }
-
-    /// Construct a scheduler without dequeue-time overlap refresh but with an overload
-    /// provider consulted during worker selection.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_with_overload_provider(
-        slots: Arc<ActiveSequencesMultiWorker<P>>,
-        workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
-        threshold_frac: Option<f64>,
-        block_size: u32,
-        selector: Sel,
-        queue_policy: RouterQueuePolicy,
-        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
-        overloaded_worker_provider: Option<OverloadedWorkerProvider>,
-        recheck_interval: Duration,
-        track_prefill_tokens_default: bool,
-        cancellation_token: CancellationToken,
-        worker_type: &'static str,
-        monitor_worker_configs: bool,
-    ) -> Self {
-        Self::new_with_overlap_refresh(
-            slots,
-            workers_with_configs,
-            threshold_frac,
-            block_size,
-            selector,
-            queue_policy,
-            prefill_load_estimator,
-            None,
-            overloaded_worker_provider,
-            None,
-            recheck_interval,
-            track_prefill_tokens_default,
-            cancellation_token,
-            worker_type,
-            monitor_worker_configs,
-        )
-    }
-
-    /// Backwards-compatible alias for callers that spell out the no-refresh path.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_without_overlap_refresh(
-        slots: Arc<ActiveSequencesMultiWorker<P>>,
-        workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
-        threshold_frac: Option<f64>,
-        block_size: u32,
-        selector: Sel,
-        queue_policy: RouterQueuePolicy,
-        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
-        recheck_interval: Duration,
-        track_prefill_tokens_default: bool,
-        cancellation_token: CancellationToken,
-        worker_type: &'static str,
-        monitor_worker_configs: bool,
-    ) -> Self {
-        Self::new(
-            slots,
-            workers_with_configs,
-            threshold_frac,
-            block_size,
-            selector,
-            queue_policy,
-            prefill_load_estimator,
-            recheck_interval,
-            track_prefill_tokens_default,
-            cancellation_token,
-            worker_type,
-            monitor_worker_configs,
-        )
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -956,14 +775,16 @@ mod tests {
         ));
         let (cfg_tx, cfg_rx) = watch::channel(workers);
         let cancel_token = CancellationToken::new();
-        let scheduler = Arc::new(LocalScheduler::new_without_overlap_refresh(
+        let scheduler = Arc::new(LocalScheduler::new(
             Arc::clone(&slots),
             cfg_rx,
-            threshold_frac,
+            PolicyProfile::synthetic(threshold_frac, RouterQueuePolicy::Fcfs),
             64,
             DefaultWorkerSelector::new(None, "test"),
-            RouterQueuePolicy::Fcfs,
             prefill_load_estimator,
+            None::<Arc<NoopOverlapScoresRefresh>>,
+            None,
+            None,
             Duration::from_secs(60),
             true,
             cancel_token.clone(),
@@ -1749,13 +1570,15 @@ mod tests {
         cfg_tx.send(updated_workers).unwrap();
 
         let cancel_token = CancellationToken::new();
-        let scheduler = LocalScheduler::new_without_overlap_refresh(
+        let scheduler = LocalScheduler::new(
             Arc::clone(&slots),
             cfg_rx,
-            None,
+            PolicyProfile::synthetic(None, RouterQueuePolicy::Fcfs),
             64,
             DefaultWorkerSelector::new(None, "test"),
-            RouterQueuePolicy::Fcfs,
+            None,
+            None::<Arc<NoopOverlapScoresRefresh>>,
+            None,
             None,
             Duration::from_secs(60),
             true,
@@ -1802,13 +1625,15 @@ mod tests {
         cfg_tx.send(HashMap::new()).unwrap();
 
         let cancel_token = CancellationToken::new();
-        let scheduler = LocalScheduler::new_without_overlap_refresh(
+        let scheduler = LocalScheduler::new(
             Arc::clone(&slots),
             cfg_rx,
-            None,
+            PolicyProfile::synthetic(None, RouterQueuePolicy::Fcfs),
             64,
             DefaultWorkerSelector::new(None, "test"),
-            RouterQueuePolicy::Fcfs,
+            None,
+            None::<Arc<NoopOverlapScoresRefresh>>,
+            None,
             None,
             Duration::from_secs(60),
             true,

--- a/lib/kv-router/src/scheduling/policy_config.rs
+++ b/lib/kv-router/src/scheduling/policy_config.rs
@@ -224,15 +224,11 @@ impl RouterPolicyConfig {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawRouterPolicyConfig {
-    #[serde(default)]
     default_policy_family: Option<String>,
-    #[serde(default)]
     policy_classes: Option<Vec<RawPolicyClassConfig>>,
-    #[serde(default)]
     uncached_isl_buckets: Option<Vec<RawUncachedIslBucket>>,
     #[serde(default)]
     models: HashMap<String, RawPolicyProfile>,
-    #[serde(default)]
     worker_selection: Option<RawWorkerSelectionConfig>,
 }
 
@@ -310,22 +306,15 @@ struct RawUncachedIslBucket {
 #[serde(deny_unknown_fields)]
 struct RawPolicyClassConfig {
     name: String,
-    #[serde(default)]
     policy_family: Option<String>,
-    #[serde(default)]
     cache_bucket: Option<String>,
     #[serde(default)]
     queue_policy: RouterQueuePolicy,
     quantum: usize,
-    #[serde(default)]
     prefill_busy_threshold: Option<usize>,
-    #[serde(default)]
     prefill_busy_threshold_frac: Option<f64>,
-    #[serde(default)]
     request_queue_limit_per_worker: Option<usize>,
-    #[serde(default)]
     raw_isl_token_queue_limit_per_worker: Option<usize>,
-    #[serde(default)]
     cached_token_queue_limit_per_worker: Option<usize>,
 }
 

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -12,6 +12,7 @@ use parking_lot::Mutex;
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time::Instant;
 
+#[cfg(test)]
 use super::config::RouterQueuePolicy;
 use super::filter::RoutingEligibility;
 use super::overlap::SelectedWorkerTierSnapshot;
@@ -464,35 +465,7 @@ impl<
 > SchedulerQueue<P, C, Sel, RF>
 {
     #[allow(clippy::too_many_arguments)]
-    pub fn new_with_overlap_refresh(
-        slots: Arc<ActiveSequencesMultiWorker<P>>,
-        workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
-        threshold_frac: Option<f64>,
-        block_size: u32,
-        selector: Sel,
-        queue_policy: RouterQueuePolicy,
-        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
-        overlap_scores_refresh: Option<Arc<RF>>,
-        overloaded_worker_provider: Option<OverloadedWorkerProvider>,
-        available_worker_provider: Option<WorkerAvailabilityProvider>,
-    ) -> Self {
-        let profile = PolicyProfile::synthetic(threshold_frac, queue_policy);
-        Self::new_with_policy_profile(
-            slots,
-            workers_with_configs,
-            profile,
-            block_size,
-            selector,
-            prefill_load_estimator,
-            overlap_scores_refresh,
-            overloaded_worker_provider,
-            available_worker_provider,
-        )
-        .expect("synthetic policy profile does not require admission policies")
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_with_policy_profile(
+    pub fn new(
         slots: Arc<ActiveSequencesMultiWorker<P>>,
         workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
         profile: PolicyProfile,
@@ -502,8 +475,8 @@ impl<
         overlap_scores_refresh: Option<Arc<RF>>,
         overloaded_worker_provider: Option<OverloadedWorkerProvider>,
         available_worker_provider: Option<WorkerAvailabilityProvider>,
-    ) -> Result<Self, KvSchedulerError> {
-        Self::new_with_policy_profile_and_capacity(
+    ) -> Self {
+        Self::new_with_capacity(
             slots,
             workers_with_configs,
             profile,
@@ -518,7 +491,7 @@ impl<
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn new_with_policy_profile_and_capacity(
+    fn new_with_capacity(
         slots: Arc<ActiveSequencesMultiWorker<P>>,
         workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
         profile: PolicyProfile,
@@ -529,7 +502,7 @@ impl<
         overloaded_worker_provider: Option<OverloadedWorkerProvider>,
         available_worker_provider: Option<WorkerAvailabilityProvider>,
         admission_channel_capacity: usize,
-    ) -> Result<Self, KvSchedulerError> {
+    ) -> Self {
         let pending = PolicyQueue::new(profile.clone());
         let queueing_enabled = profile
             .classes()
@@ -596,7 +569,7 @@ impl<
             non_max_overlap_selection_observer: Arc::clone(&non_max_overlap_selection_observer),
         };
         tokio::spawn(actor.run(admission_rx));
-        Ok(Self {
+        Self {
             admission_tx,
             cleanup,
             pending_count,
@@ -608,63 +581,7 @@ impl<
             supports_overlap_refresh: overlap_refresh_after.is_some(),
             non_max_overlap_selection_observer,
             _marker: PhantomData,
-        })
-    }
-}
-
-impl<
-    P: SequencePublisher + 'static,
-    C: WorkerConfigLike + Send + Sync + 'static,
-    Sel: WorkerSelector<C> + Send + 'static,
-> SchedulerQueue<P, C, Sel, NoopOverlapScoresRefresh>
-{
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        slots: Arc<ActiveSequencesMultiWorker<P>>,
-        workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
-        threshold_frac: Option<f64>,
-        block_size: u32,
-        selector: Sel,
-        queue_policy: RouterQueuePolicy,
-        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
-    ) -> Self {
-        Self::new_with_overlap_refresh(
-            slots,
-            workers_with_configs,
-            threshold_frac,
-            block_size,
-            selector,
-            queue_policy,
-            prefill_load_estimator,
-            None,
-            None,
-            None,
-        )
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_with_overload_provider(
-        slots: Arc<ActiveSequencesMultiWorker<P>>,
-        workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
-        threshold_frac: Option<f64>,
-        block_size: u32,
-        selector: Sel,
-        queue_policy: RouterQueuePolicy,
-        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
-        overloaded_worker_provider: Option<OverloadedWorkerProvider>,
-    ) -> Self {
-        Self::new_with_overlap_refresh(
-            slots,
-            workers_with_configs,
-            threshold_frac,
-            block_size,
-            selector,
-            queue_policy,
-            prefill_load_estimator,
-            None,
-            overloaded_worker_provider,
-            None,
-        )
+        }
     }
 }
 
@@ -1935,10 +1852,12 @@ mod tests {
         let queue = Arc::new(SchedulerQueue::new(
             Arc::clone(&slots),
             cfg_rx,
-            threshold_frac,
+            PolicyProfile::synthetic(threshold_frac, RouterQueuePolicy::Fcfs),
             block_size,
             selector,
-            RouterQueuePolicy::Fcfs,
+            None,
+            None,
+            None,
             None,
         ));
 
@@ -1984,11 +1903,13 @@ mod tests {
         let queue = Arc::new(SchedulerQueue::new(
             Arc::clone(&slots),
             cfg_rx,
-            threshold_frac,
+            PolicyProfile::synthetic(threshold_frac, RouterQueuePolicy::Fcfs),
             block_size,
             selector,
-            RouterQueuePolicy::Fcfs,
             prefill_load_estimator,
+            None,
+            None,
+            None,
         ));
 
         (queue, slots, cfg_tx)
@@ -2052,20 +1973,17 @@ mod tests {
             })
             .collect();
         let (cfg_tx, cfg_rx) = watch::channel(configs);
-        let queue = Arc::new(
-            SchedulerQueue::new_with_policy_profile(
-                Arc::clone(&slots),
-                cfg_rx,
-                profile,
-                block_size,
-                DefaultWorkerSelector::new(None, "test"),
-                None,
-                None,
-                None,
-                None,
-            )
-            .unwrap(),
-        );
+        let queue = Arc::new(SchedulerQueue::new(
+            Arc::clone(&slots),
+            cfg_rx,
+            profile,
+            block_size,
+            DefaultWorkerSelector::new(None, "test"),
+            None,
+            None,
+            None,
+            None,
+        ));
         (queue, slots, cfg_tx)
     }
 
@@ -2103,13 +2021,12 @@ mod tests {
         let (_cfg_tx, cfg_rx) = watch::channel(configs);
 
         let selector = DefaultWorkerSelector::new(None, "test");
-        let queue = Arc::new(SchedulerQueue::new_with_overlap_refresh(
+        let queue = Arc::new(SchedulerQueue::new(
             Arc::clone(&slots),
             cfg_rx,
-            None,
+            PolicyProfile::synthetic(None, RouterQueuePolicy::Fcfs),
             block_size,
             selector,
-            RouterQueuePolicy::Fcfs,
             None,
             None,
             overloaded_worker_provider,
@@ -2222,13 +2139,12 @@ mod tests {
         }
         let (_cfg_tx, cfg_rx) = watch::channel(configs);
 
-        let queue = Arc::new(SchedulerQueue::new_with_overlap_refresh(
+        let queue = Arc::new(SchedulerQueue::new(
             Arc::clone(&slots),
             cfg_rx,
-            threshold_frac,
+            PolicyProfile::synthetic(threshold_frac, RouterQueuePolicy::Fcfs),
             block_size,
             DefaultWorkerSelector::new(None, "test"),
-            RouterQueuePolicy::Fcfs,
             None,
             Some(refresher),
             None,
@@ -2280,21 +2196,18 @@ mod tests {
         }
         let (_cfg_tx, cfg_rx) = watch::channel(configs);
 
-        let queue = Arc::new(
-            SchedulerQueue::new_with_policy_profile_and_capacity(
-                Arc::clone(&slots),
-                cfg_rx,
-                PolicyProfile::synthetic(threshold_frac, crate::config::RouterQueuePolicy::Fcfs),
-                block_size,
-                DefaultWorkerSelector::new(None, "test"),
-                None,
-                Some(refresher),
-                None,
-                None,
-                admission_channel_capacity,
-            )
-            .unwrap(),
-        );
+        let queue = Arc::new(SchedulerQueue::new_with_capacity(
+            Arc::clone(&slots),
+            cfg_rx,
+            PolicyProfile::synthetic(threshold_frac, crate::config::RouterQueuePolicy::Fcfs),
+            block_size,
+            DefaultWorkerSelector::new(None, "test"),
+            None,
+            Some(refresher),
+            None,
+            None,
+            admission_channel_capacity,
+        ));
 
         (queue, slots)
     }
@@ -2674,10 +2587,12 @@ mod tests {
         let queue = SchedulerQueue::new(
             Arc::clone(&slots),
             cfg_rx,
-            None,
+            PolicyProfile::synthetic(None, RouterQueuePolicy::Fcfs),
             16,
             DefaultWorkerSelector::new(None, "test"),
-            RouterQueuePolicy::Fcfs,
+            None,
+            None::<Arc<NoopOverlapScoresRefresh>>,
+            None,
             None,
         );
 

--- a/lib/kv-router/src/scheduling/selector/default.rs
+++ b/lib/kv-router/src/scheduling/selector/default.rs
@@ -10,14 +10,13 @@ use parking_lot::Mutex;
 
 use super::policy::WorkerSelectionPolicyStateRef;
 use super::{
-    LogitWeights, MaterializedSelectionInput, ScoredWorkerCandidate, WorkerCandidate,
-    WorkerInputView, WorkerInputs, WorkerPicker, WorkerSelectionContext, WorkerSelectionInput,
-    WorkerSelector, select_worker_with_policy,
+    LogitWeights, MaterializedSelectionInput, WorkerCandidate, WorkerInputs,
+    WorkerSelectionContext, WorkerSelectionInput, WorkerSelector, select_worker_with_policy,
 };
 use crate::protocols::{WorkerConfigLike, WorkerId, WorkerSelectionResult, WorkerWithDpRank};
 use crate::scheduling::config::KvRouterConfig;
 use crate::scheduling::filter::RoutingEligibility;
-use crate::scheduling::types::{KvSchedulerError, SchedulingRequest, WorkerSelectionPolicyError};
+use crate::scheduling::types::{KvSchedulerError, SchedulingRequest};
 
 #[cfg(any(test, feature = "bench"))]
 fn softmax_sample_entries<T: Copy>(
@@ -108,7 +107,6 @@ struct DefaultScoringContext {
 }
 
 pub(super) struct DefaultWorkerPicker {
-    default_temperature: f64,
     // Preserve DefaultWorkerSelector's Sync contract. Zero-temperature selection never locks.
     softmax_scratch: Mutex<DefaultSoftmaxScratch>,
     #[cfg(any(test, feature = "bench"))]
@@ -173,7 +171,6 @@ impl DefaultWorkerSelector {
         #[cfg(any(test, feature = "bench"))] deterministic_rng: Option<Arc<Mutex<fastrand::Rng>>>,
     ) -> Self {
         let picker = DefaultWorkerPicker::from_parts(
-            kv_router_config.router_temperature,
             #[cfg(any(test, feature = "bench"))]
             deterministic_rng,
         );
@@ -406,36 +403,12 @@ impl<C: Borrow<KvRouterConfig>> DefaultWorkerScorer<C> {
 }
 
 impl DefaultWorkerPicker {
-    pub(super) fn new(default_temperature: f64) -> Self {
+    pub(super) fn new() -> Self {
         Self::from_parts(
-            default_temperature,
             #[cfg(any(test, feature = "bench"))]
             None,
         )
     }
-}
-
-fn minimum_cost_index(
-    candidates: &[ScoredWorkerCandidate],
-    mut random_index: impl FnMut(usize) -> usize,
-) -> usize {
-    let mut best_row = 0;
-    let mut best_cost = f64::INFINITY;
-    let mut tie_count = 0;
-    for (row, candidate) in candidates.iter().enumerate() {
-        let cost = candidate.cost;
-        if cost < best_cost {
-            best_row = row;
-            best_cost = cost;
-            tie_count = 1;
-        } else if cost == best_cost {
-            tie_count += 1;
-            if random_index(tie_count) == 0 {
-                best_row = row;
-            }
-        }
-    }
-    best_row
 }
 
 #[inline(always)]
@@ -555,56 +528,13 @@ pub(super) fn pick_default_worker<C: WorkerConfigLike>(
 
 impl DefaultWorkerPicker {
     fn from_parts(
-        default_temperature: f64,
         #[cfg(any(test, feature = "bench"))] deterministic_rng: Option<Arc<Mutex<fastrand::Rng>>>,
     ) -> Self {
         Self {
-            default_temperature,
             softmax_scratch: Mutex::default(),
             #[cfg(any(test, feature = "bench"))]
             deterministic_rng,
         }
-    }
-}
-
-impl WorkerPicker for DefaultWorkerPicker {
-    fn pick(
-        &mut self,
-        context: &WorkerSelectionContext<'_>,
-        input: WorkerInputView<'_>,
-    ) -> Result<usize, WorkerSelectionPolicyError> {
-        let candidates = input.candidates();
-        let temperature = context
-            .router_temperature_override
-            .unwrap_or(self.default_temperature);
-        #[cfg(any(test, feature = "bench"))]
-        if let Some(rng) = &self.deterministic_rng {
-            let mut rng = rng.lock();
-            if temperature == 0.0 {
-                return Ok(minimum_cost_index(candidates, |count| rng.usize(0..count)));
-            }
-            let sample = rng.f64();
-            drop(rng);
-            return Ok(softmax_sample_index(
-                candidates,
-                |candidate| candidate.cost,
-                temperature,
-                sample,
-                &mut self.softmax_scratch.get_mut().probabilities,
-            ));
-        }
-        if temperature == 0.0 {
-            return Ok(minimum_cost_index(candidates, |count| {
-                fastrand::usize(0..count)
-            }));
-        }
-        Ok(softmax_sample_index(
-            candidates,
-            |candidate| candidate.cost,
-            temperature,
-            fastrand::f64(),
-            &mut self.softmax_scratch.get_mut().probabilities,
-        ))
     }
 }
 

--- a/lib/kv-router/src/scheduling/selector/policy.rs
+++ b/lib/kv-router/src/scheduling/selector/policy.rs
@@ -427,7 +427,7 @@ impl WorkerSelectionPolicy {
     /// `worker_label` selects the built-in scoring and logging contract. Typed hosts use
     /// [`crate::WorkerType::default_selector_label`] to preserve Dynamo's historical behavior.
     pub fn default(kv_router_config: KvRouterConfig, worker_label: &'static str) -> Self {
-        let picker = DefaultWorkerPicker::new(kv_router_config.router_temperature);
+        let picker = DefaultWorkerPicker::new();
         Self {
             kv_router_config,
             worker_label,
@@ -638,13 +638,25 @@ mod tests {
 
     use rustc_hash::FxHashMap;
 
+    use super::super::DefaultWorkerSelector;
     use super::super::test_support::*;
-    use super::super::{DefaultWorkerPicker, DefaultWorkerSelector};
     use super::*;
     use crate::scheduling::{WorkerSelectionInputTrigger, WorkerSelectionKvHints};
 
     fn uses_exclusive_affinity(selector: &impl WorkerSelector<TaintedWorkerConfig>) -> bool {
         selector.uses_exclusive_affinity_target()
+    }
+
+    struct FirstPicker;
+
+    impl WorkerPicker for FirstPicker {
+        fn pick(
+            &mut self,
+            _context: &WorkerSelectionContext<'_>,
+            _input: WorkerInputView<'_>,
+        ) -> Result<usize, WorkerSelectionPolicyError> {
+            Ok(0)
+        }
     }
 
     #[test]
@@ -1082,7 +1094,7 @@ mod tests {
             "test",
             vec![Box::new(RejectWithoutSignals)],
             vec![Box::new(CacheScorer)],
-            Box::new(DefaultWorkerPicker::new(0.0)),
+            Box::new(FirstPicker),
         );
 
         assert!(matches!(
@@ -1125,17 +1137,6 @@ mod tests {
                 _candidate: &WorkerCandidate,
             ) -> Result<f64, WorkerSelectionPolicyError> {
                 Ok(0.0)
-            }
-        }
-
-        struct FirstPicker;
-        impl WorkerPicker for FirstPicker {
-            fn pick(
-                &mut self,
-                _context: &WorkerSelectionContext<'_>,
-                _input: WorkerInputView<'_>,
-            ) -> Result<usize, WorkerSelectionPolicyError> {
-                Ok(0)
             }
         }
 

--- a/lib/kv-router/src/scheduling/worker_selection_config.rs
+++ b/lib/kv-router/src/scheduling/worker_selection_config.rs
@@ -72,13 +72,9 @@ impl WorkerSelectionInstance {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct RawWorkerSelectionConfig {
-    #[serde(default)]
     aggregated: Option<String>,
-    #[serde(default)]
     prefill: Option<String>,
-    #[serde(default)]
     decode: Option<String>,
-    #[serde(default)]
     encode: Option<String>,
     #[serde(default)]
     instances: Vec<RawWorkerSelectionInstance>,

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -381,14 +381,17 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         router_id: u64,
         worker_type: &'static str,
     ) -> Self {
-        Self::new_with_replica_worker_policy(
+        Self::new_with_options(
             publisher,
             block_size,
             dp_range,
             replica_sync,
             router_id,
             worker_type,
-            ReplicaWorkerPolicy::LazyRegister,
+            SequenceTrackerOptions {
+                replica_worker_policy: ReplicaWorkerPolicy::LazyRegister,
+                expiry_duration: Some(active_request_expiry_duration()),
+            },
         )
     }
 
@@ -411,38 +414,6 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             SequenceTrackerOptions {
                 replica_worker_policy: ReplicaWorkerPolicy::LazyRegister,
                 expiry_duration: None,
-            },
-        )
-    }
-
-    /// Create a tracker with an explicit stale active-request cleanup guard.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `expiry_duration` or `block_size` is zero.
-    pub fn new_with_expiry_duration(
-        publisher: P,
-        block_size: usize,
-        dp_range: HashMap<u64, (u32, u32)>,
-        replica_sync: bool,
-        router_id: u64,
-        worker_type: &'static str,
-        expiry_duration: Duration,
-    ) -> Self {
-        assert!(
-            !expiry_duration.is_zero(),
-            "expiry_duration must be greater than zero"
-        );
-        Self::new_with_options(
-            publisher,
-            block_size,
-            dp_range,
-            replica_sync,
-            router_id,
-            worker_type,
-            SequenceTrackerOptions {
-                replica_worker_policy: ReplicaWorkerPolicy::LazyRegister,
-                expiry_duration: Some(expiry_duration),
             },
         )
     }
@@ -483,12 +454,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
     ) -> Self {
         assert!(block_size > 0, "block_size must be greater than 0");
         let (remote_state_updates, _) = watch::channel(());
-        let workers = match options.expiry_duration {
-            Some(duration) => {
-                WorkerTable::new_with_expiry_duration(block_size, &dp_range, duration)
-            }
-            None => WorkerTable::new_without_expiry(block_size, &dp_range),
-        };
+        let workers = WorkerTable::new_with_expiry(block_size, &dp_range, options.expiry_duration);
         let initial_workers: Vec<_> = workers.workers().collect();
         let prompt_registry = PromptRegistry::new(initial_workers.iter().copied());
         let publisher = Arc::new(publisher);
@@ -1622,21 +1588,6 @@ mod tests {
                 DEFAULT_ACTIVE_REQUEST_EXPIRY_DURATION
             );
         }
-    }
-
-    /// Verifies that zero duration is rejected before worker-table construction.
-    #[test]
-    #[should_panic(expected = "expiry_duration must be greater than zero")]
-    fn custom_expiry_rejects_zero_duration_at_multi_worker_boundary() {
-        let _ = ActiveSequencesMultiWorker::new_with_expiry_duration(
-            NoopSequencePublisher,
-            4,
-            HashMap::new(),
-            false,
-            0,
-            "test",
-            Duration::ZERO,
-        );
     }
 
     fn make_sequences() -> ActiveSequencesMultiWorker<NoopSequencePublisher> {

--- a/lib/kv-router/src/sequences/prompt_membership_trie.rs
+++ b/lib/kv-router/src/sequences/prompt_membership_trie.rs
@@ -13,7 +13,7 @@ use crate::protocols::WorkerWithDpRank;
 
 type SharedNode = Arc<RwLock<PromptTrieNode>>;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(super) struct PromptTrieNode {
     edge: Vec<SequenceHash>,
     worker_cutoffs: FxHashMap<WorkerWithDpRank, usize>,
@@ -22,15 +22,6 @@ pub(super) struct PromptTrieNode {
 }
 
 impl PromptTrieNode {
-    fn new() -> Self {
-        Self {
-            edge: Vec::new(),
-            worker_cutoffs: FxHashMap::default(),
-            full_edge_workers: FxHashSet::default(),
-            children: FxHashMap::default(),
-        }
-    }
-
     fn full_edge_workers_for(worker: WorkerWithDpRank) -> FxHashSet<WorkerWithDpRank> {
         let mut full_edge_workers = FxHashSet::with_capacity_and_hasher(1, FxBuildHasher);
         full_edge_workers.insert(worker);
@@ -128,15 +119,10 @@ impl CleanableNode for PromptTrieNode {
     }
 }
 
+#[derive(Default)]
 pub(super) struct PromptMembershipTrie {
     root: SharedNode,
     cleanup: CleanupState,
-}
-
-impl Default for PromptMembershipTrie {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl Drop for PromptMembershipTrie {
@@ -157,13 +143,6 @@ impl Drop for PromptMembershipTrie {
 }
 
 impl PromptMembershipTrie {
-    pub(super) fn new() -> Self {
-        Self {
-            root: Arc::new(RwLock::new(PromptTrieNode::new())),
-            cleanup: CleanupState::new(),
-        }
-    }
-
     /// Run the stale-child sweep if the throttle interval has elapsed.
     ///
     /// Safe to call from any write path; the sweep is a no-op until
@@ -604,7 +583,7 @@ mod tests {
 
     #[test]
     fn full_path_continuations_extend_and_trim() {
-        let trie = PromptMembershipTrie::new();
+        let trie = PromptMembershipTrie::default();
         let worker = worker(1, 0);
 
         trie.store_path(worker, &[1, 2, 3], 0);
@@ -624,7 +603,7 @@ mod tests {
 
     #[test]
     fn branching_continuations_across_workers_match_expected_depths() {
-        let trie = PromptMembershipTrie::new();
+        let trie = PromptMembershipTrie::default();
         let worker_a = worker(1, 0);
         let worker_b = worker(2, 0);
 
@@ -643,7 +622,7 @@ mod tests {
 
     #[test]
     fn partial_suffix_removal_keeps_prefix() {
-        let trie = PromptMembershipTrie::new();
+        let trie = PromptMembershipTrie::default();
         let worker = worker(1, 0);
 
         trie.store_path(worker, &[1, 2, 3, 4, 5], 0);
@@ -657,7 +636,7 @@ mod tests {
 
     #[test]
     fn remove_worker_preserves_other_workers() {
-        let trie = PromptMembershipTrie::new();
+        let trie = PromptMembershipTrie::default();
         let worker_a = worker(1, 0);
         let worker_b = worker(2, 0);
 
@@ -674,7 +653,7 @@ mod tests {
 
     #[test]
     fn multiple_dp_ranks_with_same_worker_id_remain_isolated() {
-        let trie = PromptMembershipTrie::new();
+        let trie = PromptMembershipTrie::default();
         let worker_a = worker(1, 0);
         let worker_b = worker(1, 1);
 
@@ -689,7 +668,7 @@ mod tests {
 
     #[test]
     fn clear_worker_state_then_reuse_starts_empty() {
-        let trie = PromptMembershipTrie::new();
+        let trie = PromptMembershipTrie::default();
         let worker = worker(1, 0);
 
         trie.store_path(worker, &[1, 2, 3], 0);
@@ -705,7 +684,7 @@ mod tests {
 
     #[test]
     fn redundant_batched_remove_is_idempotent() {
-        let trie = PromptMembershipTrie::new();
+        let trie = PromptMembershipTrie::default();
         let worker = worker(1, 0);
 
         trie.store_path(worker, &[1, 2, 3, 4], 0);
@@ -720,7 +699,7 @@ mod tests {
 
     #[test]
     fn path_ending_inside_another_workers_edge_uses_a_cutoff() {
-        let trie = PromptMembershipTrie::new();
+        let trie = PromptMembershipTrie::default();
         let worker_a = worker(1, 0);
         let worker_b = worker(2, 0);
 
@@ -735,7 +714,7 @@ mod tests {
 
     #[test]
     fn full_path_mutation_follows_suffix_after_a_split() {
-        let trie = PromptMembershipTrie::new();
+        let trie = PromptMembershipTrie::default();
         let worker_a = worker(1, 0);
         let worker_b = worker(2, 0);
 
@@ -782,7 +761,7 @@ mod tests {
 
     #[test]
     fn randomized_prefix_union_matches_naive_model() {
-        let trie = PromptMembershipTrie::new();
+        let trie = PromptMembershipTrie::default();
         let workers = [worker(1, 0), worker(2, 0), worker(2, 1)];
         // Every hash denotes exactly one lineage position. Shared prefixes
         // reuse hashes; branches and unrelated roots use distinct hashes.
@@ -868,7 +847,7 @@ mod tests {
     #[test]
     fn concurrent_cross_worker_splits_preserve_both_paths() {
         for _ in 0..128 {
-            let trie = Arc::new(PromptMembershipTrie::new());
+            let trie = Arc::new(PromptMembershipTrie::default());
             let worker_a = worker(1, 0);
             let worker_b = worker(2, 0);
             let worker_c = worker(3, 0);
@@ -909,7 +888,7 @@ mod tests {
     #[test]
     fn concurrent_first_root_insertion_preserves_both_workers() {
         for _ in 0..128 {
-            let trie = Arc::new(PromptMembershipTrie::new());
+            let trie = Arc::new(PromptMembershipTrie::default());
             let worker_a = worker(1, 0);
             let worker_b = worker(2, 0);
             let barrier = Arc::new(std::sync::Barrier::new(3));
@@ -943,7 +922,7 @@ mod tests {
 
     #[test]
     fn cleanup_does_not_unlink_a_pinned_child() {
-        let trie = PromptMembershipTrie::new();
+        let trie = PromptMembershipTrie::default();
         let worker = worker(1, 0);
         trie.store_path(worker, &[1, 2, 3], 0);
         let pinned = trie

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -114,19 +114,11 @@ impl WorkerLoadSlot {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct WorkerLoadTable {
     // IndexMap gives us the dense full-worker scan plus point lookup shape that was previously
     // hand-rolled as Vec<WorkerLoadSlot> + FxHashMap<WorkerWithDpRank, usize>.
     entries: IndexMap<WorkerWithDpRank, WorkerLoadSlot, FxBuildHasher>,
-}
-
-impl Default for WorkerLoadTable {
-    fn default() -> Self {
-        Self {
-            entries: IndexMap::with_hasher(FxBuildHasher),
-        }
-    }
 }
 
 impl WorkerLoadTable {
@@ -167,6 +159,7 @@ impl WorkerLoadTable {
     }
 }
 
+#[derive(Default)]
 pub(super) struct PromptRegistry {
     // WARNING: prompt membership and worker load are only eventually consistent.
     // Each mutation still starts from one worker-local source of truth: we mutate the chosen
@@ -178,17 +171,6 @@ pub(super) struct PromptRegistry {
     loads: RwLock<WorkerLoadTable>,
     #[cfg(test)]
     cleanup_attempts: AtomicUsize,
-}
-
-impl Default for PromptRegistry {
-    fn default() -> Self {
-        Self {
-            membership: PromptMembershipTrie::new(),
-            loads: RwLock::new(WorkerLoadTable::default()),
-            #[cfg(test)]
-            cleanup_attempts: AtomicUsize::new(0),
-        }
-    }
 }
 
 impl PromptRegistry {

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -125,27 +125,13 @@ impl ActiveSequences {
         Self::new_with_expiry(block_size, Some(DEFAULT_ACTIVE_REQUEST_EXPIRY_DURATION))
     }
 
-    /// Creates a tracker with an explicit stale-request expiry duration.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `expiry_duration` is zero or `block_size` is zero.
-    pub(super) fn new_with_expiry_duration(block_size: usize, expiry_duration: Duration) -> Self {
+    /// Builds a tracker from an optional stale-request expiry policy.
+    pub(super) fn new_with_expiry(block_size: usize, expiry_duration: Option<Duration>) -> Self {
+        assert!(block_size > 0, "block_size must be greater than 0");
         assert!(
-            !expiry_duration.is_zero(),
+            expiry_duration.is_none_or(|duration| !duration.is_zero()),
             "expiry_duration must be greater than zero"
         );
-        Self::new_with_expiry(block_size, Some(expiry_duration))
-    }
-
-    /// Creates a tracker that relies only on explicit request lifecycle events.
-    pub(super) fn new_without_expiry(block_size: usize) -> Self {
-        Self::new_with_expiry(block_size, None)
-    }
-
-    /// Builds a tracker from an optional stale-request expiry policy.
-    fn new_with_expiry(block_size: usize, expiry_duration: Option<Duration>) -> Self {
-        assert!(block_size > 0, "block_size must be greater than 0");
 
         Self {
             requests: HashMap::new(),
@@ -396,7 +382,7 @@ mod tests {
     #[test]
     fn active_worker_teardown_with_a_live_long_chain_is_iterative() {
         const DEPTH: usize = 65_536;
-        let mut sequences = ActiveSequences::new_without_expiry(1);
+        let mut sequences = ActiveSequences::new_with_expiry(1, None);
         sequences.add_request_with_prefill_tracking(
             "long-lived".to_string(),
             Some((1..=DEPTH as u64).collect()),
@@ -810,7 +796,7 @@ mod tests {
     async fn test_force_expiry_uses_custom_duration() {
         let block_size = 4;
         let mut seq_manager =
-            ActiveSequences::new_with_expiry_duration(block_size, Duration::from_secs(60));
+            ActiveSequences::new_with_expiry(block_size, Some(Duration::from_secs(60)));
 
         seq_manager.add_request_with_prefill_tracking(
             "r1".to_string(),
@@ -836,13 +822,12 @@ mod tests {
     #[test]
     #[should_panic(expected = "expiry_duration must be greater than zero")]
     fn test_custom_expiry_rejects_zero_duration() {
-        let _ = ActiveSequences::new_with_expiry_duration(4, Duration::ZERO);
+        let _ = ActiveSequences::new_with_expiry(4, Some(Duration::ZERO));
     }
 
     #[tokio::test(start_paused = true)]
     async fn test_force_expiry_reanchors_new_oldest_request() {
-        let mut seq_manager =
-            ActiveSequences::new_with_expiry_duration(4, Duration::from_secs(120));
+        let mut seq_manager = ActiveSequences::new_with_expiry(4, Some(Duration::from_secs(120)));
         let first_decay_now = Instant::now();
 
         seq_manager.add_request_with_prefill_tracking(

--- a/lib/kv-router/src/sequences/topology.rs
+++ b/lib/kv-router/src/sequences/topology.rs
@@ -91,10 +91,7 @@ pub(super) struct WorkerSlot {
 impl WorkerSlot {
     /// Creates a worker slot with the table's expiry policy.
     fn new(worker: WorkerWithDpRank, block_size: usize, expiry_duration: Option<Duration>) -> Self {
-        let sequences = match expiry_duration {
-            Some(duration) => ActiveSequences::new_with_expiry_duration(block_size, duration),
-            None => ActiveSequences::new_without_expiry(block_size),
-        };
+        let sequences = ActiveSequences::new_with_expiry(block_size, expiry_duration);
         Self {
             worker,
             sequences: RwLock::new(sequences),
@@ -113,28 +110,15 @@ impl WorkerTable {
     /// Creates test worker slots with the default stale-request expiry duration.
     #[cfg(test)]
     pub(super) fn new(block_size: usize, dp_range: &HashMap<u64, (u32, u32)>) -> Self {
-        Self::new_with_expiry_duration(block_size, dp_range, DEFAULT_ACTIVE_REQUEST_EXPIRY_DURATION)
-    }
-
-    /// Creates worker slots with an explicit stale-request expiry duration.
-    pub(super) fn new_with_expiry_duration(
-        block_size: usize,
-        dp_range: &HashMap<u64, (u32, u32)>,
-        expiry_duration: Duration,
-    ) -> Self {
-        Self::new_with_expiry(block_size, dp_range, Some(expiry_duration))
-    }
-
-    /// Creates worker slots that rely only on explicit request lifecycle events.
-    pub(super) fn new_without_expiry(
-        block_size: usize,
-        dp_range: &HashMap<u64, (u32, u32)>,
-    ) -> Self {
-        Self::new_with_expiry(block_size, dp_range, None)
+        Self::new_with_expiry(
+            block_size,
+            dp_range,
+            Some(DEFAULT_ACTIVE_REQUEST_EXPIRY_DURATION),
+        )
     }
 
     /// Builds worker slots from an optional stale-request expiry policy.
-    fn new_with_expiry(
+    pub(super) fn new_with_expiry(
         block_size: usize,
         dp_range: &HashMap<u64, (u32, u32)>,
         expiry_duration: Option<Duration>,

--- a/lib/kv-router/src/services/indexer/server.rs
+++ b/lib/kv-router/src/services/indexer/server.rs
@@ -90,9 +90,7 @@ struct RegisterRequest {
     #[serde(default = "default_routing_group", rename = "tenant_id")]
     _tenant_id: String,
     block_size: u32,
-    #[serde(default)]
     dp_rank: Option<u32>,
-    #[serde(default)]
     replay_endpoint: Option<String>,
     /// Optional per-tenant salt (Mooncake RFC #1403 `additionalsalt`).
     /// Currently accepted but not yet mixed into hashes — engines apply
@@ -105,11 +103,9 @@ struct RegisterRequest {
 struct UnregisterRequest {
     instance_id: WorkerId,
     model_name: String,
-    #[serde(default)]
     routing_group: Option<String>,
     #[serde(default, rename = "tenant_id")]
     _tenant_id: Option<String>,
-    #[serde(default)]
     dp_rank: Option<u32>,
 }
 
@@ -121,10 +117,8 @@ struct QueryRequest {
     routing_group: String,
     #[serde(default = "default_routing_group", rename = "tenant_id")]
     _tenant_id: String,
-    #[serde(default)]
     lora_name: Option<String>,
     /// Optional per-request cache salt (Mooncake RFC #1403), mixed into `/query` hashes.
-    #[serde(default)]
     cache_salt: Option<String>,
 }
 
@@ -138,7 +132,6 @@ struct QueryByHashRequest {
     _tenant_id: String,
     /// Invalid for `/query_by_hash`. Callers must precompute `block_hashes` with the intended
     /// cache salt and omit this field; a non-null value is rejected.
-    #[serde(default)]
     cache_salt: Option<String>,
 }
 
@@ -397,7 +390,6 @@ async fn query_by_hash(
 #[derive(Deserialize)]
 struct ListenerControlRequest {
     instance_id: WorkerId,
-    #[serde(default)]
     dp_rank: Option<u32>,
 }
 

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -144,28 +144,6 @@ impl SelectionCore {
             .collect()
     }
 
-    /// Create an intentionally local selector without replica synchronization
-    /// or startup recovery.
-    ///
-    /// # Panics
-    ///
-    /// Panics when the tracking-hash configuration is invalid. Use
-    /// [`Self::try_new_local`] when configuration errors must be reported.
-    pub fn new_local(
-        kv_router_config: crate::config::KvRouterConfig,
-        indexer_threads: usize,
-        cancel_token: CancellationToken,
-        cache_config: SelectionCacheConfig,
-    ) -> Self {
-        Self::try_new_local(
-            kv_router_config,
-            indexer_threads,
-            cancel_token,
-            cache_config,
-        )
-        .expect("selection tracking hash configuration must be valid")
-    }
-
     /// Create a local selector and report invalid tracking configuration.
     pub fn try_new_local(
         kv_router_config: crate::config::KvRouterConfig,
@@ -489,7 +467,7 @@ impl SelectionCore {
                     .kv_router_config
                     .policy_profile(Some(&key.model_name))
                     .map_err(|error| SelectionError::BadRequest(error.to_string()))?;
-                let scheduler = LocalScheduler::new_with_policy_profile(
+                let scheduler = LocalScheduler::new(
                     slots,
                     workers_rx,
                     profile,
@@ -505,7 +483,7 @@ impl SelectionCore {
                     self.cancel_token.child_token(),
                     worker_label,
                     true,
-                )?;
+                );
                 Ok(Arc::new(SelectionEntry {
                     key: key.clone(),
                     block_size,
@@ -1364,12 +1342,13 @@ mod tests {
     #[test]
     fn parent_cancel_cancels_core() {
         let parent = CancellationToken::new();
-        let core = SelectionCore::new_local(
+        let core = SelectionCore::try_new_local(
             test_config(false),
             1,
             parent.clone(),
             SelectionCacheConfig::default(),
-        );
+        )
+        .expect("valid test config");
 
         assert!(!core.cancel_token.is_cancelled());
         parent.cancel();
@@ -1416,12 +1395,13 @@ mod tests {
     #[test]
     fn shutdown_keeps_parent_alive() {
         let parent = CancellationToken::new();
-        let core = SelectionCore::new_local(
+        let core = SelectionCore::try_new_local(
             test_config(false),
             1,
             parent.clone(),
             SelectionCacheConfig::default(),
-        );
+        )
+        .expect("valid test config");
 
         core.shutdown();
 
@@ -1432,12 +1412,13 @@ mod tests {
     #[tokio::test]
     async fn shutdown_cancels_listeners() {
         let parent = CancellationToken::new();
-        let core = SelectionCore::new_local(
+        let core = SelectionCore::try_new_local(
             test_config(true),
             1,
             parent,
             SelectionCacheConfig::default(),
-        );
+        )
+        .expect("valid test config");
 
         let record = core
             .upsert_worker(worker_with_kv_events(1))
@@ -1452,12 +1433,13 @@ mod tests {
 
     #[tokio::test]
     async fn upsert_moves_global_worker_id_between_routing_groups() {
-        let core = SelectionCore::new_local(
+        let core = SelectionCore::try_new_local(
             test_config(true),
             1,
             CancellationToken::new(),
             SelectionCacheConfig::default(),
-        );
+        )
+        .expect("valid test config");
         let mut group_a = worker_with_kv_events(1);
         group_a.routing_group = "group-a".to_string();
         core.upsert_worker(group_a).await.expect("group A upsert");
@@ -1506,12 +1488,13 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_reports_not_ready_and_rejects_new_work() {
-        let core = SelectionCore::new_local(
+        let core = SelectionCore::try_new_local(
             test_config(false),
             1,
             CancellationToken::new(),
             SelectionCacheConfig::default(),
-        );
+        )
+        .expect("valid test config");
         core.upsert_worker(worker(1)).await.expect("worker upsert");
         assert!(core.ready().ready);
 
@@ -1573,12 +1556,15 @@ mod tests {
     async fn queued_selection_errors_on_shutdown() {
         let mut config = test_config(false);
         config.router_queue_threshold = Some(0.0);
-        let core = Arc::new(SelectionCore::new_local(
-            config,
-            1,
-            CancellationToken::new(),
-            SelectionCacheConfig::default(),
-        ));
+        let core = Arc::new(
+            SelectionCore::try_new_local(
+                config,
+                1,
+                CancellationToken::new(),
+                SelectionCacheConfig::default(),
+            )
+            .expect("valid test config"),
+        );
 
         let record = core.upsert_worker(worker(1)).await.expect("worker upsert");
         assert_eq!(record.lifecycle, WorkerLifecycle::Schedulable);
@@ -1607,12 +1593,13 @@ mod tests {
     async fn lifecycle_operations_find_reservation_in_later_entry() {
         let mut config = test_config(false);
         config.router_track_prefill_tokens = true;
-        let core = SelectionCore::new_local(
+        let core = SelectionCore::try_new_local(
             config,
             1,
             CancellationToken::new(),
             SelectionCacheConfig::default(),
-        );
+        )
+        .expect("valid test config");
 
         for (worker_id, routing_group) in [(1, "group-a"), (2, "group-b")] {
             let mut request = worker(worker_id);
@@ -1665,12 +1652,15 @@ mod tests {
     async fn queued_selection_returns_refreshed_overlap_snapshot() {
         let mut config = test_config(false);
         config.router_queue_threshold = Some(0.0);
-        let core = Arc::new(SelectionCore::new_local(
-            config,
-            1,
-            CancellationToken::new(),
-            SelectionCacheConfig::default(),
-        ));
+        let core = Arc::new(
+            SelectionCore::try_new_local(
+                config,
+                1,
+                CancellationToken::new(),
+                SelectionCacheConfig::default(),
+            )
+            .expect("valid test config"),
+        );
 
         for worker_id in [1, 2] {
             let mut request = worker(worker_id);

--- a/lib/kv-router/src/services/selection/input.rs
+++ b/lib/kv-router/src/services/selection/input.rs
@@ -28,23 +28,15 @@ pub struct MmRoutingInfoRequest {
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct PromptRequest {
-    #[serde(default)]
     pub token_ids: Option<Vec<u32>>,
-    #[serde(default)]
     pub mm_routing_info: Option<MmRoutingInfoRequest>,
-    #[serde(default)]
     pub block_mm_infos: Option<Vec<Option<BlockExtraInfo>>>,
-    #[serde(default)]
     pub block_hashes: Option<Vec<i64>>,
-    #[serde(default)]
     pub sequence_hashes: Option<Vec<i64>>,
-    #[serde(default)]
     pub isl_tokens: Option<usize>,
-    #[serde(default)]
     pub lora_name: Option<String>,
     #[serde(default, rename = "cache_salt")]
     pub cache_namespace: Option<String>,
-    #[serde(default)]
     pub is_eagle: Option<bool>,
 }
 

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -233,12 +233,15 @@ impl SelectionService {
     ) -> Self {
         let cancel_token = CancellationToken::new();
         Self {
-            core: Arc::new(SelectionCore::new_local(
-                kv_router_config,
-                indexer_threads,
-                cancel_token.clone(),
-                SelectionCacheConfig::default(),
-            )),
+            core: Arc::new(
+                SelectionCore::try_new_local(
+                    kv_router_config,
+                    indexer_threads,
+                    cancel_token.clone(),
+                    SelectionCacheConfig::default(),
+                )
+                .expect("valid test config"),
+            ),
             peer_manager: None,
             replica_runtime: None,
             replica_sync_port: None,

--- a/lib/kv-router/src/services/selection/types.rs
+++ b/lib/kv-router/src/services/selection/types.rs
@@ -266,73 +266,44 @@ pub struct WorkerRequest {
     pub model_name: String,
     #[serde(default = "default_routing_group")]
     pub routing_group: String,
-    #[serde(default)]
     pub endpoint: Option<String>,
-    #[serde(default)]
     pub kv_events_endpoint: Option<String>,
     #[serde(default)]
     pub kv_events_endpoints: HashMap<u32, String>,
-    #[serde(default)]
     pub replay_endpoint: Option<String>,
-    #[serde(default)]
     pub block_size: Option<u32>,
-    #[serde(default)]
     pub data_parallel_start_rank: Option<u32>,
-    #[serde(default)]
     pub data_parallel_size: Option<u32>,
-    #[serde(default)]
     pub max_num_batched_tokens: Option<u64>,
-    #[serde(default)]
     pub total_kv_blocks: Option<u64>,
-    #[serde(default)]
     pub stable_routing_id: Option<String>,
-    #[serde(default)]
     pub is_eagle: Option<bool>,
     #[serde(default)]
     pub taints: HashSet<String>,
     #[serde(default)]
     pub topology_domains: HashMap<String, String>,
-    #[serde(default)]
     pub kv_transfer_domain: Option<String>,
-    #[serde(default)]
     pub kv_transfer_enforcement: Option<KvTransferEnforcement>,
-    #[serde(default)]
     pub kv_transfer_preferred_weight: Option<f32>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct WorkerPatchRequest {
-    #[serde(default)]
     pub endpoint: Option<String>,
-    #[serde(default)]
     pub kv_events_endpoint: Option<String>,
-    #[serde(default)]
     pub kv_events_endpoints: Option<HashMap<u32, String>>,
-    #[serde(default)]
     pub replay_endpoint: Option<String>,
-    #[serde(default)]
     pub block_size: Option<u32>,
-    #[serde(default)]
     pub data_parallel_start_rank: Option<u32>,
-    #[serde(default)]
     pub data_parallel_size: Option<u32>,
-    #[serde(default)]
     pub max_num_batched_tokens: Option<u64>,
-    #[serde(default)]
     pub total_kv_blocks: Option<u64>,
-    #[serde(default)]
     pub stable_routing_id: Option<String>,
-    #[serde(default)]
     pub is_eagle: Option<bool>,
-    #[serde(default)]
     pub taints: Option<HashSet<String>>,
-    #[serde(default)]
     pub topology_domains: Option<HashMap<String, String>>,
-    #[serde(default)]
     pub kv_transfer_domain: Option<String>,
-    #[serde(default)]
     pub kv_transfer_enforcement: Option<KvTransferEnforcement>,
-    #[serde(default)]
     pub kv_transfer_preferred_weight: Option<f32>,
 }
 
@@ -398,25 +369,16 @@ pub struct SelectRequest {
     pub model_name: String,
     #[serde(default = "default_routing_group")]
     pub routing_group: String,
-    #[serde(default)]
     pub selection_id: Option<String>,
     #[serde(flatten)]
     pub prompt: PromptRequest,
-    #[serde(default)]
     pub router_config_override: Option<RouterConfigOverride>,
-    #[serde(default)]
     pub expected_output_tokens: Option<u32>,
-    #[serde(default)]
     pub priority_jump: Option<f64>,
-    #[serde(default)]
     pub strict_priority: Option<u32>,
-    #[serde(default)]
     pub session_id: Option<String>,
-    #[serde(default)]
     pub affinity_target: Option<WorkerAffinityTarget>,
-    #[serde(default)]
     pub pinned_worker: Option<WorkerWithDpRank>,
-    #[serde(default)]
     pub allowed_worker_ids: Option<HashSet<WorkerId>>,
     #[serde(default)]
     pub routing_constraints: RoutingConstraints,
@@ -428,25 +390,16 @@ pub struct SelectAndReserveRequest {
     pub model_name: String,
     #[serde(default = "default_routing_group")]
     pub routing_group: String,
-    #[serde(default)]
     pub selection_id: Option<String>,
     #[serde(flatten)]
     pub prompt: PromptRequest,
-    #[serde(default)]
     pub router_config_override: Option<RouterConfigOverride>,
-    #[serde(default)]
     pub expected_output_tokens: Option<u32>,
-    #[serde(default)]
     pub priority_jump: Option<f64>,
-    #[serde(default)]
     pub strict_priority: Option<u32>,
-    #[serde(default)]
     pub session_id: Option<String>,
-    #[serde(default)]
     pub affinity_target: Option<WorkerAffinityTarget>,
-    #[serde(default)]
     pub pinned_worker: Option<WorkerWithDpRank>,
-    #[serde(default)]
     pub allowed_worker_ids: Option<HashSet<WorkerId>>,
     #[serde(default)]
     pub routing_constraints: RoutingConstraints,
@@ -466,25 +419,18 @@ pub struct ReservationRequest {
     pub selection_id: String,
     /// Explicit, self-contained form: books under `selection_id` on this worker
     /// without a cached select. Omit to replay the cached `selection_id`.
-    #[serde(default)]
     pub worker_id: Option<WorkerId>,
-    #[serde(default)]
     pub dp_rank: Option<DpRank>,
     #[serde(flatten)]
     pub prompt: PromptRequest,
-    #[serde(default)]
     pub router_config_override: Option<RouterConfigOverride>,
-    #[serde(default)]
     pub expected_output_tokens: Option<u32>,
-    #[serde(default)]
     pub effective_prefill_tokens: Option<usize>,
-    #[serde(default)]
     pub track_prefill_tokens: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct OutputBlockRequest {
-    #[serde(default)]
     pub decay_fraction: Option<f64>,
 }
 
@@ -496,7 +442,6 @@ pub struct PotentialLoadsRequest {
     pub routing_group: String,
     #[serde(flatten)]
     pub prompt: PromptRequest,
-    #[serde(default)]
     pub router_config_override: Option<RouterConfigOverride>,
 }
 
@@ -508,7 +453,6 @@ pub struct OverlapScoresRequest {
     pub routing_group: String,
     #[serde(flatten)]
     pub prompt: PromptRequest,
-    #[serde(default)]
     pub router_config_override: Option<RouterConfigOverride>,
 }
 

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -191,7 +191,7 @@ where
             .map(|(index, class)| (class.name.clone(), index))
             .collect();
 
-        let inner = Arc::new(LocalScheduler::new_with_policy_profile(
+        let inner = Arc::new(LocalScheduler::new(
             slots,
             workers_with_configs.clone(),
             profile,
@@ -206,7 +206,7 @@ where
             cancellation_token.child_token(),
             worker_type,
             watch_worker_configs,
-        )?);
+        ));
         if worker_type == WORKER_TYPE_PREFILL {
             let locality_observer: NonMaxOverlapSelectionObserver =
                 Arc::new(move |request_id, selection| {

--- a/lib/mocker/src/replay/online/router.rs
+++ b/lib/mocker/src/replay/online/router.rs
@@ -205,7 +205,7 @@ impl KvReplayRouter {
             .configured_policy_profile()
             .map_err(anyhow::Error::from)?;
         let scheduler_cancel = CancellationToken::new();
-        let scheduler = Arc::new(dynamo_kv_router::LocalScheduler::new_with_policy_profile(
+        let scheduler = Arc::new(dynamo_kv_router::LocalScheduler::new(
             slots,
             worker_config_rx,
             profile,
@@ -220,7 +220,7 @@ impl KvReplayRouter {
             scheduler_cancel.clone(),
             "replay",
             false,
-        )?);
+        ));
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         let indexer_clone = indexer.clone();
         let event_task = tokio::spawn(async move {


### PR DESCRIPTION
## Summary

- remove redundant external-hash scans, impossible CRTC retry states, and CAS loops already serialized by the node shape gate
- replace branch-sharded fallback flags with explicit routes, fail closed on missing anchors/private-state corruption, and make CKF snapshot recovery one attempt per caller invocation
- collapse scheduler, sequence-tracker, trie, and selection constructor ladders; remove deprecated branch-sharded compatibility shims and redundant `serde(default)` attributes on `Option` fields
- preserve CLI, HTTP, Python, and wire behavior; this intentionally removes obsolete Rust-only source APIs such as the scheduler constructor variants, `SelectionCore::new_local`, the branch-sharded aliases, and `LocalCkfRecoveryPolicy`

The patch is 746 net lines smaller (478 additions, 1,224 deletions). It adds one focused CKF recovery contract test while deleting obsolete policy/boundary tests; it does not add duplicative test coverage.

## Validation

- `cargo clippy --no-deps --all-targets -- -D warnings` and `cargo fmt` in `lib/kv-router`
- `cargo clippy --no-default-features -- -D warnings` and `cargo fmt` in `lib/llm`
- `cargo clippy --no-deps --all-targets -- -D warnings` and `cargo fmt` in `lib/mocker`
- `cargo clippy --no-default-features -- -D warnings` and `cargo fmt` in `lib/bench`
- `cargo clippy -p dynamo-bench --bench mooncake_bench --no-default-features --features mooncake -- -D warnings`
- `cargo test -p dynamo-kv-router --all-features`, 100 consecutive runs: each run passed 1,075 library tests and 7 standalone HTTP integration tests (108,200 passing test executions total; 2 ignored per run)
- `docs/fern/scripts/docs_lint.py`: 0 errors (8 pre-existing warnings outside the edited page)
- `git diff --check`

### CRTC Mooncake benchmark

Ran 20 fresh processes per side from an isolated `origin/main` baseline and this candidate. The full trace checksum was `b434f1816a707f4bac697235588184ebc374c9907cb981bb65fb0643471fe711`. Both used 128 query lanes, 128 inference workers, 20x trace duplication, 4x trace length, 750 ms replay, 8 event workers, and 512-token trace blocks. CPU affinity was adapted to this 24-core host: issuers 0-7, query issuer 8, backends 9-23.

| | Baseline | Candidate | Delta |
|---|---:|---:|---:|
| Mean block ops/s | 58.127M | 58.236M | +0.19% |
| Median block ops/s | 58.137M | 58.145M | +0.01% |
| Generator-valid runs | 20/20 | 20/20 | - |
| `kept_up` runs | 0/20 | 0/20 | - |

Both variants were overloaded by this host adaptation, so the result demonstrates throughput parity under identical pressure rather than an SLO pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated integration guidance to recommend the supported builder for production use.

* **API Changes**
  * Simplified scheduler, queue, sequence, and indexer construction APIs.
  * Local selection initialization now reports configuration errors instead of silently assuming valid settings.
  * Removed legacy constructors, aliases, and compatibility exports.

* **Behavior Changes**
  * Invalid routing, arithmetic, ownership, and capacity states now fail explicitly.
  * Snapshot recovery performs a single attempt and leaves admission closed on failure.
  * Several request and configuration fields must now be explicitly provided during deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->