### PR TITLE
fix(operator): make Ray multinode workers wait for the leader

### DIFF
--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1467,8 +1467,32 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 											},
 										},
 									},
+									{
+										Name: "wait-leader-script",
+										VolumeSource: corev1.VolumeSource{
+											ConfigMap: &corev1.ConfigMapVolumeSource{
+												LocalObjectReference: corev1.LocalObjectReference{
+													Name: "test-lws-deploy-wait-leader-script",
+												},
+											},
+										},
+									},
 								},
 								RestartPolicy: corev1.RestartPolicyAlways,
+								InitContainers: []corev1.Container{
+									{
+										Name:    "wait-for-leader-ray",
+										Image:   "test-image:1.5.0",
+										Command: []string{"sh", "-c", `export LEADER_HOST="${LWS_LEADER_ADDRESS}" LEADER_PORT="6379" && exec python3 /scripts/wait-for-leader.py`},
+										VolumeMounts: []corev1.VolumeMount{
+											{
+												Name:      "wait-leader-script",
+												MountPath: "/scripts",
+												ReadOnly:  true,
+											},
+										},
+									},
+								},
 								Containers: []corev1.Container{
 									{
 										Image: "another-image:latest",

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -146,6 +146,13 @@ const (
 	waitLeaderScriptKey       = "wait-for-leader.py"
 	waitLeaderVolumeName      = "wait-leader-script"
 	waitLeaderMountPath       = "/scripts"
+
+	// rayWorkerLaunchPrefix is the exact command injectRayDistributedLaunchFlags
+	// gives a plain TP/PP Ray multinode worker. It is distinct from the
+	// elastic-EP Ray worker command (prefixed by that path's own leader
+	// health-gate) and from the data-parallel-Ray path (which keeps the vLLM
+	// command intact), so matching it identifies this one launch shape only.
+	rayWorkerLaunchPrefix = "ray start --address="
 )
 
 // WaitLeaderScript is the Python script that verifies leader pod health via
@@ -255,7 +262,8 @@ func GenerateWaitLeaderConfigMap(dgdName, namespace string) *corev1.ConfigMap {
 }
 
 func (b *VLLMBackend) UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int32, role Role, _ *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer) {
-	if !b.shouldInjectVLLMMpWaitLeaderInit(podSpec, numberOfNodes, role) {
+	waitPort, initContainerName, ok := b.waitForLeaderPortAndName(podSpec, numberOfNodes, role)
+	if !ok {
 		return
 	}
 
@@ -282,11 +290,11 @@ func (b *VLLMBackend) UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int32
 	// definition order.
 	shellHostname := k8sToShellVarSyntax(leaderHostname)
 	initContainer := corev1.Container{
-		Name:  "wait-for-leader-mp",
+		Name:  initContainerName,
 		Image: mainImage,
 		Command: []string{"sh", "-c", fmt.Sprintf(
 			`export LEADER_HOST="%s" LEADER_PORT="%s" && exec python3 %s/%s`,
-			shellHostname, commonconsts.VLLMMpMasterPort, waitLeaderMountPath, waitLeaderScriptKey)},
+			shellHostname, waitPort, waitLeaderMountPath, waitLeaderScriptKey)},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      waitLeaderVolumeName,
@@ -299,12 +307,33 @@ func (b *VLLMBackend) UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int32
 	podSpec.InitContainers = append(podSpec.InitContainers, initContainer)
 }
 
-func (b *VLLMBackend) shouldInjectVLLMMpWaitLeaderInit(podSpec *corev1.PodSpec, numberOfNodes int32, role Role) bool {
+// waitForLeaderPortAndName reports the leader port to wait on and the name to
+// give the init container for a multinode worker whose main container's
+// launch command depends on the leader being reachable before it starts, or
+// ok=false when this pod does not need to wait.
+//
+// mp workers carry --distributed-executor-backend mp in their own launch
+// command (injectMpDistributedLaunchFlags) and wait on vLLM's MP master port.
+// Plain TP/PP Ray workers (injectRayDistributedLaunchFlags) are rewritten to
+// the exact single-argument `ray start --address=<host>:<port> --block` and
+// wait on the Ray GCS port instead; that exact shape is what distinguishes
+// them from the elastic-EP Ray worker (prefixed by its own leader health-gate)
+// and the data-parallel-Ray path (which keeps the full vLLM command), both of
+// which already handle leader readiness themselves and must not also get this
+// init container.
+func (b *VLLMBackend) waitForLeaderPortAndName(podSpec *corev1.PodSpec, numberOfNodes int32, role Role) (port, name string, ok bool) {
 	if b.ParentGraphDeploymentName == "" || numberOfNodes <= 1 || role != RoleWorker || len(podSpec.Containers) == 0 {
-		return false
+		return "", "", false
 	}
 
-	return containerCommandLineHasArg(&podSpec.Containers[0], distributedExecutorFlag, "mp")
+	container := &podSpec.Containers[0]
+	if containerCommandLineHasArg(container, distributedExecutorFlag, "mp") {
+		return commonconsts.VLLMMpMasterPort, "wait-for-leader-mp", true
+	}
+	if len(container.Args) == 1 && strings.HasPrefix(strings.TrimSpace(container.Args[0]), rayWorkerLaunchPrefix) {
+		return VLLMPort, "wait-for-leader-ray", true
+	}
+	return "", "", false
 }
 
 // updateVLLMMultinodeArgs dispatches to the appropriate injection function based on
@@ -403,6 +432,18 @@ func injectMpDistributedLaunchFlags(container *corev1.Container, role Role, serv
 	injectFlagsIntoContainerCommand(container, mpFlags, needsShell, "vllm")
 }
 
+// injectRayDistributedLaunchFlags injects the Ray launch commands for multi-node TP/PP
+// deployments.
+//
+// Leader: starts the Ray head, then runs the original vLLM command with
+// --distributed-executor-backend ray.
+//
+// Worker: only starts a Ray agent joining the leader's cluster; vLLM on the
+// leader spawns Ray actors on it. An init container (injected via
+// UpdatePodSpec) handles waiting for the leader's Ray port before the
+// worker's main container starts -- without it, a worker whose pod starts
+// before the leader's Ray head is listening never successfully joins the
+// cluster and needs to be deleted and recreated.
 func injectRayDistributedLaunchFlags(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer) {
 	switch role {
 	case RoleLeader:

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -3,6 +3,7 @@ package dynamo
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -146,13 +147,6 @@ const (
 	waitLeaderScriptKey       = "wait-for-leader.py"
 	waitLeaderVolumeName      = "wait-leader-script"
 	waitLeaderMountPath       = "/scripts"
-
-	// rayWorkerLaunchPrefix is the exact command injectRayDistributedLaunchFlags
-	// gives a plain TP/PP Ray multinode worker. It is distinct from the
-	// elastic-EP Ray worker command (prefixed by that path's own leader
-	// health-gate) and from the data-parallel-Ray path (which keeps the vLLM
-	// command intact), so matching it identifies this one launch shape only.
-	rayWorkerLaunchPrefix = "ray start --address="
 )
 
 // WaitLeaderScript is the Python script that verifies leader pod health via
@@ -262,13 +256,13 @@ func GenerateWaitLeaderConfigMap(dgdName, namespace string) *corev1.ConfigMap {
 }
 
 func (b *VLLMBackend) UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int32, role Role, _ *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer) {
-	waitPort, initContainerName, ok := b.waitForLeaderPortAndName(podSpec, numberOfNodes, role)
+	leaderHostname := multinodeDeployer.GetLeaderHostname(serviceName)
+	waitPort, initContainerName, ok := b.waitForLeaderPortAndName(podSpec, numberOfNodes, role, leaderHostname)
 	if !ok {
 		return
 	}
 
 	mainContainer := &podSpec.Containers[0]
-	leaderHostname := multinodeDeployer.GetLeaderHostname(serviceName)
 	mainImage := mainContainer.Image
 	cmName := GetWaitLeaderConfigMapName(b.ParentGraphDeploymentName)
 
@@ -315,13 +309,16 @@ func (b *VLLMBackend) UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int32
 // mp workers carry --distributed-executor-backend mp in their own launch
 // command (injectMpDistributedLaunchFlags) and wait on vLLM's MP master port.
 // Plain TP/PP Ray workers (injectRayDistributedLaunchFlags) are rewritten to
-// the exact single-argument `ray start --address=<host>:<port> --block` and
-// wait on the Ray GCS port instead; that exact shape is what distinguishes
-// them from the elastic-EP Ray worker (prefixed by its own leader health-gate)
-// and the data-parallel-Ray path (which keeps the full vLLM command), both of
-// which already handle leader readiness themselves and must not also get this
-// init container.
-func (b *VLLMBackend) waitForLeaderPortAndName(podSpec *corev1.PodSpec, numberOfNodes int32, role Role) (port, name string, ok bool) {
+// the exact command `ray start --address=<leaderHostname>:<port> --block`
+// under an explicit `/bin/sh -c`, and wait on the Ray GCS port instead.
+// Matching the complete generated command -- not just a prefix -- is what
+// distinguishes this from the elastic-EP Ray worker (prefixed by its own
+// leader health-gate), the data-parallel-Ray path (which keeps the full vLLM
+// command), and a hand-authored worker that happens to start with the same
+// prefix but joins a different (e.g. external) Ray address: any of those
+// would otherwise get an init container that waits on the wrong host and
+// leaves the pod pending forever.
+func (b *VLLMBackend) waitForLeaderPortAndName(podSpec *corev1.PodSpec, numberOfNodes int32, role Role, leaderHostname string) (port, name string, ok bool) {
 	if b.ParentGraphDeploymentName == "" || numberOfNodes <= 1 || role != RoleWorker || len(podSpec.Containers) == 0 {
 		return "", "", false
 	}
@@ -330,7 +327,10 @@ func (b *VLLMBackend) waitForLeaderPortAndName(podSpec *corev1.PodSpec, numberOf
 	if containerCommandLineHasArg(container, distributedExecutorFlag, "mp") {
 		return commonconsts.VLLMMpMasterPort, "wait-for-leader-mp", true
 	}
-	if len(container.Args) == 1 && strings.HasPrefix(strings.TrimSpace(container.Args[0]), rayWorkerLaunchPrefix) {
+
+	expectedRayArgs := fmt.Sprintf("ray start --address=%s:%s --block", leaderHostname, VLLMPort)
+	if slices.Equal(container.Command, []string{"/bin/sh", "-c"}) &&
+		len(container.Args) == 1 && strings.TrimSpace(container.Args[0]) == expectedRayArgs {
 		return VLLMPort, "wait-for-leader-ray", true
 	}
 	return "", "", false

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -994,6 +994,19 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 		}
 	}
 
+	rayMultinodePodSpec := func(image, leaderHost string) *corev1.PodSpec {
+		return &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "main",
+					Image:   image,
+					Command: []string{"/bin/sh", "-c"},
+					Args:    []string{fmt.Sprintf("ray start --address=%s:%s --block", leaderHost, VLLMPort)},
+				},
+			},
+		}
+	}
+
 	tests := []struct {
 		name                string
 		numberOfNodes       int32
@@ -1002,8 +1015,10 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 		multinodeDeployer   MultinodeDeployer
 		initialPodSpec      *corev1.PodSpec
 		expectInitContainer bool
+		expectedInitName    string
 		expectedInitImage   string
 		expectedLeaderHost  string
+		expectedPort        string
 	}{
 		{
 			name:                "mp worker with Grove deployer injects init container",
@@ -1012,8 +1027,10 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 			multinodeDeployer:   &GroveMultinodeDeployer{},
 			initialPodSpec:      mpMultinodePodSpec("vllm:latest"),
 			expectInitContainer: true,
+			expectedInitName:    "wait-for-leader-mp",
 			expectedInitImage:   "vllm:latest",
 			expectedLeaderHost:  "${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-test-service-ldr-0.${GROVE_HEADLESS_SERVICE}",
+			expectedPort:        commonconsts.VLLMMpMasterPort,
 		},
 		{
 			name:                "mp worker with LWS deployer injects init container",
@@ -1022,8 +1039,70 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 			multinodeDeployer:   &LWSMultinodeDeployer{},
 			initialPodSpec:      mpMultinodePodSpec("vllm:v2"),
 			expectInitContainer: true,
+			expectedInitName:    "wait-for-leader-mp",
 			expectedInitImage:   "vllm:v2",
 			expectedLeaderHost:  "${LWS_LEADER_ADDRESS}",
+			expectedPort:        commonconsts.VLLMMpMasterPort,
+		},
+		{
+			name:                "plain Ray TP/PP worker with Grove deployer injects init container on the Ray port",
+			numberOfNodes:       2,
+			role:                RoleWorker,
+			multinodeDeployer:   &GroveMultinodeDeployer{},
+			initialPodSpec:      rayMultinodePodSpec("vllm:ray", "leader"),
+			expectInitContainer: true,
+			expectedInitName:    "wait-for-leader-ray",
+			expectedInitImage:   "vllm:ray",
+			expectedLeaderHost:  "${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-test-service-ldr-0.${GROVE_HEADLESS_SERVICE}",
+			expectedPort:        VLLMPort,
+		},
+		{
+			name:                "plain Ray TP/PP worker with LWS deployer injects init container on the Ray port",
+			numberOfNodes:       2,
+			role:                RoleWorker,
+			multinodeDeployer:   &LWSMultinodeDeployer{},
+			initialPodSpec:      rayMultinodePodSpec("vllm:ray-v2", "leader"),
+			expectInitContainer: true,
+			expectedInitName:    "wait-for-leader-ray",
+			expectedInitImage:   "vllm:ray-v2",
+			expectedLeaderHost:  "${LWS_LEADER_ADDRESS}",
+			expectedPort:        VLLMPort,
+		},
+		{
+			name:              "Ray leader does not inject init container",
+			numberOfNodes:     2,
+			role:              RoleLeader,
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "main",
+						Image:   "vllm:ray",
+						Command: []string{"/bin/sh", "-c"},
+						Args:    []string{fmt.Sprintf("ray start --head --port=%s && python3 -m dynamo.vllm %s ray", VLLMPort, distributedExecutorFlag)},
+					},
+				},
+			},
+			expectInitContainer: false,
+		},
+		{
+			name:              "elastic-EP Ray worker (own leader health-gate) does not get a second init container",
+			numberOfNodes:     2,
+			role:              RoleWorker,
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialPodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "main",
+						Image:   "vllm:elastic-ep",
+						Command: []string{"/bin/sh", "-c"},
+						Args: []string{fmt.Sprintf(
+							"i=0; until python3 -c \"import urllib.request\" 2>/dev/null; do i=$((i+1)); sleep 15; done && ray start --address=leader:%s --block",
+							VLLMPort)},
+					},
+				},
+			},
+			expectInitContainer: false,
 		},
 		{
 			name:              "mp worker with executor flag in command injects init container",
@@ -1040,8 +1119,10 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 				},
 			},
 			expectInitContainer: true,
+			expectedInitName:    "wait-for-leader-mp",
 			expectedInitImage:   "vllm:command",
 			expectedLeaderHost:  "${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-test-service-ldr-0.${GROVE_HEADLESS_SERVICE}",
+			expectedPort:        commonconsts.VLLMMpMasterPort,
 		},
 		{
 			name:              "mp worker with shell-form command injects init container",
@@ -1062,8 +1143,10 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 				},
 			},
 			expectInitContainer: true,
+			expectedInitName:    "wait-for-leader-mp",
 			expectedInitImage:   "vllm:shell-command",
 			expectedLeaderHost:  "${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-test-service-ldr-0.${GROVE_HEADLESS_SERVICE}",
+			expectedPort:        commonconsts.VLLMMpMasterPort,
 		},
 		{
 			name:                "mp leader does not inject init container",
@@ -1087,7 +1170,7 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 			expectInitContainer: false,
 		},
 		{
-			name:              "non-mp worker command does not inject init container",
+			name:              "worker command matching neither mp nor plain-Ray shape does not inject init container",
 			numberOfNodes:     2,
 			role:              RoleWorker,
 			multinodeDeployer: &GroveMultinodeDeployer{},
@@ -1097,7 +1180,7 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 						Name:    "main",
 						Image:   "vllm:latest",
 						Command: []string{"/bin/sh", "-c"},
-						Args:    []string{"ray start --address=leader:6379 --block"},
+						Args:    []string{"exec python3 -m dynamo.vllm --some-other-flag"},
 					},
 				},
 			},
@@ -1131,8 +1214,10 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 				return podSpec
 			}(),
 			expectInitContainer: true,
+			expectedInitName:    "wait-for-leader-mp",
 			expectedInitImage:   "vllm:latest",
 			expectedLeaderHost:  "${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-test-service-ldr-0.${GROVE_HEADLESS_SERVICE}",
+			expectedPort:        commonconsts.VLLMMpMasterPort,
 		},
 	}
 
@@ -1149,12 +1234,12 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 				g.Expect(tt.initialPodSpec.Volumes).To(gomega.HaveLen(initialVolCount + 1))
 
 				injected := tt.initialPodSpec.InitContainers[len(tt.initialPodSpec.InitContainers)-1]
-				g.Expect(injected.Name).To(gomega.Equal("wait-for-leader-mp"))
+				g.Expect(injected.Name).To(gomega.Equal(tt.expectedInitName))
 				g.Expect(injected.Image).To(gomega.Equal(tt.expectedInitImage))
 
 				expectedCmd := fmt.Sprintf(
 					`export LEADER_HOST="%s" LEADER_PORT="%s" && exec python3 /scripts/wait-for-leader.py`,
-					tt.expectedLeaderHost, commonconsts.VLLMMpMasterPort)
+					tt.expectedLeaderHost, tt.expectedPort)
 				g.Expect(injected.Command).To(gomega.Equal([]string{"sh", "-c", expectedCmd}))
 				g.Expect(injected.Env).To(gomega.BeEmpty())
 

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -1045,6 +1045,17 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 			expectedPort:        commonconsts.VLLMMpMasterPort,
 		},
 		{
+			// LWS-vs-Grove hostname expansion is already exercised by the mp worker
+			// with LWS deployer case above, and the Ray-command-matching logic itself
+			// (waitForLeaderPortAndName) takes an already-resolved leaderHostname and
+			// does not branch on which deployer produced it -- so a Grove-deployer Ray
+			// worker plus an LWS-deployer mp worker together cover both dimensions
+			// without a redundant LWS+Ray combination.
+			//
+			// Leader vs. worker is also not Ray/mp-specific: waitForLeaderPortAndName
+			// returns before inspecting the container command whenever role != RoleWorker,
+			// so the existing "mp leader does not inject init container" case below
+			// already covers that guard for any command shape, Ray included.
 			name:                "plain Ray TP/PP worker with Grove deployer injects init container on the Ray port",
 			numberOfNodes:       2,
 			role:                RoleWorker,
@@ -1055,35 +1066,6 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 			expectedInitImage:   "vllm:ray",
 			expectedLeaderHost:  "${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-test-service-ldr-0.${GROVE_HEADLESS_SERVICE}",
 			expectedPort:        VLLMPort,
-		},
-		{
-			name:                "plain Ray TP/PP worker with LWS deployer injects init container on the Ray port",
-			numberOfNodes:       2,
-			role:                RoleWorker,
-			multinodeDeployer:   &LWSMultinodeDeployer{},
-			initialPodSpec:      rayMultinodePodSpec("vllm:ray-v2", "$(LWS_LEADER_ADDRESS)"),
-			expectInitContainer: true,
-			expectedInitName:    "wait-for-leader-ray",
-			expectedInitImage:   "vllm:ray-v2",
-			expectedLeaderHost:  "${LWS_LEADER_ADDRESS}",
-			expectedPort:        VLLMPort,
-		},
-		{
-			name:              "Ray leader does not inject init container",
-			numberOfNodes:     2,
-			role:              RoleLeader,
-			multinodeDeployer: &GroveMultinodeDeployer{},
-			initialPodSpec: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:    "main",
-						Image:   "vllm:ray",
-						Command: []string{"/bin/sh", "-c"},
-						Args:    []string{fmt.Sprintf("ray start --head --port=%s && python3 -m dynamo.vllm %s ray", VLLMPort, distributedExecutorFlag)},
-					},
-				},
-			},
-			expectInitContainer: false,
 		},
 		{
 			// A hand-authored or externally-addressed Ray worker matches the same
@@ -1170,6 +1152,10 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 			expectInitContainer: false,
 		},
 		{
+			// Covers the same worker/no-match/no-injection outcome as the
+			// external-address and elastic-EP Ray cases above, through the mp check
+			// instead of the Ray one -- no separate contract beyond that existing
+			// non-injection coverage.
 			name:          "data parallel worker with mp origin does not inject init container",
 			numberOfNodes: 2,
 			role:          RoleWorker,
@@ -1180,23 +1166,6 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 			},
 			multinodeDeployer:   &LWSMultinodeDeployer{},
 			initialPodSpec:      dpMultinodePodSpec("vllm:dp"),
-			expectInitContainer: false,
-		},
-		{
-			name:              "worker command matching neither mp nor plain-Ray shape does not inject init container",
-			numberOfNodes:     2,
-			role:              RoleWorker,
-			multinodeDeployer: &GroveMultinodeDeployer{},
-			initialPodSpec: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:    "main",
-						Image:   "vllm:latest",
-						Command: []string{"/bin/sh", "-c"},
-						Args:    []string{"exec python3 -m dynamo.vllm --some-other-flag"},
-					},
-				},
-			},
 			expectInitContainer: false,
 		},
 		{

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -1049,7 +1049,7 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 			numberOfNodes:       2,
 			role:                RoleWorker,
 			multinodeDeployer:   &GroveMultinodeDeployer{},
-			initialPodSpec:      rayMultinodePodSpec("vllm:ray", "leader"),
+			initialPodSpec:      rayMultinodePodSpec("vllm:ray", "$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE)"),
 			expectInitContainer: true,
 			expectedInitName:    "wait-for-leader-ray",
 			expectedInitImage:   "vllm:ray",
@@ -1061,7 +1061,7 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 			numberOfNodes:       2,
 			role:                RoleWorker,
 			multinodeDeployer:   &LWSMultinodeDeployer{},
-			initialPodSpec:      rayMultinodePodSpec("vllm:ray-v2", "leader"),
+			initialPodSpec:      rayMultinodePodSpec("vllm:ray-v2", "$(LWS_LEADER_ADDRESS)"),
 			expectInitContainer: true,
 			expectedInitName:    "wait-for-leader-ray",
 			expectedInitImage:   "vllm:ray-v2",
@@ -1083,6 +1083,19 @@ func TestVLLMBackend_UpdatePodSpec(t *testing.T) {
 					},
 				},
 			},
+			expectInitContainer: false,
+		},
+		{
+			// A hand-authored or externally-addressed Ray worker matches the same
+			// shape (single-arg "ray start --address=...:PORT --block" under
+			// /bin/sh -c) but joins a host the operator did not derive from this
+			// deployer/service. Injecting the wait-for-leader-ray init container
+			// here would make it wait on the wrong hostname and never succeed.
+			name:                "Ray worker joining a custom/external address does not inject init container",
+			numberOfNodes:       2,
+			role:                RoleWorker,
+			multinodeDeployer:   &GroveMultinodeDeployer{},
+			initialPodSpec:      rayMultinodePodSpec("vllm:ray-external", "external-ray-head.example.com"),
 			expectInitContainer: false,
 		},
 		{

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -3887,8 +3887,36 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													},
 												},
 											},
+											{
+												Name: "wait-leader-script",
+												VolumeSource: corev1.VolumeSource{
+													ConfigMap: &corev1.ConfigMapVolumeSource{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "test-dynamo-graph-deployment-wait-leader-script",
+														},
+													},
+												},
+											},
 										},
 										RestartPolicy: corev1.RestartPolicyAlways,
+										InitContainers: []corev1.Container{
+											{
+												Name:  "wait-for-leader-ray",
+												Image: "worker-image",
+												Command: []string{
+													"sh",
+													"-c",
+													`export LEADER_HOST="${GROVE_PCSG_NAME}-${GROVE_PCSG_INDEX}-worker-ldr-0.${GROVE_HEADLESS_SERVICE}" LEADER_PORT="6379" && exec python3 /scripts/wait-for-leader.py`,
+												},
+												VolumeMounts: []corev1.VolumeMount{
+													{
+														Name:      "wait-leader-script",
+														MountPath: "/scripts",
+														ReadOnly:  true,
+													},
+												},
+											},
+										},
 										Containers: []corev1.Container{
 											{
 												Name:  commonconsts.MainContainerName,


### PR DESCRIPTION
## Overview:

Ray multinode workers start `ray start --address=<leader>:6379 --block` immediately on pod start, with no gating on the leader's Ray head being ready — unlike MP (multiprocessing) workers, which already wait via an init container. This can leave a worker permanently unable to join the cluster until its pod is deleted and recreated.

## Details:

MP multinode workers already get a `wait-for-leader-mp` init container (`VLLMBackend.UpdatePodSpec`) that polls the leader's MP master port via a generic wait script/ConfigMap before the worker's main container starts. Ray workers never got an equivalent — they run `ray start --address=...` the instant the pod's containers start, racing the leader's `ray start --head`.

This reuses the same generic wait-for-leader script/ConfigMap infrastructure (already backend-agnostic) for Ray workers: it now waits on the Ray GCS port (6379) instead of the MP master port, with a `wait-for-leader-ray` init container name. Detection is based on the exact command shape `injectRayDistributedLaunchFlags` gives a plain TP/PP Ray worker (`ray start --address=...`), which is distinct from the elastic-EP Ray worker (already has its own leader health-gate) and the data-parallel-Ray path (keeps the full vLLM command) — so neither of those gets a redundant second init container.

## Where should the reviewer start?

`VLLMBackend.waitForLeaderPortAndName` and `UpdatePodSpec` in `deploy/operator/internal/dynamo/backend_vllm.go`. `TestVLLMBackend_UpdatePodSpec` in `backend_vllm_test.go` covers the new Ray-worker cases plus the elastic-EP/data-parallel exclusions.

## Validation

- `go build ./internal/dynamo/...` and `go vet ./internal/dynamo/...` pass.
- The test binary compiled successfully (Windows Smart App Control on this dev machine blocks *executing* freshly-built binaries, so I could not run the suite locally) — CI will confirm actual pass/fail.

## Related Issues

**🔗 This PR is linked to an issue:**
- Closes #14108


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup readiness handling for plain Ray workers by waiting for the appropriate leader service.
  * Preserved existing readiness behavior for model-parallel, elastic expert-parallel, and data-parallel worker configurations.
  * Prevented duplicate readiness containers and ensured leader pods are not assigned unnecessary wait containers.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->