### PR TITLE
fix(runtime): strip the whole reserved __ prefix from sanitized labels

### DIFF
--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -931,12 +931,11 @@ pub fn sanitize_prometheus_label(raw: &str) -> anyhow::Result<String> {
         sanitized = format!("_{}", sanitized);
     }
 
-    // Prevent __ prefix (reserved for Prometheus internal use) but allow __ elsewhere
+    // Prevent __ prefix (reserved for Prometheus internal use) but allow __ elsewhere.
+    // Every leading underscore has to go, not just the first two: removing one "__"
+    // from "___label" leaves "_label", and the re-prefix below then restores "__label".
     if sanitized.starts_with("__") {
-        sanitized = sanitized
-            .strip_prefix("__")
-            .unwrap_or(&sanitized)
-            .to_string();
+        sanitized = sanitized.trim_start_matches('_').to_string();
         if sanitized.is_empty() || !sanitized.chars().next().unwrap().is_ascii_alphabetic() {
             sanitized = format!("_{}", sanitized);
         }
@@ -1176,6 +1175,50 @@ mod tests {
         // Test that strings with only invalid characters return error
         assert!(sanitize_prometheus_label("@#$%").is_err()); // @#$% -> ____ -> ___ -> all underscores error
         assert!(sanitize_prometheus_label("!!!!").is_err()); // !!!! -> ____ -> ___ -> all underscores error
+    }
+
+    #[test]
+    fn test_sanitize_prometheus_label_strips_every_leading_underscore() {
+        // Three or more leading underscores: removing a single "__" left "_test",
+        // whose leading underscore was then re-prefixed back to the reserved "__test".
+        assert_eq!(sanitize_prometheus_label("___test").unwrap(), "test");
+        assert_eq!(sanitize_prometheus_label("____test").unwrap(), "test");
+
+        // Same path when the leading characters only become underscores after
+        // invalid-character replacement.
+        assert_eq!(sanitize_prometheus_label("...test").unwrap(), "test");
+        assert_eq!(sanitize_prometheus_label("-.-test").unwrap(), "test");
+        assert_eq!(sanitize_prometheus_label(":::test").unwrap(), "test");
+
+        // A leading digit still needs exactly one underscore in front of it.
+        assert_eq!(sanitize_prometheus_label("___1test").unwrap(), "_1test");
+
+        // The postcondition the doc comment promises, over every accepted spelling
+        // exercised here and in test_sanitize_prometheus_label.
+        for raw in [
+            "___test",
+            "____test",
+            "...test",
+            "-.-test",
+            ":::test",
+            "___1test",
+            "__test",
+            "__1abc",
+            "test___label",
+            "@test",
+            "123test",
+            "valid_label",
+        ] {
+            let sanitized = sanitize_prometheus_label(raw).unwrap();
+            assert!(
+                !sanitized.starts_with("__"),
+                "sanitize_prometheus_label({raw:?}) returned reserved name {sanitized:?}"
+            );
+        }
+
+        // All-underscore inputs still error rather than sanitizing to "_".
+        assert!(sanitize_prometheus_label("___").is_err());
+        assert!(sanitize_prometheus_label("_____").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Overview:

`sanitize_prometheus_label` documents "No colons, no `__` prefix (reserved)" and its existing test asserts that `__test` sanitizes to `test`, but the strip only removes the first two underscores. `___test` comes back as `__test`, `____test` comes back as `___test`, and `...test` comes back as `__test`, so the function hands back exactly the reserved prefix that block exists to remove.

## Details:

`lib/runtime/src/metrics/prometheus_names.rs:935` called `strip_prefix("__")` once, and the next line puts a single underscore back whenever the remainder does not start with an ASCII letter. For `___test` the strip leaves `_test`, which starts with `_`, so the guard prefixes another underscore and the result is `__test`. Any input whose first three or more characters become underscores after `LABEL_INVALID_CHARS_PATTERN` replacement lands in the same place, for example `...test` and `-.-test`.

Trimming every leading underscore instead of exactly one pair closes it. The re-prefix branch can then only add one underscore back, so the result carries at most one leading underscore for any input. Nothing else moves: inputs with zero, one or two leading underscores take the path they took before, `___1test` still gets its single underscore in front of the digit, and an all-underscore input still falls through to the existing error below. Every assertion in `test_sanitize_prometheus_label` passes unchanged.

On scope: the only in-tree caller is `lib/runtime/src/metrics.rs:304-322`, which passes namespace, component and endpoint label *values*, and Prometheus does not reserve `__` in values. So this is a contract fix on the exported helper rather than a label being dropped in a running deployment today. The reserved-prefix rule applies to label *names*, which is what this function is documented for and what the next caller will pass.

## Where should the reviewer start?

`sanitize_prometheus_label` in `lib/runtime/src/metrics/prometheus_names.rs`, then `test_sanitize_prometheus_label_strips_every_leading_underscore` at the bottom of the same file.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed, no related issue

## Validation:

macOS arm64, Rust 1.96.1 from `rust-toolchain.toml`. `dynamo-runtime` declares `default = []`, so no feature flags are needed and none of the Linux/CUDA `block-manager` code is in the path.

```
cargo test -p dynamo-runtime --lib metrics::prometheus_names   8 passed, 0 failed
cargo test -p dynamo-runtime --lib metrics::                  23 passed, 0 failed
cargo fmt -p dynamo-runtime -- --check                        clean
cargo clippy -p dynamo-runtime --all-targets                  clean
```

Reverting only the one-line change in `sanitize_prometheus_label` and keeping the new test makes exactly that test fail, at the first assertion, with `left: "__test"` / `right: "test"`. The other seven tests in the module still pass, so the new coverage is load-bearing and does not overlap what was already checked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Prometheus label sanitization to prevent reserved double-underscore prefixes, including labels with multiple leading underscores or invalid characters.
  - Labels beginning with digits are handled more reliably.
  - Inputs consisting entirely of underscores now return a clear validation error.
  - Sanitization behavior consistently enforces valid, non-reserved label names across edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->