### PR TITLE
fix(runtime): cache configured etcd lease TTL once per process

### DIFF
--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -204,8 +204,9 @@ pub mod etcd {
 
     /// Requested ETCD lease TTL in seconds for discovery liveness. Must be >= 1;
     /// unset, zero, or invalid values fall back to the documented default of 10
-    /// seconds. Read once per process, so every client in the process requests
-    /// the same TTL. Keep-alive cadence derives from the granted TTL.
+    /// seconds. Read once per process as the shared default; explicit
+    /// `ClientOptions::lease_ttl` overrides may differ. Keep-alive cadence
+    /// derives from the granted TTL.
     pub const ETCD_LEASE_TTL: &str = "ETCD_LEASE_TTL";
 
     /// Maximum time in seconds to retry the initial ETCD connection (default: 120)

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -202,7 +202,10 @@ pub mod etcd {
     /// ETCD endpoints (comma-separated list of URLs)
     pub const ETCD_ENDPOINTS: &str = "ETCD_ENDPOINTS";
 
-    /// ETCD lease TTL in seconds (default: 10)
+    /// Requested ETCD lease TTL in seconds for discovery liveness. Must be >= 1;
+    /// unset, zero, or invalid values fall back to the documented default of 10
+    /// seconds. Read once per process, so every client in the process requests
+    /// the same TTL. Keep-alive cadence derives from the granted TTL.
     pub const ETCD_LEASE_TTL: &str = "ETCD_LEASE_TTL";
 
     /// Maximum time in seconds to retry the initial ETCD connection (default: 120)

--- a/lib/runtime/src/transports/etcd.rs
+++ b/lib/runtime/src/transports/etcd.rs
@@ -926,10 +926,9 @@ fn default_servers() -> Vec<String> {
 /// Default lease TTL (seconds) used when `ETCD_LEASE_TTL` is unset or invalid.
 const DEFAULT_LEASE_TTL_SECS: u64 = 10;
 
-/// Requested lease TTL, cached so it is read from the environment exactly once
-/// per process (issue #12312: env var + [`OnceLock`]). Every `ClientOptions`
-/// constructed in this process — primary runtime, component clients, planner —
-/// then requests the same TTL even if the environment changes mid-process.
+/// Default requested lease TTL, read from the environment once per process.
+/// Clients using the default share this cached value even if the environment
+/// changes; explicit `ClientOptions::lease_ttl` overrides may differ.
 static LEASE_TTL_SECS: OnceLock<u64> = OnceLock::new();
 
 /// Lease TTL in seconds to request from etcd.
@@ -1277,8 +1276,6 @@ mod unit_tests {
         assert!(!Client::is_etcd_connection_error(&err));
     }
 
-    /// Valid `ETCD_LEASE_TTL` values pass through unchanged, including values
-    /// far above the default (the operator ask in issue #12312).
     #[test]
     fn resolves_valid_lease_ttl() {
         assert_eq!(resolve_lease_ttl(Some("1")), 1);
@@ -1286,15 +1283,12 @@ mod unit_tests {
         assert_eq!(resolve_lease_ttl(Some("900")), 900);
     }
 
-    /// An unset variable keeps the documented default behavior.
     #[test]
     fn unset_lease_ttl_falls_back_to_default() {
         assert_eq!(resolve_lease_ttl(None), DEFAULT_LEASE_TTL_SECS);
         assert_eq!(DEFAULT_LEASE_TTL_SECS, 10);
     }
 
-    /// Zero, negative, non-numeric, and empty values all fall back to the
-    /// documented default instead of panicking or producing a zero-TTL lease.
     #[test]
     fn invalid_lease_ttl_falls_back_to_default() {
         for raw in ["0", "", " 30", "30s", "abc", "-1", "1.5"] {
@@ -1322,8 +1316,6 @@ mod unit_tests {
         );
     }
 
-    /// `Default` and the builder default must carry the same resolved TTL, and
-    /// an explicit builder value must win over the default.
     #[test]
     fn client_options_default_and_builder_carry_lease_ttl() {
         assert_eq!(ClientOptions::default().lease_ttl, default_lease_ttl());

--- a/lib/runtime/src/transports/etcd.rs
+++ b/lib/runtime/src/transports/etcd.rs
@@ -9,7 +9,7 @@ use derive_builder::Builder;
 use derive_getters::Dissolve;
 use futures::StreamExt;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use tokio::sync::{RwLock, mpsc};
 use validator::Validate;
 
@@ -864,7 +864,12 @@ pub struct ClientOptions {
     #[builder(default = "true")]
     pub attach_lease: bool,
 
-    /// Lease TTL in seconds
+    /// Lease TTL in seconds requested from etcd for discovery liveness.
+    ///
+    /// Defaults to `ETCD_LEASE_TTL` (read once per process) or
+    /// `DEFAULT_LEASE_TTL_SECS` when unset or invalid. The keep-alive cadence
+    /// always derives from the TTL etcd actually grants, not from this
+    /// requested value.
     #[builder(default = "default_lease_ttl()")]
     pub lease_ttl: u64,
 
@@ -918,27 +923,55 @@ fn default_servers() -> Vec<String> {
     }
 }
 
+/// Default lease TTL (seconds) used when `ETCD_LEASE_TTL` is unset or invalid.
+const DEFAULT_LEASE_TTL_SECS: u64 = 10;
+
+/// Requested lease TTL, cached so it is read from the environment exactly once
+/// per process (issue #12312: env var + [`OnceLock`]). Every `ClientOptions`
+/// constructed in this process — primary runtime, component clients, planner —
+/// then requests the same TTL even if the environment changes mid-process.
+static LEASE_TTL_SECS: OnceLock<u64> = OnceLock::new();
+
+/// Lease TTL in seconds to request from etcd.
+///
+/// Resolves `ETCD_LEASE_TTL` once per process; see [`resolve_lease_ttl`] for
+/// the invalid-value policy.
 fn default_lease_ttl() -> u64 {
-    match std::env::var(env_etcd::ETCD_LEASE_TTL) {
-        Ok(raw) => match raw.parse::<u64>() {
+    *LEASE_TTL_SECS
+        .get_or_init(|| resolve_lease_ttl(std::env::var(env_etcd::ETCD_LEASE_TTL).ok().as_deref()))
+}
+
+/// Resolve a raw `ETCD_LEASE_TTL` value into a requested lease TTL.
+///
+/// A valid value parses as `u64` and is >= 1. Unset, zero, negative,
+/// non-numeric, or empty values fall back to [`DEFAULT_LEASE_TTL_SECS`] with a
+/// warning — a documented default rather than a hard failure, so one bad value
+/// cannot take down an otherwise healthy deployment.
+fn resolve_lease_ttl(raw: Option<&str>) -> u64 {
+    match raw {
+        None => DEFAULT_LEASE_TTL_SECS,
+        Some(raw) => match raw.parse::<u64>() {
             Ok(ttl) if ttl > 0 => ttl,
             Ok(_) => {
                 tracing::warn!(
-                    "{} must be >= 1; got 0. Falling back to 10.",
-                    env_etcd::ETCD_LEASE_TTL
+                    env_var = env_etcd::ETCD_LEASE_TTL,
+                    value = %raw,
+                    default = DEFAULT_LEASE_TTL_SECS,
+                    "lease TTL must be >= 1 second; falling back to default"
                 );
-                10
+                DEFAULT_LEASE_TTL_SECS
             }
             Err(err) => {
                 tracing::warn!(
-                    "Invalid {}='{}' ({err}). Falling back to 10.",
-                    env_etcd::ETCD_LEASE_TTL,
-                    raw
+                    env_var = env_etcd::ETCD_LEASE_TTL,
+                    value = %raw,
+                    error = %err,
+                    default = DEFAULT_LEASE_TTL_SECS,
+                    "invalid lease TTL; falling back to default"
                 );
-                10
+                DEFAULT_LEASE_TTL_SECS
             }
         },
-        Err(_) => 10,
     }
 }
 
@@ -1243,6 +1276,65 @@ mod unit_tests {
         let err = anyhow::anyhow!("missing header during watch resync");
         assert!(!Client::is_etcd_connection_error(&err));
     }
+
+    /// Valid `ETCD_LEASE_TTL` values pass through unchanged, including values
+    /// far above the default (the operator ask in issue #12312).
+    #[test]
+    fn resolves_valid_lease_ttl() {
+        assert_eq!(resolve_lease_ttl(Some("1")), 1);
+        assert_eq!(resolve_lease_ttl(Some("30")), 30);
+        assert_eq!(resolve_lease_ttl(Some("900")), 900);
+    }
+
+    /// An unset variable keeps the documented default behavior.
+    #[test]
+    fn unset_lease_ttl_falls_back_to_default() {
+        assert_eq!(resolve_lease_ttl(None), DEFAULT_LEASE_TTL_SECS);
+        assert_eq!(DEFAULT_LEASE_TTL_SECS, 10);
+    }
+
+    /// Zero, negative, non-numeric, and empty values all fall back to the
+    /// documented default instead of panicking or producing a zero-TTL lease.
+    #[test]
+    fn invalid_lease_ttl_falls_back_to_default() {
+        for raw in ["0", "", " 30", "30s", "abc", "-1", "1.5"] {
+            assert_eq!(
+                resolve_lease_ttl(Some(raw)),
+                DEFAULT_LEASE_TTL_SECS,
+                "raw value {raw:?} must fall back to the default"
+            );
+        }
+    }
+
+    /// `default_lease_ttl` must resolve the environment exactly once per
+    /// process: a later environment change must not give a differently aged
+    /// client a different requested TTL. Both calls return the cached value,
+    /// so they are equal regardless of which test initialized the lock first.
+    #[test]
+    fn default_lease_ttl_is_read_once_per_process() {
+        let first =
+            temp_env::with_vars([(env_etcd::ETCD_LEASE_TTL, Some("41"))], default_lease_ttl);
+        let second =
+            temp_env::with_vars([(env_etcd::ETCD_LEASE_TTL, Some("59"))], default_lease_ttl);
+        assert_eq!(
+            first, second,
+            "lease TTL must be pinned by the process-wide OnceLock"
+        );
+    }
+
+    /// `Default` and the builder default must carry the same resolved TTL, and
+    /// an explicit builder value must win over the default.
+    #[test]
+    fn client_options_default_and_builder_carry_lease_ttl() {
+        assert_eq!(ClientOptions::default().lease_ttl, default_lease_ttl());
+
+        let options = Client::builder()
+            .etcd_url(vec!["http://localhost:2379".to_string()])
+            .lease_ttl(29)
+            .build()
+            .unwrap();
+        assert_eq!(options.lease_ttl, 29);
+    }
 }
 
 #[cfg(feature = "integration")]
@@ -1314,6 +1406,43 @@ mod tests {
         rt_clone.primary().block_on(async move {
             let drt = DistributedRuntime::new(rt, config).await.unwrap();
             test_kv_cache_operations(drt).await.unwrap();
+        });
+    }
+
+    /// The lease TTL requested through `ClientOptions::lease_ttl` must reach
+    /// etcd's lease grant (issue #12312). etcd reports the initially granted
+    /// TTL, so it must equal the requested value rather than the default.
+    #[test]
+    fn test_requested_lease_ttl_is_granted() {
+        const REQUESTED_TTL: u64 = 29;
+
+        let rt = Runtime::single_threaded().unwrap();
+        let rt_clone = rt.clone();
+
+        rt_clone.primary().block_on(async move {
+            let options = ClientOptions {
+                lease_ttl: REQUESTED_TTL,
+                ..ClientOptions::default()
+            };
+            let client = Client::new(options, rt.clone())
+                .await
+                .expect("etcd client should be available");
+            let lease_id = client.lease_id();
+
+            let mut lease_client = client.etcd_client().lease_client();
+            let resp = lease_client
+                .time_to_live(lease_id as i64, None)
+                .await
+                .expect("lease time-to-live query should succeed");
+
+            assert_eq!(
+                resp.granted_ttl() as u64,
+                REQUESTED_TTL,
+                "granted TTL must match the requested TTL, not the default"
+            );
+
+            // Cleanup so nothing lingers past the keep-alive task shutdown.
+            let _ = lease_client.revoke(lease_id as i64).await;
         });
     }
 


### PR DESCRIPTION
## Overview:

Read the existing `ETCD_LEASE_TTL` environment setting once per process using `OnceLock`, so runtime/component clients consistently request the same configured default. Preserve explicit builder overrides and the existing 10-second fallback for unset or invalid values; keep renewal cadence based on the granted lease.

## Details:

Cache only the environment-derived default TTL. Clients using that default share the cached value even after the environment changes; explicit `ClientOptions::lease_ttl` or builder overrides may request different TTLs. The documentation now states this distinction in both configuration and transport code.

## Where should the reviewer start?

- `lib/runtime/src/transports/etcd.rs`: `LEASE_TTL_SECS`, `default_lease_ttl`, `resolve_lease_ttl`, and the unit/integration tests for caching and explicit overrides.
- `lib/runtime/src/config/environment_names.rs`: the `ETCD_LEASE_TTL` configuration contract.

## Related Issues

- Relates to #12312: completes the requested once-per-process configuration behavior.
- Relates to #8076: the environment variable was introduced there.

## Validation

- Focused runtime lease-TTL tests: 5 passed, covering valid/invalid input, fallback, process caching, and explicit builder override.
- Added an etcd-backed grant test behind the existing integration feature; it was not run locally.
- Rust formatting and git diff --check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the `ETCD_LEASE_TTL` setting.
  * Unset, zero, negative, empty, or invalid values now safely fall back to 10 seconds with a warning.
  * Positive values are honored consistently throughout the process.
  * Keep-alive timing now follows the lease duration granted by etcd.

* **Documentation**
  * Clarified supported values, fallback behavior, and configuration timing for `ETCD_LEASE_TTL`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->