### PR TITLE
fix(common): check the IPv4 inside IPv6 transition addresses

### DIFF
--- a/components/src/dynamo/common/http/url_validator.py
+++ b/components/src/dynamo/common/http/url_validator.py
@@ -72,13 +72,50 @@ _BLOCKED_HOSTS: frozenset[str] = frozenset(
 )
 
 
+# Well-known NAT64 prefix (RFC 6052). Addresses inside it carry the IPv4
+# destination in the low 32 bits, so an IPv6-only cluster reaches IPv4 hosts
+# through it. A network-specific prefix may use a different length and is not
+# detectable from the address alone.
+_NAT64_WELL_KNOWN = ipaddress.ip_network("64:ff9b::/96")
+
+
+def _embedded_ipv4(ip: ipaddress.IPv6Address) -> tuple[ipaddress.IPv4Address, ...]:
+    """Return the IPv4 addresses an IPv6 transition address actually reaches.
+
+    6to4 and Teredo are decoded by the stdlib. Without this, a blocked IPv4
+    wrapped in one of these formats passes the range check, because the range
+    check only sees the IPv6 form.
+    """
+    if ip.sixtofour is not None:
+        return (ip.sixtofour,)
+    if ip.teredo is not None:
+        # (server, client): traffic involves both.
+        return ip.teredo
+    if ip in _NAT64_WELL_KNOWN:
+        return (ipaddress.IPv4Address(int(ip) & 0xFFFFFFFF),)
+    return ()
+
+
 def is_blocked_ip(ip_text: str) -> bool:
-    """Return True if ``ip_text`` parses as an IP inside one of the blocked ranges."""
+    """Return True if ``ip_text`` parses as an IP inside one of the blocked ranges.
+
+    IPv6 transition addresses are resolved to the IPv4 address they reach and
+    that address is checked too, so a blocked IPv4 cannot be smuggled through
+    in 6to4, Teredo or NAT64 form.
+    """
     try:
         ip = ipaddress.ip_address(ip_text)
     except ValueError:
         return False
-    return any(ip in net for net in _BLOCKED_IP_NETWORKS)
+    if any(ip in net for net in _BLOCKED_IP_NETWORKS):
+        return True
+    if isinstance(ip, ipaddress.IPv6Address):
+        return any(
+            embedded in net
+            for embedded in _embedded_ipv4(ip)
+            for net in _BLOCKED_IP_NETWORKS
+        )
+    return False
 
 
 @dataclass(frozen=True)

--- a/components/src/dynamo/common/tests/http/test_url_validator.py
+++ b/components/src/dynamo/common/tests/http/test_url_validator.py
@@ -111,6 +111,44 @@ def test_is_blocked_ip_allows_public(ip: str) -> None:
     assert is_blocked_ip(ip) is False
 
 
+@pytest.mark.parametrize(
+    ("ip", "reaches"),
+    [
+        ("64:ff9b::7f00:1", "127.0.0.1"),
+        ("64:ff9b::a9fe:a9fe", "169.254.169.254"),
+        ("64:ff9b::a00:1", "10.0.0.1"),
+        ("2002:7f00:1::", "127.0.0.1"),
+        ("2002:a9fe:a9fe::", "169.254.169.254"),
+    ],
+)
+def test_is_blocked_ip_blocks_ipv4_smuggled_through_transition_formats(
+    ip: str, reaches: str
+) -> None:
+    """A blocked IPv4 must stay blocked when wrapped in a transition format.
+
+    NAT64 and 6to4 carry an IPv4 destination inside the IPv6 address, so an
+    IPv6-only cluster routes them to that IPv4. Matching only the IPv6 form
+    against the range list let the metadata and loopback addresses through.
+    """
+    assert is_blocked_ip(reaches) is True, "fixture expects a blocked target"
+    assert is_blocked_ip(ip) is True
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "64:ff9b::808:808",  # NAT64 to 8.8.8.8
+        "2002:808:808::",  # 6to4 to 8.8.8.8
+    ],
+)
+def test_is_blocked_ip_allows_transition_formats_reaching_public_ipv4(
+    ip: str,
+) -> None:
+    """An IPv6-only cluster reaches public IPv4 through NAT64, so do not
+    block the prefixes wholesale."""
+    assert is_blocked_ip(ip) is False
+
+
 def test_is_blocked_ip_non_ip_literal_returns_false() -> None:
     # A hostname, not an IP — is_blocked_ip only classifies literals.
     assert is_blocked_ip("example.com") is False

--- a/components/src/dynamo/common/tests/http/test_url_validator.py
+++ b/components/src/dynamo/common/tests/http/test_url_validator.py
@@ -114,11 +114,9 @@ def test_is_blocked_ip_allows_public(ip: str) -> None:
 @pytest.mark.parametrize(
     ("ip", "reaches"),
     [
-        ("64:ff9b::7f00:1", "127.0.0.1"),
         ("64:ff9b::a9fe:a9fe", "169.254.169.254"),
-        ("64:ff9b::a00:1", "10.0.0.1"),
-        ("2002:7f00:1::", "127.0.0.1"),
         ("2002:a9fe:a9fe::", "169.254.169.254"),
+        ("2001:0:808:808:0:0:5601:5601", "169.254.169.254"),
     ],
 )
 def test_is_blocked_ip_blocks_ipv4_smuggled_through_transition_formats(
@@ -129,6 +127,11 @@ def test_is_blocked_ip_blocks_ipv4_smuggled_through_transition_formats(
     NAT64 and 6to4 carry an IPv4 destination inside the IPv6 address, so an
     IPv6-only cluster routes them to that IPv4. Matching only the IPv6 form
     against the range list let the metadata and loopback addresses through.
+
+    One row per format, since the format is what this protects; blocklist
+    membership of each IPv4 is asserted directly in
+    `test_is_blocked_ip_ranges`. The Teredo client is stored bitwise negated,
+    so 5601:5601 is 169.254.169.254.
     """
     assert is_blocked_ip(reaches) is True, "fixture expects a blocked target"
     assert is_blocked_ip(ip) is True
@@ -139,6 +142,7 @@ def test_is_blocked_ip_blocks_ipv4_smuggled_through_transition_formats(
     [
         "64:ff9b::808:808",  # NAT64 to 8.8.8.8
         "2002:808:808::",  # 6to4 to 8.8.8.8
+        "2001:0:808:808:0:0:f7f7:f7f7",  # Teredo, server and client both 8.8.8.8
     ],
 )
 def test_is_blocked_ip_allows_transition_formats_reaching_public_ipv4(


### PR DESCRIPTION
## Summary

`_BLOCKED_IP_NETWORKS` is documented as the "IP ranges that must never be reachable from a
user-controlled URL", and the comment calls out that `169.254/16` covers the AWS and
OpenStack metadata IP. `is_blocked_ip` enforced that by matching the address it was handed
against the list directly.

An IPv4 address carried inside an IPv6 transition address does not match any listed range,
because the range check only ever sees the IPv6 form:

| address | reaches | before | after |
|---|---|---|---|
| `64:ff9b::a9fe:a9fe` | `169.254.169.254` | allowed | blocked |
| `64:ff9b::7f00:1` | `127.0.0.1` | allowed | blocked |
| `2002:a9fe:a9fe::` | `169.254.169.254` | allowed | blocked |
| `2002:7f00:1::` | `127.0.0.1` | allowed | blocked |

Both branches of `validate_url` depend on this single check, so it applies to an IP literal
in the URL host and to a hostname whose AAAA record points at one of these.

This decodes the embedded IPv4 and checks that too. 6to4 and Teredo come from `ipaddress`
(`.sixtofour`, `.teredo`). NAT64 is handled for the well-known `64:ff9b::/96` prefix, where
RFC 6052 places the address in the low 32 bits. A network-specific NAT64 prefix can use
other lengths and is not identifiable from the address alone; that limitation is noted in
the code.

**Deliberately not blocking these prefixes wholesale.** An IPv6-only cluster reaches every
IPv4 host through NAT64, so blanket-blocking `64:ff9b::/96` would break ordinary media
fetching from IPv4-only origins. Only the embedded address decides, so
`64:ff9b::808:808` (8.8.8.8) still passes. There are tests for both directions.

Found by sweeping `is_blocked_ip` over the usual set of loopback-and-metadata-equivalent
representations and diffing what it classified against what each form actually routes to.
The IPv4-mapped case (`::ffff:127.0.0.1`) was already covered by `::ffff:0:0/96` being
listed.

## Validation

Local, on macOS. Pure address classification, no network I/O in these paths.

- `pytest components/src/dynamo/common/tests/` — 538 passed, versus 531 on clean
  `upstream/main`, with the same 16 pre-existing failures and no new failing node IDs.
- The added tests were confirmed against the unfixed source with only `url_validator.py`
  reverted: the 5 blocking cases fail, and the 2 "still allow public IPv4 via NAT64/6to4"
  cases pass either way, which is what they should do.
- `black` at the pinned `23.1.0` and `pre-commit` on the touched files are clean.

I have not exercised this against a real NAT64 cluster; the change is to address
classification only, and the behaviour above is covered by unit tests.

One caveat on how I ran the tests: this suite skips unless the `dynamo.llm` bindings import,
and they do not build in my environment (`ImportError: cannot import name
'LoadThresholdConfig' from 'dynamo._core'`). I inject that one missing symbol before
importing. Nothing on these code paths touches it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL and IP validation to detect blocked IPv4 addresses embedded in IPv6 transition formats, including 6to4, Teredo, and NAT64.
  - Prevented blocked IPv4 destinations from bypassing network restrictions through IPv6 representations.
  - Continued allowing IPv6 transition addresses that resolve to public IPv4 destinations.

- **Tests**
  - Added coverage for blocked and permitted IPv4 destinations embedded in IPv6 addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->