### PR TITLE
fix(profiler): set swept engine args with the unique setter

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -74,6 +74,33 @@ def _pod_spec(component: dict) -> dict:
     return component["podTemplate"]["spec"]
 
 
+def test_tp_sweep_overrides_an_equals_spelled_user_value() -> None:
+    """The swept TP must win over a user's --tp=N, not lose to it.
+
+    set_argument_value cannot match the equals spelling, so it replaced the
+    stock `--tp 1` in place and left the user's `--tp=N` sitting after it.
+    SGLang's parser takes the last occurrence, so the worker ran the user's
+    value while the point was recorded against the swept one, with GPU
+    resources sized for the swept one.
+    """
+    from dynamo.planner.config.defaults import SubComponentType
+
+    modifier = CONFIG_MODIFIERS["sglang"]
+    config = modifier.load_default_config("agg")
+    worker_args = _main_container(_worker_components(config)[0])["args"]
+    assert "--tp" in worker_args, "fixture expects a stock --tp to replace"
+    worker_args.append("--tp=7")
+
+    converted = modifier.set_config_tp_size(
+        config, 2, component_type=SubComponentType.DECODE
+    )
+    converted_args = _main_container(_worker_components(converted)[0])["args"]
+
+    occurrences = [arg for arg in converted_args if str(arg).startswith("--tp")]
+    assert occurrences == ["--tp"], f"expected one canonical --tp, got {occurrences}"
+    assert converted_args[converted_args.index("--tp") + 1] == "2"
+
+
 def _worker_components(config: dict) -> list[dict]:
     return [
         component

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -75,14 +75,8 @@ def _pod_spec(component: dict) -> dict:
 
 
 def test_tp_sweep_overrides_an_equals_spelled_user_value() -> None:
-    """The swept TP must win over a user's --tp=N, not lose to it.
-
-    set_argument_value cannot match the equals spelling, so it replaced the
-    stock `--tp 1` in place and left the user's `--tp=N` sitting after it.
-    SGLang's parser takes the last occurrence, so the worker ran the user's
-    value while the point was recorded against the swept one, with GPU
-    resources sized for the swept one.
-    """
+    """SGLang's parser takes the last `--tp` occurrence, so a user's
+    `--tp=N` left sitting after the swept value silently wins."""
     from dynamo.planner.config.defaults import SubComponentType
 
     modifier = CONFIG_MODIFIERS["sglang"]

--- a/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
@@ -17,7 +17,6 @@ from dynamo.profiler.utils.config import (
     get_main_container,
     get_worker_component_from_config,
     remove_valued_arguments,
-    set_argument_value,
     set_unique_argument_value,
     setup_worker_component_resources,
     update_image,
@@ -329,7 +328,7 @@ class SGLangConfigModifier(BaseConfigModifier):
         args = validate_and_get_worker_args(worker_service, backend="sglang")
 
         # Set --tp argument
-        args = set_argument_value(args, "--tp", str(tp_size))
+        args = set_unique_argument_value(args, "--tp", str(tp_size))
         args = remove_valued_arguments(args, "--tp-size")
         args = remove_valued_arguments(args, "--tensor-parallel-size")
 
@@ -366,12 +365,12 @@ class SGLangConfigModifier(BaseConfigModifier):
         args = validate_and_get_worker_args(worker_service, backend="sglang")
 
         # 1. Set --tp=tep_size, if not present add it
-        args = set_argument_value(args, "--tp", str(tep_size))
+        args = set_unique_argument_value(args, "--tp", str(tep_size))
         args = remove_valued_arguments(args, "--tp-size")
         args = remove_valued_arguments(args, "--tensor-parallel-size")
 
         # 2. Set --ep=tep_size, if not present add it
-        args = set_argument_value(args, "--ep", str(tep_size))
+        args = set_unique_argument_value(args, "--ep", str(tep_size))
         args = remove_valued_arguments(args, "--ep-size")
         args = remove_valued_arguments(args, "--expert-parallel-size")
 
@@ -407,12 +406,12 @@ class SGLangConfigModifier(BaseConfigModifier):
         args = validate_and_get_worker_args(worker_service, backend="sglang")
 
         # 1. Set --tp=dep_size
-        args = set_argument_value(args, "--tp", str(dep_size))
+        args = set_unique_argument_value(args, "--tp", str(dep_size))
         args = remove_valued_arguments(args, "--tp-size")
         args = remove_valued_arguments(args, "--tensor-parallel-size")
 
         # 2. Set --dp=dep_size (data parallelism across experts)
-        args = set_argument_value(args, "--dp", str(dep_size))
+        args = set_unique_argument_value(args, "--dp", str(dep_size))
         args = remove_valued_arguments(args, "--dp-size")
         args = remove_valued_arguments(args, "--data-parallel-size")
 
@@ -421,7 +420,7 @@ class SGLangConfigModifier(BaseConfigModifier):
             args = append_argument(args, "--enable-dp-attention")
 
         # 4. Set --ep=dep_size (expert parallelism size)
-        args = set_argument_value(args, "--ep", str(dep_size))
+        args = set_unique_argument_value(args, "--ep", str(dep_size))
         args = remove_valued_arguments(args, "--ep-size")
         args = remove_valued_arguments(args, "--expert-parallel-size")
 
@@ -511,11 +510,15 @@ class SGLangConfigModifier(BaseConfigModifier):
         args = break_arguments(args)
 
         # Set max concurrency to control effective batch size
-        args = set_argument_value(args, "--max-running-requests", str(max_batch_size))
+        args = set_unique_argument_value(
+            args, "--max-running-requests", str(max_batch_size)
+        )
         args = _normalize_prefill_dp_limits(args)
 
         # Cap total tokens processed in a batch to avoid chunked prefill
-        args = set_argument_value(args, "--chunked-prefill-size", str(max_num_tokens))
+        args = set_unique_argument_value(
+            args, "--chunked-prefill-size", str(max_num_tokens)
+        )
 
         args = append_argument(args, "--enable-dp-lm-head")
 

--- a/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
@@ -19,7 +19,6 @@ from dynamo.profiler.utils.config import (
     get_main_container,
     get_worker_component_from_config,
     remove_valued_arguments,
-    set_argument_value,
     set_unique_argument_value,
     setup_worker_component_resources,
     update_image,
@@ -437,7 +436,7 @@ class VllmV1ConfigModifier(BaseConfigModifier):
 
         # Remove --tp alias if present, use --tensor-parallel-size as canonical form
         args = remove_valued_arguments(args, "--tp")
-        args = set_argument_value(args, "--tensor-parallel-size", str(tp_size))
+        args = set_unique_argument_value(args, "--tensor-parallel-size", str(tp_size))
 
         get_main_container(worker_service).args = args
 
@@ -473,9 +472,9 @@ class VllmV1ConfigModifier(BaseConfigModifier):
 
         # Remove aliases, use canonical forms
         args = remove_valued_arguments(args, "--tp")
-        args = set_argument_value(args, "--tensor-parallel-size", str(tep_size))
+        args = set_unique_argument_value(args, "--tensor-parallel-size", str(tep_size))
         args = remove_valued_arguments(args, "--dp")
-        args = set_argument_value(args, "--data-parallel-size", "1")
+        args = set_unique_argument_value(args, "--data-parallel-size", "1")
 
         # Remove hybrid load balancing flags - not compatible with DP=1
         args = remove_valued_arguments(args, "--data-parallel-size-local")
@@ -519,15 +518,15 @@ class VllmV1ConfigModifier(BaseConfigModifier):
 
         # Remove aliases, use canonical forms
         args = remove_valued_arguments(args, "--tp")
-        args = set_argument_value(args, "--tensor-parallel-size", "1")
+        args = set_unique_argument_value(args, "--tensor-parallel-size", "1")
         args = remove_valued_arguments(args, "--dp")
-        args = set_argument_value(args, "--data-parallel-size", str(dep_size))
+        args = set_unique_argument_value(args, "--data-parallel-size", str(dep_size))
 
         # Handle hybrid load balancing for multinode DEP
         # If dep_size > num_gpus_per_node, we need multinode and can use hybrid-lb
         if dep_size > num_gpus_per_node and "--data-parallel-hybrid-lb" in args:
             # Set local DP size to GPUs per node for hybrid load balancing
-            args = set_argument_value(
+            args = set_unique_argument_value(
                 args, "--data-parallel-size-local", str(num_gpus_per_node)
             )
         else:
@@ -659,8 +658,8 @@ class VllmV1ConfigModifier(BaseConfigModifier):
             max_num_tokens // dp_size if dp_size > 1 else max_num_tokens
         )
 
-        args = set_argument_value(args, "--max-num-seqs", str(max_batch_size))
-        args = set_argument_value(
+        args = set_unique_argument_value(args, "--max-num-seqs", str(max_batch_size))
+        args = set_unique_argument_value(
             args, "--max-num-batched-tokens", str(per_gpu_max_tokens)
         )
 


### PR DESCRIPTION
## Summary

`set_argument_value` matches a flag only as a bare token, so it cannot see `--flag=value`.
When the stock template already carries the bare form, it replaces that in place and leaves
the user's equals-spelled copy sitting after it. SGLang and vLLM both take the last
occurrence, so the worker runs the user's value while the point is recorded against the
swept one, and `setup_worker_component_resources` has already sized GPUs for the swept one.

Reproduced on `main` with the stock SGLang `agg` template, which ships `--tp 1`, plus a
worker that also sets `--tp=7`, swept at `tp=2`:

```
before: ['--model-path', ..., '--tp', '2', '--trust-remote-code', '--skip-tokenizer-init', '--tp=7']
                                                                                           ^ engine uses 7
after:  ['--model-path', ..., '--trust-remote-code', '--skip-tokenizer-init', '--tp', '2']
```

`config.py` already exports `set_unique_argument_value` for exactly this. Its docstring is
explicit that it exists so "appended DGD overrides must not leave a later conflicting value
for the backend parser to consume", which is this bug.

The strongest argument that this is an oversight rather than a choice is that these two
modules already use the unique setter for the args they must control exactly: model
identity in `protocol.py`, `--max-model-len` in `vllm.py`, and the
`--max-running-requests` clamp in `sglang.py`. Only the parallelism and batch setters were
left on the weak one, and `sglang.py` ends up setting `--max-running-requests` both ways.

This routes the remaining setters through it. It becomes the only setter these modules use,
so the `set_argument_value` import goes with it. vLLM's ordering happens to be benign today
because it appends rather than replacing in place, but it is the same latent hazard and is
covered by the same change.

I found this by sweeping every flag these modifiers touch, in the equals spelling, through
each parallelism setter and asserting no flag ends up duplicated: 25 duplicate cases before,
0 after.

Note for whoever merges: this touches the same two files as #14384, but different lines and
a different mechanism (that one is about removals, this one about setters). They should not
conflict beyond the import block.

## Validation

Local, on macOS. Config shaping only, no engine was launched.

- `pytest components/src/dynamo/profiler/tests/` — 431 passed, versus 430 on clean
  `upstream/main`, with the same 17 pre-existing `test_replay_aic_parity.py` failures and no
  new failing node IDs. Those 17 fail on `AIC perf model requires the 'aic-forward-pass'
  feature`, which this box does not build.
- The added test was confirmed to fail with only the sources reverted:
  `AssertionError: expected one canonical --tp, got ['--tp', '--tp=7']`.
- `black` at the pinned `23.1.0` and `pre-commit` on the touched files are clean.

One caveat on how I ran the tests: this suite skips unless the `dynamo.llm` bindings import,
and they do not build in my environment (`ImportError: cannot import name
'LoadThresholdConfig' from 'dynamo._core'`). I inject that one missing symbol before
importing. Nothing on these code paths touches it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Profiler configuration now ensures parallelism and prefill settings use a single canonical value.
  - SGLang and vLLM configurations consistently override duplicate or conflicting command-line settings.
  - Added regression coverage for tensor-parallel argument overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->