### PR TITLE
test(lora): add nightly LoRA churn regression

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -526,6 +526,18 @@ jobs:
       copy_timeout_minutes: 20
     secrets: inherit
 
+  frontend-copy-to-acr:
+    name: dynamo-frontend-nightly
+    needs: [compute-release-mode, frontend-build]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: $/.github/workflows/shared-copy.yml
+    with:
+      target_tag_plain: ${{ format('{0}-nightly', needs.frontend-build.outputs.target_tag_plain) }}
+      cuda_version: '[""]'
+      override_arch: amd64
+      copy_timeout_minutes: 10
+    secrets: inherit
+
   sglang-copy-to-acr:
     name: sglang-runtime-nightly
     needs: [compute-release-mode, sglang-build]
@@ -594,6 +606,25 @@ jobs:
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
     secrets: inherit
 
+  deploy-test-lora-churn-vllm:
+    name: vLLM LoRA Churn Nightly Deploy Test
+    needs: [compute-release-mode, deploy-operator, vllm-build, vllm-copy-to-acr, frontend-build, frontend-copy-to-acr]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: $/.github/workflows/shared-deploy-test.yml
+    with:
+      framework: vllm
+      profiles: '["lora_churn"]'
+      image_tag: ${{ needs.vllm-copy-to-acr.outputs.image_tag }}
+      namespace: ${{ needs.deploy-operator.outputs.namespace }}
+      vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
+      operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+      test_file: tests/deploy/test_lora_churn.py
+      test_name: lora_churn
+      extra_pytest_args: >-
+        --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ needs.frontend-copy-to-acr.outputs.image_tag }}
+      timeout_minutes: 35
+    secrets: inherit
+
   deploy-test-sglang:
     name: sglang Nightly Deploy Test
     needs: [compute-release-mode, deploy-operator, sglang-build, sglang-copy-to-acr]
@@ -625,7 +656,7 @@ jobs:
   deploy-cleanup:
     name: Nightly Deploy Cleanup
     if: always()
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm]
+    needs: [deploy-operator, deploy-test-vllm, deploy-test-lora-churn-vllm, deploy-test-sglang, deploy-test-trtllm]
     runs-on: prod-deploy-tester-v1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -622,7 +622,7 @@ jobs:
       test_name: lora_churn
       extra_pytest_args: >-
         --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ needs.frontend-copy-to-acr.outputs.image_tag }}
-      timeout_minutes: 35
+      timeout_minutes: 40
     secrets: inherit
 
   deploy-test-sglang:

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -620,8 +620,7 @@ jobs:
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
       test_file: tests/deploy/test_lora_churn.py
       test_name: lora_churn
-      extra_pytest_args: >-
-        --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ needs.frontend-copy-to-acr.outputs.image_tag }}
+      frontend_image_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
       timeout_minutes: 40
     secrets: inherit
 

--- a/.github/workflows/shared-deploy-test.yml
+++ b/.github/workflows/shared-deploy-test.yml
@@ -18,6 +18,11 @@ on:
         description: 'Runtime image tag'
         type: string
         required: true
+      frontend_image_tag:
+        description: 'Optional frontend image tag'
+        type: string
+        required: false
+        default: ''
       namespace:
         description: 'Host namespace where the vCluster lives'
         type: string
@@ -107,7 +112,9 @@ jobs:
           platform_arch: amd64
           test_file: ${{ inputs.test_file }}
           test_name: ${{ inputs.test_name }}
-          extra_pytest_args: ${{ inputs.extra_pytest_args }}
+          extra_pytest_args: >-
+            ${{ inputs.extra_pytest_args }}
+            ${{ inputs.frontend_image_tag != '' && format('--frontend-image={0}/{1}:{2}', secrets.AZURE_ACR_HOSTNAME, vars.ACR_REPOSITORY, inputs.frontend_image_tag) || '' }}
           # Mount the shared model cache only when both endpoint vars are set
           # (matches the PV/PVC creation gate); otherwise workers download from HF.
           model_cache_pvc: ${{ vars.AZURE_MODEL_CACHE_SERVER != '' && vars.AZURE_MODEL_CACHE_PATH != '' && 'model-cache' || '' }}

--- a/.github/workflows/shared-deploy-test.yml
+++ b/.github/workflows/shared-deploy-test.yml
@@ -31,10 +31,30 @@ on:
         type: string
         required: true
 
+      test_file:
+        description: 'Pytest file to run'
+        type: string
+        required: false
+        default: 'tests/deploy/test_dgd.py'
+      test_name:
+        description: 'Name used for test result artifacts'
+        type: string
+        required: false
+        default: ''
+      extra_pytest_args:
+        description: 'Additional pytest arguments'
+        type: string
+        required: false
+        default: '-m framework_only'
+      timeout_minutes:
+        description: 'Maximum duration of the deploy test job'
+        type: number
+        required: false
+        default: 25
 jobs:
   deploy-test:
     runs-on: prod-deploy-tester-v1
-    timeout-minutes: 25
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     permissions:
       contents: read
     strategy:
@@ -85,7 +105,9 @@ jobs:
           profile: ${{ matrix.profile }}
           image: ${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ inputs.image_tag }}
           platform_arch: amd64
-          extra_pytest_args: -m framework_only
+          test_file: ${{ inputs.test_file }}
+          test_name: ${{ inputs.test_name }}
+          extra_pytest_args: ${{ inputs.extra_pytest_args }}
           # Mount the shared model cache only when both endpoint vars are set
           # (matches the PV/PVC creation gate); otherwise workers download from HF.
           model_cache_pvc: ${{ vars.AZURE_MODEL_CACHE_SERVER != '' && vars.AZURE_MODEL_CACHE_PATH != '' && 'model-cache' || '' }}

--- a/tests/deploy/test_lora_churn.py
+++ b/tests/deploy/test_lora_churn.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Nightly regression coverage for repeated vLLM LoRA registration."""
+
+import asyncio
+import json
+import logging
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+import requests
+import yaml
+
+from tests.deploy.dgd_utils import DeploymentSpec, ManagedDeployment, _get_workspace_dir
+from tests.utils.client import send_request, wait_for_model_availability
+
+logger = logging.getLogger(__name__)
+
+BASE_MODEL = "Qwen/Qwen3-0.6B"
+LORA_NAME = "codelion/Qwen3-0.6B-accuracy-recovery-lora"
+LORA_SOURCE = f"hf://{LORA_NAME}"
+CHURN_CYCLES = 30
+CHATS_PER_CYCLE = 3
+MAX_FD_GROWTH = 3
+MAX_RSS_GROWTH_KIB = 64 * 1024
+UNLOAD_TIMEOUT_SECONDS = 30
+RSS_SETTLE_SECONDS = 60
+
+
+def _memory_probe(pod: Any) -> dict[str, int]:
+    """Read the main process's RSS and descriptor counts from its namespace."""
+    snippet = """
+import json
+import os
+from pathlib import Path
+
+status = Path("/proc/1/status").read_text().splitlines()
+rss_kib = next(int(line.split()[1]) for line in status if line.startswith("VmRSS:"))
+targets = []
+for descriptor in Path("/proc/1/fd").iterdir():
+    try:
+        targets.append(os.readlink(descriptor))
+    except FileNotFoundError:
+        pass
+print(json.dumps({
+    "fds": len(targets),
+    "sockets": sum(target.startswith("socket:") for target in targets),
+    "rss_kib": rss_kib,
+}))
+"""
+    result = pod.exec(["python3", "-c", snippet])
+    return json.loads(result.stdout.decode())
+
+
+def _snapshot(deployment: ManagedDeployment) -> dict[str, dict[str, int]]:
+    snapshots: dict[str, dict[str, int]] = {}
+    for service_name in ("Frontend", "VllmDecodeWorker"):
+        pods = deployment.get_pods([service_name]).get(service_name, [])
+        assert len(pods) == 1, f"Expected one {service_name} pod, got {len(pods)}"
+        snapshots[service_name] = _memory_probe(pods[0])
+    return snapshots
+
+
+def _dgd_manifest_path(tmp_path: Path) -> Path:
+    """Write the DGD from the two-document LoRA example to an isolated file."""
+    manifest = Path(_get_workspace_dir()) / "examples/backends/vllm/deploy/lora/agg_lora_hf.yaml"
+    documents = list(yaml.safe_load_all(manifest.read_text()))
+    dgd = next(
+        document
+        for document in documents
+        if document and document.get("kind") == "DynamoGraphDeployment"
+    )
+    dgd_path = tmp_path / "lora-churn-dgd.yaml"
+    dgd_path.write_text(yaml.safe_dump(dgd, sort_keys=False))
+    return dgd_path
+
+
+def _adapter_present(base_url: str) -> bool:
+    response = requests.get(f"{base_url}/v1/models", timeout=10)
+    response.raise_for_status()
+    return any(model.get("id") == LORA_NAME for model in response.json().get("data", []))
+
+
+def _adapter_removed(base_url: str) -> bool:
+    loras = requests.get(f"{base_url}/v1/loras", timeout=10)
+    loras.raise_for_status()
+    return not _adapter_present(base_url) and loras.json().get("count") == 0
+
+
+def _wait_for(predicate: Callable[[], bool], description: str) -> None:
+    deadline = time.monotonic() + UNLOAD_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(1)
+    pytest.fail(f"Timed out waiting for {description}")
+
+
+def _load_lora(base_url: str) -> None:
+    response = requests.post(
+        f"{base_url}/v1/loras",
+        json={"lora_name": LORA_NAME, "source": {"uri": LORA_SOURCE}},
+        timeout=60,
+    )
+    assert response.ok, response.text
+    _wait_for(lambda: _adapter_present(base_url), "LoRA to appear in /v1/models")
+
+
+def _unload_lora(base_url: str) -> None:
+    response = requests.delete(f"{base_url}/v1/loras/{LORA_NAME}", timeout=60)
+    assert response.ok, response.text
+    _wait_for(lambda: _adapter_removed(base_url), "LoRA to leave discovery")
+
+
+def _assert_bounded_growth(
+    baseline: dict[str, dict[str, int]],
+    current: dict[str, dict[str, int]],
+    cycle: int,
+) -> None:
+    for service_name, baseline_values in baseline.items():
+        current_values = current[service_name]
+        assert current_values["fds"] <= baseline_values["fds"] + MAX_FD_GROWTH, (
+            f"{service_name} retained descriptors after cycle {cycle}: "
+            f"baseline={baseline_values}, current={current_values}"
+        )
+        assert current_values["sockets"] <= baseline_values["sockets"] + MAX_FD_GROWTH, (
+            f"{service_name} retained sockets after cycle {cycle}: "
+            f"baseline={baseline_values}, current={current_values}"
+        )
+        assert current_values["rss_kib"] <= baseline_values["rss_kib"] + MAX_RSS_GROWTH_KIB, (
+            f"{service_name} RSS grew after cycle {cycle}: "
+            f"baseline={baseline_values}, current={current_values}"
+        )
+
+
+@pytest.mark.nightly
+@pytest.mark.framework_only
+@pytest.mark.core
+@pytest.mark.e2e
+@pytest.mark.k8s
+@pytest.mark.deploy
+@pytest.mark.gpu_1
+@pytest.mark.timeout(1200)
+async def test_lora_registration_churn_has_bounded_resources(
+    image: str,
+    namespace: str,
+    skip_service_restart: bool,
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Repeated dynamic LoRA load/unload must not retain sockets or RSS."""
+    frontend_image = request.config.getoption("--frontend-image")
+    assert image, "--image is required for the vLLM decode worker"
+    assert frontend_image, "--frontend-image is required for the frontend"
+    assert namespace, "--namespace is required for the Kubernetes deployment"
+
+    deployment_spec = DeploymentSpec(str(_dgd_manifest_path(tmp_path)))
+    deployment_spec.name = "vllm-lora-churn"
+    deployment_spec.set_image(frontend_image, service_name="Frontend")
+    deployment_spec.set_image(image, service_name="VllmDecodeWorker")
+    deployment_spec.add_arg_to_service(
+        "VllmDecodeWorker", "--gpu-memory-utilization", "0.7"
+    )
+    model_cache_pvc = request.config.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        deployment_spec.mount_model_cache_pvc(model_cache_pvc)
+
+    async with ManagedDeployment(
+        log_dir=request.node.name,
+        deployment_spec=deployment_spec,
+        namespace=namespace,
+        skip_service_restart=skip_service_restart,
+        readiness_timeout=900,
+    ) as deployment:
+        frontend = deployment.get_pods(["Frontend"])["Frontend"]
+        assert len(frontend) == 1, "Expected one frontend pod"
+        port_forward = deployment.port_forward(frontend[0], deployment_spec.port)
+        assert port_forward is not None, "Unable to port-forward the frontend"
+        base_url = f"http://localhost:{port_forward.local_port}"
+        assert wait_for_model_availability(
+            url=base_url,
+            endpoint=deployment_spec.endpoint,
+            model=BASE_MODEL,
+            logger=logger,
+            max_attempts=30,
+        ), "Base model did not become available"
+
+        _load_lora(base_url)
+        _unload_lora(base_url)
+        baseline = _snapshot(deployment)
+        logger.info("LoRA churn resource baseline: %s", baseline)
+
+        for cycle in range(1, CHURN_CYCLES + 1):
+            _load_lora(base_url)
+            for _ in range(CHATS_PER_CYCLE):
+                response = send_request(
+                    f"{base_url}/v1/chat/completions",
+                    {
+                        "model": LORA_NAME,
+                        "messages": [{"role": "user", "content": "Reply with NVIDIA Dynamo."}],
+                        "max_tokens": 16,
+                        "temperature": 0,
+                    },
+                    timeout=60,
+                )
+                assert response.ok, response.text
+                body = response.json()
+                assert body.get("object") == "chat.completion", body
+                assert body.get("choices"), body
+            _unload_lora(base_url)
+            measurements = _snapshot(deployment)
+            logger.info("LoRA churn cycle %d: %s", cycle, measurements)
+            _assert_bounded_growth(baseline, measurements, cycle)
+
+        await asyncio.sleep(RSS_SETTLE_SECONDS)
+        settled = _snapshot(deployment)
+        logger.info("LoRA churn settled resources: %s", settled)
+        _assert_bounded_growth(baseline, settled, CHURN_CYCLES)

--- a/tests/deploy/test_lora_churn.py
+++ b/tests/deploy/test_lora_churn.py
@@ -93,7 +93,6 @@ def _dgd_manifest_path(tmp_path: Path) -> Path:
 
 
 def _adapter_present(base_url: str) -> bool:
-    """Return whether the loaded adapter is advertised by the frontend."""
     response = requests.get(f"{base_url}/v1/models", timeout=10)
     response.raise_for_status()
     return any(
@@ -102,14 +101,12 @@ def _adapter_present(base_url: str) -> bool:
 
 
 def _adapter_removed(base_url: str) -> bool:
-    """Return whether discovery has removed the unloaded adapter."""
     loras = requests.get(f"{base_url}/v1/loras", timeout=10)
     loras.raise_for_status()
     return not _adapter_present(base_url) and loras.json().get("count") == 0
 
 
 def _wait_for(predicate: Callable[[], bool], description: str) -> None:
-    """Wait for a condition or fail after the unload timeout."""
     deadline = time.monotonic() + UNLOAD_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
         if predicate():
@@ -119,7 +116,6 @@ def _wait_for(predicate: Callable[[], bool], description: str) -> None:
 
 
 def _load_lora(base_url: str) -> None:
-    """Register the test adapter and wait until it is routable."""
     response = requests.post(
         f"{base_url}/v1/loras",
         json={"lora_name": LORA_NAME, "source": {"uri": LORA_SOURCE}},
@@ -130,7 +126,6 @@ def _load_lora(base_url: str) -> None:
 
 
 def _unload_lora(base_url: str) -> None:
-    """Remove the test adapter and wait until discovery releases it."""
     response = requests.delete(f"{base_url}/v1/loras/{LORA_NAME}", timeout=60)
     assert response.ok, response.text
     _wait_for(lambda: _adapter_removed(base_url), "LoRA to leave discovery")
@@ -141,7 +136,6 @@ def _assert_bounded_growth(
     current: dict[str, dict[str, int]],
     cycle: int,
 ) -> None:
-    """Assert measurements remain within the leak regression bounds."""
     for service_name, baseline_values in baseline.items():
         current_values = current[service_name]
         assert current_values["fds"] <= baseline_values["fds"] + MAX_FD_GROWTH, (

--- a/tests/deploy/test_lora_churn.py
+++ b/tests/deploy/test_lora_churn.py
@@ -144,7 +144,7 @@ def _assert_bounded_growth(
 @pytest.mark.k8s
 @pytest.mark.deploy
 @pytest.mark.gpu_1
-@pytest.mark.timeout(1200)
+@pytest.mark.timeout(1800)
 async def test_lora_registration_churn_has_bounded_resources(
     image: str,
     namespace: str,

--- a/tests/deploy/test_lora_churn.py
+++ b/tests/deploy/test_lora_churn.py
@@ -6,6 +6,7 @@
 import asyncio
 import json
 import logging
+import os
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -24,7 +25,7 @@ BASE_MODEL = "Qwen/Qwen3-0.6B"
 LORA_NAME = "codelion/Qwen3-0.6B-accuracy-recovery-lora"
 LORA_SOURCE = f"hf://{LORA_NAME}"
 CHURN_CYCLES = 30
-CHATS_PER_CYCLE = 3
+CHATS_PER_CYCLE = 1
 MAX_FD_GROWTH = 3
 MAX_RSS_GROWTH_KIB = 64 * 1024
 UNLOAD_TIMEOUT_SECONDS = 30
@@ -32,14 +33,22 @@ RSS_SETTLE_SECONDS = 60
 
 
 def _memory_probe(pod: Any) -> dict[str, int]:
-    """Read the main process's RSS and descriptor counts from its namespace."""
+    """Read cgroup memory and PID 1 descriptor counts from a pod."""
     snippet = """
 import json
 import os
 from pathlib import Path
+memory_paths = (
+    Path("/sys/fs/cgroup/memory.current"),
+    Path("/sys/fs/cgroup/memory/memory.usage_in_bytes"),
+)
+memory_bytes = next(
+    (int(path.read_text()) for path in memory_paths if path.exists()),
+    None,
+)
+if memory_bytes is None:
+    raise RuntimeError("No cgroup memory counter is available")
 
-status = Path("/proc/1/status").read_text().splitlines()
-rss_kib = next(int(line.split()[1]) for line in status if line.startswith("VmRSS:"))
 targets = []
 for descriptor in Path("/proc/1/fd").iterdir():
     try:
@@ -49,7 +58,7 @@ for descriptor in Path("/proc/1/fd").iterdir():
 print(json.dumps({
     "fds": len(targets),
     "sockets": sum(target.startswith("socket:") for target in targets),
-    "rss_kib": rss_kib,
+    "rss_kib": memory_bytes // 1024,
 }))
 """
     result = pod.exec(["python3", "-c", snippet])
@@ -57,6 +66,7 @@ print(json.dumps({
 
 
 def _snapshot(deployment: ManagedDeployment) -> dict[str, dict[str, int]]:
+    """Capture resource measurements for the frontend and decode worker."""
     snapshots: dict[str, dict[str, int]] = {}
     for service_name in ("Frontend", "VllmDecodeWorker"):
         pods = deployment.get_pods([service_name]).get(service_name, [])
@@ -67,7 +77,10 @@ def _snapshot(deployment: ManagedDeployment) -> dict[str, dict[str, int]]:
 
 def _dgd_manifest_path(tmp_path: Path) -> Path:
     """Write the DGD from the two-document LoRA example to an isolated file."""
-    manifest = Path(_get_workspace_dir()) / "examples/backends/vllm/deploy/lora/agg_lora_hf.yaml"
+    manifest = (
+        Path(_get_workspace_dir())
+        / "examples/backends/vllm/deploy/lora/agg_lora_hf.yaml"
+    )
     documents = list(yaml.safe_load_all(manifest.read_text()))
     dgd = next(
         document
@@ -80,18 +93,23 @@ def _dgd_manifest_path(tmp_path: Path) -> Path:
 
 
 def _adapter_present(base_url: str) -> bool:
+    """Return whether the loaded adapter is advertised by the frontend."""
     response = requests.get(f"{base_url}/v1/models", timeout=10)
     response.raise_for_status()
-    return any(model.get("id") == LORA_NAME for model in response.json().get("data", []))
+    return any(
+        model.get("id") == LORA_NAME for model in response.json().get("data", [])
+    )
 
 
 def _adapter_removed(base_url: str) -> bool:
+    """Return whether discovery has removed the unloaded adapter."""
     loras = requests.get(f"{base_url}/v1/loras", timeout=10)
     loras.raise_for_status()
     return not _adapter_present(base_url) and loras.json().get("count") == 0
 
 
 def _wait_for(predicate: Callable[[], bool], description: str) -> None:
+    """Wait for a condition or fail after the unload timeout."""
     deadline = time.monotonic() + UNLOAD_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
         if predicate():
@@ -101,6 +119,7 @@ def _wait_for(predicate: Callable[[], bool], description: str) -> None:
 
 
 def _load_lora(base_url: str) -> None:
+    """Register the test adapter and wait until it is routable."""
     response = requests.post(
         f"{base_url}/v1/loras",
         json={"lora_name": LORA_NAME, "source": {"uri": LORA_SOURCE}},
@@ -111,6 +130,7 @@ def _load_lora(base_url: str) -> None:
 
 
 def _unload_lora(base_url: str) -> None:
+    """Remove the test adapter and wait until discovery releases it."""
     response = requests.delete(f"{base_url}/v1/loras/{LORA_NAME}", timeout=60)
     assert response.ok, response.text
     _wait_for(lambda: _adapter_removed(base_url), "LoRA to leave discovery")
@@ -121,22 +141,33 @@ def _assert_bounded_growth(
     current: dict[str, dict[str, int]],
     cycle: int,
 ) -> None:
+    """Assert measurements remain within the leak regression bounds."""
     for service_name, baseline_values in baseline.items():
         current_values = current[service_name]
         assert current_values["fds"] <= baseline_values["fds"] + MAX_FD_GROWTH, (
             f"{service_name} retained descriptors after cycle {cycle}: "
             f"baseline={baseline_values}, current={current_values}"
         )
-        assert current_values["sockets"] <= baseline_values["sockets"] + MAX_FD_GROWTH, (
+        assert (
+            current_values["sockets"] <= baseline_values["sockets"] + MAX_FD_GROWTH
+        ), (
             f"{service_name} retained sockets after cycle {cycle}: "
             f"baseline={baseline_values}, current={current_values}"
         )
-        assert current_values["rss_kib"] <= baseline_values["rss_kib"] + MAX_RSS_GROWTH_KIB, (
+        assert (
+            current_values["rss_kib"] <= baseline_values["rss_kib"] + MAX_RSS_GROWTH_KIB
+        ), (
             f"{service_name} RSS grew after cycle {cycle}: "
             f"baseline={baseline_values}, current={current_values}"
         )
 
 
+@pytest.mark.framework_agnostic
+@pytest.mark.vllm
+@pytest.mark.model(BASE_MODEL)
+@pytest.mark.model(LORA_NAME)
+@pytest.mark.profiled_vram_gib(4.0)
+@pytest.mark.requested_vllm_kv_cache_bytes(941_712_000)
 @pytest.mark.nightly
 @pytest.mark.framework_only
 @pytest.mark.core
@@ -158,12 +189,21 @@ async def test_lora_registration_churn_has_bounded_resources(
     assert frontend_image, "--frontend-image is required for the frontend"
     assert namespace, "--namespace is required for the Kubernetes deployment"
 
+    kv_cache_marker = request.node.get_closest_marker("requested_vllm_kv_cache_bytes")
+    assert kv_cache_marker and kv_cache_marker.args, "vLLM KV cache budget is required"
+    kv_cache_bytes = os.environ.get(
+        "_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES", str(kv_cache_marker.args[0])
+    )
+
     deployment_spec = DeploymentSpec(str(_dgd_manifest_path(tmp_path)))
     deployment_spec.name = "vllm-lora-churn"
     deployment_spec.set_image(frontend_image, service_name="Frontend")
     deployment_spec.set_image(image, service_name="VllmDecodeWorker")
     deployment_spec.add_arg_to_service(
-        "VllmDecodeWorker", "--gpu-memory-utilization", "0.7"
+        "VllmDecodeWorker", "--kv-cache-memory-bytes", kv_cache_bytes
+    )
+    deployment_spec.add_arg_to_service(
+        "VllmDecodeWorker", "--gpu-memory-utilization", "0.01"
     )
     model_cache_pvc = request.config.getoption("--model-cache-pvc")
     if model_cache_pvc:
@@ -201,7 +241,9 @@ async def test_lora_registration_churn_has_bounded_resources(
                     f"{base_url}/v1/chat/completions",
                     {
                         "model": LORA_NAME,
-                        "messages": [{"role": "user", "content": "Reply with NVIDIA Dynamo."}],
+                        "messages": [
+                            {"role": "user", "content": "Reply with NVIDIA Dynamo."}
+                        ],
                         "max_tokens": 16,
                         "temperature": 0,
                     },


### PR DESCRIPTION
## Summary

- Add a nightly Kubernetes LoRA churn test that performs 30 load, inference, and unload cycles against separately built frontend and vLLM images.
- Assert bounded frontend and worker file-descriptor, socket, and RSS growth after every unload and a 60-second settle.
- Extend the reusable deploy workflow with test-file, artifact-name, pytest-argument, and timeout inputs; copy the nightly frontend image to the deployment registry.

closes: [OPS-8483](https://linear.app/nvidia/issue/OPS-8483)

## Validation

- `uvx ruff check tests/deploy/test_lora_churn.py`
- `python -m pytest --collect-only tests/deploy/test_lora_churn.py`
- GKE execution was attempted in `bis-ops-8483` with the 1.4.2 image pair, but the scheduler had no eligible GPU/ephemeral-storage capacity. The test DGD and pods were removed cleanly; the nightly vCluster job will provide the full execution environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added nightly end-to-end coverage for repeated vLLM LoRA adapter registration, loading, unloading, and chat requests.
  - The regression test monitors file descriptors, sockets, and memory usage across repeated cycles.

- **CI**
  - Added amd64 frontend image handling for nightly deployment tests.
  - Deployment test workflows now support configurable test files, names, pytest options, and timeouts.
  - Cleanup waits for the additional nightly test to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->