### PR TITLE
fix(mocker): give fp8_e5m2 a byte size

### DIFF
--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -22,6 +22,17 @@ DEFAULT_PREFILL_ENDPOINT = f"dyn://{DYN_NAMESPACE}.prefill.generate"
 logger = logging.getLogger(__name__)
 
 
+KV_CACHE_DTYPE_CHOICES = [
+    "auto",
+    "bfloat16",
+    "fp8",
+    "fp8_ds_mla",
+    "fp8_e4m3",
+    "fp8_e5m2",
+    "fp8_inc",
+]
+
+
 def positive_int(value: str) -> int:
     try:
         parsed = int(value)
@@ -559,15 +570,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--kv-cache-dtype",
         type=str,
         default="auto",
-        choices=[
-            "auto",
-            "bfloat16",
-            "fp8",
-            "fp8_ds_mla",
-            "fp8_e4m3",
-            "fp8_e5m2",
-            "fp8_inc",
-        ],
+        choices=KV_CACHE_DTYPE_CHOICES,
         help="Data type for KV cache, used to compute kv_bytes_per_token. "
         "'auto' uses the model's dtype (default).",
     )

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -15,6 +15,7 @@ import pytest
 
 from dynamo.llm import EngineType, EntrypointArgs
 from dynamo.mocker import MockEngineArgs
+from dynamo.mocker import args as mocker_args
 from dynamo.mocker.args import parse_args
 from dynamo.mocker.utils import kv_cache
 
@@ -515,6 +516,24 @@ def test_compute_kv_bytes_reads_local_config_json_without_transformers(
     monkeypatch.setitem(sys.modules, "transformers", None)
 
     assert kv_cache.compute_kv_bytes_per_token(str(tmp_path)) == 256
+
+
+@pytest.mark.parametrize(
+    "dtype", ["fp8", "fp8_ds_mla", "fp8_e4m3", "fp8_e5m2", "fp8_inc"]
+)
+def test_fp8_kv_cache_dtypes_are_one_byte_end_to_end(dtype):
+    """Every fp8 choice the CLI accepts must have a byte size.
+
+    A choice the table does not know falls through to the 2-byte default, so
+    the mocker sizes its cache for the wrong dtype and says nothing.
+    ``fp8_e5m2`` was advertised by ``--kv-cache-dtype`` and absent from the
+    table, while every other fp8 variant, and its own torch spelling
+    ``float8_e5m2``, mapped to 1. The list mirrors the choices in
+    ``dynamo.mocker.args``.
+    """
+    args = mocker_args.parse_args(["--model-path", "model", "--kv-cache-dtype", dtype])
+
+    assert kv_cache.get_kv_cache_dtype_bytes({}, args.kv_cache_dtype) == 1
 
 
 def test_compute_kv_bytes_unwraps_multimodal_text_config_json(tmp_path):

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -519,17 +519,15 @@ def test_compute_kv_bytes_reads_local_config_json_without_transformers(
 
 
 @pytest.mark.parametrize(
-    "dtype", ["fp8", "fp8_ds_mla", "fp8_e4m3", "fp8_e5m2", "fp8_inc"]
+    "dtype", [d for d in mocker_args.KV_CACHE_DTYPE_CHOICES if d.startswith("fp8")]
 )
 def test_fp8_kv_cache_dtypes_are_one_byte_end_to_end(dtype):
-    """Every fp8 choice the CLI accepts must have a byte size.
+    """Every fp8 choice the CLI accepts must map to one byte.
 
     A choice the table does not know falls through to the 2-byte default, so
-    the mocker sizes its cache for the wrong dtype and says nothing.
-    ``fp8_e5m2`` was advertised by ``--kv-cache-dtype`` and absent from the
-    table, while every other fp8 variant, and its own torch spelling
-    ``float8_e5m2``, mapped to 1. The list mirrors the choices in
-    ``dynamo.mocker.args``.
+    the mocker sizes its cache for the wrong dtype and says nothing. The cases
+    are read off the CLI choices, so a new fp8 spelling cannot be advertised
+    without a mapping.
     """
     args = mocker_args.parse_args(["--model-path", "model", "--kv-cache-dtype", dtype])
 

--- a/components/src/dynamo/mocker/utils/kv_cache.py
+++ b/components/src/dynamo/mocker/utils/kv_cache.py
@@ -22,6 +22,7 @@ TORCH_DTYPE_BYTES = {
     "fp8": 1,
     "fp8_ds_mla": 1,
     "fp8_e4m3": 1,
+    "fp8_e5m2": 1,
     "fp8_inc": 1,
     # AIC KVCacheQuantMode also allows int8 (1 byte per element)
     "int8": 1,


### PR DESCRIPTION
## Summary

`--kv-cache-dtype` advertises `fp8_e5m2` as a valid choice, but `TORCH_DTYPE_BYTES` had no
entry for it, so `get_kv_cache_dtype_bytes` fell through to its 2-byte default:

```
auto         -> 2   (handled separately)
bfloat16     -> 2
fp8          -> 1
fp8_ds_mla   -> 1
fp8_e4m3     -> 1
fp8_e5m2     -> 2   <- advertised by the CLI, absent from the table
fp8_inc      -> 1
```

`kv_bytes_per_token` then came out twice the real size, so the mocker simulated half the KV
capacity it should have. Nothing reports the mismatch: the CLI accepts the flag, the run
proceeds, and the cache is simply modelled for the wrong dtype.

`fp8_e5m2` is the only advertised choice this affects. Every other fp8 variant maps to 1, and
the same dtype is already in the table under its torch spelling `float8_e5m2`, so the byte
size was known and only the vLLM CLI spelling was missing.

The added test drives each fp8 choice through `parse_args` rather than asserting against the
table directly, so a choice that argparse accepts but the table cannot size fails there
instead of silently halving the cache.

## Validation

Local, on macOS. Table lookup and argument parsing only, no model is loaded.

- `pytest components/src/dynamo/mocker/tests/` — 47 passed, versus 42 on clean
  `upstream/main`, with an identical single pre-existing failure
  (`test_public_cli.py::test_public_mocker_module_cli_executes`, which shells out to the CLI
  and does not touch this path).
- The added test was confirmed red with only `utils/kv_cache.py` reverted: the `fp8_e5m2`
  case fails, the other four pass either way, which is what they are for.
- `black` at the pinned `23.1.0` and `pre-commit` on the touched files are clean.

I have not run the mocker against a real workload; this is the byte size used to derive
`kv_bytes_per_token`, and the arithmetic around it is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `fp8_e5m2` data type when configuring KV-cache storage.
  - KV-cache sizing now correctly accounts for one byte per `fp8_e5m2` element.

- **Tests**
  - Added coverage for accepted FP8 KV-cache data type names and their sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->