### PR TITLE
docs(kubernetes): check existing platforms before quickstart

### DIFF
--- a/docs/fern/pages/kubernetes/getting-started/quickstart.mdx
+++ b/docs/fern/pages/kubernetes/getting-started/quickstart.mdx
@@ -34,7 +34,32 @@ follow that tab throughout the guide. The Intel GPU path uses the XPU runtime an
     </Tabs>
   </Step>
 
+  <Step title="Check for an existing Dynamo platform">
+    Before installing anything, inventory Helm releases, operator images, and Dynamo Custom
+    Resource Definitions (CRDs). These commands do not change the cluster:
+
+```bash
+helm list --all-namespaces --all
+kubectl get deployments --all-namespaces \
+  -o 'custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,IMAGES:.spec.template.spec.containers[*].image'
+kubectl get crd dynamographdeployments.nvidia.com \
+  dynamographdeploymentrequests.nvidia.com --ignore-not-found
+```
+
+    If Dynamo is already installed, record its release name, namespace, chart version, and operator
+    image. Follow [Existing Platforms](../installation/install-dynamo.md#existing-platforms) to
+    confirm its scope and version before continuing. If you cannot inventory all namespaces, or
+    find Dynamo resources without a known owner, stop and ask the cluster administrator.
+
+<Warning>
+Run only one cluster-wide Dynamo operator. A different release name or namespace is not a way to
+install a second one. Do not apply this guide's manifests to an older operator without checking
+the installed API schema.
+</Warning>
+  </Step>
+
   <Step title="Install accelerator support">
+    Skip this step if your cluster administrator has already configured accelerator support.
     <Tabs>
       <Tab title="NVIDIA GPU">
         Install the NVIDIA GPU Operator:
@@ -66,20 +91,50 @@ kubectl get resourceslices
     </Tabs>
   </Step>
 
-  <Step title="Install Dynamo">
-    Use the `DYNAMO_VERSION` value from the selector above to install the Dynamo platform chart in a dedicated namespace. Helm creates the namespace for you:
+  <Step title="Install or reuse Dynamo">
+    Choose the path established by the preflight. Keep the model workload separate from the
+    platform namespace:
 
 ```bash
-export NAMESPACE=dynamo-system
+export NAMESPACE=dynamo-quickstart
+```
 
-helm upgrade --install dynamo-platform \
+    <Tabs>
+      <Tab title="No existing platform">
+        Only if the inventory found no existing Dynamo platform or CRDs, install the version
+        selected above. Use `helm install` so this step cannot upgrade an existing release:
+
+```bash
+export PLATFORM_NAMESPACE=dynamo-system
+
+helm install dynamo-platform \
   "https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-${DYNAMO_VERSION}.tgz" \
-  --namespace "$NAMESPACE" \
+  --namespace "$PLATFORM_NAMESPACE" \
   --create-namespace \
   --wait \
   --timeout=10m
 
-kubectl get pods --namespace "$NAMESPACE"
+kubectl get pods --namespace "$PLATFORM_NAMESPACE"
+```
+      </Tab>
+      <Tab title="Existing platform">
+        Reuse the cluster-wide operator without running a Helm install or upgrade. Confirm with
+        its owner that the operator and CRDs match the selected `DYNAMO_VERSION`, the operator is
+        healthy, and no namespace-restricted operator owns `dynamo-quickstart`.
+
+        If versions differ, stop here. Select the installed release's documentation and obtain
+        manifests from that release's Git tag, or have the platform owner review
+        [Upgrade Checks](../installation/install-dynamo.md#upgrade-checks)
+        before upgrading the existing release. Changing only the image tag does not make an
+        older CRD accept newer fields such as `spec.runtimeVersionOverride`. Validate the chosen
+        manifests with `kubectl apply --dry-run=server` before applying them.
+      </Tab>
+    </Tabs>
+
+    Create the workload namespace, or use an existing namespace approved by the platform owner:
+
+```bash
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
 ```
 
     For the NVIDIA GPU DGDR path, `DYNAMO_IMAGE` points to the Dynamo planner image from the selector above. The planner profiles the model and creates the worker deployment; you do not need to choose a separate runtime image for that path.
@@ -213,11 +268,14 @@ curl --silent --show-error http://localhost:8000/v1/chat/completions \
 ## What You Did
 
 - Installed the accelerator support required by your hardware.
-- Installed the Dynamo platform on your Kubernetes cluster.
+- Installed or reused the Dynamo platform on your Kubernetes cluster.
 - Created either a DGDR that generated a DGD, or a DGD directly.
 - Sent an OpenAI-compatible request to the deployed model.
 
 ## Clean Up
+
+The commands below remove only the quickstart workload. Do not uninstall a shared platform or
+delete its CRDs as part of this cleanup.
 
 Stop the port-forward and remove the quickstart deployment:
 

--- a/docs/fern/pages/kubernetes/installation/install-dynamo.md
+++ b/docs/fern/pages/kubernetes/installation/install-dynamo.md
@@ -46,6 +46,54 @@ kubectl version --client
 helm version
 ```
 
+## Existing Platforms
+
+Before installing the chart, run the [Quickstart preflight](../getting-started/quickstart.mdx).
+For an existing Helm-managed operator, inspect its release using the name and namespace from
+`helm list --all-namespaces --all`:
+
+```bash
+helm status "$PLATFORM_RELEASE" --namespace "$PLATFORM_NAMESPACE"
+helm get values "$PLATFORM_RELEASE" --namespace "$PLATFORM_NAMESPACE" --all
+```
+
+Set `PLATFORM_RELEASE` and `PLATFORM_NAMESPACE` to the discovered values before running these
+commands. Treat Helm values as private configuration; they may contain credentials.
+
+Confirm `dynamo-operator.namespaceRestriction.enabled` is `false` for the cluster-wide operator.
+A namespace-restricted operator is a development/test controller, not a replacement for the
+cluster-wide operator that owns CRDs and conversion webhooks. Check with the platform owner
+before using a namespace managed by a restricted operator. For installations managed outside
+Helm, have their owner verify the operator configuration and CRD version.
+
+Reuse a healthy, matching-version platform for the Quickstart. Keep the workload namespace
+separate from `PLATFORM_NAMESPACE`; do not reinstall Dynamo under another release name. If the
+installed release differs from the selected documentation version, stop before creating workload
+resources. Use the installed release's documentation and manifests, or plan an upgrade with the
+platform owner. A successful server-side dry run validates admission, not runtime compatibility.
+
+### Upgrade Checks
+
+The Quickstart is not a platform upgrade or rollback procedure. Before changing an existing
+release, the platform owner must review the target release's
+[chart upgrade notes](https://github.com/ai-dynamo/dynamo/blob/main/deploy/helm/charts/platform/README.md)
+and [release notes](../../reference/general/releases/release-history.mdx), including:
+
+- Preserve and review the existing Helm values, image overrides, and external service settings.
+  Do not apply the Quickstart's fresh-install defaults to a shared release.
+- Decide whether to retain bundled NATS with `global.nats.install=true` or preserve external
+  `dynamo-operator.natsAddr`. Removing NATS settings can trigger workload rollouts and break
+  explicitly selected NATS transports.
+- Check mandatory admission webhooks, certificates, and the target release's CRD conversion and
+  migration requirements. Do not delete CRDs to resolve installation conflicts.
+- Match Grove to the target Dynamo release using the
+  [multinode compatibility matrix](#multinode). Do not upgrade one independently of the other.
+- Validate the operator, webhooks, and existing workloads after the upgrade, then server-side
+  dry-run new workload manifests before applying them.
+- Agree on recovery steps before upgrading. Do not assume `helm rollback` restores migrated CRDs
+  or stored custom resources; retain the previous configuration and verify downgrade support for
+  the specific release transition.
+
 ## Overview
 
 Every Dynamo deployment requires accelerator support and the **Dynamo Platform**. NVIDIA GPU clusters can use the NVIDIA GPU Operator. Intel GPU clusters use the Intel resource driver with DRA. The Dynamo Platform installation is the same after the cluster exposes its accelerator resources. Everything else is optional.


### PR DESCRIPTION
## Summary

Address the existing-platform preflight in #14074. The Kubernetes Quickstart now inventories releases, operator images, and Dynamo CRDs before installation, distinguishes fresh installation from reuse, and stops on version mismatches or unknown ownership. It keeps the workload namespace separate from the platform namespace and uses `helm install` instead of an implicit upgrade.

The Installation Guide collects scope checks and upgrade considerations for existing Helm values, NATS, required webhooks, CRD conversion, Grove compatibility, validation, and rollback limitations. This does not add a new upgrade mechanism or claim a generic Helm rollback is safe.

## Details

The preflight is read-only. Existing installations are not changed by the inventory. Readers who lack cluster-wide visibility or cannot identify the resource owner must stop rather than infer that the platform is absent. Existing-platform users are directed to release-matched manifests and server-side dry runs, not just newer image tags.

## Where should the reviewer start?

`docs/fern/pages/kubernetes/getting-started/quickstart.mdx`, then the new Existing Platforms section in `docs/fern/pages/kubernetes/installation/install-dynamo.md`.

## Related Issues

Addresses #14074. The target-release upgrade checks are guidance for the platform owner, not an end-to-end tested production upgrade/rollback runbook.

## Validation

- Docs lint: passed, 0 errors. Eight existing warnings remain elsewhere in the site.
- `fern check` with the repository-pinned Fern 5.80.2: passed, 0 errors and 2 warnings, after generating the gitignored Python/Rust API reference pages.
- All five new or changed shell blocks pass `bash -n`; all 16 Quickstart shell blocks also pass.
- All applicable pre-commit hooks passed for both edited files.
- `git diff --check`: passed.
- `fern docs broken-links`: one pre-existing error remains in `pages/recipes/model-recipes/deepseek-v4-pro-0813.mdx:254`, linking to `/dynamo/recipes/model-recipes/deepseek-v4-pro`. That page and the navigation are unchanged by this PR; the same link is present at base `946accea5edfd778f5120a3096b082e54e5bce2b`.

No Kubernetes/GPU cluster was available. Inventory and install/reuse commands were checked against the current chart and operator source, but a live cluster walkthrough, model serving, and platform upgrade/rollback were not performed. The five shell syntax checks are not a substitute for that deployment validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Kubernetes quickstart with preflight checks for existing Dynamo installations and CRDs.
  - Clarified separate setup paths for new and existing platforms, including version and operator-scope validation.
  - Documented workload isolation in the `dynamo-quickstart` namespace.
  - Clarified cleanup expectations so shared platform resources and CRDs are preserved.
  - Added upgrade guidance covering configuration, webhooks, CRD migrations, compatibility, validation, and rollback limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->