### PR TITLE
fix(common): treat the data URI scheme and base64 token case-insensitively

### DIFF
--- a/components/src/dynamo/common/multimodal/media_source.py
+++ b/components/src/dynamo/common/multimodal/media_source.py
@@ -49,6 +49,18 @@ def is_local_media_url(url: str) -> bool:
 # Generous enough to keep an ordinary URL intact and identifiable.
 SOURCE_LABEL_LIMIT: Final = 120
 
+_DATA_SCHEME: Final = "data:"
+
+
+def _is_data_uri(source: str) -> bool:
+    """True when ``source`` carries the ``data:`` scheme, in any case.
+
+    URI schemes are case-insensitive (RFC 3986), and ``urlparse`` lowercases
+    them, so the rest of this module already accepts ``DATA:``. Slicing keeps
+    this cheap on a multi-megabyte payload.
+    """
+    return source[: len(_DATA_SCHEME)].lower() == _DATA_SCHEME
+
 
 def describe_media_source(source: str, limit: int = SOURCE_LABEL_LIMIT) -> str:
     """Render ``source`` as a bounded label safe to put in an error or log.
@@ -61,8 +73,8 @@ def describe_media_source(source: str, limit: int = SOURCE_LABEL_LIMIT) -> str:
     """
     if not isinstance(source, str):
         return "<non-string media source>"
-    if source.startswith("data:"):
-        meta = source[len("data:") :].partition(",")[0]
+    if _is_data_uri(source):
+        meta = source[len(_DATA_SCHEME) :].partition(",")[0]
         media_type = meta.split(";")[0] or "application/octet-stream"
         return f"data:{media_type} ({len(source)} chars, payload elided)"
     if len(source) > limit:
@@ -81,7 +93,8 @@ def _decode_data_uri(url: str) -> bytes:
     meta, sep, payload = remainder.partition(",")
     if not sep:
         raise UrlValidationError("Malformed data URI: missing ',' separator")
-    if "base64" not in meta.split(";"):
+    # RFC 2045 makes the encoding token case-insensitive.
+    if "base64" not in [token.lower() for token in meta.split(";")]:
         raise UrlValidationError("Unsupported data URI: expected base64 payload")
     try:
         return base64.b64decode(unquote(payload), validate=True)

--- a/components/src/dynamo/common/tests/multimodal/test_media_source.py
+++ b/components/src/dynamo/common/tests/multimodal/test_media_source.py
@@ -18,6 +18,7 @@ import pytest
 
 from dynamo.common.http.url_validator import UrlValidationError, UrlValidationPolicy
 from dynamo.common.multimodal.media_source import (
+    _decode_data_uri,
     describe_media_source,
     is_local_media_url,
     read_local_media_bytes,
@@ -123,6 +124,33 @@ def test_describe_media_source_elides_a_data_uri_payload() -> None:
     assert "data:video/mp4" in label
     assert "payload elided" in label
     assert len(label) < 100
+
+
+@pytest.mark.parametrize("scheme", ["DATA:", "Data:"])
+def test_describe_media_source_elides_a_data_uri_in_any_scheme_case(
+    scheme: str,
+) -> None:
+    """URI schemes are case-insensitive, and the rest of this module accepts
+    ``DATA:`` because ``urlparse`` lowercases it. A case-sensitive check here
+    reproduced the payload it exists to withhold, in full when the URI was
+    shorter than the truncation limit."""
+    payload = base64.b64encode(b"secret-media-bytes").decode()
+    url = f"{scheme}image/png;base64,{payload}"
+    assert len(url) < 120, "fixture must sit under the truncation limit"
+
+    label = describe_media_source(url)
+
+    assert payload not in label
+    assert "payload elided" in label
+
+
+@pytest.mark.parametrize("token", ["BASE64", "Base64"])
+def test_base64_data_uri_accepted_in_any_token_case(token: str) -> None:
+    """RFC 2045 makes the encoding token case-insensitive, so a spec-valid
+    ``;BASE64`` URI must not be refused."""
+    payload = base64.b64encode(b"hello").decode()
+
+    assert _decode_data_uri(f"data:image/png;{token},{payload}") == b"hello"
 
 
 def test_describe_media_source_keeps_an_ordinary_url_intact() -> None:

--- a/components/src/dynamo/common/tests/multimodal/test_media_source.py
+++ b/components/src/dynamo/common/tests/multimodal/test_media_source.py
@@ -126,7 +126,7 @@ def test_describe_media_source_elides_a_data_uri_payload() -> None:
     assert len(label) < 100
 
 
-@pytest.mark.parametrize("scheme", ["DATA:", "Data:"])
+@pytest.mark.parametrize("scheme", ["DATA:"])
 def test_describe_media_source_elides_a_data_uri_in_any_scheme_case(
     scheme: str,
 ) -> None:
@@ -144,7 +144,7 @@ def test_describe_media_source_elides_a_data_uri_in_any_scheme_case(
     assert "payload elided" in label
 
 
-@pytest.mark.parametrize("token", ["BASE64", "Base64"])
+@pytest.mark.parametrize("token", ["BASE64"])
 def test_base64_data_uri_accepted_in_any_token_case(token: str) -> None:
     """RFC 2045 makes the encoding token case-insensitive, so a spec-valid
     ``;BASE64`` URI must not be refused."""


### PR DESCRIPTION
## Summary

`describe_media_source` exists so a `data:` URI never reaches a log sink or an error body by
content. Its docstring is explicit: "Describe those by media type and size instead, never by
content."

It tested the scheme with a case-sensitive `startswith("data:")`, while the rest of the
module routes through `urlparse`, which lowercases the scheme. So `DATA:` and `Data:` URIs
are accepted by `is_local_media_url` and decoded by `_decode_data_uri` like any other, and
then described by content here. For a URI shorter than the 120-character truncation limit,
that is the whole payload verbatim:

```
data:  ->  'data:image/png (46 chars, payload elided)'
DATA:  ->  'DATA:image/png;base64,c2VjcmV0LW1lZGlhLWJ5dGVz'
```

Longer URIs are truncated rather than elided, so they leak the first 120 characters instead
of all of it.

`_decode_data_uri` has the mirror of the same problem. RFC 2045 makes the encoding token
case-insensitive, so `data:image/png;BASE64,...` is a valid data URI, and it was refused
with "Unsupported data URI: expected base64 payload".

One root cause, case-sensitive handling of case-insensitive syntax, in both directions: the
redaction failed open and the decoder failed closed.

The scheme is compared on a 5-character slice rather than by lowercasing the whole string,
because the payload can be megabytes and this runs on the error path.

## Validation

Local, on macOS. Pure string handling, no network or filesystem access in these paths.

- `pytest components/src/dynamo/common/tests/` — 535 passed, versus 531 on clean
  `upstream/main`, with the same 16 pre-existing failures and no new failing node IDs.
- The 4 added tests were confirmed against the unfixed source with only `media_source.py`
  reverted: all 4 fail, 2 for the redaction and 2 for the decoder.
- `black` at the pinned `23.1.0` and `pre-commit` on the touched files are clean.

One caveat on how I ran the tests: this suite skips unless the `dynamo.llm` bindings import,
and they do not build in my environment (`ImportError: cannot import name
'LoadThresholdConfig' from 'dynamo._core'`). I inject that one missing symbol before
importing. Nothing on these code paths touches it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of data URIs with uppercase or mixed-case scheme names.
  - Data URI payloads are now correctly redacted in media-source descriptions regardless of letter casing.
  - Base64-encoded data URIs now decode correctly when the encoding token uses uppercase or mixed-case letters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->