### PR TITLE
fix(profiler): [cherry-pick 1.5.0] stop the RAPID naive fallback ignoring the declared workload size (#14205)

### DIFF
--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -139,6 +139,11 @@ def _generate_dgd_from_pick(
 # Fallback backend when AIC simulation is unavailable and no concrete backend is specified.
 _DEFAULT_NAIVE_BACKEND = "vllm"
 
+# build_naive_generator_params seeds its own SlaConfig with these; kept only
+# to detect and report substitution, since the declared values are forwarded.
+_NAIVE_GENERATOR_DEFAULT_ISL = 4000
+_NAIVE_GENERATOR_DEFAULT_OSL = 1000
+
 
 def _run_naive_fallback(
     dgdr: DynamoGraphDeploymentRequestSpec,
@@ -146,6 +151,8 @@ def _run_naive_fallback(
     total_gpus: int,
     system: str,
     backend: str,
+    isl: int | None,
+    osl: int | None,
 ) -> dict:
     """Handle the AIC-unsupported path via naive config generation."""
     if backend == "auto":
@@ -172,11 +179,32 @@ def _run_naive_fallback(
         backend,
     )
 
+    # WorkloadSpec.isl/osl are Optional and an explicit null reaches here intact,
+    # so substitute the generator's own defaults rather than overriding with None.
+    if isl is None:
+        isl = _NAIVE_GENERATOR_DEFAULT_ISL
+    if osl is None:
+        osl = _NAIVE_GENERATOR_DEFAULT_OSL
+
+    if isl != _NAIVE_GENERATOR_DEFAULT_ISL or osl != _NAIVE_GENERATOR_DEFAULT_OSL:
+        logger.warning(
+            "Declared workload (isl=%d, osl=%d) differs from the naive generator "
+            "defaults (isl=%d, osl=%d); forwarding the declared values so the "
+            "generated worker is sized for the requested sequence length.",
+            isl,
+            osl,
+            _NAIVE_GENERATOR_DEFAULT_ISL,
+            _NAIVE_GENERATOR_DEFAULT_OSL,
+        )
+
+    # The generator derives max_seq_len from SlaConfig during generation, so the
+    # declared workload must be an input; patching the params after is too late.
     generator_params = build_naive_generator_params(
         model_name=model,
         total_gpus=total_gpus,
         system_name=system,
         backend_name=backend,
+        generator_overrides={"SlaConfig": {"isl": isl, "osl": osl}},
     )
 
     k8s_overrides = _build_k8s_overrides(dgdr, backend)
@@ -377,7 +405,7 @@ def run_rapid(
     ``best_config_df``, ``best_latencies``, and ``dgd_config``.
     """
     if not aic_supported:
-        return _run_naive_fallback(dgdr, model, total_gpus, system, backend)
+        return _run_naive_fallback(dgdr, model, total_gpus, system, backend, isl, osl)
     if picking_mode == "autoscale":
         return _run_autoscale_sim(
             dgdr,

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
@@ -1327,6 +1327,8 @@ class TestNaiveFallbackResolvedBackend:
                 total_gpus=8,
                 system="h200_sxm",
                 backend="auto",
+                isl=4000,
+                osl=1000,
             )
 
         # The resolved backend must be a concrete name, not 'auto'
@@ -1374,6 +1376,8 @@ class TestNaiveFallbackResolvedBackend:
                 total_gpus=8,
                 system="h200_sxm",
                 backend="vllm",
+                isl=4000,
+                osl=1000,
             )
 
         assert result.get("resolved_backend") == "vllm"
@@ -1407,6 +1411,8 @@ class TestNaiveFallbackResolvedBackend:
                 total_gpus=8,
                 system="h200_sxm",
                 backend="vllm",
+                isl=4000,
+                osl=1000,
             )
 
         assert result.get("chosen_exp") == "agg"

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_rapid.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_rapid.py
@@ -85,7 +85,9 @@ class TestRunNaiveFallback:
                 return_value={},
             ),
         ):
-            result = _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm")
+            result = _run_naive_fallback(
+                dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm", 4000, 1000
+            )
 
         assert set(result) >= {
             "best_config_df",
@@ -117,7 +119,9 @@ class TestRunNaiveFallback:
                 return_value={},
             ),
         ):
-            result = _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm")
+            result = _run_naive_fallback(
+                dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm", 4000, 1000
+            )
         assert result["dgd_config"] is None
 
     @pytest.mark.pre_merge
@@ -136,7 +140,7 @@ class TestRunNaiveFallback:
             ),
             caplog.at_level(logging.WARNING),
         ):
-            _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm")
+            _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm", 4000, 1000)
 
         assert "SLA is unverified (ttft=1.0ms, itl=1.0ms)" in caplog.text
         assert "model=Qwen/Qwen3-32B, system=l40s, backend=vllm" in caplog.text
@@ -158,7 +162,7 @@ class TestRunNaiveFallback:
             ),
             caplog.at_level(logging.WARNING),
         ):
-            _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm")
+            _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm", 4000, 1000)
 
         assert "SLA is unverified (e2eLatency=35000.0ms)" in caplog.text
         assert "ttft=" not in caplog.text
@@ -180,7 +184,7 @@ class TestRunNaiveFallback:
             ),
             caplog.at_level(logging.WARNING),
         ):
-            _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm")
+            _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm", 4000, 1000)
 
         assert "SLA is unverified (requested SLA)" in caplog.text
         assert "ttft=" not in caplog.text
@@ -215,7 +219,7 @@ class TestRunNaiveFallback:
                 side_effect=fake_generate,
             ),
         ):
-            _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm")
+            _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm", 4000, 1000)
 
         k8s = captured_params.get("K8sConfig", {})
         assert k8s.get("k8s_pvc_name") == "model-cache"
@@ -254,7 +258,9 @@ class TestRunNaiveFallback:
                 side_effect=fake_generate,
             ),
         ):
-            _run_naive_fallback(dgdr, "Qwen/Qwen3-0.6B", 4, "a100_pcie", "vllm")
+            _run_naive_fallback(
+                dgdr, "Qwen/Qwen3-0.6B", 4, "a100_pcie", "vllm", 4000, 1000
+            )
 
         k8s = captured_params.get("K8sConfig", {})
         assert k8s.get("k8s_pvc_mount_path") == "/opt/models"
@@ -291,7 +297,9 @@ class TestRunNaiveFallback:
                 side_effect=fake_generate,
             ),
         ):
-            _run_naive_fallback(dgdr, "Qwen/Qwen3-0.6B", 4, "a100_pcie", "vllm")
+            _run_naive_fallback(
+                dgdr, "Qwen/Qwen3-0.6B", 4, "a100_pcie", "vllm", 4000, 1000
+            )
 
         k8s = captured_params.get("K8sConfig", {})
         assert k8s.get("k8s_pvc_name") == "model-cache"
@@ -321,11 +329,94 @@ class TestRunNaiveFallback:
                 side_effect=fake_generate,
             ),
         ):
-            _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm")
+            _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm", 4000, 1000)
 
         k8s = captured_params.get("K8sConfig", {})
         assert "k8s_pvc_name" not in k8s
         assert "k8s_pvc_mount_path" not in k8s
+
+
+class TestRunNaiveFallbackWorkloadForwarding:
+    """The declared workload must reach the naive generator as an input.
+
+    ``build_naive_generator_params`` seeds its own ``SlaConfig`` with
+    ``isl=4000`` / ``osl=1000`` and the backend rule plugin derives
+    ``max_seq_len`` from that section *during* generation. A declared workload
+    that never reaches the generator therefore produces a worker sized for the
+    generator's defaults, which cannot hold the requested sequence — the
+    defect this class guards against.
+    """
+
+    @staticmethod
+    def _run(dgdr, isl, osl):
+        """Invoke the fallback, returning the generator's kwargs and params."""
+        captured_kwargs: dict = {}
+        captured_params: dict = {}
+
+        def fake_build(**kwargs):
+            captured_kwargs.update(kwargs)
+            return copy.deepcopy(_FAKE_GENERATOR_PARAMS)
+
+        def fake_generate(params, backend, use_dynamo_generator=False):
+            captured_params.update(params)
+            return {
+                "k8s_deploy.yaml": "kind: DGD\nmetadata:\n  name: test\nspec:\n  services: {}"
+            }
+
+        with (
+            patch(
+                "dynamo.profiler.rapid.build_naive_generator_params",
+                side_effect=fake_build,
+            ),
+            patch(
+                "dynamo.profiler.rapid.generate_backend_artifacts",
+                side_effect=fake_generate,
+            ),
+        ):
+            result = _run_naive_fallback(
+                dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm", isl, osl
+            )
+        return result, captured_kwargs, captured_params
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_declared_workload_is_forwarded_to_generator(self, caplog):
+        """A non-default declared workload reaches the generator's SlaConfig."""
+        dgdr = _make_dgdr(workload=WorkloadSpec(isl=7200, osl=2000))
+        with caplog.at_level(logging.WARNING):
+            _, captured_kwargs, _ = self._run(dgdr, 7200, 2000)
+
+        assert captured_kwargs.get("generator_overrides") == {
+            "SlaConfig": {"isl": 7200, "osl": 2000}
+        }
+        assert "Declared workload (isl=7200, osl=2000)" in caplog.text
+        assert "defaults (isl=4000, osl=1000)" in caplog.text
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_default_workload_forwards_defaults_without_warning(self, caplog):
+        """Default workload is forwarded without a substitution warning."""
+        dgdr = _make_dgdr(workload=WorkloadSpec(isl=4000, osl=1000))
+        with caplog.at_level(logging.WARNING):
+            _, captured_kwargs, _ = self._run(dgdr, 4000, 1000)
+
+        assert captured_kwargs.get("generator_overrides") == {
+            "SlaConfig": {"isl": 4000, "osl": 1000}
+        }
+        assert "Declared workload" not in caplog.text
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_absent_workload_lengths_fall_back_to_generator_defaults(self, caplog):
+        """An explicit null sequence length must not override the defaults."""
+        dgdr = _make_dgdr(workload=WorkloadSpec(isl=None, osl=None))
+        with caplog.at_level(logging.WARNING):
+            _, captured_kwargs, _ = self._run(dgdr, None, None)
+
+        assert captured_kwargs.get("generator_overrides") == {
+            "SlaConfig": {"isl": 4000, "osl": 1000}
+        }
+        assert "Declared workload" not in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -299,6 +299,85 @@ def test_build_dgd_config_vllm_disagg_removes_legacy_role_flags() -> None:
         assert args[args.index("--disaggregation-mode") + 1] == expected_mode
 
 
+@pytest.mark.parametrize("mode", ["agg", "disagg"])
+def test_build_dgd_config_vllm_drops_generated_max_model_len(mode: str) -> None:
+    """A generated context cap would pin the deployment to one target ISL/OSL."""
+    modifier = CONFIG_MODIFIERS["vllm"]
+    worker_args = [
+        "--max-model-len",
+        "6500",
+        "--tensor-parallel-size",
+        "2",
+        "--max-model-len=6500",
+    ]
+    dgd_config = modifier.build_dgd_config(
+        mode=mode,
+        model_name="test/model",
+        image="example/vllm:test",
+        prefill_cli_args=list(worker_args),
+        decode_cli_args=list(worker_args),
+        agg_cli_args=list(worker_args),
+    )
+
+    workers = _worker_components(dgd_config)
+    assert workers
+    for worker in workers:
+        args = _main_container(worker)["args"]
+        assert not any(str(arg).startswith("--max-model-len") for arg in args)
+        assert args[args.index("--tensor-parallel-size") + 1] == "2"
+
+
+def test_materialize_dgd_keeps_overridden_max_model_len() -> None:
+    """An explicit context cap is merged after generation and stays intact."""
+    from dynamo.profiler.utils.dgd_materialization import (
+        DGDMaterializationPurpose,
+        materialize_dgd,
+    )
+
+    modifier = CONFIG_MODIFIERS["vllm"]
+    blueprint = modifier.build_dgd_config(
+        mode="agg",
+        model_name="test/model",
+        image="example/vllm:test",
+        agg_cli_args=["--max-model-len", "6500", "--tensor-parallel-size", "1"],
+    )
+
+    def _fake_apply_dgd_overrides(dgd_config: dict, overrides: dict) -> dict:
+        merged = copy.deepcopy(dgd_config)
+        for component in merged["spec"]["components"]:
+            if component.get("type") in ("worker", "prefill", "decode"):
+                _main_container(component)["args"] += ["--max-model-len", "4096"]
+        return merged
+
+    with (
+        patch(
+            "dynamo.profiler.utils.dgd_materialization.apply_dgd_overrides",
+            side_effect=_fake_apply_dgd_overrides,
+        ),
+        patch(
+            "dynamo.profiler.utils.config_modifiers.vllm.get_model_context_length",
+            return_value=8192,
+        ),
+        patch(
+            "dynamo.profiler.utils.dgd_materialization.model_has_auto_map",
+            return_value=False,
+        ),
+    ):
+        result = materialize_dgd(
+            blueprint,
+            purpose=DGDMaterializationPurpose.FINAL_OUTPUT,
+            override={"spec": {"services": {}}},
+            runtime_backend="vllm",
+            model_name_or_path="test/model",
+        )
+
+    workers = _worker_components(result)
+    assert workers
+    for worker in workers:
+        args = _main_container(worker)["args"]
+        assert args[args.index("--max-model-len") + 1] == "4096"
+
+
 def test_build_dgd_config_shapes_multinode_worker_resources() -> None:
     """DP-only workers keep per-node GPU shaping without multinode inflation."""
     modifier = CONFIG_MODIFIERS["sglang"]

--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -221,6 +221,29 @@ def remove_valued_arguments(args: list[str], key: str) -> list[str]:
     return args
 
 
+def remove_all_argument_occurrences(args: list[str], arg_name: str) -> list[str]:
+    """Drop every occurrence of a valued argument in both CLI spellings.
+
+    Handles ``--arg value`` and ``--arg=value``, and returns a new list rather
+    than mutating the input. Unlike :func:`remove_valued_arguments`, no
+    occurrence survives, so the backend parser cannot consume a duplicate that
+    an earlier removal left behind.
+    """
+    filtered: list[str] = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == arg_name:
+            index += 2 if index + 1 < len(args) else 1
+            continue
+        if isinstance(arg, str) and arg.startswith(f"{arg_name}="):
+            index += 1
+            continue
+        filtered.append(arg)
+        index += 1
+    return filtered
+
+
 def sanitize_cli_args(args: list[str]) -> list[str]:
     """Strip valued arguments whose value is the literal string ``"None"``.
 
@@ -557,20 +580,9 @@ def set_unique_argument_value(args: list[str], arg_name: str, value: str) -> lis
     for identity-bearing arguments where appended DGD overrides must not leave
     a later conflicting value for the backend parser to consume.
     """
-    filtered: list[str] = []
-    index = 0
-    while index < len(args):
-        arg = args[index]
-        if arg == arg_name:
-            index += 2 if index + 1 < len(args) else 1
-            continue
-        if isinstance(arg, str) and arg.startswith(f"{arg_name}="):
-            index += 1
-            continue
-        filtered.append(arg)
-        index += 1
-
-    return append_argument(filtered, [arg_name, value])
+    return append_argument(
+        remove_all_argument_occurrences(args, arg_name), [arg_name, value]
+    )
 
 
 def set_unique_env_value(

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -29,6 +29,7 @@ from dynamo.profiler.utils.config import (
     get_component_by_name,
     get_component_name_by_type,
     get_main_container,
+    remove_all_argument_occurrences,
     sanitize_cli_args,
     set_unique_argument_value,
     setup_worker_component_resources,
@@ -171,6 +172,14 @@ class BaseConfigModifier:
     # Worker CLI arg name for model path / name. vLLM uses "--model"; others use "--model-path".
     WORKER_MODEL_PATH_ARG: str = "--model-path"
     WORKER_SERVED_MODEL_NAME_ARG: str = "--served-model-name"
+
+    # Worker CLI args that cap the context window. An external generator derives
+    # these from one workload's target sequence lengths, which would leave the
+    # deployment unable to serve a longer request the model itself supports, so
+    # they are dropped from generated args and the engine default applies. A
+    # value set in `spec.overrides.dgd` is merged after generation and survives.
+    # Subclasses declare the arg their backend reads.
+    GENERATED_CONTEXT_LENGTH_ARGS: tuple[str, ...] = ()
 
     @classmethod
     def _get_model_name_and_path_from_args(cls, args: list[str]) -> Tuple[str, str]:
@@ -608,8 +617,23 @@ class BaseConfigModifier:
                 return component.name
         return None
 
-    @staticmethod
+    @classmethod
+    def _drop_generated_context_length_args(cls, args: list[str]) -> list[str]:
+        """Drop context-window caps a generator derived from the target ISL/OSL."""
+        for arg_name in cls.GENERATED_CONTEXT_LENGTH_ARGS:
+            remaining = remove_all_argument_occurrences(args, arg_name)
+            if remaining != args:
+                logger.info(
+                    "Dropping generated %s so the worker keeps the engine default; "
+                    "set it in spec.overrides.dgd to pin an explicit value.",
+                    arg_name,
+                )
+            args = remaining
+        return args
+
+    @classmethod
     def _apply_worker_config(
+        cls,
         component: Component,
         cli_args: list[str],
         replicas: int,
@@ -618,7 +642,9 @@ class BaseConfigModifier:
     ) -> None:
         """Apply CLI args, replicas, and GPU resources to one worker component."""
         component.replicas = replicas
-        get_main_container(component).args = sanitize_cli_args(list(cli_args))
+        get_main_container(component).args = cls._drop_generated_context_length_args(
+            sanitize_cli_args(list(cli_args))
+        )
 
         # Apply resources after args so multinode sizing can inspect final TP/PP flags.
         setup_worker_component_resources(component, gpus, num_gpus_per_node)

--- a/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
@@ -115,6 +115,8 @@ class VllmV1ConfigModifier(BaseConfigModifier):
     BACKEND = "vllm"
     # vllm uses a different arg for model path
     WORKER_MODEL_PATH_ARG = "--model"
+    # vllm reads the context window cap from --max-model-len
+    GENERATED_CONTEXT_LENGTH_ARGS = ("--max-model-len",)
 
     @classmethod
     def load_default_config(cls, mode: str = "disagg") -> dict:


### PR DESCRIPTION
Cherry-pick of #14205 to `release/1.5.0`.

Preserves declared `spec.workload.isl` and `spec.workload.osl` when RAPID falls back to naive generation.

Signed-off cherry-pick with `-x --signoff -m 1`.