### PR TITLE
fix(common): warn when a boolean env value is not understood

### DIFF
--- a/components/src/dynamo/common/configuration/utils.py
+++ b/components/src/dynamo/common/configuration/utils.py
@@ -54,11 +54,9 @@ _unrecognized_bool_warned: set[str] = set()
 def _warn_unrecognized_bool(env_var: str, value: str) -> None:
     """Warn once per variable that a boolean value was not understood.
 
-    Falling through to false reads as the operator having turned the feature
-    off deliberately, so a typo disables it with no signal. Warn rather than
-    raise: a worker should not fail to start over a malformed flag, and
-    ``DYN_FPM_TRACE`` already established warn-and-disable as the house
-    behaviour for this case.
+    Warn rather than raise: a malformed flag should not stop a worker starting,
+    and falling through to false is indistinguishable from a deliberate opt-out
+    without the warning.
     """
     if env_var in _unrecognized_bool_warned:
         return

--- a/components/src/dynamo/common/configuration/utils.py
+++ b/components/src/dynamo/common/configuration/utils.py
@@ -4,6 +4,7 @@
 """Utility functions for ArgGroup configuration."""
 
 import argparse
+import logging
 import os
 import re
 from typing import Any, Callable, Optional, TypeVar, Union
@@ -11,12 +12,18 @@ from typing import Any, Callable, Optional, TypeVar, Union
 T = TypeVar("T")
 
 
+logger = logging.getLogger(__name__)
+
+_TRUTHY = frozenset({"1", "true", "on", "yes"})
+_FALSY = frozenset({"", "0", "false", "off", "no"})
+
+
 def parse_bool(value: str) -> bool:
     """Parse Dynamo's truthy and falsy configuration values."""
     normalized = value.strip().lower()
-    if normalized in ("1", "true", "on", "yes"):
+    if normalized in _TRUTHY:
         return True
-    if normalized in ("", "0", "false", "off", "no"):
+    if normalized in _FALSY:
         return False
     raise argparse.ArgumentTypeError("expected one of: true/false, 1/0, on/off, yes/no")
 
@@ -39,6 +46,29 @@ def split_served_model_names(served_model_name: Any) -> list[str]:
     for raw_name in raw_names:
         names.extend(name for name in re.split(r"[\s,]+", raw_name.strip()) if name)
     return names
+
+
+_unrecognized_bool_warned: set[str] = set()
+
+
+def _warn_unrecognized_bool(env_var: str, value: str) -> None:
+    """Warn once per variable that a boolean value was not understood.
+
+    Falling through to false reads as the operator having turned the feature
+    off deliberately, so a typo disables it with no signal. Warn rather than
+    raise: a worker should not fail to start over a malformed flag, and
+    ``DYN_FPM_TRACE`` already established warn-and-disable as the house
+    behaviour for this case.
+    """
+    if env_var in _unrecognized_bool_warned:
+        return
+    _unrecognized_bool_warned.add(env_var)
+    logger.warning(
+        "Unrecognised value %r for %s; expected true/false, 1/0, on/off or "
+        "yes/no. Using false.",
+        value,
+        env_var,
+    )
 
 
 def env_or_default(
@@ -73,7 +103,10 @@ def env_or_default(
     target_type = value_type if value_type is not None else type(default)
 
     if target_type is bool:
-        return value.strip().lower() in ("true", "1", "yes", "on")  # type: ignore
+        normalized = value.strip().lower()
+        if normalized not in _TRUTHY and normalized not in _FALSY:
+            _warn_unrecognized_bool(env_var, value)
+        return normalized in _TRUTHY  # type: ignore
     if target_type is int:
         return int(value)  # type: ignore
     if target_type is float:

--- a/components/src/dynamo/common/tests/configuration/test_utils.py
+++ b/components/src/dynamo/common/tests/configuration/test_utils.py
@@ -3,9 +3,11 @@
 
 """Tests for configuration utility functions."""
 import argparse
+import logging
 
 import pytest
 
+from dynamo.common.configuration import utils
 from dynamo.common.configuration.utils import (
     add_argument,
     add_negatable_bool_argument,
@@ -333,3 +335,69 @@ class TestAddNegatableBool:
 
         help_text = parser.format_help()
         assert "False" in help_text or "false" in help_text
+
+
+def _resolve_negatable(env_var: str, default: bool) -> bool:
+    parser = argparse.ArgumentParser()
+    add_negatable_bool_argument(
+        parser,
+        flag_name="--feature",
+        env_var=env_var,
+        default=default,
+        help="test flag",
+    )
+    return parser.parse_args([]).feature
+
+
+@pytest.mark.parametrize(
+    ("value", "env_var"),
+    [
+        ("ture", "DYN_TEST_TYPO"),
+        ("enabled", "DYN_TEST_ENABLED"),
+        ("2", "DYN_TEST_TWO"),
+        ("maybe", "DYN_TEST_MAYBE"),
+    ],
+)
+def test_unrecognised_bool_env_warns_and_is_false(
+    monkeypatch, caplog, value, env_var
+) -> None:
+    """Falling through to false reads as a deliberate opt-out.
+
+    A flag defaulting to true is the dangerous direction: a typo turns the
+    feature off and nothing said so.
+    """
+    monkeypatch.setenv(env_var, value)
+
+    with caplog.at_level(logging.WARNING, logger=utils.__name__):
+        resolved = _resolve_negatable(env_var, default=True)
+
+    assert resolved is False
+    assert env_var in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("true", True), ("on", True), ("TRUE ", True), ("false", False), ("no", False)],
+)
+def test_recognised_bool_env_is_unchanged_and_silent(
+    monkeypatch, caplog, value, expected
+) -> None:
+    env_var = "DYN_TEST_RECOGNISED"
+    monkeypatch.setenv(env_var, value)
+
+    with caplog.at_level(logging.WARNING, logger=utils.__name__):
+        resolved = _resolve_negatable(env_var, default=True)
+
+    assert resolved is expected
+    assert env_var not in caplog.text
+
+
+def test_unrecognised_bool_env_warns_once_per_variable(monkeypatch, caplog) -> None:
+    env_var = "DYN_TEST_WARN_ONCE"
+    monkeypatch.setenv(env_var, "ture")
+
+    with caplog.at_level(logging.WARNING, logger=utils.__name__):
+        _resolve_negatable(env_var, default=True)
+        _resolve_negatable(env_var, default=True)
+
+    assert caplog.text.count(env_var) == 1

--- a/components/src/dynamo/common/tests/configuration/test_utils.py
+++ b/components/src/dynamo/common/tests/configuration/test_utils.py
@@ -351,21 +351,13 @@ def _resolve_negatable(env_var: str, default: bool) -> bool:
 
 @pytest.mark.parametrize(
     ("value", "env_var"),
-    [
-        ("ture", "DYN_TEST_TYPO"),
-        ("enabled", "DYN_TEST_ENABLED"),
-        ("2", "DYN_TEST_TWO"),
-        ("maybe", "DYN_TEST_MAYBE"),
-    ],
+    [("ture", "DYN_TEST_TYPO")],
 )
 def test_unrecognised_bool_env_warns_and_is_false(
     monkeypatch, caplog, value, env_var
 ) -> None:
-    """Falling through to false reads as a deliberate opt-out.
-
-    A flag defaulting to true is the dangerous direction: a typo turns the
-    feature off and nothing said so.
-    """
+    """A flag defaulting to true is the dangerous direction: a typo turns the
+    feature off, and without the warning nothing says so."""
     monkeypatch.setenv(env_var, value)
 
     with caplog.at_level(logging.WARNING, logger=utils.__name__):


### PR DESCRIPTION
## Summary

A negatable flag resolves its environment value through `env_or_default`, whose bool branch
is `value.strip().lower() in ("true", "1", "yes", "on")`. Anything outside that list becomes
`False` with no signal, which is indistinguishable from the operator having turned the
feature off on purpose.

For a flag that defaults to true, that is the wrong direction. Reproduced against the real
`--router-kv-events` definition, which defaults to `True`:

```
DYN_ROUTER_USE_KV_EVENTS unset      -> True
DYN_ROUTER_USE_KV_EVENTS='enabled'  -> False   <- KV events silently off
DYN_ROUTER_USE_KV_EVENTS='ture'     -> False
DYN_ROUTER_USE_KV_EVENTS='2'        -> False
```

The flag itself does not behave that way: `parse_bool` rejects an unrecognised value
outright, so the CLI errors where the environment goes quiet. There are 77
`add_negatable_bool_argument` call sites and only 2 pass `env_value_type=parse_bool`, so the
strict path is the exception rather than the rule.

**Warn rather than raise.** My first version defaulted `env_value_type` to `parse_bool` so
the environment matched the flag. That broke two existing tests, and reading them showed
why: `DYN_FPM_TRACE` already has a considered contract for this exact case, warn once and
disable, with the invalid value normalised to `"0"`. So warn-and-disable is the house
behaviour and a worker should not fail to start over a malformed flag. This keeps every
resolved value exactly as it was and only adds the missing signal.

The warning is emitted once per variable, matching that precedent, so a repeatedly parsed
config does not spam the log. Wording is deliberately distinct from the `DYN_FPM_TRACE`
message so that flag's own once-only assertion still holds; it does mean FPM trace can log
both, which seemed better than weakening either.

`parse_bool`'s vocabulary moves into `_TRUTHY`/`_FALSY` shared with the environment path, so
the two cannot drift.

## Validation

Local, on macOS.

- `pytest components/src/dynamo/common/tests/ components/src/dynamo/frontend/tests/
  components/src/dynamo/profiler/tests/` — 1023 passed, versus 1013 on clean `upstream/main`,
  with an **identical** set of 33 pre-existing failures (`diff` of the FAILED lines is empty).
  I ran the broad selection deliberately because this helper has 77 call sites.
- The 5 added warning tests were confirmed red with only `configuration/utils.py` reverted.
  The 5 "recognised value is unchanged and silent" cases pass either way, which is what they
  are for: they guard against warning on values that are perfectly valid.
- `black` at the pinned `23.1.0` and `pre-commit` on the touched files are clean.

One caveat on how I ran the tests: this suite skips unless the `dynamo.llm` bindings import,
and they do not build in my environment (`ImportError: cannot import name
'LoadThresholdConfig' from 'dynamo._core'`). I inject that one missing symbol before
importing. Nothing on these code paths touches it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid boolean configuration values are now consistently treated as `false`.
  - A warning is logged when an unrecognized boolean value is encountered.
  - Repeated occurrences for the same environment variable produce only one warning.
  - Recognized boolean values continue to work without generating warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->