### PR TITLE
feat(router): yield decode affinity under KV pressure

### DIFF
--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -34,6 +34,7 @@ _KV_ROUTER_FIELDS: tuple[str, ...] = (
     "overlap_score_credit_decay",
     "prefill_load_scale",
     "decode_active_request_weight",
+    "router_decode_affinity_high_watermark",
     "host_cache_hit_weight",
     "disk_cache_hit_weight",
     "router_temperature",
@@ -195,6 +196,7 @@ class KvRouterConfigBase(ConfigBase):
     overlap_score_credit_decay: float
     prefill_load_scale: float
     decode_active_request_weight: float
+    router_decode_affinity_high_watermark: Optional[float] = None
     host_cache_hit_weight: float
     disk_cache_hit_weight: float
     router_temperature: float
@@ -229,6 +231,13 @@ class KvRouterConfigBase(ConfigBase):
     conditional_disagg_decode_busy_threshold: Optional[float] = None
     router_predicted_ttl_secs: Optional[float] = None
     load_aware: bool = False
+
+    def validate_decode_affinity_high_watermark(self) -> None:
+        value = self.router_decode_affinity_high_watermark
+        if value is not None and not 0.0 <= value <= 1.0:
+            raise ValueError(
+                "--router-decode-affinity-high-watermark must be between 0.0 and 1.0"
+            )
 
     def apply_load_aware_preset(self) -> None:
         if not self.load_aware:
@@ -361,6 +370,18 @@ class KvRouterArgGroup(ArgGroup):
             ),
             arg_type=float,
             dest="decode_active_request_weight",
+        )
+        add_argument(
+            g,
+            flag_name="--router-decode-affinity-high-watermark",
+            env_var="DYN_ROUTER_DECODE_AFFINITY_HIGH_WATERMARK",
+            default=None,
+            help=(
+                "[EXPERIMENTAL] KV Router: Yield an implicit decode session-affinity "
+                "pin when its projected active blocks exceed this fraction of KV "
+                "capacity. Explicit pins remain strict. Omit to disable."
+            ),
+            arg_type=nullable_float,
         )
         add_argument(
             g,

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -191,6 +191,37 @@ def test_decode_active_request_weight_flows_to_binding_kwargs() -> None:
     assert kwargs["decode_active_request_weight"] == 64.0
 
 
+def test_decode_affinity_high_watermark_cli_and_environment(monkeypatch) -> None:
+    monkeypatch.delenv("DYN_ROUTER_DECODE_AFFINITY_HIGH_WATERMARK", raising=False)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    config = FrontendConfig.from_cli_args(
+        parser.parse_args(["--router-decode-affinity-high-watermark", "0.70"])
+    )
+    config.validate()
+    assert config.kv_router_kwargs()["router_decode_affinity_high_watermark"] == 0.70
+
+    monkeypatch.setenv("DYN_ROUTER_DECODE_AFFINITY_HIGH_WATERMARK", "0.65")
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+    config = FrontendConfig.from_cli_args(parser.parse_args([]))
+    config.validate()
+    assert config.router_decode_affinity_high_watermark == 0.65
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1.1", "nan"])
+def test_decode_affinity_high_watermark_rejects_invalid_values(value: str) -> None:
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+    config = FrontendConfig.from_cli_args(
+        parser.parse_args(["--router-decode-affinity-high-watermark", value])
+    )
+
+    with pytest.raises(ValueError, match="router-decode-affinity-high-watermark"):
+        config.validate()
+
+
 def test_load_aware_cli_applies_no_cache_load_balancing_preset() -> None:
     parser = argparse.ArgumentParser()
     KvRouterArgGroup().add_arguments(parser)

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -133,6 +133,7 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
                 "--router-session-affinity-ttl-secs must be between 1 and "
                 f"{_MAX_SESSION_AFFINITY_TTL_SECS}"
             )
+        self.validate_decode_affinity_high_watermark()
         if self.tokenizer_backend not in self._VALID_TOKENIZER_BACKENDS:
             raise ValueError(
                 f"--tokenizer: invalid value '{self.tokenizer_backend}' "

--- a/components/src/dynamo/router/args.py
+++ b/components/src/dynamo/router/args.py
@@ -32,6 +32,7 @@ class DynamoRouterConfig(KvRouterConfigBase, AicPerfConfigBase):
     def validate(self) -> None:
         """Validate config invariants (aligned with Rust KvRouterConfig where applicable)."""
         self.apply_load_aware_preset()
+        self.validate_decode_affinity_high_watermark()
 
         if not self.endpoint:
             raise ValueError(

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -242,7 +242,7 @@ impl AicPerfConfig {
 #[pymethods]
 impl KvRouterConfig {
     #[new]
-    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, *, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_ttl_secs=120.0, router_approximate_cache_policy="ttl", router_queue_threshold=None, router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, conditional_disagg_enabled=false, conditional_disagg_policy="isl_bounding", conditional_disagg_eff_isl_threshold=2048, conditional_disagg_eff_isl_ratio_threshold=0.7, conditional_disagg_prefill_busy_threshold=None, conditional_disagg_decode_busy_threshold=None, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, decode_active_request_weight=0.0, router_policy_config=None, router_prefill_policy=None, router_decode_policy=None, router_tracking_hash="public-xxh3-v1", router_tracking_key_file=None, router_tracking_key_id=None))]
+    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, *, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_ttl_secs=120.0, router_approximate_cache_policy="ttl", router_queue_threshold=None, router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, conditional_disagg_enabled=false, conditional_disagg_policy="isl_bounding", conditional_disagg_eff_isl_threshold=2048, conditional_disagg_eff_isl_ratio_threshold=0.7, conditional_disagg_prefill_busy_threshold=None, conditional_disagg_decode_busy_threshold=None, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, decode_active_request_weight=0.0, router_decode_affinity_high_watermark=None, router_policy_config=None, router_prefill_policy=None, router_decode_policy=None, router_tracking_hash="public-xxh3-v1", router_tracking_key_file=None, router_tracking_key_id=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         overlap_score_weight: Option<f64>,
@@ -276,6 +276,7 @@ impl KvRouterConfig {
         overlap_score_credit_decay: f64,
         mut prefill_load_scale: f64,
         decode_active_request_weight: f64,
+        router_decode_affinity_high_watermark: Option<f64>,
         router_policy_config: Option<String>,
         router_prefill_policy: Option<String>,
         router_decode_policy: Option<String>,
@@ -296,6 +297,7 @@ impl KvRouterConfig {
             overlap_score_credit_decay,
             prefill_load_scale,
             decode_active_request_weight,
+            router_decode_affinity_high_watermark,
             host_cache_hit_weight,
             disk_cache_hit_weight,
             router_temperature,
@@ -426,6 +428,20 @@ impl KvRouterConfig {
     fn set_decode_active_request_weight(&mut self, value: f64) -> PyResult<()> {
         let mut inner = self.inner.clone();
         inner.decode_active_request_weight = value;
+        validate_kv_router_config(&inner)?;
+        self.inner = inner;
+        Ok(())
+    }
+
+    #[getter]
+    fn router_decode_affinity_high_watermark(&self) -> Option<f64> {
+        self.inner.router_decode_affinity_high_watermark
+    }
+
+    #[setter]
+    fn set_router_decode_affinity_high_watermark(&mut self, value: Option<f64>) -> PyResult<()> {
+        let mut inner = self.inner.clone();
+        inner.router_decode_affinity_high_watermark = value;
         validate_kv_router_config(&inner)?;
         self.inner = inner;
         Ok(())

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1807,6 +1807,7 @@ class KvRouterConfig:
         overlap_score_credit_decay: float = 0.0,
         prefill_load_scale: float = 1.0,
         decode_active_request_weight: float = 0.0,
+        router_decode_affinity_high_watermark: Optional[float] = None,
         router_policy_config: Optional[str] = None,
         router_prefill_policy: Optional[str] = None,
         router_decode_policy: Optional[str] = None,
@@ -1822,6 +1823,7 @@ class KvRouterConfig:
             overlap_score_credit: Finite, non-negative credit multiplier for device-local prefix overlap (default: 1.0). Values above 1.0 give device overlap extra credit, with adjusted prefill cost clamped at zero.
             prefill_load_scale: Scale for adjusted prompt-side prefill load after cache-hit credits (default: 1.0)
             decode_active_request_weight: Experimental block-equivalent decode cost added for each active request on a candidate worker (default: 0.0)
+            router_decode_affinity_high_watermark: Yield an implicit hard decode session-affinity pin when projected active blocks exceed this fraction of KV capacity (default: None)
             host_cache_hit_weight: Credit multiplier for host-pinned cache hits (default: 0.75)
             disk_cache_hit_weight: Credit multiplier for disk/external cache hits (default: 0.25)
             router_temperature: Temperature for normalized worker sampling via softmax (default: 0.0)
@@ -1912,6 +1914,10 @@ class KvRouterConfig:
     def decode_active_request_weight(self) -> float: ...
     @decode_active_request_weight.setter
     def decode_active_request_weight(self, value: float) -> None: ...
+    @property
+    def router_decode_affinity_high_watermark(self) -> Optional[float]: ...
+    @router_decode_affinity_high_watermark.setter
+    def router_decode_affinity_high_watermark(self, value: Optional[float]) -> None: ...
 
     def with_overrides(
         self,

--- a/lib/bindings/python/tests/test_kv_router_config.py
+++ b/lib/bindings/python/tests/test_kv_router_config.py
@@ -25,3 +25,17 @@ def test_decode_active_request_weight_defaults_to_zero_and_validates() -> None:
     for invalid in [-1.0, float("nan"), float("inf")]:
         with pytest.raises(ValueError, match="decode_active_request_weight"):
             KvRouterConfig(decode_active_request_weight=invalid)
+
+
+def test_decode_affinity_high_watermark_defaults_to_none_and_validates() -> None:
+    assert KvRouterConfig().router_decode_affinity_high_watermark is None
+    assert (
+        KvRouterConfig(
+            router_decode_affinity_high_watermark=0.7
+        ).router_decode_affinity_high_watermark
+        == 0.7
+    )
+
+    for invalid in [-0.1, 1.1, float("nan")]:
+        with pytest.raises(ValueError, match="router_decode_affinity_high_watermark"):
+            KvRouterConfig(router_decode_affinity_high_watermark=invalid)

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -170,6 +170,7 @@ fn log_env_config(config: &KvRouterConfig) {
         overlap_score_credit_decay = config.overlap_score_credit_decay,
         prefill_load_scale = config.prefill_load_scale,
         decode_active_request_weight = config.decode_active_request_weight,
+        router_decode_affinity_high_watermark = ?config.router_decode_affinity_high_watermark,
         router_temperature = config.router_temperature,
         use_kv_events = config.use_kv_events,
         router_replica_sync = config.router_replica_sync,
@@ -237,6 +238,9 @@ fn kv_router_config_from_lookup(
     }
     if let Some(value) = parse_f64(&get_env, "DYN_ROUTER_DECODE_ACTIVE_REQUEST_WEIGHT") {
         config.decode_active_request_weight = value;
+    }
+    if let Some(value) = parse_f64(&get_env, "DYN_ROUTER_DECODE_AFFINITY_HIGH_WATERMARK") {
+        config.router_decode_affinity_high_watermark = Some(value);
     }
     for key in [
         "DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT",
@@ -651,6 +655,7 @@ struct KvRouterConfigSerde {
     overlap_score_credit_decay: f64,
     prefill_load_scale: f64,
     decode_active_request_weight: f64,
+    router_decode_affinity_high_watermark: Option<f64>,
     overlap_score_weight: Option<f64>,
     host_cache_hit_weight: f64,
     disk_cache_hit_weight: f64,
@@ -704,6 +709,7 @@ impl Default for KvRouterConfigSerde {
             overlap_score_credit_decay: config.overlap_score_credit_decay,
             prefill_load_scale: config.prefill_load_scale,
             decode_active_request_weight: config.decode_active_request_weight,
+            router_decode_affinity_high_watermark: config.router_decode_affinity_high_watermark,
             overlap_score_weight: None,
             host_cache_hit_weight: config.host_cache_hit_weight,
             disk_cache_hit_weight: config.disk_cache_hit_weight,
@@ -768,6 +774,12 @@ pub struct KvRouterConfig {
     /// compute matters more than resident KV footprint. Defaults to 0.0.
     #[serde(default, skip_serializing_if = "is_default")]
     pub decode_active_request_weight: f64,
+
+    /// Yield an implicit hard decode-affinity pin when the request's projected
+    /// active blocks exceed this fraction of the worker rank's KV capacity.
+    /// Explicit request pins remain strict. `None` disables the pressure check.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub router_decode_affinity_high_watermark: Option<f64>,
 
     #[serde(default = "default_host_cache_hit_weight")]
     pub host_cache_hit_weight: f64,
@@ -955,6 +967,7 @@ impl Default for KvRouterConfig {
             overlap_score_credit_decay: default_overlap_score_credit_decay(),
             prefill_load_scale: default_prefill_load_scale(),
             decode_active_request_weight: default_decode_active_request_weight(),
+            router_decode_affinity_high_watermark: None,
             host_cache_hit_weight: default_host_cache_hit_weight(),
             disk_cache_hit_weight: default_disk_cache_hit_weight(),
             router_temperature: 0.0,
@@ -1019,6 +1032,7 @@ impl TryFrom<KvRouterConfigSerde> for KvRouterConfig {
             overlap_score_credit_decay: compat.overlap_score_credit_decay,
             prefill_load_scale,
             decode_active_request_weight: compat.decode_active_request_weight,
+            router_decode_affinity_high_watermark: compat.router_decode_affinity_high_watermark,
             host_cache_hit_weight: compat.host_cache_hit_weight,
             disk_cache_hit_weight: compat.disk_cache_hit_weight,
             router_temperature: compat.router_temperature,
@@ -1372,6 +1386,9 @@ impl KvRouterConfig {
             0.0,
             f64::MAX,
         )?;
+        if let Some(value) = self.router_decode_affinity_high_watermark {
+            validate_range("router_decode_affinity_high_watermark", value, 0.0, 1.0)?;
+        }
         validate_range(
             "host_cache_hit_weight",
             self.host_cache_hit_weight,
@@ -1602,6 +1619,7 @@ mod tests {
             ("DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT_DECAY", "0.75"),
             ("DYN_ROUTER_PREFILL_LOAD_SCALE", "2.5"),
             ("DYN_ROUTER_DECODE_ACTIVE_REQUEST_WEIGHT", "32"),
+            ("DYN_ROUTER_DECODE_AFFINITY_HIGH_WATERMARK", "0.7"),
             ("DYN_ROUTER_TEMPERATURE", "0.7"),
             ("DYN_ROUTER_USE_KV_EVENTS", "false"),
             ("DYN_ROUTER_REPLICA_SYNC", "yes"),
@@ -1636,6 +1654,7 @@ mod tests {
         assert_eq!(config.router_prefill_policy.as_deref(), Some("prefill-cli"));
         assert_eq!(config.router_decode_policy.as_deref(), Some("decode-cli"));
         assert_eq!(config.decode_active_request_weight, 32.0);
+        assert_eq!(config.router_decode_affinity_high_watermark, Some(0.7));
         assert_eq!(config.router_temperature, 0.7);
         assert!(!config.use_kv_events);
         assert!(config.router_replica_sync);
@@ -2221,6 +2240,7 @@ worker_selection:
         let value = serde_json::to_value(KvRouterConfig::default()).unwrap();
         for post_v1_3_field in [
             "decode_active_request_weight",
+            "router_decode_affinity_high_watermark",
             "router_tracking_hash",
             "router_tracking_key_file",
             "router_tracking_key_id",

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -844,6 +844,7 @@ impl RoutingOverheadMetrics {
 /// independently.
 pub struct RouterRequestMetrics {
     pub requests_total: prometheus::IntCounter,
+    pub decode_affinity_yields_total: prometheus::IntCounter,
     pub time_to_first_token_seconds: prometheus::Histogram,
     pub inter_token_latency_seconds: prometheus::Histogram,
     pub input_sequence_tokens: prometheus::Histogram,
@@ -906,6 +907,13 @@ impl RouterRequestMetrics {
                         extra_labels,
                     )
                     .expect("failed to create router_requests_total");
+                let decode_affinity_yields_total = metrics
+                    .create_intcounter(
+                        &router_metric("decode_affinity_yields_total"),
+                        "Total number of implicit decode affinity pins yielded due to projected KV pressure",
+                        extra_labels,
+                    )
+                    .expect("failed to create router_decode_affinity_yields_total");
                 let time_to_first_token_seconds = metrics
                     .create_histogram(
                         &router_metric(frontend_service::TIME_TO_FIRST_TOKEN_SECONDS),
@@ -991,6 +999,7 @@ impl RouterRequestMetrics {
                 overlap_blocks_lost.with_label_values(&[WORKER_TYPE_PREFILL]);
                 Arc::new(Self {
                     requests_total,
+                    decode_affinity_yields_total,
                     time_to_first_token_seconds,
                     inter_token_latency_seconds,
                     input_sequence_tokens,

--- a/lib/llm/src/kv_router/routing_host/kv.rs
+++ b/lib/llm/src/kv_router/routing_host/kv.rs
@@ -79,10 +79,75 @@ where
         phase: RequestPhase,
         is_query_only: bool,
     ) -> Result<(WorkerSelection, Option<AffinityAcquire>), Error> {
-        self.select_with_session_affinity(request, phase, is_query_only, |target| {
-            self.select_request(request, phase, is_query_only, target)
-        })
-        .await
+        let pressure_threshold = if phase == RequestPhase::Decode
+            && !is_query_only
+            && self.session_affinity_mode == SessionAffinityMode::Hard
+            && explicit_target(request.content(), phase)?.is_none()
+        {
+            self.kv_router()
+                .kv_router_config()
+                .router_decode_affinity_high_watermark
+        } else {
+            None
+        };
+        let ((selection, yielded_affinity), operation) = self
+            .select_with_session_affinity(request, phase, is_query_only, |target| async move {
+                if let (Some(threshold), Some(target)) = (pressure_threshold, target) {
+                    match self
+                        .select_request_outcome(
+                            request,
+                            phase,
+                            true,
+                            Some(target),
+                            None,
+                            FindBestMatchAdmission::WithoutAdmission,
+                        )
+                        .await
+                        .and_then(SelectionOutcome::into_result)
+                    {
+                        Ok(preview) => {
+                            let signals = self.route_signals(&preview);
+                            if signals.decode_load_exceeds(threshold) == Some(true) {
+                                let selection = self
+                                    .select_request(request, phase, is_query_only, None)
+                                    .await?;
+                                return Ok((selection, Some((signals, threshold))));
+                            }
+                        }
+                        Err(error) if is_cancelled(&error) => return Err(error),
+                        Err(error) => tracing::warn!(
+                            error = %error,
+                            worker_id = target.worker_id,
+                            dp_rank = ?target.dp_rank,
+                            "failed to inspect decode affinity pressure; honoring pin"
+                        ),
+                    }
+                }
+                Ok((
+                    self.select_request(request, phase, is_query_only, target)
+                        .await?,
+                    None,
+                ))
+            })
+            .await?;
+
+        if let Some((previous, threshold)) = yielded_affinity {
+            drop(operation); // Release the lease without invalidating the stored pin.
+            self.request_metrics.decode_affinity_yields_total.inc();
+            tracing::info!(
+                old_worker_id = previous.worker.worker_id,
+                old_dp_rank = previous.worker.dp_rank,
+                selected_worker_id = selection.worker.worker_id,
+                selected_dp_rank = selection.worker.dp_rank,
+                pinned_potential_decode_blocks = previous.potential_decode_blocks,
+                total_kv_blocks = ?previous.total_kv_blocks,
+                threshold,
+                "decode_affinity_yield"
+            );
+            return Ok((selection, None));
+        }
+
+        Ok((selection, operation))
     }
 
     fn route_signals(&self, selection: &WorkerSelection) -> RoutePlanSignals {

--- a/lib/llm/src/kv_router/routing_host/request_guard.rs
+++ b/lib/llm/src/kv_router/routing_host/request_guard.rs
@@ -1000,6 +1000,11 @@ mod prefill_start_tests {
         }
         Arc::new(RouterRequestMetrics {
             requests_total: prometheus::IntCounter::new("requests_total", "test").unwrap(),
+            decode_affinity_yields_total: prometheus::IntCounter::new(
+                "decode_affinity_yields_total",
+                "test",
+            )
+            .unwrap(),
             time_to_first_token_seconds: hist("ttft_seconds"),
             inter_token_latency_seconds: hist("itl_seconds"),
             input_sequence_tokens: hist("isl_tokens"),

--- a/lib/llm/src/kv_router/routing_host/tests.rs
+++ b/lib/llm/src/kv_router/routing_host/tests.rs
@@ -1108,6 +1108,20 @@ async fn router_with_worker_configs(
     session_affinity_ttl: Option<Duration>,
     workers: HashMap<u64, ModelRuntimeConfig>,
 ) -> (RoutingHost, Runtime) {
+    let config = KvRouterConfig {
+        skip_initial_worker_wait: true,
+        use_kv_events: false,
+        router_track_active_blocks: false,
+        ..Default::default()
+    };
+    router_with_config_and_worker_configs(session_affinity_ttl, config, workers).await
+}
+
+async fn router_with_config_and_worker_configs(
+    session_affinity_ttl: Option<Duration>,
+    config: KvRouterConfig,
+    workers: HashMap<u64, ModelRuntimeConfig>,
+) -> (RoutingHost, Runtime) {
     let runtime = Runtime::from_current().unwrap();
     let distributed = DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
         .await
@@ -1121,12 +1135,6 @@ async fn router_with_worker_configs(
     let client = endpoint.client().await.unwrap();
     let worker_ids = workers.keys().copied().collect::<Vec<_>>();
     let (_tx, workers) = watch::channel(workers);
-    let config = KvRouterConfig {
-        skip_initial_worker_wait: true,
-        use_kv_events: false,
-        router_track_active_blocks: false,
-        ..Default::default()
-    };
     let chooser = KvRouter::new(
         endpoint,
         client.clone(),
@@ -1154,6 +1162,28 @@ async fn router_with_worker_configs(
         .override_discovered_instances(worker_ids.clone());
     router.inner.client.override_instance_avail(worker_ids);
     (router, runtime)
+}
+
+async fn affinity_pressure_router(high_watermark: f64) -> (RoutingHost, Runtime) {
+    let config = KvRouterConfig {
+        skip_initial_worker_wait: true,
+        use_kv_events: false,
+        router_track_active_blocks: true,
+        router_assume_kv_reuse: false,
+        router_decode_affinity_high_watermark: Some(high_watermark),
+        ..Default::default()
+    };
+    let worker = ModelRuntimeConfig {
+        total_kv_blocks: Some(10),
+        data_parallel_size: 2,
+        ..Default::default()
+    };
+    router_with_config_and_worker_configs(
+        Some(Duration::from_secs(10)),
+        config,
+        HashMap::from([(7, worker)]),
+    )
+    .await
 }
 
 async fn track_request(
@@ -1614,6 +1644,110 @@ async fn bind_affinity_target(
         panic!("first request must initialize");
     };
     drop(initializer.commit(target).unwrap());
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn decode_affinity_above_high_watermark_reselects_least_loaded_rank() {
+    let (router, runtime) = affinity_pressure_router(0.7).await;
+    let session_id = SessionAffinityId::new("heavy-pinned-rank");
+    bind_affinity_target(&router, &session_id, AffinityTarget::new(7, Some(0))).await;
+    router
+        .kv_router()
+        .add_request(
+            "existing-heavy-request".to_string(),
+            &[1; 128],
+            None,
+            0,
+            None,
+            WorkerWithDpRank::new(7, 0),
+            None,
+            None,
+            None,
+        )
+        .await;
+
+    let yields_before = router.request_metrics.decode_affinity_yields_total.get();
+    let mut request = Context::new(request());
+    request.insert(SESSION_AFFINITY_CONTEXT_KEY, session_id.clone());
+    let (selection, operation) = router
+        .select_with_affinity(&request, RequestPhase::Decode, false)
+        .await
+        .unwrap();
+
+    assert_eq!(selection.worker, WorkerWithDpRank::new(7, 1));
+    assert!(operation.is_none());
+    assert_eq!(
+        router.request_metrics.decode_affinity_yields_total.get(),
+        yields_before + 1
+    );
+    assert_eq!(
+        router
+            .affinity
+            .as_ref()
+            .unwrap()
+            .query_target(&session_id, None)
+            .unwrap(),
+        Some(AffinityTarget::new(7, Some(0)))
+    );
+
+    router.kv_router().free(request.id()).await.unwrap();
+    router
+        .kv_router()
+        .free("existing-heavy-request")
+        .await
+        .unwrap();
+    drop(router);
+    runtime.shutdown();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn decode_affinity_below_high_watermark_honors_pin() {
+    let (router, runtime) = affinity_pressure_router(0.7).await;
+    let session_id = SessionAffinityId::new("light-pinned-rank");
+    bind_affinity_target(&router, &session_id, AffinityTarget::new(7, Some(0))).await;
+
+    let mut request = Context::new(request());
+    request.insert(SESSION_AFFINITY_CONTEXT_KEY, session_id);
+    let (selection, operation) = router
+        .select_with_affinity(&request, RequestPhase::Decode, false)
+        .await
+        .unwrap();
+
+    assert_eq!(selection.worker, WorkerWithDpRank::new(7, 0));
+    assert!(matches!(operation, Some(AffinityAcquire::Bound { .. })));
+
+    router.kv_router().free(request.id()).await.unwrap();
+    drop(operation);
+    drop(router);
+    runtime.shutdown();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn decode_affinity_high_watermark_preserves_explicit_pin() {
+    let (router, runtime) = affinity_pressure_router(0.0).await;
+    let session_id = SessionAffinityId::new("explicit-pinned-rank");
+    bind_affinity_target(&router, &session_id, AffinityTarget::new(7, Some(0))).await;
+
+    let mut input = request();
+    input.routing_mut().decode_worker_id = Some(7);
+    input.routing_mut().dp_rank = Some(0);
+    let mut request = Context::new(input);
+    request.insert(SESSION_AFFINITY_CONTEXT_KEY, session_id);
+    let (selection, operation) = router
+        .select_with_affinity(&request, RequestPhase::Decode, false)
+        .await
+        .unwrap();
+
+    assert_eq!(selection.worker, WorkerWithDpRank::new(7, 0));
+    assert!(operation.is_some());
+
+    router.kv_router().free(request.id()).await.unwrap();
+    drop(operation);
+    drop(router);
+    runtime.shutdown();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem this solves

Hard session affinity preserves KV locality for multi-turn requests, but today an implicitly bound decode request remains pinned even when that data-parallel rank's projected active KV footprint is near capacity. The normal KV-aware selector cannot relieve the hot rank because the affinity binding is presented as a strict placement constraint. Long-lived sessions can therefore concentrate decode work on one rank while other eligible ranks retain headroom.

This change adds an opt-in pressure escape hatch for **implicit decode affinity only**. It keeps hard affinity as the default behavior and leaves explicit request pins strict.

## Summary

- Add the experimental `--router-decode-affinity-high-watermark` option and `DYN_ROUTER_DECODE_AFFINITY_HIGH_WATERMARK` environment variable.
- Before admitting a hard-affinity decode request, preview the bound rank's projected active blocks against its advertised KV capacity.
- When the projected fraction is strictly above the configured watermark, release only the current affinity lease and rerun normal unpinned KV selection.
- Preserve the stored session binding so later turns can reuse the original locality once pressure falls.
- Export `dynamo_component_router_decode_affinity_yields_total` to make the behavior observable.

The feature is disabled by default (`None`), and the accepted range is `0.0` through `1.0`.

## Workload evidence and motivation

The motivating case was GLM-5.2 NVFP4 serving a disaggregated, multi-turn coding workload across 32 backend GB200 GPUs. At concurrency 160, a matched end-to-end A/B changed only the pressure-aware affinity behavior and measured:

| Metric | Existing hard affinity | Watermark `0.70` | Change |
|---|---:|---:|---:|
| Throughput per GPU | 19,748.50 tokens/s/GPU | 22,389.05 tokens/s/GPU | **+13.37%** |
| p90 per-user throughput | 90.933 tokens/s/user | 90.038 tokens/s/user | **-0.98%** |

The optimized configuration also retained a GSM8K score of 0.9682. This is evidence for the motivating topology, not a claim that `0.70` is a universal threshold: the appropriate watermark depends on model memory use, DP layout, request lengths, and the value of session locality.

## Behavior and safety

The pressure check runs only when all of the following are true:

- the request is in the decode phase;
- session affinity is in hard mode;
- the affinity target came from the stored session binding, not an explicit request pin;
- the request is not a query-only route preview; and
- a watermark was explicitly configured.

Explicit decode worker/rank pins, prefill routing, aggregated routing, soft affinity, and the default configuration are unchanged.

The check fails safe toward existing behavior:

- missing worker capacity or a below-threshold projection honors the pin;
- failure to inspect pressure logs a warning and honors the pin;
- cancellation remains cancellation rather than being swallowed;
- yielding drops the current lease without invalidating or rewriting the stored affinity binding; and
- reselection uses the existing KV scheduler, including its eligibility, allowlist, taint, and admission logic.

## Implementation notes

The pressure probe uses the scheduler's advisory no-admission path, so it does not reserve capacity or mutate active-request state. The compared load is the request-inclusive `potential_decode_blocks` projection already produced by the scheduler, divided by the selected worker rank's advertised `total_kv_blocks`. Selection is then performed exactly once through the normal admission path.

Configuration is wired consistently through the shared frontend/router CLI layer, Rust environment parsing and serialization, and the Python binding. The optional field is omitted from default serialization to preserve the existing default wire shape.

## Validation

- `cargo fmt --all -- --check`
- `(cd lib/bindings/python && cargo fmt -- --check)`
- `cargo check -p dynamo-llm --no-default-features`
- `cargo test -p dynamo-llm --no-default-features decode_affinity -- --nocapture` (3 passed)
- `cargo test -p dynamo-kv-router dynamo_env_config_parses_canonical_settings -- --nocapture`
- `cargo test -p dynamo-kv-router kv_router_config_preserves_v1_3_wire_compatibility -- --nocapture`
- `python3 -m compileall -q` for the touched Python configuration and test modules
- Added unit coverage for above-watermark reselection, below-watermark pin retention, explicit-pin preservation, CLI/environment propagation, binding validation, and default serialization compatibility.

## Limitations

- Enabling the feature adds one advisory selection pass for decode requests that already have an implicit hard-affinity target.
- It depends on active-block tracking and advertised KV capacity being representative of the decode rank. Missing capacity deliberately disables yielding for that request.
- It handles rank-local pressure; it cannot create capacity when every eligible rank is saturated.
- It does not permanently migrate the session binding. A later turn reevaluates the original binding and may yield again while pressure remains high.
- Threshold selection remains workload- and topology-specific; this PR intentionally provides no non-disabled default.
