### PR TITLE
fix(responses): reject unsupported tools before dispatch

### DIFF
--- a/docs/fern/pages/use-cases/agents/agent-harnesses.mdx
+++ b/docs/fern/pages/use-cases/agents/agent-harnesses.mdx
@@ -31,9 +31,14 @@ bash examples/backends/sglang/launch/agg_agent.sh
     wire_api = "responses"
     ```
 
+    Dynamo's Responses adapter currently supports function tools, including functions inside namespaces, and `tool_choice` values of `none`, `auto`, `required`, or a named function. Unsupported tool or tool-choice types return HTTP 400 before inference. Unsupported tools are rejected even when `tool_choice` is `none` or `auto`.
+
+    Disable Codex's hosted web search when using Dynamo. The following command overrides the top-level `web_search` setting for this run:
+
     ```bash
     # replace -m <model> with your model
-    codex -m zai-org/GLM-4.7-Flash -c model_provider=dynamo
+    codex -m zai-org/GLM-4.7-Flash -c model_provider=dynamo \
+      -c 'web_search="disabled"'
     ```
 
     Dynamo maps Codex's `thread-id` header to `session_id`. A spawned child thread also sends `x-codex-parent-thread-id`, which Dynamo maps to `parent_session_id`.

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -679,7 +679,8 @@ fn convert_input_items_to_messages(
 ///
 /// Bare function names are preserved for model compatibility. Reject collisions
 /// from different origins instead of guessing which namespace to restore on the
-/// response path.
+/// response path. Return `InvalidArgument` for non-function tools, including
+/// namespace members, instead of silently discarding unsupported definitions.
 fn convert_tools(tools: &[Tool]) -> anyhow::Result<Vec<ChatCompletionTool>> {
     let mut converted = Vec::new();
     let mut origins = HashMap::<String, Option<String>>::new();
@@ -737,6 +738,8 @@ fn convert_tools(tools: &[Tool]) -> anyhow::Result<Vec<ChatCompletionTool>> {
     Ok(converted)
 }
 
+/// Identify an unsupported tool or choice by its serialized type and return
+/// `InvalidArgument` with the affected request field and supported alternatives.
 fn unsupported_tool<T>(tool: &impl serde::Serialize, field: &str) -> anyhow::Result<T> {
     let value = serde_json::to_value(tool)?;
     let tool_type = value["type"].as_str().unwrap_or("unknown");
@@ -747,6 +750,9 @@ fn unsupported_tool<T>(tool: &impl serde::Serialize, field: &str) -> anyhow::Res
 }
 
 /// Convert Responses API ToolChoiceParam to ChatCompletionToolChoiceOption.
+///
+/// Preserve supported modes and named functions; return `InvalidArgument` for
+/// choices whose semantics cannot be represented by the adapter.
 fn convert_tool_choice(tc: &ToolChoiceParam) -> anyhow::Result<ChatCompletionToolChoiceOption> {
     Ok(match tc {
         ToolChoiceParam::Mode(mode) => match mode {

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -719,27 +719,36 @@ fn convert_tools(tools: &[Tool]) -> anyhow::Result<Vec<ChatCompletionTool>> {
             }
             Tool::Namespace(namespace) => {
                 for tool in &namespace.tools {
-                    if let NamespaceToolParamTool::Function(f) = tool {
-                        push_function(
+                    match tool {
+                        NamespaceToolParamTool::Function(f) => push_function(
                             &f.name,
                             &f.description,
                             &f.parameters,
                             f.strict,
                             Some(&namespace.name),
-                        )?;
+                        )?,
+                        _ => return unsupported_tool(tool, "tools"),
                     }
                 }
             }
-            // Only function tools are forwarded to Chat Completions.
-            _ => {}
+            _ => return unsupported_tool(tool, "tools"),
         }
     }
     Ok(converted)
 }
 
+fn unsupported_tool<T>(tool: &impl serde::Serialize, field: &str) -> anyhow::Result<T> {
+    let value = serde_json::to_value(tool)?;
+    let tool_type = value["type"].as_str().unwrap_or("unknown");
+    Err(ResponsesConversionError::InvalidArgument(format!(
+        "Unsupported Responses {field} type '{tool_type}': the Chat Completions adapter supports only function tools and none, auto, required, or named function tool choices"
+    ))
+    .into())
+}
+
 /// Convert Responses API ToolChoiceParam to ChatCompletionToolChoiceOption.
-fn convert_tool_choice(tc: &ToolChoiceParam) -> ChatCompletionToolChoiceOption {
-    match tc {
+fn convert_tool_choice(tc: &ToolChoiceParam) -> anyhow::Result<ChatCompletionToolChoiceOption> {
+    Ok(match tc {
         ToolChoiceParam::Mode(mode) => match mode {
             ToolChoiceOptions::None => ChatCompletionToolChoiceOption::None,
             ToolChoiceOptions::Auto => ChatCompletionToolChoiceOption::Auto,
@@ -753,15 +762,8 @@ fn convert_tool_choice(tc: &ToolChoiceParam) -> ChatCompletionToolChoiceOption {
                 },
             })
         }
-        ToolChoiceParam::Hosted(_) => {
-            // Hosted tools are not forwarded to chat completions
-            ChatCompletionToolChoiceOption::Auto
-        }
-        _ => {
-            // Other tool choice types (AllowedTools, Mcp, Custom, etc.) default to auto
-            ChatCompletionToolChoiceOption::Auto
-        }
-    }
+        _ => return unsupported_tool(tc, "tool_choice"),
+    })
 }
 
 /// Convert Responses API `text.format` to Chat Completions `response_format`.
@@ -876,7 +878,12 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
             .filter(|t: &Vec<_>| !t.is_empty());
 
         // Convert tool_choice if present
-        let tool_choice = resp.inner.tool_choice.as_ref().map(convert_tool_choice);
+        let tool_choice = resp
+            .inner
+            .tool_choice
+            .as_ref()
+            .map(convert_tool_choice)
+            .transpose()?;
 
         // Determine stream setting: respect caller's preference, default to true for aggregation
         let stream = resp.inner.stream.or(Some(true));

--- a/lib/llm/tests/responses_http_replay.rs
+++ b/lib/llm/tests/responses_http_replay.rs
@@ -30,6 +30,87 @@ use http_harness::{
 
 const ENV: [(&str, Option<&str>); 1] = [(DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0"))];
 
+#[tokio::test]
+#[serial]
+async fn unsupported_hosted_tools_fail_before_dispatch_or_streaming() {
+    temp_env::async_with_vars(ENV, async {
+        let svc = HarnessService::start([]).await;
+        for stream in [false, true] {
+            for (tools, tool_type) in [
+                (json!([{"type": "web_search"}]), "web_search"),
+                (
+                    json!([tool("read_file"), {"type": "web_search"}]),
+                    "web_search",
+                ),
+                (
+                    json!([{
+                        "type": "namespace", "name": "custom", "description": "Custom tools",
+                        "tools": [{"type": "custom", "name": "run", "format": {"type": "text"}}]
+                    }]),
+                    "custom",
+                ),
+            ] {
+                for choice in [
+                    None,
+                    Some(json!("auto")),
+                    Some(json!("required")),
+                    Some(json!("none")),
+                ] {
+                    let mut body = json!({
+                        "model": MODEL,
+                        "input": "ping",
+                        "stream": stream,
+                        "tools": tools,
+                    });
+                    if let Some(choice) = choice {
+                        body["tool_choice"] = choice;
+                    }
+                    let response = post_responses(&svc, &body).await;
+                    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+                    let error: Value = response.json().await.unwrap();
+                    assert!(error["message"].as_str().unwrap().contains(tool_type));
+                }
+            }
+        }
+        assert!(svc.engine.take_requests().await.is_empty());
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn unsupported_tool_choices_fail_before_dispatch_or_streaming() {
+    temp_env::async_with_vars(ENV, async {
+        let svc = HarnessService::start([]).await;
+        for stream in [false, true] {
+            for choice in [
+                json!({"type": "web_search_preview"}),
+                json!({"type": "allowed_tools", "mode": "required", "tools": [{"type": "function", "name": "read_file"}]}),
+            ] {
+                for tools in [None, Some(json!([tool("read_file")]))] {
+                    let mut body = json!({
+                        "model": MODEL,
+                        "input": "ping",
+                        "stream": stream,
+                        "tool_choice": choice,
+                    });
+                    if let Some(tools) = tools {
+                        body["tools"] = tools;
+                    }
+                    let response = post_responses(&svc, &body).await;
+                    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+                    let error: Value = response.json().await.unwrap();
+                    assert!(error["message"].as_str().unwrap().contains("tool_choice"));
+                }
+            }
+        }
+        assert!(svc.engine.take_requests().await.is_empty());
+        svc.shutdown().await;
+    })
+    .await;
+}
+
 async fn post_responses(svc: &HarnessService, body: &Value) -> reqwest::Response {
     svc.client
         .post(format!("{}/v1/responses", svc.base_url))

--- a/lib/llm/tests/responses_http_replay.rs
+++ b/lib/llm/tests/responses_http_replay.rs
@@ -30,6 +30,8 @@ use http_harness::{
 
 const ENV: [(&str, Option<&str>); 1] = [(DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0"))];
 
+/// Unsupported tool definitions return HTTP 400 before backend dispatch for both
+/// unary and streaming requests, including mixed tools and namespace members.
 #[tokio::test]
 #[serial]
 async fn unsupported_hosted_tools_fail_before_dispatch_or_streaming() {
@@ -68,6 +70,8 @@ async fn unsupported_hosted_tools_fail_before_dispatch_or_streaming() {
     .await;
 }
 
+/// Unsupported choices return HTTP 400 without dispatch for unary and streaming
+/// requests even when the supplied function tool definitions are valid.
 #[tokio::test]
 #[serial]
 async fn unsupported_tool_choices_fail_before_dispatch_or_streaming() {

--- a/lib/llm/tests/responses_http_replay.rs
+++ b/lib/llm/tests/responses_http_replay.rs
@@ -50,26 +50,16 @@ async fn unsupported_hosted_tools_fail_before_dispatch_or_streaming() {
                     "custom",
                 ),
             ] {
-                for choice in [
-                    None,
-                    Some(json!("auto")),
-                    Some(json!("required")),
-                    Some(json!("none")),
-                ] {
-                    let mut body = json!({
-                        "model": MODEL,
-                        "input": "ping",
-                        "stream": stream,
-                        "tools": tools,
-                    });
-                    if let Some(choice) = choice {
-                        body["tool_choice"] = choice;
-                    }
-                    let response = post_responses(&svc, &body).await;
-                    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
-                    let error: Value = response.json().await.unwrap();
-                    assert!(error["message"].as_str().unwrap().contains(tool_type));
-                }
+                let body = json!({
+                    "model": MODEL,
+                    "input": "ping",
+                    "stream": stream,
+                    "tools": tools,
+                });
+                let response = post_responses(&svc, &body).await;
+                assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+                let error: Value = response.json().await.unwrap();
+                assert!(error["message"].as_str().unwrap().contains(tool_type));
             }
         }
         assert!(svc.engine.take_requests().await.is_empty());
@@ -88,21 +78,17 @@ async fn unsupported_tool_choices_fail_before_dispatch_or_streaming() {
                 json!({"type": "web_search_preview"}),
                 json!({"type": "allowed_tools", "mode": "required", "tools": [{"type": "function", "name": "read_file"}]}),
             ] {
-                for tools in [None, Some(json!([tool("read_file")]))] {
-                    let mut body = json!({
-                        "model": MODEL,
-                        "input": "ping",
-                        "stream": stream,
-                        "tool_choice": choice,
-                    });
-                    if let Some(tools) = tools {
-                        body["tools"] = tools;
-                    }
-                    let response = post_responses(&svc, &body).await;
-                    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
-                    let error: Value = response.json().await.unwrap();
-                    assert!(error["message"].as_str().unwrap().contains("tool_choice"));
-                }
+                let body = json!({
+                    "model": MODEL,
+                    "input": "ping",
+                    "stream": stream,
+                    "tool_choice": choice,
+                    "tools": [tool("read_file")],
+                });
+                let response = post_responses(&svc, &body).await;
+                assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+                let error: Value = response.json().await.unwrap();
+                assert!(error["message"].as_str().unwrap().contains("tool_choice"));
             }
         }
         assert!(svc.engine.take_requests().await.is_empty());

--- a/tests/frontend/agent_smoke_inputs.py
+++ b/tests/frontend/agent_smoke_inputs.py
@@ -35,6 +35,9 @@ non_code_mode_only = false
     (codex_home / "config.toml").write_text(
         f"""
 model_max_output_tokens = 4096
+# Dynamo's Responses adapter supports function tools, not hosted web search.
+# Disable Codex's default web-search tool for both parent and child smokes.
+web_search = "disabled"
 
 {multi_agent_config}
 


### PR DESCRIPTION
## Summary

Responses requests containing unsupported tools currently lose those definitions when converted to Chat Completions, and unsupported `tool_choice` variants silently become `auto`. Reject these requests with an actionable HTTP 400 before backend dispatch or streaming begins.

Preserve ordinary and namespaced function tools and the existing function choice modes. This addresses the explicit unsupported-feature error portion of #12859; hosted tool execution and backend capability handling remain separate work.

Codex clients must disable hosted web search when using this adapter. The shared compliance fixture sets `web_search = "disabled"` for ordinary and multi-agent sessions, and the agent-harness guide documents the supported tool surface and a per-run `-c 'web_search="disabled"'` override. Requests that still advertise unsupported tools receive 400 even with `tool_choice: "none"` or `"auto"`. The production rejection and its separate no-dispatch regressions remain enabled.

## Validation

- Reproduced on upstream `946accea5e`: the HTTP regression reached the scripted backend and returned 500 instead of the expected client-side 400.
- `cargo test -p dynamo-llm --no-default-features --test responses_http_replay --offline`: 17 passed again on the final changes. Includes 10 rejection cases across streaming/non-streaming requests, hosted-only/mixed/namespace-custom tools, and explicit hosted/allowed-tools choices with valid function definitions. Rejected requests never reach the engine; existing successful Responses replays pass.
- `cargo clippy -p dynamo-llm --no-default-features --lib --offline -- -D warnings`, `cargo fmt -p dynamo-llm -- --check`, applicable pre-commit hooks, and `git diff --check` passed.
- A real Codex CLI 0.154.0 session against this PR's Dynamo HTTP service completed an `exec_command` / `ls` round trip with a scripted chat backend; the backend received the actual marker filename from the shell output. This validates the real client and HTTP adapter without a GPU model.
- Captured real Codex requests before/after the fixture change in ordinary and multi-agent configurations: `web_search` is removed while function tools remain. These captures do not establish a complete child-agent/GPU-model round trip.
- Docs lint and `fern check` report zero errors. `fern docs broken-links` reports an existing broken recipe link in `deepseek-v4-pro-0813.mdx:254`, unchanged by this PR.
- Full `tests/frontend/test_frontend_api_surface_compliance.py` and SGLang amd64 validation remain pending NVIDIA CI approval of the latest head. The local environment is configured for vLLM and does not provide a complete SGLang runtime.

## Related Issues

Relates to #12859.
