### PR TITLE
fix(common): mask the whole URL userinfo when logging pip args

### DIFF
--- a/components/src/dynamo/common/tests/test_install_media_decoders.py
+++ b/components/src/dynamo/common/tests/test_install_media_decoders.py
@@ -370,6 +370,20 @@ def test_redact_masks_credentials_when_the_username_holds_an_unencoded_at():
     assert "https://***@pypi.corp/simple" in masked
 
 
+def test_redact_stops_at_a_query_or_fragment_after_the_host():
+    """An "@" in a query must not drag the match past the host.
+
+    The bounding class used to be `[^/\\s]+`, so a credentialed URL collapsed to
+    `https://***@value` and lost its host, and a URL with no userinfo at all
+    gained a redaction it never needed.
+    """
+    line = "pip install --index-url https://user:secret@pypi.corp?next=a@b"
+    masked = install_media_decoders._redact(line)
+
+    assert "secret" not in masked
+    assert masked == "pip install --index-url https://***@pypi.corp?next=a@b"
+
+
 def test_redact_masks_every_credentialed_url_on_one_line():
     line = "https://a@h1/x https://user@corp.com:secret@h2/y"
     masked = install_media_decoders._redact(line)
@@ -382,9 +396,10 @@ def test_redact_masks_every_credentialed_url_on_one_line():
     "line",
     [
         "https://pypi.org/simple and mail user@example.com",
-        "contact: ops@example.com",
-        "https://pypi.org/simple",
-        "pip install numpy",
+        # An "@" past the host is query or fragment text, not userinfo. No
+        # path, so the "/" boundary cannot be what stops the match.
+        "https://pypi.org?next=user@example.com",
+        "https://pypi.org#frag@x",
     ],
 )
 def test_redact_leaves_lines_without_url_userinfo_alone(line: str):

--- a/components/src/dynamo/common/tests/test_install_media_decoders.py
+++ b/components/src/dynamo/common/tests/test_install_media_decoders.py
@@ -357,6 +357,41 @@ def test_redact_masks_url_credentials():
     assert "https://***@pypi.corp/simple" in masked
 
 
+def test_redact_masks_credentials_when_the_username_holds_an_unencoded_at():
+    """Registry URLs are routinely written with an email as the username.
+
+    Stopping at the first "@" masked only the username and left the password
+    in the log line.
+    """
+    line = "pip install --index-url https://user@corp.com:secret@pypi.corp/simple"
+    masked = install_media_decoders._redact(line)
+
+    assert "secret" not in masked
+    assert "https://***@pypi.corp/simple" in masked
+
+
+def test_redact_masks_every_credentialed_url_on_one_line():
+    line = "https://a@h1/x https://user@corp.com:secret@h2/y"
+    masked = install_media_decoders._redact(line)
+
+    assert "secret" not in masked
+    assert masked == "https://***@h1/x https://***@h2/y"
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "https://pypi.org/simple and mail user@example.com",
+        "contact: ops@example.com",
+        "https://pypi.org/simple",
+        "pip install numpy",
+    ],
+)
+def test_redact_leaves_lines_without_url_userinfo_alone(line: str):
+    """A bare address in the text is not userinfo and must not be rewritten."""
+    assert install_media_decoders._redact(line) == line
+
+
 # ---------------------------------------------------------------------------
 # CLI.
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/common/utils/install_media_decoders.py
+++ b/components/src/dynamo/common/utils/install_media_decoders.py
@@ -86,7 +86,12 @@ logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT_S = 600
 _LOCK_PATH = Path(tempfile.gettempdir()) / "dynamo_media_decoders.lock"
 # Mask URL userinfo (user:token@) before pip args reach the logs.
-_CRED_RE = re.compile(r"(\w+://)[^/@\s]+@")
+# Userinfo runs to the last "@" before the host. RFC 3986 wants a literal "@"
+# inside it percent-encoded, but registry URLs are routinely written with an
+# email as the username, so match greedily rather than stopping at the first
+# "@" and leaving the password behind. "/" and whitespace still bound the match,
+# so a bare address elsewhere in the line is untouched.
+_CRED_RE = re.compile(r"(\w+://)[^/\s]+@")
 
 
 @dataclass(frozen=True)

--- a/components/src/dynamo/common/utils/install_media_decoders.py
+++ b/components/src/dynamo/common/utils/install_media_decoders.py
@@ -85,13 +85,13 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT_S = 600
 _LOCK_PATH = Path(tempfile.gettempdir()) / "dynamo_media_decoders.lock"
-# Mask URL userinfo (user:token@) before pip args reach the logs.
-# Userinfo runs to the last "@" before the host. RFC 3986 wants a literal "@"
-# inside it percent-encoded, but registry URLs are routinely written with an
-# email as the username, so match greedily rather than stopping at the first
-# "@" and leaving the password behind. "/" and whitespace still bound the match,
-# so a bare address elsewhere in the line is untouched.
-_CRED_RE = re.compile(r"(\w+://)[^/\s]+@")
+# Mask URL userinfo (user:token@) before pip args reach the logs. Matching runs
+# to the last "@" before the host, because registry URLs are routinely written
+# with an unencoded email as the username and stopping at the first "@" leaves
+# the password in the line. "?" and "#" bound the match alongside "/" and
+# whitespace, so an "@" in a query or fragment cannot drag the match past the
+# host.
+_CRED_RE = re.compile(r"(\w+://)[^/?#\s]+@")
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

`_redact` masks URL userinfo so a credentialed `--pip-args` index URL never reaches a log
line, including via `str(CalledProcessError)`, which embeds the full pip command. The
pattern stopped at the first `@`:

```
_CRED_RE = re.compile(r"(\w+://)[^/@\s]+@")

https://user@corp.com:secret@pypi.corp/simple
  -> https://***@corp.com:secret@pypi.corp/simple
```

The username is masked and the password survives.

RFC 3986 wants a literal `@` inside userinfo percent-encoded, and the encoded form
(`user%40corp:secret@`) was already handled correctly. The reason this matters anyway is
that registry URLs are routinely written with an email as the username, and that unencoded
form is exactly the one that leaks.

Matching greedily to the last `@` fixes it. `/` and whitespace still bound the match, so:

- a bare address elsewhere in the line is untouched (`https://pypi.org/simple and mail
  user@example.com` is unchanged),
- several credentialed URLs on one line are each masked independently.

There are tests for both, since a greedier pattern is the obvious thing to get wrong in the
over-matching direction.

## Validation

Local, on macOS. Pure string handling.

- `pytest components/src/dynamo/common/tests/` — 537 passed, versus 531 on clean
  `upstream/main`, with the same 16 pre-existing failures and no new failing node IDs.
- The 2 added masking tests were confirmed red with only
  `utils/install_media_decoders.py` reverted. The 4 added negative-case tests pass either
  way, which is what they are for.
- The existing `test_cli_error_log_redacts_credentialed_pip_args` and
  `test_redact_masks_url_credentials` still pass, so the previously covered shapes did not
  regress.
- `black` at the pinned `23.1.0` and `pre-commit` on the touched files are clean.

One caveat on how I ran the tests: this suite skips unless the `dynamo.llm` bindings import,
and they do not build in my environment (`ImportError: cannot import name
'LoadThresholdConfig' from 'dynamo._core'`). I inject that one missing symbol before
importing. Nothing on these code paths touches it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved credential redaction in URLs, including usernames and passwords containing `@`.
  - Ensured all credentialed URLs on a line are properly masked.
  - Preserved ordinary URLs, email addresses, and non-URL text during redaction.

- **Tests**
  - Added coverage for credential masking and preservation of non-sensitive text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->