### PR TITLE
fix(vllm): project generate request controls

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -831,6 +831,8 @@ def build_sampling_params(
     # Apply output_options (logprobs, prompt_logprobs, etc.)
     output_options = request.get("output_options", {}) or {}
     logprobs, prompt_logprobs = _shared_logprobs.parse_logprob_options(output_options)
+    logprobs = -1 if logprobs == 2**32 - 1 else logprobs
+    prompt_logprobs = -1 if prompt_logprobs == 2**32 - 1 else prompt_logprobs
     # Explicit `logprob_token_ids` replace vLLM's natural top-k selection, so the
     # requested width no longer applies. vLLM's own OpenAI adapters null `logprobs`
     # in this case and let `num_logprobs` derive the width from the id list; mirror
@@ -842,6 +844,15 @@ def build_sampling_params(
         sampling_params.logprobs = logprobs
     if prompt_logprobs is not None:
         sampling_params.prompt_logprobs = prompt_logprobs
+        explicit_cache_setting = sampling_options.get(
+            "skip_reading_prefix_cache",
+            extra_args.get("skip_reading_prefix_cache")
+            if isinstance(extra_args, dict)
+            else None,
+        )
+        sampling_params.skip_reading_prefix_cache = (
+            True if explicit_cache_setting is None else explicit_cache_setting
+        )
 
     # skip_special_tokens is intentionally NOT forwarded to vLLM here: this path
     # forces detokenize=False (below), so vLLM never detokenizes and ignores it.

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -834,7 +834,9 @@ def build_sampling_params(
     output_options = request.get("output_options", {}) or {}
     logprobs, prompt_logprobs = _shared_logprobs.parse_logprob_options(output_options)
     logprobs = -1 if logprobs == _FULL_VOCAB_LOGPROBS_SENTINEL else logprobs
-    prompt_logprobs = -1 if prompt_logprobs == _FULL_VOCAB_LOGPROBS_SENTINEL else prompt_logprobs
+    prompt_logprobs = (
+        -1 if prompt_logprobs == _FULL_VOCAB_LOGPROBS_SENTINEL else prompt_logprobs
+    )
     # Explicit `logprob_token_ids` replace vLLM's natural top-k selection, so the
     # requested width no longer applies. vLLM's own OpenAI adapters null `logprobs`
     # in this case and let `num_logprobs` derive the width from the id list; mirror

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -113,6 +113,8 @@ from .state_agent import state_agent_settings
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
+_FULL_VOCAB_LOGPROBS_SENTINEL = 2**32 - 1
+
 
 # Marker set by the Rust conditional-disagg bypass path. When present on a
 # DECODE-mode worker, the request runs as local prefill+decode instead of
@@ -831,8 +833,8 @@ def build_sampling_params(
     # Apply output_options (logprobs, prompt_logprobs, etc.)
     output_options = request.get("output_options", {}) or {}
     logprobs, prompt_logprobs = _shared_logprobs.parse_logprob_options(output_options)
-    logprobs = -1 if logprobs == 2**32 - 1 else logprobs
-    prompt_logprobs = -1 if prompt_logprobs == 2**32 - 1 else prompt_logprobs
+    logprobs = -1 if logprobs == _FULL_VOCAB_LOGPROBS_SENTINEL else logprobs
+    prompt_logprobs = -1 if prompt_logprobs == _FULL_VOCAB_LOGPROBS_SENTINEL else prompt_logprobs
     # Explicit `logprob_token_ids` replace vLLM's natural top-k selection, so the
     # requested width no longer applies. vLLM's own OpenAI adapters null `logprobs`
     # in this case and let `num_logprobs` derive the width from the id list; mirror

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -216,7 +216,7 @@ class TestLogprobTokenIds:
     OpenAI adapters do, so `SamplingParams.verify()` accepts the pair."""
 
     @staticmethod
-    def _build(output_options, sampling_options=None):
+    def _build(output_options, sampling_options=None, extra_args=None):
         from dynamo.vllm.handlers import build_sampling_params
 
         return build_sampling_params(
@@ -225,6 +225,7 @@ class TestLogprobTokenIds:
                 "sampling_options": sampling_options or {},
                 "stop_conditions": {},
                 "output_options": output_options,
+                "extra_args": extra_args or {},
             },
             {},
         )
@@ -244,6 +245,23 @@ class TestLogprobTokenIds:
     def test_empty_id_list_falls_through_to_top_k(self):
         sp = self._build({"logprobs": 5}, sampling_options={"logprob_token_ids": []})
         assert sp.logprobs == 5
+
+    def test_unsigned_full_vocab_sentinel_restores_vllm_value(self):
+        sp = self._build({"logprobs": 2**32 - 1, "prompt_logprobs": 2**32 - 1})
+        assert sp.logprobs == -1
+        assert sp.prompt_logprobs == -1
+
+    def test_prompt_logprobs_bypass_prefix_cache_by_default(self):
+        sp = self._build({"prompt_logprobs": 1})
+        assert sp.prompt_logprobs == 1
+        assert sp.skip_reading_prefix_cache is True
+
+    def test_explicit_prefix_cache_setting_is_preserved(self):
+        sp = self._build(
+            {"prompt_logprobs": 1},
+            extra_args={"skip_reading_prefix_cache": False},
+        )
+        assert sp.skip_reading_prefix_cache is False
 
 
 class TestFlattenLogprobs:

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -37,7 +37,6 @@ use super::{RouteDoc, service_v2};
 use crate::local_model::runtime_config::VLLM_INFERENCE_V1_GENERATE_CAPABILITY;
 use crate::protocols::common::preprocessor::{MmRoutingInfo, PreprocessedRequest};
 use crate::protocols::common::timing::RequestTracker;
-use crate::protocols::common::{SamplingOptions, StopConditions};
 use crate::protocols::openai::generate::{
     GenerateRequest, GenerateResponse, GenerateResponseOptions, SamplingParams, StreamOptions,
 };
@@ -567,8 +566,13 @@ fn preprocessed_from_generate_with_tracker(
     } = routing_metadata;
     let sampling = &request.sampling_params;
     let max_tokens = sampling.max_tokens();
-    let min_tokens = sampling.min_tokens();
-    let ignore_eos = sampling.ignore_eos();
+    let stop_conditions = sampling.project_stop_conditions();
+    let sampling_options = sampling
+        .project_sampling_options()
+        .map_err(anyhow::Error::msg)?;
+    let output_options = sampling
+        .project_output_options()
+        .map_err(anyhow::Error::msg)?;
     let routing_priority = dynamo_routing_priority(request.priority);
     // With vLLM's default `enable_tower_connector_lora=false`, MM identifiers
     // are adapter-invariant and `lora_name` separately salts LM KV hashes. When
@@ -596,6 +600,12 @@ fn preprocessed_from_generate_with_tracker(
     let vllm_tito = serde_json::to_value(VllmTitoEnvelope::new(&request, request_id))?;
     let mut extra_args = serde_json::Map::new();
     extra_args.insert("vllm_tito".to_string(), vllm_tito);
+    if let Some(skip_reading_prefix_cache) = sampling.skip_reading_prefix_cache() {
+        extra_args.insert(
+            "skip_reading_prefix_cache".to_string(),
+            serde_json::Value::Bool(skip_reading_prefix_cache),
+        );
+    }
     if let Some(projection) = &mm_routing {
         extra_args.insert(
             "dynamo_mm_routing_hashes".to_string(),
@@ -612,17 +622,9 @@ fn preprocessed_from_generate_with_tracker(
     PreprocessedRequest::builder()
         .model(model.to_string())
         .token_ids(token_ids)
-        .stop_conditions(StopConditions {
-            max_tokens,
-            min_tokens,
-            ignore_eos: Some(ignore_eos),
-            ..Default::default()
-        })
-        .sampling_options(SamplingOptions {
-            n: Some(1),
-            ..Default::default()
-        })
-        .output_options(Default::default())
+        .stop_conditions(stop_conditions)
+        .sampling_options(sampling_options)
+        .output_options(output_options)
         .mm_routing_info(mm_routing_info)
         .routing(Some(crate::protocols::common::preprocessor::RoutingHints {
             dp_rank: data_parallel_rank,
@@ -2194,6 +2196,64 @@ mod tests {
         )
         .expect("build request");
         assert_eq!(preprocessed.stop_conditions.min_tokens, Some(0));
+    }
+
+    #[test]
+    fn generate_projects_training_text_controls() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [1, 2],
+            "sampling_params": {
+                "temperature": 0.25,
+                "top_p": 0.9,
+                "top_k": 0,
+                "min_p": 0.05,
+                "seed": 23,
+                "max_tokens": 8,
+                "min_tokens": 2,
+                "presence_penalty": 0.1,
+                "frequency_penalty": 0.2,
+                "repetition_penalty": 1.1,
+                "ignore_eos": true,
+                "logprobs": 1,
+                "prompt_logprobs": 1,
+                "skip_reading_prefix_cache": false,
+                "skip_special_tokens": false
+            },
+            "model": "test-model"
+        }))
+        .expect("deserialize request");
+
+        let preprocessed = preprocessed_from_generate(
+            request,
+            "test-model",
+            None,
+            "resolved-request",
+            routing_metadata(16, false, None),
+        )
+        .expect("build request");
+
+        assert_eq!(preprocessed.sampling_options.temperature, Some(0.25));
+        assert_eq!(preprocessed.sampling_options.top_p, Some(0.9));
+        assert_eq!(preprocessed.sampling_options.top_k, Some(0));
+        assert_eq!(preprocessed.sampling_options.min_p, Some(0.05));
+        assert_eq!(preprocessed.sampling_options.seed, Some(23));
+        assert_eq!(preprocessed.sampling_options.presence_penalty, Some(0.1));
+        assert_eq!(preprocessed.sampling_options.frequency_penalty, Some(0.2));
+        assert_eq!(preprocessed.sampling_options.repetition_penalty, Some(1.1));
+        assert_eq!(preprocessed.stop_conditions.max_tokens, Some(8));
+        assert_eq!(preprocessed.stop_conditions.min_tokens, Some(2));
+        assert_eq!(preprocessed.stop_conditions.ignore_eos, Some(true));
+        assert_eq!(preprocessed.output_options.logprobs, Some(1));
+        assert_eq!(preprocessed.output_options.prompt_logprobs, Some(1));
+        assert_eq!(
+            preprocessed
+                .extra_args
+                .as_ref()
+                .and_then(serde_json::Value::as_object)
+                .and_then(|extra| extra.get("skip_reading_prefix_cache")),
+            Some(&serde_json::Value::Bool(false))
+        );
+        assert_eq!(preprocessed.output_options.skip_special_tokens, Some(false));
     }
 
     #[test]

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -2211,7 +2211,7 @@ mod tests {
             "sampling_params": {
                 "temperature": 0.25,
                 "top_p": 0.9,
-                "top_k": 0,
+                "top_k": -1,
                 "min_p": 0.05,
                 "seed": 23,
                 "max_tokens": 8,
@@ -2244,7 +2244,7 @@ mod tests {
 
         assert_eq!(preprocessed.sampling_options.temperature, Some(0.25));
         assert_eq!(preprocessed.sampling_options.top_p, Some(0.9));
-        assert_eq!(preprocessed.sampling_options.top_k, Some(0));
+        assert_eq!(preprocessed.sampling_options.top_k, Some(-1));
         assert_eq!(preprocessed.sampling_options.min_p, Some(0.05));
         assert_eq!(preprocessed.sampling_options.seed, Some(23));
         assert_eq!(preprocessed.sampling_options.presence_penalty, Some(0.1));
@@ -2274,6 +2274,16 @@ mod tests {
                 .and_then(serde_json::Value::as_object)
                 .and_then(|extra| extra.get("kv_transfer_params")),
             Some(&serde_json::json!({"connector_data": {"block_ids": [1, 2]}}))
+        );
+        assert_eq!(
+            preprocessed
+                .extra_args
+                .as_ref()
+                .and_then(serde_json::Value::as_object)
+                .and_then(|extra| extra.get("vllm_tito"))
+                .and_then(|tito| tito.get("sampling_params"))
+                .and_then(|sampling| sampling.get("top_k")),
+            Some(&serde_json::json!(-1))
         );
         assert_eq!(preprocessed.output_options.skip_special_tokens, Some(false));
     }

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -600,6 +600,12 @@ fn preprocessed_from_generate_with_tracker(
     let vllm_tito = serde_json::to_value(VllmTitoEnvelope::new(&request, request_id))?;
     let mut extra_args = serde_json::Map::new();
     extra_args.insert("vllm_tito".to_string(), vllm_tito);
+    if let Some(kv_transfer_params) = request.kv_transfer_params.as_ref() {
+        extra_args.insert(
+            "kv_transfer_params".to_string(),
+            serde_json::Value::Object(kv_transfer_params.clone()),
+        );
+    }
     if let Some(skip_reading_prefix_cache) = sampling.skip_reading_prefix_cache() {
         extra_args.insert(
             "skip_reading_prefix_cache".to_string(),
@@ -2213,11 +2219,15 @@ mod tests {
                 "presence_penalty": 0.1,
                 "frequency_penalty": 0.2,
                 "repetition_penalty": 1.1,
+                "stop_token_ids": [7, 8],
                 "ignore_eos": true,
                 "logprobs": 1,
                 "prompt_logprobs": 1,
                 "skip_reading_prefix_cache": false,
                 "skip_special_tokens": false
+            },
+            "kv_transfer_params": {
+                "connector_data": {"block_ids": [1, 2]}
             },
             "model": "test-model"
         }))
@@ -2242,6 +2252,10 @@ mod tests {
         assert_eq!(preprocessed.sampling_options.repetition_penalty, Some(1.1));
         assert_eq!(preprocessed.stop_conditions.max_tokens, Some(8));
         assert_eq!(preprocessed.stop_conditions.min_tokens, Some(2));
+        assert_eq!(
+            preprocessed.stop_conditions.stop_token_ids_hidden,
+            Some(vec![7, 8])
+        );
         assert_eq!(preprocessed.stop_conditions.ignore_eos, Some(true));
         assert_eq!(preprocessed.output_options.logprobs, Some(1));
         assert_eq!(preprocessed.output_options.prompt_logprobs, Some(1));
@@ -2252,6 +2266,14 @@ mod tests {
                 .and_then(serde_json::Value::as_object)
                 .and_then(|extra| extra.get("skip_reading_prefix_cache")),
             Some(&serde_json::Value::Bool(false))
+        );
+        assert_eq!(
+            preprocessed
+                .extra_args
+                .as_ref()
+                .and_then(serde_json::Value::as_object)
+                .and_then(|extra| extra.get("kv_transfer_params")),
+            Some(&serde_json::json!({"connector_data": {"block_ids": [1, 2]}}))
         );
         assert_eq!(preprocessed.output_options.skip_special_tokens, Some(false));
     }

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -22,6 +22,8 @@ use serde_json::{Map, Value};
 use super::{convert_backend_top_logprobs, token_to_utf8_bytes};
 use crate::protocols::Annotated;
 use crate::protocols::common::llm_backend::{LLMEngineOutput, PromptLogprobs};
+use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
+use crate::protocols::openai::validate;
 
 /// Token-in/token-out generation request.
 ///
@@ -90,6 +92,24 @@ impl GenerateRequest {
 
         if self.sampling_params.max_tokens() == Some(0) {
             return Err("sampling_params.max_tokens must be greater than 0.".to_string());
+        }
+
+        validate::validate_temperature(self.sampling_params.temperature)
+            .map_err(|error| error.to_string())?;
+        validate::validate_top_p(self.sampling_params.top_p).map_err(|error| error.to_string())?;
+        validate::validate_frequency_penalty(self.sampling_params.frequency_penalty)
+            .map_err(|error| error.to_string())?;
+        validate::validate_presence_penalty(self.sampling_params.presence_penalty)
+            .map_err(|error| error.to_string())?;
+        validate::validate_repetition_penalty(self.sampling_params.repetition_penalty)
+            .map_err(|error| error.to_string())?;
+        validate::validate_min_p(self.sampling_params.min_p).map_err(|error| error.to_string())?;
+
+        if let Some(logprobs) = self.sampling_params.logprobs()
+            && logprobs < 0
+            && logprobs != -1
+        {
+            return Err("sampling_params.logprobs must be non-negative or -1.".to_string());
         }
 
         if let Some(prompt_logprobs) = self.sampling_params.prompt_logprobs() {
@@ -172,6 +192,7 @@ pub struct SamplingParams {
     /// typed view opaque avoids duplicating version-specific vLLM validation.
     structured_outputs: Option<Value>,
     skip_reading_prefix_cache: Option<bool>,
+    skip_special_tokens: Option<bool>,
     vllm_xargs: Option<HashMap<String, Value>>,
 }
 
@@ -196,8 +217,64 @@ impl SamplingParams {
         self.prompt_logprobs
     }
 
+    pub fn skip_reading_prefix_cache(&self) -> Option<bool> {
+        self.skip_reading_prefix_cache
+    }
+
     pub fn as_value(&self) -> &Value {
         &self.raw
+    }
+
+    pub(crate) fn project_sampling_options(&self) -> Result<SamplingOptions, String> {
+        let top_k = self
+            .top_k
+            .map(|value| {
+                i32::try_from(value).map_err(|_| {
+                    format!("sampling_params.top_k exceeds Dynamo's supported range: {value}")
+                })
+            })
+            .transpose()?;
+        Ok(SamplingOptions {
+            n: Some(1),
+            presence_penalty: self.presence_penalty,
+            frequency_penalty: self.frequency_penalty,
+            repetition_penalty: self.repetition_penalty,
+            temperature: self.temperature,
+            top_p: self.top_p,
+            top_k,
+            min_p: self.min_p,
+            seed: self.seed,
+            ..Default::default()
+        })
+    }
+
+    pub(crate) fn project_stop_conditions(&self) -> StopConditions {
+        StopConditions {
+            max_tokens: self.max_tokens,
+            min_tokens: self.min_tokens,
+            ignore_eos: Some(self.ignore_eos),
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn project_output_options(&self) -> Result<OutputOptions, String> {
+        Ok(OutputOptions {
+            logprobs: project_logprob_count(self.logprobs, "logprobs")?,
+            prompt_logprobs: project_logprob_count(self.prompt_logprobs, "prompt_logprobs")?,
+            skip_special_tokens: self.skip_special_tokens,
+            ..Default::default()
+        })
+    }
+}
+
+fn project_logprob_count(value: Option<i32>, field: &str) -> Result<Option<u32>, String> {
+    match value {
+        None => Ok(None),
+        Some(-1) => Ok(Some(u32::MAX)),
+        Some(value) if value >= 0 => Ok(Some(value as u32)),
+        Some(value) => Err(format!(
+            "sampling_params.{field} must be non-negative or -1, got {value}"
+        )),
     }
 }
 
@@ -254,6 +331,7 @@ impl<'de> Deserialize<'de> for SamplingParams {
             logprob_token_ids: field!(logprob_token_ids),
             structured_outputs: field!(structured_outputs),
             skip_reading_prefix_cache: field!(skip_reading_prefix_cache),
+            skip_special_tokens: field!(skip_special_tokens),
             vllm_xargs: field!(vllm_xargs),
             raw,
         })

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -252,6 +252,7 @@ impl SamplingParams {
         StopConditions {
             max_tokens: self.max_tokens,
             min_tokens: self.min_tokens,
+            stop_token_ids_hidden: self.stop_token_ids.clone(),
             ignore_eos: Some(self.ignore_eos),
             ..Default::default()
         }

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -107,8 +107,13 @@ impl GenerateRequest {
             .map_err(|error| error.to_string())?;
         validate::validate_presence_penalty(self.sampling_params.presence_penalty)
             .map_err(|error| error.to_string())?;
-        validate::validate_repetition_penalty(self.sampling_params.repetition_penalty)
-            .map_err(|error| error.to_string())?;
+        if let Some(value) = self.sampling_params.repetition_penalty
+            && (!value.is_finite() || value <= 0.0)
+        {
+            return Err(format!(
+                "sampling_params.repetition_penalty must be a finite positive number, got {value}"
+            ));
+        }
         validate::validate_min_p(self.sampling_params.min_p).map_err(|error| error.to_string())?;
 
         if let Some(logprobs) = self.sampling_params.logprobs()
@@ -876,6 +881,19 @@ mod tests {
             let error = req.validate().expect_err("must reject");
             assert!(error.contains(expected), "unexpected error: {error}");
         }
+    }
+
+    #[test]
+    fn generate_request_accepts_vllm_repetition_penalty_above_two() {
+        let request: GenerateRequest = serde_json::from_value(json!({
+            "token_ids": [1],
+            "sampling_params": {"repetition_penalty": 2.5}
+        }))
+        .expect("deserialize");
+
+        request
+            .validate()
+            .expect("vLLM accepts finite positive repetition penalties");
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -94,6 +94,12 @@ impl GenerateRequest {
             return Err("sampling_params.max_tokens must be greater than 0.".to_string());
         }
 
+        if self.sampling_params.thinking_token_budget.is_some() {
+            return Err(
+                "sampling_params.thinking_token_budget is not supported by vLLM gRPC.".to_string(),
+            );
+        }
+
         validate::validate_temperature(self.sampling_params.temperature)
             .map_err(|error| error.to_string())?;
         validate::validate_top_p(self.sampling_params.top_p).map_err(|error| error.to_string())?;
@@ -841,6 +847,13 @@ mod tests {
                     "sampling_params": {"max_tokens": 0}
                 }),
                 "max_tokens",
+            ),
+            (
+                json!({
+                    "token_ids": [1],
+                    "sampling_params": {"thinking_token_budget": 32}
+                }),
+                "thinking_token_budget",
             ),
             (
                 json!({

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -103,6 +103,7 @@ impl GenerateRequest {
         validate::validate_temperature(self.sampling_params.temperature)
             .map_err(|error| error.to_string())?;
         validate::validate_top_p(self.sampling_params.top_p).map_err(|error| error.to_string())?;
+        validate::validate_top_k(self.sampling_params.top_k).map_err(|error| error.to_string())?;
         validate::validate_frequency_penalty(self.sampling_params.frequency_penalty)
             .map_err(|error| error.to_string())?;
         validate::validate_presence_penalty(self.sampling_params.presence_penalty)
@@ -182,7 +183,7 @@ pub struct SamplingParams {
     // reads only the controls it needs; `raw` remains authoritative.
     temperature: Option<f32>,
     top_p: Option<f32>,
-    top_k: Option<u32>,
+    top_k: Option<i32>,
     seed: Option<i64>,
     max_tokens: Option<u32>,
     min_tokens: Option<u32>,
@@ -237,14 +238,6 @@ impl SamplingParams {
     }
 
     pub(crate) fn project_sampling_options(&self) -> Result<SamplingOptions, String> {
-        let top_k = self
-            .top_k
-            .map(|value| {
-                i32::try_from(value).map_err(|_| {
-                    format!("sampling_params.top_k exceeds Dynamo's supported range: {value}")
-                })
-            })
-            .transpose()?;
         Ok(SamplingOptions {
             n: Some(1),
             presence_penalty: self.presence_penalty,
@@ -252,7 +245,7 @@ impl SamplingParams {
             repetition_penalty: self.repetition_penalty,
             temperature: self.temperature,
             top_p: self.top_p,
-            top_k,
+            top_k: self.top_k,
             min_p: self.min_p,
             seed: self.seed,
             ..Default::default()
@@ -811,6 +804,25 @@ mod tests {
     }
 
     #[test]
+    fn generate_request_accepts_disabled_top_k_sentinel() {
+        let request: GenerateRequest = serde_json::from_value(json!({
+            "token_ids": [1],
+            "sampling_params": {"top_k": -1}
+        }))
+        .expect("deserialize");
+
+        request.validate().expect("validate");
+        assert_eq!(
+            request
+                .sampling_params
+                .project_sampling_options()
+                .expect("project")
+                .top_k,
+            Some(-1)
+        );
+    }
+
+    #[test]
     fn generate_request_matches_rust_integer_types() {
         for raw in [
             json!({
@@ -824,7 +836,7 @@ mod tests {
             }),
             json!({
                 "token_ids": [1],
-                "sampling_params": {"top_k": -1}
+                "sampling_params": {"top_k": i64::from(i32::MAX) + 1}
             }),
             json!({
                 "token_ids": [1],
@@ -866,6 +878,13 @@ mod tests {
                     "sampling_params": {"prompt_logprobs": -2}
                 }),
                 "prompt_logprobs",
+            ),
+            (
+                json!({
+                    "token_ids": [1],
+                    "sampling_params": {"top_k": -2}
+                }),
+                "Top_k",
             ),
             (
                 json!({

--- a/lib/mocker/servers/vllm/src/server.rs
+++ b/lib/mocker/servers/vllm/src/server.rs
@@ -133,6 +133,7 @@ impl VllmMockerService {
                 })?
                 .unwrap_or_default(),
             rl_capabilities: None,
+            supports_native_sampling_params_json: false,
         };
         Ok(Self {
             config: Arc::new(config),

--- a/lib/sidecar/vllm/proto/README.md
+++ b/lib/sidecar/vllm/proto/README.md
@@ -5,9 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 
 # Vendored vLLM protocol
 
-- Inference source: [`rust/proto/inference.proto`](https://github.com/vllm-project/vllm/blob/42156466db66f6d54cbea6075af82304cdfdaa6a/rust/proto/inference.proto) at `42156466db66f6d54cbea6075af82304cdfdaa6a`
-- RL Control source: [`rust/proto/control.proto`](https://github.com/vllm-project/vllm/blob/2991f864083fdd5c60aa140d4fe1a561585a85dc/rust/proto/control.proto) from [vllm-project/vllm#51316](https://github.com/vllm-project/vllm/pull/51316) and [vllm-project/vllm#53204](https://github.com/vllm-project/vllm/pull/53204) at `2991f864083fdd5c60aa140d4fe1a561585a85dc`
-- `inference.proto` SHA-256: `4c04f91d4967d1ba873fff6f546df138bc15cd29565c707c8554163392bb609a`
-- `control.proto` SHA-256: `c8363fd4397187a44e667d3d04ada30401e078ab6763ed5144f674184dd8d787`
+- Inference base source: [`rust/proto/inference.proto`](https://github.com/vllm-project/vllm/blob/42156466db66f6d54cbea6075af82304cdfdaa6a/rust/proto/inference.proto) at `42156466db66f6d54cbea6075af82304cdfdaa6a`
+- RL Control base source: [`rust/proto/control.proto`](https://github.com/vllm-project/vllm/blob/2991f864083fdd5c60aa140d4fe1a561585a85dc/rust/proto/control.proto) from [vllm-project/vllm#51316](https://github.com/vllm-project/vllm/pull/51316) and [vllm-project/vllm#53204](https://github.com/vllm-project/vllm/pull/53204) at `2991f864083fdd5c60aa140d4fe1a561585a85dc`
+- Dynamo adds `GenerateRequest.native_sampling_params_json` and `ServerInfo.supports_native_sampling_params_json`; the sidecar advertises native Generate support only when the worker reports this extension.
+- `inference.proto` SHA-256: `134be6a7e3ee6318ae814f7a40d49dda7b139798a44222a495ce39074731789c`
+- `control.proto` SHA-256: `abfb3829c8e142cadd649943d41ea67f8f75ff070686575153ff2b6f936312aa`
 
-The files are copied without modification. Update the revision and checksums together. `dynamo-vllm-sidecar` generates and temporarily exports these types for `dynamo-vllm-mocker-server`.
+Update the base revisions, extensions, and checksums together. `dynamo-vllm-sidecar` generates and temporarily exports these types for `dynamo-vllm-mocker-server`.

--- a/lib/sidecar/vllm/proto/README.md
+++ b/lib/sidecar/vllm/proto/README.md
@@ -5,9 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # Vendored vLLM protocol
 
-- Inference source: [`rust/proto/inference.proto`](https://github.com/vllm-project/vllm/blob/3d1f5cee1552b8208f3009c75f8bc856f27e0eff/rust/proto/inference.proto) at `3d1f5cee1552b8208f3009c75f8bc856f27e0eff`
+- Inference source: [`rust/proto/inference.proto`](https://github.com/vllm-project/vllm/blob/42156466db66f6d54cbea6075af82304cdfdaa6a/rust/proto/inference.proto) at `42156466db66f6d54cbea6075af82304cdfdaa6a`
 - RL Control source: [`rust/proto/control.proto`](https://github.com/vllm-project/vllm/blob/2991f864083fdd5c60aa140d4fe1a561585a85dc/rust/proto/control.proto) from [vllm-project/vllm#51316](https://github.com/vllm-project/vllm/pull/51316) and [vllm-project/vllm#53204](https://github.com/vllm-project/vllm/pull/53204) at `2991f864083fdd5c60aa140d4fe1a561585a85dc`
-- `inference.proto` SHA-256: `6152c306583166ecd691c9c715cab950523e8d1ed2db3dc2bcb538f6ca90e56f`
+- `inference.proto` SHA-256: `4c04f91d4967d1ba873fff6f546df138bc15cd29565c707c8554163392bb609a`
 - `control.proto` SHA-256: `c8363fd4397187a44e667d3d04ada30401e078ab6763ed5144f674184dd8d787`
 
 The files are copied without modification. Update the revision and checksums together. `dynamo-vllm-sidecar` generates and temporarily exports these types for `dynamo-vllm-mocker-server`.

--- a/lib/sidecar/vllm/proto/control.proto
+++ b/lib/sidecar/vllm/proto/control.proto
@@ -39,6 +39,7 @@ message ServerInfo {
   uint64 max_running_requests = 8;
   uint64 max_batched_tokens = 9;
   RlCapabilities rl_capabilities = 11;
+  bool supports_native_sampling_params_json = 12;
 }
 
 message RlCapabilities {

--- a/lib/sidecar/vllm/proto/inference.proto
+++ b/lib/sidecar/vllm/proto/inference.proto
@@ -107,6 +107,8 @@ message ResponseOptions {
   bool output_token_ids = 5;
   bool output_logprobs = 6;
   optional CandidateTokens output_candidates = 7;
+  // Defaults to true when omitted.
+  optional bool skip_special_tokens = 8;
 }
 
 message KVCacheParameters {

--- a/lib/sidecar/vllm/proto/inference.proto
+++ b/lib/sidecar/vllm/proto/inference.proto
@@ -50,6 +50,11 @@ message GenerateRequest {
 
   // Multimodal inputs aligned with placeholder markers in token_ids.
   repeated MediaItem media = 14;
+
+  // Exact JSON object from native /inference/v1/generate sampling_params.
+  // When non-empty, this is the sampling authority; structured fields remain
+  // the compatibility path for generic gRPC clients.
+  bytes native_sampling_params_json = 16;
 }
 
 message RandomSampling {

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -414,20 +414,6 @@ fn top_n_candidates(count: u32) -> Result<pb::CandidateTokens, DynamoError> {
     })
 }
 
-#[cfg(test)]
-mod candidate_tests {
-    use super::{pb, top_n_candidates};
-
-    #[test]
-    fn full_vocabulary_logprobs_select_all_candidates() {
-        let candidates = top_n_candidates(u32::MAX).expect("map full vocabulary");
-        assert_eq!(
-            candidates.select,
-            Some(pb::candidate_tokens::Select::All(true))
-        );
-    }
-}
-
 fn normalize_top_k(top_k: Option<i32>) -> Result<u32, DynamoError> {
     match top_k {
         None | Some(-1) | Some(0) => Ok(0),
@@ -1085,5 +1071,19 @@ fn normalize_logprob(logprob: f32) -> f64 {
         f64::from(logprob).max(VLLM_LOGPROB_FLOOR)
     } else {
         VLLM_LOGPROB_FLOOR
+    }
+}
+
+#[cfg(test)]
+mod candidate_tests {
+    use super::{pb, top_n_candidates};
+
+    #[test]
+    fn full_vocabulary_logprobs_select_all_candidates() {
+        let candidates = top_n_candidates(u32::MAX).expect("map full vocabulary");
+        assert_eq!(
+            candidates.select,
+            Some(pb::candidate_tokens::Select::All(true))
+        );
     }
 }

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -24,8 +24,13 @@ pub(crate) fn build_generate_request(
     request_id: String,
     mode: DisaggregationMode,
 ) -> Result<pb::GenerateRequest, DynamoError> {
+    let request = normalize_response_options(request)?;
     validate_request(&request, mode)?;
     validate_multimodal_cache_uuids(&request)?;
+    let mut native_sampling_params_json = native_sampling_params_json(&request)?;
+    if mode.is_prefill() || mode.is_encode() {
+        native_sampling_params_json.clear();
+    }
 
     let has_media = request
         .multi_modal_data
@@ -83,7 +88,7 @@ pub(crate) fn build_generate_request(
     let stop_conditions = request.stop_conditions;
     let encoder_result = request.encoder_result;
     let mut extra_args = request.extra_args;
-    let skip_special_tokens = consume_vllm_tito(&mut extra_args, skip_special_tokens)?;
+    consume_vllm_tito(&mut extra_args)?;
     consume_redundant_nvext(&mut extra_args, cache_salt.as_deref())?;
     if has_media && let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() {
         // These fields are already represented by token_ids and media.
@@ -141,6 +146,7 @@ pub(crate) fn build_generate_request(
         priority,
         session_id: None,
         media,
+        native_sampling_params_json,
     })
 }
 
@@ -155,22 +161,211 @@ pub(crate) fn data_parallel_rank(
     })
 }
 
-fn consume_vllm_tito(
-    extra_args: &mut Option<serde_json::Value>,
-    canonical_skip_special_tokens: Option<bool>,
-) -> Result<Option<bool>, DynamoError> {
-    let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() else {
-        return Ok(canonical_skip_special_tokens);
+/// Compatibility with v1.4 frontends during v1.5 and v1.6 rolling upgrades.
+/// TODO(v1.7): Remove after v1.4 falls outside the N-2 compatibility window.
+pub(crate) fn normalize_response_options(
+    mut request: PreprocessedRequest,
+) -> Result<PreprocessedRequest, DynamoError> {
+    let Some(sampling) = vllm_tito_sampling(&request.extra_args)?.cloned() else {
+        return Ok(request);
     };
-    let Some(envelope) = extra.remove("vllm_tito") else {
-        return Ok(canonical_skip_special_tokens);
+    let legacy_kv_transfer = request
+        .extra_args
+        .as_ref()
+        .and_then(serde_json::Value::as_object)
+        .and_then(|extra| extra.get("vllm_tito"))
+        .and_then(serde_json::Value::as_object)
+        .and_then(|envelope| envelope.get("kv_transfer_params"))
+        .cloned();
+    if request.output_options.logprobs.is_none() {
+        request.output_options.logprobs = legacy_logprob_count(&sampling, "logprobs")?;
+    }
+    if request.output_options.prompt_logprobs.is_none() {
+        request.output_options.prompt_logprobs =
+            legacy_logprob_count(&sampling, "prompt_logprobs")?;
+    }
+    if request.output_options.skip_special_tokens.is_none() {
+        request.output_options.skip_special_tokens = legacy_bool(&sampling, "skip_special_tokens")?;
+    }
+    if let Some(legacy_kv_transfer) = legacy_kv_transfer
+        && let Some(extra) = request
+            .extra_args
+            .as_mut()
+            .and_then(serde_json::Value::as_object_mut)
+        && !extra.contains_key("kv_transfer_params")
+    {
+        extra.insert("kv_transfer_params".to_string(), legacy_kv_transfer);
+    }
+    Ok(request)
+}
+
+fn native_sampling_params_json(request: &PreprocessedRequest) -> Result<Vec<u8>, DynamoError> {
+    let Some(mut native) = vllm_tito_sampling(&request.extra_args)?.cloned() else {
+        return Ok(Vec::new());
+    };
+    macro_rules! overlay {
+        ($name:literal, $value:expr) => {
+            if let Some(value) = $value {
+                native.insert(
+                    $name.to_string(),
+                    serde_json::to_value(value).map_err(|error| {
+                        client::invalid_argument(format!(
+                            "failed to serialize canonical sampling_params.{}: {error}",
+                            $name
+                        ))
+                    })?,
+                );
+            }
+        };
+    }
+
+    let sampling = &request.sampling_options;
+    overlay!("temperature", sampling.temperature);
+    overlay!("top_p", sampling.top_p);
+    overlay!("min_p", sampling.min_p);
+    overlay!("seed", sampling.seed);
+    overlay!("presence_penalty", sampling.presence_penalty);
+    overlay!("frequency_penalty", sampling.frequency_penalty);
+    overlay!("repetition_penalty", sampling.repetition_penalty);
+    overlay!(
+        "include_stop_str_in_output",
+        sampling.include_stop_str_in_output
+    );
+    if let Some(top_k) = sampling.top_k {
+        overlay!("top_k", Some(if top_k == -1 { 0 } else { top_k }));
+    }
+
+    let stopping = &request.stop_conditions;
+    overlay!("max_tokens", stopping.max_tokens);
+    overlay!("min_tokens", stopping.min_tokens);
+    overlay!("ignore_eos", stopping.ignore_eos);
+    if stopping.stop_token_ids.is_some() || stopping.stop_token_ids_hidden.is_some() {
+        overlay!(
+            "stop_token_ids",
+            Some(stop_token_ids(
+                stopping.stop_token_ids.clone(),
+                stopping.stop_token_ids_hidden.clone(),
+            ))
+        );
+    }
+
+    let output = &request.output_options;
+    if native
+        .get("logprob_token_ids")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|ids| !ids.is_empty())
+    {
+        native.remove("logprobs");
+    } else {
+        overlay!("logprobs", output.logprobs.map(native_logprob_count));
+    }
+    overlay!(
+        "prompt_logprobs",
+        output.prompt_logprobs.map(native_logprob_count)
+    );
+    overlay!("skip_special_tokens", output.skip_special_tokens);
+    let extra = request
+        .extra_args
+        .as_ref()
+        .and_then(serde_json::Value::as_object);
+    overlay!(
+        "skip_reading_prefix_cache",
+        bool_extra(extra, "skip_reading_prefix_cache")?
+    );
+
+    if native
+        .get("return_token_ids")
+        .is_some_and(|value| value != &serde_json::Value::Bool(true))
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.sampling_params.return_token_ids must be true",
+        ));
+    }
+    serde_json::to_vec(&native).map_err(|error| {
+        client::invalid_argument(format!(
+            "extra_args.vllm_tito.sampling_params is invalid: {error}"
+        ))
+    })
+}
+
+fn vllm_tito_sampling(
+    extra_args: &Option<serde_json::Value>,
+) -> Result<Option<&serde_json::Map<String, serde_json::Value>>, DynamoError> {
+    let Some(serde_json::Value::Object(extra)) = extra_args else {
+        return Ok(None);
+    };
+    let Some(envelope) = extra.get("vllm_tito") else {
+        return Ok(None);
     };
     let serde_json::Value::Object(envelope) = envelope else {
         return Err(client::invalid_argument(
             "extra_args.vllm_tito must be a JSON object",
         ));
     };
+    let sampling = envelope.get("sampling_params").ok_or_else(|| {
+        client::invalid_argument("extra_args.vllm_tito.sampling_params is required")
+    })?;
+    let serde_json::Value::Object(sampling) = sampling else {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.sampling_params must be a JSON object",
+        ));
+    };
+    Ok(Some(sampling))
+}
 
+fn legacy_bool(
+    sampling: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<Option<bool>, DynamoError> {
+    match sampling.get(field) {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::Bool(value)) => Ok(Some(*value)),
+        Some(_) => Err(client::invalid_argument(format!(
+            "extra_args.vllm_tito.sampling_params.{field} must be a boolean"
+        ))),
+    }
+}
+
+fn legacy_logprob_count(
+    sampling: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<Option<u32>, DynamoError> {
+    match sampling.get(field) {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(value) => match value.as_i64() {
+            Some(-1) => Ok(Some(u32::MAX)),
+            Some(value) if value >= 0 => u32::try_from(value).map(Some).map_err(|_| {
+                client::invalid_argument(format!(
+                    "extra_args.vllm_tito.sampling_params.{field} exceeds u32"
+                ))
+            }),
+            _ => Err(client::invalid_argument(format!(
+                "extra_args.vllm_tito.sampling_params.{field} must be non-negative or -1"
+            ))),
+        },
+    }
+}
+
+fn native_logprob_count(value: u32) -> i64 {
+    if value == u32::MAX {
+        -1
+    } else {
+        i64::from(value)
+    }
+}
+
+fn consume_vllm_tito(extra_args: &mut Option<serde_json::Value>) -> Result<(), DynamoError> {
+    let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() else {
+        return Ok(());
+    };
+    let Some(envelope) = extra.remove("vllm_tito") else {
+        return Ok(());
+    };
+    let serde_json::Value::Object(envelope) = envelope else {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito must be a JSON object",
+        ));
+    };
     for key in envelope.keys() {
         if !matches!(
             key.as_str(),
@@ -188,68 +383,8 @@ fn consume_vllm_tito(
             )));
         }
     }
-
-    let sampling = envelope.get("sampling_params").ok_or_else(|| {
-        client::invalid_argument("extra_args.vllm_tito.sampling_params is required")
-    })?;
-    let serde_json::Value::Object(sampling) = sampling else {
-        return Err(client::invalid_argument(
-            "extra_args.vllm_tito.sampling_params must be a JSON object",
-        ));
-    };
-    for key in sampling.keys() {
-        if !matches!(
-            key.as_str(),
-            "temperature"
-                | "top_p"
-                | "top_k"
-                | "min_p"
-                | "seed"
-                | "max_tokens"
-                | "min_tokens"
-                | "presence_penalty"
-                | "frequency_penalty"
-                | "repetition_penalty"
-                | "stop_token_ids"
-                | "ignore_eos"
-                | "logprobs"
-                | "prompt_logprobs"
-                | "skip_reading_prefix_cache"
-                | "skip_special_tokens"
-                | "return_token_ids"
-        ) {
-            return Err(client::invalid_argument(format!(
-                "extra_args.vllm_tito.sampling_params.{key} is not supported by vLLM gRPC"
-            )));
-        }
-    }
-    let skip_special_tokens = match sampling.get("skip_special_tokens") {
-        None | Some(serde_json::Value::Null) => canonical_skip_special_tokens,
-        Some(serde_json::Value::Bool(value)) => {
-            if canonical_skip_special_tokens.is_some_and(|canonical| canonical != *value) {
-                return Err(client::invalid_argument(
-                    "extra_args.vllm_tito.sampling_params.skip_special_tokens does not match the canonical output option",
-                ));
-            }
-            Some(*value)
-        }
-        Some(_) => {
-            return Err(client::invalid_argument(
-                "extra_args.vllm_tito.sampling_params.skip_special_tokens must be a boolean",
-            ));
-        }
-    };
-    if sampling
-        .get("return_token_ids")
-        .is_some_and(|value| value != &serde_json::Value::Bool(true))
-    {
-        return Err(client::invalid_argument(
-            "extra_args.vllm_tito.sampling_params.return_token_ids must be true",
-        ));
-    }
-    Ok(skip_special_tokens)
+    Ok(())
 }
-
 fn consume_redundant_nvext(
     extra_args: &mut Option<serde_json::Value>,
     cache_namespace: Option<&str>,

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -70,10 +70,11 @@ pub(crate) fn build_generate_request(
         request.stop_conditions.min_tokens.unwrap_or(0)
     };
     let mut routing = request.routing;
-    let priority = routing
+    let dynamo_priority = routing
         .as_ref()
         .and_then(|routing| routing.priority)
         .unwrap_or(0);
+    let priority = dynamo_priority.saturating_neg();
     let cache_salt = routing
         .as_mut()
         .and_then(|routing| routing.cache_namespace.take());
@@ -82,7 +83,8 @@ pub(crate) fn build_generate_request(
     let stop_conditions = request.stop_conditions;
     let encoder_result = request.encoder_result;
     let mut extra_args = request.extra_args;
-    consume_vllm_tito(&mut extra_args)?;
+    let skip_special_tokens =
+        consume_vllm_tito(&mut extra_args, dynamo_priority, skip_special_tokens)?;
     consume_redundant_nvext(&mut extra_args, cache_salt.as_deref())?;
     if has_media && let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() {
         // These fields are already represented by token_ids and media.
@@ -154,12 +156,16 @@ pub(crate) fn data_parallel_rank(
     })
 }
 
-fn consume_vllm_tito(extra_args: &mut Option<serde_json::Value>) -> Result<(), DynamoError> {
+fn consume_vllm_tito(
+    extra_args: &mut Option<serde_json::Value>,
+    canonical_priority: i32,
+    canonical_skip_special_tokens: Option<bool>,
+) -> Result<Option<bool>, DynamoError> {
     let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() else {
-        return Ok(());
+        return Ok(canonical_skip_special_tokens);
     };
     let Some(envelope) = extra.remove("vllm_tito") else {
-        return Ok(());
+        return Ok(canonical_skip_special_tokens);
     };
     let serde_json::Value::Object(envelope) = envelope else {
         return Err(client::invalid_argument(
@@ -219,6 +225,37 @@ fn consume_vllm_tito(extra_args: &mut Option<serde_json::Value>) -> Result<(), D
             )));
         }
     }
+    let skip_special_tokens = match sampling.get("skip_special_tokens") {
+        None | Some(serde_json::Value::Null) => canonical_skip_special_tokens,
+        Some(serde_json::Value::Bool(value)) => {
+            if canonical_skip_special_tokens.is_some_and(|canonical| canonical != *value) {
+                return Err(client::invalid_argument(
+                    "extra_args.vllm_tito.sampling_params.skip_special_tokens does not match the canonical output option",
+                ));
+            }
+            Some(*value)
+        }
+        Some(_) => {
+            return Err(client::invalid_argument(
+                "extra_args.vllm_tito.sampling_params.skip_special_tokens must be a boolean",
+            ));
+        }
+    };
+    if let Some(value) = envelope.get("priority") {
+        let priority = value
+            .as_i64()
+            .and_then(|priority| i32::try_from(priority).ok())
+            .ok_or_else(|| {
+                client::invalid_argument(
+                    "extra_args.vllm_tito.priority must be a signed 32-bit integer",
+                )
+            })?;
+        if priority.saturating_neg() != canonical_priority {
+            return Err(client::invalid_argument(
+                "extra_args.vllm_tito.priority does not match the canonical Dynamo routing priority",
+            ));
+        }
+    }
     if sampling
         .get("return_token_ids")
         .is_some_and(|value| value != &serde_json::Value::Bool(true))
@@ -227,7 +264,7 @@ fn consume_vllm_tito(extra_args: &mut Option<serde_json::Value>) -> Result<(), D
             "extra_args.vllm_tito.sampling_params.return_token_ids must be true",
         ));
     }
-    Ok(())
+    Ok(skip_special_tokens)
 }
 
 fn consume_redundant_nvext(

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -399,6 +399,11 @@ fn build_media(
 }
 
 fn top_n_candidates(count: u32) -> Result<pb::CandidateTokens, DynamoError> {
+    if count == u32::MAX {
+        return Ok(pb::CandidateTokens {
+            select: Some(pb::candidate_tokens::Select::All(true)),
+        });
+    }
     i32::try_from(count).map_err(|_| {
         client::invalid_argument(format!(
             "vLLM logprobs request must fit in i32; got {count}"
@@ -407,6 +412,20 @@ fn top_n_candidates(count: u32) -> Result<pb::CandidateTokens, DynamoError> {
     Ok(pb::CandidateTokens {
         select: Some(pb::candidate_tokens::Select::TopN(count)),
     })
+}
+
+#[cfg(test)]
+mod candidate_tests {
+    use super::{pb, top_n_candidates};
+
+    #[test]
+    fn full_vocabulary_logprobs_select_all_candidates() {
+        let candidates = top_n_candidates(u32::MAX).expect("map full vocabulary");
+        assert_eq!(
+            candidates.select,
+            Some(pb::candidate_tokens::Select::All(true))
+        );
+    }
 }
 
 fn normalize_top_k(top_k: Option<i32>) -> Result<u32, DynamoError> {

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -56,6 +56,7 @@ pub(crate) fn build_generate_request(
         // supplies the prompt KV.
         strip_multimodal_prompt_token_ids(&mut prefill_result);
     }
+    let skip_special_tokens = request.output_options.skip_special_tokens;
     let prompt_logprobs = request.output_options.prompt_logprobs;
     let output_logprobs = request.output_options.logprobs;
     let max_new_tokens = if mode.is_prefill() || mode.is_encode() {
@@ -81,6 +82,7 @@ pub(crate) fn build_generate_request(
     let stop_conditions = request.stop_conditions;
     let encoder_result = request.encoder_result;
     let mut extra_args = request.extra_args;
+    consume_vllm_tito(&mut extra_args)?;
     consume_redundant_nvext(&mut extra_args, cache_salt.as_deref())?;
     if has_media && let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() {
         // These fields are already represented by token_ids and media.
@@ -131,6 +133,7 @@ pub(crate) fn build_generate_request(
             output_token_ids: true,
             output_logprobs: output_logprobs.is_some(),
             output_candidates: output_logprobs.map(top_n_candidates).transpose()?,
+            skip_special_tokens,
         }),
         kv: Some(kv),
         truncate_prompt_tokens: 0,
@@ -149,6 +152,82 @@ pub(crate) fn data_parallel_rank(
         DisaggregationMode::Prefill => routing.prefill_dp_rank.or(routing.dp_rank),
         DisaggregationMode::Aggregated | DisaggregationMode::Decode => routing.dp_rank,
     })
+}
+
+fn consume_vllm_tito(extra_args: &mut Option<serde_json::Value>) -> Result<(), DynamoError> {
+    let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() else {
+        return Ok(());
+    };
+    let Some(envelope) = extra.remove("vllm_tito") else {
+        return Ok(());
+    };
+    let serde_json::Value::Object(envelope) = envelope else {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito must be a JSON object",
+        ));
+    };
+
+    for key in envelope.keys() {
+        if !matches!(
+            key.as_str(),
+            "request_id"
+                | "sampling_params"
+                | "model"
+                | "stream"
+                | "stream_options"
+                | "cache_salt"
+                | "priority"
+                | "kv_transfer_params"
+        ) {
+            return Err(client::invalid_argument(format!(
+                "extra_args.vllm_tito.{key} is not supported by vLLM gRPC"
+            )));
+        }
+    }
+
+    let sampling = envelope.get("sampling_params").ok_or_else(|| {
+        client::invalid_argument("extra_args.vllm_tito.sampling_params is required")
+    })?;
+    let serde_json::Value::Object(sampling) = sampling else {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.sampling_params must be a JSON object",
+        ));
+    };
+    for key in sampling.keys() {
+        if !matches!(
+            key.as_str(),
+            "temperature"
+                | "top_p"
+                | "top_k"
+                | "min_p"
+                | "seed"
+                | "max_tokens"
+                | "min_tokens"
+                | "presence_penalty"
+                | "frequency_penalty"
+                | "repetition_penalty"
+                | "stop_token_ids"
+                | "ignore_eos"
+                | "logprobs"
+                | "prompt_logprobs"
+                | "skip_reading_prefix_cache"
+                | "skip_special_tokens"
+                | "return_token_ids"
+        ) {
+            return Err(client::invalid_argument(format!(
+                "extra_args.vllm_tito.sampling_params.{key} is not supported by vLLM gRPC"
+            )));
+        }
+    }
+    if sampling
+        .get("return_token_ids")
+        .is_some_and(|value| value != &serde_json::Value::Bool(true))
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.sampling_params.return_token_ids must be true",
+        ));
+    }
+    Ok(())
 }
 
 fn consume_redundant_nvext(
@@ -680,11 +759,6 @@ fn validate_request(
     if request.stop_conditions.max_thinking_tokens.is_some() {
         return Err(client::invalid_argument(
             "max_thinking_tokens is not supported by vLLM gRPC",
-        ));
-    }
-    if request.output_options.skip_special_tokens == Some(false) {
-        return Err(client::invalid_argument(
-            "skip_special_tokens=false is not supported by vLLM gRPC",
         ));
     }
     let sampling = &request.sampling_options;

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -83,8 +83,7 @@ pub(crate) fn build_generate_request(
     let stop_conditions = request.stop_conditions;
     let encoder_result = request.encoder_result;
     let mut extra_args = request.extra_args;
-    let skip_special_tokens =
-        consume_vllm_tito(&mut extra_args, dynamo_priority, skip_special_tokens)?;
+    let skip_special_tokens = consume_vllm_tito(&mut extra_args, skip_special_tokens)?;
     consume_redundant_nvext(&mut extra_args, cache_salt.as_deref())?;
     if has_media && let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() {
         // These fields are already represented by token_ids and media.
@@ -158,7 +157,6 @@ pub(crate) fn data_parallel_rank(
 
 fn consume_vllm_tito(
     extra_args: &mut Option<serde_json::Value>,
-    canonical_priority: i32,
     canonical_skip_special_tokens: Option<bool>,
 ) -> Result<Option<bool>, DynamoError> {
     let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() else {
@@ -241,21 +239,6 @@ fn consume_vllm_tito(
             ));
         }
     };
-    if let Some(value) = envelope.get("priority") {
-        let priority = value
-            .as_i64()
-            .and_then(|priority| i32::try_from(priority).ok())
-            .ok_or_else(|| {
-                client::invalid_argument(
-                    "extra_args.vllm_tito.priority must be a signed 32-bit integer",
-                )
-            })?;
-        if priority.saturating_neg() != canonical_priority {
-            return Err(client::invalid_argument(
-                "extra_args.vllm_tito.priority does not match the canonical Dynamo routing priority",
-            ));
-        }
-    }
     if sampling
         .get("return_token_ids")
         .is_some_and(|value| value != &serde_json::Value::Bool(true))

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -17,7 +17,9 @@ use tokio_util::sync::CancellationToken;
 
 use crate::args::Args;
 use crate::client::{self, CONTROL_SERVICE, INFERENCE_SERVICE, VllmClient};
-use crate::convert::{ResponseState, build_generate_request, data_parallel_rank};
+use crate::convert::{
+    ResponseState, build_generate_request, data_parallel_rank, normalize_response_options,
+};
 use crate::model::DiscoveredModel;
 
 pub struct VllmSidecarEngine {
@@ -214,6 +216,7 @@ impl LLMEngine for VllmSidecarEngine {
             .get()
             .ok_or_else(|| client::engine_shutdown("vLLM sidecar is not started"))?;
         let request_id = ctx.id().to_string();
+        let request = normalize_response_options(request)?;
         let mut state = ResponseState::new(&request, self.mode);
         let data_parallel_rank = data_parallel_rank(&request, self.mode);
         let mut proto_request = build_generate_request(request, request_id, self.mode)?;

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -9,6 +9,7 @@ use crate::client;
 use crate::proto as pb;
 
 const SUPPORTED_API_VERSION: &str = "vllm";
+const VLLM_INFERENCE_V1_GENERATE_CAPABILITY: &str = "vllm_inference_v1_generate";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ModelIdentity {
@@ -141,7 +142,12 @@ impl DiscoveredModel {
             model: self.source.clone(),
             served_model_name: Some(self.served_name.clone()),
             model_aliases: self.identity.aliases.clone(),
-            runtime_data: Default::default(),
+            runtime_data: [(
+                VLLM_INFERENCE_V1_GENERATE_CAPABILITY.to_string(),
+                serde_json::Value::Bool(true),
+            )]
+            .into_iter()
+            .collect(),
             llm: Some(LlmRegistration {
                 context_length: nonzero(self.server.max_model_len),
                 kv_cache_block_size: nonzero(self.server.kv_block_size),

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -138,16 +138,21 @@ impl DiscoveredModel {
 
     pub(crate) fn engine_config(&self) -> EngineConfig {
         let parallelism = self.server.parallelism.as_ref();
-        EngineConfig {
-            model: self.source.clone(),
-            served_model_name: Some(self.served_name.clone()),
-            model_aliases: self.identity.aliases.clone(),
-            runtime_data: [(
+        let runtime_data = if self.server.supports_native_sampling_params_json {
+            [(
                 VLLM_INFERENCE_V1_GENERATE_CAPABILITY.to_string(),
                 serde_json::Value::Bool(true),
             )]
             .into_iter()
-            .collect(),
+            .collect()
+        } else {
+            Default::default()
+        };
+        EngineConfig {
+            model: self.source.clone(),
+            served_model_name: Some(self.served_name.clone()),
+            model_aliases: self.identity.aliases.clone(),
+            runtime_data,
             llm: Some(LlmRegistration {
                 context_length: nonzero(self.server.max_model_len),
                 kv_cache_block_size: nonzero(self.server.kv_block_size),

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -847,6 +847,54 @@ fn request() -> PreprocessedRequest {
         .expect("request")
 }
 
+#[test]
+fn skip_special_tokens_is_forwarded_without_compatibility_envelope() {
+    let mut request = request();
+    request.output_options.skip_special_tokens = Some(false);
+    request
+        .extra_args
+        .as_mut()
+        .and_then(serde_json::Value::as_object_mut)
+        .expect("object extra_args")
+        .insert("vllm_tito".to_string(), json!({"sampling_params": {}}));
+
+    let wire = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect("native controls should be forwarded");
+
+    assert_eq!(
+        wire.response
+            .and_then(|response| response.skip_special_tokens),
+        Some(false)
+    );
+}
+
+#[test]
+fn unprojected_generate_controls_are_rejected() {
+    let mut request = request();
+    request
+        .extra_args
+        .as_mut()
+        .and_then(serde_json::Value::as_object_mut)
+        .expect("object extra_args")
+        .insert(
+            "vllm_tito".to_string(),
+            json!({"sampling_params": {"logit_bias": {"42": 1.0}}}),
+        );
+
+    let error = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect_err("unprojected controls must be rejected");
+
+    assert!(error.to_string().contains("logit_bias is not supported"));
+}
+
 fn epd_image_request() -> PreprocessedRequest {
     let mut request = request();
     request.output_options.prompt_logprobs = None;
@@ -995,6 +1043,20 @@ fn engine_config_normalizes_total_kv_blocks_per_dp_rank() {
     let registration = model.engine_config().llm.expect("LLM registration");
 
     assert_eq!(registration.total_kv_blocks, Some(2048));
+}
+
+#[test]
+fn engine_config_advertises_vllm_generate_capability() {
+    let model =
+        DiscoveredModel::from_proto(model_info(), server_info()).expect("valid discovery metadata");
+
+    assert_eq!(
+        model
+            .engine_config()
+            .runtime_data
+            .get("vllm_inference_v1_generate"),
+        Some(&json!(true))
+    );
 }
 
 #[test]

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -873,6 +873,74 @@ fn skip_special_tokens_is_forwarded_without_compatibility_envelope() {
 }
 
 #[test]
+fn compatibility_envelope_projects_skip_special_tokens() {
+    let mut request = request();
+    request
+        .extra_args
+        .as_mut()
+        .and_then(serde_json::Value::as_object_mut)
+        .expect("object extra_args")
+        .insert(
+            "vllm_tito".to_string(),
+            json!({"sampling_params": {"skip_special_tokens": false}}),
+        );
+
+    let wire = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect("compatibility option should be projected");
+
+    assert_eq!(
+        wire.response
+            .and_then(|response| response.skip_special_tokens),
+        Some(false)
+    );
+}
+
+#[test]
+fn compatibility_envelope_rejects_conflicting_skip_special_tokens() {
+    let mut request = request();
+    request.output_options.skip_special_tokens = Some(false);
+    request
+        .extra_args
+        .as_mut()
+        .and_then(serde_json::Value::as_object_mut)
+        .expect("object extra_args")
+        .insert(
+            "vllm_tito".to_string(),
+            json!({"sampling_params": {"skip_special_tokens": true}}),
+        );
+
+    let error = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect_err("conflicting compatibility option should fail");
+
+    assert!(error.to_string().contains("skip_special_tokens"));
+}
+
+#[test]
+fn canonical_dynamo_priority_is_converted_for_vllm() {
+    for (dynamo_priority, vllm_priority) in [(-7, 7), (7, -7), (i32::MIN, i32::MAX)] {
+        let mut request = request();
+        request.routing.as_mut().expect("routing").priority = Some(dynamo_priority);
+
+        let wire = build_generate_request(
+            request,
+            "request-1".to_string(),
+            DisaggregationMode::Aggregated,
+        )
+        .expect("canonical priority should be converted");
+
+        assert_eq!(wire.priority, vllm_priority);
+    }
+}
+
+#[test]
 fn unprojected_generate_controls_are_rejected() {
     let mut request = request();
     request

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -959,13 +959,16 @@ fn canonical_controls_override_compatibility_envelope() {
 #[test]
 fn released_envelope_preserves_native_sampling_semantics() {
     let mut request = request();
-    request.sampling_options = SamplingOptions::default();
+    request.sampling_options = SamplingOptions {
+        top_k: Some(-1),
+        ..Default::default()
+    };
     request.stop_conditions = StopConditions::default();
     request.output_options = OutputOptions::default();
     request.extra_args = Some(json!({
         "skip_reading_prefix_cache": false,
         "vllm_tito": {"sampling_params": {
-            "top_k": 0,
+            "top_k": -1,
             "repetition_penalty": 2.5,
             "logprobs": -1,
             "prompt_logprobs": 0,
@@ -987,6 +990,7 @@ fn released_envelope_preserves_native_sampling_semantics() {
     .expect("convert released envelope");
     let native: serde_json::Value =
         serde_json::from_slice(&wire.native_sampling_params_json).expect("native sampling JSON");
+    assert_eq!(wire.sampling.expect("sampling").top_k, 0);
     assert!(native.get("temperature").is_none());
     assert_eq!(native["top_k"], json!(0));
     assert_eq!(native["repetition_penalty"], json!(2.5));

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -851,13 +851,6 @@ fn request() -> PreprocessedRequest {
 fn skip_special_tokens_is_forwarded_without_compatibility_envelope() {
     let mut request = request();
     request.output_options.skip_special_tokens = Some(false);
-    request
-        .extra_args
-        .as_mut()
-        .and_then(serde_json::Value::as_object_mut)
-        .expect("object extra_args")
-        .insert("vllm_tito".to_string(), json!({"sampling_params": {}}));
-
     let wire = build_generate_request(
         request,
         "request-1".to_string(),

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -24,7 +24,7 @@ use tonic::{Request, Response, Status};
 use tonic_health::ServingStatus as HealthServingStatus;
 
 use crate::client::{CONTROL_SERVICE, INFERENCE_SERVICE, VllmClient};
-use crate::convert::{ResponseState, build_generate_request};
+use crate::convert::{ResponseState, build_generate_request, normalize_response_options};
 use crate::engine::VllmSidecarEngine;
 use crate::json::{json_to_struct, struct_to_json};
 use crate::model::DiscoveredModel;
@@ -468,7 +468,31 @@ fn server_info() -> pb::ServerInfo {
             sleep_mode_enabled: true,
             draft_weight_updates_enabled: true,
         }),
+        supports_native_sampling_params_json: true,
     }
+}
+
+#[test]
+fn native_generate_capability_requires_worker_support() {
+    let model = DiscoveredModel::from_proto(model_info(), server_info()).expect("valid discovery");
+    assert_eq!(
+        model
+            .engine_config()
+            .runtime_data
+            .get("vllm_inference_v1_generate")
+            .and_then(serde_json::Value::as_bool),
+        Some(true)
+    );
+
+    let mut legacy_server = server_info();
+    legacy_server.supports_native_sampling_params_json = false;
+    let legacy = DiscoveredModel::from_proto(model_info(), legacy_server).expect("valid discovery");
+    assert!(
+        !legacy
+            .engine_config()
+            .runtime_data
+            .contains_key("vllm_inference_v1_generate")
+    );
 }
 
 #[test]
@@ -893,7 +917,7 @@ fn compatibility_envelope_projects_skip_special_tokens() {
 }
 
 #[test]
-fn compatibility_envelope_rejects_conflicting_skip_special_tokens() {
+fn canonical_controls_override_compatibility_envelope() {
     let mut request = request();
     request.output_options.skip_special_tokens = Some(false);
     request
@@ -903,17 +927,161 @@ fn compatibility_envelope_rejects_conflicting_skip_special_tokens() {
         .expect("object extra_args")
         .insert(
             "vllm_tito".to_string(),
-            json!({"sampling_params": {"skip_special_tokens": true}}),
+            json!({"sampling_params": {
+                "temperature": 0.7,
+                "seed": 456,
+                "max_tokens": 8,
+                "logprobs": 2,
+                "skip_special_tokens": true,
+                "future_vllm_field": {"preserved": true}
+            }}),
         );
 
-    let error = build_generate_request(
+    let wire = build_generate_request(
         request,
         "request-1".to_string(),
         DisaggregationMode::Aggregated,
     )
-    .expect_err("conflicting compatibility option should fail");
+    .expect("canonical controls should override compatibility values");
+    let native: serde_json::Value =
+        serde_json::from_slice(&wire.native_sampling_params_json).expect("native sampling JSON");
+    assert!(
+        (native["temperature"].as_f64().expect("temperature") - f64::from(0.2_f32)).abs()
+            < f64::EPSILON
+    );
+    assert_eq!(native["seed"], json!(123));
+    assert_eq!(native["max_tokens"], json!(1));
+    assert_eq!(native["logprobs"], json!(1));
+    assert_eq!(native["skip_special_tokens"], json!(false));
+    assert_eq!(native["future_vllm_field"], json!({"preserved": true}));
+}
 
-    assert!(error.to_string().contains("skip_special_tokens"));
+#[test]
+fn released_envelope_preserves_native_sampling_semantics() {
+    let mut request = request();
+    request.sampling_options = SamplingOptions::default();
+    request.stop_conditions = StopConditions::default();
+    request.output_options = OutputOptions::default();
+    request.extra_args = Some(json!({
+        "skip_reading_prefix_cache": false,
+        "vllm_tito": {"sampling_params": {
+            "top_k": 0,
+            "repetition_penalty": 2.5,
+            "logprobs": -1,
+            "prompt_logprobs": 0,
+            "skip_reading_prefix_cache": true,
+            "skip_special_tokens": false,
+            "return_token_ids": true
+        }}
+    }));
+
+    let request = normalize_response_options(request).expect("normalize response options");
+    assert_eq!(request.output_options.logprobs, Some(u32::MAX));
+    assert_eq!(request.output_options.prompt_logprobs, Some(0));
+    assert_eq!(request.output_options.skip_special_tokens, Some(false));
+    let wire = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect("convert released envelope");
+    let native: serde_json::Value =
+        serde_json::from_slice(&wire.native_sampling_params_json).expect("native sampling JSON");
+    assert!(native.get("temperature").is_none());
+    assert_eq!(native["top_k"], json!(0));
+    assert_eq!(native["repetition_penalty"], json!(2.5));
+    assert_eq!(native["logprobs"], json!(-1));
+    assert_eq!(native["skip_reading_prefix_cache"], json!(false));
+}
+
+#[test]
+fn prefill_does_not_forward_decode_sampling_json() {
+    let mut request = request();
+    request
+        .extra_args
+        .as_mut()
+        .and_then(serde_json::Value::as_object_mut)
+        .expect("object extra_args")
+        .insert(
+            "vllm_tito".to_string(),
+            json!({"sampling_params": {"top_k": 0, "return_token_ids": true}}),
+        );
+
+    let wire = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Prefill,
+    )
+    .expect("convert prefill request");
+    assert!(wire.native_sampling_params_json.is_empty());
+}
+#[test]
+fn explicit_zero_temperature_is_preserved() {
+    let mut request = request();
+    request.sampling_options = SamplingOptions::default();
+    request.extra_args = Some(json!({
+        "vllm_tito": {"sampling_params": {"temperature": 0.0}}
+    }));
+
+    let wire = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect("convert explicit zero temperature");
+    let native: serde_json::Value =
+        serde_json::from_slice(&wire.native_sampling_params_json).expect("native sampling JSON");
+    assert_eq!(native["temperature"], json!(0.0));
+}
+
+#[test]
+fn explicit_logprob_token_ids_override_native_logprob_count() {
+    let mut request = request();
+    request.output_options.logprobs = Some(5);
+    request.extra_args = Some(json!({
+        "vllm_tito": {"sampling_params": {"logprob_token_ids": [5000]}}
+    }));
+
+    let wire = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect("convert explicit logprob token IDs");
+    let native: serde_json::Value =
+        serde_json::from_slice(&wire.native_sampling_params_json).expect("native sampling JSON");
+    assert!(native.get("logprobs").is_none());
+    assert_eq!(native["logprob_token_ids"], json!([5000]));
+}
+
+#[test]
+fn released_envelope_hydrates_kv_transfer_with_canonical_precedence() {
+    let mut legacy = request();
+    legacy.extra_args = Some(json!({
+        "vllm_tito": {
+            "sampling_params": {},
+            "kv_transfer_params": {"source": "legacy"}
+        }
+    }));
+    let legacy = normalize_response_options(legacy).expect("normalize legacy KV transfer");
+    assert_eq!(
+        legacy.extra_args.as_ref().unwrap()["kv_transfer_params"],
+        json!({"source": "legacy"})
+    );
+
+    let mut canonical = request();
+    canonical.extra_args = Some(json!({
+        "kv_transfer_params": {"source": "canonical"},
+        "vllm_tito": {
+            "sampling_params": {},
+            "kv_transfer_params": {"source": "legacy"}
+        }
+    }));
+    let canonical = normalize_response_options(canonical).expect("normalize canonical KV transfer");
+    assert_eq!(
+        canonical.extra_args.as_ref().unwrap()["kv_transfer_params"],
+        json!({"source": "canonical"})
+    );
 }
 
 #[test]
@@ -931,29 +1099,6 @@ fn canonical_dynamo_priority_is_converted_for_vllm() {
 
         assert_eq!(wire.priority, vllm_priority);
     }
-}
-
-#[test]
-fn unprojected_generate_controls_are_rejected() {
-    let mut request = request();
-    request
-        .extra_args
-        .as_mut()
-        .and_then(serde_json::Value::as_object_mut)
-        .expect("object extra_args")
-        .insert(
-            "vllm_tito".to_string(),
-            json!({"sampling_params": {"logit_bias": {"42": 1.0}}}),
-        );
-
-    let error = build_generate_request(
-        request,
-        "request-1".to_string(),
-        DisaggregationMode::Aggregated,
-    )
-    .expect_err("unprojected controls must be rejected");
-
-    assert!(error.to_string().contains("logit_bias is not supported"));
 }
 
 fn epd_image_request() -> PreprocessedRequest {


### PR DESCRIPTION
## Overview

Project typed `/inference/v1/generate` controls into `PreprocessedRequest` and preserve their exact semantics through the vLLM gRPC boundary.

## Changes

- Preserve sampling controls, token limits, stop-token IDs, logprobs, prompt logprobs, special-token output behavior, and cache-read overrides.
- Retain released v1.4 frontend envelopes during the N-2 compatibility window, with current canonical fields taking precedence.
- Preserve omitted values and explicit zero or false values through capability-gated native sampling JSON.
- Accept Prime-RL's `top_k = -1` disabled sentinel and normalize it to vLLM's unsigned `0` representation at the sidecar boundary.
- Accept every finite positive vLLM repetition penalty.
- Preserve legacy KV-transfer parameters and explicit-token logprob behavior.
- Name the unsigned full-vocabulary logprob sentinel.

## Reviewer start

- `lib/llm/src/protocols/openai/generate.rs` for request validation and typed projection.
- `lib/sidecar/vllm/src/convert.rs` for canonical/native vLLM conversion.
- `components/src/dynamo/vllm/handlers.py` for released Python frontend compatibility.

## Validation

- `cargo fmt --all -- --check`
- Focused release tests for `top_k = -1` acceptance, `< -1` rejection, HTTP projection, and sidecar `-1 -> 0` normalization — 4 passed.
- `cargo test -p dynamo-vllm-sidecar --no-default-features --lib` — 43 passed before the focused sentinel addition.
- `python3 -m py_compile components/src/dynamo/vllm/handlers.py`
- Previous five-step Qwen3-0.6B math run passed with 32/32 trainable rollouts per step, zero errors/cancellations/truncations, and startup plus five NCCL updates.
- Five-step Qwen3.5-4B multimodal RL run passed on `bis-rl-3` with Prime-RL main plus #3492, this PR plus the minimal image-only Dynamo sidecar layer, and vLLM #56421: 5/5 orchestrator steps, 5/5 trainer steps, 2/2 trainable rollouts per step, zero rollout errors/cancellations, six NCCL weight receives, and successful pre/post image probes.

## Related issues

- Companion vLLM v0.28 frontend PR: vllm-project/vllm#56421
