### PR TITLE
fix(runtime): release multimodal cache indexers after consumer teardown

### DIFF
--- a/lib/llm/src/kv_router/indexer/embedding_cache.rs
+++ b/lib/llm/src/kv_router/indexer/embedding_cache.rs
@@ -16,6 +16,7 @@ use dynamo_runtime::{
     transports::event_plane::EventSubscriber,
 };
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 
 use crate::kv_router::{
     MULTIMODAL_EMBEDDING_CACHE_SUBJECT, publisher::MultimodalEmbeddingCacheEvent,
@@ -24,6 +25,16 @@ use crate::protocols::common::{llm_backend::PreprocessedRequest, preprocessor::M
 
 fn multimodal_cache_key_from_url(url: &str) -> String {
     blake3::hash(url.as_bytes()).to_hex().to_string()
+}
+
+/// Cancels the token when the last indexer reference is dropped.
+#[derive(Debug, Default)]
+struct CancelOnDrop(CancellationToken);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.0.cancel();
+    }
 }
 
 pub fn preprocessed_multimodal_cache_keys(request: &PreprocessedRequest) -> Vec<String> {
@@ -58,6 +69,8 @@ pub struct EmbeddingCacheIndexer {
     key_workers: Arc<DashMap<String, HashSet<WorkerId>>>,
     worker_cache_keys: Arc<DashMap<WorkerId, HashSet<String>>>,
     started: Arc<AtomicBool>,
+    /// Cancels the subscriber when the last indexer reference is dropped.
+    drop_notify: Arc<CancelOnDrop>,
 }
 
 type SharedIndexerKey = (u64, String);
@@ -173,6 +186,7 @@ impl EmbeddingCacheIndexer {
         }
 
         let cancellation_token = endpoint.drt().child_token();
+        let drop_token = self.drop_notify.0.clone();
         let endpoint = endpoint.clone();
         let subscriber = match EventSubscriber::for_endpoint(
             &endpoint,
@@ -187,7 +201,7 @@ impl EmbeddingCacheIndexer {
             }
         };
 
-        let indexer = Arc::clone(self);
+        let indexer = Arc::downgrade(self);
         tokio::spawn(async move {
             let mut subscriber = subscriber;
             const RECONNECT_BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
@@ -199,12 +213,23 @@ impl EmbeddingCacheIndexer {
                             tracing::debug!("Embedding cache indexer subscriber cancelled");
                             break 'reconnect;
                         }
+                        _ = drop_token.cancelled() => {
+                            tracing::debug!("Embedding cache indexer dropped; subscriber stopping");
+                            break 'reconnect;
+                        }
                         maybe_event = subscriber.next() => {
                             let Some(result) = maybe_event else {
                                 tracing::warn!(
                                     "Embedding cache indexer stream ended; reconnecting"
                                 );
                                 break;
+                            };
+
+                            let Some(indexer) = indexer.upgrade() else {
+                                tracing::debug!(
+                                    "Embedding cache indexer dropped; subscriber stopping"
+                                );
+                                break 'reconnect;
                             };
 
                             match result {
@@ -227,14 +252,22 @@ impl EmbeddingCacheIndexer {
                             tracing::debug!("Embedding cache indexer subscriber cancelled");
                             break 'reconnect;
                         }
+                        _ = drop_token.cancelled() => {
+                            tracing::debug!("Embedding cache indexer dropped; subscriber stopping");
+                            break 'reconnect;
+                        }
                     }
 
-                    match EventSubscriber::for_endpoint(
-                        &endpoint,
-                        MULTIMODAL_EMBEDDING_CACHE_SUBJECT,
-                    )
-                    .await
-                    {
+                    let next_subscriber = tokio::select! {
+                        _ = cancellation_token.cancelled() => break 'reconnect,
+                        _ = drop_token.cancelled() => break 'reconnect,
+                        result = EventSubscriber::for_endpoint(
+                            &endpoint,
+                            MULTIMODAL_EMBEDDING_CACHE_SUBJECT,
+                        ) => result,
+                    };
+
+                    match next_subscriber {
                         Ok(subscriber) => {
                             break subscriber.typed::<MultimodalEmbeddingCacheEvent>();
                         }
@@ -247,7 +280,9 @@ impl EmbeddingCacheIndexer {
                 };
             }
 
-            indexer.started.store(false, Ordering::Release);
+            if let Some(indexer) = indexer.upgrade() {
+                indexer.started.store(false, Ordering::Release);
+            }
         });
 
         Ok(())
@@ -304,6 +339,10 @@ impl MultimodalCacheIndex for EmbeddingCacheIndexer {
 
     fn remove_worker(&self, worker_id: WorkerId) {
         EmbeddingCacheIndexer::remove_worker(self, worker_id);
+    }
+
+    fn drop_token(&self) -> Option<CancellationToken> {
+        Some(self.drop_notify.0.clone())
     }
 }
 
@@ -412,5 +451,81 @@ mod tests {
 
         assert_eq!(indexer.workers_with_cached_keys(["a"]), vec![3, 4]);
         assert_eq!(indexer.workers_with_cached_keys(["a", "b"]), vec![3, 4]);
+    }
+
+    #[test]
+    fn drop_token_cancels_with_last_indexer_reference() {
+        let first = Arc::new(EmbeddingCacheIndexer::default());
+        let second = Arc::clone(&first);
+        let token = first
+            .drop_token()
+            .expect("embedding indexer must expose a drop token");
+
+        drop(first);
+        assert!(!token.is_cancelled());
+        drop(second);
+        assert!(token.is_cancelled());
+    }
+
+    /// The subscriber must not keep a shared indexer alive after its consumers
+    /// drop their references.
+    #[tokio::test]
+    async fn shared_registry_evicts_indexer_after_last_consumer_drops() {
+        use dynamo_runtime::{
+            DistributedRuntime, Runtime,
+            config::environment_names::{
+                event_plane::DYN_EVENT_PLANE,
+                zmq_broker::{DYN_ZMQ_BROKER_ENABLED, DYN_ZMQ_BROKER_URL},
+            },
+            distributed::DistributedConfig,
+        };
+
+        temp_env::async_with_vars(
+            [
+                (DYN_EVENT_PLANE, None::<&str>),
+                (DYN_ZMQ_BROKER_URL, None::<&str>),
+                (DYN_ZMQ_BROKER_ENABLED, None::<&str>),
+            ],
+            async {
+                let runtime = Runtime::from_current().unwrap();
+                let drt =
+                    DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                        .await
+                        .unwrap();
+                let endpoint = drt
+                    .namespace("embedding-cache-eviction-test".to_string())
+                    .unwrap()
+                    .component("workers".to_string())
+                    .unwrap()
+                    .endpoint("generate".to_string());
+
+                let first = try_build_cache_indexer(&endpoint)
+                    .await
+                    .expect("indexer should build under the local event plane");
+                let second = try_build_cache_indexer(&endpoint)
+                    .await
+                    .expect("indexer should build under the local event plane");
+                assert!(
+                    Arc::ptr_eq(&first, &second),
+                    "concurrent consumers must share one live indexer"
+                );
+
+                let weak = Arc::downgrade(&first);
+
+                drop(first);
+                assert!(
+                    weak.upgrade().is_some(),
+                    "the remaining consumer must keep the indexer alive"
+                );
+
+                drop(second);
+                assert!(
+                    weak.upgrade().is_none(),
+                    "subscriber must not keep the indexer alive after the last consumer drops"
+                );
+                runtime.shutdown();
+            },
+        )
+        .await;
     }
 }

--- a/lib/llm/src/kv_router/indexer/embedding_cache.rs
+++ b/lib/llm/src/kv_router/indexer/embedding_cache.rs
@@ -27,7 +27,6 @@ fn multimodal_cache_key_from_url(url: &str) -> String {
     blake3::hash(url.as_bytes()).to_hex().to_string()
 }
 
-/// Cancels the token when the last indexer reference is dropped.
 #[derive(Debug, Default)]
 struct CancelOnDrop(CancellationToken);
 

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -539,12 +539,10 @@ fn spawn_multimodal_cache_cleanup_watcher(
             let discovery = endpoint.drt().discovery();
             let discovery_request = discovery.list_and_watch(query, None);
             tokio::pin!(discovery_request);
-            let discovery_result = loop {
-                tokio::select! {
-                    result = &mut discovery_request => break result,
-                    _ = cancel_token.cancelled() => break 'reconnect,
-                    _ = &mut indexer_dropped => break 'reconnect,
-                }
+            let discovery_result = tokio::select! {
+                result = &mut discovery_request => result,
+                _ = cancel_token.cancelled() => break 'reconnect,
+                _ = &mut indexer_dropped => break 'reconnect,
             };
 
             let mut stream = match discovery_result {
@@ -556,12 +554,10 @@ fn spawn_multimodal_cache_cleanup_watcher(
                     );
                     let reconnect_delay = tokio::time::sleep(RECONNECT_BACKOFF);
                     tokio::pin!(reconnect_delay);
-                    loop {
-                        tokio::select! {
-                            _ = &mut reconnect_delay => continue 'reconnect,
-                            _ = cancel_token.cancelled() => break 'reconnect,
-                            _ = &mut indexer_dropped => break 'reconnect,
-                        }
+                    tokio::select! {
+                        _ = &mut reconnect_delay => continue 'reconnect,
+                        _ = cancel_token.cancelled() => break 'reconnect,
+                        _ = &mut indexer_dropped => break 'reconnect,
                     }
                 }
             };

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -31,7 +31,7 @@ use std::{
     collections::{HashMap, HashSet},
     marker::PhantomData,
     pin::Pin,
-    sync::{Arc, atomic::AtomicU64},
+    sync::{Arc, Weak, atomic::AtomicU64},
     task::Poll,
     time::Instant,
 };
@@ -126,6 +126,13 @@ pub trait WorkerLoadMonitor: Send + Sync {
 pub trait MultimodalCacheIndex: Send + Sync {
     fn workers_with_cache_key_hits(&self, cache_keys: &[String]) -> Vec<(u64, usize)>;
     fn remove_worker(&self, worker_id: u64);
+
+    /// Returns a token cancelled when this index is dropped, when available.
+    /// Implementations without an index lifecycle token use the runtime token
+    /// as their only shutdown path.
+    fn drop_token(&self) -> Option<tokio_util::sync::CancellationToken> {
+        None
+    }
 }
 
 pub type MultimodalCacheKeyExtractor<T> = Arc<dyn Fn(&T) -> Vec<String> + Send + Sync>;
@@ -354,7 +361,7 @@ impl RuntimeEndpointId {
 
 /// At most one multimodal cache cleanup watcher per runtime endpoint.
 static ENDPOINT_CACHE_INDEXER_WATCHER_ACTIVE: std::sync::OnceLock<
-    dashmap::DashMap<RuntimeEndpointId, ()>,
+    dashmap::DashMap<RuntimeEndpointId, Weak<dyn MultimodalCacheIndex>>,
 > = std::sync::OnceLock::new();
 
 /// Watch discovery for instance removals and cancel pending response-stream
@@ -474,17 +481,28 @@ fn spawn_multimodal_cache_cleanup_watcher(
     cancel_token: tokio_util::sync::CancellationToken,
 ) {
     use crate::discovery::{DiscoveryEvent, DiscoveryInstanceId, DiscoveryQuery};
+    use dashmap::mapref::entry::Entry;
     use tokio_stream::StreamExt as _;
 
-    let guard = ENDPOINT_CACHE_INDEXER_WATCHER_ACTIVE.get_or_init(dashmap::DashMap::new);
     let watcher_id = RuntimeEndpointId::for_endpoint(&endpoint);
-    if guard.insert(watcher_id.clone(), ()).is_some() {
-        tracing::debug!(
-            connection_id = watcher_id.connection_id,
-            ?watcher_id.endpoint_id,
-            "Multimodal cache cleanup watcher already running for this runtime endpoint, skipping"
-        );
-        return;
+    let drop_token = indexer.drop_token();
+    let indexer = Arc::downgrade(&indexer);
+    let guard = ENDPOINT_CACHE_INDEXER_WATCHER_ACTIVE.get_or_init(dashmap::DashMap::new);
+    match guard.entry(watcher_id.clone()) {
+        Entry::Occupied(mut entry) if entry.get().strong_count() == 0 => {
+            *entry.get_mut() = indexer.clone();
+        }
+        Entry::Occupied(_) => {
+            tracing::debug!(
+                connection_id = watcher_id.connection_id,
+                ?watcher_id.endpoint_id,
+                "Multimodal cache cleanup watcher already running for this runtime endpoint, skipping"
+            );
+            return;
+        }
+        Entry::Vacant(entry) => {
+            entry.insert(indexer.clone());
+        }
     }
 
     let endpoint_name = endpoint.name().to_string();
@@ -492,15 +510,23 @@ fn spawn_multimodal_cache_cleanup_watcher(
     let component = endpoint.component().name().to_string();
 
     tokio::spawn(async move {
-        struct GuardRelease(RuntimeEndpointId);
+        struct GuardRelease(RuntimeEndpointId, Weak<dyn MultimodalCacheIndex>);
         impl Drop for GuardRelease {
             fn drop(&mut self) {
                 if let Some(map) = ENDPOINT_CACHE_INDEXER_WATCHER_ACTIVE.get() {
-                    map.remove(&self.0);
+                    map.remove_if(&self.0, |_, current| Weak::ptr_eq(current, &self.1));
                 }
             }
         }
-        let _release = GuardRelease(watcher_id);
+        let _release = GuardRelease(watcher_id, indexer.clone());
+        let indexer_dropped = async move {
+            if let Some(drop_token) = drop_token {
+                drop_token.cancelled().await;
+            } else {
+                std::future::pending::<()>().await;
+            }
+        };
+        tokio::pin!(indexer_dropped);
 
         const RECONNECT_BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
         'reconnect: loop {
@@ -510,25 +536,49 @@ fn spawn_multimodal_cache_cleanup_watcher(
                 endpoint: endpoint_name.clone(),
             };
 
-            let mut stream = match endpoint.drt().discovery().list_and_watch(query, None).await {
+            let discovery = endpoint.drt().discovery();
+            let discovery_request = discovery.list_and_watch(query, None);
+            tokio::pin!(discovery_request);
+            let discovery_result = loop {
+                tokio::select! {
+                    result = &mut discovery_request => break result,
+                    _ = cancel_token.cancelled() => break 'reconnect,
+                    _ = &mut indexer_dropped => break 'reconnect,
+                }
+            };
+
+            let mut stream = match discovery_result {
                 Ok(stream) => stream,
                 Err(error) => {
                     tracing::warn!(
                         endpoint = %endpoint_name,
                         "Failed to start multimodal cache cleanup watcher (will retry): {error}"
                     );
-                    tokio::select! {
-                        _ = tokio::time::sleep(RECONNECT_BACKOFF) => continue 'reconnect,
-                        _ = cancel_token.cancelled() => break 'reconnect,
+                    let reconnect_delay = tokio::time::sleep(RECONNECT_BACKOFF);
+                    tokio::pin!(reconnect_delay);
+                    loop {
+                        tokio::select! {
+                            _ = &mut reconnect_delay => continue 'reconnect,
+                            _ = cancel_token.cancelled() => break 'reconnect,
+                            _ = &mut indexer_dropped => break 'reconnect,
+                        }
                     }
                 }
             };
 
             loop {
                 tokio::select! {
+                    _ = &mut indexer_dropped => break 'reconnect,
                     event = stream.next() => {
                         match event {
                             Some(Ok(DiscoveryEvent::Removed(DiscoveryInstanceId::Endpoint(eid)))) => {
+                                let Some(indexer) = indexer.upgrade() else {
+                                    tracing::debug!(
+                                        endpoint = %endpoint_name,
+                                        "Multimodal cache index dropped; cleanup watcher exiting"
+                                    );
+                                    break 'reconnect;
+                                };
                                 indexer.remove_worker(eid.instance_id);
                             }
                             Some(Ok(_)) => {}
@@ -2218,7 +2268,7 @@ impl<U: Data + MaybeError> crate::engine::AsyncEngineStream<U> for OccupancyTrac
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::Ordering;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use crate::{
         DistributedRuntime, Runtime,
@@ -3479,6 +3529,137 @@ mod tests {
         assert_eq!(first.endpoint_id, second.endpoint_id);
         assert_ne!(first.connection_id, second.connection_id);
         assert_ne!(first, second);
+
+        runtime.shutdown();
+    }
+
+    /// Wait for a spawned watcher to release its deduplication entry.
+    async fn wait_until(mut predicate: impl FnMut() -> bool) {
+        for _ in 0..500 {
+            if predicate() {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
+    /// Cache index whose teardown is externally observable.
+    struct ObservableCacheIndex {
+        drop_token: tokio_util::sync::CancellationToken,
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl ObservableCacheIndex {
+        fn new() -> (Arc<Self>, Arc<AtomicBool>) {
+            let dropped = Arc::new(AtomicBool::new(false));
+            let index = Arc::new(Self {
+                drop_token: tokio_util::sync::CancellationToken::new(),
+                dropped: dropped.clone(),
+            });
+            (index, dropped)
+        }
+    }
+
+    impl MultimodalCacheIndex for ObservableCacheIndex {
+        fn workers_with_cache_key_hits(&self, _cache_keys: &[String]) -> Vec<(u64, usize)> {
+            Vec::new()
+        }
+
+        fn remove_worker(&self, _worker_id: u64) {}
+
+        fn drop_token(&self) -> Option<tokio_util::sync::CancellationToken> {
+            Some(self.drop_token.clone())
+        }
+    }
+
+    impl Drop for ObservableCacheIndex {
+        fn drop(&mut self) {
+            self.drop_token.cancel();
+            self.dropped.store(true, Ordering::Relaxed);
+        }
+    }
+
+    fn cache_watcher_guard()
+    -> &'static dashmap::DashMap<RuntimeEndpointId, Weak<dyn MultimodalCacheIndex>> {
+        ENDPOINT_CACHE_INDEXER_WATCHER_ACTIVE.get_or_init(dashmap::DashMap::new)
+    }
+
+    fn cache_watcher_is_for(
+        guard: &dashmap::DashMap<RuntimeEndpointId, Weak<dyn MultimodalCacheIndex>>,
+        watcher_id: &RuntimeEndpointId,
+        indexer: &Weak<dyn MultimodalCacheIndex>,
+    ) -> bool {
+        guard
+            .get(watcher_id)
+            .is_some_and(|current| Weak::ptr_eq(current.value(), indexer))
+    }
+
+    /// The cleanup watcher must not keep its index alive after the last
+    /// consumer drops it when the index exposes a lifecycle token.
+    #[tokio::test]
+    async fn cache_cleanup_watcher_stops_with_last_index_consumer() {
+        let runtime = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let endpoint = drt
+            .namespace("cache-watcher-last-consumer".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap()
+            .endpoint("generate".to_string());
+
+        let (index, dropped) = ObservableCacheIndex::new();
+        let index: Arc<dyn MultimodalCacheIndex> = index;
+        spawn_multimodal_cache_cleanup_watcher(
+            endpoint.clone(),
+            index.clone(),
+            drt.primary_token(),
+        );
+
+        let watcher_id = RuntimeEndpointId::for_endpoint(&endpoint);
+        let guard = cache_watcher_guard();
+        assert!(
+            guard.contains_key(&watcher_id),
+            "watcher must register its dedup entry"
+        );
+
+        drop(index);
+
+        // Re-arm before the old task has run its Drop guard. Its cleanup must
+        // not remove the replacement generation.
+        let (fresh, fresh_dropped) = ObservableCacheIndex::new();
+        let fresh: Arc<dyn MultimodalCacheIndex> = fresh;
+        let fresh_weak = Arc::downgrade(&fresh);
+        spawn_multimodal_cache_cleanup_watcher(
+            endpoint.clone(),
+            fresh.clone(),
+            drt.primary_token(),
+        );
+        assert!(
+            guard.contains_key(&watcher_id),
+            "fresh index must re-arm the watcher for the same endpoint"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(
+            cache_watcher_is_for(guard, &watcher_id, &fresh_weak),
+            "old watcher must not remove a replacement generation"
+        );
+        assert!(
+            dropped.load(Ordering::Relaxed),
+            "watcher must not keep the old index alive with a strong reference"
+        );
+
+        drop(fresh);
+        wait_until(|| !guard.contains_key(&watcher_id)).await;
+        assert!(
+            !guard.contains_key(&watcher_id),
+            "re-armed watcher must also exit with its index"
+        );
+        assert!(
+            fresh_dropped.load(Ordering::Relaxed),
+            "re-armed watcher must not keep the fresh index alive"
+        );
 
         runtime.shutdown();
     }


### PR DESCRIPTION
Shared multimodal embedding-cache indexers could remain alive after their last consumer disappeared because subscriber and endpoint-cleanup tasks retained them. Both tasks now hold weak index references and observe index-lifecycle cancellation, including during reconnect waits and subscription setup.

Cleanup watcher registrations also retain weak generation references. A retiring watcher removes only its own generation, so it cannot erase a replacement watcher registered for the same endpoint.

GitHub Rust CI passed the last-consumer cancellation, shared-registry eviction, cleanup-watcher shutdown, and replacement-generation tests on commit `a2fbd28b7b84`. The Pre Merge and full PR workflows passed on that commit, including both planner CPU architectures after retrying an image-build timeout. Closes #13335.
