### PR TITLE
fix(mocker): use the config's head_dim when it declares one

### DIFF
--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -517,6 +517,55 @@ def test_compute_kv_bytes_reads_local_config_json_without_transformers(
     assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) == 256
 
 
+def test_compute_kv_bytes_uses_head_dim_when_the_config_declares_one(
+    monkeypatch, tmp_path
+):
+    """A declared head_dim is authoritative.
+
+    Several model families size their heads independently of
+    hidden_size / num_attention_heads, so deriving it under-counts the cache
+    and the mocker then simulates more capacity than the engine has.
+    """
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "num_hidden_layers": 2,
+                "num_key_value_heads": 4,
+                "num_attention_heads": 16,
+                "hidden_size": 3584,
+                "head_dim": 256,
+                "torch_dtype": "bfloat16",
+            }
+        )
+    )
+    monkeypatch.setitem(sys.modules, "transformers", None)
+
+    # 2 layers * 2 (K+V) * 4 kv heads * 256 head_dim * 2 bytes.
+    # Deriving 3584 // 16 = 224 would give 7168.
+    assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) == 8192
+
+
+@pytest.mark.parametrize("head_dim", [None, 0, "128"])
+def test_compute_kv_bytes_derives_head_dim_when_not_usable(
+    monkeypatch, tmp_path, head_dim
+):
+    """Absent, zero or non-integer head_dim falls back to the derived value."""
+    config = {
+        "num_hidden_layers": 2,
+        "num_key_value_heads": 4,
+        "num_attention_heads": 16,
+        "hidden_size": 3584,
+        "torch_dtype": "bfloat16",
+    }
+    if head_dim is not None:
+        config["head_dim"] = head_dim
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    monkeypatch.setitem(sys.modules, "transformers", None)
+
+    # 3584 // 16 = 224 head_dim.
+    assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) == 7168
+
+
 def test_compute_kv_bytes_unwraps_multimodal_text_config_json(tmp_path):
     (tmp_path / "config.json").write_text(
         json.dumps(

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -540,16 +540,19 @@ def test_compute_kv_bytes_uses_head_dim_when_the_config_declares_one(
     )
     monkeypatch.setitem(sys.modules, "transformers", None)
 
-    # 2 layers * 2 (K+V) * 4 kv heads * 256 head_dim * 2 bytes.
-    # Deriving 3584 // 16 = 224 would give 7168.
+    # Deriving 3584 // 16 = 224 would give 7168 instead.
     assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) == 8192
 
 
-@pytest.mark.parametrize("head_dim", [None, 0, "128"])
-def test_compute_kv_bytes_derives_head_dim_when_not_usable(
+@pytest.mark.parametrize("head_dim", [0, "128", True])
+def test_compute_kv_bytes_derives_head_dim_when_declared_but_unusable(
     monkeypatch, tmp_path, head_dim
 ):
-    """Absent, zero or non-integer head_dim falls back to the derived value."""
+    """A declared but unusable head_dim falls back to the derived value.
+
+    `True` is in here because `isinstance(True, int)` holds, so a JSON `true`
+    would otherwise be taken as an authoritative head dimension of 1.
+    """
     config = {
         "num_hidden_layers": 2,
         "num_key_value_heads": 4,
@@ -557,12 +560,10 @@ def test_compute_kv_bytes_derives_head_dim_when_not_usable(
         "hidden_size": 3584,
         "torch_dtype": "bfloat16",
     }
-    if head_dim is not None:
-        config["head_dim"] = head_dim
+    config["head_dim"] = head_dim
     (tmp_path / "config.json").write_text(json.dumps(config))
     monkeypatch.setitem(sys.modules, "transformers", None)
 
-    # 3584 // 16 = 224 head_dim.
     assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) == 7168
 
 

--- a/components/src/dynamo/mocker/utils/kv_cache.py
+++ b/components/src/dynamo/mocker/utils/kv_cache.py
@@ -136,6 +136,9 @@ def compute_kv_bytes_per_token(
 
     Formula: num_layers * 2 (K+V) * num_kv_heads * head_dim * dtype_bytes
 
+    ``head_dim`` comes from the config when it declares one, and falls back to
+    ``hidden_size // num_attention_heads`` otherwise.
+
     Reads the model's text config directly so the mocker stays independent of
     the profiler's upper AIC dependencies.
 
@@ -170,7 +173,12 @@ def compute_kv_bytes_per_token(
     num_kv_heads = _config_get(config, "num_key_value_heads", "num_kv_heads")
     if num_kv_heads is None:
         num_kv_heads = num_attention_heads
-    head_dim = hidden_size // num_attention_heads
+    # A config that declares head_dim is authoritative: several model families
+    # size their heads independently of hidden_size / num_attention_heads, so
+    # deriving it silently mis-sizes the cache for those.
+    head_dim = _config_get(config, "head_dim")
+    if not isinstance(head_dim, int) or head_dim <= 0:
+        head_dim = hidden_size // num_attention_heads
     dtype_bytes = get_kv_cache_dtype_bytes(config, kv_cache_dtype)
     kv_bytes = num_layers * 2 * num_kv_heads * head_dim * dtype_bytes
     logger.debug(

--- a/components/src/dynamo/mocker/utils/kv_cache.py
+++ b/components/src/dynamo/mocker/utils/kv_cache.py
@@ -75,6 +75,16 @@ def _config_get(config: Any, *names: str) -> Any:
 # model's config, e.g. ``text_config`` (most VLMs) or ``thinker_config.text_config``
 # (Qwen2.5-Omni). Transformers' ``get_text_config`` picks the sub-config the same
 # way plus per-model overrides; a layout not found here falls back to transformers.
+def _is_positive_int(value: Any) -> bool:
+    """A usable size from a JSON config.
+
+    `isinstance(True, int)` is true in Python, so a config carrying
+    `"head_dim": true` would otherwise be read as an authoritative dimension of
+    1 and silently under-size the cache.
+    """
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
 _TEXT_CONFIG_KEYS = (
     "text_config",
     "llm_config",
@@ -161,7 +171,7 @@ def compute_kv_bytes_per_token(
     num_attention_heads = _config_get(config, "num_attention_heads")
     hidden_size = _config_get(config, "hidden_size")
     sizes = (num_layers, num_attention_heads, hidden_size)
-    if not all(isinstance(v, int) for v in sizes) or num_attention_heads == 0:
+    if not all(_is_positive_int(v) for v in sizes):
         logger.warning(
             "Could not compute kv_bytes_per_token: model config for %s lacks "
             "layer, head, or hidden sizes (%s)",
@@ -177,7 +187,7 @@ def compute_kv_bytes_per_token(
     # size their heads independently of hidden_size / num_attention_heads, so
     # deriving it silently mis-sizes the cache for those.
     head_dim = _config_get(config, "head_dim")
-    if not isinstance(head_dim, int) or head_dim <= 0:
+    if not _is_positive_int(head_dim):
         head_dim = hidden_size // num_attention_heads
     dtype_bytes = get_kv_cache_dtype_bytes(config, kv_cache_dtype)
     kv_bytes = num_layers * 2 * num_kv_heads * head_dim * dtype_bytes


### PR DESCRIPTION
## Summary

`compute_kv_bytes_per_token` always derives the head dimension:

```python
head_dim = hidden_size // num_attention_heads
```

Several model families size their heads independently of that ratio and declare `head_dim`
in `config.json`. When a config declares one it is authoritative, and deriving it instead
mis-sizes the cache. Reproduced against a local config with `head_dim: 256`,
`hidden_size: 3584` and 16 attention heads:

```
config declares head_dim=256, derived hidden/heads=224
computed kv_bytes = 7168
correct  kv_bytes = 8192      (under-counts by 12.5%)
```

The mocker sizes its simulated KV cache from this number, so it believes it can hold more
tokens than the engine would and the simulated hit rate comes out optimistic. Nothing in the
output says the estimate was derived rather than read.

`_config_get` already handles both shapes this function sees, the dict from a local
`config.json` and the object from the transformers path, so reading `head_dim` is a lookup
through the same helper. The derivation stays for configs that declare nothing, and for a
declared value that is not a usable positive integer.

I noticed this reading #14383, which added the local `config.json` path. The behaviour is
not a regression from that change: the derivation predates it and applies to the transformers
path too.

## Validation

Local, on macOS. Pure arithmetic over a parsed config, no model is loaded.

- `pytest components/src/dynamo/mocker/tests/` — 46 passed, versus 42 on clean
  `upstream/main`, with an identical single pre-existing failure
  (`test_public_cli.py::test_public_mocker_module_cli_executes`, which shells out to the CLI
  and does not touch this path).
- The added `head_dim` test was confirmed red with only `utils/kv_cache.py` reverted. The
  three fallback cases (absent, `0`, non-integer) pass either way, which is what they are
  for: they guard the derivation from regressing.
- `black` at the pinned `23.1.0` and `pre-commit` on the touched files are clean.

I have not verified the numbers against a downloaded checkpoint; the test uses a synthetic
config, and the arithmetic is the documented `layers * 2 * kv_heads * head_dim * dtype_bytes`.

One caveat on how I ran the tests: this suite skips unless the `dynamo.llm` bindings import,
and they do not build in my environment (`ImportError: cannot import name
'LoadThresholdConfig' from 'dynamo._core'`). I inject that one missing symbol before
importing. Nothing on these code paths touches it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved KV-cache memory estimation by honoring a valid configured attention head dimension.
  - Invalid or missing head-dimension values now fall back to the derived dimension for reliable estimates.

- **Tests**
  - Added coverage for configured, missing, zero, and non-integer head-dimension values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->