### PR TITLE
fix(operator): stop a replicated EPP failing to start when it reads its peer Service

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/epp.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/epp.yaml
@@ -47,6 +47,10 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "watch", "list"]
+# Peer Service lookup on replicated EPP startup (DYN_EPP_PEER_SERVICE)
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get"]
 # Dynamo k8s service discovery - endpointslices
 - apiGroups: ["discovery.k8s.io"]
   resources: ["endpointslices"]
@@ -92,6 +96,10 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "watch", "list"]
+# Peer Service lookup on replicated EPP startup (DYN_EPP_PEER_SERVICE)
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get"]
 # Dynamo k8s service discovery - endpointslices
 - apiGroups: ["discovery.k8s.io"]
   resources: ["endpointslices"]

--- a/deploy/helm/charts/platform/tests/epp_rbac_test.yaml
+++ b/deploy/helm/charts/platform/tests/epp_rbac_test.yaml
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# The EPP reads its own peer Service by name at startup when DYN_EPP_PEER_SERVICE
+# is set (ensure_peer_service_exists in deploy/inference-gateway/ext-proc). Without
+# a core-API services/get grant on the role bound to epp-serviceaccount, the API
+# server denies that read and the replicated EPP never becomes ready.
+#
+# `contains` matches a rule element exactly, so pinning verbs to ["get"] is also
+# the negative control: widening the grant (create/update/delete/patch, or a
+# wildcard) changes the element and fails these assertions.
+suite: EPP RBAC — core services/get for peer discovery
+templates:
+  - charts/dynamo-operator/templates/epp.yaml
+
+tests:
+  # ── cluster-wide mode (default) ──────────────────────────────────────────────
+
+  - it: grants get on core services in the ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - services
+            verbs:
+              - get
+        documentIndex: 0
+
+  - it: leaves the existing ClusterRole pod and endpointslice grants untouched
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - pods
+            verbs:
+              - get
+              - watch
+              - list
+        documentIndex: 0
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - discovery.k8s.io
+            resources:
+              - endpointslices
+            verbs:
+              - get
+              - list
+              - watch
+        documentIndex: 0
+
+  # ── namespace-restricted mode ────────────────────────────────────────────────
+
+  - it: grants get on core services in the namespace-restricted Role
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      dynamo-operator.upgradeCRD: false
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - services
+            verbs:
+              - get
+        documentIndex: 1
+
+  - it: leaves the existing Role pod and endpointslice grants untouched
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      dynamo-operator.upgradeCRD: false
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - pods
+            verbs:
+              - get
+              - watch
+              - list
+        documentIndex: 1
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - discovery.k8s.io
+            resources:
+              - endpointslices
+            verbs:
+              - get
+              - list
+              - watch
+        documentIndex: 1

--- a/deploy/helm/charts/platform/tests/epp_rbac_test.yaml
+++ b/deploy/helm/charts/platform/tests/epp_rbac_test.yaml
@@ -29,33 +29,6 @@ tests:
               - get
         documentIndex: 0
 
-  - it: leaves the existing ClusterRole pod and endpointslice grants untouched
-    asserts:
-      - contains:
-          path: rules
-          content:
-            apiGroups:
-              - ""
-            resources:
-              - pods
-            verbs:
-              - get
-              - watch
-              - list
-        documentIndex: 0
-      - contains:
-          path: rules
-          content:
-            apiGroups:
-              - discovery.k8s.io
-            resources:
-              - endpointslices
-            verbs:
-              - get
-              - list
-              - watch
-        documentIndex: 0
-
   # ── namespace-restricted mode ────────────────────────────────────────────────
 
   - it: grants get on core services in the namespace-restricted Role
@@ -72,34 +45,4 @@ tests:
               - services
             verbs:
               - get
-        documentIndex: 1
-
-  - it: leaves the existing Role pod and endpointslice grants untouched
-    set:
-      dynamo-operator.namespaceRestriction.enabled: true
-      dynamo-operator.upgradeCRD: false
-    asserts:
-      - contains:
-          path: rules
-          content:
-            apiGroups:
-              - ""
-            resources:
-              - pods
-            verbs:
-              - get
-              - watch
-              - list
-        documentIndex: 1
-      - contains:
-          path: rules
-          content:
-            apiGroups:
-              - discovery.k8s.io
-            resources:
-              - endpointslices
-            verbs:
-              - get
-              - list
-              - watch
         documentIndex: 1

--- a/deploy/helm/charts/platform/tests/epp_rbac_test.yaml
+++ b/deploy/helm/charts/platform/tests/epp_rbac_test.yaml
@@ -1,14 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# The EPP reads its own peer Service by name at startup when DYN_EPP_PEER_SERVICE
-# is set (ensure_peer_service_exists in deploy/inference-gateway/ext-proc). Without
-# a core-API services/get grant on the role bound to epp-serviceaccount, the API
-# server denies that read and the replicated EPP never becomes ready.
-#
-# `contains` matches a rule element exactly, so pinning verbs to ["get"] is also
-# the negative control: widening the grant (create/update/delete/patch, or a
-# wildcard) changes the element and fails these assertions.
+# EPP reads its peer Service at startup when DYN_EPP_PEER_SERVICE is set; without
+# core services/get the replicated EPP never becomes ready.
 suite: EPP RBAC — core services/get for peer discovery
 templates:
   - charts/dynamo-operator/templates/epp.yaml


### PR DESCRIPTION
## Overview:

A replicated Endpoint Picker (EPP) installed by the operator's Helm chart reads its own peer `Service` by name before it starts serving. The role the chart binds to `epp-serviceaccount` never granted read access to core `services`, so the API server denied that read and the EPP exited at startup with a `services is forbidden` error. This adds the missing grant, so a replicated EPP deployment with `DYN_EPP_PEER_SERVICE` set starts instead of crashing.

## Details:

`deploy/helm/charts/platform/components/operator/templates/epp.yaml` gains one rule — API group `""`, resource `services`, verb `get` — in both branches of the template: the namespaced `Role` used when `namespaceRestriction` is enabled, and the cluster-wide `ClusterRole` used by default. Both branches matter, because each install mode binds `epp-serviceaccount` to a different one. The verb is only `get`, since the call site issues a single namespaced read by name and needs no `list` or `watch`. No other role in the chart changes.

A new `helm unittest` suite, `deploy/helm/charts/platform/tests/epp_rbac_test.yaml`, renders the chart in each mode and asserts the rule is present. `contains` matches a rule element exactly, so the suite also fails if the grant is later widened.

## Validation:

- `make -C deploy/helm/charts/platform lint test` — passed. The two new tests fail when the template change is reverted.
- `pre-commit run --files deploy/helm/charts/platform/components/operator/templates/epp.yaml deploy/helm/charts/platform/tests/epp_rbac_test.yaml --hook-stage manual` — passed.

Not verified against a live cluster: the evidence is the rendered manifest, not an admission decision from a running API server.

## Where should the reviewer start?

`deploy/helm/charts/platform/components/operator/templates/epp.yaml` — check that the same rule landed in both the `Role` and the `ClusterRole` branch. Then `deploy/inference-gateway/ext-proc/src/peer_discovery.rs`, which makes the single `get` call this permission allows.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Tracked internally as `DYN-4310`; there is no public GitHub issue for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved replicated startup reliability by enabling peer discovery through Kubernetes Service resources.
  - Applied the fix to both namespace-restricted and cluster-wide deployments.

- **Tests**
  - Added coverage to verify the required Service read permissions in both RBAC configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->