### PR TITLE
fix(vllm): stop the embedding worker pool crashing at startup

### DIFF
--- a/components/src/dynamo/vllm/embedding_worker_processes.py
+++ b/components/src/dynamo/vllm/embedding_worker_processes.py
@@ -377,6 +377,17 @@ def _short_rpc_directory() -> tempfile.TemporaryDirectory:
     return rpc_directory
 
 
+def _unrecognized_launch_shape(detail: str) -> RuntimeError:
+    """Name the installed vLLM and the shape it yielded, not just the symptom."""
+    return RuntimeError(
+        f"vLLM {vllm.__version__} yields {detail} from launch_core_engines. "
+        f"This unpacking was verified against vLLM "
+        f"{' and '.join(_VERIFIED_VLLM_VERSIONS)}; the result shape has most "
+        "likely changed upstream and _unpack_core_engine_launch needs "
+        "updating to match."
+    )
+
+
 def _unpack_core_engine_launch(launch: Any) -> tuple[Any, Any, Any, Any]:
     """Normalize what ``launch_core_engines`` yields across vLLM releases.
 
@@ -386,6 +397,10 @@ def _unpack_core_engine_launch(launch: Any) -> tuple[Any, Any, Any, Any]:
     exist before 0.28.
     """
     if isinstance(launch, tuple):
+        if len(launch) != 4:
+            raise _unrecognized_launch_shape(
+                f"a {len(launch)}-tuple rather than the expected 4-tuple"
+            )
         return launch
     try:
         return (
@@ -395,13 +410,8 @@ def _unpack_core_engine_launch(launch: Any) -> tuple[Any, Any, Any, Any]:
             launch.tensor_queue,
         )
     except AttributeError as error:
-        raise RuntimeError(
-            f"vLLM {vllm.__version__} yields {type(launch).__name__} from "
-            f"launch_core_engines with no {error.name!r} attribute. This "
-            f"unpacking was verified against vLLM "
-            f"{' and '.join(_VERIFIED_VLLM_VERSIONS)}; the field has most "
-            "likely been renamed upstream and _unpack_core_engine_launch "
-            "needs updating to match."
+        raise _unrecognized_launch_shape(
+            f"a {type(launch).__name__} with no {error.name!r} attribute"
         ) from error
 
 

--- a/components/src/dynamo/vllm/embedding_worker_processes.py
+++ b/components/src/dynamo/vllm/embedding_worker_processes.py
@@ -25,6 +25,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable
 
+import vllm
 from vllm.config import VllmConfig
 from vllm.usage.usage_lib import UsageContext
 from vllm.v1.engine.async_llm import AsyncLLM
@@ -39,6 +40,10 @@ _PARENT_PID_ENV = "DYN_VLLM_EMBEDDING_PARENT_PID"
 _ENGINE_ADDRESSES_ENV = "DYN_VLLM_EMBEDDING_ENGINE_ADDRESSES"
 _CHILD_ROLE = "child"
 _RPC_BASE_PATH_ENV = "VLLM_RPC_BASE_PATH"
+# The two shapes _unpack_core_engine_launch accepts were read from these vLLM
+# releases: 0.27.1, which container/context.yaml builds the XPU images on, and
+# 0.28.0, the pin in pyproject.toml. Re-check that helper when either moves.
+_VERIFIED_VLLM_VERSIONS = ("0.27.1", "0.28.0")
 
 
 def is_embedding_process_child() -> bool:
@@ -375,21 +380,29 @@ def _short_rpc_directory() -> tempfile.TemporaryDirectory:
 def _unpack_core_engine_launch(launch: Any) -> tuple[Any, Any, Any, Any]:
     """Normalize what ``launch_core_engines`` yields across vLLM releases.
 
-    vLLM 0.28 yields a ``CoreEngineLaunch`` dataclass, which defines no
-    ``__iter__``; earlier releases, including the 0.27.1 that the XPU images
-    are built on, yield a plain 4-tuple. Duck-typing on the yielded object
-    rather than importing ``CoreEngineLaunch`` keeps both working: that name
-    does not exist before 0.28, so importing it would turn this into an
-    ``ImportError`` on the XPU images.
+    vLLM 0.28 and later yield a ``CoreEngineLaunch`` object defining no
+    ``__iter__``; earlier releases yield a plain 4-tuple. Duck-typing the
+    yielded object avoids importing ``CoreEngineLaunch``, a name that does not
+    exist before 0.28.
     """
     if isinstance(launch, tuple):
         return launch
-    return (
-        launch.engine_manager,
-        launch.coordinator,
-        launch.addresses,
-        launch.tensor_queue,
-    )
+    try:
+        return (
+            launch.engine_manager,
+            launch.coordinator,
+            launch.addresses,
+            launch.tensor_queue,
+        )
+    except AttributeError as error:
+        raise RuntimeError(
+            f"vLLM {vllm.__version__} yields {type(launch).__name__} from "
+            f"launch_core_engines with no {error.name!r} attribute. This "
+            f"unpacking was verified against vLLM "
+            f"{' and '.join(_VERIFIED_VLLM_VERSIONS)}; the field has most "
+            "likely been renamed upstream and _unpack_core_engine_launch "
+            "needs updating to match."
+        ) from error
 
 
 def create_shared_embedding_engine_client(

--- a/components/src/dynamo/vllm/embedding_worker_processes.py
+++ b/components/src/dynamo/vllm/embedding_worker_processes.py
@@ -372,6 +372,26 @@ def _short_rpc_directory() -> tempfile.TemporaryDirectory:
     return rpc_directory
 
 
+def _unpack_core_engine_launch(launch: Any) -> tuple[Any, Any, Any, Any]:
+    """Normalize what ``launch_core_engines`` yields across vLLM releases.
+
+    vLLM 0.28 yields a ``CoreEngineLaunch`` dataclass, which defines no
+    ``__iter__``; earlier releases, including the 0.27.1 that the XPU images
+    are built on, yield a plain 4-tuple. Duck-typing on the yielded object
+    rather than importing ``CoreEngineLaunch`` keeps both working: that name
+    does not exist before 0.28, so importing it would turn this into an
+    ``ImportError`` on the XPU images.
+    """
+    if isinstance(launch, tuple):
+        return launch
+    return (
+        launch.engine_manager,
+        launch.coordinator,
+        launch.addresses,
+        launch.tensor_queue,
+    )
+
+
 def create_shared_embedding_engine_client(
     *,
     vllm_config: VllmConfig,
@@ -438,8 +458,13 @@ def create_shared_embedding_engine_client(
                 executor_class,
                 not disable_log_stats,
                 addresses,
-                process_count,
-            ) as (engine_manager, coordinator, addresses, tensor_queue):
+            ) as core_engine_launch:
+                (
+                    engine_manager,
+                    coordinator,
+                    addresses,
+                    tensor_queue,
+                ) = _unpack_core_engine_launch(core_engine_launch)
                 if coordinator is not None or tensor_queue is not None:
                     raise RuntimeError(
                         "--embedding-worker-processes currently supports one "

--- a/components/src/dynamo/vllm/tests/test_embedding_worker_processes.py
+++ b/components/src/dynamo/vllm/tests/test_embedding_worker_processes.py
@@ -234,9 +234,8 @@ def test_parent_launches_n_minus_one_children_and_one_engine(monkeypatch, make_l
         children.append(child)
         return child
 
-    # The parameters mirror vLLM's own launch_core_engines signature exactly.
-    # A permissive *args stub here is what let a call with one argument too
-    # many pass this test while crashing at startup, so keep it strict.
+    # Mirrors vLLM's launch_core_engines signature exactly: no *args, so a
+    # call with the wrong arity fails here instead of at startup.
     @contextmanager
     def launch_context(vllm_config, executor_class, log_stats, addresses):
         yield make_launch(engine_manager, addresses)

--- a/components/src/dynamo/vllm/tests/test_embedding_worker_processes.py
+++ b/components/src/dynamo/vllm/tests/test_embedding_worker_processes.py
@@ -36,6 +36,25 @@ def _vllm_config():
     )
 
 
+def _core_engine_launch_object(engine_manager, addresses):
+    """The shape vLLM 0.28 yields: a ``CoreEngineLaunch`` dataclass.
+
+    Reproduced locally rather than imported, because the name does not exist
+    in the vLLM releases that yield the tuple below.
+    """
+    return SimpleNamespace(
+        engine_manager=engine_manager,
+        coordinator=None,
+        addresses=addresses,
+        tensor_queue=None,
+    )
+
+
+def _core_engine_launch_tuple(engine_manager, addresses):
+    """The shape vLLM yields before 0.28, including the 0.27.1 XPU images."""
+    return (engine_manager, None, addresses, None)
+
+
 def test_child_environment_offsets_system_port_by_index(monkeypatch):
     monkeypatch.setenv("DYN_SYSTEM_PORT", "19401")
     env = processes._child_environment(
@@ -193,7 +212,12 @@ def test_process_group_reports_unexpected_child_exit():
     group._stopping.set()
 
 
-def test_parent_launches_n_minus_one_children_and_one_engine(monkeypatch):
+@pytest.mark.parametrize(
+    "make_launch",
+    [_core_engine_launch_object, _core_engine_launch_tuple],
+    ids=["core-engine-launch-object", "legacy-tuple"],
+)
+def test_parent_launches_n_minus_one_children_and_one_engine(monkeypatch, make_launch):
     process_count = 4
     addresses = SimpleNamespace(
         inputs=[f"in{i}" for i in range(process_count)],
@@ -210,9 +234,12 @@ def test_parent_launches_n_minus_one_children_and_one_engine(monkeypatch):
         children.append(child)
         return child
 
+    # The parameters mirror vLLM's own launch_core_engines signature exactly.
+    # A permissive *args stub here is what let a call with one argument too
+    # many pass this test while crashing at startup, so keep it strict.
     @contextmanager
-    def launch_context(*_args, **_kwargs):
-        yield engine_manager, None, addresses, None
+    def launch_context(vllm_config, executor_class, log_stats, addresses):
+        yield make_launch(engine_manager, addresses)
 
     parent_client = Mock()
     parent_config = _vllm_config()

--- a/components/src/dynamo/vllm/tests/test_embedding_worker_processes.py
+++ b/components/src/dynamo/vllm/tests/test_embedding_worker_processes.py
@@ -212,6 +212,20 @@ def test_process_group_reports_unexpected_child_exit():
     group._stopping.set()
 
 
+def test_unpack_core_engine_launch_names_a_renamed_field():
+    """An upstream rename must say which field went missing."""
+    launch = SimpleNamespace(engine_manager=Mock(), coordinator=None, addresses=Mock())
+
+    with pytest.raises(RuntimeError) as raised:
+        processes._unpack_core_engine_launch(launch)
+
+    message = str(raised.value)
+    assert "tensor_queue" in message
+    for version in processes._VERIFIED_VLLM_VERSIONS:
+        assert version in message
+    assert isinstance(raised.value.__cause__, AttributeError)
+
+
 @pytest.mark.parametrize(
     "make_launch",
     [_core_engine_launch_object, _core_engine_launch_tuple],

--- a/components/src/dynamo/vllm/tests/test_embedding_worker_processes.py
+++ b/components/src/dynamo/vllm/tests/test_embedding_worker_processes.py
@@ -212,6 +212,11 @@ def test_process_group_reports_unexpected_child_exit():
     group._stopping.set()
 
 
+def _assert_names_verified_versions(message):
+    for version in processes._VERIFIED_VLLM_VERSIONS:
+        assert version in message
+
+
 def test_unpack_core_engine_launch_names_a_renamed_field():
     """An upstream rename must say which field went missing."""
     launch = SimpleNamespace(engine_manager=Mock(), coordinator=None, addresses=Mock())
@@ -221,9 +226,19 @@ def test_unpack_core_engine_launch_names_a_renamed_field():
 
     message = str(raised.value)
     assert "tensor_queue" in message
-    for version in processes._VERIFIED_VLLM_VERSIONS:
-        assert version in message
+    _assert_names_verified_versions(message)
     assert isinstance(raised.value.__cause__, AttributeError)
+
+
+@pytest.mark.parametrize("size", [3, 5], ids=["short-tuple", "long-tuple"])
+def test_unpack_core_engine_launch_rejects_a_resized_tuple(size):
+    """A tuple of the wrong arity must not reach the caller's four-name unpack."""
+    with pytest.raises(RuntimeError) as raised:
+        processes._unpack_core_engine_launch(tuple(range(size)))
+
+    message = str(raised.value)
+    assert f"{size}-tuple" in message
+    _assert_names_verified_versions(message)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Overview:

Starting a vLLM embedding worker pool with `--embedding-worker` and
`--embedding-worker-processes N` (N > 1) died during startup instead of reaching a
serving state. This change makes it start.

## Details:

The parent process brings up the shared `EngineCore` through vLLM's
`launch_core_engines`. One statement in
`components/src/dynamo/vllm/embedding_worker_processes.py` got two things wrong about
it.

It passed a fifth positional argument, `process_count`, to a function that declares
four, raising `TypeError: launch_core_engines() takes 4 positional arguments but 5 were
given`. That argument was redundant: the same value already reaches vLLM through
`vllm_config.parallel_config._api_process_count` and `get_engine_zmq_addresses`, neither
of which changes here.

It also tuple-unpacked what the context manager yields. On the pinned vLLM `0.28.0`
that is a `CoreEngineLaunch` dataclass with no `__iter__`, so dropping only the extra
argument moves the crash one line down to `TypeError: cannot unpack non-iterable
CoreEngineLaunch object`. A new module-private helper, `_unpack_core_engine_launch`,
reads the four values by duck-typing on the yielded object, so the pre-`0.28` 4-tuple
keeps working — `container/context.yaml` still builds the XPU images on vLLM `0.27.1`,
where the name `CoreEngineLaunch` does not exist and importing it would raise
`ImportError`.

Duck-typing is only safe while the two known shapes hold, so the helper says so when
they stop holding. Anything it does not recognise — an object missing one of the four
attributes, or a tuple of some other arity — raises a `RuntimeError` built by
`_unrecognized_launch_shape`, naming the installed vLLM version, the shape that was
actually yielded, and the releases the unpacking was verified against. Without that,
a renamed field escapes as a bare `AttributeError` and a resized tuple reaches the
caller's four-name unpack and escapes as a bare `ValueError`; neither says what
changed. The verified releases are recorded beside the other module constants as
`_VERIFIED_VLLM_VERSIONS = ("0.27.1", "0.28.0")`, so whoever next moves the pin in
`pyproject.toml` or the image tags in `container/context.yaml` knows what to re-check.

The existing test hid both defects: its `launch_core_engines` stub accepted `*_args`
and yielded a plain tuple. It now declares vLLM's four parameters exactly and is
parameterized over both yielded shapes. Further tests drive the helper with an object
missing `tensor_queue` and with three- and five-item tuples, asserting each message
names the offending shape and both verified versions.

## Validation:

```bash
pytest components/src/dynamo/vllm/tests/test_embedding_worker_processes.py -m 'unit and not gpu'
```

Passes, 16 tests, including the `legacy-tuple` case that covers the vLLM `0.27.1` shape
and the three cases that cover the diagnostic.

```bash
pre-commit run --files components/src/dynamo/vllm/embedding_worker_processes.py components/src/dynamo/vllm/tests/test_embedding_worker_processes.py
```

Passes; `isort`, `black`, `flake8`, `ruff`, and `codespell` all report clean on both
files.

## Where should the reviewer start?

`_unpack_core_engine_launch` and the `with launch_core_engines(...)` statement in
`components/src/dynamo/vllm/embedding_worker_processes.py`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedding engine startup compatibility across supported vLLM versions.
  * Startup now handles both legacy tuple results and newer structured launch results.
  * Added clearer validation and error messages when required launch information is missing.

* **Tests**
  * Added coverage for both launch-result formats.
  * Added validation for launch interface and argument handling.
  * Verified compatibility across supported vLLM versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->