### PR TITLE
fix(vllm): size the EPD encode worker image cache from DYN_MM_IMAGE_CACHE_SIZE

### DIFF
--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -78,7 +78,7 @@ class ImageLoader:
 
         Args:
             cache_size: Maximum number of images to store in the in-memory LRU cache.
-                Defaults to CACHE_SIZE_MAXIMUM.
+                Zero or less disables caching. Defaults to CACHE_SIZE_MAXIMUM.
             http_timeout: Timeout in seconds for HTTP requests when fetching remote images.
                 Defaults to 30.0 seconds.
             enable_frontend_decoding: If True, enables NIXL RDMA for transferring
@@ -117,6 +117,10 @@ class ImageLoader:
 
     def _cache_put(self, key: str, image: Image.Image) -> None:
         """Insert into cache if not already present. Sync — no awaits."""
+        # A capacity of zero or less means caching is off. Falling through would
+        # try to evict from an empty OrderedDict and raise KeyError.
+        if self._cache_size <= 0:
+            return
         if key not in self._image_cache:
             if len(self._image_cache) >= self._cache_size:
                 self._image_cache.popitem(last=False)

--- a/components/src/dynamo/common/tests/multimodal/test_media_connector.py
+++ b/components/src/dynamo/common/tests/multimodal/test_media_connector.py
@@ -88,3 +88,12 @@ class TestImageLoaderCache:
         loader._cache_put("url1", img)
         loader._cache_put("url1", img)
         assert len(loader._image_cache) == 1
+
+    def test_cache_size_zero_disables_cache(self):
+        """A capacity of zero stores nothing rather than evicting from an empty cache."""
+        loader = ImageLoader(cache_size=0)
+
+        loader._cache_put("url1", _make_pil_image())
+        loader._cache_put("url2", _make_pil_image())
+
+        assert len(loader._image_cache) == 0

--- a/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
@@ -130,9 +130,8 @@ class EncodeWorkerHandler:
 
         self._enable_frontend_decoding = enable_frontend_decoding
         self._decoded_content_hash_warning_emitted = False
-        # No cache_size here on purpose: ImageLoader's own default is derived
-        # from DYN_MM_IMAGE_CACHE_SIZE, so an operator who exports that
-        # variable also sizes the encode worker's image cache.
+        # No cache_size: ImageLoader's default reads DYN_MM_IMAGE_CACHE_SIZE,
+        # so passing one here would ignore the operator's setting.
         self.image_loader = ImageLoader(
             enable_frontend_decoding=enable_frontend_decoding,
         )

--- a/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
@@ -38,8 +38,6 @@ from ..multimodal_utils.model import ModelFamily, resolve_model_family
 
 logger = logging.getLogger(__name__)
 
-CACHE_SIZE_MAXIMUM = 8
-
 # [gluo WIP] now it's time to revisit
 # Both embedding transfer suffers from increasing latency as
 # number of concurrent requests increases, NixlPersistentEmbedding transfers
@@ -132,8 +130,10 @@ class EncodeWorkerHandler:
 
         self._enable_frontend_decoding = enable_frontend_decoding
         self._decoded_content_hash_warning_emitted = False
+        # No cache_size here on purpose: ImageLoader's own default is derived
+        # from DYN_MM_IMAGE_CACHE_SIZE, so an operator who exports that
+        # variable also sizes the encode worker's image cache.
         self.image_loader = ImageLoader(
-            cache_size=CACHE_SIZE_MAXIMUM,
             enable_frontend_decoding=enable_frontend_decoding,
         )
         self.image_processor = _load_image_processor(self.engine_args)

--- a/components/src/dynamo/vllm/tests/test_vllm_encode_worker_decoded.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_encode_worker_decoded.py
@@ -46,7 +46,8 @@ def _image_loader_class_reading_current_env() -> type:
     cache-size default is refreshed without mutating the shared module.
     """
     spec = importlib.util.find_spec("dynamo.common.multimodal.image_loader")
-    assert spec is not None and spec.loader is not None
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not locate dynamo.common.multimodal.image_loader")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module.ImageLoader

--- a/components/src/dynamo/vllm/tests/test_vllm_encode_worker_decoded.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_encode_worker_decoded.py
@@ -3,12 +3,15 @@
 
 """Unit tests for encode-worker multimodal helpers."""
 
+import importlib.util
 import logging
 from types import SimpleNamespace
 
 import pytest
 import torch
+from PIL import Image
 
+from dynamo.vllm.constants import EmbeddingTransferMode
 from dynamo.vllm.multimodal_handlers import encode_worker_handler
 from dynamo.vllm.multimodal_handlers.encode_worker_handler import (
     EmbeddingItem,
@@ -36,6 +39,77 @@ def _handler(*, frontend_decoding: bool) -> EncodeWorkerHandler:
 
 def _embedding_item(values: torch.Tensor) -> EmbeddingItem:
     return EmbeddingItem(key=None, image_grid_thw=[], embeddings=values)
+
+
+def _image_loader_class_reading_current_env() -> type:
+    """Return an ``ImageLoader`` class that re-reads ``DYN_MM_IMAGE_CACHE_SIZE``.
+
+    ``ImageLoader.CACHE_SIZE_MAXIMUM`` is evaluated once while the class body
+    runs, and that value is then frozen into the ``cache_size`` parameter
+    default. Executing a private copy of the module picks up the environment as
+    it stands now -- which is what a worker launched with the variable exported
+    sees -- without mutating the module object the rest of the session shares.
+    """
+    spec = importlib.util.find_spec("dynamo.common.multimodal.image_loader")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.ImageLoader
+
+
+def _encode_handler_with_cache_env(monkeypatch, cache_size_env) -> EncodeWorkerHandler:
+    """Run the real ``EncodeWorkerHandler.__init__`` with the heavy parts stubbed."""
+    if cache_size_env is None:
+        monkeypatch.delenv("DYN_MM_IMAGE_CACHE_SIZE", raising=False)
+    else:
+        monkeypatch.setenv("DYN_MM_IMAGE_CACHE_SIZE", cache_size_env)
+
+    monkeypatch.setattr(
+        encode_worker_handler, "ImageLoader", _image_loader_class_reading_current_env()
+    )
+    monkeypatch.setattr(
+        encode_worker_handler, "_load_image_processor", lambda engine_args: object()
+    )
+    monkeypatch.setattr(
+        encode_worker_handler, "load_vision_model", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(
+        encode_worker_handler,
+        "get_encoder_components",
+        lambda *args, **kwargs: (object(), object()),
+    )
+
+    engine_args = SimpleNamespace(
+        model="model",
+        trust_remote_code=False,
+        enforce_eager=True,
+    )
+    return EncodeWorkerHandler(engine_args, EmbeddingTransferMode.LOCAL)
+
+
+@pytest.mark.parametrize(
+    "cache_size_env, expected_capacity",
+    [("2", 2), (None, 8)],
+    ids=["env-set", "env-unset-default"],
+)
+async def test_encode_worker_image_cache_capacity_follows_env(
+    monkeypatch, cache_size_env, expected_capacity
+):
+    handler = _encode_handler_with_cache_env(monkeypatch, cache_size_env)
+    try:
+        loader = handler.image_loader
+        keys = [
+            f"https://example.com/{index}.png" for index in range(expected_capacity + 1)
+        ]
+        for key in keys:
+            loader._cache_put(key, Image.new("RGB", (4, 4), color="blue"))
+
+        assert len(loader._image_cache) == expected_capacity
+        assert keys[0] not in loader._image_cache
+        assert keys[-1] in loader._image_cache
+    finally:
+        handler.cleanup()
+        await handler.send_complete_checker_task
 
 
 def test_prepare_embedding_transfers_coalesces_uneven_images():

--- a/components/src/dynamo/vllm/tests/test_vllm_encode_worker_decoded.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_encode_worker_decoded.py
@@ -42,13 +42,8 @@ def _embedding_item(values: torch.Tensor) -> EmbeddingItem:
 
 
 def _image_loader_class_reading_current_env() -> type:
-    """Return an ``ImageLoader`` class that re-reads ``DYN_MM_IMAGE_CACHE_SIZE``.
-
-    ``ImageLoader.CACHE_SIZE_MAXIMUM`` is evaluated once while the class body
-    runs, and that value is then frozen into the ``cache_size`` parameter
-    default. Executing a private copy of the module picks up the environment as
-    it stands now -- which is what a worker launched with the variable exported
-    sees -- without mutating the module object the rest of the session shares.
+    """Execute a private copy of the module so the environment-derived ``ImageLoader``
+    cache-size default is refreshed without mutating the shared module.
     """
     spec = importlib.util.find_spec("dynamo.common.multimodal.image_loader")
     assert spec is not None and spec.loader is not None
@@ -59,10 +54,7 @@ def _image_loader_class_reading_current_env() -> type:
 
 def _encode_handler_with_cache_env(monkeypatch, cache_size_env) -> EncodeWorkerHandler:
     """Run the real ``EncodeWorkerHandler.__init__`` with the heavy parts stubbed."""
-    if cache_size_env is None:
-        monkeypatch.delenv("DYN_MM_IMAGE_CACHE_SIZE", raising=False)
-    else:
-        monkeypatch.setenv("DYN_MM_IMAGE_CACHE_SIZE", cache_size_env)
+    monkeypatch.setenv("DYN_MM_IMAGE_CACHE_SIZE", cache_size_env)
 
     monkeypatch.setattr(
         encode_worker_handler, "ImageLoader", _image_loader_class_reading_current_env()
@@ -89,8 +81,8 @@ def _encode_handler_with_cache_env(monkeypatch, cache_size_env) -> EncodeWorkerH
 
 @pytest.mark.parametrize(
     "cache_size_env, expected_capacity",
-    [("2", 2), (None, 8)],
-    ids=["env-set", "env-unset-default"],
+    [("2", 2), ("0", 0)],
+    ids=["env-set", "env-set-zero"],
 )
 async def test_encode_worker_image_cache_capacity_follows_env(
     monkeypatch, cache_size_env, expected_capacity
@@ -106,7 +98,8 @@ async def test_encode_worker_image_cache_capacity_follows_env(
 
         assert len(loader._image_cache) == expected_capacity
         assert keys[0] not in loader._image_cache
-        assert keys[-1] in loader._image_cache
+        if expected_capacity:
+            assert keys[-1] in loader._image_cache
     finally:
         handler.cleanup()
         await handler.send_complete_checker_task

--- a/docs/fern/pages/recipes/cli-templates/vllm.mdx
+++ b/docs/fern/pages/recipes/cli-templates/vllm.mdx
@@ -218,7 +218,7 @@ The default model is `Qwen/Qwen3-VL-2B-Instruct`.
 | `ETCD_ENDPOINTS` | `http://127.0.0.1:2379` | etcd endpoint used for Dynamo discovery state. |
 | `VLLM_SYSTEM_PORT_BASE` | `18081` | Starting system and metrics port for vLLM workers. |
 | `KV_EVENTS_PORT_BASE` | `29080` | Starting port for per-worker KV event publishers. |
-| `DYN_MM_IMAGE_CACHE_SIZE` | `32` | Frontend multimodal image-cache capacity. |
+| `DYN_MM_IMAGE_CACHE_SIZE` | `8` | Multimodal image-cache capacity, applied by every component that loads images; `0` disables caching. |
 | `DYNAMO_MM_TRANSFER` | `shm` | Transport used to transfer preprocessed multimodal data. |
 | `VLLM_EXTRA_ARGS` | `Empty` | Additional arguments appended to each `dynamo.vllm` worker command. |
 | `FRONTEND_EXTRA_ARGS` | `Empty` | Additional arguments appended to each frontend command. |
@@ -1274,7 +1274,7 @@ The default model is `Qwen/Qwen3-VL-2B-Instruct`.
 | `ETCD_ENDPOINTS` | `http://127.0.0.1:2379` | etcd endpoint used for Dynamo discovery state. |
 | `VLLM_SYSTEM_PORT_BASE` | `18081` | Starting system and metrics port for vLLM workers. |
 | `KV_EVENTS_PORT_BASE` | `29080` | Starting port for per-worker KV event publishers. |
-| `DYN_MM_IMAGE_CACHE_SIZE` | `32` | Frontend multimodal image-cache capacity. |
+| `DYN_MM_IMAGE_CACHE_SIZE` | `8` | Multimodal image-cache capacity, applied by every component that loads images; `0` disables caching. |
 | `DYNAMO_MM_TRANSFER` | `shm` | Transport used to transfer preprocessed multimodal data. |
 | `VLLM_EXTRA_ARGS` | `Empty` | Additional arguments appended to each `dynamo.vllm` worker command. |
 | `FRONTEND_EXTRA_ARGS` | `Empty` | Additional arguments appended to each frontend command. |


### PR DESCRIPTION
## Overview:

The vLLM encode-prefill-decode (EPD) encode worker was the only `ImageLoader` caller passing an explicit `cache_size`, hardcoded to `8`. `ImageLoader`'s own default is the single place `DYN_MM_IMAGE_CACHE_SIZE` is read, so that argument shadowed it: an operator who exported the variable resized every other image cache while this one worker silently kept `8`.

## Details:

`components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py` drops the module-level `CACHE_SIZE_MAXIMUM = 8` and the `cache_size=` argument in `EncodeWorkerHandler.__init__`. Nothing else in the tree referenced the constant. With the variable unset the behaviour is unchanged — `ImageLoader` resolves its default as `int(os.environ.get("DYN_MM_IMAGE_CACHE_SIZE", "8"))`. With it exported, the worker's cache is now sized by it, which is a real behaviour change for deployments that already set it.

`components/src/dynamo/common/multimodal/image_loader.py` makes a non-positive capacity mean "caching off". `_cache_put` evicts before inserting whenever the cache is at capacity, and `len(self._image_cache) >= 0` is always true, so a capacity of `0` called `popitem(last=False)` on an empty `OrderedDict` and raised `KeyError` on the first uncached image. `_fetch_and_cache` does not catch it, so the image load failed rather than bypassing the cache. That value is not hypothetical: `benchmarks/multimodal/sweep/experiments/epd/scripts/config.sh` exports `DYN_MM_IMAGE_CACHE_SIZE=0` for both the vLLM and SGLang EPD topologies. The guard is in the shared loader, so the SGLang encode worker and the frontend get the same behaviour.

Two tests cover the boundary. `test_vllm_encode_worker_decoded.py` runs the real `EncodeWorkerHandler.__init__` with the model-loading dependencies stubbed and asserts observable capacity: `2` when the variable is `2`, and nothing retained when it is `0`. The file's existing helper builds handlers through `__new__` and skips `__init__`, which is why no test covered this line before. `test_media_connector.py` adds the loader-level case to `TestImageLoaderCache`.

`docs/fern/pages/recipes/cli-templates/vllm.mdx` rescopes the two table rows that document the variable. Both described it as frontend-only, which was accurate while the encode worker carried its own hardcoded capacity; now that every caller resolves the same default, the value reaches each component that loads images, and the rows say so and note that `0` disables caching. One cell in them still needs correcting: the documented default should read `32`, the value `launch/agg_multimodal_router_chat_processor.sh` and its XPU counterpart export at their line 64. `8` is only `ImageLoader`'s fallback when nothing exports the variable.

## Where should the reviewer start?

Start with `encode_worker_handler.py`; the fix itself is three lines. Then the `_cache_put` guard in `image_loader.py`, which is what makes `DYN_MM_IMAGE_CACHE_SIZE=0` a supported setting rather than a crash.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Image caching now honors the configured `DYN_MM_IMAGE_CACHE_SIZE` value, including its default setting.
  - Cache capacity and eviction behavior now consistently follow operator configuration.
  - Setting the cache size to zero or a negative value disables image caching without producing invalid eviction behavior.

- **Tests**
  - Added coverage for configured, default, and disabled cache settings, including eviction and handler cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->