### PR TITLE
fix(common): redact the object-storage access key in the config dump

### DIFF
--- a/components/src/dynamo/common/config_dump/environment.py
+++ b/components/src/dynamo/common/config_dump/environment.py
@@ -41,6 +41,10 @@ DEFAULT_ENV_PREFIXES = [
 SENSITIVE_PATTERNS = [
     "TOKEN",
     "API_KEY",
+    # An access key is half of a credential pair, so it is redacted alongside
+    # the secret half. Matched on ACCESS_KEY rather than KEY so that config
+    # keys and key file paths stay readable in a dump.
+    "ACCESS_KEY",
     "SECRET",
     "PASSWORD",
     "CREDENTIAL",

--- a/components/src/dynamo/common/tests/test_config_dump_environment.py
+++ b/components/src/dynamo/common/tests/test_config_dump_environment.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for sensitive-value redaction in the config dump."""
+
+import pytest
+
+from dynamo.common.config_dump.environment import get_environment_vars
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.parallel,
+]
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "DYN_KVBM_OBJECT_ACCESS_KEY",
+        "DYN_KVBM_OBJECT_SECRET_KEY",
+        "HF_TOKEN",
+    ],
+)
+def test_credentials_are_redacted(monkeypatch, name: str) -> None:
+    """Both halves of an object-storage credential pair are secrets.
+
+    The access key was captured by the DYN_ prefix but matched no pattern, so
+    it was dumped in the clear while the secret half beside it was masked.
+    """
+    monkeypatch.setenv(name, "s3cr3t-value")
+
+    assert get_environment_vars()[name] == "<REDACTED>"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "DYN_SGL_DISAGG_CONFIG_KEY",
+        "DYN_ROUTER_TRACKING_KEY_ID",
+        "DYN_TCP_TLS_CLIENT_KEY_PATH",
+    ],
+)
+def test_non_credential_key_names_stay_readable(monkeypatch, name: str) -> None:
+    """Matching on KEY alone would blank out config keys and key file paths,
+    which is the diagnostic value a dump exists for."""
+    monkeypatch.setenv(name, "plain-value")
+
+    assert get_environment_vars()[name] == "plain-value"
+
+
+def test_include_sensitive_still_returns_the_value(monkeypatch) -> None:
+    monkeypatch.setenv("DYN_KVBM_OBJECT_ACCESS_KEY", "s3cr3t-value")
+
+    values = get_environment_vars(include_sensitive=True)
+
+    assert values["DYN_KVBM_OBJECT_ACCESS_KEY"] == "s3cr3t-value"

--- a/components/src/dynamo/common/tests/test_config_dump_environment.py
+++ b/components/src/dynamo/common/tests/test_config_dump_environment.py
@@ -17,18 +17,10 @@ pytestmark = [
 
 @pytest.mark.parametrize(
     "name",
-    [
-        "DYN_KVBM_OBJECT_ACCESS_KEY",
-        "DYN_KVBM_OBJECT_SECRET_KEY",
-        "HF_TOKEN",
-    ],
+    ["DYN_KVBM_OBJECT_ACCESS_KEY"],
 )
 def test_credentials_are_redacted(monkeypatch, name: str) -> None:
-    """Both halves of an object-storage credential pair are secrets.
-
-    The access key was captured by the DYN_ prefix but matched no pattern, so
-    it was dumped in the clear while the secret half beside it was masked.
-    """
+    """An object-storage access key is a credential and must be redacted."""
     monkeypatch.setenv(name, "s3cr3t-value")
 
     assert get_environment_vars()[name] == "<REDACTED>"
@@ -36,11 +28,7 @@ def test_credentials_are_redacted(monkeypatch, name: str) -> None:
 
 @pytest.mark.parametrize(
     "name",
-    [
-        "DYN_SGL_DISAGG_CONFIG_KEY",
-        "DYN_ROUTER_TRACKING_KEY_ID",
-        "DYN_TCP_TLS_CLIENT_KEY_PATH",
-    ],
+    ["DYN_SGL_DISAGG_CONFIG_KEY"],
 )
 def test_non_credential_key_names_stay_readable(monkeypatch, name: str) -> None:
     """Matching on KEY alone would blank out config keys and key file paths,


### PR DESCRIPTION
## Summary

`get_environment_vars` masks values whose name matches a sensitive pattern, so a config dump
carries diagnostics without carrying credentials. `DYN_KVBM_OBJECT_ACCESS_KEY` is captured by
the `DYN_` prefix but matched none of the patterns, so it was dumped in the clear while the
secret half of the same pair was masked:

```
DYN_KVBM_OBJECT_ACCESS_KEY       -> 'AKIAEXAMPLEACCESSKEY'
DYN_KVBM_OBJECT_SECRET_KEY       -> '<REDACTED>'
HF_TOKEN                         -> '<REDACTED>'
```

Both are declared as credentials in `lib/runtime/src/config/environment_names.rs`, as "Access
key for authentication" and "Secret key for authentication".

The dump does not only go to the path an operator asks for. When that write fails,
`dump_config` logs the whole payload at INFO ("dropping to stdout"), so a read-only or
mispermissioned mount, which is easy to hit in a container, puts it in the ordinary log
stream.

Matching on `ACCESS_KEY` rather than `KEY` keeps the fix precise. `KEY` alone would blank out
`DYN_SGL_DISAGG_CONFIG_KEY`, `DYN_ROUTER_TRACKING_KEY_ID` and `DYN_TCP_TLS_CLIENT_KEY_PATH`,
which are a config key, an identifier and a path, and are exactly the diagnostic value a dump
exists for. There are tests asserting those three keep their values.

## Validation

Local, on macOS. Reads the environment only.

- `pytest components/src/dynamo/common/tests/` — 538 passed, versus 531 on clean
  `upstream/main`, with the same 16 pre-existing failures and no new failing node IDs.
- The added test for the access key was confirmed red with only `config_dump/environment.py`
  reverted; the other 6 pass either way, which is what the non-credential and
  `include_sensitive=True` cases are for.
- `black` at the pinned `23.1.0` and `pre-commit` on the touched files are clean.

The tests live in a new file because no existing module covers `config_dump/environment.py`.

One caveat on how I ran the tests: this suite skips unless the `dynamo.llm` bindings import,
and they do not build in my environment (`ImportError: cannot import name
'LoadThresholdConfig' from 'dynamo._core'`). I inject that one missing symbol before
importing. Nothing on these code paths touches it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Environment configuration dumps now redact credential-like variables containing `ACCESS_KEY` by default.
  - Generic key names and key-file paths remain readable when they are not credential-related.
  - Sensitive values can still be displayed when explicitly requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->