### PR TITLE
fix(backend-common): track worker readiness on the runtime health route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,6 +2402,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serial_test",
  "temp-env",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2399,6 +2399,7 @@ dependencies = [
  "opentelemetry",
  "parking_lot",
  "prometheus",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "temp-env",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,6 +2401,7 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
+ "temp-env",
  "tokio",
  "tokio-util",
  "tracing",

--- a/lib/backend-common/Cargo.toml
+++ b/lib/backend-common/Cargo.toml
@@ -44,4 +44,5 @@ tracing-opentelemetry = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 tracing-subscriber = { workspace = true }

--- a/lib/backend-common/Cargo.toml
+++ b/lib/backend-common/Cargo.toml
@@ -45,5 +45,6 @@ tracing-opentelemetry = { workspace = true }
 [dev-dependencies]
 reqwest = { workspace = true }
 serde_json = { workspace = true }
+serial_test = "3"
 temp-env = { version = "0.3.6", features = ["async_closure"] }
 tracing-subscriber = { workspace = true }

--- a/lib/backend-common/Cargo.toml
+++ b/lib/backend-common/Cargo.toml
@@ -43,6 +43,7 @@ tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 
 [dev-dependencies]
+reqwest = { workspace = true }
 serde_json = { workspace = true }
 temp-env = { version = "0.3.6", features = ["async_closure"] }
 tracing-subscriber = { workspace = true }

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -1095,14 +1095,10 @@ impl Worker {
             })?;
         }
         // Readiness is this worker's to publish: it is not serviceable until every
-        // mandatory endpoint is registered and the engine routes are open. Take the
-        // hold before registration, so the runtime's own transport-registration
-        // signal cannot report ready ahead of the gate below.
-        endpoint
-            .drt()
-            .system_health()
-            .lock()
-            .hold_endpoint_readiness(endpoint.name());
+        // mandatory endpoint is registered and the engine routes are open. The
+        // hold suppresses the whole process's readiness, so covering the primary
+        // endpoint also covers the RL endpoint registered further down.
+        let readiness_hold = ReadinessHold::take(&endpoint, endpoint.name());
 
         let start_fut = builder.start_with_registration();
         tokio::pin!(start_fut);
@@ -1186,8 +1182,10 @@ impl Worker {
 
         // First instant the worker is serviceable: every mandatory endpoint is
         // registered, the token is uncancelled, and engine routes are open. The
-        // readiness hold taken before registration is what keeps the runtime's
-        // transport-registration signal from reporting ready before this point.
+        // hold taken before registration is what kept the runtime from reporting
+        // ready before this point; drop it here, because the write below
+        // publishes readiness through the very signal it suppresses.
+        drop(readiness_hold);
         set_worker_health(&endpoint, HealthStatus::Ready);
 
         let serve_fut = primary_endpoint.wait();
@@ -1333,6 +1331,40 @@ impl Worker {
     }
 }
 
+/// Withholds the runtime's transport-registration readiness signal for one
+/// endpoint until dropped, so the worker's own gate decides when that endpoint
+/// counts as ready.
+///
+/// Taking the hold *before* the endpoint registers is what makes this race-free
+/// on both request planes: the NATS path publishes readiness from a spawned
+/// task, so a write issued after registration returns would race it.
+///
+/// Never let one drop while the `SystemHealth` mutex is held — `Drop` takes that
+/// lock and it is not reentrant.
+struct ReadinessHold {
+    system_health: Arc<parking_lot::Mutex<dynamo_runtime::SystemHealth>>,
+    endpoint: String,
+}
+
+impl ReadinessHold {
+    fn take(endpoint: &dynamo_runtime::component::Endpoint, name: &str) -> Self {
+        let system_health = endpoint.drt().system_health();
+        system_health.lock().hold_endpoint_readiness(name);
+        Self {
+            system_health,
+            endpoint: name.to_string(),
+        }
+    }
+}
+
+impl Drop for ReadinessHold {
+    fn drop(&mut self) {
+        self.system_health
+            .lock()
+            .release_endpoint_readiness(&self.endpoint);
+    }
+}
+
 /// Publish worker readiness on both layers the runtime's health route reads.
 ///
 /// `SystemHealth::get_health_status` consults `use_endpoint_health_status`, then
@@ -1348,10 +1380,6 @@ impl Worker {
 fn set_worker_health(endpoint: &dynamo_runtime::component::Endpoint, status: HealthStatus) {
     let system_health = endpoint.drt().system_health();
     let mut system_health = system_health.lock();
-    // This call *is* the worker's readiness decision, so the startup hold has
-    // served its purpose; drop it before writing so later transport signals
-    // behave normally.
-    system_health.release_endpoint_readiness(endpoint.name());
     match status {
         HealthStatus::Ready => system_health.set_endpoint_registered(endpoint.name()),
         HealthStatus::NotReady => {

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -1847,7 +1847,6 @@ fn wrap_engine_control_callback(
                             "engine resumed but re-registration failed after /engine/control/{control_name}: {e}; retry /engine/control/{control_name} to rejoin discovery"
                         )));
                     }
-                    // Back in discovery and serving-safe, so routable again.
                     set_process_health(&endpoint, HealthStatus::Ready);
                     Ok(response)
                 }

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -1132,9 +1132,8 @@ impl Worker {
         // the exact primary discovery instance is callable.
         self.activate_engine_routes().await;
 
-        // Registration succeeded, no signal intervened, and the administrative
-        // routes are open: this is the first instant the worker is serviceable,
-        // so it is the first instant the health route may report ready.
+        // First instant the worker is serviceable: registered, not cancelled,
+        // and engine routes open. Nothing earlier may report ready.
         set_process_health(&endpoint, HealthStatus::Ready);
 
         let rl_endpoint = if let Some(rl_config) = rl_config {
@@ -1193,9 +1192,8 @@ impl Worker {
         // routes. No resume callback can re-register after the final unregister.
         self.begin_engine_route_shutdown().await;
 
-        // Symmetric with the ready write above: give readiness back before the
-        // orchestrator drains and unregisters, so a terminating worker stops
-        // advertising itself as ready while it is still winding down.
+        // Symmetric with the ready write: stop advertising ready before the
+        // orchestrator drains and unregisters.
         set_process_health(&endpoint, HealthStatus::NotReady);
 
         if let Some(rl_endpoint) = rl_endpoint

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -1132,16 +1132,11 @@ impl Worker {
         // the exact primary discovery instance is callable.
         self.activate_engine_routes().await;
 
-        // First instant the worker is serviceable: registered, not cancelled,
-        // and engine routes open. Nothing earlier may report ready.
-        set_process_health(&endpoint, HealthStatus::Ready);
-
         let rl_endpoint = if let Some(rl_config) = rl_config {
             match crate::rl::serve_endpoint(&endpoint, rl_config).await {
                 Ok(endpoint) => Some(endpoint),
                 Err(error) => {
                     self.begin_engine_route_shutdown().await;
-                    set_process_health(&endpoint, HealthStatus::NotReady);
                     if let Err(shutdown_error) = primary_endpoint.shutdown().await {
                         tracing::warn!(%shutdown_error, "primary endpoint shutdown failed");
                     }
@@ -1155,6 +1150,11 @@ impl Worker {
         } else {
             None
         };
+
+        // First instant the worker is serviceable: every mandatory endpoint is
+        // registered, the token is uncancelled, and engine routes are open.
+        // Nothing earlier may report ready.
+        set_process_health(&endpoint, HealthStatus::Ready);
 
         let serve_fut = primary_endpoint.wait();
         tokio::pin!(serve_fut);
@@ -1299,15 +1299,8 @@ impl Worker {
     }
 }
 
-/// Publish the process-wide readiness that the runtime's health route reports.
-///
-/// The route consults per-endpoint canary results first and only falls back to
-/// this process-wide status when no health-check target was registered — which
-/// is the default for a Rust backend, because [`LLMEngine::health_check_payload`]
-/// returns `None` unless an engine opts in. Without this write such a worker
-/// serves traffic while the health route reports not ready forever. Python
-/// workers reach the same status through their own bindings; this keeps the
-/// Rust path consistent with them.
+/// Set the process-wide health the runtime's health route falls back to when no
+/// endpoint canary target is registered.
 fn set_process_health(endpoint: &dynamo_runtime::component::Endpoint, status: HealthStatus) {
     endpoint
         .drt()
@@ -1758,6 +1751,11 @@ fn wrap_engine_control_callback(
                             "failed to unregister endpoint before /engine/control/{control_name}: {e}"
                         )));
                     }
+                    // Out of discovery, so no longer routable. Whether the
+                    // control itself then succeeds or fails, the endpoint is
+                    // left unregistered, so readiness stays withdrawn until a
+                    // resume control re-registers it.
+                    set_process_health(&endpoint, HealthStatus::NotReady);
 
                     let callback_result = tokio::select! {
                         biased;
@@ -1832,6 +1830,8 @@ fn wrap_engine_control_callback(
                             "engine resumed but re-registration failed after /engine/control/{control_name}: {e}; retry /engine/control/{control_name} to rejoin discovery"
                         )));
                     }
+                    // Back in discovery and serving-safe, so routable again.
+                    set_process_health(&endpoint, HealthStatus::Ready);
                     Ok(response)
                 }
             }
@@ -3939,9 +3939,6 @@ mod handoff_and_lifecycle_tests {
         (endpoint, system_health, worker, engine_config)
     }
 
-    /// Poll the process-wide health flag until it reaches `expected`, giving
-    /// the serve loop time to reach its serviceable point. Returns false if it
-    /// never does.
     async fn health_reaches(
         system_health: &Arc<parking_lot::Mutex<dynamo_runtime::SystemHealth>>,
         expected: bool,
@@ -3955,43 +3952,48 @@ mod handoff_and_lifecycle_tests {
         false
     }
 
-    /// Regression: a Rust sidecar never published a process-wide readiness, so
-    /// an engine that supplies no health-check payload served traffic while the
-    /// health route still reported not ready forever. This drives the real
-    /// serve path and reads the status back through the same runtime accessor
-    /// the route uses.
+    /// A pause control leaves the endpoint out of discovery, so readiness must
+    /// be withdrawn with it and restored only once a resume control has
+    /// re-registered.
     #[tokio::test]
-    async fn serving_worker_reports_ready_once_it_is_serviceable() {
-        let (endpoint, system_health, mut worker, engine_config) =
-            payload_free_serving_worker().await;
+    async fn engine_controls_track_readiness_with_discovery() {
+        let endpoint = test_local_endpoint().await;
+        let system_health = endpoint.drt().system_health();
+        let (engine, _) = HandoffMockEngine::new(
+            false,
+            vec!["sleep".to_string(), "wake_up".to_string()],
+            Vec::new(),
+        );
+        let worker = Worker::new(engine, WorkerConfig::default());
+        worker.register_engine_controls(&endpoint).await.unwrap();
+        worker.activate_engine_routes().await;
+        endpoint.register_endpoint_instance().await.unwrap();
+        set_process_health(&endpoint, HealthStatus::Ready);
+
+        let routes = endpoint.drt().engine_routes();
+        let response = routes.get("control/sleep").unwrap()(serde_json::json!({}))
+            .await
+            .unwrap();
+        assert_eq!(response, serde_json::json!({"status": "paused"}));
         assert!(
             !system_health.lock().get_health_status().0,
-            "a worker that has not reached its serviceable point must not report ready"
+            "an unregistered worker must not keep reporting ready"
         );
 
-        let shutdown = CancellationToken::new();
-        let serve = tokio::spawn({
-            let shutdown = shutdown.clone();
-            async move {
-                worker
-                    .serve_with_orchestrator(&engine_config, endpoint, shutdown)
-                    .await
-            }
-        });
-
-        let became_ready = health_reaches(&system_health, true).await;
-        shutdown.cancel();
-        let outcome = tokio::time::timeout(Duration::from_secs(120), serve).await;
+        let response = routes.get("control/wake_up").unwrap()(serde_json::json!({}))
+            .await
+            .unwrap();
+        assert_eq!(response, serde_json::json!({"status": "awake"}));
         assert!(
-            became_ready,
-            "worker must report ready once registration succeeded and engine routes opened; \
-             serve loop returned {outcome:?}"
+            system_health.lock().get_health_status().0,
+            "a re-registered worker must report ready again"
         );
+
+        worker.begin_engine_route_shutdown().await;
     }
 
-    /// Regression companion: readiness must be given back at the shutdown
-    /// boundary, so a draining worker stops advertising itself as ready before
-    /// the orchestrator unregisters it.
+    /// Ensures a payload-free Rust backend publishes process readiness while it
+    /// is serviceable and withdraws it again on shutdown.
     #[tokio::test]
     async fn shutdown_returns_the_serving_worker_to_not_ready() {
         let (endpoint, system_health, mut worker, engine_config) =

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -26,6 +26,7 @@ use dynamo_runtime::config::HealthStatus;
 use dynamo_runtime::engine_routes::EngineRouteCallback;
 use dynamo_runtime::pipeline::network::Ingress;
 use dynamo_runtime::protocols::EndpointId;
+use dynamo_runtime::system_health::ReadinessHold;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
 use dynamo_runtime::{DistributedRuntime, Runtime};
 use tokio_util::sync::CancellationToken;
@@ -1098,7 +1099,7 @@ impl Worker {
         // mandatory endpoint is registered and the engine routes are open. The
         // hold suppresses the whole process's readiness, so covering the primary
         // endpoint also covers the RL endpoint registered further down.
-        let readiness_hold = ReadinessHold::take(&endpoint, endpoint.name());
+        let readiness_hold = ReadinessHold::take(endpoint.drt().system_health(), endpoint.name());
 
         let start_fut = builder.start_with_registration();
         tokio::pin!(start_fut);
@@ -1328,40 +1329,6 @@ impl Worker {
             }
             tokio::time::sleep(Duration::from_secs_f64(DRAIN_POLL_INTERVAL_S)).await;
         }
-    }
-}
-
-/// Withholds the runtime's transport-registration readiness signal for one
-/// endpoint until dropped, so the worker's own gate decides when that endpoint
-/// counts as ready.
-///
-/// Taking the hold *before* the endpoint registers is what makes this race-free
-/// on both request planes: the NATS path publishes readiness from a spawned
-/// task, so a write issued after registration returns would race it.
-///
-/// Never let one drop while the `SystemHealth` mutex is held — `Drop` takes that
-/// lock and it is not reentrant.
-struct ReadinessHold {
-    system_health: Arc<parking_lot::Mutex<dynamo_runtime::SystemHealth>>,
-    endpoint: String,
-}
-
-impl ReadinessHold {
-    fn take(endpoint: &dynamo_runtime::component::Endpoint, name: &str) -> Self {
-        let system_health = endpoint.drt().system_health();
-        system_health.lock().hold_endpoint_readiness(name);
-        Self {
-            system_health,
-            endpoint: name.to_string(),
-        }
-    }
-}
-
-impl Drop for ReadinessHold {
-    fn drop(&mut self) {
-        self.system_health
-            .lock()
-            .release_endpoint_readiness(&self.endpoint);
     }
 }
 

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -1094,6 +1094,16 @@ impl Worker {
                 )
             })?;
         }
+        // Readiness is this worker's to publish: it is not serviceable until every
+        // mandatory endpoint is registered and the engine routes are open. Take the
+        // hold before registration, so the runtime's own transport-registration
+        // signal cannot report ready ahead of the gate below.
+        endpoint
+            .drt()
+            .system_health()
+            .lock()
+            .hold_endpoint_readiness(endpoint.name());
+
         let start_fut = builder.start_with_registration();
         tokio::pin!(start_fut);
         let primary_endpoint = tokio::select! {
@@ -1121,6 +1131,7 @@ impl Worker {
         // accepting administrative calls during shutdown.
         if shutdown.is_cancelled() {
             self.begin_engine_route_shutdown().await;
+            set_worker_health(&endpoint, HealthStatus::NotReady);
             if let Err(error) = primary_endpoint.shutdown().await {
                 tracing::warn!(%error, "primary endpoint shutdown failed");
             }
@@ -1174,8 +1185,9 @@ impl Worker {
         }
 
         // First instant the worker is serviceable: every mandatory endpoint is
-        // registered, the token is uncancelled, and engine routes are open.
-        // Nothing earlier may report ready.
+        // registered, the token is uncancelled, and engine routes are open. The
+        // readiness hold taken before registration is what keeps the runtime's
+        // transport-registration signal from reporting ready before this point.
         set_worker_health(&endpoint, HealthStatus::Ready);
 
         let serve_fut = primary_endpoint.wait();
@@ -1336,6 +1348,10 @@ impl Worker {
 fn set_worker_health(endpoint: &dynamo_runtime::component::Endpoint, status: HealthStatus) {
     let system_health = endpoint.drt().system_health();
     let mut system_health = system_health.lock();
+    // This call *is* the worker's readiness decision, so the startup hold has
+    // served its purpose; drop it before writing so later transport signals
+    // behave normally.
+    system_health.release_endpoint_readiness(endpoint.name());
     match status {
         HealthStatus::Ready => system_health.set_endpoint_registered(endpoint.name()),
         HealthStatus::NotReady => {
@@ -4043,6 +4059,7 @@ mod handoff_and_lifecycle_tests {
     /// be withdrawn with it and restored only once a resume control has
     /// re-registered.
     #[tokio::test]
+    #[serial_test::serial]
     async fn engine_controls_track_readiness_with_discovery() {
         with_each_health_route_shape(engine_controls_track_readiness_case).await;
     }
@@ -4083,9 +4100,97 @@ mod handoff_and_lifecycle_tests {
         worker.begin_engine_route_shutdown().await;
     }
 
+    /// The canary-backed row: with verification enabled and a target registered,
+    /// a resume must not publish endpoint readiness on the worker's say-so. This
+    /// is the one configuration where writing `Ready` straight to the endpoint
+    /// layer would differ from deferring to `set_endpoint_registered`.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn resume_defers_to_the_canary_when_a_target_is_registered() {
+        temp_env::async_with_vars(
+            [("DYN_HEALTH_CHECK_ENABLED", Some("true"))],
+            resume_defers_to_the_canary_case(),
+        )
+        .await;
+    }
+
+    async fn resume_defers_to_the_canary_case() {
+        let endpoint = test_local_endpoint().await;
+        let system_health = endpoint.drt().system_health();
+        assert!(
+            system_health.lock().health_check_enabled(),
+            "this case is only meaningful with canary verification enabled"
+        );
+        let instance = dynamo_runtime::component::Instance {
+            component: endpoint.component().name().to_string(),
+            endpoint: endpoint.name().to_string(),
+            namespace: "lifecycle_ns".to_string(),
+            instance_id: 1,
+            transport: dynamo_runtime::component::TransportType::Tcp("127.0.0.1:0".to_string()),
+            device_type: None,
+            request_plane_codec: None,
+        };
+        system_health.lock().register_health_check_target(
+            endpoint.name(),
+            instance,
+            serde_json::json!({}),
+        );
+
+        let (engine, _) = HandoffMockEngine::new(
+            false,
+            vec!["sleep".to_string(), "wake_up".to_string()],
+            Vec::new(),
+        );
+        let worker = Worker::new(engine, WorkerConfig::default());
+        worker.register_engine_controls(&endpoint).await.unwrap();
+        worker.activate_engine_routes().await;
+        endpoint.register_endpoint_instance().await.unwrap();
+
+        // The worker asserting readiness must not override an unverified canary.
+        set_worker_health(&endpoint, HealthStatus::Ready);
+        assert!(
+            !system_health.lock().get_health_status().0,
+            "a canary-backed endpoint must wait for verification, not the worker"
+        );
+
+        // Stand in for a successful canary probe.
+        system_health
+            .lock()
+            .set_endpoint_health_status(endpoint.name(), HealthStatus::Ready);
+        assert!(system_health.lock().get_health_status().0);
+
+        let routes = endpoint.drt().engine_routes();
+        routes.get("control/sleep").unwrap()(serde_json::json!({}))
+            .await
+            .unwrap();
+        assert!(
+            !system_health.lock().get_health_status().0,
+            "a paused worker must not keep reporting ready"
+        );
+
+        routes.get("control/wake_up").unwrap()(serde_json::json!({}))
+            .await
+            .unwrap();
+        assert!(
+            !system_health.lock().get_health_status().0,
+            "resume must leave readiness to the canary while a target is registered"
+        );
+
+        system_health
+            .lock()
+            .set_endpoint_health_status(endpoint.name(), HealthStatus::Ready);
+        assert!(
+            system_health.lock().get_health_status().0,
+            "the canary's verification is what restores readiness"
+        );
+
+        worker.begin_engine_route_shutdown().await;
+    }
+
     /// Ensures a payload-free Rust backend publishes readiness while it is
     /// serviceable and withdraws it again on shutdown.
     #[tokio::test]
+    #[serial_test::serial]
     async fn shutdown_returns_the_serving_worker_to_not_ready() {
         with_each_health_route_shape(shutdown_returns_the_serving_worker_to_not_ready_case).await;
     }
@@ -4125,6 +4230,7 @@ mod handoff_and_lifecycle_tests {
     /// `503 notready` to `200 ready` and back, so the wiring between this
     /// crate's readiness writes and the route a probe reads is covered too.
     #[tokio::test]
+    #[serial_test::serial]
     async fn the_health_route_follows_the_serving_worker() {
         use dynamo_runtime::config::environment_names::runtime::system::{
             DYN_SYSTEM_HOST, DYN_SYSTEM_PORT,

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -1137,6 +1137,7 @@ impl Worker {
                 Ok(endpoint) => Some(endpoint),
                 Err(error) => {
                     self.begin_engine_route_shutdown().await;
+                    set_worker_health(&endpoint, HealthStatus::NotReady);
                     if let Err(shutdown_error) = primary_endpoint.shutdown().await {
                         tracing::warn!(%shutdown_error, "primary endpoint shutdown failed");
                     }
@@ -1156,6 +1157,10 @@ impl Worker {
         // readiness that shutdown has already invalidated.
         if shutdown.is_cancelled() {
             self.begin_engine_route_shutdown().await;
+            // Engine routes have been open since `activate_engine_routes`, so a
+            // resume control may already have published readiness. Withdraw it
+            // here as the serve loop's own teardown does.
+            set_worker_health(&endpoint, HealthStatus::NotReady);
             if let Some(rl_endpoint) = rl_endpoint
                 && let Err(error) = rl_endpoint.shutdown().await
             {
@@ -1171,7 +1176,7 @@ impl Worker {
         // First instant the worker is serviceable: every mandatory endpoint is
         // registered, the token is uncancelled, and engine routes are open.
         // Nothing earlier may report ready.
-        set_process_health(&endpoint, HealthStatus::Ready);
+        set_worker_health(&endpoint, HealthStatus::Ready);
 
         let serve_fut = primary_endpoint.wait();
         tokio::pin!(serve_fut);
@@ -1211,7 +1216,7 @@ impl Worker {
 
         // Symmetric with the ready write: stop advertising ready before the
         // orchestrator drains and unregisters.
-        set_process_health(&endpoint, HealthStatus::NotReady);
+        set_worker_health(&endpoint, HealthStatus::NotReady);
 
         if let Some(rl_endpoint) = rl_endpoint
             && let Err(error) = rl_endpoint.shutdown().await
@@ -1316,14 +1321,28 @@ impl Worker {
     }
 }
 
-/// Set the process-wide health the runtime's health route falls back to when no
-/// endpoint canary target is registered.
-fn set_process_health(endpoint: &dynamo_runtime::component::Endpoint, status: HealthStatus) {
-    endpoint
-        .drt()
-        .system_health()
-        .lock()
-        .set_health_status(status);
+/// Publish worker readiness on both layers the runtime's health route reads.
+///
+/// `SystemHealth::get_health_status` consults `use_endpoint_health_status`, then
+/// the canary targets, and only falls back to the process-wide status last. The
+/// operator renders those two shapes on different containers — worker base
+/// containers get `DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS`, failover engine
+/// containers have it stripped — so a write to either layer alone is invisible
+/// to half the fleet.
+///
+/// `Ready` goes through `set_endpoint_registered`, which skips the endpoint
+/// layer whenever that endpoint owns a canary target. Writing the target
+/// `Ready` here instead would report readiness the canary has not yet verified.
+fn set_worker_health(endpoint: &dynamo_runtime::component::Endpoint, status: HealthStatus) {
+    let system_health = endpoint.drt().system_health();
+    let mut system_health = system_health.lock();
+    match status {
+        HealthStatus::Ready => system_health.set_endpoint_registered(endpoint.name()),
+        HealthStatus::NotReady => {
+            system_health.set_endpoint_health_status(endpoint.name(), HealthStatus::NotReady)
+        }
+    }
+    system_health.set_health_status(status);
 }
 
 /// Drain-budget resolver: `DYN_PREFILL_DRAIN_TIMEOUT_S` with the same
@@ -1772,7 +1791,7 @@ fn wrap_engine_control_callback(
                     // control itself then succeeds or fails, the endpoint is
                     // left unregistered, so readiness stays withdrawn until a
                     // resume control re-registers it.
-                    set_process_health(&endpoint, HealthStatus::NotReady);
+                    set_worker_health(&endpoint, HealthStatus::NotReady);
 
                     let callback_result = tokio::select! {
                         biased;
@@ -1847,7 +1866,7 @@ fn wrap_engine_control_callback(
                             "engine resumed but re-registration failed after /engine/control/{control_name}: {e}; retry /engine/control/{control_name} to rejoin discovery"
                         )));
                     }
-                    set_process_health(&endpoint, HealthStatus::Ready);
+                    set_worker_health(&endpoint, HealthStatus::Ready);
                     Ok(response)
                 }
             }
@@ -3936,9 +3955,9 @@ mod handoff_and_lifecycle_tests {
 
     /// Assemble a worker whose engine supplies no health-check payload — the
     /// `LLMEngine` trait default — over the in-memory discovery runtime, and
-    /// hand back the process-wide health handle the runtime's health route
-    /// reads. With no payload there is no health-check target, so that route
-    /// falls through to the process-wide status and nothing else can mask it.
+    /// hand back the health handle the runtime's health route reads. With no
+    /// payload there is no canary target, so the route resolves to whichever of
+    /// the remaining branches the caller's environment selects.
     async fn payload_free_serving_worker() -> (
         dynamo_runtime::component::Endpoint,
         Arc<parking_lot::Mutex<dynamo_runtime::SystemHealth>>,
@@ -3968,11 +3987,39 @@ mod handoff_and_lifecycle_tests {
         false
     }
 
+    /// `DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS` as the operator renders it on a
+    /// worker base container. Selects the endpoint-health branch of
+    /// `SystemHealth::get_health_status`; absent, the process-wide fallback
+    /// branch runs instead, which is the shape a failover engine container gets.
+    const WORKER_CONTAINER_ENDPOINT_HEALTH: &str = r#"["generate"]"#;
+
+    /// Run `case` under each health-route shape the operator renders, so a
+    /// readiness write that lands on only one layer of the cascade fails here.
+    async fn with_each_health_route_shape<F, Fut>(case: F)
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        use dynamo_runtime::config::environment_names::runtime::system::DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS;
+
+        for endpoint_health in [None, Some(WORKER_CONTAINER_ENDPOINT_HEALTH)] {
+            temp_env::async_with_vars(
+                [(DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS, endpoint_health)],
+                case(),
+            )
+            .await;
+        }
+    }
+
     /// A pause control leaves the endpoint out of discovery, so readiness must
     /// be withdrawn with it and restored only once a resume control has
     /// re-registered.
     #[tokio::test]
     async fn engine_controls_track_readiness_with_discovery() {
+        with_each_health_route_shape(engine_controls_track_readiness_case).await;
+    }
+
+    async fn engine_controls_track_readiness_case() {
         let endpoint = test_local_endpoint().await;
         let system_health = endpoint.drt().system_health();
         let (engine, _) = HandoffMockEngine::new(
@@ -3984,7 +4031,7 @@ mod handoff_and_lifecycle_tests {
         worker.register_engine_controls(&endpoint).await.unwrap();
         worker.activate_engine_routes().await;
         endpoint.register_endpoint_instance().await.unwrap();
-        set_process_health(&endpoint, HealthStatus::Ready);
+        set_worker_health(&endpoint, HealthStatus::Ready);
 
         let routes = endpoint.drt().engine_routes();
         let response = routes.get("control/sleep").unwrap()(serde_json::json!({}))
@@ -4008,10 +4055,14 @@ mod handoff_and_lifecycle_tests {
         worker.begin_engine_route_shutdown().await;
     }
 
-    /// Ensures a payload-free Rust backend publishes process readiness while it
-    /// is serviceable and withdraws it again on shutdown.
+    /// Ensures a payload-free Rust backend publishes readiness while it is
+    /// serviceable and withdraws it again on shutdown.
     #[tokio::test]
     async fn shutdown_returns_the_serving_worker_to_not_ready() {
+        with_each_health_route_shape(shutdown_returns_the_serving_worker_to_not_ready_case).await;
+    }
+
+    async fn shutdown_returns_the_serving_worker_to_not_ready_case() {
         let (endpoint, system_health, mut worker, engine_config) =
             payload_free_serving_worker().await;
 

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -3993,6 +3993,34 @@ mod handoff_and_lifecycle_tests {
     /// branch runs instead, which is the shape a failover engine container gets.
     const WORKER_CONTAINER_ENDPOINT_HEALTH: &str = r#"["generate"]"#;
 
+    /// Read the runtime's health route the way an orchestrator probe does, and
+    /// return the two things a probe acts on: the HTTP status and the `status`
+    /// field of the body.
+    async fn probe_health_route(client: &reqwest::Client, url: &str) -> (u16, String) {
+        let response = client
+            .get(url)
+            .send()
+            .await
+            .expect("health route must answer");
+        let status = response.status().as_u16();
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .expect("health route must return a JSON body");
+        let reported = body["status"].as_str().unwrap_or_default().to_string();
+        (status, reported)
+    }
+
+    async fn health_route_reaches(client: &reqwest::Client, url: &str, expected: u16) -> bool {
+        for _ in 0..600 {
+            if probe_health_route(client, url).await.0 == expected {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        false
+    }
+
     /// Run `case` under each health-route shape the operator renders, so a
     /// readiness write that lands on only one layer of the cascade fails here.
     async fn with_each_health_route_shape<F, Fut>(case: F)
@@ -4088,6 +4116,75 @@ mod handoff_and_lifecycle_tests {
         assert!(
             !system_health.lock().get_health_status().0,
             "worker must report not ready again after the shutdown path runs"
+        );
+    }
+
+    /// An orchestrator probes the runtime's `/health` route over HTTP, not
+    /// `SystemHealth::get_health_status`. This drives the same serve path with
+    /// the system status server running and asserts the served route moves from
+    /// `503 notready` to `200 ready` and back, so the wiring between this
+    /// crate's readiness writes and the route a probe reads is covered too.
+    #[tokio::test]
+    async fn the_health_route_follows_the_serving_worker() {
+        use dynamo_runtime::config::environment_names::runtime::system::{
+            DYN_SYSTEM_HOST, DYN_SYSTEM_PORT,
+        };
+
+        with_each_health_route_shape(|| {
+            // Port 0 takes whatever port is free, and loopback keeps the
+            // server off the host's other interfaces.
+            temp_env::async_with_vars(
+                [
+                    (DYN_SYSTEM_HOST, Some("127.0.0.1")),
+                    (DYN_SYSTEM_PORT, Some("0")),
+                ],
+                the_health_route_follows_the_serving_worker_case(),
+            )
+        })
+        .await;
+    }
+
+    async fn the_health_route_follows_the_serving_worker_case() {
+        let (endpoint, _system_health, mut worker, engine_config) =
+            payload_free_serving_worker().await;
+        let health_url = {
+            let server = endpoint
+                .drt()
+                .system_status_server_info()
+                .expect("DYN_SYSTEM_PORT=0 must start the system status server");
+            format!("http://{}/health", server.socket_addr)
+        };
+        let client = reqwest::Client::new();
+
+        assert_eq!(
+            probe_health_route(&client, &health_url).await,
+            (503, "notready".to_string()),
+            "a worker that has not begun serving must fail the readiness probe"
+        );
+
+        let shutdown = CancellationToken::new();
+        let serve = tokio::spawn({
+            let shutdown = shutdown.clone();
+            async move {
+                worker
+                    .serve_with_orchestrator(&engine_config, endpoint, shutdown)
+                    .await
+            }
+        });
+
+        let served_ready = health_route_reaches(&client, &health_url, 200).await;
+        shutdown.cancel();
+        let outcome = tokio::time::timeout(Duration::from_secs(120), serve)
+            .await
+            .expect("serve loop must finish after shutdown");
+        assert!(
+            served_ready,
+            "health route must pass the probe while the worker is serving; serve loop returned {outcome:?}"
+        );
+        assert_eq!(
+            probe_health_route(&client, &health_url).await,
+            (503, "notready".to_string()),
+            "health route must fail the probe again after the shutdown path runs"
         );
     }
 

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -1151,6 +1151,23 @@ impl Worker {
             None
         };
 
+        // Opening the routes and registering the RL endpoint are both awaits, so
+        // a signal can land after the check above. Re-check before publishing a
+        // readiness that shutdown has already invalidated.
+        if shutdown.is_cancelled() {
+            self.begin_engine_route_shutdown().await;
+            if let Some(rl_endpoint) = rl_endpoint
+                && let Err(error) = rl_endpoint.shutdown().await
+            {
+                tracing::warn!(%error, "RL discovery endpoint shutdown failed");
+            }
+            if let Err(error) = primary_endpoint.shutdown().await {
+                tracing::warn!(%error, "primary endpoint shutdown failed");
+            }
+            self.orchestrator_steps(&endpoint).await;
+            return Ok(());
+        }
+
         // First instant the worker is serviceable: every mandatory endpoint is
         // registered, the token is uncancelled, and engine routes are open.
         // Nothing earlier may report ready.

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -22,6 +22,7 @@ use dynamo_llm::local_model::{LocalModel, LocalModelBuilder, update_model_taints
 use dynamo_llm::model_type::{ModelInput, ModelType};
 use dynamo_llm::preprocessor::media::{MediaDecoder, MediaFetcher};
 use dynamo_llm::worker_type::WorkerType;
+use dynamo_runtime::config::HealthStatus;
 use dynamo_runtime::engine_routes::EngineRouteCallback;
 use dynamo_runtime::pipeline::network::Ingress;
 use dynamo_runtime::protocols::EndpointId;
@@ -1131,11 +1132,17 @@ impl Worker {
         // the exact primary discovery instance is callable.
         self.activate_engine_routes().await;
 
+        // Registration succeeded, no signal intervened, and the administrative
+        // routes are open: this is the first instant the worker is serviceable,
+        // so it is the first instant the health route may report ready.
+        set_process_health(&endpoint, HealthStatus::Ready);
+
         let rl_endpoint = if let Some(rl_config) = rl_config {
             match crate::rl::serve_endpoint(&endpoint, rl_config).await {
                 Ok(endpoint) => Some(endpoint),
                 Err(error) => {
                     self.begin_engine_route_shutdown().await;
+                    set_process_health(&endpoint, HealthStatus::NotReady);
                     if let Err(shutdown_error) = primary_endpoint.shutdown().await {
                         tracing::warn!(%shutdown_error, "primary endpoint shutdown failed");
                     }
@@ -1185,6 +1192,11 @@ impl Worker {
         // guards and any discovery-mutation critical section, then close the
         // routes. No resume callback can re-register after the final unregister.
         self.begin_engine_route_shutdown().await;
+
+        // Symmetric with the ready write above: give readiness back before the
+        // orchestrator drains and unregisters, so a terminating worker stops
+        // advertising itself as ready while it is still winding down.
+        set_process_health(&endpoint, HealthStatus::NotReady);
 
         if let Some(rl_endpoint) = rl_endpoint
             && let Err(error) = rl_endpoint.shutdown().await
@@ -1287,6 +1299,23 @@ impl Worker {
             tokio::time::sleep(Duration::from_secs_f64(DRAIN_POLL_INTERVAL_S)).await;
         }
     }
+}
+
+/// Publish the process-wide readiness that the runtime's health route reports.
+///
+/// The route consults per-endpoint canary results first and only falls back to
+/// this process-wide status when no health-check target was registered — which
+/// is the default for a Rust backend, because [`LLMEngine::health_check_payload`]
+/// returns `None` unless an engine opts in. Without this write such a worker
+/// serves traffic while the health route reports not ready forever. Python
+/// workers reach the same status through their own bindings; this keeps the
+/// Rust path consistent with them.
+fn set_process_health(endpoint: &dynamo_runtime::component::Endpoint, status: HealthStatus) {
+    endpoint
+        .drt()
+        .system_health()
+        .lock()
+        .set_health_status(status);
 }
 
 /// Drain-budget resolver: `DYN_PREFILL_DRAIN_TIMEOUT_S` with the same
@@ -3889,6 +3918,110 @@ mod handoff_and_lifecycle_tests {
 
         worker.begin_engine_route_shutdown().await;
         assert!(control_response_is_error(&resume_request.await.unwrap()));
+    }
+
+    /// Assemble a worker whose engine supplies no health-check payload — the
+    /// `LLMEngine` trait default — over the in-memory discovery runtime, and
+    /// hand back the process-wide health handle the runtime's health route
+    /// reads. With no payload there is no health-check target, so that route
+    /// falls through to the process-wide status and nothing else can mask it.
+    async fn payload_free_serving_worker() -> (
+        dynamo_runtime::component::Endpoint,
+        Arc<parking_lot::Mutex<dynamo_runtime::SystemHealth>>,
+        Worker,
+        EngineConfig,
+    ) {
+        let endpoint = test_local_endpoint().await;
+        let system_health = endpoint.drt().system_health();
+        let worker = Worker::new(Arc::new(DefaultsEngine), WorkerConfig::default());
+        let engine_config = EngineConfig {
+            model: "payload-free-mock".to_string(),
+            ..EngineConfig::default()
+        };
+        (endpoint, system_health, worker, engine_config)
+    }
+
+    /// Poll the process-wide health flag until it reaches `expected`, giving
+    /// the serve loop time to reach its serviceable point. Returns false if it
+    /// never does.
+    async fn health_reaches(
+        system_health: &Arc<parking_lot::Mutex<dynamo_runtime::SystemHealth>>,
+        expected: bool,
+    ) -> bool {
+        for _ in 0..600 {
+            if system_health.lock().get_health_status().0 == expected {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        false
+    }
+
+    /// Regression: a Rust sidecar never published a process-wide readiness, so
+    /// an engine that supplies no health-check payload served traffic while the
+    /// health route still reported not ready forever. This drives the real
+    /// serve path and reads the status back through the same runtime accessor
+    /// the route uses.
+    #[tokio::test]
+    async fn serving_worker_reports_ready_once_it_is_serviceable() {
+        let (endpoint, system_health, mut worker, engine_config) =
+            payload_free_serving_worker().await;
+        assert!(
+            !system_health.lock().get_health_status().0,
+            "a worker that has not reached its serviceable point must not report ready"
+        );
+
+        let shutdown = CancellationToken::new();
+        let serve = tokio::spawn({
+            let shutdown = shutdown.clone();
+            async move {
+                worker
+                    .serve_with_orchestrator(&engine_config, endpoint, shutdown)
+                    .await
+            }
+        });
+
+        let became_ready = health_reaches(&system_health, true).await;
+        shutdown.cancel();
+        let outcome = tokio::time::timeout(Duration::from_secs(120), serve).await;
+        assert!(
+            became_ready,
+            "worker must report ready once registration succeeded and engine routes opened; \
+             serve loop returned {outcome:?}"
+        );
+    }
+
+    /// Regression companion: readiness must be given back at the shutdown
+    /// boundary, so a draining worker stops advertising itself as ready before
+    /// the orchestrator unregisters it.
+    #[tokio::test]
+    async fn shutdown_returns_the_serving_worker_to_not_ready() {
+        let (endpoint, system_health, mut worker, engine_config) =
+            payload_free_serving_worker().await;
+
+        let shutdown = CancellationToken::new();
+        let serve = tokio::spawn({
+            let shutdown = shutdown.clone();
+            async move {
+                worker
+                    .serve_with_orchestrator(&engine_config, endpoint, shutdown)
+                    .await
+            }
+        });
+
+        let became_ready = health_reaches(&system_health, true).await;
+        shutdown.cancel();
+        let outcome = tokio::time::timeout(Duration::from_secs(120), serve)
+            .await
+            .expect("serve loop must finish after shutdown");
+        assert!(
+            became_ready,
+            "shutdown case needs a ready worker to start from; serve loop returned {outcome:?}"
+        );
+        assert!(
+            !system_health.lock().get_health_status().0,
+            "worker must report not ready again after the shutdown path runs"
+        );
     }
 
     #[cfg(feature = "integration")]

--- a/lib/runtime/src/system_health.rs
+++ b/lib/runtime/src/system_health.rs
@@ -121,11 +121,19 @@ impl SystemHealth {
         }
     }
 
-    /// Withhold readiness for `endpoint` until [`release_endpoint_readiness`]:
-    /// transport registration no longer marks it ready, so its owner decides when
-    /// it is serviceable. Take the hold *before* the endpoint registers with its
-    /// transport — that is what makes this race-free on both request planes, since
-    /// the NATS path publishes readiness from a spawned task.
+    /// Withhold readiness for `endpoint` until [`release_endpoint_readiness`].
+    ///
+    /// Two effects, because one alone is not enough: transport registration no
+    /// longer marks this endpoint ready, and while any hold is outstanding
+    /// [`get_health_status`] reports not-ready for the whole process. Without the
+    /// second, a sibling endpoint registering unheld would answer the health route
+    /// on the held endpoint's behalf.
+    ///
+    /// Take the hold *before* the endpoint registers with its transport — that is
+    /// what makes this race-free on both request planes, since the NATS path
+    /// publishes readiness from a spawned task.
+    ///
+    /// [`get_health_status`]: SystemHealth::get_health_status
     ///
     /// [`release_endpoint_readiness`]: SystemHealth::release_endpoint_readiness
     pub fn hold_endpoint_readiness(&self, endpoint: &str) {
@@ -168,6 +176,13 @@ impl SystemHealth {
                     "notready".to_string()
                 },
             );
+        }
+
+        // An owner that has withheld an endpoint's readiness has not yet declared
+        // itself serviceable. Report not-ready for the whole process rather than
+        // letting some other endpoint's registration answer for it.
+        if !self.readiness_holds.read().unwrap().is_empty() {
+            return (false, endpoints);
         }
 
         let healthy = if !self.use_endpoint_health_status.is_empty() {
@@ -422,9 +437,9 @@ mod tests {
         let health = system_health(false);
         health.hold_endpoint_readiness(ENDPOINT);
         health.set_endpoint_registered(ENDPOINT);
-        assert_eq!(
+        assert_ne!(
             health.get_endpoint_health_status(ENDPOINT),
-            None,
+            Some(HealthStatus::Ready),
             "a held endpoint must not be marked ready by transport registration"
         );
 
@@ -435,6 +450,28 @@ mod tests {
             Some(HealthStatus::Ready),
             "after release the owner's registration signal publishes readiness"
         );
+    }
+
+    /// A sibling endpoint registering while another is held must not answer the
+    /// health route on the held endpoint's behalf. With the canary on and no
+    /// registered target, `get_health_status` otherwise reduces to "every
+    /// endpoint present in the map is ready", which a held endpoint is absent
+    /// from.
+    #[test]
+    fn an_unheld_sibling_endpoint_cannot_report_the_worker_ready() {
+        let health = system_health(true);
+        health.hold_endpoint_readiness(ENDPOINT);
+        health.set_endpoint_registered(ENDPOINT);
+        health.set_endpoint_registered("rl_system");
+
+        assert!(
+            !health.get_health_status().0,
+            "a held endpoint must keep the worker not-ready however many siblings register"
+        );
+
+        health.release_endpoint_readiness(ENDPOINT);
+        health.set_endpoint_registered(ENDPOINT);
+        assert!(health.get_health_status().0);
     }
 
     /// The hold gates only the endpoint it names.

--- a/lib/runtime/src/system_health.rs
+++ b/lib/runtime/src/system_health.rs
@@ -26,6 +26,43 @@ use crate::component;
 use crate::config::HealthStatus;
 use crate::metrics::{MetricsHierarchy, prometheus_names::distributed_runtime};
 
+/// Withholds readiness for one endpoint until dropped, so the endpoint's owner
+/// decides when it is serviceable rather than its transport registration.
+///
+/// Two effects, matching [`SystemHealth::hold_endpoint_readiness`]: transport
+/// registration no longer marks the named endpoint ready, and while any hold is
+/// outstanding [`SystemHealth::get_health_status`] reports not-ready for the
+/// whole process.
+///
+/// Take the hold *before* the endpoint registers with its transport — that is
+/// what makes it race-free on both request planes, since the NATS path publishes
+/// readiness from a spawned task.
+///
+/// Never let one drop while the `SystemHealth` mutex is held: `Drop` takes that
+/// lock and it is not reentrant.
+pub struct ReadinessHold {
+    system_health: Arc<parking_lot::Mutex<SystemHealth>>,
+    endpoint: String,
+}
+
+impl ReadinessHold {
+    pub fn take(system_health: Arc<parking_lot::Mutex<SystemHealth>>, endpoint: &str) -> Self {
+        system_health.lock().hold_endpoint_readiness(endpoint);
+        Self {
+            system_health,
+            endpoint: endpoint.to_string(),
+        }
+    }
+}
+
+impl Drop for ReadinessHold {
+    fn drop(&mut self) {
+        self.system_health
+            .lock()
+            .release_endpoint_readiness(&self.endpoint);
+    }
+}
+
 /// Health check target containing instance info and payload
 #[derive(Clone, Debug)]
 pub struct HealthCheckTarget {
@@ -131,7 +168,8 @@ impl SystemHealth {
     ///
     /// Take the hold *before* the endpoint registers with its transport — that is
     /// what makes this race-free on both request planes, since the NATS path
-    /// publishes readiness from a spawned task.
+    /// publishes readiness from a spawned task. Prefer [`ReadinessHold`], which
+    /// pairs this with its release.
     ///
     /// [`get_health_status`]: SystemHealth::get_health_status
     ///
@@ -474,9 +512,11 @@ mod tests {
         assert!(health.get_health_status().0);
     }
 
-    /// The hold gates only the endpoint it names.
+    /// A hold suppresses the *whole process's* readiness, but the per-endpoint
+    /// suppression inside `set_endpoint_registered` stays scoped to the endpoint
+    /// it names — a sibling still records its own transport registration.
     #[test]
-    fn a_hold_does_not_leak_to_other_endpoints() {
+    fn a_hold_does_not_suppress_a_siblings_endpoint_flag() {
         let health = system_health(false);
         health.hold_endpoint_readiness(ENDPOINT);
         health.set_endpoint_registered("other");

--- a/lib/runtime/src/system_health.rs
+++ b/lib/runtime/src/system_health.rs
@@ -16,7 +16,7 @@
 //! System health monitoring and health check management
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, OnceLock},
     time::Instant,
 };
@@ -45,6 +45,9 @@ pub struct SystemHealth {
     health_check_targets: Arc<std::sync::RwLock<HashMap<String, HealthCheckTarget>>>,
     /// Maps endpoint subject to its specific health check notifier
     health_check_notifiers: Arc<std::sync::RwLock<HashMap<String, Arc<tokio::sync::Notify>>>>,
+    /// Endpoints whose owner publishes readiness itself. Transport registration
+    /// does not mark these ready; see [`SystemHealth::hold_endpoint_readiness`].
+    readiness_holds: Arc<std::sync::RwLock<HashSet<String>>>,
     /// Channel for new endpoint registrations
     /// This solves the race condition where HealthCheckManager starts before endpoints are registered
     /// Using a channel ensures no registrations are lost.
@@ -85,6 +88,7 @@ impl SystemHealth {
             endpoint_health: Arc::new(std::sync::RwLock::new(endpoint_health)),
             health_check_targets: Arc::new(std::sync::RwLock::new(HashMap::new())),
             health_check_notifiers: Arc::new(std::sync::RwLock::new(HashMap::new())),
+            readiness_holds: Arc::new(std::sync::RwLock::new(HashSet::new())),
             new_endpoint_tx: tx,
             new_endpoint_rx: Arc::new(parking_lot::Mutex::new(Some(rx))),
             use_endpoint_health_status,
@@ -104,6 +108,9 @@ impl SystemHealth {
     /// NotReady until verification succeeds. Payload-less endpoints cannot run a
     /// canary, so transport registration is their readiness signal.
     pub fn set_endpoint_registered(&self, endpoint: &str) {
+        if self.readiness_holds.read().unwrap().contains(endpoint) {
+            return;
+        }
         let has_health_check_target = self
             .health_check_targets
             .read()
@@ -112,6 +119,28 @@ impl SystemHealth {
         if !self.health_check_enabled || !has_health_check_target {
             self.set_endpoint_health_status(endpoint, HealthStatus::Ready);
         }
+    }
+
+    /// Withhold readiness for `endpoint` until [`release_endpoint_readiness`]:
+    /// transport registration no longer marks it ready, so its owner decides when
+    /// it is serviceable. Take the hold *before* the endpoint registers with its
+    /// transport — that is what makes this race-free on both request planes, since
+    /// the NATS path publishes readiness from a spawned task.
+    ///
+    /// [`release_endpoint_readiness`]: SystemHealth::release_endpoint_readiness
+    pub fn hold_endpoint_readiness(&self, endpoint: &str) {
+        self.readiness_holds
+            .write()
+            .unwrap()
+            .insert(endpoint.to_string());
+    }
+
+    /// Drop a [`hold_endpoint_readiness`] hold. Readiness is not published here —
+    /// the owner writes it.
+    ///
+    /// [`hold_endpoint_readiness`]: SystemHealth::hold_endpoint_readiness
+    pub fn release_endpoint_readiness(&self, endpoint: &str) {
+        self.readiness_holds.write().unwrap().remove(endpoint);
     }
 
     pub fn set_health_status(&mut self, status: HealthStatus) {
@@ -383,6 +412,40 @@ mod tests {
             !healthy,
             "with no health-check target the endpoint's readiness is ignored and \
              the worker falls back to system_health (NotReady) — this is the 503"
+        );
+    }
+
+    /// A held endpoint does not become ready on transport registration, so its
+    /// owner can keep the route at 503 until every mandatory endpoint is up.
+    #[test]
+    fn held_endpoint_is_not_ready_on_transport_registration() {
+        let health = system_health(false);
+        health.hold_endpoint_readiness(ENDPOINT);
+        health.set_endpoint_registered(ENDPOINT);
+        assert_eq!(
+            health.get_endpoint_health_status(ENDPOINT),
+            None,
+            "a held endpoint must not be marked ready by transport registration"
+        );
+
+        health.release_endpoint_readiness(ENDPOINT);
+        health.set_endpoint_registered(ENDPOINT);
+        assert_eq!(
+            health.get_endpoint_health_status(ENDPOINT),
+            Some(HealthStatus::Ready),
+            "after release the owner's registration signal publishes readiness"
+        );
+    }
+
+    /// The hold gates only the endpoint it names.
+    #[test]
+    fn a_hold_does_not_leak_to_other_endpoints() {
+        let health = system_health(false);
+        health.hold_endpoint_readiness(ENDPOINT);
+        health.set_endpoint_registered("other");
+        assert_eq!(
+            health.get_endpoint_health_status("other"),
+            Some(HealthStatus::Ready)
         );
     }
 


### PR DESCRIPTION
## Overview:

`SystemHealth::get_health_status` resolves the runtime's health route through a cascade: `use_endpoint_health_status` first, then the registered canary targets, and the process-wide status only as a last fallback. A Rust backend wrote none of those layers, so a worker that had registered and was serving traffic kept answering the health route with the `NotReady` it started on, for the life of the process. An orchestrator gating on readiness restarts such a worker instead of using it. Python workers set their status through their own bindings, so only the Rust path is affected.

The two layers are not interchangeable, because the operator renders both shapes. `deploy/operator/internal/dynamo/component_worker.go` sets `DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS` on every worker base container, which selects the endpoint-health branch; `deploy/operator/internal/dynamo/failover.go` strips it from GMS and failover engine containers, which leaves them on the process-wide fallback with a readiness probe pointed at it. A worker that writes only one layer is invisible to half the fleet.

## Details:

**Publishing readiness.** `set_worker_health` in `lib/backend-common/src/worker.rs` writes both layers, and the worker calls it wherever its routability changes.

`Ready` goes through `SystemHealth::set_endpoint_registered` rather than writing the endpoint entry directly. That call deliberately leaves the endpoint layer alone when the endpoint owns a canary target, so an engine that supplies a `health_check_payload` still waits for canary verification instead of being marked ready on the worker's say-so. `NotReady` is written to both layers unconditionally: withdrawing readiness is always safe. The endpoint key is `Endpoint::name()`, the same plain endpoint name every other writer uses — `push_endpoint.rs`, `shared_tcp_endpoint.rs`, and canary target registration in `component/endpoint.rs`.

`Worker::serve_with_orchestrator` publishes readiness once every mandatory endpoint is registered and withdraws it at the shutdown boundary, before the orchestrator drains and unregisters. Every teardown path that runs after the engine routes are open withdraws readiness on the way out, including the early returns: a resume control can publish readiness through an open route before either path observes the cancelled token.

`wrap_engine_control_callback` keeps readiness in step with the administrative controls that move the endpoint in and out of discovery. `pause_generation`, `sleep`, and `release_memory_occupation` unregister first, so readiness is withdrawn as soon as that unregister succeeds; `resume_generation`, `wake_up`, and `resume_memory_occupation` restore it only once re-registration succeeds.

**Making the worker's gate authoritative.** Publishing at the gate is not sufficient on its own, because the worker is not the only writer. `start_with_registration` reaches `SystemHealth::set_endpoint_registered` from inside the transport (`shared_tcp_endpoint.rs:477`, `push_endpoint.rs:53`), which marks a payload-free endpoint ready the moment it registers — before `activate_engine_routes`, before the RL endpoint registers, and before the worker's gate. With the canary off, which is the default (`config.rs:368`), that applies to payload-bearing endpoints too, so a stock deployment could report ready ahead of the gate.

`SystemHealth::hold_endpoint_readiness` / `release_endpoint_readiness` let an endpoint's owner withhold that signal, with `ReadinessHold` as the RAII pairing. A hold has two effects, because one alone is not enough: transport registration no longer marks the held endpoint ready, and while any hold is outstanding `get_health_status` reports not-ready for the whole process. Without the second, the payload-free RL discovery endpoint — which registers unheld, between the primary's registration and the gate — answered the health route on the held endpoint's behalf.

The hold is taken *before* the primary endpoint registers. That ordering is what makes it race-free on both request planes: the NATS path publishes readiness from a spawned task, so a `NotReady` write issued after registration returns would race it rather than reliably suppress it. The addition is default-off — endpoints that never take a hold are unaffected, and `get_health_status` has exactly one production caller, the `/health` handler in `system_status_server.rs`.

## Validation

Tests in `handoff_and_lifecycle_tests` run under both health-route shapes the operator renders — `DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS` absent, and set to `["generate"]` — so a readiness write that reaches only one layer of the cascade fails the suite. `shutdown_returns_the_serving_worker_to_not_ready` drives the real serve path against an engine that supplies no health-check payload. `engine_controls_track_readiness_with_discovery` drives `control/sleep` and `control/wake_up` through the real route callbacks and asserts readiness follows discovery in both directions. `resume_defers_to_the_canary_when_a_target_is_registered` covers the canary-on plus registered-target case — the one configuration where writing `Ready` straight to the endpoint layer would differ from deferring to `set_endpoint_registered`.

`the_health_route_follows_the_serving_worker` covers the surface an orchestrator actually probes: the same serve path with the system status server bound to an ephemeral loopback port, reading `/health` over HTTP and asserting `503 notready` before serving, `200 ready` while serving, and `503 notready` again after shutdown.

The hold is what makes that coverage bite. Deleting the gate's `Ready` write previously still passed that test under `DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS=["generate"]`, because the endpoint layer was already ready from transport registration; the mutant now fails under both shapes. On the runtime side, `an_unheld_sibling_endpoint_cannot_report_the_worker_ready` pins the sibling-endpoint case and `held_endpoint_is_not_ready_on_transport_registration` pins the hold itself.

Env-mutating tests are `#[serial_test::serial]`: they set `DYN_SYSTEM_*` process-wide while every `DistributedRuntime::new` reads `from_settings()`, so without serialization they race any other test in the binary that builds a runtime.

- `cargo test -p dynamo-backend-common --lib` — `149 passed; 0 failed`
- `cargo test -p dynamo-runtime --lib` — `689 passed; 0 failed`
- `cargo check --workspace --all-targets`, `cargo check` in `lib/bindings/python`, `cargo clippy -p dynamo-runtime -p dynamo-backend-common --all-targets`, `cargo fmt --all --check` — each exit 0
- `pre-commit run --files <changed files>` — every applicable hook passed

## Where should the reviewer start?

`lib/runtime/src/system_health.rs` — `hold_endpoint_readiness`, the `ReadinessHold` guard, and the short-circuit in `get_health_status`. This is the new public runtime API and the part that affects every backend, so it warrants a runtime owner's eye. Then `lib/backend-common/src/worker.rs` — where the hold is taken and dropped in `serve_with_orchestrator`, `set_worker_health` and its call sites.

One constraint the API now carries: the short-circuit is process-wide, so if a process ever ran two `Worker`s sharing a `DistributedRuntime`, one worker's startup hold would gate the other's readiness. Not reachable today — `serve_with_orchestrator` has a single call site and is terminal in `run_inner`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Related work: #8592 changes the cascade in `lib/runtime/src/system_health.rs` to reach the same symptom from the other side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime health status now reports **Ready** only after all serving endpoints are registered and shutdown has not begun.
  * Health status changes to **Not Ready** before endpoint teardown, endpoint unregistration, and shutdown.
  * Health status is restored to **Ready** after endpoints successfully resume.
  * Improved readiness handling for workers without payloads and during sleep/resume transitions.

* **New Features**
  * Endpoint owners can withhold readiness across transport registration, so the health route reports ready only once the owner declares the process serviceable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
