### PR TITLE
fix(profiler): stop the argument removers eating the next flag

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_config_arg_removal.py
+++ b/components/src/dynamo/profiler/tests/unit/test_config_arg_removal.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the shared argument removers in profiler/utils/config.py."""
+
+import pytest
+
+from dynamo.profiler.utils.config import (
+    remove_all_argument_occurrences,
+    remove_valued_arguments,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.planner,
+    pytest.mark.parallel,
+]
+
+REMOVERS = (remove_all_argument_occurrences, remove_valued_arguments)
+
+
+@pytest.mark.parametrize("remove", REMOVERS)
+def test_key_without_a_value_does_not_consume_the_next_flag(remove) -> None:
+    """A key left without a value must take only itself.
+
+    Both removers used to delete the following token unconditionally, so a
+    mistyped ``--tp`` swallowed the next argument as well and left its value
+    behind as a stray positional.
+    """
+    args = ["--tp", "--model-path", "/models/m", "--trust-remote-code"]
+
+    assert remove(list(args), "--tp") == [
+        "--model-path",
+        "/models/m",
+        "--trust-remote-code",
+    ]
+
+
+@pytest.mark.parametrize("remove", REMOVERS)
+def test_negative_values_are_still_consumed(remove) -> None:
+    """``-1`` is a value, not the start of another argument."""
+    args = ["--max-model-len", "-1", "--model-path", "/models/m"]
+
+    assert remove(list(args), "--max-model-len") == ["--model-path", "/models/m"]
+
+
+@pytest.mark.parametrize("remove", REMOVERS)
+def test_ordinary_valued_argument_still_removes_both_tokens(remove) -> None:
+    args = ["--model-path", "/models/m", "--tp", "2", "--trust-remote-code"]
+
+    assert remove(list(args), "--tp") == [
+        "--model-path",
+        "/models/m",
+        "--trust-remote-code",
+    ]
+
+
+@pytest.mark.parametrize("remove", REMOVERS)
+def test_trailing_key_is_removed(remove) -> None:
+    assert remove(["--model-path", "/models/m", "--tp"], "--tp") == [
+        "--model-path",
+        "/models/m",
+    ]

--- a/components/src/dynamo/profiler/tests/unit/test_config_arg_removal.py
+++ b/components/src/dynamo/profiler/tests/unit/test_config_arg_removal.py
@@ -23,12 +23,9 @@ REMOVERS = (remove_all_argument_occurrences, remove_valued_arguments)
 
 @pytest.mark.parametrize("remove", REMOVERS)
 def test_key_without_a_value_does_not_consume_the_next_flag(remove) -> None:
-    """A key left without a value must take only itself.
-
-    Both removers used to delete the following token unconditionally, so a
-    mistyped ``--tp`` swallowed the next argument as well and left its value
-    behind as a stray positional.
-    """
+    """Both removers used to delete the following token unconditionally, so a
+    mistyped ``--tp`` swallowed the next argument and left its value behind as
+    a stray positional."""
     args = ["--tp", "--model-path", "/models/m", "--trust-remote-code"]
 
     assert remove(list(args), "--tp") == [

--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -251,8 +251,6 @@ def remove_all_argument_occurrences(args: list[str], arg_name: str) -> list[str]
         arg = args[index]
         if arg == arg_name:
             index += 1
-            # Only consume a value. A following flag belongs to another
-            # argument, so a key left without one takes just itself.
             if index < len(args) and not _is_flag(args[index]):
                 index += 1
             continue

--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -211,12 +211,28 @@ def break_arguments(args: list[str] | str | None) -> list[str]:
     return ans
 
 
+def _is_flag(token: object) -> bool:
+    """True when ``token`` starts a new argument rather than being a value.
+
+    Long form only, matching the guard already used in the TensorRT-LLM
+    modifier. A bare ``-`` prefix would misread negative values such as
+    ``--max-model-len -1``.
+    """
+    return isinstance(token, str) and token.startswith("--")
+
+
 def remove_valued_arguments(args: list[str], key: str) -> list[str]:
-    """Remove a valued argument (e.g., --key value) from the arguments list if exists."""
+    """Remove a valued argument (e.g., --key value) from the arguments list if exists.
+
+    Only the value is consumed with the key. A following token that is itself a
+    flag belongs to another argument, so a key left without a value takes just
+    itself rather than eating its neighbour.
+    """
     if key in args:
         idx = args.index(key)
-        if idx + 1 < len(args):
-            del args[idx : idx + 2]
+        del args[idx]
+        if idx < len(args) and not _is_flag(args[idx]):
+            del args[idx]
 
     return args
 
@@ -234,7 +250,11 @@ def remove_all_argument_occurrences(args: list[str], arg_name: str) -> list[str]
     while index < len(args):
         arg = args[index]
         if arg == arg_name:
-            index += 2 if index + 1 < len(args) else 1
+            index += 1
+            # Only consume a value. A following flag belongs to another
+            # argument, so a key left without one takes just itself.
+            if index < len(args) and not _is_flag(args[index]):
+                index += 1
             continue
         if isinstance(arg, str) and arg.startswith(f"{arg_name}="):
             index += 1


### PR DESCRIPTION
## Summary

Both shared argument removers in `profiler/utils/config.py` consumed the token after the key
unconditionally, so a key that had lost its value took its neighbour with it:

```python
remove_all_argument_occurrences(["--tp", "--model-path", "/models/m"], "--tp")
# -> ["/models/m"]
```

`--model-path` is gone and its value is left behind as a stray positional, which the engine
rejects with an error far from the cause. `remove_valued_arguments` does the same thing.

The TensorRT-LLM modifier already gets this right when it strips its chunked-prefill flag
(`config_modifiers/trtllm.py`): it deletes the key, then deletes the following token only
when that token is not itself a flag. This moves that same rule into the shared helpers, so
the two paths agree.

The flag check is long form only (`--`), deliberately. A bare `-` prefix would misread
negative values, and `--max-model-len -1` must still consume its `-1`.

**Second defect, found while testing the first.** `remove_valued_arguments` never removed a
*trailing* key at all, because the deletion was guarded by `idx + 1 < len(args)`:

```
main:  remove_valued_arguments(["--model-path", "/m", "--tp"], "--tp") -> ["--model-path", "/m", "--tp"]
fixed: -> ["--model-path", "/m"]
```

Deleting the key first and the value conditionally fixes both cases in one change.

I found the first one by property-sweeping these helpers over every arrangement of a flag in
both spellings, with and without values, asserting that removal leaves no residue and takes
no unrelated argument. One violation before, none after.

## Validation

Local, on macOS. Pure list manipulation, no engine involved.

- `pytest components/src/dynamo/profiler/tests/` — 438 passed, versus 430 on clean
  `upstream/main`, with the same 17 pre-existing `test_replay_aic_parity.py` failures and no
  new failing node IDs. Those 17 fail on `AIC perf model requires the 'aic-forward-pass'
  feature`, which this box does not build.
- The added tests were confirmed against the unfixed source with only
  `utils/config.py` reverted: 3 of 8 fail, covering both defects and both removers.
- `black` at the pinned `23.1.0` and `pre-commit` on the touched files are clean.

The new tests live in their own file because no existing test module covers these helpers
directly. They are shared primitives with roughly 39 call sites, so I did not want the
coverage attached to an unrelated subject.

One caveat on how I ran them: this suite skips unless the `dynamo.llm` bindings import, and
they do not build in my environment (`ImportError: cannot import name 'LoadThresholdConfig'
from 'dynamo._core'`). I inject that one missing symbol before importing. Nothing on these
code paths touches it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line argument handling so standalone flags are preserved when removing valued options.
  - Correctly handles negative values, regular option-value pairs, and trailing options.

- **Tests**
  - Added coverage for argument-removal behavior across supported implementations and execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->