### PR TITLE
fix(llm): check the IPv4 inside IPv6 transition addresses

### DIFF
--- a/lib/llm/src/preprocessor/media/loader.rs
+++ b/lib/llm/src/preprocessor/media/loader.rs
@@ -1164,15 +1164,14 @@ mod tests_non_nixl {
 
     #[test]
     fn test_is_blocked_ip_blocks_ipv4_smuggled_through_transition_formats() {
-        // NAT64 and 6to4 carry an IPv4 destination inside the IPv6 address, so
-        // an IPv6-only cluster routes them to that IPv4. Matching only the IPv6
-        // form against the range list let metadata and loopback through.
+        // One row per transition format, since the format is what this test
+        // protects; the blocklist membership of each IPv4 is covered directly
+        // by test_is_blocked_ip_ranges. The Teredo client is stored bitwise
+        // negated, so 5601:5601 is 169.254.169.254.
         for (ip, reaches) in [
-            ("64:ff9b::7f00:1", "127.0.0.1"),
             ("64:ff9b::a9fe:a9fe", "169.254.169.254"),
-            ("64:ff9b::a00:1", "10.0.0.1"),
-            ("2002:7f00:1::", "127.0.0.1"),
             ("2002:a9fe:a9fe::", "169.254.169.254"),
+            ("2001:0:808:808:0:0:5601:5601", "169.254.169.254"),
         ] {
             let target: IpAddr = reaches.parse().unwrap();
             assert!(is_blocked_ip(&target), "fixture expects {reaches} blocked");
@@ -1188,7 +1187,11 @@ mod tests_non_nixl {
     fn test_is_blocked_ip_allows_transition_formats_reaching_public_ipv4() {
         // An IPv6-only cluster reaches public IPv4 through NAT64, so the
         // prefixes must not be blocked wholesale.
-        for ip in ["64:ff9b::808:808", "2002:808:808::"] {
+        for ip in [
+            "64:ff9b::808:808",
+            "2002:808:808::",
+            "2001:0:808:808:0:0:f7f7:f7f7",
+        ] {
             let addr: IpAddr = ip.parse().unwrap();
             assert!(
                 !is_blocked_ip(&addr),

--- a/lib/llm/src/preprocessor/media/loader.rs
+++ b/lib/llm/src/preprocessor/media/loader.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashSet;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
@@ -87,9 +87,84 @@ static BLOCKED_HOSTS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     .collect()
 });
 
+/// Well-known NAT64 prefix (RFC 6052). Addresses inside it carry the IPv4
+/// destination in the low 32 bits, so an IPv6-only cluster reaches IPv4 hosts
+/// through it. A network-specific prefix may use a different length and is not
+/// identifiable from the address alone.
+const NAT64_WELL_KNOWN: [u16; 2] = [0x0064, 0xff9b];
+
+/// Return the IPv4 addresses an IPv6 transition address actually reaches.
+///
+/// Without this, a blocked IPv4 wrapped in 6to4, Teredo or NAT64 form passes
+/// the range check, because that check only sees the IPv6 form.
+fn embedded_ipv4(ip: &Ipv6Addr) -> Vec<Ipv4Addr> {
+    let segments = ip.segments();
+
+    // 6to4 (RFC 3056): 2002:V4ADDR::/48.
+    if segments[0] == 0x2002 {
+        return vec![Ipv4Addr::new(
+            (segments[1] >> 8) as u8,
+            segments[1] as u8,
+            (segments[2] >> 8) as u8,
+            segments[2] as u8,
+        )];
+    }
+
+    // Teredo (RFC 4380): 2001:0::/32, server in segments 2-3, client in the
+    // last two segments stored obfuscated (bitwise NOT).
+    if segments[0] == 0x2001 && segments[1] == 0 {
+        let server = Ipv4Addr::new(
+            (segments[2] >> 8) as u8,
+            segments[2] as u8,
+            (segments[3] >> 8) as u8,
+            segments[3] as u8,
+        );
+        let client_hi = !segments[6];
+        let client_lo = !segments[7];
+        let client = Ipv4Addr::new(
+            (client_hi >> 8) as u8,
+            client_hi as u8,
+            (client_lo >> 8) as u8,
+            client_lo as u8,
+        );
+        return vec![server, client];
+    }
+
+    // NAT64 well-known prefix: the address sits in the low 32 bits.
+    if segments[0] == NAT64_WELL_KNOWN[0]
+        && segments[1] == NAT64_WELL_KNOWN[1]
+        && segments[2] == 0
+        && segments[3] == 0
+        && segments[4] == 0
+        && segments[5] == 0
+    {
+        return vec![Ipv4Addr::new(
+            (segments[6] >> 8) as u8,
+            segments[6] as u8,
+            (segments[7] >> 8) as u8,
+            segments[7] as u8,
+        )];
+    }
+
+    Vec::new()
+}
+
 /// Return `true` if `ip` falls inside any of the blocked ranges.
+///
+/// IPv6 transition addresses are resolved to the IPv4 address they reach and
+/// that address is checked too, so a blocked IPv4 cannot be smuggled through
+/// in 6to4, Teredo or NAT64 form.
 pub fn is_blocked_ip(ip: &IpAddr) -> bool {
-    BLOCKED_IP_NETWORKS.iter().any(|net| net.contains(ip))
+    if BLOCKED_IP_NETWORKS.iter().any(|net| net.contains(ip)) {
+        return true;
+    }
+    if let IpAddr::V6(v6) = ip {
+        return embedded_ipv4(v6).into_iter().any(|v4| {
+            let addr = IpAddr::V4(v4);
+            BLOCKED_IP_NETWORKS.iter().any(|net| net.contains(&addr))
+        });
+    }
+    false
 }
 
 /// Build a policy refusal that the HTTP service maps to 400.
@@ -1084,6 +1159,41 @@ mod tests_non_nixl {
             let url = url::Url::parse(&format!("{scheme}://example.com/x")).unwrap();
             let error = fetcher.check_if_url_allowed(&url).unwrap_err();
             assert_invalid_argument_in_chain(error.as_ref());
+        }
+    }
+
+    #[test]
+    fn test_is_blocked_ip_blocks_ipv4_smuggled_through_transition_formats() {
+        // NAT64 and 6to4 carry an IPv4 destination inside the IPv6 address, so
+        // an IPv6-only cluster routes them to that IPv4. Matching only the IPv6
+        // form against the range list let metadata and loopback through.
+        for (ip, reaches) in [
+            ("64:ff9b::7f00:1", "127.0.0.1"),
+            ("64:ff9b::a9fe:a9fe", "169.254.169.254"),
+            ("64:ff9b::a00:1", "10.0.0.1"),
+            ("2002:7f00:1::", "127.0.0.1"),
+            ("2002:a9fe:a9fe::", "169.254.169.254"),
+        ] {
+            let target: IpAddr = reaches.parse().unwrap();
+            assert!(is_blocked_ip(&target), "fixture expects {reaches} blocked");
+            let addr: IpAddr = ip.parse().unwrap();
+            assert!(
+                is_blocked_ip(&addr),
+                "{ip} reaches {reaches}, must be blocked"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_blocked_ip_allows_transition_formats_reaching_public_ipv4() {
+        // An IPv6-only cluster reaches public IPv4 through NAT64, so the
+        // prefixes must not be blocked wholesale.
+        for ip in ["64:ff9b::808:808", "2002:808:808::"] {
+            let addr: IpAddr = ip.parse().unwrap();
+            assert!(
+                !is_blocked_ip(&addr),
+                "{ip} reaches 8.8.8.8, must be allowed"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

This is the Rust half of #14405. The two guards are deliberate mirrors: this file's comments
name `components/src/dynamo/common/http/url_validator.py::_BLOCKED_IP_NETWORKS` as the
source of truth for both the range list and the host list. They were consistent in the
ranges they list, and consistent in missing this.

`BLOCKED_IP_NETWORKS` is documented as ranges that must never be reachable from a
user-controlled URL, with `169.254/16` called out as covering the AWS and OpenStack metadata
IP. `is_blocked_ip` matched the address it was handed against that list directly, so an IPv4
carried inside an IPv6 transition address never matched:

| address | reaches | before | after |
|---|---|---|---|
| `64:ff9b::a9fe:a9fe` | `169.254.169.254` | allowed | blocked |
| `64:ff9b::7f00:1` | `127.0.0.1` | allowed | blocked |
| `2002:a9fe:a9fe::` | `169.254.169.254` | allowed | blocked |
| `2002:7f00:1::` | `127.0.0.1` | allowed | blocked |

`is_blocked_ip` is the single gate for the IP-literal path, the resolved-address path and the
redirect-hop filter in this file, so all three were affected.

This decodes the embedded IPv4 and checks that too, covering 6to4 (RFC 3056), Teredo
(RFC 4380, whose client address is stored bitwise-negated) and the well-known NAT64 prefix
(RFC 6052, address in the low 32 bits). A network-specific NAT64 prefix can use other
lengths and is not identifiable from the address alone; that limitation is noted in the code.
The IPv4-mapped case was already covered by `::ffff:0:0/96` being listed.

**Deliberately not blocking these prefixes wholesale.** An IPv6-only cluster reaches every
IPv4 host through NAT64, so blanket-blocking `64:ff9b::/96` would break ordinary media
fetching from IPv4-only origins. Only the embedded address decides, so `64:ff9b::808:808`
(8.8.8.8) still passes, and there is a test for that direction as well.

Rust has no stdlib equivalent of Python's `.sixtofour` / `.teredo`, so the extraction is
written out against the segment layout rather than borrowed.

## Validation

Local, on macOS, with `--no-default-features` per AGENTS.md. Pure address classification, no
network I/O in these paths.

- `cargo test -p dynamo-llm --no-default-features --lib` — 2421 passed, 1 failed. The one
  failure is `http::service::service_v2::tests::test_oversized_body_returns_json_413`, a
  known flake unrelated to this change: it fails 9 times in 12 on clean `upstream/main` on
  this machine, and #13704 fixes it.
- The added blocking test was confirmed red with only `is_blocked_ip` reverted to its
  previous one-line body: `64:ff9b::7f00:1 reaches 127.0.0.1, must be blocked`. The
  "still allow public IPv4" test passes either way, which is what it should do.
- `cargo fmt --all -- --check` clean. `cargo clippy -p dynamo-llm --no-default-features
  --lib` produces no lints on this code.

I have not exercised this against a real NAT64 cluster; the change is to address
classification only, and the behaviour above is covered by unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved network address validation for IPv6 transition formats, including 6to4, Teredo, and NAT64 addresses.
  - Blocked destinations can no longer bypass address restrictions by being embedded within supported IPv6 transition addresses.
  - Added coverage to verify that blocked addresses remain protected while publicly reachable addresses continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->