### PR TITLE
fix(multimodal): serialize mm_kwargs transfer with vLLM msgpack, not pickle

### DIFF
--- a/components/src/dynamo/common/multimodal/mm_kwargs_transfer.py
+++ b/components/src/dynamo/common/multimodal/mm_kwargs_transfer.py
@@ -25,7 +25,7 @@ import asyncio
 import logging
 import multiprocessing.shared_memory as shm
 import os
-import pickle
+import struct
 import uuid
 from abc import ABC, abstractmethod
 from queue import Queue
@@ -38,6 +38,64 @@ from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.runtime import run_async
 
 logger = logging.getLogger(__name__)
+
+
+# The mm_kwargs transfer serializes vLLM's Python-only MultiModalKwargsItem
+# objects. We use vLLM's own typed msgpack serializer (vllm.v1.serial_utils)
+# rather than pickle: it is pickle-free and type-restricted by default, so a
+# crafted payload cannot execute code on the receiving worker. vLLM's
+# MsgpackEncoder.encode() returns a sequence of buffers (msgpack + any large
+# tensor "aux" buffers); the SHM/NIXL transport carries a single bytes blob per
+# item, so we frame the sequence with a small length prefix and reverse it on
+# receive. The vllm imports are lazy so non-vLLM code paths that import this
+# module do not require vLLM.
+
+
+def _pack_buffers(bufs) -> bytes:
+    """Frame a sequence of buffers into one bytes blob for the byte transport."""
+    out = bytearray(struct.pack("<I", len(bufs)))
+    for b in bufs:
+        mv = memoryview(b)
+        out += struct.pack("<Q", mv.nbytes)
+        out += mv
+    return bytes(out)
+
+
+def _unpack_buffers(blob) -> list:
+    """Inverse of _pack_buffers: split a framed blob back into buffers."""
+    mv = memoryview(blob)
+    (count,) = struct.unpack_from("<I", mv, 0)
+    offset = 4
+    bufs = []
+    for _ in range(count):
+        (length,) = struct.unpack_from("<Q", mv, offset)
+        offset += 8
+        bufs.append(mv[offset : offset + length])
+        offset += length
+    return bufs
+
+
+def encode_mm_kwargs_item(obj) -> bytes:
+    """Serialize a vLLM ``MultiModalKwargsItem`` to transport bytes with vLLM's
+    typed msgpack encoder (no pickle). Inverse of :func:`decode_mm_kwargs_item`.
+    A fresh encoder is used per call: it accumulates aux-buffer state and is not
+    thread-safe."""
+    from vllm.v1.serial_utils import MsgpackEncoder
+
+    return _pack_buffers(MsgpackEncoder().encode(obj))
+
+
+def decode_mm_kwargs_item(blob):
+    """Deserialize bytes from :func:`encode_mm_kwargs_item` back into a
+    ``MultiModalKwargsItem``. Pickle-free and type-restricted: the decoder only
+    yields the target type, and with ``VLLM_ALLOW_INSECURE_SERIALIZATION`` unset
+    (vLLM's default) it refuses any pickle extension. A fresh decoder is used per
+    call (not thread-safe)."""
+    from vllm.multimodal.inputs import MultiModalKwargsItem
+    from vllm.v1.serial_utils import MsgpackDecoder
+
+    return MsgpackDecoder(MultiModalKwargsItem).decode(_unpack_buffers(blob))
+
 
 # Upper bound on how long cleanup() waits for the backend to read a transferred
 # payload before releasing the NIXL-registered buffer anyway. Unbounded waiting
@@ -161,9 +219,9 @@ class MmKwargsSender(ABC):
                     continue
 
                 with _nvtx.annotate(self._pickle_nvtx_label, color=self._nvtx_color):
-                    pickled = pickle.dumps(feat.data)
+                    serialized = encode_mm_kwargs_item(feat.data)
 
-                encoded, cleanup = await self._encode_item(i, pickled)
+                encoded, cleanup = await self._encode_item(i, serialized)
                 encoded_items.append(encoded)
                 if cleanup is not None:
                     cleanup_items.append(cleanup)

--- a/components/src/dynamo/vllm/multimodal_utils/request_processor.py
+++ b/components/src/dynamo/vllm/multimodal_utils/request_processor.py
@@ -12,7 +12,6 @@ multimodal UUIDs, and the model-specific prefill/decode handoff.
 from __future__ import annotations
 
 import logging
-import pickle
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -34,6 +33,7 @@ from dynamo.common.multimodal.mm_kwargs_transfer import (
     MmKwargsShmReceiver,
     MmKwargsShmTransferMetadata,
     MmKwargsTransferMetadata,
+    decode_mm_kwargs_item,
 )
 from dynamo.common.multimodal.video_loader import VideoLoader
 from dynamo.common.utils import nvtx_utils as _nvtx
@@ -702,10 +702,12 @@ class VllmMultimodalRequestProcessor:
 
             kwargs_items = []
             for payload in pickled_items:
-                # The sender is Dynamo's internal frontend transfer service,
-                # which deliberately serializes vLLM's Python-only kwargs
-                # objects. External request payloads never supply these bytes.
-                item = pickle.loads(payload)
+                # Deserialize with vLLM's typed msgpack decoder (pickle-free,
+                # type-restricted). The sender is Dynamo's internal frontend
+                # transfer service; external request payloads never supply these
+                # bytes, and the decoder refuses any pickle extension unless
+                # VLLM_ALLOW_INSECURE_SERIALIZATION is explicitly set.
+                item = decode_mm_kwargs_item(payload)
                 if not isinstance(item, MultiModalKwargsItem):
                     logger.warning(
                         "%s transfer produced %s instead of MultiModalKwargsItem",


### PR DESCRIPTION
## Summary

The multimodal `mm_kwargs` SHM/NIXL transfer serialized vLLM `MultiModalKwargsItem` objects with **pickle** — producer `mm_kwargs_transfer.py` did `pickle.dumps(feat.data)`, worker `request_processor.py` did `pickle.loads(payload)` **before** the `isinstance` type-check. Pickle executes during `loads()`, so a crafted payload placed on the transfer buffer could run code on the worker.

This swaps pickle for vLLM's own typed **msgpack** serializer — `MsgpackEncoder` / `MsgpackDecoder(MultiModalKwargsItem)` from `vllm.v1.serial_utils`, the same serializer vLLM uses for its engine-core↔worker `MultiModalKwargs` transfer. It is **pickle-free and type-restricted by default**: the decoder yields only the target type and refuses any pickle extension unless `VLLM_ALLOW_INSECURE_SERIALIZATION` is explicitly set (vLLM's built-in backwards-compat opt-out, left untouched).

`encode()` can return multiple buffers (msgpack + large-tensor aux buffers), so a small length-prefix framing keeps the existing single-`bytes`-per-item SHM/NIXL transport. The vLLM imports are lazy (this path is vLLM-only); encoder/decoder are instantiated per call since they hold aux-buffer state (not thread-safe).

## Validation

- `py_compile` clean; no remaining `pickle` references in either file.
- **Not yet run: a multimodal round-trip test** (encode → frame → transport → unframe → decode of real `MultiModalKwargsItem` payloads, incl. large tensors that spill to aux buffers). Requesting that before merge — this is the main thing to verify.

## Notes

Scope is vLLM-only (SGLang/TRT-LLM do not use this transfer path). No wire-compat concern beyond a same-release frontend+worker (both switch together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Multimodal request data now uses a typed, restricted serialization format instead of pickle.
  * Added validation and framing for transferred multimodal data to improve transfer safety and reliability.
  * Existing fallback handling and error reporting remain in place for invalid or unsupported data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->## Backwards compatibility

This changes the wire format on the SHM/NIXL transfer buffer (pickle → msgpack), so producer (frontend) and consumer (worker) must match. It is **not** wire-compatible with an old pickle producer/consumer — **but it degrades gracefully, so nothing breaks:** the transfer is a best-effort fast path, and `_receive_mm_kwargs` wraps receive+decode in `try/except → logger.exception(... falling back) → return None` (`request_processor.py`). In a mixed-version rolling upgrade (new frontend + old worker, or vice versa), the format mismatch is caught and the request **falls back to normal multimodal processing** (correct, slightly slower); the fast path resumes once both sides are on the new version. The buffers are ephemeral per-request, so there is no at-rest/stored-format concern. Note: this is distinct from `VLLM_ALLOW_INSECURE_SERIALIZATION`, which governs msgpack-incompatible payload *types*, not reading old pickle bytes.